### PR TITLE
[ONNX] Replace torchscript with new graph building

### DIFF
--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -979,9 +979,7 @@ class Exporter:
                 onnxscript_graph.initializers = initializers_with_real_tensors
 
             # Export TorchScript graph to ONNX ModelProto.
-            onnx_model = onnxscript_graph.to_model_proto(
-                self.options.onnx_registry.opset_version,
-            )
+            onnx_model = onnxscript_graph.to_onnx_model()
 
             return torch.onnx.ExportOutput(
                 onnx_model,

--- a/torch/onnx/_internal/fx/type_utils.py
+++ b/torch/onnx/_internal/fx/type_utils.py
@@ -93,6 +93,11 @@ def from_scalar_type_to_torch_dtype(scalar_type: type) -> Optional[torch.dtype]:
     return _SCALAR_TYPE_TO_TORCH_DTYPE.get(scalar_type)
 
 
+# NOTE: from https://github.com/onnx/onnx/blob/main/onnx/mapping.py
+def from_torch_dtype_to_np_dtype(dtype: torch.dtype) -> numpy.dtype:
+    return _TORCH_DTYPE_TO_ONNX_NP_DTYPE[dtype]
+
+
 # NOTE: this is a mapping from torch dtype to a set of compatible onnx types
 # It's used in dispatcher to find the best match overload for the input dtypes
 _TORCH_DTYPE_TO_COMPATIBLE_ONNX_TYPE_STRINGS: Dict[
@@ -163,7 +168,7 @@ _TORCH_DTYPE_TO_ABBREVIATION = {
     torch.uint8: "u8",
 }
 
-_TORCH_DTYPE_TO_NUMPY_DTYPE = {
+_TORCH_DTYPE_TO_NUMPY_DTYPE: Dict[torch.dtype, type] = {
     torch.float16: numpy.float16,
     torch.float32: numpy.float32,
     torch.float64: numpy.float64,
@@ -173,6 +178,18 @@ _TORCH_DTYPE_TO_NUMPY_DTYPE = {
     torch.int32: numpy.int32,
     torch.int64: numpy.longlong,
     torch.bool: numpy.bool_,
+}
+
+_TORCH_DTYPE_TO_ONNX_NP_DTYPE: Dict[torch.dtype, numpy.dtype] = {
+    torch.float16: numpy.dtype("float16"),
+    torch.float32: numpy.dtype("float32"),
+    torch.float64: numpy.dtype("float64"),
+    torch.uint8: numpy.dtype("uint8"),
+    torch.int8: numpy.dtype("int8"),
+    torch.int16: numpy.dtype("int16"),
+    torch.int32: numpy.dtype("int32"),
+    torch.int64: numpy.dtype("int64"),
+    torch.bool: numpy.dtype("bool"),
 }
 
 _ONNX_TENSOR_ELEMENT_TYPE_TO_TORCH_DTYPE = {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110241

This PR works with https://github.com/microsoft/onnxscript/pull/1071, providing a general idea/starting point of new graph building without TorchScriptGraph. Tested with only `test_add` unittest case in `test_fx_to_onnx_onnxruntime.py`.

NOTE: still need to test with:
1. `add_module_call`
2. multiple outputs
3. initializers
4. sequence type and split node

More detail should be found in https://github.com/microsoft/onnxscript/pull/1071