### PR TITLE
[TD] Make test class times available during CI

### DIFF
--- a/tools/stats/export_test_times.py
+++ b/tools/stats/export_test_times.py
@@ -5,6 +5,7 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
 sys.path.append(str(REPO_ROOT))
 from tools.stats.import_test_stats import (
     get_test_class_ratings,
+    get_test_class_times,
     get_test_file_ratings,
     get_test_times,
 )
@@ -13,6 +14,7 @@ from tools.stats.import_test_stats import (
 def main() -> None:
     print("Exporting files from test-infra")
     get_test_times()
+    get_test_class_times()
     get_test_file_ratings()
     get_test_class_ratings()
 

--- a/tools/stats/import_test_stats.py
+++ b/tools/stats/import_test_stats.py
@@ -21,6 +21,7 @@ SLOW_TESTS_FILE = ".pytorch-slow-tests.json"
 DISABLED_TESTS_FILE = ".pytorch-disabled-tests.json"
 ADDITIONAL_CI_FILES_FOLDER = pathlib.Path(".additional_ci_files")
 TEST_TIMES_FILE = "test-times.json"
+TEST_CLASS_TIMES_FILE = "test-class-times.json"
 TEST_FILE_RATINGS_FILE = "test-file-ratings.json"
 TEST_CLASS_RATINGS_FILE = "test-class-ratings.json"
 
@@ -84,6 +85,14 @@ def get_test_times() -> Dict[str, Dict[str, float]]:
     return get_from_test_infra_generated_stats(
         "test-times.json",
         TEST_TIMES_FILE,
+        "Couldn't download test times...",
+    )
+
+
+def get_test_class_times() -> Dict[str, Dict[str, float]]:
+    return get_from_test_infra_generated_stats(
+        "test-class-times.json",
+        TEST_CLASS_TIMES_FILE,
         "Couldn't download test times...",
     )
 


### PR DESCRIPTION
Makes the test class durations uploaded by https://github.com/pytorch/test-infra/pull/4670 available during CI.