### PR TITLE
weak symbol on c10::Warning::Warning

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -141,6 +141,12 @@
 #define __has_attribute(x) 0
 #endif
 
+#if __has_attribute(weak)
+#define C10_WEAK __attribute__((weak))
+#else
+#define C10_WEAK
+#endif
+
 // Direct port of LLVM_ATTRIBUTE_USED.
 #if __has_attribute(used)
 #define C10_USED __attribute__((__used__))

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -117,13 +117,13 @@ class C10_API Warning {
 
   using warning_variant_t = std::variant<UserWarning, DeprecationWarning>;
 
-  Warning(
+  C10_WEAK Warning(
       warning_variant_t type,
       const SourceLocation& source_location,
       std::string msg,
       bool verbatim);
 
-  Warning(
+  C10_WEAK Warning(
       warning_variant_t type,
       SourceLocation source_location,
       const char* msg,


### PR DESCRIPTION
recent c10::variant to std::variant change breaks binary compatibility. See PR #109723 

```
undefined symbol: _ZN3c107WarningC1ESt7variantIJNS0_11UserWarningENS0_18DeprecationWarningEEERKNS_14SourceLocationENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEb
```

Adding weak annotation allows binary to ignore the import error.