### PR TITLE
Fix _CudaStreamBase type annotations

### DIFF
--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1760,7 +1760,7 @@ def _gather(
 def _gather_out(tensors: List[Tensor], out_tensor: Tensor, dim: _int) -> Tensor: ...
 
 # Defined in torch/csrc/cuda/Stream.cpp
-class _CudaStreamBase:
+class _CudaStreamBase(Stream):
     stream_id: _int
     device_index: _int
     device_type: _int


### PR DESCRIPTION
Make it inherit from `Stream` as indeed it is, see https://github.com/pytorch/pytorch/blob/97a513ed077323550b808e690a0b5a0452f87334/torch/csrc/cuda/Stream.cpp#L208 and
```
python3 -c "import torch;print(torch._C._CudaStreamBase.__base__)"
<class 'torch.Stream'>
```

Fixes https://github.com/pytorch/pytorch/issues/111268

TODO (in separate PR): Revive `test_typing` and add regression test
