### PR TITLE
Add tests for strided layout in factory functions

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2195,16 +2195,16 @@ class TestFakeTensor(TestCase):
     @skipOps('TestFakeTensor', 'test_fake_crossref_backward_amp', fake_backward_xfails | fake_autocast_backward_xfails)
     def test_fake_crossref_backward_amp(self, device, dtype, op):
         self._test_fake_crossref_helper(device, dtype, op, torch.cuda.amp.autocast)
-        
-    @ops([op for op in op_db if op.is_factory_method])
+
+    @ops([op for op in op_db if op.is_factory_function])
     def test_strided_layout(self, device, dtype, op):
         samples = op.sample_inputs(device, dtype)
         for sample in samples:
             kwargs = sample.kwargs.copy()
-            kwargs['layout'] = torch.strided  
+            kwargs['layout'] = torch.strided
             strided_result = op(sample.input, *sample.args, **kwargs)
             self.assertEqual(strided_result.layout, torch.strided)
-    
+
 
 instantiate_device_type_tests(TestCommon, globals())
 instantiate_device_type_tests(TestCompositeCompliance, globals())

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2195,14 +2195,14 @@ class TestFakeTensor(TestCase):
     @skipOps('TestFakeTensor', 'test_fake_crossref_backward_amp', fake_backward_xfails | fake_autocast_backward_xfails)
     def test_fake_crossref_backward_amp(self, device, dtype, op):
         self._test_fake_crossref_helper(device, dtype, op, torch.cuda.amp.autocast)
-    @ops([op for op in op_db if op.is_factory_method], allowed_dtypes=(torch.float,))
+    @ops([op for op in op_db if op.is_factory_method])
     def test_strided_layout(self, device, dtype, op):
         samples = op.sample_inputs(device, dtype)
         for sample in samples:
-            default_result = op(sample.input, *sample.args, **sample.kwargs)
-            self.assertEqual(default_result.layout, torch.strided)
-            strided_result = op(sample.input.to(layout=torch.strided), *sample.args, **sample.kwargs)
-            self.assertEqual(strided_result, default_result)
+                kwargs = sample.kwargs.copy()
+                kwargs['layout'] = torch.strided  
+                strided_result = op(sample.input, *sample.args, **kwargs)
+                self.assertEqual(strided_result.layout, torch.strided)
     
 
 instantiate_device_type_tests(TestCommon, globals())

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2195,14 +2195,15 @@ class TestFakeTensor(TestCase):
     @skipOps('TestFakeTensor', 'test_fake_crossref_backward_amp', fake_backward_xfails | fake_autocast_backward_xfails)
     def test_fake_crossref_backward_amp(self, device, dtype, op):
         self._test_fake_crossref_helper(device, dtype, op, torch.cuda.amp.autocast)
+        
     @ops([op for op in op_db if op.is_factory_method])
     def test_strided_layout(self, device, dtype, op):
         samples = op.sample_inputs(device, dtype)
         for sample in samples:
-                kwargs = sample.kwargs.copy()
-                kwargs['layout'] = torch.strided  
-                strided_result = op(sample.input, *sample.args, **kwargs)
-                self.assertEqual(strided_result.layout, torch.strided)
+            kwargs = sample.kwargs.copy()
+            kwargs['layout'] = torch.strided  
+            strided_result = op(sample.input, *sample.args, **kwargs)
+            self.assertEqual(strided_result.layout, torch.strided)
     
 
 instantiate_device_type_tests(TestCommon, globals())

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2195,7 +2195,22 @@ class TestFakeTensor(TestCase):
     @skipOps('TestFakeTensor', 'test_fake_crossref_backward_amp', fake_backward_xfails | fake_autocast_backward_xfails)
     def test_fake_crossref_backward_amp(self, device, dtype, op):
         self._test_fake_crossref_helper(device, dtype, op, torch.cuda.amp.autocast)
+    def test_empty_strided(self, device):
+        result = torch.empty((3, 3), layout=torch.strided, device=device)
+        self.assertEqual(result.layout, torch.strided)
 
+    def test_zeros_strided(self, device):
+        result = torch.zeros((3, 3), layout=torch.strided, device=device)
+        self.assertEqual(result.layout, torch.strided)
+
+    def test_ones_strided(self, device):
+        result = torch.ones((3, 3), layout=torch.strided, device=device)
+        self.assertEqual(result.layout, torch.strided)
+
+    def test_rand_strided(self, device):
+        result = torch.rand((3, 3), layout=torch.strided, device=device)
+        self.assertEqual(result.layout, torch.strided)
+    
 
 instantiate_device_type_tests(TestCommon, globals())
 instantiate_device_type_tests(TestCompositeCompliance, globals())


### PR DESCRIPTION
Fixes #111222
This pull request adds tests for factory functions that create tensors with a strided layout. The tests are added to the `test_ops.py` file and check the behavior of the `empty`, `zeros`, `ones`, and `rand` factory functions when used with the `layout=torch.strided` argument.