### PR TITLE
[symnode] support symbool -> symint casting for symint arithmetic

### DIFF
--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -322,7 +322,8 @@ class ExprPrinter(Printer):
 
     def _print_Piecewise(self, expr):
         # This is a hack, but we only ever emit `Piecewise` when converting bool to int
-        return f"bool({expr.args[0]}[0])"
+        return f"bool({expr.args[0]}[1])"
+
 
 class PythonPrinter(ExprPrinter):
     def _print_ModularIndexing(self, expr):

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -320,6 +320,9 @@ class ExprPrinter(Printer):
         # Go figure...
         return " >= ".join(map(self.paren, map(self._print, expr.args)))
 
+    def _print_Piecewise(self, expr):
+        # This is a hack, but we only ever emit `Piecewise` when converting bool to int
+        return f"bool({expr.args[0]}[0])"
 
 class PythonPrinter(ExprPrinter):
     def _print_ModularIndexing(self, expr):


### PR DESCRIPTION
Possible hacky fix to: https://github.com/pytorch/pytorch/issues/110738

I doubt you would approve @lezcano, but sympy does not handle bool -> int casting as python does.

I don't think this is complete, but it is at least a start so I'll leave it up here in case anyone has a better idea for how to continue. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @lezcano  