### PR TITLE
[export] Update ArgumentSpec definition.

### DIFF
--- a/docs/source/export.rst
+++ b/docs/source/export.rst
@@ -575,7 +575,5 @@ API Reference
 
 .. autoclass:: ExportBackwardSignature
 .. autoclass:: ExportGraphSignature
-.. autoclass:: ArgumentKind
-.. autoclass:: ArgumentSpec
 .. autoclass:: ModuleCallSignature
 .. autoclass:: ModuleCallEntry

--- a/torch/_export/exported_program.py
+++ b/torch/_export/exported_program.py
@@ -23,8 +23,6 @@ from torch._export.passes.add_runtime_assertions_for_constraints_pass import (
 # TODO(ycao): This is added to avoid breaking existing code temporarily.
 # Remove when migration is done.
 from torch.export import (
-    ArgumentKind,
-    ArgumentSpec,
     ExportBackwardSignature,
     ExportGraphSignature,
     ExportedProgram,
@@ -34,8 +32,6 @@ from torch.export import (
 
 
 __all__ = [
-    "ArgumentKind",
-    "ArgumentSpec",
     "ExportBackwardSignature",
     "ExportGraphSignature",
     "ExportedProgram",

--- a/torch/_export/passes/collect_tracepoints_pass.py
+++ b/torch/_export/passes/collect_tracepoints_pass.py
@@ -2,9 +2,7 @@ import operator
 
 import torch
 
-from torch._export.exported_program import ArgumentKind, ArgumentSpec
-
-from torch.ao.quantization.fx._decomposed import quantized_decomposed_lib  # noqa: F401
+from torch.export.exported_program import ConstantArgument, TensorArgument
 from torch.fx.passes.infra.pass_base import PassBase, PassResult
 
 __all__ = ["CollectTracepointsPass"]
@@ -23,13 +21,13 @@ class CollectTracepointsPass(PassBase):
         def get_arg_spec(arg):
             if isinstance(arg, torch.fx.Node):
                 if isinstance(arg.meta.get("val"), torch.Tensor):
-                    return ArgumentSpec(kind=ArgumentKind.Tensor, value=arg.name)
+                    return TensorArgument(name=arg.name)
                 else:
                     raise AssertionError(
                         "Symint input is not implemented yet for submodule call signature."
                     )
             else:
-                return ArgumentSpec(kind=ArgumentKind.Constant, value=arg)
+                return ConstantArgument(value=arg)
 
         for module in gm.modules():
             if not isinstance(module, torch.fx.GraphModule):

--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -29,8 +29,6 @@ from torch.utils._pytree import (
 
 
 __all__ = [
-    "ArgumentKind",
-    "ArgumentSpec",
     "Constraint",
     "Dim",
     "ExportBackwardSignature",
@@ -50,8 +48,6 @@ __all__ = [
 
 
 from .exported_program import (
-    ArgumentKind,
-    ArgumentSpec,
     ExportBackwardSignature,
     ExportedProgram,
     ExportGraphSignature,

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -1,6 +1,5 @@
 import copy
 import dataclasses
-from enum import auto, Enum
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 import sympy
@@ -15,8 +14,9 @@ from torch.fx.passes.infra.pass_manager import PassManager
 
 
 __all__ = [
-    "ArgumentKind",
-    "ArgumentSpec",
+    "TensorArgument",
+    "ConstantArgument",
+    "SymIntArgument",
     "ExportBackwardSignature",
     "ExportedProgram",
     "ExportGraphSignature",
@@ -171,20 +171,22 @@ class ExportGraphSignature:
         )
 
 
-class ArgumentKind(Enum):
-    Tensor = auto()
-    SymInt = auto()
-    Constant = auto()
+@dataclasses.dataclass
+class TensorArgument:
+    name: str
 
 
 @dataclasses.dataclass
-class ArgumentSpec:
-    kind: ArgumentKind
-    value: Any
+class SymIntArgument:
+    name: str
 
-    def __post_init__(self):
-        if self.kind in (ArgumentKind.Tensor, ArgumentKind.SymInt):
-            assert isinstance(self.value, str)
+
+@dataclasses.dataclass
+class ConstantArgument:
+    value: Union[int, float, bool, None]
+
+
+ArgumentSpec = Union[TensorArgument, SymIntArgument, ConstantArgument]
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Summary: Changing ArgumentSpec into a true union type in Python without changing serialization format.

Test Plan: CI

Differential Revision: D49871088




cc @avikchaudhuri @gmagogsfm