### PR TITLE
[generate_opcheck_tests] Add some reasonable defaults

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -1813,7 +1813,9 @@ optests.generate_opcheck_tests(
 class TestGenerateOpcheckTests(CustomOpTestCaseBase):
     def test_MiniOpTest(self):
         for orig_test in ["test_mm", "test_nonzero"]:
-            for test in torch.testing._internal.optests.generate_tests.DEFAULT_TEST_UTILS:
+            for (
+                test
+            ) in torch.testing._internal.optests.generate_tests.DEFAULT_TEST_UTILS:
                 expected_test = f"{test}__{orig_test}"
                 self.assertTrue(hasattr(MiniOpTest, expected_test), msg=expected_test)
 
@@ -1905,7 +1907,9 @@ opcheck(op, args, kwargs, test_utils="test_schema")
         }
         with self.assertRaisesRegex(RuntimeError, "got status=success"):
             validate_failures_dict_structure(
-                FailuresDict("", failures), torch.testing._internal.optests.generate_tests.DEFAULT_TEST_UTILS, MiniOpTest
+                FailuresDict("", failures),
+                torch.testing._internal.optests.generate_tests.DEFAULT_TEST_UTILS,
+                MiniOpTest,
             )
 
         failures = {
@@ -1918,7 +1922,9 @@ opcheck(op, args, kwargs, test_utils="test_schema")
         }
         with self.assertRaisesRegex(RuntimeError, "should begin with one of"):
             validate_failures_dict_structure(
-                FailuresDict("", failures), torch.testing._internal.optests.generate_tests.DEFAULT_TEST_UTILS, MiniOpTest
+                FailuresDict("", failures),
+                torch.testing._internal.optests.generate_tests.DEFAULT_TEST_UTILS,
+                MiniOpTest,
             )
 
         failures = {
@@ -1931,7 +1937,9 @@ opcheck(op, args, kwargs, test_utils="test_schema")
         }
         with self.assertRaisesRegex(RuntimeError, "does not exist on the TestCase"):
             validate_failures_dict_structure(
-                FailuresDict("", failures), torch.testing._internal.optests.generate_tests.DEFAULT_TEST_UTILS, MiniOpTest
+                FailuresDict("", failures),
+                torch.testing._internal.optests.generate_tests.DEFAULT_TEST_UTILS,
+                MiniOpTest,
             )
 
     def test_dont_generate_decorator(self):

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -1791,14 +1791,6 @@ class MiniOpTestOther(CustomOpTestCaseBase):
         self.assertEqual(y, torch.tensor([[1], [2]]))
 
 
-mini_op_test_checks = [
-    "test_schema",
-    "test_autograd_registration",
-    "test_faketensor",
-    "test_aot_dispatch_static",
-    "test_aot_dispatch_dynamic",
-]
-
 optests.generate_opcheck_tests(
     MiniOpTest,
     ["aten", "mini_op_test"],
@@ -1806,8 +1798,6 @@ optests.generate_opcheck_tests(
         os.path.dirname(__file__),
         "minioptest_failures_dict.json",
     ),
-    [],
-    mini_op_test_checks,
 )
 
 optests.generate_opcheck_tests(
@@ -1817,15 +1807,13 @@ optests.generate_opcheck_tests(
         os.path.dirname(__file__),
         "minioptest_failures_dict.json",
     ),
-    [],
-    mini_op_test_checks,
 )
 
 
 class TestGenerateOpcheckTests(CustomOpTestCaseBase):
     def test_MiniOpTest(self):
         for orig_test in ["test_mm", "test_nonzero"]:
-            for test in mini_op_test_checks:
+            for test in torch.testing._internal.optests.generate_tests.DEFAULT_TEST_UTILS:
                 expected_test = f"{test}__{orig_test}"
                 self.assertTrue(hasattr(MiniOpTest, expected_test), msg=expected_test)
 
@@ -1917,7 +1905,7 @@ opcheck(op, args, kwargs, test_utils="test_schema")
         }
         with self.assertRaisesRegex(RuntimeError, "got status=success"):
             validate_failures_dict_structure(
-                FailuresDict("", failures), mini_op_test_checks, MiniOpTest
+                FailuresDict("", failures), torch.testing._internal.optests.generate_tests.DEFAULT_TEST_UTILS, MiniOpTest
             )
 
         failures = {
@@ -1930,7 +1918,7 @@ opcheck(op, args, kwargs, test_utils="test_schema")
         }
         with self.assertRaisesRegex(RuntimeError, "should begin with one of"):
             validate_failures_dict_structure(
-                FailuresDict("", failures), mini_op_test_checks, MiniOpTest
+                FailuresDict("", failures), torch.testing._internal.optests.generate_tests.DEFAULT_TEST_UTILS, MiniOpTest
             )
 
         failures = {
@@ -1943,7 +1931,7 @@ opcheck(op, args, kwargs, test_utils="test_schema")
         }
         with self.assertRaisesRegex(RuntimeError, "does not exist on the TestCase"):
             validate_failures_dict_structure(
-                FailuresDict("", failures), mini_op_test_checks, MiniOpTest
+                FailuresDict("", failures), torch.testing._internal.optests.generate_tests.DEFAULT_TEST_UTILS, MiniOpTest
             )
 
     def test_dont_generate_decorator(self):

--- a/torch/testing/_internal/optests/generate_tests.py
+++ b/torch/testing/_internal/optests/generate_tests.py
@@ -1,6 +1,7 @@
 import datetime
 import difflib
 import functools
+import inspect
 import json
 import os
 import tempfile
@@ -10,13 +11,11 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import torch
 
 import torch._dynamo
-import inspect
-import os
 
 import torch.utils._pytree as pytree
 from torch._dynamo.utils import clone_input
-from torch._utils_internal import get_file_path_2
 from torch._subclasses.schema_check_mode import SchemaCheckMode
+from torch._utils_internal import get_file_path_2
 from torch.overrides import TorchFunctionMode
 from torch.testing._internal.optests import (
     aot_autograd_check,
@@ -128,6 +127,7 @@ DEFAULT_TEST_UTILS = [
     "test_aot_dispatch_dynamic",
 ]
 
+
 def generate_opcheck_tests(
     testcase: Any,
     namespaces: List[str],
@@ -179,7 +179,9 @@ def generate_opcheck_tests(
         # the same directory as the test file.
         prev_frame = inspect.currentframe().f_back
         filename = inspect.getframeinfo(prev_frame)[0]
-        failures_dict_path = get_file_path_2(os.path.dirname(filename), "failures_dict.json")
+        failures_dict_path = get_file_path_2(
+            os.path.dirname(filename), "failures_dict.json"
+        )
     failures_dict = FailuresDict.load(
         failures_dict_path, create_file=should_update_failures_dict()
     )

--- a/torch/testing/_internal/optests/generate_tests.py
+++ b/torch/testing/_internal/optests/generate_tests.py
@@ -10,9 +10,12 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import torch
 
 import torch._dynamo
+import inspect
+import os
 
 import torch.utils._pytree as pytree
 from torch._dynamo.utils import clone_input
+from torch._utils_internal import get_file_path_2
 from torch._subclasses.schema_check_mode import SchemaCheckMode
 from torch.overrides import TorchFunctionMode
 from torch.testing._internal.optests import (
@@ -117,13 +120,20 @@ ALL_TEST_UTILS = {
 
 GDOC = "https://docs.google.com/document/d/1Pj5HRZvdOq3xpFpbEjUZp2hBovhy7Wnxw14m6lF2154/edit"
 
+DEFAULT_TEST_UTILS = [
+    "test_schema",
+    "test_autograd_registration",
+    "test_faketensor",
+    "test_aot_dispatch_static",
+    "test_aot_dispatch_dynamic",
+]
 
 def generate_opcheck_tests(
     testcase: Any,
     namespaces: List[str],
-    failures_dict_path: str,
-    additional_decorators: List[Callable],
-    test_utils: List[str],
+    failures_dict_path: Optional[str] = None,
+    additional_decorators: Dict[str, Callable] = None,
+    test_utils: List[str] = DEFAULT_TEST_UTILS,
 ) -> None:
     """Given an existing TestCase, use the existing tests to generate
     additional validation tests for custom operators.
@@ -157,11 +167,19 @@ def generate_opcheck_tests(
         failures_dict_path: See ``validate_failures_dict_structure`` for more details
         test_utils: a list of test_utils to generate. Example: ["test_schema", "test_faketensor"]
     """
+    if additional_decorators is None:
+        additional_decorators = {}
     test_methods = [
         m
         for m in dir(testcase)
         if m.startswith("test_") and callable(getattr(testcase, m))
     ]
+    if failures_dict_path is None:
+        # The default failures_dict_path is failures_dict.json in
+        # the same directory as the test file.
+        prev_frame = inspect.currentframe().f_back
+        filename = inspect.getframeinfo(prev_frame)[0]
+        failures_dict_path = get_file_path_2(os.path.dirname(filename), "failures_dict.json")
     failures_dict = FailuresDict.load(
         failures_dict_path, create_file=should_update_failures_dict()
     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110977
* #110951

Summary:
Make it easier to add `generate_opcheck_tests` by adding defaults for
the failures_dict location, the additional decorators, and the test
utils.

Test Plan:
Existing tests

Reviewers:

Subscribers:

Tasks:

Tags: