### PR TITLE
[dynamo] Remove checkpoint in GenericContextManager

### DIFF
--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -114,9 +114,7 @@ class GenericContextWrappingVariable(ContextWrappingVariable):
                 f"Unsupported context manager {self.cm_obj}'s __exit__ function"
             ) from e
 
-        # Remove the checkpoint if there is no graph break
-        # under this GenericContextWrappingVariable.
-        tx.states_before_block.pop()
+        tx.generic_context_manager_depth -= 1
         return x
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #112962
* #112961
* #111726
* #111725
* #111415
* #111717
* #111306
* #112921
* #112902
* #112939
* #112899
* __->__ #112920
* #112898
* #112897

Checkpointing here is pointless since we just call `unimplemented()`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng