### PR TITLE
[dtensor] make replicate -> partial do division instead

### DIFF
--- a/test/distributed/_tensor/test_redistribute.py
+++ b/test/distributed/_tensor/test_redistribute.py
@@ -116,7 +116,7 @@ class RedistributeTest(DTensorTestBase):
         # replicate to partial internally, and also partial to replicate
         # backward should work as expected
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
-        partial_local = torch.randn(12, 3, device=self.device_type, requires_grad=True)
+        partial_local = torch.ones(12, 3, device=self.device_type, requires_grad=True)
         partial_spec = [_Partial()]
         replica_spec = [Replicate()]
         # test partial -> replicate, which trigger all_reduce
@@ -131,8 +131,9 @@ class RedistributeTest(DTensorTestBase):
         # test backward to have replicate grad on partial
         global_partial_tensor.backward(torch.ones_like(global_partial_tensor))
         self.assertIsNotNone(partial_local.grad)
-        if device_mesh.get_rank() == 0:
-            self.assertEqual(partial_local.grad, torch.ones_like(partial_local))
+        self.assertEqual(
+            partial_local.grad, torch.ones_like(partial_local) / self.world_size
+        )
 
     @with_comms
     def test_replicate_to_partial(self):

--- a/torch/distributed/_tensor/redistribute.py
+++ b/torch/distributed/_tensor/redistribute.py
@@ -159,12 +159,9 @@ def redistribute_local_tensor(
 
         elif target.is_partial():
             if current.is_replicate():
-                # For replicate -> partial, we zero out all other ranks of the current mesh dim
-                # and leave only 1 rank have the data, to perform a "zero cost" reshard.
-                if my_coordinate[i] != 0:
-                    new_local_tensor = local_tensor.zero_()
-                else:
-                    new_local_tensor = local_tensor
+                # For replicate -> partial, we perform division to num of chunks and generate
+                # parial, and recover it back when pending sum get cleared.
+                new_local_tensor = local_tensor / num_chunks
             else:
                 raise RuntimeError(
                     f"redistribute from {current_placements} to {target_placements} not supported yet"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #110900
* __->__ #110898

This PR switches the replicate -> partial to do division instead of
zeroing out other ranks, it preserve same numerics, but avoid the
per-rank behavior difference, and friendly to torch compile