### PR TITLE
TST: make test_shape_base traceable by Dynamo

### DIFF
--- a/test/torch_np/numpy_tests/core/test_shape_base.py
+++ b/test/torch_np/numpy_tests/core/test_shape_base.py
@@ -4,29 +4,53 @@ import functools
 
 from unittest import expectedFailure as xfail, skipIf as skipif
 
-import pytest
+import numpy
 
-import torch._numpy as np
+import pytest
 from pytest import raises as assert_raises
-from torch._numpy import (
-    array,
-    atleast_1d,
-    atleast_2d,
-    atleast_3d,
-    AxisError,
-    concatenate,
-    hstack,
-    newaxis,
-    stack,
-    vstack,
-)
-from torch._numpy.testing import assert_, assert_array_equal, assert_equal
+
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
+    xpassIfTorchDynamo,
 )
+
+# If we are going to trace through these, we should use NumPy
+# If testing on eager mode, we use torch._numpy
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy import (
+        array,
+        atleast_1d,
+        atleast_2d,
+        atleast_3d,
+        AxisError,
+        concatenate,
+        hstack,
+        newaxis,
+        stack,
+        vstack,
+    )
+    from numpy.testing import assert_, assert_array_equal, assert_equal
+else:
+    import torch._numpy as np
+    from torch._numpy import (
+        array,
+        atleast_1d,
+        atleast_2d,
+        atleast_3d,
+        AxisError,
+        concatenate,
+        hstack,
+        newaxis,
+        stack,
+        vstack,
+    )
+    from torch._numpy.testing import assert_, assert_array_equal, assert_equal
+
 
 skip = functools.partial(skipif, True)
 
@@ -178,6 +202,7 @@ class TestHstack(TestCase):
         # with assert_warns(FutureWarning):
         hstack(x for x in np.ones((3, 2)))
 
+    @skipif(numpy.__version__ < "1.24", reason="NP_VER: fails on NumPy 1.23.x")
     def test_casting_and_dtype(self):
         a = np.array([1, 2, 3])
         b = np.array([2.5, 3.5, 4.5])
@@ -232,6 +257,7 @@ class TestVstack(TestCase):
         with pytest.raises(TypeError, match="arrays to stack must be"):
             vstack(np.arange(3) for _ in range(2))
 
+    @skipif(numpy.__version__ < "1.24", reason="casting kwarg is new in NumPy 1.24")
     def test_casting_and_dtype(self):
         a = np.array([1, 2, 3])
         b = np.array([2.5, 3.5, 4.5])
@@ -239,6 +265,7 @@ class TestVstack(TestCase):
         expected_res = np.array([[1, 2, 3], [2, 3, 4]])
         assert_array_equal(res, expected_res)
 
+    @skipif(numpy.__version__ < "1.24", reason="casting kwarg is new in NumPy 1.24")
     def test_casting_and_dtype_type_error(self):
         a = np.array([1, 2, 3])
         b = np.array([2.5, 3.5, 4.5])
@@ -332,7 +359,7 @@ class TestConcatenate(TestCase):
         assert out is rout
         assert np.all(r == rout)
 
-    @xfail  # (reason="concatenate(x, axis=None) relies on x being a sequence")
+    @xpassIfTorchDynamo  # (reason="concatenate(x, axis=None) relies on x being a sequence")
     def test_large_concatenate_axis_None(self):
         # When no axis is given, concatenate uses flattened versions.
         # This also had a bug with many arrays (see gh-5979).
@@ -442,6 +469,7 @@ class TestConcatenate(TestCase):
 
 @instantiate_parametrized_tests
 class TestStackMisc(TestCase):
+    @skipif(numpy.__version__ < "1.24", reason="NP_VER: fails on NumPy 1.23.x")
     def test_stack(self):
         # non-iterable input
         assert_raises(TypeError, stack, 1)
@@ -523,6 +551,7 @@ class TestStackMisc(TestCase):
         with assert_raises(TypeError):
             stack((a, b), dtype=np.int64, axis=1, casting="safe")
 
+    @skipif(numpy.__version__ < "1.24", reason="NP_VER: fails on NumPy 1.23.x")
     @parametrize("axis", [0])
     @parametrize("out_dtype", ["c8", "f4", "f8", "i8"])  # torch does not have ">f8",
     @parametrize("casting", ["no", "equiv", "safe", "same_kind", "unsafe"])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #112075
* #112074
* #112073
* #112071
* #112070
* #112069
* #112068
* #112067
* #112066
* #112065
* __->__ #112064
* #112063
* #112062
* #112061
* #112060
* #112059
* #112058
* #112057

