### PR TITLE
[pytree] Avoid constructing intermediate lists in tree_{flatten,leaves}

### DIFF
--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -297,43 +297,51 @@ class LeafSpec(TreeSpec):
         return "*"
 
 
+def _tree_flatten_helper(pytree: PyTree, out_leaves: List[Any]) -> TreeSpec:
+    if _is_leaf(pytree):
+        out_leaves.append(pytree)
+        return LeafSpec()
+
+    node_type = _get_node_type(pytree)
+    flatten_fn = SUPPORTED_NODES[node_type].flatten_fn
+    child_pytrees, context = flatten_fn(pytree)
+
+    # Recursively flatten the children
+    children_specs = [
+        _tree_flatten_helper(child, out_leaves) for child in child_pytrees
+    ]
+
+    return TreeSpec(node_type, context, children_specs)
+
+
 def tree_flatten(pytree: PyTree) -> Tuple[List[Any], TreeSpec]:
     """Flattens a pytree into a list of values and a TreeSpec that can be used
     to reconstruct the pytree.
     """
+    leaves: List[Any] = []
+    spec = _tree_flatten_helper(pytree, leaves)
+    return leaves, spec
+
+
+def _tree_leaves_helper(pytree: PyTree, out_leaves: List[Any]) -> None:
     if _is_leaf(pytree):
-        return [pytree], LeafSpec()
+        out_leaves.append(pytree)
+        return
 
     node_type = _get_node_type(pytree)
     flatten_fn = SUPPORTED_NODES[node_type].flatten_fn
-    child_pytrees, context = flatten_fn(pytree)
+    child_pytrees, _ = flatten_fn(pytree)
 
     # Recursively flatten the children
-    result: List[Any] = []
-    children_specs: List[TreeSpec] = []
     for child in child_pytrees:
-        flat, child_spec = tree_flatten(child)
-        result += flat
-        children_specs.append(child_spec)
-
-    return result, TreeSpec(node_type, context, children_specs)
+        _tree_leaves_helper(child, out_leaves)
 
 
 def tree_leaves(pytree: PyTree) -> List[Any]:
     """Get a list of leaves of a pytree."""
-    if _is_leaf(pytree):
-        return [pytree]
-
-    node_type = _get_node_type(pytree)
-    flatten_fn = SUPPORTED_NODES[node_type].flatten_fn
-    child_pytrees, context = flatten_fn(pytree)
-
-    # Recursively flatten the children
-    result: List[Any] = []
-    for child in child_pytrees:
-        result += tree_leaves(child)
-
-    return result
+    leaves: List[Any] = []
+    _tree_leaves_helper(pytree, leaves)
+    return leaves
 
 
 def tree_structure(pytree: PyTree) -> TreeSpec:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #112418
* #112417
* #112394
* #112393
* #112392
* __->__ #112391

Instead of concatenating lists of child nodes, this appends the leaf nodes
directly onto the list of leaves to be returned which gives a small perf
improvement.

cc @zou3519 @XuehaiPan @jon-chuang 