### PR TITLE
Make `test_distributed_spawn.py` tell you how to run it correctly

### DIFF
--- a/test/distributed/test_distributed_spawn.py
+++ b/test/distributed/test_distributed_spawn.py
@@ -34,14 +34,13 @@ if (
     or not path.exists(path.join(os.environ["TEMP_DIR"], "barrier"))
 ):
     # TODO can we actually have `run_tests.py` emit the complete instructions when it prints a repro command?
-    print(
+    raise RuntimeError(
         "Missing expected env vars for `test_distributed_spawn.py`.  Please ensure to specify the following:\n"
         f"'BACKEND' = one of {_allowed_backends}\n"
         f"'WORLD_SIZE' = int >= 2\n"
         "'TEMP_DIR' specifying a directory containing a barrier file named 'barrier'.\n\n"
         f"e.g.\ntouch /tmp/barrier && TEMP_DIR=/tmp BACKEND='nccl' WORLD_SIZE=2 python {__file__}",
     )
-    sys.exit(0)
 
 BACKEND = os.environ["BACKEND"]
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #112924

Sample output if incorrect/missing args are specified:

```
RuntimeError: Missing expected env vars for `test_distributed_spawn.py`.  Please
ensure to specify the following:
'BACKEND' = one of ('gloo', 'nccl', 'ucc')
'WORLD_SIZE' = int >= 2
'TEMP_DIR' specifying a directory containing a barrier file named
'barrier'.

e.g.
touch /tmp/barrier && TEMP_DIR=/tmp BACKEND='nccl' WORLD_SIZE=2 python
/data/users/whc/pytorch/test/distributed/test_distributed_spawn.py
```