### PR TITLE
[BE]: Enable ruff's flake8-PYI rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,17 @@ ignore = [
     "G101", "G201", "G202",
     # these ignores are from RUFF perf; please fix!
     "PERF203", "PERF4",
+    "PYI001", # these ignores are from PYI; please fix!
+    "PYI018",
+    "PYI019",
+    "PYI024",
+    "PYI030",
+    "PYI034",
+    "PYI036",
+    "PYI041",
+    "PYI042",
+    "PYI045",
+    "PYI056",
     "SIM102", "SIM103", "SIM112", # flake8-simplify code styles
     "SIM105", # these ignores are from flake8-simplify. please fix or ignore with commented reason
     "SIM108",
@@ -82,6 +93,7 @@ select = [
     "PT024",
     "PT025",
     "PT026",
+    "PYI",
     "RUF017",
     "TRY302",
 ]
@@ -89,6 +101,7 @@ select = [
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]
 "test/jit/**" = [
+    "PYI",
     "UP", # We don't want to modify the jit test as they test specify syntax
 ]
 "torch/onnx/**" = [

--- a/torch/jit/_script.pyi
+++ b/torch/jit/_script.pyi
@@ -13,7 +13,7 @@ from typing import (
 )
 
 from _typeshed import Incomplete
-from typing_extensions import Never
+from typing_extensions import Never, TypeAlias
 
 import torch
 from torch._classes import classes as classes
@@ -65,7 +65,7 @@ ScriptFunction = torch._C.ScriptFunction
 type_trace_db: JitTypeTraceStore
 
 # Defined in torch/csrc/jit/python/script_init.cpp
-ResolutionCallback = Callable[[str], Callable[..., Any]]
+ResolutionCallback: TypeAlias = Callable[[str], Callable[..., Any]]
 ClassVar = TypeVar("ClassVar", bound=type)
 
 def _reduce(cls) -> None: ...

--- a/torchgen/utils.py
+++ b/torchgen/utils.py
@@ -185,7 +185,7 @@ class FileManager:
     def write(
         self,
         filename: str,
-        env_callable: Callable[[], Union[str, Union[str, Dict[str, Any]]]],
+        env_callable: Callable[[], Union[str, Dict[str, Any]]],
     ) -> None:
         self.write_with_template(filename, filename, env_callable)
 


### PR DESCRIPTION
Enable Flake8-PYI rules codebase wide. Most of the rules already match our codebase style, the remaining ones that were not autofixed I have added to the pyproject.toml to be enabled in a later PR.
