### PR TITLE
[PyTorch] -DNDEBUG in inductor codecache builds

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -964,7 +964,7 @@ def cpp_wrapper_flags() -> str:
 
 
 def optimization_flags() -> str:
-    base_flags = "-O3 -ffast-math -fno-finite-math-only"
+    base_flags = "-O3 -DNDEBUG -ffast-math -fno-finite-math-only"
     if config.is_fbcode():
         # FIXME: passing `-fopenmp` adds libgomp.so to the generated shared library's dependencies.
         # This causes `ldopen` to fail in fbcode, because libgomp does not exist in the default paths.


### PR DESCRIPTION
Summary: Things like TORCH_INTERNAL_ASSERT_DEBUG_ONLY care about this!

Test Plan: builds. checked effect on internal benchmark, was neutral but it came up during development of code that hit debug-only asserts

Reviewed By: chenyang78

Differential Revision: D49972742




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler