### PR TITLE
[PyTorch FX] ProxyableClassMeta  skip map_aggregate if not is_fx_tracing

### DIFF
--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -98,6 +98,10 @@ class ProxyableClassMeta(type):
     def __call__(cls, *args, **kwargs):
         instance = cls.__new__(cls)  # type: ignore[call-overload]
 
+        if not is_fx_tracing():
+            cls.__init__(instance, *args, **kwargs)  # type: ignore[misc]
+            return instance
+
         found_proxies = []
 
         def check_proxy(a):


### PR DESCRIPTION
Summary: TorchRec KJT (https://fburl.com/code/yoaqqsgi) and LazyAwaitable (https://fburl.com/code/4bygm7tg) inherits ProxyableClassMeta in order to make torchrec model fx traceble. The issue is that even when is not fx tracing, it still triggers this `map_aggregate(args, check_proxy)` https://fburl.com/code/mpbmjsqw, which will iterate every inputs to KJT and flatten the list/dict to run a function on every element. It's super slow if the len(list) is large. This diff is to skip the map_aggregate when it's not fx tracing.

Test Plan:
#facebook
# before: [trace](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/traces/dynocli/devgpu021.odn1.facebook.com/rank-0.Nov_03_16_56_11.243575.pt.trace.json.gz&bucket=aps_traces)
move_id_list features takes ~80ms when profiling with stack, most of the time is `map_aggregate`

{F1140039564}

# after: [trace](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/traces/dynocli/devgpu021.odn1.facebook.com/rank-0.Nov_03_16_27_50.3617247.pt.trace.json.gz&bucket=aps_traces)

now it's less than 3ms, no `map_aggregate`
 {F1140038095}

Differential Revision: D50994285


