### PR TITLE
[AOTInductor] ProxyExecutor supports Tuple of Tensor and List[Tensor] in returns

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3895,29 +3895,37 @@ class FallbackKernel(ExternKernelAlloc):
         named_arguments = serializer.serialize_inputs(self.op_overload, args, kwargs)
 
         # serialize_outputs
-        if isinstance(self.outputs, tuple):
-            # For tuple returns, e.g "-> (Tensor, Tensor)"
-            output_arguments = [
-                export_schema.Argument.create(
-                    as_tensor=export_schema.TensorArgument(name=output.get_name())
+        def handle_single_output(return_type, output):
+            if isinstance(output, list):
+                # For single TensorList
+                assert isinstance(return_type, torch.ListType) and isinstance(
+                    return_type.getElementType(), torch.TensorType
                 )
-                for output in self.outputs
-            ]
-        elif isinstance(self.outputs, list):
-            # For list of tensor, e.g. "-> List[Tensor]"
-            output_arguments = [
-                export_schema.Argument.create(
+                return export_schema.Argument.create(
                     as_tensors=[
-                        export_schema.TensorArgument(name=output.get_name())
-                        for output in self.outputs
+                        export_schema.TensorArgument(name=out.get_name())
+                        for out in output
                     ]
                 )
-            ]
-        else:
-            output_arguments = [
-                export_schema.Argument.create(
-                    as_tensor=export_schema.TensorArgument(name=self.outputs.get_name())
+            else:
+                # for single Tensor
+                assert isinstance(return_type, torch.TensorType)
+                return export_schema.Argument.create(
+                    as_tensor=export_schema.TensorArgument(name=output.get_name())
                 )
+
+        target = self.op_overload
+        returns = target._schema.returns
+        if len(returns) == 1:
+            return_type = returns[0].real_type
+            output_arguments = [handle_single_output(return_type, self.outputs)]
+        else:
+            # For tuple returns, e.g "-> (Tensor, Tensor)" or "-> (Tesnor, Tensor[])"
+            assert isinstance(self.outputs, tuple)
+            assert len(returns) == len(self.outputs)
+            output_arguments = [
+                handle_single_output(return_schema.real_type, output)
+                for return_schema, output in zip(returns, self.outputs)
             ]
 
         node = ExternKernelNode(


### PR DESCRIPTION
Summary:
ProxyExecutor supports custom ops that return a tuple mixed of Tensor and List[Tensor]
e.g. `"fn_with_mix_outputs(Tensor t, Tensor[] tensors) -> (Tensor, Tensor[])"`

Example:
`out7, [out8, out9] = torch.ops.fb.fn_with_mix_outputs(out5, [out6, out4])`
got compiled into
```
    AtenTensorHandle buf11_handle;  // output buffer
    AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_new_uninitialized_tensor(&buf11_handle));
    RAIIAtenTensorHandle buf11(buf11_handle);
    AtenTensorHandle buf12_handle;  // output buffer
    AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_new_uninitialized_tensor(&buf12_handle));
    RAIIAtenTensorHandle buf12(buf12_handle);
    AtenTensorHandle buf13_handle;  // output buffer
    AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_new_uninitialized_tensor(&buf13_handle));
    RAIIAtenTensorHandle buf13(buf13_handle);
    AtenTensorHandle tensor_args_var_7[] = {buf8.get(), buf9.get(), buf6.get(), buf11.get(), buf12.get(), buf13.get()};
    int64_t int_args_var_8[] = {};
    aoti_torch_proxy_executor_call_function(proxy_executor, 3, 0, int_args_var_8, 6, tensor_args_var_7);
```

Serialized extern node
```
    {
      "name": "buf10",
      "node": {
        "target": "fb::fn_with_mix_outputs",
        "inputs": [
          {
            "name": "t",
            "arg": {
              "asTensor": {
                "name": "buf8"
              }
            }
          },
          {
            "name": "tensors",
            "arg": {
              "asTensors": [
                {
                  "name": "buf9"
                },
                {
                  "name": "buf6"
                }
              ]
            }
          }
        ],
        "outputs": [
          {
            "asTensor": {
              "name": "buf11"
            }
          },
          {
            "asTensors": [
              {
                "name": "buf12"
              },
              {
                "name": "buf13"
              }
            ]
          }
        ],
        "metadata": {}
      }
    }
```

Test Plan: Test

Differential Revision: D49710320



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler