### PR TITLE
[inductor][fx pass] Fix a split cat bug in the pre grad

### DIFF
--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -1126,6 +1126,8 @@ def merge_getitem_cat(match: Match, split_sections: List[int], dim: int):
             indices = []
             for arg in cat_user.args[0]:
                 indices.append(arg.args[1])
+            # indices may not be necessarily sorted, we sort them first
+            indices.sort()
             # update the arg of cat user, only keep the first getitem
             cat_user.update_arg(0, cat_user.args[0][0])
             # calculate the fused tensor sizes in the indices


### PR DESCRIPTION
Summary: blue reels vdd v3 has unit test failure, we fix the bug

Test Plan:
```
buck2 test 'fbcode//mode/opt' fbcode//pytorch/benchmark/fb/test_gpu:run_test_gpu -- --exact 'pytorch/benchmark/fb/test_gpu:run_test_gpu - test_train_blue_reels_vdd_v3_inductor_accuracy (pytorch.benchmark.fb.test_gpu.test_gpu.TestBenchmarkFbGpu)'
```
Test UI: https://www.internalfb.com/intern/testinfra/testrun/13229323914259182
Network: Up: 2.5MiB  Down: 8.3MiB  (reSessionID-b3362362-c80a-4ac2-8332-bc1321aaf0bd)
Jobs completed: 6. Time elapsed: 5:13.2s.
Tests finished: Pass 1. Fail 0. Fatal 0. Skip 0. Build failure 0

```
buck2 test 'fbcode//mode/opt' fbcode//pytorch/benchmark/fb/test_gpu:run_test_gpu -- --exact 'pytorch/benchmark/fb/test_gpu:run_test_gpu - test_train_blue_reels_vdd_v3_inductor_speedup (pytorch.benchmark.fb.test_gpu.test_gpu.TestBenchmarkFbGpu)'
```
Buck UI: https://www.internalfb.com/buck2/aa3031a9-3f1b-4f42-a78c-decbf2beb14f
Test UI: https://www.internalfb.com/intern/testinfra/testrun/4785074810906355
Network: Up: 1.3GiB  Down: 40MiB  (reSessionID-801ddf16-ff5d-4135-9758-ff286d1d59aa)
Jobs completed: 69. Time elapsed: 10:12.4s.
Cache hits: 10%. Commands: 61 (cached: 6, remote: 4, local: 51)
Tests finished: Pass 1. Fail 0. Fatal 0. Skip 0. Build failure 0


Differential Revision: D50901626




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler