### PR TITLE
Expose CompPhoto library to Fbcode for Consumption by IQCloud Service

### DIFF
--- a/aten/src/ATen/core/dynamic_type.h
+++ b/aten/src/ATen/core/dynamic_type.h
@@ -58,16 +58,17 @@ constexpr DynamicTypeBits kDynamicClassTypeBit = DYNAMIC_TYPE_BIT(10);
   _(Future, DYNAMIC_TYPE_BIT(22), 0)                                         \
   _(Await, DYNAMIC_TYPE_BIT(23), 0)                                          \
   _(Any, 0xffffffff, 1)
+#undef Complex
 
-#define FORALL_DYNAMIC_TYPES_FAKE(_) \
-  _(ScalarType, kDynamicIntTypeBit, 1)                                \
-  _(Layout, kDynamicIntTypeBit, 1)                                        \
-  _(SymInt, kDynamicIntTypeBit, 1)                                        \
+#define FORALL_DYNAMIC_TYPES_FAKE(_)   \
+  _(ScalarType, kDynamicIntTypeBit, 1) \
+  _(Layout, kDynamicIntTypeBit, 1)     \
+  _(SymInt, kDynamicIntTypeBit, 1)     \
   _(MemoryFormat, kDynamicIntTypeBit, 1)
 
-#define FORWARD_DECL_TYPE(NAME, _, __) struct NAME ## Type;
-  FORALL_DYNAMIC_TYPES(FORWARD_DECL_TYPE)
-  FORALL_DYNAMIC_TYPES_FAKE(FORWARD_DECL_TYPE)
+#define FORWARD_DECL_TYPE(NAME, _, __) struct NAME##Type;
+FORALL_DYNAMIC_TYPES(FORWARD_DECL_TYPE)
+FORALL_DYNAMIC_TYPES_FAKE(FORWARD_DECL_TYPE)
 #undef FORWARD_DECL_TYPE
 
 class DynamicType;
@@ -144,7 +145,7 @@ class DynamicType : public SharedType {
   enum class Tag : DynamicTypeBits {
 #define DYNAMIC_TYPE_ITEM(NAME, VAL, _) NAME = VAL,
     FORALL_DYNAMIC_TYPES(DYNAMIC_TYPE_ITEM)
-    FORALL_DYNAMIC_TYPES_FAKE(DYNAMIC_TYPE_ITEM)
+        FORALL_DYNAMIC_TYPES_FAKE(DYNAMIC_TYPE_ITEM)
 #undef DYNAMIC_TYPE_ITEM
   };
 

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -74,6 +74,7 @@ namespace c10 {
   _(at::BFloat16, BFloat16)                                        \
   _(at::Float8_e5m2, Float8_e5m2)                                  \
   _(at::Float8_e4m3fn, Float8_e4m3fn)
+#undef Bool
 
 #define AT_FORALL_SCALAR_TYPES_WITH_COMPLEX(_) \
   _(uint8_t, Byte)                             \
@@ -91,6 +92,7 @@ namespace c10 {
   _(at::BFloat16, BFloat16)                    \
   _(at::Float8_e5m2, Float8_e5m2)              \
   _(at::Float8_e4m3fn, Float8_e4m3fn)
+#undef Bool
 
 enum class ScalarType : int8_t {
 #define DEFINE_ST_ENUM_VAL_(_1, n) n,


### PR DESCRIPTION
Summary:
Bacground:

For Photo processing on IQCloud service on Photo GraphNode, we want to expose CompPhoto SDK code in xplat to be available in fbcode.

I have exported all necessary CompPhoto dependencies to fbcode.

I had to handle conflict with global variable names for
Bool and Complex types between platform X11 and Caffe2 library. The #undef directive is used to make sure the conflict doesn't exist.

I was able to compile and build the following

buck2 build //xplat/compphoto/sdk/pipeline/graphs/stella/stella_background/image:StellaBackgroundImageProcessingGraphFbcode

Test Plan:
buck2 build //xplat/compphoto/sdk/pipeline/graphs/stella/stella_background/image:StellaBackgroundImageProcessingGraphFbcode

File changed: fbsource//xplat/caffe2/c10/core/ScalarType.h
File changed: fbcode//caffe2/c10/core/ScalarType.h
Buck UI: https://www.internalfb.com/buck2/da8ed23b-0735-4325-881c-796bb01b0ce4
Network: Up: 10MiB  Down: 511MiB  (reSessionID-1fda6d02-0545-4135-ba2d-57e5d55b5971)
Jobs completed: 4438. Time elapsed: 8:06.7s.
Cache hits: 1%. Commands: 2189 (cached: 25, remote: 2156, local: 8)
BUILD SUCCEEDED


********************

buck2 build //xplat/compphoto/sdk/pipeline/graphs/stella/stella_background/image:StellaBackgroundImageProcessingGraph
Buck UI: https://www.internalfb.com/buck2/191b4f4a-2bc7-436b-9d3b-d322bad5c6f5
Network: Up: 232KiB  Down: 416KiB  (reSessionID-3fb50098-a64d-4cf2-923f-375953beac6e)
Jobs completed: 12. Time elapsed: 19.9s.
Cache hits: 0%. Commands: 3 (cached: 0, remote: 0, local: 3)
BUILD SUCCEEDED

Differential Revision: D50036045


