### PR TITLE
Add sdpa to Autocast CPU

### DIFF
--- a/aten/src/ATen/autocast_mode.cpp
+++ b/aten/src/ATen/autocast_mode.cpp
@@ -404,6 +404,7 @@ TORCH_LIBRARY_IMPL(aten, AutocastCPU, m) {
   KERNEL_CPU2(conv_transpose2d, input, lower_precision_fp)
   KERNEL_CPU2(conv_transpose3d, input, lower_precision_fp)
   KERNEL_CPU(prelu, lower_precision_fp)
+  KERNEL_CPU(scaled_dot_product_attention, lower_precision_fp)
 
   // fp32 cast policy
   KERNEL_CPU(avg_pool3d, fp32)


### PR DESCRIPTION
Fixes #111276

This PR adds sdpa to Autocast CPU policy.

Behavior: Within the scope of `torch.cpu.amp.autocast(dtype=torch.bfloat16)`, `scaled_dot_product_attention` will be forced to run with bf16 data type.

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5