### PR TITLE
[TorchFix] Update old pretrained TorchVision API in tests

### DIFF
--- a/test/mobile/custom_build/prepare_model.py
+++ b/test/mobile/custom_build/prepare_model.py
@@ -5,12 +5,11 @@ build script to create a tailored build which only contains these used ops.
 """
 
 import torch
-import torchvision
 import yaml
 from torchvision import models
 
 # Download and trace the model.
-model = torchvision.models.mobilenet_v2(weights=models.MobileNet_V2_Weights.IMAGENET1K_V1)
+model = models.mobilenet_v2(weights=models.MobileNet_V2_Weights.IMAGENET1K_V1)
 model.eval()
 example = torch.rand(1, 3, 224, 224)
 traced_script_module = torch.jit.trace(model, example)

--- a/test/mobile/custom_build/prepare_model.py
+++ b/test/mobile/custom_build/prepare_model.py
@@ -7,9 +7,10 @@ build script to create a tailored build which only contains these used ops.
 import torch
 import torchvision
 import yaml
+from torchvision import models
 
 # Download and trace the model.
-model = torchvision.models.mobilenet_v2(pretrained=True)
+model = torchvision.models.mobilenet_v2(weights=models.MobileNet_V2_Weights.IMAGENET1K_V1)
 model.eval()
 example = torch.rand(1, 3, 224, 224)
 traced_script_module = torch.jit.trace(model, example)

--- a/test/mobile/model_test/torchvision_models.py
+++ b/test/mobile/model_test/torchvision_models.py
@@ -2,11 +2,12 @@ import torch
 import torchvision
 from torch.utils.bundled_inputs import augment_model_with_bundled_inputs
 from torch.utils.mobile_optimizer import optimize_for_mobile
+from torchvision import models
 
 
 class MobileNetV2Module:
     def getModule(self):
-        model = torchvision.models.mobilenet_v2(pretrained=True)
+        model = torchvision.models.mobilenet_v2(weights=models.MobileNet_V2_Weights.IMAGENET1K_V1)
         model.eval()
         example = torch.zeros(1, 3, 224, 224)
         traced_script_module = torch.jit.trace(model, example)
@@ -23,7 +24,7 @@ class MobileNetV2Module:
 
 class MobileNetV2VulkanModule:
     def getModule(self):
-        model = torchvision.models.mobilenet_v2(pretrained=True)
+        model = torchvision.models.mobilenet_v2(weights=models.MobileNet_V2_Weights.IMAGENET1K_V1)
         model.eval()
         example = torch.zeros(1, 3, 224, 224)
         traced_script_module = torch.jit.trace(model, example)
@@ -40,7 +41,7 @@ class MobileNetV2VulkanModule:
 
 class Resnet18Module:
     def getModule(self):
-        model = torchvision.models.resnet18(pretrained=True)
+        model = torchvision.models.resnet18(weights=models.ResNet18_Weights.IMAGENET1K_V1)
         model.eval()
         example = torch.zeros(1, 3, 224, 224)
         traced_script_module = torch.jit.trace(model, example)

--- a/test/mobile/model_test/torchvision_models.py
+++ b/test/mobile/model_test/torchvision_models.py
@@ -1,5 +1,4 @@
 import torch
-import torchvision
 from torch.utils.bundled_inputs import augment_model_with_bundled_inputs
 from torch.utils.mobile_optimizer import optimize_for_mobile
 from torchvision import models
@@ -7,7 +6,7 @@ from torchvision import models
 
 class MobileNetV2Module:
     def getModule(self):
-        model = torchvision.models.mobilenet_v2(weights=models.MobileNet_V2_Weights.IMAGENET1K_V1)
+        model = models.mobilenet_v2(weights=models.MobileNet_V2_Weights.IMAGENET1K_V1)
         model.eval()
         example = torch.zeros(1, 3, 224, 224)
         traced_script_module = torch.jit.trace(model, example)
@@ -24,7 +23,7 @@ class MobileNetV2Module:
 
 class MobileNetV2VulkanModule:
     def getModule(self):
-        model = torchvision.models.mobilenet_v2(weights=models.MobileNet_V2_Weights.IMAGENET1K_V1)
+        model = models.mobilenet_v2(weights=models.MobileNet_V2_Weights.IMAGENET1K_V1)
         model.eval()
         example = torch.zeros(1, 3, 224, 224)
         traced_script_module = torch.jit.trace(model, example)
@@ -41,7 +40,7 @@ class MobileNetV2VulkanModule:
 
 class Resnet18Module:
     def getModule(self):
-        model = torchvision.models.resnet18(weights=models.ResNet18_Weights.IMAGENET1K_V1)
+        model = models.resnet18(weights=models.ResNet18_Weights.IMAGENET1K_V1)
         model.eval()
         example = torch.zeros(1, 3, 224, 224)
         traced_script_module = torch.jit.trace(model, example)

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -261,7 +261,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         # So we are explicitly calling `model.eval()` for any model that contains
         # batch norm.
         # Ref: https://github.com/pytorch/pytorch/issues/99662#issuecomment-1528178221
-        model = torchvision.models.resnet18(pretrained=False).eval()
+        model = torchvision.models.resnet18(weights=None).eval()
         dummy_input = torch.randn(1, 3, 224, 224)
 
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(
@@ -276,7 +276,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
     @skip_if_no_torchvision
     def test_shufflenet_v2(self):
         # TODO(bowbao): see Note [training vs eval in dynamo_export]
-        model = torchvision.models.shufflenet_v2_x0_5(pretrained=False).eval()
+        model = torchvision.models.shufflenet_v2_x0_5(weights=None).eval()
         dummy_input = torch.randn(1, 3, 224, 224, requires_grad=False)
         test_inputs = torch.randn(3, 3, 224, 224, requires_grad=False)
 

--- a/test/onnx/test_models.py
+++ b/test/onnx/test_models.py
@@ -253,7 +253,7 @@ class TestModels(pytorch_test_common.ExportTestCase):
     def test_fcn(self):
         x = Variable(torch.randn(BATCH_SIZE, 3, 224, 224).fill_(1.0))
         self.exportTest(
-            toC(fcn_resnet101(pretrained=False, pretrained_backbone=False)),
+            toC(fcn_resnet101(weights=None, weights_backbone=None)),
             toC(x),
             rtol=1e-3,
             atol=1e-5,
@@ -263,7 +263,7 @@ class TestModels(pytorch_test_common.ExportTestCase):
     def test_deeplab(self):
         x = Variable(torch.randn(BATCH_SIZE, 3, 224, 224).fill_(1.0))
         self.exportTest(
-            toC(deeplabv3_resnet101(pretrained=False, pretrained_backbone=False)),
+            toC(deeplabv3_resnet101(weights=None, weights_backbone=None)),
             toC(x),
             rtol=1e-3,
             atol=1e-5,

--- a/test/onnx/test_models_onnxruntime.py
+++ b/test/onnx/test_models_onnxruntime.py
@@ -420,7 +420,7 @@ class TestModelsONNXRuntime(onnx_test_common._TestONNXRuntime):
     @skipIfUnsupportedMinOpsetVersion(11)
     @skipScriptTest()
     def test_shufflenet_v2_dynamic_axes(self):
-        model = torchvision.models.shufflenet_v2_x0_5(pretrained=False)
+        model = torchvision.models.shufflenet_v2_x0_5(weights=None)
         dummy_input = torch.randn(1, 3, 224, 224, requires_grad=True)
         test_inputs = torch.randn(3, 3, 224, 224, requires_grad=True)
         self.run_test(

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -1668,7 +1668,7 @@ class TestUtilityFuns(_BaseTestCase):
         self.assertEqual(len(list(graph.nodes())), 1)
 
     def test_fuse_resnet18(self):
-        model = torchvision.models.resnet18(pretrained=False)
+        model = torchvision.models.resnet18(weights=None)
         x = torch.randn(2, 3, 224, 224, requires_grad=True)
         graph, _, __ = self._model_to_graph(
             model,

--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -1440,12 +1440,12 @@ class TestMkldnn(TestCase):
 
     @skipIfNoTorchVision
     def test_resnet18(self):
-        model = torchvision.models.resnet.resnet18(pretrained=False)
+        model = torchvision.models.resnet.resnet18(weights=None)
         self._test_imagenet_model(model)
 
     @skipIfNoTorchVision
     def test_resnext50_32x4d(self):
-        model = torchvision.models.resnet.resnext50_32x4d(pretrained=False)
+        model = torchvision.models.resnet.resnext50_32x4d(weights=None)
         self._test_imagenet_model(model)
 
     def _lstm_params_list(self):


### PR DESCRIPTION
For TorchVision models, `pretrained` parameters have been deprecated in favor of "Multi-weight support API" - see https://pytorch.org/vision/0.15/models.html

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10