### PR TITLE
Skip aliasing correction for `lift_fresh`.

### DIFF
--- a/test/test_functionalization.py
+++ b/test/test_functionalization.py
@@ -1640,6 +1640,14 @@ def forward(self, arg0_1):
     return add""")
         self.assertEqual(fx_g_cpp.code.strip(), fx_g.code.strip())
 
+    def test_python_functionalization_lift_fresh_storage(self):
+        unlifted = torch.tensor([0.0])
+
+        maybe_disable = torch._C._ExcludeDispatchKeyGuard(torch._C.DispatchKeySet(torch._C.DispatchKey.Functionalize))
+        with maybe_disable, FunctionalTensorMode():
+            lifted = torch.ops.aten.lift_fresh.default(unlifted)
+
+        self.assertNotEqual(unlifted.untyped_storage(), lifted.untyped_storage())
 
 
 @xfail_inherited_tests([

--- a/test/test_functionalization.py
+++ b/test/test_functionalization.py
@@ -1649,6 +1649,26 @@ def forward(self, arg0_1):
 
         self.assertNotEqual(unlifted.untyped_storage(), lifted.untyped_storage())
 
+    def test_python_functionalization_lift_fresh(self):
+        def f(x):
+            tmp = torch.tensor([0.0])
+            return tmp + x
+
+        x = torch.randn(4)
+        out_ref = f(x)
+        out_test = dispatch_functionalize(f)(x)
+        out_test_cpp = _functionalize(f, reapply_views=True, crossref=False, skip_input_mutations=True)(x)
+        self.assertEqual(out_ref, out_test)
+        self.assertEqual(out_ref, out_test_cpp)
+        fx_g = make_fx(dispatch_functionalize(f))(x)
+        fx_g_cpp = make_fx(_functionalize(f, reapply_views=True, crossref=False, skip_input_mutations=True))(x)
+        self.assertExpectedInline(fx_g.code.strip(), """\
+def forward(self, arg0_1):
+    _tensor_constant0 = self._tensor_constant0
+    lift_fresh_copy = torch.ops.aten.lift_fresh_copy.default(_tensor_constant0);  _tensor_constant0 = None
+    add = torch.ops.aten.add.Tensor(lift_fresh_copy, arg0_1);  lift_fresh_copy = arg0_1 = None
+    return add""")
+        self.assertEqual(fx_g_cpp.code.strip(), fx_g.code.strip())
 
 @xfail_inherited_tests([
     "test_as_strided",

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -309,15 +309,15 @@ class FunctionalTensorMode(TorchDispatchMode):
         assert is_excluded or not is_included
 
         if (
-                # If no outputs are our functional subclass, then don't try to fix up aliasing
-                not any(
-                    isinstance(x, FunctionalTensor) for x in pytree.tree_leaves(outs_wrapped)
-                )
-                # Since lift_fresh lifts its argument into a functional tensor, we can skip the
-                # aliasing correction step. Otherwise, we would be setting the storage of a
-                # lifted tensor to that of an unlifted tensor.
-                # Ref: https://github.com/pytorch/pytorch/issues/111506
-                or func == torch.ops.aten.lift_fresh.default
+            # If no outputs are our functional subclass, then don't try to fix up aliasing
+            not any(
+                isinstance(x, FunctionalTensor) for x in pytree.tree_leaves(outs_wrapped)
+            )
+            # Since lift_fresh lifts its argument into a functional tensor, we can skip the
+            # aliasing correction step. Otherwise, we would be setting the storage of a
+            # lifted tensor to that of an unlifted tensor.
+            # Ref: https://github.com/pytorch/pytorch/issues/111506
+            or func == torch.ops.aten.lift_fresh.default
         ):
             return outs_wrapped
         # Wrapper tensor subclasses do not have correct aliasing info! Use this util to manually correct the output aliasing.

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -311,7 +311,8 @@ class FunctionalTensorMode(TorchDispatchMode):
         if (
             # If no outputs are our functional subclass, then don't try to fix up aliasing
             not any(
-                isinstance(x, FunctionalTensor) for x in pytree.tree_leaves(outs_wrapped)
+                isinstance(x, FunctionalTensor)
+                for x in pytree.tree_leaves(outs_wrapped)
             )
             # Since lift_fresh lifts its argument into a functional tensor, we can skip the
             # aliasing correction step. Otherwise, we would be setting the storage of a

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -308,9 +308,16 @@ class FunctionalTensorMode(TorchDispatchMode):
         )
         assert is_excluded or not is_included
 
-        # If no outputs are our functional subclass, then don't try to fix up aliasing
-        if not any(
-            isinstance(x, FunctionalTensor) for x in pytree.tree_leaves(outs_wrapped)
+        if (
+                # If no outputs are our functional subclass, then don't try to fix up aliasing
+                not any(
+                    isinstance(x, FunctionalTensor) for x in pytree.tree_leaves(outs_wrapped)
+                )
+                # Since lift_fresh lifts its argument into a functional tensor, we can skip the
+                # aliasing correction step. Otherwise, we would be setting the storage of a
+                # lifted tensor to that of an unlifted tensor.
+                # Ref: https://github.com/pytorch/pytorch/issues/111506
+                or func == torch.ops.aten.lift_fresh.default
         ):
             return outs_wrapped
         # Wrapper tensor subclasses do not have correct aliasing info! Use this util to manually correct the output aliasing.


### PR DESCRIPTION
Fix: #111506

This PR skips aliasing correction on `lift_fresh` calls. Reasoning is: although unlifted and lifted tensors are technically aliases, they are from different levels of abstraction (`FunctionalTensorWrapper` and `XLATensor`).

cc @bdhirsh @ezyang