### PR TITLE
[torch.library] FuncAndLocation -> Kernel

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -1425,7 +1425,7 @@ class TestCustomOp(CustomOpTestCaseBase):
         custom_op = torch._custom_op.impl._find_custom_op(
             "_torch_testing::numpy_nonzero"
         )
-        loc = custom_op._get_impl("abstract").location
+        loc = custom_op._get_impl("abstract").source
         matches = re.match(r".*custom_op_db.py:\d+", loc)
         self.assertIsNotNone(matches)
 

--- a/torch/_custom_op/autograd.py
+++ b/torch/_custom_op/autograd.py
@@ -31,7 +31,7 @@ def autograd_kernel_indirection(custom_op):
                 else 'backward'
             )
             found = 'save_for_backward' if missing == 'backward' else 'backward'
-            loc = custom_op._get_impl(found).location
+            loc = custom_op._get_impl(found).source
             raise RuntimeError(
                 f"We found a '{found}' registration for {custom_op} at "
                 f"{loc} but were unable to find a '{missing}' registration. "
@@ -177,7 +177,7 @@ def validate_grad_inputs_dict(grad_inputs_dict, forward_op, args_info):
         backward = forward_op._get_impl('backward')
         raise RuntimeError(
             f"In the backward function defined for {forward_op} at "
-            f"{backward.location} using the CustomOp API, {what}")
+            f"{backward.source} using the CustomOp API, {what}")
 
     if not isinstance(grad_inputs_dict, dict):
         error(f"expected the output of the backward function to be a dict but "

--- a/torch/_library/utils.py
+++ b/torch/_library/utils.py
@@ -1,5 +1,17 @@
 import inspect
 import sys
+from typing import Callable
+
+
+class Kernel:
+    """Models a (function, source location)"""
+
+    def __init__(self, func: Callable, source: str):
+        self.func: Callable = func
+        self.source: str = source
+
+    def __call__(self, *args, **kwargs):
+        return self.func(*args, **kwargs)
 
 
 def get_source(stacklevel: int) -> str:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110017
* #110016
* #110015
* #110011

This PR refactors FuncAndLocation into "Kernel". I got tired of typing
this out all the time; we also make Kernel callable so one doesn't need
to worry about grabbing the function from it and then calling the
function.

Test Plan:
- existing tests