### PR TITLE
Allow specifiying inputs as GradientEdge in autograd APIs

### DIFF
--- a/docs/source/autograd.rst
+++ b/docs/source/autograd.rst
@@ -317,6 +317,11 @@ Also see :ref:`saved-tensors-hooks-doc`.
 
 .. autoclass:: torch.autograd.graph.allow_mutation_on_saved_tensors
 
+.. autoclass:: torch.autograd.graph.GradientEdge
+
+.. autofunction:: torch.autograd.graph.get_gradient_edge
+
+
 
 .. This module needs to be documented. Adding here in the meantime
 .. for tracking purposes

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -534,6 +534,7 @@ known_failing_tests = {
     "test_select_sum",  # torch.autograd.gradcheck.GradcheckError: While computing batched gradients
     "test_unrelated_inputs",  # torch.autograd.gradcheck.GradcheckError: While computing batched gradients
     "test_will_engine_execute_node",  # RuntimeError: specifying inputs= with .backward() not yet implemented for compiled autograd
+    "test_backward_to_node", # RuntimeError: specifying inputs= with .backward() not yet implemented for compiled autograd
 }
 
 if not HAS_CUDA:

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -534,7 +534,7 @@ known_failing_tests = {
     "test_select_sum",  # torch.autograd.gradcheck.GradcheckError: While computing batched gradients
     "test_unrelated_inputs",  # torch.autograd.gradcheck.GradcheckError: While computing batched gradients
     "test_will_engine_execute_node",  # RuntimeError: specifying inputs= with .backward() not yet implemented for compiled autograd
-    "test_backward_to_node", # RuntimeError: specifying inputs= with .backward() not yet implemented for compiled autograd
+    "test_backward_to_node",  # RuntimeError: specifying inputs= with .backward() not yet implemented for compiled autograd
 }
 
 if not HAS_CUDA:

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -37,6 +37,8 @@ from torch.testing._internal.common_utils import (
 from torch.autograd import Variable, Function, detect_anomaly, kineto_available, _calculate_shape
 from torch.autograd.function import InplaceFunction
 import torch.autograd.forward_ad as fwAD
+from torch.autograd.graph import GradientEdge
+import torch.autograd._functions
 from torch.testing._internal.common_methods_invocations import mask_not_all_zeros
 from torch.testing._internal.common_device_type import (instantiate_device_type_tests,
                                                         onlyCPU, onlyCUDA, dtypes, dtypesIfCUDA,
@@ -797,6 +799,73 @@ class TestAutograd(TestCase):
             self.assertEqual(str(error), "Mismatch in shape: grad_output[0] has a shape of "
                              + str(grad_out.shape) + " and output[0] has a shape of "
                              + str(grad_sum.shape) + ".")
+
+    def test_grad_to_node(self):
+        def check_matches(out, inp):
+            ref = torch.autograd.grad(out.sum(), inp)
+
+            grad_fn = inp.grad_fn if inp.grad_fn else inp.clone().grad_fn.next_functions[0][0]
+            edge = torch.autograd.graph.GradientEdge(grad_fn, inp.output_nr)
+
+            new = torch.autograd.grad(out.sum(), edge)
+            self.assertEqual(ref, new)
+
+        # We need to ensure that our main types of Node work (regular cpp Nodes,
+        # AccumulateGrad Nodes and custom Function)
+        x = torch.rand(2, requires_grad=True)
+        out = x.clone()
+        check_matches(out, x)
+
+        x = x.clone()
+        out = x.clone()
+        check_matches(out, x)
+
+        x = torch.autograd._functions.Resize.apply(x, (2,))
+        out = x.clone()
+        check_matches(out, x)
+
+    def test_grad_to_node_multi(self):
+        x = torch.rand(2, requires_grad=True).clone()
+        y = torch.rand(2, requires_grad=True).clone()
+
+        out = x + y
+
+        ref = torch.autograd.grad(out.sum(), (x, y))
+
+        inp_edges = (GradientEdge(x.grad_fn, x.output_nr), GradientEdge(y.grad_fn, y.output_nr))
+        new = torch.autograd.grad(out.sum(), inp_edges)
+
+        self.assertEqual(ref, new)
+
+    def test_grad_to_node_materialize(self):
+        x = torch.rand(2, requires_grad=True).clone()
+        edge_x = GradientEdge(x.grad_fn, x.output_nr)
+        y = torch.rand(2, requires_grad=True).clone()
+        edge_y = GradientEdge(y.grad_fn, y.output_nr)
+
+        out = x.clone()
+
+        # Works
+        torch.autograd.grad(out.sum(), (edge_x, y), allow_unused=True, materialize_grads=True)
+        torch.autograd.grad(out.sum(), (x, y), allow_unused=True, materialize_grads=True)
+        torch.autograd.grad(out.sum(), (x, edge_y), allow_unused=True)
+
+        with self.assertRaisesRegex(RuntimeError, "materialize_grads cannot be used when the given input is a GradientEdge"):
+            torch.autograd.grad(out.sum(), (x, edge_y), allow_unused=True, materialize_grads=True)
+
+    def test_backward_to_node(self):
+        x = torch.rand(2, requires_grad=True).clone()
+        edge_x = GradientEdge(x.grad_fn, x.output_nr)
+        y = torch.rand(2, requires_grad=True).clone()
+        edge_y = GradientEdge(y.grad_fn, y.output_nr)
+
+        out = x.clone()
+
+        # All should work in this case
+        torch.autograd.backward(out.sum(), inputs=(edge_x, y))
+        torch.autograd.backward(out.sum(), inputs=(x, y))
+        torch.autograd.backward(out.sum(), inputs=(x, edge_y))
+        torch.autograd.backward(out.sum(), inputs=(edge_x, edge_y))
 
     def test_grad_nonleaf(self):
         x_init = torch.randn(2, 2, requires_grad=True)

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, cast, List, Optional, Sequence, Tuple, Union
 
 import torch
 
-from torch.types import _size, _TensorOrTensors
+from torch.types import _size, _TensorOrTensors, _TensorOrTensorsOrGradEdge
 from .. import _vmap_internals
 from ..overrides import handle_torch_function, has_torch_function, is_tensor_like
 from . import forward_ad, functional, graph
@@ -152,7 +152,7 @@ def backward(
     retain_graph: Optional[bool] = None,
     create_graph: bool = False,
     grad_variables: Optional[_TensorOrTensors] = None,
-    inputs: Optional[_TensorOrTensors] = None,
+    inputs: Optional[_TensorOrTensorsOrGradEdge] = None,
 ) -> None:
     r"""Computes the sum of gradients of given tensors with respect to graph
     leaves.
@@ -206,7 +206,7 @@ def backward(
         create_graph (bool, optional): If ``True``, graph of the derivative will
             be constructed, allowing to compute higher order derivative products.
             Defaults to ``False``.
-        inputs (Sequence[Tensor] or Tensor, optional): Inputs w.r.t. which the gradient
+        inputs (Sequence[Tensor] or Tensor or Sequence[GradientEdge], optional): Inputs w.r.t. which the gradient
             be will accumulated into ``.grad``. All other Tensors will be ignored. If
             not provided, the gradient is accumulated into all the leaf Tensors that
             were used to compute the attr::tensors.
@@ -234,7 +234,7 @@ def backward(
     tensors = (tensors,) if isinstance(tensors, torch.Tensor) else tuple(tensors)
     inputs = (
         (inputs,)
-        if isinstance(inputs, torch.Tensor)
+        if isinstance(inputs, (torch.Tensor, graph.GradientEdge))
         else tuple(inputs)
         if inputs is not None
         else tuple()
@@ -261,7 +261,7 @@ def backward(
 
 def grad(
     outputs: _TensorOrTensors,
-    inputs: _TensorOrTensors,
+    inputs: _TensorOrTensorsOrGradEdge,
     grad_outputs: Optional[_TensorOrTensors] = None,
     retain_graph: Optional[bool] = None,
     create_graph: bool = False,
@@ -292,7 +292,7 @@ def grad(
 
     Args:
         outputs (sequence of Tensor): outputs of the differentiated function.
-        inputs (sequence of Tensor): Inputs w.r.t. which the gradient will be
+        inputs (sequence of Tensor or GradientEdge): Inputs w.r.t. which the gradient will be
             returned (and not accumulated into ``.grad``).
         grad_outputs (sequence of Tensor): The "vector" in the vector-Jacobian product.
             Usually gradients w.r.t. each output. None values can be specified for scalar
@@ -337,16 +337,16 @@ def grad(
         Tuple[torch.Tensor, ...],
         (outputs,) if is_tensor_like(outputs) else tuple(outputs),
     )
-    t_inputs = cast(
-        Tuple[torch.Tensor, ...], (inputs,) if is_tensor_like(inputs) else tuple(inputs)
-    )
+    if is_tensor_like(inputs) or isinstance(inputs, graph.GradientEdge):
+        inputs = cast(_TensorOrTensorsOrGradEdge, (inputs,))
+    t_inputs = tuple(i for i in inputs if is_tensor_like(i))
     overridable_args = t_outputs + t_inputs
     if has_torch_function(overridable_args):
         return handle_torch_function(
             grad,
             overridable_args,
             t_outputs,
-            t_inputs,
+            inputs,
             grad_outputs=grad_outputs,
             retain_graph=retain_graph,
             create_graph=create_graph,
@@ -382,7 +382,7 @@ def grad(
                 gO,
                 retain_graph,
                 create_graph,
-                t_inputs,
+                inputs,
                 allow_unused,
                 accumulate_grad=False,
             )  # Calls into the C++ engine to run the backward pass
@@ -396,16 +396,23 @@ def grad(
             grad_outputs_,
             retain_graph,
             create_graph,
-            t_inputs,
+            inputs,
             allow_unused,
             accumulate_grad=False,
         )  # Calls into the C++ engine to run the backward pass
     if materialize_grads:
+        if any(
+            result[i] is None and not is_tensor_like(inputs[i])
+            for i in range(len(inputs))
+        ):
+            raise RuntimeError(
+                "materialize_grads cannot be used when the given input is a GradientEdge"
+            )
         result = tuple(
             output
             if output is not None
             else torch.zeros_like(input, requires_grad=True)
-            for (output, input) in zip(result, t_inputs)
+            for (output, input) in zip(result, inputs)
         )
     return result
 

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -339,6 +339,8 @@ def grad(
     )
     if is_tensor_like(inputs) or isinstance(inputs, graph.GradientEdge):
         inputs = cast(_TensorOrTensorsOrGradEdge, (inputs,))
+    else:
+        inputs = tuple(inputs)
     t_inputs = tuple(i for i in inputs if is_tensor_like(i))
     overridable_args = t_outputs + t_inputs
     if has_torch_function(overridable_args):

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -141,13 +141,16 @@ To get the gradient edge where a given Tensor gradient will be computed,
 you can do ``edge = autograd.graph.get_gradient_edge(tensor)``.
 """
 
+
 def get_gradient_edge(tensor):
     """This function can be used to get the gradient edge where the gradient of
     the given Tensor will be computed. In particular, it is equivalent to call
     ``g = autograd.grad(loss, input)`` and ``g = autograd.grad(loss, get_gradient_edge(input))``.
     """
     if not tensor.requires_grad:
-        raise RuntimeError("It is not possible to get the gradient edge for a Tensor that does not require gradients")
+        raise RuntimeError(
+            "It is not possible to get the gradient edge for a Tensor that does not require gradients"
+        )
     grad_fn = tensor.grad_fn
     if grad_fn is None:
         # Do an op to force AccumulateGrad lazy creation and get it
@@ -156,6 +159,7 @@ def get_gradient_edge(tensor):
     # Note that output_nr default to 0 which is the right value
     # for the AccumulateGrad node.
     return GradientEdge(grad_fn, tensor.output_nr)
+
 
 def increment_version(tensor):
     """This function can be used to let autograd know that a given Tensor was modified

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -1,7 +1,7 @@
 import abc
 import contextlib
 import weakref
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple
 
 import torch
@@ -15,6 +15,7 @@ __all__ = [
     "register_multi_grad_hook",
     "allow_mutation_on_saved_tensors",
     "Node",
+    "GradientEdge",
     "increment_version",
 ]
 
@@ -131,6 +132,14 @@ class Node(abc.ABC):
             ) or issubclass(C, torch.autograd.function.BackwardCFunction):
                 return True
         return NotImplemented
+
+
+GradientEdge = namedtuple("GradientEdge", ("node output_nr"))
+GradientEdge.__doc__ = """\
+Object representing a given gradient edge within the autograd graph.
+To get the gradient edge where a given Tensor gradient will be computed,
+you can do ``edge = GradientEdge(t.grad_fn, t.output_nr)``.
+"""
 
 
 def increment_version(tensor):

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -16,6 +16,7 @@ __all__ = [
     "allow_mutation_on_saved_tensors",
     "Node",
     "GradientEdge",
+    "get_gradient_edge",
     "increment_version",
 ]
 

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -106,6 +106,14 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
   if (!THPFunctionClass)
     return nullptr;
 
+  // NOTE: "leaks" GradientEdge
+  auto autograd_graph_mod =
+      THPObjectPtr(PyImport_ImportModule("torch.autograd.graph"));
+  THPGradientEdgeClass =
+      PyObject_GetAttrString(autograd_graph_mod, "GradientEdge");
+  if (!THPGradientEdgeClass)
+    return nullptr;
+
   auto torch_C_module = THPObjectPtr(PyImport_ImportModule("torch._C"));
   if (!torch_C_module)
     return nullptr;

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -345,7 +345,7 @@ PyObject* THPEngine_run_backward(
       } else {
         THPUtils_assert(
             false,
-            "all inputs have to be Tensors or GradiendEdges, but got %s",
+            "all inputs have to be Tensors or GradientEdges, but got %s",
             THPUtils_typename(input));
       }
     }

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -11,6 +11,7 @@
 #include <torch/csrc/autograd/function.h>
 #include <torch/csrc/autograd/functions/basic_ops.h>
 #include <torch/csrc/autograd/python_anomaly_mode.h>
+#include <torch/csrc/autograd/python_cpp_function.h>
 #include <torch/csrc/autograd/python_function.h>
 #include <torch/csrc/autograd/python_saved_variable_hooks.h>
 #include <torch/csrc/utils/pybind.h>
@@ -289,41 +290,62 @@ PyObject* THPEngine_run_backward(
     output_edges.reserve(num_inputs);
     for (const auto i : c10::irange(num_inputs)) {
       PyObject* input = PyTuple_GET_ITEM(inputs, i);
-      THPUtils_assert(
-          THPVariable_Check(input),
-          "all inputs have to be Tensors, but got %s",
-          THPUtils_typename(input));
-      const auto& tensor = THPVariable_Unpack(input);
-      TORCH_CHECK(
-          !isBatchedTensor(tensor),
-          "torch.autograd.grad(outputs, inputs, grad_outputs) called inside ",
-          "torch.vmap. We do not support the case where any inputs are ",
-          "vmapped tensors (input ",
-          i,
-          " is being vmapped over). Please "
-          "call autograd.grad() outside torch.vmap or file a bug report "
-          "with your use case.")
-      const auto output_nr = tensor.output_nr();
-      auto grad_fn = tensor.grad_fn();
-      if (!grad_fn) {
-        grad_fn = torch::autograd::impl::try_get_grad_accumulator(tensor);
-      }
-      if (accumulate_grad) {
-        tensor.retain_grad();
-      }
-      THPUtils_assert(
-          tensor.requires_grad(),
-          "One of the differentiated Tensors does not require grad");
-      if (!grad_fn) {
-        // NOTE [ Autograd Unreachable Input ]
-        // Since input has no grad_accumulator, its guaranteed to be
-        // unreachable. We initialize an edge pointing to a non-nullptr Node so
-        // nodes in the graph (e.g., mul when an operand is scalar) that have
-        // edges pointing to nullptr don't get erroneously assigned `needed =
-        // True` in exec_info.
-        output_edges.emplace_back(std::make_shared<Identity>(), 0);
+      if (THPVariable_Check(input)) {
+        const auto& tensor = THPVariable_Unpack(input);
+        TORCH_CHECK(
+            !isBatchedTensor(tensor),
+            "torch.autograd.grad(outputs, inputs, grad_outputs) called inside ",
+            "torch.vmap. We do not support the case where any inputs are ",
+            "vmapped tensors (input ",
+            i,
+            " is being vmapped over). Please "
+            "call autograd.grad() outside torch.vmap or file a bug report "
+            "with your use case.")
+        const auto output_nr = tensor.output_nr();
+        auto grad_fn = tensor.grad_fn();
+        if (!grad_fn) {
+          grad_fn = torch::autograd::impl::try_get_grad_accumulator(tensor);
+        }
+        if (accumulate_grad) {
+          tensor.retain_grad();
+        }
+        THPUtils_assert(
+            tensor.requires_grad(),
+            "One of the differentiated Tensors does not require grad");
+        if (!grad_fn) {
+          // NOTE [ Autograd Unreachable Input ]
+          // Since input has no grad_accumulator, its guaranteed to be
+          // unreachable. We initialize an edge pointing to a non-nullptr Node
+          // so nodes in the graph (e.g., mul when an operand is scalar) that
+          // have edges pointing to nullptr don't get erroneously assigned
+          // `needed = True` in exec_info.
+          output_edges.emplace_back(std::make_shared<Identity>(), 0);
+        } else {
+          output_edges.emplace_back(grad_fn, output_nr);
+        }
+      } else if (PyObject_IsInstance(input, THPGradientEdgeClass)) {
+        auto node = PyTuple_GetItem(input, 0);
+        bool isTHPFunction = THPFunction_Check(node);
+        bool isTHPCppFunction = THPCppFunction_Check(node);
+        THPUtils_assert(
+            isTHPFunction || isTHPCppFunction,
+            "GradientEdge first object must be an autograd.graph.Node "
+            "but got %s",
+            THPUtils_typename(node));
+        std::shared_ptr<torch::autograd::Node> node_sp;
+        if (isTHPFunction) {
+          node_sp = ((THPFunction*)node)->cdata.lock();
+        } else {
+          node_sp = ((torch::autograd::THPCppFunction*)node)->cdata;
+        }
+
+        auto output_nr = THPUtils_unpackUInt32(PyTuple_GetItem(input, 1));
+        output_edges.emplace_back(node_sp, output_nr);
       } else {
-        output_edges.emplace_back(grad_fn, output_nr);
+        THPUtils_assert(
+            false,
+            "all inputs have to be Tensors or GradiendEdges, but got %s",
+            THPUtils_typename(input));
       }
     }
   }

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -286,7 +286,8 @@ PyObject* THPEngine_run_backward(
 
   std::vector<Edge> output_edges;
   if (inputs != nullptr) {
-    TORCH_CHECK(PyTuple_CheckExact(inputs), "inputs to run_backward must be a tuple");
+    TORCH_CHECK(
+        PyTuple_CheckExact(inputs), "inputs to run_backward must be a tuple");
     int num_inputs = PyTuple_GET_SIZE(inputs);
     output_edges.reserve(num_inputs);
     for (const auto i : c10::irange(num_inputs)) {

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -286,6 +286,7 @@ PyObject* THPEngine_run_backward(
 
   std::vector<Edge> output_edges;
   if (inputs != nullptr) {
+    TORCH_CHECK(PyTuple_CheckExact(inputs), "inputs to run_backward must be a tuple");
     int num_inputs = PyTuple_GET_SIZE(inputs);
     output_edges.reserve(num_inputs);
     for (const auto i : c10::irange(num_inputs)) {

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -45,6 +45,7 @@ using namespace torch::autograd;
 using at::Tensor;
 
 PyObject* THPFunctionClass = nullptr;
+PyObject* THPGradientEdgeClass = nullptr;
 
 #define THPFunction_assert(condition, ...) \
   if (!(condition)) {                      \

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -135,6 +135,7 @@ struct THPFunction {
 bool THPFunction_initModule(PyObject* module);
 extern PyTypeObject THPFunctionType;
 extern PyObject* THPFunctionClass;
+extern PyObject* THPGradientEdgeClass;
 
 inline bool THPFunction_Check(PyObject* obj) {
   return PyObject_IsInstance(obj, (PyObject*)&THPFunctionType);

--- a/torch/types.py
+++ b/torch/types.py
@@ -7,6 +7,10 @@ import builtins
 # to talk about in PyTorch
 
 _TensorOrTensors = Union[torch.Tensor, Sequence[torch.Tensor]]
+_TensorOrTensorsOrGradEdge = Union[
+    torch.Tensor, Sequence[torch.Tensor],
+    "torch.autograd.graph.GradientEdge",
+    Sequence["torch.autograd.graph.GradientEdge"]]
 
 # In some cases, these basic types are shadowed by corresponding
 # top-level values.  The underscore variants let us refer to these


### PR DESCRIPTION
This can be useful for advanced users (like AOTAutograd) who don't want to keep the corresponding Tensor alive (for memory reasons for example) or when inplace op will change the Tensor's grad_fn (but gradients wrt to the original value is needed).

I went minimal API change but open to suggestions.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler