### PR TITLE
python_arg_parser + dynamic shapes: fix segfault coercing symint to intlist

### DIFF
--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -343,6 +343,17 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
         compl_fn = torch.compile(fn, dynamic=True, backend="eager", fullgraph=True)
         self.assertEqual(compl_fn(inputs, dim), fn(inputs, dim))
 
+    # https://github.com/pytorch/pytorch/issues/104812
+    def test_argmin_coerces_symint_to_intlist_spec(self):
+        def fn(x, dim):
+            # the python arg parser coerces dim into a vector<int>
+            return torch.amin(x, dim=dim, keepdim=True)
+
+        x = torch.randn(4, 4, 4)
+        dim = 2
+        compl_fn = torch.compile(fn, dynamic=True, backend="eager", fullgraph=True)
+        self.assertEqual(compl_fn(x, dim), fn(x, dim))
+
     def test_exponential(self):
         def fn(inputs, op_inputs_dict):
             res = inputs.exponential_(**op_inputs_dict)

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -629,6 +629,11 @@ inline std::vector<int64_t> PythonArgs::intlistWithDefault(
   if (size1 > 0 && THPUtils_checkLong(arg)) {
     return std::vector<int64_t>(size1, THPUtils_unpackLong(arg));
   }
+  if (size1 > 0 && torch::is_symint(py::handle(arg))) {
+    return std::vector<int64_t>(
+        size1,
+        py::handle(arg).cast<c10::SymInt>().guard_int(__FILE__, __LINE__));
+  }
   auto tuple = PyTuple_Check(arg);
   // NOLINTNEXTLINE(bugprone-branch-clone)
   const auto size2 = tuple ? PyTuple_GET_SIZE(arg) : PyList_GET_SIZE(arg);


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/104812.

As of https://github.com/pytorch/pytorch/pull/111216, the python arg parser will now guard and cast symints from dynamo into ints when it is forced to (e.g. when we pass a symint to an op that only accepts ints).

But the python arg parser also has logic to try to coerce ints into int[] - we need the same logic for symint -> int[].

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #111554
* __->__ #111642
* #111553



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng