### PR TITLE
[dynamo - testing] Add repro for higher order op list inputs

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -763,6 +763,31 @@ class ActivationCheckpointingViaTagsTests(torch._dynamo.test_case.TestCase):
         ):
             opt_fn(x)
 
+    @requires_cuda()
+    def test_list_inputs(self):
+        class MockModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, ys):
+                a = torch.sin(x)
+                b = torch.cos(ys[0])
+                c = torch.cos(ys[1])
+                return (x, [b, c])
+
+        mod = MockModule().cuda()
+
+        def fn(x, ys):
+            return torch.utils.checkpoint.checkpoint(mod, x, ys)
+
+        x = torch.randn(4, 4).cuda()
+        y = torch.randn(4, 4).cuda()
+        z = torch.randn(4, 4).cuda()
+        ref = fn(x, [y, z])
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        res = opt_fn(x, [y, z])
+        self.assertEqual(ref, res)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests


### PR DESCRIPTION
Add repro from https://github.com/pytorch/pytorch/issues/110118 now that it has been fixed


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @anijain2305 