### PR TITLE
Adds broadcast to functional collectives

### DIFF
--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -77,13 +77,8 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
                     torch.ones(4, 4, device="cuda") if self.rank == 0 else torch.zeros(4,4, device="cuda"),
                     0
                 )
-            print(f"{inputs()=}")
-            eager_out = example(*inputs())
-            print(f"{eager_out=}")
             compiled_func = compile(example, inputs())
             compiled_out = compiled_func(*inputs())
-            print(f"{compiled_out=}")
-            self.assertTrue(same(torch.ones(4,4, device="cuda"), eager_out))
             self.assertTrue(same(torch.ones(4,4, device="cuda"), compiled_out))
 
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")

--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -72,13 +72,12 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
                 example,
                 **self.get_world_trs(),
             )
-            def inputs():
-                return (
+            inputs = (
                     torch.ones(4, 4, device="cuda") if self.rank == 0 else torch.zeros(4,4, device="cuda"),
                     0
                 )
-            compiled_func = compile(example, inputs())
-            compiled_out = compiled_func(*inputs())
+            compiled_func = compile(example, inputs)
+            compiled_out = compiled_func(*inputs)
             self.assertTrue(same(torch.ones(4,4, device="cuda"), compiled_out))
 
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")

--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -52,6 +52,44 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
     @skip_if_lt_x_gpu(2)
     # TODO: somehow inductor bg compile threads are causing hangs at exit with distributed work dtor
     @patch.object(torch._inductor.config, "compile_threads", 1)
+    def test_broadcast_inductor(self):
+        """
+        Testing if broadcast works correctly when using inductor
+        """
+
+        def example(tensor, src, *, tag, ranks, group_size):
+            res = torch.ops.c10d_functional.broadcast(tensor, src, tag, ranks, group_size)
+            res = torch.ops.c10d_functional.wait_tensor(res)
+            return res
+
+        def compile(func, example_inputs):
+            graph = make_fx(func)(*example_inputs)
+            return inductor_compile_fx(graph, example_inputs)
+
+        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+
+            example = functools.partial(
+                example,
+                **self.get_world_trs(),
+            )
+            def inputs():
+                return (
+                    torch.ones(4, 4, device="cuda") if self.rank == 0 else torch.zeros(4,4, device="cuda"),
+                    0
+                )
+            print(f"{inputs()=}")
+            eager_out = example(*inputs())
+            print(f"{eager_out=}")
+            compiled_func = compile(example, inputs())
+            compiled_out = compiled_func(*inputs())
+            print(f"{compiled_out=}")
+            self.assertTrue(same(torch.ones(4,4, device="cuda"), eager_out))
+            self.assertTrue(same(torch.ones(4,4, device="cuda"), compiled_out))
+
+    @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
+    @skip_if_lt_x_gpu(2)
+    # TODO: somehow inductor bg compile threads are causing hangs at exit with distributed work dtor
+    @patch.object(torch._inductor.config, "compile_threads", 1)
     def test_allreduce_inductor(self):
         """
         This is matmul/cat/allreduce is a pattern we aim to optimize.

--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -72,13 +72,17 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
                 example,
                 **self.get_world_trs(),
             )
+            t = torch.randn(4, 4, device="cuda")
             inputs = (
-                    torch.ones(4, 4, device="cuda") if self.rank == 0 else torch.zeros(4,4, device="cuda"),
-                    0
-                )
+                t if self.rank == 0 else torch.zeros(4,4, device="cuda"),
+                0
+            )
+            eager_out = example(*inputs)
+            self.assertTrue(same(t, eager_out))
+
             compiled_func = compile(example, inputs)
             compiled_out = compiled_func(*inputs)
-            self.assertTrue(same(torch.ones(4,4, device="cuda"), compiled_out))
+            self.assertTrue(same(eager_out, compiled_out))
 
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
     @skip_if_lt_x_gpu(2)

--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -74,7 +74,7 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
             )
             t = torch.randn(4, 4, device="cuda")
             inputs = (
-                t if self.rank == 0 else torch.zeros(4,4, device="cuda"),
+                t if self.rank == 0 else torch.zeros(4, 4, device="cuda"),
                 0
             )
             eager_out = example(*inputs)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6675,7 +6675,6 @@ class MultiOutputNoSizeAssert(MultiOutput):
 
 
 class Broadcast(InPlaceCollectiveKernel):
-
     def __init__(self, layout, inputs, constant_args, src):
         super().__init__(layout, inputs, constant_args)
         self.src = src

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6687,14 +6687,13 @@ class Broadcast(InPlaceCollectiveKernel):
         cls, x: "TensorBox", src: int, tag: str, ranks: List[int], group_size: int
     ):
         inplace_inputs = cls.wrap_inputs_as_inplace([x])
-        layout = MutationLayout(inplace_inputs[0])
-
-        _ = Broadcast(
-            layout=layout,
+        packed = Broadcast(
+            layout=NoneLayout(inplace_inputs[0].get_device()),  # type: ignore[arg-type]
             inputs=inplace_inputs,
             constant_args=[tag, ranks, group_size],
             src=src,
         )
+        mark_node_as_mutating(packed, inplace_inputs[0])
         return inplace_inputs[0]
 
     def codegen_collective(self, wrapper, output_name, input_names):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6682,6 +6682,9 @@ class Broadcast(InPlaceCollectiveKernel):
     def get_mutation_names(self):
         return [self.inputs[0].get_name()]
 
+    def get_unbacked_symbol_defs(self):
+        return {}
+
     @classmethod
     def create(
         cls, x: "TensorBox", src: int, tag: str, ranks: List[int], group_size: int

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -5088,6 +5088,10 @@ try:
     def wait(input):
         return TensorBox.create(ir.Wait.create(input))
 
+    @register_lowering(c10d_functional.broadcast)
+    def broadcast(input, src, tag, ranks, group_size):
+        return ir.Broadcast.create(input, src, tag, ranks, group_size)
+
     @register_lowering(c10d_functional.all_reduce)
     def allreduce(input, reduce_op, tag, ranks, group_size):
         return ir.AllReduce.create(input, reduce_op, tag, ranks, group_size)

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -137,9 +137,6 @@ def broadcast(self: torch.Tensor, src: int, group: RANK_TYPES, tag: str = ""):
         group (ProcessGroup or List[int]): The process group to work on.
         tag (str, optional): A unique identifier for the collective. Default: empty string
     """
-    # if _are_we_tracing():
-    #     raise NotImplementedError("broadcast is not currently supported with torch.compile")
-
     tag, rankset, group_size = _expand_group(group, tag)
     tensor = torch.ops.c10d_functional.broadcast(self, src, tag, rankset, group_size)
     return _maybe_wrap_tensor(tensor)

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -137,8 +137,8 @@ def broadcast(self: torch.Tensor, src: int, group: RANK_TYPES, tag: str = ""):
         group (ProcessGroup or List[int]): The process group to work on.
         tag (str, optional): A unique identifier for the collective. Default: empty string
     """
-    if _are_we_tracing():
-        raise NotImplementedError("broadcast is not currently supported with torch.compile")
+    # if _are_we_tracing():
+    #     raise NotImplementedError("broadcast is not currently supported with torch.compile")
 
     tag, rankset, group_size = _expand_group(group, tag)
     tensor = torch.ops.c10d_functional.broadcast(self, src, tag, rankset, group_size)

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -137,6 +137,9 @@ def broadcast(self: torch.Tensor, src: int, group: RANK_TYPES, tag: str = ""):
         group (ProcessGroup or List[int]): The process group to work on.
         tag (str, optional): A unique identifier for the collective. Default: empty string
     """
+    if _are_we_tracing():
+        raise NotImplementedError("broadcast is not currently supported with torch.compile")
+
     tag, rankset, group_size = _expand_group(group, tag)
     tensor = torch.ops.c10d_functional.broadcast(self, src, tag, rankset, group_size)
     return _maybe_wrap_tensor(tensor)

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -1,15 +1,15 @@
-import warnings
 import sys
+import warnings
+from typing import cast, List, Optional, Tuple, TYPE_CHECKING, Union
+
 import torch
 import torch.distributed as dist
 import torch.distributed.distributed_c10d as c10d
-from typing import Tuple, Union, List, Optional, cast, TYPE_CHECKING
+from torch._custom_ops import impl_abstract
+from torch.fx.experimental.proxy_tensor import get_innermost_proxy_mode
+
 from . import _functional_collectives_impl as fun_col_impl
 from ._functional_collectives_impl import _register_tensor_wrapper
-from torch.fx.experimental.proxy_tensor import (
-    get_innermost_proxy_mode,
-)
-from torch._custom_ops import impl_abstract
 
 try:
     from torch.utils._pytree.api.cxx import tree_map_only
@@ -18,12 +18,16 @@ except ImportError:
 
 
 if torch._running_with_deploy():
+
     def is_torchdynamo_compiling():
         """Can't import torchdynamo in torchdeploy builds currently."""
         return False
+
 else:
     try:
-        from torch._dynamo.external_utils import is_compiling as is_torchdynamo_compiling
+        from torch._dynamo.external_utils import (
+            is_compiling as is_torchdynamo_compiling,
+        )
     except Exception:
         warnings.warn(
             "Unable to import torchdynamo util `is_torchdynamo_compiling`, so won't support torchdynamo correctly"
@@ -31,6 +35,7 @@ else:
 
         def is_torchdynamo_compiling():
             return False
+
 
 """
 New traceable, functional collectives.
@@ -88,7 +93,13 @@ Functional collectives can accept any of these types to describe the ranks parti
 
 The different types will be desugared to a canonical format
 """
-RANK_TYPES = Union[List[int], List[List[int]], dist.ProcessGroup, "dist._tensor.DeviceMesh", Tuple["dist._tensor.DeviceMesh", int]]
+RANK_TYPES = Union[
+    List[int],
+    List[List[int]],
+    dist.ProcessGroup,
+    "dist._tensor.DeviceMesh",
+    Tuple["dist._tensor.DeviceMesh", int],
+]
 
 
 """
@@ -119,6 +130,7 @@ all_reduce(...)
                                           which issues wait_tensor() at the time of first use
 """
 
+
 def wait_tensor(tensor):
     """
     Wait on a tensor returned by the collectives ops.
@@ -126,6 +138,20 @@ def wait_tensor(tensor):
     Waiting follows device semantics, which means blocking on CPU and synchronizing streams on CUDA.
     """
     return torch.ops.c10d_functional.wait_tensor(tensor)  # type: ignore[attr-defined]
+
+
+def broadcast(self: torch.Tensor, src: int, group: RANK_TYPES, tag: str = ""):
+    """
+    Broadcasts the tensor to all processes in the given process group.
+
+    Args:
+        src (int): Source rank
+        group (ProcessGroup or List[int]): The process group to work on.
+        tag (str, optional): A unique identifier for the collective. Default: empty string
+    """
+    tag, rankset, group_size = _expand_group(group, tag)
+    tensor = torch.ops.c10d_functional.broadcast(self, src, tag, rankset, group_size)
+    return _maybe_wrap_tensor(tensor)
 
 
 def all_reduce(self: torch.Tensor, reduceOp: str, group: RANK_TYPES, tag: str = ""):
@@ -181,6 +207,7 @@ def all_gather_tensor(
         res = torch.cat(torch.chunk(res, group_size, dim=0), dim=gather_dim)
     return res
 
+
 def reduce_scatter_tensor(
     self: torch.Tensor,
     reduceOp: str,
@@ -216,7 +243,9 @@ def reduce_scatter_tensor(
     return res
 
 
-def all_reduce_coalesced(self: List[torch.Tensor], reduceOp: str, group: RANK_TYPES, tag: str = "") -> List[torch.Tensor]:
+def all_reduce_coalesced(
+    self: List[torch.Tensor], reduceOp: str, group: RANK_TYPES, tag: str = ""
+) -> List[torch.Tensor]:
     """
     Reduces a list of tensors across all machines in such a way that all get
     the final result.
@@ -238,7 +267,9 @@ def all_reduce_coalesced(self: List[torch.Tensor], reduceOp: str, group: RANK_TY
     return list(map(_maybe_wrap_tensor, tensor_list))
 
 
-def all_gather_into_tensor_coalesced(self: List[torch.Tensor], group: RANK_TYPES, tag: str = "") -> List[torch.Tensor]:
+def all_gather_into_tensor_coalesced(
+    self: List[torch.Tensor], group: RANK_TYPES, tag: str = ""
+) -> List[torch.Tensor]:
     """
     Gather a list of tensors across from all machines.
 
@@ -331,9 +362,13 @@ def all_to_all_single(
     that information and perform collective algebraic optimization. Use other forms of input for that.
     """
     if output_split_sizes is not None:
-        assert all(isinstance(size, (int, torch.SymInt)) for size in output_split_sizes), output_split_sizes
+        assert all(
+            isinstance(size, (int, torch.SymInt)) for size in output_split_sizes
+        ), output_split_sizes
     if input_split_sizes is not None:
-        assert all(isinstance(size, (int, torch.SymInt)) for size in input_split_sizes), input_split_sizes
+        assert all(
+            isinstance(size, (int, torch.SymInt)) for size in input_split_sizes
+        ), input_split_sizes
     tag, rankset, group_size = _expand_group(group, tag)
     tensor = torch.ops.c10d_functional.all_to_all_single(self, output_split_sizes, input_split_sizes, tag, rankset, group_size)  # type: ignore[attr-defined]
     return _maybe_wrap_tensor(tensor)
@@ -351,7 +386,7 @@ class AsyncCollectiveTensor(torch.Tensor):
     """
     elem: torch.Tensor
 
-    __slots__ = ['elem']
+    __slots__ = ["elem"]
 
     __torch_function__ = torch._C._disabled_torch_function_impl
 
@@ -359,10 +394,14 @@ class AsyncCollectiveTensor(torch.Tensor):
     def __new__(cls, elem: torch.Tensor):
 
         r = torch.Tensor._make_wrapper_subclass(  # type: ignore[attr-defined]
-            cls, elem.size(),
-            strides=elem.stride(), storage_offset=elem.storage_offset(),
-            dtype=elem.dtype, layout=elem.layout,
-            device=elem.device, requires_grad=False
+            cls,
+            elem.size(),
+            strides=elem.stride(),
+            storage_offset=elem.storage_offset(),
+            dtype=elem.dtype,
+            layout=elem.layout,
+            device=elem.device,
+            requires_grad=False,
         )
         r.elem = elem
         return r
@@ -425,6 +464,8 @@ class AsyncCollectiveTensor(torch.Tensor):
 """
 Utils and infrastructure for tracing support
 """
+
+
 def _expand_group(group: RANK_TYPES, tag: str = "") -> Tuple[str, List[int], int]:
     """
     _expand_group desugars the different RANK_TYPES types into a canonical format that is traceable.
@@ -439,6 +480,7 @@ def _expand_group(group: RANK_TYPES, tag: str = "") -> Tuple[str, List[int], int
     # graph_break [('torch.* op returned non-Tensor int
     # caused by 'cast_*` functions being treated as 'torch.*' ops (iiuc)
     if TYPE_CHECKING:
+
         def cast_listlistint(x):
             return cast(List[List[int]], x)
 
@@ -476,12 +518,18 @@ def _expand_group(group: RANK_TYPES, tag: str = "") -> Tuple[str, List[int], int
         group_size = len(rankset)
         tag = tag or c10d._get_group_tag(group)
     elif isinstance(group, dt.DeviceMesh):
-        assert group.ndim == 1, "Only 1D mesh is supported, pass in (DeviceMesh, int) together if mesh > 1D"
+        assert (
+            group.ndim == 1
+        ), "Only 1D mesh is supported, pass in (DeviceMesh, int) together if mesh > 1D"
         # TODO: it should run collective in the whole mesh instead of dim 0
         tag, rankset = group._dim_group_infos[0]
         group_size = len(rankset)
     elif isinstance(group, tuple):
-        if len(group) == 2 and isinstance(group[0], dt.DeviceMesh) and isinstance(group[1], int):
+        if (
+            len(group) == 2
+            and isinstance(group[0], dt.DeviceMesh)
+            and isinstance(group[1], int)
+        ):
             dmesh = group[0]
             dim = group[1]
             tag, rankset = dmesh._dim_group_infos[dim]
@@ -489,9 +537,12 @@ def _expand_group(group: RANK_TYPES, tag: str = "") -> Tuple[str, List[int], int
         else:
             raise ValueError("Invalid tuple for group must be (DeviceMesh, int)")
     else:
-        raise ValueError("Invalid type for group, must be one of List, Processgroup, DeviceMesh or (DeviceMesh, int).")
+        raise ValueError(
+            "Invalid type for group, must be one of List, Processgroup, DeviceMesh or (DeviceMesh, int)."
+        )
 
     return (tag, rankset, group_size)
+
 
 def _are_we_tracing() -> bool:
     if is_torchdynamo_compiling():
@@ -499,12 +550,16 @@ def _are_we_tracing() -> bool:
     # If functionalization is turned on, we are almost definitely compiling/tracing.
     # (In particular, AOTAutograd traces a model once with functionalization on
     #  but proxy tracing turned of, so this is how we detect it).
-    if torch._C._get_dispatch_mode(torch._C._TorchDispatchModeKey.FUNCTIONAL) is not None:
+    if (
+        torch._C._get_dispatch_mode(torch._C._TorchDispatchModeKey.FUNCTIONAL)
+        is not None
+    ):
         return True
     mode = get_innermost_proxy_mode()
     if mode is None:
         return False
     return mode.tracer is not None
+
 
 def _maybe_wrap_tensor(self) -> torch.Tensor:
     if _are_we_tracing():
@@ -512,6 +567,7 @@ def _maybe_wrap_tensor(self) -> torch.Tensor:
     res = AsyncCollectiveTensor(self)
     _register_tensor_wrapper(res)
     return cast(torch.Tensor, res)
+
 
 def _all_gather_into_tensor_coalesced_meta(self, tag, rankset, group_size):
     def mk_out_tensor(shard):
@@ -522,25 +578,35 @@ def _all_gather_into_tensor_coalesced_meta(self, tag, rankset, group_size):
 
     return [mk_out_tensor(t) for t in self]
 
+
 # We now register meta kernels to deal with tracing
+def _broadcast_meta(self, *args):
+    return torch.empty_like(self)
+
+
 def _all_reduce_meta(self, *args):
     return torch.empty_like(self)
 
+
 def _wait_tensor_meta(self, *args):
     return torch.empty_like(self)
+
 
 def _all_gather_into_tensor_meta(shard, tag, rankset, group_size):
     out_size = list(shard.size())
     out_size[0] *= group_size
     return shard.new_empty(out_size)
 
+
 def _reduce_scatter_tensor_meta(input, reduce_op, tag, rankset, group_size):
     out_size = list(input.size())
     out_size[0] //= group_size
     return input.new_empty(out_size)
 
+
 def _all_reduce_coalesced_meta(self, *args):
     return [torch.empty_like(t) for t in self]
+
 
 def _reduce_scatter_tensor_coalesced_meta(inputs, reduceOp, tag, rankset, group_size):
     def mk_out_tensor(input):
@@ -551,12 +617,15 @@ def _reduce_scatter_tensor_coalesced_meta(inputs, reduceOp, tag, rankset, group_
 
     return [mk_out_tensor(t) for t in inputs]
 
+
 # NB: We often say all_to_all has dynamic output size, but this is not
 # technically true: instead, what typically happens is you manually
 # communicate the output_split_sizes ahead of time (which is dynamic),
 # but then you pass those sizes explicitly, and the all to all itself
 # isn't dynamic, it just follows the specified output splits
-def _all_to_all_single_meta(input, output_split_sizes, input_split_sizes, tag, rankset, group_size):
+def _all_to_all_single_meta(
+    input, output_split_sizes, input_split_sizes, tag, rankset, group_size
+):
     if output_split_sizes is None:
         return input.new_empty(input.size())
     else:
@@ -566,10 +635,12 @@ def _all_to_all_single_meta(input, output_split_sizes, input_split_sizes, tag, r
         out_size[0] = sum(output_split_sizes)
         return input.new_empty(out_size)
 
+
 def _all_gather_into_tensor_native_meta(input, group_size, group_name):
     shape = list(input.size())
     shape[0] *= group_size
     return input.new_empty(shape)
+
 
 def _all_gather_into_tensor_coalesced_native_meta(inputs, group_size, group_name):
     return [
@@ -577,10 +648,12 @@ def _all_gather_into_tensor_coalesced_native_meta(inputs, group_size, group_name
         for input in inputs
     ]
 
+
 def _reduce_scatter_tensor_native_meta(input, group_size, group_name):
     shape = list(input.size())
     shape[0] //= group_size
     return input.new_empty(shape)
+
 
 def _reduce_scatter_tensor_coalesced_native_meta(inputs, group_size, group_name):
     return [
@@ -588,8 +661,10 @@ def _reduce_scatter_tensor_coalesced_native_meta(inputs, group_size, group_name)
         for input in inputs
     ]
 
+
 def _register_ops():
     ops_defs = [
+        "broadcast(Tensor self, int src, str tag, int[] ranks, int group_size) -> Tensor",
         "all_reduce(Tensor self, str reduceOp, str tag, int[] ranks, int group_size) -> Tensor",
         "all_reduce_coalesced(Tensor[] self, str reduceOp, str tag, int[] ranks, int group_size) -> Tensor[]",
         "wait_tensor(Tensor self) -> Tensor",
@@ -602,7 +677,7 @@ def _register_ops():
 
     my_module = sys.modules[__name__]
     for op_def in ops_defs:
-        op_name = op_def[0:op_def.index('(')]
+        op_name = op_def[0 : op_def.index("(")]
         backend_impl = getattr(fun_col_impl, f"_{op_name}")
         meta_impl = getattr(my_module, f"_{op_name}_meta")
         c10_lib.define(op_def, tags=torch.Tag.pt2_compliant_tag)
@@ -619,15 +694,30 @@ if not torch._running_with_deploy():
     _register_ops()
 
     _c10_lib_impl = torch.library.Library("_c10d_functional", "IMPL")
+    # _c10_lib_impl.impl("broadcast", _broadcast_meta, "Meta")
     _c10_lib_impl.impl("all_reduce", _all_reduce_meta, "Meta")
     _c10_lib_impl.impl("all_reduce_coalesced", _all_reduce_coalesced_meta, "Meta")
     _c10_lib_impl.impl("wait_tensor", _wait_tensor_meta, "Meta")
-    _c10_lib_impl.impl("all_gather_into_tensor", _all_gather_into_tensor_native_meta, "Meta")
-    _c10_lib_impl.impl("all_gather_into_tensor_coalesced", _all_gather_into_tensor_coalesced_native_meta, "Meta")
-    _c10_lib_impl.impl("reduce_scatter_tensor", _reduce_scatter_tensor_native_meta, "Meta")
-    _c10_lib_impl.impl("reduce_scatter_tensor_coalesced", _reduce_scatter_tensor_coalesced_native_meta, "Meta")
+    _c10_lib_impl.impl(
+        "all_gather_into_tensor", _all_gather_into_tensor_native_meta, "Meta"
+    )
+    _c10_lib_impl.impl(
+        "all_gather_into_tensor_coalesced",
+        _all_gather_into_tensor_coalesced_native_meta,
+        "Meta",
+    )
+    _c10_lib_impl.impl(
+        "reduce_scatter_tensor", _reduce_scatter_tensor_native_meta, "Meta"
+    )
+    _c10_lib_impl.impl(
+        "reduce_scatter_tensor_coalesced",
+        _reduce_scatter_tensor_coalesced_native_meta,
+        "Meta",
+    )
 else:
-    warnings.warn("PyTorch Distributed functional collectives do not work with torch::deploy.")
+    warnings.warn(
+        "PyTorch Distributed functional collectives do not work with torch::deploy."
+    )
 
 
 """
@@ -639,16 +729,21 @@ the mapping dict below.
 
 These schemas intentionally match torch.distributed.distributed_c10d.* ops that we are trying to remap from
 """
+
+
 def all_gather_tensor_inplace(
     output: torch.Tensor,
     input: torch.Tensor,
     group,  # TODO add a type,
     async_op: bool = False,
     tag: str = "",
-    gather_dim: int = 0
+    gather_dim: int = 0,
 ):
-    assert not async_op, "Can't remap async version of inplace op to functional collective"
+    assert (
+        not async_op
+    ), "Can't remap async version of inplace op to functional collective"
     return output.copy_(all_gather_tensor(input, gather_dim, group, tag))
+
 
 def reduce_scatter_tensor_inplace(
     output: torch.Tensor,
@@ -659,8 +754,11 @@ def reduce_scatter_tensor_inplace(
     scatter_dim: int = 0,
     tag: str = "",
 ):
-    assert not async_op, "Can't remap async version of inplace op to functional collective"
+    assert (
+        not async_op
+    ), "Can't remap async version of inplace op to functional collective"
     return output.copy_(reduce_scatter_tensor(input, op, scatter_dim, group, tag))
+
 
 from torch.distributed.distributed_c10d import (
     all_gather_into_tensor as legacy_allgather,

--- a/torch/distributed/_functional_collectives_impl.py
+++ b/torch/distributed/_functional_collectives_impl.py
@@ -1,11 +1,10 @@
 import logging
 import warnings
 import weakref
-from typing import cast, List, Optional
-
 import torch
 import torch.distributed as dist
 import torch.distributed.distributed_c10d as c10d
+from typing import List, Optional, cast
 
 """
 Moved eager kernel implementations to a separate file partly for readability and partly as it is currently
@@ -27,7 +26,6 @@ logger = logging.getLogger(__name__)
 
 data_ptr_to_work = dict()
 work_version = 0
-
 
 class _WaitRegistration:
     def __init__(self, work):
@@ -62,10 +60,7 @@ class _WaitRegistration:
             self.wait()
         else:
             self.ptr_alias_count[ptr] -= 1
-            if (
-                self.ptr_alias_count[ptr] < 1
-                and data_ptr_to_work.get(ptr, None) == self
-            ):
+            if self.ptr_alias_count[ptr] < 1 and data_ptr_to_work.get(ptr, None) == self:
                 del data_ptr_to_work[ptr]
 
     def cleanup(self):
@@ -87,9 +82,9 @@ def _register_tensor_work(tensor_or_list, work_or_list):
             reg._register_tensor_ptr(tensor.data_ptr())
 
 
+
 def _wait_reg_dec(ptr, wait_reg):
     wait_reg.decrement_live_tensor(ptr)
-
 
 def _register_tensor_wrapper(tensor) -> None:
     global data_ptr_to_work
@@ -119,7 +114,6 @@ def _wait_tensor(tensor: torch.Tensor) -> torch.Tensor:
         wait_reg.wait()
     return tensor
 
-
 def _tensor_needs_wait(tensor: torch.Tensor) -> bool:
     """Returns true if ```tensor``` needs to be waited. Works with ACS and inner tensors."""
     if hasattr(tensor, "_get_acs_underlying_tensor"):
@@ -128,17 +122,14 @@ def _tensor_needs_wait(tensor: torch.Tensor) -> bool:
     wait_reg = data_ptr_to_work.get(data_ptr)
     return wait_reg is not None and wait_reg.work is not None
 
-
 def _outstanding_wait_count() -> int:
-    """Returns the number of outstanding work objects waiting to be waited (sic)."""
+    """ Returns the number of outstanding work objects waiting to be waited (sic). """
     return len(data_ptr_to_work)
 
-
 def _wait_all() -> None:
-    """Wait for all outstanding collectives."""
+    """ Wait for all outstanding collectives. """
     for work_reg in list(data_ptr_to_work.values()):
         work_reg.wait()
-
 
 def _str_to_reduce_op(reduceOp: str) -> dist.ReduceOp:
     reduceOp = reduceOp.upper()
@@ -154,8 +145,6 @@ Kernel implementations (for eager runtime only) - should never be traced by torc
 These functions should all be bound to dispatcher ops.  During tracing, the op itself should be
 captured in the graph and the backend should implement the op however it prefers.
 """
-
-
 def _broadcast(self, src, tag, ranks, group_size):
     group = c10d._find_or_create_pg_by_ranks_and_tag(tag, ranks, group_size)
     assert group is not None
@@ -165,7 +154,6 @@ def _broadcast(self, src, tag, ranks, group_size):
     _register_tensor_work(inplace_tensor, work)
 
     return inplace_tensor
-
 
 # TODO assert if ranks has duplicated entries
 def _all_reduce(self, reduceOp, tag, ranks, group_size):
@@ -179,20 +167,16 @@ def _all_reduce(self, reduceOp, tag, ranks, group_size):
 
     return inplace_tensor
 
-
 def _all_reduce_coalesced(self, reduceOp, tag, ranks, group_size):
     op = _str_to_reduce_op(reduceOp)
     group = c10d._find_or_create_pg_by_ranks_and_tag(tag, ranks, group_size)
     assert group is not None
 
     inplace_tensor_list = [t.clone(memory_format=torch.contiguous_format) for t in self]
-    work = dist.all_reduce_coalesced(
-        inplace_tensor_list, op=op, group=group, async_op=True
-    )
+    work = dist.all_reduce_coalesced(inplace_tensor_list, op=op, group=group, async_op=True)
     _register_tensor_work(inplace_tensor_list, work)
 
     return inplace_tensor_list
-
 
 def _all_gather_into_tensor(shard, tag, ranks, group_size):
     # TODO add dim support?
@@ -207,9 +191,7 @@ def _all_gather_into_tensor(shard, tag, ranks, group_size):
         tensor_list = list(torch.chunk(out_tensor, group_size))
         work = dist.all_gather(tensor_list, shard, group=group, async_op=True)
     else:
-        work = dist.all_gather_into_tensor(
-            out_tensor, shard, group=group, async_op=True
-        )
+        work = dist.all_gather_into_tensor(out_tensor, shard, group=group, async_op=True)
     _register_tensor_work(out_tensor, work)
 
     return out_tensor
@@ -229,12 +211,14 @@ def _all_gather_into_tensor_coalesced(self, tag, rankset, group_size):
     out_tensors = [mk_out_tensor(t) for t in self]
 
     work_list = _all_gather_into_tensor_coalesced_fallback(
-        output_tensors=out_tensors, input_tensors=self, group=group, async_op=True
-    )
+        output_tensors=out_tensors,
+        input_tensors=self,
+        group=group,
+        async_op=True)
+
 
     _register_tensor_work(out_tensors, work_list)
     return out_tensors
-
 
 def _reduce_scatter_tensor(
     input: torch.Tensor,
@@ -270,7 +254,6 @@ def _reduce_scatter_tensor(
 
     return out_tensor
 
-
 def _reduce_scatter_tensor_coalesced(
     inputs: List[torch.Tensor],
     reduce_op: str,
@@ -281,6 +264,7 @@ def _reduce_scatter_tensor_coalesced(
     group = c10d._find_or_create_pg_by_ranks_and_tag(tag, ranks, group_size)
     assert group is not None
     op = _str_to_reduce_op(reduce_op)
+
 
     def mk_out_tensor(shard):
         out_size = list(shard.size())
@@ -296,16 +280,12 @@ def _reduce_scatter_tensor_coalesced(
         input_tensors=inputs,
         op=op,
         group=group,
-        async_op=False,
-    )
+        async_op=False)
 
     _register_tensor_work(out_tensors, work_list)
     return out_tensors
 
-
-def _all_gather_into_tensor_coalesced_fallback(
-    output_tensors, input_tensors, group, async_op=False
-):
+def _all_gather_into_tensor_coalesced_fallback(output_tensors, input_tensors, group, async_op=False):
     # all_gather_coalesced is useless, it doesn't work under NCCL and does lots of copies under Gloo
     # all_gather is useless too because it's single tensor
     # NCCL's PG::all_gather with multiple tensors is broken, it only works for the multi-device setting
@@ -327,16 +307,11 @@ def _all_gather_into_tensor_coalesced_fallback(
                 dist.all_gather_into_tensor(out_t, in_t, group=group, async_op=True)
         return cm
 
-
-def _reduce_scatter_tensor_coalesced_fallback(
-    output_tensors, input_tensors, op, group, async_op=False
-):
+def _reduce_scatter_tensor_coalesced_fallback(output_tensors, input_tensors, op, group, async_op=False):
     # All the same reasons as the all_gather fallback
     work_list = []
     for shard, out_tensor in zip(input_tensors, output_tensors):
-        work = c10d.reduce_scatter_tensor(
-            out_tensor, shard, op=op, group=group, async_op=async_op
-        )
+        work = c10d.reduce_scatter_tensor(out_tensor, shard, op=op, group=group, async_op=async_op)
         work_list.append(work)
     return work_list
 
@@ -352,10 +327,7 @@ def _all_to_all_single(
     group = c10d._find_or_create_pg_by_ranks_and_tag(tag, ranks, group_size)
 
     if output_split_sizes is not None:
-        torch._check(
-            input.dim() >= 1,
-            lambda: f"Expected input to have at least 1 dim but got {input.dim()} dim",
-        )
+        torch._check(input.dim() >= 1, lambda: f"Expected input to have at least 1 dim but got {input.dim()} dim")
         out_size = list(input.size())
         out_size[0] = sum(output_split_sizes)
         out_tensor = input.new_empty(out_size)
@@ -363,12 +335,8 @@ def _all_to_all_single(
         out_tensor = input.new_empty(input.size())
 
     work = c10d.all_to_all_single(
-        out_tensor,
-        input,
-        output_split_sizes=output_split_sizes,
-        input_split_sizes=input_split_sizes,
-        group=group,
-        async_op=True,
+        out_tensor, input, output_split_sizes=output_split_sizes,
+        input_split_sizes=input_split_sizes, group=group, async_op=True
     )
     _register_tensor_work(out_tensor, work)
 


### PR DESCRIPTION
Adds `broadcast` to functional collectives, including inductor support.

Test with `python test_inductor_collectives.py -- TestCollectivesMultiProc.test_broadcast_inductor`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler