### PR TITLE
[dynamo] Always use DataClassVariable for model outputs

### DIFF
--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -610,14 +610,11 @@ class CustomizedDictVariable(ConstDictVariable):
     @staticmethod
     def is_matching_cls(cls):
         # True if using default OrderedDict.__init__ and did not implement __post_init__
-        if (
+        return (
             issubclass(cls, collections.OrderedDict)
             and cls.__init__ is collections.OrderedDict.__init__
-            and cls.__getitem__ is collections.OrderedDict.__getitem__
-            and cls.__setitem__ is collections.OrderedDict.__setitem__
             and not hasattr(cls, "__post_init__")
-        ):
-            return True
+        )
 
     @classmethod
     def is_matching_object(cls, obj):
@@ -628,7 +625,7 @@ class CustomizedDictVariable(ConstDictVariable):
     @classmethod
     def create(cls, user_cls, args, kwargs, options):
         # avoid tracing when returning ModelOutput from forward func
-        for attr_name in ("__init__", "__setattr__", "__setitem__"):
+        for attr_name in ("__init__", "__post_init__", "__setattr__", "__setitem__"):
             if hasattr(user_cls, attr_name):
                 fn = getattr(user_cls, attr_name)
                 assert callable(fn), f"expect callable attr {attr_name}"
@@ -639,10 +636,10 @@ class CustomizedDictVariable(ConstDictVariable):
             # CustomDict() init with empty arguments
             raw_items = collections.OrderedDict()
         elif not args:
-            # CustomDict(a=1, b=2) in the general (non-dataclass) case.
+            # CustomDict(a=1, b=2) init with keyword arguments
             raw_items = collections.OrderedDict(kwargs)
         elif len(args) == 1 and isinstance(args[0], ConstDictVariable) and not kwargs:
-            # CustomDict({'a': 1, 'b': 2})
+            # CustomDict({'a': 1, 'b': 2}) with a dict literal argument
             raw_items = args[0].items
         else:
             unimplemented("custom dict init with args/kwargs unimplemented")
@@ -697,6 +694,13 @@ class CustomizedDictVariable(ConstDictVariable):
         ):
             # for python dict method without overridden
             return super().call_method(tx, name, args, kwargs)
+        elif name in ("__getitem__", "to_tuple", "__setitem__", "__setattr__"):
+            # for user overridden method
+            return tx.inline_user_function_return(
+                variables.UserFunctionVariable(fn, source=source, **options),
+                [self] + list(args),
+                kwargs,
+            )
 
         unimplemented("custom dict: call_method unimplemented name=%s", name)
 


### PR DESCRIPTION
[dynamo] Always use DataClassVariable for model outputs

    Summary:

    In https://github.com/pytorch/pytorch/pull/105044 we added
    support for custom subclasses of dict and OrderedDict to dynamo.

    This change makes sense on its own, and it mostly works although
    there are still gaps in the functionality due to lack of a
    `wraps` implementation and `builder.py` hooks.

    But the stated goal was to support the `ModelOutput` class from
    HF (and more recently the similar `BaseOutput` class from
    `diffusers`). This support is not complete for several reasons:
    - First, when we pass a *value* of a `ModelOutput` or `BaseModel`
      type, we wind up using `DataClassVariable` because there is no
      `wrap` implementation or `builder.py` hook for `CustomDictVariable`
      today. As a result, the behavior of dynamo is somewhat unpredictable;
      bugs can show up in cases where we construct classes that don't exist
      when we pass values of the same type and vice-versa because we're
      using different VariableTracker classes to model these cases.
    - Second, the dataclass behaviors are not implemented; much of
      the logic in DataClassVariable exists to ensure that dataclass
      fields behave properly does not exist on CustomDictVariable. I
      confirmed by hacking the tests that the logic in
      `test_model_output.py`s `test_mo_init` actually fails if we
      make a few changes to trigger the `CustomDictVariable` logic.

    The simplest path forward is to separate these two cases rather
    than trying to handle `ModelOutput` - which unifies dict and
    dataclass behavior in a very specific and unusual way - in the
    same `VariableTracker` implementation as ordinary custom dicts.

    We can potentially make the `ModelOutput` impelementation
    inherit behavior from the general case, but that's more of
    an impelementation detail and we should separate the two first.

    Test Plan:

    ```
    pytest test/dynamo/test_functions.py
    pytest test/dynamo/test_model_output.py
    ```

    The extended version of `test_mo_init` fails without this change,
    because `CustomDictVariable` does not support the dataclass operations
    needed.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng