### PR TITLE
[ProcessGroupNCCL] Avoid recording stream for synchronous ops

### DIFF
--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -295,7 +295,7 @@ ALLOW_LIST = [
      datetime.date(9999, 1, 1)),
     ("mkldnn::_convolution_pointwise_.binary", datetime.date(2023, 7, 1)),
     ("c10d::allreduce_", datetime.date(2023, 7, 30)),
-    ("c10d::_all_gather_base_", datetime.date(2023, 12, 30)),
+    ("c10d::_allgather_base_", datetime.date(2023, 12, 30)),
     ("c10d::_reduce_scatter_base_", datetime.date(2023, 12, 30)),
     # These ops were moved to python under the c10d_functional namespace
     ("aten::wait_tensor", datetime.date(9999, 1, 30)),

--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -294,8 +294,10 @@ ALLOW_LIST = [
     ("aten::_native_decoder_only_multi_head_attention",
      datetime.date(9999, 1, 1)),
     ("mkldnn::_convolution_pointwise_.binary", datetime.date(2023, 7, 1)),
-    # These ops were moved to python under the c10d_functional namespace
     ("c10d::allreduce_", datetime.date(2023, 7, 30)),
+    ("c10d::_all_gather_base_", datetime.date(2023, 12, 30)),
+    ("c10d::_reduce_scatter_base_", datetime.date(2023, 12, 30)),
+    # These ops were moved to python under the c10d_functional namespace
     ("aten::wait_tensor", datetime.date(9999, 1, 30)),
     ("aten::reduce_scatter_tensor", datetime.date(9999, 1, 30)),
     ("aten::all_gather_into_tensor", datetime.date(9999, 1, 30)),

--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -134,8 +134,9 @@ class ReduceOptions:
     rootTensor: int
     timeout: timedelta
 
-class AllGatherOptions:
+class AllgatherOptions:
     timeout: timedelta
+    asyncOp: bool
 
 class GatherOptions:
     rootRank: int
@@ -148,6 +149,7 @@ class ScatterOptions:
 class ReduceScatterOptions:
     reduceOp: ReduceOp
     timeout: timedelta
+    asyncOp: bool
 
 class BarrierOptions:
     device_ids: List[int]

--- a/torch/csrc/distributed/c10d/Ops.cpp
+++ b/torch/csrc/distributed/c10d/Ops.cpp
@@ -25,7 +25,7 @@ TORCH_LIBRARY(c10d, m) {
   m.def(
       "allgather_(Tensor[][] output_tensors, Tensor[] input_tensors, __torch__.torch.classes.c10d.ProcessGroup process_group, int timeout) -> (Tensor[][], __torch__.torch.classes.c10d.Work)");
   m.def(
-      "_allgather_base_(Tensor output_tensor, Tensor input_tensor, __torch__.torch.classes.c10d.ProcessGroup process_group) -> (Tensor, __torch__.torch.classes.c10d.Work)");
+      "_allgather_base_(Tensor output_tensor, Tensor input_tensor, __torch__.torch.classes.c10d.ProcessGroup process_group, bool asyncOp, int timeout) -> (Tensor, __torch__.torch.classes.c10d.Work)");
   m.def(
       "allgather_coalesced_(Tensor[][] output_lists, Tensor[] input_list, __torch__.torch.classes.c10d.ProcessGroup process_group) -> __torch__.torch.classes.c10d.Work");
   m.def(
@@ -33,7 +33,7 @@ TORCH_LIBRARY(c10d, m) {
   m.def(
       "reduce_scatter_(Tensor[] output_tensors, Tensor[][] input_tensors, __torch__.torch.classes.c10d.ProcessGroup process_group, __torch__.torch.classes.c10d.ReduceOp reduce_op, int timeout) -> (Tensor[], __torch__.torch.classes.c10d.Work)");
   m.def(
-      "_reduce_scatter_base_(Tensor output_tensor, Tensor input_tensor, __torch__.torch.classes.c10d.ProcessGroup process_group, __torch__.torch.classes.c10d.ReduceOp reduce_op, int timeout) -> (Tensor, __torch__.torch.classes.c10d.Work)");
+      "_reduce_scatter_base_(Tensor output_tensor, Tensor input_tensor, __torch__.torch.classes.c10d.ProcessGroup process_group, __torch__.torch.classes.c10d.ReduceOp reduce_op, bool asyncOp, int timeout) -> (Tensor, __torch__.torch.classes.c10d.Work)");
   m.def(
       "reduce_scatter_tensor_coalesced_(Tensor[] outputs, Tensor[] inputs, __torch__.torch.classes.c10d.ProcessGroup process_group, __torch__.torch.classes.c10d.ReduceOp reduce_op, int timeout) -> __torch__.torch.classes.c10d.Work");
   m.def(
@@ -231,9 +231,17 @@ IMPL_ALLGATHER(PrivateUse1)
   std::tuple<at::Tensor, c10::intrusive_ptr<Work>> _allgather_base_##DEV( \
       at::Tensor& output_tensor,                                          \
       at::Tensor& input_tensor,                                           \
-      const c10::intrusive_ptr<ProcessGroup>& process_group) {            \
+      const c10::intrusive_ptr<ProcessGroup>& process_group,              \
+      bool asyncOp,                                                       \
+      int64_t timeout) {                                                  \
     auto work = process_group->getBackend(c10::DeviceType::DEV)           \
-                    ->_allgather_base(output_tensor, input_tensor);       \
+                    ->_allgather_base(                                    \
+                        output_tensor,                                    \
+                        input_tensor,                                     \
+                        AllgatherOptions{                                 \
+                          std::chrono::milliseconds(timeout),             \
+                          asyncOp                                         \
+                        });                                               \
     return std::tuple<at::Tensor, c10::intrusive_ptr<Work>>(              \
         output_tensor, work);                                             \
   }
@@ -304,6 +312,7 @@ IMPL_REDUCE_SCATTER(PrivateUse1)
       at::Tensor& input_tensor,                                                \
       const c10::intrusive_ptr<ProcessGroup>& process_group,                   \
       const c10::intrusive_ptr<ReduceOp>& reduce_op,                           \
+      bool asyncOp,                                                            \
       int64_t timeout) {                                                       \
     auto work =                                                                \
         process_group->getBackend(c10::DeviceType::DEV)                        \
@@ -311,7 +320,10 @@ IMPL_REDUCE_SCATTER(PrivateUse1)
                 output_tensor,                                                 \
                 input_tensor,                                                  \
                 ReduceScatterOptions{                                          \
-                    *reduce_op.get(), std::chrono::milliseconds(timeout)});    \
+                  *reduce_op.get(),                                            \
+                  std::chrono::milliseconds(timeout),                          \
+                  asyncOp                                                      \
+                });                                                            \
     return std::tuple<at::Tensor, c10::intrusive_ptr<Work>>(                   \
         output_tensor, work);                                                  \
   }

--- a/torch/csrc/distributed/c10d/Ops.cpp
+++ b/torch/csrc/distributed/c10d/Ops.cpp
@@ -227,23 +227,21 @@ IMPL_ALLGATHER(CPU)
 IMPL_ALLGATHER(CUDA)
 IMPL_ALLGATHER(PrivateUse1)
 
-#define IMPL__ALLGATHER_BASE(DEV)                                         \
-  std::tuple<at::Tensor, c10::intrusive_ptr<Work>> _allgather_base_##DEV( \
-      at::Tensor& output_tensor,                                          \
-      at::Tensor& input_tensor,                                           \
-      const c10::intrusive_ptr<ProcessGroup>& process_group,              \
-      bool asyncOp,                                                       \
-      int64_t timeout) {                                                  \
-    auto work = process_group->getBackend(c10::DeviceType::DEV)           \
-                    ->_allgather_base(                                    \
-                        output_tensor,                                    \
-                        input_tensor,                                     \
-                        AllgatherOptions{                                 \
-                          std::chrono::milliseconds(timeout),             \
-                          asyncOp                                         \
-                        });                                               \
-    return std::tuple<at::Tensor, c10::intrusive_ptr<Work>>(              \
-        output_tensor, work);                                             \
+#define IMPL__ALLGATHER_BASE(DEV)                                          \
+  std::tuple<at::Tensor, c10::intrusive_ptr<Work>> _allgather_base_##DEV(  \
+      at::Tensor& output_tensor,                                           \
+      at::Tensor& input_tensor,                                            \
+      const c10::intrusive_ptr<ProcessGroup>& process_group,               \
+      bool asyncOp,                                                        \
+      int64_t timeout) {                                                   \
+    auto work = process_group->getBackend(c10::DeviceType::DEV)            \
+                    ->_allgather_base(                                     \
+                        output_tensor,                                     \
+                        input_tensor,                                      \
+                        AllgatherOptions{                                  \
+                            std::chrono::milliseconds(timeout), asyncOp}); \
+    return std::tuple<at::Tensor, c10::intrusive_ptr<Work>>(               \
+        output_tensor, work);                                              \
   }
 
 IMPL__ALLGATHER_BASE(CPU)
@@ -314,16 +312,14 @@ IMPL_REDUCE_SCATTER(PrivateUse1)
       const c10::intrusive_ptr<ReduceOp>& reduce_op,                           \
       bool asyncOp,                                                            \
       int64_t timeout) {                                                       \
-    auto work =                                                                \
-        process_group->getBackend(c10::DeviceType::DEV)                        \
-            ->_reduce_scatter_base(                                            \
-                output_tensor,                                                 \
-                input_tensor,                                                  \
-                ReduceScatterOptions{                                          \
-                  *reduce_op.get(),                                            \
-                  std::chrono::milliseconds(timeout),                          \
-                  asyncOp                                                      \
-                });                                                            \
+    auto work = process_group->getBackend(c10::DeviceType::DEV)                \
+                    ->_reduce_scatter_base(                                    \
+                        output_tensor,                                         \
+                        input_tensor,                                          \
+                        ReduceScatterOptions{                                  \
+                            *reduce_op.get(),                                  \
+                            std::chrono::milliseconds(timeout),                \
+                            asyncOp});                                         \
     return std::tuple<at::Tensor, c10::intrusive_ptr<Work>>(                   \
         output_tensor, work);                                                  \
   }

--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -247,12 +247,16 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
             .typed<std::tuple<at::Tensor, c10::intrusive_ptr<Work>>(
                 at::Tensor&,
                 at::Tensor&,
-                const c10::intrusive_ptr<::c10d::ProcessGroup>&)>();
+                const c10::intrusive_ptr<::c10d::ProcessGroup>&,
+                bool,
+                int64_t)>();
 
     return std::get<1>(op.call(
         outputBuffer,
         inputBuffer,
-        c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this)));
+        c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this),
+        opts.asyncOp,
+        opts.timeout.count()));
   }
 
   // This function is deprecated and will be moved out of ProcessGroup to comms:
@@ -374,12 +378,14 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
                 at::Tensor&,
                 const c10::intrusive_ptr<::c10d::ProcessGroup>&,
                 const c10::intrusive_ptr<::c10d::ReduceOp>&,
+                bool,
                 int64_t)>();
     return std::get<1>(op.call(
         outputBuffer,
         inputBuffer,
         c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this),
         c10::make_intrusive<::c10d::ReduceOp>(opts.reduceOp),
+        opts.asyncOp,
         opts.timeout.count()));
   }
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -2735,6 +2735,16 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::_reduce_scatter_base(
 
   int dev_in_group = 0;
   // avoidRecordStreams_ note: collective() will stash inputs and outputs.
+  // Note 2: for asyncOp = false, we don't want to record streams because we
+  // know that the NCCL stream will join back to the "current" stream right
+  // after this op. So we might just as well keep the stream ownership of the
+  // input/output tensors unchanged. The benefit would be that the
+  // allocation/free of the tensors would look deterministic to the "current"
+  // stream so that the caching allocator can reuse memory pool for this stream
+  // in a clever way. This setting is added for libraries like FSDP which uses
+  // `reduce_scatter_tensor`.
+  bool avoidRecordStreams = avoidRecordStreams_ || (!opts.asyncOp);
+
   return collective(
       inputs,
       outputs,
@@ -2742,7 +2752,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::_reduce_scatter_base(
           at::Tensor& output,
           ncclComm_t comm,
           at::cuda::CUDAStream& stream) {
-        if (!avoidRecordStreams_) {
+        if (!avoidRecordStreams) {
           c10::cuda::CUDACachingAllocator::recordStream(
               output.storage().data_ptr(), stream);
         }
@@ -3312,7 +3322,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::recvAnysource(
 c10::intrusive_ptr<Work> ProcessGroupNCCL::_allgather_base(
     at::Tensor& output_tensor,
     at::Tensor& input_tensor,
-    const AllgatherOptions& /*unused */) {
+    const AllgatherOptions& opts) {
   check_gpu_single_tensor(input_tensor);
   check_gpu_single_tensor(output_tensor);
 
@@ -3331,6 +3341,16 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::_allgather_base(
   auto outputs = std::vector<at::Tensor>{output_tensor};
 
   // avoidRecordStreams_ note: collective() will stash inputs and outputs.
+  // Note 2: for asyncOp = false, we don't want to record streams because we
+  // know that the NCCL stream will join back to the "current" stream right
+  // after this op. So we might just as well keep the stream ownership of the
+  // input/output tensors unchanged. The benefit would be that the
+  // allocation/free of the tensors would look deterministic to the "current"
+  // stream so that the caching allocator can reuse memory pool for this stream
+  // in a clever way. This setting is added for libraries like FSDP which uses
+  // `all_gather_into_tensor`.
+  bool avoidRecordStreams = avoidRecordStreams_ || (!opts.asyncOp);
+
   return collective(
       inputs,
       outputs,
@@ -3338,7 +3358,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::_allgather_base(
           at::Tensor& output,
           ncclComm_t comm,
           at::cuda::CUDAStream& stream) {
-        if (!avoidRecordStreams_) {
+        if (!avoidRecordStreams) {
           c10::cuda::CUDACachingAllocator::recordStream(
               output.storage().data_ptr(), stream);
         }

--- a/torch/csrc/distributed/c10d/Types.hpp
+++ b/torch/csrc/distributed/c10d/Types.hpp
@@ -137,6 +137,7 @@ struct ReduceOptions {
 
 struct AllgatherOptions {
   std::chrono::milliseconds timeout = kUnsetTimeout;
+  bool asyncOp = true;
 };
 
 struct GatherOptions {
@@ -152,6 +153,7 @@ struct ScatterOptions {
 struct ReduceScatterOptions {
   ReduceOp reduceOp = ReduceOp::SUM;
   std::chrono::milliseconds timeout = kUnsetTimeout;
+  bool asyncOp = true;
 };
 
 struct AllToAllOptions {

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -861,7 +861,8 @@ This class does not support ``__members__`` property.)");
 
   py::class_<::c10d::AllgatherOptions>(module, "AllgatherOptions")
       .def(py::init<>())
-      .def_readwrite("timeout", &::c10d::AllgatherOptions::timeout);
+      .def_readwrite("timeout", &::c10d::AllgatherOptions::timeout)
+      .def_readwrite("asyncOp", &::c10d::AllgatherOptions::asyncOp);
 
   py::class_<::c10d::GatherOptions>(module, "GatherOptions")
       .def(py::init<>())
@@ -876,7 +877,8 @@ This class does not support ``__members__`` property.)");
   py::class_<::c10d::ReduceScatterOptions>(module, "ReduceScatterOptions")
       .def(py::init<>())
       .def_readwrite("reduceOp", &::c10d::ReduceScatterOptions::reduceOp)
-      .def_readwrite("timeout", &::c10d::ReduceScatterOptions::timeout);
+      .def_readwrite("timeout", &::c10d::ReduceScatterOptions::timeout)
+      .def_readwrite("asyncOp", &::c10d::ReduceScatterOptions::asyncOp);
 
   py::class_<::c10d::BarrierOptions>(module, "BarrierOptions")
       .def(py::init<>())

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -14,6 +14,7 @@ from typing import Any, Callable, Dict, Optional, Tuple, Union, List
 
 import torch
 from torch._C._distributed_c10d import (
+    AllgatherOptions,
     AllreduceCoalescedOptions,
     AllreduceOptions,
     AllToAllOptions,
@@ -2916,6 +2917,9 @@ def all_gather_into_tensor(output_tensor, input_tensor, group=None, async_op=Fal
         else torch.view_as_real(input_tensor)
     )
 
+    opts = AllgatherOptions()
+    opts.asyncOp = async_op
+
     group = group or _get_default_group()
 
     if group in _world.pg_coalesce_state.keys():
@@ -2927,7 +2931,7 @@ def all_gather_into_tensor(output_tensor, input_tensor, group=None, async_op=Fal
         else:
             return None
 
-    work = group._allgather_base(output_tensor, input_tensor)
+    work = group._allgather_base(output_tensor, input_tensor, opts)
 
     if async_op:
         return work
@@ -3392,6 +3396,7 @@ def reduce_scatter_tensor(output, input, op=ReduceOp.SUM, group=None, async_op=F
 
     opts = ReduceScatterOptions()
     opts.reduceOp = op
+    opts.asyncOp = async_op
 
     group = group or _get_default_group()
 


### PR DESCRIPTION
For synchronous ops (i.e. `asyncOp = False`), we don't want to record streams because we know that the NCCL stream will join back to the "current" stream right after this op. So we might just as well keep the stream ownership of the input/output tensors unchanged (i.e. not telling the caching allocator there is a stream-stream hand off). The benefit would be that the allocation/free of the tensors would look deterministic to the "current" stream so that the caching allocator can reuse memory pool for this stream in a clever way. 

To prevent the input/output tensors from being recycled by python, we rely on the stashing mechanism in ProcessGroupNCCL (which can be also turned on by setting `TORCH_NCCL_AVOID_RECORD_STREAMS=1`).

This mechanism change is for libraries like FSDP which uses `all_gather_into_tensor` and `reduce_scatter_tensor` in a synchronous way and which cannot set `TORCH_NCCL_AVOID_RECORD_STREAMS=1` for their users. And therefore, this change is limited to these two collectives for now.

Cc: @awgu @janeyx99 @albanD 