### PR TITLE
Handle the `.tolist` method of np.arrays in dynamo

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1610,6 +1610,20 @@ utils_device.CURRENT_DEVICE == None""",
         self.assertEqual(type(r), list)
         self.assertEqual(cnts.frame_count, 1)
 
+    def test_numpy_size_attr(self):
+        def fn(x):
+            return x.size + x
+
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch._dynamo.optimize(cnts, nopython=True)(fn)
+
+        x = np.arange(5)
+        r = opt_fn(x)
+
+        self.assertEqual(r, fn(x))
+        self.assertEqual(type(r), np.ndarray)
+        self.assertEqual(cnts.frame_count, 1)
+
     def test_numpy_no_raise(self):
         def _inf_nan_preprocess(t, t_np):
             t_np = np.nan_to_num(t_np)

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1596,6 +1596,20 @@ utils_device.CURRENT_DEVICE == None""",
             self.assertEqual(ref, res)
         self.assertEqual(cnts.frame_count, 1)
 
+    def test_numpy_tolist(self):
+        def fn(x):
+            return x.tolist()
+
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch._dynamo.optimize(cnts, nopython=True)(fn)
+
+        x = np.arange(5)
+        r = opt_fn(x)
+
+        self.assertEqual(r, [0, 1, 2, 3, 4])
+        self.assertEqual(type(r), list)
+        self.assertEqual(cnts.frame_count, 1)
+
     def test_numpy_no_raise(self):
         def _inf_nan_preprocess(t, t_np):
             t_np = np.nan_to_num(t_np)

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1075,7 +1075,7 @@ class NumpyNdarrayVariable(TensorVariable):
         options = VariableTracker.propagate([[self]], [args], [list(kwargs.values())])
         from ..utils import numpy_method_wrapper
 
-        if name in ["__len__", "size"]:
+        if name in ["__len__", "size", "tolist"]:
             # delegate back to TensorVariable
             return super().call_method(tx, name, args, kwargs)
         proxy = tx.output.create_proxy(


### PR DESCRIPTION
Fixes part 1 of https://github.com/pytorch/pytorch/issues/111370#issuecomment-1764730773

While at it, add a test for numpy ndarray `.size` attribute. This started as an attempt to remove the delegation of what looks like a `.size()` method --- which does not exist in numpy --- on the same line this patch adds a `tolist` to. 
But this is apparently needed for something else and existing tests start failing. Thus, declare it as _ain't broken don't fix_, and only keep the test. Can remove the test if wanted though. 


cc @mruberry @rgommers @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng