### PR TITLE
Quantized max pool 2d

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/quantized_max_pool2d_qint8.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_max_pool2d_qint8.glsl
@@ -1,0 +1,50 @@
+#version 450 core
+#define PRECISION $precision
+#define FORMAT    $format
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, rgba8i) uniform PRECISION restrict writeonly iimage3D   uOutput;
+layout(set = 0, binding = 1)         uniform PRECISION                    isampler3D uInput; // Quantized input
+layout(set = 0, binding = 2)         uniform PRECISION restrict           Block {
+  ivec4 size;
+  ivec4 kernel;
+  ivec2 stride;
+  ivec2 padding;
+  ivec2 dilate;
+  vec2 scale;
+  ivec2 zero_point;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+#define FLT_MIN -3.402823466e+38
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (all(lessThan(pos, uBlock.size.xyz))) {
+    const ivec2 ipos = pos.xy * uBlock.stride - uBlock.padding;
+
+    const ivec2 start = ipos;
+    const ivec2 end = ipos + uBlock.kernel.xy * uBlock.dilate.xy;
+
+    vec4 outtex = vec4(FLT_MIN);
+
+    for (int y = start.y; y < end.y; y += uBlock.dilate.y) {
+      for (int x = start.x; x < end.x; x += uBlock.dilate.x) {
+        if ((x >= 0 && x < uBlock.kernel.z) && (y >= 0 && y < uBlock.kernel.w)) {
+          vec4 outtexy = texelFetch(uInput, ivec3(x, y, pos.z), 0);
+          outtexy = uBlock.scale.x * (outtexy - uBlock.zero_point.x);
+          outtex = max(outtexy, outtex);
+        }
+      }
+    }
+
+    outtex = roundEven(outtex / uBlock.scale.x) + uBlock.zero_point.x;
+    ivec4 store = ivec4(outtex);
+    imageStore(uOutput, pos, store);
+  }
+}

--- a/aten/src/ATen/native/vulkan/glsl/quantized_max_pool2d_quint8.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_max_pool2d_quint8.glsl
@@ -1,0 +1,50 @@
+#version 450 core
+#define PRECISION $precision
+#define FORMAT    $format
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, rgba8ui) uniform PRECISION restrict writeonly uimage3D   uOutput;
+layout(set = 0, binding = 1)         uniform PRECISION                    isampler3D uInput; // Quantized input
+layout(set = 0, binding = 2)         uniform PRECISION restrict           Block {
+  ivec4 size;
+  ivec4 kernel;
+  ivec2 stride;
+  ivec2 padding;
+  ivec2 dilate;
+  vec2 scale;
+  ivec2 zero_point;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+#define FLT_MIN -3.402823466e+38
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (all(lessThan(pos, uBlock.size.xyz))) {
+    const ivec2 ipos = pos.xy * uBlock.stride - uBlock.padding;
+
+    const ivec2 start = ipos;
+    const ivec2 end = ipos + uBlock.kernel.xy * uBlock.dilate.xy;
+
+    vec4 outtex = vec4(FLT_MIN);
+
+    for (int y = start.y; y < end.y; y += uBlock.dilate.y) {
+      for (int x = start.x; x < end.x; x += uBlock.dilate.x) {
+        if ((x >= 0 && x < uBlock.kernel.z) && (y >= 0 && y < uBlock.kernel.w)) {
+          vec4 outtexy = texelFetch(uInput, ivec3(x, y, pos.z), 0);
+          outtexy = uBlock.scale.x * (outtexy - uBlock.zero_point.x);
+          outtex = max(outtexy, outtex);
+        }
+      }
+    }
+
+    outtex = roundEven(outtex / uBlock.scale.x) + uBlock.zero_point.x;
+    uvec4 store = uvec4(outtex);
+    imageStore(uOutput, pos, store);
+  }
+}

--- a/aten/src/ATen/native/vulkan/ops/Pool.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Pool.cpp
@@ -161,39 +161,91 @@ Tensor pool2d(
       },
       self_arg.scalar_type(),
   };
+  if (v_self.is_quantized()) {
+    v_output.set_is_quantized();
+    v_output.set_scale(v_self.get_scale());
+    v_output.set_zero_point(v_self.get_zero_point());
+  }
 
-  const struct Block final {
-    uvec3 extents;
-    int32_t range;
-    ivec4 kernel;
-    ivec2 stride;
-    ivec2 padding;
-    ivec2 dilation;
-  } block{
-      v_output.extents(),
-      safe_downcast<int32_t>(
-          kernel[Layout::Parameter::width] * kernel[Layout::Parameter::height]),
-      {
-          safe_downcast<int32_t>(kernel[Layout::Parameter::width]),
-          safe_downcast<int32_t>(kernel[Layout::Parameter::height]),
-          safe_downcast<int32_t>(self_arg.size(Layout::Activation4D::width)),
-          safe_downcast<int32_t>(self_arg.size(Layout::Activation4D::height)),
-      },
-      {
-          safe_downcast<int32_t>(stride[Layout::Parameter::width]),
-          safe_downcast<int32_t>(stride[Layout::Parameter::height]),
-      },
-      {
-          safe_downcast<int32_t>(padding[Layout::Parameter::width]),
-          safe_downcast<int32_t>(padding[Layout::Parameter::height]),
-      },
-      {
-          safe_downcast<int32_t>(dilation[Layout::Parameter::width]),
-          safe_downcast<int32_t>(dilation[Layout::Parameter::height]),
-      },
-  };
+  api::UniformParamsBuffer params;
+  if (v_self.is_quantized()) {
+    const struct Block final {
+      uvec3 extents;
+      int32_t range;
+      ivec4 kernel;
+      ivec2 stride;
+      ivec2 padding;
+      ivec2 dilation;
+      vec2 scale;
+      ivec2 zero_point;
+    } block{
+        v_output.extents(),
+        safe_downcast<int32_t>(
+            kernel[Layout::Parameter::width] *
+            kernel[Layout::Parameter::height]),
+        {
+            safe_downcast<int32_t>(kernel[Layout::Parameter::width]),
+            safe_downcast<int32_t>(kernel[Layout::Parameter::height]),
+            safe_downcast<int32_t>(self_arg.size(Layout::Activation4D::width)),
+            safe_downcast<int32_t>(self_arg.size(Layout::Activation4D::height)),
+        },
+        {
+            safe_downcast<int32_t>(stride[Layout::Parameter::width]),
+            safe_downcast<int32_t>(stride[Layout::Parameter::height]),
+        },
+        {
+            safe_downcast<int32_t>(padding[Layout::Parameter::width]),
+            safe_downcast<int32_t>(padding[Layout::Parameter::height]),
+        },
+        {
+            safe_downcast<int32_t>(dilation[Layout::Parameter::width]),
+            safe_downcast<int32_t>(dilation[Layout::Parameter::height]),
+        },
+        {
+            safe_downcast<float>(v_self.get_scale()),
+            0.0f,
+        },
+        {
+            safe_downcast<int32_t>(v_self.get_zero_point()),
+            0u,
+        },
+    };
+    params = api::UniformParamsBuffer(context, block);
+  } else {
+    const struct Block final {
+      uvec3 extents;
+      int32_t range;
+      ivec4 kernel;
+      ivec2 stride;
+      ivec2 padding;
+      ivec2 dilation;
+    } block{
+        v_output.extents(),
+        safe_downcast<int32_t>(
+            kernel[Layout::Parameter::width] *
+            kernel[Layout::Parameter::height]),
+        {
+            safe_downcast<int32_t>(kernel[Layout::Parameter::width]),
+            safe_downcast<int32_t>(kernel[Layout::Parameter::height]),
+            safe_downcast<int32_t>(self_arg.size(Layout::Activation4D::width)),
+            safe_downcast<int32_t>(self_arg.size(Layout::Activation4D::height)),
+        },
+        {
+            safe_downcast<int32_t>(stride[Layout::Parameter::width]),
+            safe_downcast<int32_t>(stride[Layout::Parameter::height]),
+        },
+        {
+            safe_downcast<int32_t>(padding[Layout::Parameter::width]),
+            safe_downcast<int32_t>(padding[Layout::Parameter::height]),
+        },
+        {
+            safe_downcast<int32_t>(dilation[Layout::Parameter::width]),
+            safe_downcast<int32_t>(dilation[Layout::Parameter::height]),
+        },
+    };
+    params = api::UniformParamsBuffer(context, block);
+  }
 
-  api::UniformParamsBuffer params(context, block);
   api::PipelineBarrier pipeline_barrier{};
 
   context->submit_compute_job(
@@ -244,14 +296,34 @@ Tensor max_pool2d(
     const IntArrayRef padding_arg,
     const IntArrayRef dilation_arg,
     const bool ceil_mode) {
-  return pool2d(
-      self_arg,
-      kernel_arg,
-      stride_arg,
-      padding_arg,
-      dilation_arg,
-      ceil_mode,
-      VK_KERNEL(max_pool2d));
+  if (self_arg.scalar_type() == kQUInt8) {
+    return pool2d(
+        self_arg,
+        kernel_arg,
+        stride_arg,
+        padding_arg,
+        dilation_arg,
+        ceil_mode,
+        VK_KERNEL(quantized_max_pool2d_quint8));
+  } else if (self_arg.scalar_type() == kQInt8) {
+    return pool2d(
+        self_arg,
+        kernel_arg,
+        stride_arg,
+        padding_arg,
+        dilation_arg,
+        ceil_mode,
+        VK_KERNEL(quantized_max_pool2d_qint8));
+  } else {
+    return pool2d(
+        self_arg,
+        kernel_arg,
+        stride_arg,
+        padding_arg,
+        dilation_arg,
+        ceil_mode,
+        VK_KERNEL(max_pool2d));
+  }
 }
 
 #ifdef USE_VULKAN_API


### PR DESCRIPTION
Summary: Add quantized max pool 2d operation

Test Plan:
Check that all quantized tests pass"

buck2 build --target-platforms ovr_config//platform/macos:arm64-fbsource  //xplat/caffe2:pt_vulkan_quantized_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1 --show-output"

Running main() from third-party/googletest/1.11.0/googletest/googletest/src/gtest_main.cc
[==========] Running 78 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 78 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.uniform_buffer_copy
[       OK ] VulkanAPITest.uniform_buffer_copy (66 ms)
[ RUN      ] VulkanAPITest.copy_to_buffer
[       OK ] VulkanAPITest.copy_to_buffer (61 ms)
[ RUN      ] VulkanAPITest.copy_to_buffer_channels_last
[       OK ] VulkanAPITest.copy_to_buffer_channels_last (28 ms)
[ RUN      ] VulkanAPITest.cpu_to_vulkan_and_dequantize_quint8
[       OK ] VulkanAPITest.cpu_to_vulkan_and_dequantize_quint8 (58 ms)
[ RUN      ] VulkanAPITest.cpu_to_vulkan_and_dequantize_qint8
[       OK ] VulkanAPITest.cpu_to_vulkan_and_dequantize_qint8 (44 ms)
[ RUN      ] VulkanAPITest.cpu_to_vulkan_and_dequantize_qint32
[       OK ] VulkanAPITest.cpu_to_vulkan_and_dequantize_qint32 (72 ms)
[ RUN      ] VulkanAPITest.quantize_dequantize
[       OK ] VulkanAPITest.quantize_dequantize (2 ms)
[ RUN      ] VulkanAPITest.quantize_per_tensor_and_dequantize_quint8
[       OK ] VulkanAPITest.quantize_per_tensor_and_dequantize_quint8 (69 ms)
[ RUN      ] VulkanAPITest.quantize_per_tensor_and_dequantize_quint8_qparams
[       OK ] VulkanAPITest.quantize_per_tensor_and_dequantize_quint8_qparams (58 ms)
[ RUN      ] VulkanAPITest.quantize_per_tensor_and_dequantize_qint8
[       OK ] VulkanAPITest.quantize_per_tensor_and_dequantize_qint8 (77 ms)
[ RUN      ] VulkanAPITest.quantize_per_tensor_and_dequantize_qint8_qparams
[       OK ] VulkanAPITest.quantize_per_tensor_and_dequantize_qint8_qparams (54 ms)
[ RUN      ] VulkanAPITest.quantize_per_tensor_and_dequantize_qint32
[       OK ] VulkanAPITest.quantize_per_tensor_and_dequantize_qint32 (93 ms)
[ RUN      ] VulkanAPITest.quantize_per_tensor_and_dequantize_qint32_qparams
[       OK ] VulkanAPITest.quantize_per_tensor_and_dequantize_qint32_qparams (90 ms)
[ RUN      ] VulkanAPITest.quantized_add
[       OK ] VulkanAPITest.quantized_add (2 ms)
[ RUN      ] VulkanAPITest.quantized_add_broadcast
WARNING: Logging before InitGoogleLogging() is written to STDERR
W1103 17:42:18.018113 4075724928 Resize.cpp:35] Warning: An output with one or more elements was resized since it had shape [2, 13, 1, 27], which does not match the required output shape [2, 13, 32, 27]. This behavior is deprecated, and in a future PyTorch release outputs will not be resized unless they have zero elements. You can explicitly reuse an out tensor t by resizing it, inplace, to zero elements with t.resize_(0). (function _resize_output_check)
[       OK ] VulkanAPITest.quantized_add_broadcast (2 ms)
[ RUN      ] VulkanAPITest.quantized_add_broadcast1
[       OK ] VulkanAPITest.quantized_add_broadcast1 (1 ms)
[ RUN      ] VulkanAPITest.quantized_add_broadcast2
W1103 17:42:18.022008 4075724928 Resize.cpp:35] Warning: An output with one or more elements was resized since it had shape [32, 1], which does not match the required output shape [32, 27]. This behavior is deprecated, and in a future PyTorch release outputs will not be resized unless they have zero elements. You can explicitly reuse an out tensor t by resizing it, inplace, to zero elements with t.resize_(0). (function _resize_output_check)
[       OK ] VulkanAPITest.quantized_add_broadcast2 (0 ms)
[ RUN      ] VulkanAPITest.quantized_add_broadcast3
[       OK ] VulkanAPITest.quantized_add_broadcast3 (0 ms)
[ RUN      ] VulkanAPITest.quantized_add_dif_params
[       OK ] VulkanAPITest.quantized_add_dif_params (1 ms)
[ RUN      ] VulkanAPITest.conv2d
[       OK ] VulkanAPITest.conv2d (4 ms)
[ RUN      ] VulkanAPITest.conv2d_pw
[       OK ] VulkanAPITest.conv2d_pw (88 ms)
[ RUN      ] VulkanAPITest.conv2d_dw
[       OK ] VulkanAPITest.conv2d_dw (32 ms)
[ RUN      ] VulkanAPITest.quantized_sub
[       OK ] VulkanAPITest.quantized_sub (1 ms)
[ RUN      ] VulkanAPITest.quantized_mul
[       OK ] VulkanAPITest.quantized_mul (1 ms)
[ RUN      ] VulkanAPITest.quantized_div
[       OK ] VulkanAPITest.quantized_div (1 ms)
[ RUN      ] VulkanAPITest.quantized_upsample_nearest2d
[       OK ] VulkanAPITest.quantized_upsample_nearest2d (0 ms)
[ RUN      ] VulkanAPITest.max_pool2d_qint8
[       OK ] VulkanAPITest.max_pool2d_qint8 (5 ms)
[ RUN      ] VulkanAPITest.max_pool2d_quint8
[       OK ] VulkanAPITest.max_pool2d_quint8 (4 ms)
[ RUN      ] VulkanAPITest.quantized_add_tests
[       OK ] VulkanAPITest.quantized_add_tests (77 ms)
[ RUN      ] VulkanAPITest.quantized_sub_tests
[       OK ] VulkanAPITest.quantized_sub_tests (104 ms)
[ RUN      ] VulkanAPITest.quantized_mul_tests
[       OK ] VulkanAPITest.quantized_mul_tests (78 ms)
[ RUN      ] VulkanAPITest.quantized_div_tests
[       OK ] VulkanAPITest.quantized_div_tests (124 ms)
[ RUN      ] VulkanAPITest.conv2d_quantized_fixed_params_uint8
[       OK ] VulkanAPITest.conv2d_quantized_fixed_params_uint8 (1 ms)
[ RUN      ] VulkanAPITest.conv2d_quantized_computed_params_uint8
[       OK ] VulkanAPITest.conv2d_quantized_computed_params_uint8 (0 ms)
[ RUN      ] VulkanAPITest.conv2d_quantized_random_params_uint8
[       OK ] VulkanAPITest.conv2d_quantized_random_params_uint8 (0 ms)
[ RUN      ] VulkanAPITest.conv2d_quantized_prepack_fixed_params_uint8
[       OK ] VulkanAPITest.conv2d_quantized_prepack_fixed_params_uint8 (0 ms)
[ RUN      ] VulkanAPITest.conv2d_quantized_prepack_computed_params_uint8
[       OK ] VulkanAPITest.conv2d_quantized_prepack_computed_params_uint8 (0 ms)
[ RUN      ] VulkanAPITest.conv2d_quantized_prepack_random_params_uint8
[       OK ] VulkanAPITest.conv2d_quantized_prepack_random_params_uint8 (0 ms)
[ RUN      ] VulkanAPITest.conv2d_dw_quantized_fixed_params_uint8
[       OK ] VulkanAPITest.conv2d_dw_quantized_fixed_params_uint8 (4 ms)
[ RUN      ] VulkanAPITest.conv2d_dw_quantized_computed_params_uint8
[       OK ] VulkanAPITest.conv2d_dw_quantized_computed_params_uint8 (3 ms)
[ RUN      ] VulkanAPITest.conv2d_dw_quantized_random_params_uint8
[       OK ] VulkanAPITest.conv2d_dw_quantized_random_params_uint8 (3 ms)
[ RUN      ] VulkanAPITest.conv2d_dw_quantized_prepack_fixed_params_uint8
[       OK ] VulkanAPITest.conv2d_dw_quantized_prepack_fixed_params_uint8 (3 ms)
[ RUN      ] VulkanAPITest.conv2d_dw_quantized_prepack_computed_params_uint8
[       OK ] VulkanAPITest.conv2d_dw_quantized_prepack_computed_params_uint8 (3 ms)
[ RUN      ] VulkanAPITest.conv2d_dw_quantized_prepack_random_params_uint8
[       OK ] VulkanAPITest.conv2d_dw_quantized_prepack_random_params_uint8 (3 ms)
[ RUN      ] VulkanAPITest.conv2d_pw_quantized_fixed_params_uint8
[       OK ] VulkanAPITest.conv2d_pw_quantized_fixed_params_uint8 (11 ms)
[ RUN      ] VulkanAPITest.conv2d_pw_quantized_computed_params_uint8
input_dif too big: 0.0175897. generating input again ...
[       OK ] VulkanAPITest.conv2d_pw_quantized_computed_params_uint8 (17 ms)
[ RUN      ] VulkanAPITest.conv2d_pw_quantized_random_params_uint8
[       OK ] VulkanAPITest.conv2d_pw_quantized_random_params_uint8 (11 ms)
[ RUN      ] VulkanAPITest.conv2d_pw_quantized_prepack_fixed_params_uint8
[       OK ] VulkanAPITest.conv2d_pw_quantized_prepack_fixed_params_uint8 (11 ms)
[ RUN      ] VulkanAPITest.conv2d_pw_quantized_prepack_computed_params_uint8
[       OK ] VulkanAPITest.conv2d_pw_quantized_prepack_computed_params_uint8 (11 ms)
[ RUN      ] VulkanAPITest.conv2d_pw_quantized_prepack_random_params_uint8
[       OK ] VulkanAPITest.conv2d_pw_quantized_prepack_random_params_uint8 (11 ms)
[ RUN      ] VulkanAPITest.conv2d_quantized_fixed_params_int8_int32
[       OK ] VulkanAPITest.conv2d_quantized_fixed_params_int8_int32 (1 ms)
[ RUN      ] VulkanAPITest.conv2d_quantized_computed_params_int8_int32
[       OK ] VulkanAPITest.conv2d_quantized_computed_params_int8_int32 (0 ms)
[ RUN      ] VulkanAPITest.conv2d_quantized_random_params_int8_int32
[       OK ] VulkanAPITest.conv2d_quantized_random_params_int8_int32 (0 ms)
[ RUN      ] VulkanAPITest.conv2d_quantized_prepack_fixed_params_int8_int32
[       OK ] VulkanAPITest.conv2d_quantized_prepack_fixed_params_int8_int32 (0 ms)
[ RUN      ] VulkanAPITest.conv2d_quantized_prepack_computed_params_int8_int32
[       OK ] VulkanAPITest.conv2d_quantized_prepack_computed_params_int8_int32 (0 ms)
[ RUN      ] VulkanAPITest.conv2d_quantized_prepack_random_params_int8_int32
[       OK ] VulkanAPITest.conv2d_quantized_prepack_random_params_int8_int32 (0 ms)
[ RUN      ] VulkanAPITest.conv2d_dw_quantized_fixed_params_int8_int32
[       OK ] VulkanAPITest.conv2d_dw_quantized_fixed_params_int8_int32 (3 ms)
[ RUN      ] VulkanAPITest.conv2d_dw_quantized_computed_params_int8_int32
[       OK ] VulkanAPITest.conv2d_dw_quantized_computed_params_int8_int32 (4 ms)
[ RUN      ] VulkanAPITest.conv2d_dw_quantized_random_params_int8_int32
[       OK ] VulkanAPITest.conv2d_dw_quantized_random_params_int8_int32 (3 ms)
[ RUN      ] VulkanAPITest.conv2d_dw_quantized_prepack_fixed_params_int8_int32
[       OK ] VulkanAPITest.conv2d_dw_quantized_prepack_fixed_params_int8_int32 (4 ms)
[ RUN      ] VulkanAPITest.conv2d_dw_quantized_prepack_computed_params_int8_int32
[       OK ] VulkanAPITest.conv2d_dw_quantized_prepack_computed_params_int8_int32 (3 ms)
[ RUN      ] VulkanAPITest.conv2d_dw_quantized_prepack_random_params_int8_int32
[       OK ] VulkanAPITest.conv2d_dw_quantized_prepack_random_params_int8_int32 (3 ms)
[ RUN      ] VulkanAPITest.conv2d_pw_quantized_fixed_params_int8_int32
[       OK ] VulkanAPITest.conv2d_pw_quantized_fixed_params_int8_int32 (11 ms)
[ RUN      ] VulkanAPITest.conv2d_pw_quantized_computed_params_int8_int32
[       OK ] VulkanAPITest.conv2d_pw_quantized_computed_params_int8_int32 (12 ms)
[ RUN      ] VulkanAPITest.conv2d_pw_quantized_random_params_int8_int32
[       OK ] VulkanAPITest.conv2d_pw_quantized_random_params_int8_int32 (11 ms)
[ RUN      ] VulkanAPITest.conv2d_pw_quantized_prepack_fixed_params_int8_int32
[       OK ] VulkanAPITest.conv2d_pw_quantized_prepack_fixed_params_int8_int32 (11 ms)
[ RUN      ] VulkanAPITest.conv2d_pw_quantized_prepack_computed_params_int8_int32
[       OK ] VulkanAPITest.conv2d_pw_quantized_prepack_computed_params_int8_int32 (12 ms)
[ RUN      ] VulkanAPITest.conv2d_pw_quantized_prepack_random_params_int8_int32
[       OK ] VulkanAPITest.conv2d_pw_quantized_prepack_random_params_int8_int32 (11 ms)
[ RUN      ] VulkanAPITest.quantized_tensor_get_scale_zero_point
[       OK ] VulkanAPITest.quantized_tensor_get_scale_zero_point (0 ms)
[ RUN      ] VulkanAPITest.linear_2d_flat
[       OK ] VulkanAPITest.linear_2d_flat (3 ms)
[ RUN      ] VulkanAPITest.linear_2d_small
[       OK ] VulkanAPITest.linear_2d_small (0 ms)
[ RUN      ] VulkanAPITest.linear_2d_large
[       OK ] VulkanAPITest.linear_2d_large (2 ms)
[ RUN      ] VulkanAPITest.linear_3d_flat
[       OK ] VulkanAPITest.linear_3d_flat (2 ms)
[ RUN      ] VulkanAPITest.linear_3d_small
[       OK ] VulkanAPITest.linear_3d_small (1 ms)
[ RUN      ] VulkanAPITest.linear_3d_large
[       OK ] VulkanAPITest.linear_3d_large (1 ms)
[ RUN      ] VulkanAPITest.linear_4d_flat
[       OK ] VulkanAPITest.linear_4d_flat (1 ms)
[ RUN      ] VulkanAPITest.linear_4d_small
[       OK ] VulkanAPITest.linear_4d_small (1 ms)
[ RUN      ] VulkanAPITest.linear_4d_large
[       OK ] VulkanAPITest.linear_4d_large (2 ms)
[----------] 78 tests from VulkanAPITest (1537 ms total)

[----------] Global test environment tear-down
[==========] 78 tests from 1 test suite ran. (1537 ms total)
[  PASSED  ] 78 tests.

Differential Revision: D50821920


