### PR TITLE
[pytorch-vulkan] Disable failing test on vulkan_api_test

### DIFF
--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -1682,7 +1682,41 @@ TEST_F(VulkanAPITest, conv2d_pw) {
   ASSERT_TRUE(check);
 }
 
-TEST_F(VulkanAPITest, conv2d_pw_prepack) {
+TEST_F(VulkanAPITest, conv2d_pw_prepack_medium) {
+  int in_channels = 17;
+  int out_channels = 29;
+  int height = 27;
+  int width = 39;
+  test_conv2d_context(
+    {1, in_channels, height, width},  // input_shape
+    {out_channels, in_channels, 1, 1},     // weight_shape
+    {out_channels},               // bias_shape
+    {1, 1},             // stride
+    {0, 0},             // padding
+    {1, 1},             // dilation
+    1);                 // groups
+}
+
+TEST_F(VulkanAPITest, conv2d_pw_prepack_bc_medium) {
+  int in_channels = 17;
+  int out_channels = 29;
+  int height = 27;
+  int width = 39;
+  test_backwards_compatible_conv2d_context(
+    {1, in_channels, height, width},  // input_shape
+    {out_channels, in_channels, 1, 1},     // weight_shape
+    {out_channels},               // bias_shape
+    {1, 1},             // stride
+    {0, 0},             // padding
+    {1, 1},             // dilation
+    1);                 // groups
+}
+
+// The followin 2 tests failed on Meta's CI when all tests are executed.  Output
+// has lots of nan. Cause unknown.
+// When this test is run alone (with gtest_filter), it passes.
+// The test also passes with smaller planes, see "conv2d_pw_prepack_medium".
+TEST_F(VulkanAPITest, DISABLED_conv2d_pw_prepack) {
   test_conv2d_context(
     {1, 17, 127, 397},  // input_shape
     {29, 17, 1, 1},     // weight_shape
@@ -1693,7 +1727,7 @@ TEST_F(VulkanAPITest, conv2d_pw_prepack) {
     1);                 // groups
 }
 
-TEST_F(VulkanAPITest, conv2d_pw_prepack_bc) {
+TEST_F(VulkanAPITest, DISABLED_conv2d_pw_prepack_bc) {
   test_backwards_compatible_conv2d_context(
     {1, 17, 127, 397},  // input_shape
     {29, 17, 1, 1},     // weight_shape


### PR DESCRIPTION
Summary:
`conv2d_pw_prepack` and `conv2d_pw_prepack_bc` has been broken for a long time on Meta's CI.

Cause unknown yet. The tests passes with a smaller input.

Hence disable the large test, and enable test with a smaller tensor.

Test Plan:
Devserver:

```
 LD_LIBRARY_PATH=third-party/swiftshader/lib/linux-x64/ buck2 run fbcode/mode/dev-nosan    //xplat/caffe2:pt_vulkan_api_test_bin  -- --gtest_filter="*"
```

Output: P872944689

```
...
[       OK ] VulkanAPITest.linear_4d_small (0 ms)
[ RUN      ] VulkanAPITest.linear_4d_large
[       OK ] VulkanAPITest.linear_4d_large (2 ms)
[ RUN      ] VulkanAPITest.lstm_success
[       OK ] VulkanAPITest.lstm_success (7 ms)
[ RUN      ] VulkanAPITest.lstm_mclareninputs_success
[       OK ] VulkanAPITest.lstm_mclareninputs_success (39 ms)
[ RUN      ] VulkanAPITest.lstm_prepack_success
[       OK ] VulkanAPITest.lstm_prepack_success (3 ms)
[ RUN      ] VulkanAPITest.querypool_flushed_shader_log
xplat/caffe2/aten/src/ATen/test/vulkan_api_test.cpp:7627: Skipped
QueryPool is not available
[  SKIPPED ] VulkanAPITest.querypool_flushed_shader_log (0 ms)
[----------] 396 tests from VulkanAPITest (23847 ms total)
[----------] Global test environment tear-down
[==========] 396 tests from 1 test suite ran. (23847 ms total)
[  PASSED  ] 395 tests.
[  SKIPPED ] 1 test, listed below:
[  SKIPPED ] VulkanAPITest.querypool_flushed_shader_log
  YOU HAVE 9 DISABLED TESTS
```

Differential Revision: D50997218


