### PR TITLE
Add ciflow/rocm label to run ROCm jobs

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -10,6 +10,7 @@ ciflow_push_tags:
 - ciflow/mps
 - ciflow/nightly
 - ciflow/periodic
+- ciflow/rocm
 - ciflow/slow
 - ciflow/trunk
 - ciflow/unstable

--- a/.github/workflows/rocm.yml
+++ b/.github/workflows/rocm.yml
@@ -1,0 +1,40 @@
+name: rocm
+
+on:
+  push:
+    branches:
+      - main
+      - release/*
+    tags:
+      - ciflow/rocm/*
+  workflow_dispatch:
+  schedule:
+    - cron: 29 8 * * *  # about 1:29am PDT
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
+  cancel-in-progress: true
+
+jobs:
+  linux-focal-rocm5_6-py3_8-build:
+    name: linux-focal-rocm5.6-py3.8
+    uses: ./.github/workflows/_linux-build.yml
+    with:
+      build-environment: linux-focal-rocm5.6-py3.8
+      docker-image-name: pytorch-linux-focal-rocm-n-py3
+      sync-tag: rocm-build
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 3, runner: "linux.rocm.gpu" },
+          { config: "default", shard: 2, num_shards: 3, runner: "linux.rocm.gpu" },
+          { config: "default", shard: 3, num_shards: 3, runner: "linux.rocm.gpu" },
+        ]}
+
+  linux-focal-rocm5_6-py3_8-test:
+    name: linux-focal-rocm5.6-py3.8
+    uses: ./.github/workflows/_rocm-test.yml
+    needs: linux-focal-rocm5_6-py3_8-build
+    with:
+      build-environment: linux-focal-rocm5.6-py3.8
+      docker-image: ${{ needs.linux-focal-rocm5_6-py3_8-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-rocm5_6-py3_8-build.outputs.test-matrix }}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -174,26 +174,3 @@ jobs:
           { config: "default", shard: 6, num_shards: 6, runner: "windows.g5.4xlarge.nvidia.gpu" },
           { config: "force_on_cpu", shard: 1, num_shards: 1, runner: "windows.4xlarge.nonephemeral" },
         ]}
-
-  linux-focal-rocm5_6-py3_8-build:
-    name: linux-focal-rocm5.6-py3.8
-    uses: ./.github/workflows/_linux-build.yml
-    with:
-      build-environment: linux-focal-rocm5.6-py3.8
-      docker-image-name: pytorch-linux-focal-rocm-n-py3
-      sync-tag: rocm-build
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 3, runner: "linux.rocm.gpu" },
-          { config: "default", shard: 2, num_shards: 3, runner: "linux.rocm.gpu" },
-          { config: "default", shard: 3, num_shards: 3, runner: "linux.rocm.gpu" },
-        ]}
-
-  linux-focal-rocm5_6-py3_8-test:
-    name: linux-focal-rocm5.6-py3.8
-    uses: ./.github/workflows/_rocm-test.yml
-    needs: linux-focal-rocm5_6-py3_8-build
-    with:
-      build-environment: linux-focal-rocm5.6-py3.8
-      docker-image: ${{ needs.linux-focal-rocm5_6-py3_8-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-rocm5_6-py3_8-build.outputs.test-matrix }}


### PR DESCRIPTION
Fixes https://github.com/pytorch/test-infra/issues/4516.  As this is not part of trunk, it won't block regular merge.  On the other hand, we can still add `ciflow/rocm` to run it on PR.

~~I'll add an auto label rule for this after this is merged and the label becomes available~~ Here it is https://github.com/pytorch/test-infra/pull/4647

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang