### PR TITLE
Configure labeler for 'module: distributed'

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -68,7 +68,7 @@
 "ciflow/trunk":
 - .ci/docker/ci_commit_pins/triton.txt
 
-"module: distributed"
+"module: distributed":
 - /torch/csrc/distributed/**
 - /torch/distributed/**
 - /torch/nn/parallel/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -67,3 +67,10 @@
 
 "ciflow/trunk":
 - .ci/docker/ci_commit_pins/triton.txt
+
+"module: distributed"
+- /torch/csrc/distributed/**
+- /torch/distributed/**
+- /torch/nn/parallel/**
+- /test/distributed/**
+- /torch/testing/_internal/distributed/**


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #112813
* __->__ #112812

To opt-in to getting notified based on this label, simply add yourself
to the summary field at the top of this issue:
https://github.com/pytorch/pytorch/issues/24422

Uses same file paths as current CODEOWNERS.

Note: can easily add sub-labels for components within distributed if we
want.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @yf225 @kiukchung @d4l3k