### PR TITLE
[dynamo] Perf (`MapHigherOrderVariable`): do not unnecessarily `get_real_value`

### DIFF
--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -653,9 +653,7 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
         )
         non_single_tensor_return_unsupported("torch.ops.higher_order.map", body_r)
         r = body_r.as_proxy().node.meta["example_value"]
-        example_value = r.new_empty(
-            [sample_shape[0], *r.shape]
-        )
+        example_value = r.new_empty([sample_shape[0], *r.shape])
 
         _, p_kwargs = proxy_args_kwargs([], kwargs)
 

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -602,7 +602,7 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
         assert type(args[0]) in (UserFunctionVariable, NestedUserFunctionVariable)
         assert type(args[1]) is TensorVariable
 
-        mapped_tensor_fake_value = get_fake_value(args[1].as_proxy().node, tx)
+        sample_shape = get_fake_value(args[1].as_proxy().node, tx).size()
 
         if len(sample_shape) < 1 or sample_shape[0] == 0:
             unimplemented(
@@ -654,7 +654,7 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
         non_single_tensor_return_unsupported("torch.ops.higher_order.map", body_r)
         r = body_r.as_proxy().node.meta["example_value"]
         example_value = r.new_empty(
-            [mapped_tensor_fake_value.shape[0], *r.shape]
+            [sample_shape[0], *r.shape]
         )
 
         _, p_kwargs = proxy_args_kwargs([], kwargs)

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -602,7 +602,8 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
         assert type(args[0]) in (UserFunctionVariable, NestedUserFunctionVariable)
         assert type(args[1]) is TensorVariable
 
-        sample_shape = args[1].get_real_value().size()
+        mapped_tensor_fake_value = get_fake_value(args[1].as_proxy().node, tx)
+
         if len(sample_shape) < 1 or sample_shape[0] == 0:
             unimplemented(
                 "map() operator doesn't support scalar or zero-sized tensors during tracing."
@@ -653,7 +654,7 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
         non_single_tensor_return_unsupported("torch.ops.higher_order.map", body_r)
         r = body_r.as_proxy().node.meta["example_value"]
         example_value = r.new_empty(
-            [get_fake_value(args[1].as_proxy().node, tx).shape[0], *r.shape]
+            [mapped_tensor_fake_value.shape[0], *r.shape]
         )
 
         _, p_kwargs = proxy_args_kwargs([], kwargs)


### PR DESCRIPTION
`get_real_value` will run the real tensor computation via the fx graph, which could be really expensive.

Let's just do the sensible thing by running the fx graph on the fake value

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng