### PR TITLE
Add IWYU pragma for umbrella header

### DIFF
--- a/aten/src/ATen/ATen.h
+++ b/aten/src/ATen/ATen.h
@@ -4,6 +4,7 @@
 #error C++17 or later compatible compiler is required to use ATen.
 #endif
 
+// IWYU pragma: begin_exports
 #include <ATen/Context.h>
 #include <ATen/Device.h>
 #include <ATen/DeviceGuard.h>
@@ -35,3 +36,4 @@
 // TODO: try to remove this
 // There is some back story, see https://github.com/pytorch/pytorch/issues/48684
 #include <ATen/NativeFunctions.h>
+// IWYU pragma: end_exports


### PR DESCRIPTION
Summary:
Include cleaner tools would benefit from IWYU pragmas that define implementation headers and exported headers.   See for more information.
```
https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md
```

Test Plan: sandcastle_pass

Differential Revision: D49632855

