### PR TITLE
[MPS][BE] Avoid redispatch in `sign_out`

### DIFF
--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -7,6 +7,7 @@
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
+#include <ATen/MPSFunctions.h>
 #else
 #include <ATen/ops/_copy_from_and_resize.h>
 #include <ATen/ops/abs_native.h>
@@ -41,8 +42,8 @@
 #include <ATen/ops/rsqrt_native.h>
 #include <ATen/ops/sgn_native.h>
 #include <ATen/ops/sigmoid_native.h>
-#include <ATen/ops/sign.h>
 #include <ATen/ops/sign_native.h>
+#include <ATen/ops/sign_mps_dispatch.h>
 #include <ATen/ops/signbit_native.h>
 #include <ATen/ops/sin_native.h>
 #include <ATen/ops/sinh_native.h>
@@ -459,9 +460,7 @@ TORCH_IMPL_FUNC(cumprod_out_mps)
 
 TORCH_IMPL_FUNC(sgn_out_mps)(const Tensor& self, const Tensor& output) {
   if (!self.is_complex()) {
-    Tensor output_copy = output.alias();
-    at::sign_out(output_copy, self);
-    output.copy_(output_copy);
+    at::mps::sign_outf(self, const_cast<Tensor&>(output));
     return;
   }
 

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -6,8 +6,8 @@
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
-#include <ATen/NativeFunctions.h>
 #include <ATen/MPSFunctions.h>
+#include <ATen/NativeFunctions.h>
 #else
 #include <ATen/ops/_copy_from_and_resize.h>
 #include <ATen/ops/abs_native.h>
@@ -42,8 +42,8 @@
 #include <ATen/ops/rsqrt_native.h>
 #include <ATen/ops/sgn_native.h>
 #include <ATen/ops/sigmoid_native.h>
-#include <ATen/ops/sign_native.h>
 #include <ATen/ops/sign_mps_dispatch.h>
+#include <ATen/ops/sign_native.h>
 #include <ATen/ops/signbit_native.h>
 #include <ATen/ops/sin_native.h>
 #include <ATen/ops/sinh_native.h>


### PR DESCRIPTION
By calling `at::mps::sign_outf` rather than `at::sign_out` that calls dispatcher again.
Also, do not copy output unnecessarily.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f942e74</samp>

> _Metal tensors rise from the ashes_
> _`sign` and `sgn` unleash their flashes_
> _MPSFunctions reign supreme_
> _In the header of the metal dream_