### PR TITLE
[ONNX] Fix partial name matching when searching parameter tensors

### DIFF
--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -715,9 +715,8 @@ class ExportOutput:
                     model_state_dict, str
                 ), "model_state_dict must be a path to the model's state_dict or the actual state_dict"
                 _model_state_dict_files.append(model_state_dict)
-
-        # Load state from previous model.load_state_dict() call within enable_fake_mode() context
-        if self._fake_context and self._fake_context.state_dict_paths:
+        elif self._fake_context and self._fake_context.state_dict_paths:
+            # Load state from previous model.load_state_dict() call within enable_fake_mode() context
             for path in self._fake_context.state_dict_paths:
                 if path in _model_state_dict_files:
                     # ignore duplicate

--- a/torch/onnx/_internal/fx/serialization.py
+++ b/torch/onnx/_internal/fx/serialization.py
@@ -123,7 +123,7 @@ def save_model_with_external_data(
 
     onnx_model_with_initializers = onnx.ModelProto()  # type: ignore[attr-defined]
     onnx_model_with_initializers.CopyFrom(onnx_model)
-    onnx_input_names = set(input.name for input in onnx_model.graph.input)
+    onnx_input_names = {input.name for input in onnx_model.graph.input}
 
     for path in torch_load_paths:
         state_dict = torch.load(path)

--- a/torch/onnx/_internal/fx/serialization.py
+++ b/torch/onnx/_internal/fx/serialization.py
@@ -145,6 +145,7 @@ def save_model_with_external_data(
             # Step 1 is required because sometimes, tensor names are stored with prefix the dictionary
             # loaded by torch.load.
             if name in onnx_input_names:
+                # Same input name shouldn't be matched again
                 onnx_input_names.remove(name)
             else:
                 for onnx_input_name in onnx_input_names:

--- a/torch/onnx/_internal/fx/serialization.py
+++ b/torch/onnx/_internal/fx/serialization.py
@@ -123,7 +123,7 @@ def save_model_with_external_data(
 
     onnx_model_with_initializers = onnx.ModelProto()  # type: ignore[attr-defined]
     onnx_model_with_initializers.CopyFrom(onnx_model)
-    onnx_input_names = [input.name for input in onnx_model.graph.input]
+    onnx_input_names = set(input.name for input in onnx_model.graph.input)
 
     for path in torch_load_paths:
         state_dict = torch.load(path)
@@ -144,12 +144,16 @@ def save_model_with_external_data(
             #      E.g., "tensor" is stored as the initializer of "attention_weight".
             # Step 1 is required because sometimes, tensor names are stored with prefix the dictionary
             # loaded by torch.load.
-            for onnx_input_name in onnx_input_names:
-                if onnx_input_name.endswith(name) or name.endswith(onnx_input_name):
-                    # Find a match. Change name to the matched ONNX input name, so that we
-                    # create initializer with the right ONNX name.
-                    name = onnx_input_name
-                    break
+            if name in onnx_input_names:
+                onnx_input_names.remove(name)
+            else:
+                for onnx_input_name in onnx_input_names:
+                    if onnx_input_name.endswith(name) or name.endswith(onnx_input_name):
+                        # Find a match. Change name to the matched ONNX input name, so that we
+                        # create initializer with the right ONNX name.
+                        name = onnx_input_name
+                        onnx_input_names.remove(onnx_input_name)
+                        break
 
             relative_tensor_file_path = os.path.join(initializer_location, name)
             # Create one file per tensor.


### PR DESCRIPTION
Now we remove name in `onnx_input_names` once it's matched by a parameter so that the same name won't be matched twice.