### PR TITLE
[profiler] use PyCFunction_Check to check both PyCMethod_Type and PyC…

### DIFF
--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -872,7 +872,7 @@ void PythonTracer::recordCCall(
     ThreadLocalResults& tls,
     PyFrameObject* frame,
     PyObject* arg) {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(Py_TYPE(arg) == &PyCFunction_Type);
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(PyCFunction_Check(arg));
   auto fn = reinterpret_cast<PyCFunctionObject*>(arg);
 
   // NB: For C calls a new frame is not created, so we use `frame` rather than


### PR DESCRIPTION
At https://github.com/pytorch/pytorch/blob/main/torch/csrc/autograd/profiler_python.cpp#L1096, when what is PyTrace_C_CALL, Py_TYPE(arg) only can be PyCFunction_Type before python3.9. But in python3.9 or later, Py_TYPE(arg) also can be PyCMethod_Type. 
PyCMethod_Type is subtype of PyCFunction_Type, ref to
https://github.com/python/cpython/blob/f2eaa92b0cc5a37a9e6010c7c6f5ad1a230ea49b/Objects/methodobject.c#L372.
So there should use PyCFunction_Check to check arg->ob_type.

Fixes #109877 
