### PR TITLE
Fix inductor CI (by updating graph break count)

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_training.csv
@@ -50,5 +50,5 @@ timm_vision_transformer_large,pass_due_to_skip,0
 timm_vovnet,pass,8
 tts_angular,pass,10
 vgg16,pass,8
-vision_maskrcnn,fail_accuracy,42
+vision_maskrcnn,fail_accuracy,39
 yolov3,pass,10


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110160

There was a vision hash update which led to fewer graph breaks. This
seems expected to me (because the hash update included
https://github.com/pytorch/vision/pull/7944 and nms is used in maskrcnn).

Test Plan:
- wait for ci

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng