### PR TITLE
[TP][Inference] Enable DTensor TP inference

### DIFF
--- a/test/distributed/tensor/parallel/test_tp_examples.py
+++ b/test/distributed/tensor/parallel/test_tp_examples.py
@@ -47,7 +47,7 @@ class DistTensorParallelExampleTest(DTensorTestBase):
                 ).to_local()
             self.assertEqual(param_m2, param_m1)
 
-    def _test_mlp_magatron_e2e(self, is_seq_parallel=False, recompute_activation=False):
+    def _test_mlp_training_e2e(self, is_seq_parallel=False, recompute_activation=False):
         inp_size = [8, 10]
         # Ensure all tp ranks have same input.
         rng_seed = self.rank if is_seq_parallel else 0
@@ -108,7 +108,7 @@ class DistTensorParallelExampleTest(DTensorTestBase):
         output_tp = model_tp(inp)
         self.assertEqual(output, output_tp)
 
-    def _test_mlp_magatron_inference(self):
+    def _test_mlp_inference(self):
         inp_size = [8, 10]
         # Ensure all tp ranks have same input.
         torch.manual_seed(0)
@@ -133,13 +133,13 @@ class DistTensorParallelExampleTest(DTensorTestBase):
     @with_comms
     @parametrize("is_seq_parallel", [True, False])
     @parametrize("recompute_activation", [True, False])
-    def test_mlp_megatron_e2e(self, is_seq_parallel, recompute_activation):
-        self._test_mlp_magatron_e2e(is_seq_parallel=is_seq_parallel, recompute_activation=recompute_activation)
+    def test_mlp_training(self, is_seq_parallel, recompute_activation):
+        self._test_mlp_training_e2e(is_seq_parallel=is_seq_parallel, recompute_activation=recompute_activation)
 
     @with_comms
-    def test_mlp_megatron_inference(self):
+    def test_mlp_inference(self):
         with torch.inference_mode():
-            self._test_mlp_magatron_inference()
+            self._test_mlp_inference()
 
 instantiate_parametrized_tests(DistTensorParallelExampleTest)
 

--- a/test/distributed/tensor/parallel/test_tp_examples.py
+++ b/test/distributed/tensor/parallel/test_tp_examples.py
@@ -1,6 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 # Owner(s): ["oncall: distributed"]
-import contextlib
 
 import torch
 import torch.distributed as dist

--- a/test/distributed/tensor/parallel/test_tp_examples.py
+++ b/test/distributed/tensor/parallel/test_tp_examples.py
@@ -25,6 +25,7 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
     NUM_DEVICES,
     with_comms,
 )
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 
 
 class DistTensorParallelExampleTest(DTensorTestBase):
@@ -136,6 +137,7 @@ class DistTensorParallelExampleTest(DTensorTestBase):
         self._test_mlp_training_e2e(is_seq_parallel=is_seq_parallel, recompute_activation=recompute_activation)
 
     @with_comms
+    @skip_if_lt_x_gpu(4)
     def test_mlp_inference(self):
         with torch.inference_mode():
             self._test_mlp_inference()

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -253,6 +253,10 @@ class DTensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
     # pyre-fixme[3]: Return type must be annotated.
     # pyre-fixme[2]: Parameter must be annotated.
     def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+        # Decomposes CompositeImplicitAutograd ops
+        r = func.decompose(*args, **kwargs)
+        if r is not NotImplemented:
+            return r
         return op_dispatch.operator_dispatch(
             func,
             args,

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -257,6 +257,8 @@ class DTensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
         # This is mostly for inference mode when we want to
         # decompose CompositeImplicitAutograd ops.
         # For the long run, we need to think of a better way to handle it.
+        # TODO: We can benchmark this decompose further to see if we can
+        # completely remove the check and apply it for all DTensor Ops.
         if func == aten.linear.default:
             r = func.decompose(*args, **kwargs)
             if r is not NotImplemented:

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -32,6 +32,7 @@ __all__ = ["DTensor", "distribute_tensor", "distribute_module"]
 
 aten = torch.ops.aten
 
+
 # NOTE [Autograd interaction between torch.Tensor]
 #
 # The autograd functions defined below are being used by the public

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -30,6 +30,7 @@ from torch.distributed._tensor.sharding_prop import ShardingPropagator
 
 __all__ = ["DTensor", "distribute_tensor", "distribute_module"]
 
+aten = torch.ops.aten
 
 # NOTE [Autograd interaction between torch.Tensor]
 #
@@ -253,10 +254,14 @@ class DTensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
     # pyre-fixme[3]: Return type must be annotated.
     # pyre-fixme[2]: Parameter must be annotated.
     def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
-        # Decomposes CompositeImplicitAutograd ops
-        r = func.decompose(*args, **kwargs)
-        if r is not NotImplemented:
-            return r
+        # This is mostly for inference mode when we want to
+        # decompose CompositeImplicitAutograd ops.
+        # For the long run, we need to think of a better way to handle it.
+        if func == aten.linear.default:
+            r = func.decompose(*args, **kwargs)
+            if r is not NotImplemented:
+                return r
+
         return op_dispatch.operator_dispatch(
             func,
             args,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110751


In https://github.com/pytorch/pytorch/pull/109977, we observed that during inference mode, aten.Linear does not get decomposed. So instead of enabling sharding propagation for linear op, we use func.decompose so that it gets decomposed to matmul and mm.
