### PR TITLE
[pytree] Add back a default serialized name

### DIFF
--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -533,6 +533,7 @@ TreeSpec(tuple, None, [*,
         # the namedtuple type.
         self.assertEqual(spec.context._fields, roundtrip_spec.context._fields)
 
+    @unittest.expectedFailure
     def test_pytree_custom_type_serialize_bad(self):
         class DummyType:
             def __init__(self, x, y):

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -170,7 +170,7 @@ def _register_pytree_node(
         )
 
     if serialized_type_name is None:
-        serialized_type_name = NO_SERIALIZED_TYPE_NAME_FOUND
+        serialized_type_name = f"{typ.__module__}.{typ.__name__}"
 
     serialize_node_def = _SerializeNodeDef(
         typ, serialized_type_name, to_dumpable_context, from_dumpable_context


### PR DESCRIPTION
Previously we added a change which required users to pass in a serialized name if they want to serialize a pytree so that the serialized name does not depend on the python environment. However this is currently breaking AOTInductor benchmark tests as AOTInductor will serialize the pytree into the .so for flattening/unflattening the inputs. However, the registration for those pytree types in the AOTInductor benchmarks are in the huggingface repo, so I'm not sure what's a good fix for now.