### PR TITLE
Include `onnx` and `onnxscript` information in collect_env.py

### DIFF
--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -391,6 +391,7 @@ def get_pip_packages(run_lambda):
                     "flake8",
                     "triton",
                     "optree",
+                    "onnx",
                 }
             )
         )


### PR DESCRIPTION
`onnx` and `onnxscript` are used in torch.onnx.dynamo_export since 2.0. It would be helpful to collect version information in user issue reports.
