### PR TITLE
[CI] Do not use `packaging` in run_tests.py

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -21,7 +21,6 @@ import pkg_resources
 
 import torch
 import torch.distributed as dist
-from packaging import version
 from torch.multiprocessing import current_process, get_context
 from torch.testing._internal.common_utils import (
     FILE_SCHEMA,
@@ -1375,9 +1374,7 @@ def get_selected_tests(options) -> List[str]:
         options.exclude.extend(DISTRIBUTED_TESTS)
 
     # these tests failing in CUDA 11.6 temporary disabling. issue https://github.com/pytorch/pytorch/issues/75375
-    if torch.version.cuda is not None and version.parse(
-        torch.version.cuda
-    ) >= version.parse("11.6"):
+    if torch.version.cuda is not None:
         options.exclude.extend(["distributions/test_constraints"])
 
     selected_tests = exclude_tests(options.exclude, selected_tests)


### PR DESCRIPTION
It used to check that CUDA is newer than 11.6, but all of them are

Yet another mitigation towards missing `packaging` on MacOS
