### PR TITLE
[pytree] Add arg_tree_leaves to optimize flattening function arguments

### DIFF
--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -729,3 +729,16 @@ def pytree_to_str(spec: TreeSpec) -> str:
 def str_to_pytree(json: str) -> TreeSpec:
     warnings.warn("str_to_pytree is deprecated. Please use treespec_loads")
     return treespec_loads(json)
+
+
+def arg_tree_leaves(*args: PyTree, **kwargs: PyTree) -> List[Any]:
+    """Get a flat list of arguments to this function
+
+    A slightly faster version of tree_leaves((args, kwargs))
+    """
+    leaves: List[Any] = []
+    for a in args:
+        _tree_leaves_helper(a, leaves)
+    for a in kwargs:
+        _tree_leaves_helper(a, leaves)
+    return leaves

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -739,6 +739,6 @@ def arg_tree_leaves(*args: PyTree, **kwargs: PyTree) -> List[Any]:
     leaves: List[Any] = []
     for a in args:
         _tree_leaves_helper(a, leaves)
-    for a in kwargs:
+    for a in kwargs.values():
         _tree_leaves_helper(a, leaves)
     return leaves


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #112493
* #112418
* #112417
* #112394
* __->__ #112393
* #112392
* #112391

We commonly do some variation of `tree_leaves((args, kwargs))`. This adds a new
function `arg_tree_leaves(*args, **kwargs)` which takes advantage of the known
structure of `args` and `kwargs` to skip their `flatten_fn`.

I see ~1 us improvement per call for args + kwargs, or a 0.5 us improvement
when passing just one of `args` or `kwargs`. For shallow structures, this can be
proportionally quite significant. For example, the empty_strided call I've been
using as a benchmark:
```
args = ((100, 100), (100, 1))
kwargs = dict(device="cuda")
```
Sees a 30% speedup from this.

cc @zou3519