### PR TITLE
[CUDA Host Allocator][ROCm] fixes

### DIFF
--- a/c10/cuda/CUDAAllocatorConfig.cpp
+++ b/c10/cuda/CUDAAllocatorConfig.cpp
@@ -202,6 +202,8 @@ size_t CUDAAllocatorConfig::parseAllocatorConfig(
         "Unknown allocator backend, "
         "options are native and cudaMallocAsync");
     used_cudaMallocAsync = (config[i] == "cudaMallocAsync");
+#ifndef USE_ROCM
+    // HIP supports hipMallocAsync and does not need to check versions
     if (used_cudaMallocAsync) {
 #if CUDA_VERSION >= 11040
       int version = 0;
@@ -219,6 +221,7 @@ size_t CUDAAllocatorConfig::parseAllocatorConfig(
           CUDA_VERSION);
 #endif
     }
+#endif
     TORCH_INTERNAL_ASSERT(
         config[i] == get()->name(),
         "Allocator backend parsed at runtime != "
@@ -264,7 +267,10 @@ void CUDAAllocatorConfig::parseArgs(const char* env) {
           i < config.size() && (config[i] == "True" || config[i] == "False"),
           "Expected a single True/False argument for expandable_segments");
       m_expandable_segments = (config[i] == "True");
-    } else if (config[i] == "release_lock_on_cudamalloc") {
+    // ROCm build's hipify step will change "cuda" to "hip", but for ease of use, accept both.
+    // We must break up the string to prevent hipify here.
+    } else if (config[i].compare("release_lock_on_c" "udamalloc") == 0
+            || config[i].compare("release_lock_on_hipmalloc") == 0) {
       used_native_specific_option = true;
       consumeToken(config, ++i, ':');
       ++i;
@@ -272,7 +278,10 @@ void CUDAAllocatorConfig::parseArgs(const char* env) {
           i < config.size() && (config[i] == "True" || config[i] == "False"),
           "Expected a single True/False argument for release_lock_on_cudamalloc");
       m_release_lock_on_cudamalloc = (config[i] == "True");
-    } else if (config[i].compare("pinned_use_cuda_host_register") == 0) {
+    // ROCm build's hipify step will change "cuda" to "hip", but for ease of use, accept both.
+    // We must break up the string to prevent hipify here.
+    } else if (config[i].compare("pinned_use_c" "uda_host_register") == 0
+            || config[i].compare("pinned_use_hip_host_register") == 0) {
       i = parsePinnedUseCudaHostRegister(config, i);
       used_native_specific_option = true;
     } else if (config[i].compare("pinned_num_register_threads") == 0) {

--- a/c10/cuda/CUDAAllocatorConfig.cpp
+++ b/c10/cuda/CUDAAllocatorConfig.cpp
@@ -267,10 +267,12 @@ void CUDAAllocatorConfig::parseArgs(const char* env) {
           i < config.size() && (config[i] == "True" || config[i] == "False"),
           "Expected a single True/False argument for expandable_segments");
       m_expandable_segments = (config[i] == "True");
-    // ROCm build's hipify step will change "cuda" to "hip", but for ease of use, accept both.
-    // We must break up the string to prevent hipify here.
-    } else if (config[i].compare("release_lock_on_c" "udamalloc") == 0
-            || config[i].compare("release_lock_on_hipmalloc") == 0) {
+    } else if (
+        // ROCm build's hipify step will change "cuda" to "hip", but for ease of
+        // use, accept both. We must break up the string to prevent hipify here.
+        config[i].compare("release_lock_on_hipmalloc") == 0 ||
+        config[i].compare("release_lock_on_c"
+                          "udamalloc") == 0) {
       used_native_specific_option = true;
       consumeToken(config, ++i, ':');
       ++i;
@@ -278,10 +280,12 @@ void CUDAAllocatorConfig::parseArgs(const char* env) {
           i < config.size() && (config[i] == "True" || config[i] == "False"),
           "Expected a single True/False argument for release_lock_on_cudamalloc");
       m_release_lock_on_cudamalloc = (config[i] == "True");
-    // ROCm build's hipify step will change "cuda" to "hip", but for ease of use, accept both.
-    // We must break up the string to prevent hipify here.
-    } else if (config[i].compare("pinned_use_c" "uda_host_register") == 0
-            || config[i].compare("pinned_use_hip_host_register") == 0) {
+    } else if (
+        // ROCm build's hipify step will change "cuda" to "hip", but for ease of
+        // use, accept both. We must break up the string to prevent hipify here.
+        config[i].compare("pinned_use_hip_host_register") == 0 ||
+        config[i].compare("pinned_use_c"
+                          "uda_host_register") == 0) {
       i = parsePinnedUseCudaHostRegister(config, i);
       used_native_specific_option = true;
     } else if (config[i].compare("pinned_num_register_threads") == 0) {


### PR DESCRIPTION
Follow up to #110123, removing the CUDA_VERSION check for ROCm because HIP already has hipMallocAsync() and doesn't need the version check there.

Follow up to #108488, fixing the unit failing unit tests by accepting either a "cuda" or "hip" attribute for the caching allocator options.  This is aligned to the masquerading strategy for ROCm/HIP.


cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang