### PR TITLE
[dynamo] Ensure Dynamo uses this graph's fakes for `Tensor` `example_value`s

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -69,6 +69,7 @@ from torch import fx
 from torch._dispatch.python import enable_python_dispatcher
 
 from torch.nn.modules.lazy import LazyModuleMixin
+from torch.utils._pytree import tree_map_only
 
 
 counters = collections.defaultdict(collections.Counter)

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1352,7 +1352,7 @@ def get_fake_value(node, tx, allow_non_graph_fake=False):
     allow_non_graph_fake: whether to allow the return result to be:
         1. non-fake or 2. fake that is not created by this instance of Dynamo.
         If `True`, you must be prepared to deal with such return values, ideally
-        by further wrapping them as fakes.
+        by further wrapping them as this graph's fakes.
     """
     from .exc import (
         TorchRuntimeError,

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -56,7 +56,7 @@ try:
         NP_SUPPORTED_MODULES = {}
 
         NP_TO_TNP_MODULE = {}
-    from torch._subclasses.fake_tensor import FakeTensor, is_fake
+    from torch._subclasses.fake_tensor import FakeTensor, is_fake, maybe_get_fake_mode
 except ImportError:
     pass
 
@@ -1373,7 +1373,9 @@ def get_fake_value(node, tx):
         return n.meta["example_value"]
 
     def wraps_non_fake(e):
-        if not tx.output.fake_mode.is_our_fake(e):
+        if not (
+            is_fake(e) and maybe_get_fake_mode(e) is tx.fake_mode
+        ):
             e = deepcopy_to_fake_tensor(e)
         return e
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1370,7 +1370,7 @@ def get_fake_value(node, tx, allow_non_graph_fake=False):
         return node.meta["example_value"]
 
     def ensure_graph_fake(e):
-        assert is_fake(e) and maybe_get_fake_mode(e) is tx.fake_mode
+        assert maybe_get_fake_mode(e) is tx.fake_mode
         return e
 
     def visit(n: torch.fx.Node):

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -69,7 +69,6 @@ from torch import fx
 from torch._dispatch.python import enable_python_dispatcher
 
 from torch.nn.modules.lazy import LazyModuleMixin
-from torch.utils._pytree import tree_map
 
 
 counters = collections.defaultdict(collections.Counter)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -42,7 +42,7 @@ from ..allowed_functions import (
 )
 
 from ..device_interface import device_interfaces
-from ..exc import unimplemented, InternalTorchDynamoError
+from ..exc import InternalTorchDynamoError, unimplemented
 from ..guards import GuardBuilder, make_dupe_guard
 from ..side_effects import SideEffects
 from ..source import (
@@ -1360,7 +1360,7 @@ def wrap_fx_proxy(tx, proxy, example_value=None, subclass_type=None, **options):
 #
 # In all cases, the returned `TensorVariable` subclass will have an `example_value`
 # and that `example_value` must be a `FakeTensor` produced by the currently running
-# instance of Dynamo. 
+# instance of Dynamo.
 #
 # Upon closer inspection, you may notice that there are a slurry of non-Tensor
 # output cases.  What gives?  Well, we sometimes trace operations into the
@@ -1452,7 +1452,7 @@ def wrap_fx_proxy_cls(
             )
         if (
             not is_fake(example_value)
-            or not maybe_get_fake_mode(example_value) is tx.fake_mode
+            or maybe_get_fake_mode(example_value) is not tx.fake_mode
         ):
             raise InternalTorchDynamoError(
                 "`example_value` needs to be a `FakeTensor` wrapped by this instance of Dynamo"

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1117,10 +1117,9 @@ class VariableBuilder:
         # TODO: I think the result is guaranteed to be fake with
         # ignore_subclass changes
         # Note: this information is conveyed via subclass_type now
-        fake_tensor_value = None
-        example_value = tensor_variable.proxy.node.meta["example_value"]
-        if is_fake(example_value):
-            fake_tensor_value = example_value
+        fake_tensor_value = tensor_variable.proxy.node.meta["example_value"]
+        if not is_fake(fake_tensor_value):
+            raise InternalTorchDynamoError("Wrapped Tensor must have a fake value")
 
         grapharg = GraphArg(source, value, False, fake_tensor_value)
         tensor_proxy.node.meta["grapharg"] = grapharg

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -209,6 +209,10 @@ def maybe_get_fake_mode(t):
         m = modes[0]
         assert all(m is x for x in modes)
         return m
+    elif isinstance(t, torch.Tensor) and torch._is_functional_tensor(t):
+        reapply_views = torch._C._functionalization_reapply_views_tls()
+        unwrapped = torch._C._functorch._unwrap_functional_tensor(t, reapply_views)
+        return maybe_get_fake_mode(unwrapped)
     return None
 
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/111869, Fixes (detailed list of cases handled): https://github.com/pytorch/pytorch/pull/111913#discussion_r1370267313, fully fixes: https://github.com/pytorch/pytorch/issues/111873

Adds sanity checks ensuring that Dynamo uses this graph's fakes for Tensor `example_values`

Handles the main (and only?) entrypoints for new `FakeTensor`s in a Dynamo graph:
- `wrap_fx_proxy_cls`
- `VariableTracker.wrap_tensor` 

Ensures that `get_fake_value` returns a fake except when we know we are going to properly wrap non-fakes.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng