### PR TITLE
[dynamo] support torch.dtype and torch.device in default class arguments

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -7511,6 +7511,22 @@ def ___make_guard_fn():
         res = opt_func(a)
         self.assertIsInstance(res, torch.Tensor)
 
+    def test_torch_device_dtype_class(self):
+        class Foo:
+            def __init__(
+                self,
+                dtype: torch.dtype = torch.float,
+                device: torch.device = torch.device("cpu"),
+            ) -> None:
+                self.value = torch.tensor(10, dtype=dtype, device=device)
+
+        def fn():
+            return Foo().value + 1
+
+        opt_func = torch._dynamo.optimize("eager", nopython=True)(fn)
+        res = opt_func()
+        self.assertEqual(res, 11.0)
+
     def test_itertools_repeat(self):
         counters.clear()
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1848,7 +1848,7 @@ class SourcelessBuilder:
             return SourcelessBuilder.wrap_constant_literal(value)
         elif is_builtin_callable(value):
             return BuiltinVariable(value)
-        elif is_allowed(value):
+        elif is_allowed(value) or isinstance(value, (torch.device, torch.dtype)):
             if is_user_defined_allowed(value):
                 self.tx.output.has_user_defined_allowed_in_graph = True
             return TorchVariable(value)


### PR DESCRIPTION
Related to #109910

Test plan:

```
pytest test/dynamo/test_misc.py -k torch_device
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng