### PR TITLE
[Inductor] Support user defined triton kernels calling other user defined triton kernels and activations

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -1377,6 +1377,9 @@ class WrapperModule(torch.nn.Module):
 
 if HAS_TRITON:
     # Define shared triton kernels here so that multiple tests can access it
+    # NB: This also addresses a triton limitation where if the kernels are
+    # getting called indirectly, triton cannot find the kernels unless they
+    # are at top level.
     @triton.jit
     def add_kernel(
         in_ptr0,
@@ -1426,6 +1429,23 @@ if HAS_TRITON:
     @triton.jit
     def zero_negs(x):
         return tl.where(x >= 0, x, 0)
+
+    @triton.jit
+    def indirection_kernel(
+        in_ptr0,
+        out_ptr,
+        n_elements,
+        BLOCK_SIZE: "tl.constexpr",
+        ACTIVATION: "tl.constexpr",
+    ):
+        pid = tl.program_id(axis=0)
+        block_start = pid * BLOCK_SIZE
+        offsets = block_start + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        if ACTIVATION == "mul2_inplace_kernel":
+            mul2_inplace_kernel(in_ptr0, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+        x = tl.load(in_ptr0 + offsets, mask=mask)
+        tl.store(out_ptr + offsets, x, mask=mask)
 
 
 class DefaultsTests(torch._dynamo.test_case.TestCase):
@@ -1852,8 +1872,20 @@ def forward(self, x_1, output_1):
             block_start = pid * BLOCK_SIZE
             offsets = block_start + tl.arange(0, BLOCK_SIZE)
             mask = offsets < n_elements
-            mul2_inplace_kernel(in_ptr0, n_elements, BLOCK_SIZE=BLOCK_SIZE)
-            mul2_inplace_kernel(in_ptr1, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+            indirection_kernel(
+                in_ptr0,
+                in_ptr0,
+                n_elements,
+                BLOCK_SIZE=BLOCK_SIZE,
+                ACTIVATION="mul2_inplace_kernel",
+            )
+            indirection_kernel(
+                in_ptr1,
+                in_ptr1,
+                n_elements,
+                BLOCK_SIZE=BLOCK_SIZE,
+                ACTIVATION="mul2_inplace_kernel",
+            )
             x = tl.load(in_ptr0 + offsets, mask=mask)
             y = tl.load(in_ptr1 + offsets, mask=mask)
             output = x + y

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -824,13 +824,22 @@ class WrapperCodeGen(CodeGen):
         # Also include any possible kernel being called indirectly
         from triton import JITFunction
 
-        for symbol_name in kernel.fn.__code__.co_names:
-            if symbol_name in kernel.fn.__globals__:
-                symbol = kernel.fn.__globals__[symbol_name]
-                if isinstance(symbol, JITFunction):
-                    compile_wrapper.newline()
-                    compile_wrapper.writeline("@triton.jit")
-                    compile_wrapper.splice(symbol.src, strip=True)
+        symbols_included = {original_name}
+
+        def traverse(cur_kernel):
+            for symbol_name in cur_kernel.fn.__code__.co_names:
+                if symbol_name in symbols_included:
+                    continue
+                if symbol_name in cur_kernel.fn.__globals__:
+                    symbol = cur_kernel.fn.__globals__[symbol_name]
+                    if isinstance(symbol, JITFunction):
+                        compile_wrapper.newline()
+                        compile_wrapper.writeline("@triton.jit")
+                        compile_wrapper.splice(symbol.src, strip=True)
+                        symbols_included.add(symbol_name)
+                        traverse(symbol)
+
+        traverse(kernel)
 
         compile_wrapper.writeline("''')")
         _, lineno = inspect.getsourcelines(kernel.fn)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #111957
* #111956
* #111939
* #111808
* #111770



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler