### PR TITLE
fix missing non-contiguous output handling for add op

### DIFF
--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1076,6 +1076,7 @@ def add(
     output = prims.add(a, b)
     return handle_noncontiguous_outputs([a, b], output)
 
+
 # TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1073,8 +1073,8 @@ def add(
             raise ValueError(msg)
         b = prims.mul(b, alpha)
 
-    return prims.add(a, b)
-
+    output = prims.add(a, b)
+    return handle_noncontiguous_outputs([a, b], output)
 
 # TODO: add docstring
 @_make_elementwise_binary_reference(


### PR DESCRIPTION
patch for https://github.com/pytorch/pytorch/pull/104689 which is missing similiar handling for add op

cc @karthiknagasub 
