### PR TITLE
[MPS] Add searchsorted op

### DIFF
--- a/aten/src/ATen/native/mps/operations/Bucketization.mm
+++ b/aten/src/ATen/native/mps/operations/Bucketization.mm
@@ -21,7 +21,7 @@ static const char* METAL_BUCKETIZATION = R"BUCKETIZE_METAL(
 #include <metal_stdlib>
 using namespace metal;
 
-/*----------Helpers--------*/
+// The bucketization kernels are mostly copied-n-pasted from bucketization.cu.
 
 template<typename input_t>
 int64_t lower_bound(constant input_t *data_ss, int64_t start, int64_t end, const input_t val, constant int64_t *data_sort) {
@@ -88,8 +88,6 @@ int64_t upper_bound(constant input_t *data_ss, int64_t start, int64_t end, const
   }
   return start;
 }
-
-/*----------Kernels----------*/
 
 template<typename input_t, typename output_t>
 kernel void searchsorted_sorter(
@@ -239,6 +237,10 @@ static void searchsorted_mps_contiguous(Tensor& result,
                                         const Tensor& boundaries,
                                         const bool right,
                                         const Tensor& sorter) {
+  TORCH_INTERNAL_ASSERT(input.is_contiguous());
+  TORCH_INTERNAL_ASSERT(boundaries.is_contiguous());
+  TORCH_INTERNAL_ASSERT(!sorter.defined() || sorter.is_contiguous());
+
   int64_t numel_in = input.numel();
   bool is_scalar_input = input.dim() == 0 && numel_in == 1;
   // inner most dim size of input and boundaries
@@ -300,27 +302,24 @@ Tensor& searchsorted_out_mps(const Tensor& sorted_sequence,
                              const c10::optional<Tensor>& sorter_opt,
                              Tensor& result) {
   // See [Note: hacky wrapper removal for optional tensor]
-  c10::MaybeOwned<Tensor> sorter_maybe_owned = at::borrow_from_optional_tensor(sorter_opt);
+  auto sorter_maybe_owned = at::borrow_from_optional_tensor(sorter_opt);
   const Tensor& sorter = *sorter_maybe_owned;
   searchsorted_pre_check(sorted_sequence, self, result, out_int32, right, side_opt, sorter);
   resize_output(result, self.sizes());
 
   // we have two inputs to set right, pre_check checks that they aren't set to opposites
-  bool is_right = (side_opt && *side_opt == "right") || right;
+  right |= (side_opt && *side_opt == "right");
   if (self.numel() == 0) {
     return result;
   }
 
   // for non-contiguous result tensors, we write the output to a contiguous copy so we can later copy back, maintaing
   // the original result tensor
-  Tensor out = result;
-  if (!result.is_contiguous()) {
-    out = result.contiguous();
-  }
+  Tensor out = result.contiguous();
 
   if (sorted_sequence.is_contiguous() && self.is_contiguous() && sorted_sequence.dtype() == self.dtype() &&
       sorter.is_contiguous()) {
-    mps::searchsorted_mps_contiguous(out, self, sorted_sequence, is_right, sorter);
+    mps::searchsorted_mps_contiguous(out, self, sorted_sequence, right, sorter);
   } else {
     Tensor trimmed_input;
     Tensor trimmed_boundaries;
@@ -330,7 +329,7 @@ Tensor& searchsorted_out_mps(const Tensor& sorted_sequence,
     const Tensor& final_input = trimmed_input.defined() ? trimmed_input : self;
     const Tensor& final_boundaries = trimmed_boundaries.defined() ? trimmed_boundaries : sorted_sequence;
     const Tensor& final_sorter = trimmed_sorter.defined() ? trimmed_sorter : sorter;
-    mps::searchsorted_mps_contiguous(out, final_input, final_boundaries, is_right, final_sorter);
+    mps::searchsorted_mps_contiguous(out, final_input, final_boundaries, right, final_sorter);
   }
 
   // if result is non-contiguous, we wrote the answer to a copied version, so we copy back to the original result tensor

--- a/aten/src/ATen/native/mps/operations/Bucketization.mm
+++ b/aten/src/ATen/native/mps/operations/Bucketization.mm
@@ -1,0 +1,377 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/ceil_div.h>
+#include <ATen/mps/MPSProfiler.h>
+#include <ATen/native/BucketizationUtils.h>
+#include <ATen/native/Resize.h>
+#include <ATen/native/mps/OperationUtils.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/empty.h>
+#include <ATen/ops/searchsorted_native.h>
+#endif
+
+namespace at::native {
+namespace mps {
+
+static const char* METAL_BUCKETIZATION = R"BUCKETIZE_METAL(
+
+#include <metal_stdlib>
+using namespace metal;
+
+/*----------Helpers--------*/
+
+template<typename input_t>
+int64_t lower_bound(constant input_t *data_ss, int64_t start, int64_t end, const input_t val, constant int64_t *data_sort) {
+  // sorter gives relative ordering for ND tensors, so we need to save and add the non-updated start as an offset
+  // i.e. the second row of a 3x3 tensors starts at element 3 but sorter's second row only contains 0, 1, or 2
+  const int64_t orig_start = start;
+  while (start < end) {
+    const int64_t mid = start + ((end - start) >> 1);
+    const input_t mid_val = data_ss[orig_start + data_sort[mid]];
+    if (!(mid_val >= val)) {
+      start = mid + 1;
+    }
+    else {
+      end = mid;
+    }
+  }
+  return start;
+}
+
+template<typename input_t>
+int64_t lower_bound(constant input_t *data_ss, int64_t start, int64_t end, const input_t val) {
+  while (start < end) {
+    const int64_t mid = start + ((end - start) >> 1);
+    const input_t mid_val = data_ss[mid];
+    if (!(mid_val >= val)) {
+      start = mid + 1;
+    }
+    else {
+      end = mid;
+    }
+  }
+  return start;
+}
+
+template<typename input_t>
+int64_t upper_bound(constant input_t *data_ss, int64_t start, int64_t end, const input_t val, constant int64_t *data_sort) {
+  // sorter gives relative ordering for ND tensors, so we need to save and add the non-updated start as an offset
+  // i.e. the second row of a 3x3 tensors starts at element 3 but sorter's second row only contains 0, 1, or 2
+  const int64_t orig_start = start;
+  while (start < end) {
+    const int64_t mid = start + ((end - start) >> 1);
+    const input_t mid_val = data_ss[orig_start + data_sort[mid]];
+    if (!(mid_val > val)) {
+      start = mid + 1;
+    }
+    else {
+      end = mid;
+    }
+  }
+  return start;
+}
+
+template<typename input_t>
+int64_t upper_bound(constant input_t *data_ss, int64_t start, int64_t end, const input_t val) {
+  while (start < end) {
+    const int64_t mid = start + ((end - start) >> 1);
+    const input_t mid_val = data_ss[mid];
+    if (!(mid_val > val)) {
+      start = mid + 1;
+    }
+    else {
+      end = mid;
+    }
+  }
+  return start;
+}
+
+/*----------Kernels----------*/
+
+template<typename input_t, typename output_t>
+kernel void searchsorted_sorter(
+    constant  input_t       * data_in     [[buffer(0)]],
+    constant  input_t       * data_bd     [[buffer(1)]],
+    device    output_t      * data_out    [[buffer(2)]],
+    constant  int64_t       & idim_in     [[buffer(3)]],
+    constant  int64_t       & idim_bd     [[buffer(4)]],
+    constant  int64_t       & numel_in    [[buffer(5)]],
+    constant  int64_t       & right       [[buffer(6)]],
+    constant  int64_t       & is_1d_boundaries [[buffer(7)]],
+    constant  int64_t       * data_sort   [[buffer(8)]],
+    uint2     tgid                        [[threadgroup_position_in_grid]],
+    uint2     tid2                        [[thread_position_in_threadgroup]],
+    uint2     tptg     [[threads_per_threadgroup]]) {
+
+  for (int64_t tid = tgid.x * tptg.x + tid2.x; tid < numel_in; tid += tptg.x) {
+    // If boundaries tensor is 1d, we always search the entire boundary tensor
+    int64_t start_bd = is_1d_boundaries ? 0 : tid / idim_in * idim_bd;
+    int64_t end_bd = start_bd + idim_bd;
+
+    int64_t pos = !right ?
+      lower_bound<input_t>(data_bd, start_bd, end_bd, data_in[tid], data_sort) - start_bd :
+      upper_bound<input_t>(data_bd, start_bd, end_bd, data_in[tid], data_sort) - start_bd;
+
+    // type conversion might happen here
+    data_out[tid] = pos;
+  }
+}
+
+template<typename input_t, typename output_t>
+kernel void searchsorted(
+    constant  input_t       * data_in     [[buffer(0)]],
+    constant  input_t       * data_bd     [[buffer(1)]],
+    device    output_t      * data_out    [[buffer(2)]],
+    constant  int64_t       & idim_in     [[buffer(3)]],
+    constant  int64_t       & idim_bd     [[buffer(4)]],
+    constant  int64_t       & numel_in    [[buffer(5)]],
+    constant  int64_t       & right       [[buffer(6)]],
+    constant  int64_t       & is_1d_boundaries [[buffer(7)]],
+    uint2     tgid                        [[threadgroup_position_in_grid]],
+    uint2     tid2                        [[thread_position_in_threadgroup]],
+    uint2     tptg     [[threads_per_threadgroup]]) {
+
+  for (int64_t tid = tgid.x * tptg.x + tid2.x; tid < numel_in; tid += tptg.x) {
+    // If boundaries tensor is 1d, we always search the entire boundary tensor
+    int64_t start_bd = is_1d_boundaries ? 0 : tid / idim_in * idim_bd;
+    int64_t end_bd = start_bd + idim_bd;
+
+    int64_t pos = !right ?
+      lower_bound<input_t>(data_bd, start_bd, end_bd, data_in[tid]) - start_bd :
+      upper_bound<input_t>(data_bd, start_bd, end_bd, data_in[tid]) - start_bd;
+
+    // type conversion might happen here
+    data_out[tid] = pos;
+  }
+}
+
+#define REGISTER_SEARCHSORTED_OP(INPUT_T, OUTPUT_T)               \
+template                                                          \
+[[host_name("searchsorted_" #INPUT_T"_"#OUTPUT_T"_sorter")]]      \
+kernel void searchsorted_sorter<INPUT_T, OUTPUT_T>(                      \
+    constant  INPUT_T       * data_in     [[buffer(0)]],          \
+    constant  INPUT_T       * data_bd     [[buffer(1)]],          \
+    device    OUTPUT_T      * data_out    [[buffer(2)]],          \
+    constant  int64_t       & idim_in     [[buffer(3)]],          \
+    constant  int64_t       & idim_bd     [[buffer(4)]],          \
+    constant  int64_t       & numel_in    [[buffer(5)]],          \
+    constant  int64_t       & right       [[buffer(6)]],          \
+    constant  int64_t       & is_1d_boundaries [[buffer(7)]],     \
+    constant  int64_t       * data_sort   [[buffer(8)]],          \
+    uint2     tgid          [[threadgroup_position_in_grid]],     \
+    uint2     tid2          [[thread_position_in_threadgroup]],   \
+    uint2     tptg          [[threads_per_threadgroup]]);         \
+template                                                          \
+[[host_name("searchsorted_" #INPUT_T"_"#OUTPUT_T)]]               \
+kernel void searchsorted<INPUT_T, OUTPUT_T>(                      \
+    constant  INPUT_T       * data_in     [[buffer(0)]],          \
+    constant  INPUT_T       * data_bd     [[buffer(1)]],          \
+    device    OUTPUT_T      * data_out    [[buffer(2)]],          \
+    constant  int64_t       & idim_in     [[buffer(3)]],          \
+    constant  int64_t       & idim_bd     [[buffer(4)]],          \
+    constant  int64_t       & numel_in    [[buffer(5)]],          \
+    constant  int64_t       & right       [[buffer(6)]],          \
+    constant  int64_t       & is_1d_boundaries [[buffer(7)]],     \
+    uint2     tgid          [[threadgroup_position_in_grid]],     \
+    uint2     tid2          [[thread_position_in_threadgroup]],   \
+    uint2     tptg          [[threads_per_threadgroup]]);         \
+
+
+REGISTER_SEARCHSORTED_OP(float, int);
+REGISTER_SEARCHSORTED_OP(float, long);
+REGISTER_SEARCHSORTED_OP(half, int);
+REGISTER_SEARCHSORTED_OP(half, long);
+REGISTER_SEARCHSORTED_OP(char, int);
+REGISTER_SEARCHSORTED_OP(char, long);
+REGISTER_SEARCHSORTED_OP(uchar, int);
+REGISTER_SEARCHSORTED_OP(uchar, long);
+REGISTER_SEARCHSORTED_OP(short, int);
+REGISTER_SEARCHSORTED_OP(short, long);
+REGISTER_SEARCHSORTED_OP(int, int);
+REGISTER_SEARCHSORTED_OP(int, long);
+REGISTER_SEARCHSORTED_OP(long, int);
+REGISTER_SEARCHSORTED_OP(long, long);
+
+)BUCKETIZE_METAL";
+
+static id<MTLLibrary> compileBucketizationOpsLibrary(id<MTLDevice> device) {
+  static id<MTLLibrary> bucketizationLibrary = nil;
+  if (bucketizationLibrary) {
+    return bucketizationLibrary;
+  }
+
+  NSError* error = nil;
+  MTLCompileOptions* options = [[MTLCompileOptions new] autorelease];
+  [options setLanguageVersion:MTLLanguageVersion2_3];
+  bucketizationLibrary = [device newLibraryWithSource:[NSString stringWithCString:METAL_BUCKETIZATION
+                                                                         encoding:NSASCIIStringEncoding]
+                                              options:options
+                                                error:&error];
+  TORCH_CHECK(
+      bucketizationLibrary, "Failed to create metal bucketization library, error: ", [[error description] UTF8String]);
+  return bucketizationLibrary;
+}
+
+static id<MTLComputePipelineState> bucketizationPipelineState(id<MTLDevice> device, const std::string& kernel) {
+  static std::unordered_map<std::string, id<MTLComputePipelineState>> psoCache;
+  id<MTLComputePipelineState> pso = psoCache[kernel];
+  if (pso) {
+    return pso;
+  }
+
+  NSError* error = nil;
+  id<MTLLibrary> bucketizationLib = compileBucketizationOpsLibrary(device);
+  id<MTLFunction> bucketizationFunc =
+      [bucketizationLib newFunctionWithName:[NSString stringWithUTF8String:kernel.c_str()]];
+  TORCH_CHECK(bucketizationFunc, "Failed to create function state object for: ", kernel);
+  pso = [device newComputePipelineStateWithFunction:bucketizationFunc error:&error];
+  TORCH_CHECK(pso, "Failed to created pipeline state object, error: ", [[error description] UTF8String]);
+
+  psoCache[kernel] = pso;
+  return pso;
+}
+
+static void searchsorted_mps_contiguous(Tensor& result,
+                                        const Tensor& input,
+                                        const Tensor& boundaries,
+                                        const bool right,
+                                        const Tensor& sorter) {
+  int64_t numel_in = input.numel();
+  bool is_scalar_input = input.dim() == 0 && numel_in == 1;
+  // inner most dim size of input and boundaries
+  int64_t idim_in = is_scalar_input ? 1 : input.sizes().back();
+  int64_t idim_bd = boundaries.sizes().back();
+  int64_t right_i64 = right;
+  int64_t is_1d_boundaries = boundaries.dim() == 1;
+
+  id<MTLBuffer> inputBuffer = getMTLBufferStorage(input);
+  id<MTLBuffer> boundariesBuffer = getMTLBufferStorage(boundaries);
+  id<MTLBuffer> sorterBuffer = sorter.defined() ? getMTLBufferStorage(sorter) : nullptr;
+  id<MTLBuffer> outputBuffer = getMTLBufferStorage(result);
+  id<MTLDevice> device = MPSDevice::getInstance()->device();
+  MPSStream* mpsStream = getCurrentMPSStream();
+  dispatch_sync(mpsStream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
+
+      const std::string kernel = "searchsorted_" + scalarToMetalTypeString(input.scalar_type()) + "_" +
+          scalarToMetalTypeString(result.scalar_type()) + (sorter.defined() ? "_sorter" : "");
+      id<MTLComputePipelineState> bucketizationPSO = mps::bucketizationPipelineState(device, kernel);
+
+      // this function call is a no-op if MPS Profiler is not enabled
+      getMPSProfiler().beginProfileKernel(bucketizationPSO, kernel, {input, boundaries, sorter});
+
+      [computeEncoder setComputePipelineState:bucketizationPSO];
+      [computeEncoder setBuffer:inputBuffer offset:input.storage_offset() * input.element_size() atIndex:0];
+      [computeEncoder setBuffer:boundariesBuffer
+                         offset:boundaries.storage_offset() * boundaries.element_size()
+                        atIndex:1];
+      [computeEncoder setBuffer:outputBuffer offset:result.storage_offset() * result.element_size() atIndex:2];
+      [computeEncoder setBytes:&idim_in length:sizeof(int64_t) atIndex:3];
+      [computeEncoder setBytes:&idim_bd length:sizeof(int64_t) atIndex:4];
+      [computeEncoder setBytes:&numel_in length:sizeof(int64_t) atIndex:5];
+      [computeEncoder setBytes:&right_i64 length:sizeof(int64_t) atIndex:6];
+      [computeEncoder setBytes:&is_1d_boundaries length:sizeof(int64_t) atIndex:7];
+      if (sorter.defined())
+        [computeEncoder setBuffer:sorterBuffer offset:sorter.storage_offset() * sorter.element_size() atIndex:8];
+
+      // A threadGroup is equivalent to a cuda's block.
+      int64_t maxThreadgroups = 1024;
+      int64_t maxThreads = bucketizationPSO.maxTotalThreadsPerThreadgroup;
+      NSUInteger tgSize = std::min(maxThreads, numel_in);
+      MTLSize threadgroupsPerGrid = MTLSizeMake(std::min(maxThreadgroups, ceil_div<int64_t>(numel_in, tgSize)), 1, 1);
+      MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
+      [computeEncoder dispatchThreadgroups:threadgroupsPerGrid threadsPerThreadgroup:threadGroupSize];
+
+      getMPSProfiler().endProfileKernel(bucketizationPSO);
+    }
+  });
+}
+} // namespace mps
+
+Tensor& searchsorted_out_mps(const Tensor& sorted_sequence,
+                             const Tensor& self,
+                             bool out_int32,
+                             bool right,
+                             const c10::optional<c10::string_view> side_opt,
+                             const c10::optional<Tensor>& sorter_opt,
+                             Tensor& result) {
+  // See [Note: hacky wrapper removal for optional tensor]
+  c10::MaybeOwned<Tensor> sorter_maybe_owned = at::borrow_from_optional_tensor(sorter_opt);
+  const Tensor& sorter = *sorter_maybe_owned;
+  searchsorted_pre_check(sorted_sequence, self, result, out_int32, right, side_opt, sorter);
+  resize_output(result, self.sizes());
+
+  // we have two inputs to set right, pre_check checks that they aren't set to opposites
+  bool is_right = (side_opt && *side_opt == "right") || right;
+  if (self.numel() == 0) {
+    return result;
+  }
+
+  // for non-contiguous result tensors, we write the output to a contiguous copy so we can later copy back, maintaing
+  // the original result tensor
+  Tensor out = result;
+  if (!result.is_contiguous()) {
+    out = result.contiguous();
+  }
+
+  if (sorted_sequence.is_contiguous() && self.is_contiguous() && sorted_sequence.dtype() == self.dtype() &&
+      sorter.is_contiguous()) {
+    mps::searchsorted_mps_contiguous(out, self, sorted_sequence, is_right, sorter);
+  } else {
+    Tensor trimmed_input;
+    Tensor trimmed_boundaries;
+    Tensor trimmed_sorter;
+    searchsorted_maybe_trim_input_tensors(
+        trimmed_input, trimmed_boundaries, trimmed_sorter, self, sorted_sequence, sorter);
+    const Tensor& final_input = trimmed_input.defined() ? trimmed_input : self;
+    const Tensor& final_boundaries = trimmed_boundaries.defined() ? trimmed_boundaries : sorted_sequence;
+    const Tensor& final_sorter = trimmed_sorter.defined() ? trimmed_sorter : sorter;
+    mps::searchsorted_mps_contiguous(out, final_input, final_boundaries, is_right, final_sorter);
+  }
+
+  // if result is non-contiguous, we wrote the answer to a copied version, so we copy back to the original result tensor
+  if (!result.is_contiguous()) {
+    result.copy_(out);
+  }
+  return result;
+}
+
+Tensor& searchsorted_out_mps(const Tensor& sorted_sequence,
+                             const Scalar& self,
+                             bool out_int32,
+                             bool right,
+                             const c10::optional<c10::string_view> side_opt,
+                             const c10::optional<Tensor>& sorter_opt,
+                             Tensor& result) {
+  const Tensor& scalar_tensor = mps::wrapped_scalar_tensor_mps(self, sorted_sequence.device());
+  return searchsorted_out_mps(sorted_sequence, scalar_tensor, out_int32, right, side_opt, sorter_opt, result);
+}
+
+Tensor searchsorted_mps(const Tensor& sorted_sequence,
+                        const Tensor& self,
+                        bool out_int32,
+                        bool right,
+                        const c10::optional<c10::string_view> side_opt,
+                        const c10::optional<Tensor>& sorter) {
+  ScalarType scalar_type = out_int32 ? ScalarType::Int : ScalarType::Long;
+  c10::TensorOptions options = TensorOptions().device(self.options().device()).dtype(scalar_type);
+  Tensor result = at::empty({0}, options, MemoryFormat::Contiguous);
+  at::native::searchsorted_out_mps(sorted_sequence, self, out_int32, right, side_opt, sorter, result);
+  return result;
+}
+
+Tensor searchsorted_mps(const Tensor& sorted_sequence,
+                        const Scalar& self,
+                        bool out_int32,
+                        bool right,
+                        const c10::optional<c10::string_view> side_opt,
+                        const c10::optional<Tensor>& sorter) {
+  const Tensor& scalar_tensor = mps::wrapped_scalar_tensor_mps(self, sorted_sequence.device());
+  return searchsorted_mps(sorted_sequence, scalar_tensor, out_int32, right, side_opt, sorter);
+}
+
+} // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -11170,21 +11170,25 @@
   dispatch:
     CPU: searchsorted_cpu
     CUDA: searchsorted_cuda
+    MPS: searchsorted_mps
 
 - func: searchsorted.Tensor_out(Tensor sorted_sequence, Tensor self, *, bool out_int32=False, bool right=False, str? side=None, Tensor? sorter=None, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: searchsorted_out_cpu
     CUDA: searchsorted_out_cuda
+    MPS: searchsorted_out_mps
 
 - func: searchsorted.Scalar(Tensor sorted_sequence, Scalar self, *, bool out_int32=False, bool right=False, str? side=None, Tensor? sorter=None) -> Tensor
   dispatch:
     CPU: searchsorted_cpu
     CUDA: searchsorted_cuda
+    MPS: searchsorted_mps
 
 - func: searchsorted.Scalar_out(Tensor sorted_sequence, Scalar self, *, bool out_int32=False, bool right=False, str? side=None, Tensor? sorter=None, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: searchsorted_out_cpu
     CUDA: searchsorted_out_cuda
+    MPS: searchsorted_out_mps
 
 - func: _convert_indices_from_coo_to_csr(Tensor self, int size, *, bool out_int32=False) -> Tensor
   structured_delegate: _convert_indices_from_coo_to_csr.out

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -609,7 +609,6 @@ def mps_ops_modifier(ops):
         'scatter_reducemean': None,
         'scatter_reduceprod': None,
         'scatter_reducesum': None,
-        'searchsorted': None,
         'segment_reduce': None,
         '_segment.reduce': None,
         'segment.reduce': None,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -16770,7 +16770,6 @@ op_db: List[OpInfo] = [
                # JIT tests don't work with Tensor keyword arguments
                # https://github.com/pytorch/pytorch/issues/58507
                DecorateInfo(unittest.skip("Expected failure!"), 'TestJit', 'test_variant_consistency_jit'),
-               DecorateInfo(unittest.skip("Unsupported on MPS for now"), 'TestCommon', 'test_numpy_ref_mps'),
            )),
     OpInfo('cat',
            ref=_cat_np,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #112830
* __->__ #112829

The metal kernels implemented are closely following `Bucketization.cu`.

Benchmark:
```
[----------------------------- searchsorted ----------------------------]
                                                         |  cpu   |  mps 
1 threads: --------------------------------------------------------------
      Batch size: 8; In features: 64; Sorter: True       |    44  |   530
      Batch size: 8; In features: 64; Sorter: False      |    31  |    12
      Batch size: 8; In features: 256; Sorter: True      |   131  |   520
      Batch size: 8; In features: 256; Sorter: False     |   107  |    12
      Batch size: 8; In features: 1024; Sorter: True     |   499  |   590
      Batch size: 8; In features: 1024; Sorter: False    |   398  |    12
      Batch size: 16; In features: 64; Sorter: True      |    71  |   540
      Batch size: 16; In features: 64; Sorter: False     |    57  |    12
      Batch size: 16; In features: 256; Sorter: True     |   242  |   610
      Batch size: 16; In features: 256; Sorter: False    |   200  |    12
      Batch size: 16; In features: 1024; Sorter: True    |   999  |   720
      Batch size: 16; In features: 1024; Sorter: False   |   842  |    12
      Batch size: 32; In features: 64; Sorter: True      |   124  |   509
      Batch size: 32; In features: 64; Sorter: False     |   103  |    12
      Batch size: 32; In features: 256; Sorter: True     |   477  |   650
      Batch size: 32; In features: 256; Sorter: False    |   407  |    12
      Batch size: 32; In features: 1024; Sorter: True    |  1940  |   833
      Batch size: 32; In features: 1024; Sorter: False   |  1710  |    12
      Batch size: 64; In features: 64; Sorter: True      |   231  |   590
      Batch size: 64; In features: 64; Sorter: False     |   194  |    12
      Batch size: 64; In features: 256; Sorter: True     |   937  |   710
      Batch size: 64; In features: 256; Sorter: False    |   800  |    13
      Batch size: 64; In features: 1024; Sorter: True    |  3980  |  1290
      Batch size: 64; In features: 1024; Sorter: False   |  3330  |    12
      Batch size: 128; In features: 64; Sorter: True     |   448  |   650
      Batch size: 128; In features: 64; Sorter: False    |   390  |    13
      Batch size: 128; In features: 256; Sorter: True    |  1830  |   850
      Batch size: 128; In features: 256; Sorter: False   |  1590  |    12
      Batch size: 128; In features: 1024; Sorter: True   |  7790  |  2850
      Batch size: 128; In features: 1024; Sorter: False  |  6670  |    13
```
