### PR TITLE
Updating documentation for `PolynomialLR`

### DIFF
--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -716,7 +716,7 @@ class PolynomialLR(LRScheduler):
     Args:
         optimizer (Optimizer): Wrapped optimizer.
         total_iters (int): The number of steps that the scheduler decays the learning rate. Default: 5.
-        power (int): The power of the polynomial. Default: 1.0.
+        power (float): The power of the polynomial. Default: 1.0.
         verbose (bool): If ``True``, prints a message to stdout for
             each update. Default: ``False``.
 


### PR DESCRIPTION
Docstring mentions the power parameter is `int`, when it should have been `float`.