### PR TITLE
fix regression which creates a new fake tensor

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -2221,10 +2221,10 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
 
         mod = Mod()
         foo(mod, torch.rand([4]))
-        self.assertEqual(compiles_without_buffers, 1)
+        self.assertEqual(compiles_without_buffers, 0)
 
         foo(mod, torch.rand([4], dtype=torch.half))
-        self.assertEqual(compiles_without_buffers, 2)
+        self.assertEqual(compiles_without_buffers, 1)
 
         class Mod2(Mod):
             def __setattr__(self, name, value):
@@ -2232,7 +2232,7 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
 
         foo(Mod2(), torch.rand([4]))
         # causes two compilations, bc unimplemented custom setattr
-        self.assertTrue(compiles_without_buffers >= 4)
+        self.assertTrue(compiles_without_buffers >= 2)
 
     def test_unspec_non_inlinable_module(self):
         mod = UnspecNonInlinableModule()

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1360,7 +1360,7 @@ def get_fake_value(node, tx):
 
     op = node.op
 
-    # FX Node should always return the same value
+    # FX Node should always return the same fake value
     if "example_value" in node.meta and is_fake(node.meta["example_value"]):
         return node.meta["example_value"]
 

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1234,12 +1234,7 @@ class BuiltinVariable(VariableTracker):
 
                 if isinstance(getattr_var, variables.TensorVariable):
                     # get_fake_val will return a real tensor here because it's an attribute on the module (get_attr node)
-                    existing_attr = get_fake_value(getattr_var.as_proxy().node, tx)
-                    existing_fake_attr = (
-                        variables.builder.wrap_to_fake_tensor_and_record(
-                            existing_attr, tx, source=getattr_var.source, is_tensor=True
-                        )
-                    )
+                    existing_fake_attr = get_fake_value(getattr_var.as_proxy().node, tx)
 
                     # same tensor identiy, setattr is a no-op
                     mod_setattr = inspect.getattr_static(obj.module_type, "__setattr__")

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1233,7 +1233,7 @@ class BuiltinVariable(VariableTracker):
                     getattr_var = None
 
                 if isinstance(getattr_var, variables.TensorVariable):
-                    # get_fake_val will return a real tensor here because it's an attribute on the module (get_attr node)
+                    # get_fake_val will get the same fake tensor
                     existing_fake_attr = get_fake_value(getattr_var.as_proxy().node, tx)
 
                     # same tensor identiy, setattr is a no-op


### PR DESCRIPTION
Fixes regression identified here: https://github.com/pytorch/pytorch/pull/111565/files/ccd6b373b5fba81b6141a6b93b2ffb6595dd49ae#r1369334484

Now that `get_fake_value` can return previously retrieved, we should not try to wrap the fake value again.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng