### PR TITLE
[BE] Remove float8 from vec is_floating_type definition

### DIFF
--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -70,9 +70,7 @@ struct is_floating_point:
     std::integral_constant<bool,
       std::is_floating_point<T>::value ||
       std::is_same<T, at::Half>::value ||
-      std::is_same<T, at::BFloat16>::value ||
-      std::is_same<T, at::Float8_e5m2>::value ||
-      std::is_same<T, at::Float8_e4m3fn>::value> {
+      std::is_same<T, at::BFloat16>::value> {
 };
 
 template<typename T>


### PR DESCRIPTION
As it's not supported yet, and it's also not clear, how support should look like


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10