### PR TITLE
Fix typo under caffe2 directory 

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1451,7 +1451,7 @@ if(MSVC AND NOT BUILD_SHARED_LIBS)
   #   1. Write out a config.h header which stores whether or not
   #      you are linking statically or dynamically.
   #
-  #   2. Force all of users to set the the macro themselves.  If they
+  #   2. Force all of users to set the macro themselves.  If they
   #      use cmake, you can set -DAT_CORE_STATIC_WINDOWS=1 as a PUBLIC
   #      compile option, in which case cmake will automatically
   #      add the macro for you.

--- a/caffe2/operators/lp_pool_op.cc
+++ b/caffe2/operators/lp_pool_op.cc
@@ -230,7 +230,7 @@ OPERATOR_SCHEMA(LpPool)
     .NumInputs(1)
     .NumOutputs(1)
     .SetDoc(R"DOC(
-`LpPool` consumes an input blob and applies max pooling across the the blob according to kernel sizes, stride sizes, pad lengths and dilation. $L_p$ pooling consists of taking the $L_p$ norm of a subset of the input tensor according to the kernel size and downsampling the data into the output blob for further processing.
+`LpPool` consumes an input blob and applies max pooling across the blob according to kernel sizes, stride sizes, pad lengths and dilation. $L_p$ pooling consists of taking the $L_p$ norm of a subset of the input tensor according to the kernel size and downsampling the data into the output blob for further processing.
 
 Pooling layers reduce the spatial dimensionality of the input blob. Each of the output blob's dimensions will reduce according to:
 

--- a/caffe2/operators/pool_op.cc
+++ b/caffe2/operators/pool_op.cc
@@ -850,7 +850,7 @@ CAFFE2_SPECIALIZED_MAX_POOL_FUNCTOR_FORWARD(float, StorageOrder::NHWC)
 
 // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 constexpr char kAveragePoolDoc[] = R"DOC(
-consumes an input blob and applies average pooling across the the blob according
+consumes an input blob and applies average pooling across the blob according
 to kernel sizes, stride sizes, pad lengths and dilation. Average pooling consists
 of taking the average value of a subset of the input tensor according to the kernel
 size and downsampling the data into the output blob for further processing. The
@@ -920,7 +920,7 @@ Y:
 
 // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 constexpr char kMaxPoolDoc[] = R"DOC(
-consumes an input blob and applies max pooling across the the blob according to
+consumes an input blob and applies max pooling across the blob according to
 kernel sizes, stride sizes, pad lengths and dilation. Max pooling consists of
 taking the maximum value of a subset of the input tensor according to the kernel
 size and downsampling the data into the output blob for further processing. The

--- a/caffe2/opt/nql/graphmatcher.cc
+++ b/caffe2/opt/nql/graphmatcher.cc
@@ -200,7 +200,7 @@ std::vector<MatchedSubgraph> GraphMatcher::getMatches(
     if (match.isMatch()) {
       MatchedSubgraph ms;
       ms.subgraph = *match.getMatchedSubgraph();
-      // This is a map from the the internal TestMatchGraph to the nodes in the
+      // This is a map from the internal TestMatchGraph to the nodes in the
       // NNGraph
       auto match_graph_map = match.getMatchNodeMap();
       // We iterate through the "varMap_" map (string ->

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -1029,7 +1029,7 @@ void addGlobalMethods(py::module& m) {
   );
 
   // if the binary is built with USE_ROCM, this is a ROCm build
-  // and therefore we need to ignore dyndep failures (because the the module
+  // and therefore we need to ignore dyndep failures (because the module
   // may not have a ROCm equivalent yet e.g. nccl)
   m.attr("use_rocm") = py::bool_(
 #if defined(USE_ROCM)


### PR DESCRIPTION
This PR fixes typo `the the` of comments in files under `caffe2` directory.
