### PR TITLE
[Trivial change] Remove duplicate line in freezing.py

### DIFF
--- a/torch/_inductor/freezing.py
+++ b/torch/_inductor/freezing.py
@@ -18,8 +18,6 @@ from torch._inductor.fx_passes.post_grad import view_to_reshape
 from . import config
 
 aten = torch.ops.aten
-
-aten = torch.ops.aten
 prims = torch.ops.prims
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
## Description

`aten = torch.ops.aten` was being called twice.
Removed one assignment in this PR.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler