### PR TITLE
[Kineto] Initialize libkineto profilers during torch init process during pybind set-up

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -18,7 +18,7 @@ import torch
 
 from torch.testing import make_tensor
 from torch.testing._internal.common_utils import \
-    (IS_FBCODE, IS_JETSON, IS_MACOS, IS_SANDCASTLE, IS_WINDOWS, TestCase, run_tests, slowTest,
+    (IS_FBCODE, IS_JETSON, IS_LINUX, IS_MACOS, IS_SANDCASTLE, IS_WINDOWS, TestCase, run_tests, slowTest,
      parametrize, subtest, instantiate_parametrized_tests, dtype_name, TEST_WITH_ROCM, decorateIf)
 from torch.testing._internal.common_device_type import \
     (PYTORCH_TESTING_DEVICE_EXCEPT_FOR_KEY, PYTORCH_TESTING_DEVICE_ONLY_FOR_KEY, dtypes,
@@ -2290,6 +2290,15 @@ class TestImports(TestCase):
         ]
         out = self._check_python_output("; ".join(commands))
         self.assertEqual(out.strip(), expected)
+
+    @unittest.skipIf(TEST_WITH_ROCM, "On-demand profiling early init not supported on ROCm")
+    @unittest.skipIf(not IS_LINUX, "On-demand profiling not supported outside of Linux")
+    def test_libkineto_profiler_is_initialized(self) -> None:
+        # Check that the profiler is initialized at import time.
+        out = self._check_python_output("""import sys; import torch;
+print(torch._C._autograd._isProfilerInitialized() if torch._C._autograd._is_use_kineto_defined() else 'True')
+""")
+        self.assertEqual(out.strip(), "True")
 
 class TestOpInfos(TestCase):
     def test_sample_input(self) -> None:

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -35,6 +35,10 @@
 #include <torch/csrc/utils/python_raii.h>
 #include <torch/csrc/utils/python_torch_function_mode.h>
 
+#ifdef USE_KINETO
+#include <libkineto.h>
+#endif
+
 #include <set>
 #include <unordered_set>
 #include <utility>
@@ -129,6 +133,30 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
   ParameterClass = PyObject_GetAttrString(parameter_module, "Parameter");
   if (!ParameterClass)
     return nullptr;
+
+#if defined(USE_KINETO) && defined(__linux__) && !defined(USE_ROCM)
+  // Initialize the Kineto profilers, if they have not already.
+  // DO NOT REMOVE, this is needed for on-demand profiling.
+  if (!libkineto::api().isProfilerRegistered()) {
+    libkineto_init(
+        /*cpuOnly=*/!(at::hasCUDA() || at::hasXPU() || at::hasMTIA()),
+        /*logOnError=*/true);
+    libkineto::api().suppressLogMessages();
+  }
+  libkineto::api().initProfilerIfRegistered();
+
+  // Used for unit test to check profiler was initialized.
+  m.def("_isProfilerInitialized", []() {
+    return libkineto::api().isProfilerInitialized();
+  });
+#endif
+
+  m.def("_is_use_kineto_defined", []() -> bool {
+#ifdef USE_KINETO
+    return true;
+#endif
+    return false;
+  });
 
   py::class_<LegacyEvent>(m, "ProfilerEvent")
       .def("kind", &LegacyEvent::kindStr)
@@ -315,18 +343,19 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
   });
 
   m.def("_supported_activities", []() {
-    std::set<ActivityType> activities{ActivityType::CPU};
+    std::set<torch::profiler::impl::ActivityType> activities{
+        torch::profiler::impl::ActivityType::CPU};
 #if defined(USE_KINETO) && \
     (!defined(LIBKINETO_NOCUPTI) || !defined(LIBKINETO_NOROCTRACER))
     if (at::getNumGPUs() > 0) {
-      activities.insert(ActivityType::CUDA);
+      activities.insert(torch::profiler::impl::ActivityType::CUDA);
     }
 #elif defined(USE_KINETO)
     if (at::hasXPU()) {
-      activities.insert(ActivityType::XPU);
+      activities.insert(torch::profiler::impl::ActivityType::XPU);
     }
     if (at::hasMTIA()) {
-      activities.insert(ActivityType::MTIA);
+      activities.insert(torch::profiler::impl::ActivityType::MTIA);
     }
 #endif
     return activities;

--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -361,6 +361,8 @@ void addMetadataJson(const std::string& key, const std::string& value) {
 
 void profilerStep() {
 #ifdef USE_KINETO
+  libkineto::api().initProfilerIfRegistered();
+
   if (libkineto::api().isProfilerInitialized()) {
     libkineto::api().activityProfiler().step();
   } else {


### PR DESCRIPTION
Summary:
We are planning to lazily initialize CUPTI when profiling is actually performed. Therefore, we need to remove profiler init dependency on CUPTI Callbacks' RESOURCE_CONTEXT_CREATED.

Instead, we can initialize the profilers during torch profiler pybind, ie. THPAutograd_initExtension() and lazily in profilerStep().

Test Plan:
CI and ran internally, see internal diff logs.

Pulled By: aaronenyeshi


