### PR TITLE
Reshape mask for triu to have the same shape as input.

### DIFF
--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5602,6 +5602,7 @@ def triu(a: TensorLikeType, diagonal: int = 0) -> TensorLikeType:
         torch.arange(w, device=a.device).unsqueeze(-2)
         - torch.arange(h, device=a.device).unsqueeze(-1)
     ) >= diagonal
+    mask = mask.broadcast_to(a.shape)
 
     # aten.triu always returns a new contiguous tensor
     # contiguous() is needed to correctly model the output stride


### PR DESCRIPTION
Currently this gives this warning:
[W Resize.cpp:35] Warning: An output with one or more elements was resized since it had shape [10, 10], which does not match the required output shape [1, 12, 10, 10]. This behavior is
deprecated, and in a future PyTorch release outputs will not be resized unless they have zero elements. You can explicitly reuse an out tensor t by resizing it, inplace, to zero elements with t.resize_(0). (function _resize_output_check)

Fixes #ISSUE_NUMBER
