### PR TITLE
Fix clang-tidy errors misc-definitions-in-headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -46,5 +46,5 @@ readability-container-size-empty,
 '
 HeaderFilterRegex: '^(c10/(?!test)|torch/csrc/).*$'
 AnalyzeTemporaryDtors: false
-WarningsAsErrors: '*'
+WarningsAsErrors: '*,-facebook-hte-*'
 ...

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -99,6 +99,8 @@ struct CompiledAutogradThreadingDebugCheck {
 
 } // namespace
 
+std::atomic<uint64_t> GraphTask::graph_task_id{0};
+
 // Threads spawned by the engine are assigned a 'worker_device' specifying
 // what device they process work for. This variable is initialized at:
 // 1. thread creation time for CUDA, XLA device threads, as they are
@@ -642,7 +644,7 @@ void Engine::thread_on_exception(
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     std::shared_ptr<GraphTask> graph_task,
     const std::shared_ptr<Node>& fn,
-    std::exception& e) {
+    std::exception&) {
   graph_task->set_exception(std::current_exception(), fn);
 }
 

--- a/torch/csrc/autograd/graph_task.h
+++ b/torch/csrc/autograd/graph_task.h
@@ -15,10 +15,6 @@ struct ReadyQueue;
 static constexpr int NO_DEVICE = -2;
 static constexpr int CPU_DEVICE = -1;
 
-namespace {
-std::atomic<uint64_t> graph_task_id{0};
-}
-
 // GraphTask holds metadata needed for a single execution of backward()
 struct GraphTask : std::enable_shared_from_this<GraphTask> {
   std::atomic<uint64_t> outstanding_tasks_{0};
@@ -192,6 +188,7 @@ struct GraphTask : std::enable_shared_from_this<GraphTask> {
 
   utils::DelayWarningHandler warning_handler_;
 
+  static std::atomic<uint64_t> graph_task_id;
   uint64_t id_;
 
   GraphTask(

--- a/torch/csrc/jit/runtime/argument_spec.h
+++ b/torch/csrc/jit/runtime/argument_spec.h
@@ -167,9 +167,7 @@ struct ArgumentSpec {
   std::vector<bool> optional_presence;
 };
 
-namespace {
 static constexpr size_t ARG_SPEC_DEPTH_LIMIT = 128;
-}
 
 // ArgumentSpecCreator takes an initial graph and comes up with a set
 // of simple instructions to compute the ArgumentSpec given a set of


### PR DESCRIPTION
Summary: Issue in graph_task.h seeme to be very real because each translation unit that includes this header will have own copy of the variable so IDs might repeat.

Differential Revision: D49635426

