### PR TITLE
[AOTInductor] ProxyExecutor skips serializing missing args with default value

### DIFF
--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -444,7 +444,7 @@ class GraphModuleSerializer:
         return serialized_args
 
     def serialize_inputs(
-        self, target: torch._ops.OpOverload, args, kwargs=None
+        self, target: torch._ops.OpOverload, args, kwargs=None, include_default_values=True
     ) -> List[NamedArgument]:
         assert isinstance(target, torch._ops.OpOverload)
         kwargs = kwargs or {}
@@ -465,12 +465,13 @@ class GraphModuleSerializer:
                     )
                 )
             else:
-                serialized_args.append(
-                    NamedArgument(
-                        name=schema_arg.name,
-                        arg=self.serialize_input(schema_arg.default_value),
+                if include_default_values:
+                    serialized_args.append(
+                        NamedArgument(
+                            name=schema_arg.name,
+                            arg=self.serialize_input(schema_arg.default_value),
+                        )
                     )
-                )
 
         return serialized_args
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3954,7 +3954,11 @@ class FallbackKernel(ExternKernelAlloc):
         tensor_args = [Shim(x.codegen_reference()) for x in self.inputs]
         args, kwargs = self.unflatten_args(tensor_args, self.constant_args)
         args = [V.graph.wrapper_code.val_to_arg_str(x) for x in args]
-        if V.graph.cpp_wrapper and hasattr(self, "args_default_value"):
+        if (
+            V.graph.cpp_wrapper
+            and hasattr(self, "args_default_value")
+            and not config.is_fbcode()
+        ):
             n_args = len(args)
             n_pos_args = len(self.args_default_value)
             # Some positional args are not provided, need to use their default value in cpp wrapper
@@ -4013,7 +4017,9 @@ class FallbackKernel(ExternKernelAlloc):
         ]
 
         serializer = GraphModuleSerializer(None, None)
-        named_arguments = serializer.serialize_inputs(self.op_overload, args, kwargs)
+        named_arguments = serializer.serialize_inputs(
+            self.op_overload, args, kwargs, include_default_values=False
+        )
 
         # serialize_outputs
         def handle_single_output(return_type, output):


### PR DESCRIPTION
Summary: In AOTInductor ABI Compatible-mode, we don't serialize missing args with default value.

Test Plan: buck2 run mode/dev-nosan deeplearning/aot_inductor/test:test_custom_ops

Differential Revision: D50345729




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan