### PR TITLE
[Reland] Add -Wdeprecated and related fixes

### DIFF
--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -14,14 +14,6 @@
 #include <array>
 #include <bitset>
 
-C10_CLANG_DIAGNOSTIC_PUSH()
-#if C10_CLANG_HAS_WARNING("-Wshorten-64-to-32")
-C10_CLANG_DIAGNOSTIC_IGNORE("-Wshorten-64-to-32")
-#endif
-#if C10_CLANG_HAS_WARNING("-Wdeprecated-copy-dtor")
-C10_CLANG_DIAGNOSTIC_IGNORE("-Wdeprecated-copy-dtor")
-#endif
-
 namespace at {
 class Tensor;
 class OptionalTensorRef;
@@ -91,6 +83,11 @@ class TORCH_API OpaqueOptionalTensorRef {
 
  public:
   OpaqueOptionalTensorRef();
+  OpaqueOptionalTensorRef(const OpaqueOptionalTensorRef&) = default;
+  OpaqueOptionalTensorRef& operator=(const OpaqueOptionalTensorRef&) = default;
+  OpaqueOptionalTensorRef(OpaqueOptionalTensorRef&&) noexcept = default;
+  OpaqueOptionalTensorRef& operator=(OpaqueOptionalTensorRef&&) noexcept =
+      default;
   ~OpaqueOptionalTensorRef();
 
   OptionalTensorRef* get() {
@@ -130,6 +127,10 @@ struct TORCH_API OperandInfo {
     validate();
   }
 
+  C10_ALWAYS_INLINE OperandInfo(const OperandInfo&) = default;
+  C10_ALWAYS_INLINE OperandInfo& operator=(const OperandInfo&) = default;
+  C10_ALWAYS_INLINE OperandInfo(OperandInfo&&) noexcept = default;
+  C10_ALWAYS_INLINE OperandInfo& operator=(OperandInfo&&) noexcept = default;
   C10_ALWAYS_INLINE ~OperandInfo() = default;
 
   /// The data pointer. This may be different from tensor->data_ptr() if the
@@ -257,14 +258,14 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
   void foreach_reduced_elt(loop_subiter_t loop, bool parallelize = true);
 
   int ndim() const {
-    return shape_.size();
+    return static_cast<int>(shape_.size());
   }
   IntArrayRef shape() const {
     return shape_;
   }
   int64_t numel() const;
   int ntensors() const {
-    return operands_.size();
+    return static_cast<int>(operands_.size());
   }
   int noutputs() const {
     return num_outputs_;
@@ -313,7 +314,7 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
     return device(arg).type();
   }
   int64_t element_size(int arg) const {
-    return elementSize(dtype(arg));
+    return static_cast<int64_t>(elementSize(dtype(arg)));
   }
   bool is_scalar(int arg) const;
   bool is_cpu_scalar(int arg) const;
@@ -462,7 +463,7 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
 
   // Helper functions for advanced stride manipulations (e.g. torch.flip)
   void _unsafe_set_arg_strides(const int arg, IntArrayRef strides) {
-    operands_[arg].stride_bytes = std::move(strides);
+    operands_[arg].stride_bytes = strides;
   }
   void _unsafe_set_arg_data(const int arg, void* data) {
     operands_[arg].data = data;
@@ -984,5 +985,3 @@ struct TORCH_API SplitUntil32Bit {
 };
 
 } // namespace at
-
-C10_CLANG_DIAGNOSTIC_POP()

--- a/aten/src/ATen/TensorMeta.h
+++ b/aten/src/ATen/TensorMeta.h
@@ -5,11 +5,6 @@
 #include <c10/core/TensorOptions.h>
 #include <c10/util/strides.h>
 
-C10_CLANG_DIAGNOSTIC_PUSH()
-#if C10_CLANG_HAS_WARNING("-Wdeprecated-copy-dtor")
-C10_CLANG_DIAGNOSTIC_IGNORE("-Wdeprecated-copy-dtor")
-#endif
-
 namespace at {
 
 class Tensor;
@@ -69,6 +64,11 @@ namespace impl {
 //
 // A notable subclass of this interface is TensorIteratorBase.
 struct TORCH_API MetaBase {
+  MetaBase() = default;
+  MetaBase(const MetaBase&) = default;
+  MetaBase& operator=(const MetaBase&) = default;
+  MetaBase(MetaBase&&) noexcept = default;
+  MetaBase& operator=(MetaBase&&) noexcept = default;
   virtual const Tensor& maybe_get_output(int64_t output_idx) = 0;
 
   // Note: [set_output_*]
@@ -135,5 +135,3 @@ struct TORCH_API MetaBase {
 } // namespace impl
 
 } // namespace at
-
-C10_CLANG_DIAGNOSTIC_POP()

--- a/aten/src/ATen/core/IListRef.h
+++ b/aten/src/ATen/core/IListRef.h
@@ -620,7 +620,6 @@ class IListRef {
     unboxed_type unboxed;
     const materialized_type* materialized;
     Payload() : boxed(nullptr) {}
-    ~Payload() {}
   };
 
   Payload payload_;

--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -102,7 +102,7 @@ class TORCH_API TensorBase {
     }
   }
   TensorBase(const TensorBase&) = default;
-  TensorBase(TensorBase&&) = default;
+  TensorBase(TensorBase&&) noexcept = default;
 
  public:
   // Creates a new wrapper from TensorImpl. Intentionally a free method because
@@ -205,6 +205,7 @@ class TORCH_API TensorBase {
     impl_.reset();
   }
 
+#if defined (_MSC_VER)
   TensorBase& operator=(const TensorBase& x) & {
     impl_ = x.impl_;
     return *this;
@@ -213,6 +214,10 @@ class TORCH_API TensorBase {
     impl_ = std::move(x.impl_);
     return *this;
   }
+#else
+  TensorBase& operator=(const TensorBase& x) & = default;
+  TensorBase& operator=(TensorBase&& x) & noexcept = default;
+#endif
 
   // Ban assignment to rvalues, since at::Tensor (weirdly) performs a deep copy here
   TensorBase& operator=(const TensorBase&) && = delete;

--- a/aten/src/ATen/core/Vitals.h
+++ b/aten/src/ATen/core/Vitals.h
@@ -39,6 +39,8 @@ struct TORCH_API TorchVital {
   std::unordered_map<std::string, TorchVitalAttr> attrs;
 
   explicit TorchVital(std::string n) : name(std::move(n)) {}
+  TorchVital(const TorchVital&) = default;
+  TorchVital(TorchVital&&) = default;
   TorchVital() = delete;
 
   TorchVitalAttr& create(const std::string& attr);

--- a/aten/src/ATen/core/function.h
+++ b/aten/src/ATen/core/function.h
@@ -36,6 +36,11 @@ TORCH_API void preoptimizeGraph(std::shared_ptr<Graph>& graph, bool disable_auto
 // execution of the function. Method is a wrapper around an
 // underlying Function that also provides a `self` object.
 struct TORCH_API Function {
+  Function() = default;
+  Function(const Function&) = default;
+  Function& operator=(const Function&) = default;
+  Function(Function&&) noexcept = default;
+  Function& operator=(Function&&) noexcept = default;
   virtual c10::string_view doc_string() const {
     static constexpr c10::string_view no_doc_string = "";
     return no_doc_string;

--- a/aten/src/ATen/core/jit_type_base.h
+++ b/aten/src/ATen/core/jit_type_base.h
@@ -145,11 +145,16 @@ struct as_shared_type<const T*> {
 
 struct TORCH_API Type {
   friend TORCH_API bool operator==(const Type& lhs, const Type& rhs);
- private:
+  private:
   TypeKind kind_;
 
   protected:
   Type(TypeKind kind) : kind_(kind) {}
+
+  Type(const Type&) = default;
+  Type& operator=(const Type&) = default;
+  Type(Type&&) noexcept = default;
+  Type& operator=(Type&&) noexcept = default;
 
   virtual std::string annotation_str_impl(TypePrinter /*printer*/) const {
     return str();

--- a/c10/CMakeLists.txt
+++ b/c10/CMakeLists.txt
@@ -44,6 +44,7 @@ file(GLOB C10_HEADERS
         util/*.h
         )
 add_library(c10 ${C10_SRCS} ${C10_HEADERS})
+target_compile_options_if_supported(c10 "-Wdeprecated")
 if(HAVE_SOVERSION)
   set_target_properties(c10 PROPERTIES
       VERSION ${TORCH_VERSION} SOVERSION ${TORCH_SOVERSION})

--- a/c10/core/Event.h
+++ b/c10/core/Event.h
@@ -50,11 +50,8 @@ struct Event final {
   Event& operator=(const Event&) = delete;
 
   // Move constructor and move assignment operator
-  Event(Event&& other) noexcept : impl_{std::move(other.impl_)} {}
-  Event& operator=(Event&& other) noexcept {
-    impl_.swap(std::move(other.impl_));
-    return *this;
-  }
+  Event(Event&&) noexcept = default;
+  Event& operator=(Event&&) noexcept = default;
 
   // Destructor
   ~Event() = default;

--- a/c10/core/impl/FakeGuardImpl.h
+++ b/c10/core/impl/FakeGuardImpl.h
@@ -97,9 +97,6 @@ template <DeviceType T>
 thread_local DeviceIndex FakeGuardImpl<T>::current_device_ = 0;
 
 template <DeviceType T>
-constexpr DeviceType FakeGuardImpl<T>::static_type;
-
-template <DeviceType T>
 thread_local std::array<StreamId, kFakeGuardImplMaxDevices>
     FakeGuardImpl<T>::current_streams_ = {0, 0, 0, 0, 0, 0, 0, 0};
 

--- a/c10/core/impl/VirtualGuardImpl.h
+++ b/c10/core/impl/VirtualGuardImpl.h
@@ -17,6 +17,10 @@ class VirtualGuardImpl final : public DeviceGuardImplInterface {
   VirtualGuardImpl(const DeviceGuardImplInterface* impl) : impl_(impl) {}
 
   // Copying and moving is OK!
+  VirtualGuardImpl(const VirtualGuardImpl&) = default;
+  VirtualGuardImpl& operator=(const VirtualGuardImpl&) = default;
+  VirtualGuardImpl(VirtualGuardImpl&&) noexcept = default;
+  VirtualGuardImpl& operator=(VirtualGuardImpl&&) noexcept = default;
 
   DeviceType type() const override {
     return impl_->type();

--- a/c10/cuda/impl/CUDAGuardImpl.cpp
+++ b/c10/cuda/impl/CUDAGuardImpl.cpp
@@ -4,8 +4,6 @@ namespace c10 {
 namespace cuda {
 namespace impl {
 
-constexpr DeviceType CUDAGuardImpl::static_type;
-
 C10_REGISTER_GUARD_IMPL(CUDA, CUDAGuardImpl);
 
 } // namespace impl

--- a/c10/util/MaybeOwned.h
+++ b/c10/util/MaybeOwned.h
@@ -127,7 +127,8 @@ class MaybeOwned final {
   }
 
   MaybeOwned(MaybeOwned&& rhs) noexcept(
-      std::is_nothrow_move_constructible<T>::value)
+      std::is_nothrow_move_constructible_v<T>&&
+          std::is_nothrow_move_assignable_v<borrow_type>)
       : isBorrowed_(rhs.isBorrowed_) {
     if (C10_LIKELY(rhs.isBorrowed_)) {
       MaybeOwnedTraits<T>::assignBorrow(borrow_, rhs.borrow_);
@@ -137,7 +138,10 @@ class MaybeOwned final {
   }
 
   MaybeOwned& operator=(MaybeOwned&& rhs) noexcept(
-      std::is_nothrow_move_assignable<T>::value) {
+      std::is_nothrow_move_assignable_v<T>&& std::is_nothrow_move_assignable_v<
+          borrow_type>&& std::is_nothrow_move_constructible_v<T>&&
+          std::is_nothrow_destructible_v<T>&&
+              std::is_nothrow_destructible_v<borrow_type>) {
     if (this == &rhs) {
       return *this;
     }
@@ -158,7 +162,6 @@ class MaybeOwned final {
         isBorrowed_ = false;
       }
     }
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(isBorrowed_ == rhs.isBorrowed_);
     return *this;
   }
 
@@ -176,7 +179,8 @@ class MaybeOwned final {
     return MaybeOwned(in_place, std::forward<Args>(args)...);
   }
 
-  ~MaybeOwned() {
+  ~MaybeOwned() noexcept(std::is_nothrow_destructible_v<T>&&
+                             std::is_nothrow_destructible_v<borrow_type>) {
     if (C10_UNLIKELY(!isBorrowed_)) {
       own_.~T();
     } else {

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -42,20 +42,6 @@
 #include <c10/util/C++17.h>
 #include <c10/util/Metaprogramming.h>
 
-C10_CLANG_DIAGNOSTIC_PUSH()
-#if C10_CLANG_HAS_WARNING("-Wstring-conversion")
-C10_CLANG_DIAGNOSTIC_IGNORE("-Wstring-conversion")
-#endif
-#if C10_CLANG_HAS_WARNING("-Wshorten-64-to-32")
-C10_CLANG_DIAGNOSTIC_IGNORE("-Wshorten-64-to-32")
-#endif
-#if C10_CLANG_HAS_WARNING("-Wimplicit-float-conversion")
-C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-float-conversion")
-#endif
-#if C10_CLANG_HAS_WARNING("-Wimplicit-int-conversion")
-C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-conversion")
-#endif
-
 #if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(push)
 #pragma warning(disable : 4624) // destructor was implicitly defined as deleted
@@ -213,6 +199,9 @@ union constexpr_storage_t {
   constexpr constexpr_storage_t(Args&&... args)
       : value_(constexpr_forward<Args>(args)...) {}
 
+  constexpr constexpr_storage_t(const constexpr_storage_t&) = default;
+  constexpr constexpr_storage_t& operator=(const constexpr_storage_t&) =
+      default;
   ~constexpr_storage_t() = default;
 };
 
@@ -440,6 +429,11 @@ struct trivially_copyable_optimization_optional_base {
       Args&&... args)
       : init_(true), storage_(il, std::forward<Args>(args)...) {}
 
+  constexpr trivially_copyable_optimization_optional_base(
+      const trivially_copyable_optimization_optional_base&) = default;
+
+  constexpr trivially_copyable_optimization_optional_base& operator=(
+      const trivially_copyable_optimization_optional_base&) = default;
   ~trivially_copyable_optimization_optional_base() = default;
 
   constexpr bool initialized() const noexcept {
@@ -688,14 +682,15 @@ class optional : private OptionalBase<T> {
 
   optional& operator=(optional&& rhs) = default;
 
-  template <class U = T>
-  auto operator=(U&& v) -> typename std::enable_if<
-      std::is_constructible<T, U>::value &&
+  template <
+      class U = T,
+      typename = std::enable_if_t<
+          std::is_constructible<T, U>::value &&
           !std::is_same<typename std::decay<U>::type, optional<T>>::value &&
           (std::is_scalar<T>::value ||
            std::is_same<typename std::decay<U>::type, T>::value) &&
-          std::is_assignable<T&, U>::value,
-      optional&>::type {
+          std::is_assignable<T&, U>::value>>
+  optional& operator=(U&& v) {
     if (initialized()) {
       contained_val() = std::forward<U>(v);
     } else {
@@ -789,9 +784,8 @@ class optional : private OptionalBase<T> {
 
   template <class V>
   constexpr T value_or(V&& v) && {
-    return *this
-        ? constexpr_move(const_cast<optional<T>&>(*this).contained_val())
-        : detail_::convert<T>(constexpr_forward<V>(v));
+    return *this ? constexpr_move(*this).contained_val()
+                 : detail_::convert<T>(constexpr_forward<V>(v));
   }
 
   // 20.6.3.6, modifiers
@@ -803,9 +797,7 @@ class optional : private OptionalBase<T> {
 template <class T, class F>
 constexpr T value_or_else(const optional<T>& v, F&& func) {
   static_assert(
-      std::is_convertible<
-          typename guts::infer_function_traits_t<F>::return_type,
-          T>::value,
+      std::is_convertible<typename std::invoke_result_t<F>, T>::value,
       "func parameters must be a callable that returns a type convertible to the value stored in the optional");
   return v.has_value() ? *v : detail_::convert<T>(std::forward<F>(func)());
 }
@@ -813,9 +805,7 @@ constexpr T value_or_else(const optional<T>& v, F&& func) {
 template <class T, class F>
 constexpr T value_or_else(optional<T>&& v, F&& func) {
   static_assert(
-      std::is_convertible<
-          typename guts::infer_function_traits_t<F>::return_type,
-          T>::value,
+      std::is_convertible<typename std::invoke_result_t<F>, T>::value,
       "func parameters must be a callable that returns a type convertible to the value stored in the optional");
   return v.has_value() ? constexpr_move(std::move(v).contained_val())
                        : detail_::convert<T>(std::forward<F>(func)());
@@ -880,10 +870,11 @@ class optional<T&> {
   // return *this;
   // }
 
-  template <typename U>
-  auto operator=(U&& rhs) noexcept -> typename std::enable_if<
-      std::is_same<typename std::decay<U>::type, optional<T&>>::value,
-      optional&>::type {
+  template <
+      typename U,
+      typename = std::enable_if_t<
+          std::is_same_v<typename std::decay<U>::type, optional<T&>>>>
+  optional& operator=(U&& rhs) noexcept {
     ref = rhs.ref;
     return *this;
   }
@@ -1261,8 +1252,6 @@ struct hash<c10::optional<T&>> {
 #undef TR2_OPTIONAL_REQUIRES
 #undef TR2_OPTIONAL_ASSERTED_EXPRESSION
 #undef TR2_OPTIONAL_HOST_CONSTEXPR
-
-C10_CLANG_DIAGNOSTIC_POP()
 
 #if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(pop)

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -84,7 +84,7 @@ inline constexpr typename std::remove_reference<T>::type&& constexpr_move(
 #define TR2_OPTIONAL_ASSERTED_EXPRESSION(CHECK, EXPR) (EXPR)
 #else
 #define TR2_OPTIONAL_ASSERTED_EXPRESSION(CHECK, EXPR) \
-  ((CHECK) ? (EXPR) : ([] { assert(!#CHECK); }(), (EXPR)))
+  ((CHECK) ? (EXPR) : ([] { assert(false); }(), (EXPR)))
 #endif
 
 #if defined(__CUDA_ARCH__)

--- a/c10/util/SmallVector.h
+++ b/c10/util/SmallVector.h
@@ -1022,7 +1022,9 @@ class SmallVectorImpl : public SmallVectorTemplateBase<T> {
 
   SmallVectorImpl& operator=(const SmallVectorImpl& RHS);
 
-  SmallVectorImpl& operator=(SmallVectorImpl&& RHS);
+  SmallVectorImpl& operator=(SmallVectorImpl&& RHS) noexcept(
+      std::is_nothrow_move_constructible_v<T>&&
+          std::is_nothrow_destructible_v<T>);
 
   bool operator==(const SmallVectorImpl& RHS) const {
     if (this->size() != RHS.size())
@@ -1127,7 +1129,9 @@ SmallVectorImpl<T>& SmallVectorImpl<T>::operator=(
 }
 
 template <typename T>
-SmallVectorImpl<T>& SmallVectorImpl<T>::operator=(SmallVectorImpl<T>&& RHS) {
+SmallVectorImpl<T>& SmallVectorImpl<T>::operator=(
+    SmallVectorImpl<T>&& RHS) noexcept(std::is_nothrow_move_constructible_v<T>&&
+                                           std::is_nothrow_destructible_v<T>) {
   // Avoid self-assignment.
   if (this == &RHS)
     return *this;
@@ -1339,7 +1343,9 @@ class /* LLVM_GSL_OWNER */ SmallVector : public SmallVectorImpl<T>,
     return *this;
   }
 
-  SmallVector(SmallVector&& RHS) : SmallVectorImpl<T>(N) {
+  SmallVector(SmallVector&& RHS) noexcept(
+      std::is_nothrow_move_assignable_v<SmallVectorImpl<T>>)
+      : SmallVectorImpl<T>(N) {
     if (!RHS.empty())
       SmallVectorImpl<T>::operator=(::std::move(RHS));
   }
@@ -1360,22 +1366,26 @@ class /* LLVM_GSL_OWNER */ SmallVector : public SmallVectorImpl<T>,
                                    .end())>::iterator_category,
                   std::input_iterator_tag>::value,
           int> = 0>
-  const SmallVector& operator=(const Container& RHS) {
+  SmallVector& operator=(const Container& RHS) {
     this->assign(RHS.begin(), RHS.end());
     return *this;
   }
 
-  SmallVector(SmallVectorImpl<T>&& RHS) : SmallVectorImpl<T>(N) {
+  SmallVector(SmallVectorImpl<T>&& RHS) noexcept(
+      std::is_nothrow_move_assignable_v<SmallVectorImpl<T>>)
+      : SmallVectorImpl<T>(N) {
     if (!RHS.empty())
       SmallVectorImpl<T>::operator=(::std::move(RHS));
   }
 
-  SmallVector& operator=(SmallVector&& RHS) {
+  SmallVector& operator=(SmallVector&& RHS) noexcept(
+      std::is_nothrow_move_assignable_v<SmallVectorImpl<T>>) {
     SmallVectorImpl<T>::operator=(::std::move(RHS));
     return *this;
   }
 
-  SmallVector& operator=(SmallVectorImpl<T>&& RHS) {
+  SmallVector& operator=(SmallVectorImpl<T>&& RHS) noexcept(
+      std::is_nothrow_move_constructible_v<SmallVectorImpl<T>>) {
     SmallVectorImpl<T>::operator=(::std::move(RHS));
     return *this;
   }
@@ -1396,7 +1406,7 @@ class /* LLVM_GSL_OWNER */ SmallVector : public SmallVectorImpl<T>,
                                    .end())>::iterator_category,
                   std::input_iterator_tag>::value,
           int> = 0>
-  const SmallVector& operator=(Container&& C) {
+  SmallVector& operator=(Container&& C) {
     this->assign(C.begin(), C.end());
     return *this;
   }

--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -383,11 +383,15 @@ class intrusive_ptr final {
   }
 
   intrusive_ptr& operator=(const intrusive_ptr& rhs) & noexcept {
+    if (this == &rhs) {
+      return *this;
+    }
     return operator=<TTarget, NullType>(rhs);
   }
 
   template <class From, class FromNullType>
-  intrusive_ptr& operator=(const intrusive_ptr<From, NullType>& rhs) & {
+  intrusive_ptr& operator=(
+      const intrusive_ptr<From, NullType>& rhs) & noexcept {
     static_assert(
         std::is_convertible<From*, TTarget*>::value,
         "Type mismatch. intrusive_ptr copy assignment got pointer of wrong type.");
@@ -405,7 +409,6 @@ class intrusive_ptr final {
   }
 
   TTarget* operator->() const noexcept {
-    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDelete)
     return target_;
   }
 
@@ -419,9 +422,7 @@ class intrusive_ptr final {
   }
 
   void swap(intrusive_ptr& rhs) noexcept {
-    TTarget* tmp = target_;
-    target_ = rhs.target_;
-    rhs.target_ = tmp;
+    std::swap(target_, rhs.target_);
   }
 
   // We do a lot of null-pointer checks in our code, good to have this be cheap.
@@ -769,6 +770,9 @@ class weak_intrusive_ptr final {
   }
 
   weak_intrusive_ptr& operator=(const weak_intrusive_ptr& rhs) & noexcept {
+    if (this == &rhs) {
+      return *this;
+    }
     return operator=<TTarget, NullType>(rhs);
   }
 
@@ -781,7 +785,7 @@ class weak_intrusive_ptr final {
 
   template <class From, class FromNullType>
   weak_intrusive_ptr& operator=(
-      const weak_intrusive_ptr<From, NullType>& rhs) & {
+      const weak_intrusive_ptr<From, NullType>& rhs) & noexcept {
     static_assert(
         std::is_convertible<From*, TTarget*>::value,
         "Type mismatch. weak_intrusive_ptr copy assignment got pointer of wrong type.");

--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -2202,8 +2202,6 @@ class LiteInterpreterDynamicTypeTestFixture
   static constexpr size_t kNumSplits = 10;
 };
 
-constexpr size_t LiteInterpreterDynamicTypeTestFixture::kNumSplits;
-
 /**
  * Enumerate all possible JIT types appearing in mobile runtime, and test
  * whether subtyping relation is preserved after one of the JIT types is

--- a/torch/csrc/distributed/c10d/PrefixStore.hpp
+++ b/torch/csrc/distributed/c10d/PrefixStore.hpp
@@ -9,8 +9,6 @@ class TORCH_API PrefixStore : public Store {
  public:
   explicit PrefixStore(std::string prefix, c10::intrusive_ptr<Store> store);
 
-  ~PrefixStore() override = default;
-
   using Store::set;
   void set(const std::string& key, const std::vector<uint8_t>& value) override;
 

--- a/torch/csrc/distributed/c10d/Store.cpp
+++ b/torch/csrc/distributed/c10d/Store.cpp
@@ -2,12 +2,6 @@
 
 namespace c10d {
 
-constexpr std::chrono::milliseconds Store::kDefaultTimeout;
-constexpr std::chrono::milliseconds Store::kNoTimeout;
-
-// Define destructor symbol for abstract base class.
-Store::~Store() = default;
-
 const std::chrono::milliseconds& Store::getTimeout() const noexcept {
   return timeout_;
 }

--- a/torch/csrc/distributed/c10d/Store.hpp
+++ b/torch/csrc/distributed/c10d/Store.hpp
@@ -28,7 +28,7 @@ class TORCH_API Store : public torch::CustomClassHolder {
   explicit Store(const std::chrono::milliseconds& timeout)
       : timeout_(timeout) {}
 
-  ~Store() override;
+  ~Store() override = default;
 
   void set(const std::string& key, const std::string& value);
 

--- a/torch/csrc/distributed/rpc/rpc_agent.cpp
+++ b/torch/csrc/distributed/rpc/rpc_agent.cpp
@@ -14,8 +14,6 @@ RegisterWorkerInfoOnce::RegisterWorkerInfoOnce() {
                                .def(torch::init<std::string, int64_t>());
 }
 
-constexpr size_t WorkerInfo::MAX_NAME_LEN;
-
 WorkerInfo::WorkerInfo(std::string name, int64_t id)
     : WorkerInfo(std::move(name), (worker_id_t)id) {
   TORCH_CHECK(

--- a/torch/csrc/distributed/rpc/rref_proto.h
+++ b/torch/csrc/distributed/rpc/rref_proto.h
@@ -18,8 +18,6 @@ class TORCH_API RRefMessageBase : public RpcCommandBase {
   RRefMessageBase(const RRefId& rrefId, MessageType type)
       : rrefId_(rrefId), type_(type) {}
 
-  ~RRefMessageBase() override = default;
-
   const RRefId& rrefId();
 
  protected:


### PR DESCRIPTION
This is reland of PRs #https://github.com/pytorch/pytorch/pull/108626 and #109564. We fixed the IOS build failure by changing 
```
((CHECK) ? (EXPR) : ([] { assert(!#CHECK); }(), (EXPR)))
```
to
```
((CHECK) ? (EXPR) : ([] { assert(false); }(), (EXPR)))
```
in TR2_OPTIONAL_ASSERTED_EXPRESSION, since the former syntax was invalid on Apple Clang. Anyway, we could apply the simple fix hoping that c10::optional would be replaced by std::optional soon.
We also enabled -Wdeprecated on c10.

cc @clee2000 