### PR TITLE
Fix get_estimated_runtime for symbolic shapes

### DIFF
--- a/test/inductor/test_snode_runtime.py
+++ b/test/inductor/test_snode_runtime.py
@@ -156,6 +156,14 @@ class MemoryBoundedTests(TestCase):
         inp = (T(10),)
         self.assertNotZero(calculate_runtime(f, *inp))
 
+    @torch._dynamo.config.patch(assume_static_by_default=False)
+    def test_dynamic(self):
+        def f(x):
+            return x.cos()
+
+        inp = (T(10),)
+        self.assertNotZero(calculate_runtime(f, *inp))
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -457,8 +457,9 @@ class BaseSchedulerNode:
             return 0
 
         if isinstance(self, SchedulerNode):
-            node_numel = sympy_product(self.get_ranges()[0]) * sympy_product(
-                self.get_ranges()[1]
+            node_numel = V.graph.sizevars.size_hint(
+                sympy_product(self.get_ranges()[0])
+                * sympy_product(self.get_ranges()[1])
             )
         else:
             node_numel = int(1e9)
@@ -1953,8 +1954,8 @@ class Scheduler:
                     node.get_name(),
                     node.get_estimated_runtime(),
                 )
-            except Exception:
-                log.error(
+            except Exception as e:
+                log.debug(
                     "Generating code for node %s with estimated runtime 0.0",
                     node.get_name(),
                 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #111314



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler