### PR TITLE
[HigherOrderOp] fallthrough some keys by default.

### DIFF
--- a/functorch/experimental/_map.py
+++ b/functorch/experimental/_map.py
@@ -375,11 +375,3 @@ def map_functionalize(ctx, f, num_mapped, *args):
 
         map_return = map_impl(wrapped_fn, num_mapped, *unwrapped_xs, *unwrapped_args)
         return ctx.wrap_tensors(map_return)
-
-
-# TODO(voz) Make this automatic for keys, this is very ugly atm
-map_impl.fallthrough(DispatchKey.PythonDispatcher)
-map_impl.fallthrough(DispatchKey.PythonTLSSnapshot)
-map_impl.fallthrough(DispatchKey.ADInplaceOrView)
-map_impl.fallthrough(DispatchKey.BackendSelect)
-map_impl.fallthrough(DispatchKey.AutocastCPU)

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -3314,6 +3314,25 @@ class ActivationCheckpointingTests(torch._dynamo.test_case.TestCase):
         backend = aot_autograd(fw_compiler=fw_compiler, bw_compiler=bw_compiler)
         self._validate(fn, backend, x)
 
+    def test_override_fallthrough_dispatch_key(self):
+        test_op = torch._ops.HigherOrderOperator("_fallthrough_test_only")
+        default_keys = torch._ops._HIGHER_ORDER_OP_DEFAULT_FALLTHROUGH_DISPATCH_KEYS
+        self.assertTrue(
+            not any(test_op.non_fallthrough_keys.has(key) for key in default_keys)
+        )
+
+        foos = [lambda x=i: x for i, k in enumerate(default_keys)]
+        for foo, fallthrough_key in zip(foos, default_keys):
+            test_op.py_impl(fallthrough_key)(foo)
+
+        self.assertTrue(
+            all(test_op.non_fallthrough_keys.has(key) for key in default_keys)
+        )
+        self.assertEqual(
+            list(range(len(default_keys))),
+            [test_op.py_kernels[key]() for key in default_keys],
+        )
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/_trace_wrapped_higher_order_op.py
+++ b/torch/_dynamo/_trace_wrapped_higher_order_op.py
@@ -117,12 +117,3 @@ def _trace_wrapped_functionalized(ctx, *args, fn):
     wrapped_fn = ctx.functionalize(fn)
     with ctx.redispatch_to_next():
         return ctx.wrap_tensors(_trace_wrapped_op(*unwrapped_args, fn=wrapped_fn))
-
-
-# TODO(voz): Make this automatic for keys, this is very ugly atm
-_trace_wrapped_op.fallthrough(DispatchKey.PythonDispatcher)  # type: ignore[attr-defined]
-_trace_wrapped_op.fallthrough(DispatchKey.PythonTLSSnapshot)  # type: ignore[attr-defined]
-_trace_wrapped_op.fallthrough(DispatchKey.ADInplaceOrView)
-_trace_wrapped_op.fallthrough(DispatchKey.BackendSelect)
-_trace_wrapped_op.fallthrough(DispatchKey.AutocastCPU)  # type: ignore[attr-defined]
-_trace_wrapped_op.fallthrough(DispatchKey.AutocastCUDA)  # type: ignore[attr-defined]

--- a/torch/_higher_order_ops/cond.py
+++ b/torch/_higher_order_ops/cond.py
@@ -408,12 +408,3 @@ def cond_func(ctx, pred, true_fn, false_fn, inputs):
             unwrapped_pred, functional_true, functional_false, unwrapped_inputs
         )
         return ctx.wrap_tensors(cond_return)
-
-
-# TODO(voz): Make this automatic for keys, this is very ugly atm
-cond_op.fallthrough(DispatchKey.PythonDispatcher)  # type: ignore[attr-defined]
-cond_op.fallthrough(DispatchKey.PythonTLSSnapshot)  # type: ignore[attr-defined]
-cond_op.fallthrough(DispatchKey.ADInplaceOrView)
-cond_op.fallthrough(DispatchKey.BackendSelect)
-cond_op.fallthrough(DispatchKey.AutocastCPU)  # type: ignore[attr-defined]
-cond_op.fallthrough(DispatchKey.AutocastCUDA)  # type: ignore[attr-defined]

--- a/torch/_higher_order_ops/out_dtype.py
+++ b/torch/_higher_order_ops/out_dtype.py
@@ -75,12 +75,6 @@ class OutDtypeOperator(HigherOrderOperator):
 
 
 out_dtype = OutDtypeOperator()
-out_dtype.fallthrough(DispatchKey.PythonDispatcher)  # type: ignore[attr-defined]
-out_dtype.fallthrough(DispatchKey.PythonTLSSnapshot)  # type: ignore[attr-defined]
-out_dtype.fallthrough(DispatchKey.ADInplaceOrView)  # type: ignore[attr-defined]
-out_dtype.fallthrough(DispatchKey.BackendSelect)  # type: ignore[attr-defined]
-out_dtype.fallthrough(DispatchKey.AutocastCPU)  # type: ignore[attr-defined]
-
 
 def trace_out_dtype(proxy_mode, func_overload, op, output_dtype, *args):
     # NB: Long-term we should put the decomposition logic into

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -279,8 +279,7 @@ class HigherOrderOperator(OperatorBase):
 
     def py_impl(self, k):
         if isinstance(k, torch._C.DispatchKey) and not self.non_fallthrough_keys.has(k):
-            self.non_fallthrough_keys.add(k)
-
+            self.non_fallthrough_keys = self.non_fallthrough_keys.add(k)
         return super().py_impl(k)
 
     @property

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -234,6 +234,15 @@ def resolve_key(op: OperatorBase, k: DispatchKey):  # type: ignore[valid-type]
 _global_higher_order_ops = {}
 _higher_order_ops = {}
 
+_HIGHER_ORDER_OP_DEFAULT_FALLTHROUGH_DISPATCH_KEYS = [
+    DispatchKey.PythonDispatcher,  # type: ignore[attr-defined]
+    DispatchKey.PythonTLSSnapshot,  # type: ignore[attr-defined]
+    DispatchKey.ADInplaceOrView,
+    DispatchKey.BackendSelect,
+    DispatchKey.AutocastCPU,  # type: ignore[attr-defined]
+    DispatchKey.AutocastCUDA,  # type: ignore[attr-defined]
+]
+
 
 class HigherOrderOperator(OperatorBase):
     # _deprecated_global_ns: Whether or not the HigherOrderOperator appears as:
@@ -264,6 +273,15 @@ class HigherOrderOperator(OperatorBase):
             self_name_space = "." + self.namespace if self.namespace else ""
             self.__module__ = self.__module__ + self_name_space
         self.non_fallthrough_keys = torch._C._dispatch_keyset_full()
+
+        for dispatch_key in _HIGHER_ORDER_OP_DEFAULT_FALLTHROUGH_DISPATCH_KEYS:
+            self.fallthrough(dispatch_key)
+
+    def py_impl(self, k):
+        if isinstance(k, torch._C.DispatchKey) and not self.non_fallthrough_keys.has(k):
+            self.non_fallthrough_keys.add(k)
+
+        return super().py_impl(k)
 
     @property
     def namespace(self):

--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -161,12 +161,6 @@ def get_device(args, kwargs):
 def register_run_and_save_rng_state_op():
     run_and_save_rng_state = HigherOrderOperator("run_and_save_rng_state")
 
-    run_and_save_rng_state.fallthrough(DispatchKey.ADInplaceOrView)
-    run_and_save_rng_state.fallthrough(DispatchKey.AutocastCPU)  # type: ignore[attr-defined]
-    run_and_save_rng_state.fallthrough(DispatchKey.AutocastCUDA)  # type: ignore[attr-defined]
-    run_and_save_rng_state.fallthrough(DispatchKey.PythonDispatcher)  # type: ignore[attr-defined]
-    run_and_save_rng_state.fallthrough(DispatchKey.PythonTLSSnapshot)  # type: ignore[attr-defined]
-
     run_and_save_rng_state.py_impl(DispatchKey.Autograd)(
         autograd_not_implemented(run_and_save_rng_state, deferred_error=True)
     )
@@ -211,12 +205,6 @@ def register_run_and_save_rng_state_op():
 
 def register_run_with_rng_state_op():
     run_with_rng_state = HigherOrderOperator("run_with_rng_state")
-
-    run_with_rng_state.fallthrough(DispatchKey.ADInplaceOrView)
-    run_with_rng_state.fallthrough(DispatchKey.AutocastCPU)  # type: ignore[attr-defined]
-    run_with_rng_state.fallthrough(DispatchKey.AutocastCUDA)  # type: ignore[attr-defined]
-    run_with_rng_state.fallthrough(DispatchKey.PythonTLSSnapshot)  # type: ignore[attr-defined]
-    run_with_rng_state.fallthrough(DispatchKey.PythonDispatcher)  # type: ignore[attr-defined]
 
     run_with_rng_state.py_impl(DispatchKey.Autograd)(
         autograd_not_implemented(run_with_rng_state, deferred_error=True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110478

Fixes #109253

Test Plan:
Added a new test that shows default fallthrough keys can be overrided.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @avikchaudhuri @gmagogsfm @zou3519