### PR TITLE
Make  import `torch.masked` lazy

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1534,10 +1534,6 @@ quantized_gru = torch.ops.aten.quantized_gru
 
 from torch.utils.dlpack import from_dlpack, to_dlpack
 
-# Import experimental masked operations support. See
-# [RFC-0016](https://github.com/pytorch/rfcs/pull/27) for more
-# information.
-from . import masked
 
 # Import removed ops with error message about removal
 from ._linalg_utils import (  # type: ignore[misc]
@@ -1844,6 +1840,7 @@ if TYPE_CHECKING:
     from torch import _dynamo as _dynamo
     from torch import _inductor as _inductor
     from torch import onnx as onnx
+    from torch import masked as masked
 
 else:
     _lazy_modules = {
@@ -1852,6 +1849,10 @@ else:
         "_export",
         # ONNX must be imported after _dynamo, _ops, _subclasses, fx, func and jit
         "onnx",
+        # Import experimental masked operations support. See
+        # [RFC-0016](https://github.com/pytorch/rfcs/pull/27) for more
+        # information.
+        "masked",
     }
 
     def __getattr__(name):


### PR DESCRIPTION
EDIT: slow import is actually due to `import sympy`, `torch.masked` just happens to be the first time this occurs. Perhaps we could ~try~ to make all modules that import `sympy` be lazily imported?

`torch.masked` import takes about a fifth of total `import torch` time, since it is a prototype perhaps we can make the import lazy

Running 
```
PYTHONPROFILEIMPORTTIME=1 python -c "import torch" 2> import_torch_profile.txt
```
then viewing the profile with [tuna](https://github.com/nschloe/tuna)


<img width="669" alt="Screenshot 2023-09-27 at 2 13 56 PM" src="https://github.com/pytorch/pytorch/assets/35276741/76102483-8a27-4d80-81fa-fe6337d7685e">


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110174

