### PR TITLE
[release only] Pin Docker images for release.

### DIFF
--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -75,16 +75,46 @@ RELEASE = "release"
 DEBUG = "debug"
 
 LIBTORCH_CONTAINER_IMAGES: Dict[Tuple[str, str], str] = {
-    ("11.8", PRE_CXX11_ABI): "pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00",
-    ("12.1", PRE_CXX11_ABI): "pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00",
-    ("11.8", CXX11_ABI): "pytorch/libtorch-cxx11-builder:cuda11.8-941be28cb5c686dc41b7ea8681701e64192c3002",
-    ("12.1", CXX11_ABI): "pytorch/libtorch-cxx11-builder:cuda12.1-941be28cb5c686dc41b7ea8681701e64192c3002",
-    ("5.5", PRE_CXX11_ABI): "pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692",
-    ("5.6", PRE_CXX11_ABI): "pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692",
-    ("5.5", CXX11_ABI): "pytorch/libtorch-cxx11-builder:rocm5.5-941be28cb5c686dc41b7ea8681701e64192c3002",
-    ("5.6", CXX11_ABI): "pytorch/libtorch-cxx11-builder:rocm5.6-17ea05e4536e78c9c0be8641952b1c5850a298cb",
-    ("cpu", PRE_CXX11_ABI): "pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00",
-    ("cpu", CXX11_ABI): "pytorch/libtorch-cxx11-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00",
+    (
+        "11.8",
+        PRE_CXX11_ABI,
+    ): "pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00",
+    (
+        "12.1",
+        PRE_CXX11_ABI,
+    ): "pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00",
+    (
+        "11.8",
+        CXX11_ABI,
+    ): "pytorch/libtorch-cxx11-builder:cuda11.8-941be28cb5c686dc41b7ea8681701e64192c3002",
+    (
+        "12.1",
+        CXX11_ABI,
+    ): "pytorch/libtorch-cxx11-builder:cuda12.1-941be28cb5c686dc41b7ea8681701e64192c3002",
+    (
+        "5.5",
+        PRE_CXX11_ABI,
+    ): "pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692",
+    (
+        "5.6",
+        PRE_CXX11_ABI,
+    ): "pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692",
+    (
+        "5.5",
+        CXX11_ABI,
+    ): "pytorch/libtorch-cxx11-builder:rocm5.5-941be28cb5c686dc41b7ea8681701e64192c3002",
+    (
+        "5.6",
+        CXX11_ABI,
+    ): "pytorch/libtorch-cxx11-builder:rocm5.6-17ea05e4536e78c9c0be8641952b1c5850a298cb",
+    (
+        "cpu",
+        PRE_CXX11_ABI,
+    ): "pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00",
+    (
+        "cpu",
+        CXX11_ABI,
+    ): "pytorch/libtorch-cxx11-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00",
 }
 
 FULL_PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -54,22 +54,19 @@ def arch_type(arch_version: str) -> str:
 
 
 WHEEL_CONTAINER_IMAGES = {
-    **{
-        gpu_arch: f"pytorch/manylinux-builder:cuda{gpu_arch}"
-        for gpu_arch in CUDA_ARCHES
-    },
-    **{
-        gpu_arch: f"pytorch/manylinux-builder:rocm{gpu_arch}"
-        for gpu_arch in ROCM_ARCHES
-    },
-    "cpu": "pytorch/manylinux-builder:cpu",
-    "cpu-cxx11-abi": "pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi",
-    "cpu-aarch64": "pytorch/manylinuxaarch64-builder:cpu-aarch64",
+    "11.8": "pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00",
+    "12.1": "pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00",
+    "5.5": "pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692",
+    "5.6": "pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692",
+    "cpu": "pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00",
+    "cpu-cxx11-abi": "pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi-59a2f92aa12c3c0cb11622b05fe77de8312f6d00",
+    "cpu-aarch64": "pytorch/manylinuxaarch64-builder:cpu-aarch64-59a2f92aa12c3c0cb11622b05fe77de8312f6d00",
 }
 
 CONDA_CONTAINER_IMAGES = {
-    **{gpu_arch: f"pytorch/conda-builder:cuda{gpu_arch}" for gpu_arch in CUDA_ARCHES},
-    "cpu": "pytorch/conda-builder:cpu",
+    "11.8": "pytorch/conda-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00",
+    "12.1": "pytorch/conda-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00",
+    "cpu": "pytorch/conda-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00",
 }
 
 PRE_CXX11_ABI = "pre-cxx11"
@@ -78,24 +75,16 @@ RELEASE = "release"
 DEBUG = "debug"
 
 LIBTORCH_CONTAINER_IMAGES: Dict[Tuple[str, str], str] = {
-    **{
-        (gpu_arch, PRE_CXX11_ABI): f"pytorch/manylinux-builder:cuda{gpu_arch}"
-        for gpu_arch in CUDA_ARCHES
-    },
-    **{
-        (gpu_arch, CXX11_ABI): f"pytorch/libtorch-cxx11-builder:cuda{gpu_arch}"
-        for gpu_arch in CUDA_ARCHES
-    },
-    **{
-        (gpu_arch, PRE_CXX11_ABI): f"pytorch/manylinux-builder:rocm{gpu_arch}"
-        for gpu_arch in ROCM_ARCHES
-    },
-    **{
-        (gpu_arch, CXX11_ABI): f"pytorch/libtorch-cxx11-builder:rocm{gpu_arch}"
-        for gpu_arch in ROCM_ARCHES
-    },
-    ("cpu", PRE_CXX11_ABI): "pytorch/manylinux-builder:cpu",
-    ("cpu", CXX11_ABI): "pytorch/libtorch-cxx11-builder:cpu",
+    ("11.8", PRE_CXX11_ABI): "pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00",
+    ("12.1", PRE_CXX11_ABI): "pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00",
+    ("11.8", CXX11_ABI): "pytorch/libtorch-cxx11-builder:cuda11.8-941be28cb5c686dc41b7ea8681701e64192c3002",
+    ("12.1", CXX11_ABI): "pytorch/libtorch-cxx11-builder:cuda12.1-941be28cb5c686dc41b7ea8681701e64192c3002",
+    ("5.5", PRE_CXX11_ABI): "pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692",
+    ("5.6", PRE_CXX11_ABI): "pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692",
+    ("5.5", CXX11_ABI): "pytorch/libtorch-cxx11-builder:rocm5.5-941be28cb5c686dc41b7ea8681701e64192c3002",
+    ("5.6", CXX11_ABI): "pytorch/libtorch-cxx11-builder:rocm5.6-17ea05e4536e78c9c0be8641952b1c5850a298cb",
+    ("cpu", PRE_CXX11_ABI): "pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00",
+    ("cpu", CXX11_ABI): "pytorch/libtorch-cxx11-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00",
 }
 
 FULL_PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]

--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -47,7 +47,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-aarch64
-      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64
+      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       runs_on: linux.arm64.2xlarge
       ALPINE_IMAGE: "arm64v8/alpine"
@@ -68,7 +68,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-aarch64
-      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64
+      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-cpu-aarch64
       build_environment: linux-aarch64-binary-manywheel
@@ -87,7 +87,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-aarch64
-      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64
+      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-cpu-aarch64
     secrets:
@@ -108,7 +108,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-aarch64
-      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64
+      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       runs_on: linux.arm64.2xlarge
       ALPINE_IMAGE: "arm64v8/alpine"
@@ -129,7 +129,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-aarch64
-      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64
+      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: manywheel-py3_9-cpu-aarch64
       build_environment: linux-aarch64-binary-manywheel
@@ -148,7 +148,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-aarch64
-      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64
+      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: manywheel-py3_9-cpu-aarch64
     secrets:
@@ -169,7 +169,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-aarch64
-      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64
+      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       runs_on: linux.arm64.2xlarge
       ALPINE_IMAGE: "arm64v8/alpine"
@@ -190,7 +190,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-aarch64
-      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64
+      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-cpu-aarch64
       build_environment: linux-aarch64-binary-manywheel
@@ -209,7 +209,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-aarch64
-      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64
+      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-cpu-aarch64
     secrets:
@@ -230,7 +230,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-aarch64
-      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64
+      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       runs_on: linux.arm64.2xlarge
       ALPINE_IMAGE: "arm64v8/alpine"
@@ -251,7 +251,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-aarch64
-      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64
+      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-cpu-aarch64
       build_environment: linux-aarch64-binary-manywheel
@@ -270,7 +270,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu-aarch64
-      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64
+      DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cpu-aarch64-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-cpu-aarch64
     secrets:

--- a/.github/workflows/generated-linux-binary-conda-nightly.yml
+++ b/.github/workflows/generated-linux-binary-conda-nightly.yml
@@ -47,7 +47,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/conda-builder:cpu
+      DOCKER_IMAGE: pytorch/conda-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: conda-py3_8-cpu
       build_environment: linux-binary-conda
@@ -65,7 +65,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/conda-builder:cpu
+      DOCKER_IMAGE: pytorch/conda-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: conda-py3_8-cpu
       build_environment: linux-binary-conda
@@ -83,7 +83,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/conda-builder:cpu
+      DOCKER_IMAGE: pytorch/conda-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: conda-py3_8-cpu
     secrets:
@@ -105,7 +105,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: conda-py3_8-cuda11_8
       build_environment: linux-binary-conda
@@ -124,7 +124,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: conda-py3_8-cuda11_8
       build_environment: linux-binary-conda
@@ -143,7 +143,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: conda-py3_8-cuda11_8
     secrets:
@@ -165,7 +165,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: conda-py3_8-cuda12_1
       build_environment: linux-binary-conda
@@ -184,7 +184,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: conda-py3_8-cuda12_1
       build_environment: linux-binary-conda
@@ -203,7 +203,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: conda-py3_8-cuda12_1
     secrets:
@@ -224,7 +224,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/conda-builder:cpu
+      DOCKER_IMAGE: pytorch/conda-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: conda-py3_9-cpu
       build_environment: linux-binary-conda
@@ -242,7 +242,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/conda-builder:cpu
+      DOCKER_IMAGE: pytorch/conda-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: conda-py3_9-cpu
       build_environment: linux-binary-conda
@@ -260,7 +260,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/conda-builder:cpu
+      DOCKER_IMAGE: pytorch/conda-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: conda-py3_9-cpu
     secrets:
@@ -282,7 +282,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: conda-py3_9-cuda11_8
       build_environment: linux-binary-conda
@@ -301,7 +301,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: conda-py3_9-cuda11_8
       build_environment: linux-binary-conda
@@ -320,7 +320,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: conda-py3_9-cuda11_8
     secrets:
@@ -342,7 +342,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: conda-py3_9-cuda12_1
       build_environment: linux-binary-conda
@@ -361,7 +361,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: conda-py3_9-cuda12_1
       build_environment: linux-binary-conda
@@ -380,7 +380,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: conda-py3_9-cuda12_1
     secrets:
@@ -401,7 +401,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/conda-builder:cpu
+      DOCKER_IMAGE: pytorch/conda-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: conda-py3_10-cpu
       build_environment: linux-binary-conda
@@ -419,7 +419,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/conda-builder:cpu
+      DOCKER_IMAGE: pytorch/conda-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: conda-py3_10-cpu
       build_environment: linux-binary-conda
@@ -437,7 +437,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/conda-builder:cpu
+      DOCKER_IMAGE: pytorch/conda-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: conda-py3_10-cpu
     secrets:
@@ -459,7 +459,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: conda-py3_10-cuda11_8
       build_environment: linux-binary-conda
@@ -478,7 +478,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: conda-py3_10-cuda11_8
       build_environment: linux-binary-conda
@@ -497,7 +497,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: conda-py3_10-cuda11_8
     secrets:
@@ -519,7 +519,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: conda-py3_10-cuda12_1
       build_environment: linux-binary-conda
@@ -538,7 +538,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: conda-py3_10-cuda12_1
       build_environment: linux-binary-conda
@@ -557,7 +557,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: conda-py3_10-cuda12_1
     secrets:
@@ -578,7 +578,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/conda-builder:cpu
+      DOCKER_IMAGE: pytorch/conda-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: conda-py3_11-cpu
       build_environment: linux-binary-conda
@@ -596,7 +596,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/conda-builder:cpu
+      DOCKER_IMAGE: pytorch/conda-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: conda-py3_11-cpu
       build_environment: linux-binary-conda
@@ -614,7 +614,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/conda-builder:cpu
+      DOCKER_IMAGE: pytorch/conda-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: conda-py3_11-cpu
     secrets:
@@ -636,7 +636,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: conda-py3_11-cuda11_8
       build_environment: linux-binary-conda
@@ -655,7 +655,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: conda-py3_11-cuda11_8
       build_environment: linux-binary-conda
@@ -674,7 +674,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/conda-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: conda-py3_11-cuda11_8
     secrets:
@@ -696,7 +696,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: conda-py3_11-cuda12_1
       build_environment: linux-binary-conda
@@ -715,7 +715,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: conda-py3_11-cuda12_1
       build_environment: linux-binary-conda
@@ -734,7 +734,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/conda-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: conda-py3_11-cuda12_1
     secrets:

--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-main.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-main.yml
@@ -42,7 +42,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cpu-shared-with-deps-cxx11-abi
@@ -61,7 +61,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cpu-shared-with-deps-cxx11-abi

--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
@@ -47,7 +47,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cpu-shared-with-deps-cxx11-abi
@@ -66,7 +66,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cpu-shared-with-deps-cxx11-abi
@@ -85,7 +85,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cpu-shared-with-deps-cxx11-abi
@@ -107,7 +107,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-without-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cpu-shared-without-deps-cxx11-abi
@@ -126,7 +126,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-without-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cpu-shared-without-deps-cxx11-abi
@@ -145,7 +145,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-without-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cpu-shared-without-deps-cxx11-abi
@@ -167,7 +167,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cpu-static-with-deps-cxx11-abi
@@ -186,7 +186,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cpu-static-with-deps-cxx11-abi
@@ -205,7 +205,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cpu-static-with-deps-cxx11-abi
@@ -227,7 +227,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-without-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cpu-static-without-deps-cxx11-abi
@@ -246,7 +246,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-without-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cpu-static-without-deps-cxx11-abi
@@ -265,7 +265,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-without-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cpu-static-without-deps-cxx11-abi
@@ -288,7 +288,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda11_8-shared-with-deps-cxx11-abi
@@ -308,7 +308,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda11_8-shared-with-deps-cxx11-abi
@@ -328,7 +328,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda11_8-shared-with-deps-cxx11-abi
@@ -351,7 +351,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: shared-without-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda11_8-shared-without-deps-cxx11-abi
@@ -371,7 +371,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: shared-without-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda11_8-shared-without-deps-cxx11-abi
@@ -391,7 +391,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: shared-without-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda11_8-shared-without-deps-cxx11-abi
@@ -414,7 +414,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda11_8-static-with-deps-cxx11-abi
@@ -434,7 +434,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda11_8-static-with-deps-cxx11-abi
@@ -454,7 +454,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda11_8-static-with-deps-cxx11-abi
@@ -477,7 +477,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: static-without-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda11_8-static-without-deps-cxx11-abi
@@ -497,7 +497,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: static-without-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda11_8-static-without-deps-cxx11-abi
@@ -517,7 +517,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda11.8-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: static-without-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda11_8-static-without-deps-cxx11-abi
@@ -540,7 +540,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda12_1-shared-with-deps-cxx11-abi
@@ -560,7 +560,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda12_1-shared-with-deps-cxx11-abi
@@ -580,7 +580,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda12_1-shared-with-deps-cxx11-abi
@@ -603,7 +603,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: shared-without-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda12_1-shared-without-deps-cxx11-abi
@@ -623,7 +623,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: shared-without-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda12_1-shared-without-deps-cxx11-abi
@@ -643,7 +643,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: shared-without-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda12_1-shared-without-deps-cxx11-abi
@@ -666,7 +666,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda12_1-static-with-deps-cxx11-abi
@@ -686,7 +686,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda12_1-static-with-deps-cxx11-abi
@@ -706,7 +706,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda12_1-static-with-deps-cxx11-abi
@@ -729,7 +729,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: static-without-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda12_1-static-without-deps-cxx11-abi
@@ -749,7 +749,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: static-without-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda12_1-static-without-deps-cxx11-abi
@@ -769,7 +769,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cuda12.1-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: static-without-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cuda12_1-static-without-deps-cxx11-abi
@@ -792,7 +792,7 @@ jobs:
       DESIRED_CUDA: rocm5.5
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.5-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-rocm5_5-shared-with-deps-cxx11-abi
@@ -814,7 +814,7 @@ jobs:
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
       SKIP_ALL_TESTS: 1
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.5-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
     steps:
@@ -855,7 +855,7 @@ jobs:
       - name: Pull Docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@release/2.1
         with:
-          docker-image: pytorch/libtorch-cxx11-builder:rocm5.5
+          docker-image: pytorch/libtorch-cxx11-builder:rocm5.5-941be28cb5c686dc41b7ea8681701e64192c3002
       - name: Test Pytorch binary
         uses: ./pytorch/.github/actions/test-pytorch-binary
       - name: Teardown ROCm
@@ -872,7 +872,7 @@ jobs:
       DESIRED_CUDA: rocm5.5
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.5-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-rocm5_5-shared-with-deps-cxx11-abi
@@ -895,7 +895,7 @@ jobs:
       DESIRED_CUDA: rocm5.5
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.5-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-rocm5_5-static-with-deps-cxx11-abi
@@ -917,7 +917,7 @@ jobs:
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
       SKIP_ALL_TESTS: 1
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.5-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
     steps:
@@ -958,7 +958,7 @@ jobs:
       - name: Pull Docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@release/2.1
         with:
-          docker-image: pytorch/libtorch-cxx11-builder:rocm5.5
+          docker-image: pytorch/libtorch-cxx11-builder:rocm5.5-941be28cb5c686dc41b7ea8681701e64192c3002
       - name: Test Pytorch binary
         uses: ./pytorch/.github/actions/test-pytorch-binary
       - name: Teardown ROCm
@@ -975,7 +975,7 @@ jobs:
       DESIRED_CUDA: rocm5.5
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.5-941be28cb5c686dc41b7ea8681701e64192c3002
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-rocm5_5-static-with-deps-cxx11-abi
@@ -998,7 +998,7 @@ jobs:
       DESIRED_CUDA: rocm5.6
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.6-17ea05e4536e78c9c0be8641952b1c5850a298cb
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-rocm5_6-shared-with-deps-cxx11-abi
@@ -1020,7 +1020,7 @@ jobs:
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
       SKIP_ALL_TESTS: 1
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.6-17ea05e4536e78c9c0be8641952b1c5850a298cb
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
     steps:
@@ -1061,7 +1061,7 @@ jobs:
       - name: Pull Docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@release/2.1
         with:
-          docker-image: pytorch/libtorch-cxx11-builder:rocm5.6
+          docker-image: pytorch/libtorch-cxx11-builder:rocm5.6-17ea05e4536e78c9c0be8641952b1c5850a298cb
       - name: Test Pytorch binary
         uses: ./pytorch/.github/actions/test-pytorch-binary
       - name: Teardown ROCm
@@ -1078,7 +1078,7 @@ jobs:
       DESIRED_CUDA: rocm5.6
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.6-17ea05e4536e78c9c0be8641952b1c5850a298cb
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-rocm5_6-shared-with-deps-cxx11-abi
@@ -1101,7 +1101,7 @@ jobs:
       DESIRED_CUDA: rocm5.6
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.6-17ea05e4536e78c9c0be8641952b1c5850a298cb
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-rocm5_6-static-with-deps-cxx11-abi
@@ -1123,7 +1123,7 @@ jobs:
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
       SKIP_ALL_TESTS: 1
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.6-17ea05e4536e78c9c0be8641952b1c5850a298cb
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
     steps:
@@ -1164,7 +1164,7 @@ jobs:
       - name: Pull Docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@release/2.1
         with:
-          docker-image: pytorch/libtorch-cxx11-builder:rocm5.6
+          docker-image: pytorch/libtorch-cxx11-builder:rocm5.6-17ea05e4536e78c9c0be8641952b1c5850a298cb
       - name: Test Pytorch binary
         uses: ./pytorch/.github/actions/test-pytorch-binary
       - name: Teardown ROCm
@@ -1181,7 +1181,7 @@ jobs:
       DESIRED_CUDA: rocm5.6
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:rocm5.6-17ea05e4536e78c9c0be8641952b1c5850a298cb
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-rocm5_6-static-with-deps-cxx11-abi

--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-main.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-main.yml
@@ -42,7 +42,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cpu-shared-with-deps-pre-cxx11
@@ -61,7 +61,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cpu-shared-with-deps-pre-cxx11

--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
@@ -47,7 +47,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cpu-shared-with-deps-pre-cxx11
@@ -66,7 +66,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cpu-shared-with-deps-pre-cxx11
@@ -85,7 +85,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cpu-shared-with-deps-pre-cxx11
@@ -107,7 +107,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-without-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cpu-shared-without-deps-pre-cxx11
@@ -126,7 +126,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-without-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cpu-shared-without-deps-pre-cxx11
@@ -145,7 +145,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-without-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cpu-shared-without-deps-pre-cxx11
@@ -167,7 +167,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cpu-static-with-deps-pre-cxx11
@@ -186,7 +186,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cpu-static-with-deps-pre-cxx11
@@ -205,7 +205,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cpu-static-with-deps-pre-cxx11
@@ -227,7 +227,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-without-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cpu-static-without-deps-pre-cxx11
@@ -246,7 +246,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-without-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cpu-static-without-deps-pre-cxx11
@@ -265,7 +265,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-without-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cpu-static-without-deps-pre-cxx11
@@ -288,7 +288,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda11_8-shared-with-deps-pre-cxx11
@@ -308,7 +308,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda11_8-shared-with-deps-pre-cxx11
@@ -328,7 +328,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda11_8-shared-with-deps-pre-cxx11
@@ -351,7 +351,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-without-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda11_8-shared-without-deps-pre-cxx11
@@ -371,7 +371,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-without-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda11_8-shared-without-deps-pre-cxx11
@@ -391,7 +391,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-without-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda11_8-shared-without-deps-pre-cxx11
@@ -414,7 +414,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda11_8-static-with-deps-pre-cxx11
@@ -434,7 +434,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda11_8-static-with-deps-pre-cxx11
@@ -454,7 +454,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda11_8-static-with-deps-pre-cxx11
@@ -477,7 +477,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-without-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda11_8-static-without-deps-pre-cxx11
@@ -497,7 +497,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-without-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda11_8-static-without-deps-pre-cxx11
@@ -517,7 +517,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-without-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda11_8-static-without-deps-pre-cxx11
@@ -540,7 +540,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda12_1-shared-with-deps-pre-cxx11
@@ -560,7 +560,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda12_1-shared-with-deps-pre-cxx11
@@ -580,7 +580,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda12_1-shared-with-deps-pre-cxx11
@@ -603,7 +603,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-without-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda12_1-shared-without-deps-pre-cxx11
@@ -623,7 +623,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-without-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda12_1-shared-without-deps-pre-cxx11
@@ -643,7 +643,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-without-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda12_1-shared-without-deps-pre-cxx11
@@ -666,7 +666,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda12_1-static-with-deps-pre-cxx11
@@ -686,7 +686,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda12_1-static-with-deps-pre-cxx11
@@ -706,7 +706,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda12_1-static-with-deps-pre-cxx11
@@ -729,7 +729,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-without-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda12_1-static-without-deps-pre-cxx11
@@ -749,7 +749,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-without-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda12_1-static-without-deps-pre-cxx11
@@ -769,7 +769,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-without-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-cuda12_1-static-without-deps-pre-cxx11
@@ -792,7 +792,7 @@ jobs:
       DESIRED_CUDA: rocm5.5
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-rocm5_5-shared-with-deps-pre-cxx11
@@ -814,7 +814,7 @@ jobs:
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
       SKIP_ALL_TESTS: 1
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
     steps:
@@ -855,7 +855,7 @@ jobs:
       - name: Pull Docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@release/2.1
         with:
-          docker-image: pytorch/manylinux-builder:rocm5.5
+          docker-image: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       - name: Test Pytorch binary
         uses: ./pytorch/.github/actions/test-pytorch-binary
       - name: Teardown ROCm
@@ -872,7 +872,7 @@ jobs:
       DESIRED_CUDA: rocm5.5
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-rocm5_5-shared-with-deps-pre-cxx11
@@ -895,7 +895,7 @@ jobs:
       DESIRED_CUDA: rocm5.5
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-rocm5_5-static-with-deps-pre-cxx11
@@ -917,7 +917,7 @@ jobs:
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
       SKIP_ALL_TESTS: 1
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
     steps:
@@ -958,7 +958,7 @@ jobs:
       - name: Pull Docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@release/2.1
         with:
-          docker-image: pytorch/manylinux-builder:rocm5.5
+          docker-image: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       - name: Test Pytorch binary
         uses: ./pytorch/.github/actions/test-pytorch-binary
       - name: Teardown ROCm
@@ -975,7 +975,7 @@ jobs:
       DESIRED_CUDA: rocm5.5
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-rocm5_5-static-with-deps-pre-cxx11
@@ -998,7 +998,7 @@ jobs:
       DESIRED_CUDA: rocm5.6
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-rocm5_6-shared-with-deps-pre-cxx11
@@ -1020,7 +1020,7 @@ jobs:
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
       SKIP_ALL_TESTS: 1
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
     steps:
@@ -1061,7 +1061,7 @@ jobs:
       - name: Pull Docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@release/2.1
         with:
-          docker-image: pytorch/manylinux-builder:rocm5.6
+          docker-image: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       - name: Test Pytorch binary
         uses: ./pytorch/.github/actions/test-pytorch-binary
       - name: Teardown ROCm
@@ -1078,7 +1078,7 @@ jobs:
       DESIRED_CUDA: rocm5.6
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-rocm5_6-shared-with-deps-pre-cxx11
@@ -1101,7 +1101,7 @@ jobs:
       DESIRED_CUDA: rocm5.6
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-rocm5_6-static-with-deps-pre-cxx11
@@ -1123,7 +1123,7 @@ jobs:
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
       SKIP_ALL_TESTS: 1
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
     steps:
@@ -1164,7 +1164,7 @@ jobs:
       - name: Pull Docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@release/2.1
         with:
-          docker-image: pytorch/manylinux-builder:rocm5.6
+          docker-image: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       - name: Test Pytorch binary
         uses: ./pytorch/.github/actions/test-pytorch-binary
       - name: Teardown ROCm
@@ -1181,7 +1181,7 @@ jobs:
       DESIRED_CUDA: rocm5.6
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: pre-cxx11
       build_name: libtorch-rocm5_6-static-with-deps-pre-cxx11

--- a/.github/workflows/generated-linux-binary-manywheel-main.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-main.yml
@@ -43,7 +43,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-cuda11_8
       build_environment: linux-binary-manywheel
@@ -62,7 +62,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-cuda11_8
       build_environment: linux-binary-manywheel
@@ -82,7 +82,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-cuda12_1-with-pypi-cudnn
       build_environment: linux-binary-manywheel
@@ -102,7 +102,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-cuda12_1-with-pypi-cudnn
       build_environment: linux-binary-manywheel

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -47,7 +47,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-cpu
       build_environment: linux-binary-manywheel
@@ -65,7 +65,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-cpu
       build_environment: linux-binary-manywheel
@@ -83,7 +83,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-cpu
     secrets:
@@ -104,7 +104,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu-cxx11-abi
       GPU_ARCH_TYPE: cpu-cxx11-abi
-      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi
+      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_DEVTOOLSET: cxx11-abi
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-cpu-cxx11-abi
@@ -123,7 +123,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu-cxx11-abi
       GPU_ARCH_TYPE: cpu-cxx11-abi
-      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi
+      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_DEVTOOLSET: cxx11-abi
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-cpu-cxx11-abi
@@ -142,7 +142,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu-cxx11-abi
       GPU_ARCH_TYPE: cpu-cxx11-abi
-      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi
+      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_DEVTOOLSET: cxx11-abi
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-cpu-cxx11-abi
@@ -165,7 +165,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-cuda11_8
       build_environment: linux-binary-manywheel
@@ -184,7 +184,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-cuda11_8
       build_environment: linux-binary-manywheel
@@ -203,7 +203,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-cuda11_8
     secrets:
@@ -225,7 +225,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-cuda12_1-with-pypi-cudnn
       build_environment: linux-binary-manywheel
@@ -245,7 +245,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-cuda12_1-with-pypi-cudnn
       build_environment: linux-binary-manywheel
@@ -264,7 +264,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-cuda12_1-with-pypi-cudnn
     secrets:
@@ -286,7 +286,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-cuda12_1
       build_environment: linux-binary-manywheel
@@ -305,7 +305,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-cuda12_1
       build_environment: linux-binary-manywheel
@@ -324,7 +324,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-cuda12_1
     secrets:
@@ -346,7 +346,7 @@ jobs:
       DESIRED_CUDA: rocm5.5
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-rocm5_5
       build_environment: linux-binary-manywheel
@@ -367,7 +367,7 @@ jobs:
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
       SKIP_ALL_TESTS: 1
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.8"
     steps:
       - name: Setup ROCm
@@ -407,7 +407,7 @@ jobs:
       - name: Pull Docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@release/2.1
         with:
-          docker-image: pytorch/manylinux-builder:rocm5.5
+          docker-image: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       - name: Test Pytorch binary
         uses: ./pytorch/.github/actions/test-pytorch-binary
       - name: Teardown ROCm
@@ -424,7 +424,7 @@ jobs:
       DESIRED_CUDA: rocm5.5
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-rocm5_5
     secrets:
@@ -446,7 +446,7 @@ jobs:
       DESIRED_CUDA: rocm5.6
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-rocm5_6
       build_environment: linux-binary-manywheel
@@ -467,7 +467,7 @@ jobs:
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
       SKIP_ALL_TESTS: 1
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.8"
     steps:
       - name: Setup ROCm
@@ -507,7 +507,7 @@ jobs:
       - name: Pull Docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@release/2.1
         with:
-          docker-image: pytorch/manylinux-builder:rocm5.6
+          docker-image: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       - name: Test Pytorch binary
         uses: ./pytorch/.github/actions/test-pytorch-binary
       - name: Teardown ROCm
@@ -524,7 +524,7 @@ jobs:
       DESIRED_CUDA: rocm5.6
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-rocm5_6
     secrets:
@@ -545,7 +545,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: manywheel-py3_9-cpu
       build_environment: linux-binary-manywheel
@@ -563,7 +563,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: manywheel-py3_9-cpu
       build_environment: linux-binary-manywheel
@@ -581,7 +581,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: manywheel-py3_9-cpu
     secrets:
@@ -602,7 +602,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu-cxx11-abi
       GPU_ARCH_TYPE: cpu-cxx11-abi
-      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi
+      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_DEVTOOLSET: cxx11-abi
       DESIRED_PYTHON: "3.9"
       build_name: manywheel-py3_9-cpu-cxx11-abi
@@ -621,7 +621,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu-cxx11-abi
       GPU_ARCH_TYPE: cpu-cxx11-abi
-      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi
+      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_DEVTOOLSET: cxx11-abi
       DESIRED_PYTHON: "3.9"
       build_name: manywheel-py3_9-cpu-cxx11-abi
@@ -640,7 +640,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu-cxx11-abi
       GPU_ARCH_TYPE: cpu-cxx11-abi
-      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi
+      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_DEVTOOLSET: cxx11-abi
       DESIRED_PYTHON: "3.9"
       build_name: manywheel-py3_9-cpu-cxx11-abi
@@ -663,7 +663,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: manywheel-py3_9-cuda11_8
       build_environment: linux-binary-manywheel
@@ -682,7 +682,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: manywheel-py3_9-cuda11_8
       build_environment: linux-binary-manywheel
@@ -701,7 +701,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: manywheel-py3_9-cuda11_8
     secrets:
@@ -723,7 +723,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: manywheel-py3_9-cuda12_1-with-pypi-cudnn
       build_environment: linux-binary-manywheel
@@ -743,7 +743,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: manywheel-py3_9-cuda12_1-with-pypi-cudnn
       build_environment: linux-binary-manywheel
@@ -762,7 +762,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: manywheel-py3_9-cuda12_1-with-pypi-cudnn
     secrets:
@@ -784,7 +784,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: manywheel-py3_9-cuda12_1
       build_environment: linux-binary-manywheel
@@ -803,7 +803,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: manywheel-py3_9-cuda12_1
       build_environment: linux-binary-manywheel
@@ -822,7 +822,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: manywheel-py3_9-cuda12_1
     secrets:
@@ -844,7 +844,7 @@ jobs:
       DESIRED_CUDA: rocm5.5
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.9"
       build_name: manywheel-py3_9-rocm5_5
       build_environment: linux-binary-manywheel
@@ -865,7 +865,7 @@ jobs:
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
       SKIP_ALL_TESTS: 1
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.9"
     steps:
       - name: Setup ROCm
@@ -905,7 +905,7 @@ jobs:
       - name: Pull Docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@release/2.1
         with:
-          docker-image: pytorch/manylinux-builder:rocm5.5
+          docker-image: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       - name: Test Pytorch binary
         uses: ./pytorch/.github/actions/test-pytorch-binary
       - name: Teardown ROCm
@@ -922,7 +922,7 @@ jobs:
       DESIRED_CUDA: rocm5.5
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.9"
       build_name: manywheel-py3_9-rocm5_5
     secrets:
@@ -944,7 +944,7 @@ jobs:
       DESIRED_CUDA: rocm5.6
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.9"
       build_name: manywheel-py3_9-rocm5_6
       build_environment: linux-binary-manywheel
@@ -965,7 +965,7 @@ jobs:
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
       SKIP_ALL_TESTS: 1
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.9"
     steps:
       - name: Setup ROCm
@@ -1005,7 +1005,7 @@ jobs:
       - name: Pull Docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@release/2.1
         with:
-          docker-image: pytorch/manylinux-builder:rocm5.6
+          docker-image: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       - name: Test Pytorch binary
         uses: ./pytorch/.github/actions/test-pytorch-binary
       - name: Teardown ROCm
@@ -1022,7 +1022,7 @@ jobs:
       DESIRED_CUDA: rocm5.6
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.9"
       build_name: manywheel-py3_9-rocm5_6
     secrets:
@@ -1043,7 +1043,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-cpu
       build_environment: linux-binary-manywheel
@@ -1061,7 +1061,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-cpu
       build_environment: linux-binary-manywheel
@@ -1079,7 +1079,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-cpu
     secrets:
@@ -1100,7 +1100,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu-cxx11-abi
       GPU_ARCH_TYPE: cpu-cxx11-abi
-      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi
+      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_DEVTOOLSET: cxx11-abi
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-cpu-cxx11-abi
@@ -1119,7 +1119,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu-cxx11-abi
       GPU_ARCH_TYPE: cpu-cxx11-abi
-      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi
+      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_DEVTOOLSET: cxx11-abi
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-cpu-cxx11-abi
@@ -1138,7 +1138,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu-cxx11-abi
       GPU_ARCH_TYPE: cpu-cxx11-abi
-      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi
+      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_DEVTOOLSET: cxx11-abi
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-cpu-cxx11-abi
@@ -1161,7 +1161,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-cuda11_8
       build_environment: linux-binary-manywheel
@@ -1180,7 +1180,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-cuda11_8
       build_environment: linux-binary-manywheel
@@ -1199,7 +1199,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-cuda11_8
     secrets:
@@ -1221,7 +1221,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-cuda12_1-with-pypi-cudnn
       build_environment: linux-binary-manywheel
@@ -1241,7 +1241,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-cuda12_1-with-pypi-cudnn
       build_environment: linux-binary-manywheel
@@ -1260,7 +1260,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-cuda12_1-with-pypi-cudnn
     secrets:
@@ -1282,7 +1282,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-cuda12_1
       build_environment: linux-binary-manywheel
@@ -1301,7 +1301,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-cuda12_1
       build_environment: linux-binary-manywheel
@@ -1320,7 +1320,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-cuda12_1
     secrets:
@@ -1342,7 +1342,7 @@ jobs:
       DESIRED_CUDA: rocm5.5
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-rocm5_5
       build_environment: linux-binary-manywheel
@@ -1363,7 +1363,7 @@ jobs:
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
       SKIP_ALL_TESTS: 1
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.10"
     steps:
       - name: Setup ROCm
@@ -1403,7 +1403,7 @@ jobs:
       - name: Pull Docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@release/2.1
         with:
-          docker-image: pytorch/manylinux-builder:rocm5.5
+          docker-image: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       - name: Test Pytorch binary
         uses: ./pytorch/.github/actions/test-pytorch-binary
       - name: Teardown ROCm
@@ -1420,7 +1420,7 @@ jobs:
       DESIRED_CUDA: rocm5.5
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-rocm5_5
     secrets:
@@ -1442,7 +1442,7 @@ jobs:
       DESIRED_CUDA: rocm5.6
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-rocm5_6
       build_environment: linux-binary-manywheel
@@ -1463,7 +1463,7 @@ jobs:
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
       SKIP_ALL_TESTS: 1
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.10"
     steps:
       - name: Setup ROCm
@@ -1503,7 +1503,7 @@ jobs:
       - name: Pull Docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@release/2.1
         with:
-          docker-image: pytorch/manylinux-builder:rocm5.6
+          docker-image: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       - name: Test Pytorch binary
         uses: ./pytorch/.github/actions/test-pytorch-binary
       - name: Teardown ROCm
@@ -1520,7 +1520,7 @@ jobs:
       DESIRED_CUDA: rocm5.6
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-rocm5_6
     secrets:
@@ -1541,7 +1541,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-cpu
       build_environment: linux-binary-manywheel
@@ -1559,7 +1559,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-cpu
       build_environment: linux-binary-manywheel
@@ -1577,7 +1577,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-cpu
     secrets:
@@ -1598,7 +1598,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu-cxx11-abi
       GPU_ARCH_TYPE: cpu-cxx11-abi
-      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi
+      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_DEVTOOLSET: cxx11-abi
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-cpu-cxx11-abi
@@ -1617,7 +1617,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu-cxx11-abi
       GPU_ARCH_TYPE: cpu-cxx11-abi
-      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi
+      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_DEVTOOLSET: cxx11-abi
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-cpu-cxx11-abi
@@ -1636,7 +1636,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu-cxx11-abi
       GPU_ARCH_TYPE: cpu-cxx11-abi
-      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi
+      DOCKER_IMAGE: pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_DEVTOOLSET: cxx11-abi
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-cpu-cxx11-abi
@@ -1659,7 +1659,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-cuda11_8
       build_environment: linux-binary-manywheel
@@ -1678,7 +1678,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-cuda11_8
       build_environment: linux-binary-manywheel
@@ -1697,7 +1697,7 @@ jobs:
       DESIRED_CUDA: cu118
       GPU_ARCH_VERSION: 11.8
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.8-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-cuda11_8
     secrets:
@@ -1719,7 +1719,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-cuda12_1-with-pypi-cudnn
       build_environment: linux-binary-manywheel
@@ -1739,7 +1739,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-cuda12_1-with-pypi-cudnn
       build_environment: linux-binary-manywheel
@@ -1758,7 +1758,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-cuda12_1-with-pypi-cudnn
     secrets:
@@ -1780,7 +1780,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-cuda12_1
       build_environment: linux-binary-manywheel
@@ -1799,7 +1799,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-cuda12_1
       build_environment: linux-binary-manywheel
@@ -1818,7 +1818,7 @@ jobs:
       DESIRED_CUDA: cu121
       GPU_ARCH_VERSION: 12.1
       GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda12.1-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-cuda12_1
     secrets:
@@ -1840,7 +1840,7 @@ jobs:
       DESIRED_CUDA: rocm5.5
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-rocm5_5
       build_environment: linux-binary-manywheel
@@ -1861,7 +1861,7 @@ jobs:
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
       SKIP_ALL_TESTS: 1
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.11"
     steps:
       - name: Setup ROCm
@@ -1901,7 +1901,7 @@ jobs:
       - name: Pull Docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@release/2.1
         with:
-          docker-image: pytorch/manylinux-builder:rocm5.5
+          docker-image: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       - name: Test Pytorch binary
         uses: ./pytorch/.github/actions/test-pytorch-binary
       - name: Teardown ROCm
@@ -1918,7 +1918,7 @@ jobs:
       DESIRED_CUDA: rocm5.5
       GPU_ARCH_VERSION: 5.5
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.5-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-rocm5_5
     secrets:
@@ -1940,7 +1940,7 @@ jobs:
       DESIRED_CUDA: rocm5.6
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-rocm5_6
       build_environment: linux-binary-manywheel
@@ -1961,7 +1961,7 @@ jobs:
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
       SKIP_ALL_TESTS: 1
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.11"
     steps:
       - name: Setup ROCm
@@ -2001,7 +2001,7 @@ jobs:
       - name: Pull Docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@release/2.1
         with:
-          docker-image: pytorch/manylinux-builder:rocm5.6
+          docker-image: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       - name: Test Pytorch binary
         uses: ./pytorch/.github/actions/test-pytorch-binary
       - name: Teardown ROCm
@@ -2018,7 +2018,7 @@ jobs:
       DESIRED_CUDA: rocm5.6
       GPU_ARCH_VERSION: 5.6
       GPU_ARCH_TYPE: rocm
-      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6
+      DOCKER_IMAGE: pytorch/manylinux-builder:rocm5.6-01ce69ff0d18320ab36787e288436586ed278692
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-rocm5_6
     secrets:

--- a/.github/workflows/generated-macos-arm64-binary-conda-nightly.yml
+++ b/.github/workflows/generated-macos-arm64-binary-conda-nightly.yml
@@ -135,7 +135,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/conda-builder:cpu
+      DOCKER_IMAGE: pytorch/conda-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: conda-py3_8-cpu
       use_s3: False
@@ -246,7 +246,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/conda-builder:cpu
+      DOCKER_IMAGE: pytorch/conda-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: conda-py3_9-cpu
       use_s3: False
@@ -357,7 +357,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/conda-builder:cpu
+      DOCKER_IMAGE: pytorch/conda-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: conda-py3_10-cpu
       use_s3: False
@@ -468,7 +468,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/conda-builder:cpu
+      DOCKER_IMAGE: pytorch/conda-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: conda-py3_11-cpu
       use_s3: False

--- a/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
@@ -136,7 +136,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: wheel-py3_8-cpu
       use_s3: False
@@ -248,7 +248,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: wheel-py3_9-cpu
       use_s3: False
@@ -360,7 +360,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: wheel-py3_10-cpu
       use_s3: False
@@ -472,7 +472,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: wheel-py3_11-cpu
       use_s3: False

--- a/.github/workflows/generated-macos-binary-conda-nightly.yml
+++ b/.github/workflows/generated-macos-binary-conda-nightly.yml
@@ -133,7 +133,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/conda-builder:cpu
+      DOCKER_IMAGE: pytorch/conda-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: conda-py3_8-cpu
       use_s3: False
@@ -244,7 +244,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/conda-builder:cpu
+      DOCKER_IMAGE: pytorch/conda-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: conda-py3_9-cpu
       use_s3: False
@@ -355,7 +355,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/conda-builder:cpu
+      DOCKER_IMAGE: pytorch/conda-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: conda-py3_10-cpu
       use_s3: False
@@ -466,7 +466,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/conda-builder:cpu
+      DOCKER_IMAGE: pytorch/conda-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: conda-py3_11-cpu
       use_s3: False

--- a/.github/workflows/generated-macos-binary-libtorch-cxx11-abi-nightly.yml
+++ b/.github/workflows/generated-macos-binary-libtorch-cxx11-abi-nightly.yml
@@ -137,7 +137,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cpu-shared-with-deps-cxx11-abi
@@ -253,7 +253,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: shared-without-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cpu-shared-without-deps-cxx11-abi
@@ -369,7 +369,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-with-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cpu-static-with-deps-cxx11-abi
@@ -485,7 +485,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu
+      DOCKER_IMAGE: pytorch/libtorch-cxx11-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       LIBTORCH_VARIANT: static-without-deps
       DESIRED_DEVTOOLSET: cxx11-abi
       build_name: libtorch-cpu-static-without-deps-cxx11-abi

--- a/.github/workflows/generated-macos-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-macos-binary-wheel-nightly.yml
@@ -134,7 +134,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.8"
       build_name: wheel-py3_8-cpu
       use_s3: False
@@ -246,7 +246,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.9"
       build_name: wheel-py3_9-cpu
       use_s3: False
@@ -358,7 +358,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.10"
       build_name: wheel-py3_10-cpu
       use_s3: False
@@ -470,7 +470,7 @@ jobs:
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
-      DOCKER_IMAGE: pytorch/manylinux-builder:cpu
+      DOCKER_IMAGE: pytorch/manylinux-builder:cpu-59a2f92aa12c3c0cb11622b05fe77de8312f6d00
       DESIRED_PYTHON: "3.11"
       build_name: wheel-py3_11-cpu
       use_s3: False


### PR DESCRIPTION
 Pins all Docker images used for  building to Sept 19 timeframe (time of final RC build for release 2.1.0)


