### PR TITLE
device agnostic: torch.cpu.set_device

### DIFF
--- a/docs/source/cpu.rst
+++ b/docs/source/cpu.rst
@@ -11,6 +11,7 @@ torch.cpu
     is_available
     synchronize
     stream
+    set_device
     device_count
     StreamContext
 

--- a/torch/cpu/__init__.py
+++ b/torch/cpu/__init__.py
@@ -15,6 +15,7 @@ __all__ = [
     "synchronize",
     "current_stream",
     "stream",
+    "set_device",
     "device_count",
     "Stream",
     "StreamContext",

--- a/torch/cpu/__init__.py
+++ b/torch/cpu/__init__.py
@@ -117,3 +117,11 @@ def device_count() -> int:
     N.B. This function only exists to facilitate device-agnostic code
     """
     return 1
+
+
+def set_device(device: _device_t) -> None:
+    r"""Sets the current device, in CPU we do nothing.
+
+    N.B. This function only exists to facilitate device-agnostic code
+    """
+    pass

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -93,10 +93,10 @@ def _get_device_handle(device_type: str = "cuda"):
     """
     Get the module corresponding to the device_type which is cuda or cuda-like device.
     For example, when the device_type is cuda, the module `torch.cuda` is returned.
-    Return None when device_type is cpu or there is no corresponding module,
-    otherwise return the corresponding module.
+    Return None when there is no corresponding module for device_type, otherwise
+    return the corresponding module.
     """
-    return getattr(torch, device_type, None) if device_type != "cpu" else None
+    return getattr(torch, device_type, None)
 
 
 class DeviceMesh:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #110717
* #109145
* __->__ #110716

to support device agnostic, add a dummpy placeholder in torch.cpu

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10