### PR TITLE
Pass in parallel strategy to tp_transform API

### DIFF
--- a/test/distributed/_tensor/experimental/test_tp_transform.py
+++ b/test/distributed/_tensor/experimental/test_tp_transform.py
@@ -1,7 +1,14 @@
 # Owner(s): ["oncall: distributed"]
+from typing import Dict
+
 import torch
 from torch.distributed._tensor.experimental.tp_transform import (
     tensor_parallel_transformation,
+)
+from torch.distributed.tensor.parallel.style import (
+    ColwiseParallel,
+    ParallelStyle,
+    RowwiseParallel,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
@@ -14,7 +21,7 @@ class MLPListModule(torch.nn.Module):
     A dummy model with list of MLPs.
     """
 
-    def __init__(self, num_mlps=3):
+    def __init__(self, num_mlps=3, bias=True):
         super().__init__()
         self.mlps = torch.nn.ModuleList()
         for _ in range(num_mlps):
@@ -22,7 +29,7 @@ class MLPListModule(torch.nn.Module):
                 torch.nn.Sequential(
                     torch.nn.Linear(6, 18),
                     torch.nn.ReLU(),
-                    torch.nn.Linear(18, 6),
+                    torch.nn.Linear(18, 6, bias=bias),
                 )
             )
 
@@ -37,11 +44,28 @@ class TensorParallelTest(DTensorTestBase):
     def setUp(self) -> None:
         super().setUp()
 
+    def assert_has_c10d_ops(
+        self, gm: torch.fx.GraphModule, expected_ops_count: Dict[str, int]
+    ) -> None:
+        actual_ops_count: Dict[str, int] = defaultdict(int)
+        for node in gm.graph.nodes:
+            if node.op == "call_function":
+                if "c10d_functional" in str(node.target):
+                    actual_ops_count[str(node.target)] += 1
+        self.assertDictEqual(expected_ops_count, actual_ops_count)
+
     @with_comms
     def test_tensor_parallel_transformation_e2e(self):
         torch.manual_seed(0)
         model = MLPListModule(2).to(device=self.device_type)
         inputs = (torch.randn((10, 12)).to(device=self.device_type),)
+        parallel_strategies: Dict[str, ParallelStyle] = {
+            "mlps.0.0": ColwiseParallel,
+            "mlps.0.2": RowwiseParallel,
+            "mlps.1.0": ColwiseParallel,
+            "mlps.1.2": RowwiseParallel,
+        }
+
         with torch.inference_mode():
             res = model(*inputs)
         exported_program = torch._export.export(
@@ -53,6 +77,37 @@ class TensorParallelTest(DTensorTestBase):
             exported_program,
             self.rank,
             self.world_size,
+            self.device_type,
+            parallel_strategies,
+        )
+        tp_model = tp_exported_program.module()
+        with torch.inference_mode():
+            tp_res = tp_model(*inputs)
+        self.assertEqual(res, tp_res)
+
+    @with_comms
+    def test_tp_transform_no_bias(self):
+        torch.manual_seed(0)
+        model = MLPListModule(1, bias=False).to(device=self.device_type)
+        inputs = (torch.randn((10, 12)).to(device=self.device_type),)
+        parallel_strategies: Dict[str, ParallelStyle] = {
+            "mlps.0.0": ColwiseParallel,
+            "mlps.0.2": RowwiseParallel,
+        }
+
+        with torch.inference_mode():
+            res = model(*inputs)
+        exported_program = torch._export.export(
+            model,
+            inputs,
+            constraints=None,
+        )
+        tp_exported_program = tensor_parallel_transformation(
+            exported_program,
+            self.rank,
+            self.world_size,
+            self.device_type,
+            parallel_strategies,
         )
         tp_model = tp_exported_program.module()
         with torch.inference_mode():

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -127,7 +127,7 @@ class DTensorTestBase(MultiProcessTestCase):
             sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
 
         if self.backend not in ["nccl", "gloo", "mpi", "cpu:gloo,cuda:nccl"]:
-            raise RuntimeError(f"Backend {backend} not supported!")
+            raise RuntimeError(f"Backend {self.backend} not supported!")
 
         dist.init_process_group(
             backend=self.backend,


### PR DESCRIPTION
Summary: Support passing in parallel strategy map and apply TP transform based on that. This is to make it easier manually select layers from real model to parallelize and benchmark.

Test Plan: buck test mode/opt  -c fbcode.enable_gpu_sections=true //caffe2/test/distributed/_tensor/experimental:tp_transform

Differential Revision: D50591039


