### PR TITLE
[dtensor] Introduce full_tensor API to DTensor

### DIFF
--- a/test/distributed/_tensor/test_dtensor_ops.py
+++ b/test/distributed/_tensor/test_dtensor_ops.py
@@ -8,7 +8,7 @@ import torch
 import torch.distributed as dist
 import torch.testing._internal.common_methods_invocations as common_ops
 
-from torch.distributed._tensor import DeviceMesh, DTensor, Replicate
+from torch.distributed._tensor import DeviceMesh, DTensor
 
 from torch.overrides import resolve_name
 from torch.testing._internal.common_device_type import (
@@ -620,11 +620,7 @@ class TestDTensorOps(DTensorOpTestBase):
         rs = concat_res_if_necessary(func, rs)
 
         def to_replicate(e: object) -> object:
-            return (
-                e.redistribute(self.mesh, self.mesh.ndim * [Replicate()])
-                if isinstance(e, DTensor)
-                else e
-            )
+            return e.full_tensor() if isinstance(e, DTensor) else e
 
         try:
             # Suppress warnings, this doesn't matter for test_meta.py

--- a/test/distributed/_tensor/test_embedding_ops.py
+++ b/test/distributed/_tensor/test_embedding_ops.py
@@ -110,10 +110,7 @@ class TestEmbeddingOp(DTensorTestBase):
             sharded_embedding.weight,
             **kwargs,
         )
-        self.assertEqual(
-            local_output,
-            sharded_output.redistribute(device_mesh, [Replicate()]).to_local(),
-        )
+        self.assertEqual(local_output, sharded_output.full_tensor())
 
     @with_comms
     def test_sharded_embedding_colwise(self):

--- a/test/distributed/_tensor/test_math_ops.py
+++ b/test/distributed/_tensor/test_math_ops.py
@@ -36,7 +36,7 @@ class DistMathOpsTest(DTensorTestBase):
 
         full_sumed_tensor = tensor_to_sum.sum()
         dt_sum = mat1.sum().full_tensor()
-        self.assertEqual(dt_sum.to_local(), full_sumed_tensor)
+        self.assertEqual(dt_sum, full_sumed_tensor)
 
     # TODO: forward test can be removed once test_softmax_with_bwd passes on CPU
     @with_comms

--- a/test/distributed/_tensor/test_math_ops.py
+++ b/test/distributed/_tensor/test_math_ops.py
@@ -31,13 +31,11 @@ class DistMathOpsTest(DTensorTestBase):
             for keep_dim in keep_dim_or_not:
                 sum_args = (dim, keep_dim) if keep_dim is not None else (dim,)
                 dim_sumed_tensor = tensor_to_sum.sum(*sum_args)
-                dt_dim_sumed_tensor = mat1.sum(*sum_args).redistribute(
-                    device_mesh, [Replicate()] * device_mesh.ndim
-                )
-                self.assertEqual(dt_dim_sumed_tensor.to_local(), dim_sumed_tensor)
+                dt_dim_sumed_tensor = mat1.sum(*sum_args).full_tensor()
+                self.assertEqual(dt_dim_sumed_tensor, dim_sumed_tensor)
 
         full_sumed_tensor = tensor_to_sum.sum()
-        dt_sum = mat1.sum().redistribute(device_mesh, [Replicate()] * device_mesh.ndim)
+        dt_sum = mat1.sum().full_tensor()
         self.assertEqual(dt_sum.to_local(), full_sumed_tensor)
 
     # TODO: forward test can be removed once test_softmax_with_bwd passes on CPU
@@ -69,8 +67,7 @@ class DistMathOpsTest(DTensorTestBase):
                 )
                 shard_dim = shard_dim + dist_y.ndim if shard_dim < 0 else shard_dim
                 self.assertTrue(dist_y.placements[0].is_shard(dim=shard_dim))
-                dist_y = dist_y.redistribute(device_mesh, [Replicate()])
-                self.assertEqual(dist_y.to_local(), local_y)
+                self.assertEqual(dist_y.full_tensor(), local_y)
 
     # TODO: get test_softmax_with_bwd pass on CPU
     # DTensor's _softmax_backward_data produces wrong result on CPU on certain dimension.
@@ -111,8 +108,7 @@ class DistMathOpsTest(DTensorTestBase):
                 self.assertIsNone(dist_x.grad)
                 dist_y.backward()
                 self.assertIsNotNone(dist_x.grad)
-                dist_x_grad = dist_x.grad.redistribute(device_mesh, [Replicate()])
-                self.assertEqual(dist_x_grad.to_local(), x.grad)
+                self.assertEqual(dist_x.grad.full_tensor(), x.grad)
 
 
 if __name__ == "__main__":

--- a/test/distributed/_tensor/test_matrix_ops.py
+++ b/test/distributed/_tensor/test_matrix_ops.py
@@ -37,10 +37,7 @@ class DistMatrixOpsTest(DTensorTestBase):
 
         dist_res = torch.addmm(input, mat1, mat2)
         local_res = torch.addmm(input_tensor, tensor_to_shard, tensor_to_replicate)
-        self.assertEqual(
-            dist_res.redistribute(device_mesh, replica_spec).to_local(),
-            local_res,
-        )
+        self.assertEqual(dist_res.full_tensor(), local_res)
 
     @with_comms
     def test_addmm_auto_redistribute(self):
@@ -64,16 +61,14 @@ class DistMatrixOpsTest(DTensorTestBase):
         self.assertIsInstance(dist_res.placements[0], _Partial)
 
         # test if result is the same as tensor
-        replica_res = dist_res.redistribute(device_mesh, replica_spec)
-        dist_local_res = replica_res.to_local()
+        dist_local_res = dist_res.full_tensor()
         self.assertEqual(local_res, dist_local_res)
 
         # backward checks
         dist_local_res.sum().backward()
         local_res.sum().backward()
         self.assertIsNotNone(mat2.grad)
-        mat2_grad = mat2.grad.redistribute(device_mesh, replica_spec)
-        self.assertEqual(mat2_grad.to_local(), tensor_to_shard0.grad)
+        self.assertEqual(mat2.grad.full_tensor(), tensor_to_shard0.grad)
 
     @with_comms
     def test_mm(self):

--- a/test/distributed/_tensor/test_pointwise_ops.py
+++ b/test/distributed/_tensor/test_pointwise_ops.py
@@ -63,10 +63,7 @@ def deepcopy_convert_from_dtensor(val: Any) -> Any:
 
     def f(x):
         if isinstance(x, DTensor):
-            return x.redistribute(
-                device_mesh=x.device_mesh,
-                placements=[Replicate()] * x.device_mesh.ndim,
-            ).to_local()
+            return x.full_tensor()
         return x
 
     return pytree.tree_map(f, [val])[0]

--- a/test/distributed/_tensor/test_random_ops.py
+++ b/test/distributed/_tensor/test_random_ops.py
@@ -125,7 +125,9 @@ class DistTensorRandomOpTest(DTensorTestBase):
         dtensor = dropout(dtensor)
 
         # allgather the local tensors
-        local_tensor = dtensor.full_tensor()
+        local_tensor = funcol.all_gather_tensor(
+            dtensor.to_local(), gather_dim=0, group=(device_mesh, 0)
+        )
 
         # compare with local tensors from other ranks
         self_slice = slice(4 * self.rank, 4 * self.rank + 4)

--- a/test/distributed/_tensor/test_random_ops.py
+++ b/test/distributed/_tensor/test_random_ops.py
@@ -50,10 +50,6 @@ class DistTensorRandomInitTest(DTensorTestBase):
             dtensor = init_op(dtensor, *args, **kwargs)
             local_tensor = dtensor.to_local()
 
-            # allgather the local tensors
-            dtensor = dtensor.redistribute(device_mesh, [Replicate()])
-            local_tensor_gathered = dtensor.to_local()
-
             # compare with local tensors from other ranks
             for other_rank in range(self.world_size):
                 if self.rank != other_rank:
@@ -64,7 +60,7 @@ class DistTensorRandomInitTest(DTensorTestBase):
                         ),
                     ]
                     # other rank should have a different local tensor
-                    self.assertNotEqual(local_tensor_gathered[slice_idx], local_tensor)
+                    self.assertNotEqual(dtensor.full_tensor()[slice_idx], local_tensor)
 
     @with_comms
     def test_init_ops(self):
@@ -129,9 +125,7 @@ class DistTensorRandomOpTest(DTensorTestBase):
         dtensor = dropout(dtensor)
 
         # allgather the local tensors
-        local_tensor = funcol.all_gather_tensor(
-            dtensor.to_local(), gather_dim=0, group=(device_mesh, 0)
-        )
+        local_tensor = dtensor.full_tensor()
 
         # compare with local tensors from other ranks
         self_slice = slice(4 * self.rank, 4 * self.rank + 4)
@@ -276,10 +270,7 @@ class DistTensorRandomOpTest(DTensorTestBase):
             # the local shard
             local_tensor = dtensor.to_local()
             # allgather the local tensors
-            dtensor = dtensor.redistribute(
-                device_mesh, [Replicate(), Replicate(), Replicate()]
-            )
-            local_tensor_gathered = dtensor.to_local()
+            full_tensor = dtensor.full_tensor()
 
             # compare local tensor with each other shard
             for other_local_shard in local_shard_comb:
@@ -288,9 +279,9 @@ class DistTensorRandomOpTest(DTensorTestBase):
                     slice(offset, offset + size) for offset, size in other_local_shard
                 ]
                 if local_shard_offset == other_local_shard_offset:
-                    self.assertEqual(local_tensor_gathered[slice_idx], local_tensor)
+                    self.assertEqual(full_tensor[slice_idx], local_tensor)
                 else:
-                    self.assertNotEqual(local_tensor_gathered[slice_idx], local_tensor)
+                    self.assertNotEqual(full_tensor[slice_idx], local_tensor)
 
     @with_comms
     @skip_if_lt_x_gpu(4)

--- a/test/distributed/_tensor/test_redistribute.py
+++ b/test/distributed/_tensor/test_redistribute.py
@@ -277,9 +277,7 @@ class MultiDimRedistributeTest(DTensorTestBase):
                     dt2 = dt.redistribute(device_mesh, outputs)
 
                     # replicate and then get first shard
-                    local_full = dt2.redistribute(
-                        device_mesh, device_mesh.ndim * [Replicate()]
-                    ).to_local()
+                    local_full = dt2.full_tensor()
 
                     if torch.distributed.get_rank() == 0:
                         self.assertEqual(local_full.shape, full_tensor.shape)

--- a/test/distributed/_tensor/test_tensor_ops.py
+++ b/test/distributed/_tensor/test_tensor_ops.py
@@ -174,10 +174,7 @@ class DistTensorOpsTest(DTensorTestBase):
 
         ones_like_dt = torch.ones_like(dist_tensor)
         ones_expected = torch.ones(dist_tensor.shape)
-        self.assertEqual(
-            ones_expected,
-            ones_like_dt.redistribute(device_mesh, [Replicate()]).to_local(),
-        )
+        self.assertEqual(ones_expected, ones_like_dt.full_tensor())
 
     @with_comms
     def test_fill_inplace_partial_sum(self):
@@ -190,10 +187,7 @@ class DistTensorOpsTest(DTensorTestBase):
 
         torch.fill_(dist_tensor, 42)
         fill_expected = torch.full(dist_tensor.shape, 42, dtype=input_tensor.dtype)
-        self.assertEqual(
-            fill_expected,
-            dist_tensor.redistribute(device_mesh, [Replicate()]).to_local(),
-        )
+        self.assertEqual(fill_expected, dist_tensor.full_tensor())
 
     @with_comms
     def test_zeros_like_partial_sum(self):
@@ -206,10 +200,7 @@ class DistTensorOpsTest(DTensorTestBase):
 
         zeros_like_dt = torch.zeros_like(dist_tensor)
         zeros_expected = torch.zeros(dist_tensor.shape)
-        self.assertEqual(
-            zeros_expected,
-            zeros_like_dt.redistribute(device_mesh, [Replicate()]).to_local(),
-        )
+        self.assertEqual(zeros_expected, zeros_like_dt.full_tensor())
 
     @with_comms
     def test_zero_inplace(self):
@@ -266,10 +257,7 @@ class DistTensorOpsTest(DTensorTestBase):
         for d_args, d_kwargs in dtc:
             self.assertTrue(dtc.successful())
             d_out = op_call(*d_args, **d_kwargs)
-            self.assertEqual(
-                d_out.redistribute(mesh, [Replicate()] * mesh.ndim).to_local(),
-                out,
-            )
+            self.assertEqual(d_out.full_tensor(), out)
 
     @with_comms
     def test_index(self):
@@ -390,7 +378,7 @@ class DistTensorOpsTest(DTensorTestBase):
             mat = distribute_tensor(global_tensor, mesh, spec)
             res = torch.where(mat > 0, 1, 0)
             ref = torch.where(global_tensor > 0, 1, 0)
-            self.assertEqual(res.redistribute(placements=[Replicate()]).to_local(), ref)
+            self.assertEqual(res.full_tensor(), ref)
 
 
 if __name__ == "__main__":

--- a/test/distributed/_tensor/test_view_ops.py
+++ b/test/distributed/_tensor/test_view_ops.py
@@ -171,9 +171,7 @@ class TestViewOps(DTensorTestBase):
 
             self.assertEqual(profiler.num_calls, 0, "Expected no redistribution.")
 
-            full_out = out_dt.redistribute(
-                device_mesh, device_mesh.ndim * [Replicate()]
-            ).to_local()
+            full_out = out_dt.full_tensor()
 
             if dist.get_rank() == 0:
                 self.assertEqual(outputs, full_out)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #112224

This PR introduces a `full_tensor` API to DTensor, there were so many
callsites that exercises the `redistribute(replicate)` path and I feel
it deserves a separate API, mostly just a syntactic sugar