### PR TITLE
Raise TypeErrors if Tensor cannot be cast to scalar

### DIFF
--- a/aten/src/ATen/native/Scalar.cpp
+++ b/aten/src/ATen/native/Scalar.cpp
@@ -16,7 +16,7 @@ namespace native {
 
 Scalar item(const Tensor& self) {
   auto numel = self.sym_numel();
-  TORCH_CHECK(numel == 1, "a Tensor with ", numel, " elements cannot be converted to Scalar");
+  TORCH_CHECK_TYPE(numel == 1, "a Tensor with ", numel, " elements cannot be converted to Scalar");
   if (self.is_sparse()) {
     if (self._nnz() == 0) return Scalar(0);
     if (self.is_coalesced()) return at::_local_scalar_dense(self._values());

--- a/aten/src/ATen/test/scalar_test.cpp
+++ b/aten/src/ATen/test/scalar_test.cpp
@@ -55,17 +55,17 @@ void test_overflow() {
   ASSERT_EQ(s1.toInt(), 100000);
 
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_THROW(s1.toHalf(), std::runtime_error);
+  ASSERT_THROW(s1.toHalf(), c10::ValueError);
 
   s1 = Scalar(NAN);
   ASSERT_TRUE(std::isnan(s1.toFloat()));
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_THROW(s1.toInt(), std::runtime_error);
+  ASSERT_THROW(s1.toInt(), c10::ValueError);
 
   s1 = Scalar(INFINITY);
   ASSERT_TRUE(std::isinf(s1.toFloat()));
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_THROW(s1.toInt(), std::runtime_error);
+  ASSERT_THROW(s1.toInt(), c10::ValueError);
 }
 
 TEST(TestScalar, TestScalar) {

--- a/c10/util/TypeCast.cpp
+++ b/c10/util/TypeCast.cpp
@@ -1,12 +1,13 @@
-#include <c10/util/TypeCast.h>
 #include <c10/util/Exception.h>
+#include <c10/util/TypeCast.h>
 
 namespace c10 {
 
 void report_overflow(const char* name) {
   std::ostringstream oss;
   oss << "value cannot be converted to type " << name << " without overflow";
-  C10_THROW_ERROR(ValueError, oss.str()); // rather than domain_error (issue 33562)
+  C10_THROW_ERROR(
+      ValueError, oss.str()); // rather than domain_error (issue 33562)
 }
 
 } // namespace c10

--- a/c10/util/TypeCast.cpp
+++ b/c10/util/TypeCast.cpp
@@ -1,11 +1,12 @@
 #include <c10/util/TypeCast.h>
+#include <c10/util/Exception.h>
 
 namespace c10 {
 
 void report_overflow(const char* name) {
   std::ostringstream oss;
   oss << "value cannot be converted to type " << name << " without overflow";
-  throw std::runtime_error(oss.str()); // rather than domain_error (issue 33562)
+  C10_THROW_ERROR(ValueError, oss.str()); // rather than domain_error (issue 33562)
 }
 
 } // namespace c10

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -330,13 +330,14 @@ class TestForeach(TestCase):
         if values is not None:
             try:
                 actual = op(inputs + [values], self.is_cuda, is_fastpath, **kwargs)
-            except RuntimeError as e:
+            except Exception as e:
                 # Match with error messages from regular non-foreach reference if no
                 # custom error message was provided.
                 if custom_values_err is None:
                     with self.assertRaisesRegex(type(e), re.escape(str(e))):
                         ref(ref_inputs, values=values)
                 else:
+                    self.assertEqual(type(e), RuntimeError)
                     self.assertEqual(re.escape(str(e)), re.escape(custom_values_err))
             else:
                 expected = ref(ref_inputs, values=values)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6672,8 +6672,8 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
     def test_interpolate_undefined_behavior_casting(self):
         x = torch.ones([1, 1, 16, 16])
-        self.assertRaises(RuntimeError, lambda: F.interpolate(x, scale_factor=-1e20, mode="bilinear"))
-        self.assertRaises(RuntimeError, lambda: F.interpolate(x, scale_factor=1e20, mode="bilinear"))
+        self.assertRaises(ValueError, lambda: F.interpolate(x, scale_factor=-1e20, mode="bilinear"))
+        self.assertRaises(ValueError, lambda: F.interpolate(x, scale_factor=1e20, mode="bilinear"))
 
     def test_interpolate_buffer_overflow(self):
         # Test buffer overflow issue due to inaccurate floating point

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1265,12 +1265,12 @@ class TestTensorCreation(TestCase):
         self.assertEqual(complex(torch.tensor(1.5j)), 1.5j)
 
         for tensor in not_ok:
-            self.assertRaises(ValueError, lambda: int(tensor))
-            self.assertRaises(ValueError, lambda: float(tensor))
-            self.assertRaises(ValueError, lambda: complex(tensor))
+            self.assertRaises(TypeError, lambda: int(tensor))
+            self.assertRaises(TypeError, lambda: float(tensor))
+            self.assertRaises(TypeError, lambda: complex(tensor))
 
-        self.assertRaises(RuntimeError, lambda: float(torch.tensor(1.5j)))
-        self.assertRaises(RuntimeError, lambda: int(torch.tensor(1.5j)))
+        self.assertRaises(ValueError, lambda: float(torch.tensor(1.5j)))
+        self.assertRaises(ValueError, lambda: int(torch.tensor(1.5j)))
 
     # TODO: update to work on CUDA, too?
     @onlyCPU

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -3454,7 +3454,7 @@ class TestRandomTensorCreation(TestCase):
                                          2**53 + 2)):
             res = torch.empty(0, dtype=dtype, device=device)
             torch.randperm(small_n, out=res)  # No exception expected
-            self.assertRaises(RuntimeError, lambda: torch.randperm(large_n, out=res, device=device))
+            self.assertRaises(ValueError, lambda: torch.randperm(large_n, out=res, device=device))
 
         # Test non-contiguous tensors
         for n in (4, 5, 6, 10, 20):

--- a/test/torch_np/numpy_tests/core/test_multiarray.py
+++ b/test/torch_np/numpy_tests/core/test_multiarray.py
@@ -2943,10 +2943,10 @@ class TestMethods(TestCase):
         ]
         for dt in dtypes:
             a = np.array([1, 2, 3], dtype=dt)
-            assert_raises(ValueError, complex, a)
+            assert_raises(TypeError, complex, a)
 
         c = np.array([(1.0, 3), (2e-3, 7)], dtype=dt)
-        assert_raises(ValueError, complex, c)
+        assert_raises(TypeError, complex, c)
 
 
 class TestCequenceMethods(TestCase):

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -320,7 +320,7 @@ static T dispatch_to(const Tensor & self) {
   pybind11::gil_scoped_release no_gil;
   OptionalDeviceGuard device_guard(device_of(self));
   if (self.sym_numel() != 1) {
-    throw ValueError("only one element tensors can be converted to Python scalars");
+    throw TypeError("only one element tensors can be converted to Python scalars");
   }
   return self.template item<T>();
 }

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -397,7 +397,7 @@ def error_inputs_item(op, device, **kwargs):
 
     for shape in cases:
         yield ErrorInput(
-            SampleInput(make_arg(shape)), error_type=RuntimeError,
+            SampleInput(make_arg(shape)), error_type=TypeError,
             error_regex="elements cannot be converted to Scalar")
 
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6157,10 +6157,12 @@ def error_inputs_masked_fill(op_info, device, **kwargs):
                      error_regex="only supports a 0-dimensional value tensor, but got tensor with 1 dimension")
     # downcasting complex value (scalar overload)
     yield ErrorInput(SampleInput(make_arg((2, 2)), args=(make_arg(()) > 0, 1j)),
+                     error_type=ValueError,
                      error_regex=r"value cannot be converted to type .* without overflow")
     # downcasting complex value (tensor overload)
     yield ErrorInput(SampleInput(torch.ones(2, dtype=torch.long, device=device),
                                  args=(make_arg(()) > 0, torch.tensor(1j, device=device))),
+                     error_type=ValueError,
                      error_regex=r"value cannot be converted to type .* without overflow")
 
     if torch.device(device).type == 'cuda':


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110642
* #110619
* #110618

From Python documentation on [built-in exceptions](https://docs.python.org/3/library/exceptions.html#TypeError):
> Passing arguments of the wrong type (e.g. passing a [list](https://docs.python.org/3/library/stdtypes.html#list) when an [int](https://docs.python.org/3/library/functions.html#int) is expected) should result in a [TypeError](https://docs.python.org/3/library/exceptions.html#TypeError), but passing arguments with the wrong value (e.g. a number outside expected boundaries) should result in a [ValueError](https://docs.python.org/3/library/exceptions.html#ValueError)


which should result in the following behavior:
```python
>>> float(torch.tensor([1, 2]))
TypeError: only one element tensors can be converted to Python scalars
>>> torch.tensor([1,2]).item()
TypeError: a Tensor with 2 elements cannot be converted to Scalar
>>> float(torch.tensor(1.5j))
ValueError: value cannot be converted to type double without overflow
```

Tested by:
 -  `test_errors_masked_fill` and `test_errors_item` in `test_ops` 
 -  `test_interpolate_undefined_behavior_casting` in `test_nn.py`
 -  `test__complex__should_not_work` in `numpy_tests/core/test_multiarray.py` 
 -  `test_simple_scalar_cast` and `test_randperm` in `test_tensor_creation_ops.py`
 - `test_pointwise_op_with_tensor_of_scalarlist_overload` in `test_foreach.py`
 -  [`aten/src/ATen/test/scalar_test.cpp`](https://github.com/pytorch/pytorch/blob/261cae793a19d91fda0d44d2c2bd8cd7e9a0b93f/aten/src/ATen/test/scalar_test.cpp#L58)

Fixes https://github.com/pytorch/pytorch/issues/110605