### PR TITLE
[Not ready for review] Restart analysis on graph break prototype

### DIFF
--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -133,6 +133,7 @@ class CodeLocation(NamedTuple):
     filename: str
     lineno: int
     funcname: Optional[str]
+    instr_ptr: int
 
 
 compile_subgraph_loc = None
@@ -409,7 +410,10 @@ def break_graph_if_unsupported(*, push):
             global compile_subgraph_loc, compile_subgraph_reason
 
             code_loc = CodeLocation(
-                self.f_code.co_filename, self.lineno, self.f_code.co_name
+                self.f_code.co_filename,
+                self.lineno,
+                self.f_code.co_name,
+                self.instruction_pointer,
             )
             if not compile_subgraph_loc == code_loc:
                 state = self.copy_graphstate()


### PR DESCRIPTION
Prototype that records which instruction causes a graph break. Restarts analysis on graph break and preemptively compiles in the second analysis pass when the previously recorded instruction is reached

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng