### PR TITLE
[execution trace] ignore some properties when symbolic size/strides exist

### DIFF
--- a/torch/csrc/profiler/standalone/execution_trace_observer.cpp
+++ b/torch/csrc/profiler/standalone/execution_trace_observer.cpp
@@ -87,7 +87,8 @@ inline std::string getValueShape(
     const size_t maxArrayLen = maxNumElements) {
   if (val.isTensor()) {
     auto& tensor = val.toTensor();
-    if (tensor.defined()) {
+    if (tensor.defined() &&
+        !tensor.unsafeGetTensorImpl()->has_symbolic_sizes_strides()) {
       return vectorToString(tensor.sizes().vec());
     }
   } else if (val.isTuple()) {
@@ -389,7 +390,8 @@ inline std::string convertIValue(
     size_t numel = 0;
     size_t itemsize = 0;
     std::string device_str = "";
-    if (t->has_storage()) {
+    // symbolic sizes/strides implies t->storage_offset() will fail
+    if (t->has_storage() && !t->has_symbolic_sizes_strides()) {
       auto& t_storage = t->storage();
       storage_id = getObjectID(ob, t_storage.data());
       offset = t->storage_offset();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #112458

Fixes #112235

Otherwise an exception will be thrown when we try to access storage or sizes on a tensor with symbolic size/strides.

Added a test in test/dynamo/test_profiler.py

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng

Differential Revision: [D50821576](https://our.internmc.facebook.com/intern/diff/D50821576)