### PR TITLE
fix TEST_ROCM definition to disable test_jit_cudnn_extension on rocm (#110385)

### DIFF
--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -20,8 +20,9 @@ from torch.testing._internal.common_utils import gradcheck
 import torch.multiprocessing as mp
 from torch.utils.cpp_extension import _TORCH_PATH, remove_extension_h_precompiler_headers, get_cxx_compiler, check_compiler_is_gcc
 
-TEST_CUDA = TEST_CUDA and CUDA_HOME is not None
+# define TEST_ROCM before changing TEST_CUDA
 TEST_ROCM = TEST_CUDA and torch.version.hip is not None and ROCM_HOME is not None
+TEST_CUDA = TEST_CUDA and CUDA_HOME is not None
 TEST_MPS = torch.backends.mps.is_available()
 IS_WINDOWS = sys.platform == "win32"
 IS_LINUX = sys.platform.startswith('linux')


### PR DESCRIPTION
Define TEST_ROCM before modification TEST_CUDA. Otherwise TEST_ROCM will always be false and will not disable test_jit_cudnn_extension for rocm Fixes https://github.com/pytorch/pytorch/issues/107182

I'm trying to see if this cherry pick fixes ROCm job on release/2.1 branch, for example https://hud.pytorch.org/pytorch/pytorch/commit/1f0450eed28f2b17a55da488f21602b3e32f1c59

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang