### PR TITLE
[AOTInductor] Avoid static vars for individual kernels

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/model.h
+++ b/torch/csrc/inductor/aoti_runtime/model.h
@@ -411,6 +411,12 @@ class AOTInductorModelBase {
   }
 };
 
+// Codegen-ed classes can derive from this to keep pointers to loaded kernels.
+class AOTInductorModelKernelsBase {
+ public:
+  virtual ~AOTInductorModelKernelsBase() = default;
+};
+
 class AOTInductorModel : public AOTInductorModelBase<AOTInductorModel> {
  public:
   AOTInductorModel(std::shared_ptr<ConstantMap>, std::optional<std::string>);
@@ -431,6 +437,9 @@ class AOTInductorModel : public AOTInductorModelBase<AOTInductorModel> {
       std::optional<std::string> cubin_dir) {
     return std::make_unique<AOTInductorModel>(constants, cubin_dir);
   }
+
+ private:
+  std::unique_ptr<AOTInductorModelKernelsBase> kernels_;
 };
 
 class AOTICudaStreamGuard {


### PR DESCRIPTION
Defining kernels as static vars is problematic for subsequent model loading on non-default CUDA devices.

Assuming those kernels were loaded in context of the device #0, so, they are not `nullptr` anymore, therefore kernels won't work on devices other than the device #0.

This change makes devices remembered at model level in AOT mode.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler