### PR TITLE
[ROCm] Properly set atol/rtol settings for test_Conv2d_groups tests

### DIFF
--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -506,10 +506,11 @@ class TestConvolutionNN(NNTestCase):
             output2 = m2(i2)
             output2.backward(grad_output[:, 2:].contiguous())
 
-            self.assertEqual(output, torch.cat([output1, output2], 1))
+            self.assertEqual(output, torch.cat([output1, output2], 1),
+                             atol=dtype2prec_DONTUSE[dtype], rtol=0)
             self.assertEqual(i.grad.data,
                              torch.cat([i1.grad.data, i2.grad.data], 1),
-                             atol=dtype2prec_DONTUSE[dtype], rtol=0)
+                             atol=1e-1 if dtype == torch.half else dtype2prec_DONTUSE[dtype], rtol=0)
             self.assertEqual(m.weight.grad.data,
                              torch.cat([m1.weight.grad.data, m2.weight.grad.data], 0),
                              atol=1e-1 if dtype == torch.half else dtype2prec_DONTUSE[dtype], rtol=0)
@@ -545,13 +546,14 @@ class TestConvolutionNN(NNTestCase):
             output2 = m2(i2)
             output2.backward(grad_output[:, 8:].contiguous())
 
-            self.assertEqual(output, torch.cat([output1, output2], 1))
+            self.assertEqual(output, torch.cat([output1, output2], 1),
+                             atol=dtype2prec_DONTUSE[dtype], rtol=0)
             self.assertEqual(i.grad.data,
                              torch.cat([i1.grad.data, i2.grad.data], 1),
-                             atol=dtype2prec_DONTUSE[dtype], rtol=0)
+                             atol=1e-1 if dtype == torch.half else dtype2prec_DONTUSE[dtype], rtol=0)
             self.assertEqual(m.weight.grad.data,
                              torch.cat([m1.weight.grad.data, m2.weight.grad.data], 0),
-                             atol=1e-1 if dtype == torch.half else dtype2prec_DONTUSE[dtype], rtol=0)
+                             atol=2e-1 if dtype in [torch.half, torch.bfloat16] else dtype2prec_DONTUSE[dtype], rtol=0)
 
     # CPU-only test for group conv3d fast implementation using bmm
     # See: https://github.com/pytorch/pytorch/pull/36355
@@ -2076,7 +2078,8 @@ class TestConvolutionNNDeviceType(NNTestCase):
         output2 = m2(i2)
         output2.backward(grad_output[:, 2:].contiguous())
 
-        self.assertEqual(output, torch.cat([output1, output2], 1))
+        self.assertEqual(output, torch.cat([output1, output2], 1),
+                         atol=dtype2prec_DONTUSE[dtype], rtol=0)
         self.assertEqual(i.grad.data,
                          torch.cat([i1.grad.data, i2.grad.data], 1),
                          atol=dtype2prec_DONTUSE[dtype], rtol=0)
@@ -2085,7 +2088,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
                          atol=dtype2prec_DONTUSE[dtype], rtol=0)
         self.assertEqual(m.weight.grad.data,
                          torch.cat([m1.weight.grad.data, m2.weight.grad.data], 0),
-                         atol=dtype2prec_DONTUSE[dtype], rtol=0)
+                         atol=1e-1 if dtype == torch.half else dtype2prec_DONTUSE[dtype], rtol=0)
 
     @dtypes(torch.double, torch.cdouble)
     def test_Conv2d_backward_depthwise(self, device, dtype):


### PR DESCRIPTION
This test was using default 1e-5 atol even for torch.half and torch.bfloat16 data types, which is impractical for half/bfloat16 hardware like MI200 and Navi 2x/3x.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang