### PR TITLE
s390x: fix inductor constructing floats out of bytes

### DIFF
--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -1,6 +1,7 @@
 import functools
 import logging
 import math
+import sys
 import typing
 from typing import Optional
 
@@ -488,7 +489,10 @@ def dequantize_per_tensor_tensor_decomp_impl(
 def q_embedding_bag_byte_unpack_decomp(packed):
     def bitcast_u8_to_f32(u8):
         x, y, z, w = (u8[..., n].to(torch.int32) for n in (0, 1, 2, 3))
-        return (x + (y << 8) + (z << 16) + (w << 24)).view(torch.float32)[..., None]
+        if sys.byteorder == "little":
+            return (x + (y << 8) + (z << 16) + (w << 24)).view(torch.float32)[..., None]
+        else:
+            return ((x << 24) + (y << 16) + (z << 8) + w).view(torch.float32)[..., None]
 
     scales = bitcast_u8_to_f32(packed[..., -8:-4])
     offsets = bitcast_u8_to_f32(packed[..., -4:])


### PR DESCRIPTION
This change fixes test_embedding_bag_byte_unpack_cpu from test/inductor/test_torchinductor.py on s390x.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler