### PR TITLE
Disable FlashAttenion for is_causal=True when seqlen q not equal kv

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -235,12 +235,12 @@ bool check_flash_causal_non_square_seqlens(sdp_params const& params, bool debug)
   // FlashAttention 2 updated the default mask meaning for causal in this PR:
   // 9e5e8bc91e it is now aligned to lower_right which would be a BC break
   // for non-square masks. We will not support non-square masks for causal w/ FAV2
-  if (params.is_causal && params.query.size(-2) != params.key.size(-2)) {
+  if (params.is_causal && params.query.sym_size(-2) != params.key.sym_size(-2)) {
     if (debug) {
       TORCH_WARN(
           "Flash attention does not support the is_causal flag when seqlen_q != seqlen_k. ",
-          "Got seqlen_q: ", params.query.size(-2), " seqlen_k: ",
-          params.key.size(-2), ". If you would like to use causal attention with non-square masks, please see CausalAttnMask.");
+          "Got seqlen_q: ", params.query.sym_size(-2), " seqlen_k: ",
+          params.key.sym_size(-2), ". If you would like to use causal attention with non-square masks, please see CausalAttnMask.");
     }
     return false;
   }

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -230,6 +230,23 @@ bool check_requires_grad_and_head_dim_gt192_and_sm_ge86_lt90(
   return true;
 }
 
+
+bool check_flash_causal_non_square_seqlens(sdp_params const& params, bool debug) {
+  // FlashAttention 2 updated the default mask meaning for causal in this PR:
+  // 9e5e8bc91e it is now aligned to lower_right which would be a BC break
+  // for non-square masks. We will not support non-square masks for causal w/ FAV2
+  if (params.is_causal && params.query.size(-2) != params.key.size(-2)) {
+    if (debug) {
+      TORCH_WARN(
+          "Flash attention does not support the is_causal flag when seqlen_q != seqlen_k. ",
+          "Got seqlen_q: ", params.query.size(-2), " seqlen_k: ",
+          params.key.size(-2), ". If you would like to use causal attention with non-square masks, please see CausalAttnMask.");
+    }
+    return false;
+  }
+  return true;
+}
+
 bool use_flash_attention(sdp_params const& params, bool debug) {
 #ifndef USE_FLASH_ATTENTION
   TORCH_WARN(!debug, "Torch was not compiled with flash attention.");
@@ -249,6 +266,7 @@ bool use_flash_attention(sdp_params const& params, bool debug) {
       check_last_dim_stride_equals_1,
       check_flash_attention_hardware_support,
       check_requires_grad_and_head_dim_gt192_and_sm_ge86_lt90,
+      check_flash_causal_non_square_seqlens,
       check_for_seq_len_0_nested_tensor);
   for (auto& constraint : constraints) {
     if (!constraint(params, debug)) {

--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -221,18 +221,18 @@ class TestFlopCounter(TestCase):
 
 
         run_nonuniform_flops = functools.partial(get_flops, batch_size, n_heads, seq_len_q, seq_len_k, head_dim, head_dim_v, dtype)
-
-        flops = [run_nonuniform_flops(backend, with_backward=False) for backend in ["math", "flash", "mem_efficient"]]
-        flops_fw_math, flops_fw_flash, flops_fw_efficient = flops
-        self.assertEqual(flops_fw_math, flops_fw_flash, flops_fw_efficient)
+        # Flash does not support non-uniform attention, i.e. seq_len_q != seq_len_k or dim_q != dim_v"
+        non_uniform_backends = ["math", "mem_efficient"]
+        flops = [run_nonuniform_flops(backend, with_backward=False) for backend in non_uniform_backends]
+        flops_fw_math, flops_fw_efficient = flops
+        self.assertEqual(flops_fw_math, flops_fw_efficient)
 
         self.assertExpectedInline(str(flops_fw_math), """268435456""")
 
-        flops = [run_nonuniform_flops(backend, with_backward=True) for backend in ["math", "flash", "mem_efficient"]]
-        flops_fw_bw_math, flops_fw_bw_flash, flops_fw_bw_efficient = flops
+        flops = [run_nonuniform_flops(backend, with_backward=True) for backend in non_uniform_backends]
+        flops_fw_bw_math, flops_fw_bw_efficient = flops
         self.assertExpectedInline(str(flops_fw_bw_math), """805306368""")
-        self.assertEqual(flops_fw_bw_flash, flops_fw_bw_efficient)
-        self.assertExpectedInline(str(flops_fw_bw_flash), """939524096""")
+        self.assertExpectedInline(str(flops_fw_bw_efficient), """939524096""")
 
     def test_hook_registration(self):
         model = torch.nn.Linear(100, 100)

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2441,6 +2441,9 @@ class TestSDPACudaOnly(NNTestCase):
 
         if isSM86or89Device and head_dim in range(193, 256 + 1):
             self.skipTest("Flash attention on sm86 and sm89 for headdim > 192 currently disabled")
+        if is_causal and seq_len_q != seq_len_k:
+            self.skipTest("Flash V2 does not accept is_casual when seq_len_q != seq_len_k")
+
         scale = scale if scale is None else (1 / head_dim)
         n_heads = 4
         query = torch.rand(batch_size, n_heads, seq_len_q, head_dim,
@@ -2572,6 +2575,9 @@ class TestSDPACudaOnly(NNTestCase):
                     dbug_mask, query_padding_mask, key_padding_mask, head_dim=head_dim, causal=is_causal)
                 dropout_mask = softmax_mask >= 0
                 return dropout_mask
+
+        if fused_kernel == SDPBackend.FLASH_ATTENTION and is_causal and seq_len_q != seq_len_k:
+            self.skipTest("Flash V2 does not accept is_casual when seq_len_q != seq_len_k")
 
         seed = 42
         scale = scale if scale is None else (1 / head_dim)


### PR DESCRIPTION
# Summary:
This pull request **removes** support for non-square sequence lengths in causal attention when using FlashAttention V2.

### Why are doing this
  // FlashAttention 2 updated the default mask meaning for causal in this PR:
  // 9e5e8bc91e it is now aligned to lower_right which would be a BC break
  // for non-square masks. We will not support non-square masks for causal w/ FAV2
  
 For more context see:
 https://github.com/pytorch/pytorch/issues/108108
 
 ### Followup
 A large number of people will likely want to use FAV2 with lower_right causal attention for non equal sequence lengths. See this RFC : https://github.com/pytorch/pytorch/issues/110681
 
