### PR TITLE
fix cpp_extension.py _run_ninja_build with ['ninja', '--version']

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -2062,7 +2062,7 @@ def _get_num_workers(verbose: bool) -> Optional[int]:
 
 
 def _run_ninja_build(build_directory: str, verbose: bool, error_prefix: str) -> None:
-    command = ['ninja', '-v']
+    command = ['ninja', '--version']
     num_workers = _get_num_workers(verbose)
     if num_workers is not None:
         command.extend(['-j', str(num_workers)])


### PR DESCRIPTION
 ['ninja', '-v'] is now return none-zero
replace with
 ['ninja', '--version']
instead

Fixes #108209
