### PR TITLE
[RFC/WIP] [Still failing tests] Better invariant - leaf guards are always hasattr/item protected

### DIFF
--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -360,21 +360,21 @@ class OutputGraph(Checkpointable[OutputGraphState]):
     def init_ambient_guards(self):
         # Register a SHAPE_ENV guard to make sure we setup shape guards
         # that show up in ShapeEnv
-        self.guards.add(ShapeEnvSource().make_guard(GuardBuilder.SHAPE_ENV))
+        self.guards.update(ShapeEnvSource().make_guards(GuardBuilder.SHAPE_ENV))
 
-        self.guards.add(
-            GlobalStateSource().make_guard(GuardBuilder.DETERMINISTIC_ALGORITHMS)
+        self.guards.update(
+            GlobalStateSource().make_guards(GuardBuilder.DETERMINISTIC_ALGORITHMS)
         )
 
-        self.guards.add(GlobalStateSource().make_guard(GuardBuilder.GRAD_MODE))
+        self.guards.update(GlobalStateSource().make_guards(GuardBuilder.GRAD_MODE))
 
-        self.guards.add(GlobalStateSource().make_guard(GuardBuilder.DEFAULT_DEVICE))
+        self.guards.update(GlobalStateSource().make_guards(GuardBuilder.DEFAULT_DEVICE))
 
-        self.guards.add(
-            GlobalStateSource().make_guard(GuardBuilder.TORCH_FUNCTION_STATE)
+        self.guards.update(
+            GlobalStateSource().make_guards(GuardBuilder.TORCH_FUNCTION_STATE)
         )
 
-        self.guards.add(GlobalStateSource().make_guard(GuardBuilder.BACKEND_MATCH))
+        self.guards.update(GlobalStateSource().make_guards(GuardBuilder.BACKEND_MATCH))
 
     @property
     def root_tracer(self):
@@ -668,10 +668,12 @@ class OutputGraph(Checkpointable[OutputGraphState]):
                 tracer = self.root_tracer
 
             if not is_constant_source(source):
-                options["guards"].add(source.make_guard(GuardBuilder.TENSOR_MATCH))
+                options["guards"].update(source.make_guards(GuardBuilder.TENSOR_MATCH))
 
             if get_static_address_type(target) == "guarded":
-                options["guards"].add(source.make_guard(GuardBuilder.DATA_PTR_MATCH))
+                options["guards"].update(
+                    source.make_guards(GuardBuilder.DATA_PTR_MATCH)
+                )
 
             def wrap_name(module_key):
                 assert self.param_name_to_source is not None
@@ -687,7 +689,7 @@ class OutputGraph(Checkpointable[OutputGraphState]):
         elif isinstance(target, torch.nn.Module):
             assert isinstance(target, torch.nn.Module)
 
-            options["guards"].add(source.make_guard(GuardBuilder.NN_MODULE))
+            options["guards"].update(source.make_guards(GuardBuilder.NN_MODULE))
 
             def wrap_name(module_key):
                 return NNModuleVariable(type(target), module_key, **options)

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -469,7 +469,7 @@ class ConstantSource(Source):
     def name(self):
         return self.source_name
 
-    def make_guard(self, fn, is_volatile=False):
+    def make_guards(self, fn, is_volatile=False):
         raise NotImplementedError()
 
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1884,8 +1884,8 @@ class InstructionTranslatorBase(Checkpointable[InstructionTranslatorGraphState])
         )
 
     def store_global_weakref(self, name, value):
-        self.output.guards.add(
-            GlobalWeakRefSource(name).make_guard(GuardBuilder.WEAKREF_ALIVE)
+        self.output.guards.update(
+            GlobalWeakRefSource(name).make_guards(GuardBuilder.WEAKREF_ALIVE)
         )
         if name not in self.output.global_scope:
             self.output.install_global(name, weakref.ref(value))

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -194,13 +194,11 @@ class VariableTracker(metaclass=HasPostInit):
         cache[idx] = (result, value)
         return result
 
-    def add_guard(self, guard):
-        return self.clone(guards=set.union(self.guards, {guard}))
-
     def add_guards(self, guards):
         if guards is None:
             return self
-        assert isinstance(guards, set)
+        if not isinstance(guards, set):
+            guards = {guards}
         return self.clone(guards=set.union(self.guards, guards))
 
     def add_options(self, options, *more):
@@ -240,20 +238,20 @@ class VariableTracker(metaclass=HasPostInit):
 
     def can_make_guard(self):
         try:
-            self.make_guard(None)
+            self.make_guards(None)
             return True
         except NotImplementedError:
             return False
 
-    def make_guard(self, fn):
+    def make_guards(self, fn):
         if self.source:
-            return self.source.make_guard(fn)
+            return self.source.make_guards(fn)
         raise NotImplementedError()
 
     def replace_guards(self, guards, *fns):
         name = self.source.name()
         new_guards = {g for g in (guards or []) if g.name != name}
-        new_guards.update(self.source.make_guard(fn) for fn in fns)
+        new_guards.update(self.source.make_guards(fn) for fn in fns)
         return new_guards
 
     def const_getattr(self, tx, name: str) -> Any:

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -829,9 +829,11 @@ class BuiltinVariable(VariableTracker):
             guards = set()
             if obj.source and not is_constant_source(obj.source):
                 if isinstance(obj, TupleIteratorVariable):
-                    guards.add(obj.source.make_guard(GuardBuilder.TUPLE_ITERATOR_LEN))
+                    guards.update(
+                        obj.source.make_guards(GuardBuilder.TUPLE_ITERATOR_LEN)
+                    )
                 else:
-                    guards.add(obj.source.make_guard(GuardBuilder.LIST_LENGTH))
+                    guards.update(obj.source.make_guards(GuardBuilder.LIST_LENGTH))
             if cls is SetVariable:
                 return cls(
                     list(obj.unpack_var_sequence(tx)),

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -42,7 +42,7 @@ class ConstantVariable(VariableTracker):
             for i, x in enumerate(value):
                 item_source = GetItemSource(source, i) if source else None
                 guards = (
-                    {item_source.make_guard(GuardBuilder.CONSTANT_MATCH)}
+                    item_source.make_guards(GuardBuilder.CONSTANT_MATCH)
                     if item_source
                     else None
                 )

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -101,7 +101,7 @@ def validate_args_and_maybe_create_graph_inputs(
 
         if isinstance(a, ConstantVariable):
             # Ensures that we recompile when the constant value changes
-            a.add_guard(GuardBuilder.CONSTANT_MATCH)
+            a.add_guards(GuardBuilder.CONSTANT_MATCH)
 
             if manually_set_subgraph_inputs:
                 # This arg is not used in the body of the higher order op.

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -823,9 +823,7 @@ class SetVariable(VariableTracker):
                             e.vt.source, set_element.vt.source
                         )
                         if alias_guard:
-                            e.vt = e.vt.add_guards(
-                                {e.vt.source.make_guard(alias_guard)}
-                            )
+                            e.vt = e.vt.add_guards(e.vt.source.make_guards(alias_guard))
 
         return self.items
 

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -127,8 +127,8 @@ class NNModuleVariable(VariableTracker):
         options = VariableTracker.propagate(self)
         mod = tx.output.get_submodule(self.module_key)
         result = hasattr(mod, name)
-        return variables.ConstantVariable.create(result, **options).add_guard(
-            NNModuleSource(AttrSource(self.source, name)).make_guard(
+        return variables.ConstantVariable.create(result, **options).add_guards(
+            NNModuleSource(AttrSource(self.source, name)).make_guards(
                 GuardBuilder.HASATTR
             )
         )
@@ -759,8 +759,8 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
                 assert not args or kwargs
                 if tx.output.side_effects.has_pending_mutation(self):
                     unimplemented("Module.parameters() with pending mutation")
-                options["guards"].add(
-                    self.source.make_guard(GuardBuilder.NN_MODULE_PARAM_NAMES)
+                options["guards"].update(
+                    self.source.make_guards(GuardBuilder.NN_MODULE_PARAM_NAMES)
                 )
                 items = []
                 for name, value in self.value.named_parameters():

--- a/torch/_dynamo/variables/optimizer.py
+++ b/torch/_dynamo/variables/optimizer.py
@@ -124,11 +124,11 @@ class OptimizerVariable(UserDefinedObjectVariable):
         # so we manually generate them here
         guards = set()
         state_source = AttrSource(self.source, "state")
-        guards.add(state_source.make_guard(GuardBuilder.DICT_KEYS))
+        guards.update(state_source.make_guards(GuardBuilder.DICT_KEYS))
         for p, value in self.value.state.items():
             tx.store_global_weakref(global_key_name(p), p)
             p_state_source = GetItemSource(state_source, self.tensor_to_source[p])
-            guards.add(p_state_source.make_guard(GuardBuilder.DICT_KEYS))
+            guards.update(p_state_source.make_guards(GuardBuilder.DICT_KEYS))
             for k, v in value.items():
                 if (
                     isinstance(v, torch.Tensor)
@@ -137,8 +137,8 @@ class OptimizerVariable(UserDefinedObjectVariable):
                 ):
                     self.tensor_to_source[v] = GetItemSource(p_state_source, k)
                 elif v is None or isinstance(v, (bool, int, float, str)):
-                    guards.add(
-                        GetItemSource(p_state_source, k).make_guard(
+                    guards.update(
+                        GetItemSource(p_state_source, k).make_guards(
                             GuardBuilder.CONSTANT_MATCH
                         )
                     )

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -201,11 +201,11 @@ class TensorVariable(VariableTracker):
         from .builder import VariableBuilder
 
         attr_source = AttrSource(self.source, name)
-        has_attr_guard = attr_source.make_guard(GuardBuilder.HASATTR)
+        has_attr_guards = attr_source.make_guards(GuardBuilder.HASATTR)
         return (
             VariableBuilder(tx, attr_source)(real_value)
             .add_options(self)
-            .add_guard(has_attr_guard)
+            .add_guards(has_attr_guards)
         )
 
     def var_getattr(self, tx, name):
@@ -249,7 +249,7 @@ class TensorVariable(VariableTracker):
         # In some cases, a <tensor>.<attr> guard can be evaluated first, and break if
         # <tensor> is later changed to another type
         if result is not None and self.source is not None:
-            result = result.add_guard(self.make_guard(GuardBuilder.TYPE_MATCH))
+            result = result.add_guards(self.make_guards(GuardBuilder.TYPE_MATCH))
 
         # It's hard to get inplace view (metadata mutation) on graph input work properly across
         # dynamo/aot/inductor, just fall back.

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -266,7 +266,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 assert all(map(ConstantVariable.is_literal, keys))
                 return TupleVariable(
                     [ConstantVariable.create(k, **options) for k in keys], **options
-                ).add_guard(self.source.make_guard(GuardBuilder.ODICT_KEYS))
+                ).add_guards(self.source.make_guards(GuardBuilder.ODICT_KEYS))
 
             if (
                 method in (collections.OrderedDict.__contains__, dict.__contains__)
@@ -278,7 +278,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 assert not kwargs
                 return ConstantVariable.create(
                     args[0].as_python_constant() in self.value, **options
-                ).add_guard(self.source.make_guard(GuardBuilder.ODICT_KEYS))
+                ).add_guards(self.source.make_guards(GuardBuilder.ODICT_KEYS))
 
             if (
                 method is collections.OrderedDict.items
@@ -374,16 +374,16 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             options = VariableTracker.propagate(self, args, kwargs.values())
             options.setdefault("guards", set())
             if self.source:
-                options["guards"].add(
-                    AttrSource(self.source, "func").make_guard(GuardBuilder.ID_MATCH)
+                options["guards"].update(
+                    AttrSource(self.source, "func").make_guards(GuardBuilder.ID_MATCH)
                 )
-                options["guards"].add(
-                    AttrSource(self.source, "args").make_guard(
+                options["guards"].update(
+                    AttrSource(self.source, "args").make_guards(
                         GuardBuilder.CONSTANT_MATCH
                     )
                 )
-                options["guards"].add(
-                    AttrSource(self.source, "keywords").make_guard(
+                options["guards"].update(
+                    AttrSource(self.source, "keywords").make_guards(
                         GuardBuilder.CONSTANT_MATCH
                     )
                 )
@@ -406,7 +406,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 tx, partial_args, partial_kwargs
             )
         elif callable(self.value):
-            self.add_guard(self.source.make_guard(GuardBuilder.FUNCTION_MATCH))
+            self.add_guards(self.source.make_guards(GuardBuilder.FUNCTION_MATCH))
             return self.call_method(tx, "__call__", args, kwargs)
 
         return super().call_function(tx, args, kwargs)
@@ -571,8 +571,8 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 pass
         options = VariableTracker.propagate(self)
         if self.source:
-            options["guards"].add(
-                AttrSource(self.source, name).make_guard(GuardBuilder.HASATTR)
+            options["guards"].update(
+                AttrSource(self.source, name).make_guards(GuardBuilder.HASATTR)
             )
         if self._check_for_getattribute() or self._check_for_getattr():
             unimplemented("hasattr with custom __getattr__")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110772

There is a rare state we can get into - wherein we produce leaf guards for objects without properly protecting the path to them via checks.

For a pathological example found by @Fidget-Spinner  - a functools.partial created on one side of a graph break with an integer value in its keywords does not have its guards installed until an invocation on the other side of the graph break. However, due to how we handle scalars, that keyword arguments value was lifted as an input. This means that the first graph has a guard for value like:

`op.keywords['dim']`

This is sound unless the functools partial, op, does not match the same state on future invocations. The guards won't just fail, they will crash.

The correct thing to do is to add a guard before this check, so that the dim key access is protected.

now, we can do this manually, trivially, with functools.partials - but I worry about the brittleness of our infra that encountering a leaf guard (TYPE_MATCH in this case) does not automatically guarantee that you accumulate all the necessary guards in the chain to that leaf.

I think the guards C++ rewrite that @anijain2305  will jam on when he gets back will solve this, but in the interim, I jotted out this PR as a quick implementation, but there are other ways of doing this. Looking for feedback. 

cc @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng