### PR TITLE
Doc: Add and Fix docstrings for torch.util.data files 

### DIFF
--- a/torch/utils/data/_utils/__init__.py
+++ b/torch/utils/data/_utils/__init__.py
@@ -1,5 +1,4 @@
-r"""Utility classes & functions for data loading. Code in this folder is mostly
-used by ../dataloder.py.
+r"""Utility classes & functions for data loading. Code in this folder is mostly used by ../dataloder.py.
 
 A lot of multiprocessing is used in data loading, which only supports running
 functions defined in global environment (py2 can't serialize static methods).

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -18,7 +18,7 @@ np_str_obj_array_pattern = re.compile(r'[SaUO]')
 
 def default_convert(data):
     r"""
-    Define function that converts each NumPy array element into a :class:`torch.Tensor`.
+    Convert each NumPy array element into a :class:`torch.Tensor`.
 
     If the input is a `Sequence`, `Collection`, or `Mapping`, it tries to convert each element inside to a :class:`torch.Tensor`.
     If the input is not an NumPy array, it is left unchanged.
@@ -209,7 +209,7 @@ default_collate_fn_map[bytes] = collate_str_fn
 
 def default_collate(batch):
     r"""
-    Define function that takes in a batch of data and puts the elements within the batch into a tensor with an additional outer dimension - batch size.
+    Take in a batch of data and put the elements within the batch into a tensor with an additional outer dimension - batch size.
 
     The exact output type can be a :class:`torch.Tensor`, a `Sequence` of :class:`torch.Tensor`, a
     Collection of :class:`torch.Tensor`, or left unchanged, depending on the input type.

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -95,9 +95,9 @@ def collate(batch, *, collate_fn_map: Optional[Dict[Union[Type, Tuple[Type, ...]
     Args:
         batch: a single batch to be collated
         collate_fn_map: Optional dictionary mapping from element type to the corresponding collate function.
-        If the element type isn't present in this dictionary,
-        this function will go through each key of the dictionary in the insertion order to
-        invoke the corresponding collate function if the element type is a subclass of the key.
+            If the element type isn't present in this dictionary,
+            this function will go through each key of the dictionary in the insertion order to
+            invoke the corresponding collate function if the element type is a subclass of the key.
 
     Examples:
         >>> def collate_tensor_fn(batch, *, collate_fn_map):

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -1,5 +1,6 @@
-r"""Contains definitions of the methods used by the _BaseDataLoaderIter workers to collate samples fetched from dataset into Tensor(s).
+r"""Contains definitions of the methods used by the _BaseDataLoaderIter workers.
 
+These methods are used to collate samples fetched from dataset into Tensor(s).
 These **needs** to be in global scope since Py2 doesn't support serializing
 static methods.
 

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -23,8 +23,8 @@ def default_convert(data):
 
     If the input is a `Sequence`, `Collection`, or `Mapping`, it tries to convert each element inside to a :class:`torch.Tensor`.
     If the input is not an NumPy array, it is left unchanged.
-    This is used as the default function for collation when both `batch_sampler` and
-    `batch_size` are NOT defined in :class:`~torch.utils.data.DataLoader`.
+    This is used as the default function for collation when both `batch_sampler` and `batch_size`
+    are NOT defined in :class:`~torch.utils.data.DataLoader`.
 
     The general input type to output type mapping is similar to that
     of :func:`~torch.utils.data.default_collate`. See the description there for more details.

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -1,5 +1,4 @@
-r""""Contains definitions of the methods used by the _BaseDataLoaderIter workers to
-collate samples fetched from dataset into Tensor(s).
+r"""Contains definitions of the methods used by the _BaseDataLoaderIter workers to collate samples fetched from dataset into Tensor(s).
 
 These **needs** to be in global scope since Py2 doesn't support serializing
 static methods.
@@ -19,35 +18,36 @@ np_str_obj_array_pattern = re.compile(r'[SaUO]')
 
 def default_convert(data):
     r"""
-        Function that converts each NumPy array element into a :class:`torch.Tensor`. If the input is a `Sequence`,
-        `Collection`, or `Mapping`, it tries to convert each element inside to a :class:`torch.Tensor`.
-        If the input is not an NumPy array, it is left unchanged.
-        This is used as the default function for collation when both `batch_sampler` and
-        `batch_size` are NOT defined in :class:`~torch.utils.data.DataLoader`.
+    Define function that converts each NumPy array element into a :class:`torch.Tensor`.
 
-        The general input type to output type mapping is similar to that
-        of :func:`~torch.utils.data.default_collate`. See the description there for more details.
+    If the input is a `Sequence`, `Collection`, or `Mapping`, it tries to convert each element inside to a :class:`torch.Tensor`.
+    If the input is not an NumPy array, it is left unchanged.
+    This is used as the default function for collation when both `batch_sampler` and
+    `batch_size` are NOT defined in :class:`~torch.utils.data.DataLoader`.
 
-        Args:
-            data: a single data point to be converted
+    The general input type to output type mapping is similar to that
+    of :func:`~torch.utils.data.default_collate`. See the description there for more details.
 
-        Examples:
-            >>> # xdoctest: +SKIP
-            >>> # Example with `int`
-            >>> default_convert(0)
-            0
-            >>> # Example with NumPy array
-            >>> default_convert(np.array([0, 1]))
-            tensor([0, 1])
-            >>> # Example with NamedTuple
-            >>> Point = namedtuple('Point', ['x', 'y'])
-            >>> default_convert(Point(0, 0))
-            Point(x=0, y=0)
-            >>> default_convert(Point(np.array(0), np.array(0)))
-            Point(x=tensor(0), y=tensor(0))
-            >>> # Example with List
-            >>> default_convert([np.array([0, 1]), np.array([2, 3])])
-            [tensor([0, 1]), tensor([2, 3])]
+    Args:
+        data: a single data point to be converted
+
+    Examples:
+        >>> # xdoctest: +SKIP
+        >>> # Example with `int`
+        >>> default_convert(0)
+        0
+        >>> # Example with NumPy array
+        >>> default_convert(np.array([0, 1]))
+        tensor([0, 1])
+        >>> # Example with NamedTuple
+        >>> Point = namedtuple('Point', ['x', 'y'])
+        >>> default_convert(Point(0, 0))
+        Point(x=0, y=0)
+        >>> default_convert(Point(np.array(0), np.array(0)))
+        Point(x=tensor(0), y=tensor(0))
+        >>> # Example with List
+        >>> default_convert([np.array([0, 1]), np.array([2, 3])])
+        [tensor([0, 1]), tensor([2, 3])]
     """
     elem_type = type(data)
     if isinstance(data, torch.Tensor):
@@ -86,30 +86,31 @@ default_collate_err_msg_format = (
 
 def collate(batch, *, collate_fn_map: Optional[Dict[Union[Type, Tuple[Type, ...]], Callable]] = None):
     r"""
-        General collate function that handles collection type of element within each batch
-        and opens function registry to deal with specific element types. `default_collate_fn_map`
-        provides default collate functions for tensors, numpy arrays, numbers and strings.
+    General collate function that handles collection type of element within each batch.
 
-        Args:
-            batch: a single batch to be collated
-            collate_fn_map: Optional dictionary mapping from element type to the corresponding collate function.
-              If the element type isn't present in this dictionary,
-              this function will go through each key of the dictionary in the insertion order to
-              invoke the corresponding collate function if the element type is a subclass of the key.
+    The function also opens function registry to deal with specific element types. `default_collate_fn_map`
+    provides default collate functions for tensors, numpy arrays, numbers and strings.
 
-        Examples:
-            >>> # Extend this function to handle batch of tensors
-            >>> def collate_tensor_fn(batch, *, collate_fn_map):
-            ...     return torch.stack(batch, 0)
-            >>> def custom_collate(batch):
-            ...     collate_map = {torch.Tensor: collate_tensor_fn}
-            ...     return collate(batch, collate_fn_map=collate_map)
-            >>> # Extend `default_collate` by in-place modifying `default_collate_fn_map`
-            >>> default_collate_fn_map.update({torch.Tensor: collate_tensor_fn})
+    Args:
+        batch: a single batch to be collated
+        collate_fn_map: Optional dictionary mapping from element type to the corresponding collate function.
+        If the element type isn't present in this dictionary,
+        this function will go through each key of the dictionary in the insertion order to
+        invoke the corresponding collate function if the element type is a subclass of the key.
 
-        Note:
-            Each collate function requires a positional argument for batch and a keyword argument
-            for the dictionary of collate functions as `collate_fn_map`.
+    Examples:
+        >>> def collate_tensor_fn(batch, *, collate_fn_map):
+        >>> # Extend this function to handle batch of tensors
+        ...     return torch.stack(batch, 0)
+        >>> def custom_collate(batch):
+        ...     collate_map = {torch.Tensor: collate_tensor_fn}
+        ...     return collate(batch, collate_fn_map=collate_map)
+        >>> # Extend `default_collate` by in-place modifying `default_collate_fn_map`
+        >>> default_collate_fn_map.update({torch.Tensor: collate_tensor_fn})
+
+    Note:
+        Each collate function requires a positional argument for batch and a keyword argument
+        for the dictionary of collate functions as `collate_fn_map`.
     """
     elem = batch[0]
     elem_type = type(elem)
@@ -208,63 +209,63 @@ default_collate_fn_map[bytes] = collate_str_fn
 
 def default_collate(batch):
     r"""
-        Function that takes in a batch of data and puts the elements within the batch
-        into a tensor with an additional outer dimension - batch size. The exact output type can be
-        a :class:`torch.Tensor`, a `Sequence` of :class:`torch.Tensor`, a
-        Collection of :class:`torch.Tensor`, or left unchanged, depending on the input type.
-        This is used as the default function for collation when
-        `batch_size` or `batch_sampler` is defined in :class:`~torch.utils.data.DataLoader`.
+    Define function that takes in a batch of data and puts the elements within the batch into a tensor with an additional outer dimension - batch size.
 
-        Here is the general input type (based on the type of the element within the batch) to output type mapping:
+    The exact output type can be a :class:`torch.Tensor`, a `Sequence` of :class:`torch.Tensor`, a
+    Collection of :class:`torch.Tensor`, or left unchanged, depending on the input type.
+    This is used as the default function for collation when
+    `batch_size` or `batch_sampler` is defined in :class:`~torch.utils.data.DataLoader`.
 
-            * :class:`torch.Tensor` -> :class:`torch.Tensor` (with an added outer dimension batch size)
-            * NumPy Arrays -> :class:`torch.Tensor`
-            * `float` -> :class:`torch.Tensor`
-            * `int` -> :class:`torch.Tensor`
-            * `str` -> `str` (unchanged)
-            * `bytes` -> `bytes` (unchanged)
-            * `Mapping[K, V_i]` -> `Mapping[K, default_collate([V_1, V_2, ...])]`
-            * `NamedTuple[V1_i, V2_i, ...]` -> `NamedTuple[default_collate([V1_1, V1_2, ...]),
-              default_collate([V2_1, V2_2, ...]), ...]`
-            * `Sequence[V1_i, V2_i, ...]` -> `Sequence[default_collate([V1_1, V1_2, ...]),
-              default_collate([V2_1, V2_2, ...]), ...]`
+    Here is the general input type (based on the type of the element within the batch) to output type mapping:
 
-        Args:
-            batch: a single batch to be collated
+        * :class:`torch.Tensor` -> :class:`torch.Tensor` (with an added outer dimension batch size)
+        * NumPy Arrays -> :class:`torch.Tensor`
+        * `float` -> :class:`torch.Tensor`
+        * `int` -> :class:`torch.Tensor`
+        * `str` -> `str` (unchanged)
+        * `bytes` -> `bytes` (unchanged)
+        * `Mapping[K, V_i]` -> `Mapping[K, default_collate([V_1, V_2, ...])]`
+        * `NamedTuple[V1_i, V2_i, ...]` -> `NamedTuple[default_collate([V1_1, V1_2, ...]),
+          default_collate([V2_1, V2_2, ...]), ...]`
+        * `Sequence[V1_i, V2_i, ...]` -> `Sequence[default_collate([V1_1, V1_2, ...]),
+          default_collate([V2_1, V2_2, ...]), ...]`
 
-        Examples:
-            >>> # xdoctest: +SKIP
-            >>> # Example with a batch of `int`s:
-            >>> default_collate([0, 1, 2, 3])
-            tensor([0, 1, 2, 3])
-            >>> # Example with a batch of `str`s:
-            >>> default_collate(['a', 'b', 'c'])
-            ['a', 'b', 'c']
-            >>> # Example with `Map` inside the batch:
-            >>> default_collate([{'A': 0, 'B': 1}, {'A': 100, 'B': 100}])
-            {'A': tensor([  0, 100]), 'B': tensor([  1, 100])}
-            >>> # Example with `NamedTuple` inside the batch:
-            >>> Point = namedtuple('Point', ['x', 'y'])
-            >>> default_collate([Point(0, 0), Point(1, 1)])
-            Point(x=tensor([0, 1]), y=tensor([0, 1]))
-            >>> # Example with `Tuple` inside the batch:
-            >>> default_collate([(0, 1), (2, 3)])
-            [tensor([0, 2]), tensor([1, 3])]
-            >>> # Example with `List` inside the batch:
-            >>> default_collate([[0, 1], [2, 3]])
-            [tensor([0, 2]), tensor([1, 3])]
-            >>> # Two options to extend `default_collate` to handle specific type
-            >>> # Option 1: Write custom collate function and invoke `default_collate`
-            >>> def custom_collate(batch):
-            ...     elem = batch[0]
-            ...     if isinstance(elem, CustomType):  # Some custom condition
-            ...         return ...
-            ...     else:  # Fall back to `default_collate`
-            ...         return default_collate(batch)
-            >>> # Option 2: In-place modify `default_collate_fn_map`
-            >>> def collate_customtype_fn(batch, *, collate_fn_map=None):
-            ...     return ...
-            >>> default_collate_fn_map.update(CustoType, collate_customtype_fn)
-            >>> default_collate(batch)  # Handle `CustomType` automatically
+    Args:
+        batch: a single batch to be collated
+
+    Examples:
+        >>> # xdoctest: +SKIP
+        >>> # Example with a batch of `int`s:
+        >>> default_collate([0, 1, 2, 3])
+        tensor([0, 1, 2, 3])
+        >>> # Example with a batch of `str`s:
+        >>> default_collate(['a', 'b', 'c'])
+        ['a', 'b', 'c']
+        >>> # Example with `Map` inside the batch:
+        >>> default_collate([{'A': 0, 'B': 1}, {'A': 100, 'B': 100}])
+        {'A': tensor([  0, 100]), 'B': tensor([  1, 100])}
+        >>> # Example with `NamedTuple` inside the batch:
+        >>> Point = namedtuple('Point', ['x', 'y'])
+        >>> default_collate([Point(0, 0), Point(1, 1)])
+        Point(x=tensor([0, 1]), y=tensor([0, 1]))
+        >>> # Example with `Tuple` inside the batch:
+        >>> default_collate([(0, 1), (2, 3)])
+        [tensor([0, 2]), tensor([1, 3])]
+        >>> # Example with `List` inside the batch:
+        >>> default_collate([[0, 1], [2, 3]])
+        [tensor([0, 2]), tensor([1, 3])]
+        >>> # Two options to extend `default_collate` to handle specific type
+        >>> # Option 1: Write custom collate function and invoke `default_collate`
+        >>> def custom_collate(batch):
+        ...     elem = batch[0]
+        ...     if isinstance(elem, CustomType):  # Some custom condition
+        ...         return ...
+        ...     else:  # Fall back to `default_collate`
+        ...         return default_collate(batch)
+        >>> # Option 2: In-place modify `default_collate_fn_map`
+        >>> def collate_customtype_fn(batch, *, collate_fn_map=None):
+        ...     return ...
+        >>> default_collate_fn_map.update(CustoType, collate_customtype_fn)
+        >>> default_collate(batch)  # Handle `CustomType` automatically
     """
     return collate(batch, collate_fn_map=default_collate_fn_map)

--- a/torch/utils/data/_utils/fetch.py
+++ b/torch/utils/data/_utils/fetch.py
@@ -1,6 +1,6 @@
-r""""Contains definitions of the methods used by the _BaseDataLoaderIter to fetch
-data from an iterable-style or map-style dataset. This logic is shared in both
-single- and multi-processing data loading.
+r"""Contains definitions of the methods used by the _BaseDataLoaderIter to fetch data from an iterable-style or map-style dataset.
+
+This logic is shared in both single- and multi-processing data loading.
 """
 
 

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -1,5 +1,4 @@
-r""""Contains definitions of the methods used by the _BaseDataLoaderIter to put
-fetched tensors into pinned memory.
+r"""Contains definitions of the methods used by the _BaseDataLoaderIter to put fetched tensors into pinned memory.
 
 These **needs** to be in global scope since Py2 doesn't support serializing
 static methods.

--- a/torch/utils/data/_utils/signal_handling.py
+++ b/torch/utils/data/_utils/signal_handling.py
@@ -1,4 +1,4 @@
-r""""Signal handling for multiprocessing data loading.
+r"""Signal handling for multiprocessing data loading.
 
 NOTE [ Signal handling in multiprocessing data loading ]
 

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -1,4 +1,4 @@
-r"""Definition of the DataLoader and associated iterators that subclass _BaseDataLoaderIter
+r"""Definition of the DataLoader and associated iterators that subclass _BaseDataLoaderIter.
 
 To support these two classes, in `./_utils` we define many utility methods and
 functions to be run in multiprocessing. E.g., the data loading worker loop is
@@ -81,6 +81,7 @@ class _DatasetKind:
 
 class _InfiniteConstantSampler(Sampler):
     r"""Analogous to ``itertools.repeat(None, None)``.
+
     Used as sampler for :class:`~torch.utils.data.IterableDataset`.
     """
 
@@ -122,8 +123,7 @@ def _share_dist_seed(generator, pg):
 
 class DataLoader(Generic[T_co]):
     r"""
-    Data loader. Combines a dataset and a sampler, and provides an iterable over
-    the given dataset.
+    Data loader combines a dataset and a sampler, and provides an iterable over the given dataset.
 
     The :class:`~torch.utils.data.DataLoader` supports both map-style and
     iterable-style datasets with single- or multi-process loading, customizing
@@ -210,6 +210,7 @@ class DataLoader(Generic[T_co]):
     .. _multiprocessing context:
         https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
     """
+
     dataset: Dataset[T_co]
     batch_size: Optional[int]
     num_workers: int
@@ -678,7 +679,7 @@ class _SingleProcessDataLoaderIter(_BaseDataLoaderIter):
 
 
 class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
-    r"""Iterates once over the DataLoader's dataset, as specified by the sampler"""
+    r"""Iterates once over the DataLoader's dataset, as specified by the sampler."""
 
     # NOTE [ Data Loader Multiprocessing Shutdown Logic ]
     #

--- a/torch/utils/data/datapipes/_decorator.py
+++ b/torch/utils/data/datapipes/_decorator.py
@@ -13,9 +13,11 @@ class functional_datapipe:
 
     def __init__(self, name: str, enable_df_api_tracing=False) -> None:
         """
-            Args:
-                enable_df_api_tracing - if set, any returned DataPipe would accept
-                DataFrames API in tracing mode.
+        Define a functional datapipe.
+
+        Args:
+            enable_df_api_tracing - if set, any returned DataPipe would accept
+            DataFrames API in tracing mode.
         """
         self.name = name
         self.enable_df_api_tracing = enable_df_api_tracing

--- a/torch/utils/data/datapipes/_hook_iterator.py
+++ b/torch/utils/data/datapipes/_hook_iterator.py
@@ -117,8 +117,9 @@ def hook_iterator(namespace):
 
     class IteratorDecorator:
         r"""
-        Wrap the iterator and modifying its `__next__` method. This decorator is applied to DataPipes of which `__iter__` method is NOT a generator function.
+        Wrap the iterator and modifying its `__next__` method.
 
+        This decorator is applied to DataPipes of which `__iter__` method is NOT a generator function.
         Those `__iter__` method commonly returns `self` but not necessarily.
         """
 

--- a/torch/utils/data/datapipes/_hook_iterator.py
+++ b/torch/utils/data/datapipes/_hook_iterator.py
@@ -8,19 +8,19 @@ import torch.autograd
 class _SnapshotState(Enum):
     r"""
     These are the snapshotting-related states that IterDataPipes can be in.
+
     `NotStarted` - allows you to restore a snapshot and create an iterator with reset
     `Restored` - cannot restore again, allows you to create an iterator without resetting the DataPipe
     `Iterating` - can restore, will reset if you create a new iterator
     """
+
     NotStarted = 0
     Restored = 1
     Iterating = 2
 
 
 def _simplify_obj_name(obj) -> str:
-    """
-    Simplify the display strings of objects for the purpose of rendering within DataPipe error messages.
-    """
+    """Simplify the display strings of objects for the purpose of rendering within DataPipe error messages."""
     if inspect.isfunction(obj):
         return obj.__name__
     else:
@@ -32,9 +32,7 @@ def _strip_datapipe_from_name(name: str) -> str:
 
 
 def _generate_input_args_string(obj):
-    """
-    Generate a string for the input arguments of an object.
-    """
+    """Generate a string for the input arguments of an object."""
     signature = inspect.signature(obj.__class__)
     input_param_names = set()
     for param_name in signature.parameters.keys():
@@ -67,6 +65,7 @@ _feedback_msg = ("\nFor feedback regarding this single iterator per IterDataPipe
 def _check_iterator_valid(datapipe, iterator_id, next_method_exists=False) -> None:
     r"""
     Given an instance of a DataPipe and an iterator ID, check if the IDs match, and if not, raises an exception.
+
     In the case of ChildDataPipe, the ID gets compared to the one stored in `main_datapipe` as well.
     """
     if next_method_exists:
@@ -89,9 +88,7 @@ def _check_iterator_valid(datapipe, iterator_id, next_method_exists=False) -> No
 
 
 def _set_datapipe_valid_iterator_id(datapipe):
-    r"""
-    Given a DataPipe, updates its valid iterator ID and reset the DataPipe.
-    """
+    """Given a DataPipe, updates its valid iterator ID and reset the DataPipe."""
     if hasattr(datapipe, "_is_child_datapipe") and datapipe._is_child_datapipe is True:
         if hasattr(datapipe, "_set_main_datapipe_valid_iterator_id"):
             datapipe._set_main_datapipe_valid_iterator_id()  # reset() is called within this method when appropriate
@@ -108,8 +105,9 @@ def _set_datapipe_valid_iterator_id(datapipe):
 
 def hook_iterator(namespace):
     r"""
-    Hook that is applied to all `__iter__` of metaclass `_DataPipeMeta`. This is done for the purpose of
-    profiling and checking if an iterator is still valid.
+    Define a hook that is applied to all `__iter__` of metaclass `_DataPipeMeta`.
+
+    This is done for the purpose of profiling and checking if an iterator is still valid.
     """
 
     def profiler_record_fn_context(datapipe):
@@ -119,10 +117,11 @@ def hook_iterator(namespace):
 
     class IteratorDecorator:
         r"""
-        Wrap the iterator and modifying its `__next__` method. This decorator is applied to
-        DataPipes of which `__iter__` method is NOT a generator function. Those `__iter__`
-        method commonly returns `self` but not necessarily.
+        Wrap the iterator and modifying its `__next__` method. This decorator is applied to DataPipes of which `__iter__` method is NOT a generator function.
+
+        Those `__iter__` method commonly returns `self` but not necessarily.
         """
+
         def __init__(self, iterator, datapipe, iterator_id, has_next_method):
             self.iterator = iterator
             self.datapipe = datapipe
@@ -135,9 +134,7 @@ def hook_iterator(namespace):
             return self
 
         def _get_next(self):
-            r"""
-            Return next with logic related to iterator validity, profiler, and incrementation of samples yielded.
-            """
+            """Return next with logic related to iterator validity, profiler, and incrementation of samples yielded."""
             _check_iterator_valid(self.datapipe, self.iterator_id)
             result = next(self.iterator)
             if not self.self_and_has_next_method:

--- a/torch/utils/data/datapipes/_typing.py
+++ b/torch/utils/data/datapipes/_typing.py
@@ -51,6 +51,7 @@ TYPE2ABC = {
 def issubtype(left, right, recursive=True):
     r"""
     Check if the left-side type is a subtype of the right-side type.
+
     If any of type is a composite type like `Union` and `TypeVar` with
     bounds, it would be expanded into a list of types and check all
     of left-side types are subtypes of either one from right-side types.
@@ -108,6 +109,7 @@ def _decompose_type(t, to_list=True):
 def _issubtype_with_constraints(variant, constraints, recursive=True):
     r"""
     Check if the variant is a subtype of either one from constraints.
+
     For composite types like `Union` and `TypeVar` with bounds, they
     would be expanded for testing.
     """
@@ -208,9 +210,7 @@ def issubinstance(data, data_type):
 
 
 class _DataPipeType:
-    r"""
-    Save type annotation in `param`
-    """
+    r"""Save type annotation in `param`."""
 
     def __init__(self, param):
         self.param = param
@@ -247,11 +247,13 @@ _DEFAULT_TYPE = _DataPipeType(Generic[T_co])
 
 class _DataPipeMeta(GenericMeta):
     r"""
-    Metaclass for `DataPipe`. Add `type` attribute and `__init_subclass__` based
-    on the type, and validate the return hint of `__iter__`.
+    Metaclass for `DataPipe`.
+
+    Add `type` attribute and `__init_subclass__` based on the type, and validate the return hint of `__iter__`.
 
     Note that there is subclass `_IterDataPipeMeta` specifically for `IterDataPipe`.
     """
+
     type: _DataPipeType
 
     def __new__(cls, name, bases, namespace, **kwargs):
@@ -338,8 +340,9 @@ class _DataPipeMeta(GenericMeta):
 
 class _IterDataPipeMeta(_DataPipeMeta):
     r"""
-    Metaclass for `IterDataPipe` and inherits from `_DataPipeMeta`. Aad various functions for behaviors
-    specific to `IterDataPipe`.
+    Metaclass for `IterDataPipe` and inherits from `_DataPipeMeta`.
+
+    Add various functions for behaviors specific to `IterDataPipe`.
     """
 
     def __new__(cls, name, bases, namespace, **kwargs):
@@ -350,8 +353,9 @@ class _IterDataPipeMeta(_DataPipeMeta):
             @functools.wraps(reset_func)
             def conditional_reset(*args, **kwargs):
                 r"""
-                Only execute DataPipe's `reset()` method if `_SnapshotState` is `Iterating` or `NotStarted`. This allows recently
-                restored DataPipe to preserve its restored state during the initial `__iter__` call.
+                Only execute DataPipe's `reset()` method if `_SnapshotState` is `Iterating` or `NotStarted`.
+
+                This allows recently restored DataPipe to preserve its restored state during the initial `__iter__` call.
                 """
                 datapipe = args[0]
                 if datapipe._snapshot_state in (_SnapshotState.Iterating, _SnapshotState.NotStarted):
@@ -410,9 +414,9 @@ def _dp_init_subclass(sub_cls, *args, **kwargs):
 
 def reinforce_type(self, expected_type):
     r"""
-    Reinforce the type for DataPipe instance. And the 'expected_type' is required
-    to be a subtype of the original type hint to restrict the type requirement
-    of DataPipe instance.
+    Reinforce the type for DataPipe instance.
+
+    And the 'expected_type' is required to be a subtype of the original type hint to restrict the type requirement of DataPipe instance.
     """
     if isinstance(expected_type, tuple):
         expected_type = Tuple[expected_type]

--- a/torch/utils/data/datapipes/_typing.py
+++ b/torch/utils/data/datapipes/_typing.py
@@ -416,7 +416,8 @@ def reinforce_type(self, expected_type):
     r"""
     Reinforce the type for DataPipe instance.
 
-    And the 'expected_type' is required to be a subtype of the original type hint to restrict the type requirement of DataPipe instance.
+    And the 'expected_type' is required to be a subtype of the original type
+    hint to restrict the type requirement of DataPipe instance.
     """
     if isinstance(expected_type, tuple):
         expected_type = Tuple[expected_type]

--- a/torch/utils/data/datapipes/gen_pyi.py
+++ b/torch/utils/data/datapipes/gen_pyi.py
@@ -30,6 +30,7 @@ def gen_from_template(dir: str, template_name: str, output_name: str, replacemen
 def find_file_paths(dir_paths: List[str], files_to_exclude: Set[str]) -> Set[str]:
     """
     When given a path to a directory, returns the paths to the relevant files within it.
+
     This function does NOT recursive traverse to subdirectories.
     """
     paths: Set[str] = set()
@@ -42,9 +43,7 @@ def find_file_paths(dir_paths: List[str], files_to_exclude: Set[str]) -> Set[str
 
 
 def extract_method_name(line: str) -> str:
-    """
-    Extracts method name from decorator in the form of "@functional_datapipe({method_name})"
-    """
+    """Extract method name from decorator in the form of "@functional_datapipe({method_name})"."""
     if "(\"" in line:
         start_token, end_token = "(\"", "\")"
     elif "(\'" in line:
@@ -56,9 +55,7 @@ def extract_method_name(line: str) -> str:
 
 
 def extract_class_name(line: str) -> str:
-    """
-    Extracts class name from class definition in the form of "class {CLASS_NAME}({Type}):"
-    """
+    """Extract class name from class definition in the form of "class {CLASS_NAME}({Type}):"."""
     start_token = "class "
     end_token = "("
     start, end = line.find(start_token) + len(start_token), line.find(end_token)
@@ -66,9 +63,7 @@ def extract_class_name(line: str) -> str:
 
 
 def parse_datapipe_file(file_path: str) -> Tuple[Dict[str, str], Dict[str, str], Set[str], Dict[str, List[str]]]:
-    """
-    Given a path to file, parses the file and returns a dictionary of method names to function signatures.
-    """
+    """Given a path to file, parses the file and returns a dictionary of method names to function signatures."""
     method_to_signature, method_to_class_name, special_output_type = {}, {}, set()
     doc_string_dict = defaultdict(lambda: list())
     with open(file_path) as f:
@@ -128,9 +123,7 @@ def parse_datapipe_files(file_paths: Set[str]) -> Tuple[Dict[str, str], Dict[str
 
 
 def split_outside_bracket(line: str, delimiter: str = ",") -> List[str]:
-    """
-    Given a line of text, split it on comma unless the comma is within a bracket '[]'.
-    """
+    """Given a line of text, split it on comma unless the comma is within a bracket '[]'."""
     bracket_count = 0
     curr_token = ""
     res = []
@@ -149,10 +142,7 @@ def split_outside_bracket(line: str, delimiter: str = ",") -> List[str]:
 
 
 def process_signature(line: str) -> str:
-    """
-    Given a raw function signature, clean it up by removing the self-referential datapipe argument,
-    default arguments of input functions, newlines, and spaces.
-    """
+    """Given a raw function signature, clean it up by removing the self-referential datapipe argument, default arguments of input functions, newlines, and spaces."""
     tokens: List[str] = split_outside_bracket(line)
     for i, token in enumerate(tokens):
         tokens[i] = token.strip(' ')
@@ -176,7 +166,8 @@ def get_method_definitions(file_path: Union[str, List[str]],
                            method_to_special_output_type: Dict[str, str],
                            root: str = "") -> List[str]:
     """
-    .pyi generation for functional DataPipes Process
+    #.pyi generation for functional DataPipes Process.
+
     # 1. Find files that we want to process (exclude the ones who don't)
     # 2. Parse method name and signature
     # 3. Remove first argument after self (unless it is "*datapipes"), default args, and spaces
@@ -226,7 +217,8 @@ mapDP_method_to_special_output_type: Dict[str, str] = {"shuffle": "IterDataPipe"
 
 def main() -> None:
     """
-    # Inject file into template datapipe.pyi.in
+    # Inject file into template datapipe.pyi.in.
+
     TODO: The current implementation of this script only generates interfaces for built-in methods. To generate
           interface for user-defined DataPipes, consider changing `IterDataPipe.register_datapipe_as_function`.
     """

--- a/torch/utils/data/datapipes/gen_pyi.py
+++ b/torch/utils/data/datapipes/gen_pyi.py
@@ -142,7 +142,12 @@ def split_outside_bracket(line: str, delimiter: str = ",") -> List[str]:
 
 
 def process_signature(line: str) -> str:
-    """Given a raw function signature, clean it up by removing the self-referential datapipe argument, default arguments of input functions, newlines, and spaces."""
+    """
+    Clean up a given raw function signature.
+
+    This includes removing the self-referential datapipe argument, default
+    arguments of input functions, newlines, and spaces.
+    """
     tokens: List[str] = split_outside_bracket(line)
     for i, token in enumerate(tokens):
         tokens[i] = token.strip(' ')

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -195,6 +195,7 @@ class TensorDataset(Dataset[Tuple[Tensor, ...]]):
     Args:
         *tensors (Tensor): tensors that have the same size of the first dimension.
     """
+
     tensors: Tuple[Tensor, ...]
 
     def __init__(self, *tensors: Tensor) -> None:
@@ -226,6 +227,7 @@ class StackDataset(Dataset[T_stack]):
         *args (Dataset): Datasets for stacking returned as tuple.
         **kwargs (Dataset): Datasets for stacking returned as dict.
     """
+
     datasets: Union[tuple, dict]
 
     def __init__(self, *args: Dataset[T_co], **kwargs: Dataset[T_co]) -> None:
@@ -296,6 +298,7 @@ class ConcatDataset(Dataset[T_co]):
     Args:
         datasets (sequence): List of datasets to be concatenated
     """
+
     datasets: List[Dataset[T_co]]
     cumulative_sizes: List[int]
 
@@ -348,6 +351,7 @@ class ChainDataset(IterableDataset):
     Args:
         datasets (iterable of IterableDataset): datasets to be chained together
     """
+
     def __init__(self, datasets: Iterable[Dataset]) -> None:
         super().__init__()
         self.datasets = datasets
@@ -373,6 +377,7 @@ class Subset(Dataset[T_co]):
         dataset (Dataset): The whole Dataset
         indices (sequence): Indices in the whole set selected for subset
     """
+
     dataset: Dataset[T_co]
     indices: Sequence[int]
 

--- a/torch/utils/data/distributed.py
+++ b/torch/utils/data/distributed.py
@@ -125,7 +125,9 @@ class DistributedSampler(Sampler[T_co]):
 
     def set_epoch(self, epoch: int) -> None:
         r"""
-        Sets the epoch for this sampler. When :attr:`shuffle=True`, this ensures all replicas
+        Set the epoch for this sampler.
+
+        When :attr:`shuffle=True`, this ensures all replicas
         use a different random ordering for each epoch. Otherwise, the next iteration of this
         sampler will yield the same ordering.
 

--- a/torch/utils/data/graph.py
+++ b/torch/utils/data/graph.py
@@ -84,6 +84,7 @@ def _list_connected_datapipes(scan_obj: DataPipe, only_datapipe: bool, cache: Se
 def traverse_dps(datapipe: DataPipe) -> DataPipeGraph:
     r"""
     Traverse the DataPipes and their attributes to extract the DataPipe graph.
+
     This only looks into the attribute from each DataPipe that is either a
     DataPipe and a Python collection object such as ``list``, ``tuple``,
     ``set`` and ``dict``.
@@ -100,10 +101,12 @@ def traverse_dps(datapipe: DataPipe) -> DataPipeGraph:
 
 def traverse(datapipe: DataPipe, only_datapipe: Optional[bool] = None) -> DataPipeGraph:
     r"""
-    [Deprecated] Traverse the DataPipes and their attributes to extract the DataPipe graph. When
-    ``only_dataPipe`` is specified as ``True``, it would only look into the attribute
-    from each DataPipe that is either a DataPipe and a Python collection object such as
-    ``list``, ``tuple``, ``set`` and ``dict``.
+    Traverse the DataPipes and their attributes to extract the DataPipe graph.
+
+    [Deprecated]
+    When ``only_dataPipe`` is specified as ``True``, it would only look into the
+    attribute from each DataPipe that is either a DataPipe and a Python collection object
+    such as ``list``, ``tuple``, ``set`` and ``dict``.
 
     Note:
         This function is deprecated. Please use `traverse_dps` instead.

--- a/torch/utils/data/graph_settings.py
+++ b/torch/utils/data/graph_settings.py
@@ -87,7 +87,10 @@ def _is_shuffle_datapipe(datapipe: DataPipe) -> bool:
 
 def apply_shuffle_settings(datapipe: DataPipe, shuffle: Optional[bool] = None) -> DataPipe:
     r"""
-    Traverse the graph of ``DataPipes`` to find and set shuffle attribute to each `DataPipe` that has APIs of ``set_shuffle`` and ``set_seed``.
+    Traverse the graph of ``DataPipes`` to find and set shuffle attribute.
+
+    Apply the method to each `DataPipe` that has APIs of ``set_shuffle``
+    and ``set_seed``.
 
     Args:
         datapipe: DataPipe that needs to set shuffle attribute
@@ -129,7 +132,9 @@ def _is_random_datapipe(datapipe: DataPipe) -> bool:
 
 def apply_random_seed(datapipe: DataPipe, rng: torch.Generator) -> DataPipe:
     r"""
-    Traverse the graph of ``DataPipes`` to find random ``DataPipe`` with an API of ``set_seed`` then set the random seed based on the provided RNG.
+    Traverse the graph of ``DataPipes`` to find random ``DataPipe`` with an API of ``set_seed``.
+
+    Then set the random seed based on the provided RNG to those ``DataPipe``.
 
     Args:
         datapipe: DataPipe that needs to set randomness

--- a/torch/utils/data/graph_settings.py
+++ b/torch/utils/data/graph_settings.py
@@ -49,6 +49,7 @@ def apply_sharding(datapipe: DataPipe,
                    sharding_group=SHARDING_PRIORITIES.DEFAULT) -> DataPipe:
     r"""
     Apply dynamic sharding over the ``sharding_filter`` DataPipe that has a method ``apply_sharding``.
+
     RuntimeError will be raised when multiple ``sharding_filter`` are presented in the same branch.
     """
     graph = traverse_dps(datapipe)
@@ -86,8 +87,7 @@ def _is_shuffle_datapipe(datapipe: DataPipe) -> bool:
 
 def apply_shuffle_settings(datapipe: DataPipe, shuffle: Optional[bool] = None) -> DataPipe:
     r"""
-    Traverse the graph of ``DataPipes`` to find and set shuffle attribute
-    to each `DataPipe` that has APIs of ``set_shuffle`` and ``set_seed``.
+    Traverse the graph of ``DataPipes`` to find and set shuffle attribute to each `DataPipe` that has APIs of ``set_shuffle`` and ``set_seed``.
 
     Args:
         datapipe: DataPipe that needs to set shuffle attribute
@@ -129,8 +129,7 @@ def _is_random_datapipe(datapipe: DataPipe) -> bool:
 
 def apply_random_seed(datapipe: DataPipe, rng: torch.Generator) -> DataPipe:
     r"""
-    Traverse the graph of ``DataPipes`` to find random ``DataPipe`` with an API of
-    ``set_seed`` then set the random seed based on the provided RNG.
+    Traverse the graph of ``DataPipes`` to find random ``DataPipe`` with an API of ``set_seed`` then set the random seed based on the provided RNG.
 
     Args:
         datapipe: DataPipe that needs to set randomness

--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -101,6 +101,7 @@ class SequentialSampler(Sampler[int]):
     Args:
         data_source (Dataset): dataset to sample from
     """
+
     data_source: Sized
 
     def __init__(self, data_source: Sized) -> None:
@@ -115,6 +116,7 @@ class SequentialSampler(Sampler[int]):
 
 class RandomSampler(Sampler[int]):
     r"""Samples elements randomly. If without replacement, then sample from a shuffled dataset.
+
     If with replacement, then user can specify :attr:`num_samples` to draw.
 
     Args:
@@ -123,6 +125,7 @@ class RandomSampler(Sampler[int]):
         num_samples (int): number of samples to draw, default=`len(dataset)`.
         generator (Generator): Generator used in sampling.
     """
+
     data_source: Sized
     replacement: bool
 
@@ -175,6 +178,7 @@ class SubsetRandomSampler(Sampler[int]):
         indices (sequence): a sequence of indices
         generator (Generator): Generator used in sampling.
     """
+
     indices: Sequence[int]
 
     def __init__(self, indices: Sequence[int], generator=None) -> None:
@@ -207,6 +211,7 @@ class WeightedRandomSampler(Sampler[int]):
         >>> list(WeightedRandomSampler([0.9, 0.4, 0.05, 0.2, 0.3, 0.1], 5, replacement=False))
         [0, 1, 4, 3, 2]
     """
+
     weights: Tensor
     num_samples: int
     replacement: bool


### PR DESCRIPTION
Fixes #112635 

Fix docstrings for `torch.utils.data` files.

```
Before:
> pydocstyle torch/utils/data/graph.py --count
Before: 5
After: 1

> pydocstyle torch/utils/data/graph_settings.py --count
Before: 8
After: 3

> pydocstyle torch/utils/data/dataloader.py --count
Before: 12
After: 6

> pydocstyle torch/utils/data/dataset.py --count
Before: 28
After: 23

> pydocstyle torch/utils/data/sampler.py --count
Before: 24
After: 19

> pydocstyle torch/utils/data/_utils/signal_handling.py --count
Before: 1
After: 0

> pydocstyle torch/utils/data/_utils/__init__.py --count
Before: 2
After: 0

> pydocstyle torch/utils/data/_utils/collate.py --count
Before: 20
After: 6

> pydocstyle torch/utils/data/_utils/fetch.py --count
Before: 3
After: 0

> pydocstyle torch/utils/data/_utils/pin_memory.py --count
Before: 4
After: 1 

> pydocstyle torch/utils/data/datapipes/_decorator.py --count
Before: 19
After: 16

> pydocstyle torch/utils/data/datapipes/_hook_iterator.py --count
Before: 13
After: 0

> pydocstyle torch/utils/data/datapipes/_typing.py --count
Before: 17
After: 4

> pydocstyle torch/utils/data/datapipes/gen_pyi.py --count
Before: 19
After: 4
```

cc @svekars @carljparker