### PR TITLE
[2/N] Dynamo supports skip by function & removes skipfiles circular import

### DIFF
--- a/test/dynamo/test_allow_inline_skip.py
+++ b/test/dynamo/test_allow_inline_skip.py
@@ -1,12 +1,30 @@
 # Owner(s): ["module: dynamo"]
+import importlib
+import types
 import unittest
 
 import torch
 import torch._dynamo.test_case
+from torch._dynamo.skipfiles import (
+    FILE_INLINELIST,
+    FUNC_INLINELIST,
+    SUBMODULE_INLINELIST,
+)
 from torch._dynamo.utils import istype
 
 
 class AllowInlineSkipTests(torch._dynamo.test_case.TestCase):
+    # We are using python function and module string names for these inlinelist,
+    # this unit test is to make sure the functions/modules can be correctly imported
+    # or loaded in case there is typo in the strings.
+    def test_skipfiles_inlinelist_correctness(self):
+        for m in FILE_INLINELIST.union(SUBMODULE_INLINELIST):
+            self.assertTrue(isinstance(importlib.import_module(m), types.ModuleType))
+        for f in FUNC_INLINELIST:
+            module_name, fn_name = f.rsplit(".", 1)
+            m = importlib.import_module(module_name)
+            self.assertTrue(isinstance(getattr(m, fn_name), types.FunctionType))
+
     def test_func_inlinelist(self):
         def fn(x):
             if istype(x, torch.Tensor):

--- a/test/dynamo/test_allow_inline_skip.py
+++ b/test/dynamo/test_allow_inline_skip.py
@@ -1,0 +1,47 @@
+# Owner(s): ["module: dynamo"]
+import unittest
+
+import torch
+import torch._dynamo.test_case
+from torch._dynamo.utils import istype
+
+
+class AllowInlineSkipTests(torch._dynamo.test_case.TestCase):
+    def test_func_inlinelist(self):
+        def fn(x):
+            if istype(x, torch.Tensor):
+                return x + 1
+            else:
+                return x - 1
+
+        my_func_inlinelist = torch._dynamo.skipfiles.FUNC_INLINELIST.copy()
+        my_func_inlinelist.add("torch._dynamo.utils.istype")
+
+        def my_get_func_inlinelist():
+            inlinelist = set()
+            for f in my_func_inlinelist:
+                inlinelist.add(eval(f).__code__)
+            return inlinelist
+
+        self.assertTrue(
+            "torch._dynamo.utils" not in torch._dynamo.skipfiles.FILE_INLINELIST
+        )
+        self.assertTrue(
+            "torch._dynamo" not in torch._dynamo.skipfiles.SUBMODULE_INLINELIST
+        )
+
+        with unittest.mock.patch(
+            "torch._dynamo.skipfiles.get_func_inlinelist",
+            my_get_func_inlinelist,
+        ):
+            x = torch.rand(3)
+            opt_fn = torch.compile(backend="eager", fullgraph=True)(fn)
+            ref = fn(x)
+            res = opt_fn(x)
+            self.assertEqual(ref, res)
+
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    run_tests()

--- a/torch/_compile.py
+++ b/torch/_compile.py
@@ -28,3 +28,9 @@ def _disable_dynamo(fn=None, recursive=True):
         # decorator usage like @_disable_dynamo(recursive=False). The resulting
         # object expects the original decorated function as the arg.
         return functools.partial(_disable_dynamo, recursive=recursive)
+
+
+def dynamo_inline(fn):
+    assert callable(fn), "dynamo_inline expects a function"
+    torch._dynamo.skipfiles.FUNC_INLINELIST.add(fn.__module__ + "." + fn.__name__)
+    return fn

--- a/torch/_compile.py
+++ b/torch/_compile.py
@@ -28,9 +28,3 @@ def _disable_dynamo(fn=None, recursive=True):
         # decorator usage like @_disable_dynamo(recursive=False). The resulting
         # object expects the original decorated function as the arg.
         return functools.partial(_disable_dynamo, recursive=recursive)
-
-
-def dynamo_inline(fn):
-    assert callable(fn), "dynamo_inline expects a function"
-    torch._dynamo.skipfiles.FUNC_INLINELIST.add(fn.__module__ + "." + fn.__name__)
-    return fn

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -181,11 +181,8 @@ class OptimizedModule(torch.nn.Module):
 
     def _initialize(self):
         # Do this stuff in constructor to lower overhead slightly
-        if (
-            isinstance(self._orig_mod.forward, types.MethodType)
-            and skipfiles.check_file(
-                inspect.getsourcefile(self._orig_mod.forward)
-            ).skipped
+        if isinstance(self._orig_mod.forward, types.MethodType) and skipfiles.check(
+            self._orig_mod.forward
         ):
             # This may be a torch.nn.* instance in skipfiles.py which
             # won't trigger a frame evaluation workaround to add an extra
@@ -365,7 +362,7 @@ class _TorchDynamoContext:
         except TypeError:
             filename = None
         if (
-            (filename is None or skipfiles.check_file(filename).skipped)
+            (filename is None or skipfiles.check(fn))
             and (
                 getattr(fn, "__name__", "") not in ["_call_impl", "_wrapped_call_impl"]
             )
@@ -522,7 +519,7 @@ def catch_errors_wrapper(callback, hooks: Hooks):
         if (
             # TODO: the first condition is not covered by any test
             frame.f_lasti >= first_real_inst_idx(frame.f_code)
-            or skipfiles.check_func(frame.f_code).skipped
+            or skipfiles.check(frame.f_code)
             or config.disable
         ):
             log.debug("skipping %s %s", frame.f_code.co_name, frame.f_code.co_filename)
@@ -1221,7 +1218,7 @@ def export(
         if (
             (shape_env := getattr(fake_mode, "shape_env", None)) is not None
             and (dim_constraints := shape_env.dim_constraints) is not None
-            and not skipfiles.check_file(inspect.getsourcefile(call_to_inspect)).skipped
+            and not skipfiles.check(call_to_inspect)
         ):
             dim_constraints.solve()
             dim_constraints.remove_redundant_dynamic_results()

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -181,8 +181,11 @@ class OptimizedModule(torch.nn.Module):
 
     def _initialize(self):
         # Do this stuff in constructor to lower overhead slightly
-        if isinstance(self._orig_mod.forward, types.MethodType) and skipfiles.check(
-            inspect.getsourcefile(self._orig_mod.forward)
+        if (
+            isinstance(self._orig_mod.forward, types.MethodType)
+            and skipfiles.check_file(
+                inspect.getsourcefile(self._orig_mod.forward)
+            ).skipped
         ):
             # This may be a torch.nn.* instance in skipfiles.py which
             # won't trigger a frame evaluation workaround to add an extra
@@ -362,7 +365,7 @@ class _TorchDynamoContext:
         except TypeError:
             filename = None
         if (
-            (filename is None or skipfiles.check(filename))
+            (filename is None or skipfiles.check_file(filename).skipped)
             and (
                 getattr(fn, "__name__", "") not in ["_call_impl", "_wrapped_call_impl"]
             )
@@ -519,7 +522,7 @@ def catch_errors_wrapper(callback, hooks: Hooks):
         if (
             # TODO: the first condition is not covered by any test
             frame.f_lasti >= first_real_inst_idx(frame.f_code)
-            or skipfiles.check(frame.f_code.co_filename)
+            or skipfiles.check_file(frame.f_code.co_filename).skipped
             or config.disable
         ):
             log.debug("skipping %s %s", frame.f_code.co_name, frame.f_code.co_filename)
@@ -1218,7 +1221,7 @@ def export(
         if (
             (shape_env := getattr(fake_mode, "shape_env", None)) is not None
             and (dim_constraints := shape_env.dim_constraints) is not None
-            and not skipfiles.check(inspect.getsourcefile(call_to_inspect))
+            and not skipfiles.check_file(inspect.getsourcefile(call_to_inspect)).skipped
         ):
             dim_constraints.solve()
             dim_constraints.remove_redundant_dynamic_results()

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -522,7 +522,7 @@ def catch_errors_wrapper(callback, hooks: Hooks):
         if (
             # TODO: the first condition is not covered by any test
             frame.f_lasti >= first_real_inst_idx(frame.f_code)
-            or skipfiles.check_file(frame.f_code.co_filename).skipped
+            or skipfiles.check_func(frame.f_code).skipped
             or config.disable
         ):
             log.debug("skipping %s %s", frame.f_code.co_name, frame.f_code.co_filename)

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -230,7 +230,10 @@ if torch.distributed.is_available():
 def get_func_inlinelist():
     inlinelist = set()
     for f in FUNC_INLINELIST:
-        inlinelist.add(eval(f).__code__)
+        module_name, fn_name = f.rsplit(".", 1)
+        m = importlib.import_module(module_name)
+        fn = getattr(m, fn_name)
+        inlinelist.add(fn.__code__)
     return inlinelist
 
 
@@ -254,7 +257,9 @@ if TYPE_CHECKING:
     for m in FILE_INLINELIST.union(SUBMODULE_INLINELIST):
         importlib.import_module(m)
     for f in FUNC_INLINELIST:
-        inspect.isfunction(eval(f))
+        module_name, fn_name = f.rsplit(".", 1)
+        m = importlib.import_module(module_name)
+        inspect.isfunction(getattr(m, fn_name))
 
 
 # skip some standard python builtin libs

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -28,7 +28,7 @@ import types
 import typing
 import unittest
 import weakref
-from typing import Optional, TYPE_CHECKING
+from typing import Optional
 
 import torch
 import torch._inductor.test_operators
@@ -165,6 +165,7 @@ FUNC_INLINELIST = set()
 # Force inline functions in these files or directories, even they are in *_SKIPLIST.
 # We are using python module name instead of file or directory object to avoid circular dependency.
 # Please keep this sorted alphabetically.
+# TODO: Merge FILE_INLINELIST into SUBMODULE_INLINELIST.
 FILE_INLINELIST = {
     "torch._dynamo._trace_wrapped_higher_order_op",
     "torch._dynamo.comptime",
@@ -226,6 +227,7 @@ if torch.distributed.is_available():
     SUBMODULE_INLINELIST.add("torch.distributed._functional_collectives")
 
 
+# TODO: support adding bound method into this list
 @functools.lru_cache(None)
 def get_func_inlinelist():
     inlinelist = set()
@@ -251,15 +253,6 @@ def get_submodule_inlinelist():
     for m in SUBMODULE_INLINELIST:
         inlinelist.add(_module_dir(torch) + m[len("torch.") :].replace(".", "/"))
     return inlinelist
-
-
-if TYPE_CHECKING:
-    for m in FILE_INLINELIST.union(SUBMODULE_INLINELIST):
-        importlib.import_module(m)
-    for f in FUNC_INLINELIST:
-        module_name, fn_name = f.rsplit(".", 1)
-        m = importlib.import_module(module_name)
-        inspect.isfunction(getattr(m, fn_name))
 
 
 # skip some standard python builtin libs

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -157,9 +157,9 @@ def _module_dir(m: types.ModuleType):
     return _strip_init_py(m.__file__)
 
 
-FUNC_INLINELIST = {
-    "torch.autograd.function.once_differentiable",
-}
+# TODO: Add a decoractor for easily adding functions to FUNC_INLINELIST
+# after resolving all circular import issues.
+FUNC_INLINELIST = set()
 
 
 # Force inline functions in these files or directories, even they are in *_SKIPLIST.
@@ -341,13 +341,12 @@ def check_file(filename, allow_torch=False, extra_check=False):
 
 
 def check_verbose(obj, allow_torch=False, extra_check=False):
-    if isinstance(obj, (UserFunctionVariable, UserMethodVariable)):
-        filename = obj.get_filename()
-        obj = obj.get_function().__code__
-    elif isinstance(obj, NestedUserFunctionVariable):
+    if isinstance(
+        obj, (UserFunctionVariable, UserMethodVariable, NestedUserFunctionVariable)
+    ):
         filename = obj.get_filename()
         obj = obj.get_code()
-    elif inspect.iscode(obj):
+    elif isinstance(obj, types.CodeType):
         filename = obj.co_filename
     elif isinstance(obj, (types.FunctionType, types.MethodType)):
         filename = getfile(obj)

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -399,7 +399,7 @@ _recompile_re()
 
 
 def is_torch_inline_allowed(filename):
-    return any(filename.startswith(_module_dir(mod)) for mod in SUBMODULE_INLINELIST)
+    return any(filename.startswith(d) for d in get_submodule_inlinelist())
 
 
 @functools.lru_cache(None)

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -399,11 +399,6 @@ _recompile_re()
 
 
 def is_torch_inline_allowed(filename):
-    if torch.distributed.is_available():
-        from torch.distributed import _functional_collectives
-
-        SUBMODULE_INLINELIST.add(_functional_collectives)
-
     return any(filename.startswith(_module_dir(mod)) for mod in SUBMODULE_INLINELIST)
 
 

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -159,7 +159,10 @@ def _module_dir(m: types.ModuleType):
 
 # TODO: Add a decoractor for easily adding functions to FUNC_INLINELIST
 # after resolving all circular import issues.
-FUNC_INLINELIST = set()
+FUNC_INLINELIST = {
+    "torch._constrain_as_size",
+    "torch._constrain_as_value",
+}
 
 
 # Force inline functions in these files or directories, even they are in *_SKIPLIST.
@@ -171,7 +174,6 @@ FILE_INLINELIST = {
     "torch._dynamo.comptime",
     "torch._dynamo.external_utils",
     "torch._dynamo.polyfill",
-    "torch._export.constraints",
     "torch._export.db.examples",
     "torch._export.wrappers",
     "torch._functorch.apis",

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -185,11 +185,6 @@ FILE_INLINELIST = {
     "torch.ao.quantization.pt2e.representation.rewrite",
     "torch.ao.quantization.pt2e.utils",
     "torch.ao.quantization.quantizer.xnnpack_quantizer",
-    "torch.distributed._tensor.api",
-    "torch.distributed._tensor.device_mesh",
-    "torch.distributed.tensor.parallel._data_parallel_utils",
-    "torch.distributed.tensor.parallel._utils",
-    "torch.distributed.tensor.parallel.style",
     "torch.nn.modules.container",
     "torch.optim._functional",
     "torch.random",
@@ -199,8 +194,14 @@ FILE_INLINELIST = {
 
 
 if torch.distributed.is_available():
-    # Inline the checkpoint code from distributed
-    FILE_INLINELIST |= {"torch.distributed.algorithms._checkpoint.checkpoint_wrapper"}
+    FILE_INLINELIST |= {
+        "torch.distributed._tensor.api",
+        "torch.distributed._tensor.device_mesh",
+        "torch.distributed.algorithms._checkpoint.checkpoint_wrapper",
+        "torch.distributed.tensor.parallel._data_parallel_utils",
+        "torch.distributed.tensor.parallel._utils",
+        "torch.distributed.tensor.parallel.style",
+    }
 
 # Include optimizer code for tracing
 FILE_INLINELIST |= {

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -2247,6 +2247,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         except NotImplementedError:
             pass  # closures
 
+        # breakpoint()
         result = skipfiles.check_verbose(func, extra_check=True)
         if result.skipped:
             from torch._dynamo.variables.misc import (

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -2247,7 +2247,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         except NotImplementedError:
             pass  # closures
 
-        result = skipfiles.check_func(func, extra_check=True)
+        result = skipfiles.check_verbose(func, extra_check=True)
         if result.skipped:
             from torch._dynamo.variables.misc import (
                 produce_trampoline_autograd_apply,

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -2247,7 +2247,6 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         except NotImplementedError:
             pass  # closures
 
-        # breakpoint()
         result = skipfiles.check_verbose(func, extra_check=True)
         if result.skipped:
             from torch._dynamo.variables.misc import (

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -2247,7 +2247,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         except NotImplementedError:
             pass  # closures
 
-        result = skipfiles.check_verbose(func.get_filename(), extra_check=True)
+        result = skipfiles.check_func(func, extra_check=True)
         if result.skipped:
             from torch._dynamo.variables.misc import (
                 produce_trampoline_autograd_apply,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -60,7 +60,6 @@ from ..utils import (
     clone_input,
     get_fake_value,
     get_static_address_type,
-    getfile,
     global_key_name,
     is_namedtuple,
     is_typing,
@@ -534,12 +533,12 @@ class VariableBuilder:
             )
         elif (
             istype(value, (type, types.FunctionType))
-            and skipfiles.check(getfile(value), allow_torch=True)
+            and skipfiles.check_func(value, allow_torch=True).skipped
             and not inspect.getattr_static(value, "_torchdynamo_inline", False)
         ):
             return SkipFilesVariable(
                 value,
-                skipfiles.check_verbose(getfile(value), allow_torch=True).reason,
+                skipfiles.check_func(value, allow_torch=True).reason,
                 source=self.source,
                 guards=make_guards(GuardBuilder.FUNCTION_MATCH),
             )

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -533,12 +533,12 @@ class VariableBuilder:
             )
         elif (
             istype(value, (type, types.FunctionType))
-            and skipfiles.check_func(value, allow_torch=True).skipped
+            and skipfiles.check(value, allow_torch=True)
             and not inspect.getattr_static(value, "_torchdynamo_inline", False)
         ):
             return SkipFilesVariable(
                 value,
-                skipfiles.check_func(value, allow_torch=True).reason,
+                skipfiles.check_verbose(value, allow_torch=True).reason,
                 source=self.source,
                 guards=make_guards(GuardBuilder.FUNCTION_MATCH),
             )


### PR DESCRIPTION
Several improvements for skipfiles:
* Add ```FUNC_INLINELIST``` to support function level skip/inline check.
  * Use ```fn.__code__``` to match function since we can't get the function object sometimes.
* Use python module string name for ```FILE_INLINELIST``` and ```SUBMODULE_INLINELIST```. 
  * Use filename to match file and python module, which can fundamentally resolved the circular import issues introduced by skipfiles. 
  * Use ```TYPE_CHECKING``` to ensure the python module string name is correct.
* Add unit tests.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng