### PR TITLE
[AOTInductor][ez] Fix FallbackKernel.codegen()

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3980,7 +3980,7 @@ class FallbackKernel(ExternKernelAlloc):
 
             exported_args = None
             args = None
-            if config.is_fbcode():
+            if config.is_fbcode() and V.graph.cpp_wrapper:
                 exported_args = self.export_extern_kernel_node()
             else:
                 args = [*self.codegen_args(), *self.codegen_kwargs()]


### PR DESCRIPTION
Summary: ProxyExecutor should only used in fbcode for cpp codegen.

Test Plan: Existing CIs

Differential Revision: D50048488




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler