### PR TITLE
[AOTInductor] Improve validation for C++ wrapper codegen

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -12,6 +12,7 @@ import numpy as np
 import sympy
 import torch
 from torch._C import FileCheck
+from torch._dynamo.exc import BackendCompilerFailed
 from torch._dynamo.testing import rand_strided
 from torch._dynamo.utils import same
 from torch._inductor import codecache, config, metrics
@@ -1261,8 +1262,17 @@ class CPUReproTests(TestCase):
                     with config.patch({"cpp_wrapper": cpp_wrapper_flag}):
                         torch._dynamo.reset()
                         metrics.reset()
-                        self.common(fn, (value, mask))
-                        assert metrics.generated_cpp_vec_kernel_count >= 1
+                        # fp16 inputs are not supported for C++ wrappers on CPU yet
+                        if cpp_wrapper_flag and dtype == torch.float16:
+                            with self.assertRaisesRegex(
+                                BackendCompilerFailed,
+                                "Unsupported input dtype torch.float16",
+                            ):
+                                self.common(fn, (value, mask))
+                            assert metrics.generated_cpp_vec_kernel_count == 0
+                        else:
+                            self.common(fn, (value, mask))
+                            assert metrics.generated_cpp_vec_kernel_count >= 1
 
     def test_load_same_bool_tensor_twice(self):
         @torch._dynamo.optimize("inductor")
@@ -1399,8 +1409,17 @@ class CPUReproTests(TestCase):
                     with config.patch({"cpp_wrapper": cpp_wrapper_flag}):
                         torch._dynamo.reset()
                         metrics.reset()
-                        self.common(fn, (x,))
-                        assert metrics.generated_cpp_vec_kernel_count == 1
+                        # fp16 inputs are not supported for C++ wrappers on CPU yet
+                        if cpp_wrapper_flag and dtype == torch.float16:
+                            with self.assertRaisesRegex(
+                                BackendCompilerFailed,
+                                "Unsupported input dtype torch.float16",
+                            ):
+                                self.common(fn, (x,))
+                            assert metrics.generated_cpp_vec_kernel_count == 0
+                        else:
+                            self.common(fn, (x,))
+                            assert metrics.generated_cpp_vec_kernel_count == 1
 
     @unittest.skipIf(
         not codecache.valid_vec_isa_list(), "Does not support vectorization"

--- a/torch/_inductor/exc.py
+++ b/torch/_inductor/exc.py
@@ -67,6 +67,11 @@ class InvalidCxxCompiler(RuntimeError):
         )
 
 
+class CppWrapperCodeGenError(RuntimeError):
+    def __init__(self, msg: str):
+        super().__init__(f"C++ wrapper codegen error: {msg}")
+
+
 class CppCompileError(RuntimeError):
     def __init__(self, cmd: list[str], output: str):
         if isinstance(output, bytes):


### PR DESCRIPTION
It's a reimplementation of #111089 

1. When using fake inputs make sure they are on the same device as the original inputs.
2. Don't change the value of self.cpp_wrapper from True to False if can't generate a C++ wrapper, instead have a check and fail early to avoid producing Python code for C++ compiler.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler