### PR TITLE
[TP] Fix TP doc format to show examples correctly

### DIFF
--- a/torch/distributed/tensor/parallel/api.py
+++ b/torch/distributed/tensor/parallel/api.py
@@ -71,7 +71,7 @@ def parallelize_module(  # type: ignore[return]
         >>>
         >>> # Define the module.
         >>> m = Model(...)
-        >>> m = parallelize_module(m, PairwiseParallel())
+        >>> m = parallelize_module(m, ColwiseParallel())
         >>>
 
     .. warning::

--- a/torch/distributed/tensor/parallel/api.py
+++ b/torch/distributed/tensor/parallel/api.py
@@ -67,7 +67,7 @@ def parallelize_module(  # type: ignore[return]
 
     Example::
         >>> # xdoctest: +SKIP("distributed")
-        >>> from torch.distributed.tensor.parallel import parallelize_module, PairwiseParallel
+        >>> from torch.distributed.tensor.parallel import parallelize_module, ColwiseParallel
         >>>
         >>> # Define the module.
         >>> m = Model(...)

--- a/torch/distributed/tensor/parallel/style.py
+++ b/torch/distributed/tensor/parallel/style.py
@@ -617,20 +617,20 @@ class PrepareModuleInput(ParallelStyle):
             None.
 
         Example::
-        >>> # xdoctest: +SKIP(failing)
-        >>> from torch.distributed.tensor.parallel import parallelize_module, PrepareModuleInput
-        >>> ...
-        >>> parallelize_plan = {
-        >>>     "attn": PrepareModuleInput(),   # The input of attn will be converted to Sharded DTensor
-        >>>                                     # and and redistributed to Replicated DTensor.
-        >>>     ...
-        >>> }
-        >>> parallelize_module(
-        >>>     module=block, # this can be a submodule or module
-        >>>     ...,
-        >>>     parallelize_plan=parallelize_plan,
-        >>> )
-        >>> ...
+            >>> # xdoctest: +SKIP(failing)
+            >>> from torch.distributed.tensor.parallel import parallelize_module, PrepareModuleInput
+            >>> ...
+            >>> parallelize_plan = {
+            >>>     "attn": PrepareModuleInput(),   # The input of attn will be converted to Sharded DTensor
+            >>>                                     # and and redistributed to Replicated DTensor.
+            >>>     ...
+            >>> }
+            >>> parallelize_module(
+            >>>     module=block, # this can be a submodule or module
+            >>>     ...,
+            >>>     parallelize_plan=parallelize_plan,
+            >>> )
+            >>> ...
         """
         super().__init__(
             input_layouts=input_layouts,
@@ -656,20 +656,20 @@ class PrepareModuleOutput(ParallelStyle):
     a no-op. Otherwise, it will throw an error.
 
     Example::
-    >>> # xdoctest: +SKIP(failing)
-    >>> from torch.distributed.tensor.parallel import parallelize_module, PrepareModuleOutput
-    >>> ...
-    >>> parallelize_plan = {
-    >>>     "submodule": PrepareModuleOutput(),   # The output of submodule will be converted to Replicated DTensor
-    >>>                                           # if it's not a DTensor, then redistributed to Sharded local tensor
-    >>>     ...
-    >>> }
-    >>> parallelize_module(
-    >>>     module=block, # this can be a submodule or module
-    >>>     ...,
-    >>>     parallelize_plan=parallelize_plan,
-    >>> )
-    >>> ...
+        >>> # xdoctest: +SKIP(failing)
+        >>> from torch.distributed.tensor.parallel import parallelize_module, PrepareModuleOutput
+        >>> ...
+        >>> parallelize_plan = {
+        >>>     "submodule": PrepareModuleOutput(),   # The output of submodule will be converted to Replicated DTensor
+        >>>                                           # if it's not a DTensor, then redistributed to Sharded local tensor
+        >>>     ...
+        >>> }
+        >>> parallelize_module(
+        >>>     module=block, # this can be a submodule or module
+        >>>     ...,
+        >>>     parallelize_plan=parallelize_plan,
+        >>> )
+        >>> ...
     """
 
     def __init__(

--- a/torch/distributed/tensor/parallel/style.py
+++ b/torch/distributed/tensor/parallel/style.py
@@ -464,20 +464,20 @@ class RowwiseParallel(ParallelStyle):
         remove them from ctor soon. Please use ``input_layouts`` and ``output_layouts`` instead.
 
     Example::
-    >>> # xdoctest: +SKIP(failing)
-    >>> from torch.distributed.tensor.parallel import parallelize_module, PrepareModuleInput
-    >>> ...
-    >>> parallelize_plan = {
-    >>>     "wo": RowwiseParallel(),   # The input of Linear will be converted to Sharded DTensor
-    >>>                                # and we will return a replicate :class:`torch.Tensor` as output.
-    >>>     ...
-    >>> }
-    >>> parallelize_module(
-    >>>     module=block, # this can be a submodule or module
-    >>>     ...,
-    >>>     parallelize_plan=parallelize_plan,
-    >>> )
-    >>> ...
+        >>> # xdoctest: +SKIP(failing)
+        >>> from torch.distributed.tensor.parallel import parallelize_module, PrepareModuleInput
+        >>> ...
+        >>> parallelize_plan = {
+        >>>     "wo": RowwiseParallel(),   # The input of Linear will be converted to Sharded DTensor
+        >>>                                # and we will return a replicate :class:`torch.Tensor` as output.
+        >>>     ...
+        >>> }
+        >>> parallelize_module(
+        >>>     module=block, # this can be a submodule or module
+        >>>     ...,
+        >>>     parallelize_plan=parallelize_plan,
+        >>> )
+        >>> ...
     """
 
     def __init__(
@@ -535,20 +535,20 @@ class ColwiseParallel(ParallelStyle):
         remove them from ctor soon. Please use ``input_layouts`` and ``output_layouts`` instead.
 
     Example::
-    >>> # xdoctest: +SKIP(failing)
-    >>> from torch.distributed.tensor.parallel import parallelize_module, PrepareModuleInput
-    >>> ...
-    >>> parallelize_plan = {
-    >>>     "w1": ColwiseParallel(),   # The input of Linear will be converted to Replicated DTensor
-    >>>                                # and we will return a sharded :class:`torch.Tensor` as output.
-    >>>     ...
-    >>> }
-    >>> parallelize_module(
-    >>>     module=block, # this can be a submodule or module
-    >>>     ...,
-    >>>     parallelize_plan=parallelize_plan,
-    >>> )
-    >>> ...
+        >>> # xdoctest: +SKIP(failing)
+        >>> from torch.distributed.tensor.parallel import parallelize_module, PrepareModuleInput
+        >>> ...
+        >>> parallelize_plan = {
+        >>>     "w1": ColwiseParallel(),   # The input of Linear will be converted to Replicated DTensor
+        >>>                                # and we will return a sharded :class:`torch.Tensor` as output.
+        >>>     ...
+        >>> }
+        >>> parallelize_module(
+        >>>     module=block, # this can be a submodule or module
+        >>>     ...,
+        >>>     parallelize_plan=parallelize_plan,
+        >>> )
+        >>> ...
     """
 
     def __init__(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #111346
* #111177
* #111176
* #111166
* #111160

