### PR TITLE
[FSDP] continue if param not exist in sharded load (#109116)

### DIFF
--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -599,7 +599,15 @@ def _sharded_pre_load_state_dict_hook(
             fqn_from_global_root = f"{prefix}{FSDP_PREFIX}{fqn}"
         else:
             fqn_from_global_root = f"{prefix}{fqn}"
-        param = state_dict.pop(fqn_from_global_root)
+        try:
+            param = state_dict.pop(fqn_from_global_root)
+        except KeyError:
+            logger.warning(
+                f"Did not find param with FQN {fqn_from_global_root}, skipping it. "  # noqa: G004
+                "The weight will not be filled if you expect it to be."
+            )
+            continue  # TODO: Improve unittesting for state_dict finetuning
+            # cases: https://github.com/pytorch/pytorch/issues/109134
 
         if not fsdp_state._state_dict_config.use_dtensor:
             # All-gather the param (ShardedTensor)


### PR DESCRIPTION
If I add a param and then wrap with FSDP + load state dict, when strict=False don't hard error here.

Differential Revision: [D49170812](https://our.internmc.facebook.com/intern/diff/D49170812/)
Pull Request resolved: https://github.com/pytorch/pytorch/pull/109116
Approved by: https://github.com/fegin
