### PR TITLE
Fix governance.rst link rendering

### DIFF
--- a/docs/source/community/governance.rst
+++ b/docs/source/community/governance.rst
@@ -313,7 +313,7 @@ relatively minor, a pull request on GitHub can be opened up immediately
 for review and merge by the project committers. For larger changes,
 please open an issue to make a proposal to discuss prior. Please also
 see the `PyTorch Contributor
-Wiki <https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions>` for contribution
+Wiki <https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions>`__ for contribution
 for a walkthrough.
 
 **Q: Can I become a committer on the project?** Unfortunately, the


### PR DESCRIPTION
By adding `__` to the end of the link decorator according to https://sublime-and-sphinx-guide.readthedocs.io/en/latest/references.html#links-to-external-web-pages

Fixes regression introduced by https://github.com/pytorch/pytorch/pull/106863

