### PR TITLE
[aoti] Remove pessimizing move

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/model.h
+++ b/torch/csrc/inductor/aoti_runtime/model.h
@@ -89,7 +89,7 @@ inline std::vector<RAIIAtenTensorHandle> steal_from_raw_handles_to_raii_handles(
   std::vector<RAIIAtenTensorHandle> result;
   result.reserve(size);
   for (size_t i = 0; i < size; i++) {
-    result.push_back(std::move(RAIIAtenTensorHandle(handles[i])));
+    result.emplace_back(handles[i]);
     handles[i] = nullptr;
   }
   return result;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110446
* #110445

"`std::move` of a temporary prevents copy elision" says the compiler,
and I am pretty sure it is right.  Since AtenTensorHandle* implicitly converts
to RAIIAtenTensorHandle, I simply called emplace_back; happy to put an explicit
ctor if that makes folks happier.

Differential Revision: [D49842542](https://our.internmc.facebook.com/intern/diff/D49842542/)