### PR TITLE
Fix typo under c10 directory

### DIFF
--- a/c10/core/DispatchKey.h
+++ b/c10/core/DispatchKey.h
@@ -17,7 +17,7 @@ namespace c10 {
 // a DispatchKeySet. The bits in the DispatchKeySet are split between the bottom
 // ~12 "BackendComponent" bits, while the remaining upper bits are assigned to
 // functionalities. When we encounter a functionality bit that is known to be
-// customizeable per-backend, then we also look at the lower BackendComponent
+// customizable per-backend, then we also look at the lower BackendComponent
 // bits and take the highest bit to determine which backend's implementation to
 // use.
 

--- a/c10/core/DispatchKeySet.h
+++ b/c10/core/DispatchKeySet.h
@@ -112,7 +112,7 @@ C10_ALWAYS_INLINE static const std::
 // Sparse, Quantized, AutogradFunctionality, ...). These keys together allow
 // every dispatcher operator to be customized in up to 12*4 different ways. Each
 // of those requires a slot in the operator table of every dispatcher operator.
-// Not every piece of functionality necessarily needs to be customizeable
+// Not every piece of functionality necessarily needs to be customizable
 // per-backend, and not every backend necessarily needs to be able to customize
 // every type of functionality.
 //
@@ -128,10 +128,10 @@ C10_ALWAYS_INLINE static const std::
 
 // (2a) and (2b) are represented identically in the DispatchKeySet logic:
 // - backend-agnostic functionalities (e.g. FuncTorchBatched) are NOT
-// customizeable per backend.
+// customizable per backend.
 //   In order to do so, we'd need to promote it to a per-backend functionality
 //   "building block" key.
-// - non-customizeable backends (e.g. FPGA) can NOT customize existing
+// - non-customizable backends (e.g. FPGA) can NOT customize existing
 // functionality like Sparse, Autograd, etc.
 //   In order to do so, we'd need to promote it to a backend "building block"
 //   key.
@@ -795,7 +795,7 @@ C10_API bool isBackendDispatchKey(DispatchKey t);
 C10_API DispatchKeySet getRuntimeDispatchKeySet(DispatchKey t);
 
 // Resolve alias dispatch key to DispatchKeySet if applicable,
-// and chek if k is a part of that set
+// and check if k is a part of that set
 C10_API bool runtimeDispatchKeySetHas(DispatchKey t, DispatchKey k);
 
 // Returns a DispatchKeySet of all backend keys mapped to Autograd dispatch key

--- a/c10/core/SingletonSymNodeImpl.h
+++ b/c10/core/SingletonSymNodeImpl.h
@@ -113,7 +113,7 @@ class C10_API SingletonSymNodeImpl : public SymNodeImpl {
   // For the purpose of computing inequalities, we consider the coefficient of
   // the SingletonInt to be a positive integer.
   //
-  // Thus, no modificaitons are needed to the logic since
+  // Thus, no modifications are needed to the logic since
   // j0 >= k implies coeff * j0 >= k
   //
   c10::SymNode eq(const c10::SymNode& other) override;

--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -150,7 +150,7 @@ class C10_API SymInt {
   // if the SymInt in question is an unbacked SymInt (or, potentially in the
   // future, if it contains unbacked SymInts), we will also treat the
   // unbacked SymInt as statically testing >= 2 (which will prevent us from
-  // choking on, e.g., contiguity chekcs.)
+  // choking on, e.g., contiguity checks.)
   bool expect_size(const char* file, int64_t line) const;
 
   // Distinguish actual symbolic values from constants stored on the heap

--- a/c10/core/impl/DeviceGuardImplInterface.h
+++ b/c10/core/impl/DeviceGuardImplInterface.h
@@ -125,7 +125,7 @@ struct C10_API DeviceGuardImplInterface {
    */
   virtual Stream getStreamFromGlobalPool(Device, bool isHighPriority = false)
       const {
-    (void)isHighPriority; // Suppress unused varaible warning
+    (void)isHighPriority; // Suppress unused variable warning
     TORCH_CHECK(false, "Backend doesn't support acquiring a stream from pool.")
   }
 

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -725,7 +725,7 @@ struct PrivatePool {
   // Instead of maintaining private BlockPools here, I could stuff all blocks
   // (private or no) into the top-level large_blocks and small_blocks, and
   // distinguish private blocks by adding a "pool id" check above the stream
-  // check in BlockComparator. BlockComparator is performance- critial though,
+  // check in BlockComparator. BlockComparator is performance- critical though,
   // I'd rather not add more logic to it.
   BlockPool large_blocks;
   BlockPool small_blocks;
@@ -1118,7 +1118,7 @@ class DeviceCachingAllocator {
           format_size(alloc_size),
           ". GPU ",
           device,
-          " has a total capacty of ",
+          " has a total capacity of ",
           format_size(device_total),
           " of which ",
           format_size(device_free),
@@ -1649,7 +1649,7 @@ class DeviceCachingAllocator {
     const auto all_blocks = get_all_blocks();
 
     for (const Block* const head_block : all_blocks) {
-      // For expandable segments, we report one segment for each continguous
+      // For expandable segments, we report one segment for each contiguous
       // mapped range of memory
       if (head_block->prev && head_block->prev->mapped) {
         continue;
@@ -2078,7 +2078,7 @@ class DeviceCachingAllocator {
       // cannot be freed when requested, but fully free pages
       // of expandable blocks can always be freed.
       // The logic to track this as statistic is pretty involved,
-      // so we simply just exclude expandable segements from
+      // so we simply just exclude expandable segments from
       // inactive_split
       if (!block->expandable_segment_) {
         update_stat(

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -251,7 +251,7 @@ class CUDAAllocator : public Allocator {
 
   // memory not allocated from cudaMalloc cannot be copied
   // across devices using cudaMemcpyAsync if peer to peer access is disabled.
-  // instead it requres cudaMemcpyAsyncPeer
+  // instead it requires cudaMemcpyAsyncPeer
   //  with P2P Enabled, all combinations work
   //  with P2P Disabled:
   //                       cudaMalloc cudaMallocAsync/cuMemMap

--- a/c10/util/TypeIndex.h
+++ b/c10/util/TypeIndex.h
@@ -167,7 +167,7 @@ inline constexpr type_index get_type_index() {
 #if !defined(TORCH_PEDANTIC)
 // Use precomputed hashsum for std::string
 // Needed to workaround ambiguity in class name resolution
-// into __PRETTY_FUNCION__ when abovementioned class is defined in inlined
+// into __PRETTY_FUNCTION__ when abovementioned class is defined in inlined
 // namespace. In multi-ABI C++ library, `std::string` is an alias to
 // `std::__cxx11::basic_string<char>` which depending on compiler flags can be
 // resolved to `basic_string<char>` either in `std` namespace or in


### PR DESCRIPTION
This PR fixes typo in comments and messages in files under `c10` directory.
