### PR TITLE
[WIP] refactor: renamed `_prefetched` to better suit its new role

### DIFF
--- a/torch/distributed/fsdp/_flat_param.py
+++ b/torch/distributed/fsdp/_flat_param.py
@@ -522,8 +522,9 @@ class FlatParamHandle:
         self._needs_pre_forward_unshard = False
         # Used for guarding against mistargeted backward prefetches
         self._needs_pre_backward_unshard = False
-        # Was the handle prefetched? Set on successful _prefetch_handle and unshard
-        self._prefetched = False
+        # Has the handle been unsharded? Set by `_unshard` and cleared by
+        # `_reshard`
+        self._unsharded = False
         # Optimistically assume a valid input `params` and set dtype attributes
         # before `_init_flat_param()`, which performs the actual validation
         self._orig_param_dtype = params[0].dtype

--- a/torch/distributed/fsdp/_unshard_param_utils.py
+++ b/torch/distributed/fsdp/_unshard_param_utils.py
@@ -18,8 +18,8 @@ from torch.distributed.fsdp._runtime_utils import (
     _reset_flat_param_grad_info_if_needed,
     _reshard,
     _reshard_grads,
-    _unshard,
     _unshard_grads,
+    _unshard_if_not_yet,
 )
 from torch.distributed.utils import _p_assert
 
@@ -193,7 +193,7 @@ def _unshard_fsdp_state_params(
     # No need to call `wait_stream()` since we unshard in the computation
     # stream directly
     computation_stream = state._device_handle.current_stream()
-    _unshard(state, handle, computation_stream, computation_stream)
+    _unshard_if_not_yet(state, handle, computation_stream, computation_stream)
     if with_grads:
         _unshard_grads(handle)
 


### PR DESCRIPTION
As discussed in #111354 , meaning of `_prefetched` has slowly changed. This PR renamed it to better suit its new role.

I also moved all mutations to `_unsharded` into `unshard_if_not_yet` and `reshard`, this should make our life easier regarding managing the flag and reasoning about the code.