### PR TITLE
updated aarch64 maintainers in docs

### DIFF
--- a/docs/source/community/persons_of_interest.rst
+++ b/docs/source/community/persons_of_interest.rst
@@ -271,6 +271,11 @@ PowerPC
 
 -  Alfredo Mendoza (`avmgithub <https://github.com/avmgithub>`__)
 
+AArch64 CPU
+~~~~~~~~~~~~
+
+-  Sunita Nadampalli (`snadampal <https://github.com/snadampal>`__)
+
 Docs / Tutorials
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR adds a new section for maintainers of `aarch64`.

Adding @snadampal to the list


cc @svekars @carljparker