### PR TITLE
[dynamo] Support custom dict constructor with kwargs

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -50,6 +50,10 @@ e = torch.nn.Linear(10, 10)
 flag = True
 
 
+class CustomDictSubclass(collections.OrderedDict):
+    pass
+
+
 clip01 = functools.partial(torch.clip, min=0.0, max=1.0)
 
 
@@ -443,6 +447,11 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
     @make_test
     def test_ordered_dict_kwargs(x):
         z = collections.OrderedDict(sample=torch.ones(10))
+        return z
+
+    @make_test
+    def test_custom_dict_kwargs(x):
+        z = CustomDictSubclass(sample=torch.ones(10))
         return z
 
     @make_test

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -623,11 +623,14 @@ class CustomizedDictVariable(ConstDictVariable):
             bound = inspect.signature(user_cls).bind(*args, **kwargs)
             bound.apply_defaults()
             raw_items = bound.arguments
+        elif not args:
+            # CustomDict(a=1, b=2) in the general (non-dataclass) case.
+            raw_items = collections.OrderedDict(kwargs)
         elif len(args) == 1 and isinstance(args[0], ConstDictVariable) and not kwargs:
             # CustomDict({'a': 1, 'b': 2})
             raw_items = args[0].items
         else:
-            unimplemented("custome dict init with args/kwargs unimplemented")
+            unimplemented("custom dict init with args/kwargs unimplemented")
 
         items = collections.OrderedDict()
         for key in raw_items.keys():


### PR DESCRIPTION
Summary:

As of https://github.com/pytorch/pytorch/pull/103192, dynamo supports code that creates OrderedDict instances using kwargs for the key-value pairs rather than passing a dict literal.

But custom dicts (for example subclasses of OrderedDict) follow a different codepath so that we can check for conditions such as a custom `__init__` that need to force a graph break.

This commit allows kwargs for custom dict constructors - if the args are empty and the class is not also a dataclass (which is the case that, for example, a
`transformers.modeling_outputs.ModelOutput` instance will wind up hitting) then treat the kwargs as the key-value pairs.

NOTE: For this to behave 100% correctly, we are relying on the fact that python dicts behave like ordered dicts so that they preserve the kwargs' ordering. Technically it is not guaranteed that future versions of Python will respect this; if that behavior changes we would need to ensure that dynamo uses OrderedDict for kwargs all the way down in order to handle special cases like OrderedDict where the kwargs' ordering does matter.

Test Plan:

```
pytest test/dynamo/test_functions.py
```

I also verified that the new test fails without the changes to `dicts.py`.

Reviewers: yanboliang

Fixes #102878


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng