### PR TITLE
Make numpy core tests Dynamo traceable.

### DIFF
--- a/test/torch_np/numpy_tests/core/test_dlpack.py
+++ b/test/torch_np/numpy_tests/core/test_dlpack.py
@@ -3,29 +3,41 @@
 import functools
 import sys
 
-from unittest import expectedFailure as xfail, skipIf as skipif
+from unittest import skipIf as skipif
+
+import numpy
 
 import pytest
 
 import torch
 
-import torch._numpy as np
-from torch._numpy.testing import assert_array_equal
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
+    xpassIfTorchDynamo,
 )
 
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy.testing import assert_array_equal
+else:
+    import torch._numpy as np
+    from torch._numpy.testing import assert_array_equal
+
+
 skip = functools.partial(skipif, True)
+
 
 IS_PYPY = False
 
 
+@skipif(numpy.__version__ < "1.24", reason="numpy.dlpack is new in numpy 1.23")
 @instantiate_parametrized_tests
 class TestDLPack(TestCase):
-    @xfail  # (reason="pytorch seems to handle refcounts differently")
+    @xpassIfTorchDynamo  # (reason="pytorch seems to handle refcounts differently")
     @skipif(IS_PYPY, reason="PyPy can't get refcounts.")
     def test_dunder_dlpack_refcount(self):
         x = np.arange(5)
@@ -34,7 +46,7 @@ class TestDLPack(TestCase):
         del y
         assert sys.getrefcount(x) == 2
 
-    @xfail  # (reason="pytorch does not raise")
+    @xpassIfTorchDynamo  # (reason="pytorch does not raise")
     def test_dunder_dlpack_stream(self):
         x = np.arange(5)
         x.__dlpack__(stream=None)
@@ -42,7 +54,7 @@ class TestDLPack(TestCase):
         with pytest.raises(RuntimeError):
             x.__dlpack__(stream=1)
 
-    @xfail  # (reason="pytorch seems to handle refcounts differently")
+    @xpassIfTorchDynamo  # (reason="pytorch seems to handle refcounts differently")
     @skipif(IS_PYPY, reason="PyPy can't get refcounts.")
     def test_from_dlpack_refcount(self):
         x = np.arange(5)

--- a/test/torch_np/numpy_tests/core/test_dtype.py
+++ b/test/torch_np/numpy_tests/core/test_dtype.py
@@ -9,22 +9,30 @@ import types
 from itertools import permutations
 from typing import Any
 
-from unittest import expectedFailure as xfail, skipIf as skipif
+from unittest import skipIf as skipif
 
 import pytest
-
-import torch._numpy as np
 from pytest import raises as assert_raises
-from torch._numpy.testing import assert_, assert_equal
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
     subtest,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
+    xpassIfTorchDynamo,
 )
 
 skip = functools.partial(skipif, True)
+
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy.testing import assert_, assert_equal
+else:
+    import torch._numpy as np
+    from torch._numpy.testing import assert_, assert_equal
+
+import numpy
 
 
 def assert_dtype_equal(a, b):
@@ -102,6 +110,10 @@ class TestBuiltin(TestCase):
         with pytest.raises(TypeError):
             operation(np.dtype(np.int32), 7)
 
+    @skipif(
+        numpy.__version__ < "1.24",
+        reason="older numpies emit DeprecatioWarnings instead",
+    )
     @parametrize(
         "dtype",
         [
@@ -195,8 +207,8 @@ class TestPickling(TestCase):
     @parametrize(
         "DType",
         [
-            subtest(type(np.dtype(t)), name=f"{np.dtype(t).name}")
-            for t in np.typecodes["All"]
+            subtest(type(np.dtype(t)), name=f"{np.dtype(t).name}_{i}")
+            for i, t in enumerate(np.typecodes["All"])
         ]
         + [np.dtype],
     )
@@ -208,6 +220,7 @@ class TestPickling(TestCase):
 
 
 @skip(reason="XXX: value-based promotions, we don't have.")
+@instantiate_parametrized_tests
 class TestPromotion(TestCase):
     """Test cases related to more complex DType promotions.  Further promotion
     tests are defined in `test_numeric.py`
@@ -218,10 +231,12 @@ class TestPromotion(TestCase):
         [
             (2**16 - 1, np.complex64, None),
             (2**32 - 1, np.complex128, np.complex64),
-            (np.float16(2), np.complex64, None),
-            (np.float32(2), np.complex64, None),
+            subtest((np.float16(2), np.complex64, None), name="float16_complex64_None"),
+            subtest((np.float32(2), np.complex64, None), name="float32_complex64_None"),
             # repeat for complex scalars:
-            (np.complex64(2), np.complex64, None),
+            subtest(
+                (np.complex64(2), np.complex64, None), name="complex64_complex64_None"
+            ),
         ],
     )
     def test_complex_other_value_based(
@@ -303,7 +318,7 @@ class TestMisc(TestCase):
         assert bool(np.dtype("f8"))
         assert bool(np.dtype("i8"))
 
-    @xfail  # (reason="No keyword arg for dtype ctor.")
+    @xpassIfTorchDynamo  # (reason="No keyword arg for dtype ctor.")
     def test_keyword_argument(self):
         # test for https://github.com/numpy/numpy/pull/16574#issuecomment-642660971
         assert np.dtype(dtype=np.float64) == np.dtype(np.float64)
@@ -343,6 +358,7 @@ class TestFromDTypeAttribute(TestCase):
 
 @skip(reason="Parameteric dtypes, our stuff is simpler.")
 @skipif(sys.version_info < (3, 9), reason="Requires python 3.9")
+@instantiate_parametrized_tests
 class TestClassGetItem(TestCase):
     def test_dtype(self) -> None:
         alias = np.dtype[Any]

--- a/test/torch_np/numpy_tests/core/test_getlimits.py
+++ b/test/torch_np/numpy_tests/core/test_getlimits.py
@@ -8,13 +8,27 @@ import warnings
 
 # from numpy.core.getlimits import _discovered_machar, _float_ma
 
-from unittest import expectedFailure as xfail, skipIf
+from unittest import skipIf
 
-import torch._numpy as np
+import numpy
+
 from pytest import raises as assert_raises
-from torch._numpy import double, finfo, half, iinfo, single
-from torch._numpy.testing import assert_, assert_equal
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    run_tests,
+    TEST_WITH_TORCHDYNAMO,
+    TestCase,
+    xpassIfTorchDynamo,
+)
+
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy import double, finfo, half, iinfo, single
+    from numpy.testing import assert_, assert_equal
+else:
+    import torch._numpy as np
+    from torch._numpy import double, finfo, half, iinfo, single
+    from torch._numpy.testing import assert_, assert_equal
+
 
 skip = functools.partial(skipIf, True)
 
@@ -54,6 +68,7 @@ class TestDouble(TestCase):
 
 
 class TestFinfo(TestCase):
+    @skipIf(numpy.__version__ < "1.23", reason=".smallest_normal is new")
     def test_basic(self):
         dts = list(
             zip(
@@ -75,7 +90,7 @@ class TestFinfo(TestCase):
         with assert_raises((TypeError, ValueError)):
             finfo("i4")
 
-    @xfail  # (reason="These attributes are not implemented yet.")
+    @skip  # (reason="Some of these attributes are not implemented vs NP versions")
     def test_basic_missing(self):
         dt = np.float32
         for attr in [
@@ -125,6 +140,7 @@ class TestRepr(TestCase):
         expected = "iinfo(min=-32768, max=32767, dtype=int16)"
         assert_equal(repr(np.iinfo(np.int16)), expected)
 
+    @skipIf(TEST_WITH_TORCHDYNAMO, reason="repr differs")
     def test_finfo_repr(self):
         repr_f32 = repr(np.finfo(np.float32))
         assert "finfo(resolution=1e-06, min=-3.40282e+38," in repr_f32
@@ -186,7 +202,7 @@ class TestMisc(TestCase):
                 # This test may fail on some platforms
                 assert len(w) == 0
 
-    @xfail  # (reason="None of nmant, minexp, maxexp is implemented.")
+    @xpassIfTorchDynamo  # (reason="None of nmant, minexp, maxexp is implemented.")
     def test_plausible_finfo(self):
         # Assert that finfo returns reasonable results for all types
         for ftype in np.sctypes["float"] + np.sctypes["complex"]:

--- a/test/torch_np/numpy_tests/core/test_indexing.py
+++ b/test/torch_np/numpy_tests/core/test_indexing.py
@@ -12,21 +12,36 @@ from unittest import expectedFailure as xfail, skipIf as skipif, SkipTest
 
 import pytest
 
-import torch._numpy as np
 from pytest import raises as assert_raises
-from torch._numpy.testing import (
-    assert_,
-    assert_array_equal,
-    assert_equal,
-    assert_warns,
-    HAS_REFCOUNT,
-)
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
+    xfailIfTorchDynamo,
+    xpassIfTorchDynamo,
 )
+
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy.testing import (
+        assert_,
+        assert_array_equal,
+        assert_equal,
+        assert_warns,
+        HAS_REFCOUNT,
+    )
+else:
+    import torch._numpy as np
+    from torch._numpy.testing import (
+        assert_,
+        assert_array_equal,
+        assert_equal,
+        assert_warns,
+        HAS_REFCOUNT,
+    )
+
 
 skip = functools.partial(skipif, True)
 
@@ -122,15 +137,13 @@ class TestIndexing(TestCase):
         assert_equal(a[None], a[np.newaxis])
         assert_equal(a[None].ndim, a.ndim + 1)
 
+    @skip
     def test_empty_tuple_index(self):
         # Empty tuple index creates a view
         a = np.array([1, 2, 3])
         assert_equal(a[()], a)
         assert_(a[()].tensor._base is a.tensor)
         a = np.array(0)
-        raise SkipTest(
-            "torch doesn't have scalar types with distinct instancing behaviours"
-        )
         assert_(isinstance(a[()], np.int_))
 
     def test_same_kind_index_casting(self):
@@ -172,7 +185,6 @@ class TestIndexing(TestCase):
         assert_(a[...] is not a)
         assert_equal(a[...], a)
         # `a[...]` was `a` in numpy <1.9.
-        assert_(a[...].tensor._base is a.tensor)
 
         # Slicing with ellipsis can skip an
         # arbitrary number of dimensions
@@ -188,6 +200,14 @@ class TestIndexing(TestCase):
         b = np.array(1)
         b[(Ellipsis,)] = 2
         assert_equal(b, 2)
+
+    @xfailIfTorchDynamo  # numpy ndarrays do not have `.tensor` attribute
+    def test_ellipsis_index_2(self):
+        a = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        assert_(a[...] is not a)
+        assert_equal(a[...], a)
+        # `a[...]` was `a` in numpy <1.9.
+        assert_(a[...].tensor._base is a.tensor)
 
     def test_single_int_index(self):
         # Single integer index selects one row
@@ -233,6 +253,7 @@ class TestIndexing(TestCase):
         a[b] = 1.0
         assert_equal(a, [[1.0, 1.0, 1.0]])
 
+    @skip(reason="NP_VER: fails on CI")
     def test_boolean_assignment_value_mismatch(self):
         # A boolean assignment should fail when the shape of the values
         # cannot be broadcast to the subscription. (see also gh-3458)
@@ -400,7 +421,7 @@ class TestIndexing(TestCase):
         # Unlike the non nd-index:
         assert_(arr[index,].shape != (1,))
 
-    @xfail  # (reason="XXX: low-prio behaviour to support")
+    @xpassIfTorchDynamo  # (reason="XXX: low-prio behaviour to support")
     def test_broken_sequence_not_nd_index(self):
         # See https://github.com/numpy/numpy/issues/5063
         # If we have an object which claims to be a sequence, but fails
@@ -558,7 +579,7 @@ class TestBroadcastedAssignments(TestCase):
 
 
 class TestFancyIndexingCast(TestCase):
-    @xfail  # (
+    @xpassIfTorchDynamo  # (
     #    reason="XXX: low-prio to support assigning complex values on floating arrays"
     # )
     def test_boolean_index_cast_assign(self):

--- a/test/torch_np/numpy_tests/core/test_numeric.py
+++ b/test/torch_np/numpy_tests/core/test_numeric.py
@@ -7,19 +7,10 @@ import platform
 import sys
 import warnings
 
+import numpy
+
 import pytest
 
-import torch._numpy as np
-from torch._numpy.random import rand, randint, randn
-from torch._numpy.testing import (
-    assert_,
-    assert_allclose,
-    assert_almost_equal,
-    assert_array_almost_equal,
-    assert_array_equal,
-    assert_equal,
-    assert_warns,  # assert_array_max_ulp, HAS_REFCOUNT, IS_WASM
-)
 
 IS_WASM = False
 HAS_REFCOUNT = True
@@ -36,7 +27,37 @@ from torch.testing._internal.common_utils import (
     subtest,
     TEST_WITH_TORCHDYNAMO,
     TestCase,
+    xfailIfTorchDynamo,
+    xpassIfTorchDynamo,
 )
+
+# If we are going to trace through these, we should use NumPy
+# If testing on eager mode, we use torch._numpy
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy.random import rand, randint, randn
+    from numpy.testing import (
+        assert_,
+        assert_allclose,
+        assert_almost_equal,
+        assert_array_almost_equal,
+        assert_array_equal,
+        assert_equal,
+        assert_warns,  # assert_array_max_ulp, HAS_REFCOUNT, IS_WASM
+    )
+else:
+    import torch._numpy as np
+    from torch._numpy.random import rand, randint, randn
+    from torch._numpy.testing import (
+        assert_,
+        assert_allclose,
+        assert_almost_equal,
+        assert_array_almost_equal,
+        assert_array_equal,
+        assert_equal,
+        assert_warns,  # assert_array_max_ulp, HAS_REFCOUNT, IS_WASM
+    )
+
 
 skip = functools.partial(skipif, True)
 
@@ -108,7 +129,7 @@ class TestNonarrayArgs(TestCase):
         tgt = [2, 5, 2, 3, 7, 2, 2]
         assert_equal(out, tgt)
 
-    @xfail  # (reason="TODO implement compress(...)")
+    @xpassIfTorchDynamo  # (reason="TODO implement compress(...)")
     def test_compress(self):
         arr = [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]
         tgt = [[5, 6, 7, 8, 9]]
@@ -178,12 +199,12 @@ class TestNonarrayArgs(TestCase):
         s = np.float64(1.0)
         assert_equal(s.round(), 1.0)
 
-    @xfail  # (reason="scalar instances")
+    @xpassIfTorchDynamo  # (reason="scalar instances")
     def test_round_2(self):
         s = np.float64(1.0)
         assert_(isinstance(s.round(), np.float64))
 
-    @xfail  # (reason="scalar instances")
+    @xpassIfTorchDynamo  # (reason="scalar instances")
     @parametrize(
         "dtype",
         [
@@ -206,7 +227,6 @@ class TestNonarrayArgs(TestCase):
         assert_equal(round(s, None), 1)
         assert_equal(round(s, ndigits=None), 1)
 
-    @xfail  # (reason="scalar instances")
     @parametrize(
         "val, ndigits",
         [
@@ -214,8 +234,14 @@ class TestNonarrayArgs(TestCase):
             #    2**31 - 1, -1, marks=pytest.mark.xfail(reason="Out of range of int32")
             # ),
             subtest((2**31 - 1, -1), decorators=[xfail]),
-            (2**31 - 1, 1 - math.ceil(math.log10(2**31 - 1))),
-            (2**31 - 1, -math.ceil(math.log10(2**31 - 1))),
+            subtest(
+                (2**31 - 1, 1 - math.ceil(math.log10(2**31 - 1))),
+                decorators=[xpassIfTorchDynamo],
+            ),
+            subtest(
+                (2**31 - 1, -math.ceil(math.log10(2**31 - 1))),
+                decorators=[xpassIfTorchDynamo],
+            ),
         ],
     )
     def test_dunder_round_edgecases(self, val, ndigits):
@@ -318,7 +344,7 @@ class TestNonarrayArgs(TestCase):
     #      assert_(w[0].category is RuntimeWarning)
 
 
-@xfail  # (reason="TODO")
+@xpassIfTorchDynamo  # (reason="TODO")
 class TestIsscalar(TestCase):
     def test_isscalar(self):
         assert_(np.isscalar(3.1))
@@ -557,7 +583,7 @@ class TestBoolCmp(TestCase):
             assert_array_equal(np.signbit(self.signd[i:]), self.ed[i:])
 
 
-@xfail  # (reason="TODO")
+@xpassIfTorchDynamo  # (reason="TODO")
 class TestSeterr(TestCase):
     def test_default(self):
         err = np.geterr()
@@ -577,6 +603,7 @@ class TestSeterr(TestCase):
         np.seterr(**old)
         assert_(np.geterr() == old)
 
+    @xfail
     @skipif(IS_WASM, reason="no wasm fp exception support")
     @skipif(platform.machine() == "armv5tel", reason="See gh-413.")
     def test_divide_err(self):
@@ -821,7 +848,7 @@ class TestTypes(TestCase):
         # assert_equal(b, [0.0, 1.5])
         # assert_equal(b.dtype, np.dtype('f4'))
 
-    @xfail  # (reason="'Scalars do not upcast arrays' rule")
+    @xpassIfTorchDynamo  # (reason="'Scalars do not upcast arrays' rule")
     def test_coercion_2(self):
         def res_type(a, b):
             return np.add(a, b).dtype
@@ -872,7 +899,7 @@ class TestTypes(TestCase):
         # Also test keyword arguments
         assert_(np.can_cast(from_=np.int32, to=np.int64))
 
-    @xfail  # (reason="value-based casting?")
+    @xpassIfTorchDynamo  # (reason="value-based casting?")
     def test_can_cast_values(self):
         # gh-5917
         for dt in np.sctypes["int"] + np.sctypes["uint"]:
@@ -893,7 +920,8 @@ class NIterError(Exception):
     pass
 
 
-@xfail  # (reason="TODO")
+@skip(reason="NP_VER: fails on CI")
+@xpassIfTorchDynamo  # (reason="TODO")
 @instantiate_parametrized_tests
 class TestFromiter(TestCase):
     def makegen(self):
@@ -939,6 +967,7 @@ class TestFromiter(TestCase):
         with pytest.raises(NIterError):
             np.fromiter(iterable, dtype=dtype, count=count)
 
+    @skip(reason="NP_VER: fails on CI")
     def test_empty_result(self):
         class MyIter:
             def __length_hint__(self):
@@ -987,6 +1016,8 @@ class TestNonzeroAndCountNonzero(TestCase):
         assert_equal(np.count_nonzero(np.array([1], dtype="?")), 1)
         assert_equal(np.nonzero(np.array([1])), ([0],))
 
+    @xfailIfTorchDynamo  # numpy returns a python int, we return a 0D array
+    def test_nonzero_trivial_differs(self):
         assert isinstance(np.count_nonzero([]), np.ndarray)
 
     def test_nonzero_zerod(self):
@@ -996,6 +1027,8 @@ class TestNonzeroAndCountNonzero(TestCase):
         assert_equal(np.count_nonzero(np.array(1)), 1)
         assert_equal(np.count_nonzero(np.array(1, dtype="?")), 1)
 
+    @xfailIfTorchDynamo  # numpy returns a python int, we return a 0D array
+    def test_nonzero_zerod_differs(self):
         assert isinstance(np.count_nonzero(np.array(1)), np.ndarray)
 
     def test_nonzero_onedim(self):
@@ -1004,6 +1037,9 @@ class TestNonzeroAndCountNonzero(TestCase):
         assert_equal(np.count_nonzero(x), 4)
         assert_equal(np.nonzero(x), ([0, 2, 3, 6],))
 
+    @xfailIfTorchDynamo  # numpy returns a python int, we return a 0D array
+    def test_nonzero_onedim_differs(self):
+        x = np.array([1, 0, 2, -1, 0, 0, 8])
         assert isinstance(np.count_nonzero(x), np.ndarray)
 
     def test_nonzero_twodim(self):
@@ -1053,7 +1089,7 @@ class TestNonzeroAndCountNonzero(TestCase):
         assert_raises(np.AxisError, np.count_nonzero, m, axis=3)
         assert_raises(TypeError, np.count_nonzero, m, axis=np.array([[1], [2]]))
 
-    @parametrize("typecode", np.typecodes["All"])
+    @parametrize("typecode", "efdFDBbhil?")
     def test_count_nonzero_axis_all_dtypes(self, typecode):
         # More thorough test that the axis argument is respected
         # for all dtypes and responds correctly when presented with
@@ -1111,7 +1147,7 @@ class TestIndex(TestCase):
         assert_equal(c.dtype, np.dtype("int32"))
 
 
-@xfail  # (reason="TODO")
+@xpassIfTorchDynamo  # (reason="TODO")
 class TestBinaryRepr(TestCase):
     def test_zero(self):
         assert_equal(np.binary_repr(0), "0")
@@ -1149,7 +1185,7 @@ class TestBinaryRepr(TestCase):
         assert_equal(np.binary_repr(np.int64(-(2**62)), width=64), "11" + "0" * 62)
 
 
-@xfail  # (reason="TODO")
+@xpassIfTorchDynamo  # (reason="TODO")
 class TestBaseRepr(TestCase):
     def test_base3(self):
         assert_equal(np.base_repr(3**5, 3), "100000")
@@ -1361,7 +1397,7 @@ class TestClip(TestCase):
         act = self.clip(a, m, M)
         assert_array_equal(ac, act)
 
-    @xfail  # (reason="byteorder not supported in torch")
+    @xpassIfTorchDynamo  # (reason="byteorder not supported in torch")
     def test_simple_nonnative(self):
         # Test non native double input with scalar min/max.
         # Test native double input with non native double scalar min/max.
@@ -1381,7 +1417,7 @@ class TestClip(TestCase):
         act = self.clip(a, m, M)
         assert_array_equal(ac, act)
 
-    @xfail  # (reason="clamp not supported for complex")
+    @xpassIfTorchDynamo  # (reason="clamp not supported for complex")
     def test_simple_complex(self):
         # Test native complex input with native double scalar min/max.
         # Test native input with complex double scalar min/max.
@@ -1434,8 +1470,14 @@ class TestClip(TestCase):
         self.clip(a, m, M, act)
         assert_array_equal(ac, act)
 
-    @xfail  # (reason="casting not supported")
-    @parametrize("casting", [None, "unsafe"])
+    #   @xpassIfTorchDynamo  # (reason="casting not supported")
+    @parametrize(
+        "casting",
+        [
+            subtest(None, decorators=[xfail]),
+            subtest("unsafe", decorators=[xpassIfTorchDynamo]),
+        ],
+    )
     def test_simple_int32_inout(self, casting):
         # Test native int32 input with double min/max and int32 out.
         a = self._generate_int32_data(self.nr, self.nc)
@@ -1561,7 +1603,7 @@ class TestClip(TestCase):
         act = self.clip(a, m * np.zeros(a.shape), M)
         assert_array_equal(ac, act)
 
-    @xfail  # (reason="newbyteorder not supported")
+    @xpassIfTorchDynamo  # (reason="newbyteorder not supported")
     def test_type_cast_06(self):
         # Test native with NON native scalar min/max.
         a = self._generate_data(self.nr, self.nc)
@@ -1572,7 +1614,7 @@ class TestClip(TestCase):
         ac = self.fastclip(a, m_s, M)
         assert_array_equal(ac, act)
 
-    @xfail  # (reason="newbyteorder not supported")
+    @xpassIfTorchDynamo  # (reason="newbyteorder not supported")
     def test_type_cast_07(self):
         # Test NON native with native array min/max.
         a = self._generate_data(self.nr, self.nc)
@@ -1584,7 +1626,7 @@ class TestClip(TestCase):
         ac = self.fastclip(a_s, m, M)
         assert_array_equal(ac, act)
 
-    @xfail  # (reason="newbyteorder not supported")
+    @xpassIfTorchDynamo  # (reason="newbyteorder not supported")
     def test_type_cast_08(self):
         # Test NON native with native scalar min/max.
         a = self._generate_data(self.nr, self.nc)
@@ -1596,7 +1638,7 @@ class TestClip(TestCase):
         act = a_s.clip(m, M)
         assert_array_equal(ac, act)
 
-    @xfail  # (reason="newbyteorder not supported")
+    @xpassIfTorchDynamo  # (reason="newbyteorder not supported")
     def test_type_cast_09(self):
         # Test native with NON native array min/max.
         a = self._generate_data(self.nr, self.nc)
@@ -1618,7 +1660,7 @@ class TestClip(TestCase):
         ac = self.fastclip(a, m, M, out=b)
         assert_array_equal(ac, act)
 
-    @xfail  # (reason="newbyteorder not supported")
+    @xpassIfTorchDynamo  # (reason="newbyteorder not supported")
     def test_type_cast_11(self):
         # Test non native with native scalar, min/max, out non native
         a = self._generate_non_native_data(self.nr, self.nc)
@@ -2091,7 +2133,8 @@ class TestCreationFuncs(TestCase):
     # Test ones, zeros, empty and full.
 
     def setUp(self):
-        dtypes = {np.dtype(tp) for tp in itertools.chain(*np.sctypes.values())}
+        # dtypes = {np.dtype(tp) for tp in itertools.chain(*np.sctypes.values())}
+        dtypes = {np.dtype(tp) for tp in "efdFDBbhil?"}
         self.dtypes = dtypes
         self.orders = {
             "C": "c_contiguous"
@@ -2464,7 +2507,7 @@ class TestArgwhere(TestCase):
         assert_equal(np.argwhere([4, 0, 2, 1, 3]), [[0], [2], [3], [4]])
 
 
-@xfail  # (reason="TODO")
+@xpassIfTorchDynamo  # (reason="TODO")
 class TestStringFunction(TestCase):
     def test_set_string_function(self):
         a = np.array([1])
@@ -2570,7 +2613,7 @@ class TestRollaxis(TestCase):
         assert_raises(np.AxisError, np.rollaxis, a, 4, 0)
         assert_raises(np.AxisError, np.rollaxis, a, 0, 5)
 
-    @xfail  # (reason="needs fancy indexing")
+    @xpassIfTorchDynamo  # (reason="needs fancy indexing")
     def test_results(self):
         a = np.arange(1 * 2 * 3 * 4).reshape(1, 2, 3, 4).copy()
         aind = np.indices(a.shape)
@@ -2771,6 +2814,7 @@ class TestCross(TestCase):
         for axisc in range(-2, 2):
             assert_equal(np.cross(u, u, axisc=axisc).shape, (3, 4))
 
+    @skipif(numpy.__version__ < "1.24", reason="fix landed in NumPy 1.24")
     def test_uint8_int32_mixed_dtypes(self):
         # regression test for gh-19138
         u = np.array([[195, 8, 9]], np.uint8)
@@ -2827,7 +2871,7 @@ class TestIndices(TestCase):
             assert_(arr.dtype == dtype)
 
 
-@xfail  # (reason="TODO")
+@xpassIfTorchDynamo  # (reason="TODO")
 class TestRequire(TestCase):
     flag_names = [
         "C",
@@ -2894,7 +2938,7 @@ class TestRequire(TestCase):
         assert_raises(ValueError, np.require, a, None, ["C", "F"])
 
 
-@xfail  # (reason="TODO")
+@xpassIfTorchDynamo  # (reason="TODO")
 class TestBroadcast(TestCase):
     def test_broadcast_in_args(self):
         # gh-5881
@@ -2953,7 +2997,7 @@ class TestBroadcast(TestCase):
         assert_raises(ValueError, np.broadcast, 1, **{"x": 1})
 
     def test_shape_mismatch_error_message(self):
-        with pytest.raises(
+        with assert_raises(
             ValueError,
             match=r"arg 0 with shape \(1, 3\) and " r"arg 2 with shape \(2,\)",
         ):

--- a/test/torch_np/numpy_tests/core/test_numeric.py
+++ b/test/torch_np/numpy_tests/core/test_numeric.py
@@ -2996,6 +2996,7 @@ class TestBroadcast(TestCase):
 
         assert_raises(ValueError, np.broadcast, 1, **{"x": 1})
 
+    @skip(reason="error messages do not match.")
     def test_shape_mismatch_error_message(self):
         with assert_raises(
             ValueError,

--- a/test/torch_np/numpy_tests/core/test_numerictypes.py
+++ b/test/torch_np/numpy_tests/core/test_numerictypes.py
@@ -4,22 +4,30 @@ import functools
 import itertools
 import sys
 
-from unittest import expectedFailure as xfail, skipIf as skipif
+from unittest import skipIf as skipif
 
-import torch._numpy as np
 from pytest import raises as assert_raises
-from torch._numpy.testing import assert_
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
+    xpassIfTorchDynamo,
 )
+
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy.testing import assert_
+else:
+    import torch._numpy as np
+    from torch._numpy.testing import assert_
+
 
 skip = functools.partial(skipif, True)
 
 
-@xfail  # (
+@xpassIfTorchDynamo  # (
 #    reason="We do not disctinguish between scalar and array types."
 #    " Thus, scalars can upcast arrays."
 # )
@@ -101,7 +109,7 @@ class TestIsSubDType(TestCase):
         assert np.issubdtype(np.float32, "f")
 
 
-@xfail  # (
+@xpassIfTorchDynamo  # (
 #    reason="We do not have (or need) np.core.numerictypes."
 #    " Our type aliases are in _dtypes.py."
 # )

--- a/test/torch_np/numpy_tests/core/test_scalar_ctors.py
+++ b/test/torch_np/numpy_tests/core/test_scalar_ctors.py
@@ -5,25 +5,33 @@ Test the scalar constructors, which also do type-coercion
 """
 import functools
 
-from unittest import expectedFailure as xfail, skipIf as skipif
+from unittest import skipIf as skipif
 
 import pytest
 
-import torch._numpy as np
-from torch._numpy.testing import assert_almost_equal, assert_equal
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
     subtest,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
+    xpassIfTorchDynamo,
 )
+
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy.testing import assert_almost_equal, assert_equal
+else:
+    import torch._numpy as np
+    from torch._numpy.testing import assert_almost_equal, assert_equal
+
 
 skip = functools.partial(skipif, True)
 
 
 class TestFromString(TestCase):
-    @xfail  # (reason="XXX: floats from strings")
+    @xpassIfTorchDynamo  # (reason="XXX: floats from strings")
     def test_floating(self):
         # Ticket #640, floats from string
         fsingle = np.single("1.234")
@@ -31,7 +39,7 @@ class TestFromString(TestCase):
         assert_almost_equal(fsingle, 1.234)
         assert_almost_equal(fdouble, 1.234)
 
-    @xfail  # (reason="XXX: floats from strings")
+    @xpassIfTorchDynamo  # (reason="XXX: floats from strings")
     def test_floating_overflow(self):
         """Strings containing an unrepresentable float overflow"""
         fhalf = np.half("1e10000")

--- a/test/torch_np/numpy_tests/core/test_scalar_methods.py
+++ b/test/torch_np/numpy_tests/core/test_scalar_methods.py
@@ -13,15 +13,23 @@ from unittest import skipIf as skipif, SkipTest
 
 import pytest
 
-import torch._numpy as np
 from pytest import raises as assert_raises
-from torch._numpy.testing import assert_equal
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
 )
+
+
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy.testing import assert_equal
+else:
+    import torch._numpy as np
+    from torch._numpy.testing import assert_equal
+
 
 skip = functools.partial(skipif, True)
 
@@ -129,6 +137,7 @@ class TestAsIntegerRatio(TestCase):
             assert_equal(nf / df, f, f"{n}/{d}")
 
 
+@skip(reason="NP_VER: older numpies has problems with .is_integer")
 @instantiate_parametrized_tests
 class TestIsInteger(TestCase):
     @parametrize("str_value", ["inf", "nan"])
@@ -138,13 +147,15 @@ class TestIsInteger(TestCase):
         value = cls(str_value)
         assert not value.is_integer()
 
-    @parametrize("code", np.typecodes["Float"] + np.typecodes["AllInteger"])
+    @parametrize(
+        "code", "efd" + "Bbhil"
+    )  # np.typecodes["Float"] + np.typecodes["AllInteger"])
     def test_true(self, code: str) -> None:
         float_array = np.arange(-5, 5).astype(code)
         for value in float_array:
             assert value.is_integer()
 
-    @parametrize("code", np.typecodes["Float"])
+    @parametrize("code", "bhil")  # np.typecodes["Float"])
     def test_false(self, code: str) -> None:
         float_array = np.arange(-5, 5).astype(code)
         float_array *= 1.1

--- a/test/torch_np/numpy_tests/core/test_scalarmath.py
+++ b/test/torch_np/numpy_tests/core/test_scalarmath.py
@@ -9,31 +9,47 @@ import warnings
 
 from unittest import expectedFailure as xfail, skipIf as skipif, SkipTest
 
+import numpy
+
 # from numpy._utils import _pep440
 import pytest
+from pytest import raises as assert_raises
 
 # from hypothesis import given, settings
 # from hypothesis.strategies import sampled_from
 # from hypothesis.extra import numpy as hynp
 
-import torch._numpy as np
-from pytest import raises as assert_raises
-from torch._numpy.testing import (
-    _gen_alignment_data,
-    assert_,
-    assert_almost_equal,
-    assert_equal,
-    #    assert_array_equal, suppress_warnings, _gen_alignment_data,
-    #    assert_warns,
-)
+
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
     slowTest as slow,
     subtest,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
+    xpassIfTorchDynamo,
 )
+
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy.testing import (
+        _gen_alignment_data,
+        assert_,
+        assert_almost_equal,
+        assert_equal,
+    )
+else:
+    import torch._numpy as np
+    from torch._numpy.testing import (
+        _gen_alignment_data,
+        assert_,
+        assert_almost_equal,
+        assert_equal,
+        #    assert_array_equal, suppress_warnings, _gen_alignment_data,
+        #    assert_warns,
+    )
+
 
 skip = functools.partial(skipif, True)
 
