### PR TITLE
[DCP][test] Make dim_0 size of params scale with world_size in torch/distributed/checkpoint/test_fsdp_optim_state.py

### DIFF
--- a/test/distributed/checkpoint/test_fsdp_optim_state.py
+++ b/test/distributed/checkpoint/test_fsdp_optim_state.py
@@ -2,29 +2,50 @@
 
 import torch
 
+import torch.distributed.checkpoint as DCP
+import torch.nn as nn
+from torch.distributed._shard.sharded_tensor.api import ShardedTensor
+from torch.distributed.checkpoint.optimizer import load_sharded_optimizer_state_dict
+
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.fully_sharded_data_parallel import StateDictType
-import torch.distributed.checkpoint as dist_cp
-import torch.distributed as dist
-
-from torch.distributed.checkpoint.default_planner import (
-    DefaultSavePlanner,
-    DefaultLoadPlanner,
-)
-from torch.distributed.checkpoint.optimizer import (
-    load_sharded_optimizer_state_dict,
-)
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_utils import run_tests
 
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
 )
-from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed.checkpoint_utils import with_temp_dir
 
 
 class FsdpOptimStateCheckpoint(DTensorTestBase):
+    def _create_model(self):
+        # make weight tensor dim_0 as large as the world size for scaling test
+        layer1_weight_dim = self.world_size
+        layer2_weight_dim = self.world_size * 2
+        layer3_weight_dim = self.world_size * 3
+
+        class TestDummyModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.net1 = nn.Sequential(nn.Linear(8, layer1_weight_dim), nn.ReLU())
+                self.net2 = nn.Sequential(
+                    nn.Linear(layer1_weight_dim, layer2_weight_dim), nn.ReLU()
+                )
+                self.net3 = nn.Sequential(
+                    nn.Linear(layer2_weight_dim, layer3_weight_dim), nn.ReLU()
+                )
+
+            def forward(self, x):
+                return self.net3(self.net2(self.net1(x)))
+
+            def get_input(self):
+                return torch.rand(8, 8, device="cuda")
+
+        model = TestDummyModel().cuda()
+        return model
+
     @property
     def backend(self):
         return "cpu:gloo,cuda:nccl"
@@ -32,78 +53,77 @@ class FsdpOptimStateCheckpoint(DTensorTestBase):
     @with_comms
     @skip_if_lt_x_gpu(2)
     @with_temp_dir
-    def test_distributed_tensor_planner(self) -> None:
+    def test_load_sharded_optimizer_state_dict(self) -> None:
         CHECKPOINT_DIR = self.temp_dir
 
-        model = FSDP(torch.nn.Linear(8, 8, device="meta"))
+        model = self._create_model()
+        model = FSDP(model)
         optim = torch.optim.Adam(model.parameters(), lr=0.1)
 
-        model(torch.rand(8, 8, device=dist.get_rank())).sum().backward()
+        # step ahead to initialize the optimizer
+        model(model.get_input()).sum().backward()
         optim.step()
 
-        with FSDP.state_dict_type(model, StateDictType.SHARDED_STATE_DICT):
-            state_dict = {
-                "model": model.state_dict(),
-                "optim": FSDP.optim_state_dict(model, optim),
-            }
+        FSDP.set_state_dict_type(
+            model,
+            StateDictType.SHARDED_STATE_DICT,
+        )
+        optim_osd = FSDP.optim_state_dict(model, optim)
 
-            dist_cp.save_state_dict(
-                state_dict=state_dict,
-                storage_writer=dist_cp.FileSystemWriter(CHECKPOINT_DIR),
-                planner=DefaultSavePlanner(),
-            )
+        state_dict = {
+            "model": model.state_dict(),
+            "optim": optim_osd,
+        }
+        DCP.save_state_dict(
+            state_dict=state_dict,
+            storage_writer=DCP.FileSystemWriter(CHECKPOINT_DIR),
+        )
 
         # now load the model and ensure the values are the same
-        model_2 = FSDP(torch.nn.Linear(8, 8, device="meta"))
+        model_2 = self._create_model()
+        model_2 = FSDP(model_2)
         optim_2 = torch.optim.Adam(model_2.parameters(), lr=0.1)
 
-        with FSDP.summon_full_params(model):
-            with FSDP.summon_full_params(model_2):
-                self.assertNotEqual(model.weight, model_2.weight)
-                self.assertNotEqual(model.bias, model_2.bias)
-
+        FSDP.set_state_dict_type(
+            model_2,
+            StateDictType.SHARDED_STATE_DICT,
+        )
         # Adam lazily creates its state
         self.assertEqual(0, len(optim_2.state))
 
-        with FSDP.state_dict_type(model_2, StateDictType.SHARDED_STATE_DICT):
-            state_dict = {
-                "model": model_2.state_dict(),
-                # cannot load the optimizer together with the model
-            }
-
-            dist_cp.load_state_dict(
-                state_dict=state_dict,
-                storage_reader=dist_cp.FileSystemReader(CHECKPOINT_DIR),
-                planner=DefaultLoadPlanner(),
-            )
-            model_2.load_state_dict(state_dict["model"])
-
-            optim_state = load_sharded_optimizer_state_dict(
-                model_state_dict=state_dict["model"],
-                optimizer_key="optim",
-                storage_reader=dist_cp.FileSystemReader(CHECKPOINT_DIR),
-            )
-
-            flattened_osd = FSDP.optim_state_dict_to_load(
-                model_2, optim_2, optim_state["optim"]
-            )
-            optim_2.load_state_dict(flattened_osd)
-
-        with FSDP.summon_full_params(model):
-            with FSDP.summon_full_params(model_2):
-                self.assertEqual(model.weight, model_2.weight)
-                self.assertEqual(model.bias, model_2.bias)
-
-        def opt_at(opt, idx):
-            return list(iter(opt.state.values()))[idx]
-
-        # Adam lazily creates its state
-        self.assertEqual(
-            opt_at(optim, 0)["exp_avg"], opt_at(optim_2, 0)["exp_avg"]
+        state_dict = {
+            "model": model_2.state_dict(),
+            # cannot load the optimizer together with the model
+        }
+        DCP.load_state_dict(
+            state_dict=state_dict,
+            storage_reader=DCP.FileSystemReader(CHECKPOINT_DIR),
         )
-        self.assertEqual(
-            opt_at(optim, 0)["exp_avg_sq"], opt_at(optim_2, 0)["exp_avg_sq"]
+        model_2.load_state_dict(state_dict["model"])
+
+        optim_state = load_sharded_optimizer_state_dict(
+            model_state_dict=state_dict["model"],
+            optimizer_key="optim",
+            storage_reader=DCP.FileSystemReader(CHECKPOINT_DIR),
         )
+        flattened_osd = FSDP.optim_state_dict_to_load(
+            model_2, optim_2, optim_state["optim"]
+        )
+        optim_2.load_state_dict(flattened_osd)
+        osd_after_load = FSDP.optim_state_dict(model_2, optim_2)
+
+        # Compare optim_state_dict prior to save and after load
+        before_optim_state = optim_osd["state"]
+        after_optim_state = osd_after_load["state"]
+        self.assertEqual(len(before_optim_state), len(after_optim_state))
+        for fqn, states in before_optim_state.items():
+            for state_name, state in states.items():
+                state2 = after_optim_state.get(fqn).get(state_name)
+                if isinstance(state, ShardedTensor):
+                    self.assertTrue(isinstance(state2, ShardedTensor))
+                    self.assertTrue(torch.allclose(state, state2))
+                else:
+                    self.assertEqual(state, state2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Make dim_0 size of params scale with world_size so it can be used to test the impact on performance when scaling up. More context of performance improvement is added in: https://github.com/pytorch/pytorch/pull/111687

For this cherry-pick pair, we remove `_shard_tensor()` call in `load_sharded_optimizer_state_dict()` in optimizer.py, which is reported to scale poorly with number of GPUs. The reason behind is that `_shard_tensor()` calls into `dist.all_gather_object()`, which is extremely expensive in communication when world_size becomes large. 

main: https://github.com/pytorch/pytorch/pull/111096 
cherry-pick: https://github.com/pytorch/pytorch/pull/111687



