### PR TITLE
[ROCm] Enable several inductor UTs

### DIFF
--- a/test/inductor/test_compiled_optimizers.py
+++ b/test/inductor/test_compiled_optimizers.py
@@ -13,7 +13,7 @@ import torch._inductor
 # The rest of the optimizers not yet imported: Adamax, LBFGS, RAdam, SGD, SparseAdam
 from torch.optim import Adadelta, Adagrad, Adam, AdamW, ASGD, NAdam, RMSprop, Rprop
 
-from torch.testing._internal.common_utils import TEST_WITH_ROCM, TestCase
+from torch.testing._internal.common_utils import TestCase
 
 from torch.testing._internal.inductor_utils import HAS_CPU, HAS_CUDA
 
@@ -225,5 +225,5 @@ class CompiledOptimizerTests(TestCase):
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 
-    if (HAS_CPU or HAS_CUDA) and not TEST_WITH_ROCM:
+    if (HAS_CPU or HAS_CUDA):
         run_tests(needs="filelock")

--- a/test/inductor/test_compiled_optimizers.py
+++ b/test/inductor/test_compiled_optimizers.py
@@ -225,5 +225,5 @@ class CompiledOptimizerTests(TestCase):
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 
-    if (HAS_CPU or HAS_CUDA):
+    if HAS_CPU or HAS_CUDA:
         run_tests(needs="filelock")

--- a/test/inductor/test_foreach.py
+++ b/test/inductor/test_foreach.py
@@ -618,5 +618,5 @@ class ForeachTests(TestCase):
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 
-    if (HAS_CPU or HAS_CUDA):
+    if HAS_CPU or HAS_CUDA:
         run_tests(needs="filelock")

--- a/test/inductor/test_foreach.py
+++ b/test/inductor/test_foreach.py
@@ -11,7 +11,6 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     IS_FBCODE,
     parametrize,
-    TEST_WITH_ROCM,
     TestCase,
 )
 
@@ -619,5 +618,5 @@ class ForeachTests(TestCase):
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 
-    if (HAS_CPU or HAS_CUDA) and not TEST_WITH_ROCM:
+    if (HAS_CPU or HAS_CUDA):
         run_tests(needs="filelock")

--- a/test/inductor/test_profiler.py
+++ b/test/inductor/test_profiler.py
@@ -9,7 +9,7 @@ import torch._inductor.utils
 from torch._inductor import config
 from torch.profiler import ProfilerActivity
 
-from torch.testing._internal.common_utils import TemporaryFileName, skipIfRocm
+from torch.testing._internal.common_utils import skipIfRocm, TemporaryFileName
 
 from torch.utils._triton import has_triton
 

--- a/test/inductor/test_profiler.py
+++ b/test/inductor/test_profiler.py
@@ -9,7 +9,7 @@ import torch._inductor.utils
 from torch._inductor import config
 from torch.profiler import ProfilerActivity
 
-from torch.testing._internal.common_utils import TemporaryFileName, TEST_WITH_ROCM
+from torch.testing._internal.common_utils import TemporaryFileName
 
 from torch.utils._triton import has_triton
 
@@ -39,12 +39,14 @@ class DynamoProfilerTests(torch._dynamo.test_case.TestCase):
         self.assertTrue("traceEvents" in trace_json)
         events = trace_json["traceEvents"]
 
+        kernel_name = "hipModuleLaunchKernel" if torch.version.hip else "cuLaunchKernel"
+
         def nameMatchesLaunchKernel(event_name):
-            return "cuLaunchKernel" in event_name
+            return kernel_name in event_name
 
         self.assertTrue(
             any(
-                ("name" in event and "cuLaunchKernel" == event["name"])
+                ("name" in event and kernel_name == event["name"])
                 for event in events
             )
         )
@@ -122,5 +124,4 @@ class DynamoProfilerTests(torch._dynamo.test_case.TestCase):
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 
-    if not TEST_WITH_ROCM:
-        run_tests()
+    run_tests()

--- a/test/inductor/test_profiler.py
+++ b/test/inductor/test_profiler.py
@@ -9,7 +9,7 @@ import torch._inductor.utils
 from torch._inductor import config
 from torch.profiler import ProfilerActivity
 
-from torch.testing._internal.common_utils import TemporaryFileName
+from torch.testing._internal.common_utils import TemporaryFileName, skipIfRocm
 
 from torch.utils._triton import has_triton
 
@@ -89,6 +89,7 @@ class DynamoProfilerTests(torch._dynamo.test_case.TestCase):
         self._test_profiling_kernel_names(fn, args, "sin")
 
     @unittest.skipIf(not HAS_TRITON, "requires cuda & triton")
+    @skipIfRocm
     def test_inductor_profiling_kernel_names_template(self):
         with config.patch(
             {"max_autotune": True, "max_autotune_gemm_backends": "TRITON"}

--- a/test/inductor/test_profiler.py
+++ b/test/inductor/test_profiler.py
@@ -45,10 +45,7 @@ class DynamoProfilerTests(torch._dynamo.test_case.TestCase):
             return kernel_name in event_name
 
         self.assertTrue(
-            any(
-                ("name" in event and kernel_name == event["name"])
-                for event in events
-            )
+            any(("name" in event and kernel_name == event["name"]) for event in events)
         )
 
     def _test_profiling_kernel_names(self, fn, args, kernel_name_str: str):


### PR DESCRIPTION
- test_compiled_optimizers.py
- test_foreach.py
- test_profiler.py
- Fix test_profiler.py:test_inductor_profiling_triton_launch - Look for hipModuleLaunchKernel in the events list for AMD GPUs instead of cuLaunchKernel



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler