### PR TITLE
[pt][group_fusion] fix shape guarding in fusion candidate search

### DIFF
--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -72,8 +72,10 @@ class GroupLinearFusion(GroupFusion):
             and len(input_shape) == 2
             and len(weight_shape) == 2
             and all(x % 2 == 0 for x in input_shape + weight_shape)
-            and shape <= MAX_FUSE_TENSOR_SIZE_GROUP_LINEAR
-            for shape in input_shape + weight_shape
+            and all(
+                shape <= MAX_FUSE_TENSOR_SIZE_GROUP_LINEAR
+                for shape in input_shape + weight_shape
+            )
         )
 
     def _mm_node_can_be_fused(self, node: torch.fx.Node):
@@ -83,8 +85,10 @@ class GroupLinearFusion(GroupFusion):
             len(input_shape) == 2
             and len(weight_shape) == 2
             and all(x % 2 == 0 for x in input_shape + weight_shape)
-            and shape <= MAX_FUSE_TENSOR_SIZE_GROUP_LINEAR
-            for shape in input_shape + weight_shape
+            and all(
+                shape <= MAX_FUSE_TENSOR_SIZE_GROUP_LINEAR
+                for shape in input_shape + weight_shape
+            )
         )
 
     def match(self, node: torch.fx.Node) -> Optional[Tuple[str, bool]]:


### PR DESCRIPTION
Summary:
without the `all` in the fix
```
node.kwargs.get("beta", 1.0) == 1.0
node.kwargs.get("alpha", 1.0) == 1.0
and len(input_shape) == 2
and len(weight_shape) == 2
and all(x % 2 == 0 for x in input_shape + weight_shape)
and shape <= MAX_FUSE_TENSOR_SIZE_GROUP_LINEAR # <----- HERE
for shape in input_shape + weight_shape
```
this statement defaults to a generator object which means it will always be true. One of the issues is that the shapes could be an odd number which forces gmm to load element-by-element rather than vectorized load. In VDDv3 torchbench example(posted in test plan), you can see there is a 37ms GMM call which swamps any gain from fusion. Overall this change makes the GMM fusion 24% faster

Differential Revision: D48696572




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler