### PR TITLE
BUG: fix torch._numpy.arange(5, dtype="float32")

### DIFF
--- a/test/torch_np/numpy_tests/core/test_multiarray.py
+++ b/test/torch_np/numpy_tests/core/test_multiarray.py
@@ -6839,11 +6839,6 @@ class TestArange(TestCase):
     def test_explicit_dtype(self, dt):
         assert np.arange(5.0, dtype=dt).dtype == dt
 
-    @parametrize("dt", [np.int32, np.complex64])
-    def test_arange_np_scalars(self, dt):
-        r = np.arange(dt(5))
-        assert_equal(r, [0, 1, 2, 3, 4])
-
 
 class TestRichcompareScalar(TestCase):
     @xfail  # (reason="comparison: builtin.bools or...?")

--- a/test/torch_np/numpy_tests/core/test_multiarray.py
+++ b/test/torch_np/numpy_tests/core/test_multiarray.py
@@ -6831,7 +6831,7 @@ class TestArange(TestCase):
             # Fails discovering start dtype
             np.arange(*args)
 
-    @parametrize("dt", [np.float32, np.uint8, complex])
+    @parametrize("dt", [np.float32, np.uint8])
     def test_explicit_dtype(self, dt):
         assert np.arange(5.0, dtype=dt).dtype == dt
 

--- a/test/torch_np/numpy_tests/core/test_multiarray.py
+++ b/test/torch_np/numpy_tests/core/test_multiarray.py
@@ -6822,7 +6822,11 @@ class TestArange(TestCase):
     def test_error_paths_and_promotion(self, which):
         args = [0, 1, 2]  # start, stop, and step
         args[which] = np.float64(2.0)  # should ensure float64 output
+        assert np.arange(*args).dtype == np.float64
 
+        # repeat with non-empty ranges
+        args = [0, 8, 2]
+        args[which] = np.float64(2.0)
         assert np.arange(*args).dtype == np.float64
 
         # Cover stranger error path, test only to achieve code coverage!
@@ -6831,12 +6835,13 @@ class TestArange(TestCase):
             # Fails discovering start dtype
             np.arange(*args)
 
-    @parametrize("dt", [np.float32, np.uint8])
+    @parametrize("dt", [np.float32, np.uint8, complex])
     def test_explicit_dtype(self, dt):
         assert np.arange(5.0, dtype=dt).dtype == dt
 
-    def test_arange_np_scalars(self):
-        r = np.arange(np.int32(5))
+    @parametrize("dt", [np.int32, np.complex64])
+    def test_arange_np_scalars(self, dt):
+        r = np.arange(dt(5))
         assert_equal(r, [0, 1, 2, 3, 4])
 
 

--- a/test/torch_np/numpy_tests/core/test_multiarray.py
+++ b/test/torch_np/numpy_tests/core/test_multiarray.py
@@ -6831,6 +6831,10 @@ class TestArange(TestCase):
             # Fails discovering start dtype
             np.arange(*args)
 
+    @parametrize("dt", [np.float32, np.uint8, complex])
+    def test_explicit_dtype(self, dt):
+        assert np.arange(5.0, dtype=dt).dtype == dt
+
 
 class TestRichcompareScalar(TestCase):
     @xfail  # (reason="comparison: builtin.bools or...?")

--- a/test/torch_np/numpy_tests/core/test_multiarray.py
+++ b/test/torch_np/numpy_tests/core/test_multiarray.py
@@ -6835,6 +6835,10 @@ class TestArange(TestCase):
     def test_explicit_dtype(self, dt):
         assert np.arange(5.0, dtype=dt).dtype == dt
 
+    def test_arange_np_scalars(self):
+        r = np.arange(np.int32(5))
+        assert_equal(r, [0, 1, 2, 3, 4])
+
 
 class TestRichcompareScalar(TestCase):
     @xfail  # (reason="comparison: builtin.bools or...?")

--- a/test/torch_np/test_function_base.py
+++ b/test/torch_np/test_function_base.py
@@ -1,92 +1,12 @@
 # Owner(s): ["module: dynamo"]
 
-from unittest import expectedFailure as xfail
 
 import pytest
 
 import torch._numpy as np
-from pytest import raises as assert_raises
-from torch._numpy.testing import assert_array_equal, assert_equal
+from torch._numpy.testing import assert_equal
 
-from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
-    parametrize,
-    run_tests,
-    TestCase,
-)
-
-
-@instantiate_parametrized_tests
-class TestArange(TestCase):
-    def test_infinite(self):
-        assert_raises(
-            (RuntimeError, ValueError), np.arange, 0, np.inf
-        )  # "size exceeded",
-
-    def test_nan_step(self):
-        assert_raises(
-            (RuntimeError, ValueError), np.arange, 0, 1, np.nan
-        )  # "cannot compute length",
-
-    def test_zero_step(self):
-        assert_raises(ZeroDivisionError, np.arange, 0, 10, 0)
-        assert_raises(ZeroDivisionError, np.arange, 0.0, 10.0, 0.0)
-
-        # empty range
-        assert_raises(ZeroDivisionError, np.arange, 0, 0, 0)
-        assert_raises(ZeroDivisionError, np.arange, 0.0, 0.0, 0.0)
-
-    def test_require_range(self):
-        assert_raises(TypeError, np.arange)
-        assert_raises(TypeError, np.arange, step=3)
-        assert_raises(TypeError, np.arange, dtype="int64")
-
-    @xfail  # (reason="XXX: arange(start=0, stop, step=1)")
-    def test_require_range_2(self):
-        assert_raises(TypeError, np.arange, start=4)
-
-    def test_start_stop_kwarg(self):
-        keyword_stop = np.arange(stop=3)
-        keyword_zerotostop = np.arange(start=0, stop=3)
-        keyword_start_stop = np.arange(start=3, stop=9)
-
-        assert len(keyword_stop) == 3
-        assert len(keyword_zerotostop) == 3
-        assert len(keyword_start_stop) == 6
-        assert_array_equal(keyword_stop, keyword_zerotostop)
-
-    @xfail  # (reason="XXX: arange(..., dtype=bool)")
-    def test_arange_booleans(self):
-        # Arange makes some sense for booleans and works up to length 2.
-        # But it is weird since `arange(2, 4, dtype=bool)` works.
-        # Arguably, much or all of this could be deprecated/removed.
-        res = np.arange(False, dtype=bool)
-        assert_array_equal(res, np.array([], dtype="bool"))
-
-        res = np.arange(True, dtype="bool")
-        assert_array_equal(res, [False])
-
-        res = np.arange(2, dtype="bool")
-        assert_array_equal(res, [False, True])
-
-        # This case is especially weird, but drops out without special case:
-        res = np.arange(6, 8, dtype="bool")
-        assert_array_equal(res, [True, True])
-
-        with pytest.raises(TypeError):
-            np.arange(3, dtype="bool")
-
-    @parametrize("which", [0, 1, 2])
-    def test_error_paths_and_promotion(self, which):
-        args = [0, 10, 2]  # start, stop, and step
-        args[which] = np.float64(2.0)  # should ensure float64 output
-        assert np.arange(*args).dtype == np.float64
-
-        # Cover stranger error path, test only to achieve code coverage!
-        args[which] = [None, []]
-        with pytest.raises((ValueError, RuntimeError)):
-            # Fails discovering start dtype
-            np.arange(*args)
+from torch.testing._internal.common_utils import run_tests, TestCase
 
 
 class TestAppend(TestCase):

--- a/torch/_numpy/_dtypes_impl.py
+++ b/torch/_numpy/_dtypes_impl.py
@@ -110,14 +110,23 @@ def _dtype_for_scalar(py_type):
     }[py_type]
 
 
-def is_float_or_fp_tensor(x):
+def _dtype_for_scalar_or_tensor(x):
+    # expect that the scalar path is more common
     try:
         # x a python scalar
         dtyp = _dtype_for_scalar(type(x))
     except KeyError:
         # x a tensor
         dtyp = x.dtype
-    return dtyp.is_floating_point
+    return dtyp
+
+
+def is_float_or_fp_tensor(x):
+    return _dtype_for_scalar_or_tensor(x).is_floating_point
+
+
+def is_complex_or_complex_tensor(x):
+    return _dtype_for_scalar_or_tensor(x).is_complex
 
 
 def _category(dtype):

--- a/torch/_numpy/_dtypes_impl.py
+++ b/torch/_numpy/_dtypes_impl.py
@@ -110,6 +110,16 @@ def _dtype_for_scalar(py_type):
     }[py_type]
 
 
+def is_float_or_fp_tensor(x):
+    try:
+        # x a python scalar
+        dtyp = _dtype_for_scalar(type(x))
+    except KeyError:
+        # x a tensor
+        dtyp = x.dtype
+    return dtyp.is_floating_point
+
+
 def _category(dtype):
     return {
         torch.bool: 0,

--- a/torch/_numpy/_dtypes_impl.py
+++ b/torch/_numpy/_dtypes_impl.py
@@ -111,14 +111,7 @@ def _dtype_for_scalar(py_type):
 
 
 def _dtype_for_scalar_or_tensor(x):
-    # expect that the scalar path is more common
-    try:
-        # x a python scalar
-        dtyp = _dtype_for_scalar(type(x))
-    except KeyError:
-        # x a tensor
-        dtyp = x.dtype
-    return dtyp
+    return x.dtype if isinstance(x, torch.Tensor) else _dtype_for_scalar(type(x))
 
 
 def is_float_or_fp_tensor(x):

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -339,9 +339,9 @@ def logspace(
 
 
 def arange(
-    start: Optional[ArrayLike] = None,
-    stop: Optional[ArrayLike] = None,
-    step: Optional[ArrayLike] = 1,
+    start: Optional[ArrayLikeOrScalar] = None,
+    stop: Optional[ArrayLikeOrScalar] = None,
+    step: Optional[ArrayLikeOrScalar] = 1,
     dtype: Optional[DTypeLike] = None,
     *,
     like: NotImplementedType = None,
@@ -359,10 +359,11 @@ def arange(
 
     # the dtype of the result
     if dtype is None:
-        dtype = _dtypes_impl.default_dtypes().int_dtype
-        # XXX: default values do not get normalized
-        start, stop, step = (_util._coerce_to_tensor(x) for x in (start, stop, step))
-        target_dtype = _dtypes_impl.result_type_impl(start, stop, step)
+        target_dtype = (
+            _dtypes_impl.default_dtypes().float_dtype
+            if any(_dtypes_impl.is_float_or_fp_tensor(x) for x in (start, stop, step))
+            else _dtypes_impl.default_dtypes().int_dtype
+        )
     else:
         target_dtype = dtype
 

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -366,11 +366,9 @@ def arange(
         )
     work_dtype = torch.float64 if dtype.is_complex else dtype
 
-    # work around RuntimeError: "lt_cpu" not implemented for 'ComplexFloat'
+    # RuntimeError: "lt_cpu" not implemented for 'ComplexFloat'. Fall back to eager.
     if any(_dtypes_impl.is_complex_or_complex_tensor(x) for x in (start, stop, step)):
-        work_dtype = torch.float64
-        dtype = torch.complex128
-        start, stop, step = float(start), float(stop), float(step)
+        raise NotImplementedError
 
     if (step > 0 and start > stop) or (step < 0 and start < stop):
         # empty range

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -360,11 +360,11 @@ def arange(
     # the dtype of the result
     if dtype is None:
         dtype = _dtypes_impl.default_dtypes().int_dtype
-    # XXX: default values do not get normalized
-    start, stop, step = (_util._coerce_to_tensor(x) for x in (start, stop, step))
-
-    dummy = torch.empty(1, dtype=dtype)
-    target_dtype = _dtypes_impl.result_type_impl(start, stop, step, dummy)
+        # XXX: default values do not get normalized
+        start, stop, step = (_util._coerce_to_tensor(x) for x in (start, stop, step))
+        target_dtype = _dtypes_impl.result_type_impl(start, stop, step)
+    else:
+        target_dtype = dtype
 
     # work around RuntimeError: "arange_cpu" not implemented for 'ComplexFloat'
     work_dtype = torch.float64 if target_dtype.is_complex else target_dtype


### PR DESCRIPTION
Make `np.arange` respect an explicitly provided dtype.

Also remove duplicated tests:
- torch_np/test_function_base.py::TestArange is a dupe of
- torch_np/numpy_tests/core/test_multiarray.py::TestArange

Fixes #109975


cc @mruberry @rgommers @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng