### PR TITLE
Fix torch distributed docs ext

### DIFF
--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -130,8 +130,7 @@ def wait_tensor(tensor):
 
 def all_reduce(self: torch.Tensor, reduceOp: str, group: RANK_TYPES, tag: str = ""):
     """
-    Reduces the tensor data across all machines in such a way that all get
-    the final result.
+    Reduces the tensor data across all machines in such a way that all get the final result.
 
     The input tensor is left unmodified.
 
@@ -189,9 +188,7 @@ def reduce_scatter_tensor(
     tag: str = "",
 ):
     """
-    Reduces the tensor data across all machines in such a way that all get
-    the final result, then scatter the results to corresponding ranks.
-
+    Scatter the tensor data across all machine corresponding to their ranks.
 
     The input tensor is left unmodified.
     Group can be one of:
@@ -218,8 +215,7 @@ def reduce_scatter_tensor(
 
 def all_reduce_coalesced(self: List[torch.Tensor], reduceOp: str, group: RANK_TYPES, tag: str = "") -> List[torch.Tensor]:
     """
-    Reduces a list of tensors across all machines in such a way that all get
-    the final result.
+    Reduces a list of tensors across all machines in such a way that all get the final result.
 
     The all tensors in the input list are left unmodified.
 
@@ -268,8 +264,7 @@ def reduce_scatter_tensor_coalesced(
     tag: str = "",
 ) -> List[torch.Tensor]:
     """
-    Reduces a list of tensors across all machines in such a way that all get
-    the final result, then scatter the results to corresponding ranks.
+    Scatter the tensor data across all machine corresponding to their ranks.
 
     The input tensors are left unmodified.
     Group can be one of:
@@ -316,8 +311,9 @@ def all_to_all_single(
     tag: str = "",
 ) -> torch.Tensor:
     """
-    Each process splits input tensor and then scatters the split list
-    to all processes in a group. Then concatenate the received tensors from all
+    Each process splits input tensor and then scatters the split list to all processes in a group.
+
+    Then concatenate the received tensors from all
     the processes in the group and return single output tensor.
 
     Group can be one of:
@@ -341,14 +337,15 @@ def all_to_all_single(
 
 class AsyncCollectiveTensor(torch.Tensor):
     r"""
-    A Tensor wrapper subclass that is used to trigger a call to wait
-    prior to first use of the underlying tensor.
+    A Tensor wrapper subclass that is used to trigger a call to wait prior to first use of the underlying tensor.
+
     Use it inside functional collective pytorch wrappers like the following:
     def functional_collective(self, group, tag):
         tag, rankset, group_size = _expand_group(group, tag)
         tensor = torch.ops.c10d_functional.{collective}(self, tag, rankset, group_size)
         return _maybe_wrap_tensor(tensor)
     """
+
     elem: torch.Tensor
 
     __slots__ = ['elem']
@@ -389,7 +386,7 @@ class AsyncCollectiveTensor(torch.Tensor):
         return self
 
     def _get_acs_underlying_tensor(self):
-        """This method enables  _functional_collectives_impl to test if a tensor is an ACS"""
+        """Enable  _functional_collectives_impl to test if a tensor is an ACS."""
         return self.elem
 
     @classmethod

--- a/torch/distributed/autograd/__init__.py
+++ b/torch/distributed/autograd/__init__.py
@@ -29,7 +29,7 @@ if is_available():
 class context:
     """
     Context object to wrap forward and backward passes when using distributed autograd.
-    
+
     The ``context_id`` generated in the ``with``
     statement  is required to uniquely identify a distributed backward pass
     on all workers. Each worker stores metadata associated with this

--- a/torch/distributed/autograd/__init__.py
+++ b/torch/distributed/autograd/__init__.py
@@ -27,9 +27,10 @@ if is_available():
 
 
 class context:
-    '''
-    Context object to wrap forward and backward passes when using
-    distributed autograd. The ``context_id`` generated in the ``with``
+    """
+    Context object to wrap forward and backward passes when using distributed autograd.
+    
+    The ``context_id`` generated in the ``with``
     statement  is required to uniquely identify a distributed backward pass
     on all workers. Each worker stores metadata associated with this
     ``context_id``, which is required to correctly execute a distributed
@@ -43,7 +44,8 @@ class context:
         >>>     t2 = torch.rand((3, 3), requires_grad=True)
         >>>     loss = rpc.rpc_sync("worker1", torch.add, args=(t1, t2)).sum()
         >>>     dist_autograd.backward(context_id, [loss])
-    '''
+    """
+
     def __enter__(self):
         self.autograd_context = _new_context()
         return self.autograd_context._context_id()

--- a/torch/distributed/optim/__init__.py
+++ b/torch/distributed/optim/__init__.py
@@ -1,4 +1,6 @@
 """
+DistributedOptimizer that runs locally on the workers from a list of remote parameters.
+
 :mod:`torch.distributed.optim` exposes DistributedOptimizer, which takes a list
 of remote parameters (:class:`~torch.distributed.rpc.RRef`) and runs the
 optimizer locally on the workers where the parameters live.  The distributed

--- a/torch/distributed/optim/apply_optimizer_in_backward.py
+++ b/torch/distributed/optim/apply_optimizer_in_backward.py
@@ -100,7 +100,7 @@ def _apply_optimizer_in_backward(
 def _get_in_backward_optimizers(module: torch.nn.Module) -> List[torch.optim.Optimizer]:
     """
     Return a list of in-backward optimizers applied to ``module``'s parameters.
-    
+
     Note that these optimizers are not intended to directly have their ``step`` or
     ``zero_grad`` methods called by the user and are intended to be used for things like checkpointing.
 

--- a/torch/distributed/optim/apply_optimizer_in_backward.py
+++ b/torch/distributed/optim/apply_optimizer_in_backward.py
@@ -19,6 +19,8 @@ def _apply_optimizer_in_backward(
     register_hook: bool = True,
 ) -> None:
     """
+    Apply optimizer for each parameter after gradient accumulation.
+
     Upon ``backward()``, the optimizer specified for each parameter will fire after
     the gradient has been accumulated into the parameter.
 
@@ -97,9 +99,10 @@ def _apply_optimizer_in_backward(
 
 def _get_in_backward_optimizers(module: torch.nn.Module) -> List[torch.optim.Optimizer]:
     """
-    Return a list of in-backward optimizers applied to ``module``'s parameters. Note that these
-    optimizers are not intended to directly have their ``step`` or ``zero_grad`` methods called
-    by the user and are intended to be used for things like checkpointing.
+    Return a list of in-backward optimizers applied to ``module``'s parameters.
+    
+    Note that these optimizers are not intended to directly have their ``step`` or
+    ``zero_grad`` methods called by the user and are intended to be used for things like checkpointing.
 
     Args:
         module: (torch.nn.Module): model to retrieve in-backward optimizers for

--- a/torch/distributed/optim/functional_adam.py
+++ b/torch/distributed/optim/functional_adam.py
@@ -63,10 +63,7 @@ class _FunctionalAdam:
         self.param_group = {"params": params}
 
     def step_param(self, param: Tensor, grad: Optional[Tensor]):
-        """
-        Similar to step, but operates on a single parameter and optionally a
-        gradient tensor.
-        """
+        """Similar to step, but operates on a single parameter and optionally a gradient tensor."""
         params_with_grad = []
         grads = []
         exp_avgs = []

--- a/torch/distributed/optim/functional_sgd.py
+++ b/torch/distributed/optim/functional_sgd.py
@@ -49,9 +49,7 @@ class _FunctionalSGD:
         self.param_group = {"params": params}
 
     def step_param(self, param: Tensor, grad: Optional[Tensor]):
-        """Similar to self.step, but operates on a single parameter and
-        its gradient.
-        """
+        """Similar to self.step, but operates on a single parameter and its gradient."""
         # TODO: Once step_param interface is robust, refactor step to call
         # step param on each param.
         weight_decay = self.defaults["weight_decay"]

--- a/torch/distributed/optim/named_optimizer.py
+++ b/torch/distributed/optim/named_optimizer.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 class _NamedOptimizer(optim.Optimizer):
     """
     ``_NamedOptimizer`` takes a dict of parameters and exposes ``state_dict`` by parameter key.
-    
+
     We replace the original key (number) in an optim to the
     fully qualified name (FQN) string. User can initialize the optim as they
     initialize a PyTorch optim, the only difference is that they also need to
@@ -122,7 +122,7 @@ class _NamedOptimizer(optim.Optimizer):
     def state_dict(self) -> Dict[str, Any]:
         """
         Return the ``state_dict`` of the optimizer.
-        
+
         Instead of using number to index parameters,
         we will use module fully qualified name (FQN) as the key.
         """

--- a/torch/distributed/optim/named_optimizer.py
+++ b/torch/distributed/optim/named_optimizer.py
@@ -18,8 +18,9 @@ logger = logging.getLogger(__name__)
 
 class _NamedOptimizer(optim.Optimizer):
     """
-    ``_NamedOptimizer`` takes a dict of parameters and exposes ``state_dict`` by
-    parameter key. We replace the original key (number) in an optim to the
+    ``_NamedOptimizer`` takes a dict of parameters and exposes ``state_dict`` by parameter key.
+    
+    We replace the original key (number) in an optim to the
     fully qualified name (FQN) string. User can initialize the optim as they
     initialize a PyTorch optim, the only difference is that they also need to
     pass in the FQN of each parameters.
@@ -120,8 +121,10 @@ class _NamedOptimizer(optim.Optimizer):
 
     def state_dict(self) -> Dict[str, Any]:
         """
-        Return the ``state_dict`` of the optimizer. Instead of using number to index
-        parameters, we will use module fully qualified name (FQN) as the key.
+        Return the ``state_dict`` of the optimizer.
+        
+        Instead of using number to index parameters,
+        we will use module fully qualified name (FQN) as the key.
         """
         state_dict = self._optimizer.state_dict()
         param_groups = state_dict["param_groups"]
@@ -154,7 +157,7 @@ class _NamedOptimizer(optim.Optimizer):
 
     def step(self, closure: Optional[Callable[[], float]] = None) -> Optional[float]:
         """
-        Performs a single optimization step.
+        Perform a single optimization step.
 
         This will call :meth:`torch.optim.Optimizer.step` on the wrapped
         optimizer.
@@ -167,8 +170,7 @@ class _NamedOptimizer(optim.Optimizer):
 
     def load_state_dict(self, state_dict: Mapping[str, Any]) -> None:
         """
-        This public function defines the default behavior to load a state_dict
-        for ``_NamedOptimizer``.
+        Define the default behavior to load a state_dict for ``_NamedOptimizer``.
 
         Sample Code
         ```
@@ -298,6 +300,8 @@ class _NamedOptimizer(optim.Optimizer):
 
     def init_state(self) -> None:
         """
+        Lazy intialize optimizer state.
+
         Runs a dummy optimizer step, which allows to initialize optimizer state
         because we do lazy init for most optimizers.
 
@@ -328,7 +332,5 @@ class _NamedOptimizer(optim.Optimizer):
 
 
 def _gen_param_group_key(param_keys: List[str]) -> str:
-    """
-    Concatenate all param keys as a unique indentifier for one param group.
-    """
+    """Concatenate all param keys as a unique indentifier for one param group."""
     return "/".join(sorted(param_keys))

--- a/torch/distributed/optim/optimizer.py
+++ b/torch/distributed/optim/optimizer.py
@@ -125,6 +125,8 @@ def _wait_for_all(rpc_futs):
 
 class DistributedOptimizer:
     """
+    Apply optimizer locally to parameters scattered across workers via remote references.
+
     DistributedOptimizer takes remote references to parameters scattered
     across workers and applies the given optimizer locally for each parameter.
 
@@ -222,7 +224,7 @@ class DistributedOptimizer:
 
     def step(self, context_id):
         """
-        Performs a single optimization step.
+        Perform a single optimization step.
 
         This will call :meth:`torch.optim.Optimizer.step` on each worker
         containing parameters to be optimized, and will block until all workers

--- a/torch/distributed/optim/post_localSGD_optimizer.py
+++ b/torch/distributed/optim/post_localSGD_optimizer.py
@@ -6,7 +6,8 @@ import torch.distributed.algorithms.model_averaging.averagers as averagers
 
 class PostLocalSGDOptimizer(torch.optim.Optimizer):
     r"""
-    Wraps an arbitrary :class:`torch.optim.Optimizer` and runs `post-local SGD <https://arxiv.org/abs/1808.07217>`_,
+    Wrap an arbitrary :class:`torch.optim.Optimizer` and runs `post-local SGD <https://arxiv.org/abs/1808.07217>`_.
+
     This optimizer runs local optimizer at every step.
     After the warm-up stage, it averages parameters periodically afer the local optimizer is applied.
 
@@ -68,6 +69,8 @@ class PostLocalSGDOptimizer(torch.optim.Optimizer):
 
     def state_dict(self):
         r"""
+        Record model averager's step to checkpoint.
+
         This is the same as :class:`torch.optim.Optimizer` :meth:`state_dict`,
         but adds an extra entry to record model averager's step to the checkpoint
         to ensure reload does not cause unnecessary warm up again.
@@ -78,6 +81,8 @@ class PostLocalSGDOptimizer(torch.optim.Optimizer):
 
     def load_state_dict(self, state_dict):
         r"""
+        Restore model averager's step value to checkpoint.
+
         This is the same as :class:`torch.optim.Optimizer` :meth:`load_state_dict`,
         but also restores model averager's step value to the one
         saved in the provided ``state_dict``.
@@ -96,9 +101,7 @@ class PostLocalSGDOptimizer(torch.optim.Optimizer):
             self.averager.step = 0
 
     def step(self):
-        r"""
-        Performs a single optimization step (parameter update).
-        """
+        r"""Perform a single optimization step i.e. parameter update."""
         self.optim.step()
         self.averager.average_parameters(params=self.param_groups)
 

--- a/torch/distributed/optim/utils.py
+++ b/torch/distributed/optim/utils.py
@@ -29,7 +29,7 @@ functional_optim_map = {
 def register_functional_optim(key, optim):
     """
     Interface to insert a new functional optimizer to functional_optim_map.
-    
+
     ``fn_optim_key`` and ``fn_optimizer`` are user defined. The optimizer and key
     need not be of :class:`torch.optim.Optimizer` (e.g. for custom optimizers)
     Example::

--- a/torch/distributed/optim/utils.py
+++ b/torch/distributed/optim/utils.py
@@ -28,7 +28,8 @@ functional_optim_map = {
 
 def register_functional_optim(key, optim):
     """
-    Interface to insert a new functional optimizer to functional_optim_map
+    Interface to insert a new functional optimizer to functional_optim_map.
+    
     ``fn_optim_key`` and ``fn_optimizer`` are user defined. The optimizer and key
     need not be of :class:`torch.optim.Optimizer` (e.g. for custom optimizers)
     Example::

--- a/torch/distributed/optim/zero_redundancy_optimizer.py
+++ b/torch/distributed/optim/zero_redundancy_optimizer.py
@@ -32,7 +32,7 @@ def _recursive_copy_to_device(
 ) -> Any:
     r"""
     Recursively searches lists, tuples, dicts and copies tensors to device if possible.
-    
+
     Non-tensor values are passed as-is in the result.
 
     .. note:  These are all copies, so if there are two objects that reference
@@ -121,7 +121,7 @@ class _ZeROJoinHook(JoinHook):
     def main_hook(self):
         """
         Perform an optimizer step.
-        
+
         Updates the joined process's shard of
         the parameters and broadcasts those parameters.
         """
@@ -177,7 +177,7 @@ class _OverlapStatus(enum.IntEnum):
         ``INITIALIZED``: The ZeRO instance is fully initialized and can now
             optimize parameters.
     """
-    
+
     UNINITIALIZED = 0
     DDP_HAS_REBUILT_BUCKETS = 1
     INITIALIZED = 2
@@ -252,7 +252,7 @@ class _OverlapInfo:
     def wait_for_broadcasts(self) -> None:
         r"""
         Wait for all parameter broadcasts.
-        
+
         This should be called once all broadcasts have been scheduled, meaning
         ``self.broadcast_handles`` is filled. This clears ``self.broadcast_handles``
         in preparation for the next iteration.
@@ -1117,7 +1117,7 @@ class ZeroRedundancyOptimizer(Optimizer, Joinable):
     def join_hook(self, **kwargs):
         r"""
         Return the ZeRO join hook.
-         
+
         The hook enables training on uneven inputs by
         shadowing the collective communications in the optimizer step.
 
@@ -1145,7 +1145,7 @@ class ZeroRedundancyOptimizer(Optimizer, Joinable):
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
         r"""
         Load the state pertaining to the given rank from the input ``state_dict``.
-        
+
         Updating the local optimizer as needed.
 
         Arguments:
@@ -1275,7 +1275,7 @@ class ZeroRedundancyOptimizer(Optimizer, Joinable):
     def _build_param_buckets(self) -> None:
         r"""
         Build parameter buckets if ``parameters_as_bucket_view=True``.
-        
+
         So that for each device that stores this rank's parameters, there is a
         bucket (represented as a tensor) containing all of the parameters on
         that device that are assigned to a given rank in the parameter update
@@ -1574,7 +1574,7 @@ class ZeroRedundancyOptimizer(Optimizer, Joinable):
     def _check_overlap_initialized(self):
         r"""
         Check for delayed initialization when ``overlap_with_ddp`` is set to True.
-         
+
         Checks that the delayed initialization has occurred (see
         :meth:`_init_zero_for_overlap`) if ``overlap_with_ddp=True``, and
         raises a ``RuntimeError`` if not. This should preface methods that

--- a/torch/distributed/rpc/__init__.py
+++ b/torch/distributed/rpc/__init__.py
@@ -89,7 +89,7 @@ if is_available():
     ):
         r"""
         Initialize RPC primitives to send and receive RPCs.
-        
+
         Initializes RPC primitives such as the local RPC agent
         and distributed autograd, which immediately makes the current
         process ready to send and receive RPCs.

--- a/torch/distributed/rpc/__init__.py
+++ b/torch/distributed/rpc/__init__.py
@@ -88,6 +88,8 @@ if is_available():
         rpc_backend_options=None,
     ):
         r"""
+        Initialize RPC primitives to send and receive RPCs.
+        
         Initializes RPC primitives such as the local RPC agent
         and distributed autograd, which immediately makes the current
         process ready to send and receive RPCs.

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -290,7 +290,7 @@ def _barrier(worker_names):
 def _wait_all_workers(timeout=DEFAULT_SHUTDOWN_TIMEOUT):
     r"""
     Block until all local and remote RPC processes reach this method and wait for all outstanding work to complete.
-    
+
     Every RPC process must call this method before exit to perform a graceful
     shutdown. This should be used to terminate the RPC framework, and there is
     no guarantee that the RPC framework will work after this method returns.
@@ -308,7 +308,7 @@ def _wait_all_workers(timeout=DEFAULT_SHUTDOWN_TIMEOUT):
 def shutdown(graceful=True, timeout=DEFAULT_SHUTDOWN_TIMEOUT):
     r"""
     Perform a shutdown of the RPC agent, and then destroy the RPC agent.
-    
+
     This stops the local agent from accepting outstanding requests, and shuts
     down the RPC framework by terminating all RPC threads. If ``graceful=True``,
     this will block until all local and remote RPC processes reach this method
@@ -744,7 +744,7 @@ def _invoke_rpc(to, func, rpc_type, args=None, kwargs=None, rpc_timeout: float =
 def rpc_sync(to, func, args=None, kwargs=None, timeout: float = UNSET_RPC_TIMEOUT):
     r"""
     Make a blocking RPC call to run function ``func`` on worker ``to``.
-    
+
     RPC messages are sent and received in parallel to execution of Python code. This
     method is thread-safe.
 

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -527,7 +527,9 @@ for method_name, method in inspect.getmembers(PyRRef):
 @_require_initialized
 def remote(to, func, args=None, kwargs=None, timeout=UNSET_RPC_TIMEOUT):
     r"""
-    Make a remote call to run ``func`` on worker ``to`` and return an :class:`~torch.distributed.rpc.RRef` to the result value immediately.
+    Make a remote call to run ``func`` on worker ``to``.
+
+    Return an :class:`~torch.distributed.rpc.RRef` to the result value immediately.
 
     Worker ``to`` will be the owner of the returned
     :class:`~torch.distributed.rpc.RRef`, and the worker calling ``remote`` is

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -60,9 +60,7 @@ _default_pickler = _internal_rpc_pickler
 
 @contextlib.contextmanager
 def _use_rpc_pickler(rpc_pickler):
-    r"""
-    rpc_pickler: (.internal._InternalRPCPickler) Overrides the default RPC pickler
-    """
+    r"""rpc_pickler: (.internal._InternalRPCPickler) Overrides the default RPC pickler."""
     global _default_pickler
     _default_pickler = rpc_pickler
     try:
@@ -151,9 +149,9 @@ _thread_local_var = threading.local()
 @contextlib.contextmanager
 def _wait_all():
     r"""
-    A context manager that collects all futures returned by ``rpc_async`` and
-    waits them on the context manager's exit; relieving the user of needing
-    to explicitly call wait.
+    Collect ``rpc_async`` futures, and waits them on the context manager's exit.
+
+    Hence, relieving the user of needing to explicitly call wait.
 
 
     Example::
@@ -180,8 +178,9 @@ def _wait_all():
 @_require_initialized
 def _all_gather(obj, worker_names=None, timeout: float = UNSET_RPC_TIMEOUT):
     r"""
-    This is similar to torch.distributed.all_gather(), but is using RPC. It
-    picks the worker with the smallest name (alphabetic order) as the leader.
+    Similar to torch.distributed.all_gather(), but is using RPC.
+
+    It picks the worker with the smallest name (alphabetic order) as the leader.
     Then all followers send their data ``obj`` to the leader. After the leader
     has received all, it will broadcast the results back to all followers. This
     function blocks until all workers have received the gathered results.
@@ -270,7 +269,7 @@ def _all_gather(obj, worker_names=None, timeout: float = UNSET_RPC_TIMEOUT):
 @_require_initialized
 def _barrier(worker_names):
     r"""
-    Synchronizes local and remote RPC processes.
+    Synchronize local and remote RPC processes.
 
     This will block until all local and remote RPC processes specified under worker_names
     reach this method to wait for all outstanding work to complete.
@@ -290,11 +289,11 @@ def _barrier(worker_names):
 @_require_initialized
 def _wait_all_workers(timeout=DEFAULT_SHUTDOWN_TIMEOUT):
     r"""
-    Block until all local and remote RPC processes reach this method and wait
-    for all outstanding work to complete. Every RPC process must call this
-    method before exit to perform a graceful shutdown. This should be used to
-    terminate the RPC framework, and there is no guarantee that the RPC
-    framework will work after this method returns.
+    Block until all local and remote RPC processes reach this method and wait for all outstanding work to complete.
+    
+    Every RPC process must call this method before exit to perform a graceful
+    shutdown. This should be used to terminate the RPC framework, and there is
+    no guarantee that the RPC framework will work after this method returns.
     """
     try:
         _all_gather(None, timeout=timeout)
@@ -308,8 +307,9 @@ def _wait_all_workers(timeout=DEFAULT_SHUTDOWN_TIMEOUT):
 @_require_initialized
 def shutdown(graceful=True, timeout=DEFAULT_SHUTDOWN_TIMEOUT):
     r"""
-    Perform a shutdown of the RPC agent, and then destroy the RPC agent. This
-    stops the local agent from accepting outstanding requests, and shuts
+    Perform a shutdown of the RPC agent, and then destroy the RPC agent.
+    
+    This stops the local agent from accepting outstanding requests, and shuts
     down the RPC framework by terminating all RPC threads. If ``graceful=True``,
     this will block until all local and remote RPC processes reach this method
     and wait for all outstanding work to complete. Otherwise, if
@@ -404,6 +404,7 @@ def _finalize_shutdown():
 def get_worker_info(worker_name=None):
     r"""
     Get :class:`~torch.distributed.rpc.WorkerInfo` of a given worker name.
+
     Use this :class:`~torch.distributed.rpc.WorkerInfo` to avoid passing an
     expensive string on every invocation.
 
@@ -526,8 +527,8 @@ for method_name, method in inspect.getmembers(PyRRef):
 @_require_initialized
 def remote(to, func, args=None, kwargs=None, timeout=UNSET_RPC_TIMEOUT):
     r"""
-    Make a remote call to run ``func`` on worker ``to`` and return an
-    :class:`~torch.distributed.rpc.RRef` to the result value immediately.
+    Make a remote call to run ``func`` on worker ``to`` and return an :class:`~torch.distributed.rpc.RRef` to the result value immediately.
+
     Worker ``to`` will be the owner of the returned
     :class:`~torch.distributed.rpc.RRef`, and the worker calling ``remote`` is
     a user. The owner manages the global reference count of its
@@ -742,8 +743,9 @@ def _invoke_rpc(to, func, rpc_type, args=None, kwargs=None, rpc_timeout: float =
 @_require_initialized
 def rpc_sync(to, func, args=None, kwargs=None, timeout: float = UNSET_RPC_TIMEOUT):
     r"""
-    Make a blocking RPC call to run function ``func`` on worker ``to``. RPC
-    messages are sent and received in parallel to execution of Python code. This
+    Make a blocking RPC call to run function ``func`` on worker ``to``.
+    
+    RPC messages are sent and received in parallel to execution of Python code. This
     method is thread-safe.
 
     Args:
@@ -816,8 +818,9 @@ def rpc_sync(to, func, args=None, kwargs=None, timeout: float = UNSET_RPC_TIMEOU
 @_require_initialized
 def rpc_async(to, func, args=None, kwargs=None, timeout=UNSET_RPC_TIMEOUT):
     r"""
-    Make a non-blocking RPC call to run function ``func`` on worker ``to``. RPC
-    messages are sent and received in parallel to execution of Python code. This
+    Make a non-blocking RPC call to run function ``func`` on worker ``to``.
+
+    RPC messages are sent and received in parallel to execution of Python code. This
     method is thread-safe. This method will immediately return a
     :class:`~torch.futures.Future` that can be awaited on.
 

--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -42,7 +42,7 @@ if BackendType.__doc__:
 
 def backend_registered(backend_name):
     """
-    Checks if backend_name is registered as an RPC backend.
+    Check if backend_name is registered as an RPC backend.
 
     Args:
         backend_name (str): string to identify the RPC backend.
@@ -56,7 +56,7 @@ def backend_registered(backend_name):
 def register_backend(
     backend_name, construct_rpc_backend_options_handler, init_backend_handler
 ):
-    """Registers a new RPC backend.
+    """Register a new RPC backend.
 
     Args:
         backend_name (str): backend string to identify the handler.

--- a/torch/distributed/rpc/functions.py
+++ b/torch/distributed/rpc/functions.py
@@ -4,7 +4,7 @@ import functools
 def async_execution(fn):
     r"""
     Decorate a function to run asynchronously on the RPC callee.
-    
+
     A decorator for a function indicating that the return value of the function
     is guaranteed to be a :class:`~torch.futures.Future` object and this
     function can run asynchronously on the RPC callee. More specifically, the

--- a/torch/distributed/rpc/functions.py
+++ b/torch/distributed/rpc/functions.py
@@ -3,6 +3,8 @@ import functools
 
 def async_execution(fn):
     r"""
+    Decorate a function to run asynchronously on the RPC callee.
+    
     A decorator for a function indicating that the return value of the function
     is guaranteed to be a :class:`~torch.futures.Future` object and this
     function can run asynchronously on the RPC callee. More specifically, the

--- a/torch/distributed/rpc/internal.py
+++ b/torch/distributed/rpc/internal.py
@@ -30,7 +30,7 @@ class RPCExecMode(Enum):
 class _InternalRPCPickler:
     r"""
     Provide interfaces to serialize data to be "binary string + tensor table" format.
-    
+
     So for RPC python UDF function and args, non tensor data will be serialized
     into regular binary string, tensor data will be put into thread local tensor
     tables, this serialization format is consistent with builtin operator and args
@@ -248,7 +248,7 @@ def _build_rpc_profiling_key(
 def _start_record_function(exec_type, func_name, current_worker_name, dest_worker_name):
     """
     Call from RPC/RRef functions to create a RecordFunction object for profiling.
-    
+
     This function also runs the before callbacks that start the profiling, though the user is responsible for
     running the appropriate callbacks when the function to be profiled finishes.
 

--- a/torch/distributed/rpc/internal.py
+++ b/torch/distributed/rpc/internal.py
@@ -29,8 +29,8 @@ class RPCExecMode(Enum):
 
 class _InternalRPCPickler:
     r"""
-    This class provides serialize() and deserialize() interfaces to serialize
-    data to be "binary string + tensor table" format
+    Provide interfaces to serialize data to be "binary string + tensor table" format.
+    
     So for RPC python UDF function and args, non tensor data will be serialized
     into regular binary string, tensor data will be put into thread local tensor
     tables, this serialization format is consistent with builtin operator and args
@@ -74,27 +74,19 @@ class _InternalRPCPickler:
 
     @classmethod
     def _script_module_receiver(cls, script_module_serialized):
-        """
-        Given a serialized representation of a ScriptModule created with torch.jit.save,
-        loads and returns the ScriptModule.
-        """
+        """Given a serialized representation of a ScriptModule created with torch.jit.save, loads and returns the ScriptModule."""
         f = io.BytesIO(script_module_serialized)
         m = torch.jit.load(f)
         return m
 
     def _script_module_reducer(self, script_module):
-        """
-        Serializes a ScriptModule.
-        """
+        """Serialize a ScriptModule."""
         f = io.BytesIO()
         torch.jit.save(script_module, f)
         return (_InternalRPCPickler._script_module_receiver, (f.getvalue(),))
 
     def serialize(self, obj):
-        r"""
-        Serialize non tensor data into binary string, tensor data into
-        tensor table
-        """
+        r"""Serialize non tensor data into binary string, tensor data into tensor table."""
         f = io.BytesIO()
         p = _pickler(f)
         p.dispatch_table = self._dispatch_table
@@ -144,9 +136,7 @@ class _InternalRPCPickler:
         return (f.getvalue(), tensors)
 
     def deserialize(self, binary_data, tensor_table):
-        r"""
-        Deserialize binary string + tensor table to original obj
-        """
+        r"""Deserialize binary string + tensor table to original obj."""
         # save _thread_local_tensor_tables.recv_tables if it is in nested call
         global _thread_local_tensor_tables
         if hasattr(_thread_local_tensor_tables, "recv_tables"):
@@ -195,11 +185,11 @@ def deserialize(binary_data, tensor_table):
 
 def _run_function(python_udf):
     r"""
+    Run a Python UDF and returns its return value.
+
+    Wraps any exception in ``RemoteException`` if the function raises.
     This function is exclusively called from C++.
     See ``torch/csrc/distributed/rpc/python_rpc_handler.cpp``.
-
-    Runs a Python UDF and returns its return value.
-    Wraps any exception in ``RemoteException`` if the function raises.
     """
     try:
         if isinstance(python_udf, AttributeError):
@@ -238,7 +228,8 @@ def _build_rpc_profiling_key(
     exec_type, func_name, current_worker_name, dst_worker_name
 ):
     """
-    Builds the key that RPC calls are profiled with using the autograd profiler.
+    Build the key that RPC calls are profiled with using the autograd profiler.
+
     This will be the name of the corresponding Event recorded in the profiler.
 
     Args:
@@ -256,9 +247,9 @@ def _build_rpc_profiling_key(
 
 def _start_record_function(exec_type, func_name, current_worker_name, dest_worker_name):
     """
-    This function should be called from RPC/RRef functions to create a
-    RecordFunction object for profiling. This function also runs the before
-    callbacks that start the profiling, though the user is responsible for
+    Call from RPC/RRef functions to create a RecordFunction object for profiling.
+    
+    This function also runs the before callbacks that start the profiling, though the user is responsible for
     running the appropriate callbacks when the function to be profiled finishes.
 
     Args:

--- a/torch/distributed/rpc/options.py
+++ b/torch/distributed/rpc/options.py
@@ -42,7 +42,9 @@ def _to_device_list(devices: List[DeviceType]) -> List[torch.device]:
 
 class TensorPipeRpcBackendOptions(_TensorPipeRpcBackendOptionsBase):
     r"""
-    Backend options for :class:`~torch.distributed.rpc.TensorPipeAgent`, derived from :class:`~torch.distributed.rpc.RpcBackendOptions`.
+    Backend options for :class:`~torch.distributed.rpc.TensorPipeAgent`.
+
+    Derived from :class:`~torch.distributed.rpc.RpcBackendOptions`.
 
     Args:
         num_worker_threads (int, optional): The number of threads in the

--- a/torch/distributed/rpc/options.py
+++ b/torch/distributed/rpc/options.py
@@ -102,7 +102,7 @@ class TensorPipeRpcBackendOptions(_TensorPipeRpcBackendOptionsBase):
     def set_device_map(self, to: str, device_map: Dict[DeviceType, DeviceType]):
         r"""
         Set device mapping between each RPC caller and callee pair.
-        
+
         This function can be called multiple times to incrementally add
         device placement configurations.
 
@@ -161,7 +161,7 @@ class TensorPipeRpcBackendOptions(_TensorPipeRpcBackendOptionsBase):
     def set_devices(self, devices: List[DeviceType]):
         r"""
         Set local devices used by the TensorPipe RPC agent.
-        
+
         When processing CUDA RPC requests, the TensorPipe RPC agent will properly synchronize
         CUDA streams for all devices in this ``List``.
 

--- a/torch/distributed/rpc/options.py
+++ b/torch/distributed/rpc/options.py
@@ -42,9 +42,7 @@ def _to_device_list(devices: List[DeviceType]) -> List[torch.device]:
 
 class TensorPipeRpcBackendOptions(_TensorPipeRpcBackendOptionsBase):
     r"""
-    The backend options for
-    :class:`~torch.distributed.rpc.TensorPipeAgent`, derived from
-    :class:`~torch.distributed.rpc.RpcBackendOptions`.
+    Backend options for :class:`~torch.distributed.rpc.TensorPipeAgent`, derived from :class:`~torch.distributed.rpc.RpcBackendOptions`.
 
     Args:
         num_worker_threads (int, optional): The number of threads in the
@@ -103,8 +101,9 @@ class TensorPipeRpcBackendOptions(_TensorPipeRpcBackendOptionsBase):
 
     def set_device_map(self, to: str, device_map: Dict[DeviceType, DeviceType]):
         r"""
-        Set device mapping between each RPC caller and callee pair. This
-        function can be called multiple times to incrementally add
+        Set device mapping between each RPC caller and callee pair.
+        
+        This function can be called multiple times to incrementally add
         device placement configurations.
 
         Args:
@@ -161,8 +160,9 @@ class TensorPipeRpcBackendOptions(_TensorPipeRpcBackendOptionsBase):
 
     def set_devices(self, devices: List[DeviceType]):
         r"""
-        Set local devices used by the TensorPipe RPC agent. When processing
-        CUDA RPC requests, the TensorPipe RPC agent will properly synchronize
+        Set local devices used by the TensorPipe RPC agent.
+        
+        When processing CUDA RPC requests, the TensorPipe RPC agent will properly synchronize
         CUDA streams for all devices in this ``List``.
 
         Args:

--- a/torch/distributed/rpc/server_process_global_profiler.py
+++ b/torch/distributed/rpc/server_process_global_profiler.py
@@ -129,7 +129,7 @@ class _server_process_global_profile(profile):
     def __exit__(self, exc_type, exc_val, exc_tb):
         """
         Turn off server-side process-global profiling.
-        
+
         Aggregate all profiling events recorded by RPC threads.
 
         These attributes are assigned on exiting context.

--- a/torch/distributed/rpc/server_process_global_profiler.py
+++ b/torch/distributed/rpc/server_process_global_profiler.py
@@ -15,8 +15,7 @@ __all__: List[str] = []
 
 class _server_process_global_profile(profile):
     """
-    It has the same API as ``torch.autograd.profiler.profile`` class,
-    except that it enables profiling on all threads running RPC server request callbacks.
+    Enable profiling on all threads running RPC server request callbacks.
 
     Context manager that manages autograd profiler state and holds a summary of results.
     Under the hood it just records events of functions being executed in C++ and
@@ -101,6 +100,7 @@ class _server_process_global_profile(profile):
     def __enter__(self):
         """
         Turn on server-side process-global profiling.
+
         This enables thread-local profiler on all RPC threads running server-side request callbacks.
         """
         if not self.enabled:
@@ -129,6 +129,7 @@ class _server_process_global_profile(profile):
     def __exit__(self, exc_type, exc_val, exc_tb):
         """
         Turn off server-side process-global profiling.
+        
         Aggregate all profiling events recorded by RPC threads.
 
         These attributes are assigned on exiting context.


### PR DESCRIPTION
Fixes #112641, #112642, and partial fix to #112643 for `torch/distributed/optim/named_optimizer.py`. This PR resolved the docstrings for `torch/distributed/optim` and `torch/distributed/rpc` completely except Missing docs warnings. 

Provides fix for the following:

`torch/distributed/_functional_collectives.py`

Before: **25**
After   : **10**

`torch/distributed/autograd/__init__.py`

Before: **8**
After   : **4**

`torch/distributed/optim/`

Before: **156**
After   : **24**

`torch/distributed/rpc/`

Before: **81**
After   : **26**

The remaining are the Missing Doc Strings issues.

cc: @svekars

cc @svekars @carljparker