### PR TITLE
[inductor] support _scaled_dot_product_flash_attention fallback

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -551,14 +551,49 @@ class AOTInductorTestsTemplate:
             constraints=constraints,
         )
 
+    # scaled_dot_product_flash_attention
+    def test_sdpa(self):
+        class Repro(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
 
-class AOTInductorTestABICompatibile(TestCase):
+            def forward(self, q, k, v):
+                return torch.nn.functional.scaled_dot_product_attention(q, k, v)[0]
+
+        example_inputs = (
+            torch.randn(1, 48, 64, 64, dtype=torch.bfloat16, device="cuda"),
+            torch.randn(1, 48, 64, 64, dtype=torch.bfloat16, device="cuda"),
+            torch.randn(1, 48, 64, 64, dtype=torch.bfloat16, device="cuda"),
+        )
+        self.check_model(Repro(), example_inputs)
+
+    def test_sdpa_2(self):
+        class Repro(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, q, k, v, x):
+                t = torch.nn.functional.scaled_dot_product_attention(
+                    q, k, v, is_causal=True
+                )[0]
+                return x + t
+
+        example_inputs = (
+            torch.randn(1, 48, 64, 64, dtype=torch.bfloat16, device="cuda"),
+            torch.randn(1, 48, 64, 64, dtype=torch.bfloat16, device="cuda"),
+            torch.randn(1, 48, 64, 64, dtype=torch.bfloat16, device="cuda"),
+            torch.randn(1, 48, 64, 64, dtype=torch.bfloat16, device="cuda"),
+        )
+        self.check_model(Repro(), example_inputs)
+
+
+class AOTInductorTestABICompatible(TestCase):
     abi_compatible = True
     check_model = check_model
     check_model_with_multiple_inputs = check_model_with_multiple_inputs
 
 
-copy_tests(AOTInductorTestsTemplate, AOTInductorTestABICompatibile, "abi_compatible")
+copy_tests(AOTInductorTestsTemplate, AOTInductorTestABICompatible, "abi_compatible")
 
 
 class AOTInductorTestNonABICompatible(TestCase):

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -152,6 +152,25 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_create_tensor_from_blob(
     AtenTensorHandle* ret // returns new reference
 );
 
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch__scaled_dot_product_flash_attention(
+    AtenTensorHandle query,
+    AtenTensorHandle key,
+    AtenTensorHandle value,
+    double dropout_p,
+    bool is_causal,
+    bool return_debug_mask,
+    double scale,
+    AtenTensorHandle* ret0, // returns new reference
+    AtenTensorHandle* ret1, // returns new reference
+    AtenTensorHandle* ret2, // returns new reference
+    AtenTensorHandle* ret3, // returns new reference
+    int64_t* ret4,
+    int64_t* ret5,
+    AtenTensorHandle* ret6, // returns new reference
+    AtenTensorHandle* ret7, // returns new reference
+    AtenTensorHandle* ret8 // returns new reference
+);
+
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_tensor_copy_(AtenTensorHandle src, AtenTensorHandle dst);
 

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -16,6 +16,7 @@
 #else
 
 #include <ATen/ops/_addmm_activation.h>
+#include <ATen/ops/_scaled_dot_product_flash_attention.h>
 #include <ATen/ops/addmm.h>
 #include <ATen/ops/as_strided.h>
 #include <ATen/ops/bmm.h>
@@ -179,6 +180,62 @@ AOTITorchError aoti_torch_create_tensor_from_blob(
                                                 .options(options)
                                                 .make_tensor());
     *ret_new_tensor = tensor_pointer_to_tensor_handle(new_tensor);
+  });
+}
+
+AOTITorchError aoti_torch__scaled_dot_product_flash_attention(
+    AtenTensorHandle query,
+    AtenTensorHandle key,
+    AtenTensorHandle value,
+    double dropout_p,
+    bool is_causal,
+    bool return_debug_mask,
+    double scale,
+    AtenTensorHandle* ret0, // returns new reference
+    AtenTensorHandle* ret1, // returns new reference
+    AtenTensorHandle* ret2, // returns new reference
+    AtenTensorHandle* ret3, // returns new reference
+    int64_t* ret4,
+    int64_t* ret5,
+    AtenTensorHandle* ret6, // returns new reference
+    AtenTensorHandle* ret7, // returns new reference
+    AtenTensorHandle* ret8 // returns new reference
+) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    at::Tensor* query_tensor = tensor_handle_to_tensor_pointer(query);
+    at::Tensor* key_tensor = tensor_handle_to_tensor_pointer(key);
+    at::Tensor* value_tensor = tensor_handle_to_tensor_pointer(value);
+    auto [r0, r1, r2, r3, r4, r5, r6, r7, r8] =
+        at::_scaled_dot_product_flash_attention(
+            *query_tensor,
+            *key_tensor,
+            *value_tensor,
+            dropout_p,
+            is_causal,
+            return_debug_mask,
+            scale);
+
+    at::Tensor* ret0_tensor = new at::Tensor(std::move(r0));
+    *ret0 = tensor_pointer_to_tensor_handle(ret0_tensor);
+    at::Tensor* ret1_tensor = new at::Tensor(std::move(r1));
+    *ret1 = tensor_pointer_to_tensor_handle(ret1_tensor);
+    // ret2 and ret3 may be null
+    if (ret2) {
+      at::Tensor* ret2_tensor = new at::Tensor(std::move(r2));
+      *ret2 = tensor_pointer_to_tensor_handle(ret2_tensor);
+    }
+    if (ret3) {
+      at::Tensor* ret3_tensor = new at::Tensor(std::move(r3));
+      *ret3 = tensor_pointer_to_tensor_handle(ret3_tensor);
+    }
+    *ret4 = r4;
+    *ret5 = r5;
+    at::Tensor* ret6_tensor = new at::Tensor(std::move(r6));
+    *ret6 = tensor_pointer_to_tensor_handle(ret6_tensor);
+    at::Tensor* ret7_tensor = new at::Tensor(std::move(r7));
+    *ret7 = tensor_pointer_to_tensor_handle(ret7_tensor);
+    at::Tensor* ret8_tensor = new at::Tensor(std::move(r8));
+    *ret8 = tensor_pointer_to_tensor_handle(ret8_tensor);
   });
 }
 


### PR DESCRIPTION
Summary:
This PR supports _scaled_dot_product_flash_attention fallback kernel.
Note that in the abi_compatible mode, we retrieve outputs by passing
output argument pointers rather than relying on std::get.

It also fixes an issue related to dynamic shapes, where we wrongfully
query undefined dynamic symbols.

Test Plan: ci

Reviewed By: frank-wei

Differential Revision: D49620191




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @kadeng @muchulee8 @aakhundov @ColinPeppler