### PR TITLE
[FSDP][optim_state_dict] Move local optimizer state to FSDP compute_device

### DIFF
--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1372,6 +1372,9 @@ def _convert_all_state_info(
                     None for _ in fsdp_param_info.param_indices
                 ]
             local_state = input_states[fqn].get(state_name, None)
+            # N.B. We need to move the state to compute_device. The reason is
+            # not yet clear and we need to figure why the state may be on a
+            # different device.
             local_state = local_state.to(fsdp_param_info.state.compute_device)
             state_buffers[state_name][fsdp_param_info.param_indices[fqn]] = local_state
 

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1373,7 +1373,7 @@ def _convert_all_state_info(
                 ]
             local_state = input_states[fqn].get(state_name, None)
             # N.B. We need to move the state to compute_device. The reason is
-            # not yet clear and we need to figure why the state may be on a
+            # not yet clear and we need to figure out why the state may be on a
             # different device.
             if local_state is not None:
                 local_state = local_state.to(fsdp_param_info.state.compute_device)

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1372,6 +1372,7 @@ def _convert_all_state_info(
                     None for _ in fsdp_param_info.param_indices
                 ]
             local_state = input_states[fqn].get(state_name, None)
+            local_state = local_state.to(fsdp_param_info.state.compute_device)
             state_buffers[state_name][fsdp_param_info.param_indices[fqn]] = local_state
 
         # Restoring the scalar and non-tensor states. If the corresponding

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1375,7 +1375,8 @@ def _convert_all_state_info(
             # N.B. We need to move the state to compute_device. The reason is
             # not yet clear and we need to figure why the state may be on a
             # different device.
-            local_state = local_state.to(fsdp_param_info.state.compute_device)
+            if local_state is not None:
+                local_state = local_state.to(fsdp_param_info.state.compute_device)
             state_buffers[state_name][fsdp_param_info.param_indices[fqn]] = local_state
 
         # Restoring the scalar and non-tensor states. If the corresponding


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110929

This will ensure all the tensors are on FSDP compute_device.

Differential Revision: [D50059492](https://our.internmc.facebook.com/intern/diff/D50059492/)