### PR TITLE
Fix typo under aten directory

### DIFF
--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -314,7 +314,7 @@ static TensorOptions original_options(const OperandInfo& op) {
   }
 }
 
-// Implements the the behavior of the following flags:
+// Implements the behavior of the following flags:
 //   - check_all_same_dtype_
 //   - check_all_same_device_
 //   - enforce_safe_casting_to_output_

--- a/aten/src/ATen/native/LossCTC.cpp
+++ b/aten/src/ATen/native/LossCTC.cpp
@@ -171,7 +171,7 @@ std::tuple<Tensor, Tensor> ctc_loss_cpu_template(const Tensor& log_probs, const 
           log_alpha_a[t][s] = std::log(std::exp(la1-lamax)+std::exp(la2-lamax)+std::exp(la3-lamax))+lamax + log_probs_a[t][current_target_prime];
         }
       }
-      // the likelihood is the the sum of the last two alphas, eq (8), the loss is the negative log likelihood
+      // the likelihood is the sum of the last two alphas, eq (8), the loss is the negative log likelihood
       if (target_length == 0) {
         // if the target is empty then there is no preceding BLANK state and hence there is no path to merge
         neg_log_likelihood_a[b] = -log_alpha_a[input_length-1][0];

--- a/aten/src/ATen/native/cuda/Math.cuh
+++ b/aten/src/ATen/native/cuda/Math.cuh
@@ -226,7 +226,7 @@ const auto lcm_string = jiterator_stringify(
 ); // lcm_string
 
 /*
- * For licensing information, please refer to the the cpu implementation located in "ATen/native/Math.h".
+ * For licensing information, please refer to the cpu implementation located in "ATen/native/Math.h".
  */
 // [C++ Standard Reference: Gamma Function] https://en.cppreference.com/w/cpp/numeric/math/tgamma
 const auto digamma_string = jiterator_stringify(
@@ -3038,7 +3038,7 @@ static inline C10_HOST_DEVICE scalar_t calc_gcd(scalar_t a_in, scalar_t b_in) {
 }
 
 /*
- * For licensing information, please refer to the the cpu implementation located in "ATen/native/Math.h".
+ * For licensing information, please refer to the cpu implementation located in "ATen/native/Math.h".
  */
 template <typename scalar_t>
 static inline C10_HOST_DEVICE scalar_t calc_digamma(scalar_t in) {
@@ -3127,7 +3127,7 @@ static inline C10_HOST_DEVICE scalar_t calc_trigamma(scalar_t in) {
 }
 
 /*
- * For licensing information and documentation, please refer to the the cpu implementation located in "ATen/native/Math.h".
+ * For licensing information and documentation, please refer to the cpu implementation located in "ATen/native/Math.h".
  */
 template <typename scalar_t>
 static inline C10_HOST_DEVICE scalar_t
@@ -3149,7 +3149,7 @@ chbevl(scalar_t _x, const scalar_t array[], size_t len) {
 }
 
 /*
- * For licensing information and documentation, please refer to the the cpu implementation located in "ATen/native/Math.h".
+ * For licensing information and documentation, please refer to the cpu implementation located in "ATen/native/Math.h".
  */
 template <typename T>
 C10_HOST_DEVICE inline std::tuple<const T*, size_t> chebyshev_coefficients_i0e_A() {

--- a/aten/src/ATen/native/cuda/MemoryAccess.cuh
+++ b/aten/src/ATen/native/cuda/MemoryAccess.cuh
@@ -237,7 +237,7 @@ struct unroll {
 // all tensors are contiguous, that is: stride == sizeof(type) for all tensors
 // Note:
 // Functions in vectorized policy does not do boundary check. It assumes the whole block
-// has its job to do. So the reminders should be handled by the the caller manually.
+// has its job to do. So the reminders should be handled by the caller manually.
 template <int vec_size, typename data_t>  // vec_size: number of scalars, can be 1, 2, or 4.
 struct vectorized {
 

--- a/aten/src/ATen/native/im2col.h
+++ b/aten/src/ATen/native/im2col.h
@@ -55,7 +55,7 @@ static void im2col(
           }
         }
 
-        // move the the next index
+        // move the next index
         data_index_step(h_col, height_col, w_col, width_col);
       }
     });

--- a/aten/src/ATen/native/mps/operations/CrossKernel.mm
+++ b/aten/src/ATen/native/mps/operations/CrossKernel.mm
@@ -23,7 +23,7 @@ static inline DTYPE ## 3 cross(DTYPE ## 3 x, DTYPE ## 3 y) {    \
 }
 
 // Metal only supports half and float for native cross implementation.
-// For all the the other data types, implement cross manually.
+// For all the other data types, implement cross manually.
 REGISTER_CROSS_FUNC(int);
 REGISTER_CROSS_FUNC(long);
 REGISTER_CROSS_FUNC(short);

--- a/aten/src/ATen/native/sparse/SparseBlasImpl.cpp
+++ b/aten/src/ATen/native/sparse/SparseBlasImpl.cpp
@@ -132,7 +132,7 @@ Tensor& _compressed_row_strided_mm_out(const Tensor& compressed, const Tensor& s
   // the strided input has to be "tilable" to (..., b1, x) with
   // any x >= 1 such that all the shapes are (block) matrix product
   // compatible. The matrix product will then have shape (..., b0, x).
-  // This in turn means the the result has to be "tilable" to
+  // This in turn means the result has to be "tilable" to
   // (..., b0, x).
   //
   // These observations imply the following restrictions:

--- a/aten/src/ATen/native/vulkan/glsl/conv2d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/conv2d.glsl
@@ -106,7 +106,7 @@ void main() {
         //   | x |              | A0 | A1 | A2 | A3 |
         //   +---+              +----+----+----+----+
         //
-        // In the uKernel graphic, cells sharing the the same letter are from
+        // In the uKernel graphic, cells sharing the same letter are from
         // the same batch/output channel index, and the number denotes a unique
         // channel index. To calculate the output texel, the following
         // calculation is performed:

--- a/aten/src/ATen/native/vulkan/glsl/quantized_conv2d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_conv2d.glsl
@@ -135,7 +135,7 @@ void main() {
         //   | x |              | A0 | A1 | A2 | A3 |
         //   +---+              +----+----+----+----+
         //
-        // In the uKernel graphic, cells sharing the the same letter are from
+        // In the uKernel graphic, cells sharing the same letter are from
         // the same batch/output channel index, and the number denotes a unique
         // channel index. To calculate the output texel, the following
         // calculation is performed:

--- a/aten/src/ATen/native/vulkan/glsl/quantized_conv2d_pw_2x2.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_conv2d_pw_2x2.glsl
@@ -151,7 +151,7 @@ void main() {
       //   | x |              | A0 | A1 | A2 | A3 |
       //   +---+              +----+----+----+----+
       //
-      // In the uKernel graphic, cells sharing the the same letter are from
+      // In the uKernel graphic, cells sharing the same letter are from
       // the same batch/output channel index, and the number denotes a unique
       // channel index. To calculate the output texel, the following
       // calculation is performed:

--- a/aten/src/ATen/native/vulkan/glsl/templates/conv2d_pw.glslt
+++ b/aten/src/ATen/native/vulkan/glsl/templates/conv2d_pw.glslt
@@ -120,7 +120,7 @@ void main() {
       //   | x |              | A0 | A1 | A2 | A3 |
       //   +---+              +----+----+----+----+
       //
-      // In the uKernel graphic, cells sharing the the same letter are from
+      // In the uKernel graphic, cells sharing the same letter are from
       // the same batch/output channel index, and the number denotes a unique
       // channel index. To calculate the output texel, the following
       // calculation is performed:

--- a/aten/src/ATen/record_function.h
+++ b/aten/src/ATen/record_function.h
@@ -462,7 +462,7 @@ struct TORCH_API RecordFunction {
   c10::ArrayRef<const IValue> inputs_;
   std::vector<c10::IValue> outputs_;
 
-  // For backward functions - thread id of the the forward function
+  // For backward functions - thread id of the forward function
   uint64_t fwd_thread_id_ = 0;
 
   // Unique id for this RecordFunction, used in callbacks to track start


### PR DESCRIPTION
This PR fixes typo `the the` of comments in files under `aten` directory.
