### PR TITLE
SGR/Assistant: making sure linker drops unnecessary dependencies

### DIFF
--- a/c2_defs.bzl
+++ b/c2_defs.bzl
@@ -9,7 +9,6 @@ load("@fbsource//tools/build_defs:fbsource_utils.bzl", "is_arvr_mode", "is_fbcod
 load("@fbsource//tools/build_defs:platform_defs.bzl", "ANDROID", "APPLE", "CXX", "IOS", "MACOSX", "WINDOWS")
 load("@fbsource//tools/build_defs/apple:build_mode_defs.bzl", "is_production_build")
 load("@fbsource//tools/build_defs/apple:config_utils_defs.bzl", "STATIC_LIBRARY_IOS_CONFIG", "STATIC_LIBRARY_MAC_CONFIG", "fbobjc_configs")
-load("@fbsource//tools/build_defs/apple:focus_config.bzl", "is_focus_enabled")
 load("@fbsource//xplat/pfh/Msgr/Mobile/ProductInfra:DEFS.bzl", "Msgr_Mobile_ProductInfra")
 
 def get_c2_expose_op_to_c10():
@@ -377,11 +376,11 @@ def c2_protobuf_rule(protos):
     for p in protos:
         proto = paths.basename(p)
         protocexe = "$(exe fbsource//third-party/protobuf:protoc-host)" if is_arvr_mode() else "$(location fbsource//xplat/third-party/protobuf:protoc.Windows)"
-        protocmd_exe  = "powershell.exe -file $(location fbsource//xplat/caffe2/scripts:proto)\\proto.ps1 -Protoc {} -Unprocessed $SRCDIR/{} -Processed $SRCDIR/{} -out $OUT -srcdir $SRCDIR".format(protocexe, p, proto)
+        protocmd_exe = "powershell.exe -file $(location fbsource//xplat/caffe2/scripts:proto)\\proto.ps1 -Protoc {} -Unprocessed $SRCDIR/{} -Processed $SRCDIR/{} -out $OUT -srcdir $SRCDIR".format(protocexe, p, proto)
         protocmd = ("cp $SRCDIR/{} $SRCDIR/{} && chmod +w $SRCDIR/{} && echo \"option optimize_for = LITE_RUNTIME;\" >> $SRCDIR/{} && ".format(p, proto, proto, proto) +
                     "cp $SRCDIR/caffe2/proto/caffe2.proto $SRCDIR/caffe2.proto && chmod +w $SRCDIR/caffe2.proto && echo \"option optimize_for = LITE_RUNTIME;\" >> $SRCDIR/caffe2.proto && " +
                     "sed -i -e 's/caffe2\\/proto\\/caffe2.proto/caffe2.proto/g' $SRCDIR/{} && ".format(proto) +
-                   ("$(exe fbsource//third-party/protobuf:protoc-host) " if using_protobuf_v3() else "$(exe fbsource//xplat/third-party/protobuf:protoc) --osx $(location fbsource//xplat/third-party/protobuf:protoc.Darwin) --linux $(location fbsource//xplat/third-party/protobuf:protoc.Linux) ") +
+                    ("$(exe fbsource//third-party/protobuf:protoc-host) " if using_protobuf_v3() else "$(exe fbsource//xplat/third-party/protobuf:protoc) --osx $(location fbsource//xplat/third-party/protobuf:protoc.Darwin) --linux $(location fbsource//xplat/third-party/protobuf:protoc.Linux) ") +
                     "-I $SRCDIR --cpp_out=$OUT $SRCDIR/{}".format(proto))
         buck_genrule(
             name = proto,
@@ -426,7 +425,7 @@ def c2_full_protobuf_rule(protos):
         protocmd = ("cp $SRCDIR/{} $SRCDIR/{} && ".format(p, proto) +
                     "cp $SRCDIR/caffe2/proto/caffe2.proto $SRCDIR/caffe2.proto && " +
                     "sed -i -e 's/caffe2\\/proto\\/caffe2.proto/caffe2.proto/g' $SRCDIR/{} && ".format(proto) +
-                   ("$(exe fbsource//third-party/protobuf:protoc-host) " if using_protobuf_v3() else "$(exe fbsource//xplat/third-party/protobuf:protoc) --osx $(location fbsource//xplat/third-party/protobuf:protoc.Darwin) --linux $(location fbsource//xplat/third-party/protobuf:protoc.Linux) ") +
+                    ("$(exe fbsource//third-party/protobuf:protoc-host) " if using_protobuf_v3() else "$(exe fbsource//xplat/third-party/protobuf:protoc) --osx $(location fbsource//xplat/third-party/protobuf:protoc.Darwin) --linux $(location fbsource//xplat/third-party/protobuf:protoc.Linux) ") +
                     "-I $SRCDIR --cpp_out=$OUT $SRCDIR/{}".format(proto))
         buck_genrule(
             name = prefix + proto,
@@ -493,9 +492,7 @@ def c2_operator_library(name, **kwargs):
     # so that loading one will implicitly load the dependencies.  So, make sure
     # that no `--as-needed` flags pulled in from dependencies cause these
     # operator deps to get dropped.
-    linker_flags = [
-        "-Wl,--no-as-needed",
-    ]
+    linker_flags = [] if (read_config("caffe2", "link_as_needed", "0") == "1") else ["-Wl,--no-as-needed"]
     c2_cxx_library(
         name = name,
         soname = "lib" + name + ".$(ext)",


### PR DESCRIPTION
Summary:
Assistant/SGR is linked in a way that links to all not-reference libraries are dropped: https://www.internalfb.com/code/fbsource/[c74911ac21d6b90d1fbca8f2de08d6269f44e1fc]/xplat/toolchains/android/ndk/ndk_toolchains.bzl?lines=931
However, `caffe2` overrides this setting https://www.internalfb.com/code/fbsource/[2536ee6849b08da1adcd5b9da0e455a4af3a06d1][blame]/xplat/caffe2/c2_defs.bzl?lines=496. That results in the build breaks like discussed here: https://fb.workplace.com/groups/llvm.gcc/permalink/25390586597229949/ : Assistant doesn't use libforce_dlopen but it sill requires it, and that library exist on device.

As we statically link all operators, the `caffe2` override doesn't seem to be necessary.

This diff adds a build parameter affecting `caffe2` linker options.

Test Plan:
Built supernova experimental build, made sure Assistant starts without operator issues.
Tried tts, ocr and asr command in SGR, made sure they work.

Verified that hypernova build doesn't required libforce_dlopen when D50695343 is applied.

Reviewed By: veselinp

Differential Revision: D50870489


