### PR TITLE
[Release/2.1.1] [dynamo] Register einops functions lazily

### DIFF
--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -255,36 +255,31 @@ def mark_static_address(t, guard=True):
         t._dynamo_static_input_type = "unguarded"
 
 
-# Note: it's preferable to not make `import torch` eagerly import other libs.
-# However, we want to provide a grace period to make borderline versions of einops
-# compatible with torch.compile.
+# Note: this carefully avoids eagerly import einops.
 # TODO: we should delete this whole _allow_in_graph_einops logic by approximately 2024 Q2
 def _allow_in_graph_einops():
+    import einops
+
     try:
-        import einops
+        # requires einops > 0.6.1, torch >= 2.0
+        from einops._torch_specific import (  # noqa: F401
+            _ops_were_registered_in_torchdynamo,
+        )
 
-        try:
-            # requires einops > 0.6.1, torch >= 2.0
-            from einops._torch_specific import (  # noqa: F401
-                _ops_were_registered_in_torchdynamo,
-            )
-
-            # einops > 0.6.1 will call the op registration logic as it is imported.
-            pass
-        except ImportError:
-            # einops <= 0.6.1
-            allow_in_graph(einops.rearrange)
-            allow_in_graph(einops.reduce)
-            if hasattr(einops, "repeat"):
-                allow_in_graph(einops.repeat)  # available since einops 0.2.0
-            if hasattr(einops, "einsum"):
-                allow_in_graph(einops.einsum)  # available since einops 0.5.0
-            if hasattr(einops, "pack"):
-                allow_in_graph(einops.pack)  # available since einops 0.6.0
-            if hasattr(einops, "unpack"):
-                allow_in_graph(einops.unpack)  # available since einops 0.6.0
-    except ImportError:
+        # einops > 0.6.1 will call the op registration logic as it is imported.
         pass
+    except ImportError:
+        # einops <= 0.6.1
+        allow_in_graph(einops.rearrange)
+        allow_in_graph(einops.reduce)
+        if hasattr(einops, "repeat"):
+            allow_in_graph(einops.repeat)  # available since einops 0.2.0
+        if hasattr(einops, "einsum"):
+            allow_in_graph(einops.einsum)  # available since einops 0.5.0
+        if hasattr(einops, "pack"):
+            allow_in_graph(einops.pack)  # available since einops 0.6.0
+        if hasattr(einops, "unpack"):
+            allow_in_graph(einops.unpack)  # available since einops 0.6.0
 
 
-_allow_in_graph_einops()
+allowed_functions.add_module_init_func("einops", _allow_in_graph_einops)

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -32,7 +32,7 @@ from . import (
     skipfiles,
     variables,
 )
-from .allowed_functions import is_allowed, is_builtin_constant
+from .allowed_functions import is_allowed, is_builtin_constant, is_forbidden
 from .bytecode_analysis import get_indexof, JUMP_OPNAMES, livevars_analysis
 from .bytecode_transformation import (
     cleaned_instructions,
@@ -552,12 +552,7 @@ class InstructionTranslatorBase(Checkpointable[InstructionTranslatorGraphState])
             inner_fn = fn.value
         if hasattr(fn, "fn"):
             inner_fn = fn.fn
-        if (
-            inner_fn
-            and callable(inner_fn)
-            and hasattr(inner_fn, "_dynamo_forbidden")
-            and inner_fn._dynamo_forbidden
-        ):
+        if inner_fn and callable(inner_fn) and is_forbidden(inner_fn):
             raise AssertionError(f"Attempt to trace forbidden callable {inner_fn}")
         self.push(fn.call_function(self, args, kwargs))
 


### PR DESCRIPTION

This backports the following PRs:
- https://github.com/pytorch/pytorch/pull/110575
- https://github.com/pytorch/pytorch/pull/110990


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng