### PR TITLE
[TD] Support downgrading test relevance

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1738,6 +1738,16 @@ def main():
             test_prioritizations.get_unranked_relevance_tests(),
             True,
         ),
+        TestBatch(
+            "unlikely_relevance",
+            test_prioritizations.get_unlikely_relevance_tests(),
+            True,
+        ),
+        TestBatch(
+            "none_relevance",
+            test_prioritizations.get_none_relevance_tests(),
+            True,
+        ),
     ]
 
     for test_batch in test_batches:

--- a/tools/test/heuristics/heuristics_test_mixin.py
+++ b/tools/test/heuristics/heuristics_test_mixin.py
@@ -24,6 +24,8 @@ class HeuristicsTestMixin(unittest.TestCase):
         expected_high_tests: Optional[TestRuns] = None,
         expected_probable_tests: Optional[TestRuns] = None,
         expected_unranked_tests: Optional[TestRuns] = None,
+        expected_unlikely_tests: Optional[TestRuns] = None,
+        expected_none_tests: Optional[TestRuns] = None,
     ) -> None:
         # if expected_prioritizations is set, none of the other expected values should be set
         if expected_prioritizations:
@@ -31,6 +33,8 @@ class HeuristicsTestMixin(unittest.TestCase):
                 expected_high_tests
                 or expected_probable_tests
                 or expected_unranked_tests
+                or expected_unlikely_tests
+                or expected_none_tests
             )
             expected_high_tests = expected_prioritizations.get_high_relevance_tests()
             expected_probable_tests = (
@@ -39,6 +43,10 @@ class HeuristicsTestMixin(unittest.TestCase):
             expected_unranked_tests = (
                 expected_prioritizations.get_unranked_relevance_tests()
             )
+            expected_unlikely_tests = (
+                expected_prioritizations.get_unlikely_relevance_tests()
+            )
+            expected_none_tests = expected_prioritizations.get_none_relevance_tests()
 
         if expected_unranked_tests:
             self.assertTupleEqual(
@@ -59,4 +67,18 @@ class HeuristicsTestMixin(unittest.TestCase):
                 test_prioritizations.get_high_relevance_tests(),
                 expected_high_tests,
                 "High relevance tests differ",
+            )
+
+        if expected_unlikely_tests:
+            self.assertTupleEqual(
+                test_prioritizations.get_unlikely_relevance_tests(),
+                expected_unlikely_tests,
+                "Unlikely relevance tests differ",
+            )
+
+        if expected_none_tests:
+            self.assertTupleEqual(
+                test_prioritizations.get_none_relevance_tests(),
+                expected_none_tests,
+                "None relevance tests differ",
             )

--- a/tools/test/heuristics/test_heuristics.py
+++ b/tools/test/heuristics/test_heuristics.py
@@ -166,6 +166,36 @@ class TestAggregatedHeuristics(HeuristicsTestMixin):
             expected_unranked_tests=expected_unranked_relevance,
         )
 
+    def test_downgrading_file_test(self) -> None:
+        tests = ["test1", "test2", "test3", "test4"]
+
+        heuristic1 = TestPrioritizations(
+            tests_being_ranked=tests,
+            probable_relevance=["test2", "test3"],
+        )
+
+        heuristic2 = TestPrioritizations(
+            tests_being_ranked=tests,
+            no_relevance=["test2"],
+        )
+
+        expected_prioritizations = TestPrioritizations(
+            tests_being_ranked=tests,
+            probable_relevance=["test3"],
+            unranked_relevance=["test1", "test4"],
+            no_relevance=["test2"],
+        )
+
+        aggregator = AggregatedHeuristics(unranked_tests=tests)
+        aggregator.add_heuristic_results(HEURISTICS[0], heuristic1)
+        aggregator.add_heuristic_results(HEURISTICS[1], heuristic2)
+
+        aggregated_pris = aggregator.get_aggregated_priorities()
+
+        self.assertHeuristicsMatch(
+            aggregated_pris, expected_prioritizations=expected_prioritizations
+        )
+
     def test_merging_file_heuristic_after_class_heuristic(self) -> None:
         tests = ["test1", "test2", "test3", "test4", "test5"]
         heuristic1 = TestPrioritizations(

--- a/tools/testing/target_determination/heuristics/interface.py
+++ b/tools/testing/target_determination/heuristics/interface.py
@@ -24,10 +24,10 @@ from tools.testing.test_run import TestRun, TestRuns
 @total_ordering
 class Relevance(Enum):
     HIGH = 4
-    PROBABLE = 3
-    UNRANKED = 2
+    NONE = 3  # Not yet supported. Needs more infra to be usable
+    PROBABLE = 2
     UNLIKELY = 1  # Not yet supported. Needs more infra to be usable
-    NONE = 0  # Not yet supported. Needs more infra to be usable
+    UNRANKED = 0
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Relevance):
@@ -44,10 +44,10 @@ class Relevance(Enum):
     @staticmethod
     def priority_traversal() -> Iterator["Relevance"]:
         yield Relevance.HIGH
-        yield Relevance.PROBABLE
-        yield Relevance.UNRANKED
-        yield Relevance.UNLIKELY
         yield Relevance.NONE
+        yield Relevance.PROBABLE
+        yield Relevance.UNLIKELY
+        yield Relevance.UNRANKED
 
 
 METRIC_RELEVANCE_GROUP = "relevance_group"

--- a/tools/testing/target_determination/heuristics/interface.py
+++ b/tools/testing/target_determination/heuristics/interface.py
@@ -244,6 +244,12 @@ class TestPrioritizations:
     def get_unranked_relevance_tests(self) -> TestRuns:
         return tuple(test for test in self._test_priorities[Relevance.UNRANKED.value])
 
+    def get_unlikely_relevance_tests(self) -> TestRuns:
+        return tuple(test for test in self._test_priorities[Relevance.UNLIKELY.value])
+
+    def get_none_relevance_tests(self) -> TestRuns:
+        return tuple(test for test in self._test_priorities[Relevance.NONE.value])
+
     def print_info(self) -> None:
         def _print_tests(label: str, tests: List[TestRun]) -> None:
             if not tests:

--- a/tools/testing/target_determination/heuristics/interface.py
+++ b/tools/testing/target_determination/heuristics/interface.py
@@ -24,9 +24,9 @@ from tools.testing.test_run import TestRun, TestRuns
 @total_ordering
 class Relevance(Enum):
     HIGH = 4
-    NONE = 3  # Not yet supported. Needs more infra to be usable
+    NONE = 3
     PROBABLE = 2
-    UNLIKELY = 1  # Not yet supported. Needs more infra to be usable
+    UNLIKELY = 1
     UNRANKED = 0
 
     def __eq__(self, other: object) -> bool:
@@ -70,7 +70,7 @@ class TestPrioritizations:
                otherwise it breaks the test sharding logic
     """
 
-    _test_priorities: List[List[TestRun]]  # This list MUST be ordered by Relevance
+    _test_priorities: List[List[TestRun]]
     _original_tests: FrozenSet[str]
 
     def __init__(
@@ -223,7 +223,6 @@ class TestPrioritizations:
             if relevance > Relevance.UNRANKED:
                 for test in other._test_priorities[relevance.value]:
                     self.raise_test_relevance(test, relevance)
-                # TODO: Hande the case where a test is moved to a lower relevance group (once we support that scenario)
 
         self.validate_test_priorities()
         return


### PR DESCRIPTION
Allow heuristics to actually downgrade the relevance of a test.  Note that NONE/UNLIKELY tests will still get executed, but they will be ran at the end of the CI

The Relevance chosen affects the outcome when Heuristics offer conflicting predictions. A relevance higher up in this list means higher confidence in the declared relevance:

HIGH > NONE > PROBABLE > UNLIKELY > UNRANKED

Given that we assume ordering based on the list in init right now since the lists are appended, do a similar thing for UNLIKELY and NONE
ex HEURISTICS = [a, b, c, d]
currently all things in b.high and added after a.high
if b.none includes things in a.high, a.high trumps
if b.none includes things in a.probable, then b.none trumps since none is stronger than probable
if b.unlikely includes things from a.high/probable, a.high/probable trumps since unlikely and probable are at a higher strength