### PR TITLE
Only set grad_fn when mirroring if original was not leaf.

### DIFF
--- a/torch/csrc/autograd/python_torch_functions_manual.cpp
+++ b/torch/csrc/autograd/python_torch_functions_manual.cpp
@@ -399,7 +399,7 @@ static PyObject* THPVariable__mirror_autograd_meta_to(
   auto inner_autograd_meta = impl::get_autograd_meta(src_);
   if (inner_autograd_meta) {
     dst_.set_requires_grad(src_.requires_grad());
-    if (dst_.requires_grad()) {
+    if (dst_.requires_grad() && inner_autograd_meta->grad_fn_) {
       auto new_grad_fn = std::shared_ptr<torch::autograd::Error>(
           new torch::autograd::Error(
               "Cannot backprop through mirrored meta, file a bug in PyTorch"),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110724

I'm not sure how the old code worked. I am not sure this is right, but it seems more right because things remain non-leaf if they weren't leaf before.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>