### PR TITLE
[fx] Add cache_result option in ShapeProp which can help cache interm tensor in meta

### DIFF
--- a/torch/fx/passes/shape_prop.py
+++ b/torch/fx/passes/shape_prop.py
@@ -112,9 +112,9 @@ class ShapeProp(torch.fx.Interpreter):
     Args:
          module (GraphModule): The module to be executed
          fake_mode (FakeTensorMode): A fake mode for copying the gm
-
+         cache_result (bool): Flag to enable caching the result of each node
     """
-    def __init__(self, gm, fake_mode=None):
+    def __init__(self, gm, fake_mode=None, cache_result=False):
         super().__init__(gm)
         if fake_mode is None:
             fake_mode = detect_fake_mode()
@@ -136,6 +136,7 @@ class ShapeProp(torch.fx.Interpreter):
             self.fake_mode = None
 
         self.real_module = self.module
+        self.cache_result = cache_result
 
     def run_node(self, n : Node) -> Any:
         try:
@@ -171,6 +172,8 @@ class ShapeProp(torch.fx.Interpreter):
         meta = map_aggregate(result, extract_tensor_meta)
         if found_tensor:
             n.meta['tensor_meta'] = meta
+            if self.cache_result:
+                n.meta['result'] = result
 
         n.meta['type'] = type(result)
         return result


### PR DESCRIPTION
Summary: While authoring transformations, we want to compare the result before and after to make sure it works as expected. Extending functionality in shape prop to catch interm result by adding "cache_result=True"

Test Plan:
buck run caffe2/test:fx

```
test_shape_prop_cache_result (test_fx.TestFX) ... ok
...
t_type_check_reshape_true (fx.test_gradual_type.TypeCheckerTest) ... ok
test_type_check_symbolic_inferenceconv2D_maxpool2d_flatten (fx.test_gradual_type.TypeCheckerTest) ... ok
test_type_check_transpose_False (fx.test_gradual_type.TypeCheckerTest) ... ok
test_type_check_transpose_true (fx.test_gradual_type.TypeCheckerTest) ... ok
test_type_maxpool2d_fully_static (fx.test_gradual_type.TypeCheckerTest) ... ok
test_type_typechecl_maxpool2d_3dinput (fx.test_gradual_type.TypeCheckerTest) ... ok
test_typecheck_basicblock (fx.test_gradual_type.TypeCheckerTest) ... ok

----------------------------------------------------------------------
Ran 1234 tests in 48.683s
```

Differential Revision: D49857532

