### PR TITLE
Remove HSDP validation check 

### DIFF
--- a/test/distributed/fsdp/test_fsdp_hybrid_shard.py
+++ b/test/distributed/fsdp/test_fsdp_hybrid_shard.py
@@ -117,46 +117,6 @@ class TestFSDPHybridShard(FSDPTest):
         with err_ctx:
             model = FSDP(model, sharding_strategy=ShardingStrategy._HYBRID_SHARD_ZERO2)
 
-    @skip_if_lt_x_gpu(2)
-    def test_hybrid_shard_pg_mismatch_raises(self):
-        model = MyModel().cuda()
-        intra_pg = self.process_group
-        inter_pg = dist.new_group(ranks=[self.rank])
-        # Mismatched process groups for intra-node
-        model.lin1 = FSDP(
-            model.lin1,
-            process_group=(intra_pg, inter_pg),
-            sharding_strategy=ShardingStrategy.HYBRID_SHARD,
-        )
-        model = FSDP(
-            model,
-            process_group=(dist.new_group(), dist.new_group()),
-            sharding_strategy=ShardingStrategy.HYBRID_SHARD,
-        )
-        # Errors during _lazy_init
-        inp = torch.randn(4, 10)
-        with self.assertRaisesRegex(
-            ValueError, "intra-node process groups do not match"
-        ):
-            model(inp)
-
-        # Mismatched process groups for inter-node
-        model = MyModel().cuda()
-        model.lin1 = FSDP(
-            model.lin1,
-            process_group=(intra_pg, inter_pg),
-            sharding_strategy=ShardingStrategy.HYBRID_SHARD,
-        )
-        model = FSDP(
-            model,
-            process_group=(intra_pg, dist.new_group()),
-            sharding_strategy=ShardingStrategy.HYBRID_SHARD,
-        )
-        with self.assertRaisesRegex(
-            ValueError, "inter-node process groups do not match"
-        ):
-            model(inp)
-
     @skip_if_lt_x_gpu(4)
     def test_hsdp_save_load_state_dict(self):
         model = MyModel().cuda()


### PR DESCRIPTION
Currently, HSDP validates that all intra/inter node PGs are the same. This makes sense if you are only using HSDP with no other forms of parallelism and is a nice but not necessary sanity check.

However, if you want to mix HSDP with other forms, say tensor parallelism on the FFN of a transformer block, the intra/inter node PGs will be different for that layer. This check raises errors in this scenario, so we need to remove this assumption.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225