### PR TITLE
Workaround double-free bug in GCC 12+

### DIFF
--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -292,11 +292,11 @@ PyObject* map_warning_to_python_type(const c10::Warning& warning) {
 /// See NOTE [ Conversion Cpp Python Warning ] for noexcept justification
 /// NOLINTNEXTLINE(bugprone-exception-escape)
 PyWarningHandler::~PyWarningHandler() noexcept(false) {
-  c10::WarningUtils::set_warning_handler(prev_handler_);
   process_warnings();
 }
 
 void PyWarningHandler::process_warnings() {
+  c10::WarningUtils::set_warning_handler(prev_handler_);
   auto& warning_buffer = internal_handler_.warning_buffer_;
 
   if (!warning_buffer.empty()) {

--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -293,6 +293,10 @@ PyObject* map_warning_to_python_type(const c10::Warning& warning) {
 /// NOLINTNEXTLINE(bugprone-exception-escape)
 PyWarningHandler::~PyWarningHandler() noexcept(false) {
   c10::WarningUtils::set_warning_handler(prev_handler_);
+  process_warnings();
+}
+
+void PyWarningHandler::process_warnings() {
   auto& warning_buffer = internal_handler_.warning_buffer_;
 
   if (!warning_buffer.empty()) {


### PR DESCRIPTION
Avoid a use-after free caused by a bug introduced in GCC 12: In `wrap_pybind_function` the destructor of `PyWarningHandler` may throw triggering the bug in GCC.
Avoid this by storing the result in a temporary, handling possible warnings and returning the temporary (which will likely be elided by NRVO).

To avoid duplicating the code replace `gil_scoped_release` by the new `conditional_gil_scoped_release` as the `void`-return case must be handled separately.

See #112383 for a description of the bug.

Note that this is not a full fix but improves the situation by making many instances of JIT generated code with `with_pytorch_error_handling = True` set much safer on affected compilers