### PR TITLE
Use CUDA image for lintrunner

### DIFF
--- a/.ci/docker/common/install_base.sh
+++ b/.ci/docker/common/install_base.sh
@@ -28,7 +28,7 @@ install_ubuntu() {
   elif [[ "$CLANG_VERSION" == 10 ]]; then
     maybe_libomp_dev="libomp-10-dev"
   else
-    maybe_libomp_dev=""
+    maybe_libomp_dev="libomp-dev"
   fi
 
   # HACK: UCC testing relies on libnccl library from NVIDIA repo, and version 2.16 crashes

--- a/.ci/docker/common/install_base.sh
+++ b/.ci/docker/common/install_base.sh
@@ -28,7 +28,7 @@ install_ubuntu() {
   elif [[ "$CLANG_VERSION" == 10 ]]; then
     maybe_libomp_dev="libomp-10-dev"
   else
-    maybe_libomp_dev="libomp-dev"
+    maybe_libomp_dev=""
   fi
 
   # HACK: UCC testing relies on libnccl library from NVIDIA repo, and version 2.16 crashes

--- a/.ci/docker/linter-cuda/Dockerfile
+++ b/.ci/docker/linter-cuda/Dockerfile
@@ -10,6 +10,9 @@ ENV DEBIAN_FRONTEND noninteractive
 COPY ./common/install_base.sh install_base.sh
 RUN bash ./install_base.sh && rm install_base.sh
 
+# Install missing libomp-dev
+RUN apt-get update && apt-get install -y --no-install-recommends libomp-dev && apt-get autoclean && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 # Install user
 COPY ./common/install_user.sh install_user.sh
 RUN bash ./install_user.sh && rm install_user.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
     with:
       timeout: 120
       runner: linux.2xlarge
-      docker-image: pytorch-linux-focal-linter
+      docker-image: pytorch-linux-jammy-cuda11.8-cudnn8-py3.9-linter
       fetch-depth: 0
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -464,13 +464,8 @@ static PyObject* THPStorage_newSharedCuda(PyObject* _unused, PyObject* args) {
   ptrdiff_t storage_offset_bytes =
       (ptrdiff_t)THPUtils_unpackLong(_offset_bytes);
 
-  auto unpacked_device = THPUtils_unpackInt(_device);
-  THPUtils_assert(
-      unpacked_device >= std::numeric_limits<c10::DeviceIndex>::min() &&
-          unpacked_device <= std::numeric_limits<c10::DeviceIndex>::max(),
-      "invalid device index",
-      unpacked_device);
-  c10::DeviceIndex device = static_cast<c10::DeviceIndex>(unpacked_device);
+  const auto device = c10::checked_convert<c10::DeviceIndex>(
+      THPUtils_unpackLong(_device), "c10::DeviceIndex");
   at::cuda::CUDAGuard device_guard(device);
 
   if (PyObject_IsTrue(_event_sync_required)) {


### PR DESCRIPTION
We switch to pytorch-linux-jammy-cuda11.8-cudnn8-py3.9-linter for lintrunner for checking CUDA cpp source. Meanwhile, there is a Dockerfile change due to missing libiomp installation and some other clang-tidy fixes triggered by the switch. 

cc @malfet 
