### PR TITLE
Fixed typo in torch/nn/modules/activation.py

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -106,7 +106,7 @@ class ReLU(Module):
 
 
 class RReLU(Module):
-    r"""Applies the randomized leaky rectified liner unit function, element-wise,
+    r"""Applies the randomized leaky rectified linear unit function, element-wise,
     as described in the paper:
 
     `Empirical Evaluation of Rectified Activations in Convolutional Network`_.

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -699,7 +699,7 @@ class Hardshrink(Module):
         \end{cases}
 
     Args:
-        lambd: the :math:`\lambda` value for the Hardshrink formulation. Default: 0.5
+        lambda: the :math:`\lambda` value for the Hardshrink formulation. Default: 0.5
 
     Shape:
         - Input: :math:`(*)`, where :math:`*` means any number of dimensions.


### PR DESCRIPTION
liner -> linear

lambd -> lambda