### PR TITLE
[TD] Add Test Removal Metrics

### DIFF
--- a/tools/testing/target_determination/dry_run.py
+++ b/tools/testing/target_determination/dry_run.py
@@ -85,7 +85,7 @@ def calculate_recall(
     ground_truth_failures_set = set(ground_truth_failures)
 
     # Calculate True Positives (TP), False Positives (FP), and False Negatives (FN)
-    TP = len(ground_truth_failures_set.intersection(selected_tests))
+    TP = len(ground_truth_failures_set.intersection(selected_tests_set))
     FN = len(ground_truth_failures_set) - TP
 
     # Calculate recall and precision

--- a/tools/testing/target_determination/dry_run.py
+++ b/tools/testing/target_determination/dry_run.py
@@ -1,8 +1,10 @@
-from typing import List, Tuple, Callable, Any, Dict
-import requests
-import random
 import json
+import os
+from typing import Any, Callable, Dict, List, Tuple
+
+import requests
 from tools.stats.upload_metrics import emit_metric
+
 
 class EnvVarMetric:
     name: str
@@ -41,11 +43,12 @@ class EnvVarMetric:
             return self.type_conversion_fn(value)
         return value
 
+
 BUILD_ENVIRONMENT = EnvVarMetric("build_environment", "BUILD_ENVIRONMENT").value()
 TEST_CONFIG = EnvVarMetric("test_config", "TEST_CONFIG", required=False).value()
 
-def get_github_json():
 
+def get_github_json() -> Dict[str, Any]:
     data = {}
 
     # Define the URL of the JSON file in the GitHub repo
@@ -56,28 +59,17 @@ def get_github_json():
 
     # Check if the request was successful
     if response.status_code == 200:
-        data = json.loads(response.content.decode('utf-8'))
-        
+        data = json.loads(response.content.decode("utf-8"))
+
     else:
         # TODO: Should we fail silently here?
         print(f"Failed to download the file. Status code: {response.status_code}")
     return data
 
-def get_test_time_in_seconds_from_data(data: Dict[str, float], test_name: str) -> float:
-    """
-    Get the test time in seconds from the JSON data.
 
-    Parameters:
-    - data: Dictionary containing the JSON data.
-    - test_name: Name of the test.
-
-    Returns:
-    - Test time in seconds.
-    """
-    # return data[BUILD_ENVIRONMENT.value()][TEST_CONFIG.value()][test_name]
-    return data[BUILD_ENVIRONMENT][TEST_CONFIG][test_name]
-
-def calculate_recall(selected_tests: List[str], ground_truth_failures: List[str]) -> float:
+def calculate_recall(
+    selected_tests: List[str], ground_truth_failures: List[str]
+) -> float:
     """
     Calculate recall and precision statistics for test selection.
 
@@ -90,7 +82,6 @@ def calculate_recall(selected_tests: List[str], ground_truth_failures: List[str]
     """
     # Convert lists to sets for faster look-up
     selected_tests_set = set(selected_tests)
-    ignored_tests_set = set(ignored_tests)
     ground_truth_failures_set = set(ground_truth_failures)
 
     # Calculate True Positives (TP), False Positives (FP), and False Negatives (FN)
@@ -102,7 +93,8 @@ def calculate_recall(selected_tests: List[str], ground_truth_failures: List[str]
 
     return recall
 
-def calculate_test_times_sum(ignored_tests: List[str]) -> Dict[str, float]:
+
+def calculate_test_times_sum(ignored_tests: List[str]) -> float:
     """
     Calculate the sum of the test times for the selected tests.
 
@@ -116,63 +108,82 @@ def calculate_test_times_sum(ignored_tests: List[str]) -> Dict[str, float]:
     ignored_tests_set = set(ignored_tests)
     data = get_github_json()
     # Calculate test times sum
-    test_times_sum = sum(get_test_time_in_seconds_from_data(data, test) for test in ignored_tests_set)
+    test_times_sum = sum(
+        data[BUILD_ENVIRONMENT][TEST_CONFIG][test] for test in ignored_tests_set
+    )
+    # assert total_test_times is a float
+    assert isinstance(test_times_sum, float)
+    return test_times_sum
 
-    return {'total_saved_test_time_seconds': test_times_sum}
 
-def calculate_failed_tests_in_ignored_tests(ignored_tests: List[str], ground_truth_failures: List[str]) -> int:
-
+def calculate_failed_tests_in_ignored_tests(
+    ignored_tests: List[str], ground_truth_failures: List[str]
+) -> int:
     ignored_tests_set = set(ignored_tests)
     ground_truth_failures_set = set(ground_truth_failures)
     return len(ground_truth_failures_set.intersection(ignored_tests_set))
 
 
-def get_metrics_dict_for_td_strategy(strategy_name, selected_tests, ignored_tests, ground_truth_failures):
-    metrics_dict = {}
+def get_metrics_dict_for_td_strategy(
+    strategy_name: str,
+    selected_tests: List[str],
+    ignored_tests: List[str],
+    ground_truth_failures: List[str],
+) -> Dict[str, Any]:
+    metrics_dict: Dict[str, Any] = {}
     # recall here is percent of failed tests that were selected
     metrics_dict["recall"] = calculate_recall(selected_tests, ground_truth_failures)
     metrics_dict["contained_failure"] = len(ground_truth_failures) > 0
     metrics_dict["num_ignored_failed_tests"] = len(ignored_tests)
     metrics_dict["time_saved_seconds"] = calculate_test_times_sum(ignored_tests)
-    metrics_dict['strategy_name'] = strategy_name
+    metrics_dict["strategy_name"] = strategy_name
     metrics_dict["metric_type"] = "td_strategy"
     return metrics_dict
+
 
 # The emit_metrics_decorator function is a decorator that emits metrics for a test dependency strategy.
 # The function takes a function as an argument, and returns a new function that emits metrics for the decorated function.
 
-def emit_td_dry_run_metrics(func: Callable[..., Tuple[str, List[str], List[str], List[str]]]) -> Callable[..., Tuple[str, List[str], List[str], List[str]]]:
+
+def emit_td_dry_run_metrics(
+    func: Callable[..., Tuple[str, List[str], List[str], List[str]]]
+) -> Callable[..., Tuple[str, List[str], List[str], List[str]]]:
     """
     Decorator to emit metrics based on the output of the decorated function.
-    
+
     Parameters:
         func (Callable): The function to be decorated.
-        
+
     Returns:
         Callable: The decorated function.
     """
-    def wrapper(*args: Any, **kwargs: Any) -> Tuple[str, List[str], List[str], List[str]]:
+
+    def wrapper(
+        *args: Any, **kwargs: Any
+    ) -> Tuple[str, List[str], List[str], List[str]]:
         """
         Wrapper function to execute the decorated function and emit metrics.
-        
+
         Parameters:
             *args (Any): Positional arguments for the decorated function.
             **kwargs (Any): Keyword arguments for the decorated function.
-            
+
         Returns:
             Tuple[str, List[str], List[str], List[str]]: The original output of the decorated function.
         """
         # Run the decorated function and store its output
         output = func(*args, **kwargs)
-        
+
         # Unpack the output to get the required variables
         strategy_name, selected_tests, ignored_tests, ground_truth_failures = output
-        
+
         # Perform additional actions (in this example, emitting metrics)
-        metrics_dict = get_metrics_dict_for_td_strategy(strategy_name, selected_tests, ignored_tests, ground_truth_failures)
+        metrics_dict = get_metrics_dict_for_td_strategy(
+            strategy_name, selected_tests, ignored_tests, ground_truth_failures
+        )
         emit_metric(f"{strategy_name}_td_stats", metrics_dict)
-        
+
         # Return the original output of the decorated function
         return output
-    
+
     return wrapper

--- a/tools/testing/target_determination/dry_run.py
+++ b/tools/testing/target_determination/dry_run.py
@@ -1,0 +1,178 @@
+from typing import List, Tuple, Callable, Any, Dict
+import requests
+import random
+import json
+from tools.stats.upload_metrics import emit_metric
+
+class EnvVarMetric:
+    name: str
+    env_var: str
+    required: bool = True
+    # Used to cast the value of the env_var to the correct type (defaults to str)
+    type_conversion_fn: Any = None
+
+    def __init__(
+        self,
+        name: str,
+        env_var: str,
+        required: bool = True,
+        type_conversion_fn: Any = None,
+    ) -> None:
+        self.name = name
+        self.env_var = env_var
+        self.required = required
+        self.type_conversion_fn = type_conversion_fn
+
+    def value(self) -> Any:
+        value = os.environ.get(self.env_var)
+
+        # Github CI will set some env vars to an empty string
+        DEFAULT_ENVVAR_VALUES = [None, ""]
+        if value in DEFAULT_ENVVAR_VALUES:
+            if not self.required:
+                return None
+
+            raise ValueError(
+                f"Missing {self.name}. Please set the {self.env_var} "
+                "environment variable to pass in this value."
+            )
+
+        if self.type_conversion_fn:
+            return self.type_conversion_fn(value)
+        return value
+
+BUILD_ENVIRONMENT = EnvVarMetric("build_environment", "BUILD_ENVIRONMENT").value()
+TEST_CONFIG = EnvVarMetric("test_config", "TEST_CONFIG", required=False).value()
+
+def get_github_json():
+
+    data = {}
+
+    # Define the URL of the JSON file in the GitHub repo
+    url = "https://raw.githubusercontent.com/pytorch/test-infra/generated-stats/stats/test-times.json"
+
+    # Fetch the file
+    response = requests.get(url)
+
+    # Check if the request was successful
+    if response.status_code == 200:
+        data = json.loads(response.content.decode('utf-8'))
+        
+    else:
+        # TODO: Should we fail silently here?
+        print(f"Failed to download the file. Status code: {response.status_code}")
+    return data
+
+def get_test_time_in_seconds_from_data(data: Dict[str, float], test_name: str) -> float:
+    """
+    Get the test time in seconds from the JSON data.
+
+    Parameters:
+    - data: Dictionary containing the JSON data.
+    - test_name: Name of the test.
+
+    Returns:
+    - Test time in seconds.
+    """
+    # return data[BUILD_ENVIRONMENT.value()][TEST_CONFIG.value()][test_name]
+    return data[BUILD_ENVIRONMENT][TEST_CONFIG][test_name]
+
+def calculate_recall(selected_tests: List[str], ground_truth_failures: List[str]) -> float:
+    """
+    Calculate recall and precision statistics for test selection.
+
+    Parameters:
+    - selected_tests: List of tests that were selected to be run.
+    - ground_truth_failures: List of tests that are known to actually fail.
+
+    Returns:
+    - float containing 'recall' stat.
+    """
+    # Convert lists to sets for faster look-up
+    selected_tests_set = set(selected_tests)
+    ignored_tests_set = set(ignored_tests)
+    ground_truth_failures_set = set(ground_truth_failures)
+
+    # Calculate True Positives (TP), False Positives (FP), and False Negatives (FN)
+    TP = len(ground_truth_failures_set.intersection(selected_tests))
+    FN = len(ground_truth_failures_set) - TP
+
+    # Calculate recall and precision
+    recall = TP / (TP + FN) if (TP + FN) != 0 else 0.0
+
+    return recall
+
+def calculate_test_times_sum(ignored_tests: List[str]) -> Dict[str, float]:
+    """
+    Calculate the sum of the test times for the selected tests.
+
+    Parameters:
+    - ignored_tests: List of tests that were ignored.
+
+    Returns:
+    - Dictionary containing 'test_times_sum' statistic.
+    """
+    # Convert lists to sets for faster look-up
+    ignored_tests_set = set(ignored_tests)
+    data = get_github_json()
+    # Calculate test times sum
+    test_times_sum = sum(get_test_time_in_seconds_from_data(data, test) for test in ignored_tests_set)
+
+    return {'total_saved_test_time_seconds': test_times_sum}
+
+def calculate_failed_tests_in_ignored_tests(ignored_tests: List[str], ground_truth_failures: List[str]) -> int:
+
+    ignored_tests_set = set(ignored_tests)
+    ground_truth_failures_set = set(ground_truth_failures)
+    return len(ground_truth_failures_set.intersection(ignored_tests_set))
+
+
+def get_metrics_dict_for_td_strategy(strategy_name, selected_tests, ignored_tests, ground_truth_failures):
+    metrics_dict = {}
+    # recall here is percent of failed tests that were selected
+    metrics_dict["recall"] = calculate_recall(selected_tests, ground_truth_failures)
+    metrics_dict["contained_failure"] = len(ground_truth_failures) > 0
+    metrics_dict["num_ignored_failed_tests"] = len(ignored_tests)
+    metrics_dict["time_saved_seconds"] = calculate_test_times_sum(ignored_tests)
+    metrics_dict['strategy_name'] = strategy_name
+    metrics_dict["metric_type"] = "td_strategy"
+    return metrics_dict
+
+# The emit_metrics_decorator function is a decorator that emits metrics for a test dependency strategy.
+# The function takes a function as an argument, and returns a new function that emits metrics for the decorated function.
+
+def emit_td_dry_run_metrics(func: Callable[..., Tuple[str, List[str], List[str], List[str]]]) -> Callable[..., Tuple[str, List[str], List[str], List[str]]]:
+    """
+    Decorator to emit metrics based on the output of the decorated function.
+    
+    Parameters:
+        func (Callable): The function to be decorated.
+        
+    Returns:
+        Callable: The decorated function.
+    """
+    def wrapper(*args: Any, **kwargs: Any) -> Tuple[str, List[str], List[str], List[str]]:
+        """
+        Wrapper function to execute the decorated function and emit metrics.
+        
+        Parameters:
+            *args (Any): Positional arguments for the decorated function.
+            **kwargs (Any): Keyword arguments for the decorated function.
+            
+        Returns:
+            Tuple[str, List[str], List[str], List[str]]: The original output of the decorated function.
+        """
+        # Run the decorated function and store its output
+        output = func(*args, **kwargs)
+        
+        # Unpack the output to get the required variables
+        strategy_name, selected_tests, ignored_tests, ground_truth_failures = output
+        
+        # Perform additional actions (in this example, emitting metrics)
+        metrics_dict = get_metrics_dict_for_td_strategy(strategy_name, selected_tests, ignored_tests, ground_truth_failures)
+        emit_metric(f"{strategy_name}_td_stats", metrics_dict)
+        
+        # Return the original output of the decorated function
+        return output
+    
+    return wrapper

--- a/tools/testing/target_determination/td_algos/default_heuristics.py
+++ b/tools/testing/target_determination/td_algos/default_heuristics.py
@@ -1,34 +1,35 @@
 import random
-from typing import List, Dict, Any, Tuple
+from typing import Any, Dict, List, Tuple
 
-from torch.testing._internal.common_utils import IS_CI
 from tools.stats.upload_metrics import emit_metric
 from tools.testing.target_determination.determinator import get_test_prioritizations
 from tools.testing.target_determination.dry_run import emit_td_dry_run_metrics
-from tools.testing.target_determination.heuristics import (
-    AggregatedHeuristics
-)
+from tools.testing.target_determination.heuristics import AggregatedHeuristics
+from tools.testing.target_determination.heuristics.interface import TestPrioritizations
 from tools.testing.test_selections import get_test_case_configs
 
+from torch.testing._internal.common_utils import IS_CI
 
 
 # This strategy uses our baseline heuristics, and then randomly eliminates unranked tests
 REMOVAL_PROBABILITY = 0.2
 VERSION = "0.0.1"
 
-class DefaultHeuristic:
 
+class DefaultHeuristic:
     def __init__(self, tests_to_run: List[str], test_directory: str, is_cpp: bool):
         self.tests_to_run = tests_to_run
         self.test_directory = test_directory
         self.is_cpp = is_cpp
-        self.aggregated_heuristics, self.metrics_dict = self.get_baseline_heuristics(tests_to_run, test_directory, is_cpp)
-
-
-    def get_baseline_heuristics(self, tests_to_run: List[str], test_directory: str, is_cpp: bool) -> AggregatedHeuristics, Dict[str, Any]:
-        aggregated_heuristics: AggregatedHeuristics = AggregatedHeuristics(
-            unranked_tests=tests_to_run
+        self.aggregated_heuristics = AggregatedHeuristics(unranked_tests=tests_to_run)
+        self.test_prioritizations, self.metrics_dict = self.get_baseline_heuristics(
+            tests_to_run, test_directory, is_cpp
         )
+
+    def get_baseline_heuristics(
+        self, tests_to_run: List[str], test_directory: str, is_cpp: bool
+    ) -> Tuple[TestPrioritizations, Dict[str, Any]]:
+        aggregated_heuristics = self.aggregated_heuristics
         metrics_dict = {}
         if IS_CI:
             # downloading test cases configuration to local environment
@@ -48,20 +49,24 @@ class DefaultHeuristic:
         return test_prioritizations, metrics_dict
 
     def get_individual_test_stats(self, test_name: str) -> Dict[str, Any]:
-        return self.aggregated_heuristics.get_individual_test_stats(test_name)
+        return self.aggregated_heuristics.get_test_stats(test_name)
 
-    def get_test_prioritizations(self) -> AggregatedHeuristics:
-        return self.aggregated_heuristics
+    def get_test_prioritizations(self) -> TestPrioritizations:
+        return self.test_prioritizations
+
     def get_metrics_dict(self) -> Dict[str, Any]:
         return self.metrics_dict
-    def add_metrics(self, metrics_dict: Dict[str, Any]):
+
+    def add_metrics(self, metrics_dict: Dict[str, Any]) -> None:
         self.metrics_dict.update(metrics_dict)
 
-    def emit_metrics(self, name: str):
+    def emit_metrics(self, name: str) -> None:
         emit_metric(name, self.metrics_dict)
 
     @emit_td_dry_run_metrics
-    def do_dry_run_with_failures(self, ground_truth_failures: List[str]) -> Tuple[str, List[str], List[str], List[str]]:
+    def do_dry_run_with_failures(
+        self, ground_truth_failures: List[str]
+    ) -> Tuple[str, List[str], List[str], List[str]]:
         """
         Perform a dry run with the given ground truth failures.
 
@@ -72,7 +77,13 @@ class DefaultHeuristic:
             Tuple[str, List[str], List[str], List[str]]: The output of the dry run.
         """
 
-        selected_tests = self.test_prioritizations.get_high_relevance_tests() + self.test_prioritizations.get_probable_relevance_tests()
+        selected_tests = list(
+            self.get_test_prioritizations().get_high_relevance_tests()
+        )
+        selected_tests.extend(
+            list(self.get_test_prioritizations().get_probable_relevance_tests())
+        )
+
         ignored_tests = []
         for test in self.test_prioritizations.get_unranked_relevance_tests():
             if random.random() > REMOVAL_PROBABILITY:
@@ -87,7 +98,3 @@ class DefaultHeuristic:
             ignored_tests,
             ground_truth_failures,
         )
-
-
-
-

--- a/tools/testing/target_determination/td_algos/default_heuristics.py
+++ b/tools/testing/target_determination/td_algos/default_heuristics.py
@@ -1,0 +1,93 @@
+import random
+from typing import List, Dict, Any, Tuple
+
+from torch.testing._internal.common_utils import IS_CI
+from tools.stats.upload_metrics import emit_metric
+from tools.testing.target_determination.determinator import get_test_prioritizations
+from tools.testing.target_determination.dry_run import emit_td_dry_run_metrics
+from tools.testing.target_determination.heuristics import (
+    AggregatedHeuristics
+)
+from tools.testing.test_selections import get_test_case_configs
+
+
+
+# This strategy uses our baseline heuristics, and then randomly eliminates unranked tests
+REMOVAL_PROBABILITY = 0.2
+VERSION = "0.0.1"
+
+class DefaultHeuristic:
+
+    def __init__(self, tests_to_run: List[str], test_directory: str, is_cpp: bool):
+        self.tests_to_run = tests_to_run
+        self.test_directory = test_directory
+        self.is_cpp = is_cpp
+        self.aggregated_heuristics, self.metrics_dict = self.get_baseline_heuristics(tests_to_run, test_directory, is_cpp)
+
+
+    def get_baseline_heuristics(self, tests_to_run: List[str], test_directory: str, is_cpp: bool) -> AggregatedHeuristics, Dict[str, Any]:
+        aggregated_heuristics: AggregatedHeuristics = AggregatedHeuristics(
+            unranked_tests=tests_to_run
+        )
+        metrics_dict = {}
+        if IS_CI:
+            # downloading test cases configuration to local environment
+            get_test_case_configs(dirpath=test_directory)
+            aggregated_heuristics = get_test_prioritizations(tests_to_run)
+
+        test_prioritizations = aggregated_heuristics.get_aggregated_priorities()
+        test_prioritizations.print_info()
+
+        if IS_CI:
+            metrics_dict = {
+                "high_relevance_tests": test_prioritizations.get_high_relevance_tests(),
+                "probable_relevance_tests": test_prioritizations.get_probable_relevance_tests(),
+                "unranked_relevance_tests": test_prioritizations.get_unranked_relevance_tests(),
+                "cpp": is_cpp,
+            }
+        return test_prioritizations, metrics_dict
+
+    def get_individual_test_stats(self, test_name: str) -> Dict[str, Any]:
+        return self.aggregated_heuristics.get_individual_test_stats(test_name)
+
+    def get_test_prioritizations(self) -> AggregatedHeuristics:
+        return self.aggregated_heuristics
+    def get_metrics_dict(self) -> Dict[str, Any]:
+        return self.metrics_dict
+    def add_metrics(self, metrics_dict: Dict[str, Any]):
+        self.metrics_dict.update(metrics_dict)
+
+    def emit_metrics(self, name: str):
+        emit_metric(name, self.metrics_dict)
+
+    @emit_td_dry_run_metrics
+    def do_dry_run_with_failures(self, ground_truth_failures: List[str]) -> Tuple[str, List[str], List[str], List[str]]:
+        """
+        Perform a dry run with the given ground truth failures.
+
+        Parameters:
+            ground_truth_failures (List[str]): The ground truth failures.
+
+        Returns:
+            Tuple[str, List[str], List[str], List[str]]: The output of the dry run.
+        """
+
+        selected_tests = self.test_prioritizations.get_high_relevance_tests() + self.test_prioritizations.get_probable_relevance_tests()
+        ignored_tests = []
+        for test in self.test_prioritizations.get_unranked_relevance_tests():
+            if random.random() > REMOVAL_PROBABILITY:
+                selected_tests.append(test)
+            else:
+                ignored_tests.append(test)
+
+        # Return the results
+        return (
+            f"default_heuristic_td_version_{VERSION}",
+            selected_tests,
+            ignored_tests,
+            ground_truth_failures,
+        )
+
+
+
+


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #111719

As we move from reordering tests to actually doing test removal, we need some stats to make sure our techniques are working.

This PR introduces metrics to evaluate the effectiveness of our test removal strategies. We track "recall," which measures how accurately we select failing tests, and the time saved from ignoring tests. These metrics are sent to Rockset. This data allows us to assess how often a strategy skips tests that would have failed, and how many PRs might be merged with undetected failing tests

Note: We only care about how many PRs would be merged with failing tests that were not run because if we only care about improving the developers perspective, if one test fails, we can just run the rest of the tests on the PR.

Two further action items could be

- [ ] Bake the default heuristics.py code into interface.py instead for simplicity
- [ ] For randomized test removal methods like the one found here, we can enable doing multiple runs for better stats