### PR TITLE
[Dynamo]remove an unnecessary check

### DIFF
--- a/torch/csrc/dynamo/eval_frame.c
+++ b/torch/csrc/dynamo/eval_frame.c
@@ -791,7 +791,6 @@ inline static PyObject* eval_custom_code_impl(
   #else
   Py_ssize_t nlocals_new = code->co_nlocals;
   Py_ssize_t nlocals_old = frame->f_code->co_nlocals;
-  DEBUG_CHECK(nlocals_new >= nlocals_old);
 
   Py_ssize_t ncells = PyCode_GetNCellvars(code);
   Py_ssize_t nfrees = PyCode_GetNFreevars(code);


### PR DESCRIPTION
Per the discussion at https://github.com/pytorch/pytorch/issues/111633#issuecomment-1774076606 , this debug check is unnecessary, and will cause segmentation fault.

For resume functions, the `nlocals` is unnecessarily large.

Let's use the typical toy example:

```python
import torch

@torch.compile(backend="eager")
def toy_example(a, b):
    x = a / (torch.abs(a) + 1)
    if b.sum() < 0:
        b = b * -1
    return x * b

for _ in range(100):
    toy_example(torch.randn(10), torch.randn(10))
```

For example, resume functions have 3 local variables `('b', 'x', 'a')`, but the bytecode only uses two: `('b', 'x')`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng