### PR TITLE
[UCC] Fix input tensor in scatter

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupUCC.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupUCC.cpp
@@ -1497,7 +1497,7 @@ c10::intrusive_ptr<Work> ProcessGroupUCC::scatter(
       coll,
       std::unique_ptr<WorkData>(data),
       tensor.device(),
-      (getRank() == opts.rootRank) ? inputTensors[0]: outputTensors,
+      (getRank() == opts.rootRank) ? inputTensors[0] : outputTensors,
       outputTensors,
       "ucc:scatter");
 }

--- a/torch/csrc/distributed/c10d/ProcessGroupUCC.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupUCC.cpp
@@ -1497,7 +1497,7 @@ c10::intrusive_ptr<Work> ProcessGroupUCC::scatter(
       coll,
       std::unique_ptr<WorkData>(data),
       tensor.device(),
-      inputTensors[0],
+      (getRank() == opts.rootRank) ? inputTensors[0]: outputTensors,
       outputTensors,
       "ucc:scatter");
 }


### PR DESCRIPTION
Input tensor is valid only for root rank. Fixes https://github.com/openucx/ucc/issues/859
