### PR TITLE
Support defaultdict with enum tuple keys

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -3462,6 +3462,29 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         x = torch.rand(4)
         self.assertTrue(same(fn(x), opt_fn(x)))
 
+    def test_no_graph_break_defaultdict_enums(self):
+        from enum import Enum
+
+        class Color(Enum):
+            RED = 1
+            GREEN = 2
+            BLUE = 3
+
+        class Shape(Enum):
+            RECTANGLE = 4
+            SQUARE = 5
+
+        d = collections.defaultdict(int)
+
+        d[(Color.RED, Shape.RECTANGLE)] = 2
+
+        def fn(x):
+            for v in d.values():
+                x = x * v
+            return x
+
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -932,6 +932,8 @@ def dict_const_keys_repr(const_keys, *, local):
         const_keys_str = f"{ {enum_repr(k, local=local) if isinstance(k, enum.Enum) else repr(k) for k in const_keys} }".replace(
             "'", ""
         )
+    elif any(istype(k, (tuple,)) for k in const_keys):
+        return str(tuple(dict_const_keys_repr(k, local=local) for k in const_keys))
     else:
         const_keys_str = f"{const_keys!r}"
     return const_keys_str

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -388,7 +388,6 @@ class VariableBuilder:
             return self.wrap_tensor(value)
         elif is_namedtuple(value):
             return self.wrap_listlike(value)
-
         elif value is torch.utils._pytree.SUPPORTED_NODES:
             result = {
                 k: UserDefinedObjectVariable(
@@ -430,6 +429,10 @@ class VariableBuilder:
             def index_source(key):
                 if self.tensor_can_be_dict_key(key):
                     return GlobalWeakRefSource(global_key_name(key))
+                elif istype(key, (tuple,)):
+                    return tuple([index_source(e) for e in key])
+                elif isinstance(key, enum.Enum):
+                    return f"{type(key).__name__}.{key.name}"
                 else:
                     return key
 

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -1,3 +1,4 @@
+import enum
 import operator
 from typing import Dict, List
 
@@ -57,6 +58,10 @@ class ConstantVariable(VariableTracker):
                 items, regen_guards=True, **kwargs
             )
 
+        # Routing for enums members
+        if is_literal and isinstance(value, enum.Enum):
+            return EnumVariable(value)
+
         return ConstantVariable(value, **kwargs)
 
     def __init__(self, value, **kwargs):
@@ -107,6 +112,9 @@ class ConstantVariable(VariableTracker):
         # The structure within is_literal get routed to variables.BaseListVariable
         if type(obj) in (list, tuple, set, frozenset, torch.Size):
             return all(ConstantVariable.is_literal(x) for x in obj)
+        # Enum member, not the Enum itself.
+        if isinstance(obj, enum.Enum) and ConstantVariable.is_literal(obj.value):
+            return True
         return False
 
     def unpack_var_sequence(self, tx):

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -274,7 +274,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 assert all(map(ConstantVariable.is_literal, keys))
                 return TupleVariable(
                     [
-                        ConstantVariable.create(k, **options, source=self.source)
+                        ConstantVariable.create(k, **options)
                         for k in keys
                     ],
                     **options,


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/107595

This fix is so big because it's actually two things: adding `defaultdict.items()` support, and also adding the ability for dictionaries to have tuples of enum values as keys.

Reproducer credits to [Animesh Jain](https://github.com/anijain2305).


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng