### PR TITLE
[dynamo] Add support for itertools.repeat

### DIFF
--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1503,6 +1503,18 @@ class BuiltinVariable(VariableTracker):
             return ConstantVariable.create(len(a.items) == 0).add_options(self, a)
 
         return None
+    
+    def call_repeat(self, tx, a, b):
+        if isinstance(a, SymNodeVariable) and isinstance(b, ConstantVariable):
+            return SymNodeVariable.create(
+                tx,
+                tx.output.create_proxy(
+                    "call_function", operator.repeat, *proxy_args_kwargs([a, b], {})
+                ),
+                sym_num=None,
+            )
+        # None no-ops this handler and lets the driving function proceed
+        return None
 
     call_eq = _comparison
     call_gt = _comparison


### PR DESCRIPTION
Implemented call_repeat function in builtin.py to handle itertools.repeat within the Dynamo context. This addresses issue #110286 where support for itertools.repeat was requested.

Fixes #110286


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng