### PR TITLE
Make python decomposition of linspace consistent with the cpu kernel of the op

### DIFF
--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -4980,9 +4980,13 @@ def linspace(
     )
     cast_rg = partial(_maybe_convert_to_dtype, dtype=computation_dtype)
 
+    start = _maybe_convert_to_dtype(start, dtype)
+    end = _maybe_convert_to_dtype(end, dtype)
+    dtype_step = torch.float32 if utils.is_integer_dtype(dtype) else dtype
+    cast_step = partial(_maybe_convert_to_dtype, dtype=dtype_step)
     # We implement torch.lerp without performing rg / (steps - 1) explicitly
     # With this we get out[0] == start, out[-1] == end
-    step = (end - start) / (steps - 1)
+    step = (cast_step(end) - cast_step(start)) / (steps - 1)
     out = torch.where(
         rg < steps / 2,
         start + step * cast_rg(rg),  # type: ignore[arg-type,operator]


### PR DESCRIPTION
The cpu kernel for `linspace`, found [here](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/cpu/RangeFactoriesKernel.cpp#L45), casts `start` and `end` to the given dtype before using them to compute the step, and before using them later on. This PR adds an equivalent cast to the python decomposition of the op, so that the two implementation will always give consistent results.