### PR TITLE
[inductor]: improve support for pow codegen to reciprocal powers of 2

### DIFF
--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -182,7 +182,7 @@ class ExprPrinterTests(TorchTestCase):
         ]
 
         gpu_cases = common_cases + [
-            (sympy.Pow(s1 + s2, 2), lambda c, L: "(bar + foo)*(bar + foo)")
+            (sympy.Pow(s1 + s2, 2), lambda c, L: "(bar + foo)*(bar + foo)"),
         ]
         cpu_cases = common_cases + [
             (
@@ -190,11 +190,23 @@ class ExprPrinterTests(TorchTestCase):
                 lambda c, L: "static_cast<long>((bar + foo)*(bar + foo))",
             )
         ]
+        sqrt_cases = [
+            (
+                sympy.Pow(s1 + s2, -0.5),
+                lambda c, _: f"{c}/math.sqrt(bar + foo)",
+            ),
+            (
+                sympy.Pow(s1 + s2, -0.25),
+                lambda c, _: f"{c}/math.sqrt(math.sqrt(bar + foo))",
+            ),
+        ]
         for expr, result in gpu_cases:
             self.assertEqual(texpr(expr), result(1, ""))
             self.assertEqual(pexpr(expr), result(1, ""))
         for expr, result in cpu_cases:
             self.assertEqual(cexpr(expr), result(1.0, "L"))  # 1.0 for FP div
+        for expr, result in sqrt_cases:
+            self.assertEqual(pexpr(expr), result(1, ""))
 
     def test_print_floor(self):
         for integer in [True, False]:

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -292,7 +292,7 @@ class ExprPrinter(Printer):
             # call nested sqrt
             if pow2.is_integer():
                 for _ in range(int(pow2)):
-                    base = self._helper_sqrt(base)   # type: ignore[attr-defined]
+                    base = self._helper_sqrt(base)  # type: ignore[attr-defined]
                 if exp > 0:
                     return base
                 if exp < 0:


### PR DESCRIPTION
fixes spda autocast fused attention codegen on my local (i.e. `test_autocast_sdpa_dynamic_shapes`)

Local compiled without flash attention nor mem-efficient attention


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @yanboliang 