### PR TITLE
add torch.dtype path for sourceless builder

### DIFF
--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1865,6 +1865,9 @@ class SourcelessBuilder:
             return cls([self(tx, x) for x in value], mutable_local=MutableLocal())
         elif isinstance(value, types.MethodWrapperType):
             return MethodWrapperVariable(value)
+        elif isinstance(value, torch.dtype):
+            return ConstantVariable.create(value)
+
         unimplemented(f"Unexpected type in sourceless builder {type(value)}")
 
     @staticmethod


### PR DESCRIPTION
# Summary
Encountered this issue when attempting to compile Float8Tensor subclass w/ eager backend

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng