### PR TITLE
Grouped query attention

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -14625,21 +14625,21 @@
     CUDA, NestedTensorCUDA: native_multi_head_attention_cuda
   autogen: _native_multi_head_attention.out
 
-- func: scaled_dot_product_attention(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool is_causal=False, *, float? scale=None) -> Tensor
+- func: scaled_dot_product_attention(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool is_causal=False, *, float? scale=None, int? num_kv_groups=None) -> Tensor
   python_module: nn
   variants: function
   autogen: scaled_dot_product_attention.out
   tags: nondeterministic_seeded
 
 # This aten function is kept so that we can test the choice function from Python
-- func: _fused_sdp_choice(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool is_causal=False, *, float? scale=None) -> int
+- func: _fused_sdp_choice(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool is_causal=False, *, float? scale=None, int? num_kv_groups=None) -> int
   dispatch:
     Meta: _fused_sdp_choice_meta
     CPU, NestedTensorCPU: _fused_sdp_choice_cpp
     CUDA, NestedTensorCUDA: _fused_sdp_choice_cuda
   tags: nondeterministic_seeded
 
-- func: _scaled_dot_product_attention_math(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool is_causal=False, Tensor? dropout_mask=None, *, float? scale=None) -> (Tensor, Tensor)
+- func: _scaled_dot_product_attention_math(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool is_causal=False, Tensor? dropout_mask=None, *, float? scale=None, int? num_kv_groups=None) -> (Tensor, Tensor)
   variants: function
   tags: nondeterministic_seeded
 

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -505,6 +505,19 @@ inline void validate_sdpa_input(
       "Scaled_dot_product_attention: Nested tensors for query / key are not supported "
       "when an explicit attn_mask is set");
   }
+  // GQA/MQA handling
+  const auto q_num_heads = query_.size(1);
+  const auto k_num_heads = key.size(1);
+  const auto v_num_heads = value.size(1);
+
+  bool all_equal = q_num_heads == k_num_heads && k_num_heads == v_num_heads;
+  bool key_divisible = q_num_heads % k_num_heads == 0;
+  bool value_divisible = q_num_heads % v_num_heads == 0;
+
+  TORCH_CHECK(all_equal || (key_divisible && value_divisible),
+              "query, key, and value must have the same number of heads, or "
+              "the number of heads in query must be divisible by the number of "
+              "heads in key and value for grouped query attention");
   return;
 }
 // This function is used to produce an attn_mask
@@ -606,6 +619,26 @@ int64_t handle_private_use(const Tensor& query_, const Tensor& key, const Tensor
   } catch(const ::c10::Error& e){
   }
   return choice_int;
+}
+
+std::tuple<at::Tensor, at::Tensor> pre_process_group_query_attention_input(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value) {
+  const auto q_num_heads = query.size(1);
+  const auto k_num_heads = key.size(1);
+  const auto v_num_heads = value.size(1);
+
+  bool all_equal = q_num_heads == k_num_heads && k_num_heads == v_num_heads;
+
+  if (all_equal){
+    return std::make_tuple(key, value);
+  }
+  auto repeat_key_shape = query.size(1) / key.size(1);
+  auto repeat_value_shape = query.size(1) / value.size(1);
+  at::Tensor key_repeated = key.repeat_interleave(repeat_key_shape, 1);
+  at::Tensor value_repeated = value.repeat_interleave(repeat_value_shape, 1);
+  return std::make_tuple(std::move(key_repeated), std::move(value_repeated));
 }
 
 } // namespace
@@ -729,7 +762,6 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math(
         "scaled_dot_product_attention: If inputs are nested tensors they must be contiguous");
   }
     auto attn_mask = attn_mask_;
-    // Naive, composite implementation defined here.
 
     // Scale q, k before matmul for stability see https://tinyurl.com/sudb9s96 for math
     bool is_negative_scaling = scale.has_value() && scale.value() < 0.0;
@@ -747,7 +779,10 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math(
         attn_mask = at::ones_symint({L, S}, query.options().dtype(at::kBool)).tril();
         attn_mask = convert_boolean_attn_mask(attn_mask, query.dtype());
     }
-    auto attn = at::matmul(query, key.transpose(-2, -1) * scaling_factor);
+    // MQA/GQA handling, HOW SHOULD WE HANDLE NESTED TENSORS?
+    auto [key_expanded, value_expanded] = pre_process_group_query_attention_input(query_, key, value);
+
+    auto attn = at::matmul(query, key_expanded.transpose(-2, -1) * scaling_factor);
     if (attn_mask.has_value()) {
       if (at::areAnyTensorSubclassLike({attn, *attn_mask})) {
         attn = attn.add(*attn_mask);
@@ -763,13 +798,13 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math(
         TORCH_WARN_ONCE("Dropout mask should only be used for testing purposes.");
         attn = attn.masked_fill(dropout_mask->logical_not(), 0.0);
         auto dropout_scaling = 1.0 / (1 - dropout_p);
-        return std::make_tuple(at::matmul(attn, value * dropout_scaling), attn);
+        return std::make_tuple(at::matmul(attn, value_expanded * dropout_scaling), attn);
       } else {
         attn = at::dropout(attn, dropout_p, true);
       }
     }
 
-    return std::make_tuple(at::matmul(attn, value), attn);
+    return std::make_tuple(at::matmul(attn, value_expanded), attn);
 }
 
 std::tuple<at::Tensor, at::Tensor>

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -423,7 +423,8 @@ std::tuple<Tensor, Tensor> native_multi_head_attention_cpu(
 }
 
 int64_t _fused_sdp_choice_cpp(const Tensor& query_, const Tensor& key, const Tensor& value,
-        const c10::optional<Tensor>& attn_mask_, double dropout_p, bool is_causal, c10::optional<double> scale){
+        const c10::optional<Tensor>& attn_mask_, double dropout_p, bool is_causal, c10::optional<double> scale,
+        c10::optional<int64_t> num_kv_groups){
   sdp::sdp_params kernel_params{query_, key, value, attn_mask_, dropout_p, is_causal};
   auto backend = sdp::select_sdp_backend_cpp(kernel_params);
   if (backend == sdp::SDPBackend::error) {
@@ -448,7 +449,8 @@ int64_t _fused_sdp_choice_meta(
     const c10::optional<Tensor>& attn_mask_,
     double dropout_p,
     bool is_causal,
-    c10::optional<double> scale) {
+    c10::optional<double> scale,
+    c10::optional<int64_t> num_kv_groups) {
   auto query_key_set = query_.key_set();
 #if defined(USE_ROCM)
   bool has_rocm = query_key_set.has(c10::DispatchKey::HIP);
@@ -467,7 +469,8 @@ int64_t _fused_sdp_choice_meta(
         attn_mask_,
         dropout_p,
         is_causal,
-        scale);
+        scale,
+        num_kv_groups);
     return choice_int;
   }
 #endif
@@ -679,7 +682,8 @@ Tensor scaled_dot_product_attention(
     const c10::optional<Tensor>& attn_mask_,
     double dropout_p,
     bool is_causal,
-    c10::optional<double> scale) {
+    c10::optional<double> scale,
+    c10::optional<int64_t> num_kv_groups) {
   validate_sdpa_input(query_, key, value, attn_mask_, dropout_p, is_causal, scale);
   int64_t choice_int = static_cast<int64_t>(sdp::SDPBackend::math);
   if (query_.device().type() == DeviceType::CUDA
@@ -753,7 +757,7 @@ Tensor scaled_dot_product_attention(
 std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math(
         const Tensor& query_, const Tensor& key, const Tensor& value,
         const c10::optional<Tensor>& attn_mask_, double dropout_p, bool is_causal,
-        const c10::optional<Tensor>& dropout_mask, c10::optional<double> scale) {
+        const c10::optional<Tensor>& dropout_mask, c10::optional<double> scale, c10::optional<int64_t> num_kv_groups) {
   C10_LOG_API_USAGE_ONCE("torch.sdpa.math_fallback");
   if (query_.is_nested() || key.is_nested() || value.is_nested()) {
     TORCH_CHECK(

--- a/aten/src/ATen/native/transformers/attention.h
+++ b/aten/src/ATen/native/transformers/attention.h
@@ -8,7 +8,7 @@ namespace at {
 namespace native {
 
 using fused_sdp_choice_fn = int64_t (*)(const Tensor& query_, const Tensor& key, const Tensor& value,
-        const c10::optional<Tensor>& attn_mask_, double dropout_p, bool is_causal, c10::optional<double> scale, 
+        const c10::optional<Tensor>& attn_mask_, double dropout_p, bool is_causal, c10::optional<double> scale,
         c10::optional<int64_t> num_kv_groups);
 
 DECLARE_DISPATCH(fused_sdp_choice_fn, _fused_sdp_choice_stub);

--- a/aten/src/ATen/native/transformers/attention.h
+++ b/aten/src/ATen/native/transformers/attention.h
@@ -2,14 +2,14 @@
 #include <ATen/core/Tensor.h>
 #include <c10/macros/Export.h>
 #include <ATen/native/DispatchStub.h>
-#include <ATen/native/transformers/attention.h>
 #include <c10/util/Optional.h>
 
 namespace at {
 namespace native {
 
 using fused_sdp_choice_fn = int64_t (*)(const Tensor& query_, const Tensor& key, const Tensor& value,
-        const c10::optional<Tensor>& attn_mask_, double dropout_p, bool is_causal, c10::optional<double> scale);
+        const c10::optional<Tensor>& attn_mask_, double dropout_p, bool is_causal, c10::optional<double> scale, 
+        c10::optional<int64_t> num_kv_groups);
 
 DECLARE_DISPATCH(fused_sdp_choice_fn, _fused_sdp_choice_stub);
 

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -817,8 +817,9 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> _scaled_dot_product_efficient_attenti
 }
 
 int64_t _fused_sdp_choice_cuda(const Tensor& query_, const Tensor& key, const Tensor& value,
-        const c10::optional<Tensor>& attn_mask_, double dropout_p, bool is_causal, c10::optional<double> scale){
-  sdp::sdp_params kernel_params{query_, key, value, attn_mask_, dropout_p, is_causal};
+        const c10::optional<Tensor>& attn_mask_, double dropout_p, bool is_causal, c10::optional<double> scale,
+        c10::optional<int64_t> num_kv_groups){
+  sdp::sdp_params kernel_params{query_, key, value, attn_mask_, dropout_p, is_causal, num_kv_groups};
   auto backend = select_sdp_backend(kernel_params);
   if (backend == sdp::SDPBackend::error) {
     TORCH_CHECK(

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -462,7 +462,7 @@ bool can_use_flash_attention(sdp_params const& params, bool debug) {
       check_runtime_disabled_flash,
       check_all_tensors_on_device,
       check_tensor_shapes,
-      check_batch_size_and_num_heads<true>, // supports_grouped_query_attention = true,
+      check_batch_size_and_num_heads_dense<true>, // supports_grouped_query_attention = true,
       check_for_attn_mask,
       check_head_dim_size_flash,
       check_flash_attention_hardware_support,
@@ -488,7 +488,7 @@ bool can_use_flash_attention(sdp_params const& params, bool debug) {
   }
   if (has_only_dense_inputs(params)) {
     constexpr auto dense_constraints = array_of<bool (*)(sdp_params const&, bool)>(
-        check_batch_size_and_num_heads_dense,
+        check_batch_size_and_num_heads_dense<true>, // supports_grouped_query_attention = true,
         check_nonzero_sequence_lengths_dense,
         check_last_dim_stride_equals_1_dense<true /*ignore_singleton_dim=*/>);
     for (auto& constraint : dense_constraints) {
@@ -537,7 +537,7 @@ bool can_use_mem_efficient_attention(sdp_params const& params, bool debug) {
   }
   if (has_only_dense_inputs(params)) {
     constexpr auto dense_constraints = array_of<bool (*)(sdp_params const&, bool)>(
-        check_batch_size_and_num_heads_dense,
+        check_batch_size_and_num_heads_dense<false>, // supports_grouped_query_attention = false,
         check_nonzero_sequence_lengths_dense,
         check_last_dim_stride_equals_1_dense<false /*ignore_singleton_dim=*/>);
     for (auto& constraint : dense_constraints) {

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -462,6 +462,7 @@ bool can_use_flash_attention(sdp_params const& params, bool debug) {
       check_runtime_disabled_flash,
       check_all_tensors_on_device,
       check_tensor_shapes,
+      check_batch_size_and_num_heads<true>, // supports_grouped_query_attention = true,
       check_for_attn_mask,
       check_head_dim_size_flash,
       check_flash_attention_hardware_support,

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.cpp
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.cpp
@@ -42,7 +42,7 @@ bool use_flash_attention_cpp(sdp_params const& params, bool debug) {
       check_nested_tensor,
       check_for_dropout,
       check_tensor_shapes,
-      check_batch_size_and_num_heads_dense,
+      check_batch_size_and_num_heads_dense<false>, // supports_grouped_query_attention = false,
       check_attn_mask_shape,
       check_head_dim_size_cpp,
       check_nonzero_sequence_lengths_dense,

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.h
@@ -342,7 +342,6 @@ inline bool check_safe_kv_broadcast(at::Tensor const& param, bool debug) {
   return true;
 }
 
-inline bool check_batch_size_and_num_heads_dense(sdp_params const& params, bool debug) {
 template <bool supports_gqa>
 inline bool check_grouped_query_attention(sdp_params const& params, bool debug) {
   const auto q_num_heads = params.query.sym_size(1);
@@ -395,7 +394,7 @@ inline bool check_grouped_query_attention(sdp_params const& params, bool debug) 
 }
 
 template <bool supports_gqa>
-inline bool check_batch_size_and_num_heads(sdp_params const& params, bool debug) {
+inline bool check_batch_size_and_num_heads_dense(sdp_params const& params, bool debug) {
   // This is expected to be called after check_tensor_shapes ensuring that the
   // size() calls won't error since the inputs are all 4 dimensional
 
@@ -466,13 +465,6 @@ inline bool check_batch_size_nested(sdp_params const& params, bool debug) {
         return false;
       }
     }
-
-inline bool check_nonzero_sequence_lengths(sdp_params const& params, bool debug) {
-  if (has_for_nested_inputs(params)){
-    // Currently we do not support any masking with NestedTensors
-    // This is checked in validate_sdpa_input so this filter func
-    // Should have no actually bearing on the kernel selection
-    return true;
   }
   return broadcastable_batch_size;
 }

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.h
@@ -47,6 +47,7 @@ struct sdp_params {
   c10::optional<at::Tensor> attn_mask;
   double dropout;
   bool is_causal;
+  c10::optional<int64_t> num_kv_groups;
 };
 
 SDPBackend select_sdp_backend_cpp(sdp_params const& kernel_params);

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.h
@@ -342,6 +342,59 @@ inline bool check_safe_kv_broadcast(at::Tensor const& param, bool debug) {
 }
 
 inline bool check_batch_size_and_num_heads_dense(sdp_params const& params, bool debug) {
+template <bool supports_gqa>
+inline bool check_grouped_query_attention(sdp_params const& params, bool debug) {
+  const auto q_num_heads = params.query.sym_size(1);
+  const auto k_num_heads = params.key.sym_size(1);
+  const auto v_num_heads = params.value.sym_size(1);
+  const bool same_kv_heads = k_num_heads == v_num_heads;
+  if (!same_kv_heads){
+    if (debug) {
+      TORCH_WARN(
+          "Both fused kernels require key and value to have the same num_heads but got: ",
+          "Key sizes(): ",
+          params.key.sizes(),
+          ", Value sizes(): ",
+          params.value.sizes(),
+          " instead.");
+    }
+    return false;
+  }
+  // Check if grouped query attention is supported and validate the number of
+  // heads
+  if (supports_gqa && q_num_heads % k_num_heads != 0) {
+    if (debug) {
+      TORCH_WARN(
+          "FlashAttentionV2 only supports grouped query attention, where the number of heads in key/value must divide number of heads in query.",
+          "Got input Key sizes(): ",
+          params.key.sizes(),
+          ", Value sizes(): ",
+          params.value.sizes(),
+          " instead.");
+    }
+    return false;
+  }
+  // If grouped query attention is not supported, ensure query and key have the
+  // same number of heads
+  else if (!supports_gqa && q_num_heads != k_num_heads) {
+    if (debug) {
+      TORCH_WARN(
+          "MemoryEfficient attention requires query, key and value to have the same num_heads but got: ",
+          "Query.sizes(): ",
+          params.query.sizes(),
+          ", Key sizes(): ",
+          params.key.sizes(),
+          ", Value sizes(): ",
+          params.value.sizes(),
+          " instead.");
+    }
+    return false;
+  }
+  return true;
+}
+
+template <bool supports_gqa>
+inline bool check_batch_size_and_num_heads(sdp_params const& params, bool debug) {
   // This is expected to be called after check_tensor_shapes ensuring that the
   // size() calls won't error since the inputs are all 4 dimensional
 
@@ -355,10 +408,7 @@ inline bool check_batch_size_and_num_heads_dense(sdp_params const& params, bool 
   auto q_num_heads = params.query.sym_size(1);
   auto k_num_heads = params.key.sym_size(1);
   auto v_num_heads = params.value.sym_size(1);
-  bool same_num_heads =
-      q_num_heads == k_num_heads && q_num_heads == v_num_heads;
-
-  if (!(same_batch_size && same_num_heads)) {
+  if (!(same_batch_size)){
     if (debug) {
       TORCH_WARN(
           "For dense inputs, both fused kernels require query, key and value to have the same batch_size and num_heads. ",
@@ -372,6 +422,8 @@ inline bool check_batch_size_and_num_heads_dense(sdp_params const& params, bool 
     }
     return false;
   }
+  return check_grouped_query_attention<supports_gqa>(params, debug);
+  // If all checks pass, return true
   return true;
 }
 
@@ -413,6 +465,13 @@ inline bool check_batch_size_nested(sdp_params const& params, bool debug) {
         return false;
       }
     }
+
+inline bool check_nonzero_sequence_lengths(sdp_params const& params, bool debug) {
+  if (has_for_nested_inputs(params)){
+    // Currently we do not support any masking with NestedTensors
+    // This is checked in validate_sdpa_input so this filter func
+    // Should have no actually bearing on the kernel selection
+    return true;
   }
   return broadcastable_batch_size;
 }

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3065,6 +3065,31 @@ class TestSDPACudaOnly(NNTestCase):
                          atol=grad_v_ref_atol, rtol=grad_v_ref_rtol)
 
     @skipIfRocm  # Nested Tensor
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support SDPA or pre-SM80 hardware")
+    def test_flash_gqa(self, device):
+        rand_query = torch.rand(8, 8, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
+        rand_key = torch.rand(8, 2, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
+        rand_value = torch.rand(8, 2, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
+
+        query_ref, key_ref, value_ref = self.query_key_value_clones(rand_query, rand_key, rand_value, dtype=rand_query.dtype)
+
+        with sdp_kernel(**backend_map[SDPBackend.FLASH_ATTENTION]):
+            out = F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
+
+        with sdp_kernel(**backend_map[SDPBackend.MATH]):
+            out_math = F.scaled_dot_product_attention(query_ref, key_ref, value_ref, dropout_p=0.0, is_causal=False)
+
+        upstream_grad = torch.rand_like(out, requires_grad=False)
+
+        out.backward(upstream_grad)
+        out_math.backward(upstream_grad)
+
+        torch.testing.assert_allclose(out, out_math, atol=1e-3, rtol=1e-2)
+        torch.testing.assert_allclose(rand_query.grad, query_ref.grad, atol=1e-3, rtol=1e-2)
+        torch.testing.assert_allclose(rand_key.grad, key_ref.grad, atol=1e-3, rtol=1e-2)
+        torch.testing.assert_allclose(rand_value.grad, value_ref.grad, atol=1e-3, rtol=1e-2)
+
+
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION, "Fused SDPA was not built for this system")
     @parametrize("fused_kernel", [SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION] if
                  PLATFORM_SUPPORTS_FLASH_ATTENTION else [SDPBackend.EFFICIENT_ATTENTION])

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1882,7 +1882,13 @@ Call this whenever a new thread is created in order to propagate values from
                        bool is_causal,
                        c10::optional<int64_t> num_kv_groups) {
         return sdp::sdp_params{
-            query, key, value, std::move(attn_mask), dropout, is_causal, num_kv_groups};
+            query,
+            key,
+            value,
+            std::move(attn_mask),
+            dropout,
+            is_causal,
+            num_kv_groups};
       }))
       .def_readonly("query", &sdp::sdp_params::query)
       .def_readonly("key", &sdp::sdp_params::key)

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1879,16 +1879,18 @@ Call this whenever a new thread is created in order to propagate values from
                        at::Tensor const& value,
                        c10::optional<at::Tensor> attn_mask,
                        double dropout,
-                       bool is_causal) {
+                       bool is_causal,
+                       c10::optional<int64_t> num_kv_groups) {
         return sdp::sdp_params{
-            query, key, value, std::move(attn_mask), dropout, is_causal};
+            query, key, value, std::move(attn_mask), dropout, is_causal, num_kv_groups};
       }))
       .def_readonly("query", &sdp::sdp_params::query)
       .def_readonly("key", &sdp::sdp_params::key)
       .def_readonly("value", &sdp::sdp_params::value)
       .def_readonly("attn_mask", &sdp::sdp_params::attn_mask)
       .def_readonly("dropout", &sdp::sdp_params::dropout)
-      .def_readonly("is_causal", &sdp::sdp_params::is_causal);
+      .def_readonly("is_causal", &sdp::sdp_params::is_causal)
+      .def_readonly("num_kv_groups", &sdp::sdp_params::num_kv_groups);
 
   py::enum_<sdp::SDPBackend>(
       py_module,


### PR DESCRIPTION
# Summary
Closed: #106730 in favor of this PR since the rebase would have been more difficult then just recreating.

There is still some edge cases I need to appropriately handle but this is how it could look.#109887 

## Design choices
This is currently implemented by looking at the "num heads" dimension, size(1) and determining if it can be repeat_interleaved to fill the query num_heads. 

Another option would be to pass in an explicit `groups` parameter to the top level SDPA and passing down. 