### PR TITLE
Fix CosineAnnealingWarmRestarts resumption from high step counts

### DIFF
--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1408,7 +1408,7 @@ class CosineAnnealingWarmRestarts(LRScheduler):
         if epoch is None:
             epoch = self.last_epoch + 1
             self.T_cur = self.T_cur + 1
-            if self.T_cur >= self.T_i:
+            while self.T_cur >= self.T_i:
                 self.T_cur = self.T_cur - self.T_i
                 self.T_i = self.T_i * self.T_mult
         else:


### PR DESCRIPTION
Fixes #88791.

If you try to resume a CosineAnnealingWarmRestarts schedule from anything except a low step count, you get fun learning rates that make your day better:  
<img width="846" alt="image" src="https://github.com/pytorch/pytorch/assets/6141784/e2d70480-0bc3-4f3f-b600-8e19204e6a3b">

See the [notebook](https://github.com/Birch-san/scheduler-play/blob/65eafcd7264042d16a8a295c84c219736c223131/script/repro.ipynb) with which I classified the behaviour and manually validated the fix.

<img width="793" alt="image" src="https://github.com/pytorch/pytorch/assets/6141784/30b13589-3aaa-4306-9610-d001bc551667">

It's worth noting though that #88791 proposes a loopless solution based on modular arithmetic. I haven't checked whether the solutions are equivalent, but that approach sounds better if it can be confirmed as working.