### PR TITLE
[PyTorch][Vulkan] Add `LayerNorm` performance test binary

### DIFF
--- a/aten/src/ATen/test/vulkan_layernorm_perf_test.cpp
+++ b/aten/src/ATen/test/vulkan_layernorm_perf_test.cpp
@@ -1,0 +1,133 @@
+#include <unordered_map>
+#ifdef USE_VULKAN_API
+
+#include <benchmark/benchmark.h>
+
+#include <ATen/ATen.h>
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <ATen/native/vulkan/api/api.h>
+#include <ATen/native/vulkan/ops/Common.h>
+#include <ATen/native/vulkan/ops/Copy.h>
+#include <ATen/native/vulkan/ops/Factory.h>
+#include <ATen/native/vulkan/ops/QuantizedFunctions.h>
+#include <ATen/native/vulkan/ops/Utils.h>
+
+namespace {
+
+#if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+static const float NANOSECONDS_IN_SECOND = 1000000000.0;
+#endif
+
+template <class... Inputs>
+inline std::vector<c10::IValue> makeStack(Inputs&&... inputs) {
+  return {std::forward<Inputs>(inputs)...};
+}
+
+template <class... Args>
+inline std::vector<c10::IValue> callOpByHandle(
+    const c10::OperatorHandle& op,
+    Args... args) {
+  auto stack = makeStack(std::forward<Args>(args)...);
+  c10::Dispatcher::singleton().callBoxed(op, &stack);
+  return stack;
+}
+
+template <class... Args>
+inline std::vector<c10::IValue> callOpByName(
+    const char* func_name,
+    const char* overload_name,
+    Args... args) {
+  const c10::optional<c10::OperatorHandle> op_handle =
+      c10::Dispatcher::singleton().findSchema({func_name, overload_name});
+  assert(op_handle.has_value());
+  return callOpByHandle(op_handle.value(), std::forward<Args>(args)...);
+}
+
+static void CommonMMBenchmarkSettings(benchmark::internal::Benchmark* b) {
+  b->Unit(benchmark::kMillisecond);
+  b->ArgNames({"N", "M", "P"});
+}
+#if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+// This function aggregate the latency of all invoked shaders except
+// `vulkan.nchw_to_image` and `vulkan.image_to_nchw`, which are moving data
+// between CPU and GPU memory.
+static void extractTotalShaderResultsAndSetState(benchmark::State& state) {
+  at::native::vulkan::api::context()->querypool().extract_results();
+
+  uint64_t sum_shader_latency_in_nanoseconds = 0;
+  auto result_aggregator =
+      [&sum_shader_latency_in_nanoseconds](
+          const at::native::vulkan::api::ShaderDuration& s) {
+        if (s.kernel_name != "vulkan.nchw_to_image" &&
+            s.kernel_name != "vulkan.image_to_nchw") {
+          sum_shader_latency_in_nanoseconds += s.execution_duration_ns;
+        }
+      };
+  at::native::vulkan::api::context()->querypool().shader_log_for_each(
+      result_aggregator);
+
+  float sum_shader_latency_in_seconds =
+      sum_shader_latency_in_nanoseconds / NANOSECONDS_IN_SECOND;
+  state.SetIterationTime(sum_shader_latency_in_seconds);
+}
+#endif
+
+static void layer_norm_benchmark(benchmark::State& state) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+#if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  at::native::vulkan::api::context()->enable_op_profiling();
+  at::native::vulkan::api::context()->reset_querypool();
+#endif
+
+  c10::InferenceMode mode;
+
+  // Arrange
+  const auto c = state.range(0);
+  const auto h = state.range(1);
+  const auto w = state.range(2);
+
+  const auto in_cpu =
+      at::rand({c, h, w}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_vulkan = in_cpu.vulkan();
+
+  const auto weight_cpu =
+      at::rand({c, h, w}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto weight_vulkan = weight_cpu.vulkan();
+
+  const auto bias_cpu =
+      at::rand({c, h, w}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto bias_vulkan = bias_cpu.vulkan();
+
+  // Act
+  for (auto _ : state) {
+    const auto vulkan_out =
+        at::layer_norm(
+            in_vulkan, {c, h, w}, weight_vulkan, bias_vulkan, 1e-05, false)
+            .cpu();
+  }
+#if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  extractTotalShaderResultsAndSetState(state);
+  at::native::vulkan::api::context()->querypool().print_results();
+#endif
+}
+
+} // namespace
+
+const uint32_t BENCHMARK_MM_N = 75;
+const uint32_t BENCHMARK_MM_M = 75;
+const uint32_t BENCHMARK_MM_P = 75;
+const uint32_t BENCHMARK_ITERATIONS = 50;
+
+BENCHMARK(layer_norm_benchmark)
+    ->Apply(CommonMMBenchmarkSettings)
+    ->UseManualTime()
+    ->Threads(1)
+    ->Iterations(BENCHMARK_ITERATIONS)
+    ->Args({BENCHMARK_MM_N, BENCHMARK_MM_M, BENCHMARK_MM_P});
+
+BENCHMARK_MAIN();
+
+#endif /* USE_VULKAN_API */


### PR DESCRIPTION
Summary:
We add a performance test binary for the recently implemented operator `LayerNorm` D50436726. The difference of this test compared to the existing `vulkan_conv_arithmetic_perf_test.cpp` and `vulkan_mm_perf_test.cpp` is that
- the existing tests benchmark a specific Vulkan shader such as `vulkan.mm`, `vulkan.addmm`, etc
- but `LayerNorm` is implemented by invoking [a sequence of other operators (shader files)](https://www.internalfb.com/code/fbsource/[ff4989384cacda66a2eed4c800f69c69f6832c52]/fbcode/caffe2/aten/src/ATen/native/vulkan/ops/Layernorm.cpp?lines=94) instead of a devoted single shader file. Reusing the exiting test code wouldn't print meaningful result.

To deal with this, we add a function `extractTotalShaderResultsAndSetState` which aggregates the latency of all invoked shaders except `nchw_to_image` and `image_to_nchw`. This test can be applied to other operators which don't have a devoted shader file.

Test Plan:
- build the binary
```
(base) luwei@luwei-mbp fbsource % buck2 build  -c ndk.debug_info_level=0  -c ndk.static_linking=true -c pt.enable_qpl=0 -c pt.vulkan_use_gpu_diagnostics=1 --target-platforms=ovr_config//platform/android:arm32-fbsource //xplat/caffe2:pt_vulkan_layernorm_perf_test_binAndroid  --show-output  -c pt.vulkan_full_precision=1
```
- push to device
```
(base) luwei@luwei-mbp fbsource % adb push buck-out/v2/gen/fbsource/f1f3f9bed27e143c/xplat/caffe2/__pt_vulkan_layernorm_perf_test_binAndroid__/pt_vulkan_layernorm_perf_test_binAndroid /data/local/tmp
```
- test on device
```
(base) luwei@luwei-mbp ~ % adb shell /data/local/tmp/pt_vulkan_layernorm_perf_test_binAndroid
```
- output, excerpt below, full test result in P871803721
**it shows that the aggregation of invoked shaders takes 14.2 ms on average**
```
Kernel Name              Workgroup Size             Duration (ns)
===========              ==============               ===========
vulkan.nchw_to_image     {75, 75, 19}                     1310660
vulkan.nchw_to_image     {75, 75, 19}                     1313260
vulkan.nchw_to_image     {75, 75, 19}                     1268748
vulkan.mean_dim_keepdim  {1, 75, 19}                       878124
vulkan.mean_dim_keepdim  {1, 1, 19}                         53300
vulkan.mean_dim_keepdim  {1, 1, 1}                          62660
vulkan.mean_dim_keepdim  {1, 75, 19}                       871260
vulkan.mean_dim_keepdim  {1, 1, 19}                         53144
vulkan.mean_dim_keepdim  {1, 1, 1}                          62400
vulkan.sub               {75, 75, 19}                     1787760
vulkan.mul               {75, 75, 19}                     1866904
vulkan.mean_dim_keepdim  {1, 75, 19}                       868764
vulkan.mean_dim_keepdim  {1, 1, 19}                         56212
vulkan.mean_dim_keepdim  {1, 1, 1}                          62400
vulkan.sub               {75, 75, 19}                     1782872
vulkan.add_scalar        {1, 1, 1}                           2028
vulkan.pow_tensor_scalar {1, 1, 1}                           2236
vulkan.mul               {75, 75, 19}                     1771276
...
vulkan.add               {75, 75, 19}                     1909544
vulkan.image_to_nchw     {75, 75, 19}                     1143844
------------------------------------------------------------------------------------------------------------------
Benchmark                                                                        Time             CPU   Iterations
------------------------------------------------------------------------------------------------------------------
layer_norm_benchmark/N:75/M:75/P:75/iterations:50/manual_time/threads:1       14.2 ms         48.9 ms           50
```

Reviewed By: yipjustin

Differential Revision: D50940613


