### PR TITLE
[AOTInductor] Add UpdateConstants for AOTInductorModel

### DIFF
--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -182,6 +182,23 @@ AOTIRuntimeError AOTInductorModelDelete(
   })
 }
 
+
+AOTIRuntimeError AOTInductorModelUpdateConstants(
+    AOTInductorModelHandle model_handle,
+    AOTInductorConstantMapHandle constant_map_handle) {
+  auto model = reinterpret_cast<torch::aot_inductor::AOTInductorModel*>(model_handle);
+  CONVERT_EXCEPTION_TO_ERROR_CODE({
+      torch::aot_inductor::ConstantMap constant_map;
+      auto input_map = reinterpret_cast<std::unordered_map<std::string, AtenTensorHandle>*>(constant_map_handle);
+
+      for (auto const& kv : *input_map) {
+        constant_map.emplace(kv.first, kv.second);
+      }
+      model->update_constants(std::move(constant_map));
+  })
+}
+
+
 AOTIRuntimeError AOTInductorModelUpdateConstantsMap(
     AOTInductorModelHandle model_handle,
     AOTInductorConstantMapHandle constant_map_handle) {

--- a/torch/csrc/inductor/aoti_model_runner.cpp
+++ b/torch/csrc/inductor/aoti_model_runner.cpp
@@ -19,6 +19,8 @@ AOTIModelRunner::AOTIModelRunner(
       model_so_->sym("AOTInductorModelGetNumOutputs"));
   run_func_ = reinterpret_cast<decltype(run_func_)>(
       model_so_->sym("AOTInductorModelRun"));
+  update_constants_func_ = reinterpret_cast<decltype(update_constants_func_)>(
+      model_so_->sym("AOTInductorModelUpdateConstants"));
   update_constants_map_func_ =
       reinterpret_cast<decltype(update_constants_map_func_)>(
           model_so_->sym("AOTInductorModelUpdateConstantsMap"));
@@ -48,6 +50,11 @@ std::vector<at::Tensor> AOTIModelRunner::run(std::vector<at::Tensor> inputs) {
 
   return torch::aot_inductor::alloc_tensors_by_stealing_from_handles(
       output_handles.data(), output_handles.size());
+}
+
+void AOTIModelRunner::update_constants(const ConstantMap& const_map) {
+  AOTI_RUNTIME_ERROR_CODE_CHECK(update_constants_func_(
+      model_handle_, (AOTInductorConstantMapHandle)&const_map));
 }
 
 void AOTIModelRunner::update_constants_map(const ConstantMap& const_map) {

--- a/torch/csrc/inductor/aoti_model_runner.h
+++ b/torch/csrc/inductor/aoti_model_runner.h
@@ -20,6 +20,7 @@ class TORCH_API AOTIModelRunner {
   AOTIModelRunner& operator=(const AOTIModelRunner& other) = delete;
   AOTIModelRunner& operator=(AOTIModelRunner&& other) = delete;
 
+  void update_constants(const ConstantMap& const_map);
   void update_constants_map(const ConstantMap& const_map);
 
  protected:
@@ -34,6 +35,7 @@ class TORCH_API AOTIModelRunner {
   decltype(&AOTInductorModelDelete) delete_func_{nullptr};
   decltype(&AOTInductorModelGetNumOutputs) get_num_outputs_func_{nullptr};
   decltype(&AOTInductorModelRun) run_func_{nullptr};
+  decltype(&AOTInductorModelUpdateConstants) update_constants_func_{nullptr};
   decltype(&AOTInductorModelUpdateConstantsMap) update_constants_map_func_{
       nullptr};
   AOTInductorModelHandle model_handle_ = nullptr;

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -115,6 +115,13 @@ AOTIRuntimeError AOTInductorModelRun(
     AtenTensorHandle* input_handles,
     AtenTensorHandle* output_handles);
 
+// Update AOTInductorModel's constant. Constants that are not updated will
+// remain intact. To swap out all constants, use the following
+// AOTInductorModelUpdateConstantsMap instead.
+AOTIRuntimeError AOTInductorModelUpdateConstants(
+    AOTInductorModelHandle model_handle,
+    AOTInductorConstantMapHandle constant_map_handle);
+
 // Replace AOTInductorModel's constant map. Note it doesn't handle concurrency
 // so be sure to handle ordering if AOTInductorModelRun is ran concurrently.
 AOTIRuntimeError AOTInductorModelUpdateConstantsMap(

--- a/torch/csrc/inductor/aoti_runtime/model.h
+++ b/torch/csrc/inductor/aoti_runtime/model.h
@@ -231,6 +231,16 @@ class AOTInductorModelBase {
     return constants_info_.at(idx).data_size;
   }
 
+  // update_constants replaces the tensors corresponding to the given name.
+  // tensors that are not included in the map provided will keep it's original
+  // value and not get updated.
+  void update_constants(ConstantMap&& constants_map) {
+    for (auto& [key, val] : constants_map) {
+      constants_->at(key) = std::move(val);
+    }
+  }
+
+  // update_constants_map replaces the mapping of model's constant as a whole.
   void update_constants_map(std::shared_ptr<ConstantMap>&& constants_map) {
     constants_ = std::move(constants_map);
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #111326
* #111325
* #111324

Summary:
Add update_constants for AOTInductorModel

Test Plan:
Included in commit

Reviewers:

Subscribers:

Tasks:

Tags:

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @aakhundov @ColinPeppler