### PR TITLE
[S366352] Avoid creating ncclStartEvent for deadlocking

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -647,7 +647,7 @@ ProcessGroupNCCL::ProcessGroupNCCL(
   desyncDebug_ = parseEnvVarFlag(NCCL_DESYNC_DEBUG) ||
       (dist_debug_level_ >= DebugLevel::Detail);
 #ifdef ENABLE_NCCL_ERROR_CHECKING
-  enableTiming_.store(parseEnvVarFlag(NCCL_ENABLE_TIMING) || desyncDebug_);
+  enableTiming_.store(parseEnvVarFlag(NCCL_ENABLE_TIMING));
 #endif
   avoidRecordStreams_ = parseEnvVarFlag(TORCH_NCCL_AVOID_RECORD_STREAMS);
 


### PR DESCRIPTION
Summary: enableTiming will make us create one more cudaEvent per collective: https://fburl.com/code/6hqzik63. From S366352, it looks we run into deadlock in cudaEventDestroy() so reducing the number of events may help. Also I don't really see ncclStartEvent used anywhere for desyncDebug.

Test Plan: sandcastle

Differential Revision: D49760869


