### PR TITLE
minor tf32 fixes for unit tests on H100 and L40

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1,9 +1,4 @@
 # Owner(s): ["module: inductor"]
-from torch.testing._internal.inductor_utils import HAS_CPU, HAS_CUDA
-from torch.testing._internal.common_utils import slowTest
-from torch._inductor.utils import has_torchvision_roi_align
-from torch._inductor.compile_fx import compile_fx, compile_fx_inner
-from torch._inductor import config, test_operators
 import contextlib
 import copy
 import dataclasses
@@ -52,7 +47,7 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FLASH_ATTENTION,
     SM80OrLater,
     TEST_CUDNN,
-    with_tf32_off,
+    with_tf32_off
 )
 
 from torch.testing._internal.common_device_type import _has_sufficient_memory
@@ -83,6 +78,13 @@ if IS_WINDOWS and IS_CI:
 importlib.import_module("functorch")
 importlib.import_module("filelock")
 
+from torch._inductor import config, test_operators
+
+from torch._inductor.compile_fx import compile_fx, compile_fx_inner
+from torch._inductor.utils import has_torchvision_roi_align
+
+from torch.testing._internal.common_utils import slowTest
+from torch.testing._internal.inductor_utils import HAS_CPU, HAS_CUDA
 
 HAS_MULTIGPU = HAS_CUDA and torch.cuda.device_count() >= 2
 HAS_AVX2 = "fbgemm" in torch.backends.quantized.supported_engines
@@ -163,7 +165,7 @@ class InputGen:
 
     def strided(self):
         return torch.randn((self.n * 2, self.n * 3), device=self.device)[
-            self.n:, self.n:: 2
+            self.n :, self.n :: 2
         ]
 
     def broadcast1(self):
@@ -1586,9 +1588,9 @@ class CommonTemplate:
             return a + 4
 
         t = torch.ones(2**31 + 1, dtype=torch.int8, device=self.device)
-        t[2**30:] = 0
+        t[2**30 :] = 0
         compiled_fn = torch._dynamo.optimize()(fn)
-        actual = compiled_fn(t[2**30:])
+        actual = compiled_fn(t[2**30 :])
         self.assertTrue((actual == 4).all())
 
     def test_large_strided_reduction(self):
@@ -3432,7 +3434,7 @@ class CommonTemplate:
             self.assertEqual(out, matmul_with_op(inps[0], inps[1], fn))
 
         # test broadcasted shape bail
-        def fn(x): return x + torch.zeros(  # noqa: E731
+        fn = lambda x: x + torch.zeros(  # noqa: E731
             [256, 256, 256], dtype=torch.bfloat16, device=self.device
         )
         out, source_codes = run_and_get_code(foo_opt, inps[0], inps[1], fn)
@@ -4732,7 +4734,7 @@ class CommonTemplate:
         with torch.no_grad():
             x = torch.randn(1024, device=self.device)
             self.assertEqual(fn(x[0:]), x[16:][:16])
-            self.assertEqual(fn(x[128:]), x[128 + 16:][:16])
+            self.assertEqual(fn(x[128:]), x[128 + 16 :][:16])
 
     # from GPT2ForSequenceClassification
     def test_index_tensor(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -47,7 +47,9 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FLASH_ATTENTION,
     SM80OrLater,
     TEST_CUDNN,
+    with_tf32_off
 )
+
 from torch.testing._internal.common_device_type import _has_sufficient_memory
 from torch.testing._internal.common_dtype import all_types
 from torch.testing._internal.common_utils import (
@@ -2936,6 +2938,7 @@ class CommonTemplate:
         )
 
     # From yolov3
+    @with_tf32_off
     def test_batch_norm_2d_2(self):
         if self.device == "cpu":
             raise unittest.SkipTest("requires CUDA")

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -47,7 +47,7 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FLASH_ATTENTION,
     SM80OrLater,
     TEST_CUDNN,
-    with_tf32_off
+    with_tf32_off,
 )
 
 from torch.testing._internal.common_device_type import _has_sufficient_memory

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -16,7 +16,7 @@ import torch.nn.functional as F
 from torch.nn import _reduction as _Reduction
 from torch.testing._internal.common_utils import TestCase, to_gpu, freeze_rng_state, is_iterable, \
     gradcheck, gradgradcheck, set_default_dtype
-from torch.testing._internal.common_cuda import TEST_CUDA, SM90OrLater
+from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.autograd.gradcheck import _get_numerical_jacobian, _iter_tensors
 from torch.autograd import Variable
 from torch.types import _TensorOrTensors
@@ -2531,7 +2531,7 @@ new_module_tests = [
         check_gradgrad=False,
         desc='gelu_activation',
         with_tf32=True,
-        tf32_precision=0.08 if SM90OrLater else 0.05,
+        tf32_precision=0.08,
         default_dtype=torch.double,
     ),
     dict(
@@ -2576,7 +2576,7 @@ new_module_tests = [
         check_gradgrad=False,
         desc='multilayer_coder',
         with_tf32=True,
-        tf32_precision=0.05 if SM90OrLater else 0.03,
+        tf32_precision=0.05,
         default_dtype=torch.double,
     ),
     dict(
@@ -2806,8 +2806,7 @@ def cross_entropy_loss_indices_target_reference(input, target, weight=None, igno
         if weight is not None:
             # TODO: This code can path can be removed if #61309 is resolved
             # loss is normalized by the weights to be consistent with nll_loss_nd
-            ret = torch.sum(smooth_loss) / weight.gather(0,
-                                                         target.masked_select(ignore_mask.logical_not()).flatten()).sum()
+            ret = torch.sum(smooth_loss) / weight.gather(0, target.masked_select(ignore_mask.logical_not()).flatten()).sum()
         else:
             ret = torch.mean(smooth_loss.masked_select(ignore_mask.logical_not()))
     elif reduction == 'sum':
@@ -3597,8 +3596,7 @@ criterion_tests = [
         input_size=(5, 3),
         target_fn=lambda: torch.rand(5, 3).softmax(dim=1),
         reference_fn=lambda i, t, m:
-            loss_reference_fns['CrossEntropyLoss'](i, t, reduction=get_reduction(
-                m), weight=get_weight(m), label_smoothing=0.15),
+            loss_reference_fns['CrossEntropyLoss'](i, t, reduction=get_reduction(m), weight=get_weight(m), label_smoothing=0.15),
         check_bfloat16=False,
         default_dtype=torch.double,
     ),
@@ -3643,8 +3641,7 @@ criterion_tests = [
         input_size=(2, 3, 5),
         target_fn=lambda: torch.rand(2, 5).mul(3).floor().long(),
         reference_fn=lambda i, t, m:
-            loss_reference_fns['CrossEntropyLoss'](
-                i, t, reduction=get_reduction(m), label_smoothing=0.15, ignore_index=1),
+            loss_reference_fns['CrossEntropyLoss'](i, t, reduction=get_reduction(m), label_smoothing=0.15, ignore_index=1),
         check_bfloat16=False,
         default_dtype=torch.double,
     ),
@@ -3667,8 +3664,7 @@ criterion_tests = [
         input_size=(2, 3, 5),
         target_fn=lambda: torch.rand(2, 5).mul(3).floor().long(),
         reference_fn=lambda i, t, m:
-            loss_reference_fns['CrossEntropyLoss'](
-                i, t, reduction=get_reduction(m), label_smoothing=0.15, ignore_index=1),
+            loss_reference_fns['CrossEntropyLoss'](i, t, reduction=get_reduction(m), label_smoothing=0.15, ignore_index=1),
         check_bfloat16=False,
         default_dtype=torch.double,
     ),
@@ -3701,8 +3697,7 @@ criterion_tests = [
         input_size=(15, 10),
         target_fn=lambda: torch.empty(15).uniform_().mul(10).floor().long(),
         reference_fn=lambda i, t, m:
-            loss_reference_fns['CrossEntropyLoss'](
-                i, t, reduction=get_reduction(m), label_smoothing=0.15, ignore_index=3),
+            loss_reference_fns['CrossEntropyLoss'](i, t, reduction=get_reduction(m), label_smoothing=0.15, ignore_index=3),
         check_bfloat16=False,
         default_dtype=torch.double,
     ),
@@ -3714,8 +3709,7 @@ criterion_tests = [
         input_size=(15, 10),
         target_fn=lambda: torch.empty(15).uniform_().mul(10).floor().long(),
         reference_fn=lambda i, t, m:
-            loss_reference_fns['CrossEntropyLoss'](i, t, reduction=get_reduction(
-                m), weight=get_weight(m), label_smoothing=0.15),
+            loss_reference_fns['CrossEntropyLoss'](i, t, reduction=get_reduction(m), weight=get_weight(m), label_smoothing=0.15),
         check_bfloat16=False,
         default_dtype=torch.double,
     ),
@@ -4871,7 +4865,6 @@ def _test_bfloat16_ops(test_case, op, device, inp_dims=(), prec=1e-2, scale_fact
 
     test_case.assertEqual(out1, out2, atol=prec, rtol=prec, exact_dtype=False)
     test_case.assertEqual(input1.grad.data, input2.grad.data, atol=prec, rtol=prec, exact_dtype=False)
-
 
 def _test_module_empty_input(test_case, module, inp, check_size=True, inference=False):
     if not inference:

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -2531,7 +2531,7 @@ new_module_tests = [
         check_gradgrad=False,
         desc='gelu_activation',
         with_tf32=True,
-        tf32_precision=0.05,
+        tf32_precision=0.08,
         default_dtype=torch.double,
     ),
     dict(
@@ -2576,7 +2576,7 @@ new_module_tests = [
         check_gradgrad=False,
         desc='multilayer_coder',
         with_tf32=True,
-        tf32_precision=0.03,
+        tf32_precision=0.05,
         default_dtype=torch.double,
     ),
     dict(

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -16,7 +16,7 @@ import torch.nn.functional as F
 from torch.nn import _reduction as _Reduction
 from torch.testing._internal.common_utils import TestCase, to_gpu, freeze_rng_state, is_iterable, \
     gradcheck, gradgradcheck, set_default_dtype
-from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_cuda import TEST_CUDA, SM90OrLater
 from torch.autograd.gradcheck import _get_numerical_jacobian, _iter_tensors
 from torch.autograd import Variable
 from torch.types import _TensorOrTensors
@@ -2531,7 +2531,7 @@ new_module_tests = [
         check_gradgrad=False,
         desc='gelu_activation',
         with_tf32=True,
-        tf32_precision=0.08,
+        tf32_precision=0.08 if SM90OrLater else 0.05,
         default_dtype=torch.double,
     ),
     dict(
@@ -2576,7 +2576,7 @@ new_module_tests = [
         check_gradgrad=False,
         desc='multilayer_coder',
         with_tf32=True,
-        tf32_precision=0.05,
+        tf32_precision=0.05 if SM90OrLater else 0.03,
         default_dtype=torch.double,
     ),
     dict(

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -16,7 +16,7 @@ import torch.nn.functional as F
 from torch.nn import _reduction as _Reduction
 from torch.testing._internal.common_utils import TestCase, to_gpu, freeze_rng_state, is_iterable, \
     gradcheck, gradgradcheck, set_default_dtype
-from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_cuda import TEST_CUDA, SM90OrLater
 from torch.autograd.gradcheck import _get_numerical_jacobian, _iter_tensors
 from torch.autograd import Variable
 from torch.types import _TensorOrTensors
@@ -2531,7 +2531,7 @@ new_module_tests = [
         check_gradgrad=False,
         desc='gelu_activation',
         with_tf32=True,
-        tf32_precision=0.08,
+        tf32_precision=0.08 if SM90OrLater else 0.05,
         default_dtype=torch.double,
     ),
     dict(
@@ -2576,7 +2576,7 @@ new_module_tests = [
         check_gradgrad=False,
         desc='multilayer_coder',
         with_tf32=True,
-        tf32_precision=0.05,
+        tf32_precision=0.05 if SM90OrLater else 0.03,
         default_dtype=torch.double,
     ),
     dict(
@@ -2806,7 +2806,8 @@ def cross_entropy_loss_indices_target_reference(input, target, weight=None, igno
         if weight is not None:
             # TODO: This code can path can be removed if #61309 is resolved
             # loss is normalized by the weights to be consistent with nll_loss_nd
-            ret = torch.sum(smooth_loss) / weight.gather(0, target.masked_select(ignore_mask.logical_not()).flatten()).sum()
+            ret = torch.sum(smooth_loss) / weight.gather(0,
+                                                         target.masked_select(ignore_mask.logical_not()).flatten()).sum()
         else:
             ret = torch.mean(smooth_loss.masked_select(ignore_mask.logical_not()))
     elif reduction == 'sum':
@@ -3596,7 +3597,8 @@ criterion_tests = [
         input_size=(5, 3),
         target_fn=lambda: torch.rand(5, 3).softmax(dim=1),
         reference_fn=lambda i, t, m:
-            loss_reference_fns['CrossEntropyLoss'](i, t, reduction=get_reduction(m), weight=get_weight(m), label_smoothing=0.15),
+            loss_reference_fns['CrossEntropyLoss'](i, t, reduction=get_reduction(
+                m), weight=get_weight(m), label_smoothing=0.15),
         check_bfloat16=False,
         default_dtype=torch.double,
     ),
@@ -3641,7 +3643,8 @@ criterion_tests = [
         input_size=(2, 3, 5),
         target_fn=lambda: torch.rand(2, 5).mul(3).floor().long(),
         reference_fn=lambda i, t, m:
-            loss_reference_fns['CrossEntropyLoss'](i, t, reduction=get_reduction(m), label_smoothing=0.15, ignore_index=1),
+            loss_reference_fns['CrossEntropyLoss'](
+                i, t, reduction=get_reduction(m), label_smoothing=0.15, ignore_index=1),
         check_bfloat16=False,
         default_dtype=torch.double,
     ),
@@ -3664,7 +3667,8 @@ criterion_tests = [
         input_size=(2, 3, 5),
         target_fn=lambda: torch.rand(2, 5).mul(3).floor().long(),
         reference_fn=lambda i, t, m:
-            loss_reference_fns['CrossEntropyLoss'](i, t, reduction=get_reduction(m), label_smoothing=0.15, ignore_index=1),
+            loss_reference_fns['CrossEntropyLoss'](
+                i, t, reduction=get_reduction(m), label_smoothing=0.15, ignore_index=1),
         check_bfloat16=False,
         default_dtype=torch.double,
     ),
@@ -3697,7 +3701,8 @@ criterion_tests = [
         input_size=(15, 10),
         target_fn=lambda: torch.empty(15).uniform_().mul(10).floor().long(),
         reference_fn=lambda i, t, m:
-            loss_reference_fns['CrossEntropyLoss'](i, t, reduction=get_reduction(m), label_smoothing=0.15, ignore_index=3),
+            loss_reference_fns['CrossEntropyLoss'](
+                i, t, reduction=get_reduction(m), label_smoothing=0.15, ignore_index=3),
         check_bfloat16=False,
         default_dtype=torch.double,
     ),
@@ -3709,7 +3714,8 @@ criterion_tests = [
         input_size=(15, 10),
         target_fn=lambda: torch.empty(15).uniform_().mul(10).floor().long(),
         reference_fn=lambda i, t, m:
-            loss_reference_fns['CrossEntropyLoss'](i, t, reduction=get_reduction(m), weight=get_weight(m), label_smoothing=0.15),
+            loss_reference_fns['CrossEntropyLoss'](i, t, reduction=get_reduction(
+                m), weight=get_weight(m), label_smoothing=0.15),
         check_bfloat16=False,
         default_dtype=torch.double,
     ),
@@ -4865,6 +4871,7 @@ def _test_bfloat16_ops(test_case, op, device, inp_dims=(), prec=1e-2, scale_fact
 
     test_case.assertEqual(out1, out2, atol=prec, rtol=prec, exact_dtype=False)
     test_case.assertEqual(input1.grad.data, input2.grad.data, atol=prec, rtol=prec, exact_dtype=False)
+
 
 def _test_module_empty_input(test_case, module, inp, check_size=True, inference=False):
     if not inference:


### PR DESCRIPTION
fixes the following tests which were failing in the NVIDIA internal CI on H100 and L40:

test/test_nn.py:
* test_TransformerEncoderLayer_gelu_activation_cuda_tf32
* test_Transformer_multilayer_coder_cuda_tf32

test/inductor/test_torchinductor.py: 
* test_batch_norm_2d_2_cuda


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler