### PR TITLE
[ez] Remove print in heuristics aggregation

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1646,6 +1646,7 @@ def main():
         aggregated_heuristics = get_test_prioritizations(selected_tests)
 
     test_prioritizations = aggregated_heuristics.get_aggregated_priorities()
+    test_prioritizations.print_info()
 
     if IS_CI:
         metrics_dict = {

--- a/tools/stats/import_test_stats.py
+++ b/tools/stats/import_test_stats.py
@@ -86,9 +86,10 @@ def get_disabled_tests(
 ) -> Optional[Dict[str, Any]]:
     def process_disabled_test(the_response: Dict[str, Any]) -> Dict[str, Any]:
         # remove re-enabled tests and condense even further by getting rid of pr_num
+        disabled_issues = get_disabled_issues()
         disabled_test_from_issues = dict()
         for test_name, (pr_num, link, platforms) in the_response.items():
-            if pr_num not in get_disabled_issues():
+            if pr_num not in disabled_issues:
                 disabled_test_from_issues[test_name] = (
                     link,
                     platforms,

--- a/tools/testing/target_determination/heuristics/interface.py
+++ b/tools/testing/target_determination/heuristics/interface.py
@@ -240,8 +240,6 @@ class AggregatedHeuristics:
         for heuristic_results in self._heuristic_results.values():
             aggregated_priorities.integrate_priorities(heuristic_results)
 
-        aggregated_priorities.print_info()
-
         return aggregated_priorities
 
     def get_test_stats(self, test: str) -> Dict[str, Any]:


### PR DESCRIPTION
Move print to the beginning instead because putting it at the end makes it so you have to scroll through when debugging, and nothing in that function indicates that it should be printing anything

Also the line for printing disabled issues out of the for loop