### PR TITLE
chore(inductor): Simplify `will_fusion_create_cycle` and cleanup to `node.ancestors` 

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2283,7 +2283,7 @@ class TritonScheduling(BaseScheduling):
                         node not in done
                         and fits_in_main_body(other_node)
                         and not (
-                            current_loop_writes & other_node.recursive_predecessors
+                            current_loop_writes & other_node.ancestors
                         )
                     ):
                         done.add(node)
@@ -2308,7 +2308,7 @@ class TritonScheduling(BaseScheduling):
             def requires_closing_previous_reduction(node, node_schedule):
                 if rnumel == 1:
                     return False
-                if not current_loop_writes & node.recursive_predecessors:
+                if not current_loop_writes & node.ancestors:
                     return False
                 assert node_schedule and not isinstance(
                     node_schedule[-1], (EnableReduction, DisableReduction)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2282,9 +2282,7 @@ class TritonScheduling(BaseScheduling):
                     if (
                         node not in done
                         and fits_in_main_body(other_node)
-                        and not (
-                            current_loop_writes & other_node.ancestors
-                        )
+                        and not (current_loop_writes & other_node.ancestors)
                     ):
                         done.add(node)
                         current_loop_writes.add(node.get_name())

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -84,7 +84,7 @@ class BaseSchedulerNode:
         self.users: Optional[List[NodeUser]] = None
         self.inverse_users: List[BaseSchedulerNode] = []
         self.set_read_writes(node.get_read_writes())
-        self.recursive_predecessors: Optional[Set[str]] = None
+        self.ancestors: Optional[Set[str]] = None
         self.min_order: Optional[int] = None
         self.max_order: Optional[int] = None
         self.last_usage: Set[str] = None  # buffers that won't be used after this kernel
@@ -724,9 +724,7 @@ class FusedSchedulerNode(BaseSchedulerNode):
         self.users = None
         self.inverse_users = []
         self.group = max(snodes, key=lambda x: int(x.is_reduction())).group
-        self.recursive_predecessors = set.union(
-            *[x.recursive_predecessors for x in snodes]
-        )
+        self.ancestors = set.union(*[x.ancestors for x in snodes])
 
         self.set_read_writes(
             dependencies.ReadWrites.merge_list([x.read_writes for x in snodes])
@@ -967,8 +965,8 @@ class ForeachKernelSchedulerNode(FusedSchedulerNode):
             foreach_node = prev_node_1 if prev_node_1.is_foreach() else prev_node_2
             other_node = prev_node_2 if prev_node_1.is_foreach() else prev_node_1
 
-            self.recursive_predecessors = foreach_node.recursive_predecessors
-            self.recursive_predecessors.update(other_node.recursive_predecessors)
+            self.ancestors = foreach_node.ancestors
+            self.ancestors.update(other_node.ancestors)
 
             self.name_to_node = foreach_node.name_to_node
             for name in other_node.get_names():
@@ -1098,7 +1096,7 @@ class Scheduler:
         self.compute_dependencies()
         self.topological_sort_schedule()
         self.dead_node_elimination()
-        self.compute_predecessors()
+        self.compute_ancestors()
 
         metrics.ir_nodes_pre_fusion += len(self.nodes)
         V.debug.ir_pre_fusion(self.nodes)
@@ -1335,19 +1333,19 @@ class Scheduler:
             visit(node)
         self.nodes = result
 
-    def compute_predecessors(self):
+    def compute_ancestors(self):
         """
-        Populate each node.recursive_predecessors
+        Populate each node.ancestors
         """
         # note self.nodes is topologically sorted
-        name_to_predecessors = {}
+        name_to_ancestors = {}
         for node in self.nodes:
-            recursive_predecessors = set()
+            ancestors = set()
             for dep in node.unmet_dependencies:
-                recursive_predecessors.add(dep.name)
-                recursive_predecessors |= name_to_predecessors[dep.name]
-            name_to_predecessors[node.get_name()] = recursive_predecessors
-            node.recursive_predecessors = recursive_predecessors
+                ancestors.add(dep.name)
+                ancestors |= name_to_ancestors[dep.name]
+            name_to_ancestors[node.get_name()] = ancestors
+            node.ancestors = ancestors
 
         for order, node in enumerate(self.nodes):
             node.min_order = order
@@ -1435,34 +1433,32 @@ class Scheduler:
         return sorted(possible_fusions, key=self.score_fusion_key, reverse=True)
 
     def will_fusion_create_cycle(self, node1, node2):
-        """Finds whether there's a path from src to dst caused indirectly by fusion"""
+        """
+        Finds whether there's a path from fusion(node1, node2) to itself
+        caused indirectly by fusion
+        """
 
-        def check(node):
+        def check_backedge(node):
             if isinstance(node, FusedSchedulerNode) and node not in visited:
                 visited.add(node)
-                cond0 = bool(combined_names & node.recursive_predecessors)
-
-                if cond0:
-                    return cond0
-
-                names = node.get_names()
-                shortcut = names.issubset(combined_predecessors)
-
-                if shortcut:
-                    return cond0
+                if bool(combined_names & node.ancestors):
+                    return True
+                elif node.get_names().issubset(combined_ancestors):
+                    # their ancestors will be checked anyway
+                    return False
                 else:
                     return any(
-                        check(self.name_to_fused_node[n])
-                        for n in node.recursive_predecessors - combined_predecessors
+                        check_backedge(self.name_to_fused_node[n])
+                        for n in node.ancestors - combined_ancestors
                     )
             return False
 
         visited = set()
         combined_names = node1.get_names() | node2.get_names()
-        combined_predecessors = (
-            node1.recursive_predecessors | node2.recursive_predecessors
-        ) - combined_names
-        return any(check(self.name_to_fused_node[n]) for n in combined_predecessors)
+        combined_ancestors = (node1.ancestors | node2.ancestors) - combined_names
+        return any(
+            check_backedge(self.name_to_fused_node[n]) for n in combined_ancestors
+        )
 
     def can_fusion_increase_peak_memory(
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
@@ -1513,7 +1509,7 @@ class Scheduler:
         if node1.is_foreach() or node2.is_foreach():
             return ForeachKernelSchedulerNode.can_fuse(node1, node2)
 
-        if node2.get_names() & node1.recursive_predecessors:
+        if node2.get_names() & node1.ancestors:
             return False  # node2 must go before node1
 
         if (
@@ -1561,7 +1557,7 @@ class Scheduler:
         ):
             return False  # heuristic not needed for correctness
 
-        if node1.get_names() & node2.recursive_predecessors:
+        if node1.get_names() & node2.ancestors:
             # node2 depends on node1 outputs
             if not self.can_fuse_vertical(node1, node2):
                 return False
@@ -1607,7 +1603,7 @@ class Scheduler:
             #   - MemoryDep("foo", x) != StarDep("foo")
             return False
         for name in remaining_deps:
-            if node1_names & self.name_to_fused_node[name].recursive_predecessors:
+            if node1_names & self.name_to_fused_node[name].ancestors:
                 return False
         return True
 


### PR DESCRIPTION
recursive_predecessors == ancestors so rename. 

Improve comments

Simplify `will_fusion_create_cycle` - make it easier to read and add detailed comments.

Diagram to illustrate clarification of shortcut.
![Inductor Deep Dive](https://github.com/pytorch/pytorch/assets/9093549/7a30e088-8a33-4a9c-a8a7-81199cd086e2)


CC: @ngimel 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler