### PR TITLE
[aotinductor] Rename if name is prefixed with integer

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1,6 +1,4 @@
 # Owner(s): ["module: inductor"]
-import copy
-import sys
 import unittest
 
 import torch
@@ -94,7 +92,6 @@ class AOTInductorModelRunner:
     ):
         if constraints is None:
             constraints = []
-        example_outputs = copy.deepcopy(example_outputs)
         optimized, exported, output_tensors, output_spec = AOTInductorModelRunner.load(
             model, example_inputs, example_outputs, options, constraints=constraints
         )
@@ -288,6 +285,18 @@ class AOTInductorTestsTemplate:
                 "max_autotune_gemm_backends": "TRITON",
             },
         )
+
+    def test_seq(self):
+        layernorm = torch.nn.LayerNorm(10)
+        net = torch.nn.Sequential(
+            layernorm,
+            torch.nn.ReLU(),
+            layernorm,
+            torch.nn.ReLU(),
+        )
+
+        example_inputs = (torch.randn(10),)
+        self.check_model(net.eval(), example_inputs)
 
     def test_addmm(self):
         class Model(torch.nn.Module):

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1,4 +1,5 @@
 # Owner(s): ["module: inductor"]
+import sys
 import unittest
 
 import torch

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -526,6 +526,8 @@ class GraphLowering(torch.fx.Interpreter):
 
             if name is None:
                 name = f"constant{len(self.constants)}"
+            if name[0].isdigit():
+                name = f"constant_{name}"
             self.constants[name] = data
             self.constant_reprs[name] = hashlib.sha256(
                 repr(data).encode("utf-8")


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/109894.
Since in c++ we cannot have variables that start with an integer, we can do some additional handling in inductor to not produce constant tensors with names starting with integers.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler