### PR TITLE
[dynamo] guarded config

### DIFF
--- a/test/dynamo/test_comptime.py
+++ b/test/dynamo/test_comptime.py
@@ -230,6 +230,13 @@ y = TensorVariable()
             'obj_weakref': None
             'guarded_class': None
         }
+        global '' CONFIG_HASH_MATCH
+        {
+            'guard_types': None,
+            'code': None,
+            'obj_weakref': None
+            'guarded_class': None
+        }
         shape_env '' SHAPE_ENV
         {
             'guard_types': None,

--- a/test/dynamo/test_config.py
+++ b/test/dynamo/test_config.py
@@ -110,6 +110,206 @@ class ConfigTests(torch._dynamo.test_case.TestCase):
         assert changed_hash != newest_hash
         assert newest_hash == starting_hash
 
+    @disable_cache_limit()
+    def test_no_saved_config(self):
+        def fn(a, b):
+            return a - b * 10
+
+        torch._dynamo.reset()
+        cnt_dynamic = torch._dynamo.testing.CompileCounter()
+        with torch._dynamo.config.patch(
+            automatic_dynamic_shapes=False, assume_static_by_default=True
+        ):
+            opt_fn_static_shape = torch._dynamo.optimize(
+                cnt_dynamic, save_config=False
+            )(fn)
+            opt_fn_static_shape(torch.randn(2), torch.randn(2))
+            opt_fn_static_shape(torch.randn(3), torch.randn(3))
+
+        self.assertEqual(cnt_dynamic.frame_count, 2)
+
+        with torch._dynamo.config.patch(
+            automatic_dynamic_shapes=True, assume_static_by_default=False
+        ):
+            for i in range(2, 12):
+                opt_fn_static_shape(
+                    torch.randn(i), torch.randn(i)
+                )  # will be recompiled under new config
+
+        self.assertEqual(cnt_dynamic.frame_count, 3)
+
+    @disable_cache_limit()
+    def test_no_saved_config_nested(self):
+        def fn(a, b):
+            return a - b * 10
+
+        torch._dynamo.reset()
+        cnt_dynamic = torch._dynamo.testing.CompileCounter()
+        cnt_dynamic_1 = torch._dynamo.testing.CompileCounter()
+        with torch._dynamo.config.patch(
+            automatic_dynamic_shapes=True, assume_static_by_default=False
+        ):
+            opt_fn_static_shape = torch._dynamo.optimize(cnt_dynamic, dynamic=False)(fn)
+
+            # Will trigger recompile as compiled as static
+            opt_fn_static_shape(torch.randn(2), torch.randn(2))
+            opt_fn_static_shape(torch.randn(3), torch.randn(3))
+
+            self.assertEqual(cnt_dynamic.frame_count, 2)
+
+            opt_fn_try_dynamic = torch._dynamo.optimize(
+                cnt_dynamic_1, save_config=False
+            )(opt_fn_static_shape)
+
+            for i in range(2, 6):
+                opt_fn_try_dynamic(torch.randn(i), torch.randn(i))
+            self.assertEqual(cnt_dynamic_1.frame_count, 1)
+
+        # Saved config = False will use whatever config is available
+        with torch._dynamo.config.patch(
+            automatic_dynamic_shapes=False, assume_static_by_default=True
+        ):
+            for i in range(6, 12):
+                opt_fn_try_dynamic(torch.randn(i), torch.randn(i))
+            self.assertEqual(cnt_dynamic_1.frame_count, 7)
+
+    @disable_cache_limit()
+    def test_config_changed_from_guarded_config_1(self):
+        def fn(a, b):
+            return a - b * 10
+
+        torch._dynamo.reset()
+
+        cnt_dynamic = torch._dynamo.testing.CompileCounter()
+        with torch._dynamo.config.patch(
+            automatic_dynamic_shapes=False, assume_static_by_default=True
+        ):
+            opt_fn_static_shape = torch._dynamo.optimize(cnt_dynamic)(fn)
+            res = opt_fn_static_shape(torch.randn(2), torch.randn(2))
+            print("RES", res)
+            opt_fn_static_shape(torch.randn(3), torch.randn(3))
+
+        self.assertEqual(cnt_dynamic.frame_count, 2)
+
+        with torch._dynamo.config.patch(
+            automatic_dynamic_shapes=True, assume_static_by_default=False
+        ):
+            for i in range(2, 12):
+                # Only 4-11 will now be recompiled under old config
+                # 2-3 have been recompiled under old config due to shape mismatch
+                opt_fn_static_shape(torch.randn(i), torch.randn(i))
+
+        self.assertEqual(cnt_dynamic.frame_count, 10)
+
+    @disable_cache_limit()
+    def test_config_changed_from_guarded_config_2(self):
+        def fn(a, b):
+            return a - b * 10
+
+        torch._dynamo.reset()
+
+        cnt_dynamic = torch._dynamo.testing.CompileCounter()
+        with torch._dynamo.config.patch(
+            automatic_dynamic_shapes=True, assume_static_by_default=False
+        ):
+            opt_fn_static_shape = torch._dynamo.optimize(cnt_dynamic)(fn)
+            opt_fn_static_shape(torch.randn(2), torch.randn(2))
+            opt_fn_static_shape(torch.randn(3), torch.randn(3))
+
+        self.assertEqual(cnt_dynamic.frame_count, 1)
+
+        with torch._dynamo.config.patch(
+            automatic_dynamic_shapes=False, assume_static_by_default=True
+        ):
+            for i in range(2, 12):
+                opt_fn_static_shape(
+                    torch.randn(i), torch.randn(i)
+                )  # will be recompiled due to shape mismatch under old config
+
+        self.assertEqual(cnt_dynamic.frame_count, 1)
+
+    @disable_cache_limit()
+    def test_nested_compile_outer_wins(self):
+        def fn(a, b):
+            return a - b * 10
+
+        torch._dynamo.reset()
+
+        cnt_dynamic = torch._dynamo.testing.CompileCounter()
+        cnt_dynamic_1 = torch._dynamo.testing.CompileCounter()
+        with torch._dynamo.config.patch(
+            automatic_dynamic_shapes=False, assume_static_by_default=True
+        ):
+            opt_fn_static_shape = torch._dynamo.optimize(cnt_dynamic)(fn)
+            opt_fn_static_shape(torch.randn(2), torch.randn(2))
+            opt_fn_static_shape(torch.randn(3), torch.randn(3))
+
+        self.assertEqual(cnt_dynamic.frame_count, 2)
+
+        with torch._dynamo.config.patch(
+            automatic_dynamic_shapes=True, assume_static_by_default=False
+        ):
+            opt_fn_dynamic = torch._dynamo.optimize(cnt_dynamic_1)(
+                lambda x, y: opt_fn_static_shape(x, y)
+            )
+            for i in range(2, 12):
+                opt_fn_dynamic(
+                    torch.randn(i), torch.randn(i)
+                )  # will be recompiled under new config
+
+        self.assertEqual(cnt_dynamic.frame_count, 2)
+        self.assertEqual(cnt_dynamic_1.frame_count, 1)
+
+    @disable_cache_limit()
+    def test_nested_fn_does_not_inherit_outer_config(self):
+        def g1(x):
+            return x + 1
+
+        def g2(x):
+            return x * 2
+
+        def f(x):
+            x = g1(x)
+            torch._dynamo.graph_break()
+            return g2(x)
+
+        torch._dynamo.reset()
+
+        cnt_dynamic = torch._dynamo.testing.CompileCounter()
+        cnt_dynamic_1 = torch._dynamo.testing.CompileCounter()
+
+        opt_fn_static_shape = torch._dynamo.optimize(cnt_dynamic, dynamic=False)(f)
+        opt_fn_static_shape(torch.randn(2))
+        opt_fn_static_shape(torch.randn(3))
+        self.assertEqual(cnt_dynamic.frame_count, 4)  # 2 compiles * 2 graphs
+
+        opt_fn_dynamic = torch._dynamo.optimize(cnt_dynamic_1, dynamic=True)(g2)
+
+        for i in range(2, 12):
+            opt_fn_dynamic(
+                torch.randn(i),
+            )  # will be recompiled under new config
+
+        self.assertEqual(cnt_dynamic_1.frame_count, 1)
+
+    @disable_cache_limit()
+    def test_multiple_compile_recompiles(self):
+        cnt_dynamic = torch._dynamo.testing.CompileCounter()
+
+        def f(dynamic, compile_count):
+            @torch._dynamo.optimize(cnt_dynamic, dynamic=dynamic)
+            def g(x):
+                return x + 1
+
+            for i in range(2, 12):
+                g(torch.randn(i))  # will be recompiled under new config
+            self.assertEqual(cnt_dynamic.frame_count, compile_count)
+            cnt_dynamic.clear()
+
+        f(dynamic=True, compile_count=1)  # first compile
+        f(dynamic=False, compile_count=10)  # recompile
+        f(dynamic=True, compile_count=0)  # reuse first compile product
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -14,7 +14,8 @@ from . import external_utils
 # or use the environment variable TORCH_LOGS="dynamo,aot,inductor" (use a prefix + to indicate higher verbosity)
 # see this design doc for more detailed info
 # Design doc: https://docs.google.com/document/d/1ZRfTWKa8eaPq1AxaiHrq4ASTPouzzlPiuquSBEJYwS8/edit#
-# the name of a file to write the logs to
+# the name of a file to write the logs to (currently unused)
+# TODO(jon-chuang): use setup_log_file in setup_compile_debug
 # [@compile_ignored: debug]
 log_file_name = None
 

--- a/torch/_dynamo/config_utils.py
+++ b/torch/_dynamo/config_utils.py
@@ -10,7 +10,7 @@ import tokenize
 import unittest
 import warnings
 from types import FunctionType, ModuleType
-from typing import Any, Dict, Set
+from typing import Any, Dict, Set, Tuple
 from unittest import mock
 
 # Types saved/loaded in configs
@@ -58,6 +58,7 @@ def install_config_module(module):
     default = dict()
 
     visit(module, module, "")
+    module._is_dirty = True
     module._config = config
     module._compile_ignored = compile_ignored
     module._default = default
@@ -119,6 +120,8 @@ class ConfigModule(ModuleType):
     _allowed_keys: Set[str]
     _bypass_keys: Set[str]
     _compile_ignored_keys: Set[str]
+    _is_dirty: bool
+    _hash_digest: str
 
     def __init__(self):
         raise NotImplementedError(
@@ -182,11 +185,26 @@ class ConfigModule(ModuleType):
             lines.append(f"{mod}.{k} = {v!r}")
         return "\n".join(lines)
 
-    def get_hash(self):
+    def get_config_and_hash_with_updates(
+        self, updates: Dict[str, Any]
+    ) -> Tuple[Dict[str, Any], str]:
+        """Hashes the configs that are not compile_ignored, along with updates"""
+        if any(k in self._compile_ignored_keys for k in updates):
+            raise ValueError("update keys cannot be @compile_ignored")
+        cfg = dict(self._config)
+        cfg.update(updates)
+        hashed = self._get_hash(cfg)
+        cfg.update(self._compile_ignored)
+        return cfg, hashed
+
+    def _get_hash(self, config: Dict[str, Any]) -> str:
+        string_to_hash = repr(sorted(config.items()))
+        return hashlib.md5(string_to_hash.encode("utf-8")).hexdigest()
+
+    def get_hash(self) -> str:
         """Hashes the configs that are not compile_ignored"""
         if self._is_dirty or self._hash_digest is None:
-            string_to_hash = repr(sorted(self._config.items()))
-            self._hash_digest = hashlib.md5(string_to_hash.encode("utf-8")).digest()
+            self._hash_digest = self._get_hash(self._config)
             self._is_dirty = False
         return self._hash_digest
 
@@ -201,8 +219,10 @@ class ConfigModule(ModuleType):
 
     def to_dict(self):
         warnings.warn(
-            "config.to_dict() has been deprecated. It may no longer change the underlying config.",
-            "use config.shallow_copy_dict() or config.get_config_copy() instead",
+            DeprecationWarning(
+                "config.to_dict() has been deprecated. It may no longer change the underlying config.",
+                "use config.shallow_copy_dict() or config.get_config_copy() instead",
+            )
         )
         return self.shallow_copy_dict()
 

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -214,13 +214,14 @@ def has_tensor_in_frame(frame):
         if has_tensor(value):
             return True
 
-    log.debug(
-        "skipping because no torch.* %s \
-            %s %s",
-        frame.f_code.co_name,
-        frame.f_code.co_filename,
-        frame.f_code.co_firstlineno,
-    )
+    if config.verbose:
+        log.debug(
+            "skipping because no torch.* %s \
+                %s %s",
+            frame.f_code.co_name,
+            frame.f_code.co_filename,
+            frame.f_code.co_firstlineno,
+        )
 
     return False
 
@@ -386,21 +387,23 @@ def convert_frame_assert(
             },
         )
 
-        return _compile(
-            frame.f_code,
-            frame.f_globals,
-            frame.f_locals,
-            frame.f_builtins,
-            compiler_fn,
-            one_graph,
-            export,
-            export_constraints,
-            hooks,
-            cache_size,
-            frame,
-            frame_state=frame_state,
-            compile_id=compile_id,
-        )
+        with config.patch(patch_config_if_changed()):
+            compiled_product = _compile(
+                frame.f_code,
+                frame.f_globals,
+                frame.f_locals,
+                frame.f_builtins,
+                compiler_fn,
+                one_graph,
+                export,
+                export_constraints,
+                hooks,
+                cache_size,
+                frame,
+                frame_state=frame_state,
+                compile_id=compile_id,
+            )
+        return compiled_product
 
     _convert_frame_assert._torchdynamo_orig_callable = compiler_fn  # type: ignore[attr-defined]
 
@@ -409,6 +412,40 @@ def convert_frame_assert(
 
     _convert_frame_assert._clone_with_backend = _clone_with_backend  # type: ignore[attr-defined]
     return wrap_convert_context(_convert_frame_assert)
+
+
+def patch_config_if_changed():
+    patch: Dict[str, Any] = {}
+    eval_frame = torch._dynamo.eval_frame
+    eval_frame._maybe_init_guarded_config_cache()
+    if eval_frame.config_cache.saved_config_and_hash is None:
+        return patch
+
+    saved_config, saved_config_hash = eval_frame.config_cache.saved_config_and_hash
+    current_config_hash = config.get_hash()
+    assert current_config_hash is not None
+
+    if saved_config_hash != current_config_hash:
+        patch = saved_config
+        if recompiles_log.isEnabledFor(logging.DEBUG):
+            recompiles_log.debug(
+                (
+                    "Current config does not match config saved when compiling\n"
+                    "Saved hash: %s, Current hash: %s\nRestoring saved config."
+                ),
+                saved_config_hash,
+                current_config_hash,
+            )
+            config_dict_ref = config.to_dict()
+            for key in patch:
+                if patch[key] != config_dict_ref[key]:
+                    recompiles_log.debug(
+                        "* %s=%s (prev: %s)",
+                        key,
+                        patch[key],
+                        config_dict_ref[key],
+                    )
+    return patch
 
 
 def maybe_cprofile(func):

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -262,19 +262,61 @@ def innermost_fn(fn):
     return unaltered_fn
 
 
+# The config to restore to should dynamo compile / recompile when
+# executing from the compiled function's _TorchDynamoContext
+config_cache = threading.local()
+
+
+def _maybe_init_guarded_config_cache():
+    if not hasattr(config_cache, "saved_config_and_hash"):
+        config_cache.saved_config_and_hash: Optional[  # type: ignore[misc]
+            Tuple[Dict[str, Any], bytes]
+        ] = None
+
+
 @contextlib.contextmanager
-def enable_dynamic(enable: Optional[bool] = None, export: bool = False):
-    if enable is None:
+def restore_guarded_dynamo_config(
+    first_ctx: bool,
+    saved_config: Dict[str, Any],
+    saved_config_hash: str,
+):
+    _maybe_init_guarded_config_cache()
+    # Set exactly once from top-level compile
+    is_top_level = False
+    try:
+        if first_ctx and config_cache.saved_config_and_hash is None:
+            is_top_level = True
+            config_cache.saved_config_and_hash = saved_config, saved_config_hash
+            log.debug("Setting top-level compile config hash: %s", saved_config_hash)
+        else:
+            log.debug("Ignoring inner dynamo compile config and hash")  # TODO: remove?
         yield
-    elif enable:
-        # Assume everything is dynamic by default
-        with config.patch(assume_static_by_default=False):
-            yield
+    finally:
+        if is_top_level:
+            log.debug(
+                "Unsetting top-level compile config hash: %s",
+                config_cache.saved_config_and_hash[1],
+            )
+            config_cache.saved_config_and_hash = None
+
+
+def _get_config_and_hash(dynamic=None):
+    if dynamic is None:
+        updates = {}
+    elif dynamic:
+        updates = {"assume_static_by_default": False}
     else:
-        with config.patch(
-            automatic_dynamic_shapes=False, assume_static_by_default=True
-        ):
-            yield
+        updates = {"automatic_dynamic_shapes": False, "assume_static_by_default": True}
+
+    return config.get_config_and_hash_with_updates(updates)
+
+
+def get_saved_else_current_config_hash():
+    _maybe_init_guarded_config_cache()
+    if config_cache.saved_config_and_hash is not None:
+        return config_cache.saved_config_and_hash[1]
+    else:
+        return config.get_hash()
 
 
 class _TorchDynamoContext:
@@ -289,6 +331,7 @@ class _TorchDynamoContext:
         export=False,
         dynamic=None,
         compiler_config=None,
+        save_config=True,
     ):
         super().__init__()
         assert callable(callback) or callback is False or callback is None
@@ -300,7 +343,18 @@ class _TorchDynamoContext:
         self.export = export
         self.dynamic = dynamic
         self.compiler_config = compiler_config
+        self.save_config = save_config and first_ctx
+        if self.save_config:
+            self.save_and_hash_config()
         patch_fn()
+
+    def save_and_hash_config(self):
+        # save current value of dynamo configs
+        self.saved_config, self.saved_config_hash = _get_config_and_hash(self.dynamic)
+        log.debug(
+            "Saving dynamo config and hash for new compiled object(s). Hash: %s",
+            self.saved_config_hash,
+        )
 
     def __enter__(self):
         if config.raise_on_ctx_manager_usage:
@@ -315,15 +369,19 @@ class _TorchDynamoContext:
         self.backend_cache_manager.__enter__()
         self.backend_ctx = self.extra_ctx_ctor()
         self.backend_ctx.__enter__()
-        self.dynamic_ctx = enable_dynamic(self.dynamic, self.export)
-        self.dynamic_ctx.__enter__()
+        if self.save_config:
+            self.dynamo_config_ctx = restore_guarded_dynamo_config(
+                self.first_ctx, self.saved_config, self.saved_config_hash
+            )
+            self.dynamo_config_ctx.__enter__()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         assert self.prior is not unset
         set_eval_frame(self.prior)
         self.prior = unset
         # TODO: This is totally not the right way to chain contexts manually
-        self.dynamic_ctx.__exit__(exc_type, exc_val, exc_tb)
+        if self.save_config:
+            self.dynamo_config_ctx.__exit__(exc_type, exc_val, exc_tb)
         self.backend_ctx.__exit__(exc_type, exc_val, exc_tb)
         self.backend_cache_manager.__exit__(exc_type, exc_val, exc_tb)
 
@@ -395,13 +453,17 @@ class _TorchDynamoContext:
             backend_cache_manager.__enter__()
             backend_ctx = backend_ctx_ctor()
             backend_ctx.__enter__()
-            dynamic_ctx = enable_dynamic(self.dynamic, self.export)
-            dynamic_ctx.__enter__()
+            if self.save_config:
+                dynamo_config_ctx = restore_guarded_dynamo_config(
+                    self.first_ctx, self.saved_config, self.saved_config_hash
+                )
+                dynamo_config_ctx.__enter__()
             try:
                 return fn(*args, **kwargs)
             finally:
                 set_eval_frame(prior)
-                dynamic_ctx.__exit__(None, None, None)
+                if self.save_config:
+                    dynamo_config_ctx.__exit__(None, None, None)
                 backend_ctx.__exit__(None, None, None)
                 backend_cache_manager.__exit__(None, None, None)
 
@@ -471,6 +533,7 @@ class OptimizeContext(_TorchDynamoContext):
         *,
         export=False,
         dynamic=None,
+        save_config=True,
         compiler_config=None,
     ):
         def on_enter():
@@ -485,6 +548,7 @@ class OptimizeContext(_TorchDynamoContext):
             export=export,
             dynamic=dynamic,
             compiler_config=compiler_config,
+            save_config=save_config,
         )
 
 
@@ -516,13 +580,17 @@ def catch_errors_wrapper(callback, hooks: Hooks):
     def catch_errors(frame, cache_entry, frame_state):
         assert frame_state is not None
 
+        is_skipfile = skipfiles.check(frame.f_code)
         if (
             # TODO: the first condition is not covered by any test
             frame.f_lasti >= first_real_inst_idx(frame.f_code)
-            or skipfiles.check(frame.f_code)
+            or is_skipfile
             or config.disable
         ):
-            log.debug("skipping %s %s", frame.f_code.co_name, frame.f_code.co_filename)
+            if not is_skipfile or config.verbose:  # don't log verbose skipfile skips
+                log.debug(
+                    "skipping %s %s", frame.f_code.co_name, frame.f_code.co_filename
+                )
             return None
         if frame.f_code.co_filename == "<string>" and frame.f_code.co_name == "__new__":
             # nametuple constructor
@@ -559,6 +627,7 @@ def _optimize_catch_errors(
     export=False,
     dynamic=None,
     compiler_config=None,
+    save_config=True,
 ):
     return OptimizeContext(
         catch_errors_wrapper(compile_fn, hooks),
@@ -567,6 +636,7 @@ def _optimize_catch_errors(
         export=export,
         dynamic=dynamic,
         compiler_config=compiler_config,
+        save_config=save_config,
     )
 
 
@@ -612,6 +682,7 @@ def optimize(
     guard_fail_fn=None,
     disable=False,
     dynamic=None,
+    save_config=True,
 ):
     """
     The main entrypoint of TorchDynamo.  Do graph capture and call
@@ -660,12 +731,14 @@ def optimize(
             backend,
             dynamic=dynamic,
             hooks=hooks,
+            save_config=save_config,
         )
     return _optimize_catch_errors(
         convert_frame.convert_frame(backend, hooks=hooks),
         hooks,
         backend_ctx_ctor,
         dynamic=dynamic,
+        save_config=save_config,
         compiler_config=backend.get_compiler_config()
         if hasattr(backend, "get_compiler_config")
         else None,
@@ -1336,6 +1409,7 @@ def optimize_assert(
     export=False,
     export_constraints=None,
     dynamic=None,
+    save_config=True,
 ):
     """
     The same as `torch._dynamo.optimize(backend, nopython=True)`
@@ -1353,6 +1427,7 @@ def optimize_assert(
         backend_ctx_ctor,
         export=export,
         dynamic=dynamic,
+        save_config=save_config,
     )
 
 

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -108,6 +108,10 @@ CLOSURE_VARS = collections.OrderedDict(
             "___skip_backend_check",
             lambda: torch._dynamo.eval_frame.guarded_backend_cache.skip_backend_check_for_run_only_mode,
         ),
+        (
+            "___applicable_config_hash",
+            lambda: torch._dynamo.eval_frame.get_saved_else_current_config_hash(),
+        ),
         ("___odict_getitem", collections.OrderedDict.__getitem__),
         ("___dict_param_key_ids", dict_param_key_ids),
         ("___dict_const_keys", dict_const_keys),
@@ -584,6 +588,15 @@ class GuardBuilder(GuardBuilderBase):
         )
         code = [
             f"___skip_backend_check() or ___current_backend() == ___lookup_backend({backend_id})"
+        ]
+        self._produce_guard_code(guard, code)
+
+    def CONFIG_HASH_MATCH(self, guard: Guard):
+        """Guard on the hash of the compiled function's dynamo config"""
+
+        assert guard.source is GuardSource.GLOBAL
+        code = [
+            f"___applicable_config_hash() == '{torch._dynamo.eval_frame.get_saved_else_current_config_hash()}'"
         ]
         self._produce_guard_code(guard, code)
 

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -376,6 +376,8 @@ class OutputGraph(Checkpointable[OutputGraphState]):
 
         self.guards.add(GlobalStateSource().make_guard(GuardBuilder.BACKEND_MATCH))
 
+        self.guards.add(GlobalStateSource().make_guard(GuardBuilder.CONFIG_HASH_MATCH))
+
     @property
     def root_tracer(self):
         return self.tracers[0]

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2513,12 +2513,12 @@ This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0"""
 
         super_run = super().run
         if TEST_WITH_TORCHINDUCTOR:
-            super_run = torch._dynamo.optimize("inductor")(super_run)
+            super_run = torch._dynamo.optimize("inductor", save_config=False)(super_run)
         elif TEST_WITH_AOT_EAGER:
-            super_run = torch._dynamo.optimize("aot_eager_decomp_partition")(super_run)
+            super_run = torch._dynamo.optimize("aot_eager_decomp_partition", save_config=False)(super_run)
         elif TEST_WITH_TORCHDYNAMO:
             # TorchDynamo optimize annotation
-            super_run = torch._dynamo.optimize("eager")(super_run)
+            super_run = torch._dynamo.optimize("eager", save_config=False)(super_run)
 
         super_run(result=result)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #111289
* #111249

Base: 
- https://github.com/pytorch/pytorch/pull/111290

Replaces: 
- https://github.com/pytorch/pytorch/pull/111074
---
Fixes: https://github.com/pytorch/pytorch/issues/110682

The guards are installed based on config that is valid at the call to `torch.compile`, rather than at any subsequent call / triggered compilation. Subsequent compilations will restore the config if there is a config mismatch with the saved config.

TODO:
- [X] add tests

Follow up PRs:
- [x] add revised cache size computation (follow up PR: https://github.com/pytorch/pytorch/pull/111145, based on: https://github.com/pytorch/pytorch/pull/107496) 
- [ ] handle run-only mode?
- [ ] config restoration itself is not thread-safe (tracked: https://github.com/pytorch/pytorch/issues/111150)




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @ezyang @Chillee 