### PR TITLE
Fix optimize_for_inference to support modules that don't have a forward method

### DIFF
--- a/test/cpp/jit/test_module_api.cpp
+++ b/test/cpp/jit/test_module_api.cpp
@@ -434,13 +434,13 @@ TEST(ModuleAPITest, OfiFreezesNoForward) {
       return self.foo + x + b
   )");
   m.eval();
-  
+
   // OFI is called without the presence of forward methods
-  auto frozen_mod = torch::jit::optimize_for_inference(m, std::vector<std::string>{"bar"});
+  auto frozen_mod =
+      torch::jit::optimize_for_inference(m, std::vector<std::string>{"bar"});
   ASSERT_EQ(
-    m.run_method("bar", torch::ones({})).toTensor().item<float>(),
-    frozen_mod.run_method("bar", torch::ones({})).toTensor().item<float>()
-  );
+      m.run_method("bar", torch::ones({})).toTensor().item<float>(),
+      frozen_mod.run_method("bar", torch::ones({})).toTensor().item<float>());
 }
 
 TEST(ModuleAPITest, To_CUDA) {

--- a/test/cpp/jit/test_module_api.cpp
+++ b/test/cpp/jit/test_module_api.cpp
@@ -426,6 +426,23 @@ TEST(ModuleAPITest, OfiFreezesTraining) {
   testing::FileCheck().check_not("GetAttr")->run(*forward_g);
 }
 
+TEST(ModuleAPITest, OfiFreezesNoForward) {
+  Module m("m");
+  m.register_parameter("foo", torch::ones({}), false);
+  m.define(R"(
+    def bar(self, x, b : int = 4):
+      return self.foo + x + b
+  )");
+  m.eval();
+  
+  // OFI is called without the presence of forward methods
+  auto frozen_mod = torch::jit::optimize_for_inference(m, std::vector<std::string>{"bar"});
+  ASSERT_EQ(
+    m.run_method("bar", torch::ones({})).toTensor().item<float>(),
+    frozen_mod.run_method("bar", torch::ones({})).toTensor().item<float>()
+  );
+}
+
 TEST(ModuleAPITest, To_CUDA) {
   Module m("test");
   {

--- a/torch/csrc/jit/api/module.cpp
+++ b/torch/csrc/jit/api/module.cpp
@@ -504,9 +504,9 @@ Module optimize_for_inference(
   } else {
     frozen_mod = module;
   }
-
-  optimize_for_inference(frozen_mod.get_method("forward").graph());
-
+  if (auto method = frozen_mod.find_method("forward")) {
+    optimize_for_inference(frozen_mod.get_method("forward").graph());
+  }
   for (const auto& method : other_methods) {
     optimize_for_inference(frozen_mod.get_method(method).graph());
   }


### PR DESCRIPTION
Fixes #108662