@@ -155,7 +171,7 @@ class TestBaseMath(TestCase):
                 np.add(2, inp2, out=out)
                 assert_almost_equal(out, exp1 + 2, err_msg=msg)
 
-    @xfail  # (reason="pytorch does not have .view")
+    @xpassIfTorchDynamo  # (reason="pytorch does not have .view")
     def test_lower_align(self):
         # check data that is not aligned to element size
         # i.e doubles are aligned to 4 bytes on i386
@@ -186,7 +202,8 @@ class TestPower(TestCase):
             else:
                 assert_almost_equal(b, 6765201, err_msg=msg)
 
-    @xfail  # (reason="Value-based casting: (2)**(-2) -> 0 in pytorch.")
+    @skip(reason="NP_VER: fails on CI on older NumPy")
+    @xpassIfTorchDynamo  # (reason="Value-based casting: (2)**(-2) -> 0 in pytorch.")
     def test_integers_to_negative_integer_power(self):
         # Note that the combination of uint64 with a signed integer
         # has common type np.float64. The other combinations should all
@@ -272,7 +289,8 @@ def _signs(dt):
 @instantiate_parametrized_tests
 class TestModulus(TestCase):
     def test_modulus_basic(self):
-        dt = np.typecodes["AllInteger"] + np.typecodes["Float"]
+        # dt = np.typecodes["AllInteger"] + np.typecodes["Float"]
+        dt = "Bbhil" + "efd"
         for op in [floordiv_and_mod, divmod]:
             for dt1, dt2 in itertools.product(dt, dt):
                 for sg1, sg2 in itertools.product(_signs(dt1), _signs(dt2)):
@@ -317,7 +335,8 @@ class TestModulus(TestCase):
 
     def test_float_modulus_roundoff(self):
         # gh-6127
-        dt = np.typecodes["Float"]
+        # dt = np.typecodes["Float"]
+        dt = "efd"
         for op in [floordiv_and_mod, divmod]:
             for dt1, dt2 in itertools.product(dt, dt):
                 for sg1, sg2 in itertools.product((+1, -1), (+1, -1)):
@@ -333,7 +352,7 @@ class TestModulus(TestCase):
                     else:
                         assert_(b > rem >= 0, msg)
 
-    @parametrize("dt", np.typecodes["Float"])
+    @parametrize("dt", "efd")
     def test_float_modulus_corner_cases(self, dt):
         if dt == "e":
             # FIXME: make xfail
@@ -353,7 +372,7 @@ class TestModulus(TestCase):
         #         sup.filter(RuntimeWarning, "divide by zero encountered in floor_divide")
         #         sup.filter(RuntimeWarning, "divide by zero encountered in divmod")
         #         sup.filter(RuntimeWarning, "invalid value encountered in divmod")
-        for dt in np.typecodes["Float"]:
+        for dt in "efd":
             fone = np.array(1.0, dtype=dt)
             fzer = np.array(0.0, dtype=dt)
             finf = np.array(np.inf, dtype=dt)
@@ -451,7 +470,8 @@ class TestConversion(TestCase):
             a = np.array(l, dtype=T)
             assert_equal([int(_m) for _m in a], li)
 
-    @xfail  # (reason="pytorch does not emit this warning.")
+    @skipif(numpy.__version__ < "1.24", reason="NP_VER: fails on NumPy 1.23.x")
+    @xpassIfTorchDynamo  # (reason="pytorch does not emit this warning.")
     def test_iinfo_long_values_1(self):
         for code in "bBh":
             with pytest.warns(DeprecationWarning):
@@ -475,7 +495,7 @@ class TestConversion(TestCase):
             dtype(np.iinfo(dtype).max + 1)
 
         for code in [np.int_, np.longlong]:
-            assert_raises(RuntimeError, overflow_error_func, code)
+            assert_raises((OverflowError, RuntimeError), overflow_error_func, code)
 
     def test_numpy_scalar_relational_operators(self):
         # All integer
@@ -554,7 +574,7 @@ class TestConversion(TestCase):
 #            assert_equal( val, val2 )
 
 
-@xfail  # (reason="can delegate repr to pytorch")
+@xpassIfTorchDynamo  # (reason="can delegate repr to pytorch")
 class TestRepr(TestCase):
     def _test_type_repr(self, t):
         finfo = np.finfo(t)
@@ -789,7 +809,7 @@ def recursionlimit(n):
 @instantiate_parametrized_tests
 class TestScalarOpsMisc(TestCase):
     @xfail  # (reason="pytorch does not warn on overflow")
-    @parametrize("dtype", np.typecodes["AllInteger"])
+    @parametrize("dtype", "Bbhil")
     @parametrize(
         "operation",
         [
@@ -807,7 +827,7 @@ class TestScalarOpsMisc(TestCase):
             operation(min, max)
 
     @skip(reason="integer overflow UB: crashes pytorch under ASAN")
-    @parametrize("dtype", np.typecodes["Integer"])
+    @parametrize("dtype", "bhil")
     @parametrize(
         "operation",
         [
@@ -829,8 +849,9 @@ class TestScalarOpsMisc(TestCase):
         with pytest.warns(RuntimeWarning, match="overflow encountered"):
             operation(min, neg_1)
 
-    @xfail  # (reason="pytorch does not warn on overflow")
-    @parametrize("dtype", np.typecodes["UnsignedInteger"])
+    @skipif(numpy.__version__ < "1.24", reason="NP_VER: fails on NumPy 1.23.x")
+    @xpassIfTorchDynamo  # (reason="pytorch does not warn on overflow")
+    @parametrize("dtype", "B")
     def test_scalar_unsigned_integer_overflow(self, dtype):
         val = np.dtype(dtype).type(8)
         with pytest.warns(RuntimeWarning, match="overflow encountered"):

--- a/test/torch_np/numpy_tests/core/test_shape_base.py
+++ b/test/torch_np/numpy_tests/core/test_shape_base.py
@@ -4,29 +4,53 @@ import functools
 
 from unittest import expectedFailure as xfail, skipIf as skipif
 
-import pytest
+import numpy
 
-import torch._numpy as np
+import pytest
 from pytest import raises as assert_raises
-from torch._numpy import (
-    array,
-    atleast_1d,
-    atleast_2d,
-    atleast_3d,
-    AxisError,
-    concatenate,
-    hstack,
-    newaxis,
-    stack,
-    vstack,
-)
-from torch._numpy.testing import assert_, assert_array_equal, assert_equal
+
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
+    xpassIfTorchDynamo,
 )
+
+# If we are going to trace through these, we should use NumPy
+# If testing on eager mode, we use torch._numpy
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy import (
+        array,
+        atleast_1d,
+        atleast_2d,
+        atleast_3d,
+        AxisError,
+        concatenate,
+        hstack,
+        newaxis,
+        stack,
+        vstack,
+    )
+    from numpy.testing import assert_, assert_array_equal, assert_equal
+else:
+    import torch._numpy as np
+    from torch._numpy import (
+        array,
+        atleast_1d,
+        atleast_2d,
+        atleast_3d,
+        AxisError,
+        concatenate,
+        hstack,
+        newaxis,
+        stack,
+        vstack,
+    )
+    from torch._numpy.testing import assert_, assert_array_equal, assert_equal
+
 
 skip = functools.partial(skipif, True)
 
@@ -178,6 +202,7 @@ class TestHstack(TestCase):
         # with assert_warns(FutureWarning):
         hstack(x for x in np.ones((3, 2)))
 
+    @skipif(numpy.__version__ < "1.24", reason="NP_VER: fails on NumPy 1.23.x")
     def test_casting_and_dtype(self):
         a = np.array([1, 2, 3])
         b = np.array([2.5, 3.5, 4.5])
@@ -232,6 +257,7 @@ class TestVstack(TestCase):
         with pytest.raises(TypeError, match="arrays to stack must be"):
             vstack(np.arange(3) for _ in range(2))
 
+    @skipif(numpy.__version__ < "1.24", reason="casting kwarg is new in NumPy 1.24")
     def test_casting_and_dtype(self):
         a = np.array([1, 2, 3])
         b = np.array([2.5, 3.5, 4.5])
@@ -239,6 +265,7 @@ class TestVstack(TestCase):
         expected_res = np.array([[1, 2, 3], [2, 3, 4]])
         assert_array_equal(res, expected_res)
 
+    @skipif(numpy.__version__ < "1.24", reason="casting kwarg is new in NumPy 1.24")
     def test_casting_and_dtype_type_error(self):
         a = np.array([1, 2, 3])
         b = np.array([2.5, 3.5, 4.5])
@@ -332,7 +359,7 @@ class TestConcatenate(TestCase):
         assert out is rout
         assert np.all(r == rout)
 
-    @xfail  # (reason="concatenate(x, axis=None) relies on x being a sequence")
+    @xpassIfTorchDynamo  # (reason="concatenate(x, axis=None) relies on x being a sequence")
     def test_large_concatenate_axis_None(self):
         # When no axis is given, concatenate uses flattened versions.
         # This also had a bug with many arrays (see gh-5979).
@@ -442,6 +469,7 @@ class TestConcatenate(TestCase):
 
 @instantiate_parametrized_tests
 class TestStackMisc(TestCase):
+    @skipif(numpy.__version__ < "1.24", reason="NP_VER: fails on NumPy 1.23.x")
     def test_stack(self):
         # non-iterable input
         assert_raises(TypeError, stack, 1)
@@ -523,6 +551,7 @@ class TestStackMisc(TestCase):
         with assert_raises(TypeError):
             stack((a, b), dtype=np.int64, axis=1, casting="safe")
 
+    @skipif(numpy.__version__ < "1.24", reason="NP_VER: fails on NumPy 1.23.x")
     @parametrize("axis", [0])
     @parametrize("out_dtype", ["c8", "f4", "f8", "i8"])  # torch does not have ">f8",
     @parametrize("casting", ["no", "equiv", "safe", "same_kind", "unsafe"])


### PR DESCRIPTION
A follow-up to https://github.com/pytorch/pytorch/pull/112084: convert vendored numpy/core submodule tests dynamo-traceable.


cc @mruberry @rgommers @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng