### PR TITLE
[fbcode] small fix on dataloader and content_understanding/main

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -1443,6 +1443,8 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
                 for q in self._index_queues:
                     q.cancel_join_thread()
                     q.close()
+            except AttributeError as e:
+                logger.warning(e)
             finally:
                 # Even though all this function does is putting into queues that
                 # we have called `cancel_join_thread` on, weird things can


### PR DESCRIPTION
Summary:
* when dl shuts down, sometimes the order of object `__del__` and object clean up may mess up, which may raise exception complaining certain properties of the obj is not defined. adding a catch to avoid it from happening.

* remove the extra `register_new_resolver` as pointed in https://www.internalfb.com/diff/D49448666?dst_version_fbid=132094109961892&transaction_fbid=1285292328796395

Test Plan: cu-cli launch -p xray_video -c xrv_mae_vit_test --no-maybe-pull -l

Reviewed By: ejguan

Differential Revision: D49710645


