### PR TITLE
Introduce is_big_gpu condition for test_max_autotune

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -607,5 +607,5 @@ class TestTuningProcess(TestCase):
 
 if __name__ == "__main__":
     # Set env to make it work in CI.
-    if HAS_CUDA and HAS_CPU:
+    if HAS_CUDA and HAS_CPU and is_big_gpu(0):
         run_tests()

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -606,6 +606,8 @@ class TestTuningProcess(TestCase):
 
 
 if __name__ == "__main__":
+    from torch._inductor.utils import is_big_gpu
+    
     # Set env to make it work in CI.
     if HAS_CUDA and HAS_CPU and is_big_gpu(0):
         run_tests()

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -607,7 +607,7 @@ class TestTuningProcess(TestCase):
 
 if __name__ == "__main__":
     from torch._inductor.utils import is_big_gpu
-    
+
     # Set env to make it work in CI.
     if HAS_CUDA and HAS_CPU and is_big_gpu(0):
         run_tests()


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/111527

Other test files that rely on `max_autotune` mode being enabled already conditionalise the UT suite on this condition (e.g. test_select_algorithm). Proposing to add this condition for test_max_autotune. 

Currently we are observing failures on these UTs on the ROCm runners but using MI200+ these tests will pass again (context: https://github.com/pytorch/pytorch/pull/111381#issuecomment-1768048732)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler