### PR TITLE
[Draft] Fix problem on the MultiheadAttention (dynamic_axes)

### DIFF
--- a/test/onnx/test_models_onnxruntime.py
+++ b/test/onnx/test_models_onnxruntime.py
@@ -448,7 +448,11 @@ class TestModelsONNXRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test(
             mha,
             (dummy_input,),
-            additional_test_inputs=[(dummy_input,), (test_inputs_small,), (test_inputs_big,)],
+            additional_test_inputs=[
+                (dummy_input,),
+                (test_inputs_small,),
+                (test_inputs_big,),
+            ],
             input_names=["input_images"],
             output_names=["outputs"],
             dynamic_axes={

--- a/test/onnx/test_models_onnxruntime.py
+++ b/test/onnx/test_models_onnxruntime.py
@@ -440,25 +440,32 @@ class TestModelsONNXRuntime(onnx_test_common._TestONNXRuntime):
     @skipIfUnsupportedMinOpsetVersion(13)
     @skipScriptTest()
     def test_multi_head_attention_dynamic_axes(self):
-        mha = torch.nn.MultiheadAttention(4, 4, batch_first=True).eval()
+        class MhaWrapper(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.mha = torch.nn.MultiheadAttention(4, 4, batch_first=True)
 
+
+            def forward(self, query: torch.Tensor) -> torch.Tensor:
+                return self.mha(query, query, query, need_weights=False)[0]
+
+        model = MhaWrapper().eval()
         dummy_input = torch.randn(1, 10, 4, requires_grad=True)
         test_inputs_small = torch.randn(1, 5, 4, requires_grad=True)
         test_inputs_big = torch.randn(1, 15, 4, requires_grad=True)
+
         self.run_test(
-            mha,
-            (dummy_input, dummy_input, dummy_input),
+            model,
+            dummy_input,
             additional_test_inputs=[
-                (dummy_input, dummy_input, dummy_input),
-                (test_inputs_small, test_inputs_small, test_inputs_small),
-                (test_inputs_big, test_inputs_big, test_inputs_big),
+                dummy_input,
+                test_inputs_small,
+                test_inputs_big,
             ],
-            input_names=["query", "key", "value"],
+            input_names=["query"],
             output_names=["output"],
             dynamic_axes={
                 "query": {0: "batch_size", 1: "sequence"},
-                "key": {0: "batch_size", 1: "sequence"},
-                "value": {0: "batch_size", 1: "sequence"},
                 "output": {0: "batch_size", 1: "sequence"},
             },
             rtol=1e-3,

--- a/test/onnx/test_models_onnxruntime.py
+++ b/test/onnx/test_models_onnxruntime.py
@@ -447,16 +447,18 @@ class TestModelsONNXRuntime(onnx_test_common._TestONNXRuntime):
         test_inputs_big = torch.randn(1, 15, 4, requires_grad=True)
         self.run_test(
             mha,
-            (dummy_input,),
+            (dummy_input, dummy_input, dummy_input),
             additional_test_inputs=[
-                (dummy_input,),
-                (test_inputs_small,),
-                (test_inputs_big,),
+                (dummy_input, dummy_input, dummy_input),
+                (test_inputs_small, test_inputs_small, test_inputs_small),
+                (test_inputs_big, test_inputs_big, test_inputs_big),
             ],
-            input_names=["input_images"],
-            output_names=["outputs"],
+            input_names=["query", "key", "value"],
+            output_names=["output"],
             dynamic_axes={
-                "input_images": {0: "batch_size", 1: "sequence"},
+                "query": {0: "batch_size", 1: "sequence"},
+                "key": {0: "batch_size", 1: "sequence"},
+                "value": {0: "batch_size", 1: "sequence"},
                 "output": {0: "batch_size", 1: "sequence"},
             },
             rtol=1e-3,

--- a/test/onnx/test_models_onnxruntime.py
+++ b/test/onnx/test_models_onnxruntime.py
@@ -437,6 +437,28 @@ class TestModelsONNXRuntime(onnx_test_common._TestONNXRuntime):
             atol=1e-5,
         )
 
+    @skipIfUnsupportedMinOpsetVersion(13)
+    @skipScriptTest()
+    def test_multi_head_attention_dynamic_axes(self):
+        mha = torch.nn.MultiheadAttention(4, 4, batch_first=True).eval()
+
+        dummy_input = torch.randn(1, 10, 4, requires_grad=True)
+        test_inputs_small = torch.randn(1, 5, 4, requires_grad=True)
+        test_inputs_big = torch.randn(1, 15, 4, requires_grad=True)
+        self.run_test(
+            mha,
+            (dummy_input,),
+            additional_test_inputs=[(dummy_input,), (test_inputs_small,), (test_inputs_big,)],
+            input_names=["input_images"],
+            output_names=["outputs"],
+            dynamic_axes={
+                "input_images": {0: "batch_size", 1: "sequence"},
+                "output": {0: "batch_size", 1: "sequence"},
+            },
+            rtol=1e-3,
+            atol=1e-5,
+        )
+
 
 if __name__ == "__main__":
     common_utils.run_tests()

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5350,7 +5350,7 @@ def multi_head_attention_forward(
     #
     q = q.view(tgt_len, bsz * num_heads, head_dim).transpose(0, 1)
     if static_k is None:
-        k = k.view(k.shape[0], bsz * num_heads, head_dim).transpose(0, 1)
+        k = k.view(src_len, bsz * num_heads, head_dim).transpose(0, 1)
     else:
         # TODO finish disentangling control flow so we don't do in-projections when statics are passed
         assert static_k.size(0) == bsz * num_heads, \
@@ -5359,7 +5359,7 @@ def multi_head_attention_forward(
             f"expecting static_k.size(2) of {head_dim}, but got {static_k.size(2)}"
         k = static_k
     if static_v is None:
-        v = v.view(v.shape[0], bsz * num_heads, head_dim).transpose(0, 1)
+        v = v.view(src_len, bsz * num_heads, head_dim).transpose(0, 1)
     else:
         # TODO finish disentangling control flow so we don't do in-projections when statics are passed
         assert static_v.size(0) == bsz * num_heads, \


### PR DESCRIPTION
The MultiheadAttention is currently not supported by the `dynamic_axes` of `torch.onnx.export`. This implies that the entire pytorch Transformer ecosystem is not either.

When trying to export to onnx, the layer freezes with the sequence that has been used as a dummy, not allowing it to be executed with other sizes.

Example:
```python

import onnxruntime as ort
import numpy as np

mha = torch.nn.MultiheadAttention(4, 4, batch_first=True).eval()

dummy_input = torch.randn(1, 10, 4, requires_grad=True)
test_inputs_small = torch.randn(1, 5, 4, requires_grad=True)
test_inputs_big = torch.randn(1, 15, 4, requires_grad=True)

torch.onnx.export(
    model.transform_for_inference(model),
    dummy_tensor,
    f="test.onnx",
    input_names=['query', 'key', 'value'],
    output_names=['attn_output'],
    dynamic_axes={'input': {0: 'batch_size', 1: 'sequence'}, 'latent': {0: 'batch_size', 1: 'sequence'}},
    do_constant_folding=True
)
ort_session = ort.InferenceSession("test.onnx", providers=["CPUExecutionProvider"])

ort_session.run(None, {'query': dummy_tensor.numpy(), 'key': dummy_tensor.numpy(), 'value': test_inputs_small.numpy()})
ort_session.run(None, {'query': test_inputs_small.numpy(), 'key': test_inputs_small.numpy(), 'value': test_inputs_small.numpy()})
ort_session.run(None, {'query': test_inputs_big.numpy(), 'key': test_inputs_big.numpy(), 'value': test_inputs_small.numpy()})
```

The author of this solution: https://github.com/pytorch/pytorch/issues/99701#issuecomment-1752324155 

PD: It is my first PR in torch, if there is the test it must be somewhere else or format the PR in another way, please tell me. Thank you

Fixes #ISSUE_NUMBER
