### PR TITLE
[export] Add run_decomposition() function to ExportedProgram

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -8,8 +8,8 @@ import torch
 import torch._dynamo as torchdynamo
 from functorch.experimental.control_flow import map, cond
 from torch import Tensor
-from torch.export import Constraint
-from torch._export import DEFAULT_EXPORT_DYNAMO_CONFIG, dynamic_dim, export, capture_pre_autograd_graph
+from torch.export import Constraint, Dim, export
+from torch._export import DEFAULT_EXPORT_DYNAMO_CONFIG, dynamic_dim, capture_pre_autograd_graph, _export
 from torch._export.constraints import constrain_as_size, constrain_as_value
 from torch._export.utils import (
     get_buffer,
@@ -144,7 +144,7 @@ class TestExport(TestCase):
 
         orig_eager = MyModule()
         inps = torch.rand(2, 3), torch.rand(2, 3)
-        ep = export(
+        ep = _export(
             orig_eager,
             inps,
             {},
@@ -1448,6 +1448,62 @@ class TestExport(TestCase):
             TypeError, "Trying to flatten user inputs with exported input tree spec"
         ):
             exported_program(torch.rand(2, 3), torch.rand(2, 3))
+
+    def test_export_decomps_simple(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin = torch.nn.Linear(10, 1)
+
+            def forward(self, x):
+                return self.lin(x)
+
+        inp = (torch.randn(5, 10),)
+        m = M()
+        with unittest.mock.patch("torch._export.DECOMP_TABLE", None):
+            ep = export(m, inp)
+
+
+        FileCheck().check_count(
+            "torch.ops.aten.t.default", 1, exactly=True
+        ).run(ep.graph_module.code)
+        self.assertTrue(torch.allclose(ep(*inp), m(*inp)))
+
+        core_aten_ep = ep.run_decompositions()
+        FileCheck().check_count(
+            "torch.ops.aten.permute.default", 1, exactly=True
+        ).run(core_aten_ep.graph_module.code)
+        FileCheck().check_count(
+            "torch.ops.aten.t.default", 0, exactly=True
+        ).run(core_aten_ep.graph_module.code)
+        self.assertTrue(torch.allclose(core_aten_ep(*inp), m(*inp)))
+
+    def test_export_decomps_dynamic(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin = torch.nn.Linear(10, 1)
+
+            def forward(self, x):
+                return self.lin(x)
+
+        inp = (torch.randn(5, 10),)
+        m = M()
+        with unittest.mock.patch("torch._export.DECOMP_TABLE", None):
+            ep = export(m, inp, dynamic_shapes={"x": {0: Dim("batch")}})
+
+        core_aten_ep = ep.run_decompositions()
+
+        input_node = [node for node in core_aten_ep.graph.nodes if node.op == "placeholder"][-1]
+        self.assertTrue(isinstance(input_node.meta["val"].shape[0], torch.SymInt))
+
+        FileCheck().check_count(
+            "torch.ops.aten.permute.default", 1, exactly=True
+        ).run(core_aten_ep.graph_module.code)
+        FileCheck().check_count(
+            "torch.ops.aten.t.default", 0, exactly=True
+        ).run(core_aten_ep.graph_module.code)
+        self.assertTrue(torch.allclose(core_aten_ep(*inp), m(*inp)))
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/_export/passes/lift_constant_tensor_pass.py
+++ b/torch/_export/passes/lift_constant_tensor_pass.py
@@ -1,9 +1,12 @@
 import torch
-from torch._export import ExportedProgram
 from torch._guards import detect_fake_mode
 
 
-def lift_constant_tensor_pass(ep: ExportedProgram) -> ExportedProgram:
+def lift_constant_tensor_pass(ep):
+    """
+    Takes an ExportedProgram and returns the ExportedProgram modified in-place,
+    with the constant tensors as buffers.
+    """
     if len([node for node in ep.graph.nodes if node.op == "placeholder"]) == 0:
         return ep
 


### PR DESCRIPTION
Summary:
https://docs.google.com/document/d/1QJJEGnj2nHGPODlw38BEG3KLLCOTfdOVjPrNQbz_LM8/edit#bookmark=id.lp80wfshq130

`exported_program.run_decompositions(decomposition_table)` will optionally take a decomposition table, and run decompositions on the exported program, returning a new exported program. By default we will run the Core ATen decomposition table.

Splitting up this diff with the following one (D49742989) to make migrating Executorch easier:
1. Land this diff
1. Wait for a pytorch nightly to include this diff
1. Update executorch's pytorch nightly
1. Land the following diff to have export() return no decomps

Test Plan: Tested in following diff

Differential Revision: D49743208


