### PR TITLE
[Docs] fix typo in example of `torch.linalg.solve_triangular`

### DIFF
--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -2242,7 +2242,7 @@ Keyword args:
 Examples::
 
     >>> A = torch.randn(3, 3).triu_()
-    >>> b = torch.randn(3, 4)
+    >>> B = torch.randn(3, 4)
     >>> X = torch.linalg.solve_triangular(A, B, upper=True)
     >>> torch.allclose(A @ X, B)
     True


### PR DESCRIPTION
Fixes #112359 
