### PR TITLE
[BE] Use `std::make_unique`

### DIFF
--- a/aten/src/ATen/native/cpu/AdaptiveAvgPoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/AdaptiveAvgPoolKernel.cpp
@@ -181,7 +181,7 @@ void cpu_adaptive_avg_pool_channels_last<BFloat16>(
 
     // temp buffer for sum, use float as accumulation type
     // can't reuse output buffer to store sum since it is BFloat16
-    std::unique_ptr<float []> sum_arr(new float[channels]);
+    auto sum_arr = std::make_unique<float []>(channels);
     float* sum = sum_arr.get();
 
     for (const auto i : c10::irange(begin, end)) {

--- a/aten/src/ATen/native/cpu/AdaptiveMaxPoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/AdaptiveMaxPoolKernel.cpp
@@ -121,7 +121,7 @@ void cpu_adaptive_max_pool_channels_last(
     int64_t size = channels;
     int64_t len = size - (size % Vec::size());
     // temp buffer holding index with integer_t
-    std::unique_ptr<integer_t []> index_buffer(new integer_t[len]);
+    auto index_buffer = std::make_unique<integer_t []>(len);
 
     for (const auto i : c10::irange(begin, end)) {
       int64_t ih0 = start_index(oh, output_height, input_height);
@@ -235,9 +235,9 @@ void cpu_adaptive_max_pool_channels_last<BFloat16>(
     int64_t size = channels;
     int64_t len = size - (size % bVec::size());
     // temp buffer holding index with integer_t
-    std::unique_ptr<int32_t []> index_buffer(new int32_t[len]);
+    auto index_buffer = std::make_unique<int32_t []>(len);
     // temp buffer holding max value with float
-    std::unique_ptr<float []> max_arr(new float[size]);
+    auto max_arr = std::make_unique<float []>(size);
     float* max = max_arr.get();
 
     for (const auto i : c10::irange(begin, end)) {

--- a/aten/src/ATen/native/cpu/AvgPoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/AvgPoolKernel.cpp
@@ -244,7 +244,7 @@ void cpu_avg_pool_channels_last<BFloat16>(
 
     // temp buffer for sum, use float as accumulation type
     // can't reuse output buffer to store sum since it is BFloat16
-    std::unique_ptr<float []> sum_arr(new float[channels]);
+    auto sum_arr = std::make_unique<float []>(channels);
     float* sum = sum_arr.get();
 
     int64_t size = channels;

--- a/aten/src/ATen/native/cpu/MaxPoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/MaxPoolKernel.cpp
@@ -422,8 +422,7 @@ void cpu_max_pool_channels_last(
     int64_t size = channels;
     int64_t len = size - (size % Vec::size());
     // temp buffer holding index with integer_t
-    // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
-    std::unique_ptr<integer_t []> index_buffer(new integer_t[len]);
+    auto index_buffer = std::make_unique<integer_t []>(len);
     integer_t * index_ptr = index_buffer.get();
     // temp buffer holding max value with opmath_t
     std::unique_ptr<opmath_t []> max_arr;

--- a/aten/src/ATen/native/cpu/PixelShuffleKernel.cpp
+++ b/aten/src/ATen/native/cpu/PixelShuffleKernel.cpp
@@ -74,7 +74,7 @@ void cpu_pixel_shuffle_channels_last(
   using Vec = vec::Vectorized<scalar_t>;
   at::parallel_for(0, nbatch * height, 0, [&](int64_t begin, int64_t end) {
     // temp buffer holding each channel lane
-    std::unique_ptr<scalar_t []> buffer(new scalar_t[channels]);
+    auto buffer = std::make_unique<scalar_t []>(channels);
     scalar_t* buffer_ptr = buffer.get();
 
     int64_t n{0}, h{0};


### PR DESCRIPTION
Since C++14 `std::unique_ptr<type_t[]> x(new type_t[NUM])` is identical to `auto x = std::make_unique<type_t[]>(NUM);`

Leave two `std::unique_ptr<float[]> arr(new float[NUM]());` as statement not just allocates, but initializes it as well, se e below:
https://github.com/pytorch/pytorch/blob/d04b35e7e31547c3cdb9684e1dd0b556bf593a93/aten/src/ATen/native/cpu/SoftMaxKernel.cpp#L700-L701

On the other hand, from https://github.com/pytorch/pytorch/pull/60371 it's not at all clear, if it needs to be initialized to zero at that point...


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10