### PR TITLE
Fix cpuinfo related crash on ppc64

### DIFF
--- a/c10/CMakeLists.txt
+++ b/c10/CMakeLists.txt
@@ -95,7 +95,7 @@ if(C10_USE_NUMA)
   target_link_libraries(c10 PRIVATE ${Numa_LIBRARIES})
 endif()
 
-if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "s390x")
+if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "s390x" AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64le")
     target_link_libraries(c10 PRIVATE cpuinfo)
 endif()
 

--- a/c10/core/thread_pool.cpp
+++ b/c10/core/thread_pool.cpp
@@ -1,6 +1,6 @@
 #include <c10/core/thread_pool.h>
 #include <c10/util/Logging.h>
-#if !defined(__s390x__)
+#if !defined(__powerpc__) &&  !defined(__s390x__)
 #include <cpuinfo.h>
 #endif
 
@@ -8,7 +8,7 @@ namespace c10 {
 
 size_t TaskThreadPoolBase::defaultNumThreads() {
   size_t num_threads = 0;
-#if !defined(__s390x__)
+#if !defined(__powerpc__) &&  !defined(__s390x__)
   cpuinfo_initialize();
   num_threads = cpuinfo_get_processors_count();
   if (num_threads > 0) {

--- a/c10/core/thread_pool.cpp
+++ b/c10/core/thread_pool.cpp
@@ -1,6 +1,6 @@
 #include <c10/core/thread_pool.h>
 #include <c10/util/Logging.h>
-#if !defined(__powerpc__) &&  !defined(__s390x__)
+#if !defined(__powerpc__) && !defined(__s390x__)
 #include <cpuinfo.h>
 #endif
 
@@ -8,7 +8,7 @@ namespace c10 {
 
 size_t TaskThreadPoolBase::defaultNumThreads() {
   size_t num_threads = 0;
-#if !defined(__powerpc__) &&  !defined(__s390x__)
+#if !defined(__powerpc__) && !defined(__s390x__)
   cpuinfo_initialize();
   num_threads = cpuinfo_get_processors_count();
   if (num_threads > 0) {


### PR DESCRIPTION
The "import  torch" crashes with following cpuinfo error on powerpc64.
==============================================================
>>> import torch
Error in cpuinfo: processor architecture is not supported in cpuinfo
Fatal error in cpuinfo: cpuinfo_get_processors_count called before cpuinfo is initialized
Aborted (core dumped)
==================================================================
The patch fixes this by excluding powerpc from using cpuinfo as it is not supported for ppc64.