### PR TITLE
[dynamo] Fix nested torch function mode not setting correct value on exiting

### DIFF
--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -222,7 +222,7 @@ class TorchFunctionDisableVariable(ContextWrappingVariable):
     def create(tx, **kwargs):
         var = TorchFunctionDisableVariable(
             target_values=[False],
-            initial_values=[torch._C._is_torch_function_enabled()],
+            initial_values=[tx.output.torch_function_enabled],
             **kwargs,
         )
         # mlazos: I think this is here to make sure we don't reinvoke on clone()


### PR DESCRIPTION
Shold exit to the dynamo stubbed value, not the real value, as the real value is never mutated.

Fixes https://github.com/pytorch/pytorch/issues/112620


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng