### PR TITLE
[TP] Refactor style to make it work with torch.compile

### DIFF
--- a/test/distributed/tensor/parallel/test_tp_style.py
+++ b/test/distributed/tensor/parallel/test_tp_style.py
@@ -13,6 +13,8 @@ from torch.distributed.tensor.parallel.style import (
     make_output_reshard_tensor,
     make_output_shard_1d,
     make_output_tensor,
+    PrepareModuleInput,
+    PrepareModuleOutput,
     RowwiseParallel,
 )
 from torch.testing._internal.common_utils import run_tests
@@ -41,13 +43,16 @@ class TensorParallelStyleTest(DTensorTestBase):
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
         # test 1: replicate local tensor
         dtensor = func(input_local_tensor, device_mesh)
-        self.assertEqual(expected_local_tensor, dtensor.to_local())
+        result = dtensor[0] if isinstance(dtensor, tuple) else dtensor
+        self.assertEqual(expected_local_tensor, result.to_local())
         # test 2: replicate DTensor
         dtensor = func(dtensor)
-        self.assertEqual(expected_local_tensor, dtensor.to_local())
+        result = dtensor[0] if isinstance(dtensor, tuple) else dtensor
+        self.assertEqual(expected_local_tensor, result.to_local())
         # test 3: replicate DTensor with DeviceMesh passed
         dtensor = func(dtensor, device_mesh)
-        self.assertEqual(expected_local_tensor, dtensor.to_local())
+        result = dtensor[0] if isinstance(dtensor, tuple) else dtensor
+        self.assertEqual(expected_local_tensor, result.to_local())
 
     @with_comms
     def test_make_input_replicate_1d(self):
@@ -187,9 +192,9 @@ class TensorParallelStyleTest(DTensorTestBase):
         dtensor = distribute_tensor(tensor, device_mesh, [Shard(0)])
         output = [dtensor]
         with self.assertRaisesRegex(
-            AssertionError,
-            "Expect output of Tensor Parallel to be a DTensor, but found"
-            f" {type(output)}.",
+            RuntimeError,
+            "Tensor parallel module expects DTensor or tensor"
+            f" when layout specified but received {type(output)}!",
         ):
             func(output, device_mesh)
 
@@ -204,9 +209,10 @@ class TensorParallelStyleTest(DTensorTestBase):
         tensor = torch.rand(8, 16, device=self.device_type)
         rs = RowwiseParallel()
         self._1d_input_func_check(
-            tensor,
+            [tensor],
             tensor,
             rs._prepare_input,
+            error_msgs="No device mesh is currently active",
         )
         # TODO: change output test
         output, dtensor, device_mesh = self._test_prepare_output(
@@ -229,14 +235,40 @@ class TensorParallelStyleTest(DTensorTestBase):
         tensor = torch.rand(8, 16, device=self.device_type)
         cs = ColwiseParallel()
         self._1d_input_func_check(
-            tensor,
+            [tensor],
             tensor,
             cs._prepare_input,
+            error_msgs="No device mesh is currently active",
         )
         output, dtensor, device_mesh = self._test_prepare_output(
             cs._prepare_output, [Shard(-1)]
         )
         self.assertEqual(output, dtensor.to_local())
+
+    @with_comms
+    def test_prepare_module_input(self):
+        tensor = torch.rand(8, 16, device=self.device_type)
+        gathered_tensors = [
+            torch.empty_like(tensor) for _ in range(self.world_size)
+        ]
+        dist.all_gather(gathered_tensors, tensor)
+        gathered_tensors = torch.cat(gathered_tensors, dim=0).contiguous()
+        prepare_hook = PrepareModuleInput(input_layouts=[Shard(0)], output_layouts=[Replicate()])
+        self._1d_input_func_check(
+            [tensor],
+            gathered_tensors,
+            prepare_hook._prepare_input,
+            error_msgs="No device mesh is currently active",
+        )
+
+    @with_comms
+    def test_prepare_module_output(self):
+        tensor = torch.rand(8, 16, device=self.device_type)
+        prepare_hook = PrepareModuleOutput(input_layouts=[Replicate()], output_layouts=[Shard(0)])
+        output, dtensor, device_mesh = self._test_prepare_output(
+            prepare_hook._prepare_output, [Replicate()]
+        )
+        self.assertEqual(output, dtensor.redistribute(device_mesh, [Shard(0)]).to_local())
 
 
 if __name__ == "__main__":

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -394,6 +394,10 @@ class DTensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
         if placements is None:
             raise RuntimeError("placements is needed for redistribute!")
 
+        # Early return the original DTensor if the placements are the same.
+        if self._spec.placements == placements:
+            return self
+
         for placement in placements:
             if placement.is_partial():
                 raise RuntimeError(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #111625

We are refactoring parallel style to solve the following things:
1. To further simplifying code logic to make more readable for users.
2. To remove tuple check so that we can work with dynamo for now. Ideally dynamo needs to support this case and we will fix it in parallel.
3. Add tests for newly added parallel style in UT and torch compile test so that we can capture regression due to code change.
4. Move placements early return check into DTensor since it is by passed by dynamo.
5. Remove PairwiseParallelStyle from unit tests to use the new Col/Rowwise parallel style.