### PR TITLE
[dynamo] `resume_at` `SETUP_FINALLY`'s jump forward target

### DIFF
--- a/test/dynamo/test_compile.py
+++ b/test/dynamo/test_compile.py
@@ -136,6 +136,7 @@ class ResumeAfterRegionTests(DynamoTestCase):
                     raise AssertionError()
                 except AssertionError:
                     x += 4
+                raise AssertionError()
             except AssertionError:
                 x += 5
             # Should resume at here

--- a/test/dynamo/test_compile.py
+++ b/test/dynamo/test_compile.py
@@ -131,6 +131,7 @@ class ResumeAfterRegionTests(DynamoTestCase):
             x = x + 1
             # Should fallback on eager here
             try:
+                # How can we trace here too?
                 x += 3
                 try:
                     raise AssertionError()

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -757,7 +757,7 @@ class InstructionTranslatorBase(Checkpointable[InstructionTranslatorGraphState])
             reason=GraphCompileReason("step_unsupported", [self.frame_summary()]),
         )
         # The reason why we fail is due to non-restorable block stack entries.
-        # If a jump target in its unwind/cleanup block exits, resume at the jump target.
+        # If a jump target in its unwind/cleanup block exists, resume at the jump target.
         if last_jump_forward:
             target_index = None
             for idx, instruction in enumerate(self.instructions):

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -729,7 +729,7 @@ class InstructionTranslatorBase(Checkpointable[InstructionTranslatorGraphState])
 
             log.debug("step triggered compile", exc_info=True)
 
-        # generate code from checkpoint
+        # generate code from checkpoint 
         assert not self.output.output_instructions
         assert self.checkpoint is not None
         continue_inst, state = self.checkpoint
@@ -738,10 +738,10 @@ class InstructionTranslatorBase(Checkpointable[InstructionTranslatorGraphState])
             (entry for entry in reversed(self.block_stack) if not entry.can_restore()),
             None,
         )
+        last_jump_forward = None
         if cannot_restore_entry and not self.one_graph:
             cannot_restore_target = cannot_restore_entry.target
             insts = self.instructions[self.instruction_pointer :]
-            last_jump_forward = None
             in_active_region = False
             for inst in insts:
                 if inst == cannot_restore_target:

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -735,7 +735,8 @@ class InstructionTranslatorBase(Checkpointable[InstructionTranslatorGraphState])
         continue_inst, state = self.checkpoint
 
         cannot_restore_entry = next(
-            entry for entry in reversed(self.block_stack) if not entry.can_restore()
+            (entry for entry in reversed(self.block_stack) if not entry.can_restore()),
+            None,
         )
         if cannot_restore_entry:
             cannot_restore_target = cannot_restore_entry.target


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/112865

When graph breaking within a try-except block, we create a call to resume at that can be traced - at the continue execution target of the lowest non-restorable block stack entry in the block stack.

This manages to compile _any_ compilable code that is outside of try-except blocks.

We leave compiling within nested try-excepts as future work. As long as we can restore the try-except stack, this is probably possible.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng