### PR TITLE
Make numpy fft and linalg tests Dynamo traceable

### DIFF
--- a/test/torch_np/numpy_tests/fft/test_helper.py
+++ b/test/torch_np/numpy_tests/fft/test_helper.py
@@ -5,10 +5,20 @@
 Copied from fftpack.helper by Pearu Peterson, October 2005
 
 """
-import torch._numpy as np
-from torch._numpy import fft, pi
-from torch._numpy.testing import assert_array_almost_equal
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    run_tests,
+    TEST_WITH_TORCHDYNAMO,
+    TestCase,
+)
+
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy import fft, pi
+    from numpy.testing import assert_array_almost_equal
+else:
+    import torch._numpy as np
+    from torch._numpy import fft, pi
+    from torch._numpy.testing import assert_array_almost_equal
 
 
 class TestFFTShift(TestCase):
@@ -73,7 +83,10 @@ class TestFFTShift(TestCase):
 
     def test_equal_to_original(self):
         """Test that the new (>=v1.15) implementation (see #10073) is equal to the original (<=v1.14)"""
-        from torch._numpy import arange, asarray, concatenate, take
+        if TEST_WITH_TORCHDYNAMO:
+            from numpy import arange, asarray, concatenate, take
+        else:
+            from torch._numpy import arange, asarray, concatenate, take
 
         def original_fftshift(x, axes=None):
             """How fftshift was implemented in v1.14"""

--- a/test/torch_np/numpy_tests/fft/test_pocketfft.py
+++ b/test/torch_np/numpy_tests/fft/test_pocketfft.py
@@ -6,18 +6,25 @@ import threading
 from unittest import skipIf as skipif, SkipTest
 
 import pytest
-import torch._numpy as np
 from pytest import raises as assert_raises
 
-from torch._numpy.random import random
-
-from torch._numpy.testing import assert_allclose, assert_array_equal  # , IS_WASM
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
 )
+
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy.random import random
+    from numpy.testing import assert_allclose  # , IS_WASM
+else:
+    import torch._numpy as np
+    from torch._numpy.random import random
+    from torch._numpy.testing import assert_allclose  # , IS_WASM
+
 
 skip = functools.partial(skipif, True)
 
@@ -62,10 +69,10 @@ class TestFFT1D(TestCase):
     def test_ifft(self, norm):
         x = random(30) + 1j * random(30)
         assert_allclose(x, np.fft.ifft(np.fft.fft(x, norm=norm), norm=norm), atol=1e-6)
+
         # Ensure we get the correct error message
-        with pytest.raises(
-            (ValueError, RuntimeError), match="Invalid number of data points"
-        ):
+        # NB: Exact wording differs slightly under Dynamo and in eager.
+        with pytest.raises((ValueError, RuntimeError), match="Invalid number of"):
             np.fft.ifft([], norm=norm)
 
     def test_fft2(self):
@@ -358,10 +365,13 @@ class TestFFTThreadSafe(TestCase):
         [x.join() for x in t]
         # Make sure all threads returned the correct value
         for i in range(self.threads):
-            assert_array_equal(
+            # under torch.dynamo `assert_array_equal` fails with relative errors of
+            # about 1.5e-14. Hence replace it with `assert_allclose(..., rtol=2e-14)`
+            assert_allclose(
                 q.get(timeout=5),
                 expected,
-                "Function returned wrong value in multithreaded context",
+                atol=2e-14
+                # msg="Function returned wrong value in multithreaded context",
             )
 
     def test_fft(self):

--- a/test/torch_np/numpy_tests/linalg/test_linalg.py
+++ b/test/torch_np/numpy_tests/linalg/test_linalg.py
@@ -15,45 +15,85 @@ from unittest import expectedFailure as xfail, skipIf as skipif, SkipTest
 
 import pytest
 
-import torch._numpy as np
 from numpy.linalg.linalg import _multi_dot_matrix_chain_order
 from pytest import raises as assert_raises
-from torch._numpy import (
-    array,
-    asarray,
-    atleast_2d,
-    cdouble,
-    csingle,
-    dot,
-    double,
-    identity,
-    inf,
-    linalg,
-    matmul,
-    single,
-    swapaxes,
-)
-from torch._numpy.linalg import LinAlgError, matrix_power, matrix_rank, multi_dot, norm
-from torch._numpy.testing import (
-    assert_,
-    assert_allclose,
-    assert_almost_equal,
-    assert_array_equal,
-    assert_equal,
-    suppress_warnings,
-    #  assert_raises_regex, HAS_LAPACK64, IS_WASM
-)
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    slowTest as slow,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
+    xpassIfTorchDynamo,
 )
 
-skip = functools.partial(skipif, True)
 
-# FIXME: slow tests have never run (= are broken)
-slow = skip
+# If we are going to trace through these, we should use NumPy
+# If testing on eager mode, we use torch._numpy
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy import (
+        array,
+        asarray,
+        atleast_2d,
+        cdouble,
+        csingle,
+        dot,
+        double,
+        identity,
+        inf,
+        linalg,
+        matmul,
+        single,
+        swapaxes,
+    )
+    from numpy.linalg import LinAlgError, matrix_power, matrix_rank, multi_dot, norm
+    from numpy.testing import (
+        assert_,
+        assert_allclose,
+        assert_almost_equal,
+        assert_array_equal,
+        assert_equal,
+        suppress_warnings,
+        #  assert_raises_regex, HAS_LAPACK64, IS_WASM
+    )
+
+else:
+    import torch._numpy as np
+    from torch._numpy import (
+        array,
+        asarray,
+        atleast_2d,
+        cdouble,
+        csingle,
+        dot,
+        double,
+        identity,
+        inf,
+        linalg,
+        matmul,
+        single,
+        swapaxes,
+    )
+    from torch._numpy.linalg import (
+        LinAlgError,
+        matrix_power,
+        matrix_rank,
+        multi_dot,
+        norm,
+    )
+    from torch._numpy.testing import (
+        assert_,
+        assert_allclose,
+        assert_almost_equal,
+        assert_array_equal,
+        assert_equal,
+        suppress_warnings,
+        #  assert_raises_regex, HAS_LAPACK64, IS_WASM
+    )
+
+
+skip = functools.partial(skipif, True)
 
 IS_WASM = False
 HAS_LAPACK64 = False
@@ -307,11 +347,11 @@ def _make_generalized_cases():
         if not isinstance(case.a, np.ndarray):
             continue
 
-        a = np.array([case.a, 2 * case.a, 3 * case.a])
+        a = np.stack([case.a, 2 * case.a, 3 * case.a])
         if case.b is None:
             b = None
         else:
-            b = np.array([case.b, 7 * case.b, 6 * case.b])
+            b = np.stack([case.b, 7 * case.b, 6 * case.b])
         new_case = LinalgCase(
             case.name + "_tile3", a, b, tags=case.tags | {"generalized"}
         )
@@ -408,7 +448,6 @@ class LinalgGeneralizedNonsquareTestCase(LinalgTestCase):
 
 
 class HermitianGeneralizedTestCase(LinalgTestCase):
-    @xfail  # (reason="sort complex")
     @slow
     def test_generalized_herm_cases(self):
         self.check_cases(require={"generalized", "hermitian"}, exclude={"size-0"})
@@ -802,7 +841,7 @@ class TestCond(CondCases, TestCase):
         for A, p in itertools.product(As, p_neg):
             linalg.cond(A, p)
 
-    @xfail  # (
+    @skip(reason="NP_VER: fails on CI")  # (
     #    True, run=False, reason="Platform/LAPACK-dependent failure, see gh-18914"
     # )
     def test_nan(self):
@@ -890,7 +929,7 @@ class DetCases(LinalgSquareTestCase, LinalgGeneralizedSquareTestCase):
             ad = asarray(a).astype(cdouble)
         ev = linalg.eigvals(ad)
         assert_almost_equal(d, np.prod(ev, axis=-1))
-        assert_almost_equal(s * np.exp(ld), np.prod(ev, axis=-1))
+        assert_almost_equal(s * np.exp(ld), np.prod(ev, axis=-1), single_decimal=5)
 
         s = np.atleast_1d(s)
         ld = np.atleast_1d(ld)
@@ -976,7 +1015,7 @@ class LstsqCases(LinalgSquareTestCase, LinalgNonsquareTestCase):
 
 @instantiate_parametrized_tests
 class TestLstsq(LstsqCases, TestCase):
-    @xfail  # (reason="Lstsq: we use the future default =None")
+    @xpassIfTorchDynamo  # (reason="Lstsq: we use the future default =None")
     def test_future_rcond(self):
         a = np.array(
             [
@@ -1306,8 +1345,8 @@ class _TestNormGeneral(_TestNormBase):
     def test_vector_return_type(self):
         a = np.array([1, 0, 1])
 
-        exact_types = np.typecodes["AllInteger"]
-        inexact_types = np.typecodes["AllFloat"]
+        exact_types = "Bbhil"  # np.typecodes["AllInteger"]
+        inexact_types = "efdFD"  # np.typecodes["AllFloat"]
 
         all_types = exact_types + inexact_types
 
@@ -1485,7 +1524,7 @@ class _TestNorm2D(_TestNormBase):
     def test_matrix_return_type(self):
         a = np.array([[1, 0, 1], [0, 1, 1]])
 
-        exact_types = np.typecodes["AllInteger"]
+        exact_types = "Bbhil"  # np.typecodes["AllInteger"]
 
         # float32, complex64, float64, complex128 types are the only types
         # allowed by `linalg`, which performs the matrix operations used
@@ -1721,7 +1760,7 @@ class TestQR(TestCase):
         assert_(isinstance(r2, a_type))
         assert_almost_equal(r2, r1)
 
-    @xfail  # (reason="torch does not allow qr(..., mode='raw'")
+    @xpassIfTorchDynamo  # (reason="torch does not allow qr(..., mode='raw'")
     @parametrize("m, n", [(3, 0), (0, 3), (0, 0)])
     def test_qr_empty(self, m, n):
         k = min(m, n)
@@ -1735,7 +1774,7 @@ class TestQR(TestCase):
         assert_equal(h.shape, (n, m))
         assert_equal(tau.shape, (k,))
 
-    @xfail  # (reason="torch does not allow qr(..., mode='raw'")
+    @xpassIfTorchDynamo  # (reason="torch does not allow qr(..., mode='raw'")
     def test_mode_raw(self):
         # The factorization is not unique and varies between libraries,
         # so it is not possible to check against known values. Functional
@@ -1870,7 +1909,7 @@ class TestCholesky(TestCase):
 
 
 class TestMisc(TestCase):
-    @xfail  # (reason="endianness")
+    @xpassIfTorchDynamo  # (reason="endianness")
     def test_byteorder_check(self):
         # Byte order check should pass for native order
         if sys.byteorder == "little":
@@ -2205,7 +2244,7 @@ class TestTensorsolve(TestCase):
 
 
 class TestMisc2(TestCase):
-    @xfail  # (reason="TODO")
+    @xpassIfTorchDynamo  # (reason="TODO")
     def test_unsupported_commontype(self):
         # linalg gracefully handles unsupported type
         arr = np.array([[1, -2], [2, 5]], dtype="float16")
@@ -2213,7 +2252,6 @@ class TestMisc2(TestCase):
         with assert_raises(TypeError):
             linalg.cholesky(arr)
 
-    @xfail  # (reason="TODO")
     # @slow
     # @pytest.mark.xfail(not HAS_LAPACK64, run=False,
     #                   reason="Numpy not compiled with 64-bit BLAS/LAPACK")

--- a/test/torch_np/numpy_tests/linalg/test_linalg.py
+++ b/test/torch_np/numpy_tests/linalg/test_linalg.py
@@ -13,6 +13,8 @@ import traceback
 
 from unittest import expectedFailure as xfail, skipIf as skipif, SkipTest
 
+import numpy
+
 import pytest
 
 from numpy.linalg.linalg import _multi_dot_matrix_chain_order
@@ -1856,6 +1858,7 @@ class TestQR(TestCase):
         assert_(isinstance(r2, a_type))
         assert_almost_equal(r2, r1)
 
+    @skipif(numpy.__version__ < "1.22", reason="NP_VER: fails on CI with numpy 1.21.2")
     @parametrize("size", [(3, 4), (4, 3), (4, 4), (3, 0), (0, 3)])
     @parametrize("outer_size", [(2, 2), (2,), (2, 3, 4)])
     @parametrize("dt", [np.single, np.double, np.csingle, np.cdouble])
@@ -2232,6 +2235,7 @@ class TestTensorsolve(TestCase):
             b = np.ones(a.shape[:2])
             linalg.tensorsolve(a, b, axes=axes)
 
+    @skipif(numpy.__version__ < "1.22", reason="NP_VER: fails on CI with numpy 1.21.2")
     @parametrize(
         "shape",
         [(2, 3, 6), (3, 4, 4, 3), (0, 3, 3, 0)],


### PR DESCRIPTION
Follow up https://github.com/pytorch/pytorch/pull/112141 and make numpy vendored tests of fft and linalg modules dynamo-traceable.


cc @mruberry @rgommers @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng