### PR TITLE
Fix docstring errors in memory.py, nvtx.py

### DIFF
--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -148,7 +148,9 @@ def set_per_process_memory_fraction(
 
 
 def empty_cache() -> None:
-    r"""Release all unoccupied cached memory currently held by the caching allocator so that those can be used in other GPU application and visible in `nvidia-smi`.
+    r"""Release all unoccupied cached memory currently held by the caching
+    allocator so that those can be used in other GPU application and visible in
+    `nvidia-smi`.
 
     .. note::
         :func:`~torch.cuda.empty_cache` doesn't increase the amount of GPU
@@ -671,7 +673,9 @@ def _record_memory_history_legacy(
 
 
 def _record_memory_history(enabled="all", *args, **kwargs):
-    """Enable recording of stack traces associated with memory allocations, so you can tell what allocated any piece of memory in :func:`torch.cuda.memory._snapshot()`.
+    """Enable recording of stack traces associated with memory
+    allocations, so you can tell what allocated any piece of memory in
+    :func:`torch.cuda.memory._snapshot()`.
 
     In addition too keeping stack traces with each current allocation and free,
     this will also enable recording of a history of all alloc/free events.
@@ -834,7 +838,10 @@ def _set_allocator_settings(env: str):
 
 
 def get_allocator_backend() -> str:
-    r"""Return a string describing the active allocator backend as set by ``PYTORCH_CUDA_ALLOC_CONF``. Currently available backends are ``native`` (PyTorch's native caching allocator) and `cudaMallocAsync`` (CUDA's built-in asynchronous allocator).
+    r"""Return a string describing the active allocator backend as set by
+    ``PYTORCH_CUDA_ALLOC_CONF``. Currently available backends are
+    ``native`` (PyTorch's native caching allocator) and `cudaMallocAsync``
+    (CUDA's built-in asynchronous allocator).
 
     .. note::
         See :ref:`cuda-memory-management` for details on choosing the allocator backend.

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -1,3 +1,5 @@
+r"""This package adds support for device memory management implemented in CUDA."""
+
 import collections
 import contextlib
 import ctypes
@@ -64,7 +66,7 @@ def _free_mutex():
 
 
 def caching_allocator_alloc(size, device: Union[Device, int] = None, stream=None):
-    r"""Performs a memory allocation using the CUDA memory allocator.
+    r"""Perform a memory allocation using the CUDA memory allocator.
 
     Memory is allocated for a given device and a stream, this
     function is intended to be used for interoperability with other
@@ -100,7 +102,7 @@ def caching_allocator_alloc(size, device: Union[Device, int] = None, stream=None
 
 
 def caching_allocator_delete(mem_ptr):
-    r"""Deletes memory allocated using the CUDA memory allocator.
+    r"""Delete memory allocated using the CUDA memory allocator.
 
     Memory allocated with :func:`~torch.cuda.caching_allocator_alloc`.
     is freed here. The associated device and stream are tracked inside
@@ -120,6 +122,7 @@ def set_per_process_memory_fraction(
     fraction, device: Union[Device, int] = None
 ) -> None:
     r"""Set memory fraction for a process.
+
     The fraction is used to limit an caching allocator to allocated memory on a CUDA device.
     The allowed value equals the total visible memory multiplied fraction.
     If trying to allocate more than the allowed value in a process, will raise an out of
@@ -145,9 +148,7 @@ def set_per_process_memory_fraction(
 
 
 def empty_cache() -> None:
-    r"""Releases all unoccupied cached memory currently held by the caching
-    allocator so that those can be used in other GPU application and visible in
-    `nvidia-smi`.
+    r"""Release all unoccupied cached memory currently held by the caching allocator so that those can be used in other GPU application and visible in `nvidia-smi`.
 
     .. note::
         :func:`~torch.cuda.empty_cache` doesn't increase the amount of GPU
@@ -160,8 +161,7 @@ def empty_cache() -> None:
 
 
 def memory_stats(device: Union[Device, int] = None) -> Dict[str, Any]:
-    r"""Returns a dictionary of CUDA memory allocator statistics for a
-    given device.
+    r"""Return a dictionary of CUDA memory allocator statistics for a given device.
 
     The return value of this function is a dictionary of statistics, each of
     which is a non-negative integer.
@@ -261,7 +261,7 @@ def memory_stats(device: Union[Device, int] = None) -> Dict[str, Any]:
 
 
 def memory_stats_as_nested_dict(device: Union[Device, int] = None) -> Dict[str, Any]:
-    r"""Returns the result of :func:`~torch.cuda.memory_stats` as a nested dictionary."""
+    r"""Return the result of :func:`~torch.cuda.memory_stats` as a nested dictionary."""
     if not is_initialized():
         return {}
     device = _get_device_index(device, optional=True)
@@ -269,7 +269,7 @@ def memory_stats_as_nested_dict(device: Union[Device, int] = None) -> Dict[str, 
 
 
 def reset_accumulated_memory_stats(device: Union[Device, int] = None) -> None:
-    r"""Resets the "accumulated" (historical) stats tracked by the CUDA memory allocator.
+    r"""Reset the "accumulated" (historical) stats tracked by the CUDA memory allocator.
 
     See :func:`~torch.cuda.memory_stats` for details. Accumulated stats correspond to
     the `"allocated"` and `"freed"` keys in each individual stat dict, as well as
@@ -289,7 +289,7 @@ def reset_accumulated_memory_stats(device: Union[Device, int] = None) -> None:
 
 
 def reset_peak_memory_stats(device: Union[Device, int] = None) -> None:
-    r"""Resets the "peak" stats tracked by the CUDA memory allocator.
+    r"""Reset the "peak" stats tracked by the CUDA memory allocator.
 
     See :func:`~torch.cuda.memory_stats` for details. Peak stats correspond to the
     `"peak"` key in each individual stat dict.
@@ -308,8 +308,7 @@ def reset_peak_memory_stats(device: Union[Device, int] = None) -> None:
 
 
 def reset_max_memory_allocated(device: Union[Device, int] = None) -> None:
-    r"""Resets the starting point in tracking maximum GPU memory occupied by
-    tensors for a given device.
+    r"""Reset the starting point in tracking maximum GPU memory occupied by tensors for a given device.
 
     See :func:`~torch.cuda.max_memory_allocated` for details.
 
@@ -335,8 +334,7 @@ def reset_max_memory_allocated(device: Union[Device, int] = None) -> None:
 
 
 def reset_max_memory_cached(device: Union[Device, int] = None) -> None:
-    r"""Resets the starting point in tracking maximum GPU memory managed by the
-    caching allocator for a given device.
+    r"""Reset the starting point in tracking maximum GPU memory managed by the caching allocator for a given device.
 
     See :func:`~torch.cuda.max_memory_cached` for details.
 
@@ -362,8 +360,7 @@ def reset_max_memory_cached(device: Union[Device, int] = None) -> None:
 
 
 def memory_allocated(device: Union[Device, int] = None) -> int:
-    r"""Returns the current GPU memory occupied by tensors in bytes for a given
-    device.
+    r"""Return the current GPU memory occupied by tensors in bytes for a given device.
 
     Args:
         device (torch.device or int, optional): selected device. Returns
@@ -380,8 +377,7 @@ def memory_allocated(device: Union[Device, int] = None) -> int:
 
 
 def max_memory_allocated(device: Union[Device, int] = None) -> int:
-    r"""Returns the maximum GPU memory occupied by tensors in bytes for a given
-    device.
+    r"""Return the maximum GPU memory occupied by tensors in bytes for a given device.
 
     By default, this returns the peak allocated memory since the beginning of
     this program. :func:`~torch.cuda.reset_peak_memory_stats` can be used to
@@ -402,8 +398,7 @@ def max_memory_allocated(device: Union[Device, int] = None) -> int:
 
 
 def memory_reserved(device: Union[Device, int] = None) -> int:
-    r"""Returns the current GPU memory managed by the caching allocator in bytes
-    for a given device.
+    r"""Return the current GPU memory managed by the caching allocator in bytes for a given device.
 
     Args:
         device (torch.device or int, optional): selected device. Returns
@@ -418,8 +413,7 @@ def memory_reserved(device: Union[Device, int] = None) -> int:
 
 
 def max_memory_reserved(device: Union[Device, int] = None) -> int:
-    r"""Returns the maximum GPU memory managed by the caching allocator in bytes
-    for a given device.
+    r"""Return the maximum GPU memory managed by the caching allocator in bytes for a given device.
 
     By default, this returns the peak cached memory since the beginning of this
     program. :func:`~torch.cuda.reset_peak_memory_stats` can be used to reset
@@ -458,7 +452,7 @@ def max_memory_cached(device: Union[Device, int] = None) -> int:
 
 
 def memory_snapshot():
-    r"""Returns a snapshot of the CUDA memory allocator state across all devices.
+    r"""Return a snapshot of the CUDA memory allocator state across all devices.
 
     Interpreting the output of this function requires familiarity with the
     memory allocator internals.
@@ -471,8 +465,7 @@ def memory_snapshot():
 
 
 def memory_summary(device: Union[Device, int] = None, abbreviated: bool = False) -> str:
-    r"""Returns a human-readable printout of the current memory allocator
-    statistics for a given device.
+    r"""Return a human-readable printout of the current memory allocator statistics for a given device.
 
     This can be useful to display periodically during training, or when
     handling out-of-memory exceptions.
@@ -609,8 +602,7 @@ def memory_summary(device: Union[Device, int] = None, abbreviated: bool = False)
 
 
 def list_gpu_processes(device: Union[Device, int] = None) -> str:
-    r"""Returns a human-readable printout of the running processes
-    and their GPU memory use for a given device.
+    r"""Return a human-readable printout of the running processes and their GPU memory use for a given device.
 
     This can be useful to display periodically during training, or when
     handling out-of-memory exceptions.
@@ -620,7 +612,6 @@ def list_gpu_processes(device: Union[Device, int] = None) -> str:
             printout for the current device, given by :func:`~torch.cuda.current_device`,
             if :attr:`device` is ``None`` (default).
     """
-
     try:
         import pynvml  # type: ignore[import]
     except ModuleNotFoundError:
@@ -645,8 +636,7 @@ def list_gpu_processes(device: Union[Device, int] = None) -> str:
 
 
 def mem_get_info(device: Union[Device, int] = None) -> Tuple[int, int]:
-    r"""Returns the global free and total GPU memory for a given
-    device using cudaMemGetInfo.
+    r"""Return the global free and total GPU memory for a given device using cudaMemGetInfo.
 
     Args:
         device (torch.device or int, optional): selected device. Returns
@@ -681,10 +671,7 @@ def _record_memory_history_legacy(
 
 
 def _record_memory_history(enabled="all", *args, **kwargs):
-    """
-    Enables recording of stack traces associated with memory
-    allocations, so you can tell what allocated any piece of memory in
-    :func:`torch.cuda.memory._snapshot()`.
+    """Enable recording of stack traces associated with memory allocations, so you can tell what allocated any piece of memory in :func:`torch.cuda.memory._snapshot()`.
 
     In addition too keeping stack traces with each current allocation and free,
     this will also enable recording of a history of all alloc/free events.
@@ -718,7 +705,6 @@ def _record_memory_history(enabled="all", *args, **kwargs):
         max_entries (int, optional): Keep a maximum of `max_entries`
             alloc/free events in the recorded history recorded.
     """
-
     if isinstance(enabled, bool):
         return _record_memory_history_legacy(enabled, *args, **kwargs)
     else:
@@ -739,7 +725,8 @@ _record_memory_history.__signature__ = signature(_record_memory_history_impl)  #
 
 
 def _snapshot(device: Union[Device, int] = None):
-    """Saves a snapshot of CUDA memory state at the time it was called.
+    """Save a snapshot of CUDA memory state at the time it was called.
+
     The state is represented as a dictionary with the following structure.
 
     .. code-block:: python
@@ -816,7 +803,8 @@ def _snapshot(device: Union[Device, int] = None):
 
 def _dump_snapshot(filename="dump_snapshot.pickle"):
     """
-    Saves a pickled version of the `torch.memory._snapshot()` dictionary to a file.
+    Save a pickled version of the `torch.memory._snapshot()` dictionary to a file.
+
     This file can be opened by the interactive snapshot viewer at pytorch.org/memory_viz
 
     Args:
@@ -846,10 +834,7 @@ def _set_allocator_settings(env: str):
 
 
 def get_allocator_backend() -> str:
-    r"""Returns a string describing the active allocator backend as set by
-    ``PYTORCH_CUDA_ALLOC_CONF``. Currently available backends are
-    ``native`` (PyTorch's native caching allocator) and `cudaMallocAsync``
-    (CUDA's built-in asynchronous allocator).
+    r"""Return a string describing the active allocator backend as set by ``PYTORCH_CUDA_ALLOC_CONF``. Currently available backends are ``native`` (PyTorch's native caching allocator) and `cudaMallocAsync`` (CUDA's built-in asynchronous allocator).
 
     .. note::
         See :ref:`cuda-memory-management` for details on choosing the allocator backend.
@@ -868,30 +853,29 @@ class _CUDAAllocator:
 
 
 class CUDAPluggableAllocator(_CUDAAllocator):
-    r"""CUDA memory allocator loaded from a so file.
-
-    Memory allocators are compiled in .so files and loaded dynamically using ctypes.
-    To change the active allocator use the :func:`torch.memory.cuda.change_current_allocator`
-    function.
-
-    Args:
-        path_to_so_file(str): Path in the filesystem to the `.so` file containing
-            the allocator functions
-        alloc_fn_name(str): Name of the function to perform the memory allocation
-            in the so file. The signature must be:
-            void* alloc_fn_name(ssize_t size, int device, cudaStream_t stream);
-        free_fn_name(str): Name of the function to perform the memory release
-            in the so file. The signature must be:
-            void free_fn_name(void* ptr, size_t size, cudaStream_t stream);
-
-    .. warning::
-        This is currently supported only in unix OSs
-
-    .. note::
-        See :ref:`cuda-memory-management` for details on creating and using a custom allocator
-    """
+    r"""CUDA memory allocator loaded from a so file."""
 
     def __init__(self, path_to_so_file: str, alloc_fn_name: str, free_fn_name: str):
+        r"""Memory allocators are compiled in .so files and loaded dynamically using ctypes.
+
+        To change the active allocator use the :func:`torch.memory.cuda.change_current_allocator` function.
+
+        Args:
+            path_to_so_file(str): Path in the filesystem to the `.so` file containing
+                the allocator functions
+            alloc_fn_name(str): Name of the function to perform the memory allocation
+                in the so file. The signature must be:
+                void* alloc_fn_name(ssize_t size, int device, cudaStream_t stream);
+            free_fn_name(str): Name of the function to perform the memory release
+                in the so file. The signature must be:
+                void free_fn_name(void* ptr, size_t size, cudaStream_t stream);
+
+        .. warning::
+            This is currently supported only in unix OSs
+
+        .. note::
+            See :ref:`cuda-memory-management` for details on creating and using a custom allocator
+        """
         allocator = ctypes.CDLL(path_to_so_file)
         alloc_fn = ctypes.cast(getattr(allocator, alloc_fn_name), ctypes.c_void_p).value
         free_fn = ctypes.cast(getattr(allocator, free_fn_name), ctypes.c_void_p).value
@@ -901,7 +885,8 @@ class CUDAPluggableAllocator(_CUDAAllocator):
 
 
 def change_current_allocator(allocator: _CUDAAllocator) -> None:
-    r"""Changes the currently used memory allocator to be the one provided.
+    r"""Change the currently used memory allocator to be the one provided.
+
     If the current allocator has already been used/initialized, this function will error.
 
 
@@ -914,7 +899,7 @@ def change_current_allocator(allocator: _CUDAAllocator) -> None:
 
 
 def _get_current_allocator() -> _CUDAAllocator:
-    r"""Returns the allocator being currently used.
+    r"""Return the allocator being currently used.
 
     .. note::
         See :ref:`cuda-memory-management` for details on creating and using a custom allocator

--- a/torch/cuda/nvtx.py
+++ b/torch/cuda/nvtx.py
@@ -1,3 +1,5 @@
+r"""This package adds support for NVIDIA Tools Extension (NVTX) used in profiling."""
+
 from contextlib import contextmanager
 
 try:
@@ -22,8 +24,7 @@ __all__ = ["range_push", "range_pop", "range_start", "range_end", "mark", "range
 
 def range_push(msg):
     """
-    Pushes a range onto a stack of nested range span.  Returns zero-based
-    depth of the range that is started.
+    Push a range onto a stack of nested range span.  Returns zero-based depth of the range that is started.
 
     Args:
         msg (str): ASCII message to associate with range
@@ -32,17 +33,13 @@ def range_push(msg):
 
 
 def range_pop():
-    """
-    Pops a range off of a stack of nested range spans.  Returns the
-    zero-based depth of the range that is ended.
-    """
+    """Pop a range off of a stack of nested range spans.  Returns the  zero-based depth of the range that is ended."""
     return _nvtx.rangePop()
 
 
 def range_start(msg) -> int:
     """
-    Mark the start of a range with string message. It returns an unique handle
-    for this range to pass to the corresponding call to rangeEnd().
+    Mark the start of a range with string message. It returns an unique handle for this range to pass to the corresponding call to rangeEnd().
 
     A key difference between this and range_push/range_pop is that the
     range_start/range_end version supports range across threads (start on one
@@ -79,9 +76,7 @@ def mark(msg):
 @contextmanager
 def range(msg, *args, **kwargs):
     """
-    Context manager / decorator that pushes an NVTX range at the beginning
-    of its scope, and pops it at the end. If extra arguments are given,
-    they are passed as arguments to msg.format().
+    Context manager / decorator that pushes an NVTX range at the beginning of its scope, and pops it at the end. If extra arguments are given, they are passed as arguments to msg.format().
 
     Args:
         msg (str): message to associate with the range

--- a/torch/cuda/nvtx.py
+++ b/torch/cuda/nvtx.py
@@ -39,7 +39,8 @@ def range_pop():
 
 def range_start(msg) -> int:
     """
-    Mark the start of a range with string message. It returns an unique handle for this range to pass to the corresponding call to rangeEnd().
+    Mark the start of a range with string message. It returns an unique handle
+    for this range to pass to the corresponding call to rangeEnd().
 
     A key difference between this and range_push/range_pop is that the
     range_start/range_end version supports range across threads (start on one
@@ -76,7 +77,9 @@ def mark(msg):
 @contextmanager
 def range(msg, *args, **kwargs):
     """
-    Context manager / decorator that pushes an NVTX range at the beginning of its scope, and pops it at the end. If extra arguments are given, they are passed as arguments to msg.format().
+    Context manager / decorator that pushes an NVTX range at the beginning
+    of its scope, and pops it at the end. If extra arguments are given,
+    they are passed as arguments to msg.format().
 
     Args:
         msg (str): message to associate with the range


### PR DESCRIPTION
Fixes #112590 

Fixed docstring errors in `torch/cuda/memory.py` and `torch/cuda/nvtx.py`.

memory.py
Before
```
torch/cuda/memory.py:1 at module level:
        D100: Missing docstring in public module
torch/cuda/memory.py:67 in public function `caching_allocator_alloc`:
        D401: First line should be in imperative mood (perhaps 'Perform', not 'Performs')
torch/cuda/memory.py:103 in public function `caching_allocator_delete`:
        D401: First line should be in imperative mood (perhaps 'Delete', not 'Deletes')
torch/cuda/memory.py:122 in public function `set_per_process_memory_fraction`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/memory.py:148 in public function `empty_cache`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/memory.py:148 in public function `empty_cache`:
        D400: First line should end with a period (not 'g')
torch/cuda/memory.py:163 in public function `memory_stats`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/memory.py:163 in public function `memory_stats`:
        D400: First line should end with a period (not 'a')
torch/cuda/memory.py:163 in public function `memory_stats`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/cuda/memory.py:264 in public function `memory_stats_as_nested_dict`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/cuda/memory.py:272 in public function `reset_accumulated_memory_stats`:
        D401: First line should be in imperative mood (perhaps 'Reset', not 'Resets')
torch/cuda/memory.py:292 in public function `reset_peak_memory_stats`:
        D401: First line should be in imperative mood (perhaps 'Reset', not 'Resets')
torch/cuda/memory.py:311 in public function `reset_max_memory_allocated`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/memory.py:311 in public function `reset_max_memory_allocated`:
        D400: First line should end with a period (not 'y')
torch/cuda/memory.py:311 in public function `reset_max_memory_allocated`:
        D401: First line should be in imperative mood (perhaps 'Reset', not 'Resets')
torch/cuda/memory.py:338 in public function `reset_max_memory_cached`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/memory.py:338 in public function `reset_max_memory_cached`:
        D400: First line should end with a period (not 'e')
torch/cuda/memory.py:338 in public function `reset_max_memory_cached`:
        D401: First line should be in imperative mood (perhaps 'Reset', not 'Resets')
torch/cuda/memory.py:365 in public function `memory_allocated`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/memory.py:365 in public function `memory_allocated`:
        D400: First line should end with a period (not 'n')
torch/cuda/memory.py:365 in public function `memory_allocated`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/cuda/memory.py:383 in public function `max_memory_allocated`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/memory.py:383 in public function `max_memory_allocated`:
        D400: First line should end with a period (not 'n')
torch/cuda/memory.py:383 in public function `max_memory_allocated`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/cuda/memory.py:405 in public function `memory_reserved`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/memory.py:405 in public function `memory_reserved`:
        D400: First line should end with a period (not 's')
torch/cuda/memory.py:405 in public function `memory_reserved`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/cuda/memory.py:421 in public function `max_memory_reserved`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/memory.py:421 in public function `max_memory_reserved`:
        D400: First line should end with a period (not 's')
torch/cuda/memory.py:421 in public function `max_memory_reserved`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/cuda/memory.py:443 in public function `memory_cached`:
        D401: First line should be in imperative mood; try rephrasing (found 'Deprecated')
torch/cuda/memory.py:452 in public function `max_memory_cached`:
        D401: First line should be in imperative mood; try rephrasing (found 'Deprecated')
torch/cuda/memory.py:461 in public function `memory_snapshot`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/cuda/memory.py:474 in public function `memory_summary`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/memory.py:474 in public function `memory_summary`:
        D400: First line should end with a period (not 'r')
torch/cuda/memory.py:474 in public function `memory_summary`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/cuda/memory.py:612 in public function `list_gpu_processes`:
        D202: No blank lines allowed after function docstring (found 1)
torch/cuda/memory.py:612 in public function `list_gpu_processes`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/memory.py:612 in public function `list_gpu_processes`:
        D400: First line should end with a period (not 's')
torch/cuda/memory.py:612 in public function `list_gpu_processes`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/cuda/memory.py:648 in public function `mem_get_info`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/memory.py:648 in public function `mem_get_info`:
        D400: First line should end with a period (not 'n')
torch/cuda/memory.py:648 in public function `mem_get_info`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/cuda/memory.py:684 in private function `_record_memory_history`:
        D202: No blank lines allowed after function docstring (found 1)
torch/cuda/memory.py:684 in private function `_record_memory_history`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/memory.py:684 in private function `_record_memory_history`:
        D400: First line should end with a period (not 'y')
torch/cuda/memory.py:684 in private function `_record_memory_history`:
        D401: First line should be in imperative mood (perhaps 'Enable', not 'Enables')
torch/cuda/memory.py:742 in private function `_snapshot`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/memory.py:742 in private function `_snapshot`:
        D401: First line should be in imperative mood (perhaps 'Save', not 'Saves')
torch/cuda/memory.py:818 in private function `_dump_snapshot`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/memory.py:818 in private function `_dump_snapshot`:
        D401: First line should be in imperative mood (perhaps 'Save', not 'Saves')
torch/cuda/memory.py:849 in public function `get_allocator_backend`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/memory.py:849 in public function `get_allocator_backend`:
        D400: First line should end with a period (not 'y')
torch/cuda/memory.py:849 in public function `get_allocator_backend`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/cuda/memory.py:894 in public method `__init__`:
        D107: Missing docstring in __init__
torch/cuda/memory.py:904 in public function `change_current_allocator`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/memory.py:904 in public function `change_current_allocator`:
        D401: First line should be in imperative mood (perhaps 'Change', not 'Changes')
torch/cuda/memory.py:917 in private function `_get_current_allocator`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
58
```
After
```
torch/cuda/memory.py:151 in public function `empty_cache`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/memory.py:151 in public function `empty_cache`:
        D400: First line should end with a period (not 'g')
torch/cuda/memory.py:439 in public function `memory_cached`:
        D401: First line should be in imperative mood; try rephrasing (found 'Deprecated')
torch/cuda/memory.py:448 in public function `max_memory_cached`:
        D401: First line should be in imperative mood; try rephrasing (found 'Deprecated')
torch/cuda/memory.py:676 in private function `_record_memory_history`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/memory.py:676 in private function `_record_memory_history`:
        D400: First line should end with a period (not 'y')
torch/cuda/memory.py:841 in public function `get_allocator_backend`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/memory.py:841 in public function `get_allocator_backend`:
        D400: First line should end with a period (not 'y')
8
```

nvtx.py
Before
```
torch/cuda/nvtx.py:1 at module level:
        D100: Missing docstring in public module
torch/cuda/nvtx.py:24 in public function `range_push`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/nvtx.py:24 in public function `range_push`:
        D400: First line should end with a period (not 'd')
torch/cuda/nvtx.py:35 in public function `range_pop`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/nvtx.py:35 in public function `range_pop`:
        D400: First line should end with a period (not 'e')
torch/cuda/nvtx.py:43 in public function `range_start`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/nvtx.py:43 in public function `range_start`:
        D400: First line should end with a period (not 'e')
torch/cuda/nvtx.py:81 in public function `range`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/nvtx.py:81 in public function `range`:
        D400: First line should end with a period (not 'g')
9
```
After
```
torch/cuda/nvtx.py:41 in public function `range_start`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/nvtx.py:41 in public function `range_start`:
        D400: First line should end with a period (not 'e')
torch/cuda/nvtx.py:79 in public function `range`:
        D205: 1 blank line required between summary line and description (found 0)
torch/cuda/nvtx.py:79 in public function `range`:
        D400: First line should end with a period (not 'g')
4
```

cc @svekars @carljparker