### PR TITLE
Re-enable test_copy_transpose_math_view, neg_view/dce fix

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4491,7 +4491,6 @@ else:
     # FIXME: move to test distributions
     @deviceCountAtLeast(2)
     @onlyCUDA
-    @skipIfTorchInductor("out_wrapper does not check devices correctly")
     def test_multinomial_gpu_device_constrain(self, devices):
         x = torch.empty(3, device=devices[0])
         y = torch.empty(3, device=devices[1])

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3144,7 +3144,6 @@ else:
             self.assertEqual(dst, src.neg().conj_physical(), exact_dtype=False)
 
     # FIXME: move to data movement test suite
-    @skipIfTorchInductor("https://github.com/pytorch/pytorch/issues/98175")
     @onlyNativeDeviceTypes
     @dtypes(torch.int64, torch.float32, torch.complex64)
     def test_copy_transpose_math_view(self, device, dtype):

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -451,7 +451,7 @@ class DebugFormatter:
 
     def _write_ir(self, filename: str, nodes: SchedulerNodeList):
         with self.fopen(filename) as fd:
-            print(f"Writing debug ir to {fd.name}")
+            log.info("Writing debug ir to  %s", fd.name)
             for node in nodes:
                 fd.write(node.debug_str())
                 fd.write("\n\n\n")

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -451,6 +451,7 @@ class DebugFormatter:
 
     def _write_ir(self, filename: str, nodes: SchedulerNodeList):
         with self.fopen(filename) as fd:
+            print(f"Writing debug ir to {fd.name}")
             for node in nodes:
                 fd.write(node.debug_str())
                 fd.write("\n\n\n")

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -32,7 +32,7 @@ from ..pattern_matcher import (
     register_graph_pattern,
     stable_topological_sort,
 )
-from ..utils import decode_device
+from ..utils import decode_device, is_view
 from ..virtualized import V
 from .group_batch_fusion import group_batch_fusion_post_grad_passes
 
@@ -764,7 +764,7 @@ def is_pointwise_use(use):
     ):
         return False
 
-    if use.target is operator.getitem or use.target.is_view:
+    if use.target is operator.getitem or is_view(use.target):
         return all(is_pointwise_use(u) for u in use.users)
 
     return torch.Tag.pointwise in use.target.tags

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3979,17 +3979,6 @@ class FallbackKernel(ExternKernelAlloc):
                 convert_shape_to_inductor(output.stride()),
             )
 
-        if isinstance(example_output, torch.Tensor):
-            return FallbackKernel(
-                tensor_to_layout(example_output),
-                kernel,
-                tensor_args,
-                non_tensor_args,
-                unflatten_args,
-                schema=schema,
-            )
-
-
         packed = FallbackKernel(
             MultiOutputLayout(device),
             kernel,
@@ -4102,6 +4091,11 @@ class MultiOutput(ExternKernel):
     def should_allocate(self):
         return False
 
+    def has_aliasing(self):
+        return any(
+            isinstance(inp, FallbackKernel) and inp.has_aliasing()
+            for inp in self.inputs
+        )
 
 def _prepare_convolution_fusion_create(
     cls,

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -11,7 +11,6 @@ from contextlib import nullcontext
 from enum import Enum
 from functools import partial
 from inspect import signature
-from torch._subclasses.fake_tensor import get_schema_info
 from typing import (
     Any,
     Callable,
@@ -45,6 +44,7 @@ from torch._prims_common import (
     make_channels_last_strides_for,
     make_contiguous_strides_for,
 )
+from torch._subclasses.fake_tensor import get_schema_info
 from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols, SymTypes
 from torch.fx.operator_schemas import get_signature_for_torch_op
 from torch.utils._sympy.functions import CleanDiv, FloorDiv, ModularIndexing

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4097,6 +4097,7 @@ class MultiOutput(ExternKernel):
             for inp in self.inputs
         )
 
+
 def _prepare_convolution_fusion_create(
     cls,
     x: "TensorBox",

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3857,7 +3857,6 @@ class FallbackKernel(ExternKernelAlloc):
         # TODO - some fallbacks are still OpOverloadPackets
         if not isinstance(self.op_overload, torch._ops.OpOverload):
             return False
-
         return torch._inductor.utils.is_view(self.op_overload)
 
     # ProxyExecutor Design Note

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -11,6 +11,7 @@ from contextlib import nullcontext
 from enum import Enum
 from functools import partial
 from inspect import signature
+from torch._subclasses.fake_tensor import get_schema_info
 from typing import (
     Any,
     Callable,
@@ -3845,6 +3846,12 @@ class FallbackKernel(ExternKernelAlloc):
                     return device
             return devices[0]
         return None
+
+    def has_side_effects(self):
+        # TODO - some fallbacks are still OpOverloadPackets
+        if isinstance(self.op_overload, torch._ops.OpOverload):
+            return get_schema_info(self.op_overload).is_mutable()
+        return False
 
     # ProxyExecutor Design Note
     # We export the ExternFallbackNodes (for custom ops) into a serialized file

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -4656,6 +4656,8 @@ sign = register_pointwise(aten.sign, override_fn_when_input_bool="identity")
 register_pointwise(aten.ceil)
 register_pointwise(aten.signbit, override_return_dtype=torch.bool)
 
+register_lowering(aten._neg_view)(neg)
+
 register_pointwise(aten.le, override_return_dtype=torch.bool)
 register_pointwise(aten.lt, override_return_dtype=torch.bool)
 register_pointwise(aten.ge, override_return_dtype=torch.bool)

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -317,6 +317,10 @@ class BaseSchedulerNode:
                                 ir.AliasedLayout,
                             ),
                         )
+                        and not (
+                            isinstance(input_node.node, ir.FallbackKernel)
+                            and input_node.node.has_aliasing()
+                        )
                         and buffer_reuse_key(input_node.node)
                         == buffer_reuse_key(self.node)
                     ):

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -318,7 +318,9 @@ class BaseSchedulerNode:
                             ),
                         )
                         and not (
-                            isinstance(input_node.node, (ir.FallbackKernel, ir.MultiOutput))
+                            isinstance(
+                                input_node.node, (ir.FallbackKernel, ir.MultiOutput)
+                            )
                             and input_node.node.has_aliasing()
                         )
                         and buffer_reuse_key(input_node.node)

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -318,7 +318,7 @@ class BaseSchedulerNode:
                             ),
                         )
                         and not (
-                            isinstance(input_node.node, ir.FallbackKernel)
+                            isinstance(input_node.node, (ir.FallbackKernel, ir.MultiOutput))
                             and input_node.node.has_aliasing()
                         )
                         and buffer_reuse_key(input_node.node)

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -256,11 +256,11 @@ def convert_shape_to_symint(
     ]
 
 
-def is_view(op: torch.ops.torch._ops.OpOverload):
+def is_view(op: torch._ops.OpOverload):
     """
     Does this op overload have aliasing
     """
-    assert isinstance(op, torch.ops.torch._ops.OpOverload)
+    assert isinstance(op, torch._ops.OpOverload)
     return any(a.alias_info is not None for a in op._schema.arguments)
 
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -256,6 +256,14 @@ def convert_shape_to_symint(
     ]
 
 
+def is_view(op: torch.ops.torch._ops.OpOverload):
+    """
+    Does this op overload have aliasing
+    """
+    assert isinstance(op, torch.ops.torch._ops.OpOverload)
+    return any(a.alias_info is not None for a in op._schema.arguments)
+
+
 def gen_gm_and_inputs(target, args, kwargs):
     g = torch.fx.Graph()
     g_args = []

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2475,7 +2475,7 @@ This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0"""
         if TEST_WITH_TORCHINDUCTOR:
             super_run = torch._dynamo.optimize("inductor")(super_run)
         elif TEST_WITH_AOT_EAGER:
-            super_run = torch._dynamo.optimize("aot_eager")(super_run)
+            super_run = torch._dynamo.optimize("aot_eager_decomp_partition")(super_run)
         elif TEST_WITH_TORCHDYNAMO:
             # TorchDynamo optimize annotation
             super_run = torch._dynamo.optimize("eager")(super_run)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #110770
* __->__ #110651



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler

- neg view can just be lowered to neg() post functionalization
- we were treating all fallback kernels as not having side effects. we shouldn't dce mutating fallback kernels - either mutations induced by the reinplacing pass or clone_ with unsupported arguments (complex)