### PR TITLE
[c10d] print NCCL_SUFFIX in NCCL version log at PG init

### DIFF
--- a/torch/csrc/distributed/c10d/NCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.cpp
@@ -48,6 +48,12 @@ std::string getNcclVersion() {
           version % (ncclMajor * majorBase + ncclMinor * minorBase);
       versionString = std::to_string(ncclMajor) + "." +
           std::to_string(ncclMinor) + "." + std::to_string(ncclPatch);
+#ifdef NCCL_SUFFIX
+      const auto ncclSuffix = std::string(NCCL_SUFFIX);
+      if (ncclSuffix.length()) {
+        versionString += "." + ncclSuffix;
+      }
+#endif
     }
   });
 


### PR DESCRIPTION
Summary: See title

Test Plan:
- Build with NCCL-EXP that defines NCCL_SUFFIX "meta-exp"
output:
```
I1031 16:04:01.328174 611521 ProcessGroupNCCL.cpp:918] [Rank 1] ProcessGroupNCCL initialization options: NCCL version: 2.18.3-meta-exp, NCCL_ASYNC_ERROR_HANDLING: 3, NCCL_DESYNC_D    EBUG: 0, NCCL_ENABLE_TIMING: 0, NCCL_BLOCKING_WAIT: 0, TIMEOUT(ms): 1800000, USE_HIGH_PRIORITY_STREAM: 0, TORCH_DISTRIBUTED_DEBUG: OFF, NCCL_DEBUG: INFO, ID=140577310728192
```

- Build with default NCCL with empty NCCL_SUFFIX
output:
```
I1031 20:35:45.665733 https://github.com/pytorch/pytorch/commit/2360419b12d2cc156c51fd81a666c55fa376e389 ProcessGroupNCCL.cpp:918] [Rank 1] ProcessGroupNCCL initialization options: NCCL version: 2.18.3, NCCL_ASYNC_ERROR_HANDLING: 3,...
```

Differential Revision: D50863335


