### PR TITLE
BUG: fix np.typecodes under Dynamo

### DIFF
--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1160,6 +1160,16 @@ class BuiltinVariable(VariableTracker):
             else:
                 return VariableBuilder(tx, source)(member).add_guards(guards)
         elif isinstance(obj, (PythonModuleVariable, DummyModule)):
+            # np.typecodes -> tnp.typecodes, both module-level Dict[Str, Str]
+            import numpy as np
+
+            import torch._numpy as tnp
+
+            if obj.value == np and name == "typecodes":
+                tcodes = tnp.typecodes
+                result = {k: ConstantVariable.create(tcodes[k]) for k in tcodes.keys()}
+                return ConstDictVariable(result, user_cls=dict)
+
             member = obj.value.__dict__[name]
 
             if config.replay_record_enabled:

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1167,7 +1167,7 @@ class BuiltinVariable(VariableTracker):
 
             if obj.value == np and name == "typecodes":
                 tcodes = tnp.typecodes
-                result = {k: ConstantVariable.create(tcodes[k]) for k in tcodes.keys()}
+                result = {k: ConstantVariable.create(v) for k, v in tcodes.items()}
                 return ConstDictVariable(result, user_cls=dict)
 
             member = obj.value.__dict__[name]


### PR DESCRIPTION
`numpy.typecodes` is a module-level Dict[Str, Str] which lists allowed dtypes by category. Since we only support a subset of numpy dtypes, `torch._numpy.typecodes` differs from `numpy.typecodes`.

Since this is a dict of primitive types, need to trick dynamo to stop it from simply inlining the numpy dict.

This is only a partial fix, it only works if there's something to compile. Otherwise, e.g. bare

```
def fn():
   return np.typecodes['AllInteger']
```

still generates a numpy dict.

Partially fixes item 2 of  https://github.com/pytorch/pytorch/issues/111370.


cc @mruberry @rgommers @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng