### PR TITLE
[PyTorch][Vulkan] Allow 0-size tensors to be represented in PyTorch Vulkan

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Context.h
+++ b/aten/src/ATen/native/vulkan/api/Context.h
@@ -178,7 +178,7 @@ class Context final {
 
  public:
   template <class S, class D>
-  void submit_copy(
+  bool submit_copy(
       const PipelineBarrier&,
       const S&,
       const D&,
@@ -188,7 +188,7 @@ class Context final {
       const VkFence fence_handle);
 
   template <typename... Arguments>
-  void submit_compute_job(
+  bool submit_compute_job(
       const ShaderInfo&,
       const PipelineBarrier&,
       const utils::uvec3&,
@@ -281,6 +281,31 @@ Context* context();
 
 namespace detail {
 
+inline void arg_is_empty(bool& any_is_empty, const VulkanBuffer& buffer) {
+  // bool(buffer) will evaluate to false if no memory has been allocated
+  any_is_empty = any_is_empty || !buffer;
+}
+
+inline void arg_is_empty(bool& any_is_empty, const VulkanImage& image) {
+  // bool(image) will evaluate to false if no memory has been allocated
+  any_is_empty = any_is_empty || !image;
+}
+
+/*
+  Reports if any VulkanBuffer or VulkanImage argument in a variadic argument
+  list does not have any memory associated with it.
+ */
+template <typename... Arguments>
+inline bool any_arg_is_empty(Arguments&&... arguments) {
+  bool any_is_empty = false;
+  C10_UNUSED const int _[]{
+      0,
+      (arg_is_empty(any_is_empty, std::forward<Arguments>(arguments)), 0)...,
+  };
+
+  return any_is_empty;
+}
+
 template <size_t... Indices, typename... Arguments>
 inline void bind(
     DescriptorSet& descriptor_set,
@@ -351,8 +376,15 @@ inline void record_copy<VulkanBuffer, VulkanImage>(
       source, destination, copy_range, src_offset, dst_offset);
 }
 
+/*
+  Records a GPU data copy into the current command buffer. If the number of
+  submit_*_job calls exceeds the configured frequency, or if a fence is
+  provided, then the command buffer is submitted to the GPU for execution.
+  Returns a bool indicating whether or not the function call resulted in a GPU
+  queue submission.
+ */
 template <class S, class D>
-inline void Context::submit_copy(
+inline bool Context::submit_copy(
     const PipelineBarrier& pipeline_barrier,
     const S& source,
     const D& destination,
@@ -360,6 +392,18 @@ inline void Context::submit_copy(
     const api::utils::uvec3& src_offset,
     const api::utils::uvec3& dst_offset,
     const VkFence fence_handle) {
+  // If any of the provided arguments does not have memory associated with it,
+  // then exit early as there is no work to be done. However, if a fence has
+  // been passed the command buffer is not empty, then the current command
+  // buffer must still be submitted so that the fence can be signaled.
+  if (!source || !destination) {
+    if (fence_handle != VK_NULL_HANDLE && submit_count_ > 0) {
+      submit_cmd_to_gpu(fence_handle);
+      return true;
+    }
+    return false;
+  }
+
   // Serialize recording to the shared command buffer. Do not initialize with a
   // mutex just yet, since in some cases it will be externally managed.
   std::unique_lock<std::mutex> cmd_lock;
@@ -393,17 +437,38 @@ inline void Context::submit_copy(
   if (fence_handle != VK_NULL_HANDLE ||
       submit_count_ >= config_.cmdSubmitFrequency) {
     submit_cmd_to_gpu(fence_handle);
+    return true;
   }
+  return false;
 }
 
+/*
+  Records a compute shader dispatch into the current command buffer. If the
+  number of submit_*_job calls exceeds the configured frequency, or if a fence
+  is provided, then the command buffer is submitted to the GPU for execution.
+  Returns a bool indicating whether or not the function call resulted in a GPU
+  queue submission.
+ */
 template <typename... Arguments>
-inline void Context::submit_compute_job(
+inline bool Context::submit_compute_job(
     const ShaderInfo& shader,
     const PipelineBarrier& pipeline_barrier,
     const utils::uvec3& global_work_group,
     const utils::uvec3& local_work_group_size,
     const VkFence fence_handle,
     Arguments&&... arguments) {
+  // If any of the provided arguments does not have memory associated with it,
+  // then exit early as there is no work to be done. However, if a fence has
+  // been passed the command buffer is not empty, then the current command
+  // buffer must still be submitted so that the fence can be signaled.
+  if (detail::any_arg_is_empty(arguments...)) {
+    if (fence_handle != VK_NULL_HANDLE && submit_count_ > 0) {
+      submit_cmd_to_gpu(fence_handle);
+      return true;
+    }
+    return false;
+  }
+
   // Serialize recording to the shared command buffer. Do not initialize with a
   // mutex just yet, since in some cases it will be externally managed.
   std::unique_lock<std::mutex> cmd_lock;
@@ -461,7 +526,10 @@ inline void Context::submit_compute_job(
   if (fence_handle != VK_NULL_HANDLE ||
       submit_count_ >= config_.cmdSubmitFrequency) {
     submit_cmd_to_gpu(fence_handle);
+    return true;
   }
+
+  return false;
 }
 
 } // namespace api

--- a/aten/src/ATen/native/vulkan/api/Resource.cpp
+++ b/aten/src/ATen/native/vulkan/api/Resource.cpp
@@ -106,6 +106,11 @@ VulkanBuffer::VulkanBuffer(
       allocator_(vma_allocator),
       allocation_(VK_NULL_HANDLE),
       handle_(VK_NULL_HANDLE) {
+  // Only allocate memory if the buffer has non-zero size
+  if (size == 0) {
+    return;
+  }
+
   const VkBufferCreateInfo buffer_create_info{
       VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO, // sType
       nullptr, // pNext
@@ -180,7 +185,9 @@ MemoryMap::MemoryMap(const VulkanBuffer& buffer, const uint8_t access)
       allocation_(buffer.allocation()),
       data_(nullptr),
       data_len_{buffer.mem_size()} {
-  VK_CHECK(vmaMapMemory(allocator_, allocation_, &data_));
+  if (allocation_) {
+    VK_CHECK(vmaMapMemory(allocator_, allocation_, &data_));
+  }
 }
 
 MemoryMap::MemoryMap(MemoryMap&& other) noexcept
@@ -198,18 +205,21 @@ MemoryMap::~MemoryMap() {
     return;
   }
 
-  if (access_ & MemoryAccessType::WRITE) {
-    // Call will be ignored by implementation if the memory type this allocation
-    // belongs to is not HOST_VISIBLE or is HOST_COHERENT, which is the behavior
-    // we want. Don't check the result here as the destructor cannot throw.
-    vmaFlushAllocation(allocator_, allocation_, 0u, VK_WHOLE_SIZE);
-  }
+  if (allocation_) {
+    if (access_ & MemoryAccessType::WRITE) {
+      // Call will be ignored by implementation if the memory type this
+      // allocation belongs to is not HOST_VISIBLE or is HOST_COHERENT, which is
+      // the behavior we want. Don't check the result here as the destructor
+      // cannot throw.
+      vmaFlushAllocation(allocator_, allocation_, 0u, VK_WHOLE_SIZE);
+    }
 
-  vmaUnmapMemory(allocator_, allocation_);
+    vmaUnmapMemory(allocator_, allocation_);
+  }
 }
 
 void MemoryMap::invalidate() {
-  if (access_ & MemoryAccessType::READ) {
+  if (access_ & MemoryAccessType::READ && allocation_) {
     // Call will be ignored by implementation if the memory type this allocation
     // belongs to is not HOST_VISIBLE or is HOST_COHERENT, which is the behavior
     // we want.
@@ -346,6 +356,13 @@ VulkanImage::VulkanImage(
           sampler,
       },
       layout_(layout) {
+  // If any dims are zero, then no memory will be allocated for the image.
+  if (image_props.image_extents.width == 0 ||
+      image_props.image_extents.height == 0 ||
+      image_props.image_extents.depth == 0) {
+    return;
+  }
+
   const VkImageCreateInfo image_create_info{
       VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, // sType
       nullptr, // pNext

--- a/aten/src/ATen/native/vulkan/api/Tensor.cpp
+++ b/aten/src/ATen/native/vulkan/api/Tensor.cpp
@@ -434,8 +434,6 @@ vTensor::vTensor(
 api::VulkanImage& vTensor::image(
     api::PipelineBarrier& pipeline_barrier,
     const api::PipelineStageFlags stage) const& {
-  TORCH_CHECK(view_->image_, "vTensor has empty image texture!");
-
   view_->transition(pipeline_barrier, stage, api::MemoryAccessType::READ);
   return view_->image_;
 }
@@ -444,8 +442,6 @@ api::VulkanImage& vTensor::image(
     api::PipelineBarrier& pipeline_barrier,
     const api::PipelineStageFlags stage,
     const api::MemoryAccessFlags access) & {
-  TORCH_CHECK(view_->image_, "vTensor has empty image texture!");
-
   view_->transition(pipeline_barrier, stage, access);
   return view_->image_;
 }
@@ -453,8 +449,6 @@ api::VulkanImage& vTensor::image(
 api::VulkanBuffer& vTensor::buffer(
     api::PipelineBarrier& pipeline_barrier,
     const api::PipelineStageFlags stage) const& {
-  TORCH_CHECK(view_->buffer_, "vTensor has empty buffer!");
-
   view_->transition(pipeline_barrier, stage, api::MemoryAccessType::READ);
   return view_->buffer_;
 }
@@ -463,8 +457,6 @@ api::VulkanBuffer& vTensor::buffer(
     api::PipelineBarrier& pipeline_barrier,
     const api::PipelineStageFlags stage,
     const api::MemoryAccessFlags access) & {
-  TORCH_CHECK(view_->buffer_, "vTensor has empty buffer!");
-
   view_->transition(pipeline_barrier, stage, access);
   return view_->buffer_;
 }

--- a/aten/src/ATen/native/vulkan/impl/Packing.cpp
+++ b/aten/src/ATen/native/vulkan/impl/Packing.cpp
@@ -148,7 +148,7 @@ void record_nchw_to_image_op(
       params.buffer());
 }
 
-void record_image_to_nchw_op(
+bool record_image_to_nchw_op(
     api::Context* const context,
     api::ShaderInfo& compute_shader,
     vTensor& v_src,
@@ -192,7 +192,7 @@ void record_image_to_nchw_op(
   }
 
   api::UniformParamsBuffer params(context, block);
-  context->submit_compute_job(
+  return context->submit_compute_job(
       // shader descriptor
       compute_shader,
       // pipeline barrier
@@ -248,7 +248,7 @@ void record_nchw_to_buffer_op(
       cpu_buffer_metadata.buffer());
 }
 
-void record_buffer_to_nchw_op(
+bool record_buffer_to_nchw_op(
     api::Context* const context,
     vTensor& v_src,
     api::VulkanBuffer& dst_buffer,
@@ -262,7 +262,7 @@ void record_buffer_to_nchw_op(
   api::UniformParamsBuffer cpu_buffer_metadata(
       context, v_src.get_cpu_buffer_metadata());
 
-  context->submit_compute_job(
+  return context->submit_compute_job(
       // shader descriptor
       VK_KERNEL(buffer_to_buffer),
       // pipeline barrier

--- a/aten/src/ATen/native/vulkan/impl/Packing.h
+++ b/aten/src/ATen/native/vulkan/impl/Packing.h
@@ -16,7 +16,7 @@ void record_nchw_to_image_op(
     api::PipelineBarrier pipeline_barrier,
     const VkFence fence_handle);
 
-void record_image_to_nchw_op(
+bool record_image_to_nchw_op(
     api::Context* const context,
     api::ShaderInfo& compute_shader,
     vTensor& v_src,
@@ -31,7 +31,7 @@ void record_nchw_to_buffer_op(
     api::PipelineBarrier pipeline_barrier,
     const VkFence fence_handle);
 
-void record_buffer_to_nchw_op(
+bool record_buffer_to_nchw_op(
     api::Context* const context,
     vTensor& v_src,
     api::VulkanBuffer& dst_buffer,

--- a/aten/src/ATen/native/vulkan/ops/Copy.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Copy.cpp
@@ -195,10 +195,14 @@ void pack_vulkan_to_cpu(vTensor& src, Tensor& dst) {
     // cmd_mutex_ must be manually managed by the calling thread.
     std::unique_lock<std::mutex> context_lock(context->dispatch_lock());
 
-    utils::pack_vtensor_to_staging(
+    bool submitted_to_gpu = utils::pack_vtensor_to_staging(
         src, staging.buffer(), fence.get_submit_handle());
 
-    fence.wait();
+    // Only wait on the fence if work was actually submitted to the GPU.
+    // Otherwise, it will hang indefinitely.
+    if (submitted_to_gpu) {
+      fence.wait();
+    }
 
     context->flush();
     // cmd_mutex_ will be released when exiting this scope.

--- a/aten/src/ATen/native/vulkan/ops/Utils.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Utils.cpp
@@ -214,7 +214,7 @@ void pack_staging_to_vtensor(api::VulkanBuffer& staging, vTensor& v_self) {
   pack_buffer_to_vtensor(staging, v_self, pipeline_barrier);
 }
 
-void pack_vtensor_to_staging(
+bool pack_vtensor_to_staging(
     vTensor& v_self,
     api::VulkanBuffer& staging,
     const VkFence fence_handle) {
@@ -222,11 +222,11 @@ void pack_vtensor_to_staging(
   api::PipelineBarrier pipeline_barrier{};
 
   if (v_self.storage_type() == api::StorageType::BUFFER) {
-    packing::record_buffer_to_nchw_op(
+    return packing::record_buffer_to_nchw_op(
         context, v_self, staging, pipeline_barrier, fence_handle);
   } else {
     api::ShaderInfo compute_shader = packing::get_image_to_nchw_shader(v_self);
-    packing::record_image_to_nchw_op(
+    return packing::record_image_to_nchw_op(
         context,
         compute_shader,
         v_self,

--- a/aten/src/ATen/native/vulkan/ops/Utils.h
+++ b/aten/src/ATen/native/vulkan/ops/Utils.h
@@ -45,7 +45,7 @@ void pack_buffer_to_vtensor(
 
 void pack_staging_to_vtensor(api::VulkanBuffer&, vTensor&);
 
-void pack_vtensor_to_staging(
+bool pack_vtensor_to_staging(
     vTensor&,
     api::VulkanBuffer&,
     const VkFence fence_handle = VK_NULL_HANDLE);

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -275,6 +275,13 @@ class VulkanAPITest : public ::testing::Test {
   }
 };
 
+TEST_F(VulkanAPITest, zero_size_tensor) {
+  auto cpu = at::rand({1, 0, 0}, at::device(at::kCPU).dtype(at::kFloat));
+  auto vk = cpu.vulkan();
+  auto out_vk = vk.cpu();
+  ASSERT_TRUE(at::equal(out_vk, cpu));
+}
+
 TEST_F(VulkanAPITest, copy_to_texture) {
   using namespace at::native::vulkan;
   at::Tensor test_tensors[] = {


### PR DESCRIPTION
Summary:
0-size tensors are allowed in PyTorch (e.g. a tensor with size {2, 1, 0}). However, this currently causes issues with PyTorch Vulkan as the Vulkan API would raise an error when attempting to allocate a resource with no memory.

This diff fixes the behaviour by adding support for `VulkanImage` and `VulkanBuffer` objects that do not have any associated memory.

Test Plan:
Tested locally with `vulkan_api_test` on Mac as a sanity test.
```
buck run //xplat/caffe2:pt_vulkan_api_test_bin --target-platforms ovr_config//platform/macos:x86_64-fbsource -- --gtest_filter="*"
```

But given how foundational of a change this is, more extensive testing should be done in order to be safe.

Reviewed By: yipjustin

Differential Revision: D50030659

