### PR TITLE
[AOTInductor] ProxyExecutor supports List[Tensor] return type

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3792,12 +3792,23 @@ class FallbackKernel(ExternKernelAlloc):
         named_arguments = serializer.serialize_inputs(self.op_overload, args, kwargs)
 
         # serialize_outputs
-        if isinstance(self.outputs, (list, tuple)):
+        if isinstance(self.outputs, tuple):
+            # For tuple returns, e.g "-> (Tensor, Tensor)"
             output_arguments = [
                 export_schema.Argument.create(
                     as_tensor=export_schema.TensorArgument(name=output.get_name())
                 )
                 for output in self.outputs
+            ]
+        elif isinstance(self.outputs, list):
+            # For list of tensor, e.g. "-> List[Tensor]"
+            output_arguments = [
+                export_schema.Argument.create(
+                    as_tensors=[
+                        export_schema.TensorArgument(name=output.get_name())
+                        for output in self.outputs
+                    ]
+                )
             ]
         else:
             output_arguments = [


### PR DESCRIPTION
Summary:
Support custom ops returns List[Tensor] type, like `"fn_with_list_output(Tensor[] tensors, int i) -> Tensor[]"`

As an example
`out5, out6 = torch.ops.fb.fn_with_list_output([out3, out4], 1)`

got compiled into

```
    AtenTensorHandle buf8_handle;  // output buffer
    AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_new_uninitialized_tensor(&buf8_handle));
    RAIIAtenTensorHandle buf8(buf8_handle);
    AtenTensorHandle buf9_handle;  // output buffer
    AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_new_uninitialized_tensor(&buf9_handle));
    RAIIAtenTensorHandle buf9(buf9_handle);
    AtenTensorHandle tensor_args_var_5[] = {buf5.get(), buf6.get(), buf8.get(), buf9.get()};
    int64_t int_args_var_6[] = {1};
    aoti_torch_proxy_executor_call_function(proxy_executor, 2, 1, int_args_var_6, 4, tensor_args_var_5);
```

Test Plan: Test

Differential Revision: D49694691



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler