### PR TITLE
Squeeze and unsqeeze 3d to 4d for sdpa

### DIFF
--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -595,7 +595,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, bool> preprocess_inputs(const at:
   // All ensured to be equal size after validate_sdpa_input
   at::Tensor maybe_query_4d, maybe_key_4d, maybe_value_4d;
   bool is_3d = false;
-  if (query.dim() == 3){
+  if (query.dim() == 3 && !query.is_nested()){
     maybe_query_4d = query.unsqueeze(0);
     maybe_key_4d = key.unsqueeze(0);
     maybe_value_4d = value.unsqueeze(0);

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1250,25 +1250,6 @@ class TestSDPAFailureModes(NNTestCase):
             self.assertRaisesRegex(RuntimeError, "No viable backend for scaled_dot_product_attention was found.",
                                    lambda: torch.nn.functional.scaled_dot_product_attention(q, k, v))
 
-    @onlyCUDA
-    @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION, "Does not support fused scaled dot product attention")
-    @parametrize(
-        "kernel",
-        [SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION]
-        if PLATFORM_SUPPORTS_FLASH_ATTENTION
-        else [SDPBackend.EFFICIENT_ATTENTION],
-    )
-    def test_invalid_fused_inputs_dim_3(self, device, kernel: SDPBackend):
-        with sdp_kernel(**backend_map[kernel]):
-            # Dim is not 4
-            size = (2, 3, 8)
-            dtype = torch.float16
-            q = torch.randn(size, device=device, dtype=dtype)
-            k = torch.randn(size, device=device, dtype=dtype)
-            v = torch.randn(size, device=device, dtype=dtype)
-            with self.assertWarnsRegex(UserWarning, "Both fused kernels requires query, key and value to be 4 dimensional"):
-                self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(
-                    q, k, v, None, 0.0, False))
 
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION, "Does not support fused scaled dot product attention")


### PR DESCRIPTION
# Summary
If input two SDPA is 3 dimensional we expand it to be 4 dimensional by adding an outer "unsqueezed" dimension. This enables the 3 dimensional input to not immediately fail the fused_attention checks.