### PR TITLE
Backport `trace frames with np.ndarray` (#110512)

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_dynamic_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_dynamic_inference.csv
@@ -13,8 +13,8 @@ clip,pass,0
 cm3leon_generate,pass,6
 dcgan,pass,0
 dlrm,pass,0
-doctr_det_predictor,pass,2
-doctr_reco_predictor,fail_accuracy,4
+doctr_det_predictor,pass,5
+doctr_reco_predictor,pass,4
 drq,pass,0
 fastNLP_Bert,pass,4
 functorch_dp_cifar10,pass,0

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_inference.csv
@@ -13,8 +13,8 @@ clip,pass,0
 cm3leon_generate,pass,6
 dcgan,pass,0
 dlrm,pass,0
-doctr_det_predictor,pass,2
-doctr_reco_predictor,fail_accuracy,4
+doctr_det_predictor,pass,5
+doctr_reco_predictor,pass,4
 drq,pass,0
 fastNLP_Bert,pass,4
 functorch_dp_cifar10,pass,0

--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -59,6 +59,7 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnts.frame_count, 1)
         self.assertEqual(cnts.op_count, 2)
 
+    @unittest.expectedFailure  # array scalars decay to 0D arrays
     def test_builtin_max_min(self):
         # test unspecialized primitive max/min
         def fn(x, y, z):
@@ -211,6 +212,7 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
         res = opt_fn(x, scale_factor)
         self.assertTrue(same(ref, res))
 
+    @unittest.expectedFailure  # fails as long as numpy scalars are 0D arrays
     def test_specializing_numpy_float_in_control_flow(self):
         # np.float is unspecialized by default,
         # but it should be specialized when used in control flow.

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3486,6 +3486,7 @@ class TestBinaryUfuncs(TestCase):
         )
         _test_helper(a, b)
 
+    @skipIfTorchDynamo     # complex infs/nans differ under Dynamo/Inductor
     @dtypesIfCUDA(torch.float32, torch.float64, torch.bfloat16)
     @dtypes(torch.float32, torch.float64, torch.bfloat16, torch.complex64, torch.complex128)
     def test_logaddexp(self, device, dtype):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5238,6 +5238,7 @@ class TestLinalg(TestCase):
 
     @unittest.skipIf(not TEST_SCIPY or (TEST_SCIPY and scipy.__version__ < '1.4.1'), "Scipy not found or older than 1.4.1")
     @skipCPUIfNoLapack
+    @skipIfTorchDynamo("fails in tracing scipy.sparse.lobpcg")
     @onlyCPU
     @dtypes(torch.double)
     def test_lobpcg_scipy(self, device, dtype):

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -1537,6 +1537,7 @@ class TestSparseCSR(TestCase):
     @parametrize("noncontiguous", [True, False])
     @skipCPUIfNoMklSparse
     @unittest.skipIf(not TEST_SCIPY, "SciPy not found")
+    @skipIfTorchDynamo("raises 'sparse matrix length is ambiguous; use getnnz()'")
     @dtypes(*floating_and_complex_types())
     @dtypesIfCUDA(*floating_and_complex_types_and(
                   *[torch.half] if SM53OrLater else [],

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2908,7 +2908,7 @@ else:
         large_size = 100000
         t = make_tensor((large_size,), dtype=dtype, device=device)
         t_np = t.cpu().numpy()
-        coordinates_np = list(np.random.randn(large_size))
+        coordinates_np = np.random.randn(large_size)
         coordinates = [torch.tensor(coordinates_np, device=device)]
         actual = torch.gradient(t, spacing=coordinates, dim=0, edge_order=1)
         expected = [np.gradient(t_np, coordinates_np, axis=0, edge_order=1)]

--- a/test/torch_np/test_ndarray_methods.py
+++ b/test/torch_np/test_ndarray_methods.py
@@ -578,3 +578,35 @@ def test_extra_methods(name):
     a = np.ones(3)
     with pytest.raises(AttributeError):
         getattr(a, name)
+
+
+@instantiate_parametrized_tests
+class TestNoExtraMethods(TestCase):
+    # make sure ndarray does not carry extra methods/attributes
+    # >>> set(dir(a)) - set(dir(a.tensor.numpy()))
+    @parametrize("name", ["fn", "ivar", "method", "name", "plain", "rvar"])
+    def test_extra_methods(self, name):
+        a = np.ones(3)
+        with pytest.raises(AttributeError):
+            getattr(a, name)
+
+
+class TestIter(TestCase):
+    def test_iter_1d(self):
+        # numpy generates array scalars, we do 0D arrays
+        a = np.arange(5)
+        lst = list(a)
+        assert all(type(x) == np.ndarray for x in lst)
+        assert all(x.ndim == 0 for x in lst)
+
+    def test_iter_2d(self):
+        # numpy iterates over the 0th axis
+        a = np.arange(5)[None, :]
+        lst = list(a)
+        assert len(lst) == 1
+        assert type(lst[0]) == np.ndarray
+        assert_equal(lst[0], np.arange(5))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_dynamo/allowed_functions.py
+++ b/torch/_dynamo/allowed_functions.py
@@ -374,4 +374,4 @@ def is_builtin_constant(obj):
 def is_numpy(obj):
     if np is None:
         return False
-    return isinstance(obj, np.ndarray) or id(obj) in _numpy_function_ids
+    return isinstance(obj, (np.ndarray, np.generic)) or id(obj) in _numpy_function_ids

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -9,6 +9,11 @@ import typing
 import weakref
 from typing import Any, Callable, Dict, List, Optional, Set
 
+try:
+    import numpy as np
+except ModuleNotFoundError:
+    np = None  # type: ignore[assignment]
+
 import torch
 import torch._logging
 from torch._guards import compile_context, CompileContext, CompileId, tracing
@@ -167,6 +172,13 @@ def has_tensor_in_frame(frame):
         seen_ids[obj_id] = False
 
         if isinstance(obj, (torch.Tensor, torch.nn.Module)):
+            seen_ids[obj_id] = True
+            return seen_ids[obj_id]
+        elif (
+            config.trace_numpy
+            and np
+            and (istype(obj, np.ndarray) or isinstance(obj, np.generic))
+        ):
             seen_ids[obj_id] = True
             return seen_ids[obj_id]
         elif istype(obj, (list, tuple)):

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -480,7 +480,7 @@ class VariableBuilder:
                 source=self.source,
                 guards=make_guards(GuardBuilder.ID_MATCH),
             )
-        elif isinstance(value, np.generic):
+        elif np is not None and isinstance(value, np.generic):
             # numpy array scalars: convert to 0D arrays
             return self.wrap_numpy_ndarray(np.asarray(value))
         elif is_numpy(value):

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -480,6 +480,9 @@ class VariableBuilder:
                 source=self.source,
                 guards=make_guards(GuardBuilder.ID_MATCH),
             )
+        elif isinstance(value, np.generic):
+            # numpy array scalars: convert to 0D arrays
+            return self.wrap_numpy_ndarray(np.asarray(value))
         elif is_numpy(value):
             assert np
             return NumpyVariable(
@@ -1011,7 +1014,15 @@ class VariableBuilder:
         assert isinstance(value, np.ndarray)
 
         source = NumpyTensorSource(self.get_source())
-        tensor_value = torch.as_tensor(value)
+
+        from torch._numpy import _util
+
+        try:
+            tensor_value = _util._try_convert_to_tensor(value)
+        except NotImplementedError as e:
+            # failed to convert to tensor, graph break
+            unimplemented(str(e))
+
         # We do this because we want the full behavior of guarding the numpy ndarray as if it were
         # a tensor. It's a little annoying to make a VT to throw out, but there's so many side effects here
         # that there's not another great way to do this atm.

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -304,7 +304,7 @@ class TensorVariable(VariableTracker):
         return self.ndim > 0
 
     def unpack_var_sequence(self, tx, idxes=None):
-        from .builder import wrap_fx_proxy
+        from .builder import wrap_fx_proxy_cls
 
         options = VariableTracker.propagate(self)
         if idxes is None:
@@ -320,7 +320,12 @@ class TensorVariable(VariableTracker):
                 else:
                     length = dyn_length.value
             idxes = range(length)
-        return [wrap_fx_proxy(tx, self.as_proxy()[i], **options) for i in idxes]
+        return [
+            wrap_fx_proxy_cls(
+                target_cls=type(self), tx=tx, proxy=self.as_proxy()[i], **options
+            )
+            for i in idxes
+        ]
 
     def _strict_mode_banned_ops(self):
         return torch._dynamo.config._autograd_backward_strict_mode_banned_ops

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -584,6 +584,12 @@ def _conv_corr_impl(a, v, mode):
 
     padding = v.shape[0] - 1 if mode == "full" else mode
 
+    if padding == "same" and v.shape[0] % 2 == 0:
+        # UserWarning: Using padding='same' with even kernel lengths and odd
+        # dilation may require a zero-padded copy of the input be created
+        # (Triggered internally at pytorch/aten/src/ATen/native/Convolution.cpp:1010.)
+        raise NotImplementedError("mode='same' and even-length weights")
+
     # NumPy only accepts 1D arrays; PyTorch requires 2D inputs and 3D weights
     aa = a[None, :]
     vv = v[None, None, :]

--- a/torch/_numpy/_ndarray.py
+++ b/torch/_numpy/_ndarray.py
@@ -344,6 +344,9 @@ class ndarray:
     def tolist(self):
         return self.tensor.tolist()
 
+    def __iter__(self):
+        return (ndarray(x) for x in self.tensor.__iter__())
+
     def __str__(self):
         return (
             str(self.tensor)

--- a/torch/_numpy/_util.py
+++ b/torch/_numpy/_util.py
@@ -171,6 +171,15 @@ def typecast_tensors(tensors, target_dtype, casting):
     return tuple(typecast_tensor(t, target_dtype, casting) for t in tensors)
 
 
+def _try_convert_to_tensor(obj):
+    try:
+        tensor = torch.as_tensor(obj)
+    except Exception as e:
+        mesg = f"failed to convert {obj} to ndarray. \nInternal error is: {str(e)}."
+        raise NotImplementedError(mesg)
+    return tensor
+
+
 def _coerce_to_tensor(obj, dtype=None, copy=False, ndmin=0):
     """The core logic of the array(...) function.
 
@@ -201,7 +210,7 @@ def _coerce_to_tensor(obj, dtype=None, copy=False, ndmin=0):
     if isinstance(obj, torch.Tensor):
         tensor = obj
     else:
-        tensor = torch.as_tensor(obj)
+        tensor = _try_convert_to_tensor(obj)
 
         # tensor.dtype is the pytorch default, typically float32. If obj's elements
         # are not exactly representable in float32, we've lost precision:


### PR DESCRIPTION
Backport https://github.com/pytorch/pytorch/pull/110512 to 2.1.1.

This one depends on https://github.com/pytorch/pytorch/pull/112027

Also, contains the cherry-picked fix from https://github.com/pytorch/pytorch/pull/112175

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng