### PR TITLE
[c10d] add nccl version to c10d logger

### DIFF
--- a/test/distributed/test_c10d_logger.py
+++ b/test/distributed/test_c10d_logger.py
@@ -117,7 +117,7 @@ class C10dErrorLoggerTest(MultiProcessTestCase):
                 re.search("({.+})", captured.output[0]).group(0).replace("'", '"')
             )
 
-            self.assertEqual(len(error_msg_dict), 9)
+            self.assertEqual(len(error_msg_dict), 10)
 
             self.assertIn("pg_name", error_msg_dict.keys())
             self.assertEqual("None", error_msg_dict["pg_name"])
@@ -129,6 +129,12 @@ class C10dErrorLoggerTest(MultiProcessTestCase):
 
             self.assertIn("backend", error_msg_dict.keys())
             self.assertEqual("nccl", error_msg_dict["backend"])
+
+            self.assertIn("nccl_version", error_msg_dict.keys())
+            nccl_ver = torch.cuda.nccl.version()
+            self.assertEqual(
+                ".".join(str(v) for v in nccl_ver), error_msg_dict["nccl_version"]
+            )
 
             # In this test case, group_size = world_size, since we don't have multiple processes on one node.
             self.assertIn("group_size", error_msg_dict.keys())
@@ -155,7 +161,7 @@ class C10dErrorLoggerTest(MultiProcessTestCase):
             msg_dict = json.loads(
                 re.search("({.+})", captured.output[0]).group(0).replace("'", '"')
             )
-            self.assertEqual(len(msg_dict), 9)
+            self.assertEqual(len(msg_dict), 10)
 
             self.assertIn("pg_name", msg_dict.keys())
             self.assertEqual("None", msg_dict["pg_name"])
@@ -167,6 +173,12 @@ class C10dErrorLoggerTest(MultiProcessTestCase):
 
             self.assertIn("backend", msg_dict.keys())
             self.assertEqual("nccl", msg_dict["backend"])
+
+            self.assertIn("nccl_version", msg_dict.keys())
+            nccl_ver = torch.cuda.nccl.version()
+            self.assertEqual(
+                ".".join(str(v) for v in nccl_ver), msg_dict["nccl_version"]
+            )
 
             # In this test case, group_size = world_size, since we don't have multiple processes on one node.
             self.assertIn("group_size", msg_dict.keys())

--- a/torch/distributed/c10d_logger.py
+++ b/torch/distributed/c10d_logger.py
@@ -11,6 +11,7 @@ import logging
 import time
 from typing import Any, Dict, List, Tuple
 
+import torch
 import torch.distributed as dist
 
 from torch.distributed.logging_handlers import _log_handlers
@@ -53,6 +54,9 @@ def _get_msg_dict(func_name, *args, **kwargs) -> Dict[str, Any]:
             "global_rank": f"{dist.get_rank()}",
             "local_rank": f"{dist.get_rank(kwargs.get('group'))}",
         }
+        if msg_dict["backend"] == "nccl":
+            nccl_version = torch.cuda.nccl.version()
+            msg_dict["nccl_version"] = ".".join(str(v) for v in nccl_version)
     else:
         msg_dict = {
             "func_name": f"{func_name}",


### PR DESCRIPTION
Summary: NCCL version is essential for debugging purpose and NCCL rollout monitoring. Log this info for easy access.

Test Plan:
run cmf10x on devgpu

https://pxl.cl/3B5gf


https://fburl.com/scuba/pytorch_c10d_logging/lybk2usq

Differential Revision: D50240853


