### PR TITLE
[optim] disable large_tensor tests for ROCm

### DIFF
--- a/test/optim/test_optim.py
+++ b/test/optim/test_optim.py
@@ -936,6 +936,7 @@ class TestOptim(TestCase):
 
     @unittest.skipIf(not torch.cuda.is_available(), "Requires a GPU")
     @largeTensorTest("72GB", "cuda")
+    @skipIfRocm
     def test_multi_tensor_optimizers_with_large_tensors(self):
         for optimizer_ctor, optimizer_params in self._multi_tensor_optimizer_configs:
             # note(crcrpar): H100 wasn't sufficient for Adamax, surprisingly
@@ -979,6 +980,7 @@ class TestOptim(TestCase):
 
     @unittest.skipIf(not torch.cuda.is_available(), "Requires a GPU")
     @largeTensorTest("64GB", "cuda")
+    @skipIfRocm
     def test_fused_optimizers_with_large_tensors(self):
         for optimizer_ctor, optimizer_params in self._fused_optimizer_configs:
             params = [torch.ones(2 ** 32, device="cuda", dtype=torch.float16)]


### PR DESCRIPTION
Closes #105825 #105820 #105754 by replacing with an incode skip.

Fixes #105825, fixes #105820, fixes #105754

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110559



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang