### PR TITLE
[release only] Docker build for release - trigger manually from pytorch channel

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Linux
         uses: ./.github/actions/setup-linux
       - name: Login to GitHub Container Registry
-        if: ${{ env.WITH_PUSH == 'true' }}
+        if: ${{ inputs.channel == 'release' }}
         uses: docker/login-action@v2
         with:
           registry: ghcr.io


### PR DESCRIPTION
Allow to push on the release channel. When manually trigger
