### PR TITLE
Initialize logging facility when running ProcessGroupNCCLTest

### DIFF
--- a/test/cpp/c10d/ProcessGroupNCCLTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLTest.cpp
@@ -734,6 +734,7 @@ void testSequenceNumInit(
 class ProcessGroupNCCLTest : public ::testing::Test {
  protected:
   void SetUp() override {
+    c10::initLogging();
     // Use WORLD_SIZE and RANK environmental variables to do multi-node
     // distributed testing
     auto sizeEnv = std::getenv("WORLD_SIZE");


### PR DESCRIPTION
If code is compiled without `glog`, there are no way to control log levels other than explicitly calling `c10::initLogging()`

Test plan: Run `TORCH_CPP_LOG_LEVEL=0 ./bin/ProcessGroupNCCLTest` and observe extra log messages
