### PR TITLE
[inductor] decomposition for complex addition

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -612,13 +612,13 @@ class CommonTemplate:
         self.common(fn, (x, y))
 
     def test_add_complex(self):
-        def fn(a, b):
-            return a + b
+        def fn(a, b, alpha):
+            return torch.add(a, b, alpha=alpha)
 
         x = torch.tensor([1 + 1j, -1 + 1j, -2 + 2j, 3 - 3j, 0, 1j, 1, -1])
         y = torch.tensor([1 + 1j, -1 + 1j, -2 + 2j, 3 - 3j, 0, 1j, 1, -1])
 
-        self.common(fn, (x, y))
+        self.common(fn, (x, y, 2))
 
     def test_concat_add_inplace(self):
         def fn(x, y, z):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -638,6 +638,19 @@ class CommonTemplate:
         interger_real_input = torch.tensor([-1, 0, 1])
         self.common(fn, (complex_input, real_input, interger_real_input))
 
+    def test_add(self):
+        def fn(a, b):
+            return a + b
+
+        x = torch.tensor(
+            [1 + 1j, -1 + 1j, -2 + 2j, 3 - 3j, 0, 1j, 1, -1]
+        )
+        y = torch.tensor(
+            [1 + 1j, -1 + 1j, -2 + 2j, 3 - 3j, 0, 1j, 1, -1]
+        )
+
+        self.common(fn, (x, y))
+
     def test_sgn(self):
         def fn(a):
             return torch.sgn(a), torch.sgn(a + 1) - 1

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3056,7 +3056,7 @@ class CommonTemplate:
             fn,
             (torch.randn([1, 2, 4, 8]).to(dtype=torch.complex64),),
         )
-        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)
+        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 0)
 
         class ToComplex(nn.Module):
             def forward(self, x):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -611,6 +611,15 @@ class CommonTemplate:
 
         self.common(fn, (x, y))
 
+    def test_add_complex(self):
+        def fn(a, b):
+            return a + b
+
+        x = torch.tensor([1 + 1j, -1 + 1j, -2 + 2j, 3 - 3j, 0, 1j, 1, -1])
+        y = torch.tensor([1 + 1j, -1 + 1j, -2 + 2j, 3 - 3j, 0, 1j, 1, -1])
+
+        self.common(fn, (x, y))
+
     def test_concat_add_inplace(self):
         def fn(x, y, z):
             return torch.cat([x, y], dim=1).add_(z)
@@ -637,19 +646,6 @@ class CommonTemplate:
         real_input = torch.tensor([-1.0, 0.0, 1.0, float("nan")])
         interger_real_input = torch.tensor([-1, 0, 1])
         self.common(fn, (complex_input, real_input, interger_real_input))
-
-    def test_add(self):
-        def fn(a, b):
-            return a + b
-
-        x = torch.tensor(
-            [1 + 1j, -1 + 1j, -2 + 2j, 3 - 3j, 0, 1j, 1, -1]
-        )
-        y = torch.tensor(
-            [1 + 1j, -1 + 1j, -2 + 2j, 3 - 3j, 0, 1j, 1, -1]
-        )
-
-        self.common(fn, (x, y))
 
     def test_sgn(self):
         def fn(a):
@@ -3060,7 +3056,7 @@ class CommonTemplate:
             fn,
             (torch.randn([1, 2, 4, 8]).to(dtype=torch.complex64),),
         )
-        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 0)
+        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)
 
         class ToComplex(nn.Module):
             def forward(self, x):

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -139,6 +139,7 @@ test_failures = {
     #
     # Failed to find for loop/triton kernel:
     #
+    "test_complex_fallback_dynamic_shapes": TestFailure(("cpu", "cuda")),
     "test_adaptive_avg_pool2d2_dynamic_shapes": TestFailure(("cpu", "cuda")),
     "test_argmax_to_float_dynamic_shapes": TestFailure(("cpu", "cuda")),
     "test_avg_pool2d7_dynamic_shapes": TestFailure(("cpu", "cuda")),

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -139,7 +139,6 @@ test_failures = {
     #
     # Failed to find for loop/triton kernel:
     #
-    "test_complex_fallback_dynamic_shapes": TestFailure(("cpu", "cuda")),
     "test_adaptive_avg_pool2d2_dynamic_shapes": TestFailure(("cpu", "cuda")),
     "test_argmax_to_float_dynamic_shapes": TestFailure(("cpu", "cuda")),
     "test_avg_pool2d7_dynamic_shapes": TestFailure(("cpu", "cuda")),

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -277,7 +277,7 @@ def add(x, y, *, alpha=None):
         return NotImplemented
     z = y
     if alpha is not None:
-        z *= y
+        z = alpha * y
     complex_type = torch.promote_types(x.dtype, y.dtype)
     return (x.view(x.real.dtype) + z.view(y.real.dtype)).view(complex_type)
 

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -268,6 +268,14 @@ def angle(x):
         nan = torch.where(torch.isnan(x), float("nan"), 0.0)
         return ret + nan
 
+@register_decomposition([aten.add])
+def add(x, y):
+    if x.is_complex():
+        z1 = x.real + y.real
+        z2 = x.imag + y.imag;
+        return torch.complex(z1, z2);
+    else:
+        return NotImplemented
 
 @register_decomposition([aten.conj_physical])
 def conj_physical(self):

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -271,25 +271,27 @@ def angle(x):
 
 @register_decomposition([aten.add])
 def add(x, y, **kwargs):
-    x_is_complex = torch.is_tensor(x) and x.is_complex()
-    y_is_complex = torch.is_tensor(y) and y.is_complex()
-    if not x_is_complex and not y_is_complex:
+    x_is_complex_tensor = torch.is_tensor(x) and x.is_complex()
+    y_is_complex_tensor = torch.is_tensor(y) and y.is_complex()
+    if not x_is_complex_tensor and not y_is_complex_tensor:
         return NotImplemented
     r = y.real
-    i = y.imag
+    i = y.imag if y_is_complex_tensor else 0.0
     alpha = kwargs.get("alpha")
     if alpha is not None:
         r *= alpha
         i *= alpha
     r = x.real + r
-    i = x.imag + i
+    if x_is_complex_tensor:
+        i = x.imag + i
+    complex_type = x.dtype if x_is_complex_tensor else y.dtype
     return (
         torch.where(
             torch.arange(2, device=x.device, dtype=torch.uint8) == 0,
             r.unsqueeze(-1),
             i.unsqueeze(-1),
         )
-        .view(x.dtype)
+        .view(complex_type)
         .squeeze(-1)
     )
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -132,7 +132,6 @@ def validate_ir(node_or_nodes):
                     sympy.Symbol,
                     sympy.logic.boolalg.Boolean,
                     Expr,
-                    torch._inductor.ir.MultiOutput
                 ),
             ), f"Found {type(nodes)}, which is not a supported top level IR node. See [Note: Inductor IR]"
 
@@ -4390,17 +4389,67 @@ class FallbackKernel(ExternKernelAlloc):
         return super().apply_constraint()
 
 
-
 @dataclasses.dataclass
-class ComplexView(FallbackKernel):
+class ComplexView(ExternKernelAlloc):
     """View a complex number as two dtyped numbers or vice versa"""
 
     def should_allocate(self):
         return False
 
+    def has_aliasing(self):
+        return True
+
     def get_alias_names(self):
         # Signal to codegen that our output buffer isn't safe to reuse
         return [self.inputs[0].get_name()]
+
+    def __init__(
+        self,
+        layout,
+        kernel,
+        tensor_args,
+        nontensor_args,
+    ):
+        super().__init__(
+            layout,
+            tuple(tensor_args),
+            tuple(nontensor_args),
+        )
+        # We need output buffers for generating kernel arguments in the
+        # abi-compatible mode, where we retrieve outputs by pass each individual
+        # output through the abi-compatible interface.
+        self.outputs: Sequence[Any] = []
+        self.kernel = kernel
+
+    @classmethod
+    def create(cls, kernel, *args, **kwargs):
+        context = V.graph.fake_mode
+        with context:
+            (
+                example_output,
+                tensor_args,
+                non_tensor_args,
+                unflatten_args,
+                schema,
+            ) = cls.process_kernel(kernel, *args, **kwargs)
+
+        device = FallbackKernel.find_device(tensor_args, example_output)
+        assert device, "Not sure where to find device info"
+
+        packed = ComplexView(
+            MultiOutputLayout(device), kernel, tensor_args, non_tensor_args
+        )
+
+        layout = FixedLayout(
+            example_output.device,
+            example_output.dtype,
+            convert_shape_to_inductor(example_output.size()),
+            convert_shape_to_inductor(example_output.stride()),
+        )
+        outputs = MultiOutput(layout, packed, [])
+
+        packed.outputs = [outputs]
+        return outputs
 
 
 @dataclasses.dataclass
@@ -4450,7 +4499,7 @@ class MultiOutput(ExternKernel):
 
     def has_aliasing(self):
         return any(
-            isinstance(inp, FallbackKernel) and inp.has_aliasing()
+            isinstance(inp, (FallbackKernel, ComplexView)) and inp.has_aliasing()
             for inp in self.inputs
         )
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -132,7 +132,7 @@ def validate_ir(node_or_nodes):
                     sympy.Symbol,
                     sympy.logic.boolalg.Boolean,
                     Expr,
-                    torch._inductor.ir.ExpandView,
+                    torch._inductor.ir.MultiOutput
                 ),
             ), f"Found {type(nodes)}, which is not a supported top level IR node. See [Note: Inductor IR]"
 
@@ -4388,6 +4388,19 @@ class FallbackKernel(ExternKernelAlloc):
 
     def apply_constraint(self):
         return super().apply_constraint()
+
+
+
+@dataclasses.dataclass
+class ComplexView(FallbackKernel):
+    """View a complex number as two dtyped numbers or vice versa"""
+
+    def should_allocate(self):
+        return False
+
+    def get_alias_names(self):
+        # Signal to codegen that our output buffer isn't safe to reuse
+        return [self.inputs[0].get_name()]
 
 
 @dataclasses.dataclass

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -543,6 +543,8 @@ def to_dtype_bitcast(x: TensorBox, dtype: torch.dtype, *, copy=False):
 
 @register_lowering(aten.view.dtype, type_promotion_kind=None)
 def _view_dtype(x: TensorBox, dtype: torch.dtype):
+    if dtype.is_complex or x.get_dtype().is_complex:
+        return ir.ComplexView.create(torch.ops.aten.view.dtype, x, dtype)
     return to_dtype_bitcast(x, dtype, copy=True)
 
 
@@ -1602,17 +1604,20 @@ def _warn_complex_not_supported():
 
 # There are some types (CPU) which we accept as input but not as
 # output.
-def unsupported_input_tensor(t: torch._subclasses.FakeTensor):
+def unsupported_input_tensor(t: torch._subclasses.FakeTensor, parent):
     "Do not support reading or writing to this tensor"
     if t.is_complex():
+        # Complex views are supported with IR ComplexView
+        if parent and parent.target == torch.ops.aten.view.dtype:
+            return False
         _warn_complex_not_supported()
         return True
     return False
 
 
-def unsupported_output_tensor(t: torch._subclasses.FakeTensor):
+def unsupported_output_tensor(t: torch._subclasses.FakeTensor, parent=None):
     "Do not support writing tensor but can read from it"
-    if unsupported_input_tensor(t):
+    if unsupported_input_tensor(t, parent):
         return True
     return t.is_cpu and config.disable_cpp_codegen
 
@@ -1626,7 +1631,7 @@ def fallback_node_due_to_unsupported_type(node: torch.fx.Node, allow_cpu_inputs=
     if node.target is aten.lift_fresh_copy.default:
         return False
 
-    def check_skip_condition(node, is_output):
+    def check_skip_condition(node, parent):
         if not isinstance(node, torch.fx.Node):
             return False
 
@@ -1637,21 +1642,21 @@ def fallback_node_due_to_unsupported_type(node: torch.fx.Node, allow_cpu_inputs=
             if not isinstance(meta, torch._subclasses.FakeTensor):
                 continue
 
-            if is_output:
-                if unsupported_output_tensor(meta):
+            if parent:
+                if unsupported_output_tensor(meta, parent):
                     return True
             else:
-                if unsupported_input_tensor(meta):
+                if unsupported_input_tensor(meta, None):
                     return True
 
         return False
 
     # only skip codegen if there is a cpu output, not input
     for arg in tree_flatten((node.args, node.kwargs))[0]:
-        if check_skip_condition(arg, is_output=False):
+        if check_skip_condition(arg, node):
             return True
 
-    return check_skip_condition(node, is_output=True)
+    return check_skip_condition(node, None)
 
 
 def make_fallback(op, layout_constraint=None, warn=True):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -544,7 +544,9 @@ def to_dtype_bitcast(x: TensorBox, dtype: torch.dtype, *, copy=False):
 @register_lowering(aten.view.dtype, type_promotion_kind=None)
 def _view_dtype(x: TensorBox, dtype: torch.dtype):
     if dtype.is_complex or x.get_dtype().is_complex:
-        return ir.ComplexView.create(torch.ops.aten.view.dtype, x, dtype)
+        return TensorBox.create(
+            ir.ComplexView.create(torch.ops.aten.view.dtype, x, dtype)
+        )
     return to_dtype_bitcast(x, dtype, copy=True)
 
 
@@ -1604,7 +1606,7 @@ def _warn_complex_not_supported():
 
 # There are some types (CPU) which we accept as input but not as
 # output.
-def unsupported_input_tensor(t: torch._subclasses.FakeTensor, parent):
+def unsupported_input_tensor(t: torch._subclasses.FakeTensor, parent=None):
     "Do not support reading or writing to this tensor"
     if t.is_complex():
         # Complex views are supported with IR ComplexView
@@ -1631,7 +1633,7 @@ def fallback_node_due_to_unsupported_type(node: torch.fx.Node, allow_cpu_inputs=
     if node.target is aten.lift_fresh_copy.default:
         return False
 
-    def check_skip_condition(node, parent):
+    def check_skip_condition(node, parent, is_output):
         if not isinstance(node, torch.fx.Node):
             return False
 
@@ -1642,21 +1644,21 @@ def fallback_node_due_to_unsupported_type(node: torch.fx.Node, allow_cpu_inputs=
             if not isinstance(meta, torch._subclasses.FakeTensor):
                 continue
 
-            if parent:
+            if is_output:
                 if unsupported_output_tensor(meta, parent):
                     return True
             else:
-                if unsupported_input_tensor(meta, None):
+                if unsupported_input_tensor(meta, parent):
                     return True
 
         return False
 
     # only skip codegen if there is a cpu output, not input
     for arg in tree_flatten((node.args, node.kwargs))[0]:
-        if check_skip_condition(arg, node):
+        if check_skip_condition(arg, node, is_output=False):
             return True
 
-    return check_skip_condition(node, None)
+    return check_skip_condition(node, node, is_output=True)
 
 
 def make_fallback(op, layout_constraint=None, warn=True):


### PR DESCRIPTION
Tracks https://github.com/pytorch/pytorch/issues/98161 

Complex number support in Pytorch isn't ideal today as complex operations will mostly end up taken care of by the aten runtime, except for `torch.angle` which is handled in [105609](https://github.com/pytorch/pytorch/pull/105609). In general a better way to handle that could be to decompose complex operations first so that more opportunities for fusion could be unveiled, and then to have Triton take care of non-continuous (strided) tensor operations more efficiently. This change adds support to decompose complex addtions.



```
@triton.jit
def triton_(in_ptr0, in_ptr1, out_ptr0, xnumel, XBLOCK : tl.constexpr):
    xnumel = 6
    xoffset = tl.program_id(0) * XBLOCK
    xindex = xoffset + tl.arange(0, XBLOCK)[:]
    xmask = xindex < xnumel
    x0 = xindex
    tmp0 = tl.load(in_ptr0 + (x0), xmask)
    tmp1 = tl.load(in_ptr1 + (x0), xmask)
    tmp2 = tmp0 + tmp1
    tl.store(out_ptr0 + (x0), tmp2, xmask)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler