### PR TITLE
Change signature of CompilerFn for register_backend decorator

### DIFF
--- a/torch/_dynamo/backends/registry.py
+++ b/torch/_dynamo/backends/registry.py
@@ -1,6 +1,6 @@
 import functools
 import sys
-from typing import Callable, Dict, List, Optional, Protocol, Sequence, Tuple
+from typing import Callable, Dict, List, Optional, Protocol, Sequence, Tuple, Union
 
 import torch
 from torch import fx
@@ -11,7 +11,7 @@ class CompiledFn(Protocol):
         ...
 
 
-CompilerFn = Callable[[fx.GraphModule, List[torch.Tensor]], CompiledFn]
+CompilerFn = Callable[[fx.GraphModule, List[torch.Tensor], Optional[Union[str, dict]]], CompiledFn]
 
 _BACKENDS: Dict[str, CompilerFn] = dict()
 


### PR DESCRIPTION
## Description
Add `...` to show that CompilerFn for custom backend could take additional options

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng