### PR TITLE
[2D] Bind _fsdp_extension to FSDP instances

### DIFF
--- a/test/distributed/fsdp/test_fsdp_flatten_params.py
+++ b/test/distributed/fsdp/test_fsdp_flatten_params.py
@@ -47,6 +47,7 @@ class TestFlattenParams(FSDPTest):
             "keep_low_precision_grads": False,
             "process_group": self.process_group,
             "use_orig_params": False,
+            "fsdp_extension": None,
         }
 
     def _get_transformer(self, seed=0):

--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -10,7 +10,7 @@ from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.distributed.fake_pg import FakeStore
 from torch.testing import FileCheck
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-from torch.distributed._tensor import DeviceMesh
+from torch.distributed._tensor import DeviceMesh, init_device_mesh
 from torch.testing._internal.common_utils import (
     TestCase,
     run_tests,
@@ -190,12 +190,13 @@ class TestFakePG(TestCase):
         device_mesh = DeviceMesh(
             "cuda", torch.arange(0, world_size).view(-1, tp_size)
         )
+        device_mesh = init_device_mesh("cuda", (world_size // tp_size, tp_size), mesh_dim_names=["dp", "tp"])
 
         for parallel_style in [SequenceParallel(), PairwiseParallel()]:
 
-            my_module = parallelize_module(MLPModule(device="cuda"), device_mesh, parallel_style, tp_mesh_dim=1)
+            my_module = parallelize_module(MLPModule(device="cuda"), device_mesh["tp"], parallel_style)
 
-            sharded_module = FSDP(my_module, use_orig_params=True)
+            sharded_module = FSDP(my_module, use_orig_params=True, device_mesh=device_mesh["dp"])
             optim = torch.optim.Adam(sharded_module.parameters(), lr=0.0001)
 
             for i in range(10):

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -1,7 +1,6 @@
 """
 This file includes private common utilities for FSDP.
 """
-
 import logging
 import traceback
 import warnings
@@ -32,6 +31,7 @@ from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     _CHECKPOINT_PREFIX,
 )
+from torch.distributed.fsdp._fsdp_extensions import FSDPExtensions
 from torch.distributed.utils import _apply_to_tensors
 from torch.utils._mode_utils import no_dispatch
 
@@ -142,7 +142,7 @@ class _FSDPState(_State):
         # Save these static lists to avoid the repeated tree traversals
         self._all_fsdp_states: List[_FSDPState] = []
         self._all_handles: List[flat_param_file.FlatParamHandle] = []
-        self._enable_extension: bool = False
+        self._fsdp_extension: Optional[FSDPExtensions] = None
 
 
 def _get_module_fsdp_state(module: nn.Module) -> Optional[_FSDPState]:

--- a/torch/distributed/fsdp/_fsdp_extensions.py
+++ b/torch/distributed/fsdp/_fsdp_extensions.py
@@ -95,20 +95,22 @@ def _set_fsdp_extensions(flattener: FSDPExtensions) -> None:
 
 def _ext_pre_flatten_transform(
     tensor: torch.Tensor,
+    fsdp_extension: Optional[FSDPExtensions] = None,
 ) -> Tuple[torch.Tensor, Optional[Any]]:
-    if _extensions is not None:
-        new_tensor, extension = _extensions.pre_flatten_transform(tensor)
-        if extension is not None:
-            return new_tensor, extension
+    if fsdp_extension is not None:
+        new_tensor, param_extension = fsdp_extension.pre_flatten_transform(tensor)
+        if param_extension is not None:
+            return new_tensor, param_extension
     return tensor, None
 
 
 def _ext_post_unflatten_transform(
     tensor: torch.Tensor,
     param_extension: Any,
+    fsdp_extension: Optional[FSDPExtensions] = None,
 ) -> torch.Tensor:
-    if _extensions is not None and param_extension is not None:
-        return _extensions.post_unflatten_transform(tensor, param_extension)
+    if fsdp_extension is not None and param_extension is not None:
+        return fsdp_extension.post_unflatten_transform(tensor, param_extension)
     return tensor
 
 
@@ -118,10 +120,11 @@ def _ext_chunk_tensor(
     world_size: int,
     num_devices_per_node: int,
     pg: dist.ProcessGroup,
+    fsdp_extension: Optional[FSDPExtensions] = None,
 ) -> torch.Tensor:
     chunk_tensor_fn = (
-        _extensions.chunk_tensor
-        if _extensions is not None
+        fsdp_extension.chunk_tensor
+        if fsdp_extension is not None
         else _create_chunk_sharded_tensor
     )
     return chunk_tensor_fn(
@@ -137,9 +140,12 @@ def _ext_chunk_dtensor(
     tensor: torch.Tensor,
     rank: int,
     device_mesh: DeviceMesh,
+    fsdp_extension: Optional[FSDPExtensions] = None,
 ) -> torch.Tensor:
     chunk_dtensor_fn = (
-        _extensions.chunk_dtensor if _extensions is not None else _create_chunk_dtensor
+        fsdp_extension.chunk_dtensor
+        if fsdp_extension is not None
+        else _create_chunk_dtensor
     )
     return chunk_dtensor_fn(
         tensor,
@@ -150,9 +156,10 @@ def _ext_chunk_dtensor(
 
 def _ext_pre_load_state_dict_transform(
     tensor: torch.Tensor,
+    fsdp_extension: Optional[FSDPExtensions] = None,
 ) -> Tuple[torch.Tensor, List[Shard]]:
-    if _extensions is not None:
-        return _extensions.pre_load_state_dict_transform(tensor)
+    if fsdp_extension is not None:
+        return fsdp_extension.pre_load_state_dict_transform(tensor)
 
     assert type(tensor) is ShardedTensor
     shards = tensor.local_shards()
@@ -162,10 +169,11 @@ def _ext_pre_load_state_dict_transform(
 def _ext_all_gather_dtensor(
     tensor: DTensor,
     parent_mesh: Optional[DeviceMesh],
+    fsdp_extension: Optional[FSDPExtensions] = None,
 ) -> torch.Tensor:
     all_gather_dtensor_fn = (
-        _extensions.all_gather_dtensor
-        if _extensions is not None
+        fsdp_extension.all_gather_dtensor
+        if fsdp_extension is not None
         else _all_gather_dtensor
     )
     return all_gather_dtensor_fn(tensor, parent_mesh)

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -299,7 +299,10 @@ def _unflatten_communicated_optim_state(
                 if getattr(osd_config, "_use_dtensor", False):
                     assert fsdp_state._device_mesh is not None
                     optim_state = _ext_chunk_dtensor(
-                        optim_state, fsdp_state.rank, fsdp_state._device_mesh
+                        optim_state,
+                        fsdp_state.rank,
+                        fsdp_state._device_mesh,
+                        fsdp_state._fsdp_extension,
                     )
                 else:
                     assert fsdp_state.process_group is not None
@@ -309,6 +312,7 @@ def _unflatten_communicated_optim_state(
                         fsdp_state.world_size,
                         fsdp_state._device_handle.device_count(),
                         fsdp_state.process_group,
+                        fsdp_state._fsdp_extension,
                     )
             unflat_state_param[state_name] = optim_state
 
@@ -1455,7 +1459,10 @@ def _unflatten_orig_param_states(
             if getattr(osd_config, "_use_dtensor", False):
                 assert fsdp_state._device_mesh is not None
                 value = _ext_chunk_dtensor(
-                    value, fsdp_state.rank, fsdp_state._device_mesh
+                    value,
+                    fsdp_state.rank,
+                    fsdp_state._device_mesh,
+                    fsdp_state._fsdp_extension,
                 )
             else:
                 assert fsdp_state.process_group is not None
@@ -1465,6 +1472,7 @@ def _unflatten_orig_param_states(
                     fsdp_state.world_size,
                     fsdp_state._device_handle.device_count(),
                     fsdp_state.process_group,
+                    fsdp_state._fsdp_extension,
                 )
         elif not cpu_offload:
             with SimpleProfiler.profile("clone"):

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -257,7 +257,7 @@ def _share_state_and_init_handle_attrs(
         # Currently, it is needed since root_state of composable APIs doesn't have DeviceMesh passed in yet.
         if hasattr(root_state, "_device_mesh"):
             fsdp_state._device_mesh = root_state._device_mesh
-            fsdp_state._enable_extension = root_state._enable_extension
+            fsdp_state._fsdp_extension = root_state._fsdp_extension
     for attr_name, attr_values in attr_name_to_values.items():
         if len(attr_values) != 1:
             raise ValueError(


### PR DESCRIPTION
Currently, when we have 2D composition, a global variable `_extensions` controls the 2D deviation we need to take in state_dict calls (See https://github.com/pytorch/pytorch/blob/release/2.1/torch/distributed/fsdp/_fsdp_extensions.py#L66-L68). This is problematic when we have both a 2D model and a plain FSDP model in the same dist environment, as the `_extensions` will be mistakenly turned on for the plain FSDP model, resulting in state_dict error (`RuntimeError: No parent device_mesh is found for FSDP device_mesh.`).

This PR binds `_fsdp_extension` to the FSDP instances to make sure that state_dict calls would not get interfered with each other when mixing both 2D and 1D parallelism. 