### PR TITLE
[sparse] Add i8i8->i32 support for cuSPARSELt

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -119,6 +119,7 @@ at::Tensor _cslt_sparse_mm(
   cudaDataType output_type;
   cusparseComputeType compute_type;
   auto compression_factor = 9;
+  c10::ScalarType pytorch_output_type;
 
 
   switch(compressed_A.scalar_type())
@@ -157,11 +158,13 @@ at::Tensor _cslt_sparse_mm(
     {
         output_type = CUDA_R_16F;
         mixed_dtype_mode = true;
+        pytorch_output_type = out_dtype;
     }
     else if (input_type == CUDA_R_8I and out_dtype == at::ScalarType::Int)
     {
         output_type = CUDA_R_32I;
         mixed_dtype_mode = true;
+        pytorch_output_type = out_dtype;
     }
     else
     {
@@ -202,8 +205,8 @@ at::Tensor _cslt_sparse_mm(
   at::Tensor res;
   if (mixed_dtype_mode)
   {
-      res = (transpose_result) ? at::empty({n, m}, c10::TensorOptions().dtype(c10::kHalf).device(dense_B.device()))
-                               : at::empty({m, n}, c10::TensorOptions().dtype(c10::kHalf).device(dense_B.device()));
+      res = (transpose_result) ? at::empty({n, m}, c10::TensorOptions().dtype(pytorch_output_type).device(dense_B.device()))
+                               : at::empty({m, n}, c10::TensorOptions().dtype(pytorch_output_type).device(dense_B.device()));
   }
   else
   {

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -158,6 +158,11 @@ at::Tensor _cslt_sparse_mm(
         output_type = CUDA_R_16F;
         mixed_dtype_mode = true;
     }
+    else if (input_type == CUDA_R_8I and out_dtype == at::ScalarType::Int)
+    {
+        output_type = CUDA_R_32I;
+        mixed_dtype_mode = true;
+    }
     else
     {
         TORCH_CHECK(false, "Setting out_dtype is only supported for int8 input and fp16 output.");

--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -244,7 +244,7 @@ class TestSparseSemiStructured(TestCase):
 
             B = torch.rand((128, 128), device=A_sparse.device).to(torch.int8)
 
-            dense_result = torch.mm(A.cpu(), B.t().cpu()).to(device, dtype=torch.float16)
+            dense_result = torch.mm(A.cpu(), B.t().cpu()).to(device, dtype=torch.int32)
             sparse_result = torch._cslt_sparse_mm(A_sparse.compressed_tensor_cusparselt, B.t(), out_dtype=torch.int32)
             assert torch.allclose(dense_result, sparse_result, rtol=1e-3, atol=1e-3)
 

--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -233,6 +233,21 @@ class TestSparseSemiStructured(TestCase):
             sparse_result = torch._cslt_sparse_mm(A_sparse.compressed_tensor_cusparselt, B.t(), out_dtype=torch.float16)
             assert torch.allclose(dense_result, sparse_result, rtol=1e-3, atol=1e-3)
 
+    def test_cslt_sparse_mm_int8_in_int32_out(self, device):
+        """
+        This test is only needed for cuSPARSELt
+        """
+        if "cusparselt" in SEMI_STRUCTURED_SUPPORTED_BACKENDS:
+            SparseSemiStructuredTensor._FORCE_CUTLASS = False
+            A = rand_sparse_semi_structured_mask(128, 128, dtype=torch.int8)
+            A_sparse = to_sparse_semi_structured(A)
+
+            B = torch.rand((128, 128), device=A_sparse.device).to(torch.int8)
+
+            dense_result = torch.mm(A.cpu(), B.t().cpu()).to(device, dtype=torch.float16)
+            sparse_result = torch._cslt_sparse_mm(A_sparse.compressed_tensor_cusparselt, B.t(), out_dtype=torch.int32)
+            assert torch.allclose(dense_result, sparse_result, rtol=1e-3, atol=1e-3)
+
     @dtypes(*SEMI_STRUCTURED_SUPPORTED_DTYPES)
     @parametrize("backend", SEMI_STRUCTURED_SUPPORTED_BACKENDS)
     def test_mm_sparse_second_NT(self, dtype, device, backend):

--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -166,8 +166,8 @@ class TestSparseSemiStructured(TestCase):
             # test transpose
             # NOTE: CUTLASS and cuSPARSELt have slightly different int8 behavior.
             # CUTLASS will output to an int32 tensor while cuSPARSELt will output to a int8 tensor
-            dense_result = torch.mm(A.cpu(), B.t().cpu()).to(device, dtype=torch.int32 if backend == "cutlass" else torch.int8)
-            sparse_result = torch.mm(A_sparse, B.t())
+            dense_result = torch.mm(A.cpu(), B.t().cpu()).to(device, dtype=torch.int64)
+            sparse_result = torch.mm(A_sparse, B.t()).to(device, dtype=torch.int64)
             assert torch.allclose(dense_result, sparse_result, rtol=1e-3, atol=1e-3)
         else:
             dense_result = torch.mm(A, B)
@@ -210,8 +210,8 @@ class TestSparseSemiStructured(TestCase):
 
         # Currently we don't support int matmul on GPU, so evaluate on CPU and copy over
         if dtype is torch.int8:
-            dense_result = torch.mm(A.cpu(), B.t().cpu()).to(device, dtype=torch.int32 if backend == "cutlass" else torch.int8)
-            sparse_result = torch.mm(A, B_sparse.t())
+            dense_result = torch.mm(A.cpu(), B.t().cpu()).to(device, torch.int64)
+            sparse_result = torch.mm(A, B_sparse.t()).to(device, torch.int64)
         else:
             dense_result = torch.mm(A, B.t())
             sparse_result = torch.mm(A, B_sparse.t())
@@ -220,7 +220,7 @@ class TestSparseSemiStructured(TestCase):
 
     def test_cslt_sparse_mm_int8_in_fp16_out(self, device):
         """
-        This test is only needed for cuSPARSELt
+        Test sparse mam with int8 input with fp16 output for cuSPARSELt
         """
         if "cusparselt" in SEMI_STRUCTURED_SUPPORTED_BACKENDS:
             SparseSemiStructuredTensor._FORCE_CUTLASS = False
@@ -235,7 +235,7 @@ class TestSparseSemiStructured(TestCase):
 
     def test_cslt_sparse_mm_int8_in_int32_out(self, device):
         """
-        This test is only needed for cuSPARSELt
+        Test sparse mam with int8 input with int32 output for cuSPARSELt
         """
         if "cusparselt" in SEMI_STRUCTURED_SUPPORTED_BACKENDS:
             SparseSemiStructuredTensor._FORCE_CUTLASS = False
@@ -244,8 +244,8 @@ class TestSparseSemiStructured(TestCase):
 
             B = torch.rand((128, 128), device=A_sparse.device).to(torch.int8)
 
-            dense_result = torch.mm(A.cpu(), B.t().cpu()).to(device, dtype=torch.int32)
-            sparse_result = torch._cslt_sparse_mm(A_sparse.compressed_tensor_cusparselt, B.t(), out_dtype=torch.int32)
+            dense_result = torch.mm(A.cpu(), B.t().cpu()).to(device, dtype=torch.int64)
+            sparse_result = torch._cslt_sparse_mm(A_sparse.compressed_tensor_cusparselt, B.t(), out_dtype=torch.int32).to(device, torch.int64)
             assert torch.allclose(dense_result, sparse_result, rtol=1e-3, atol=1e-3)
 
     @dtypes(*SEMI_STRUCTURED_SUPPORTED_DTYPES)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110499

Summary:

With the release of cuSPARSELt v0.5.0, we now have support for
int8 int8 -> int32 matmul.

This PR adds support for this via out_dtype.

Test Plan:
```
python test/test_sparse_semi_structured.py -k int32
```

Reviewers:

Subscribers:

Tasks:

Tags: