### PR TITLE
[WIP] Make ONNX OpSchema function matcher more robust

### DIFF
--- a/torch/onnx/_internal/fx/fx_onnx_interpreter.py
+++ b/torch/onnx/_internal/fx/fx_onnx_interpreter.py
@@ -637,10 +637,6 @@ class FxOnnxInterpreter:
             fx_name_to_onnxscript_value[node.name] = output
             return
 
-        default_and_custom_functions = onnxfunction_dispatcher.get_function_overloads(
-            node, self.diagnostic_context
-        )
-
         # Map FX inputs to ONNX inputs and fill optional inputs with default values.
         # torch_args and torch_kwargs are for op-level validation
         fx_args, fx_kwargs, default_set_kwargs = _fill_in_default_kwargs(node)


### PR DESCRIPTION
Make the algorithm for "finding the perfect/nearest matched OnnxFunction for the given FX node, arguments, and keyword arguments" more robust in the case when keyword arguments differ, but are set to the default value.

For example:
- fx node is: "split" (tensor,dim,drop_remainder=False (default value))
- ONNX op is: "split" (tensor,dim)

(see PR #107484 which adds an optional drop_remainder=False to torch.split). The [corresponding torch op in ONNX script](https://github.com/microsoft/onnxscript/blob/b6c5e3bb9729f939e979a41d8d724009df9f3b58/onnxscript/function_libs/torch_lib/ops/core.py#L6918) doesn't yet have the new attribute "drop_remainder", this causes the following error during ONNX dynamo_export:

`torch.onnx._internal.diagnostics.infra.context.RuntimeErrorWithDiagnostic: Cannot find any perfect/nearest match of symbolic function for aten::split.Tensor,which should be registered under aten.split.Tensor.`

(because of the attribute list mismatch between ONNX script torch_op and the Pytorch fx node).

This PR improves the lookup of a any perfect/nearest match of symbolic function, by ignoring keyword attributes that are set to a default value (which should be backward compatible).

Fixes https://github.com/pytorch/pytorch/issues/110131