### PR TITLE
[tp] fix SP style regression

### DIFF
--- a/torch/distributed/tensor/parallel/style.py
+++ b/torch/distributed/tensor/parallel/style.py
@@ -133,8 +133,8 @@ class SequenceParallel(PairwiseParallel):
             "SequenceParallel", "Use ColwiseParallel and RowwiseParallel instead."
         )
         super().__init__(  # type: ignore[misc]
-            _prepare_input,
-            _prepare_output,
+            make_input_reshard_replicate,
+            make_output_reshard_tensor,
             input_layouts=input_layouts,
             output_layouts=output_layouts,
             use_local_output=use_local_output,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #111353

[tp] fix SP style regression

Although we want to remove prepare_input/output, we should still keep
the old behavior for SequenceParallel