### PR TITLE
[inductor] Move inductor ops to CompositeExplicitAutograd

### DIFF
--- a/torch/csrc/inductor/inductor_ops.cpp
+++ b/torch/csrc/inductor/inductor_ops.cpp
@@ -59,10 +59,11 @@ static void accumulate_grad_(const Tensor& variable, const Tensor& new_grad) {
 TORCH_LIBRARY_FRAGMENT(inductor, m) {
   m.def(
       "_mm_plus_mm(Tensor a, Tensor b, Tensor c, Tensor d, Tensor(t!) out) -> Tensor(t!)",
-      _mm_plus_mm);
+      dispatch(c10::DispatchKey::CompositeExplicitAutograd, _mm_plus_mm));
   m.def(
       "_reinterpret_tensor(Tensor self, int[] size, int[] stride, int offset_increment=0) -> Tensor",
-      _reinterpret_tensor);
+      dispatch(
+          c10::DispatchKey::CompositeExplicitAutograd, _reinterpret_tensor));
   m.def(
       "accumulate_grad_(Tensor variable, Tensor new_grad) -> ()",
       dispatch(c10::DispatchKey::CompositeExplicitAutograd, accumulate_grad_));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #111702
* #111701
* #111700

Relands #111274