### PR TITLE
[export] Fix graph signature data model to list of specs.

### DIFF
--- a/docs/source/export.rst
+++ b/docs/source/export.rst
@@ -571,6 +571,8 @@ API Reference
 .. autoclass:: ModuleCallEntry
 
 
-.. This module needs to be documented. Adding here in the meantime
-.. for tracking purposes
-.. py:module:: torch.export.exported_program
+.. automodule:: torch.export.exported_program
+.. autoclass:: InputKind
+.. autoclass:: InputSpec
+.. autoclass:: OutputKind
+.. autoclass:: OutputSpec

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1365,45 +1365,6 @@ class TestExport(TestCase):
         exp_source_fns = [["cond", "cos"], ["cond", "sin"]]
         self.assertEqual(actual_source_fns, exp_source_fns)
 
-    def test_lift_constants(self) -> None:
-        from torch._export.passes.lift_constant_tensor_pass import lift_constant_tensor_pass
-
-        def f(x):
-            return x + torch.tensor(3)
-
-        ep = export(f, (torch.tensor(1),))
-        ep = lift_constant_tensor_pass(ep)
-
-        for node in ep.graph.nodes:
-            self.assertTrue(node.op != "get_attr")
-        self.assertEqual(len(ep.graph_signature.buffers), 1)
-        self.assertEqual(len(ep.state_dict), 1)
-
-        class Foo(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.a = torch.tensor(3)
-
-            def forward(self, x):
-                list_tensor = [torch.tensor(3), torch.tensor(4)]
-                return x + self.a + list_tensor[0] + list_tensor[1]
-
-        ep = export(Foo(), (torch.tensor(1),))
-        ep = lift_constant_tensor_pass(ep)
-
-        nodes = list(ep.graph.nodes)
-
-        for node in nodes:
-            self.assertTrue(node.op != "get_attr")
-        self.assertEqual(len(ep.graph_signature.buffers), 3)
-        self.assertEqual(len(ep.state_dict), 3)
-
-        # These constants should be placed after the param/buffers
-        self.assertTrue(
-            nodes[1].name in ep.graph_signature.inputs_to_buffers and
-            nodes[2].name in ep.graph_signature.inputs_to_buffers
-        )
-
     def test_preserve_shape_dynamism_for_unused_inputs(self):
         @dataclass
         class Input:

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -4,9 +4,9 @@ import io
 import pathlib
 import re
 import sys
-import warnings
 
 import types
+import warnings
 import weakref
 import zipfile
 from collections import OrderedDict
@@ -33,12 +33,20 @@ from torch._functorch.aot_autograd import aot_export_module
 from torch._functorch.eager_transforms import functionalize
 from torch._guards import detect_fake_mode
 from torch._ops import OpOverload
-from torch._subclasses.fake_tensor import FakeTensorMode
+from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch.export import _create_constraint, _Dim, Constraint
 from torch.export.exported_program import (
-    ExportBackwardSignature,
     ExportedProgram,
     ExportGraphSignature,
+    _sig_to_specs,
+    ArgumentSpec,
+    ConstantArgument,
+    InputKind,
+    OutputKind,
+    OutputSpec,
+    SymIntArgument,
+    TensorArgument,
+    InputSpec
 )
 from torch.fx import traceback as fx_traceback
 from torch.fx._compatibility import compatibility
@@ -61,11 +69,11 @@ from .passes.add_runtime_assertions_for_constraints_pass import (
     _AddRuntimeAssertionsForInlineConstraintsPass,
 )
 from .passes.lift_constant_tensor_pass import lift_constant_tensor_pass
+from .passes.remove_runtime_assertions import _RemoveRuntimeAssertionsPass
 from .passes.replace_sym_size_ops_pass import _ReplaceSymSizeOpPass
 from .passes.replace_view_ops_with_view_copy_ops_pass import (
     ReplaceViewOpsWithViewCopyOpsPass,
 )
-from .passes.remove_runtime_assertions import _RemoveRuntimeAssertionsPass
 from .wrappers import _wrap_submodules
 
 
@@ -395,18 +403,10 @@ def _safe_to_skip_dynamo(gm: torch.fx.GraphModule):
 
 
 def _replace_param_buffer_names(param_buffer_table, sig):
-    def replace(x):
-        return param_buffer_table.get(x, x)
-
-    sig.parameters = pytree.tree_map(replace, sig.parameters)
-    sig.buffers = pytree.tree_map(replace, sig.buffers)
-    sig.inputs_to_parameters = pytree.tree_map(replace, sig.inputs_to_parameters)
-    sig.inputs_to_buffers = pytree.tree_map(replace, sig.inputs_to_buffers)
-    sig.buffers_to_mutate = pytree.tree_map(replace, sig.buffers_to_mutate)
-    if sig.backward_signature is not None:
-        sig.backward_signature.gradients_to_parameters = pytree.tree_map(
-            replace, sig.backward_signature.gradients_to_parameters
-        )
+    for spec in sig.input_specs:
+        spec.target = param_buffer_table.get(spec.target, spec.target)
+    for spec in sig.output_specs:
+        spec.target = param_buffer_table.get(spec.target, spec.target)
 
 
 def _normalize_nn_module_stack(gm_torch_level, root_cls):
@@ -651,28 +651,11 @@ def _export(
         trace_joint=False
     )
 
-    export_backward_signature = ExportBackwardSignature(
-        gradients_to_parameters=graph_signature.backward_signature.gradients_to_parameters,
-        gradients_to_user_inputs=graph_signature.backward_signature.gradients_to_user_inputs,
-        loss_output=graph_signature.backward_signature.loss_output
-    ) if graph_signature.backward_signature is not None else None
-
     def to_str_list(sig_component: List[Any]):
         return [str(v) for v in sig_component]
 
     def to_str_dict(sig_component: Dict[Any, Any]):
         return {str(k): str(v) for k, v in sig_component.items()}
-
-    export_graph_signature = ExportGraphSignature(
-        parameters=to_str_list(graph_signature.parameters),
-        buffers=to_str_list(graph_signature.buffers),
-        user_inputs=to_str_list(graph_signature.user_inputs),
-        user_outputs=to_str_list(graph_signature.user_outputs),
-        inputs_to_parameters=to_str_dict(graph_signature.inputs_to_parameters),
-        inputs_to_buffers=to_str_dict(graph_signature.inputs_to_buffers),
-        buffers_to_mutate=to_str_dict(graph_signature.buffers_to_mutate),
-        backward_signature=export_backward_signature
-    )
 
     # NOTE: aot_export adds symint metadata for placeholders with int values;
     # since these become specialized, we replace such metadata with the original values
@@ -706,18 +689,42 @@ def _export(
     # without relying on this metadata
     for node in gm.graph.nodes:
         if node.op == "placeholder":
-            if node.target in export_graph_signature.inputs_to_parameters:
-                param_name = export_graph_signature.inputs_to_parameters[node.target]
+            if node.target in graph_signature.inputs_to_parameters:
+                param_name = graph_signature.inputs_to_parameters[node.target]
                 if param_name in params_buffers_to_node_meta:
                     for k, v in params_buffers_to_node_meta[param_name].items():
                         node.meta[k] = v
-            if node.target in export_graph_signature.inputs_to_buffers:
-                buffer_name = export_graph_signature.inputs_to_buffers[node.target]
+            if node.target in graph_signature.inputs_to_buffers:
+                buffer_name = graph_signature.inputs_to_buffers[node.target]
                 if buffer_name in params_buffers_to_node_meta:
                     for k, v in params_buffers_to_node_meta[buffer_name].items():
                         node.meta[k] = v
 
         node.meta["is_torch_exported"] = True
+
+    is_joint = graph_signature.backward_signature is not None
+
+    def make_argument_spec(node) -> ArgumentSpec:
+        val = node.meta["val"]
+        if isinstance(val, FakeTensor):
+            return TensorArgument(name=node.name)
+        elif isinstance(val, torch.SymInt):
+            return SymIntArgument(name=node.name)
+        else:
+            return ConstantArgument(value=val)
+    input_specs, output_specs = _sig_to_specs(
+        user_inputs=set(graph_signature.user_inputs),
+        inputs_to_parameters=graph_signature.inputs_to_parameters,  # type: ignore[arg-type]
+        inputs_to_buffers=graph_signature.inputs_to_buffers,  # type: ignore[arg-type]
+        user_outputs=set(graph_signature.user_outputs),  # type: ignore[arg-type]
+        buffer_mutations=graph_signature.buffers_to_mutate,  # type: ignore[arg-type]
+        grad_params=graph_signature.backward_signature.gradients_to_parameters if is_joint else {},  # type: ignore[arg-type, union-attr]
+        grad_user_inputs=graph_signature.backward_signature.gradients_to_user_inputs if is_joint else {},  # type: ignore[arg-type, union-attr]
+        loss_output=graph_signature.backward_signature.loss_output if is_joint else None,  # type: ignore[arg-type, union-attr]
+        inputs=[make_argument_spec(node) for node in gm.graph.nodes if node.op == "placeholder"],
+        outputs=[make_argument_spec(node) for node in pytree.tree_flatten(next(iter(reversed(gm.graph.nodes))).args)[0]],
+    )
+    export_graph_signature = ExportGraphSignature(input_specs=input_specs, output_specs=output_specs)
 
     range_constraints, equality_constraints = _process_constraints(
         gm,
@@ -917,14 +924,20 @@ def aot_compile(
         unlifted_module,
         unlifted_module.graph,
         ExportGraphSignature(
-            parameters=[],
-            buffers=[],
-            user_inputs=user_inputs,
-            user_outputs=user_outputs,
-            inputs_to_parameters={},
-            inputs_to_buffers={},
-            buffers_to_mutate={},
-            backward_signature=None,
+            input_specs=[
+                InputSpec(
+                    kind=InputKind.USER_INPUT,
+                    arg=TensorArgument(name=i),
+                    target=None,
+                ) for i in user_inputs
+            ],
+            output_specs=[
+                OutputSpec(
+                    kind=OutputKind.USER_OUTPUT,
+                    arg=TensorArgument(name=o),
+                    target=None,
+                ) for o in user_outputs
+            ]
         ),
         call_spec=copy.deepcopy(ep.call_spec),
         state_dict={},

--- a/torch/_export/passes/lift_constant_tensor_pass.py
+++ b/torch/_export/passes/lift_constant_tensor_pass.py
@@ -1,5 +1,6 @@
 import torch
 from torch._guards import detect_fake_mode
+from torch.export.exported_program import InputKind, InputSpec, TensorArgument
 
 
 def lift_constant_tensor_pass(ep):
@@ -11,7 +12,6 @@ def lift_constant_tensor_pass(ep):
         return ep
 
     graph_signature = ep.graph_signature
-    inputs_to_buffers = graph_signature.inputs_to_buffers
     buffers = graph_signature.buffers
 
     fake_mode = detect_fake_mode(
@@ -20,6 +20,7 @@ def lift_constant_tensor_pass(ep):
     assert fake_mode is not None
 
     first_user_input = None
+    lifted_buffers = []
     for node in ep.graph.nodes:
         if node.op == "placeholder" and node.name in graph_signature.user_inputs:
             first_user_input = node
@@ -39,16 +40,29 @@ def lift_constant_tensor_pass(ep):
                 for k, v in node.meta.items():
                     const_placeholder_node.meta[k] = v
                 const_placeholder_node.meta["val"] = fake_mode.from_tensor(
-                    constant_tensor
+                    constant_tensor, static_shapes=True
                 )
                 const_placeholder_node.meta["val"].constant = constant_tensor
                 node.replace_all_uses_with(const_placeholder_node)
                 ep.graph.erase_node(node)
 
                 # Add the constant as a buffer to the graph signature
-                inputs_to_buffers[const_placeholder_node.name] = constant_tensor_fqn
+                lifted_buffers.append(
+                    InputSpec(
+                        kind=InputKind.BUFFER,
+                        arg=TensorArgument(name=const_placeholder_node.name),
+                        target=constant_tensor_fqn,
+                    )
+                )
                 buffers.append(constant_tensor_fqn)
                 ep.state_dict[constant_tensor_fqn] = constant_tensor
 
+    new_input_specs = []
+    for s in graph_signature.input_specs:
+        if s.kind == InputKind.USER_INPUT and len(lifted_buffers) > 0:
+            new_input_specs.extend(lifted_buffers)
+            lifted_buffers.clear()
+        new_input_specs.append(s)
+    ep.graph_signature.input_specs = new_input_specs
     ep.graph_module.recompile()
     return ep

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -1,6 +1,19 @@
 import copy
 import dataclasses
-from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
+from enum import auto, Enum
+from typing import (
+    Any,
+    Callable,
+    Collection,
+    Dict,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 import sympy
 
@@ -23,10 +36,132 @@ __all__ = [
     "ExportGraphSignature",
     "ModuleCallEntry",
     "ModuleCallSignature",
+    "InputKind",
+    "InputSpec",
+    "OutputKind",
+    "OutputSpec",
 ]
 
 
 PassType = Callable[[torch.fx.GraphModule], Optional[PassResult]]
+
+
+@dataclasses.dataclass
+class TensorArgument:
+    name: str
+
+
+@dataclasses.dataclass
+class SymIntArgument:
+    name: str
+
+
+@dataclasses.dataclass
+class ConstantArgument:
+    value: Union[int, float, bool, None]
+
+
+ArgumentSpec = Union[TensorArgument, SymIntArgument, ConstantArgument]
+
+
+class InputKind(Enum):
+    USER_INPUT = auto()
+    PARAMETER = auto()
+    BUFFER = auto()
+
+
+@dataclasses.dataclass
+class InputSpec:
+    kind: InputKind
+    arg: ArgumentSpec
+    target: Optional[str]
+
+    def __post_init__(self):
+        assert isinstance(self.arg, (TensorArgument, SymIntArgument, ConstantArgument))
+
+
+class OutputKind(Enum):
+    USER_OUTPUT = auto()
+    LOSS_OUTPUT = auto()
+    BUFFER_MUTATION = auto()
+    GRADIENT_TO_PARAMETER = auto()
+    GRADIENT_TO_USER_INPUT = auto()
+
+
+@dataclasses.dataclass
+class OutputSpec:
+    kind: OutputKind
+    arg: ArgumentSpec
+    target: Optional[str]
+
+    def __post_init__(self):
+        assert isinstance(self.arg, (TensorArgument, SymIntArgument, ConstantArgument))
+
+
+def _sig_to_specs(
+    *,
+    user_inputs: Set[str],
+    inputs_to_parameters: Mapping[str, str],
+    inputs_to_buffers: Mapping[str, str],
+    user_outputs: Set[str],
+    buffer_mutations: Mapping[str, str],
+    grad_params: Mapping[str, str],
+    grad_user_inputs: Mapping[str, str],
+    loss_output: Optional[str],
+    inputs: List[ArgumentSpec],
+    outputs: List[ArgumentSpec],
+) -> Tuple[List[InputSpec], List[OutputSpec]]:
+    def to_input_spec(i: ArgumentSpec) -> InputSpec:
+        if not isinstance(i, TensorArgument):
+            return InputSpec(kind=InputKind.USER_INPUT, arg=i, target=None)
+        name = i.name
+        if name in user_inputs:
+            return InputSpec(kind=InputKind.USER_INPUT, arg=i, target=None)
+        elif name in inputs_to_parameters:
+            return InputSpec(
+                kind=InputKind.PARAMETER,
+                arg=i,
+                target=inputs_to_parameters[name],
+            )
+        elif name in inputs_to_buffers:
+            return InputSpec(
+                kind=InputKind.BUFFER, arg=i, target=inputs_to_buffers[name]
+            )
+        else:
+            raise AssertionError(f"Unknown tensor input kind: {name}")
+
+    def to_output_spec(o: ArgumentSpec) -> OutputSpec:
+        if not isinstance(o, TensorArgument):
+            return OutputSpec(kind=OutputKind.USER_OUTPUT, arg=o, target=None)
+        name = o.name
+        if name in user_outputs:
+            return OutputSpec(kind=OutputKind.USER_OUTPUT, arg=o, target=None)
+        elif name in buffer_mutations:
+            return OutputSpec(
+                kind=OutputKind.BUFFER_MUTATION,
+                arg=o,
+                target=buffer_mutations[name],
+            )
+        elif name in grad_params:
+            return OutputSpec(
+                kind=OutputKind.GRADIENT_TO_PARAMETER,
+                arg=o,
+                target=grad_params[name],
+            )
+        elif name in grad_user_inputs:
+            return OutputSpec(
+                kind=OutputKind.GRADIENT_TO_USER_INPUT,
+                arg=o,
+                target=grad_user_inputs[name],
+            )
+        elif name == loss_output:
+            return OutputSpec(kind=OutputKind.LOSS_OUTPUT, arg=o, target=None)
+        else:
+            raise AssertionError(f"Unknown tensor output kind: {name}")
+
+    input_specs = [to_input_spec(i) for i in inputs]
+    output_specs = [to_output_spec(o) for o in outputs]
+    return input_specs, output_specs
 
 
 @dataclasses.dataclass
@@ -129,36 +264,119 @@ class ExportGraphSignature:
         )
     """
 
+    input_specs: List[InputSpec]
+    output_specs: List[OutputSpec]
+
     # A list of parameters uniquely identified by mangled fully qualified name
-    parameters: List[str]
+    @property
+    def parameters(self) -> Collection[str]:
+        # TODO Make this tuple.
+        return [
+            s.target
+            for s in self.input_specs
+            if s.kind == InputKind.PARAMETER
+            if isinstance(s.target, str)
+        ]
 
     # A list of buffers uniquely identified by mangled fully qualified name
-    buffers: List[str]
+    @property
+    def buffers(self) -> Collection[str]:
+        # TODO Make this tuple.
+        return [
+            s.target
+            for s in self.input_specs
+            if s.kind == InputKind.BUFFER
+            if isinstance(s.target, str)
+        ]
 
     # Graph node names of pytree-flattened inputs of original program
-    user_inputs: List[str]
+    @property
+    def user_inputs(self) -> Collection[str]:
+        return tuple(
+            s.arg.name
+            for s in self.input_specs
+            if s.kind == InputKind.USER_INPUT and isinstance(s.arg, TensorArgument)
+        )
 
     # Graph node names of pytree-flattened outputs of original program
-    user_outputs: List[str]
+    @property
+    def user_outputs(self) -> Collection[str]:
+        return tuple(
+            s.arg.name
+            for s in self.output_specs
+            if s.kind == OutputKind.USER_OUTPUT and isinstance(s.arg, TensorArgument)
+        )
 
     # A dictionary mapping graph input node names to parameters. If a graph input
     # name is found in this dictionary, it is guranteed to be a lifted parameter.
-    inputs_to_parameters: Dict[str, str]
+    @property
+    def inputs_to_parameters(self) -> Mapping[str, str]:
+        return {
+            s.arg.name: s.target
+            for s in self.input_specs
+            if s.kind == InputKind.PARAMETER
+            and isinstance(s.arg, TensorArgument)
+            and isinstance(s.target, str)
+        }
 
     # A dictionary mapping graph input node names to buffers. If a graph input
     # name is found in this dictionary, it is guranteed to be a lifted buffer.
-    inputs_to_buffers: Dict[str, str]
+    @property
+    def inputs_to_buffers(self) -> Mapping[str, str]:
+        return {
+            s.arg.name: s.target
+            for s in self.input_specs
+            if s.kind == InputKind.BUFFER
+            and isinstance(s.arg, TensorArgument)
+            and isinstance(s.target, str)
+        }
 
     # A dictionary mapping graph output node names to buffers that are mutated in the
     # original program. Buffers that are not mutated will not be found in this dictionary.
-    buffers_to_mutate: Dict[str, str]
+    @property
+    def buffers_to_mutate(self) -> Mapping[str, str]:
+        return {
+            s.arg.name: s.target
+            for s in self.output_specs
+            if s.kind == OutputKind.BUFFER_MUTATION
+            and isinstance(s.arg, TensorArgument)
+            and isinstance(s.target, str)
+        }
 
-    backward_signature: Optional[ExportBackwardSignature]
+    @property
+    def backward_signature(self) -> Optional[ExportBackwardSignature]:
+        loss_output = None
+        gradients_to_parameters: Dict[str, str] = {}
+        gradients_to_user_inputs: Dict[str, str] = {}
+        for spec in self.output_specs:
+            if spec.kind == OutputKind.LOSS_OUTPUT:
+                assert loss_output is None
+                assert isinstance(spec.arg, TensorArgument)
+                loss_output = spec.arg.name
+            elif spec.kind == OutputKind.GRADIENT_TO_PARAMETER:
+                assert isinstance(spec.target, str)
+                assert isinstance(spec.arg, TensorArgument)
+                gradients_to_parameters[spec.arg.name] = spec.target
+            elif spec.kind == OutputKind.GRADIENT_TO_USER_INPUT:
+                assert isinstance(spec.target, str)
+                assert isinstance(spec.arg, TensorArgument)
+                gradients_to_user_inputs[spec.arg.name] = spec.target
+
+        if loss_output is None:
+            return None
+
+        return ExportBackwardSignature(
+            loss_output=loss_output,
+            gradients_to_parameters=gradients_to_parameters,
+            gradients_to_user_inputs=gradients_to_user_inputs,
+        )
 
     # Map from assertion dependency token index to assertion dep token output
     # name in output. The shape of output after aot_autograd will be like:
     # (updated_inputs, user_outputs, dep_token).
-    assertion_dep_token: Optional[Dict[int, str]] = None
+    @property
+    def assertion_dep_token(self) -> Optional[Mapping[int, str]]:
+        return None
 
     def __post_init__(self) -> None:
         assertion_dep_token = self.assertion_dep_token
@@ -170,24 +388,6 @@ class ExportGraphSignature:
             len(self.user_outputs) + len(self.buffers_to_mutate)
             == assertion_dep_token_index
         )
-
-
-@dataclasses.dataclass
-class TensorArgument:
-    name: str
-
-
-@dataclasses.dataclass
-class SymIntArgument:
-    name: str
-
-
-@dataclasses.dataclass
-class ConstantArgument:
-    value: Union[int, float, bool, None]
-
-
-ArgumentSpec = Union[TensorArgument, SymIntArgument, ConstantArgument]
 
 
 @dataclasses.dataclass
@@ -458,6 +658,9 @@ class ExportedProgram:
         old_placeholders = _get_placeholders(self.graph_module)
         fake_args = [node.meta["val"] for node in old_placeholders]
 
+        for name, _ in self.graph_module.named_buffers():
+            delattr(self.graph_module, name)
+        # TODO(zhxhchen17) Return the new graph_signature directly.
         gm, graph_signature = aot_export_module(
             self.graph_module, fake_args, decompositions=decomp_table, trace_joint=False
         )
@@ -478,39 +681,53 @@ class ExportedProgram:
             for old_node, new_node in zip(old_outputs, new_outputs)
         }
 
-        new_backward_signature = (
-            ExportBackwardSignature(
-                copy.deepcopy(
-                    self.graph_signature.backward_signature.gradients_to_parameters
-                ),
-                {
-                    old_new_placeholder_map[inp]: param
-                    for inp, param in self.graph_signature.backward_signature.gradients_to_parameters
-                },
-                copy.deepcopy(self.graph_signature.backward_signature.loss_output),
-            )
-            if self.graph_signature.backward_signature is not None
-            else None
-        )
+        def make_argument_spec(node) -> ArgumentSpec:
+            val = node.meta["val"]
+            if isinstance(val, torch.Tensor):
+                return TensorArgument(name=node.name)
+            elif isinstance(val, torch.SymInt):
+                return SymIntArgument(name=node.name)
+            else:
+                return ConstantArgument(value=val)
 
-        new_graph_signature = ExportGraphSignature(
-            copy.deepcopy(self.graph_signature.parameters),
-            copy.deepcopy(self.graph_signature.buffers),
-            [old_new_placeholder_map[inp] for inp in self.graph_signature.user_inputs],
-            [old_new_output_map[out] for out in self.graph_signature.user_outputs],
-            {
+        input_specs, output_specs = _sig_to_specs(
+            user_inputs={
+                old_new_placeholder_map[inp] for inp in self.graph_signature.user_inputs
+            },
+            inputs_to_parameters={
                 old_new_placeholder_map[inp]: param
                 for inp, param in self.graph_signature.inputs_to_parameters.items()
             },
-            {
+            inputs_to_buffers={
                 old_new_placeholder_map[inp]: buffer
                 for inp, buffer in self.graph_signature.inputs_to_buffers.items()
             },
-            copy.deepcopy(self.graph_signature.buffers_to_mutate),
-            new_backward_signature,
-            copy.deepcopy(self.graph_signature.assertion_dep_token),
+            user_outputs={
+                old_new_output_map[out] for out in self.graph_signature.user_outputs
+            },
+            buffer_mutations={
+                old_new_output_map[out]: buffer
+                for out, buffer in self.graph_signature.buffers_to_mutate.items()
+            },
+            grad_params={},
+            grad_user_inputs={},
+            loss_output=None,
+            inputs=[
+                make_argument_spec(node)
+                for node in gm.graph.nodes
+                if node.op == "placeholder"
+            ],
+            outputs=[
+                make_argument_spec(node)
+                for node in pytree.tree_flatten(
+                    next(iter(reversed(gm.graph.nodes))).args
+                )[0]
+            ],
         )
 
+        new_graph_signature = ExportGraphSignature(
+            input_specs=input_specs, output_specs=output_specs
+        )
         # NOTE: aot_export adds symint metadata for placeholders with int
         # values; since these become specialized, we replace such metadata with
         # the original values.
@@ -570,6 +787,10 @@ class ExportedProgram:
         transformed_gm = res.graph_module if res is not None else self.graph_module
         assert transformed_gm is not None
 
+        if transformed_gm is self.graph_module and not res.modified:
+            return self
+
+        # TODO(zhxchen17) Remove this.
         def _get_updated_graph_signature(
             old_signature: ExportGraphSignature,
             new_gm: torch.fx.GraphModule,
@@ -583,7 +804,13 @@ class ExportedProgram:
             num_inputs = (
                 len(old_signature.parameters)
                 + len(old_signature.buffers)
-                + len(old_signature.user_inputs)
+                + len(
+                    [
+                        s
+                        for s in old_signature.input_specs
+                        if s.kind == InputKind.USER_INPUT
+                    ]
+                )
             )
 
             assert len(new_graph_inputs) == num_inputs, (
@@ -591,13 +818,9 @@ class ExportedProgram:
                 f"to {num_inputs} after transformation. This transformation "
                 "is currently not supported."
             )
-            new_parameter_inputs = new_graph_inputs[: len(old_signature.parameters)]
             num_param_buffers = len(old_signature.buffers) + len(
                 old_signature.parameters
             )
-            new_buffer_inputs = new_graph_inputs[
-                len(old_signature.parameters) : num_param_buffers
-            ]
             new_user_inputs = new_graph_inputs[num_param_buffers:]
 
             output_node = list(new_gm.graph.nodes)[-1]
@@ -605,7 +828,11 @@ class ExportedProgram:
             new_graph_outputs = [arg.name for arg in output_node.args[0]]
 
             assert len(new_graph_outputs) == len(old_signature.buffers_to_mutate) + len(
-                old_signature.user_outputs
+                [
+                    s
+                    for s in old_signature.output_specs
+                    if s.kind == OutputKind.USER_OUTPUT
+                ]
             ), (
                 f"Number of output nodes changed from {len(new_graph_outputs)} "
                 f"to {len(old_signature.buffers_to_mutate) + len(old_signature.user_outputs)} "
@@ -613,16 +840,38 @@ class ExportedProgram:
             )
             new_user_outputs = new_graph_outputs[len(old_signature.buffers_to_mutate) :]
 
+            def make_argument_spec(node) -> ArgumentSpec:
+                val = node.meta["val"]
+                if isinstance(val, torch.Tensor):
+                    return TensorArgument(name=node.name)
+                elif isinstance(val, torch.SymInt):
+                    return SymIntArgument(name=node.name)
+                else:
+                    return ConstantArgument(value=val)
+
+            input_specs, output_specs = _sig_to_specs(
+                user_inputs=set(new_user_inputs),
+                inputs_to_parameters=old_signature.inputs_to_parameters,
+                inputs_to_buffers=old_signature.inputs_to_buffers,
+                user_outputs=set(new_user_outputs),
+                buffer_mutations=old_signature.buffers_to_mutate,
+                grad_params={},
+                grad_user_inputs={},
+                loss_output=None,
+                inputs=[
+                    make_argument_spec(node)
+                    for node in transformed_gm.graph.nodes
+                    if node.op == "placeholder"
+                ],
+                outputs=[
+                    make_argument_spec(node)
+                    for node in pytree.tree_flatten(
+                        next(iter(reversed(transformed_gm.graph.nodes))).args
+                    )[0]
+                ],
+            )
             new_signature = ExportGraphSignature(
-                copy.deepcopy(old_signature.parameters),
-                copy.deepcopy(old_signature.buffers),
-                new_user_inputs,
-                new_user_outputs,
-                copy.deepcopy(old_signature.inputs_to_parameters),
-                copy.deepcopy(old_signature.inputs_to_buffers),
-                copy.deepcopy(old_signature.buffers_to_mutate),
-                copy.deepcopy(old_signature.backward_signature),
-                copy.deepcopy(old_signature.assertion_dep_token),
+                input_specs=input_specs, output_specs=output_specs
             )
             return new_signature
 


### PR DESCRIPTION
Summary:
Previously we design the GraphSignature format as a bunch of inputs and outputs node names. After a discussion in the design meeting we decide to change the format to make signature more self-contained. Now the signature format look like the following:
```
[
InputSpec(
   kind=InputKind.USER_INPUT,
   arg=TensorArgument(name="arg0_1"),
   target=None,
),
...
]
```

Test Plan: CI

Reviewed By: angelayi

Differential Revision: D49876258




cc @avikchaudhuri @gmagogsfm @tugsbayasgalan