### PR TITLE
bypass nvml for torch.cuda.device_count() if rocm

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -736,7 +736,8 @@ def device_count() -> int:
     r"""Returns the number of GPUs available."""
     if not _is_compiled():
         return 0
-    nvml_count = _device_count_nvml()
+    # bypass _device_count_nvml() if rocm (not supported)
+    nvml_count = -1 if torch.version.hip else _device_count_nvml()
     return torch._C._cuda_getDeviceCount() if nvml_count < 0 else nvml_count
 
 


### PR DESCRIPTION
This is a quick-fix to suppress printing "UserWarning: Can't initialize NVML" when calling torch.cuda.device_count() if [NVIDIA Management Library] (https://developer.nvidia.com/nvidia-management-library-nvml) (nvml module) is installed with ROCm. 
Fixes https://ontrack-internal.amd.com/browse/SWDEV-414997


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang