### PR TITLE
Upload ROCm artifacts from the new workflow to S3

### DIFF
--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -2,7 +2,7 @@ name: Upload test stats
 
 on:
   workflow_run:
-    workflows: [pull, trunk, periodic, inductor, unstable, slow, unstable-periodic, inductor-periodic]
+    workflows: [pull, trunk, periodic, inductor, unstable, slow, unstable-periodic, inductor-periodic, rocm]
     types:
       - completed
 


### PR DESCRIPTION
This is raised as a regression after https://github.com/pytorch/pytorch/pull/111394#issuecomment-1785858263.  The jobs are now in a different workflow, so their artifacts weren't uploaded to S3 like other trunk jobs.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang