### PR TITLE
[AOTInductor] Include AOTI debug folder in package

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -551,6 +551,10 @@ class trace:
     # master switch for all debugging flags below
     enabled = os.environ.get("TORCH_COMPILE_DEBUG", "0") == "1"
 
+    # Save debug information to a temporary directory
+    # If not specified, a temp directory will be created by system
+    debug_dir = None
+
     # Save python logger call >=logging.DEBUG
     debug_log = False
 

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -306,9 +306,10 @@ class DebugContext:
 
     @staticmethod
     def create_debug_dir(folder_name: str) -> Optional[str]:
+        debug_dir = config.trace.debug_dir or get_debug_dir()
         for n in DebugContext._counter:
             dirname = os.path.join(
-                get_debug_dir(),
+                debug_dir,
                 "torchinductor",
                 f"{folder_name}.{n}",
             )


### PR DESCRIPTION
Summary:
Allow user to set debug dir for Inductor

Include AOTInductor debug folder in the package.

```
zipinfo package.zip
Archive:  package.zip
Zip file size: 1325264 bytes, number of entries: 46
-rw----     0.0 fat      212 bl stor 80-000-00 00:00 package/data/aotinductor/merge-a100/aotinductor_pickle_data.json
-rw----     0.0 fat     6024 bl stor 80-000-00 00:00 package/data/aotinductor/merge-a100/debug/torchinductor/model___9.0/fx_graph_runnable.py
-rw----     0.0 fat     9031 bl stor 80-000-00 00:00 package/data/aotinductor/merge-a100/debug/torchinductor/model___9.0/fx_graph_readable.py
-rw----     0.0 fat     9202 bl stor 80-000-00 00:00 package/data/aotinductor/merge-a100/debug/torchinductor/model___9.0/fx_graph_transformed.py
-rw----     0.0 fat    10865 bl stor 80-000-00 00:00 package/data/aotinductor/merge-a100/debug/torchinductor/model___9.0/ir_pre_fusion.txt
-rw----     0.0 fat    10865 bl stor 80-000-00 00:00 package/data/aotinductor/merge-a100/debug/torchinductor/model___9.0/ir_post_fusion.txt
-rw----     0.0 fat    13553 bl stor 80-000-00 00:00 package/data/aotinductor/merge-a100/debug/torchinductor/model___9.0/output_code.py
-rw----     0.0 fat     5822 bl stor 80-000-00 00:00 package/data/aotinductor/merge-a100/debug/torchinductor/model___9.1/fx_graph_runnable.py
-rw----     0.0 fat     8817 bl stor 80-000-00 00:00 package/data/aotinductor/merge-a100/debug/torchinductor/model___9.1/fx_graph_readable.py
-rw----     0.0 fat     8988 bl stor 80-000-00 00:00 package/data/aotinductor/merge-a100/debug/torchinductor/model___9.1/fx_graph_transformed.py
-rw----     0.0 fat    10858 bl stor 80-000-00 00:00 package/data/aotinductor/merge-a100/debug/torchinductor/model___9.1/ir_pre_fusion.txt
-rw----     0.0 fat    10858 bl stor 80-000-00 00:00 package/data/aotinductor/merge-a100/debug/torchinductor/model___9.1/ir_post_fusion.txt
```

Test Plan: CIs

Reviewed By: chenyang78

Differential Revision: D50815320




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler