### PR TITLE
constant output errors

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -2197,7 +2197,7 @@ def forward(self, x):
         with self.assertRaisesRegex(
             AssertionError,
             "graph-captured input #1, of type .*Tensor.*, "
-            "is not among original args of types: .*Tensors",
+            "is not among original inputs of types: .*Tensors",
         ):
             torch._dynamo.export(
                 f, Tensors(x=torch.randn(10), y=torch.randn(10)), aten_graph=False
@@ -2208,7 +2208,7 @@ def forward(self, x):
 
         with self.assertRaisesRegex(
             AssertionError,
-            "traced result #1 is .*Tensors.*, "
+            "original output #1 is .*Tensors.*, "
             "but only the following types are supported",
         ):
             torch._dynamo.export(f, torch.randn(10), torch.randn(10), aten_graph=False)
@@ -2219,7 +2219,7 @@ def forward(self, x):
 
         with self.assertRaisesRegex(
             AssertionError,
-            "traced result #1 is None, but only the following types are supported",
+            "original output #1 is None, but only the following types are supported",
         ):
             torch._dynamo.export(f, torch.randn(10), torch.randn(10), aten_graph=False)
 
@@ -2231,7 +2231,7 @@ def forward(self, x):
 
         with self.assertRaisesRegex(
             AssertionError,
-            "traced result #2 is 5, but only the following types are supported",
+            "original output #2 is 5, but only the following types are supported",
         ):
             torch.export.export(foo, (torch.tensor(3),))
 
@@ -2241,7 +2241,7 @@ def forward(self, x):
         # new behavior
         with self.assertRaisesRegex(
             AssertionError,
-            "traced result #2 is 5, but only the following types are supported",
+            "original output #2 is 5, but only the following types are supported",
         ):
             torch.export.export(bar, (torch.tensor(3), 5))
 
@@ -2250,7 +2250,7 @@ def forward(self, x):
 
         with self.assertRaisesRegex(
             AssertionError,
-            "traced result #2 is 4, but only the following types are supported",
+            "original output #2 is 4, but only the following types are supported",
         ):
             torch.export.export(qux, (torch.tensor(3), 5))
 

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -887,13 +887,17 @@ def rewrite_signature(
     orig_args, orig_kwargs = pytree.tree_unflatten(flat_args, in_spec)
 
     supported_types = (torch.Tensor, torch.SymInt, torch.SymFloat, torch.SymBool)
+
     def is_supported_type(arg):
         return isinstance(arg, supported_types)
 
     def produce_matching(sources, candidates):
         source_types = " or ".join(
             [
-                desc + " of types: (" + ", ".join([str(type(arg)) for arg in args]) + ")"
+                desc
+                + " of types: ("
+                + ", ".join([str(type(arg)) for arg in args])
+                + ")"
                 for desc, args in sources.items()
             ]
         )

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -886,7 +886,7 @@ def rewrite_signature(
 ):
     orig_args, orig_kwargs = pytree.tree_unflatten(flat_args, in_spec)
 
-    supported_types = (torch.Tensor, torch.SymInt, torch.SymFloat)
+    supported_types = (torch.Tensor, torch.SymInt, torch.SymFloat, torch.SymBool)
     def is_supported_type(arg):
         return isinstance(arg, supported_types)
 

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -901,11 +901,11 @@ def rewrite_signature(
 
         for candidate_desc, candidate_args in candidates.items():
             for i, arg in enumerate(candidate_args):
-                # 1-element tensor arg can be unspec int/float
-                if isinstance(arg, torch.Tensor) and torch.numel(arg) == 1:
+                if isinstance(arg, torch.Tensor):
                     if id(arg) in dict_of_source_args:
                         matched_elements_positions.append(dict_of_source_args[id(arg)])
-                    elif id(arg.item()) in dict_of_source_args:
+                    # 1-element tensor arg can be unspec int/float
+                    elif torch.numel(arg) == 1 and id(arg.item()) in dict_of_source_args:
                         matched_elements_positions.append(
                             dict_of_source_args[id(arg.item())]
                         )
@@ -914,11 +914,9 @@ def rewrite_signature(
                             f"{candidate_desc} #{i} ({type(arg)}) is not among {source_types}"
                         )
                 else:
-                    if id(arg) not in dict_of_source_args:
-                        raise AssertionError(
-                            f"{candidate_desc} #{i} ({type(arg)}) is not among {source_types}"
-                        )
-                    matched_elements_positions.append(dict_of_source_args[id(arg)])
+                    raise AssertionError(
+                        f"{candidate_desc} #{i} ({type(arg)}) is not among {source_types}"
+                    )
 
         return matched_elements_positions
 

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -888,44 +888,44 @@ def rewrite_signature(
 
     supported_types = (torch.Tensor, torch.SymInt, torch.SymFloat, torch.SymBool)
 
-    def is_supported_type(arg):
-        return isinstance(arg, supported_types)
+    def is_supported_type(val):
+        return isinstance(val, supported_types)
 
     def produce_matching(sources, candidates):
         source_types = " or ".join(
             [
                 desc
                 + " of types: ("
-                + ", ".join([str(type(arg)) for arg in args])
+                + ", ".join([str(type(val)) for val in vals])
                 + ")"
-                for desc, args in sources.items()
+                for desc, vals in sources.items()
             ]
         )
-        source_args = [arg for args in sources.values() for arg in args]
+        source_vals = [val for vals in sources.values() for val in vals]
         matched_elements_positions = []
-        dict_of_source_args = dict()
-        for i, arg in enumerate(source_args):
-            dict_of_source_args[id(arg)] = i
+        dict_of_source_vals = {}
+        for i, val in enumerate(source_vals):
+            dict_of_source_vals[id(val)] = i
 
-        for candidate_desc, candidate_args in candidates.items():
-            for i, arg in enumerate(candidate_args):
-                if is_supported_type(arg):
-                    if id(arg) in dict_of_source_args:
-                        matched_elements_positions.append(dict_of_source_args[id(arg)])
+        for candidate_desc, candidate_vals in candidates.items():
+            for i, val in enumerate(candidate_vals):
+                if is_supported_type(val):
+                    if id(val) in dict_of_source_vals:
+                        matched_elements_positions.append(dict_of_source_vals[id(val)])
                     else:
                         raise AssertionError(
-                            f"{candidate_desc} #{i+1}, of type {type(arg)}, is not among {source_types}"
+                            f"{candidate_desc} #{i+1}, of type {type(val)}, is not among {source_types}"
                         )
                 else:
                     raise AssertionError(
-                        f"{candidate_desc} #{i+1} is {arg}, but only "
+                        f"{candidate_desc} #{i+1} is {val}, but only "
                         f"the following types are supported: {supported_types}"
                     )
 
         return matched_elements_positions
 
     matched_input_elements_positions = produce_matching(
-        sources={"original args": flat_args},
+        sources={"original inputs": flat_args},
         candidates={"graph-captured input": graph_captured_input},
     )
 
@@ -935,9 +935,9 @@ def rewrite_signature(
     matched_output_elements_positions = produce_matching(
         sources={
             "graph-captured outputs": list(graph_captured_output),
-            "original args": flat_args,
+            "original inputs": flat_args,
         },
-        candidates={"traced result": flat_results_traced},
+        candidates={"original output": flat_results_traced},
     )
 
     new_graph = FlattenInputOutputSignature(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110472

When mapping between the original signature of a program and the graph-captured signature of its exported program, we emit errors when we see unexpected original or graph-captured inputs or outputs. 

These errors can arise because of various reasons, e.g.:
1. some input or output has been lifted because of mutation
2. some type is not pytree-registered for flattening / unflattening
3. some type cannot be realized with graph operations

(This is probably not an exhaustive list.)

Previously we used to emit errors based on a vanilla id-based membership check between the two sides, mostly anticipating (1) as the reason for errors. But this does not do justice to errors because of (2) or (3). 

This PR emits a different error when it finds (3) to be a probable cause. Specifically, it considers only Tensor and Sym* types to be "supported": no other type seems to be realizable by graph operations. 

When (2) is a probable cause, we sometimes also hit the same error because we would expect the supported types to show through upon registration. But this kind of error may need some more work in the future.

Differential Revision: [D49885828](https://our.internmc.facebook.com/intern/diff/D49885828/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng