### PR TITLE
Skip launching kernels with zero grid in AOT Inductor

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -330,6 +330,8 @@ inject_BUILD_SET_unimplemented_TESTING_ONLY = False
 # lists, and incorrectly issue guards.
 inject_EVALUATE_EXPR_flip_equality_TESTING_ONLY = False
 
+add_runtime_assertions_for_inline_constraints = True
+
 _autograd_backward_strict_mode_banned_ops = [
     "stride",
     "requires_grad",

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -725,10 +725,11 @@ def _export(
         (args, kwargs),
     )
 
-    if len(range_constraints) > 0 or len(equality_constraints) > 0:
-        exported_program = exported_program._transform(
-            _AddRuntimeAssertionsForInlineConstraintsPass(range_constraints, equality_constraints)
-        )
+    if torch._dynamo.config.add_runtime_assertions_for_inline_constraints:
+        if len(range_constraints) > 0 or len(equality_constraints) > 0:
+            exported_program = exported_program._transform(
+                _AddRuntimeAssertionsForInlineConstraintsPass(range_constraints, equality_constraints)
+            )
     exported_program = lift_constant_tensor_pass(exported_program)
 
     return exported_program._transform(_ReplaceSymSizeOpPass())

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4060,14 +4060,20 @@ class MultiOutput(ExternKernel):
         symbols_to_define = self.get_unbacked_symbol_defs()
         for i, s in enumerate(self.get_size()):
             if s in symbols_to_define:
-                wrapper.writeline(f"{s} = {self.get_name()}.size({i})")
+                wrapper.writeline(
+                    f"{wrapper.declare}{s} = {self.get_name()}.size({i}){wrapper.ending}"
+                )
                 symbols_to_define.remove(s)
         for i, s in enumerate(self.get_stride()):
             if s in symbols_to_define:
-                wrapper.writeline(f"{s} = {self.get_name()}.stride({i})")
+                wrapper.writeline(
+                    f"{wrapper.declare}{s} = {self.get_name()}.stride({i}){wrapper.ending}"
+                )
                 symbols_to_define.remove(s)
         if (s := self.get_offset()) in symbols_to_define:
-            wrapper.writeline(f"{s} = {self.get_name()}.storage_offset()")
+            wrapper.writeline(
+                f"{wrapper.declare}{s} = {self.get_name()}.storage_offset(){wrapper.ending}"
+            )
             symbols_to_define.remove(s)
         assert (
             not symbols_to_define


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110312

Summary: with the grid computed in terms of unbacked `SymInt`s, it can happen that the grid is zero size. This causes CUDA error on `cuLaunchKernel` in the AOT Inductor codegen.

In this PR, when the grid contains unbacked `SymInt`s, a check is added around the `launchKernel` in the AOT Inductor's C++ wrapper codegen to make sure that the grid is not zero-size.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler