### PR TITLE
Mark more decomp tests as slow

### DIFF
--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -466,9 +466,19 @@ core_backward_failures = {
     xfail('zero_'),
 }
 if not TEST_WITH_SLOW:
-  core_backward_failures.add(skip('baddbmm'))  # slow: takes 800+ sec on A100
-  core_backward_failures.add(skip('clamp_min'))
-  core_backward_failures.add(skip('clamp_max'))
+  core_backward_failures.update({
+      skip('addr'),  # slow: takes 46 sec on A100
+      skip('baddbmm'),  # slow: takes 800+ sec on A100
+      skip('clamp_min'),  # slow: takes 800 sec on A100
+      skip('clamp_max'),  # slow: takes 800 sec on A100
+      skip('logit'),  # slow: takes 44 sec on A100
+      skip('nn.functional.hardswish'),  # slow: takes 60 sec on A100
+      skip('std_mean'),  # slow: takes 170 sec on A100
+      skip('split', variant_name='list_args'),  # slow: takes 118 sec on A100
+      skip('transpose'),  # slow: takes 50 sec on A100
+      skip('unbind'),  # slow: takes 70 sec on A100
+      skip('unsafe_split'),  # slow: takes 49 sec on A100
+  })
 
 
 class TestDecomp(TestCase):

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -15,6 +15,7 @@ from torch.testing._internal.common_utils import (
     skipIfCrossRef,
     suppress_warnings,
     TEST_WITH_ASAN,
+    TEST_WITH_SLOW,
     run_tests,
     skipIfTorchDynamo,
 )
@@ -435,7 +436,6 @@ core_backward_failures = {
     skip('_softmax_backward_data'),  # slow: fails with --timeout=360 secs
     xfail('addcdiv'),
     skip('addcmul'),  # slow: fails with --timeout=360 secs
-    skip('baddbmm'),  # slow: takes 800+ sec on A100
     skip('deg2rad'),  # slow: fails with --timeout=360 secs
     skip('diag_embed'),  # slow: fails with --timeout=360 secs
     skip('frac'),  # slow: fails with --timeout=360 secs
@@ -465,6 +465,10 @@ core_backward_failures = {
     skip('xlogy'),  # slow: fails with --timeout=360 secs
     xfail('zero_'),
 }
+if not TEST_WITH_SLOW:
+  core_backward_failures.add(skip('baddbmm'))  # slow: takes 800+ sec on A100
+  core_backward_failures.add(skip('clamp_min'))
+  core_backward_failures.add(skip('clamp_max'))
 
 
 class TestDecomp(TestCase):

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -466,19 +466,19 @@ core_backward_failures = {
     xfail('zero_'),
 }
 if not TEST_WITH_SLOW:
-  core_backward_failures.update({
-      skip('addr'),  # slow: takes 46 sec on A100
-      skip('baddbmm'),  # slow: takes 800+ sec on A100
-      skip('clamp_min'),  # slow: takes 800 sec on A100
-      skip('clamp_max'),  # slow: takes 800 sec on A100
-      skip('logit'),  # slow: takes 44 sec on A100
-      skip('nn.functional.hardswish'),  # slow: takes 60 sec on A100
-      skip('std_mean'),  # slow: takes 170 sec on A100
-      skip('split', variant_name='list_args'),  # slow: takes 118 sec on A100
-      skip('transpose'),  # slow: takes 50 sec on A100
-      skip('unbind'),  # slow: takes 70 sec on A100
-      skip('unsafe_split'),  # slow: takes 49 sec on A100
-  })
+    core_backward_failures.update({
+        skip('addr'),  # slow: takes 46 sec on A100
+        skip('baddbmm'),  # slow: takes 800+ sec on A100
+        skip('clamp_min'),  # slow: takes 800 sec on A100
+        skip('clamp_max'),  # slow: takes 800 sec on A100
+        skip('logit'),  # slow: takes 44 sec on A100
+        skip('nn.functional.hardswish'),  # slow: takes 60 sec on A100
+        skip('std_mean'),  # slow: takes 170 sec on A100
+        skip('split', variant_name='list_args'),  # slow: takes 118 sec on A100
+        skip('transpose'),  # slow: takes 50 sec on A100
+        skip('unbind'),  # slow: takes 70 sec on A100
+        skip('unsafe_split'),  # slow: takes 49 sec on A100
+    })
 
 
 class TestDecomp(TestCase):


### PR DESCRIPTION
Something is broken with automatic slow detection, so let's do it manually

Those tests were previously classified as slow, see: 
```
test_decomp.py::TestDecompCUDA::test_quick_core_backward_baddbmm_cuda_float64 SKIPPED [0.0003s] (test is slow; run with PYTORCH_TEST_WITH_SLOW to enable test) [ 53%] 
test_decomp.py::TestDecompCUDA::test_quick_core_backward_clamp_max_cuda_float64 SKIPPED [0.0002s] (test is slow; run with PYTORCH_TEST_WITH_SLOW to enable test) [ 53%] 
test_decomp.py::TestDecompCUDA::test_quick_core_backward_clamp_min_cuda_float64 SKIPPED [0.0002s] (test is slow; run with PYTORCH_TEST_WITH_SLOW to enable test) [ 53%]
```
from https://ossci-raw-job-status.s3.amazonaws.com/log/17792633247
