### PR TITLE
[inductor] Unify run_and_get_*_code implementations

### DIFF
--- a/test/distributed/test_compute_comm_reordering.py
+++ b/test/distributed/test_compute_comm_reordering.py
@@ -21,13 +21,13 @@ from torch._inductor.comm_analysis import (
     NCCL_PROTO,
     NVIDIA_GPU_TYPE,
 )
-from torch._inductor.utils import run_and_get_triton_code
 from torch.testing._internal.common_distributed import (
     _dynamo_dist_per_rank_init,
     DynamoDistributedMultiProcTestCase,
     requires_nccl,
     skip_if_lt_x_gpu,
 )
+from torch.testing._internal.inductor_utils import run_and_get_code
 from torch.utils._triton import has_triton
 
 
@@ -91,7 +91,7 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
         with _dynamo_dist_per_rank_init(self.rank, self.world_size):
             inputs = torch.ones(4, 4, dtype=torch.float, device="cuda") + self.rank
             compiled = torch.compile(func)
-            code = run_and_get_triton_code(compiled, inputs, **self.get_world_trs())
+            _, code = run_and_get_code(compiled, inputs, **self.get_world_trs())
             # NOTE: notice that `_wait_tensor` is delayed until right before first use
             FileCheck().check("dist.all_reduce(").check("triton_poi_fused_relu").check(
                 "_wait_tensor("
@@ -124,7 +124,7 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
         with _dynamo_dist_per_rank_init(self.rank, self.world_size):
             inputs = torch.ones(4, 4, dtype=torch.float, device="cuda") + self.rank
             compiled = torch.compile(func)
-            code = run_and_get_triton_code(compiled, inputs, **self.get_world_trs())
+            _, code = run_and_get_code(compiled, inputs, **self.get_world_trs())
             # NOTE: notice that `dist.all_reduce` is raised above relu and matmul
             FileCheck().check("dist.all_reduce(").check("_wait_tensor(").check(
                 "triton_poi_fused_relu"
@@ -158,7 +158,7 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
         with _dynamo_dist_per_rank_init(self.rank, self.world_size):
             inputs = torch.ones(4, 4, dtype=torch.float, device="cuda") + self.rank
             compiled = torch.compile(func)
-            code = run_and_get_triton_code(compiled, inputs, **self.get_world_trs())
+            _, code = run_and_get_code(compiled, inputs, **self.get_world_trs())
             # NOTE: notice that `dist.all_reduce` is raised above relu and matmul,
             # and `_wait_tensor` is delayed until right before first use
             FileCheck().check("dist.all_reduce(").check("triton_poi_fused_relu").check(
@@ -195,7 +195,7 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
         with _dynamo_dist_per_rank_init(self.rank, self.world_size):
             inputs = torch.ones(4, 4, dtype=torch.float, device="cuda") + self.rank
             compiled = torch.compile(func)
-            code = run_and_get_triton_code(compiled, inputs, **self.get_world_trs())
+            _, code = run_and_get_code(compiled, inputs, **self.get_world_trs())
             # NOTE: after scheduling the first all_reduce:
             # 1. we first schedule the ops (c and d) that ARE required for second all_reduce but DO NOT depend on first all_reduce.
             # 2. then, we schedule the ops (g) that ARE NOT required for second all_reduce and DO NOT depend on first all_reduce.
@@ -252,7 +252,7 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
         with _dynamo_dist_per_rank_init(self.rank, self.world_size):
             inputs = torch.ones(4, 4, dtype=torch.float, device="cuda") + self.rank
             compiled = torch.compile(func)
-            code = run_and_get_triton_code(compiled, inputs, **self.get_world_trs())
+            _, code = run_and_get_code(compiled, inputs, **self.get_world_trs())
             # NOTE: after scheduling the first all_reduce:
             # 1. we first schedule the ops (c and d) that ARE required for second all_reduce but DO NOT depend on first all_reduce.
             # 2. then, we schedule the ops (g) that ARE NOT required for second all_reduce and DO NOT depend on first all_reduce.

--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -21,7 +21,7 @@ from torch.testing._internal.common_distributed import (
 )
 from torch._inductor.compile_fx import compile_fx as inductor_compile_fx
 from torch.utils._triton import has_triton
-from torch._inductor.utils import run_and_get_triton_code
+from torch.testing._internal.inductor_utils import run_and_get_code
 import torch._dynamo.logging
 
 def _tolist_with_constrain_as_size(tensor):
@@ -330,7 +330,7 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
             trs = self.get_world_trs()
 
             compiled_fn = torch.compile(example, fullgraph=True, dynamic=True)
-            code = run_and_get_triton_code(compiled_fn, *inputs, **trs)
+            _, code = run_and_get_code(compiled_fn, *inputs, **trs)
 
             FileCheck() \
                 .check_regex("all_to_all_single\\(buf\\d+\\[0\\], buf\\d+_inputs\\[0\\], output_split_sizes=\\[i\\d+, i\\d+\\], input_split_sizes=\\[i\\d+, i\\d+\\]") \
@@ -369,7 +369,7 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
             trs = self.get_world_trs()
 
             compiled_fn = torch.compile(example, fullgraph=True, dynamic=True)
-            code = run_and_get_triton_code(compiled_fn, *inputs, **trs)
+            _, code = run_and_get_code(compiled_fn, *inputs, **trs)
             FileCheck() \
                 .check_regex("all_to_all_single\\(buf\\d+\\[0\\], buf\\d+_inputs\\[0\\], output_split_sizes=None, input_split_sizes=\\[i\\d+, i\\d+\\]") \
                 .run(code)  # noqa: B950
@@ -411,7 +411,7 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
             trs = self.get_world_trs()
 
             compiled_fn = torch.compile(example, fullgraph=True, dynamic=True)
-            code = run_and_get_triton_code(compiled_fn, *inputs, **trs)
+            _, code = run_and_get_code(compiled_fn, *inputs, **trs)
             FileCheck() \
                 .check_regex("all_to_all_single\\(buf\\d+\\[0\\], buf\\d+_inputs\\[0\\], output_split_sizes=\\[i\\d+, i\\d+\\], input_split_sizes=None") \
                 .run(code)  # noqa: B950
@@ -443,7 +443,7 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
             trs = self.get_world_trs()
 
             compiled_fn = torch.compile(example, fullgraph=True, dynamic=True)
-            code = run_and_get_triton_code(compiled_fn, *inputs, **trs)
+            _, code = run_and_get_code(compiled_fn, *inputs, **trs)
             FileCheck() \
                 .check_regex("all_to_all_single\\(buf\\d+\\[0\\], buf\\d+_inputs\\[0\\], output_split_sizes=None, input_split_sizes=None") \
                 .run(code)  # noqa: B950
@@ -478,7 +478,7 @@ class TestCollectivesInductor(DynamoDistributedSingleProcTestCase):
 
         compiled = torch.compile(func)
         out = compiled(inputs, **self.get_world_trs())
-        code = run_and_get_triton_code(compiled, inputs, **self.get_world_trs())
+        _, code = run_and_get_code(compiled, inputs, **self.get_world_trs())
         # NOTE: Make sure we are not unneccessarily copying the outputs of
         # wait_tensors before they are returned from the graph.
         FileCheck() \
@@ -512,7 +512,7 @@ class TestCollectivesInductor(DynamoDistributedSingleProcTestCase):
         inputs = torch.ones(4, 4, device="cuda")
 
         compiled = torch.compile(func)
-        code = run_and_get_triton_code(compiled, inputs, **self.get_world_trs())
+        _, code = run_and_get_code(compiled, inputs, **self.get_world_trs())
         # NOTE: Make sure we are not unneccessarily copying the outputs of
         # wait_tensors before they are returned from the graph.
         FileCheck() \
@@ -550,7 +550,7 @@ class TestCollectivesInductor(DynamoDistributedSingleProcTestCase):
         inputs = torch.ones(4, 4, device="cuda")
 
         compiled = torch.compile(func)
-        code = run_and_get_triton_code(compiled, inputs, **self.get_world_trs())
+        _, code = run_and_get_code(compiled, inputs, **self.get_world_trs())
         # NOTE: Make sure we are not unneccessarily copying the outputs of
         # wait_tensors before they are returned from the graph.
         FileCheck() \
@@ -793,7 +793,7 @@ class TestCollectivesInductor(DynamoDistributedSingleProcTestCase):
         inputs = torch.ones(4, 4, device="cuda")
 
         compiled = torch.compile(func)
-        code = run_and_get_triton_code(compiled, inputs, **self.get_world_trs())
+        _, code = run_and_get_code(compiled, inputs, **self.get_world_trs())
         # NOTE: Make sure we are not unneccessarily copying the outputs of
         # wait_tensors before they are returned from the graph.
         FileCheck() \
@@ -840,7 +840,7 @@ class TestCollectivesInductor(DynamoDistributedSingleProcTestCase):
         inputs = torch.ones(4, 4, device="cuda")
 
         compiled = torch.compile(func)
-        code = run_and_get_triton_code(compiled, inputs, **self.get_world_trs())
+        _, code = run_and_get_code(compiled, inputs, **self.get_world_trs())
         # NOTE: The first return value should be the output of the first wait_tensor.
         # We want to make sure no unneccessary copy is made.
         FileCheck() \

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -1904,7 +1904,7 @@ def forward(self, x_1, output_1):
     @common_utils.parametrize("grad", [False, True])
     @patch.object(torch._inductor.config, "implicit_fallbacks", False)
     def test_triton_kernel_no_clones(self, grad):
-        from torch._inductor.utils import run_and_get_code
+        from torch.testing._internal.inductor_utils import run_and_get_code
 
         def call_triton_add(
             x: torch.Tensor,
@@ -1922,7 +1922,7 @@ def forward(self, x_1, output_1):
         t2 = torch.rand(5, device="cuda", requires_grad=grad)
 
         torch_add = t1 + t2
-        test, (code,) = run_and_get_code(torch.compile(call_triton_add), t1, t2)
+        test, code = run_and_get_code(torch.compile(call_triton_add), t1, t2)
         self.assertEqual(torch_add, test)
         self.assertTrue("aten.copy" not in code)
         self.assertTrue("aten.clone" not in code)

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -8196,7 +8196,7 @@ ShapeEnv not equal: field values don't match:
         self.assertEqual(expect, actual)
 
         self.assertTrue(
-            all("aten.pow" not in code),
+            "aten.pow" not in code,
             msg="Encountered an unexpected fallback to 'aten pow' in dynamo compiled code",
         )
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -46,7 +46,6 @@ from torch._dynamo.testing import (
 )
 
 from torch._dynamo.utils import CompileProfiler, counters, ifdynstaticdefault
-from torch._inductor.utils import run_and_get_code
 from torch.ao.quantization import MinMaxObserver
 from torch.ao.quantization.fake_quantize import FakeQuantize
 from torch.ao.quantization.qconfig import QConfig
@@ -76,6 +75,7 @@ from torch.testing._internal.common_utils import (
     IS_FBCODE,
     set_default_dtype,
 )
+from torch.testing._internal.inductor_utils import run_and_get_code
 from torch.testing._internal.jit_utils import JitTestCase
 
 mytuple = collections.namedtuple("mytuple", ["a", "b", "ab"])
@@ -8190,13 +8190,13 @@ ShapeEnv not equal: field values don't match:
         x = np.arange(8)
         pow_opt = torch.compile(pow)
 
-        actual, source_code = run_and_get_code(pow_opt, x)
+        actual, code = run_and_get_code(pow_opt, x)
         expect = pow(x)
 
         self.assertEqual(expect, actual)
 
         self.assertTrue(
-            all("aten.pow" not in code for code in source_code),
+            all("aten.pow" not in code),
             msg="Encountered an unexpected fallback to 'aten pow' in dynamo compiled code",
         )
 

--- a/test/inductor/test_cpp_wrapper.py
+++ b/test/inductor/test_cpp_wrapper.py
@@ -12,7 +12,7 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ROCM,
     TestCase as TorchTestCase,
 )
-from torch.testing._internal.inductor_utils import HAS_CPU, HAS_CUDA
+from torch.testing._internal.inductor_utils import HAS_CPU, HAS_CUDA, run_and_get_code
 
 
 try:
@@ -104,9 +104,7 @@ def make_test_case(name, device, tests, condition=True, slow=False, func_inputs=
         tests.setUpClass()
         tests.setUp()
         try:
-            _, code = test_torchinductor.run_and_get_cpp_code(
-                func, *func_inputs if func_inputs else []
-            )
+            _, code = run_and_get_code(func, *func_inputs if func_inputs else [])
             self.assertEqual("CppWrapperCodeCache" in code, True)
         finally:
             tests.tearDown()

--- a/test/inductor/test_extension_backend.py
+++ b/test/inductor/test_extension_backend.py
@@ -27,6 +27,7 @@ from torch._inductor.codegen.common import (
     register_backend_for_device,
 )
 from torch.testing._internal.common_utils import IS_FBCODE, IS_MACOS
+from torch.testing._internal.inductor_utils import run_and_get_code
 
 try:
     try:
@@ -39,7 +40,6 @@ except unittest.SkipTest:
     raise
 
 
-run_and_get_cpp_code = test_torchinductor.run_and_get_cpp_code
 TestCase = test_torchinductor.TestCase
 
 
@@ -130,7 +130,7 @@ class ExtensionBackendTests(TestCase):
 
         metrics.reset()
         opt_fn = torch.compile()(fn)
-        _, code = run_and_get_cpp_code(opt_fn, x, y, z)
+        _, code = run_and_get_code(opt_fn, x, y, z)
         FileCheck().check("void kernel").check("loadu").check("extension_device").run(
             code
         )

--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -67,7 +67,7 @@ class TestSDPAPatternRewriterTemplate(TestCase):
 
             counters.clear()
             torch.manual_seed(1234)
-            result2, (source_code,) = run_and_get_code(
+            result2, source_code = run_and_get_code(
                 torch.compile(dot_prod_attention, fullgraph=True),
                 *(args2 + dropout_arg),
             )
@@ -144,7 +144,7 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             torch.randn(tensor_shape, device=self.device),
             torch.randn(tensor_shape, device=self.device),
         ]
-        _, (source_code,) = run_and_get_code(dot_prod_attention, *args)
+        _, source_code = run_and_get_code(dot_prod_attention, *args)
         self.assertNotIn("aten._scaled_dot_product_efficient_attention", source_code)
 
     @skipIfRocm

--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -8,13 +8,12 @@ import torch._inductor.config
 import torch.utils.checkpoint
 from torch._dynamo.test_case import run_tests, TestCase
 from torch._dynamo.utils import counters
-from torch._inductor.utils import run_and_get_code
 from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FUSED_ATTENTION,
     SM80OrLater,
 )
 from torch.testing._internal.common_utils import IS_LINUX, skipIfRocm
-from torch.testing._internal.inductor_utils import HAS_CPU, HAS_CUDA
+from torch.testing._internal.inductor_utils import HAS_CPU, HAS_CUDA, run_and_get_code
 
 
 def checkpoint_wrapper(fn):

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -22,7 +22,6 @@ from torch._inductor.select_algorithm import (
     ChoiceCaller,
     TritonTemplateCaller,
 )
-from torch._inductor.utils import run_and_get_code
 from torch._inductor.virtualized import V
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing import FileCheck
@@ -33,7 +32,7 @@ from torch.testing._internal.common_utils import (
     skipIfRocm,
 )
 
-from torch.testing._internal.inductor_utils import HAS_CPU, HAS_CUDA
+from torch.testing._internal.inductor_utils import HAS_CPU, HAS_CUDA, run_and_get_code
 
 torch.set_float32_matmul_precision("high")
 if HAS_CUDA:
@@ -409,7 +408,7 @@ class TestMaxAutotune(TestCase):
             with torch.no_grad():
                 out, code = run_and_get_code(foo, conv1x1, input_tensor)
 
-            FileCheck().check_not("extern_kernels.convolution").run(code[0])
+            FileCheck().check_not("extern_kernels.convolution").run(code)
             self.assertEqual(conv1x1(input_tensor), out, atol=1e-2, rtol=0)
 
     def test_cat_addmm(self):

--- a/test/inductor/test_memory_planning.py
+++ b/test/inductor/test_memory_planning.py
@@ -60,6 +60,7 @@ class TestMemoryPlanning(TestCase):
         )
         self.assertTrue(same(f(*args), result))
 
+    @skipIfRocm
     def test_cpp_wrapper(self):
         f, args = self._generate(device="cuda")
         compiled = torch.compile(f, dynamic=True)

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -10,7 +10,11 @@ from torch._dynamo.test_case import run_tests, TestCase
 from torch._dynamo.utils import counters
 from torch._export import capture_pre_autograd_graph
 from torch._inductor import config
-from torch.ao.quantization.quantize_pt2e import convert_pt2e, prepare_pt2e
+from torch.ao.quantization.quantize_pt2e import (
+    convert_pt2e,
+    prepare_pt2e,
+    prepare_qat_pt2e,
+)
 from torch.ao.quantization.quantizer.x86_inductor_quantizer import X86InductorQuantizer
 from torch.nn import functional as F
 from torch.testing._internal.common_quantization import (

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -10,12 +10,7 @@ from torch._dynamo.test_case import run_tests, TestCase
 from torch._dynamo.utils import counters
 from torch._export import capture_pre_autograd_graph
 from torch._inductor import config
-from torch._inductor.utils import run_and_get_code
-from torch.ao.quantization.quantize_pt2e import (
-    convert_pt2e,
-    prepare_pt2e,
-    prepare_qat_pt2e,
-)
+from torch.ao.quantization.quantize_pt2e import convert_pt2e, prepare_pt2e
 from torch.ao.quantization.quantizer.x86_inductor_quantizer import X86InductorQuantizer
 from torch.nn import functional as F
 from torch.testing._internal.common_quantization import (
@@ -23,7 +18,11 @@ from torch.testing._internal.common_quantization import (
     skipIfNoONEDNN,
 )
 from torch.testing._internal.common_utils import IS_LINUX, skipIfRocm
-from torch.testing._internal.inductor_utils import _check_has_dynamic_shape, HAS_CPU
+from torch.testing._internal.inductor_utils import (
+    _check_has_dynamic_shape,
+    HAS_CPU,
+    run_and_get_code,
+)
 
 
 # The dict value is match_nodes(computation_op+unary_op)
@@ -163,7 +162,7 @@ class TestPatternMatcherBase(TestCase):
             if check_quantization:
                 mod = self._generate_qdq_quantized_model(mod, inputs)
             expected = mod(*inputs)
-            actual, (source_code,) = run_and_get_code(
+            actual, source_code = run_and_get_code(
                 torch.compile(mod, fullgraph=True, dynamic=check_dynamic),
                 *clone_inputs,
             )

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -8101,7 +8101,7 @@ if HAS_CUDA and not TEST_WITH_ASAN:
 
             x = torch.randn(2, 1024, device="cuda")
             ref = f(x)
-            actual, (code,) = run_and_get_code(torch.compile(f), x)
+            actual, code = run_and_get_code(torch.compile(f), x)
             self.assertTrue(torch.allclose(ref, actual))
             self.assertTrue(
                 re.search(r"assert not .*\.isnan\(\)\.any\(\).item\(\)", code)

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -31,13 +31,9 @@ importlib.import_module("filelock")
 # Make the helper files in test/ importable
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(pytorch_test_dir)
-from inductor.test_torchinductor import (
-    CommonTemplate,
-    copy_tests,
-    run_and_get_cpp_code,
-    run_and_get_triton_code,
-    TestFailure,
-)
+from torch.testing._internal.inductor_utils import run_and_get_code
+
+from inductor.test_torchinductor import CommonTemplate, copy_tests, TestFailure
 from inductor.test_torchinductor_dynamic_shapes import make_dynamic_cls
 
 
@@ -81,11 +77,10 @@ def check_codegen(
 
     run = torch._dynamo.optimize(compile_fx_wrapper, nopython=True)(run)
 
+    _, code = run_and_get_code(run, *example_inputs, **kwargs)
     if is_cpp_code:
-        _, code = run_and_get_cpp_code(run, *example_inputs, **kwargs)
         _check_has_dynamic_shape(self, code)
     else:
-        code = run_and_get_triton_code(run, *example_inputs, **kwargs)
         triton_kernel_found = False
         lines = code.split("\n")
         for line in lines:

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -9,6 +9,7 @@ from torch.testing._internal.common_utils import (
 from torch._dynamo.backends.registry import register_backend
 from torch._inductor.compile_fx import compile_fx, count_bytes_inner
 from torch.testing._internal.common_utils import TestCase
+from unittest.mock import patch
 import torch
 import re
 
@@ -49,3 +50,39 @@ def _check_has_dynamic_shape(
         has_dynamic, msg=f"Failed to find dynamic for loop variable\n{code}"
     )
     self.assertTrue(for_loop_found, f"Failed to find for loop\n{code}")
+
+def run_and_get_code(fn, *args, **kwargs):
+    """
+    Run fn and return the result along with the generated code.
+    """
+    from torch._inductor import config
+    # We use the patch context manager instead of using it as a decorator.
+    # In this way, we can ensure that the attribute is patched and unpatched correctly
+    # even if this run_and_get_cpp_code function is called multiple times.
+    with patch.object(config, "debug", True):
+        torch._dynamo.reset()
+        import io
+        import logging
+
+        log_capture_string = io.StringIO()
+        ch = logging.StreamHandler(log_capture_string)
+        from torch._inductor.graph import output_code_log
+
+        output_code_log.addHandler(ch)
+        prev_level = output_code_log.level
+        output_code_log.setLevel(logging.DEBUG)
+        result = fn(*args, **kwargs)
+        s = log_capture_string.getvalue()
+        output_code_log.setLevel(prev_level)
+        output_code_log.removeHandler(ch)
+    return result, s
+
+def run_and_get_multiple_code(fn, *args, **kwargs):
+    """
+    Similar to run_and_get_code(), but split the logged code by output file. Useful for separating code from the forward
+    and backward passes.
+    """
+    result, s = run_and_get_code(fn, *args, **kwargs)
+    source_codes = s.split("Output code:")
+    assert source_codes[0] == ""
+    return result, source_codes[1:]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #112808

The old implementation of `run_and_get_code` did not work for
AOTInductor. Thus AOTI used `run_and_get_cpp_code` instead. However,
`run_and_get_cpp_code` has nearly the same functionality as
`run_and_get_code`, and with some modification (specifically, splitting
the output code by forward/backward pass), it works for all the use
cases that called the old impl of `run_and_get_code`.

Moreover, I moved the implementation of `run_and_get_cpp_code` out of
test_torchinductor.py because the latter file pulls in many
dependencies.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler