### PR TITLE
Allow storages to alias even when the deleter is deleteNothing

### DIFF
--- a/c10/core/Storage.cpp
+++ b/c10/core/Storage.cpp
@@ -1,14 +1,16 @@
 #include <c10/core/RefcountedDeleter.h>
 #include <c10/core/Storage.h>
+#include <c10/util/UniqueVoidPtr.h>
 
 namespace c10 {
 
 bool isSharedStorageAlias(const Storage& storage0, const Storage& storage1) {
-  c10::DeleterFnPtr deleter_expected = &c10::refcounted_deleter;
   c10::DeleterFnPtr deleter0 = storage0.data_ptr().get_deleter();
   c10::DeleterFnPtr deleter1 = storage1.data_ptr().get_deleter();
 
-  if ((deleter0 != deleter_expected) || (deleter1 != deleter_expected)) {
+  if (deleter0 != deleter1 ||
+      (deleter0 != &c10::refcounted_deleter &&
+       deleter0 != &c10::detail::deleteNothing)) {
     return false;
   }
 


### PR DESCRIPTION
This improves the debugging experience for devices that provide custom storage pointer.