### PR TITLE
Make addc[mul|div] support different out dtypes

### DIFF
--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -947,6 +947,7 @@ void TensorIteratorBase::build_ternary_op(
     const TensorBase& b, const TensorBase& c) {
   build(TensorIteratorConfig()
       .promote_inputs_to_common_dtype(true)
+      .cast_common_dtype_to_outputs(true)
       .enforce_safe_casting_to_output(true)
       .add_owned_output(out)
       .add_owned_input(a)

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -1165,6 +1165,19 @@ class TestTypePromotion(TestCase):
                     actual = torch.clamp_max_(inp, val)
                     self.assertEqual(actual, expected, exact_dtype=False)
 
+    @onlyNativeDeviceTypes
+    def test_ternary_out_promotion(self, device):
+        for op in [torch.addcdiv, torch.addcmul]:
+            for dtype in [torch.float32, torch.cfloat]:
+                prom_dtype = torch.float64 if dtype is torch.float32 else torch.cdouble if dtype is torch.cfloat else dtype
+                x = torch.rand(3, device=device, dtype=dtype)
+                y = torch.empty(3, device=device, dtype=dtype)
+                y_promo = torch.empty(3, device=device, dtype=prom_dtype)
+                op(x, x, x, out=y)
+                op(x, x, x, out=y_promo)
+                self.assertEqual(y, y_promo.to(dtype=dtype))
+
+
 
 
 instantiate_device_type_tests(TestTypePromotion, globals())


### PR DESCRIPTION
By adding `.cast_common_dtype_to_outputs(true)` to `build_ternary_op`.
According to profiling, this change does not result in additional kernel invocation on GPUs, i.e. following script
```python
import torch
def bench_addcdiv(size=(32*1024**2, 5), device="cuda"):
    x=torch.rand(size, device=device, dtype=torch.float)
    y=torch.rand(size, device=device, dtype=torch.double)
    with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CUDA]) as prof:
      torch.addcdiv(x, x, x, out=y)
    rc=prof.key_averages()
    print(rc)


if __name__ == "__main__":
    bench_addcdiv()
```
Shows that before and after the change it took roughly the same time to finish the computation. 
Before:
```
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                                   Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg    # of Calls  
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                       cudaLaunchKernel        92.99%      20.096ms        92.99%      20.096ms      20.096ms       0.000us         0.00%       0.000us       0.000us             1  
void at::native::unrolled_elementwise_kernel<at::nat...         0.00%       0.000us         0.00%       0.000us       0.000us       1.605ms       100.00%       1.605ms       1.605ms             1  
                                  cudaDeviceSynchronize         7.01%       1.515ms         7.01%       1.515ms       1.515ms       0.000us         0.00%       0.000us       0.000us             1  
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 21.611ms
Self CUDA time total: 1.605ms
```
After:
```
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                                   Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg    # of Calls  
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                       cudaLaunchKernel        92.92%      19.996ms        92.92%      19.996ms      19.996ms       0.000us         0.00%       0.000us       0.000us             1  
void at::native::unrolled_elementwise_kernel<at::nat...         0.00%       0.000us         0.00%       0.000us       0.000us       1.603ms       100.00%       1.603ms       1.603ms             1  
                                  cudaDeviceSynchronize         7.08%       1.523ms         7.08%       1.523ms       1.523ms       0.000us         0.00%       0.000us       0.000us             1  
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 21.519ms
Self CUDA time total: 1.603ms
```
Add regression test.

Fixes https://github.com/pytorch/pytorch/issues/112490
