### PR TITLE
Add current_device() to torch.cpu

### DIFF
--- a/docs/source/cpu.rst
+++ b/docs/source/cpu.rst
@@ -7,6 +7,7 @@ torch.cpu
     :toctree: generated
     :nosignatures:
 
+    current_device
     current_stream
     is_available
     synchronize

--- a/torch/cpu/__init__.py
+++ b/torch/cpu/__init__.py
@@ -7,12 +7,14 @@ from contextlib import AbstractContextManager
 from typing import Any, Optional, Union
 
 import torch
+
 from .. import device as _device
 from . import amp
 
 __all__ = [
     "is_available",
     "synchronize",
+    "current_device",
     "current_stream",
     "stream",
     "set_device",
@@ -126,3 +128,11 @@ def set_device(device: _device_t) -> None:
     N.B. This function only exists to facilitate device-agnostic code
     """
     pass
+
+
+def current_device() -> str:
+    r"""Returns current device for cpu. Always 'cpu'.
+
+    N.B. This function only exists to facilitate device-agnostic code
+    """
+    return "cpu"

--- a/torch/distributed/checkpoint/optimizer.py
+++ b/torch/distributed/checkpoint/optimizer.py
@@ -100,17 +100,13 @@ def _is_nested_tensor(val: torch.Tensor) -> bool:
 
 
 def _alloc_tensor(props: TensorProperties, size: Sequence[int], device_type: str = "cuda") -> torch.Tensor:
-    if device_type == "cpu":
-        device = cast(torch.device, "cpu")
-    else:
-        device = cast(torch.device, _get_device_module(device_type).current_device())
     return torch.empty(
         size=size,
         dtype=props.dtype,
         layout=props.layout,
         requires_grad=props.requires_grad,
         pin_memory=props.pin_memory,
-        device=device,
+        device=cast(torch.device, _get_device_module(device_type).current_device()),
     )
 
 


### PR DESCRIPTION
Better support device agnostic, add a "cpu" return for `current_device()` in torch.cpu so that we won't run into `AttributeError: module 'torch.cpu' has no attribute 'current_device'`.



cc @ptrblck @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10