### PR TITLE
[pytorch][PR] [Inductor][FX passes] Pre grad batch relu fusion

### DIFF
--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -212,6 +212,17 @@ class MyModule6(torch.nn.Module):
         return torch.cat(tanh_1, dim=1) + torch.cat(tanh_2, dim=1)
 
 
+class MyModule7(torch.nn.Module):
+    def __init__(self, device, has_bias=True):
+        super().__init__()
+        self.device = device
+
+    def forward(self, x):
+        inputs = torch.unbind(x.to(self.device), dim=0)
+        relu = [torch.nn.functional.relu(inputs[i]) for i in range(len(inputs))]
+        return torch.stack(relu, dim=0)
+
+
 @requires_cuda()
 @torch._inductor.config.patch(group_fusion=True, batch_fusion=True)
 class TestGroupBatchFusion(TestCase):
@@ -402,6 +413,21 @@ class TestGroupBatchFusion(TestCase):
             counters["inductor"]["scmerge_cat_removed"],
             2,
         )
+        ref.sum().backward()
+        res.sum().backward()
+        self.compare_parameters(module, traced, rtol=1e-8, atol=1e-8)
+        self.compare_gradients(module, traced, rtol=1e-8, atol=1e-8)
+        counters.clear()
+
+    def test_batch_relu_pre_grad_fusion(self):
+        counters.clear()
+        module = MyModule7("cuda")
+        input = [torch.randn(20, 40, 60, requires_grad=True, device="cuda")]
+        traced = torch.compile(module)
+        ref = module(*input)
+        res = traced(*input)
+        self.compare_pred(module, traced, input)
+        self.assertEqual(counters["inductor"]["batch_fusion"], 1)
         ref.sum().backward()
         res.sum().backward()
         self.compare_parameters(module, traced, rtol=1e-8, atol=1e-8)

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -468,6 +468,67 @@ class BatchLayernormFusion(BatchFusion):
             graph.erase_node(node)
 
 
+class BatchReLUFusion(BatchFusion):
+    """
+    Batch relu fusion in pre grad pass.
+    We only fuse the relu if the input is after same split/unbind node.
+    """
+    def _getitem_args(self, getitem_node: torch.fx.Node):
+        if getitem_node.target != operator.__getitem__ or (
+            getitem_node.op != "call_function"
+        ):
+            return None
+        return getitem_node.args[0]
+
+    def match(self, node: torch.fx.Node):
+
+        input = get_arg_value(node, 0, "input")
+        if (
+            CallFunctionVarArgs(torch.nn.functional.relu).match(node)
+            and is_node_meta_valid(node)
+            and self._getitem_args(input) is not None
+        ):
+            group_key = (
+                "batch_relu",
+                self._getitem_args(input),
+                str(input.meta["example_value"].shape),
+            )
+        else:
+            group_key = None
+        return group_key
+
+    def fuse(self, graph: torch.fx.GraphModule, subset: List[torch.fx.Node]):
+        batch_nodes = []
+        batch_inputs = []
+
+        for node in subset:
+            batch_nodes.append(node)
+            batch_inputs.append(get_arg_value(node, 0, "input"))
+
+        # assume all the nodes to be batched have the same inplace
+        inplace = subset[0].kwargs.get("inplace", False)
+        with graph.inserting_before(subset[0]):
+            stack_inputs = graph.call_function(torch.stack, args=(batch_inputs, 0))
+
+            batch_relu = graph.call_function(
+                torch.nn.functional.relu,
+                args=(stack_inputs,),
+                kwargs={"inplace": inplace},
+            )
+            unbind_relu = graph.call_function(
+                torch.unbind, args=(batch_relu,), kwargs={"dim": 0}
+            )
+            for i, node in enumerate(batch_nodes):
+                with graph.inserting_after(unbind_relu):
+                    getitem = graph.call_function(
+                        operator.getitem, args=(unbind_relu, i)
+                    )
+                node.replace_all_uses_with(getitem)
+                getitem.meta.update(node.meta)
+                graph.erase_node(node)
+
+
+
 def find_independent_subset_greedy(
     node_list: List[torch.fx.Node],
 ) -> Iterator[List[torch.fx.Node]]:
@@ -599,6 +660,7 @@ def group_batch_fusion_pre_grad_passes(graph: torch.fx.Graph):
             BatchLinearLHSFusion(),
             BatchLayernormFusion(),
             BatchTanhFusion(),
+            BatchReLUFusion(),
         ]
     for rule in fusions:
         apply_group_batch_fusion(graph, rule)


### PR DESCRIPTION
Summary: We detect independent relu operators and do the fusion in the pre grad.

Test Plan:
### unit test
```
buck2 test mode/dev-nosan //caffe2/test/inductor:group_batch_fusion
```
Test UI: https://www.internalfb.com/intern/testinfra/testrun/16888498608558485

### Inlinve cvr
f479655232
```
buck2 run mode/opt //scripts/jackiexu0313/pt2:local_model_with_pt2 -- --test_mode split_batch_group
```
before vs after transformation
https://www.internalfb.com/intern/diffing/?paste_number=851907099

```
buck2 run mode/opt //scripts/jackiexu0313/pt2:local_model_with_pt2 -- --test_mode split_batch_group -c
```

P852036786

Differential Revision: D50207610




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler