### PR TITLE
[aotinductor] Add example_value metadata to nodes

### DIFF
--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -947,6 +947,10 @@ def aot_compile(
     # We want to export to Torch IR here to utilize the pre_grad passes in
     # inductor, which run on Torch IR.
     gm = _export_to_torch_ir(f, args, kwargs, constraints)
+
+    from torch._export.passes.fake_tensor_prop import FakeTensorProp
+    FakeTensorProp(gm).run()
+
     flat_example_inputs = pytree.arg_tree_leaves(*args, **kwargs or {})
 
     with torch.no_grad():

--- a/torch/_export/passes/fake_tensor_prop.py
+++ b/torch/_export/passes/fake_tensor_prop.py
@@ -1,0 +1,18 @@
+from torch.fx.interpreter import Interpreter
+
+
+class FakeTensorProp(Interpreter):
+    def run(self):
+        inp = tuple(
+            node.meta["val"]
+            for node in self.module.graph.nodes
+            if node.op == "placeholder"
+        )
+        super().run(*inp)
+
+    def run_node(self, node):
+        res = super().run_node(node)
+        # split_cat fx passes expect "example_value" metadata on the nodes
+        node.meta["example_value"] = res
+        node.meta["val"] = res
+        return res


### PR DESCRIPTION
split_cat fx passes expect the `example_value` metadata on every node. However, the graph module from _export_torch_ir does not contain this metadata, causing the split_cat fx passes to not run. So, I added a pass to add this metadata to every node in the graph.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan @suo @ydwu4