### PR TITLE
[MPS] Make the device in MPSGenerator consistent with MPSAllocator

### DIFF
--- a/aten/src/ATen/mps/MPSGeneratorImpl.mm
+++ b/aten/src/ATen/mps/MPSGeneratorImpl.mm
@@ -21,7 +21,7 @@ Generator createMPSGenerator(uint64_t seed_val) {
 } // namespace mps::detail
 
 MPSGeneratorImpl::MPSGeneratorImpl(uint64_t seed_in)
-    : c10::GeneratorImpl{Device(DeviceType::MPS), DispatchKeySet(c10::DispatchKey::MPS)},
+    : c10::GeneratorImpl{Device(DeviceType::MPS, 0), DispatchKeySet(c10::DispatchKey::MPS)},
       data_({.seed = seed_in}),
       engine_(seed_in, 0, 0) {}
 

--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -248,7 +248,7 @@ MPSStream* MPSStreamImpl::_stream = nullptr;
 
 MPSStream* MPSStreamImpl::getInstance() {
   if (_stream == nullptr) {
-    _stream = new MPSStream(Stream(Stream::UNSAFE, c10::Device(DeviceType::MPS), 0));
+    _stream = new MPSStream(Stream(Stream::UNSAFE, c10::Device(DeviceType::MPS, 0), 0));
   }
   return _stream;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #112188

https://github.com/pytorch/pytorch/blob/1b702b185e8dddadb4ad3f487f5412a02c8777e1/aten/src/ATen/mps/MPSAllocator.mm#L751-L760

The device in an MPS tensor is actually allocated with a device index, so this PR makes the device generated by `MPSGenerator` consistent with that.

Fixes https://github.com/pytorch/pytorch/issues/110820#issuecomment-1752088865