### PR TITLE
Revert tl.int1 casting change for ROCm to avoid hangs

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1426,12 +1426,11 @@ class TritonKernel(Kernel):
             dtype = V.graph.get_dtype(name)
             if dtype in (torch.float16, torch.bfloat16):
                 line += ".to(tl.float32)"
-            if dtype == torch.bool:
+            if dtype == torch.bool and torch.version.hip is None::
                 # Workaround for https://github.com/openai/triton/issues/2151
                 # tl.load returns int8 when loading from pointer to int1
                 # NOTE: Currently causes hangs on bool UTs for ROCm
-                if torch.version.hip is None:
-                    line += ".to(tl.int1)"
+                line += ".to(tl.int1)"
 
         if "tmp" in mask:
             # Masked loads must come after the mask is computed

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1429,7 +1429,9 @@ class TritonKernel(Kernel):
             if dtype == torch.bool:
                 # Workaround for https://github.com/openai/triton/issues/2151
                 # tl.load returns int8 when loading from pointer to int1
-                line += ".to(tl.int1)"
+                # NOTE: Currently causes hangs on bool UTs for ROCm
+                if torch.version.hip is None:
+                    line += ".to(tl.int1)"
 
         if "tmp" in mask:
             # Masked loads must come after the mask is computed

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1426,7 +1426,7 @@ class TritonKernel(Kernel):
             dtype = V.graph.get_dtype(name)
             if dtype in (torch.float16, torch.bfloat16):
                 line += ".to(tl.float32)"
-            if dtype == torch.bool and torch.version.hip is None::
+            if dtype == torch.bool and torch.version.hip is None:
                 # Workaround for https://github.com/openai/triton/issues/2151
                 # tl.load returns int8 when loading from pointer to int1
                 # NOTE: Currently causes hangs on bool UTs for ROCm


### PR DESCRIPTION
Seeing hangs on ROCm seemingly after this PR https://github.com/pytorch/pytorch/pull/110388
https://ossci-raw-job-status.s3.amazonaws.com/log/17381916785
`inductor/test_torchinductor_opinfo.py::TestInductorOpInfoCUDA::test_comprehensive_exp2_cuda_bool Command took >30min, returning 124`

Conditionalising out of this while we investigate.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler