### PR TITLE
[easy] Reapply D49842542 (remove pessimizing move)

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -122,8 +122,7 @@ class AOTInductorModelContainer {
           device_type,
           device_idx,
           &tensor_handle));
-      constants_->emplace(
-          std::move(name), std::move(RAIIAtenTensorHandle(tensor_handle)));
+      constants_->emplace(std::move(name), tensor_handle);
     }
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #111910

This fixes a pessimizing move; for some reason the linked diff was
allowed to land with this change applied only to the internal fork of pytorch.

Differential Revision: [D50599188](https://our.internmc.facebook.com/intern/diff/D50599188/)