### PR TITLE
Add support for generators on the IPU device

### DIFF
--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -8,6 +8,7 @@
 #include <ATen/core/LegacyTypeDispatch.h>
 #include <ATen/detail/CUDAHooksInterface.h>
 #include <ATen/detail/HIPHooksInterface.h>
+#include <ATen/detail/IPUHooksInterface.h>
 #include <ATen/detail/MPSHooksInterface.h>
 #include <ATen/detail/MTIAHooksInterface.h>
 #include <ATen/detail/ORTHooksInterface.h>
@@ -46,6 +47,8 @@ class TORCH_API Context {
       return at::detail::getMPSHooks().getDefaultMPSGenerator();
     } else if (device_type == at::kXPU) {
       return at::detail::getXPUHooks().getDefaultXPUGenerator(device.index());
+    } else if (device_type == at::kIPU) {
+      return at::detail::getIPUHooks().getDefaultIPUGenerator(device.index());
     } else if (device_type == at::kPrivateUse1) {
       return at::GetPrivateUse1HooksInterface()->getDefaultGenerator(
           device.index());

--- a/aten/src/ATen/detail/IPUHooksInterface.cpp
+++ b/aten/src/ATen/detail/IPUHooksInterface.cpp
@@ -1,0 +1,24 @@
+#include <ATen/detail/IPUHooksInterface.h>
+
+#include <c10/util/CallOnce.h>
+
+namespace at {
+namespace detail {
+
+const IPUHooksInterface& getIPUHooks() {
+  static std::unique_ptr<IPUHooksInterface> hooks;
+  static c10::once_flag once;
+  c10::call_once(once, [] {
+    hooks = IPUHooksRegistry()->Create("IPUHooks", IPUHooksArgs{});
+    if (!hooks) {
+      hooks = std::make_unique<IPUHooksInterface>();
+    }
+  });
+  return *hooks;
+}
+
+} // namespace detail
+
+C10_DEFINE_REGISTRY(IPUHooksRegistry, IPUHooksInterface, IPUHooksArgs)
+
+} // namespace at

--- a/aten/src/ATen/detail/IPUHooksInterface.h
+++ b/aten/src/ATen/detail/IPUHooksInterface.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <ATen/core/Generator.h>
+#include <c10/core/Allocator.h>
+#include <c10/util/Exception.h>
+#include <c10/util/Registry.h>
+
+namespace at {
+
+struct TORCH_API IPUHooksInterface {
+  virtual ~IPUHooksInterface() = default;
+
+  virtual const Generator& getDefaultIPUGenerator(
+      DeviceIndex device_index = -1) const {
+    AT_ERROR(
+        "Cannot get the default IPU generator: the IPU backend is not "
+        "available.");
+  }
+
+  virtual const Generator& newIPUGenerator(
+      DeviceIndex device_index = -1) const {
+    AT_ERROR(
+        "Cannot create a new IPU generator: the IPU backend is not available.");
+  }
+};
+
+struct TORCH_API IPUHooksArgs {};
+
+TORCH_DECLARE_REGISTRY(IPUHooksRegistry, IPUHooksInterface, IPUHooksArgs);
+#define REGISTER_IPU_HOOKS(clsname) \
+  C10_REGISTER_CLASS(IPUHooksRegistry, clsname, clsname)
+
+namespace detail {
+TORCH_API const IPUHooksInterface& getIPUHooks();
+} // namespace detail
+} // namespace at

--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -968,6 +968,7 @@ aten_cpu_non_globed_sources = [
     "aten/src/ATen/detail/PrivateUse1HooksInterface.cpp",
     "aten/src/ATen/detail/XPUHooksInterface.cpp",
     "aten/src/ATen/detail/MTIAHooksInterface.cpp",
+    "aten/src/ATen/detail/IPUHooksInterface.cpp",
     "aten/src/ATen/record_function.cpp",
     "aten/src/ATen/Dispatch.cpp",
     "aten/src/ATen/SequenceNumber.cpp",
@@ -983,6 +984,7 @@ aten_cpu_non_globed_headers = [
     "aten/src/ATen/detail/PrivateUse1HooksInterface.h",
     "aten/src/ATen/detail/XPUHooksInterface.h",
     "aten/src/ATen/detail/MTIAHooksInterface.h",
+    "aten/src/ATen/detail/IPUHooksInterface.h",
 ]
 
 aten_cpu_source_non_codegen_list = [

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -74,6 +74,8 @@ static PyObject* THPGenerator_pynew(
 #endif
   else if (device.type() == at::kXPU) {
     self->cdata = at::detail::getXPUHooks().getXPUGenerator(device.index());
+  } else if (device.type() == at::kIPU) {
+    self->cdata = at::detail::getIPUHooks().newIPUGenerator(device.index());
   } else if (device.type() == at::kPrivateUse1) {
     self->cdata = at::GetGeneratorForPrivateuse1(device.index());
   } else {


### PR DESCRIPTION
This change adds hooks similar to those used on other device types, to allow the Torch to create and use generators provided by the IPU backend.