### PR TITLE
Clean up test_external_module_register

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -806,7 +806,7 @@ class DummyXPUModule:
 
 
 class TestExtensionUtils(TestCase):
-    @unittest.skip("TODO: somehow unregister xpu")
+    @unittest.skip("See https://github.com/pytorch/pytorch/pull/110254")
     def test_external_module_register(self):
         # Built-in module
         with self.assertRaisesRegex(RuntimeError, "The runtime module of"):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -806,6 +806,13 @@ class DummyXPUModule:
 
 
 class TestExtensionUtils(TestCase):
+    def tearDown(self):
+        # Clean up from test_external_module_register
+        if hasattr(torch, "xpu"):
+            delattr(torch, "xpu")
+        if "torch.xpu" in sys.modules:
+            del sys.modules["torch.xpu"]
+
     def test_external_module_register(self):
         # Built-in module
         with self.assertRaisesRegex(RuntimeError, "The runtime module of"):
@@ -825,10 +832,6 @@ class TestExtensionUtils(TestCase):
         # No supporting for override
         with self.assertRaisesRegex(RuntimeError, "The runtime module of"):
             torch._register_device_module('xpu', DummyXPUModule)
-
-        # Clean up
-        delattr(torch, "xpu")
-        del sys.modules["torch.xpu"]
 
     def test_external_module_and_backend_register(self):
         torch.utils.rename_privateuse1_backend('foo')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -806,7 +806,6 @@ class DummyXPUModule:
 
 
 class TestExtensionUtils(TestCase):
-    @unittest.skip("See https://github.com/pytorch/pytorch/pull/110254")
     def test_external_module_register(self):
         # Built-in module
         with self.assertRaisesRegex(RuntimeError, "The runtime module of"):
@@ -826,6 +825,10 @@ class TestExtensionUtils(TestCase):
         # No supporting for override
         with self.assertRaisesRegex(RuntimeError, "The runtime module of"):
             torch._register_device_module('xpu', DummyXPUModule)
+
+        # Clean up
+        delattr(torch, "xpu")
+        del sys.modules["torch.xpu"]
 
     def test_external_module_and_backend_register(self):
         torch.utils.rename_privateuse1_backend('foo')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -806,6 +806,7 @@ class DummyXPUModule:
 
 
 class TestExtensionUtils(TestCase):
+    @unittest.skip("TODO: somehow unregister xpu")
     def test_external_module_register(self):
         # Built-in module
         with self.assertRaisesRegex(RuntimeError, "The runtime module of"):


### PR DESCRIPTION
caused by #109866

The test registers new device module, the above pr checks for xpu, sees that it got registered and uses it but its a dummy module.

This causes any test after it to fail so I "clean up" the registered module

Another possible solution would be to run this test last lol