### PR TITLE
[dynamo][easy] Patch unit test to exercise our code

### DIFF
--- a/test/dynamo/test_model_output.py
+++ b/test/dynamo/test_model_output.py
@@ -137,6 +137,11 @@ class TestModelOutput(torch._dynamo.test_case.TestCase):
             d: torch.Tensor = None
             e: torch.Tensor = None
 
+        # Patch the __module__; to avoid expensive imports we currently only
+        # trigger custom logic for ModelOutput and BaseModel when the module
+        # names match.
+        MyDataClass.__module__ = "transformers.modeling_outputs"
+
         def fn(obj):
             class_fields = dataclasses.fields(obj)
             assert len(class_fields)


### PR DESCRIPTION
Summary:

We currently gate the logic for constructing a VariableTracker that matches the HF `ModelOutput` or diffusers `BaseOutput` classes based on the `__module__` of the class, in order to avoid expensive imports (to some extent it also protects us against end users adding overrides that violate the assumptions we make about these classes).

But as a result, `test_mo_init` hasn't actually been exercising our `ModelOutput` logic in quite some time - the compile here has been falling back to default behaviors!

By manually overriding `__module__` in our test class we can revive this test case, which currently passes.

Test Plan:

`pytest test/dynamo/test_model_output.py -k test_mo_init`
