### PR TITLE
[dynamo] `ExecutorchCallDelegateHigherOrderVariable` - add sanity check that input and output tensors are disjoint

### DIFF
--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -3439,6 +3439,18 @@ class ActivationCheckpointingTests(torch._dynamo.test_case.TestCase):
             [test_op.py_kernels[key]() for key in default_keys],
         )
 
+    def test_non_aliasing_util(self):
+        from torch._dynamo.variables.higher_order_ops import _assert_tensors_nonaliasing
+
+        a = [torch.tensor(1), {"a": torch.tensor(1)}]
+        b = (torch.tensor(1),)
+        _assert_tensors_nonaliasing(a, b)
+
+        with self.assertRaisesRegex(
+            AssertionError, "inputs to function body cannot alias outputs"
+        ):
+            _assert_tensors_nonaliasing(a, a)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -709,10 +709,9 @@ class ExecutorchCallDelegateHigherOrderVariable(TorchHigherOrderOperatorVariable
 
         example_res = lowered_module.original_module(*real_sub_args)
 
-        # In order to guarantee an equivalent aliasing relationship among
-        # FakeTensors in Dynamo and Tensors in eager execution, executorch
-        # promises not to alias inputs and outputs.
-        # Thus, output FakeTensors shall not alias input FakeTensors.
+        # executorch modules promise not to alias inputs and outputs.
+        # Thus, output FakeTensors correctly will not alias input FakeTensors.
+        # This helps guarantee the 1-1 correspondence property of FakeTensors in Dynamo.
         _assert_tensors_nonaliasing(real_sub_args, example_res)
 
         example_value = deepcopy_to_fake_tensor(example_res, tx.fake_mode)

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -709,9 +709,9 @@ class ExecutorchCallDelegateHigherOrderVariable(TorchHigherOrderOperatorVariable
 
         example_res = lowered_module.original_module(*real_sub_args)
 
+        # NOTE [Guaranteeing the 1-1 correspondence of FakeTensors and real tensors]:
         # executorch modules promise not to alias inputs and outputs.
-        # Thus, output FakeTensors correctly will not alias input FakeTensors.
-        # This helps guarantee the 1-1 correspondence property of FakeTensors in Dynamo.
+        # Thus, output FakeTensors will correctly not alias input FakeTensors.
         _assert_tensors_nonaliasing(real_sub_args, example_res)
 
         example_value = deepcopy_to_fake_tensor(example_res, tx.fake_mode)

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -712,7 +712,7 @@ class ExecutorchCallDelegateHigherOrderVariable(TorchHigherOrderOperatorVariable
         # In order to guarantee an equivalent aliasing relationship among
         # FakeTensors in Dynamo and eager execution, executorch promises not to
         # alias inputs and outputs.
-        # Thus, output fake tensors always correctly do not alias input fake tensors.
+        # Thus, output FakeTensors shall not alias input FakeTensors.
         _assert_tensors_nonaliasing(real_sub_args, example_res)
 
         example_value = deepcopy_to_fake_tensor(example_res, tx.fake_mode)

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -81,6 +81,16 @@ def only_consist_of(var, types):
         return all(only_consist_of(item, types) for item in var.items.values())
     return False
 
+def _assert_tensors_nonaliasing(inputs, outputs):
+    input_tensor_ids = set(
+        pytree.tree_flatten_only(torch.Tensor, lambda t: id(t), inputs)
+    )
+    output_tensor_ids = set(
+        pytree.tree_flatten_only(torch.Tensor, lambda t: id(t), outputs)
+    )
+    assert input_tensor_ids.isdisjoint(
+        output_tensor_ids
+    ), "inputs to function body cannot alias outputs"
 
 def validate_args_and_maybe_create_graph_inputs(
     sub_args, tracer, tx, manually_set_subgraph_inputs
@@ -694,16 +704,15 @@ class ExecutorchCallDelegateHigherOrderVariable(TorchHigherOrderOperatorVariable
         real_sub_args = pytree.tree_map_only(
             torch.fx.Proxy, lambda a: get_real_value(a.node, tx.output), p_args
         )
-        real_args_tensor_ids = set(
-            pytree.tree_flatten_only(torch.Tensor, lambda t: id(t), real_sub_args)
-        )
 
         example_res = lowered_module.original_module(*real_sub_args)
 
-        real_res_tensor_ids = set(
-            pytree.tree_flatten_only(torch.Tensor, lambda t: id(t), example_res)
-        )
-        assert real_args_tensor_ids.isdisjoint(real_res_tensor_ids)
+        # In order to guarantee an equivalent aliasing relationship among 
+        # FakeTensors in Dynamo and eager execution, executorch promises not to 
+        # alias inputs and outputs. 
+        # Thus, output fake tensors cannot alias any input fake tensor.
+        _assert_tensors_nonaliasing(real_sub_args, example_res)
+
         example_value = deepcopy_to_fake_tensor(example_res, tx.fake_mode)
 
         p_args = (lowered_node,) + p_args

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -81,6 +81,7 @@ def only_consist_of(var, types):
         return all(only_consist_of(item, types) for item in var.items.values())
     return False
 
+
 def _assert_tensors_nonaliasing(inputs, outputs):
     input_tensor_ids = set(
         pytree.tree_flatten_only(torch.Tensor, lambda t: id(t), inputs)
@@ -91,6 +92,7 @@ def _assert_tensors_nonaliasing(inputs, outputs):
     assert input_tensor_ids.isdisjoint(
         output_tensor_ids
     ), "inputs to function body cannot alias outputs"
+
 
 def validate_args_and_maybe_create_graph_inputs(
     sub_args, tracer, tx, manually_set_subgraph_inputs
@@ -707,9 +709,9 @@ class ExecutorchCallDelegateHigherOrderVariable(TorchHigherOrderOperatorVariable
 
         example_res = lowered_module.original_module(*real_sub_args)
 
-        # In order to guarantee an equivalent aliasing relationship among 
-        # FakeTensors in Dynamo and eager execution, executorch promises not to 
-        # alias inputs and outputs. 
+        # In order to guarantee an equivalent aliasing relationship among
+        # FakeTensors in Dynamo and eager execution, executorch promises not to
+        # alias inputs and outputs.
         # Thus, output fake tensors always correctly do not alias input fake tensors.
         _assert_tensors_nonaliasing(real_sub_args, example_res)
 

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -83,12 +83,12 @@ def only_consist_of(var, types):
 
 
 def _assert_tensors_nonaliasing(inputs, outputs):
-    input_tensor_ids = set(
-        pytree.tree_flatten_only(torch.Tensor, lambda t: id(t), inputs)
-    )
-    output_tensor_ids = set(
-        pytree.tree_flatten_only(torch.Tensor, lambda t: id(t), outputs)
-    )
+    input_tensor_ids = {
+        id(t) for t in pytree.tree_leaves(inputs) if isinstance(t, torch.Tensor)
+    }
+    output_tensor_ids = {
+        id(t) for t in pytree.tree_leaves(outputs) if isinstance(t, torch.Tensor)
+    }
     assert input_tensor_ids.isdisjoint(
         output_tensor_ids
     ), "inputs to function body cannot alias outputs"

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -710,7 +710,7 @@ class ExecutorchCallDelegateHigherOrderVariable(TorchHigherOrderOperatorVariable
         # In order to guarantee an equivalent aliasing relationship among 
         # FakeTensors in Dynamo and eager execution, executorch promises not to 
         # alias inputs and outputs. 
-        # Thus, output fake tensors cannot alias any input fake tensor.
+        # Thus, output fake tensors always correctly do not alias input fake tensors.
         _assert_tensors_nonaliasing(real_sub_args, example_res)
 
         example_value = deepcopy_to_fake_tensor(example_res, tx.fake_mode)

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -710,8 +710,8 @@ class ExecutorchCallDelegateHigherOrderVariable(TorchHigherOrderOperatorVariable
         example_res = lowered_module.original_module(*real_sub_args)
 
         # In order to guarantee an equivalent aliasing relationship among
-        # FakeTensors in Dynamo and eager execution, executorch promises not to
-        # alias inputs and outputs.
+        # FakeTensors in Dynamo and Tensors in eager execution, executorch
+        # promises not to alias inputs and outputs.
         # Thus, output FakeTensors shall not alias input FakeTensors.
         _assert_tensors_nonaliasing(real_sub_args, example_res)
 

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -694,7 +694,16 @@ class ExecutorchCallDelegateHigherOrderVariable(TorchHigherOrderOperatorVariable
         real_sub_args = pytree.tree_map_only(
             torch.fx.Proxy, lambda a: get_real_value(a.node, tx.output), p_args
         )
+        real_args_tensor_ids = set(
+            pytree.tree_flatten_only(torch.Tensor, lambda t: id(t), real_sub_args)
+        )
+
         example_res = lowered_module.original_module(*real_sub_args)
+
+        real_res_tensor_ids = set(
+            pytree.tree_flatten_only(torch.Tensor, lambda t: id(t), example_res)
+        )
+        assert real_args_tensor_ids.isdisjoint(real_res_tensor_ids)
         example_value = deepcopy_to_fake_tensor(example_res, tx.fake_mode)
 
         p_args = (lowered_node,) + p_args


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/111917




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng