### PR TITLE
[dynamo] Convert dtype arguments as well as inputs in `cast_to_fp64`

### DIFF
--- a/test/dynamo/test_debug_utils.py
+++ b/test/dynamo/test_debug_utils.py
@@ -1,7 +1,10 @@
+# Owner(s): ["module: dynamo"]
+
 import torch
+from functorch import make_fx
 from torch._dynamo import debug_utils
 from torch._dynamo.test_case import TestCase
-from functorch import make_fx
+
 
 class TestDebugUtils(TestCase):
     def test_cast_model_to_fp64_dtype_args(self):
@@ -19,26 +22,33 @@ class TestDebugUtils(TestCase):
         decomps = torch._decomp.core_aten_decompositions()
         fx = make_fx(fn, decomposition_table=decomps)(x)
 
-        self.assertExpectedInline(fx.code.lstrip(), """\
+        self.assertExpectedInline(
+            fx.code.lstrip(),
+            """\
 def forward(self, x_1):
     convert_element_type = torch.ops.prims.convert_element_type.default(x_1, torch.float16)
     _to_copy = torch.ops.aten._to_copy.default(x_1, dtype = torch.float16);  x_1 = None
     full = torch.ops.aten.full.default([32], 2, dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
     empty = torch.ops.aten.empty.memory_format([32], dtype = torch.float32, layout = torch.strided, device = device(type='cpu'), pin_memory = False)
     return (convert_element_type, _to_copy, full, empty)
-    """)
+    """,  # NOQA: B950
+        )
 
         fp64_model, fp64_examples = debug_utils.cast_to_fp64(fx, (x,))
         self.assertEqual(fp64_examples, (x.to(torch.float64),))
 
-        self.assertExpectedInline(fx.code.lstrip(), """\
+        self.assertExpectedInline(
+            fx.code.lstrip(),
+            """\
 def forward(self, x_1):
     convert_element_type = torch.ops.prims.convert_element_type.default(x_1, torch.float64)
     _to_copy = torch.ops.aten._to_copy.default(x_1, dtype = torch.float64);  x_1 = None
     full = torch.ops.aten.full.default([32], 2, dtype = torch.float64, device = device(type='cpu'), pin_memory = False)
     empty = torch.ops.aten.empty.memory_format([32], dtype = torch.float64, layout = torch.strided, device = device(type='cpu'), pin_memory = False)
     return (convert_element_type, _to_copy, full, empty)
-    """)
+    """,  # NOQA: B950
+        )
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_debug_utils.py
+++ b/test/dynamo/test_debug_utils.py
@@ -1,0 +1,46 @@
+import torch
+from torch._dynamo import debug_utils
+from torch._dynamo.test_case import TestCase
+from functorch import make_fx
+
+class TestDebugUtils(TestCase):
+    def test_cast_model_to_fp64_dtype_args(self):
+        # Test that dtype arguments are converted to fp64
+
+        def fn(x):
+            return (
+                torch.ops.prims.convert_element_type(x, torch.float16),
+                x.to(torch.float16),
+                torch.full(x.shape, 2, dtype=torch.float32, device=x.device),
+                x.new_empty(x.shape),
+            )
+
+        x = torch.randn(32, device="cpu")
+        decomps = torch._decomp.core_aten_decompositions()
+        fx = make_fx(fn, decomposition_table=decomps)(x)
+
+        self.assertExpectedInline(fx.code.lstrip(), """\
+def forward(self, x_1):
+    convert_element_type = torch.ops.prims.convert_element_type.default(x_1, torch.float16)
+    _to_copy = torch.ops.aten._to_copy.default(x_1, dtype = torch.float16);  x_1 = None
+    full = torch.ops.aten.full.default([32], 2, dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
+    empty = torch.ops.aten.empty.memory_format([32], dtype = torch.float32, layout = torch.strided, device = device(type='cpu'), pin_memory = False)
+    return (convert_element_type, _to_copy, full, empty)
+    """)
+
+        fp64_model, fp64_examples = debug_utils.cast_to_fp64(fx, (x,))
+        self.assertEqual(fp64_examples, (x.to(torch.float64),))
+
+        self.assertExpectedInline(fx.code.lstrip(), """\
+def forward(self, x_1):
+    convert_element_type = torch.ops.prims.convert_element_type.default(x_1, torch.float64)
+    _to_copy = torch.ops.aten._to_copy.default(x_1, dtype = torch.float64);  x_1 = None
+    full = torch.ops.aten.full.default([32], 2, dtype = torch.float64, device = device(type='cpu'), pin_memory = False)
+    empty = torch.ops.aten.empty.memory_format([32], dtype = torch.float64, layout = torch.strided, device = device(type='cpu'), pin_memory = False)
+    return (convert_element_type, _to_copy, full, empty)
+    """)
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    run_tests()

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -411,9 +411,7 @@ def cast_dtype_args_to_fp64(model):
             assert len(node.args) == 2
             if is_float_dtype(node.args[1]) and node.args[1] != torch.float64:
                 node.args = (node.args[0], torch.float64)
-        if (
-            node.op == "call_function"
-        ):
+        if node.op == "call_function":
             dtype = node.kwargs.get("dtype")
             if dtype is not None and is_float_dtype(dtype):
                 new_kwargs = dict(node.kwargs)

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -402,7 +402,7 @@ def same_two_models(
     return passing
 
 
-def cast_convert_element_type_to_fp64(model):
+def cast_dtype_args_to_fp64(model):
     for node in model.graph.nodes:
         if (
             node.op == "call_function"
@@ -411,6 +411,15 @@ def cast_convert_element_type_to_fp64(model):
             assert len(node.args) == 2
             if is_float_dtype(node.args[1]) and node.args[1] != torch.float64:
                 node.args = (node.args[0], torch.float64)
+        if (
+            node.op == "call_function"
+        ):
+            dtype = node.kwargs.get("dtype")
+            if dtype is not None and is_float_dtype(dtype):
+                new_kwargs = dict(node.kwargs)
+                new_kwargs["dtype"] = torch.float64
+                node.kwargs = new_kwargs
+
     model.graph.lint()
     model.recompile()
     return model
@@ -422,8 +431,8 @@ def cast_to(dtype, model, inputs):
     model = model.to(dtype)
     if dtype == torch.float64:
         # If casting to fp64 for accuracy comparison, we need to
-        # take care of convert_element_type explicitly
-        model = cast_convert_element_type_to_fp64(model)
+        # replace dtype arguments embedded in the graph with fp64
+        model = cast_dtype_args_to_fp64(model)
 
     inputs = tree_map(
         lambda x: x.to(dtype)

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -443,38 +443,35 @@ def cat_slice_cat(match, cat_input, size, dim=1):
         )
 
 
-@register_graph_pattern(
+@register_lowering_pattern(
     CallFunction(
         aten.add,
         CallFunction(aten.mm, Arg(), Arg()),
         KeywordArg("inp"),
     ),
-    pass_dict=pass_patterns[2]
+    pass_number=2,
 )
-@register_graph_pattern(
+@register_lowering_pattern(
     CallFunction(
         aten.add,
         KeywordArg("inp"),
         CallFunction(aten.mm, Arg(), Arg()),
     ),
-    pass_dict=pass_patterns[2]
+    pass_number=2,
 )
 def addmm(match, mat1, mat2, inp):
-    if not isinstance(inp, torch.Tensor):
-        return  # inp is a Number
-
-    matched = len(inp.shape) <= 2
-    mm_shape = mat1.shape[0], mat2.shape[1]
-    for i, m in zip(inp.shape, mm_shape):
-        matched &= i == 1 or i == m
-    if not matched:
-        return
-
-    def repl(inp, mat1, mat2):
-        return aten.addmm(inp, mat1, mat2)
-
-    with V.fake_mode:
-        match.replace_by_example(repl, [inp, mat1, mat2])
+    if isinstance(inp, ir.TensorBox):
+        inp_shape = inp.get_size()
+        matched = len(inp_shape) <= 2
+        mm_shape = shape_of_mm(mat1, mat2)
+        for i, m in zip(inp_shape, mm_shape):
+            matched &= i == 1 or i == m
+    else:  # inp is a Number
+        matched = False
+    if matched:
+        return L[aten.addmm](inp, mat1, mat2)
+    else:
+        return L[aten.add](inp, L[aten.mm](mat1, mat2))
 
 
 def is_valid_splitwithsizes_cat(match):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #110235
* __->__ #110232

Generating reference outputs somtimes fails because of type mismatches in the graph,
an issue which was noticed previously for `prims.convert_element_type` and fixed in #92036
but the same issue happens with other functions such as tensor constructors.

This expands the fix from #92036 to all dtype keyword arguments.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler