### PR TITLE
Linear Quantize

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/quantized_addmm_qint8.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_addmm_qint8.glsl
@@ -1,0 +1,102 @@
+#version 450 core
+#define PRECISION $precision
+#define FORMAT    $format
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, rgba8i) uniform PRECISION restrict writeonly iimage3D   uOutput;
+layout(set = 0, binding = 1)         uniform PRECISION                    isampler3D uM1; //quantized input
+layout(set = 0, binding = 2)         uniform PRECISION                    isampler3D uM2; //quantized input
+layout(set = 0, binding = 3)         uniform PRECISION                    sampler3D uT;
+layout(set = 0, binding = 4)         uniform PRECISION restrict           Block {
+  ivec4 size;
+  ivec4 um1_size;
+  ivec4 um2_size;
+  ivec4 ut_size;
+  vec2 multiplier;
+  vec2 scales;
+  vec2 out_scale;
+  ivec2 zero_points;
+  ivec2 out_zero_point;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+  const ivec3 posx = ivec3(pos.x*2, pos.y*2, pos.z);
+
+  if (all(lessThan(posx, uBlock.size.xyz))) {
+    vec4 sum = vec4(0);
+    for (int k = 0; k < uBlock.size.w; ++k) {
+      const ivec3 inposx = ivec3(2*k, 2*pos.y, pos.z);
+      vec4 intexx = vec4(0.0);
+      if (all(lessThan(inposx, uBlock.um1_size.xyz))) {
+        const vec4 intexx_quant = texelFetch(uM1, inposx, 0);
+        intexx = uBlock.scales.x * (intexx_quant - uBlock.zero_points.x);
+      }
+      const ivec3 inposy = ivec3(inposx.x + 1, inposx.y, pos.z);
+      vec4 intexy = vec4(0.0);
+      if (all(lessThan(inposy, uBlock.um1_size.xyz))) {
+        const vec4 intexy_quant = texelFetch(uM1, inposy, 0);
+        intexy = uBlock.scales.x * (intexy_quant - uBlock.zero_points.x);
+      }
+      const ivec3 inposz = ivec3(inposx.x, inposx.y + 1, pos.z);
+      vec4 intexz = vec4(0.0);
+      if (all(lessThan(inposz, uBlock.um1_size.xyz))) {
+        const vec4 intexz_quant = texelFetch(uM1, inposz, 0);
+        intexz = uBlock.scales.x * (intexz_quant - uBlock.zero_points.x);
+      }
+      const ivec3 inposw = ivec3(inposx.x + 1, inposx.y + 1, pos.z);
+      vec4 intexw = vec4(0.0);
+      if (all(lessThan(inposw, uBlock.um1_size.xyz))) {
+        const vec4 intexw_quant = texelFetch(uM1, inposw, 0);
+        intexw = uBlock.scales.x * (intexw_quant - uBlock.zero_points.x);
+      }
+
+      vec4 texel1 = vec4(intexx.x, intexy.x, intexz.x, intexw.x);
+      vec4 texel2 = vec4(0.0);
+      ivec3 um2_pos = ivec3(pos.x, k, pos.z);
+      if (all(lessThan(um2_pos, uBlock.um2_size.xyz))) {
+        vec4 texel2_quant = texelFetch(uM2, um2_pos, 0);
+        texel2 = uBlock.scales.y * (texel2_quant - uBlock.zero_points.y);
+      }
+      sum = fma(texel1.xxzz, texel2.xyxy, sum);
+      sum = fma(texel1.yyww, texel2.zwzw, sum);
+    }
+
+    vec4 outtex;
+    const ivec3 bias_pos = pos % uBlock.ut_size.xyz;
+    if (all(lessThan(bias_pos, uBlock.ut_size.xyz))) {
+      outtex = uBlock.multiplier.x * sum + uBlock.multiplier.y * texelFetch(uT, bias_pos, 0);
+    } else {
+      outtex = uBlock.multiplier.x * sum;
+    }
+
+    const ivec3 posy = posx + ivec3(int((posx.x + 1) < uBlock.size.x), 0, 0);
+    vec4 outy = vec4(outtex.y, 0, 0, 0);
+    outy = roundEven(outy / uBlock.out_scale.x) + uBlock.out_zero_point.x;
+    ivec4 storey = ivec4(outy);
+    imageStore(uOutput, posy, storey);
+
+    const ivec3 posz = posx + ivec3(0, int((posx.y + 1) < uBlock.size.y), 0);
+    vec4 outz = vec4(outtex.z, 0, 0, 0);
+    outz = roundEven(outz / uBlock.out_scale.x) + uBlock.out_zero_point.x;
+    ivec4 storez = ivec4(outz);
+    imageStore(uOutput, posz, storez);
+
+    const int valid = int((posx.x + 1) < uBlock.size.x && (posx.y + 1) < uBlock.size.y);
+    const ivec3 posw = posx + ivec3(valid, valid, 0);
+    vec4 outw = vec4(outtex.w, 0, 0, 0);
+    outw = roundEven(outw / uBlock.out_scale.x) + uBlock.out_zero_point.x;
+    ivec4 storew = ivec4(outw);
+    imageStore(uOutput, posw, storew);
+
+    vec4 outx = vec4(outtex.x, 0, 0, 0);
+    outx = roundEven(outx / uBlock.out_scale.x) + uBlock.out_zero_point.x;
+    ivec4 storex = ivec4(outx);
+    imageStore(uOutput, posx, storex);
+  }
+}

--- a/aten/src/ATen/native/vulkan/glsl/quantized_addmm_quint8.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_addmm_quint8.glsl
@@ -1,0 +1,102 @@
+#version 450 core
+#define PRECISION $precision
+#define FORMAT    $format
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, rgba8ui) uniform PRECISION restrict writeonly uimage3D   uOutput;
+layout(set = 0, binding = 1)         uniform PRECISION                    isampler3D uM1; //quantized input
+layout(set = 0, binding = 2)         uniform PRECISION                    isampler3D uM2; //quantized input
+layout(set = 0, binding = 3)         uniform PRECISION                    sampler3D uT;
+layout(set = 0, binding = 4)         uniform PRECISION restrict           Block {
+  ivec4 size;
+  ivec4 um1_size;
+  ivec4 um2_size;
+  ivec4 ut_size;
+  vec2 multiplier;
+  vec2 scales;
+  vec2 out_scale;
+  ivec2 zero_points;
+  ivec2 out_zero_point;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+  const ivec3 posx = ivec3(pos.x*2, pos.y*2, pos.z);
+
+  if (all(lessThan(posx, uBlock.size.xyz))) {
+    vec4 sum = vec4(0);
+    for (int k = 0; k < uBlock.size.w; ++k) {
+      const ivec3 inposx = ivec3(2*k, 2*pos.y, pos.z);
+      vec4 intexx = vec4(0.0);
+      if (all(lessThan(inposx, uBlock.um1_size.xyz))) {
+        const vec4 intexx_quant = texelFetch(uM1, inposx, 0);
+        intexx = uBlock.scales.x * (intexx_quant - uBlock.zero_points.x);
+      }
+      const ivec3 inposy = ivec3(inposx.x + 1, inposx.y, pos.z);
+      vec4 intexy = vec4(0.0);
+      if (all(lessThan(inposy, uBlock.um1_size.xyz))) {
+        const vec4 intexy_quant = texelFetch(uM1, inposy, 0);
+        intexy = uBlock.scales.x * (intexy_quant - uBlock.zero_points.x);
+      }
+      const ivec3 inposz = ivec3(inposx.x, inposx.y + 1, pos.z);
+      vec4 intexz = vec4(0.0);
+      if (all(lessThan(inposz, uBlock.um1_size.xyz))) {
+        const vec4 intexz_quant = texelFetch(uM1, inposz, 0);
+        intexz = uBlock.scales.x * (intexz_quant - uBlock.zero_points.x);
+      }
+      const ivec3 inposw = ivec3(inposx.x + 1, inposx.y + 1, pos.z);
+      vec4 intexw = vec4(0.0);
+      if (all(lessThan(inposw, uBlock.um1_size.xyz))) {
+        const vec4 intexw_quant = texelFetch(uM1, inposw, 0);
+        intexw = uBlock.scales.x * (intexw_quant - uBlock.zero_points.x);
+      }
+
+      vec4 texel1 = vec4(intexx.x, intexy.x, intexz.x, intexw.x);
+      vec4 texel2 = vec4(0.0);
+      ivec3 um2_pos = ivec3(pos.x, k, pos.z);
+      if (all(lessThan(um2_pos, uBlock.um2_size.xyz))) {
+        vec4 texel2_quant = texelFetch(uM2, um2_pos, 0);
+        texel2 = uBlock.scales.y * (texel2_quant - uBlock.zero_points.y);
+      }
+      sum = fma(texel1.xxzz, texel2.xyxy, sum);
+      sum = fma(texel1.yyww, texel2.zwzw, sum);
+    }
+
+    vec4 outtex;
+    const ivec3 bias_pos = pos % uBlock.ut_size.xyz;
+    if (all(lessThan(bias_pos, uBlock.ut_size.xyz))) {
+      outtex = uBlock.multiplier.x * sum + uBlock.multiplier.y * texelFetch(uT, bias_pos, 0);
+    } else {
+      outtex = uBlock.multiplier.x * sum;
+    }
+
+    const ivec3 posy = posx + ivec3(int((posx.x + 1) < uBlock.size.x), 0, 0);
+    vec4 outy = vec4(outtex.y, 0, 0, 0);
+    outy = roundEven(outy / uBlock.out_scale.x) + uBlock.out_zero_point.x;
+    uvec4 storey = uvec4(outy);
+    imageStore(uOutput, posy, storey);
+
+    const ivec3 posz = posx + ivec3(0, int((posx.y + 1) < uBlock.size.y), 0);
+    vec4 outz = vec4(outtex.z, 0, 0, 0);
+    outz = roundEven(outz / uBlock.out_scale.x) + uBlock.out_zero_point.x;
+    uvec4 storez = uvec4(outz);
+    imageStore(uOutput, posz, storez);
+
+    const int valid = int((posx.x + 1) < uBlock.size.x && (posx.y + 1) < uBlock.size.y);
+    const ivec3 posw = posx + ivec3(valid, valid, 0);
+    vec4 outw = vec4(outtex.w, 0, 0, 0);
+    outw = roundEven(outw / uBlock.out_scale.x) + uBlock.out_zero_point.x;
+    uvec4 storew = uvec4(outw);
+    imageStore(uOutput, posw, storew);
+
+    vec4 outx = vec4(outtex.x, 0, 0, 0);
+    outx = roundEven(outx / uBlock.out_scale.x) + uBlock.out_zero_point.x;
+    uvec4 storex = uvec4(outx);
+    imageStore(uOutput, posx, storex);
+  }
+}

--- a/aten/src/ATen/native/vulkan/glsl/quantized_mm_qint8.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_mm_qint8.glsl
@@ -1,0 +1,98 @@
+#version 450 core
+#define PRECISION $precision
+#define FORMAT    $format
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, rgba8i) uniform PRECISION restrict writeonly iimage3D   uOutput;
+layout(set = 0, binding = 1)         uniform PRECISION                    isampler3D uM1; //quantized input
+layout(set = 0, binding = 2)         uniform PRECISION                    isampler3D uM2; //quantized input
+layout(set = 0, binding = 3)         uniform PRECISION restrict           Block {
+  ivec4 size;
+  ivec4 um1_size;
+  ivec4 um2_size;
+  vec2 scales;
+  vec2 out_scale;
+  ivec2 zero_points;
+  ivec2 out_zero_point;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+  ivec3 posx = ivec3(pos.x*2, pos.y*2, pos.z);
+
+  if (all(lessThan(posx, uBlock.size.xyz))) {
+    vec4 sum = vec4(0);
+
+    for (int k = 0; k < uBlock.size.w; ++k) {
+      ivec3 inposx = ivec3(2*k, 2*pos.y, pos.z);
+      vec4 intexx = vec4(0.0);
+      if (all(lessThan(inposx, uBlock.um1_size.xyz))) {
+        const vec4 intexx_quant = texelFetch(uM1, inposx, 0);
+        intexx = uBlock.scales.x * (intexx_quant - uBlock.zero_points.x);
+      }
+      ivec3 inposy = ivec3(inposx.x + 1, inposx.y, pos.z);
+      vec4 intexy = vec4(0.0);
+      if (all(lessThan(inposy, uBlock.um1_size.xyz))) {
+        const vec4 intexy_quant = texelFetch(uM1, inposy, 0);
+        intexy = uBlock.scales.x * (intexy_quant - uBlock.zero_points.x);
+      }
+      ivec3 inposz = ivec3(inposx.x, inposx.y + 1, pos.z);
+      vec4 intexz = vec4(0.0);
+      if (all(lessThan(inposz, uBlock.um1_size.xyz))) {
+        const vec4 intexz_quant = texelFetch(uM1, inposz, 0);
+        intexz = uBlock.scales.x * (intexz_quant - uBlock.zero_points.x);
+      }
+      ivec3 inposw = ivec3(inposx.x + 1, inposx.y + 1, pos.z);
+      vec4 intexw = vec4(0.0);
+      if (all(lessThan(inposw, uBlock.um1_size.xyz))) {
+        const vec4 intexw_quant = texelFetch(uM1, inposw, 0);
+        intexw = uBlock.scales.x * (intexw_quant - uBlock.zero_points.x);
+      }
+
+      vec4 texel1 = vec4(intexx.x, intexy.x, intexz.x, intexw.x);
+      vec4 texel2 = vec4(0.0);
+      ivec3 texel2_loc = ivec3(pos.x, k, pos.z);
+      if (all(lessThan(texel2_loc, uBlock.um2_size.xyz))) {
+        const vec4 texel2_quant = texelFetch(uM2, texel2_loc, 0);
+        texel2 = uBlock.scales.y * (texel2_quant - uBlock.zero_points.y);
+      }
+      sum = fma(texel1.xxzz, texel2.xyxy, sum);
+      sum = fma(texel1.yyww, texel2.zwzw, sum);
+    }
+
+    vec4 outx = vec4(sum.x, 0, 0, 0);
+
+    ivec3 posy = ivec3(posx.x+1, posx.y, pos.z);
+    vec4 outy = vec4(sum.y, 0, 0, 0);
+
+    ivec3 posz = ivec3(posx.x, posx.y+1, pos.z);
+    vec4 outz = vec4(sum.z, 0, 0, 0);
+
+    ivec3 posw = ivec3(posx.x+1, posx.y+1, pos.z);
+    vec4 outw = vec4(sum.w, 0, 0, 0);
+
+    outx = roundEven(outx / uBlock.out_scale.x) + uBlock.out_zero_point.x;
+    ivec4 storex = ivec4(outx);
+    imageStore(uOutput, posx, storex);
+    if (all(lessThan(posy, uBlock.size.xyz))) {
+      outy = roundEven(outy / uBlock.out_scale.x) + uBlock.out_zero_point.x;
+      ivec4 storey = ivec4(outy);
+      imageStore(uOutput, posy, storey);
+    }
+    if (all(lessThan(posz, uBlock.size.xyz))) {
+      outz = roundEven(outz / uBlock.out_scale.x) + uBlock.out_zero_point.x;
+      ivec4 storez = ivec4(outz);
+      imageStore(uOutput, posz, storez);
+    }
+    if (all(lessThan(posw, uBlock.size.xyz))) {
+      outw = roundEven(outw / uBlock.out_scale.x) + uBlock.out_zero_point.x;
+      ivec4 storew = ivec4(outw);
+      imageStore(uOutput, posw, storew);
+    }
+  }
+}

--- a/aten/src/ATen/native/vulkan/glsl/quantized_mm_quint8.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_mm_quint8.glsl
@@ -1,0 +1,98 @@
+#version 450 core
+#define PRECISION $precision
+#define FORMAT    $format
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, rgba8ui) uniform PRECISION restrict writeonly uimage3D   uOutput;
+layout(set = 0, binding = 1)         uniform PRECISION                    isampler3D uM1; //quantized input
+layout(set = 0, binding = 2)         uniform PRECISION                    isampler3D uM2; //quantized input
+layout(set = 0, binding = 3)         uniform PRECISION restrict           Block {
+  ivec4 size;
+  ivec4 um1_size;
+  ivec4 um2_size;
+  vec2 scales;
+  vec2 out_scale;
+  ivec2 zero_points;
+  ivec2 out_zero_point;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+  ivec3 posx = ivec3(pos.x*2, pos.y*2, pos.z);
+
+  if (all(lessThan(posx, uBlock.size.xyz))) {
+    vec4 sum = vec4(0);
+
+    for (int k = 0; k < uBlock.size.w; ++k) {
+      ivec3 inposx = ivec3(2*k, 2*pos.y, pos.z);
+      vec4 intexx = vec4(0.0);
+      if (all(lessThan(inposx, uBlock.um1_size.xyz))) {
+        const vec4 intexx_quant = texelFetch(uM1, inposx, 0);
+        intexx = uBlock.scales.x * (intexx_quant - uBlock.zero_points.x);
+      }
+      ivec3 inposy = ivec3(inposx.x + 1, inposx.y, pos.z);
+      vec4 intexy = vec4(0.0);
+      if (all(lessThan(inposy, uBlock.um1_size.xyz))) {
+        const vec4 intexy_quant = texelFetch(uM1, inposy, 0);
+        intexy = uBlock.scales.x * (intexy_quant - uBlock.zero_points.x);
+      }
+      ivec3 inposz = ivec3(inposx.x, inposx.y + 1, pos.z);
+      vec4 intexz = vec4(0.0);
+      if (all(lessThan(inposz, uBlock.um1_size.xyz))) {
+        const vec4 intexz_quant = texelFetch(uM1, inposz, 0);
+        intexz = uBlock.scales.x * (intexz_quant - uBlock.zero_points.x);
+      }
+      ivec3 inposw = ivec3(inposx.x + 1, inposx.y + 1, pos.z);
+      vec4 intexw = vec4(0.0);
+      if (all(lessThan(inposw, uBlock.um1_size.xyz))) {
+        const vec4 intexw_quant = texelFetch(uM1, inposw, 0);
+        intexw = uBlock.scales.x * (intexw_quant - uBlock.zero_points.x);
+      }
+
+      vec4 texel1 = vec4(intexx.x, intexy.x, intexz.x, intexw.x);
+      vec4 texel2 = vec4(0.0);
+      ivec3 texel2_loc = ivec3(pos.x, k, pos.z);
+      if (all(lessThan(texel2_loc, uBlock.um2_size.xyz))) {
+        const vec4 texel2_quant = texelFetch(uM2, texel2_loc, 0);
+        texel2 = uBlock.scales.y * (texel2_quant - uBlock.zero_points.y);
+      }
+      sum = fma(texel1.xxzz, texel2.xyxy, sum);
+      sum = fma(texel1.yyww, texel2.zwzw, sum);
+    }
+
+    vec4 outx = vec4(sum.x, 0, 0, 0);
+
+    ivec3 posy = ivec3(posx.x+1, posx.y, pos.z);
+    vec4 outy = vec4(sum.y, 0, 0, 0);
+
+    ivec3 posz = ivec3(posx.x, posx.y+1, pos.z);
+    vec4 outz = vec4(sum.z, 0, 0, 0);
+
+    ivec3 posw = ivec3(posx.x+1, posx.y+1, pos.z);
+    vec4 outw = vec4(sum.w, 0, 0, 0);
+
+    outx = roundEven(outx / uBlock.out_scale.x) + uBlock.out_zero_point.x;
+    uvec4 storex = uvec4(outx);
+    imageStore(uOutput, posx, storex);
+    if (all(lessThan(posy, uBlock.size.xyz))) {
+      outy = roundEven(outy / uBlock.out_scale.x) + uBlock.out_zero_point.x;
+      uvec4 storey = uvec4(outy);
+      imageStore(uOutput, posy, storey);
+    }
+    if (all(lessThan(posz, uBlock.size.xyz))) {
+      outz = roundEven(outz / uBlock.out_scale.x) + uBlock.out_zero_point.x;
+      uvec4 storez = uvec4(outz);
+      imageStore(uOutput, posz, storez);
+    }
+    if (all(lessThan(posw, uBlock.size.xyz))) {
+      outw = roundEven(outw / uBlock.out_scale.x) + uBlock.out_zero_point.x;
+      uvec4 storew = uvec4(outw);
+      imageStore(uOutput, posw, storew);
+    }
+  }
+}

--- a/aten/src/ATen/native/vulkan/ops/Mm.h
+++ b/aten/src/ATen/native/vulkan/ops/Mm.h
@@ -2,7 +2,9 @@
 
 #ifdef USE_VULKAN_API
 
+#include <ATen/native/quantized/PackedParams.h>
 #include <ATen/native/vulkan/ops/Common.h>
+#include <ATen/native/vulkan/ops/Utils.h>
 #include <ATen/native/vulkan/ops/VulkanPackedContext.h>
 #include <torch/library.h>
 
@@ -10,6 +12,46 @@ namespace at {
 namespace native {
 namespace vulkan {
 namespace ops {
+
+template <typename T>
+void stage_pack_weights(
+    api::Context* const context,
+    vTensor& v_weight,
+    const Tensor& weight,
+    const int64_t src_kb_sz,
+    const int64_t src_kh_sz,
+    const int64_t src_kw_sz,
+    const int64_t dst_kh_sz,
+    const int64_t dst_kw_sz) {
+  const int64_t src_matrix_sz = src_kw_sz * src_kh_sz;
+  const int64_t dst_plane_sz = dst_kw_sz * dst_kh_sz;
+  const int64_t dst_matrix_sz = dst_plane_sz * 4;
+  const T* const src_weight_ptr = weight.data_ptr<T>();
+  api::StorageBuffer staging(context, at::kFloat, v_weight.gpu_numel());
+  {
+    api::MemoryMap mapping(staging.buffer(), api::MemoryAccessType::WRITE);
+
+    T* dst_weight_ptr = mapping.template data<T>();
+
+    memset(dst_weight_ptr, 0, v_weight.nbytes());
+
+    for (const auto src_b : c10::irange(src_kb_sz)) {
+      for (const auto src_h : c10::irange(src_kh_sz)) {
+        for (const auto src_w : c10::irange(src_kw_sz)) {
+          int64_t dst_plane = 2 * (src_h % 2) + (src_w % 2);
+          int64_t dst_index = (src_h / 2) * dst_kw_sz + (src_w / 2);
+          memcpy(
+              dst_weight_ptr + src_b * dst_matrix_sz +
+                  dst_plane * dst_plane_sz + dst_index,
+              src_weight_ptr + src_b * src_matrix_sz + src_h * src_kw_sz +
+                  src_w,
+              sizeof(T));
+        }
+      }
+    }
+  }
+  utils::pack_staging_to_vtensor(staging.buffer(), v_weight);
+}
 
 class LinearPackedContext final : virtual public VulkanPackedContext,
                                   public torch::jit::CustomClassHolder {
@@ -59,6 +101,12 @@ c10::intrusive_ptr<LinearPackedContext> create_linear_context(
 
 Tensor run_linear_context(
     const Tensor& input,
+    const c10::intrusive_ptr<LinearPackedContext>& context);
+
+Tensor run_qlinear_context(
+    const Tensor& input,
+    double output_scale,
+    int64_t output_zero_point,
     const c10::intrusive_ptr<LinearPackedContext>& context);
 
 } // namespace ops

--- a/aten/src/ATen/native/vulkan/ops/Register.h
+++ b/aten/src/ATen/native/vulkan/ops/Register.h
@@ -6,6 +6,7 @@ namespace vulkan {
 namespace ops {
 
 int register_vulkan_conv2d_packed_context();
+int register_vulkan_linear_packed_context();
 
 } // namespace ops
 } // namespace vulkan

--- a/aten/src/ATen/native/vulkan/ops/Shape.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Shape.cpp
@@ -21,6 +21,11 @@ Tensor view_internal(const Tensor& self_arg, const IntArrayRef shape) {
       inferred_size,
       self_arg.scalar_type(),
   };
+  if (v_self.is_quantized()) {
+    v_output.set_is_quantized();
+    v_output.set_scale(v_self.get_scale());
+    v_output.set_zero_point(v_self.get_zero_point());
+  }
 
   api::StorageBuffer buffer(context, at::kFloat, v_self.gpu_numel(), true);
 

--- a/aten/src/ATen/test/vulkan_quantized_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_quantized_api_test.cpp
@@ -7,11 +7,15 @@
 #include <ATen/native/vulkan/ops/Common.h>
 #include <ATen/native/vulkan/ops/Copy.h>
 #include <ATen/native/vulkan/ops/Factory.h>
+#include <ATen/native/vulkan/ops/Mm.h>
 #include <ATen/native/vulkan/ops/QuantizedFunctions.h>
 #include <c10/util/irange.h>
 #include <gtest/gtest.h>
 #include <cstring>
 #include <random>
+#include <ATen/native/quantized/PackedParams.h>
+
+#include <cstdio>
 
 using namespace at::native::vulkan::api::utils;
 
@@ -57,7 +61,8 @@ bool exactlyEqual(const at::Tensor& a, const at::Tensor& b) {
 }
 */
 
-void showRtol(const at::Tensor& a, const at::Tensor& b) {
+void showRtol(const at::Tensor& a, const at::Tensor& b,
+    long *xpos=nullptr, long *ypos=nullptr) {
   const auto diff = (a - b).abs();
 
   double maxValue = a.abs().max().item<double>();
@@ -71,6 +76,7 @@ void showRtol(const at::Tensor& a, const at::Tensor& b) {
 
   const double maxDiff = maxValue * tolerance;
   std::cout << "Max Diff allowed: " << maxDiff << std::endl;
+  std::cout << "Max Diff found is: " << diff.max().item<double>() << std::endl;
   if (diff.sizes().size() == 2) {
     for (const auto y : c10::irange(diff.sizes()[0])) {
       std::cout << y << ":";
@@ -78,6 +84,14 @@ void showRtol(const at::Tensor& a, const at::Tensor& b) {
         double diff_xy = diff[y][x].item<double>();
         if (diff_xy > maxDiff) {
           std::cout << std::setw(5) << x;
+          if (diff.max().item<double>() == diff_xy) {
+            std::cout << " : " << diff_xy;
+            if (xpos && xpos) {
+              *xpos = x;
+              *ypos = y;
+              return;
+            }
+          }
         } else {
           std::cout << std::setw(5) << " ";
         }
@@ -3039,6 +3053,205 @@ TEST_F(VulkanAPITest, quantized_tensor_get_scale_zero_point) {
 
   ASSERT_TRUE(cpu_quantized_scale == vulkan_quantized_scale &&
       cpu_quantized_zero_point == vulkan_quantized_zero_point);
+}
+
+bool _test_quantized_linear(
+    const at::Tensor& input_cpu,
+    const at::Tensor& weight,
+    const at::Tensor& bias,
+    double out_scale,
+    int out_zero_point,
+    bool input_quant_dtype_int8,
+    bool weight_quant_dtype_int8) {
+  const auto input_quant_params = compute_quant_params(input_cpu,
+      input_quant_dtype_int8 ? c10::ScalarType::QInt8 : c10::ScalarType::QUInt8);
+  double scale = std::get<0>(input_quant_params);
+  scale = safe_downcast<float>(scale);
+  int zero_point = std::get<1>(input_quant_params);
+  auto input_cpu_quantized = at::quantize_per_tensor(input_cpu,
+      scale,
+      zero_point,
+      input_quant_dtype_int8 ? c10::ScalarType::QInt8 : c10::ScalarType::QUInt8);
+
+  const auto weight_quant_params = compute_quant_params(weight,
+      weight_quant_dtype_int8 ? c10::ScalarType::QInt8 : c10::ScalarType::QUInt8);
+  double w_scale = std::get<0>(weight_quant_params);
+  w_scale = safe_downcast<float>(w_scale);
+  // Weight zero point is expected to always be 0
+  int w_zero_point = 0;
+  const auto weight_cpu_quantized = at::quantize_per_tensor(weight,
+      w_scale,
+      w_zero_point,
+      weight_quant_dtype_int8 ? c10::ScalarType::QInt8 : c10::ScalarType::QUInt8);
+
+  auto pack =
+      callOpByName(
+          "quantized::linear_prepack", "",
+          weight_cpu_quantized,
+          bias);
+
+  auto out_cpu_quant = callOpByName(
+      "quantized::linear", "",
+      input_cpu_quantized,
+      pack[0],
+      out_scale,
+      out_zero_point);
+
+  at::Tensor out_cpu_dequant = at::dequantize(out_cpu_quant[0].toTensor());
+
+  // Vulkan
+  auto input_vk_quantized =
+      at::quantize_per_tensor(
+          input_cpu.vulkan(),
+          scale, zero_point,
+          input_quant_dtype_int8 ? c10::ScalarType::QInt8 : c10::ScalarType::QUInt8);
+
+  at::Tensor out_vk_quant;
+
+  c10::intrusive_ptr<at::native::vulkan::ops::LinearPackedContext> vk_pack =
+      at::native::vulkan::ops::create_linear_context(weight_cpu_quantized.t(), bias);
+
+  out_vk_quant =
+      at::native::vulkan::ops::run_qlinear_context(
+          input_vk_quantized,
+          out_scale, out_zero_point, vk_pack);
+
+  auto out_vk_dequant = at::dequantize(out_vk_quant);
+  auto out_vk_to_cpu_dequant = vulkan_to_cpu(out_vk_dequant, out_cpu_dequant);
+
+  const auto check = almostEqual(out_cpu_dequant, out_vk_to_cpu_dequant, out_scale);
+  if (!check) {
+    long xpos = -1, ypos = -1;
+    if (input_cpu.sizes().size() == 2) {
+      // for 2D tensor get the row col that caused failure
+      showRtol(out_cpu_dequant, out_vk_to_cpu_dequant, &xpos, &ypos);
+    } else {
+      showRtol(out_cpu_dequant, out_vk_to_cpu_dequant);
+    }
+    if (xpos != -1 && ypos != -1) {
+      std::cout << "\nFailure caused on row/col: " << ypos << "/" << xpos << "\n";
+      std::cout << "Input tensor scale: " << scale << " zerop: " << zero_point << "\n";
+      std::cout << "Input tensor row " << ypos << "\n";
+      for (int i = 0; i < input_cpu.sizes()[1]; i++) {
+        std::cout << input_cpu[ypos][i].item<double>() << ", ";
+      }
+      std::cout << "\n";
+
+      std::cout << "Weight tensor scale: " << w_scale << " zerop: " << w_zero_point << "\n";
+      std::cout << "Weight tensor col " << xpos << "\n";
+      for (int i = 0; i < weight.sizes()[1]; i++) {
+        std::cout << weight[xpos][i].item<double>() << ", ";
+      }
+      std::cout << "\n";
+
+      std::cout << "Input tensor quantized row " << ypos << " with dtype " << (input_quant_dtype_int8 ? "QInt8" : "QUInt8") << "\n";
+      for (int i = 0; i < input_cpu.sizes()[1]; i++) {
+        std::cout << input_cpu_quantized[ypos][i].item<double>() << ", ";
+      }
+      std::cout << "\n";
+
+      std::cout << "Weight tensor quantized col " << xpos << " with dtype " << (weight_quant_dtype_int8 ? "QInt8" : "QUInt8") << "\n";
+      for (int i = 0; i < weight.sizes()[1]; i++) {
+        std::cout << weight_cpu_quantized[xpos][i].item<double>() << ", ";
+      }
+      std::cout << "\n";
+
+      std::cout << "bias tensor\n";
+      for (int i = 0; i < bias.sizes()[0]; i++) {
+        std::cout << bias[i].item<double>() << ", ";
+      }
+      std::cout << "\n";
+
+      std::cout << "out_scale: " << out_scale << " out_zero_point: " << out_zero_point << "\n";
+
+      std::cout << "cpu unmatched output: " << out_cpu_dequant[ypos][xpos].item<double>() << "\n";
+      std::cout << "vk unmatched output: " << out_vk_to_cpu_dequant[ypos][xpos].item<double>() << "\n";
+    }
+  }
+  return check;
+}
+
+bool test_quantized_linear_for_dtypes(
+    const at::Tensor& input_cpu,
+    const at::Tensor& weight,
+    const at::Tensor& bias,
+    bool input_quant_dtype_int8,
+    bool weight_quant_dtype_int8) {
+  double out_scale = produce_random_scale();
+  out_scale = safe_downcast<float>(out_scale);
+  int out_zero_point = produce_random_zero_point(
+      input_quant_dtype_int8 ? c10::ScalarType::QInt8 : c10::ScalarType::QUInt8);
+  const auto check = _test_quantized_linear(input_cpu, weight, bias,
+      out_scale, out_zero_point, input_quant_dtype_int8, weight_quant_dtype_int8);
+  if (!check) {
+    // on failure we want to print the exact row/col that causes the
+    // failure in 2D, so we can debug
+    if (input_cpu.sizes().size() != 2) {
+      const auto d =
+        c10::multiply_integers(input_cpu.sizes().cbegin(), input_cpu.sizes().end() - 1);
+      auto input_cpu_2d = input_cpu.view({d, input_cpu.size(-1)});
+
+      _test_quantized_linear(input_cpu_2d, weight, bias, out_scale, out_zero_point,
+          input_quant_dtype_int8, weight_quant_dtype_int8);
+    }
+  }
+  return check;
+}
+
+void test_quantized_linear(
+    const at::IntArrayRef input_shape,
+    const at::IntArrayRef weight_shape,
+    const at::IntArrayRef bias_shape) {
+  c10::InferenceMode mode;
+
+  const auto input_cpu = produce_random_tensor(input_shape);
+
+  const auto weight = produce_random_tensor(weight_shape);
+
+  const auto bias = produce_random_tensor(bias_shape);
+
+  bool check = test_quantized_linear_for_dtypes(input_cpu, weight, bias,
+      false, true);
+  ASSERT_TRUE(check);
+  check = test_quantized_linear_for_dtypes(input_cpu, weight, bias,
+      true, true);
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, linear_2d_flat) {
+  test_quantized_linear({1, 100}, {1, 100}, {1});
+}
+
+TEST_F(VulkanAPITest, linear_2d_small) {
+  test_quantized_linear({2, 3}, {4, 3}, {4});
+}
+
+TEST_F(VulkanAPITest, linear_2d_large) {
+  test_quantized_linear({1287, 17}, {23, 17}, {23});
+}
+
+TEST_F(VulkanAPITest, linear_3d_flat) {
+  test_quantized_linear({1, 1, 37}, {41, 37}, {41});
+}
+
+TEST_F(VulkanAPITest, linear_3d_small) {
+  test_quantized_linear({2, 3, 4}, {5, 4}, {5});
+}
+
+TEST_F(VulkanAPITest, linear_3d_large) {
+  test_quantized_linear({23, 17, 41}, {15, 41}, {15});
+}
+
+TEST_F(VulkanAPITest, linear_4d_flat) {
+  test_quantized_linear({1, 1, 1, 37}, {41, 37}, {41});
+}
+
+TEST_F(VulkanAPITest, linear_4d_small) {
+  test_quantized_linear({2, 3, 4, 5}, {6, 5}, {6});
+}
+
+TEST_F(VulkanAPITest, linear_4d_large) {
+  test_quantized_linear({9, 13, 11, 17}, {23, 17}, {23});
 }
 
 } // namespace


### PR DESCRIPTION
Summary: Adding Linear vulkan quantize operator

Test Plan:
buck2 run --target-platforms ovr_config//platform/macos:arm64-fbsource -c pt.vulkan_full_precision=1

//xplat/caffe2/fb/custom_ops/vulkan_quantized:pt_vulkan_quantized_test_binAppleMac\#macosx-arm64

[       OK ] VulkanAPITest.convert_qconv2d_context (135 ms)
[ RUN      ] VulkanAPITest.linear_2d
[       OK ] VulkanAPITest.linear_2d (4 ms)
[----------] 2 tests from VulkanAPITest (139 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (139 ms total)
[  PASSED  ] 2 tests.

##############################################################

buck2 build --target-platforms ovr_config//platform/macos:arm64-fbsource

//xplat/caffe2:pt_vulkan_quantized_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1 --show-output"
buck-out//v2/gen/fbsource/xplat/caffe2/pt_vulkan_quantized_api_test_binAppleMac
[       OK ] VulkanAPITest.conv2d_pw_quantized_prepack_random_params_int8_int32 (11 ms)
[ RUN      ] VulkanAPITest.linear_2d_flat
[       OK ] VulkanAPITest.linear_2d_flat (4 ms)
[ RUN      ] VulkanAPITest.linear_2d_small
[       OK ] VulkanAPITest.linear_2d_small (1 ms)
[ RUN      ] VulkanAPITest.linear_2d_large
[       OK ] VulkanAPITest.linear_2d_large (1 ms)
[ RUN      ] VulkanAPITest.linear_3d_flat
[       OK ] VulkanAPITest.linear_3d_flat (2 ms)
[ RUN      ] VulkanAPITest.linear_3d_small
[       OK ] VulkanAPITest.linear_3d_small (2 ms)
[ RUN      ] VulkanAPITest.linear_3d_large
[       OK ] VulkanAPITest.linear_3d_large (1 ms)
[ RUN      ] VulkanAPITest.linear_4d_flat
[       OK ] VulkanAPITest.linear_4d_flat (1 ms)
[ RUN      ] VulkanAPITest.linear_4d_small
[       OK ] VulkanAPITest.linear_4d_small (1 ms)
[ RUN      ] VulkanAPITest.linear_4d_large
[       OK ] VulkanAPITest.linear_4d_large (1 ms)
[ RUN      ] VulkanAPITest.linear_custom
[       OK ] VulkanAPITest.linear_custom (0 ms)
[----------] 76 tests from VulkanAPITest (1811 ms total)

[----------] Global test environment tear-down
[==========] 76 tests from 1 test suite ran. (1811 ms total)
[  PASSED  ] 76 tests.

  YOU HAVE 8 DISABLED TESTS

##############################################################

buck2 run --target-platforms ovr_config//platform/macos:arm64-fbsource //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1

[----------] Global test environment tear-down
[==========] 346 tests from 1 test suite ran. (5648 ms total)
[  PASSED  ] 345 tests.
[  SKIPPED ] 1 test, listed below:
[  SKIPPED ] VulkanAPITest.querypool_flushed_shader_log

  YOU HAVE 5 DISABLED TESTS

Reviewed By: manuelcandales

Differential Revision: D48812642


