### PR TITLE
[MPS] add complex_out to MPS backend

### DIFF
--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -11,12 +11,12 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
+#include <ATen/ops/complex_native.h>
 #include <ATen/ops/maximum.h>
 #include <ATen/ops/minimum.h>
 #include <ATen/ops/nextafter_native.h>
 #include <ATen/ops/polar_native.h>
 #include <ATen/ops/view_as_real.h>
-#include <ATen/ops/complex_native.h>
 #endif
 
 namespace at::native {

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -16,6 +16,7 @@
 #include <ATen/ops/nextafter_native.h>
 #include <ATen/ops/polar_native.h>
 #include <ATen/ops/view_as_real.h>
+#include <ATen/ops/complex_native.h>
 #endif
 
 namespace at::native {
@@ -185,10 +186,10 @@ REGISTER_COMPLEX_MUL_OP(half);
 
 template<typename T, typename U>
 kernel void nextafter_kernel(constant void  * input_       [[buffer(0)]],
-                      constant void  * other_       [[buffer(1)]],
-                      device   void  * out_         [[buffer(2)]],
-                      constant uint3 * offsets      [[buffer(3)]],
-                      uint tid [[thread_position_in_grid]]) {
+                             constant void  * other_       [[buffer(1)]],
+                             device   void  * out_         [[buffer(2)]],
+                             constant uint3 * offsets      [[buffer(3)]],
+                             uint tid [[thread_position_in_grid]]) {
   device   T* out   = (device   T*)((device uint8_t*)out_ + offsets[tid].x);
   constant T* input = (constant T*)((constant uint8_t*)input_ + offsets[tid].y);
   constant T* other = (constant T*)((constant uint8_t*)other_ + offsets[tid].z);
@@ -221,6 +222,33 @@ kernel void nextafter_kernel<DTYPE, UTYPE>(  \
 
 REGISTER_NEXTAFTER_OP(float, uint);
 REGISTER_NEXTAFTER_OP(half, ushort);
+
+template<typename T>
+kernel void complex_kernel(constant void  * real_       [[buffer(0)]],
+                           constant void  * imag_       [[buffer(1)]],
+                           device   void  * out_        [[buffer(2)]],
+                           constant uint3 * offsets     [[buffer(3)]],
+                           uint tid [[thread_position_in_grid]]) {
+  device   T* out  = (device   T*)((device uint8_t*)out_ + offsets[tid].x);
+  constant T* real = (constant T*)((constant uint8_t*)real_ + offsets[tid].y);
+  constant T* imag = (constant T*)((constant uint8_t*)imag_ + offsets[tid].z);
+  out[0] = real[0];
+  out[1] = imag[0];
+}
+
+#define REGISTER_COMPLEX_OUT_OP(DTYPE)   \
+template                                 \
+[[host_name("complex_kernel_" #DTYPE)]]  \
+kernel void complex_kernel<DTYPE>(       \
+  constant void    * real,               \
+  constant void    * imag,               \
+  device   void    * out,                \
+  constant uint3   * offsets,            \
+  uint tid)
+
+REGISTER_COMPLEX_OUT_OP(float);
+REGISTER_COMPLEX_OUT_OP(half);
+
 )BINARY_METAL";
 
 using namespace mps;
@@ -399,6 +427,22 @@ Tensor& polar_out_mps(const Tensor& abs, const Tensor& angle, Tensor& output) {
   auto iter = TensorIteratorConfig().add_output(output_as_real).add_input(abs).add_input(angle).build();
 
   mps::binary_mps_impl(iter, "polar");
+  return output;
+}
+
+Tensor& complex_out_mps(const Tensor& real, const Tensor& imag, Tensor& output) {
+  auto new_size = at::infer_size(real.sizes(), imag.sizes());
+  if (!output.sizes().equals(new_size)) {
+    output.resize_(new_size);
+  }
+  uint32_t length = output.numel();
+  if (length == 0) {
+    return output;
+  }
+  auto output_as_real = at::view_as_real(output).select(output.dim(), 0);
+  auto iter = TensorIteratorConfig().add_output(output_as_real).add_input(real).add_input(imag).build();
+
+  mps::binary_mps_impl(iter, "complex_kernel");
   return output;
 }
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1591,6 +1591,7 @@
 - func: complex.out(Tensor real, Tensor imag, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU, CUDA: complex_out
+    MPS: complex_out_mps
 
 - func: polar(Tensor abs, Tensor angle) -> Tensor
   variants: function

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -658,7 +658,6 @@ def mps_ops_modifier(ops):
         'bfloat16': None,
         'cdouble': None,
         'cfloat': None,
-        'complex': None,
         'double': None,
         'chalf': None,
         'nn.functional.softminwith_dtype': None,


### PR DESCRIPTION
Adds support for at::complex_out to the MPS backend

Implemented in a binary kernel using the view_as_real pattern for handling complex dtypes in the mps backend.