### PR TITLE
Fix typo under test directory

### DIFF
--- a/test/distributed/_shard/sharded_optim/test_sharded_optim.py
+++ b/test/distributed/_shard/sharded_optim/test_sharded_optim.py
@@ -104,7 +104,7 @@ class TestShardedOptimizer(ShardedTensorTestBase):
         local_model = MyShardedModel().cuda()
         sharded_model = MyShardedModel(spec=rowwise_spec).cuda()
 
-        # copy the parameteres from local model
+        # copy the parameters from local model
         sharded_model.sharded_param.local_shards()[0].tensor = \
             local_model.sharded_param.detach().clone().requires_grad_()
 

--- a/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
+++ b/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
@@ -1594,7 +1594,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         # test ability to move st to CPU
         spec_before_move = st.sharding_spec()
         new_st = st.cpu(process_group=gloo_pg)
-        # return a copy of orginal st
+        # return a copy of original st
         self.assertFalse(st is new_st)
         # check the spec is still ChunkShardingSpec
         spec_after_move = new_st.sharding_spec()
@@ -1626,7 +1626,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
 
         st = sharded_tensor.zeros(mixed_spec, h, w, process_group=gloo_pg)
         new_st = st.cpu()
-        # return a copy of orginal st
+        # return a copy of original st
         self.assertFalse(st is new_st)
         # check the spec is still ChunkShardingSpec
         spec_after_move = new_st.sharding_spec()

--- a/test/distributed/_spmd/test_tracing.py
+++ b/test/distributed/_spmd/test_tracing.py
@@ -669,7 +669,7 @@ class TraceTrainStepTest(DTensorTestBase):
         train_step(mod, opt, inp)
         for node in train_step._compiled_obj.gm.graph.nodes:
             if node.target == torch.ops.aten.expand.default:
-                # backward grad expandion op should match local batch size
+                # backward grad expansion op should match local batch size
                 # instead of global batch size.
                 self.assertEqual(node.args[1], [2, 10])
 

--- a/test/distributed/_tensor/test_dtensor_ops.py
+++ b/test/distributed/_tensor/test_dtensor_ops.py
@@ -495,7 +495,7 @@ dtensor_fails = {
     xfail("zeros"),
     # ops inside this might even fail without dtensor
     # tests, as we rescale op db common test size factor (i.e. L, M, S)
-    # which triggered the orignal function run failures with input
+    # which triggered the original function run failures with input
     # generation becomes wrong, we skip them for now but should enable later.
     # TODO: need to clean this list and remove all cases
     skip("argwhere"),
@@ -643,7 +643,7 @@ class TestDTensorOps(DTensorOpTestBase):
                         # errors
                         dtensor_rs = func(*dtensor_args, **dtensor_kwargs)
 
-                        # we need to skip tests containing tensors of zero elmeents for now.
+                        # we need to skip tests containing tensors of zero elements for now.
                         # see issue: https://github.com/pytorch/tau/issues/470
                         # TODO remove this once issue above fixed.
                         flat_args = pytree.tree_leaves(dtensor_rs)

--- a/test/distributed/checkpoint/e2e/test_fine_tuning.py
+++ b/test/distributed/checkpoint/e2e/test_fine_tuning.py
@@ -93,7 +93,7 @@ class TestFineTuning(DTensorTestBase):
         model = FSDP(model, device_mesh=device_mesh)
         optim = torch.optim.Adam(model.parameters(), lr=1e-3)
 
-        # Trainining
+        # Training
         for i in range(3):
             batch = torch.rand(32, DIM, device="cuda")
             loss = model(batch).sum()
@@ -158,7 +158,7 @@ class TestFineTuning(DTensorTestBase):
                 # If this is the restart of the fine tuning, then checkpoint should exit.
                 self.assertEqual(i, 0)
 
-            # Trainining
+            # Training
             for j in range(3):
                 batch = torch.rand(32, DIM, device="cuda")
                 loss = model(batch).sum()

--- a/test/distributed/checkpoint/test_dtensor_resharding.py
+++ b/test/distributed/checkpoint/test_dtensor_resharding.py
@@ -87,7 +87,7 @@ class TestDTensorReshardPlacementChange(DTensorTestBase):
             )
             self.assertEqual(global_tensor, state_dict_to_load["dtensor"].to_local())
 
-            # redistribute the tensor back to its original placment for comparison.
+            # redistribute the tensor back to its original placement for comparison.
             state_dict_to_load["dtensor"] = state_dict_to_load["dtensor"].redistribute(
                 device_mesh,
                 placements=original_placement,

--- a/test/distributed/elastic/agent/server/test/local_elastic_agent_test.py
+++ b/test/distributed/elastic/agent/server/test/local_elastic_agent_test.py
@@ -336,7 +336,7 @@ class LocalElasticAgentTest(unittest.TestCase):
     ) -> Optional[RunResult]:
         """
         Runs a single agent. This method can be called either on a separate process
-        or the main test process. When calling this method on a sparate process make
+        or the main test process. When calling this method on a separate process make
         sure to pass the ``agent_results`` multiprocessing Queue so that the agent's
         run results can be returned. If ``agent_results`` is omitted, then the
         run result is returned from the method.

--- a/test/distributed/elastic/timer/local_timer_example.py
+++ b/test/distributed/elastic/timer/local_timer_example.py
@@ -40,7 +40,7 @@ def _stuck_function(rank, mp_queue):
         time.sleep(5)
 
 
-# timer is not supported on macos or windowns
+# timer is not supported on macos or windows
 if not (IS_WINDOWS or IS_MACOS):
     class LocalTimerExample(TestCase):
         """

--- a/test/distributed/fsdp/test_fsdp_core.py
+++ b/test/distributed/fsdp/test_fsdp_core.py
@@ -327,7 +327,7 @@ class TestHooks(FSDPTest):
     def _test_pre_backward_hook_registration(self, model):
         optim = torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.9)
         optim.zero_grad()
-        # Inputs always cuda, as computation happes on CUDA device only
+        # Inputs always cuda, as computation happens on CUDA device only
         input = model.module.get_input(torch.device("cuda"))
         output = model(*input)
         # this is pre-bwd hook

--- a/test/distributed/fsdp/test_fsdp_fine_tune.py
+++ b/test/distributed/fsdp/test_fsdp_fine_tune.py
@@ -181,7 +181,7 @@ class TestFSDPFineTune(FSDPTest):
     def test_hooks_multi_traversal(self):
         """
         Tests that the hooks do reshard / unshard correctly in the case of same
-        parameters being used mutliple times during forward pass.
+        parameters being used multiple times during forward pass.
         """
         self.run_subtests(
             {

--- a/test/distributed/fsdp/test_fsdp_memory.py
+++ b/test/distributed/fsdp/test_fsdp_memory.py
@@ -191,8 +191,8 @@ class TestFSDPMemory(FSDPTest):
                 # sharded model size + sharded grad size + 1M temp memory
                 expected[f"iter {iteration}: after bwd"] = 2 * sharded_model_size_mb + 1
             else:
-                # after optimizer step in the first iteraiton, memory usage increased by
-                # sharded_model_size_mb becasue of increased optimizer states memory usage
+                # after optimizer step in the first iteration, memory usage increased by
+                # sharded_model_size_mb because of increased optimizer states memory usage
                 expected[f"iter {iteration}: start"] = 2 * sharded_model_size_mb + 1
                 if ckpt == "ckpt":
                     expected[f"iter {iteration}: after fwd"] = (

--- a/test/distributed/fsdp/test_fsdp_meta.py
+++ b/test/distributed/fsdp/test_fsdp_meta.py
@@ -108,7 +108,7 @@ class NestedModel(nn.Module):
 def _init_with_reset_params(module: nn.Module):
     """
     to_empty + reset_parameters() init function example for modules
-    initailized with device="meta"
+    initialized with device="meta"
     """
     has_meta_states = any(
         t.is_meta

--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -507,7 +507,7 @@ class TestFSDPMiscMultiProcess(FSDPTest):
         # Move me to MT test once warning logging and backward collective issue
         # is resolved.
         """Tests that passing a CPU module to FSDP preserves that the wrapped
-        module is on CPU after FSDP initialization, albeit after loging a
+        module is on CPU after FSDP initialization, albeit after logging a
         warning, and that FSDP moves CPU input to GPU before the forward."""
         torch.cuda.set_device(self.rank)
         regex = "passed-in `module` is on CPU"

--- a/test/distributed/fsdp/test_fsdp_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_state_dict.py
@@ -702,7 +702,7 @@ class TestFSDPStateDict(FSDPTest):
             optim.step()
 
         trained_params = get_full_params(model)
-        # Ensure some training occured
+        # Ensure some training occurred
         self.assertNotEqual(initial_params, trained_params)
         # Save a copy of the state_dict
         fsd_mgr = self._get_state_dict_mgr(

--- a/test/distributed/pipeline/sync/test_bugs.py
+++ b/test/distributed/pipeline/sync/test_bugs.py
@@ -49,7 +49,7 @@ def test_python_autograd_function(setup_rpc):
 
 def test_exception_no_hang(setup_rpc):
     # In v0.0.2, once a failed partition receives a normal message
-    # (non-closing) for the next micro-batch, a hang occured. The reason was
+    # (non-closing) for the next micro-batch, a hang occurred. The reason was
     # that a failed partition didn't call in_queue.task_done() on a normal
     # message. So the former partition was blocked at out_queue.join() for the
     # next of next micro-batch.

--- a/test/distributed/tensor/parallel/test_tp_random_state.py
+++ b/test/distributed/tensor/parallel/test_tp_random_state.py
@@ -115,11 +115,11 @@ class TensorParallelRandomStateTests(DTensorTestBase):
                 # compare local shards across TP groups
                 def dp_weights_assert(tensor1, tensor2):
                     if enable_distribute_flag:
-                        # local weights shall be initialized the same acorss TP groups
+                        # local weights shall be initialized the same across TP groups
                         self.assertEqual(tensor1, tensor2)
                     else:
                         # without the parallel RNG, weight initialization violates the TP setup:
-                        # local weights are initialized differently acorss TP groups due to different
+                        # local weights are initialized differently across TP groups due to different
                         # random seeds set in data loading.
                         self.assertNotEqual(tensor1, tensor2)
 

--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -137,7 +137,7 @@ class TimeoutTest(TestCase):
         port = common.find_free_port()
 
         def thread_work(timeout, init_type, world_size, rank, error_list):
-            # we need to create a seperate store just for the store barrier test
+            # we need to create a separate store just for the store barrier test
             if init_type == "file":
                 barrier_store = dist.FileStore(f.name)
             elif init_type == "tcp":
@@ -572,7 +572,7 @@ class CommonDistributedDataParallelTest:
     @parametrize("use_reentrant", [True, False])
     def test_ddp_checkpointing_twice(self, use_reentrant):
         """
-        Checkpoitning twice fails for non-static graph with reentrant checkpoint
+        Checkpointing twice fails for non-static graph with reentrant checkpoint
         implementation, succeeds with non-reentrant checkpoint implementation.
         """
         process_group = self._get_process_group()
@@ -684,7 +684,7 @@ class CommonDistributedDataParallelTest:
     def test_ddp_checkpointing_twice_weight_sharing(self):
         """
         Checkpointing should work with static graph in the case of checkpointing
-        same layer twice and having weights shared acrosss layers.
+        same layer twice and having weights shared across layers.
         """
         process_group = self._get_process_group()
         torch.cuda.set_device(self.rank)

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -2584,7 +2584,7 @@ class WorkHookTest(MultiProcessTestCase):
         pg._register_on_completion_hook(hook)
         tensor = torch.ones([2, 3]).cuda(self.rank)
         tensor_list = [torch.empty_like(tensor) for _ in range(self.world_size)]
-        # intentionall using async ops.
+        # intentionally using async ops.
         pg.allreduce(tensor)
         pg.allgather(tensor_list, tensor)
         pg.allreduce(tensor)
@@ -2936,7 +2936,7 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
         target += torch.arange(60, dtype=half, device=device).chunk(5)
         target += torch.arange(60, dtype=torch.float32, device=device).chunk(5)
 
-        # The tensors to pass to broadcast are idential to the target
+        # The tensors to pass to broadcast are identical to the target
         # only on the process that is the root of the broadcast.
         if self.rank == root_rank:
             tensors = [tensor.clone() for tensor in target]

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -196,7 +196,7 @@ class InitDeviceMeshTest(DTensorTestBase):
     def test_raises_duplicate_mesh_dim_names(self):
         with self.assertRaisesRegex(
             RuntimeError,
-            "Each mesh_dim_name must be uqique.",
+            "Each mesh_dim_name must be unique.",
         ):
             mesh = init_device_mesh(
                 self.device_type,

--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -558,7 +558,7 @@ class TestSingleProc(DynamoDistributedSingleProcTestCase):
         self.assertTrue(same(correct_outputs, opt_outputs))
         self.assertEqual(check_splits_compiler.compiler_called, 3)
 
-        # ensure compatibilty with dynamo explain
+        # ensure compatibility with dynamo explain
 
         explain_out = torch._dynamo.explain(ddp_m)(inputs)
         break_reasons = explain_out.break_reasons
@@ -586,7 +586,7 @@ class TestSingleProc(DynamoDistributedSingleProcTestCase):
     def test_no_split(self):
         """
         Ensures the DDPOptimizer returns a correct, compiled module without
-        introducing graph splits. (Based on model parmeters fitting in the bucket)
+        introducing graph splits. (Based on model parameters fitting in the bucket)
         """
         # DDP will always do a 'first bucket' with a really small size;  so only a tiny model will escape this
         m, inputs, correct_outputs = self.get_model(hidden_feat=5)

--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -277,9 +277,9 @@ class AotAutogradFallbackTests(torch._dynamo.test_case.TestCase):
     # This test is a spiritual equivalent to test_invalid_requires_grad_fake in test_autodispatch.py
     # The point of this test is to invoke aot_autograd in a way that would normally trigger an assertion
     # (This is what test_invalid_requires_grad_fake) does. However, the point of this test is to prove
-    # that we do not hit this asseriton, as dynamo recompiles correctly and protects this condition.
+    # that we do not hit this assertion, as dynamo recompiles correctly and protects this condition.
     #
-    # Subnote: The reason for us having test_invalid_requires_grad_fake utilizing fake tenosrs
+    # Subnote: The reason for us having test_invalid_requires_grad_fake utilizing fake tensors
     # is because dynamo sends fake tensors down to aot_autograd.
     @patch("torch._functorch.config.debug_assert", True)
     def test_requires_grad_fake_via_dynamo_recompiles(self):

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -280,7 +280,7 @@ Failed Source Expressions:
             """\
 translation validation failed when evaluating: Eq(s1 + s2 + s3, s0)
 
-Failure ocurred while running node:
+Failure occurred while running node:
     %split : [num_users=1] = call_method[target=split](args = (%l_x_, (%l_shape_0_, %l_shape_1_, %l_shape_2_)), kwargs = {})
 
 Model:

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -8131,8 +8131,8 @@ ShapeEnv not equal: field values don't match:
         other.create_unbacked_symint()
 
         # Create a runtime assert: r % 3 == 0 (only in the main ShapeEnv)
-        #   - +1 defferred_runtime_asserts entry
-        #   - Change: num_defferred_runtime_asserts
+        #   - +1 deferred_runtime_asserts entry
+        #   - Change: num_deferred_runtime_asserts
         expect_true(r % 3 == 0)
 
         self.assertExpectedRaisesInline(

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1527,7 +1527,7 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         mod = MockModule()
         opt_mod = torch._dynamo.optimize("eager")(mod)
 
-        # Check parameteres and buffers
+        # Check parameters and buffers
         for p1, p2 in zip(mod.parameters(), opt_mod.parameters()):
             self.assertTrue(id(p1) == id(p2))
         for b1, b2 in zip(mod.buffers(), opt_mod.buffers()):
@@ -1768,7 +1768,7 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
 
         """
         Summary:
-          - removing a hook doesn't fail a guard, becuase we weren't compiling the hook
+          - removing a hook doesn't fail a guard, because we weren't compiling the hook
             (at least into the same graph) as forward in the first place! We do correctly
             omit calling the removed hook, but since this hook is a post forward hook,
             the 'RETURN' from forward is breaking the graph.

--- a/test/dynamo/test_python_autograd.py
+++ b/test/dynamo/test_python_autograd.py
@@ -95,7 +95,7 @@ def grad(L, desired_results: List[Variable]) -> List[Variable]:
         # perform chain rule propagation specific to each compute
         dL_dinputs = entry.propagate(dL_doutputs)
 
-        # Accululate the gradient produced for each input.
+        # Accumulate the gradient produced for each input.
         # Each use of a variable produces some gradient dL_dinput for that
         # use. The multivariate chain rule tells us it is safe to sum
         # all the contributions together.

--- a/test/dynamo/test_recompile_ux.py
+++ b/test/dynamo/test_recompile_ux.py
@@ -72,7 +72,7 @@ class RecompileUxTests(torch._dynamo.test_case.TestCase):
         # self.assertEqual(counters["frames"]["ok"], 1 + self.cache_limit)
 
         # compile_counter only sees frames that were fed to the backend compiler,
-        # which is a subset of counters["frames"]["ok"] -- probably becuase
+        # which is a subset of counters["frames"]["ok"] -- probably because
         # counters["frames"]["ok"] includes frames not containing torch ops?
         self.assertEqual(compile_counter.frame_count, self.cache_limit)
 
@@ -104,7 +104,7 @@ class RecompileUxTests(torch._dynamo.test_case.TestCase):
     def test_nvfuser_guards(self):
         # we may want to model dynamo's guards sufficiently after nvfuser's ProfilingExecutor guards
         # such that we ensure dynamo is in charge of all the recompilations at the top level,
-        # and we could thus simplfy the underlying torchscript executor
+        # and we could thus simplify the underlying torchscript executor
         def func(a, b, c):
             return a + b * c
 

--- a/test/dynamo/test_replay_record.py
+++ b/test/dynamo/test_replay_record.py
@@ -176,7 +176,7 @@ class ReplayRecordTests(torch._dynamo.test_case.TestCase):
 
         self.check_replay(test_fn, torch.ones(1, 1), exp_exc_name="RuntimeError")
 
-    # Verfiy that we replay when we have tensor arguments to the frame being replayed
+    # Verify that we replay when we have tensor arguments to the frame being replayed
     @requires_dill
     def test_fn_call_args(self):
         def test_fn(x, y):

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -513,7 +513,7 @@ class PartialMaml(torch.nn.Module):
         corrects = [0 for _ in range(self.update_step_test + 1)]
 
         # in order to not ruin the state of running_mean/variance and bn_weight/bias
-        # we finetunning on the copied model instead of self.net
+        # we finetuning on the copied model instead of self.net
         net = deepcopy(self.net)
 
         # 1. run the i-th task and compute loss for k=0

--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -197,7 +197,7 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
             x.sigmoid()
 
         msg = (
-            "Accessing overidden method/attribute sigmoid on a tensor"
+            "Accessing overridden method/attribute sigmoid on a tensor"
             " subclass with a __torch_function__ override is not supported"
         )
         with torch._dynamo.config.patch(
@@ -221,7 +221,7 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
             return x.ndim
 
         msg = (
-            "Accessing overidden method/attribute ndim on a tensor"
+            "Accessing overridden method/attribute ndim on a tensor"
             " subclass with a __torch_function__ override is not supported"
         )
         with torch._dynamo.config.patch(
@@ -254,7 +254,7 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
             return x.ndim
 
         msg = (
-            "Accessing overidden method/attribute ndim on a tensor"
+            "Accessing overridden method/attribute ndim on a tensor"
             " subclass with a __torch_function__ override is not supported"
         )
         with torch._dynamo.config.patch(
@@ -613,7 +613,7 @@ class GraphModule(torch.nn.Module):
             context = torch._guards.TracingContext.get()
             val_to_guards = list(context.fake_mode.shape_env.var_to_guards.values())
 
-            # Grab info on sources and guards from the shapenv
+            # Grab info on sources and guards from the shapeenv
             nonlocal lower_bound_str
             nonlocal upper_bound_str
             nonlocal curr_var_to_val

--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -110,7 +110,7 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
 
     # Really annoying intersection of specialization and RandomValueSource
     # If we get a RandomValueSource with a single element tensor, we should return a ConstantVariable like other
-    # unspects... but if we do, we break the bytecode assumptions and guards will not work as we will be reffering
+    # unspects... but if we do, we break the bytecode assumptions and guards will not work as we will be referring
     # to a name from a source that is not there. If we call .item() and take the wrapped_value out, where we do
     # wrapped_value = wrapped_value.item() where we send unspec down to wrap_fx_proxy, this test passes and then
     # some models fail on missing codegen.tx.output.random_values_var. If we let the tensor value go into wrap as

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -84,7 +84,7 @@ class TestSerialize(TestCase):
         serialized, _ = ExportedProgramSerializer().serialize(exported_module)
         node = serialized.graph_module.graph.nodes[-1]
         self.assertEqual(node.target, "torch.ops.aten.native_layer_norm.default")
-        # aten::native_layer_norm returns 3 tensnors
+        # aten::native_layer_norm returns 3 tensors
         self.assertEqual(len(node.outputs), 3)
 
         # check the names are unique

--- a/test/functorch/attn_ft.py
+++ b/test/functorch/attn_ft.py
@@ -55,7 +55,7 @@ class BertSelfAttention(nn.Module):
         v = self.value(hidden_states)
 
         # introduce values that represent each dimension. dimensions are 'first class'
-        # becaue they are actual python values introduced here
+        # because they are actual python values introduced here
         batch, query_sequence, key_sequence, heads, features = dims()
         heads.size = self.num_attention_heads
 
@@ -72,12 +72,12 @@ class BertSelfAttention(nn.Module):
 
 
         # this option allows the model to attend to not just the elements of the current sequence
-        # but the previouse elements as well as additional tokens.
+        # but the previous elements as well as additional tokens.
         if past_key_value is not None:
             extended_key_sequence = dims()
             key_past = past_key_value[0][batch, heads, key_sequence, features]
             value_past = past_key_value[1][batch, heads, key_sequence, features]
-            # cat introduces a new dimension exteneded_key_sequence, becuase it is twice as long
+            # cat introduces a new dimension extended_key_sequence, because it is twice as long
             # as the original key_sequence
             k = cat([key_past, k], key_sequence, extended_key_sequence)
             v = cat([value_past, v], key_sequence, extended_key_sequence)
@@ -109,7 +109,7 @@ class BertSelfAttention(nn.Module):
             # this is just a `gather` primitive op. The resulting tensor will
             # have all the dimensions of embeddeding_idx (query_sequence x key_sequence),
             # plus all the dimensions of `embed` that were not indirectly accessed (`embedding_range`).
-            # this form of indirect indexing is more strainghtforward than either advanced indexing or torch.gather which both
+            # this form of indirect indexing is more straightforward than either advanced indexing or torch.gather which both
             # have a lot of dependencies on the positions of indexing tensors.
 
             positional_embedding = self.distance_embedding.weight[self.max_position_embeddings - 1 + distance, features]

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -850,7 +850,7 @@ def forward(self, primals_1):
         out_ref = f1(inp_ref)
         out_test = f1_compiled(inp)
         # Assert that we get CompiledFunctionBackward in the backward graph,
-        # and not AsStridedBackward. No view-regeneration necesssary for this mult-output view case.
+        # and not AsStridedBackward. No view-regeneration necessary for this mult-output view case.
         # See Note: [AOTAutograd: differentiable outputs that alias each other from a multi-output view call]
         self.assertTrue(all('CompiledFunctionBackward' in str(o.grad_fn) for o in out_test))
 
@@ -903,7 +903,7 @@ def forward(self, primals_1):
         out_ref = f1(inp_ref)
         out_test = f1_compiled(inp)
         # Assert that we get CompiledFunctionBackward in the backward graph,
-        # and not AsStridedBackward. No view-regeneration necesssary for this mult-output view case.
+        # and not AsStridedBackward. No view-regeneration necessary for this mult-output view case.
         # See Note: [AOTAutograd: differentiable outputs that alias each other from a multi-output view call]
         self.assertTrue(all('CompiledFunctionBackward' in str(o.grad_fn) for o in out_test))
 
@@ -923,7 +923,7 @@ def forward(self, primals_1):
         out_ref = f2(inp_ref)
         out_test = f2_compiled(inp)
         # Assert that we get CompiledFunctionBackward in the backward graph,
-        # and not AsStridedBackward. No view-regeneration necesssary for this mult-output view case.
+        # and not AsStridedBackward. No view-regeneration necessary for this mult-output view case.
         # See Note: [AOTAutograd: differentiable outputs that alias each other from a multi-output view call]
         self.assertTrue(all('CompiledFunctionBackward' in str(o.grad_fn) for o in out_test))
 
@@ -946,7 +946,7 @@ def forward(self, primals_1):
         out_ref = f3(inp_ref)
         out_test = f3_compiled(inp)
         # Assert that we get CompiledFunctionBackward in the backward graph,
-        # and not AsStridedBackward. No view-regeneration necesssary for this mult-output view case.
+        # and not AsStridedBackward. No view-regeneration necessary for this mult-output view case.
         # See Note: [AOTAutograd: differentiable outputs that alias each other from a multi-output view call]
         self.assertTrue(all('CompiledFunctionBackward' in str(o.grad_fn) for o in out_test))
 

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -1047,7 +1047,7 @@ def forward(self, arg0_1):
                         c += int(schema.is_mutable)
             return c
         self.assertEqual(count_mutable(fgm), 0)
-        # One for forward, one for recompuation logic in backward
+        # One for forward, one for recomputation logic in backward
         self.assertEqual(count_mutable(gm), 2)
 
     def test_map_functionalized(self):
@@ -1250,7 +1250,7 @@ def forward(self, arg0_1):
             return cond(x.shape[0] == 4, true_fn, false_fn, [x])
 
         gm = make_fx(foo, tracing_mode="symbolic")(torch.ones(3, 2, 1))
-        # The symbols in make_fx's shape_env should not be speciliazed.
+        # The symbols in make_fx's shape_env should not be specialized.
         self.assertEqual(len(gm.shape_env.guards), 0)
 
         self.assertExpectedInline(gm.code.strip(), """\

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -63,7 +63,7 @@ except ImportError:
                   "`--no-deps` to avoid overwriting the pytorch installation",
                   UserWarning)
 
-# TestCase for _slice_argnums, an important helper funciton
+# TestCase for _slice_argnums, an important helper function
 
 
 class TestSliceArgnums(TestCase):

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -344,7 +344,7 @@ aliasing_ops = {
     'narrow',
     'permute',
     'positive',
-    # 'ravel', is composite implict autograd and may call clone
+    # 'ravel', is composite implicit autograd and may call clone
     'real',
     'reshape',
     'resolve_conj',
@@ -1058,7 +1058,7 @@ class TestOperators(TestCase):
     }))
     # This is technically a superset of test_vmapjvp. We should either delete test_vmapjvp
     # or figure out if we can split vmapjvpall. It's useful to keep test_vmapjvp intact
-    # because that coresponds to "batched forward-mode AD" testing in PyTorch core
+    # because that corresponds to "batched forward-mode AD" testing in PyTorch core
     def test_vmapjvpall(self, device, dtype, op):
         if is_inplace(op, op.get_op()):
             # TODO: test in-place
@@ -1463,7 +1463,7 @@ class TestOperators(TestCase):
 
     @with_tf32_off  # https://github.com/pytorch/pytorch/issues/86798
     @skipOps('TestOperators', 'test_vmapjvpvjp', vjp_fail.union({
-        # Following operatos take too long, hence skipped
+        # Following operators take too long, hence skipped
         skip('atleast_1d'),
         skip('atleast_2d'),
         skip('atleast_3d'),
@@ -1574,7 +1574,7 @@ class TestOperators(TestCase):
              {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
     ))
     def test_vmapjvpvjp(self, device, dtype, op):
-        # Since we test `jvpvjp` seperately,
+        # Since we test `jvpvjp` separately,
         # in this we just check that vmap of `jvpvjp`
         # is correct.
         if not op.supports_autograd:

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -1556,7 +1556,7 @@ class TestVmapOperators(Namespace.TestVmapBase):
         test(op, (getter([2, B0], device), getter([2], device)), in_dims=(1, None))
 
     @skipIf(TEST_WITH_TORCHDYNAMO and os.getenv('BUILD_ENVIRONMENT', '') == 'linux-focal-py3.8-clang10',
-            "Segfauls with dynamo on focal, see https://github.com/pytorch/pytorch/issues/107173")
+            "Segfaults with dynamo on focal, see https://github.com/pytorch/pytorch/issues/107173")
     @parametrize('case', [
         subtest(_make_case(torch.add), name='add'),
         subtest(_make_case(lambda x, y: x + y), name='add_dunder'),
@@ -2092,7 +2092,7 @@ class TestVmapOperators(Namespace.TestVmapBase):
 
             # Interesting case #2: Batch dim at end of tensor, success cases
             # view_as_complex requires that the dim with size 2 have stride 1
-            # in order for the view to function propertly
+            # in order for the view to function property
             test(op, [get([B0, 2]).transpose(0, 1)], in_dims=1)
             test(vmap(op, in_dims=1), [get([B0, B1, 2]).movedim(1, 2)])
             test(vmap(op, in_dims=2), [get([B0, 3, B1, 2]).movedim(2, 3)])
@@ -4355,7 +4355,7 @@ class TestVmapOperatorsOpInfo(TestCase):
 
     def test_searchsorted_bucketize(self, device):
         # OpInfo generates test with repeated samples in batch dim.
-        # Thus we test explicitily with different samples across a batch.
+        # Thus we test explicitly with different samples across a batch.
 
         def test():
             boundaries = torch.tensor([[1, 4, 5, 7, 9], [1, 2, 6, 8, 10]], device=device)
@@ -4541,7 +4541,7 @@ class TestRandomness(TestCase):
                 vmap(op, randomness=randomness, in_dims=in_dims)(passed, always_batched)
             return
 
-        # I have no clue how to actually test corectness of alpha dropout because the docs
+        # I have no clue how to actually test correctness of alpha dropout because the docs
         # seem wrong: https://github.com/pytorch/pytorch/issues/74004
         vmap_result = vmap(op, randomness=randomness, in_dims=in_dims)(passed, always_batched)
         if randomness == 'different':
@@ -4608,7 +4608,7 @@ class TestRandomness(TestCase):
 
         vmap_result = vmap(op, randomness=randomness, in_dims=in_dims)(passed, always_batched)
 
-        # I have no clue how to actually test corectness of alpha dropout because the docs
+        # I have no clue how to actually test correctness of alpha dropout because the docs
         # seem wrong: https://github.com/pytorch/pytorch/issues/74004
 
         # Check the "feature" pattern

--- a/test/fx/test_gradual_type.py
+++ b/test/fx/test_gradual_type.py
@@ -33,8 +33,8 @@ class AnnotationsTest(TestCase):
     def test_annotations(self):
         """
         Test type annotations in the forward function.
-        The annoation should appear in the n.graph
-        where n is the corresoinding node in the resulting graph.
+        The annotation should appear in the n.graph
+        where n is the corresponding node in the resulting graph.
         """
         class M(torch.nn.Module):
             def forward(self,
@@ -827,7 +827,7 @@ class TypeCheckerTest(TestCase):
         for n1, n2 in zip(gm_static.graph.nodes, gm_run.graph.nodes):
             assert is_consistent(n1.type, TensorType(n2.meta['tensor_meta'].shape))
 
-        # here we give the same input as to runtume
+        # here we give the same input as to runtime
         gm_static_with_types = symbolic_trace(resnet50())
 
         # we initialize our placeholder

--- a/test/fx/test_subgraph_rewriter.py
+++ b/test/fx/test_subgraph_rewriter.py
@@ -381,7 +381,7 @@ class TestSubgraphRewriter(JitTestCase):
 
         Here, we want to be able to match the original graph's
         `call_function.add` Node with the pattern graph's
-        `plaeholder.x` Node.
+        `placeholder.x` Node.
 
         Credit to Jerry Zhang (GitHub: jerryzh168) for this test case
         """

--- a/test/fx/test_z3_gradual_types.py
+++ b/test/fx/test_z3_gradual_types.py
@@ -622,7 +622,7 @@ class HFOperations(unittest.TestCase):
         self.assertNotEqual(s.model()[arange_result].arg(0).arg(0).as_long(), 0)
         self.assertEqual(s.model()[arange_result].arg(0).arg(1).as_long(), B.size()[0])
 
-        # change the annotation to Dyn. This will migrate to an arbitirary type
+        # change the annotation to Dyn. This will migrate to an arbitrary type
         for n in symbolic_traced.graph.nodes:
             if n.op == 'placeholder':
                 n.type = Dyn
@@ -737,7 +737,7 @@ class HFOperations(unittest.TestCase):
         assert s.model()[embedding_result].arg(1).arg(0) == 0
         assert s.model()[embedding_result].arg(2).arg(1) == B[2]
 
-        # change the type to Dyn. Here, we will get an arbitirary migration
+        # change the type to Dyn. Here, we will get an arbitrary migration
         for n in traced.graph.nodes:
             if n.op == 'placeholder':
                 n.type = Dyn
@@ -1086,7 +1086,7 @@ class ComposeOperationsGradualTypes(unittest.TestCase):
         self.assertEqual(s.model()[masked_fill_res].arg(0).arg(1).as_long(), B.size()[0])
         self.assertEqual(s.model()[masked_fill_res].arg(1).arg(1).as_long(), B.size()[1])
 
-        # change the annotation to Dyn. This will migrate to an arbitirary type
+        # change the annotation to Dyn. This will migrate to an arbitrary type
         for n in symbolic_traced.graph.nodes:
             if n.op == 'placeholder':
                 n.type = Dyn

--- a/torch/_dynamo/variables/torch_function.py
+++ b/torch/_dynamo/variables/torch_function.py
@@ -166,7 +166,7 @@ class TensorWithTFOverrideVariable(TensorVariable):
 
         if _is_attr_overidden(tx, self, name):
             unimplemented(
-                f"Accessing overidden method/attribute {name} on a tensor"
+                f"Accessing overridden method/attribute {name} on a tensor"
                 " subclass with a __torch_function__ override is not supported"
             )
 
@@ -218,7 +218,7 @@ class TensorWithTFOverrideVariable(TensorVariable):
 
             if _is_attr_overidden(tx, self, name):
                 unimplemented(
-                    f"Calling overidden method {name} on a tensor"
+                    f"Calling overridden method {name} on a tensor"
                     " subclass with a __torch_function__ override is not supported"
                 )
 

--- a/torch/distributed/_device_mesh.py
+++ b/torch/distributed/_device_mesh.py
@@ -434,7 +434,7 @@ def init_device_mesh(
     if mesh_dim_names is not None:
         if len(set(mesh_dim_names)) != len(mesh_dim_names):
             raise RuntimeError(
-                "Each mesh_dim_name must be uqique.",
+                "Each mesh_dim_name must be unique.",
                 f"Found repeated mesh_dim_name in mesh_dim_names {mesh_dim_names}",
             )
 

--- a/torch/fx/experimental/validator.py
+++ b/torch/fx/experimental/validator.py
@@ -603,7 +603,7 @@ class BisectValidationException(TorchDynamoException):
     def __init__(self, validation_exc, expr, failed_action, traced_node):
         self.msg = f"translation validation failed when {failed_action}: {expr}"
         self.details = f"""\
-Failure ocurred while running node:
+Failure occurred while running node:
     {traced_node.format_node()}
 
 {validation_exc.details}"""


### PR DESCRIPTION
This PR fixes typo in comments and messages under `test` directory. This PR also fixes related typo in messages under `torch` directory.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan @angelayi @suo @ydwu4