### PR TITLE
Fix create source distribution step for release

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -30,13 +30,14 @@ jobs:
         run: |
           tag_or_branch="${PT_GITHUB_REF#refs/tags/}"
           tag_or_branch="${tag_or_branch#refs/heads/}"
+          # replace directory separators with _ in branch name
+          tag_or_branch="${tag_or_branch//\//_}"
           echo "PT_RELEASE_NAME=pytorch-$tag_or_branch" >> "$GITHUB_ENV"
           echo "PT_RELEASE_FILE=pytorch-$tag_or_branch.tar.gz" >> "$GITHUB_ENV"
       - name: Create source distribution
         run: |
             # Create new folder with specified name so extracting the archive yields that
             rm -rf "/tmp/$PT_RELEASE_NAME"
-            mkdir "/tmp/$PT_RELEASE_NAME"
             cp -r "$PWD" "/tmp/$PT_RELEASE_NAME"
             mv "/tmp/$PT_RELEASE_NAME" .
             # Cleanup

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
             # Create new folder with specified name so extracting the archive yields that
             rm -rf "/tmp/$PT_RELEASE_NAME"
+            mkdir "/tmp/$PT_RELEASE_NAME"
             cp -r "$PWD" "/tmp/$PT_RELEASE_NAME"
             mv "/tmp/$PT_RELEASE_NAME" .
             # Cleanup


### PR DESCRIPTION
This is fixing following failure in the release branch:
```
cp: cannot create directory '/tmp/pytorch-release/2.1': No such file or directory
```
Link: https://github.com/pytorch/pytorch/actions/runs/6591657669/job/17910724990

cp will report that error if the parent directory (pytorch-release in this case) does not exist. 
This is working in main since ``PT_RELEASE_NAME: pytorch-main`` however for release its ``PT_RELEASE_NAME: pytorch-release/2.1`` 

Test:
```
export tag_or_branch=release/2.1
tag_or_branch="${tag_or_branch//\//_}"
echo $tag_or_branch 
release_2.1
```
