### PR TITLE
[PT-D] Updated Dynamo skip message for `@contract` tests

### DIFF
--- a/test/distributed/_composable/test_contract.py
+++ b/test/distributed/_composable/test_contract.py
@@ -25,7 +25,7 @@ class ToyModel(nn.Module):
 
 
 class TestContract(TestCase):
-    @skipIfTorchDynamo("Dynamo does not yet capture module hooks")
+    @skipIfTorchDynamo("Dynamo does not support the state key")
     def test_add_hooks(self):
         def forward_pre_hook(
             module: nn.Module, inp: Tuple[torch.Tensor]
@@ -69,7 +69,7 @@ class TestContract(TestCase):
         for p1, p2 in zip(model.parameters(), model_with_hooks.parameters()):
             self.assertEqual(p1, p2)
 
-    @skipIfTorchDynamo("Dynamo does not yet capture module hooks")
+    @skipIfTorchDynamo("Dynamo does not support the state key")
     def test_modify_fqn(self):
         class ModelWrapper(nn.Module):
             def __init__(self, module):
@@ -91,7 +91,7 @@ class TestContract(TestCase):
         ):
             wrap_module(model.seq1)
 
-    @skipIfTorchDynamo("Dynamo does not yet capture module hooks")
+    @skipIfTorchDynamo("Dynamo does not support the state key")
     def test_state(self):
         def check_and_update_state_hook(
             module: nn.Module, inp: Tuple[torch.Tensor]
@@ -115,7 +115,7 @@ class TestContract(TestCase):
         model(torch.zeros(10, 10), torch.zeros(10, 10))
         self.assertEqual(api.state(model.seq1).dummy_state, 8)
 
-    @skipIfTorchDynamo("Dynamo does not yet capture module hooks")
+    @skipIfTorchDynamo("Dynamo does not support the state key")
     def test_registry(self):
         @contract()
         def api1(module: nn.Module) -> nn.Module:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #112625
* __->__ #112793

Even Dynamo can now trace through module hooks, its regex matcher for `HASATTR` does not like the state key:
https://github.com/pytorch/pytorch/blob/12a6f5aa6bf3e11668293c36b436eead2f3b8614/torch/distributed/_composable/contract.py#L10-L14
https://github.com/pytorch/pytorch/blob/12a6f5aa6bf3e11668293c36b436eead2f3b8614/torch/_dynamo/guards.py#L353-L355


```
PYTORCH_TEST_WITH_DYNAMO=1 python -m pytest test/distributed/_composable/test_contract.py
```

```
------------------------------------- Captured stderr call -------------------------------------
[2023-11-02 14:40:02,242] torch._dynamo.convert_frame: [WARNING] WON'T CONVERT resume_in_test_registry /data/users/andgu/pytorch/test/distributed/_composable/test_contract.py line 125 
[2023-11-02 14:40:02,242] torch._dynamo.convert_frame: [WARNING] due to: 
[2023-11-02 14:40:02,242] torch._dynamo.convert_frame: [WARNING] Traceback (most recent call last):
[2023-11-02 14:40:02,242] torch._dynamo.convert_frame: [WARNING]   File "/data/users/andgu/pytorch/torch/_dynamo/convert_frame.py", line 687, in _convert_frame
[2023-11-02 14:40:02,242] torch._dynamo.convert_frame: [WARNING]     result = inner_convert(frame, cache_entry, hooks, frame_state)
[2023-11-02 14:40:02,242] torch._dynamo.convert_frame: [WARNING]   File "/data/users/andgu/pytorch/torch/_dynamo/convert_frame.py", line 148, in _fn
[2023-11-02 14:40:02,242] torch._dynamo.convert_frame: [WARNING]     return fn(*args, **kwargs)
[2023-11-02 14:40:02,242] torch._dynamo.convert_frame: [WARNING]   File "/data/users/andgu/pytorch/torch/_dynamo/convert_frame.py", line 406, in _convert_frame_assert
[2023-11-02 14:40:02,242] torch._dynamo.convert_frame: [WARNING]     return _compile(
[2023-11-02 14:40:02,242] torch._dynamo.convert_frame: [WARNING]   File "/data/users/andgu/pytorch/torch/_dynamo/convert_frame.py", line 614, in _compile
[2023-11-02 14:40:02,242] torch._dynamo.convert_frame: [WARNING]     guarded_code = compile_inner(code, one_graph, hooks, transform)
[2023-11-02 14:40:02,242] torch._dynamo.convert_frame: [WARNING]   File "/data/users/andgu/pytorch/torch/_dynamo/utils.py", line 221, in time_wrapper
[2023-11-02 14:40:02,242] torch._dynamo.convert_frame: [WARNING]     r = func(*args, **kwargs)
[2023-11-02 14:40:02,242] torch._dynamo.convert_frame: [WARNING]   File "/data/users/andgu/pytorch/torch/_dynamo/convert_frame.py", line 594, in compile_inner
[2023-11-02 14:40:02,242] torch._dynamo.convert_frame: [WARNING]     check_fn = CheckFunctionManager(
[2023-11-02 14:40:02,242] torch._dynamo.convert_frame: [WARNING]   File "/data/users/andgu/pytorch/torch/_dynamo/guards.py", line 987, in __init__
[2023-11-02 14:40:02,242] torch._dynamo.convert_frame: [WARNING]     guard.create(builder)
[2023-11-02 14:40:02,242] torch._dynamo.convert_frame: [WARNING]   File "/data/users/andgu/pytorch/torch/_guards.py", line 244, in create
[2023-11-02 14:40:02,242] torch._dynamo.convert_frame: [WARNING]     return self.create_fn(builder, self)
[2023-11-02 14:40:02,242] torch._dynamo.convert_frame: [WARNING]   File "/data/users/andgu/pytorch/torch/_dynamo/guards.py", line 354, in HASATTR
[2023-11-02 14:40:02,242] torch._dynamo.convert_frame: [WARNING]     assert m, f"invalid hasattr check {guard.name}"
[2023-11-02 14:40:02,242] torch._dynamo.convert_frame: [WARNING] AssertionError: invalid hasattr check getattr(L['___stack0'], '__composable_api_state_key_643e6a56-3313-4c8f-9401-a5af7bd3ee26')
```