### PR TITLE
[TD] Create metrics for test removal

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -23,7 +23,6 @@ import torch
 import torch.distributed as dist
 from packaging import version
 
-from tools.testing.target_determination.heuristics import TD_STRATEGIES
 from torch.multiprocessing import current_process, get_context
 from torch.testing._internal.common_utils import (
     FILE_SCHEMA,
@@ -47,6 +46,7 @@ from tools.stats.upload_metrics import add_global_metric, emit_metric
 from tools.testing.target_determination.determinator import (
     AggregatedHeuristics,
     get_test_prioritizations,
+    TD_STRATEGIES,
 )
 from tools.testing.test_selections import (
     calculate_shards,

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -22,6 +22,8 @@ import pkg_resources
 import torch
 import torch.distributed as dist
 from packaging import version
+
+from tools.testing.target_determination.heuristics import TD_STRATEGIES
 from torch.multiprocessing import current_process, get_context
 from torch.testing._internal.common_utils import (
     FILE_SCHEMA,
@@ -1777,6 +1779,10 @@ def main():
 
                 print_to_stderr("Emiting td_test_failure_stats")
                 emit_metric("td_test_failure_stats", test_stats)
+
+    for td_strategy in TD_STRATEGIES:
+        td_strategy.gen_selected_tests(selected_tests)
+        td_strategy.emit_dry_run_metrics(all_failures)
 
     if len(all_failures):
         for _, err in all_failures:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -46,8 +46,9 @@ from tools.stats.upload_metrics import add_global_metric, emit_metric
 from tools.testing.target_determination.determinator import (
     AggregatedHeuristics,
     get_test_prioritizations,
-    TD_STRATEGIES,
 )
+
+from tools.testing.target_determination.heuristics.test_eliminators import TD_STRATEGIES
 from tools.testing.test_selections import (
     calculate_shards,
     get_test_case_configs,

--- a/tools/testing/target_determination/determinator.py
+++ b/tools/testing/target_determination/determinator.py
@@ -5,7 +5,18 @@ from tools.testing.target_determination.heuristics import (
     HEURISTICS,
     TestPrioritizations as TestPrioritizations,
 )
-from tools.testing.target_determination.heuristics.interface import HeuristicInterface
+from tools.testing.target_determination.heuristics.interface import (
+    HeuristicInterface,
+    TargetDeterminatorInterface,
+)
+from tools.testing.target_determination.heuristics.test_eliminators.remove_unranked_from_heuristics import (
+    RemoveUnrankedUsingHeuristics,
+)
+
+# TD Methods to test
+TD_STRATEGIES: List[TargetDeterminatorInterface] = [
+    RemoveUnrankedUsingHeuristics(heuristics=HEURISTICS)
+]
 
 
 def get_test_prioritizations(

--- a/tools/testing/target_determination/determinator.py
+++ b/tools/testing/target_determination/determinator.py
@@ -5,18 +5,7 @@ from tools.testing.target_determination.heuristics import (
     HEURISTICS,
     TestPrioritizations as TestPrioritizations,
 )
-from tools.testing.target_determination.heuristics.interface import (
-    HeuristicInterface,
-    TargetDeterminatorInterface,
-)
-from tools.testing.target_determination.heuristics.test_eliminators.remove_unranked_from_heuristics import (
-    RemoveUnrankedUsingHeuristics,
-)
-
-# TD Methods to test
-TD_STRATEGIES: List[TargetDeterminatorInterface] = [
-    RemoveUnrankedUsingHeuristics(heuristics=HEURISTICS)
-]
+from tools.testing.target_determination.heuristics.interface import HeuristicInterface
 
 
 def get_test_prioritizations(

--- a/tools/testing/target_determination/determinator.py
+++ b/tools/testing/target_determination/determinator.py
@@ -5,15 +5,18 @@ from tools.testing.target_determination.heuristics import (
     HEURISTICS,
     TestPrioritizations as TestPrioritizations,
 )
+from tools.testing.target_determination.heuristics.interface import HeuristicInterface
 
 
-def get_test_prioritizations(tests: List[str]) -> AggregatedHeuristics:
+def get_test_prioritizations(
+    tests: List[str], heuristics: List[HeuristicInterface] = HEURISTICS
+) -> AggregatedHeuristics:
     aggregated_results = AggregatedHeuristics(unranked_tests=tests)
     print(f"Received {len(tests)} tests to prioritize")
     for test in tests:
         print(f"  {test}")
 
-    for heuristic in HEURISTICS:
+    for heuristic in heuristics:
         new_rankings: TestPrioritizations = heuristic.get_test_priorities(tests)
         aggregated_results.add_heuristic_results(heuristic, new_rankings)
 

--- a/tools/testing/target_determination/heuristics/__init__.py
+++ b/tools/testing/target_determination/heuristics/__init__.py
@@ -11,7 +11,6 @@ from tools.testing.target_determination.heuristics.historical_edited_files impor
 from tools.testing.target_determination.heuristics.interface import (
     AggregatedHeuristics as AggregatedHeuristics,
     HeuristicInterface as HeuristicInterface,
-    TargetDeterminatorInterface,
     TestPrioritizations as TestPrioritizations,
 )
 
@@ -19,9 +18,6 @@ from tools.testing.target_determination.heuristics.previously_failed_in_pr impor
     PreviouslyFailedInPR,
 )
 from tools.testing.target_determination.heuristics.profiling import Profiling
-from tools.testing.target_determination.heuristics.test_eliminators.remove_unranked_from_heuristics import (
-    RemoveUnrankedUsingHeuristics,
-)
 
 # All currently running heuristics.
 # To add a heurstic in trial mode, specify the keywork argument `trial_mode=True`.
@@ -31,9 +27,4 @@ HEURISTICS: List[HeuristicInterface] = [
     CorrelatedWithHistoricalFailures(),
     HistorialEditedFiles(trial_mode=True),
     Profiling(trial_mode=True),
-]
-
-# TD Methods to test
-TD_STRATEGIES: List[TargetDeterminatorInterface] = [
-    RemoveUnrankedUsingHeuristics(heuristics=HEURISTICS)
 ]

--- a/tools/testing/target_determination/heuristics/__init__.py
+++ b/tools/testing/target_determination/heuristics/__init__.py
@@ -11,6 +11,7 @@ from tools.testing.target_determination.heuristics.historical_edited_files impor
 from tools.testing.target_determination.heuristics.interface import (
     AggregatedHeuristics as AggregatedHeuristics,
     HeuristicInterface as HeuristicInterface,
+    TargetDeterminatorInterface,
     TestPrioritizations as TestPrioritizations,
 )
 
@@ -18,6 +19,9 @@ from tools.testing.target_determination.heuristics.previously_failed_in_pr impor
     PreviouslyFailedInPR,
 )
 from tools.testing.target_determination.heuristics.profiling import Profiling
+from tools.testing.target_determination.heuristics.test_eliminators.remove_unranked_from_heuristics import (
+    RemoveUnrankedUsingHeuristics,
+)
 
 # All currently running heuristics.
 # To add a heurstic in trial mode, specify the keywork argument `trial_mode=True`.
@@ -27,4 +31,9 @@ HEURISTICS: List[HeuristicInterface] = [
     CorrelatedWithHistoricalFailures(),
     HistorialEditedFiles(trial_mode=True),
     Profiling(trial_mode=True),
+]
+
+# TD Methods to test
+TD_STRATEGIES: List[TargetDeterminatorInterface] = [
+    RemoveUnrankedUsingHeuristics(heuristics=HEURISTICS)
 ]

--- a/tools/testing/target_determination/heuristics/test_eliminators/__init__.py
+++ b/tools/testing/target_determination/heuristics/test_eliminators/__init__.py
@@ -1,0 +1,14 @@
+from typing import List
+
+from tools.testing.target_determination.heuristics import HEURISTICS
+from tools.testing.target_determination.heuristics.interface import (
+    TargetDeterminatorInterface,
+)
+from tools.testing.target_determination.heuristics.test_eliminators.remove_unranked_from_heuristics import (
+    RemoveUnrankedUsingHeuristics,
+)
+
+# TD Methods to test
+TD_STRATEGIES: List[TargetDeterminatorInterface] = [
+    RemoveUnrankedUsingHeuristics(heuristics=HEURISTICS)
+]

--- a/tools/testing/target_determination/heuristics/test_eliminators/dry_run_utils.py
+++ b/tools/testing/target_determination/heuristics/test_eliminators/dry_run_utils.py
@@ -1,0 +1,102 @@
+import json
+from typing import Any, Dict, List
+
+import requests
+from tools.stats.upload_metrics import EnvVarMetric
+
+
+BUILD_ENVIRONMENT = EnvVarMetric("build_environment", "BUILD_ENVIRONMENT").value()
+TEST_CONFIG = EnvVarMetric("test_config", "TEST_CONFIG", required=False).value()
+
+
+def get_github_json() -> Dict[str, Any]:
+    data = {}
+
+    # Define the URL of the JSON file in the GitHub repo
+    url = "https://raw.githubusercontent.com/pytorch/test-infra/generated-stats/stats/test-times.json"
+
+    # Fetch the file
+    response = requests.get(url)
+
+    # Check if the request was successful
+    if response.status_code == 200:
+        data = json.loads(response.content.decode("utf-8"))
+
+    else:
+        # TODO: Should we fail silently here?
+        print(f"Failed to download the file. Status code: {response.status_code}")
+    return data
+
+
+def calculate_recall(
+    selected_tests: List[str], ground_truth_failures: List[str]
+) -> float:
+    """
+    Calculate recall and precision statistics for test selection.
+
+    Parameters:
+    - selected_tests: List of tests that were selected to be run.
+    - ground_truth_failures: List of tests that are known to actually fail.
+
+    Returns:
+    - float containing 'recall' stat.
+    """
+    # Convert lists to sets for faster look-up
+    selected_tests_set = set(selected_tests)
+    ground_truth_failures_set = set(ground_truth_failures)
+
+    # Calculate True Positives (TP), False Positives (FP), and False Negatives (FN)
+    TP = len(ground_truth_failures_set.intersection(selected_tests_set))
+    FN = len(ground_truth_failures_set) - TP
+
+    # Calculate recall and precision
+    recall = TP / (TP + FN) if (TP + FN) != 0 else 0.0
+
+    return recall
+
+
+def calculate_test_times_sum(ignored_tests: List[str]) -> float:
+    """
+    Calculate the sum of the test times for the selected tests.
+
+    Parameters:
+    - ignored_tests: List of tests that were ignored.
+
+    Returns:
+    - Dictionary containing 'test_times_sum' statistic.
+    """
+    # Convert lists to sets for faster look-up
+    ignored_tests_set = set(ignored_tests)
+    data = get_github_json()
+    # Calculate test times sum
+    test_times_sum = sum(
+        data[BUILD_ENVIRONMENT][TEST_CONFIG][test] for test in ignored_tests_set
+    )
+    # assert total_test_times is a float
+    assert isinstance(test_times_sum, float)
+    return test_times_sum
+
+
+def calculate_failed_tests_in_ignored_tests(
+    ignored_tests: List[str], ground_truth_failures: List[str]
+) -> int:
+    ignored_tests_set = set(ignored_tests)
+    ground_truth_failures_set = set(ground_truth_failures)
+    return len(ground_truth_failures_set.intersection(ignored_tests_set))
+
+
+def get_metrics_dict_for_td_strategy(
+    strategy_name: str,
+    selected_tests: List[str],
+    ignored_tests: List[str],
+    ground_truth_failures: List[str],
+) -> Dict[str, Any]:
+    metrics_dict: Dict[str, Any] = {}
+    # recall here is percent of failed tests that were selected
+    metrics_dict["recall"] = calculate_recall(selected_tests, ground_truth_failures)
+    metrics_dict["contained_failure"] = len(ground_truth_failures) > 0
+    metrics_dict["num_ignored_failed_tests"] = len(ignored_tests)
+    metrics_dict["time_saved_seconds"] = calculate_test_times_sum(ignored_tests)
+    metrics_dict["strategy_name"] = strategy_name
+    metrics_dict["metric_type"] = "td_strategy"
+    return metrics_dict

--- a/tools/testing/target_determination/heuristics/test_eliminators/remove_unranked_from_heuristics.py
+++ b/tools/testing/target_determination/heuristics/test_eliminators/remove_unranked_from_heuristics.py
@@ -1,0 +1,53 @@
+from typing import Any, Dict, List
+
+from tools.testing.target_determination.determinator import get_test_prioritizations
+from tools.testing.target_determination.heuristics.interface import (
+    HeuristicInterface,
+    TargetDeterminatorInterface,
+)
+from tools.testing.target_determination.heuristics.test_eliminators.dry_run_utils import (
+    get_metrics_dict_for_td_strategy,
+)
+
+
+class RemoveUnrankedUsingHeuristics(TargetDeterminatorInterface):
+    """
+    remove unranked tests by using heuristics
+    """
+
+    def __init__(self, heuristics: List[HeuristicInterface], **kwargs: Dict[str, Any]):
+        super().__init__(**kwargs)
+        self.heuristics: List[HeuristicInterface] = heuristics  # type: ignore[assignment]
+
+    def gen_selected_tests(self, tests: List[str]) -> List[str]:
+        """
+        get selected tests by using heuristics and set selected_tests and ignored_tests
+        """
+        aggregate_results = get_test_prioritizations(tests, self.heuristics)
+        test_prioritizations = aggregate_results.get_aggregated_priorities()
+        selected_tests = self.selected_tests
+        ignored_tests = self.ignored_tests
+        selected_tests.extend(test_prioritizations.get_high_relevance_tests())
+        selected_tests.extend(test_prioritizations.get_probable_relevance_tests())
+        ignored_tests.extend(test_prioritizations.get_unranked_relevance_tests())
+        # remove duplicates
+        selected_tests = list(set(self.selected_tests))
+        ignored_tests = list(set(self.ignored_tests))
+        self.selected_tests = selected_tests
+        self.ignored_tests = ignored_tests
+
+        return self.selected_tests
+
+    def create_metrics_dict_for_dry_run(
+        self, ground_truth_failures: List[str]
+    ) -> Dict[str, Any]:
+        """
+        Returns the prioritizations for the given tests.
+
+        """
+        return get_metrics_dict_for_td_strategy(
+            self.name,
+            self.selected_tests,
+            self.ignored_tests,
+            ground_truth_failures,
+        )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #112307

As we move from reordering tests to actually doing test removal, we need some stats to make sure our techniques are working.

This PR introduces metrics to evaluate the effectiveness of our test removal strategies. We track "recall," which measures how accurately we select failing tests, and the time saved from ignoring tests. These metrics are sent to Rockset. This data allows us to assess how often a strategy skips tests that would have failed, and how many PRs might be merged with undetected failing tests

Note: We only care about how many PRs would be merged with failing tests that were not run because if we only care about improving the developers perspective, if one test fails, we can just run the rest of the tests on the PR.

Two further action items could be

 Bake the default heuristics.py code into interface.py instead for simplicity
 For randomized test removal methods like the one found here, we can enable doing multiple runs for better stats