### PR TITLE
[3/N] Merge skipfiles.check rules

### DIFF
--- a/test/dynamo/test_allow_inline_skip.py
+++ b/test/dynamo/test_allow_inline_skip.py
@@ -6,9 +6,9 @@ import unittest
 import torch
 import torch._dynamo.test_case
 from torch._dynamo.skipfiles import (
-    FILE_INLINELIST,
+    ALWAYS_MOD_INLINELIST,
     FUNC_INLINELIST,
-    SUBMODULE_INLINELIST,
+    MOD_INLINELIST,
 )
 from torch._dynamo.utils import istype
 
@@ -36,7 +36,7 @@ class AllowInlineSkipTests(torch._dynamo.test_case.TestCase):
     # this unit test is to make sure the functions/modules can be correctly imported
     # or loaded in case there is typo in the strings.
     def test_skipfiles_inlinelist_correctness(self):
-        for m in FILE_INLINELIST.union(SUBMODULE_INLINELIST):
+        for m in ALWAYS_MOD_INLINELIST.union(MOD_INLINELIST):
             self.assertTrue(isinstance(importlib.import_module(m), types.ModuleType))
         for f in FUNC_INLINELIST:
             module_name, fn_name = f.rsplit(".", 1)
@@ -54,11 +54,9 @@ class AllowInlineSkipTests(torch._dynamo.test_case.TestCase):
         func_inlinelist.add("torch._dynamo.utils.istype")
 
         self.assertTrue(
-            "torch._dynamo.utils" not in torch._dynamo.skipfiles.FILE_INLINELIST
+            "torch._dynamo" not in torch._dynamo.skipfiles.ALWAYS_MOD_INLINELIST
         )
-        self.assertTrue(
-            "torch._dynamo" not in torch._dynamo.skipfiles.SUBMODULE_INLINELIST
-        )
+        self.assertTrue("torch._dynamo" not in torch._dynamo.skipfiles.MOD_INLINELIST)
 
         with unittest.mock.patch(
             "torch._dynamo.skipfiles.get_func_inlinelist",

--- a/test/dynamo/test_allow_inline_skip.py
+++ b/test/dynamo/test_allow_inline_skip.py
@@ -6,7 +6,7 @@ import unittest
 import torch
 import torch._dynamo.test_case
 from torch._dynamo.skipfiles import (
-    ALWAYS_MOD_INLINELIST,
+    LEGACY_MOD_INLINELIST,
     FUNC_INLINELIST,
     MOD_INLINELIST,
 )
@@ -36,7 +36,7 @@ class AllowInlineSkipTests(torch._dynamo.test_case.TestCase):
     # this unit test is to make sure the functions/modules can be correctly imported
     # or loaded in case there is typo in the strings.
     def test_skipfiles_inlinelist_correctness(self):
-        for m in ALWAYS_MOD_INLINELIST.union(MOD_INLINELIST):
+        for m in LEGACY_MOD_INLINELIST.union(MOD_INLINELIST):
             self.assertTrue(isinstance(importlib.import_module(m), types.ModuleType))
         for f in FUNC_INLINELIST:
             module_name, fn_name = f.rsplit(".", 1)
@@ -54,7 +54,7 @@ class AllowInlineSkipTests(torch._dynamo.test_case.TestCase):
         func_inlinelist.add("torch._dynamo.utils.istype")
 
         self.assertTrue(
-            "torch._dynamo" not in torch._dynamo.skipfiles.ALWAYS_MOD_INLINELIST
+            "torch._dynamo" not in torch._dynamo.skipfiles.LEGACY_MOD_INLINELIST
         )
         self.assertTrue("torch._dynamo" not in torch._dynamo.skipfiles.MOD_INLINELIST)
 

--- a/test/dynamo/test_allow_inline_skip.py
+++ b/test/dynamo/test_allow_inline_skip.py
@@ -6,8 +6,8 @@ import unittest
 import torch
 import torch._dynamo.test_case
 from torch._dynamo.skipfiles import (
-    LEGACY_MOD_INLINELIST,
     FUNC_INLINELIST,
+    LEGACY_MOD_INLINELIST,
     MOD_INLINELIST,
 )
 from torch._dynamo.utils import istype

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -193,7 +193,6 @@ FILE_INLINELIST = {
     "torch.utils._content_store",
     "torch.utils._contextlib",
     "torch.utils._foreach_utils",
-    "torch.utils._pytree",
 }
 
 

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -64,10 +64,10 @@ Dynamo skip/inline rules & priorities are defined as follows:
     * BUILTIN_SKIPLIST contains builtin python modules, such as abc, collections, etc.
     * THIRDPARTY_SKIPLIST contains common third party libraries, such as numpy, pandas, etc.
 * Functions in these two SKIPLISTs are always skipped, except when they are explicitly
-    put into the three INLINELIST: FUNC_INLINELIST, FILE_INLINELIST and SUBMODULE_INLINELIST.
+    put into the two INLINELIST: FUNC_INLINELIST and MOD_INLINELIST.
 * PyTorch(torch) is in the BUILTIN_SKIPLIST by default, but there are many cases
     where we want inline the functions under torch namespace. We should add them
-    into one of the three *_INLINELIST to make dynamo inline those functions.
+    into one of the two *_INLINELIST to make dynamo inline those functions.
 * If you call functions under skipped modules/files, Dynamo will wrap these functions
     as SkipFilesVariable. There are a few functions(e.g, collections.OrderedDict) that
     we have special handling at SkipFilesVariable.call_function.
@@ -76,17 +76,14 @@ Overall: *_INLINELIST has precedence over *_SKIPLIST has precedence over DEFAULT
 
 To figure out what the behavior is, check the following list in order:
 * FUNC_INLINELIST (Inline if YES)
-* FILE_INLINELIST (Inline if YES)
-* SUBMODULE_INLINELIST (Inline if YES)
+* MOD_INLINELIST (Inline if YES)
 * BUILTIN_SKIPLIST & THIRDPARTY_SKIPLIST (Skip if YES)
 * Inline by default
 
 In general, if you want to force inline a function or module, please consider adding
-the function's file or python module to FILE_INLINELIST first.
-Use the FUNC_INLINELIST only when there are other functions under the same file that
-you don't want to inline.
-In the future, we will consolidate FILE_INLINELIST and SUBMODULE_INLINELIST into one list
-as we use the same logic (filename.startswith) to determine if a file or module is skipped.
+the function's python module to MOD_INLINELIST first.
+Use the FUNC_INLINELIST only when there are other functions under the same module that
+you don't want to inline them.
 """
 
 
@@ -114,7 +111,7 @@ BUILTIN_SKIPLIST = (
     tempfile,
     threading,
     tokenize,
-    torch,  # torch/* is skipped by default unless specified in FILE_INLINELIST or SUBMODULE_INLINELIST
+    torch,  # torch/* is skipped by default unless specified in FUNC_INLINELIST or MOD_INLINELIST
     traceback,
     types,
     typing,
@@ -165,14 +162,15 @@ FUNC_INLINELIST = {
 }
 
 
-# Force inline functions in these files or directories, even they are in *_SKIPLIST.
+# Force inline functions under these modules, even they are in *_SKIPLIST.
 # We are using python module name instead of file or directory object to avoid circular dependency.
 # Please keep this sorted alphabetically.
-# TODO: Merge FILE_INLINELIST into SUBMODULE_INLINELIST.
-FILE_INLINELIST = {
+MOD_INLINELIST = {
+    "torch._refs",
+    "torch._prims",
+    "torch._decomp",
     "torch._dynamo._trace_wrapped_higher_order_op",
     "torch._dynamo.comptime",
-    "torch._dynamo.external_utils",
     "torch._dynamo.polyfill",
     "torch._export.db.examples",
     "torch._export.wrappers",
@@ -180,6 +178,7 @@ FILE_INLINELIST = {
     "torch._functorch.deprecated",
     "torch._higher_order_ops.cond",
     "torch._inductor.test_operators",
+    "torch.ao.nn",
     "torch.ao.quantization.pt2e.eval_utils",
     "torch.ao.quantization.pt2e.qat_utils",
     "torch.ao.quantization.pt2e.representation.rewrite",
@@ -187,50 +186,26 @@ FILE_INLINELIST = {
     "torch.ao.quantization.quantizer.xnnpack_quantizer",
     "torch.distributions",
     "torch.fx._pytree",
-    "torch.nn.modules.container",
+    "torch.nn",
     "torch.optim._functional",
     "torch.random",
+    "torch.sparse",
+    "torch.testing",
     "torch.utils._content_store",
     "torch.utils._contextlib",
     "torch.utils._foreach_utils",
-}
-
-
-if torch.distributed.is_available():
-    FILE_INLINELIST |= {
-        "torch.distributed._tensor.api",
-        "torch.distributed._tensor.device_mesh",
-        "torch.distributed.algorithms._checkpoint.checkpoint_wrapper",
-        "torch.distributed.tensor.parallel._data_parallel_utils",
-        "torch.distributed.tensor.parallel._utils",
-        "torch.distributed.tensor.parallel.style",
-    }
-
-# Include optimizer code for tracing
-FILE_INLINELIST |= {
-    str(obj.__module__) for obj in torch.optim.__dict__.values() if inspect.isclass(obj)
-}
-
-# TODO: consolidate SUBMODULE_INLINELIST and FILE_INLINELIST into one list
-# Force inline functions under these modules, even the modules is in *_SKIPLIST.
-SUBMODULE_INLINELIST = {
-    "torch._refs",
-    "torch._prims",
-    "torch._decomp",
-    "torch.ao.nn",
-    "torch.distributions",
-    "torch.fx._pytree",
-    "torch.nn",
-    "torch.sparse",
-    "torch.testing",
-    "torch.utils._contextlib",
     "torch.utils._pytree",
 }
 
 
 if torch.distributed.is_available():
-    SUBMODULE_INLINELIST.add("torch.distributed")
-    SUBMODULE_INLINELIST.add("torch.distributed._functional_collectives")
+    MOD_INLINELIST.add("torch.distributed")
+
+
+# Include optimizer code for tracing
+MOD_INLINELIST |= {
+    str(obj.__module__) for obj in torch.optim.__dict__.values() if inspect.isclass(obj)
+}
 
 
 # TODO: support adding bound method into this list
@@ -246,17 +221,14 @@ def get_func_inlinelist():
 
 
 @functools.lru_cache(None)
-def get_file_inlinelist():
-    inlinelist = set()
-    for f in FILE_INLINELIST:
-        inlinelist.add(_module_dir(torch) + f[len("torch.") :].replace(".", "/"))
-    return inlinelist
+def get_external_utils_filename():
+    return _module_dir(torch) + "_dynamo/external_utils.py"
 
 
 @functools.lru_cache(None)
-def get_submodule_inlinelist():
+def get_mod_inlinelist():
     inlinelist = set()
-    for m in SUBMODULE_INLINELIST:
+    for m in MOD_INLINELIST:
         inlinelist.add(_module_dir(torch) + m[len("torch.") :].replace(".", "/"))
     return inlinelist
 
@@ -310,15 +282,15 @@ def check_file(filename, allow_torch=False):
     """Should skip this file?"""
     if filename is None:
         return SkipResult(True, "filename is None")
-    if any(filename.startswith(d) for d in get_file_inlinelist()):
+    if filename == get_external_utils_filename():
         return SkipResult(
             False,
-            "inlined according skipfiles.FILE_INLINELIST",
+            "inlined according torch._dynamo.external_utils",
         )
     if allow_torch and is_torch_inline_allowed(filename):
         return SkipResult(
             False,
-            "inlined according skipfiles.SUBMODULE_INLINELIST",
+            "inlined according skipfiles.MOD_INLINELIST",
         )
     if is_fbcode and bool(FBCODE_SKIP_DIRS_RE.match(filename)):
         return SkipResult(
@@ -356,6 +328,9 @@ There are mainly three call sites of check/check_verbose:
     * If f2 is skipped by Dynamo, when evaluating the frame of f3, Dynamo need the inline/skip check again
       and the call site is in catch_errors_wrapper.catch_errors of eval_frame.py.
 * For global variables and function arguments, Dynamo needs to decide if they are wrapped as SkipFilesVariable in builder.py.
+
+allow_torch is used to indicate whether we are checking the MOD_INLINELIST (torch modules), we only do this check when
+f2 is not skipped.
 """
 
 
@@ -392,7 +367,7 @@ _recompile_re()
 
 
 def is_torch_inline_allowed(filename):
-    return any(filename.startswith(d) for d in get_submodule_inlinelist())
+    return any(filename.startswith(d) for d in get_mod_inlinelist())
 
 
 @functools.lru_cache(None)

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -161,8 +161,13 @@ FUNC_INLINELIST = {
     "torch._constrain_as_value",
 }
 
-ALWAYS_MOD_INLINELIST = {
+LEGACY_MOD_INLINELIST = {
     "torch._dynamo.external_utils",
+    "torch._export.db.examples",
+    "torch._export.wrappers",
+    "torch._functorch.apis",
+    "torch._functorch.deprecated",
+    "torch._higher_order_ops.cond",
     "torch.ao.quantization.pt2e.eval_utils",
     "torch.ao.quantization.pt2e.qat_utils",
     "torch.ao.quantization.pt2e.representation.rewrite",
@@ -172,7 +177,7 @@ ALWAYS_MOD_INLINELIST = {
 }
 
 if torch.distributed.is_available():
-    ALWAYS_MOD_INLINELIST |= {
+    LEGACY_MOD_INLINELIST |= {
         "torch.distributed._tensor.api",
         "torch.distributed._tensor.device_mesh",
         "torch.distributed.algorithms._checkpoint.checkpoint_wrapper",
@@ -192,11 +197,6 @@ MOD_INLINELIST = {
     "torch._dynamo._trace_wrapped_higher_order_op",
     "torch._dynamo.comptime",
     "torch._dynamo.polyfill",
-    "torch._export.db.examples",
-    "torch._export.wrappers",
-    "torch._functorch.apis",
-    "torch._functorch.deprecated",
-    "torch._higher_order_ops.cond",
     "torch._inductor.test_operators",
     "torch.ao.nn",
     "torch.distributions",
@@ -230,9 +230,9 @@ def get_func_inlinelist():
 
 
 @functools.lru_cache(None)
-def get_always_mod_inlinelist():
+def get_legacy_mod_inlinelist():
     inlinelist = set()
-    for m in ALWAYS_MOD_INLINELIST:
+    for m in LEGACY_MOD_INLINELIST:
         inlinelist.add(_module_dir(torch) + m[len("torch.") :].replace(".", "/"))
     return inlinelist
 
@@ -294,10 +294,10 @@ def check_file(filename, allow_torch=False):
     """Should skip this file?"""
     if filename is None:
         return SkipResult(True, "filename is None")
-    if any(filename.startswith(d) for d in get_always_mod_inlinelist()):
+    if any(filename.startswith(d) for d in get_legacy_mod_inlinelist()):
         return SkipResult(
             False,
-            "inlined according skipfiles.ALWAYS_MOD_INLINELIST",
+            "inlined according skipfiles.LEGACY_MOD_INLINELIST",
         )
     if allow_torch and is_torch_inline_allowed(filename):
         return SkipResult(

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -161,6 +161,9 @@ FUNC_INLINELIST = {
     "torch._constrain_as_value",
 }
 
+
+# These are legacy workarounds, don't add new modules to this list.
+# Please use the MOD_INLINELIST instead to force inline functions under particular modules.
 LEGACY_MOD_INLINELIST = {
     "torch._dynamo.external_utils",
     "torch._export.db.examples",

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -187,7 +187,7 @@ MOD_INLINELIST = {
     "torch.distributions",
     "torch.fx._pytree",
     "torch.nn",
-    "torch.optim._functional",
+    "torch.optim",
     "torch.random",
     "torch.sparse",
     "torch.testing",
@@ -200,12 +200,6 @@ MOD_INLINELIST = {
 
 if torch.distributed.is_available():
     MOD_INLINELIST.add("torch.distributed")
-
-
-# Include optimizer code for tracing
-MOD_INLINELIST |= {
-    str(obj.__module__) for obj in torch.optim.__dict__.values() if inspect.isclass(obj)
-}
 
 
 # TODO: support adding bound method into this list

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -2242,7 +2242,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         except NotImplementedError:
             pass  # closures
 
-        result = skipfiles.check_verbose(func, extra_check=True)
+        result = skipfiles.check_verbose(func, allow_torch=True)
         if result.skipped:
             from torch._dynamo.variables.misc import (
                 produce_trampoline_autograd_apply,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -727,6 +727,7 @@ class VariableBuilder:
             istype(value, (type, types.FunctionType))
             and skipfiles.check(value, allow_torch=True)
             and not inspect.getattr_static(value, "_torchdynamo_inline", False)
+            and not inspect.getattr_static(value, "__script_if_tracing_wrapper", False)
         ):
             return SkipFilesVariable(
                 value,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -529,6 +529,18 @@ class VariableBuilder:
                     else GuardBuilder.TYPE_MATCH
                 ),
             )
+        elif (
+            istype(value, (type, types.FunctionType))
+            and skipfiles.check(value, allow_torch=True)
+            and not inspect.getattr_static(value, "_torchdynamo_inline", False)
+            and not inspect.getattr_static(value, "__script_if_tracing_wrapper", False)
+        ):
+            return SkipFilesVariable(
+                value,
+                skipfiles.check_verbose(value, allow_torch=True).reason,
+                source=self.source,
+                guards=make_guards(GuardBuilder.FUNCTION_MATCH),
+            )
         # NB: These can't be put in type_dispatch, they have to run later
         elif CollectiveFunctionRewriteVariable.can_rewrite(value):
             new_fn, new_source = CollectiveFunctionRewriteVariable.rewrite(value)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -529,18 +529,6 @@ class VariableBuilder:
                     else GuardBuilder.TYPE_MATCH
                 ),
             )
-        elif (
-            istype(value, (type, types.FunctionType))
-            and skipfiles.check(value, allow_torch=True)
-            and not inspect.getattr_static(value, "_torchdynamo_inline", False)
-            and not inspect.getattr_static(value, "__script_if_tracing_wrapper", False)
-        ):
-            return SkipFilesVariable(
-                value,
-                skipfiles.check_verbose(value, allow_torch=True).reason,
-                source=self.source,
-                guards=make_guards(GuardBuilder.FUNCTION_MATCH),
-            )
         # NB: These can't be put in type_dispatch, they have to run later
         elif CollectiveFunctionRewriteVariable.can_rewrite(value):
             new_fn, new_source = CollectiveFunctionRewriteVariable.rewrite(value)


### PR DESCRIPTION
This major change in this PR is to consolidate the skipfiles.check rules, the major thing done is merging the original ```FILE_INLINELIST``` with ```SUBMOD_INLINELIST``` into new ```MOD_INLINELIST``` and a legacy  ```LEGACY_MOD_INLINELIST```.
Let's use the following example to illustrate what is the expected behavior for this force inline list:
https://github.com/pytorch/pytorch/blob/fa995626a8e181e3666b27fdb4edbe6116b22ee3/torch/_dynamo/skipfiles.py#L344-L369


The handling logic is:
* If f2 is inlined, we will check both ```MOD_INLINELIST``` and ```LEGACY_MOD_INLINELIST``` to consultant force inline rules for f3. 
* If f2 is skipped, we will check ```LEGACY_MOD_INLINELIST``` only for inline rules for f3.

The reason behind this design is: if f2 is skipped, if we always trace all recursively called functions, we will go to the very low level functions (e.g, ```super().__init__```) which caused graph breaks. We treated this as a signal that all functions that f2 recursively called should be skipped as well if f2 is skipped. This is also a feature that many PyTorch developers requested, they just want to skip all recursive functions if they mark the upper level functions as skipped.

For PyTorch developers, we should only use ```MOD_INLINELIST``` going forward. I think most of the modules in the ```LEGACY_MOD_INLINELIST``` are legacy things to workaround when we didn't have a good skip/inline API. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng