### PR TITLE
[CODEMOD][numpy] replace np.complex with complex

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -9196,7 +9196,7 @@ def reference_sgn(x):
     if out.ndim == 0:
         # Handle x == 0 case
         if (x == 0):
-            # Can't assign to np.complex object
+            # Can't assign to complex object
             # So make a new one.
             return np.array(complex(0, 0), dtype=x.dtype)
         return out


### PR DESCRIPTION
Summary:
numpy.float is long deprecated and now removed in numpy.1.20.0 [1].
This was generated using the following oneliners:
```
% fbgr '\bnp\.complex\b' -lsf '.*\.py$' | xargs perl -pi -e 's,\bnp\.complex\b,complex,g'
% fbgr '\bnumpy\.complex\b' -lsf '.*\.py$' | xargs perl -pi -e 's,\bnumpy\.complex\b,complex,g'
```
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

Test Plan: sandcastle

Differential Revision: D50723266

