### PR TITLE
[AOTInductor] Wrapper codegen fixes

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1,7 +1,7 @@
 import contextlib
 import dataclasses
 import functools
-import itertools
+from itertools import count
 import logging
 import sys
 import time
@@ -873,7 +873,7 @@ def compile_fx_aot(
         )
 
 
-_graph_counter = itertools.count(0)
+_graph_counter = count(0)
 
 
 def fw_compiler_freezing(
@@ -988,7 +988,15 @@ def compile_fx(
                     if node.op == "placeholder"
                 ]
                 if all(v is not None for v in fake_inputs):
+                    # Validate devices before switching to fake tensors.
+                    for idx, fi, i in zip(count(), fake_inputs, inputs_):
+                        if fi.device != i.device:
+                            raise ValueError(
+                                f"Device mismatch between fake input and example input at position #{idx}: {fi.device} vs {i.device}. "
+                                "If the model was exported via torch.export(), make sure torch.export() and torch.aot_compile() run on the same device."
+                            )
                     inputs_ = fake_inputs
+
             return compile_fx(
                 model_,
                 inputs_,

--- a/torch/_inductor/exc.py
+++ b/torch/_inductor/exc.py
@@ -66,6 +66,10 @@ class InvalidCxxCompiler(RuntimeError):
             f"No working C++ compiler found in {config.__name__}.cpp.cxx: {config.cpp.cxx}"
         )
 
+class CppWrapperCodeGenError(RuntimeError):
+    def __init__(self, msg: str):
+        super().__init__(f"C++ wrapper codegen error: {msg}")
+
 
 class CppCompileError(RuntimeError):
     def __init__(self, cmd: list[str], output: str):

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -34,6 +34,7 @@ from .codegen.common import (
 )
 from .codegen.wrapper import CppWrapperCodeGen, CudaWrapperCodeGen, WrapperCodeGen
 from .exc import (
+    CppWrapperCodeGenError,
     LoweringException,
     MissingOperatorWithDecomp,
     MissingOperatorWithoutDecomp,
@@ -463,11 +464,6 @@ class GraphLowering(torch.fx.Interpreter):
     def run(self, *args):
         return super().run(*args)
 
-    def disable_cpp_wrapper(self, cond):
-        metrics.disable_cpp_wrapper += 1
-        self.cpp_wrapper = False
-        log.debug("Set cpp_wrapper to False due to %s", cond)
-
     def register_buffer(self, buffer: ir.ComputedBuffer):
         name = f"buf{len(self.buffers)}"
         self.buffers.append(buffer)
@@ -723,6 +719,15 @@ class GraphLowering(torch.fx.Interpreter):
         for buf in self.buffers:
             buf.decide_layout()
 
+    @contextmanager
+    def set_current_node(self, node: torch.fx.Node):
+        old = self.current_node
+        try:
+            self.current_node = node
+            yield
+        finally:
+            self.current_node = old
+
     def run_node(self, n: torch.fx.Node):
         log.debug("lowering %s", LazyString(lambda: n.format_node()))
         origins = {n}
@@ -876,15 +881,15 @@ class GraphLowering(torch.fx.Interpreter):
 
         return result
 
-    def check_cpp_codegen_disabled(self):
+    def validate_can_generate_cpp_wrapper(self):
         if config.disable_cpp_codegen:
-            self.disable_cpp_wrapper("cpp codegen disabled")
+            metrics.disable_cpp_wrapper += 1
+            raise CppWrapperCodeGenError("C++ codegen is disabled")
 
-    def check_platform(self):
         if sys.platform != "linux":
-            self.disable_cpp_wrapper("platform not linux")
+            metrics.disable_cpp_wrapper += 1
+            raise CppWrapperCodeGenError(f"Unsupported platform {sys.platform}")
 
-    def check_input_for_cpp_buffer(self):
         for value in self.graph_inputs.values():
             dtype = None
             if isinstance(value, TensorBox):
@@ -895,35 +900,17 @@ class GraphLowering(torch.fx.Interpreter):
                 dtype = may_get_constant_buffer_dtype(value)
 
             if not supported_dtype_of_cpp_wrapper(dtype, self.cuda):
-                self.disable_cpp_wrapper("unsupported inputs dtype")
-
-    @contextmanager
-    def set_current_node(self, node: torch.fx.Node):
-        old = self.current_node
-        try:
-            self.current_node = node
-            yield
-        finally:
-            self.current_node = old
-
-    def check_cpp_wrapper(self):
-        self.check_cpp_codegen_disabled()
-        self.check_platform()
-        self.check_input_for_cpp_buffer()
+                metrics.disable_cpp_wrapper += 1
+                raise CppWrapperCodeGenError(f"Unsupported input dtype {dtype}")
 
     def init_wrapper_code(self):
         self.cuda = "cuda" in self.device_types
         if self.cpp_wrapper:
-            self.check_cpp_wrapper()
-            # Re-check self.cpp_wrapper because it might be disabled due to failed checking
-            if self.cuda:
-                assert self.cpp_wrapper, "CudaWrapperCodeGen hit unsupported case"
-
-            if self.cpp_wrapper:
-                self.wrapper_code = (
-                    CudaWrapperCodeGen() if self.cuda else CppWrapperCodeGen()
-                )
-                return
+            self.validate_can_generate_cpp_wrapper()
+            self.wrapper_code = (
+                CudaWrapperCodeGen() if self.cuda else CppWrapperCodeGen()
+            )
+            return
 
         device_types = self.device_types.copy()
         # In terms of some operations that don't have input tensors, we need to


### PR DESCRIPTION
Summary:
The changes:
1. When using fake inputs make sure they are on the same device as the original inputs.
1. Don't change the value of `self.cpp_wrapper` from `True` to `False` if can't generate a C++ wrapper, instead have a check and fail early to avoid producing Python code for C++ compiler.

Differential Revision: D50154720




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler