### PR TITLE
[cuda] introduce trace tracker callback in cache allocator

### DIFF
--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -70,6 +70,7 @@ list(APPEND ATen_CUDA_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_optional_test.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_packedtensoraccessor_test.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_reportMemoryUsage_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_allocatorTraceTracker_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_stream_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_vectorized_test.cu)
 if(CAFFE2_USE_CUDNN)

--- a/aten/src/ATen/test/cuda_allocatorTraceTracker_test.cpp
+++ b/aten/src/ATen/test/cuda_allocatorTraceTracker_test.cpp
@@ -1,0 +1,51 @@
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <gtest/gtest.h>
+
+static int segmentAllocCalled = 0;
+static int segmentFreeCalled = 0;
+
+static void SegmentAllocTraceTracker(
+    const c10::cuda::CUDACachingAllocator::TraceEntry& te) {
+  if (te.action_ ==
+      c10::cuda::CUDACachingAllocator::TraceEntry::Action::SEGMENT_ALLOC) {
+    segmentAllocCalled++;
+  }
+}
+
+static void SegmentFreeTraceTracker(
+    const c10::cuda::CUDACachingAllocator::TraceEntry& te) {
+  if (te.action_ ==
+      c10::cuda::CUDACachingAllocator::TraceEntry::Action::SEGMENT_FREE) {
+    segmentFreeCalled++;
+  }
+}
+
+static void allocateLargeBuffer() {
+  const auto _500mb = 500 * 1024 * 1024;
+  auto* allocator = c10::cuda::CUDACachingAllocator::get();
+  auto buffer = allocator->allocate(_500mb);
+}
+
+TEST(AllocatorTraceTracker, TrackMallocFree) {
+  c10::cuda::CUDACachingAllocator::attachAllocatorTraceTracker(
+      &SegmentAllocTraceTracker);
+  c10::cuda::CUDACachingAllocator::attachAllocatorTraceTracker(
+      &SegmentFreeTraceTracker);
+
+  // Expect to trigger segment allocation for large buffer
+  // and expect the buffer would be marked as inactive when return from
+  // allocateLargeBuffer and be freed when calling emptyCache
+  allocateLargeBuffer();
+  ASSERT_EQ(segmentAllocCalled, 1);
+
+  // Expect allocated buffer has been released back to allocator, thus empty
+  // cache would trigger segment free
+  c10::cuda::CUDACachingAllocator::emptyCache();
+  ASSERT_EQ(segmentFreeCalled, 1);
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  c10::cuda::CUDACachingAllocator::init(1);
+  return RUN_ALL_TESTS();
+}

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -884,6 +884,7 @@ class DeviceCachingAllocator {
   bool set_fraction = false;
 
   bool record_history = false;
+
   std::atomic<CreateContextFn> context_recorder_;
   size_t alloc_trace_next = 0;
   RecordContext record_context_ = RecordContext::NEVER;
@@ -911,6 +912,8 @@ class DeviceCachingAllocator {
 
   // XXX - maybe we should generalize and have multiple events
   std::vector<OutOfMemoryObserver> oom_observers_;
+
+  std::vector<AllocatorTraceTracker> trace_trackers_;
 
  public:
   DeviceCachingAllocator()
@@ -967,6 +970,11 @@ class DeviceCachingAllocator {
 
   void attachOutOfMemoryObserver(OutOfMemoryObserver observer) {
     oom_observers_.emplace_back(std::move(observer));
+  }
+
+  void attachAllocatorTraceTracker(AllocatorTraceTracker tracker) {
+    std::unique_lock<std::recursive_mutex> lock(mutex);
+    trace_trackers_.emplace_back(std::move(tracker));
   }
 
   // Must be called outside of `mutex` or deadlocks are possible with Python
@@ -1053,14 +1061,13 @@ class DeviceCachingAllocator {
 
       std::string proc_info = reportProcessMemoryInfo(device);
 
-      if (record_history) {
-        record_trace(
-            TraceEntry::OOM,
-            device_free,
-            params.size(),
-            params.stream(),
-            std::move(context));
-      }
+      record_trace(
+          TraceEntry::OOM,
+          device_free,
+          params.size(),
+          params.stream(),
+          params.device(),
+          std::move(context));
       stats.num_ooms += 1;
 
       c10::reportOutOfMemoryToProfiler(
@@ -1202,15 +1209,15 @@ class DeviceCachingAllocator {
 
     block->allocated = true;
     block->requested_size = orig_size;
-    if (record_history) {
-      block->context_when_allocated = std::move(context);
-      record_trace(
-          TraceEntry::ALLOC,
-          int64_t(block->ptr),
-          orig_size,
-          block->stream,
-          block->context_when_allocated);
-    }
+
+    block->context_when_allocated = std::move(context);
+    record_trace(
+        TraceEntry::ALLOC,
+        int64_t(block->ptr),
+        orig_size,
+        block->stream,
+        block->device,
+        block->context_when_allocated);
 
     bool inserted = active_blocks.insert(block).second;
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(inserted);
@@ -1260,14 +1267,15 @@ class DeviceCachingAllocator {
           stats.allocated_bytes[stat_type],
           -static_cast<std::int64_t>(block->size));
     });
-    if (record_history) {
-      record_trace(
-          TraceEntry::FREE_REQUESTED,
-          int64_t(block->ptr),
-          block->requested_size,
-          block->stream,
-          context ? context : block->context_when_allocated);
-    }
+
+    record_trace(
+        TraceEntry::FREE_REQUESTED,
+        int64_t(block->ptr),
+        block->requested_size,
+        block->stream,
+        block->device,
+        context ? context : block->context_when_allocated);
+
     if (block->size >= CUDAAllocatorConfig::max_split_size())
       update_stat(stats.oversize_allocations, -1);
 
@@ -1700,9 +1708,7 @@ class DeviceCachingAllocator {
           return a.address < b.address;
         });
 
-    if (record_history) {
-      record_trace(TraceEntry::SNAPSHOT, 0, total_active, nullptr, nullptr);
-    }
+    record_trace(TraceEntry::SNAPSHOT, 0, total_active, nullptr, 0, nullptr);
     return result;
   }
 
@@ -1979,16 +1985,16 @@ class DeviceCachingAllocator {
     for_each_selected_stat_type(stat_types, [&](size_t stat_type) {
       update_stat(stats.reserved_bytes[stat_type], mapped_range.size);
     });
-    if (record_history) {
-      record_trace(
-          TraceEntry::SEGMENT_MAP,
-          int64_t(mapped_range.ptr),
-          mapped_range.size,
-          to_map->stream,
-          ctx);
-      if (!to_map->prev && !to_map->context_when_segment_allocated) {
-        to_map->context_when_segment_allocated = ctx;
-      }
+
+    record_trace(
+        TraceEntry::SEGMENT_MAP,
+        int64_t(mapped_range.ptr),
+        mapped_range.size,
+        to_map->stream,
+        to_map->device,
+        ctx);
+    if (!to_map->prev && !to_map->context_when_segment_allocated) {
+      to_map->context_when_segment_allocated = ctx;
     }
 
     return true;
@@ -2034,14 +2040,15 @@ class DeviceCachingAllocator {
     TORCH_INTERNAL_ASSERT(
         !block->allocated && block->event_count == 0 &&
         block->stream_uses.empty());
-    if (record_history) {
-      record_trace(
-          TraceEntry::FREE_COMPLETED,
-          int64_t(block->ptr),
-          block->requested_size,
-          block->stream,
-          context ? context : block->context_when_allocated);
-    }
+
+    record_trace(
+        TraceEntry::FREE_COMPLETED,
+        int64_t(block->ptr),
+        block->requested_size,
+        block->stream,
+        block->device,
+        context ? context : block->context_when_allocated);
+
     block->context_when_allocated = nullptr;
     size_t original_block_size = block->size;
     size_t requested_size = block->requested_size;
@@ -2400,15 +2407,14 @@ class DeviceCachingAllocator {
 
     // p.block came from new, not cudaMalloc. It should not be nullptr here.
     TORCH_INTERNAL_ASSERT(p.block != nullptr && p.block->ptr != nullptr);
-    if (record_history) {
-      record_trace(
-          TraceEntry::SEGMENT_ALLOC,
-          int64_t(p.block->ptr),
-          p.block->size,
-          p.stream(),
-          ctx);
-      p.block->context_when_segment_allocated = ctx;
-    }
+    record_trace(
+        TraceEntry::SEGMENT_ALLOC,
+        int64_t(p.block->ptr),
+        p.block->size,
+        p.stream(),
+        p.device(),
+        ctx);
+    p.block->context_when_segment_allocated = ctx;
     return true;
   }
 
@@ -2506,6 +2512,14 @@ class DeviceCachingAllocator {
 
   void release_block(Block* block) {
     TORCH_INTERNAL_ASSERT(!block->expandable_segment_);
+    record_trace(
+        TraceEntry::SEGMENT_FREE,
+        int64_t(block->ptr),
+        block->size,
+        block->stream,
+        block->device,
+        nullptr);
+
     C10_CUDA_CHECK(cudaFree((void*)block->ptr));
     total_allocated_memory -= block->size;
 
@@ -2526,14 +2540,6 @@ class DeviceCachingAllocator {
 
     if (block->size >= CUDAAllocatorConfig::max_split_size())
       update_stat(stats.oversize_segments, -1);
-    if (record_history) {
-      record_trace(
-          TraceEntry::SEGMENT_FREE,
-          int64_t(block->ptr),
-          block->size,
-          block->stream,
-          nullptr);
-    }
     pool->blocks.erase(block);
     delete block;
   }
@@ -2585,14 +2591,14 @@ class DeviceCachingAllocator {
     for_each_selected_stat_type(stat_types, [&](size_t stat_type) {
       update_stat(stats.reserved_bytes[stat_type], -unmapped.size);
     });
-    if (record_history) {
-      record_trace(
-          TraceEntry::SEGMENT_UNMAP,
-          int64_t(unmapped.ptr),
-          unmapped.size,
-          block->stream,
-          nullptr);
-    }
+
+    record_trace(
+        TraceEntry::SEGMENT_UNMAP,
+        int64_t(unmapped.ptr),
+        unmapped.size,
+        block->stream,
+        block->device,
+        nullptr);
   }
   void release_blocks(BlockPool& pool) {
     std::vector<Block*> to_unmap;
@@ -2738,19 +2744,32 @@ class DeviceCachingAllocator {
       int64_t addr,
       size_t size,
       cudaStream_t stream,
+      int device,
       std::shared_ptr<GatheredContext> context) {
+    if (!record_history && !trace_trackers_.size())
+      return;
+
     auto te = TraceEntry(
         action,
+        device,
         addr,
         size,
         stream,
         record_context_ >= RecordContext::ALLOC ? std::move(context) : nullptr);
-    if (alloc_trace->size() < alloc_trace_max_entries_) {
-      alloc_trace->emplace_back(te);
-    } else {
-      (*alloc_trace)[alloc_trace_next++] = te;
-      if (alloc_trace_next == alloc_trace_max_entries_) {
-        alloc_trace_next = 0;
+
+    // Callbacks should not include any Pytorch call
+    for (const auto& cb : trace_trackers_) {
+      cb(te);
+    }
+
+    if (record_history) {
+      if (alloc_trace->size() < alloc_trace_max_entries_) {
+        alloc_trace->emplace_back(te);
+      } else {
+        (*alloc_trace)[alloc_trace_next++] = te;
+        if (alloc_trace_next == alloc_trace_max_entries_) {
+          alloc_trace_next = 0;
+        }
       }
     }
   }
@@ -2897,6 +2916,12 @@ class NativeCachingAllocator : public CUDAAllocator {
   void attachOutOfMemoryObserver(OutOfMemoryObserver observer) override {
     for (auto& allocator : device_allocator) {
       allocator->attachOutOfMemoryObserver(std::move(observer));
+    }
+  }
+
+  void attachAllocatorTraceTracker(AllocatorTraceTracker tracker) override {
+    for (auto& allocator : device_allocator) {
+      allocator->attachAllocatorTraceTracker(tracker);
     }
   }
 

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -154,16 +154,19 @@ struct TraceEntry {
   };
   TraceEntry(
       Action action,
+      int device,
       int64_t addr,
       size_t size,
       cudaStream_t stream,
       std::shared_ptr<GatheredContext> context = nullptr)
       : action_(action),
+        device_(device),
         addr_(addr),
         context_(std::move(context)),
         stream_(stream),
         size_(size) {}
   Action action_;
+  int device_;
   int64_t addr_; // for OOM, this is the amount of free bytes reported by cuda
   std::shared_ptr<GatheredContext> context_;
   cudaStream_t stream_;
@@ -198,6 +201,8 @@ using OutOfMemoryObserver = std::function<void(
     int64_t allocated,
     int64_t device_total,
     int64_t device_free)>;
+
+using AllocatorTraceTracker = std::function<void(const TraceEntry&)>;
 
 class CUDAAllocator : public Allocator {
  public:
@@ -246,6 +251,14 @@ class CUDAAllocator : public Allocator {
       size_t alloc_trace_max_entries,
       RecordContext when) = 0;
   virtual void attachOutOfMemoryObserver(OutOfMemoryObserver observer) = 0;
+
+  // Attached AllocatorTraceTracker callbacks will be called while the
+  // per-device allocator lock is held. Any additional locks taken from within
+  // the callback must be proven to always have the lock order that never
+  // triggers a deadlock. In particular, Python's GIL may be held when
+  // calling the allocator so it is unsafe to try to acquire the GIL in this
+  // callback.
+  virtual void attachAllocatorTraceTracker(AllocatorTraceTracker tracker) = 0;
 
   virtual void enablePeerAccess(int dev, int dev_to_access) = 0;
 
@@ -388,6 +401,10 @@ inline bool checkPoolLiveAllocations(
 
 inline void attachOutOfMemoryObserver(OutOfMemoryObserver observer) {
   return get()->attachOutOfMemoryObserver(observer);
+}
+
+inline void attachAllocatorTraceTracker(AllocatorTraceTracker tracker) {
+  return get()->attachAllocatorTraceTracker(tracker);
 }
 
 inline void releasePool(int device, MempoolId_t mempool_id) {

--- a/c10/cuda/CUDAMallocAsyncAllocator.cpp
+++ b/c10/cuda/CUDAMallocAsyncAllocator.cpp
@@ -632,6 +632,13 @@ struct CudaMallocAsyncAllocator : public CUDAAllocator {
         "If you need it, please file an issue describing your use case.");
   }
 
+  void attachAllocatorTraceTracker(AllocatorTraceTracker tracker) override {
+    TORCH_CHECK(
+        false,
+        "cudaMallocAsync does not yet support attachAllocatorTraceTracker. "
+        "If you need it, please file an issue describing your use case.");
+  }
+
   std::shared_ptr<AllocatorState> getCheckpointState(int device, MempoolId_t id)
       override {
     TORCH_CHECK(

--- a/torch/csrc/cuda/CUDAPluggableAllocator.cpp
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.cpp
@@ -276,6 +276,14 @@ void CUDAPluggableAllocator::attachOutOfMemoryObserver(
       "If you need it, please file an issue describing your use case.");
 }
 
+void CUDAPluggableAllocator::attachAllocatorTraceTracker(
+    c10::cuda::CUDACachingAllocator::AllocatorTraceTracker tracker) {
+  TORCH_CHECK(
+      false,
+      "CUDAPluggableAllocator does not support attachAllocatorTraceTracker. "
+      "attachAllocatorTraceTracker is only used inside Pytorch.");
+}
+
 std::shared_ptr<c10::cuda::CUDACachingAllocator::AllocatorState>
 CUDAPluggableAllocator::getCheckpointState(
     int device,

--- a/torch/csrc/cuda/CUDAPluggableAllocator.h
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.h
@@ -102,6 +102,8 @@ struct CUDAPluggableAllocator
       c10::cuda::CUDACachingAllocator::RecordContext when) override;
   void attachOutOfMemoryObserver(
       c10::cuda::CUDACachingAllocator::OutOfMemoryObserver observer) override;
+  void attachAllocatorTraceTracker(
+      c10::cuda::CUDACachingAllocator::AllocatorTraceTracker tracker) override;
   std::shared_ptr<c10::cuda::CUDACachingAllocator::AllocatorState>
   getCheckpointState(int device, at::cuda::MempoolId_t id) override;
   c10::cuda::CUDACachingAllocator::CheckpointDelta setCheckpointPoolState(


### PR DESCRIPTION
Summary:
This patch prototypes a trace tracker callback mechanism based on existing TraceEntry records.

- It allows external of cache allocator to "attach" trace tracker callbacks. 
- When a TraceEntry is recorded, it triggers all attached callbacks. Callbacks can selectively behave based on the trace action. 
- **RISK**: The attached callback would be called within an allocator call stack (e.g., free during an allocate call). Potential deadlock may occur if other locks are called within the callback and has interdependency w/ the device allocator lock. It is the callback developer's responsibility to avoid any potential deadlock. 
- **ADVICE**: The callback mechanism is designed **only for Pytorch internal use**. We should not expose it to Python layer due to Python GIL that would cause a deadlock.

See example in D50726970 that attaches NCCL register/deregister hooks via the trace tracker callback, so that all CUDA segments allocated by the allocator can be registered to NCCL communicators before any NCCL communication happens. This enables fast zero copy algorithms in NCCL.

Differential Revision: D50726971


