### PR TITLE
Avoid passing generator to parametrize

### DIFF
--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -1328,7 +1328,7 @@ class TestMeta(TestCase):
         assertEqualShapes(out_kwargs["out2"], expected_shapes[2])
 
     @onlyCPU
-    @parametrize("output_mask", itertools.product([True, False], [True, False], [True, False]))
+    @parametrize("output_mask", list(itertools.product([True, False], [True, False], [True, False])))
     def test_layer_norm_backward(self, output_mask):
         from torch.testing._internal.common_methods_invocations import sample_inputs_layer_norm
 
@@ -1361,7 +1361,7 @@ class TestMeta(TestCase):
                                                  args, output_mask, expected_shapes)
 
     @onlyCPU
-    @parametrize("output_mask", itertools.product([True, False], [True, False], [True, False]))
+    @parametrize("output_mask", list(itertools.product([True, False], [True, False], [True, False])))
     def test_group_norm_backward(self, output_mask):
         from torch.testing._internal.common_methods_invocations import sample_inputs_group_norm
 
@@ -1392,7 +1392,7 @@ class TestMeta(TestCase):
                                                  args, output_mask, expected_shapes)
 
     @onlyCPU
-    @parametrize("output_mask", itertools.product([True], [True, False], [True, False]))
+    @parametrize("output_mask", list(itertools.product([True], [True, False], [True, False])))
     def test_batch_norm_backward(self, output_mask):
         from torch.testing._internal.common_methods_invocations import sample_inputs_batch_norm
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110104

Fixes

```
ValueError: <function TestMeta.test_layer_norm_backward at 0x7f555f56e440>: An empty arg_values was passed to @parametrize. Note that this may result from reuse of a generator.
```

Signed-off-by: Edward Z. Yang <ezyang@meta.com>