### PR TITLE
[export] Skip guard propagation for export only.

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -706,18 +706,12 @@ class MiscTests(torch._dynamo.test_case.TestCase):
             "\n".join(guard_code),
             """\
 2 <= L['x'].size()[0]
-L['x'] is L['y']
 L['x'].ndimension() == 2
 L['x'].requires_grad == False
 L['x'].size()[1] == L['x'].size()[0]
 L['x'].storage_offset() == 0
-___dict_contains('builtins', G['sys'].modules)
-___dict_contains('operator', G['sys'].modules)
 ___dict_contains('operator', G['sys'].modules)
 hasattr(L['x'], '_dynamo_dynamic_indices') == False
-not ___dict_contains('aaaaaaaa', G['sys'].modules)
-not ___dict_contains('bbbbbbbb', G['sys'].modules)
-not ___dict_contains('cccccccc', G['sys'].modules)
 str(L['x'].device) == 'cpu'
 str(L['x'].dtype) == 'torch.float32'
 utils_device.CURRENT_DEVICE == None""",

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -293,7 +293,7 @@ class OutputGraph(Checkpointable[OutputGraphState]):
             # TODO (tmanlaibaatar) Remove this once we always lift params and buffers
             allow_non_fake_inputs=True if self.export else False,
         )
-        self.tracing_context: TracingContext = TracingContext(fake_mode)
+        self.tracing_context: TracingContext = TracingContext(fake_mode, self.export)
         self.init_ambient_guards()
 
         # Map each tensor id to a list of sources. This is necessary because


### PR DESCRIPTION
Summary:
IIUC, from the beginning of torch.export to the current moment, we never really find a way to meaningfully use generated guards from torch dynamo, since export by design must output a non Python dependent artifact to users. Therefore I think in the forseeable future we still don't need dynamo guards to be present.

Recently we ran into some slowness in dynamo for internal models and observed a substantial time consumed in guard propagation logic, especially when we're dealing with list VTs. This PR effectively detects whether we're exporting and if so skip the entire guard propagation logic.

This doesn't resolve the fundemental issue of O(n^2) algorithm used in VT but greatly reduce the constant factor of it, thus still gives us great speedup for exporting time. We've discussed the resolution in pt2 core meeting but as a quick unblocker in the short term I think we could also try to skip guards to unblock several internal models.

Some experiment ran on the internal FM model:
local_fm (training): 15min -> 4min
ads launcher ir generation (training, D50847630): >1hr -> 30min

Test Plan: CI

Differential Revision: D50914819




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng