### PR TITLE
[AOTInductor] remove CUDA dependency for cpp backend

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -69,7 +69,7 @@ class AOTInductorModelRunner:
                 cpp_sources=[launcher],
                 functions=["run"],
                 extra_ldflags=[so_path],
-                with_cuda=True,  # TODO: change this to not is_cpu
+                with_cuda=not is_cpu,
             ).run
 
         return optimized, exported

--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -77,7 +77,7 @@ AOTIRuntimeError AOTInductorModelContainerRun(
   AOTI_VECTOR_SIZE_CHECK(num_inputs, container->num_inputs(), "inputs");
   AOTI_VECTOR_SIZE_CHECK(num_outputs, container->num_outputs(), "outputs");
 
-  auto stream = reinterpret_cast<cudaStream_t>(stream_handle);
+  auto stream = reinterpret_cast<torch::aot_inductor::DeviceStreamType>(stream_handle);
   CONVERT_EXCEPTION_TO_ERROR_CODE({
     container->run(
         input_handles,
@@ -208,7 +208,11 @@ AOTIRuntimeError AOTInductorModelRun(
     AtenTensorHandle* output_handles) {
   auto model = reinterpret_cast<torch::aot_inductor::AOTInductorModel*>(model_handle);
   CONVERT_EXCEPTION_TO_ERROR_CODE({
-      model->run_impl(input_handles, output_handles, (cudaStream_t)nullptr, nullptr);
+      model->run_impl(
+          input_handles,
+          output_handles,
+          (torch::aot_inductor::DeviceStreamType)nullptr,
+          nullptr);
   })
 }
 

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1131,7 +1131,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
                         output_handles, // array for writing output AtenTensorHandle; handles
                                         // will be stolen by the caller; the array itself is
                                         // borrowed
-                    cudaStream_t stream,
+                    DeviceStreamType stream,
                     AOTIProxyExecutorHandle proxy_executor
                 ) {
                 """

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1176,7 +1176,9 @@ class Placeholder(enum.Enum):
 
 # A utility function for easier AOTInductor testing
 aot_inductor_launcher = """
+#ifdef USE_CUDA
     #include <c10/cuda/CUDAStream.h>
+#endif // USE_CUDA
     #include <torch/csrc/inductor/aoti_runtime/interface.h>
     #include <torch/csrc/inductor/aoti_torch/tensor_converter.h>
 
@@ -1219,10 +1221,14 @@ aot_inductor_launcher = """
                 &num_outputs));
         std::vector<AtenTensorHandle> output_handles(num_outputs);
 
+#ifdef USE_CUDA
         const auto& cuda_stream = c10::cuda::getCurrentCUDAStream();
         const auto stream_id = cuda_stream.stream();
         AOTInductorStreamHandle stream_handle =
             reinterpret_cast<AOTInductorStreamHandle>(stream_id);
+#else // !USE_CUDA
+        AOTInductorStreamHandle stream_handle = nullptr;
+#endif
 
         AOTIProxyExecutorHandle proxy_executor_handle = nullptr;
 

--- a/torch/csrc/inductor/aoti_runtime/device_utils.h
+++ b/torch/csrc/inductor/aoti_runtime/device_utils.h
@@ -4,10 +4,17 @@
 // in model.so, and should not refer to any aten/c10 headers except the stable
 // C ABI defined in torch/csrc/inductor/aoti_torch/c/shim.h. The same rule
 // applies to other files under torch/csrc/inductor/aoti_runtime/.
+
+#ifdef USE_CUDA
+
+// FIXME: Currently, CPU and CUDA backend are mutually exclusive.
+// This is a temporary workaround. We need a better way to support
+// multi devices.
+
 #include <cuda.h>
 #include <cuda_runtime_api.h>
 
-#define AOTI_RUNTIME_CUDA_CHECK(EXPR)                      \
+#define AOTI_RUNTIME_DEVICE_CHECK(EXPR)                    \
   do {                                                     \
     const cudaError_t code = EXPR;                         \
     const char* msg = cudaGetErrorString(code);            \
@@ -16,3 +23,29 @@
           std::string("CUDA error: ") + std::string(msg)); \
     }                                                      \
   } while (0)
+
+namespace torch {
+namespace aot_inductor {
+
+using DeviceStreamType = cudaStream_t;
+
+} // namespace aot_inductor
+} // namespace torch
+
+#else // !USE_CUDA
+
+#define AOTI_RUNTIME_DEVICE_CHECK(EXPR)            \
+  bool ok = EXPR;                                  \
+  if (!ok) {                                       \
+    throw std::runtime_error("CPU runtime error"); \
+  }
+
+namespace torch {
+namespace aot_inductor {
+
+using DeviceStreamType = void*;
+
+} // namespace aot_inductor
+} // namespace torch
+
+#endif // USE_CUDA

--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -26,14 +26,19 @@ extern const uint8_t _binary_constants_bin_end[];
 
 namespace {
 
+#ifdef USE_CUDA
+
 using CUDAPtr = std::unique_ptr<void, std::function<void(void*)>>;
 
 CUDAPtr RAII_cudaMalloc(size_t num_bytes) {
   void* data_ptr;
-  AOTI_RUNTIME_CUDA_CHECK(cudaMalloc((void**)&data_ptr, num_bytes));
-  auto deleter = [](void* ptr) { AOTI_RUNTIME_CUDA_CHECK(cudaFree(ptr)); };
+  AOTI_RUNTIME_DEVICE_CHECK(cudaMalloc((void**)&data_ptr, num_bytes));
+  auto deleter = [](void* ptr) { AOTI_RUNTIME_DEVICE_CHECK(cudaFree(ptr)); };
   return CUDAPtr(data_ptr, deleter);
 }
+
+#endif // USE_CUDA
+
 } // anonymous namespace
 
 namespace torch {
@@ -89,40 +94,15 @@ class AOTInductorModelContainer {
 
     std::vector<size_t> constants_internal_offset(num_constants);
     if (!is_cpu) {
-      // Compute required blob size with 64-alignment if on GPU.
-      size_t max_blob = 0;
-      for (size_t i = 0; i < num_constants; i++) {
-        size_t data_size = model->constant_data_size(i);
-        if (data_size % AOTI_CONST_GPU_ALIGNMENT) {
-          data_size = AOTI_CONST_GPU_ALIGNMENT +
-              (data_size / AOTI_CONST_GPU_ALIGNMENT) * AOTI_CONST_GPU_ALIGNMENT;
-        }
-        constants_internal_offset[i] = max_blob;
-        max_blob += data_size;
-      }
-      constant_blob_ = RAII_cudaMalloc(max_blob);
+      make_cuda_constant_blob(model, constants_internal_offset);
     }
 
     size_t bytes_read = 0;
     for (size_t i = 0; i < num_constants; i++) {
       std::string name = model->constant_name(i);
       size_t data_size = model->constant_data_size(i);
-      uint8_t* internal_ptr;
-      if (is_cpu) {
-        // get pointer to constant which is packed in model during compile time.
-        internal_ptr =
-            const_cast<uint8_t*>(_binary_constants_bin_start) + bytes_read;
-      } else {
-        auto* constants_ptr = static_cast<uint8_t*>(constant_blob_.get());
-        internal_ptr = constants_ptr + constants_internal_offset[i];
-        // Copy data to GPU memory
-        // TODO: Handle shared storage case.
-        AOTI_RUNTIME_CUDA_CHECK(cudaMemcpy(
-            internal_ptr,
-            _binary_constants_bin_start + bytes_read,
-            data_size,
-            cudaMemcpyHostToDevice));
-      }
+      uint8_t* internal_ptr =
+          constant_ptr(constants_internal_offset[i], bytes_read, data_size);
       bytes_read += data_size;
 
       // Create at::Tensor from copied memory.
@@ -138,8 +118,10 @@ class AOTInductorModelContainer {
       }
 
       AtenTensorHandle tensor_handle;
-      int device_idx; // should be the same as was used for constant_blob_
-      AOTI_RUNTIME_CUDA_CHECK(cudaGetDevice(&device_idx));
+      int device_idx = -1; // should be the same as was used for constant_blob_
+#ifdef USE_CUDA
+      AOTI_RUNTIME_DEVICE_CHECK(cudaGetDevice(&device_idx));
+#endif // USE_CUDA
       AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_create_tensor_from_blob(
           internal_ptr,
           ndim,
@@ -163,7 +145,7 @@ class AOTInductorModelContainer {
           output_handles, // array for writing output AtenTensorHandle; handles
                           // will be stolen by the caller; the array itself is
                           // borrowed
-      cudaStream_t stream,
+      DeviceStreamType stream,
       AOTIProxyExecutorHandle proxy_executor) {
     auto* model = get_available_model();
     try {
@@ -228,11 +210,14 @@ class AOTInductorModelContainer {
   // Holds the upper-bound value for each dimension of any output shape.
   std::vector<std::vector<int64_t>> max_output_shapes_;
 
-  // Holds the blob storage for constants' at::Tensor.
+#ifdef USE_CUDA
+  // Holds the blob storage for constants' at::Tensor for CUDA.
   CUDAPtr constant_blob_;
+#endif // USE_CUDA
 
   // Holds the mapping of constants to at::Tensor.
-  // The underlying data of at::Tensor is in constant_blob_.
+  // The underlying data of at::Tensor is in either constant_blob_ (for CUDA).
+  // or _binary_constants_bin_start (for CPU).
   std::shared_ptr<ConstantMap> constants_;
 
   // Holds the current value for each dimension of any output shape.
@@ -298,6 +283,47 @@ class AOTInductorModelContainer {
     }
     lk.lock();
     available_models_.push_back(model);
+  }
+
+  uint8_t* constant_ptr(
+      size_t constant_offset,
+      size_t bytes_read,
+      size_t data_size) {
+#ifdef USE_CUDA
+    auto* constants_ptr = static_cast<uint8_t*>(constant_blob_.get());
+    uint8_t* internal_ptr = constants_ptr + constant_offset;
+    // Copy data to GPU memory
+    // TODO: Handle shared storage case.
+    AOTI_RUNTIME_DEVICE_CHECK(cudaMemcpy(
+        internal_ptr,
+        _binary_constants_bin_start + bytes_read,
+        data_size,
+        cudaMemcpyHostToDevice));
+    return internal_ptr;
+#else // !USE_CUDA
+    // get pointer to constant which is packed in model during compile time.
+    return const_cast<uint8_t*>(_binary_constants_bin_start) + bytes_read;
+#endif // USE_CUDA
+  }
+
+  void make_cuda_constant_blob(
+      AOTInductorModel* model,
+      std::vector<size_t>& constants_internal_offset) {
+#ifdef USE_CUDA
+    size_t num_constants = model->num_constants();
+    // Compute required blob size with 64-alignment if on GPU.
+    size_t max_blob = 0;
+    for (size_t i = 0; i < num_constants; i++) {
+      size_t data_size = model->constant_data_size(i);
+      if (data_size % AOTI_CONST_GPU_ALIGNMENT) {
+        data_size = AOTI_CONST_GPU_ALIGNMENT +
+            (data_size / AOTI_CONST_GPU_ALIGNMENT) * AOTI_CONST_GPU_ALIGNMENT;
+      }
+      constants_internal_offset[i] = max_blob;
+      max_blob += data_size;
+    }
+    constant_blob_ = RAII_cudaMalloc(max_blob);
+#endif // USE_CUDA
   }
 };
 


### PR DESCRIPTION
Summary:
Previously, we link against cuda libs even for pure cpp backend.
This caused issues for cases where the inference platform does not
have GPUs. This diff removed cuda dependency for cpp backend.

Reviewed By: bertmaher, muchulee8, mikekgfb

Differential Revision: D49800712




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @kadeng @muchulee8 @aakhundov @ColinPeppler