### PR TITLE
docs: fix docstrings in functional.py and others

### DIFF
--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -195,7 +195,7 @@ class Guard:
     @staticmethod
     def weakref_to_str(obj_weakref):
         """
-        This is a workaround of a Python weakref bug.
+        Work around a Python weakref bug.
 
         `obj_weakref` is instance returned by `weakref.ref`,
         `str(obj_weakref)` is buggy if the original obj overrides __getattr__, e.g:
@@ -416,10 +416,7 @@ class GlobalContextCheckpointState:
 
 
 class GlobalContext(Checkpointable[GlobalContextCheckpointState]):
-    """
-    This keeps track of the global torch state during tracing of a function.
-    For example, torch.is_grad_enabled.
-    """
+    """This keeps track of the global torch state during tracing of a function. For example, torch.is_grad_enabled."""
 
     _supported_global_states = {
         "grad_enabled",
@@ -724,8 +721,7 @@ def compile_context(context: CompileContext):
 @contextmanager
 def tracing(context: TracingContext):
     """
-    This function installs the passed in tracing context as a dynamic scoped
-    global variable.
+    Install the passed in tracing context as a dynamic scoped global variable.
 
     Calls to TracingContext.get() while not under a `with tracing()` context
     will return None.
@@ -778,10 +774,10 @@ class ChainedSource(Source):
 
 def detect_fake_mode(inputs: Any = None):
     """
-    Attempts to "detect" what the current fake mode is.  If there is one ambiently
-    available from TracingContext, we preferentially use that.  Otherwise, we
-    heuristically detect the fake mode via the following sources, in order of
-    priority:
+    Attempt to "detect" what the current fake mode is.
+
+    If there is one ambiently available from TracingContext, we preferentially use that.
+    Otherwise, we heuristically detect the fake mode via the following sources, in order of priority.:
 
         - Currently active fake mode on stack
         - Fake mode associated with passed in tensors (inputs does not

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -1,4 +1,9 @@
-"""The weak_script annotation needs to be here instead of inside torch/jit/ so it can be used in other places in torch/ (namely torch.nn) without running into circular dependency problems."""
+"""
+weak_srcipt annotation exists here to avoid circular dependency issues.
+
+The weak_script annotation needs to be here instead of inside torch/jit/ so it can be used in other places in torch
+/ (namely torch.nn) without running into circular dependency problems.
+"""
 
 import ast
 import builtins
@@ -91,7 +96,10 @@ loader = SourceLoader()
 
 def createResolutionCallbackFromEnv(lookup_base):
     """
-    Create a resolution callback that will look up qualified names in an environment, starting with `lookup_base` for the base of any qualified names, then proceeding down the lookup chain with the resolved object.
+    Create a resolution callback that will look up qualified names in an environment.
+
+    This starts with `lookup_base` for the base of any qualified names,
+    then proceeding down the lookup chain with the resolved object.
 
     You should not use this directly, it should only be used from the other
     createResolutionCallbackFrom* functions.
@@ -156,8 +164,10 @@ def createResolutionCallbackFromEnv(lookup_base):
 
 def createResolutionCallbackFromFrame(frames_up: int = 0):
     """
-    Return the value of the variable in the scope of the caller of the function which called createResolutionCallbackFromFrame (by default) given a string variable name.
-    
+    Return the value of the variable in the scope of the caller of the calling function given a string variable name.
+
+    Calling function is the function which called createResolutionCallbackFromFrame (by default)
+
     This is used to enable access in-scope Python variables inside TorchScript fragments.
 
     frames_up is number of additional frames to go up on the stack.
@@ -299,7 +309,9 @@ def can_compile_class(cls) -> bool:
 
 def get_callable_argument_names(fn) -> List[str]:
     """
-    Get names of all POSITIONAL_OR_KEYWORD arguments for callable `fn`. Return an empty list when other types of arguments are present.
+    Get names of all POSITIONAL_OR_KEYWORD arguments for callable `fn`.
+
+    Return an empty list when other types of arguments are present.
 
     This is used by `torch.jit.trace` to assign meaningful argument names to
     traced functions and modules.
@@ -348,7 +360,9 @@ def get_annotation_str(annotation):
 
 def get_type_hint_captures(fn):
     """
-    Get a dictionary containing type resolution mappings necessary to resolve types for the literal annotations on 'fn'. These are not considered to be closed-over by fn and must be obtained separately (e.g. using this function).
+    Get a dictionary containing type resolution mappings necessary to resolve types for the literal annotations on 'fn'.
+
+    These are not considered to be closed-over by fn and must be obtained separately (e.g. using this function).
 
     Args:
         fn: A callable.
@@ -457,7 +471,12 @@ def createResolutionCallbackForClassMethods(cls):
 def boolean_dispatch(
     arg_name, arg_index, default, if_true, if_false, module_name, func_name
 ):
-    """Dispatch to either of 2 script functions based on a boolean argument. In TorchScript, the boolean argument must be constant so that the correct function to use can be determined at compile time."""
+    """
+    Dispatch to either of 2 script functions based on a boolean argument.
+
+    In TorchScript, the boolean argument must be constant so that the correct function
+    to use can be determined at compile time.
+    """
 
     def fn(*args, **kwargs):
         dispatch_flag = default
@@ -514,7 +533,7 @@ class FunctionModifiers:
 
 def export(fn):
     """
-    Indicate (decorator) that a method on an ``nn.Module`` is used as an entry point into a :class:`ScriptModule` and should be compiled.
+    Indicate that a method on an ``nn.Module`` is used as an entry point into a `ScriptModule` and should be compiled.
 
     ``forward`` implicitly is assumed to be an entry point, so it does not need this decorator.
     Functions and methods called from ``forward`` are compiled as they are seen
@@ -559,7 +578,9 @@ def export(fn):
 
 def unused(fn):
     """
-    Indicate (decorator) to the compiler that a function or method should be ignored and replaced with the raising of an exception. This allows you to leave code in your model that is not yet TorchScript compatible and still export your model.
+    Indicate to the compiler that a function/method should be ignored and replaced with the raising of an exception.
+
+    This allows you to leave code in your model that is not yet TorchScript compatible and still export your model.
 
         Example (using ``@torch.jit.unused`` on a method)::
 
@@ -619,7 +640,11 @@ class _IgnoreContextManager(contextlib.AbstractContextManager):
 
 def ignore(drop=False, **kwargs):
     """
-    Indicate (decorator) to the compiler that a function or method should be ignored and left as a Python function. This allows you to leave code in your model that is not yet TorchScript compatible. If called from TorchScript, ignored functions will dispatch the call to the Python interpreter. Models with ignored functions cannot be exported; use :func:`@torch.jit.unused <torch.jit.unused>` instead.
+    Indicate (decorator) to the compiler that a function or method should be ignored and left as a Python function.
+
+    This allows you to leave code in your model that is not yet TorchScript compatible.
+    If called from TorchScript, ignored functions will dispatch the call to the Python interpreter.
+    Models with ignored functions cannot be exported; use :func:`@torch.jit.unused <torch.jit.unused>` instead.
 
     Example (using ``@torch.jit.ignore`` on a method)::
 
@@ -1080,7 +1105,10 @@ for i in range(2, 7):
 
 def is_scripting() -> bool:
     r"""
-    Return True when in compilation and False otherwise. This is useful especially with the @unused decorator to leave code in your model that is not yet TorchScript compatible.
+    Return True when in compilation and False otherwise.
+
+    This is useful especially with the @unused decorator to leave code in your model that is
+    not yet TorchScript compatible.
 
     .. testcode::
 

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -1,8 +1,4 @@
-"""
-The weak_script annotation needs to be here instead of inside torch/jit/ so it
-can be used in other places in torch/ (namely torch.nn) without running into
-circular dependency problems
-"""
+"""The weak_script annotation needs to be here instead of inside torch/jit/ so it can be used in other places in torch/ (namely torch.nn) without running into circular dependency problems."""
 
 import ast
 import builtins
@@ -95,9 +91,7 @@ loader = SourceLoader()
 
 def createResolutionCallbackFromEnv(lookup_base):
     """
-    Creates a resolution callback that will look up qualified names in an
-    environment, starting with `lookup_base` for the base of any qualified
-    names, then proceeding down the lookup chain with the resolved object.
+    Create a resolution callback that will look up qualified names in an environment, starting with `lookup_base` for the base of any qualified names, then proceeding down the lookup chain with the resolved object.
 
     You should not use this directly, it should only be used from the other
     createResolutionCallbackFrom* functions.
@@ -162,12 +156,9 @@ def createResolutionCallbackFromEnv(lookup_base):
 
 def createResolutionCallbackFromFrame(frames_up: int = 0):
     """
-    Creates a function which, given a string variable name,
-    returns the value of the variable in the scope of the caller of
-    the function which called createResolutionCallbackFromFrame (by default).
-
-    This is used to enable access in-scope Python variables inside
-    TorchScript fragments.
+    Return the value of the variable in the scope of the caller of the function which called createResolutionCallbackFromFrame (by default) given a string variable name.
+    
+    This is used to enable access in-scope Python variables inside TorchScript fragments.
 
     frames_up is number of additional frames to go up on the stack.
     The default value is 0, which correspond to the frame of the caller
@@ -211,9 +202,7 @@ def createResolutionCallbackFromFrame(frames_up: int = 0):
 
 
 def get_closure(fn):
-    """
-    Get a dictionary of closed over variables from a function
-    """
+    """Get a dictionary of closed over variables from a function."""
     captures = {}
     captures.update(fn.__globals__)
 
@@ -269,10 +258,7 @@ def get_closure(fn):
 
 
 def createResolutionCallbackFromClosure(fn):
-    """
-    Create a resolutionCallback by introspecting the function instead of
-    looking up the stack for the enclosing scope
-    """
+    """Create a resolutionCallback by introspecting the function instead of looking up the stack for the enclosing scope."""
     closure = get_closure(fn)
 
     class closure_lookup:
@@ -313,8 +299,7 @@ def can_compile_class(cls) -> bool:
 
 def get_callable_argument_names(fn) -> List[str]:
     """
-    Gets names of all POSITIONAL_OR_KEYWORD arguments for callable `fn`.
-    Returns an empty list when other types of arguments are present.
+    Get names of all POSITIONAL_OR_KEYWORD arguments for callable `fn`. Return an empty list when other types of arguments are present.
 
     This is used by `torch.jit.trace` to assign meaningful argument names to
     traced functions and modules.
@@ -343,10 +328,7 @@ def get_callable_argument_names(fn) -> List[str]:
 
 
 def get_annotation_str(annotation):
-    """
-    Convert an AST node containing a type annotation to the string present in the source
-    that represents the same annotation.
-    """
+    """Convert an AST node containing a type annotation to the string present in the source that represents the same annotation."""
     if isinstance(annotation, ast.Name):
         return annotation.id
     elif isinstance(annotation, ast.Attribute):
@@ -366,9 +348,7 @@ def get_annotation_str(annotation):
 
 def get_type_hint_captures(fn):
     """
-    Get a dictionary containing type resolution mappings necessary to resolve types
-    for the literal annotations on 'fn'. These are not considered to be closed-over by fn
-    and must be obtained separately (e.g. using this function).
+    Get a dictionary containing type resolution mappings necessary to resolve types for the literal annotations on 'fn'. These are not considered to be closed-over by fn and must be obtained separately (e.g. using this function).
 
     Args:
         fn: A callable.
@@ -447,10 +427,7 @@ def get_type_hint_captures(fn):
 
 
 def createResolutionCallbackForClassMethods(cls):
-    """
-    This looks at all the methods defined in a class and pulls their closed-over
-    variables into a dictionary and uses that to resolve variables.
-    """
+    """Pull pulls closed-over variables from all methods defined in a class into a dictionary and uses that to resolve variables."""
     # cls is a type here, so `ismethod` is false since the methods on the type
     # aren't bound to anything, so Python treats them as regular functions
     fns = [
@@ -480,11 +457,7 @@ def createResolutionCallbackForClassMethods(cls):
 def boolean_dispatch(
     arg_name, arg_index, default, if_true, if_false, module_name, func_name
 ):
-    """
-    Dispatches to either of 2 script functions based on a boolean argument.
-    In TorchScript, the boolean argument must be constant so that the correct
-    function to use can be determined at compile time.
-    """
+    """Dispatch to either of 2 script functions based on a boolean argument. In TorchScript, the boolean argument must be constant so that the correct function to use can be determined at compile time."""
 
     def fn(*args, **kwargs):
         dispatch_flag = default
@@ -527,10 +500,7 @@ def boolean_dispatch(
 
 
 class FunctionModifiers:
-    """
-    Used to denote the behavior of a function in TorchScript. See export() and
-    ignore() for details.
-    """
+    """Used to denote the behavior of a function in TorchScript. See export() and ignore() for details."""
 
     UNUSED = "unused (ignored and replaced with raising of an exception)"
     IGNORE = "ignore (leave as a call to Python, cannot be torch.jit.save'd)"
@@ -544,8 +514,7 @@ class FunctionModifiers:
 
 def export(fn):
     """
-    This decorator indicates that a method on an ``nn.Module`` is used as an entry point into a
-    :class:`ScriptModule` and should be compiled.
+    Indicate (decorator) that a method on an ``nn.Module`` is used as an entry point into a :class:`ScriptModule` and should be compiled.
 
     ``forward`` implicitly is assumed to be an entry point, so it does not need this decorator.
     Functions and methods called from ``forward`` are compiled as they are seen
@@ -590,10 +559,7 @@ def export(fn):
 
 def unused(fn):
     """
-    This decorator indicates to the compiler that a function or method should
-    be ignored and replaced with the raising of an exception. This allows you
-    to leave code in your model that is not yet TorchScript compatible and still
-    export your model.
+    Indicate (decorator) to the compiler that a function or method should be ignored and replaced with the raising of an exception. This allows you to leave code in your model that is not yet TorchScript compatible and still export your model.
 
         Example (using ``@torch.jit.unused`` on a method)::
 
@@ -653,11 +619,7 @@ class _IgnoreContextManager(contextlib.AbstractContextManager):
 
 def ignore(drop=False, **kwargs):
     """
-    This decorator indicates to the compiler that a function or method should
-    be ignored and left as a Python function. This allows you to leave code in
-    your model that is not yet TorchScript compatible. If called from TorchScript,
-    ignored functions will dispatch the call to the Python interpreter. Models with ignored
-    functions cannot be exported; use :func:`@torch.jit.unused <torch.jit.unused>` instead.
+    Indicate (decorator) to the compiler that a function or method should be ignored and left as a Python function. This allows you to leave code in your model that is not yet TorchScript compatible. If called from TorchScript, ignored functions will dispatch the call to the Python interpreter. Models with ignored functions cannot be exported; use :func:`@torch.jit.unused <torch.jit.unused>` instead.
 
     Example (using ``@torch.jit.ignore`` on a method)::
 
@@ -712,7 +674,6 @@ def ignore(drop=False, **kwargs):
         import os
         os.remove('m.pt')
     """
-
     if callable(drop):
         # used without any args, so drop is actually a function
         #   @torch.jit.ignore
@@ -1119,9 +1080,8 @@ for i in range(2, 7):
 
 def is_scripting() -> bool:
     r"""
-    Function that returns True when in compilation and False otherwise. This
-    is useful especially with the @unused decorator to leave code in your
-    model that is not yet TorchScript compatible.
+    Return True when in compilation and False otherwise. This is useful especially with the @unused decorator to leave code in your model that is not yet TorchScript compatible.
+
     .. testcode::
 
         import torch
@@ -1489,8 +1449,7 @@ class _TensorExtractor(pickle.Pickler):
 
 def _extract_tensors(obj):
     r"""
-    This function is exclusively called from C++.
-    See ``torch/csrc/jit/python/python_ivalue.h``.
+    See ``torch/csrc/jit/python/python_ivalue.h``. This function is exclusively called from C++.
 
     It extracts the tensors contained in the given object, through pickling.
     """

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -1,5 +1,5 @@
 """
-weak_srcipt annotation exists here to avoid circular dependency issues.
+The ``weak_srcipt`` annotation exists here to avoid circular dependency issues.
 
 The weak_script annotation needs to be here instead of inside torch/jit/ so it can be used in other places in torch
 / (namely torch.nn) without running into circular dependency problems.
@@ -162,11 +162,12 @@ def createResolutionCallbackFromEnv(lookup_base):
     return lambda expr: parseExpr(expr, lookup_base)
 
 
-def createResolutionCallbackFromFrame(frames_up: int = 0):
+def createResolutionCallbackFromFrame(frames_up: int = 0): # noqa D400
     """
-    Return the value of the variable in the scope of the caller of the calling function given a string variable name.
+    Create a function which returns a string variable's value, given its name, from the scope of the caller's caller.
 
-    Calling function is the function which called createResolutionCallbackFromFrame (by default)
+    Returns the value of the variable in the scope of the caller of the function which called
+    createResolutionCallbackFromFrame (by default).
 
     This is used to enable access in-scope Python variables inside TorchScript fragments.
 

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -442,7 +442,7 @@ def get_type_hint_captures(fn):
 
 
 def createResolutionCallbackForClassMethods(cls):
-    """Pull pulls closed-over variables from all methods defined in a class into a dictionary and uses that to resolve variables."""
+    """Pulls closed-over variables from all methods defined in a class into a dictionary and uses that to resolve variables."""
     # cls is a type here, so `ismethod` is false since the methods on the type
     # aren't bound to anything, so Python treats them as regular functions
     fns = [

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -641,7 +641,7 @@ class _IgnoreContextManager(contextlib.AbstractContextManager):
 
 def ignore(drop=False, **kwargs):
     """
-    Indicate (decorator) to the compiler that a function or method should be ignored and left as a Python function.
+    Indicate to the compiler that a function or method should be ignored and left as a Python function.
 
     This allows you to leave code in your model that is not yet TorchScript compatible.
     If called from TorchScript, ignored functions will dispatch the call to the Python interpreter.

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -18,10 +18,7 @@ _SET_GLOBAL_FLAGS = hasattr(sys, "getdlopenflags") and hasattr(sys, "setdlopenfl
 
 @contextlib.contextmanager
 def dl_open_guard():
-    """
-    Context manager to set the RTLD_GLOBAL dynamic linker flag while we open a
-    shared library to load custom operators.
-    """
+    """Context manager to set the RTLD_GLOBAL dynamic linker flag while we open a shared library to load custom operators."""
     if not _SET_GLOBAL_FLAGS:
         yield
         return
@@ -34,10 +31,7 @@ def dl_open_guard():
 
 
 class OperatorBase:
-    """
-    Base class for OpOverload (which represents C++ ATen operators) and HigherOrderOperator
-    (which represents Python-only operators that are unrepresentable in TorchScript).
-    """
+    """Base class for OpOverload (which represents C++ ATen operators) and HigherOrderOperator (which represents Python-only operators that are unrepresentable in TorchScript)."""
 
     def __init__(self):
         # The dispatch cache precomputes a mapping of dispatch key that the
@@ -882,7 +876,7 @@ class _Ops(types.ModuleType):
 
     def import_module(self, module):
         """
-        Imports a Python module that has torch.library registrations.
+        Import a Python module that has torch.library registrations.
 
         Generally, to extend PyTorch with custom operators, a user will
         create a Python module whose import triggers registration of
@@ -901,7 +895,7 @@ class _Ops(types.ModuleType):
 
     def load_library(self, path):
         """
-        Loads a shared library from the given path into the current process.
+        Load a shared library from the given path into the current process.
 
         The library being loaded may run global initialization code to register
         custom operators with the PyTorch JIT runtime. This allows dynamically

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -31,7 +31,12 @@ def dl_open_guard():
 
 
 class OperatorBase:
-    """Base class for OpOverload (which represents C++ ATen operators) and HigherOrderOperator (which represents Python-only operators that are unrepresentable in TorchScript)."""
+    """
+    Base class for OpOverload and HigherOrderOperator.
+
+    OpOverload: represents C++ ATen operators.
+    HigherOrderOperator: represents Python-only operators that are unrepresentable in TorchScript.
+    """
 
     def __init__(self):
         # The dispatch cache precomputes a mapping of dispatch key that the

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -29,7 +29,7 @@ def set_printoptions(
     profile=None,
     sci_mode=None,
 ):
-    r"""Set options for printing. Items shamelessly taken from NumPy
+    r"""Set options for printing. Items shamelessly taken from NumPy.
 
     Args:
         precision: Number of digits of precision for floating point output
@@ -95,16 +95,13 @@ def set_printoptions(
 
 
 def get_printoptions() -> Dict[str, Any]:
-    r"""Gets the current options for printing, as a dictionary that
-    can be passed as ``**kwargs`` to set_printoptions().
-    """
+    r"""Get the current options for printing, as a dictionary that can be passed as ``**kwargs`` to set_printoptions()."""
     return dataclasses.asdict(PRINT_OPTS)
 
 
 @contextlib.contextmanager
 def printoptions(**kwargs):
-    r"""Context manager that temporarily changes the print options.  Accepted
-    arguments are same as :func:`set_printoptions`."""
+    r"""Context manager that temporarily changes the print options. Accepted arguments are same as :func:`set_printoptions`."""
     old_kwargs = get_printoptions()
     set_printoptions(**kwargs)
     try:

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -196,7 +196,9 @@ def split(
 
 def einsum(*args: Any) -> Tensor:
     r"""
-    Sum the product of the elements of the input :attr:`operands` along dimensions specified using a notation based on the Einstein summation convention.
+    Sum the product of the elements of the input :attr:`operands`.
+
+    The sum is taken along dimensions specified using a notation based on the Einstein summation convention.
 
     einsum(equation, *operands) -> Tensor
 
@@ -1379,7 +1381,9 @@ def atleast_1d(*tensors):
 
 def atleast_2d(*tensors):
     r"""
-    Return a 2-dimensional view of each input tensor with zero dimensions. Input tensors with two or more dimensions are returned as-is.
+    Return a 2-dimensional view of each input tensor with zero dimensions.
+
+    Input tensors with two or more dimensions are returned as-is.
 
     Args:
         input (Tensor or list of Tensors)
@@ -1416,7 +1420,9 @@ def atleast_2d(*tensors):
 
 def atleast_3d(*tensors):
     r"""
-    Return a 3-dimensional view of each input tensor with zero dimensions. Input tensors with three or more dimensions are returned as-is.
+    Return a 3-dimensional view of each input tensor with zero dimensions.
+
+    Input tensors with three or more dimensions are returned as-is.
 
     Args:
         input (Tensor or list of Tensors)
@@ -1693,7 +1699,10 @@ def norm(input, p: Optional[Union[float, str]] = "fro", dim=None, keepdim=False,
                 return _VF.norm(input, p, _dim, keepdim=keepdim, dtype=dtype, out=out)  # type: ignore[attr-defined]
 
 def unravel_index(indices: Tensor, shape: Union[int, Sequence[int], torch.Size]) -> List[Tensor]:
-    r"""Convert a tensor of flat indices into a tuple of coordinate tensors that index into an arbitrary tensor of the specified shape.
+    r"""
+    Convert a tensor of flat indices into a tuple of coordinate tensors.
+
+    The coordinate tensors index into an arbitrary tensor of the specified shape.
 
     Args:
         indices (Tensor): An integer tensor containing indices into the
@@ -1774,7 +1783,10 @@ def _unravel_index(indices: Tensor, shape: Union[int, Sequence[int]]) -> Tensor:
     ) % torch.tensor(shape, device=indices.device, dtype=torch.int64)
 
 def chain_matmul(*matrices, out=None):
-    r"""Return the matrix product of the :math:`N` 2-D tensors. This product is efficiently computed using the matrix chain order algorithm which selects the order in which incurs the lowest cost in terms of arithmetic operations (`[CLRS]`_).
+    r"""Return the matrix product of the :math:`N` 2-D tensors.
+
+    This product is efficiently computed using the matrix chain order algorithm which selects
+    the order in which incurs the lowest cost in terms of arithmetic operations (`[CLRS]`_).
 
     Note that since this is a function to compute the product, :math:`N`
     needs to be greater than or equal to 2; if equal to 2 then a trivial matrix-matrix product is returned.

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -45,9 +45,11 @@ __all__ = [
 
 
 def broadcast_tensors(*tensors):
-    r"""broadcast_tensors(*tensors) -> List of Tensors
-
+    r"""
     Broadcasts the given tensors according to :ref:`broadcasting-semantics`.
+
+    broadcast_tensors(*tensors) -> List of Tensors
+
 
     Args:
         *tensors: any number of tensors of the same type
@@ -77,9 +79,11 @@ def broadcast_tensors(*tensors):
 
 
 def broadcast_shapes(*shapes):
-    r"""broadcast_shapes(*shapes) -> Size
-
+    r"""
     Similar to :func:`broadcast_tensors` but for shapes.
+
+    broadcast_shapes(*shapes) -> Size
+
 
     This is equivalent to
     ``torch.broadcast_tensors(*map(torch.empty, shapes))[0].shape``
@@ -141,7 +145,7 @@ def broadcast_shapes(*shapes):
 def split(
     tensor: Tensor, split_size_or_sections: Union[int, List[int]], dim: int = 0
 ) -> Tuple[Tensor, ...]:
-    r"""Splits the tensor into chunks. Each chunk is a view of the original tensor.
+    r"""Split tensor into chunks. Each chunk is a view of the original tensor.
 
     If :attr:`split_size_or_sections` is an integer type, then :attr:`tensor` will
     be split into equally sized chunks (if possible). Last chunk will be smaller if
@@ -191,10 +195,10 @@ def split(
 
 
 def einsum(*args: Any) -> Tensor:
-    r"""einsum(equation, *operands) -> Tensor
+    r"""
+    Sum the product of the elements of the input :attr:`operands` along dimensions specified using a notation based on the Einstein summation convention.
 
-    Sums the product of the elements of the input :attr:`operands` along dimensions specified using a notation
-    based on the Einstein summation convention.
+    einsum(equation, *operands) -> Tensor
 
     Einsum allows computing many common multi-dimensional linear algebraic array operations by representing them
     in a short-hand format based on the Einstein summation convention, given by :attr:`equation`. The details of
@@ -396,7 +400,7 @@ if TYPE_CHECKING:
         return _meshgrid(*tensors, indexing=indexing)
 else:
     def meshgrid(*tensors, indexing: Optional[str] = None) -> Tuple[Tensor, ...]:
-        r"""Creates grids of coordinates specified by the 1D inputs in `attr`:tensors.
+        r"""Create grids of coordinates specified by the 1D inputs in `attr`:tensors.
 
         This is helpful when you want to visualize data over some
         range of inputs. See below for a plotting example.
@@ -755,9 +759,10 @@ else:
 def _unique_impl(input: Tensor, sorted: bool = True,
                  return_inverse: bool = False, return_counts: bool = False,
                  dim: Optional[int] = None) -> _unique_impl_out:
-    r"""unique(input, sorted=True, return_inverse=False, return_counts=False, dim=None) -> Tuple[Tensor, Tensor, Tensor]
+    r"""
+    Return the unique elements of the input tensor.
 
-    Returns the unique elements of the input tensor.
+    unique(input, sorted=True, return_inverse=False, return_counts=False, dim=None) -> Tuple[Tensor, Tensor, Tensor]
 
     .. note:: This function is different from :func:`torch.unique_consecutive` in the sense that
         this function also eliminates non-consecutive duplicate values.
@@ -1118,7 +1123,7 @@ else:
 
 
 def tensordot(a, b, dims=2, out: Optional[torch.Tensor] = None):  # noqa: F811
-    r"""Returns a contraction of a and b over multiple dimensions.
+    r"""Return a contraction of a and b over multiple dimensions.
 
     :attr:`tensordot` implements a generalized matrix product.
 
@@ -1211,8 +1216,7 @@ def tensordot(a, b, dims=2, out: Optional[torch.Tensor] = None):  # noqa: F811
 
 
 def cartesian_prod(*tensors: Tensor) -> Tensor:
-    """Do cartesian product of the given sequence of tensors. The behavior is similar to
-    python's `itertools.product`.
+    """Do cartesian product of the given sequence of tensors. The behavior is similar to python's `itertools.product`.
 
     Args:
         *tensors: any number of 1 dimensional tensors.
@@ -1283,7 +1287,7 @@ def block_diag(*tensors):
 
 def cdist(x1, x2, p=2., compute_mode='use_mm_for_euclid_dist_if_necessary'):
     # type: (Tensor, Tensor, float, str) -> (Tensor)
-    r"""Computes batched the p-norm distance between each pair of the two collections of row vectors.
+    r"""Compute batched the p-norm distance between each pair of the two collections of row vectors.
 
     Args:
         x1 (Tensor): input tensor of shape :math:`B \times P \times M`.
@@ -1307,7 +1311,7 @@ def cdist(x1, x2, p=2., compute_mode='use_mm_for_euclid_dist_if_necessary'):
     `scipy.spatial.distance.cdist(input, 'hamming') * M`. When :math:`p = \infty`, the closest
     scipy function is `scipy.spatial.distance.cdist(xn, lambda x, y: np.abs(x - y).max())`.
 
-    Example:
+    Example::
 
         >>> a = torch.tensor([[0.9041,  0.0196], [-0.3108, -2.4423], [-0.4821,  1.059]])
         >>> a
@@ -1338,7 +1342,8 @@ def cdist(x1, x2, p=2., compute_mode='use_mm_for_euclid_dist_if_necessary'):
 
 def atleast_1d(*tensors):
     r"""
-    Returns a 1-dimensional view of each input tensor with zero dimensions.
+    Return a 1-dimensional view of each input tensor with zero dimensions.
+
     Input tensors with one or more dimensions are returned as-is.
 
     Args:
@@ -1374,8 +1379,7 @@ def atleast_1d(*tensors):
 
 def atleast_2d(*tensors):
     r"""
-    Returns a 2-dimensional view of each input tensor with zero dimensions.
-    Input tensors with two or more dimensions are returned as-is.
+    Return a 2-dimensional view of each input tensor with zero dimensions. Input tensors with two or more dimensions are returned as-is.
 
     Args:
         input (Tensor or list of Tensors)
@@ -1412,8 +1416,7 @@ def atleast_2d(*tensors):
 
 def atleast_3d(*tensors):
     r"""
-    Returns a 3-dimensional view of each input tensor with zero dimensions.
-    Input tensors with three or more dimensions are returned as-is.
+    Return a 3-dimensional view of each input tensor with zero dimensions. Input tensors with three or more dimensions are returned as-is.
 
     Args:
         input (Tensor or list of Tensors)
@@ -1493,7 +1496,7 @@ else:
 
 
 def norm(input, p: Optional[Union[float, str]] = "fro", dim=None, keepdim=False, out=None, dtype=None):  # noqa: F811
-    r"""Returns the matrix norm or vector norm of a given tensor.
+    r"""Return the matrix norm or vector norm of a given tensor.
 
     .. warning::
 
@@ -1690,8 +1693,7 @@ def norm(input, p: Optional[Union[float, str]] = "fro", dim=None, keepdim=False,
                 return _VF.norm(input, p, _dim, keepdim=keepdim, dtype=dtype, out=out)  # type: ignore[attr-defined]
 
 def unravel_index(indices: Tensor, shape: Union[int, Sequence[int], torch.Size]) -> List[Tensor]:
-    r"""Converts a tensor of flat indices into a tuple of coordinate tensors that
-    index into an arbitrary tensor of the specified shape.
+    r"""Convert a tensor of flat indices into a tuple of coordinate tensors that index into an arbitrary tensor of the specified shape.
 
     Args:
         indices (Tensor): An integer tensor containing indices into the
@@ -1772,9 +1774,9 @@ def _unravel_index(indices: Tensor, shape: Union[int, Sequence[int]]) -> Tensor:
     ) % torch.tensor(shape, device=indices.device, dtype=torch.int64)
 
 def chain_matmul(*matrices, out=None):
-    r"""Returns the matrix product of the :math:`N` 2-D tensors. This product is efficiently computed
-    using the matrix chain order algorithm which selects the order in which incurs the lowest cost in terms
-    of arithmetic operations (`[CLRS]`_). Note that since this is a function to compute the product, :math:`N`
+    r"""Return the matrix product of the :math:`N` 2-D tensors. This product is efficiently computed using the matrix chain order algorithm which selects the order in which incurs the lowest cost in terms of arithmetic operations (`[CLRS]`_).
+
+    Note that since this is a function to compute the product, :math:`N`
     needs to be greater than or equal to 2; if equal to 2 then a trivial matrix-matrix product is returned.
     If :math:`N` is 1, then this is a no-op - the original matrix is returned as is.
 
@@ -1820,7 +1822,8 @@ def chain_matmul(*matrices, out=None):
 
 def _lu_impl(A, pivot=True, get_infos=False, out=None):
     # type: (Tensor, bool, bool, Any) -> Tuple[Tensor, Tensor, Tensor]
-    r"""Computes the LU factorization of a matrix or batches of matrices
+    r"""Compute the LU factorization of a matrix or batches of matrices.
+
     :attr:`A`. Returns a tuple containing the LU factorization and
     pivots of :attr:`A`.  Pivoting is done if :attr:`pivot` is set to
     ``True``.

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -44,12 +44,10 @@ __all__ = [
 ]
 
 
-def broadcast_tensors(*tensors):
-    r"""
+def broadcast_tensors(*tensors): # noqa D400
+    r"""broadcast_tensors(*tensors) -> List of Tensors
+
     Broadcasts the given tensors according to :ref:`broadcasting-semantics`.
-
-    broadcast_tensors(*tensors) -> List of Tensors
-
 
     Args:
         *tensors: any number of tensors of the same type
@@ -78,12 +76,10 @@ def broadcast_tensors(*tensors):
     return _VF.broadcast_tensors(tensors)  # type: ignore[attr-defined]
 
 
-def broadcast_shapes(*shapes):
-    r"""
+def broadcast_shapes(*shapes): # noqa D400
+    r"""broadcast_shapes(*shapes) -> Size
+
     Similar to :func:`broadcast_tensors` but for shapes.
-
-    broadcast_shapes(*shapes) -> Size
-
 
     This is equivalent to
     ``torch.broadcast_tensors(*map(torch.empty, shapes))[0].shape``
@@ -145,7 +141,9 @@ def broadcast_shapes(*shapes):
 def split(
     tensor: Tensor, split_size_or_sections: Union[int, List[int]], dim: int = 0
 ) -> Tuple[Tensor, ...]:
-    r"""Split tensor into chunks. Each chunk is a view of the original tensor.
+    r"""Split the tensor into chunks.
+
+    Each chunk is a view of the original tensor.
 
     If :attr:`split_size_or_sections` is an integer type, then :attr:`tensor` will
     be split into equally sized chunks (if possible). Last chunk will be smaller if
@@ -194,13 +192,11 @@ def split(
     return tensor.split(split_size_or_sections, dim)
 
 
-def einsum(*args: Any) -> Tensor:
-    r"""
+def einsum(*args: Any) -> Tensor: # noqa D400
+    r"""einsum(equation, *operands) -> Tensor
+
     Sum the product of the elements of the input :attr:`operands`.
-
     The sum is taken along dimensions specified using a notation based on the Einstein summation convention.
-
-    einsum(equation, *operands) -> Tensor
 
     Einsum allows computing many common multi-dimensional linear algebraic array operations by representing them
     in a short-hand format based on the Einstein summation convention, given by :attr:`equation`. The details of
@@ -760,11 +756,10 @@ else:
 
 def _unique_impl(input: Tensor, sorted: bool = True,
                  return_inverse: bool = False, return_counts: bool = False,
-                 dim: Optional[int] = None) -> _unique_impl_out:
-    r"""
-    Return the unique elements of the input tensor.
+                 dim: Optional[int] = None) -> _unique_impl_out: # noqa D400
+    r"""unique(input, sorted=True, return_inverse=False, return_counts=False, dim=None) -> Tuple[Tensor, Tensor, Tensor]
 
-    unique(input, sorted=True, return_inverse=False, return_counts=False, dim=None) -> Tuple[Tensor, Tensor, Tensor]
+    Return the unique elements of the input tensor.
 
     .. note:: This function is different from :func:`torch.unique_consecutive` in the sense that
         this function also eliminates non-consecutive duplicate values.
@@ -1218,7 +1213,9 @@ def tensordot(a, b, dims=2, out: Optional[torch.Tensor] = None):  # noqa: F811
 
 
 def cartesian_prod(*tensors: Tensor) -> Tensor:
-    """Do cartesian product of the given sequence of tensors. The behavior is similar to python's `itertools.product`.
+    """Compute the cartesian product of the given sequence of tensors.
+
+    The behavior is similar to python's `itertools.product`.
 
     Args:
         *tensors: any number of 1 dimensional tensors.
@@ -1594,7 +1591,6 @@ def norm(input, p: Optional[Union[float, str]] = "fro", dim=None, keepdim=False,
         >>> torch.norm(d[0, :, :]), torch.norm(d[1, :, :])
         (tensor(3.7417), tensor(11.2250))
     """
-
     if has_torch_function_unary(input):
         return handle_torch_function(
             norm, (input,), input, p=p, dim=dim, keepdim=keepdim, out=out, dtype=dtype)

--- a/torch/library.py
+++ b/torch/library.py
@@ -30,7 +30,10 @@ def fallthrough_kernel():
 
 class Library:
     """
-    A class to create libraries that can be used to register new operators or override operators in existing libraries from Python. A user can optionally pass in a dispatch keyname if they only want to register kernels corresponding to only one specific dispatch key.
+    A class to create libraries that can be used to register new or override operators in existing Python libraries .
+
+    A user can optionally pass in a dispatch keyname if they only want to register kernels
+    corresponding to only one specific dispatch key.
 
     To create a library to override operators in an existing library (with name ns), set the kind to "IMPL".
     To create a new library (with name ns) to register new operators, set the kind to "DEF".


### PR DESCRIPTION
Fixes #112586

# Files Changed
- _guards.py
- _ops.py
-  _jit_internal.py
-  _tensor_str.py
-  library.py
- functional.py

# Output (Pre/Post)

Running ``pydocstyle path-to-file --count``

## Functional
```
functional.py:1 at module level:
        D100: Missing docstring in public module
functional.py:48 in public function `broadcast_tensors`:
        D400: First line should end with a period (not 's')
functional.py:48 in public function `broadcast_tensors`:
        D402: First line should not be the function's "signature"
functional.py:80 in public function `broadcast_shapes`:
        D400: First line should end with a period (not 'e')
functional.py:80 in public function `broadcast_shapes`:
        D402: First line should not be the function's "signature"
functional.py:144 in public function `split`:
        D401: First line should be in imperative mood (perhaps 'Split', not 'Splits')
functional.py:194 in public function `einsum`:
        D400: First line should end with a period (not 'r')
functional.py:194 in public function `einsum`:
        D402: First line should not be the function's "signature"
functional.py:394 in public function `meshgrid`:
        D103: Missing docstring in public function
functional.py:399 in public function `meshgrid`:
        D401: First line should be in imperative mood (perhaps 'Create', not 'Creates')
functional.py:758 in private function `_unique_impl`:
        D400: First line should end with a period (not ']')
functional.py:1108 in public function `tensordot` (skipping F811):
        D103: Missing docstring in public function
functional.py:1112 in public function `tensordot` (skipping F811):
        D103: Missing docstring in public function
functional.py:1116 in public function `tensordot` (skipping F811):
        D103: Missing docstring in public function
functional.py:1121 in public function `tensordot` (skipping F811):
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
functional.py:1214 in public function `cartesian_prod`:
        D205: 1 blank line required between summary line and description (found 0)
functional.py:1214 in public function `cartesian_prod`:
        D400: First line should end with a period (not 'o')
functional.py:1286 in public function `cdist`:
        D401: First line should be in imperative mood (perhaps 'Compute', not 'Computes')
functional.py:1286 in public function `cdist`:
        D412: No blank lines allowed between a section header and its content ('Example')
functional.py:1340 in public function `atleast_1d`:
        D205: 1 blank line required between summary line and description (found 0)
functional.py:1340 in public function `atleast_1d`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
functional.py:1376 in public function `atleast_2d`:
        D205: 1 blank line required between summary line and description (found 0)
functional.py:1376 in public function `atleast_2d`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
functional.py:1414 in public function `atleast_3d`:
        D205: 1 blank line required between summary line and description (found 0)
functional.py:1414 in public function `atleast_3d`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
functional.py:1480 in public function `norm` (skipping F811):
        D103: Missing docstring in public function
functional.py:1485 in public function `norm` (skipping F811):
        D103: Missing docstring in public function
functional.py:1490 in public function `norm` (skipping F811):
        D103: Missing docstring in public function
functional.py:1496 in public function `norm` (skipping F811):
        D202: No blank lines allowed after function docstring (found 1)
functional.py:1496 in public function `norm` (skipping F811):
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
functional.py:1693 in public function `unravel_index`:
        D205: 1 blank line required between summary line and description (found 0)
functional.py:1693 in public function `unravel_index`:
        D400: First line should end with a period (not 't')
functional.py:1693 in public function `unravel_index`:
        D401: First line should be in imperative mood (perhaps 'Convert', not 'Converts')
functional.py:1775 in public function `chain_matmul`:
        D205: 1 blank line required between summary line and description (found 0)
functional.py:1775 in public function `chain_matmul`:
        D400: First line should end with a period (not 'd')
functional.py:1775 in public function `chain_matmul`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
functional.py:1823 in private function `_lu_impl`:
        D205: 1 blank line required between summary line and description (found 0)
functional.py:1823 in private function `_lu_impl`:
        D400: First line should end with a period (not 's')
functional.py:1823 in private function `_lu_impl`:
        D401: First line should be in imperative mood (perhaps 'Compute', not 'Computes')
functional.py:1977 in public function `align_tensors`:
        D103: Missing docstring in public function
40
```
```
torch/functional.py:1 at module level:
        D100: Missing docstring in public module
torch/functional.py:396 in public function `meshgrid`:
        D103: Missing docstring in public function
torch/functional.py:1110 in public function `tensordot` (skipping F811):
        D103: Missing docstring in public function
torch/functional.py:1114 in public function `tensordot` (skipping F811):
        D103: Missing docstring in public function
torch/functional.py:1118 in public function `tensordot` (skipping F811):
        D103: Missing docstring in public function
torch/functional.py:1486 in public function `norm` (skipping F811):
        D103: Missing docstring in public function
torch/functional.py:1491 in public function `norm` (skipping F811):
        D103: Missing docstring in public function
torch/functional.py:1496 in public function `norm` (skipping F811):
        D103: Missing docstring in public function
torch/functional.py:1988 in public function `align_tensors`:
        D103: Missing docstring in public function
9
```

## Guards
```
_guards.py:52 in public class `CompileId`:
        D101: Missing docstring in public class
_guards.py:61 in public method `__str__`:
        D105: Missing docstring in magic method
_guards.py:65 in public class `TraceId`:
        D101: Missing docstring in public class
_guards.py:71 in public method `__str__`:
        D105: Missing docstring in magic method
_guards.py:78 in public class `GuardSource`:
        D101: Missing docstring in public class
_guards.py:89 in public method `is_fsdp_module`:
        D102: Missing docstring in public method
_guards.py:92 in public method `is_nn_module`:
        D102: Missing docstring in public method
_guards.py:102 in public method `is_local`:
        D102: Missing docstring in public method
_guards.py:124 in public class `GuardBuilderBase`:
        D101: Missing docstring in public class
_guards.py:128 in public class `ShapeGuard`:
        D101: Missing docstring in public class
_guards.py:134 in public class `Guard`:
        D101: Missing docstring in public class
_guards.py:165 in public method `__hash__`:
        D105: Missing docstring in magic method
_guards.py:170 in public method `sort_key`:
        D102: Missing docstring in public method
_guards.py:178 in public method `__lt__`:
        D105: Missing docstring in magic method
_guards.py:181 in public method `inner_create_fn`:
        D102: Missing docstring in public method
_guards.py:188 in public method `name`:
        D102: Missing docstring in public method
_guards.py:192 in public method `source`:
        D102: Missing docstring in public method
_guards.py:197 in public method `weakref_to_str`:
        D401: First line should be in imperative mood; try rephrasing (found 'This')
_guards.py:220 in public method `__repr__`:
        D105: Missing docstring in magic method
_guards.py:232 in public method `__str__`:
        D105: Missing docstring in magic method
_guards.py:243 in public method `create`:
        D102: Missing docstring in public method
_guards.py:246 in public method `is_nn_module`:
        D102: Missing docstring in public method
_guards.py:249 in public method `is_fsdp_module`:
        D102: Missing docstring in public method
_guards.py:252 in public method `is_local`:
        D102: Missing docstring in public method
_guards.py:255 in public method `set_export_info`:
        D102: Missing docstring in public method
_guards.py:290 in public class `GuardEnvExpr`:
        D101: Missing docstring in public class
_guards.py:301 in public class `DuplicateInputs`:
        D101: Missing docstring in public class
_guards.py:305 in public method `__post_init__`:
        D105: Missing docstring in magic method
_guards.py:322 in public class `Checkpointable`:
        D101: Missing docstring in public class
_guards.py:324 in public method `copy_graphstate`:
        D102: Missing docstring in public method
_guards.py:328 in public method `restore_graphstate`:
        D102: Missing docstring in public method
_guards.py:337 in public class `GuardsCheckpointState`:
        D101: Missing docstring in public class
_guards.py:340 in public method `__init__`:
        D107: Missing docstring in __init__
_guards.py:350 in public method `diff`:
        D102: Missing docstring in public method
_guards.py:356 in public method `__eq__`:
        D105: Missing docstring in magic method
_guards.py:360 in public class `ModuleContextCheckpointState`:
        D101: Missing docstring in public class
_guards.py:363 in public method `__init__`:
        D107: Missing docstring in __init__
_guards.py:373 in public method `diff`:
        D102: Missing docstring in public method
_guards.py:379 in public method `__eq__`:
        D105: Missing docstring in magic method
_guards.py:383 in public class `ModuleContext`:
        D101: Missing docstring in public class
_guards.py:384 in public method `__init__`:
        D107: Missing docstring in __init__
_guards.py:387 in public method `copy_graphstate`:
        D102: Missing docstring in public method
_guards.py:390 in public method `restore_graphstate`:
        D102: Missing docstring in public method
_guards.py:395 in public class `GlobalContextCheckpointState`:
        D101: Missing docstring in public class
_guards.py:398 in public method `__init__`:
        D107: Missing docstring in __init__
_guards.py:408 in public method `diff`:
        D102: Missing docstring in public method
_guards.py:414 in public method `__eq__`:
        D105: Missing docstring in magic method
_guards.py:419 in public class `GlobalContext`:
        D205: 1 blank line required between summary line and description (found 0)
_guards.py:434 in public method `__init__`:
        D107: Missing docstring in __init__
_guards.py:437 in public method `copy_graphstate`:
        D102: Missing docstring in public method
_guards.py:440 in public method `restore_graphstate`:
        D102: Missing docstring in public method
_guards.py:461 in public class `GuardsSet`:
        D101: Missing docstring in public class
_guards.py:462 in public method `__init__`:
        D107: Missing docstring in __init__
_guards.py:467 in public method `__iter__`:
        D105: Missing docstring in magic method
_guards.py:470 in public method `__len__`:
        D105: Missing docstring in magic method
_guards.py:475 in public method `__sub__`:
        D105: Missing docstring in magic method
_guards.py:478 in public method `__bool__`:
        D105: Missing docstring in magic method
_guards.py:481 in public method `add`:
        D102: Missing docstring in public method
_guards.py:490 in public method `update`:
        D102: Missing docstring in public method
_guards.py:496 in public class `GuardsContext`:
        D101: Missing docstring in public class
_guards.py:497 in public method `__init__`:
        D107: Missing docstring in __init__
_guards.py:501 in public method `copy_graphstate`:
        D102: Missing docstring in public method
_guards.py:504 in public method `restore_graphstate`:
        D102: Missing docstring in public method
_guards.py:531 in public class `CompileContext`:
        D101: Missing docstring in public class
_guards.py:533 in public method `get`:
        D102: Missing docstring in public method
_guards.py:536 in public method `__init__`:
        D107: Missing docstring in __init__
_guards.py:542 in public method `current_compile_id`:
        D102: Missing docstring in public method
_guards.py:549 in public method `current_trace_id`:
        D102: Missing docstring in public method
_guards.py:567 in public method `get`:
        D102: Missing docstring in public method
_guards.py:570 in public method `__init__`:
        D107: Missing docstring in __init__
_guards.py:605 in public method `patch`:
        D102: Missing docstring in public method
_guards.py:622 in public method `extract_stack`:
        D102: Missing docstring in public method
_guards.py:635 in public method `clear_frame`:
        D102: Missing docstring in public method
_guards.py:669 in public method `current_frame`:
        D102: Missing docstring in public method
_guards.py:693 in public method `report_output_strides`:
        D102: Missing docstring in public method
_guards.py:706 in public method `set_current_loc`:
        D102: Missing docstring in public method
_guards.py:715 in public function `compile_context`:
        D103: Missing docstring in public function
_guards.py:726 in public function `tracing`:
        D205: 1 blank line required between summary line and description (found 0)
_guards.py:726 in public function `tracing`:
        D400: First line should end with a period (not 'd')
_guards.py:726 in public function `tracing`:
        D401: First line should be in imperative mood; try rephrasing (found 'This')
_guards.py:754 in public class `Source`:
        D101: Missing docstring in public class
_guards.py:755 in public method `reconstruct`:
        D102: Missing docstring in public method
_guards.py:758 in public method `guard_source`:
        D102: Missing docstring in public method
_guards.py:761 in public method `name`:
        D102: Missing docstring in public method
_guards.py:764 in public method `make_guard`:
        D102: Missing docstring in public method
_guards.py:769 in public method `is_nn_module`:
        D102: Missing docstring in public method
_guards.py:775 in public class `ChainedSource`:
        D101: Missing docstring in public class
_guards.py:780 in public function `detect_fake_mode`:
        D205: 1 blank line required between summary line and description (found 0)
_guards.py:780 in public function `detect_fake_mode`:
        D400: First line should end with a period (not 'y')
_guards.py:780 in public function `detect_fake_mode`:
        D401: First line should be in imperative mood (perhaps 'Attempt', not 'Attempts')
90
```
```
_guards.py:52 in public class `CompileId`:
        D101: Missing docstring in public class
_guards.py:61 in public method `__str__`:
        D105: Missing docstring in magic method
_guards.py:65 in public class `TraceId`:
        D101: Missing docstring in public class
_guards.py:71 in public method `__str__`:
        D105: Missing docstring in magic method
_guards.py:78 in public class `GuardSource`:
        D101: Missing docstring in public class
_guards.py:89 in public method `is_fsdp_module`:
        D102: Missing docstring in public method
_guards.py:92 in public method `is_nn_module`:
        D102: Missing docstring in public method
_guards.py:102 in public method `is_local`:
        D102: Missing docstring in public method
_guards.py:124 in public class `GuardBuilderBase`:
        D101: Missing docstring in public class
_guards.py:128 in public class `ShapeGuard`:
        D101: Missing docstring in public class
_guards.py:134 in public class `Guard`:
        D101: Missing docstring in public class
_guards.py:165 in public method `__hash__`:
        D105: Missing docstring in magic method
_guards.py:170 in public method `sort_key`:
        D102: Missing docstring in public method
_guards.py:178 in public method `__lt__`:
        D105: Missing docstring in magic method
_guards.py:181 in public method `inner_create_fn`:
        D102: Missing docstring in public method
_guards.py:188 in public method `name`:
        D102: Missing docstring in public method
_guards.py:192 in public method `source`:
        D102: Missing docstring in public method
_guards.py:220 in public method `__repr__`:
        D105: Missing docstring in magic method
_guards.py:232 in public method `__str__`:
        D105: Missing docstring in magic method
_guards.py:243 in public method `create`:
        D102: Missing docstring in public method
_guards.py:246 in public method `is_nn_module`:
        D102: Missing docstring in public method
_guards.py:249 in public method `is_fsdp_module`:
        D102: Missing docstring in public method
_guards.py:252 in public method `is_local`:
        D102: Missing docstring in public method
_guards.py:255 in public method `set_export_info`:
        D102: Missing docstring in public method
_guards.py:290 in public class `GuardEnvExpr`:
        D101: Missing docstring in public class
_guards.py:301 in public class `DuplicateInputs`:
        D101: Missing docstring in public class
_guards.py:305 in public method `__post_init__`:
        D105: Missing docstring in magic method
_guards.py:322 in public class `Checkpointable`:
        D101: Missing docstring in public class
_guards.py:324 in public method `copy_graphstate`:
        D102: Missing docstring in public method
_guards.py:328 in public method `restore_graphstate`:
        D102: Missing docstring in public method
_guards.py:337 in public class `GuardsCheckpointState`:
        D101: Missing docstring in public class
_guards.py:340 in public method `__init__`:
        D107: Missing docstring in __init__
_guards.py:350 in public method `diff`:
        D102: Missing docstring in public method
_guards.py:356 in public method `__eq__`:
        D105: Missing docstring in magic method
_guards.py:360 in public class `ModuleContextCheckpointState`:
        D101: Missing docstring in public class
_guards.py:363 in public method `__init__`:
        D107: Missing docstring in __init__
_guards.py:373 in public method `diff`:
        D102: Missing docstring in public method
_guards.py:379 in public method `__eq__`:
        D105: Missing docstring in magic method
_guards.py:383 in public class `ModuleContext`:
        D101: Missing docstring in public class
_guards.py:384 in public method `__init__`:
        D107: Missing docstring in __init__
_guards.py:387 in public method `copy_graphstate`:
        D102: Missing docstring in public method
_guards.py:390 in public method `restore_graphstate`:
        D102: Missing docstring in public method
_guards.py:395 in public class `GlobalContextCheckpointState`:
        D101: Missing docstring in public class
_guards.py:398 in public method `__init__`:
        D107: Missing docstring in __init__
_guards.py:408 in public method `diff`:
        D102: Missing docstring in public method
_guards.py:414 in public method `__eq__`:
        D105: Missing docstring in magic method
_guards.py:431 in public method `__init__`:
        D107: Missing docstring in __init__
_guards.py:434 in public method `copy_graphstate`:
        D102: Missing docstring in public method
_guards.py:437 in public method `restore_graphstate`:
        D102: Missing docstring in public method
_guards.py:458 in public class `GuardsSet`:
        D101: Missing docstring in public class
_guards.py:459 in public method `__init__`:
        D107: Missing docstring in __init__
_guards.py:464 in public method `__iter__`:
        D105: Missing docstring in magic method
_guards.py:467 in public method `__len__`:
        D105: Missing docstring in magic method
_guards.py:472 in public method `__sub__`:
        D105: Missing docstring in magic method
_guards.py:475 in public method `__bool__`:
        D105: Missing docstring in magic method
_guards.py:478 in public method `add`:
        D102: Missing docstring in public method
_guards.py:487 in public method `update`:
        D102: Missing docstring in public method
_guards.py:493 in public class `GuardsContext`:
        D101: Missing docstring in public class
_guards.py:494 in public method `__init__`:
        D107: Missing docstring in __init__
_guards.py:498 in public method `copy_graphstate`:
        D102: Missing docstring in public method
_guards.py:501 in public method `restore_graphstate`:
        D102: Missing docstring in public method
_guards.py:528 in public class `CompileContext`:
        D101: Missing docstring in public class
_guards.py:530 in public method `get`:
        D102: Missing docstring in public method
_guards.py:533 in public method `__init__`:
        D107: Missing docstring in __init__
_guards.py:539 in public method `current_compile_id`:
        D102: Missing docstring in public method
_guards.py:546 in public method `current_trace_id`:
        D102: Missing docstring in public method
_guards.py:564 in public method `get`:
        D102: Missing docstring in public method
_guards.py:567 in public method `__init__`:
        D107: Missing docstring in __init__
_guards.py:602 in public method `patch`:
        D102: Missing docstring in public method
_guards.py:619 in public method `extract_stack`:
        D102: Missing docstring in public method
_guards.py:632 in public method `clear_frame`:
        D102: Missing docstring in public method
_guards.py:666 in public method `current_frame`:
        D102: Missing docstring in public method
_guards.py:690 in public method `report_output_strides`:
        D102: Missing docstring in public method
_guards.py:703 in public method `set_current_loc`:
        D102: Missing docstring in public method
_guards.py:712 in public function `compile_context`:
        D103: Missing docstring in public function
_guards.py:750 in public class `Source`:
        D101: Missing docstring in public class
_guards.py:751 in public method `reconstruct`:
        D102: Missing docstring in public method
_guards.py:754 in public method `guard_source`:
        D102: Missing docstring in public method
_guards.py:757 in public method `name`:
        D102: Missing docstring in public method
_guards.py:760 in public method `make_guard`:
        D102: Missing docstring in public method
_guards.py:765 in public method `is_nn_module`:
        D102: Missing docstring in public method
_guards.py:771 in public class `ChainedSource`:
        D101: Missing docstring in public class
82
```

## JIT Internal
```
_jit_internal.py:1 at module level:
        D205: 1 blank line required between summary line and description (found 0)
_jit_internal.py:1 at module level:
        D400: First line should end with a period (not 't')
_jit_internal.py:82 in public class `SourceLoader`:
        D101: Missing docstring in public class
_jit_internal.py:83 in public method `__init__`:
        D107: Missing docstring in __init__
_jit_internal.py:86 in public method `cache`:
        D102: Missing docstring in public method
_jit_internal.py:89 in public method `get_source`:
        D102: Missing docstring in public method
_jit_internal.py:97 in public function `createResolutionCallbackFromEnv`:
        D205: 1 blank line required between summary line and description (found 0)
_jit_internal.py:97 in public function `createResolutionCallbackFromEnv`:
        D400: First line should end with a period (not 'n')
_jit_internal.py:97 in public function `createResolutionCallbackFromEnv`:
        D401: First line should be in imperative mood (perhaps 'Create', not 'Creates')
_jit_internal.py:164 in public function `createResolutionCallbackFromFrame`:
        D205: 1 blank line required between summary line and description (found 0)
_jit_internal.py:164 in public function `createResolutionCallbackFromFrame`:
        D400: First line should end with a period (not ',')
_jit_internal.py:164 in public function `createResolutionCallbackFromFrame`:
        D401: First line should be in imperative mood (perhaps 'Create', not 'Creates')
_jit_internal.py:214 in public function `get_closure`:
        D200: One-line docstring should fit on one line with quotes (found 3)
_jit_internal.py:214 in public function `get_closure`:
        D400: First line should end with a period (not 'n')
_jit_internal.py:272 in public function `createResolutionCallbackFromClosure`:
        D205: 1 blank line required between summary line and description (found 0)
_jit_internal.py:272 in public function `createResolutionCallbackFromClosure`:
        D400: First line should end with a period (not 'f')
_jit_internal.py:293 in public function `can_compile_class`:
        D103: Missing docstring in public function
_jit_internal.py:315 in public function `get_callable_argument_names`:
        D205: 1 blank line required between summary line and description (found 0)
_jit_internal.py:315 in public function `get_callable_argument_names`:
        D401: First line should be in imperative mood (perhaps 'Get', not 'Gets')
_jit_internal.py:346 in public function `get_annotation_str`:
        D205: 1 blank line required between summary line and description (found 0)
_jit_internal.py:346 in public function `get_annotation_str`:
        D400: First line should end with a period (not 'e')
_jit_internal.py:368 in public function `get_type_hint_captures`:
        D205: 1 blank line required between summary line and description (found 0)
_jit_internal.py:368 in public function `get_type_hint_captures`:
        D400: First line should end with a period (not 's')
_jit_internal.py:450 in public function `createResolutionCallbackForClassMethods`:
        D205: 1 blank line required between summary line and description (found 0)
_jit_internal.py:450 in public function `createResolutionCallbackForClassMethods`:
        D400: First line should end with a period (not 'r')
_jit_internal.py:450 in public function `createResolutionCallbackForClassMethods`:
        D401: First line should be in imperative mood; try rephrasing (found 'This')
_jit_internal.py:483 in public function `boolean_dispatch`:
        D205: 1 blank line required between summary line and description (found 0)
_jit_internal.py:530 in public class `FunctionModifiers`:
        D205: 1 blank line required between summary line and description (found 0)
_jit_internal.py:530 in public class `FunctionModifiers`:
        D400: First line should end with a period (not 'd')
_jit_internal.py:546 in public function `export`:
        D205: 1 blank line required between summary line and description (found 0)
_jit_internal.py:546 in public function `export`:
        D400: First line should end with a period (not 'a')
_jit_internal.py:546 in public function `export`:
        D401: First line should be in imperative mood; try rephrasing (found 'This')
_jit_internal.py:592 in public function `unused`:
        D205: 1 blank line required between summary line and description (found 0)
_jit_internal.py:592 in public function `unused`:
        D400: First line should end with a period (not 'd')
_jit_internal.py:592 in public function `unused`:
        D401: First line should be in imperative mood; try rephrasing (found 'This')
_jit_internal.py:655 in public function `ignore`:
        D202: No blank lines allowed after function docstring (found 1)
_jit_internal.py:655 in public function `ignore`:
        D205: 1 blank line required between summary line and description (found 0)
_jit_internal.py:655 in public function `ignore`:
        D400: First line should end with a period (not 'd')
_jit_internal.py:655 in public function `ignore`:
        D401: First line should be in imperative mood; try rephrasing (found 'This')
_jit_internal.py:767 in public function `module_has_exports`:
        D103: Missing docstring in public function
_jit_internal.py:780 in public function `should_drop`:
        D103: Missing docstring in public function
_jit_internal.py:787 in public function `is_ignored_fn`:
        D103: Missing docstring in public function
_jit_internal.py:801 in public function `is_static_fn`:
        D103: Missing docstring in public function
_jit_internal.py:805 in public function `get_static_fn`:
        D103: Missing docstring in public function
_jit_internal.py:809 in public function `get_torchscript_modifier`:
        D103: Missing docstring in public function
_jit_internal.py:817 in public function `copy_torchscript_modifier`:
        D103: Missing docstring in public function
_jit_internal.py:850 in public function `get_overload_no_implementation_error_message`:
        D103: Missing docstring in public function
_jit_internal.py:910 in public function `get_class_name_lineno`:
        D103: Missing docstring in public function
_jit_internal.py:993 in public function `is_tuple`:
        D103: Missing docstring in public function
_jit_internal.py:1007 in public function `is_list`:
        D103: Missing docstring in public function
_jit_internal.py:1020 in public function `is_dict`:
        D103: Missing docstring in public function
_jit_internal.py:1033 in public function `is_union`:
        D103: Missing docstring in public function
_jit_internal.py:1044 in public function `is_optional`:
        D103: Missing docstring in public function
_jit_internal.py:1062 in public function `is_future`:
        D103: Missing docstring in public function
_jit_internal.py:1072 in public function `is_await`:
        D103: Missing docstring in public function
_jit_internal.py:1082 in public function `is_rref`:
        D103: Missing docstring in public function
_jit_internal.py:1091 in public function `is_rref_instance`:
        D103: Missing docstring in public function
_jit_internal.py:1096 in public function `is_rref_instance`:
        D103: Missing docstring in public function
_jit_internal.py:1101 in public function `is_final`:
        D103: Missing docstring in public function
_jit_internal.py:1108 in public class `BroadcastingListCls`:
        D101: Missing docstring in public class
_jit_internal.py:1109 in public method `__getitem__`:
        D105: Missing docstring in magic method
_jit_internal.py:1121 in public function `is_scripting`:
        D205: 1 blank line required between summary line and description (found 0)
_jit_internal.py:1121 in public function `is_scripting`:
        D400: First line should end with a period (not 's')
_jit_internal.py:1121 in public function `is_scripting`:
        D401: First line should be in imperative mood; try rephrasing (found 'Function')
_jit_internal.py:1331 in public function `raise_error_container_parameter_missing`:
        D103: Missing docstring in public function
_jit_internal.py:1345 in public function `check_args_exist`:
        D103: Missing docstring in public function
_jit_internal.py:1356 in public function `check_empty_containers`:
        D103: Missing docstring in public function
_jit_internal.py:1369 in public function `container_checker`:
        D103: Missing docstring in public function
_jit_internal.py:1491 in private function `_extract_tensors`:
        D205: 1 blank line required between summary line and description (found 0)
_jit_internal.py:1491 in private function `_extract_tensors`:
        D401: First line should be in imperative mood; try rephrasing (found 'This')
70
```
```
torch/_jit_internal.py:83 in public class `SourceLoader`:
        D101: Missing docstring in public class
torch/_jit_internal.py:84 in public method `__init__`:
        D107: Missing docstring in __init__
torch/_jit_internal.py:87 in public method `cache`:
        D102: Missing docstring in public method
torch/_jit_internal.py:90 in public method `get_source`:
        D102: Missing docstring in public method
torch/_jit_internal.py:289 in public function `can_compile_class`:
        D103: Missing docstring in public function
torch/_jit_internal.py:753 in public function `module_has_exports`:
        D103: Missing docstring in public function
torch/_jit_internal.py:766 in public function `should_drop`:
        D103: Missing docstring in public function
torch/_jit_internal.py:773 in public function `is_ignored_fn`:
        D103: Missing docstring in public function
torch/_jit_internal.py:787 in public function `is_static_fn`:
        D103: Missing docstring in public function
torch/_jit_internal.py:791 in public function `get_static_fn`:
        D103: Missing docstring in public function
torch/_jit_internal.py:795 in public function `get_torchscript_modifier`:
        D103: Missing docstring in public function
torch/_jit_internal.py:803 in public function `copy_torchscript_modifier`:
        D103: Missing docstring in public function
torch/_jit_internal.py:836 in public function `get_overload_no_implementation_error_message`:
        D103: Missing docstring in public function
torch/_jit_internal.py:896 in public function `get_class_name_lineno`:
        D103: Missing docstring in public function
torch/_jit_internal.py:979 in public function `is_tuple`:
        D103: Missing docstring in public function
torch/_jit_internal.py:993 in public function `is_list`:
        D103: Missing docstring in public function
torch/_jit_internal.py:1006 in public function `is_dict`:
        D103: Missing docstring in public function
torch/_jit_internal.py:1019 in public function `is_union`:
        D103: Missing docstring in public function
torch/_jit_internal.py:1030 in public function `is_optional`:
        D103: Missing docstring in public function
torch/_jit_internal.py:1048 in public function `is_future`:
        D103: Missing docstring in public function
torch/_jit_internal.py:1058 in public function `is_await`:
        D103: Missing docstring in public function
torch/_jit_internal.py:1068 in public function `is_rref`:
        D103: Missing docstring in public function
torch/_jit_internal.py:1077 in public function `is_rref_instance`:
        D103: Missing docstring in public function
torch/_jit_internal.py:1082 in public function `is_rref_instance`:
        D103: Missing docstring in public function
torch/_jit_internal.py:1087 in public function `is_final`:
        D103: Missing docstring in public function
torch/_jit_internal.py:1094 in public class `BroadcastingListCls`:
        D101: Missing docstring in public class
torch/_jit_internal.py:1095 in public method `__getitem__`:
        D105: Missing docstring in magic method
torch/_jit_internal.py:1319 in public function `raise_error_container_parameter_missing`:
        D103: Missing docstring in public function
torch/_jit_internal.py:1333 in public function `check_args_exist`:
        D103: Missing docstring in public function
torch/_jit_internal.py:1344 in public function `check_empty_containers`:
        D103: Missing docstring in public function
torch/_jit_internal.py:1357 in public function `container_checker`:
        D103: Missing docstring in public function
31
```

## Library
```
library.py:1 at module level:
        D100: Missing docstring in public module
library.py:28 in public function `fallthrough_kernel`:
        D200: One-line docstring should fit on one line with quotes (found 3)
library.py:28 in public function `fallthrough_kernel`:
        D401: First line should be in imperative mood; try rephrasing (found 'A')
library.py:34 in public class `Library`:
        D204: 1 blank line required after class docstring (found 0)
library.py:34 in public class `Library`:
        D205: 1 blank line required between summary line and description (found 0)
library.py:34 in public class `Library`:
        D400: First line should end with a period (not 'r')
library.py:51 in public method `__init__`:
        D107: Missing docstring in __init__
library.py:72 in public method `__repr__`:
        D105: Missing docstring in magic method
library.py:76 in public method `define`:
        D300: Use """triple double quotes""" (found '''-quotes)
library.py:76 in public method `define`:
        D401: First line should be in imperative mood (perhaps 'Define', not 'Defines')
library.py:105 in public method `impl`:
        D300: Use """triple double quotes""" (found '''-quotes)
library.py:105 in public method `impl`:
        D401: First line should be in imperative mood (perhaps 'Register', not 'Registers')
library.py:186 in public function `define`:
        D401: First line should be in imperative mood (perhaps 'Define', not 'Defines')
library.py:252 in private function `_`:
        D205: 1 blank line required between summary line and description (found 0)
library.py:252 in private function `_`:
        D401: First line should be in imperative mood; try rephrasing (found 'The')
library.py:339 in private function `_`:
        D400: First line should end with a period (not 'C')
library.py:348 in public function `impl_abstract`:
        D202: No blank lines allowed after function docstring (found 1)
library.py:435 in public function `get_ctx`:
        D402: First line should not be the function's "signature"
18
```
```
library.py:1 at module level:
        D100: Missing docstring in public module
library.py:47 in public method `__init__`:
        D107: Missing docstring in __init__
library.py:68 in public method `__repr__`:
        D105: Missing docstring in magic method
3
```

## Ops
```
_ops.py:21 in public function `dl_open_guard`:
        D205: 1 blank line required between summary line and description (found 0)
_ops.py:21 in public function `dl_open_guard`:
        D400: First line should end with a period (not 'a')
_ops.py:37 in public class `OperatorBase`:
        D205: 1 blank line required between summary line and description (found 0)
_ops.py:37 in public class `OperatorBase`:
        D400: First line should end with a period (not 'r')
_ops.py:42 in public method `__init__`:
        D107: Missing docstring in __init__
_ops.py:88 in public method `__call__`:
        D102: Missing docstring in public method
_ops.py:91 in public method `has_kernel_for_dispatch_key`:
        D102: Missing docstring in public method
_ops.py:94 in public method `has_kernel_for_any_dispatch_key`:
        D102: Missing docstring in public method
_ops.py:100 in public method `py_impl`:
        D102: Missing docstring in public method
_ops.py:142 in public method `py_functionalize_impl`:
        D102: Missing docstring in public method
_ops.py:171 in public method `name`:
        D102: Missing docstring in public method
_ops.py:181 in public function `resolve_key`:
        D103: Missing docstring in public function
_ops.py:247 in public class `HigherOrderOperator`:
        D101: Missing docstring in public class
_ops.py:255 in public method `__init__`:
        D107: Missing docstring in __init__
_ops.py:280 in public method `py_impl`:
        D102: Missing docstring in public method
_ops.py:286 in public method `namespace`:
        D102: Missing docstring in public method
_ops.py:289 in public method `fallthrough`:
        D102: Missing docstring in public method
_ops.py:292 in public method `dispatch`:
        D102: Missing docstring in public method
_ops.py:350 in public method `__call__`:
        D102: Missing docstring in public method
_ops.py:371 in public method `__str__`:
        D105: Missing docstring in magic method
_ops.py:374 in public method `name`:
        D102: Missing docstring in public method
_ops.py:395 in public function `key_extractor`:
        D103: Missing docstring in public function
_ops.py:418 in public function `temporarily_pop_mode`:
        D103: Missing docstring in public function
_ops.py:427 in public function `mode_stack_per_key`:
        D103: Missing docstring in public function
_ops.py:433 in public function `push_mode_for_key`:
        D103: Missing docstring in public function
_ops.py:442 in public function `pop_mode_for_key`:
        D103: Missing docstring in public function
_ops.py:453 in public function `add_cached_op`:
        D103: Missing docstring in public function
_ops.py:458 in public function `reset_cached_ops`:
        D103: Missing docstring in public function
_ops.py:463 in public function `get_cached_ops`:
        D103: Missing docstring in public function
_ops.py:470 in public class `OpOverload`:
        D101: Missing docstring in public class
_ops.py:471 in public method `__init__`:
        D107: Missing docstring in __init__
_ops.py:504 in public method `__deepcopy__`:
        D105: Missing docstring in magic method
_ops.py:507 in public method `__repr__`:
        D105: Missing docstring in magic method
_ops.py:512 in public method `__call__`:
        D102: Missing docstring in public method
_ops.py:515 in public method `__hash__`:
        D105: Missing docstring in magic method
_ops.py:519 in public method `__str__`:
        D105: Missing docstring in magic method
_ops.py:522 in public method `has_kernel_for_dispatch_key`:
        D102: Missing docstring in public method
_ops.py:527 in public method `has_kernel_for_any_dispatch_key`:
        D102: Missing docstring in public method
_ops.py:533 in public method `namespace`:
        D102: Missing docstring in public method
_ops.py:536 in public method `decompose`:
        D102: Missing docstring in public method
_ops.py:657 in public method `name`:
        D102: Missing docstring in public method
_ops.py:661 in public method `overloadpacket`:
        D102: Missing docstring in public method
_ops.py:665 in public method `op`:
        D102: Missing docstring in public method
_ops.py:669 in public method `tags`:
        D102: Missing docstring in public method
_ops.py:677 in public class `OpOverloadPacket`:
        D101: Missing docstring in public class
_ops.py:678 in public method `__init__`:
        D107: Missing docstring in __init__
_ops.py:688 in public method `__deepcopy__`:
        D105: Missing docstring in magic method
_ops.py:691 in public method `__repr__`:
        D105: Missing docstring in magic method
_ops.py:696 in public method `__hash__`:
        D105: Missing docstring in magic method
_ops.py:699 in public method `__str__`:
        D105: Missing docstring in magic method
_ops.py:703 in public method `op`:
        D102: Missing docstring in public method
_ops.py:706 in public method `__getattr__`:
        D105: Missing docstring in magic method
_ops.py:749 in public method `__iter__`:
        D105: Missing docstring in magic method
_ops.py:752 in public method `__call__`:
        D102: Missing docstring in public method
_ops.py:760 in public method `overloads`:
        D102: Missing docstring in public method
_ops.py:896 in private method `import_module`:
        D401: First line should be in imperative mood (perhaps 'Import', not 'Imports')
_ops.py:915 in private method `load_library`:
        D401: First line should be in imperative mood (perhaps 'Load', not 'Loads')
57
```
```
_ops.py:36 in public method `__init__`:
        D107: Missing docstring in __init__
_ops.py:82 in public method `__call__`:
        D102: Missing docstring in public method
_ops.py:85 in public method `has_kernel_for_dispatch_key`:
        D102: Missing docstring in public method
_ops.py:88 in public method `has_kernel_for_any_dispatch_key`:
        D102: Missing docstring in public method
_ops.py:94 in public method `py_impl`:
        D102: Missing docstring in public method
_ops.py:136 in public method `py_functionalize_impl`:
        D102: Missing docstring in public method
_ops.py:165 in public method `name`:
        D102: Missing docstring in public method
_ops.py:175 in public function `resolve_key`:
        D103: Missing docstring in public function
_ops.py:241 in public class `HigherOrderOperator`:
        D101: Missing docstring in public class
_ops.py:249 in public method `__init__`:
        D107: Missing docstring in __init__
_ops.py:274 in public method `py_impl`:
        D102: Missing docstring in public method
_ops.py:280 in public method `namespace`:
        D102: Missing docstring in public method
_ops.py:283 in public method `fallthrough`:
        D102: Missing docstring in public method
_ops.py:286 in public method `dispatch`:
        D102: Missing docstring in public method
_ops.py:344 in public method `__call__`:
        D102: Missing docstring in public method
_ops.py:365 in public method `__str__`:
        D105: Missing docstring in magic method
_ops.py:368 in public method `name`:
        D102: Missing docstring in public method
_ops.py:389 in public function `key_extractor`:
        D103: Missing docstring in public function
_ops.py:412 in public function `temporarily_pop_mode`:
        D103: Missing docstring in public function
_ops.py:421 in public function `mode_stack_per_key`:
        D103: Missing docstring in public function
_ops.py:427 in public function `push_mode_for_key`:
        D103: Missing docstring in public function
_ops.py:436 in public function `pop_mode_for_key`:
        D103: Missing docstring in public function
_ops.py:447 in public function `add_cached_op`:
        D103: Missing docstring in public function
_ops.py:452 in public function `reset_cached_ops`:
        D103: Missing docstring in public function
_ops.py:457 in public function `get_cached_ops`:
        D103: Missing docstring in public function
_ops.py:464 in public class `OpOverload`:
        D101: Missing docstring in public class
_ops.py:465 in public method `__init__`:
        D107: Missing docstring in __init__
_ops.py:498 in public method `__deepcopy__`:
        D105: Missing docstring in magic method
_ops.py:501 in public method `__repr__`:
        D105: Missing docstring in magic method
_ops.py:506 in public method `__call__`:
        D102: Missing docstring in public method
_ops.py:509 in public method `__hash__`:
        D105: Missing docstring in magic method
_ops.py:513 in public method `__str__`:
        D105: Missing docstring in magic method
_ops.py:516 in public method `has_kernel_for_dispatch_key`:
        D102: Missing docstring in public method
_ops.py:521 in public method `has_kernel_for_any_dispatch_key`:
        D102: Missing docstring in public method
_ops.py:527 in public method `namespace`:
        D102: Missing docstring in public method
_ops.py:530 in public method `decompose`:
        D102: Missing docstring in public method
_ops.py:651 in public method `name`:
        D102: Missing docstring in public method
_ops.py:655 in public method `overloadpacket`:
        D102: Missing docstring in public method
_ops.py:659 in public method `op`:
        D102: Missing docstring in public method
_ops.py:663 in public method `tags`:
        D102: Missing docstring in public method
_ops.py:671 in public class `OpOverloadPacket`:
        D101: Missing docstring in public class
_ops.py:672 in public method `__init__`:
        D107: Missing docstring in __init__
_ops.py:682 in public method `__deepcopy__`:
        D105: Missing docstring in magic method
_ops.py:685 in public method `__repr__`:
        D105: Missing docstring in magic method
_ops.py:690 in public method `__hash__`:
        D105: Missing docstring in magic method
_ops.py:693 in public method `__str__`:
        D105: Missing docstring in magic method
_ops.py:697 in public method `op`:
        D102: Missing docstring in public method
_ops.py:700 in public method `__getattr__`:
        D105: Missing docstring in magic method
_ops.py:743 in public method `__iter__`:
        D105: Missing docstring in magic method
_ops.py:746 in public method `__call__`:
        D102: Missing docstring in public method
_ops.py:754 in public method `overloads`:
        D102: Missing docstring in public method
51
```

## Tensor Str
```
_tensor_str.py:32 in public function `set_printoptions`:
        D400: First line should end with a period (not 'y')
_tensor_str.py:98 in public function `get_printoptions`:
        D205: 1 blank line required between summary line and description (found 0)
_tensor_str.py:98 in public function `get_printoptions`:
        D400: First line should end with a period (not 't')
_tensor_str.py:98 in public function `get_printoptions`:
        D401: First line should be in imperative mood (perhaps 'Get', not 'Gets')
_tensor_str.py:106 in public function `printoptions`:
        D205: 1 blank line required between summary line and description (found 0)
_tensor_str.py:106 in public function `printoptions`:
        D209: Multi-line docstring closing quotes should be on a separate line
_tensor_str.py:106 in public function `printoptions`:
        D400: First line should end with a period (not 'd')
_tensor_str.py:116 in public function `tensor_totype`:
        D103: Missing docstring in public function
_tensor_str.py:367 in public function `get_summarized_data`:
        D103: Missing docstring in public function
9
```
```
_tensor_str.py:113 in public function `tensor_totype`:
        D103: Missing docstring in public function
_tensor_str.py:364 in public function `get_summarized_data`:
        D103: Missing docstring in public function
2
```



cc @svekars @brycebortree @carljparker