### PR TITLE
[qnnpack] suppress empty translation unit warning

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/buckbuild.bzl
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/buckbuild.bzl
@@ -89,6 +89,7 @@ def define_qnnpack(third_party, labels = []):
             "-Wno-error=unused-variable",
             "-Wno-shadow",
             "-DPYTORCH_QNNPACK_RUNTIME_QUANTIZATION",
+            "-Wno-empty-translation-unit",
         ],
         fbobjc_preprocessor_flags = [
             "-DQNNP_PRIVATE=",
@@ -135,6 +136,7 @@ def define_qnnpack(third_party, labels = []):
             "-Wno-error=unused-variable",
             "-Wno-shadow",
             "-DPYTORCH_QNNPACK_RUNTIME_QUANTIZATION",
+            "-Wno-empty-translation-unit",
         ],
         fbobjc_preprocessor_flags = [
             "-DQNNP_PRIVATE=",
@@ -189,6 +191,7 @@ def define_qnnpack(third_party, labels = []):
             "-Wno-error=unused-variable",
             "-Wno-shadow",
             "-DPYTORCH_QNNPACK_RUNTIME_QUANTIZATION",
+            "-Wno-empty-translation-unit",
         ],
         fbobjc_preprocessor_flags = [
             "-DQNNP_PRIVATE=",


### PR DESCRIPTION
Summary: Spotted this while compiling on a Mac M1. The code in these files is gated behind #ifdef and requires SSE, so when building for ARM these files become empty.

Test Plan: CI

Differential Revision: D50407334




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10