### PR TITLE
[foreach] Speed up slow path perf for foreach binary ops

### DIFF
--- a/aten/src/ATen/native/ForeachOpsKernels.cpp
+++ b/aten/src/ATen/native/ForeachOpsKernels.cpp
@@ -105,8 +105,9 @@ namespace at::native {
       TensorList tensors, const Scalar& scalar) {               \
     check_foreach_api_restrictions(tensors);                    \
                                                                 \
+    Tensor scalar_tensor = tensors[0].new_empty({}).fill_(scalar); \
     for (auto& t : tensors) {                                   \
-      t.OP##_(scalar);                                          \
+      t.OP##_(scalar_tensor);                                   \
     }                                                           \
   }                                                             \
                                                                 \
@@ -116,8 +117,9 @@ namespace at::native {
                                                                 \
     std::vector<Tensor> result;                                 \
     result.reserve(tensors.size());                             \
+    Tensor scalar_tensor = tensors[0].new_empty({}).fill_(scalar); \
     for (const auto& t : tensors) {                             \
-      result.emplace_back(t.OP(scalar));                        \
+      result.emplace_back(t.OP(scalar_tensor));                        \
     }                                                           \
                                                                 \
     return result;                                              \

--- a/aten/src/ATen/native/ForeachOpsKernels.cpp
+++ b/aten/src/ATen/native/ForeachOpsKernels.cpp
@@ -100,29 +100,41 @@ namespace at::native {
     return result;                                              \
   }
 
-#define FOREACH_BINARY_OP_SCALAR(OP)                            \
-  void foreach_tensor_##OP##_scalar_kernel_slow_(               \
-      TensorList tensors, const Scalar& scalar) {               \
-    check_foreach_api_restrictions(tensors);                    \
-                                                                \
+#define FOREACH_BINARY_OP_SCALAR(OP)                               \
+  void foreach_tensor_##OP##_scalar_kernel_slow_(                  \
+      TensorList tensors, const Scalar& scalar) {                  \
+    check_foreach_api_restrictions(tensors);                       \
+                                                                   \
     Tensor scalar_tensor = tensors[0].new_empty({}).fill_(scalar); \
-    for (auto& t : tensors) {                                   \
-      t.OP##_(scalar_tensor);                                   \
-    }                                                           \
-  }                                                             \
-                                                                \
-  std::vector<Tensor> foreach_tensor_##OP##_scalar_kernel_slow( \
-      TensorList tensors, const Scalar& scalar) {               \
-    check_foreach_api_restrictions(tensors);                    \
-                                                                \
-    std::vector<Tensor> result;                                 \
-    result.reserve(tensors.size());                             \
+    for (auto& t : tensors) {                                      \
+      if (t.is_floating_point() &&                                 \
+          t.dtype() == scalar_tensor.dtype() &&                    \
+          t.device() == scalar_tensor.device()) {                  \
+        t.OP##_(scalar_tensor);                                    \
+      } else {                                                     \
+        t.OP##_(scalar);                                           \
+      }                                                            \
+    }                                                              \
+  }                                                                \
+                                                                   \
+  std::vector<Tensor> foreach_tensor_##OP##_scalar_kernel_slow(    \
+      TensorList tensors, const Scalar& scalar) {                  \
+    check_foreach_api_restrictions(tensors);                       \
+                                                                   \
+    std::vector<Tensor> result;                                    \
+    result.reserve(tensors.size());                                \
     Tensor scalar_tensor = tensors[0].new_empty({}).fill_(scalar); \
-    for (const auto& t : tensors) {                             \
-      result.emplace_back(t.OP(scalar_tensor));                        \
-    }                                                           \
-                                                                \
-    return result;                                              \
+    for (const auto& t : tensors) {                                \
+      if (t.is_floating_point() &&                                 \
+          t.dtype() == scalar_tensor.dtype() &&                    \
+          t.device() == scalar_tensor.device()) {                  \
+        result.emplace_back(t.OP(scalar_tensor));                  \
+      } else {                                                     \
+        result.emplace_back(t.OP(scalar));                         \
+      }                                                            \
+    }                                                              \
+                                                                   \
+    return result;                                                 \
   }
 
 #define FOREACH_BINARY_OP_SCALARLIST(OP)                            \


### PR DESCRIPTION
For the slow path scalar overload, we for-loop call aten::op(tensor_from_list, scalar). This is inefficient as it will call empty_strided and copy_ for every iter of the loop. 

We can likely take advantage of the heuristics and make the tensor from the scalar only once. The main benefit of this change will be for optimizers, where foreach_add_(steps, 1) is a common codepath and the step tensors are on CPU.

Anticipated qs:
1. what if the scalarlist is empty? we error on this earlier in the stack, so the kernel can assume the tensorlist has content.
2. what if the rest of the list doesn't match the first tensor in shape, device, dtype, layout? Broadcasting solves for shape and layout. We add a check for dtype + device to maintain BCness. 
3. why do I guard on `is_floating_point()`? If we create a bool tensor, the wrong behavior happens where `torch.tensor(True) + 3` will return `torch.tensor(True)` instead of `torch.tensor(4)`. IMO the first behavior makes more sense but would be BC breaking.
4. why not use `wrapped_scalar_tensor()`? We could. However, it defaults to kDouble instead of kFloat due to Python scalars being 64bits wide, which is inconvenient since most training is done in lower precision. Thus, an extra `.to(dtype)` would be required at the very least, and there would still need to be some sort of check added to ensure correctness. This, using `wrapped_scalar_tensor()` did not seem more performant nor clearer.


Code to test:
```
import torch
steps = [torch.zeros((), device="cpu") for i in range(1000)]

with torch.profiler.profile(
    activities=[
        torch.profiler.ProfilerActivity.CPU,
        torch.profiler.ProfilerActivity.CUDA,
    ]
) as p:
    torch._foreach_add_(steps, 1024.1024)

print(p.key_averages().table(sort_by="cpu_time_total"))
```

Profile (for 1000 tensors in a list):

```
current state of world on main:
-------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
                     Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls  
-------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
       aten::_foreach_add        37.43%      52.961ms        99.99%     141.461ms     141.461ms             1  
                aten::add        28.48%      40.300ms        62.55%      88.500ms      88.500us          1000  
                 aten::to         4.12%       5.825ms        34.07%      48.200ms      48.200us          1000  
           aten::_to_copy        10.67%      15.102ms        29.95%      42.375ms      42.375us          1000  
              aten::copy_        14.92%      21.103ms        14.92%      21.103ms      21.103us          1000  
      aten::empty_strided         4.36%       6.170ms         4.36%       6.170ms       6.170us          1000  
    cudaDeviceSynchronize         0.01%      19.000us         0.01%      19.000us      19.000us             1  
-------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 141.480ms

new state after pr:
-------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
                     Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls  
-------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
      aten::_foreach_add_        74.60%      53.748ms        99.97%      72.022ms      72.022ms             1  
               aten::add_        25.28%      18.212ms        25.28%      18.212ms      18.212us          1000  
          aten::new_empty         0.03%      22.000us         0.07%      51.000us      51.000us             1  
              aten::empty         0.04%      29.000us         0.04%      29.000us      29.000us             1  
    cudaDeviceSynchronize         0.03%      22.000us         0.03%      22.000us      22.000us             1  
              aten::fill_         0.02%      11.000us         0.02%      11.000us      11.000us             1  
-------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 72.044ms
```
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110954

