### PR TITLE
[dynamo] Make configs more deterministic

### DIFF
--- a/test/dynamo/test_config.py
+++ b/test/dynamo/test_config.py
@@ -77,6 +77,10 @@ class ConfigTests(torch._dynamo.test_case.TestCase):
             ):
                 torch._dynamo.config_utils.install_config_module(my_module)
 
+    def test_able_to_import_constant_functions(self):
+        for fn_name in torch._dynamo.config.constant_functions:
+            fn = torch._dynamo.variables.torch.get_function_from_string(fn_name)
+
     @disable_cache_limit()
     def test_no_automatic_dynamic(self):
         def fn(a, b):

--- a/test/dynamo/test_config.py
+++ b/test/dynamo/test_config.py
@@ -20,7 +20,7 @@ class ConfigTests(torch._dynamo.test_case.TestCase):
 
         my_module.config_1 = ["a", 1, 1.0, True]
         my_module.config_2 = namedtuple("Name", "x y")(1, 2), None
-        my_module.config_3 = {"k": 1, 1: True, 2.0: "a"}
+        my_module.config_3 = {"k": 1, 1: True, 2.0: "a"}, b"bytestring".hex()
 
         torch._dynamo.config_utils.install_config_module(my_module)
         assert all(f"config_{i+1}" in my_module._config for i in range(3))
@@ -38,6 +38,7 @@ class ConfigTests(torch._dynamo.test_case.TestCase):
         for config in [
             set({"a"}),
             {fn: 1},
+            {"b": b"bytestring"},
         ]:
             my_module = MyModule("my_module")
             my_module.config = config

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1155,7 +1155,7 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
             def __torch_function__(cls, func, types, args=(), kwargs=None):
                 return super().__torch_function__(func, types, args, kwargs)
 
-        torch._dynamo.config.traceable_tensor_subclasses.add(TensorProxy)
+        torch._dynamo.config.traceable_tensor_subclasses.append(TensorProxy)
 
         try:
             x = torch.randn(1).as_subclass(TensorProxy)
@@ -1168,7 +1168,7 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
             self.assertTrue(torch._dynamo.testing.same(out1, out2))
 
         finally:
-            torch._dynamo.config.traceable_tensor_subclasses.remove(TensorProxy)
+            torch._dynamo.config.traceable_tensor_subclasses.pop()
 
     def test_torch_function_with_closure(self):
         def run():
@@ -1192,7 +1192,7 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
                     counter + 1
                     return super().__torch_function__(func, types, args, kwargs)
 
-            torch._dynamo.config.traceable_tensor_subclasses.add(TensorProxy)
+            torch._dynamo.config.traceable_tensor_subclasses.append(TensorProxy)
 
             try:
                 x = torch.randn(1).as_subclass(TensorProxy)
@@ -1205,7 +1205,7 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
                 self.assertEqual(cnt.op_count, 4)
                 self.assertTrue(torch._dynamo.testing.same(out1, out2))
             finally:
-                torch._dynamo.config.traceable_tensor_subclasses.remove(TensorProxy)
+                torch._dynamo.config.traceable_tensor_subclasses.pop()
 
         run()
 

--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -37,13 +37,13 @@ class EagerRecordGraphAndInputs:
 
 @contextlib.contextmanager
 def preserve_subclass_config():
-    old_subclass_set = set(torch._dynamo.config.traceable_tensor_subclasses)
+    old_subclass_set = list(torch._dynamo.config.traceable_tensor_subclasses)
     try:
-        torch._dynamo.config.traceable_tensor_subclasses.add(MockSubclass)
+        torch._dynamo.config.traceable_tensor_subclasses.append(MockSubclass)
         yield
     finally:
         torch._dynamo.config.traceable_tensor_subclasses.clear()
-        torch._dynamo.config.traceable_tensor_subclasses.update(old_subclass_set)
+        torch._dynamo.config.traceable_tensor_subclasses = old_subclass_set
 
 
 class SubclassTests(torch._dynamo.test_case.TestCase):
@@ -111,7 +111,7 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
                     kwargs = {}
                 return func(*args, **kwargs)
 
-        torch._dynamo.config.traceable_tensor_subclasses.add(LocalSubclass)
+        torch._dynamo.config.traceable_tensor_subclasses.append(LocalSubclass)
 
         @torch.compile(backend="eager", fullgraph=True)
         def fn(x):

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -6,8 +6,6 @@ import tempfile
 from os.path import abspath, dirname
 
 import torch
-from . import external_utils
-
 
 # to configure logging for dynamo, aot, and inductor
 # use the following API in the torch._logging module
@@ -48,13 +46,13 @@ specialize_int = False
 
 # Assume these functions return constants
 constant_functions = {
-    torch.jit.is_scripting: False,
-    torch.jit.is_tracing: False,
-    torch._C._get_tracing_state: None,
-    torch.fx._symbolic_trace.is_fx_tracing: False,
-    torch.onnx.is_in_onnx_export: False,
-    external_utils.is_compiling: True,
-    torch._utils.is_compiling: True,
+    "torch.jit.is_scripting": False,
+    "torch.jit.is_tracing": False,
+    "torch._C._get_tracing_state": None,
+    "torch.fx._symbolic_trace.is_fx_tracing": False,
+    "torch.onnx.is_in_onnx_export": False,
+    "torch._dynamo.external_utils.is_compiling": True,
+    "torch._utils.is_compiling": True,
 }
 
 # legacy config, does nothing now!
@@ -154,13 +152,13 @@ skipfiles_inline_module_allowlist = {}
 # the `allowed_functions.is_allowed` function will not consider it
 # when creating a list of PyTorch functions that will appear in
 # FX IR.
-allowed_functions_module_string_ignorelist = {
+allowed_functions_module_string_ignorelist = [
     "torch.distributions",
     "torch.testing",
     "torch._refs",
     "torch._prims",
     "torch._decomp",
-}
+]
 
 # Debug Flag to try minifier at different stages. Possible values are {None, "aot", "dynamo"}
 # None - Minifier is switched off
@@ -314,14 +312,14 @@ else:
     debug_dir_root = os.path.join(os.getcwd(), "torch_compile_debug")
 
 
-_save_config_ignore = {
+_save_config_ignore = [
     "repro_after",
     "repro_level",
     # workaround: "cannot pickle PyCapsule"
     "constant_functions",
     # workaround: "cannot pickle module"
     "skipfiles_inline_module_allowlist",
-}
+]
 
 capture_autograd_function = True
 

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -121,7 +121,7 @@ guard_nn_modules_using_dict_tags = True
 # We do NOT currently support __torch_dispatch__.  The implementation is
 # currently buggy, the main show stopper for nontrivial use is
 # https://github.com/pytorch/torchdynamo/issues/1952
-traceable_tensor_subclasses = set()
+traceable_tensor_subclasses = []
 
 # Suppress errors in torch._dynamo.optimize, instead forcing a fallback to eager.
 # This is a good way to get your model to work one way or another, but you may
@@ -146,7 +146,7 @@ disable = os.environ.get("TORCH_COMPILE_DISABLE", False)
 cprofile = os.environ.get("TORCH_COMPILE_CPROFILE", False)
 
 # legacy config, does nothing now!
-skipfiles_inline_module_allowlist = {}
+skipfiles_inline_module_allowlist = []
 
 # If a string representing a PyTorch module is in this ignorelist,
 # the `allowed_functions.is_allowed` function will not consider it

--- a/torch/_dynamo/config_utils.py
+++ b/torch/_dynamo/config_utils.py
@@ -61,7 +61,7 @@ def _check_deterministically_serializable(inp: Any):
             "Config needs to be deterministically serializable. Please do not use sets, python objects, "
             "or functions. Further, bytestrings and complex numbers are also forbidden. "
             "Instead of sets, use lists. Instead of functions, use strings representing the function."
-            "(e.g. 'torch._utils.is_compiling')."
+            "(e.g. 'torch._utils.is_compiling'). Instead of bytestrings, use hex strings."
         ) from e
 
 

--- a/torch/_dynamo/config_utils.py
+++ b/torch/_dynamo/config_utils.py
@@ -9,6 +9,9 @@ from typing import Any, Dict, Set
 from unittest import mock
 
 # Types saved/loaded in configs
+# In 1-to-1 correspondance with JSON serializable types:
+# https://docs.python.org/3/library/json.html#json.JSONEncoder
+# Any derived Enum types are also allowed.
 CONFIG_TYPES = (int, float, bool, type(None), str, list, tuple, dict)
 
 
@@ -55,7 +58,7 @@ def install_config_module(module):
 
 def _check_deterministically_serializable(inp: Any):
     try:
-        dumped = json.dumps(inp)
+        _ = json.dumps(inp)
     except TypeError as e:
         raise ValueError(
             "Config needs to be deterministically serializable. Please do not use sets, python objects, "

--- a/torch/_dynamo/config_utils.py
+++ b/torch/_dynamo/config_utils.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Set
 from unittest import mock
 
 # Types saved/loaded in configs
-CONFIG_TYPES = (int, float, bool, type(None), str, list, set, tuple, dict)
+CONFIG_TYPES = (int, float, bool, type(None), str, list, tuple, dict)
 
 
 def install_config_module(module):

--- a/torch/_dynamo/config_utils.py
+++ b/torch/_dynamo/config_utils.py
@@ -58,9 +58,9 @@ def _check_deterministically_serializable(inp: Any):
         dumped = json.dumps(inp)
     except TypeError as e:
         raise ValueError(
-            "Config needs to be deterministically serializable. Please do not use sets, "
-            "python objects, or functions. Instead of sets, use lists. "
-            "Instead of functions, use strings representing the function."
+            "Config needs to be deterministically serializable. Please do not use sets, python objects, "
+            "or functions. Further, bytestrings and complex numbers are also forbidden. "
+            "Instead of sets, use lists. Instead of functions, use strings representing the function."
             "(e.g. 'torch._utils.is_compiling')."
         ) from e
 

--- a/torch/_dynamo/config_utils.py
+++ b/torch/_dynamo/config_utils.py
@@ -59,8 +59,8 @@ def _check_deterministically_serializable(inp: Any):
     except TypeError as e:
         raise ValueError(
             "Config needs to be deterministically serializable. Please do not use sets, "
-            "python classes and objects, or functions. Instead of sets, use lists. "
-            "Instead of functions or classes, use strings representing the function "
+            "python objects, or functions. Instead of sets, use lists. "
+            "Instead of functions, use strings representing the function."
             "(e.g. 'torch._utils.is_compiling')."
         ) from e
 

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -261,7 +261,7 @@ class TorchVariable(VariableTracker):
                 self.value,
                 source=self.source,
             ).call_function(tx, args, kwargs)
-        elif value in constant_functions:
+        elif self.value in constant_functions:
             assert not args and not kwargs
             return ConstantVariable.create(constant_functions[full_name], **options)
         elif self.value is torch._functorch.eager_transforms.grad_impl:

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -139,7 +139,9 @@ def get_function_from_string(func_string):
     return fn
 
 
-constant_functions = [get_function_from_string(f) for f in config.constant_functions]
+constant_functions = {
+    get_function_from_string(f): v for f, v in config.constant_functions.items()
+}
 
 try:
     # Wed need to monkeypatch transformers here, sadly.
@@ -263,7 +265,7 @@ class TorchVariable(VariableTracker):
             ).call_function(tx, args, kwargs)
         elif self.value in constant_functions:
             assert not args and not kwargs
-            return ConstantVariable.create(constant_functions[full_name], **options)
+            return ConstantVariable.create(constant_functions[self.value], **options)
         elif self.value is torch._functorch.eager_transforms.grad_impl:
             op = TorchHigherOrderOperatorVariable.make(
                 self.value,

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -236,15 +236,21 @@ class TorchVariable(VariableTracker):
         unspec_python_args = check_unspec_python_args(args, kwargs)
         options = VariableTracker.propagate(self, args, kwargs.values())
 
+        def get_full_name(value):
+            if hasattr(value, "__module__") and hasattr(value, "__name__"):
+                if value.__module__ is not None and value.__name__ is not None:
+                    return value.__module__ + "." + value.__name__
+            return None
+
         if self.value is torch._functorch.vmap.vmap_impl:
             return TorchHigherOrderOperatorVariable.make(
                 self.value,
                 source=self.source,
             ).call_function(tx, args, kwargs)
-        elif self.value in config.constant_functions:
+        elif (full_name := get_full_name(self.value)) in config.constant_functions:
             assert not args and not kwargs
             return ConstantVariable.create(
-                config.constant_functions[self.value], **options
+                config.constant_functions[full_name], **options
             )
         elif self.value is torch._functorch.eager_transforms.grad_impl:
             op = TorchHigherOrderOperatorVariable.make(

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -554,10 +554,10 @@ class trace:
     upload_tar = None
 
 
-_save_config_ignore = {
+_save_config_ignore = [
     # workaround: "Can't pickle <function ...>"
     "trace.upload_tar",
-}
+]
 
 
 from .._dynamo.config_utils import install_config_module


### PR DESCRIPTION
While not strictly necessary, it will definitely make config serialization easier and more portable, which may better support future efforts and testing/debugging.

Part of https://github.com/pytorch/pytorch/issues/111235

Split out from: https://github.com/pytorch/pytorch/pull/111298

cc @ezyang @gchanan @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @yanboliang 