### PR TITLE
Make numpy/lib vendored tests dynamo traceable

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -13,3 +13,5 @@ testpaths =
 junit_logging_reruns = all
 filterwarnings =
     ignore:Module already imported so cannot be rewritten.*hypothesis:pytest.PytestAssertRewriteWarning
+
+xfail_strict = True

--- a/test/torch_np/numpy_tests/lib/test_arraypad.py
+++ b/test/torch_np/numpy_tests/lib/test_arraypad.py
@@ -1,15 +1,27 @@
 # Owner(s): ["module: dynamo"]
 
-from unittest import expectedFailure as xfail, skipIf as skipif
+from unittest import skipIf as skipif
 
-import torch._numpy as np
-from torch._numpy.testing import assert_allclose, assert_array_equal
+from torch.testing._internal.common_utils import (
+    run_tests,
+    TEST_WITH_TORCHDYNAMO,
+    TestCase,
+    xpassIfTorchDynamo,
+)
 
-from torch.testing._internal.common_utils import run_tests, TestCase
+
+# If we are going to trace through these, we should use NumPy
+# If testing on eager mode, we use torch._numpy
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy.testing import assert_allclose, assert_array_equal
+else:
+    import torch._numpy as np
+    from torch._numpy.testing import assert_allclose, assert_array_equal
 
 
 class TestConstant(TestCase):
-    @xfail  # (reason="tuple values")
+    @xpassIfTorchDynamo  # (reason="tuple values")
     def test_check_constant(self):
         a = np.arange(100)
         a = np.pad(a, (25, 20), "constant", constant_values=(10, 20))
@@ -357,7 +369,7 @@ class TestConstant(TestCase):
         )
         assert_allclose(test, expected)
 
-    @xfail  # (reason="tuple values")
+    @xpassIfTorchDynamo  # (reason="tuple values")
     def test_check_constant_float3(self):
         a = np.arange(100, dtype=float)
         a = np.pad(a, (25, 20), "constant", constant_values=(-1.1, -1.2))
@@ -528,7 +540,7 @@ class TestConstant(TestCase):
         )
         assert_allclose(test, expected)
 
-    @xfail  # (reason="tuple values")
+    @xpassIfTorchDynamo  # (reason="tuple values")
     def test_check_constant_pad_2d(self):
         arr = np.arange(4).reshape(2, 2)
         test = np.lib.pad(

--- a/test/torch_np/numpy_tests/lib/test_arraysetops.py
+++ b/test/torch_np/numpy_tests/lib/test_arraysetops.py
@@ -3,24 +3,39 @@
 """Test functions for 1D array set operations.
 
 """
-from unittest import expectedFailure as xfail
+from unittest import skipIf
 
-import torch._numpy as np
+import numpy
+
 from pytest import raises as assert_raises
-
-from torch._numpy import unique
-
-from torch._numpy.testing import assert_array_equal, assert_equal
 
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    subtest,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
+    xfailIfTorchDynamo,
+    xpassIfTorchDynamo,
 )
 
 
-@xfail  # (reason="TODO")
+# If we are going to trace through these, we should use NumPy
+# If testing on eager mode, we use torch._numpy
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy import ediff1d, in1d, intersect1d, setdiff1d, setxor1d, union1d, unique
+    from numpy.testing import assert_array_equal, assert_equal, assert_raises_regex
+
+else:
+    import torch._numpy as np
+    from torch._numpy import unique
+    from torch._numpy.testing import assert_array_equal, assert_equal
+
+
+@skipIf(numpy.__version__ < "1.24", reason="NP_VER: fails on NumPy 1.23.x")
+@xpassIfTorchDynamo  # (reason="TODO")
 @instantiate_parametrized_tests
 class TestSetOps(TestCase):
     def test_intersect1d(self):
@@ -145,11 +160,14 @@ class TestSetOps(TestCase):
             (np.array([1, 2, 3], dtype=np.int64), None, np.nan, "to_end"),
             # should fail because attempting
             # to downcast to int type:
-            (
-                np.array([1, 2, 3], dtype=np.int64),
-                np.array([5, 7, 2], dtype=np.float32),
-                None,
-                "to_begin",
+            subtest(
+                (
+                    np.array([1, 2, 3], dtype=np.int64),
+                    np.array([5, 7, 2], dtype=np.float32),
+                    None,
+                    "to_begin",
+                ),
+                decorators=[xfailIfTorchDynamo],
             ),
             # should fail because attempting to cast
             # two special floating point values
@@ -205,6 +223,7 @@ class TestSetOps(TestCase):
         assert_equal(actual, expected)
         assert actual.dtype == expected.dtype
 
+    @skipIf(True, reason="NP_VER: fails with NumPy 1.22.x")
     @parametrize("kind", [None, "sort", "table"])
     def test_isin(self, kind):
         # the tests for in1d cover most of isin's behavior
@@ -217,7 +236,7 @@ class TestSetOps(TestCase):
         isin_slow = np.vectorize(_isin_slow, otypes=[bool], excluded={1})
 
         def assert_isin_equal(a, b):
-            x = isin(a, b, kind=kind)
+            x = np.isin(a, b, kind=kind)
             y = isin_slow(a, b)
             assert_array_equal(x, y)
 
@@ -444,7 +463,7 @@ class TestSetOps(TestCase):
         a = np.array([0, 1, 2], dtype="timedelta64[s]")
         b = a
         # Make sure it raises a value error:
-        with pytest.raises(ValueError):
+        with assert_raises(ValueError):
             in1d(a, b, kind="table")
 
     @parametrize(
@@ -475,7 +494,7 @@ class TestSetOps(TestCase):
         )
 
         if expect_failure:
-            with pytest.raises(RuntimeError, match="exceed the maximum"):
+            with assert_raises(RuntimeError, match="exceed the maximum"):
                 in1d(ar1, ar2, kind=kind)
         else:
             assert_array_equal(in1d(ar1, ar2, kind=kind), expected)
@@ -744,7 +763,7 @@ class TestUnique(TestCase):
     #    assert_equal(a3_idx.dtype, np.intp)
     #    assert_equal(a3_inv.dtype, np.intp)
 
-    @xfail  # (reason="unique with nans")
+    @xpassIfTorchDynamo  # (reason="unique with nans")
     def test_unique_1d_2(self):
         # test for ticket 2111 - float
         a = [2.0, np.nan, 1.0, np.nan]
@@ -790,7 +809,7 @@ class TestUnique(TestCase):
         assert_array_equal(unique(inp, axis=0), unique(inp_arr, axis=0), msg)
         assert_array_equal(unique(inp, axis=1), unique(inp_arr, axis=1), msg)
 
-    @xfail  # _run_axis_tests xfails with the message
+    @xpassIfTorchDynamo  # _run_axis_tests xfails with the message
     #   torch has different unique ordering behaviour"
     def test_unique_axis(self):
         types = []
@@ -816,7 +835,7 @@ class TestUnique(TestCase):
         uniq = unique(x, axis=axis)
         assert_array_equal(uniq, [1, 2, 3, 4])
 
-    @xfail  # (reason="unique / return_index")
+    @xpassIfTorchDynamo  # (reason="unique / return_index")
     def test_unique_axis_zeros(self):
         # issue 15559
         single_zero = np.empty(shape=(2, 0), dtype=np.int8)
@@ -923,7 +942,8 @@ class TestUnique(TestCase):
         msg = "Unique's return_counts=True failed with axis=1"
         assert_array_equal(cnt, np.array([2, 1, 1]), msg)
 
-    @xfail  # (reason="unique / return_index / nans")
+    @skipIf(True, reason="NP_VER: fails on CI with older NumPy")
+    @xpassIfTorchDynamo  # (reason="unique / return_index / nans")
     def test_unique_nanequals(self):
         # issue 20326
         a = np.array([1, 1, np.nan, np.nan, np.nan])

--- a/test/torch_np/numpy_tests/lib/test_function_base.py
+++ b/test/torch_np/numpy_tests/lib/test_function_base.py
@@ -2947,6 +2947,7 @@ class TestPercentile(TestCase):
         x = np.arange(8) * 0.5
         assert_equal(np.percentile(x, [0, 100, 50]), [0, 3.5, 1.75])
 
+    @skip(reason="NP_VER: fails on CI")
     def test_axis(self):
         x = np.arange(12).reshape(3, 4)
 

--- a/test/torch_np/numpy_tests/lib/test_function_base.py
+++ b/test/torch_np/numpy_tests/lib/test_function_base.py
@@ -2808,7 +2808,6 @@ class TestInterp(TestCase):
 
 @instantiate_parametrized_tests
 class TestPercentile(TestCase):
-
     @skip(reason="NP_VER: fails on CI; no method=")
     def test_basic(self):
         x = np.arange(8) * 0.5
@@ -2992,6 +2991,7 @@ class TestPercentile(TestCase):
             np.percentile(x, (25, 50, 75), axis=1, method="higher").shape, (3, 3, 5, 6)
         )
 
+    @skipif(numpy.__version__ < "1.22", reason="NP_VER: fails with NumPy 1.21.2 on CI")
     def test_scalar_q(self):
         # test for no empty dimensions for compatibility with old percentile
         x = np.arange(12).reshape(3, 4)
@@ -3470,6 +3470,7 @@ class TestQuantile(TestCase):
         arr_c = np.array([0.5 + 3.0j, 2.1 + 0.5j, 1.6 + 2.3j], dtype="F")
         assert_raises(TypeError, np.quantile, arr_c, 0.5)
 
+    @skipif(numpy.__version__ < "1.22", reason="NP_VER: fails with NumPy 1.21.2 on CI")
     def test_no_p_overwrite(self):
         # this is worth retesting, because quantile does not make a copy
         p0 = np.array([0, 0.75, 0.25, 0.5, 1.0])
@@ -3482,12 +3483,14 @@ class TestQuantile(TestCase):
         np.quantile(np.arange(100.0), p, method="midpoint")
         assert_array_equal(p, p0)
 
+    @skipif(numpy.__version__ < "1.22", reason="NP_VER: fails with NumPy 1.21.2 on CI")
     @xpassIfTorchDynamo  # (reason="TODO: make quantile preserve integers")
     @parametrize("dtype", "Bbhil")  # np.typecodes["AllInteger"])
     def test_quantile_preserve_int_type(self, dtype):
         res = np.quantile(np.array([1, 2], dtype=dtype), [0.5], method="nearest")
         assert res.dtype == dtype
 
+    @skipif(numpy.__version__ < "1.22", reason="NP_VER: fails with NumPy 1.21.2 on CI")
     @parametrize(
         "method",
         [

--- a/test/torch_np/numpy_tests/lib/test_function_base.py
+++ b/test/torch_np/numpy_tests/lib/test_function_base.py
@@ -11,29 +11,21 @@ from unittest import expectedFailure as xfail, skipIf as skipif
 
 import hypothesis
 import hypothesis.strategies as st
-import pytest
 
-import torch._numpy as np
+import numpy
+
+import pytest
 from hypothesis.extra.numpy import arrays
 from pytest import raises as assert_raises
 
-from torch._numpy.testing import (
-    assert_,
-    assert_allclose,  # IS_PYPY,
-    assert_almost_equal,
-    assert_array_almost_equal,
-    assert_array_equal,
-    assert_equal,
-    assert_raises_regex,
-    assert_warns,
-    suppress_warnings,  # HAS_REFCOUNT, IS_WASM
-)
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
     subtest,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
+    xpassIfTorchDynamo,
 )
 
 skip = functools.partial(skipif, True)
@@ -47,25 +39,79 @@ IS_PYPY = False
 # from numpy lib import digitize, piecewise, trapz, select, trim_zeros, interp
 from numpy.lib import delete, extract, insert, msort, place, setxor1d, unwrap, vectorize
 
-from torch._numpy import (
-    angle,
-    bartlett,
-    blackman,
-    corrcoef,
-    cov,
-    diff,
-    flipud,
-    gradient,
-    hamming,
-    hanning,
-    i0,
-    kaiser,
-    meshgrid,
-    sinc,
-    unique,
-)
-from torch._numpy._util import normalize_axis_tuple
-from torch._numpy.random import rand
+
+# If we are going to trace through these, we should use NumPy
+# If testing on eager mode, we use torch._numpy
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy import (
+        angle,
+        bartlett,
+        blackman,
+        corrcoef,
+        cov,
+        diff,
+        digitize,
+        flipud,
+        gradient,
+        hamming,
+        hanning,
+        i0,
+        interp,
+        kaiser,
+        meshgrid,
+        sinc,
+        trapz,
+        trim_zeros,
+        unique,
+    )
+    from numpy.core.numeric import normalize_axis_tuple
+    from numpy.random import rand
+
+    from numpy.testing import (
+        assert_,
+        assert_allclose,  # IS_PYPY,
+        assert_almost_equal,
+        assert_array_almost_equal,
+        assert_array_equal,
+        assert_equal,
+        assert_raises_regex,
+        assert_warns,
+        suppress_warnings,  # HAS_REFCOUNT, IS_WASM
+    )
+else:
+    import torch._numpy as np
+    from torch._numpy import (
+        angle,
+        bartlett,
+        blackman,
+        corrcoef,
+        cov,
+        diff,
+        flipud,
+        gradient,
+        hamming,
+        hanning,
+        i0,
+        kaiser,
+        meshgrid,
+        sinc,
+        unique,
+    )
+    from torch._numpy._util import normalize_axis_tuple
+    from torch._numpy.random import rand
+
+    from torch._numpy.testing import (
+        assert_,
+        assert_allclose,  # IS_PYPY,
+        assert_almost_equal,
+        assert_array_almost_equal,
+        assert_array_equal,
+        assert_equal,
+        assert_raises_regex,
+        assert_warns,
+        suppress_warnings,  # HAS_REFCOUNT, IS_WASM
+    )
 
 
 def get_mat(n):
@@ -251,7 +297,7 @@ class TestCopy(TestCase):
         assert_equal(a[0, 0], 1)
         assert_equal(a_copy[0, 0], 10)
 
-    @xfail  # (reason="order='F' not implemented")
+    @xpassIfTorchDynamo  # (reason="order='F' not implemented")
     def test_order(self):
         # It turns out that people rely on np.copy() preserving order by
         # default; changing this broke scikit-learn:
@@ -477,7 +523,7 @@ class TestSelect(TestCase):
         select(conditions, choices)
 
 
-@xfail  # (reason="TODO: implement")
+@xpassIfTorchDynamo  # (reason="TODO: implement")
 @instantiate_parametrized_tests
 class TestInsert(TestCase):
     def test_basic(self):
@@ -795,7 +841,7 @@ class TestDiff(TestCase):
         assert_raises(np.AxisError, diff, x, append=0, axis=3)
 
 
-@xfail  # (reason="TODO: implement")
+@xpassIfTorchDynamo  # (reason="TODO: implement")
 @instantiate_parametrized_tests
 class TestDelete(TestCase):
     def setUp(self):
@@ -867,7 +913,9 @@ class TestDelete(TestCase):
         with pytest.raises(IndexError):
             np.delete([0, 1, 2], np.array([], dtype=float))
 
-    @parametrize("indexer", [np.array([1]), [1]])
+    @parametrize(
+        "indexer", [subtest(np.array([1]), name="array([1])"), subtest([1], name="[1]")]
+    )
     def test_single_item_array(self, indexer):
         a_del_int = delete(self.a, 1)
         a_del = delete(self.a, indexer)
@@ -1142,7 +1190,7 @@ class TestAngle(TestCase):
         assert_array_almost_equal(z, zo, 11)
 
 
-@xfail  # (reason="trim_zeros not implemented")
+@xpassIfTorchDynamo
 @instantiate_parametrized_tests
 class TestTrimZeros(TestCase):
     a = np.array([0, 0, 1, 0, 2, 3, 4, 0])
@@ -1151,7 +1199,11 @@ class TestTrimZeros(TestCase):
     #    d = a.astype(object)
 
     def values(self):
-        attr_names = ("a", "b", "c", "d")
+        attr_names = (
+            "a",
+            "b",
+            "c",
+        )  # "d")
         return (getattr(self, name) for name in attr_names)
 
     def test_basic(self):
@@ -1210,7 +1262,7 @@ class TestTrimZeros(TestCase):
         assert isinstance(res, list)
 
 
-@xfail  # (reason="TODO: implement")
+@xpassIfTorchDynamo  # (reason="TODO: implement")
 class TestExtins(TestCase):
     def test_basic(self):
         a = np.array([1, 3, 2, 1, 2, 3, 3])
@@ -1612,7 +1664,7 @@ class TestVectorize(TestCase):
             f(x)
 
 
-@xfail  # (reason="TODO: implement")
+@xpassIfTorchDynamo  # (reason="TODO: implement")
 class TestDigitize(TestCase):
     def test_forward(self):
         x = np.arange(-6, 5)
@@ -1716,7 +1768,9 @@ class TestUnwrap(TestCase):
 
 @instantiate_parametrized_tests
 class TestFilterwindows(TestCase):
-    @parametrize("dtype", np.typecodes["AllInteger"] + np.typecodes["Float"])
+    @parametrize(
+        "dtype", "Bbhil" + "efd"
+    )  # np.typecodes["AllInteger"] + np.typecodes["Float"])
     @parametrize("M", [0, 1, 10])
     def test_hanning(self, dtype: str, M: int) -> None:
         scalar = M
@@ -1736,7 +1790,9 @@ class TestFilterwindows(TestCase):
         else:
             assert_almost_equal(np.sum(w, axis=0), 4.500, 4)
 
-    @parametrize("dtype", np.typecodes["AllInteger"] + np.typecodes["Float"])
+    @parametrize(
+        "dtype", "Bbhil" + "efd"
+    )  # np.typecodes["AllInteger"] + np.typecodes["Float"])
     @parametrize("M", [0, 1, 10])
     def test_hamming(self, dtype: str, M: int) -> None:
         scalar = M
@@ -1756,7 +1812,9 @@ class TestFilterwindows(TestCase):
         else:
             assert_almost_equal(np.sum(w, axis=0), 4.9400, 4)
 
-    @parametrize("dtype", np.typecodes["AllInteger"] + np.typecodes["Float"])
+    @parametrize(
+        "dtype", "Bbhil" + "efd"
+    )  # np.typecodes["AllInteger"] + np.typecodes["Float"])
     @parametrize("M", [0, 1, 10])
     def test_bartlett(self, dtype: str, M: int) -> None:
         scalar = M
@@ -1776,7 +1834,9 @@ class TestFilterwindows(TestCase):
         else:
             assert_almost_equal(np.sum(w, axis=0), 4.4444, 4)
 
-    @parametrize("dtype", np.typecodes["AllInteger"] + np.typecodes["Float"])
+    @parametrize(
+        "dtype", "Bbhil" + "efd"
+    )  # np.typecodes["AllInteger"] + np.typecodes["Float"])
     @parametrize("M", [0, 1, 10])
     def test_blackman(self, dtype: str, M: int) -> None:
         scalar = M
@@ -1796,7 +1856,9 @@ class TestFilterwindows(TestCase):
         else:
             assert_almost_equal(np.sum(w, axis=0), 3.7800, 4)
 
-    @parametrize("dtype", np.typecodes["AllInteger"] + np.typecodes["Float"])
+    @parametrize(
+        "dtype", "Bbhil" + "efd"
+    )  # np.typecodes["AllInteger"] + np.typecodes["Float"])
     @parametrize("M", [0, 1, 10])
     def test_kaiser(self, dtype: str, M: int) -> None:
         scalar = M
@@ -1817,7 +1879,7 @@ class TestFilterwindows(TestCase):
             assert_almost_equal(np.sum(w, axis=0), 10, 15)
 
 
-@xfail  # (reason="TODO: implement")
+@xpassIfTorchDynamo  # (reason="TODO: implement")
 class TestTrapz(TestCase):
     def test_simple(self):
         x = np.arange(-10, 10, 0.1)
@@ -1886,13 +1948,13 @@ class TestUnique(TestCase):
 
         assert_(unique(np.array([1, 1, 1, 1, 1])) == np.array([1]))
 
-    @xfail  # (reason="unique not implemented for 'ComplexDouble'")
+    @xpassIfTorchDynamo  # (reason="unique not implemented for 'ComplexDouble'")
     def test_simple_complex(self):
         x = np.array([5 + 6j, 1 + 1j, 1 + 10j, 10, 5 + 6j])
         assert_(np.all(unique(x) == [1 + 1j, 1 + 10j, 5 + 6j, 10]))
 
 
-@xfail  # (reason="TODO: implement")
+@xpassIfTorchDynamo  # (reason="TODO: implement")
 class TestCheckFinite(TestCase):
     def test_simple(self):
         a = [1, 2, 3]
@@ -2537,7 +2599,19 @@ class TestBincount(TestCase):
             np.bincount(vals)
 
 
-@xfail  # (reason="TODO: implement")
+parametrize_interp_sc = parametrize(
+    "sc",
+    [
+        subtest(lambda x: np.float_(x), name="real"),
+        subtest(lambda x: _make_complex(x, 0), name="complex-real"),
+        subtest(lambda x: _make_complex(0, x), name="complex-imag"),
+        subtest(lambda x: _make_complex(x, np.multiply(x, -2)), name="complex-both"),
+    ],
+)
+
+
+@xpassIfTorchDynamo  # (reason="TODO: implement")
+@instantiate_parametrized_tests
 class TestInterp(TestCase):
     def test_exceptions(self):
         assert_raises(ValueError, interp, 0, [], [])
@@ -2612,19 +2686,7 @@ class TestInterp(TestCase):
         fp = [1, 2, np.nan, 4]
         assert_almost_equal(np.interp(x, xp, fp), [1, 2, np.nan, np.nan, 4])
 
-    @pytest.fixture(
-        params=[
-            lambda x: np.float_(x),
-            lambda x: _make_complex(x, 0),
-            lambda x: _make_complex(0, x),
-            lambda x: _make_complex(x, np.multiply(x, -2)),
-        ],
-        ids=["real", "complex-real", "complex-imag", "complex-both"],
-    )
-    def sc(self, request):
-        """scale function used by the below tests"""
-        return request.param
-
+    @parametrize_interp_sc
     def test_non_finite_any_nan(self, sc):
         """test that nans are propagated"""
         assert_equal(np.interp(0.5, [np.nan, 1], sc([0, 10])), sc(np.nan))
@@ -2632,6 +2694,7 @@ class TestInterp(TestCase):
         assert_equal(np.interp(0.5, [0, 1], sc([np.nan, 10])), sc(np.nan))
         assert_equal(np.interp(0.5, [0, 1], sc([0, np.nan])), sc(np.nan))
 
+    @parametrize_interp_sc
     def test_non_finite_inf(self, sc):
         """Test that interp between opposite infs gives nan"""
         assert_equal(np.interp(0.5, [-np.inf, +np.inf], sc([0, 10])), sc(np.nan))
@@ -2641,6 +2704,7 @@ class TestInterp(TestCase):
         # unless the y values are equal
         assert_equal(np.interp(0.5, [-np.inf, +np.inf], sc([10, 10])), sc(10))
 
+    @parametrize_interp_sc
     def test_non_finite_half_inf_xf(self, sc):
         """Test that interp where both axes have a bound at inf gives nan"""
         assert_equal(np.interp(0.5, [-np.inf, 1], sc([-np.inf, 10])), sc(np.nan))
@@ -2652,6 +2716,7 @@ class TestInterp(TestCase):
         assert_equal(np.interp(0.5, [0, +np.inf], sc([0, -np.inf])), sc(np.nan))
         assert_equal(np.interp(0.5, [0, +np.inf], sc([0, +np.inf])), sc(np.nan))
 
+    @parametrize_interp_sc
     def test_non_finite_half_inf_x(self, sc):
         """Test interp where the x axis has a bound at inf"""
         assert_equal(np.interp(0.5, [-np.inf, -np.inf], sc([0, 10])), sc(10))
@@ -2659,6 +2724,7 @@ class TestInterp(TestCase):
         assert_equal(np.interp(0.5, [0, +np.inf], sc([0, 10])), sc(0))
         assert_equal(np.interp(0.5, [+np.inf, +np.inf], sc([0, 10])), sc(0))
 
+    @parametrize_interp_sc
     def test_non_finite_half_inf_f(self, sc):
         """Test interp where the f axis has a bound at inf"""
         assert_equal(np.interp(0.5, [0, 1], sc([0, -np.inf])), sc(-np.inf))
@@ -2786,7 +2852,7 @@ class TestPercentile(TestCase):
         x = np.array([[1, 1, 1], [1, 1, 1], [4, 4, 3], [1, 1, 1], [1, 1, 1]])
         assert_array_equal(np.percentile(x, 50, axis=0), [1, 1, 1])
 
-    @xfail  # (reason="TODO: implement")
+    @xpassIfTorchDynamo  # (reason="TODO: implement")
     @parametrize("dtype", np.typecodes["Float"])
     def test_linear_nan_1D(self, dtype):
         # METHOD 1 of H&F
@@ -2796,14 +2862,14 @@ class TestPercentile(TestCase):
         np.testing.assert_equal(res.dtype, arr.dtype)
 
     H_F_TYPE_CODES = [
-        (int_type, np.float64) for int_type in np.typecodes["AllInteger"]
+        (int_type, np.float64) for int_type in "Bbhil"  # np.typecodes["AllInteger"]
     ] + [
         (np.float16, np.float16),
         (np.float32, np.float32),
         (np.float64, np.float64),
     ]
 
-    @xfail  # (reason="TODO: implement percentile interpolations")
+    @skip(reason="NEP 50 is new in 1.24")
     @parametrize("input_dtype, expected_dtype", H_F_TYPE_CODES)
     @parametrize(
         "method, expected",
@@ -2821,7 +2887,8 @@ class TestPercentile(TestCase):
     )
     def test_linear_interpolation(self, method, expected, input_dtype, expected_dtype):
         expected_dtype = np.dtype(expected_dtype)
-        if np._get_promotion_state() == "legacy":
+
+        if hasattr(np, '_get_promotion_state') and np._get_promotion_state() == "legacy":
             expected_dtype = np.promote_types(expected_dtype, np.float64)
 
         arr = np.asarray([15.0, 20.0, 35.0, 40.0, 50.0], dtype=input_dtype)
@@ -3076,7 +3143,7 @@ class TestPercentile(TestCase):
         b = np.percentile([2, 3, 4, 1], [50], overwrite_input=True)
         assert_equal(b, np.array([2.5]))
 
-    @xfail  # (reason="pytorch percentile does not support tuple axes.")
+    @xpassIfTorchDynamo  # (reason="pytorch percentile does not support tuple axes.")
     def test_extended_axis(self):
         o = np.random.normal(size=(71, 23))
         x = np.dstack([o] * 10)
@@ -3165,6 +3232,7 @@ class TestPercentile(TestCase):
             np.percentile(d, [1, 7], axis=(0, 3), keepdims=True).shape, (2, 1, 5, 7, 1)
         )
 
+    @skipif(numpy.__version__ < "1.24", reason="NP_VER: fails on NumPy 1.23.x")
     @parametrize(
         "q",
         [
@@ -3172,7 +3240,7 @@ class TestPercentile(TestCase):
             subtest(
                 [1, 7],
                 decorators=[
-                    xfail,
+                    xpassIfTorchDynamo,
                 ],
             ),
         ],
@@ -3186,13 +3254,13 @@ class TestPercentile(TestCase):
             subtest(
                 (0, 1),
                 decorators=[
-                    xfail,
+                    xpassIfTorchDynamo,
                 ],
             ),
             subtest(
                 (-3, -1),
                 decorators=[
-                    xfail,
+                    xpassIfTorchDynamo,
                 ],
             ),
         ],
@@ -3242,7 +3310,7 @@ class TestPercentile(TestCase):
             assert_equal(np.percentile(d, 1, out=o), o)
             assert_equal(np.percentile(d, 1, method="nearest", out=o), o)
 
-    @xfail  # (reason="np.percentile undocumented nan weirdness")
+    @xpassIfTorchDynamo  # (reason="np.percentile undocumented nan weirdness")
     def test_nan_behavior(self):
         a = np.arange(24, dtype=float)
         a[2] = np.nan
@@ -3335,7 +3403,7 @@ class TestQuantile(TestCase):
         assert_equal(np.quantile(x, 1), 3.5)
         assert_equal(np.quantile(x, 0.5), 1.75)
 
-    @xfail  # (reason="quantile w/integers or bools")
+    @xpassIfTorchDynamo  # (reason="quantile w/integers or bools")
     def test_correct_quantile_value(self):
         a = np.array([True])
         tf_quant = np.quantile(True, False)
@@ -3394,8 +3462,8 @@ class TestQuantile(TestCase):
         np.quantile(np.arange(100.0), p, method="midpoint")
         assert_array_equal(p, p0)
 
-    @xfail  # (reason="TODO: make quantile preserve integers")
-    @parametrize("dtype", np.typecodes["AllInteger"])
+    @xpassIfTorchDynamo  # (reason="TODO: make quantile preserve integers")
+    @parametrize("dtype", "Bbhil")  # np.typecodes["AllInteger"])
     def test_quantile_preserve_int_type(self, dtype):
         res = np.quantile(np.array([1, 2], dtype=dtype), [0.5], method="nearest")
         assert res.dtype == dtype
@@ -3406,50 +3474,50 @@ class TestQuantile(TestCase):
             subtest(
                 "inverted_cdf",
                 decorators=[
-                    xfail,
+                    xpassIfTorchDynamo,
                 ],
             ),
             subtest(
                 "averaged_inverted_cdf",
                 decorators=[
-                    xfail,
+                    xpassIfTorchDynamo,
                 ],
             ),
             subtest(
                 "closest_observation",
                 decorators=[
-                    xfail,
+                    xpassIfTorchDynamo,
                 ],
             ),
             subtest(
                 "interpolated_inverted_cdf",
                 decorators=[
-                    xfail,
+                    xpassIfTorchDynamo,
                 ],
             ),
             subtest(
                 "hazen",
                 decorators=[
-                    xfail,
+                    xpassIfTorchDynamo,
                 ],
             ),
             subtest(
                 "weibull",
                 decorators=[
-                    xfail,
+                    xpassIfTorchDynamo,
                 ],
             ),
             "linear",
             subtest(
                 "median_unbiased",
                 decorators=[
-                    xfail,
+                    xpassIfTorchDynamo,
                 ],
             ),
             subtest(
                 "normal_unbiased",
                 decorators=[
-                    xfail,
+                    xpassIfTorchDynamo,
                 ],
             ),
             "nearest",
@@ -3517,7 +3585,7 @@ class TestMedian(TestCase):
         a = np.array([0.0444502, 0.141249, 0.0463301])
         assert_equal(a[-1], np.median(a))
 
-    @xfail  # (reason="median: scalar output vs 0-dim")
+    @xpassIfTorchDynamo  # (reason="median: scalar output vs 0-dim")
     def test_basic_2(self):
         # check array scalar result
         a = np.array([0.0444502, 0.141249, 0.0463301])
@@ -3626,7 +3694,7 @@ class TestMedian(TestCase):
         b[1, 2] = np.nan
         assert_equal(np.median(a, 1), b)
 
-    @xfail  # (reason="median: does not support tuple axes")
+    @xpassIfTorchDynamo  # (reason="median: does not support tuple axes")
     def test_nan_behavior_2(self):
         a = np.arange(24, dtype=float).reshape(2, 3, 4)
         a[1, 2, 3] = np.nan
@@ -3638,7 +3706,7 @@ class TestMedian(TestCase):
         b[2] = np.nan
         assert_equal(np.median(a, (0, 2)), b)
 
-    @xfail  # (reason="median: scalar vs 0-dim")
+    @xpassIfTorchDynamo  # (reason="median: scalar vs 0-dim")
     def test_nan_behavior_3(self):
         a = np.arange(24, dtype=float).reshape(2, 3, 4)
         a[1, 2, 3] = np.nan
@@ -3647,7 +3715,7 @@ class TestMedian(TestCase):
         # no axis
         assert_equal(np.median(a).ndim, 0)
 
-    @xfail  # (reason="median: torch.quantile does not handle empty tensors")
+    @xpassIfTorchDynamo  # (reason="median: torch.quantile does not handle empty tensors")
     @skipif(IS_WASM, reason="fp errors don't work correctly")
     def test_empty(self):
         # mean(empty array) emits two warnings: empty slice and divide by 0
@@ -3678,7 +3746,7 @@ class TestMedian(TestCase):
             assert_equal(np.median(a, axis=2), b)
             assert_(w[0].category is RuntimeWarning)
 
-    @xfail  # (reason="median: tuple axes not implemented")
+    @xpassIfTorchDynamo  # (reason="median: tuple axes not implemented")
     def test_extended_axis(self):
         o = np.random.normal(size=(71, 23))
         x = np.dstack([o] * 10)
@@ -3728,7 +3796,7 @@ class TestMedian(TestCase):
         d = np.ones((3, 5, 7, 11))
         assert_equal(np.median(d, axis=None, keepdims=True).shape, (1, 1, 1, 1))
 
-    @xfail  # (reason="median: tuple axis")
+    @xpassIfTorchDynamo  # (reason="median: tuple axis")
     def test_keepdims_2(self):
         d = np.ones((3, 5, 7, 11))
         assert_equal(np.median(d, axis=(0, 1), keepdims=True).shape, (1, 1, 7, 11))
@@ -3737,6 +3805,7 @@ class TestMedian(TestCase):
         assert_equal(np.median(d, axis=(0, 1, 2, 3), keepdims=True).shape, (1, 1, 1, 1))
         assert_equal(np.median(d, axis=(0, 1, 3), keepdims=True).shape, (1, 1, 7, 1))
 
+    @skipif(numpy.__version__ < "1.24", reason="NP_VER: fails on NumPy 1.23.x")
     @parametrize(
         "axis",
         [
@@ -3746,13 +3815,13 @@ class TestMedian(TestCase):
             subtest(
                 (0, 1),
                 decorators=[
-                    xfail,
+                    xpassIfTorchDynamo,
                 ],
             ),
             subtest(
                 (-3, -1),
                 decorators=[
-                    xfail,
+                    xpassIfTorchDynamo,
                 ],
             ),
         ],
@@ -3772,7 +3841,7 @@ class TestMedian(TestCase):
         assert_equal(result.shape, shape_out)
 
 
-@xfail  # (reason="TODO: implement")
+@xpassIfTorchDynamo  # (reason="TODO: implement")
 @instantiate_parametrized_tests
 class TestSortComplex(TestCase):
     @parametrize(

--- a/test/torch_np/numpy_tests/lib/test_function_base.py
+++ b/test/torch_np/numpy_tests/lib/test_function_base.py
@@ -610,6 +610,7 @@ class TestInsert(TestCase):
         with pytest.raises(IndexError):
             np.insert([0, 1, 2], np.array([], dtype=float), [])
 
+    @skip(reason="NP_VER: fails on CI")
     @parametrize("idx", [4, -4])
     def test_index_out_of_bounds(self, idx):
         with pytest.raises(IndexError, match="out of bounds"):

--- a/test/torch_np/numpy_tests/lib/test_function_base.py
+++ b/test/torch_np/numpy_tests/lib/test_function_base.py
@@ -336,6 +336,7 @@ class TestAverage(TestCase):
         assert_almost_equal(y5.mean(0), np.average(y5, 0))
         assert_almost_equal(y5.mean(1), np.average(y5, 1))
 
+    @skip(reason="NP_VER: fails on CI")
     @parametrize(
         "x, axis, expected_avg, weights, expected_wavg, expected_wsum",
         [

--- a/test/torch_np/numpy_tests/lib/test_function_base.py
+++ b/test/torch_np/numpy_tests/lib/test_function_base.py
@@ -370,6 +370,7 @@ class TestAverage(TestCase):
         assert wsum.shape == np.shape(expected_wsum)
         assert_array_equal(wsum, expected_wsum)
 
+    @skip(reason="NP_VER: fails on CI")
     def test_weights(self):
         y = np.arange(10)
         w = np.arange(10)

--- a/test/torch_np/numpy_tests/lib/test_function_base.py
+++ b/test/torch_np/numpy_tests/lib/test_function_base.py
@@ -2888,7 +2888,10 @@ class TestPercentile(TestCase):
     def test_linear_interpolation(self, method, expected, input_dtype, expected_dtype):
         expected_dtype = np.dtype(expected_dtype)
 
-        if hasattr(np, '_get_promotion_state') and np._get_promotion_state() == "legacy":
+        if (
+            hasattr(np, "_get_promotion_state")
+            and np._get_promotion_state() == "legacy"
+        ):
             expected_dtype = np.promote_types(expected_dtype, np.float64)
 
         arr = np.asarray([15.0, 20.0, 35.0, 40.0, 50.0], dtype=input_dtype)

--- a/test/torch_np/numpy_tests/lib/test_function_base.py
+++ b/test/torch_np/numpy_tests/lib/test_function_base.py
@@ -2808,6 +2808,8 @@ class TestInterp(TestCase):
 
 @instantiate_parametrized_tests
 class TestPercentile(TestCase):
+
+    @skip(reason="NP_VER: fails on CI; no method=")
     def test_basic(self):
         x = np.arange(8) * 0.5
         assert_equal(np.percentile(x, 0), 0.0)
@@ -2855,6 +2857,7 @@ class TestPercentile(TestCase):
         x = np.array([[1, 1, 1], [1, 1, 1], [4, 4, 3], [1, 1, 1], [1, 1, 1]])
         assert_array_equal(np.percentile(x, 50, axis=0), [1, 1, 1])
 
+    @skip(reason="NP_VER: fails on CI; no method=")
     @xpassIfTorchDynamo  # (reason="TODO: implement")
     @parametrize("dtype", np.typecodes["Float"])
     def test_linear_nan_1D(self, dtype):
@@ -2909,11 +2912,13 @@ class TestPercentile(TestCase):
 
     TYPE_CODES = np.typecodes["AllInteger"] + np.typecodes["Float"]
 
+    @skip(reason="NP_VER: fails on CI; no method=")
     @parametrize("dtype", TYPE_CODES)
     def test_lower_higher(self, dtype):
         assert_equal(np.percentile(np.arange(10, dtype=dtype), 50, method="lower"), 4)
         assert_equal(np.percentile(np.arange(10, dtype=dtype), 50, method="higher"), 5)
 
+    @skip(reason="NP_VER: fails on CI; no method=")
     @parametrize("dtype", TYPE_CODES)
     def test_midpoint(self, dtype):
         assert_equal(
@@ -2929,6 +2934,7 @@ class TestPercentile(TestCase):
             np.percentile(np.arange(11, dtype=dtype), 50, method="midpoint"), 5
         )
 
+    @skip(reason="NP_VER: fails on CI; no method=")
     @parametrize("dtype", TYPE_CODES)
     def test_nearest(self, dtype):
         assert_equal(np.percentile(np.arange(10, dtype=dtype), 51, method="nearest"), 5)
@@ -3037,6 +3043,7 @@ class TestPercentile(TestCase):
         assert_equal(c, r1)
         assert_equal(out, r1)
 
+    @skip(reason="NP_VER: fails on CI; no method=")
     def test_exception(self):
         assert_raises(
             (RuntimeError, ValueError), np.percentile, [1, 2], 56, method="foobar"
@@ -3053,6 +3060,7 @@ class TestPercentile(TestCase):
     def test_percentile_list(self):
         assert_equal(np.percentile([1, 2, 3], 0), 1)
 
+    @skip(reason="NP_VER: fails on CI; no method=")
     def test_percentile_out(self):
         x = np.array([1, 2, 3])
         y = np.zeros((3,))
@@ -3093,6 +3101,7 @@ class TestPercentile(TestCase):
         assert_equal(c, r1)
         assert_equal(out, r1)
 
+    @skip(reason="NP_VER: fails on CI; no method=")
     def test_percentile_empty_dim(self):
         # empty dims are preserved
         d = np.arange(11 * 2).reshape(11, 1, 2, 1)
@@ -3134,6 +3143,7 @@ class TestPercentile(TestCase):
         np.percentile(a, [50])
         assert_equal(a, np.array([2, 3, 4, 1]))
 
+    @skip(reason="NP_VER: fails on CI; no method=")
     def test_no_p_overwrite(self):
         p = np.linspace(0.0, 100.0, num=5)
         np.percentile(np.arange(100.0), p, method="midpoint")
@@ -3288,6 +3298,7 @@ class TestPercentile(TestCase):
         assert result is out
         assert_equal(result.shape, shape_out)
 
+    @skip(reason="NP_VER: fails on CI; no method=")
     def test_out(self):
         o = np.zeros((4,))
         d = np.ones((3, 4))
@@ -3302,6 +3313,7 @@ class TestPercentile(TestCase):
         assert_equal(np.percentile(d, 2, out=o), o)
         assert_equal(np.percentile(d, 2, method="nearest", out=o), o)
 
+    @skip(reason="NP_VER: fails on CI; no method=")
     def test_out_nan(self):
         with warnings.catch_warnings(record=True):
             warnings.filterwarnings("always", "", RuntimeWarning)
@@ -3317,6 +3329,7 @@ class TestPercentile(TestCase):
             assert_equal(np.percentile(d, 1, out=o), o)
             assert_equal(np.percentile(d, 1, method="nearest", out=o), o)
 
+    @skip(reason="NP_VER: fails on CI; no method=")
     @xpassIfTorchDynamo  # (reason="np.percentile undocumented nan weirdness")
     def test_nan_behavior(self):
         a = np.arange(24, dtype=float)

--- a/test/torch_np/numpy_tests/lib/test_histograms.py
+++ b/test/torch_np/numpy_tests/lib/test_histograms.py
@@ -3,32 +3,46 @@
 # from numpy.testing._private.utils import requires_memory
 import functools
 
-from unittest import expectedFailure as xfail, skipIf
+from unittest import skipIf
 
-import pytest
-import torch._numpy as np
 from pytest import raises as assert_raises
-from torch._numpy import histogram, histogramdd
 
-# from numpy.lib.histograms import histogram, histogramdd, histogram_bin_edges
-from torch._numpy.testing import (
-    assert_,
-    assert_allclose,
-    assert_almost_equal,
-    assert_array_almost_equal,
-    assert_array_equal,
-    assert_equal,
-    # assert_array_max_ulp, #assert_raises_regex, suppress_warnings,
-)
+skip = functools.partial(skipIf, True)
+
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
     slowTest as slow,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
+    xpassIfTorchDynamo,
 )
 
-skip = functools.partial(skipIf, True)
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy import histogram, histogram_bin_edges, histogramdd
+    from numpy.testing import (
+        assert_,
+        assert_allclose,
+        assert_almost_equal,
+        assert_array_almost_equal,
+        assert_array_equal,
+        assert_equal,
+        # assert_array_max_ulp, #assert_raises_regex, suppress_warnings,
+    )
+else:
+    import torch._numpy as np
+    from torch._numpy import histogram, histogramdd
+    from torch._numpy.testing import (
+        assert_,
+        assert_allclose,
+        assert_almost_equal,
+        assert_array_almost_equal,
+        assert_array_equal,
+        assert_equal,
+        # assert_array_max_ulp, #assert_raises_regex, suppress_warnings,
+    )
 
 
 class TestHistogram(TestCase):
@@ -189,7 +203,7 @@ class TestHistogram(TestCase):
         )
         assert_almost_equal(a, [0.2, 0.1, 0.1, 0.075])
 
-    @xfail  # (reason="histogram complex weights")
+    @xpassIfTorchDynamo  # (reason="histogram complex weights")
     def test_exotic_weights(self):
         # Test the use of weights that are not integer or floats, but e.g.
         # complex numbers or object types.
@@ -251,7 +265,7 @@ class TestHistogram(TestCase):
         with assert_raises((RuntimeError, ValueError)):
             np.histogram(vals, range=[0.1, 0.01])
 
-    @xfail  # (reason="edge cases")
+    @xpassIfTorchDynamo  # (reason="edge cases")
     def test_bin_edge_cases(self):
         # Ensure that floating-point computations correctly place edge cases.
         arr = np.array([337, 404, 739, 806, 1007, 1811, 2012])
@@ -275,7 +289,7 @@ class TestHistogram(TestCase):
         with assert_raises((RuntimeError, ValueError)):
             np.histogram(vals, bins=bins)
 
-    @xfail  # (reason="no uint64")
+    @xpassIfTorchDynamo  # (reason="no uint64")
     def test_unsigned_monotonicity_check(self):
         # Ensures ValueError is raised if bins not increasing monotonically
         # when bins contain unsigned values (see #9222)
@@ -301,7 +315,7 @@ class TestHistogram(TestCase):
         np.histogram([np.array(0.5) for i in range(10)] + [0.500000000000001])
         np.histogram([np.array(0.5) for i in range(10)] + [0.5])
 
-    @xfail  # (reason="bins='auto'")
+    @xpassIfTorchDynamo  # (reason="bins='auto'")
     def test_some_nan_values(self):
         # gh-7503
         one_nan = np.array([0, 1, np.nan])
@@ -339,7 +353,7 @@ class TestHistogram(TestCase):
         self.do_signed_overflow_bounds(np.short)
         self.do_signed_overflow_bounds(np.intc)
 
-    @xfail  # (reason="int->float conversin loses precision")
+    @xpassIfTorchDynamo  # (reason="int->float conversin loses precision")
     def test_signed_overflow_bounds_2(self):
         self.do_signed_overflow_bounds(np.int_)
         self.do_signed_overflow_bounds(np.longlong)
@@ -382,14 +396,14 @@ class TestHistogram(TestCase):
         self.do_precision_lower_bound(float_small, float_large)
         self.do_precision_upper_bound(float_small, float_large)
 
-    @xfail  # (reason="mixed dtypes")
+    @xpassIfTorchDynamo  # (reason="mixed dtypes")
     def test_precision(self):
         # not looping results in a useful stack trace upon failure
         self.do_precision(np.half, np.single)
         self.do_precision(np.half, np.double)
         self.do_precision(np.single, np.double)
 
-    @xfail  # (reason="histogram_bin_edges")
+    @xpassIfTorchDynamo  # (reason="histogram_bin_edges")
     def test_histogram_bin_edges(self):
         hist, e = histogram([1, 2, 3, 4], [1, 2])
         edges = histogram_bin_edges([1, 2, 3, 4], [1, 2])
@@ -405,7 +419,7 @@ class TestHistogram(TestCase):
         assert_array_equal(edges, e)
 
     # @requires_memory(free_bytes=1e10)
-    @xfail  # (reason="pytorch does not support bins = [int, int, array]")
+    @xpassIfTorchDynamo  # (reason="pytorch does not support bins = [int, int, array]")
     @slow
     def test_big_arrays(self):
         sample = np.zeros([100000000, 3])
@@ -416,7 +430,7 @@ class TestHistogram(TestCase):
         assert_equal(type(hist), type((1, 2)))
 
 
-@xfail  # (reason="TODO")
+@xpassIfTorchDynamo  # (reason="TODO")
 @instantiate_parametrized_tests
 class TestHistogramOptimBinNums(TestCase):
     """
@@ -698,7 +712,6 @@ class TestHistogramOptimBinNums(TestCase):
         """
         Check that weighted data raises a TypeError
         """
-        pytest.xpass(reason="passes by chance")
         estimator_list = ["fd", "scott", "rice", "sturges", "auto"]
         for estimator in estimator_list:
             assert_raises(TypeError, histogram, [1, 2, 3], estimator, weights=[1, 2, 3])
@@ -840,13 +853,13 @@ class TestHistogramdd(TestCase):
             (RuntimeError, ValueError), np.histogramdd, x, bins=[1, 1, 1, [1, 2, 3, -3]]
         )
 
-    @xfail  # (reason="pytorch does not support bins = [int, int, array]")
+    @xpassIfTorchDynamo  # (reason="pytorch does not support bins = [int, int, array]")
     def test_bins_error_2(self):
         # mixing scalar (# of bins) and explicit bin arrays, ugh
         x = np.arange(8).reshape(2, 4)
         assert_(np.histogramdd(x, bins=[1, 1, 1, [1, 2, 3, 4]]))
 
-    @xfail  # (reason="pytorch does not support bins = [int, int, array]")
+    @xpassIfTorchDynamo  # (reason="pytorch does not support bins = [int, int, array]")
     def test_inf_edges(self):
         # Test using +/-inf bin edges works. See #1788.
         x = np.arange(6).reshape(3, 2)
@@ -897,7 +910,7 @@ class TestHistogramdd(TestCase):
             range=[[0.0, 1.0], [np.nan, 0.75], [0.25, 0.5]],
         )
 
-    @xfail  # (reason="pytorch does not allow equal entries")
+    @xpassIfTorchDynamo  # (reason="pytorch does not allow equal entries")
     def test_equal_edges(self):
         """Test that adjacent entries in an edge array can be equal"""
         x = np.array([0, 1, 2])
@@ -928,7 +941,7 @@ class TestHistogramdd(TestCase):
     def test_large_integers(self):
         big = 2**60  # Too large to represent with a full precision float
 
-        x = np.array([0], np.int64)
+        x = np.asarray([0], dtype=np.int64)
         x_edges = np.array([-1, +1], np.int64)
         y = big + x
         y_edges = big + x_edges

--- a/test/torch_np/numpy_tests/lib/test_index_tricks.py
+++ b/test/torch_np/numpy_tests/lib/test_index_tricks.py
@@ -4,29 +4,52 @@ import functools
 
 from unittest import expectedFailure as xfail, skipIf
 
-import torch._numpy as np
-
 from pytest import raises as assert_raises  # , assert_raises_regex,
 
-from torch._numpy import diag_indices, diag_indices_from, fill_diagonal, index_exp, s_
-from torch._numpy.testing import (
-    assert_,
-    assert_almost_equal,
-    assert_array_almost_equal,
-    assert_array_equal,
-    assert_equal,
-)
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
+    xpassIfTorchDynamo,
 )
 
 skip = functools.partial(skipIf, True)
 
 
-@xfail  # (reason="unravel_index not implemented")
+# If we are going to trace through these, we should use NumPy
+# If testing on eager mode, we use torch._numpy
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy import diag_indices, diag_indices_from, fill_diagonal, index_exp, s_
+    from numpy.testing import (
+        assert_,
+        assert_almost_equal,
+        assert_array_almost_equal,
+        assert_array_equal,
+        assert_equal,
+        assert_raises_regex,
+    )
+else:
+    import torch._numpy as np
+    from torch._numpy import (
+        diag_indices,
+        diag_indices_from,
+        fill_diagonal,
+        index_exp,
+        s_,
+    )
+    from torch._numpy.testing import (
+        assert_,
+        assert_almost_equal,
+        assert_array_almost_equal,
+        assert_array_equal,
+        assert_equal,
+    )
+
+
+@xpassIfTorchDynamo  # (reason="unravel_index not implemented")
 @instantiate_parametrized_tests
 class TestRavelUnravelIndex(TestCase):
     def test_basic(self):
@@ -428,7 +451,7 @@ class TestIx_(TestCase):
 
 
 class TestC(TestCase):
-    @xfail  # (reason="c_ not implemented")
+    @xpassIfTorchDynamo  # (reason="c_ not implemented")
     def test_c_(self):
         a = np.c_[np.array([[1, 2, 3]]), 0, 0, np.array([[4, 5, 6]])]
         assert_equal(a, [[1, 2, 3, 0, 0, 4, 5, 6]])

--- a/test/torch_np/numpy_tests/lib/test_shape_base_.py
+++ b/test/torch_np/numpy_tests/lib/test_shape_base_.py
@@ -5,33 +5,61 @@ import sys
 
 from unittest import expectedFailure as xfail, skipIf as skipif
 
-import torch._numpy as np
-
 from pytest import raises as assert_raises
-from torch._numpy import (
-    array_split,
-    column_stack,
-    dsplit,
-    dstack,
-    expand_dims,
-    hsplit,
-    kron,
-    put_along_axis,
-    split,
-    take_along_axis,
-    tile,
-    vsplit,
-)
 
-from torch._numpy.random import rand, randint
-
-from torch._numpy.testing import assert_, assert_array_equal, assert_equal
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
+    xfailIfTorchDynamo,
+    xpassIfTorchDynamo,
 )
+
+
+# If we are going to trace through these, we should use NumPy
+# If testing on eager mode, we use torch._numpy
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy import (
+        apply_along_axis,
+        array_split,
+        column_stack,
+        dsplit,
+        dstack,
+        expand_dims,
+        hsplit,
+        kron,
+        put_along_axis,
+        split,
+        take_along_axis,
+        tile,
+        vsplit,
+    )
+    from numpy.random import rand, randint
+
+    from numpy.testing import assert_, assert_array_equal, assert_equal
+
+else:
+    import torch._numpy as np
+    from torch._numpy import (
+        array_split,
+        column_stack,
+        dsplit,
+        dstack,
+        expand_dims,
+        hsplit,
+        kron,
+        put_along_axis,
+        split,
+        take_along_axis,
+        tile,
+        vsplit,
+    )
+    from torch._numpy.random import rand, randint
+    from torch._numpy.testing import assert_, assert_array_equal, assert_equal
+
 
 skip = functools.partial(skipif, True)
 
@@ -126,7 +154,7 @@ class TestPutAlongAxis(TestCase):
 
             assert_equal(i_min, i_max)
 
-    @xfail  # (
+    @xpassIfTorchDynamo  # (
     # reason="RuntimeError: Expected index [1, 2, 5] to be smaller than self [3, 4, 1] apart from dimension 1")
     def test_broadcast(self):
         """Test that non-indexing dimensions are broadcast in both directions"""
@@ -136,7 +164,7 @@ class TestPutAlongAxis(TestCase):
         assert_equal(take_along_axis(a, ai, axis=1), 20)
 
 
-@xfail  # (reason="apply_along_axis not implemented")
+@xpassIfTorchDynamo  # (reason="apply_along_axis not implemented")
 class TestApplyAlongAxis(TestCase):
     def test_simple(self):
         a = np.ones((20, 10), "d")
@@ -679,6 +707,8 @@ class TestSqueeze(TestCase):
         assert_equal(res.ndim, 0)
         assert type(res) is np.ndarray
 
+    @xfailIfTorchDynamo
+    def test_basic_2(self):
         aa = np.ones((3, 1, 4, 1, 1))
         assert aa.squeeze().tensor._base is aa.tensor
 
@@ -712,7 +742,7 @@ class TestSqueeze(TestCase):
         assert_(a.flags.f_contiguous)
         assert_(b.flags.f_contiguous)
 
-    @xfail  # (reason="XXX: noop in torch, while numpy raises")
+    @xpassIfTorchDynamo  # (reason="XXX: noop in torch, while numpy raises")
     def test_squeeze_axis_handling(self):
         with assert_raises(ValueError):
             np.squeeze(np.array([[1], [2], [3]]), axis=0)
@@ -810,7 +840,7 @@ class TestTile(TestCase):
                 assert_equal(large, klarge)
 
 
-@xfail  # (reason="TODO: implement")
+@xpassIfTorchDynamo  # (reason="TODO: implement")
 class TestMayShareMemory(TestCase):
     def test_basic(self):
         d = np.ones((50, 60))

--- a/test/torch_np/numpy_tests/lib/test_shape_base_.py
+++ b/test/torch_np/numpy_tests/lib/test_shape_base_.py
@@ -779,6 +779,7 @@ class TestKron(TestCase):
         k = np.array([[[1, 2], [3, 4]], [[2, 4], [6, 8]]])
         assert_array_equal(np.kron(a, b), k)
 
+    @skip(reason="NP_VER: fails on CI")
     @parametrize(
         "shape_a,shape_b",
         [

--- a/test/torch_np/numpy_tests/lib/test_twodim_base.py
+++ b/test/torch_np/numpy_tests/lib/test_twodim_base.py
@@ -8,39 +8,71 @@ import functools
 from unittest import expectedFailure as xfail, skipIf as skipif
 
 import pytest
-
-import torch._numpy as np
 from pytest import raises as assert_raises
 
-from torch._numpy import (
-    arange,
-    array,
-    diag,
-    eye,
-    fliplr,
-    flipud,
-    histogram2d,
-    ones,
-    tri,  # mask_indices,
-    tril_indices,
-    tril_indices_from,
-    triu_indices,
-    triu_indices_from,
-    vander,
-    zeros,
-)
-from torch._numpy.testing import (
-    assert_allclose,
-    assert_array_almost_equal,
-    assert_array_equal,  # assert_array_max_ulp,
-    assert_equal,
-)
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TEST_WITH_TORCHDYNAMO,
     TestCase,
+    xpassIfTorchDynamo,
 )
+
+
+# If we are going to trace through these, we should use NumPy
+# If testing on eager mode, we use torch._numpy
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy import (
+        arange,
+        array,
+        diag,
+        eye,
+        fliplr,
+        flipud,
+        histogram2d,
+        ones,
+        tri,  # mask_indices,
+        tril_indices,
+        tril_indices_from,
+        triu_indices,
+        triu_indices_from,
+        vander,
+        zeros,
+    )
+    from numpy.testing import (
+        assert_allclose,
+        assert_array_almost_equal,
+        assert_array_equal,  # assert_array_max_ulp,
+        assert_equal,
+    )
+else:
+    import torch._numpy as np
+    from torch._numpy import (
+        arange,
+        array,
+        diag,
+        eye,
+        fliplr,
+        flipud,
+        histogram2d,
+        ones,
+        tri,  # mask_indices,
+        tril_indices,
+        tril_indices_from,
+        triu_indices,
+        triu_indices_from,
+        vander,
+        zeros,
+    )
+    from torch._numpy.testing import (
+        assert_allclose,
+        assert_array_almost_equal,
+        assert_array_equal,  # assert_array_max_ulp,
+        assert_equal,
+    )
+
 
 skip = functools.partial(skipif, True)
 
@@ -101,7 +133,7 @@ class TestEye(TestCase):
     def test_bool(self):
         assert_equal(eye(2, 2, dtype=bool), [[True, False], [False, True]])
 
-    @xfail  # (reason="TODO: implement order=non-default")
+    @xpassIfTorchDynamo  # (reason="TODO: implement order=non-default")
     def test_order(self):
         mat_c = eye(4, 3, k=-1)
         mat_f = eye(4, 3, k=-1, order="F")
@@ -127,9 +159,10 @@ class TestDiag(TestCase):
         assert_equal(diag(vals, k=2), b)
         assert_equal(diag(vals, k=-2), c)
 
-    def test_matrix(self, vals=None):
-        if vals is None:
-            vals = (100 * get_mat(5) + 1).astype("l")
+    def test_matrix(self):
+        self.check_matrix(vals=(100 * get_mat(5) + 1).astype("l"))
+
+    def check_matrix(self, vals):
         b = zeros((5,))
         for k in range(5):
             b[k] = vals[k, k]
@@ -142,10 +175,10 @@ class TestDiag(TestCase):
             b[k] = vals[k + 2, k]
         assert_equal(diag(vals, -2), b[:3])
 
-    @xfail  # (reason="TODO implement orders")
+    @xpassIfTorchDynamo  # (reason="TODO implement orders")
     def test_fortran_order(self):
         vals = array((100 * get_mat(5) + 1), order="F", dtype="l")
-        self.test_matrix(vals)
+        self.check_matrix(vals)
 
     def test_diag_bounds(self):
         A = [[1, 2], [3, 4], [5, 6]]
@@ -251,7 +284,7 @@ class TestHistogram2d(TestCase):
         # assert_array_max_ulp(a, np.zeros((4, 4)))
         assert_allclose(a, np.zeros((4, 4)), atol=1e-15)
 
-    @xfail  # (reason="pytorch does not support bins = [int, array]")
+    @xpassIfTorchDynamo  # (reason="pytorch does not support bins = [int, array]")
     def test_binparameter_combination(self):
         x = array([0, 0.09207008, 0.64575234, 0.12875982, 0.47390599, 0.59944483, 1])
         y = array([0, 0.14344267, 0.48988575, 0.30558665, 0.44700682, 0.15886423, 1])
@@ -285,6 +318,7 @@ class TestHistogram2d(TestCase):
         assert_array_equal(H, answer)
         assert_array_equal(xe, array([0.0, 0.25, 0.5, 0.75, 1]))
 
+    @skip(reason="NP_VER: fails on CI with older NumPy")
     @parametrize("x_len, y_len", [(10, 11), (20, 19)])
     def test_bad_length(self, x_len, y_len):
         x, y = np.ones(x_len), np.ones(y_len)
@@ -368,7 +402,7 @@ class TestTri(TestCase):
         iu1 = mask_indices(3, np.triu, 1)
         assert_array_equal(a[iu1], array([1, 2, 5]))
 
-    @xfail  # (reason="np.tril_indices == our tuple(tril_indices)")
+    @xpassIfTorchDynamo  # (reason="np.tril_indices == our tuple(tril_indices)")
     def test_tril_indices(self):
         # indices without and with offset
         il1 = tril_indices(4)
@@ -428,7 +462,7 @@ class TestTri(TestCase):
         )
 
 
-@xfail  # (reason="np.triu_indices == our tuple(triu_indices)")
+@xpassIfTorchDynamo  # (reason="np.triu_indices == our tuple(triu_indices)")
 class TestTriuIndices(TestCase):
     def test_triu_indices(self):
         iu1 = triu_indices(4)

--- a/test/torch_np/numpy_tests/lib/test_type_check.py
+++ b/test/torch_np/numpy_tests/lib/test_type_check.py
@@ -5,22 +5,44 @@ import functools
 
 from unittest import expectedFailure as xfail, skipIf as skipif
 
-import torch._numpy as np
 from pytest import raises as assert_raises
-
-from torch._numpy import (
-    common_type,
-    iscomplex,
-    iscomplexobj,
-    isneginf,
-    isposinf,
-    isreal,
-    isrealobj,
-    nan_to_num,
-    real_if_close,
+from torch.testing._internal.common_utils import (
+    run_tests,
+    TEST_WITH_TORCHDYNAMO,
+    TestCase,
+    xpassIfTorchDynamo,
 )
-from torch._numpy.testing import assert_, assert_array_equal, assert_equal
-from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+if TEST_WITH_TORCHDYNAMO:
+    import numpy as np
+    from numpy import (
+        common_type,
+        iscomplex,
+        iscomplexobj,
+        isneginf,
+        isposinf,
+        isreal,
+        isrealobj,
+        nan_to_num,
+        real_if_close,
+    )
+    from numpy.testing import assert_, assert_array_equal, assert_equal
+else:
+    import torch._numpy as np
+    from torch._numpy import (
+        common_type,
+        iscomplex,
+        iscomplexobj,
+        isneginf,
+        isposinf,
+        isreal,
+        isrealobj,
+        nan_to_num,
+        real_if_close,
+    )
+    from torch._numpy.testing import assert_, assert_array_equal, assert_equal
+
 
 skip = functools.partial(skipif, True)
 
@@ -29,7 +51,7 @@ def assert_all(x):
     assert_(np.all(x), x)
 
 
-@xfail  # (reason="common_type not implemented")
+@xpassIfTorchDynamo  # (reason="common_type not implemented")
 class TestCommonType(TestCase):
     def test_basic(self):
         ai32 = np.array([[1, 2], [3, 4]], dtype=np.int32)
@@ -96,7 +118,7 @@ class TestMintypecode(TestCase):
         assert_equal(mintypecode("idD"), "D")
 
 
-@xfail  # (reason="TODO: decide on if [1] is a scalar or not")
+@xpassIfTorchDynamo  # (reason="TODO: decide on if [1] is a scalar or not")
 class TestIsscalar(TestCase):
     def test_basic(self):
         assert_(np.isscalar(3))


### PR DESCRIPTION
Follow up https://github.com/pytorch/pytorch/pull/112146 and  #112141 : make numpy/lib vendored tests dynamo traceable

cc @mruberry @rgommers @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng