### PR TITLE
Use 'device' argument  in test_sparse.py::TestSparseAnyCUDA::test_as_sparse_gradcheck_*

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -5079,7 +5079,7 @@ class TestSparseAny(TestCase):
     @all_sparse_layouts('layout', include_strided=False)
     @parametrize("masked", [subtest(False, name='nonmasked'), subtest(True, name='masked')])
     @parametrize("fast_mode", [subtest(False, name='slow'), subtest(True, name='fast')])
-    def test_as_sparse_gradcheck(self, layout, masked, fast_mode):
+    def test_as_sparse_gradcheck(self, layout, device, masked, fast_mode):
         gradcheck = torch.sparse.as_sparse_gradcheck(torch.autograd.gradcheck)
         sparse_compressed_layouts = {torch.sparse_csr, torch.sparse_csc, torch.sparse_bsr, torch.sparse_bsc}
 
@@ -5099,6 +5099,7 @@ class TestSparseAny(TestCase):
                 continue
             for x in self.generate_simple_inputs(
                     layout,
+                    device=device,
                     dtype=torch.float64,
                     # TODO: fix gh-104868  to enable batched samples:
                     enable_batch=layout not in sparse_compressed_layouts,


### PR DESCRIPTION
Argument "device" was missed.
So, "test_sparse.py::TestSparseAnyCUDA::test_as_sparse_gradcheck_*_cuda" was always run on the default device ("cpu") if another default torch device was not configured before. 
This fix will probably detect a number of issues on various devices which were previously missed.
Should fix failed rocm CI jobs with "##[error]The action has timed out."  and speedup test execution
