### PR TITLE
[dynamo][guards-log] Add debug msg for nn_module_guards only when log is enabled

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -480,9 +480,14 @@ class GuardBuilder(GuardBuilderBase):
             )
             return
         name = self.check_fn_manager.add_extra_closure_var("__nn_module_guard", g)
-        # debug_msg is only for debugging help and goes to kwargs of guard call,
-        # which is ignored.
-        self._produce_guard_code(guard, [f'{name}({ref}, debug_msg="{g}")'])
+        if guards_log.isEnabledFor(logging.DEBUG):
+            # Avoid debug_msg related python bytecode overhead in the runtime.
+
+            # debug_msg is only for debugging help and goes to kwargs of guard call,
+            # which is ignored.
+            self._produce_guard_code(guard, [f'{name}({ref}, debug_msg="{g}")'])
+        else:
+            self._produce_guard_code(guard, [f"{name}({ref})"])
 
     def FUNCTION_MATCH(self, guard: Guard):
         """things like torch.add and user defined functions"""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110167


I did not do any benchmarks, but there could be a small overhead of creating the debug_msg. Adding debug_msg only when guards log is enabled.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng