### PR TITLE
Pass `BUILD_ENVIRONMENT` to MPS tests

### DIFF
--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -25,11 +25,6 @@ on:
         type: string
         description: |
           A JSON description of what configs to run later on.
-      runs-on:
-        required: false
-        type: string
-        default: "macos-m1-12"
-        description: Hardware to run tests on
 
 jobs:
   filter:
@@ -60,7 +55,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.filter.outputs.test-matrix) }}
       fail-fast: false
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Print runner OS/HW info
         shell: arch -arch arm64 bash {0}
@@ -158,4 +153,8 @@ jobs:
         if: always() && steps.test.conclusion && steps.test.conclusion != 'skipped'
         with:
           use-gha: true
-          file-suffix: ${{ github.job }}-mps-1-1-macos-m1-12_${{ steps.get-job-id.outputs.job-id }}
+          file-suffix: ${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}_${{ steps.get-job-id.outputs.job-id }}
+      - name: Clean up disk space
+        if: always()
+        continue-on-error: true
+        uses: pytorch/test-infra/.github/actions/check-disk-space@main

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -94,6 +94,8 @@ jobs:
       - name: Install PyTorch and run MPS tests
         id: test
         env:
+          GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
           ENV_NAME: conda-test-env-${{ github.run_id }}
           PY_VERS: 3.9
           PR_BODY: ${{ github.event.pull_request.body }}

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -96,6 +96,7 @@ jobs:
         env:
           GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
+          TEST_CONFIG: ${{ matrix.config }}
           ENV_NAME: conda-test-env-${{ github.run_id }}
           PY_VERS: 3.9
           PR_BODY: ${{ github.event.pull_request.body }}

--- a/.github/workflows/mac-mps.yml
+++ b/.github/workflows/mac-mps.yml
@@ -27,7 +27,8 @@ jobs:
       environment-file: .github/requirements/conda-env-macOS-ARM64
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 1 },
+          { config: "mps", shard: 1, num_shards: 1, runner: "macos-m1-12" },
+          { config: "mps", shard: 1, num_shards: 1, runner: "macos-m1-13" },
         ]}
 
   macos-12-py3-arm64-mps-test:
@@ -40,14 +41,3 @@ jobs:
       # Same as the build job
       python-version: 3.9.12
       test-matrix: ${{ needs.macos-12-py3-arm64-build.outputs.test-matrix }}
-
-  macos-13-py3-arm64-mps-test:
-    name: macos-13-py3-arm64-mps
-    uses: ./.github/workflows/_mac-test-mps.yml
-    needs: macos-12-py3-arm64-build
-    with:
-      build-environment: macos-12-py3-arm64
-      # Same as the build job
-      python-version: 3.9.12
-      test-matrix: ${{ needs.macos-12-py3-arm64-build.outputs.test-matrix }}
-      runs-on: macos-m1-13

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -120,7 +120,7 @@ jobs:
       python-version: 3.9.12
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 1 },
+          { config: "mps", shard: 1, num_shards: 1, runner: "macos-m1-12" },
         ]}
 
   macos-12-py3-arm64-test:


### PR DESCRIPTION
- Pass `GIT_DEFAULT_BRANCH` and `TEST_CONFIG` as well.
- Unify `_mac-test.yml` and `_mac-test-mps.yml` further by passing runner type via the matrix and uploading results using the same pattern (before the change MacOS12 and MacOS13 results on PRs were overwritten)
- Add `Cleanup disk space` step to `_mac-test-mps.yml` job

Should fix the
```
Warning:  Gathered no stats from artifacts for build env None build env and None test config. Using default build env and default test config instead.
```
