### PR TITLE
Remove outdated declarations from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -926,16 +926,10 @@ def configure_extension_build():
             "-Wno-unused-parameter",
             "-Wno-missing-field-initializers",
             "-Wno-unknown-pragmas",
-            # This is required for Python 2 declarations that are deprecated in 3.
-            "-Wno-deprecated-declarations",
             # Python 2.6 requires -fno-strict-aliasing, see
             # http://legacy.python.org/dev/peps/pep-3123/
             # We also depend on it in our code (even Python 3).
             "-fno-strict-aliasing",
-            # Clang has an unfixed bug leading to spurious missing
-            # braces warnings, see
-            # https://bugs.llvm.org/show_bug.cgi?id=21629
-            "-Wno-missing-braces",
         ]
 
     library_dirs.append(lib_path)


### PR DESCRIPTION
`-Wno-deprecated-declarations` should not be needed after Python 2 not supported.

Clang issue for `-Wno-missing-braces` was fixed in 2018.

