### PR TITLE
[pytorch-vulkan] aten::floor_divide

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/templates/binary_op_params.yaml
+++ b/aten/src/ATen/native/vulkan/glsl/templates/binary_op_params.yaml
@@ -7,6 +7,8 @@ binary_op_scalar:
         OPERATOR: X * Y
       - NAME: pow_tensor_scalar
         OPERATOR: pow (X, Y)
+      - NAME: floor_mul_scalar
+        OPERATOR: floor(X * Y)
 
 binary_op_scalar_inplace:
   parameter_names_with_default_values:
@@ -17,6 +19,8 @@ binary_op_scalar_inplace:
         OPERATOR: X * Y
       - NAME: pow_tensor_scalar_
         OPERATOR: pow (X, Y)
+      - NAME: floor_mul_scalar_
+        OPERATOR: floor(X * Y)
 
 binary_op_tensor:
   parameter_names_with_default_values:

--- a/aten/src/ATen/native/vulkan/ops/BinaryOp.cpp
+++ b/aten/src/ATen/native/vulkan/ops/BinaryOp.cpp
@@ -547,6 +547,26 @@ Tensor pow_scalar_tensor(const Scalar& self, const Tensor& other) {
       other, self, c10::optional<Scalar>(), VK_KERNEL(pow_scalar_tensor));
 }
 
+Tensor floor_divide_scalar(const Tensor& self, const Scalar& other) {
+  TORCH_CHECK(
+      other.to<float>() != 0.0f, "floor_divide_scalar: can't divide by zero");
+  return binary_op_scalar(
+      self,
+      1.0 / other.to<float>(),
+      c10::optional<Scalar>(),
+      VK_KERNEL(floor_mul_scalar));
+}
+
+Tensor& floor_divide_scalar_(Tensor& self, const Scalar& other) {
+  TORCH_CHECK(
+      other.to<float>() != 0.0f, "floor_divide_scalar_: can't divide by zero");
+  return binary_op_scalar_(
+      self,
+      1.0 / other.to<float>(),
+      c10::optional<Scalar>(),
+      VK_KERNEL(floor_mul_scalar_));
+}
+
 #ifdef USE_VULKAN_API
 
 TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
@@ -574,6 +594,12 @@ TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
   m.impl(
       TORCH_SELECTIVE_NAME("aten::pow_.Scalar"), TORCH_FN(pow_tensor_scalar_));
   m.impl(TORCH_SELECTIVE_NAME("aten::pow.Scalar"), TORCH_FN(pow_scalar_tensor));
+  m.impl(
+      TORCH_SELECTIVE_NAME("aten::floor_divide.Scalar"),
+      TORCH_FN(floor_divide_scalar));
+  m.impl(
+      TORCH_SELECTIVE_NAME("aten::floor_divide_.Scalar"),
+      TORCH_FN(floor_divide_scalar_));
 }
 
 #endif /* USE_VULKAN_API */


### PR DESCRIPTION
Summary:
as title. only tensor_scalar.

this diff does not include the element-wise tensor-tensor operation.

Test Plan:
```
[yipjustin@33167.od ~/fbsource (9cfca7c97)]$ LD_LIBRARY_PATH=third-party/swiftshader/lib/linux-x64/ buck2 run fbcode/mode/dev-nosan    //xplat/caffe2:pt_vulkan_api_test_bin  -- --gtest_filter="*floor_divide_scalar*"
Watchman fresh instance: new mergebase, cleared graph state, cleared dep files
Buck UI: https://www.internalfb.com/buck2/bcac40be-79af-47c5-bd3f-95c11179aa68
Network: Up: 29MiB  Down: 264MiB  (reSessionID-2fef8b89-76b0-4496-bb27-b10d42cf7ef4)
Jobs completed: 5196. Time elapsed: 45.9s.
Cache hits: 81%. Commands: 2070 (cached: 1672, remote: 375, local: 23)
BUILD SUCCEEDED
Running main() from third-party/googletest/1.11.0/googletest/googletest/src/gtest_main.cc
Note: Google Test filter = *floor_divide_scalar*
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.floor_divide_scalar
[       OK ] VulkanAPITest.floor_divide_scalar (150 ms)
[ RUN      ] VulkanAPITest.floor_divide_scalar_inplace
[       OK ] VulkanAPITest.floor_divide_scalar_inplace (39 ms)
[----------] 2 tests from VulkanAPITest (189 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (190 ms total)
[  PASSED  ] 2 tests.
```

Differential Revision: D50001740


