### PR TITLE
[core IR] Add a core decomposition for aten.all

### DIFF
--- a/test/expect/HasDecompTest.test_aten_core_operators.expect
+++ b/test/expect/HasDecompTest.test_aten_core_operators.expect
@@ -42,10 +42,6 @@ aten::addmv
 aten::addmv.out
 aten::addmv_
 aten::alias
-aten::all
-aten::all.all_out
-aten::all.dim
-aten::all.out
 aten::amax
 aten::amax.out
 aten::amin

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -259,6 +259,7 @@ def core_aten_decompositions() -> Dict[torch._ops.OperatorBase, Callable]:
             aten.addcmul_,
             aten.addr,
             aten.affine_grid_generator,
+            aten.all,
             aten.aminmax,
             aten.arange.default,
             aten.arange.start,

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -181,16 +181,6 @@ def round_dec(x, decimals=0):
     return aten.round(x * ten_pow_decimals) * (1.0 / ten_pow_decimals)
 
 
-@register_decomposition([aten.all.default])
-def all(input):
-    return torch.logical_not(torch.any(torch.logical_not(input)))
-
-
-@register_decomposition([aten.all.dim])
-def all_dim(input, dim, keepdim=False):
-    return torch.logical_not(torch.any(torch.logical_not(input), dim, keepdim))
-
-
 @register_decomposition([aten.bmm])
 def bmm(self, batch2):
     if self.device == "cpu":

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -2224,20 +2224,20 @@ py_all = all
 @out_wrapper()
 def all(
     a: TensorLikeType,
-    dim: Optional[DimsType] = None,
+    dim: Optional[int] = None,
     keepdim: bool = False,
 ) -> TensorLikeType:
-    # Computes nelem
-    if isinstance(dim, Dim):
-        dim = (dim,)  # type: ignore[assignment]
+    # torch.any and torch.all both do not currently support torch.any(x, keepdim=True), thus the dim=None
+    # case must be handled separately.
+    if dim is None:
+        result = torch.logical_not(torch.any(torch.logical_not(a)))
+    else:
+        result = torch.logical_not(
+            torch.any(torch.logical_not(a), dim, keepdim=keepdim)
+        )
 
-    a_ = _maybe_convert_to_dtype(a, torch.bool)
-    # avoid comparison with symbolic number of elements to make this op symint friendly
-    result = eq(sum(logical_not(a_), dim=dim, keepdim=keepdim), 0)
-
-    # Preserves uint8 -- probably a legacy mask thing
-    if a.dtype is torch.uint8:
-        return prims.convert_element_type(result, torch.uint8)
+    if a.dtype == torch.uint8:
+        result = result.to(dtype=torch.uint8)
 
     return result
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -2230,6 +2230,7 @@ def all(
     # torch.any and torch.all both do not currently support torch.any(x, keepdim=True), thus the dim=None
     # case must be handled separately.
     if dim is None:
+        assert not keepdim
         result = torch.logical_not(torch.any(torch.logical_not(a)))
     else:
         result = torch.logical_not(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -21110,8 +21110,12 @@ python_ref_db = [
     ReductionPythonRefInfo(
         "_refs.all",
         torch_opinfo_name="all",
-        supports_multiple_dims=True,
+        supports_multiple_dims=False,
         skips=(
+            # FIXME: does not support passing keepdim without dim
+            DecorateInfo(unittest.expectedFailure, 'TestReductions', 'test_dim_default_keepdim'),
+            # FIXME: does not support dim=None
+            DecorateInfo(unittest.expectedFailure, 'TestReductions', 'test_dim_none_keepdim'),
             # FIXME: uint8 input returns uint8 instead of bool
             DecorateInfo(
                 unittest.expectedFailure, 'TestReductions', 'test_result_dtype',


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110093

## Context

Change the ref implementation of `aten.all` to only use other `torch` operators such that we can use it for the core ATen decomposition table. This will replace the decomposition for `aten.all` that was used specifically by Inductor.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler