### PR TITLE
[inductor] Lower small gemvs on CPU

### DIFF
--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -195,6 +195,9 @@ def addmm(self, mat1, mat2, beta=1, alpha=1):
                 mat1.squeeze(0) * mat2.squeeze(-1), dim=0, keepdim=True
             ).unsqueeze(0)
             return alpha * out + beta * self
+        if mat1.size(0) == 1 and mat2.size(0) <= 16 and mat2.size(1) <= 16:
+            out = (mat1.T * mat2).sum(dim=0, keepdim=True)
+            return alpha * out + beta * self
     return NotImplemented
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110456

If the gemv fits in registers, like [1,16]*[16,16], MKL isn't going to
do much better than compiling a simple for-loop, and we end up paying
allocation overhead and ATen overhead.

A very small internal inference model drops from 7->5 us with this change.

Differential Revision: [D49875991](https://our.internmc.facebook.com/intern/diff/D49875991/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler