### PR TITLE
[aotinductor] Move cache_dir to utils.py

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -13,7 +13,7 @@ import torch.fx._pytree as fx_pytree
 from torch._dynamo.testing import same
 from torch._inductor import config
 from torch._inductor.exc import CppWrapperCodeGenError
-from torch._inductor.utils import aot_inductor_launcher
+from torch._inductor.utils import aot_inductor_launcher, cache_dir
 
 from torch.testing import FileCheck
 
@@ -92,7 +92,7 @@ class AOTInductorModelRunner:
                 name="aot_inductor",
                 cpp_sources=[aot_inductor_launcher(so_path, device)],
                 # use a unique build directory to avoid test interference
-                build_directory=tempfile.mkdtemp(),
+                build_directory=tempfile.mkdtemp(dir=cache_dir()),
                 functions=["run", "get_call_spec"],
                 with_cuda=(device == "cuda"),
             )
@@ -245,7 +245,7 @@ class AOTInductorTestsTemplate:
             torch.randn(10, 10, device=self.device),
             torch.randn(10, 10, device=self.device),
         )
-        expected_path = os.path.join(tempfile.mkdtemp(), "model.so")
+        expected_path = os.path.join(tempfile.mkdtemp(dir=cache_dir()), "model.so")
         actual_path = AOTInductorModelRunner.compile(
             model, example_inputs, options={"aot_inductor.output_path": expected_path}
         )

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -4,7 +4,6 @@ import base64
 import copyreg
 import dataclasses
 import functools
-import getpass
 import hashlib
 import importlib
 import io
@@ -49,7 +48,7 @@ from torch._dynamo.device_interface import (
 from torch._dynamo.utils import counters
 from torch._inductor import config, exc
 from torch._inductor.codegen.cuda import cuda_env
-from torch._inductor.utils import developer_warning, is_linux
+from torch._inductor.utils import cache_dir, developer_warning, is_linux
 from torch._prims_common import suggest_memory_format
 from torch.fx.experimental.symbolic_shapes import has_hint, hint_int, ShapeEnv
 
@@ -110,15 +109,6 @@ def _compile_end() -> None:
 
 
 log = logging.getLogger(__name__)
-
-
-@functools.lru_cache(None)
-def cache_dir() -> str:
-    cache_dir = os.environ.get("TORCHINDUCTOR_CACHE_DIR")
-    if cache_dir is None:
-        cache_dir = f"{tempfile.gettempdir()}/torchinductor_{getpass.getuser()}"
-    os.makedirs(cache_dir, exist_ok=True)
-    return cache_dir
 
 
 def cpp_wrapper_cache_dir(name: str) -> str:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -4,6 +4,7 @@ import collections
 import contextlib
 import enum
 import functools
+import getpass
 import inspect
 import itertools
 import logging
@@ -589,6 +590,15 @@ instance_descriptor = collections.namedtuple(
     ["divisible_by_16", "equal_to_1", "ids_of_folded_args", "divisible_by_8"],
     defaults=[tuple(), tuple(), tuple(), tuple()],
 )
+
+
+@functools.lru_cache(None)
+def cache_dir() -> str:
+    cache_dir = os.environ.get("TORCHINDUCTOR_CACHE_DIR")
+    if cache_dir is None:
+        cache_dir = f"{tempfile.gettempdir()}/torchinductor_{getpass.getuser()}"
+    os.makedirs(cache_dir, exist_ok=True)
+    return cache_dir
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #112728
* #112651

Summary: Some tests can utilize cache_dir()

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler