### PR TITLE
Fix typo under torch directory

### DIFF
--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -467,7 +467,7 @@ def backend_accuracy_fails(
             ignore_non_fp=ignore_non_fp,
         )
     except Exception as e:
-        # This means that the the minified graph is bad/exposes a different problem.
+        # This means that the minified graph is bad/exposes a different problem.
         # As we are checking accuracy here, lets log the exception and return False.
         log.exception(
             "While minifying the program in accuracy minification mode, "

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -1409,7 +1409,7 @@ def make_dupe_guard(obj_source, dupe_source):
     # Prior to the addition of tracking to all relevant objects, we would handle this just fine by
     # eagerly re-entering VB and rewrapping inputs, correctly creating graphargs and placeholders. However,
     # with tracking on inputs, duplicate inputs or aliased relationships may end up getting erased here -
-    # In the the fn(x, x) example call above look like a graph with a single input.
+    # In the fn(x, x) example call above look like a graph with a single input.
     # In order to ensure that we do not reuse fn(x, x) for fn(x, y), we create a duplicate input guard.
 
     # Note - we may not have a source, that is fine, it just means we had an object that is safe to have

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1034,7 +1034,7 @@ class GraphSignature:
         to its parameter/buffer FQN in the original nn.Module.
     (3) If there are input mutations, these are represented as extra outputs
         in the fx GraphModule. We provide a mapping from these
-        extra output names to the names of the the actual inputs.
+        extra output names to the names of the actual inputs.
     (4) The pytree metadata on how to flatten/unflatten inputs and outputs.
         The corresponding FX GraphModule only accepts and returns
         pytree-flattened inputs/outputs.
@@ -2938,7 +2938,7 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Any], aot_config: AOTConfig, 
                 seed, offset = CUDARngStateHelper.get_torch_state_as_tuple(fake_mode)
                 adjusted_flat_args.extend([seed, offset])
                 # We are not clearing flat_args here because
-                # 1) There is a check in the the debug compiler at the end
+                # 1) There is a check in the debug compiler at the end
                 # 2) It does not matter as these are fake tensors
 
             if torch._guards.TracingContext.get():

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -136,7 +136,7 @@ def clear_cublass_cache():
     Cublas keeps a persistent workspace allocation for running matmuls. This poses a problem for
     doing warmup within a CUDAGraph private pool because we do not want persistent allocations from
     one one run to the next. When we begin a new run of a cudagraphs path (generation), all tensors
-    from the previous generation are freed. This frees them the the memory pool, but not elsewhere.
+    from the previous generation are freed. This frees them the memory pool, but not elsewhere.
     A tensor in the cublas workspace would continue to be in use the workspace but would also get allocated
     in the next run. The memory would be in use in two places.
 

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -923,7 +923,7 @@ def get_class_name_lineno(method) -> Tuple[str, int]:
     return class_name, line_no
 
 
-# At the the point the decorator is applied to class methods the method
+# At the point the decorator is applied to class methods the method
 # has no reference to its owning class. _qualified_name would not include
 # the class it is defined in, so any methods with the same name in the same file
 # would have the same _qualified_name, even if they were defined in different
@@ -1181,7 +1181,7 @@ def _qualified_name(obj, mangle_name=True) -> str:
 
     # if getattr(sys.modules[module_name], name) is not obj:
     #     raise RuntimeError(f"Could not get qualified name for class '{name}': "
-    #                        f"the attr {name} on module {module_name} is not the the class")
+    #                        f"the attr {name} on module {module_name} is not the class")
 
     # torch.package and TorchScript have separate mangling schemes to avoid
     # name collisions from multiple packages. To avoid them interfering with

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -772,7 +772,7 @@ class OpOverloadPacket:
 # correct one at runtime and always calls into the boxed version of the method
 # Autograd codegen creates VariableType, TracerType,
 # inplace or view type and python bindings.
-# Aten codegen generates tensor methods for the the tensor class.
+# Aten codegen generates tensor methods for the tensor class.
 
 # _OpNamespace is a subclass of ModuleType because the torch script
 # allows attribute lookups on modules only. Since we want torch.ops.foo.bar()

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -151,7 +151,7 @@ def _get_async_or_non_blocking(function_name, non_blocking, kwargs):
 #     serialize the *state_dict* of a model, not the model itself
 #     (since this is more stable to code changes affecting the model
 #     serialization), and the state dict saves "data" only, thus
-#     stripping the the backward hooks.  In some cases, hooks are
+#     stripping the backward hooks.  In some cases, hooks are
 #     essential to the well-functioning of a model (e.g., DDP),
 #     but DDP already manages readding the hooks!
 #

--- a/torch/ao/quantization/fake_quantize.py
+++ b/torch/ao/quantization/fake_quantize.py
@@ -228,7 +228,7 @@ class FakeQuantize(FakeQuantizeBase):
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
                               missing_keys, unexpected_keys, error_msgs):
-        # Removing this function throws an error that the the size of the loaded tensor does not match the original size
+        # Removing this function throws an error that the size of the loaded tensor does not match the original size
         # i.e., These buffers start out with numel 0 and become numel 1 once they have their first forward pass.
         local_state = ['scale', 'zero_point']
         for name in local_state:

--- a/torch/ao/quantization/fx/_model_report/detector.py
+++ b/torch/ao/quantization/fx/_model_report/detector.py
@@ -117,7 +117,7 @@ class DetectorBase(ABC):
     Concrete detectors should follow the same general API, which includes:
     - A method to calculate and return observer insertion points
         - Should return both the fqns and the Observer class to insert
-    - A method to return a report based on the the detector
+    - A method to return a report based on the detector
         - Should return a str-based report and dict info in Tuple[str,Dict] format
     """
 

--- a/torch/ao/quantization/pt2e/port_metadata_pass.py
+++ b/torch/ao/quantization/pt2e/port_metadata_pass.py
@@ -169,7 +169,7 @@ class PortNodeMetaForQDQ(_ExportPassBase):
           - [Q-> [DQ -> Conv -> Q] -> DQ -> [AvgPool] -> Q -> [DQ -> Linear -> Q] -> DQ]
           - Note DQ and Q nodes around AvgPool do not inherit metadata from AvgPool because
             AvgPool was not supposed to be quantized. Metadata porting relies on quantization_annotation
-            on the nodes (in this case AvgPool node) to conclude if the the node or patter was
+            on the nodes (in this case AvgPool node) to conclude if the node or patter was
             supposed to be quantized. And subsequntly decide if the preceding Q, if any, should
             inherit metadata from AvgPool.
       - Dynamically quantized patterns:

--- a/torch/csrc/api/include/torch/nn/modules/container/functional.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/functional.h
@@ -29,7 +29,7 @@ namespace nn {
 /// \endrst
 ///
 /// While a `Functional` module only accepts a single `Tensor` as input, it is
-/// possible for the the wrapped function to accept further arguments. However,
+/// possible for the wrapped function to accept further arguments. However,
 /// these have to be bound *at construction time*. For example, if
 /// you want to wrap `torch::leaky_relu`, which accepts a `slope` scalar as its
 /// second argument, with a particular value for its `slope` in a `Functional`

--- a/torch/csrc/dynamo/eval_frame.c
+++ b/torch/csrc/dynamo/eval_frame.c
@@ -289,7 +289,7 @@ inline static const char* get_frame_name(THP_EVAL_API_FRAME_OBJECT* frame) {
 typedef PyObject FrameState;
 /*
 Our cache resides on the extra scratch space of the code object. The structure
-of the the cache is as follows:
+of the cache is as follows:
 
 -> ExtraState
   -> CacheEntry

--- a/torch/csrc/profiler/orchestration/observer.h
+++ b/torch/csrc/profiler/orchestration/observer.h
@@ -73,7 +73,7 @@ struct TORCH_API ExperimentalConfig {
    * their child events) and delaying CPU event start times (to
    * prevent overlaps), so this should not be used unless Vulkan events are
    * being profiled and it is ok to use this modified timestamp/duration
-   * information instead of the the original information.
+   * information instead of the original information.
    */
   bool adjust_timestamps;
 };

--- a/torch/distributed/_spmd/graph_optimization.py
+++ b/torch/distributed/_spmd/graph_optimization.py
@@ -549,7 +549,7 @@ def schedule_comm_wait(gm: IterGraphModule) -> None:
 )
 def remove_copy_from_optimizer(gm: IterGraphModule) -> None:
     """
-    Erase the the orphant copy_ that generated when tracing optimizer.
+    Erase the orphant copy_ that generated when tracing optimizer.
     Two reasons why we could not simply use the DCE of fx.Graph.
     1. fx.Graph treats copy_ as a side-effect node and does not erase it.
     2. Users may want to preserve some orphan `copy_` that is not from the

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -3935,7 +3935,7 @@ def _new_group_with_tag(
         for rank in ranks:
             if rank < 0 or rank >= global_world_size:
                 raise ValueError(
-                    "The new group's rank should be within the "
+                    "The new group's rank should be within "
                     "the world_size set by init_process_group"
                 )
         if global_rank in ranks:

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -342,7 +342,7 @@ def proxy_call(proxy_mode, func, pre_dispatch, args, kwargs):
     #
     # If lift_fresh returns t directly, the subsequent add_ call will
     # modify the tensor constant. Really, the problem is we've violated
-    # the invariant the the argument to lift is fresh.  So what we should
+    # the invariant the argument to lift is fresh.  So what we should
     # preserve the invariant by replacing lift_fresh with lift_fresh_copy:
     #
     #       t = self._tensor_constant0  # initialized to torch.tensor(1)

--- a/torch/jit/_async.py
+++ b/torch/jit/_async.py
@@ -91,7 +91,7 @@ def wait(future):
     Args:
         future (torch.jit.Future[T]): an asynchronous task reference, created through `torch.jit.fork`
     Returns:
-        `T`: the return value of the the completed task
+        `T`: the return value of the completed task
     """
     return torch._C.wait(future)
 

--- a/torch/package/importer.py
+++ b/torch/package/importer.py
@@ -61,7 +61,7 @@ class Importer(ABC):
         object from this environment.
 
         Args:
-            obj: An object to get the the module-environment-relative name for.
+            obj: An object to get the module-environment-relative name for.
             name: If set, use this name instead of looking up __name__ or __qualname__ on `obj`.
                 This is only here to match how Pickler handles __reduce__ functions that return a string,
                 don't use otherwise.

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -681,7 +681,7 @@ class ExecutionTraceObserver:
 
     def register_callback(self, output_file_path: str):
         """
-        Adds ET observer to record function callbacks. The the data will be
+        Adds ET observer to record function callbacks. The data will be
         written to output_file_path.
         """
         if not self._registered:

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -955,7 +955,7 @@ class DistributedTest:
 
             with self.assertRaisesRegex(
                 RuntimeError,
-                "The new group's rank should be within the the world_size set by init_process_group",
+                "The new group's rank should be within the world_size set by init_process_group",
             ):
                 dist.new_subgroups_by_enumeration(
                     ranks_per_subgroup_list=[[0, 1], [world_size, 2]]
@@ -971,7 +971,7 @@ class DistributedTest:
 
             with self.assertRaisesRegex(
                 ValueError,
-                "The new group's rank should be within the the world_size set by init_process_group",
+                "The new group's rank should be within the world_size set by init_process_group",
             ):
                 dist.new_subgroups_by_enumeration(
                     ranks_per_subgroup_list=[[-1, -2], [-3, -4]]


### PR DESCRIPTION
This PR fixes typo `the the` of comments and exception messages in files under `torch` directory.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler