### PR TITLE
Fix for out of bounds registers_ access in mobile TorchScript interpreter

### DIFF
--- a/torch/csrc/jit/mobile/interpreter.cpp
+++ b/torch/csrc/jit/mobile/interpreter.cpp
@@ -395,6 +395,8 @@ bool InterpreterState::run(Stack& stack) {
 }
 
 IValue& InterpreterState::reg(size_t reg) {
+  TORCH_CHECK(
+      reg > 0 && reg <= registers_.size(), "Invalid register index: ", reg);
   return *(registers_.end() - reg);
 }
 


### PR DESCRIPTION
Summary:
The TorchScript interpreter had multiple opcodes whose logic had the potential to access the registers_ array out of bounds.

This change ensures that all registers_ accesses are in bounds or an exception will be thrown.

Test Plan: contbuild + OSS signals

Differential Revision: D49748737


