### PR TITLE
s390x: skip tests relying on specific openblas precision

### DIFF
--- a/test/test_ops_fwd_gradients.py
+++ b/test/test_ops_fwd_gradients.py
@@ -1,6 +1,8 @@
 # Owner(s): ["module: unknown"]
 
 from functools import partial
+import platform
+from unittest import skipIf as skipif
 import torch
 
 from torch.testing._internal.common_utils import (
@@ -52,6 +54,8 @@ class TestFwdGradients(TestGradients):
                 call_grad_test_helper()
 
     @_gradcheck_ops(op_db)
+    @skipif(platform.machine() == "s390x",
+            reason="Different precision of openblas functions: https://github.com/OpenMathLib/OpenBLAS/issues/4194")
     def test_forward_mode_AD(self, device, dtype, op):
         self._skip_helper(op, device, dtype)
 


### PR DESCRIPTION
This change skips test_forward_mode_AD_linalg_det_singular_cpu_complex128 and test_forward_mode_AD_linalg_det_singular_cpu_float64 from test/test_ops_fwd_gradients.py
due to https://github.com/OpenMathLib/OpenBLAS/issues/4194
