### PR TITLE
Merge kBackendDefaultTimeout into kProcessGroupDefaultTimeout

### DIFF
--- a/test/cpp/c10d/ProcessGroupNCCLTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLTest.cpp
@@ -22,7 +22,7 @@ class NCCLTestBase {
  public:
   NCCLTestBase(
       const std::string& path,
-      const std::chrono::milliseconds pgTimeout = kBackendDefaultTimeout)
+      const std::chrono::milliseconds pgTimeout = kProcessGroupDefaultTimeout)
       : path_(path), pgTimeout_(pgTimeout) {}
 
   NCCLTestBase(NCCLTestBase&& other) {
@@ -56,7 +56,7 @@ class NCCLTest : public NCCLTestBase {
   NCCLTest(
       const std::string& path,
       int worldSize,
-      std::chrono::milliseconds pgTimeout = kBackendDefaultTimeout,
+      std::chrono::milliseconds pgTimeout = kProcessGroupDefaultTimeout,
       int inputDim = 3)
       : NCCLTestBase(path, pgTimeout),
         numDevices_(cudaNumDevices()),
@@ -222,7 +222,7 @@ class AllreduceNCCLTest : public NCCLTest {
 class SparseAllreduceNCCLTest : public NCCLTest {
  public:
   SparseAllreduceNCCLTest(const std::string& path, int worldSize, int inputDim)
-      : NCCLTest(path, worldSize, kBackendDefaultTimeout, inputDim) {}
+      : NCCLTest(path, worldSize, kProcessGroupDefaultTimeout, inputDim) {}
 
   c10::intrusive_ptr<c10d::Work> run() {
     // For the duration of this function, make THC use our streams

--- a/torch/csrc/distributed/c10d/Backend.hpp
+++ b/torch/csrc/distributed/c10d/Backend.hpp
@@ -15,9 +15,7 @@
 #include <torch/csrc/distributed/c10d/Utils.hpp>
 #include <torch/csrc/distributed/c10d/Work.hpp>
 #include <torch/csrc/distributed/c10d/debug.h>
-
-constexpr auto kBackendDefaultTimeout =
-    std::chrono::milliseconds(10 * 60 * 1000);
+#include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
 
 namespace c10d {
 
@@ -30,7 +28,7 @@ class TORCH_API Backend : public torch::CustomClassHolder {
   struct TORCH_API Options : torch::CustomClassHolder {
     explicit Options(
         std::string backend,
-        std::chrono::milliseconds timeout = kBackendDefaultTimeout)
+        std::chrono::milliseconds timeout = kProcessGroupDefaultTimeout)
         : timeout(timeout), backend(std::move(backend)) {}
     ~Options() override = default;
 

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
@@ -228,11 +228,11 @@ class TORCH_API ProcessGroupGloo : public Backend {
 
   struct TORCH_API Options : public Backend::Options {
     explicit Options(
-        std::chrono::milliseconds timeout = kBackendDefaultTimeout);
+        std::chrono::milliseconds timeout = kProcessGroupDefaultTimeout);
 
     // return intrusive_ptr of the object
     static c10::intrusive_ptr<Options> create(
-        std::chrono::milliseconds timeout = kBackendDefaultTimeout) {
+        std::chrono::milliseconds timeout = kProcessGroupDefaultTimeout) {
       return c10::make_intrusive<Options>(timeout);
     }
 

--- a/torch/csrc/distributed/c10d/ProcessGroupUCC.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupUCC.hpp
@@ -153,7 +153,7 @@ class TORCH_API ProcessGroupUCC : public Backend {
       const c10::intrusive_ptr<Store>& store,
       int rank = -1,
       int size = -1,
-      std::chrono::duration<float> timeout = kBackendDefaultTimeout);
+      std::chrono::duration<float> timeout = kProcessGroupDefaultTimeout);
 
   void initComm(c10::Device dev);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110910
* #110901

These two timeout constants were set to the same value, but in two
different files.  There is no indication that they were kept separate
for intentional reasons, as backends are actually processgroups.