### PR TITLE
Fixed cat uint8 lowering

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3455,6 +3455,16 @@ class CommonTemplate:
             (torch.randn([1, 3, 3, 16]).to(memory_format=torch.channels_last),),
         )
 
+        def fn(x):
+            batch_shape = x.shape[:1]
+            out = torch.cat([x.new_zeros(1).expand(batch_shape + (1,)), x], dim=-1)
+            return out
+
+        self.common(
+            fn,
+            (torch.randint(0, 256, size=(3, 255), dtype=torch.uint8),),
+        )
+
     def test_cat_empty(self):
         def fn_2(*tensors):
             return torch.cat(tensors)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3455,6 +3455,7 @@ class CommonTemplate:
             (torch.randn([1, 3, 3, 16]).to(memory_format=torch.channels_last),),
         )
 
+    def test_cat_uint8(self):
         def fn(x):
             batch_shape = x.shape[:1]
             out = torch.cat([x.new_zeros(1).expand(batch_shape + (1,)), x], dim=-1)

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -195,6 +195,9 @@ test_failures = {
         ("cpu", "cuda")
     ),
     "test_zero_element_mutation_dynamic_shapes": TestFailure(("cpu", "cuda")),
+    "test_cat_uint8_dynamic_shapes": TestFailure(
+        ("cpu",)
+    ),  # cat on uint8 input is using aten fallback on cpu
     #
     # Tests not using 'common' or directly calling 'assertEqual':
     #

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1034,7 +1034,7 @@ def cat(inputs, dim=0):
         # code gen with uint8 data type directly.
         for input in inputs:
             input.realize()
-        if all(len(input.layout.size) == 4 for input in inputs):
+        if all(len(input.get_size()) == 4 for input in inputs):
             inputs, _ = require_channels_last(aten.cat, *inputs)
         return fallback_handler(aten.cat.default)(inputs, dim)
 


### PR DESCRIPTION
Description:
- Fixed cat uint8 lowering

Otherwise, it gives the following issue on the repro code:
```python
def func(x):
    batch_shape = x.shape[:1]
    out = torch.cat([x.new_zeros(1).expand(batch_shape + (1,)), x], dim=-1)
    return out


cfunc = torch.compile(func)

x = torch.randint(0, 256, size=(3, 255), dtype=torch.uint8)
out = cfunc(x)
```
Error message:
```
  File "/pytorch/torch/_inductor/lowering.py", line 1037, in <genexpr>                                                                                                                                                
    if all(len(input.layout.size) == 4 for input in inputs):                                                                                                                                                          
  File "/pytorch/torch/_inductor/ir.py", line 5795, in __getattr__                                                                                                                                                    
    fn = getattr(self.data, name)                                                                                                                                                                                     
torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:                                                                                                                                           
LoweringException: AttributeError: 'ExpandView' object has no attribute 'layout'                                                                                                                                      
  target: aten.cat.default                                                                                                                                                               
  args[0]: [TensorBox(                                                                                                                                                                                                
    ExpandView(data=StorageBox(                                                                                                                                                                                       
      ComputedBuffer(name='buf0', layout=FlexibleLayout('cpu', torch.uint8, size=[1], stride=[1]), data=Pointwise(                                                                                                    
        'cpu',                                                                                                                                                                                                        
        torch.uint8,                                                                                                                                                                                                  
        def inner_fn(index):                                                                                                                                                                                          
            _ = index                                                                                                                                                                                                 
            tmp0 = ops.constant(0, torch.uint8)                                                                                                                                               
            return tmp0                                                                                                                                                                                               
        ,                                                                                                                                                                               
        ranges=[1],                                                                                                                                                                                                   
        origin_node=full,                                                                                                                                                                                       
        origins={full}                                                                                                                                                                                                
      ))                                                                                                                                                                                                              
    ), size=[3, 1])                                                                                                                                                                                                   
  ), TensorBox(StorageBox(                                                                                                                                                                                            
    InputBuffer(name='arg0_1', layout=FixedLayout('cpu', torch.uint8, size=[3, 255], stride=[255, 1]))                                                                                                                
  ))]                                                                                                                                                                                                         
  args[1]: 1                                                                                                                                                                                                          
                                                                                                                                                                                         
Set TORCH_LOGS="+dynamo" and TORCHDYNAMO_VERBOSE=1 for more information   
```

Context: compiling is not working for torchvision's `F.equalize` op: https://github.com/pytorch/vision/issues/8056


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler