### PR TITLE
Back out "[pytorch][PR] [Inductor] Extend Pattern Matcher to Match Equivalent Function Invocation"

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -8,24 +8,16 @@ import torch._inductor.config as inductor_config
 from torch._dynamo.test_case import run_tests, TestCase
 from torch._dynamo.utils import count_calls, counters
 from torch._inductor.fx_passes import joint_graph
-
 from torch._inductor.fx_passes.serialized_patterns.central_index import (
     get_serialized_pattern,
 )
 from torch._inductor.pattern_matcher import (
     _TargetExpr,
-    Arg,
-    CallFunction,
     gen_pattern,
-    KeywordArg,
-    Match,
     PatternExpr,
-    PatternMatcherPass,
     PatternPrettyPrinter,
-    register_graph_pattern,
 )
 from torch._inductor.utils import run_and_get_code
-from torch._inductor.virtualized import V
 from torch.testing import FileCheck
 from torch.testing._internal.common_cuda import SM80OrLater
 from torch.testing._internal.common_utils import IS_LINUX
@@ -681,6 +673,13 @@ class TestPaternMatcher(TestCase):
         counters.clear()
 
     def test_match_with_mutation(self):
+        from torch._inductor.pattern_matcher import (
+            CallFunction,
+            KeywordArg,
+            PatternMatcherPass,
+            register_graph_pattern,
+        )
+
         counter = 0
         test_pass = PatternMatcherPass(prevent_match_across_mutations=True)
 
@@ -845,154 +844,6 @@ class TestPaternMatcher(TestCase):
                     PatternPrettyPrinter.run(search_fn_pattern),
                     msg=f"Found mismatched pattern {key}. Run gen_attention_patterns.py",
                 )
-
-    def test_match_equivalent_function_invocations1(self):
-        counter = 0
-        test_pass = PatternMatcherPass(prevent_match_across_mutations=True)
-
-        args = [
-            torch.randn(20, device="cuda"),
-            torch.randn(10, 15, device="cuda"),
-            torch.randn(15, 20, device="cuda"),
-        ]
-
-        def f0(inp, a, b):
-            return torch.ops.aten.addmm(inp, a, b)
-
-        def f1(inp, a, b):
-            return torch.ops.aten.addmm(inp, a, b, beta=1.0)
-
-        def f2(inp, a, b):
-            return torch.ops.aten.addmm(inp, a, b, beta=1.0, alpha=1.0)
-
-        # This graph pattern should successfully match all of the above functions
-        @register_graph_pattern(
-            CallFunction(
-                torch.ops.aten.addmm,
-                Arg(),
-                Arg(),
-                Arg(),
-                beta=KeywordArg("beta"),
-                alpha=KeywordArg("alpha"),
-            ),
-            pass_dict=test_pass,
-        )
-        def addmm_replacement(match: Match, inp, mat1, mat2, beta, alpha):
-            nonlocal counter
-            counter += 1
-
-            def repl(inp, x1, x2):
-                return (x1 @ x2) * alpha + inp * beta
-
-            with V.fake_mode:
-                match.replace_by_example(repl, [inp, mat1, mat2])
-
-        with unittest.mock.patch(
-            "torch._inductor.fx_passes.post_grad.pass_patterns",
-            torch._inductor.fx_passes.post_grad.pass_patterns + [test_pass],
-        ):
-            for fn in (f0, f1, f2):
-                counter = 0
-                expected = fn(*copy.deepcopy(args))
-                opt_fn = torch.compile(fn)
-                actual, (code) = run_and_get_code(opt_fn, args[0], args[1], args[2])
-                # pattern should match
-                self.assertEqual(counter, 1)
-                torch.testing.assert_close(actual, expected)
-                # addmm should be replaced
-                FileCheck().check_not("extern_kernels.addmm(").run(code[0])
-
-    def test_match_equivalent_function_invocations2(self):
-        counter = 0
-        test_pass = PatternMatcherPass(prevent_match_across_mutations=True)
-
-        args = [
-            torch.randn(20, device="cuda"),
-            torch.randn(10, 15, device="cuda"),
-            torch.randn(15, 20, device="cuda"),
-        ]
-
-        def f0(inp, a, b):
-            return torch.ops.aten.addmm(inp, a, b)
-
-        def f1(inp, a, b):
-            return torch.ops.aten.addmm(inp, a, b, beta=1.0)
-
-        def f2(inp, a, b):
-            return torch.ops.aten.addmm(inp, a, b, beta=1.0, alpha=1.0)
-
-        # This graph pattern should only match f0
-        @register_graph_pattern(
-            CallFunction(torch.ops.aten.addmm, Arg(), Arg(), Arg()),
-            pass_dict=test_pass,
-        )
-        def addmm_replacement(match: Match, inp, mat1, mat2):
-            nonlocal counter
-            counter += 1
-
-            def repl(inp, x1, x2):
-                return x1 @ x2 + inp
-
-            with V.fake_mode:
-                match.replace_by_example(repl, [inp, mat1, mat2])
-
-        with unittest.mock.patch(
-            "torch._inductor.fx_passes.post_grad.pass_patterns",
-            torch._inductor.fx_passes.post_grad.pass_patterns + [test_pass],
-        ):
-            for fn in (f0, f1, f2):
-                counter = 0
-                expected = fn(*copy.deepcopy(args))
-                actual = torch.compile(fn)(*copy.deepcopy(args))
-                self.assertEqual(counter, 1)
-                torch.testing.assert_close(actual, expected)
-
-    def test_match_equivalent_function_invocations3(self):
-        counter = 0
-        test_pass = PatternMatcherPass(prevent_match_across_mutations=True)
-
-        args = [
-            torch.randn(20, device="cuda"),
-            torch.randn(10, 15, device="cuda"),
-            torch.randn(15, 20, device="cuda"),
-        ]
-
-        def f0(inp, a, b):
-            return torch.ops.aten.addmm(inp, a, b)
-
-        def f1(inp, a, b):
-            return torch.ops.aten.addmm(inp, a, b, beta=1.0)
-
-        def f2(inp, a, b):
-            return torch.ops.aten.addmm(inp, a, b, beta=1.0, alpha=1.0)
-
-        # This graph pattern should only match f1
-        @register_graph_pattern(
-            CallFunction(
-                torch.ops.aten.addmm, Arg(), Arg(), Arg(), beta=KeywordArg("beta")
-            ),
-            pass_dict=test_pass,
-        )
-        def addmm_replacement(match: Match, inp, mat1, mat2, beta):
-            nonlocal counter
-            counter += 1
-
-            def repl(inp, x1, x2):
-                return x1 @ x2 + inp
-
-            with V.fake_mode:
-                match.replace_by_example(repl, [inp, mat1, mat2])
-
-        with unittest.mock.patch(
-            "torch._inductor.fx_passes.post_grad.pass_patterns",
-            torch._inductor.fx_passes.post_grad.pass_patterns + [test_pass],
-        ):
-            for fn in (f0, f1, f2):
-                counter = 0
-                expected = fn(*copy.deepcopy(args))
-                actual = torch.compile(fn)(*copy.deepcopy(args))
-                self.assertEqual(counter, 1)
-                torch.testing.assert_close(actual, expected)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -778,7 +778,7 @@ class UnbindCatRemover(SplitCatSimplifier):
         split_dim = unbind_node.kwargs["dim"]
         transform_params_list = []
         for user_node, user_inputs in zip(next_users, user_inputs_list):
-            cat_dim = get_arg_value(user_node, 1, "dim") or 0
+            cat_dim = get_arg_value(user_node, 1, "dim")
             transform_params = []
             for user_input in user_inputs:
                 if isinstance(user_input, tuple):

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -387,35 +387,17 @@ class _TargetArgsExpr(_TargetExpr):
         return f"{self.__class__.__name__}({joiner_str.join(args)})"
 
     def _match(self, node: torch.fx.Node, ctx: MatchContext):
-        if not self._match_fns(node) or len(node.args) != len(self.args):
+        if (
+            not self._match_fns(node)
+            or len(node.args) != len(self.args)
+            or len(node.kwargs) != len(self.kwargs)
+        ):
             return FailedMatch(f"function_mismatch: node={node}, pattern={self}")
 
         if not self._match_users(node, ctx):
             return FailedMatch(f"multiple_users {node}")
 
-        _args = node.args
-        _kwargs = node.kwargs
-        if len(_kwargs) < len(self.kwargs):
-            from torch.fx.operator_schemas import normalize_function
-
-            normalized_args_and_kwargs = normalize_function(
-                node.target, node.args, node.kwargs
-            )
-
-            if normalized_args_and_kwargs is None:
-                return FailedMatch(f"function_mismatch: node={node}, pattern={self}")
-            else:
-                _args, _kwargs = normalized_args_and_kwargs
-                if len(_args) == len(self.args) and len(_kwargs) >= len(self.kwargs):
-                    _kwargs = {i: _kwargs[i] for i in _kwargs if i in self.kwargs}
-                else:
-                    return FailedMatch(
-                        f"function_mismatch: node={node}, pattern={self}"
-                    )
-        else:
-            _kwargs = {i: _kwargs[i] for i in _kwargs if i in self.kwargs}
-
-        node_items, node_spec = self.flatten(_args, _kwargs)
+        node_items, node_spec = self.flatten(node.args, node.kwargs)
         self_items, self_spec = self.flat_args_kwargs
         if node_spec != self_spec:
             return FailedMatch(f"args_structure {node_spec} {self_spec}")


### PR DESCRIPTION
Summary:
Original commit changeset: 3466b85fe0a1

Original Phabricator Diff: D49433268

More context D49536556

bypass-github-pytorch-ci-checks

Test Plan: revertreverthammer

Differential Revision: D49565384




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov