### PR TITLE
Add support for event_tracer in codegen layer

### DIFF
--- a/test/edge/event_tracer.h
+++ b/test/edge/event_tracer.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <stdlib.h>
+#include <cstdint>
+
+#pragma once
+
+namespace torch {
+namespace executor {
+
+typedef uint32_t AllocatorID;
+typedef int32_t ChainID;
+typedef uint32_t DebugHandle;
+
+/**
+ * EventTracer is a class that users can inherit and implement to
+ * log/serialize/stream etc. the profiling and debugging events that are
+ * generated at runtime for a model. An example of this is the ETDump
+ * implementation in the SDK codebase that serializes these events to a
+ * flatbuffer.
+ */
+class EventTracer {};
+
+struct EventTracerEntry {};
+
+} // namespace executor
+} // namespace torch

--- a/test/edge/event_tracer_hooks.h
+++ b/test/edge/event_tracer_hooks.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <event_tracer.h>
+
+/**
+ * @file
+ *
+ * This file contains the hooks that are inserted across various parts of the
+ * core runtime code to call into the EventTracer class for logging of profiling
+ * and debugging events. Any calls made to the EventTracer from the runtime must
+ * be made via these hooks.
+ * Users shouldn't directly add these hooks in their code and it's meant only
+ * for usage in ExecuTorch internal code.
+ *
+ * The benefit of defining these hooks is that we can easily control whether or
+ * not we want to compile in the EventTracer code based on the status of the
+ * ET_EVENT_TRACER_ENABLED flag.
+ */
+
+namespace torch {
+namespace executor {
+namespace internal {
+
+/**
+ * This class enables scope based profiling where needed using RAII.
+ * Profiling will be started when the object is created and will end
+ * when the object goes out of scope.
+ */
+class EventTracerProfileScope final {
+ public:
+  EventTracerProfileScope(EventTracer* event_tracer, const char* name) {};
+
+  ~EventTracerProfileScope() {};
+
+ private:
+  EventTracer* event_tracer_;
+  EventTracerEntry event_entry_;
+};
+
+/**
+ * This class helps us set and then clear out the chain id and debug handle
+ * values stored in the event tracer class using RAII. This is typically called
+ * in the executor loop before entering the codegen layer to configure the chain
+ * id and debug handle of the current instruction being executed.
+ * After we return from the kernel execution we can then reset the chain id and
+ * debug handle to defaults when this object goes out of scope.
+ */
+class EventTracerProfileInstructionScope final {
+ public:
+  EventTracerProfileInstructionScope(
+      EventTracer* event_tracer,
+      ChainID chain_idx,
+      DebugHandle debug_handle) {};
+
+  ~EventTracerProfileInstructionScope() {};
+
+ private:
+  EventTracer* event_tracer_;
+};
+
+
+} // namespace internal
+} // namespace executor
+} // namespace torch

--- a/test/edge/kernel_runtime_context.h
+++ b/test/edge/kernel_runtime_context.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "event_tracer.h"
+
 namespace torch {
 namespace executor {
 
@@ -15,7 +17,28 @@ namespace executor {
  * operators that need more then constant space, and a TensorResizer for dynamic
  * shape tensors allowing programs to be more flexible with Tensor shape.
  */
-class KernelRuntimeContext {};
+class KernelRuntimeContext {
+  public:
+  /**
+   * Construct a new kernel runtime context along with an optional event tracer.
+   */
+  KernelRuntimeContext(EventTracer* event_tracer = nullptr)
+      : event_tracer_(event_tracer) {}
+
+  /**
+   * INTERNAL ONLY
+   *
+   * Returns a pointer to an instance of EventTracer to do profiling/debugging
+   * logging inside the codegen layer. This is only for internal usage inside
+   * the codegen layer and users should not be accessing this.
+   */
+  EventTracer* internal_event_tracer() {
+    return event_tracer_;
+  }
+
+  private:
+  EventTracer* event_tracer_;
+};
 
 } // namespace executor
 } // namespace torch

--- a/test/edge/templates/RegisterCodegenUnboxedKernels.cpp
+++ b/test/edge/templates/RegisterCodegenUnboxedKernels.cpp
@@ -1,8 +1,11 @@
 #include <operator_registry.h>
+#include <event_tracer_hooks.h>
 #include "${fn_header}" // Generated Function import headers
 
 namespace torch {
 namespace executor {
+
+using namespace internal;
 
 namespace {
 using KernelArrayRef = ::at::ArrayRef<::torch::executor::Kernel>;

--- a/tools/test/test_executorch_gen.py
+++ b/tools/test/test_executorch_gen.py
@@ -467,6 +467,7 @@ Kernel(
         """
             + """
 
+        internal::EventTracerProfileScope event_tracer_scope(context.internal_event_tracer(), "native_call_op_1");
         EXECUTORCH_SCOPE_PROF("native_call_op_1");
         bool result_ = at::native::default_kernel(context, );
 
@@ -552,6 +553,7 @@ Kernel(
         """
             + """
 
+        internal::EventTracerProfileScope event_tracer_scope(context.internal_event_tracer(), "native_call_op_1");
         EXECUTORCH_SCOPE_PROF("native_call_op_1");
         bool result_ = at::native::default_kernel(context, );
 
@@ -586,6 +588,7 @@ Kernel(
         """
             + """
 
+        internal::EventTracerProfileScope event_tracer_scope(context.internal_event_tracer(), "native_call_op_1");
         EXECUTORCH_SCOPE_PROF("native_call_op_1");
         bool result_ = at::native::default_kernel(context, );
 

--- a/torchgen/gen_executorch.py
+++ b/torchgen/gen_executorch.py
@@ -234,6 +234,7 @@ Kernel(
     []({contextArg.defn()}, EValue** stack) {{
         {code_connector.join(code_list)}
 
+        internal::EventTracerProfileScope event_tracer_scope(context.internal_event_tracer(), "native_call_{f.func.name}");
         EXECUTORCH_SCOPE_PROF("native_call_{f.func.name}");
         {ret_prefix}{kernel_call}(context, {args_str});
 


### PR DESCRIPTION
Summary: Split out from D48975975, this handles the pytorch specific changes to add support for event_tracer in codegen layer.

Test Plan: CI

Reviewed By: dbort

Differential Revision: D49487710


