### PR TITLE
Fix C++20 build

### DIFF
--- a/test/cpp/jit/test_memory_dag.cpp
+++ b/test/cpp/jit/test_memory_dag.cpp
@@ -36,7 +36,7 @@ TEST(MemoryDAGTest, Basic) {
     t->makePointerTo(e, a);
     t->makePointerTo(e, f);
 
-    auto dag = std::make_unique<MemoryDAG>(std::move(t));
+    auto dag = std::move(*t).createMemoryDAG();
 
     /**
      * Test mayAlias()
@@ -69,7 +69,7 @@ TEST(MemoryDAGTest, Basic) {
     auto c = t->makeFreshValue(cValue);
     t->addToContainedElements(a, c);
 
-    auto dag = std::make_unique<MemoryDAG>(std::move(t));
+    auto dag = std::move(*t).createMemoryDAG();
     EXPECT_TRUE(dag->mayContainAlias(a, b));
     EXPECT_TRUE(dag->mayContainAlias(b, a));
 
@@ -99,7 +99,7 @@ TEST(MemoryDAGTest, Basic) {
     auto d = t->makeFreshValue(dValue);
     t->addToContainedElements(b, d);
 
-    auto dag = std::make_unique<MemoryDAG>(std::move(t));
+    auto dag = std::move(*t).createMemoryDAG();
     EXPECT_TRUE(dag->mayContainAlias(b, d));
     EXPECT_TRUE(dag->mayContainAlias(d, b));
 
@@ -126,7 +126,7 @@ TEST(MemoryDAGTest, Basic) {
 
     t->addToContainedElements(f, e);
 
-    auto dag = std::make_unique<MemoryDAG>(std::move(t));
+    auto dag = std::move(*t).createMemoryDAG();
     for (auto elem : {a, b, c, d}) {
       EXPECT_FALSE(dag->mayContainAlias(f, elem));
       EXPECT_FALSE(dag->mayContainAlias(e, elem));

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -228,7 +228,7 @@ AliasDb::AliasDb(
       writeRegistry_(std::make_unique<AliasDb::WriteRegistry>()) {
   analyze(graph_);
 
-  memoryDAG_ = std::make_unique<MemoryDAG>(std::move(memoryDAGBuilder_));
+  memoryDAG_ = std::move(*memoryDAGBuilder_).createMemoryDAG();
   memoryDAGBuilder_ = nullptr; // to make further access a hard error
 
   memoryDAG_->setWildcards(

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -240,7 +240,6 @@ class TORCH_API StaticRuntimeMetadata : public torch::CustomClassHolder {
 ///
 class MemoryPlanner;
 class StaticNodeInfo;
-class ProcessedFunction;
 class ProcessedNode;
 class StaticRuntime;
 
@@ -258,6 +257,42 @@ struct TORCH_API SROperatorObserver {
   static void onEnd(const Node* name);
 };
 #endif
+
+class TORCH_API ProcessedFunction {
+ public:
+  ProcessedFunction(
+      Node* node,
+      bool enable_out_variant,
+      bool check_memory_overlap);
+
+  enum class Kind : uint8_t {
+    kOutVariant,
+    kNativeFunction,
+    kInterpreterFallback,
+  };
+
+  void run(ProcessedNode* pnode) const {
+    return f_(pnode);
+  }
+
+  Kind kind() const {
+    return kind_;
+  }
+
+  bool checkMemoryOverlap() const {
+    return check_memory_overlap_;
+  }
+
+  size_t num_outputs() const {
+    return num_outputs_;
+  }
+
+ private:
+  SROperator f_;
+  Kind kind_{ProcessedFunction::Kind::kOutVariant};
+  bool check_memory_overlap_{false};
+  size_t num_outputs_{0};
+};
 
 // A `BlockInfo` instance stores all of the shared state that each
 // `BlockRunner` will need to access. Most of this information is
@@ -776,42 +811,6 @@ class TORCH_API BlockRunner {
 
   std::vector<IValue*> outputs_;
   std::vector<ProcessedNode> nodes_;
-};
-
-class TORCH_API ProcessedFunction {
- public:
-  ProcessedFunction(
-      Node* node,
-      bool enable_out_variant,
-      bool check_memory_overlap);
-
-  enum class Kind : uint8_t {
-    kOutVariant,
-    kNativeFunction,
-    kInterpreterFallback,
-  };
-
-  void run(ProcessedNode* pnode) const {
-    return f_(pnode);
-  }
-
-  Kind kind() const {
-    return kind_;
-  }
-
-  bool checkMemoryOverlap() const {
-    return check_memory_overlap_;
-  }
-
-  size_t num_outputs() const {
-    return num_outputs_;
-  }
-
- private:
-  SROperator f_;
-  Kind kind_{ProcessedFunction::Kind::kOutVariant};
-  bool check_memory_overlap_{false};
-  size_t num_outputs_{0};
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)


### PR DESCRIPTION
Currently C++20 fails because of incorrect template initialization order. This PR adjusted the order of theses classes and a constructor to address the issue. 
