### PR TITLE
State_dict serialization for meta tensors

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -206,7 +206,10 @@ class TestDeserialize(TestCase):
         for orig, loaded in zip(flat_orig_outputs, flat_loaded_outputs):
             self.assertEqual(type(orig), type(loaded))
             if isinstance(orig, torch.Tensor):
-                self.assertTrue(torch.allclose(orig, loaded))
+                if orig.is_meta:
+                    self.assertEqual(orig, loaded)
+                else:
+                    self.assertTrue(torch.allclose(orig, loaded))
             else:
                 self.assertEqual(orig, loaded)
 
@@ -374,6 +377,21 @@ class TestDeserialize(TestCase):
 
         inputs = (torch.randn(3, 3),)
         self.check_graph(M(), inputs)
+
+    def test_module_meta(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.p = torch.nn.Parameter(torch.ones(3, 3))
+
+            def forward(self, x):
+                return self.p + x
+
+        with torch.device("meta"):
+            mod = M()
+
+        inputs = (torch.randn(3, 3, device="meta"),)
+        self.check_graph(mod, inputs)
 
     def test_cond(self):
         from functorch.experimental.control_flow import cond

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -224,7 +224,13 @@ def serialize_torch_artifact(artifact) -> bytes:
     # on the designated device.
     # For now, we simply move the tensor to cpu before saving.
     # TODO: this should be fixed by deserialization instead.
-    artifact = tree_map_only(torch.Tensor, lambda t: t.cpu(), artifact)
+
+    def _tensor_to_cpu(t: torch.Tensor):
+        if t.is_meta:
+            return t
+        else:
+            return t.cpu()
+    artifact = tree_map_only(torch.Tensor, _tensor_to_cpu, artifact)
     torch.save(artifact, buffer)
     return buffer.getvalue()
 


### PR DESCRIPTION
Summary: Add cases for serializing meta tensors from state_dict

Test Plan: sandcastle

Differential Revision: D50718161




cc @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan @angelayi @suo