### PR TITLE
[pytorch vulkan] add tensor vulkan check for at::cat

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Concat.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Concat.cpp
@@ -23,7 +23,8 @@ Tensor cat_batch(const MaterializedITensorListRef& tensors, vTensor& v_output) {
   uvec3 dst_offset{};
 
   for (const at::Tensor& tensor : tensors) {
-    const vTensor& v_self = convert(tensor);
+    const Tensor self = tensor.is_vulkan() ? tensor : tensor.vulkan();
+    const vTensor& v_self = convert(self);
 
     api::PipelineBarrier pipeline_barrier{};
 
@@ -141,8 +142,7 @@ Tensor cat_feature(
 
 Tensor cat_feature_mult4ch(
     const MaterializedITensorListRef& tensors,
-    vTensor& v_output,
-    uint32_t ndim) {
+    vTensor& v_output) {
   api::Context* const context = api::context();
 
   int64_t depth_size_allprior = 0;
@@ -204,7 +204,8 @@ Tensor cat_width(const MaterializedITensorListRef& tensors, vTensor& v_output) {
   uvec3 dst_offset{};
 
   for (const at::Tensor& tensor : tensors) {
-    const vTensor& v_self = convert(tensor);
+    const Tensor self = tensor.is_vulkan() ? tensor : tensor.vulkan();
+    const vTensor& v_self = convert(self);
 
     api::PipelineBarrier pipeline_barrier{};
 
@@ -240,7 +241,8 @@ Tensor cat_height(
   uvec3 dst_offset{};
 
   for (const at::Tensor& tensor : tensors) {
-    const vTensor& v_self = convert(tensor);
+    const Tensor self = tensor.is_vulkan() ? tensor : tensor.vulkan();
+    const vTensor& v_self = convert(self);
 
     api::PipelineBarrier pipeline_barrier{};
 
@@ -312,7 +314,7 @@ Tensor cat(const at::ITensorListRef& tensors, const int64_t in_dim) {
     return cat_height(materialized, v_output);
   } else if (dim == ndim - 3) {
     if (is_mult4ch) {
-      return cat_feature_mult4ch(materialized, v_output, ndim);
+      return cat_feature_mult4ch(materialized, v_output);
     }
     return cat_feature(materialized, v_output);
   }


### PR DESCRIPTION
Summary:
Saw this issue when running pytorch vulkan on a LSTM model:

https://www.internalfb.com/phabricator/paste/view/P834993118

Found that we don't always to the vulkan transfer on `at::cat`

Test Plan:
(Not running the LSTM model yet. Since there are other crahses.)

```
[yipjustin@47884.od /data/sandcastle/boxes/fbsource (3fd2308f8|remote/fbcode/warm_fbcode_od_stable...)]$ LD_LIBRARY_PATH=third-party/swiftshader/lib/linux-x64/ buck run fbcode/mode/dev-nosan //xplat/caffe2:pt_vulkan_api_test_bin  -- --gtest_filter="*cat*"
Building: finished in 0.1 sec (100%) 330/330 jobs, 0/330 updated
  Total time: 0.2 sec
BUILD SUCCEEDED
Running main() from third-party/googletest/1.11.0/googletest/googletest/src/gtest_main.cc
Note: Google Test filter = *cat*
[==========] Running 43 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 43 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.replication_pad2d
[       OK ] VulkanAPITest.replication_pad2d (102 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim0_invalidinputs_exceptions
[       OK ] VulkanAPITest.cat_4d_dim0_invalidinputs_exceptions (67 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim0_samebatch_success
[       OK ] VulkanAPITest.cat_4d_dim0_samebatch_success (111 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim0_diffbatch_success
[       OK ] VulkanAPITest.cat_4d_dim0_diffbatch_success (76 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim0_singledepth_success
[       OK ] VulkanAPITest.cat_4d_dim0_singledepth_success (40 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim0_singletensor_success
[       OK ] VulkanAPITest.cat_4d_dim0_singletensor_success (7 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim0_twotensors_success
[       OK ] VulkanAPITest.cat_4d_dim0_twotensors_success (30 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim0_negdim_success
[       OK ] VulkanAPITest.cat_4d_dim0_negdim_success (78 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim1_negdim_success
[       OK ] VulkanAPITest.cat_4d_dim1_negdim_success (130 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim2_negdim_success
[       OK ] VulkanAPITest.cat_4d_dim2_negdim_success (75 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim3_negdim_success
[       OK ] VulkanAPITest.cat_4d_dim3_negdim_success (68 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim1_texture2d_success
[       OK ] VulkanAPITest.cat_4d_dim1_texture2d_success (2 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim1_singledepth_success
[       OK ] VulkanAPITest.cat_4d_dim1_singledepth_success (65 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim1_singletensor_success
[       OK ] VulkanAPITest.cat_4d_dim1_singletensor_success (8 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim1_bat1_mult4ch_success
[       OK ] VulkanAPITest.cat_4d_dim1_bat1_mult4ch_success (9 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim1_bat2_mult4ch_success
[       OK ] VulkanAPITest.cat_4d_dim1_bat2_mult4ch_success (18 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim1_mult4ch_mixed_success
[       OK ] VulkanAPITest.cat_4d_dim1_mult4ch_mixed_success (60 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim2_sameheight_success
[       OK ] VulkanAPITest.cat_4d_dim2_sameheight_success (80 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim2_diffheight_success
[       OK ] VulkanAPITest.cat_4d_dim2_diffheight_success (69 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim2_singledepth_success
[       OK ] VulkanAPITest.cat_4d_dim2_singledepth_success (12 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim2_invalidinputs_exceptions
[       OK ] VulkanAPITest.cat_4d_dim2_invalidinputs_exceptions (63 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim3_invalidinputs_exceptions
[       OK ] VulkanAPITest.cat_4d_dim3_invalidinputs_exceptions (86 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim3_samewidth_success
[       OK ] VulkanAPITest.cat_4d_dim3_samewidth_success (117 ms)
[ RUN      ] VulkanAPITest.cat_4d_dim3_diffwidth_success
[       OK ] VulkanAPITest.cat_4d_dim3_diffwidth_success (72 ms)
[ RUN      ] VulkanAPITest.cat_3d_dim0_mult4ch_success
[       OK ] VulkanAPITest.cat_3d_dim0_mult4ch_success (12 ms)
[ RUN      ] VulkanAPITest.cat_3d_dim0_diff_channel_success
[       OK ] VulkanAPITest.cat_3d_dim0_diff_channel_success (28 ms)
[ RUN      ] VulkanAPITest.cat_3d_dim0_same_channel_success
[       OK ] VulkanAPITest.cat_3d_dim0_same_channel_success (15 ms)
[ RUN      ] VulkanAPITest.cat_3d_dim1_diffheight_success
[       OK ] VulkanAPITest.cat_3d_dim1_diffheight_success (21 ms)
[ RUN      ] VulkanAPITest.cat_3d_dim1_same_height_success
[       OK ] VulkanAPITest.cat_3d_dim1_same_height_success (10 ms)
[ RUN      ] VulkanAPITest.cat_3d_dim2_diffwidth_success
[       OK ] VulkanAPITest.cat_3d_dim2_diffwidth_success (21 ms)
[ RUN      ] VulkanAPITest.cat_3d_dim2_samewidth_success
[       OK ] VulkanAPITest.cat_3d_dim2_samewidth_success (11 ms)
[ RUN      ] VulkanAPITest.cat_3d_dim0_negdim_success
[       OK ] VulkanAPITest.cat_3d_dim0_negdim_success (25 ms)
[ RUN      ] VulkanAPITest.cat_3d_dim1_negdim_success
[       OK ] VulkanAPITest.cat_3d_dim1_negdim_success (23 ms)
[ RUN      ] VulkanAPITest.cat_3d_dim2_negdim_success
[       OK ] VulkanAPITest.cat_3d_dim2_negdim_success (10 ms)
[ RUN      ] VulkanAPITest.cat_2d_dim0_same_height_success
[       OK ] VulkanAPITest.cat_2d_dim0_same_height_success (3 ms)
[ RUN      ] VulkanAPITest.cat_2d_dim0_diff_height_success
[       OK ] VulkanAPITest.cat_2d_dim0_diff_height_success (2 ms)
[ RUN      ] VulkanAPITest.cat_2d_dim1_same_width_success
[       OK ] VulkanAPITest.cat_2d_dim1_same_width_success (3 ms)
[ RUN      ] VulkanAPITest.cat_2d_dim1_diff_width_success
[       OK ] VulkanAPITest.cat_2d_dim1_diff_width_success (4 ms)
[ RUN      ] VulkanAPITest.cat_2d_dim0_negdim_success
[       OK ] VulkanAPITest.cat_2d_dim0_negdim_success (3 ms)
[ RUN      ] VulkanAPITest.cat_2d_dim1_negdim_success
[       OK ] VulkanAPITest.cat_2d_dim1_negdim_success (3 ms)
[ RUN      ] VulkanAPITest.cat_1d_dim0_same_width_success
[       OK ] VulkanAPITest.cat_1d_dim0_same_width_success (52 ms)
[ RUN      ] VulkanAPITest.cat_1d_dim0_diff_width_success
[       OK ] VulkanAPITest.cat_1d_dim0_diff_width_success (0 ms)
[ RUN      ] VulkanAPITest.cat_1d_dim0_negdim_success
[       OK ] VulkanAPITest.cat_1d_dim0_negdim_success (0 ms)
[----------] 43 tests from VulkanAPITest (1717 ms total)

[----------] Global test environment tear-down
[==========] 43 tests from 1 test suite ran. (1717 ms total)
[  PASSED  ] 43 tests.

  YOU HAVE 4 DISABLED TESTS
```

Differential Revision: D49566743


