### PR TITLE
[Profiler] Fix docstring syntax issue in export_memory_timeline

### DIFF
--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -258,18 +258,18 @@ class _KinetoProfile:
         ``path``'s suffix.
 
         - For an HTML compatible plot, use the suffix ``.html``, and a memory timeline
-        plot will be embedded as a PNG file in the HTML file.
+          plot will be embedded as a PNG file in the HTML file.
 
         - For plot points consisting of ``[times, [sizes by category]]``, where
-        ``times`` are timestamps and ``sizes`` are memory usage for each category.
-        The memory timeline plot will be saved a JSON (``.json``) or gzipped JSON
-        (``.json.gz``) depending on the suffix.
+          ``times`` are timestamps and ``sizes`` are memory usage for each category.
+          The memory timeline plot will be saved a JSON (``.json``) or gzipped JSON
+          (``.json.gz``) depending on the suffix.
 
         - For raw memory points, use the suffix ``.raw.json.gz``. Each raw memory
-        event will consist of ``(timestamp, action, numbytes, category)``, where
-        ``action`` is one of ``[PREEXISTING, CREATE, INCREMENT_VERSION, DESTROY]``,
-        and ``category`` is one of the enums from
-        ``torch.profiler._memory_profiler.Category``.
+          event will consist of ``(timestamp, action, numbytes, category)``, where
+          ``action`` is one of ``[PREEXISTING, CREATE, INCREMENT_VERSION, DESTROY]``,
+          and ``category`` is one of the enums from
+          ``torch.profiler._memory_profiler.Category``.
 
         Output: Memory timeline written as gzipped JSON, JSON, or HTML.
         """


### PR DESCRIPTION
Summary: The bullet list items need proper indentation. Need this forward fix for the docstring.

Test Plan: CI

Differential Revision: D50136379

Pulled By: aaronenyeshi


