### PR TITLE
[5/N] Apply clang-tidy to aten/src/ATen/core 

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -254,7 +254,7 @@ command = [
 [[linter]]
 code = 'CLANGTIDY'
 include_patterns = [
-    'aten/src/ATen/core/**',
+    'aten/src/ATen/core/*.cpp',
     'c10/**/*.cpp',
     'torch/csrc/**/*.cpp',
 ]
@@ -266,6 +266,7 @@ exclude_patterns = [
     '**/*pb.h',
     '**/*CUDA*',
     '**/cuda/*pp',
+    'aten/src/ATen/core/TensorImpl_test.cpp',
     'third_party/**/*',
     'torch/csrc/api/**',
     'torch/csrc/autograd/generated/**',

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -254,6 +254,7 @@ command = [
 [[linter]]
 code = 'CLANGTIDY'
 include_patterns = [
+    'aten/src/ATen/core/**',
     'c10/**/*.cpp',
     'torch/csrc/**/*.cpp',
 ]

--- a/aten/src/ATen/core/IListRef_test.cpp
+++ b/aten/src/ATen/core/IListRef_test.cpp
@@ -1,9 +1,11 @@
+#ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
+#else
+#include <ATen/ops/empty.h>
+#endif
 #include <ATen/core/IListRef.h>
-#include <ATen/core/Tensor.h>
 #include <gtest/gtest.h>
 #include <algorithm>
-#include <iterator>
 
 using namespace c10;
 

--- a/aten/src/ATen/core/List_test.cpp
+++ b/aten/src/ATen/core/List_test.cpp
@@ -3,7 +3,7 @@
 
 using namespace c10;
 
-// NOLINTBEGIN(performance-move-const-arg)
+// NOLINTBEGIN(performance-move-const-arg, bugprone-use-after-move)
 TEST(ListTestIValueBasedList, givenEmptyList_whenCallingEmpty_thenReturnsTrue) {
     List<string> list;
     EXPECT_TRUE(list.empty());
@@ -1160,4 +1160,4 @@ TEST(ListTest, toTypedList) {
   genericList = impl::toList(std::move(stringList));
   EXPECT_THROW(c10::impl::toTypedList<int64_t>(std::move(genericList)), c10::Error);
 }
-// NOLINTEND(performance-move-const-arg)
+// NOLINTEND(performance-move-const-arg, bugprone-use-after-move)

--- a/aten/src/ATen/core/MT19937RNGEngine.h
+++ b/aten/src/ATen/core/MT19937RNGEngine.h
@@ -110,6 +110,7 @@ struct mt19937_data_pod {
 class mt19937_engine {
 public:
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   inline explicit mt19937_engine(uint64_t seed = 5489) {
     init_with_uint32(seed);
   }
@@ -136,12 +137,10 @@ public:
   }
 
   inline uint32_t operator()() {
-    uint32_t y;
-
     if (--(data_.left_) == 0) {
         next_state();
     }
-    y = *(data_.state_.data() + data_.next_++);
+    uint32_t y = *(data_.state_.data() + data_.next_++);
     y ^= (y >> 11);
     y ^= (y << 7) & 0x9d2c5680;
     y ^= (y << 15) & 0xefc60000;

--- a/aten/src/ATen/core/PhiloxRNGEngine.h
+++ b/aten/src/ATen/core/PhiloxRNGEngine.h
@@ -6,7 +6,6 @@
 #include <math.h>
 #endif
 
-#include <stdint.h>
 
 #ifdef __CUDACC__
 #include <cuda.h>
@@ -17,6 +16,7 @@
 #include <c10/util/Exception.h>
 #include <c10/util/Half.h>
 #include <cmath>
+#include <cstdint>
 
 namespace at {
 
@@ -68,6 +68,7 @@ typedef at::detail::Array<float, 2> FLOAT2;
 class philox_engine {
 public:
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   C10_HOST_DEVICE inline explicit philox_engine(uint64_t seed = 67280421310721,
                                  uint64_t subsequence = 0,
                                  uint64_t offset = 0) {
@@ -113,6 +114,7 @@ public:
       output_ = rand(counter, key, n_rounds);
       incr();
     }
+    // NOLINTNEXTLINE(*-narrowing-conversions)
     uint32_t ret = output_[STATE];
     STATE = (STATE + 1) & 3;
     return ret;
@@ -132,7 +134,7 @@ public:
     // TODO(voz) We use std:: below, and thus need a separate impl for CUDA.
     float u1 = 1 - uint32_to_uniform_float(output_[0]); // uint32_to_uniform_float returns [0,1), we need (0,1] to avoid passing 0 to log.
     float u2 = 1 - uint32_to_uniform_float(output_[1]);
-    return std::sqrt(-2.0 * std::log(u1)) * std::cos(2.0 * M_PI * u2);
+    return static_cast<float>(std::sqrt(-2.0 * std::log(u1)) * std::cos(2.0 * M_PI * u2));
   }
 
   /**
@@ -201,8 +203,8 @@ private:
   }
 
   C10_HOST_DEVICE inline detail::UINT4 single_round(detail::UINT4 ctr, detail::UINT2 in_key) {
-    uint32_t hi0;
-    uint32_t hi1;
+    uint32_t hi0 = 0;
+    uint32_t hi1 = 0;
     uint32_t lo0 = mulhilo32(kPhiloxSA, ctr[0], &hi0);
     uint32_t lo1 = mulhilo32(kPhiloxSB, ctr[2], &hi1);
     detail::UINT4 ret;

--- a/aten/src/ATen/core/PhiloxRNGEngine.h
+++ b/aten/src/ATen/core/PhiloxRNGEngine.h
@@ -114,8 +114,7 @@ public:
       output_ = rand(counter, key, n_rounds);
       incr();
     }
-    // NOLINTNEXTLINE(*-narrowing-conversions)
-    uint32_t ret = output_[STATE];
+    uint32_t ret = output_[static_cast<int>(STATE)];
     STATE = (STATE + 1) & 3;
     return ret;
   }

--- a/aten/src/ATen/core/TensorAccessor.h
+++ b/aten/src/ATen/core/TensorAccessor.h
@@ -5,8 +5,8 @@
 #include <c10/util/Deprecated.h>
 #include <c10/util/Exception.h>
 #include <c10/util/irange.h>
-#include <stdint.h>
 #include <cstddef>
+#include <cstdint>
 
 namespace at {
 
@@ -120,6 +120,7 @@ template<typename T, size_t N, template <typename U> class PtrTraits = DefaultPt
 class GenericPackedTensorAccessorBase {
 public:
   typedef typename PtrTraits<T>::PtrType PtrType;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   C10_HOST GenericPackedTensorAccessorBase(
       PtrType data_,
       const index_t* sizes_,
@@ -131,6 +132,7 @@ public:
 
   // if index_t is not int64_t, we want to have an int64_t constructor
   template <typename source_index_t, class = typename std::enable_if<std::is_same<source_index_t, int64_t>::value>::type>
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   C10_HOST GenericPackedTensorAccessorBase(
       PtrType data_,
       const source_index_t* sizes_,
@@ -156,7 +158,9 @@ public:
   }
 protected:
   PtrType data_;
+  // NOLINTNEXTLINE(*c-arrays*)
   index_t sizes_[N];
+  // NOLINTNEXTLINE(*c-arrays*)
   index_t strides_[N];
   C10_HOST void bounds_check_(index_t i) const {
     TORCH_CHECK_INDEX(


### PR DESCRIPTION
Enlarge clang-tidy coverage to aten/src/ATen/core/* files
