### PR TITLE
[aotinductor] Update benchmark to include compilation time

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2293,12 +2293,21 @@ class BenchmarkRunner:
             eager_latency, eager_peak_mem, _ = warmup(
                 self.model_iter_fn, model, example_inputs, "eager"
             )
-            optimized_model_iter_fn = optimize_ctx(self.model_iter_fn)
+
+            if self.args.export_aot_inductor:
+                t_0 = time.perf_counter()
+                optimized_model_iter_fn = optimize_ctx(self.model_iter_fn)
+                t_1 = time.perf_counter()
+                aot_compilation_time = t_1 - t_0
+            else:
+                optimized_model_iter_fn = optimize_ctx(self.model_iter_fn)
+                aot_compilation_time = 0
+
             dynamo_latency, dynamo_peak_mem, dynamo_stats = warmup(
                 optimized_model_iter_fn, model, example_inputs, "dynamo"
             )
 
-            compilation_time = dynamo_latency - eager_latency
+            compilation_time = dynamo_latency - eager_latency + aot_compilation_time
             compression_ratio = (
                 eager_peak_mem / dynamo_peak_mem if dynamo_peak_mem else 0.0
             )


### PR DESCRIPTION
Fixes [comment](https://github.com/pytorch/pytorch/pull/109820#pullrequestreview-1638629777)
Updated benchmark [here](https://hud.pytorch.org/benchmark/compilers?startTime=Fri%2C%2022%20Sep%202023%2022%3A39%3A50%20GMT&stopTime=Mon%2C%2025%20Sep%202023%2022%3A39%3A50%20GMT&granularity=hour&suite=torchbench&mode=inference&dtype=bfloat16&lBranch=angelayi/aot_inductor_bench_comp_time&lCommit=e20364c231e0ba9dc2b5fb259d91a897ea9172a0&rBranch=main&rCommit=85ddc985d098d00e81ec6539d9a006751e85d1ea)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng