### PR TITLE
Fix: empty tensor is not supported by `linalg_matrix_exp` method

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2678,8 +2678,8 @@ Tensor backward_analytic_function_of_a_matrix(
 // Mathematics 2019, 7, 1174.
 //
 Tensor linalg_matrix_exp(const Tensor& a) {
-  squareCheckInputs(a, "linalg.matrix_exp");
-  checkFloatingOrComplex(a, "matrix_exp");
+  checkIsMatrix(a, "linalg.matrix_exp");
+  checkFloatingOrComplex(a, "linalg.matrix_exp");
 
   NoTF32Guard disable_tf32;
 
@@ -2687,7 +2687,9 @@ Tensor linalg_matrix_exp(const Tensor& a) {
   const auto n = a.size(-1);
   if (n == 0) {
     return a.clone();
-  } else if (n == 1) {
+  }
+  checkIsSquareSize(a, "linalg.matrix_exp");
+   if (n == 1) {
     return a.exp();
   } else {
     return at::native::mexp(a);

--- a/aten/src/ATen/native/LinearAlgebraUtils.h
+++ b/aten/src/ATen/native/LinearAlgebraUtils.h
@@ -126,12 +126,15 @@ static inline int64_t matrixStride(const Tensor& batched_matrices) {
 static inline void checkIsMatrix(const Tensor& A, const char* const f_name, const char* const arg_name = "A") {
   TORCH_CHECK(A.dim() >= 2, f_name, ": The input tensor ", arg_name, " must have at least 2 dimensions.");
 }
-static inline void squareCheckInputs(const Tensor& self, const char* const f_name, const char* const arg_name = "A") {
-  checkIsMatrix(self, f_name, arg_name);
+static inline void checkIsSquareSize(const Tensor& self, const char* const f_name, const char* const arg_name = "A") {
   TORCH_CHECK(self.sym_size(-1) == self.sym_size(-2),
               f_name,
               ": ", arg_name, " must be batches of square matrices, "
               "but they are ", self.sym_size(-2), " by ", self.sym_size(-1), " matrices");
+}
+static inline void squareCheckInputs(const Tensor& self, const char* const f_name, const char* const arg_name = "A") {
+  checkIsMatrix(self, f_name, arg_name);
+  checkIsSquareSize(self, f_name, arg_name);
 }
 
 static inline void checkInputsSolver(const Tensor& A,

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -6326,6 +6326,13 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         with self.assertRaisesRegex(RuntimeError, "must be batches of square matrices"):
             expm(torch.randn(3, 2, 1))
 
+        # check empty tensor
+        with self.assertRaisesRegex(RuntimeError, "must have at least 2 dimensions"):
+            expm(torch.tensor([]))
+
+        x = torch.tensor([[]])
+        self.assertEqual(expm(x), x)
+
         # check 1x1 matrices
         x = torch.randn(3, 3, 1, 1)
         self.assertEqual(expm(x), x.exp())


### PR DESCRIPTION
The trivial case for `n == 0` in linalg_matrix_exp method currently will never be executed:

```ipython
In [2]: torch.matrix_exp(torch.tensor([[]]))
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Cell In [2], line 1
----> 1 torch.matrix_exp(torch.tensor([[]]))

RuntimeError: linalg.matrix_exp: A must be batches of square matrices, but they are 0 by 1 matrices
```

This PR fixed this issue:
```ipython
In [2]: torch.matrix_exp(torch.tensor([[]]))
Out[2]: tensor([], size=(1, 0))
```
