### PR TITLE
Delete rogue print from `test_quantize_pt2e.py`

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -1986,7 +1986,6 @@ class TestQuantizePT2EModels(PT2EQuantizationTestCase):
             m = prepare_pt2e(m, quantizer)
             # checking that we inserted observers correctly for maxpool operator (input and
             # output share observer instance)
-            print("m:", m)
             self.assertEqual(
                 id(m.activation_post_process_3), id(m.activation_post_process_2)
             )


### PR DESCRIPTION
Introduced by https://github.com/pytorch/pytorch/pull/110308
