### PR TITLE
Update the magma to version 2.7.2 (#111442)

### DIFF
--- a/.ci/docker/common/install_rocm_magma.sh
+++ b/.ci/docker/common/install_rocm_magma.sh
@@ -5,8 +5,10 @@ set -ex
 # "install" hipMAGMA into /opt/rocm/magma by copying after build
 git clone https://bitbucket.org/icl/magma.git
 pushd magma
-# Fixes memory leaks of magma found while executing linalg UTs
-git checkout 28592a7170e4b3707ed92644bf4a689ed600c27f
+
+# Version 2.7.2 + ROCm related updates
+git checkout 823531632140d0edcb7e77c3edc0e837421471c5
+
 cp make.inc-examples/make.inc.hip-gcc-mkl make.inc
 echo 'LIBDIR += -L$(MKLROOT)/lib' >> make.inc
 echo 'LIB += -Wl,--enable-new-dtags -Wl,--rpath,/opt/rocm/lib -Wl,--rpath,$(MKLROOT)/lib -Wl,--rpath,/opt/rocm/magma/lib' >> make.inc


### PR DESCRIPTION
- 2.7.2 version + few ROCm related commits: https://bitbucket.org/icl/magma/pull-requests/37

I'm trying to see if this cherry pick fixes ROCm job on `release/2.1` branch, for example https://hud.pytorch.org/pytorch/pytorch/commit/1f0450eed28f2b17a55da488f21602b3e32f1c59
