### PR TITLE
[TP][Inference] Add decompose for matmul op

### DIFF
--- a/test/distributed/tensor/parallel/test_tp_examples.py
+++ b/test/distributed/tensor/parallel/test_tp_examples.py
@@ -107,13 +107,13 @@ class DistTensorParallelExampleTest(DTensorTestBase):
         output_tp = model_tp(inp)
         self.assertEqual(output, output_tp)
 
-    def _test_mlp_inference(self, device_mesh):
+    def _test_mlp_inference(self, device_mesh, bias):
         inp_size = [8, 10]
         # Ensure all tp ranks have same input.
         torch.manual_seed(0)
         inp = torch.rand(*inp_size, device=self.device_type)
-        model = MLPModule(self.device_type)
-        model_tp = MLPModule(self.device_type)
+        model = MLPModule(self.device_type, bias=bias)
+        model_tp = MLPModule(self.device_type, bias=bias)
 
         # Ensure model are initialized the same way.
         self._check_module(model, model_tp)
@@ -134,13 +134,14 @@ class DistTensorParallelExampleTest(DTensorTestBase):
         )
 
     @with_comms
-    def test_mlp_inference(self):
+    @parametrize("bias", [True, False])
+    def test_mlp_inference(self, bias):
         device_mesh = DeviceMesh(
             self.device_type,
             torch.arange(0, NUM_DEVICES),
         )
         with torch.inference_mode():
-            self._test_mlp_inference(device_mesh)
+            self._test_mlp_inference(device_mesh, bias)
 
 
 instantiate_parametrized_tests(DistTensorParallelExampleTest)

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -260,7 +260,7 @@ class DTensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
         # For the long run, we need to think of a better way to handle it.
         # TODO: We can benchmark this decompose further to see if we can
         # completely remove the check and apply it for all DTensor Ops.
-        if func == aten.linear.default:
+        if func in [aten.linear.default, aten.matmul.default]:
             r = func.decompose(*args, **kwargs)
             if r is not NotImplemented:
                 return r

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -53,12 +53,12 @@ T = TypeVar("T")
 
 
 class MLPModule(torch.nn.Module):
-    def __init__(self, device):
+    def __init__(self, device, bias=True):
         super().__init__()
         torch.manual_seed(5)
-        self.net1 = torch.nn.Linear(10, 16, device=device)
+        self.net1 = torch.nn.Linear(10, 16, device=device, bias=bias)
         self.relu = torch.nn.ReLU()
-        self.net2 = torch.nn.Linear(16, 10, device=device)
+        self.net2 = torch.nn.Linear(16, 10, device=device, bias=bias)
 
     def forward(self, x):
         return self.net2(self.relu(self.net1(x)))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110833
* #110751

When we set the bias to False in the linear, it will trigger `matmul` during the decomposition of  `linear`. So we want to add matmul op in the decomposition as well. Also since we didn't cover this case in unit test, we add a new unit test case so that we have it covered in our UT.

cc @wanchaol @XilunWu @tianyu-l