### PR TITLE
dynamic_shapes + retrace exported program

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1255,9 +1255,7 @@ class TestExport(TestCase):
             torch._dynamo.exc.UserError,
             "Cannot provide constraints for already exported program.",
         ):
-            _ = torch.export.export(
-                exported, (inp,), dynamic_shapes={"args": [{0: dim0_x}]}
-            )
+            _ = torch.export.export(exported, (inp,), dynamic_shapes={"x": {0: dim0_x}})
         # Reexported program should still work for dynamic shapes.
         reexported = torch.export.export(exported, (inp,))
         self.assertTrue(reexported(torch.ones(7, 5)), Foo()(torch.ones(7, 5)))


### PR DESCRIPTION
An `ExportedProgram`'s `__call__` signature is different from the original module, so `dynamic_shapes` that follow the original signature would fail when applied to re-export an `ExportedProgram`.

This PR fixes this issue, in other words, the original `dynamic_shapes` should now work when re-exporting.

Differential Revision: D49764011


