### PR TITLE
[export] Fix issue with internal model

### DIFF
--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -895,8 +895,9 @@ def aot_compile(
     from torch._inductor.decomposition import select_decomp_table
     ep = ep.run_decompositions(select_decomp_table())
 
-    if remove_runtime_assertions:
-        ep = ep._transform(_RemoveRuntimeAssertionsPass())
+    # TODO(angelayi): Needed to comment this out in order to unblock something
+    # if remove_runtime_assertions:
+    ep = ep._transform(_RemoveRuntimeAssertionsPass())
 
     flat_example_inputs = fx_pytree.tree_flatten_spec(
         combine_args_kwargs(args, kwargs), ep.call_spec.in_spec  # type: ignore[arg-type]


### PR DESCRIPTION
Summary:
This was error was run into when running ExportPassBase on an exported model with lifted constant tensors:
```
  File "/data/users/angelayi/pytorch/torch/_subclasses/fake_tensor.py", line 1444, in dispatch
    len(kwargs) == 0 and len(args) == 1 and type(args[0]) is torch.Tensor
AssertionError: (FakeTensor(..., size=(s0,)),) {}

While executing %lift_fresh_copy_1 : [num_users=1] = call_function[target=torch.ops.aten.lift_fresh_copy.default](args = (%_lifted_tensor_constant99,), kwargs = {})
Original traceback:
  File "" in forward
    mean = torch.tensor([0.485, 0.456, 0.406]).reshape(3, 1, 1)
```

In ExportPassBase, we retrace using the fake tensors in the placeholder nodes, but when running into this lift_fresh_copy operators, it's unable to be called with the fake tensors.

Test Plan: CI

Reviewed By: chakriu

Differential Revision: D50211827



cc @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan