### PR TITLE
[inductor] Make sure unfuse_addmm and addmm patterns don't overlap

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -328,28 +328,33 @@ class TestPaternMatcher(TestCase):
                 torch.randn(16, 16, device="cuda"),
                 torch.randn(16, 16, device="cuda"),
                 torch.randn(16, 16, device="cuda"),
+                True,
             ),
             (
                 torch.randn(16, 16, device="cuda"),
                 torch.randn(1, 16, device="cuda"),
                 torch.randn(16, 16, device="cuda"),
+                False,
             ),
             (
                 torch.randn(1, 16, 16, device="cuda"),
                 torch.randn(16, 16, device="cuda"),
                 torch.randn(16, 16, device="cuda"),
+                False
             ),
-            (4, torch.randn(16, 16, device="cuda"), torch.randn(16, 16, device="cuda")),
+            (4, torch.randn(16, 16, device="cuda"), torch.randn(16, 16, device="cuda"), False),
         ]
-        for args in args_list:
+        for a, b, c, should_fuse in args_list:
             torch._dynamo.reset()
             counters.clear()
+            args = (a, b, c)
             e1, e2 = fn(*args)
             a1, a2 = torch.compile(fn)(*args)
             torch.testing.assert_close(a1, e1)
             torch.testing.assert_close(a2, e2)
-            self.assertEqual(counters["inductor"]["pattern_matcher_count"], 2)
-            self.assertEqual(counters["inductor"]["pattern_matcher_nodes"], 4)
+            count, nodes = 2, 4 if should_fuse else 0, 0
+            self.assertEqual(counters["inductor"]["pattern_matcher_count"], count)
+            self.assertEqual(counters["inductor"]["pattern_matcher_nodes"], nodes)
 
     def test_cat_mm(self):
         def fn(a, b, c):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110235
* #110232

Inductor has two opposing patterns,
```
addmm -> add + mm
add + mm -> addmm
```

This uses the `extra_check` to disable the addmm fusion pattern when the
heuristic to unfuse add is met, for consistency.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler