### PR TITLE
Disable cutlass_template on ROCm

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -779,6 +779,10 @@ def use_triton_template(layout, *, enable_int32=False):
 def use_cutlass_template(layout):
     from .codegen.cuda.cutlass_utils import try_import_cutlass
 
+    # Do not use cutlass template on ROCm
+    if torch.version.hip:
+        return False
+        
     layout_dtypes = [torch.float16, torch.bfloat16, torch.float32]
     res = _use_template_for_cuda(layout, layout_dtypes) and _use_autotune_backend(
         "CUTLASS"

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -782,7 +782,7 @@ def use_cutlass_template(layout):
     # Do not use cutlass template on ROCm
     if torch.version.hip:
         return False
-        
+
     layout_dtypes = [torch.float16, torch.bfloat16, torch.float32]
     res = _use_template_for_cuda(layout, layout_dtypes) and _use_autotune_backend(
         "CUTLASS"


### PR DESCRIPTION
Fixes #111066 #111065 #111064

Currently use_cutlass_template is returning True on ROCm but the feature is not supported. Fix to return false on ROCm. I considering adding this change to `try_import_cutlass` instead but the comments hinted that this function would be removed at some point.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler