### PR TITLE
Add constant node sizes to proto size calculation

### DIFF
--- a/test/onnx/expect/TestOperators.test_addconstant.expect
+++ b/test/onnx/expect/TestOperators.test_addconstant.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Add_1"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -19,7 +19,7 @@ graph {
     input: "onnx::Add_0"
     input: "onnx::Add_1"
     output: "2"
-    name: "Add_1"
+    name: "Add_2"
     op_type: "Add"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_arange_dynamic.expect
+++ b/test/onnx/expect/TestOperators.test_arange_dynamic.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "1"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"

--- a/test/onnx/expect/TestOperators.test_aten_embedding_1.expect
+++ b/test/onnx/expect/TestOperators.test_aten_embedding_1.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "3"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"

--- a/test/onnx/expect/TestOperators.test_aten_embedding_2.expect
+++ b/test/onnx/expect/TestOperators.test_aten_embedding_2.expect
@@ -6,7 +6,7 @@ graph {
     input: "emb.weight"
     input: "input_1"
     output: "onnx::Add_3"
-    name: "ATen_0"
+    name: "ATen_1"
     op_type: "ATen"
     attribute {
       name: "custom_attributes_json"
@@ -29,18 +29,18 @@ graph {
     input: "onnx::Add_3"
     input: "input_2"
     output: "onnx::Shape_4"
-    name: "Add_1"
+    name: "Add_2"
     op_type: "Add"
   }
   node {
     input: "onnx::Shape_4"
     output: "onnx::Gather_5"
-    name: "Shape_2"
+    name: "Shape_3"
     op_type: "Shape"
   }
   node {
     output: "onnx::Gather_6"
-    name: "Constant_3"
+    name: "Constant_4"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -55,7 +55,7 @@ graph {
     input: "onnx::Gather_5"
     input: "onnx::Gather_6"
     output: "onnx::Unsqueeze_7"
-    name: "Gather_4"
+    name: "Gather_5"
     op_type: "Gather"
     attribute {
       name: "axis"
@@ -66,7 +66,7 @@ graph {
   node {
     input: "onnx::Unsqueeze_7"
     output: "onnx::Concat_8"
-    name: "Unsqueeze_5"
+    name: "Unsqueeze_6"
     op_type: "Unsqueeze"
     attribute {
       name: "axes"
@@ -77,7 +77,7 @@ graph {
   node {
     input: "onnx::Concat_8"
     output: "onnx::ConstantOfShape_9"
-    name: "Concat_6"
+    name: "Concat_7"
     op_type: "Concat"
     attribute {
       name: "axis"
@@ -88,7 +88,7 @@ graph {
   node {
     input: "onnx::ConstantOfShape_9"
     output: "10"
-    name: "ConstantOfShape_7"
+    name: "ConstantOfShape_8"
     op_type: "ConstantOfShape"
     attribute {
       name: "value"

--- a/test/onnx/expect/TestOperators.test_baddbmm.expect
+++ b/test/onnx/expect/TestOperators.test_baddbmm.expect
@@ -6,12 +6,12 @@ graph {
     input: "onnx::MatMul_1"
     input: "onnx::MatMul_2"
     output: "onnx::Mul_4"
-    name: "MatMul_0"
+    name: "MatMul_2"
     op_type: "MatMul"
   }
   node {
     output: "onnx::Mul_10"
-    name: "Constant_1"
+    name: "Constant_3"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -26,12 +26,12 @@ graph {
     input: "onnx::Mul_4"
     input: "onnx::Mul_10"
     output: "onnx::Add_6"
-    name: "Mul_2"
+    name: "Mul_4"
     op_type: "Mul"
   }
   node {
     output: "onnx::Mul_11"
-    name: "Constant_3"
+    name: "Constant_5"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -46,14 +46,14 @@ graph {
     input: "onnx::Mul_0"
     input: "onnx::Mul_11"
     output: "onnx::Add_8"
-    name: "Mul_4"
+    name: "Mul_6"
     op_type: "Mul"
   }
   node {
     input: "onnx::Add_6"
     input: "onnx::Add_8"
     output: "9"
-    name: "Add_5"
+    name: "Add_7"
     op_type: "Add"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_batchnorm_noaffine.expect
+++ b/test/onnx/expect/TestOperators.test_batchnorm_noaffine.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::BatchNormalization_4"
-    name: "Constant_0"
+    name: "Constant_2"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -18,7 +18,7 @@ graph {
   }
   node {
     output: "onnx::BatchNormalization_5"
-    name: "Constant_1"
+    name: "Constant_3"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -37,7 +37,7 @@ graph {
     input: "running_mean"
     input: "running_var"
     output: "6"
-    name: "BatchNormalization_2"
+    name: "BatchNormalization_4"
     op_type: "BatchNormalization"
     attribute {
       name: "epsilon"

--- a/test/onnx/expect/TestOperators.test_bitshift.expect
+++ b/test/onnx/expect/TestOperators.test_bitshift.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::BitShift_7"
-    name: "Constant_0"
+    name: "Constant_2"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -19,7 +19,7 @@ graph {
     input: "onnx::BitShift_0"
     input: "onnx::BitShift_7"
     output: "3"
-    name: "BitShift_1"
+    name: "BitShift_3"
     op_type: "BitShift"
     attribute {
       name: "direction"
@@ -29,7 +29,7 @@ graph {
   }
   node {
     output: "onnx::BitShift_8"
-    name: "Constant_2"
+    name: "Constant_4"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -44,7 +44,7 @@ graph {
     input: "onnx::BitShift_0"
     input: "onnx::BitShift_8"
     output: "6"
-    name: "BitShift_3"
+    name: "BitShift_5"
     op_type: "BitShift"
     attribute {
       name: "direction"

--- a/test/onnx/expect/TestOperators.test_chunk.expect
+++ b/test/onnx/expect/TestOperators.test_chunk.expect
@@ -5,12 +5,12 @@ graph {
   node {
     input: "onnx::Shape_0"
     output: "onnx::Gather_1"
-    name: "Shape_0"
+    name: "Shape_6"
     op_type: "Shape"
   }
   node {
     output: "onnx::Gather_2"
-    name: "Constant_1"
+    name: "Constant_7"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -26,7 +26,7 @@ graph {
     input: "onnx::Gather_1"
     input: "onnx::Gather_2"
     output: "onnx::Add_3"
-    name: "Gather_2"
+    name: "Gather_8"
     op_type: "Gather"
     attribute {
       name: "axis"
@@ -36,7 +36,7 @@ graph {
   }
   node {
     output: "onnx::Slice_4"
-    name: "Constant_3"
+    name: "Constant_9"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -50,7 +50,7 @@ graph {
   }
   node {
     output: "onnx::Add_5"
-    name: "Constant_4"
+    name: "Constant_10"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -66,12 +66,12 @@ graph {
     input: "onnx::Add_3"
     input: "onnx::Add_5"
     output: "onnx::Div_6"
-    name: "Add_5"
+    name: "Add_11"
     op_type: "Add"
   }
   node {
     output: "onnx::Div_7"
-    name: "Constant_6"
+    name: "Constant_12"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -87,12 +87,12 @@ graph {
     input: "onnx::Div_6"
     input: "onnx::Div_7"
     output: "onnx::Mul_8"
-    name: "Div_7"
+    name: "Div_13"
     op_type: "Div"
   }
   node {
     output: "onnx::Mul_9"
-    name: "Constant_8"
+    name: "Constant_14"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -108,7 +108,7 @@ graph {
     input: "onnx::Mul_8"
     input: "onnx::Mul_9"
     output: "onnx::Slice_10"
-    name: "Mul_9"
+    name: "Mul_15"
     op_type: "Mul"
   }
   node {
@@ -117,12 +117,12 @@ graph {
     input: "onnx::Slice_10"
     input: "onnx::Gather_2"
     output: "11"
-    name: "Slice_10"
+    name: "Slice_16"
     op_type: "Slice"
   }
   node {
     output: "onnx::Mul_12"
-    name: "Constant_11"
+    name: "Constant_17"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -138,7 +138,7 @@ graph {
     input: "onnx::Mul_8"
     input: "onnx::Mul_12"
     output: "onnx::Slice_13"
-    name: "Mul_12"
+    name: "Mul_18"
     op_type: "Mul"
   }
   node {
@@ -147,7 +147,7 @@ graph {
     input: "onnx::Slice_13"
     input: "onnx::Gather_2"
     output: "14"
-    name: "Slice_13"
+    name: "Slice_19"
     op_type: "Slice"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_clip.expect
+++ b/test/onnx/expect/TestOperators.test_clip.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Clip_6"
-    name: "Constant_0"
+    name: "Constant_2"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -17,7 +17,7 @@ graph {
   }
   node {
     output: "onnx::Clip_7"
-    name: "Constant_1"
+    name: "Constant_3"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -33,7 +33,7 @@ graph {
     input: "onnx::Clip_6"
     input: "onnx::Clip_7"
     output: "5"
-    name: "Clip_2"
+    name: "Clip_4"
     op_type: "Clip"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_clip_max.expect
+++ b/test/onnx/expect/TestOperators.test_clip_max.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Clip_7"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -20,7 +20,7 @@ graph {
     input: ""
     input: "onnx::Clip_7"
     output: "5"
-    name: "Clip_1"
+    name: "Clip_2"
     op_type: "Clip"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_clip_min.expect
+++ b/test/onnx/expect/TestOperators.test_clip_min.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Clip_7"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -20,7 +20,7 @@ graph {
     input: "onnx::Clip_7"
     input: ""
     output: "5"
-    name: "Clip_1"
+    name: "Clip_2"
     op_type: "Clip"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_cumsum.expect
+++ b/test/onnx/expect/TestOperators.test_cumsum.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::CumSum_1"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -19,7 +19,7 @@ graph {
     input: "onnx::CumSum_0"
     input: "onnx::CumSum_1"
     output: "2"
-    name: "CumSum_1"
+    name: "CumSum_2"
     op_type: "CumSum"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_dict_str.expect
+++ b/test/onnx/expect/TestOperators.test_dict_str.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Add_1"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -19,7 +19,7 @@ graph {
     input: "onnx::Add_0"
     input: "onnx::Add_1"
     output: "2"
-    name: "Add_1"
+    name: "Add_2"
     op_type: "Add"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_dim.expect
+++ b/test/onnx/expect/TestOperators.test_dim.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "1"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"

--- a/test/onnx/expect/TestOperators.test_dropout_default.expect
+++ b/test/onnx/expect/TestOperators.test_dropout_default.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Dropout_1"
-    name: "Constant_0"
+    name: "Constant_2"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -17,7 +17,7 @@ graph {
   }
   node {
     output: "onnx::Dropout_2"
-    name: "Constant_1"
+    name: "Constant_3"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -34,13 +34,13 @@ graph {
     input: "onnx::Dropout_2"
     output: "onnx::ReduceMax_3"
     output: "4"
-    name: "Dropout_2"
+    name: "Dropout_4"
     op_type: "Dropout"
   }
   node {
     input: "onnx::ReduceMax_3"
     output: "5"
-    name: "ReduceMax_3"
+    name: "ReduceMax_5"
     op_type: "ReduceMax"
     attribute {
       name: "keepdims"

--- a/test/onnx/expect/TestOperators.test_dropout_training.expect
+++ b/test/onnx/expect/TestOperators.test_dropout_training.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Dropout_1"
-    name: "Constant_0"
+    name: "Constant_2"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -17,7 +17,7 @@ graph {
   }
   node {
     output: "onnx::Dropout_2"
-    name: "Constant_1"
+    name: "Constant_3"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -34,13 +34,13 @@ graph {
     input: "onnx::Dropout_2"
     output: "onnx::ReduceMax_3"
     output: "4"
-    name: "Dropout_2"
+    name: "Dropout_4"
     op_type: "Dropout"
   }
   node {
     input: "onnx::ReduceMax_3"
     output: "5"
-    name: "ReduceMax_3"
+    name: "ReduceMax_5"
     op_type: "ReduceMax"
     attribute {
       name: "keepdims"

--- a/test/onnx/expect/TestOperators.test_dropout_training_opset12.expect
+++ b/test/onnx/expect/TestOperators.test_dropout_training_opset12.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Dropout_1"
-    name: "Constant_0"
+    name: "Constant_2"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -17,7 +17,7 @@ graph {
   }
   node {
     output: "onnx::Dropout_2"
-    name: "Constant_1"
+    name: "Constant_3"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -34,13 +34,13 @@ graph {
     input: "onnx::Dropout_2"
     output: "onnx::ReduceMax_3"
     output: "4"
-    name: "Dropout_2"
+    name: "Dropout_4"
     op_type: "Dropout"
   }
   node {
     input: "onnx::ReduceMax_3"
     output: "5"
-    name: "ReduceMax_3"
+    name: "ReduceMax_5"
     op_type: "ReduceMax"
     attribute {
       name: "keepdims"

--- a/test/onnx/expect/TestOperators.test_embedding_bags.expect
+++ b/test/onnx/expect/TestOperators.test_embedding_bags.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Loop_33"
-    name: "Constant_0"
+    name: "Constant_9"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -17,7 +17,7 @@ graph {
   }
   node {
     output: "5"
-    name: "Constant_1"
+    name: "Constant_10"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -32,12 +32,12 @@ graph {
   node {
     input: "input"
     output: "onnx::Gather_6"
-    name: "Shape_2"
+    name: "Shape_11"
     op_type: "Shape"
   }
   node {
     output: "onnx::Gather_7"
-    name: "Constant_3"
+    name: "Constant_12"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -52,7 +52,7 @@ graph {
     input: "onnx::Gather_6"
     input: "onnx::Gather_7"
     output: "onnx::Unsqueeze_8"
-    name: "Gather_4"
+    name: "Gather_13"
     op_type: "Gather"
     attribute {
       name: "axis"
@@ -62,7 +62,7 @@ graph {
   }
   node {
     output: "onnx::Unsqueeze_9"
-    name: "Constant_5"
+    name: "Constant_14"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -78,14 +78,14 @@ graph {
     input: "onnx::Unsqueeze_8"
     input: "onnx::Unsqueeze_9"
     output: "onnx::Concat_10"
-    name: "Unsqueeze_6"
+    name: "Unsqueeze_15"
     op_type: "Unsqueeze"
   }
   node {
     input: "offsets"
     input: "onnx::Concat_10"
     output: "onnx::Slice_11"
-    name: "Concat_7"
+    name: "Concat_16"
     op_type: "Concat"
     attribute {
       name: "axis"
@@ -95,7 +95,7 @@ graph {
   }
   node {
     output: "onnx::Slice_12"
-    name: "Constant_8"
+    name: "Constant_17"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -109,7 +109,7 @@ graph {
   }
   node {
     output: "onnx::Slice_13"
-    name: "Constant_9"
+    name: "Constant_18"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -123,7 +123,7 @@ graph {
   }
   node {
     output: "onnx::Slice_14"
-    name: "Constant_10"
+    name: "Constant_19"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -137,7 +137,7 @@ graph {
   }
   node {
     output: "onnx::Slice_15"
-    name: "Constant_11"
+    name: "Constant_20"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -156,18 +156,18 @@ graph {
     input: "onnx::Slice_12"
     input: "onnx::Slice_15"
     output: "onnx::Shape_16"
-    name: "Slice_12"
+    name: "Slice_21"
     op_type: "Slice"
   }
   node {
     input: "onnx::Shape_16"
     output: "onnx::Gather_17"
-    name: "Shape_13"
+    name: "Shape_22"
     op_type: "Shape"
   }
   node {
     output: "onnx::Gather_18"
-    name: "Constant_14"
+    name: "Constant_23"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -182,7 +182,7 @@ graph {
     input: "onnx::Gather_17"
     input: "onnx::Gather_18"
     output: "onnx::Loop_19"
-    name: "Gather_15"
+    name: "Gather_24"
     op_type: "Gather"
     attribute {
       name: "axis"
@@ -194,7 +194,7 @@ graph {
     input: "onnx::Loop_19"
     input: "onnx::Loop_33"
     output: "20"
-    name: "Loop_16"
+    name: "Loop_25"
     op_type: "Loop"
     attribute {
       name: "body"
@@ -203,7 +203,7 @@ graph {
           input: "onnx::Slice_11"
           input: "21"
           output: "23"
-          name: "Gather_17"
+          name: "Gather_26"
           op_type: "Gather"
           attribute {
             name: "axis"
@@ -215,7 +215,7 @@ graph {
           input: "onnx::Shape_16"
           input: "21"
           output: "24"
-          name: "Gather_18"
+          name: "Gather_27"
           op_type: "Gather"
           attribute {
             name: "axis"
@@ -225,7 +225,7 @@ graph {
         }
         node {
           output: "25"
-          name: "Constant_19"
+          name: "Constant_28"
           op_type: "Constant"
           attribute {
             name: "value"
@@ -241,12 +241,12 @@ graph {
           input: "23"
           input: "25"
           output: "26"
-          name: "Unsqueeze_20"
+          name: "Unsqueeze_29"
           op_type: "Unsqueeze"
         }
         node {
           output: "27"
-          name: "Constant_21"
+          name: "Constant_30"
           op_type: "Constant"
           attribute {
             name: "value"
@@ -262,7 +262,7 @@ graph {
           input: "24"
           input: "27"
           output: "28"
-          name: "Unsqueeze_22"
+          name: "Unsqueeze_31"
           op_type: "Unsqueeze"
         }
         node {
@@ -271,14 +271,14 @@ graph {
           input: "28"
           input: "5"
           output: "29"
-          name: "Slice_23"
+          name: "Slice_32"
           op_type: "Slice"
         }
         node {
           input: "weight"
           input: "29"
           output: "30"
-          name: "Gather_24"
+          name: "Gather_33"
           op_type: "Gather"
           attribute {
             name: "axis"
@@ -289,7 +289,7 @@ graph {
         node {
           input: "30"
           output: "31"
-          name: "ReduceMean_25"
+          name: "ReduceMean_34"
           op_type: "ReduceMean"
           attribute {
             name: "axes"
@@ -305,7 +305,7 @@ graph {
         node {
           input: "onnx::Loop_33"
           output: "32"
-          name: "Cast_26"
+          name: "Cast_35"
           op_type: "Cast"
           attribute {
             name: "to"

--- a/test/onnx/expect/TestOperators.test_empty_like.expect
+++ b/test/onnx/expect/TestOperators.test_empty_like.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "1"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"

--- a/test/onnx/expect/TestOperators.test_expand.expect
+++ b/test/onnx/expect/TestOperators.test_expand.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Where_1"
-    name: "Constant_0"
+    name: "Constant_4"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -18,7 +18,7 @@ graph {
   }
   node {
     output: "onnx::ConstantOfShape_10"
-    name: "Constant_1"
+    name: "Constant_5"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -33,7 +33,7 @@ graph {
   node {
     input: "onnx::ConstantOfShape_10"
     output: "onnx::Mul_3"
-    name: "ConstantOfShape_2"
+    name: "ConstantOfShape_6"
     op_type: "ConstantOfShape"
     attribute {
       name: "value"
@@ -47,7 +47,7 @@ graph {
   }
   node {
     output: "onnx::Mul_4"
-    name: "Constant_3"
+    name: "Constant_7"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -62,12 +62,12 @@ graph {
     input: "onnx::Mul_3"
     input: "onnx::Mul_4"
     output: "onnx::Equal_5"
-    name: "Mul_4"
+    name: "Mul_8"
     op_type: "Mul"
   }
   node {
     output: "onnx::Equal_6"
-    name: "Constant_5"
+    name: "Constant_9"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -83,7 +83,7 @@ graph {
     input: "onnx::Equal_6"
     input: "onnx::Equal_5"
     output: "onnx::Where_7"
-    name: "Equal_6"
+    name: "Equal_10"
     op_type: "Equal"
   }
   node {
@@ -91,14 +91,14 @@ graph {
     input: "onnx::Mul_3"
     input: "onnx::Where_1"
     output: "onnx::Expand_8"
-    name: "Where_7"
+    name: "Where_11"
     op_type: "Where"
   }
   node {
     input: "onnx::Expand_0"
     input: "onnx::Expand_8"
     output: "9"
-    name: "Expand_8"
+    name: "Expand_12"
     op_type: "Expand"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_flatten.expect
+++ b/test/onnx/expect/TestOperators.test_flatten.expect
@@ -5,12 +5,12 @@ graph {
   node {
     input: "onnx::Shape_0"
     output: "onnx::Slice_1"
-    name: "Shape_0"
+    name: "Shape_4"
     op_type: "Shape"
   }
   node {
     output: "onnx::Slice_2"
-    name: "Constant_1"
+    name: "Constant_5"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -24,7 +24,7 @@ graph {
   }
   node {
     output: "onnx::Slice_3"
-    name: "Constant_2"
+    name: "Constant_6"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -38,7 +38,7 @@ graph {
   }
   node {
     output: "onnx::Slice_4"
-    name: "Constant_3"
+    name: "Constant_7"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -56,12 +56,12 @@ graph {
     input: "onnx::Slice_4"
     input: "onnx::Slice_2"
     output: "onnx::Concat_5"
-    name: "Slice_4"
+    name: "Slice_8"
     op_type: "Slice"
   }
   node {
     output: "onnx::Concat_6"
-    name: "Constant_5"
+    name: "Constant_9"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -77,7 +77,7 @@ graph {
     input: "onnx::Concat_5"
     input: "onnx::Concat_6"
     output: "onnx::Reshape_7"
-    name: "Concat_6"
+    name: "Concat_10"
     op_type: "Concat"
     attribute {
       name: "axis"
@@ -89,7 +89,7 @@ graph {
     input: "onnx::Shape_0"
     input: "onnx::Reshape_7"
     output: "8"
-    name: "Reshape_7"
+    name: "Reshape_11"
     op_type: "Reshape"
     attribute {
       name: "allowzero"

--- a/test/onnx/expect/TestOperators.test_frobenius_norm.expect
+++ b/test/onnx/expect/TestOperators.test_frobenius_norm.expect
@@ -5,12 +5,12 @@ graph {
   node {
     input: "x"
     output: "onnx::Pow_1"
-    name: "Abs_0"
+    name: "Abs_3"
     op_type: "Abs"
   }
   node {
     output: "onnx::Pow_2"
-    name: "Constant_1"
+    name: "Constant_4"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -25,12 +25,12 @@ graph {
     input: "onnx::Pow_1"
     input: "onnx::Pow_2"
     output: "onnx::ReduceSum_3"
-    name: "Pow_2"
+    name: "Pow_5"
     op_type: "Pow"
   }
   node {
     output: "onnx::ReduceSum_4"
-    name: "Constant_3"
+    name: "Constant_6"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -46,7 +46,7 @@ graph {
     input: "onnx::ReduceSum_3"
     input: "onnx::ReduceSum_4"
     output: "onnx::Pow_5"
-    name: "ReduceSum_4"
+    name: "ReduceSum_7"
     op_type: "ReduceSum"
     attribute {
       name: "keepdims"
@@ -61,7 +61,7 @@ graph {
   }
   node {
     output: "onnx::Pow_10"
-    name: "Constant_5"
+    name: "Constant_8"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -76,7 +76,7 @@ graph {
     input: "onnx::Pow_5"
     input: "onnx::Pow_10"
     output: "9"
-    name: "Pow_6"
+    name: "Pow_9"
     op_type: "Pow"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_full.expect
+++ b/test/onnx/expect/TestOperators.test_full.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "1"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"

--- a/test/onnx/expect/TestOperators.test_full_like.expect
+++ b/test/onnx/expect/TestOperators.test_full_like.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "1"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"

--- a/test/onnx/expect/TestOperators.test_gelu.expect
+++ b/test/onnx/expect/TestOperators.test_gelu.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Div_1"
-    name: "Constant_0"
+    name: "Constant_3"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -19,18 +19,18 @@ graph {
     input: "onnx::Div_0"
     input: "onnx::Div_1"
     output: "onnx::Erf_2"
-    name: "Div_1"
+    name: "Div_4"
     op_type: "Div"
   }
   node {
     input: "onnx::Erf_2"
     output: "onnx::Add_3"
-    name: "Erf_2"
+    name: "Erf_5"
     op_type: "Erf"
   }
   node {
     output: "onnx::Add_4"
-    name: "Constant_3"
+    name: "Constant_6"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -45,19 +45,19 @@ graph {
     input: "onnx::Add_3"
     input: "onnx::Add_4"
     output: "onnx::Mul_5"
-    name: "Add_4"
+    name: "Add_7"
     op_type: "Add"
   }
   node {
     input: "onnx::Div_0"
     input: "onnx::Mul_5"
     output: "onnx::Mul_6"
-    name: "Mul_5"
+    name: "Mul_8"
     op_type: "Mul"
   }
   node {
     output: "onnx::Mul_7"
-    name: "Constant_6"
+    name: "Constant_9"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -72,7 +72,7 @@ graph {
     input: "onnx::Mul_6"
     input: "onnx::Mul_7"
     output: "8"
-    name: "Mul_7"
+    name: "Mul_10"
     op_type: "Mul"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_hardtanh.expect
+++ b/test/onnx/expect/TestOperators.test_hardtanh.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Clip_1"
-    name: "Constant_0"
+    name: "Constant_2"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -17,7 +17,7 @@ graph {
   }
   node {
     output: "onnx::Clip_2"
-    name: "Constant_1"
+    name: "Constant_3"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -33,7 +33,7 @@ graph {
     input: "onnx::Clip_1"
     input: "onnx::Clip_2"
     output: "3"
-    name: "Clip_2"
+    name: "Clip_4"
     op_type: "Clip"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_implicit_expand.expect
+++ b/test/onnx/expect/TestOperators.test_implicit_expand.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Add_1"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -19,7 +19,7 @@ graph {
     input: "onnx::Add_0"
     input: "onnx::Add_1"
     output: "2"
-    name: "Add_1"
+    name: "Add_2"
     op_type: "Add"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_index.expect
+++ b/test/onnx/expect/TestOperators.test_index.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Gather_1"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -19,7 +19,7 @@ graph {
     input: "onnx::Gather_0"
     input: "onnx::Gather_1"
     output: "2"
-    name: "Gather_1"
+    name: "Gather_2"
     op_type: "Gather"
     attribute {
       name: "axis"

--- a/test/onnx/expect/TestOperators.test_lstm_none_sequence_lens.expect
+++ b/test/onnx/expect/TestOperators.test_lstm_none_sequence_lens.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "7"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"

--- a/test/onnx/expect/TestOperators.test_maxpool_indices.expect
+++ b/test/onnx/expect/TestOperators.test_maxpool_indices.expect
@@ -6,7 +6,7 @@ graph {
     input: "onnx::MaxPool_0"
     output: "1"
     output: "onnx::Sub_2"
-    name: "MaxPool_0"
+    name: "MaxPool_3"
     op_type: "MaxPool"
     attribute {
       name: "ceil_mode"
@@ -34,7 +34,7 @@ graph {
     input: "onnx::MaxPool_0"
     output: "3"
     output: "onnx::Slice_4"
-    name: "MaxPool_1"
+    name: "MaxPool_4"
     op_type: "MaxPool"
     attribute {
       name: "kernel_shape"
@@ -49,7 +49,7 @@ graph {
   }
   node {
     output: "onnx::Slice_5"
-    name: "Constant_2"
+    name: "Constant_5"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -63,7 +63,7 @@ graph {
   }
   node {
     output: "onnx::Slice_6"
-    name: "Constant_3"
+    name: "Constant_6"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -77,7 +77,7 @@ graph {
   }
   node {
     output: "onnx::Slice_7"
-    name: "Constant_4"
+    name: "Constant_7"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -95,14 +95,14 @@ graph {
     input: "onnx::Slice_7"
     input: "onnx::Slice_5"
     output: "onnx::Sub_8"
-    name: "Slice_5"
+    name: "Slice_8"
     op_type: "Slice"
   }
   node {
     input: "onnx::Sub_2"
     input: "onnx::Sub_8"
     output: "9"
-    name: "Sub_6"
+    name: "Sub_9"
     op_type: "Sub"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_meshgrid.expect
+++ b/test/onnx/expect/TestOperators.test_meshgrid.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Reshape_3"
-    name: "Constant_0"
+    name: "Constant_6"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -20,7 +20,7 @@ graph {
     input: "onnx::Reshape_0"
     input: "onnx::Reshape_3"
     output: "onnx::Shape_4"
-    name: "Reshape_1"
+    name: "Reshape_7"
     op_type: "Reshape"
     attribute {
       name: "allowzero"
@@ -30,7 +30,7 @@ graph {
   }
   node {
     output: "onnx::Reshape_5"
-    name: "Constant_2"
+    name: "Constant_8"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -46,7 +46,7 @@ graph {
     input: "onnx::Reshape_1"
     input: "onnx::Reshape_5"
     output: "onnx::Shape_6"
-    name: "Reshape_3"
+    name: "Reshape_9"
     op_type: "Reshape"
     attribute {
       name: "allowzero"
@@ -56,7 +56,7 @@ graph {
   }
   node {
     output: "onnx::Reshape_7"
-    name: "Constant_4"
+    name: "Constant_10"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -72,7 +72,7 @@ graph {
     input: "onnx::Reshape_2"
     input: "onnx::Reshape_7"
     output: "onnx::Shape_8"
-    name: "Reshape_5"
+    name: "Reshape_11"
     op_type: "Reshape"
     attribute {
       name: "allowzero"
@@ -83,19 +83,19 @@ graph {
   node {
     input: "onnx::Shape_4"
     output: "onnx::Concat_9"
-    name: "Shape_6"
+    name: "Shape_12"
     op_type: "Shape"
   }
   node {
     input: "onnx::Shape_6"
     output: "onnx::Concat_10"
-    name: "Shape_7"
+    name: "Shape_13"
     op_type: "Shape"
   }
   node {
     input: "onnx::Shape_8"
     output: "onnx::Concat_11"
-    name: "Shape_8"
+    name: "Shape_14"
     op_type: "Shape"
   }
   node {
@@ -103,7 +103,7 @@ graph {
     input: "onnx::Concat_10"
     input: "onnx::Concat_11"
     output: "onnx::Expand_12"
-    name: "Concat_9"
+    name: "Concat_15"
     op_type: "Concat"
     attribute {
       name: "axis"
@@ -113,7 +113,7 @@ graph {
   }
   node {
     output: "onnx::Concat_13"
-    name: "Constant_10"
+    name: "Constant_16"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -130,7 +130,7 @@ graph {
     input: "onnx::Concat_13"
     input: "onnx::Concat_13"
     output: "onnx::Reshape_14"
-    name: "Concat_11"
+    name: "Concat_17"
     op_type: "Concat"
     attribute {
       name: "axis"
@@ -142,7 +142,7 @@ graph {
     input: "onnx::Shape_4"
     input: "onnx::Reshape_14"
     output: "onnx::Expand_15"
-    name: "Reshape_12"
+    name: "Reshape_18"
     op_type: "Reshape"
     attribute {
       name: "allowzero"
@@ -154,12 +154,12 @@ graph {
     input: "onnx::Expand_15"
     input: "onnx::Expand_12"
     output: "16"
-    name: "Expand_13"
+    name: "Expand_19"
     op_type: "Expand"
   }
   node {
     output: "onnx::Concat_17"
-    name: "Constant_14"
+    name: "Constant_20"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -176,7 +176,7 @@ graph {
     input: "onnx::Concat_10"
     input: "onnx::Concat_17"
     output: "onnx::Reshape_18"
-    name: "Concat_15"
+    name: "Concat_21"
     op_type: "Concat"
     attribute {
       name: "axis"
@@ -188,7 +188,7 @@ graph {
     input: "onnx::Shape_6"
     input: "onnx::Reshape_18"
     output: "onnx::Expand_19"
-    name: "Reshape_16"
+    name: "Reshape_22"
     op_type: "Reshape"
     attribute {
       name: "allowzero"
@@ -200,12 +200,12 @@ graph {
     input: "onnx::Expand_19"
     input: "onnx::Expand_12"
     output: "20"
-    name: "Expand_17"
+    name: "Expand_23"
     op_type: "Expand"
   }
   node {
     output: "onnx::Concat_21"
-    name: "Constant_18"
+    name: "Constant_24"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -222,7 +222,7 @@ graph {
     input: "onnx::Concat_21"
     input: "onnx::Concat_11"
     output: "onnx::Reshape_22"
-    name: "Concat_19"
+    name: "Concat_25"
     op_type: "Concat"
     attribute {
       name: "axis"
@@ -234,7 +234,7 @@ graph {
     input: "onnx::Shape_8"
     input: "onnx::Reshape_22"
     output: "onnx::Expand_23"
-    name: "Reshape_20"
+    name: "Reshape_26"
     op_type: "Reshape"
     attribute {
       name: "allowzero"
@@ -246,7 +246,7 @@ graph {
     input: "onnx::Expand_23"
     input: "onnx::Expand_12"
     output: "24"
-    name: "Expand_21"
+    name: "Expand_27"
     op_type: "Expand"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_meshgrid_indexing.expect
+++ b/test/onnx/expect/TestOperators.test_meshgrid_indexing.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Reshape_3"
-    name: "Constant_0"
+    name: "Constant_6"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -20,12 +20,12 @@ graph {
     input: "onnx::Reshape_1"
     input: "onnx::Reshape_3"
     output: "onnx::Shape_4"
-    name: "Reshape_1"
+    name: "Reshape_7"
     op_type: "Reshape"
   }
   node {
     output: "onnx::Reshape_5"
-    name: "Constant_2"
+    name: "Constant_8"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -41,12 +41,12 @@ graph {
     input: "onnx::Reshape_0"
     input: "onnx::Reshape_5"
     output: "onnx::Shape_6"
-    name: "Reshape_3"
+    name: "Reshape_9"
     op_type: "Reshape"
   }
   node {
     output: "onnx::Reshape_7"
-    name: "Constant_4"
+    name: "Constant_10"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -62,25 +62,25 @@ graph {
     input: "onnx::Reshape_2"
     input: "onnx::Reshape_7"
     output: "onnx::Shape_8"
-    name: "Reshape_5"
+    name: "Reshape_11"
     op_type: "Reshape"
   }
   node {
     input: "onnx::Shape_4"
     output: "onnx::Concat_9"
-    name: "Shape_6"
+    name: "Shape_12"
     op_type: "Shape"
   }
   node {
     input: "onnx::Shape_6"
     output: "onnx::Concat_10"
-    name: "Shape_7"
+    name: "Shape_13"
     op_type: "Shape"
   }
   node {
     input: "onnx::Shape_8"
     output: "onnx::Concat_11"
-    name: "Shape_8"
+    name: "Shape_14"
     op_type: "Shape"
   }
   node {
@@ -88,7 +88,7 @@ graph {
     input: "onnx::Concat_10"
     input: "onnx::Concat_11"
     output: "onnx::Expand_12"
-    name: "Concat_9"
+    name: "Concat_15"
     op_type: "Concat"
     attribute {
       name: "axis"
@@ -98,7 +98,7 @@ graph {
   }
   node {
     output: "onnx::Concat_13"
-    name: "Constant_10"
+    name: "Constant_16"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -115,7 +115,7 @@ graph {
     input: "onnx::Concat_13"
     input: "onnx::Concat_13"
     output: "onnx::Reshape_14"
-    name: "Concat_11"
+    name: "Concat_17"
     op_type: "Concat"
     attribute {
       name: "axis"
@@ -127,19 +127,19 @@ graph {
     input: "onnx::Shape_4"
     input: "onnx::Reshape_14"
     output: "onnx::Expand_15"
-    name: "Reshape_12"
+    name: "Reshape_18"
     op_type: "Reshape"
   }
   node {
     input: "onnx::Expand_15"
     input: "onnx::Expand_12"
     output: "16"
-    name: "Expand_13"
+    name: "Expand_19"
     op_type: "Expand"
   }
   node {
     output: "onnx::Concat_17"
-    name: "Constant_14"
+    name: "Constant_20"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -156,7 +156,7 @@ graph {
     input: "onnx::Concat_10"
     input: "onnx::Concat_17"
     output: "onnx::Reshape_18"
-    name: "Concat_15"
+    name: "Concat_21"
     op_type: "Concat"
     attribute {
       name: "axis"
@@ -168,19 +168,19 @@ graph {
     input: "onnx::Shape_6"
     input: "onnx::Reshape_18"
     output: "onnx::Expand_19"
-    name: "Reshape_16"
+    name: "Reshape_22"
     op_type: "Reshape"
   }
   node {
     input: "onnx::Expand_19"
     input: "onnx::Expand_12"
     output: "20"
-    name: "Expand_17"
+    name: "Expand_23"
     op_type: "Expand"
   }
   node {
     output: "onnx::Concat_21"
-    name: "Constant_18"
+    name: "Constant_24"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -197,7 +197,7 @@ graph {
     input: "onnx::Concat_21"
     input: "onnx::Concat_11"
     output: "onnx::Reshape_22"
-    name: "Concat_19"
+    name: "Concat_25"
     op_type: "Concat"
     attribute {
       name: "axis"
@@ -209,14 +209,14 @@ graph {
     input: "onnx::Shape_8"
     input: "onnx::Reshape_22"
     output: "onnx::Expand_23"
-    name: "Reshape_20"
+    name: "Reshape_26"
     op_type: "Reshape"
   }
   node {
     input: "onnx::Expand_23"
     input: "onnx::Expand_12"
     output: "24"
-    name: "Expand_21"
+    name: "Expand_27"
     op_type: "Expand"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_narrow.expect
+++ b/test/onnx/expect/TestOperators.test_narrow.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Slice_13"
-    name: "Constant_0"
+    name: "Constant_3"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -18,7 +18,7 @@ graph {
   }
   node {
     output: "onnx::Slice_14"
-    name: "Constant_1"
+    name: "Constant_4"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -32,7 +32,7 @@ graph {
   }
   node {
     output: "onnx::Slice_15"
-    name: "Constant_2"
+    name: "Constant_5"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -50,7 +50,7 @@ graph {
     input: "onnx::Slice_15"
     input: "onnx::Slice_13"
     output: "11"
-    name: "Slice_3"
+    name: "Slice_6"
     op_type: "Slice"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_norm_p1.expect
+++ b/test/onnx/expect/TestOperators.test_norm_p1.expect
@@ -5,12 +5,12 @@ graph {
   node {
     input: "onnx::Abs_0"
     output: "onnx::Pow_1"
-    name: "Abs_0"
+    name: "Abs_3"
     op_type: "Abs"
   }
   node {
     output: "onnx::Pow_2"
-    name: "Constant_1"
+    name: "Constant_4"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -25,12 +25,12 @@ graph {
     input: "onnx::Pow_1"
     input: "onnx::Pow_2"
     output: "onnx::ReduceSum_3"
-    name: "Pow_2"
+    name: "Pow_5"
     op_type: "Pow"
   }
   node {
     output: "onnx::ReduceSum_4"
-    name: "Constant_3"
+    name: "Constant_6"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -46,7 +46,7 @@ graph {
     input: "onnx::ReduceSum_3"
     input: "onnx::ReduceSum_4"
     output: "onnx::Pow_5"
-    name: "ReduceSum_4"
+    name: "ReduceSum_7"
     op_type: "ReduceSum"
     attribute {
       name: "keepdims"
@@ -61,7 +61,7 @@ graph {
   }
   node {
     output: "onnx::Pow_10"
-    name: "Constant_5"
+    name: "Constant_8"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -76,7 +76,7 @@ graph {
     input: "onnx::Pow_5"
     input: "onnx::Pow_10"
     output: "9"
-    name: "Pow_6"
+    name: "Pow_9"
     op_type: "Pow"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_norm_p2.expect
+++ b/test/onnx/expect/TestOperators.test_norm_p2.expect
@@ -5,12 +5,12 @@ graph {
   node {
     input: "onnx::Abs_0"
     output: "onnx::Pow_1"
-    name: "Abs_0"
+    name: "Abs_3"
     op_type: "Abs"
   }
   node {
     output: "onnx::Pow_2"
-    name: "Constant_1"
+    name: "Constant_4"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -25,12 +25,12 @@ graph {
     input: "onnx::Pow_1"
     input: "onnx::Pow_2"
     output: "onnx::ReduceSum_3"
-    name: "Pow_2"
+    name: "Pow_5"
     op_type: "Pow"
   }
   node {
     output: "onnx::ReduceSum_4"
-    name: "Constant_3"
+    name: "Constant_6"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -46,7 +46,7 @@ graph {
     input: "onnx::ReduceSum_3"
     input: "onnx::ReduceSum_4"
     output: "onnx::Pow_5"
-    name: "ReduceSum_4"
+    name: "ReduceSum_7"
     op_type: "ReduceSum"
     attribute {
       name: "keepdims"
@@ -61,7 +61,7 @@ graph {
   }
   node {
     output: "onnx::Pow_10"
-    name: "Constant_5"
+    name: "Constant_8"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -76,7 +76,7 @@ graph {
     input: "onnx::Pow_5"
     input: "onnx::Pow_10"
     output: "9"
-    name: "Pow_6"
+    name: "Pow_9"
     op_type: "Pow"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_ones_like.expect
+++ b/test/onnx/expect/TestOperators.test_ones_like.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "1"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"

--- a/test/onnx/expect/TestOperators.test_pad.expect
+++ b/test/onnx/expect/TestOperators.test_pad.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::ConstantOfShape_27"
-    name: "Constant_0"
+    name: "Constant_8"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -18,7 +18,7 @@ graph {
   }
   node {
     output: "onnx::Concat_28"
-    name: "Constant_1"
+    name: "Constant_9"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -33,7 +33,7 @@ graph {
   node {
     input: "onnx::ConstantOfShape_27"
     output: "onnx::Concat_10"
-    name: "ConstantOfShape_2"
+    name: "ConstantOfShape_10"
     op_type: "ConstantOfShape"
     attribute {
       name: "value"
@@ -49,7 +49,7 @@ graph {
     input: "onnx::Concat_28"
     input: "onnx::Concat_10"
     output: "onnx::Reshape_11"
-    name: "Concat_3"
+    name: "Concat_11"
     op_type: "Concat"
     attribute {
       name: "axis"
@@ -59,7 +59,7 @@ graph {
   }
   node {
     output: "onnx::Reshape_12"
-    name: "Constant_4"
+    name: "Constant_12"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -75,7 +75,7 @@ graph {
     input: "onnx::Reshape_11"
     input: "onnx::Reshape_12"
     output: "onnx::Slice_13"
-    name: "Reshape_5"
+    name: "Reshape_13"
     op_type: "Reshape"
     attribute {
       name: "allowzero"
@@ -85,7 +85,7 @@ graph {
   }
   node {
     output: "onnx::Slice_14"
-    name: "Constant_6"
+    name: "Constant_14"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -99,7 +99,7 @@ graph {
   }
   node {
     output: "onnx::Slice_15"
-    name: "Constant_7"
+    name: "Constant_15"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -113,7 +113,7 @@ graph {
   }
   node {
     output: "onnx::Slice_16"
-    name: "Constant_8"
+    name: "Constant_16"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -127,7 +127,7 @@ graph {
   }
   node {
     output: "onnx::Slice_17"
-    name: "Constant_9"
+    name: "Constant_17"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -146,13 +146,13 @@ graph {
     input: "onnx::Slice_14"
     input: "onnx::Slice_17"
     output: "onnx::Transpose_18"
-    name: "Slice_10"
+    name: "Slice_18"
     op_type: "Slice"
   }
   node {
     input: "onnx::Transpose_18"
     output: "onnx::Reshape_19"
-    name: "Transpose_11"
+    name: "Transpose_19"
     op_type: "Transpose"
     attribute {
       name: "perm"
@@ -163,7 +163,7 @@ graph {
   }
   node {
     output: "onnx::Reshape_20"
-    name: "Constant_12"
+    name: "Constant_20"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -179,7 +179,7 @@ graph {
     input: "onnx::Reshape_19"
     input: "onnx::Reshape_20"
     output: "onnx::Cast_21"
-    name: "Reshape_13"
+    name: "Reshape_21"
     op_type: "Reshape"
     attribute {
       name: "allowzero"
@@ -190,7 +190,7 @@ graph {
   node {
     input: "onnx::Cast_21"
     output: "onnx::Pad_22"
-    name: "Cast_14"
+    name: "Cast_22"
     op_type: "Cast"
     attribute {
       name: "to"
@@ -202,7 +202,7 @@ graph {
     input: "onnx::Pad_0"
     input: "onnx::Pad_22"
     output: "23"
-    name: "Pad_15"
+    name: "Pad_23"
     op_type: "Pad"
     attribute {
       name: "mode"

--- a/test/onnx/expect/TestOperators.test_reduce_sum_negative_indices.expect
+++ b/test/onnx/expect/TestOperators.test_reduce_sum_negative_indices.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::ReduceSum_1"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -20,7 +20,7 @@ graph {
     input: "onnx::ReduceSum_0"
     input: "onnx::ReduceSum_1"
     output: "2"
-    name: "ReduceSum_1"
+    name: "ReduceSum_2"
     op_type: "ReduceSum"
     attribute {
       name: "keepdims"

--- a/test/onnx/expect/TestOperators.test_reduced_sum.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_sum.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::ReduceSum_1"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -20,7 +20,7 @@ graph {
     input: "onnx::ReduceSum_0"
     input: "onnx::ReduceSum_1"
     output: "2"
-    name: "ReduceSum_1"
+    name: "ReduceSum_2"
     op_type: "ReduceSum"
     attribute {
       name: "keepdims"

--- a/test/onnx/expect/TestOperators.test_reduced_sum_dtype.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_sum_dtype.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::ReduceSum_1"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -19,7 +19,7 @@ graph {
   node {
     input: "onnx::Cast_0"
     output: "onnx::ReduceSum_2"
-    name: "Cast_1"
+    name: "Cast_2"
     op_type: "Cast"
     attribute {
       name: "to"
@@ -31,7 +31,7 @@ graph {
     input: "onnx::ReduceSum_2"
     input: "onnx::ReduceSum_1"
     output: "3"
-    name: "ReduceSum_2"
+    name: "ReduceSum_3"
     op_type: "ReduceSum"
     attribute {
       name: "keepdims"

--- a/test/onnx/expect/TestOperators.test_reduced_sum_keepdim.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_sum_keepdim.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::ReduceSum_1"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -20,7 +20,7 @@ graph {
     input: "onnx::ReduceSum_0"
     input: "onnx::ReduceSum_1"
     output: "2"
-    name: "ReduceSum_1"
+    name: "ReduceSum_2"
     op_type: "ReduceSum"
     attribute {
       name: "keepdims"

--- a/test/onnx/expect/TestOperators.test_repeat.expect
+++ b/test/onnx/expect/TestOperators.test_repeat.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Tile_1"
-    name: "Constant_0"
+    name: "Constant_2"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -18,7 +18,7 @@ graph {
   }
   node {
     output: "onnx::ConstantOfShape_6"
-    name: "Constant_1"
+    name: "Constant_3"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -33,7 +33,7 @@ graph {
   node {
     input: "onnx::ConstantOfShape_6"
     output: "onnx::Expand_3"
-    name: "ConstantOfShape_2"
+    name: "ConstantOfShape_4"
     op_type: "ConstantOfShape"
     attribute {
       name: "value"
@@ -49,14 +49,14 @@ graph {
     input: "onnx::Expand_0"
     input: "onnx::Expand_3"
     output: "onnx::Tile_4"
-    name: "Expand_3"
+    name: "Expand_5"
     op_type: "Expand"
   }
   node {
     input: "onnx::Tile_4"
     input: "onnx::Tile_1"
     output: "5"
-    name: "Tile_4"
+    name: "Tile_6"
     op_type: "Tile"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_repeat_dim_overflow.expect
+++ b/test/onnx/expect/TestOperators.test_repeat_dim_overflow.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Tile_1"
-    name: "Constant_0"
+    name: "Constant_2"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -18,7 +18,7 @@ graph {
   }
   node {
     output: "onnx::ConstantOfShape_6"
-    name: "Constant_1"
+    name: "Constant_3"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -33,7 +33,7 @@ graph {
   node {
     input: "onnx::ConstantOfShape_6"
     output: "onnx::Expand_3"
-    name: "ConstantOfShape_2"
+    name: "ConstantOfShape_4"
     op_type: "ConstantOfShape"
     attribute {
       name: "value"
@@ -49,14 +49,14 @@ graph {
     input: "onnx::Expand_0"
     input: "onnx::Expand_3"
     output: "onnx::Tile_4"
-    name: "Expand_3"
+    name: "Expand_5"
     op_type: "Expand"
   }
   node {
     input: "onnx::Tile_4"
     input: "onnx::Tile_1"
     output: "5"
-    name: "Tile_4"
+    name: "Tile_6"
     op_type: "Tile"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_rsqrt.expect
+++ b/test/onnx/expect/TestOperators.test_rsqrt.expect
@@ -5,12 +5,12 @@ graph {
   node {
     input: "onnx::Sqrt_0"
     output: "onnx::Div_1"
-    name: "Sqrt_0"
+    name: "Sqrt_1"
     op_type: "Sqrt"
   }
   node {
     output: "onnx::Div_2"
-    name: "Constant_1"
+    name: "Constant_2"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -25,7 +25,7 @@ graph {
     input: "onnx::Div_2"
     input: "onnx::Div_1"
     output: "3"
-    name: "Div_2"
+    name: "Div_3"
     op_type: "Div"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_rsub.expect
+++ b/test/onnx/expect/TestOperators.test_rsub.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Sub_1"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -19,7 +19,7 @@ graph {
     input: "onnx::Sub_1"
     input: "onnx::Sub_0"
     output: "2"
-    name: "Sub_1"
+    name: "Sub_2"
     op_type: "Sub"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_scatter_add_opset11.expect
+++ b/test/onnx/expect/TestOperators.test_scatter_add_opset11.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::ScatterElements_3"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -22,7 +22,7 @@ graph {
     input: "onnx::ScatterElements_1"
     input: "onnx::ScatterElements_2"
     output: "onnx::Add_4"
-    name: "ScatterElements_1"
+    name: "ScatterElements_2"
     op_type: "ScatterElements"
     attribute {
       name: "axis"
@@ -34,7 +34,7 @@ graph {
     input: "onnx::Add_0"
     input: "onnx::Add_4"
     output: "5"
-    name: "Add_2"
+    name: "Add_3"
     op_type: "Add"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_shape_value_map.expect
+++ b/test/onnx/expect/TestOperators.test_shape_value_map.expect
@@ -5,12 +5,12 @@ graph {
   node {
     input: "x"
     output: "onnx::Gather_1"
-    name: "Shape_0"
+    name: "Shape_7"
     op_type: "Shape"
   }
   node {
     output: "onnx::Gather_2"
-    name: "Constant_1"
+    name: "Constant_8"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -25,7 +25,7 @@ graph {
     input: "onnx::Gather_1"
     input: "onnx::Gather_2"
     output: "onnx::Unsqueeze_3"
-    name: "Gather_2"
+    name: "Gather_9"
     op_type: "Gather"
     attribute {
       name: "axis"
@@ -35,7 +35,7 @@ graph {
   }
   node {
     output: "onnx::Unsqueeze_7"
-    name: "Constant_3"
+    name: "Constant_10"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -51,12 +51,12 @@ graph {
     input: "onnx::Unsqueeze_3"
     input: "onnx::Unsqueeze_7"
     output: "onnx::Concat_8"
-    name: "Unsqueeze_4"
+    name: "Unsqueeze_11"
     op_type: "Unsqueeze"
   }
   node {
     output: "onnx::Concat_25"
-    name: "Constant_5"
+    name: "Constant_12"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -70,7 +70,7 @@ graph {
   }
   node {
     output: "onnx::Concat_26"
-    name: "Constant_6"
+    name: "Constant_13"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -84,7 +84,7 @@ graph {
   }
   node {
     output: "onnx::Concat_27"
-    name: "Constant_7"
+    name: "Constant_14"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -102,7 +102,7 @@ graph {
     input: "onnx::Concat_26"
     input: "onnx::Concat_27"
     output: "onnx::Reshape_15"
-    name: "Concat_8"
+    name: "Concat_15"
     op_type: "Concat"
     attribute {
       name: "axis"
@@ -114,7 +114,7 @@ graph {
     input: "x"
     input: "onnx::Reshape_15"
     output: "onnx::Transpose_16"
-    name: "Reshape_9"
+    name: "Reshape_16"
     op_type: "Reshape"
     attribute {
       name: "allowzero"
@@ -125,7 +125,7 @@ graph {
   node {
     input: "onnx::Transpose_16"
     output: "x.1"
-    name: "Transpose_10"
+    name: "Transpose_17"
     op_type: "Transpose"
     attribute {
       name: "perm"
@@ -139,7 +139,7 @@ graph {
   node {
     input: "x.1"
     output: "onnx::Reshape_18"
-    name: "Softmax_11"
+    name: "Softmax_18"
     op_type: "Softmax"
     attribute {
       name: "axis"
@@ -149,7 +149,7 @@ graph {
   }
   node {
     output: "onnx::Unsqueeze_19"
-    name: "Constant_12"
+    name: "Constant_19"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -165,12 +165,12 @@ graph {
     input: "onnx::Unsqueeze_3"
     input: "onnx::Unsqueeze_19"
     output: "onnx::Concat_20"
-    name: "Unsqueeze_13"
+    name: "Unsqueeze_20"
     op_type: "Unsqueeze"
   }
   node {
     output: "onnx::Concat_28"
-    name: "Constant_14"
+    name: "Constant_21"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -186,7 +186,7 @@ graph {
     input: "onnx::Concat_20"
     input: "onnx::Concat_28"
     output: "onnx::Reshape_23"
-    name: "Concat_15"
+    name: "Concat_22"
     op_type: "Concat"
     attribute {
       name: "axis"
@@ -198,7 +198,7 @@ graph {
     input: "onnx::Reshape_18"
     input: "onnx::Reshape_23"
     output: "24"
-    name: "Reshape_16"
+    name: "Reshape_23"
     op_type: "Reshape"
     attribute {
       name: "allowzero"

--- a/test/onnx/expect/TestOperators.test_slice.expect
+++ b/test/onnx/expect/TestOperators.test_slice.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Slice_12"
-    name: "Constant_0"
+    name: "Constant_4"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -18,7 +18,7 @@ graph {
   }
   node {
     output: "onnx::Slice_13"
-    name: "Constant_1"
+    name: "Constant_5"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -32,7 +32,7 @@ graph {
   }
   node {
     output: "onnx::Slice_14"
-    name: "Constant_2"
+    name: "Constant_6"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -46,7 +46,7 @@ graph {
   }
   node {
     output: "onnx::Slice_15"
-    name: "Constant_3"
+    name: "Constant_7"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -65,7 +65,7 @@ graph {
     input: "onnx::Slice_12"
     input: "onnx::Slice_15"
     output: "11"
-    name: "Slice_4"
+    name: "Slice_8"
     op_type: "Slice"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_slice_dynamic.expect
+++ b/test/onnx/expect/TestOperators.test_slice_dynamic.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Slice_12"
-    name: "Constant_0"
+    name: "Constant_5"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -18,7 +18,7 @@ graph {
   }
   node {
     output: "onnx::Slice_13"
-    name: "Constant_1"
+    name: "Constant_6"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -32,7 +32,7 @@ graph {
   }
   node {
     output: "onnx::Slice_14"
-    name: "Constant_2"
+    name: "Constant_7"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -46,7 +46,7 @@ graph {
   }
   node {
     output: "onnx::Slice_15"
-    name: "Constant_3"
+    name: "Constant_8"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -65,12 +65,12 @@ graph {
     input: "onnx::Slice_12"
     input: "onnx::Slice_15"
     output: "onnx::Gather_9"
-    name: "Slice_4"
+    name: "Slice_9"
     op_type: "Slice"
   }
   node {
     output: "onnx::Gather_10"
-    name: "Constant_5"
+    name: "Constant_10"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -85,7 +85,7 @@ graph {
     input: "onnx::Gather_9"
     input: "onnx::Gather_10"
     output: "11"
-    name: "Gather_6"
+    name: "Gather_11"
     op_type: "Gather"
     attribute {
       name: "axis"

--- a/test/onnx/expect/TestOperators.test_split.expect
+++ b/test/onnx/expect/TestOperators.test_split.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Split_1"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -22,7 +22,7 @@ graph {
     output: "2"
     output: "3"
     output: "4"
-    name: "Split_1"
+    name: "Split_2"
     op_type: "Split"
     attribute {
       name: "axis"

--- a/test/onnx/expect/TestOperators.test_split_with_sizes.expect
+++ b/test/onnx/expect/TestOperators.test_split_with_sizes.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Split_1"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -22,7 +22,7 @@ graph {
     output: "2"
     output: "3"
     output: "4"
-    name: "Split_1"
+    name: "Split_2"
     op_type: "Split"
     attribute {
       name: "axis"

--- a/test/onnx/expect/TestOperators.test_std.expect
+++ b/test/onnx/expect/TestOperators.test_std.expect
@@ -5,7 +5,7 @@ graph {
   node {
     input: "onnx::ReduceMean_0"
     output: "onnx::Sub_1"
-    name: "ReduceMean_0"
+    name: "ReduceMean_2"
     op_type: "ReduceMean"
     attribute {
       name: "axes"
@@ -22,12 +22,12 @@ graph {
   node {
     input: "onnx::ReduceMean_0"
     output: "onnx::Gather_2"
-    name: "Shape_1"
+    name: "Shape_3"
     op_type: "Shape"
   }
   node {
     output: "onnx::Gather_3"
-    name: "Constant_2"
+    name: "Constant_4"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -43,7 +43,7 @@ graph {
     input: "onnx::Gather_2"
     input: "onnx::Gather_3"
     output: "onnx::ReduceProd_4"
-    name: "Gather_3"
+    name: "Gather_5"
     op_type: "Gather"
     attribute {
       name: "axis"
@@ -54,7 +54,7 @@ graph {
   node {
     input: "onnx::ReduceProd_4"
     output: "onnx::Cast_5"
-    name: "ReduceProd_4"
+    name: "ReduceProd_6"
     op_type: "ReduceProd"
     attribute {
       name: "keepdims"
@@ -66,20 +66,20 @@ graph {
     input: "onnx::ReduceMean_0"
     input: "onnx::Sub_1"
     output: "onnx::Mul_6"
-    name: "Sub_5"
+    name: "Sub_7"
     op_type: "Sub"
   }
   node {
     input: "onnx::Mul_6"
     input: "onnx::Mul_6"
     output: "onnx::ReduceMean_7"
-    name: "Mul_6"
+    name: "Mul_8"
     op_type: "Mul"
   }
   node {
     input: "onnx::ReduceMean_7"
     output: "onnx::Mul_8"
-    name: "ReduceMean_7"
+    name: "ReduceMean_9"
     op_type: "ReduceMean"
     attribute {
       name: "axes"
@@ -96,7 +96,7 @@ graph {
   node {
     input: "onnx::Cast_5"
     output: "onnx::Mul_9"
-    name: "Cast_8"
+    name: "Cast_10"
     op_type: "Cast"
     attribute {
       name: "to"
@@ -108,12 +108,12 @@ graph {
     input: "onnx::Mul_8"
     input: "onnx::Mul_9"
     output: "onnx::Div_10"
-    name: "Mul_9"
+    name: "Mul_11"
     op_type: "Mul"
   }
   node {
     output: "onnx::Sub_11"
-    name: "Constant_10"
+    name: "Constant_12"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -128,20 +128,20 @@ graph {
     input: "onnx::Mul_9"
     input: "onnx::Sub_11"
     output: "onnx::Div_12"
-    name: "Sub_11"
+    name: "Sub_13"
     op_type: "Sub"
   }
   node {
     input: "onnx::Div_10"
     input: "onnx::Div_12"
     output: "onnx::Sqrt_13"
-    name: "Div_12"
+    name: "Div_14"
     op_type: "Div"
   }
   node {
     input: "onnx::Sqrt_13"
     output: "14"
-    name: "Sqrt_13"
+    name: "Sqrt_15"
     op_type: "Sqrt"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_topk.expect
+++ b/test/onnx/expect/TestOperators.test_topk.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Reshape_2"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -20,7 +20,7 @@ graph {
     input: "onnx::Reshape_1"
     input: "onnx::Reshape_2"
     output: "onnx::TopK_3"
-    name: "Reshape_1"
+    name: "Reshape_2"
     op_type: "Reshape"
   }
   node {
@@ -28,7 +28,7 @@ graph {
     input: "onnx::TopK_3"
     output: "4"
     output: "5"
-    name: "TopK_2"
+    name: "TopK_3"
     op_type: "TopK"
     attribute {
       name: "axis"

--- a/test/onnx/expect/TestOperators.test_topk_smallest_unsorted.expect
+++ b/test/onnx/expect/TestOperators.test_topk_smallest_unsorted.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Reshape_2"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -20,7 +20,7 @@ graph {
     input: "onnx::Reshape_1"
     input: "onnx::Reshape_2"
     output: "onnx::TopK_3"
-    name: "Reshape_1"
+    name: "Reshape_2"
     op_type: "Reshape"
   }
   node {
@@ -28,7 +28,7 @@ graph {
     input: "onnx::TopK_3"
     output: "4"
     output: "5"
-    name: "TopK_2"
+    name: "TopK_3"
     op_type: "TopK"
     attribute {
       name: "axis"

--- a/test/onnx/expect/TestOperators.test_unfold.expect
+++ b/test/onnx/expect/TestOperators.test_unfold.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Slice_1"
-    name: "Constant_0"
+    name: "Constant_8"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -18,7 +18,7 @@ graph {
   }
   node {
     output: "onnx::Slice_2"
-    name: "Constant_1"
+    name: "Constant_9"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -32,7 +32,7 @@ graph {
   }
   node {
     output: "onnx::Slice_3"
-    name: "Constant_2"
+    name: "Constant_10"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -50,12 +50,12 @@ graph {
     input: "onnx::Slice_3"
     input: "onnx::Slice_1"
     output: "onnx::Unsqueeze_4"
-    name: "Slice_3"
+    name: "Slice_11"
     op_type: "Slice"
   }
   node {
     output: "onnx::Slice_5"
-    name: "Constant_4"
+    name: "Constant_12"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -69,7 +69,7 @@ graph {
   }
   node {
     output: "onnx::Slice_6"
-    name: "Constant_5"
+    name: "Constant_13"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -83,7 +83,7 @@ graph {
   }
   node {
     output: "onnx::Slice_7"
-    name: "Constant_6"
+    name: "Constant_14"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -101,12 +101,12 @@ graph {
     input: "onnx::Slice_7"
     input: "onnx::Slice_5"
     output: "onnx::Unsqueeze_8"
-    name: "Slice_7"
+    name: "Slice_15"
     op_type: "Slice"
   }
   node {
     output: "onnx::Unsqueeze_9"
-    name: "Constant_8"
+    name: "Constant_16"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -122,12 +122,12 @@ graph {
     input: "onnx::Unsqueeze_4"
     input: "onnx::Unsqueeze_9"
     output: "onnx::Concat_10"
-    name: "Unsqueeze_9"
+    name: "Unsqueeze_17"
     op_type: "Unsqueeze"
   }
   node {
     output: "onnx::Unsqueeze_11"
-    name: "Constant_10"
+    name: "Constant_18"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -143,14 +143,14 @@ graph {
     input: "onnx::Unsqueeze_8"
     input: "onnx::Unsqueeze_11"
     output: "onnx::Concat_12"
-    name: "Unsqueeze_11"
+    name: "Unsqueeze_19"
     op_type: "Unsqueeze"
   }
   node {
     input: "onnx::Concat_10"
     input: "onnx::Concat_12"
     output: "13"
-    name: "Concat_12"
+    name: "Concat_20"
     op_type: "Concat"
     attribute {
       name: "axis"

--- a/test/onnx/expect/TestOperators.test_unsqueeze.expect
+++ b/test/onnx/expect/TestOperators.test_unsqueeze.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Unsqueeze_1"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -20,7 +20,7 @@ graph {
     input: "onnx::Unsqueeze_0"
     input: "onnx::Unsqueeze_1"
     output: "2"
-    name: "Unsqueeze_1"
+    name: "Unsqueeze_2"
     op_type: "Unsqueeze"
   }
   name: "main_graph"

--- a/test/onnx/expect/TestOperators.test_upsample_nearest_scale.expect
+++ b/test/onnx/expect/TestOperators.test_upsample_nearest_scale.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Resize_6"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -21,7 +21,7 @@ graph {
     input: ""
     input: "onnx::Resize_6"
     output: "5"
-    name: "Resize_1"
+    name: "Resize_2"
     op_type: "Resize"
     attribute {
       name: "coordinate_transformation_mode"

--- a/test/onnx/expect/TestOperators.test_upsample_nearest_scale_default_scale_factor.expect
+++ b/test/onnx/expect/TestOperators.test_upsample_nearest_scale_default_scale_factor.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Resize_6"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -21,7 +21,7 @@ graph {
     input: ""
     input: "onnx::Resize_6"
     output: "5"
-    name: "Resize_1"
+    name: "Resize_2"
     op_type: "Resize"
     attribute {
       name: "coordinate_transformation_mode"

--- a/test/onnx/expect/TestOperators.test_upsample_nearest_size.expect
+++ b/test/onnx/expect/TestOperators.test_upsample_nearest_size.expect
@@ -5,12 +5,12 @@ graph {
   node {
     input: "x"
     output: "onnx::Slice_2"
-    name: "Shape_0"
+    name: "Shape_4"
     op_type: "Shape"
   }
   node {
     output: "onnx::Slice_3"
-    name: "Constant_1"
+    name: "Constant_5"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -24,7 +24,7 @@ graph {
   }
   node {
     output: "onnx::Slice_4"
-    name: "Constant_2"
+    name: "Constant_6"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -38,7 +38,7 @@ graph {
   }
   node {
     output: "onnx::Slice_5"
-    name: "Constant_3"
+    name: "Constant_7"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -56,12 +56,12 @@ graph {
     input: "onnx::Slice_5"
     input: "onnx::Slice_3"
     output: "onnx::Concat_6"
-    name: "Slice_4"
+    name: "Slice_8"
     op_type: "Slice"
   }
   node {
     output: "onnx::Concat_12"
-    name: "Constant_5"
+    name: "Constant_9"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -77,7 +77,7 @@ graph {
     input: "onnx::Concat_6"
     input: "onnx::Concat_12"
     output: "onnx::Resize_8"
-    name: "Concat_6"
+    name: "Concat_10"
     op_type: "Concat"
     attribute {
       name: "axis"
@@ -91,7 +91,7 @@ graph {
     input: ""
     input: "onnx::Resize_8"
     output: "11"
-    name: "Resize_7"
+    name: "Resize_11"
     op_type: "Resize"
     attribute {
       name: "coordinate_transformation_mode"

--- a/test/onnx/expect/TestOperators.test_view.expect
+++ b/test/onnx/expect/TestOperators.test_view.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Reshape_1"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -20,7 +20,7 @@ graph {
     input: "onnx::Reshape_0"
     input: "onnx::Reshape_1"
     output: "2"
-    name: "Reshape_1"
+    name: "Reshape_2"
     op_type: "Reshape"
     attribute {
       name: "allowzero"

--- a/test/onnx/expect/TestOperators.test_view_flatten.expect
+++ b/test/onnx/expect/TestOperators.test_view_flatten.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "onnx::Reshape_11"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -20,7 +20,7 @@ graph {
     input: "onnx::Reshape_0"
     input: "onnx::Reshape_11"
     output: "8"
-    name: "Reshape_1"
+    name: "Reshape_2"
     op_type: "Reshape"
     attribute {
       name: "allowzero"

--- a/test/onnx/expect/TestOperators.test_zeros_like.expect
+++ b/test/onnx/expect/TestOperators.test_zeros_like.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     output: "1"
-    name: "Constant_0"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"


### PR DESCRIPTION
Fixes #110982

https://github.com/pytorch/pytorch/pull/62257 deprecated `torch.onnx.export(use_external_data_format: bool=...)`  argument, but it seems the introduced `EncoderBase::GetGraphProtoSize` has a bug and doesn't detect models > 2GB when onnx Constant nodes are large (and responsible for the size overflow)

This PR adds the constant node to the total size of the model, along with initializers.

In python, what we need to do is:

```python
import onnx

def compute_tensor_size(tensor):
    # Compute the size of the tensor based on its shape and data type
    size = tensor.size * tensor.itemsize
    return size

def sum_constant_and_initializer_sizes(model_path):
    # Load the ONNX model
    model = onnx.load(model_path)

    total_size = 0
    initializer_size = 0
    constant_size = 0

    # Compute the size of constant nodes
    for node in model.graph.node:
        if node.op_type == 'Constant':
            constant_value = node.attribute[0].t
            # Convert constant value to numpy array
            constant_array = onnx.numpy_helper.to_array(constant_value)
            # Compute the size of the constant tensor
            tensor_size = compute_tensor_size(constant_array)
            total_size += tensor_size
            constant_size += tensor_size

    # Compute the size of initializer nodes that are not graph inputs
    for initializer in model.graph.initializer:
        if initializer.name not in [input.name for input in model.graph.input]:
            # Convert the shape and data type information to calculate size
            # tensor = onnx.helper.tensor_value_info_to_tensor(input)
            tensor = onnx.numpy_helper.to_array(initializer)
            tensor_size = compute_tensor_size(tensor)
            total_size += tensor_size
            initializer_size += tensor_size

    return total_size, constant_size, initializer_size

model_path = '/path/to/model.onnx'
total_size, constant_size, initializer_size = sum_constant_and_initializer_sizes(model_path)

print("Total size of constant nodes in bytes:", constant_size)
print("Total size of initializer nodes (excluding graph inputs) in bytes:", initializer_size)
print("Total size of constant and initializer nodes (excluding graph inputs) in bytes:", total_size)
```

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel