### PR TITLE
Remove dynamo suported check for Windows.

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -71,7 +71,7 @@ except ImportError:
 from torch.export import export
 
 
-@unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
+@unittest.skipIf(not torchdynamo.is_win32(), "not supported for windows")
 class TestDynamismExpression(TestCase):
     def test_export_inline_constraints(self):
         def f(x):
@@ -133,7 +133,7 @@ class TestDynamismExpression(TestCase):
         export(WrapperModule(branch_on_shape), inp)
 
 
-@unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
+@unittest.skipIf(not torchdynamo.is_win32(), "not supported for windows")
 class TestExport(TestCase):
     def _test_export_same_as_eager(self, f, args, kwargs=None):
         kwargs = kwargs or {}
@@ -3032,7 +3032,7 @@ def forward(self, arg0_1, arg1_1, arg2_1):
             ep = torch.export.export(m, (inp,))
 
 
-@unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
+@unittest.skipIf(not torchdynamo.is_win32(), "not supported for windows")
 class TestOneOffModelExportResult(TestCase):
     def test_scaled_dot_product_attention_cpu(self):
         """
@@ -3178,7 +3178,7 @@ def forward(self, l_q_, l_k_, l_v_):
         self.assertEqual(res[0], torch.tensor(16))
         self.assertEqual(res[1], None)
 
-@unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")
+@unittest.skipIf(not torchdynamo.is_win32(), "not supported for windows")
 class TestExportCustomClass(TorchTestCase):
     def setUp(self):
         if IS_FBCODE:

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -71,7 +71,7 @@ except ImportError:
 from torch.export import export
 
 
-@unittest.skipIf(not torchdynamo.is_win32(), "not supported for windows")
+@unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
 class TestDynamismExpression(TestCase):
     def test_export_inline_constraints(self):
         def f(x):
@@ -133,7 +133,7 @@ class TestDynamismExpression(TestCase):
         export(WrapperModule(branch_on_shape), inp)
 
 
-@unittest.skipIf(not torchdynamo.is_win32(), "not supported for windows")
+@unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
 class TestExport(TestCase):
     def _test_export_same_as_eager(self, f, args, kwargs=None):
         kwargs = kwargs or {}
@@ -3032,7 +3032,7 @@ def forward(self, arg0_1, arg1_1, arg2_1):
             ep = torch.export.export(m, (inp,))
 
 
-@unittest.skipIf(not torchdynamo.is_win32(), "not supported for windows")
+@unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
 class TestOneOffModelExportResult(TestCase):
     def test_scaled_dot_product_attention_cpu(self):
         """
@@ -3178,7 +3178,7 @@ def forward(self, l_q_, l_k_, l_v_):
         self.assertEqual(res[0], torch.tensor(16))
         self.assertEqual(res[1], None)
 
-@unittest.skipIf(not torchdynamo.is_win32(), "not supported for windows")
+@unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")
 class TestExportCustomClass(TorchTestCase):
     def setUp(self):
         if IS_FBCODE:

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -2494,6 +2494,7 @@ def forward(self, l_x_):
         )
         self.assertEqual(ep.module()(*inputs), m3(*inputs))
 
+    @unittest.skipIf(torchdynamo.is_win32(), "no compile support for windows")
     def test_export_then_compile_tensor_ctor(self):
         class M(torch.nn.Module):
             def forward(self, scores, mask):

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -3262,7 +3262,7 @@ class <lambda>(torch.nn.Module):
             aot_export_module(mod, [inp], trace_joint=True, output_loss_index=1)
 
     @unittest.skipIf(not torch._dynamo.is_dynamo_supported(), "Cond needs dynamo to run")
-    @unittest.skipIf(not torch._dynamo.is_win32(), "Cond not supported on windows")
+    @unittest.skipIf(torch._dynamo.is_win32(), "Cond not supported on windows")
     def test_aot_export_with_torch_cond(self):
         class M(torch.nn.Module):
             def __init__(self):

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -3262,6 +3262,7 @@ class <lambda>(torch.nn.Module):
             aot_export_module(mod, [inp], trace_joint=True, output_loss_index=1)
 
     @unittest.skipIf(not torch._dynamo.is_dynamo_supported(), "Cond needs dynamo to run")
+    @unittest.skipIf(not torch._dynamo.is_win32(), "Cond not supported on windows")
     def test_aot_export_with_torch_cond(self):
         class M(torch.nn.Module):
             def __init__(self):

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -3262,7 +3262,6 @@ class <lambda>(torch.nn.Module):
             aot_export_module(mod, [inp], trace_joint=True, output_loss_index=1)
 
     @unittest.skipIf(not torch._dynamo.is_dynamo_supported(), "Cond needs dynamo to run")
-    @unittest.skipIf(torch._dynamo.is_win32(), "Cond not supported on windows")
     def test_aot_export_with_torch_cond(self):
         class M(torch.nn.Module):
             def __init__(self):

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -4789,8 +4789,6 @@ class TestCompileTransforms(TestCase):
         actual = opt_fn(params_and_buffers, x)
         self.assertEqual(actual, expected)
 
-    # torch.compile is not supported on Windows
-    @expectedFailureIf(IS_WINDOWS)
     @torch._dynamo.config.patch(suppress_errors=False)
     @torch._dynamo.config.patch(capture_func_transforms=True)
     @skipIfTorchDynamo("Do not test torch.compile on top of torch.compile")

--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -1,4 +1,5 @@
 import sys
+
 import torch
 from . import convert_frame, eval_frame, resume_execution
 from .backends.registry import list_backends, lookup_backend, register_backend
@@ -90,6 +91,7 @@ def reset_code_caches() -> None:
             if code:
                 reset_code(code)
         code_context.clear()
+
 
 def is_win32():
     if sys.platform == "win32":

--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -1,3 +1,4 @@
+import sys
 import torch
 from . import convert_frame, eval_frame, resume_execution
 from .backends.registry import list_backends, lookup_backend, register_backend
@@ -89,3 +90,9 @@ def reset_code_caches() -> None:
             if code:
                 reset_code(code)
         code_context.clear()
+
+def is_win32():
+    if sys.platform == "win32":
+        return True
+    else:
+        return False

--- a/torch/_dynamo/backends/inductor.py
+++ b/torch/_dynamo/backends/inductor.py
@@ -1,10 +1,14 @@
 # mypy: ignore-errors
 
+import sys
 from torch._dynamo import register_backend
 
 
 @register_backend
 def inductor(*args, **kwargs):
+    if sys.platform == "win32":
+        raise RuntimeError("Windows not yet supported for inductor")
+        
     # do import here to avoid loading inductor into memory when it is not used
     from torch._inductor.compile_fx import compile_fx
 

--- a/torch/_dynamo/backends/inductor.py
+++ b/torch/_dynamo/backends/inductor.py
@@ -1,6 +1,6 @@
 # mypy: ignore-errors
 
-from torch._dynamo import register_backend, is_win32
+from torch._dynamo import is_win32, register_backend
 
 
 @register_backend

--- a/torch/_dynamo/backends/inductor.py
+++ b/torch/_dynamo/backends/inductor.py
@@ -1,13 +1,11 @@
 # mypy: ignore-errors
 
-import sys
-
-from torch._dynamo import register_backend
+from torch._dynamo import register_backend, is_win32
 
 
 @register_backend
 def inductor(*args, **kwargs):
-    if sys.platform == "win32":
+    if is_win32():
         raise RuntimeError("Windows not yet supported for inductor")
 
     # do import here to avoid loading inductor into memory when it is not used

--- a/torch/_dynamo/backends/inductor.py
+++ b/torch/_dynamo/backends/inductor.py
@@ -1,6 +1,7 @@
 # mypy: ignore-errors
 
 import sys
+
 from torch._dynamo import register_backend
 
 
@@ -8,7 +9,7 @@ from torch._dynamo import register_backend
 def inductor(*args, **kwargs):
     if sys.platform == "win32":
         raise RuntimeError("Windows not yet supported for inductor")
-        
+
     # do import here to avoid loading inductor into memory when it is not used
     from torch._inductor.compile_fx import compile_fx
 

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -307,9 +307,9 @@ def convert_frame_assert(
             return None
         if code.co_name == "<genexpr>" and code.co_filename.endswith(
             (
-                "transformers/file_utils.py",
-                "transformers/utils/generic.py",
-                "diffusers/utils/outputs.py",
+                "transformers/file_utils.py".replace("/", os.sep),
+                "transformers/utils/generic.py".replace("/", os.sep),
+                "diffusers/utils/outputs.py".replace("/", os.sep),
             )
         ):
             # not needed, but cleans up torchbench error stats

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -174,7 +174,9 @@ def backend_cache_manager(callback: DynamoCallback):
 DONT_WRAP_FILES = {
     # For tracing into fx modules
     inspect.getsourcefile(GraphModule),
-    join(dirname(dirname(__file__)), "onnx/_internal/fx/dynamo_graph_extractor.py"),
+    join(
+        dirname(dirname(__file__)), "onnx/_internal/fx/dynamo_graph_extractor.py"
+    ).replace("/", os.sep),
 }
 
 

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -592,8 +592,6 @@ class _NullDecorator(contextlib.nullcontext):  # type: ignore[type-arg]
 
 
 def check_if_dynamo_supported():
-    if sys.platform == "win32":
-        raise RuntimeError("Windows not yet supported for torch.compile")
     if sys.version_info >= (3, 12):
         raise RuntimeError("Python 3.12+ not yet supported for torch.compile")
 

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -3195,7 +3195,7 @@ if torch.distributed.is_available():
 def get_legacy_mod_inlinelist():
     inlinelist = set()
     for m in LEGACY_MOD_INLINELIST:
-        inlinelist.add(_module_dir(torch) + m[len("torch.") :].replace(".", "/"))
+        inlinelist.add(_module_dir(torch) + m[len("torch.") :].replace(".", os.sep))
     return inlinelist
 
 
@@ -3203,7 +3203,7 @@ def get_legacy_mod_inlinelist():
 def get_mod_inlinelist():
     inlinelist = set()
     for m in MOD_INLINELIST:
-        inlinelist.add(_module_dir(torch) + m[len("torch.") :].replace(".", "/"))
+        inlinelist.add(_module_dir(torch) + m[len("torch.") :].replace(".", os.sep))
     return inlinelist
 
 
@@ -3221,9 +3221,9 @@ is_fbcode = importlib.import_module("torch._inductor.config").is_fbcode()
 # Skip fbcode paths(including torch.package paths) containing
 # one of the following strings.
 FBCODE_SKIP_DIRS = {
-    "torchrec/distributed",
-    "torchrec/fb/distributed",
-    "caffe2/torch/fb/sparsenn/pooled_embeddings_modules.py",
+    "torchrec/distributed".replace("/", os.sep),
+    "torchrec/fb/distributed".replace("/", os.sep),
+    "caffe2/torch/fb/sparsenn/pooled_embeddings_modules.py".replace("/", os.sep),
 }
 FBCODE_SKIP_DIRS_RE = re.compile(f".*({'|'.join(map(re.escape, FBCODE_SKIP_DIRS))})")
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2140,8 +2140,8 @@ def build_checkpoint_variable(**options):
 
 
 def is_compile_supported(device_type):
-    from .eval_frame import is_dynamo_supported
     from . import is_win32
+    from .eval_frame import is_dynamo_supported
 
     compile_supported = is_dynamo_supported()
     if device_type == "cpu":

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2140,12 +2140,13 @@ def build_checkpoint_variable(**options):
 
 
 def is_compile_supported(device_type):
+    from .eval_frame import is_dynamo_supported
     from . import is_win32
 
-    compile_supported = not is_win32()
+    compile_supported = is_dynamo_supported()
     if device_type == "cpu":
         pass
-    elif device_type == "cuda" and compile_supported:
+    elif device_type == "cuda" and compile_supported and not is_win32():
         from torch.utils._triton import has_triton
 
         compile_supported = has_triton()

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2140,9 +2140,9 @@ def build_checkpoint_variable(**options):
 
 
 def is_compile_supported(device_type):
-    from .eval_frame import is_dynamo_supported
+    from . import is_win32
 
-    compile_supported = is_dynamo_supported()
+    compile_supported = not is_win32()
     if device_type == "cpu":
         pass
     elif device_type == "cuda" and compile_supported:

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2143,10 +2143,10 @@ def is_compile_supported(device_type):
     from . import is_win32
     from .eval_frame import is_dynamo_supported
 
-    compile_supported = is_dynamo_supported()
+    compile_supported = is_dynamo_supported() and not is_win32()
     if device_type == "cpu":
         pass
-    elif device_type == "cuda" and compile_supported and not is_win32():
+    elif device_type == "cuda" and compile_supported:
         from torch.utils._triton import has_triton
 
         compile_supported = has_triton()


### PR DESCRIPTION
We've had developers using Dynamo via torch.compile and torch._dynamo.export for months on Windows via SHARK (by just deleting these lines locally). The Windows check is moved to just the inductor backend, since it is based on Triton not supporting Windows.

Progress on #90768



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng