### PR TITLE
[HigherOrderOp] Move map_impl to torch.ops.higher_order

### DIFF
--- a/functorch/experimental/_map.py
+++ b/functorch/experimental/_map.py
@@ -35,7 +35,7 @@ class MapWrapper(HigherOrderOperator):
 
 
 map = MapWrapper("map", _deprecated_global_ns=True)
-map_impl = HigherOrderOperator("map_impl", _deprecated_global_ns=True)
+map_impl = HigherOrderOperator("map_impl")
 
 dummy_aot_config = AOTConfig(
     fw_compiler=None,

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -257,7 +257,7 @@ class TestDeserialize(TestCase):
                         false_graph1 = getattr(gm1, node1.args[2].target)
                         false_graph2 = getattr(gm2, node2.args[2].target)
                         _check_graph_nodes(false_graph1, false_graph2)
-                    elif node1.target == torch.ops.map_impl:
+                    elif node1.target == torch.ops.higher_order.map_impl:
                         map_graph1 = getattr(gm1, node1.args[0].target)
                         map_graph2 = getattr(gm2, node2.args[0].target)
                         _check_graph_nodes(map_graph1, map_graph2, False)

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -885,7 +885,7 @@ def forward(self, arg0_1):
         i = 0
         for m in gm.modules():
             for node in m.graph.nodes:
-                if node.op == "call_function" and node.target == torch.ops.map_impl:
+                if node.op == "call_function" and node.target == torch.ops.higher_order.map_impl:
                     i += 1
         self.assertEqual(i, op_count)
 
@@ -1041,7 +1041,7 @@ def forward(self, arg0_1):
             c = 0
             for node in gm.graph.nodes:
                 if node.op == "call_function":
-                    if node.target == torch.ops.map_impl:
+                    if node.target == torch.ops.higher_order.map_impl:
                         c += count_mutable(getattr(gm, str(node.args[0])))
                     elif schema := getattr(node.target, "_schema", None):
                         c += int(schema.is_mutable)
@@ -1446,7 +1446,8 @@ def forward(self, arg0_1, arg1_1, arg2_1):
         self.assertExpectedInline(gm.code.strip(), """\
 def forward(self, pred_1, x_1):
     body_graph_0 = self.body_graph_0
-    map_impl = torch.ops.map_impl(body_graph_0, 1, x_1, pred_1);  body_graph_0 = x_1 = pred_1 = None
+    map_impl = torch.ops.higher_order.map_impl(body_graph_0, 1, x_1, pred_1);\
+  body_graph_0 = x_1 = pred_1 = None
     getitem = map_impl[0];  map_impl = None
     return getitem""")
         self.assertExpectedInline(gm.body_graph_0.code.strip(), """\


### PR DESCRIPTION
The purpose of this pr is as titled. Because of some misusage of ghstack, ghimport, and export to github from internal, the stack of https://github.com/pytorch/pytorch/pull/111092 is a mess. I'll try to land them one by one. This is a replacement for #111092 and #111400.


cc @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan @angelayi