### PR TITLE
[Reland][3/N] Add -Wdeprecated and related fixes

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/VulkanPackedContext.h
+++ b/aten/src/ATen/native/vulkan/ops/VulkanPackedContext.h
@@ -15,12 +15,14 @@ class VulkanPackedContext {
 
  public:
   VulkanPackedContext() : packed_{c10::AnyType::get()} {}
+  VulkanPackedContext(const VulkanPackedContext&) = default;
+  VulkanPackedContext(VulkanPackedContext&&) = default;
 
   inline const c10::IValue get_val(int64_t i) const {
     return packed_.get(i);
   }
 
-  inline void set_val(int64_t i, c10::IValue val) const {
+  inline void set_val(int64_t i, const c10::IValue& val) const {
     return packed_.set(i, val);
   }
 

--- a/c10/core/impl/DeviceGuardImplInterface.h
+++ b/c10/core/impl/DeviceGuardImplInterface.h
@@ -62,6 +62,14 @@ namespace impl {
  * those uses will be devirtualized.
  */
 struct C10_API DeviceGuardImplInterface {
+  DeviceGuardImplInterface() = default;
+  DeviceGuardImplInterface(const DeviceGuardImplInterface&) = default;
+  DeviceGuardImplInterface& operator=(const DeviceGuardImplInterface&) =
+      default;
+  DeviceGuardImplInterface(DeviceGuardImplInterface&&) noexcept = default;
+  DeviceGuardImplInterface& operator=(DeviceGuardImplInterface&&) noexcept =
+      default;
+
   /**
    * Return the type of device managed by this guard implementation.
    */

--- a/torch/csrc/api/include/torch/imethod.h
+++ b/torch/csrc/api/include/torch/imethod.h
@@ -22,6 +22,11 @@ class TORCH_API IMethod {
   using IValueList = std::vector<c10::IValue>;
   using IValueMap = std::unordered_map<std::string, at::IValue>;
 
+  IMethod() = default;
+  IMethod(const IMethod&) = default;
+  IMethod& operator=(const IMethod&) = default;
+  IMethod(IMethod&&) noexcept = default;
+  IMethod& operator=(IMethod&&) noexcept = default;
   virtual ~IMethod() = default;
 
   virtual c10::IValue operator()(

--- a/torch/csrc/api/include/torch/nn/cloneable.h
+++ b/torch/csrc/api/include/torch/nn/cloneable.h
@@ -21,7 +21,7 @@ namespace nn {
 /// because then storing a module would always require templatizing it.
 template <typename Derived>
 // NOLINTNEXTLINE(bugprone-exception-escape)
-class Cloneable : public virtual Module {
+class Cloneable : public Module {
  public:
   using Module::Module;
 
@@ -90,7 +90,7 @@ class Cloneable : public virtual Module {
         clone != nullptr,
         "Attempted to clone submodule, but it is of a "
         "different type than the submodule it was to be cloned into");
-    static_cast<Derived&>(*this) = std::move(*clone);
+    static_cast<Derived&>(*this) = *clone;
   }
 };
 

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -81,6 +81,10 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
   /// The name of the submodule is inferred via RTTI (if possible) the first
   /// time `.name()` is invoked.
   Module();
+  Module(const Module&) = default;
+  Module& operator=(const Module&) = default;
+  Module(Module&&) noexcept = default;
+  Module& operator=(Module&&) noexcept = default;
 
   virtual ~Module() = default;
 

--- a/torch/csrc/api/include/torch/nn/modules/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/batchnorm.h
@@ -137,7 +137,23 @@ class BatchNormImplBase : public NormImplBase<D, Derived, BatchNormOptions> {
   }
 
   /// Pretty prints the `BatchNorm{1,2,3}d` module into the given `stream`.
-  void pretty_print(std::ostream& stream) const override;
+  void pretty_print(std::ostream& stream) const override {
+    stream << std::boolalpha << "torch::nn::BatchNorm" << D << "d("
+           << this->options.num_features() << ", "
+           << "eps=" << this->options.eps() << ", "
+           << "momentum=";
+
+    if (this->options.momentum().has_value()) {
+      stream << this->options.momentum().value();
+    } else {
+      stream << "None";
+    }
+
+    stream << ", "
+           << "affine=" << this->options.affine() << ", "
+           << "track_running_stats=" << this->options.track_running_stats()
+           << ")";
+  }
 };
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ BatchNorm1d

--- a/torch/csrc/api/include/torch/nn/modules/container/any_value.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/any_value.h
@@ -91,6 +91,8 @@ class AnyValue {
   struct Placeholder {
     explicit Placeholder(const std::type_info& type_info_) noexcept
         : type_info(type_info_) {}
+    Placeholder(const Placeholder&) = default;
+    Placeholder(Placeholder&&) = default;
     virtual ~Placeholder() = default;
     virtual std::unique_ptr<Placeholder> clone() const {
       TORCH_CHECK(false, "clone() should only be called on `AnyValue::Holder`");

--- a/torch/csrc/api/include/torch/nn/modules/instancenorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/instancenorm.h
@@ -45,7 +45,15 @@ class InstanceNormImpl
   }
 
   /// Pretty prints the `InstanceNorm{1,2,3}d` module into the given `stream`.
-  void pretty_print(std::ostream& stream) const override;
+  void pretty_print(std::ostream& stream) const override {
+    stream << std::boolalpha << "torch::nn::InstanceNorm" << D << "d("
+           << this->options.num_features() << ", "
+           << "eps=" << this->options.eps() << ", "
+           << "momentum=" << this->options.momentum() << ", "
+           << "affine=" << this->options.affine() << ", "
+           << "track_running_stats=" << this->options.track_running_stats()
+           << ")";
+  }
 };
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ InstanceNorm1d

--- a/torch/csrc/api/include/torch/nn/options/rnn.h
+++ b/torch/csrc/api/include/torch/nn/options/rnn.h
@@ -164,8 +164,6 @@ struct TORCH_API RNNCellOptionsBase {
       int64_t hidden_size,
       bool bias,
       int64_t num_chunks);
-  virtual ~RNNCellOptionsBase() = default;
-
   TORCH_ARG(int64_t, input_size);
   TORCH_ARG(int64_t, hidden_size);
   TORCH_ARG(bool, bias);

--- a/torch/csrc/api/include/torch/optim/adagrad.h
+++ b/torch/csrc/api/include/torch/optim/adagrad.h
@@ -34,7 +34,6 @@ struct TORCH_API AdagradOptions
   TORCH_API friend bool operator==(
       const AdagradOptions& lhs,
       const AdagradOptions& rhs);
-  ~AdagradOptions() override = default;
   double get_lr() const override;
   void set_lr(const double lr) override;
 };
@@ -45,12 +44,16 @@ struct TORCH_API AdagradParamState
   TORCH_ARG(int64_t, step) = 0;
 
  public:
+  AdagradParamState() = default;
+  AdagradParamState(const AdagradParamState&) = default;
+  AdagradParamState& operator=(const AdagradParamState&) = default;
+  AdagradParamState(AdagradParamState&&) noexcept = default;
+  AdagradParamState& operator=(AdagradParamState&&) noexcept = default;
   void serialize(torch::serialize::InputArchive& archive) override;
   void serialize(torch::serialize::OutputArchive& archive) const override;
   TORCH_API friend bool operator==(
       const AdagradParamState& lhs,
       const AdagradParamState& rhs);
-  ~AdagradParamState() override = default;
 };
 
 class TORCH_API Adagrad : public Optimizer {

--- a/torch/csrc/api/include/torch/optim/adam.h
+++ b/torch/csrc/api/include/torch/optim/adam.h
@@ -32,7 +32,6 @@ struct TORCH_API AdamOptions : public OptimizerCloneableOptions<AdamOptions> {
   TORCH_API friend bool operator==(
       const AdamOptions& lhs,
       const AdamOptions& rhs);
-  ~AdamOptions() override = default;
   double get_lr() const override;
   void set_lr(const double lr) override;
 };
@@ -50,7 +49,6 @@ struct TORCH_API AdamParamState
   TORCH_API friend bool operator==(
       const AdamParamState& lhs,
       const AdamParamState& rhs);
-  ~AdamParamState() override = default;
 };
 
 class TORCH_API Adam : public Optimizer {

--- a/torch/csrc/api/include/torch/optim/adamw.h
+++ b/torch/csrc/api/include/torch/optim/adamw.h
@@ -32,7 +32,6 @@ struct TORCH_API AdamWOptions : public OptimizerCloneableOptions<AdamWOptions> {
   TORCH_API friend bool operator==(
       const AdamWOptions& lhs,
       const AdamWOptions& rhs);
-  ~AdamWOptions() override = default;
   double get_lr() const override;
   void set_lr(const double lr) override;
 };
@@ -50,7 +49,6 @@ struct TORCH_API AdamWParamState
   TORCH_API friend bool operator==(
       const AdamWParamState& lhs,
       const AdamWParamState& rhs);
-  ~AdamWParamState() override = default;
 };
 
 class TORCH_API AdamW : public Optimizer {

--- a/torch/csrc/api/include/torch/optim/lbfgs.h
+++ b/torch/csrc/api/include/torch/optim/lbfgs.h
@@ -29,7 +29,6 @@ struct TORCH_API LBFGSOptions : public OptimizerCloneableOptions<LBFGSOptions> {
   TORCH_API friend bool operator==(
       const LBFGSOptions& lhs,
       const LBFGSOptions& rhs);
-  ~LBFGSOptions() override = default;
   double get_lr() const override;
   void set_lr(const double lr) override;
 };
@@ -54,7 +53,6 @@ struct TORCH_API LBFGSParamState
   TORCH_API friend bool operator==(
       const LBFGSParamState& lhs,
       const LBFGSParamState& rhs);
-  ~LBFGSParamState() override = default;
 };
 
 class TORCH_API LBFGS : public Optimizer {

--- a/torch/csrc/api/include/torch/optim/optimizer.h
+++ b/torch/csrc/api/include/torch/optim/optimizer.h
@@ -34,6 +34,11 @@ namespace optim {
 
 class TORCH_API OptimizerParamState {
  public:
+  OptimizerParamState() = default;
+  OptimizerParamState(const OptimizerParamState&) = default;
+  OptimizerParamState& operator=(const OptimizerParamState&) = default;
+  OptimizerParamState(OptimizerParamState&&) noexcept = default;
+  OptimizerParamState& operator=(OptimizerParamState&&) noexcept = default;
   virtual std::unique_ptr<OptimizerParamState> clone() const;
   virtual void serialize(torch::serialize::InputArchive& archive);
   virtual void serialize(torch::serialize::OutputArchive& archive) const;
@@ -49,6 +54,11 @@ class OptimizerCloneableParamState : public OptimizerParamState {
 
 class TORCH_API OptimizerOptions {
  public:
+  OptimizerOptions() = default;
+  OptimizerOptions(const OptimizerOptions&) = default;
+  OptimizerOptions& operator=(const OptimizerOptions&) = default;
+  OptimizerOptions(OptimizerOptions&&) noexcept = default;
+  OptimizerOptions& operator=(OptimizerOptions&&) noexcept = default;
   virtual std::unique_ptr<OptimizerOptions> clone() const;
   virtual void serialize(torch::serialize::InputArchive& archive);
   virtual void serialize(torch::serialize::OutputArchive& archive) const;

--- a/torch/csrc/api/include/torch/optim/rmsprop.h
+++ b/torch/csrc/api/include/torch/optim/rmsprop.h
@@ -37,7 +37,6 @@ struct TORCH_API RMSpropOptions
   TORCH_API friend bool operator==(
       const RMSpropOptions& lhs,
       const RMSpropOptions& rhs);
-  ~RMSpropOptions() override = default;
   double get_lr() const override;
   void set_lr(const double lr) override;
 };
@@ -55,7 +54,6 @@ struct TORCH_API RMSpropParamState
   TORCH_API friend bool operator==(
       const RMSpropParamState& lhs,
       const RMSpropParamState& rhs);
-  ~RMSpropParamState() override = default;
 };
 
 class TORCH_API RMSprop : public Optimizer {

--- a/torch/csrc/api/include/torch/optim/sgd.h
+++ b/torch/csrc/api/include/torch/optim/sgd.h
@@ -34,7 +34,6 @@ struct TORCH_API SGDOptions : public OptimizerCloneableOptions<SGDOptions> {
   TORCH_API friend bool operator==(
       const SGDOptions& lhs,
       const SGDOptions& rhs);
-  ~SGDOptions() override = default;
   double get_lr() const override;
   void set_lr(const double lr) override;
 };
@@ -49,7 +48,6 @@ struct TORCH_API SGDParamState
   TORCH_API friend bool operator==(
       const SGDParamState& lhs,
       const SGDParamState& rhs);
-  ~SGDParamState() override = default;
 };
 
 class TORCH_API SGD : public Optimizer {

--- a/torch/csrc/api/src/nn/modules/activation.cpp
+++ b/torch/csrc/api/src/nn/modules/activation.cpp
@@ -432,7 +432,7 @@ void ThresholdImpl::pretty_print(std::ostream& stream) const {
 
 MultiheadAttentionImpl::MultiheadAttentionImpl(
     const MultiheadAttentionOptions& options_)
-    : Module("torch::nn::MultiheadAttention"), options(options_) {
+    : Cloneable("torch::nn::MultiheadAttention"), options(options_) {
   // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
   reset();
 }

--- a/torch/csrc/api/src/nn/modules/batchnorm.cpp
+++ b/torch/csrc/api/src/nn/modules/batchnorm.cpp
@@ -14,25 +14,6 @@
 namespace torch {
 namespace nn {
 
-template <size_t D, typename Derived>
-void BatchNormImplBase<D, Derived>::pretty_print(std::ostream& stream) const {
-  stream << std::boolalpha << "torch::nn::BatchNorm" << D << "d("
-         << this->options.num_features() << ", "
-         << "eps=" << this->options.eps() << ", "
-         << "momentum=";
-
-  if (this->options.momentum().has_value()) {
-    stream << this->options.momentum().value();
-  } else {
-    stream << "None";
-  }
-
-  stream << ", "
-         << "affine=" << this->options.affine() << ", "
-         << "track_running_stats=" << this->options.track_running_stats()
-         << ")";
-}
-
 void BatchNorm1dImpl::_check_input_dim(const Tensor& input) {
   TORCH_CHECK(
       input.dim() == 2 || input.dim() == 3,

--- a/torch/csrc/api/src/nn/modules/instancenorm.cpp
+++ b/torch/csrc/api/src/nn/modules/instancenorm.cpp
@@ -4,17 +4,6 @@
 namespace torch {
 namespace nn {
 
-template <size_t D, typename Derived>
-void InstanceNormImpl<D, Derived>::pretty_print(std::ostream& stream) const {
-  stream << std::boolalpha << "torch::nn::InstanceNorm" << D << "d("
-         << this->options.num_features() << ", "
-         << "eps=" << this->options.eps() << ", "
-         << "momentum=" << this->options.momentum() << ", "
-         << "affine=" << this->options.affine() << ", "
-         << "track_running_stats=" << this->options.track_running_stats()
-         << ")";
-}
-
 void InstanceNorm1dImpl::_check_input_dim(const Tensor& input) {
   if (input.dim() != 3 && input.dim() != 2) {
     TORCH_CHECK(

--- a/torch/csrc/distributed/c10d/Store.hpp
+++ b/torch/csrc/distributed/c10d/Store.hpp
@@ -28,6 +28,9 @@ class TORCH_API Store : public torch::CustomClassHolder {
   explicit Store(const std::chrono::milliseconds& timeout)
       : timeout_(timeout) {}
 
+  Store(const Store&) = default;
+  Store(Store&&) noexcept = default;
+
   ~Store() override = default;
 
   void set(const std::string& key, const std::string& value);

--- a/torch/csrc/distributed/rpc/py_rref.h
+++ b/torch/csrc/distributed/rpc/py_rref.h
@@ -18,6 +18,7 @@ class PYBIND11_EXPORT PyRRef {
   // for more explanations.
   explicit PyRRef(const py::object& value, const py::object& type_hint);
   explicit PyRRef(c10::intrusive_ptr<RRef> rref);
+  PyRRef(const PyRRef&) = default;
   ~PyRRef();
 
   bool isOwner() const;

--- a/torch/csrc/distributed/rpc/rref_proto.cpp
+++ b/torch/csrc/distributed/rpc/rref_proto.cpp
@@ -142,8 +142,7 @@ std::unique_ptr<RRefUserDelete> RRefUserDelete::fromMessage(
     const Message& message) {
   auto pair =
       ForkMessageBase::fromMessage(message, MessageType::RREF_USER_DELETE);
-  return std::make_unique<RRefUserDelete>(
-      RRefUserDelete(pair.first, pair.second));
+  return std::make_unique<RRefUserDelete>(pair.first, pair.second);
 }
 
 std::unique_ptr<RemoteRet> RemoteRet::fromMessage(const Message& message) {

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -194,8 +194,8 @@ class TORCH_API TensorPipeAgent : public RpcAgent {
   std::vector<WorkerInfo> getWorkerInfos() const override;
   void updateGroupMembership(
       const WorkerInfo& workerInfo,
-      const std::vector<c10::Device> devices,
-      const std::unordered_map<std::string, DeviceMap> reverseDeviceMaps,
+      const std::vector<c10::Device>& devices,
+      const std::unordered_map<std::string, DeviceMap>& reverseDeviceMaps,
       bool isJoin);
 
   std::unordered_map<std::string, std::string> getMetrics() override;

--- a/torch/csrc/jit/mobile/train/optim/sgd.h
+++ b/torch/csrc/jit/mobile/train/optim/sgd.h
@@ -22,7 +22,6 @@ class SGDParamState {
         static_cast<const SGDParamState&>(*this));
   }
   friend bool operator==(const SGDParamState& lhs, const SGDParamState& rhs);
-  ~SGDParamState() = default;
 };
 
 struct TORCH_API SGDOptions {
@@ -40,7 +39,6 @@ struct TORCH_API SGDOptions {
   TORCH_API friend bool operator==(
       const SGDOptions& lhs,
       const SGDOptions& rhs);
-  ~SGDOptions() = default;
 };
 
 /// Stores parameters in the param_group and stores a pointer to the SGDOptions

--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -1100,7 +1100,6 @@ Code::Code(
           remaining_bailout_depth)) {}
 
 Code::Code(CodeImpl* codeImpl) : pImpl(codeImpl) {}
-Code::~Code() = default;
 
 MobileCode::MobileCode(
     const std::shared_ptr<Graph>& graph,
@@ -1116,8 +1115,6 @@ MobileCode::MobileCode(
           support_default_args_before_out,
           emit_promoted_ops,
           remaining_bailout_depth)) {}
-
-MobileCode::~MobileCode() = default;
 
 const std::vector<GraphExecutor*>& Code::grad_executors() {
   return pImpl->grad_executors();
@@ -1172,7 +1169,6 @@ InterpreterState::InterpreterState(const Code& code, TaskLauncher taskLauncher)
     : pImpl(c10::make_intrusive<InterpreterStateImpl>(
           code,
           std::move(taskLauncher))) {}
-InterpreterState::~InterpreterState() = default;
 
 void InterpreterState::run(Stack& stack) {
   static_cast<InterpreterStateImpl*>(pImpl.get())->run(stack);

--- a/torch/csrc/jit/serialization/python_print.cpp
+++ b/torch/csrc/jit/serialization/python_print.cpp
@@ -1677,8 +1677,6 @@ uint64_t PythonPrint::minVersion() const {
   return pImpl->min_version_;
 }
 
-PythonPrint::~PythonPrint() = default;
-
 static std::vector<IValue> traverseIValueAndGetObjects(IValue ivalue) {
   std::vector<IValue> result;
   std::vector<IValue> stack;

--- a/torch/csrc/jit/serialization/python_print.h
+++ b/torch/csrc/jit/serialization/python_print.h
@@ -42,8 +42,6 @@ struct TORCH_API PythonPrint {
   const SourceRangeRecords& ranges() const;
   uint64_t minVersion() const;
 
-  ~PythonPrint();
-
  private:
   std::shared_ptr<PythonPrintImpl> pImpl;
 };

--- a/torch/csrc/jit/tensorexpr/reduction.h
+++ b/torch/csrc/jit/tensorexpr/reduction.h
@@ -29,7 +29,6 @@ class TORCH_API Reducer {
   template <typename RI>
   Reducer(ExprHandle init, RI interaction)
       : init_(init.node()), interaction_(std::move(interaction)) {}
-  virtual ~Reducer() = default;
 
   ExprPtr initializer() const {
     return init_;

--- a/torch/csrc/lazy/core/tensor.h
+++ b/torch/csrc/lazy/core/tensor.h
@@ -67,6 +67,8 @@ class TORCH_API LazyTensor : public c10::intrusive_ptr_target {
   // used to rely on a LazyTensor obj with a null Data can now rely on a null
   // LazyTensorPtr instead.
   LazyTensor() = delete;
+  LazyTensor(const LazyTensor&) = default;
+  LazyTensor(LazyTensor&&) noexcept = default;
 
   ~LazyTensor() override = default;
 

--- a/torch/csrc/profiler/orchestration/observer.h
+++ b/torch/csrc/profiler/orchestration/observer.h
@@ -49,7 +49,6 @@ struct TORCH_API ExperimentalConfig {
       std::vector<std::string> performance_events = {},
       bool enable_cuda_sync_events = false,
       bool adjust_timestamps = false);
-  ~ExperimentalConfig() = default;
   explicit operator bool() const;
 
   std::vector<std::string> profiler_metrics;
@@ -88,7 +87,6 @@ struct TORCH_API ProfilerConfig {
       bool with_flops = false,
       bool with_modules = false,
       ExperimentalConfig experimental_config = ExperimentalConfig());
-  ~ProfilerConfig() = default;
 
   bool disabled() const;
   bool global() const;

--- a/torch/csrc/utils/invalid_arguments.cpp
+++ b/torch/csrc/utils/invalid_arguments.cpp
@@ -17,6 +17,11 @@ std::string py_typename(PyObject* object) {
 }
 
 struct Type {
+  Type() = default;
+  Type(const Type&) = default;
+  Type& operator=(const Type&) = default;
+  Type(Type&&) noexcept = default;
+  Type& operator=(Type&&) noexcept = default;
   virtual bool is_matching(PyObject* object) = 0;
   virtual ~Type() = default;
 };


### PR DESCRIPTION
Fixes the string_view errors and reland the work. The previous changes in torch/csrc/utils/invalid_arguments.cpp were too aggressive and not tested thoroughly. They are discarded.
cc @EikanWang @jgong5 @PaliC 
