### PR TITLE
Add an explicit _shutdown method to ProcessGroupNCCL

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -1147,7 +1147,7 @@ class ProcessGroupNCCLTest(MultiProcessTestCase):
         dist.all_reduce(t)
 
         def abortpg():
-            c10d.distributed_c10d._get_default_group()._get_backend(torch.device(device))._abort()
+            c10d.distributed_c10d._get_default_group()._get_backend(torch.device(device))._shutdown()
 
         # Initialize DDP to ensure "destroy_process_group" will not call
         # ProcessGroupNCCL destructor since DDP holds a reference to process group.
@@ -1173,20 +1173,29 @@ class ProcessGroupNCCLTest(MultiProcessTestCase):
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(torch.cuda.device_count() < 2, "NCCL test requires 2+ GPUs")
     def test_close_pg(self):
+        # Disable ASYNC_ERROR_HANDLING for this test to ensure we can programmatically
+        # abort the process group.
+        os.environ["NCCL_ASYNC_ERROR_HANDLING"] = "0"
+
         store = c10d.FileStore(self.file_name, self.world_size)
-        self._create_process_group_nccl(store, self.opts())
+        pg = self._create_process_group_nccl(store, self.opts())
         device = self.rank_to_GPU[self.rank][0]
 
         t = torch.rand(10, 10, device=device)
         # First allreduce to initialize state.
-        dist.all_reduce(t)
+        pg.allreduce(t)
 
-        # Close the process group.
-        c10d.distributed_c10d._get_default_group()._get_backend(torch.device(device))._close()
+        # Destroy pg and validate pg is still in working condition since we hold a
+        # reference above.
+        dist.destroy_process_group()
+        pg.allreduce([t])
+
+        # Now close pg and validate it no longer works.
+        pg._get_backend(torch.device(device))._shutdown()
 
         # Try another collective.
         with self.assertRaises(dist.DistBackendError):
-            dist.all_reduce(t)
+            pg.allreduce([t])
 
 class DistributedDataParallelTest(
     test_c10d_common.CommonDistributedDataParallelTest, MultiProcessTestCase

--- a/torch/csrc/distributed/c10d/NCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.cpp
@@ -15,7 +15,8 @@ ncclComm_t NCCLComm::getNcclComm() {
     auto commFailureMsg = commFailureReason_ != c10::nullopt
         ? c10::str(" Original reason for failure was: ", *commFailureReason_)
         : "";
-    TORCH_CHECK(
+    TORCH_CHECK_WITH(
+        DistBackendError,
         false,
         c10::str(
             "NCCL communicator was aborted on rank ",

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -878,7 +878,7 @@ void ProcessGroupNCCL::abort(c10::optional<std::string> abortReason) {
   abortCommsFromMap(inInitializationCommMap_, rank_, abortReason);
 }
 
-ProcessGroupNCCL::~ProcessGroupNCCL() {
+void ProcessGroupNCCL::close() {
   terminateProcessGroup_.store(true);
 
   workMetaListCV_.notify_one();
@@ -892,6 +892,10 @@ ProcessGroupNCCL::~ProcessGroupNCCL() {
   // Abort all NCCL Communicators on Process Group Destruction
   std::string abortReason = c10::str("Process Group destroyed on rank ", rank_);
   abort(abortReason);
+}
+
+ProcessGroupNCCL::~ProcessGroupNCCL() {
+  close();
 }
 
 void ProcessGroupNCCL::ncclCommWatchdog() {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -885,7 +885,7 @@ void ProcessGroupNCCL::shutdown() {
   terminateProcessGroup_.store(true);
 
   std::string abortReason =
-      fmt::format("Process Group shutdown on rank {}", rank_);
+      c10::str("Process Group shutdown on rank ", rank_);
   abort(abortReason);
 
   workMetaListCV_.notify_one();
@@ -907,7 +907,7 @@ ProcessGroupNCCL::~ProcessGroupNCCL() {
   // Abort communicators after all threads have exited to avoid having the
   // threads dying due to aborted communicator and raising a SIGABRT
   std::string abortReason =
-      fmt::format("Process Group destroyed on rank {}", rank_);
+      c10::str("Process Group destroyed on rank ", rank_);
   abort(abortReason);
 }
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -884,8 +884,7 @@ void ProcessGroupNCCL::shutdown() {
   // potentially block and hence avoid it in this method.
   terminateProcessGroup_.store(true);
 
-  std::string abortReason =
-      c10::str("Process Group shutdown on rank ", rank_);
+  std::string abortReason = c10::str("Process Group shutdown on rank ", rank_);
   abort(abortReason);
 
   workMetaListCV_.notify_one();
@@ -906,8 +905,7 @@ ProcessGroupNCCL::~ProcessGroupNCCL() {
 
   // Abort communicators after all threads have exited to avoid having the
   // threads dying due to aborted communicator and raising a SIGABRT
-  std::string abortReason =
-      c10::str("Process Group destroyed on rank ", rank_);
+  std::string abortReason = c10::str("Process Group destroyed on rank ", rank_);
   abort(abortReason);
 }
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -497,6 +497,8 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // instead of relying on ProcessGroupNCCL destructor.
   void abort(c10::optional<std::string> abortReason = c10::nullopt);
 
+  void close();
+
  protected:
   // Helper that broadcasts nccl unique ID to all ranks through the store
   void broadcastUniqueNCCLID(

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -497,7 +497,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // instead of relying on ProcessGroupNCCL destructor.
   void abort(c10::optional<std::string> abortReason = c10::nullopt);
 
-  void close();
+  void shutdown();
 
  protected:
   // Helper that broadcasts nccl unique ID to all ranks through the store

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -2246,6 +2246,12 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
               },
               py::arg("abort_reason") = py::none(),
               py::call_guard<py::gil_scoped_release>())
+          .def(
+              "_close",
+              [](const c10::intrusive_ptr<::c10d::ProcessGroupNCCL>& self) {
+                return self->close();
+              },
+              py::call_guard<py::gil_scoped_release>())
           .def("_group_start", &::c10d::ProcessGroupNCCL::groupStart)
           .def("_group_end", &::c10d::ProcessGroupNCCL::groupEnd)
           .def_property_readonly(

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -2239,17 +2239,9 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
               py::arg("timeout") = ::c10d::kProcessGroupNCCLDefaultTimeout,
               py::call_guard<py::gil_scoped_release>())
           .def(
-              "_abort",
-              [](const c10::intrusive_ptr<::c10d::ProcessGroupNCCL>& self,
-                 const c10::optional<std::string>& abortReason) {
-                return self->abort(abortReason);
-              },
-              py::arg("abort_reason") = py::none(),
-              py::call_guard<py::gil_scoped_release>())
-          .def(
-              "_close",
+              "_shutdown",
               [](const c10::intrusive_ptr<::c10d::ProcessGroupNCCL>& self) {
-                return self->close();
+                return self->shutdown();
               },
               py::call_guard<py::gil_scoped_release>())
           .def("_group_start", &::c10d::ProcessGroupNCCL::groupStart)

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -9771,7 +9771,7 @@ class DistributedTest:
             def abort(device):
                 pg = _get_default_group()
                 while running:
-                    pg._get_backend(torch.device(device))._abort()
+                    pg._get_backend(torch.device(device))._shutdown()
                     time.sleep(1)
 
             if self.rank != 1:


### PR DESCRIPTION
Currently, the only way ProcessGroupNCCL shuts down its background threads and aborts all communicators is via the destructor.

However, given how python GC works and code holding references to the PG in multiple places, in practice calling `destroy_process_group` doesn't actually end up invoking the destructor.

As a result, in this PR I'm adding a explicit shutdown method to that users can call to cleanup all resources.