### PR TITLE
[WIP] Added consistent default values for torch.dropout and related functions.

### DIFF
--- a/aten/src/ATen/functorch/PyTorchOperatorHacks.cpp
+++ b/aten/src/ATen/functorch/PyTorchOperatorHacks.cpp
@@ -253,13 +253,14 @@ ALIAS_SPECIALIZATION(_feature_dropout,       true,  false)
 ALIAS_SPECIALIZATION(_alpha_dropout,         false, true )
 ALIAS_SPECIALIZATION(_feature_alpha_dropout, true,  true )
 
-static Tensor dropout(const Tensor& input, double p, bool train) {
+static Tensor dropout(const Tensor& input, double p, c10::optional<bool> train) {
   auto result = [&]() {
     NoNamesGuard guard;
-    if (train && is_fused_kernel_acceptable(input, p)) {
-      return std::get<0>(at::native_dropout(input, p, train));
+    bool _train = train.value_or(true);
+    if (_train && is_fused_kernel_acceptable(input, p)) {
+      return std::get<0>(at::native_dropout(input, p, _train));
     }
-    return _dropout<false>(input, p, train);
+    return _dropout<false>(input, p, _train);
   }();
   namedinference::propagate_names(result, input);
   return result;

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -1080,11 +1080,11 @@ struct PackedBidirectionalLayer
 // into the given layer. returns the last layer's outputs, and a vector of final
 // hidden states produced at each level.
 
-Tensor dropout(const Tensor& input, double p) {
+Tensor _dropout(const Tensor& input, double p) {
   return at::dropout(input, p, /*train=*/true);
 }
 
-PackedSequence dropout(const PackedSequence& input, double p) {
+PackedSequence _dropout(const PackedSequence& input, double p) {
   return {at::dropout(input.data, p, /*train=*/true), input.batch_sizes};
 }
 
@@ -1106,7 +1106,7 @@ apply_layer_stack(const Layer<io_type, hidden_type, weight_type>& layer, const i
     layer_input = layer_output.outputs;
 
     if (dropout_p != 0 && train && l < num_layers - 1) {
-      layer_input = dropout(layer_input, dropout_p);
+      layer_input = _dropout(layer_input, dropout_p);
     }
   }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -296,7 +296,7 @@
 
 - func: _shape_as_tensor(Tensor self) -> Tensor
 
-- func: dropout(Tensor input, float p=0.5, bool train=True) -> Tensor
+- func: dropout(Tensor input, float p=0.5, bool? train=True) -> Tensor
   tags: nondeterministic_seeded
 
 - func: dropout_(Tensor(a!) self, float p=0.5, bool train=True) -> Tensor(a!)

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -296,28 +296,28 @@
 
 - func: _shape_as_tensor(Tensor self) -> Tensor
 
-- func: dropout(Tensor input, float p, bool train) -> Tensor
+- func: dropout(Tensor input, float p=0.5, bool train=True) -> Tensor
   tags: nondeterministic_seeded
 
-- func: dropout_(Tensor(a!) self, float p, bool train) -> Tensor(a!)
+- func: dropout_(Tensor(a!) self, float p=0.5, bool train=True) -> Tensor(a!)
   tags: nondeterministic_seeded
 
-- func: feature_dropout(Tensor input, float p, bool train) -> Tensor
+- func: feature_dropout(Tensor input, float p=0.5, bool train=True) -> Tensor
   tags: nondeterministic_seeded
 
-- func: feature_dropout_(Tensor(a!) self, float p, bool train) -> Tensor(a!)
+- func: feature_dropout_(Tensor(a!) self, float p=0.5, bool train=True) -> Tensor(a!)
   tags: nondeterministic_seeded
 
-- func: alpha_dropout(Tensor input, float p, bool train) -> Tensor
+- func: alpha_dropout(Tensor input, float p=0.5, bool train=True) -> Tensor
   tags: nondeterministic_seeded
 
-- func: alpha_dropout_(Tensor(a!) self, float p, bool train) -> Tensor(a!)
+- func: alpha_dropout_(Tensor(a!) self, float p=0.5, bool train=True) -> Tensor(a!)
   tags: nondeterministic_seeded
 
-- func: feature_alpha_dropout(Tensor input, float p, bool train) -> Tensor
+- func: feature_alpha_dropout(Tensor input, float p=0.5, bool train=True) -> Tensor
   tags: nondeterministic_seeded
 
-- func: feature_alpha_dropout_(Tensor(a!) self, float p, bool train) -> Tensor(a!)
+- func: feature_alpha_dropout_(Tensor(a!) self, float p=0.5, bool train=True) -> Tensor(a!)
   tags: nondeterministic_seeded
 
 - func: abs(Tensor self) -> Tensor

--- a/test/cpp/jit/test_alias_analysis.cpp
+++ b/test/cpp/jit/test_alias_analysis.cpp
@@ -1660,7 +1660,7 @@ TEST(IRNonDeterminismTest, DropoutSpecialCase) {
 
 TEST(NonDeterminismBackwardsCompatibility, BackwardsCompatibility) {
   static const std::vector<std::string> nondeterministic_ops = {
-      "aten::dropout(Tensor input, float p, bool train) -> Tensor",
+      "aten::dropout(Tensor input, float p=0.5, bool? train=True) -> Tensor",
       "aten::_fused_dropout(Tensor self, float p, Generator? generator) -> (Tensor, Tensor)",
       "aten::_standard_gamma(Tensor self, Generator? generator) -> Tensor",
       "aten::bernoulli(Tensor self, *, Generator? generator) -> Tensor",

--- a/test/cpp/jit/test_ir.cpp
+++ b/test/cpp/jit/test_ir.cpp
@@ -159,7 +159,7 @@ graph(%x : Tensor,
 TEST(IRTest, OperatorMap) {
   OperatorMap<int> op_map;
   const char* literal1 =
-      "aten::dropout(Tensor input, float p, bool train) -> Tensor";
+      "aten::dropout(Tensor input, float p=0.5, bool? train=True) -> Tensor";
   const char* literal2 =
       "aten::bernoulli(Tensor self, *, Generator? generator) -> Tensor";
   const char* literal3 =

--- a/test/cpp/jit/test_schema_info.cpp
+++ b/test/cpp/jit/test_schema_info.cpp
@@ -109,7 +109,7 @@ TEST(SchemaInfoIsNonDeterministicTest, Basic) {
 
 TEST(SchemaInfoIsNonDeterministicTest, Dropout) {
   SchemaInfo droupout_schema_info(
-      "aten::dropout(Tensor input, float p, bool train) -> Tensor");
+      "aten::dropout(Tensor input, float p=0.5, bool? train=True) -> Tensor");
   ASSERT_TRUE(droupout_schema_info.is_nondeterministic());
   droupout_schema_info.addArgumentValue("train", false);
   ASSERT_FALSE(droupout_schema_info.is_nondeterministic());

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -836,7 +836,7 @@ class ShapePropagator : public PropertyPropBase {
             "aten::cos(Tensor self) -> Tensor",
             "aten::cosh(Tensor self) -> Tensor",
             "aten::digamma(Tensor self) -> Tensor",
-            "aten::dropout(Tensor input, float p, bool train) -> Tensor",
+            "aten::dropout(Tensor input, float p=0.5, bool? train=True) -> Tensor",
             "aten::elu(Tensor self, Scalar alpha, Scalar scale, Scalar input_scale) -> Tensor",
             "aten::erf(Tensor self) -> Tensor",
             "aten::erfc(Tensor self) -> Tensor",

--- a/torch/csrc/jit/runtime/autodiff.cpp
+++ b/torch/csrc/jit/runtime/autodiff.cpp
@@ -60,7 +60,7 @@ bool isDifferentiable(const Node* n) {
     return true;
 
   if (n->matches(
-          "aten::dropout(Tensor input, float p, bool train) -> Tensor",
+          "aten::dropout(Tensor input, float p=0.5, bool? train=True) -> Tensor",
           attr::train)) {
     return n->get<bool>(attr::train).value();
   }

--- a/torch/csrc/jit/runtime/serialized_shape_function_registry.cpp
+++ b/torch/csrc/jit/runtime/serialized_shape_function_registry.cpp
@@ -3246,7 +3246,7 @@ const OperatorMap<std::string>& GetShapeFunctionMappings() {
  static const OperatorMap<std::string> shape_mappings {
     {"aten::contiguous(Tensor(a) self, *, MemoryFormat memory_format=contiguous_format) -> Tensor(a)", "unary"},
     {"aten::rsub.Tensor(Tensor self, Scalar other, Scalar alpha=1) -> Tensor", "unary"},
-    {"aten::dropout(Tensor input, float p, bool train) -> Tensor", "unary"},
+    {"aten::dropout(Tensor input, float p=0.5, bool? train=True) -> Tensor", "unary"},
     {"aten::adaptive_avg_pool2d(Tensor self, int[2] output_size) -> Tensor", "adaptive_avg_pool2d"},
     {"prim::NumToTensor.Scalar(Scalar a) -> Tensor", "zero_dim_tensor"},
     {"prim::NumToTensor.bool(bool a) -> Tensor", "zero_dim_tensor"},

--- a/torch/csrc/utils/schema_info.cpp
+++ b/torch/csrc/utils/schema_info.cpp
@@ -114,7 +114,7 @@ bool SchemaInfo::is_mutable(c10::string_view name) {
 
 bool SchemaInfo::is_nondeterministic() const {
   static const c10::FunctionSchema dropout_schema = torch::jit::parseSchema(
-      "aten::dropout(Tensor input, float p, bool train) -> Tensor");
+      "aten::dropout(Tensor input, float p=0.5, bool? train=True) -> Tensor");
   if (dropout_schema == schema_ && value_map_.count("train") &&
       !value_map_.at("train").toBool()) {
     return false;
@@ -234,7 +234,7 @@ void SchemaInfo::ensureConservativity(
 std::vector<c10::FunctionSchema> SchemaInfo::getNonDeterministicOps() {
   // This list of nondeterministic ops is copied from JIT ir.cpp.
   static const std::vector<std::string> nondeterministic_op_strings = {
-      "aten::dropout(Tensor input, float p, bool train) -> Tensor",
+      "aten::dropout(Tensor input, float p=0.5, bool? train=True) -> Tensor",
       "aten::_fused_dropout(Tensor self, float p, Generator? generator) -> (Tensor, Tensor)",
       "aten::_standard_gamma(Tensor self, Generator? generator) -> Tensor",
       "aten::bernoulli(Tensor self, *, Generator? generator) -> Tensor",

--- a/torch/jit/_shape_functions.py
+++ b/torch/jit/_shape_functions.py
@@ -1218,7 +1218,7 @@ add_shape_compute_mapping(
     "aten::rsub.Tensor(Tensor self, Scalar other, Scalar alpha=1) -> Tensor", unary
 )
 add_shape_compute_mapping(
-    "aten::dropout(Tensor input, float p, bool train) -> Tensor", unary
+    "aten::dropout(Tensor input, float p=0.5, bool? train=True) -> Tensor", unary
 )
 add_shape_compute_mapping(
     "aten::adaptive_avg_pool2d(Tensor self, int[2] output_size) -> Tensor",


### PR DESCRIPTION
Fixes #110356.

This PR makes the functional-style `torch.*` versions of `nn.Dropout` and related functions consistent with their `torch.nn.functional.*` siblings.

The C++ functions in `RNN.cpp` had to be renamed, as they are now ambiguous with the introduction of default values. The impact of this should be minimal, as they are only helper functions used within the file.