### PR TITLE
Enforce both input tensor shapes of CosineEmbeddingLoss to be equal. 

### DIFF
--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -164,14 +164,6 @@ Tensor cosine_embedding_loss(const Tensor& input1, const Tensor& input2, const T
         input2.sizes(),
         ".");
   }
-  TORCH_CHECK(
-      is_expandable_to(input1.sym_sizes(), input2.sym_sizes()) || is_expandable_to(input2.sym_sizes(), input1.sym_sizes()),
-      "Expected input1 and input2 to be broadcastable to a common shape, but got ",
-      input1.sym_sizes(),
-      " and ",
-      input2.sym_sizes(),
-      ".");
-
 
   auto prod_sum = (input1 * input2).sum(targ_dim);
   auto mag_square1 = (input1 * input1).sum(targ_dim) + EPSILON;

--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -10,7 +10,6 @@
 #include <ATen/native/cpu/Loops.h>
 #include <c10/util/Exception.h>
 #include <ATen/TensorSubclassLikeUtils.h>
-#include <ATen/ExpandUtils.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>

--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -147,11 +147,11 @@ Tensor cosine_embedding_loss(const Tensor& input1, const Tensor& input2, const T
       targ_dim == 1 || targ_dim == 0,
       "0D or 1D target tensor expected, multi-target not supported");
   TORCH_CHECK(
-      input1.sizes() == input2.sizes(),
+      input1.sym_sizes() == input2.sym_sizes(),
       "Expected input1 to be of same shape as input2, but got ",
-      input1.sizes(),
+      input1.sym_sizes(),
       " and ",
-      input2.sizes(),
+      input2.sym_sizes(),
       ".");
 
   if (targ_dim == 1) {

--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -146,6 +146,13 @@ Tensor cosine_embedding_loss(const Tensor& input1, const Tensor& input2, const T
   TORCH_CHECK(
       targ_dim == 1 || targ_dim == 0,
       "0D or 1D target tensor expected, multi-target not supported");
+  TORCH_CHECK(
+      input1.sizes() == input2.sizes(),
+      "Expected input1 to be of same shape as input2, but got ",
+      input1.sizes(),
+      " and ",
+      input2.sizes(),
+      ".");
 
   if (targ_dim == 1) {
     TORCH_CHECK(

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5408,7 +5408,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             input1 = torch.empty((1, 5), dtype=torch.double, device=device)
             input2 = torch.empty((1, 6), dtype=torch.double, device=device)
             target = torch.ones((1,), dtype=torch.int, device=device)
-            with self.assertRaisesRegex(RuntimeError, ".*common shape.*"):
+            with self.assertRaisesRegex(RuntimeError, ".*must match the size.*"):
                 torch.nn.functional.cosine_embedding_loss(input1, input2, target)
 
     def test_kl_div_with_diff_type(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5400,7 +5400,15 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             input1 = torch.empty((0, 0), dtype=torch.double, device=device)
             input2 = torch.empty((0,), dtype=torch.double, device=device)
             target = torch.empty((0,), dtype=torch.int, device=device)
-            with self.assertRaisesRegex(RuntimeError, ".*same shape.*"):
+            with self.assertRaisesRegex(RuntimeError, ".*expects 2D.*"):
+                torch.nn.functional.cosine_embedding_loss(input1, input2, target)
+
+    def test_cosine_embedding_loss_error_on_nonexpandable_shapes(self):
+        for device in device_():
+            input1 = torch.empty((1, 5), dtype=torch.double, device=device)
+            input2 = torch.empty((1, 6), dtype=torch.double, device=device)
+            target = torch.ones((1,), dtype=torch.int, device=device)
+            with self.assertRaisesRegex(RuntimeError, ".*common shape.*"):
                 torch.nn.functional.cosine_embedding_loss(input1, input2, target)
 
     def test_kl_div_with_diff_type(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5395,6 +5395,14 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                         result = torch.nn.functional.cosine_embedding_loss(input1, input2, target)
                         self.assertEqual(result.item(), expected.item(), atol=0.001, rtol=0)
 
+    def test_cosine_embedding_loss_error_on_diff_shapes(self):
+        for device in device_():
+            input1 = torch.empty((0, 0), dtype=torch.double, device=device)
+            input2 = torch.empty((0,), dtype=torch.double, device=device)
+            target = torch.empty((0,), dtype=torch.int, device=device)
+            with self.assertRaisesRegex(RuntimeError, ".*same shape.*"):
+                torch.nn.functional.cosine_embedding_loss(input1, input2, target)
+
     def test_kl_div_with_diff_type(self):
         for device in device_():
             input = torch.tensor([[2, 3, 5], [3, 2, 1]], dtype=torch.double, device=device)


### PR DESCRIPTION
…Added a test to prevent regressions.

Fixes #112732.
