### PR TITLE
[ROCm] Unskip functorch tests that now work

### DIFF
--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -1771,7 +1771,7 @@ class TestOperators(TestCase):
         xfail('nn.functional.max_unpool2d'),  # contiguous call
         xfail('to_sparse'),  # dispatch key issue
 
-       # https://github.com/pytorch/pytorch/issues/96560
+        # https://github.com/pytorch/pytorch/issues/96560
         decorate('xlogy', decorator=skipIfRocm),
 
         # numerical inconsistencies, look like bugs

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -1768,9 +1768,6 @@ class TestOperators(TestCase):
         xfail('nn.functional.max_unpool2d'),  # contiguous call
         xfail('to_sparse'),  # dispatch key issue
 
-        # https://github.com/pytorch/pytorch/issues/96560
-        decorate('xlogy', decorator=skipIfRocm),
-
         # numerical inconsistencies, look like bugs
         skip('matrix_exp', dtypes=(torch.float32,), device_type='cuda'),  # fails on linux, passes on windows
         skip('ldexp', dtypes=(torch.float32,), device_type='cpu'),  # fails on all but mac

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -318,6 +318,8 @@ def is_inplace(op, variant):
 
 vjp_fail = {
     xfail('tensor_split'),  # data_ptr composite compliance
+    decorate('nn.functional.batch_norm', decorator=skipIfRocm),
+    decorate('nn.functional.instance_norm', decorator=skipIfRocm),
 }
 
 aliasing_ops = {
@@ -386,7 +388,6 @@ class TestOperators(TestCase):
         xfail('view_as_complex'),
         # query: last dimension must be contiguous
         # Fused attention kernels require last dim to be contiguous
-        xfail('nn.functional.scaled_dot_product_attention'),
     }))
     @opsToleranceOverride('TestOperators', 'test_grad', (
         tol1('nn.functional.binary_cross_entropy_with_logits',

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -320,6 +320,8 @@ vjp_fail = {
     xfail('tensor_split'),  # data_ptr composite compliance
     decorate('nn.functional.batch_norm', decorator=skipIfRocm),
     decorate('nn.functional.instance_norm', decorator=skipIfRocm),
+    # https://github.com/pytorch/pytorch/issues/96560
+    decorate('nn.functional.scaled_dot_product_attention', decorator=skipIfRocm),
 }
 
 aliasing_ops = {
@@ -388,6 +390,7 @@ class TestOperators(TestCase):
         xfail('view_as_complex'),
         # query: last dimension must be contiguous
         # Fused attention kernels require last dim to be contiguous
+        xfail('nn.functional.scaled_dot_product_attention'),
     }))
     @opsToleranceOverride('TestOperators', 'test_grad', (
         tol1('nn.functional.binary_cross_entropy_with_logits',
@@ -1767,6 +1770,9 @@ class TestOperators(TestCase):
         xfail('nn.functional.max_unpool2d', 'grad'),  # contiguous call
         xfail('nn.functional.max_unpool2d'),  # contiguous call
         xfail('to_sparse'),  # dispatch key issue
+
+       # https://github.com/pytorch/pytorch/issues/96560
+        decorate('xlogy', decorator=skipIfRocm),
 
         # numerical inconsistencies, look like bugs
         skip('matrix_exp', dtypes=(torch.float32,), device_type='cuda'),  # fails on linux, passes on windows

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -318,14 +318,6 @@ def is_inplace(op, variant):
 
 vjp_fail = {
     xfail('tensor_split'),  # data_ptr composite compliance
-    # https://github.com/pytorch/pytorch/issues/96560
-    decorate('nn.functional.batch_norm', decorator=skipIfRocm),
-    # https://github.com/pytorch/pytorch/issues/96560
-    decorate('nn.functional.instance_norm', decorator=skipIfRocm),
-    # https://github.com/pytorch/pytorch/issues/96560
-    decorate('nn.functional.layer_norm', decorator=skipIfRocm),
-    # https://github.com/pytorch/pytorch/issues/96560
-    decorate('nn.functional.scaled_dot_product_attention', decorator=skipIfRocm),
 }
 
 aliasing_ops = {
@@ -482,11 +474,10 @@ class TestOperators(TestCase):
         xfail('NumpyExpMarkDirtyAutogradFunction'),  # TODO: https://github.com/pytorch/pytorch/issues/91280
 
         # https://github.com/pytorch/pytorch/issues/96560
+        # ROCm: NotImplementedError
         decorate('nn.functional.batch_norm', decorator=skipIfRocm),
-        # https://github.com/pytorch/pytorch/issues/96560
+        # ROCm: NotImplementedError
         decorate('nn.functional.instance_norm', decorator=skipIfRocm),
-        # https://github.com/pytorch/pytorch/issues/96560
-        decorate('nn.functional.layer_norm', decorator=skipIfRocm),
 
         # --- Non-Contiguous Failures! ---
         # This is expected to fail as the operator
@@ -1035,11 +1026,8 @@ class TestOperators(TestCase):
         xfail("_native_batch_norm_legit"),
 
         # https://github.com/pytorch/pytorch/issues/96560
-        decorate('nn.functional.batch_norm', decorator=skipIfRocm),
-        # https://github.com/pytorch/pytorch/issues/96560
+        # ROCm: NotImplementedError
         decorate('nn.functional.instance_norm', decorator=skipIfRocm),
-        # https://github.com/pytorch/pytorch/issues/96560
-        decorate('nn.functional.layer_norm', decorator=skipIfRocm),
         # ----------------------------------------------------------------------
     }
 
@@ -1555,8 +1543,6 @@ class TestOperators(TestCase):
         xfail("native_batch_norm"),
         xfail("_native_batch_norm_legit"),
         xfail('native_dropout_backward'),
-        decorate('linalg.svd', decorator=skipIfRocm),  # https://github.com/pytorch/pytorch/issues/97256
-        decorate('svd', decorator=skipIfRocm),  # Flaky tensor-likes are not close error on ROCm, adjust tolerance?
     }))
     @ops(op_db + additional_op_db + autograd_function_db, allowed_dtypes=(torch.float,))
     @toleranceOverride({torch.float32: tol(atol=1e-04, rtol=1e-04)})
@@ -1781,12 +1767,6 @@ class TestOperators(TestCase):
         xfail('nn.functional.max_unpool2d'),  # contiguous call
         xfail('to_sparse'),  # dispatch key issue
 
-        # https://github.com/pytorch/pytorch/issues/96560
-        decorate('nn.functional.batch_norm', decorator=skipIfRocm),
-        # https://github.com/pytorch/pytorch/issues/96560
-        decorate('nn.functional.instance_norm', decorator=skipIfRocm),
-        # https://github.com/pytorch/pytorch/issues/96560
-        decorate('nn.functional.layer_norm', decorator=skipIfRocm),
         # https://github.com/pytorch/pytorch/issues/96560
         decorate('xlogy', decorator=skipIfRocm),
 

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -3598,8 +3598,6 @@ class TestVmapOperatorsOpInfo(TestCase):
 
         # https://github.com/pytorch/pytorch/issues/96560
         decorate('nn.functional.batch_norm', decorator=skipIfRocm),
-        decorate('nn.functional.instance_norm', decorator=skipIfRocm),
-        decorate('nn.functional.layer_norm', decorator=skipIfRocm),
 
         # RuntimeError: output with shape [4, 4] doesn't match the broadcast shape [1, 4, 4]
         xfail('addcdiv'),
@@ -3743,8 +3741,6 @@ class TestVmapOperatorsOpInfo(TestCase):
         skip('_softmax_backward_data'),
         # https://github.com/pytorch/pytorch/issues/96560
         decorate('nn.functional.batch_norm', decorator=skipIfRocm),
-        decorate('nn.functional.instance_norm', decorator=skipIfRocm),
-        decorate('nn.functional.layer_norm', decorator=skipIfRocm),
 
         # One or more of the overload doesn't have a Batch rule.
         xfail('bincount'),


### PR DESCRIPTION
This issue unskips some of the working tests that were skipped as a result of https://github.com/pytorch/pytorch/issues/96560


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang