### PR TITLE
[inductor][easy] Free functions in headers should be declared inline

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/model.h
+++ b/torch/csrc/inductor/aoti_runtime/model.h
@@ -83,7 +83,7 @@ class RAIIAtenTensorHandle {
 using ConstantMap = std::unordered_map<std::string, RAIIAtenTensorHandle>;
 
 // Steal the ownership from raw AtenTensorHandle to RAIIAtenTensorHandle
-std::vector<RAIIAtenTensorHandle> steal_from_raw_handles_to_raii_handles(
+inline std::vector<RAIIAtenTensorHandle> steal_from_raw_handles_to_raii_handles(
     AtenTensorHandle* handles,
     size_t size) {
   std::vector<RAIIAtenTensorHandle> result;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #110446
* __->__ #110445

If multiple files include model.h, you end up with duplicate symbols errors.

Differential Revision: [D49842167](https://our.internmc.facebook.com/intern/diff/D49842167/)