### PR TITLE
[user errors] compulsory case names, allow multiple

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -869,6 +869,7 @@ def check_signature_rewritable(graph):
             "like its value to be embedded as an exported constant, wrap its access "
             "in a function marked with @assume_constant_result.\n\n"
             + "\n\n".join(input_errors),
+            case_names=[],
         )
 
 
@@ -1289,7 +1290,7 @@ def export(
                     raise UserError(
                         UserErrorType.DYNAMIC_CONTROL_FLOW,
                         str(e),
-                        case_name="cond_operands",
+                        case_names=["cond_predicate", "cond_operands"],
                     )
 
         if same_signature:

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -2,25 +2,21 @@ import os
 import textwrap
 from enum import auto, Enum
 from traceback import extract_stack, format_exc, format_list, StackSummary
-from typing import cast, Optional
+from typing import cast, List, Optional
 
 import torch._guards
 
 from . import config
-from .config import is_fbcode
 
 from .utils import counters
 
-if is_fbcode():
-    from torch.fb.exportdb.logging import exportdb_error_message
-else:
-
-    def exportdb_error_message(case_name):
-        return (
-            "For more information about this error, see: "
-            + "https://pytorch.org/docs/main/generated/exportdb/index.html#"
-            + case_name.replace("_", "-")
-        )
+def exportdb_error_message(case_names):
+    case_names_str = "\n  ".join(
+        "https://pytorch.org/docs/main/generated/exportdb/index.html#"
+        + case_name.replace("_", "-")
+        for case_name in case_names
+    )
+    return f"\nFor more information about this error, see:\n  {case_names_str}"
 
 
 import logging
@@ -127,22 +123,18 @@ class UserErrorType(Enum):
 
 
 class UserError(Unsupported):
-    def __init__(self, error_type: UserErrorType, msg, case_name=None):
+    def __init__(self, error_type: UserErrorType, msg: str, case_names: List[str]):
         """
         Type of errors that would be valid in Eager, but not supported in TorchDynamo.
         The error message should tell user about next actions.
 
         error_type: Type of user error
         msg: Actionable error message
-        case_name: (Optional) Unique name (snake case) for the usage example in exportdb.
+        case_name: Unique names (snake case) for relevant examples in exportdb.
         """
-        if case_name is not None:
-            assert isinstance(case_name, str)
-            if msg.endswith("."):
-                msg += " "
-            else:
-                msg += "\n"
-            msg += exportdb_error_message(case_name)
+        if case_names:
+            assert all(isinstance(case_name, str) for case_name in case_names)
+            msg += exportdb_error_message(case_names)
         super().__init__(msg)
         self.error_type = error_type
         self.message = msg

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -10,6 +10,7 @@ from . import config
 
 from .utils import counters
 
+
 def exportdb_error_message(case_names):
     case_names_str = "\n  ".join(
         "https://pytorch.org/docs/main/generated/exportdb/index.html#"

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -383,7 +383,7 @@ def generic_jump(truth_fn: typing.Callable[[object], bool], push: bool):
                 exc.UserErrorType.DYNAMIC_CONTROL_FLOW,
                 "Dynamic control flow is not supported at the moment. Please use "
                 "functorch.experimental.control_flow.cond to explicitly capture the control flow.",
-                case_name="cond_operands",
+                case_names=["cond_predicate", "cond_operands"],
             )
 
     return inner

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1415,10 +1415,10 @@ def get_fake_value(node, tx):
                 "This can happen when we encounter unbounded dynamic value that is unknown during tracing time."
                 "You will need to explicitly give hint to the compiler. Please take a look at "
                 "constrain_as_value OR constrain_as_size APIs",
-                case_name="constrain_as_size_example",
+                case_names=["constrain_as_value_example", "constrain_as_size_example"],
             )
         elif isinstance(cause, torch.utils._sympy.value_ranges.ValueRangeError):
-            raise UserError(UserErrorType.CONSTRAINT_VIOLATION, e.args[0]) from e
+            raise UserError(UserErrorType.CONSTRAINT_VIOLATION, e.args[0], case_names=[]) from e
         raise TorchRuntimeError(str(e)).with_traceback(e.__traceback__) from None
 
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1418,7 +1418,9 @@ def get_fake_value(node, tx):
                 case_names=["constrain_as_value_example", "constrain_as_size_example"],
             )
         elif isinstance(cause, torch.utils._sympy.value_ranges.ValueRangeError):
-            raise UserError(UserErrorType.CONSTRAINT_VIOLATION, e.args[0], case_names=[]) from e
+            raise UserError(
+                UserErrorType.CONSTRAINT_VIOLATION, e.args[0], case_names=[]
+            ) from e
         raise TorchRuntimeError(str(e)).with_traceback(e.__traceback__) from None
 
 

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -652,7 +652,7 @@ class BuiltinVariable(VariableTracker):
                     UserErrorType.STANDARD_LIBRARY,
                     "Calling round() on symbolic value is not supported. "
                     "You can use floor() to implement this functionality",
-                    case_name="dynamic_shape_round",
+                    case_names=["dynamic_shape_round"],
                 )
         return super().call_function(tx, args, kwargs)
 
@@ -1273,7 +1273,7 @@ class BuiltinVariable(VariableTracker):
             UserErrorType.ANTI_PATTERN,
             f"Can't call type() on generated custom object {obj}. "
             "Please use __class__ instead",
-            case_name="type_reflection_method",
+            case_names=["type_reflection_method"],
         )
 
     def call_reversed(self, tx, obj: VariableTracker):

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -124,7 +124,7 @@ class ConstantVariable(VariableTracker):
                 UserErrorType.ANTI_PATTERN,
                 "Can't access members of type(obj) for a generated custom object. "
                 "Please use __class__ instead",
-                case_name="type_reflection_method",
+                case_names=["type_reflection_method"],
             )
         member = getattr(self.value, name)
         if callable(member):

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -802,6 +802,7 @@ class FunctorchGradHigherOrderVariable(TorchHigherOrderOperatorVariable):
                 raise UserError(
                     UserErrorType.INVALID_INPUT,
                     f"argnums is expected to be int or tuple of ints. Got {argnums}.",
+                    case_names=[],
                 )
 
             if isinstance(argnums, ConstantVariable):
@@ -809,6 +810,7 @@ class FunctorchGradHigherOrderVariable(TorchHigherOrderOperatorVariable):
                     raise UserError(
                         UserErrorType.INVALID_INPUT,
                         f"argnums is expected to be int or tuple of ints. Got {argnums}.",
+                        case_names=[],
                     )
                 return argnums.value
             else:
@@ -820,6 +822,7 @@ class FunctorchGradHigherOrderVariable(TorchHigherOrderOperatorVariable):
                     raise UserError(
                         UserErrorType.INVALID_INPUT,
                         f"argnums is expected to contain int only. Got {const_vars}.",
+                        case_names=[],
                     )
                 return tuple(var.value for var in const_vars)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110733

We want to get to a point where most `UserError`s link to `exportdb` examples. This PR makes passing case names non-optional to make this intent clearer and encourage developers who raise `UserError`s to make or point to examples that make fixing such errors more obvious for users.

In addition, sometimes there are multiple examples that are relevant to an error. Thus this PR also enables passing multiple case names.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @gmagogsfm @zhxchen17 @tugsbayasgalan