### PR TITLE
Monitor baseline for TD prioritizations

### DIFF
--- a/tools/testing/target_determination/heuristics/interface.py
+++ b/tools/testing/target_determination/heuristics/interface.py
@@ -253,7 +253,9 @@ class AggregatedHeuristics:
         }
 
         # Get baseline metrics assuming we didn't have any TD heuristics
-        baseline_priorities = TestPrioritizations(tests_being_ranked=self.unranked_tests)
+        baseline_priorities = TestPrioritizations(
+            tests_being_ranked=self.unranked_tests
+        )
         baseline_stats = baseline_priorities.get_priority_info_for_test(test)
         baseline_stats["heuristic_name"] = "baseline"
         stats["without_heuristics"] = baseline_stats

--- a/tools/testing/target_determination/heuristics/interface.py
+++ b/tools/testing/target_determination/heuristics/interface.py
@@ -251,6 +251,14 @@ class AggregatedHeuristics:
         stats: Dict[str, Any] = {
             "test_name": test,
         }
+
+        # Get baseline metrics assuming we didn't have any TD heuristics
+        baseline_priorities = TestPrioritizations(tests_being_ranked=self.unranked_tests)
+        baseline_stats = baseline_priorities.get_priority_info_for_test(test)
+        baseline_stats["heuristic_name"] = "baseline"
+        stats["without_heuristics"] = baseline_stats
+
+        # Get metrics about the heuristics used
         heuristics = []
 
         # Figure out which heuristic gave this test the highest priority (if any)


### PR DESCRIPTION
For tests that TD prioritizes, we should track what their ordering _would have been_ if none of the TD heuristics had applied to it.

This is useful for two reasons:
1. It lets us better understand TD may have contributed to that test running sooner
2. it's possible that heuristics actually mark a test as less important than the default sorting would have claimed (the default sorts tests in a fixed order). This will let us track how often that happens