### PR TITLE
[core IR] Add a core decomposition for floor_divide

### DIFF
--- a/test/expect/HasDecompTest.test_aten_core_operators.expect
+++ b/test/expect/HasDecompTest.test_aten_core_operators.expect
@@ -220,8 +220,6 @@ aten::flip.out
 aten::floor
 aten::floor.out
 aten::floor_
-aten::floor_divide
-aten::floor_divide.out
 aten::floor_divide_.Tensor
 aten::fmax
 aten::fmax.out

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1797,6 +1797,7 @@ class TestRefsOpsInfo(TestCase):
         # duplicated in _decomp and _refs
         '_refs.nn.functional.group_norm',
         '_refs.nn.functional.mse_loss',
+        '_refs.floor_divide',
         '_refs.rsub',
         # duplicated as refs do not have decent support for advanced indexing
         '_refs.index_copy',

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -254,6 +254,7 @@ def core_aten_decompositions() -> Dict[torch._ops.OperatorBase, Callable]:
             aten.eye,
             aten.fill,
             aten.fill_,
+            aten.floor_divide,
             aten.frac,
             aten.frac_,
             aten._fused_moving_avg_obs_fq_helper,

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -4162,6 +4162,12 @@ def baddbmm(self, batch1, batch2, beta=1, alpha=1):
     return self + result
 
 
+@register_decomposition(aten.floor_divide)
+@out_wrapper()
+def floor_divide(self, other):
+    return torch.div(self, other, rounding_mode="floor")
+
+
 register_inplace(aten.addbmm_, aten.addbmm)
 register_inplace(aten.addmm_, aten.addmm)
 register_inplace(aten.addmv_, aten.addmv)

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -119,13 +119,6 @@ def full(size, fill_value, **kwargs):
     return NotImplemented
 
 
-# TorchInductor-only decomposition. It should not be taken to core.
-# See https://github.com/pytorch/torchdynamo/pull/1120
-@register_decomposition([aten.floor_divide.default])
-def floordiv(a, b):
-    return aten.div.Tensor_mode(a, b, rounding_mode="floor")
-
-
 # Not really sure how to put this into the main library.  PrimTorch wants
 # empty_permuted to go to the prim, and typically users don't really want
 # to decompose to empty_strided (but inductor is OK with it, because we are

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1000,6 +1000,7 @@ def _make_elementwise_binary_reference(
     supports_lhs_python_scalar=True,
     supports_rhs_python_scalar=True,
     supports_two_python_scalars=False,
+    should_register_decomposition=True,
 ) -> Callable:
     def inner(prim: Callable):
         nonlocal aten_op, name
@@ -1040,7 +1041,7 @@ def _make_elementwise_binary_reference(
         _ref.__name__ = name
         if aten_op is infer_aten_op:
             aten_op = utils.get_aten_op(prim, name)
-        if aten_op is not None:
+        if aten_op is not None and should_register_decomposition:
             register_decomposition(aten_op)(_ref)
 
         return _ref
@@ -1273,6 +1274,7 @@ def float_power(
 @_make_elementwise_binary_reference(
     type_promotion_kind=utils.ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
     supports_two_python_scalars=True,
+    should_register_decomposition=False,
 )
 def floor_divide(
     a: Union[TensorLikeType, NumberType], b: Union[TensorLikeType, NumberType]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110046

## Context

Introduce a core decomposition for `aten.floor_divide` into other `aten` ops, and add it to the core ATen decomposition table.

This replaces the decomposition of `floor_divide` that was used by Inductor. I noticed there was a note on that decomposition

```
# TorchInductor-only decomposition. It should not be taken to core.
# See https://github.com/pytorch/torchdynamo/pull/1120
```

but couldn't discern the reason why this is the case. cc: @lezcano 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov