### PR TITLE
fix(dynamo): Incorrect `accumulate` implementation, bad tests

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -7313,6 +7313,7 @@ def ___make_guard_fn():
 
     def test_itertools_accumulate_tensors_user_defined(self):
         from torch._dynamo.utils import counters
+
         def udo_fn_0(a, b):
             return -1
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -7273,7 +7273,7 @@ def ___make_guard_fn():
             l = [a, b, c, d, x]
             for i, t in enumerate(l):
                 l[i] = t * x
-            return list(itertools.accumulate(l))
+            return itertools.accumulate(l)
 
         t_list = [torch.tensor([i + 1]) for i in range(4)]
         x = torch.tensor([[1, 2], [3, 4]])
@@ -7297,7 +7297,7 @@ def ___make_guard_fn():
                 l = [a, b, c, d, x]
                 for i, t in enumerate(l):
                     l[i] = t * x
-                return list(itertools.accumulate(l, builtin_op))
+                return itertools.accumulate(l, builtin_op)
 
             t_list = [torch.tensor([i + 1]) for i in range(4)]
             x = torch.tensor([[1, 2], [3, 4]])
@@ -7337,7 +7337,7 @@ def ___make_guard_fn():
                 l = [a, b, c, d, x]
                 for i, t in enumerate(l):
                     l[i] = t * x
-                return list(itertools.accumulate(l, udo_fn))
+                return itertools.accumulate(l, udo_fn)
 
             t_list = [torch.tensor([i]) for i in range(4)]
             x = torch.tensor([[1, 2], [3, 4]])

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -15,12 +15,12 @@ from ..source import AttrSource, ODictGetItemSource
 from ..utils import check_constant_args, identity, proxy_args_kwargs
 from .base import MutableLocal, VariableTracker
 from .dicts import DefaultDictVariable
-from .lists import ListVariable
 from .functions import (
     NestedUserFunctionVariable,
     UserFunctionVariable,
     UserMethodVariable,
 )
+from .lists import ListVariable
 from .user_defined import UserDefinedObjectVariable
 
 
@@ -798,9 +798,7 @@ class SkipFilesVariable(VariableTracker):
 
                 def func(tx, item, acc):
                     return BuiltinVariable(sum).call_function(
-                        tx, 
-                        [ListVariable([item, acc])], 
-                        {}
+                        tx, [ListVariable([item, acc])], {}
                     )
 
             elif (

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -15,6 +15,7 @@ from ..source import AttrSource, ODictGetItemSource
 from ..utils import check_constant_args, identity, proxy_args_kwargs
 from .base import MutableLocal, VariableTracker
 from .dicts import DefaultDictVariable
+from .lists import ListVariable
 from .functions import (
     NestedUserFunctionVariable,
     UserFunctionVariable,
@@ -796,7 +797,11 @@ class SkipFilesVariable(VariableTracker):
                 seq = args[0].unpack_var_sequence(tx)
 
                 def func(tx, item, acc):
-                    return BuiltinVariable(sum).call_function(tx, [item, acc], {})
+                    return BuiltinVariable(sum).call_function(
+                        tx, 
+                        [ListVariable([item, acc])], 
+                        {}
+                    )
 
             elif (
                 len(args) == 2

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -790,7 +790,7 @@ class SkipFilesVariable(VariableTracker):
             return variables.ListIteratorVariable(
                 items, mutable_local=MutableLocal(), **options
             )
-        elif self.value is itertools.accumulate:
+        elif self.value is itertools.accumulate and not kwargs:
             from .builtin import BuiltinVariable
 
             if len(args) == 1 and args[0].has_unpack_var_sequence(tx):
@@ -812,7 +812,6 @@ class SkipFilesVariable(VariableTracker):
                     return args[1].call_function(tx, [item, acc], {})
 
             else:
-                print("TRYING ACCUMULATE", args[1].is_callable(tx))
                 raise unimplemented("Unsupported arguments for itertools.accumulate")
 
             items = []

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -807,10 +807,9 @@ class SkipFilesVariable(VariableTracker):
                 and hasattr(args[1], "call_function")
             ):
                 seq = args[0].unpack_var_sequence(tx)
+
                 def func(tx, item, acc):
-                    return args[1].call_function(
-                        tx, [item, acc], {}
-                    )
+                    return args[1].call_function(tx, [item, acc], {})
 
             else:
                 print("TRYING ACCUMULATE", args[1].is_callable(tx))

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -802,7 +802,6 @@ class SkipFilesVariable(VariableTracker):
             elif (
                 len(args) == 2
                 and args[0].has_unpack_var_sequence(tx)
-                and hasattr(args[1], "call_function")
             ):
                 seq = args[0].unpack_var_sequence(tx)
 

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -2,6 +2,7 @@ import collections
 import functools
 import inspect
 import itertools
+import operator
 import sys
 import types
 from typing import Dict, List
@@ -20,7 +21,6 @@ from .functions import (
     UserFunctionVariable,
     UserMethodVariable,
 )
-from .lists import ListVariable
 from .user_defined import UserDefinedObjectVariable
 
 
@@ -796,10 +796,8 @@ class SkipFilesVariable(VariableTracker):
             if len(args) == 1 and args[0].has_unpack_var_sequence(tx):
                 seq = args[0].unpack_var_sequence(tx)
 
-                def func(tx, item, acc):
-                    return BuiltinVariable(sum).call_function(
-                        tx, [ListVariable([item, acc])], {}
-                    )
+                def func(tx, acc, item):
+                    return BuiltinVariable(operator.add).call_function(tx, [acc, item], {})
 
             elif (
                 len(args) == 2
@@ -808,8 +806,8 @@ class SkipFilesVariable(VariableTracker):
             ):
                 seq = args[0].unpack_var_sequence(tx)
 
-                def func(tx, item, acc):
-                    return args[1].call_function(tx, [item, acc], {})
+                def func(tx, acc, item):
+                    return args[1].call_function(tx, [acc, item], {})
 
             else:
                 raise unimplemented("Unsupported arguments for itertools.accumulate")


### PR DESCRIPTION
Root cause of: https://github.com/pytorch/pytorch/issues/110287

Fixed many tests that didn't actually test due to unreliability of `CompileCounter.frame_count` in detecting graph breaks: https://github.com/pytorch/pytorch/issues/110730



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @ezyang 