### PR TITLE
Fix concurrency limits for Create Release

### DIFF
--- a/.github/scripts/ensure_actions_will_cancel.py
+++ b/.github/scripts/ensure_actions_will_cancel.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import argparse
 import sys
 
 from pathlib import Path
@@ -10,9 +9,11 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 WORKFLOWS = REPO_ROOT / ".github" / "workflows"
-EXPECTED_GROUP = (
+EXPECTED_GROUP_PREFIX = (
     "${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}"
-    "-${{ github.event_name == 'workflow_dispatch' }}"
+)
+EXPECTED_GROUP = (
+    EXPECTED_GROUP_PREFIX + "-${{ github.event_name == 'workflow_dispatch' }}"
 )
 
 
@@ -26,15 +27,8 @@ def should_check(filename: Path) -> bool:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="Ensure all relevant GitHub actions jobs will be cancelled based on a concurrency key"
-    )
-    args = parser.parse_args()
-
-    files = list(WORKFLOWS.glob("*.yml"))
-
     errors_found = False
-    files = [f for f in files if should_check(f)]
+    files = [f for f in WORKFLOWS.glob("*.yml") if should_check(f)]
     names = set()
     for filename in files:
         with open(filename) as f:
@@ -46,7 +40,18 @@ if __name__ == "__main__":
             errors_found = True
         names.add(name)
         actual = data.get("concurrency", {})
-        if not actual.get("group", "").startswith(EXPECTED_GROUP):
+        if filename.name == "create_release.yml":
+            if not actual.get("group", "").startswith(EXPECTED_GROUP_PREFIX):
+                print(
+                    f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
+                    file=sys.stderr,
+                )
+                print(
+                    f"concurrency group should start with {EXPECTED_GROUP_PREFIX} but found {actual.get('group', None)}",
+                    file=sys.stderr,
+                )
+                errors_found = True
+        elif not actual.get("group", "").startswith(EXPECTED_GROUP):
             print(
                 f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
                 file=sys.stderr,

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -2,10 +2,9 @@ name: Create Release
 
 on:
   push:
-    tags: ['v*']
     branches:
       - main
-      - nightly
+      - release/*
   release:
     types: [published]
   pull_request:
@@ -52,5 +51,5 @@ jobs:
           files: ${{env.PT_RELEASE_FILE}}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name }}
   cancel-in-progress: true


### PR DESCRIPTION
Also, don't run it on tags, but run on release branch and on `release` event.
Tweak linter to accept different concurrency limits for `create_release.yml`

Fixes https://github.com/pytorch/pytorch/issues/110569 as all the invocations of workflow in the past were cancelled by concurrently limit due to the tag push and release happening at roughly the same time, see https://github.com/pytorch/pytorch/actions/workflows/create_release.yml?query=event%3Arelease
