### PR TITLE
Improve batched torch.matrix_exp performance

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2543,6 +2543,7 @@ Tensor compute_T18_scale_square(
   // With above example, `sorted_s` is [0, 1, 1, 4], we also will need the index
   // info, so we can use it to compose the result back.
   std::tie(sorted_s, sorted_s_inds) = at::sort(s, /*dim=*/0);
+  sorted_s = sorted_s.to(at::kLong);
   // Then we call `unique_consecutive` and we will use it to split `sorted_s`,
   // with above example, `split_counts` is [1, 2, 1].
   auto split_counts = std::get<2>(at::unique_consecutive(sorted_s, true, /*return_counts=*/true));
@@ -2552,7 +2553,7 @@ Tensor compute_T18_scale_square(
   // use the cumulative matrix multiplication.
   // With about example, `mul_times` will be [0, 1, 3].
   auto split_edges = at::cumsum(split_counts, /*dim=*/0) - 1;
-  auto unique_s = sorted_s.index_select(0, split_edges).to(at::kLong).clamp(/*min=*/0);
+  auto unique_s = sorted_s.index_select(0, split_edges).clamp(/*min=*/0);
   auto mul_times = at::diff(unique_s, 1, -1, /*prepend=*/unique_s.new_zeros({1}));
 
   // Square

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2603,7 +2603,7 @@ Tensor mexp_impl(
   // For large batch size, the cost of the above decision on CPU will be quite
   // expensive (compared to the synchronization overhead from GPU to CPU), so
   // here we have a threshold to determine whether to move norm to CPU.
-  const auto batch_size = a_3d.size(0);
+  const auto batch_size = a.size(0);
   const auto norm_small_to_cpu = ((a.device().type() == at::kCUDA)
     && batch_size < large_batch_threshold) ? norm.to(at::kCPU) : norm;
 

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2172,7 +2172,7 @@ using array2d = std::array<std::array<scalar_t, COL>, ROW>;
 // we consider 6 Taylor expansions of degree
 // 1, 2, 4, 8, 12, 18
 constexpr int total_n_degs = 6;
-constexpr int large_batch_threshold = 100;
+constexpr int large_batch_threshold = 350;
 
 Tensor operator_1_norm(const Tensor& tensor) {
   return std::get<0>(tensor.abs().sum(-2).max(-1));
@@ -2607,7 +2607,7 @@ Tensor mexp_impl(
   // expensive (compared to the synchronization overhead from GPU to CPU), so
   // here we have a threshold to determine whether to move norm to CPU.
   const auto norm_small_to_cpu = ((a.device().type() == at::kCUDA)
-    && a.size(0) <= large_batch_threshold) ? norm.to(at::kCPU) : norm;
+    && a.size(0) < large_batch_threshold) ? norm.to(at::kCPU) : norm;
 
   if (!compute_highest_degree_approx) {
     constexpr std::array<

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2172,7 +2172,7 @@ using array2d = std::array<std::array<scalar_t, COL>, ROW>;
 // we consider 6 Taylor expansions of degree
 // 1, 2, 4, 8, 12, 18
 constexpr int total_n_degs = 6;
-constexpr int large_batch_threshold = 350;
+constexpr int large_batch_threshold = 2 << 9;
 
 Tensor operator_1_norm(const Tensor& tensor) {
   return std::get<0>(tensor.abs().sum(-2).max(-1));
@@ -2554,8 +2554,8 @@ Tensor compute_T18_scale_square(
   // use the cumulative matrix multiplication.
   // With about example, `mul_times` will be [0, 1, 3].
   auto split_edges = at::cumsum(split_counts, /*dim=*/0) - 1;
-  auto unique_s = sorted_s.index_select(0, split_edges).to(at::kLong);
-  auto mul_times = at::diff(unique_s, 1, -1, /*prepend=*/unique_s.new_zeros({1})).to(at::kCPU);
+  auto unique_s = sorted_s.index_select(0, split_edges).to(at::kCPU).to(at::kLong);
+  auto mul_times = at::diff(unique_s, 1, -1, /*prepend=*/unique_s.new_zeros({1}));
 
   // Square
   TORCH_INTERNAL_ASSERT(split_counts_cpu.is_contiguous());

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2573,7 +2573,7 @@ Tensor compute_T18_scale_square(
   auto acc = mexp_scaled.index_select(0, sorted_s_inds);
   for (int64_t i = 0; i < section_numel; ++i) {
     for (int64_t j = 0; j < pts[i]; j++) {
-        acc = at::matmul(acc, acc);
+      acc = at::matmul(acc, acc);
     }
     output_pieces.push_back(acc.slice(0, 0, scs[i]));
     acc = acc.slice(0, scs[i]);

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2534,7 +2534,7 @@ Tensor compute_T18_scale_square(
   auto mexp_scaled = at::native::compute_T18<scalar_t>(a_scaled);
 
   // Sort:
-  // Consider inputs are square matrix, so if we first power `martix 0,1,2`, then
+  // Consider inputs are square matrix, so if we first power `matrix 0,1,2`, then
   // the remain thing will only be multiply `matrix 0` by (2^4 - 1) times, which
   // gives us an opportunity to calculate the matrix multiplication in a batch.
   // The first thing we need to do is sort tensor `s`, which will be helpful to
@@ -2564,10 +2564,10 @@ Tensor compute_T18_scale_square(
   auto pts = &scs[section_numel];
 
   // We now will do the matrix muplication in a batch, with above example:
-  // 1. Multiply all matrixes by 0 (`mul_times[0]`) times, then do `slice`
-  // to get the remain matrixes by acc[1:] (`split_counts[0]`),
-  // 2. Multiply remain matrixes by 1 times and slice to acc[2:]
-  // 3. Multiply remain matrixes by 3 times and slice to acc[1:]
+  // 1. Multiply all matrices by 0 (`mul_times[0]`) times, then do `slice`
+  // to get the remain matrices by acc[1:] (`split_counts[0]`),
+  // 2. Multiply remain matrices by 1 times and slice to acc[2:]
+  // 3. Multiply remain matrices by 3 times and slice to acc[1:]
   // All processed matrices will be stored in `output_pieces`.
   std::vector<Tensor> output_pieces;
   auto acc = mexp_scaled.index_select(0, sorted_s_inds);

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2590,15 +2590,14 @@ Tensor mexp_impl(
   std::array<scalar_t, total_n_degs> thetas,
   bool compute_highest_degree_approx = false
 ) {
-  auto res = at::empty_like(a);
   const auto norm = operator_1_norm(a);
-
   const auto batch_size = a.size(0);
   if (batch_size > 1) {
     compute_highest_degree_approx = true;
   }
 
   if (!compute_highest_degree_approx) {
+    auto res = at::empty_like(a);
     // `norm_cpu` is used to decide which Tensors require which approximation
     // based on their norm. This decision takes place on CPU.
     // It requires moving data back and forth between devices when `a` is on CUDA,

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2646,17 +2646,16 @@ Tensor mexp_impl(
         a_large_norm,
         large_norm_subset,
         thetas[total_n_degs - 1]
-      );
+      ).to(a.dtype());
       res.index_put_({idx_large_norm}, mexp_out);
     }
-
     return res;
   }
 
   return compute_T18_scale_square(
     a, norm,
     thetas[total_n_degs - 1]
-  );
+  ).to(a.dtype());
 }
 
 // matrix exponential

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2172,6 +2172,7 @@ using array2d = std::array<std::array<scalar_t, COL>, ROW>;
 // we consider 6 Taylor expansions of degree
 // 1, 2, 4, 8, 12, 18
 constexpr int total_n_degs = 6;
+constexpr int large_batch_threshold = 100;
 
 Tensor operator_1_norm(const Tensor& tensor) {
   return std::get<0>(tensor.abs().sum(-2).max(-1));
@@ -2573,14 +2574,17 @@ Tensor mexp_impl(
     res.fill_(std::numeric_limits<double>::quiet_NaN());
     return res;
   }
-  
-  // `norm_cpu` is used to decide which Tensors require which approximation
-  // based on their norm. This decision takes place on CPU.
-  // It requires moving data back and forth between devices when `a` is on CUDA,
-  // but at the cost of only one sigle CPU-CUDA synchronization (instead of 6),
+
+  // `norm_small_to_cpu` is used to decide which Tensors require which
+  // approximation based on their norm. This decision may take place on CPU.
+  // It could require moving data back and forth between devices when `a` is on CUDA,
+  // but at the cost of only one single CPU-CUDA synchronization (instead of 6),
   // and better performance overall (benchmarked).
-  const auto norm_cpu = (a.device().type() == at::kCUDA)
-    ? norm.to(at::kCPU) : norm;
+  // For large batch size, the cost of the above decision on CPU will be quite 
+  // expensive (compared to the synchronization overhead from GPU to CPU), so
+  // here we have a threshold to determine whether or not to move norm to CPU.
+  const auto norm_small_to_cpu = ((a.device().type() == at::kCUDA) 
+    && a.size(0) >= large_batch_threshold) ? norm.to(at::kCPU) : norm;
 
   if (!compute_highest_degree_approx) {
     constexpr std::array<
@@ -2596,7 +2600,7 @@ Tensor mexp_impl(
       auto norm_upper_bound = thetas[i];
       // nonzero returns a 2D tensor, hence squeeze(-1) to make it 1D
       auto idx_curr_norm_interval = (
-        (norm_lower_bound < norm_cpu) * (norm_cpu <= norm_upper_bound)
+        (norm_lower_bound < norm_small_to_cpu) * (norm_small_to_cpu <= norm_upper_bound)
       ).nonzero().squeeze(-1);
 
       if (idx_curr_norm_interval.numel()) {
@@ -2609,7 +2613,7 @@ Tensor mexp_impl(
     }
 
     // nonzero returns a 2D tensor, hence squeeze(-1) to make it 1D
-    auto idx_large_norm = (norm_cpu >= thetas[total_n_degs - 2])
+    auto idx_large_norm = (norm_small_to_cpu >= thetas[total_n_degs - 2])
       .nonzero().squeeze(-1);
 
     if (idx_large_norm.numel()) {

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2645,7 +2645,7 @@ Tensor mexp_impl(
         a_large_norm,
         large_norm_subset,
         thetas[total_n_degs - 1]
-      );
+      ).to(res.dtype());
       res.index_put_({idx_large_norm}, mexp_out);
     }
     return res;

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2181,8 +2181,7 @@ Tensor operator_1_norm(const Tensor& tensor) {
 // of shape [n_copies, a.size()]
 Tensor _allocate_buffer(const Tensor& a, int n_copies, bool is_zero = false) {
   auto res = at::empty(
-    {n_copies, a.size(0), a.size(1), a.size(2)},
-    a.options().memory_format(at::MemoryFormat::Contiguous)
+    {n_copies, a.size(0), a.size(1), a.size(2)}
   );
 
   if (is_zero) {
@@ -2646,7 +2645,7 @@ Tensor mexp_impl(
         a_large_norm,
         large_norm_subset,
         thetas[total_n_degs - 1]
-      ).to(a.dtype());
+      );
       res.index_put_({idx_large_norm}, mexp_out);
     }
     return res;

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2181,7 +2181,8 @@ Tensor operator_1_norm(const Tensor& tensor) {
 // of shape [n_copies, a.size()]
 Tensor _allocate_buffer(const Tensor& a, int n_copies, bool is_zero = false) {
   auto res = at::empty(
-    {n_copies, a.size(0), a.size(1), a.size(2)}
+    {n_copies, a.size(0), a.size(1), a.size(2)},
+    a.options().memory_format(at::MemoryFormat::Contiguous)
   );
 
   if (is_zero) {

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -813,6 +813,7 @@ meta_dispatch_expected_failures = {
 
 # these sometimes pass and sometimes fail
 meta_dispatch_skips = {
+    aten.linalg_matrix_exp.default : {f32},
     aten.index.Tensor: {i64, bf16, f16, u8, b8, f32, i8, f64, i16, i32, c32, c64, c128},  # at::nonzero doesn't have a Meta function
     aten._to_copy.default: {i64, bf16, f16, u8, b8, f32, i8, f64, i16, i32, c32, c64, c128},
     aten.empty.memory_format: {b8, bf16, c128, c64, c32, f16, f32, f64, i16, i32, i64, i8, u8},

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -813,7 +813,6 @@ meta_dispatch_expected_failures = {
 
 # these sometimes pass and sometimes fail
 meta_dispatch_skips = {
-    aten.linalg_matrix_exp.default : {f32},
     aten.index.Tensor: {i64, bf16, f16, u8, b8, f32, i8, f64, i16, i32, c32, c64, c128},  # at::nonzero doesn't have a Meta function
     aten._to_copy.default: {i64, bf16, f16, u8, b8, f32, i8, f64, i16, i32, c32, c64, c128},
     aten.empty.memory_format: {b8, bf16, c128, c64, c32, f16, f32, f64, i16, i32, i64, i8, u8},

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -170,7 +170,7 @@ def linalg_cross(self, other, *, dim=-1):
 @out_wrapper()
 def linalg_matrix_exp(self):
     squareCheckInputs(self, "linalg.matrix_exp")
-    checkFloatingOrComplex(self, "matrix_exp")
+    checkFloatingOrComplex(self, "linalg.matrix_exp")
     return torch.empty_like(self)
 
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -171,7 +171,7 @@ def linalg_cross(self, other, *, dim=-1):
 def linalg_matrix_exp(self):
     squareCheckInputs(self, "linalg.matrix_exp")
     checkFloatingOrComplex(self, "linalg.matrix_exp")
-    return torch.empty_like(self)
+    return torch.empty_like(self, memory_format=torch.contiguous_format)
 
 
 @register_meta(


### PR DESCRIPTION
Fixes #105225

- New implementation for `compute_T18_scale_square` method.
- Always use the new highest degree algo for large batch sizes (size > 1).


cc @jianyuh @nikitaved @pearu @mruberry @walterddr @xwang233 @Lezcano @JubilantJerry