### PR TITLE
perf(inductor): use for loop with shortcut in `Optimizer`s to speedup against list comprehensions (e.g. complex conversion)

### DIFF
--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -320,7 +320,7 @@ def _multi_tensor_adagrad(
 
     grouped_tensorlists = Optimizer._group_tensors_by_device_and_dtype([params, grads, state_sums, state_steps])
     for ((device_params, device_grads, device_state_sums, device_state_steps), _) in grouped_tensorlists.values():
-        device_has_sparse_grad = any(grad.is_sparse for grad in device_grads)
+        device_has_sparse_grad = has_sparse_grad and any(grad.is_sparse for grad in device_grads)
 
         if device_has_sparse_grad:
             _single_tensor_adagrad(

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -320,7 +320,9 @@ def _multi_tensor_adagrad(
 
     grouped_tensorlists = Optimizer._group_tensors_by_device_and_dtype([params, grads, state_sums, state_steps])
     for ((device_params, device_grads, device_state_sums, device_state_steps), _) in grouped_tensorlists.values():
-        if has_sparse_grad:
+        device_has_sparse_grad = any(grad.is_sparse for grad in device_grads)
+
+        if device_has_sparse_grad:
             _single_tensor_adagrad(
                 device_params,
                 device_grads,

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -323,7 +323,7 @@ def _multi_tensor_adagrad(
         device_has_sparse_grad = has_sparse_grad and any(grad.is_sparse for grad in device_grads)
 
         if device_has_sparse_grad:
-            _single_tensor_adagrad(
+            return _single_tensor_adagrad(
                 device_params,
                 device_grads,
                 device_state_sums,
@@ -336,7 +336,6 @@ def _multi_tensor_adagrad(
                 maximize=False,
                 differentiable=differentiable,
             )
-            continue
 
         if maximize:
             device_grads = torch._foreach_neg(device_grads)

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -321,7 +321,11 @@ def _multi_tensor_adagrad(
     grouped_tensorlists = Optimizer._group_tensors_by_device_and_dtype([params, grads, state_sums, state_steps])
     for ((device_params, device_grads, device_state_sums, device_state_steps), _) in grouped_tensorlists.values():
 
-        device_has_sparse_grad = any(grad.is_sparse for grad in device_grads)
+        device_has_sparse_grad = False
+        for grad in device_grads:
+            if grad.is_sparse:
+                device_has_sparse_grad = True
+                break
 
         if device_has_sparse_grad:
             return _single_tensor_adagrad(

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -342,11 +342,11 @@ def _multi_tensor_adagrad(
             device_grads = torch._foreach_neg(device_grads)
 
         # Handle complex parameters
-        device_grads = [torch.view_as_real(x) if torch.is_complex(x) else x for x in device_grads]
-        device_state_sums = [
-            torch.view_as_real(x) if torch.is_complex(x) else x for x in device_state_sums
-        ]
-        device_params = [torch.view_as_real(x) if torch.is_complex(x) else x for x in device_params]
+        for i in range(len(device_params)):
+            if torch.is_complex(device_params[i]):
+                device_params[i] = torch.view_as_real(device_params[i])
+                device_grads[i] = torch.view_as_real(device_grads[i])
+                device_state_sums[i] = torch.view_as_real(device_state_sums[i])
 
         # Update steps
         torch._foreach_add_(device_state_steps, 1)

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -320,15 +320,8 @@ def _multi_tensor_adagrad(
 
     grouped_tensorlists = Optimizer._group_tensors_by_device_and_dtype([params, grads, state_sums, state_steps])
     for ((device_params, device_grads, device_state_sums, device_state_steps), _) in grouped_tensorlists.values():
-
-        device_has_sparse_grad = False
-        for grad in device_grads:
-            if grad.is_sparse:
-                device_has_sparse_grad = True
-                break
-
-        if device_has_sparse_grad:
-            return _single_tensor_adagrad(
+        if has_sparse_grad:
+            _single_tensor_adagrad(
                 device_params,
                 device_grads,
                 device_state_sums,
@@ -341,6 +334,7 @@ def _multi_tensor_adagrad(
                 maximize=False,
                 differentiable=differentiable,
             )
+            continue
 
         if maximize:
             device_grads = torch._foreach_neg(device_grads)

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -488,12 +488,12 @@ def _multi_tensor_adam(params: List[Tensor],
         # Handle complex parameters
         for i in range(len(device_params)):
             if torch.is_complex(device_params[i]):
+                device_params[i] = torch.view_as_real(device_params[i])
                 device_grads[i] = torch.view_as_real(device_grads[i])
                 device_exp_avgs[i] = torch.view_as_real(device_exp_avgs[i])
                 device_exp_avg_sqs[i] = torch.view_as_real(device_exp_avg_sqs[i])
                 if len(device_max_exp_avg_sqs) > 0:
                     device_max_exp_avg_sqs[i] = torch.view_as_real(device_max_exp_avg_sqs[i])
-                device_params[i] = torch.view_as_real(device_params[i])
 
         # update steps
         torch._foreach_add_(device_state_steps, 1)

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -492,7 +492,7 @@ def _multi_tensor_adam(params: List[Tensor],
                 device_grads[i] = torch.view_as_real(device_grads[i])
                 device_exp_avgs[i] = torch.view_as_real(device_exp_avgs[i])
                 device_exp_avg_sqs[i] = torch.view_as_real(device_exp_avg_sqs[i])
-                if len(device_max_exp_avg_sqs) > 0:
+                if amsgrad:
                     device_max_exp_avg_sqs[i] = torch.view_as_real(device_max_exp_avg_sqs[i])
 
         # update steps

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -486,11 +486,14 @@ def _multi_tensor_adam(params: List[Tensor],
             device_grads = torch._foreach_neg(device_grads)
 
         # Handle complex parameters
-        device_grads = [torch.view_as_real(x) if torch.is_complex(x) else x for x in device_grads]
-        device_exp_avgs = [torch.view_as_real(x) if torch.is_complex(x) else x for x in device_exp_avgs]
-        device_exp_avg_sqs = [torch.view_as_real(x) if torch.is_complex(x) else x for x in device_exp_avg_sqs]
-        device_max_exp_avg_sqs = [torch.view_as_real(x) if torch.is_complex(x) else x for x in device_max_exp_avg_sqs]
-        device_params = [torch.view_as_real(x) if torch.is_complex(x) else x for x in device_params]
+        for i in range(len(device_params)):
+            if torch.is_complex(device_params[i]):
+                device_grads[i] = torch.view_as_real(device_grads[i])
+                device_exp_avgs[i] = torch.view_as_real(device_exp_avgs[i])
+                device_exp_avg_sqs[i] = torch.view_as_real(device_exp_avg_sqs[i])
+                if len(device_max_exp_avg_sqs) > 0:
+                    device_max_exp_avg_sqs[i] = torch.view_as_real(device_max_exp_avg_sqs[i])
+                device_params[i] = torch.view_as_real(device_params[i])
 
         # update steps
         torch._foreach_add_(device_state_steps, 1)

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -309,17 +309,19 @@ def _multi_tensor_adamax(
         if maximize:
             grouped_grads = torch._foreach_neg(grouped_grads)
 
-        grouped_params = [torch.view_as_real(x) if torch.is_complex(x) else x for x in grouped_params]
-        grouped_grads = [torch.view_as_real(x) if torch.is_complex(x) else x for x in grouped_grads]
-        grouped_exp_avgs = [torch.view_as_real(x) if torch.is_complex(x) else x for x in grouped_exp_avgs]
-        grouped_exp_infs = [torch.view_as_real(x) if torch.is_complex(x) else x for x in grouped_exp_infs]
+        for i in range(len(grouped_params)):
+            if torch.is_complex(grouped_params[i]):
+                grouped_params[i] = torch.view_as_real(grouped_params[i])
+                grouped_grads[i] = torch.view_as_real(grouped_grads[i])
+                grouped_exp_avgs[i] = torch.view_as_real(grouped_exp_avgs[i])
+                grouped_exp_infs[i] = torch.view_as_real(grouped_exp_infs[i])
 
         # Update steps
         torch._foreach_add_(grouped_state_steps, 1)
 
         if weight_decay != 0:
             if maximize:
-                # Re-use the intermediate memory (device_grads) already allocated for maximize
+                # Re-use the intermediate memory (grouped_grads) already allocated for maximize
                 torch._foreach_add_(grouped_grads, grouped_params, alpha=weight_decay)
             else:
                 grouped_grads = torch._foreach_add(grouped_grads, grouped_params, alpha=weight_decay)

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -519,15 +519,14 @@ def _multi_tensor_adamw(
         if maximize:
             device_grads = torch._foreach_neg(device_grads)
 
-        device_grads = [torch.view_as_real(x) if torch.is_complex(x) else x for x in device_grads]
-        device_exp_avgs = [torch.view_as_real(x) if torch.is_complex(x) else x for x in device_exp_avgs]
-        device_exp_avg_sqs = [
-            torch.view_as_real(x) if torch.is_complex(x) else x for x in device_exp_avg_sqs
-        ]
-        device_max_exp_avg_sqs = [
-            torch.view_as_real(x) if torch.is_complex(x) else x for x in device_max_exp_avg_sqs
-        ]
-        device_params = [torch.view_as_real(x) if torch.is_complex(x) else x for x in device_params]
+        for i in range(len(device_params)):
+            if torch.is_complex(device_params[i]):
+                device_params[i] = torch.view_as_real(device_params[i])
+                device_grads[i] = torch.view_as_real(device_grads[i])
+                device_exp_avgs[i] = torch.view_as_real(device_exp_avgs[i])
+                device_exp_avg_sqs[i] = torch.view_as_real(device_exp_avg_sqs[i])
+                if len(device_max_exp_avg_sqs) > 0:
+                    device_max_exp_avg_sqs[i] = torch.view_as_real(device_max_exp_avg_sqs[i])
 
         # update steps
         torch._foreach_add_(device_state_steps, 1)

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -525,7 +525,7 @@ def _multi_tensor_adamw(
                 device_grads[i] = torch.view_as_real(device_grads[i])
                 device_exp_avgs[i] = torch.view_as_real(device_exp_avgs[i])
                 device_exp_avg_sqs[i] = torch.view_as_real(device_exp_avg_sqs[i])
-                if len(device_max_exp_avg_sqs) > 0:
+                if amsgrad:
                     device_max_exp_avg_sqs[i] = torch.view_as_real(device_max_exp_avg_sqs[i])
 
         # update steps

--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -308,14 +308,12 @@ def _multi_tensor_asgd(
         if maximize:
             grouped_grads = torch._foreach_neg(grouped_grads)
 
-        def _view_complex_as_real(tensor_list):
-            return [
-                torch.view_as_real(t) if torch.is_complex(t) else t for t in tensor_list
-            ]
-
-        grouped_grads = _view_complex_as_real(grouped_grads)
-        grouped_params = _view_complex_as_real(grouped_params)
-        grouped_axs = _view_complex_as_real(grouped_axs)
+        grouped_grads = list(grouped_grads)
+        for i in range(len(grouped_params)):
+            if torch.is_complex(grouped_params[i]):
+                grouped_params[i] = torch.view_as_real(grouped_params[i])
+                grouped_grads[i] = torch.view_as_real(grouped_grads[i])
+                grouped_axs[i] = torch.view_as_real(grouped_axs[i])
 
         # update step
         torch._foreach_add_(grouped_state_steps, 1)

--- a/torch/optim/rprop.py
+++ b/torch/optim/rprop.py
@@ -283,15 +283,12 @@ def _multi_tensor_rprop(
     grouped_tensors = Optimizer._group_tensors_by_device_and_dtype([params, grads, prevs, step_sizes])
     for ((grouped_params, grouped_grads, grouped_prevs, grouped_step_sizes), _) in grouped_tensors.values():
         # Handle complex params
-        def _view_complex_as_real(tensor_list):
-            return [
-                torch.view_as_real(t) if torch.is_complex(t) else t for t in tensor_list
-            ]
-
-        grouped_grads = _view_complex_as_real(grouped_grads)
-        grouped_prevs = _view_complex_as_real(grouped_prevs)
-        grouped_params = _view_complex_as_real(grouped_params)
-        grouped_step_sizes = _view_complex_as_real(grouped_step_sizes)
+        for i in range(len(grouped_params)):
+            if torch.is_complex(grouped_params[i]):
+                grouped_params[i] = torch.view_as_real(grouped_params[i])
+                grouped_grads[i] = torch.view_as_real(grouped_grads[i])
+                grouped_prevs[i] = torch.view_as_real(grouped_prevs[i])
+                grouped_step_sizes[i] = torch.view_as_real(grouped_step_sizes[i])
 
         signs = torch._foreach_mul(grouped_grads, grouped_prevs)
         if maximize:


### PR DESCRIPTION
Fully fixes: https://github.com/pytorch/pytorch/issues/110506

Depends: https://github.com/pytorch/pytorch/pull/110607
Potential merge conflicts: 
- https://github.com/pytorch/pytorch/pull/110339
- https://github.com/pytorch/pytorch/pull/110345
- https://github.com/pytorch/pytorch/pull/110454

Related:
- https://github.com/pytorch/pytorch/issues/110606 (we can apply the improvements here orthogonally to the complex support)

### Results

Benchmark: 100 params.

Breakdowns (float32, dynamo):
```
Adagrad: this PR: 4.4s, main: 8.8s
Adam: this PR: 2.1s, main: 9.8s
AdamW: this PR: 2.5s, main: 8.2s
ASGD: this PR: 3.1s, main: 8.5s
RMSProp: this PR: 1.3s, main: 4.2s
RProp: this PR: 6.7s, main: 14.9s
```

Notes:
1. Adagrad is still slow due to `_get_value` list comprehension. Can be fixed in https://github.com/pytorch/pytorch/pull/110339/files by utilizing capturable path
2. Adamax is not actually compiled (it is currently disabled).
3. Inductor compile time is quite variable. We calculate dynamo by subtracting `call_user_compiler` from `compile_inner` timing.

<details>

This PR:
```
Adagrad (torch.float32): 28.47496461868286s
Adagrad (torch.complex64): 29.379547357559204s
Adam (torch.float32): 17.334211587905884s
Adam (torch.complex64): 29.637500524520874s
Adamax (torch.float32): 2.4749321937561035s
Adamax (torch.complex64): 3.1997995376586914s
AdamW (torch.float32): 18.06532859802246s
AdamW (torch.complex64): 28.25661015510559s
ASGD (torch.float32): 23.70255398750305s
ASGD (torch.complex64): 25.33756995201111s
RMSprop (torch.float32): 7.964028596878052s
RMSprop (torch.complex64): 12.909599781036377s
Rprop (torch.float32): 30.512362003326416s
Rprop (torch.complex64): 44.74405765533447s
```

Main
```
Adagrad (torch.float32): 26.919506072998047s
Adagrad (torch.complex64): 35.190622091293335s
Adam (torch.float32): 25.715000867843628s
Adam (torch.complex64): 24.17716670036316s
Adamax (torch.float32): 2.4404726028442383s
Adamax (torch.complex64): 3.3538928031921387s
AdamW (torch.float32): 25.2022807598114s
AdamW (torch.complex64): 28.915700912475586s
ASGD (torch.float32): 24.108731985092163s
ASGD (torch.complex64): 26.589075088500977s
RMSprop (torch.float32): 10.781344175338745s
RMSprop (torch.complex64): 15.136352777481079s
Rprop (torch.float32): 42.46482181549072s
Rprop (torch.complex64): 48.28277635574341s
```

Seems that it doesn't help the complex case by much (but that's not the majority case). torch.float32 is generally positive, when it does not show drastic improvement / regresses, it is due to inductor variance (by manually inspecting the logs).


</details>

### Benchmark Script
```python
import torch
import time
from torch.optim import Adagrad, Adam, Adamax, AdamW, ASGD, RMSprop, Rprop

OPTIMS = [Adagrad, Adam, Adamax, AdamW, ASGD, RMSprop, Rprop]
DTYPES = [torch.float, torch.cfloat]

NUM_PARAMS = 100
kwargs = { "lr": 0.01, "foreach": True }
summary = []

for optim_cls in OPTIMS:
    for dtype in DTYPES:
        torch._dynamo.reset()
        # torch._inductor.metrics.reset()
        input = torch.ones([10, 10], dtype=dtype, device="cuda:0")
        model = torch.nn.Sequential(
            *[torch.nn.Linear(10, 10, dtype=dtype, device="cuda:0") for _ in range(NUM_PARAMS)]
        )

        model(input).sum().abs().backward()
        opt_compiled = optim_cls(model.parameters(), **kwargs)
        compiled_step = torch.compile(opt_compiled.step)

        with torch.set_grad_enabled(False):
            start_time = time.time()
            compiled_step()
            summary.append(f"{optim_cls.__name__} ({dtype}): {time.time() - start_time}s")

        print(optim_cls, kwargs, dtype, torch._dynamo.utils.compile_times())

for s in summary:
    print(s)
```

CC: @janeyx99 @mlazos 