### PR TITLE
[exp][fbcode] run fp8 linear transform on merge net for ads model

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -100,7 +100,7 @@ def do_bench_using_profiling(fn: Callable[[], Any], warmup=25, rep=100) -> float
     log.debug(p.key_averages().table(sort_by="self_cuda_time_total", row_limit=-1))
 
     filtered_events = EventList(
-        [event for event in p.events() if event.device_type == DeviceType.CUDA]
+        [event for event in p.events() if event.device_type == DeviceType.CUDA  and event.name != "Context Sync"]
     )
     if len(filtered_events) % n_repeat != 0:
         raise RuntimeError(


### PR DESCRIPTION
Summary:
this diff add a experimental pass to convert linear module to FP8 linear for torch.pkg model.

Also added a benchmark for different options.
- No quantization
- Dynamic Quantization
- Static Quantization
- Cultass FP8 VS Culbas FP8
- profile with cuda-only-time

Test Plan:
CUDA_VISIBLE_DEVICES=2 buck run mode/opt  -c fbcode.platform010_cuda_version=12 -c fbcode.nvcc_arch=h100,0,h100a -c fbcode.use_link_groups=false caffe2/torch/fb/model_transform/experimental/test:test_fp8_model_transform  -- --local-model /home/xiaoruichao/test_models/463113248.input.predictor.disagg.gpu.merge

```
FP16 eager mode: time per iteration: 0.016101167678833007
Replaced 11 linear modules with FP8Linear.
INFO:root:Start to benchmark ...
Replaced 11 linear modules with FP8Linear.
INFO:root:Start to benchmark ...
transform fp8_float_model_no_quantization: fp8_cublas: 0.016741212844848634, fp8_cutlass: 0.017486152648925782
transform fp8_float_model_no_quantization speed up: fp8_cublas vs fp16: -3.975147509686806%, fp8_cutlass vs fp16: -8.601767261349073%
Replaced 11 linear modules with FP8Linear.
INFO:root:Start to benchmark ...
Replaced 11 linear modules with FP8Linear.
INFO:root:Start to benchmark ...
transform fp8_float_model_static_quantization: fp8_cublas: 0.016303768157958986, fp8_cutlass: 0.01647454643249512
transform fp8_float_model_static_quantization speed up: fp8_cublas vs fp16: -1.2582968090713247%, fp8_cutlass vs fp16: -2.318954507584971%
Replaced 11 linear modules with FP8Linear.
INFO:root:Start to benchmark ...
Replaced 11 linear modules with FP8Linear.
INFO:root:Start to benchmark ...
transform fp8_float_model_dynamic_quantization: fp8_cublas: 0.01737088394165039, fp8_cutlass: 0.017009300231933595
transform fp8_float_model_dynamic_quantization speed up: fp8_cublas vs fp16: -7.88586447979536%, fp8_cutlass vs fp16: -5.640165801729039%
```

CUDA_VISIBLE_DEVICES=2 buck run mode/opt  -c fbcode.platform010_cuda_version=12 -c fbcode.nvcc_arch=h100,0,h100a -c fbcode.use_link_groups=false caffe2/torch/fb/model_transform/experimental/test:test_fp8_model_transform  -- --local-model /home/xiaoruichao/test_models/463113248.input.predictor.disagg.gpu.merge --cuda-only-time

```
transform fp8_float_model_no_quantization: fp8_cublas: 4.076640470556731, fp8_cutlass: 4.559762257419994
transform fp8_float_model_no_quantization speed up: fp8_cublas vs fp16: 15.457339398681459%, fp8_cutlass vs fp16: 5.43820684311777%
transform fp8_float_model_static_quantization: fp8_cublas: 4.189811604712719, fp8_cutlass: 4.554543922987392
transform fp8_float_model_static_quantization speed up: fp8_cublas vs fp16: 13.110360592500555%, fp8_cutlass vs fp16: 5.546426314524671%
transform fp8_float_model_dynamic_quantization: fp8_cublas: 4.705541305393046, fp8_cutlass: 4.642870460312832
transform fp8_float_model_dynamic_quantization speed up: fp8_cublas vs fp16: 2.4149947976645745%, fp8_cutlass vs fp16: 3.7146826223529286%
```

Reviewed By: tter1

Differential Revision: D50437271




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler