### PR TITLE
define public API for torch.nn.utils

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -355,7 +355,9 @@ Utilities
 ---------
 .. automodule:: torch.nn.utils
 
-From the ``torch.nn.utils`` module
+From the ``torch.nn.utils`` module:
+
+Utility functions to clip parameter gradients.
 
 .. currentmodule:: torch.nn.utils
 .. autosummary::
@@ -366,12 +368,16 @@ From the ``torch.nn.utils`` module
     clip_grad_norm
     clip_grad_value_
 
+Utility functions to flatten and unflatten Module parameters to and from a single vector.
+
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
     parameters_to_vector
     vector_to_parameters
+
+Utility functions to fuse Modules with BatchNorm modules.
 
 .. autosummary::
     :toctree: generated
@@ -382,11 +388,15 @@ From the ``torch.nn.utils`` module
     fuse_linear_bn_eval
     fuse_linear_bn_weights
 
+Utility functions to convert Module parameter memory formats.
+
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
     convert_conv2d_weight_memory_format
+
+Utility functions to apply and remove weight normalization from Module parameters.
 
 .. autosummary::
     :toctree: generated
@@ -394,19 +404,18 @@ From the ``torch.nn.utils`` module
 
     weight_norm
     remove_weight_norm
-
-.. autosummary::
-    :toctree: generated
-    :nosignatures:
-
     spectral_norm
     remove_spectral_norm
+
+Utility functions for initializing Module parameters.
 
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
     skip_init
+
+Utility classes and functions for pruning Module parameters.
 
 .. autosummary::
     :toctree: generated
@@ -464,7 +473,7 @@ for more information on how to implement your own parametrizations.
 
     parametrize.ParametrizationList
 
-Utility functions to calls a given Module in a stateless manner.
+Utility functions to call a given Module in a stateless manner.
 
 .. autosummary::
     :toctree: generated

--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -363,15 +363,56 @@ From the ``torch.nn.utils`` module
     :nosignatures:
 
     clip_grad_norm_
+    clip_grad_norm
     clip_grad_value_
-    parameters_to_vector
-    vector_to_parameters
-    prune.BasePruningMethod
 
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
+    parameters_to_vector
+    vector_to_parameters
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    fuse_conv_bn_eval
+    fuse_conv_bn_weights
+    fuse_linear_bn_eval
+    fuse_linear_bn_weights
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    convert_conv2d_weight_memory_format
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    weight_norm
+    remove_weight_norm
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    spectral_norm
+    remove_spectral_norm
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    skip_init
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    prune.BasePruningMethod
     prune.PruningContainer
     prune.Identity
     prune.RandomUnstructured
@@ -388,11 +429,6 @@ From the ``torch.nn.utils`` module
     prune.custom_from_mask
     prune.remove
     prune.is_pruned
-    weight_norm
-    remove_weight_norm
-    spectral_norm
-    remove_spectral_norm
-    skip_init
 
 Parametrizations implemented using the new parametrization functionality
 in :func:`torch.nn.utils.parameterize.register_parametrization`.

--- a/torch/ao/nn/intrinsic/qat/modules/conv_fused.py
+++ b/torch/ao/nn/intrinsic/qat/modules/conv_fused.py
@@ -338,6 +338,7 @@ class _ConvBnNd(nn.modules.conv._ConvNd, nni._FusedModule):
 
         if cls._FLOAT_BN_MODULE:  # type: ignore[attr-defined]
             # fuse bn into conv
+            assert self.bn.running_var is not None and self.bn.running_mean is not None
             conv.weight, conv.bias = fuse_conv_bn_weights(
                 conv.weight,
                 conv.bias,

--- a/torch/ao/nn/intrinsic/qat/modules/linear_fused.py
+++ b/torch/ao/nn/intrinsic/qat/modules/linear_fused.py
@@ -159,6 +159,7 @@ class LinearBn1d(nn.modules.linear.Linear, nni._FusedModule):
 
     def to_float(self):
         linear = torch.nn.Linear(self.in_features, self.out_features)
+        assert self.bn.running_var is not None and self.bn.running_mean is not None
         linear.weight, linear.bias = fuse_linear_bn_weights(
             self.weight,
             self.bias,

--- a/torch/ao/nn/intrinsic/quantized/modules/conv_relu.py
+++ b/torch/ao/nn/intrinsic/quantized/modules/conv_relu.py
@@ -55,6 +55,7 @@ class ConvReLU1d(nnq.Conv1d):
     @classmethod
     def from_float(cls, mod):
         if type(mod) == torch.ao.nn.intrinsic.qat.ConvBnReLU1d:
+            assert mod.bn.running_var is not None and mod.bn.running_mean is not None
             mod.weight, mod.bias = fuse_conv_bn_weights(
                 mod.weight, mod.bias, mod.bn.running_mean, mod.bn.running_var,
                 mod.bn.eps, mod.bn.weight, mod.bn.bias)
@@ -104,6 +105,7 @@ class ConvReLU2d(nnq.Conv2d):
     @classmethod
     def from_float(cls, mod):
         if type(mod) == torch.ao.nn.intrinsic.qat.ConvBnReLU2d:
+            assert mod.bn.running_var is not None and mod.bn.running_mean is not None
             mod.weight, mod.bias = fuse_conv_bn_weights(
                 mod.weight, mod.bias, mod.bn.running_mean, mod.bn.running_var,
                 mod.bn.eps, mod.bn.weight, mod.bn.bias)
@@ -154,6 +156,7 @@ class ConvReLU3d(nnq.Conv3d):
     @classmethod
     def from_float(cls, mod):
         if type(mod) == torch.ao.nn.intrinsic.qat.ConvBnReLU3d:
+            assert mod.bn.running_var is not None and mod.bn.running_mean is not None
             mod.weight, mod.bias = fuse_conv_bn_weights(
                 mod.weight,
                 mod.bias,

--- a/torch/nn/utils/__init__.py
+++ b/torch/nn/utils/__init__.py
@@ -3,15 +3,21 @@ from .clip_grad import clip_grad_norm, clip_grad_norm_, clip_grad_value_
 from .weight_norm import weight_norm, remove_weight_norm
 from .convert_parameters import parameters_to_vector, vector_to_parameters
 from .spectral_norm import spectral_norm, remove_spectral_norm
-from .fusion import fuse_conv_bn_eval, fuse_conv_bn_weights
+from .fusion import fuse_conv_bn_eval, fuse_conv_bn_weights, fuse_linear_bn_eval, fuse_linear_bn_weights
 from .memory_format import convert_conv2d_weight_memory_format
 from . import parametrizations
 from .init import skip_init
 from . import stateless
 
 __all__ = [
+    "clip_grad_norm",
     "clip_grad_norm_",
     "clip_grad_value_",
+    "convert_conv2d_weight_memory_format",
+    "fuse_conv_bn_eval",
+    "fuse_conv_bn_weights",
+    "fuse_linear_bn_eval",
+    "fuse_linear_bn_weights",
     "parameters_to_vector",
     "parametrizations",
     "remove_spectral_norm",

--- a/torch/nn/utils/__init__.py
+++ b/torch/nn/utils/__init__.py
@@ -8,3 +8,18 @@ from .memory_format import convert_conv2d_weight_memory_format
 from . import parametrizations
 from .init import skip_init
 from . import stateless
+
+__all__ = [
+    "clip_grad_norm_",
+    "clip_grad_value_",
+    "parameters_to_vector",
+    "parametrizations",
+    "remove_spectral_norm",
+    "remove_weight_norm",
+    "rnn",
+    "skip_init",
+    "spectral_norm",
+    "stateless",
+    "vector_to_parameters",
+    "weight_norm",
+]

--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -12,7 +12,7 @@ __all__ = ['clip_grad_norm_', 'clip_grad_norm', 'clip_grad_value_']
 def clip_grad_norm_(
         parameters: _tensor_or_tensors, max_norm: float, norm_type: float = 2.0,
         error_if_nonfinite: bool = False, foreach: Optional[bool] = None) -> torch.Tensor:
-    r"""Clips gradient norm of an iterable of parameters.
+    r"""Clip the gradient norm of an iterable of parameters.
 
     The norm is computed over all gradients together, as if they were
     concatenated into a single vector. Gradients are modified in-place.
@@ -87,7 +87,7 @@ def clip_grad_norm_(
 def clip_grad_norm(
         parameters: _tensor_or_tensors, max_norm: float, norm_type: float = 2.,
         error_if_nonfinite: bool = False, foreach: Optional[bool] = None) -> torch.Tensor:
-    r"""Clips gradient norm of an iterable of parameters.
+    r"""Clip the gradient norm of an iterable of parameters.
 
     .. warning::
         This method is now deprecated in favor of
@@ -99,7 +99,7 @@ def clip_grad_norm(
 
 
 def clip_grad_value_(parameters: _tensor_or_tensors, clip_value: float, foreach: Optional[bool] = None) -> None:
-    r"""Clips gradient of an iterable of parameters at specified value.
+    r"""Clip the gradients of an iterable of parameters at specified value.
 
     Gradients are modified in-place.
 

--- a/torch/nn/utils/convert_parameters.py
+++ b/torch/nn/utils/convert_parameters.py
@@ -3,10 +3,10 @@ from typing import Iterable, Optional
 
 
 def parameters_to_vector(parameters: Iterable[torch.Tensor]) -> torch.Tensor:
-    r"""Convert parameters to one vector
+    r"""Flatten an iterable of parameters into a single vector.
 
     Args:
-        parameters (Iterable[Tensor]): an iterator of Tensors that are the
+        parameters (Iterable[Tensor]): an iterable of Tensors that are the
             parameters of a model.
 
     Returns:
@@ -25,11 +25,11 @@ def parameters_to_vector(parameters: Iterable[torch.Tensor]) -> torch.Tensor:
 
 
 def vector_to_parameters(vec: torch.Tensor, parameters: Iterable[torch.Tensor]) -> None:
-    r"""Convert one vector to the parameters
+    r"""Copy slices of a vector into an iterable of parameters.
 
     Args:
-        vec (Tensor): a single vector represents the parameters of a model.
-        parameters (Iterable[Tensor]): an iterator of Tensors that are the
+        vec (Tensor): a single vector representing the parameters of a model.
+        parameters (Iterable[Tensor]): an iterable of Tensors that are the
             parameters of a model.
     """
     # Ensure vec of type Tensor

--- a/torch/nn/utils/fusion.py
+++ b/torch/nn/utils/fusion.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import copy
 from typing import Optional, Tuple, TypeVar
 
 import torch
 
-ConvT = TypeVar("ConvT", bound=torch.nn.modules.conv._ConvNd)
-LinearT = TypeVar("LinearT", bound=torch.nn.Linear)
+ConvT = TypeVar("ConvT", bound="torch.nn.modules.conv._ConvNd")
+LinearT = TypeVar("LinearT", bound="torch.nn.Linear")
 
 def fuse_conv_bn_eval(conv: ConvT, bn: torch.nn.modules.batchnorm._BatchNorm, transpose: bool = False) -> ConvT:
     r"""Fuse a convolutional module and a BatchNorm module into a single, new convolutional module.

--- a/torch/nn/utils/fusion.py
+++ b/torch/nn/utils/fusion.py
@@ -1,19 +1,60 @@
-
-
 import copy
+from typing import Optional, Tuple, TypeVar
+
 import torch
 
-def fuse_conv_bn_eval(conv, bn, transpose=False):
-    assert(not (conv.training or bn.training)), "Fusion only for eval!"
+ConvT = TypeVar("ConvT", bound=torch.nn.modules.conv._ConvNd)
+LinearT = TypeVar("LinearT", bound=torch.nn.Linear)
+
+def fuse_conv_bn_eval(conv: ConvT, bn: torch.nn.modules.batchnorm._BatchNorm, transpose: bool = False) -> ConvT:
+    r"""Fuse a convolutional module and a BatchNorm module into a single, new convolutional module.
+
+    Args:
+        conv (torch.nn.modules.conv._ConvNd): A convolutional module.
+        bn (torch.nn.modules.batchnorm._BatchNorm): A BatchNorm module.
+        transpose (bool, optional): If True, transpose the convolutional weight. Defaults to False.
+
+    Returns:
+        torch.nn.modules.conv._ConvNd: The fused convolutional module.
+
+    .. note::
+        Both ``conv`` and ``bn`` must be in eval mode, and ``bn`` must have its running buffers computed.
+    """
+    assert not (conv.training or bn.training), "Fusion only for eval!"
     fused_conv = copy.deepcopy(conv)
 
-    fused_conv.weight, fused_conv.bias = \
-        fuse_conv_bn_weights(fused_conv.weight, fused_conv.bias,
-                             bn.running_mean, bn.running_var, bn.eps, bn.weight, bn.bias, transpose)
+    assert bn.running_mean is not None and bn.running_var is not None
+    fused_conv.weight, fused_conv.bias = fuse_conv_bn_weights(
+        fused_conv.weight, fused_conv.bias,
+        bn.running_mean, bn.running_var, bn.eps, bn.weight, bn.bias, transpose)
 
     return fused_conv
 
-def fuse_conv_bn_weights(conv_w, conv_b, bn_rm, bn_rv, bn_eps, bn_w, bn_b, transpose=False):
+def fuse_conv_bn_weights(
+    conv_w: torch.Tensor,
+    conv_b: Optional[torch.Tensor],
+    bn_rm: torch.Tensor,
+    bn_rv: torch.Tensor,
+    bn_eps: float,
+    bn_w: Optional[torch.Tensor],
+    bn_b: Optional[torch.Tensor],
+    transpose: bool = False
+) -> Tuple[torch.nn.Parameter, torch.nn.Parameter]:
+    r"""Fuse convolutional module parameters and BatchNorm module parameters into new convolutional module parameters.
+
+    Args:
+        conv_w (torch.Tensor): Convolutional weight.
+        conv_b (Optional[torch.Tensor]): Convolutional bias.
+        bn_rm (torch.Tensor): BatchNorm running mean.
+        bn_rv (torch.Tensor): BatchNorm running variance.
+        bn_eps (float): BatchNorm epsilon.
+        bn_w (Optional[torch.Tensor]): BatchNorm weight.
+        bn_b (Optional[torch.Tensor]): BatchNorm bias.
+        transpose (bool, optional): If True, transpose the conv weight. Defaults to False.
+
+    Returns:
+        Tuple[torch.nn.Parameter, torch.nn.Parameter]: Fused convolutional weight and bias.
+    """
     conv_weight_dtype = conv_w.dtype
     conv_bias_dtype = conv_b.dtype if conv_b is not None else conv_weight_dtype
     if conv_b is None:
@@ -32,19 +73,57 @@ def fuse_conv_bn_weights(conv_w, conv_b, bn_rm, bn_rv, bn_eps, bn_w, bn_b, trans
     fused_conv_w = (conv_w * (bn_w * bn_var_rsqrt).reshape(shape)).to(dtype=conv_weight_dtype)
     fused_conv_b = ((conv_b - bn_rm) * bn_var_rsqrt * bn_w + bn_b).to(dtype=conv_bias_dtype)
 
-    return torch.nn.Parameter(fused_conv_w, conv_w.requires_grad), torch.nn.Parameter(fused_conv_b, conv_b.requires_grad)
+    return (
+        torch.nn.Parameter(fused_conv_w, conv_w.requires_grad), torch.nn.Parameter(fused_conv_b, conv_b.requires_grad)
+    )
 
-def fuse_linear_bn_eval(linear, bn):
-    assert(not (linear.training or bn.training)), "Fusion only for eval!"
+def fuse_linear_bn_eval(linear: LinearT, bn: torch.nn.modules.batchnorm._BatchNorm) -> LinearT:
+    r"""Fuse a linear module and a BatchNorm module into a single, new linear module.
+
+    Args:
+        linear (torch.nn.Linear): A Linear module.
+        bn (torch.nn.modules.batchnorm._BatchNorm): A BatchNorm module.
+
+    Returns:
+        torch.nn.Linear: The fused linear module.
+
+    .. note::
+        Both ``linear`` and ``bn`` must be in eval mode, and ``bn`` must have its running buffers computed.
+    """
+    assert not (linear.training or bn.training), "Fusion only for eval!"
     fused_linear = copy.deepcopy(linear)
 
+    assert bn.running_mean is not None and bn.running_var is not None
     fused_linear.weight, fused_linear.bias = fuse_linear_bn_weights(
         fused_linear.weight, fused_linear.bias,
         bn.running_mean, bn.running_var, bn.eps, bn.weight, bn.bias)
 
     return fused_linear
 
-def fuse_linear_bn_weights(linear_w, linear_b, bn_rm, bn_rv, bn_eps, bn_w, bn_b):
+def fuse_linear_bn_weights(
+    linear_w: torch.Tensor,
+    linear_b: Optional[torch.Tensor],
+    bn_rm: torch.Tensor,
+    bn_rv: torch.Tensor,
+    bn_eps: float,
+    bn_w: torch.Tensor,
+    bn_b: torch.Tensor,
+) -> Tuple[torch.nn.Parameter, torch.nn.Parameter]:
+    r"""Fuse linear module parameters and BatchNorm module parameters into new linear module parameters.
+
+    Args:
+        linear_w (torch.Tensor): Linear weight.
+        linear_b (Optional[torch.Tensor]): Linear bias.
+        bn_rm (torch.Tensor): BatchNorm running mean.
+        bn_rv (torch.Tensor): BatchNorm running variance.
+        bn_eps (float): BatchNorm epsilon.
+        bn_w (torch.Tensor): BatchNorm weight.
+        bn_b (torch.Tensor): BatchNorm bias.
+        transpose (bool, optional): If True, transpose the conv weight. Defaults to False.
+
+    Returns:
+        Tuple[torch.nn.Parameter, torch.nn.Parameter]: Fused linear weight and bias.
+    """
     if linear_b is None:
         linear_b = torch.zeros_like(bn_rm)
     bn_scale = bn_w * torch.rsqrt(bn_rv + bn_eps)

--- a/torch/nn/utils/fusion.py
+++ b/torch/nn/utils/fusion.py
@@ -5,6 +5,8 @@ from typing import Optional, Tuple, TypeVar
 
 import torch
 
+__all__ = ['fuse_conv_bn_eval', 'fuse_conv_bn_weights', 'fuse_linear_bn_eval', 'fuse_linear_bn_weights']
+
 ConvT = TypeVar("ConvT", bound="torch.nn.modules.conv._ConvNd")
 LinearT = TypeVar("LinearT", bound="torch.nn.Linear")
 

--- a/torch/nn/utils/init.py
+++ b/torch/nn/utils/init.py
@@ -4,7 +4,7 @@ import torch
 
 def skip_init(module_cls, *args, **kwargs):
     r"""
-    Given a module class object and args / kwargs, instantiates the module without initializing
+    Given a module class object and args / kwargs, instantiate the module without initializing
     parameters / buffers.  This can be useful if initialization is slow or if custom initialization will
     be performed, making the default initialization unnecessary. There are some caveats to this, due to
     the way this function is implemented:

--- a/torch/nn/utils/memory_format.py
+++ b/torch/nn/utils/memory_format.py
@@ -20,9 +20,9 @@ def convert_conv2d_weight_memory_format(module, memory_format):
         Hence our strategy here is to convert only the weight of convolution to
         channels_last. This ensures that;
         1. Fast convolution kernels will be used, the benefit of which could
-           outweigh overhead of permutation (if input is not in the same format)
+        outweigh overhead of permutation (if input is not in the same format)
         2. No unnecessary permutations are applied on layers that do not benefit
-           from memory_format conversion.
+        from memory_format conversion.
 
         The optimal case is that, layers between convolution layers are channels
         last compatible. Input tensor would be permuted to channels last when it


### PR DESCRIPTION
Adding modules imported here and the following functions to the `__all__`:
* [clip_grad_norm_](https://pytorch.org/docs/stable/generated/torch.nn.utils.clip_grad_norm_.html)
* [clip_grad_value_](https://pytorch.org/docs/stable/generated/torch.nn.utils.clip_grad_value_.html)
* [remove_weight_norm](https://pytorch.org/docs/stable/generated/torch.nn.utils.remove_weight_norm.html)
* [parameters_to_vector](https://pytorch.org/docs/stable/generated/torch.nn.utils.parameters_to_vector.html)
* [vector_to_parameters](https://pytorch.org/docs/stable/generated/torch.nn.utils.vector_to_parameters.html)
* [remove_spectral_norm](https://pytorch.org/docs/stable/generated/torch.nn.utils.remove_spectral_norm.html)
* [skip_init](https://pytorch.org/docs/stable/generated/torch.nn.utils.skip_init.html)