### PR TITLE
TD: Fix sorting bug for historical correlations heuristic

### DIFF
--- a/tools/testing/target_determination/heuristics/correlated_with_historical_failures.py
+++ b/tools/testing/target_determination/heuristics/correlated_with_historical_failures.py
@@ -47,5 +47,5 @@ def _get_file_rating_tests() -> List[str]:
     for file in changed_files:
         for test_file, score in test_file_ratings.get(file, {}).items():
             ratings[test_file] += score
-    prioritize = sorted(ratings, key=lambda x: ratings[x])
+    prioritize = sorted(ratings, key=lambda x: -ratings[x])
     return prioritize


### PR DESCRIPTION
Fix bug where the historical correlations heuristic currently sorts heuristics in the opposite order, ranking the least relevant tests most highly

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 70333d1</samp>

> _`test_files` sorted_
> _by ratings, high to low_
> _a faster spring test_