### PR TITLE
run_tests.py minor logging changes

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -649,6 +649,7 @@ def _test_cpp_extensions_aot(test_directory, options, use_ninja):
     if use_ninja:
         try:
             from torch.utils import cpp_extension
+
             cpp_extension.verify_ninja_availability()
         except RuntimeError:
             print_to_stderr(CPP_EXTENSIONS_ERROR)
@@ -1414,7 +1415,9 @@ def download_test_times(file: str = TEST_TIMES_FILE) -> Dict[str, float]:
     # Download previous test times to make sharding decisions
     path = os.path.join(str(REPO_ROOT), file)
     if not os.path.exists(path):
-        print_to_stderr("::warning:: Failed to find test times file. Using round robin sharding.")
+        print_to_stderr(
+            "::warning:: Failed to find test times file. Using round robin sharding."
+        )
         return {}
 
     with open(path) as f:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -33,7 +33,6 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ROCM,
     TEST_WITH_SLOW_GRADCHECK,
 )
-from torch.utils import cpp_extension
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 
@@ -649,9 +648,10 @@ def run_test_with_subprocess(test_module, test_directory, options):
 def _test_cpp_extensions_aot(test_directory, options, use_ninja):
     if use_ninja:
         try:
+            from torch.utils import cpp_extension
             cpp_extension.verify_ninja_availability()
         except RuntimeError:
-            print(CPP_EXTENSIONS_ERROR)
+            print_to_stderr(CPP_EXTENSIONS_ERROR)
             return 1
 
     # Wipe the build folder, if it exists already
@@ -1414,7 +1414,7 @@ def download_test_times(file: str = TEST_TIMES_FILE) -> Dict[str, float]:
     # Download previous test times to make sharding decisions
     path = os.path.join(str(REPO_ROOT), file)
     if not os.path.exists(path):
-        print("::warning:: Failed to find test times file. Using round robin sharding.")
+        print_to_stderr("::warning:: Failed to find test times file. Using round robin sharding.")
         return {}
 
     with open(path) as f:
@@ -1422,16 +1422,16 @@ def download_test_times(file: str = TEST_TIMES_FILE) -> Dict[str, float]:
     build_environment = os.environ.get("BUILD_ENVIRONMENT")
     test_config = os.environ.get("TEST_CONFIG")
     if test_config in test_times_file.get(build_environment, {}):
-        print("Found test times from artifacts")
+        print_to_stderr("Found test times from artifacts")
         return test_times_file[build_environment][test_config]
     elif test_config in test_times_file["default"]:
-        print(
+        print_to_stderr(
             f"::warning:: Gathered no stats from artifacts for {build_environment} build env"
             f" and {test_config} test config. Using default build env and {test_config} test config instead."
         )
         return test_times_file["default"][test_config]
     else:
-        print(
+        print_to_stderr(
             f"::warning:: Gathered no stats from artifacts for build env {build_environment} build env"
             f" and {test_config} test config. Using default build env and default test config instead."
         )
@@ -1611,7 +1611,7 @@ def check_pip_packages() -> None:
     installed_packages = [i.key for i in pkg_resources.working_set]
     for package in packages:
         if package not in installed_packages:
-            print(
+            print_to_stderr(
                 f"Missing pip dependency: {package}, please run `pip install -r .ci/docker/requirements-ci.txt`"
             )
             sys.exit(1)
@@ -1699,7 +1699,7 @@ def main():
     ]
 
     for test_batch in test_batches:
-        print(test_batch)
+        print_to_stderr(test_batch)
 
     if options.dry_run:
         return
@@ -1719,10 +1719,10 @@ def main():
         start_time = time.time()
         for test_batch in test_batches:
             elapsed_time = time.time() - start_time
-            print(
+            print_to_stderr(
                 f"Starting test batch '{test_batch.name}' {elapsed_time} seconds after initiating testing"
             )
-            print(
+            print_to_stderr(
                 f"With sharding, this batch will run {len(test_batch.sharded_tests)} tests"
             )
             metrics_dict[f"{test_batch.name}_start_time"] = elapsed_time
@@ -1756,7 +1756,7 @@ def main():
                 test_stats = aggregated_heuristics.get_test_stats(test)
                 test_stats["num_total_tests"] = num_tests
 
-                print("Emiting td_test_failure_stats")
+                print_to_stderr("Emiting td_test_failure_stats")
                 emit_metric("td_test_failure_stats", test_stats)
 
     if len(all_failures):

--- a/tools/stats/import_test_stats.py
+++ b/tools/stats/import_test_stats.py
@@ -15,8 +15,6 @@ def get_disabled_issues() -> List[str]:
     return issue_numbers
 
 
-IGNORE_DISABLED_ISSUES: List[str] = get_disabled_issues()
-
 SLOW_TESTS_FILE = ".pytorch-slow-tests.json"
 DISABLED_TESTS_FILE = ".pytorch-disabled-tests.json"
 
@@ -90,7 +88,7 @@ def get_disabled_tests(
         # remove re-enabled tests and condense even further by getting rid of pr_num
         disabled_test_from_issues = dict()
         for test_name, (pr_num, link, platforms) in the_response.items():
-            if pr_num not in IGNORE_DISABLED_ISSUES:
+            if pr_num not in get_disabled_issues():
                 disabled_test_from_issues[test_name] = (
                     link,
                     platforms,


### PR DESCRIPTION
Minor logging changes that just kind of annoyed me:
* prevent constant printing of `No CUDA runtime is found, using CUDA_HOME='/usr/local/cuda'` by moving import within the function (idk if this is ok)
* prevent constant printing of `Ignoring disabled issues:  ['']` (no idea why it was not gated behind a function or main)
* change all prints in run_tests.py to be through stderr so theres no weird interleaving (although if everything goes through stderr, might as well just print everything through stdout...)