### PR TITLE
[sparse] Add padding for dense matrices in semi-structured sparse

### DIFF
--- a/torch/sparse/semi_structured.py
+++ b/torch/sparse/semi_structured.py
@@ -53,7 +53,7 @@ class SparseSemiStructuredTensor(torch.Tensor):
 
     _FUSE_TRANSPOSE = False
     _FORCE_CUTLASS = True
-    _WARNING_SHOWN = False
+    _PROTOTYPE_WARNING_SHOWN = False
 
     @staticmethod
     def __new__(
@@ -88,7 +88,7 @@ class SparseSemiStructuredTensor(torch.Tensor):
         """
         assert compressed_tensor_cusparselt is None or (sparse_tensor_cutlass is None and meta_tensor_cutlass is None)
 
-        if not cls._WARNING_SHOWN:
+        if not cls._PROTOTYPE_WARNING_SHOWN:
             warnings.warn(
                 (
                     "The PyTorch API of SparseSemiStructuredTensor is in prototype stage "
@@ -98,7 +98,7 @@ class SparseSemiStructuredTensor(torch.Tensor):
                 ),
                 UserWarning,
             )
-            cls._WARNING_SHOWN = True
+            cls._PROTOTYPE_WARNING_SHOWN = True
 
         if original_tensor is not None:
             previous_tensor = original_tensor
@@ -232,6 +232,26 @@ class SparseSemiStructuredTensor(torch.Tensor):
 
     __torch_function__ = torch._C._disabled_torch_function_impl
 
+    def _pad_tensor_for_matmul(self, original_tensor : torch.Tensor) -> torch.Tensor:
+        """
+        Calculates padding for dense tensor and pads tensor if necessary.
+        If padding is not required, this function returns the original tensor.
+        """
+        # only 2d matmul
+        assert original_tensor.dim() == 2
+
+        # check shape
+        m, n = original_tensor.shape
+        min_rows = _DTYPE_TO_SEMI_STRUCTURED_SPARSE_CONFIG[original_tensor.dtype].min_rows
+        min_cols = _DTYPE_TO_SEMI_STRUCTURED_SPARSE_CONFIG[original_tensor.dtype].min_cols
+        to_pad_m = -m % min_rows if m < min_rows or m % min_rows else 0
+        to_pad_n = -n % min_cols if n < min_cols or n % min_rows else 0
+        if to_pad_m or to_pad_n:
+            return torch.nn.functional.pad(original_tensor, (0, to_pad_n, 0, to_pad_m))
+        else:
+            return original_tensor
+
+
     @classmethod
     def __torch_dispatch__(cls, func, types, args, kwargs) -> Any:
         """Overload __torch_dispatch__ to use torch._sparse_semi_structured_linear.
@@ -290,38 +310,52 @@ class SparseSemiStructuredTensor(torch.Tensor):
             # F.linear(x) = addmm(bias, input, weight.t()) = b + xW' = (b + xW')''
             #        = (W''x' + b')' = (Wx' + b')' = addmm(bias.T, weight, input).T
             if isinstance(input_B, cls) and input_B.transposed:
+                row, col = input_A.shape
+                input_A_padded = input_B._pad_tensor_for_matmul(input_A)
                 if input_B.compressed_tensor_cusparselt is None:
                     assert input_B.sparse_tensor_cutlass is not None and input_B.meta_tensor_cutlass is not None
-                    return torch._sparse_semi_structured_linear(
-                        input_A, input_B.sparse_tensor_cutlass, input_B.meta_tensor_cutlass, bias=bias
+                    res = torch._sparse_semi_structured_linear(
+                        input_A_padded, input_B.sparse_tensor_cutlass, input_B.meta_tensor_cutlass, bias=bias
                     )
                 else:
-                    return torch._cslt_sparse_mm(
-                        input_B.compressed_tensor_cusparselt, input_A.T, bias  # type: ignore[arg-type]
+                    res = torch._cslt_sparse_mm(
+                        input_B.compressed_tensor_cusparselt, input_A_padded.t(), bias  # type: ignore[arg-type]
                     ).t()
+                return res[:row, :]
 
         # handle mm
         if func is torch.ops.aten.mm.default:
             input_A, input_B = args
 
+            # first element sparse
             if isinstance(input_A, cls) and not input_A.transposed:
+                row, col = input_B.shape
+                input_B_padded = input_A._pad_tensor_for_matmul(input_B)
                 if input_A.compressed_tensor_cusparselt is None:
                     assert input_A.sparse_tensor_cutlass is not None and input_A.meta_tensor_cutlass is not None
-                    return torch._sparse_semi_structured_linear(
-                        input_B.t(), input_A.sparse_tensor_cutlass, input_A.meta_tensor_cutlass
+                    res = torch._sparse_semi_structured_linear(
+                        input_B_padded.t(), input_A.sparse_tensor_cutlass, input_A.meta_tensor_cutlass
                     ).t()
                 else:
-                    return torch._cslt_sparse_mm(
-                        input_A.compressed_tensor_cusparselt, input_B, None  # type: ignore[arg-type]
+                    res = torch._cslt_sparse_mm(
+                        input_A.compressed_tensor_cusparselt, input_B_padded, None  # type: ignore[arg-type]
                     )
+                return res[:, :col]
+
+            # second element sparse
             elif isinstance(input_B, cls) and input_B.transposed:
+                row, col = input_A.shape
+                input_A_padded = input_B._pad_tensor_for_matmul(input_A)
+
                 if input_B.compressed_tensor_cusparselt is None:
                     assert input_B.sparse_tensor_cutlass is not None and input_B.meta_tensor_cutlass is not None
-                    return torch._sparse_semi_structured_linear(
-                        input_A, input_B.sparse_tensor_cutlass, input_B.meta_tensor_cutlass
+                    res = torch._sparse_semi_structured_linear(
+                        input_A_padded, input_B.sparse_tensor_cutlass, input_B.meta_tensor_cutlass
                     )
                 else:
-                    return torch._cslt_sparse_mm(input_B.compressed_tensor_cusparselt, input_A.T, None).t()  # type: ignore[arg-type]
+                    res = torch._cslt_sparse_mm(input_B.compressed_tensor_cusparselt, input_A_padded.t(), None).t()  # type: ignore[arg-type]
+
+                return res[:row, :]
 
         # When torch is run with inference mode, pytorch does not decompose torch.ops.aten.linear into a .t() and addmm(),
         # so we must match the aten.linear op. In this case, we need to explicitly handle collapsing to 2d matmul
@@ -329,21 +363,29 @@ class SparseSemiStructuredTensor(torch.Tensor):
         if func is torch.ops.aten.linear.default:
             input_tensor, weight, bias = args
             shape = input_tensor.shape
+
+            input_tensor_2d = input_tensor.view(-1, shape[-1])
+            row, col = input_tensor_2d.shape
+            # this is a noop if already padded
+            input_tensor_2d_padded = weight._pad_tensor_for_matmul(input_tensor_2d)
+
             if isinstance(weight, cls):
                 if weight.compressed_tensor_cusparselt is None:
                     assert weight.sparse_tensor_cutlass is not None and weight.meta_tensor_cutlass is not None
-                    return torch._sparse_semi_structured_linear(
-                        input_tensor,
+                    res = torch._sparse_semi_structured_linear(
+                        input_tensor_2d_padded,
                         weight.sparse_tensor_cutlass,
                         weight.meta_tensor_cutlass,
                         bias=bias
                     )
                 else:
-                    return torch._cslt_sparse_mm(
+                    res = torch._cslt_sparse_mm(
                         weight.compressed_tensor_cusparselt,  # type: ignore[arg-type]
-                        input_tensor.view(-1, shape[-1]).t(),
+                        input_tensor_2d_padded.t(),
                         bias
-                    ).t().view(*shape[:-1], -1)
+                    ).t()
+                return res[:row, :].view(*shape[:-1], -1)
+
 
         # handle values
         if func is torch.ops.aten.values.default:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #111389
* __->__ #111388

Summary:

Currently we have shape constraints in semi-structured sparsity for both
CUTLASS and cuSPARSELt

These shape constraints unfortunately apply to both the dense and sparse
matrices in sparsedense matmul.

This PR adds in support for calling `F.pad` in order to pad dense
matrices to the right size with zeros and then pull out the
corresponding rows from the resultant result matrix.

We also throw a warning in this case.
The tests have also been updated to take in a dense_input_shape
parameter.

Test Plan:
```
python test/test_sparse_semi_structured.py
```

Reviewers:

Subscribers:

Tasks:

Tags: