### PR TITLE
[2D] Enable 2D FSDP+TP model.load_state_dict()

### DIFF
--- a/torch/distributed/fsdp/_fsdp_extensions.py
+++ b/torch/distributed/fsdp/_fsdp_extensions.py
@@ -7,6 +7,7 @@ from torch.distributed._shard.sharded_tensor.api import ShardedTensor
 from torch.distributed._shard.sharded_tensor.shard import Shard
 from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.distributed.fsdp._shard_utils import (
+    _all_gather_dtensor,
     _create_chunk_dtensor,
     _create_chunk_sharded_tensor,
 )
@@ -67,6 +68,19 @@ class FSDPExtensions(ABC):
         """
         This is to be called before loading a *sharded* model state dict and
         should return the tensor and list of shards from which to load data.
+        """
+        ...
+
+    @abstractmethod
+    def all_gather_dtensor(
+        self,
+        tensor: torch.Tensor,
+        parent_mesh: DeviceMesh,
+    ) -> torch.Tensor:
+        """
+        This is to be called before loading a *sharded* DTensor state dict.
+        This gathers tensor in FSDP dimension and returns local tensor of
+        TP DTensor.
         """
         ...
 
@@ -143,3 +157,15 @@ def _ext_pre_load_state_dict_transform(
     assert type(tensor) is ShardedTensor
     shards = tensor.local_shards()
     return (tensor, shards)
+
+
+def _ext_all_gather_dtensor(
+    tensor: torch.Tensor,
+    parent_mesh: DeviceMesh,
+) -> torch.Tensor:
+    all_gather_dtensor_fn = (
+        _extensions.all_gather_dtensor
+        if _extensions is not None
+        else _all_gather_dtensor
+    )
+    return all_gather_dtensor_fn(tensor, parent_mesh)

--- a/torch/distributed/fsdp/_fsdp_extensions.py
+++ b/torch/distributed/fsdp/_fsdp_extensions.py
@@ -5,7 +5,7 @@ import torch
 import torch.distributed as dist
 from torch.distributed._shard.sharded_tensor.api import ShardedTensor
 from torch.distributed._shard.sharded_tensor.shard import Shard
-from torch.distributed._tensor.device_mesh import DeviceMesh
+from torch.distributed._tensor import DeviceMesh, DTensor
 from torch.distributed.fsdp._shard_utils import (
     _all_gather_dtensor,
     _create_chunk_dtensor,
@@ -161,7 +161,7 @@ def _ext_pre_load_state_dict_transform(
 
 def _ext_all_gather_dtensor(
     tensor: torch.Tensor,
-    parent_mesh: DeviceMesh,
+    parent_mesh: Optional[DeviceMesh],
 ) -> torch.Tensor:
     all_gather_dtensor_fn = (
         _extensions.all_gather_dtensor

--- a/torch/distributed/fsdp/_fsdp_extensions.py
+++ b/torch/distributed/fsdp/_fsdp_extensions.py
@@ -75,7 +75,7 @@ class FSDPExtensions(ABC):
     def all_gather_dtensor(
         self,
         tensor: DTensor,
-        parent_mesh: DeviceMesh,
+        parent_mesh: Optional[DeviceMesh],
     ) -> torch.Tensor:
         """
         This is to be called before loading a *sharded* DTensor state dict.
@@ -160,7 +160,7 @@ def _ext_pre_load_state_dict_transform(
 
 
 def _ext_all_gather_dtensor(
-    tensor: torch.Tensor,
+    tensor: DTensor,
     parent_mesh: Optional[DeviceMesh],
 ) -> torch.Tensor:
     all_gather_dtensor_fn = (

--- a/torch/distributed/fsdp/_fsdp_extensions.py
+++ b/torch/distributed/fsdp/_fsdp_extensions.py
@@ -74,7 +74,7 @@ class FSDPExtensions(ABC):
     @abstractmethod
     def all_gather_dtensor(
         self,
-        tensor: torch.Tensor,
+        tensor: DTensor,
         parent_mesh: DeviceMesh,
     ) -> torch.Tensor:
         """

--- a/torch/distributed/fsdp/_shard_utils.py
+++ b/torch/distributed/fsdp/_shard_utils.py
@@ -190,3 +190,24 @@ def _create_chunk_dtensor(
         device_mesh=device_mesh,
         placements=shard_placements,
     )
+
+
+def _all_gather_dtensor(
+    tensor: DTensor,
+    parent_mesh: DeviceMesh,
+) -> torch.Tensor:
+    """
+    All gather a DTensor in its sharded dimension and return the local tensor.
+    """
+    assert parent_mesh is None
+
+    placements = list(copy.deepcopy(tensor.placements))
+    # FSDP placements: [Shard(0)] -> [Replicate()]
+    # HSDP placements: [Replicate(), Shard(0)] -> [Replicate(), Replicate()]
+    placements[-1] = Replicate()
+    tensor = tensor.redistribute(
+        device_mesh=tensor.device_mesh,
+        placements=placements,
+    )
+
+    return tensor.to_local()

--- a/torch/distributed/fsdp/_shard_utils.py
+++ b/torch/distributed/fsdp/_shard_utils.py
@@ -194,7 +194,7 @@ def _create_chunk_dtensor(
 
 def _all_gather_dtensor(
     tensor: DTensor,
-    parent_mesh: DeviceMesh,
+    parent_mesh: Optional[DeviceMesh],
 ) -> torch.Tensor:
     """
     All gather a DTensor in its sharded dimension and return the local tensor.

--- a/torch/distributed/tensor/parallel/fsdp.py
+++ b/torch/distributed/tensor/parallel/fsdp.py
@@ -293,6 +293,26 @@ def _pre_load_state_dict(
     return (tensor, shards if len(shards) > 0 else [])
 
 
+def _all_gather_dtensor(
+    tensor: DTensor,
+    parent_mesh: DeviceMesh,
+) -> DTensor:
+    """
+    All gather a DTensor in its FSDP dimension and return the local tensor.
+    """
+    assert parent_mesh == tensor.device_mesh
+
+    placements = list(copy.deepcopy(tensor.placements))
+    # FSDP + TP: [Shard(0), tp_placement] -> [Replicate(), tp_placement]
+    placements[0] = Replicate()
+    tensor = tensor.redistribute(
+        device_mesh=tensor.device_mesh,
+        placements=placements,
+    )
+
+    return tensor.to_local()
+
+
 class DTensorExtensions(FSDPExtensions):
     """
     DTensorExtension is the TensorFlattener extension needed for 2D FSDP + TP.
@@ -337,6 +357,13 @@ class DTensorExtensions(FSDPExtensions):
         tensor: torch.Tensor,
     ) -> Tuple[torch.Tensor, List[Shard]]:
         return _pre_load_state_dict(tensor)
+
+    def all_gather_dtensor(
+        self,
+        tensor: torch.Tensor,
+        parent_mesh: DeviceMesh,
+    ) -> torch.Tensor:
+        return _all_gather_dtensor(tensor, parent_mesh)
 
 
 # TODO: remove enable_2d_with_fsdp() once we roll out the new 2D flow.

--- a/torch/distributed/tensor/parallel/fsdp.py
+++ b/torch/distributed/tensor/parallel/fsdp.py
@@ -360,7 +360,7 @@ class DTensorExtensions(FSDPExtensions):
 
     def all_gather_dtensor(
         self,
-        tensor: torch.Tensor,
+        tensor: DTensor,
         parent_mesh: DeviceMesh,
     ) -> torch.Tensor:
         return _all_gather_dtensor(tensor, parent_mesh)

--- a/torch/distributed/tensor/parallel/fsdp.py
+++ b/torch/distributed/tensor/parallel/fsdp.py
@@ -295,7 +295,7 @@ def _pre_load_state_dict(
 
 def _all_gather_dtensor(
     tensor: DTensor,
-    parent_mesh: DeviceMesh,
+    parent_mesh: Optional[DeviceMesh],
 ) -> torch.Tensor:
     """
     All gather a DTensor in its FSDP dimension and return the local tensor.
@@ -361,7 +361,7 @@ class DTensorExtensions(FSDPExtensions):
     def all_gather_dtensor(
         self,
         tensor: DTensor,
-        parent_mesh: DeviceMesh,
+        parent_mesh: Optional[DeviceMesh],
     ) -> torch.Tensor:
         return _all_gather_dtensor(tensor, parent_mesh)
 

--- a/torch/distributed/tensor/parallel/fsdp.py
+++ b/torch/distributed/tensor/parallel/fsdp.py
@@ -296,7 +296,7 @@ def _pre_load_state_dict(
 def _all_gather_dtensor(
     tensor: DTensor,
     parent_mesh: DeviceMesh,
-) -> DTensor:
+) -> torch.Tensor:
     """
     All gather a DTensor in its FSDP dimension and return the local tensor.
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110925
* #110846
* #110831

This PR adds a all_gather_dtensor() method to fsdp/_fsdp_extensions.py and the actual implementation in tensor/parallel/fsdp.py. This enables FSDP to load 2D DTensor state_dict into model when calling `model.load_state_dict()`.

cc. @fegin 
