### PR TITLE
Allow nn.Transformer to be exported as ONNX.

### DIFF
--- a/test/onnx/test_pytorch_onnx_no_runtime.py
+++ b/test/onnx/test_pytorch_onnx_no_runtime.py
@@ -774,6 +774,20 @@ class TestONNXExport(pytorch_test_common.ExportTestCase):
         with warnings.catch_warnings(record=True):
             torch.onnx.export(MyDrop(), (eg,), f, verbose=False)
 
+    def test_transformer(self):
+        model = torch.nn.Transformer(
+            d_model=16,
+            nhead=4,
+            num_encoder_layers=1,
+            num_decoder_layers=1,
+            batch_first=False,
+        )
+        src = torch.randn(3, 1, 16, dtype=torch.float32)
+        tgt = torch.randn(5, 1, 16, dtype=torch.float32)
+        f = io.BytesIO()
+        with warnings.catch_warnings(record=True):
+            torch.onnx.export(model, ({"src": src, "tgt": tgt},), f, verbose=False)
+
     def test_pack_padded_pad_packed_trace(self):
         from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5192,6 +5192,9 @@ def multi_head_attention_forward(
           :math:`S` is the source sequence length. If ``average_attn_weights=False``, returns attention weights per
           head of shape :math:`(num_heads, L, S)` when input is unbatched or :math:`(N, num_heads, L, S)`.
     """
+    # Ensure that `is_causal` is an actual bool and not a tensor containing a bool, which happens during tracing.
+    is_causal = bool(is_causal)
+
     tens_ops = (query, key, value, in_proj_weight, in_proj_bias, bias_k, bias_v, out_proj_weight, out_proj_bias)
     if has_torch_function(tens_ops):
         return handle_torch_function(


### PR DESCRIPTION
Fixes #110255.

During ONNX export tracing, the `is_causal` parameter is not actually a `bool` but instead `tensor(bool)`. The native function `scaled_dot_product_attention` does not seem to handle this case, so we can just cast it to a Python `bool` for now.
