### PR TITLE
[C10D] Reduce default timeout from 30m to 10m

### DIFF
--- a/torch/csrc/distributed/c10d/Backend.hpp
+++ b/torch/csrc/distributed/c10d/Backend.hpp
@@ -17,7 +17,7 @@
 #include <torch/csrc/distributed/c10d/debug.h>
 
 constexpr auto kBackendDefaultTimeout =
-    std::chrono::milliseconds(30 * 60 * 1000);
+    std::chrono::milliseconds(10 * 60 * 1000);
 
 namespace c10d {
 

--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -22,7 +22,7 @@
 // *************************************************************************
 
 constexpr auto kProcessGroupDefaultTimeout =
-    std::chrono::milliseconds(30 * 60 * 1000);
+    std::chrono::milliseconds(10 * 60 * 1000);
 
 namespace c10d {
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #110910
* __->__ #110901

This timeout affects NCCL/Gloo/UCC backends (and potentially any other
backend depending on default options).

The 30 minute timeout is causing jobs to waste valuable cluster time.

It's not clear how low we can set the timeout.  In practice, collectives
generally are expected to complete in milliseconds or seconds, but
certain exceptional cases may exist.  This change is an attempt
to make a significant improvement in a low-risk way.

If you are a fringe use case and know that you expect/need a long
timeout, please consider explicitly overriding the default timeout
to a value appropriate to your application.