### PR TITLE
[aotinductor] Fix benchmarks with self.autocast

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/aot_inductor_huggingface_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/aot_inductor_huggingface_inference.csv
@@ -19,10 +19,10 @@ DistilBertForQuestionAnswering,pass,0
 DistillGPT2,pass,0
 ElectraForCausalLM,pass,0
 ElectraForQuestionAnswering,pass,0
-GPT2ForSequenceClassification,fail_to_run,0
+GPT2ForSequenceClassification,pass,0
 GoogleFnet,pass,0
 LayoutLMForMaskedLM,pass,0
-LayoutLMForSequenceClassification,fail_to_run,0
+LayoutLMForSequenceClassification,pass,0
 M2M100ForConditionalGeneration,pass,0
 MBartForCausalLM,pass,0
 MBartForConditionalGeneration,pass,0

--- a/benchmarks/dynamo/ci_expected_accuracy/aot_inductor_timm_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/aot_inductor_timm_inference.csv
@@ -4,7 +4,7 @@ beit_base_patch16_224,pass,0
 botnet26t_256,pass,0
 cait_m36_384,infra_error,0
 coat_lite_mini,pass,0
-convit_base,fail_to_run,0
+convit_base,pass,0
 convmixer_768_32,pass,0
 convnext_base,pass,0
 crossvit_9_240,pass,0
@@ -59,4 +59,4 @@ twins_pcpvt_base,pass,0
 visformer_small,pass,0
 vit_base_patch16_224,pass,0
 volo_d1_224,pass,0
-xcit_large_24_p8_224,fail_accuracy,0
+xcit_large_24_p8_224,pass,0

--- a/benchmarks/dynamo/ci_expected_accuracy/aot_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/aot_inductor_torchbench_inference.csv
@@ -61,4 +61,4 @@ timm_vision_transformer_large,pass_due_to_skip,0
 timm_vovnet,pass,0
 tts_angular,fail_to_run,0
 vgg16,pass,0
-yolov3,fail_to_run,0
+yolov3,pass,0

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_dynamic_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_dynamic_inference.csv
@@ -31,7 +31,6 @@ mnasnet1_0,pass,0
 mobilenet_v2,pass,0
 mobilenet_v3_large,pass,0
 moco,pass,11
-nanogpt,pass,0
 nvidia_deeprecommender,pass,0
 opacus_cifar10,pass,32
 phlippe_densenet,pass,0

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -709,9 +709,7 @@ def speedup_experiment(args, model_iter_fn, model, example_inputs, **kwargs):
 
     with maybe_profile(args.export_profiler_trace) as p:
         if args.export_aot_inductor:
-            frozen_model_iter_fn = export_aot_inductor(
-                model, example_inputs, model_iter_fn
-            )
+            frozen_model_iter_fn = export_aot_inductor(model, example_inputs)
         else:
             frozen_model_iter_fn = torch._dynamo.run(model_iter_fn)
 
@@ -1155,16 +1153,14 @@ class AOTInductorModelCache:
     cache = dict()
 
     @classmethod
-    def load(cls, model, example_inputs, eager_forward):
+    def load(cls, model, example_inputs):
         key = weakref.ref(model)
         if key not in cls.cache:
             # Register the output dataclass to pytree
-            example_outputs = eager_forward(
-                copy.deepcopy(model), clone_inputs(example_inputs)
-            )
+            example_args, example_kwargs = _normalize_bench_inputs(example_inputs)
+            example_outputs = model(*example_args, **example_kwargs)
             _register_dataclass_output_as_pytree(example_outputs)
 
-            example_args, example_kwargs = _normalize_bench_inputs(example_inputs)
             so_path, exported = torch._export.aot_compile(
                 model, example_args, example_kwargs
             )
@@ -1189,8 +1185,8 @@ class AOTInductorModelCache:
         )
 
 
-def export_aot_inductor(model, example_inputs, eager_forward):
-    module, exported = AOTInductorModelCache.load(model, example_inputs, eager_forward)
+def export_aot_inductor(model, example_inputs):
+    module, exported = AOTInductorModelCache.load(model, example_inputs)
 
     def opt_aot_inductor(_, example_inputs, collect_outputs=False):
         example_args, example_kwargs = _normalize_bench_inputs(example_inputs)
@@ -2305,6 +2301,13 @@ class BenchmarkRunner:
                         new_result = optimized_model_iter_fn(
                             *example_args, **example_kwargs
                         )
+                if self.args.export_aot_inductor:
+                    # apply export on module directly
+                    # no need for n iterations
+                    # the logic should be the same to self.model_iter_fn (forward_pass)
+                    with self.autocast():
+                        optimized_model_iter_fn = optimize_ctx()
+                        new_result = optimized_model_iter_fn(model_copy, example_inputs)
                 else:
                     optimized_model_iter_fn = optimize_ctx(self.run_n_iterations)
                     new_result = optimized_model_iter_fn(model_copy, example_inputs)
@@ -2496,7 +2499,7 @@ class BenchmarkRunner:
 
             if self.args.export_aot_inductor:
                 t_0 = time.perf_counter()
-                optimized_model_iter_fn = optimize_ctx(self.model_iter_fn)
+                optimized_model_iter_fn = optimize_ctx()
                 t_1 = time.perf_counter()
                 aot_compilation_time = t_1 - t_0
             else:


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/108173

The original error was that there was a type mismatch between the output of eager mode (float16) and from aot_compile (float32). This is because when we run the model eagerly in the benchmarks, we call [self.model_iter_fn](https://github.com/pytorch/pytorch/blob/main/benchmarks/dynamo/common.py#L2072-L2076) to run the model, rather than directly calling the model. In the case of timm models, it calls the model with [self.autocast()](https://github.com/pytorch/pytorch/blob/main/benchmarks/dynamo/timm_models.py#L321-L323), causing the eager model to return a float16 value. However, the model we export with aot_compile does not have the self.autocast context, so it returns float32. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng