### PR TITLE
Fix for PyTorch mobile flatbuffer loader out of bounds reads

### DIFF
--- a/torch/csrc/jit/mobile/flatbuffer_loader.cpp
+++ b/torch/csrc/jit/mobile/flatbuffer_loader.cpp
@@ -302,7 +302,7 @@ mobile::Module FlatbufferLoader::parseModule(
   storage_loaded_.resize(module->storage_data_size(), false);
 
   mobile_ivalue_size_ = module_->mobile_ivalue_size();
-  if (mobile_ivalue_size_ == 0) {
+  if (mobile_ivalue_size_ == 0 || mobile_ivalue_size_ > ivalues->size()) {
     mobile_ivalue_size_ = ivalues->size();
   }
 


### PR DESCRIPTION
Summary:
The mobile_ivalue_size field in the mobile_bytecode flatbuffer schema can be larger than the ivalues vector. This introduces potential for memory corruption when parsing the mobile_bytecode Module.

This diff fixes the issue by ensuring that  mobile_ivalue_size is less than the size of the ivalues vector.

Test Plan: contbuild & OSS CI

Differential Revision: D49687548


