### PR TITLE
Fix internal test listing errors

### DIFF
--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -82,8 +82,8 @@ class TestFP8Types(TestCase):
     @unittest.skipIf(TEST_WITH_ROCM, "FP8 is not supported on ROCM")
     @unittest.skipIf(not SM90OrLater, "FP8 is only supported on H100+")
     @parametrize("dtype", (torch.float16, torch.bfloat16, torch.float))
-    @parametrize("shape", ((15, 3, 13), (4, 2048, 4096)))
-    def test_valid_cast(self, dtype: torch.dtype, shape: Tuple[int]):
+    @parametrize("shape", ("15,3,13", "4,2048,4096"))
+    def test_valid_cast(self, dtype: torch.dtype, shape: str):
         def fp8_cast(x):
             y0 = x.to(dtype=torch.float8_e4m3fn).to(dtype)
             y1 = x.to(dtype=torch.float8_e5m2).to(dtype)
@@ -91,6 +91,7 @@ class TestFP8Types(TestCase):
 
         compiled_fp8_cast = torch.compile(fp8_cast, backend="inductor", dynamic=True)
 
+        shape = [int(dim) for dim in shape.split(",")]
         x = torch.rand(*shape, device="cuda", dtype=dtype)
         y0_fp8, y1_fp8 = compiled_fp8_cast(x)
 
@@ -125,9 +126,9 @@ class TestFP8Types(TestCase):
     @unittest.skipIf(not SM90OrLater, "FP8 is only supported on H100+")
     @parametrize("src_dtype", (torch.float16, torch.bfloat16, torch.float))
     @parametrize("dst_dtype", (torch.float8_e4m3fn, torch.float8_e5m2))
-    @parametrize("shape", ((16, 16, 16), (4, 2048, 4096)))
+    @parametrize("shape", ("16,16,16", "4,2048,4096"))
     def test_to_fp8_saturated(
-        self, src_dtype: torch.dtype, dst_dtype: torch.dtype, shape: Tuple[int]
+        self, src_dtype: torch.dtype, dst_dtype: torch.dtype, shape: str
     ):
         def fp8_saturated(x, dtype):
             return _to_fp8_saturated(x, dtype)
@@ -135,6 +136,7 @@ class TestFP8Types(TestCase):
         compiled_fp8_cast = torch.compile(
             fp8_saturated, backend="inductor", dynamic=True
         )
+        shape = [int(dim) for dim in shape.split(",")]
         x = torch.rand(*shape, device="cuda", dtype=src_dtype)
         y_compiled = compiled_fp8_cast(x, dst_dtype)
         y = fp8_saturated(x, dst_dtype)
@@ -145,9 +147,10 @@ class TestFP8Types(TestCase):
     @unittest.skipIf(not SM90OrLater, "FP8 is only supported on H100+")
     @parametrize("float8_dtype", (torch.float8_e4m3fn, torch.float8_e5m2))
     @parametrize(
-        "shape", ((1, 1, 15), (1, 10, 15), (1, 10, 512), (1, 10, 4096), (4, 2048, 4096))
+        "shape", ("1,1,15", "1,10,15", "1,10,512", "1,10,4096", "4,2048,4096")
     )
-    def test_amax_fp8_quant(self, float8_dtype: torch.dtype, shape: Tuple[int]):
+    def test_amax_fp8_quant(self, float8_dtype: torch.dtype, shape: str):
+        shape = [int(dim) for dim in shape.split(",")]
         batch_size, sequence_length, hidden_size = shape
 
         def amax_fp8(x: Tensor, scale: Tensor):
@@ -171,11 +174,12 @@ class TestFP8Types(TestCase):
     @unittest.skipIf(not SM90OrLater, "FP8 is only supported on H100+")
     @parametrize("float8_dtype", (torch.float8_e4m3fn, torch.float8_e5m2))
     @parametrize(
-        "shape", ((1, 1, 15), (1, 10, 15), (1, 10, 512), (1, 10, 4096), (4, 2048, 4096))
+        "shape", ("1,1,15", "1,10,15", "1,10,512", "1,10,4096", "4,2048,4096")
     )
     def test_amax_along_with_fp8_quant(
-        self, float8_dtype: torch.dtype, shape: Tuple[int]
+        self, float8_dtype: torch.dtype, shape: str
     ):
+        shape = [int(dim) for dim in shape.split(",")]
         batch_size, sequence_length, hidden_size = shape
 
         def amax_fp8(x: Tensor, scale: Tensor, amax_buffer: Tensor):
@@ -205,11 +209,12 @@ class TestFP8Types(TestCase):
     @parametrize("float8_dtype", (torch.float8_e4m3fn, torch.float8_e5m2))
     @parametrize("amax_keep_dim", (True, False))
     @parametrize(
-        "shape", ((1, 1, 15), (1, 10, 15), (1, 10, 512), (1, 10, 4096), (4, 2048, 4096))
+        "shape", ("1,1,15", "1,10,15", "1,10,512", "1,10,4096", "4,2048,4096")
     )
     def test_layernorm_fp8_quant(
-        self, float8_dtype: torch.dtype, amax_keep_dim: bool, shape: Tuple[int]
+        self, float8_dtype: torch.dtype, amax_keep_dim: bool, shape: str
     ):
+        shape = [int(dim) for dim in shape.split(",")]
         batch_size, sequence_length, hidden_size = shape
 
         def ln_fp8(x: Tensor, scale: Tensor, amax_buffer: Tensor):
@@ -246,12 +251,13 @@ class TestFP8Types(TestCase):
     @unittest.skipIf(TEST_WITH_ROCM, "FP8 is not supported on ROCM")
     @unittest.skipIf(not SM90OrLater, "FP8 is only supported on H100+")
     @parametrize("float8_dtype", (torch.float8_e4m3fn, torch.float8_e5m2))
-    @parametrize("shape", ((4, 2048, 4096),))
+    @parametrize("shape", ("4,2048,4096",))
     def test_layernorm_fp8_quant_benchmark(
         self,
         float8_dtype: torch.dtype,
-        shape: Tuple[int],
+        shape: str,
     ):
+        shape = [int(dim) for dim in shape.split(",")]
         batch_size, sequence_length, hidden_size = shape
 
         def ln(x: Tensor):

--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -2,7 +2,6 @@
 
 import functools
 import unittest
-from typing import Tuple
 
 import torch
 from torch import Tensor

--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -145,9 +145,7 @@ class TestFP8Types(TestCase):
     @unittest.skipIf(TEST_WITH_ROCM, "FP8 is not supported on ROCM")
     @unittest.skipIf(not SM90OrLater, "FP8 is only supported on H100+")
     @parametrize("float8_dtype", (torch.float8_e4m3fn, torch.float8_e5m2))
-    @parametrize(
-        "shape", ("1,1,15", "1,10,15", "1,10,512", "1,10,4096", "4,2048,4096")
-    )
+    @parametrize("shape", ("1,1,15", "1,10,15", "1,10,512", "1,10,4096", "4,2048,4096"))
     def test_amax_fp8_quant(self, float8_dtype: torch.dtype, shape: str):
         shape = [int(dim) for dim in shape.split(",")]
         batch_size, sequence_length, hidden_size = shape
@@ -172,12 +170,8 @@ class TestFP8Types(TestCase):
     @unittest.skipIf(TEST_WITH_ROCM, "FP8 is not supported on ROCM")
     @unittest.skipIf(not SM90OrLater, "FP8 is only supported on H100+")
     @parametrize("float8_dtype", (torch.float8_e4m3fn, torch.float8_e5m2))
-    @parametrize(
-        "shape", ("1,1,15", "1,10,15", "1,10,512", "1,10,4096", "4,2048,4096")
-    )
-    def test_amax_along_with_fp8_quant(
-        self, float8_dtype: torch.dtype, shape: str
-    ):
+    @parametrize("shape", ("1,1,15", "1,10,15", "1,10,512", "1,10,4096", "4,2048,4096"))
+    def test_amax_along_with_fp8_quant(self, float8_dtype: torch.dtype, shape: str):
         shape = [int(dim) for dim in shape.split(",")]
         batch_size, sequence_length, hidden_size = shape
 
@@ -207,9 +201,7 @@ class TestFP8Types(TestCase):
     @unittest.skipIf(not SM90OrLater, "FP8 is only supported on H100+")
     @parametrize("float8_dtype", (torch.float8_e4m3fn, torch.float8_e5m2))
     @parametrize("amax_keep_dim", (True, False))
-    @parametrize(
-        "shape", ("1,1,15", "1,10,15", "1,10,512", "1,10,4096", "4,2048,4096")
-    )
+    @parametrize("shape", ("1,1,15", "1,10,15", "1,10,512", "1,10,4096", "4,2048,4096"))
     def test_layernorm_fp8_quant(
         self, float8_dtype: torch.dtype, amax_keep_dim: bool, shape: str
     ):


### PR DESCRIPTION
For some reason, fbcode internal tests have list errors when a test is skipped and have ", " in the name. This fix tries to replace shape list into a string to avoid internal test listing errors.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler