### PR TITLE
Quieter logs in CI

### DIFF
--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -43,14 +43,14 @@ runs:
         FILE_SUFFIX: ${{ inputs.file-suffix }}
       run: |
         # Remove any previous test reports if they exist
-        rm -f usage-log-*.zip
+        rm -f logs-*.zip
         # this workflow is also run in bazel build test, but we dont generate usage reports for it
         # so check to see if the file exists first
         if [ -f 'usage_log.txt' ]; then
-            zip "usage-log-${FILE_SUFFIX}.zip" 'usage_log.txt'
+            zip "logs-${FILE_SUFFIX}.zip" 'usage_log.txt'
         fi
         if ls test/**/*.log 1> /dev/null 2>&1; then
-            zip -r "usage-log-${FILE_SUFFIX}.zip" test -i '*.log'
+            zip -r "logs-${FILE_SUFFIX}.zip" test -i '*.log'
         fi
 
     # Windows zip
@@ -80,7 +80,7 @@ runs:
         FILE_SUFFIX: ${{ inputs.file-suffix }}
       run: |
         # -ir => recursive include all files in pattern
-        7z a "usage-log-$Env:FILE_SUFFIX.zip" 'usage_log.txt' -ir'!test\*.log'
+        7z a "logs-$Env:FILE_SUFFIX.zip" 'usage_log.txt' -ir'!test\*.log'
 
     # S3 upload
     - name: Store Test Downloaded JSONs on S3
@@ -112,7 +112,7 @@ runs:
           ${{ github.repository }}/${{ github.run_id }}/${{ github.run_attempt }}/artifact
         retention-days: 14
         if-no-files-found: ignore
-        path: usage-log-*.zip
+        path: logs-*.zip
 
     # GHA upload
     - name: Store Test Downloaded JSONs on Github
@@ -146,7 +146,7 @@ runs:
       continue-on-error: true
       with:
         # Add the run attempt, see [Artifact run attempt]
-        name: usage-log-runattempt${{ github.run_attempt }}-${{ inputs.file-suffix }}.zip
+        name: logs-runattempt${{ github.run_attempt }}-${{ inputs.file-suffix }}.zip
         retention-days: 14
         if-no-files-found: ignore
         path: |

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -184,7 +184,7 @@ jobs:
         shell: bash
         if: always() && steps.test.conclusion
         run: |
-          cat test/**/*.log || true
+          cat test/**/*_toprint.log || true
 
       - name: Chown workspace
         uses: ./.github/actions/chown-workspace

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -251,7 +251,7 @@ jobs:
         shell: bash
         if: always() && steps.test.conclusion
         run: |
-          cat test/**/*.log || true
+          cat test/**/*_toprint.log || true
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -141,7 +141,7 @@ jobs:
         shell: bash
         if: always() && steps.test.conclusion
         run: |
-          cat test/**/*.log || true
+          cat test/**/*_toprint.log || true
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -178,7 +178,7 @@ jobs:
         shell: bash
         if: always() && steps.test.conclusion
         run: |
-          cat test/**/*.log || true
+          cat test/**/*_toprint.log || true
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -199,7 +199,7 @@ jobs:
         shell: bash
         if: always() && steps.test.conclusion
         run: |
-          cat test/**/*.log || true
+          cat test/**/*_toprint.log || true
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -180,7 +180,7 @@ jobs:
         shell: bash
         if: always() && steps.test.conclusion
         run: |
-          cat test/**/*.log || true
+          cat test/**/*_toprint.log || true
 
       - name: Get workflow job id
         id: get-job-id

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -943,7 +943,7 @@ def handle_log_file(
             f"\n{test} was successful, full logs can be found in artifacts with path {new_file}"
         )
         for line in full_text.splitlines():
-            if re.search(b"Running .* items in this shard:", line):
+            if re.search("Running .* items in this shard:", line):
                 print_to_stderr(line.strip())
         print_to_stderr()
         return

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -931,10 +931,8 @@ def print_log_file(test: ShardedTest, file_path: str, failed: bool) -> None:
     if not failed and not verbose:
         # If not verbose + success, print only what tests ran, rename the log
         # file so it doesn't get printed later, and do not remove logs.
-        new_file = (
-            "test"
-            / "test-reports"
-            / sanitize_file_name(f"{str(test)}_{os.urandom(8).hex()}_.log")
+        new_file = "test/test-reports/" + sanitize_file_name(
+            f"{test}_{os.urandom(8).hex()}_.log"
         )
         os.rename(file_path, REPO_ROOT / new_file)
         print(

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -927,6 +927,7 @@ def sanitize_file_name(file: str):
 
 def print_log_file(test: ShardedTest, file_path: str, failed: bool) -> None:
     verbose = "VERBOSE_LOGS=1" in os.environ.get("PR_BODY", "")
+    test = str(test)
     if not failed and not verbose:
         # If not verbose + success, print only what tests ran, rename the log
         # file so it doesn't get printed later, and do not remove logs.
@@ -945,7 +946,6 @@ def print_log_file(test: ShardedTest, file_path: str, failed: bool) -> None:
                     print_to_stderr(line.strip())
         return
     # Test failure or verbose logs: print entire file and then remove it
-    test = str(test)
     with open(file_path, "rb") as f:
         print_to_stderr("")
         print_to_stderr(f"PRINTING LOG FILE of {test} ({file_path})")

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -631,8 +631,7 @@ def run_test(
         # comes up in the future.
         ret_code = 0 if ret_code == 5 or ret_code == 4 else ret_code
 
-    print_log_file(test_module, log_path, failed=(ret_code != 0))
-    os.remove(log_path)
+    handle_log_file(test_module, log_path, failed=(ret_code != 0))
     return ret_code
 
 
@@ -925,7 +924,7 @@ def sanitize_file_name(file: str):
     return file.replace("\\", ".").replace("/", ".").replace(" ", "_")
 
 
-def print_log_file(test: ShardedTest, file_path: str, failed: bool) -> None:
+def handle_log_file(test: ShardedTest, file_path: str, failed: bool) -> None:
     verbose = "VERBOSE_LOGS=1" in os.environ.get("PR_BODY", "")
     test = str(test)
     if not failed and not verbose:
@@ -950,7 +949,7 @@ def print_log_file(test: ShardedTest, file_path: str, failed: bool) -> None:
         print_to_stderr(f.read().decode("utf-8", errors="ignore"))
         print_to_stderr(f"FINISHED PRINTING LOG FILE of {test} ({file_path})")
         print_to_stderr("")
-        os.remove(file_path)
+    os.remove(file_path)
 
 
 def get_pytest_args(

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -928,29 +928,29 @@ def handle_log_file(
     test: ShardedTest, file_path: str, failed: bool, was_rerun: bool
 ) -> None:
     test = str(test)
-    if not failed and not was_rerun:
-        # If success + no file level retries, print only what tests ran, rename
-        # the log file so it doesn't get printed later, and do not remove logs.
+    with open(file_path, "rb") as f:
+        full_text = f.read().decode("utf-8", errors="ignore")
+
+    if not failed and not was_rerun and "=== RERUNS ===" not in full_text:
+        # If success + no retries (idk how else to check for test level retries
+        # other than reparse xml), print only what tests ran, rename the log
+        # file so it doesn't get printed later, and do not remove logs.
         new_file = "test/test-reports/" + sanitize_file_name(
             f"{test}_{os.urandom(8).hex()}_.log"
         )
         os.rename(file_path, REPO_ROOT / new_file)
-        print(
+        print_to_stderr(
             f"\n{test} was successful, full logs can be found in artifacts with path {new_file}"
         )
-        with open(REPO_ROOT / new_file, "rb") as f:
-            for line in f.readlines():
-                if re.search(b"Running .* items in this shard:", line):
-                    print_to_stderr(line.decode("utf-8", errors="ignore").strip())
-        print()
+        for line in full_text.splitlines():
+            if re.search(b"Running .* items in this shard:", line):
+                print_to_stderr(line.strip())
+        print_to_stderr()
         return
     # otherwise: print entire file and then remove it
-    with open(file_path, "rb") as f:
-        print_to_stderr("")
-        print_to_stderr(f"PRINTING LOG FILE of {test} ({file_path})")
-        print_to_stderr(f.read().decode("utf-8", errors="ignore"))
-        print_to_stderr(f"FINISHED PRINTING LOG FILE of {test} ({file_path})")
-        print_to_stderr("")
+    print_to_stderr(f"\nPRINTING LOG FILE of {test} ({file_path})")
+    print_to_stderr(full_text)
+    print_to_stderr(f"FINISHED PRINTING LOG FILE of {test} ({file_path})\n")
     os.remove(file_path)
 
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -945,7 +945,7 @@ def handle_log_file(
         for line in full_text.splitlines():
             if re.search("Running .* items in this shard:", line):
                 print_to_stderr(line.strip())
-        print_to_stderr()
+        print_to_stderr("")
         return
     # otherwise: print entire file and then remove it
     print_to_stderr(f"\nPRINTING LOG FILE of {test} ({file_path})")

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -924,13 +924,13 @@ def sanitize_file_name(file: str):
     return file.replace("\\", ".").replace("/", ".").replace(" ", "_")
 
 
-def handle_log_file(test: ShardedTest, file_path: str, failed: bool, was_rerun: bool) -> None:
-    verbose = "VERBOSE_LOGS=1" in os.environ.get("PR_BODY", "")
+def handle_log_file(
+    test: ShardedTest, file_path: str, failed: bool, was_rerun: bool
+) -> None:
     test = str(test)
-    if not failed and not was_rerun and not verbose:
-        # If not verbose + success + no file level retries, print only what
-        # tests ran, rename the log file so it doesn't get printed later, and do
-        # not remove logs.
+    if not failed and not was_rerun:
+        # If success + no file level retries, print only what tests ran, rename
+        # the log file so it doesn't get printed later, and do not remove logs.
         new_file = "test/test-reports/" + sanitize_file_name(
             f"{test}_{os.urandom(8).hex()}_.log"
         )

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -922,7 +922,7 @@ def run_doctests(test_module, test_directory, options):
 
 
 def sanitize_file_name(file: str):
-    return file.replace("\\", "-").replace("/", "-").replace(" ", "_")
+    return file.replace("\\", ".").replace("/", ".").replace(" ", "_")
 
 
 def print_log_file(test: ShardedTest, file_path: str, failed: bool) -> None:
@@ -940,7 +940,7 @@ def print_log_file(test: ShardedTest, file_path: str, failed: bool) -> None:
         )
         with open(REPO_ROOT / new_file, "rb") as f:
             for line in f.readlines():
-                if re.search("Running .* items in this shard:", line):
+                if re.search(b"Running .* items in this shard:", line):
                     print_to_stderr(line.strip())
         return
     # Test failure or verbose logs: print entire file and then remove it

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -562,7 +562,6 @@ class TestCommon(TestCase):
     @suppress_warnings
     @ops(op_db, allowed_dtypes=(torch.float32, torch.long, torch.complex64))
     def test_noncontiguous_samples(self, device, dtype, op):
-        self.assertEqual(1, 2)
         test_grad = dtype in op.supported_backward_dtypes(torch.device(device).type)
         sample_inputs = op.sample_inputs(device, dtype, requires_grad=test_grad)
         for sample_input in sample_inputs:

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -466,6 +466,7 @@ class TestCommon(TestCase):
     @ops(python_ref_db)
     @skipIfTorchInductor("Takes too long for inductor")
     def test_python_ref(self, device, dtype, op):
+        self.assertEqual(1, 2)
         # In this test, primTorch refs call into the refs namespace
         # For example, a ref with torch.foo in it will calls refs.foo instead
         # Direct calls to refs and prims are not affected
@@ -562,6 +563,7 @@ class TestCommon(TestCase):
     @suppress_warnings
     @ops(op_db, allowed_dtypes=(torch.float32, torch.long, torch.complex64))
     def test_noncontiguous_samples(self, device, dtype, op):
+        self.assertEqual(1, 2)
         test_grad = dtype in op.supported_backward_dtypes(torch.device(device).type)
         sample_inputs = op.sample_inputs(device, dtype, requires_grad=test_grad)
         for sample_input in sample_inputs:

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -466,7 +466,6 @@ class TestCommon(TestCase):
     @ops(python_ref_db)
     @skipIfTorchInductor("Takes too long for inductor")
     def test_python_ref(self, device, dtype, op):
-        self.assertEqual(1, 2)
         # In this test, primTorch refs call into the refs namespace
         # For example, a ref with torch.foo in it will calls refs.foo instead
         # Direct calls to refs and prims are not affected

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -719,19 +719,54 @@ def shell(command, cwd=None, env=None, stdout=None, stderr=None, timeout=None):
     return wait_for_process(p, timeout=timeout)
 
 
-def retry_shell(command, cwd=None, env=None, stdout=None, stderr=None, timeout=None, retries=1):
-    assert retries >= 0, f"Expecting non negative number for number of retries, got {retries}"
+def retry_shell(
+    command,
+    cwd=None,
+    env=None,
+    stdout=None,
+    stderr=None,
+    timeout=None,
+    retries=1,
+    was_rerun=False,
+) -> Tuple[int, bool]:
+    # Returns exicode + whether it was rerun
+    assert (
+        retries >= 0
+    ), f"Expecting non negative number for number of retries, got {retries}"
     try:
-        exit_code = shell(command, cwd=cwd, env=env, stdout=stdout, stderr=stderr, timeout=timeout)
+        exit_code = shell(
+            command, cwd=cwd, env=env, stdout=stdout, stderr=stderr, timeout=timeout
+        )
         if exit_code == 0 or retries == 0:
-            return exit_code
-        print(f"Got exit code {exit_code}, retrying (retries left={retries})", file=stdout, flush=True)
+            return exit_code, was_rerun
+        print(
+            f"Got exit code {exit_code}, retrying (retries left={retries})",
+            file=stdout,
+            flush=True,
+        )
     except subprocess.TimeoutExpired:
         if retries == 0:
-            print(f"Command took >{timeout // 60}min, returning 124", file=stdout, flush=True)
-            return 124
-        print(f"Command took >{timeout // 60}min, retrying (retries left={retries})", file=stdout, flush=True)
-    return retry_shell(command, cwd=cwd, env=env, stdout=stdout, stderr=stderr, timeout=timeout, retries=retries - 1)
+            print(
+                f"Command took >{timeout // 60}min, returning 124",
+                file=stdout,
+                flush=True,
+            )
+            return 124, was_rerun
+        print(
+            f"Command took >{timeout // 60}min, retrying (retries left={retries})",
+            file=stdout,
+            flush=True,
+        )
+    return retry_shell(
+        command,
+        cwd=cwd,
+        env=env,
+        stdout=stdout,
+        stderr=stderr,
+        timeout=timeout,
+        retries=retries - 1,
+        was_rerun=True,
+    )
 
 
 def discover_test_cases_recursively(suite_or_case):
@@ -889,7 +924,7 @@ def run_tests(argv=UNITTEST_ARGS):
 
             timeout = None if RERUN_DISABLED_TESTS else 15 * 60
 
-            exitcode = retry_shell(cmd, timeout=timeout, retries=0 if RERUN_DISABLED_TESTS else 1)
+            exitcode,_ = retry_shell(cmd, timeout=timeout, retries=0 if RERUN_DISABLED_TESTS else 1)
 
             if exitcode != 0:
                 # This is sort of hacky, but add on relevant env variables for distributed tests.

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -924,7 +924,7 @@ def run_tests(argv=UNITTEST_ARGS):
 
             timeout = None if RERUN_DISABLED_TESTS else 15 * 60
 
-            exitcode,_ = retry_shell(cmd, timeout=timeout, retries=0 if RERUN_DISABLED_TESTS else 1)
+            exitcode, _ = retry_shell(cmd, timeout=timeout, retries=0 if RERUN_DISABLED_TESTS else 1)
 
             if exitcode != 0:
                 # This is sort of hacky, but add on relevant env variables for distributed tests.


### PR DESCRIPTION
To reduce the amount of logs
* for successes, only print the part that says what tests ran and don't print the rest.  Zip the log into an artifact.  The line listing al the test names is really long, but if you view source of the raw logs, it will not wrap so it will only be one line.  The log classifier can also be configured to ignored this line. Gets rid of lines like `test_ops.py::TestCommonCPU::test_multiple_devices_round_cpu_int64 SKIPPED [0.0010s] (Only runs on cuda) [  9%]`
* for failures/reruns, print logs.  Do not zip.

Also
* change log artifact name 

Examples of various logs: 
https://hud.pytorch.org/pytorch/pytorch/commit/a074db0f7f27390ebacb4b5b198a990e2016b194 failures
https://hud.pytorch.org/pytorch/pytorch/commit/1b439e24c42b8fac4ff6e3c1c0b706baec2e319f failures


possibly controversial haha
should i include an option for always printing?