### PR TITLE
Add timeout for master store if clients do not join

### DIFF
--- a/test/distributed/elastic/utils/distributed_test.py
+++ b/test/distributed/elastic/utils/distributed_test.py
@@ -14,7 +14,7 @@ import sys
 import unittest
 from contextlib import closing
 
-from torch.distributed import DistNetworkError
+from torch.distributed import DistNetworkError, DistStoreError
 from torch.distributed.elastic.utils.distributed import (
     create_c10d_store,
     get_socket_with_port,
@@ -98,7 +98,7 @@ class DistributedUtilTest(TestCase):
         self.assertEqual(0, worker1.exitcode)
 
     def test_create_store_timeout_on_server(self):
-        with self.assertRaises(TimeoutError):
+        with self.assertRaises(DistStoreError):
             # use any available port (port 0) since timeout is expected
             create_c10d_store(
                 is_server=True,

--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -1,4 +1,5 @@
 #include <c10/util/irange.h>
+#include <fmt/format.h>
 #include <torch/csrc/distributed/c10d/TCPStore.hpp>
 #include <torch/csrc/distributed/c10d/TCPStoreBackend.hpp>
 #include <torch/csrc/distributed/c10d/logging.h>
@@ -371,7 +372,13 @@ void TCPStore::waitForWorkers() {
       const auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
           std::chrono::steady_clock::now() - start);
       if (timeout_ != kNoTimeout && elapsed > timeout_) {
-        break;
+        C10_THROW_ERROR(
+            DistStoreError,
+            fmt::format(
+                "Timed out after {} seconds waiting for clients. {}/{} clients joined.",
+                elapsed.count(),
+                numWorkersCompleted,
+                *numWorkers_));
       }
       /* sleep override */
       std::this_thread::sleep_for(std::chrono::milliseconds(10));


### PR DESCRIPTION
Currently, if the master_store does not have all clients join in the `timeout` time, it will just continue silently which could lead to errors down the road. However, if a client does not connect with the master within the specified time then an exception will be raised. This change will have master_store error out if not all clients have joined, making server and client consistent with each other.

Since this is changing the default behavior of master store I am open to suggestions.

Example:

```python
import torch.distributed as dist
import torch.multiprocessing as mp
from datetime import timedelta

def main(rank, world_size):
    if rank == 0:
        print("creating store")
        # world size is 2 so this eventually times out
        store = dist.TCPStore("localhost", 1234, 2, True, timeout=timedelta(seconds=5))
        print("finished creating store")

if __name__ == "__main__":
    world_size = 2
    mp.spawn(main, (world_size,), nprocs=world_size)
```

Previous
```
print("creating store")
print("finished creating store")
```

Now
```
print("creating store")
torch.distributed.DistStoreError: Timed out after 6 seconds waiting for workers. 1/2 workers joined.
```