### PR TITLE
[TP] Validate TP mesh dim for 2D composition

### DIFF
--- a/test/distributed/tensor/parallel/test_fsdp_2d_parallel.py
+++ b/test/distributed/tensor/parallel/test_fsdp_2d_parallel.py
@@ -318,6 +318,18 @@ class TestNew2dParallelIntegration(DTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
+    def test_raise_invalid_tp_composition(self):
+        with self.assertRaisesRegex(
+            RuntimeError, r"Found TP device_mesh on the \d dimension of its parent mesh"
+        ):
+            mesh_2d = init_device_mesh(
+                self.device_type, (2, self.world_size // 2), mesh_dim_names=("tp", "dp")
+            )
+            model_2d = parallelize_module(SimpleModel().cuda(), mesh_2d["tp"], PairwiseParallel())
+
+
+    @with_comms
+    @skip_if_lt_x_gpu(4)
     def test_2d_fsdp_state_enable_extension(self):
         mesh_2d = init_device_mesh(
             self.device_type, (2, self.world_size // 2), mesh_dim_names=("dp", "tp")

--- a/torch/distributed/tensor/parallel/api.py
+++ b/torch/distributed/tensor/parallel/api.py
@@ -15,7 +15,7 @@ from torch.distributed._tensor.random import (
     is_rng_supported_mesh,
     TensorParallelRNGTracker,
 )
-from torch.distributed.tensor.parallel._utils import _create_1d_device_mesh
+from torch.distributed.tensor.parallel._utils import _create_1d_device_mesh, _validate_tp_mesh_dim
 from torch.distributed.tensor.parallel.style import (
     ColwiseParallel,
     PairwiseParallel,
@@ -94,6 +94,9 @@ def parallelize_module(  # type: ignore[return]
 
     if device_mesh.ndim > 1:
         device_mesh = _create_1d_device_mesh(device_mesh, tp_mesh_dim)
+    else:
+        _validate_tp_mesh_dim(device_mesh)
+
 
     if isinstance(parallelize_plan, ParallelStyle):
         # RowwiseParallel or ColwiseParallel


### PR DESCRIPTION
Currently, we only support intranode TP when compositin TP with other parallelism. This PR adds additional check to validate the TP mesh dim in TP initialization when parent mesh exists. 

cc. @fegin, @fduwjj 