### PR TITLE
[torch op][xs] verbose error message for type mismatch in toList()

### DIFF
--- a/torch/csrc/jit/mobile/promoted_prim_ops.cpp
+++ b/torch/csrc/jit/mobile/promoted_prim_ops.cpp
@@ -180,7 +180,10 @@ void toList(Stack& stack) {
       (out_ty == at::FloatType::get() && t.is_floating_point()) ||
           (out_ty == at::ComplexType::get() && t.is_complex()) ||
           tryScalarTypeFromJitType(*out_ty) == t.scalar_type(),
-      "Output annotation element type and runtime tensor element type must match for tolist()");
+      "Output annotation element type and runtime tensor element type must match for tolist(): ",
+      *tryScalarTypeFromJitType(*out_ty),
+      " vs ",
+      t.scalar_type());
 
   // Check that the dimension of the Tensor matches that of the
   // annotation.


### PR DESCRIPTION
Summary:
Currently error message doesn't give you details on nature of mismatch:
  Output annotation element type and runtime tensor element type must match for tolist()

After update, error becomes actionable:
  RuntimeError: Output annotation element type and runtime tensor element type must match for tolist(): Long vs Int

Test Plan: existing unit tests

Reviewed By: iseeyuan

Differential Revision: D50082858


