### PR TITLE
Remove runtime assertions between export and AOT compilation

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -63,6 +63,7 @@ class AOTInductorModelRunner:
             example_inputs,
             options=options,
             constraints=constraints,
+            remove_runtime_assertions=True,
         )
         return so_path, exported
 
@@ -685,10 +686,7 @@ class AOTInductorTestsTemplate:
             torch.tensor([1, 1, 1], device="cuda"),
             torch.randn((1, 32), dtype=torch.float16, device="cuda"),
         )
-        with torch._dynamo.config.patch(
-            {"add_runtime_assertions_for_inline_constraints": False}
-        ):
-            self.check_model(Repro(), example_inputs)
+        self.check_model(Repro(), example_inputs)
 
     def test_dynamic_cat(self):
         class Model(torch.nn.Module):

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -333,8 +333,6 @@ inject_BUILD_SET_unimplemented_TESTING_ONLY = False
 # lists, and incorrectly issue guards.
 inject_EVALUATE_EXPR_flip_equality_TESTING_ONLY = False
 
-add_runtime_assertions_for_inline_constraints = True
-
 _autograd_backward_strict_mode_banned_ops = [
     "stride",
     "requires_grad",

--- a/torch/_export/passes/remove_runtime_assertions.py
+++ b/torch/_export/passes/remove_runtime_assertions.py
@@ -1,6 +1,3 @@
-import operator
-from typing import Optional
-
 import torch
 from torch.fx.passes.infra.pass_base import PassBase, PassResult
 

--- a/torch/_export/passes/remove_runtime_assertions.py
+++ b/torch/_export/passes/remove_runtime_assertions.py
@@ -1,0 +1,29 @@
+import operator
+from typing import Optional
+
+import torch
+from torch.fx.passes.infra.pass_base import PassBase, PassResult
+
+
+class _RemoveRuntimeAssertionsPass(PassBase):
+    """
+    Remove runtime assertions inserted by the
+    _AddRuntimeAssertionsForInlineConstraintsPass.
+    """
+
+    def call(self, graph_module) -> PassResult:
+        modified = False
+        for module in graph_module.modules():
+            if not isinstance(module, torch.fx.GraphModule):
+                continue
+            for node in module.graph.nodes:
+                if node.target == torch.ops.aten._assert_async.msg:
+                    assert_async_node = node
+                    if len(assert_async_node.users) > 0:
+                        continue
+                    module.graph.erase_node(assert_async_node)
+                    # the upstream scalar_tensor <- {le, ge} <- sym_size
+                    # linear chain of nodes of nodes is removed by the
+                    # downstream dead code elimination
+                    modified = True
+        return PassResult(graph_module, modified)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110710

Summary: The runtime assertions inserted in the `torch._export.export` by the `_AddRuntimeAssertionsForInlineConstraintsPass` lead to errors in AOT Inductor like #109884. In `torch._export.aot_compile` export and AOT compilation are run consecutively which would lead to the above issue if any assertions are inserted.

In this PR, we're adding a new parameter / flag to `torch._export.aot_compile`, `remove_runtime_assertions`, to remove the assertions inserted during export before AOT compilation. The flag is set to `False` for BC.

Additionally, we remove the flag `add_runtime_assertions_for_inline_constraints` recently added to `torch._dynamo.config`, as it can lead to undesirable `torch._export` behavior and is 's no longer required for the AOT Inductor testing purposes.

Test Plan: CI

Reviewers:

Subscribers:

Tasks:

Tags:

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan