### PR TITLE
[aotinductor] Use dynamic_shape instead of constraints

### DIFF
--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -90,7 +90,7 @@ def export__RC__(
 
     See `export` for documentation of `f`, `args`, `kwargs` and return.
     """
-    if dynamic_shapes is None:
+    if dynamic_shapes is None or len(dynamic_shapes) == 0:
         return export(f, args, kwargs)
 
     kwargs = kwargs if kwargs is not None else {}


### PR DESCRIPTION
Summary:
Previously we used export's constraints to specify all batch-size dimensions being dynamic. This is done by creating 1 constraint `dynamic_dim(inp[0][0], lower, upper)`, followed by `dynamic_dim(inp[0][0]) == dynamic_dim(inp[i][0])` for every input `i`.

Through the new `dynamic_shapes` API, we can use `Dims("batch_size")` on every dimension to specify which dimensions are dynamic and equal to each other, and `None` otherwise: `{i: [Dims("batch_size", lower, upper), None] for every input i}`

Note: `dynamic_shapes` and `constraints` utilize the same "constraints" backend so this diff should be idempotent.

Test Plan: `buck2 run @//mode/dev-nosan //caffe2/torch/fb/model_transform/experimental/benchmark/test/aotinductor:test_aot_inductor_benchmark`

Reviewed By: chenyang78, aakhundov

Differential Revision: D49784351


