### PR TITLE
[Dist][ez][nit] Formatted nccl version string in startup

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -690,13 +690,8 @@ ProcessGroupNCCL::ProcessGroupNCCL(
       parseEnvVarString("TORCH_DISTRIBUTED_DEBUG", OFF.c_str());
   const char* nccl_debug = parseEnvVarString("NCCL_DEBUG", OFF.c_str());
   LOG(INFO) << "[Rank " << rank_
-            << "] ProcessGroupNCCL initialization options:"
-#ifdef NCCL_VERSION_CODE
-            // NCCL > 2.3.5 should have NCCL_VERSION_CODE defined
-            << "NCCL VERSION: " << NCCL_VERSION_CODE
-#else
-            << "NCCL VERSION: " << NCCL_MAJOR << NCCL_MINOR << NCCL_PATCH
-#endif
+            << "] ProcessGroupNCCL initialization options: "
+            << "NCCL version: " << getNcclVersion()
             << ", NCCL_ASYNC_ERROR_HANDLING: " << asyncErrorHandling_
             << ", NCCL_DESYNC_DEBUG: " << desyncDebug_
             << ", NCCL_ENABLE_TIMING: " << enableTiming_.load()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #111076

Formats the string using the existing getNCCLversion

Differential Revision: [D50193558](https://our.internmc.facebook.com/intern/diff/D50193558/)