### PR TITLE
[caffe2] avoid variable shadowing

### DIFF
--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -263,7 +263,8 @@ inline std::vector<at::Tensor> as_view(
   if (base.is_inference())
     return tensors;
 
-  auto diff_view_meta = torch::autograd::impl::get_view_autograd_meta(base);
+  const auto diff_view_meta =
+      torch::autograd::impl::get_view_autograd_meta(base);
 
   // Special case when view info can be shared for forward and backward
   // differentiable views
@@ -309,7 +310,6 @@ inline std::vector<at::Tensor> as_view(
   c10::optional<ViewInfo> new_fw_info = c10::nullopt;
 
   if (is_bw_differentiable) {
-    auto diff_view_meta = torch::autograd::impl::get_view_autograd_meta(base);
     if (diff_view_meta && diff_view_meta->has_bw_view()) {
       const auto& base_bw_info = diff_view_meta->get_backward_view();
       // TODO: fix fb internal use-case so that it doesn't trigger this internal
@@ -333,7 +333,6 @@ inline std::vector<at::Tensor> as_view(
   }
   if (is_fw_differentiable) {
     // Check if base is a forward differentiable view
-    auto diff_view_meta = torch::autograd::impl::get_view_autograd_meta(base);
     if (diff_view_meta && diff_view_meta->has_fw_view()) {
       const auto& base_fw_info = diff_view_meta->get_forward_view();
       TORCH_INTERNAL_ASSERT(
@@ -351,7 +350,6 @@ inline std::vector<at::Tensor> as_view(
 
   if ((is_fw_differentiable || is_bw_differentiable) && base.is_view()) {
     // is_view() => diff_view_meta
-    auto diff_view_meta = torch::autograd::impl::get_view_autograd_meta(base);
     creation_meta = propagate_creation_meta(
         diff_view_meta->get_creation_meta(), creation_meta);
   }


### PR DESCRIPTION
Summary:
Some builds use -Wshadow and currently there is a compiler warning when building that file.

Code inspection shows that `torch::autograd::impl::get_view_autograd_meta` simply extracts information from the passed object, which is `const`. Therefore the returned views should be the same all the time, and we can fetch the view only once.

Test Plan:
CI

NOTE: please advise for a more comprehensive test plan.

Differential Revision: D50407625


