### PR TITLE
Support Numpy ints in the `torch.nn.functional.interpolate` dtype check

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3785,7 +3785,7 @@ def _is_integer(x) -> bool:
     """
     if isinstance(x, (int, torch.SymInt)):
         return True
-    if np is not None and isinstance(x, np.ndarray) and np.issubdtype(x.dtype, np.integer):
+    if np is not None and isinstance(x, np.integer):
         return True
     return isinstance(x, Tensor) and not x.is_floating_point()
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3776,9 +3776,11 @@ if upsample.__doc__:
 
 def _is_integer(x) -> bool:
     r"""Type check the input number is an integer.
-    Will return True for int, SymInt and Tensors with integer elements.
+    Will return True for int, SymInt and Tensors / Numpy arrays with integer elements.
     """
     if isinstance(x, (int, torch.SymInt)):
+        return True
+    if isinstance(x, np.ndarray) and np.issubdtype(x.dtype. np.integer):
         return True
     return isinstance(x, Tensor) and not x.is_floating_point()
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3781,7 +3781,7 @@ if upsample.__doc__:
 
 def _is_integer(x) -> bool:
     r"""Type check the input number is an integer.
-    Will return True for int, SymInt and Tensors / Numpy arrays with integer elements.
+    Will return True for int, SymInt, Numpy integers and Tensors with integer elements.
     """
     if isinstance(x, (int, torch.SymInt)):
         return True

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -4,6 +4,11 @@ import math
 import warnings
 import importlib
 
+try:
+    import numpy as np
+except ModuleNotFoundError:
+    np = None
+
 import torch
 from torch import _VF
 from torch import sym_int as _sym_int
@@ -3780,7 +3785,7 @@ def _is_integer(x) -> bool:
     """
     if isinstance(x, (int, torch.SymInt)):
         return True
-    if isinstance(x, np.ndarray) and np.issubdtype(x.dtype. np.integer):
+    if np is not None and isinstance(x, np.ndarray) and np.issubdtype(x.dtype. np.integer):
         return True
     return isinstance(x, Tensor) and not x.is_floating_point()
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3785,7 +3785,7 @@ def _is_integer(x) -> bool:
     """
     if isinstance(x, (int, torch.SymInt)):
         return True
-    if np is not None and isinstance(x, np.ndarray) and np.issubdtype(x.dtype. np.integer):
+    if np is not None and isinstance(x, np.ndarray) and np.issubdtype(x.dtype, np.integer):
         return True
     return isinstance(x, Tensor) and not x.is_floating_point()
 


### PR DESCRIPTION
In https://github.com/pytorch/pytorch/pull/99243, a check was added to ensure the `size` only contained integers.

This PR updates the check to also include numpy integers based on this comment (cc @kit1980): https://github.com/pytorch/pytorch/pull/99243#issuecomment-1646736646. Similar to the other commenter, I also ran into issues where existing software broke due to this after upgrading to PT2.1:

```
                if not torch.jit.is_scripting():
                    if not all(_is_integer(x) for x in size):
>                       raise TypeError(
                            "expected size to be one of int or Tuple[int] or Tuple[int, int] or "
                            f"Tuple[int, int, int], but got size with types {[type(x) for x in size]}"
                        )
E                       TypeError: expected size to be one of int or Tuple[int] or Tuple[int, int] or Tuple[int, int, int], but got size with types [<class 'numpy.int64'>, <class 'numpy.int64'>]

/conda-env/lib/python3.8/site-packages/torch/nn/functional.py:3924: TypeError
```