### PR TITLE
Fix inconsistency of max_split_size between DeviceStats and CUDAAllocatorConfig

### DIFF
--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -98,7 +98,7 @@ struct DeviceStats {
   Stat oversize_segments;
 
   // SIZE: maximum block size that is allowed to be split.
-  int64_t max_split_size = 0;
+  size_t max_split_size = 0;
 };
 
 typedef std::shared_ptr<GatheredContext> (*CreateContextFn)(void);


### PR DESCRIPTION
CUDAAllocatorConfig uses size_t max_split_size and initializes it to std:: numeric_limits<size_t>::max(), and then the value is assigned to max_split_size of DeviceStats which is of type int64_t, so that the command 
```
python3 -c "import torch;y=torch.empty(3,device='cuda');print(torch.cuda.memory_stats(0)['max_split_size'])"
```
returned -1.

After skimming through the code, and reading the doc in https://pytorch.org/docs/stable/generated/torch.cuda.memory_stats.html, It was sure that negative values of max_split_size make no sense and we should use size_t instead. Now the error has been fixed and the command returns std:: numeric_limits<size_t>::max().

This issue was found in revert of #111137

cc @malfet 
