### PR TITLE
[Resubmit][S372460 follow up] Reduce embedding feature validation failure carry-on impact

### DIFF
--- a/caffe2/operators/gather_ranges_to_dense_op.h
+++ b/caffe2/operators/gather_ranges_to_dense_op.h
@@ -45,6 +45,7 @@ class GatherRangesToDenseOp final : public Operator<Context> {
     // Initialize the empty and mismatch counter.
     for (const auto i : c10::irange(OutputSize())) {
       (void)i; // Suppress unused variable warning
+      totalRanges_.push_back(0);
       emptyRanges_.push_back(0);
       mismatchedRanges_.push_back(0);
       mismatchedLengths_.push_back(set<int>());
@@ -52,7 +53,11 @@ class GatherRangesToDenseOp final : public Operator<Context> {
   }
 
   ~GatherRangesToDenseOp() noexcept override {
-    if (totalRanges_ > minObservation_) {
+    bool exceedMinObservation = false;
+    for (const auto range : totalRanges_) {
+      exceedMinObservation |= range > minObservation_;
+    }
+    if (exceedMinObservation) {
       string debugString;
       if (this->has_debug_def()) {
         debugString =
@@ -62,11 +67,11 @@ class GatherRangesToDenseOp final : public Operator<Context> {
       }
 
       LOG(INFO) << "In GatherRangesToDenseOp:\n"
-                << "  Lifetime empty ranges for each feature is "
+                << "  The latest empty ranges for each feature is "
                 << emptyRanges_ << ".\n"
-                << "  Lifetime mismatched ranges for each feature is "
+                << "  The latest mismatched ranges for each feature is "
                 << mismatchedRanges_ << ".\n"
-                << "  With a total of " << totalRanges_ << " examples.\n"
+                << "  With a total of " << totalRanges_ << " examples for each feature.\n"
                 << debugString;
     }
   }
@@ -173,42 +178,56 @@ class GatherRangesToDenseOp final : public Operator<Context> {
     CAFFE_ENFORCE_EQ(rangesDataOffset, ranges.numel());
 
     // Check whether the empty and mismatch ratio exceeded the threshold.
-    totalRanges_ += batchSize;
+    for (const auto j : c10::irange(OutputSize())) {
+      totalRanges_[j] += batchSize;
+    }
     for (const auto j : c10::irange(OutputSize())) {
       // Only check when the ratio is not set to allow all mismatches.
+      auto totalRangesTemp = totalRanges_[j];
+      auto emptyRangesTemp = emptyRanges_[j];
+      auto mismatchedRangesTemp = mismatchedRanges_[j];
+      auto mismatchedLengthsTemp = mismatchedLengths_[j];
+      // if one feature triggers ENFORCEMENT failure, reset the counter for this feature to avoid carry-on impact
+      if ((maxMismatchedRatio_ < 1.0 && std::max(totalRangesTemp, minObservation_) * maxMismatchedRatio_ < mismatchedRangesTemp) || (maxEmptyRatio_ < 1.0 && std::max(totalRangesTemp, minObservation_) * maxEmptyRatio_ < emptyRangesTemp)) {
+        totalRanges_[j] = 0;
+        emptyRanges_[j] = 0;
+        mismatchedRanges_[j] = 0;
+        mismatchedLengths_[j].clear();
+      }
+
       if (maxMismatchedRatio_ < 1.0) {
         CAFFE_ENFORCE_GE(
-            std::max(totalRanges_, minObservation_) * maxMismatchedRatio_,
-            mismatchedRanges_[j],
+            std::max(totalRangesTemp, minObservation_) * maxMismatchedRatio_,
+            mismatchedRangesTemp,
             "Ratio of range length mismatch for feature at index ",
             j,
             " is ",
-            (static_cast<double>(mismatchedRanges_[j]) /
-             static_cast<double>(totalRanges_)),
+            (static_cast<double>(mismatchedRangesTemp) /
+             static_cast<double>(totalRangesTemp)),
             " (",
-            mismatchedRanges_[j],
+            mismatchedRangesTemp,
             "/",
-            totalRanges_,
+            totalRangesTemp,
             ") which exceeds ",
             maxMismatchedRatio_,
             ". The incorrect lengths include: ",
-            mismatchedLengths_[j]);
+            mismatchedLengthsTemp);
       }
 
       // Only check when the ratio is not set to allow all examples to be empty.
       if (maxEmptyRatio_ < 1.0) {
         CAFFE_ENFORCE_GE(
-            std::max(totalRanges_, minObservation_) * maxEmptyRatio_,
-            emptyRanges_[j],
+            std::max(totalRangesTemp, minObservation_) * maxEmptyRatio_,
+            emptyRangesTemp,
             "Ratio of empty ranges for feature at index ",
             j,
             " is ",
-            (static_cast<double>(emptyRanges_[j]) /
-             static_cast<double>(totalRanges_)),
+            (static_cast<double>(emptyRangesTemp) /
+             static_cast<double>(totalRangesTemp)),
             " (",
-            emptyRanges_[j],
+            emptyRangesTemp,
             "/",
-            totalRanges_,
+            totalRangesTemp,
             ") which exceeds ",
             maxEmptyRatio_);
       }
@@ -221,7 +240,7 @@ class GatherRangesToDenseOp final : public Operator<Context> {
 
  private:
   vector<int> lengths_;
-  int64_t totalRanges_ = 0;
+  vector<int64_t> totalRanges_;
   vector<int64_t> emptyRanges_;
   vector<int64_t> mismatchedRanges_;
   vector<set<int>> mismatchedLengths_;


### PR DESCRIPTION
Summary:
## Context
The embedding feature validation for GatherRangeToDense was added in the previous diff: D18031155. The logic will check the mismatchedranges or empty ranges in the whole model lifecycle, once the ratio exceeds some thresehold, it will trigger ENFORCE failure (exception).
In the current implementation, it may have carry-on impact. The mismatch ratio is equal to:
```
ratio = mismatched_ranges_from_t0_to_t1 / total_ranges_from_t0_to_t1
```
if the mismatched_ranges_from_t0 somehow increased a lot (bad value spike) at request N, the ratio will be much larger than the treshold.  Then it may take long util t2 to make the new ratio drops below the threshold. however, the requests between t1 and t2 may be all good requests, then it brings carry-on impact.
Instead, we would like to propose a new strategy, when exception happen at T1, we will clean up all the history counters for this bad feature, and make it a clean run for the next phase util the next exception. it then will get rid of the carry-on impact.
In this logic, we will clean up the counter based on the bad feature J.
more context: https://docs.google.com/document/d/1tYHISyiLf-PVKPVGlZRZ0iq2Hvog3g5BjCKMCDLZHHo/edit

Test Plan:
hardcode a much smaller threshold as 0.0001 to force trigger the exception, deploy on some hosts in prod tiers

```
EPHEMERAL_PACKAGE=d44a3de1305c3b4c30fd62bc354a1285 tw update fbcode/tupperware/config/admarket/sigrid/predictor/prod.tw tsp_cln/admarket/sigrid_predictor_v2_dh_t1_elastic_ha --tasks=100-199 --fast --force
```

## 1) totalRanges can be correct logged
```
I1018 20:37:09.012523  2074 gather_ranges_to_dense_op.h:69 req:00f00000001abbf1] In GatherRangesToDenseOp:
  Lifetime empty ranges for each feature is 12354.
  Lifetime mismatched ranges for each feature is 526.
  With a total of 87503 examples for each feature.
```

## 2) exception can be still triggered
```
E1018 21:08:42.007398   668 LoggingPredictorService.cpp:701 req:001000000013df51] getRequestPrecomputedDataOnePass failure on model 481948521_146: [enforce fail at gather_ranges_to_dense_op.h:215] std::max(totalRangesTemp, minObservation_) * maxMismatchedRatio_ >= mismatchedRangesTemp. 0.1 vs 1. Ratio of range length mismatch for feature at index 0 is 0.00813008 (1/123) which exceeds 1e-05. The incorrect lengths include: 15 (Error from operator:

```

Differential Revision: D50570811


