### PR TITLE
Fix typo under torch/_numpy directory

### DIFF
--- a/torch/_numpy/_dtypes_impl.py
+++ b/torch/_numpy/_dtypes_impl.py
@@ -1,4 +1,4 @@
-"""Dtypes/scalar type implementtaions with torch dtypes.
+"""Dtypes/scalar type implementaions with torch dtypes.
 
 Here `dtype` is always a torch.dtype, this module knows nothing about
 scalar types, wrapper dtypes or anything like that. PyTorch only.

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -497,7 +497,7 @@ def zeros_like(
 
 
 def _xy_helper_corrcoef(x_tensor, y_tensor=None, rowvar=True):
-    """Prepate inputs for cov and corrcoef."""
+    """Prepare inputs for cov and corrcoef."""
 
     # https://github.com/numpy/numpy/blob/v1.24.0/numpy/lib/function_base.py#L2636
     if y_tensor is not None:
@@ -891,7 +891,7 @@ def put(
     if ind.numel() > v.numel():
         ratio = (ind.numel() + v.numel() - 1) // v.numel()
         v = v.unsqueeze(0).expand((ratio,) + v.shape)
-    # Trim unnecessary elements, regarldess if v was expanded or not. Note
+    # Trim unnecessary elements, regardless if v was expanded or not. Note
     # np.put() trims v to match ind by default too.
     if ind.numel() < v.numel():
         v = v.flatten()
@@ -1479,7 +1479,7 @@ def reshape(a: ArrayLike, newshape, order: NotImplementedType = "C"):
 
 
 def transpose(a: ArrayLike, axes=None):
-    # numpy allows both .tranpose(sh) and .transpose(*sh)
+    # numpy allows both .transpose(sh) and .transpose(*sh)
     # also older code uses axes being a list
     if axes in [(), None, (None,)]:
         axes = tuple(reversed(range(a.ndim)))

--- a/torch/_numpy/_ndarray.py
+++ b/torch/_numpy/_ndarray.py
@@ -469,7 +469,7 @@ class ndarray:
 
 
 def _tolist(obj):
-    """Recusrively convert tensors into lists."""
+    """Recursively convert tensors into lists."""
     a1 = []
     for elem in obj:
         if isinstance(elem, (list, tuple)):
@@ -510,7 +510,7 @@ def array(obj, dtype=None, *, copy=True, order="K", subok=False, ndmin=0, like=N
     if isinstance(obj, ndarray):
         obj = obj.tensor
 
-    # is a specific dtype requrested?
+    # is a specific dtype requested?
     torch_dtype = None
     if dtype is not None:
         torch_dtype = _dtypes.dtype(dtype).torch_dtype

--- a/torch/_numpy/_normalizations.py
+++ b/torch/_numpy/_normalizations.py
@@ -139,7 +139,7 @@ normalizers = {
 
 
 def maybe_normalize(arg, parm):
-    """Normalize arg if a normalizer is registred."""
+    """Normalize arg if a normalizer is registered."""
     normalizer = normalizers.get(parm.annotation, None)
     return normalizer(arg, parm) if normalizer else arg
 

--- a/torch/_numpy/_reductions_impl.py
+++ b/torch/_numpy/_reductions_impl.py
@@ -24,7 +24,7 @@ from ._normalizations import (
 def _deco_axis_expand(func):
     """
     Generically handle axis arguments in reductions.
-    axis is *always* the 2nd arg in the funciton so no need to have a look at its signature
+    axis is *always* the 2nd arg in the function so no need to have a look at its signature
     """
 
     @functools.wraps(func)


### PR DESCRIPTION
This PR fixes typo of comments in files under torch/_numpy directory.
