### PR TITLE
Optest: Allow parametrized names for xfails checks

### DIFF
--- a/torch/testing/_internal/optests/generate_tests.py
+++ b/torch/testing/_internal/optests/generate_tests.py
@@ -335,7 +335,7 @@ def validate_failures_dict_structure(
                     continue
                 base_test_name = actual_test_name[len(test) + 2 :]
                 # remove potential pytest parametrization suffix
-                base_test_name = re.sub("\[.*\]", "", base_test_name)
+                base_test_name = re.sub(r"\[.*\]", "", base_test_name)
                 if testcase.__name__ != test_class:
                     continue
                 if hasattr(testcase, base_test_name):

--- a/torch/testing/_internal/optests/generate_tests.py
+++ b/torch/testing/_internal/optests/generate_tests.py
@@ -4,6 +4,7 @@ import functools
 import inspect
 import json
 import os
+import re
 import tempfile
 import threading
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
@@ -333,7 +334,8 @@ def validate_failures_dict_structure(
                 if not actual_test_name.startswith(test):
                     continue
                 base_test_name = actual_test_name[len(test) + 2 :]
-                base_test_name = base_test_name.split("[")[0]  # remove potential pytest parametrization suffix
+                # remove potential pytest parametrization suffix
+                base_test_name = re.sub("\[.*\]", "", base_test_name)
                 if testcase.__name__ != test_class:
                     continue
                 if hasattr(testcase, base_test_name):

--- a/torch/testing/_internal/optests/generate_tests.py
+++ b/torch/testing/_internal/optests/generate_tests.py
@@ -333,6 +333,7 @@ def validate_failures_dict_structure(
                 if not actual_test_name.startswith(test):
                     continue
                 base_test_name = actual_test_name[len(test) + 2 :]
+                base_test_name = base_test_name.split("[")[0]  # remove potential pytest parametrization suffix
                 if testcase.__name__ != test_class:
                     continue
                 if hasattr(testcase, base_test_name):


### PR DESCRIPTION
CC @zou3519 

This is hopefully a fix for https://github.com/pytorch/vision/pull/8058/files#r1368570541. It seems to work for me locally, but maybe there's a more elegant way of handling this?