### PR TITLE
[fx] remove unneeded raise for external nn.Parameter

### DIFF
--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -320,10 +320,6 @@ class Tracer(TracerBase):
 
             The value ``a`` converted into the appropriate ``Argument``
         """
-        # The base tracer is used to construct Graphs when there is no associated
-        # module hierarchy, so it can never create parameter references.
-        # The default tracer adds the ability to refer to parameters when
-        # tracing modules.
         if isinstance(a, torch.nn.Parameter):
             for n, p in self.root.named_parameters():
                 if a is p:

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -328,7 +328,6 @@ class Tracer(TracerBase):
             for n, p in self.root.named_parameters():
                 if a is p:
                     return self.create_node("get_attr", n, (), {})
-            raise NameError("parameter is not a member of this module")
         elif isinstance(a, torch.Tensor):
             for n_, p_ in self.root.named_buffers():
                 if a is p_:

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -305,7 +305,8 @@ class Tracer(TracerBase):
         #. Given a Proxy object, return a reference to the underlying IR ``Node``
         #. Given a non-Proxy Tensor object, emit IR for various cases:
 
-            * For a Parameter, emit a ``get_attr`` node referring to that Parameter
+            * For a Parameter, emit a ``get_attr`` node referring to that Parameter,
+              if not exist, create a new ``get_attr`` node and add it to the graph.
             * For a non-Parameter Tensor, store the Tensor away in a special
               attribute referring to that attribute.
 

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -306,7 +306,8 @@ class Tracer(TracerBase):
         #. Given a non-Proxy Tensor object, emit IR for various cases:
 
             * For a Parameter, emit a ``get_attr`` node referring to that Parameter,
-              if not exist, create a new ``get_attr`` node and add it to the graph.
+              if it is an external parameter, it will be added as a special
+              attribute similar to non-parameter and non-buffer tensors.
             * For a non-Parameter Tensor, store the Tensor away in a special
               attribute referring to that attribute.
 
@@ -321,6 +322,10 @@ class Tracer(TracerBase):
 
             The value ``a`` converted into the appropriate ``Argument``
         """
+        # The base tracer is used to construct Graphs when there is no associated
+        # module hierarchy, so it can never create parameter references.
+        # The default tracer adds the ability to refer to parameters when
+        # tracing modules.
         if isinstance(a, torch.nn.Parameter):
             for n, p in self.root.named_parameters():
                 if a is p:


### PR DESCRIPTION
When passing nn.Parameter here, we don't have to raise it, instead it should be created as a member variable if it doesn't exist, this raise is not needed.