### PR TITLE
[Dynamo] Dynamo Compile samples should record file/line that raised exception

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -263,6 +263,9 @@ report_guard_failures = os.environ.get("TORCHDYNAMO_REPORT_GUARD_FAILURES") == "
 # Whether to report all guard failures or just the first one that fails
 report_all_guard_failures = False
 
+# If to log Dynamo compilation metrics into log files (for OSS) and Scuba tables (for fbcode).
+log_compilation_metrics = True
+
 # root folder of the project
 base_dir = dirname(dirname(dirname(abspath(__file__))))
 

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -678,7 +678,6 @@ def _compile(
                 fail_reason,
                 fail_user_frame_summary,
             )
-            print("---->>>>>>  ", metrics)
             log_compilation_event(metrics)
 
 

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -238,14 +238,14 @@ def has_tensor_in_frame(frame):
     return False
 
 
-def exception_handler(e, code, frame, innermost_user_frame_str, export=False):
+def exception_handler(e, code, frame=None, export=False):
     record_filename = None
     if hasattr(e, "exec_record"):
         record_filename = gen_record_file_name(e, code)
         write_record_to_file(record_filename, e.exec_record)
         e.record_filename = record_filename
 
-    augment_exc_message(e, innermost_user_frame_str, export=export)
+    augment_exc_message(e, export=export)
 
 
 FRAME_COUNTER = 0
@@ -624,12 +624,14 @@ def _compile(
         ) as e:
             fail_type = str(type(e))
             fail_reason = str(e)
-            exception_handler(e, code, frame, fail_user_frame_summary, export=export)
+            exception_handler(e, code, frame, export=export)
+            fail_user_frame_summary = str(e.innermost_user_frame_summary)
             raise
         except Exception as e:
             fail_type = str(type(e))
             fail_reason = str(e)
-            exception_handler(e, code, frame, fail_user_frame_summary, export=export)
+            exception_handler(e, code, frame, export=export)
+            fail_user_frame_summary = str(e.innermost_user_frame_summary)
             raise InternalTorchDynamoError(str(e)).with_traceback(
                 e.__traceback__
             ) from None
@@ -676,6 +678,7 @@ def _compile(
                 fail_reason,
                 fail_user_frame_summary,
             )
+            print("---->>>>>>  ", metrics)
             log_compilation_event(metrics)
 
 

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -474,6 +474,7 @@ def _compile(
     # This is shared across restarts
     mutated_closure_cell_contents: Set[str] = set()
     fail_reason: Optional[str] = None
+    fail_details: Optional[str] = None
 
     def transform(instructions, code_options):
         nonlocal output
@@ -620,12 +621,14 @@ def _compile(
             UncapturedHigherOrderOpError,
             BisectValidationException,
         ) as e:
-            exception_handler(e, code, frame, export=export)
             fail_reason = str(e)
+            exception_handler(e, code, frame, export=export)
+            fail_details = str(e)  # fail details after exc msg augment
             raise
         except Exception as e:
-            exception_handler(e, code, frame, export=export)
             fail_reason = str(e)
+            exception_handler(e, code, frame, export=export)
+            fail_details = str(e)  # fail details after exc msg augment
             raise InternalTorchDynamoError(str(e)).with_traceback(
                 e.__traceback__
             ) from None
@@ -669,6 +672,7 @@ def _compile(
                 entire_frame_compile_time,
                 backend_compile_time,
                 fail_reason,
+                fail_details,
             )
             log_compilation_event(metrics)
 

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -620,12 +620,12 @@ def _compile(
             UncapturedHigherOrderOpError,
             BisectValidationException,
         ) as e:
-            fail_reason = str(e)
             exception_handler(e, code, frame, export=export)
+            fail_reason = str(e)
             raise
         except Exception as e:
-            fail_reason = str(e)
             exception_handler(e, code, frame, export=export)
+            fail_reason = str(e)
             raise InternalTorchDynamoError(str(e)).with_traceback(
                 e.__traceback__
             ) from None

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -210,9 +210,7 @@ def augment_exc_message(exc, msg="\n", export=False):
     real_stack = get_real_stack(exc)
     if real_stack is not None and len(real_stack) > 0:
         exc.innermost_user_frame_summary = real_stack[-1]
-        msg += (
-            f"\nfrom user code:\n {''.join(traceback.format_list(real_stack))}"
-        )
+        msg += f"\nfrom user code:\n {''.join(traceback.format_list(real_stack))}"
 
     if config.replay_record_enabled and hasattr(exc, "record_filename"):
         msg += f"\nLast frame execution written to {exc.record_filename}. To run only this frame while debugging, run\

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -208,11 +208,10 @@ def augment_exc_message(exc, msg="\n", export=False):
     exc.innermost_user_frame_summary = None
 
     real_stack = get_real_stack(exc)
-    if real_stack is not None:
-        if len(real_stack) > 0:
-            exc.innermost_user_frame_summary = real_stack[-1]
+    if real_stack is not None and len(real_stack) > 0:
+        exc.innermost_user_frame_summary = real_stack[-1]
         msg += (
-            f"\nfrom user code:\n {''.join(traceback.format_list(get_real_stack(exc)))}"
+            f"\nfrom user code:\n {''.join(traceback.format_list(real_stack))}"
         )
 
     if config.replay_record_enabled and hasattr(exc, "record_filename"):

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -202,11 +202,12 @@ class KeyErrorMsg:
         return self.__str__()
 
 
-def augment_exc_message(exc, msg="\n", export=False):
+def augment_exc_message(exc, innermost_user_frame_str, msg="\n", export=False):
     import traceback
 
     real_stack = get_real_stack(exc)
     if real_stack is not None:
+        innermost_user_frame_str = str(real_stack[-1])
         msg += (
             f"\nfrom user code:\n {''.join(traceback.format_list(get_real_stack(exc)))}"
         )

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -202,12 +202,14 @@ class KeyErrorMsg:
         return self.__str__()
 
 
-def augment_exc_message(exc, innermost_user_frame_str, msg="\n", export=False):
+def augment_exc_message(exc, msg="\n", export=False):
     import traceback
+
+    exc.innermost_user_frame_summary = None
 
     real_stack = get_real_stack(exc)
     if real_stack is not None:
-        innermost_user_frame_str = str(real_stack[-1])
+        exc.innermost_user_frame_summary = real_stack[-1]
         msg += (
             f"\nfrom user code:\n {''.join(traceback.format_list(get_real_stack(exc)))}"
         )

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -209,7 +209,8 @@ def augment_exc_message(exc, msg="\n", export=False):
 
     real_stack = get_real_stack(exc)
     if real_stack is not None:
-        exc.innermost_user_frame_summary = real_stack[-1]
+        if len(real_stack) > 0:
+            exc.innermost_user_frame_summary = real_stack[-1]
         msg += (
             f"\nfrom user code:\n {''.join(traceback.format_list(get_real_stack(exc)))}"
         )

--- a/torch/_dynamo/test_case.py
+++ b/torch/_dynamo/test_case.py
@@ -49,7 +49,11 @@ class TestCase(TorchTestCase):
         super().setUpClass()
         cls._exit_stack = contextlib.ExitStack()
         cls._exit_stack.enter_context(
-            config.patch(raise_on_ctx_manager_usage=True, suppress_errors=False),
+            config.patch(
+                raise_on_ctx_manager_usage=True,
+                suppress_errors=False,
+                log_compilation_metrics=False,
+            ),
         )
 
     def setUp(self):

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -549,7 +549,8 @@ class CompilationMetrics:
     backend_compile_time_s: Optional[float]
     fail_type: Optional[str]
     fail_reason: Optional[str]
-    fail_user_frame_summary: Optional[str]
+    fail_user_frame_filename: Optional[str]
+    fail_user_frame_lineno: Optional[int]
 
 
 @dataclasses.dataclass

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -548,6 +548,7 @@ class CompilationMetrics:
     entire_frame_compile_time_s: Optional[float]
     backend_compile_time_s: Optional[float]
     fail_reason: Optional[str]
+    fail_details: Optional[str]
 
 
 @dataclasses.dataclass

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -547,8 +547,9 @@ class CompilationMetrics:
     graph_input_count: Optional[int]
     entire_frame_compile_time_s: Optional[float]
     backend_compile_time_s: Optional[float]
+    fail_type: Optional[str]
     fail_reason: Optional[str]
-    fail_details: Optional[str]
+    fail_user_frame_summary: Optional[str]
 
 
 @dataclasses.dataclass

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -473,6 +473,7 @@ class BatchReLUFusion(BatchFusion):
     Batch relu fusion in pre grad pass.
     We only fuse the relu if the input is after same split/unbind node.
     """
+
     def _getitem_args(self, getitem_node: torch.fx.Node):
         if getitem_node.target != operator.__getitem__ or (
             getitem_node.op != "call_function"
@@ -481,7 +482,6 @@ class BatchReLUFusion(BatchFusion):
         return getitem_node.args[0]
 
     def match(self, node: torch.fx.Node):
-
         input = get_arg_value(node, 0, "input")
         if (
             CallFunctionVarArgs(torch.nn.functional.relu).match(node)
@@ -526,7 +526,6 @@ class BatchReLUFusion(BatchFusion):
                 node.replace_all_uses_with(getitem)
                 getitem.meta.update(node.meta)
                 graph.erase_node(node)
-
 
 
 def find_independent_subset_greedy(

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1181,6 +1181,8 @@ if TEST_WITH_TORCHDYNAMO:
     import torch._dynamo
     # Do not spend time on helper functions that are called with different inputs
     torch._dynamo.config.accumulated_cache_size_limit = 8
+    # Do not log compilation metrics from unit tests
+    torch._dynamo.config.log_compilation_metrics = False
     # TODO: Remove this; this is grandfathered in because we suppressed errors
     # on test suite previously
     torch._dynamo.config.suppress_errors = True


### PR DESCRIPTION
Fixes #111674

CompilationMetrics example:
``` 
frame_key='1', 
co_name='fn', 
co_filename='/data/users/ybliang/debug/debug1.py', 
co_firstlineno=58, 
cache_size=0, 
accumulated_cache_size=0, 
guard_count=None, 
graph_op_count=None, 
graph_node_count=None, 
graph_input_count=None, 
entire_frame_compile_time_s=None, 
backend_compile_time_s=None, 
fail_type="<class 'torch._dynamo.exc.Unsupported'>", 
fail_reason='custome dict init with args/kwargs unimplemented', 
fail_user_frame_filename='/data/users/ybliang/debug/debug1.py',
fail_user_frame_lineno=61
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler