### PR TITLE
[Compiled Autograd] Turn accumulate_grad into an op

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -346,6 +346,7 @@ class WrapperCodeGen(CodeGen):
                 from torch._inductor.select_algorithm import extern_kernels
 
                 aten = torch.ops.aten
+                inductor_ops = torch.ops.inductor
                 assert_size_stride = torch._C._dynamo.guards.assert_size_stride
                 reinterpret_tensor = torch.ops.inductor._reinterpret_tensor
                 async_compile = AsyncCompile()

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3590,6 +3590,33 @@ class InplaceBernoulliFallback(ExternKernel):
         self.name = V.graph.register_buffer(self)
 
 
+class AccumulateGrad(ExternKernel):
+    """
+    This needs to be a custom class to handle mutation properly
+    """
+
+    kernel = "inductor_ops.accumulate_grad_"
+
+    def codegen(self, wrapper):
+        (variable, new_grad) = (t.codegen_reference() for t in self.inputs)
+        wrapper.writeline(f"{self.kernel}({variable}, {new_grad})")
+
+    def should_allocate(self):
+        return False
+
+    def get_mutation_names(self):
+        assert isinstance(self.layout, MutationLayout)
+        return (self.layout.target.get_name(),)
+
+    def __init__(self, variable, new_grad):
+        super().__init__(
+            None,
+            MutationLayout(variable),
+            self.unwrap_storage([variable, new_grad]),
+        )
+        self.name = V.graph.register_buffer(self)
+
+
 class ScatterFallback(ExternKernel):
     """
     This needs to be a custom class to handle mutation properly.

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -4793,6 +4793,15 @@ def _realize(x):
     return clone(x)
 
 
+@register_lowering(torch.ops.inductor.accumulate_grad_)
+def accumulate_grad_(variable, new_grad):
+    # TODO(jansel): decompose into `variable.grad += new_grad` when variable.grad is defined
+    variable.realize()
+    new_grad.realize()
+    ir.AccumulateGrad(variable, new_grad)
+    return variable
+
+
 try:
     import torch.distributed._functional_collectives
 

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -85,6 +85,7 @@ variable_list AccumulateGrad::apply_with_saved(
   saved.before(variable_copy);
   saved.before(grad_copy);
   variable_copy.mutable_grad() = grad_copy;
+  // op is intentionally static
   static auto op = c10::Dispatcher::singleton()
                        .findSchemaOrThrow("inductor::accumulate_grad_", "")
                        .typed<void(const at::Tensor&, const at::Tensor&)>();

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/autograd/functions/accumulate_grad.h>
 
+#include <ATen/core/dispatch/Dispatcher.h>
 #include <torch/csrc/autograd/functions/basic_ops.h>
 #include <torch/csrc/autograd/functions/tensor.h>
 #include <torch/csrc/autograd/functions/utils.h>
@@ -83,14 +84,11 @@ variable_list AccumulateGrad::apply_with_saved(
   at::Tensor grad_copy = variable.grad();
   saved.before(variable_copy);
   saved.before(grad_copy);
-  accumulateGrad(
-      variable_copy,
-      grad_copy,
-      grads[0],
-      0 /* num_expected_refs, 0 disables aliased reuse */,
-      [&saved, this](const at::Tensor& grad_update) {
-        saved.assign_mutable_grad(variable, grad_update);
-      });
+  variable_copy.mutable_grad() = grad_copy;
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("inductor::accumulate_grad_", "")
+                       .typed<void(const at::Tensor&, const at::Tensor&)>();
+  op.call(variable_copy, grads[0]);
   saved.after(variable_copy);
   saved.after(grad_copy);
 

--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -469,7 +469,6 @@ struct TraceState {
   size_t sym_sizes_index;
   std::vector<c10::optional<c10::SymInt>> sym_sizes;
   variable_list outputs;
-  std::vector<size_t> output_grad_targets;
 };
 
 class SwapSavedVariables {
@@ -619,17 +618,6 @@ class SwapSavedVariables {
   NO_OP_VISIT(bool);
   NO_OP_VISIT(double);
 #undef NO_OP_VISIT
-
-  // record the need to run `dst.mutable_grad() = src` after the graph
-  // dst is a real tensor, src is a fake tensor
-  void assign_mutable_grad(const at::Tensor& dst, const at::Tensor& src) {
-    const TensorArg& arg = compiler.tensor_args.lookup(dst);
-    TORCH_INTERNAL_ASSERT(arg.defined());
-    TORCH_INTERNAL_ASSERT(
-        state.outputs.size() == state.output_grad_targets.size());
-    state.outputs.emplace_back(src);
-    state.output_grad_targets.emplace_back(arg.index());
-  }
 
   SwapSavedVariables(AutogradCompilerCall& c, TraceState& s)
       : compiler(c), state(s) {}

--- a/torch/csrc/inductor/inductor_ops.cpp
+++ b/torch/csrc/inductor/inductor_ops.cpp
@@ -4,6 +4,7 @@
 #include <ATen/ops/mm.h>
 #endif
 
+#include <torch/csrc/autograd/functions/accumulate_grad.h>
 #include <torch/csrc/inductor/inductor_ops.h>
 #include <torch/library.h>
 
@@ -38,6 +39,23 @@ Tensor _reinterpret_tensor(
   return self_;
 }
 
+void accumulate_grad_(const Tensor& variable, const Tensor& new_grad) {
+  at::Tensor& grad = variable.mutable_grad();
+  if (new_grad.device() != kMeta) {
+    torch::autograd::AccumulateGrad::accumulateGrad(
+        variable,
+        grad,
+        new_grad,
+        1 /* num_expected_refs */,
+        [&grad](at::Tensor&& grad_update) { grad = std::move(grad_update); });
+  } else {
+    // no shape checking for `device="meta"` to workaround FSDP inplace mutation
+    if (!grad.defined()) {
+      grad = new_grad;
+    }
+  }
+}
+
 TORCH_LIBRARY_FRAGMENT(inductor, m) {
   m.def(
       "_mm_plus_mm(Tensor a, Tensor b, Tensor c, Tensor d, Tensor(t!) out) -> Tensor(t!)",
@@ -45,6 +63,11 @@ TORCH_LIBRARY_FRAGMENT(inductor, m) {
   m.def(
       "_reinterpret_tensor(Tensor self, int[] size, int[] stride, int offset_increment=0) -> Tensor",
       _reinterpret_tensor);
+  m.def("accumulate_grad_(Tensor variable, Tensor new_grad) -> ()");
+}
+
+TORCH_LIBRARY_IMPL(inductor, CompositeExplicitAutograd, m) {
+  m.impl("accumulate_grad_", TORCH_FN(accumulate_grad_));
 }
 
 } // namespace inductor

--- a/torch/csrc/inductor/inductor_ops.cpp
+++ b/torch/csrc/inductor/inductor_ops.cpp
@@ -39,7 +39,7 @@ Tensor _reinterpret_tensor(
   return self_;
 }
 
-void accumulate_grad_(const Tensor& variable, const Tensor& new_grad) {
+static void accumulate_grad_(const Tensor& variable, const Tensor& new_grad) {
   at::Tensor& grad = variable.mutable_grad();
   if (new_grad.device() != kMeta) {
     torch::autograd::AccumulateGrad::accumulateGrad(

--- a/torch/csrc/inductor/inductor_ops.cpp
+++ b/torch/csrc/inductor/inductor_ops.cpp
@@ -63,11 +63,9 @@ TORCH_LIBRARY_FRAGMENT(inductor, m) {
   m.def(
       "_reinterpret_tensor(Tensor self, int[] size, int[] stride, int offset_increment=0) -> Tensor",
       _reinterpret_tensor);
-  m.def("accumulate_grad_(Tensor variable, Tensor new_grad) -> ()");
-}
-
-TORCH_LIBRARY_IMPL(inductor, CompositeExplicitAutograd, m) {
-  m.impl("accumulate_grad_", TORCH_FN(accumulate_grad_));
+  m.def(
+      "accumulate_grad_(Tensor variable, Tensor new_grad) -> ()",
+      dispatch(c10::DispatchKey::CompositeExplicitAutograd, accumulate_grad_));
 }
 
 } // namespace inductor

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -39,7 +39,9 @@ _side_effectful_functions: Set[Callable] = {
     _ops.aten.sym_constrain_range_for_size.default,
     _ops.profiler._record_function_enter,
     _ops.profiler._record_function_enter_new,
-    _ops.profiler._record_function_exit}
+    _ops.profiler._record_function_exit,
+    _ops.inductor.accumulate_grad_.default,
+}
 
 
 @compatibility(is_backward_compatible=False)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #111274
* #111273
* __->__ #111271


Rather than baking the behavior of `AccumulateGrad` nodes into the generated graph (either as `+=`, or as a return value of the graph).  This creates a new `accumulate_grad_` dispatcher op that is included in the generated graph like:
```
def forward(self, inputs, sizes, hooks):
    getitem = inputs[0]
    getitem_1 = inputs[1]
    getitem_2 = inputs[2]
    getitem_3 = inputs[3]
    getitem_4 = inputs[4]
    getitem_5 = inputs[5]
    getitem_6 = inputs[6]
    getitem_7 = inputs[7]
    getitem_8 = inputs[8]
    getitem_9 = inputs[9];  inputs = None
    expand = torch.ops.aten.expand.default(getitem, [2, 4]);  getitem = None
    threshold_backward = torch.ops.aten.threshold_backward.default(expand, getitem_1, 0);  expand = getitem_1 = None
    t = torch.ops.aten.t.default(getitem_3);  getitem_3 = None
    mm = torch.ops.aten.mm.default(threshold_backward, t);  t = None
    t_1 = torch.ops.aten.t.default(threshold_backward)
    mm_1 = torch.ops.aten.mm.default(t_1, getitem_2);  t_1 = getitem_2 = None
    t_2 = torch.ops.aten.t.default(mm_1);  mm_1 = None
    sum_1 = torch.ops.aten.sum.dim_IntList(threshold_backward, [0], True);  threshold_backward = None
    view = torch.ops.aten.view.default(sum_1, [4]);  sum_1 = None
    t_3 = torch.ops.aten.t.default(t_2);  t_2 = None
    accumulate_grad_ = torch.ops.inductor.accumulate_grad_.default(getitem_4, t_3);  getitem_4 = t_3 = None
    threshold_backward_1 = torch.ops.aten.threshold_backward.default(mm, getitem_5, 0);  mm = getitem_5 = None
    t_4 = torch.ops.aten.t.default(threshold_backward_1)
    mm_2 = torch.ops.aten.mm.default(t_4, getitem_6);  t_4 = getitem_6 = None
    t_5 = torch.ops.aten.t.default(mm_2);  mm_2 = None
    sum_2 = torch.ops.aten.sum.dim_IntList(threshold_backward_1, [0], True);  threshold_backward_1 = None
    view_1 = torch.ops.aten.view.default(sum_2, [4]);  sum_2 = None
    t_6 = torch.ops.aten.t.default(t_5);  t_5 = None
    accumulate_grad__1 = torch.ops.inductor.accumulate_grad_.default(getitem_7, t_6);  getitem_7 = t_6 = None
    accumulate_grad__2 = torch.ops.inductor.accumulate_grad_.default(getitem_8, view_1);  getitem_8 = view_1 = None
    accumulate_grad__3 = torch.ops.inductor.accumulate_grad_.default(getitem_9, view);  getitem_9 = view = None
    return []

```

The motivation here is `AccumulateGrad` nodes are causing trouble in FSDP tracing, since FSDP is in-place resizing parameters and parameter storage in hooks.  We will model this mutation in dynamo, but not during the initial compiled autograd capture.  This allows us to bypass failing shape checks in the initial capture. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler