### PR TITLE
[state_dict][2/N] Let distributed.state_dict accepts single optimizer

### DIFF
--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -172,8 +172,6 @@ class TestStateDict(FSDPTest):
         # Get the state_dict, and compare the result
         msd = model.state_dict()
         osd = optim.state_dict()
-        if not isinstance(dist_optim, list):
-            dist_optim = [dist_optim]
         dist_msd, dist_osd = state_dict(dist_model, dist_optim, options=options)
         self._verify_msd(model, msd, dist_msd, options)
         self._verify_osd_by_load(model, optim, copy_optim, dist_osd)

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -474,7 +474,9 @@ def _load_optim_state_dict(
 
 def state_dict(
     model: nn.Module,
-    optimizers: Iterable[torch.optim.Optimizer] = tuple(),
+    optimizers: Union[
+        None, torch.optim.Optimizer, Iterable[torch.optim.Optimizer]
+    ] = None,
     *,
     model_only: bool = False,
     optim_only: bool = False,
@@ -532,10 +534,9 @@ def state_dict(
 
     Args:
         model (nn.Module): the nn.Module to the model.
-        optimizers (Iterable[Optimizer]): The optimizers that are used to optimize
-            ``model``. Note that optimizers accept multiple optimizers so the type
-            is Iterable. If optimizers is empty, the returned optimizer state_dict
-            will also be empty.
+        optimizers (Union[None, Optimizer, Iterable[Optimizer]]):
+            The optimizers that are used to optimize ``model``. Note that
+            optimizers accept multiple optimizers so the typing can be Iterable.
         model_only (bool): if model_only is True, the returned optimizer
             state_dict will be empty (default: False)
 
@@ -551,7 +552,15 @@ def state_dict(
         `model_only` is True or `optimizers` is empty.
     """
     with gc_context():
-        optimizers = tuple(optimizers)
+        optimizers = (
+            tuple()
+            if optimizers is None
+            else (
+                (optimizers,)
+                if isinstance(optimizers, torch.optim.Optimizer)
+                else tuple(optimizers)
+            )
+        )
         info = _verify_options(model, optimizers, model_only, optim_only, options)
         model_state_dict = _get_model_state_dict(model, info)
         optim_state_dict = _get_optim_state_dict(model, optimizers, info)
@@ -561,7 +570,9 @@ def state_dict(
 
 def load_state_dict(
     model: nn.Module,
-    optimizers: Iterable[torch.optim.Optimizer] = tuple(),
+    optimizers: Union[
+        None, torch.optim.Optimizer, Iterable[torch.optim.Optimizer]
+    ] = None,
     *,
     model_state_dict: Optional[Dict[str, ValueType]] = None,
     optim_state_dict: Optional[OptimizerStateType] = None,
@@ -583,9 +594,9 @@ def load_state_dict(
 
     Args:
         model (nn.Module): the nn.Module to the model.
-        optimizers (Iterable[Optimizer]): The optimizers that are used to optimize
-            ``model``. Note that optimizers accept multiple optimizers so the typing
-            is Iterable. ``optimizers`` can be an empty Iterable.
+        optimizers (Union[None, Optimizer, Iterable[Optimizer]]):
+            The optimizers that are used to optimize ``model``. Note that
+            optimizers accept multiple optimizers so the typing can be Iterable.
         model_only (bool): if model_only is True, only the model state_dict will
             be loaded (default: False)
         optim_only (bool): if optim_only is True, only the optimizer state_dict
@@ -599,7 +610,15 @@ def load_state_dict(
     model_state_dict = model_state_dict if model_state_dict else {}
     optim_state_dict = optim_state_dict if optim_state_dict else {}
     with gc_context():
-        optimizers = tuple(optimizers)
+        optimizers = (
+            tuple()
+            if optimizers is None
+            else (
+                (optimizers,)
+                if isinstance(optimizers, torch.optim.Optimizer)
+                else tuple(optimizers)
+            )
+        )
         info = _verify_options(model, optimizers, model_only, optim_only, options)
         _verify_state_dict(model_state_dict, optim_state_dict, info)
         _load_model_state_dict(model, model_state_dict, info)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #111111
* #111120
* #111110
* #111109
* #111108
* __->__ #111107
* #111106

It's quite annoying that users have to create a tuple of optimizers even if there is only one optimizer. This PR makes most users' life easier.

Differential Revision: [D50209704](https://our.internmc.facebook.com/intern/diff/D50209704/)