### PR TITLE
Fix typo under docs directory

### DIFF
--- a/docs/source/notes/extending.rst
+++ b/docs/source/notes/extending.rst
@@ -819,9 +819,9 @@ changes without warning in the future.
 First, to get a listing of all overridable functions, use
 ``torch.overrides._get_overridable_functions``. This returns a dictionary whose
 keys are namespaces in the ``PyTorch`` Python API and whose values are a list of
-functions in that namespace that can be overriden. For example, let's print the
+functions in that namespace that can be overridden. For example, let's print the
 names of the first 5 functions in ``torch.nn.functional`` that can be
-overriden::
+overridden::
 
   >>> from torch.overrides import get_overridable_functions
   >>> func_dict = get_overridable_functions()
@@ -850,7 +850,7 @@ signature of the original ``PyTorch`` function::
 Finally, ``torch.overrides.get_ignored_functions`` returns a tuple of functions
 that explicitly cannot be overrided by ``__torch_function__``. This list can be
 useful to confirm that a function that isn't present in the dictionary returned
-by ``get_overridable_functions`` cannot be overriden.
+by ``get_overridable_functions`` cannot be overridden.
 
 
 .. _extending-torch-c++:

--- a/docs/source/sparse.rst
+++ b/docs/source/sparse.rst
@@ -176,7 +176,7 @@ Sparse Semi-Structured Tensors
 
 .. warning::
 
-   Sparse semi-sturctured tensors are currently a prototype feature and subject to change. Please feel free to open an issue to report a bug or if you have feedback to share.
+   Sparse semi-structured tensors are currently a prototype feature and subject to change. Please feel free to open an issue to report a bug or if you have feedback to share.
 
 Semi-Structured sparsity is a sparse data layout that was first introduced in NVIDIA's Ampere architecture. It is also referred to as **fine-grained structured sparsity** or **2:4 structured sparsity**.
 

--- a/docs/source/torch.compiler_transformations.rst
+++ b/docs/source/torch.compiler_transformations.rst
@@ -406,7 +406,7 @@ The
 class is used by the partitioner to determine if a specific node in the
 graph belongs in the partition. This is done by overriding the
 ``is_node_supported`` function. You can chain multiple
-``OperatorSuppportBase`` by using
+``OperatorSupportBase`` by using
 ```chain`` <https://github.com/pytorch/pytorch/blob/main/torch/fx/passes/operator_support.py#L150>`__\ (which
 returns False if any of the OperatorSupportBase return False) and
 ```any_chain`` <https://github.com/pytorch/pytorch/blob/main/torch/fx/passes/operator_support.py#L164>`__

--- a/docs/source/torch_cuda_memory.rst
+++ b/docs/source/torch_cuda_memory.rst
@@ -43,13 +43,13 @@ Allocator State History
 
 The Allocator State History shows individual allocator events in a timeline on the left. Select an event in the timeline to see a visual summary of the
 allocator state at that event. This summary shows each individual segment returned from cudaMalloc and how it is split up into blocks of individual allocations
-or free space. Mouse over segments and blocks to see the stack trace when the memory was allocated. Mouse over events to see the stack trace when the event occured,
+or free space. Mouse over segments and blocks to see the stack trace when the memory was allocated. Mouse over events to see the stack trace when the event occurred,
 such as when a tensor was freed. Out of memory errors are reported as OOM events. Looking at the state of memory during an OOM may provide insight into why
 an allocation failed even though reserved memory still exists.
 
 .. image:: _static/img/torch_cuda_memory/allocator_state_history.png
 
-The stack trace information also reports the address at which an allocation occured.
+The stack trace information also reports the address at which an allocation occurred.
 The address b7f064c000000_0 refers to the (b)lock at address 7f064c000000 which is the "_0"th time this address was allocated.
 This unique string can be looked up in the Active Memory Timeline and searched
 in the Active State History to examine the memory state when a tensor was allocated or freed.


### PR DESCRIPTION
This PR fixes typo in `.rst` files under docs directory
