### PR TITLE
[BE] Move ASAN from clang-12 to clang-15

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -249,6 +249,12 @@ case "$image" in
     CONDA_CMAKE=yes
     TRITON=yes
     ;;
+  pytorch-linux-jammy-py3-clang15-asan)
+    ANACONDA_PYTHON_VERSION=3.10
+    CLANG_VERSION=15
+    CONDA_CMAKE=yes
+    VISION=yes
+    ;;
   pytorch-linux-jammy-py3.8-gcc11)
     ANACONDA_PYTHON_VERSION=3.8
     GCC_VERSION=11

--- a/.ci/docker/common/install_base.sh
+++ b/.ci/docker/common/install_base.sh
@@ -23,7 +23,9 @@ install_ubuntu() {
     maybe_libiomp_dev="libiomp-dev"
   fi
 
-  if [[ "$CLANG_VERSION" == 12 ]]; then
+  if [[ "$CLANG_VERSION" == 15 ]]; then
+    maybe_libomp_dev="libomp-15-dev"
+  elif [[ "$CLANG_VERSION" == 12 ]]; then
     maybe_libomp_dev="libomp-12-dev"
   elif [[ "$CLANG_VERSION" == 10 ]]; then
     maybe_libomp_dev="libomp-10-dev"

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -148,7 +148,7 @@ if [[ "$BUILD_ENVIRONMENT" == *asan* ]]; then
     export PYTORCH_TEST_WITH_ASAN=1
     export PYTORCH_TEST_WITH_UBSAN=1
     # TODO: Figure out how to avoid hard-coding these paths
-    export ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-12/bin/llvm-symbolizer
+    export ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-15/bin/llvm-symbolizer
     export TORCH_USE_RTLD_GLOBAL=1
     # NB: We load libtorch.so with RTLD_GLOBAL for UBSAN, unlike our
     # default behavior.
@@ -182,7 +182,7 @@ if [[ "$BUILD_ENVIRONMENT" == *asan* ]]; then
     # have, and it applies to child processes.
 
     # TODO: get rid of the hardcoded path
-    export LD_PRELOAD=/usr/lib/llvm-12/lib/clang/12.0.1/lib/linux/libclang_rt.asan-x86_64.so
+    export LD_PRELOAD=/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/libclang_rt.asan-x86_64.so
     # Disable valgrind for asan
     export VALGRIND=OFF
     # Increase stack size, because ASAN red zones use more stack

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -45,7 +45,7 @@ jobs:
           - docker-image-name: pytorch-linux-focal-py3-clang9-android-ndk-r19c
           - docker-image-name: pytorch-linux-jammy-py3.8-gcc11
           - docker-image-name: pytorch-linux-jammy-py3.8-gcc11-inductor-benchmarks
-          - docker-image-name: pytorch-linux-jammy-py3-clang12-asan
+          - docker-image-name: pytorch-linux-jammy-py3-clang15-asan
           - docker-image-name: pytorch-linux-focal-py3-clang10-onnx
           - docker-image-name: pytorch-linux-focal-linter
           - docker-image-name: pytorch-linux-jammy-cuda11.8-cudnn8-py3.9-linter

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -75,12 +75,12 @@ jobs:
           { config: "default", shard: 1, num_shards: 1 },
         ]}
 
-  linux-jammy-py3_9-clang12-asan-build:
-    name: linux-jammy-py3.9-clang12-asan
+  linux-jammy-py3_10-clang15-asan-build:
+    name: linux-jammy-py3.10-clang15-asan
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-jammy-py3.9-clang12-asan
-      docker-image-name: pytorch-linux-jammy-py3-clang12-asan
+      build-environment: linux-jammy-py3.10-clang15-asan
+      docker-image-name: pytorch-linux-jammy-py3-clang15-asan
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 6, runner: "linux.4xlarge" },
@@ -92,14 +92,14 @@ jobs:
         ]}
       sync-tag: asan-build
 
-  linux-jammy-py3_9-clang12-asan-test:
-    name: linux-jammy-py3.9-clang12-asan
+  linux-jammy-py3_10-clang15-asan-test:
+    name: linux-jammy-py3.10-clang15-asan
     uses: ./.github/workflows/_linux-test.yml
-    needs: linux-jammy-py3_9-clang12-asan-build
+    needs: linux-jammy-py3_10-clang15-asan-build
     with:
-      build-environment: linux-jammy-py3.9-clang12-asan
-      docker-image: ${{ needs.linux-jammy-py3_9-clang12-asan-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-py3_9-clang12-asan-build.outputs.test-matrix }}
+      build-environment: linux-jammy-py3.10-clang15-asan
+      docker-image: ${{ needs.linux-jammy-py3_10-clang15-asan-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-py3_10-clang15-asan-build.outputs.test-matrix }}
       sync-tag: asan-test
 
   linux-focal-py3_8-clang10-onnx-build:

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -104,12 +104,12 @@ jobs:
       docker-image: ${{ needs.linux-focal-rocm5_6-py3_8-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-rocm5_6-py3_8-build.outputs.test-matrix }}
 
-  linux-jammy-py3_9-clang12-asan-build:
-    name: linux-jammy-py3.9-clang12-asan
+  linux-jammy-py3_10-clang15-asan-build:
+    name: linux-jammy-py3.10-clang15-asan
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-jammy-py3.9-clang12-asan
-      docker-image-name: pytorch-linux-jammy-py3-clang12-asan
+      build-environment: linux-jammy-py3.10-clang15-asan
+      docker-image-name: pytorch-linux-jammy-py3-clang15-asan
       test-matrix: |
         { include: [
           { config: "slow", shard: 1, num_shards: 2, runner: "linux.4xlarge" },
@@ -117,12 +117,12 @@ jobs:
         ]}
       sync-tag: asan-build
 
-  linux-jammy-py3_9-clang12-asan-test:
-    name: linux-jammy-py3.9-clang12-asan
+  linux-jammy-py3_10-clang15-asan-test:
+    name: linux-jammy-py3.10-clang15-asan
     uses: ./.github/workflows/_linux-test.yml
-    needs: linux-jammy-py3_9-clang12-asan-build
+    needs: linux-jammy-py3_10-clang15-asan-build
     with:
-      build-environment: linux-jammy-py3.9-clang12-asan
-      docker-image: ${{ needs.linux-jammy-py3_9-clang12-asan-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-py3_9-clang12-asan-build.outputs.test-matrix }}
+      build-environment: linux-jammy-py3.10-clang15-asan
+      docker-image: ${{ needs.linux-jammy-py3_10-clang15-asan-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-py3_10-clang15-asan-build.outputs.test-matrix }}
       sync-tag: asan-test


### PR DESCRIPTION
Hopefully it will align with internal system and they will detect heap-overlow access reported in https://github.com/pytorch/pytorch/issues/111189 Also, do not build neither Triton, nor protobuf nor DB dependencies (as they are not needed for ASAN builds/tests)
