### PR TITLE
[Nested tensor]support nested tensor in hook

### DIFF
--- a/aten/src/ATen/native/TensorProperties.cpp
+++ b/aten/src/ATen/native/TensorProperties.cpp
@@ -41,6 +41,18 @@ bool nested_is_same_size(const Tensor& self, const Tensor& other) {
       "nested. While Other ",
       other.is_nested()? "is " : "is not ",
       "nested.")
+  const auto self_is_python_dispatch =
+      self.unsafeGetTensorImpl()->is_python_dispatch();
+  const auto other_is_python_dispatch =
+      other.unsafeGetTensorImpl()->is_python_dispatch();
+
+  TORCH_CHECK(
+      self_is_python_dispatch == other_is_python_dispatch,
+      "Expected both self and other to be both python dispatch ",
+      "or both not python dispatch.")
+  if (self_is_python_dispatch && other_is_python_dispatch) {
+    return self.sym_sizes() == other.sym_sizes();
+  }
   const auto self_nt_size = _nested_tensor_size(self);
   const auto other_nt_size = _nested_tensor_size(other);
   return at::equal(self_nt_size, other_nt_size);

--- a/test/cpp/api/autograd.cpp
+++ b/test/cpp/api/autograd.cpp
@@ -1014,6 +1014,14 @@ TEST(CustomAutogradTest, Hooks) {
   ASSERT_VARIABLE_EQ(y.grad(), (x + 1) * 4);
 
   ASSERT_THROWS_WITH(y.remove_hook(3), "Invalid index");
+
+  std::function<Variable(Variable)> bw_hook_change_size([](Variable grad) {
+    return torch::ones({4, 4});
+  });
+  z.register_hook(bw_hook_change_size);
+  ASSERT_THROWS_WITH(
+      z.backward(torch::ones({5, 5}), true, true),
+      "hook '3' has changed the size of value");
 }
 
 TEST(CustomAutogradTest, HooksInplace) {

--- a/torch/csrc/autograd/cpp_hook.cpp
+++ b/torch/csrc/autograd/cpp_hook.cpp
@@ -8,8 +8,8 @@
 namespace {
 using torch::autograd::Variable;
 void check_single_result(
-    const at::TensorBase& value,
-    const at::TensorBase& result,
+    const at::Tensor& value,
+    const at::Tensor& result,
     const std::string& hook_name) {
   if (!value.defined()) {
     throw std::runtime_error(
@@ -50,7 +50,7 @@ variable_list CppFunctionTensorPreHook::operator()(
 }
 
 CppFunctionSingleTensorPreHook::CppFunctionSingleTensorPreHook(
-    std::function<at::TensorBase(const at::TensorBase&)> hook,
+    std::function<at::Tensor(const at::Tensor&)> hook,
     size_t value_idx)
     : hook_(std::move(hook)), value_idx_(value_idx) {}
 

--- a/torch/csrc/autograd/cpp_hook.h
+++ b/torch/csrc/autograd/cpp_hook.h
@@ -6,8 +6,7 @@
 namespace torch {
 namespace autograd {
 
-using hooks_list =
-    std::vector<std::function<at::TensorBase(const at::TensorBase&)>>;
+using hooks_list = std::vector<std::function<at::Tensor(const at::Tensor&)>>;
 
 struct CppFunctionTensorPreHook : public FunctionPreHook {
   CppFunctionTensorPreHook(std::shared_ptr<hooks_list> hooks, size_t value_idx);
@@ -19,11 +18,11 @@ struct CppFunctionTensorPreHook : public FunctionPreHook {
 
 struct CppFunctionSingleTensorPreHook : public FunctionPreHook {
   CppFunctionSingleTensorPreHook(
-      std::function<at::TensorBase(const at::TensorBase&)> hook,
+      std::function<at::Tensor(const at::Tensor&)> hook,
       size_t value_idx);
   variable_list operator()(const variable_list& values) override;
 
-  std::function<at::TensorBase(const at::TensorBase&)> hook_;
+  std::function<at::Tensor(const at::Tensor&)> hook_;
   size_t value_idx_;
 };
 

--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -483,8 +483,8 @@ optional_variable_list _wrap_outputs(
 }
 
 void check_variable_result(
-    const at::TensorBase& original,
-    const at::TensorBase& result,
+    const at::Tensor& original,
+    const at::Tensor& result,
     const std::string& hook_name) {
   if (!original.options().type_equal(result.options())) {
     std::stringstream ss;
@@ -504,8 +504,7 @@ void check_variable_result(
     }
     throw std::runtime_error(ss.str());
   }
-
-  if (original.sym_sizes().vec() != result.sym_sizes().vec()) {
+  if (!original.is_same_size(result)) {
     std::stringstream ss;
     ss << "hook '" << hook_name << "' has changed the size of value";
     throw std::runtime_error(ss.str());

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -24,8 +24,8 @@ TORCH_API std::vector<c10::optional<Variable>> _wrap_outputs(
     const std::unordered_set<at::TensorImpl*>& to_save_if_setup_context);
 
 TORCH_API void check_variable_result(
-    const at::TensorBase& original,
-    const at::TensorBase& result,
+    const at::Tensor& original,
+    const at::Tensor& result,
     const std::string& hook_name);
 
 // Get the return type of the forward function of the custom Function class X


### PR DESCRIPTION
Summary:
## Motivation:
In hook, the check_variable_result check the grad size to make sure that the hook function doesn't change the grad size.
Since C++ Nested tensor doesn't support size, it got blocked when using hook.

## This diff:
Replace the sym_sizes call with is_same_size which supports nested tensor.
To use is_same_size, also change the signatures from TensorBase to Tensor.

Test Plan: add a test case that the hook changes the tensor size and it throws.

Differential Revision: D50106928


