### PR TITLE
Revert D49640259: Revert D49615962: [optests] Test names in failure dicts should be prefixed with test class

### DIFF
--- a/test/minioptest_failures_dict.json
+++ b/test/minioptest_failures_dict.json
@@ -4,38 +4,38 @@
   "data": {
     "aten::mm": {},
     "aten::nonzero": {
-      "test_aot_dispatch_static__test_nonzero": {
+      "MiniOpTest.test_aot_dispatch_static__test_nonzero": {
         "comment": "",
         "status": "xfail"
       }
     },
     "aten::sin_": {},
     "mini_op_test::delayed_error": {
-      "test_aot_dispatch_dynamic__test_delayed_error": {
+      "MiniOpTest.test_aot_dispatch_dynamic__test_delayed_error": {
         "comment": "",
         "status": "xfail"
       },
-      "test_aot_dispatch_static__test_delayed_error": {
+      "MiniOpTest.test_aot_dispatch_static__test_delayed_error": {
         "comment": "",
         "status": "xfail"
       }
     },
     "mini_op_test::incorrect_schema": {
-      "test_schema__test_incorrect_schema": {
+      "MiniOpTest.test_schema__test_incorrect_schema": {
         "comment": "",
         "status": "xfail"
       }
     },
     "mini_op_test::no_abstract": {
-      "test_aot_dispatch_dynamic__test_no_abstract": {
+      "MiniOpTest.test_aot_dispatch_dynamic__test_no_abstract": {
         "comment": "",
         "status": "xfail"
       },
-      "test_aot_dispatch_static__test_no_abstract": {
+      "MiniOpTest.test_aot_dispatch_static__test_no_abstract": {
         "comment": "testing a skip just for the fun of it",
         "status": "skip"
       },
-      "test_faketensor__test_no_abstract": {
+      "MiniOpTest.test_faketensor__test_no_abstract": {
         "comment": "",
         "status": "xfail"
       }

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -1883,7 +1883,7 @@ opcheck(op, args, kwargs, test_utils="test_schema")
 
         failures = {
             "mini_op_test::incorrect_schema": {
-                "test_aot_dispatch_static__test_delayed_error": {
+                "MiniOpTest.test_aot_dispatch_static__test_delayed_error": {
                     "comment": "",
                     "status": "success",
                 }
@@ -1896,7 +1896,7 @@ opcheck(op, args, kwargs, test_utils="test_schema")
 
         failures = {
             "mini_op_test::incorrect_schema": {
-                "test_aot_dispatch__test_delayed_error": {
+                "MiniOpTest.test_aot_dispatch__test_delayed_error": {
                     "comment": "",
                     "status": "xfail",
                 },
@@ -1909,7 +1909,7 @@ opcheck(op, args, kwargs, test_utils="test_schema")
 
         failures = {
             "mini_op_test::incorrect_schema": {
-                "test_aot_dispatch_static__test_delayed_error_nopenopenope": {
+                "MiniOpTest.test_aot_dispatch_static__test_delayed_error_nopenopenope": {
                     "comment": "",
                     "status": "xfail",
                 },

--- a/torch/testing/_internal/optests/generate_tests.py
+++ b/torch/testing/_internal/optests/generate_tests.py
@@ -170,7 +170,7 @@ def generate_opcheck_tests(
                 prefix,
                 tester,
                 failures_dict,
-                new_method_name,
+                f"{testcase.__name__}.{new_method_name}",
                 failures_dict_path,
             ):
                 result = method(*args, **kwargs)
@@ -293,20 +293,23 @@ def validate_failures_dict_structure(
                 raise RuntimeError(
                     f"In failures_dict, got status={test_option} but it needs to be in {TEST_OPTIONS}"
                 )
-            if not any(test_name.startswith(test) for test in test_utils):
+            test_class, actual_test_name = test_name.split(".")
+            if not any(actual_test_name.startswith(test) for test in test_utils):
                 raise RuntimeError(
                     f"In failures_dict, test name '{test_name}' should begin with one of {test_utils}"
                 )
             for test in test_utils:
-                if not test_name.startswith(test):
+                if not actual_test_name.startswith(test):
                     continue
-                base_test_name = test_name[len(test) + 2 :]
-                if hasattr(testcase, base_test_name):
+                base_test_name = actual_test_name[len(test) + 2 :]
+                if testcase.__name__ == test_class and hasattr(
+                    testcase, base_test_name
+                ):
                     continue
                 raise RuntimeError(
                     f"In failures dict, got test name '{test_name}'. We parsed this as "
                     f"running test '{test}' on '{base_test_name}', but "
-                    f"{base_test_name} does not exist on the TestCase. "
+                    f"{base_test_name} does not exist on the TestCase '{testcase.__name__}]. "
                     f"Maybe you need to change the test name?"
                 )
 


### PR DESCRIPTION
Summary: Revert D49640259: Revert D49615962: [optests] Test names in failure dicts should

Test Plan: revert-hammer

Differential Revision: D49645397


