### PR TITLE
Correct output shape of meta registration for qlinear_pointwise

### DIFF
--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -979,6 +979,36 @@ class TestPatternMatcher(TestPatternMatcherBase):
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN
     @skipIfRocm
+    def test_qlinear_add_cpu(self):
+        r"""
+        This testcase will quantize a Linear->Add pattern.
+        """
+
+        class M(torch.nn.Module):
+            def __init__(self, use_bias):
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 5, use_bias)
+
+            def forward(self, x1, x2):
+                return torch.add(self.linear(x1), x2)
+
+        bias_list = [True, False]
+        for bias in bias_list:
+            mod = M(bias).eval()
+            x1 = torch.randn((2, 4))
+            x2 = torch.randn((2, 5))
+
+            self._test_common(
+                mod,
+                (x1, x2),
+                4,
+                17,
+                check_quantization=True,
+            )
+
+    @skipIfNoDynamoSupport
+    @skipIfNoONEDNN
+    @skipIfRocm
     def test_qlinear_dequant_promotion_cpu(self):
         r"""
         This testcase test if dequant node before linear is promoted correctly:

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -979,9 +979,9 @@ class TestPatternMatcher(TestPatternMatcherBase):
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN
     @skipIfRocm
-    def test_qlinear_add_cpu(self):
+    def test_qlinear_mul_cpu(self):
         r"""
-        This testcase will quantize a Linear->Add pattern.
+        This testcase will quantize a Linear->Mul pattern.
         """
 
         class M(torch.nn.Module):
@@ -990,7 +990,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
                 self.linear = torch.nn.Linear(4, 5, use_bias)
 
             def forward(self, x1, x2):
-                return torch.add(self.linear(x1), x2)
+                return torch.mul(self.linear(x1), x2)
 
         bias_list = [True, False]
         for bias in bias_list:
@@ -1001,8 +1001,8 @@ class TestPatternMatcher(TestPatternMatcherBase):
             self._test_common(
                 mod,
                 (x1, x2),
-                4,
-                17,
+                2,
+                8,
                 check_quantization=True,
             )
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2161,7 +2161,8 @@ if torch._C._has_mkldnn:
         post_op_algorithm,
     ):
         output_shape = list(x.shape)
-        output_shape[-1] = w.shape[0]
+        # The weight has been transposed during the qlinear weight prepack process.
+        output_shape[-1] = w.shape[1]
         assert output_dtype in [torch.float32, torch.bfloat16]
         out = x.new_empty(output_shape, dtype=output_dtype)
         return out


### PR DESCRIPTION
Corrected output shape of meta registration for qlinear_pointwise. 
Because the weight of qlinear_pointwise has been transposed during the qLinear weight prepack process, the shape of the weight of qlinear_pointwise is (in_features, out_features).


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler