### PR TITLE
[BE]: Enable some basic pytest style rules

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -2662,6 +2662,6 @@ init_command = [
     'python3',
     'tools/linter/adapters/pip_init.py',
     '--dry-run={{DRYRUN}}',
-    'ruff==0.0.290',
+    'ruff==0.0.291',
 ]
 is_formatter = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,12 @@ select = [
     "PLE",
     "PLR1722", # use sys exit
     "PLW3301", # nested min max
+    "PT006", # TODO: enable more PT rules
+    "PT022",
+    "PT023",
+    "PT024",
+    "PT025",
+    "PT026",
     "RUF017",
     "TRY302",
 ]

--- a/test/distributions/test_constraints.py
+++ b/test/distributions/test_constraints.py
@@ -64,7 +64,7 @@ def build_constraint(constraint_fn, args, is_cuda=False):
     t = torch.cuda.DoubleTensor if is_cuda else torch.DoubleTensor
     return constraint_fn(*(t(x) if isinstance(x, list) else x for x in args))
 
-@pytest.mark.parametrize('constraint_fn, result, value', EXAMPLES)
+@pytest.mark.parametrize(('constraint_fn', 'result', 'value'), EXAMPLES)
 @pytest.mark.parametrize('is_cuda', [False,
                                      pytest.param(True, marks=pytest.mark.skipif(not TEST_CUDA,
                                                                                  reason='CUDA not found.'))])
@@ -73,7 +73,7 @@ def test_constraint(constraint_fn, result, value, is_cuda):
     assert constraint_fn.check(t(value)).all() == result
 
 
-@pytest.mark.parametrize('constraint_fn, args', [(c[0], c[1:]) for c in CONSTRAINTS])
+@pytest.mark.parametrize(('constraint_fn', 'args'), [(c[0], c[1:]) for c in CONSTRAINTS])
 @pytest.mark.parametrize('is_cuda', [False,
                                      pytest.param(True, marks=pytest.mark.skipif(not TEST_CUDA,
                                                                                  reason='CUDA not found.'))])
@@ -104,7 +104,7 @@ def test_biject_to(constraint_fn, args, is_cuda):
     assert j.shape == x.shape[:x.dim() - t.domain.event_dim]
 
 
-@pytest.mark.parametrize('constraint_fn, args', [(c[0], c[1:]) for c in CONSTRAINTS])
+@pytest.mark.parametrize(('constraint_fn', 'args'), [(c[0], c[1:]) for c in CONSTRAINTS])
 @pytest.mark.parametrize('is_cuda', [False,
                                      pytest.param(True, marks=pytest.mark.skipif(not TEST_CUDA,
                                                                                  reason='CUDA not found.'))])

--- a/test/distributions/test_transforms.py
+++ b/test/distributions/test_transforms.py
@@ -252,7 +252,7 @@ base_dist1 = Dirichlet(torch.ones(4, 4))
 base_dist2 = Normal(torch.zeros(3, 4, 4), torch.ones(3, 4, 4))
 
 
-@pytest.mark.parametrize('batch_shape, event_shape, dist', [
+@pytest.mark.parametrize(('batch_shape', 'event_shape', 'dist'), [
     ((4, 4), (), base_dist0),
     ((4,), (4,), base_dist1),
     ((4, 4), (), TransformedDistribution(base_dist0, [transform0])),

--- a/test/torch_np/numpy_tests/core/test_multiarray.py
+++ b/test/torch_np/numpy_tests/core/test_multiarray.py
@@ -3774,7 +3774,7 @@ class TestIO(TestCase):
         filename = tmp_path / "file"
         if request.param == "string":
             filename = str(filename)
-        yield filename
+        return filename
 
     def test_nofile(self):
         # this should probably be supported as a file


### PR DESCRIPTION
Adds some basic flake8-pytest-style rules from ruff with their autofixes. I just picked a couple uncontroversial changes about having a consistent pytest style that were already following. We should consider enabling some more in the future, but this is a good start. I also upgraded ruff to the latest version.
