### PR TITLE
warn once for use flash attention and memory efficient attention

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -249,7 +249,7 @@ bool check_flash_causal_non_square_seqlens(sdp_params const& params, bool debug)
 
 bool use_flash_attention(sdp_params const& params, bool debug) {
 #ifndef USE_FLASH_ATTENTION
-  TORCH_WARN(!debug, "Torch was not compiled with flash attention.");
+  TORCH_WARN_ONCE(!debug, "Torch was not compiled with flash attention.");
   return false;
 #endif
 
@@ -287,7 +287,7 @@ bool use_flash_attention(sdp_params const& params, bool debug) {
 
 bool use_mem_efficient_attention(sdp_params const& params, bool debug) {
 #ifndef USE_MEM_EFF_ATTENTION
-  TORCH_WARN(!debug, "Torch was not compiled with memory efficient attention.");
+  TORCH_WARN_ONCE(!debug, "Torch was not compiled with memory efficient attention.");
   return false;
 #endif
   // Constraints specific to mem efficient attention


### PR DESCRIPTION
Summary: these logs can get pretty spammy if we use TORCH_WARN, it could be better to use TORCH_WARN_ONCE

Test Plan: ci

Differential Revision: D50941941


