### PR TITLE
[Export] Don't serialize missing args with default value

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -174,11 +174,11 @@ class TestSerialize(TestCase):
 
         node = serialized.graph_module.graph.nodes[-1]
         self.assertEqual(node.target, "torch.ops.aten.searchsorted.Tensor")
-        self.assertEqual(len(node.inputs), 6)
-        self.assertEqual(node.inputs[2].arg.as_bool, False)
-        self.assertEqual(node.inputs[3].arg.as_bool, True)
-        self.assertEqual(node.inputs[4].arg.as_string, "right")
-        self.assertEqual(node.inputs[5].arg.as_none, ())
+        self.assertEqual(len(node.inputs), 4)
+        self.assertEqual(node.inputs[2].name, "right")
+        self.assertEqual(node.inputs[2].arg.as_bool, True)
+        self.assertEqual(node.inputs[3].name, "side")
+        self.assertEqual(node.inputs[3].arg.as_string, "right")
 
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -459,7 +459,7 @@ class GraphModuleSerializer:
         return serialized_args
 
     def serialize_inputs(
-        self, target: torch._ops.OpOverload, args, kwargs=None, include_default_values=True
+        self, target: torch._ops.OpOverload, args, kwargs=None
     ) -> List[NamedArgument]:
         assert isinstance(target, torch._ops.OpOverload)
         kwargs = kwargs or {}
@@ -480,13 +480,10 @@ class GraphModuleSerializer:
                     )
                 )
             else:
-                if include_default_values:
-                    serialized_args.append(
-                        NamedArgument(
-                            name=schema_arg.name,
-                            arg=self.serialize_input(schema_arg.default_value),
-                        )
-                    )
+                # We intentionally don't serialize the missing arguments
+                # with default values
+                pass
+
 
         return serialized_args
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4238,9 +4238,7 @@ class FallbackKernel(ExternKernelAlloc):
         ]
 
         serializer = GraphModuleSerializer(None, None)
-        named_arguments = serializer.serialize_inputs(
-            self.op_overload, args, kwargs, include_default_values=False
-        )
+        named_arguments = serializer.serialize_inputs(self.op_overload, args, kwargs)
 
         # serialize_outputs
         def handle_single_output(return_type, output):


### PR DESCRIPTION
Summary: Per https://docs.google.com/document/d/1FzWm-sHYwmRi3x_g036kOxd99KaYquUsA-L5JwOn8ys/edit

I wonder if this would break executorch? @larryliu0820 
I see exir/serialize.py using export's GraphModuleSerializer. 

Test Plan: Existing CIs

Differential Revision: D50519217




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan