### PR TITLE
Allow traceable_subclass_tensors to have multiple dynamic tensor attributes

### DIFF
--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -434,7 +434,9 @@ class MetaConverter:
                                     sizes,
                                     strides,
                                     storage_offset,
-                                ) = sym_sizes_strides_storage_offset(t, source, temp_dynamic_dims, temp_constraint_dims)
+                                ) = sym_sizes_strides_storage_offset(
+                                    t, source, temp_dynamic_dims, temp_constraint_dims
+                                )
                                 return base.as_strided(sizes, strides, storage_offset)
 
                         if safe_is_leaf(t):


### PR DESCRIPTION
# Summary
FP8Tensor contains two tensor attrs:
- `_data`, shape = (x0, x1)
- `_scale`, shape = scaler

When attempting to compile in eager mode this will cause these two asserts: https://github.com/pytorch/pytorch/blob/main/torch/fx/experimental/symbolic_shapes.py#L2839-L2841 to fail

See this note for a comment:
https://github.com/pytorch/pytorch/blob/main/torch/_subclasses/meta_utils.py#L240-L245




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng