### PR TITLE
[dynamo] add sanity check that we do not wrap tracked tensors

### DIFF
--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -996,6 +996,10 @@ class VariableBuilder:
     def wrap_tensor(self, value: torch.Tensor):
         source = self.get_source()
 
+        # We cannot already be tracking the tensor, which implies
+        # it would have already been wrapped
+        assert value not in self.tx.output.side_effects
+
         if (
             source.guard_source().is_nn_module()
             or get_static_address_type(value) is not None


### PR DESCRIPTION
Identified as a result of https://github.com/pytorch/pytorch/pull/111911

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng