### PR TITLE
[aot_inductor] return a copy of any constant

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -901,6 +901,19 @@ class AOTInductorTestsTemplate:
 
         self.check_model(Model(), (torch.empty(4, 1, 4, 4),))
 
+    def test_return_constant(self):
+        class Model(torch.nn.Module):
+            def __init__(self, device):
+                super().__init__()
+                self.cst = torch.randn(10, 10, device=device)
+
+            def forward(self, x):
+                a = self.cst.clone()
+                return (x, a)
+
+        x = torch.randn(4, device=self.device)
+        self.check_model(Model(self.device), (x,))
+
 
 class AOTInductorTestABICompatibleCpu(TestCase):
     device = "cpu"

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1311,9 +1311,10 @@ class CppWrapperCodeGen(WrapperCodeGen):
 
     def generate_return(self, output_refs):
         if V.graph.aot_mode:
+            cst_names = V.graph.constants.keys()
             for idx, output in enumerate(output_refs):
                 if config.aot_inductor.abi_compatible:
-                    if output in self.cached_thread_locals:
+                    if output in self.cached_thread_locals or output in cst_names:
                         self.wrapper_call.writeline(
                             f"aoti_torch_new_uninitialized_tensor(&output_handles[{idx}]);"
                         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #111356

When the model returns a constant, we cannot "release" its handle,
because the constant doesn't have any handle at all. Instead,
we should allocate a new tensor and then return a copy of the constant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @kadeng @muchulee8 @aakhundov @ColinPeppler