### PR TITLE
TST: make test_indexing traceable by Dynamo

### DIFF
--- a/test/torch_np/numpy_tests/core/test_indexing.py
+++ b/test/torch_np/numpy_tests/core/test_indexing.py
@@ -12,21 +12,36 @@ from unittest import expectedFailure as xfail, skipIf as skipif, SkipTest
 
 import pytest
 
-import torch._numpy as np
 from pytest import raises as assert_raises
-from torch._numpy.testing import (
-    assert_,
-    assert_array_equal,
-    assert_equal,
-    assert_warns,
-    HAS_REFCOUNT,
-)
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
+    xfailIfTorchDynamo,
+    xpassIfTorchDynamo,
 )
+
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy.testing import (
+        assert_,
+        assert_array_equal,
+        assert_equal,
+        assert_warns,
+        HAS_REFCOUNT,
+    )
+else:
+    import torch._numpy as np
+    from torch._numpy.testing import (
+        assert_,
+        assert_array_equal,
+        assert_equal,
+        assert_warns,
+        HAS_REFCOUNT,
+    )
+
 
 skip = functools.partial(skipif, True)
 
@@ -122,15 +137,13 @@ class TestIndexing(TestCase):
         assert_equal(a[None], a[np.newaxis])
         assert_equal(a[None].ndim, a.ndim + 1)
 
+    @skip
     def test_empty_tuple_index(self):
         # Empty tuple index creates a view
         a = np.array([1, 2, 3])
         assert_equal(a[()], a)
         assert_(a[()].tensor._base is a.tensor)
         a = np.array(0)
-        raise SkipTest(
-            "torch doesn't have scalar types with distinct instancing behaviours"
-        )
         assert_(isinstance(a[()], np.int_))
 
     def test_same_kind_index_casting(self):
@@ -172,7 +185,6 @@ class TestIndexing(TestCase):
         assert_(a[...] is not a)
         assert_equal(a[...], a)
         # `a[...]` was `a` in numpy <1.9.
-        assert_(a[...].tensor._base is a.tensor)
 
         # Slicing with ellipsis can skip an
         # arbitrary number of dimensions
@@ -188,6 +200,14 @@ class TestIndexing(TestCase):
         b = np.array(1)
         b[(Ellipsis,)] = 2
         assert_equal(b, 2)
+
+    @xfailIfTorchDynamo  # numpy ndarrays do not have `.tensor` attribute
+    def test_ellipsis_index_2(self):
+        a = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        assert_(a[...] is not a)
+        assert_equal(a[...], a)
+        # `a[...]` was `a` in numpy <1.9.
+        assert_(a[...].tensor._base is a.tensor)
 
     def test_single_int_index(self):
         # Single integer index selects one row
@@ -233,6 +253,7 @@ class TestIndexing(TestCase):
         a[b] = 1.0
         assert_equal(a, [[1.0, 1.0, 1.0]])
 
+    @skip(reason="NP_VER: fails on CI")
     def test_boolean_assignment_value_mismatch(self):
         # A boolean assignment should fail when the shape of the values
         # cannot be broadcast to the subscription. (see also gh-3458)
@@ -400,7 +421,7 @@ class TestIndexing(TestCase):
         # Unlike the non nd-index:
         assert_(arr[index,].shape != (1,))
 
-    @xfail  # (reason="XXX: low-prio behaviour to support")
+    @xpassIfTorchDynamo  # (reason="XXX: low-prio behaviour to support")
     def test_broken_sequence_not_nd_index(self):
         # See https://github.com/numpy/numpy/issues/5063
         # If we have an object which claims to be a sequence, but fails
@@ -558,7 +579,7 @@ class TestBroadcastedAssignments(TestCase):
 
 
 class TestFancyIndexingCast(TestCase):
-    @xfail  # (
+    @xpassIfTorchDynamo  # (
     #    reason="XXX: low-prio to support assigning complex values on floating arrays"
     # )
     def test_boolean_index_cast_assign(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #112075
* #112074
* #112073
* #112071
* #112070
* #112069
* #112068
* #112067
* #112066
* #112065
* #112064
* __->__ #112063
* #112062
* #112061
* #112060
* #112059
* #112058
* #112057

