### PR TITLE
Revert "Fix bug: not creating empty tensor with correct sizes and device. (#106734)" (#112170)

### DIFF
--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -1393,7 +1393,7 @@ Tensor& comparison_op_out(Tensor& result, const Tensor& self, const Tensor& othe
 
 template <typename OutImpl>
 Tensor comparison_op(const Tensor& self, const Tensor& other, OutImpl& out_impl) {
-  Tensor result = at::empty(self.sizes(), self.options().dtype(kBool).device(self.device()));
+  Tensor result = at::empty({0}, self.options().dtype(kBool));
   return out_impl(result, self, other);
 }
 


### PR DESCRIPTION
This reverts commit 528a2c0aa97d152b8004254040076b8ae605bf9f.

The PR is wrong, see #110941.