### PR TITLE
[generate_opcheck_tests] Enable using same failures_dict for multiple testclasses

### DIFF
--- a/test/minioptest_failures_dict.json
+++ b/test/minioptest_failures_dict.json
@@ -7,6 +7,10 @@
       "MiniOpTest.test_aot_dispatch_static__test_nonzero": {
         "comment": "",
         "status": "xfail"
+      },
+      "MiniOpTestOther.test_aot_dispatch_static__test_nonzero_again": {
+        "comment": "",
+        "status": "xfail"
       }
     },
     "aten::sin_": {},

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -1785,7 +1785,6 @@ class MiniOpTestOther(CustomOpTestCaseBase):
         self.assertEqual(y, torch.tensor([[1], [2]]))
 
 
-
 mini_op_test_checks = [
     "test_schema",
     "test_autograd_registration",

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -1776,6 +1776,16 @@ class MiniOpTest(CustomOpTestCaseBase):
         y = op(x)
 
 
+class MiniOpTestOther(CustomOpTestCaseBase):
+    test_ns = "mini_op_test"
+
+    def test_nonzero_again(self):
+        x = torch.tensor([0, 1, 2, 0, 0])
+        y = torch.ops.aten.nonzero.default(x)
+        self.assertEqual(y, torch.tensor([[1], [2]]))
+
+
+
 mini_op_test_checks = [
     "test_schema",
     "test_autograd_registration",
@@ -1786,6 +1796,17 @@ mini_op_test_checks = [
 
 optests.generate_opcheck_tests(
     MiniOpTest,
+    ["aten", "mini_op_test"],
+    get_file_path_2(
+        os.path.dirname(__file__),
+        "minioptest_failures_dict.json",
+    ),
+    [],
+    mini_op_test_checks,
+)
+
+optests.generate_opcheck_tests(
+    MiniOpTestOther,
     ["aten", "mini_op_test"],
     get_file_path_2(
         os.path.dirname(__file__),

--- a/torch/testing/_internal/optests/generate_tests.py
+++ b/torch/testing/_internal/optests/generate_tests.py
@@ -302,9 +302,9 @@ def validate_failures_dict_structure(
                 if not actual_test_name.startswith(test):
                     continue
                 base_test_name = actual_test_name[len(test) + 2 :]
-                if testcase.__name__ == test_class and hasattr(
-                    testcase, base_test_name
-                ):
+                if testcase.__name__ != test_class:
+                    continue
+                if hasattr(testcase, base_test_name):
                     continue
                 raise RuntimeError(
                     f"In failures dict, got test name '{test_name}'. We parsed this as "


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110164

This PR allows us to use the same failures_dict for multiple test
classes. This is helpful if you have a bunch of small TestCase(es) and
to centralize all the failures dict into one big one.

Test Plan:
- existing tests