### PR TITLE
Fix scope name when parent scope is empty for torch.onnx.export

### DIFF
--- a/torch/csrc/jit/passes/onnx/naming.cpp
+++ b/torch/csrc/jit/passes/onnx/naming.cpp
@@ -24,7 +24,7 @@ std::string nameFromRoot(
     return out;
   }
   auto parent = scope->parent();
-  while (!parent->isRoot()) {
+  while (isCompatibleScope(parent)) {
     out = std::string((*name_func)(parent)).append(layer_separator).append(out);
     parent = parent->parent();
   }


### PR DESCRIPTION
Previous to this PR, we only checked TorchScript nodes for scope compatibility, skipping their parent's scope reference check.
This PR fixes adds a check not only for the node being traversed, but its parents as well