### PR TITLE
Reland: Use fmt::format in NCCLUtils and ProcessGroupNCCL instead of c10::str

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -955,7 +955,8 @@ if(USE_ROCM)
   torch_compile_options(torch_hip)  # see cmake/public/utils.cmake
   # TODO: Not totally sure if this is live or not
   if(USE_NCCL)
-    target_link_libraries(torch_hip PRIVATE __caffe2_nccl)
+    # fmt::fmt-header-only is needed by the NCCL code in torch/csrc/distributed/c10d
+    target_link_libraries(torch_hip PRIVATE __caffe2_nccl fmt::fmt-header-only)
     target_compile_definitions(torch_hip PRIVATE USE_NCCL)
   endif()
 
@@ -991,7 +992,8 @@ elseif(USE_CUDA)
       target_compile_definitions(torch_cuda PRIVATE USE_CUSPARSELT)
   endif()
   if(USE_NCCL)
-    target_link_libraries(torch_cuda PRIVATE __caffe2_nccl)
+    # fmt::fmt-header-only is needed by the NCCL code in torch/csrc/distributed/c10d
+    target_link_libraries(torch_cuda PRIVATE __caffe2_nccl fmt::fmt-header-only)
     target_compile_definitions(torch_cuda PRIVATE USE_NCCL)
   endif()
   if(USE_UCC)

--- a/torch/csrc/distributed/c10d/NCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.cpp
@@ -1,11 +1,13 @@
+#ifdef USE_C10D_NCCL
+
 #include <torch/csrc/distributed/c10d/NCCLUtils.hpp>
 
 #include <c10/util/CallOnce.h>
 #include <c10/util/env.h>
 
-#ifdef USE_C10D_NCCL
-
 #include <mutex>
+
+#include <fmt/format.h>
 
 namespace c10d {
 
@@ -13,15 +15,15 @@ ncclComm_t NCCLComm::getNcclComm() {
   std::unique_lock<std::mutex> lock(mutex_);
   if (aborted_) {
     auto commFailureMsg = commFailureReason_ != c10::nullopt
-        ? c10::str(" Original reason for failure was: ", *commFailureReason_)
+        ? fmt::format(
+              " Original reason for failure was: {}", *commFailureReason_)
         : "";
     TORCH_CHECK_WITH(
         DistBackendError,
         false,
-        c10::str(
-            "NCCL communicator was aborted on rank ",
+        fmt::format(
+            "NCCL communicator was aborted on rank {}. {}",
             rank_,
-            ". ",
             commFailureMsg));
   }
   return ncclComm_;

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -247,6 +247,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
     friend std::ostream& operator<<(
         std::ostream& output,
         const WorkNCCL& workNCCL);
+    friend std::string getWorkInfo(const WorkNCCL& workNCCL);
 
    private:
     // Helper function for synchronize


### PR DESCRIPTION
Fixes #64604, corrects the reverted PR #107268

Added @cyyever's suggestions from [here](https://github.com/pytorch/pytorch/pull/107268#issuecomment-1773962453).


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan @angelayi @suo @ydwu4