### PR TITLE
[tp] fix PrepareModuleInput for multiple inputs

### DIFF
--- a/test/distributed/tensor/parallel/test_tp_style.py
+++ b/test/distributed/tensor/parallel/test_tp_style.py
@@ -22,14 +22,14 @@ from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
+    NUM_DEVICES,
 )
 
 
 class TensorParallelStyleTest(DTensorTestBase):
     @property
     def world_size(self):
-        gpu_num = torch.cuda.device_count()
-        return gpu_num if gpu_num % 2 == 0 and gpu_num > 4 else 4
+        return NUM_DEVICES
 
     def _1d_input_func_check(
         self,

--- a/test/distributed/tensor/parallel/test_tp_style.py
+++ b/test/distributed/tensor/parallel/test_tp_style.py
@@ -283,9 +283,9 @@ class TensorParallelStyleTest(DTensorTestBase):
         )
         output = test_mod(
             torch.randn(2, 8, device=self.device_type),
-            torch.ones(self.world_size * 2, 8, device=self.device_type)
+            torch.ones(self.world_size * 2, 8 // self.world_size, device=self.device_type)
         )
-        self.assertEqual(output.shape, (16, 8))
+        self.assertEqual(output.shape, (self.world_size * 2, 8 // self.world_size))
 
     @with_comms
     def test_prepare_module_output(self):

--- a/test/distributed/tensor/parallel/test_tp_style.py
+++ b/test/distributed/tensor/parallel/test_tp_style.py
@@ -4,6 +4,7 @@
 import torch
 import torch.distributed as dist
 from torch.distributed._tensor import DeviceMesh, distribute_tensor, Replicate, Shard
+from torch.distributed.tensor.parallel import parallelize_module
 from torch.distributed.tensor.parallel.style import (
     ColwiseParallel,
     make_input_replicate_1d,
@@ -260,6 +261,31 @@ class TensorParallelStyleTest(DTensorTestBase):
             prepare_hook._prepare_input,
             error_msgs="No device mesh is currently active",
         )
+
+    @with_comms
+    def test_prepare_module_input_multiple_inputs(self):
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(8, 8)
+
+            def forward(self, x, y):
+                return self.linear(x) + y
+
+        test_mod = TestModule().to(self.device_type)
+        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+
+        parallelize_module(test_mod.linear, mesh, ColwiseParallel())
+        parallelize_module(
+            test_mod,
+            mesh,
+            PrepareModuleInput(input_layouts=(Shard(0), None), output_layouts=(Replicate(), None))
+        )
+        output = test_mod(
+            torch.randn(2, 8, device=self.device_type),
+            torch.ones(self.world_size * 2, 8, device=self.device_type)
+        )
+        self.assertEqual(output.shape, (16, 8))
 
     @with_comms
     def test_prepare_module_output(self):

--- a/torch/distributed/tensor/parallel/style.py
+++ b/torch/distributed/tensor/parallel/style.py
@@ -476,11 +476,11 @@ class ColwiseParallel(ParallelStyle):
             )
 
         super().__init__(
+            _prepare_input=prepare_input_fn,
+            _prepare_output=prepare_output_fn,
             input_layouts=input_layouts,
             output_layouts=output_layouts,
             use_local_output=use_local_output,
-            _prepare_input=prepare_input_fn,
-            _prepare_output=prepare_output_fn,
         )
 
     @staticmethod
@@ -570,11 +570,14 @@ class PrepareModuleInput(ParallelStyle):
         for input, input_layout, output_layout in zip(
             inputs, input_layouts, output_layouts  # type: ignore[arg-type]
         ):
-            results.append(
-                _redistribute_per_both_layouts(
-                    input, input_layout, output_layout, device_mesh
+            if input_layout is None:
+                results.append(input)
+            else:
+                results.append(
+                    _redistribute_per_both_layouts(
+                        input, input_layout, output_layout, device_mesh
+                    )
                 )
-            )
         return tuple(results)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #112204

Not all inputs needs to annotate shardings and convert to DTensors, if
user annotate only one inputs are mark the rest as Nones, we should skip
creating DTensors