### PR TITLE
[Inductor] add negative index handle for indirect indexing in CPU

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6978,6 +6978,21 @@ class CommonTemplate:
             rtol=1e-2,  # to pass lowp check on GPU
         )
 
+    def test_negative_index(self):
+        def fn(primals_1, primals_2):
+            full_default = torch.ops.aten.full.default(
+                [1],
+                0,
+                dtype=torch.int64,
+                layout=torch.strided,
+                device=torch.device(type="cpu"),
+                pin_memory=False,
+            )
+            index = torch.ops.aten.index.Tensor(primals_1, [full_default, primals_2])
+            return index
+
+        self.common(fn, (torch.randn((1, 4, 3)), torch.tensor([-1])))
+
     @skipIfRocm
     def test_scaled_dot_product_efficient_attention(self):
         if self.device == "cpu":

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6979,19 +6979,11 @@ class CommonTemplate:
         )
 
     def test_negative_index(self):
-        def fn(primals_1, primals_2):
-            full_default = torch.ops.aten.full.default(
-                [1],
-                0,
-                dtype=torch.int64,
-                layout=torch.strided,
-                device=torch.device(type="cpu"),
-                pin_memory=False,
-            )
-            index = torch.ops.aten.index.Tensor(primals_1, [full_default, primals_2])
-            return index
+        def fn(logits, sequence_lengths):
+            pooled_logits = logits[torch.arange(1, device=self.device), sequence_lengths]
+            return pooled_logits
 
-        self.common(fn, (torch.randn((1, 4, 3)), torch.tensor([-1])))
+        self.common(fn, (torch.randn((1, 128, 64)), torch.tensor([-1])))
 
     @skipIfRocm
     def test_scaled_dot_product_efficient_attention(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6980,7 +6980,9 @@ class CommonTemplate:
 
     def test_negative_index(self):
         def fn(logits, sequence_lengths):
-            pooled_logits = logits[torch.arange(1, device=self.device), sequence_lengths]
+            pooled_logits = logits[
+                torch.arange(1, device=self.device), sequence_lengths
+            ]
             return pooled_logits
 
         self.common(fn, (torch.randn((1, 128, 64)), torch.tensor([-1])))

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1248,10 +1248,6 @@ class CppKernel(Kernel):
             new_var.update_on_args("index_wrap", (index_var,), {})
             index_var = new_var
 
-        # TODO <Leslie>: add the generate of assert as
-        # https://github.com/pytorch/pytorch/blob/
-        # f0e7a910304c6af4fe59524ab29348d906cf1dd4/torch/_inductor/codegen/triton.py#L1319
-
         return sympy_symbol(str(index_var))
 
     def load(self, name: str, index: sympy.Expr):

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1222,12 +1222,6 @@ class CppKernel(Kernel):
         new_index = sympy_subs(index, replacement)
         return new_index
 
-    def index_to_str(self, index: sympy.Expr) -> str:
-        # TODO <Leslie>: Implementate it as refer to:
-        # https://github.com/pytorch/pytorch/blob/
-        # f0e7a910304c6af4fe59524ab29348d906cf1dd4/torch/_inductor/codegen/triton.py#L1088
-        return index
-
     def indirect_indexing(self, index_var, size, check=True):
         # Refer to triton implementation:
         # https://github.com/pytorch/pytorch/blob/
@@ -1247,7 +1241,7 @@ class CppKernel(Kernel):
                     pos = index_var.bounds & ValueRanges(0, sympy.oo)
                     new_bounds = new_bounds | pos
 
-            stm = f"{index_var} + {self.index_to_str(size)}"
+            stm = f"{index_var} + {self.rename_indexing(size)}"
             if index_var.bounds.upper >= 0:
                 stm = f"{index_var} < 0 ? {stm} : {index_var}"
             new_var = self.cse.generate(self.compute, stm, bounds=new_bounds)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #111118

**Summary**
Fix the issue: https://github.com/pytorch/pytorch/issues/109019 of negative value used in tensor index.
This implementation refers to https://github.com/pytorch/pytorch/pull/105055

**Test Plan**
```
python -m pytest test_torchinductor.py -k test_negative_index
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler