### PR TITLE
fix: reset prefetch flag upon reshard

### DIFF
--- a/test/distributed/fsdp/test_fsdp_fine_tune.py
+++ b/test/distributed/fsdp/test_fsdp_fine_tune.py
@@ -169,15 +169,19 @@ class TestFSDPFineTune(FSDPTest):
                 x = self.layer_0(x)
                 for _ in range(10):
                     x = self.layer_no_grad(self.layer_with_grad(x))
+                    # Make sure calling the same layer multiple times works
+                    # regardless whether gradient is enabled.
+                    with torch.no_grad():
+                        x += self.layer_with_grad(x)
                 return x
 
         return TestModule()
 
     @skip_if_lt_x_gpu(2)
-    def test_backward_hooks_multi_traversal(self):
+    def test_hooks_multi_traversal(self):
         """
-        Tests that the backward hooks do reshard / unshard correctly in the case
-        of same parameters being used mutliple times during forward pass.
+        Tests that the hooks do reshard / unshard correctly in the case of same
+        parameters being used mutliple times during forward pass.
         """
         self.run_subtests(
             {
@@ -188,15 +192,17 @@ class TestFSDPFineTune(FSDPTest):
                 ],
                 "use_orig_params": [False, True],
                 "inp_requires_grad": [False, True],
+                "forward_prefetch": [False, True],
             },
-            self._test_backward_hooks_multi_traversal,
+            self._test_hooks_multi_traversal,
         )
 
-    def _test_backward_hooks_multi_traversal(
+    def _test_hooks_multi_traversal(
         self,
         sharding_strategy: ShardingStrategy,
         use_orig_params: bool,
         inp_requires_grad: bool,
+        forward_prefetch: bool,
     ):
         seq = self._init_multi_traversal_module()
         policy = ModuleWrapPolicy({nn.Linear})
@@ -205,6 +211,7 @@ class TestFSDPFineTune(FSDPTest):
             auto_wrap_policy=policy,
             sharding_strategy=sharding_strategy,
             use_orig_params=use_orig_params,
+            forward_prefetch=forward_prefetch,
         )
         ddp_seq = DDP(copy.deepcopy(seq), device_ids=[self.rank])
         fsdp_optim = torch.optim.Adam(fsdp_seq.parameters(), lr=1e-2)

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -352,10 +352,9 @@ def _reshard(
             free_event.record()
             state._free_event_queue.enqueue(free_event)
     handle.post_reshard()
-    # Since we prefetch entire handles keys at a time, conservatively mark
-    # the entire key as no longer prefetched once we free at least one
-    if free_unsharded_flat_param:
-        handle._prefetched = False
+    # Flat parameter freed or not, we always have to "unshard" the parameter
+    # upon next access to get its shape correct.
+    handle._prefetched = False
 
 
 def _unshard_grads(


### PR DESCRIPTION
The `prefetched` flag should be reset upon reshard. Otherwise, for zero2, next access to the corresponding parameter will skip "unshard" operation, and results in wrong parameter shape. 

The need of unsharding is also metioned [in the comment of `FlatParameterHandle.unshard`](https://github.com/pytorch/pytorch/blob/main/torch/distributed/fsdp/_flat_param.py#L1241-L1242).

As [`FlatParameterHandle` already guarded it against unnecessary all gather](https://github.com/pytorch/pytorch/blob/main/torch/distributed/fsdp/_flat_param.py#L1240), this shouldn't incur extra communication overhead.

_Personally I also find `_prefetched` a bit of mis-named, it should really be `_unsharded`._