### PR TITLE
Fix typo under torch/_dynamo directory

### DIFF
--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -171,7 +171,7 @@ def mark_dynamic(t, index):
     1) torch._dynamo.config dynamic_shapes True or False.
         a) dynamic_shapes=True - dynamic_shapes must be True for mark_dynamic to work.
         a) dynamic_shapes=False - This config will raise an exception when used in conjunction with
-        mark_dyamic. We will eventually support this.
+        mark_dynamic. We will eventually support this.
 
     2) If the dimension is fully constrained - as in, it does not allow more than a single value
     in both eager (torch.compile, torch._dynamo.optimize) mode and export mode (torch._dynamo.export),

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -267,7 +267,7 @@ def enable_dynamic(enable: Optional[bool] = None, export: bool = False):
     if enable is None:
         yield
     elif enable:
-        # Assume everything is dynamic by deafult
+        # Assume everything is dynamic by default
         with config.patch(assume_static_by_default=False):
             yield
     else:
@@ -712,7 +712,7 @@ def explain(f, *extra_args, **extra_kwargs):
             nopython=False,
             guard_export_fn=guard_export_print,
         )(f)
-        # TODO(voz): We may have instances of `f` that mutate inputs, we should track sideffects and reject.
+        # TODO(voz): We may have instances of `f` that mutate inputs, we should track sideeffects and reject.
         opt_f(*args, **kwargs)
 
         graph_count = len(graphs)
@@ -1206,7 +1206,7 @@ def export(
                 export=True,
                 export_constraints=constraints,
             )(f)
-            # TODO(voz): We may have instances of `f` that mutate inputs, we should track sideffects and reject.
+            # TODO(voz): We may have instances of `f` that mutate inputs, we should track sideeffects and reject.
             try:
                 result_traced = opt_f(*args, **kwargs)
             except ConstraintViolationError as e:
@@ -1256,7 +1256,7 @@ def export(
         assert out_guards is not None, "Failed to produce guards during tracing"
         assert fake_mode is not None
 
-        # This check need to happend before aten_graph
+        # This check need to happened before aten_graph
         # because placeholder's _source_node attribute is not preserved by make_fx
         if same_signature:
             check_signature_rewritable(graph)

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -150,7 +150,7 @@ def strip_function_call(name):
     "getattr(getattr(a.x[3], '0'), '3')" ==> "a"
     "a.layers[slice(None, -1, None)][0]._xyz" ==> "a"
     """
-    # recursively find valid object name in fuction
+    # recursively find valid object name in function
     valid_name = re.compile("[A-Za-z_].*")
     curr = ""
     for char in name:
@@ -1021,7 +1021,7 @@ class CheckFunctionManager:
         # info is stored alongside optimized_code and check_fn and is used to
         # limit the number of cache entries with same ID_MATCH'd object.
         # TODO(janimesh) - Currently this information is stored as an attr on
-        # the check_fn itself to avoid changing CacehEntry datastrucutre in
+        # the check_fn itself to avoid changing CacehEntry datastructure in
         # eval_frame.c. In future, we should probably replace check_fn with a
         # queryable data structure such that this information is already present
         # in some form.
@@ -1422,7 +1422,7 @@ def make_dupe_guard(obj_source, dupe_source):
         # so maybe we should do this refactor before we land this...
         # TODO(voz): Combine local and global guard builders.
         if ser_source_is_local == source_is_local:
-            # Note - this is a little agressive - these being duplicate input does not always matter.
+            # Note - this is a little aggressive - these being duplicate input does not always matter.
             # However, this should always be a sound guard to add here.
             return functools.partial(GuardBuilder.DUPLICATE_INPUT, source_b=dupe_source)
     return None

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1198,7 +1198,7 @@ class SubgraphTracer(fx.Tracer):
         # to new Proxy objects that wrap inputs to this subgraph.
         #
         # This dict serves two purposes:
-        # - Proxies are associatd with VariableTrackers. If we see
+        # - Proxies are associated with VariableTrackers. If we see
         # the same VariableTracker twice (and it is a free variable),
         # then we want to use the same Proxy in the current subgraph to
         # record the tracing.
@@ -1216,7 +1216,7 @@ class SubgraphTracer(fx.Tracer):
         self._orig_gm_firstlineno = None
         # Each SubgraphTracer is associated with a source target, which indicates
         # which operator this subgraph is attached to. We compute a source_fn_stack
-        # based on the source tareget. For the root tracer, it's set to [].
+        # based on the source target. For the root tracer, it's set to [].
         # This is useful for debugging and transforming the exported graph.
         if self.parent is None:
             self.source_fn_stack = []

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -440,7 +440,7 @@ class SideEffects:
             # can be generated at any time after this point, and can be generated multiple times! If we were to defer
             # actual codegen of the handle object until we saw a codegen call to it - then we would end up generating multiple
             # register_hook calls, which is incorrect. This turns the codegen reconstruct(handle) call for the handle into
-            # esentially a lookup.
+            # essentially a lookup.
             if (
                 hasattr(handle, "user_code_variable_name")
                 and handle.user_code_variable_name

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -2323,7 +2323,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             trace_call_log.debug("%s", LazyString(get_trace_call_log_str))
         log.debug("INLINING %s%s", code, suffix)
 
-        # Detect inline GraphModule calls in order to propgate node metadata,
+        # Detect inline GraphModule calls in order to propagate node metadata,
         # by checking if the first argument (self) is a variable tracking a GraphModule.
         if args and isinstance(args[0], NNModuleVariable):
             module = parent.output.get_submodule(args[0].module_key)

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1412,7 +1412,7 @@ def run_node(tracer, node, args, kwargs, nnmodule):
     """
     Runs a given node, with the given args and kwargs.
 
-    Behavior is dicatated by a node's op.
+    Behavior is dictated by a node's op.
 
     run_node is useful for extracting real values out of nodes.
     See get_real_value for more info on common usage.
@@ -1581,7 +1581,7 @@ def tensor_always_has_static_shape(
 
     Args:
     tensor - the real tensor to evaluate, parameters force a static shape.
-    is_tensor - internal dynamo check, esentially "is_tensor": target_cls is TensorVariable,
+    is_tensor - internal dynamo check, essentially "is_tensor": target_cls is TensorVariable,
     tensors not in a TensorVariable for whatever reason are forced static.
 
     Returns a tuple, where the first element is the bool of whether or not this tensor should have a static shape.
@@ -1820,7 +1820,7 @@ def defake(x):
 
 
 def is_utils_checkpoint(obj):
-    # Lazy import to avoid circular dependenices
+    # Lazy import to avoid circular dependencies
     import torch.utils.checkpoint
 
     return obj is torch.utils.checkpoint.checkpoint
@@ -1830,8 +1830,8 @@ def build_checkpoint_variable(**options):
     import torch._higher_order_ops.wrap as higher_order_ops
     from .variables.higher_order_ops import TorchHigherOrderOperatorVariable
 
-    # TODO - This is a temporary sitaution where we have two versions of
-    # checkpointing implemetation. We will converge on one and remove the other.
+    # TODO - This is a temporary situation where we have two versions of
+    # checkpointing implementation. We will converge on one and remove the other.
     activation_checkpoint_op = higher_order_ops.tag_activation_checkpoint
     if torch._functorch.config.functionalize_rng_ops:
         activation_checkpoint_op = higher_order_ops.wrap_activation_checkpoint

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1183,7 +1183,7 @@ class VariableBuilder:
 
                 name = self.source.name()
                 if name not in self.tx.output.frame_state:
-                    # Note - this esentially means that if this name gets reused as a tensor,
+                    # Note - this essentially means that if this name gets reused as a tensor,
                     # it will start fully dynamic. That should always be a safe option, and not awfully inefficient.
                     # Alternatively, if we want to improve pef here, we can add a third state of unset, but I am not
                     # sure that is necessary for now.

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -465,7 +465,7 @@ class CustomizedDictVariable(ConstDictVariable):
     # when is_matching_cls(cls) is true
     @classmethod
     def create(cls, user_cls, args, kwargs, options):
-        # avoid tracing when returnning ModelOutput from forward func
+        # avoid tracing when returning ModelOutput from forward func
         for attr_name in ("__init__", "__post_init__", "__setattr__", "__setitem__"):
             if hasattr(user_cls, attr_name):
                 fn = getattr(user_cls, attr_name)

--- a/torch/_dynamo/variables/optimizer.py
+++ b/torch/_dynamo/variables/optimizer.py
@@ -53,7 +53,7 @@ class OptimizerVariable(UserDefinedObjectVariable):
         args: "List[VariableTracker]",
         kwargs: "Dict[str, VariableTracker]",
     ) -> "VariableTracker":
-        """This is an optimization to avoid tracing the very slow intialization of the optimizer"""
+        """This is an optimization to avoid tracing the very slow initialization of the optimizer"""
         if name == "_init_group":
             try:
                 py_args, py_kwargs = self.get_python_args(*args, **kwargs)

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -315,7 +315,7 @@ class TensorVariable(VariableTracker):
                 dyn_length = self.call_method(
                     tx, "size", [ConstantVariable.create(0)], {}
                 )
-                # SymNodeVariable for symbolic sizes, ConstantVariable for constants OR values prouced through
+                # SymNodeVariable for symbolic sizes, ConstantVariable for constants OR values produced through
                 # symbolic_shapes, but that end up as int/sympy.Integer
                 assert isinstance(dyn_length, (SymNodeVariable, ConstantVariable))
                 if isinstance(dyn_length, SymNodeVariable):
@@ -498,9 +498,9 @@ class TensorVariable(VariableTracker):
                 )
             # We don't check that the tensor is on CPU when force is False, as this
             # allows us to execute NumPy code on CUDA.
-            # We don't check that requires_grad=False as we are curently doing an
+            # We don't check that requires_grad=False as we are currently doing an
             # unconditional detach.
-            # TODO: We may want to avoid detching if `requires_grad=True`
+            # TODO: We may want to avoid detaching if `requires_grad=True`
             #       and `force=False` to allow computing gradients.
             force = "force" in kwargs and kwargs["force"].as_python_constant()
             proxy = tx.output.create_proxy(

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -538,7 +538,7 @@ class TorchVariable(VariableTracker):
             invocation_result = self.value(args[0].as_python_constant())
             # Note - while we *could* cook up sources around invocations, like a FunctionSource
             # the space of invoking functions in the middle of the guard chain is very iffy. As such,
-            # guard propagaiton via options is the best we can do.
+            # guard propagation via options is the best we can do.
             from .builder import SourcelessBuilder
 
             return SourcelessBuilder()(tx, invocation_result).add_options(options)


### PR DESCRIPTION
This PR fixes typo of comments in files under `torch/_dynamo` directory


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng