### PR TITLE
[onnx] support attn_mask fp16 type

### DIFF
--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -190,7 +190,7 @@ def scaled_dot_product_attention(
         mul_qk_add = g.op("Add", mul_qk, attn_mask)
     elif (
         _type_utils.JitScalarType.from_value(attn_mask)
-        == _type_utils.JitScalarType.FLOAT
+        in (_type_utils.JitScalarType.FLOAT, _type_utils.JitScalarType.HALF)
     ):
         mul_qk_add = g.op("Add", mul_qk, attn_mask)
     else:

--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -188,9 +188,9 @@ def scaled_dot_product_attention(
         const_neg_inf = g.op("Constant", value_t=torch.tensor([-float("inf")]))
         attn_mask = g.op("Where", attn_mask, const_zero, const_neg_inf)
         mul_qk_add = g.op("Add", mul_qk, attn_mask)
-    elif (
-        _type_utils.JitScalarType.from_value(attn_mask)
-        in (_type_utils.JitScalarType.FLOAT, _type_utils.JitScalarType.HALF)
+    elif _type_utils.JitScalarType.from_value(attn_mask) in (
+        _type_utils.JitScalarType.FLOAT,
+        _type_utils.JitScalarType.HALF,
     ):
         mul_qk_add = g.op("Add", mul_qk, attn_mask)
     else:


### PR DESCRIPTION
When users define customized `attention mask` using `dtype=torch.float16`, e.g.

```
from torch.nn import functional as F

float_min = torch.finfo(torch.float16).min

attention_mask_fp16 = (attention_mask * 1.0).masked_fill(attention_mask, float_min).to(torch.float16)

attn_output = F.scaled_dot_product_attention(
                 query_layer_, key_layer_, value_layer_, attention_mask_fp16, 0.0, is_causal=False
 )
```

 the onnx graph cannot be exported. 

When q, k ,v have the fp16 type, we can support this `attn_mask` to be `fp16` type, by adding
```
elif (
        _type_utils.JitScalarType.from_value(attn_mask)
        == _type_utils.JitScalarType.FLOAT
        in (_type_utils.JitScalarType.FLOAT, _type_utils.JitScalarType.HALF)
```
This can export `.onnx` graph. 


Fixes #109336
