### PR TITLE
[MPS] Fix output stride holistically when input isn't contiguous

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -317,6 +317,11 @@ MPSGraphTensor* log1p(MPSGraph* mpsGraph, MPSGraphTensor* inputTensor);
 size_t compute_storage_numel_distance(const at::Tensor& t);
 
 /**
+ * Set contiguous strides to given tensor in-place.
+ */
+void restride_contiguous_(const at::Tensor& t);
+
+/**
  * Checks whether tensor is mapped to a contiguous area in the storage.
  */
 inline bool is_dense_in_storage(const at::Tensor& t) {

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -3,6 +3,7 @@
 #include <ATen/mps/MPSAllocatorInterface.h>
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <c10/util/strides.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -40,6 +41,13 @@ size_t compute_storage_numel_distance(const at::Tensor& t) {
     rc += (t.size(i) - 1) * t.stride(i);
   }
   return rc;
+}
+
+/**
+ * Set contiguous strides to given tensor in-place.
+ */
+void restride_contiguous_(const at::Tensor& t) {
+  t.as_strided_(t.sizes(), c10::contiguous_strides(t.sizes()));
 }
 
 void runMPSGraph(MPSStream* mpsStream, MPSGraph* mpsGraph, NSDictionary* feeds, NSDictionary* results) {

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -822,6 +822,7 @@ Tensor& masked_fill__mps(Tensor& self, const Tensor& mask, const Scalar& value) 
     runMPSGraph(stream, cachedGraph->graph(), feeds, results);
   }
   namedinference::propagate_names_if_nonempty(self, maybe_outnames);
+  restride_contiguous_(self);
   return self;
 }
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2018,7 +2018,7 @@ class TestMPS(TestCaseMPS):
             self.assertEqual(dst.to("cpu"), dst2, atol=0, rtol=0)
 
             # test non-contiguous case
-            dst = ((torch.randn(num_dest, num_dest, num_dest) * 10).to(dtype)).permute((2, 0, 1))
+            dst = ((torch.randn(num_dest, num_dest, num_dest, device=device) * 10).to(dtype)).permute((2, 0, 1))
             dst2 = dst.contiguous()
             if dtype.is_complex:
                 mask = dst.abs() > 0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110120
* #109584
* #109574
* #109557

This is a long lasting bug, related issues: https://github.com/pytorch/pytorch/issues/107694, https://github.com/pytorch/pytorch/issues/94396 (and more).

In general, we want to gather cached contiguous input tensors so that we don't need to make non-contiguous input tensors contiguous before the mps graph is run, since making tensors contiguous is an inefficient operation. However, when the output has been pre-set a non-contiguous stride, which usually happens when the kernel is structured or in-place, the result becomes incorrect because the gathered input tensors are contiguous, thereby producing a contiguous output.

Therefore, this PR makes output tensor's stride contiguous when cached input tensors are gathered.

This is a POC PR which only applies the fix to `clamp` & `masked_fill_`. If it is feasible, we could think about how to apply it to every MPS Graph kernel.