### PR TITLE
[BE] Fix `pointless comparison` warning

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -1281,7 +1281,7 @@ struct TORCH_API IValue final {
             0;
 
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-        uint32_t(tag) >= 0 && uint32_t(tag) < kNumTags,
+        static_cast<uint32_t>(tag) < kNumTags,
         "unexpected tag ",
         static_cast<int>(tag));
     return kTruthTableBitVector & (1 << (uint32_t(tag) % 32));


### PR DESCRIPTION
As Indeed `uint32_t(x) >= 0` is always true


Warning typically looks as follows:
```
[337/1379] Building CUDA object caffe2/CMakeFiles/torch_cuda.dir/__/aten/src/ATen/native/cuda/EmbeddingBag.cu.o
../aten/src/ATen/core/ivalue.h(1283): warning #186-D: pointless comparison of unsigned integer with zero

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"


```