### PR TITLE
[fuzzing result][fuzz_torch_jit_lite_interpreter] read-heap-use-after-free (size 8) in std::_Function_base::_M_empty()

### DIFF
--- a/torch/csrc/jit/mobile/interpreter.cpp
+++ b/torch/csrc/jit/mobile/interpreter.cpp
@@ -128,7 +128,10 @@ bool InterpreterState::run(Stack& stack) {
               mobile_debug_info->setOpIdx(pc);
             }
           }
-
+          if (inst.X < 0 ||
+              static_cast<size_t>(inst.X) >= code.operators_.size()) {
+            throw JITException("Invalid OP Instruction");
+          }
           RECORD_EDGE_SCOPE_WITH_DEBUG_HANDLE_AND_INPUTS(
               code.op_names_[inst.X].name, debug_handle, stack);
           code.operators_[inst.X](stack);


### PR DESCRIPTION
Summary: This diff fixes a heap UAF found by fuzzing in torch/csrc/jit/mobile/interpreter.cpp

Test Plan:
CI and
```
arc lionhead crash reproduce 1009060456885023
```
doesn't crash anymore.

Reviewed By: malfet

Differential Revision: D49538326


