### PR TITLE
[pytree] fix `treemap` always turns `torch.Size` into `tuple`

### DIFF
--- a/test/functorch/common_utils.py
+++ b/test/functorch/common_utils.py
@@ -26,8 +26,9 @@ def loop(op, in_dims, out_dim, batch_size, *batched_args, **kwarg_values):
     out_spec = None
     for idx in range(batch_size):
         flat_args, args_spec = pytree.tree_flatten(batched_args)
+        args_spec_with_tuple = args_spec.replace_types({torch.Size: tuple})
         flat_dims, dims_spec = pytree.tree_flatten(in_dims)
-        assert(args_spec == dims_spec)
+        assert(args_spec_with_tuple == dims_spec)
         new_args = [a.select(in_dim, idx) if in_dim is not None else a for a, in_dim in zip(flat_args, flat_dims)]
         out = op(*pytree.tree_unflatten(new_args, args_spec), **kwarg_values)
         flat_out, out_spec = pytree.tree_flatten(out)

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -2525,7 +2525,6 @@ class TestPartitioning(AOTTestCase):
         real_outs = f(*inp)
         self.assertEqual(compiled_outs, real_outs)
         self.assertTrue(isinstance(real_outs[1], torch.Size))
-
         self.assertTrue(isinstance(compiled_outs[1], torch.Size))
 
     @unittest.skipIf(not USE_NETWORKX, "networkx not available")
@@ -2577,9 +2576,7 @@ class TestPartitioning(AOTTestCase):
         real_outs = f(*inp)
         self.assertEqual(compiled_outs, real_outs)
         self.assertTrue(isinstance(real_outs[1], torch.Size))
-
-        # TODO(whc) we should learn to return torch.Sizes
-        self.assertFalse(isinstance(compiled_outs[1], torch.Size))
+        self.assertTrue(isinstance(compiled_outs[1], torch.Size))
 
     @unittest.skipIf(not USE_NETWORKX, "networkx not available")
     def test_min_cut_partitioner(self):

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -2526,8 +2526,7 @@ class TestPartitioning(AOTTestCase):
         self.assertEqual(compiled_outs, real_outs)
         self.assertTrue(isinstance(real_outs[1], torch.Size))
 
-        # TODO(whc) we should learn to return torch.Sizes
-        self.assertFalse(isinstance(compiled_outs[1], torch.Size))
+        self.assertTrue(isinstance(compiled_outs[1], torch.Size))
 
     @unittest.skipIf(not USE_NETWORKX, "networkx not available")
     def test_min_cut_partitioner_output_tensor_shape_tensor(self):

--- a/torch/_functorch/vmap.py
+++ b/torch/_functorch/vmap.py
@@ -86,7 +86,11 @@ def _process_batched_inputs(
             f'The latter is unsupported.')
 
     flat_args, args_spec = tree_flatten(args)
-    flat_in_dims = _broadcast_to_and_flatten(in_dims, args_spec)
+    flat_in_dims = _broadcast_to_and_flatten(
+        in_dims,
+        args_spec,
+        replace_spec_types={torch.Size: tuple}
+    )
     if flat_in_dims is None:
         raise ValueError(
             f'vmap({_get_name(func)}, in_dims={in_dims}, ...)(<inputs>): '

--- a/torch/_functorch/vmap.py
+++ b/torch/_functorch/vmap.py
@@ -86,12 +86,12 @@ def _process_batched_inputs(
             f'The latter is unsupported.')
 
     flat_args, args_spec = tree_flatten(args)
+    # We have to replace spec types because in_dims must be tuple
+    # (to accomodate `None`) but args may have torch.Size.
+    args_spec_with_tuple = args_spec.replace_types({torch.Size: tuple})
     flat_in_dims = _broadcast_to_and_flatten(
         in_dims,
-        args_spec,
-        # We have to replace spec types because in_dims must be tuple
-        # (to accomodate `None`) but args may have torch.Size.
-        replace_spec_types={torch.Size: tuple}
+        args_spec_with_tuple,
     )
     if flat_in_dims is None:
         raise ValueError(

--- a/torch/_functorch/vmap.py
+++ b/torch/_functorch/vmap.py
@@ -89,6 +89,8 @@ def _process_batched_inputs(
     flat_in_dims = _broadcast_to_and_flatten(
         in_dims,
         args_spec,
+        # We have to replace spec types because in_dims must be tuple
+        # (to accomodate `None`) but args may have torch.Size.
         replace_spec_types={torch.Size: tuple}
     )
     if flat_in_dims is None:

--- a/torch/fx/_pytree.py
+++ b/torch/fx/_pytree.py
@@ -67,7 +67,7 @@ register_pytree_flatten_spec(dict, _dict_flatten_spec, _dict_flatten_spec_exact_
 register_pytree_flatten_spec(list, _list_flatten_spec, _list_flatten_spec_exact_match)
 register_pytree_flatten_spec(tuple, _tuple_flatten_spec, _tuple_flatten_spec_exact_match)
 register_pytree_flatten_spec(namedtuple, _namedtuple_flatten_spec, _tuple_flatten_spec_exact_match)
-def lazy_register():
+def _lazy_register():
     import torch
     register_pytree_flatten_spec(torch.Size, _tuple_flatten_spec, _tuple_flatten_spec_exact_match)
-lazy_register()
+_lazy_register()

--- a/torch/fx/_pytree.py
+++ b/torch/fx/_pytree.py
@@ -67,3 +67,7 @@ register_pytree_flatten_spec(dict, _dict_flatten_spec, _dict_flatten_spec_exact_
 register_pytree_flatten_spec(list, _list_flatten_spec, _list_flatten_spec_exact_match)
 register_pytree_flatten_spec(tuple, _tuple_flatten_spec, _tuple_flatten_spec_exact_match)
 register_pytree_flatten_spec(namedtuple, _namedtuple_flatten_spec, _tuple_flatten_spec_exact_match)
+def lazy_register():
+    import torch
+    register_pytree_flatten_spec(torch.Size, _tuple_flatten_spec, _tuple_flatten_spec_exact_match)
+lazy_register()

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -52,7 +52,7 @@ CONSTANT_NUMEL_LIMIT = 1
 pytree._register_pytree_node(
     torch.Size,
     lambda x: (list(x), None),
-    lambda xs, _: tuple(xs) if not all(isinstance(x, (int, SymInt)) for x in xs) else torch.Size(xs)
+    lambda xs, _: tuple(xs) if not all(type(x) in [int, SymInt] for x in xs) else torch.Size(xs)
 )
 
 def fake_signature(fn, nargs):

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -48,11 +48,11 @@ CONSTANT_NUMEL_LIMIT = 1
 
 # We currently convert all SymInt to proxies before we use them.
 # Hence we transform any torch.Size node into an equivalent tuple
-# if all of its items are `Proxy`s
+# if any of its items are not int/SymInt
 pytree._register_pytree_node(
     torch.Size,
     lambda x: (list(x), None),
-    lambda xs, _: tuple(xs) if all(isinstance(x, Proxy) for x in xs) else torch.Size(xs)
+    lambda xs, _: tuple(xs) if not all(isinstance(x, (int, SymInt)) for x in xs) else torch.Size(xs)
 )
 
 def fake_signature(fn, nargs):

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -245,7 +245,7 @@ class TreeSpec:
 
     def replace_types(self, mapping: Dict[Any, Any]) -> "TreeSpec":
         if self.is_leaf():
-            return self
+            return LeafSpec()
         new_children_specs = [child.replace_types(mapping) for child in self.children_specs]
         new_type = self.type
         if new_type in mapping:
@@ -457,10 +457,7 @@ def tree_any_only(ty: TypeAny, pred: FnAny[bool], pytree: PyTree) -> bool:
 # a user can pass in vmap(fn, in_dims)(*inputs). `in_dims` should be
 # broadcastable to the tree structure of `inputs` and we use
 # _broadcast_to_and_flatten to check this.
-def _broadcast_to_and_flatten(
-    pytree: PyTree,
-    spec: TreeSpec,
-) -> Optional[List[Any]]:
+def _broadcast_to_and_flatten(pytree: PyTree, spec: TreeSpec) -> Optional[List[Any]]:
     assert isinstance(spec, TreeSpec)
 
     if _is_leaf(pytree):


### PR DESCRIPTION
Fixes:
- https://github.com/pytorch/pytorch/issues/111962

Also improve testing of `tree_map_only`

Root cause: https://github.com/pytorch/pytorch/pull/86098 was too laissez faire with converting `torch.Size` into `tuple`s

As it turns out, `vmap_impl` also depends on this quite unusual behaviour - Hyrum's law at work. We fix that by allowing special-case equivalence between tuple and Size for the vmap `in_dim` case.