### PR TITLE
[pytorch-vulkan] Support zero-dim

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/BinaryOp.cpp
+++ b/aten/src/ATen/native/vulkan/ops/BinaryOp.cpp
@@ -402,13 +402,6 @@ Tensor add_tensor(
     const Tensor& self_arg,
     const Tensor& other_arg,
     const Scalar& alpha) {
-  if (other_arg.dim() == 0) {
-    return binary_op_scalar(
-        self_arg,
-        other_arg.item(),
-        c10::optional<Scalar>(),
-        VK_KERNEL(add_scalar));
-  }
   return binary_op_tensor(
       self_arg, other_arg, c10::optional<Scalar>(alpha), VK_KERNEL(add));
 }
@@ -444,13 +437,6 @@ Tensor sub_tensor(
     const Tensor& self_arg,
     const Tensor& other_arg,
     const Scalar& alpha) {
-  if (other_arg.dim() == 0) {
-    return binary_op_scalar(
-        self_arg,
-        other_arg.item(),
-        c10::optional<Scalar>(-1 * alpha.to<float>()),
-        VK_KERNEL(add_scalar));
-  }
   return binary_op_tensor(
       self_arg, other_arg, c10::optional<Scalar>(alpha), VK_KERNEL(sub));
 }
@@ -474,13 +460,6 @@ Tensor& mul_scalar_(Tensor& self, const Scalar& other) {
 }
 
 Tensor mul_tensor(const Tensor& self_arg, const Tensor& other_arg) {
-  if (other_arg.dim() == 0) {
-    return binary_op_scalar(
-        self_arg,
-        other_arg.item(),
-        c10::optional<Scalar>(),
-        VK_KERNEL(mul_scalar));
-  }
   return binary_op_tensor(
       self_arg, other_arg, c10::optional<Scalar>(), VK_KERNEL(mul));
 }
@@ -507,13 +486,6 @@ Tensor& div_scalar_(Tensor& self, const Scalar& other) {
 }
 
 Tensor div_tensor(const Tensor& self_arg, const Tensor& other_arg) {
-  if (other_arg.dim() == 0) {
-    return binary_op_scalar(
-        self_arg,
-        1.0 / other_arg.item().to<float>(),
-        c10::optional<Scalar>(),
-        VK_KERNEL(mul_scalar));
-  }
   return binary_op_tensor(
       self_arg, other_arg, c10::optional<Scalar>(), VK_KERNEL(div));
 }

--- a/aten/src/ATen/native/vulkan/ops/Scalar.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Scalar.cpp
@@ -1,0 +1,33 @@
+#include <ATen/native/vulkan/ops/Common.h>
+
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+namespace {
+
+using namespace api::utils;
+
+Scalar _local_scalar_dense(const Tensor& self) {
+  TORCH_CHECK(
+      self.dtype() == ScalarType::Float, "Only float dtype is supported");
+  return Scalar(self.cpu().item<float>());
+}
+
+#ifdef USE_VULKAN_API
+
+TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
+  m.impl(
+      TORCH_SELECTIVE_NAME("aten::_local_scalar_dense"),
+      TORCH_FN(_local_scalar_dense));
+}
+
+#endif /* USE_VULKAN_API */
+
+} // namespace
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at


### PR DESCRIPTION
Summary:
1. Add zero-dim (Tensor with 1 element) support.
2. New operator `_local_scalar_dense` that map a zero-dim tensor into a Scalar
3. `sum_dim`:
3.1. Add zero-dim support.
3.2. Fix bug in negative indices when handling multi-dim reduction call
3.3. Add unittests to test new coverages
4. Add `aten::sum` support.
5. Change bug in `add_tensor` (and other binary ops), when `other` is zero dim, we will use broadcast instead.

Test Plan:
## Devserver

Full Paste: P858982150

```
[yipjustin@31799.od ~/fbsource (8593e7559)]$ LD_LIBRARY_PATH=third-party/swiftshader/lib/linux-x64/ buck2 run fbcode/mode/dev-nosan  -c pt.has_backtraces=1    //xplat/caffe2:pt_vulkan_api_test_bin  --
File changed: fbsource//xplat/caffe2/aten/src/ATen/test/vulkan_api_test.cpp
Buck UI: https://www.internalfb.com/buck2/90cad0ff-ac98-4dbf-8d6f-0e419c06208d
Network: Up: 43KiB  Down: 1.4MiB  (reSessionID-dfc3a318-fd1a-4ad6-b077-c454ebb4c6a8)
Jobs completed: 6. Time elapsed: 26.4s.
Cache hits: 0%. Commands: 2 (cached: 0, remote: 1, local: 1)
BUILD SUCCEEDED
Running main() from third-party/googletest/1.11.0/googletest/googletest/src/gtest_main.cc
[==========] Running 385 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 385 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.zero_size_tensor
[       OK ] VulkanAPITest.zero_size_tensor (9 ms)
[ RUN      ] VulkanAPITest.zero_dim_tensor_1
[       OK ] VulkanAPITest.zero_dim_tensor_1 (84 ms)
[ RUN      ] VulkanAPITest.zero_dim_tensor_2
[       OK ] VulkanAPITest.zero_dim_tensor_2 (22 ms)
[ RUN      ] VulkanAPITest.local_scalar_dense
[       OK ] VulkanAPITest.local_scalar_dense (10 ms)
...
[       OK ] VulkanAPITest.lstm_prepack_success (2 ms)
[ RUN      ] VulkanAPITest.querypool_flushed_shader_log
xplat/caffe2/aten/src/ATen/test/vulkan_api_test.cpp:7484: Skipped
QueryPool is not available
[  SKIPPED ] VulkanAPITest.querypool_flushed_shader_log (0 ms)
[----------] 385 tests from VulkanAPITest (46915 ms total)
[----------] Global test environment tear-down
[==========] 385 tests from 1 test suite ran. (46915 ms total)
[  PASSED  ] 382 tests.
[  SKIPPED ] 1 test, listed below:
[  SKIPPED ] VulkanAPITest.querypool_flushed_shader_log
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] VulkanAPITest.conv2d_pw_prepack
[  FAILED  ] VulkanAPITest.conv2d_pw_prepack_bc
 2 FAILED TESTS
  YOU HAVE 7 DISABLED TESTS
```

## M1 MAC

P859975219
```
buck run //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64   --target-platforms ovr_config//platform/macos:arm64-fbsource -- --gtest_filter="*"
Using additional configuration options from .buckconfig.local
Building: finished in 0.2 sec (100%) 269/2875 jobs, 0/2875 updated
  Total time: 0.2 sec
BUILD SUCCEEDED
Running main() from third-party/googletest/1.11.0/googletest/googletest/src/gtest_main.cc
[==========] Running 384 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 384 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.zero_size_tensor
[       OK ] VulkanAPITest.zero_size_tensor (40 ms)
[ RUN      ] VulkanAPITest.zero_dim_tensor_1
[       OK ] VulkanAPITest.zero_dim_tensor_1 (7 ms)
[ RUN      ] VulkanAPITest.zero_dim_tensor_2
[       OK ] VulkanAPITest.zero_dim_tensor_2 (1 ms)
[ RUN      ] VulkanAPITest.local_scalar_dense
[       OK ] VulkanAPITest.local_scalar_dense (0 ms)
[ RUN      ] VulkanAPITest.copy_to_texture
[       OK ] VulkanAPITest.copy_to_texture (45 ms)
...
[  SKIPPED ] VulkanAPITest.querypool_flushed_shader_log (0 ms)
[----------] 384 tests from VulkanAPITest (5127 ms total)

[----------] Global test environment tear-down
[==========] 384 tests from 1 test suite ran. (5127 ms total)
[  PASSED  ] 382 tests.
[  SKIPPED ] 1 test, listed below:
[  SKIPPED ] VulkanAPITest.querypool_flushed_shader_log
[  FAILED  ] 1 test, listed below:
[  FAILED  ] VulkanAPITest.normal_large

 1 FAILED TEST
  YOU HAVE 5 DISABLED TESTS
```

Differential Revision: D50347338


