### PR TITLE
[TD] Enable trial mode for new heuristics

### DIFF
--- a/tools/testing/target_determination/determinator.py
+++ b/tools/testing/target_determination/determinator.py
@@ -15,7 +15,7 @@ def get_test_prioritizations(tests: List[str]) -> AggregatedHeuristics:
 
     for heuristic in HEURISTICS:
         new_rankings: TestPrioritizations = heuristic.get_test_priorities(tests)
-        aggregated_results.add_heuristic_results(str(heuristic), new_rankings)
+        aggregated_results.add_heuristic_results(heuristic, new_rankings)
 
         num_tests_found = len(new_rankings.get_prioritized_tests())
         print(

--- a/tools/testing/target_determination/heuristics/__init__.py
+++ b/tools/testing/target_determination/heuristics/__init__.py
@@ -17,7 +17,7 @@ from tools.testing.target_determination.heuristics.previously_failed_in_pr impor
 )
 
 # All currently running heuristics.
-# To add a heurstic in test mode, specify the keywork argument `test_mode=True`.
+# To add a heurstic in trial mode, specify the keywork argument `trial_mode=True`.
 HEURISTICS: List[HeuristicInterface] = [
     PreviouslyFailedInPR(),
     EditedByPR(),

--- a/tools/testing/target_determination/heuristics/__init__.py
+++ b/tools/testing/target_determination/heuristics/__init__.py
@@ -16,6 +16,8 @@ from tools.testing.target_determination.heuristics.previously_failed_in_pr impor
     PreviouslyFailedInPR,
 )
 
+# All currently running heuristics.
+# To add a heurstic in test mode, specify the keywork argument `test_mode=True`.
 HEURISTICS: List[HeuristicInterface] = [
     PreviouslyFailedInPR(),
     EditedByPR(),

--- a/tools/testing/target_determination/heuristics/interface.py
+++ b/tools/testing/target_determination/heuristics/interface.py
@@ -222,12 +222,12 @@ class AggregatedHeuristics:
         self._heuristic_results = {}
 
     def add_heuristic_results(
-        self, heuristic_name: str, heuristic_results: TestPrioritizations
+        self, heuristic: "HeuristicInterface", heuristic_results: TestPrioritizations
     ) -> None:
-        if heuristic_name in self._heuristic_results:
-            raise ValueError(f"We already have heuristics for {heuristic_name}")
+        if heuristic in self._heuristic_results:
+            raise ValueError(f"We already have heuristics for {heuristic.name}")
 
-        self._heuristic_results[heuristic_name] = heuristic_results
+        self._heuristic_results[heuristic] = heuristic_results
 
     def get_aggregated_priorities(self) -> TestPrioritizations:
         """
@@ -237,7 +237,10 @@ class AggregatedHeuristics:
             tests_being_ranked=self.unranked_tests
         )
 
-        for heuristic_results in self._heuristic_results.values():
+        for heuristic, heuristic_results in self._heuristic_results.items():
+            if heuristic.test_mode:
+                continue
+
             aggregated_priorities.integrate_priorities(heuristic_results)
 
         return aggregated_priorities
@@ -268,12 +271,13 @@ class AggregatedHeuristics:
         # And figure out how many heuristics suggested prioritizing this test
         num_heuristics_prioritized_by = 0
 
-        for heuristic_name, heuristic_results in self._heuristic_results.items():
+        for heuristic, heuristic_results in self._heuristic_results.items():
             metrics = heuristic_results.get_priority_info_for_test(test)
-            metrics["heuristic_name"] = heuristic_name
+            metrics["heuristic_name"] = heuristic.name
+            metrics["test_mode"] = heuristic.test_mode
             heuristics.append(metrics)
 
-            if heuristic_results._get_test_relevance_group(test) in [
+            if not heuristic.test_mode and heuristic_results._get_test_relevance_group(test) in [
                 Relevance.HIGH,
                 Relevance.PROBABLE,
             ]:
@@ -284,7 +288,7 @@ class AggregatedHeuristics:
                 # because it was randomly sorted higher initially, while the heuristic that actually prioritized it
                 # used other data to determined it to be slighlty less relevant than other tests.
                 if metrics[METRIC_ORDER_OVERALL] < highest_ranking_heuristic_order:
-                    highest_ranking_heuristic = heuristic_name
+                    highest_ranking_heuristic = heuristic.name
                     highest_ranking_heuristic_order = metrics[METRIC_ORDER_OVERALL]
 
         stats["heuristics"] = heuristics
@@ -307,11 +311,15 @@ class HeuristicInterface:
     Interface for all heuristics.
     """
 
-    name: str
     description: str
+
+    # When test mode is set to True, this heuristic's predictions will not be used
+    # to reorder tests. It's results will however be emitted in the metrics.
+    test_mode: bool
 
     @abstractmethod
     def __init__(self, **kwargs: Dict[str, Any]) -> None:
+        self.test_mode = kwargs.get("test_mode", False)
         pass
 
     @abstractmethod
@@ -323,5 +331,9 @@ class HeuristicInterface:
         """
         pass
 
-    def __str__(self) -> str:
+    @property
+    def name(self) -> str:
         return self.__class__.__name__
+
+    def __str__(self) -> str:
+        return self.name

--- a/tools/testing/target_determination/heuristics/interface.py
+++ b/tools/testing/target_determination/heuristics/interface.py
@@ -316,7 +316,7 @@ class AggregatedHeuristics:
 
 class HeuristicInterface:
     """
-    Interface for all heuristics.
+    Interface for all heuristics
     """
 
     description: str

--- a/tools/testing/target_determination/heuristics/interface.py
+++ b/tools/testing/target_determination/heuristics/interface.py
@@ -316,7 +316,7 @@ class AggregatedHeuristics:
 
 class HeuristicInterface:
     """
-    Interface for all heuristics
+    Interface for all heuristics.
     """
 
     description: str
@@ -328,7 +328,6 @@ class HeuristicInterface:
     @abstractmethod
     def __init__(self, **kwargs: Dict[str, Any]) -> None:
         self.trial_mode = kwargs.get("trial_mode", False)  # type: ignore[assignment]
-        pass
 
     @abstractmethod
     def get_test_priorities(self, tests: List[str]) -> TestPrioritizations:

--- a/tools/testing/target_determination/heuristics/interface.py
+++ b/tools/testing/target_determination/heuristics/interface.py
@@ -238,7 +238,7 @@ class AggregatedHeuristics:
         )
 
         for heuristic, heuristic_results in self._heuristic_results.items():
-            if heuristic.test_mode:
+            if heuristic.trial_mode:
                 continue
 
             aggregated_priorities.integrate_priorities(heuristic_results)
@@ -274,10 +274,10 @@ class AggregatedHeuristics:
         for heuristic, heuristic_results in self._heuristic_results.items():
             metrics = heuristic_results.get_priority_info_for_test(test)
             metrics["heuristic_name"] = heuristic.name
-            metrics["test_mode"] = heuristic.test_mode
+            metrics["trial_mode"] = heuristic.trial_mode
             heuristics.append(metrics)
 
-            if not heuristic.test_mode and heuristic_results._get_test_relevance_group(test) in [
+            if not heuristic.trial_mode and heuristic_results._get_test_relevance_group(test) in [
                 Relevance.HIGH,
                 Relevance.PROBABLE,
             ]:
@@ -313,13 +313,13 @@ class HeuristicInterface:
 
     description: str
 
-    # When test mode is set to True, this heuristic's predictions will not be used
+    # When trial mode is set to True, this heuristic's predictions will not be used
     # to reorder tests. It's results will however be emitted in the metrics.
-    test_mode: bool
+    trial_mode: bool
 
     @abstractmethod
     def __init__(self, **kwargs: Dict[str, Any]) -> None:
-        self.test_mode = kwargs.get("test_mode", False)
+        self.trial_mode = kwargs.get("trial_mode", False)
         pass
 
     @abstractmethod


### PR DESCRIPTION
This lets one get metrics from a new heuristic and evaluate it's results without having it actually reorder the tests