### PR TITLE
Small optimization to how we call flash-attention

### DIFF
--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -553,10 +553,6 @@ at::Tensor post_process_flash_output(
     c10::SymInt const& og_size) {
   if (!out.is_nested() && out.sym_size(-1) != og_size) {
     out = out.slice_symint(-1, 0, og_size);
-  } else {
-    TORCH_CHECK(
-        out.size(-1) == og_size,
-        "FlashAttentionV2 returned a nested tensor with an incorrect size")
   }
   return out;
 }

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -551,7 +551,7 @@ at::Tensor pad_last_dim(const at::Tensor& attn_bias) {
 at::Tensor post_process_flash_output(
     at::Tensor out,
     c10::SymInt const& og_size) {
-  if (!out.is_nested()) {
+  if (!out.is_nested() && out.sym_size(-1) != og_size) {
     out = out.slice_symint(-1, 0, og_size);
   } else {
     TORCH_CHECK(


### PR DESCRIPTION
# Summary
Logging Mode is great, and helped me identify that we are doing an unnecessary slice sometimes.


### Numbers
For small sizes: ie. (16, 16, 32, 32)
This brings the timing from:

`flash_time: 29.344002110883594 micro seconds`

to

`flash_time: 26.971791498363018 micro seconds`


cc @ptrblck