### PR TITLE
perf(inductor): improve `Adam` compile times drastically by moving list comprehensions into `_init_group`

### DIFF
--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -373,14 +373,6 @@ def _single_tensor_adam(params: List[Tensor],
         if weight_decay != 0:
             grad = grad.add(param, alpha=weight_decay)
 
-        # if torch.is_complex(param):
-        #     grad = torch.view_as_real(grad)
-        #     exp_avg = torch.view_as_real(exp_avg)
-        #     exp_avg_sq = torch.view_as_real(exp_avg_sq)
-        #     if amsgrad:
-        #         max_exp_avg_sqs[i] = torch.view_as_real(max_exp_avg_sqs[i])
-        #     param = torch.view_as_real(param)
-
         # Decay the first and second moment running average coefficient
         exp_avg.lerp_(grad, 1 - beta1)
         exp_avg_sq.mul_(beta2).addcmul_(grad, grad.conj(), value=1 - beta2)
@@ -485,13 +477,6 @@ def _multi_tensor_adam(params: List[Tensor],
 
         if maximize:
             device_grads = torch._foreach_neg(device_grads)
-
-        # Handle complex parameters
-        # device_grads = [torch.view_as_real(x) if torch.is_complex(x) else x for x in device_grads]
-        # device_exp_avgs = [torch.view_as_real(x) if torch.is_complex(x) else x for x in device_exp_avgs]
-        # device_exp_avg_sqs = [torch.view_as_real(x) if torch.is_complex(x) else x for x in device_exp_avg_sqs]
-        # device_max_exp_avg_sqs = [torch.view_as_real(x) if torch.is_complex(x) else x for x in device_max_exp_avg_sqs]
-        # device_params = [torch.view_as_real(x) if torch.is_complex(x) else x for x in device_params]
 
         # update steps
         torch._foreach_add_(device_state_steps, 1)


### PR DESCRIPTION
Adam part of: https://github.com/pytorch/pytorch/issues/110506

TODO:
- If this approach is validated as a good one, it an also be applied to all other optimizers which convert `complex` via list comprehensions
- Unclear whether strategy in this PR (move conversion into `_init_group`) is better than alternate (convert list comprehensions into for loop with single branch)
    - I believe both are fine, but the `_init_group` method seems more elegant, as it reduces duplicate code in `single` and `multi_tensor` cases. It's also faster.

### Results:
`NUM_PARAMS=200, foreach=True`
- main: dynamo: 43s, inductor: 31s, total: 74s
- this PR: dynamo: 3s, inductor: 31s, total: 34s (speedup: 40s, 2.17x)
- alternate strategy: dynamo: 6s, inductor: 30s, total: 36s (speedup: 38s, 2.0x)

`NUM_PARAMS=200, foreach=False`
- main: dynamo: 15s, inductor: 61s, total: 76s
- this PR: dynamo: 16s, inductor: 61s, total: 77s

### Results (With logs enabled):

<details>
`NUM_PARAMS=200, foreach=True,TORCH_LOGS=+dynamo,schedule`
- main: dynamo: 48s, inductor: 32s, total: 80s
- this PR: dynamo: 20s, inductor: 32s, total: 52s (speedup: 28s)

`NUM_PARAMS=200, foreach=False,TORCH_LOGS=+dynamo,schedule`
- main: dynamo: 19s, inductor: 64s, total 84s
- this PR: dynamo: 20s, inductor: 64s, total: 84s
- 
</details>

### Benchmark script
```python
import time
import torch
from torch.optim import Adam, SGD, Adagrad, NAdam

optim_cls = Adam
NUM_PARAMS = 200
kwargs = { "lr": 0.01, "foreach": True }

torch._dynamo.reset()
# torch._inductor.metrics.reset()
input = torch.ones([10, 10], device="cuda:0")
model = torch.nn.Sequential(
    *[torch.nn.Linear(10, 10, device="cuda:0") for _ in range(NUM_PARAMS)]
)

model(input).sum().backward()
opt_compiled = optim_cls(model.parameters(), **kwargs)
compiled_step = torch.compile(opt_compiled.step)

with torch.set_grad_enabled(False):
    start_time = time.time()
    compiled_step()
    print("compile opt took: %s seconds", time.time() - start_time)

print(torch._dynamo.utils.compile_times())
```

### Alternate Strategy
Use for loops rather than list comprehensions
```python
# Handle complex parameters
for i in range(len(device_grads)):
    if torch.is_complex(device_params[i]):
        device_grads[i] = torch.view_as_real(device_grads[i])
        device_exp_avgs[i] = torch.view_as_real(device_exp_avgs[i])
        device_exp_avg_sqs[i] = torch.view_as_real(device_exp_avg_sqs[i])
        device_max_exp_avg_sqs[i] = torch.view_as_real(device_max_exp_avg_sqs[i])
        device_params[i] = torch.view_as_real(device_params[i])
```
CC: @janeyx99 @mlazos 