### PR TITLE
[dtensor] hide xla imports to avoid warning

### DIFF
--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -9,7 +9,6 @@ import torch.distributed._tensor.random as random
 import torch.nn as nn
 from torch.distributed._tensor._collective_utils import mesh_broadcast
 from torch.distributed._tensor._utils import compute_global_tensor_info
-from torch.distributed._tensor._xla import xla_distribute_tensor
 from torch.distributed._tensor.device_mesh import DeviceMesh, mesh_resources
 from torch.distributed._tensor.placement_types import (
     DTensorSpec,
@@ -467,6 +466,7 @@ def distribute_tensor(
     if device_type == "xla":
         # call PyTorch/XLA SPMD for `xla` backend type device mesh.
         # This returns XLAShardedTensor
+        from torch.distributed._tensor._xla import xla_distribute_tensor
         return xla_distribute_tensor(
             tensor, device_mesh, placements
         )  # type:ignore[return-value]

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -467,6 +467,7 @@ def distribute_tensor(
         # call PyTorch/XLA SPMD for `xla` backend type device mesh.
         # This returns XLAShardedTensor
         from torch.distributed._tensor._xla import xla_distribute_tensor
+
         return xla_distribute_tensor(
             tensor, device_mesh, placements
         )  # type:ignore[return-value]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #111751

xla imports throw warnings about xla not imported and we should only
import xla when needed