### PR TITLE
[quant][pt2][be] Refactor QAT q-dq patterns

### DIFF
--- a/torch/ao/quantization/pt2e/qat_utils.py
+++ b/torch/ao/quantization/pt2e/qat_utils.py
@@ -57,15 +57,13 @@ def _get_quantized_conv2d_bn_pattern_example_inputs_kwargs(
     Optional example inputs for both `_quantized_qat_conv2d_bn_pattern`
     and `_folded_quantized_qat_conv2d_bn_pattern`, expressed as kwargs.
 
-    Note that weight_scale and weight_zero_point are only used when
-    `is_per_channel` is True. This is because for per tensor quantization,
-    scale and zero point are hard coded into quantize/dequantize ops
-    in the pattern.
     """
     kwargs = {}
+    # Per tensor quantization uses literals to represent scale and zero
+    # point, so there is no need to include them here as kwargs
     if is_per_channel:
-        kwargs["weight_scale"] = torch.tensor([1], dtype=torch.float)
-        kwargs["weight_zero_point"] = torch.tensor([0], dtype=torch.int)
+        kwargs["scale"] = torch.tensor([1], dtype=torch.float)
+        kwargs["zero_point"] = torch.tensor([0], dtype=torch.int)
     if has_bias:
         kwargs["conv_bias"] = torch.randn(1)
     if is_cuda:
@@ -192,6 +190,30 @@ def _get_input_output_quantized_filter():
 
     return _input_output_quantized_filter
 
+def _append_qdq(x, is_per_channel, kwargs):
+    """
+    Helper function to append q-dq ops after `x`, using dummy values for the qparams
+    and qmin/qmax. We use dummy values here because we match with `ignore_literals=True`
+    and will manually replace these values after subgraph rewriting.
+
+    Return the dq node.
+    """
+    # Dummy args to be passed into q-dq ops
+    per_channel_axis = 0
+    scale = kwargs["scale"] if is_per_channel else 1.0
+    zp = kwargs["zero_point"] if is_per_channel else 0
+    qmin = -127
+    qmax = 127
+    dtype = torch.int8
+
+    qd = torch.ops.quantized_decomposed
+    if is_per_channel:
+        x = qd.quantize_per_channel(x, scale, zp, per_channel_axis, qmin, qmax, dtype)
+        x = qd.dequantize_per_channel(x, scale, zp, per_channel_axis, qmin, qmax, dtype)
+    else:
+        x = qd.quantize_per_tensor(x, scale, zp, qmin, qmax, dtype)
+        x = qd.dequantize_per_tensor(x, scale, zp, qmin, qmax, dtype)
+    return x
 
 def _get_quantized_qat_conv2d_bn_pattern(
     is_per_channel: bool,
@@ -208,9 +230,6 @@ def _get_quantized_qat_conv2d_bn_pattern(
     """
     # TODO: allow setting eps
     bn_eps = 1e-5
-    weight_quant_min = -127
-    weight_quant_max = 127
-    per_channel_axis = 0
 
     def _quantized_qat_conv2d_bn_pattern(
         x: torch.Tensor,
@@ -228,22 +247,7 @@ def _get_quantized_qat_conv2d_bn_pattern(
         bias_shape = [1] * len(conv_weight.shape)
         bias_shape[1] = -1
         scaled_weight = conv_weight * scale_factor.reshape(weight_shape)
-        if is_per_channel:
-            scaled_weight = torch.ops.quantized_decomposed.quantize_per_channel(
-                scaled_weight, kwargs['weight_scale'], kwargs['weight_zero_point'], per_channel_axis,
-                weight_quant_min, weight_quant_max, torch.int8,
-            )
-            scaled_weight = torch.ops.quantized_decomposed.dequantize_per_channel(
-                scaled_weight, kwargs['weight_scale'], kwargs['weight_zero_point'], per_channel_axis,
-                weight_quant_min, weight_quant_max, torch.int8,
-            )
-        else:
-            scaled_weight = torch.ops.quantized_decomposed.quantize_per_tensor(
-                scaled_weight, 1.0, 0, weight_quant_min, weight_quant_max, torch.int8,
-            )
-            scaled_weight = torch.ops.quantized_decomposed.dequantize_per_tensor(
-                scaled_weight, 1.0, 0, weight_quant_min, weight_quant_max, torch.int8,
-            )
+        scaled_weight = _append_qdq(scaled_weight, is_per_channel, kwargs)
         if has_bias:
             zero_bias = torch.zeros_like(kwargs["conv_bias"], dtype=x.dtype)
             x = F.conv2d(x, scaled_weight, zero_bias)
@@ -272,9 +276,6 @@ def _get_folded_quantized_qat_conv2d_bn_pattern(
     """
     # TODO: allow setting eps
     bn_eps = 1e-5
-    weight_quant_min = -127
-    weight_quant_max = 127
-    per_channel_axis = 0
 
     def _folded_quantized_qat_conv2d_bn_pattern(
         x: torch.Tensor,
@@ -285,22 +286,7 @@ def _get_folded_quantized_qat_conv2d_bn_pattern(
         bn_running_var: torch.Tensor,
         **kwargs,
     ) -> torch.Tensor:
-        if is_per_channel:
-            conv_weight = torch.ops.quantized_decomposed.quantize_per_channel(
-                conv_weight, kwargs['weight_scale'], kwargs['weight_zero_point'], per_channel_axis,
-                weight_quant_min, weight_quant_max, torch.int8,
-            )
-            conv_weight = torch.ops.quantized_decomposed.dequantize_per_channel(
-                conv_weight, kwargs['weight_scale'], kwargs['weight_zero_point'], per_channel_axis,
-                weight_quant_min, weight_quant_max, torch.int8,
-            )
-        else:
-            conv_weight = torch.ops.quantized_decomposed.quantize_per_tensor(
-                conv_weight, 1.0, 0, weight_quant_min, weight_quant_max, torch.int8,
-            )
-            conv_weight = torch.ops.quantized_decomposed.dequantize_per_tensor(
-                conv_weight, 1.0, 0, weight_quant_min, weight_quant_max, torch.int8,
-            )
+        conv_weight = _append_qdq(conv_weight, is_per_channel, kwargs)
         if has_bias:
             x = F.conv2d(x, conv_weight, kwargs["conv_bias"])
         else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #112279
* #112159

Summary: This commit refactors q-dq patterns used in QAT fusion,
reducing code duplication. This is important for future efforts
to support quantizing bias.

Test Plan:
python test/test_quantization.py TestQuantizePT2EQAT

Reviewers: jerryzh168, kimishpatel

Subscribers: jerryzh168, kimishpatel, supriyar

Differential Revision: [D50856379](https://our.internmc.facebook.com/intern/diff/D50856379)