### PR TITLE
Back out "[Inductor] Break the loop fusion when node2 depends on node1 mutations (#109172)"

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7135,24 +7135,6 @@ class CommonTemplate:
         self.assertEqual(ref, actual)
         self.assertTrue(called)
 
-    def test_mutations_loop_fusion(self):
-        def fn(tensor, index, source):
-            out = tensor.index_add(0, index, source, alpha=2.0) / 2
-            return out
-
-        device = "cpu"
-        tensor = torch.rand((1,), dtype=torch.double, device=device)
-        index = torch.tensor([0], dtype=torch.long, device=device)
-        source = torch.rand((1,), dtype=torch.double, device=device)
-        self.common(
-            fn,
-            (
-                tensor,
-                index,
-                source,
-            ),
-        )
-
 
 @dataclasses.dataclass
 class TestFailure:

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -268,10 +268,6 @@ test_failures = {
     # test_roi_align uses torchvision, which doesn't work with dynamic shapes
     "test_roi_align_dynamic_shapes": TestFailure(("cpu", "cuda")),
     "test_aliased_buffer_reuse_dynamic_shapes": TestFailure(("cpu",)),
-    # The input of this case has only 1 elements
-    "test_mutations_loop_fusion_dynamic_shapes": TestFailure(
-        ("cpu", "cuda"), is_skip=True
-    ),
 }
 
 

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -238,6 +238,7 @@ inductor_expected_failures_single_sample["cuda"] = {
     "log_normal": {f16},
     "masked_scatter": {f16, f32, f64},
     "multinomial": {f16, f32, f64},
+    "nanquantile": {f32, f64},
     "nn.functional.normalize": {f16},
     ("normal", "in_place"): {f16, f32, f64},
     ("normal", "number_mean"): {f16, f32, f64},
@@ -254,6 +255,7 @@ inductor_gradient_expected_failures_single_sample = defaultdict(dict)
 
 inductor_gradient_expected_failures_single_sample["cuda"] = {
     "atanh": {f32},
+    "nanquantile": {f32, f64},
     "nn.functional.normalize": {f16},
 }
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -687,28 +687,6 @@ class SchedulerNode(BaseSchedulerNode):
             return read_dep.index == write_dep.index and read_dep.size == write_dep.size
         return False
 
-    @cache_on_self
-    def _get_atomic_add_buffers(self) -> Set[str]:
-        buffers_store_as_atomic_add = set()
-        for node in self._body.get_nodes():
-            if (
-                node.op == "call_method"
-                and node.target == "store"
-                and (
-                    ("mode" in node.kwargs and node.kwargs["mode"] == "atomic_add")
-                    or (len(node.args) == 5 and node.args[4] == "atomic_add")
-                )
-            ):
-                buffers_store_as_atomic_add.add(
-                    node.kwargs["name"]
-                    if "name" in node.kwargs
-                    else (node.args[1] if len(node.args) >= 2 else "")
-                )
-        return buffers_store_as_atomic_add
-
-    def has_atomic_add(self, check_buf):
-        return check_buf in self._get_atomic_add_buffers()
-
 
 class FusedSchedulerNode(BaseSchedulerNode):
     """
@@ -810,15 +788,6 @@ class FusedSchedulerNode(BaseSchedulerNode):
         for node in self.snodes:
             op_counts.update(node.op_counts())
         return op_counts
-
-    def has_atomic_add(self, check_buf):
-        return any(
-            (
-                isinstance(sub_schedule_node1, SchedulerNode)
-                and sub_schedule_node1.has_atomic_add(check_buf)
-            )
-            for sub_schedule_node1 in self.get_nodes()
-        )
 
     # None of these need to be implemented, as a FusedSchedulerNode is just an
     # abstraction for scheduling purposes
@@ -1546,25 +1515,6 @@ class Scheduler:
 
         if node2.get_names() & node1.ancestors:
             return False  # node1 must go before node2
-
-        if (
-            isinstance(node1, (FusedSchedulerNode, SchedulerNode))
-            and isinstance(node2, SchedulerNode)
-            and isinstance(node2._body, ir.LoopBody)
-        ):
-            # Fix issue: https://github.com/pytorch/pytorch/issues/108963
-            # Check:
-            #   If node2 reads a buf which is a mutation buf of node1(SchedulerNode) or among nodes in node1(FusedSchedulerNode),
-            #   we will get the corresponding mutation buf and check if this mutation buf is stored by atomic_add mode.
-            # If True, we will disable the fusion of node1 and node2.
-            if any(
-                (
-                    node2_used_buf in self.mutation_renames
-                    and node1.has_atomic_add(self.mutation_renames[node2_used_buf])
-                )
-                for node2_used_buf in node2._body.reads_name2expr.keys()
-            ):
-                return False
 
         if node2.is_template():
             return False  # only epilogues


### PR DESCRIPTION
Summary:
Original commit changeset: 03980fb054d5

Original Phabricator Diff: D49519512

Bisecting shows that this diff is the cause of S369683. Since this affects Ads production, need to back out this diff immediately.

Test Plan: See S369683

Reviewed By: ezyang

Differential Revision: D49958638




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler