### PR TITLE
[dynamo][guards-log] Print nn module guard saved dict versions for debugging

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -1052,19 +1052,28 @@ class CheckFunctionManager:
             if not log_only:
                 code_parts.append(code)
 
-        seen = set()
-        for gcl in local_builder.code:
-            for code in gcl.code_list:
-                if code not in seen:
-                    add_code_part(code, gcl.guard)
-                    seen.add(code)
+        def add_nn_module_guard(code, guard):
+            # Prints the versions of the nn module guard for debugging.
+            # Manually append the code part
+            code_parts.append(code)
 
-        seen = set()
-        for gcl in global_builder.code:
-            for code in gcl.code_list:
-                if code not in seen:
-                    add_code_part(code, gcl.guard)
-                    seen.add(code)
+            # Log the verbose part
+            nn_module_guard = self._extra_closure_vars[code.split("(")[0]]
+            add_code_part(f"{code} # {nn_module_guard}", guard, log_only=True)
+
+        def add_code_parts_for_builder(builder):
+            seen = set()
+            for gcl in builder.code:
+                for code in gcl.code_list:
+                    if code not in seen:
+                        if "__nn_module_guard" in code:
+                            add_nn_module_guard(code, gcl.guard)
+                        else:
+                            add_code_part(code, gcl.guard)
+                        seen.add(code)
+
+        add_code_parts_for_builder(local_builder)
+        add_code_parts_for_builder(global_builder)
 
         tensor_check_names = (
             local_builder.tensor_check_names + global_builder.tensor_check_names

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -651,6 +651,23 @@ static PyObject* NNModuleGuard_call(
   Py_RETURN_TRUE;
 }
 
+static PyObject* NNModuleGuard_repr(PyObject* self) {
+  // Prints versions of the module and the attributes.
+  NNModuleGuard* guard = (NNModuleGuard*)self;
+  std::ostringstream oss;
+  oss << "versions(mod=" << guard->version_tag;
+
+  for (size_t index = 0;
+       index < sizeof(module_guard_attrs) / sizeof(module_guard_attrs[0]);
+       index++) {
+    oss << ", " << module_guard_attrs[index] << "="
+        << guard->attr_tags[index].dict_version_tag;
+  }
+
+  oss << ")";
+  return Py_BuildValue("s", oss.str().c_str());
+}
+
 static PyObject* nn_module_guard(PyObject* dummy, PyObject* obj) {
   // Uses a private tags introduced in PEP 509 - ma_version_tag to check if
   // there are any changes in the dict.
@@ -763,6 +780,7 @@ PyObject* torch_c_dynamo_guards_init() {
   NNModuleGuardType.tp_call = NNModuleGuard_call;
   NNModuleGuardType.tp_dealloc = (destructor)NNModuleGuard_dealloc;
   NNModuleGuardType.tp_flags = Py_TPFLAGS_DEFAULT;
+  NNModuleGuardType.tp_repr = NNModuleGuard_repr;
 
   GlobalStateGuardType.tp_name = "torch._C._dynamo.guards.GlobalStateGuard";
   GlobalStateGuardType.tp_basicsize = sizeof(GlobalStateGuard);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110028
* #110039
* #110023

This is the output for nn module guards

~~~
[DEBUG] GUARDS:
[DEBUG] hasattr(L['x'], '_dynamo_dynamic_indices') == False           # _dynamo/variables/builder.py:1356 in wrap_fx_proxy_cls
[DEBUG] ___check_obj_id(L['self'], 139820807110912)                   # for mod in self.mods:  # examples/graph_break.py:35 in forward
[DEBUG] __nn_module_guard_0(L['self']) # versions(mod=9998, _parameters=1194395, _buffers=1194397, _modules=1194423, _forward_hooks=1194405, _forward_pre_hooks=1194411, _backward_hooks=1194402, _backward_pre_hooks=1194400)  # for mod in self.mods:  # examples/graph_break.py:35 in forward
[DEBUG] ___check_obj_id(L['self'].mods[0], 139817945727568)           # for mod in self.mods:  # examples/graph_break.py:35 in forward
[DEBUG] __nn_module_guard_1(L['self'].mods[0]) # versions(mod=10001, _parameters=1194428, _buffers=1194430, _modules=1194522, _forward_hooks=1194438, _forward_pre_hooks=1194444, _backward_hooks=1194435, _backward_pre_hooks=1194433)  # for mod in self.mods:  # examples/graph_break.py:35 in forward
[DEBUG] ___check_obj_id(L['self'].mods[1], 139817945560640)           # for mod in self.mods:  # examples/graph_break.py:35 in forward
[DEBUG] __nn_module_guard_2(L['self'].mods[1]) # versions(mod=10001, _parameters=1194660, _buffers=1194662, _modules=1194753, _forward_hooks=1194670, _forward_pre_hooks=1194676, _backward_hooks=1194667, _backward_pre_hooks=1194665)  # for mod in self.mods:  # examples/graph_break.py:35 in forward
[DEBUG] ___check_obj_id(L['self'].mods[0].linear, 139817945727856)    # return self.linear(a)  # examples/graph_break.py:24 in helper
[DEBUG] __nn_module_guard_3(L['self'].mods[0].linear) # versions(mod=10004, _parameters=1470004, _buffers=1194467, _modules=1194493, _forward_hooks=1194475, _forward_pre_hooks=1194481, _backward_hooks=1194472, _backward_pre_hooks=1194470)  # return self.linear(a)  # examples/graph_break.py:24 in helper
[DEBUG] ___check_obj_id(L['self'].mods[1].linear, 139817945561120)    # return self.linear(a)  # examples/graph_break.py:24 in helper
[DEBUG] __nn_module_guard_4(L['self'].mods[1].linear) # versions(mod=10004, _parameters=1470008, _buffers=1194699, _modules=1194725, _forward_hooks=1194707, _forward_pre_hooks=1194713, _backward_hooks=1194704, _backward_pre_hooks=1194702)  # return self.linear(a)  # examples/graph_break.py:24 in helper
[DEBUG] utils_device.CURRENT_DEVICE == None                           # _dynamo/output_graph.py:373 in init_ambient_guards
~~~

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng