### PR TITLE
Fix linalg_vector_norm ONNX export with wrong output dtype

### DIFF
--- a/test/onnx/onnx_test_common.py
+++ b/test/onnx/onnx_test_common.py
@@ -161,6 +161,8 @@ class _TestONNXRuntime(pytorch_test_common.ExportTestCase):
         verbose=False,
     ):
         def _run_test(m, remained_onnx_input_idx, flatten=True, ignore_none=True):
+            print("m", type(m))
+
             return run_model_test(
                 self,
                 m,

--- a/test/onnx/test_op_consistency.py
+++ b/test/onnx/test_op_consistency.py
@@ -65,6 +65,7 @@ TESTED_OPS: frozenset[str] = frozenset(
         "flatten",
         "hstack",
         "logical_not",
+        "linalg.vector_norm",
         # "logit",  # TODO: enable after fixing https://github.com/pytorch/pytorch/issues/102211
         "nn.functional.scaled_dot_product_attention",
         "repeat",

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -6019,6 +6019,13 @@ def linalg_vector_norm(
                 ord_op,
             ),
         )
+
+        out_dtype = self.type().dtype()
+        if out_dtype == torch.float16:
+            result = g.op("Cast", result, to_i=_C_onnx.TensorProtoDataType.FLOAT16)
+        elif out_dtype == torch.bfloat16:
+            result = g.op("Cast", result, to_i=_C_onnx.TensorProtoDataType.BFLOAT16)
+
     return result
 
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -6020,11 +6020,9 @@ def linalg_vector_norm(
             ),
         )
 
-        out_dtype = self.type().dtype()
-        if out_dtype == torch.float16:
-            result = g.op("Cast", result, to_i=_C_onnx.TensorProtoDataType.FLOAT16)
-        elif out_dtype == torch.bfloat16:
-            result = g.op("Cast", result, to_i=_C_onnx.TensorProtoDataType.BFLOAT16)
+        out_dtype = _type_utils.JitScalarType.from_value(self)
+        if out_dtype != _type_utils.JitScalarType.FLOAT:
+            result = g.op("Cast", result, to_i=out_dtype.onnx_type())
 
     return result
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -6021,7 +6021,8 @@ def linalg_vector_norm(
         )
 
         out_dtype = _type_utils.JitScalarType.from_value(self)
-        if out_dtype != _type_utils.JitScalarType.FLOAT:
+        # Cast to bf16 requires opset>=13
+        if out_dtype not in [_type_utils.JitScalarType.FLOAT, _type_utils.JitScalarType.BFLOAT16]:
             result = g.op("Cast", result, to_i=out_dtype.onnx_type())
 
     return result


### PR DESCRIPTION
Up to now, the export of `aten::linalg_vector_norm` was wrongly giving as output dtype `torch.float32` although the input may be of other dtype. This does not match PyTorch behavior (e.g. see https://github.com/pytorch/pytorch/blob/23938640706214921c0c0c29b1ed4855a0536cd8/torch/_refs/linalg/__init__.py#L72 or https://github.com/pytorch/pytorch/blob/23938640706214921c0c0c29b1ed4855a0536cd8/aten/src/ATen/native/LinearAlgebra.cpp#L2713 - though the second one is quite unreadable to me, I would need to compile pytorch with `DEBUG=1` and use `TORCH_SHOW_DISPATCH_TRACE=1` to understand where the output is allocated).

Example of the issue:
```python
import torch
import torch.nn as nn

class MyModel(nn.Module):
    def __init__(self):
        super().__init__()
        self.lin = nn.Linear(10, 20)
        self.eps = 1e-12
        self.dim = -1
        
    def forward(self, x):
        denom = x.norm(2.0, self.dim, keepdim=True)
        print("denom", denom.dtype)
        return denom

model = MyModel()
model = model.eval().to(torch.float16).to("cuda")

inp = torch.rand(8, 10, device="cuda", dtype=torch.float16)

with torch.no_grad():
    res = model(inp)

    torch.onnx.export(model, (inp,), f="normalize.onnx")
```

giving out
![image](https://github.com/pytorch/pytorch/assets/9808326/44b3ea0b-e1d2-4f23-a963-e8bc8e7cb9df)
with the current implementation, while giving
![image](https://github.com/pytorch/pytorch/assets/9808326/dc737a45-bcc1-464e-bce0-d68728033a79)
in this proposed PR.

WDYT @justinchuby @BowenBao? This is an issue for the ONNX export in fp16 for some models, where ORT later raise at load time the error `FAIL : Load model from speecht5_onnx/decoder_model.onnx failed:Type Error: Type parameter (T) of Optype (MatMul) bound to different types (tensor(float) and tensor(float16)` due to this bug.