### PR TITLE
Fix default timeouts for python entrypoints (e.g. init_process_group)

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -1220,7 +1220,7 @@ class ProcessGroupNCCLTest(MultiProcessTestCase):
 
         # test the default value coming from the `init_process_group` kwarg default
         dist.init_process_group(**base_opts)
-        _check_nccl_timeout(torch.distributed.distributed_c10d.default_pg_timeout)
+        _check_nccl_timeout(torch.distributed.constants.default_pg_nccl_timeout)
         dist.destroy_process_group()
 
         # test that `kwarg` timeout takes effect
@@ -1238,7 +1238,7 @@ class ProcessGroupNCCLTest(MultiProcessTestCase):
             # TODO(whc) i verified that we are indeed emitting this warning, and i can't figure out why i can't catch it.
             # self.assertEqual(len(w), 1)
             # self.assertTrue("pg_options._timeout was specified" in str(w[-1].message))
-        _check_nccl_timeout(torch.distributed.distributed_c10d.default_pg_timeout)
+        _check_nccl_timeout(torch.distributed.constants.default_pg_nccl_timeout)
         dist.destroy_process_group()
 
 

--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -11,6 +11,7 @@ from torch.futures import Future
 _DEFAULT_FIRST_BUCKET_BYTES: int
 _DEFAULT_NO_TIMEOUT: timedelta
 _DEFAULT_PG_TIMEOUT: timedelta
+_DEFAULT_PG_NCCL_TIMEOUT: timedelta
 
 class BuiltinCommHookType(Enum):
     ALLREDUCE = ...

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -2659,8 +2659,10 @@ Example::
 
   module.attr("_DEFAULT_FIRST_BUCKET_BYTES") = ::c10d::kDefaultFirstBucketBytes;
   module.attr("_DEFAULT_PG_TIMEOUT") = py::cast(kProcessGroupDefaultTimeout);
+#ifdef USE_C10D_NCCL
   module.attr("_DEFAULT_PG_NCCL_TIMEOUT") =
       py::cast(::c10d::kProcessGroupNCCLDefaultTimeout);
+#endif
   module.attr("_DEFAULT_NO_TIMEOUT") = py::cast(kNoTimeout);
 
   module.def(

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -2659,6 +2659,8 @@ Example::
 
   module.attr("_DEFAULT_FIRST_BUCKET_BYTES") = ::c10d::kDefaultFirstBucketBytes;
   module.attr("_DEFAULT_PG_TIMEOUT") = py::cast(kProcessGroupDefaultTimeout);
+  module.attr("_DEFAULT_PG_NCCL_TIMEOUT") =
+      py::cast(::c10d::kProcessGroupNCCLDefaultTimeout);
   module.attr("_DEFAULT_NO_TIMEOUT") = py::cast(kNoTimeout);
 
   module.def(

--- a/torch/distributed/constants.py
+++ b/torch/distributed/constants.py
@@ -1,6 +1,9 @@
 from torch._C._distributed_c10d import _DEFAULT_PG_TIMEOUT
 from datetime import timedelta
 from typing import Optional
+
+__all__ = ['default_pg_timeout', 'default_pg_nccl_timeout']
+
 # Default process group wide timeout, if applicable.
 # This only applies to the non-nccl backends
 # To make an attempt at backwards compatibility with THD, we use an
@@ -10,6 +13,7 @@ default_pg_timeout: timedelta = _DEFAULT_PG_TIMEOUT
 # there was one default that applied across all backends in the python layer.
 # Later, we could consider merging them back together at the c++ layer if we can align on a same value.
 # (only if NCCL_BLOCKING_WAIT or NCCL_ASYNC_ERROR_HANDLING is set to 1).
+
 try:
     from torch._C._distributed_c10d import _DEFAULT_PG_NCCL_TIMEOUT
     default_pg_nccl_timeout: Optional[timedelta] = _DEFAULT_PG_NCCL_TIMEOUT

--- a/torch/distributed/constants.py
+++ b/torch/distributed/constants.py
@@ -1,11 +1,19 @@
-from torch._C._distributed_c10d import _DEFAULT_PG_TIMEOUT, _DEFAULT_PG_NCCL_TIMEOUT
+from torch._C._distributed_c10d import _DEFAULT_PG_TIMEOUT
+from datetime import timedelta
+from typing import Optional
 # Default process group wide timeout, if applicable.
 # This only applies to the non-nccl backends
 # To make an attempt at backwards compatibility with THD, we use an
 # extraordinarily high default timeout, given that THD did not have timeouts.
-default_pg_timeout = _DEFAULT_PG_TIMEOUT
+default_pg_timeout: timedelta = _DEFAULT_PG_TIMEOUT
 # Separate timeout for PGNCCL mainly becuase it's always been that way in the C++ layer, but until recently
 # there was one default that applied across all backends in the python layer.
 # Later, we could consider merging them back together at the c++ layer if we can align on a same value.
 # (only if NCCL_BLOCKING_WAIT or NCCL_ASYNC_ERROR_HANDLING is set to 1).
-default_pg_nccl_timeout = _DEFAULT_PG_NCCL_TIMEOUT
+try:
+    from torch._C._distributed_c10d import _DEFAULT_PG_NCCL_TIMEOUT
+    default_pg_nccl_timeout: Optional[timedelta] = _DEFAULT_PG_NCCL_TIMEOUT
+except ImportError:
+    # if C++ NCCL support is not compiled, we don't have access to the default nccl value.
+    # if anyone is actually trying to use nccl in this state, it should error.
+    default_pg_nccl_timeout = None

--- a/torch/distributed/constants.py
+++ b/torch/distributed/constants.py
@@ -1,7 +1,11 @@
-from torch._C._distributed_c10d import _DEFAULT_PG_TIMEOUT
+from torch._C._distributed_c10d import _DEFAULT_PG_TIMEOUT, _DEFAULT_PG_NCCL_TIMEOUT
 # Default process group wide timeout, if applicable.
-# This only applies to the gloo and nccl backends
-# (only if NCCL_BLOCKING_WAIT or NCCL_ASYNC_ERROR_HANDLING is set to 1).
+# This only applies to the non-nccl backends
 # To make an attempt at backwards compatibility with THD, we use an
 # extraordinarily high default timeout, given that THD did not have timeouts.
 default_pg_timeout = _DEFAULT_PG_TIMEOUT
+# Separate timeout for PGNCCL mainly becuase it's always been that way in the C++ layer, but until recently
+# there was one default that applied across all backends in the python layer.
+# Later, we could consider merging them back together at the c++ layer if we can align on a same value.
+# (only if NCCL_BLOCKING_WAIT or NCCL_ASYNC_ERROR_HANDLING is set to 1).
+default_pg_nccl_timeout = _DEFAULT_PG_NCCL_TIMEOUT

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -586,7 +586,7 @@ def _get_default_timeout(backend: Backend) -> timedelta:
 def _check_valid_timeout(timeout: Any) -> None:
     if not isinstance(timeout, timedelta):
         raise TypeError(
-            "Expected timeout argument to be of type datetime.timedelta"
+            f"Expected timeout argument to be of type datetime.timedelta, got {timeout}"
         )
 
 # Default process group state
@@ -3790,6 +3790,14 @@ def monitored_barrier(group=GroupMember.WORLD, timeout=None, wait_all_ranks=Fals
 
     if timeout is None:
         timeout = _get_default_timeout(get_backend(group))
+    elif isinstance(timeout, float):
+        # TODO(whc) aparently some existing test case for monitored_barrier passes in a timeout in float format?
+        warnings.warn(
+            "Please specify timeout arg as a timedelta. "
+            f"Converting current value of {timeout} assuming it represents seconds",
+        )
+        timeout = timedelta(seconds=timeout)
+
     _check_valid_timeout(timeout)
 
     group_to_use = _get_default_group() if group is None else group


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #113044
* __->__ #112893
* #112803
* #112611

Previous PRs changed the c++ default timeout for PGNccl, but this path
was only hit in some cases, and the python defaults took over in other
cases.

This PR ensures that NCCL pg always default to the changed NCCL-specific
timeout value.