### PR TITLE
Move Docker official builds to Cuda 12.1.1 (#110703)

### DIFF
--- a/docker.Makefile
+++ b/docker.Makefile
@@ -8,7 +8,7 @@ $(warning WARNING: No docker user found using results from whoami)
 DOCKER_ORG                = $(shell whoami)
 endif
 
-CUDA_VERSION              = 11.8.0
+CUDA_VERSION              = 12.1.1
 CUDNN_VERSION             = 8
 BASE_RUNTIME              = ubuntu:20.04
 BASE_DEVEL                = nvidia/cuda:$(CUDA_VERSION)-cudnn$(CUDNN_VERSION)-devel-ubuntu20.04


### PR DESCRIPTION
Since our pipy released CUDA version is 12.1.1, Moving the Docker builds to 12.1.1. Related to : https://github.com/pytorch/pytorch/issues/110643
Pull Request resolved: https://github.com/pytorch/pytorch/pull/110703
Approved by: https://github.com/DanilBaibak

Fixes #110643
