### PR TITLE
WIP: fix compiling np.array(list_of_arrays)

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1755,7 +1755,8 @@ utils_device.CURRENT_DEVICE == None""",
                 (1, 2),
                 (np.arange(3), np.arange(3) + 5),
                 (np.arange(3, dtype=float), np.arange(3, dtype=float) + 5),
-                (np.array([1, 1e12]), np.array([2, 1e12]))
+                (np.array([1, 1e12]), np.array([2, 1e12])),
+                (np.float64(1), np.float64(2)),
                 # (1, np.array(2)),      # XXX: rework _ndarray.array _tolist logic
                 # ([1, 2], [3, np.array(4)])
             ]

--- a/test/torch_np/numpy_tests/core/test_indexing.py
+++ b/test/torch_np/numpy_tests/core/test_indexing.py
@@ -1191,7 +1191,7 @@ class TestNonIntegerArrayLike(TestCase):
 class TestMultipleEllipsisError(TestCase):
     """An index can only have a single ellipsis."""
 
-    @xfail  # (
+    @xpassIfTorchDynamo  # (
     #    reason=(
     #        "torch currently consumes multiple ellipsis, no bother raising "
     #        "here. See https://github.com/pytorch/pytorch/issues/59787#issue-917252204"

--- a/test/torch_np/numpy_tests/core/test_numeric.py
+++ b/test/torch_np/numpy_tests/core/test_numeric.py
@@ -1436,7 +1436,7 @@ class TestClip(TestCase):
         act = self.clip(a, m, M)
         assert_array_equal(ac, act)
 
-    @xfail  # (reason="clamp not supported for complex")
+    @xpassIfTorchDynamo  # (reason="clamp not supported for complex")
     def test_clip_complex(self):
         # Address Issue gh-5354 for clipping complex arrays
         # Test native complex input without explicit min/max
@@ -1835,7 +1835,7 @@ class TestClip(TestCase):
         actual = np.clip(arr, amin, amax)
         assert_equal(actual, expected)
 
-    @xfail  # (reason="np.maximum(..., dtype=) needs implementing")
+    @xpassIfTorchDynamo  # (reason="np.maximum(..., dtype=) needs implementing")
     @given(
         data=st.data(),
         arr=hynp.arrays(

--- a/test/torch_np/numpy_tests/core/test_scalarmath.py
+++ b/test/torch_np/numpy_tests/core/test_scalarmath.py
@@ -808,7 +808,7 @@ def recursionlimit(n):
 
 @instantiate_parametrized_tests
 class TestScalarOpsMisc(TestCase):
-    @xfail  # (reason="pytorch does not warn on overflow")
+    @xpassIfTorchDynamo  # (reason="pytorch does not warn on overflow")
     @parametrize("dtype", "Bbhil")
     @parametrize(
         "operation",
@@ -860,8 +860,8 @@ class TestScalarOpsMisc(TestCase):
         zero = np.dtype(dtype).type(0)
         -zero  # does not warn
 
-    @xfail  # (reason="pytorch raises RuntimeError on division by zero")
-    @parametrize("dtype", np.typecodes["AllInteger"])
+    @xpassIfTorchDynamo  # (reason="pytorch raises RuntimeError on division by zero")
+    @parametrize("dtype", 'Bbhil') #np.typecodes["AllInteger"])
     @parametrize(
         "operation",
         [

--- a/test/torch_np/numpy_tests/lib/test_arraysetops.py
+++ b/test/torch_np/numpy_tests/lib/test_arraysetops.py
@@ -167,7 +167,7 @@ class TestSetOps(TestCase):
                     None,
                     "to_begin",
                 ),
-                decorators=[xfailIfTorchDynamo],
+                decorators=[],
             ),
             # should fail because attempting to cast
             # two special floating point values

--- a/test/torch_np/numpy_tests/lib/test_function_base.py
+++ b/test/torch_np/numpy_tests/lib/test_function_base.py
@@ -844,13 +844,13 @@ class TestDiff(TestCase):
         assert_raises(np.AxisError, diff, x, append=0, axis=3)
 
 
-@xpassIfTorchDynamo  # (reason="TODO: implement")
 @instantiate_parametrized_tests
 class TestDelete(TestCase):
     def setUp(self):
         self.a = np.arange(5)
         self.nd_a = np.arange(5).repeat(2).reshape(1, 5, 2)
 
+    @xpassIfTorchDynamo  # (reason="TODO: implement")
     def _check_inverse_of_slicing(self, indices):
         a_del = delete(self.a, indices)
         nd_a_del = delete(self.nd_a, indices, axis=1)
@@ -859,6 +859,7 @@ class TestDelete(TestCase):
         xor = setxor1d(nd_a_del[0, :, 0], self.nd_a[0, indices, 0])
         assert_array_equal(xor, self.nd_a[0, :, 0], err_msg=msg)
 
+    @xpassIfTorchDynamo  # (reason="TODO: implement")
     def test_slices(self):
         lims = [-6, -2, 0, 1, 2, 4, 5]
         steps = [-3, -1, 1, 3]
@@ -868,6 +869,7 @@ class TestDelete(TestCase):
                     s = slice(start, stop, step)
                     self._check_inverse_of_slicing(s)
 
+    @xpassIfTorchDynamo  # (reason="TODO: implement")
     def test_fancy(self):
         self._check_inverse_of_slicing(np.array([[0, 1], [2, 1]]))
         with pytest.raises(IndexError):
@@ -893,6 +895,7 @@ class TestDelete(TestCase):
         self._check_inverse_of_slicing(0)
         self._check_inverse_of_slicing(-4)
 
+    @xpassIfTorchDynamo  # (reason="TODO: implement")
     def test_0d(self):
         a = np.array(1)
         with pytest.raises(np.AxisError):
@@ -900,6 +903,7 @@ class TestDelete(TestCase):
         with pytest.raises(TypeError):
             delete(a, [], axis="nonsense")
 
+    @xpassIfTorchDynamo  # (reason="TODO: implement")
     def test_array_order_preserve(self):
         # See gh-7113
         k = np.arange(10).reshape(2, 5, order="F")
@@ -910,12 +914,14 @@ class TestDelete(TestCase):
         assert_equal(m.flags.c_contiguous, k.flags.c_contiguous)
         assert_equal(m.flags.f_contiguous, k.flags.f_contiguous)
 
+    @xpassIfTorchDynamo  # (reason="TODO: implement")
     def test_index_floats(self):
         with pytest.raises(IndexError):
             np.delete([0, 1, 2], np.array([1.0, 2.0]))
         with pytest.raises(IndexError):
             np.delete([0, 1, 2], np.array([], dtype=float))
 
+    @xpassIfTorchDynamo  # (reason="TODO: implement")
     @parametrize(
         "indexer", [subtest(np.array([1]), name="array([1])"), subtest([1], name="[1]")]
     )
@@ -928,6 +934,7 @@ class TestDelete(TestCase):
         nd_a_del = delete(self.nd_a, np.array([1]), axis=1)
         assert_equal(nd_a_del_int, nd_a_del)
 
+    @xpassIfTorchDynamo  # (reason="TODO: implement")
     def test_single_item_array_non_int(self):
         # Special handling for integer arrays must not affect non-integer ones.
         # If `False` was cast to `0` it would delete the element:
@@ -1265,13 +1272,13 @@ class TestTrimZeros(TestCase):
         assert isinstance(res, list)
 
 
-@xpassIfTorchDynamo  # (reason="TODO: implement")
 class TestExtins(TestCase):
     def test_basic(self):
         a = np.array([1, 3, 2, 1, 2, 3, 3])
         b = extract(a > 1, a)
         assert_array_equal(b, [3, 2, 2, 3, 3])
 
+    @xpassIfTorchDynamo  # (reason="TODO: implement")
     def test_place(self):
         # Make sure that non-np.ndarray objects
         # raise an error instead of doing nothing
@@ -1297,6 +1304,7 @@ class TestExtins(TestCase):
         place(a, [0, 1], "9")
         assert_array_equal(a, ["12", "9"])
 
+    @xpassIfTorchDynamo  # (reason="TODO: implement")
     def test_both(self):
         a = rand(10)
         mask = a > 0.5

--- a/test/torch_np/numpy_tests/linalg/test_linalg.py
+++ b/test/torch_np/numpy_tests/linalg/test_linalg.py
@@ -2128,6 +2128,7 @@ class TestMultiDot(TestCase):
         assert out is ret
         assert_almost_equal(out, A.dot(B).dot(C).dot(D))
 
+    @xpassIfTorchDynamo  # (reason="_multi_dot_chain_order is from numpy only")
     def test_dynamic_programming_logic(self):
         # Test for the dynamic programming part
         # This test is directly taken from Cormen page 376.

--- a/test/torch_np/test_binary_ufuncs.py
+++ b/test/torch_np/test_binary_ufuncs.py
@@ -11,46 +11,46 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class TestBinaryUfuncBasic(TestCase):
     def test_add(self):
-        assert_allclose(np.add(0.5, 0.6), add(0.5, 0.6), atol=1e-7, check_dtype=False)
+        assert_allclose(np.add(0.5, 0.6).item(), add(0.5, 0.6), atol=1e-7, check_dtype=False)
 
     def test_arctan2(self):
         assert_allclose(
-            np.arctan2(0.5, 0.6), arctan2(0.5, 0.6), atol=1e-7, check_dtype=False
+            np.arctan2(0.5, 0.6).item(), arctan2(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
     def test_bitwise_and(self):
         assert_allclose(
-            np.bitwise_and(5, 6), bitwise_and(5, 6), atol=1e-7, check_dtype=False
+            np.bitwise_and(5, 6).item(), bitwise_and(5, 6), atol=1e-7, check_dtype=False
         )
 
     def test_bitwise_or(self):
         assert_allclose(
-            np.bitwise_or(5, 6), bitwise_or(5, 6), atol=1e-7, check_dtype=False
+            np.bitwise_or(5, 6).item(), bitwise_or(5, 6), atol=1e-7, check_dtype=False
         )
 
     def test_bitwise_xor(self):
         assert_allclose(
-            np.bitwise_xor(5, 6), bitwise_xor(5, 6), atol=1e-7, check_dtype=False
+            np.bitwise_xor(5, 6).item(), bitwise_xor(5, 6), atol=1e-7, check_dtype=False
         )
 
     def test_copysign(self):
         assert_allclose(
-            np.copysign(0.5, 0.6), copysign(0.5, 0.6), atol=1e-7, check_dtype=False
+            np.copysign(0.5, 0.6).item(), copysign(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
     def test_divide(self):
         assert_allclose(
-            np.divide(0.5, 0.6), divide(0.5, 0.6), atol=1e-7, check_dtype=False
+            np.divide(0.5, 0.6).item(), divide(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
     def test_equal(self):
         assert_allclose(
-            np.equal(0.5, 0.6), equal(0.5, 0.6), atol=1e-7, check_dtype=False
+            np.equal(0.5, 0.6).item(), equal(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
     def test_float_power(self):
         assert_allclose(
-            np.float_power(0.5, 0.6),
+            np.float_power(0.5, 0.6).item(),
             float_power(0.5, 0.6),
             atol=1e-7,
             check_dtype=False,
@@ -58,32 +58,32 @@ class TestBinaryUfuncBasic(TestCase):
 
     def test_floor_divide(self):
         assert_allclose(
-            np.floor_divide(0.5, 0.6),
+            np.floor_divide(0.5, 0.6).item(),
             floor_divide(0.5, 0.6),
             atol=1e-7,
             check_dtype=False,
         )
 
     def test_fmax(self):
-        assert_allclose(np.fmax(0.5, 0.6), fmax(0.5, 0.6), atol=1e-7, check_dtype=False)
+        assert_allclose(np.fmax(0.5, 0.6).item(), fmax(0.5, 0.6), atol=1e-7, check_dtype=False)
 
     def test_fmin(self):
-        assert_allclose(np.fmin(0.5, 0.6), fmin(0.5, 0.6), atol=1e-7, check_dtype=False)
+        assert_allclose(np.fmin(0.5, 0.6).item(), fmin(0.5, 0.6), atol=1e-7, check_dtype=False)
 
     def test_fmod(self):
-        assert_allclose(np.fmod(0.5, 0.6), fmod(0.5, 0.6), atol=1e-7, check_dtype=False)
+        assert_allclose(np.fmod(0.5, 0.6).item(), fmod(0.5, 0.6), atol=1e-7, check_dtype=False)
 
     def test_gcd(self):
-        assert_allclose(np.gcd(5, 6), gcd(5, 6), atol=1e-7, check_dtype=False)
+        assert_allclose(np.gcd(5, 6).item(), gcd(5, 6), atol=1e-7, check_dtype=False)
 
     def test_greater(self):
         assert_allclose(
-            np.greater(0.5, 0.6), greater(0.5, 0.6), atol=1e-7, check_dtype=False
+            np.greater(0.5, 0.6).item(), greater(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
     def test_greater_equal(self):
         assert_allclose(
-            np.greater_equal(0.5, 0.6),
+            np.greater_equal(0.5, 0.6).item(),
             greater_equal(0.5, 0.6),
             atol=1e-7,
             check_dtype=False,
@@ -91,46 +91,46 @@ class TestBinaryUfuncBasic(TestCase):
 
     def test_heaviside(self):
         assert_allclose(
-            np.heaviside(0.5, 0.6), heaviside(0.5, 0.6), atol=1e-7, check_dtype=False
+            np.heaviside(0.5, 0.6).item(), heaviside(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
     def test_hypot(self):
         assert_allclose(
-            np.hypot(0.5, 0.6), hypot(0.5, 0.6), atol=1e-7, check_dtype=False
+            np.hypot(0.5, 0.6).item(), hypot(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
     def test_lcm(self):
-        assert_allclose(np.lcm(5, 6), lcm(5, 6), atol=1e-7, check_dtype=False)
+        assert_allclose(np.lcm(5, 6).item(), lcm(5, 6), atol=1e-7, check_dtype=False)
 
     def test_ldexp(self):
-        assert_allclose(np.ldexp(0.5, 6), ldexp(0.5, 6), atol=1e-7, check_dtype=False)
+        assert_allclose(np.ldexp(0.5, 6).item(), ldexp(0.5, 6), atol=1e-7, check_dtype=False)
 
     def test_left_shift(self):
         assert_allclose(
-            np.left_shift(5, 6), left_shift(5, 6), atol=1e-7, check_dtype=False
+            np.left_shift(5, 6).item(), left_shift(5, 6), atol=1e-7, check_dtype=False
         )
 
     def test_less(self):
-        assert_allclose(np.less(0.5, 0.6), less(0.5, 0.6), atol=1e-7, check_dtype=False)
+        assert_allclose(np.less(0.5, 0.6).item(), less(0.5, 0.6), atol=1e-7, check_dtype=False)
 
     def test_less_equal(self):
         assert_allclose(
-            np.less_equal(0.5, 0.6), less_equal(0.5, 0.6), atol=1e-7, check_dtype=False
+            np.less_equal(0.5, 0.6).item(), less_equal(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
     def test_logaddexp(self):
         assert_allclose(
-            np.logaddexp(0.5, 0.6), logaddexp(0.5, 0.6), atol=1e-7, check_dtype=False
+            np.logaddexp(0.5, 0.6).item(), logaddexp(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
     def test_logaddexp2(self):
         assert_allclose(
-            np.logaddexp2(0.5, 0.6), logaddexp2(0.5, 0.6), atol=1e-7, check_dtype=False
+            np.logaddexp2(0.5, 0.6).item(), logaddexp2(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
     def test_logical_and(self):
         assert_allclose(
-            np.logical_and(0.5, 0.6),
+            np.logical_and(0.5, 0.6).item(),
             logical_and(0.5, 0.6),
             atol=1e-7,
             check_dtype=False,
@@ -138,12 +138,12 @@ class TestBinaryUfuncBasic(TestCase):
 
     def test_logical_or(self):
         assert_allclose(
-            np.logical_or(0.5, 0.6), logical_or(0.5, 0.6), atol=1e-7, check_dtype=False
+            np.logical_or(0.5, 0.6).item(), logical_or(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
     def test_logical_xor(self):
         assert_allclose(
-            np.logical_xor(0.5, 0.6),
+            np.logical_xor(0.5, 0.6).item(),
             logical_xor(0.5, 0.6),
             atol=1e-7,
             check_dtype=False,
@@ -151,52 +151,52 @@ class TestBinaryUfuncBasic(TestCase):
 
     def test_matmul(self):
         assert_allclose(
-            np.matmul([0.5], [0.6]), matmul([0.5], [0.6]), atol=1e-7, check_dtype=False
+            np.matmul([0.5], [0.6]).item(), matmul([0.5], [0.6]), atol=1e-7, check_dtype=False
         )
 
     def test_maximum(self):
         assert_allclose(
-            np.maximum(0.5, 0.6), maximum(0.5, 0.6), atol=1e-7, check_dtype=False
+            np.maximum(0.5, 0.6).item(), maximum(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
     def test_minimum(self):
         assert_allclose(
-            np.minimum(0.5, 0.6), minimum(0.5, 0.6), atol=1e-7, check_dtype=False
+            np.minimum(0.5, 0.6).item(), minimum(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
     def test_remainder(self):
         assert_allclose(
-            np.remainder(0.5, 0.6), remainder(0.5, 0.6), atol=1e-7, check_dtype=False
+            np.remainder(0.5, 0.6).item(), remainder(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
     def test_multiply(self):
         assert_allclose(
-            np.multiply(0.5, 0.6), multiply(0.5, 0.6), atol=1e-7, check_dtype=False
+            np.multiply(0.5, 0.6).item(), multiply(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
     def test_nextafter(self):
         assert_allclose(
-            np.nextafter(0.5, 0.6), nextafter(0.5, 0.6), atol=1e-7, check_dtype=False
+            np.nextafter(0.5, 0.6).item(), nextafter(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
     def test_not_equal(self):
         assert_allclose(
-            np.not_equal(0.5, 0.6), not_equal(0.5, 0.6), atol=1e-7, check_dtype=False
+            np.not_equal(0.5, 0.6).item(), not_equal(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
     def test_power(self):
         assert_allclose(
-            np.power(0.5, 0.6), power(0.5, 0.6), atol=1e-7, check_dtype=False
+            np.power(0.5, 0.6).item(), power(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
     def test_right_shift(self):
         assert_allclose(
-            np.right_shift(5, 6), right_shift(5, 6), atol=1e-7, check_dtype=False
+            np.right_shift(5, 6).item(), right_shift(5, 6), atol=1e-7, check_dtype=False
         )
 
     def test_subtract(self):
         assert_allclose(
-            np.subtract(0.5, 0.6), subtract(0.5, 0.6), atol=1e-7, check_dtype=False
+            np.subtract(0.5, 0.6).item(), subtract(0.5, 0.6), atol=1e-7, check_dtype=False
         )
 
 

--- a/test/torch_np/test_ndarray_methods.py
+++ b/test/torch_np/test_ndarray_methods.py
@@ -662,21 +662,42 @@ class TestIter(TestCase):
         assert_equal(lst[0], np.arange(5))
 
 
+
+cases = [  # input, expected
+    ([], np.array([])),
+    (1, np.array(1)),
+    ([1, 2, 3], np.array([1, 2, 3])), 
+    ([np.array(1), np.array(2)], np.array([1, 2])),
+    ([1, np.array(2), 3], np.array([1, 2, 3])), 
+    ([1, np.array(2), np.array(3), 4], np.array([1, 2, 3, 4])),
+    ([np.array(1), 2, 3, np.array(4), 5], np.array([1, 2, 3, 4, 5])),
+
+    ([np.float64(1), np.float64(2)], np.array([1., 2.])),
+
+    ([[1, 2], [3, 4]], np.array([[1, 2], [3, 4]])),
+    ([[1, 2], [3, np.array(4)]], np.array([[1, 2], [3, 4]])),
+
+    ([[1, 2], np.array([3, 4])], np.array([[1, 2], [3, 4]])),
+    ([np.array([1, 2]), np.array([3, 4])], np.array([[1, 2], [3, 4]])),
+    ([np.array([1, 2]), [3, 4]],  np.array([[1, 2], [3, 4]])),
+
+    ([[ [np.array([1, 2])], [[3, 4]] ]], np.array([[ [[1, 2]], [[3, 4]] ]])),
+    ([np.array([[1, 2], [3, 4]]), [[5, 6], [7, 8]]], np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])),
+]
+
+
+@instantiate_parametrized_tests
 class TestArray(TestCase):
-    def test_nested_0D(self):
-        a = np.array([1, 2, np.array(3)])
-        assert_equal(a, [1, 2, 3])
 
-        a = np.array([[1, 2], [3, np.array(4)]])
-        assert_equal(a, [[1, 2], [3, 4]])
+    @parametrize("inputs, expected", cases)
+    def test_array_ctor(self, inputs, expected):
+    #    breakpoint()
+        res = np.array(inputs)
+        assert_equal(res, expected)
 
-    def test_array_of_arrays_0D(self):
-        a = np.array([np.array(1), np.array(2)])
-        assert_equal(a, [1, 2])
-
-    def test_array_of_arrays_1D(self):
-        a = np.array([np.array([1, 2]), np.array([3, 4])])
-        assert_equal(a, [[1, 2], [3, 4]])
+        if TEST_WITH_TORCHDYNAMO:
+            ref = np.asarray( numpy.array(inputs) )
+            assert_equal(res, ref)
 
 
 if __name__ == "__main__":

--- a/test/torch_np/test_ndarray_methods.py
+++ b/test/torch_np/test_ndarray_methods.py
@@ -662,5 +662,22 @@ class TestIter(TestCase):
         assert_equal(lst[0], np.arange(5))
 
 
+class TestArray(TestCase):
+    def test_nested_0D(self):
+        a = np.array([1, 2, np.array(3)])
+        assert_equal(a, [1, 2, 3])
+
+        a = np.array([[1, 2], [3, np.array(4)]])
+        assert_equal(a, [[1, 2], [3, 4]])
+
+    def test_array_of_arrays_0D(self):
+        a = np.array([np.array(1), np.array(2)])
+        assert_equal(a, [1, 2])
+
+    def test_array_of_arrays_1D(self):
+        a = np.array([np.array([1, 2]), np.array([3, 4])])
+        assert_equal(a, [[1, 2], [3, 4]])
+
+
 if __name__ == "__main__":
     run_tests()

--- a/test/torch_np/test_scalars_0D_arrays.py
+++ b/test/torch_np/test_scalars_0D_arrays.py
@@ -63,6 +63,8 @@ class TestArrayScalars(TestCase):
         # Our scalars follow 0D array behavior (because they are 0D arrays)
         lst = [1, 2, 3]
 
+###        breakpoint()
+
         product = value * lst
         assert isinstance(product, np.ndarray)
         assert product.shape == (3,)

--- a/test/torch_np/test_unary_ufuncs.py
+++ b/test/torch_np/test_unary_ufuncs.py
@@ -13,136 +13,136 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class TestUnaryUfuncs(TestCase):
     def test_absolute(self):
-        assert_allclose(np.absolute(0.5), absolute(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.absolute(0.5).item(), absolute(0.5), atol=1e-14, check_dtype=False)
 
     def test_arccos(self):
-        assert_allclose(np.arccos(0.5), arccos(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.arccos(0.5).item(), arccos(0.5), atol=1e-14, check_dtype=False)
 
     def test_arccosh(self):
-        assert_allclose(np.arccosh(1.5), arccosh(1.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.arccosh(1.5).item(), arccosh(1.5), atol=1e-14, check_dtype=False)
 
     def test_arcsin(self):
-        assert_allclose(np.arcsin(0.5), arcsin(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.arcsin(0.5).item(), arcsin(0.5), atol=1e-14, check_dtype=False)
 
     def test_arcsinh(self):
-        assert_allclose(np.arcsinh(0.5), arcsinh(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.arcsinh(0.5).item(), arcsinh(0.5), atol=1e-14, check_dtype=False)
 
     def test_arctan(self):
-        assert_allclose(np.arctan(0.5), arctan(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.arctan(0.5).item(), arctan(0.5), atol=1e-14, check_dtype=False)
 
     def test_arctanh(self):
-        assert_allclose(np.arctanh(0.5), arctanh(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.arctanh(0.5).item(), arctanh(0.5), atol=1e-14, check_dtype=False)
 
     def test_cbrt(self):
-        assert_allclose(np.cbrt(0.5), cbrt(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.cbrt(0.5).item(), cbrt(0.5), atol=1e-14, check_dtype=False)
 
     def test_ceil(self):
-        assert_allclose(np.ceil(0.5), ceil(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.ceil(0.5).item(), ceil(0.5), atol=1e-14, check_dtype=False)
 
     def test_conjugate(self):
         assert_allclose(
-            np.conjugate(0.5), conjugate(0.5), atol=1e-14, check_dtype=False
+            np.conjugate(0.5).item(), conjugate(0.5), atol=1e-14, check_dtype=False
         )
 
     def test_cos(self):
-        assert_allclose(np.cos(0.5), cos(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.cos(0.5).item(), cos(0.5), atol=1e-14, check_dtype=False)
 
     def test_cosh(self):
-        assert_allclose(np.cosh(0.5), cosh(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.cosh(0.5).item(), cosh(0.5), atol=1e-14, check_dtype=False)
 
     def test_deg2rad(self):
-        assert_allclose(np.deg2rad(0.5), deg2rad(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.deg2rad(0.5).item(), deg2rad(0.5), atol=1e-14, check_dtype=False)
 
     def test_degrees(self):
-        assert_allclose(np.degrees(0.5), degrees(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.degrees(0.5).item(), degrees(0.5), atol=1e-14, check_dtype=False)
 
     def test_exp(self):
-        assert_allclose(np.exp(0.5), exp(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.exp(0.5).item(), exp(0.5), atol=1e-14, check_dtype=False)
 
     def test_exp2(self):
-        assert_allclose(np.exp2(0.5), exp2(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.exp2(0.5).item(), exp2(0.5), atol=1e-14, check_dtype=False)
 
     def test_expm1(self):
-        assert_allclose(np.expm1(0.5), expm1(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.expm1(0.5).item(), expm1(0.5), atol=1e-14, check_dtype=False)
 
     def test_fabs(self):
-        assert_allclose(np.fabs(0.5), fabs(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.fabs(0.5).item(), fabs(0.5), atol=1e-14, check_dtype=False)
 
     def test_floor(self):
-        assert_allclose(np.floor(0.5), floor(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.floor(0.5).item(), floor(0.5), atol=1e-14, check_dtype=False)
 
     def test_isfinite(self):
-        assert_allclose(np.isfinite(0.5), isfinite(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.isfinite(0.5).item(), isfinite(0.5), atol=1e-14, check_dtype=False)
 
     def test_isinf(self):
-        assert_allclose(np.isinf(0.5), isinf(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.isinf(0.5).item(), isinf(0.5), atol=1e-14, check_dtype=False)
 
     def test_isnan(self):
-        assert_allclose(np.isnan(0.5), isnan(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.isnan(0.5).item(), isnan(0.5), atol=1e-14, check_dtype=False)
 
     def test_log(self):
-        assert_allclose(np.log(0.5), log(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.log(0.5).item(), log(0.5), atol=1e-14, check_dtype=False)
 
     def test_log10(self):
-        assert_allclose(np.log10(0.5), log10(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.log10(0.5).item(), log10(0.5), atol=1e-14, check_dtype=False)
 
     def test_log1p(self):
-        assert_allclose(np.log1p(0.5), log1p(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.log1p(0.5).item(), log1p(0.5), atol=1e-14, check_dtype=False)
 
     def test_log2(self):
-        assert_allclose(np.log2(0.5), log2(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.log2(0.5).item(), log2(0.5), atol=1e-14, check_dtype=False)
 
     def test_logical_not(self):
         assert_allclose(
-            np.logical_not(0.5), logical_not(0.5), atol=1e-14, check_dtype=False
+            np.logical_not(0.5).item(), logical_not(0.5), atol=1e-14, check_dtype=False
         )
 
     def test_negative(self):
-        assert_allclose(np.negative(0.5), negative(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.negative(0.5).item(), negative(0.5), atol=1e-14, check_dtype=False)
 
     def test_positive(self):
-        assert_allclose(np.positive(0.5), positive(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.positive(0.5).item(), positive(0.5), atol=1e-14, check_dtype=False)
 
     def test_rad2deg(self):
-        assert_allclose(np.rad2deg(0.5), rad2deg(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.rad2deg(0.5).item(), rad2deg(0.5), atol=1e-14, check_dtype=False)
 
     def test_radians(self):
-        assert_allclose(np.radians(0.5), radians(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.radians(0.5).item(), radians(0.5), atol=1e-14, check_dtype=False)
 
     def test_reciprocal(self):
         assert_allclose(
-            np.reciprocal(0.5), reciprocal(0.5), atol=1e-14, check_dtype=False
+            np.reciprocal(0.5).item(), reciprocal(0.5), atol=1e-14, check_dtype=False
         )
 
     def test_rint(self):
-        assert_allclose(np.rint(0.5), rint(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.rint(0.5).item(), rint(0.5), atol=1e-14, check_dtype=False)
 
     def test_sign(self):
-        assert_allclose(np.sign(0.5), sign(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.sign(0.5).item(), sign(0.5), atol=1e-14, check_dtype=False)
 
     def test_signbit(self):
-        assert_allclose(np.signbit(0.5), signbit(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.signbit(0.5).item(), signbit(0.5), atol=1e-14, check_dtype=False)
 
     def test_sin(self):
-        assert_allclose(np.sin(0.5), sin(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.sin(0.5).item(), sin(0.5), atol=1e-14, check_dtype=False)
 
     def test_sinh(self):
-        assert_allclose(np.sinh(0.5), sinh(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.sinh(0.5).item(), sinh(0.5), atol=1e-14, check_dtype=False)
 
     def test_sqrt(self):
-        assert_allclose(np.sqrt(0.5), sqrt(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.sqrt(0.5).item(), sqrt(0.5), atol=1e-14, check_dtype=False)
 
     def test_square(self):
-        assert_allclose(np.square(0.5), square(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.square(0.5).item(), square(0.5), atol=1e-14, check_dtype=False)
 
     def test_tan(self):
-        assert_allclose(np.tan(0.5), tan(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.tan(0.5).item(), tan(0.5), atol=1e-14, check_dtype=False)
 
     def test_tanh(self):
-        assert_allclose(np.tanh(0.5), tanh(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.tanh(0.5).item(), tanh(0.5), atol=1e-14, check_dtype=False)
 
     def test_trunc(self):
-        assert_allclose(np.trunc(0.5), trunc(0.5), atol=1e-14, check_dtype=False)
+        assert_allclose(np.trunc(0.5).item(), trunc(0.5), atol=1e-14, check_dtype=False)
 
 
 if __name__ == "__main__":

--- a/torch/_numpy/_ndarray.py
+++ b/torch/_numpy/_ndarray.py
@@ -471,6 +471,8 @@ class ndarray:
         return self.tensor.__dlpack_device__()
 
 
+# ### array(...) helpers
+
 def _tolist(obj):
     """Recursively convert tensors into lists."""
     a1 = []
@@ -506,8 +508,8 @@ def array(obj, dtype=None, *, copy=True, order="K", subok=False, ndmin=0, like=N
         return obj
 
     # lists of ndarrays: [1, [2, 3], ndarray(4)] convert to lists of lists
-    if isinstance(obj, (list, tuple)):
-        obj = _tolist(obj)
+ #   if isinstance(obj, (list, tuple)):
+ #       obj = _tolist(obj)
 
     # is obj an ndarray already?
     if isinstance(obj, ndarray):


### PR DESCRIPTION
Fix dynamo compilation of nested numpy arrays. Repro:

```
import torch
import numpy as np

def func():
    x = np.array([1, 2, 3])
    return np.array([np.sin(x), np.cos(x)])

print(func())
o_func = torch.compile(fullgraph=True)(func)
print(o_func())
```

fails on main with

```
...
    raise Unsupported(msg)
torch._dynamo.exc.Unsupported: running call_function <Wrapped function <original array>>(*([FakeTensor(..., size=(3,), dtype=torch.float64), FakeTensor(..., size=(3,), dtype=torch.float64)],), **{})
```

This PR delegates these cases to `torch.stack` instead of `torch.as_tensor`.


cc @mruberry @rgommers @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng