### PR TITLE
[WIP] 2D optimizer change

### DIFF
--- a/test/distributed/tensor/parallel/test_fsdp_2d_parallel.py
+++ b/test/distributed/tensor/parallel/test_fsdp_2d_parallel.py
@@ -15,6 +15,7 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     checkpoint_wrapper,
     CheckpointImpl,
 )
+from torch.distributed.checkpoint.state_dict import get_state_dict, set_state_dict
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp._common_utils import (
     _get_module_fsdp_state,
@@ -439,6 +440,8 @@ class TestNew2dParallelTraining(DTensorTestBase):
         self._test_2d_e2e_training(recompute_activation=True)
 
 
+# TODO: update all state dict unit tests to use distributed.checkpoint.state_dict,
+# and consolidate all the state_dict test in test.distributed.checkpoint.
 class TestNew2dParallelStateDict(DTensorTestBase):
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -552,6 +555,66 @@ class TestNew2dParallelStateDict(DTensorTestBase):
             self.assertEqual(v1.to_local(), v2.to_local())
             self.assertEqual(v1.device_mesh, v2.device_mesh)
             self.assertEqual(v1.placements, v2.placements)
+
+
+    @with_comms
+    @skip_if_lt_x_gpu(4)
+    @parametrize("is_even_sharded_model", [True, False])
+    @parametrize("use_orig_params", [True, False])
+    def test_2d_optim_state_dict(self, is_even_sharded_model, use_orig_params):
+        simple_model = SimpleModel if is_even_sharded_model else SimpleModelUneven
+
+        # Create a model without wrapper
+        torch.manual_seed(0)
+        no_wrap_model = simple_model().cuda(self.rank)
+        no_wrap_state_dict = no_wrap_model.state_dict()
+        no_wrap_optim = torch.optim.Adam(no_wrap_model.parameters(), lr=0.01)
+        no_wrap_model(no_wrap_model.get_input().cuda(self.rank)).sum().backward()
+        no_wrap_optim.step()
+        _, no_wrap_osd = get_state_dict(no_wrap_model, optimizers=no_wrap_optim, optim_only=True)
+
+        # Create a model and sharded it with 2D FSDP + TP
+        torch.manual_seed(0)
+        mesh_2d = init_device_mesh(
+            self.device_type, (2, self.world_size // 2), mesh_dim_names=("dp", "tp")
+        )
+        model_2d = parallelize_module(
+            simple_model().cuda(), mesh_2d["tp"], PairwiseParallel()
+        )
+        model_2d = FSDP(
+            model_2d,
+            device_mesh=mesh_2d["dp"],
+            use_orig_params=use_orig_params,
+        )
+        FSDP.set_state_dict_type(
+            model_2d,
+            StateDictType.SHARDED_STATE_DICT,
+        )
+        optim_2d = torch.optim.Adam(model_2d.parameters(), lr=0.01)
+        model_2d(model_2d.get_input().cuda(self.rank)).sum().backward()
+        optim_2d.step()
+        _, optim_2d_osd = get_state_dict(model_2d, optimizers=optim_2d, optim_only=True)
+        ref_optim_2d_osd = deepcopy(optim_2d_osd)
+
+        no_wrap_osd_states = no_wrap_osd["state"]
+        optim_2d_osd_states = optim_2d_osd["state"]
+
+        for fqn, states in no_wrap_osd_states.items():
+            dist_states = optim_2d_osd_states.get(fqn)
+
+            for (state_name, state), (dist_state_name, dist_state) in zip(states.items(), dist_states.items()):
+                self.assertEqual(state_name, dist_state_name)
+                if isinstance(dist_state, DT):
+                    # optimizer state always get offload to cpu so we need to move it to cuda redistribute
+                    dist_state = dist_state.cuda()
+                    dist_state = dist_state.redistribute(placements=(Replicate(), Replicate())).to_local()
+                self.assertTrue(isinstance(dist_state, torch.Tensor))
+                self.assertTrue(torch.allclose(state, dist_state))
+
+
+        # Update the parameters 2d optim states will be different from ref_optim_state_dict.
+        model_2d(model_2d.get_input().cuda(self.rank)).sum().backward()
+        optim_2d.step()
 
 
 instantiate_parametrized_tests(TestNew2dParallelStateDict)

--- a/torch/distributed/fsdp/_flat_param.py
+++ b/torch/distributed/fsdp/_flat_param.py
@@ -1755,6 +1755,8 @@ class FlatParamHandle:
     def _get_unflat_views_aligned(
         self,
         tensor: Optional[Tensor] = None,
+        *,
+        disable_ext: bool = False,
     ) -> List[Tensor]:
         """
         This has the same contract as :meth:`_get_unflat_views_unaligned`
@@ -1772,12 +1774,15 @@ class FlatParamHandle:
         for split, is_padding in zip(splits, flat_param._is_padding_mask):
             if is_padding:
                 continue
-            views.append(
-                _ext_post_unflatten_transform(
-                    split.view(flat_param._shapes[idx]),
-                    flat_param._param_extensions[idx],
+            if not disable_ext:
+                views.append(
+                    _ext_post_unflatten_transform(
+                        split.view(flat_param._shapes[idx]),
+                        flat_param._param_extensions[idx],
+                    )
                 )
-            )
+            else:
+                views.append(split.view(flat_param._shapes[idx]))
             idx += 1
         return views
 

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1601,7 +1601,7 @@ def _allgather_orig_param_states(
 
         unpadded_tensor = gathered_tensor[: flat_param._unpadded_unsharded_size.numel()]
         flat_param_handle = fsdp_param_info.handle
-        orig_states = flat_param_handle._get_unflat_views_aligned(unpadded_tensor)
+        orig_states = flat_param_handle._get_unflat_views_aligned(unpadded_tensor, disable_ext=True)
         assert len(orig_states) == len(fsdp_param_info.param_indices), (
             "The number of parameters from FlatParameter is not consistent to "
             "the number of states used by optimizer state dict reconstruction "


### PR DESCRIPTION
This PR: 
1. This PR adds a kwarg to the flat_param util in _get_unflat_views_aligned. We use _get_unflat_views_aligned() in both runtime and optim_state_dict. For optim_state_dict, we do not need to unflatten the dtensor in tp dimension for the views. 
2. Add unit test for 2d_optim_state_dict.

Changes for optim state dict loading and unit test will be in next PR. 