### PR TITLE
[pytorch-vulkan] Add operator<< for uvec3

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Resource.cpp
+++ b/aten/src/ATen/native/vulkan/api/Resource.cpp
@@ -45,7 +45,9 @@ VkFormat vk_format(const at::ScalarType dtype) {
 
     default:
       TORCH_CHECK(
-          false, "Vulkan vk_format(): no corresponding format for dtype");
+          false,
+          "Vulkan vk_format(): no corresponding format for dtype: ",
+          dtype);
   }
 }
 

--- a/aten/src/ATen/native/vulkan/api/Utils.h
+++ b/aten/src/ATen/native/vulkan/api/Utils.h
@@ -99,6 +99,12 @@ using vec2 = vec<2u>;
 using vec3 = vec<3u>;
 using vec4 = vec<4u>;
 
+// uvec3 is the type representing tensor extents. Useful for debugging.
+inline std::ostream& operator<<(std::ostream& os, const uvec3& v) {
+  os << "(" << v.data[0u] << ", " << v.data[1u] << ", " << v.data[2u] << ")";
+  return os;
+}
+
 //
 // IntArrayRef Handling
 //


### PR DESCRIPTION
Summary: Useful for debugging.

Test Plan:
```
LD_LIBRARY_PATH=third-party/swiftshader/lib/linux-x64/ buck2 run fbcode/mode/dev-nosan    //xplat/caffe2:pt_vulkan_api_test_bin  | pastry
```
Test all pass: P865112285

Differential Revision: D50676692


