### PR TITLE
[BE] Enhance `OpInfo.supported_dtype`

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -430,7 +430,8 @@ if __name__ == '__main__':
     def test_supported_dtypes(self, device, op):
         self.assertNotEqual(op.supported_dtypes("cpu"), op.supported_dtypes("cuda"))
         self.assertEqual(op.supported_dtypes("cuda"), op.supported_dtypes("cuda:0"))
-        self.assertEqual( op.supported_dtypes(torch.device("cuda")),
+        self.assertEqual(
+            op.supported_dtypes(torch.device("cuda")),
             op.supported_dtypes(torch.device("cuda", index=1)),
         )
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -414,13 +414,25 @@ if __name__ == '__main__':
             self.assertTrue(set(dtypes) == set(dynamic_dispatch.dispatch_fn()))
 
     @onlyCPU
-    def test_supported_dtypes(self, device):
-        for op in op_db:
-          if len(op.supported_dtypes('cpu').symmetric_difference(op.supported_dtypes('cuda'))) > 0:
-            break
-        self.assertNotEqual(op.supported_dtypes('cpu'), op.supported_dtypes('cuda'))
-        self.assertEqual(op.supported_dtypes('cuda'), op.supported_dtypes('cuda:0'))
-        self.assertEqual(op.supported_dtypes(torch.device('cuda')), op.supported_dtypes(torch.device('cuda', index=1)))
+    @ops(
+        [
+            op
+            for op in op_db
+            if len(
+                op.supported_dtypes("cpu").symmetric_difference(
+                    op.supported_dtypes("cuda")
+                )
+            )
+            > 0
+        ][:1],
+        dtypes=OpDTypes.none,
+    )
+    def test_supported_dtypes(self, device, op):
+        self.assertNotEqual(op.supported_dtypes("cpu"), op.supported_dtypes("cuda"))
+        self.assertEqual(op.supported_dtypes("cuda"), op.supported_dtypes("cuda:0"))
+        self.assertEqual( op.supported_dtypes(torch.device("cuda")),
+            op.supported_dtypes(torch.device("cuda", index=1)),
+        )
 
 instantiate_device_type_tests(TestTesting, globals())
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -22,7 +22,7 @@ from torch.testing._internal.common_utils import \
      parametrize, subtest, instantiate_parametrized_tests, dtype_name, TEST_WITH_ROCM, decorateIf)
 from torch.testing._internal.common_device_type import \
     (PYTORCH_TESTING_DEVICE_EXCEPT_FOR_KEY, PYTORCH_TESTING_DEVICE_ONLY_FOR_KEY, dtypes,
-     get_device_type_test_bases, instantiate_device_type_tests, onlyCUDA, onlyNativeDeviceTypes,
+     get_device_type_test_bases, instantiate_device_type_tests, onlyCPU, onlyCUDA, onlyNativeDeviceTypes,
      deviceCountAtLeast, ops, expectedFailureMeta, OpDTypes)
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal import opinfo
@@ -412,6 +412,15 @@ if __name__ == '__main__':
 
             self.assertTrue(set(dtypes) == set(dynamic_dtypes))
             self.assertTrue(set(dtypes) == set(dynamic_dispatch.dispatch_fn()))
+
+    @onlyCPU
+    def test_supported_dtypes(self, device):
+        for op in op_db:
+          if len(op.supported_dtypes('cpu').symmetric_difference(op.supported_dtypes('cuda'))) > 0:
+            break
+        self.assertNotEqual(op.supported_dtypes('cpu'), op.supported_dtypes('cuda'))
+        self.assertEqual(op.supported_dtypes('cuda'), op.supported_dtypes('cuda:0'))
+        self.assertEqual(op.supported_dtypes(torch.device('cuda')), op.supported_dtypes(torch.device('cuda', index=1)))
 
 instantiate_device_type_tests(TestTesting, globals())
 

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -1305,21 +1305,18 @@ class OpInfo:
         return result
 
     def supported_dtypes(self, device_type):
-        if device_type == "cpu":
-            return self.dtypes
+        device_type = str(device_type).split(":", 1)[0]
         if device_type == "cuda":
             return self.dtypesIfROCM if TEST_WITH_ROCM else self.dtypesIfCUDA
-        else:
-            return self.dtypes
+        return self.dtypes
 
     def supported_backward_dtypes(self, device_type):
         if not self.supports_autograd:
             return set()
 
+        device_type = str(device_type).split(":", 1)[0]
         backward_dtypes = None
-        if device_type == "cpu":
-            backward_dtypes = self.backward_dtypes
-        elif device_type == "cuda":
+        if device_type == "cuda":
             backward_dtypes = (
                 self.backward_dtypesIfROCM
                 if TEST_WITH_ROCM
@@ -1333,7 +1330,7 @@ class OpInfo:
         )
         return set(allowed_backward_dtypes).intersection(backward_dtypes)
 
-    def supports_dtype(self, dtype, device_type):
+    def supports_dtype(self, dtype, device_type) -> bool:
         return dtype in self.supported_dtypes(device_type)
 
     @property

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -1305,7 +1305,7 @@ class OpInfo:
         return result
 
     def supported_dtypes(self, device_type):
-        device_type = str(device_type).split(":", 1)[0]
+        device_type = torch.device(device_type).type
         if device_type == "cuda":
             return self.dtypesIfROCM if TEST_WITH_ROCM else self.dtypesIfCUDA
         return self.dtypes
@@ -1314,7 +1314,7 @@ class OpInfo:
         if not self.supports_autograd:
             return set()
 
-        device_type = str(device_type).split(":", 1)[0]
+        device_type = torch.device(device_type).type
         backward_dtypes = None
         if device_type == "cuda":
             backward_dtypes = (


### PR DESCRIPTION
Current implementation is prone to errors, as it accepts any object, but does not print an error or something if device_type is not recognized.

Remediate it by accepting both device-type and device identifies (either `torch.device` instance or "{device_type}:{ordinal}" string

Fixes https://github.com/pytorch/pytorch/issues/111179
