### PR TITLE
Prevent OOB access in foreach_list variants

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -411,6 +411,8 @@ class TestForeach(TestCase):
         tensors2.append(torch.tensor([1], device=device))
         with self.assertRaisesRegex(RuntimeError, "Tensor lists must have the same number of tensors, got 1 and 2"):
             foreach_op(tensors1, tensors2)
+        with self.assertRaisesRegex(RuntimeError, "Tensor lists must have the same number of tensors, got 2 and 1"):
+            foreach_op(tensors2, tensors1)
 
         # Corresponding tensors with different sizes that aren't compatible with broadcast
         # If sizes are different then foreach chooses slow path, thus error messages are expected

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -719,7 +719,7 @@ FW_DERIVATIVE_SIZE_CHECK_TEMPLATE = CodeTemplate(
         "Tensor lists must have the same number of tensors, got ",
       self.size(),
         " and ",
-      {inp_name}.size());
+      ${inp_name}.size());
 """
 )
 

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -712,6 +712,16 @@ FW_DERIVATIVE_CHECK_TEMPLATE = CodeTemplate(
 isFwGradDefined(${req_inp})\
 """
 )
+FW_DERIVATIVE_SIZE_CHECK_TEMPLATE = CodeTemplate(
+    """\
+  TORCH_CHECK(
+      self.size() == ${inp_name}.size(),
+        "Tensor lists must have the same number of tensors, got ",
+      self.size(),
+        " and ",
+      {inp_name}.size());
+"""
+)
 
 FW_DERIVATIVE_TENSORLIST_CHECK_TEMPLATE = CodeTemplate(
     """\
@@ -1785,27 +1795,39 @@ def emit_body(
         else:
             for derivative in fw_derivatives:
                 bool_vector_name = get_any_has_forward_grad_name(derivative.var_names)
-                cur_derivative_conditions = [
-                    FW_DERIVATIVE_CHECK_TEMPLATE.substitute(
-                        req_inp=(
-                            inp.name
-                            if not inplace
-                            else refargname2inplace_foreacharg[inp.name].name
-                        )
-                        + (
-                            "[i]"
-                            if is_tensor_list_type(
-                                inp.type
-                                if not inplace
-                                else refargname2inplace_foreacharg[inp.name].type
-                            )
-                            else ""
-                        ),
+                cur_derivative_conditions = []
+                for inp in differentiable_inputs:
+                    if derivative.required_inputs_fw_grad is None:
+                        continue
+                    if inp.name not in derivative.required_inputs_fw_grad:
+                        continue
+                    inp_name = (
+                        inp.name
+                        if not inplace
+                        else refargname2inplace_foreacharg[inp.name].name
                     )
-                    for inp in differentiable_inputs
-                    if derivative.required_inputs_fw_grad is not None
-                    and inp.name in derivative.required_inputs_fw_grad
-                ]
+                    inp_type = (
+                        inp.type
+                        if not inplace
+                        else refargname2inplace_foreacharg[inp.name].type
+                    )
+                    is_list_type = is_tensor_list_type(inp_type)
+                    if is_list_type:
+                        content.append(
+                            FW_DERIVATIVE_SIZE_CHECK_TEMPLATE.substitute(
+                                inp_name=inp_name
+                            )
+                        )
+                        cur_derivative_conditions.append(
+                            FW_DERIVATIVE_CHECK_TEMPLATE.substitute(
+                                req_inp=inp_name + "[i]"
+                            )
+                        )
+                    else:
+                        cur_derivative_conditions.append(
+                            FW_DERIVATIVE_CHECK_TEMPLATE.substitute(req_inp=inp_name)
+                        )
+
                 content.append(f"std::vector<bool> {bool_vector_name}(self.size());")
                 content.append("for (const auto& i : c10::irange(self.size())) {")
                 content.append(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #112348
* __->__ #112349

By checking that lists sizes are the same before computing forward gradients.

Before the change
```cpp
::std::vector<at::Tensor> _foreach_add_List(c10::DispatchKeySet ks, at::TensorList self, at::TensorList other, const at::Scalar & alpha) {
  auto self_ = unpack(self, "self", 0);
  auto other_ = unpack(other, "other", 1);
  [[maybe_unused]] auto _any_requires_grad = compute_requires_grad( self, other );

  std::vector<bool> _any_has_forward_grad_result(self.size());
  for (const auto& i : c10::irange(self.size())) {
    _any_has_forward_grad_result[i] = isFwGradDefined(self[i]) || isFwGradDefined(other[i]);
  }
  ...
```
after the change:
```cpp
::std::vector<at::Tensor> _foreach_add_List(c10::DispatchKeySet ks, at::TensorList self, at::TensorList other, const at::Scalar & alpha) {
    auto self_ = unpack(self, "self", 0);
    auto other_ = unpack(other, "other", 1);
    [[maybe_unused]] auto _any_requires_grad = compute_requires_grad( self, other );

    TORCH_CHECK(
        self.size() == other.size(),
          "Tensor lists must have the same number of tensors, got ",
        self.size(),
          " and ",
        other.size());
    std::vector<bool> _any_has_forward_grad_result(self.size());
    for (const auto& i : c10::irange(self.size())) {
      _any_has_forward_grad_result[i] = isFwGradDefined(self[i]) || isFwGradDefined(other[i]);
    }

```
Add regression test

Fixes https://github.com/pytorch/pytorch/issues/112305