### PR TITLE
[FSDP] fix: fix for fsdp zero2 validation error

### DIFF
--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -195,6 +195,12 @@ class TestFSDPMiscMultiProcess(FSDPTest):
             for _ in range(5):
                 loss = model(x, y)
 
+        model.train()
+        for _ in range(5):
+            loss = model(x, y)
+            loss = loss.sum()
+            loss.backward()
+
     @skip_if_lt_x_gpu(2)
     @parametrize("use_second_layer", [True, False])
     @parametrize("sharding_strategy", [ShardingStrategy.NO_SHARD, None])

--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -189,7 +189,7 @@ class TestFSDPMiscMultiProcess(FSDPTest):
             model1,
         )
         x = torch.randn(8, 1, 28, 28, device='cuda').requires_grad_()
-        y = torch.randint(low=0,high=9,size=(8,), device='cuda')
+        y = torch.randint(low=0, high=9, size=(8,), device="cuda")
         x1 = x.clone().detach().requires_grad_()
         y1 = y.clone().detach()
         seed = 20231010

--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -188,7 +188,7 @@ class TestFSDPMiscMultiProcess(FSDPTest):
         ddp_model = torch.nn.parallel.DistributedDataParallel(
             model1,
         )
-        x = torch.randn(8, 1, 28, 28, device='cuda').requires_grad_()
+        x = torch.randn(8, 1, 28, 28, device="cuda").requires_grad_()
         y = torch.randint(low=0, high=9, size=(8,), device="cuda")
         x1 = x.clone().detach().requires_grad_()
         y1 = y.clone().detach()

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -599,6 +599,7 @@ def _root_pre_forward(
                     handles.append(fsdp_state._handle)
             for handle in handles:
                 handle._needs_pre_forward_unshard = True
+                handle._prefetched = False
         _wait_for_computation_stream(
             state._device_handle.current_stream(),
             state._unshard_stream,


### PR DESCRIPTION
# Problem
When sharding_strategy is set to SHARD_GRAD_OP and forward_prefetch is turned on, the validation after the train has an incorrect weight shape.
<img width="1508" alt="image" src="https://github.com/pytorch/pytorch/assets/41232043/57a9c3bb-cb5c-46df-ac26-922740686f9e">

# Analyze
When using `SHARD_GRAD_OP`, the `free_unsharded_flat_param` in `_post_forward_reshard` is often False, so it does not set the handle's `_prefetched` flag to False after the forward.

The normal train phase sets this flag to False in the `_post_backward_final_callback`, and the validation phase doesn't execute the hook, so after the first iter of the validation is done, the flag of the handle of the prefetched will remain True.

This will cause the handle to skip the `_unshard` in the next `_pre_forward_unshard`, and the `_prefetch_handle` will not do a prefetch, which will result in an incorrect weight shape.