### PR TITLE
[Doc] Fix typo in cpp/installing when wheel is used

### DIFF
--- a/docs/cpp/source/installing.rst
+++ b/docs/cpp/source/installing.rst
@@ -97,7 +97,7 @@ using `torch.utils.cmake_prefix_path` variable. In that case CMake configuration
 
 .. code-block:: sh
 
-  cmake -DCMAKE_PREFIX_PATH=`python -c 'import torch;print(torch.utils.cmake_prefix_path)'`
+  cmake -DCMAKE_PREFIX_PATH=`python3 -c 'import torch;print(torch.utils.cmake_prefix_path)'` ..
 
 If all goes well, it will look something like this:
 


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 34a15a6</samp>

Updated the cmake command in `docs/cpp/source/installing.rst` to use python3 and fix a documentation error.