### PR TITLE
[quant][pt2e] Disable remove_qconfig

### DIFF
--- a/torch/ao/quantization/quantize_fx.py
+++ b/torch/ao/quantization/quantize_fx.py
@@ -655,7 +655,6 @@ def convert_to_reference_fx(
 def _convert_to_reference_decomposed_fx(
     graph_module: GraphModule,
     convert_custom_config: Union[ConvertCustomConfig, Dict[str, Any], None] = None,
-    _remove_qconfig: bool = True,
     qconfig_mapping: Union[QConfigMapping, Dict[str, Any], None] = None,
     backend_config: Union[BackendConfig, Dict[str, Any], None] = None,
 ) -> GraphModule:
@@ -699,7 +698,7 @@ def _convert_to_reference_decomposed_fx(
         graph_module,
         is_reference=True,
         convert_custom_config=convert_custom_config,
-        _remove_qconfig=_remove_qconfig,
+        _remove_qconfig=False,
         qconfig_mapping=qconfig_mapping,
         backend_config=backend_config,
         is_decomposed=True,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #111000

Summary:
This is a hacky flag that we had before in fx flow, and we don't want this in the new flow

Test Plan:
python test/test_quantization.py TestQuantizePT2E

Reviewers:

Subscribers:

Tasks:

Tags: