### PR TITLE
[state_dict][3/N] Cleanup StateDictOptions, make it more readable

### DIFF
--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -14,11 +14,11 @@ from torch.distributed._tensor import DTensor
 from torch.distributed.checkpoint.state_dict import (
     _patch_model_state_dict,
     _patch_optimizer_state_dict,
-    DistributedStateDictOptions,
     load_state_dict,
     PG,
     STATE,
     state_dict,
+    StateDictOptions,
 )
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp._shard_utils import _gather_state_dict
@@ -64,13 +64,13 @@ class TestStateDict(FSDPTest):
         model: nn.Module,
         msd: Dict[str, Any],
         dist_msd: Dict[str, Any],
-        options: DistributedStateDictOptions,
+        options: StateDictOptions,
     ) -> None:
-        if options.save_frozen_params:
+        if not options.ignore_frozen_params:
             self.assertEqual(len(msd), len(dist_msd))
         for fqn, param in msd.items():
             dist_param = dist_msd.get(fqn, None)
-            if options.save_frozen_params:
+            if not options.ignore_frozen_params:
                 self.assertIsNotNone(dist_param)
                 self._compare_tensor(param, dist_param)
             elif dist_param is None:
@@ -151,7 +151,7 @@ class TestStateDict(FSDPTest):
         init_model_optim: Callable,
         test_frozen: bool = False,
     ) -> None:
-        options = DistributedStateDictOptions(save_frozen_params=(not test_frozen))
+        options = StateDictOptions(ignore_frozen_params=test_frozen)
         # Initialize original model and distributed model.
         model, optim, copy_optim, dist_model, dist_optim = init_model_optim()
 

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -72,16 +72,16 @@ def gc_context():
 
 
 @dataclass
-class DistributedStateDictOptions:
+class StateDictOptions:
     # The default should be sharded_state_dict
     fsdp_state_dict_type: StateDictType = StateDictType.SHARDED_STATE_DICT
-    save_to_cpu: bool = True
-    # Whether to save the frozen parameters. The default is True.
-    save_frozen_params: bool = True
+    # Whether to ignore the frozen parameters when getting the state_dict.
+    # The default is False.
+    ignore_frozen_params: bool = False
 
 
 @dataclass
-class _StateDictInfo(DistributedStateDictOptions):
+class _StateDictInfo(StateDictOptions):
     fqn_param_mapping: Dict[
         Union[str, torch.Tensor], Union[FQNS_T, torch.Tensor]
     ] = field(default_factory=dict)
@@ -142,7 +142,7 @@ def _verify_options(
     optims: Tuple[torch.optim.Optimizer, ...],
     model_only: bool,
     optim_only: bool,
-    options: Optional[DistributedStateDictOptions] = None,
+    options: Optional[StateDictOptions] = None,
 ) -> _StateDictInfo:
     """
     Verify the model and options passed by the user and generates _StateDictInfo.
@@ -160,7 +160,7 @@ def _verify_options(
             "Optimizers are not passed in but optim_only is set to True."
         )
 
-    options = options or DistributedStateDictOptions()
+    options = options or StateDictOptions()
 
     fqn_param_mapping: Dict[
         Union[str, torch.Tensor], Union[Set[str], torch.Tensor]
@@ -298,7 +298,7 @@ def _get_model_state_dict(
                 raise RuntimeError(f"An unexpected key, {key}, exists. FQN is {fqn}")
             state_dict[fqn] = state_dict.pop(key)
 
-    if not info.save_frozen_params:
+    if info.ignore_frozen_params:
         for key, param in model.named_parameters():
             if param.requires_grad:
                 continue
@@ -480,7 +480,7 @@ def state_dict(
     *,
     model_only: bool = False,
     optim_only: bool = False,
-    options: Optional[DistributedStateDictOptions] = None,
+    options: Optional[StateDictOptions] = None,
 ) -> Tuple[Dict[str, ValueType], OptimizerStateType]:
     """
     Return the model state_dict and optimizers state_dict.
@@ -542,9 +542,9 @@ def state_dict(
 
         optim_only (bool): if optim_only is True, the returned model state_dict
             will be empty (default: False)
-        options (DistributedStateDictOptions): the options to control how
+        options (StateDictOptions): the options to control how
             model state_dict and optimizer state_dict should be returned. See
-            `DistributedStateDictOptions` for the details.
+            `StateDictOptions` for the details.
     Returns:
         A tuple of state_dict's. The first one is the module  state_dict and the second
         one is the optimizer state_dict. The model state_dict will be empty if
@@ -578,7 +578,7 @@ def load_state_dict(
     optim_state_dict: Optional[OptimizerStateType] = None,
     model_only: bool = False,
     optim_only: bool = False,
-    options: Optional[DistributedStateDictOptions] = None,
+    options: Optional[StateDictOptions] = None,
 ) -> None:
     """Load the model state_dict and optimizers state_dict.
 
@@ -601,9 +601,9 @@ def load_state_dict(
             be loaded (default: False)
         optim_only (bool): if optim_only is True, only the optimizer state_dict
             will be loaded (default: False)
-        options (DistributedStateDictOptions): the options to control how
+        options (StateDictOptions): the options to control how
             model state_dict and optimizer state_dict should be loaded. See
-            `DistributedStateDictOptions` for the details.
+            `StateDictOptions` for the details.
     Returns:
         None
     """
@@ -631,7 +631,7 @@ def load_state_dict(
 def _patch_model_state_dict(
     model: nn.Module,
     *,
-    options: Optional[DistributedStateDictOptions] = None,
+    options: Optional[StateDictOptions] = None,
 ) -> None:
     """Patch the ``state_dict`` and ``load_state_dict`` attributes of ``model``.
 
@@ -647,9 +647,9 @@ def _patch_model_state_dict(
 
     Args:
         model (nn.Module): the nn.Module to the model.
-        options (DistributedStateDictOptions): the options to control how
+        options (StateDictOptions): the options to control how
             model state_dict and optimizer state_dict should be loaded. See
-            `DistributedStateDictOptions` for the details.
+            `StateDictOptions` for the details.
     Returns:
         None
     """
@@ -691,7 +691,7 @@ def _patch_optimizer_state_dict(
     model: nn.Module,
     optimizers: Tuple[torch.optim.Optimizer, ...],
     *,
-    options: Optional[DistributedStateDictOptions] = None,
+    options: Optional[StateDictOptions] = None,
 ) -> None:
     """Patch the ``state_dict`` and ``load_state_dict`` attributes of ``optimizers``.
 
@@ -710,9 +710,9 @@ def _patch_optimizer_state_dict(
 
     Args:
         model (nn.Module): the nn.Module to the model.
-        options (DistributedStateDictOptions): the options to control how
+        options (StateDictOptions): the options to control how
             model state_dict and optimizer state_dict should be loaded. See
-            `DistributedStateDictOptions` for the details.
+            `StateDictOptions` for the details.
     Returns:
         None
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #111111
* #111120
* #111110
* #111109
* __->__ #111108
* #111107
* #111106

1. Rename DistributedStateDictOptions to StateDictOptions.
2. Remove cpu_offload as we have not yet required this option.
3. Rename save_frozen_parameters to ignore_frozen_params.
