### PR TITLE
IPUHooksInterface: fix a typo, remove const &

### DIFF
--- a/aten/src/ATen/detail/IPUHooksInterface.h
+++ b/aten/src/ATen/detail/IPUHooksInterface.h
@@ -17,8 +17,7 @@ struct TORCH_API IPUHooksInterface {
         "available.");
   }
 
-  virtual const Generator& newIPUGenerator(
-      DeviceIndex device_index = -1) const {
+  virtual Generator newIPUGenerator(DeviceIndex device_index = -1) const {
     AT_ERROR(
         "Cannot create a new IPU generator: the IPU backend is not available.");
   }


### PR DESCRIPTION
Return an `at::Generator` from `newIPUGenerator`, not a reference to one.