### PR TITLE
fix(optim): adagrad sparse multitensor incorrect early exit

### DIFF
--- a/test/optim/test_optim.py
+++ b/test/optim/test_optim.py
@@ -134,8 +134,6 @@ class TestOptim(TestCase):
             if not sparse_only:
                 optimizer_c.step(functools.partial(eval, params_c, False, w))
                 self.assertEqual(params, params_c, atol=5e-6, rtol=5e-6)
-            
-            print("LOOPING", i)
 
         if not maximize:
             self.assertLessEqual(

--- a/test/optim/test_optim.py
+++ b/test/optim/test_optim.py
@@ -82,7 +82,7 @@ class TestOptim(TestCase):
 
         solution = torch.tensor([1, 1])
         with torch.no_grad():
-            initial_dist = torch.sum(torch.stack([param.dist(solution) for param in params]))
+            initial_dist = sum([param.dist(solution) for param in params])
 
         def get_grad(param, sparse_grad):
             grad = drosenbrock(param)
@@ -137,13 +137,13 @@ class TestOptim(TestCase):
 
         if not maximize:
             self.assertLessEqual(
-                torch.sum(torch.stack([param.dist(solution) for param in params])),
+                sum([param.dist(solution) for param in params]),
                 initial_dist
             )
         else:
             self.assertGreaterEqual(
-                torch.sum(torch.stack([rosenbrock(param) for param in params])),
-                torch.sum(torch.stack([rosenbrock(param_t) for param_t in params_t])),
+                sum([rosenbrock(param) for param in params]),
+                sum([rosenbrock(param_t) for param_t in params_t]),
             )
 
     def _test_basic_cases_template(
@@ -621,11 +621,13 @@ class TestOptim(TestCase):
     def test_sgd_sparse(self):
         for foreach in (False, True):
             self._test_rosenbrock_sparse(
-                lambda params: optim.SGD(params, lr=4.8e-3, foreach=foreach)
+                lambda params: optim.SGD(params, lr=4.8e-3, foreach=foreach),
+                multi_tensor=foreach,
             )
             self._test_rosenbrock_sparse(
                 lambda params: optim.SGD(params, lr=0.0048, foreach=foreach),
                 scheduler_constructors=[lambda opt: StepLR(opt, gamma=0.99999, step_size=300)],
+                multi_tensor=foreach,
             )
 
     def test_sgd_complex(self):

--- a/test/optim/test_optim.py
+++ b/test/optim/test_optim.py
@@ -133,7 +133,7 @@ class TestOptim(TestCase):
                     scheduler.step()
             if not sparse_only:
                 optimizer_c.step(functools.partial(eval, params_c, False, w))
-                # Tolerance is increased due to floating point error from different 
+                # Tolerance is increased due to floating point error from different
                 # code path for dense case: x v.s. x - x / 4.0 + x / 4.0
                 self.assertEqual(params, params_c, atol=5e-6, rtol=5e-6)
 

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -324,7 +324,7 @@ def _multi_tensor_adagrad(
         device_has_sparse_grad = any(grad.is_sparse for grad in device_grads)
 
         if device_has_sparse_grad:
-            return _single_tensor_adagrad(
+            _single_tensor_adagrad(
                 device_params,
                 device_grads,
                 device_state_sums,
@@ -337,6 +337,7 @@ def _multi_tensor_adagrad(
                 maximize=False,
                 differentiable=differentiable,
             )
+            continue
 
         if maximize:
             device_grads = torch._foreach_neg(device_grads)


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/110444#issuecomment-1745181530

This PR:
Passes

Main:
```
test/optim/test_optim.py::TestOptim::test_adagrad_sparse FAILED [0.0058s]

==================================================================================================================================== FAILURES =====================================================================================================================================
__________________________________________________________________________________________________________________________ TestOptim.test_adagrad_sparse __________________________________________________________________________________________________________________________
Traceback (most recent call last):
  File "/home/jonch/Desktop/Programming/mlsys/pytorch/test/optim/test_optim.py", line 1448, in test_adagrad_sparse
    self._test_rosenbrock_sparse(
  File "/home/jonch/Desktop/Programming/mlsys/pytorch/test/optim/test_optim.py", line 128, in _test_rosenbrock_sparse
    self.assertEqual(params, params_c, atol=1e-6, rtol=1e-6)
  File "/home/jonch/Desktop/Programming/mlsys/pytorch/torch/testing/_internal/common_utils.py", line 3309, in assertEqual
    raise error_metas.pop()[0].to_error(
AssertionError: Tensor-likes are not close!

Mismatched elements: 1 / 2 (50.0%)
Greatest absolute difference: 0.09999999999993325 at index (1,) (up to 1e-06 allowed)
Greatest relative difference: 0.06249999999996089 at index (1,) (up to 1e-06 allowed)

```

CC: @janeyx99 