### PR TITLE
[1/N] Fix clang-tidy warnings in torch/csrc/profiler

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -167,7 +167,8 @@ struct MetadataBase {
 
   void addMetadata(const std::string& key, const std::string& value) {
     if (kineto_activity_ && !value.empty() && value != "\"\"") {
-      torch::profiler::impl::kineto::addMetadata(kineto_activity_, key, value);
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+      torch::profiler::impl::kineto::addMetadata(const_cast<torch::profiler::impl::kineto::activity_t*>(kineto_activity_), key, value);
     }
   }
 

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -167,8 +167,12 @@ struct MetadataBase {
 
   void addMetadata(const std::string& key, const std::string& value) {
     if (kineto_activity_ && !value.empty() && value != "\"\"") {
-      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-      torch::profiler::impl::kineto::addMetadata(const_cast<torch::profiler::impl::kineto::activity_t*>(kineto_activity_), key, value);
+      torch::profiler::impl::kineto::addMetadata(
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+          const_cast<torch::profiler::impl::kineto::activity_t*>(
+              kineto_activity_),
+          key,
+          value);
     }
   }
 

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -54,6 +54,7 @@ TensorMetadata::TensorMetadata(
     const RawTensorMetadata& r,
     std::vector<int64_t> sizes,
     std::vector<int64_t> strides)
+    // NOLINTNEXTLINE(cppcoreguidelines-slicing)
     : RawTensorMetadataBase(r),
       weak_self_{r.weak_self_.value_or(WeakTensor(at::Tensor()))},
       device_{r.device_type_, r.device_index_},
@@ -624,7 +625,9 @@ c10::DeviceType Result::deviceType() const {
 ThreadLocalSubqueue::ThreadLocalSubqueue(
     const uint64_t tid,
     ProfilerConfig config)
-    : tid_{tid}, config_{std::move(config)}, kineto_info_{kineto::kineto_ids()} {
+    : tid_{tid},
+      config_{std::move(config)},
+      kineto_info_{kineto::kineto_ids()} {
   torch::profiler::impl::kineto::recordThreadInfo();
   if (!config_.experimental_config.performance_events.empty()) {
     perf_profiler_ =
@@ -636,7 +639,9 @@ ThreadLocalSubqueue::ThreadLocalSubqueue(
 RecordQueue::RecordQueue(
     ProfilerConfig config,
     std::set<ActivityType> activities)
-    : id_(++queue_id_), config_{std::move(config)}, activities_{std::move(activities)} {
+    : id_(++queue_id_),
+      config_{std::move(config)},
+      activities_{std::move(activities)} {
   if (tracePython()) {
     python_tracer_ = python_tracer::PythonTracerBase::make(this);
   }
@@ -805,7 +810,8 @@ void passEventsToKineto(
     uint64_t end_time_us,
     const ProfilerConfig& config) {
   using namespace torch::profiler::impl::kineto;
-  TraceWrapper cpu_trace(start_time_us, "PyTorch Profiler");
+  TraceWrapper cpu_trace(
+      static_cast<int64_t>(start_time_us), "PyTorch Profiler");
 
   // Generate Kineto events for each event recorded by the PyTorch profiler.
   for (const auto i : c10::irange(results.size())) {
@@ -839,7 +845,7 @@ void passEventsToKineto(
   }
 
   // Kineto adds the events that it collected.
-  cpu_trace.transferCpuTrace(end_time_us);
+  cpu_trace.transferCpuTrace(static_cast<int64_t>(end_time_us));
 }
 
 #ifdef USE_KINETO
@@ -1028,7 +1034,7 @@ class TransferEvents {
 
   void setParents() {
     // First pass: Collect start events and set parent to linked event.
-    ska::flat_hash_map<int, std::shared_ptr<Result>> flow_map;
+    ska::flat_hash_map<uint32_t, std::shared_ptr<Result>> flow_map;
     for (auto& e : results_.get()) {
       TORCH_INTERNAL_ASSERT(e != nullptr);
       e->visit(c10::overloaded(
@@ -1402,7 +1408,9 @@ RecordQueue::getRecords(
 
   if (python_tracer_) {
     for (const auto& i : python_tracer_->getEvents(
-             converter, python_enters, end_time_us * 1000)) {
+             converter,
+             python_enters,
+             static_cast<c10::time_t>(end_time_us * 1000))) {
       out.push_back(i);
     }
     python_tracer_.reset();

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -634,9 +634,9 @@ ThreadLocalSubqueue::ThreadLocalSubqueue(
 }
 
 RecordQueue::RecordQueue(
-    const ProfilerConfig& config,
+    ProfilerConfig config,
     std::set<ActivityType> activities)
-    : id_(++queue_id_), config_{config}, activities_{std::move(activities)} {
+    : id_(++queue_id_), config_{std::move(config)}, activities_{std::move(activities)} {
   if (tracePython()) {
     python_tracer_ = python_tracer::PythonTracerBase::make(this);
   }
@@ -810,7 +810,7 @@ void passEventsToKineto(
   // Generate Kineto events for each event recorded by the PyTorch profiler.
   for (const auto i : c10::irange(results.size())) {
     const auto& e = results[i];
-    const auto* activity = cpu_trace.addCPUActivity(
+    auto* activity = cpu_trace.addCPUActivity(
         e->name(),
         e->kinetoType(),
         e->kineto_info_,

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -623,8 +623,8 @@ c10::DeviceType Result::deviceType() const {
 
 ThreadLocalSubqueue::ThreadLocalSubqueue(
     const uint64_t tid,
-    const ProfilerConfig& config)
-    : tid_{tid}, config_{config}, kineto_info_{kineto::kineto_ids()} {
+    ProfilerConfig config)
+    : tid_{tid}, config_{std::move(config)}, kineto_info_{kineto::kineto_ids()} {
   torch::profiler::impl::kineto::recordThreadInfo();
   if (!config_.experimental_config.performance_events.empty()) {
     perf_profiler_ =

--- a/torch/csrc/profiler/collection.h
+++ b/torch/csrc/profiler/collection.h
@@ -303,10 +303,10 @@ struct ExtraFields<EventType::PyCall> : public PyExtraFieldsBase {
       size_t python_tid,
       PyFrameState caller,
       args_t args)
-      : PyExtraFieldsBase(end_time_ns, python_tid, caller),
-        callsite_{args.frame_state_},
-        module_{args.module_info_},
-        optimizer_{args.optimizer_info_} {}
+      : PyExtraFieldsBase(end_time_ns, python_tid, std::move(caller)),
+        callsite_{std::move(args.frame_state_)},
+        module_{std::move(args.module_info_)},
+        optimizer_{std::move(args.optimizer_info_)} {}
 
   PyFrameState callsite_;
   c10::optional<NNModuleInfo> module_;
@@ -322,7 +322,7 @@ struct ExtraFields<EventType::PyCCall> : public PyExtraFieldsBase {
       size_t python_tid,
       PyFrameState caller,
       args_t args)
-      : PyExtraFieldsBase(end_time_ns, python_tid, caller),
+      : PyExtraFieldsBase(end_time_ns, python_tid, std::move(caller)),
         function_name_{std::move(args)} {}
 
   at::StringView function_name_;
@@ -502,7 +502,7 @@ using perf_profiler_t = torch::profiler::impl::linux_perf::PerfProfiler;
 
 class TORCH_API ThreadLocalSubqueue {
  public:
-  ThreadLocalSubqueue(const uint64_t tid, const ProfilerConfig& config);
+  ThreadLocalSubqueue(const uint64_t tid, ProfilerConfig config);
 
   std::unique_ptr<KinetoObserverContext> begin_op(const at::RecordFunction& fn);
 

--- a/torch/csrc/profiler/collection.h
+++ b/torch/csrc/profiler/collection.h
@@ -621,7 +621,7 @@ class TORCH_API ThreadLocalSubqueue {
 
 class TORCH_API RecordQueue {
  public:
-  RecordQueue(const ProfilerConfig& config, std::set<ActivityType> activities);
+  RecordQueue(ProfilerConfig config, std::set<ActivityType> activities);
 
   bool tracePython() const;
   ThreadLocalSubqueue* getSubqueue();

--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -66,14 +66,11 @@ const DeviceAndResource kineto_ids() {
 }
 
 void addMetadata(
-    const activity_t* activity,
+    activity_t* activity,
     const std::string& key,
     const std::string& value) {
 #ifdef USE_KINETO
-  // ActivityTraceInterface returns const pointers, so we have to cast away the
-  // constness to add metadata.
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-  const_cast<activity_t*>(activity)->addMetadata(key, value);
+  activity->addMetadata(key, value);
 #endif // USE_KINETO
 }
 

--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -203,6 +203,7 @@ class ExperimentalConfigWrapper {
   }
 
  private:
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const torch::profiler::impl::ExperimentalConfig& config_;
 };
 } // namespace

--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -101,8 +101,7 @@ activity_t* TraceWrapper::addCPUActivity(
   auto& act = libkineto::CpuTraceBuffer::toRef(cpu_trace_->activities.back());
   act.device = device_and_resource.device;
   act.resource = device_and_resource.resource;
-  // NOLINTNEXTLINE
-  act.id = correlation_id;
+  act.id = static_cast<int32_t>(correlation_id);
   act.startTime = start_time;
   if (type != libkineto::ActivityType::CPU_INSTANT_EVENT) {
     act.endTime = end_time;

--- a/torch/csrc/profiler/kineto_shim.h
+++ b/torch/csrc/profiler/kineto_shim.h
@@ -61,7 +61,7 @@ struct activity_t;
 #endif // USE_KINETO
 
 void addMetadata(
-    const activity_t* activity,
+    activity_t* activity,
     const std::string& key,
     const std::string& value);
 

--- a/torch/csrc/profiler/python/init.cpp
+++ b/torch/csrc/profiler/python/init.cpp
@@ -159,6 +159,7 @@ int RecordFunctionFast_init(
     PyObject* args,
     PyObject* kwargs) {
   auto self = (RecordFunctionFast*)selfGeneric;
+  // NOLINTNEXTLINE(*-c-arrays*)
   constexpr const char* kwlist[] = {"name", nullptr};
   PyObject* name = nullptr;
   if (!PyArg_ParseTupleAndKeywords(
@@ -307,7 +308,7 @@ void initPythonBindings(PyObject* module) {
                 p.enable_cuda_sync_events,
                 p.performance_events);
           },
-          [](py::tuple t) { // __setstate__
+          [](const py::tuple& t) { // __setstate__
             if (t.size() >= 4) {
               throw std::runtime_error("Expected atleast 4 values in state");
             }
@@ -528,7 +529,7 @@ void initPythonBindings(PyObject* module) {
       py::arg("python") = true,
       py::arg("script") = true,
       py::arg("cpp") = true);
-  m.def("symbolize_tracebacks", [](py::list tbs) {
+  m.def("symbolize_tracebacks", [](const py::list& tbs) {
     std::vector<CapturedTraceback*> tb_ptrs;
     tb_ptrs.reserve(tbs.size());
     for (py::handle tb : tbs) {
@@ -538,6 +539,7 @@ void initPythonBindings(PyObject* module) {
   });
   installCapturedTracebackPython();
 
+  // NOLINTNEXTLINE(*-c-arrays*)
   static PyMethodDef RecordFunctionFast_methods[] = {
       {"__enter__", RecordFunctionFast_enter, METH_NOARGS, nullptr},
       {"__exit__", RecordFunctionFast_exit, METH_VARARGS, nullptr},

--- a/torch/csrc/profiler/python/init.cpp
+++ b/torch/csrc/profiler/python/init.cpp
@@ -83,7 +83,6 @@ namespace detail {
 template <>
 struct type_caster<std::shared_ptr<torch::CapturedTraceback>> {
  public:
-  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   PYBIND11_TYPE_CASTER(
       std::shared_ptr<torch::CapturedTraceback>,
       _("torch._C._profiler.CapturedTraceback"));
@@ -404,7 +403,9 @@ void initPythonBindings(PyObject* module) {
       .def_readonly("sequence_number", &torch_op_t::sequence_number_)
       .def_readonly("allow_tf32_cublas", &torch_op_t::allow_tf32_cublas_);
 
+  // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<ExtraFields<EventType::Backend>>(m, "_ExtraFields_Backend");
+  // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<ExtraFields<EventType::Vulkan>>(m, "_ExtraFields_Vulkan");
 
   using allocation_t = ExtraFields<EventType::Allocation>;
@@ -464,9 +465,11 @@ void initPythonBindings(PyObject* module) {
   py::class_<ExtraFields<EventType::PyCCall>>(m, "_ExtraFields_PyCCall")
       .def_readonly("caller", &ExtraFields<EventType::PyCall>::caller_);
 
+  // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<ExtraFields<EventType::OutOfMemory>>(
       m, "_ExtraFields_OutOfMemory");
 
+  // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<ExtraFields<EventType::Kineto>>(m, "_ExtraFields_Kineto");
 
   py::class_<Result, std::shared_ptr<Result>>(m, "_ProfilerEvent")

--- a/torch/csrc/profiler/stubs/cuda.cpp
+++ b/torch/csrc/profiler/stubs/cuda.cpp
@@ -42,8 +42,7 @@ struct CUDAMethods : public ProfilerStubs {
     if (device) {
       TORCH_CUDA_CHECK(c10::cuda::GetDevice(device));
     }
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    CUevent_st* cuda_event_ptr;
+    CUevent_st* cuda_event_ptr{nullptr};
     TORCH_CUDA_CHECK(cudaEventCreate(&cuda_event_ptr));
     *event = std::shared_ptr<CUevent_st>(cuda_event_ptr, [](CUevent_st* ptr) {
       TORCH_CUDA_CHECK(cudaEventDestroy(ptr));
@@ -62,20 +61,17 @@ struct CUDAMethods : public ProfilerStubs {
     auto event2 = (const ProfilerEventStub*)(event2_);
     TORCH_CUDA_CHECK(cudaEventSynchronize(event->get()));
     TORCH_CUDA_CHECK(cudaEventSynchronize(event2->get()));
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    float ms;
+    float ms = 0;
     TORCH_CUDA_CHECK(cudaEventElapsedTime(&ms, event->get(), event2->get()));
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-avoid-magic-numbers,cppcoreguidelines-narrowing-conversions)
     return ms * 1000.0;
   }
 
   void mark(const char* name) const override {
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     ::nvtxMark(name);
   }
 
   void rangePush(const char* name) const override {
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     ::nvtxRangePushA(name);
   }
 

--- a/torch/csrc/profiler/stubs/itt.cpp
+++ b/torch/csrc/profiler/stubs/itt.cpp
@@ -20,12 +20,10 @@ struct ITTMethods : public ProfilerStubs {
   }
 
   void mark(const char* name) const override {
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     torch::profiler::itt_mark(name);
   }
 
   void rangePush(const char* name) const override {
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     torch::profiler::itt_range_push(name);
   }
 


### PR DESCRIPTION
This PR fixes some clang-tidy warnings in torch/csrc/profiler

cc @Skylion007 @albanD @ezyang 