### PR TITLE
[CI] Call upload step `upload`

### DIFF
--- a/.github/workflows/_binary-upload.yml
+++ b/.github/workflows/_binary-upload.yml
@@ -72,7 +72,7 @@ on:
         required: true
         description: Conda PyTorchBot token
 jobs:
-  build:
+  upload:
     runs-on: ubuntu-22.04
     environment: ${{ (github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || startsWith(github.event.ref, 'refs/tags/v'))) && 'conda-aws-upload' || '' }}
     container:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #112452
* __->__ #112451

Rather than `build`