### PR TITLE
[easy] Remove duplicate exprs in produce_guards

### DIFF
--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -3431,7 +3431,7 @@ class ShapeEnv:
             expr = self.simplify(guard.expr)
 
             # Avoid re-issueing the same guard.
-            if guard.expr in issued:
+            if expr in issued:
                 return
 
             issued.add(expr)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #111270

Summary: We're checking the original guard.expr in the issued set instead of the simplified expr, leading to duplicate guards in cases where one expression simplifies to another.