### PR TITLE
[PyTorch] AOTI: use array of constants

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1182,12 +1182,12 @@ class CppWrapperCodeGen(WrapperCodeGen):
                     # Don't call std::move here because it will cause constants_ to lose the ownership.
                     if config.aot_inductor.abi_compatible:
                         self.prefix.writeline(
-                            f"""auto {constants_key} = constants_->at("{constants_key}").get();"""
+                            f"""auto {constants_key} = constants_.at({idx});"""
                         )
                     else:
                         self.prefix.writeline(
                             f"auto {constants_key} = *tensor_handle_to_tensor_pointer("
-                            + f"""constants_->at("{constants_key}").get());"""
+                            + f"""constants_.at({idx}));"""
                         )
                 else:
                     # Append constants as inputs to the graph
@@ -1291,7 +1291,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
                     f"constants_info_[{idx}].stride = {{{stride_str}}};"
                 )
 
-            self.prefix.writeline("constants_ = constants_map;")
+            self.prefix.writeline("update_constants_map(std::move(constants_map));")
 
             for idx, output in enumerate(V.graph.graph_outputs):
                 assert not isinstance(

--- a/torch/csrc/inductor/aoti_runtime/model.h
+++ b/torch/csrc/inductor/aoti_runtime/model.h
@@ -231,8 +231,20 @@ class AOTInductorModelBase {
     return constants_info_.at(idx).data_size;
   }
 
-  void update_constants_map(std::shared_ptr<ConstantMap>&& constants_map) {
-    constants_ = std::move(constants_map);
+  void update_constants_map(std::shared_ptr<ConstantMap> constants_map) {
+    constants_map_ = std::move(constants_map);
+    if (!constants_map_) {
+      return;
+    }
+    constants_.resize(constants_info_.size());
+    int idx = 0;
+    for (const auto& info : constants_info_) {
+      const auto it = constants_map_->find(info.name);
+      if (it != constants_map_->end()) {
+        constants_[idx] = it->second;
+      }
+      idx++;
+    }
   }
 
   /// Returns true if the model is complete.
@@ -286,7 +298,8 @@ class AOTInductorModelBase {
   std::vector<ParamInfo> outputs_info_;
   std::vector<ConstInfo> constants_info_;
 
-  std::shared_ptr<ConstantMap> constants_;
+  std::shared_ptr<ConstantMap> constants_map_;
+  std::vector<AtenTensorHandle> constants_;
 
   // A directory with CUDA binary files, e.g. compiled kernels, etc.
   const std::optional<std::string> cubin_dir_;

--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -125,6 +125,10 @@ class AOTInductorModelContainer {
       constants_->emplace(
           std::move(name), std::move(RAIIAtenTensorHandle(tensor_handle)));
     }
+
+    for (auto& model : models_) {
+      model->update_constants_map(constants_);
+    }
   }
 
   void run(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #111820
* #111816
* __->__ #111815

We continue to allow the user to set clients with a map, but under the hood we use an array of constants.

model_container thought it was OK to hand over the map, assume we just
kept a pointer, and then mutate the map later; I had to fix that. I
hope there aren't other sites that do the same thing...

Differential Revision: [D50111512](https://our.internmc.facebook.com/intern/diff/D50111512/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler