### PR TITLE
[logging] log exceptions when provided

### DIFF
--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -638,6 +638,13 @@ class TorchLogsFormatter(logging.Formatter):
         record.message = record.getMessage()
         record.asctime = self.formatTime(record, self.datefmt)
 
+        # copied from https://github.com/python/cpython/blob/main/Lib/logging/__init__.py#L707-L711
+        if record.exc_info:
+            # Cache the traceback text to avoid converting it multiple times
+            # (it's constant anyway)
+            if not record.exc_text:
+                record.exc_text = self.formatException(record.exc_info)
+
         lines = record.message.split("\n")
         record.rankprefix = ""
         if dist.is_available() and dist.is_initialized():

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -638,7 +638,7 @@ class TorchLogsFormatter(logging.Formatter):
         record.message = record.getMessage()
         record.asctime = self.formatTime(record, self.datefmt)
 
-        # copied from https://github.com/python/cpython/blob/main/Lib/logging/__init__.py#L707-L711
+        # exception handling - copied from logging.Formatter.format
         if record.exc_info:
             # Cache the traceback text to avoid converting it multiple times
             # (it's constant anyway)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #111164

This PR will cause logging.exception() to also dump the exception and stacktrace. Copied from https://github.com/python/cpython/blob/74723e11109a320e628898817ab449b3dad9ee96/Lib/logging/__init__.py#L707-L711

repro:

<details>

```python
import torch
import torch._inductor.config

torch._inductor.config.triton.inject_relu_bug_TESTING_ONLY = "runtime_error"

def fn(x, y):
    return (x @ y).relu()

x, y = [torch.rand((16, 16), device='cuda') for _ in range (2)]
torch.compile(fn)(x, y)
```
run with TORCHDYNAMO_REPRO_AFTER=aot TORCHDYNAMO_REPRO_LEVEL=4

</details>

before:
```
...
[2023-10-12 14:18:52,902] torch._dynamo.debug_utils: [ERROR] While minifying the program in accuracy minification mode, ran into a runtime exception which is likely an unrelated issue. Skipping this graph.
```

now:
```
...
[2023-10-12 14:18:52,902] torch._dynamo.debug_utils: [ERROR] While minifying the program in accuracy minification mode, ran into a runtime exception which is likely an unrelated issue. Skipping this graph.
Traceback (most recent call last):
  File "/data/users/dberard/scripts/relu_accuracy_issue.py", line 10, in <module>
    torch.compile(fn)(x, y)
...
```