### PR TITLE
[dtensor] add grad placements kwarg to to_local API

### DIFF
--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -329,10 +329,10 @@ class DTensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
             grad_placements (List[:class:`Placement`], optional): the placements describes
                 the future layout of any gradient layout of the Tensor returned from this
                 function.
-                `to_local` converts DTensor to local tensor and after that the returned local
-                tensor might not be used as the original DTensor layout later, this argument
-                is the hint that user can give to autograd in case the gradient layout of
-                the returned tensor does not match the original DTensor layout.
+                `to_local` converts DTensor to local tensor and the returned local tensor
+                might not be used as the original DTensor layout later in the code. This
+                argument is the hint that user can give to autograd in case the gradient
+                layout of the returned tensor does not match the original DTensor layout.
                 If not specified, we will assume the gradient layout remains the same
                 as the original DTensor and use that for gradient computation.
 

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -326,12 +326,13 @@ class DTensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
         its current rank.
 
         Keyword args:
-            grad_placements (List[:class:`Placement`], optional): the placements that
-                describes the gradient layout of the local torch.Tensor on DeviceMesh.
-                `to_local` converts DTensor to local tensor and after that the local
-                tensor might not be used as the original DTensor layout, this argument
-                is the hint user can give to autograd in case the gradient layout of
-                the local tensor does not match the original DTensor layout.
+            grad_placements (List[:class:`Placement`], optional): the placements describes
+                the future layout of any gradient layout of the Tensor returned from this
+                function.
+                `to_local` converts DTensor to local tensor and after that the returned local
+                tensor might not be used as the original DTensor layout later, this argument
+                is the hint that user can give to autograd in case the gradient layout of
+                the returned tensor does not match the original DTensor layout.
                 If not specified, we will assume the gradient layout remains the same
                 as the original DTensor and use that for gradient computation.
 

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -21,7 +21,10 @@ from torch.distributed._tensor.random import (
     is_rng_supported_mesh,
     OffsetBasedRNGTracker,
 )
-from torch.distributed._tensor.redistribute import Redistribute
+from torch.distributed._tensor.redistribute import (
+    Redistribute,
+    redistribute_local_tensor,
+)
 from torch.distributed._tensor.sharding_prop import ShardingPropagator
 
 
@@ -54,8 +57,9 @@ __all__ = ["DTensor", "distribute_tensor", "distribute_module"]
 #
 class _ToTorchTensor(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, input: "DTensor"):  # type: ignore[override]
+    def forward(ctx, input: "DTensor", grad_placements: Optional[Sequence[Placement]]):  # type: ignore[override]
         ctx.dtensor_spec = input._spec
+        ctx.grad_placements = grad_placements
         # We need to return a fresh Tensor object there as autograd metadata
         # will be inplaced into it. So we don't want to polute the Tensor
         # object stored in _local_tensor.
@@ -64,18 +68,30 @@ class _ToTorchTensor(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_output: torch.Tensor):  # type: ignore[override]
         dtensor_spec = ctx.dtensor_spec
+        mesh = dtensor_spec.mesh
+        grad_placements = ctx.grad_placements
         dtensor_meta = dtensor_spec.tensor_meta
+
+        if grad_placements is not None:
+            grad_spec = DTensorSpec(mesh, grad_placements)
+            grad_output = redistribute_local_tensor(
+                grad_output, grad_spec, dtensor_spec
+            )
+
         _, tensor_stride = compute_global_tensor_info(
-            grad_output, dtensor_spec.mesh, dtensor_spec.placements
+            grad_output, mesh, dtensor_spec.placements
         )
-        return DTensor(
-            grad_output,
-            dtensor_spec.mesh,
-            dtensor_spec.placements,
-            shape=dtensor_meta.shape,
-            dtype=dtensor_meta.dtype,
-            requires_grad=grad_output.requires_grad,
-            stride=tuple(tensor_stride),
+        return (
+            DTensor(
+                grad_output,
+                mesh,
+                dtensor_spec.placements,
+                shape=dtensor_meta.shape,
+                dtype=dtensor_meta.dtype,
+                requires_grad=grad_output.requires_grad,
+                stride=tuple(tensor_stride),
+            ),
+            None,
         )
 
 
@@ -301,11 +317,23 @@ class DTensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
             local_tensor, device_mesh, tuple(placements), run_check
         )
 
-    def to_local(self) -> torch.Tensor:
+    def to_local(
+        self, *, grad_placements: Optional[Sequence[Placement]] = None
+    ) -> torch.Tensor:
         """
         Get the local tensor of this DTensor on its current rank. For sharding it returns
         a local shard of the logical tensor view, for replication it returns the replica on
         its current rank.
+
+        Keyword args:
+            grad_placements (List[:class:`Placement`], optional): the placements that
+                describes the gradient layout of the local torch.Tensor on DeviceMesh.
+                `to_local` converts DTensor to local tensor and after that the local
+                tensor might not be used as the original DTensor layout, this argument
+                is the hint user can give to autograd in case the gradient layout of
+                the local tensor does not match the original DTensor layout.
+                If not specified, we will assume the gradient layout remains the same
+                as the original DTensor and use that for gradient computation.
 
         Returns:
             A :class:`torch.Tensor` object that represents the local tensor of its current rank.
@@ -313,7 +341,9 @@ class DTensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
         .. note:: `to_local` is differentiable, the `requires_grad` of the local tensor returned
             will depend on if the `DTensor` requires_grad or not.
         """
-        return _ToTorchTensor.apply(self)  # pyre-ignore[16]: autograd func
+        return _ToTorchTensor.apply(
+            self, grad_placements
+        )  # pyre-ignore[16]: autograd func
 
     def redistribute(
         self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110629

When we convert to local tensor, dtensor can't track autograd or
gradient layout of the local tensor anymore, if user do sth not expected, there
needs to be a way for user to hint about the gradient layout of the
local tensor