### PR TITLE
Don't search getitem for batch fusions

### DIFF
--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -37,6 +37,10 @@ MAX_FUSE_SEARCH_DEPTH = 5
 # The maximum tensor size that can go into the fusion group
 MAX_FUSE_TENSOR_SIZE_GROUP_LINEAR = 4096
 
+# exclude these nodes from BFS
+# excluding get item improves optimizer compilation time by 60s
+SEARCH_EXCLUSIONS = {operator.getitem}
+
 
 class GroupBatchFusionBase:
     def match(self, node):
@@ -582,6 +586,10 @@ def get_fusion_candidates(
     candidate_dict: DefaultDict[Any, List[torch.fx.Node]] = collections.defaultdict(
         list
     )
+
+    if root_node.target in SEARCH_EXCLUSIONS:
+        return candidate_dict
+
     visited_set: Set[torch.fx.Node] = set()
 
     for next_node in root_node.all_input_nodes:


### PR DESCRIPTION
Batch mm fusion regressed optimizer compile time by about ~1m, excluding getitem solves this problem.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler