### PR TITLE
Fix typo under test directory

### DIFF
--- a/test/ao/sparsity/test_activation_sparsifier.py
+++ b/test/ao/sparsity/test_activation_sparsifier.py
@@ -172,7 +172,7 @@ class TestActivationSparsifier(TestCase):
             data (torch tensor)
                 dummy batched data
         """
-        # create a forward hook for checking ouput == layer(input * mask)
+        # create a forward hook for checking output == layer(input * mask)
         def check_output(name):
             mask = activation_sparsifier.get_mask(name)
             features = activation_sparsifier.data_groups[name].get('features')
@@ -271,7 +271,7 @@ class TestActivationSparsifier(TestCase):
             return torch.mean(x, dim=0)
 
         def _vanilla_norm_sparsifier(data, sparsity_level):
-            r"""Similar to data norm spasifier but block_shape = (1,1).
+            r"""Similar to data norm sparsifier but block_shape = (1,1).
             Simply, flatten the data, sort it and mask out the values less than threshold
             """
             data_norm = torch.abs(data).flatten()

--- a/test/ao/sparsity/test_composability.py
+++ b/test/ao/sparsity/test_composability.py
@@ -110,7 +110,7 @@ class TestComposability(TestCase):
         self.assertTrue(hasattr(mod[5], "parametrizations"))
 
         # check that correct observers were inserted and that matching
-        # occured successfully
+        # occurred successfully
         self.assertTrue(hasattr(mod[5], "activation_post_process"))
 
         _squash_mask_calibrate_and_convert(
@@ -141,7 +141,7 @@ class TestComposability(TestCase):
         self.assertTrue(hasattr(mod[5], "parametrizations"))
 
         # check that correct observers were inserted and that matching
-        # occured successfully
+        # occurred successfully
         self.assertTrue(hasattr(mod[5], "activation_post_process"))
         sparsifier.step()
         sparsity_level = _calculate_sparsity(mod[5].weight)
@@ -180,7 +180,7 @@ class TestComposability(TestCase):
         self.assertTrue(hasattr(mod[5][0], "parametrizations"))
 
         # check that correct observers were inserted and that matching
-        # occured successfully
+        # occurred successfully
         self.assertTrue(hasattr(mod[5], "activation_post_process"))
         _squash_mask_calibrate_and_convert(
             mod, sparsifier, torch.randn(1, 4, 4, 4)
@@ -221,7 +221,7 @@ class TestComposability(TestCase):
         self.assertTrue(hasattr(mod[5][0], "parametrizations"))
 
         # check that correct observers were inserted and that matching
-        # occured successfully
+        # occurred successfully
         self.assertTrue(hasattr(mod[5], "activation_post_process"))
         sparsifier.step()
         sparsity_level = _calculate_sparsity(mod[5][0].weight)
@@ -242,7 +242,7 @@ class TestComposability(TestCase):
 
     # This tests whether performing sparse prepare before qat prepare causes issues.
     # The primary worries were that qat_prep wouldn't recognize the parametrized
-    # modules and that the convert step for qat would remove the paramerizations
+    # modules and that the convert step for qat would remove the parametrizations
     # from the modules.
     def test_s_prep_before_qat_prep(self):
         (
@@ -258,7 +258,7 @@ class TestComposability(TestCase):
         self.assertTrue(hasattr(mod[5], "parametrizations"))
 
         # check that correct observers were inserted and that matching
-        # occured successfully
+        # occurred successfully
         self.assertTrue(hasattr(mod[5], "activation_post_process"))
         self.assertTrue(isinstance(mod[5], torch.ao.nn.qat.Linear))
         _squash_mask_calibrate_and_convert(
@@ -297,7 +297,7 @@ class TestComposability(TestCase):
         self.assertTrue(hasattr(mod[5], "parametrizations"))
 
         # check that correct observers were inserted and that matching
-        # occured successfully
+        # occurred successfully
         self.assertTrue(hasattr(mod[5], "activation_post_process"))
         self.assertTrue(isinstance(mod[5], torch.ao.nn.qat.Linear))
 
@@ -366,7 +366,7 @@ class TestFxComposability(TestCase):
         self.assertTrue(hasattr(fqn_to_module(mod, "5.0"), "parametrizations"))
 
         # check that correct observers were inserted and that matching
-        # occured successfully
+        # occurred successfully
         self.assertTrue(_module_has_activation_post_process(mod, "5"))
         sparsifier.step()
         sparsity_level = _calculate_sparsity(fqn_to_module(mod, "5.0.weight"))
@@ -424,7 +424,7 @@ class TestFxComposability(TestCase):
         self.assertTrue(hasattr(fqn_to_module(mod, "5.0"), "parametrizations"))
 
         # check that correct observers were inserted and that matching
-        # occured successfully
+        # occurred successfully
         self.assertTrue(_module_has_activation_post_process(mod, "5"))
         sparsifier.step()
         sparsity_level = _calculate_sparsity(fqn_to_module(mod, "5.0.weight"))
@@ -470,7 +470,7 @@ class TestFxComposability(TestCase):
         self.assertTrue(hasattr(fqn_to_module(mod, "5.0"), "parametrizations"))
 
         # check that correct observers were inserted and that matching
-        # occured successfully
+        # occurred successfully
         self.assertTrue(_module_has_activation_post_process(mod, "5"))
         sparsifier.step()
         sparsity_level = _calculate_sparsity(fqn_to_module(mod, "5.0.weight"))
@@ -516,7 +516,7 @@ class TestFxComposability(TestCase):
         self.assertTrue(isinstance(fqn_to_module(mod, "5"), torch.ao.nn.intrinsic.qat.LinearReLU))
 
         # check that correct observers were inserted and that matching
-        # occured successfully
+        # occurred successfully
         self.assertTrue(_module_has_activation_post_process(mod, "5"))
         sparsifier.step()
         sparsity_level = _calculate_sparsity(fqn_to_module(mod, "5.weight"))
@@ -561,7 +561,7 @@ class TestFxComposability(TestCase):
         self.assertTrue(hasattr(fqn_to_module(mod, "5.0"), "parametrizations"))
 
         # check that correct observers were inserted and that matching
-        # occured successfully
+        # occurred successfully
         self.assertTrue(_module_has_activation_post_process(mod, "5"))
         sparsifier.step()
         sparsity_level = _calculate_sparsity(fqn_to_module(mod, "5.0.weight"))

--- a/test/ao/sparsity/test_data_sparsifier.py
+++ b/test/ao/sparsity/test_data_sparsifier.py
@@ -518,7 +518,7 @@ class TestQuantizationUtils(TestCase):
         This unit test checks that
         1. Embeddings and EmbeddingBags are sparsified to the right sparsity levels
         2. Embeddings and EmbeddingBags are quantized
-        3. Linear modules are not quanitzed
+        3. Linear modules are not quantized
         """
         model = Model()
 
@@ -557,7 +557,7 @@ class TestQuantizationUtils(TestCase):
         This unit test checks that
         1. Embeddings and EmbeddingBags are sparsified to the right sparsity levels
         2. Embeddings and EmbeddingBags are quantized
-        3. Linear modules are not quanitzed
+        3. Linear modules are not quantized
         """
         model = Model()
 

--- a/test/ao/sparsity/test_parametrization.py
+++ b/test/ao/sparsity/test_parametrization.py
@@ -108,7 +108,7 @@ class TestFakeSparsity(TestCase):
         assert hasattr(model_load.seq[1], 'parametrizations')
         assert parametrize.is_parametrized(model_load.linear, 'weight')
 
-        # Check the weigths are preserved
+        # Check the weights are preserved
         self.assertEqual(model_save.linear.parametrizations['weight'].original,
                          model_load.linear.parametrizations['weight'].original)
         self.assertEqual(model_save.seq[0].parametrizations['weight'].original,

--- a/test/ao/sparsity/test_structured_sparsifier.py
+++ b/test/ao/sparsity/test_structured_sparsifier.py
@@ -596,7 +596,7 @@ class TestBaseStructuredSparsifier(TestCase):
         # Conv2d with Activation and no Bias
         configs, shapes = [], []
 
-        # conv2d(no bias) -> activatation -> conv2d(no bias)
+        # conv2d(no bias) -> activation -> conv2d(no bias)
         configs.append(
             [
                 {"tensor_fqn": "seq.4.weight"},
@@ -604,7 +604,7 @@ class TestBaseStructuredSparsifier(TestCase):
         )
         shapes.append((1, 52, 18, 18))
 
-        # conv2d(bias) -> activatation -> conv2d(bias)
+        # conv2d(bias) -> activation -> conv2d(bias)
         configs.append(
             [
                 {"tensor_fqn": "seq.0.weight"},

--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -43,7 +43,7 @@ FIXME_base_and_xfail_logging_tensor = parametrize("ctors", [subtest(base_ctors, 
                                                             subtest(logging_tensor_ctors, name="logging_tensor",
                                                                     decorators=[unittest.expectedFailure])])
 
-# NB: This is equivalent to having both @parmetrize("vectorized", [True, False]) and
+# NB: This is equivalent to having both @parametrize("vectorized", [True, False]) and
 #     FIXME_base_and_xfail_logging_tensor, except the non-vectorized logging_tensor case is
 #     actually expected to succeed
 FIXME_xfail_vectorized_logging_tensor = (

--- a/test/cpp/api/dataloader.cpp
+++ b/test/cpp/api/dataloader.cpp
@@ -1344,7 +1344,7 @@ struct Barrier {
 // each worker thread has a unique ID in `0...kNumberOfWorkers-1`.
 // There is a hard-coded ordering, `kOrderInWhichWorkersReturnTheirBatch`, in
 // which we want the worker threads to return. For this, an iterator into this
-// order is maintained. When the derferenced iterator (the current order index)
+// order is maintained. When the dereferenced iterator (the current order index)
 // matches the thread ID of a worker, it knows it can now return its index as
 // well as progress the iterator. Inside the dataloader, the sequencer should
 // buffer these indices such that they are ultimately returned in order.
@@ -2003,7 +2003,7 @@ TEST(DataLoaderTest, ChunkDatasetSave) {
           // statues, there are three possible scenarios for the writer thread:
           // 1. it hasn't started loading the next chunk data yet, so the
           // sequential sampler index is still 0;
-          // 2. it started to load the second chunk, so the sequencial sampler
+          // 2. it started to load the second chunk, so the sequential sampler
           // index is at 1;
           // 3. it finished loading the second chunk, and start to load the
           // third chunk, because the cache is still fully occupied by the data
@@ -2124,7 +2124,7 @@ TEST(DataLoaderTest, ChunkDatasetCrossChunkShuffle) {
       indices_.resize(size_);
       size_t index = 0;
 
-      // Repeatly sample every 5 indices.
+      // Repeatedly sample every 5 indices.
       for (const auto i : c10::irange(batch_size)) {
         for (size_t j = 0; j < size_ / batch_size; ++j) {
           indices_[index++] = i + batch_size * j;

--- a/test/cpp/api/tensor_flatten.cpp
+++ b/test/cpp/api/tensor_flatten.cpp
@@ -28,7 +28,7 @@ TEST(UnflattenDenseTensorTest, TestEmptyTensor) {
   ASSERT_EQ(unflatten_results.at(2).data_ptr(), nullptr);
   // without fix in unflatten_dense_tensors() for empty tensors,
   // unflattend empty tensor unflatten_results.at(1) will share the same storage
-  // as other non-empty tenosr like unflatten_results.at(3).
+  // as other non-empty tensor like unflatten_results.at(3).
   // after fix, the empty tensor and non-empty tensor do not share the same
   // storage.
   ASSERT_NE(

--- a/test/cpp/c10d/ProcessGroupNCCLTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLTest.cpp
@@ -438,7 +438,7 @@ void testSparseAllreduce(const std::string& path, int rank, int size) {
       // row indices
       EXPECT_EQ(sizes[1], inputDim);
     } else if (sizes[0] == 2) {
-      // coorindate indices
+      // coordinate indices
       EXPECT_EQ(sizes[1], inputDim * inputDim);
     }
 
@@ -489,7 +489,7 @@ void testSparseAllreduceLarge(const std::string& path, int rank, int size) {
       // row indices
       EXPECT_EQ(sizes[1], inputDim);
     } else if (sizes[0] == 2) {
-      // coorindate indices
+      // coordinate indices
       EXPECT_EQ(sizes[1], inputDim * inputDim);
     }
 

--- a/test/cpp/jit/test_exception.cpp
+++ b/test/cpp/jit/test_exception.cpp
@@ -133,7 +133,7 @@ TEST(TestException, TestCustomException) {
       {def},
       // class PythonResolver is defined in
       // torch/csrc/jit/python/script_init.cpp. It's not in a header file so I
-      // can not use it. Create a SimpleResolver insteand
+      // can not use it. Create a SimpleResolver instead
       {std::make_shared<SimpleResolver>()},
       nullptr);
   torch::jit::GraphFunction* gf =

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -3049,7 +3049,7 @@ TEST(TestFunctionExecutor, RunDecompositionTest) {
 TEST(TestShapeGraphLinting, Basic) {
   auto schemas = RegisteredShapeComputeSchemas();
   for (const auto& schema : schemas) {
-    // arange does not acually support complex, leave as
+    // arange does not actually support complex, leave as
     // union[int, float] for now
     if (schema->name() == "aten::arange") {
       continue;

--- a/test/cpp/jit/test_module_api.cpp
+++ b/test/cpp/jit/test_module_api.cpp
@@ -77,7 +77,7 @@ TEST(ModuleAPITest, MethodRunAsync) {
 
   future->wait();
 
-  // expect 2 forks and 2 wait callbacks being excuted on provided taskLauncher
+  // expect 2 forks and 2 wait callbacks being executed on provided taskLauncher
   // but ivalue::Future would be marked completed and release wait before
   // finishing all callbacks
   ASSERT_GE(counter, 2);

--- a/test/cpp/jit/test_shape_analysis.cpp
+++ b/test/cpp/jit/test_shape_analysis.cpp
@@ -401,7 +401,7 @@ TEST(ShapeAnalysisTest, SymbolicShapeCaching) {
   EXPECT_EQ(get_shape_cache_size(), 1);
 
   // Same shape but different symbols should return same shape
-  // but different symbolic indicies
+  // but different symbolic indices
   res = calculateSymbolicShapesOnOp(schema, {ss2, const_size_2});
   auto res3_val = res->at(0);
 

--- a/test/cpp/lazy/test_lazy_ops_util.cpp
+++ b/test/cpp/lazy/test_lazy_ops_util.cpp
@@ -21,7 +21,7 @@ std::unordered_set<std::string>* CreateIgnoredCounters() {
   std::unordered_set<std::string>* icounters =
       new std::unordered_set<std::string>();
   // Add below the counters whose name need to be ignored when doing
-  // is-any-counter-changed assertins.
+  // is-any-counter-changed assertions.
   icounters->insert("aten::rand");
   return icounters;
 }

--- a/test/cpp/lite_interpreter_runtime/test_mobile_profiler.cpp
+++ b/test/cpp/lite_interpreter_runtime/test_mobile_profiler.cpp
@@ -32,7 +32,7 @@ bool checkMetaData(
           if (line.find(metadata_val) != std::string::npos ||
               !metadata_val.size()) {
             /* if found the right metadata_val OR if expected
-             * metadata value is an empty string then ignore the matadata_val */
+             * metadata value is an empty string then ignore the metadata_val */
             return true;
           }
         }

--- a/test/cpp/rpc/test_tensorpipe_serialization.cpp
+++ b/test/cpp/rpc/test_tensorpipe_serialization.cpp
@@ -72,7 +72,7 @@ TEST(TensorpipeSerialize, Base) {
         recvingTpAllocation.payloads[i];
     if (srcPayload.length) {
       // Empty vector's data() can return nullptr, use the length to avoid
-      // coying into nullptr
+      // copying into nullptr
       memcpy(dstPayload.data, srcPayload.data, srcPayload.length);
     }
   }

--- a/test/cpp/tensorexpr/test_cuda.cpp
+++ b/test/cpp/tensorexpr/test_cuda.cpp
@@ -2119,7 +2119,7 @@ TEST(Cuda, MaskMultiDimMultiAxis_CUDA) {
   std::ostringstream oss;
   oss << *cuda_cg.stmt();
 
-  // Both stores masked agaist the other thread dim < 1.
+  // Both stores masked against the other thread dim < 1.
   const std::string& verification_pattern =
       R"IR(
 # CHECK: if (threadIdx.y<1

--- a/test/cpp/tensorexpr/test_expr.cpp
+++ b/test/cpp/tensorexpr/test_expr.cpp
@@ -132,7 +132,7 @@ TEST(Expr, IsChannelsLastContiguous) {
     }
   };
 
-  // channels-last contigous
+  // channels-last contiguous
   for (size_t i = 0; i < dims.size(); i++) {
     auto shape_info = shape_gen_fn(dims[i], channels_last_cont_shape_conf);
     for (size_t j = 0; j < shape_info.second.size(); j++) {
@@ -141,7 +141,7 @@ TEST(Expr, IsChannelsLastContiguous) {
     }
   }
 
-  // channels-last non-contigous
+  // channels-last non-contiguous
   for (size_t i = 0; i < dims.size(); i++) {
     auto shape_info = shape_gen_fn(dims[i], channels_last_non_cont_shape_conf);
     for (size_t j = 0; j < shape_info.second.size(); j++) {

--- a/test/cpp/tensorexpr/test_ir_verifier.cpp
+++ b/test/cpp/tensorexpr/test_ir_verifier.cpp
@@ -145,7 +145,7 @@ TEST(IRVerifier, Block) {
     StmtPtr block1 = alloc<Block>(std::vector<StmtPtr>({store}));
     // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
     StmtPtr block2 = alloc<Block>(std::vector<StmtPtr>({store}));
-    // Stmt can't have multiple parrents, thus inserting it into several blocks
+    // Stmt can't have multiple parents, thus inserting it into several blocks
     // is illegal
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto,clang-analyzer-cplusplus.NewDeleteLeaks)
     EXPECT_ANY_THROW(verify(block2));

--- a/test/cpp/tensorexpr/test_kernel.cpp
+++ b/test/cpp/tensorexpr/test_kernel.cpp
@@ -1113,7 +1113,7 @@ TEST_F(Kernel, Softmax2D) {
         const auto verification_pattern =
             format(verification_template, ver_env);
 
-        // verication sting temporarily disabled until
+        // verification sting temporarily disabled until
         // inlining of exp() is benchmarked and determined
         // torch::jit::testing::FileCheck().run(verification_pattern,
         // oss.str());
@@ -1192,7 +1192,7 @@ TEST_F(Kernel, Softmax3D) {
       ver_env.d("softmax_dim_size", softmax_dim_size);
       const auto verification_pattern = format(verification_template, ver_env);
 
-      // verication sting temporarily disabled until
+      // verification sting temporarily disabled until
       // inlining of exp() is benchmarked and determined
       // torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
 
@@ -1275,7 +1275,7 @@ TEST_F(Kernel, Softmax4D) {
       ver_env.d("softmax_dim_size", softmax_dim_size);
       const auto verification_pattern = format(verification_template, ver_env);
 
-      // verication sting temporarily disabled until
+      // verification sting temporarily disabled until
       // inlining of exp() is benchmarked and determined
       // torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
 
@@ -1548,7 +1548,7 @@ TEST_F(Kernel, ConstantTensorsNonContiguous) {
   auto graph = std::make_shared<Graph>();
   parseIR(graph_string, &*graph);
   // IRParser doesn't support tensor constants, so we generate several aten
-  // calls to produce non-contiguos constant tensor and then const-prop it
+  // calls to produce non-contiguous constant tensor and then const-prop it
   ConstantPropagation(graph);
 
   TensorExprKernel k(graph);
@@ -1637,7 +1637,7 @@ TEST_F(Kernel, CodegenInspection) {
   auto graph = std::make_shared<Graph>();
   parseIR(graph_string, &*graph);
   // IRParser doesn't support tensor constants, so we generate several aten
-  // calls to produce non-contiguos constant tensor and then const-prop it
+  // calls to produce non-contiguous constant tensor and then const-prop it
   ConstantPropagation(graph);
 
   TensorExprKernel k(graph);

--- a/test/cpp/tensorexpr/test_loopnest.cpp
+++ b/test/cpp/tensorexpr/test_loopnest.cpp
@@ -6292,7 +6292,7 @@ TEST(LoopNest, areLoopsPerfectlyNested) {
   ASSERT_FALSE(LoopNest::areLoopsPerfectlyNested({forI, forK, forJ}));
   ASSERT_FALSE(LoopNest::areLoopsPerfectlyNested({forK, forJ, forI}));
 
-  // Adding a statment to forK body should be OK.
+  // Adding a statement to forK body should be OK.
   auto init = Store::make(a_buf, {i, j}, 0);
   forK->body()->insert_stmt_before(init, store);
   ASSERT_TRUE(LoopNest::areLoopsPerfectlyNested({forI, forJ, forK}));

--- a/test/cpp/tensorexpr/test_memdependency.cpp
+++ b/test/cpp/tensorexpr/test_memdependency.cpp
@@ -694,7 +694,7 @@ TEST(MemDependency, MemDependencyCheckerLoopReduce) {
   // B -> A.
   ASSERT_TRUE(analyzer.dependsDirectly(bStore, aReduce));
 
-  // B depends indirectly on the intializer of A, since the reduction depends
+  // B depends indirectly on the initializer of A, since the reduction depends
   // on it.
   ASSERT_FALSE(analyzer.dependsDirectly(bStore, aInit));
   ASSERT_TRUE(analyzer.dependsIndirectly(bStore, aInit));
@@ -751,7 +751,7 @@ TEST(MemDependency, MemDependencyCheckerLoopReduceExpanded) {
   // B -> A.
   ASSERT_TRUE(analyzer.dependsDirectly(bStore, aReduce));
 
-  // B depends indirectly on the intializer of A, since the reduction depends
+  // B depends indirectly on the initializer of A, since the reduction depends
   // on it.
   ASSERT_FALSE(analyzer.dependsDirectly(bStore, aInit));
   ASSERT_TRUE(analyzer.dependsIndirectly(bStore, aInit));
@@ -1177,7 +1177,7 @@ TEST(MemDependency, MemDependencyCheckerLoopBoundsIndexShift) {
   // The seventh access is the store to A[9 - x] in the third loop.
   ASSERT_EQ(history[6]->type(), AccessType::Store);
   ASSERT_EQ(history[6]->var(), aVar);
-  // This store has a negative stride on it's indices, but is notmalized
+  // This store has a negative stride on it's indices, but is normalized
   // internally.
   ASSERT_TRUE(EQ(history[6]->bounds(), {CB(1, 9)}));
 
@@ -1185,7 +1185,7 @@ TEST(MemDependency, MemDependencyCheckerLoopBoundsIndexShift) {
   ASSERT_EQ(history[7]->type(), AccessType::Load);
   ASSERT_EQ(history[7]->var(), aVar);
   // It has the bounds of the loop (0 <= x < 9), modified by the offset 9 - x,
-  // which esstentially traverses the loop backwards.
+  // which essentially traverses the loop backwards.
   ASSERT_TRUE(EQ(history[7]->bounds(), {CB(0, 9)}));
   // This Load has three write dependencies:
   ASSERT_EQ(history[7]->dependencies().size(), 3);
@@ -1201,11 +1201,11 @@ TEST(MemDependency, MemDependencyCheckerLoopBoundsIndexShift) {
   // The ninth access is the store to A[x] in the fourth loop.
   ASSERT_EQ(history[8]->type(), AccessType::Store);
   ASSERT_EQ(history[8]->var(), aVar);
-  // This store has a negative stride on it's indices, but is notmalized
+  // This store has a negative stride on it's indices, but is normalized
   // internally.
   ASSERT_TRUE(EQ(history[8]->bounds(), {CB(0, 9)}));
 
-  // The tenth and 11th acceses are the copy from A[x] to B[x].
+  // The tenth and 11th accesses are the copy from A[x] to B[x].
   ASSERT_EQ(history[9]->type(), AccessType::Load);
   ASSERT_EQ(history[9]->var(), aVar);
   ASSERT_EQ(history[10]->type(), AccessType::Store);
@@ -1308,7 +1308,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
      * }
      */
 
-    // Is not self dependent beacause there is no store to the buffer that is
+    // Is not self dependent because there is no store to the buffer that is
     // read.
 
     MemDependencyChecker analyzer;
@@ -1526,8 +1526,8 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
 
     // Here we can use the common stride of the accesses to determine they are
     // distinct.
-    // Note, this is the only place (loop self depedency) we use this stride
-    // to avoid unnecessary depedence.
+    // Note, this is the only place (loop self dependency) we use this stride
+    // to avoid unnecessary dependence.
 
     MemDependencyChecker analyzer;
     // Execution order doesn't matter since the read and the write are totally
@@ -1724,7 +1724,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
      * }
      */
 
-    // If they have strides with no common muliple > 1, they overlap.
+    // If they have strides with no common multiple > 1, they overlap.
     MemDependencyChecker analyzer;
     StmtPtr stmt = For::make(
         x, 0, 10, Store::make(a, {x * 2}, Load::make(a, {x * 3 + 1})));
@@ -1862,8 +1862,8 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
 }
 
 // Verify that a strided access still works.
-// TODO: actually this only works because of the size of the ranges, revist this
-// test after strided overlap is implemented.
+// TODO: actually this only works because of the size of the ranges, revisit
+// this test after strided overlap is implemented.
 TEST(MemDependency, MemDependencyCheckerLoopDistinctStrides) {
   BufHandle a("A", {20}, kInt);
   BufHandle b("B", {20}, kInt);
@@ -2200,7 +2200,7 @@ TEST(MemDependency, MemDependencyCheckerIfThenElse) {
     // In this case C is dependent on both A and B.
 
     // TODO: in cases like this it would be possible to split the range of B
-    // into two bounds, one dependent on A and one depenent on B. We'd need to
+    // into two bounds, one dependent on A and one dependent on B. We'd need to
     // examine conditions relative to previously encountered loop variables. I'm
     // uncertain if this would be helpful.
 
@@ -2249,7 +2249,7 @@ TEST(MemDependency, MemDependencyCheckerCutLoop) {
     // Output depends on input.
     ASSERT_TRUE(analyzer.dependsIndirectly(b.node(), a.node()));
 
-    // Output has 2 depdenencies.
+    // Output has 2 dependencies.
     auto outputAccess = analyzer.output(b.node());
     ASSERT_NE(outputAccess, nullptr);
     ASSERT_EQ(outputAccess->dependencies().size(), 2);
@@ -2289,7 +2289,7 @@ TEST(MemDependency, MemDependencyCheckerCutLoop) {
     // Output depends on input.
     ASSERT_TRUE(analyzer.dependsIndirectly(b.node(), a.node()));
 
-    // Output has 4 depdenencies.
+    // Output has 4 dependencies.
     auto outputAccess = analyzer.output(b.node());
     ASSERT_NE(outputAccess, nullptr);
     ASSERT_EQ(outputAccess->dependencies().size(), 4);

--- a/test/cpp/tensorexpr/test_registerizer.cpp
+++ b/test/cpp/tensorexpr/test_registerizer.cpp
@@ -2284,8 +2284,8 @@ TEST(Registerizer, RegisterizerPartialConditionInternalCut) {
   torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
 }
 
-// First statment in condition closes outer access, but can be registerized with
-// later statements.
+// First statement in condition closes outer access, but can be registerized
+// with later statements.
 TEST(Registerizer, RegisterizerPartialConditionInternalStart) {
   BufHandle a("A", {1}, kInt);
   VarHandle x("x", kInt);
@@ -2326,7 +2326,7 @@ TEST(Registerizer, RegisterizerPartialConditionInternalStart) {
    * A[x] = A_2;
    */
 
-  // TODO: I suppose we could refactor with a conditional initializier?
+  // TODO: I suppose we could refactor with a conditional initializer?
 
   std::ostringstream oss;
   oss << *stmt;
@@ -3145,7 +3145,7 @@ TEST(Registerizer, RegisterizerHiddenAccessMultiLoop) {
   torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
 }
 
-// Accesses are registerized inside two conditions, but the immeidate parent is
+// Accesses are registerized inside two conditions, but the immediate parent is
 // not a condition.
 TEST(Registerizer, RegisterizerTwoConditionalLoops) {
   BufHandle a("A", {1}, kInt);

--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -732,7 +732,7 @@ TEST(Simplify, SimplifyMuls) {
 
   {
     // (x + y) * (x + y) => (x + y) * (x + y)
-    // We don't attempt to simplify mulitplication of polynomials since the
+    // We don't attempt to simplify multiplication of polynomials since the
     // result is only very rarely more efficient.
     ExprHandle body = (x + y) * (x + y);
     ExprHandle simplified = IRSimplifier::simplify(body);

--- a/test/cpp/tensorexpr/test_type_specializations.cpp
+++ b/test/cpp/tensorexpr/test_type_specializations.cpp
@@ -8,7 +8,7 @@
 #include <torch/csrc/jit/passes/pass_manager.h>
 #include <torch/csrc/jit/passes/tensorexpr_fuser.h>
 
-// Test that tensor type specializations are availabie in
+// Test that tensor type specializations are available in
 // the custom passes
 
 namespace torch {
@@ -65,7 +65,7 @@ graph(%a.1 : Tensor,
   };
   run(graph, stack);
 
-  // Priofiling mode will not be run with simple executor
+  // Profiling mode will not be run with simple executor
   if (!getExecutorMode()) {
     EXPECT_TRUE(hasSpecializations);
   }


### PR DESCRIPTION
This PR fixes typo in comments under `test` directory.
