### PR TITLE
Add generated opcheck test for if the pt2_compliant_tag is incorrectly applied

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -1819,10 +1819,11 @@ def op_with_incorrect_schema(testcase, name):
 class MiniOpTest(CustomOpTestCaseBase):
     test_ns = "mini_op_test"
 
-    def _op_delayed_backward_error(self, name):
+    def _init_op_delayed_backward_error(self):
+        name = "delayed_error"
+        qualname = f"{self.test_ns}::{name}"
         lib = self.lib()
         lib.define(f"{name}(Tensor x) -> Tensor")
-        qualname = f"{self.test_ns}::{name}"
         lib.impl(name, lambda x: x.clone(), "CompositeExplicitAutograd")
         op = self.get_op(qualname)
 
@@ -1842,12 +1843,18 @@ class MiniOpTest(CustomOpTestCaseBase):
         lib.impl(name, autograd_impl, "Autograd")
         return op
 
-    def _op_with_no_abstract_impl(self, name):
-        lib = self.lib()
-        lib.define(f"{name}(Tensor x) -> Tensor")
+    def _init_op_with_no_abstract_impl(self):
+        name = "no_abstract"
         qualname = f"{self.test_ns}::{name}"
+        lib = self.lib()
+        lib.define(f"{name}(Tensor x) -> Tensor", tags=(torch.Tag.pt2_compliant_tag,))
         lib.impl(name, lambda x: x.clone(), "CPU")
-        return self.get_op(qualname)
+        return torch._library.utils.lookup_op(qualname)
+
+    def setUp(self):
+        super().setUp()
+        self._op_with_no_abstract_impl = self._init_op_with_no_abstract_impl()
+        self._op_delayed_backward_error = self._init_op_delayed_backward_error()
 
     @optests.dontGenerateOpCheckTests("Testing this API")
     def test_dont_generate(self):
@@ -1897,19 +1904,19 @@ class MiniOpTest(CustomOpTestCaseBase):
         op(x)
 
     def test_no_abstract(self):
-        op = self._op_with_no_abstract_impl("no_abstract")
+        op = self._op_with_no_abstract_impl
         x = torch.randn(3)
         op(x)
 
     def test_delayed_error(self):
-        op = self._op_delayed_backward_error("delayed_error")
+        op = self._op_delayed_backward_error
         x = torch.randn([], requires_grad=True)
         y = op(x)
         with self.assertRaises(NotImplementedError):
             y.sum().backward()
 
     def test_delayed_error_no_requires_grad(self):
-        op = self._op_delayed_backward_error("delayed_error")
+        op = self._op_delayed_backward_error
         x = torch.randn([])
         y = op(x)
 
@@ -1930,6 +1937,9 @@ optests.generate_opcheck_tests(
         os.path.dirname(__file__),
         "minioptest_failures_dict.json",
     ),
+    additional_decorators={
+        "test_pt2_compliant_tag_mini_op_test_no_abstract": [unittest.expectedFailure]
+    },
 )
 
 optests.generate_opcheck_tests(

--- a/torch/testing/_internal/optests/generate_tests.py
+++ b/torch/testing/_internal/optests/generate_tests.py
@@ -7,6 +7,7 @@ import os
 import re
 import tempfile
 import threading
+import unittest
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
@@ -252,6 +253,62 @@ def generate_opcheck_tests(
     for attr in test_methods:
         for prefix, tester in test_utils.items():
             construct_method(attr, prefix, tester)
+
+    generate_tag_tests(testcase, failures_dict, additional_decorators)
+
+
+def generate_tag_tests(testcase, failures_dict, additional_decorators):
+    def generate_test(qualname, definitely_not_pt2_compliant, xfailed_tests):
+        def inner(self):
+            try:
+                op = torch._library.utils.lookup_op(qualname)
+            except AttributeError as e:
+                # Operator not importable in this test file
+                raise unittest.SkipTest(f"Can't import operator {qualname}") from e
+            op_marked_as_compliant = torch.Tag.pt2_compliant_tag in op.tags
+            if not op_marked_as_compliant:
+                return
+            if not definitely_not_pt2_compliant:
+                return
+            raise AssertionError(
+                f"op '{qualname}' was tagged with torch.Tag.pt2_compliant_tag "
+                f"but it failed some of the generated opcheck tests "
+                f"({xfailed_tests}). This may lead to silent correctness issues, "
+                f"please fix this."
+            )
+
+        return inner
+
+    for qualname, test_dict in failures_dict.data.items():
+        xfailed_tests = [
+            test
+            for test, status_dict in test_dict.items()
+            # We're about to delete the following test after Ed's PR
+            # to specialize on C++ .size() calls
+            if "test_aot_dispatch_static" not in test
+            and status_dict["status"] == "xfail"
+        ]
+        definitely_not_pt2_compliant = len(xfailed_tests) > 0
+        generated = generate_test(qualname, definitely_not_pt2_compliant, xfailed_tests)
+
+        # Could result in collisions, but unlikely. We'll raise if we see one below.
+        mangled_qualname = qualname.replace("::", "_").replace(".", "_")
+        test_name = "test_pt2_compliant_tag_" + mangled_qualname
+
+        # You can skip this test via the additional_decorators argument
+        # in generate_opcheck_tests
+        if test_name in additional_decorators:
+            for decorator in additional_decorators[test_name]:
+                generated = decorator(generated)
+
+        if hasattr(testcase, test_name):
+            raise RuntimeError(
+                f"Tried to generate a test named {test_name}, but it exists "
+                f"already. This could be because of a name collision (where "
+                f"we generated two tests with the same name), or where we "
+                f"generated a test with the same name as an existing test."
+            )
+        setattr(testcase, test_name, generated)
 
 
 TEST_OPTIONS = ("xfail", "skip", "xsuccess")


### PR DESCRIPTION
Summary:
If there are xfails in the failures_dict and the operator has the
pt2_compliant_tag, then we raise an error. These generated tests are separate
from those in the failures dict because we don't actually need any sample
inputs to check this.

Test Plan: - New tests

Differential Revision: D50936201


