### PR TITLE
Fix typo under torch/_decomp directory

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -2152,14 +2152,14 @@ def adaptive_avg_pool2d(input: Tensor, output_size: Tuple[int, int]):
         range_max = torch.arange(maxlength, device=device, dtype=torch.int64)
         idx = i0.unsqueeze(-1) + range_max
         if adaptive:
-            # Need to clamp to avoid accesing out-of-bounds memory
+            # Need to clamp to avoid accessing out-of-bounds memory
             # TODO make minimum accept scalars
             maxval = torch.scalar_tensor(
                 in_size - 1, dtype=idx.dtype, device=idx.device
             )
             idx = torch.minimum(idx, maxval)
 
-            # Compute the lenghts
+            # Compute the length
             i1 = end_index(orange, out_size, in_size)
             length = i1 - i0
         else:
@@ -3468,7 +3468,7 @@ def _grid_sampler_2d(
     _expand_grid: bool = True,
 ) -> Tensor:
     # This method is a copy of grid_sampler_2d implementation and introduced with additional arg _expand_grid to
-    # optionaly expand the input grid for performance reasons.
+    # optionally expand the input grid for performance reasons.
     # Experimenting locally it was found that compiled CUDA code is accelerated by ~5x
     # and CPU code by ~2x on bicubic mode, if we expand the grid from (N, H, W, 2) into (N, C, H, W, 2)
     # However, this leads to a slowdown around ~0.8x on CPU bilinear mode, channels first.
@@ -4136,7 +4136,7 @@ def scaled_dot_product_flash_attention(
     # In pre-dispatch export scaled_dot_product_attention is executed via
     # * flash_attention.
     # flash_attention allocates output tensor as (N, L, H, E)
-    #   it then tranposes that to get (N, H, L, E) which is supposed to be the return
+    #   it then transposes that to get (N, H, L, E) which is supposed to be the return
     # tensor dim for scaled_dot_product_attention
     # assume x: [N, H, L, E] is the output sdpa
     # In MHA code, this output is then permuted via (2, 0, 1, 3) to get
@@ -4155,14 +4155,14 @@ def scaled_dot_product_flash_attention(
     # exactly same as *flash* variant.
     # flash variants output is contiguous as [N, L, H, E]
     # _match variant out is contiguous as [N, H, L, E]
-    # out = out.tranpose(1, 2).contiguous gets output as contiguous
+    # out = out.transpose(1, 2).contiguous gets output as contiguous
     # in [N, L, H, E].
-    # Subsrequent tranpose(1, 2) then returns a view on which
+    # Subsrequent transpose(1, 2) then returns a view on which
     # aforementioned code snippet, as showm below, is valid
     # x = x.permute(2, 0, 1, 3).contiguous() and the viewed via
     # x = x.view(L * N, H * E)
 
-    # Really the invairant you want to maintain is:
+    # Really the invariant you want to maintain is:
     # pre-dispatch op-output and its decomposed representation must
     # return tensor with same view and dims
     output = output.transpose(1, 2).contiguous(memory_format=torch.contiguous_format)

--- a/torch/_decomp/decompositions_for_rng.py
+++ b/torch/_decomp/decompositions_for_rng.py
@@ -214,13 +214,13 @@ class PhiloxStateTracker:
 
 
 # Adding more decompositions which eventually use rand_like inside decomps.
-# Adding these in rng_decompositins ensures the functionalization of rand_like
+# Adding these in rng_decompositions ensures the functionalization of rand_like
 # ops used in these decomps. The list is copied from inductor codebase, which
 # uses it for similar purpose.
 #
 # Caution - These decomps do not have same accuracy as that of eager. However,
 # we can't just disable them with a config flag like fallback_random, because
-# for fuctionalization of rng ops, we have to decompose these ops.
+# for functionalization of rng ops, we have to decompose these ops.
 extra_random_decomps = get_decompositions(
     [
         aten.cauchy,


### PR DESCRIPTION
This PR fixes typo of comments in files under `torch/_decomp` directory.
