### PR TITLE
BUG: compile np.array(list_of_arrays)

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1716,6 +1716,25 @@ utils_device.CURRENT_DEVICE == None""",
             self.assertEqual(ref, res)
         self.assertEqual(cnts.frame_count, 1)
 
+    def test_numpy_array_of_arrays(self):
+        def fn(x, y):
+            return np.array([x, y])
+
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch._dynamo.optimize(cnts, nopython=True)(fn)
+
+        x, y = np.float64(1), np.float64(2)
+        res = opt_fn(x, y)
+        self.assertEqual(res, np.array([1, 2], dtype=float))
+        self.assertEqual(type(res), np.ndarray)
+        self.assertEqual(cnts.frame_count, 1)
+
+        x, y = np.arange(2), np.arange(2) + 2
+        res = opt_fn(x, y)
+        self.assertEqual(res, np.array([[0, 1], [2, 3]]))
+        self.assertEqual(type(res), np.ndarray)
+        self.assertEqual(cnts.frame_count, 2)
+
     def test_numpy_readonly(self):
         @torch.compile(fullgraph=True)
         def fn(x):

--- a/torch/_numpy/_ndarray.py
+++ b/torch/_numpy/_ndarray.py
@@ -506,13 +506,13 @@ def array(obj, dtype=None, *, copy=True, order="K", subok=False, ndmin=0, like=N
         return obj
 
     if isinstance(obj, (list, tuple)):
-        # list of arrays *under torch.Dynamo*
         if obj and all(isinstance(x, torch.Tensor) for x in obj):
-            return ndarray(torch.stack(obj))
-
-        # XXX: remove tolist
-        # lists of ndarrays: [1, [2, 3], ndarray(4)] convert to lists of lists
-        obj = _tolist(obj)
+            # list of arrays: *under torch.Dynamo* these are FakeTensors
+            obj = torch.stack(obj)
+        else:
+            # XXX: remove tolist
+            # lists of ndarrays: [1, [2, 3], ndarray(4)] convert to lists of lists
+            obj = _tolist(obj)
 
     # is obj an ndarray already?
     if isinstance(obj, ndarray):

--- a/torch/_numpy/_ndarray.py
+++ b/torch/_numpy/_ndarray.py
@@ -505,8 +505,13 @@ def array(obj, dtype=None, *, copy=True, order="K", subok=False, ndmin=0, like=N
     ):
         return obj
 
-    # lists of ndarrays: [1, [2, 3], ndarray(4)] convert to lists of lists
     if isinstance(obj, (list, tuple)):
+        # list of arrays *under torch.Dynamo*
+        if obj and all(isinstance(x, torch.Tensor) for x in obj):
+            return ndarray(torch.stack(obj))
+
+        # XXX: remove tolist
+        # lists of ndarrays: [1, [2, 3], ndarray(4)] convert to lists of lists
         obj = _tolist(obj)
 
     # is obj an ndarray already?


### PR DESCRIPTION
Add a shortcut for a sequence of arrays only. This remove a graph break on a common pattern of
`np.array([np.cos(theta), np.sin(theta)])` and its ilk.

This PR is a simpified alternative to https://github.com/pytorch/pytorch/pull/112521 --- it still breaks on mixing arrays and scalars or array_likes (e.g.  `np.array([[1, 2], np.array[3, 4]])`) and instead adds a simple shortcut.


cc @mruberry @rgommers @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng