### PR TITLE
Fix type promotion of float8_e5m2 and float8_e4m3fn

### DIFF
--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -46,15 +46,15 @@ namespace c10 {
   _(c10::quint8, QUInt8) /* 13 */                        \
   _(c10::qint32, QInt32) /* 14 */                        \
   _(at::BFloat16, BFloat16) /* 15 */                     \
-  _(c10::quint4x2, QUInt4x2) /* 16 */                    \
-  _(c10::quint2x4, QUInt2x4) /* 17 */                    \
-  _(c10::bits1x8, Bits1x8) /* 18 */                      \
-  _(c10::bits2x4, Bits2x4) /* 19 */                      \
-  _(c10::bits4x2, Bits4x2) /* 20 */                      \
-  _(c10::bits8, Bits8) /* 21 */                          \
-  _(c10::bits16, Bits16) /* 22 */                        \
-  _(c10::Float8_e5m2, Float8_e5m2) /* 23 */              \
-  _(c10::Float8_e4m3fn, Float8_e4m3fn) /* 24 */
+  _(c10::Float8_e5m2, Float8_e5m2) /* 16 */              \
+  _(c10::Float8_e4m3fn, Float8_e4m3fn) /* 17 */          \
+  _(c10::quint4x2, QUInt4x2) /* 18 */                    \
+  _(c10::quint2x4, QUInt2x4) /* 19 */                    \
+  _(c10::bits1x8, Bits1x8) /* 20 */                      \
+  _(c10::bits2x4, Bits2x4) /* 21 */                      \
+  _(c10::bits4x2, Bits4x2) /* 22 */                      \
+  _(c10::bits8, Bits8) /* 23 */                          \
+  _(c10::bits16, Bits16) /* 24 */
 
 // If you want to support ComplexHalf for real, add ComplexHalf
 // into this macro (and change the name).  But beware: convert()

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -46,15 +46,15 @@ namespace c10 {
   _(c10::quint8, QUInt8) /* 13 */                        \
   _(c10::qint32, QInt32) /* 14 */                        \
   _(at::BFloat16, BFloat16) /* 15 */                     \
-  _(c10::Float8_e5m2, Float8_e5m2) /* 16 */              \
-  _(c10::Float8_e4m3fn, Float8_e4m3fn) /* 17 */          \
-  _(c10::quint4x2, QUInt4x2) /* 18 */                    \
-  _(c10::quint2x4, QUInt2x4) /* 19 */                    \
-  _(c10::bits1x8, Bits1x8) /* 20 */                      \
-  _(c10::bits2x4, Bits2x4) /* 21 */                      \
-  _(c10::bits4x2, Bits4x2) /* 22 */                      \
-  _(c10::bits8, Bits8) /* 23 */                          \
-  _(c10::bits16, Bits16) /* 24 */
+  _(c10::quint4x2, QUInt4x2) /* 16 */                    \
+  _(c10::quint2x4, QUInt2x4) /* 17 */                    \
+  _(c10::bits1x8, Bits1x8) /* 18 */                      \
+  _(c10::bits2x4, Bits2x4) /* 19 */                      \
+  _(c10::bits4x2, Bits4x2) /* 20 */                      \
+  _(c10::bits8, Bits8) /* 21 */                          \
+  _(c10::bits16, Bits16) /* 22 */                        \
+  _(c10::Float8_e5m2, Float8_e5m2) /* 23 */              \
+  _(c10::Float8_e4m3fn, Float8_e4m3fn) /* 24 */
 
 // If you want to support ComplexHalf for real, add ComplexHalf
 // into this macro (and change the name).  But beware: convert()
@@ -510,6 +510,19 @@ static inline ScalarType promoteTypes(ScalarType a, ScalarType b) {
     return a;
   } else if (isBitsType(a) || isBitsType(b)) {
     return ScalarType::Undefined;
+  }
+
+  // To avoid 7 rows/cols consiting only of Undefined promotion
+  // related to qints and bits between bfloat16 and float8 dtypes,
+  // below ScalarTypes are decreased by 7.
+  // TODO since more dtypes will probably be added in future,
+  // it's worth to generalize this solution or come up with different one.
+  if (isFloat8Type(a)) {
+    a = static_cast<ScalarType>(static_cast<int>(a) - 7);
+  }
+
+  if (isFloat8Type(b)) {
+    b = static_cast<ScalarType>(static_cast<int>(b) - 7);
   }
 
   // Ignore the 5 bits types, since they are handled by the if statement

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -678,10 +678,13 @@ class TestTypePromotion(TestCase):
         self.assertEqual(torch.promote_types(torch.float, torch.int), torch.float)
         self.assertEqual(torch.promote_types(torch.float, torch.double), torch.double)
         self.assertEqual(torch.promote_types(torch.int, torch.uint8), torch.int)
+        self.assertEqual(torch.promote_types(torch.float8_e5m2, torch.float), torch.float)
+        self.assertEqual(torch.promote_types(torch.float, torch.float8_e4m3fn), torch.float)
 
     @float_double_default_dtype
     def test_promote_self(self, device):
-        for dtype in all_types_and_complex_and(torch.half, torch.bfloat16, torch.chalf, torch.bool):
+        for dtype in all_types_and_complex_and(torch.half, torch.bfloat16, torch.chalf, torch.bool,
+                                               torch.float8_e5m2, torch.float8_e4m3fn):
             self.assertEqual(torch.promote_types(dtype, dtype), dtype)
 
     @expectedFailureMeta

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -198,6 +198,14 @@ class _StorageBase:
         """Casts this storage to complex float type"""
         return self._to(torch.cfloat)
 
+    def float8_e5m2(self):
+        """Casts this storage to float8_e5m2 type"""
+        return self._to(torch.float8_e5m2)
+
+    def float8_e4m3fn(self):
+        """Casts this storage to float8_e4m3fn type"""
+        return self._to(torch.float8_e4m3fn)
+
     def is_pinned(self, device: Union[str, torch.device] = 'cuda'):
         r"""Determine whether the CPU storage is already pinned on device.
 
@@ -1026,6 +1034,16 @@ class TypedStorage:
         """Casts this storage to complex float type"""
         _warn_typed_storage_removal()
         return self._to(torch.cfloat)
+
+    def float8_e5m2(self):
+        """Casts this storage to float8_e5m2 type"""
+        _warn_typed_storage_removal()
+        return self._to(torch.float8_e5m2)
+
+    def float8_e4m3fn(self):
+        """Casts this storage to float8_e4m3fn type"""
+        _warn_typed_storage_removal()
+        return self._to(torch.float8_e4m3fn)
 
     @classmethod
     def from_file(cls, filename, shared, size):


### PR DESCRIPTION
There is an issue with float8 type promotion, because _promoteTypesLookup doesn't contain records for few types between bfloat16 and float8.
I have simply moved float8 types just after bfloat16, however I'm not sure if it doesn't break serialization.

Please, decide if it can stay like this, or should I insert missing records filled with "ud" into _promoteTypesLookup instead of moving types.

cc @vkuzo @albanD 