### PR TITLE
Fix regression from pointwise + multi-level reduction fusion

### DIFF
--- a/test/inductor/test_perf.py
+++ b/test/inductor/test_perf.py
@@ -427,7 +427,7 @@ class FusionTests(TestCase):
         # kernel 3: (input = first-level amax, output = final amax)
         # scale (1) + X (4*2048*hidden_size) * 3 + amax (num_splits * 2 + 1)
         # num_splits depends on SM architectures.
-        expected_numel = 1 + 4 * 2048 * hidden_size * 3 + 432 * 2 + 1
+        expected_numel = 1 + 4 * 2048 * hidden_size * 3 + 1
         actual_numel_amax_keep_dim = count_numel(f, *inp, True)
         actual_numel_amax_no_keep_dim = count_numel(f, *inp, False)
         self.assertEqual(actual_numel_amax_keep_dim, actual_numel_amax_no_keep_dim)

--- a/test/inductor/test_perf.py
+++ b/test/inductor/test_perf.py
@@ -361,9 +361,6 @@ class FusionTests(TestCase):
         inp = (T(10, 10), T(10, 10), T(10, 10))
         self.assertExpectedInline(count_numel(f, *inp), """500""")
 
-    @unittest.skipif(
-        torch.cuda.is_available() and torch.cuda.get_device_capability() == (8, 0)
-    )
     def test_reduction_pointwise_multi_level_reduction(self):
         hidden_size = 4096
 

--- a/test/inductor/test_perf.py
+++ b/test/inductor/test_perf.py
@@ -361,6 +361,78 @@ class FusionTests(TestCase):
         inp = (T(10, 10), T(10, 10), T(10, 10))
         self.assertExpectedInline(count_numel(f, *inp), """500""")
 
+    @unittest.skipif(
+        torch.cuda.is_available() and torch.cuda.get_device_capability() == (8, 0)
+    )
+    def test_reduction_pointwise_multi_level_reduction(self):
+        hidden_size = 4096
+
+        def f(x, scale, amax_keep_dim):
+            x = torch.nn.functional.layer_norm(
+                x.to(dtype=torch.float),
+                [hidden_size],
+                weight=None,
+                bias=None,
+                eps=1e-05,
+            )
+            amax = torch.amax(torch.abs(x), keepdim=amax_keep_dim)
+            x_scaled = x * scale
+            y = torch.nn.functional.sigmoid(x_scaled)
+            return (y, amax)
+
+        inp = (T(4, 2048, hidden_size, dtype=torch.float), T(1, dtype=torch.float))
+
+        # 3 kernels:
+        # kernel 1: (input = X, scale, output = LN_pointwise(X), welford_reduction(X) * 2)
+        # kernel 2: (input = X, welford_reduction(X) * 2, output = first-level amax (split-reduction))
+        # kernel 3: (input = first-level amax, output = final amax)
+        # scale (1) + X (4*2048*hidden_size) * 3 + welford_reduction (4*2048) * 4 + amax (num_splits * 2 + 1)
+        # num_splits depends on SM architectures.
+        expected_amax_keep_dim_numel = 1 + 4 * 2048 * hidden_size * 3 + 4 * 2048 * 4 + 1
+        self.assertGreaterAlmostEqual(
+            count_numel(f, *inp, True), str(expected_amax_keep_dim_numel)
+        )
+
+        # 2 kernels:
+        # kernel 1: (input = X, scale, output = LN_pointwise(X), first-level amax (split-reduction))
+        # kernel 2: (input = first-level amax, output = final amax)
+        # scale (1) + X (4*2048*hidden_size) * 2 + amax (4 * 2048 * 2 + 1)
+        expected_amax_no_keep_dim_numel = (
+            1 + 4 * 2048 * hidden_size * 2 + 4 * 2048 * 2 + 1
+        )
+        self.assertExpectedInline(
+            count_numel(f, *inp, False), str(expected_amax_no_keep_dim_numel)
+        )
+
+    def test_pointwise_multi_level_reduction(self):
+        # TODO: this can be optimized by having the first pointwise kernel leveraging block sizes
+        # of the first-level reduction kernel.
+        hidden_size = 4096
+
+        def f(x, scale, amax_keep_dim):
+            x = x * 1.1
+            amax = torch.amax(torch.abs(x), keepdim=amax_keep_dim)
+            x_scaled = x * scale
+            y = torch.nn.functional.sigmoid(x_scaled)
+            return (y, amax)
+
+        inp = (T(4, 2048, hidden_size, dtype=torch.float), T(1, dtype=torch.float))
+
+        compiled_f = torch.compile(f)
+        compiled_f(*inp, True)
+
+        # 3 kernels:
+        # kernel 1: (input = X, scale, output = pointwise(X))
+        # kernel 2: (input = X, output = first-level amax)
+        # kernel 3: (input = first-level amax, output = final amax)
+        # scale (1) + X (4*2048*hidden_size) * 3 + amax (num_splits * 2 + 1)
+        # num_splits depends on SM architectures.
+        expected_numel = 1 + 4 * 2048 * hidden_size * 3 + 432 * 2 + 1
+        actual_numel_amax_keep_dim = count_numel(f, *inp, True)
+        actual_numel_amax_no_keep_dim = count_numel(f, *inp, False)
+        self.assertEqual(actual_numel_amax_keep_dim, actual_numel_amax_no_keep_dim)
+        self.assertGreaterAlmostEqual(actual_numel_amax_keep_dim, str(expected_numel))
+
 
 class SchedulerFusionTests(TestCase):
     """

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -390,14 +390,18 @@ def extract_input_node_reduction_ranges(  # noqa: F722
 
     from .ir import ComputedBuffer, Loops
 
-    if not isinstance(input_node.data.data, Loops):
+    if isinstance(input_node.data, ComputedBuffer):
         # Input node has already been realized. Return its size and reduction_size.
-        if hasattr(input_node, "get_size") and hasattr(
-            input_node, "get_reduction_size"
-        ):
-            return (input_node.get_size(), input_node.get_reduction_size())
+        size = input_node.get_size()
+        reduction_size = input_node.get_reduction_size()
+        if len(reduction_size) > 0:
+            return (size, reduction_size)
         else:
             return (None, None)
+
+    if not isinstance(input_node.data.data, Loops):
+        # Other IRNodes do not have reduction_ranges.
+        return (None, None)
 
     # There is one issue: what if there are views / permutations between the input node and its dependent realized nodes?
     # The current method still uses reduction ranges from the dependent realized node, which is not ideal.

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -755,7 +755,11 @@ class Reduction(Loops):
                             "Use previous IRNode's range and reduction_ranges instead of split. "
                             "current ranges: %s, current reduction ranges: %s, current split: %d, "
                             "new ranges: %s, new reduction ranges: %s",
-                            ranges, reduction_ranges, split, new_ranges, new_reduction_ranges
+                            ranges,
+                            reduction_ranges,
+                            split,
+                            new_ranges,
+                            new_reduction_ranges,
                         )
                         # If the input_node or its dependent nodes are also Reduction nodes,
                         # use reduction_sizes of this node or its dependent nodes directly.

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -751,6 +751,12 @@ class Reduction(Loops):
                         sympy_product(new_ranges + new_reduction_ranges)
                     )
                     if reduction_numel_hint == extracted_numel_hint:
+                        log.debug(
+                            "Use previous IRNode's range and reduction_ranges instead of split. "
+                            "current ranges: %s, current reduction ranges: %s, current split: %d, "
+                            "new ranges: %s, new reduction ranges: %s",
+                            ranges, reduction_ranges, split, new_ranges, new_reduction_ranges
+                        )
                         # If the input_node or its dependent nodes are also Reduction nodes,
                         # use reduction_sizes of this node or its dependent nodes directly.
                         return ReductionHint.INNER, -1


### PR DESCRIPTION
In https://github.com/pytorch/pytorch/pull/111122, an optimization is introduced for reduction + pointwise + multi-level reduction fusion. The main idea of this optimization is to have the first-level reduction of the multi-level reduction reuses the reduction sizes of the first reduction kernel so that there are better chances that the first reduction kernel and the first-level reduction of the multi-level reduction kernel can be fused. However, it introduces a bug for pattern pointwise + multi-level reduction, where the first-level reduction kernel wrongly reuses the reduction ranges (which is []) from the previous pointwise kernel. This PR fixes this issue.

Test plan:
`python timm_models.py --training --amp --performance --only=dm_nfnet_f0 --inductor`
Results before this PR: 0.869x
Results after this PR: 1.232x

Benchmark results:
![Screenshot 2023-10-30 at 2 30 10 PM](https://github.com/pytorch/pytorch/assets/10527447/c7b241c0-92a4-49ff-96fb-2805c8fcc45a)

<img width="1491" alt="Screenshot 2023-10-30 at 3 10 06 PM" src="https://github.com/pytorch/pytorch/assets/10527447/608d26ea-dcc5-4f2a-8700-4a928701392b">



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler