### PR TITLE
Fix typo under torch/onnx directory

### DIFF
--- a/torch/onnx/_internal/fx/diagnostics.py
+++ b/torch/onnx/_internal/fx/diagnostics.py
@@ -253,7 +253,7 @@ class UnsupportedFxNodeDiagnostic(Diagnostic):
         super().__post_init__()
         # NOTE: This is a hack to make sure that the additional fields must be set and
         # not None. Ideally they should not be set as optional. But this is a known
-        # limiation with `dataclasses`. Resolvable in Python 3.10 with `kw_only=True`.
+        # limitation with `dataclasses`. Resolvable in Python 3.10 with `kw_only=True`.
         # https://stackoverflow.com/questions/69711886/python-dataclasses-inheritance-and-default-values
         if self.unsupported_fx_node is None:
             raise ValueError("unsupported_fx_node must be specified.")

--- a/torch/onnx/_internal/fx/fx_onnx_interpreter.py
+++ b/torch/onnx/_internal/fx/fx_onnx_interpreter.py
@@ -134,7 +134,7 @@ def _retrieve_or_adapt_input_to_graph_set(
                 sequence_mixed_elements.append(fx_name_to_onnxscript_value[tensor.name])
             elif isinstance(tensor, int):
                 # NOTE: op.Concat doesn't support scalar, so we need to wrap it with
-                # dim, and onnx-script will promote it to tensot(int64)
+                # dim, and onnx-script will promote it to tensor(int64)
                 sequence_mixed_elements.append([tensor])
         # Concat all the elements in the sequence.
         # shapes are mapped to tensors in ONNX graph (TorchScriptGraph),
@@ -514,7 +514,7 @@ class FxOnnxInterpreter:
         )
         # In the following loop, a TorchScript graph is created to
         # represent the input FX graph with ONNX symbols (e.g., onnx::add).
-        # To connect the values to nodes in the TorchScript graph, we maintian
+        # To connect the values to nodes in the TorchScript graph, we maintain
         # fx_name_to_onnxscript_value. Basically, we want to translate
         #   fx_tensor_x (type: torch.fx.Node) -> fx_node_1 -> fx_tensor_y (type: torch.fx.Node)
         # to

--- a/torch/onnx/_internal/fx/onnxfunction_dispatcher.py
+++ b/torch/onnx/_internal/fx/onnxfunction_dispatcher.py
@@ -380,7 +380,7 @@ class OnnxFunctionDispatcher:
         )
 
         # If the ATen/Custom operators are not registered, the group will be None.
-        # And non-registerd ATen/Custom operators will trigger error in the next step.
+        # And non-registered ATen/Custom operators will trigger error in the next step.
         function_group: Optional[List[registration.ONNXFunction]] = None
 
         function_group = self.onnx_registry.get_op_functions(

--- a/torch/onnx/_internal/fx/op_validation.py
+++ b/torch/onnx/_internal/fx/op_validation.py
@@ -121,7 +121,7 @@ def validate_op_between_ort_torch(
                     function_eager_attributes
                 )
             )
-        # NOTE: Imcompatible kwargs or missing required args
+        # NOTE: Incompatible kwargs or missing required args
         except TypeError as type_error:
             diagnostic = diagnostic_context.inflight_diagnostic()
             with diagnostic.log_section(logging.WARNING, "Op level debug is bypassed"):

--- a/torch/onnx/_internal/fx/patcher.py
+++ b/torch/onnx/_internal/fx/patcher.py
@@ -37,7 +37,7 @@ class ONNXTorchPatcher:
         This list is extended with (torch.Tensor, "__getitem__") so that
         weight[x, :, y] becomes exportable with torch.fx.symbolic_trace.
     safetensors.torch.load_file:
-        This function is patached to allow safetensors to be loaded within
+        This function is patched to allow safetensors to be loaded within
         FakeTensorMode. Remove after https://github.com/huggingface/safetensors/pull/318
 
     Search for ONNXTorchPatcher in test_fx_to_onnx_with_onnxruntime.py for

--- a/torch/onnx/_internal/onnxruntime.py
+++ b/torch/onnx/_internal/onnxruntime.py
@@ -182,7 +182,7 @@ class OrtOperatorSupport(OperatorSupport):
 
 def _move_placeholder_to_front(graph_module: torch.fx.GraphModule) -> None:
     """
-    In torch.fx.Graph, placehoder is a special assignment node. If it's not
+    In torch.fx.Graph, placeholder is a special assignment node. If it's not
     executed in the beginning, it could overwrite values computed by upstream
     nodes.
     """
@@ -597,7 +597,7 @@ class OrtBackend:
     """A backend compiles (sub-)graphs in torch.fx.GraphModule to onnxruntime.InferenceSession calls.
 
     The compiler entry point is OrtBackend.compile, which
-        1. partitions the original graph into supported sub-graphs (type: torch.fx.GrpahModule) and unsupported
+        1. partitions the original graph into supported sub-graphs (type: torch.fx.GraphModule) and unsupported
            sub-graphs.
         2. For each supported sub-graph, it replaces its _wrapped_call function with _ort_accelerated_call.
         3. Inside _ort_accelerated_call, it creates onnxruntime.InferenceSession and calls it to execute the sub-graph.
@@ -923,7 +923,7 @@ class OrtBackend:
 
             # Overriding fused_module's __call__() function with ort_acclerated_call()
             # This loop goes through all graph partitions (each of them is an ONNX-representable graph)
-            # and override their _wrappped_call function with _ort_accelerated_call.
+            # and override their _wrapped_call function with _ort_accelerated_call.
             # Inside _ort_accelerated_call, the partition's graph is exported into ONNX and executed by ORT.
             for node in partitioned_prim_graph_module.graph.nodes:
                 # TODO(wschin): use a better way to identify fused submodule

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1655,7 +1655,7 @@ def _max_pool(name, tuple_fn, ndims, return_indices):
         # To convert the indices to the same format used by Pytorch,
         # we first execute a maxpool with a kernel and stride of 1 on the same input.
         # This will result in a tensor of indices in which each index will have it's own value.
-        # Using this tensor as a reference, we extract the first index of each axis and substract
+        # Using this tensor as a reference, we extract the first index of each axis and subtract
         # it from each index of this axis in the indices to convert.
         # This step will result in a tensor were each dimension has values of indices within
         # the dimension it is in.
@@ -6047,7 +6047,7 @@ def linalg_matrix_norm(
             # ord = 2/-2 unimplemented due to lack of operators
             # used to calculate singular values
             return symbolic_helper._unimplemented("linalg.matrix_norm", "ord==2", self)
-        # Wrap the dim vector to handle neagtive dim values
+        # Wrap the dim vector to handle negative dim values
         self_dim = symbolic_helper._get_tensor_rank(self)
         if self_dim is None:
             return symbolic_helper._unimplemented(
@@ -7162,7 +7162,7 @@ def unsupported_complex_operators(g: jit_utils.GraphContext, input: _C.Value):
     # However, a few torch APIs (e.g. .tolist()) use complex operations when input is real,
     # which results in failures due to missing operators for complex numbers
 
-    # While `aten::_conj` and `aten::conj_phisical` raise exception when input is complex
+    # While `aten::_conj` and `aten::conj_physical` raise exception when input is complex
     if symbolic_helper.is_complex_value(input):
         # FIXME(justinchuby): report correct name for symbolic being executed
         return symbolic_helper._onnx_unsupported(


### PR DESCRIPTION
This PR fixes typo of comments in files under `torch/onnx` directory.
