### PR TITLE
Fix unit tests and add logging for Inductor intra-graph reordering

### DIFF
--- a/test/distributed/test_compute_comm_reordering.py
+++ b/test/distributed/test_compute_comm_reordering.py
@@ -15,11 +15,11 @@ from torch._inductor import ir
 from torch._inductor.comm_analysis import (
     baseLat,
     hwLat,
+    llMaxBws,
     NCCL_ALGO,
     NCCL_HW,
     NCCL_PROTO,
     NVIDIA_GPU_TYPE,
-    llMaxBws,
 )
 from torch._inductor.utils import run_and_get_triton_code
 from torch.testing._internal.common_distributed import (

--- a/test/distributed/test_compute_comm_reordering.py
+++ b/test/distributed/test_compute_comm_reordering.py
@@ -19,6 +19,7 @@ from torch._inductor.comm_analysis import (
     NCCL_HW,
     NCCL_PROTO,
     NVIDIA_GPU_TYPE,
+    llMaxBws,
 )
 from torch._inductor.utils import run_and_get_triton_code
 from torch.testing._internal.common_distributed import (
@@ -28,6 +29,7 @@ from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
 )
 from torch.utils._triton import has_triton
+from torch.testing._internal.logging_utils import make_logging_test
 
 
 def get_snode_runtime_for_reorder_compute_test(snode):

--- a/test/distributed/test_compute_comm_reordering.py
+++ b/test/distributed/test_compute_comm_reordering.py
@@ -29,7 +29,6 @@ from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
 )
 from torch.utils._triton import has_triton
-from torch.testing._internal.logging_utils import make_logging_test
 
 
 def get_snode_runtime_for_reorder_compute_test(snode):

--- a/test/distributed/test_compute_comm_reordering.py
+++ b/test/distributed/test_compute_comm_reordering.py
@@ -281,3 +281,8 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
         assert list(baseLat.shape) == [len(NCCL_ALGO), len(NCCL_PROTO)]
         assert list(hwLat.shape) == [len(NCCL_HW), len(NCCL_ALGO), len(NCCL_PROTO)]
         assert llMaxBws.shape[0] == len(NVIDIA_GPU_TYPE)
+
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+    run_tests()

--- a/test/distributed/test_compute_comm_reordering.py
+++ b/test/distributed/test_compute_comm_reordering.py
@@ -285,4 +285,5 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
+
     run_tests()

--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -597,6 +597,7 @@ exclusions = {
     "output_code",
     "schedule",
     "fusion",
+    "overlap",
     "aot_graphs",
     "post_grad_graphs",
     "compiled_autograd",

--- a/torch/_inductor/comm_analysis.py
+++ b/torch/_inductor/comm_analysis.py
@@ -67,8 +67,11 @@ class NCCL_ALGO(IntEnum):
 
 
 class NCCL_PROTO(IntEnum):
-    LL = 0
-    # LL128 = 1
+    # The ordering and enum values here matches original in
+    # https://github.com/NVIDIA/nccl/blob/0b083e52096c387bad7a5c5c65b26a9dca54de8c/src/include/devcomm.h#L28
+    # For difference between these protocols, see https://github.com/NVIDIA/nccl/issues/281#issuecomment-571816990
+    LL = 0  # Low-latency
+    # LL128 = 1   # Low-latency 128-byte
     # SIMPLE = 2
 
 

--- a/torch/_inductor/comm_analysis.py
+++ b/torch/_inductor/comm_analysis.py
@@ -40,7 +40,7 @@ for more information and license details.
 """
 
 import math
-from enum import Enum
+from enum import IntEnum
 
 import torch
 from . import ir
@@ -49,30 +49,30 @@ from .utils import get_dtype_size, sympy_product
 from .virtualized import V
 
 
-class NCCL_COLL(Enum):
+class NCCL_COLL(IntEnum):
     ALL_REDUCE = 0
     ALL_GATHER = 1
     REDUCE_SCATTER = 2
 
 
-class NCCL_HW(Enum):
+class NCCL_HW(IntEnum):
     NVLINK = 0
     PCI = 1
     NET = 2
 
 
-class NCCL_ALGO(Enum):
+class NCCL_ALGO(IntEnum):
     TREE = 0
     RING = 1
 
 
-class NCCL_PROTO(Enum):
-    SIMPLE = 0
-    LL = 1
-    LL128 = 2
+class NCCL_PROTO(IntEnum):
+    LL = 0
+    # LL128 = 1
+    # SIMPLE = 2
 
 
-class NVIDIA_GPU_TYPE(Enum):
+class NVIDIA_GPU_TYPE(IntEnum):
     VOLTA = 0
     AMPERE = 1
     HOPPER = 2
@@ -200,6 +200,7 @@ def estimate_nccl_collective_runtime(snode: "BaseSchedulerNode") -> float:  # ty
 
     # Assumes ring algorithm
     nccl_algo = NCCL_ALGO.RING
+    nccl_proto = NCCL_PROTO.LL
     coll = get_collective_type(snode)
 
     # =============== bandwidth computation ===============
@@ -212,7 +213,7 @@ def estimate_nccl_collective_runtime(snode: "BaseSchedulerNode") -> float:  # ty
     index2 = nNodes - 1 if nNodes <= 2 else 2
     # LL: for single node, we look at GPU type; for multi-node, we look at CPU type
     index1 = compCapIndex if nNodes == 1 else 0
-    llMaxBw = llMaxBws[index1][index2]
+    llMaxBw = llMaxBws[index1][index2].item()
 
     # NOTE: each step of ring algorithm is synchronized,
     # and is bottlenecked by the slowest link which is the inter-node interconnect.
@@ -254,11 +255,10 @@ def estimate_nccl_collective_runtime(snode: "BaseSchedulerNode") -> float:  # ty
         nInterSteps = nNodes - 1
 
     # First compute latency in us; then at the end, convert it to ns
-    latency = baseLat[nccl_algo]
-    intraLat = hwLat[intraHw][nccl_algo]
-    interLat = hwLat[NCCL_HW.NET][nccl_algo]
+    latency = baseLat[nccl_algo][nccl_proto].item()
+    intraLat = hwLat[intraHw][nccl_algo][nccl_proto].item()
+    interLat = hwLat[NCCL_HW.NET][nccl_algo][nccl_proto].item()
 
-    lat = hwLat[hw][nccl_algo]
     # Inter-node rings still have to launch nsteps * net overhead.
     netOverhead = 0.0
     if nNodes > 1:

--- a/torch/_inductor/comms.py
+++ b/torch/_inductor/comms.py
@@ -300,7 +300,7 @@ def node_summary(snode):
 
 
 def visualize_overlap(order):
-    total_est_runtime = 0
+    total_est_runtime: float = 0.0
     cur_comm_node = None
     for snode in order:
         if cur_comm_node is None:
@@ -313,7 +313,7 @@ def visualize_overlap(order):
                 )
             else:  # exposed compute op
                 total_est_runtime += estimate_op_runtime(snode)
-            overlap_log.debug(f"{node_summary(snode)}")
+            overlap_log.debug(f"{node_summary(snode)}")  # noqa: G004
         else:  # cur_comm_node is not None
             if isinstance(snode.node, ir.CollectiveKernel):
                 raise Exception(
@@ -321,11 +321,13 @@ def visualize_overlap(order):
                     "`visualize_overlap` needs to be updated to handle this case."
                 )
             elif isinstance(snode.node, ir.Wait):  # end of this comm op
-                overlap_log.debug(f"{node_summary(snode)}")
+                overlap_log.debug(f"{node_summary(snode)}")  # noqa: G004
                 cur_comm_node = None
             else:  # overlapped compute op
                 overlap_log.debug(f"| {node_summary(snode)}")
-    overlap_log.debug(f"Est. runtime (ms): {total_est_runtime / 1000 / 1000}")
+    overlap_log.debug(
+        f"Est. runtime (ms): {total_est_runtime / 1000 / 1000}"
+    )  # noqa: G004
 
 
 def reorder_compute_and_comm_for_overlap(
@@ -336,10 +338,14 @@ def reorder_compute_and_comm_for_overlap(
         if isinstance(p, str) and p in globals():
             p = globals()[p]  # it is a builtin pass
         if torch.distributed.get_rank() == 0:
-            overlap_log.debug(f"==== Visualize overlap before reordering pass {p} ====")
+            overlap_log.debug(
+                f"==== Visualize overlap before reordering pass {p} ===="
+            )  # noqa: G004
             visualize_overlap(order)
         order = p(order)  # type: ignore[operator]
         if torch.distributed.get_rank() == 0:
-            overlap_log.debug(f"==== Visualize overlap after reordering pass {p} ====")
+            overlap_log.debug(
+                f"==== Visualize overlap after reordering pass {p} ===="
+            )  # noqa: G004
             visualize_overlap(order)
     return order

--- a/torch/_inductor/comms.py
+++ b/torch/_inductor/comms.py
@@ -1,13 +1,13 @@
 # pyre-strict
 
 from typing import List
-import copy
+
+import torch
 
 from . import config, ir, scheduler
 from .dependencies import WeakDep
 from .utils import tuple_sorted
 
-import torch
 overlap_log = torch._logging.getArtifactLogger(__name__, "overlap")
 
 
@@ -291,8 +291,12 @@ def node_summary(snode):
     detail = ""
     if isinstance(snode.node, ir.ExternKernelOut):
         detail = f" ({snode.node.kernel})"
-    out_tensor_info = f" (size={snode.node.layout.size}, stride={snode.node.layout.stride})"
-    return f"{snode.node.__class__.__name__}{detail}{out_tensor_info} ({snode.node.name})"
+    out_tensor_info = (
+        f" (size={snode.node.layout.size}, stride={snode.node.layout.stride})"
+    )
+    return (
+        f"{snode.node.__class__.__name__}{detail}{out_tensor_info} ({snode.node.name})"
+    )
 
 
 def visualize_overlap(order):
@@ -304,7 +308,9 @@ def visualize_overlap(order):
                 total_est_runtime += estimate_op_runtime(snode)
                 cur_comm_node = snode.node
             elif isinstance(snode.node, ir.Wait):
-                raise Exception("Wait is not expected when there is no collective running.")
+                raise Exception(
+                    "Wait is not expected when there is no collective running."
+                )
             else:  # exposed compute op
                 total_est_runtime += estimate_op_runtime(snode)
             overlap_log.debug(f"{node_summary(snode)}")

--- a/torch/_inductor/comms.py
+++ b/torch/_inductor/comms.py
@@ -309,7 +309,7 @@ def visualize_overlap(order):
                 cur_comm_node = snode.node
             elif isinstance(snode.node, ir.Wait):
                 raise Exception(
-                    "Wait is not expected when there is no collective running."
+                    "Wait is not expected when there is no collective running"
                 )
             else:  # exposed compute op
                 total_est_runtime += estimate_op_runtime(snode)
@@ -318,16 +318,16 @@ def visualize_overlap(order):
             if isinstance(snode.node, ir.CollectiveKernel):
                 raise Exception(
                     "Found two collectives running at the same time, which is unexpected. "
-                    "`visualize_overlap` needs to be updated to handle this case."
+                    "`visualize_overlap` needs to be updated to handle this case"
                 )
             elif isinstance(snode.node, ir.Wait):  # end of this comm op
                 overlap_log.debug(f"{node_summary(snode)}")  # noqa: G004
                 cur_comm_node = None
             else:  # overlapped compute op
-                overlap_log.debug(f"| {node_summary(snode)}")
+                overlap_log.debug(f"| {node_summary(snode)}")  # noqa: G004
     overlap_log.debug(
-        f"Est. runtime (ms): {total_est_runtime / 1000 / 1000}"
-    )  # noqa: G004
+        f"Est. runtime (ms): {total_est_runtime / 1000 / 1000}"  # noqa: G004
+    )
 
 
 def reorder_compute_and_comm_for_overlap(
@@ -339,13 +339,13 @@ def reorder_compute_and_comm_for_overlap(
             p = globals()[p]  # it is a builtin pass
         if torch.distributed.get_rank() == 0:
             overlap_log.debug(
-                f"==== Visualize overlap before reordering pass {p} ===="
-            )  # noqa: G004
+                f"==== Visualize overlap before reordering pass {p} ===="  # noqa: G004
+            )
             visualize_overlap(order)
         order = p(order)  # type: ignore[operator]
         if torch.distributed.get_rank() == 0:
             overlap_log.debug(
-                f"==== Visualize overlap after reordering pass {p} ===="
-            )  # noqa: G004
+                f"==== Visualize overlap after reordering pass {p} ===="  # noqa: G004
+            )
             visualize_overlap(order)
     return order

--- a/torch/_inductor/comms.py
+++ b/torch/_inductor/comms.py
@@ -1,37 +1,41 @@
 # pyre-strict
 
 from typing import List
+import copy
 
 from . import config, ir, scheduler
 from .dependencies import WeakDep
 from .utils import tuple_sorted
 
+import torch
+overlap_log = torch._logging.getArtifactLogger(__name__, "overlap")
+
 
 def sink_waits(
-    result: List["scheduler.BaseSchedulerNode"],
+    snodes: List["scheduler.BaseSchedulerNode"],
 ) -> List["scheduler.BaseSchedulerNode"]:
     """
     Greedily moves waits as late as possible (i.e. until we reach a use). Optimal in terms of
     communication overlap.
     """
-    new_result = []
+    new_order = []
     cur_waits = set()
-    for snode in result:
+    for snode in snodes:
         if isinstance(snode.node, ir.Wait):
             cur_waits.add(snode)
         else:
             for wait in tuple_sorted(cur_waits):
                 if snode in wait.node_users:
-                    new_result.append(wait)
+                    new_order.append(wait)
                     cur_waits.remove(wait)
-            new_result.append(snode)
+            new_order.append(snode)
     for snode in tuple_sorted(cur_waits):
-        new_result.append(snode)
-    return new_result
+        new_order.append(snode)
+    return new_order
 
 
 def raise_comms(
-    result: List["scheduler.BaseSchedulerNode"],
+    snodes: List["scheduler.BaseSchedulerNode"],
 ) -> List["scheduler.BaseSchedulerNode"]:
     """
     Greedily moves comms as early as possible (i.e. until we reach an input).
@@ -42,9 +46,9 @@ def raise_comms(
     which is the beginning of the forwards pass. We'll have to either do a special pass for FSDP,
     or we'll want to redo this pass with memory considerations so we handle the FSDP case in a general way.
     """
-    new_result: List["scheduler.BaseSchedulerNode"] = []
+    new_order_reversed: List["scheduler.BaseSchedulerNode"] = []
     cur_comms: List["scheduler.BaseSchedulerNode"] = []
-    for snode in reversed(result):
+    for snode in reversed(snodes):
         if isinstance(snode.node, ir.CollectiveKernel):
             cur_comms.append(snode)
         else:
@@ -54,13 +58,12 @@ def raise_comms(
                 snode in comm.inverse_users for comm in cur_comms
             ):
                 comm = cur_comms.pop(0)
-                new_result.append(comm)
-            new_result.append(snode)
+                new_order_reversed.append(comm)
+            new_order_reversed.append(snode)
     assert len(cur_comms) <= 1
     for snode in tuple_sorted(cur_comms):
-        new_result.append(snode)
-    result = new_result[::-1]
-    return result
+        new_order_reversed.append(snode)
+    return new_order_reversed[::-1]
 
 
 def get_ancestors(node):
@@ -284,12 +287,53 @@ def reorder_compute_for_overlap(
     return final_order
 
 
+def node_summary(snode):
+    detail = ""
+    if isinstance(snode.node, ir.ExternKernelOut):
+        detail = f" ({snode.node.kernel})"
+    out_tensor_info = f" (size={snode.node.layout.size}, stride={snode.node.layout.stride})"
+    return f"{snode.node.__class__.__name__}{detail}{out_tensor_info} ({snode.node.name})"
+
+
+def visualize_overlap(order):
+    total_est_runtime = 0
+    cur_comm_node = None
+    for snode in order:
+        if cur_comm_node is None:
+            if isinstance(snode.node, ir.CollectiveKernel):
+                total_est_runtime += estimate_op_runtime(snode)
+                cur_comm_node = snode.node
+            elif isinstance(snode.node, ir.Wait):
+                raise Exception("Wait is not expected when there is no collective running.")
+            else:  # exposed compute op
+                total_est_runtime += estimate_op_runtime(snode)
+            overlap_log.debug(f"{node_summary(snode)}")
+        else:  # cur_comm_node is not None
+            if isinstance(snode.node, ir.CollectiveKernel):
+                raise Exception(
+                    "Found two collectives running at the same time, which is unexpected. "
+                    "`visualize_overlap` needs to be updated to handle this case."
+                )
+            elif isinstance(snode.node, ir.Wait):  # end of this comm op
+                overlap_log.debug(f"{node_summary(snode)}")
+                cur_comm_node = None
+            else:  # overlapped compute op
+                overlap_log.debug(f"| {node_summary(snode)}")
+    overlap_log.debug(f"Est. runtime (ms): {total_est_runtime / 1000 / 1000}")
+
+
 def reorder_compute_and_comm_for_overlap(
     snodes: List["scheduler.BaseSchedulerNode"],
 ) -> List["scheduler.BaseSchedulerNode"]:
-    ret = snodes
+    order = snodes
     for p in config.reorder_for_compute_comm_overlap_passes:
         if isinstance(p, str) and p in globals():
             p = globals()[p]  # it is a builtin pass
-        ret = p(ret)  # type: ignore[operator]
-    return ret
+        if torch.distributed.get_rank() == 0:
+            overlap_log.debug(f"==== Visualization of overlap before reordering pass {p} ====")
+            visualize_overlap(order)
+        order = p(order)  # type: ignore[operator]
+        if torch.distributed.get_rank() == 0:
+            overlap_log.debug(f"==== Visualization of overlap after reordering pass {p} ====")
+            visualize_overlap(order)
+    return order

--- a/torch/_inductor/comms.py
+++ b/torch/_inductor/comms.py
@@ -330,10 +330,10 @@ def reorder_compute_and_comm_for_overlap(
         if isinstance(p, str) and p in globals():
             p = globals()[p]  # it is a builtin pass
         if torch.distributed.get_rank() == 0:
-            overlap_log.debug(f"==== Visualization of overlap before reordering pass {p} ====")
+            overlap_log.debug(f"==== Visualize overlap before reordering pass {p} ====")
             visualize_overlap(order)
         order = p(order)  # type: ignore[operator]
         if torch.distributed.get_rank() == 0:
-            overlap_log.debug(f"==== Visualization of overlap after reordering pass {p} ====")
+            overlap_log.debug(f"==== Visualize overlap after reordering pass {p} ====")
             visualize_overlap(order)
     return order

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -293,7 +293,7 @@ def set_logs(
         fusion (:class:`bool`):
             Whether to emit detailed Inductor fusion decisions. Default: ``False``
 
-        fusion (:class:`bool`):
+        overlap (:class:`bool`):
             Whether to emit detailed Inductor compute/comm overlap decisions. Default: ``False``
 
         modules (dict):

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -170,6 +170,7 @@ def set_logs(
     post_grad_graphs: bool = False,
     onnx_diagnostics: bool = False,
     fusion: bool = False,
+    overlap: bool = False,
     modules: Optional[Dict[str, Union[int, bool]]] = None,
 ):
     """
@@ -292,6 +293,9 @@ def set_logs(
         fusion (:class:`bool`):
             Whether to emit detailed Inductor fusion decisions. Default: ``False``
 
+        fusion (:class:`bool`):
+            Whether to emit detailed Inductor compute/comm overlap decisions. Default: ``False``
+
         modules (dict):
             This argument provides an alternate way to specify the above log
             component and artifact settings, in the format of a keyword args
@@ -401,6 +405,7 @@ def set_logs(
         onnx=onnx,
         onnx_diagnostics=onnx_diagnostics,
         fusion=fusion,
+        overlap=overlap,
     )
 
 

--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -90,5 +90,10 @@ register_artifact(
     "Detailed Inductor fusion decisions. More detailed than 'schedule'",
     off_by_default=True,
 )
+register_artifact(
+    "overlap",
+    "Detailed Inductor compute/comm overlap decisions",
+    off_by_default=True,
+)
 
 register_artifact("custom_format_test_artifact", "Testing only", log_format="")

--- a/torch/utils/__init__.py
+++ b/torch/utils/__init__.py
@@ -4,6 +4,7 @@ import torch
 from .throughput_benchmark import ThroughputBenchmark
 from .cpp_backtrace import get_cpp_backtrace
 from .backend_registration import rename_privateuse1_backend, generate_methods_for_privateuse1_backend
+from . import collect_env
 
 def set_module(obj, mod):
     """


### PR DESCRIPTION
1. Fix code to make unit tests pass (incl. collect_env issue called out by @int3  in https://github.com/pytorch/pytorch/pull/108091#discussion_r1362901686).
2. Add logging for Inductor intra-graph reordering passes (`TORCH_LOGS="overlap"`), for easier debugging. Example log:
```
[rank0]:[2023-10-24 16:28:26,446] [0/0] torch._inductor.comms.__overlap: [DEBUG] ==== Visualize overlap before reordering pass <function reorder_compute_for_overlap at 0x7fa68c5568e0> ====
[rank0]:[2023-10-24 16:28:26,446] [0/0] torch._inductor.comms.__overlap: [DEBUG] ComputedBuffer (size=[4, 4], stride=[4, 1]) (buf0)
[rank0]:[2023-10-24 16:28:26,447] [0/0] torch._inductor.comms.__overlap: [DEBUG] ExternKernelOut (extern_kernels.mm) (size=[4, 4], stride=[4, 1]) (buf1)
[rank0]:[2023-10-24 16:28:26,447] [0/0] torch._inductor.comms.__overlap: [DEBUG] InPlaceHint (size=[4, 4], stride=[4, 1]) (buf2)
[rank0]:[2023-10-24 16:28:26,447] [0/0] torch._inductor.comms.__overlap: [DEBUG] AllReduce (size=[4, 4], stride=[4, 1]) (buf3)
[rank0]:[2023-10-24 16:28:26,447] [0/0] torch._inductor.comms.__overlap: [DEBUG] Wait (size=[4, 4], stride=[4, 1]) (buf4)
[rank0]:[2023-10-24 16:28:26,447] [0/0] torch._inductor.comms.__overlap: [DEBUG] ComputedBuffer (size=[4, 4], stride=[4, 1]) (buf5)
[rank0]:[2023-10-24 16:28:26,447] [0/0] torch._inductor.comms.__overlap: [DEBUG] InPlaceHint (size=[4, 4], stride=[4, 1]) (buf6)
[rank0]:[2023-10-24 16:28:26,447] [0/0] torch._inductor.comms.__overlap: [DEBUG] AllReduce (size=[4, 4], stride=[4, 1]) (buf7)
[rank0]:[2023-10-24 16:28:26,447] [0/0] torch._inductor.comms.__overlap: [DEBUG] Wait (size=[4, 4], stride=[4, 1]) (buf8)
[rank0]:[2023-10-24 16:28:26,447] [0/0] torch._inductor.comms.__overlap: [DEBUG] ExternKernelOut (extern_kernels.mm) (size=[4, 4], stride=[4, 1]) (buf9)
[rank0]:[2023-10-24 16:28:26,447] [0/0] torch._inductor.comms.__overlap: [DEBUG] ComputedBuffer (size=[4, 4], stride=[4, 1]) (buf10)
[rank0]:[2023-10-24 16:28:26,447] [0/0] torch._inductor.comms.__overlap: [DEBUG] ExternKernelOut (extern_kernels.mm) (size=[4, 4], stride=[4, 1]) (buf11)
[rank0]:[2023-10-24 16:28:26,447] [0/0] torch._inductor.comms.__overlap: [DEBUG] Est. runtime (ms): 0.000228

[rank0]:[2023-10-24 16:28:26,448] [0/0] torch._inductor.comms.__overlap: [DEBUG] ==== Visualize overlap after reordering pass <function reorder_compute_for_overlap at 0x7fa68c5568e0> ====
[rank0]:[2023-10-24 16:28:26,448] [0/0] torch._inductor.comms.__overlap: [DEBUG] InPlaceHint (size=[4, 4], stride=[4, 1]) (buf2)
[rank0]:[2023-10-24 16:28:26,448] [0/0] torch._inductor.comms.__overlap: [DEBUG] AllReduce (size=[4, 4], stride=[4, 1]) (buf3)
[rank0]:[2023-10-24 16:28:26,448] [0/0] torch._inductor.comms.__overlap: [DEBUG] | ComputedBuffer (size=[4, 4], stride=[4, 1]) (buf0)
[rank0]:[2023-10-24 16:28:26,448] [0/0] torch._inductor.comms.__overlap: [DEBUG] | ExternKernelOut (extern_kernels.mm) (size=[4, 4], stride=[4, 1]) (buf1)
[rank0]:[2023-10-24 16:28:26,448] [0/0] torch._inductor.comms.__overlap: [DEBUG] | ExternKernelOut (extern_kernels.mm) (size=[4, 4], stride=[4, 1]) (buf9)
[rank0]:[2023-10-24 16:28:26,448] [0/0] torch._inductor.comms.__overlap: [DEBUG] Wait (size=[4, 4], stride=[4, 1]) (buf4)
[rank0]:[2023-10-24 16:28:26,448] [0/0] torch._inductor.comms.__overlap: [DEBUG] ComputedBuffer (size=[4, 4], stride=[4, 1]) (buf5)
[rank0]:[2023-10-24 16:28:26,448] [0/0] torch._inductor.comms.__overlap: [DEBUG] InPlaceHint (size=[4, 4], stride=[4, 1]) (buf6)
[rank0]:[2023-10-24 16:28:26,448] [0/0] torch._inductor.comms.__overlap: [DEBUG] AllReduce (size=[4, 4], stride=[4, 1]) (buf7)
[rank0]:[2023-10-24 16:28:26,448] [0/0] torch._inductor.comms.__overlap: [DEBUG] Wait (size=[4, 4], stride=[4, 1]) (buf8)
[rank0]:[2023-10-24 16:28:26,448] [0/0] torch._inductor.comms.__overlap: [DEBUG] ComputedBuffer (size=[4, 4], stride=[4, 1]) (buf10)
[rank0]:[2023-10-24 16:28:26,448] [0/0] torch._inductor.comms.__overlap: [DEBUG] ExternKernelOut (extern_kernels.mm) (size=[4, 4], stride=[4, 1]) (buf11)
[rank0]:[2023-10-24 16:28:26,448] [0/0] torch._inductor.comms.__overlap: [DEBUG] Est. runtime (ms): 0.000217
```
The `| SomeComputeOp` means the compute op is overlapped with the comm op above.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler