### PR TITLE
[HigherOrderOp] wrap (and checkpoint) should accept pytree inputs

### DIFF
--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -337,6 +337,18 @@ def forward(self, l_x_, size):
         y = torch.randn(3, 3)
         self._test_wrap_simple(f, (x, y, (x, y)), 3)
 
+    def test_wrap_pytree_args_not_const_symint_tensor(self):
+        class MyClass:
+            def __init__(self, x):
+                self.val = x
+
+        def f(x, y):
+            return wrap(lambda z: z[0].sin() * z[1].val.cos(), (x, y))
+
+        x = torch.tensor(1.2)
+        y = MyClass(torch.tensor(3.4))
+        self._assert_wrap_fallback(f, (x, y))
+
     def test_capture_constants(self):
         x = torch.randn(3, 3)
         y = 4.0
@@ -1626,7 +1638,7 @@ def forward(self):
         assert_dict_matches_regex(
             self,
             dict(counters["graph_break"]),
-            {".*HigherOrderOperator body's output must consist of tensors only": 1},
+            {".*torch.* op returned non-Tensor dict call_function": 1},
         )
 
     def test_access_module_attr(self):

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -126,8 +126,7 @@ class HigherOrderOpTests(torch._dynamo.test_case.TestCase):
         args,
         expected_num_wrap_args,
         expected_opcount=1,
-        expected_graph=None,
-        expected_body_graph=None,
+        return_graph=False,
     ):
         # Given a `func` that has a single call to `wrap`,
         # we check that:
@@ -149,12 +148,8 @@ class HigherOrderOpTests(torch._dynamo.test_case.TestCase):
         graph = backend.graphs[0]
         wrap_node = find_first_node(graph, wrap)
         self.assertEqual(len(wrap_node.args), expected_num_wrap_args)
-        if expected_graph:
-            self.assertExpectedInline(graph.code.strip(), expected_graph)
-        if expected_body_graph:
-            self.assertExpectedInline(
-                graph.wrap_body_0.code.strip(), expected_body_graph
-            )
+        if return_graph:
+            return normalize_gm(graph.print_readable(print_output=False))
 
     def test_error_message_sane(self):
         foo = []
@@ -253,31 +248,34 @@ class HigherOrderOpTests(torch._dynamo.test_case.TestCase):
         y = torch.tensor(2.0)
         z = torch.tensor(3.0)
         d = {"x": x, "y": (y, [x, y, z])}
-        expected_graph = """
-def forward(self, L_x_ : torch.Tensor, L_y_ : torch.Tensor, L_z_ : torch.Tensor):
-    l_x_ = L_x_
-    l_y_ = L_y_
-    l_z_ = L_z_
-    wrap_body_0 = self.wrap_body_0
-    wrap = torch._higher_order_ops.wrap.wrap(wrap_body_0, l_x_, l_y_, l_z_);  \
-wrap_body_0 = l_x_ = l_y_ = l_z_ = None
-    return (wrap,)
-        """.strip()
-        body_graph = """
-def forward(self, l_x_, l_y_, l_z_):
-    sin = l_x_.sin();  l_x_ = None
-    cos = l_y_.cos();  l_y_ = None
-    add = sin + cos;  sin = cos = None
-    sin_1 = l_z_.sin();  l_z_ = None
-    sub = add - sin_1;  add = sin_1 = None
-    return sub
-        """.strip()
-        self._test_wrap_simple(
+        actual_graph = self._test_wrap_simple(
             f,
             (x, y, z),
             4,
-            expected_graph=expected_graph,
-            expected_body_graph=body_graph,
+            return_graph=True,
+        )
+        self.assertExpectedInline(
+            actual_graph,
+            """\
+class GraphModule(torch.nn.Module):
+    def forward(self, L_x_ : torch.Tensor, L_y_ : torch.Tensor, L_z_ : torch.Tensor):
+        l_x_ = L_x_
+        l_y_ = L_y_
+        l_z_ = L_z_
+
+        wrap_body_0 = self.wrap_body_0
+        wrap = torch._higher_order_ops.wrap.wrap(wrap_body_0, l_x_, l_y_, l_z_);  wrap_body_0 = l_x_ = l_y_ = l_z_ = None
+        return (wrap,)
+
+    class GraphModule(torch.nn.Module):
+        def forward(self, l_x_, l_y_, l_z_):
+            sin = l_x_.sin();  l_x_ = None
+            cos = l_y_.cos();  l_y_ = None
+            add = sin + cos;  sin = cos = None
+            sin_1 = l_z_.sin();  l_z_ = None
+            sub = add - sin_1;  add = sin_1 = None
+            return sub
+""",
         )
 
     def test_wrap_pytree_args_with_symint_constant(self):
@@ -287,43 +285,53 @@ def forward(self, l_x_, l_y_, l_z_):
 
         x = torch.randn(3, 1)
         y = 0.5
-        static_graph = """
-def forward(self, L_x_ : torch.Tensor):
-    l_x_ = L_x_
-    wrap_body_0 = self.wrap_body_0
-    wrap = torch._higher_order_ops.wrap.wrap(wrap_body_0, l_x_);  wrap_body_0 = l_x_ = None
-    return (wrap,)
-        """.strip()
-        static_body_graph = """
-def forward(self, l_x_):
-    view = l_x_.view(3);  l_x_ = None
-    add = view + 0.5;  view = None
-    return add
-        """.strip()
-        dynamic_graph = """
-def forward(self, s0 : torch.SymInt, L_x_ : torch.Tensor):
-    l_x_ = L_x_
-    size = l_x_.size(0)
-    wrap_body_0 = self.wrap_body_0
-    wrap = torch._higher_order_ops.wrap.wrap(wrap_body_0, l_x_, size);  wrap_body_0 = l_x_ = size = None
-    return (wrap,)
-        """.strip()
-        dynamic_body_graph = """
-def forward(self, l_x_, size):
-    view = l_x_.view(size);  l_x_ = size = None
-    add = view + 0.5;  view = None
-    return add
-        """.strip()
-        self._test_wrap_simple(
+        actual_graph = self._test_wrap_simple(
             f,
             (x, y),
             ifdynstaticdefault(2, 3),
             expected_opcount=ifdynstaticdefault(1, 2),
-            expected_graph=ifdynstaticdefault(static_graph, dynamic_graph),
-            expected_body_graph=ifdynstaticdefault(
-                static_body_graph, dynamic_body_graph
-            ),
+            return_graph=True,
         )
+        if torch._dynamo.config.assume_static_by_default:
+            self.assertExpectedInline(
+                actual_graph,
+                """\
+class GraphModule(torch.nn.Module):
+    def forward(self, L_x_ : torch.Tensor):
+        l_x_ = L_x_
+
+        wrap_body_0 = self.wrap_body_0
+        wrap = torch._higher_order_ops.wrap.wrap(wrap_body_0, l_x_);  wrap_body_0 = l_x_ = None
+        return (wrap,)
+
+    class GraphModule(torch.nn.Module):
+        def forward(self, l_x_):
+            view = l_x_.view(3);  l_x_ = None
+            add = view + 0.5;  view = None
+            return add
+""",
+            )
+        else:
+            self.assertExpectedInline(
+                actual_graph,
+                """\
+class GraphModule(torch.nn.Module):
+    def forward(self, s0 : torch.SymInt, L_x_ : torch.Tensor):
+        l_x_ = L_x_
+
+        size = l_x_.size(0)
+
+        wrap_body_0 = self.wrap_body_0
+        wrap = torch._higher_order_ops.wrap.wrap(wrap_body_0, l_x_, size);  wrap_body_0 = l_x_ = size = None
+        return (wrap,)
+
+    class GraphModule(torch.nn.Module):
+        def forward(self, l_x_, size):
+            view = l_x_.view(size);  l_x_ = size = None
+            add = view + 0.5;  view = None
+            return add
+""",
+            )
 
     def test_wrap_pytree_kwargs(self):
         def f(x, y, z):

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -227,6 +227,14 @@ class HigherOrderOpTests(torch._dynamo.test_case.TestCase):
             f, (x,), ifdynstaticdefault(2, 3), expected_opcount=ifdynstaticdefault(1, 2)
         )
 
+    def test_wrap_pytree_inputs(self):
+        def f(x, y):
+            return wrap(lambda z: z[0].sin() * z[1].cos(), (x, y))
+
+        x = torch.tensor(1.5)
+        y = torch.tensor(2.0)
+        self._test_wrap_simple(f, (x, y), 3)
+
     def test_capture_constants(self):
         x = torch.randn(3, 3)
         y = 4.0

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -28,6 +28,7 @@ from ..exc import (
 from ..guards import GuardBuilder
 from ..source import FSDPNNModuleSource, GetItemSource, NNModuleSource
 from ..utils import proxy_args_kwargs
+from .dicts import ConstDictVariable
 from .lists import ListVariable, TupleVariable
 from .nn_module import NNModuleVariable
 
@@ -71,13 +72,13 @@ def dynamo_enable_grad(tx):
         GradModeVariable.create(tx, org_value)
 
 
-def are_tensors(var):
-    from . import TensorVariable
-
-    if isinstance(var, TensorVariable):
+def only_consist_of(var, types):
+    if isinstance(var, types):
         return True
     if isinstance(var, (TupleVariable, ListVariable)):
-        return all(are_tensors(item) for item in var.items)
+        return all(only_consist_of(item, types) for item in var.items)
+    if isinstance(var, ConstDictVariable):
+        return all(only_consist_of(item, types) for item in var.items.values())
     return False
 
 
@@ -140,7 +141,15 @@ def validate_args_and_maybe_create_graph_inputs(
                     f"Got: {a.python_type()}"
                 )
             else:
-                new_arg = a
+                # leverage tracer's lifting mechanism to lift these args.
+                if only_consist_of(
+                    a, (ConstantVariable, SymNodeVariable, TensorVariable)
+                ):
+                    new_arg = a
+                else:
+                    unimplemented(
+                        "HigherOrderOperator with body that accepts non-Tensors as input that can't be lifted by tracer."
+                    )
 
         args.append(new_arg)
     return args
@@ -214,7 +223,9 @@ def speculate_subgraph(
                 # Nothing left to do here
                 return output, tx.output.graph, tracer.lifted_freevars
             else:
-                if not are_tensors(output):
+                from . import TensorVariable
+
+                if not only_consist_of(output, TensorVariable):
                     unimplemented(
                         "HigherOrderOperator body's output must consist of tensors only"
                     )

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -134,10 +134,13 @@ def validate_args_and_maybe_create_graph_inputs(
                 tracer.create_graph_input(a.as_proxy().node.name)
             new_arg = a
         else:
-            raise unimplemented(
-                f"HigherOrderOperator with body that accepts non-Tensors as input. "
-                f"Got: {a.python_type()}"
-            )
+            if manually_set_subgraph_inputs:
+                raise unimplemented(
+                    f"HigherOrderOperator with body that accepts non-Tensors as input. "
+                    f"Got: {a.python_type()}"
+                )
+            else:
+                new_arg = a
 
         args.append(new_arg)
     return args


### PR DESCRIPTION
Fixes #109250


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng