### PR TITLE
[ONNX] Create onnxscript-torchlib specific xfails/skips for fx tests

### DIFF
--- a/test/onnx/test_fx_op_consistency.py
+++ b/test/onnx/test_fx_op_consistency.py
@@ -162,6 +162,12 @@ COMPLEX_TESTED_OPS = frozenset(
     ]
 )
 
+# NOTE: For ATen signature modifications that will break ONNX export,
+# use **xfail_onnxscript** and **skip_onnxscript** instead of xfail or skip
+# to make the signal apparent for maintainers.
+xfail_onnxscript = xfail
+skip_onnxscript = skip
+
 # fmt: off
 # Turn off black formatting to keep the list compact
 

--- a/test/onnx/test_fx_op_consistency.py
+++ b/test/onnx/test_fx_op_consistency.py
@@ -164,9 +164,9 @@ COMPLEX_TESTED_OPS = frozenset(
 
 
 # NOTE: For ATen signature modifications that will break ONNX export,
-# use **xfail_onnxscript_forward_compatibility** and **skip_torchlib_forward_compatibility** instead of xfail or skip
+# use **xfail_torchlib_forward_compatibility** and **skip_torchlib_forward_compatibility** instead of xfail or skip
 # to make the signal apparent for maintainers.
-def xfail_onnxscript_forward_compatibility(
+def xfail_torchlib_forward_compatibility(
     op_name: str,
     variant_name: str = "",
     *,
@@ -177,6 +177,10 @@ def xfail_onnxscript_forward_compatibility(
     matcher: Optional[Callable[[Any], bool]] = None,
     enabled_if: bool = True,
 ):
+    """Prefer using this (xfail) over skip when possible.
+
+    Only skip when the test is not failing consistently.
+    """
     return xfail(
         op_name,
         variant_name=variant_name,
@@ -199,6 +203,10 @@ def skip_torchlib_forward_compatibility(
     matcher: Optional[Callable[[Any], Any]] = None,
     enabled_if: bool = True,
 ):
+    """Prefer using xfail_torchlib_forward_compatibility over this (skip) when possible.
+
+    Only skip when the test is not failing consistently.
+    """
     return skip(
         op_name,
         variant_name=variant_name,

--- a/test/onnx/test_fx_op_consistency.py
+++ b/test/onnx/test_fx_op_consistency.py
@@ -604,14 +604,6 @@ SKIP_XFAIL_SUBTESTS: tuple[onnx_test_common.DecorateMeta, ...] = (
         and sample.kwargs.get("padding") == 1,
         reason="FIXME: After https://github.com/microsoft/onnxruntime/issues/15446 is fixed",
     ),
-    skip_torchlib_forward_compatibility(
-        "nn.functional.nll_loss",
-        matcher=lambda sample: isinstance(sample.kwargs.get("reduction"), str),
-        reason=onnx_test_common.reason_onnx_script_does_not_support(
-            "string in reduction kwarg"
-        ),
-        github_issue="https://github.com/microsoft/onnxscript/issues/726",
-    ),
     xfail(
         "nonzero",
         matcher=lambda sample: len(sample.input.shape) == 0

--- a/test/onnx/test_fx_op_consistency.py
+++ b/test/onnx/test_fx_op_consistency.py
@@ -164,9 +164,9 @@ COMPLEX_TESTED_OPS = frozenset(
 
 
 # NOTE: For ATen signature modifications that will break ONNX export,
-# use **xfail_onnxscript** and **skip_onnxscript** instead of xfail or skip
+# use **xfail_onnxscript_forward_compatibility** and **skip_torchlib_forward_compatibility** instead of xfail or skip
 # to make the signal apparent for maintainers.
-def xfail_onnxscript(
+def xfail_onnxscript_forward_compatibility(
     op_name: str,
     variant_name: str = "",
     *,
@@ -188,7 +188,7 @@ def xfail_onnxscript(
     )
 
 
-def skip_onnxscript(
+def skip_torchlib_forward_compatibility(
     op_name: str,
     variant_name: str = "",
     *,
@@ -589,7 +589,7 @@ SKIP_XFAIL_SUBTESTS: tuple[onnx_test_common.DecorateMeta, ...] = (
         matcher=lambda sample: not isinstance(sample.kwargs.get("weight"), int),
         reason="ONNX SoftmaxCrossEntropyLoss op only accept argument[weight] is int type",
     ),
-    skip_onnxscript(
+    skip_torchlib_forward_compatibility(
         "nn.functional.embedding_bag",
         matcher=lambda sample: sample.kwargs.get("padding_idx") is not None or True,
         reason=onnx_test_common.reason_onnx_script_does_not_support(
@@ -604,7 +604,7 @@ SKIP_XFAIL_SUBTESTS: tuple[onnx_test_common.DecorateMeta, ...] = (
         and sample.kwargs.get("padding") == 1,
         reason="FIXME: After https://github.com/microsoft/onnxruntime/issues/15446 is fixed",
     ),
-    skip_onnxscript(
+    skip_torchlib_forward_compatibility(
         "nn.functional.nll_loss",
         matcher=lambda sample: isinstance(sample.kwargs.get("reduction"), str),
         reason=onnx_test_common.reason_onnx_script_does_not_support(


### PR DESCRIPTION
Creates xfail_onnxscript/skip_onnxscript so that it is clear torchlib needs to support it.