### PR TITLE
[2/N] Apply clang-tidy to c10 CUDA files

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -259,7 +259,6 @@ exclude_patterns = [
     '**/fb/**',
     '**/*pb.h',
     '**/*CUDA*',
-    '**/cuda/*pp',
     'third_party/**/*',
     'torch/csrc/api/**',
     'torch/csrc/autograd/functions/**',


### PR DESCRIPTION
Finally we are able to cover all c10 CUDA files.