### PR TITLE
Fix S367052 to unblock ICVR MC3

### DIFF
--- a/torch/fx/passes/annotate_getitem_nodes.py
+++ b/torch/fx/passes/annotate_getitem_nodes.py
@@ -23,9 +23,7 @@ def annotate_getitem_nodes(graph: torch.fx.Graph) -> None:
             # container types
             if hasattr(sequence_node.type, "_name"):
                 parameterized_types = sequence_node.type.__args__
-                if sequence_node.type._name == "Tensor":
-                    continue
-                elif sequence_node.type._name == "Tuple":
+                if sequence_node.type._name == "Tuple":
                     if len(parameterized_types) == 2 and isinstance(
                         parameterized_types[1], type(...)
                     ):
@@ -39,6 +37,8 @@ def annotate_getitem_nodes(graph: torch.fx.Graph) -> None:
                     node.type = parameterized_types[0]
             # NamedTuple type
             elif hasattr(sequence_node.type, "__annotations__"):
+                if sequence_node.type == torch.Tensor:
+                    continue
                 sequence_node_field_types = sequence_node.type.__annotations__
                 field_name = sequence_node.type._fields[index_node]
                 node.type = sequence_node_field_types[field_name]


### PR DESCRIPTION
Summary: Somehow "getitem" started to get Tensor starting from ads_ranking:996 and broke SDD pipelining FX-transformer. We need to skip the Tensor node in annotation.

Test Plan:
N4326037
with ads_ranking kernel
# Before
ads_ranking:v996
 {F1100009226}
# With this diff
 {F1100009310}

Differential Revision: D49567615


