### PR TITLE
Update sdp_utils functions to accept const& params

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -43,7 +43,7 @@
 namespace sdp {
 namespace {
 // flash_attention V2 is universally faster than efficient_attention and Math
-std::array<SDPBackend, num_backends> priority_order(sdp_params params) {
+std::array<SDPBackend, num_backends> priority_order(sdp_params const& params) {
   constexpr std::array<SDPBackend, num_backends> default_order{
       SDPBackend::flash_attention,
       SDPBackend::efficient_attention,
@@ -51,7 +51,7 @@ std::array<SDPBackend, num_backends> priority_order(sdp_params params) {
   return default_order;
 }
 
-bool use_tensor_cores(sdp_params params, cudaDeviceProp* dprops, bool is_half) {
+bool use_tensor_cores(sdp_params const& params, cudaDeviceProp* dprops, bool is_half) {
   if (dprops->major >= 8) {
     return true;
   }
@@ -60,7 +60,7 @@ bool use_tensor_cores(sdp_params params, cudaDeviceProp* dprops, bool is_half) {
   }
   return false;
 }
-int64_t minimum_gemm_alignment(sdp_params params) {
+int64_t minimum_gemm_alignment(sdp_params const& params) {
   auto dprops = at::cuda::getCurrentDeviceProperties();
   bool is_half = (params.query.dtype() == at::kHalf) ||
       (params.query.dtype() == at::kBFloat16);
@@ -76,7 +76,7 @@ int64_t minimum_gemm_alignment(sdp_params params) {
   return matmul_alignment_mn;
 }
 
-bool check_head_dim_size_flash(sdp_params params, bool debug) {
+bool check_head_dim_size_flash(sdp_params const& params, bool debug) {
   // All head_dim sizes must be equal and less than 256
   const auto max_size = c10::SymInt(256);
   const auto query_size_last = params.query.sym_size(-1);
@@ -118,7 +118,7 @@ bool check_head_dim_size_flash(sdp_params params, bool debug) {
   return true;
 }
 
-bool check_head_dim_size_mem_efficient(sdp_params params, bool debug) {
+bool check_head_dim_size_mem_efficient(sdp_params const& params, bool debug) {
   const auto query_size_last = params.query.sym_size(-1);
   const auto value_size_last = params.value.sym_size(-1);
   const int64_t alignment = minimum_gemm_alignment(params);
@@ -169,7 +169,7 @@ bool check_sm_version(cudaDeviceProp * dprops) {
   return is_gte_lower_bound && is_lte_upper_bound;
 }
 
-bool check_flash_attention_hardware_support(sdp_params params, bool debug) {
+bool check_flash_attention_hardware_support(sdp_params const& params, bool debug) {
   // Check that the gpu is capable of running flash attention
   using sm80 = SMVersion<8, 0>;
   using sm90 = SMVersion<9, 0>;
@@ -188,7 +188,7 @@ bool check_flash_attention_hardware_support(sdp_params params, bool debug) {
   return true;
 }
 
-bool check_mem_efficient_hardware_support(sdp_params params, bool debug) {
+bool check_mem_efficient_hardware_support(sdp_params const& params, bool debug) {
   // Mem Efficient attention supports hardware in the range [sm_50, sm_90]
   using sm50 = SMVersion<5, 0>;
   using sm90 = SMVersion<9, 0>;
@@ -208,7 +208,7 @@ bool check_mem_efficient_hardware_support(sdp_params params, bool debug) {
 }
 
 bool check_requires_grad_and_head_dim_gt192_and_sm_ge86_lt90(
-    sdp_params params,
+    sdp_params const& params,
     bool debug) {
   // Flash Attention will raise an error in the backward pass if the head_dim
   // size is greater than 64 And the device is between in the range [sm86, sm89]
@@ -230,7 +230,7 @@ bool check_requires_grad_and_head_dim_gt192_and_sm_ge86_lt90(
   return true;
 }
 
-bool use_flash_attention(sdp_params params, bool debug) {
+bool use_flash_attention(sdp_params const& params, bool debug) {
 #ifndef USE_FLASH_ATTENTION
   TORCH_WARN(!debug, "Torch was not compiled with flash attention.");
   return false;
@@ -238,7 +238,7 @@ bool use_flash_attention(sdp_params params, bool debug) {
 
   // Define gate functions that determine if a flash kernel can be ran
   // Replace with std::to_array when we migrate to c++20
-  constexpr auto constraints = array_of<bool (*)(sdp_params, bool)>(
+  constexpr auto constraints = array_of<bool (*)(sdp_params const&, bool)>(
       check_runtime_disabled_flash,
       check_tensor_shapes,
       check_batch_size_and_num_heads,
@@ -267,7 +267,7 @@ bool use_flash_attention(sdp_params params, bool debug) {
   }
 }
 
-bool use_mem_efficient_attention(sdp_params params, bool debug) {
+bool use_mem_efficient_attention(sdp_params const& params, bool debug) {
 #ifndef USE_MEM_EFF_ATTENTION
   TORCH_WARN(!debug, "Torch was not compiled with memory efficient attention.");
   return false;
@@ -279,7 +279,7 @@ bool use_mem_efficient_attention(sdp_params params, bool debug) {
       array_of<at::ScalarType>(at::kHalf, at::kFloat);
 
   //  Define gate functions that determine if a flash kernel can be ran
-  constexpr auto constraints = array_of<bool (*)(sdp_params, bool)>(
+  constexpr auto constraints = array_of<bool (*)(sdp_params const&, bool)>(
       check_runtime_disabled_mem_efficient,
       check_mem_efficient_hardware_support,
       check_requires_grad_and_nested,
@@ -303,7 +303,7 @@ bool use_mem_efficient_attention(sdp_params params, bool debug) {
 }
 } // namespace
 
-SDPBackend select_sdp_backend(sdp_params kernel_params) {
+SDPBackend select_sdp_backend(sdp_params const& kernel_params) {
   // This function defines the priority order of the different sdp backends
   // 1. Flash Attention
   // 2. Mem Efficient Attention
@@ -356,7 +356,7 @@ SDPBackend select_sdp_backend(sdp_params kernel_params) {
   return SDPBackend::error;
 }
 
-bool check_for_seq_len_1_nested_tensor(sdp_params params, bool debug) {
+bool check_for_seq_len_1_nested_tensor(sdp_params const& params, bool debug) {
   // When this function is called we are assured that the nt is dim==4
   if (!params.query.is_nested()) {
     return true;

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.h
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.h
@@ -5,7 +5,7 @@
 
 namespace sdp {
 
-bool check_for_seq_len_1_nested_tensor(sdp_params params, bool debug);
-SDPBackend select_sdp_backend(sdp_params kernel_params);
+bool check_for_seq_len_1_nested_tensor(sdp_params const& params, bool debug);
+SDPBackend select_sdp_backend(sdp_params const& kernel_params);
 
 } // namespace sdp

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.cpp
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.cpp
@@ -3,7 +3,7 @@
 namespace sdp {
 namespace {
 
-std::array<SDPBackend, num_backends> priority_order_cpp(sdp_params params) {
+std::array<SDPBackend, num_backends> priority_order_cpp(sdp_params const& params) {
   constexpr std::array<SDPBackend, num_backends> default_order{
       SDPBackend::flash_attention,
       SDPBackend::math};
@@ -11,7 +11,7 @@ std::array<SDPBackend, num_backends> priority_order_cpp(sdp_params params) {
   return default_order;
 }
 
-bool check_head_dim_size_cpp(sdp_params params, bool debug) {
+bool check_head_dim_size_cpp(sdp_params const& params, bool debug) {
   const auto query_size_last = params.query.sym_size(-1);
   const auto key_size_last = params.key.sym_size(-1);
   const auto value_size_last = params.value.sym_size(-1);
@@ -33,12 +33,12 @@ bool check_head_dim_size_cpp(sdp_params params, bool debug) {
   return true;
 }
 
-bool use_flash_attention_cpp(sdp_params params, bool debug) {
+bool use_flash_attention_cpp(sdp_params const& params, bool debug) {
   constexpr auto cpp_supported_flash_dtypes =
       array_of<at::ScalarType>(at::kFloat, at::kDouble, at::kBFloat16);
 
   // Define gate functions that determine if a flash kernel can be run
-  constexpr auto constraints = array_of<bool (*)(sdp_params, bool)>(
+  constexpr auto constraints = array_of<bool (*)(sdp_params const&, bool)>(
       check_runtime_disabled_flash,
       check_nested_tensor,
       check_for_dropout,
@@ -58,7 +58,7 @@ bool use_flash_attention_cpp(sdp_params params, bool debug) {
 }
 } // namespace
 
-SDPBackend select_sdp_backend_cpp(sdp_params kernel_params) {
+SDPBackend select_sdp_backend_cpp(sdp_params const& kernel_params) {
   // This function defines the priority order of the different sdp backends
   // 1. Flash Attention
   // 2. Mem Efficient Attention


### PR DESCRIPTION
# Summary
All our filter functions should not mutate the passed in params, this both makes the intent more clear and allows for the compiler to possible produce more optimal code.

### Note
I used East-const style cause I think it is more clear:
https://mariusbancila.ro/blog/2018/11/23/join-the-east-const-revolution/
