### PR TITLE
Switch eigen to GitHub mirror

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "third_party/eigen"]
     ignore = dirty
     path = third_party/eigen
-    url = https://github.com/eigen-mirror/eigen
+    url = https://github.com/eigen-mirror/eigen.git
 [submodule "third_party/googletest"]
     ignore = dirty
     path = third_party/googletest

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "third_party/eigen"]
     ignore = dirty
     path = third_party/eigen
-    url = https://gitlab.com/libeigen/eigen.git
+    url = https://github.com/eigen-mirror/eigen
 [submodule "third_party/googletest"]
     ignore = dirty
     path = third_party/googletest
@@ -123,29 +123,29 @@
     path = third_party/tensorpipe
     url = https://github.com/pytorch/tensorpipe.git
 [submodule "third_party/cudnn_frontend"]
-	path = third_party/cudnn_frontend
-	url = https://github.com/NVIDIA/cudnn-frontend.git
+    path = third_party/cudnn_frontend
+    url = https://github.com/NVIDIA/cudnn-frontend.git
 [submodule "third_party/kineto"]
     path = third_party/kineto
     url = https://github.com/pytorch/kineto
 [submodule "third_party/pocketfft"]
-	path = third_party/pocketfft
-	url = https://github.com/mreineck/pocketfft
+    path = third_party/pocketfft
+    url = https://github.com/mreineck/pocketfft
 [submodule "third_party/ittapi"]
-	path = third_party/ittapi
-	url = https://github.com/intel/ittapi.git
+    path = third_party/ittapi
+    url = https://github.com/intel/ittapi.git
 [submodule "third_party/flatbuffers"]
-	path = third_party/flatbuffers
-	url = https://github.com/google/flatbuffers.git
+    path = third_party/flatbuffers
+    url = https://github.com/google/flatbuffers.git
 [submodule "third_party/nlohmann"]
-	path = third_party/nlohmann
-	url = https://github.com/nlohmann/json.git
+    path = third_party/nlohmann
+    url = https://github.com/nlohmann/json.git
 [submodule "third_party/VulkanMemoryAllocator"]
-	path = third_party/VulkanMemoryAllocator
-	url = https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git
+    path = third_party/VulkanMemoryAllocator
+    url = https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git
 [submodule "third_party/cutlass"]
-	path = third_party/cutlass
-	url = https://github.com/NVIDIA/cutlass.git
+    path = third_party/cutlass
+    url = https://github.com/NVIDIA/cutlass.git
 [submodule "third_party/mimalloc"]
-	path = third_party/mimalloc
-	url = https://github.com/microsoft/mimalloc.git
+    path = third_party/mimalloc
+    url = https://github.com/microsoft/mimalloc.git


### PR DESCRIPTION
I found this mirror https://github.com/eigen-mirror/eigen/tree/master that we can use.  Should we make the switch?  One less flaky source is better than twos, i.e. https://hud.pytorch.org/pr/pytorch/pytorch/110530#17400038975

Please let me know if there are any concerns as the gitlab one is still considered official.