### PR TITLE
Fix DDP notes

### DIFF
--- a/docs/source/notes/ddp.rst
+++ b/docs/source/notes/ddp.rst
@@ -28,6 +28,7 @@ updated, and all models on different processes should be exactly the same.
     import torch.multiprocessing as mp
     import torch.nn as nn
     import torch.optim as optim
+    import os
     from torch.nn.parallel import DistributedDataParallel as DDP
 
 


### PR DESCRIPTION
To include `import os` otherwise sample is not syntactically correct Reported in https://github.com/pytorch/pytorch.github.io/pull/1490

