### PR TITLE
Fix for out of bounds read in mobile interpreter FORMAT opcode handler

### DIFF
--- a/torch/csrc/jit/runtime/vararg_functions.cpp
+++ b/torch/csrc/jit/runtime/vararg_functions.cpp
@@ -106,6 +106,10 @@ void tupleUnpack(Stack& stack) {
 }
 
 void format(Stack& stack, size_t num_inputs) {
+  if (num_inputs == 0 || num_inputs > stack.size()) {
+    AT_ERROR("Invalid number of inputs for format string: ", num_inputs);
+  }
+
   // static const std::regex unsupported_options("\\{(.*?)\\}");
   auto format = peek(stack, 0, num_inputs).toStringRef();
   // // Temporally comment out the warning message because of


### PR DESCRIPTION
Summary:
The FORMAT opcode for the mobile TorchScript interpreter contained an out of bounds read issue leading to memory corruption.

This change adds an explicit check that the number of inputs passed to the format method called when handling the FORMAT opcode is a valid and within bounds of the stack.

Test Plan: contbuild + OSS signals

Differential Revision: D49739095


