### PR TITLE
Back out "Enable pickling model prepared with QAT qconfig"

### DIFF
--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -1,5 +1,5 @@
 # Owner(s): ["oncall: quantization"]
-import pickle
+
 from collections import OrderedDict
 import contextlib
 import torch
@@ -9714,18 +9714,6 @@ class TestQuantizeFxModels(QuantizationTestCase):
             out_ref = converted_ref(inp)
 
             torch.testing.assert_close(out, out_ref)
-
-    @override_qengines
-    def test_qat_pickle(self):
-        model = torch.nn.Sequential(nn.Conv2d(3, 32, 5), nn.BatchNorm2d(32), nn.ReLU())
-        example_inputs = torch.randn(1, 3, 128, 128)
-
-        qengine = torch.backends.quantized.engine
-        qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig(qengine)}
-        model = prepare_qat_fx(model, qconfig_dict, example_inputs)
-        pickle.dumps(model)
-
-
 if __name__ == '__main__':
     raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
                        "\tpython test/test_quantization.py TESTNAME\n\n"

--- a/torch/ao/quantization/qconfig.py
+++ b/torch/ao/quantization/qconfig.py
@@ -1,5 +1,4 @@
 from collections import namedtuple
-from functools import partial
 from typing import Optional, Any, Union, Type
 
 import torch
@@ -459,13 +458,6 @@ def _assert_valid_qconfig(qconfig: Optional[QConfig],
 QConfigAny = Optional[QConfig]
 QConfigAny.__module__ = "torch.ao.quantization.qconfig"
 
-def _get_factory_kwargs_based_on_module_device(module):
-    assert isinstance(module, torch.nn.Module)
-    devices = {p.device for p in module.parameters()} | \
-        {p.device for p in module.buffers()}
-    device = next(iter(devices)) if len(devices) > 0 else None
-    return None if device is None else {'device': device}
-
 def _add_module_to_qconfig_obs_ctr(
         qconfig: QConfigAny,
         module: Optional[nn.Module]) -> Any:
@@ -485,14 +477,19 @@ def _add_module_to_qconfig_obs_ctr(
     if module is None or qconfig is None or qconfig._fields != ('activation', 'weight'):
         return qconfig
 
+    def get_factory_kwargs_based_on_module_device():
+        assert isinstance(module, torch.nn.Module)
+        devices = {p.device for p in module.parameters()} | \
+            {p.device for p in module.buffers()}
+        device = next(iter(devices)) if len(devices) > 0 else None
+        return None if device is None else {'device': device}
 
     def configure_constructor_to_put_obs_on_module_device(original_constructor):
-        get_factory_kwargs_based_on_module_device_with_model = partial(_get_factory_kwargs_based_on_module_device, module)
         try:
             # check if constructor can accept factory_kwargs
             check = original_constructor.with_args(factory_kwargs=None)
             check()
-            return original_constructor.with_callable_args(factory_kwargs=get_factory_kwargs_based_on_module_device_with_model)
+            return original_constructor.with_callable_args(factory_kwargs=get_factory_kwargs_based_on_module_device)
         except AttributeError:  # qconfig doesn't have activation or weight
             return original_constructor
         except TypeError:  # the class doesn't accept factory_kwargs argument


### PR DESCRIPTION
Summary:
D49187352 caused our model conversion and loading of QAT checkpoint to be stuck with thrift time out.

we are actively checking in final code and model for static quant HTP prod model, and encountered this breakage at head Thursday.

Thrift timeout is a not failing, and because of that, it's hard to bisect and find this culprit. It is also hard to set up unit test, because the job simply time-out. Better test is needed to guard downstream model conversion against upstream changes.

Our suspicion of why this diff broke us is that we create a lot of modules with qat (in a recursive manner) but our model is not a qat traceable module (it is a graph with many qat modules and floating point modules). With fuctools.partial as in the original diff, we will be caching modules in the memory and causing the memory of the machine to be taken up completely.