### PR TITLE
Hide the contiguous requirement for user input mesh when initializing DeviceMesh

### DIFF
--- a/test/distributed/_tensor/test_device_mesh.py
+++ b/test/distributed/_tensor/test_device_mesh.py
@@ -120,6 +120,15 @@ class DeviceMeshTest(DTensorTestBase):
             else:
                 mesh = DeviceMesh(self.device_type, mesh_subpg_2)
 
+        mesh_non_contiguous = (
+            torch.arange(0, self.world_size).view(2, 2).transpose(0, 1)
+        )
+        device_mesh = DeviceMesh(
+            self.device_type, mesh_non_contiguous, mesh_dim_names=("dp", "mp")
+        )
+        self.assertEqual(device_mesh.size(0), 2)
+        self.assertEqual(device_mesh.size(1), 2)
+
 
 class DeviceMeshTestNDim(DTensorTestBase):
     @property

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -212,7 +212,7 @@ class DeviceMesh:
             )
 
         # validate that all calling ranks pass in the same `mesh` argument.
-        self_mesh = self.mesh.to(self.device_type)
+        self_mesh = self.mesh.to(self.device_type).contiguous()
         mesh_tensor = funcol.all_gather_tensor(
             self_mesh, gather_dim=0, group=_get_default_group()
         )


### PR DESCRIPTION
Summary:
As title, this diff hides the contiguous requirement for user input mesh when initializing DeviceMesh.

In the current implementation, when testing with inter-node model parallelism, an exception is thrown during mesh validation when the following input is provided:
```
mesh = torch.arange(0, world_size).view(mp_size, dp_size).transpose(0, 1)
device_mesh = DeviceMesh(
                "cuda",
mesh.contiguous(),
mesh_dim_names=("dp", "mp")
)
```

Test Plan:
**Unit Test**:
```
buck2 test mode/dev-nosan //caffe2/test/distributed/_tensor:device_mesh -- test_validate_device_mesh

Test UI: https://www.internalfb.com/intern/testinfra/testrun/3940649876878399
Network: Up: 0B  Down: 0B
Jobs completed: 6. Time elapsed: 1:58.7s.
Tests finished: Pass 1. Fail 0. Fatal 0. Skip 0. Build failure 0
```

**Test with MP**
```
mesh = torch.arange(0, world_size).view(mp_size, dp_size).transpose(0, 1)
device_mesh = DeviceMesh(
                "cuda",
mesh.contiguous(),
mesh_dim_names=("dp", "mp")
)
```
Without the change: exception.
After this change: initialzied sucessfully.

Differential Revision: D49942839


