### PR TITLE
[Pytorch][Vulkan] Fix the implementation of `aten::sum.dim_IntList`

### DIFF
--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -4209,6 +4209,40 @@ TEST_F(VulkanAPITest, sub_to_scalar_wrapped) {
   ASSERT_TRUE(check);
 }
 
+TEST_F(VulkanAPITest, sum_invalid_inputs) {
+  c10::InferenceMode mode;
+
+  // Act: input dimension too large
+  EXPECT_THROW({
+    at::sum(at::rand({3, 5, 7, 8, 9}, at::device(at::kCPU).dtype(at::kFloat))
+      .vulkan(), {3});
+  }, ::c10::Error);
+
+  // Act: dimension out of range
+  EXPECT_THROW({
+    at::sum(at::rand({7, 8, 9}, at::device(at::kCPU).dtype(at::kFloat))
+      .vulkan(), {3});
+  }, ::c10::Error);
+
+  // Act: dimension out of range
+  EXPECT_THROW({
+    at::sum(at::rand({7, 8, 9}, at::device(at::kCPU).dtype(at::kFloat))
+      .vulkan(), {-4});
+  }, ::c10::Error);
+
+  // Act: repeated dimensions
+  EXPECT_THROW({
+    at::sum(at::rand({7, 8, 9}, at::device(at::kCPU).dtype(at::kFloat))
+      .vulkan(), {1, 1});
+  }, ::c10::Error);
+
+  // Act: repeated dimensions
+  EXPECT_THROW({
+    at::sum(at::rand({7, 8, 9}, at::device(at::kCPU).dtype(at::kFloat))
+      .vulkan(), {1, -2});
+  }, ::c10::Error);
+}
+
 void test_sum_dim(const at::IntArrayRef input_shape, const at::IntArrayRef dim_list, bool keepdim=false) {
   const auto in_cpu = at::rand(input_shape, at::device(at::kCPU).dtype(at::kFloat));
   const auto in_vulkan = in_cpu.vulkan();
@@ -4239,6 +4273,8 @@ TEST_F(VulkanAPITest, sum_dim_3d) {
   test_sum_dim({10, 7, 5}, {0, 1});
   test_sum_dim({10, 7, 5}, {0, 2});
   test_sum_dim({10, 7, 5}, {1, 2});
+  test_sum_dim({10, 7, 5}, {-1, -2});
+  test_sum_dim({10, 7, 5}, {0, -2});
 }
 
 TEST_F(VulkanAPITest, sum_dim_4d) {
@@ -4253,11 +4289,14 @@ TEST_F(VulkanAPITest, sum_dim_4d) {
   test_sum_dim({10, 7, 5, 6}, {1, 2});
   test_sum_dim({10, 7, 5, 6}, {1, 3});
   test_sum_dim({10, 7, 5, 6}, {2, 3});
+  test_sum_dim({10, 7, 5, 6}, {-2, -4});
 
   test_sum_dim({10, 7, 5, 6}, {0, 1, 2});
   test_sum_dim({10, 7, 5, 6}, {0, 1, 3});
   test_sum_dim({10, 7, 5, 6}, {0, 2, 3});
   test_sum_dim({10, 7, 5, 6}, {3, 2, 1});
+  test_sum_dim({10, 7, 5, 6}, {3, -2, 1});
+  test_sum_dim({10, 7, 5, 6}, {-3, -2, -1});
 }
 
 TEST_F(VulkanAPITest, sum_dim_keepdim_2d) {


### PR DESCRIPTION
Summary:
The existing implementation of `aten::sum.dim_IntList` depends on the following steps:
- store the items of arguments `opt_dim` in a  `std::set<int64_t> dims_set;`
- iterate through `dims_set` in the reverse order(i.e. from largest to smallest) and compute the sum for one designated dim in `sum_dim`

But when `opt_dim` contains negative items and `keepdim==false`, the dimension iteration over the  set will be messed up. For example, the existing implementation will fail at the test case `test_sum_dim({10, 7, 5}, {-1, -2});`.

We fix the issue by invoking `int64_t dim_normalized = utils::normalize(d, self.dim());` to get normalized dim in the range [0, `self.dim()` - 1].

Moreover the existing TORCH_CHECK of the condition
```
d >= -self.dim() - 1 && d <= self.dim()
```
is wrong and fixed by
```
d >= -self.dim() && d < self.dim()
```

Test Plan:
```
[luwei@devbig984.prn1 /data/users/luwei/fbsource (04b08a835)]$ LD_LIBRARY_PATH=third-party/swiftshader/lib/linux-x64/ buck run fbcode/mode/dev-nosan //xplat/caffe2:pt_vulkan_api_test_bin -- --gtest_filter="*sum*"
Building: finished in 0.1 sec (100%) 339/339 jobs, 0/339 updated
  Total time: 0.2 sec
BUILD SUCCEEDED
Running main() from third-party/googletest/1.11.0/googletest/googletest/src/gtest_main.cc
Note: Google Test filter = *sum*
[==========] Running 8 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 8 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.cumsum
[       OK ] VulkanAPITest.cumsum (105 ms)
[ RUN      ] VulkanAPITest.sum_invalid_inputs
[       OK ] VulkanAPITest.sum_invalid_inputs (0 ms)
[ RUN      ] VulkanAPITest.sum_dim_2d
[       OK ] VulkanAPITest.sum_dim_2d (145 ms)
[ RUN      ] VulkanAPITest.sum_dim_3d
[       OK ] VulkanAPITest.sum_dim_3d (91 ms)
[ RUN      ] VulkanAPITest.sum_dim_4d
[       OK ] VulkanAPITest.sum_dim_4d (89 ms)
[ RUN      ] VulkanAPITest.sum_dim_keepdim_2d
[       OK ] VulkanAPITest.sum_dim_keepdim_2d (63 ms)
[ RUN      ] VulkanAPITest.sum_dim_keepdim_3d
[       OK ] VulkanAPITest.sum_dim_keepdim_3d (135 ms)
[ RUN      ] VulkanAPITest.sum_dim_keepdim_4d
[       OK ] VulkanAPITest.sum_dim_keepdim_4d (4 ms)
[----------] 8 tests from VulkanAPITest (637 ms total)

[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (637 ms total)
[  PASSED  ] 8 tests.
```

Reviewed By: yipjustin

Differential Revision: D50442152

