### PR TITLE
[dynamo] allow DeviceMesh variable desugar ProcessGroup

### DIFF
--- a/torch/_dynamo/variables/distributed.py
+++ b/torch/_dynamo/variables/distributed.py
@@ -161,6 +161,7 @@ class DeviceMeshVariable(DistributedVariable):
             kwargs_val = {k: v.as_python_constant() for k, v in kwargs.items()}
             # ensure no DeviceMesh subclassing happened
             from torch.distributed._tensor.device_mesh import DeviceMesh
+
             assert istype(self.value, DeviceMesh), f"{self.value} is not a DeviceMesh"
             dim_groups = self.value.get_dim_groups(*args_val, **kwargs_val)
             # desugar the results to ProcessGroupVariables


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #111461

As titled, when calling get_dim_groups, DeviceMeshVariable should be
de-sugared to ProcessGroup Variable in dynamo

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng

Differential Revision: [D50400451](https://our.internmc.facebook.com/intern/diff/D50400451)