### PR TITLE
[dynamo] Fix context wrapping grad mode variable

### DIFF
--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -891,31 +891,45 @@ class GraphModule(torch.nn.Module):
         check_graph(actual, expected)
 
     def test_context_wrapping_grad_mode_decorator(self):
-        for ctx_wrapper in [torch.no_grad, torch.enable_grad]:
+        ctx_wrappers = [torch.enable_grad, torch.no_grad]
+        for i in range(2):
+            torch._dynamo.reset()
+
+            ctx_wrapper = ctx_wrappers[i]
+            ctx_wrapper_inverse = ctx_wrappers[(i + 1) % 2]
 
             def fn(x):
-                def cool_name(x):
+                def inner_func(x):
                     return x.sin()
 
-                return ctx_wrapper(cool_name)(x)
+                with ctx_wrapper_inverse():
+                    return ctx_wrapper(inner_func)(x)
 
-            x = torch.zeros(10)
+            x = torch.zeros(10, requires_grad=True)
             opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
             self.assertEqual(fn(x), opt_fn(x))
+            self.assertEqual(fn(x).requires_grad, opt_fn(x).requires_grad)
 
     def test_context_wrapping_grad_mode_nested_decorator(self):
-        for ctx_wrapper in [torch.no_grad, torch.enable_grad]:
+        ctx_wrappers = [torch.enable_grad, torch.no_grad]
+        for i in range(2):
+            torch._dynamo.reset()
+
+            ctx_wrapper = ctx_wrappers[i]
+            ctx_wrapper_inverse = ctx_wrappers[(i + 1) % 2]
 
             def fn(x):
                 @ctx_wrapper
-                def cool_name(x):
+                def inner_func(x):
                     return x.sin()
 
-                return cool_name(x)
+                with ctx_wrapper_inverse():
+                    return inner_func(x)
 
-            x = torch.zeros(10)
+            x = torch.zeros(10, requires_grad=True)
             opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
             self.assertEqual(fn(x), opt_fn(x))
+            self.assertEqual(fn(x).requires_grad, opt_fn(x).requires_grad)
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -910,7 +910,7 @@ class GraphModule(torch.nn.Module):
             self.assertEqual(fn(x), opt_fn(x))
             self.assertEqual(fn(x).requires_grad, opt_fn(x).requires_grad)
 
-    def test_context_wrapping_grad_mode_nested_decorator(self):
+    def test_context_wrapping_grad_mode_nested_function_decorator(self):
         ctx_wrappers = [torch.enable_grad, torch.no_grad]
         for i in range(2):
             torch._dynamo.reset()

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -135,7 +135,6 @@ class GradModeVariable(ContextWrappingVariable):
             initial_values=[torch.is_grad_enabled()],
             **kwargs,
         )
-        var._call_func(tx, [target_value])
         return var
 
     def __init__(self, target_values, initial_values=None, **kwargs):
@@ -145,6 +144,7 @@ class GradModeVariable(ContextWrappingVariable):
         self.guards = self.guards | self._guards_singleton
 
     def enter(self, tx):
+        self._call_func(tx, self.target_values)
         return variables.ConstantVariable.create(
             None, **VariableTracker.propagate(self)
         )

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -59,7 +59,9 @@ class ContextWrappingVariable(VariableTracker):
         assert len(args) == 1
         if isinstance(args[0], NestedUserFunctionVariable):
             args[0] = UserFunctionVariable(args[0].get_function())
-        assert isinstance(args[0], (UserMethodVariable, UserFunctionVariable))
+        assert isinstance(args[0], (UserMethodVariable, UserFunctionVariable)), type(
+            args[0]
+        )
 
         if isinstance(args[0], UserMethodVariable):
             return WrappedUserMethodVariable(args[0], self)

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -59,9 +59,7 @@ class ContextWrappingVariable(VariableTracker):
         assert len(args) == 1
         if isinstance(args[0], NestedUserFunctionVariable):
             args[0] = UserFunctionVariable(args[0].get_function())
-        assert isinstance(args[0], (UserMethodVariable, UserFunctionVariable)), type(
-            args[0]
-        )
+        assert isinstance(args[0], (UserMethodVariable, UserFunctionVariable))
 
         if isinstance(args[0], UserMethodVariable):
             return WrappedUserMethodVariable(args[0], self)

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -129,12 +129,15 @@ class GradModeVariable(ContextWrappingVariable):
     _guards_singleton = {Guard(GlobalStateSource(), GuardBuilder.GRAD_MODE)}
 
     @staticmethod
-    def create(tx, target_value, **kwargs):
+    def create(tx, target_value, should_initialize_once=True, **kwargs):
         var = GradModeVariable(
             target_values=[target_value],
             initial_values=[torch.is_grad_enabled()],
             **kwargs,
         )
+        var._should_initialize_once = should_initialize_once
+        if var._should_initialize_once:
+            var._call_func(tx, var.target_values)
         return var
 
     def __init__(self, target_values, initial_values=None, **kwargs):
@@ -144,7 +147,8 @@ class GradModeVariable(ContextWrappingVariable):
         self.guards = self.guards | self._guards_singleton
 
     def enter(self, tx):
-        self._call_func(tx, self.target_values)
+        if not self._should_initialize_once:
+            self._call_func(tx, self.target_values)
         return variables.ConstantVariable.create(
             None, **VariableTracker.propagate(self)
         )

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -322,7 +322,9 @@ class TorchVariable(VariableTracker):
             if len(args) == 1 and isinstance(
                 args[0], variables.functions.BaseUserFunctionVariable
             ):
-                ctx = GradModeVariable.create(tx, False, should_initialize_once=False, **options)
+                ctx = GradModeVariable.create(
+                    tx, False, should_initialize_once=False, **options
+                )
                 return ctx.call_function(tx, args, kwargs)
             else:
                 return GradModeVariable.create(tx, False, **options)
@@ -330,7 +332,9 @@ class TorchVariable(VariableTracker):
             if len(args) == 1 and isinstance(
                 args[0], variables.functions.BaseUserFunctionVariable
             ):
-                ctx = GradModeVariable.create(tx, True, should_initialize_once=False, **options)
+                ctx = GradModeVariable.create(
+                    tx, True, should_initialize_once=False, **options
+                )
                 return ctx.call_function(tx, args, kwargs)
             return GradModeVariable.create(tx, True, **options)
         elif self.value is torch.set_grad_enabled and len(args) == 1:

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -322,7 +322,7 @@ class TorchVariable(VariableTracker):
             if len(args) == 1 and isinstance(
                 args[0], variables.functions.BaseUserFunctionVariable
             ):
-                ctx = GradModeVariable.create(tx, False, **options)
+                ctx = GradModeVariable.create(tx, False, should_initialize_once=False, **options)
                 return ctx.call_function(tx, args, kwargs)
             else:
                 return GradModeVariable.create(tx, False, **options)
@@ -330,7 +330,7 @@ class TorchVariable(VariableTracker):
             if len(args) == 1 and isinstance(
                 args[0], variables.functions.BaseUserFunctionVariable
             ):
-                ctx = GradModeVariable.create(tx, True, **options)
+                ctx = GradModeVariable.create(tx, True, should_initialize_once=False, **options)
                 return ctx.call_function(tx, args, kwargs)
             return GradModeVariable.create(tx, True, **options)
         elif self.value is torch.set_grad_enabled and len(args) == 1:

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -319,8 +319,19 @@ class TorchVariable(VariableTracker):
         ):
             return self._call_ntuple(tx, args, kwargs, options)
         elif self.value is torch.no_grad:
-            return GradModeVariable.create(tx, False, **options)
+            if len(args) == 1 and isinstance(
+                args[0], variables.functions.BaseUserFunctionVariable
+            ):
+                ctx = GradModeVariable.create(tx, False, **options)
+                return ctx.call_function(tx, args, kwargs)
+            else:
+                return GradModeVariable.create(tx, False, **options)
         elif self.value is torch.enable_grad:
+            if len(args) == 1 and isinstance(
+                args[0], variables.functions.BaseUserFunctionVariable
+            ):
+                ctx = GradModeVariable.create(tx, True, **options)
+                return ctx.call_function(tx, args, kwargs)
             return GradModeVariable.create(tx, True, **options)
         elif self.value is torch.set_grad_enabled and len(args) == 1:
             return GradModeVariable.create(tx, args[0].as_python_constant(), **options)

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -322,9 +322,7 @@ class TorchVariable(VariableTracker):
             if len(args) == 1 and isinstance(
                 args[0], variables.functions.BaseUserFunctionVariable
             ):
-                ctx = GradModeVariable.create(
-                    tx, False, should_initialize_once=False, **options
-                )
+                ctx = GradModeVariable.create(tx, False, initialized=False, **options)
                 return ctx.call_function(tx, args, kwargs)
             else:
                 return GradModeVariable.create(tx, False, **options)
@@ -332,9 +330,7 @@ class TorchVariable(VariableTracker):
             if len(args) == 1 and isinstance(
                 args[0], variables.functions.BaseUserFunctionVariable
             ):
-                ctx = GradModeVariable.create(
-                    tx, True, should_initialize_once=False, **options
-                )
+                ctx = GradModeVariable.create(tx, True, initialized=False, **options)
                 return ctx.call_function(tx, args, kwargs)
             return GradModeVariable.create(tx, True, **options)
         elif self.value is torch.set_grad_enabled and len(args) == 1:


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/111528

Makes use of `ContextWrappingVariable` so that the function will enter the grad mode whenever it is called, and exit once it is done calling.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng