### PR TITLE
[inductor][Optimus]Improve logging for Optimus

### DIFF
--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -13,6 +13,11 @@ from ..pattern_matcher import (
     stable_topological_sort,
 )
 
+if config.is_fbcode():
+    from torch._inductor.fb.utils import (  # type: ignore[import]  # noqa: F401
+        get_everpaste_url,
+    )
+
 try:
     # importing this will register fbgemm lowerings for inductor
     import deeplearning.fbgemm.fbgemm_gpu.fb.inductor_lowerings  # noqa: F401
@@ -564,7 +569,13 @@ def apply_group_batch_fusion(graph: torch.fx.GraphModule, rule: GroupBatchFusion
                 )
 
 
+def print_graph(graph: torch.fx.Graph, msg: str):
+    if config.is_fbcode():
+        log.info("%s Print graph: %s", msg, get_everpaste_url(str(graph)))  # noqa: F401
+
+
 def group_batch_fusion_post_grad_passes(graph: torch.fx.Graph):
+    print_graph(graph, "Before group_batch fusion in post grads pass.")
     fusions: List[GroupBatchFusionBase] = []
 
     if config.group_fusion and has_fbgemm:
@@ -572,9 +583,11 @@ def group_batch_fusion_post_grad_passes(graph: torch.fx.Graph):
 
     for rule in fusions:
         apply_group_batch_fusion(graph, rule)
+        print_graph(graph, f"Apply fusion {rule.__class__.__name__}.")
 
 
 def group_batch_fusion_pre_grad_passes(graph: torch.fx.Graph):
+    print_graph(graph, "Before group_batch fusion in pre grads pass.")
     fusions: List[GroupBatchFusionBase] = []
     if config.batch_fusion:
         fusions += [
@@ -585,3 +598,4 @@ def group_batch_fusion_pre_grad_passes(graph: torch.fx.Graph):
         ]
     for rule in fusions:
         apply_group_batch_fusion(graph, rule)
+        print_graph(graph, f"Apply fusion {rule.__class__.__name__}.")

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -93,6 +93,11 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
     gm.recompile()
     gm.graph.lint()
 
+    if config.is_fbcode():
+        from torch._inductor.fb.utils import get_everpaste_url  # type: ignore[import]
+
+        log.info(f"Print graph after recompile in post grad passes: {get_everpaste_url(str(gm.graph))}")
+
 
 @init_once_fakemode
 def lazy_init():

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -73,6 +73,11 @@ def pre_grad_passes(gm: torch.fx.GraphModule, example_inputs):
     gm.graph.lint()
     gm.recompile()
 
+    if config.is_fbcode():
+        from torch._inductor.fb.utils import get_everpaste_url  # type: ignore[import]
+
+        log.info(f"Print graph after recompile in pre grad passes: {get_everpaste_url(str(gm.graph))}")
+
     return gm
 
 


### PR DESCRIPTION
Summary: It is based on the diff D49340843. We add more logs for better debug and logging purposes.

Test Plan:
```
[2023-09-27 20:35:53,844] [0/0] torch._inductor.fx_passes.group_batch_fusion: [INFO] Before group_batch fusion in pre grads pass. Print graph: https://www.internalfb.com/intern/everpaste/?color=0&handle=GEoA8xb22jibUNEEAPYecF9_RVM1br0LAAAz
[2023-09-27 20:35:55,001] [0/0] torch._inductor.fx_passes.group_batch_fusion: [INFO] Apply fusion BatchLinearFusion. Print graph: https://www.internalfb.com/intern/everpaste/?color=0&handle=GPMR9BYffjwToEQCAFS7rgixMi0pbr0LAAAz
[2023-09-27 20:35:57,419] [0/0] torch._inductor.fx_passes.group_batch_fusion: [INFO] Apply fusion BatchLinearLHSFusion. Print graph: https://www.internalfb.com/intern/everpaste/?color=0&handle=GKiA8hNycGpBdAIDAOn0c1Hpef4sbr0LAAAz
[2023-09-27 20:35:57,585] [0/0] torch._inductor.fx_passes.group_batch_fusion: [INFO] BatchLayernormFusion: key = ('batch_layernorm', 'torch.Size([2048, 128])', 'torch.Size([128])', 'torch.Size([128])', '(128,)', '1e-05'); subset size = 7
[2023-09-27 20:35:58,493] [0/0] torch._inductor.fx_passes.group_batch_fusion: [INFO] Apply fusion BatchLayernormFusion. Print graph: https://www.internalfb.com/intern/everpaste/?color=0&handle=GKpftRa9Glxm-MYDAOZb_D80JHsYbr0LAAAz
[2023-09-27 20:35:59,754] [0/0] torch._inductor.fx_passes.group_batch_fusion: [INFO] Apply fusion BatchTanhFusion. Print graph: https://www.internalfb.com/intern/everpaste/?color=0&handle=GPgh9BZQl4EKGckAAES094iV3Atrbr0LAAAz
I0927 20:36:00.532000 3750607 pre_grad.py:71] After group_batch_fusion_pre_grad_passes: https://www.internalfb.com/intern/everpaste/?color=0&handle=GBPb8xYxfrbXuCMDAI5d_a4YyhFBbr0LAAAz
```

Differential Revision: D49710166



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler