### PR TITLE
[C10D] Split watchdog into CUDA and non-cuda calls.

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1078,7 +1078,7 @@ void ProcessGroupNCCL::workCleanupLoop() {
     auto monitorLastStart = lastMonitorStart_.load();
     if (monitorLastStart != time_point()) {
       auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(
-                      std::chrono::steady_clock::now() - monitorLastStart);
+          std::chrono::steady_clock::now() - monitorLastStart);
       // if the mon thread is running for this long, it's stuck
       // TODO this should probably be a lot smaller than the general timeout
       if (diff > options_->timeout) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110449

A common problem with the current watchdog is that it hangs
trying to abort NCCL or destroy events, those take CUDA locks
that might be held by the main thread that is starved due to a stuck collective.

We do it by introducing a second thread called the monitor thread.

Here some details of this design.

We introduce started_ and _completed_ atomics that track progress.

We set them as part of isCompleted and isStarted. Note that we can't
detect that a collective started if we're not recording those events.

Important visibility rule. We set started_ then completed_ so we must
read them in the opposite order.

Beyond that, we use a pair of queues so collectives can flow between them
as they complete. The new queue is used for the sole purpose of carrying
the destruction on the monitor thread.