### PR TITLE
[aotinductor] Turn clang warning ignored-optimization-argument into error

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -761,6 +761,10 @@ def is_gcc() -> bool:
     return bool(re.search(r"(gcc|g\+\+)", cpp_compiler()))
 
 
+def is_clang() -> bool:
+    return bool(re.search(r"(clang|clang\+\+)", cpp_compiler()))
+
+
 @functools.lru_cache(None)
 def is_apple_clang() -> bool:
     cxx = cpp_compiler()
@@ -975,7 +979,10 @@ def get_glibcxx_abi_build_flags() -> str:
 
 
 def cpp_flags() -> str:
-    return "-std=c++17 -Wno-unused-variable -Wno-unknown-pragmas"
+    flags = ["-std=c++17", "-Wno-unused-variable", "-Wno-unknown-pragmas"]
+    if is_clang():
+        flags.append("-Werror=ignored-optimization-argument")
+    return " ".join(flags)
 
 
 def cpp_wrapper_flags() -> str:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #112008

Now we compile the generated wrapper C++ code with clang in fbcode.
When the Model's run_impl function is too large, clang will issue
a warning like:

  Function foo is too big to optimize [-Wignored-optimization-argument]

and compile the code without any optimization.

I think we may want to be more proactive in such cases. If the
generated C++ code is too complex or too large to be optimized,
we would like to be notified loudly with errors, so that we
would figure out ways to address the issue.

Later if we feel that turning this warning into an error is too
aggressive, we would add a config to disable it.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @kadeng @muchulee8 @aakhundov @ColinPeppler