### PR TITLE
[fuzzing result][fuzz_torch_jit_lite_interpreter] read-heap-buffer-overflow-far-from-bounds (size 4) in c10::IValue::IValue()

### DIFF
--- a/torch/csrc/jit/mobile/interpreter.cpp
+++ b/torch/csrc/jit/mobile/interpreter.cpp
@@ -129,8 +129,9 @@ bool InterpreterState::run(Stack& stack) {
             }
           }
           if (inst.X < 0 ||
+              static_cast<size_t>(inst.X) >= code.op_names_.size() ||
               static_cast<size_t>(inst.X) >= code.operators_.size()) {
-            throw JITException("Invalid OP Instruction");
+            TORCH_CHECK(false, "Can't load op with index: ", inst.X);
           }
           RECORD_EDGE_SCOPE_WITH_DEBUG_HANDLE_AND_INPUTS(
               code.op_names_[inst.X].name, debug_handle, stack);
@@ -138,6 +139,11 @@ bool InterpreterState::run(Stack& stack) {
           frame.step();
         } break;
         case OPN: {
+          if (inst.X < 0 ||
+              static_cast<size_t>(inst.X) >= code.op_names_.size() ||
+              static_cast<size_t>(inst.X) >= code.operators_.size()) {
+            TORCH_CHECK(false, "Can't load op with index: ", inst.X);
+          }
           stack.emplace_back(inst.N);
           RECORD_EDGE_SCOPE_WITH_DEBUG_HANDLE_AND_INPUTS(
               code.op_names_[inst.X].name, debug_handle, stack);
@@ -149,6 +155,10 @@ bool InterpreterState::run(Stack& stack) {
           callFunction(function, stack);
         } break;
         case INTERFACE_CALL: {
+          if (inst.X < 0 ||
+              static_cast<size_t>(inst.X) >= code.constants_.size()) {
+            TORCH_CHECK(false, "Can't load constant with index: ", inst.X);
+          }
           torch::jit::Function& method =
               peek(stack, 0, inst.N)
                   .toObject()
@@ -185,6 +195,10 @@ bool InterpreterState::run(Stack& stack) {
           frame.step();
           break;
         case LOADC:
+          if (inst.X < 0 ||
+              static_cast<size_t>(inst.X) >= code.constants_.size()) {
+            TORCH_CHECK(false, "Can't load constant with index: ", inst.X);
+          }
           stack.emplace_back(code.constants_[inst.X]);
           frame.step();
           break;


### PR DESCRIPTION
Summary: This diff fixes an OOB read found by fuzzing in torch/../jit/mobile

Test Plan:
CI and
```
arc lionhead crash reproduce 853835926354224
```
doesn't crash anymore.

Differential Revision: D49537377


