### PR TITLE
[Inductor] support channel last for xpu conv in inductor layout opt path

### DIFF
--- a/aten/src/ATen/native/ConvUtils.h
+++ b/aten/src/ATen/native/ConvUtils.h
@@ -416,4 +416,31 @@ static inline bool thnn_conv_use_channels_last(const at::Tensor& input, const at
   return can_use_thnn_channels_last_2d;
 }
 
+static inline bool xpu_conv_use_channels_last(const at::Tensor& input, const at::Tensor& weight) {
+
+  // check layout only for xpu tensor.
+  if (!input.is_xpu() || !weight.is_xpu()) {
+    return false;
+  }
+
+  // disable NHWC for float64 input.
+  if (input.scalar_type() == at::kDouble ||
+      weight.scalar_type() == at::kDouble) {
+    return false;
+  }
+
+  auto input_memory_format = input.suggest_memory_format();
+  auto weight_memory_format = weight.suggest_memory_format();
+
+  bool can_use_xpu_channels_last_2d =
+      (input_memory_format  == at::MemoryFormat::ChannelsLast) ||
+      (weight_memory_format == at::MemoryFormat::ChannelsLast);
+
+  bool can_use_xpu_channels_last_3d =
+      (input_memory_format  == at::MemoryFormat::ChannelsLast3d) ||
+      (weight_memory_format == at::MemoryFormat::ChannelsLast3d);
+
+  return can_use_xpu_channels_last_2d || can_use_xpu_channels_last_3d;
+}
+
 } // namespace at::native

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -1434,6 +1434,11 @@ static inline at::MemoryFormat determine_backend_memory_format(
         backend_memory_format = at::MemoryFormat::ChannelsLast;
       }
       break;
+    case ConvBackend::Overrideable:
+      if (xpu_conv_use_channels_last(input, weight)) {
+        backend_memory_format = at::MemoryFormat::ChannelsLast;
+      }
+      break;
     default:
       backend_memory_format = at::MemoryFormat::Contiguous;
   }

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -1436,7 +1436,7 @@ static inline at::MemoryFormat determine_backend_memory_format(
       break;
     case ConvBackend::Overrideable:
       if (xpu_conv_use_channels_last(input, weight)) {
-        backend_memory_format = at::MemoryFormat::ChannelsLast;
+        backend_memory_format = (k == 5) ? at::MemoryFormat::ChannelsLast3d : at::MemoryFormat::ChannelsLast;
       }
       break;
     default:

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1073,7 +1073,8 @@ class FakeTensor(torch.Tensor):
             init_cuda_context()
 
         if (
-            device.type in ["cuda", "hpu", torch._C._get_privateuse1_backend_name()]
+            device.type
+            in ["cuda", "hpu", "xpu", torch._C._get_privateuse1_backend_name()]
             and device.index is None
         ):
             device = torch.device(


### PR DESCRIPTION
# Motivation
support xpu channel last for inductor layout optimization path.
Currently, `_conv_determine_backend_memory_format` always returns torch.contiguous_format for XPU conv.

# Solution
Add xpu channel last detection stragey in `determine_backend_memory_format`



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10