### PR TITLE
Re-enable some embedded bag tests

### DIFF
--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -1018,7 +1018,6 @@ class TestEmbeddingNNDeviceType(NNTestCase):
             self.assertEqual(per_sample_weights.grad, per_sample_weights_reference.grad,
                              atol=dtype2prec_DONTUSE[wdtype], rtol=0)
 
-    @skipCUDAIf(True, "Temporarily disabled. See t54369166")
     @dtypesIfCUDA(*itertools.product((torch.int, torch.long), (torch.half, torch.float, torch.double)))
     @dtypes(*itertools.product((torch.int, torch.long), (torch.float, torch.double)))
     def test_EmbeddingBag_per_sample_weights_and_no_offsets(self, device, dtypes):

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -1009,7 +1009,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
         # We have more floating point error here because we are dealing with larger numbers
         if backward_prec is None:
             needed_prec = dtype2prec_DONTUSE[wdtype] * 5
-            rtol = 0.02 if wdtype==torch.half else 0
+            rtol = 0.02 if wdtype == torch.half else 0
         else:
             needed_prec = backward_prec
             rtol = 0

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -1009,10 +1009,12 @@ class TestEmbeddingNNDeviceType(NNTestCase):
         # We have more floating point error here because we are dealing with larger numbers
         if backward_prec is None:
             needed_prec = dtype2prec_DONTUSE[wdtype] * 5
+            rtol = 0.02 if wdtype==torch.half else 0
         else:
             needed_prec = backward_prec
+            rtol = 0
 
-        self.assertEqual(es_weight_grad, e.weight.grad, atol=needed_prec, rtol=0)
+        self.assertEqual(es_weight_grad, e.weight.grad, atol=needed_prec, rtol=rtol)
 
         if test_per_sample_weights and trainable_per_sample_weights:
             self.assertEqual(per_sample_weights.grad, per_sample_weights_reference.grad,


### PR DESCRIPTION
They were temporary disabled in 2019 by  https://github.com/pytorch/pytorch/pull/26599

As suggested, increased relative tolerance from 0 to 2% when tests are using float16 dtype

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1e49d84</samp>

> _`TestEmbeddingNN`_
> _CUDA tests restored_
> _Bug fixed in autumn breeze_
