### PR TITLE
[dynamo, test] remove #ops comparison to fx.symbolic_trace from dynamo standard_test

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -6563,7 +6563,7 @@ def fn():
             y = b.shape[0]
             return -x * -y * a * b
 
-        torch._dynamo.testing.standard_test(self, int_neg, 2)
+        torch._dynamo.testing.standard_test(self, int_neg, 2, expected_ops=2)
 
     def test_hash_getitem_slice(self):
         s = GetItemSource(LocalSource("foo"), slice(None, -1, None))

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -6563,7 +6563,7 @@ def fn():
             y = b.shape[0]
             return -x * -y * a * b
 
-        torch._dynamo.testing.standard_test(self, int_neg, 2, expected_ops=2)
+        torch._dynamo.testing.standard_test(self, int_neg, 2)
 
     def test_hash_getitem_slice(self):
         s = GetItemSource(LocalSource("foo"), slice(None, -1, None))

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -249,16 +249,6 @@ def standard_test(self, fn, nargs, expected_ops=None, expected_ops_dynamic=None)
         expected_ops = expected_ops_dynamic
 
     actual = CompileCounter()
-    if expected_ops is None:
-        expected = CompileCounter()
-        try:
-            gm = torch.fx.symbolic_trace(fn)
-            expected(gm)  # type: ignore[call-arg] # FIXME: https://github.com/pytorch/pytorch/issues/112230
-            print("\nfx.symbolic_trace graph:")
-            gm.graph.print_tabular()
-            expected_ops = expected.op_count
-        except Exception:
-            pass  # Silently ignore FX errors (not our issue)
 
     args1 = [torch.randn(10, 10) for _ in range(nargs)]
     args2 = [torch.randn(10, 10) for _ in range(nargs)]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #112420

Fix https://github.com/pytorch/pytorch/issues/112230 by removing the comparison of number of ops in dynamo vs. fx.symbolic_trace. A number of tests fail in `test_functions.py` fail because the number of ops is no longer the same, but this seems to be acceptable behavior by dynamo.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng