### PR TITLE
Change ProcessGroupNCCL default timeout to 10 min

### DIFF
--- a/test/cpp/c10d/ProcessGroupNCCLTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLTest.cpp
@@ -23,7 +23,7 @@ class NCCLTestBase {
   NCCLTestBase(
       const std::string& path,
       const std::chrono::milliseconds pgTimeout =
-          kProcessGroupNCCLDefaultTimeout)
+          c10d::kProcessGroupNCCLDefaultTimeout)
       : path_(path), pgTimeout_(pgTimeout) {}
 
   NCCLTestBase(NCCLTestBase&& other) {
@@ -57,7 +57,8 @@ class NCCLTest : public NCCLTestBase {
   NCCLTest(
       const std::string& path,
       int worldSize,
-      std::chrono::milliseconds pgTimeout = kProcessGroupNCCLDefaultTimeout,
+      std::chrono::milliseconds pgTimeout =
+          c10d::kProcessGroupNCCLDefaultTimeout,
       int inputDim = 3)
       : NCCLTestBase(path, pgTimeout),
         numDevices_(cudaNumDevices()),
@@ -223,7 +224,11 @@ class AllreduceNCCLTest : public NCCLTest {
 class SparseAllreduceNCCLTest : public NCCLTest {
  public:
   SparseAllreduceNCCLTest(const std::string& path, int worldSize, int inputDim)
-      : NCCLTest(path, worldSize, kProcessGroupNCCLDefaultTimeout, inputDim) {}
+      : NCCLTest(
+            path,
+            worldSize,
+            c10d::kProcessGroupNCCLDefaultTimeout,
+            inputDim) {}
 
   c10::intrusive_ptr<c10d::Work> run() {
     // For the duration of this function, make THC use our streams

--- a/test/cpp/c10d/ProcessGroupNCCLTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLTest.cpp
@@ -22,7 +22,8 @@ class NCCLTestBase {
  public:
   NCCLTestBase(
       const std::string& path,
-      const std::chrono::milliseconds pgTimeout = kBackendDefaultTimeout)
+      const std::chrono::milliseconds pgTimeout =
+          kProcessGroupNCCLDefaultTimeout)
       : path_(path), pgTimeout_(pgTimeout) {}
 
   NCCLTestBase(NCCLTestBase&& other) {
@@ -56,7 +57,7 @@ class NCCLTest : public NCCLTestBase {
   NCCLTest(
       const std::string& path,
       int worldSize,
-      std::chrono::milliseconds pgTimeout = kBackendDefaultTimeout,
+      std::chrono::milliseconds pgTimeout = kProcessGroupNCCLDefaultTimeout,
       int inputDim = 3)
       : NCCLTestBase(path, pgTimeout),
         numDevices_(cudaNumDevices()),
@@ -222,7 +223,7 @@ class AllreduceNCCLTest : public NCCLTest {
 class SparseAllreduceNCCLTest : public NCCLTest {
  public:
   SparseAllreduceNCCLTest(const std::string& path, int worldSize, int inputDim)
-      : NCCLTest(path, worldSize, kBackendDefaultTimeout, inputDim) {}
+      : NCCLTest(path, worldSize, kProcessGroupNCCLDefaultTimeout, inputDim) {}
 
   c10::intrusive_ptr<c10d::Work> run() {
     // For the duration of this function, make THC use our streams

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1610,7 +1610,7 @@ void ProcessGroupNCCL::workEnqueue(
 }
 
 ProcessGroupNCCL::Options::Options(bool is_high_priority_stream)
-    : Backend::Options(NCCL_BACKEND_NAME),
+    : Backend::Options(NCCL_BACKEND_NAME, kProcessGroupNCCLDefaultTimeout),
       is_high_priority_stream(is_high_priority_stream) {}
 
 static constexpr int CoalActive = 0x01, CoalColl = 0x02, CoalP2P = 0x04;

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -46,6 +46,9 @@ constexpr const char* NCCL_ENABLE_TIMING = "NCCL_ENABLE_TIMING";
 
 constexpr const char* NCCL_BACKEND_NAME = "nccl";
 
+constexpr auto kProcessGroupNCCLDefaultTimeout =
+    std::chrono::milliseconds(10 * 60 * 1000);
+
 // NoHandling: do not handle asynchronous NCCL errors
 // TearDown: tear down process upon error, see `WorkNCCL::handleException`
 // CleanUpOnly: just clean up collectives and abort communicators without
@@ -176,7 +179,8 @@ class TORCH_API ProcessGroupNCCL : public Backend {
     // In case of timeout, set exception on the WorkNCCL object.
     bool checkTimeout(
         c10::optional<std::chrono::milliseconds> timeout = c10::nullopt);
-
+    bool checkDesyncTimeout(
+        c10::optional<std::chrono::milliseconds> timeout = c10::nullopt);
     std::vector<at::Tensor> result() override;
 
    protected:

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -179,8 +179,6 @@ class TORCH_API ProcessGroupNCCL : public Backend {
     // In case of timeout, set exception on the WorkNCCL object.
     bool checkTimeout(
         c10::optional<std::chrono::milliseconds> timeout = c10::nullopt);
-    bool checkDesyncTimeout(
-        c10::optional<std::chrono::milliseconds> timeout = c10::nullopt);
     std::vector<at::Tensor> result() override;
 
    protected:

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -179,6 +179,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
     // In case of timeout, set exception on the WorkNCCL object.
     bool checkTimeout(
         c10::optional<std::chrono::milliseconds> timeout = c10::nullopt);
+
     std::vector<at::Tensor> result() override;
 
    protected:

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -2234,7 +2234,7 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
               py::arg("store"),
               py::arg("rank"),
               py::arg("size"),
-              py::arg("timeout") = kProcessGroupNCCLDefaultTimeout,
+              py::arg("timeout") = c10d::kProcessGroupNCCLDefaultTimeout,
               py::call_guard<py::gil_scoped_release>())
           .def(
               "_abort",

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -2234,7 +2234,7 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
               py::arg("store"),
               py::arg("rank"),
               py::arg("size"),
-              py::arg("timeout") = kProcessGroupDefaultTimeout,
+              py::arg("timeout") = kProcessGroupNCCLDefaultTimeout,
               py::call_guard<py::gil_scoped_release>())
           .def(
               "_abort",

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -2234,7 +2234,7 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
               py::arg("store"),
               py::arg("rank"),
               py::arg("size"),
-              py::arg("timeout") = c10d::kProcessGroupNCCLDefaultTimeout,
+              py::arg("timeout") = ::c10d::kProcessGroupNCCLDefaultTimeout,
               py::call_guard<py::gil_scoped_release>())
           .def(
               "_abort",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110947

Avoid changing default for other backends as CPU backend (GLOO) may need
longer timeouts.

Motivated by trying to save cluster time when encountering collective
hangs.  Generally collectives should time out within seconds and 30
minutes (or 10 minutes) should provide ample headroom for edge cases.