### PR TITLE
Disable dynamo cache limit when PYTORCH_TEST_WITH_DYNAMO=1

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -260,6 +260,7 @@ test_dynamo_shard() {
       test_reductions \
       test_namedtensor \
       test_namedtuple_return_api \
+      test_nestedtensor \
       profiler/test_profiler \
       profiler/test_profiler_tree \
       test_overrides \

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -136,8 +136,9 @@ jobs:
           { config: "default", shard: 3, num_shards: 3, runner: "linux.2xlarge" },
           { config: "crossref", shard: 1, num_shards: 2, runner: "linux.2xlarge" },
           { config: "crossref", shard: 2, num_shards: 2, runner: "linux.2xlarge" },
-          { config: "dynamo", shard: 1, num_shards: 2, runner: "linux.2xlarge" },
-          { config: "dynamo", shard: 2, num_shards: 2, runner: "linux.2xlarge" },
+          { config: "dynamo", shard: 1, num_shards: 3, runner: "linux.2xlarge" },
+          { config: "dynamo", shard: 2, num_shards: 3, runner: "linux.2xlarge" },
+          { config: "dynamo", shard: 3, num_shards: 3, runner: "linux.2xlarge" },
         ]}
 
   linux-focal-py3_8-clang10-test:
@@ -162,8 +163,9 @@ jobs:
           { config: "default", shard: 3, num_shards: 3, runner: "linux.2xlarge" },
           { config: "crossref", shard: 1, num_shards: 2, runner: "linux.2xlarge" },
           { config: "crossref", shard: 2, num_shards: 2, runner: "linux.2xlarge" },
-          { config: "dynamo", shard: 1, num_shards: 2, runner: "linux.2xlarge" },
-          { config: "dynamo", shard: 2, num_shards: 2, runner: "linux.2xlarge" },
+          { config: "dynamo", shard: 1, num_shards: 3, runner: "linux.2xlarge" },
+          { config: "dynamo", shard: 2, num_shards: 3, runner: "linux.2xlarge" },
+          { config: "dynamo", shard: 3, num_shards: 3, runner: "linux.2xlarge" },
         ]}
 
   linux-focal-py3_11-clang10-test:

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -296,6 +296,7 @@ class TestGradTransform(TestCase):
 
         self.assertEqual(result, expected)
 
+    @skipIfTorchDynamo()
     def test_inplace_on_captures(self, device):
         x = torch.tensor([1., 2., 3.], device=device)
         captured = torch.randn(3, device=device)
@@ -2324,6 +2325,7 @@ class TestHessian(TestCase):
 
 
 class TestJvp(TestCase):
+    @skipIfTorchDynamo()
     def test_inplace_on_captures(self, device):
         x = torch.tensor([1., 2., 3.], device=device)
         captured = torch.randn(3, device=device)
@@ -3294,6 +3296,7 @@ class TestComposability(TestCase):
     @parametrize('transform', [
         'vmap', 'grad', 'jacrev', 'jacfwd', 'grad_and_value', 'hessian', 'functionalize'
     ])
+    @skipIfTorchDynamo()
     def test_autograd_function_no_setup_context(self, device, transform):
         class MySin(torch.autograd.Function):
             @staticmethod

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -11,7 +11,7 @@ import unittest
 
 from torch.testing._internal.common_utils import TestCase, run_tests, is_iterable_of_tensors, IS_MACOS, \
     IS_X86, parametrize, TEST_WITH_ASAN, noncontiguous_like
-from torch.testing._internal.common_utils import skipIfRocm, runOnRocm
+from torch.testing._internal.common_utils import skipIfRocm, runOnRocm, skipIfTorchDynamo
 import torch
 from torch import Tensor
 import functools
@@ -326,6 +326,8 @@ vjp_fail = {
     decorate('nn.functional.layer_norm', decorator=skipIfRocm),
     # https://github.com/pytorch/pytorch/issues/96560
     decorate('nn.functional.scaled_dot_product_attention', decorator=skipIfRocm),
+    decorate('svd', decorator=skipIfTorchDynamo()),
+    decorate('linalg.svd', decorator=skipIfTorchDynamo()),
 }
 
 aliasing_ops = {
@@ -939,6 +941,8 @@ class TestOperators(TestCase):
         xfail('sparse.mm', 'reduce'),
         xfail('as_strided_scatter', ''),  # calls as_strided
         xfail('index_reduce', ''),  # .item() call
+        decorate('svd', decorator=skipIfTorchDynamo()),
+        decorate('linalg.svd', decorator=skipIfTorchDynamo()),
         # ---------------------------------------------------------------------
     })
 
@@ -1225,6 +1229,8 @@ class TestOperators(TestCase):
         xfail("_native_batch_norm_legit"),
         xfail("native_dropout_backward"),
         xfail("index_fill"),  # aten::_unique hit the vmap fallback which is currently disabled
+        decorate('svd', decorator=skipIfTorchDynamo()),
+        decorate('linalg.svd', decorator=skipIfTorchDynamo()),
     }))
     def test_vmapvjp_has_batch_rule(self, device, dtype, op):
         if not op.supports_autograd:
@@ -1394,6 +1400,7 @@ class TestOperators(TestCase):
         xfail('index_reduce', ''),  # NYI: forward-AD for index_reduce
         xfail('_segment_reduce', 'lengths'),  # NYI: forward-AD for _segment_reduce
         xfail('native_dropout_backward'),  # NYI
+        decorate('addcdiv', decorator=skipIfTorchDynamo()),
 
     }))
     @opsToleranceOverride('TestOperators', 'test_jvpvjp', (

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1565,6 +1565,7 @@ class TestBinaryUfuncs(TestCase):
             regex = "doesn't match the broadcast shape"
             self.assertRaisesRegex(RuntimeError, regex, base.pow_, exponent)
 
+    @torch.testing._internal.common_utils.skipIfTorchDynamo()
     def test_int_tensor_pow_neg_ints(self, device):
         ints = [
             torch.iinfo(torch.int32).min,

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -141,6 +141,7 @@ class TestForeach(TestCase):
             'fastpath' if not x else 'slowpath', 'inplace' if y else 'outplace'
         )
     )
+    @skipIfTorchDynamo()
     def test_parity(self, device, dtype, op, noncontiguous, inplace):
         if inplace:
             _, _, func, ref = self._get_funcs(op)

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -2881,6 +2881,7 @@ class TestNestedTensorSubclass(TestCase):
 
         gradcheck(grad_test_func, inputs=(a, b, c, weight), check_batched_grad=False)
 
+    @torch.testing._internal.common_utils.skipIfTorchDynamo()
     def test_unary_pointwise(self, device):
         a = torch.randn(2, 3, requires_grad=True, dtype=torch.float64, device=device)
         b = torch.randn(3, 3, requires_grad=True, dtype=torch.float64, device=device)

--- a/torch/_dynamo/test_case.py
+++ b/torch/_dynamo/test_case.py
@@ -1,6 +1,7 @@
 import contextlib
 import importlib
 import sys
+import unittest
 
 import torch
 import torch.testing
@@ -54,6 +55,14 @@ class TestCase(TorchTestCase):
 
     def setUp(self):
         super().setUp()
+        if TEST_WITH_TORCHDYNAMO:
+            raise unittest.SkipTest(
+                "Cannot run the Dynamo tests with "
+                "PYTORCH_TEST_WITH_TORCHDYNAMO=1 "
+                "because torch._dynamo.reset() may not be called "
+                "inside of a Dynamo-optimized function"
+            )
+
         reset()
         utils.counters.clear()
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -33,7 +33,8 @@ from torch.testing._internal.common_utils import (
     make_fullrank_matrices_with_distinct_singular_values,
     TEST_WITH_ROCM, IS_WINDOWS, IS_MACOS, TEST_SCIPY,
     torch_to_numpy_dtype_dict, TEST_WITH_ASAN,
-    GRADCHECK_NONDET_TOL, freeze_rng_state, slowTest, TEST_WITH_SLOW
+    GRADCHECK_NONDET_TOL, freeze_rng_state, slowTest, TEST_WITH_SLOW,
+    skipIfTorchDynamo,
 )
 
 import torch._refs as refs  # noqa: F401
@@ -10420,6 +10421,7 @@ op_db: List[OpInfo] = [
                             'TestNNCOpInfo',
                             'test_nnc_correctness',
                             dtypes=(torch.bool,)),
+               DecorateInfo(skipIfTorchDynamo(), "TestCommon", "test_out_warning"),
            )),
     UnaryUfuncInfo('positive',
                    ref=np.positive,
@@ -20039,6 +20041,7 @@ python_ref_db = [
             DecorateInfo(
                 unittest.expectedFailure, 'TestCommon', 'test_python_ref_executor', device_type="cuda"
             ),
+            DecorateInfo(skipIfTorchDynamo(), 'TestCommon', 'test_out_warning'),
         ),
     ),
     PythonRefInfo(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110513

The main motivation is that many of the tests in CI are being run
without Dynamo because they have hit the cache limit. We want all tests
to be run underneath Dynamo, otherwise, CI becomes non-deterministic
(the order that we run those tests end up mattering).

We also:
- disable running test/dynamo/* tests under PYTORCH_TEST_WITH_DYNAMO=1.
  Those don't work, I am not sure why our CI isn't red.
- disables the nestedtensor tests. Those seem flaky with or without this
  PR.

Test Plan:
- CI

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng