### PR TITLE
Deprecated verbose parameter in LR schedulers

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -3,6 +3,7 @@ import types
 import warnings
 import math
 import pickle
+from functools import partial
 
 import torch
 import torch.optim as optim
@@ -2211,6 +2212,37 @@ class TestLRScheduler(TestCase):
             last_lr = optimizer.param_groups[0]["lr"]
 
         self.assertLessEqual(last_lr, max_lr)
+
+
+    @parametrize("LRClass", [
+        partial(LambdaLR, lr_lambda=lambda e: e // 10),
+        partial(MultiplicativeLR, lr_lambda=lambda: 0.95),
+        partial(StepLR, step_size=30),
+        partial(MultiStepLR, milestones=[30, 80]),
+        ConstantLR,
+        LinearLR,
+        partial(ExponentialLR, gamma=0.9),
+        lambda opt, **kwargs: SequentialLR(
+            opt, schedulers=[ConstantLR(opt), ConstantLR(opt)], milestones=[2], **kwargs),
+        PolynomialLR,
+        partial(CosineAnnealingLR, T_max=10),
+        ReduceLROnPlateau,
+        partial(CyclicLR, base_lr=0.01, max_lr=0.1),
+        partial(CosineAnnealingWarmRestarts, T_0=20),
+        partial(OneCycleLR, max_lr=0.01, total_steps=10),
+    ])
+    def test_lr_scheduler_verbose_deprecation_warning(self, LRClass):
+        """Check that a deprecating warning with verbose parameter."""
+        with self.assertWarnsOnceRegex(UserWarning, "The verbose parameter is deprecated"):
+            LRClass(self.opt, verbose=True)
+
+        with self.assertWarnsOnceRegex(UserWarning, "The verbose parameter is deprecated"):
+            LRClass(self.opt, verbose=False)
+
+        # No warning is raised when verbose is the default value.
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            LRClass(self.opt)
 
 
 instantiate_parametrized_tests(TestLRScheduler)

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -22,10 +22,17 @@ EPOCH_DEPRECATION_WARNING = (
     "https://github.com/pytorch/pytorch/issues/new/choose."
 )
 
+def _check_verbose_deprecated_warning(verbose):
+    """Raises a warning when verbose is not the default value."""
+    if verbose != "deprecated":
+        warnings.warn("The verbose parameter is deprecated. Please use get_last_lr() "
+                      "to access the learning rate.", UserWarning)
+        return verbose
+    return False
 
 class LRScheduler:
 
-    def __init__(self, optimizer, last_epoch=-1, verbose=False):
+    def __init__(self, optimizer, last_epoch=-1, verbose="deprecated"):
 
         # Attach optimizer
         if not isinstance(optimizer, Optimizer):
@@ -73,7 +80,7 @@ class LRScheduler:
             return wrapper
 
         self.optimizer.step = with_counter(self.optimizer.step)
-        self.verbose = verbose
+        self.verbose = _check_verbose_deprecated_warning(verbose)
 
         self._initial_step()
 
@@ -156,7 +163,6 @@ class LRScheduler:
         for i, data in enumerate(zip(self.optimizer.param_groups, values)):
             param_group, lr = data
             param_group['lr'] = lr
-            self.print_lr(self.verbose, i, lr, epoch)
 
         self._last_lr = [group['lr'] for group in self.optimizer.param_groups]
 
@@ -193,6 +199,10 @@ class LambdaLR(LRScheduler):
         verbose (bool): If ``True``, prints a message to stdout for
             each update. Default: ``False``.
 
+            .. deprecated:: 2.2
+                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
+                learning rate.
+
     Example:
         >>> # xdoctest: +SKIP
         >>> # Assuming optimizer has two groups.
@@ -205,7 +215,7 @@ class LambdaLR(LRScheduler):
         >>>     scheduler.step()
     """
 
-    def __init__(self, optimizer, lr_lambda, last_epoch=-1, verbose=False):
+    def __init__(self, optimizer, lr_lambda, last_epoch=-1, verbose="deprecated"):
         self.optimizer = optimizer
 
         if not isinstance(lr_lambda, list) and not isinstance(lr_lambda, tuple):
@@ -278,6 +288,10 @@ class MultiplicativeLR(LRScheduler):
         verbose (bool): If ``True``, prints a message to stdout for
             each update. Default: ``False``.
 
+            .. deprecated:: 2.2
+                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
+                learning rate.
+
     Example:
         >>> # xdoctest: +SKIP
         >>> lmbda = lambda epoch: 0.95
@@ -288,7 +302,7 @@ class MultiplicativeLR(LRScheduler):
         >>>     scheduler.step()
     """
 
-    def __init__(self, optimizer, lr_lambda, last_epoch=-1, verbose=False):
+    def __init__(self, optimizer, lr_lambda, last_epoch=-1, verbose="deprecated"):
         self.optimizer = optimizer
 
         if not isinstance(lr_lambda, list) and not isinstance(lr_lambda, tuple):
@@ -360,6 +374,10 @@ class StepLR(LRScheduler):
         verbose (bool): If ``True``, prints a message to stdout for
             each update. Default: ``False``.
 
+            .. deprecated:: 2.2
+                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
+                learning rate.
+
     Example:
         >>> # xdoctest: +SKIP
         >>> # Assuming optimizer uses lr = 0.05 for all groups
@@ -374,7 +392,7 @@ class StepLR(LRScheduler):
         >>>     scheduler.step()
     """
 
-    def __init__(self, optimizer, step_size, gamma=0.1, last_epoch=-1, verbose=False):
+    def __init__(self, optimizer, step_size, gamma=0.1, last_epoch=-1, verbose="deprecated"):
         self.step_size = step_size
         self.gamma = gamma
         super().__init__(optimizer, last_epoch, verbose)
@@ -409,6 +427,10 @@ class MultiStepLR(LRScheduler):
         verbose (bool): If ``True``, prints a message to stdout for
             each update. Default: ``False``.
 
+            .. deprecated:: 2.2
+                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
+                learning rate.
+
     Example:
         >>> # xdoctest: +SKIP
         >>> # Assuming optimizer uses lr = 0.05 for all groups
@@ -422,7 +444,7 @@ class MultiStepLR(LRScheduler):
         >>>     scheduler.step()
     """
 
-    def __init__(self, optimizer, milestones, gamma=0.1, last_epoch=-1, verbose=False):
+    def __init__(self, optimizer, milestones, gamma=0.1, last_epoch=-1, verbose="deprecated"):
         self.milestones = Counter(milestones)
         self.gamma = gamma
         super().__init__(optimizer, last_epoch, verbose)
@@ -458,6 +480,10 @@ class ConstantLR(LRScheduler):
         verbose (bool): If ``True``, prints a message to stdout for
             each update. Default: ``False``.
 
+            .. deprecated:: 2.2
+                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
+                learning rate.
+
     Example:
         >>> # xdoctest: +SKIP
         >>> # Assuming optimizer uses lr = 0.05 for all groups
@@ -473,7 +499,7 @@ class ConstantLR(LRScheduler):
         >>>     scheduler.step()
     """
 
-    def __init__(self, optimizer, factor=1.0 / 3, total_iters=5, last_epoch=-1, verbose=False):
+    def __init__(self, optimizer, factor=1.0 / 3, total_iters=5, last_epoch=-1, verbose="deprecated"):
         if factor > 1.0 or factor < 0:
             raise ValueError('Constant multiplicative factor expected to be between 0 and 1.')
 
@@ -518,6 +544,10 @@ class LinearLR(LRScheduler):
         verbose (bool): If ``True``, prints a message to stdout for
             each update. Default: ``False``.
 
+            .. deprecated:: 2.2
+                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
+                learning rate.
+
     Example:
         >>> # xdoctest: +SKIP
         >>> # Assuming optimizer uses lr = 0.05 for all groups
@@ -534,7 +564,7 @@ class LinearLR(LRScheduler):
     """
 
     def __init__(self, optimizer, start_factor=1.0 / 3, end_factor=1.0, total_iters=5, last_epoch=-1,
-                 verbose=False):
+                 verbose="deprecated"):
         if start_factor > 1.0 or start_factor <= 0:
             raise ValueError('Starting multiplicative factor expected to be greater than 0 and less or equal to 1.')
 
@@ -577,9 +607,13 @@ class ExponentialLR(LRScheduler):
         last_epoch (int): The index of last epoch. Default: -1.
         verbose (bool): If ``True``, prints a message to stdout for
             each update. Default: ``False``.
+
+            .. deprecated:: 2.2
+                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
+                learning rate.
     """
 
-    def __init__(self, optimizer, gamma, last_epoch=-1, verbose=False):
+    def __init__(self, optimizer, gamma, last_epoch=-1, verbose="deprecated"):
         self.gamma = gamma
         super().__init__(optimizer, last_epoch, verbose)
 
@@ -610,6 +644,10 @@ class SequentialLR(LRScheduler):
         last_epoch (int): The index of last epoch. Default: -1.
         verbose (bool): Does nothing.
 
+            .. deprecated:: 2.2
+                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
+                learning rate.
+
     Example:
         >>> # xdoctest: +SKIP
         >>> # Assuming optimizer uses lr = 1. for all groups
@@ -627,7 +665,7 @@ class SequentialLR(LRScheduler):
         >>>     scheduler.step()
     """
 
-    def __init__(self, optimizer, schedulers, milestones, last_epoch=-1, verbose=False):
+    def __init__(self, optimizer, schedulers, milestones, last_epoch=-1, verbose="deprecated"):
         for scheduler_idx in range(len(schedulers)):
             if schedulers[scheduler_idx].optimizer != optimizer:
                 raise ValueError(
@@ -646,6 +684,7 @@ class SequentialLR(LRScheduler):
                 f"than the number of milestone points, but got number of schedulers {len(schedulers)} and the "
                 f"number of milestones to be equal to {len(milestones)}"
             )
+        _check_verbose_deprecated_warning(verbose)
         self._schedulers = schedulers
         self._milestones = milestones
         self.last_epoch = last_epoch + 1
@@ -718,6 +757,10 @@ class PolynomialLR(LRScheduler):
         verbose (bool): If ``True``, prints a message to stdout for
             each update. Default: ``False``.
 
+            .. deprecated:: 2.2
+                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
+                learning rate.
+
     Example:
         >>> # xdoctest: +SKIP("undefined vars")
         >>> # Assuming optimizer uses lr = 0.001 for all groups
@@ -732,7 +775,7 @@ class PolynomialLR(LRScheduler):
         >>>     validate(...)
         >>>     scheduler.step()
     """
-    def __init__(self, optimizer, total_iters=5, power=1.0, last_epoch=-1, verbose=False):
+    def __init__(self, optimizer, total_iters=5, power=1.0, last_epoch=-1, verbose="deprecated"):
         self.total_iters = total_iters
         self.power = power
         super().__init__(optimizer, last_epoch, verbose)
@@ -793,11 +836,15 @@ class CosineAnnealingLR(LRScheduler):
         verbose (bool): If ``True``, prints a message to stdout for
             each update. Default: ``False``.
 
+            .. deprecated:: 2.2
+                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
+                learning rate.
+
     .. _SGDR\: Stochastic Gradient Descent with Warm Restarts:
         https://arxiv.org/abs/1608.03983
     """
 
-    def __init__(self, optimizer, T_max, eta_min=0, last_epoch=-1, verbose=False):
+    def __init__(self, optimizer, T_max, eta_min=0, last_epoch=-1, verbose="deprecated"):
         self.T_max = T_max
         self.eta_min = eta_min
         super().__init__(optimizer, last_epoch, verbose)
@@ -942,6 +989,10 @@ class ReduceLROnPlateau(LRScheduler):
         verbose (bool): If ``True``, prints a message to stdout for
             each update. Default: ``False``.
 
+            .. deprecated:: 2.2
+                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
+                learning rate.
+
     Example:
         >>> # xdoctest: +SKIP
         >>> optimizer = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
@@ -955,7 +1006,7 @@ class ReduceLROnPlateau(LRScheduler):
 
     def __init__(self, optimizer, mode='min', factor=0.1, patience=10,
                  threshold=1e-4, threshold_mode='rel', cooldown=0,
-                 min_lr=0, eps=1e-8, verbose=False):
+                 min_lr=0, eps=1e-8, verbose="deprecated"):
 
         if factor >= 1.0:
             raise ValueError('Factor should be < 1.0.')
@@ -974,7 +1025,8 @@ class ReduceLROnPlateau(LRScheduler):
             self.min_lrs = [min_lr] * len(optimizer.param_groups)
 
         self.patience = patience
-        self.verbose = verbose
+
+        self.verbose = _check_verbose_deprecated_warning(verbose)
         self.cooldown = cooldown
         self.cooldown_counter = 0
         self.mode = mode
@@ -1027,10 +1079,6 @@ class ReduceLROnPlateau(LRScheduler):
             new_lr = max(old_lr * self.factor, self.min_lrs[i])
             if old_lr - new_lr > self.eps:
                 param_group['lr'] = new_lr
-                if self.verbose:
-                    epoch_str = ("%.2f" if isinstance(epoch, float) else
-                                 "%.5d") % epoch
-                    print(f'Epoch {epoch_str}: reducing learning rate of group {i} to {new_lr:.4e}.')
 
     @property
     def in_cooldown(self):
@@ -1154,6 +1202,10 @@ class CyclicLR(LRScheduler):
         verbose (bool): If ``True``, prints a message to stdout for
             each update. Default: ``False``.
 
+            .. deprecated:: 2.2
+                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
+                learning rate.
+
     Example:
         >>> # xdoctest: +SKIP
         >>> optimizer = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
@@ -1183,7 +1235,7 @@ class CyclicLR(LRScheduler):
                  base_momentum=0.8,
                  max_momentum=0.9,
                  last_epoch=-1,
-                 verbose=False):
+                 verbose="deprecated"):
 
         # Attach optimizer
         if not isinstance(optimizer, Optimizer):
@@ -1348,11 +1400,15 @@ class CosineAnnealingWarmRestarts(LRScheduler):
         verbose (bool): If ``True``, prints a message to stdout for
             each update. Default: ``False``.
 
+            .. deprecated:: 2.2
+                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
+                learning rate.
+
     .. _SGDR\: Stochastic Gradient Descent with Warm Restarts:
         https://arxiv.org/abs/1608.03983
     """
 
-    def __init__(self, optimizer, T_0, T_mult=1, eta_min=0, last_epoch=-1, verbose=False):
+    def __init__(self, optimizer, T_0, T_mult=1, eta_min=0, last_epoch=-1, verbose="deprecated"):
         if T_0 <= 0 or not isinstance(T_0, int):
             raise ValueError(f"Expected positive integer T_0, but got {T_0}")
         if T_mult < 1 or not isinstance(T_mult, int):
@@ -1443,7 +1499,6 @@ class CosineAnnealingWarmRestarts(LRScheduler):
             for i, data in enumerate(zip(self.optimizer.param_groups, self.get_lr())):
                 param_group, lr = data
                 param_group['lr'] = lr
-                self.print_lr(self.verbose, i, lr, epoch)
 
         self._last_lr = [group['lr'] for group in self.optimizer.param_groups]
 
@@ -1535,6 +1590,10 @@ class OneCycleLR(LRScheduler):
         verbose (bool): If ``True``, prints a message to stdout for
             each update. Default: ``False``.
 
+            .. deprecated:: 2.2
+                ``verbose`` is deprecated. Please use ``get_last_lr()`` to access the
+                learning rate.
+
     Example:
         >>> # xdoctest: +SKIP
         >>> data_loader = torch.utils.data.DataLoader(...)
@@ -1565,7 +1624,7 @@ class OneCycleLR(LRScheduler):
                  final_div_factor=1e4,
                  three_phase=False,
                  last_epoch=-1,
-                 verbose=False):
+                 verbose="deprecated"):
 
         # Validate optimizer
         if not isinstance(optimizer, Optimizer):


### PR DESCRIPTION
## BC Breaking
As of this commit, the `verbose` parameter of `LRScheduler` is deprecated and will **no longer trigger print statements during execution**. Based on the discussion in https://github.com/pytorch/pytorch/issues/100847, having one-off print statements/logging smattered throughout PyTorch is not a future we want to move towards. Instead, we would prefer a consolidated logging system (usually used for debugging). If you would like to print the learning rate during execution, please use `get_last_lr()`.

For example, instead of the following:
```
optimizer = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
scheduler = ReduceLROnPlateau(optimizer, 'min', verbose=True)
for epoch in range(10):
    train(...)
    val_loss = validate(...)
    # Note that step should be called after validate()
    scheduler.step(val_loss)
```

Please instead have something like:
```
optimizer = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
scheduler = ReduceLROnPlateau(optimizer, 'min')
for epoch in range(10):
    train(...)
    val_loss = validate(...)
    # Note that step should be called after validate()
    scheduler.step(val_loss)
	print(f"Epoch {epoch} has concluded with lr of {scheduler.get_last_lr()}")
```

## Context

Fixes https://github.com/pytorch/pytorch/issues/100847

This PR follows the comment in https://github.com/pytorch/pytorch/issues/100847#issuecomment-1546247239 by deprecating the `verbose` parameter and removing the print statements. Removing the print statements is technically BC breaking, so I would be okay with putting them back in.

To be less annoying, this PR raises a warning only when `verbose` is explicitly passed in.