### PR TITLE
fix ShardedTensor.gather when shard is empty

### DIFF
--- a/torch/distributed/_shard/sharded_tensor/api.py
+++ b/torch/distributed/_shard/sharded_tensor/api.py
@@ -436,6 +436,9 @@ class ShardedTensor(ShardedTensorBase):
 
             for shard in local_shards:
                 src = shard.tensor.flatten()
+                if src.nelement() == 0 :
+                    warnings.warn("Gathering a tensor with zero elements on rank " + str(rank))
+                    return
                 shard_offset = shard_placement[shard.metadata][1]
                 data[shard_offset: shard_offset + src.numel()].copy_(src)
 


### PR DESCRIPTION
Summary:
current ShardedTensor.gather is not working as expectation when the shard is empty on any rank

The root cause is identified that when a sharded tensor has no placement on a specific rank, the metadata doesn't include that rank's placement which introduces KeyError in :                 ```shard_offset = shard_placement[shard. Metadata][1]```

It's fixed by adding an empty tensor check.

Test Plan:
before change:


after change:

Differential Revision: D50114085


