### PR TITLE
[fuzzing result][fuzz_torch_jit_lite_interpreter] read-heap-buffer-overflow-far-from-bounds (size 4) in c10::IValue::IValue()

### DIFF
--- a/torch/csrc/jit/runtime/vararg_functions.cpp
+++ b/torch/csrc/jit/runtime/vararg_functions.cpp
@@ -267,6 +267,9 @@ void listUnpack(Stack& stack, size_t num_outputs) {
 }
 
 void tupleConstruct(Stack& stack, size_t num_inputs) {
+  if (num_inputs > stack.size()) {
+    TORCH_CHECK(false, "Invalid number of inputs: ", num_inputs);
+  }
   switch (num_inputs) {
     case 0:
       stack.emplace_back(c10::ivalue::Tuple::create());


### PR DESCRIPTION
Summary: This diff fixes a heap underflow found by fuzzing in torch/csrc/jit/runtime/vararg_functions.cpp

Test Plan:
CI and
```
arc lionhead crash reproduce 1753074381791061
```
doesn't crash anymore.

Differential Revision: D49537535


