### PR TITLE
Docker release build don't include build suffix in the release

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -91,12 +91,9 @@ jobs:
           set -eou pipefail
           # To get QEMU binaries in our PATH
           echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
-          # Generate PyTorch version to use
-          if [[ ${CHANNEL} == "release" ]]; then
-            echo "PYTORCH_VERSION=2.1.0" >> "${GITHUB_ENV}"
-          else
-            echo "PYTORCH_VERSION=$(python3 .github/scripts/generate_pytorch_version.py)" >> "${GITHUB_ENV}"
-          fi
+          # Generate PyTorch version to use without suffix
+          echo "PYTORCH_VERSION=$(python3 .github/scripts/generate_pytorch_version.py --no-build-suffix)" >> "${GITHUB_ENV}"
+
       - name: Setup release specific variables
         run: |
           {


### PR DESCRIPTION
This build is used in release as far as I know. For release we don't need suffix.

Test in Release:
```
python3 .github/scripts/generate_pytorch_version.py
2.1.1+cpu
python3 .github/scripts/generate_pytorch_version.py --no-build-suffix
2.1.1
```

Test with nightly:
```
python3 .github/scripts/generate_pytorch_version.py --no-build-suffix
2.2.0.dev20231025
```

With suffix:
```
python3 .github/scripts/generate_pytorch_version.py
2.2.0.dev20231025+cpu
````