### PR TITLE
[aotinductor] Fix a bug post_grad when suffix copy_ to an attribute

### DIFF
--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -164,8 +164,10 @@ def constant_fold_uniform_value(gm: torch.fx.GraphModule):
     for node, value in node_replacements.items():
         # we dont have a functional way right now of instantiating a non-contiguous tensor with full/zeros/ones right now
         # hasn't shown up to be important yet
-        fake_tensor = node.meta["val"]
-        if not fake_tensor.is_contiguous(memory_format=torch.contiguous_format):
+        fake_tensor = node.meta.get("val", None)
+        if fake_tensor is None or not fake_tensor.is_contiguous(
+            memory_format=torch.contiguous_format
+        ):
             continue
 
         if constant_data_ptr_count[cf.constant_data_ptrs[node]] > 1:

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -646,6 +646,9 @@ def reinplace_scatters(graph):
     for node in reversed(graph.nodes):
         storage_to_nodes[get_node_storage(node)].append(node)
         if node.target == aten.copy_.default:
+            if node.args[0].op == "get_attr":
+                # skip mutation to attributes
+                continue
             copy_args_to_copy_nodes[(node.args[0], node.args[1])] = node
             assert node.args[0].op == "placeholder"
             mutated_inputs.add(node.args[0])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110297

Summary: Skip reinplace_scatters on ops copy_ to attributes. This fixes https://github.com/pytorch/pytorch/issues/110304.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler