### PR TITLE
[torchdynamo] preserve deterministic_algorithms_warn_only in convert_context

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -129,6 +129,7 @@ def wrap_convert_context(fn):
         guards = GlobalStateGuard()
         prior_grad_mode = torch.is_grad_enabled()
         prior_deterministic = torch.are_deterministic_algorithms_enabled()
+        prior_warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
         py_rng_state = random.getstate()
         torch_rng_state = torch.random.get_rng_state()
         if torch.cuda.is_available():
@@ -141,7 +142,9 @@ def wrap_convert_context(fn):
         finally:
             cleanup.close()
             torch._C._set_grad_enabled(prior_grad_mode)
-            torch.use_deterministic_algorithms(prior_deterministic)
+            torch.use_deterministic_algorithms(
+                prior_deterministic, warn_only=prior_warn_only
+            )
             random.setstate(py_rng_state)
             torch.random.set_rng_state(torch_rng_state)
             if torch.cuda.is_available():

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -433,6 +433,7 @@ struct GlobalStateGuard {
     _grad_mode = at::GradMode::is_enabled();
     _torch_function = torch::torch_function_enabled();
     _deterministic_algorithms = ctx.deterministicAlgorithms();
+    _deterministic_algorithms_warn_only = ctx.deterministicAlgorithmsWarnOnly();
     _allow_tf32 = ctx.allowTF32CuBLAS();
     _allow_fp16_reduce = ctx.allowFP16ReductionCuBLAS();
     _allow_bf16_reduce = ctx.allowBF16ReductionCuBLAS();
@@ -445,6 +446,8 @@ struct GlobalStateGuard {
     return (_grad_mode == at::GradMode::is_enabled() &&
             _torch_function == torch::torch_function_enabled() &&
             _deterministic_algorithms == ctx.deterministicAlgorithms() &&
+            _deterministic_algorithms_warn_only ==
+                ctx.deterministicAlgorithmsWarnOnly() &&
             _allow_tf32 == ctx.allowTF32CuBLAS() &&
             _allow_fp16_reduce == ctx.allowFP16ReductionCuBLAS() &&
             _allow_bf16_reduce == ctx.allowBF16ReductionCuBLAS() &&
@@ -455,6 +458,7 @@ struct GlobalStateGuard {
   bool _grad_mode;
   bool _torch_function;
   bool _deterministic_algorithms;
+  bool _deterministic_algorithms_warn_only;
   bool _allow_tf32;
   bool _allow_fp16_reduce;
   bool _allow_bf16_reduce;


### PR DESCRIPTION
Summary: preserve deterministic_algorithms_warn_only  in dynamo context

Test Plan: modified unit tests to test warn_only

Differential Revision: D49872622




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng