### PR TITLE
[PyTorch][ET] collect comms in ET for send/recv

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -3333,6 +3333,24 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::send(
     int dstRank,
     int /* unused */) {
   check_gpu_tensors_different_devices(tensors);
+
+  // @lint-ignore CLANGTIDY
+  auto tensor = tensors.back();
+  RECORD_PARAM_COMMS_DATA(
+      static_cast<int>(
+          this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
+      this->getID(),
+      tensors, // inputTensors
+      tensors, // outputTensors
+      dstRank, // rank
+      "send", // colName
+      tensor.numel(), // inSize
+      tensor.numel(), // outSize
+      tensor.scalar_type(), // dType
+      std::vector<int64_t>(), // inSplitSizes
+      std::vector<int64_t>(), // outSplitSizes
+      this->getSize()); // worldSize
+
   auto ret = pointToPoint(
       tensors,
       [&](at::Tensor& input,
@@ -3353,6 +3371,24 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::recv(
     int srcRank,
     int /* unused */) {
   check_gpu_tensors_different_devices(tensors);
+
+  // @lint-ignore CLANGTIDY
+  auto tensor = tensors.back();
+  RECORD_PARAM_COMMS_DATA(
+      static_cast<int>(
+          this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
+      this->getID(),
+      tensors, // inputTensors
+      tensors, // outputTensors
+      srcRank, // rank
+      "recv", // colName
+      tensor.numel(), // inSize
+      tensor.numel(), // outSize
+      tensor.scalar_type(), // dType
+      std::vector<int64_t>(), // inSplitSizes
+      std::vector<int64_t>(), // outSplitSizes
+      this->getSize()); // worldSize
+
   auto ret = pointToPoint(
       tensors,
       [&](at::Tensor& output,


### PR DESCRIPTION
Summary: collect send/recv comms op in Execution Trace

Test Plan:
run param comms with arbitrary collective size to collect operator
send
```
{
      "name": "record_param_comms", "id": 153, "rf_id": 141, "parent": 152, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "",
      "inputs": [[[21,22,0,262144,4,"cuda:0"]],215038,139890792374272,1,"send",[],[]], "input_shapes": [[[262144]],[],[],[],[],[],[]], "input_types": ["GenericList[Tensor(float)]","Int","Int","Int","String","GenericList[]","GenericList[]"],
      "outputs": [[[21,22,0,262144,4,"cuda:0"]]], "output_shapes": [[[262144]]], "output_types": ["GenericList[Tensor(float)]"]
   },
```
recv
```
{
      "name": "record_param_comms", "id": 172, "rf_id": 160, "parent": 171, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "",
      "inputs": [[[138,139,0,262144,4,"cuda:0"]],215042,139890792374272,1,"recv",[],[]], "input_shapes": [[[262144]],[],[],[],[],[],[]], "input_types": ["GenericList[Tensor(float)]","Int","Int","Int","String","GenericList[]","GenericList[]"],
      "outputs": [[[138,139,0,262144,4,"cuda:0"]]], "output_shapes": [[[262144]]], "output_types": ["GenericList[Tensor(float)]"]
    },
```


Differential Revision: D50624443


