### PR TITLE
Fix typo under torch/_export directory

### DIFF
--- a/torch/_export/db/gen_example.py
+++ b/torch/_export/db/gen_example.py
@@ -24,5 +24,5 @@ if __name__ == "__main__":
     root_dir = examples.__name__.replace(".", "/")
     assert os.path.exists(root_dir)
     with open(os.path.join(root_dir, sys.argv[1] + ".py"), "w") as f:
-        print("Wrting to", f.name, "...")
+        print("Writing to", f.name, "...")
         f.write(TEMPLATE.format(case_name=sys.argv[1]))

--- a/torch/_export/exported_program.py
+++ b/torch/_export/exported_program.py
@@ -336,7 +336,7 @@ def _process_constraints(
     for symbol, value_range in inline_constraints.items():
         range_constraints[symbol] = RangeConstraint(value_range.lower, value_range.upper)
 
-    # Add input range constraints to range_constraintss
+    # Add input range constraints to range_constraints
     for input_dim, multi_range_constraint in multi_range_constraints.items():  # type: ignore[assignment]
         # Simplify the range constraints into a single range constraint
         # Ex. ranges [2, 10] and [3, 11] would get merged to [3, 10]

--- a/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
+++ b/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
@@ -98,7 +98,7 @@ class _AddRuntimeAssertionsForInlineConstraintsPass(_ExportPassBase):
         # We use post-order traversal to collect all the proxies callbacks needed, construct
         # the error message callbacks, and at the top-level traversal tree we execute all the callbacks.
         # We need the callbacks because, in order to call the function to create a proxy for shape[0], we
-        # need the proxy for shape, which further requries the proxy for ret[1], etc.
+        # need the proxy for shape, which further requires the proxy for ret[1], etc.
         def add_assertions(val):
             call_backs = []
             messages = []
@@ -265,7 +265,7 @@ class _AddRuntimeAssertionsForConstraintsPass(_AddRuntimeAssertionsForInlineCons
         # input dim N >=2 generalizes to N < 2. Ideally we should check that:
         # 1. if we can generalize to N < 2, not add any assertion saying N >= 2
         # 2. If we can't generalize to N < 2, add an assertion saying N >= 2
-        # Above can be achieved via a seperate pass.
+        # Above can be achieved via a separate pass.
         with graph.inserting_after(dim_node):
             if min_val > 2:
                 self._insert_assert_async_inplace(

--- a/torch/_export/serde/upgrade.py
+++ b/torch/_export/serde/upgrade.py
@@ -132,7 +132,7 @@ class GraphModuleOpUpgrader:
     def _populate_passes(upgraders: List[Tuple[str, str]]) -> List[UpgraderPass]:
         """Given a list of upgraders, loop through it from lower version to higher version and create passes for all
         upgraders. se torch.Library API to register old ops. Op name will be
-        <name>_<valid_from_ver>_<valid_till_ver>. Register upgarders as CompositeImplicitAutograd kernels. For example:
+        <name>_<valid_from_ver>_<valid_till_ver>. Register upgraders as CompositeImplicitAutograd kernels. For example:
 
         lib = Library("aten", "FRAGMENT")
         lib.define(old_schema)

--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -232,7 +232,7 @@ def verify_exported_program_signature(exported_program) -> None:
     total_gs_placeholders = len(gs.inputs_to_parameters) + len(gs.inputs_to_buffers) + len(gs.user_inputs)
     if len(placeholder_nodes) != total_gs_placeholders:
         raise SpecViolationError(
-            f"Number of placholders nodes {len(placeholder_nodes)} is different "
+            f"Number of placeholders nodes {len(placeholder_nodes)} is different "
             "Than the number of inputs specified by the graph signature: \n"
             f"Number of parameters: {len(gs.inputs_to_parameters)}. \n"
             f"Number of buffers: {len(gs.inputs_to_buffers)}. \n"
@@ -303,7 +303,7 @@ def verify_exported_program_signature(exported_program) -> None:
             gs.buffers_to_mutate[buffer_node] not in gs.buffers
         ):
             raise SpecViolationError(
-                f"Buffer output {buffer_node} is not in buffer mutation dictinoary "
+                f"Buffer output {buffer_node} is not in buffer mutation dictionary "
                 "or, it does not point to a buffer that exists. \n"
                 f"Dict of buffers that are mutated, in order: {gs.buffers_to_mutate} \n"
                 f"Buffer nodes available: {gs.buffers} \n"


### PR DESCRIPTION
This PR fixes typo of comments and message in files under `torch/_export` directory.


cc @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan