### PR TITLE
make no-inline calls to throw exceptions

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/model.h
+++ b/torch/csrc/inductor/aoti_runtime/model.h
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <optional>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -22,11 +23,26 @@
     }                                 \
   } while (0)
 
-#define AOTI_TORCH_ERROR_CODE_CHECK(call)                                  \
-  if ((call) != AOTI_TORCH_SUCCESS) {                                      \
-    throw std::runtime_error(                                              \
-        std::string(#call " API call failed at ") + __FILE__ + ", line " + \
-        std::to_string(__LINE__));                                         \
+#if defined(__GNUC__) || defined(__clang__)
+#define AOTI_NOINLINE __attribute__((noinline))
+#elif _MSC_VER
+#define AOTI_NOINLINE __declspec(noinline)
+#else
+#define AOTI_NOINLINE
+#endif
+
+AOTI_NOINLINE static void throw_exception(
+    const char* call,
+    const char* file,
+    int64_t line) {
+  std::stringstream ss;
+  ss << call << " API call failed at " << file << ", line " << line;
+  throw std::runtime_error(ss.str());
+}
+
+#define AOTI_TORCH_ERROR_CODE_CHECK(call)       \
+  if ((call) != AOTI_TORCH_SUCCESS) {           \
+    throw_exception(#call, __FILE__, __LINE__); \
   }
 
 using DeleterFnPtr = void (*)(void*);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #111787

Previously, we throw runtime_error exceptions with some string
operations upon failures. However, inlining such calls into
the main run function causes some exponential compilation-time
behavior for the host compiler, where the compiler may spend
an hour running call-graph related passes for some large models.

This PR replaces the relevant code with no-inline calls.
With this change, we reduced the compilation time from more than
an hour down to a couple of minutes for some large models.
Note that these non-inline calls have little impact to the
model inference runtime, because they are on the error-handling
paths.