### PR TITLE
Enable aarch64 for fixing undefined symbol error.

### DIFF
--- a/torch/csrc/profiler/unwind/unwind_fb.cpp
+++ b/torch/csrc/profiler/unwind/unwind_fb.cpp
@@ -1,4 +1,5 @@
-#if defined(__linux__) && defined(__x86_64__) && defined(__has_include) && \
+#if defined(__linux__) && (defined(__x86_64__) || defined(__aarch64__)) && \
+    defined(__has_include) &&                                              \
     __has_include("ext/stdio_filebuf.h") && defined(FBCODE_CAFFE2)
 #include <c10/util/flat_hash_map.h>
 #include <llvm/DebugInfo/Symbolize/Symbolize.h>


### PR DESCRIPTION
Summary: ARM can be safely supported

Reviewed By: andrewjcg, aaronenyeshi

Differential Revision: D49921679


