### PR TITLE
TST: make the rest of numpy_tests/core dynamo traceable

### DIFF
--- a/test/torch_np/numpy_tests/core/test_dlpack.py
+++ b/test/torch_np/numpy_tests/core/test_dlpack.py
@@ -3,29 +3,41 @@
 import functools
 import sys
 
-from unittest import expectedFailure as xfail, skipIf as skipif
+from unittest import skipIf as skipif
+
+import numpy
 
 import pytest
 
 import torch
 
-import torch._numpy as np
-from torch._numpy.testing import assert_array_equal
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
+    xpassIfTorchDynamo,
 )
 
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy.testing import assert_array_equal
+else:
+    import torch._numpy as np
+    from torch._numpy.testing import assert_array_equal
+
+
 skip = functools.partial(skipif, True)
+
 
 IS_PYPY = False
 
 
+@skipif(numpy.__version__ < "1.24", reason="numpy.dlpack is new in numpy 1.23")
 @instantiate_parametrized_tests
 class TestDLPack(TestCase):
-    @xfail  # (reason="pytorch seems to handle refcounts differently")
+    @xpassIfTorchDynamo  # (reason="pytorch seems to handle refcounts differently")
     @skipif(IS_PYPY, reason="PyPy can't get refcounts.")
     def test_dunder_dlpack_refcount(self):
         x = np.arange(5)
@@ -34,7 +46,7 @@ class TestDLPack(TestCase):
         del y
         assert sys.getrefcount(x) == 2
 
-    @xfail  # (reason="pytorch does not raise")
+    @xpassIfTorchDynamo  # (reason="pytorch does not raise")
     def test_dunder_dlpack_stream(self):
         x = np.arange(5)
         x.__dlpack__(stream=None)
@@ -42,7 +54,7 @@ class TestDLPack(TestCase):
         with pytest.raises(RuntimeError):
             x.__dlpack__(stream=1)
 
-    @xfail  # (reason="pytorch seems to handle refcounts differently")
+    @xpassIfTorchDynamo  # (reason="pytorch seems to handle refcounts differently")
     @skipif(IS_PYPY, reason="PyPy can't get refcounts.")
     def test_from_dlpack_refcount(self):
         x = np.arange(5)

--- a/test/torch_np/numpy_tests/core/test_dtype.py
+++ b/test/torch_np/numpy_tests/core/test_dtype.py
@@ -9,22 +9,30 @@ import types
 from itertools import permutations
 from typing import Any
 
-from unittest import expectedFailure as xfail, skipIf as skipif
+from unittest import skipIf as skipif
 
 import pytest
-
-import torch._numpy as np
 from pytest import raises as assert_raises
-from torch._numpy.testing import assert_, assert_equal
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
     subtest,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
+    xpassIfTorchDynamo,
 )
 
 skip = functools.partial(skipif, True)
+
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy.testing import assert_, assert_equal
+else:
+    import torch._numpy as np
+    from torch._numpy.testing import assert_, assert_equal
+
+import numpy
 
 
 def assert_dtype_equal(a, b):
@@ -102,6 +110,10 @@ class TestBuiltin(TestCase):
         with pytest.raises(TypeError):
             operation(np.dtype(np.int32), 7)
 
+    @skipif(
+        numpy.__version__ < "1.24",
+        reason="older numpies emit DeprecatioWarnings instead",
+    )
     @parametrize(
         "dtype",
         [
@@ -195,8 +207,8 @@ class TestPickling(TestCase):
     @parametrize(
         "DType",
         [
-            subtest(type(np.dtype(t)), name=f"{np.dtype(t).name}")
-            for t in np.typecodes["All"]
+            subtest(type(np.dtype(t)), name=f"{np.dtype(t).name}_{i}")
+            for i, t in enumerate(np.typecodes["All"])
         ]
         + [np.dtype],
     )
@@ -208,6 +220,7 @@ class TestPickling(TestCase):
 
 
 @skip(reason="XXX: value-based promotions, we don't have.")
+@instantiate_parametrized_tests
 class TestPromotion(TestCase):
     """Test cases related to more complex DType promotions.  Further promotion
     tests are defined in `test_numeric.py`
@@ -218,10 +231,12 @@ class TestPromotion(TestCase):
         [
             (2**16 - 1, np.complex64, None),
             (2**32 - 1, np.complex128, np.complex64),
-            (np.float16(2), np.complex64, None),
-            (np.float32(2), np.complex64, None),
+            subtest((np.float16(2), np.complex64, None), name="float16_complex64_None"),
+            subtest((np.float32(2), np.complex64, None), name="float32_complex64_None"),
             # repeat for complex scalars:
-            (np.complex64(2), np.complex64, None),
+            subtest(
+                (np.complex64(2), np.complex64, None), name="complex64_complex64_None"
+            ),
         ],
     )
     def test_complex_other_value_based(
@@ -303,7 +318,7 @@ class TestMisc(TestCase):
         assert bool(np.dtype("f8"))
         assert bool(np.dtype("i8"))
 
-    @xfail  # (reason="No keyword arg for dtype ctor.")
+    @xpassIfTorchDynamo  # (reason="No keyword arg for dtype ctor.")
     def test_keyword_argument(self):
         # test for https://github.com/numpy/numpy/pull/16574#issuecomment-642660971
         assert np.dtype(dtype=np.float64) == np.dtype(np.float64)
@@ -343,6 +358,7 @@ class TestFromDTypeAttribute(TestCase):
 
 @skip(reason="Parameteric dtypes, our stuff is simpler.")
 @skipif(sys.version_info < (3, 9), reason="Requires python 3.9")
+@instantiate_parametrized_tests
 class TestClassGetItem(TestCase):
     def test_dtype(self) -> None:
         alias = np.dtype[Any]

--- a/test/torch_np/numpy_tests/core/test_getlimits.py
+++ b/test/torch_np/numpy_tests/core/test_getlimits.py
@@ -8,13 +8,27 @@ import warnings
 
 # from numpy.core.getlimits import _discovered_machar, _float_ma
 
-from unittest import expectedFailure as xfail, skipIf
+from unittest import skipIf
 
-import torch._numpy as np
+import numpy
+
 from pytest import raises as assert_raises
-from torch._numpy import double, finfo, half, iinfo, single
-from torch._numpy.testing import assert_, assert_equal
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    run_tests,
+    TEST_WITH_TORCHDYNAMO,
+    TestCase,
+    xpassIfTorchDynamo,
+)
+
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy import double, finfo, half, iinfo, single
+    from numpy.testing import assert_, assert_equal
+else:
+    import torch._numpy as np
+    from torch._numpy import double, finfo, half, iinfo, single
+    from torch._numpy.testing import assert_, assert_equal
+
 
 skip = functools.partial(skipIf, True)
 
@@ -54,6 +68,7 @@ class TestDouble(TestCase):
 
 
 class TestFinfo(TestCase):
+    @skipIf(numpy.__version__ < "1.23", reason=".smallest_normal is new")
     def test_basic(self):
         dts = list(
             zip(
@@ -75,7 +90,7 @@ class TestFinfo(TestCase):
         with assert_raises((TypeError, ValueError)):
             finfo("i4")
 
-    @xfail  # (reason="These attributes are not implemented yet.")
+    @skip  # (reason="Some of these attributes are not implemented vs NP versions")
     def test_basic_missing(self):
         dt = np.float32
         for attr in [
@@ -125,6 +140,7 @@ class TestRepr(TestCase):
         expected = "iinfo(min=-32768, max=32767, dtype=int16)"
         assert_equal(repr(np.iinfo(np.int16)), expected)
 
+    @skipIf(TEST_WITH_TORCHDYNAMO, reason="repr differs")
     def test_finfo_repr(self):
         repr_f32 = repr(np.finfo(np.float32))
         assert "finfo(resolution=1e-06, min=-3.40282e+38," in repr_f32
@@ -186,7 +202,7 @@ class TestMisc(TestCase):
                 # This test may fail on some platforms
                 assert len(w) == 0
 
-    @xfail  # (reason="None of nmant, minexp, maxexp is implemented.")
+    @xpassIfTorchDynamo  # (reason="None of nmant, minexp, maxexp is implemented.")
     def test_plausible_finfo(self):
         # Assert that finfo returns reasonable results for all types
         for ftype in np.sctypes["float"] + np.sctypes["complex"]:

--- a/test/torch_np/numpy_tests/core/test_numerictypes.py
+++ b/test/torch_np/numpy_tests/core/test_numerictypes.py
@@ -4,22 +4,30 @@ import functools
 import itertools
 import sys
 
-from unittest import expectedFailure as xfail, skipIf as skipif
+from unittest import skipIf as skipif
 
-import torch._numpy as np
 from pytest import raises as assert_raises
-from torch._numpy.testing import assert_
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
+    xpassIfTorchDynamo,
 )
+
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy.testing import assert_
+else:
+    import torch._numpy as np
+    from torch._numpy.testing import assert_
+
 
 skip = functools.partial(skipif, True)
 
 
-@xfail  # (
+@xpassIfTorchDynamo  # (
 #    reason="We do not disctinguish between scalar and array types."
 #    " Thus, scalars can upcast arrays."
 # )
@@ -101,7 +109,7 @@ class TestIsSubDType(TestCase):
         assert np.issubdtype(np.float32, "f")
 
 
-@xfail  # (
+@xpassIfTorchDynamo  # (
 #    reason="We do not have (or need) np.core.numerictypes."
 #    " Our type aliases are in _dtypes.py."
 # )

--- a/test/torch_np/numpy_tests/core/test_scalar_ctors.py
+++ b/test/torch_np/numpy_tests/core/test_scalar_ctors.py
@@ -5,25 +5,33 @@ Test the scalar constructors, which also do type-coercion
 """
 import functools
 
-from unittest import expectedFailure as xfail, skipIf as skipif
+from unittest import skipIf as skipif
 
 import pytest
 
-import torch._numpy as np
-from torch._numpy.testing import assert_almost_equal, assert_equal
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
     subtest,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
+    xpassIfTorchDynamo,
 )
+
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy.testing import assert_almost_equal, assert_equal
+else:
+    import torch._numpy as np
+    from torch._numpy.testing import assert_almost_equal, assert_equal
+
 
 skip = functools.partial(skipif, True)
 
 
 class TestFromString(TestCase):
-    @xfail  # (reason="XXX: floats from strings")
+    @xpassIfTorchDynamo  # (reason="XXX: floats from strings")
     def test_floating(self):
         # Ticket #640, floats from string
         fsingle = np.single("1.234")
@@ -31,7 +39,7 @@ class TestFromString(TestCase):
         assert_almost_equal(fsingle, 1.234)
         assert_almost_equal(fdouble, 1.234)
 
-    @xfail  # (reason="XXX: floats from strings")
+    @xpassIfTorchDynamo  # (reason="XXX: floats from strings")
     def test_floating_overflow(self):
         """Strings containing an unrepresentable float overflow"""
         fhalf = np.half("1e10000")

--- a/test/torch_np/numpy_tests/core/test_scalar_methods.py
+++ b/test/torch_np/numpy_tests/core/test_scalar_methods.py
@@ -13,15 +13,23 @@ from unittest import skipIf as skipif, SkipTest
 
 import pytest
 
-import torch._numpy as np
 from pytest import raises as assert_raises
-from torch._numpy.testing import assert_equal
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
 )
+
+
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy.testing import assert_equal
+else:
+    import torch._numpy as np
+    from torch._numpy.testing import assert_equal
+
 
 skip = functools.partial(skipif, True)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #112075
* #112074
* #112073
* #112071
* #112070
* #112069
* #112068
* #112067
* __->__ #112066
* #112065
* #112064
* #112063
* #112062
* #112061
* #112060
* #112059
* #112058
* #112057

