### PR TITLE
[Pytorch][Vulkan] var.dim

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Var.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Var.cpp
@@ -1,0 +1,76 @@
+#include <ATen/native/vulkan/ops/Common.h>
+#include <ATen/native/vulkan/ops/Utils.h>
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+namespace {
+
+using namespace api::utils;
+
+Tensor var_dim_IntList(
+    const at::Tensor& self_arg,
+    const OptionalIntArrayRef opt_dim,
+    bool unbiased = true, // correction=1 in version 2.0
+    bool keepdim = false) {
+  TORCH_CHECK(
+      self_arg.dim() >= 2 && self_arg.dim() <= 4,
+      "Vulkan var.dim_IntList only supports 2d, 3d, 4d tensors as input!");
+
+  TORCH_CHECK(
+      opt_dim.has_value(), "Vulkan var without a dim arg is not implemented");
+
+  const Tensor self = self_arg.is_vulkan() ? self_arg : self_arg.vulkan();
+
+  std::set<int64_t> dims_set;
+  if (opt_dim.has_value()) {
+    int sample_size = 1;
+    auto dims = opt_dim.value();
+
+    for (const auto& d : dims) {
+      TORCH_CHECK(d >= -self.dim() || d < self.dim(), "Dimension out of range");
+
+      int64_t dim_normalized = utils::normalize(d, self.dim());
+      if (dims_set.find(dim_normalized) != dims_set.end()) {
+        TORCH_CHECK(
+            false,
+            "dim ",
+            dim_normalized,
+            " appears multiple times in the list of dims")
+      }
+      dims_set.insert(dim_normalized);
+
+      sample_size *= self.sizes().vec()[dim_normalized];
+    }
+
+    at::Tensor self_mean = self.mean(opt_dim, true);
+    at::Tensor self_minus_mean = self.sub(self_mean);
+    // We write `self_minus_mean.mul(self_minus_mean)` instead of
+    // `self.sub(self_mean).pow(2)` because Vulkan driver on Android doesn't
+    // support negative input: "The result is undefined if x<0 or if x=0 and
+    // y≤0" see https://registry.khronos.org/OpenGL-Refpages/gl4/html/pow.xhtml
+    at::Tensor output =
+        self_minus_mean.mul(self_minus_mean).mean(opt_dim, keepdim);
+    if (unbiased == true) {
+      output = output.mul(sample_size * 1.0 / (sample_size - 1));
+    }
+    return output;
+  }
+  return self;
+}
+
+#ifdef USE_VULKAN_API
+
+TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
+  m.impl(TORCH_SELECTIVE_NAME("aten::var.dim"), TORCH_FN(var_dim_IntList));
+}
+
+#endif /* USE_VULKAN_API */
+
+} // namespace
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at


### PR DESCRIPTION
Summary:
We implement [`torch.var`](https://pytorch.org/docs/stable/generated/torch.var.html) for tensors of 2d to 4d.

By using the `mean`, `sub` and `pow` ops, we can compute the variance as below without adding a new shader.
```
at::Tensor self_mean = self.mean(opt_dim, true);
at::Tensor output = (self.sub(self_mean).pow(2)).mean(opt_dim, keepdim);
```

Test Plan:
```
[luwei@devbig984.prn1 /data/users/luwei/fbsource (2da0640c6)]$ LD_LIBRARY_PATH=third-party/swiftshader/lib/linux-x64/ buck run fbcode/mode/dev-nosan //xplat/caffe2:pt_vulkan_api_test_bin -- --gtest_filter="*var*"
Building: finished in 0.1 sec (100%) 339/339 jobs, 0/339 updated
  Total time: 0.1 sec
BUILD SUCCEEDED
Running main() from third-party/googletest/1.11.0/googletest/googletest/src/gtest_main.cc
Note: Google Test filter = *var*
[==========] Running 6 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 6 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.var_2d_unbiased
[       OK ] VulkanAPITest.var_2d_unbiased (322 ms)
[ RUN      ] VulkanAPITest.var_2d_biased
[       OK ] VulkanAPITest.var_2d_biased (0 ms)
[ RUN      ] VulkanAPITest.var_3d_unbiased
[       OK ] VulkanAPITest.var_3d_unbiased (2 ms)
[ RUN      ] VulkanAPITest.var_3d_biased
[       OK ] VulkanAPITest.var_3d_biased (2 ms)
[ RUN      ] VulkanAPITest.var_4d_unbiased
[       OK ] VulkanAPITest.var_4d_unbiased (175 ms)
[ RUN      ] VulkanAPITest.var_4d_biased
[       OK ] VulkanAPITest.var_4d_biased (5 ms)
[----------] 6 tests from VulkanAPITest (508 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (508 ms total)
[  PASSED  ] 6 tests.
```

Reviewed By: yipjustin

Differential Revision: D50398925


