### PR TITLE
[DCP] Improve with_temp_dir robustness

### DIFF
--- a/torch/testing/_internal/distributed/checkpoint_utils.py
+++ b/torch/testing/_internal/distributed/checkpoint_utils.py
@@ -32,7 +32,6 @@ def with_temp_dir(
         dist.broadcast_object_list(object_list)
         self.temp_dir = object_list[0]
         os.sync()
-        assert os.path.exists(self.temp_dir)
 
         try:
             func(self, *args, **kwargs)

--- a/torch/testing/_internal/distributed/checkpoint_utils.py
+++ b/torch/testing/_internal/distributed/checkpoint_utils.py
@@ -1,10 +1,12 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 
+import os
 import shutil
 import tempfile
 from functools import wraps
 from typing import Any, Callable, Dict, Optional, Tuple
 
+import torch
 import torch.distributed as dist
 
 
@@ -29,6 +31,8 @@ def with_temp_dir(
         # Broadcast temp_dir to all the other ranks
         dist.broadcast_object_list(object_list)
         self.temp_dir = object_list[0]
+        os.sync()
+        assert os.path.exists(self.temp_dir)
 
         try:
             func(self, *args, **kwargs)

--- a/torch/testing/_internal/distributed/checkpoint_utils.py
+++ b/torch/testing/_internal/distributed/checkpoint_utils.py
@@ -6,7 +6,6 @@ import tempfile
 from functools import wraps
 from typing import Any, Callable, Dict, Optional, Tuple
 
-import torch
 import torch.distributed as dist
 
 

--- a/torch/testing/_internal/distributed/checkpoint_utils.py
+++ b/torch/testing/_internal/distributed/checkpoint_utils.py
@@ -28,6 +28,7 @@ def with_temp_dir(
         object_list = [temp_dir]
 
         # Broadcast temp_dir to all the other ranks
+        os.sync()
         dist.broadcast_object_list(object_list)
         self.temp_dir = object_list[0]
         os.sync()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #111111
* #111120
* #111110
* #111109
* #111108
* #111107
* __->__ #111106

Calling os.sync() to ensure the tempfile can be seens across ranks.

Differential Revision: [D50209697](https://our.internmc.facebook.com/intern/diff/D50209697/)