### PR TITLE
Increase coverage of clang-tidy to CudaIPCTypes.cpp

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -265,7 +265,6 @@ exclude_patterns = [
     'torch/csrc/autograd/functions/**',
     'torch/csrc/autograd/generated/**',
     'torch/csrc/autograd/profiler_legacy.cpp',
-    'torch/csrc/CudaIPCTypes.cpp',
     'torch/csrc/cuda/**',
     'torch/csrc/dynamo/*',
     'torch/csrc/distributed/**/*',

--- a/torch/csrc/CudaIPCTypes.cpp
+++ b/torch/csrc/CudaIPCTypes.cpp
@@ -1,8 +1,9 @@
 #include <ATen/MapAllocator.h>
+#include <c10/cuda/CUDAGuard.h>
 #include <torch/csrc/CudaIPCTypes.h>
+#include <atomic>
 #include <map>
 #include <mutex>
-#include <random>
 #include <string>
 
 namespace torch {

--- a/torch/csrc/CudaIPCTypes.h
+++ b/torch/csrc/CudaIPCTypes.h
@@ -3,8 +3,6 @@
 #include <c10/core/Allocator.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAException.h>
-#include <c10/cuda/CUDAGuard.h>
-#include <c10/cuda/CUDAStream.h>
 #include <c10/util/Logging.h>
 #include <cuda_runtime_api.h>
 #include <torch/csrc/Export.h>
@@ -54,13 +52,13 @@ TORCH_CUDA_CU_API at::DataPtr GetNewRefCountedSentData(
 
 namespace {
 
-constexpr int64_t CUDA_IPC_REF_COUNTER_FILE_SIZE = 10000;
-constexpr int64_t CUDA_IPC_WARN_AFTER_X_BLOCKS_IN_LIMBO = 1000;
+inline constexpr int64_t CUDA_IPC_REF_COUNTER_FILE_SIZE = 10000;
+inline constexpr int64_t CUDA_IPC_WARN_AFTER_X_BLOCKS_IN_LIMBO = 1000;
 // This was determined empirically that CUDA (v10.1 and below) have the limit
 // on the number of recorded blocking interprocess events. It is around ~22,000.
 // And to give us leeway, we picked 1000 as it gives us enough events to share
 // tensors effectively.
-constexpr int64_t CUDA_IPC_MAXIMUM_EVENTS_TO_USE = 1000;
+inline constexpr int64_t CUDA_IPC_MAXIMUM_EVENTS_TO_USE = 1000;
 
 // All to be deleted data blocks with non zero reference counter goes there
 struct CudaIPCSentDataLimbo final {


### PR DESCRIPTION
This PR uses clang-tidy in torch/csrc/CudaIPCTypes.cpp