### PR TITLE
Speed-up casts to FP8

### DIFF
--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -33,51 +33,61 @@ void float8_copy_kernel_cuda(TensorIteratorBase &iter) {
   ScalarType dtype = iter.dtype(0);
   ScalarType other_dtype = iter.dtype(1);
   if (dtype == kFloat8_e4m3fn) {
-    if (other_dtype == kFloat) {
-       gpu_kernel_nocast(iter, [] GPU_LAMBDA(float value) {
-           return Float8_e4m3fn(value);
-       });
-    } else if (other_dtype == kHalf) {
-       gpu_kernel_nocast(iter, [] GPU_LAMBDA(Half value) {
-           return Float8_e4m3fn(value);
-       });
-    } else if (other_dtype == kBFloat16) {
-       gpu_kernel_nocast(iter, [] GPU_LAMBDA(BFloat16 value) {
-           return Float8_e4m3fn(value);
-       });
-    } else {
-      gpu_kernel(iter, [] GPU_LAMBDA(Float8_e4m3fn x) { return x; });
+    switch (other_dtype) {
+      case kFloat:
+         gpu_kernel_nocast(iter, [] GPU_LAMBDA(float value) {
+             return Float8_e4m3fn(value);
+         });
+         break;
+      case kHalf:
+         gpu_kernel_nocast(iter, [] GPU_LAMBDA(Half value) {
+             return Float8_e4m3fn(value);
+         });
+         break;
+      case kBFloat16:
+         gpu_kernel_nocast(iter, [] GPU_LAMBDA(BFloat16 value) {
+             return Float8_e4m3fn(value);
+         });
+         break;
+      default:
+        gpu_kernel(iter, [] GPU_LAMBDA(Float8_e4m3fn x) { return x; });
+        break;
     }
   } else if (dtype == kFloat8_e5m2) {
-    if (other_dtype == kFloat) {
-       gpu_kernel_nocast(iter, [] GPU_LAMBDA(float value) {
+    switch (other_dtype) {
+      case kFloat:
+         gpu_kernel_nocast(iter, [] GPU_LAMBDA(float value) {
 #ifdef AT_USE_NV_CVT_INTRINSICS
-           const auto x =  __nv_cvt_float_to_fp8(value, __NV_NOSAT, __NV_E5M2);
-           return Float8_e5m2(x, Float8_e5m2::from_bits());
+             const auto x =  __nv_cvt_float_to_fp8(value, __NV_NOSAT, __NV_E5M2);
+             return Float8_e5m2(x, Float8_e5m2::from_bits());
 #else
-           return Float8_e5m2(value);
+             return Float8_e5m2(value);
 #endif
-       });
-    } else if (other_dtype == kHalf) {
-       gpu_kernel_nocast(iter, [] GPU_LAMBDA(Half value) {
+         });
+         break;
+      case kHalf:
+         gpu_kernel_nocast(iter, [] GPU_LAMBDA(Half value) {
 #ifdef AT_USE_NV_CVT_INTRINSICS
-           const auto x =  __nv_cvt_halfraw_to_fp8(static_cast<__half>(value), __NV_NOSAT, __NV_E5M2);
-           return Float8_e5m2(x, Float8_e5m2::from_bits());
+             const auto x =  __nv_cvt_halfraw_to_fp8(static_cast<__half>(value), __NV_NOSAT, __NV_E5M2);
+             return Float8_e5m2(x, Float8_e5m2::from_bits());
 #else
-           return Float8_e5m2(value);
+             return Float8_e5m2(value);
 #endif
-       });
-    } else if (dtype == kFloat8_e5m2 && other_dtype == kBFloat16) {
-       gpu_kernel_nocast(iter, [] GPU_LAMBDA(BFloat16 value) {
+         });
+         break;
+      case kBFloat16:
+         gpu_kernel_nocast(iter, [] GPU_LAMBDA(BFloat16 value) {
 #ifdef AT_USE_NV_CVT_INTRINSICS
-           const auto x =  __nv_cvt_bfloat16raw_to_fp8(static_cast<__nv_bfloat16>(value), __NV_NOSAT, __NV_E5M2);
-           return Float8_e5m2(x, Float8_e5m2::from_bits());
+             const auto x =  __nv_cvt_bfloat16raw_to_fp8(static_cast<__nv_bfloat16>(value), __NV_NOSAT, __NV_E5M2);
+             return Float8_e5m2(x, Float8_e5m2::from_bits());
 #else
-           return Float8_e5m2(value);
+             return Float8_e5m2(value);
 #endif
-       });
-    } else {
-        gpu_kernel(iter, [] GPU_LAMBDA(Float8_e5m2 x) { return x; });
+         });
+         break;
+      default:
+         gpu_kernel(iter, [] GPU_LAMBDA(Float8_e5m2 x) { return x; });
+         break;
     }
   } else {
     TORCH_CHECK(false, "This supposed ot be called only for Float8 types");

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -34,6 +34,7 @@ void float8_copy_kernel_cuda(TensorIteratorBase &iter) {
   ScalarType other_dtype = iter.dtype(1);
   if (dtype == kFloat8_e4m3fn) {
     switch (other_dtype) {
+#if !defined(USE_ROCM)
       case kFloat:
          gpu_kernel_nocast(iter, [] GPU_LAMBDA(float value) {
              return Float8_e4m3fn(value);
@@ -49,12 +50,14 @@ void float8_copy_kernel_cuda(TensorIteratorBase &iter) {
              return Float8_e4m3fn(value);
          });
          break;
+#endif /* !defined(USE_ROCM) */
       default:
         gpu_kernel(iter, [] GPU_LAMBDA(Float8_e4m3fn x) { return x; });
         break;
     }
   } else if (dtype == kFloat8_e5m2) {
     switch (other_dtype) {
+#if !defined(USE_ROCM)
       case kFloat:
          gpu_kernel_nocast(iter, [] GPU_LAMBDA(float value) {
 #ifdef AT_USE_NV_CVT_INTRINSICS
@@ -85,6 +88,7 @@ void float8_copy_kernel_cuda(TensorIteratorBase &iter) {
 #endif
          });
          break;
+#endif /* !defined(USE_ROCM) */
       default:
          gpu_kernel(iter, [] GPU_LAMBDA(Float8_e5m2 x) { return x; });
          break;


### PR DESCRIPTION
Unlike half/bfloat16 casts, where entire model is cast to half-precision floats, only parts of the network can be in float8 and therefore performance of the casts is important.

Speedup casts by implementing non-dynamically castable variants using new refactored `gpu_kernel_nocast` template.

Mesaure performance using the following script:
```python
import torch

def run_cast_bench(size=(10000, 10000), src_dtype=torch.float16, dtype=torch.float8_e5m2):
    x=torch.rand(size, device="cuda", requires_grad=False, dtype=src_dtype)
    z=torch.empty(size, device="cuda", dtype=dtype, requires_grad=False)
    with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CUDA]) as prof:
        z.copy_(x)
    rc=prof.key_averages()
    print(f"Running bench for src_dtype={src_dtype} dst_dtype={dtype} cuda_time={rc[1].cuda_time}")

if __name__ == "__main__":
    for dtype in [torch.float8_e5m2, torch.float8_e4m3fn]:
        run_cast_bench(src_dtype=torch.half, dtype=dtype)
        run_cast_bench(src_dtype=torch.float, dtype=dtype)
        run_cast_bench(src_dtype=torch.bfloat16, dtype=dtype)
```

Below are before and after results:
|  Cast type | After | Before |
| ---------- | ------ | ----- |
| fp32->e5m2 | 228 us | 336 us|
| fp16->e5m2 | 150 us | 323 us|
| bf16->e5m2 | 150 us | 322 us|
| fp32->e4m3 | 227 us | 331 us|
| fp16->e4m3 | 148 us | 318 us|
| bf16->e4m3 | 149 us | 318 us|

Skip the optimizations on ROCm platform
TODO:
 - Investigate why `__nv_cvt` intrinsics defined in https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__FP8__MISC.html end up being slower
