### PR TITLE
Revert 109859

### DIFF
--- a/torch/_export/exported_program.py
+++ b/torch/_export/exported_program.py
@@ -13,10 +13,10 @@ import torch.utils._pytree as pytree
 from torch._subclasses.fake_tensor import FakeTensor
 from torch.fx.experimental.symbolic_shapes import SymInt
 from torch.fx.graph import _PyTreeCodeGen, _PyTreeInfo
-from torch.utils._sympy.value_ranges import ValueRanges
 
 from torch._export.passes.add_runtime_assertions_for_constraints_pass import (
     InputDim,
+    RangeConstraint,
 )
 
 
@@ -271,7 +271,7 @@ def _process_constraints(
     graph_module: torch.fx.GraphModule,
     graph_signature: ExportGraphSignature,
     example_inputs: List[torch.Tensor],
-) -> Tuple[Dict[sympy.Symbol, ValueRanges], List[Tuple[InputDim, InputDim]]]:
+) -> Tuple[Dict[sympy.Symbol, RangeConstraint], List[Tuple[InputDim, InputDim]]]:
     """
     Process the constraints stored in the graph module to return something more readable.
 
@@ -283,7 +283,7 @@ def _process_constraints(
         example_inputs: Flattened list of example inputs used to export the graph module
 
     Returns:
-        range_constraints (Dict[sympy.Symbol, ValueRanges]): Mapping of
+        range_constraints (Dict[sympy.Symbol, RangeConstraints]): Mapping of
             symbols (from SymInts) appearing in the fake tensors in
             node.meta["val"] to their range constraints, which are a tuple
             containing (lower, upper) constraints.
@@ -313,14 +313,14 @@ def _process_constraints(
     equality_constraints: List[Tuple[InputDim, InputDim]] = []
     # Create dict mapping (node name, dim) a list of range (lower, upper)
     # constraints
-    multi_range_constraints: Dict[InputDim, List[ValueRanges]] = defaultdict(list)
+    multi_range_constraints: Dict[InputDim, List[RangeConstraint]] = defaultdict(list)
     for constraint in input_shape_constraints:
         for node in tensor_id_to_nodes[constraint["t_id"]]:
             node_dim = InputDim(node, constraint["dim"])
 
             # Accumulate range constraints
             multi_range_constraints[node_dim].append(
-                ValueRanges(constraint["min"], constraint["max"])
+                RangeConstraint(constraint["min"], constraint["max"])
             )
 
             # Accumulate equality constraints
@@ -330,20 +330,21 @@ def _process_constraints(
                     equality_constraints.append((node_dim, other_node_dim))
 
     # Create dict mapping symbol to a singular range (lower, upper)
-    range_constraints: Dict[sympy.Symbol, ValueRanges] = {}
+    range_constraints: Dict[sympy.Symbol, RangeConstraint] = {}
 
     # Add inline constraints to range_constraints
-    range_constraints = {symbol: inline_constraints[symbol] for symbol in inline_constraints}
+    for symbol, value_range in inline_constraints.items():
+        range_constraints[symbol] = RangeConstraint(value_range.lower, value_range.upper)
 
     # Add input range constraints to range_constraints
     for input_dim, multi_range_constraint in multi_range_constraints.items():  # type: ignore[assignment]
         # Simplify the range constraints into a single range constraint
         # Ex. ranges [2, 10] and [3, 11] would get merged to [3, 10]
-        min_vals = [rc.lower for rc in multi_range_constraint]
-        max_vals = [rc.upper for rc in multi_range_constraint]
-        min_val = max(min_vals)  # type: ignore[type-var]
-        max_val = min(max_vals)  # type: ignore[type-var]
-        assert min_val <= max_val  # type: ignore[operator]
+        min_vals = [rc.min_val for rc in multi_range_constraint]
+        max_vals = [rc.max_val for rc in multi_range_constraint]
+        min_val = max(min_vals)
+        max_val = min(max_vals)
+        assert min_val <= max_val
 
         # Add input node range constraints
         val = placeholder_nodes[input_dim.input_name].meta["val"]
@@ -351,7 +352,7 @@ def _process_constraints(
         symint = val.shape[input_dim.dim]
         assert isinstance(symint, SymInt), f"Expected SymInt but got {symint}: {type(symint)}"
         symbol = symint.node._expr
-        range_constraints[symbol] = ValueRanges(min_val, max_val)
+        range_constraints[symbol] = RangeConstraint(min_val, max_val)
 
     return range_constraints, equality_constraints
 

--- a/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
+++ b/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import copy
 import math
 import operator
@@ -13,15 +14,20 @@ import torch.fx
 from torch.fx.experimental.symbolic_shapes import SymInt
 from torch._export.pass_base import _ExportPassBase, ProxyValue, PassResult
 from torch._subclasses.fake_tensor import FakeTensor
-from torch.utils._sympy.value_ranges import ValueRanges
 
 
-__all__ = ["_AddRuntimeAssertionsForConstraintsPass", "InputDim"]
+__all__ = ["_AddRuntimeAssertionsForConstraintsPass", "InputDim", "RangeConstraint"]
 
 
 class InputDim(NamedTuple):
     input_name: str
     dim: int
+
+
+@dataclass
+class RangeConstraint:
+    min_val: sympy.Expr
+    max_val: sympy.Expr
 
 
 def _convert_to_int(val):
@@ -37,21 +43,21 @@ def _convert_to_int(val):
     )
 
 
-def _convert_range_to_int(range: ValueRanges):
-    assert isinstance(range, ValueRanges)
-    min_val = _convert_to_int(range.lower)
-    max_val = _convert_to_int(range.upper)
+def _convert_range_to_int(range: RangeConstraint):
+    assert isinstance(range, RangeConstraint)
+    min_val = _convert_to_int(range.min_val)
+    max_val = _convert_to_int(range.max_val)
     return min_val, max_val
 
 
 class _AddRuntimeAssertionsForInlineConstraintsPass(_ExportPassBase):
     def __init__(
         self,
-        range_constraints: Dict[sympy.Symbol, ValueRanges],
+        range_constraints: Dict[sympy.Symbol, RangeConstraint],
         equality_constraints: List[Tuple[InputDim, InputDim]],
     ):
         super().__init__()
-        self.range_constraints: Dict[sympy.Symbol, ValueRanges] = range_constraints
+        self.range_constraints: Dict[sympy.Symbol, RangeConstraint] = range_constraints
         self.equality_constraints: List[Tuple[InputDim, InputDim]] = equality_constraints
         self.counter = 0
 
@@ -151,7 +157,7 @@ class _AddRuntimeAssertionsForInlineConstraintsPass(_ExportPassBase):
 class _AddRuntimeAssertionsForConstraintsPass(_AddRuntimeAssertionsForInlineConstraintsPass):
     def __init__(
         self,
-        range_constraints: Dict[sympy.Symbol, ValueRanges],
+        range_constraints: Dict[sympy.Symbol, RangeConstraint],
         equality_constraints: List[Tuple[InputDim, InputDim]],
     ):
         super().__init__(range_constraints, equality_constraints)
@@ -243,7 +249,7 @@ class _AddRuntimeAssertionsForConstraintsPass(_AddRuntimeAssertionsForInlineCons
             _ = graph.call_function(torch.ops.aten._assert_async.msg, (tensor_eq_node, assert_msg))
 
     def _insert_range_assert_inplace(
-        self, graph: torch.fx.Graph, input_dim: InputDim, dim_node: torch.fx.Node, range: ValueRanges
+        self, graph: torch.fx.Graph, input_dim: InputDim, dim_node: torch.fx.Node, range: RangeConstraint
     ):
         """
         Add runtime asserts for user-specified range constraints for

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -20,7 +20,6 @@ import torch.export.exported_program as ep
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch.fx.experimental import symbolic_shapes
 from torch.utils._pytree import tree_map_only, treespec_dumps, treespec_loads
-from torch.utils._sympy.value_ranges import ValueRanges
 
 from .schema import (  # type: ignore[attr-defined]
     _Union,
@@ -277,12 +276,12 @@ def _int_to_sympy_int(val) -> sympy.Expr:
 
 
 def serialize_range_constraints(
-    range_constraints: Dict[sympy.Symbol, ValueRanges]
+    range_constraints: Dict[sympy.Symbol, torch._export.exported_program.RangeConstraint]
 ) -> Dict[str, RangeConstraint]:
     return {
         str(k): RangeConstraint(
-            _sympy_int_to_int(v.lower),  # type: ignore[arg-type]
-            _sympy_int_to_int(v.upper),  # type: ignore[arg-type]
+            _sympy_int_to_int(v.min_val),
+            _sympy_int_to_int(v.max_val),
         )
         for k, v in range_constraints.items()
     }
@@ -1403,11 +1402,11 @@ class ExportedProgramDeserializer:
         self,
         symbol_name_to_range: Dict[str, symbolic_shapes.ValueRanges],
         symbol_name_to_symbol: Dict[str, sympy.Symbol],
-    ) -> Dict[sympy.Symbol, ValueRanges]:
+    ) -> Dict[sympy.Symbol, torch._export.exported_program.RangeConstraint]:
         range_constraints = {}
         for k, v in symbol_name_to_range.items():
             if symbol := symbol_name_to_symbol.get(k):
-                range_constraints[symbol] = v  # type: ignore[arg-type]
+                range_constraints[symbol] = torch._export.exported_program.RangeConstraint(v.lower, v.upper)  # type: ignore[arg-type]
             else:
                 log.warning(f"Symbol {k} did not appear in the graph that was deserialized")  # noqa: G004
         return range_constraints


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/109859 caused Meta-internal build breakages because it removes an API
https://github.com/pytorch/pytorch/pull/110757 depends on 109859 and is already reverted via pytorchbot revert


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan