### PR TITLE
One more small Perf Tweak to fill_

### DIFF
--- a/aten/src/ATen/native/Fill.cpp
+++ b/aten/src/ATen/native/Fill.cpp
@@ -57,6 +57,9 @@ Tensor& fill_(Tensor& self, const Tensor& value) {
   TORCH_CHECK(value.dim() == 0, "fill_ only supports 0-dimension value tensor but got tensor with ", value.dim(), " dimensions.");
   // Check if value is a view of self and if it is we clone
   // it to avoid overwriting self prematurely
+  if (self.device() != value.device()){
+    return fill_out(self, value.item());
+  }
   if(self.is_alias_of(value)) {
     self.copy_(value.clone());
   } else{

--- a/aten/src/ATen/native/Fill.cpp
+++ b/aten/src/ATen/native/Fill.cpp
@@ -55,11 +55,11 @@ Tensor& fill_quantized_(Tensor& self, const Scalar& value) {
 
 Tensor& fill_(Tensor& self, const Tensor& value) {
   TORCH_CHECK(value.dim() == 0, "fill_ only supports 0-dimension value tensor but got tensor with ", value.dim(), " dimensions.");
-  // Check if value is a view of self and if it is we clone
-  // it to avoid overwriting self prematurely
   if (self.device() != value.device()){
     return fill_out(self, value.item());
   }
+  // Check if value is a view of self and if it is we clone
+  // it to avoid overwriting self prematurely
   if(self.is_alias_of(value)) {
     self.copy_(value.clone());
   } else{


### PR DESCRIPTION
# Summary
Perf win by check which device tensors are on

## Before this PR:
``` Shell
CPU | CPU: 1.3328152848407626
GPU | GPU: 6.614773320034146
CPU | GPU: 29.027153505012393
GPU | CPU: 17.22372299991548
```
## After this PR
``` Shell
CPU | CPU: 1.4241038949694484
GPU | GPU: 7.060713530518115
CPU | GPU: 15.149936103262007
GPU | CPU: 5.774620908778161
```

#### Repro Script
``` Python
    a = torch.tensor([0.2, 0.5], device="cpu")
    amax = torch.tensor(0.5, device="cpu")  
    print(f"CPU | CPU: {benchmark_torch_function_in_microseconds(torch.fill_, a, amax)}")

    a = torch.tensor([0.2, 0.5], device="cuda")
    amax = torch.tensor(0.5, device="cuda")
    print(f"GPU | GPU: {benchmark_torch_function_in_microseconds(torch.fill_, a, amax)}")

    a = torch.tensor([0.2, 0.5], device="cpu")
    amax = torch.tensor(0.5, device="cuda")
    print(f"CPU | GPU: {benchmark_torch_function_in_microseconds(torch.fill_, a, amax)}")

    a = torch.tensor([0.2, 0.5], device="cuda")
    amax = torch.tensor(0.5, device="cpu")
    print(f"GPU | CPU: {benchmark_torch_function_in_microseconds(torch.fill_, a, amax)}")
```