### PR TITLE
S390x inductor support

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -58,7 +58,7 @@ if(NOT BUILD_CAFFE2 AND NOT BUILD_LITE_INTERPRETER)
   EXCLUDE(ATen_CORE_TEST_SRCS "${ATen_CORE_TEST_SRCS}" ${ATen_CORE_EXCLUDED_TEST_SRCS})
 endif()
 
-file(GLOB base_h "*.h" "detail/*.h" "cpu/*.h" "cpu/vec/vec512/*.h" "cpu/vec/vec256/*.h" "cpu/vec/vec256/vsx/*.h" "cpu/vec/*.h" "quantized/*.h" "functorch/*.h")
+file(GLOB base_h "*.h" "detail/*.h" "cpu/*.h" "cpu/vec/vec512/*.h" "cpu/vec/vec256/*.h" "cpu/vec/vec256/vsx/*.h" "cpu/vec/vec256/zarch/*.h" "cpu/vec/*.h" "quantized/*.h" "functorch/*.h")
 file(GLOB base_cpp "*.cpp" "detail/*.cpp" "cpu/*.cpp" "functorch/*.cpp")
 file(GLOB cuda_h "cuda/*.h" "cuda/detail/*.h" "cuda/*.cuh" "cuda/detail/*.cuh")
 file(GLOB cuda_cpp "cuda/*.cpp" "cuda/detail/*.cpp")

--- a/aten/src/ATen/cpu/vec/vec256/zarch/vec256_zarch.h
+++ b/aten/src/ATen/cpu/vec/vec256/zarch/vec256_zarch.h
@@ -409,6 +409,13 @@ struct Vectorized<T, std::enable_if_t<is_zarch_implemented<T>()>> {
         vec_xl(offset16, reinterpret_cast<const ElementType*>(tmp_values))};
   }
 
+  static Vectorized<value_type> C10_ALWAYS_INLINE
+  loadu_one_fourth(const void* ptr) {
+    // load only first 8 bytes
+    // only intended to be used with uint8_t
+    return loadu(ptr, 8 / sizeof(ElementType));
+  }
+
   void C10_ALWAYS_INLINE store(void* ptr, int count = size()) const {
     if (count == size()) {
       vec_xst(_vec0, offset0, reinterpret_cast<ElementType*>(ptr));
@@ -1304,6 +1311,55 @@ struct Vectorized<T, std::enable_if_t<is_zarch_implemented<T>()>> {
       std::enable_if_t<std::is_floating_point<U>::value, int> = 0>
   Vectorized<T> mergeo() const {
     return {vec_mergeo(_vec0, _vec0), vec_mergeo(_vec1, _vec1)};
+  }
+
+  template <
+      typename U = T,
+      std::enable_if_t<std::is_same<U, uint8_t>::value, int> = 0>
+  Vectorized<int32_t> to_vec_float_helper() const {
+    int32_t values[8] = {
+      _vec0[0],
+      _vec0[1],
+      _vec0[2],
+      _vec0[3],
+      _vec0[4],
+      _vec0[5],
+      _vec0[6],
+      _vec0[7],
+    };
+
+    return Vectorized<int32_t>{
+      values[0], values[1], values[2], values[3],
+      values[4], values[5], values[6], values[7]
+    };
+  }
+
+  template <
+      typename U = T,
+      std::enable_if_t<std::is_same<U, int32_t>::value, int> = 0>
+  Vectorized<uint8_t> to_vec_uint8_helper() const {
+    // helper function for float to uint8_t conversion
+    uint8_t values[8] = {
+      static_cast<uint8_t>(_vec0[0]),
+      static_cast<uint8_t>(_vec0[1]),
+      static_cast<uint8_t>(_vec0[2]),
+      static_cast<uint8_t>(_vec0[3]),
+      static_cast<uint8_t>(_vec1[0]),
+      static_cast<uint8_t>(_vec1[1]),
+      static_cast<uint8_t>(_vec1[2]),
+      static_cast<uint8_t>(_vec1[3]),
+    };
+
+    return Vectorized<uint8_t>{
+      values[0], values[1], values[2], values[3],
+      values[4], values[5], values[6], values[7],
+      0, 0, 0, 0,
+      0, 0, 0, 0,
+      0, 0, 0, 0,
+      0, 0, 0, 0,
+      0, 0, 0, 0,
+      0, 0, 0, 0,
+    };
   }
 };
 
@@ -2656,6 +2712,23 @@ template <>
 std::pair<Vectorized<int64_t>, Vectorized<int64_t>> inline deinterleave2<
     int64_t>(const Vectorized<int64_t>& a, const Vectorized<int64_t>& b) {
   return inner_deinterleave2<int64_t>(a, b);
+}
+
+inline Vectorized<float> convert_uint8_to_float(const Vectorized<uint8_t> &src) {
+  // Note: this function only convert inputs number of elements equal to at::vec::Vectorized<float>.size()
+  // Only handle first 64 bits
+  auto vec_int = src.to_vec_float_helper();
+
+  return convert_to_float(vec_int);
+}
+
+inline Vectorized<uint8_t> convert_float_to_uint8(const Vectorized<float> &src) {
+  constexpr auto min_val = std::numeric_limits<uint8_t>::min();
+  constexpr auto max_val = std::numeric_limits<uint8_t>::max();
+
+  auto vec_int = clamp(convert_to_int(src), Vectorized<int32_t>(min_val), Vectorized<int32_t>(max_val));
+
+  return vec_int.to_vec_uint8_helper();
 }
 
 #undef DEFINE_CLAMP_MAXMIN_FUNCS

--- a/setup.py
+++ b/setup.py
@@ -1216,6 +1216,7 @@ def main():
         "include/ATen/cpu/*.h",
         "include/ATen/cpu/vec/vec256/*.h",
         "include/ATen/cpu/vec/vec256/vsx/*.h",
+        "include/ATen/cpu/vec/vec256/zarch/*.h",
         "include/ATen/cpu/vec/vec512/*.h",
         "include/ATen/cpu/vec/*.h",
         "include/ATen/core/*.h",

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -3,6 +3,7 @@ import contextlib
 import copy
 import itertools
 import math
+import platform
 import sys
 import unittest
 from typing import Callable
@@ -1195,7 +1196,8 @@ class CPUReproTests(TestCase):
             self.common(fn, (value,))
 
     @unittest.skipIf(
-        not codecache.valid_vec_isa_list(), "Does not support vectorization"
+        platform.machine() != "x86_64" or not codecache.valid_vec_isa_list(),
+        "Does not support vectorization or not x86_64 machine",
     )
     @patch("torch.cuda.is_available", lambda: False)
     def test_auto_simd(self):

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -916,7 +916,6 @@ class InvalidVecISA(VecISA):
 
 invalid_vec_isa = InvalidVecISA()
 supported_vec_isa_list = [VecAVX512(), VecAVX2()]
-supported_vec_isa_list_s390x = [VecZVECTOR()]
 
 
 # Cache the cpuinfo to avoid I/O overhead. Meanwhile, the cpuinfo content
@@ -928,7 +927,7 @@ def valid_vec_isa_list() -> List[VecISA]:
         return []
 
     if platform.machine() == "s390x":
-        return supported_vec_isa_list_s390x
+        return [VecZVECTOR()]
 
     isa_list = []
     with open("/proc/cpuinfo") as _cpu_info:
@@ -1065,7 +1064,7 @@ def get_include_and_linking_paths(
     vec_isa: VecISA = invalid_vec_isa,
     cuda: bool = False,
     aot_mode: bool = False,
-) -> Tuple[str, str, str, str]:
+) -> Tuple[Any, str, str, str, str]:
     if (
         config.is_fbcode()
         and "CUDA_HOME" not in os.environ

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -891,7 +891,7 @@ class VecZVECTOR(VecISA):
     _bit_width = 256
     _macro = "CPU_CAPABILITY_ZVECTOR"
     _arch_flags = "-mvx -mzvector"
-    _dtype_nelements = {torch.float: 8, torch.bfloat16: 16}
+    _dtype_nelements = {torch.float: 8, torch.bfloat16: 16, torch.float16: 16}
 
     def __str__(self) -> str:
         return "vx"

--- a/torch/_inductor/codegen/cpp_prefix.h
+++ b/torch/_inductor/codegen/cpp_prefix.h
@@ -17,7 +17,7 @@
 #include <c10/util/Half.h>
 #include <c10/util/TypeCast.h>
 
-#if defined(CPU_CAPABILITY_AVX512) || defined(CPU_CAPABILITY_AVX2)
+#if defined(CPU_CAPABILITY_AVX512) || defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_ZVECTOR)
 #define INDUCTOR_USE_VECTOR_TYPES() 1
 #else
 #define INDUCTOR_USE_VECTOR_TYPES() 0
@@ -247,7 +247,7 @@ inline float flag_to_float_scalar(T src) {
   return ret;
 }
 
-#if defined(CPU_CAPABILITY_AVX512) || defined(CPU_CAPABILITY_AVX2)
+#if defined(CPU_CAPABILITY_AVX512) || defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_ZVECTOR)
 
 inline at::vec::Vectorized<float> masked_load(const float* src, at::vec::Vectorized<float> mask) {
   at::vec::Vectorized<float> zero_vec(0);
@@ -357,6 +357,7 @@ inline at::vec::Vectorized<float> to_float_mask(at::vec::Vectorized<SRC> src) {
   return vec_convert_to_mask(src);
 }
 
+#if defined(CPU_CAPABILITY_AVX512) || defined(CPU_CAPABILITY_AVX2)
 template <>
 inline at::vec::Vectorized<float> to_float_mask(at::vec::Vectorized<int> src) {
 #if defined(CPU_CAPABILITY_AVX2)
@@ -365,6 +366,7 @@ inline at::vec::Vectorized<float> to_float_mask(at::vec::Vectorized<int> src) {
   return at::vec::Vectorized<float>(_mm512_castsi512_ps(src));
 #endif
 }
+#endif
 
 template <>
 inline at::vec::Vectorized<float> to_float_mask(at::vec::Vectorized<float> src) {

--- a/torch/_inductor/codegen/cpp_prefix.h
+++ b/torch/_inductor/codegen/cpp_prefix.h
@@ -250,15 +250,20 @@ inline float flag_to_float_scalar(T src) {
 #if defined(CPU_CAPABILITY_AVX512) || defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_ZVECTOR)
 
 inline at::vec::Vectorized<float> masked_load(const float* src, at::vec::Vectorized<float> mask) {
-  at::vec::Vectorized<float> zero_vec(0);
 # if defined(CPU_CAPABILITY_AVX512)
+    at::vec::Vectorized<float> zero_vec(0);
     auto all_ones = _mm512_set1_epi32(0xFFFFFFFF);
     auto mmask = _mm512_cmp_epi32_mask(_mm512_castps_si512(mask), all_ones, _MM_CMPINT_EQ);
     return _mm512_mask_loadu_ps(zero_vec, mmask, src);
-# else // AVX2
+# elif defined(CPU_CAPABILITY_AVX2)
     auto all_ones = _mm256_set1_epi32(0xFFFFFFFF);
     auto mmask = _mm256_cmpeq_epi32(_mm256_castps_si256(mask), all_ones);
     return _mm256_maskload_ps(src, mmask);
+# elif defined(CPU_CAPABILITY_ZVECTOR)
+    auto result = at::vec::Vectorized<float>::loadu(src);
+    return (result & mask);
+# else
+# error Unsupported vectorization CPU capability
 # endif
 }
 
@@ -271,7 +276,7 @@ inline masked_load(const T* src, at::vec::Vectorized<float> mask) {
   auto zero = _mm256_set1_epi16(0);
   auto temp = _mm256_mask_loadu_epi16(zero, mmask, src);
   return _mm512_inserti32x8(_mm512_castsi256_si512(temp), zero, 1);
-# else // AVX2
+# elif defined(CPU_CAPABILITY_AVX2)
   auto all_ones = _mm256_set1_epi32(0xFFFFFFFF);
   auto mmask_vec = _mm256_cmpeq_epi32(_mm256_castps_si256(mask), all_ones);
   __at_align__ uint32_t mmask[8];
@@ -281,6 +286,18 @@ inline masked_load(const T* src, at::vec::Vectorized<float> mask) {
     result[i] = mmask[i] == 0xFFFFFFFF ? src[i].x: uint16_t(0);
   }
   return at::vec::Vectorized<T>::loadu(result);
+# elif defined(CPU_CAPABILITY_ZVECTOR)
+  auto result = at::vec::Vectorized<T>::loadu(src, 8);
+  uint32_t maskdata[8] = { 0 };
+  uint16_t maskdata_dest[16] = { 0 };
+  mask.store(maskdata);
+  for (auto i = 0; i < 8; i++) {
+    maskdata_dest[i] = (maskdata[i] == 0xFFFFFFFF) ? 0xFFFF: 0;
+  }
+  auto maskvector = at::vec::Vectorized<T>::loadu(maskdata_dest);
+  return (result & maskvector);
+# else
+# error Unsupported vectorization CPU capability
 # endif
 }
 
@@ -291,7 +308,7 @@ inline at::vec::Vectorized<uint8_t> masked_load(const uint8_t* src, at::vec::Vec
     auto zero = _mm_set1_epi8(0);
     auto temp = _mm_mask_loadu_epi8(zero, mmask, src);
     return _mm512_inserti64x2(_mm512_set1_epi32(0), temp, 0);
-# else // AVX2
+# elif defined(CPU_CAPABILITY_AVX2)
     auto all_ones = _mm256_set1_epi32(0xFFFFFFFF);
     auto mmask_vec = _mm256_cmpeq_epi32(_mm256_castps_si256(mask), all_ones);
     __at_align__ uint32_t mmask[8];
@@ -301,6 +318,18 @@ inline at::vec::Vectorized<uint8_t> masked_load(const uint8_t* src, at::vec::Vec
       result[i] = mmask[i] == 0xFFFFFFFF ? src[i]: uint8_t(0);
     }
     return at::vec::Vectorized<uint8_t>::loadu(result);
+# elif defined(CPU_CAPABILITY_ZVECTOR)
+    auto result = at::vec::Vectorized<uint8_t>::loadu(src, 8);
+    uint32_t maskdata[8];
+    uint8_t maskdata_dest[32] = { 0 };
+    mask.store(maskdata);
+    for (auto i = 0; i < 8; i++) {
+      maskdata_dest[i] = (maskdata[i] == 0xFFFFFFFF) ? 0xFF: 0;
+    }
+    auto maskvector = at::vec::Vectorized<uint8_t>::loadu(maskdata_dest);
+    return (result & maskvector);
+# else
+# error Unsupported vectorization CPU capability
 # endif
 }
 

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1449,7 +1449,7 @@ def _check_and_build_extension_h_precompiler_headers(
             raise RuntimeError(f"Compile PreCompile Header fail, command: {pch_cmd}") from e
 
     extra_cflags_str = listToString(extra_cflags)
-    extra_include_paths_str = listToString(extra_include_paths)
+    extra_include_paths_str = " ".join([f'-I{include}' for include in extra_include_paths])
 
     lib_include = os.path.join(_TORCH_PATH, 'include')
     torch_include_dirs = [


### PR DESCRIPTION
Use arch compile flags. They are needed for vectorization support on s390x.
Implement new helper functions for inductor.

This change fixes multiple tests in test_cpu_repro.py

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler