### PR TITLE
[cpu][inductor] improve cpu vec implementations of log

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float.h
@@ -208,7 +208,7 @@ public:
     return Vectorized<float>(Sleef_fmodf8(values, q));
   }
   Vectorized<float> log() const {
-    return Vectorized<float>(Sleef_logf8_u10(values));
+    return Vectorized<float>(Sleef_logf8_u35(values));
   }
   Vectorized<float> log2() const {
     return Vectorized<float>(Sleef_log2f8_u10(values));

--- a/aten/src/ATen/cpu/vec/vec512/vec512_float.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_float.h
@@ -238,7 +238,7 @@ public:
     return Vectorized<float>(Sleef_fmodf16(values, q));
   }
   Vectorized<float> log() const {
-    return Vectorized<float>(Sleef_logf16_u10(values));
+    return Vectorized<float>(Sleef_logf16_u35(values));
   }
   Vectorized<float> log2() const {
     return Vectorized<float>(Sleef_log2f16_u10(values));

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1429,7 +1429,7 @@ class CPUReproTests(TestCase):
     @patch("torch.cuda.is_available", lambda: False)
     def test_vec_cpu_only_for_all_available_isa(self):
         def fn(x):
-            return torch.sin(torch.cos(torch.erf(x)))
+            return torch.sin(torch.cos(torch.log(torch.erf(x))))
 
         x = torch.randn((2, 9))
         x[0, 0] = torch.nan


### PR DESCRIPTION
Fixes #110611.

The current Torchinductor's `log` implementations will call `sleef` functions in `aten::Vec` which show worse performance than Aten's `log` implementations that invoke `MKL` functions. The reason is that the `sleef` algorithms sacrifice performance in order to have a higher precision. This PR changes Torchinductor's `log` implementations from the `sleef` functions with `1.0` ULP error bound to the ones with `3.5` ULP error bound.

**Performance**
Machine: ICX

The original perf number, perf with `Sleef_logf16_u10`:
```bash
numactl -C0 python test.py
log
eager:    368.8463559374213
compiled: 616.8672097846866
logit
eager:    565.499295014888
compiled: 1010.4096410796046
```

Perf with `Sleef_logf16_u35`:
```bash
numactl -C0 python test.py
log
eager:    364.8629770614207
compiled: 360.2141812443733
logit
eager:    562.3160391114652
compiled: 545.2622110024095
```

**Accuracy**
error_bound | tol=1e-6 | tol=1e-7
-- | -- | --
1.0 ULP | PASS | FAIL
3.5 ULP | PASS | FAIL



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @mlazos @soumith @yanboliang @anijain2305 @Xia-Weiwen @desertfire
