### PR TITLE
[HighOrderOp] allow aliasing a variable from outer scope in higher order op

### DIFF
--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -1545,6 +1545,11 @@ def forward(self):
             3,
             return_graph=True,
         )
+
+        # Dynamic shapes produce a slightly different graph.
+        if check_dynamic_shape_capture():
+            return
+
         self.assertExpectedInline(
             actual_graph,
             """\

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -1518,6 +1518,56 @@ def forward(self):
             },
         )
 
+    def test_wrap_allow_local_assign_in_body_fn(self):
+        def f(arg1, arg2):
+            def inner_f(arg1, arg2):
+                a = arg1
+                b = arg2
+                ret = []
+                for x in a:
+                    ret.append(x + 1)
+                for x in b:
+                    ret.append(x + 1)
+                return ret
+
+            return wrap(inner_f, arg1, arg2)
+
+        x = torch.ones(3)
+
+        def my_args_generator():
+            yield [x], [x.sin()]
+            yield (x,), (x.sin(),)
+
+        actual_graph = self._test_wrap_simple(
+            f,
+            my_args_generator(),
+            3,
+            3,
+            return_graph=True,
+        )
+        self.assertExpectedInline(
+            actual_graph,
+            """\
+class GraphModule(torch.nn.Module):
+    def forward(self, L_arg1_0_ : torch.Tensor, L_arg2_0_ : torch.Tensor):
+        l_arg1_0_ = L_arg1_0_
+        l_arg2_0_ = L_arg2_0_
+
+        wrap_body_0 = self.wrap_body_0
+        wrap = torch._higher_order_ops.wrap.wrap(wrap_body_0, l_arg1_0_, l_arg2_0_);  wrap_body_0 = l_arg1_0_ = l_arg2_0_ = None
+        getitem = wrap[0]
+        getitem_1 = wrap[1];  wrap = None
+        return (getitem, getitem_1)
+
+    class GraphModule(torch.nn.Module):
+        def forward(self, l_arg1_0_, l_arg2_0_):
+            add = l_arg1_0_ + 1;  l_arg1_0_ = None
+
+            add_1 = l_arg2_0_ + 1;  l_arg2_0_ = None
+            return (add, add_1)
+""",
+        )
+
     def test_capture_global_num(self):
         def f(x):
             return wrap(lambda x: x + global_num, x)
@@ -1709,9 +1759,9 @@ class GraphModule(torch.nn.Module):
 
     class GraphModule(torch.nn.Module):
         def forward(self, l_x_):
-            child = l_x_.sin()
-            child_1 = l_x_.cos();  l_x_ = None
-            return (child, child_1)
+            sin = l_x_.sin()
+            cos = l_x_.cos();  l_x_ = None
+            return (sin, cos)
 """,
         )
 
@@ -1744,8 +1794,8 @@ class GraphModule(torch.nn.Module):
 
     class GraphModule(torch.nn.Module):
         def forward(self, l_x_):
-            child = -l_x_;  l_x_ = None
-            return (child,)
+            neg = -l_x_;  l_x_ = None
+            return (neg,)
 """,
         )
 
@@ -2907,14 +2957,11 @@ class GraphModule(torch.nn.Module):
 
     class GraphModule(torch.nn.Module):
         def forward(self, select, select_1):
-            child = select
-            child_1 = select_1
-
-            select_2 = child.select(1, 0)
-            select_3 = child_1.select(1, 0)
+            select_2 = select.select(1, 0)
+            select_3 = select_1.select(1, 0)
             vmap_body_0 = self.vmap_body_0
             vmap_proxy = torch.func.vmap(vmap_body_0, (1, 1), 0, 'error');  vmap_body_0 = None
-            call = vmap_proxy.__call__(child, child_1);  vmap_proxy = child = child_1 = None
+            call = vmap_proxy.__call__(select, select_1);  vmap_proxy = select = select_1 = None
             return call
 
         class GraphModule(torch.nn.Module):
@@ -2957,12 +3004,10 @@ class GraphModule(torch.nn.Module):
 
     class GraphModule(torch.nn.Module):
         def forward(self, select, l_x_):
-            child = select
-
-            select_1 = child.select(0, 0)
+            select_1 = select.select(0, 0)
             vmap_body_0 = self.vmap_body_0
             vmap_proxy = torch.func.vmap(vmap_body_0, (0, None), 0, 'error');  vmap_body_0 = None
-            call = vmap_proxy.__call__(child, l_x_);  vmap_proxy = child = l_x_ = None
+            call = vmap_proxy.__call__(select, l_x_);  vmap_proxy = select = l_x_ = None
             return call
 
         class GraphModule(torch.nn.Module):

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -50,6 +50,7 @@ from .bytecode_transformation import (
 )
 from .code_context import code_context
 from .codegen import PyCodegen
+from .current_scope_id import current_scope_id
 from .exc import ArgsMismatchError, BackendCompilerFailed, unimplemented, Unsupported
 from .funcname_cache import get_funcname
 from .guards import GuardBuilder
@@ -72,7 +73,13 @@ from .utils import (
     LazyString,
     proxy_args_kwargs,
 )
-from .variables.base import is_side_effect_safe, MutableLocal, typestr, VariableTracker
+from .variables.base import (
+    _is_top_level_scope,
+    is_side_effect_safe,
+    MutableLocal,
+    typestr,
+    VariableTracker,
+)
 from .variables.builder import VariableBuilder, wrap_fx_proxy
 from .variables.builtin import BuiltinVariable
 from .variables.constant import ConstantVariable, EnumVariable
@@ -813,7 +820,11 @@ class InstructionTranslatorBase(Checkpointable[InstructionTranslatorGraphState])
     def STORE_FAST(self, inst):
         loaded_vt = self.pop()
         name = inst.argval
-        loaded_vt = loaded_vt.rename(self, name)
+        # Only rename at the top-level scope, this is to avoid the confusion between
+        # mutating a variable vs renaming it (e.g. a = b) during speculating a higher order op,
+        # where mutation is prohibited and it's difficult to differentiate it with renaming.
+        if _is_top_level_scope(current_scope_id()):
+            loaded_vt = loaded_vt.rename(self, name)
         self.symbolic_locals[name] = loaded_vt
 
     def DELETE_FAST(self, inst):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #112537

Fixes #112169

This PR follows voz's idea of disabling rename inside higher order operator body to avoid the confusion between renaming and mutating, where we'd like to allow rename and forbid mutation. Specifically, the confusion is because rename creates a new variable tracker and calls replace_all for MutableLocal. We either have to 1. look at the fields of the variable tracker to determine whether it's just a name change or 2. pass some information into replace_all and telling it it's a rename op so don't check for side-effects. Both approach seems undesirable, or 3. make rename mutate the user_code_variable_name for the variable tracker (note that: we've been doing this for MutableSideEffects). All approaches seem undesirable.

We end up disabling rename if dynamo is speculating inside a higher order operator's body.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @zou3519