### PR TITLE
[AOTInductor] Change UpdateConstants to UpdateConstantsMap

### DIFF
--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -172,7 +172,7 @@ AOTIRuntimeError AOTInductorModelDelete(
   })
 }
 
-AOTIRuntimeError AOTInductorModelUpdateConstants(
+AOTIRuntimeError AOTInductorModelUpdateConstantsMap(
     AOTInductorModelHandle model_handle,
     AOTInductorConstantMapHandle constant_map_handle) {
   auto model = reinterpret_cast<torch::aot_inductor::AOTInductorModel*>(model_handle);

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -112,7 +112,7 @@ AOTIRuntimeError AOTInductorModelRun(
 
 // Replace AOTInductorModel's constant map. Note it doesn't handle concurrency
 // so be sure to handle ordering if AOTInductorModelRun is ran concurrently.
-AOTIRuntimeError AOTInductorModelUpdateConstants(
+AOTIRuntimeError AOTInductorModelUpdateConstantsMap(
     AOTInductorModelHandle model_handle,
     AOTInductorConstantMapHandle constant_map_handle);
 


### PR DESCRIPTION
Summary: Change name of UpdateConstants to UpdateConstantsMap

Test Plan: 

Differential Revision: D49937744



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @aakhundov @ColinPeppler