### PR TITLE
Revert "[aotinductor] only include -lc10 for non-fbcode case (#112125)"

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1201,10 +1201,9 @@ def get_include_and_linking_paths(
         else:
             libs = ["omp"] if config.is_fbcode() else ["gomp"]
 
-    # Unconditionally import c10 for non-fbcode to use TORCH_CHECK - See PyTorch #108690
-    if not config.is_fbcode():
-        libs += ["c10"]
-        lpaths += [cpp_extension.TORCH_LIB_PATH]
+    # Unconditionally import c10 to use TORCH_CHECK - See PyTorch #108690
+    libs += ["c10"]
+    lpaths += [cpp_extension.TORCH_LIB_PATH]
 
     # third party libs
     if config.is_fbcode():


### PR DESCRIPTION
This reverts commit 5e5329155e0aea98418923cf8046fa3cdbde81cc.

Fixes #ISSUE_NUMBER


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler