### PR TITLE
[2D] Remove enable_2d_with_fsdp() API and make remove_enable_2d_with_fsdp private

### DIFF
--- a/docs/source/distributed.tensor.parallel.rst
+++ b/docs/source/distributed.tensor.parallel.rst
@@ -67,20 +67,3 @@ Currently, there are some constraints which makes it hard for the ``MultiheadAtt
 module to work out of box for Tensor Parallelism, so we recommend users to try ``ColwiseParallel``
 and ``RowwiseParallel`` for each parameter. There might be some code changes needed now
 since we are parallelizing on the head dim of the ``MultiheadAttention`` module.
-
-
-We also support 2D parallelism, where we compose tensor parallelism with data parallelism.
-To integrate with ``FullyShardedDataParallel``,
-users just need to call the following API explicitly:
-
-
-.. currentmodule:: torch.distributed.tensor.parallel.fsdp
-.. autofunction::  enable_2d_with_fsdp
-
-
-To integrate with ``DistributedDataParallel``,
-users just need to call the following API explicitly:
-
-
-.. currentmodule:: torch.distributed.tensor.parallel.ddp
-.. autofunction::  pre_dp_module_transform

--- a/test/distributed/tensor/parallel/test_ddp_2d_parallel.py
+++ b/test/distributed/tensor/parallel/test_ddp_2d_parallel.py
@@ -4,7 +4,7 @@ import torch
 import torch.distributed as dist
 from torch.distributed._tensor import DeviceMesh, DTensor, Replicate
 from torch.distributed.tensor.parallel import PairwiseParallel, parallelize_module
-from torch.distributed.tensor.parallel.ddp import pre_dp_module_transform
+from torch.distributed.tensor.parallel.ddp import _pre_dp_module_transform
 
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
@@ -41,7 +41,7 @@ def init_model(device_type, model_parallel_size=TP_DEGREE):
     twod_model = parallelize_module(
         twod_model, twod_mesh, PairwiseParallel(), tp_mesh_dim=1
     )
-    pre_dp_module_transform(twod_model)
+    _pre_dp_module_transform(twod_model)
     # TODO: Add tests when using gradient_as_bucket_view and static_graph for DDP.
     twod_model = DDP(twod_model, process_group=dp_pg)
     return model, twod_model, dp_pg

--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -20,7 +20,6 @@ from torch.distributed.tensor.parallel import (
     SequenceParallel,
     parallelize_module,
 )
-from torch.distributed.tensor.parallel.fsdp import enable_2d_with_fsdp
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     MLPModule,
 )
@@ -179,7 +178,7 @@ class TestFakePG(TestCase):
         dist.recv(output, 1)
         self.assertEqual(tuple(output.shape), (3, 3))
 
-    @unittest.skipIf(not HAS_CUDA or not enable_2d_with_fsdp(), "No CUDA or TP+FSDP")
+    @unittest.skipIf(not HAS_CUDA, "No CUDA or TP+FSDP")
     def test_fsdp_tp_fake_e2e(self):
         world_size = 4
         tp_size = 2

--- a/torch/distributed/tensor/parallel/ddp.py
+++ b/torch/distributed/tensor/parallel/ddp.py
@@ -6,7 +6,7 @@ from torch.distributed.tensor.parallel._data_parallel_utils import (
     _unflatten_tensor,
 )
 
-__all__ = ["pre_dp_module_transform"]
+__all__ = []  # type: ignore[var-annotated]
 
 
 def _get_submodule_n_params(module: nn.Module, path: str):
@@ -59,7 +59,7 @@ def _localize_dtensor(module: nn.Module, *_: Any):
     _update_module_param(param_list)  # type: ignore[arg-type]
 
 
-def pre_dp_module_transform(module: nn.Module):
+def _pre_dp_module_transform(module: nn.Module):
     """
     Enable the composability between Tensor Parallelism (TP) and Data
     Parallelism(DP) in PyTorch when using DDP. We need to convert Parameters which

--- a/torch/distributed/tensor/parallel/fsdp.py
+++ b/torch/distributed/tensor/parallel/fsdp.py
@@ -1,5 +1,4 @@
 import copy
-import warnings
 from typing import Any, cast, List, Optional, Tuple
 
 import torch
@@ -20,7 +19,7 @@ from torch.distributed._tensor import DeviceMesh, DTensor, Replicate, Shard as D
 from torch.distributed._tensor.device_mesh import _mesh_resources
 
 from torch.distributed.fsdp._common_utils import _set_fsdp_flattened
-from torch.distributed.fsdp._fsdp_extensions import _set_fsdp_extensions, FSDPExtensions
+from torch.distributed.fsdp._fsdp_extensions import FSDPExtensions
 from torch.distributed.fsdp._shard_utils import _create_chunk_sharded_tensor
 from torch.distributed.remote_device import _remote_device
 from torch.distributed.tensor.parallel._data_parallel_utils import (
@@ -28,7 +27,7 @@ from torch.distributed.tensor.parallel._data_parallel_utils import (
     _unflatten_tensor,
 )
 
-__all__ = ["enable_2d_with_fsdp", "DTensorExtensions"]
+__all__ = ["DTensorExtensions"]
 
 
 def _get_box(tensor: DTensor) -> Tuple[torch.Size, torch.Size]:
@@ -366,31 +365,3 @@ class DTensorExtensions(FSDPExtensions):
         parent_mesh: Optional[DeviceMesh],
     ) -> torch.Tensor:
         return _all_gather_dtensor(tensor, parent_mesh)
-
-
-# TODO: remove enable_2d_with_fsdp() once we roll out the new 2D flow.
-def enable_2d_with_fsdp() -> bool:
-    """
-    Register the extension which is needed for Tensor Parallelism (TP) to work with FullyShardedDataParallel (FSDP).
-
-    We first parallelize parameters within one module or sub_modules based on a parallelize_plan and will let FSDP
-    reshard the local tensor of distributed parameter which is essentially a DTensor.
-
-    Return:
-        A `bool` indicated whether extension registration succeeds or not.
-    """
-    torch._C._log_api_usage_once(
-        "torch.distributed.tensor.parallel.enable_2d_with_fsdp"
-    )
-
-    try:
-        _set_fsdp_extensions(DTensorExtensions())
-        return True
-
-    except BaseException as e:
-        warnings.warn(
-            "PyTorch doesn't have TensorFlattener extension point available"
-            "2D parallelism won't work with FSDP"
-            f"exception: {e}"
-        )
-        return False


### PR DESCRIPTION
As we have our new 2D flow out, we want to remove `enable_2d_with_fsdp()`.
In addition, we change pre_dp_module_transform to private, as we may need to change the UX later on.