### PR TITLE
docs: fix docstring errors in quantized modules and others

### DIFF
--- a/torch/backends/_nnapi/prepare.py
+++ b/torch/backends/_nnapi/prepare.py
@@ -174,7 +174,7 @@ def process_for_nnapi(
     # We have to create a new class here every time this function is called
     # because module.define adds a method to the *class*, not the instance.
     class ShapeComputeModule(torch.nn.Module):
-        """Code-gen-ed module for tensor shape computation
+        """Code-gen-ed module for tensor shape computation.
 
         module.prepare will mutate ser_model according to the computed operand
         shapes, based on the shapes of args.  Returns a list of output templates.

--- a/torch/backends/_nnapi/serializer.py
+++ b/torch/backends/_nnapi/serializer.py
@@ -1333,8 +1333,8 @@ class _NnapiSerializer:
 
         self.add_operation(opcode, inputs, outputs)
 
-    def _do_add_binary(self, node, opcode, fuse_code, *, qparams=None):
-        """Helper for pointwise binary broadcast ops with superfluous extra args"""
+    def _do_add_binary(self, node, opcode, fuse_code, *, qparams=None):  # noqa: D401
+        """Helper for pointwise binary broadcast ops with superfluous extra args."""
         assert node.outputsSize() == 1
 
         assert node.inputsAt(0).type().kind() == "TensorType"
@@ -2177,7 +2177,8 @@ class _NnapiSerializer:
 def serialize_model(
     module, inputs, *, config=None, return_shapes=None, use_int16_for_qint16=False
 ):
-    """Convert to NNAPI and serialize torchscript module:
+    """Convert to NNAPI and serialize torchscript module.
+
     Parameters:
         module: Torchscript module to convert
         inputs: Tensors used to specify input details for NNAPI
@@ -2187,7 +2188,6 @@ def serialize_model(
             buffer size for NNAPI
         use_int16_for_qint16 (optional): Use Pytorch int16 to represent NNAPI qint16 values
     """
-
     return _NnapiSerializer(config, use_int16_for_qint16).serialize_model(
         module, inputs, return_shapes
     )

--- a/torch/backends/cuda/__init__.py
+++ b/torch/backends/cuda/__init__.py
@@ -27,10 +27,12 @@ __all__ = [
 
 
 def is_built():
-    r"""Returns whether PyTorch is built with CUDA support.  Note that this
-    doesn't necessarily mean CUDA is available; just that if this PyTorch
-    binary were run a machine with working CUDA drivers and devices, we
-    would be able to use it."""
+    r"""
+    Return whether PyTorch is built with CUDA support.
+
+    Note that this doesn't necessarily mean CUDA is available; just that if this PyTorch
+    binary were run on a machine with working CUDA drivers and devices, we would be able to use it.
+    """
     return torch._C._has_cuda
 
 
@@ -52,8 +54,9 @@ class cuFFTPlanCacheAttrContextProp:
 
 class cuFFTPlanCache:
     r"""
-    Represents a specific plan cache for a specific `device_index`. The
-    attributes `size` and `max_size`, and method `clear`, can fetch and/ or
+    Represent a specific plan cache for a specific `device_index`.
+
+    The attributes `size` and `max_size`, and method `clear`, can fetch and/ or
     change properties of the C++ cuFFT plan cache.
     """
 
@@ -76,8 +79,7 @@ class cuFFTPlanCache:
 
 class cuFFTPlanCacheManager:
     r"""
-    Represents all cuFFT plan caches. When indexed with a device object/index,
-    this object returns the `cuFFTPlanCache` corresponding to that device.
+    Represent all cuFFT plan caches, return the cuFFTPlanCache for a given device when indexed.
 
     Finally, this object, when used directly as a `cuFFTPlanCache` object (e.g.,
     setting the `.max_size`) attribute, the current device's cuFFT plan cache is
@@ -145,6 +147,8 @@ def preferred_linalg_library(
     backend: Union[None, str, torch._C._LinalgBackend] = None
 ) -> torch._C._LinalgBackend:
     r"""
+    Override the heuristic PyTorch uses to choose between cuSOLVER and MAGMA for CUDA linear algebra operations.
+
     .. warning:: This flag is experimental and subject to change.
 
     When PyTorch runs a CUDA linear algebra operation it often uses the cuSOLVER or MAGMA libraries,
@@ -183,7 +187,6 @@ def preferred_linalg_library(
     * :func:`torch.linalg.svd`
     * :func:`torch.linalg.svdvals`
     """
-
     if backend is None:
         pass
     elif isinstance(backend, str):
@@ -208,6 +211,7 @@ class SDPBackend(IntEnum):
     This class needs to stay aligned with the enum defined in:
     pytorch/aten/src/ATen/native/transformers/sdp_utils_cpp.h
     """
+
     ERROR = -1
     MATH = 0
     FLASH_ATTENTION = 1

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -78,7 +78,7 @@ else:
 
 
 def version():
-    """Returns the version of cuDNN"""
+    """Return the version of cuDNN."""
     if not _init():
         return None
     return __cudnn_version
@@ -92,7 +92,7 @@ CUDNN_TENSOR_DTYPES = {
 
 
 def is_available():
-    r"""Returns a bool indicating if CUDNN is currently available."""
+    r"""Return a bool indicating if CUDNN is currently available."""
     return torch._C._has_cudnn
 
 

--- a/torch/backends/mkl/__init__.py
+++ b/torch/backends/mkl/__init__.py
@@ -2,7 +2,7 @@ import torch
 
 
 def is_available():
-    r"""Returns whether PyTorch is built with MKL support."""
+    r"""Return whether PyTorch is built with MKL support."""
     return torch._C.has_mkl
 
 
@@ -12,7 +12,8 @@ VERBOSE_ON = 1
 
 class verbose:
     """
-    On-demand oneMKL verbosing functionality
+    On-demand oneMKL verbosing functionality.
+
     To make it easier to debug performance issues, oneMKL can dump verbose
     messages containing execution information like duration while executing
     the kernel. The verbosing functionality can be invoked via an environment

--- a/torch/backends/mkldnn/__init__.py
+++ b/torch/backends/mkldnn/__init__.py
@@ -6,7 +6,7 @@ from torch.backends import __allow_nonbracketed_mutation, ContextProp, PropModul
 
 
 def is_available():
-    r"""Returns whether PyTorch is built with MKL-DNN support."""
+    r"""Return whether PyTorch is built with MKL-DNN support."""
     return torch._C._has_mkldnn
 
 
@@ -17,7 +17,8 @@ VERBOSE_ON_CREATION = 2
 
 class verbose:
     """
-    On-demand oneDNN (former MKL-DNN) verbosing functionality
+    On-demand oneDNN (former MKL-DNN) verbosing functionality.
+
     To make it easier to debug performance issues, oneDNN can dump verbose
     messages containing information like kernel size, input data size and
     execution duration while executing the kernel. The verbosing functionality

--- a/torch/backends/openmp/__init__.py
+++ b/torch/backends/openmp/__init__.py
@@ -2,5 +2,5 @@ import torch
 
 
 def is_available():
-    r"""Returns whether PyTorch is built with OpenMP support."""
+    r"""Return whether PyTorch is built with OpenMP support."""
     return torch._C.has_openmp

--- a/torch/nn/intrinsic/qat/modules/conv_fused.py
+++ b/torch/nn/intrinsic/qat/modules/conv_fused.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Intrinsic QAT Modules
+r"""Intrinsic QAT Modules.
 
 This file is in the process of migration to `torch/ao/nn/intrinsic/qat`, and
 is kept here for compatibility while the migration process is ongoing.

--- a/torch/nn/intrinsic/qat/modules/linear_fused.py
+++ b/torch/nn/intrinsic/qat/modules/linear_fused.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Intrinsic QAT Modules
+r"""Intrinsic QAT Modules.
 
 This file is in the process of migration to `torch/ao/nn/intrinsic/qat`, and
 is kept here for compatibility while the migration process is ongoing.

--- a/torch/nn/intrinsic/qat/modules/linear_relu.py
+++ b/torch/nn/intrinsic/qat/modules/linear_relu.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Intrinsic QAT Modules
+r"""Intrinsic QAT Modules.
 
 This file is in the process of migration to `torch/ao/nn/intrinsic/qat`, and
 is kept here for compatibility while the migration process is ongoing.

--- a/torch/nn/qat/__init__.py
+++ b/torch/nn/qat/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""QAT Dynamic Modules
+r"""QAT Dynamic Modules.
 
 This package is in the process of being deprecated.
 Please, use `torch.ao.nn.qat.dynamic` instead.

--- a/torch/nn/qat/dynamic/__init__.py
+++ b/torch/nn/qat/dynamic/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""QAT Dynamic Modules
+r"""QAT Dynamic Modules.
 
 This package is in the process of being deprecated.
 Please, use `torch.ao.nn.qat.dynamic` instead.

--- a/torch/nn/qat/dynamic/modules/linear.py
+++ b/torch/nn/qat/dynamic/modules/linear.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""QAT Modules
+r"""QAT Modules.
 
 This file is in the process of migration to `torch/ao/nn/qat/dynamic`, and
 is kept here for compatibility while the migration process is ongoing.

--- a/torch/nn/qat/modules/__init__.py
+++ b/torch/nn/qat/modules/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""QAT Modules
+r"""QAT Modules.
 
 This package is in the process of being deprecated.
 Please, use `torch.ao.nn.qat.modules` instead.

--- a/torch/nn/qat/modules/conv.py
+++ b/torch/nn/qat/modules/conv.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""QAT Modules
+r"""QAT Modules.
 
 This file is in the process of migration to `torch/ao/nn/qat`, and
 is kept here for compatibility while the migration process is ongoing.

--- a/torch/nn/qat/modules/embedding_ops.py
+++ b/torch/nn/qat/modules/embedding_ops.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""QAT Modules
+r"""QAT Modules.
 
 This file is in the process of migration to `torch/ao/nn/qat`, and
 is kept here for compatibility while the migration process is ongoing.

--- a/torch/nn/qat/modules/linear.py
+++ b/torch/nn/qat/modules/linear.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""QAT Modules
+r"""QAT Modules.
 
 This file is in the process of migration to `torch/ao/nn/qat`, and
 is kept here for compatibility while the migration process is ongoing.

--- a/torch/nn/quantizable/modules/activation.py
+++ b/torch/nn/quantizable/modules/activation.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Quantizable Modules
+r"""Quantizable Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantizable`, and
 is kept here for compatibility while the migration process is ongoing.

--- a/torch/nn/quantizable/modules/rnn.py
+++ b/torch/nn/quantizable/modules/rnn.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Quantizable Modules
+r"""Quantizable Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantizable`, and
 is kept here for compatibility while the migration process is ongoing.

--- a/torch/nn/quantized/_reference/modules/__init__.py
+++ b/torch/nn/quantized/_reference/modules/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Quantized Reference Modules
+r"""Quantized Reference Modules.
 
 This module is in the process of migration to
 `torch/ao/nn/quantized/reference`, and is kept here for

--- a/torch/nn/quantized/_reference/modules/conv.py
+++ b/torch/nn/quantized/_reference/modules/conv.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Quantized Reference Modules
+r"""Quantized Reference Modules.
 
 This module is in the process of migration to
 `torch/ao/nn/quantized/reference`, and is kept here for

--- a/torch/nn/quantized/_reference/modules/linear.py
+++ b/torch/nn/quantized/_reference/modules/linear.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Quantized Reference Modules
+r"""Quantized Reference Modules.
 
 This module is in the process of migration to
 `torch/ao/nn/quantized/reference`, and is kept here for

--- a/torch/nn/quantized/_reference/modules/rnn.py
+++ b/torch/nn/quantized/_reference/modules/rnn.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Quantized Reference Modules
+r"""Quantized Reference Modules.
 
 This module is in the process of migration to
 `torch/ao/nn/quantized/reference`, and is kept here for

--- a/torch/nn/quantized/_reference/modules/sparse.py
+++ b/torch/nn/quantized/_reference/modules/sparse.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Quantized Reference Modules
+r"""Quantized Reference Modules.
 
 This module is in the process of migration to
 `torch/ao/nn/quantized/reference`, and is kept here for

--- a/torch/nn/quantized/_reference/modules/utils.py
+++ b/torch/nn/quantized/_reference/modules/utils.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Quantized Reference Modules
+r"""Quantized Reference Modules.
 
 This module is in the process of migration to
 `torch/ao/nn/quantized/reference`, and is kept here for

--- a/torch/nn/quantized/dynamic/modules/__init__.py
+++ b/torch/nn/quantized/dynamic/modules/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Quantized Dynamic Modules
+r"""Quantized Dynamic Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantized/dynamic`,
 and is kept here for compatibility while the migration process is ongoing.

--- a/torch/nn/quantized/dynamic/modules/conv.py
+++ b/torch/nn/quantized/dynamic/modules/conv.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Quantized Dynamic Modules
+r"""Quantized Dynamic Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantized/dynamic`,
 and is kept here for compatibility while the migration process is ongoing.

--- a/torch/nn/quantized/dynamic/modules/linear.py
+++ b/torch/nn/quantized/dynamic/modules/linear.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Quantized Dynamic Modules
+r"""Quantized Dynamic Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantized/dynamic`,
 and is kept here for compatibility while the migration process is ongoing.

--- a/torch/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/nn/quantized/dynamic/modules/rnn.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Quantized Dynamic Modules
+r"""Quantized Dynamic Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantized/dynamic`,
 and is kept here for compatibility while the migration process is ongoing.

--- a/torch/nn/quantized/functional.py
+++ b/torch/nn/quantized/functional.py
@@ -1,4 +1,4 @@
-r"""nn.quantized.functional
+r"""nn.quantized.functional.
 
 Quantized equivalents of the `nn.functional`.
 

--- a/torch/nn/quantized/modules/__init__.py
+++ b/torch/nn/quantized/modules/__init__.py
@@ -1,4 +1,4 @@
-r"""Quantized Modules
+r"""Quantized Modules.
 
 Note::
     The `torch.nn.quantized` namespace is in the process of being deprecated.

--- a/torch/nn/quantized/modules/activation.py
+++ b/torch/nn/quantized/modules/activation.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Quantized Modules
+r"""Quantized Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantized`, and
 is kept here for compatibility while the migration process is ongoing.

--- a/torch/nn/quantized/modules/batchnorm.py
+++ b/torch/nn/quantized/modules/batchnorm.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Quantized Modules
+r"""Quantized Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantized`, and
 is kept here for compatibility while the migration process is ongoing.

--- a/torch/nn/quantized/modules/conv.py
+++ b/torch/nn/quantized/modules/conv.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Quantized Modules
+r"""Quantized Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantized`, and
 is kept here for compatibility while the migration process is ongoing.

--- a/torch/nn/quantized/modules/dropout.py
+++ b/torch/nn/quantized/modules/dropout.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Quantized Modules
+r"""Quantized Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantized`, and
 is kept here for compatibility while the migration process is ongoing.

--- a/torch/nn/quantized/modules/embedding_ops.py
+++ b/torch/nn/quantized/modules/embedding_ops.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Quantized Modules
+r"""Quantized Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantized`, and
 is kept here for compatibility while the migration process is ongoing.

--- a/torch/nn/quantized/modules/functional_modules.py
+++ b/torch/nn/quantized/modules/functional_modules.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Quantized Modules
+r"""Quantized Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantized`, and
 is kept here for compatibility while the migration process is ongoing.

--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Quantized Modules
+r"""Quantized Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantized`, and
 is kept here for compatibility while the migration process is ongoing.

--- a/torch/nn/quantized/modules/normalization.py
+++ b/torch/nn/quantized/modules/normalization.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Quantized Modules
+r"""Quantized Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantized`, and
 is kept here for compatibility while the migration process is ongoing.

--- a/torch/nn/quantized/modules/rnn.py
+++ b/torch/nn/quantized/modules/rnn.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Quantized Modules
+r"""Quantized Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantized`, and
 is kept here for compatibility while the migration process is ongoing.

--- a/torch/nn/quantized/modules/utils.py
+++ b/torch/nn/quantized/modules/utils.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-r"""Quantized Modules
+r"""Quantized Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantized`, and
 is kept here for compatibility while the migration process is ongoing.

--- a/torch/nn/utils/_expanded_weights/conv_utils.py
+++ b/torch/nn/utils/_expanded_weights/conv_utils.py
@@ -187,7 +187,8 @@ def unfold3d(
     dilation,
 ):
     r"""
-    Extracts sliding local blocks from an batched input tensor.
+    Extract sliding local blocks from an batched input tensor.
+
     :class:`torch.nn.Unfold` only supports 4D inputs (batched image-like tensors).
     This method implements the same action for 5D inputs
     Args:
@@ -206,7 +207,6 @@ def unfold3d(
         >>> unfold3d(tensor, kernel_size=2, padding=0, stride=1).shape
         torch.Size([3, 32, 120])
     """
-
     if len(tensor.shape) != 5:
         raise ValueError(
             f"Input tensor must be of the shape [B, C, D, H, W]. Got{tensor.shape}"

--- a/torch/nn/utils/_expanded_weights/expanded_weights_utils.py
+++ b/torch/nn/utils/_expanded_weights/expanded_weights_utils.py
@@ -16,17 +16,20 @@ def is_batch_first(expanded_args_and_kwargs):
     return batch_first
 
 def standard_kwargs(kwarg_names, expanded_args):
-    r'''Most `__torch_function__`s standardize the kwargs that they give, so this will separate
-    the args and kwargs they pass. Functions that don't are linear and convND
-    '''
+    r"""Separate args and kwargs from `__torch_function__`s that standardize kwargs.
+
+    Most `__torch_function__`s standardize the kwargs that they give, so this will separate
+    the args and kwargs they pass. Functions that don't are linear and convND.
+    """
     kwarg_values = expanded_args[len(expanded_args) - len(kwarg_names):]
     expanded_args_without_kwargs = expanded_args[:len(expanded_args) - len(kwarg_names)]
     expanded_kwargs = dict(zip(kwarg_names, kwarg_values))
     return expanded_args_without_kwargs, expanded_kwargs
 
 def forward_helper(func, expanded_args, expanded_kwargs):
-    r'''Forward helper computes the forward pass for a function that has expanded weight(s)
-    passed to it. It will run the forward pass where all ExpandedWeights are their original
+    r"""Compute the forward pass for a function that has expanded weight(s) passed to it.
+
+    It will run the forward pass where all ExpandedWeights are their original
     weight. It runs checks on the given arguments and detaches the outputs.
 
     .. note:: First argument in :attr:`expanded_args` must be the input with the batch
@@ -40,7 +43,7 @@ def forward_helper(func, expanded_args, expanded_kwargs):
           that need to be unpacked because they are ExpandedWeights
         expanded_kwargs: Keyword arguments to be passed to :attr:`func`.
           Similar to :attr:`expanded_args`.
-    '''
+    """
     unexpanded_args, unexpanded_kwargs = _check_and_unexpand_args(func, expanded_args, expanded_kwargs)
     return func(*unexpanded_args, **unexpanded_kwargs)
 
@@ -121,8 +124,8 @@ def sum_over_all_but_batch_and_last_n(
     tensor: torch.Tensor, n_dims: int
 ) -> torch.Tensor:
     r"""
-    Calculates the sum over all dimensions, except the first
-    (batch dimension), and excluding the last n_dims.
+    Calculate the sum over all dimensions, except the first (batch dimension), and excluding the last n_dims.
+
     This function will ignore the first dimension and it will
     not aggregate over the last n_dims dimensions.
     Args:

--- a/torch/nn/utils/convert_parameters.py
+++ b/torch/nn/utils/convert_parameters.py
@@ -54,10 +54,10 @@ def vector_to_parameters(vec: torch.Tensor, parameters: Iterable[torch.Tensor]) 
 
 
 def _check_param_device(param: torch.Tensor, old_param_device: Optional[int]) -> int:
-    r"""This helper function is to check if the parameters are located
-    in the same device. Currently, the conversion between model parameters
-    and single vector form is not supported for multiple allocations,
-    e.g. parameters in different GPUs/PrivateUse1s, or mixture of CPU/GPU/PrivateUse1.
+    r"""Check if the parameters are located on the same device.
+
+    Currently, the conversion between model parameters and single vector form is not supported
+    for multiple allocations, e.g. parameters in different GPUs/PrivateUse1s, or mixture of CPU/GPU/PrivateUse1.
 
     Args:
         param ([Tensor]): a Tensor of a parameter of a model
@@ -67,7 +67,6 @@ def _check_param_device(param: torch.Tensor, old_param_device: Optional[int]) ->
     Returns:
         old_param_device (int): report device for the first time
     """
-
     # Meet the first parameter
     support_device_types = ["cuda", torch._C._get_privateuse1_backend_name()]
     if old_param_device is None:

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -60,6 +60,7 @@ class PackedSequence(PackedSequence_):
         (i.e., they only pass in tensors conforming to this constraint).
 
     """
+
     def __new__(cls, data, batch_sizes=None, sorted_indices=None, unsorted_indices=None):
         return super().__new__(
             cls,
@@ -116,7 +117,7 @@ class PackedSequence(PackedSequence_):
         return self.to(dtype=torch.uint8)
 
     def to(self, *args, **kwargs):
-        r"""Performs dtype and/or device conversion on `self.data`.
+        r"""Perform dtype and/or device conversion on `self.data`.
 
         It has similar signature as :meth:`torch.Tensor.to`, except optional
         arguments like `non_blocking` and `copy` should be passed as kwargs,
@@ -128,7 +129,6 @@ class PackedSequence(PackedSequence_):
             and :class:`torch.device`, then ``self`` is returned.
             Otherwise, returns a copy with the desired configuration.
         """
-
         # Why not convert `batch_sizes`?
         # See NOTE [ device and dtype of a PackedSequence ]
         data = self.data.to(*args, **kwargs)
@@ -143,11 +143,11 @@ class PackedSequence(PackedSequence_):
 
     @property
     def is_cuda(self):
-        r"""Returns true if `self.data` stored on a gpu"""
+        r"""Return true if `self.data` stored on a gpu."""
         return self.data.is_cuda
 
     def is_pinned(self):
-        r"""Returns true if `self.data` stored on in pinned memory"""
+        r"""Return true if `self.data` stored on in pinned memory."""
         return self.data.is_pinned()
 
 
@@ -271,7 +271,7 @@ def pad_packed_sequence(
     padding_value: float = 0.0,
     total_length: Optional[int] = None,
 ) -> Tuple[Tensor, Tensor]:
-    r"""Pads a packed batch of variable length sequences.
+    r"""Pad a packed batch of variable length sequences.
 
     It is an inverse operation to :func:`pack_padded_sequence`.
 
@@ -344,7 +344,7 @@ def pad_sequence(
     batch_first: bool = False,
     padding_value: float = 0.0,
 ) -> Tensor:
-    r"""Pad a list of variable length Tensors with ``padding_value``
+    r"""Pad a list of variable length Tensors with ``padding_value``.
 
     ``pad_sequence`` stacks a list of Tensors along a new dimension,
     and pads them to equal length. For example, if the input is a list of
@@ -379,7 +379,6 @@ def pad_sequence(
         Tensor of size ``T x B x *`` if :attr:`batch_first` is ``False``.
         Tensor of size ``B x T x *`` otherwise
     """
-
     if not (torch.jit.is_tracing() or torch.jit.is_scripting()):
         # JIT doesn't support `Iterable`
         if not isinstance(sequences, Iterable):
@@ -405,7 +404,7 @@ def unpad_sequence(
     lengths: Tensor,
     batch_first: bool = False,
 ) -> List[Tensor]:
-    r"""Unpad padded Tensor into a list of variable length Tensors
+    r"""Unpad padded Tensor into a list of variable length Tensors.
 
     ``unpad_sequence`` unstacks padded Tensor into a list of variable length Tensors.
 
@@ -433,7 +432,6 @@ def unpad_sequence(
     Returns:
         a list of :class:`Tensor` objects
     """
-
     unpadded_sequences = []
 
     if not batch_first:
@@ -451,7 +449,7 @@ def unpad_sequence(
 
 
 def pack_sequence(sequences: List[Tensor], enforce_sorted: bool = True) -> PackedSequence:
-    r"""Packs a list of variable length Tensors
+    r"""Packs a list of variable length Tensors.
 
     Consecutive call of the next functions: ``pad_sequence``, ``pack_padded_sequence``.
 
@@ -487,7 +485,7 @@ def pack_sequence(sequences: List[Tensor], enforce_sorted: bool = True) -> Packe
 
 
 def unpack_sequence(packed_sequences: PackedSequence) -> List[Tensor]:
-    r"""Unpacks PackedSequence into a list of variable length Tensors
+    r"""Unpack PackedSequence into a list of variable length Tensors.
 
     ``packed_sequences`` should be a PackedSequence object.
 
@@ -514,7 +512,6 @@ def unpack_sequence(packed_sequences: PackedSequence) -> List[Tensor]:
     Returns:
         a list of :class:`Tensor` objects
     """
-
     padded_sequences, lengths = pad_packed_sequence(packed_sequences, batch_first=True)
     unpacked_sequences = unpad_sequence(padded_sequences, lengths, batch_first=True)
     return unpacked_sequences


### PR DESCRIPTION
Fixes #112632

Before: 171
```
torch/backends/_nnapi/prepare.py:24 in public method `__init__`:
        D107: Missing docstring in __init__
torch/backends/_nnapi/prepare.py:46 in public method `init`:
        D102: Missing docstring in public method
torch/backends/_nnapi/prepare.py:60 in public method `forward`:
        D102: Missing docstring in public method
torch/backends/_nnapi/prepare.py:94 in public function `convert_model_to_nnapi`:
        D103: Missing docstring in public function
torch/backends/_nnapi/prepare.py:153 in public function `process_for_nnapi`:
        D103: Missing docstring in public function
torch/backends/_nnapi/prepare.py:177 in private nested class `ShapeComputeModule`:
        D400: First line should end with a period (not 'n')
torch/backends/_nnapi/serializer.py:19 in public class `NNAPI_OperandCode`:
        D101: Missing docstring in public class
torch/backends/_nnapi/serializer.py:35 in public class `NNAPI_OperationCode`:
        D101: Missing docstring in public class
torch/backends/_nnapi/serializer.py:133 in public class `NNAPI_FuseCode`:
        D101: Missing docstring in public class
torch/backends/_nnapi/serializer.py:140 in public class `OperandValueSourceType`:
        D101: Missing docstring in public class
torch/backends/_nnapi/serializer.py:150 in public class `TorchScalarTypes`:
        D101: Missing docstring in public class
torch/backends/_nnapi/serializer.py:154 in public function `approx_equal`:
        D103: Missing docstring in public function
torch/backends/_nnapi/serializer.py:158 in public function `tensor_size`:
        D103: Missing docstring in public function
torch/backends/_nnapi/serializer.py:172 in public function `change_element`:
        D103: Missing docstring in public function
torch/backends/_nnapi/serializer.py:194 in public class `DimOrder`:
        D101: Missing docstring in public class
torch/backends/_nnapi/serializer.py:225 in public method `use_nchw`:
        D102: Missing docstring in public method
torch/backends/_nnapi/serializer.py:233 in public function `broadcast_shapes`:
        D103: Missing docstring in public function
torch/backends/_nnapi/serializer.py:260 in public function `get_conv_pool_shape`:
        D103: Missing docstring in public function
torch/backends/_nnapi/serializer.py:284 in public function `fix_shape`:
        D103: Missing docstring in public function
torch/backends/_nnapi/serializer.py:301 in public function `reverse_map_dim`:
        D103: Missing docstring in public function
torch/backends/_nnapi/serializer.py:312 in public function `flex_name`:
        D103: Missing docstring in public function
torch/backends/_nnapi/serializer.py:1337 in private method `_do_add_binary`:
        D400: First line should end with a period (not 's')
torch/backends/_nnapi/serializer.py:1337 in private method `_do_add_binary`:
        D401: First line should be in imperative mood; try rephrasing (found 'Helper')
torch/backends/_nnapi/serializer.py:2180 in public function `serialize_model`:
        D202: No blank lines allowed after function docstring (found 1)
torch/backends/_nnapi/serializer.py:2180 in public function `serialize_model`:
        D205: 1 blank line required between summary line and description (found 0)
torch/backends/_nnapi/serializer.py:2180 in public function `serialize_model`:
        D400: First line should end with a period (not ':')
torch/backends/cuda/__init__.py:1 at module level:
        D104: Missing docstring in public package
torch/backends/cuda/__init__.py:30 in public function `is_built`:
        D205: 1 blank line required between summary line and description (found 0)
torch/backends/cuda/__init__.py:30 in public function `is_built`:
        D209: Multi-line docstring closing quotes should be on a separate line
torch/backends/cuda/__init__.py:30 in public function `is_built`:
        D400: First line should end with a period (not 's')
torch/backends/cuda/__init__.py:30 in public function `is_built`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/backends/cuda/__init__.py:37 in public class `cuFFTPlanCacheAttrContextProp`:
        D101: Missing docstring in public class
torch/backends/cuda/__init__.py:40 in public method `__init__`:
        D107: Missing docstring in __init__
torch/backends/cuda/__init__.py:44 in public method `__get__`:
        D105: Missing docstring in magic method
torch/backends/cuda/__init__.py:47 in public method `__set__`:
        D105: Missing docstring in magic method
torch/backends/cuda/__init__.py:54 in public class `cuFFTPlanCache`:
        D205: 1 blank line required between summary line and description (found 0)
torch/backends/cuda/__init__.py:54 in public class `cuFFTPlanCache`:
        D400: First line should end with a period (not 'e')
torch/backends/cuda/__init__.py:60 in public method `__init__`:
        D107: Missing docstring in __init__
torch/backends/cuda/__init__.py:73 in public method `clear`:
        D102: Missing docstring in public method
torch/backends/cuda/__init__.py:78 in public class `cuFFTPlanCacheManager`:
        D205: 1 blank line required between summary line and description (found 0)
torch/backends/cuda/__init__.py:78 in public class `cuFFTPlanCacheManager`:
        D400: First line should end with a period (not ',')
torch/backends/cuda/__init__.py:89 in public method `__init__`:
        D107: Missing docstring in __init__
torch/backends/cuda/__init__.py:93 in public method `__getitem__`:
        D105: Missing docstring in magic method
torch/backends/cuda/__init__.py:106 in public method `__getattr__`:
        D105: Missing docstring in magic method
torch/backends/cuda/__init__.py:109 in public method `__setattr__`:
        D105: Missing docstring in magic method
torch/backends/cuda/__init__.py:116 in public class `cuBLASModule`:
        D101: Missing docstring in public class
torch/backends/cuda/__init__.py:117 in public method `__getattr__`:
        D105: Missing docstring in magic method
torch/backends/cuda/__init__.py:126 in public method `__setattr__`:
        D105: Missing docstring in magic method
torch/backends/cuda/__init__.py:147 in public function `preferred_linalg_library`:
        D202: No blank lines allowed after function docstring (found 1)
torch/backends/cuda/__init__.py:204 in public class `SDPBackend`:
        D204: 1 blank line required after class docstring (found 0)
torch/backends/cudnn/__init__.py:1 at module level:
        D104: Missing docstring in public package
torch/backends/cudnn/__init__.py:81 in public function `version`:
        D400: First line should end with a period (not 'N')
torch/backends/cudnn/__init__.py:81 in public function `version`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/backends/cudnn/__init__.py:95 in public function `is_available`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/backends/cudnn/__init__.py:99 in public function `is_acceptable`:
        D103: Missing docstring in public function
torch/backends/cudnn/__init__.py:122 in public function `set_flags`:
        D103: Missing docstring in public function
torch/backends/cudnn/__init__.py:150 in public function `flags`:
        D103: Missing docstring in public function
torch/backends/cudnn/__init__.py:174 in public class `CudnnModule`:
        D101: Missing docstring in public class
torch/backends/cudnn/__init__.py:175 in public method `__init__`:
        D107: Missing docstring in __init__
torch/backends/mkl/__init__.py:1 at module level:
        D104: Missing docstring in public package
torch/backends/mkl/__init__.py:5 in public function `is_available`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/backends/mkl/__init__.py:14 in public class `verbose`:
        D205: 1 blank line required between summary line and description (found 0)
torch/backends/mkl/__init__.py:14 in public class `verbose`:
        D400: First line should end with a period (not 'y')
torch/backends/mkl/__init__.py:41 in public method `__init__`:
        D107: Missing docstring in __init__
torch/backends/mkl/__init__.py:44 in public method `__enter__`:
        D105: Missing docstring in magic method
torch/backends/mkl/__init__.py:53 in public method `__exit__`:
        D105: Missing docstring in magic method
torch/backends/mkldnn/__init__.py:1 at module level:
        D104: Missing docstring in public package
torch/backends/mkldnn/__init__.py:9 in public function `is_available`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/backends/mkldnn/__init__.py:19 in public class `verbose`:
        D205: 1 blank line required between summary line and description (found 0)
torch/backends/mkldnn/__init__.py:19 in public class `verbose`:
        D400: First line should end with a period (not 'y')
torch/backends/mkldnn/__init__.py:47 in public method `__init__`:
        D107: Missing docstring in __init__
torch/backends/mkldnn/__init__.py:50 in public method `__enter__`:
        D105: Missing docstring in magic method
torch/backends/mkldnn/__init__.py:59 in public method `__exit__`:
        D105: Missing docstring in magic method
torch/backends/mkldnn/__init__.py:64 in public function `set_flags`:
        D103: Missing docstring in public function
torch/backends/mkldnn/__init__.py:71 in public function `flags`:
        D103: Missing docstring in public function
torch/backends/mkldnn/__init__.py:81 in public class `MkldnnModule`:
        D101: Missing docstring in public class
torch/backends/mkldnn/__init__.py:82 in public method `__init__`:
        D107: Missing docstring in __init__
torch/backends/openmp/__init__.py:1 at module level:
        D104: Missing docstring in public package
torch/backends/openmp/__init__.py:5 in public function `is_available`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/nn/intrinsic/qat/modules/conv_fused.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/intrinsic/qat/modules/linear_fused.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/intrinsic/qat/modules/linear_relu.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/qat/__init__.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/qat/dynamic/__init__.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/qat/dynamic/modules/linear.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/qat/modules/__init__.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/qat/modules/conv.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/qat/modules/embedding_ops.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/qat/modules/linear.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/quantizable/modules/activation.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/quantizable/modules/rnn.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/quantized/_reference/modules/__init__.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/quantized/_reference/modules/conv.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/quantized/_reference/modules/linear.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/quantized/_reference/modules/rnn.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/quantized/_reference/modules/sparse.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/quantized/_reference/modules/utils.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/quantized/dynamic/modules/__init__.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/quantized/dynamic/modules/conv.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/quantized/dynamic/modules/linear.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/quantized/dynamic/modules/rnn.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/quantized/functional.py:1 at module level:
        D400: First line should end with a period (not 'l')
torch/nn/quantized/modules/__init__.py:1 at module level:
        D400: First line should end with a period (not 's')
torch/nn/quantized/modules/activation.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/quantized/modules/batchnorm.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/quantized/modules/conv.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/quantized/modules/dropout.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/quantized/modules/embedding_ops.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/quantized/modules/functional_modules.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/quantized/modules/linear.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/quantized/modules/normalization.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/quantized/modules/rnn.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/quantized/modules/utils.py:2 at module level:
        D400: First line should end with a period (not 's')
torch/nn/utils/_expanded_weights/conv_utils.py:13 in public function `conv_picker`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/conv_utils.py:23 in public function `conv_args_and_kwargs`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/conv_utils.py:31 in public function `conv_normalizer`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/conv_utils.py:35 in public function `conv_input_for_string_padding`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/conv_utils.py:43 in public function `int_padding_for_string_padding`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/conv_utils.py:59 in public function `conv_padding_for_same`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/conv_utils.py:66 in public function `conv_backward`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/conv_utils.py:131 in public function `conv_unfold_weight_grad_sample`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/conv_utils.py:166 in public function `conv_group_weight_grad_sample`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/conv_utils.py:189 in public function `unfold3d`:
        D202: No blank lines allowed after function docstring (found 1)
torch/nn/utils/_expanded_weights/conv_utils.py:189 in public function `unfold3d`:
        D205: 1 blank line required between summary line and description (found 0)
torch/nn/utils/_expanded_weights/conv_utils.py:189 in public function `unfold3d`:
        D401: First line should be in imperative mood (perhaps 'Extract', not 'Extracts')
torch/nn/utils/_expanded_weights/expanded_weights_utils.py:6 in public function `is_batch_first`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/expanded_weights_utils.py:19 in public function `standard_kwargs`:
        D205: 1 blank line required between summary line and description (found 0)
torch/nn/utils/_expanded_weights/expanded_weights_utils.py:19 in public function `standard_kwargs`:
        D300: Use """triple double quotes""" (found '''-quotes)
torch/nn/utils/_expanded_weights/expanded_weights_utils.py:19 in public function `standard_kwargs`:
        D400: First line should end with a period (not 'e')
torch/nn/utils/_expanded_weights/expanded_weights_utils.py:28 in public function `forward_helper`:
        D205: 1 blank line required between summary line and description (found 0)
torch/nn/utils/_expanded_weights/expanded_weights_utils.py:28 in public function `forward_helper`:
        D300: Use """triple double quotes""" (found '''-quotes)
torch/nn/utils/_expanded_weights/expanded_weights_utils.py:28 in public function `forward_helper`:
        D400: First line should end with a period (not ')')
torch/nn/utils/_expanded_weights/expanded_weights_utils.py:84 in public function `maybe_scale_by_batch_size`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/expanded_weights_utils.py:90 in public function `set_grad_sample_if_exists`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/expanded_weights_utils.py:108 in public function `unpack_expanded_weight_or_tensor`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/expanded_weights_utils.py:123 in public function `sum_over_all_but_batch_and_last_n`:
        D205: 1 blank line required between summary line and description (found 0)
torch/nn/utils/_expanded_weights/expanded_weights_utils.py:123 in public function `sum_over_all_but_batch_and_last_n`:
        D400: First line should end with a period (not 't')
torch/nn/utils/_expanded_weights/expanded_weights_utils.py:123 in public function `sum_over_all_but_batch_and_last_n`:
        D401: First line should be in imperative mood (perhaps 'Calculate', not 'Calculates')
torch/nn/utils/convert_parameters.py:1 at module level:
        D100: Missing docstring in public module
torch/nn/utils/convert_parameters.py:57 in private function `_check_param_device`:
        D202: No blank lines allowed after function docstring (found 1)
torch/nn/utils/convert_parameters.py:57 in private function `_check_param_device`:
        D205: 1 blank line required between summary line and description (found 0)
torch/nn/utils/convert_parameters.py:57 in private function `_check_param_device`:
        D400: First line should end with a period (not 'd')
torch/nn/utils/convert_parameters.py:57 in private function `_check_param_device`:
        D401: First line should be in imperative mood; try rephrasing (found 'This')
torch/nn/utils/rnn.py:1 at module level:
        D100: Missing docstring in public module
torch/nn/utils/rnn.py:28 in public class `PackedSequence`:
        D204: 1 blank line required after class docstring (found 0)
torch/nn/utils/rnn.py:63 in public method `__new__`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:73 in public method `pin_memory`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:80 in public method `cuda`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:87 in public method `cpu`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:94 in public method `double`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:97 in public method `float`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:100 in public method `half`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:103 in public method `long`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:106 in public method `int`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:109 in public method `short`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:112 in public method `char`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:115 in public method `byte`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:119 in public method `to`:
        D202: No blank lines allowed after function docstring (found 1)
torch/nn/utils/rnn.py:119 in public method `to`:
        D401: First line should be in imperative mood (perhaps 'Perform', not 'Performs')
torch/nn/utils/rnn.py:146 in public method `is_cuda`:
        D400: First line should end with a period (not 'u')
torch/nn/utils/rnn.py:150 in public method `is_pinned`:
        D400: First line should end with a period (not 'y')
torch/nn/utils/rnn.py:150 in public method `is_pinned`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/nn/utils/rnn.py:198 in public function `invert_permutation`:
        D103: Missing docstring in public function
torch/nn/utils/rnn.py:274 in public function `pad_packed_sequence`:
        D401: First line should be in imperative mood (perhaps 'Pad', not 'Pads')
torch/nn/utils/rnn.py:347 in public function `pad_sequence`:
        D202: No blank lines allowed after function docstring (found 1)
torch/nn/utils/rnn.py:347 in public function `pad_sequence`:
        D400: First line should end with a period (not '`')
torch/nn/utils/rnn.py:408 in public function `unpad_sequence`:
        D202: No blank lines allowed after function docstring (found 1)
torch/nn/utils/rnn.py:408 in public function `unpad_sequence`:
        D400: First line should end with a period (not 's')
torch/nn/utils/rnn.py:454 in public function `pack_sequence`:
        D400: First line should end with a period (not 's')
torch/nn/utils/rnn.py:490 in public function `unpack_sequence`:
        D202: No blank lines allowed after function docstring (found 1)
torch/nn/utils/rnn.py:490 in public function `unpack_sequence`:
        D400: First line should end with a period (not 's')
171
```

After: 81
```
torch/backends/_nnapi/prepare.py:24 in public method `__init__`:
        D107: Missing docstring in __init__
torch/backends/_nnapi/prepare.py:46 in public method `init`:
        D102: Missing docstring in public method
torch/backends/_nnapi/prepare.py:60 in public method `forward`:
        D102: Missing docstring in public method
torch/backends/_nnapi/prepare.py:94 in public function `convert_model_to_nnapi`:
        D103: Missing docstring in public function
torch/backends/_nnapi/prepare.py:153 in public function `process_for_nnapi`:
        D103: Missing docstring in public function
torch/backends/_nnapi/serializer.py:19 in public class `NNAPI_OperandCode`:
        D101: Missing docstring in public class
torch/backends/_nnapi/serializer.py:35 in public class `NNAPI_OperationCode`:
        D101: Missing docstring in public class
torch/backends/_nnapi/serializer.py:133 in public class `NNAPI_FuseCode`:
        D101: Missing docstring in public class
torch/backends/_nnapi/serializer.py:140 in public class `OperandValueSourceType`:
        D101: Missing docstring in public class
torch/backends/_nnapi/serializer.py:150 in public class `TorchScalarTypes`:
        D101: Missing docstring in public class
torch/backends/_nnapi/serializer.py:154 in public function `approx_equal`:
        D103: Missing docstring in public function
torch/backends/_nnapi/serializer.py:158 in public function `tensor_size`:
        D103: Missing docstring in public function
torch/backends/_nnapi/serializer.py:172 in public function `change_element`:
        D103: Missing docstring in public function
torch/backends/_nnapi/serializer.py:194 in public class `DimOrder`:
        D101: Missing docstring in public class
torch/backends/_nnapi/serializer.py:225 in public method `use_nchw`:
        D102: Missing docstring in public method
torch/backends/_nnapi/serializer.py:233 in public function `broadcast_shapes`:
        D103: Missing docstring in public function
torch/backends/_nnapi/serializer.py:260 in public function `get_conv_pool_shape`:
        D103: Missing docstring in public function
torch/backends/_nnapi/serializer.py:284 in public function `fix_shape`:
        D103: Missing docstring in public function
torch/backends/_nnapi/serializer.py:301 in public function `reverse_map_dim`:
        D103: Missing docstring in public function
torch/backends/_nnapi/serializer.py:312 in public function `flex_name`:
        D103: Missing docstring in public function
torch/backends/cuda/__init__.py:1 at module level:
        D104: Missing docstring in public package
torch/backends/cuda/__init__.py:39 in public class `cuFFTPlanCacheAttrContextProp`:
        D101: Missing docstring in public class
torch/backends/cuda/__init__.py:42 in public method `__init__`:
        D107: Missing docstring in __init__
torch/backends/cuda/__init__.py:46 in public method `__get__`:
        D105: Missing docstring in magic method
torch/backends/cuda/__init__.py:49 in public method `__set__`:
        D105: Missing docstring in magic method
torch/backends/cuda/__init__.py:63 in public method `__init__`:
        D107: Missing docstring in __init__
torch/backends/cuda/__init__.py:76 in public method `clear`:
        D102: Missing docstring in public method
torch/backends/cuda/__init__.py:91 in public method `__init__`:
        D107: Missing docstring in __init__
torch/backends/cuda/__init__.py:95 in public method `__getitem__`:
        D105: Missing docstring in magic method
torch/backends/cuda/__init__.py:108 in public method `__getattr__`:
        D105: Missing docstring in magic method
torch/backends/cuda/__init__.py:111 in public method `__setattr__`:
        D105: Missing docstring in magic method
torch/backends/cuda/__init__.py:118 in public class `cuBLASModule`:
        D101: Missing docstring in public class
torch/backends/cuda/__init__.py:119 in public method `__getattr__`:
        D105: Missing docstring in magic method
torch/backends/cuda/__init__.py:128 in public method `__setattr__`:
        D105: Missing docstring in magic method
torch/backends/cudnn/__init__.py:1 at module level:
        D104: Missing docstring in public package
torch/backends/cudnn/__init__.py:99 in public function `is_acceptable`:
        D103: Missing docstring in public function
torch/backends/cudnn/__init__.py:122 in public function `set_flags`:
        D103: Missing docstring in public function
torch/backends/cudnn/__init__.py:150 in public function `flags`:
        D103: Missing docstring in public function
torch/backends/cudnn/__init__.py:174 in public class `CudnnModule`:
        D101: Missing docstring in public class
torch/backends/cudnn/__init__.py:175 in public method `__init__`:
        D107: Missing docstring in __init__
torch/backends/mkl/__init__.py:1 at module level:
        D104: Missing docstring in public package
torch/backends/mkl/__init__.py:42 in public method `__init__`:
        D107: Missing docstring in __init__
torch/backends/mkl/__init__.py:45 in public method `__enter__`:
        D105: Missing docstring in magic method
torch/backends/mkl/__init__.py:54 in public method `__exit__`:
        D105: Missing docstring in magic method
torch/backends/mkldnn/__init__.py:1 at module level:
        D104: Missing docstring in public package
torch/backends/mkldnn/__init__.py:48 in public method `__init__`:
        D107: Missing docstring in __init__
torch/backends/mkldnn/__init__.py:51 in public method `__enter__`:
        D105: Missing docstring in magic method
torch/backends/mkldnn/__init__.py:60 in public method `__exit__`:
        D105: Missing docstring in magic method
torch/backends/mkldnn/__init__.py:65 in public function `set_flags`:
        D103: Missing docstring in public function
torch/backends/mkldnn/__init__.py:72 in public function `flags`:
        D103: Missing docstring in public function
torch/backends/mkldnn/__init__.py:82 in public class `MkldnnModule`:
        D101: Missing docstring in public class
torch/backends/mkldnn/__init__.py:83 in public method `__init__`:
        D107: Missing docstring in __init__
torch/backends/openmp/__init__.py:1 at module level:
        D104: Missing docstring in public package
torch/nn/utils/_expanded_weights/conv_utils.py:13 in public function `conv_picker`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/conv_utils.py:23 in public function `conv_args_and_kwargs`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/conv_utils.py:31 in public function `conv_normalizer`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/conv_utils.py:35 in public function `conv_input_for_string_padding`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/conv_utils.py:43 in public function `int_padding_for_string_padding`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/conv_utils.py:59 in public function `conv_padding_for_same`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/conv_utils.py:66 in public function `conv_backward`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/conv_utils.py:131 in public function `conv_unfold_weight_grad_sample`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/conv_utils.py:166 in public function `conv_group_weight_grad_sample`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/expanded_weights_utils.py:6 in public function `is_batch_first`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/expanded_weights_utils.py:87 in public function `maybe_scale_by_batch_size`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/expanded_weights_utils.py:93 in public function `set_grad_sample_if_exists`:
        D103: Missing docstring in public function
torch/nn/utils/_expanded_weights/expanded_weights_utils.py:111 in public function `unpack_expanded_weight_or_tensor`:
        D103: Missing docstring in public function
torch/nn/utils/convert_parameters.py:1 at module level:
        D100: Missing docstring in public module
torch/nn/utils/rnn.py:1 at module level:
        D100: Missing docstring in public module
torch/nn/utils/rnn.py:64 in public method `__new__`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:74 in public method `pin_memory`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:81 in public method `cuda`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:88 in public method `cpu`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:95 in public method `double`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:98 in public method `float`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:101 in public method `half`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:104 in public method `long`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:107 in public method `int`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:110 in public method `short`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:113 in public method `char`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:116 in public method `byte`:
        D102: Missing docstring in public method
torch/nn/utils/rnn.py:198 in public function `invert_permutation`:
        D103: Missing docstring in public function
81
```


cc @svekars @carljparker