### PR TITLE
Add test_jit_cuda_fuser to ROCM_BLOCKLIST

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -290,6 +290,7 @@ ROCM_BLOCKLIST = [
     "test_determination",
     "test_jit_legacy",
     "test_cuda_nvml_based_avail",
+    "test_jit_cuda_fuser",
 ]
 
 # The tests inside these files should never be run in parallel with each other


### PR DESCRIPTION
Adds the nvfuser related unit test suite to ROCM_BLOCKLIST as should not be run on ROCm.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang