### PR TITLE
[optests] Add dontGenerateOpCheckTests and is_inside_opcheck_mode

### DIFF
--- a/torch/testing/_internal/optests/__init__.py
+++ b/torch/testing/_internal/optests/__init__.py
@@ -2,4 +2,4 @@ from .make_fx import make_fx_check
 from .aot_autograd import aot_autograd_check, _test_aot_autograd_forwards_backwards_helper
 from .fake_tensor import fake_check
 from .autograd_registration import autograd_registration_check
-from .generate_tests import generate_opcheck_tests, opcheck, OpCheckError
+from .generate_tests import generate_opcheck_tests, opcheck, OpCheckError, dontGenerateOpCheckTests, is_inside_opcheck_mode


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #110977
* __->__ #110951

This PR adds the following helper functions for generated opcheck tests:
- dontGenerateOpCheckTests is a decorator that skips generation of the
  opcheck tests for the generated function
- is_inside_opcheck_mode lets us query if we are in a generated test.
  Useful for fast debugging out-of-tree without needing to update
  PyTorch.

Test Plan:
- new tests