### PR TITLE
[inductor][fx pass] Add new split cat pattern detection

### DIFF
--- a/test/inductor/test_split_cat_fx_passes.py
+++ b/test/inductor/test_split_cat_fx_passes.py
@@ -530,9 +530,9 @@ class TestSplitCatFxPasses(TestCase):
             expected_sections_removed,
             args,
         ) in [
-            (simple_split_cat, 0, 1, 0, 1, 7, default_args),
-            (simple_split_cat_argspec1, 0, 1, 0, 1, 7, default_args),
-            (simple_split_cat_argspec2, 0, 1, 0, 1, 7, default_args),
+            (simple_split_cat, 0, 0, 0, 0, 0, default_args),
+            (simple_split_cat_argspec1, 0, 0, 0, 0, 0, default_args),
+            (simple_split_cat_argspec2, 0, 0, 0, 0, 0, default_args),
             (simple_split_cat_argspec3, 0, 1, 0, 1, 7, default_args),
             (simple_split_cat_argspec4, 0, 1, 0, 1, 7, default_args),
             (simple_split_stack, 0, 1, 0, 1, 7, default_args),
@@ -871,6 +871,162 @@ class TestSplitCatFxPasses(TestCase):
             self.assertEqual(
                 counters["inductor"]["scmerge_split_sections_removed"],
                 expected_sections_removed,
+            )
+            counters.clear()
+
+    @patch
+    def test_getitem_cat_merge(self):
+        def split_cat_split(x):
+            l1_out = torch.split(x, [200, 50, 50, 20, 20, 20, 20, 20, 20, 50, 30], 1)
+            item0 = l1_out[0]
+            item1 = l1_out[1]
+            item2 = l1_out[2]
+            item3 = l1_out[3]
+            item4 = l1_out[4]
+            item5 = l1_out[5]
+            item6 = l1_out[6]
+            item7 = l1_out[7]
+            item8 = l1_out[8]
+            item9 = l1_out[9]
+            item10 = l1_out[10]
+            cat_1 = torch.cat((item0, item1), 1)
+            cat_2 = torch.cat((item9, item10), 1)
+            l2_out = torch.split(cat_1, [50, 120, 80], 1)
+            l3_out = torch.split(cat_2, [10, 20, 50], 1)
+            item11 = l2_out[0]
+            item12 = l2_out[1]
+            item13 = l2_out[2]
+            item14 = l3_out[0]
+            item15 = l3_out[1]
+            item16 = l3_out[2]
+
+            output = torch.cat(
+                [
+                    item11,
+                    item12,
+                    item13,
+                    item14,
+                    item15,
+                    item16,
+                    item2,
+                    item3,
+                    item4,
+                    item5,
+                    item6,
+                    item7,
+                    item8,
+                ],
+                1,
+            )
+            return output
+
+        def split_cat_split_kwarg(x):
+            l1_out = torch.split(
+                x, [200, 50, 50, 20, 20, 20, 20, 20, 20, 50, 30], dim=1
+            )
+            item0 = l1_out[0]
+            item1 = l1_out[1]
+            item2 = l1_out[2]
+            item3 = l1_out[3]
+            item4 = l1_out[4]
+            item5 = l1_out[5]
+            item6 = l1_out[6]
+            item7 = l1_out[7]
+            item8 = l1_out[8]
+            item9 = l1_out[9]
+            item10 = l1_out[10]
+            cat_1 = torch.cat((item0, item1), dim=1)
+            cat_2 = torch.cat((item9, item10), dim=1)
+            l2_out = torch.split(cat_1, [50, 120, 80], dim=1)
+            l3_out = torch.split(cat_2, [10, 20, 50], dim=1)
+            item11 = l2_out[0]
+            item12 = l2_out[1]
+            item13 = l2_out[2]
+            item14 = l3_out[0]
+            item15 = l3_out[1]
+            item16 = l3_out[2]
+
+            output = torch.cat(
+                [
+                    item11,
+                    item12,
+                    item13,
+                    item14,
+                    item15,
+                    item16,
+                    item2,
+                    item3,
+                    item4,
+                    item5,
+                    item6,
+                    item7,
+                    item8,
+                ],
+                dim=1,
+            )
+            return output
+
+        def split_cat_split_with_multiple_users(x):
+            l1_out = torch.split(
+                x, [50, 50, 200, 20, 20, 20, 20, 20, 40, 10, 50], dim=0
+            )
+            item0 = l1_out[0]
+            item1 = l1_out[1]
+            item2 = l1_out[2]
+            item3 = l1_out[3]
+            item4 = l1_out[4]
+            item5 = l1_out[5]
+            item6 = l1_out[6]
+            item7 = l1_out[7]
+            item8 = l1_out[8]
+            item9 = l1_out[9]
+            item10 = l1_out[10]
+            cat_1 = torch.cat((item0, item1), dim=0)
+            cat_2 = torch.cat((item0, item10), dim=0)
+            l2_out = torch.split(cat_1, [20, 30, 50], dim=0)
+            l3_out = torch.split(cat_2, [10, 60, 30], dim=0)
+            item11 = l2_out[0]
+            item12 = l2_out[1]
+            item13 = l2_out[2]
+            item14 = l3_out[0]
+            item15 = l3_out[1]
+            item16 = l3_out[2]
+
+            output = torch.cat(
+                [
+                    item11,
+                    item12,
+                    item13,
+                    item14,
+                    item15,
+                    item16,
+                    item2,
+                    item3,
+                    item4,
+                    item5,
+                    item6,
+                    item7,
+                    item8,
+                ],
+                dim=0,
+            )
+            return output
+
+        args = [
+            torch.randn(500, 500),
+        ]
+        for fn, expected_getitem_cat_merged in [
+            (split_cat_split, 2),
+            (split_cat_split_kwarg, 2),
+            (split_cat_split_with_multiple_users, 0),
+        ]:
+            expected = fn(*args)
+            actual = torch.compile(fn)(*args)
+
+            torch.testing.assert_close(actual, expected)
+            self.assertEqual(
+                counters["inductor"]["getitem_cat_merged"],
+                expected_getitem_cat_merged,
             )
             counters.clear()
 

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -31,9 +31,11 @@ merge_splits_pass = PatternMatcherPass(prevent_match_across_mutations=True)
 split_cat_pass = PatternMatcherPass(prevent_match_across_mutations=True)
 unbind_stack_pass = PatternMatcherPass(prevent_match_across_mutations=True)
 efficient_conv_bn_eval_pass = PatternMatcherPass(prevent_match_across_mutations=True)
+merge_getitem_cat_pass = PatternMatcherPass(prevent_match_across_mutations=True)
 
 pattern_matcher_passes: List[PatternMatcherPass] = [
     normalization_pass,
+    merge_getitem_cat_pass,
     merge_splits_pass,
     split_cat_pass,
     unbind_stack_pass,

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -27,6 +27,7 @@ from ..pattern_matcher import (
     RepeatedExpr,
 )
 from .pre_grad import (
+    merge_getitem_cat_pass,
     merge_splits_pass,
     normalization_pass,
     split_cat_pass,
@@ -1002,3 +1003,134 @@ def simplify_split_cat(match: Match, split_sections: List[int], dim: int):
         return
     split_node = next(node for node in match.nodes if node.target == torch.split)
     SplitCatSimplifier().simplify(match.graph, split_node, split_sections)
+
+
+# noqa: W605
+# ############The pattern to be optimized is#########
+
+#                 split_node(dim=1)
+#       /     \         ...       /         \
+# getitem    getitem          getitem     getitem   -> user=1
+#    \       /                     \       /
+#      cat (user=mul, dim=1)           cat(user=mul, dim=1)
+#       |            \                   |          \
+
+# ################After transformation#############
+
+#                 split_node(dim=1)
+#       /              ...                  \
+#     getitem                             getitem
+#     |    \                              |     \
+
+
+def safe_to_abort_node(node: torch.fx.Node):
+    """
+    1. the input nodes of the node should come from the same parent
+    2. the user of all the input nodes should be only one
+    """
+    prev_node = None
+    for arg in node.args[0]:
+        if len(arg.users) != 1 or arg.target != operator.getitem:
+            return False
+        if prev_node is None:
+            prev_node = arg.args[0]
+        else:
+            if arg.args[0] != prev_node:
+                return False
+    return True
+
+
+def remove_zeros(split_sections: List[int]):
+    """
+    Remove zeros from the list and get the index mapping dict from getitem
+    in split node to getitem in new split node
+    """
+    new_split_sections, index_mapping = [], {}
+    idx = 0
+    for i in range(len(split_sections)):
+        if split_sections[i] > 0:
+            new_split_sections.append(split_sections[i])
+            index_mapping[i] = idx
+            idx += 1
+
+    return new_split_sections, index_mapping
+
+
+@register_graph_pattern(
+    CallFunction(
+        torch.cat,
+        getitem_split,
+        dim=Ignored(),
+        _users=MULTIPLE,
+    ),
+    pass_dict=merge_getitem_cat_pass,
+    extra_check=config_flag("split_cat_fx_passes"),
+)
+def merge_getitem_cat(match: Match, split_sections: List[int], dim: int):
+    if not isinstance(split_sections, (list, tuple)):  # Unnormalized split
+        return
+    graph = match.graph
+    split_node = next(node for node in match.nodes if node.target == torch.split)
+    split_input, split_size, split_dim = _get_split_args_default(split_node)
+    # if the cat and split have different dims, return
+    # Find the next users (i.e. users after the getitem)
+    next_users = find_next_users(split_node)
+    # 'immutable_list' object does not support mutation. Create a new copy of it
+    split_sections = list(split_sections)
+    for cat_user in next_users:
+        if cat_user.target == torch.cat:
+            cat_dim = get_arg_value(cat_user, 1, "dim")
+            if split_dim != cat_dim:
+                continue
+            # check the all getitems in the cat_user from the same node
+            if not safe_to_abort_node(cat_user):
+                continue
+            # find the index of getitems to be cated/stacked
+            indices = []
+            for arg in cat_user.args[0]:
+                indices.append(arg.args[1])
+            # update the arg of cat user, only keep the first getitem
+            cat_user.update_arg(0, cat_user.args[0][0])
+            # calculate the fused tensor sizes in the indices
+            fused_tensor_size = 0
+            for i in range(len(split_node.args[1])):
+                if i in indices:
+                    fused_tensor_size += split_node.args[1][i]
+            # update the split sections
+            split_sections[indices[0]] = fused_tensor_size
+            # padding others with zeros to keep the same dict size
+            for i in indices[1:]:
+                split_sections[i] = 0
+            # remove all unused indexes in the split_node
+            new_split_sections, index_mapping = remove_zeros(split_sections)
+            with graph.inserting_after(split_node):
+                new_split_node = graph.call_function(
+                    torch.split,
+                    args=(split_input, split_sections),
+                    kwargs={"dim": split_dim},
+                )
+                split_node.replace_all_uses_with(new_split_node)
+                new_split_node.meta.update(split_node.meta)
+                # remove all unused getitem nodes
+                to_remove = [cat_user]
+                # dictionary keys changed during iteration
+                new_split_getitem_nodes = list(new_split_node.users.keys())
+                for getitem_node in new_split_getitem_nodes:
+                    if getitem_node.args[1] in indices[1:]:
+                        to_remove.append(getitem_node)
+                    # update meta data of getitem
+                    elif getitem_node.args[1] == indices[0]:
+                        cat_user.replace_all_uses_with(getitem_node)
+                        getitem_node.meta.update(cat_user.meta)
+                    else:
+                        # update getitem index for new split node
+                        getitem_node.update_arg(1, index_mapping[getitem_node.args[1]])
+                graph.erase_node(split_node)
+                for getitem_node in to_remove:
+                    graph.erase_node(getitem_node)
+                # update the split sections of new split node
+                new_split_node.update_arg(1, new_split_sections)
+                split_node = new_split_node
+                split_sections = new_split_sections
+
+                counters["inductor"]["getitem_cat_merged"] += 1


### PR DESCRIPTION
Summary: We add a new pattern to merge getitem_cat to enable further split merges

Test Plan:
### test mcf model
Patch D49972740
```
buck2 run mode/opt //scripts/jackiexu0313/pt2:local_model_with_pt2 -- --test_mode split-only -c
```

P850153017

### unit test
```
buck2 test mode/dev-nosan //caffe2/test/inductor:split_cat_fx_passes -- test_getitem_cat_merge
```
Buck UI: https://www.internalfb.com/buck2/eb7411a5-a6bd-46bc-bf66-756341e3ce10
Test UI: https://www.internalfb.com/intern/testinfra/testrun/13792273864439068
Network: Up: 48KiB  Down: 15KiB  (reSessionID-39ca57cc-5743-423e-b94f-9d0f642010f8)
Jobs completed: 8. Time elapsed: 1:44.7s.
Cache hits: 0%. Commands: 2 (cached: 0, remote: 0, local: 2)
Tests finished: Pass 1. Fail 0. Fatal 0. Skip 0. Build failure 0

### before vs after transformation
https://www.internalfb.com/intern/diffing/?paste_number=847958889

Differential Revision: D50100667




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler