### PR TITLE
Fix scatter_mm kernel failure on non-contiguous tensor arguments

### DIFF
--- a/torch/sparse/_triton_ops.py
+++ b/torch/sparse/_triton_ops.py
@@ -1781,11 +1781,33 @@ if has_triton():
         assert p_offsets.stride(0) == 1
         assert q_offsets.stride(0) == 1
 
+        # Re non-contiguous tensor arguments. Sometimes triton kernel
+        # launches may fail with
+        #
+        #   RuntimeError: Triton Error [CUDA]: an illegal memory access was encountered
+        #
+        # that appears to be case when the size of a non-contiguous
+        # tensor argument is larger than a certain threshold. Could
+        # this be related to shared memory or L1 cache size of a GPU
+        # card? In anycase, ensuring that tensor arguments are
+        # contiguous seems to avoid the above exception. So, in the
+        # following we'll always convert tensor arguments to
+        # C-contiguous tensors.
+
+        blocks = blocks.contiguous()
+
+        others = others.contiguous()
+
+        if not accumulators.is_contiguous():
+            accumulators_ = accumulators.contiguous()
+        else:
+            accumulators_ = accumulators
+
         _scatter_mm6_kernel[grid](
             B, Ms, Ks, N,
             blocks, blocks.stride(0), blocks.stride(1), blocks.stride(2),
             others, others.stride(0), others.stride(1), others.stride(2),
-            accumulators, accumulators.stride(0), accumulators.stride(1), accumulators.stride(2),
+            accumulators_, accumulators_.stride(0), accumulators_.stride(1), accumulators_.stride(2),
             c_indices,
             r_offsets,
             p_offsets,
@@ -1793,6 +1815,9 @@ if has_triton():
             dot_out_dtype=dot_out_dtype,
             **meta
         )
+
+        if not accumulators.is_contiguous():
+            accumulators.copy_(accumulators_)
 
 else:
     bsr_softmax = None  # type: ignore[assignment]


### PR DESCRIPTION
This PR fixes
```
RuntimeError: Triton Error [CUDA]: an illegal memory access was encountered
```
that appears when using large non-contiguous tensor arguments in `scatter_mm` kernel launch.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #112337
* #112076
* #112154

