### PR TITLE
[torch] Add LOAD_METHOD_SUPER and LOAD_ATTR_SUPER

### DIFF
--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1189,6 +1189,21 @@ class InstructionTranslatorBase(Checkpointable[InstructionTranslatorGraphState])
         assert len(kwargs) == len(argnames)
         self.call_function(fn, args, kwargs)
 
+    def LOAD_METHOD_SUPER(self, inst):
+        self.CALL_FUNCTION(dataclasses.replace(inst, argval=2))
+        arg = inst.argval[0]
+        argval = self.code_options["co_names"][arg]
+        if sys.version_info < (3, 11):
+            self.LOAD_ATTR(dataclasses.replace(inst, argval=argval))
+        else:
+            self.LOAD_METHOD(dataclasses.replace(inst, argval=argval))
+
+    def LOAD_ATTR_SUPER(self, inst):
+        self.CALL_FUNCTION(dataclasses.replace(inst, argval=2))
+        arg = inst.argval[0]
+        argval = self.code_options["co_names"][arg]
+        self.LOAD_ATTR(dataclasses.replace(inst, argval=argval))
+
     def LOAD_METHOD(self, inst):
         self.LOAD_ATTR(inst)
         obj = self.pop()


### PR DESCRIPTION
Summary:
Cinder has two new opcodes which optimize `super()` in classes. This implements
the opcodes for `torch._dynamo`.

Test Plan:
```
buck2 test mode/opt-split-dwarf aps_models/ads/icvr/... -c fbcode.use_cinder_fast_test=true
```

Differential Revision: D50516475




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng