### PR TITLE
Dynamo runner: add FSDP handcrafted module wrapping policy

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2199,15 +2199,17 @@ class BenchmarkRunner:
         return start, end
 
     def get_fsdp_auto_wrap_policy(self, model_name: str) -> Optional[ModuleWrapPolicy]:
-        from torch.distributed.fsdp.wrap import size_based_auto_wrap_policy
+        from diffusers.models.transformer_2d import Transformer2DModel
+
+        from torch.distributed.fsdp.wrap import (
+            ModuleWrapPolicy,
+            size_based_auto_wrap_policy,
+        )
+        from torchbenchmark.models.nanogpt.model import Block
+        from transformers.models.llama.modeling_llama import LlamaDecoderLayer
 
         from transformers.models.t5.modeling_t5 import T5Block
         from transformers.models.whisper.modeling_whisper import WhisperEncoderLayer
-        from transformers.models.llama.modeling_llama import LlamaDecoderLayer
-        from diffusers.models.transformer_2d import Transformer2DModel
-        from torchbenchmark.models.nanogpt.model import Block
-
-        from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 
         # handcrafted wrap policy
         MODEL_FSDP_WRAP = {


### PR DESCRIPTION
The default size based auto wrap policy may not be representative of actual usage of the models. We add support for a few handpicked models, and fallback to the size based policy.

sample command: 
`PYTHONPATH=~/benchmark/ python benchmarks/dynamo/torchbench.py -dcuda --training --backend=inductor --multiprocess --performance --only nanogpt --fsdp`

1.257x                                                           
1.256x                                                           
1.257x                                                           
1.252x                                                           
1.257x                                                                                                                            
1.262x                                
1.258x             
1.272x

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng