### PR TITLE
[DeviceMesh] Remove _validate_mesh from device_mesh.py

### DIFF
--- a/test/distributed/_tensor/test_dtensor.py
+++ b/test/distributed/_tensor/test_dtensor.py
@@ -311,9 +311,7 @@ class DTensorTest(DTensorTestBase):
         # we haven't synced the collective yet).
         from torch.distributed._functional_collectives_impl import _tensor_needs_wait
 
-        mesh = DeviceMesh(
-            self.device_type, torch.arange(self.world_size), _validate_mesh=False
-        )
+        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
 
         def fn(dt):
             dt_out_redistribute = dt.redistribute(mesh, [Replicate()])

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -109,26 +109,6 @@ class DeviceMeshTest(DTensorTestBase):
         )
         self.assertEqual(global_tensor.shape, (self.world_size * 2, 8))
 
-    @with_comms
-    def test_validate_device_mesh(self):
-        mesh = torch.arange(self.world_size).reshape(2, -1)
-        mesh_subpg_1 = mesh[0]
-        mesh_subpg_2 = mesh[1]
-        with self.assertRaisesRegex(RuntimeError, "different mesh"):
-            if self.rank in mesh_subpg_1:
-                mesh = DeviceMesh(self.device_type, mesh_subpg_1)
-            else:
-                mesh = DeviceMesh(self.device_type, mesh_subpg_2)
-
-        mesh_non_contiguous = (
-            torch.arange(0, self.world_size).view(2, 2).transpose(0, 1)
-        )
-        device_mesh = DeviceMesh(
-            self.device_type, mesh_non_contiguous, mesh_dim_names=("dp", "mp")
-        )
-        self.assertEqual(device_mesh.size(0), 2)
-        self.assertEqual(device_mesh.size(1), 2)
-
 
 class DeviceMeshTestNDim(DTensorTestBase):
     @property

--- a/torch/distributed/_device_mesh.py
+++ b/torch/distributed/_device_mesh.py
@@ -4,7 +4,6 @@ import math
 from typing import Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import torch
-import torch.distributed._functional_collectives as funcol
 
 from torch.distributed.distributed_c10d import (
     _find_pg_by_ranks_and_tag,
@@ -124,6 +123,13 @@ class DeviceMesh:
     DTensor implementation.
 
     DeviceMesh can be used as a context manager.
+
+    .. note::
+        DeviceMesh follows SPMD programming model, which means the same PyTorch Python program
+        is running on all processes/ranks in the cluster. Therefore, users need to make sure the
+        `mesh` array (which describes the layout of devices) should be identical across all ranks.
+        Inconsistent `mesh` will lead to silent hang.
+
     Args:
         device_type (str): device type of the mesh. Currently supports: cpu, cuda/cuda-like.
         mesh (ndarray): could be a multi-dimension array or an integer tensor that
@@ -161,7 +167,6 @@ class DeviceMesh:
         *,
         mesh_dim_names: Optional[Tuple[str, ...]] = None,
         _init_process_groups: bool = True,
-        _validate_mesh: bool = True,
     ) -> None:
         self.device_type = device_type
         self.mesh = (
@@ -183,7 +188,7 @@ class DeviceMesh:
             # process (we need to know if the current global rank is in the mesh or not).
             self._get_or_create_default_group()
             if _init_process_groups:
-                self._init_process_groups(_validate_mesh)
+                self._init_process_groups()
 
     def _get_or_create_default_group(self):
         default_initialized = is_initialized()
@@ -220,32 +225,7 @@ class DeviceMesh:
         )
         return _get_default_group()
 
-    def _validate_mesh(self):
-        # check mesh tensor validity
-        unique_mesh_values = self.mesh.unique(sorted=True)
-        if unique_mesh_values.numel() != self.mesh.numel():
-            raise RuntimeError(
-                f"DeviceMesh cannot have duplicate values, but found {self.mesh.tolist()}"
-            )
-
-        # validate that all calling ranks pass in the same `mesh` argument.
-        self_mesh = self.mesh.to(self.device_type).contiguous()
-        mesh_tensor = funcol.all_gather_tensor(
-            self_mesh, gather_dim=0, group=_get_default_group()
-        )
-        mesh_tensor_chunked = torch.chunk(mesh_tensor, get_world_size())
-        for other_rank, other_mesh in enumerate(mesh_tensor_chunked):
-            if not torch.equal(self_mesh, other_mesh):
-                raise RuntimeError(
-                    f"DeviceMesh initialization does not allow different mesh argument:"
-                    f"rank {get_rank()} has mesh {self_mesh} while rank {other_rank}"
-                    f"has mesh {other_mesh}!"
-                )
-
-    def _init_process_groups(self, _validate_mesh):
-        if _validate_mesh:
-            self._validate_mesh()
-
+    def _init_process_groups(self):
         # group tag/ranks associated with each mesh dimension, each mesh dimension should
         # have one sub-group per rank
         dim_group_infos: List[Tuple[str, List[int]]] = []
@@ -408,10 +388,15 @@ def init_device_mesh(
     and ith dimension being in size mesh_shape[i]. If mesh_dim_names is provided, each dimension is
     labeled as mesh_dim_names[i].
 
+    .. note::
+        `init_device_mesh` follows SPMD programming model, which means the same PyTorch Python program
+        is running on all processes/ranks in the cluster. Therefore, users need to make sure the `mesh_shape`
+        tuple (the dimension of the nD array that describes the layout of devices) should be identical across
+        all ranks. Inconsistent `mesh_shape` will lead to silent hang.
 
     Args:
         device_type (str): device type of the mesh. Currently supports: cpu, cuda/cuda-like.
-        mesh_shape: Tuple[int]: A tuple describes the dimension of the multi-dimesnion array
+        mesh_shape: Tuple[int]: A tuple defines the dimension of the multi-dimesnion array
         that describes the layout of devices.
     Kwargs:
         mesh_dim_names: Optional[Tuple[str]]: A tuple of mesh dim names to be assigned to each dimension


### PR DESCRIPTION
Plan B for https://github.com/pytorch/pytorch/pull/112839

Motivation for the change:
1. We need to remove `funcol` as a dependency for device_mesh.py to resolve circular dependency issues when introducing device_mesh as an arg for DDP. In the meantime, we should not go from funcol to non-funcol as @voznesenskym suggested. Therefore, we want to remove this all_gather check completely. 
2. For large scale, it would not make sense to validate the mesh at global scale anyway. 