### PR TITLE
Create a Mergability Check (for ghstack)

### DIFF
--- a/.github/workflows/mergability_check.yml
+++ b/.github/workflows/mergability_check.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   do_merge_dry_run:
-    name: try_merge_pr_${{ github.event.pull_request.number }}
+    name: mergability_check_${{ github.event.pull_request.number }}
     runs-on: linux.20_04.4x
     env:
         GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/mergability_check.yml
+++ b/.github/workflows/mergability_check.yml
@@ -1,0 +1,53 @@
+name: Validate and check if PR is mergable
+
+on:
+  repository_dispatch:
+    types: [try-merge]
+  pull_request:
+
+jobs:
+  do_merge:
+    name: try_merge_pr_${{ github.event.client_payload.pr_num }}
+    runs-on: linux.20_04.4x
+    environment: mergebot
+    env:
+        GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Checkout repo
+        id: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+          check-latest: false
+          cache: pip
+          architecture: x64
+      - run: pip install pyyaml==6.0 rockset==1.0.3
+
+      - name: Dry Run Merge PR
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
+          PR_NUM: ${{ github.event.client_payload.pr_num }}
+          REBASE: ${{ github.event.client_payload.rebase }}
+          ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
+        run: |
+          set -ex
+          trap 'if [ $? -ne 0 ]; then echo "This PR is not mergable, please rebase and fix merge conflicts"; fi' EXIT
+          if [ -n "${REBASE}" ]; then
+            python3 .github/scripts/tryrebase.py "${PR_NUM}" --branch "${REBASE}"
+            git checkout main
+            git fetch -p
+            # give github some time between the push and start workflows so that Github's messages
+            # on the PR appear in chronological order (timing issues can shuffle them around)
+            sleep 60
+          fi
+          python3 .github/scripts/trymerge.py --force --dry-run "${PR_NUM}"
+# We want newer merge commands to supercede old ones
+concurrency:
+  group: try-merge-${{ github.event.client_payload.pr_num }}
+  cancel-in-progress: true

--- a/.github/workflows/mergability_check.yml
+++ b/.github/workflows/mergability_check.yml
@@ -29,7 +29,7 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUM: ${{ github.event.pull_request.number  }}
+          PR_NUM: ${{ github.event.pull_request.number }}
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
         run: |
           set -ex

--- a/.github/workflows/mergability_check.yml
+++ b/.github/workflows/mergability_check.yml
@@ -1,8 +1,6 @@
 name: Validate and check if PR is mergable
 
 on:
-  repository_dispatch:
-    types: [try-merge]
   pull_request:
 
 jobs:
@@ -33,19 +31,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
           PR_NUM: ${{ github.event.client_payload.pr_num }}
-          REBASE: ${{ github.event.client_payload.rebase }}
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
         run: |
           set -ex
           trap 'if [ $? -ne 0 ]; then echo "This PR is not mergable, please rebase and fix merge conflicts"; fi' EXIT
-          if [ -n "${REBASE}" ]; then
-            python3 .github/scripts/tryrebase.py "${PR_NUM}" --branch "${REBASE}"
-            git checkout main
-            git fetch -p
-            # give github some time between the push and start workflows so that Github's messages
-            # on the PR appear in chronological order (timing issues can shuffle them around)
-            sleep 60
-          fi
           python3 .github/scripts/trymerge.py --force --dry-run "${PR_NUM}"
 # We want newer merge commands to supercede old ones
 concurrency:

--- a/.github/workflows/mergability_check.yml
+++ b/.github/workflows/mergability_check.yml
@@ -33,7 +33,7 @@ jobs:
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
         run: |
           set -ex
-          trap 'if [ $? -ne 0 ]; then echo "This PR is not mergable, please rebase and fix merge conflicts"; fi' EXIT
+          git fetch
           python3 .github/scripts/trymerge.py --force --dry-run "${PR_NUM}"
 # We want newer merge commands to supercede old ones
 concurrency:

--- a/.github/workflows/mergability_check.yml
+++ b/.github/workflows/mergability_check.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
 
 jobs:
-  do_merge:
-    name: try_merge_pr_${{ github.event.client_payload.pr_num }}
+  do_merge_dry_run:
+    name: try_merge_pr_${{ github.event.pull_request.number }}
     runs-on: linux.20_04.4x
     env:
         GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -29,7 +29,7 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUM: ${{ github.event.client_payload.pr_num }}
+          PR_NUM: ${{ github.event.pull_request.number  }}
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
         run: |
           set -ex
@@ -37,5 +37,5 @@ jobs:
           python3 .github/scripts/trymerge.py --force --dry-run "${PR_NUM}"
 # We want newer merge commands to supercede old ones
 concurrency:
-  group: mergability-check-${{ github.event.client_payload.pr_num }}
+  group: mergability-check-${{ github.event.pull_request.number  }}
   cancel-in-progress: true

--- a/.github/workflows/mergability_check.yml
+++ b/.github/workflows/mergability_check.yml
@@ -7,7 +7,6 @@ jobs:
   do_merge:
     name: try_merge_pr_${{ github.event.client_payload.pr_num }}
     runs-on: linux.20_04.4x
-    environment: mergebot
     env:
         GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
@@ -29,7 +28,7 @@ jobs:
       - name: Dry Run Merge PR
         if: github.event_name == 'pull_request'
         env:
-          GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUM: ${{ github.event.client_payload.pr_num }}
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
         run: |
@@ -38,5 +37,5 @@ jobs:
           python3 .github/scripts/trymerge.py --force --dry-run "${PR_NUM}"
 # We want newer merge commands to supercede old ones
 concurrency:
-  group: try-merge-${{ github.event.client_payload.pr_num }}
+  group: mergability-check-${{ github.event.client_payload.pr_num }}
   cancel-in-progress: true

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -3,6 +3,7 @@ name: Validate and merge PR
 on:
   repository_dispatch:
     types: [try-merge]
+  pull_request:
 
 jobs:
   do_merge:
@@ -33,6 +34,7 @@ jobs:
           git config --global user.email "pytorchmergebot@users.noreply.github.com"
           git config --global user.name "PyTorch MergeBot"
       - name: Merge PR
+        if : github.event_name == 'repository_dispatch'
         env:
           GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
           PR_NUM: ${{ github.event.client_payload.pr_num }}
@@ -70,7 +72,7 @@ jobs:
             python3 .github/scripts/trymerge.py "${PR_NUM}"
           fi
       - name: Comment on Canceled
-        if: ${{ cancelled() && steps.checkout.outcome == 'success' }}
+        if: ${{ cancelled() && steps.checkout.outcome == 'success' && github.event_name == 'repository_dispatch' }}
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
@@ -78,7 +80,27 @@ jobs:
         run: |
           set -ex
           python3 .github/scripts/comment_on_pr.py "${PR_NUM}" "merge"
-
+      - name: Dry Run Merge PR
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
+          PR_NUM: ${{ github.event.client_payload.pr_num }}
+          FORCE: ${{ github.event.client_payload.force}}
+          REBASE: ${{ github.event.client_payload.rebase }}
+          ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
+          DRCI_BOT_KEY: ${{ secrets.DRCI_BOT_KEY }}
+        run: |
+          set -ex
+          trap 'if [ $? -ne 0 ]; then echo "This PR is not mergable, please rebase and fix merge conflicts"; fi' EXIT
+          if [ -n "${REBASE}" ]; then
+            python3 .github/scripts/tryrebase.py "${PR_NUM}" --branch "${REBASE}"
+            git checkout main
+            git fetch -p
+            # give github some time between the push and start workflows so that Github's messages
+            # on the PR appear in chronological order (timing issues can shuffle them around)
+            sleep 60
+          fi
+          python3 .github/scripts/trymerge.py --force --dry-run "${PR_NUM}"
 # We want newer merge commands to supercede old ones
 concurrency:
   group: try-merge-${{ github.event.client_payload.pr_num }}

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -3,7 +3,6 @@ name: Validate and merge PR
 on:
   repository_dispatch:
     types: [try-merge]
-  pull_request:
 
 jobs:
   do_merge:
@@ -34,7 +33,6 @@ jobs:
           git config --global user.email "pytorchmergebot@users.noreply.github.com"
           git config --global user.name "PyTorch MergeBot"
       - name: Merge PR
-        if : github.event_name == 'repository_dispatch'
         env:
           GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
           PR_NUM: ${{ github.event.client_payload.pr_num }}
@@ -72,7 +70,7 @@ jobs:
             python3 .github/scripts/trymerge.py "${PR_NUM}"
           fi
       - name: Comment on Canceled
-        if: ${{ cancelled() && steps.checkout.outcome == 'success' && github.event_name == 'repository_dispatch' }}
+        if: ${{ cancelled() && steps.checkout.outcome == 'success' }}
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
@@ -80,27 +78,7 @@ jobs:
         run: |
           set -ex
           python3 .github/scripts/comment_on_pr.py "${PR_NUM}" "merge"
-      - name: Dry Run Merge PR
-        if: github.event_name == 'pull_request'
-        env:
-          GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
-          PR_NUM: ${{ github.event.client_payload.pr_num }}
-          FORCE: ${{ github.event.client_payload.force}}
-          REBASE: ${{ github.event.client_payload.rebase }}
-          ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
-          DRCI_BOT_KEY: ${{ secrets.DRCI_BOT_KEY }}
-        run: |
-          set -ex
-          trap 'if [ $? -ne 0 ]; then echo "This PR is not mergable, please rebase and fix merge conflicts"; fi' EXIT
-          if [ -n "${REBASE}" ]; then
-            python3 .github/scripts/tryrebase.py "${PR_NUM}" --branch "${REBASE}"
-            git checkout main
-            git fetch -p
-            # give github some time between the push and start workflows so that Github's messages
-            # on the PR appear in chronological order (timing issues can shuffle them around)
-            sleep 60
-          fi
-          python3 .github/scripts/trymerge.py --force --dry-run "${PR_NUM}"
+
 # We want newer merge commands to supercede old ones
 concurrency:
   group: try-merge-${{ github.event.client_payload.pr_num }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #112210

Unfortunately, we do not have a good way of propogating the mergability of a ghstack PR internally. This PR attempts to fix this by creating a breadcrumb we can propogate to ghexport checks in order to say if the PR is mergable with pytorch bot.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9bc6cfc</samp>

Add a new GitHub Actions workflow to check pull request mergability. The workflow `.github/workflows/mergability_check.yml` runs some validation and checks on the pull request title, labels, and conflicts.
