### PR TITLE
Add torch.ops.import_module

### DIFF
--- a/test/custom_operator/test_custom_ops.py
+++ b/test/custom_operator/test_custom_ops.py
@@ -1,6 +1,5 @@
 # Owner(s): ["module: unknown"]
 
-import importlib
 import os.path
 import sys
 import tempfile
@@ -28,7 +27,7 @@ class TestCustomOperators(TestCase):
         with self.assertRaises(torch._subclasses.fake_tensor.UnsupportedOperatorException):
             gm = make_fx(torch.ops.custom.nonzero.default, tracing_mode="symbolic")(x)
 
-        importlib.import_module("my_custom_ops")
+        torch.ops.import_module("my_custom_ops")
         gm = make_fx(torch.ops.custom.nonzero.default, tracing_mode="symbolic")(x)
         self.assertExpectedInline("""\
 def forward(self, arg0_1):
@@ -41,7 +40,7 @@ def forward(self, arg0_1):
         self.assertNotIn("my_custom_ops2", sys.modules.keys())
         with self.assertRaisesRegex(NotImplementedError, r"import the 'my_custom_ops2'"):
             y = torch.ops.custom.sin.default(x)
-        importlib.import_module("my_custom_ops2")
+        torch.ops.import_module("my_custom_ops2")
         y = torch.ops.custom.sin.default(x)
 
     def test_calling_custom_op_string(self):

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -1,5 +1,6 @@
 import contextlib
 import ctypes
+import importlib
 import inspect
 import sys
 import types
@@ -872,6 +873,25 @@ class _Ops(types.ModuleType):
 
     def __iter__(self):
         return iter(self._dir)
+
+    def import_module(self, module):
+        """
+        Imports a Python module that has torch.library registrations.
+
+        Generally, to extend PyTorch with custom operators, a user will
+        create a Python module whose import triggers registration of
+        the custom operators via a torch.ops.load_library call or a call
+        to one or more torch.library.* APIs.
+
+        It is unexpected for Python modules to have side effects, so some
+        linters and formatters will complain. Use this API to import Python
+        modules that contain these torch.library side effects.
+
+        Args:
+            module (str): The name of the Python module to import
+
+        """
+        importlib.import_module(module)
 
     def load_library(self, path):
         """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110090

Generally, to extend PyTorch with custom operators, a user will
create a Python module whose import triggers registration of
the custom operators via a torch.ops.load_library call or a call
to one or more torch.library.* APIs.

It is unexpected for Python modules to have side effects, so some
linters and formatters will complain. Use torch.ops.import_module to
import the module without a linter or formatter complaining.

NB: A more robust API would actually check if a custom op was registered
or modified, but this is technically challenging to do. In the future we
can add a warning if a custom op wasn't registered or modified.

Test Plan:
- existing tests