### PR TITLE
[CODEMOD][numpy] replace np.float with float

### DIFF
--- a/caffe2/python/core_test.py
+++ b/caffe2/python/core_test.py
@@ -255,25 +255,25 @@ class TestExternalInputs(test_util.TestCase):
     def testAddExternalInputShouldRaiseIfDuplicate(self):
         net = core.Net("test")
         net.AddExternalInput(
-            schema.Struct(("x", schema.Scalar(np.float))),
+            schema.Struct(("x", schema.Scalar(float))),
         )
         with self.assertRaises(AssertionError):
             net.AddExternalInput(
-                schema.Struct(("x", schema.Scalar(np.float))),
+                schema.Struct(("x", schema.Scalar(float))),
             )
 
     def testAddExternalInputShouldRaiseIfDuplicateInSameCall(self):
         net = core.Net("test")
         with self.assertRaises(AssertionError):
             net.AddExternalInput(
-                schema.Struct(("x", schema.Scalar(np.float))),
-                schema.Struct(("x", schema.Scalar(np.float))),
+                schema.Struct(("x", schema.Scalar(float))),
+                schema.Struct(("x", schema.Scalar(float))),
             )
 
     def testSetInputRecordWithBlobs(self):
         net = core.Net("test")
         record = schema.NewRecord(net, schema.Struct(
-            ("x", schema.Scalar(np.float)),
+            ("x", schema.Scalar(float)),
         ))
         input_record = net.set_input_record(record)
         self.assertTrue(net.BlobIsDefined(input_record.x()))
@@ -281,7 +281,7 @@ class TestExternalInputs(test_util.TestCase):
 
     def testSetInputRecordWithoutBlobs(self):
         net = core.Net("test")
-        record = schema.Struct(("x", schema.Scalar(np.float)))
+        record = schema.Struct(("x", schema.Scalar(float)))
         input_record = net.set_input_record(record)
         self.assertTrue(net.BlobIsDefined(input_record.x()))
         self.assertIn(input_record.x(), net.external_inputs)

--- a/caffe2/python/layer_model_helper.py
+++ b/caffe2/python/layer_model_helper.py
@@ -124,7 +124,7 @@ class LayerModelHelper(model_helper.ModelHelper):
         assert isinstance(
             blob, (str, core.BlobReference)
         ), "expect type str or BlobReference, but got {}".format(type(blob))
-        dtype = dtype or (np.float, (1, ))
+        dtype = dtype or (float, (1, ))
         self.add_metric_field(str(blob), schema.Scalar(dtype, blob))
         self.ad_hoc_plot_blobs.append(blob)
 

--- a/caffe2/python/modeling/compute_norm_for_blobs.py
+++ b/caffe2/python/modeling/compute_norm_for_blobs.py
@@ -81,7 +81,7 @@ class ComputeNormForBlobs(NetModifier):
 
                 if modify_output_record:
                     output_field_name = str(blob) + self._field_name_suffix
-                    output_scalar = schema.Scalar((np.float, (1,)), norm)
+                    output_scalar = schema.Scalar((float, (1,)), norm)
 
                     if net.output_record() is None:
                         net.set_output_record(

--- a/caffe2/python/modeling/compute_statistics_for_blobs.py
+++ b/caffe2/python/modeling/compute_statistics_for_blobs.py
@@ -39,7 +39,7 @@ class ComputeStatisticsForBlobs(NetModifier):
 
             if modify_output_record:
                 output_field_name = str(blob) + self._field_name_suffix
-                output_scalar = schema.Scalar((np.float, (1,)), stats)
+                output_scalar = schema.Scalar((float, (1,)), stats)
 
                 if net.output_record() is None:
                     net.set_output_record(

--- a/caffe2/python/modeling/get_entry_from_blobs.py
+++ b/caffe2/python/modeling/get_entry_from_blobs.py
@@ -70,7 +70,7 @@ class GetEntryFromBlobs(NetModifier):
 
             if modify_output_record:
                 output_field_name = str(blob) + self._field_name_suffix
-                output_scalar = schema.Scalar((np.float), blob_i1_i2)
+                output_scalar = schema.Scalar((float), blob_i1_i2)
 
                 if net.output_record() is None:
                     net.set_output_record(

--- a/caffe2/python/operator_test/concat_op_cost_test.py
+++ b/caffe2/python/operator_test/concat_op_cost_test.py
@@ -38,7 +38,7 @@ class TestConcatOpCost(TestCase):
 
         [
             _test_columnwise_concat_for_type(t)
-            for t in [np.int64, np.float, np.half, np.int8]
+            for t in [np.int64, float, np.half, np.int8]
         ]
 
     def test_split_then_concat(self):

--- a/caffe2/python/operator_test/dropout_op_test.py
+++ b/caffe2/python/operator_test/dropout_op_test.py
@@ -101,7 +101,7 @@ class TestDropout(serial.SerializedTestCase):
             self.assertGradientChecks(gc, op, [X], 0, [0])
 
         def reference_dropout_ratio1(x):
-            return (x,) if is_test else (np.zeros(x.shape, dtype=np.float), np.zeros(x.shape, dtype=bool))
+            return (x,) if is_test else (np.zeros(x.shape, dtype=float), np.zeros(x.shape, dtype=bool))
         self.assertReferenceChecks(
             gc, op, [X], reference_dropout_ratio1,
             # Don't check the mask with cuDNN because it's packed data

--- a/caffe2/python/operator_test/feature_maps_ops_test.py
+++ b/caffe2/python/operator_test/feature_maps_ops_test.py
@@ -23,7 +23,7 @@ class TestFeatureMapsOps(TestCase):
         # Input 1.
         workspace.FeedBlob(
             "in1",
-            np.array([[11.1, 12.1, 13.1, 14.1], [11.2, 12.2, 13.2, 14.2]], dtype=np.float)
+            np.array([[11.1, 12.1, 13.1, 14.1], [11.2, 12.2, 13.2, 14.2]], dtype=float)
         )
         workspace.FeedBlob(
             "in1_presence",
@@ -42,7 +42,7 @@ class TestFeatureMapsOps(TestCase):
         )
         np.testing.assert_array_equal(
             workspace.FetchBlob("out_values"),
-            np.array([11.1, 14.1, 12.2, 13.2], dtype=np.float)
+            np.array([11.1, 14.1, 12.2, 13.2], dtype=float)
         )
 
 
@@ -62,7 +62,7 @@ class TestFeatureMapsOps(TestCase):
         # Input 1.
         workspace.FeedBlob(
             "in1",
-            np.array([11.1, 0.0], dtype=np.float)
+            np.array([11.1, 0.0], dtype=float)
         )
         workspace.FeedBlob(
             "in1_presence",
@@ -71,7 +71,7 @@ class TestFeatureMapsOps(TestCase):
         # Input 2.
         workspace.FeedBlob(
             "in2",
-            np.array([12.1, 12.2], dtype=np.float)
+            np.array([12.1, 12.2], dtype=float)
         )
         workspace.FeedBlob(
             "in2_presence",
@@ -90,7 +90,7 @@ class TestFeatureMapsOps(TestCase):
         )
         np.testing.assert_array_equal(
             workspace.FetchBlob("out_values"),
-            np.array([11.1, 12.1, 12.2], dtype=np.float)
+            np.array([11.1, 12.1, 12.2], dtype=float)
         )
 
     def test_merge_single_scalar_feature_tensors_gradient(self):
@@ -123,22 +123,22 @@ class TestFeatureMapsOps(TestCase):
         # Input 4.
         workspace.FeedBlob(
             "out_values_grad",
-            np.array([0.1, 1.1, 1.2, 2.3], dtype=np.float)
+            np.array([0.1, 1.1, 1.2, 2.3], dtype=float)
         )
 
         workspace.RunOperatorOnce(op)
 
         np.testing.assert_array_equal(
             workspace.FetchBlob("in1_grad"),
-            np.array([0.1, 0], dtype=np.float)
+            np.array([0.1, 0], dtype=float)
         )
         np.testing.assert_array_equal(
             workspace.FetchBlob("in2_grad"),
-            np.array([1.1, 1.2], dtype=np.float)
+            np.array([1.1, 1.2], dtype=float)
         )
         np.testing.assert_array_equal(
             workspace.FetchBlob("in3_grad"),
-            np.array([0, 2.3], dtype=np.float)
+            np.array([0, 2.3], dtype=float)
         )
 
     def test_merge_single_scalar_feature_tensors_gradient_with_strings(self):
@@ -210,7 +210,7 @@ class TestFeatureMapsOps(TestCase):
         )
         workspace.FeedBlob(
             "in1_values",
-            np.array([11.1, 11.2], dtype=np.float)
+            np.array([11.1, 11.2], dtype=float)
         )
         workspace.FeedBlob(
             "in1_presence",
@@ -223,7 +223,7 @@ class TestFeatureMapsOps(TestCase):
         )
         workspace.FeedBlob(
             "in2_values",
-            np.array([12.1, 12.2, 12.3, 12.4], dtype=np.float)
+            np.array([12.1, 12.2, 12.3, 12.4], dtype=float)
         )
         workspace.FeedBlob(
             "in2_presence",
@@ -246,7 +246,7 @@ class TestFeatureMapsOps(TestCase):
         )
         np.testing.assert_array_equal(
             workspace.FetchBlob("out_values_values"),
-            np.array([11.1, 11.2, 12.1, 12.2, 12.3, 12.4], dtype=np.float)
+            np.array([11.1, 11.2, 12.1, 12.2, 12.3, 12.4], dtype=float)
         )
 
     def test_merge_single_list_feature_tensors_gradient(self):
@@ -293,18 +293,18 @@ class TestFeatureMapsOps(TestCase):
         )
         workspace.FeedBlob(
             "out_values_values_grad",
-            np.array([11.1, 11.2, 12.1, 12.2, 12.3, 12.4], dtype=np.float)
+            np.array([11.1, 11.2, 12.1, 12.2, 12.3, 12.4], dtype=float)
         )
 
         workspace.RunOperatorOnce(op)
 
         np.testing.assert_array_equal(
             workspace.FetchBlob("in1_values_grad"),
-            np.array([11.1, 11.2], dtype=np.float)
+            np.array([11.1, 11.2], dtype=float)
         )
         np.testing.assert_array_equal(
             workspace.FetchBlob("in2_values_grad"),
-            np.array([12.1, 12.2, 12.3, 12.4], dtype=np.float)
+            np.array([12.1, 12.2, 12.3, 12.4], dtype=float)
         )
 
     def test_merge_single_map_feature_tensors(self):
@@ -332,7 +332,7 @@ class TestFeatureMapsOps(TestCase):
         )
         workspace.FeedBlob(
             "in1_values",
-            np.array([11.1, 11.2], dtype=np.float)
+            np.array([11.1, 11.2], dtype=float)
         )
         workspace.FeedBlob(
             "in1_presence",
@@ -349,7 +349,7 @@ class TestFeatureMapsOps(TestCase):
         )
         workspace.FeedBlob(
             "in2_values",
-            np.array([12.1, 12.2, 12.3, 12.4], dtype=np.float)
+            np.array([12.1, 12.2, 12.3, 12.4], dtype=float)
         )
         workspace.FeedBlob(
             "in2_presence",
@@ -376,7 +376,7 @@ class TestFeatureMapsOps(TestCase):
         )
         np.testing.assert_array_equal(
             workspace.FetchBlob("out_values_values"),
-            np.array([11.1, 11.2, 12.1, 12.2, 12.3, 12.4], dtype=np.float)
+            np.array([11.1, 11.2, 12.1, 12.2, 12.3, 12.4], dtype=float)
         )
 
     def test_merge_multi_scalar_feature_tensors(self):
@@ -402,7 +402,7 @@ class TestFeatureMapsOps(TestCase):
         )
         workspace.FeedBlob(
             "in1_values",
-            np.array([11.0, 12.0, 13.0], dtype=np.float)
+            np.array([11.0, 12.0, 13.0], dtype=float)
         )
         # Input 2.
         workspace.FeedBlob(
@@ -415,7 +415,7 @@ class TestFeatureMapsOps(TestCase):
         )
         workspace.FeedBlob(
             "in2_values",
-            np.array([14.0, 15.0, 16.0], dtype=np.float)
+            np.array([14.0, 15.0, 16.0], dtype=float)
         )
 
         workspace.RunOperatorOnce(op)
@@ -430,7 +430,7 @@ class TestFeatureMapsOps(TestCase):
         )
         np.testing.assert_array_equal(
             workspace.FetchBlob("out_values"),
-            np.array([11.0, 14.0, 15.0, 12.0, 13.0, 16.0], dtype=np.float)
+            np.array([11.0, 14.0, 15.0, 12.0, 13.0, 16.0], dtype=float)
         )
 
     def test_merge_multi_scalar_feature_tensors_gradient(self):
@@ -460,18 +460,18 @@ class TestFeatureMapsOps(TestCase):
         # Grad input.
         workspace.FeedBlob(
             "out_values_grad",
-            np.array([11.0, 14.0, 15.0, 12.0, 13.0, 16.0, 17.0], dtype=np.float)
+            np.array([11.0, 14.0, 15.0, 12.0, 13.0, 16.0, 17.0], dtype=float)
         )
 
         workspace.RunOperatorOnce(op)
 
         np.testing.assert_array_equal(
             workspace.FetchBlob("in1_values_grad"),
-            np.array([11.0, 12.0, 13.0], dtype=np.float)
+            np.array([11.0, 12.0, 13.0], dtype=float)
         )
         np.testing.assert_array_equal(
             workspace.FetchBlob("in2_values_grad"),
-            np.array([14.0, 15.0, 16.0, 17.0], dtype=np.float)
+            np.array([14.0, 15.0, 16.0, 17.0], dtype=float)
         )
 
     def test_merge_multi_list_feature_tensors(self):
@@ -504,7 +504,7 @@ class TestFeatureMapsOps(TestCase):
         )
         workspace.FeedBlob(
             "in1_values_values",
-            np.array([11.1, 11.2, 12.1, 12.2, 13.1, 13.2], dtype=np.float)
+            np.array([11.1, 11.2, 12.1, 12.2, 13.1, 13.2], dtype=float)
         )
         # Input 2.
         workspace.FeedBlob(
@@ -521,7 +521,7 @@ class TestFeatureMapsOps(TestCase):
         )
         workspace.FeedBlob(
             "in2_values_values",
-            np.array([14.1, 14.2, 15.1, 15.2, 16.1, 16.2], dtype=np.float)
+            np.array([14.1, 14.2, 15.1, 15.2, 16.1, 16.2], dtype=float)
         )
 
         workspace.RunOperatorOnce(op)
@@ -545,7 +545,7 @@ class TestFeatureMapsOps(TestCase):
                     11.1, 11.2, 14.1, 14.2, 15.1, 15.2, 12.1, 12.2, 13.1, 13.2,
                     16.1, 16.2
                 ],
-                dtype=np.float
+                dtype=float
             )
         )
 
@@ -583,7 +583,7 @@ class TestFeatureMapsOps(TestCase):
         )
         workspace.FeedBlob(
             "in1_values_values",
-            np.array([11.1, 11.2, 12.1, 12.2, 13.1, 13.2], dtype=np.float)
+            np.array([11.1, 11.2, 12.1, 12.2, 13.1, 13.2], dtype=float)
         )
         # Input 2.
         workspace.FeedBlob(
@@ -604,7 +604,7 @@ class TestFeatureMapsOps(TestCase):
         )
         workspace.FeedBlob(
             "in2_values_values",
-            np.array([14.1, 14.2, 15.1, 15.2, 16.1, 16.2], dtype=np.float)
+            np.array([14.1, 14.2, 15.1, 15.2, 16.1, 16.2], dtype=float)
         )
 
         workspace.RunOperatorOnce(op)
@@ -635,7 +635,7 @@ class TestFeatureMapsOps(TestCase):
                     11.1, 11.2, 14.1, 14.2, 15.1, 15.2, 12.1, 12.2, 13.1, 13.2,
                     16.1, 16.2
                 ],
-                dtype=np.float
+                dtype=float
             )
         )
 
@@ -689,7 +689,7 @@ class TestFeatureMapsOps(TestCase):
                     11.1, 11.2, 14.1, 14.2, 15.1, 15.2, 12.1, 12.2, 13.1, 13.2,
                     16.1, 16.2
                 ],
-                dtype=np.float
+                dtype=float
             )
         )
 
@@ -697,9 +697,9 @@ class TestFeatureMapsOps(TestCase):
 
         np.testing.assert_array_equal(
             workspace.FetchBlob("in1_values_values_grad"),
-            np.array([11.1, 11.2, 12.1, 12.2, 13.1, 13.2], dtype=np.float)
+            np.array([11.1, 11.2, 12.1, 12.2, 13.1, 13.2], dtype=float)
         )
         np.testing.assert_array_equal(
             workspace.FetchBlob("in2_values_values_grad"),
-            np.array([14.1, 14.2, 15.1, 15.2, 16.1, 16.2], dtype=np.float)
+            np.array([14.1, 14.2, 15.1, 15.2, 16.1, 16.2], dtype=float)
         )

--- a/caffe2/python/operator_test/self_binning_histogram_test.py
+++ b/caffe2/python/operator_test/self_binning_histogram_test.py
@@ -147,7 +147,7 @@ class TestSelfBinningHistogramBase:
     def test_histogram_min_max_equal(self):
         """This test uses exact value match, so is only relevant for float type."""
         X = np.array([0., 0., 0., 0., 0.], dtype='f')
-        logspacing_start = np.float(1e-24)
+        logspacing_start = float(1e-24)
         self._run_single_op_net([X], 3, logspacing_start)
         if self.bin_spacing == "linear":
             self._check_histogram(

--- a/caffe2/python/operator_test/stats_put_ops_test.py
+++ b/caffe2/python/operator_test/stats_put_ops_test.py
@@ -16,7 +16,7 @@ class TestPutOps(TestCase):
         count_postfix = "/stat_value/count".encode("ascii")
         default_value = 16.0
 
-        workspace.FeedBlob("value", np.array([], dtype=np.float))
+        workspace.FeedBlob("value", np.array([], dtype=float))
 
         workspace.RunOperatorOnce(core.CreateOperator(
             "AveragePut",
@@ -48,7 +48,7 @@ class TestPutOps(TestCase):
         sum_postfix = "/stat_value/sum".encode("ascii")
         count_postfix = "/stat_value/count".encode("ascii")
 
-        workspace.FeedBlob("value", np.array([put_value], dtype=np.float))
+        workspace.FeedBlob("value", np.array([put_value], dtype=float))
 
         workspace.RunOperatorOnce(core.CreateOperator(
             "AveragePut",
@@ -79,7 +79,7 @@ class TestPutOps(TestCase):
         sum_postfix = "/stat_value/sum".encode("ascii")
         count_postfix = "/stat_value/count".encode("ascii")
 
-        workspace.FeedBlob("value", np.array([put_value], dtype=np.float))
+        workspace.FeedBlob("value", np.array([put_value], dtype=float))
 
         workspace.RunOperatorOnce(core.CreateOperator(
             "AveragePut",
@@ -110,7 +110,7 @@ class TestPutOps(TestCase):
         sum_postfix = "/stat_value/sum".encode("ascii")
         count_postfix = "/stat_value/count".encode("ascii")
 
-        workspace.FeedBlob("value", np.array([put_value], dtype=np.float))
+        workspace.FeedBlob("value", np.array([put_value], dtype=float))
 
         workspace.RunOperatorOnce(core.CreateOperator(
             "AveragePut",
@@ -139,7 +139,7 @@ class TestPutOps(TestCase):
         stat_name = "i1".encode('ascii')
         member_postfix = "/stat_value".encode("ascii")
 
-        workspace.FeedBlob("value", np.array([put_value], dtype=np.float))
+        workspace.FeedBlob("value", np.array([put_value], dtype=float))
 
         workspace.RunOperatorOnce(core.CreateOperator(
             "IncrementPut",
@@ -169,7 +169,7 @@ class TestPutOps(TestCase):
         sumoffset_postfix = "/stat_value/sumoffset".encode("ascii")
         sumsqoffset_postfix = "/stat_value/sumsqoffset".encode("ascii")
 
-        workspace.FeedBlob("value", np.array([put_value], dtype=np.float))
+        workspace.FeedBlob("value", np.array([put_value], dtype=float))
 
         workspace.RunOperatorOnce(core.CreateOperator(
             "StdDevPut",

--- a/caffe2/python/sparse_to_dense_mask_test.py
+++ b/caffe2/python/sparse_to_dense_mask_test.py
@@ -21,12 +21,12 @@ class TestSparseToDenseMask(TestCase):
             np.array([2, 4, 6, 1, 2, 999999999, 2], dtype=np.int32))
         workspace.FeedBlob(
             'values',
-            np.array([1, 2, 3, 4, 5, 6, 7], dtype=np.float))
-        workspace.FeedBlob('default', np.array(-1, dtype=np.float))
+            np.array([1, 2, 3, 4, 5, 6, 7], dtype=float))
+        workspace.FeedBlob('default', np.array(-1, dtype=float))
         workspace.FeedBlob('lengths', np.array([3, 4], dtype=np.int32))
         workspace.RunOperatorOnce(op)
         output = workspace.FetchBlob('output')
-        expected = np.array([[-1, 1, 3], [6, 7, -1]], dtype=np.float)
+        expected = np.array([[-1, 1, 3], [6, 7, -1]], dtype=float)
         self.assertEqual(output.shape, expected.shape)
         np.testing.assert_array_equal(output, expected)
 
@@ -42,8 +42,8 @@ class TestSparseToDenseMask(TestCase):
             np.array([2000000000000, 999999999, 2, 3, 4, 5], dtype=np.int32))
         workspace.FeedBlob(
             'values',
-            np.array([1, 2, 3, 4, 5, 6], dtype=np.float))
-        workspace.FeedBlob('default', np.array(-1, dtype=np.float))
+            np.array([1, 2, 3, 4, 5, 6], dtype=float))
+        workspace.FeedBlob('default', np.array(-1, dtype=float))
         workspace.FeedBlob('lengths', np.array([6], dtype=np.int32))
         try:
             workspace.RunOperatorOnce(op)
@@ -69,14 +69,14 @@ class TestSparseToDenseMask(TestCase):
         workspace.FeedBlob(
             'values',
             np.array([[[1, -1]], [[2, -2]], [[3, -3]], [[4, -4]], [[5, -5]]],
-                     dtype=np.float))
-        workspace.FeedBlob('default', np.array([[-1, 0]], dtype=np.float))
+                     dtype=float))
+        workspace.FeedBlob('default', np.array([[-1, 0]], dtype=float))
         workspace.FeedBlob('lengths', np.array([2, 3], dtype=np.int32))
         workspace.RunOperatorOnce(op)
         output = workspace.FetchBlob('output')
         expected = np.array([
             [[[-1, 0]], [[1, -1]], [[-1, 0]], [[-1, 0]]],
-            [[[4, -4]], [[5, -5]], [[-1, 0]], [[3, -3]]]], dtype=np.float)
+            [[[4, -4]], [[5, -5]], [[-1, 0]], [[3, -3]]]], dtype=float)
         self.assertEqual(output.shape, expected.shape)
         np.testing.assert_array_equal(output, expected)
 
@@ -108,11 +108,11 @@ class TestSparseToDenseMask(TestCase):
             ['output'],
             mask=[1, 2, 6])
         workspace.FeedBlob('indices', np.array([2, 4, 6], dtype=np.int32))
-        workspace.FeedBlob('values', np.array([1, 2, 3], dtype=np.float))
-        workspace.FeedBlob('default', np.array(-1, dtype=np.float))
+        workspace.FeedBlob('values', np.array([1, 2, 3], dtype=float))
+        workspace.FeedBlob('default', np.array(-1, dtype=float))
         workspace.RunOperatorOnce(op)
         output = workspace.FetchBlob('output')
-        expected = np.array([-1, 1, 3], dtype=np.float)
+        expected = np.array([-1, 1, 3], dtype=float)
         self.assertEqual(output.shape, expected.shape)
         np.testing.assert_array_equal(output, expected)
 
@@ -123,11 +123,11 @@ class TestSparseToDenseMask(TestCase):
             ['output'],
             mask=[1, 2, 6])
         workspace.FeedBlob('indices', np.array([2, 4, 6], dtype=np.int32))
-        workspace.FeedBlob('values', np.array([1, 2, 3], dtype=np.float))
-        workspace.FeedBlob('default', np.array(-1, dtype=np.float))
+        workspace.FeedBlob('values', np.array([1, 2, 3], dtype=float))
+        workspace.FeedBlob('default', np.array(-1, dtype=float))
         workspace.RunOperatorOnce(op)
         output = workspace.FetchBlob('output')
-        expected = np.array([-1, 1, 3], dtype=np.float)
+        expected = np.array([-1, 1, 3], dtype=float)
         self.assertEqual(output.shape, expected.shape)
         np.testing.assert_array_equal(output, expected)
 
@@ -139,15 +139,15 @@ class TestSparseToDenseMask(TestCase):
             mask=[11, 12],
             return_presence_mask=True)
         workspace.FeedBlob('indices', np.array([11, 12, 13], dtype=np.int32))
-        workspace.FeedBlob('values', np.array([11, 12, 13], dtype=np.float))
-        workspace.FeedBlob('default', np.array(-1, dtype=np.float))
+        workspace.FeedBlob('values', np.array([11, 12, 13], dtype=float))
+        workspace.FeedBlob('default', np.array(-1, dtype=float))
         workspace.FeedBlob('lengths', np.array([1, 2], dtype=np.int32))
 
         workspace.RunOperatorOnce(op)
 
         output = workspace.FetchBlob('output')
         presence_mask = workspace.FetchBlob('presence_mask')
-        expected_output = np.array([[11, -1], [-1, 12]], dtype=np.float)
+        expected_output = np.array([[11, -1], [-1, 12]], dtype=float)
         expected_presence_mask = np.array(
             [[True, False], [False, True]],
             dtype=bool)

--- a/functorch/examples/maml_omniglot/support/omniglot_loaders.py
+++ b/functorch/examples/maml_omniglot/support/omniglot_loaders.py
@@ -187,7 +187,7 @@ class OmniglotNShot:
 
             # as different class may have different number of imgs
             self.x = np.array(self.x).astype(
-                np.float
+                float
             )  # [[20 imgs],..., 1623 classes in total]
             # each character contains 20 imgs
             print("data shape:", self.x.shape)  # [1623, 20, 84, 84, 1]

--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -214,7 +214,7 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
 
     @unittest.expectedFailure  # fails as long as numpy scalars are 0D arrays
     def test_specializing_numpy_float_in_control_flow(self):
-        # np.float is unspecialized by default,
+        # float is unspecialized by default,
         # but it should be specialized when used in control flow.
         def fn(x, y):
             if y > 1.0:


### PR DESCRIPTION
Summary:
`numpy.float` is long deprecated and now removed in numpy.1.20.0 [1].

This was generated using the following oneliners:
```
% fbgr '\bnp\.float\b' -lsf '.*\.py$' | xargs perl -pi -e 's,\bnp\.float\b,float,g'
% fbgr '\bnumpy\.float\b' -lsf '.*\.py$' | xargs perl -pi -e 's,\bnumpy\.float\b,float,g'
```

1. https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

Test Plan: sandcastle

Differential Revision: D50723172




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng