### PR TITLE
Fix Android publish step with lite interpreter

### DIFF
--- a/android/pytorch_android/host/build.gradle
+++ b/android/pytorch_android/host/build.gradle
@@ -17,6 +17,7 @@ sourceSets {
         java {
             srcDir '../src/main/java'
             exclude 'org/pytorch/PyTorchAndroid.java'
+            exclude 'org/pytorch/LitePyTorchAndroid.java'
             exclude 'org/pytorch/LiteModuleLoader.java'
             exclude 'org/pytorch/LiteNativePeer.java'
         }


### PR DESCRIPTION
This file needs to be added to the list like others.  The publish command `BUILD_LITE_INTERPRETER=1 android/gradlew -p android publish` finishes successfully with this and files are available on Nexus:

![Screenshot 2023-10-11 at 11 56 53](https://github.com/pytorch/pytorch/assets/475357/849d4aa7-79f6-47fa-a471-d452d7c1bdf6)
