### PR TITLE
[aotinductor] support _scaled_dot_product_flash_attention fallback

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -538,14 +538,49 @@ class AOTInductorTestsTemplate:
             constraints=constraints,
         )
 
+    # scaled_dot_product_flash_attention
+    def test_sdpa(self):
+        class Repro(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
 
-class AOTInductorTestABICompatibile(TestCase):
+            def forward(self, q, k, v):
+                return torch.ops.aten._scaled_dot_product_flash_attention(q, k, v)[0]
+
+        example_inputs = (
+            torch.randn(1, 48, 64, 64, dtype=torch.bfloat16, device="cuda"),
+            torch.randn(1, 48, 64, 64, dtype=torch.bfloat16, device="cuda"),
+            torch.randn(1, 48, 64, 64, dtype=torch.bfloat16, device="cuda"),
+        )
+        self.check_model(Repro(), example_inputs)
+
+    def test_sdpa_2(self):
+        class Repro(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, q, k, v, x):
+                t = torch.ops.aten._scaled_dot_product_flash_attention(
+                    q, k, v, is_causal=True
+                )[0]
+                return x + t
+
+        example_inputs = (
+            torch.randn(1, 48, 64, 64, dtype=torch.bfloat16, device="cuda"),
+            torch.randn(1, 48, 64, 64, dtype=torch.bfloat16, device="cuda"),
+            torch.randn(1, 48, 64, 64, dtype=torch.bfloat16, device="cuda"),
+            torch.randn(1, 48, 64, 64, dtype=torch.bfloat16, device="cuda"),
+        )
+        self.check_model(Repro(), example_inputs)
+
+
+class AOTInductorTestABICompatible(TestCase):
     abi_compatible = True
     check_model = check_model
     check_model_with_multiple_inputs = check_model_with_multiple_inputs
 
 
-copy_tests(AOTInductorTestsTemplate, AOTInductorTestABICompatibile, "abi_compatible")
+copy_tests(AOTInductorTestsTemplate, AOTInductorTestABICompatible, "abi_compatible")
 
 
 class AOTInductorTestNonABICompatible(TestCase):

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -545,7 +545,7 @@ class AOTInductorTestsTemplate:
                 super().__init__()
 
             def forward(self, q, k, v):
-                return torch.ops.aten._scaled_dot_product_flash_attention(q, k, v)[0]
+                return torch.nn.functional.scaled_dot_product_attention(q, k, v)[0]
 
         example_inputs = (
             torch.randn(1, 48, 64, 64, dtype=torch.bfloat16, device="cuda"),
@@ -560,7 +560,7 @@ class AOTInductorTestsTemplate:
                 super().__init__()
 
             def forward(self, q, k, v, x):
-                t = torch.ops.aten._scaled_dot_product_flash_attention(
+                t = torch.nn.functional.scaled_dot_product_attention(
                     q, k, v, is_causal=True
                 )[0]
                 return x + t

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3627,6 +3627,10 @@ class FallbackKernel(ExternKernelAlloc):
             tuple(tensor_args),
             tuple(nontensor_args),
         )
+        # We need output buffers for generating kernel arguments in the
+        # abi-compatible mode, where we retrieve outputs by pass each individual
+        # output through the abi-compatible interface.
+        self.outputs = []
         self.use_cpp_op_schema = False
 
         self.op_overload = kernel
@@ -3879,7 +3883,8 @@ class FallbackKernel(ExternKernelAlloc):
                 assert output is None, "FallbackKernel output type is not supported"
                 return None
 
-        return generate_output(example_output, [])
+        packed.outputs = generate_output(example_output, [])
+        return packed.outputs
 
     def apply_constraint(self):
         return super().apply_constraint()
@@ -3899,7 +3904,7 @@ class MultiOutput(ExternKernel):
             elif itype == tuple:
                 # cpp wrapper code needs to use std::get<> to access a tuple
                 tuple_access = V.graph.wrapper_code.codegen_tuple_access(
-                    basename, str(i)
+                    basename, self.get_name(), str(i)
                 )
                 return self.codegen_list_tuple_access(tuple_access, indices[1:])
             else:
@@ -3908,10 +3913,10 @@ class MultiOutput(ExternKernel):
             return basename
 
     def codegen(self, wrapper):
-        line = V.graph.wrapper_code.declare
-        line += f"{self.get_name()} = {self.codegen_list_tuple_access(self.inputs[0].get_name(), self.indices)}"
-        line += V.graph.wrapper_code.ending
-        V.graph.wrapper_code.writeline(line)
+        V.graph.wrapper_code.codegen_multi_output(
+            self.get_name(),
+            self.codegen_list_tuple_access(self.inputs[0].get_name(), self.indices),
+        )
         self.codegen_size_asserts(V.graph.wrapper_code)
 
     def __init__(self, layout, input, indices: List[Tuple[Any, ...]]):

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -152,6 +152,22 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_create_tensor_from_blob(
     AtenTensorHandle* ret // returns new reference
 );
 
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch__scaled_dot_product_flash_attention(
+    AtenTensorHandle* ret0, // returns new reference
+    AtenTensorHandle* ret1, // returns new reference
+    AtenTensorHandle* ret2, // returns new reference
+    AtenTensorHandle* ret3, // returns new reference
+    int64_t* ret4,
+    int64_t* ret5,
+    AtenTensorHandle* ret6, // returns new reference
+    AtenTensorHandle* ret7, // returns new reference
+    AtenTensorHandle* ret8, // returns new reference
+    int32_t num_inputs,
+    AtenTensorHandle query,
+    AtenTensorHandle key,
+    AtenTensorHandle value,
+    ...);
+
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_tensor_copy_(AtenTensorHandle src, AtenTensorHandle dst);
 

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -153,6 +153,13 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_create_tensor_from_blob(
 );
 
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch__scaled_dot_product_flash_attention(
+    AtenTensorHandle query,
+    AtenTensorHandle key,
+    AtenTensorHandle value,
+    double dropout_p,
+    bool is_causal,
+    bool return_debug_mask,
+    double scale,
     AtenTensorHandle* ret0, // returns new reference
     AtenTensorHandle* ret1, // returns new reference
     AtenTensorHandle* ret2, // returns new reference
@@ -161,12 +168,8 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch__scaled_dot_product_flash_attention(
     int64_t* ret5,
     AtenTensorHandle* ret6, // returns new reference
     AtenTensorHandle* ret7, // returns new reference
-    AtenTensorHandle* ret8, // returns new reference
-    int32_t num_inputs,
-    AtenTensorHandle query,
-    AtenTensorHandle key,
-    AtenTensorHandle value,
-    ...);
+    AtenTensorHandle* ret8 // returns new reference
+);
 
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_tensor_copy_(AtenTensorHandle src, AtenTensorHandle dst);

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -6,16 +6,19 @@
 #include <torch/csrc/inductor/aoti_torch/tensor_converter.h>
 #include <torch/csrc/inductor/aoti_torch/utils.h>
 #include <torch/csrc/inductor/inductor_ops.h>
+#include <cstdarg>
 #include <cstdint>
 #include <cstdio>
 #include <iostream>
 #include <memory>
+#include <tuple>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
 #else
 
 #include <ATen/ops/_addmm_activation.h>
+#include <ATen/ops/_scaled_dot_product_flash_attention.h>
 #include <ATen/ops/addmm.h>
 #include <ATen/ops/as_strided.h>
 #include <ATen/ops/bmm.h>
@@ -180,6 +183,186 @@ AOTITorchError aoti_torch_create_tensor_from_blob(
                                                 .make_tensor());
     *ret_new_tensor = tensor_pointer_to_tensor_handle(new_tensor);
   });
+}
+
+static AOTITorchError aoti_torch__scaled_dot_product_flash_attention_internal(
+    AtenTensorHandle* ret0, // returns new reference
+    AtenTensorHandle* ret1, // returns new reference
+    AtenTensorHandle* ret2, // returns new reference
+    AtenTensorHandle* ret3, // returns new reference
+    int64_t* ret4,
+    int64_t* ret5,
+    AtenTensorHandle* ret6, // returns new reference
+    AtenTensorHandle* ret7, // returns new reference
+    AtenTensorHandle* ret8, // returns new reference
+    AtenTensorHandle query,
+    AtenTensorHandle key,
+    AtenTensorHandle value,
+    double dropout_p = 0.0,
+    bool is_causal = false,
+    bool return_debug_mask = false,
+    c10::optional<double> scale = c10::nullopt) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    at::Tensor* query_tensor = tensor_handle_to_tensor_pointer(query);
+    at::Tensor* key_tensor = tensor_handle_to_tensor_pointer(key);
+    at::Tensor* value_tensor = tensor_handle_to_tensor_pointer(value);
+    auto ret = at::_scaled_dot_product_flash_attention(
+        *query_tensor,
+        *key_tensor,
+        *value_tensor,
+        dropout_p,
+        is_causal,
+        return_debug_mask,
+        scale);
+
+    at::Tensor* ret0_tensor = new at::Tensor(std::move(std::get<0>(ret)));
+    *ret0 = tensor_pointer_to_tensor_handle(ret0_tensor);
+    at::Tensor* ret1_tensor = new at::Tensor(std::move(std::get<1>(ret)));
+    *ret1 = tensor_pointer_to_tensor_handle(ret1_tensor);
+    // ret2 and ret3 may be null
+    if (ret2) {
+      at::Tensor* ret2_tensor = new at::Tensor(std::move(std::get<2>(ret)));
+      *ret2 = tensor_pointer_to_tensor_handle(ret2_tensor);
+    }
+    if (ret3) {
+      at::Tensor* ret3_tensor = new at::Tensor(std::move(std::get<3>(ret)));
+      *ret3 = tensor_pointer_to_tensor_handle(ret3_tensor);
+    }
+    *ret4 = std::get<4>(ret);
+    *ret5 = std::get<5>(ret);
+    at::Tensor* ret6_tensor = new at::Tensor(std::move(std::get<6>(ret)));
+    *ret6 = tensor_pointer_to_tensor_handle(ret6_tensor);
+    at::Tensor* ret7_tensor = new at::Tensor(std::move(std::get<7>(ret)));
+    *ret7 = tensor_pointer_to_tensor_handle(ret7_tensor);
+    at::Tensor* ret8_tensor = new at::Tensor(std::move(std::get<8>(ret)));
+    *ret8 = tensor_pointer_to_tensor_handle(ret8_tensor);
+  });
+}
+
+AOTITorchError aoti_torch__scaled_dot_product_flash_attention(
+    AtenTensorHandle* ret0, // returns new reference
+    AtenTensorHandle* ret1, // returns new reference
+    AtenTensorHandle* ret2, // returns new reference
+    AtenTensorHandle* ret3, // returns new reference
+    int64_t* ret4,
+    int64_t* ret5,
+    AtenTensorHandle* ret6, // returns new reference
+    AtenTensorHandle* ret7, // returns new reference
+    AtenTensorHandle* ret8, // returns new reference
+    int32_t num_inputs,
+    AtenTensorHandle query,
+    AtenTensorHandle key,
+    AtenTensorHandle value,
+    ...) {
+  if (num_inputs < 3 || num_inputs > 7) {
+    return AOTI_TORCH_FAILURE;
+  }
+  if (num_inputs == 3) {
+    return aoti_torch__scaled_dot_product_flash_attention_internal(
+        ret0,
+        ret1,
+        ret2,
+        ret3,
+        ret4,
+        ret5,
+        ret6,
+        ret7,
+        ret8,
+        query,
+        key,
+        value);
+  }
+
+  AOTITorchError ret = AOTI_TORCH_FAILURE;
+  va_list args;
+  va_start(args, value);
+
+  double dropout_p = 0.0;
+  if (num_inputs >= 4) {
+    dropout_p = va_arg(args, double);
+    ret = aoti_torch__scaled_dot_product_flash_attention_internal(
+        ret0,
+        ret1,
+        ret2,
+        ret3,
+        ret4,
+        ret5,
+        ret6,
+        ret7,
+        ret8,
+        query,
+        key,
+        value,
+        dropout_p);
+  }
+
+  bool is_causal = false;
+  if (num_inputs >= 5) {
+    int32_t is_causal_i = va_arg(args, int32_t);
+    is_causal = is_causal_i != 0;
+    ret = aoti_torch__scaled_dot_product_flash_attention_internal(
+        ret0,
+        ret1,
+        ret2,
+        ret3,
+        ret4,
+        ret5,
+        ret6,
+        ret7,
+        ret8,
+        query,
+        key,
+        value,
+        dropout_p,
+        is_causal);
+  }
+
+  bool return_debug_mask = false;
+  if (num_inputs >= 6) {
+    int32_t return_debug_mask_i = va_arg(args, int32_t);
+    return_debug_mask = return_debug_mask_i != 0;
+    ret = aoti_torch__scaled_dot_product_flash_attention_internal(
+        ret0,
+        ret1,
+        ret2,
+        ret3,
+        ret4,
+        ret5,
+        ret6,
+        ret7,
+        ret8,
+        query,
+        key,
+        value,
+        dropout_p,
+        is_causal,
+        return_debug_mask);
+  }
+
+  double scale;
+  if (num_inputs >= 7) {
+    scale = va_arg(args, double);
+    ret = aoti_torch__scaled_dot_product_flash_attention_internal(
+        ret0,
+        ret1,
+        ret2,
+        ret3,
+        ret4,
+        ret5,
+        ret6,
+        ret7,
+        ret8,
+        query,
+        key,
+        value,
+        dropout_p,
+        is_causal,
+        return_debug_mask,
+        scale);
+  }
+
+  va_end(args);
+  return ret;
 }
 
 // TODO: implement a more efficient version instead of calling into aten

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -185,7 +185,14 @@ AOTITorchError aoti_torch_create_tensor_from_blob(
   });
 }
 
-static AOTITorchError aoti_torch__scaled_dot_product_flash_attention_internal(
+AOTITorchError aoti_torch__scaled_dot_product_flash_attention(
+    AtenTensorHandle query,
+    AtenTensorHandle key,
+    AtenTensorHandle value,
+    double dropout_p,
+    bool is_causal,
+    bool return_debug_mask,
+    double scale,
     AtenTensorHandle* ret0, // returns new reference
     AtenTensorHandle* ret1, // returns new reference
     AtenTensorHandle* ret2, // returns new reference
@@ -194,175 +201,44 @@ static AOTITorchError aoti_torch__scaled_dot_product_flash_attention_internal(
     int64_t* ret5,
     AtenTensorHandle* ret6, // returns new reference
     AtenTensorHandle* ret7, // returns new reference
-    AtenTensorHandle* ret8, // returns new reference
-    AtenTensorHandle query,
-    AtenTensorHandle key,
-    AtenTensorHandle value,
-    double dropout_p = 0.0,
-    bool is_causal = false,
-    bool return_debug_mask = false,
-    c10::optional<double> scale = c10::nullopt) {
+    AtenTensorHandle* ret8 // returns new reference
+) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     at::Tensor* query_tensor = tensor_handle_to_tensor_pointer(query);
     at::Tensor* key_tensor = tensor_handle_to_tensor_pointer(key);
     at::Tensor* value_tensor = tensor_handle_to_tensor_pointer(value);
-    auto ret = at::_scaled_dot_product_flash_attention(
-        *query_tensor,
-        *key_tensor,
-        *value_tensor,
-        dropout_p,
-        is_causal,
-        return_debug_mask,
-        scale);
+    auto [r0, r1, r2, r3, r4, r5, r6, r7, r8] =
+        at::_scaled_dot_product_flash_attention(
+            *query_tensor,
+            *key_tensor,
+            *value_tensor,
+            dropout_p,
+            is_causal,
+            return_debug_mask,
+            scale);
 
-    at::Tensor* ret0_tensor = new at::Tensor(std::move(std::get<0>(ret)));
+    at::Tensor* ret0_tensor = new at::Tensor(std::move(r0));
     *ret0 = tensor_pointer_to_tensor_handle(ret0_tensor);
-    at::Tensor* ret1_tensor = new at::Tensor(std::move(std::get<1>(ret)));
+    at::Tensor* ret1_tensor = new at::Tensor(std::move(r1));
     *ret1 = tensor_pointer_to_tensor_handle(ret1_tensor);
     // ret2 and ret3 may be null
     if (ret2) {
-      at::Tensor* ret2_tensor = new at::Tensor(std::move(std::get<2>(ret)));
+      at::Tensor* ret2_tensor = new at::Tensor(std::move(r2));
       *ret2 = tensor_pointer_to_tensor_handle(ret2_tensor);
     }
     if (ret3) {
-      at::Tensor* ret3_tensor = new at::Tensor(std::move(std::get<3>(ret)));
+      at::Tensor* ret3_tensor = new at::Tensor(std::move(r3));
       *ret3 = tensor_pointer_to_tensor_handle(ret3_tensor);
     }
-    *ret4 = std::get<4>(ret);
-    *ret5 = std::get<5>(ret);
-    at::Tensor* ret6_tensor = new at::Tensor(std::move(std::get<6>(ret)));
+    *ret4 = r4;
+    *ret5 = r5;
+    at::Tensor* ret6_tensor = new at::Tensor(std::move(r6));
     *ret6 = tensor_pointer_to_tensor_handle(ret6_tensor);
-    at::Tensor* ret7_tensor = new at::Tensor(std::move(std::get<7>(ret)));
+    at::Tensor* ret7_tensor = new at::Tensor(std::move(r7));
     *ret7 = tensor_pointer_to_tensor_handle(ret7_tensor);
-    at::Tensor* ret8_tensor = new at::Tensor(std::move(std::get<8>(ret)));
+    at::Tensor* ret8_tensor = new at::Tensor(std::move(r8));
     *ret8 = tensor_pointer_to_tensor_handle(ret8_tensor);
   });
-}
-
-AOTITorchError aoti_torch__scaled_dot_product_flash_attention(
-    AtenTensorHandle* ret0, // returns new reference
-    AtenTensorHandle* ret1, // returns new reference
-    AtenTensorHandle* ret2, // returns new reference
-    AtenTensorHandle* ret3, // returns new reference
-    int64_t* ret4,
-    int64_t* ret5,
-    AtenTensorHandle* ret6, // returns new reference
-    AtenTensorHandle* ret7, // returns new reference
-    AtenTensorHandle* ret8, // returns new reference
-    int32_t num_inputs,
-    AtenTensorHandle query,
-    AtenTensorHandle key,
-    AtenTensorHandle value,
-    ...) {
-  if (num_inputs < 3 || num_inputs > 7) {
-    return AOTI_TORCH_FAILURE;
-  }
-  if (num_inputs == 3) {
-    return aoti_torch__scaled_dot_product_flash_attention_internal(
-        ret0,
-        ret1,
-        ret2,
-        ret3,
-        ret4,
-        ret5,
-        ret6,
-        ret7,
-        ret8,
-        query,
-        key,
-        value);
-  }
-
-  AOTITorchError ret = AOTI_TORCH_FAILURE;
-  va_list args;
-  va_start(args, value);
-
-  double dropout_p = 0.0;
-  if (num_inputs >= 4) {
-    dropout_p = va_arg(args, double);
-    ret = aoti_torch__scaled_dot_product_flash_attention_internal(
-        ret0,
-        ret1,
-        ret2,
-        ret3,
-        ret4,
-        ret5,
-        ret6,
-        ret7,
-        ret8,
-        query,
-        key,
-        value,
-        dropout_p);
-  }
-
-  bool is_causal = false;
-  if (num_inputs >= 5) {
-    int32_t is_causal_i = va_arg(args, int32_t);
-    is_causal = is_causal_i != 0;
-    ret = aoti_torch__scaled_dot_product_flash_attention_internal(
-        ret0,
-        ret1,
-        ret2,
-        ret3,
-        ret4,
-        ret5,
-        ret6,
-        ret7,
-        ret8,
-        query,
-        key,
-        value,
-        dropout_p,
-        is_causal);
-  }
-
-  bool return_debug_mask = false;
-  if (num_inputs >= 6) {
-    int32_t return_debug_mask_i = va_arg(args, int32_t);
-    return_debug_mask = return_debug_mask_i != 0;
-    ret = aoti_torch__scaled_dot_product_flash_attention_internal(
-        ret0,
-        ret1,
-        ret2,
-        ret3,
-        ret4,
-        ret5,
-        ret6,
-        ret7,
-        ret8,
-        query,
-        key,
-        value,
-        dropout_p,
-        is_causal,
-        return_debug_mask);
-  }
-
-  double scale;
-  if (num_inputs >= 7) {
-    scale = va_arg(args, double);
-    ret = aoti_torch__scaled_dot_product_flash_attention_internal(
-        ret0,
-        ret1,
-        ret2,
-        ret3,
-        ret4,
-        ret5,
-        ret6,
-        ret7,
-        ret8,
-        query,
-        key,
-        value,
-        dropout_p,
-        is_causal,
-        return_debug_mask,
-        scale);
-  }
-
-  va_end(args);
-  return ret;
 }
 
 // TODO: implement a more efficient version instead of calling into aten


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110003

This PR supports _scaled_dot_product_flash_attention fallback kernel.
Note that in the abi_compatible mode, we retrieve outputs by passing
output argument pointers rather than relying on std::get.

It also fixes an issue related to dynamic shapes, where we wrongfully
query undefined dynamic symbols.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @kadeng @muchulee8 @aakhundov