### PR TITLE
[DeviceMesh] Make mesh_resources private

### DIFF
--- a/test/distributed/_tensor/test_device_mesh.py
+++ b/test/distributed/_tensor/test_device_mesh.py
@@ -10,9 +10,9 @@ from torch.distributed._tensor._collective_utils import (
     mesh_scatter,
 )
 from torch.distributed._tensor.device_mesh import (
+    _mesh_resources,
     DeviceMesh,
     init_device_mesh,
-    mesh_resources,
 )
 from torch.distributed._tensor.placement_types import Shard
 
@@ -277,8 +277,8 @@ class TestDeviceMeshGetItem(DTensorTestBase):
             self.device_type, mesh_shape, mesh_dim_names=mesh_dim_names
         )
 
-        self.assertEqual(mesh_resources.get_parent_mesh(mesh_2d["DP"]), mesh_2d)
-        self.assertEqual(mesh_resources.get_parent_mesh(mesh_2d["TP"]), mesh_2d)
+        self.assertEqual(_mesh_resources.get_parent_mesh(mesh_2d["DP"]), mesh_2d)
+        self.assertEqual(_mesh_resources.get_parent_mesh(mesh_2d["TP"]), mesh_2d)
 
     @with_comms
     def test_get_parent_mesh_dim_exist(self):
@@ -288,15 +288,15 @@ class TestDeviceMeshGetItem(DTensorTestBase):
             self.device_type, mesh_shape, mesh_dim_names=mesh_dim_names
         )
 
-        self.assertEqual(mesh_resources.get_parent_mesh_dim(mesh_2d["DP"]), 0)
-        self.assertEqual(mesh_resources.get_parent_mesh_dim(mesh_2d["TP"]), 1)
+        self.assertEqual(_mesh_resources.get_parent_mesh_dim(mesh_2d["DP"]), 0)
+        self.assertEqual(_mesh_resources.get_parent_mesh_dim(mesh_2d["TP"]), 1)
 
     @with_comms
     def test_get_parent_mesh_dim_not_exist(self):
         mesh_shape = (self.world_size,)
         mesh = init_device_mesh(self.device_type, mesh_shape)
 
-        self.assertEqual(mesh_resources.get_parent_mesh_dim(mesh), None)
+        self.assertEqual(_mesh_resources.get_parent_mesh_dim(mesh), None)
 
 
 class DeviceMeshCollectiveTest(DTensorTestBase):

--- a/test/distributed/fsdp/test_hsdp_dtensor_state_dict.py
+++ b/test/distributed/fsdp/test_hsdp_dtensor_state_dict.py
@@ -7,8 +7,8 @@ import torch
 import torch.nn as nn
 from torch.distributed._shard.sharded_tensor import ShardedTensor
 
-from torch.distributed._tensor import DTensor, mesh_resources, Replicate, Shard
-from torch.distributed._tensor.device_mesh import init_device_mesh
+from torch.distributed._tensor import DTensor, Replicate, Shard
+from torch.distributed._tensor.device_mesh import _mesh_resources, init_device_mesh
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.api import (
     ShardedOptimStateDictConfig,
@@ -55,7 +55,7 @@ class TestHSDPWithDeviceMeshAndDTensor(DTensorTestBase):
         mesh_2d = init_device_mesh(self.device_type, (2, self.world_size // 2))
         # manually set a fake parent mesh to mesh_2d
         fake_parent_mesh = init_device_mesh(self.device_type, (self.world_size,))
-        mesh_resources.child_to_parent_mapping[mesh_2d] = fake_parent_mesh
+        _mesh_resources.child_to_parent_mapping[mesh_2d] = fake_parent_mesh
 
         with self.assertRaisesRegex(
             RuntimeError,

--- a/torch/distributed/_tensor/__init__.py
+++ b/torch/distributed/_tensor/__init__.py
@@ -8,9 +8,9 @@ import torch.distributed._tensor.random as random
 from torch.distributed._tensor._utils import compute_local_shape
 from torch.distributed._tensor.api import distribute_module, distribute_tensor, DTensor
 from torch.distributed._tensor.device_mesh import (
+    _mesh_resources,
     DeviceMesh,
     init_device_mesh,
-    mesh_resources,
 )
 from torch.distributed._tensor.placement_types import Placement, Replicate, Shard
 
@@ -34,7 +34,7 @@ def _dtensor_init_helper(
     **kwargs,
 ) -> DTensor:
     # if device_mesh is None, use the one from mesh resources
-    device_mesh = device_mesh or mesh_resources.get_current_mesh()
+    device_mesh = device_mesh or _mesh_resources.get_current_mesh()
     kwargs["device"] = device_mesh.device_type
 
     # set default placements to replicated if not specified

--- a/torch/distributed/_tensor/_collective_utils.py
+++ b/torch/distributed/_tensor/_collective_utils.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 import torch
 import torch.distributed._tensor.placement_types as placement_types
-from torch.distributed._tensor.device_mesh import DeviceMesh, mesh_resources
+from torch.distributed._tensor.device_mesh import _mesh_resources, DeviceMesh
 from torch.distributed.distributed_c10d import (
     all_to_all,
     broadcast,
@@ -170,7 +170,7 @@ def spec_to_bytes(spec: "placement_types.DTensorSpec") -> int:
 def get_bandwidth_factor(mesh: DeviceMesh) -> List[float]:
     # generate bandwidth factor for intra-host/inter-host communication pattern
     factors = [1.0] * mesh.ndim
-    num_devices_per_host = mesh_resources.num_devices_per_host(mesh.device_type)
+    num_devices_per_host = _mesh_resources.num_devices_per_host(mesh.device_type)
 
     num_devices = 1
     for mesh_dim in reversed(range(mesh.ndim)):

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -9,7 +9,7 @@ import torch.distributed._tensor.random as random
 import torch.nn as nn
 from torch.distributed._tensor._collective_utils import mesh_broadcast
 from torch.distributed._tensor._utils import compute_global_tensor_info
-from torch.distributed._tensor.device_mesh import DeviceMesh, mesh_resources
+from torch.distributed._tensor.device_mesh import _mesh_resources, DeviceMesh
 from torch.distributed._tensor.placement_types import (
     DTensorSpec,
     Placement,
@@ -312,7 +312,7 @@ class DTensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
         # There should be no data communication unless there's replication
         # strategy, where we broadcast the replication from the first rank
         # in the mesh dimension
-        device_mesh = device_mesh or mesh_resources.get_current_mesh()
+        device_mesh = device_mesh or _mesh_resources.get_current_mesh()
         device_type = device_mesh.device_type
 
         # convert the local tensor to desired device base on device mesh's device_type
@@ -464,7 +464,7 @@ def distribute_tensor(
     torch._C._log_api_usage_once("torch.dtensor.distribute_tensor")
 
     # get default device mesh if there's nothing specified
-    device_mesh = device_mesh or mesh_resources.get_current_mesh()
+    device_mesh = device_mesh or _mesh_resources.get_current_mesh()
     device_type = device_mesh.device_type
     if device_type == "xla":
         # call PyTorch/XLA SPMD for `xla` backend type device mesh.
@@ -579,7 +579,7 @@ def distribute_module(
 
     torch._C._log_api_usage_once("torch.dtensor.distribute_module")
 
-    device_mesh = device_mesh or mesh_resources.get_current_mesh()
+    device_mesh = device_mesh or _mesh_resources.get_current_mesh()
 
     def replicate_module_params_buffers(m: nn.Module, mesh: DeviceMesh) -> None:
         # This function loop over the immediate module parameters and

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -96,7 +96,7 @@ class _MeshEnv:
         return get_world_size() // _MeshEnv.num_devices_per_host(device_type)
 
 
-mesh_resources: _MeshEnv = _MeshEnv()
+_mesh_resources: _MeshEnv = _MeshEnv()
 
 
 def _get_device_handle(device_type: str = "cuda"):
@@ -287,13 +287,13 @@ class DeviceMesh:
 
     def __enter__(self) -> "DeviceMesh":
         # set this mesh as the current mesh in mesh env
-        mesh_resources.mesh_stack.append(self)
+        _mesh_resources.mesh_stack.append(self)
         return self
 
     # pyre-fixme[2]: Parameter must be annotated.
     def __exit__(self, exc_type, exc_value, exc_traceback) -> None:
         # pop this mesh from mesh env
-        mesh_resources.mesh_stack.pop()
+        _mesh_resources.mesh_stack.pop()
 
     def __repr__(self) -> str:
         return f"DeviceMesh:({self.mesh.tolist()})"
@@ -355,7 +355,7 @@ class DeviceMesh:
                 f"Available mesh dimensions are: {self.mesh_dim_names}",
             )
         mesh_dim = self.mesh_dim_names.index(mesh_dim_name)
-        submesh = mesh_resources.create_child_mesh(self, mesh_dim, mesh_dim_name)
+        submesh = _mesh_resources.create_child_mesh(self, mesh_dim, mesh_dim_name)
 
         return submesh
 

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -24,7 +24,7 @@ import torch.distributed.fsdp._exec_order_utils as exec_order_utils
 import torch.distributed.fsdp._traversal_utils as traversal_utils
 import torch.distributed.fsdp.fully_sharded_data_parallel as fsdp_file
 import torch.nn as nn
-from torch.distributed._tensor import DeviceMesh, mesh_resources
+from torch.distributed._tensor.device_mesh import _mesh_resources, DeviceMesh
 from torch.distributed.algorithms._comm_hooks import default_hooks
 from torch.distributed.distributed_c10d import _get_default_group
 from torch.distributed.fsdp._common_utils import (
@@ -203,7 +203,7 @@ def _is_valid_hybrid_shard_pg_type(process_group: Any) -> bool:
 
 @no_type_check
 def _is_valid_hybrid_shard_device_mesh(device_mesh: DeviceMesh) -> bool:
-    parent_mesh = mesh_resources.get_parent_mesh(device_mesh)
+    parent_mesh = _mesh_resources.get_parent_mesh(device_mesh)
     if parent_mesh is not None:
         raise RuntimeError(
             f"Found device_mesh {device_mesh} passed in has a parent device_mesh {parent_mesh}.",
@@ -514,7 +514,7 @@ def _init_extension(state: _FSDPState, device_mesh: DeviceMesh = None) -> _FSDPS
     # This check is currently sufficient, since we only support FSDP + TP.
     if device_mesh:
         state._enable_extension = (
-            mesh_resources.get_parent_mesh(state._device_mesh) is not None
+            _mesh_resources.get_parent_mesh(state._device_mesh) is not None
         )
 
         if state._enable_extension:

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -17,7 +17,7 @@ from torch.distributed._shard.sharded_tensor import (
     ShardedTensor,
 )
 from torch.distributed._tensor import DTensor
-from torch.distributed._tensor.device_mesh import mesh_resources
+from torch.distributed._tensor.device_mesh import _mesh_resources
 
 from torch.distributed.fsdp._common_utils import (
     _FSDPState,
@@ -291,7 +291,7 @@ def _full_pre_state_dict_hook(
     ``nn.Module``.
     """
     if getattr(fsdp_state, "_device_mesh", False):
-        parent_mesh = mesh_resources.get_parent_mesh(fsdp_state._device_mesh)
+        parent_mesh = _mesh_resources.get_parent_mesh(fsdp_state._device_mesh)
         if parent_mesh:
             raise RuntimeError(
                 f"Found FSDP's device_mesh {fsdp_state._device_mesh} has a parent device_mesh {parent_mesh}.",
@@ -666,7 +666,7 @@ def _sharded_pre_load_state_dict_hook(
             if param.device != fsdp_state._device_mesh.device_type:
                 param = param.to(fsdp_state._device_mesh.device_type)
 
-            parent_mesh = mesh_resources.get_parent_mesh(fsdp_state._device_mesh)
+            parent_mesh = _mesh_resources.get_parent_mesh(fsdp_state._device_mesh)
             local_tensor = _ext_all_gather_dtensor(param, parent_mesh)
 
             if fqn_to_param_ext.get(fqn) is not None:

--- a/torch/distributed/tensor/parallel/_utils.py
+++ b/torch/distributed/tensor/parallel/_utils.py
@@ -4,7 +4,7 @@ from typing import Callable, Tuple, Optional, Union
 
 import torch
 from torch.distributed._tensor import DeviceMesh, DTensor
-from torch.distributed._tensor.device_mesh import mesh_resources
+from torch.distributed._tensor.device_mesh import _mesh_resources
 from torch.distributed._tensor.placement_types import Placement
 try:
     from torch._dynamo.external_utils import is_compiling as is_torchdynamo_compiling
@@ -191,7 +191,7 @@ def _validate_tp_mesh_dim(
         `True` if the mesh dimension
         is valid, `False` otherwise.
     """
-    parent_mesh = mesh_resources.get_parent_mesh(device_mesh)
+    parent_mesh = _mesh_resources.get_parent_mesh(device_mesh)
     if parent_mesh:
         if parent_mesh.ndim != 2:
             raise RuntimeError(
@@ -199,7 +199,7 @@ def _validate_tp_mesh_dim(
                 "Currently we only support 2D TP composition with DP.",
             )
 
-        tp_mesh_dim = mesh_resources.get_parent_mesh_dim(device_mesh)
+        tp_mesh_dim = _mesh_resources.get_parent_mesh_dim(device_mesh)
         if tp_mesh_dim != 1:
             raise RuntimeError(
                 f"Found TP device_mesh on the {tp_mesh_dim} dimension of its parent mesh.",

--- a/torch/distributed/tensor/parallel/fsdp.py
+++ b/torch/distributed/tensor/parallel/fsdp.py
@@ -17,7 +17,7 @@ from torch.distributed._shard.sharded_tensor import (
 from torch.distributed._shard.sharding_spec import ShardMetadata
 from torch.distributed._shard.sharding_spec.chunk_sharding_spec import ChunkShardingSpec
 from torch.distributed._tensor import DeviceMesh, DTensor, Replicate, Shard as DShard
-from torch.distributed._tensor.device_mesh import mesh_resources
+from torch.distributed._tensor.device_mesh import _mesh_resources
 
 from torch.distributed.fsdp._common_utils import _set_fsdp_flattened
 from torch.distributed.fsdp._fsdp_extensions import _set_fsdp_extensions, FSDPExtensions
@@ -230,7 +230,7 @@ def _chunk_dtensor(
     Shard a tensor to chunks along the first dimension. The local rank will gets its
     corresponding chunk as the local tensor to create a DTensor.
     """
-    parent_mesh = mesh_resources.get_parent_mesh(device_mesh)
+    parent_mesh = _mesh_resources.get_parent_mesh(device_mesh)
     if parent_mesh is None:
         raise RuntimeError("No parent device_mesh is found for FSDP device_mesh.")
     if parent_mesh.ndim != 2:


### PR DESCRIPTION
This is to prepare moving DeviceMesh as a standalone distributed package.

`_mesh_resources` should only be used in torch.distributed package.