### PR TITLE
[aotinductor] Pass TorchIR to AOTInductor

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/aot_inductor_huggingface_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/aot_inductor_huggingface_inference.csv
@@ -46,11 +46,11 @@ CamemBert,pass,0
 
 
 
-DebertaForMaskedLM,fail_to_run,0
+DebertaForMaskedLM,pass,0
 
 
 
-DebertaForQuestionAnswering,fail_to_run,0
+DebertaForQuestionAnswering,pass,0
 
 
 
@@ -58,7 +58,7 @@ DebertaV2ForMaskedLM,pass_due_to_skip,0
 
 
 
-DebertaV2ForQuestionAnswering,fail_to_run,0
+DebertaV2ForQuestionAnswering,pass,0
 
 
 

--- a/test/cpp/aot_inductor/compile_model.py
+++ b/test/cpp/aot_inductor/compile_model.py
@@ -67,7 +67,7 @@ def compile_model(device, data):
     }
     with torch.no_grad():
         # aot-compile the module into a .so pointed by lib_path
-        lib_path, _ = torch._export.aot_compile(
+        lib_path = torch._export.aot_compile(
             module, inputs, dynamic_shapes=dynamic_shapes
         )
     script_module = make_script_module(lib_path, device, *inputs)

--- a/test/cpp/aot_inductor/test.py
+++ b/test/cpp/aot_inductor/test.py
@@ -28,7 +28,7 @@ for device in ["cpu", "cuda"]:
             dynamic_dim(x, 0) <= 1024,
             dynamic_dim(x, 0) == dynamic_dim(y, 0),
         ]
-        model_so_path, _ = aot_compile(model, (x, y), constraints=constraints)
+        model_so_path = aot_compile(model, (x, y), constraints=constraints)
 
     data.update({
         f"model_so_path_{device}": model_so_path,

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -4,6 +4,7 @@ import os
 import sys
 import tempfile
 import unittest
+from typing import Dict
 
 import torch
 import torch._export
@@ -59,50 +60,61 @@ class AOTInductorModelRunner:
     @classmethod
     def compile(cls, model, example_inputs, options=None, constraints=None):
         # The exact API is subject to change
-        so_path, exported = torch._export.aot_compile(
+        so_path = torch._export.aot_compile(
             model,
             example_inputs,
             options=options,
             constraints=constraints,
             remove_runtime_assertions=True,
         )
-        return so_path, exported
+        return so_path
 
     @classmethod
     def load(cls, device, so_path, example_inputs):
         if IS_FBCODE:
             from .fb import test_aot_inductor_model_runner_pybind
 
-            optimized = test_aot_inductor_model_runner_pybind.Runner(
+            module = test_aot_inductor_model_runner_pybind.Runner(
                 so_path, device == "cpu"
-            ).run
+            )
+
+            call_spec = module.get_call_spec()
+            in_spec = pytree.treespec_loads(call_spec[0])
+            out_spec = pytree.treespec_loads(call_spec[1])
+
+            def optimized(*args):
+                flat_inputs = fx_pytree.tree_flatten_spec((*args, {}), in_spec)
+                flat_outputs = module.run(flat_inputs)
+                return pytree.tree_unflatten(flat_outputs, out_spec)
+
         else:
-            optimized = torch.utils.cpp_extension.load_inline(
+            module = torch.utils.cpp_extension.load_inline(
                 name="aot_inductor",
                 cpp_sources=[aot_inductor_launcher(so_path, device)],
                 # use a unique build directory to avoid test interference
                 build_directory=tempfile.mkdtemp(),
-                functions=["run"],
+                functions=["run", "get_call_spec"],
                 with_cuda=(device == "cuda"),
-            ).run
+            )
+
+            call_spec = module.get_call_spec()
+            in_spec = pytree.treespec_loads(call_spec[0])
+            out_spec = pytree.treespec_loads(call_spec[1])
+
+            def optimized(*args):
+                flat_inputs = fx_pytree.tree_flatten_spec((*args, {}), in_spec)
+                flat_outputs = module.run(flat_inputs)
+                return pytree.tree_unflatten(flat_outputs, out_spec)
 
         return optimized
 
     @classmethod
-    def run_compiled(cls, optimized, exported, example_inputs):
-        flat_example_inputs = fx_pytree.tree_flatten_spec(
-            (example_inputs, {}), exported.call_spec.in_spec
-        )
-        output_tensors = optimized(flat_example_inputs)
-        return pytree.tree_unflatten(output_tensors, exported.call_spec.out_spec)
-
-    @classmethod
     def run(cls, device, model, example_inputs, options=None, constraints=None):
-        so_path, exported = AOTInductorModelRunner.compile(
+        so_path = AOTInductorModelRunner.compile(
             model, example_inputs, options=options, constraints=constraints
         )
         optimized = AOTInductorModelRunner.load(device, so_path, example_inputs)
-        return AOTInductorModelRunner.run_compiled(optimized, exported, example_inputs)
+        return optimized(example_inputs)
 
     @classmethod
     def run_multiple(
@@ -113,7 +125,7 @@ class AOTInductorModelRunner:
         options=None,
         constraints=None,
     ):
-        so_path, exported = AOTInductorModelRunner.compile(
+        so_path = AOTInductorModelRunner.compile(
             model,
             list_example_inputs[0],
             options=options,
@@ -122,9 +134,7 @@ class AOTInductorModelRunner:
         optimized = AOTInductorModelRunner.load(device, so_path, list_example_inputs[0])
         list_output_tensors = []
         for example_inputs in list_example_inputs:
-            list_output_tensors.append(
-                AOTInductorModelRunner.run_compiled(optimized, exported, example_inputs)
-            )
+            list_output_tensors.append(optimized(example_inputs))
         return list_output_tensors
 
 
@@ -760,7 +770,7 @@ class AOTInductorTestsTemplate:
         with torch.cuda.device(0), config.patch(
             "aot_inductor.abi_compatible", self.abi_compatible
         ):
-            so_path, exported = AOTInductorModelRunner.compile(
+            so_path = AOTInductorModelRunner.compile(
                 model=Model(w1.cuda(0), w2.cuda(0)),
                 example_inputs=tuple(t.cuda(0) for t in inputs),
             )
@@ -770,10 +780,24 @@ class AOTInductorTestsTemplate:
             with torch.cuda.device(i):
                 example_inputs = tuple(t.cuda(i) for t in inputs)
                 optimized = AOTInductorModelRunner.load("cuda", so_path, example_inputs)
-                result_cuda = AOTInductorModelRunner.run_compiled(
-                    optimized, exported, example_inputs
-                )
+                result_cuda = optimized(example_inputs)
             self.assertTrue(same(result_cpu, result_cuda.cpu()))
+
+    def test_pytree_inputs(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x: Dict[str, torch.Tensor]):
+                add_ = torch.zeros(5)
+                mul_ = torch.ones(5)
+                for v in x.values():
+                    add_ += v
+                    mul_ *= v
+
+                return [add_, mul_]
+
+        self.check_model(M(), ({"x": torch.ones(5), "y": torch.ones(5)},))
 
     @requires_multigpu()
     def test_non_default_cuda_device(self):
@@ -828,7 +852,7 @@ class AOTInductorTestsTemplate:
         self.check_model(Model(), example_inputs)
 
         if self.device == "cuda":
-            so_path, _ = torch._export.aot_compile(Model(), example_inputs)
+            so_path = torch._export.aot_compile(Model(), example_inputs)
             with open(os.path.splitext(so_path)[0] + ".cpp") as cpp:
                 src_code = cpp.read()
                 FileCheck().check_count(

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -1,6 +1,7 @@
 import copy
 import dataclasses
 import io
+import json
 import pathlib
 import re
 import sys
@@ -77,32 +78,14 @@ from .passes.replace_view_ops_with_view_copy_ops_pass import (
 from .wrappers import _wrap_submodules
 
 
-def export__RC__(
+def _process_dynamic_shapes(
     f: Callable,
     args: Tuple[Any, ...],
     kwargs: Optional[Dict[str, Any]] = None,
-    *,
     dynamic_shapes: Optional[Dict[str, Any]] = None,
-) -> ExportedProgram:
-    """
-    API for exporting with dynamic shape specifications instead of constraints.
-    It should be considered "release candidate" (RC), meant to replace `export`.
-
-    Here, `dynamic_shapes` is expected to be a (possibly partial) dict from
-    argument names of `f` to dynamic shape specifications, as follows:
-    - The dynamic shape of a tensor argument can be specified as:
-      - Either a dict from dynamic dimension indices to Dim types. It is not
-        required to include static dimension indices in this dict, but when
-        they are, they should be mapped to None.
-      - Or a tuple of Dim types or None. The Dim types correspond to dynamic
-        dimensions, whereas static dimensions are denoted by None.
-    - Arguments that are dicts or tuples of tensors are recursively specified
-      by using mappings or sequences of contained specifications.
-
-    See `export` for documentation of `f`, `args`, `kwargs` and return.
-    """
+) -> Optional[List[Constraint]]:
     if dynamic_shapes is None or len(dynamic_shapes) == 0:
-        return export(f, args, kwargs)
+        return None
 
     kwargs = kwargs if kwargs is not None else {}
 
@@ -238,6 +221,34 @@ def export__RC__(
         else:
             constraints.append(primary)
 
+    return constraints
+
+
+def export__RC__(
+    f: Callable,
+    args: Tuple[Any, ...],
+    kwargs: Optional[Dict[str, Any]] = None,
+    *,
+    dynamic_shapes: Optional[Dict[str, Any]] = None,
+) -> ExportedProgram:
+    """
+    API for exporting with dynamic shape specifications instead of constraints.
+    It should be considered "release candidate" (RC), meant to replace `export`.
+
+    Here, `dynamic_shapes` is expected to be a (possibly partial) dict from
+    argument names of `f` to dynamic shape specifications, as follows:
+    - The dynamic shape of a tensor argument can be specified as:
+      - Either a dict from dynamic dimension indices to Dim types. It is not
+        required to include static dimension indices in this dict, but when
+        they are, they should be mapped to None.
+      - Or a tuple of Dim types or None. The Dim types correspond to dynamic
+        dimensions, whereas static dimensions are denoted by None.
+    - Arguments that are dicts or tuples of tensors are recursively specified
+      by using mappings or sequences of contained specifications.
+
+    See `export` for documentation of `f`, `args`, `kwargs` and return.
+    """
+    constraints = _process_dynamic_shapes(f, args, kwargs, dynamic_shapes)
     return _export(f, args, kwargs, constraints=constraints)
 
 
@@ -451,6 +462,79 @@ def _normalize_nn_module_stack(gm_torch_level, root_cls):
                     for key, (path, ty) in nn_module_stack.items()
                 }
 
+def _export_to_torch_ir(
+    f: Callable,
+    args: Tuple[Any, ...],
+    kwargs: Optional[Dict[str, Any]] = None,
+    constraints: Optional[List[Constraint]] = None,
+    *,
+    preserve_module_call_signature: Tuple[str, ...] = (),
+) -> torch.fx.GraphModule:
+    """
+    Traces either an nn.Module's forward function or just a callable with PyTorch
+    operations inside and produce a torch.fx.GraphModule in torch IR.
+    """
+
+    if constraints is not None:
+        warnings.warn(
+            "Using `constraints` to specify dynamic shapes for export is DEPRECATED "
+            "and will not be supported in the future. "
+            "Please use `dynamic_shapes` instead (see docs on `torch.export.export`).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    constraints = constraints or []
+    kwargs = kwargs or {}
+
+    if not isinstance(args, tuple):
+        raise UserError(UserErrorType.INVALID_INPUT,
+                        f"Expecting `args` to be a tuple of example positional inputs, got {type(args)}")
+
+    # We convert to nn.Module because __call__ of ExportedProgram
+    # is untracable right now.
+    if isinstance(f, ExportedProgram):
+        if len(constraints) > 0:
+            raise UserError(
+                UserErrorType.INVALID_INPUT,
+                "Cannot provide constraints for already exported program."
+            )
+        f = f.module()
+
+    with torch._dynamo.config.patch(dataclasses.asdict(DEFAULT_EXPORT_DYNAMO_CONFIG)):  # type: ignore[attr-defined]
+        try:
+            module_call_specs: Dict[str, Dict[str, pytree.TreeSpec]] = {}
+            # TODO Horrible hack to skip dynamo
+            if isinstance(f, torch.fx.GraphModule) and _safe_to_skip_dynamo(f):
+                if len(constraints) > 0:
+                    raise UserError(
+                        UserErrorType.INVALID_INPUT,
+                        "Cannot provide constraints for already exported program."
+                    )
+                gm_torch_level = f
+            else:
+                with _wrap_submodules(f, preserve_module_call_signature, module_call_specs):
+                    gm_torch_level, _ = torch._dynamo.export(
+                        f,
+                        constraints=constraints,
+                        assume_static_by_default=True,
+                        tracing_mode="symbolic",
+                    )(
+                        *args,
+                        **kwargs,
+                    )
+        except (ConstraintViolationError, ValueRangeError) as e:
+            raise UserError(UserErrorType.CONSTRAINT_VIOLATION, str(e))  # noqa: TRY200
+        except GuardOnDataDependentSymNode as e:
+            raise UserError(  # noqa: TRY200
+                UserErrorType.ANTI_PATTERN,
+                f"Consider annotating your code using torch._constrain_as_*(). {str(e)}",
+                case_name="constrain_as_size_example",
+            )
+
+    gm_torch_level.meta["module_call_specs"] = module_call_specs
+    return gm_torch_level
+
 
 def export(
     f: Callable,
@@ -509,50 +593,13 @@ def _export(
     constraints = constraints or []
     kwargs = kwargs or {}
 
-    if not isinstance(args, tuple):
-        raise UserError(UserErrorType.INVALID_INPUT,
-                        f"Expecting `args` to be a tuple of example positional inputs, got {type(args)}")
-
-    # We convert to nn.Module because __call__ of ExportedProgram
-    # is untracable right now.
-    if isinstance(f, ExportedProgram):
-        if len(constraints) > 0:
-            raise UserError(
-                UserErrorType.INVALID_INPUT,
-                "Cannot provide constraints for already exported program."
-            )
-        f = f.module()
-
-    with torch._dynamo.config.patch(dataclasses.asdict(DEFAULT_EXPORT_DYNAMO_CONFIG)):  # type: ignore[attr-defined]
-        try:
-            module_call_specs: Dict[str, Dict[str, pytree.TreeSpec]] = {}
-            # TODO Horrible hack to skip dynamo
-            if isinstance(f, torch.fx.GraphModule) and _safe_to_skip_dynamo(f):
-                if len(constraints) > 0:
-                    raise UserError(
-                        UserErrorType.INVALID_INPUT,
-                        "Cannot provide constraints for already exported program."
-                    )
-                gm_torch_level = f
-            else:
-                with _wrap_submodules(f, preserve_module_call_signature, module_call_specs):
-                    gm_torch_level, _ = torch._dynamo.export(
-                        f,
-                        constraints=constraints,
-                        assume_static_by_default=True,
-                        tracing_mode="symbolic",
-                    )(
-                        *args,
-                        **kwargs,
-                    )
-        except (ConstraintViolationError, ValueRangeError) as e:
-            raise UserError(UserErrorType.CONSTRAINT_VIOLATION, str(e))  # noqa: TRY200
-        except GuardOnDataDependentSymNode as e:
-            raise UserError(  # noqa: TRY200
-                UserErrorType.ANTI_PATTERN,
-                f"Consider annotating your code using torch._constrain_as_*(). {str(e)}",
-                case_name="constrain_as_size_example",
-            )
+    gm_torch_level = _export_to_torch_ir(
+        f,
+        args,
+        kwargs,
+        constraints,
+        preserve_module_call_signature=preserve_module_call_signature
+    )
 
     params_buffers: Dict[str, Union[torch.Tensor, torch.nn.Parameter]] = {}
     for name, param in gm_torch_level.named_parameters(remove_duplicate=False):
@@ -607,6 +654,7 @@ def _export(
 
     # Fix the graph output signature to be tuple if scalar
     out_spec = orig_out_spec = gm_torch_level._out_spec
+    assert out_spec is not None
     # aot_export expect the return type to always be a tuple.
     if out_spec.type not in (list, tuple):
         out_spec = pytree.TreeSpec(tuple, None, [out_spec])
@@ -736,7 +784,10 @@ def _export(
         _replace_param_buffer_names(param_buffer_table, export_graph_signature)
         params_buffers = {param_buffer_table.get(name, name): tensor for name, tensor in params_buffers.items()}
 
-    module_call_signatures = {fqn: ModuleCallSignature(inputs=[], outputs=[], **specs) for fqn, specs in module_call_specs.items()}
+    module_call_signatures = {
+        fqn: ModuleCallSignature(inputs=[], outputs=[], **specs)
+        for fqn, specs in gm_torch_level.meta["module_call_specs"].items()
+    }
 
     if len(preserve_module_call_signature) > 0:
         res = CollectTracepointsPass(module_call_signatures)(gm)
@@ -846,7 +897,7 @@ def aot_compile(
     dynamic_shapes: Optional[Dict[str, Any]] = None,
     options: Optional[Dict[str, Any]] = None,
     remove_runtime_assertions: bool = False,
-) -> Tuple[str, ExportedProgram]:
+) -> str:
     """
     Note: this function is not stable yet
 
@@ -872,12 +923,8 @@ def aot_compile(
 
         options: A dictionary of options to control inductor
 
-        remove_runtime_assertions: Whether the runtime assertion fx nodes
-            (and the related fx nodes) inserted by export should be removed
-            from the graph before running _inductor.aot_compile.
-
     Returns:
-        Path to the generated shared library, and the exported program
+        Path to the generated shared library
     """
     if constraints is not None:
         warnings.warn(
@@ -885,63 +932,17 @@ def aot_compile(
             "Please use dynamic_shapes instead."
         )
 
-    if constraints is not None:
-        ep = export(f, args, kwargs, constraints)
-    else:
-        ep = export__RC__(f, args, kwargs, dynamic_shapes=dynamic_shapes)
-
     from torch._inductor.decomposition import select_decomp_table
-    ep = ep.run_decompositions(select_decomp_table())
 
-    # TODO(angelayi): Needed to comment this out in order to unblock something
-    # if remove_runtime_assertions:
-    ep = ep._transform(_RemoveRuntimeAssertionsPass())
+    if constraints is None:
+        constraints = _process_dynamic_shapes(f, args, kwargs, dynamic_shapes)
 
-    flat_example_inputs = fx_pytree.tree_flatten_spec(
-        combine_args_kwargs(args, kwargs), ep.call_spec.in_spec  # type: ignore[arg-type]
-    )
+    # We want to export to Torch IR here to utilize the pre_grad passes in
+    # inductor, which run on Torch IR.
+    gm = _export_to_torch_ir(f, args, kwargs, constraints)
+    flat_example_inputs, _ = pytree.tree_flatten(combine_args_kwargs(args, kwargs))
 
-    unlifted_module = ep.module()
-    unlifted_module.graph.set_codegen(torch.fx.CodeGen())  # type: ignore[attr-defined]
-    unlifted_module.recompile()
-    options = (
-        {"from_export": True}
-        if options is None
-        else {**options, "from_export": True}
-    )
-    so_path = torch._inductor.aot_compile(unlifted_module, flat_example_inputs, options)  # type: ignore[arg-type]
+    with torch.no_grad():
+        so_path = torch._inductor.aot_compile(gm, flat_example_inputs, options)  # type: ignore[arg-type]
 
-    user_inputs = []
-    user_outputs = []
-    for node in unlifted_module.graph.nodes:
-        if node.op == "placeholder":
-            user_inputs.append(node.name)
-        elif node.op == "output":
-            user_outputs = [arg.name for arg in node.args[0]]
-
-    unlifted_ep = ExportedProgram(
-        unlifted_module,
-        unlifted_module.graph,
-        ExportGraphSignature(
-            input_specs=[
-                InputSpec(
-                    kind=InputKind.USER_INPUT,
-                    arg=TensorArgument(name=i),
-                    target=None,
-                ) for i in user_inputs
-            ],
-            output_specs=[
-                OutputSpec(
-                    kind=OutputKind.USER_OUTPUT,
-                    arg=TensorArgument(name=o),
-                    target=None,
-                ) for o in user_outputs
-            ]
-        ),
-        state_dict={},
-        range_constraints=copy.deepcopy(ep.range_constraints),
-        equality_constraints=copy.deepcopy(ep.equality_constraints),
-        module_call_graph=ep.module_call_graph,
-    )
-
-    return so_path, unlifted_ep
+    return so_path

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Optional
 
 import torch.fx
+import torch.utils._pytree as pytree
 
 __all__ = ["compile", "list_mode_options", "list_options", "cudagraph_mark_step_begin"]
 
@@ -46,6 +47,33 @@ def aot_compile(
         Path to the generated shared library
     """
     from .compile_fx import compile_fx_aot
+
+    # We will serialize the pytree info into the .so as constant strings
+    serialized_in_spec = ""
+    serialized_out_spec = ""
+    if isinstance(gm.graph._codegen, torch.fx.graph._PyTreeCodeGen):
+        codegen = gm.graph._codegen
+        gm.graph._codegen = torch.fx.graph.CodeGen()
+        gm.recompile()
+
+        if codegen.pytree_info.in_spec is not None:
+            serialized_in_spec = pytree.treespec_dumps(codegen.pytree_info.in_spec)
+
+        if codegen.pytree_info.out_spec is not None:
+            serialized_out_spec = pytree.treespec_dumps(codegen.pytree_info.out_spec)
+
+    options = (
+        {
+            "aot_inductor.serialized_in_spec": serialized_in_spec,
+            "aot_inductor.serialized_out_spec": serialized_out_spec,
+        }
+        if options is None
+        else {
+            **options,
+            "aot_inductor.serialized_in_spec": serialized_in_spec,
+            "aot_inductor.serialized_out_spec": serialized_out_spec,
+        }
+    )
 
     return compile_fx_aot(
         gm,

--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -129,6 +129,19 @@ AOTIRuntimeError AOTInductorModelContainerGetOutputName(
       { *ret_output_names = container->output_name(output_idx); })
 }
 
+AOTIRuntimeError AOTInductorModelContainerGetCallSpec(
+    AOTInductorModelContainerHandle container_handle,
+    const char** in_spec,
+    const char** out_spec) {
+  auto* container =
+      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
+          container_handle);
+  CONVERT_EXCEPTION_TO_ERROR_CODE({
+    *in_spec = container->get_in_spec();
+    *out_spec = container->get_out_spec();
+  })
+}
+
 AOTIRuntimeError AOTInductorModelCreate(
     AOTInductorModelHandle* model_handle,
     AOTInductorConstantMapHandle constant_map_handle) {

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1438,6 +1438,21 @@ class CppWrapperCodeGen(WrapperCodeGen):
 
             self.prefix.writeline("update_constants_map(std::move(constants_map));")
 
+            def escape_string(x):
+                return (
+                    x.replace("\\", "\\\\")
+                    .replace('"', '\\"')
+                    .replace("\n", "\\n")
+                    .replace("\t", "\\t")
+                )
+
+            self.prefix.writeline(
+                f'in_spec_ = "{escape_string(config.aot_inductor.serialized_in_spec)}";'
+            )
+            self.prefix.writeline(
+                f'out_spec_ = "{escape_string(config.aot_inductor.serialized_out_spec)}";'
+            )
+
             for idx, output in enumerate(V.graph.graph_outputs):
                 assert not isinstance(
                     output, sympy.Expr

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -23,7 +23,7 @@ from torch._dynamo import (
     utils as dynamo_utils,
 )
 from torch._dynamo.utils import detect_fake_mode, lazy_format_graph_code
-from torch._functorch.aot_autograd import make_boxed_func
+from torch._functorch.aot_autograd import aot_export_module, make_boxed_func
 from torch._inductor.codecache import code_hash, CompiledFxGraph, FxGraphCache
 
 from torch._inductor.debug import save_args_for_compile_fx_inner
@@ -132,6 +132,35 @@ def _warn_tf32_disabled():
             "TensorFloat32 tensor cores for float32 matrix multiplication available but not enabled. "
             "Consider setting `torch.set_float32_matmul_precision('high')` for better performance."
         )
+
+
+def _unlift_graph(mod, gm, graph_signature):
+    state_dict = {}
+    for name, param in mod.named_parameters(remove_duplicate=False):
+        state_dict[name] = param
+    for name, param in mod.named_buffers(remove_duplicate=False):
+        state_dict[name] = param
+
+    from torch._export.exported_program import (
+        _construct_inp_pos_to_param_buffer_name,
+        _unlift,
+    )
+
+    inp_pos_to_param_buffer_name = _construct_inp_pos_to_param_buffer_name(
+        gm,
+        graph_signature,
+        state_dict,
+    )
+    unlifted_gm = _unlift(
+        gm,
+        inp_pos_to_param_buffer_name,
+        pytree.LeafSpec(),
+        None,
+        state_dict,
+        graph_signature.buffers_to_mutate,
+        set(graph_signature.user_outputs),
+    )
+    return unlifted_gm
 
 
 def is_tf32_warning_applicable(gm: torch.fx.GraphModule):
@@ -1038,11 +1067,7 @@ def compile_fx(
                 recursive_compile_fx,
             )
 
-        if not config.from_export:
-            # Since handle_dynamo_export_graph will trigger compile_fx again,
-            # Move these passes after handle_dynamo_export_graph to avoid repeated calls.
-            # If we come from export, the graph is already in aten IR, so pre-grad passes is no-op.
-            model_ = pre_grad_passes(model_, example_inputs_)
+        model_ = pre_grad_passes(model_, example_inputs_)
 
     if any(isinstance(x, (list, tuple, dict)) for x in example_inputs_):
         return flatten_graph_inputs(
@@ -1181,9 +1206,13 @@ def compile_fx(
         torch._guards.TracingContext.get() or torch._guards.TracingContext(fake_mode)
     )
 
-    if config.from_export and V.aot_compilation is True:
+    if V.aot_compilation is True:
+        gm, graph_signature = aot_export_module(
+            model_, example_inputs_, trace_joint=False, decompositions=decompositions
+        )
+        unlifted_gm = _unlift_graph(model_, gm, graph_signature)
         with V.set_fake_mode(fake_mode), compiled_autograd.disable():
-            return inference_compiler(model_, example_inputs_)
+            return inference_compiler(unlifted_gm, example_inputs_)
 
     with V.set_fake_mode(fake_mode), torch._guards.tracing(  # type: ignore[call-arg]
         tracing_context

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -100,9 +100,6 @@ use_mixed_mm = False
 # (if force_mixed_mm is true, the use_mixed_mm flag will be ignored)
 force_mixed_mm = False
 
-# TODO: capture whether the graph is from export
-from_export = False
-
 # enable reordering pass for increasing overlap between compute and communication
 reorder_for_compute_comm_overlap = False
 
@@ -489,6 +486,12 @@ class aot_inductor:
 
     # Wether to codegen abi compatible model.so
     abi_compatible = is_fbcode()
+
+    # Serialized tree spec for flattening inputs
+    serialized_in_spec = ""
+
+    # Serialized tree spec for flattening outputs
+    serialized_out_spec = ""
 
 
 class cuda:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1258,6 +1258,10 @@ def aot_inductor_launcher(so_path: str, device: str):
             std::vector<at::Tensor> run(std::vector<at::Tensor>& input_tensors) {{
                 return runner.run(input_tensors);
             }}
+
+            std::vector<const char*> get_call_spec() {{
+                return runner.get_call_spec();
+            }}
         """
     elif device == "cpu":
         return f"""
@@ -1267,6 +1271,10 @@ def aot_inductor_launcher(so_path: str, device: str):
 
             std::vector<at::Tensor> run(std::vector<at::Tensor>& input_tensors) {{
                 return runner.run(input_tensors);
+            }}
+
+            std::vector<const char*> get_call_spec() {{
+                return runner.get_call_spec();
             }}
         """
     else:

--- a/torch/csrc/inductor/aoti_model_runner.cpp
+++ b/torch/csrc/inductor/aoti_model_runner.cpp
@@ -21,6 +21,8 @@ AOTIModelRunner::AOTIModelRunner(
       model_so_->sym("AOTInductorModelContainerGetNumOutputs"));
   run_func_ = reinterpret_cast<decltype(run_func_)>(
       model_so_->sym("AOTInductorModelContainerRun"));
+  get_call_spec_func_ = reinterpret_cast<decltype(get_call_spec_func_)>(
+      model_so_->sym("AOTInductorModelContainerGetCallSpec"));
 
   AOTI_RUNTIME_ERROR_CODE_CHECK(
       create_func_(&container_handle_, num_models, is_cpu, cubin_dir));
@@ -57,6 +59,15 @@ std::vector<at::Tensor> AOTIModelRunner::run(
 
   return torch::aot_inductor::alloc_tensors_by_stealing_from_handles(
       output_handles.data(), output_handles.size());
+}
+
+std::vector<const char*> AOTIModelRunner::get_call_spec() {
+  const char* in_spec;
+  const char* out_spec;
+  AOTI_RUNTIME_ERROR_CODE_CHECK(
+      get_call_spec_func_(container_handle_, &in_spec, &out_spec));
+  std::vector<const char*> call_spec = {in_spec, out_spec};
+  return call_spec;
 }
 
 } // namespace torch::inductor

--- a/torch/csrc/inductor/aoti_model_runner.h
+++ b/torch/csrc/inductor/aoti_model_runner.h
@@ -25,6 +25,8 @@ class TORCH_API AOTIModelRunner {
       AOTInductorStreamHandle cuda_stream_handle = nullptr,
       AOTIProxyExecutorHandle proxy_executor_handle = nullptr);
 
+  std::vector<const char*> get_call_spec();
+
   AOTIModelRunner(
       const char* model_path,
       size_t num_models,
@@ -38,6 +40,7 @@ class TORCH_API AOTIModelRunner {
   decltype(&AOTInductorModelContainerGetNumOutputs) get_num_outputs_func_{
       nullptr};
   decltype(&AOTInductorModelContainerRun) run_func_{nullptr};
+  decltype(&AOTInductorModelContainerGetCallSpec) get_call_spec_func_{nullptr};
   AOTInductorModelContainerHandle container_handle_ = nullptr;
 };
 
@@ -50,6 +53,10 @@ class TORCH_API AOTIModelRunnerCpu : public AOTIModelRunner {
       std::vector<at::Tensor> inputs,
       AOTIProxyExecutorHandle proxy_executor_handle = nullptr) {
     return AOTIModelRunner::run(inputs, nullptr, proxy_executor_handle);
+  }
+
+  std::vector<const char*> get_call_spec() {
+    return AOTIModelRunner::get_call_spec();
   }
 };
 

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -119,4 +119,9 @@ AOTIRuntimeError AOTInductorModelUpdateConstantsMap(
 // Delete an AOTInductorModel created by AOTInductorModelCreate.
 AOTIRuntimeError AOTInductorModelDelete(AOTInductorModelHandle model_handle);
 
+AOTIRuntimeError AOTInductorModelContainerGetCallSpec(
+    AOTInductorModelContainerHandle container_handle,
+    const char** in_spec,
+    const char** out_spec);
+
 } // extern "C"

--- a/torch/csrc/inductor/aoti_runtime/model.h
+++ b/torch/csrc/inductor/aoti_runtime/model.h
@@ -247,6 +247,14 @@ class AOTInductorModelBase {
     return constants_info_.at(idx).data_size;
   }
 
+  const char* get_in_spec() const {
+    return in_spec_.c_str();
+  }
+
+  const char* get_out_spec() const {
+    return out_spec_.c_str();
+  }
+
   void update_constants_map(std::shared_ptr<ConstantMap> constants_map) {
     constants_map_ = std::move(constants_map);
     if (!constants_map_) {
@@ -313,6 +321,8 @@ class AOTInductorModelBase {
   std::vector<ParamInfo> inputs_info_;
   std::vector<ParamInfo> outputs_info_;
   std::vector<ConstInfo> constants_info_;
+  std::string in_spec_;
+  std::string out_spec_;
 
   std::shared_ptr<ConstantMap> constants_map_;
   std::vector<AtenTensorHandle> constants_;

--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -128,6 +128,9 @@ class AOTInductorModelContainer {
     for (auto& model : models_) {
       model->update_constants_map(constants_);
     }
+
+    in_spec_ = model->get_in_spec();
+    out_spec_ = model->get_out_spec();
   }
 
   void run(
@@ -176,9 +179,19 @@ class AOTInductorModelContainer {
     return models_.size();
   }
 
+  const char* get_in_spec() const {
+    return in_spec_;
+  }
+
+  const char* get_out_spec() const {
+    return out_spec_;
+  }
+
  private:
   std::vector<std::string> input_names_;
   std::vector<std::string> output_names_;
+  const char* in_spec_;
+  const char* out_spec_;
 
 #ifdef USE_CUDA
   // Holds the blob storage for constants' at::Tensor for CUDA.


### PR DESCRIPTION
Updates `_export.aot_compile` to pass a torch IR graph to inductor, allowing inductor to now run the pre_grad_passes, and reuse more of inductor's code. 
Also updates the API to only return the `so_path`, and not returning the exported program. The pytree call spec is now serialized and placed inside of the generated model code. When calling the model, because there is no c++ pytree implementation linked yet, we can access the call specs through `get_call_spec()`, and call pytree flatten/unflattenin python.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan