### PR TITLE
[Release-2.1.1] Fix regression in `torch.equal` behavior for NaNs

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6312,6 +6312,11 @@ class TestTorch(TestCase):
             self.assertNotEqual(t_0.size(), t_1.size())
             self.assertFalse(torch.equal(t_0, t_1))
 
+            # Fast path: tensor containing `nan` is not equal to self
+            for dtype in floating_and_complex_types():
+                t = torch.tensor([1., float('nan')], dtype=dtype)
+                self.assertFalse(torch.equal(t, t))
+
     def test_element_size(self):
         byte = torch.ByteStorage().element_size()
         char = torch.CharStorage().element_size()


### PR DESCRIPTION
`torch.equal(x, x)` should return false if one of `x` is a tenor of floats one of which is NaN.
So, it renders some of the optimization proposed in https://github.com/pytorch/pytorch/pull/100024 invalid, though as result `torch.equal` will become much slower for identical floating point tensors.

Add regression test that calls torch.equal for tensor containing NaN

Fixes https://github.com/pytorch/pytorch/issues/111251

This is a cherry-pick of  https://github.com/pytorch/pytorch/pull/111699 into release/2.1 branch