### PR TITLE
[pytorch-vulkan] disable one zero-dim tensor test to fix test

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Sum.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Sum.cpp
@@ -135,6 +135,11 @@ Tensor sum_dim_IntList(
 Tensor sum(const Tensor& self, const c10::optional<ScalarType> dtype) {
   std::vector<int64_t> dims;
   for (int64_t d = 0; d < self.dim(); d++) {
+    // If any dimension has zero elements, we will shortcut to a zero-dim.
+    if (self.size(d) == 0) {
+      return self.new_zeros({}, at::device(at::kVulkan).dtype(self.dtype()));
+    }
+
     dims.push_back(d);
   }
 

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -282,6 +282,11 @@ TEST_F(VulkanAPITest, zero_size_tensor) {
   ASSERT_TRUE(at::equal(out_vk, cpu));
 }
 
+TEST_F(VulkanAPITest, zero_size_tensor_numel) {
+  auto vk = at::rand({18, 0, 5}, at::device(at::kVulkan).dtype(at::kFloat));
+  ASSERT_TRUE(vk.numel() == 0);
+}
+
 TEST_F(VulkanAPITest, zero_dim_tensor_1) {
   auto cpu = at::rand({}, at::device(at::kCPU).dtype(at::kFloat));
   auto vv = cpu.item<float>();
@@ -300,6 +305,12 @@ TEST_F(VulkanAPITest, zero_dim_tensor_2) {
   auto vk = at::empty({}, at::device(at::kVulkan).dtype(at::kFloat)) + v;
 
   ASSERT_TRUE(almostEqual(cpu, vk.cpu()));
+}
+
+TEST_F(VulkanAPITest, zero_dim_tensor_3) {
+  auto vk = at::zeros({}, at::device(at::kVulkan).dtype(at::kFloat));
+
+  ASSERT_TRUE(vk.cpu().item<float>() == 0.0f);
 }
 
 TEST_F(VulkanAPITest, local_scalar_dense) {
@@ -4530,6 +4541,8 @@ TEST_F(VulkanAPITest, sum_test) {
   test_sum({6});
   test_sum({5, 6});
   test_sum({0, 3, 1});
+  test_sum({5, 0, 1});
+  test_sum({5, 3, 0});
   test_sum({3, 3, 1});
   test_sum({7, 6, 6});
   test_sum({7, 8, 5, 6});


### PR DESCRIPTION
Summary:
D50347338 has bug on android (not Mac, not Devserver).

This diff disable the test for time being while I identify the actual cause.

Test Plan:
##  Compile on devserver

```
[yipjustin@129360.od ~/fbsource (e415d865c)]$ buck2 build -c ndk.static_linking=true -c pt.enable_qpl=0  --target-platforms=ovr_config//platform/android:arm32-fbsource //xplat/caffe2:pt_vulkan_api_test_binAndroid  --show-output
File changed: fbcode//caffe2/aten/src/ATen/test/vulkan_api_test.cpp
File changed: fbsource//xplat/caffe2/aten/src/ATen/test/vulkan_api_test.cpp
Buck UI: https://www.internalfb.com/buck2/99d47e63-ed6e-4db9-bee2-24909d647b78
Network: Up: 3.2KiB  Down: 67KiB  (reSessionID-459e359b-773c-48a4-b129-81fde7c5e876)
Jobs completed: 4664. Time elapsed: 7.3s.
Cache hits: 100%. Commands: 38 (cached: 38, remote: 0, local: 0)
BUILD SUCCEEDED
fbsource//xplat/caffe2:pt_vulkan_api_test_binAndroid buck-out/v2/gen/fbsource/f1f3f9bed27e143c/xplat/caffe2/__pt_vulkan_api_test_binAndroid__/pt_vulkan_api_test_binAndroid
```

## Run test.
adb shell /data/local/tmp/pt_vulkan_api_test_binAndroid | pastry

Result: P864940908
```
...
[       OK ] VulkanAPITest.lstm_success (7 ms)
[ RUN      ] VulkanAPITest.lstm_mclareninputs_success
[       OK ] VulkanAPITest.lstm_mclareninputs_success (56 ms)
[ RUN      ] VulkanAPITest.lstm_prepack_success
[       OK ] VulkanAPITest.lstm_prepack_success (7 ms)
[ RUN      ] VulkanAPITest.querypool_flushed_shader_log
xplat/caffe2/aten/src/ATen/test/vulkan_api_test.cpp:7568: Skipped
QueryPool is not available
[  SKIPPED ] VulkanAPITest.querypool_flushed_shader_log (0 ms)
[----------] 391 tests from VulkanAPITest (30715 ms total)
[----------] Global test environment tear-down
[==========] 391 tests from 1 test suite ran. (30715 ms total)
[  PASSED  ] 390 tests.
[  SKIPPED ] 1 test, listed below:
[  SKIPPED ] VulkanAPITest.querypool_flushed_shader_log
  YOU HAVE 7 DISABLED TESTS

```

Reviewed By: liuk22

Differential Revision: D50668570


