### PR TITLE
Avoid calling as_tensor twice

### DIFF
--- a/torch/_numpy/_ndarray.py
+++ b/torch/_numpy/_ndarray.py
@@ -494,7 +494,7 @@ def array(obj, dtype=None, *, copy=True, order="K", subok=False, ndmin=0, like=N
     if like is not None:
         raise NotImplementedError("'like' parameter is not supported.")
     if order != "K":
-        raise NotImplementedError
+        raise NotImplementedError()
 
     # a happy path
     if (
@@ -506,13 +506,10 @@ def array(obj, dtype=None, *, copy=True, order="K", subok=False, ndmin=0, like=N
         return obj
 
     if isinstance(obj, (list, tuple)):
+        # FIXME and they have the same dtype, device, etc
         if obj and all(isinstance(x, torch.Tensor) for x in obj):
             # list of arrays: *under torch.Dynamo* these are FakeTensors
             obj = torch.stack(obj)
-        else:
-            # XXX: remove tolist
-            # lists of ndarrays: [1, [2, 3], ndarray(4)] convert to lists of lists
-            obj = _tolist(obj)
 
     # is obj an ndarray already?
     if isinstance(obj, ndarray):

--- a/torch/_numpy/_ndarray.py
+++ b/torch/_numpy/_ndarray.py
@@ -510,6 +510,10 @@ def array(obj, dtype=None, *, copy=True, order="K", subok=False, ndmin=0, like=N
         if obj and all(isinstance(x, torch.Tensor) for x in obj):
             # list of arrays: *under torch.Dynamo* these are FakeTensors
             obj = torch.stack(obj)
+        else:
+            # XXX: remove tolist
+            # lists of ndarrays: [1, [2, 3], ndarray(4)] convert to lists of lists
+            obj = _tolist(obj)
 
     # is obj an ndarray already?
     if isinstance(obj, ndarray):

--- a/torch/_numpy/_util.py
+++ b/torch/_numpy/_util.py
@@ -210,17 +210,16 @@ def _coerce_to_tensor(obj, dtype=None, copy=False, ndmin=0):
     if isinstance(obj, torch.Tensor):
         tensor = obj
     else:
-        tensor = _try_convert_to_tensor(obj)
-
         # tensor.dtype is the pytorch default, typically float32. If obj's elements
         # are not exactly representable in float32, we've lost precision:
         # >>> torch.as_tensor(1e12).item() - 1e12
         # -4096.0
-
-        # Therefore, we treat `tensor.dtype` as a hint, and convert the
-        # original object *again*, this time with an explicit dtype.
-        torch_dtype = _dtypes_impl.get_default_dtype_for(tensor.dtype)
-        tensor = torch.as_tensor(obj, dtype=torch_dtype)
+        default_dtype = torch.get_default_dtype()
+        torch.set_default_dtype(_dtypes_impl.get_default_dtype_for(torch.float32))
+        try:
+            tensor = _try_convert_to_tensor(obj)
+        finally:
+            torch.set_default_dtype(default_dtype)
 
     # type cast if requested
     tensor = cast_if_needed(tensor, dtype)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #112866

Sometimes doing so may copy and that's not good. We avoid that by
setting global flags.

cc @mruberry @rgommers @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng