### PR TITLE
[AOTInductor] Initial functionality for Inf and NaN checker

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -161,22 +161,25 @@ def check_model_with_multiple_inputs(
     self.assertTrue(same(list_actual, list_expected))
 
 
+class SimpleLinear(torch.nn.Module):
+    def __init__(self, w_dims):
+        super().__init__()
+        self.weight = torch.randn(*w_dims, device="cuda")
+
+    def forward(self, x, y):
+        return x + torch.nn.functional.linear(y, self.weight)
+
+
 @unittest.skipIf(IS_FBCODE, "cpp extension doesn't work in fbcode CI")
 class AOTInductorTestsTemplate:
     def test_simple(self):
-        class Repro(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.weight = torch.randn(10, 10, device="cuda")
-
-            def forward(self, x, y):
-                return x + torch.nn.functional.linear(y, self.weight)
+        model = SimpleLinear((10, 10))
 
         example_inputs = (
             torch.randn(10, 10, device="cuda"),
             torch.randn(10, 10, device="cuda"),
         )
-        self.check_model(Repro(), example_inputs)
+        self.check_model(model, example_inputs)
 
     def test_simple_cpu(self):
         class Repro(torch.nn.Module):
@@ -223,19 +226,50 @@ class AOTInductorTestsTemplate:
         self.check_model(Repro(), example_inputs)
 
     def test_large(self):
-        class Repro(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.weight = torch.randn(250112, 512, device="cuda")
-
-            def forward(self, x, y):
-                return x + torch.nn.functional.linear(y, self.weight)
+        model = SimpleLinear((250112, 512))
 
         example_inputs = (
             torch.randn(1, 250112, device="cuda"),
             torch.randn(1, 512, device="cuda"),
         )
         self.check_model(Repro(), example_inputs)
+
+    @unittest.skip("Skip this test, only for local test. SIGABRT is produced.")
+    def test_inf(self):
+        model = SimpleLinear((10, 10))
+
+        x = torch.randn(10, 10, device="cuda")
+        x[0][0] = float("Inf")
+        example_inputs = (
+            x,
+            torch.randn(1, 10, device="cuda"),
+        )
+        expected = model(*example_inputs)
+        actual = AOTInductorModelRunner.run(
+            model,
+            example_inputs,
+            expected,
+            options={"debug_check_inf_and_nan": True},
+        )
+        self.assertTrue(same(actual, expected))
+
+    @unittest.skip("Skip this test, only for local test. SIGABRT is produced.")
+    def test_nan(self):
+        model = SimpleLinear((10, 10))
+
+        x = torch.randn(10, 10, device="cuda")
+        x[0][0] = float("nan")
+        example_inputs = (
+            x,
+            torch.randn(1, 10, device="cuda"),
+        )
+        expected = model(*example_inputs)
+        actual = AOTInductorModelRunner.run(
+            model,
+            example_inputs,
+            expected,
+            options={"debug_check_inf_and_nan": True},
+        )
 
     def test_with_offset(self):
         class Repro(torch.nn.Module):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -6,6 +6,9 @@ import torch
 # add some debug printouts
 debug = False
 
+# add inf and NaN checkers
+debug_check_inf_and_nan = False
+
 # Whether to disable a progress bar for autotuning
 disable_progress = True
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1859,6 +1859,9 @@ class Scheduler:
                 assert isinstance(node, NopKernelSchedulerNode)
                 node.allocate()
 
+            if config.debug_check_inf_and_nan:
+                V.graph.wrapper_code.generate_inf_and_nan_checker(node)
+
             if config.triton.debug_sync_kernel:
                 self.get_backend(device).codegen_sync()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110274

Summary:
Add initial functionality for Inf and NaN checker for AOTInductor.

Test Plan:
Included in commit. Skipped for CI as SIGABRT can't be captured by pytest.

Reviewers:

Subscribers:

Tasks:

Tags:

cc voznesenskym penguinwu EikanWang jgong5 Guobing-Chen XiaobingSuper zhuhaozhe blzheng Xia-Weiwen wenzhe-nrv jiayisunx peterbell10 ipiszy ngimel yf225 chenyang78 kadeng aakhundov

Differential Revision: [D49379751](https://our.internmc.facebook.com/intern/diff/D49379751)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @aakhundov @ColinPeppler