### PR TITLE
Fix for out of bounds read in mobile interpreter INTERFACE_CALL opcode handler

### DIFF
--- a/torch/csrc/jit/mobile/interpreter.cpp
+++ b/torch/csrc/jit/mobile/interpreter.cpp
@@ -159,6 +159,15 @@ bool InterpreterState::run(Stack& stack) {
               static_cast<size_t>(inst.X) >= code.constants_.size()) {
             TORCH_CHECK(false, "Can't load constant with index: ", inst.X);
           }
+          if (inst.N == 0 || inst.N > stack.size()) {
+            TORCH_CHECK(
+                false,
+                "INTERFACE_CALL N=",
+                inst.N,
+                " not in range [1, ",
+                stack.size(),
+                "]");
+          }
           torch::jit::Function& method =
               peek(stack, 0, inst.N)
                   .toObject()


### PR DESCRIPTION
Summary:
The INTERFACE_CALL opcode for the mobile TorchScript interpreter contained an out of bounds read issue leading to memory corruption.

This change adds an explicit check that the number of inputs passed to the format method called when handling the INTERFACE_CALL opcode is a valid and within bounds of the stack.

Test Plan: contbuild + OSS signals

Differential Revision: D49739450


