### PR TITLE
[DEMO] cached allocate across devices

### DIFF
--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -13,7 +13,7 @@
       if (get_error_str_err != CUDA_SUCCESS) {                             \
         AT_ERROR("CUDA driver error: unknown error");                      \
       } else {                                                             \
-        AT_ERROR("CUDA driver error: ", err_str);                          \
+        AT_ERROR(__FILE__, __LINE__, "CUDA driver error: ", err_str);                          \
       }                                                                    \
     }                                                                      \
   } while (0)

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -920,3 +920,11 @@ def _get_current_allocator() -> _CUDAAllocator:
         See :ref:`cuda-memory-management` for details on creating and using a custom allocator
     """
     return _CUDAAllocator(torch._C._cuda_getAllocator())
+
+@contextlib.contextmanager
+def _multi_device_allocator():
+    try:
+        prev = torch._C.set_multi_device_allocator(True)
+        yield
+    finally:
+        torch._C.set_multi_device_allocator(prev)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110500

This is a demo of functionality that allows the caching allocator to create
as single tensor that exists allocated across all devices. The outer stride of
the tensor steps across the allocations on different devices.

The implementation uses the expandable segment functionality to control the
mapping of memory to ensure a single stride to cross devices. For N devices,
it creates N blocks of virtual memory that are sequential. Then it performs
the same map/unmap operations in each block, but wiring memory from the
corresponding devices. We use the standard caching allocator to manage
the allocation as if it were on just one of the devices and then hack
in the extra stride that reveals that we also allocated memory on the other devices.

Bug - the tensor returned from _reveal_multiple_devices does not own the data. The original tensor needs to be kept around to keep it alive. This can probably be fixed using the right DataPtr callbacks to keep a handle on the right storage object.

    import torch

    # tensors allocated under this guard will be
    # allocated as a copy per device,
    # torch will think the tensor is allocated on
    # whatever the 'current' device is.
    with torch.cuda.memory._multi_device_allocator():
        x = torch.empty(3, 4, device='cuda')

    # use this function to get a tensor with a stride over
    # all the devices. the second argument tells torch
    # where it should run the kernels on it
    y = torch._C._reveal_multiple_devices(x, torch.device('cuda', 1))
    print(y.size()) # 2, 3, 4
    # note: no need for enable peer access!
    y.fill_(4)
    print(y)