### PR TITLE
Allow to specify specific files for debug info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1227,7 +1227,7 @@ if(BUILD_FUNCTORCH)
 endif()
 
 # Parse custom debug info
-if (DEFINED USE_CUSTOM_DEBINFO)
+if(DEFINED USE_CUSTOM_DEBINFO)
     string(REPLACE ";" " " SOURCE_FILES "${USE_CUSTOM_DEBINFO}")
     message(STATUS "Source files with custom debug infos: ${SOURCE_FILES}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1225,3 +1225,23 @@ caffe2_print_configuration_summary()
 if(BUILD_FUNCTORCH)
   add_subdirectory(functorch)
 endif()
+
+# Parse custom debug info
+if (DEFINED USE_CUSTOM_DEBINFO)
+    string(REPLACE ";" " " SOURCE_FILES "${USE_CUSTOM_DEBINFO}")
+    message(STATUS "Source files with custom debug infos: ${SOURCE_FILES}")
+
+    string(REGEX REPLACE " +" ";" SOURCE_FILES_LIST "${SOURCE_FILES}")
+
+    # Set the COMPILE_FLAGS property for each source file
+    foreach(SOURCE_FILE ${SOURCE_FILES_LIST})
+        # We have to specify the scope here. We do this by specifying the
+        # targets we care about and caffe2/ for all test targets defined there
+        set(ALL_PT_TARGETS "torch_python;c10;torch_cpu;torch")
+        set_source_files_properties(${SOURCE_FILE} DIRECTORY "caffe2/" TARGET_DIRECTORY ${ALL_PT_TARGETS} PROPERTIES COMPILE_FLAGS "-g")
+    endforeach()
+
+    # Link everything with debug info when any file is in debug mode
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -g")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -g")
+endif()

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,9 @@
 #   REL_WITH_DEB_INFO
 #     build with optimizations and -g (debug symbols)
 #
+#   USE_CUSTOM_DEBINFO="path/to/file1.cpp;path/to/file2.cpp"
+#     build with debug info only for specified files
+#
 #   MAX_JOBS
 #     maximum number of compile jobs we should use to compile your code
 #


### PR DESCRIPTION
Building with `USE_CUSTOM_DEBINFO=torch/csrc/Module.cpp python setup.py develop` for example will provide debug info only for this file.
This allows to enable debug symbols very fast from a non-debug build by doing a clean then develop (as long as you have ccache) and avoid very large binaries that take a very long time to load in gdb.