### PR TITLE
fix bugs in export docstrings

### DIFF
--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -693,7 +693,7 @@ def load(
         extra_files = {'foo.txt': ''}  # values will be replaced with data
         ep = torch.export.load('exported_program.pt2', extra_files=extra_files)
         print(extra_files['foo.txt'])
-
+        print(ep(torch.randn(5)))
     """
     from torch._export import load
 

--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -625,7 +625,7 @@ def save(
             def forward(self, x):
                 return x + 10
 
-        ep = torch.export.export(MyModule(), torch.randn(5))
+        ep = torch.export.export(MyModule(), (torch.randn(5),))
 
         # Save to file
         torch.export.save(ep, 'exported_program.pt2')
@@ -635,7 +635,7 @@ def save(
         torch.export.save(ep, buffer)
 
         # Save with extra files
-        extra_files = {'foo.txt': b'bar'}
+        extra_files = {'foo.txt': b'bar'.decode('utf-8')}
         torch.export.save(ep, 'exported_program.pt2', extra_files=extra_files)
 
     """


### PR DESCRIPTION
First error

```
Traceback (most recent call last):
  File "/home/ubuntu/exporty.py", line 8, in <module>
    ep = torch.export.export(MyModule(), torch.randn(5))
  File "/opt/conda/envs/sam/lib/python3.10/site-packages/torch/export/__init__.py", line 509, in export
    return export(f, args, kwargs, constraints)
  File "/opt/conda/envs/sam/lib/python3.10/site-packages/torch/_export/__init__.py", line 314, in export
    raise UserError(UserErrorType.INVALID_INPUT,
torch._dynamo.exc.UserError: Expecting `args` to be a tuple of example positional inputs, got <class 'torch.Tensor'>
```

Second error

```
(sam) ubuntu@ip-172-31-9-217:~$ python exporty.py 
Traceback (most recent call last):
  File "/home/ubuntu/exporty.py", line 13, in <module>
    torch.export.save(ep, 'exported_program.pt2', extra_files=extra_files)
  File "/opt/conda/envs/sam/lib/python3.10/site-packages/torch/export/__init__.py", line 566, in save
    save(ep, f, extra_files=extra_files, opset_version=opset_version)
  File "/opt/conda/envs/sam/lib/python3.10/site-packages/torch/_export/__init__.py", line 595, in save
    encoded_content = content.encode('utf-8')
AttributeError: 'bytes' object has no attribute 'encode'. Did you mean: 'decode'?
```