### PR TITLE
[pytorch-vulkan] slices to support zero-size output

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Slice.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Slice.cpp
@@ -267,7 +267,6 @@ Tensor slice(
 
   auto len = end_val - start_val;
   newSizes[dim] = (len + step - 1) / step; // round-up
-  TORCH_CHECK(len > 0, "Vulkan doesn't support zero-sized slice");
 
   // generalize into 4D tensor
   uvec4 in_tsize{1u, 1u, 1u, 1u}, out_tsize{1u, 1u, 1u, 1u};

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -19,10 +19,16 @@ namespace {
 #endif
 
 bool checkRtol(const at::Tensor& diff, float maxTolerance) {
+  if (diff.numel() == 0) {
+    return true;
+  }
   return diff.abs().max().item<float>() <= maxTolerance;
 }
 
 bool checkRtol(const at::Tensor& diff, const std::vector<at::Tensor>& inputs) {
+  if (diff.numel() == 0) {
+    return true;
+  }
   float maxValue = 0.0f;
 
   for (const auto& tensor : inputs) {
@@ -167,7 +173,12 @@ static void gen_all_subsets(
   }
 }
 
-static void slice_test(const std::vector<int64_t>& size, int64_t dim, c10::optional<int64_t> start, c10::optional<int64_t> end, int64_t step) {
+static void slice_test(
+    const std::vector<int64_t>& size,
+    int64_t dim,
+    c10::optional<int64_t> start,
+    c10::optional<int64_t> end,
+    int64_t step) {
   // Arrange
   const auto in_cpu = at::rand(size, at::device(at::kCPU).dtype(at::kFloat));
   const auto in_vulkan = in_cpu.vulkan();
@@ -6289,20 +6300,17 @@ TEST_F(VulkanAPITest, slice_batch_success) {
   slice_tests(dim2sizes);
 }
 
+TEST_F(VulkanAPITest, slice_zero_sized) {
+  // When start == end
+  slice_test({2, 3, 4, 5}, 3, 0, 0, 1);
+  // When start > end
+  slice_test({2, 3, 4, 5}, 3, 3, 2, 1);
+}
+
 TEST_F(VulkanAPITest, slice_invalidinputs_exceptions) {
   // Act: slice step must be positive
   EXPECT_THROW({
     slice_test({2, 3, 4, 5}, 3, 0, 3, 0);
-  }, ::c10::Error);
-
-  // Act: Vulkan doesn't support zero-sized slice (when start=end)
-  EXPECT_THROW({
-    slice_test({2, 3, 4, 5}, 3, 0, 0, 1);
-  }, ::c10::Error);
-
-  // Act: Vulkan doesn't support zero-sized slice (when start > end)
-  EXPECT_THROW({
-    slice_test({2, 3, 4, 5}, 3, 3, 2, 1);
   }, ::c10::Error);
 }
 


### PR DESCRIPTION
Summary: With D50030659, we are able to support zero-size tensor. Hence remove the check in slice. Also update related tests.

Test Plan:
```
[yipjustin@189650.od ~/fbsource (876ab81e3)]$ LD_LIBRARY_PATH=third-party/swiftshader/lib/linux-x64/ buck2 run fbcode/mode/dev-nosan    //xplat/caffe2:pt_vulkan_api_test_bin  -- --gtest_filter="*slice*"
File changed: fbsource//xplat/caffe2/aten/src/ATen/test/vulkan_api_test.cpp
File changed: fbcode//caffe2/aten/src/ATen/test/vulkan_api_test.cpp
File changed: fbcode//caffe2/aten/src/ATen/native/vulkan/ops/Slice.cpp
1 additional file change events
Buck UI: https://www.internalfb.com/buck2/85adf6a3-7d17-4685-8d8b-a0b600df0b73
Network: Up: 44KiB  Down: 1.3MiB  (reSessionID-5afd53d4-0303-4f4d-a245-1eb810308fd3)
Jobs completed: 6. Time elapsed: 22.8s.
Cache hits: 0%. Commands: 2 (cached: 0, remote: 1, local: 1)
BUILD SUCCEEDED
Running main() from third-party/googletest/1.11.0/googletest/googletest/src/gtest_main.cc
Note: Google Test filter = *slice*
[==========] Running 6 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 6 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.slice_width_success
[       OK ] VulkanAPITest.slice_width_success (160 ms)
[ RUN      ] VulkanAPITest.slice_height_success
[       OK ] VulkanAPITest.slice_height_success (6 ms)
[ RUN      ] VulkanAPITest.slice_feature_success
[       OK ] VulkanAPITest.slice_feature_success (84 ms)
[ RUN      ] VulkanAPITest.slice_batch_success
[       OK ] VulkanAPITest.slice_batch_success (5 ms)
[ RUN      ] VulkanAPITest.slice_zero_sized
[       OK ] VulkanAPITest.slice_zero_sized (0 ms)
[ RUN      ] VulkanAPITest.slice_invalidinputs_exceptions
[       OK ] VulkanAPITest.slice_invalidinputs_exceptions (0 ms)
[----------] 6 tests from VulkanAPITest (257 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (257 ms total)
[  PASSED  ] 6 tests.
```

Differential Revision: D50961979


