### PR TITLE
[inductor] speedup faketensorprop a bit

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -101,14 +101,16 @@ def tabulate(rows, headers):
 def cprofile_wrapper(func):
     @wraps(func)
     def profile_wrapper(*args, **kwargs):
-        global timer_counter
-        profile_path = Path(func.__name__ + f"{next(timer_counter)}.profile")
+        iter_no = next(timer_counter)
+        profile_path = Path(func.__name__ + f"{iter_no}.profile")
         prof = cProfile.Profile()
         prof.enable()
         retval = prof.runcall(func, *args, **kwargs)
         prof.disable()
-        print(f"### Cprofile for {func.__name__} iter {next(timer_counter)} ###")
         ps = pstats.Stats(prof)
+        print(
+            f"### Cprofile for {func.__name__} iter {iter_no}, total time {ps.total_tt:6f} seconds ###"
+        )
         prof.dump_stats(profile_path)
         svg_path = profile_path.with_suffix(".svg")
         try:

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -264,7 +264,9 @@ def fake_tensor_prop(
     fake_mode = detect_fake_mode(example_inputs)
     if not fake_mode:
         fake_mode = torch._subclasses.FakeTensorMode(allow_non_fake_inputs=True)
-        FakeTensorProp(gm, mode=fake_mode).propagate(*example_inputs)
+        FakeTensorProp(gm, mode=fake_mode, only_detach_requires_grad=True).propagate(
+            *example_inputs
+        )
     else:
         ctx = (
             contextlib.nullcontext()
@@ -272,9 +274,9 @@ def fake_tensor_prop(
             else mock.patch.object(fake_mode, "allow_non_fake_inputs", True)
         )
         with ctx:  # type: ignore[attr-defined]
-            FakeTensorProp(gm, mode=fake_mode).propagate_dont_convert_inputs(
-                *example_inputs
-            )
+            FakeTensorProp(
+                gm, mode=fake_mode, only_detach_requires_grad=True
+            ).propagate_dont_convert_inputs(*example_inputs)
 
     return fake_mode
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #112209

Horace mentioned that FakeTensorProp takes non-trivial time during torch.compile. I did some profiling and here is a cProfile dump for a BertForMaskedLM training compilation job : https://www.svgviewer.dev/s/N6NJcEut . The profile shows a large portion of FakeTensorProp is spent on snapshot_fake function.

I added some temporary dynamo_timed decorator and get the following information: 
<img width="410" alt="Screenshot 2023-10-26 at 2 21 26 PM" src="https://github.com/pytorch/pytorch/assets/52589240/9ec3a03b-b3e6-4520-9e2d-82e023400d38">

- fake_tensor_prop takes 5.4s within which snapshot_fake takes 2s.
- Since snapshot_fake just does `t.detach()`. If we only call `t.detach()` when `t.requires_grad()` is true, we can reduce fake_tensor_prop to 3.5s and snapshot_fake to 0.15s.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @bdhirsh @ezyang since I'm not sure if it's safe to skip `t.detach()` call here.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler