### PR TITLE
Support mutating constant attributes in export

### DIFF
--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1221,7 +1221,7 @@ class InstructionTranslatorBase(Checkpointable[InstructionTranslatorGraphState])
         prior = self.copy_graphstate()
         val, obj = self.popn(2)
 
-        if isinstance(obj, NNModuleVariable):
+        if isinstance(obj, NNModuleVariable) and not isinstance(val, ConstantVariable):
             # We don't allow side effects during export
             # https://github.com/pytorch/torchdynamo/issues/1475
             assert (
@@ -2304,7 +2304,9 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         if code.co_name in ("__setitem__", "__setattr__") and not (
             args is not None
             and len(args) > 0
-            and isinstance(args[0], variables.CustomizedDictVariable)
+            and isinstance(
+                args[0], (variables.CustomizedDictVariable, variables.NNModuleVariable)
+            )
         ):
             unimplemented(f"inline {code.co_name}")
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -2305,7 +2305,12 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             args is not None
             and len(args) > 0
             and isinstance(
-                args[0], (variables.CustomizedDictVariable, variables.NNModuleVariable)
+                args[0],
+                (
+                    variables.CustomizedDictVariable,
+                    variables.NNModuleVariable,
+                    variables.dicts.HFPretrainedConfigVariable,
+                ),
             )
         ):
             unimplemented(f"inline {code.co_name}")

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -183,6 +183,7 @@ class CompileCounter:
 
     def __call__(self, gm: torch.fx.GraphModule, example_inputs):
         self.frame_count += 1
+        print("GRAPH MODULE")
         for node in gm.graph.nodes:
             if "call" in node.op:
                 self.op_count += 1

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1238,6 +1238,10 @@ class BuiltinVariable(VariableTracker):
                         and mod_setattr is torch.nn.Module.__setattr__
                     ):
                         return getattr_var
+            elif name_var.is_python_constant() and isinstance(
+                val, variables.ConstantVariable
+            ):
+                return obj.call_method(tx, "__setattr__", [name_var, val], {})
 
             obj.convert_to_unspecialized(tx)
 

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1238,12 +1238,18 @@ class BuiltinVariable(VariableTracker):
                         and mod_setattr is torch.nn.Module.__setattr__
                     ):
                         return getattr_var
+
             elif name_var.is_python_constant() and isinstance(
                 val, variables.ConstantVariable
             ):
                 return obj.call_method(tx, "__setattr__", [name_var, val], {})
 
             obj.convert_to_unspecialized(tx)
+        elif isinstance(obj, variables.dicts.HFPretrainedConfigVariable):
+            if name_var.is_python_constant() and isinstance(
+                val, variables.ConstantVariable
+            ):
+                return obj.var_setattr(tx, name_var, val)
 
     def call_delattr(self, tx, obj: VariableTracker, name_var: VariableTracker):
         return self.call_setattr(tx, obj, name_var, variables.DeletedVariable())

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1241,7 +1241,7 @@ class BuiltinVariable(VariableTracker):
 
             elif name_var.is_python_constant() and isinstance(
                 val, variables.ConstantVariable
-            ):
+            ) and tx.export:
                 return obj.call_method(tx, "__setattr__", [name_var, val], {})
 
             obj.convert_to_unspecialized(tx)

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -573,13 +573,27 @@ class HFPretrainedConfigVariable(VariableTracker):
     def is_matching_object(cls, obj):
         return cls.is_matching_cls(type(obj))
 
-    def __init__(self, obj, **kwargs):
+    def __init__(self, obj, constant_attributes_tracker_EXPORT_ONLY=None, **kwargs):
         super().__init__(**kwargs)
         self.obj = obj
+        self.constant_attributes_tracker_EXPORT_ONLY = (
+            constant_attributes_tracker_EXPORT_ONLY
+            if constant_attribute_tracker_EXPORT_ONLY is not None
+            else {}
+        )
+
         assert self.is_matching_cls(type(obj))
+
+    def python_type(self):
+        return type(self.obj)
 
     def var_getattr(self, tx, name: str) -> "VariableTracker":
         from . import ConstantVariable
+
+        if tx.export and name in self.constant_attributes_tracker_EXPORT_ONLY:
+            return ConstantVariable.create(
+                self.constant_attributes_tracker_EXPORT_ONLY[name]
+            )
 
         return ConstantVariable.create(getattr(self.obj, name))
 
@@ -587,3 +601,22 @@ class HFPretrainedConfigVariable(VariableTracker):
         return variables.ConstantVariable.create(hasattr(self.obj, name)).add_options(
             self
         )
+
+    def var_setattr(self, tx, name, val):
+        assert name.is_python_constant() and val.is_python_constant()
+        if tx.export:
+            self.constant_attributes_tracker_EXPORT_ONLY[name.value] = val.value
+            return variables.ConstantVariable(None)
+        else:
+            source = (
+                None
+                if self.source is None
+                else AttrSource(self.source, name.as_python_constant())
+            )
+            return tx.inline_user_function_return(
+                variables.UserFunctionVariable(
+                    self.obj.__setattr__.__func__, source=source
+                ),
+                [self] + [name, val],
+                {},
+            )

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -560,6 +560,8 @@ class HFPretrainedConfigVariable(VariableTracker):
     Hack for HuggingFace PretrainedConfig
     """
 
+    _nonvar_fields = ["constant_attribute_tracker_EXPORT_ONLY"]
+
     @staticmethod
     def is_matching_cls(cls):
         try:
@@ -576,7 +578,7 @@ class HFPretrainedConfigVariable(VariableTracker):
     def __init__(self, obj, constant_attribute_tracker_EXPORT_ONLY={}, **kwargs):
         super().__init__(**kwargs)
         self.obj = obj
-        self.constant_attribute_tracker_EXPORT_ONLY = {}
+        self.constant_attribute_tracker_EXPORT_ONLY = constant_attribute_tracker_EXPORT_ONLY
         assert self.is_matching_cls(type(obj))
 
     def python_type(self):

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -87,12 +87,14 @@ class NNModuleVariable(VariableTracker):
         constant_attribute_tracker_EXPORT_ONLY=None,
         **kwargs,
     ):
-        if constant_attribute_tracker_EXPORT_ONLY is None:
-            constant_attribute_tracker_EXPORT_ONLY = {}
         super().__init__(**kwargs)
         self.module_type = module_type
         self.module_key = module_key
-        self.constant_attribute_tracker_EXPORT_ONLY = {}
+        self.constant_attribute_tracker_EXPORT_ONLY = (
+            constant_attribute_tracker_EXPORT_ONLY
+            if constant_attribute_tracker_EXPORT_ONLY is not None
+            else {}
+        )
         assert self.source
 
     def python_type(self):
@@ -675,7 +677,7 @@ class NNModuleVariable(VariableTracker):
                 self.constant_attribute_tracker_EXPORT_ONLY[args[0].value] = args[
                     1
                 ].value
-                return variables.UnknownVariable(**options)
+                return variables.ConstantVariable(None)
         else:
             return super().call_method(tx, name, args, kwargs)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110471

In this PR, we implement simulating setattr on nn.Module and HuggingFacePretrainedConfig objets while not changing the original object. For nn.Module, we do:

1. If the nn.Module has custom setattr, we inline it
2. If the nn.Module has default setattr, we inline it in torch.compile and simulate this behavior in export only. The reason is inlining setattr will cause a graph break (https://github.com/pytorch/pytorch/blame/f2d7faf4ba92a6ed43890775ca6ca174ddbf99ea/torch/nn/modules/module.py#L1755) This is fine because this simulation only happens for constant attributes so it is pretty easy to keep track.

For HuggingFacePreTrained, we do:
1. Inline setattr for torch.compile 
2. Simulate the setattr in torch.export. This seems bit problematic for attributes that are stored inside https://github.com/huggingface/transformers/blob/2f3ea08a077ba3133fa8a604b22436cad250b055/src/transformers/configuration_utils.py#L254 but i am not really sure how likely these occur in practice. If the issue rises, we can probably revisit this issue? 

In the future, I think we should create ExportInstructionTranslator that knows how to deal with mutations. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng 