### PR TITLE
[dynamo] add config for displaying all guard failures

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -258,6 +258,9 @@ error_on_recompile = False
 # causing recompilations.
 report_guard_failures = os.environ.get("TORCHDYNAMO_REPORT_GUARD_FAILURES") == "1"
 
+# Whether to report all guard failures or just the first one that fails
+report_all_guard_failures = False
+
 # root folder of the project
 base_dir = dirname(dirname(dirname(abspath(__file__))))
 

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -260,22 +260,20 @@ def convert_frame_assert(
             recompiles_log.isEnabledFor(logging.DEBUG) or config.error_on_recompile
         ):
             if is_guard_failure_reporting_enabled():
+                failures = str(guard_failures[code][-1])
                 if config.report_all_guard_failures:
-                    failures = str(guard_failures[code][-1]).strip().split("\n")
-                    message = (
-                        f"Recompiling function {code.co_name} in {code.co_filename}:{code.co_firstlineno}",
-                        f"triggered by the following guard failures: {failures}",
-                    )
-                else:
-                    message = (
-                        f"Recompiling function {code.co_name} in {code.co_filename}:{code.co_firstlineno}",
-                        f"triggered by the following guard failure: {str(guard_failures[code][-1])}",
-                    )
-            else:
-                message = (
-                    f"Recompiling function {code.co_name} in {code.co_filename}:{code.co_firstlineno}",
-                    "set env var TORCHDYNAMO_REPORT_GUARD_FAILURES=1 to debug further",
+                    failures = failures.strip().split("\n")  # type: ignore[assignment]
+                guard_failure_details = (
+                    f"triggered by the following guard failure(s): {failures}"
                 )
+            else:
+                guard_failure_details = (
+                    "set env var TORCHDYNAMO_REPORT_GUARD_FAILURES=1 to debug further"
+                )
+            message = (
+                f"Recompiling function {code.co_name} in {code.co_filename}:{code.co_firstlineno}",
+                guard_failure_details,
+            )
 
             if recompiles_log.isEnabledFor(logging.DEBUG):
                 recompiles_log.debug(message, stack_info=True)

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -260,10 +260,17 @@ def convert_frame_assert(
             recompiles_log.isEnabledFor(logging.DEBUG) or config.error_on_recompile
         ):
             if is_guard_failure_reporting_enabled():
-                message = (
-                    f"Recompiling function {code.co_name} in {code.co_filename}:{code.co_firstlineno}",
-                    f"triggered by the following guard failure: {str(guard_failures[code][-1])}",
-                )
+                if config.report_all_guard_failures:
+                    failures = str(guard_failures[code][-1]).strip().split("\n")
+                    message = (
+                        f"Recompiling function {code.co_name} in {code.co_filename}:{code.co_firstlineno}",
+                        f"triggered by the following guard failures: {failures}",
+                    )
+                else:
+                    message = (
+                        f"Recompiling function {code.co_name} in {code.co_filename}:{code.co_firstlineno}",
+                        f"triggered by the following guard failure: {str(guard_failures[code][-1])}",
+                    )
             else:
                 message = (
                     f"Recompiling function {code.co_name} in {code.co_filename}:{code.co_firstlineno}",

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -1331,7 +1331,7 @@ def guard_fail_hook(
     scope = {"L": f_locals, "G": guard_fn.global_scope["G"]}
     scope.update(guard_fn.closure_vars)
     scope["___check_tensors"] = scope["___check_tensors_verbose"]
-    reason = None
+    reason = ""
     for part in guard_fn.code_parts:
         global_scope = dict(guard_fn.global_scope)
         global_scope["__compile_source__"] = part
@@ -1339,12 +1339,15 @@ def guard_fail_hook(
             fail_reason = eval(part, global_scope, scope)
         # Only ___check_tensors knows how to return a fancy fail reason;
         # for everything else we just report the code that failed
+
+        if isinstance(fail_reason, bool) and not fail_reason:
+            fail_reason = part
         if isinstance(fail_reason, str):
-            reason = fail_reason
-            break
-        elif isinstance(fail_reason, bool) and not fail_reason:
-            reason = part
-            break
+            reason += fail_reason
+            if config.report_all_guard_failures:
+                reason += "\n"
+            else:
+                break
 
     if first:
         stashed_first_fail_reason = reason


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/110879

Example output:
```
('Recompiling function fn in /home/jonch/Desktop/Programming/mlsys/pytorch/test/dynamo/test_misc.py:4578', 'triggered by the following guard failures: ["___check_type_id(L[\'obj\'], 94834370481168)", "L[\'obj\'].x == -0.5"]')
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @yanboliang @Fidget-Spinner @anijain2305 @soulitzer @lezcano 