### PR TITLE
[pytree] Remove LeafSpec construction cost in tree_flatten

### DIFF
--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -297,10 +297,15 @@ class LeafSpec(TreeSpec):
         return "*"
 
 
+# All leaves are equivalent, so represent with a single object to save on
+# object construction time
+_LEAF_SPEC = LeafSpec()
+
+
 def _tree_flatten_helper(pytree: PyTree, out_leaves: List[Any]) -> TreeSpec:
     if _is_leaf(pytree):
         out_leaves.append(pytree)
-        return LeafSpec()
+        return _LEAF_SPEC
 
     node_type = _get_node_type(pytree)
     flatten_fn = SUPPORTED_NODES[node_type].flatten_fn


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #112418
* #112417
* #112394
* #112393
* __->__ #112392
* #112391

On my machine, `pytree.LeafSpec()` takes ~600ns but since every leaf spec is the
same, we can just use a global constant.

cc @zou3519 @XuehaiPan @jon-chuang 