### PR TITLE
[TP][Inference] Add aten.linear.default op implementation

### DIFF
--- a/torch/distributed/_tensor/ops/matrix_ops.py
+++ b/torch/distributed/_tensor/ops/matrix_ops.py
@@ -6,6 +6,7 @@ import torch
 from torch.distributed._tensor.op_schema import OpSchema, OutputSharding
 from torch.distributed._tensor.ops.common_rules import einop_rule, pointwise_rule
 from torch.distributed._tensor.ops.utils import register_prop_rule
+from torch.distributed._tensor.placement_types import DTensorSpec, Shard, TensorMeta
 
 aten = torch.ops.aten
 
@@ -81,6 +82,61 @@ def addmm_rules(op_schema: OpSchema) -> OutputSharding:
         return _update_schema_suggestion_for_addmm(output_sharding, op_schema)
 
     return output_sharding
+
+
+@register_prop_rule(aten.linear.default)
+def linear_rules(op_schema: OpSchema) -> OutputSharding:
+    if len(op_schema.args_spec) < 3:
+        input_spec, weight_spec = op_schema.args_spec
+        bias_spec = None
+    else:
+        input_spec, weight_spec, bias_spec = op_schema.args_spec
+    if (not isinstance(weight_spec, DTensorSpec) or len(weight_spec.placements) > 1):
+        raise NotImplementedError("Only support weight sharded by one dimension.")
+    input_dim = len(input_spec.tensor_meta.shape)
+    t_weight_spec = DTensorSpec(
+        mesh=weight_spec.mesh,
+        placements=tuple(
+            Shard(len(weight_spec.tensor_meta.shape) - p.dim - 1)
+            for p in weight_spec.placements
+        ),
+        tensor_meta=TensorMeta(
+            shape=(weight_spec.tensor_meta.shape[1], weight_spec.tensor_meta.shape[0]),
+            stride=(weight_spec.tensor_meta.stride[1], weight_spec.tensor_meta.stride[0]),
+            dtype=weight_spec.tensor_meta.dtype,
+        )
+    )
+    alphabet = "abcdefghijlopqrstuvwxyz"
+    einrule = f"m{alphabet[:input_dim - 2]}k,kn->mn"
+    mm_out_sharding = einop_rule(einrule, OpSchema(op_schema.op, (input_spec, t_weight_spec), {}), linearity=False)
+    if mm_out_sharding.output_spec is None:
+        # non-eligible input, suggest addmm input specs
+        if mm_out_sharding.schema_suggestions is not None:
+            # TODO: add more suggestions for resharding
+            return _update_schema_suggestion_for_addmm(
+                mm_out_sharding,
+                op_schema,
+                pointwise_add_update=False,
+            )
+        else:
+            return OutputSharding(None)
+
+    if bias_spec is not None:
+        # run point wise rule on input + (mm_out) with linearity
+        output_sharding = pointwise_rule(
+            OpSchema(op_schema.op, (bias_spec, mm_out_sharding.output_spec), {}),
+            linearity=True,
+        )
+        # if propagation failed, edit the schema suggestion from pointwise rules
+        # to return addmm suggestion instead as it's a chained suggestion.
+        if (
+            output_sharding.output_spec is None
+            and output_sharding.schema_suggestions is not None
+        ):
+            return _update_schema_suggestion_for_addmm(output_sharding, op_schema)
+        return output_sharding
+    else:
+        return mm_out_sharding
 
 
 @register_prop_rule(aten.t.default)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #109977

A Hack to unblock dist inference for now. Will sync with @wanchaol to see how we can land this before PT conference. Somehow in the inference part, the `aten.linear.default` rather than `aten.addmm.default` is called. (Maybe because of fp16/bf16?). So we need to support this op so that folks can do TP on inference.
