### PR TITLE
remove intel_extension_for_pytorch from THIRDPARTY_SKIPLIST

### DIFF
--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -126,7 +126,6 @@ BUILTIN_SKIPLIST = (
 THIRDPARTY_SKIPLIST = (
     "functorch",
     "fx2trt_oss",
-    "intel_extension_for_pytorch",
     "networkx",
     "numpy",
     "omegaconf",


### PR DESCRIPTION
Motivation: Since `intel_extension_for_pytorch` is added to `THIRDPARTY_SKIPLIST`, when the IPEX optimized model uses `torch.compile`, the functions defined in IPEX will be skipped, these functions will not be able to generate the corresponding FX graph through dynamo, cannot be optimized by the compiler, and unnecessary graph breaks occurred. This PR is to remove `intel_extension_for_pytorch` from `THIRDPARTY_SKIPLIST` so that IPEX and torch.compile can work better together.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @chenyang78 @aakhundov @kadeng