### PR TITLE
[AOTInductor] Simplified AOTInductor interface and model class

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -670,6 +670,25 @@ class AOTInductorTestsTemplate:
         ):
             self.check_model(Repro(), example_inputs)
 
+    def test_dynamic_cat(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x1, x2):
+                return torch.cat([x1, x2], dim=0)
+
+        a = torch.randn(2, 4, device=self.device)
+        b = torch.randn(3, 4, device=self.device)
+        constraints = [
+            torch._export.dynamic_dim(a, 0) >= 1,
+            torch._export.dynamic_dim(a, 0) <= 10,
+            torch._export.dynamic_dim(b, 0) >= 1,
+            torch._export.dynamic_dim(b, 0) <= 20,
+        ]
+        example_inputs = (a, b)
+        self.check_model(Model(), example_inputs, constraints=constraints)
+
     @unittest.skipIf(
         torch.cuda.device_count() < 2, "The test requires multiple devices"
     )
@@ -719,6 +738,7 @@ copy_tests(
     {
         "test_addmm_multiple_dynamic": TestFailure(("abi_compatible_cpu",)),
         "test_bmm_multiple_dynamic": TestFailure(("abi_compatible_cpu",)),
+        "test_dynamic_cat": TestFailure(("abi_compatible_cpu",)),
         "test_dynamic_smem_above_default_limit": TestFailure(("abi_compatible_cpu",)),
         "test_foreach_multiple_dynamic": TestFailure(("abi_compatible_cpu",)),
         # TODO: test_freezing_abi_compatible_cpu somehow fails on CI but not locally,

--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -108,17 +108,6 @@ AOTIRuntimeError AOTInductorModelContainerGetInputName(
       { *ret_input_names = container->input_name(input_idx); })
 }
 
-AOTIRuntimeError AOTInductorModelContainerGetInputDtype(
-    AOTInductorModelContainerHandle container_handle,
-    size_t input_idx,
-    const char** ret_input_dtypes) {
-  auto* container =
-      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
-          container_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE(
-      { *ret_input_dtypes = container->get_input_dtype(input_idx); })
-}
-
 AOTIRuntimeError AOTInductorModelContainerGetNumOutputs(
     AOTInductorModelContainerHandle container_handle,
     size_t* ret_num_outputs) {
@@ -138,49 +127,6 @@ AOTIRuntimeError AOTInductorModelContainerGetOutputName(
           container_handle);
   CONVERT_EXCEPTION_TO_ERROR_CODE(
       { *ret_output_names = container->output_name(output_idx); })
-}
-
-AOTIRuntimeError AOTInductorModelContainerGetOutputDtype(
-    AOTInductorModelContainerHandle container_handle,
-    size_t output_idx,
-    const char** ret_output_dtypes) {
-  auto* container =
-      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
-          container_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE(
-      { *ret_output_dtypes = container->get_output_dtype(output_idx); })
-}
-
-AOTIRuntimeError AOTInductorModelContainerGetMaxInputShape(
-    AOTInductorModelContainerHandle container_handle,
-    size_t input_idx,
-    const int64_t** ret_input_sizes,
-    int64_t* ret_input_ndim) {
-  auto* container =
-      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
-          container_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    const std::vector<int64_t>& max_input_shape =
-        container->max_input_shape(input_idx);
-    *ret_input_sizes = max_input_shape.data();
-    *ret_input_ndim = max_input_shape.size();
-  })
-}
-
-AOTIRuntimeError AOTInductorModelContainerGetMaxOutputShape(
-    AOTInductorModelContainerHandle container_handle,
-    size_t output_idx,
-    const int64_t** ret_output_sizes,
-    int64_t* ret_output_ndim) {
-  auto* container =
-      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
-          container_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    const std::vector<int64_t>& max_output_shape =
-        container->max_output_shape(output_idx);
-    *ret_output_sizes = max_output_shape.data();
-    *ret_output_ndim = max_output_shape.size();
-  })
 }
 
 AOTIRuntimeError AOTInductorModelCreate(

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -300,11 +300,6 @@ class WrapperCodeGen(CodeGen):
         self.last_seen_device_guard_index = None
         self.supports_intermediate_hooks = True
         self.expr_printer = pexpr
-        # Not all the dynamic symbols will be used in the generated code. This
-        # set contains those actually being defined by something like
-        # "{self.declare_shape} s0 = ...". It ensures that we are not going to
-        # emit queries for undefined symbols.
-        self.defined_symbols = set()
 
         self.write_header()
         self.write_prefix()
@@ -603,7 +598,6 @@ class WrapperCodeGen(CodeGen):
         for name, shape in graph_inputs_expr:
             shape = V.graph.sizevars.simplify(shape)
             if shape in needed:
-                self.defined_symbols.add(shape)
                 needed.remove(shape)
                 code.writeline(f"{self.declare}{shape} = {name}{self.ending}")
 
@@ -612,7 +606,6 @@ class WrapperCodeGen(CodeGen):
             for dim, shape in enumerate(shapes):
                 shape = V.graph.sizevars.simplify(shape)
                 if shape in needed:
-                    self.defined_symbols.add(shape)
                     needed.remove(shape)
                     code.writeline(
                         f"{self.declare}{shape} = {sizeof(name)}[{dim}]{self.ending}"
@@ -623,7 +616,6 @@ class WrapperCodeGen(CodeGen):
             for dim, shape in enumerate(shapes):
                 shape = V.graph.sizevars.simplify(shape)
                 if shape in needed:
-                    self.defined_symbols.add(shape)
                     needed.remove(shape)
                     code.writeline(
                         f"{self.declare}{shape} = {strideof(name)}[{dim}]{self.ending}"
@@ -1101,26 +1093,8 @@ class CppWrapperCodeGen(WrapperCodeGen):
         info_kind: str,
         idx: int,
         name: str,
-        dtype: str,
-        sizes: List[sympy.Expr],
     ):
         self.prefix.writeline(f"""{info_kind}[{idx}].name = "{name}";""")
-        self.prefix.writeline(f"""{info_kind}[{idx}].dtype = "{dtype}";""")
-        self.prefix.writeline(f"{info_kind}[{idx}].shape.reserve({len(sizes)});")
-        for size in sizes:
-            if isinstance(size, sympy.Integer):
-                self.prefix.writeline(
-                    f"{info_kind}[{idx}].shape.push_back(make_static_dim({size}));"
-                )
-            else:
-                size = V.graph.sizevars.simplify(size)
-                # FIXME: handle non-Symbol cases later.
-                assert isinstance(
-                    size, sympy.Symbol
-                ), f"expected {size=} to be a Symbol"
-                self.prefix.writeline(
-                    f"{info_kind}[{idx}].shape.push_back({size.name});"
-                )
 
     def write_wrapper_decl(self):
         inputs_len = len(V.graph.graph_inputs.keys())
@@ -1213,16 +1187,6 @@ class CppWrapperCodeGen(WrapperCodeGen):
 
             if V.graph.aot_mode:
                 self.prefix.writeline("inputs.clear();")
-                dynamic_symbols = [
-                    s
-                    for s in V.graph.sizevars.free_symbols()
-                    if s in self.defined_symbols
-                ]
-                for dim in dynamic_symbols:
-                    self.prefix.writeline(
-                        f'auto dim_{dim} = find_dynamic_dim("{dim}");'
-                    )
-                    self.prefix.writeline(f"dim_{dim}->set_value({dim});")
 
             if not config.aot_inductor.abi_compatible:
                 self.wrapper_call.splice(
@@ -1258,14 +1222,8 @@ class CppWrapperCodeGen(WrapperCodeGen):
         // Generated code example
         AOTInductorModel::AOTInductorModel()
             : AOTInductorModelBase(4, 1) {
-        auto s0 = make_dynamic_dim("s0", 2048);
         inputs_info_[0].name = "input0";
-        inputs_info_[0].shape.reserve(2);
-        inputs_info_[0].shape.push_back(make_static_dim(10));
-        inputs_info_[0].shape.push_back(make_static_dim(64));
-        inputs_info_[1].shape.reserve(2);
-        inputs_info_[1].shape.push_back(s0);
-        inputs_info_[1].shape.push_back(make_static_dim(64));
+        inputs_info_[0].dtype = "torch.float16";
         ...
         constants_info_[0].name = "L__self___weight";
         constants_info_[0].dtype = at::kFloat;
@@ -1275,23 +1233,9 @@ class CppWrapperCodeGen(WrapperCodeGen):
         constants_info_[0].stride = {32, 1};
         ...
         outputs_info_[0].name = "output0";
-        outputs_info_[0].shape.reserve(2);
-        outputs_info_[0].shape.push_back(s0);
-        outputs_info_[0].shape.push_back(make_static_dim(10));
+        outputs_info_[0].dtype = "torch.float16";
         }
         """
-
-        def codegen_dynamic_dims():
-            dynamic_symbols = V.graph.sizevars.free_symbols()
-            for dim in dynamic_symbols:
-                var_to_range = V.graph.sizevars.shape_env.var_to_range
-                dim_range = var_to_range.get(dim, None)
-                assert (
-                    dim_range is not None
-                ), f"Could not find dim_range for {dim=} from {var_to_range=}"
-                self.prefix.writeline(
-                    f'auto {dim.name} = make_dynamic_dim("{dim.name}", {dim_range.lower}, {dim_range.upper});'
-                )
 
         num_inputs = len(V.graph.graph_inputs)
         num_outputs = len(V.graph.graph_outputs)
@@ -1304,14 +1248,11 @@ class CppWrapperCodeGen(WrapperCodeGen):
         )
 
         with self.prefix.indent():
-            codegen_dynamic_dims()
             for idx, (name, inp) in enumerate(V.graph.graph_inputs.items()):
                 assert not isinstance(
                     inp, sympy.Expr
                 ), f"input {name=} cannot be symbolic"
-                sizes = inp.get_size()
-                dtype = V.graph.graph_inputs[name].get_dtype()
-                self.write_input_output_info("inputs_info_", idx, name, dtype, sizes)
+                self.write_input_output_info("inputs_info_", idx, name)
 
             for idx, (name, tensor) in enumerate(V.graph.constants.items()):
                 assert isinstance(tensor, torch.Tensor)
@@ -1340,10 +1281,8 @@ class CppWrapperCodeGen(WrapperCodeGen):
                 assert not isinstance(
                     output, sympy.Expr
                 ), f"output {name=} cannot be symbolic"
-                sizes = output.get_size()
                 name = f"output{idx}"
-                dtype = output.get_dtype()
-                self.write_input_output_info("outputs_info_", idx, name, dtype, sizes)
+                self.write_input_output_info("outputs_info_", idx, name)
 
         self.prefix.writeline("}")
 

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -81,12 +81,6 @@ AOTIRuntimeError AOTInductorModelContainerGetInputName(
     size_t input_idx,
     const char** ret_input_names);
 
-// Retrieves the input dtype at the given index.
-AOTIRuntimeError AOTInductorModelContainerGetInputDtype(
-    AOTInductorModelContainerHandle container_handle,
-    size_t input_idx,
-    const char** ret_input_dtypes);
-
 // Retrieves the number of outputs for the model.
 AOTIRuntimeError AOTInductorModelContainerGetNumOutputs(
     AOTInductorModelContainerHandle container_handle,
@@ -97,26 +91,6 @@ AOTIRuntimeError AOTInductorModelContainerGetOutputName(
     AOTInductorModelContainerHandle container_handle,
     size_t output_idx,
     const char** ret_output_names);
-
-// Retrieves the output dtype at the given index.
-AOTIRuntimeError AOTInductorModelContainerGetOutputDtype(
-    AOTInductorModelContainerHandle container_handle,
-    size_t output_idx,
-    const char** ret_output_dtypes);
-
-// Retieves the input shape with the maximum dimension size for each dimension.
-AOTIRuntimeError AOTInductorModelContainerGetMaxInputShape(
-    AOTInductorModelContainerHandle container_handle,
-    size_t input_idx,
-    const int64_t** ret_input_sizes,
-    int64_t* ret_input_ndim);
-
-// Retieves the output shape with the maximum dimension size for each dimension.
-AOTIRuntimeError AOTInductorModelContainerGetMaxOutputShape(
-    AOTInductorModelContainerHandle container_handle,
-    size_t output_idx,
-    const int64_t** ret_output_sizes,
-    int64_t* ret_output_ndim);
 
 // Creates an AOTInductorModel instance.  This is a thin and light wrapper
 // around the compiled model; it doesn't handle concurrency, queueing, device

--- a/torch/csrc/inductor/aoti_runtime/model.h
+++ b/torch/csrc/inductor/aoti_runtime/model.h
@@ -99,8 +99,7 @@ inline std::vector<RAIIAtenTensorHandle> steal_from_raw_handles_to_raii_handles(
 // AOTInductor cpp codegen. Since we do not need dynamic dispatch, we rely
 // on curiously recurring template pattern (CRTP) to save some runtime
 // v-table overhead. The generated AOTInductorModel is specialized with
-// methods such as run_impl and members like shape params used for dynamic
-// shape cases.
+// methods such as run_impl.
 template <typename Model>
 class AOTInductorModelBase {
  public:
@@ -184,24 +183,8 @@ class AOTInductorModelBase {
     return outputs_info_.at(idx).name;
   }
 
-  const char* get_input_dtype(int64_t idx) const {
-    return inputs_info_.at(idx).dtype;
-  }
-
-  const char* get_output_dtype(int64_t idx) const {
-    return outputs_info_.at(idx).dtype;
-  }
-
   const char* constant_name(int64_t idx) const {
     return constants_info_.at(idx).name;
-  }
-
-  std::vector<int64_t> max_input_shape(int64_t idx) const {
-    return max_shape(inputs_info_, idx);
-  }
-
-  std::vector<int64_t> max_output_shape(int64_t idx) const {
-    return max_shape(outputs_info_, idx);
   }
 
   size_t constant_ndim(int64_t idx) {
@@ -226,14 +209,6 @@ class AOTInductorModelBase {
 
   size_t constant_data_size(int64_t idx) const {
     return constants_info_.at(idx).data_size;
-  }
-
-  std::vector<int64_t> input_shape(int64_t idx) const {
-    return shape(inputs_info_, idx);
-  }
-
-  std::vector<int64_t> output_shape(int64_t idx) const {
-    return shape(outputs_info_, idx);
   }
 
   void update_constants_map(std::shared_ptr<ConstantMap>&& constants_map) {
@@ -274,102 +249,8 @@ class AOTInductorModelBase {
   }
 
  protected:
-  class DimInfo {
-   public:
-    virtual int64_t value() const = 0;
-    virtual void set_value(int64_t val) = 0;
-    virtual int64_t lower_bound() const = 0;
-    virtual int64_t upper_bound() const = 0;
-    virtual ~DimInfo() {}
-  };
-
-  class StaticDimInfo : public DimInfo {
-   public:
-    StaticDimInfo(int64_t val) : value_(val) {}
-
-    int64_t value() const {
-      return value_;
-    }
-
-    void set_value(int64_t val) {
-      throw std::runtime_error("cannot change the value of a StaticDim");
-    }
-
-    int64_t lower_bound() const {
-      return value_;
-    }
-
-    int64_t upper_bound() const {
-      return value_;
-    }
-
-   private:
-    const int64_t value_;
-  };
-
-  class DynamicDimInfo : public DimInfo {
-   public:
-    DynamicDimInfo(const char* name, int64_t lb, int64_t ub)
-        : name_(name), lower_bound_(lb), upper_bound_(ub), value_(-1) {}
-
-    void set_value(int64_t val) {
-      if (val != 1 && (val < lower_bound_ || val > upper_bound_)) {
-        throw std::runtime_error(
-            std::string(
-                "dim value out of bounds: expected value to be between (") +
-            std::to_string(lower_bound_) + ", " + std::to_string(upper_bound_) +
-            "), but got " + std::to_string(val));
-      }
-      value_ = val;
-    }
-
-    int64_t value() const {
-      return value_;
-    }
-
-    int64_t lower_bound() const {
-      return lower_bound_;
-    }
-
-    int64_t upper_bound() const {
-      return upper_bound_;
-    }
-
-   private:
-    const std::string name_;
-    const int64_t lower_bound_;
-    const int64_t upper_bound_;
-    int64_t value_;
-  };
-
-  DynamicDimInfo* find_dynamic_dim(const char* name) {
-    auto iter = dynamic_dims_.find(name);
-    if (iter == dynamic_dims_.end()) {
-      throw std::runtime_error(
-          std::string("dynamic_dim `") + name + "` does not exist");
-    }
-    return iter->second.get();
-  }
-
-  DynamicDimInfo* make_dynamic_dim(const char* name, int64_t lb, int64_t ub) {
-    if (dynamic_dims_.find(name) != dynamic_dims_.end()) {
-      throw std::runtime_error(
-          std::string("dynamic_dim `") + name + "` already exists");
-    }
-    auto iter = dynamic_dims_.emplace(
-        name, std::make_unique<DynamicDimInfo>(name, lb, ub));
-    return (iter.first->second).get();
-  }
-
-  StaticDimInfo* make_static_dim(int64_t val) {
-    static_dims_.push_back(std::make_unique<StaticDimInfo>(val));
-    return static_dims_.back().get();
-  }
-
   struct ParamInfo {
     const char* name = nullptr;
-    const char* dtype = nullptr;
-    std::vector<DimInfo*> shape;
   };
 
   struct ConstInfo {
@@ -400,37 +281,6 @@ class AOTInductorModelBase {
 
   // Generated model uses this device index to create CUDA guards.
   int device_idx_;
-
- protected:
-  std::vector<std::unique_ptr<StaticDimInfo>> static_dims_;
-  // A map from dynamic symbol names to their dim info
-  std::unordered_map<std::string, std::unique_ptr<DynamicDimInfo>>
-      dynamic_dims_;
-
- private:
-  std::vector<int64_t> shape(
-      const std::vector<ParamInfo>& params,
-      int64_t idx,
-      bool max = false) const {
-    std::vector<int64_t> shape;
-    const ParamInfo& param = params.at(idx);
-    auto rank = param.shape.size();
-    shape.reserve(rank);
-    for (size_t i = 0; i < rank; i++) {
-      if (max) {
-        shape.push_back(param.shape[i]->upper_bound());
-      } else {
-        shape.push_back(param.shape[i]->value());
-      }
-    }
-    return shape;
-  }
-
-  std::vector<int64_t> max_shape(
-      const std::vector<ParamInfo>& params,
-      int64_t idx) const {
-    return shape(params, idx, /*max=*/true);
-  }
 };
 
 class AOTInductorModel : public AOTInductorModelBase<AOTInductorModel> {

--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -58,8 +58,8 @@ class AOTInductorModelContainer {
       available_models_.push_back(models_.back().get());
     }
 
-    // Note that the all following fields (input_names_, output_names
-    // and max_output_shapes_) can be filled in by the AOT
+    // Note that the all following fields (input_names_, output_names,
+    // etc) can be filled in by the AOT
     // codegen. However, we choose to query such information from
     // the owned AOTInductorModel for a couple of reasons:
     //   * simplify the codegen templates
@@ -69,24 +69,14 @@ class AOTInductorModelContainer {
     auto* model = available_models_[0];
     size_t num_inputs = model->num_inputs();
     input_names_.reserve(num_inputs);
-    input_dtypes_.reserve(num_inputs);
-    max_input_shapes_.reserve(num_inputs);
     for (size_t i = 0; i < num_inputs; i++) {
       input_names_.push_back(model->input_name(i));
-      input_dtypes_.push_back(model->get_input_dtype(i));
-      max_input_shapes_.push_back(model->max_input_shape(i));
     }
 
     size_t num_outputs = model->num_outputs();
     output_names_.reserve(num_outputs);
-    output_dtypes_.reserve(num_outputs);
-    max_output_shapes_.reserve(num_outputs);
-    output_shapes_.reserve(num_outputs);
     for (size_t i = 0; i < num_outputs; i++) {
       output_names_.push_back(model->output_name(i));
-      output_dtypes_.push_back(model->get_output_dtype(i));
-      max_output_shapes_.push_back(model->max_output_shape(i));
-      output_shapes_.emplace_back(max_output_shapes_.back().size(), -1);
     }
 
     size_t num_constants = model->num_constants();
@@ -179,36 +169,13 @@ class AOTInductorModelContainer {
     return output_names_.at(idx).c_str();
   }
 
-  const char* get_input_dtype(size_t idx) const {
-    return input_dtypes_.at(idx).c_str();
-  }
-
-  const char* get_output_dtype(size_t idx) const {
-    return output_dtypes_.at(idx).c_str();
-  }
-
   size_t num_models() const {
     return models_.size();
-  }
-
-  const std::vector<int64_t>& max_input_shape(size_t idx) const {
-    return max_input_shapes_[idx];
-  }
-
-  const std::vector<int64_t>& max_output_shape(size_t idx) const {
-    return max_output_shapes_[idx];
   }
 
  private:
   std::vector<std::string> input_names_;
   std::vector<std::string> output_names_;
-  std::vector<std::string> input_dtypes_;
-  std::vector<std::string> output_dtypes_;
-  // Holds the upper-bound value for each dimension of any input shape.
-  std::vector<std::vector<int64_t>> max_input_shapes_;
-
-  // Holds the upper-bound value for each dimension of any output shape.
-  std::vector<std::vector<int64_t>> max_output_shapes_;
 
 #ifdef USE_CUDA
   // Holds the blob storage for constants' at::Tensor for CUDA.
@@ -219,9 +186,6 @@ class AOTInductorModelContainer {
   // The underlying data of at::Tensor is in either constant_blob_ (for CUDA).
   // or _binary_constants_bin_start (for CPU).
   std::shared_ptr<ConstantMap> constants_;
-
-  // Holds the current value for each dimension of any output shape.
-  std::vector<std::vector<int64_t>> output_shapes_;
 
   // Holds all the AOTInductorModel instances owned by this container.
   std::vector<std::unique_ptr<AOTInductorModel>> models_;


### PR DESCRIPTION
Summary:
This PR removed several APIs from the AOTInductor interface,
which are not used by the client.

It also simplified AOTInductor's model class by removing
the dim info for input/output tensors. We included dim info
before to return max output shapes, which was used by the client
to allocate memory for output tensors. Now, we allocate output
tensor memory from the .so so that we don't need to maintain
such information any more. The deletion of dim info from
the model class also simplified the codegen quite a bit.

Test Plan: ci

Reviewed By: khabinov

Differential Revision: D49835430




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @kadeng @muchulee8 @aakhundov @ColinPeppler