### PR TITLE
Fix docstrings issues for torch.utils.tensorboard files and others

### DIFF
--- a/torch/utils/hipify/constants.py
+++ b/torch/utils/hipify/constants.py
@@ -1,9 +1,10 @@
-""" Constants for annotations in the mapping.
+"""
+Constants for annotations in the mapping.
+
 The constants defined here are used to annotate the mapping tuples in cuda_to_hip_mappings.py.
 They are based on
 https://github.com/ROCm-Developer-Tools/HIP/blob/master/hipify-clang/src/Statistics.h
-and fall in three categories: 1) type of mapping, 2) API of mapping, 3) unsupported
-mapping.
+and fall in three categories: 1) type of mapping, 2) API of mapping, 3) unsupported mapping.
 """
 
 CONV_VERSION = 0,

--- a/torch/utils/tensorboard/_caffe2_graph.py
+++ b/torch/utils/tensorboard/_caffe2_graph.py
@@ -41,6 +41,7 @@ def _make_unique_name(seen: Set[str], name: str, min_version: int = 0):
 def _rename_tensorflow_style(shapes, blob_name_tracker, ops):
     """
     Convert some of the common names in Caffe2 to tensorflow.
+
     NOTE: The common names in both Caffe2 and Tensorflow are currently
         hardcoded, if either side changes at some point, then this code should
         change as well.
@@ -81,6 +82,7 @@ def _rename_tensorflow_style(shapes, blob_name_tracker, ops):
 def _convert_to_ssa(shapes, blob_name_tracker, ops):
     """
     Convert an operator graph to SSA (i.e. out-of-place).
+
     i.e. blobs will be renamed so that each blob is produced only once.
 
     Args:
@@ -215,8 +217,8 @@ def _rename_all(shapes, blob_name_tracker, ops, rename_fn):
 
 def _add_gradient_scope(shapes, blob_name_tracker, ops):
     """
-    For all operators or blobs with name containing "_grad", add a
-    "GRADIENTS/" scope.
+    For all operators or blobs with name containing "_grad", add a "GRADIENTS/" scope.
+
     Note: breaks graph execution since the blob -> gradient mapping is
     hardcoded.
 
@@ -241,9 +243,9 @@ def _add_gradient_scope(shapes, blob_name_tracker, ops):
 
 def _replace_colons(shapes, blob_name_tracker, ops, repl):
     """
-    `:i` has a special meaning in Tensorflow. This function replaces all colons
-    with $ to avoid any possible conflicts.
+    Replace all colons with $ to avoid any possible conflicts.
 
+    NOTE: `:i` has a special meaning in Tensorflow. 
     Args:
         shapes: Dictionary mapping blob names to their shapes/dimensions.
         blob_name_tracker: Dictionary of all unique blob names (with respect to
@@ -266,6 +268,7 @@ def _replace_colons(shapes, blob_name_tracker, ops, repl):
 def _fill_missing_operator_names(ops):
     """
     Give missing operators a name.
+
     We expect C2 operators to be generally unnamed. This gives them a scope
     (inferred from their outputs) and a name after their type. Duplicates will
     be postfixed by an index.
@@ -323,8 +326,7 @@ def _tf_device(device_option):
 
 def _add_tf_shape(attr_dict, ints):
     """
-    Converts a list of ints to a TensorShapeProto representing the dimensions of
-    a blob/object.
+    Convert a list of ints to a TensorShapeProto representing the dimensions of a blob/object.
 
     Args:
         attr_dict: Dictionary to update (usually attributes of a Node)
@@ -343,8 +345,9 @@ def _add_tf_shape(attr_dict, ints):
 
 def _set_tf_attr(attr_dict, arg):
     """
-    Add attributes to a node. Key is the arg.name, and values can be shape,
-        floats, strings, ints or an empty list.
+    Add attributes to a node.
+    
+    Key is the arg.name, and values can be shape, floats, strings, ints or an empty list.
 
     Args:
         attr_dict: Dictionary to update (usually attributes of a Node)
@@ -388,7 +391,7 @@ def _set_tf_attr(attr_dict, arg):
 
 def _operator_to_node(shapes, op):
     """
-    Converts an operator to a node in a TF graph.
+    Convert an operator to a node in a TF graph.
 
     Args:
         shapes: Dictionary mapping blob names to their shapes/dimensions.
@@ -477,7 +480,7 @@ def _operator_to_node_simp(op, inter_blobs, seen):
 
 def _blob_to_node(producing_ops, shapes, name):
     """
-    Converts a blob (operator input or output) to a node in a TF graph.
+    Convert a blob (operator input or output) to a node in a TF graph.
 
     Args:
         producing_ops: Dictionary of blob name to list of
@@ -512,7 +515,7 @@ def _blob_to_node(producing_ops, shapes, name):
 
 def _clear_debug_info(ops, perform_clear):
     """
-    Removes debug information from operators, they are copious.
+    Remove debug information from operators, they are copious.
 
     Args:
         ops: List of Caffe2 operators
@@ -535,8 +538,9 @@ def _clear_debug_info(ops, perform_clear):
 
 def _check_if_forward(blob):
     """
-    Blobs with names containing '_m' or 'grad' are part of the backward pass.
-        This function references facebookresearch/Detectron/detectron/utils/net.py.
+    Check for blobs with names containing '_m' or 'grad' as they are part of the backward pass.
+        
+    This function references facebookresearch/Detectron/detectron/utils/net.py.
 
     Args:
         blob: The blob to inspect
@@ -636,7 +640,7 @@ def _operators_to_graph_def(
     custom_rename=None,
 ):
     """
-    Main function to convert set of operators to a graph.
+    Convert set of operators to a graph.
 
     Args:
         shapes: Dictionary mapping blob names to their shapes/dimensions.
@@ -760,8 +764,9 @@ def _try_get_shapes(nets):
 
 def model_to_graph_def(model, **kwargs):
     """
-    Convert a Caffe2 model to a Tensorflow graph. This function extracts
-    'param_init_net' and 'net' from the model and passes it to nets_to_graph()
+    Convert a Caffe2 model to a Tensorflow graph.
+    
+    This function extracts 'param_init_net' and 'net' from the model and passes it to nets_to_graph()
     for further processing.
 
     Args:

--- a/torch/utils/tensorboard/_caffe2_graph.py
+++ b/torch/utils/tensorboard/_caffe2_graph.py
@@ -245,7 +245,7 @@ def _replace_colons(shapes, blob_name_tracker, ops, repl):
     """
     Replace all colons with $ to avoid any possible conflicts.
 
-    NOTE: `:i` has a special meaning in Tensorflow. 
+    NOTE: `:i` has a special meaning in Tensorflow.
     Args:
         shapes: Dictionary mapping blob names to their shapes/dimensions.
         blob_name_tracker: Dictionary of all unique blob names (with respect to
@@ -346,7 +346,7 @@ def _add_tf_shape(attr_dict, ints):
 def _set_tf_attr(attr_dict, arg):
     """
     Add attributes to a node.
-    
+
     Key is the arg.name, and values can be shape, floats, strings, ints or an empty list.
 
     Args:
@@ -539,7 +539,7 @@ def _clear_debug_info(ops, perform_clear):
 def _check_if_forward(blob):
     """
     Check for blobs with names containing '_m' or 'grad' as they are part of the backward pass.
-        
+
     This function references facebookresearch/Detectron/detectron/utils/net.py.
 
     Args:
@@ -765,7 +765,7 @@ def _try_get_shapes(nets):
 def model_to_graph_def(model, **kwargs):
     """
     Convert a Caffe2 model to a Tensorflow graph.
-    
+
     This function extracts 'param_init_net' and 'net' from the model and passes it to nets_to_graph()
     for further processing.
 

--- a/torch/utils/tensorboard/_proto_graph.py
+++ b/torch/utils/tensorboard/_proto_graph.py
@@ -5,9 +5,11 @@ from tensorboard.compat.proto.tensor_shape_pb2 import TensorShapeProto
 
 
 def attr_value_proto(dtype, shape, s):
-    """Creates a dict of objects matching
-    https://github.com/tensorflow/tensorboard/blob/master/tensorboard/compat/proto/attr_value.proto
-    specifically designed for a NodeDef. The values have been
+    """
+    Create a dict of objects matching the AttrValue proto.
+
+    Following https://github.com/tensorflow/tensorboard/blob/master/tensorboard/compat/proto/attr_value.proto
+    which is specifically designed for a NodeDef. The values have been
     reverse engineered from standard TensorBoard logged data.
     """
     attr = {}
@@ -20,8 +22,10 @@ def attr_value_proto(dtype, shape, s):
 
 
 def tensor_shape_proto(outputsize):
-    """Creates an object matching
-    https://github.com/tensorflow/tensorboard/blob/master/tensorboard/compat/proto/tensor_shape.proto
+    """
+    Create an object matching the TensorShapeProto proto.
+
+    Following https://github.com/tensorflow/tensorboard/blob/master/tensorboard/compat/proto/tensor_shape.proto
     """
     return TensorShapeProto(dim=[TensorShapeProto.Dim(size=d) for d in outputsize])
 
@@ -35,8 +39,9 @@ def node_proto(
     outputsize=None,
     attributes="",
 ):
-    """Creates an object matching
-    https://github.com/tensorflow/tensorboard/blob/master/tensorboard/compat/proto/node_def.proto
+    """Create an object matching the NodeDef proto.
+
+    Following https://github.com/tensorflow/tensorboard/blob/master/tensorboard/compat/proto/node_def.proto
     """
     if input is None:
         input = []

--- a/torch/utils/tensorboard/_pytorch_graph.py
+++ b/torch/utils/tensorboard/_pytorch_graph.py
@@ -119,8 +119,8 @@ class NodePyOP(NodePy):
 
 
 class GraphPy:
-    """Helper class to convert torch.nn.Module to GraphDef proto and visualization
-    with TensorBoard.
+    """
+    Helper class to convert torch.nn.Module to GraphDef proto and visualization with TensorBoard.
 
     GraphDef generation operates in two passes:
 
@@ -139,7 +139,6 @@ class GraphPy:
     in a heuristic kind of way. Bookkeeping is done with shallowest_scope_name
     and scope_name_appeared.
     """
-
     def __init__(self):
         self.nodes_op = []
         self.nodes_io = OrderedDict()
@@ -213,10 +212,7 @@ class GraphPy:
                 ]
 
     def to_proto(self):
-        """
-        Converts graph representation of GraphPy object to TensorBoard
-        required format.
-        """
+        """Convert graph representation of GraphPy object to TensorBoard required format."""
         # TODO: compute correct memory usage and CPU time once
         # PyTorch supports it
         nodes = []
@@ -234,7 +230,10 @@ class GraphPy:
 
 
 def parse(graph, trace, args=None, omit_useless_nodes=True):
-    """This method parses an optimized PyTorch model graph and produces
+    """
+    Parse PyTorch autograd graph to a list of TensorBoard NodeDef proto.
+
+    This method parses an optimized PyTorch model graph and produces
     a list of nodes and node stats for eventual conversion to TensorBoard
     protobuf format.
 
@@ -318,6 +317,8 @@ def parse(graph, trace, args=None, omit_useless_nodes=True):
 
 def graph(model, args, verbose=False, use_strict_trace=True):
     """
+    Process PyTorch model to produce TensorBoard GraphDef proto.
+
     This method processes a PyTorch model and produces a `GraphDef` proto
     that can be logged to TensorBoard.
 
@@ -363,7 +364,7 @@ def graph(model, args, verbose=False, use_strict_trace=True):
 
 @contextlib.contextmanager
 def _set_model_to_eval(model):
-    """A context manager to temporarily set the training mode of ``model`` to eval."""
+    """Set model temporarily to eval mode."""
     if not isinstance(model, torch.jit.ScriptFunction):
         originally_training = model.training
         model.train(False)
@@ -380,6 +381,6 @@ def _set_model_to_eval(model):
 
 
 def _node_get(node: torch._C.Node, key: str):
-    """Gets attributes of a node which is polymorphic over return type."""
+    """Get attributes of a node which is polymorphic over return type."""
     sel = node.kindOf(key)
     return getattr(node, sel)(key)

--- a/torch/utils/tensorboard/_utils.py
+++ b/torch/utils/tensorboard/_utils.py
@@ -3,7 +3,8 @@ import numpy as np
 
 # Functions for converting
 def figure_to_image(figures, close=True):
-    """Render matplotlib figure to numpy format.
+    """
+    Render matplotlib figure to numpy format.
 
     Note that this requires the ``matplotlib`` package.
 
@@ -38,8 +39,11 @@ def figure_to_image(figures, close=True):
 
 def _prepare_video(V):
     """
-    Converts a 5D tensor [batchsize, time(frame), channel(color), height, width]
+    Prepare video in a specific format.
+
+    Convert a 5D tensor [batchsize, time(frame), channel(color), height, width]
     into 4D tensor with dimension [time(frame), new_width, new_height, channel].
+    
     A batch of images are spreaded to a grid, which forms a frame.
     e.g. Video with batchsize 16 will have a 4x4 grid.
     """
@@ -67,6 +71,16 @@ def _prepare_video(V):
 
 
 def make_grid(I, ncols=8):
+    """
+    Make a grid of images.
+
+    Args:
+      I (numpy.ndarray): a batch of images
+      ncols (int): number of columns
+
+    Returns:
+      numpy.ndarray: a grid of images
+    """
     # I: N1HW or N3HW
     assert isinstance(I, np.ndarray), "plugin error, should pass numpy array here"
     if I.shape[1] == 1:
@@ -93,6 +107,7 @@ def make_grid(I, ncols=8):
 
 
 def convert_to_HWC(tensor, input_format):  # tensor: numpy array
+    """Convert tensor to HWC format."""
     assert len(set(input_format)) == len(
         input_format
     ), f"You can not use the same dimension shordhand twice.         input_format: {input_format}"

--- a/torch/utils/tensorboard/_utils.py
+++ b/torch/utils/tensorboard/_utils.py
@@ -43,7 +43,7 @@ def _prepare_video(V):
 
     Convert a 5D tensor [batchsize, time(frame), channel(color), height, width]
     into 4D tensor with dimension [time(frame), new_width, new_height, channel].
-    
+
     A batch of images are spreaded to a grid, which forms a frame.
     e.g. Video with batchsize 16 will have a 4x4 grid.
     """

--- a/torch/utils/tensorboard/summary.py
+++ b/torch/utils/tensorboard/summary.py
@@ -1,3 +1,5 @@
+"""Utilities for generating TensorBoard summaries."""
+
 import json
 import logging
 import os
@@ -161,7 +163,9 @@ def _draw_single_box(
 
 
 def hparams(hparam_dict=None, metric_dict=None, hparam_domain_discrete=None):
-    """Outputs three `Summary` protocol buffers needed by hparams plugin.
+    """
+    Output three `Summary` protocol buffers needed by hparams plugin.
+
     `Experiment` keeps the metadata of an experiment, such as the name of the
       hyperparameters and the name of the metrics.
     `SessionStartInfo` keeps key-value pairs of the hyperparameters
@@ -349,7 +353,9 @@ def hparams(hparam_dict=None, metric_dict=None, hparam_domain_discrete=None):
 
 
 def scalar(name, tensor, collections=None, new_style=False, double_precision=False):
-    """Outputs a `Summary` protocol buffer containing a single scalar value.
+    """
+    Output a `Summary` protocol buffer containing a single scalar value.
+    
     The generated Summary has a Tensor.proto containing the input Tensor.
     Args:
       name: A name for the generated node. Will also serve as the series name in
@@ -391,7 +397,9 @@ def scalar(name, tensor, collections=None, new_style=False, double_precision=Fal
 
 
 def tensor_proto(tag, tensor):
-    """Outputs a `Summary` protocol buffer containing the full tensor.
+    """
+    Output a `Summary` protocol buffer containing the full tensor.
+
     The generated Summary has a Tensor.proto containing the input Tensor.
     Args:
       name: A name for the generated node. Will also serve as the series name in
@@ -429,7 +437,9 @@ def tensor_proto(tag, tensor):
 
 def histogram_raw(name, min, max, num, sum, sum_squares, bucket_limits, bucket_counts):
     # pylint: disable=line-too-long
-    """Outputs a `Summary` protocol buffer with a histogram.
+    """
+    Output a `Summary` protocol buffer with a histogram.
+    
     The generated
     [`Summary`](https://www.tensorflow.org/code/tensorflow/core/framework/summary.proto)
     has one summary value containing a histogram for `values`.
@@ -461,7 +471,9 @@ def histogram_raw(name, min, max, num, sum, sum_squares, bucket_limits, bucket_c
 
 def histogram(name, values, bins, max_bins=None):
     # pylint: disable=line-too-long
-    """Outputs a `Summary` protocol buffer with a histogram.
+    """
+    Output a `Summary` protocol buffer with a histogram.
+
     The generated
     [`Summary`](https://www.tensorflow.org/code/tensorflow/core/framework/summary.proto)
     has one summary value containing a histogram for `values`.
@@ -536,7 +548,9 @@ def make_histogram(values, bins, max_bins=None):
 
 
 def image(tag, tensor, rescale=1, dataformats="NCHW"):
-    """Outputs a `Summary` protocol buffer with images.
+    """
+    Output a `Summary` protocol buffer with images.
+
     The summary has up to `max_images` summary values containing images. The
     images are built from `tensor` which must be 3-D with shape `[height, width,
     channels]` and where `channels` can be:
@@ -574,7 +588,7 @@ def image(tag, tensor, rescale=1, dataformats="NCHW"):
 def image_boxes(
     tag, tensor_image, tensor_boxes, rescale=1, dataformats="CHW", labels=None
 ):
-    """Outputs a `Summary` protocol buffer with images."""
+    """Output a `Summary` protocol buffer with images."""
     tensor_image = make_np(tensor_image)
     tensor_image = convert_to_HWC(tensor_image, dataformats)
     tensor_boxes = make_np(tensor_boxes)
@@ -589,7 +603,19 @@ def image_boxes(
 
 
 def draw_boxes(disp_image, boxes, labels=None):
-    # xyxy format
+    """
+    Draw bounding boxes on an image tensor.
+
+    Args:
+      disp_image: A numpy array of shape [height, width, 3] representing the
+          image pixels in RGB format.
+      boxes: A numpy array of shape [num_boxes, 4] representing the coordinates
+          of the boxes in xyxy format.
+      labels: A list of strings representing the class labels for each box.
+
+    Returns:
+      A numpy array representing the image overlaid with boxes.
+    """
     num_boxes = boxes.shape[0]
     list_gt = range(num_boxes)
     for i in list_gt:
@@ -606,7 +632,7 @@ def draw_boxes(disp_image, boxes, labels=None):
 
 
 def make_image(tensor, rescale=1, rois=None, labels=None):
-    """Convert a numpy representation of an image to Image protobuf"""
+    """Convert a numpy representation of an image to Image protobuf."""
     from PIL import Image
 
     height, width, channel = tensor.shape
@@ -635,6 +661,18 @@ def make_image(tensor, rescale=1, rois=None, labels=None):
 
 
 def video(tag, tensor, fps=4):
+    """
+    Create a video summary of a tensor.
+
+    Args:
+      tag: A name for the generated node. Will also serve as a series 
+        name in TensorBoard.
+      tensor : Input tensor containing consecutive video frames
+      fps : Frames per second of the video
+
+    Returns:
+      A scalar `Tensor` of type `string`. The serialized `Summary` protocol
+    """
     tensor = make_np(tensor)
     tensor = _prepare_video(tensor)
     # If user passes in uint8, then we don't need to rescale by 255
@@ -646,6 +684,16 @@ def video(tag, tensor, fps=4):
 
 
 def make_video(tensor, fps):
+    """
+    Convert a numpy representation of a video to a video protobuf.
+
+    Args:
+      tensor : Input tensor containing consecutive video frames
+      fps : Frames per second of the video
+
+    Returns:
+        A video protobuf in a `Summary` protobuf.
+    """
     try:
         import moviepy  # noqa: F401
     except ImportError:
@@ -689,6 +737,18 @@ def make_video(tensor, fps):
 
 
 def audio(tag, tensor, sample_rate=44100):
+    """
+    Create an audio summary of a tensor.
+
+    Args:
+      tag: A name for the generated node. Will also serve as a series 
+          name in TensorBoard.
+      tensor : Input tensor containing consecutive audio frames
+      sample_rate : Sample rate of the audio
+
+    Returns:
+      A scalar `Tensor` of type `string`. The serialized `Summary` protocol
+    """
     array = make_np(tensor)
     array = array.squeeze()
     if abs(array).max() > 1:
@@ -719,6 +779,16 @@ def audio(tag, tensor, sample_rate=44100):
 
 
 def custom_scalars(layout):
+    """
+    Output a `Summary` protocol buffer with custom scalar data.
+
+    Args:
+      layout: A list of category-title pairs. Within each category, a chart
+          will be generated for each scalar.
+    
+    Returns:
+      A scalar `Tensor` of type `string`. The serialized `Summary` protocol
+    """
     categories = []
     for k, v in layout.items():
         charts = []
@@ -756,6 +826,18 @@ def custom_scalars(layout):
 
 
 def text(tag, text):
+    """
+    Create a text summary.
+
+    Args:
+      tag: A name for the generated node. Will also serve as a series 
+          name in TensorBoard.
+      text : A string
+    
+    Returns:
+      A scalar `Tensor` of type `string`. The serialized `Summary` protocol.
+
+    """
     plugin_data = SummaryMetadata.PluginData(
         plugin_name="text", content=TextPluginData(version=0).SerializeToString()
     )
@@ -773,6 +855,25 @@ def text(tag, text):
 def pr_curve_raw(
     tag, tp, fp, tn, fn, precision, recall, num_thresholds=127, weights=None
 ):
+    """
+    Output a `Summary` protocol buffer with PR curve data.
+
+    Args:
+      tag: A name for the generated node. Will also serve as a series 
+          name in TensorBoard.
+      tp: True positives counts.
+      fp: False positives counts.
+      tn: True negatives counts.
+      fn: False negatives counts.
+      precision: Precision values.
+      recall: Recall values.
+      num_thresholds: Number of thresholds used to draw the curve.
+      weights: Optional weight each value of the curve by threshold.
+
+    Returns:
+      A scalar `Tensor` of type `string`. The serialized `Summary` protocol.
+
+    """
     if num_thresholds > 127:  # weird, value > 127 breaks protobuf
         num_thresholds = 127
     data = np.stack((tp, fp, tn, fn, precision, recall))
@@ -797,6 +898,20 @@ def pr_curve_raw(
 
 
 def pr_curve(tag, labels, predictions, num_thresholds=127, weights=None):
+    """
+    Output a `Summary` protocol buffer with PR curve data.
+
+    Args:
+      tag: A name for the generated node. Will also serve as a series 
+          name in TensorBoard.
+      labels: Ground truth values. shape = [batch_size, d0, .. dN].
+      predictions: The predicted values. shape = [batch_size, d0, .. dN].
+      num_thresholds: Number of thresholds used to draw the curve.
+      weights: Optional weight each value of the curve by threshold.
+
+    Returns:
+      A scalar `Tensor` of type `string`. The serialized `Summary` protocol.
+    """
     # weird, value > 127 breaks protobuf
     num_thresholds = min(num_thresholds, 127)
     data = compute_curve(
@@ -824,6 +939,19 @@ def pr_curve(tag, labels, predictions, num_thresholds=127, weights=None):
 
 # https://github.com/tensorflow/tensorboard/blob/master/tensorboard/plugins/pr_curve/summary.py
 def compute_curve(labels, predictions, num_thresholds=None, weights=None):
+    """
+    Compute the entries of the PR curve.
+
+    Args:
+      labels: Ground truth values. shape = [batch_size, d0, .. dN].
+      predictions: The predicted values. shape = [batch_size, d0, .. dN].
+      num_thresholds: Number of thresholds used to draw the curve.
+      weights: Optional weight each value of the curve by threshold.
+
+    Returns:
+      numpy array with columns [tp, fp, tn, fn, precision, recall].
+    
+    """
     _MINIMUM_COUNT = 1e-7
 
     if weights is None:
@@ -859,7 +987,7 @@ def compute_curve(labels, predictions, num_thresholds=None, weights=None):
 def _get_tensor_summary(
     name, display_name, description, tensor, content_type, components, json_config
 ):
-    """Creates a tensor summary with summary metadata.
+    """Create a tensor summary with summary metadata.
 
     Args:
       name: Uniquely identifiable name of the summary op. Could be replaced by
@@ -916,7 +1044,7 @@ def _get_tensor_summary(
 
 
 def _get_json_config(config_dict):
-    """Parses and returns JSON string from python dictionary."""
+    """Parse and returns JSON string from python dictionary."""
     json_config = "{}"
     if config_dict is not None:
         json_config = json.dumps(config_dict, sort_keys=True)
@@ -927,7 +1055,8 @@ def _get_json_config(config_dict):
 def mesh(
     tag, vertices, colors, faces, config_dict, display_name=None, description=None
 ):
-    """Outputs a merged `Summary` protocol buffer with a mesh/point cloud.
+    """
+    Output a merged `Summary` protocol buffer with a mesh/point cloud.
 
     Args:
       tag: A name for this summary operation.

--- a/torch/utils/tensorboard/summary.py
+++ b/torch/utils/tensorboard/summary.py
@@ -355,7 +355,7 @@ def hparams(hparam_dict=None, metric_dict=None, hparam_domain_discrete=None):
 def scalar(name, tensor, collections=None, new_style=False, double_precision=False):
     """
     Output a `Summary` protocol buffer containing a single scalar value.
-    
+
     The generated Summary has a Tensor.proto containing the input Tensor.
     Args:
       name: A name for the generated node. Will also serve as the series name in
@@ -439,7 +439,7 @@ def histogram_raw(name, min, max, num, sum, sum_squares, bucket_limits, bucket_c
     # pylint: disable=line-too-long
     """
     Output a `Summary` protocol buffer with a histogram.
-    
+
     The generated
     [`Summary`](https://www.tensorflow.org/code/tensorflow/core/framework/summary.proto)
     has one summary value containing a histogram for `values`.
@@ -665,7 +665,7 @@ def video(tag, tensor, fps=4):
     Create a video summary of a tensor.
 
     Args:
-      tag: A name for the generated node. Will also serve as a series 
+      tag: A name for the generated node. Will also serve as a series
         name in TensorBoard.
       tensor : Input tensor containing consecutive video frames
       fps : Frames per second of the video
@@ -741,7 +741,7 @@ def audio(tag, tensor, sample_rate=44100):
     Create an audio summary of a tensor.
 
     Args:
-      tag: A name for the generated node. Will also serve as a series 
+      tag: A name for the generated node. Will also serve as a series
           name in TensorBoard.
       tensor : Input tensor containing consecutive audio frames
       sample_rate : Sample rate of the audio
@@ -785,7 +785,7 @@ def custom_scalars(layout):
     Args:
       layout: A list of category-title pairs. Within each category, a chart
           will be generated for each scalar.
-    
+
     Returns:
       A scalar `Tensor` of type `string`. The serialized `Summary` protocol
     """
@@ -830,10 +830,10 @@ def text(tag, text):
     Create a text summary.
 
     Args:
-      tag: A name for the generated node. Will also serve as a series 
+      tag: A name for the generated node. Will also serve as a series
           name in TensorBoard.
       text : A string
-    
+
     Returns:
       A scalar `Tensor` of type `string`. The serialized `Summary` protocol.
 
@@ -859,7 +859,7 @@ def pr_curve_raw(
     Output a `Summary` protocol buffer with PR curve data.
 
     Args:
-      tag: A name for the generated node. Will also serve as a series 
+      tag: A name for the generated node. Will also serve as a series
           name in TensorBoard.
       tp: True positives counts.
       fp: False positives counts.
@@ -902,7 +902,7 @@ def pr_curve(tag, labels, predictions, num_thresholds=127, weights=None):
     Output a `Summary` protocol buffer with PR curve data.
 
     Args:
-      tag: A name for the generated node. Will also serve as a series 
+      tag: A name for the generated node. Will also serve as a series
           name in TensorBoard.
       labels: Ground truth values. shape = [batch_size, d0, .. dN].
       predictions: The predicted values. shape = [batch_size, d0, .. dN].
@@ -950,7 +950,7 @@ def compute_curve(labels, predictions, num_thresholds=None, weights=None):
 
     Returns:
       numpy array with columns [tp, fp, tn, fn, precision, recall].
-    
+
     """
     _MINIMUM_COUNT = 1e-7
 

--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -1147,7 +1147,7 @@ class SummaryWriter:
     ):
         """
         Shorthand for creating multilinechart.
-        
+
         Similar to ``add_custom_scalars()``, but the only necessary argument
         is *tags*.
 
@@ -1169,7 +1169,7 @@ class SummaryWriter:
     ):
         """
         Shorthand for creating marginchart.
-        
+
         Similar to ``add_custom_scalars()``, but the only necessary argument
         is *tags*, which should have exactly 3 elements.
 
@@ -1190,8 +1190,8 @@ class SummaryWriter:
     def add_custom_scalars(self, layout):
         """
         Create special chart by collecting charts tags in 'scalars'.
-        
-        NOTE: This function can only be called once for each SummaryWriter() object. 
+
+        NOTE: This function can only be called once for each SummaryWriter() object.
         Because it only provides metadata to tensorboard, the function can be called
         before or after the training loop.
 
@@ -1224,10 +1224,10 @@ class SummaryWriter:
     ):
         """
         Add meshes or 3D point clouds to TensorBoard.
-        
-        The visualization is based on Three.js, so it allows users to interact with the rendered object. 
-        Besides the basic definitions such as vertices, faces, users can further provide camera parameter, 
-        lighting condition, etc. Please check https://threejs.org/docs/index.html#manual/en/introduction/Creating-a-scene 
+
+        The visualization is based on Three.js, so it allows users to interact with the rendered object.
+        Besides the basic definitions such as vertices, faces, users can further provide camera parameter,
+        lighting condition, etc. Please check https://threejs.org/docs/index.html#manual/en/introduction/Creating-a-scene
         for advanced usage.
 
         Args:
@@ -1282,7 +1282,7 @@ class SummaryWriter:
     def flush(self):
         """
         Flush the event file to disk.
-        
+
         Call this method to make sure that all pending events have been written to
         disk.
         """

--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -1,5 +1,4 @@
-"""Provides an API for writing protocol buffers to event files to be
-consumed by TensorBoard for visualization."""
+"""Provide an API for writing protocol buffers to event files to be consumed by TensorBoard for visualization."""
 
 import os
 import time
@@ -41,7 +40,8 @@ __all__ = ["FileWriter", "SummaryWriter"]
 
 
 class FileWriter:
-    """Writes protocol buffers to event files to be consumed by TensorBoard.
+    """
+    Writes protocol buffers to event files to be consumed by TensorBoard.
 
     The `FileWriter` class provides a mechanism to create an event file in a
     given directory and add summaries and events to it. The class updates the
@@ -51,7 +51,9 @@ class FileWriter:
     """
 
     def __init__(self, log_dir, max_queue=10, flush_secs=120, filename_suffix=""):
-        """Creates a `FileWriter` and an event file.
+        """
+        Create a `FileWriter` and an event file.
+
         On construction the writer creates a new event file in `log_dir`.
         The other arguments to the constructor control the asynchronous writes to
         the event file.
@@ -77,11 +79,13 @@ class FileWriter:
         )
 
     def get_logdir(self):
-        """Returns the directory where event file will be written."""
+        """Return the directory where event file will be written."""
         return self.event_writer.get_logdir()
 
     def add_event(self, event, step=None, walltime=None):
-        """Adds an event to the event file.
+        """
+        Add an event to the event file.
+
         Args:
           event: An `Event` protocol buffer.
           step: Number. Optional global step value for training process
@@ -97,7 +101,9 @@ class FileWriter:
         self.event_writer.add_event(event)
 
     def add_summary(self, summary, global_step=None, walltime=None):
-        """Adds a `Summary` protocol buffer to the event file.
+        """
+        Add a `Summary` protocol buffer to the event file.
+
         This method wraps the provided summary in an `Event` protocol buffer
         and adds it to the event file.
 
@@ -112,7 +118,8 @@ class FileWriter:
         self.add_event(event, global_step, walltime)
 
     def add_graph(self, graph_profile, walltime=None):
-        """Adds a `Graph` and step stats protocol buffer to the event file.
+        """
+        Add a `Graph` and step stats protocol buffer to the event file.
 
         Args:
           graph_profile: A `Graph` and step stats protocol buffer.
@@ -131,7 +138,8 @@ class FileWriter:
         self.add_event(event, None, walltime)
 
     def add_onnx_graph(self, graph, walltime=None):
-        """Adds a `Graph` protocol buffer to the event file.
+        """
+        Add a `Graph` protocol buffer to the event file.
 
         Args:
           graph: A `Graph` protocol buffer.
@@ -142,20 +150,26 @@ class FileWriter:
         self.add_event(event, None, walltime)
 
     def flush(self):
-        """Flushes the event file to disk.
+        """
+        Flush the event file to disk.
+
         Call this method to make sure that all pending events have been written to
         disk.
         """
         self.event_writer.flush()
 
     def close(self):
-        """Flushes the event file to disk and close the file.
+        """
+        Flush the event file to disk and close the file.
+
         Call this method when you do not need the summary writer anymore.
         """
         self.event_writer.close()
 
     def reopen(self):
-        """Reopens the EventFileWriter.
+        """
+        Reopens the EventFileWriter.
+
         Can be called after `close()` to add more events in the same directory.
         The events will go into a new events file.
         Does nothing if the EventFileWriter was not closed.
@@ -164,8 +178,8 @@ class FileWriter:
 
 
 class SummaryWriter:
-    """Writes entries directly to event files in the log_dir to be
-    consumed by TensorBoard.
+    """
+    Write entries directly to event files in the log_dir to be consumed by TensorBoard.
 
     The `SummaryWriter` class provides a high-level API to create an event file
     in a given directory and add summaries and events to it. The class updates the
@@ -183,8 +197,8 @@ class SummaryWriter:
         flush_secs=120,
         filename_suffix="",
     ):
-        """Creates a `SummaryWriter` that will write out events and summaries
-        to the event file.
+        """
+        Create a `SummaryWriter` that will write out events and summaries to the event file.
 
         Args:
             log_dir (str): Save directory location. Default is
@@ -257,6 +271,8 @@ class SummaryWriter:
 
     def _check_caffe2_blob(self, item):
         """
+        Check if the input is a string representing a Caffe2 blob name.
+
         Caffe2 users have the option of passing a string representing the name of
         a blob in the workspace instead of passing the actual Tensor/array containing
         the numeric values. Thus, we need to check if we received a string as input
@@ -271,7 +287,7 @@ class SummaryWriter:
         return isinstance(item, str)
 
     def _get_file_writer(self):
-        """Returns the default FileWriter instance. Recreates it if closed."""
+        """Return the default FileWriter instance. Recreates it if closed."""
         if self.all_writers is None or self.file_writer is None:
             self.file_writer = FileWriter(
                 self.log_dir, self.max_queue, self.flush_secs, self.filename_suffix
@@ -292,13 +308,14 @@ class SummaryWriter:
         return self.file_writer
 
     def get_logdir(self):
-        """Returns the directory where event files will be written."""
+        """Return the directory where event files will be written."""
         return self.log_dir
 
     def add_hparams(
         self, hparam_dict, metric_dict, hparam_domain_discrete=None, run_name=None, global_step=None
     ):
-        """Add a set of hyperparameters to be compared in TensorBoard.
+        """
+        Add a set of hyperparameters to be compared in TensorBoard.
 
         Args:
             hparam_dict (dict): Each key-value pair in the dictionary is the
@@ -354,7 +371,8 @@ class SummaryWriter:
         new_style=False,
         double_precision=False,
     ):
-        """Add scalar data to summary.
+        """
+        Add scalar data to summary.
 
         Args:
             tag (str): Data identifier
@@ -391,7 +409,8 @@ class SummaryWriter:
         self._get_file_writer().add_summary(summary, global_step, walltime)
 
     def add_scalars(self, main_tag, tag_scalar_dict, global_step=None, walltime=None):
-        """Adds many scalar data to summary.
+        """
+        Add many scalar data to summary.
 
         Args:
             main_tag (str): The parent name for the tags
@@ -445,7 +464,8 @@ class SummaryWriter:
         global_step=None,
         walltime=None,
     ):
-        """Add tensor data to summary.
+        """
+        Add tensor data to summary.
 
         Args:
             tag (str): Data identifier
@@ -483,7 +503,8 @@ class SummaryWriter:
         walltime=None,
         max_bins=None,
     ):
-        """Add histogram to summary.
+        """
+        Add histogram to summary.
 
         Args:
             tag (str): Data identifier
@@ -534,7 +555,8 @@ class SummaryWriter:
         global_step=None,
         walltime=None,
     ):
-        """Adds histogram with raw data.
+        """
+        Add histogram with raw data.
 
         Args:
             tag (str): Data identifier
@@ -599,7 +621,8 @@ class SummaryWriter:
     def add_image(
         self, tag, img_tensor, global_step=None, walltime=None, dataformats="CHW"
     ):
-        """Add image data to summary.
+        """
+        Add image data to summary.
 
         Note that this requires the ``pillow`` package.
 
@@ -654,7 +677,8 @@ class SummaryWriter:
     def add_images(
         self, tag, img_tensor, global_step=None, walltime=None, dataformats="NCHW"
     ):
-        """Add batched image data to summary.
+        """
+        Add batched image data to summary.
 
         Note that this requires the ``pillow`` package.
 
@@ -710,7 +734,8 @@ class SummaryWriter:
         dataformats="CHW",
         labels=None,
     ):
-        """Add image and draw bounding boxes on the image.
+        """
+        Add image and draw bounding boxes on the image.
 
         Args:
             tag (str): Data identifier
@@ -766,7 +791,8 @@ class SummaryWriter:
         close: bool = True,
         walltime: Optional[float] = None
     ) -> None:
-        """Render matplotlib figure into an image and add it to summary.
+        """
+        Render matplotlib figure into an image and add it to summary.
 
         Note that this requires the ``matplotlib`` package.
 
@@ -797,7 +823,8 @@ class SummaryWriter:
             )
 
     def add_video(self, tag, vid_tensor, global_step=None, fps=4, walltime=None):
-        """Add video data to summary.
+        """
+        Add video data to summary.
 
         Note that this requires the ``moviepy`` package.
 
@@ -819,7 +846,8 @@ class SummaryWriter:
     def add_audio(
         self, tag, snd_tensor, global_step=None, sample_rate=44100, walltime=None
     ):
-        """Add audio data to summary.
+        """
+        Add audio data to summary.
 
         Args:
             tag (str): Data identifier
@@ -841,7 +869,8 @@ class SummaryWriter:
         )
 
     def add_text(self, tag, text_string, global_step=None, walltime=None):
-        """Add text data to summary.
+        """
+        Add text data to summary.
 
         Args:
             tag (str): Data identifier
@@ -860,13 +889,15 @@ class SummaryWriter:
         )
 
     def add_onnx_graph(self, prototxt):
+        """Add ONNX graph data to summary."""
         torch._C._log_api_usage_once("tensorboard.logging.add_onnx_graph")
         self._get_file_writer().add_onnx_graph(load_onnx_graph(prototxt))
 
     def add_graph(
         self, model, input_to_model=None, verbose=False, use_strict_trace=True
     ):
-        """Add graph data to summary.
+        """
+        Add graph data to summary.
 
         Args:
             model (torch.nn.Module): Model to draw.
@@ -923,7 +954,8 @@ class SummaryWriter:
         tag="default",
         metadata_header=None,
     ):
-        """Add embedding projector data to summary.
+        """
+        Add embedding projector data to summary.
 
         Args:
             mat (torch.Tensor or numpy.ndarray): A matrix which each row is the feature vector of the data point
@@ -1022,7 +1054,9 @@ class SummaryWriter:
         weights=None,
         walltime=None,
     ):
-        """Adds precision recall curve.
+        """
+        Add precision recall curve.
+
         Plotting a precision-recall curve lets you understand your model's
         performance under different threshold settings. With this function,
         you provide the ground truth labeling (T/F) and prediction confidence
@@ -1074,7 +1108,8 @@ class SummaryWriter:
         weights=None,
         walltime=None,
     ):
-        """Adds precision recall curve with raw data.
+        """
+        Add precision recall curve with raw data.
 
         Args:
             tag (str): Data identifier
@@ -1110,7 +1145,10 @@ class SummaryWriter:
     def add_custom_scalars_multilinechart(
         self, tags, category="default", title="untitled"
     ):
-        """Shorthand for creating multilinechart. Similar to ``add_custom_scalars()``, but the only necessary argument
+        """
+        Shorthand for creating multilinechart.
+        
+        Similar to ``add_custom_scalars()``, but the only necessary argument
         is *tags*.
 
         Args:
@@ -1129,7 +1167,10 @@ class SummaryWriter:
     def add_custom_scalars_marginchart(
         self, tags, category="default", title="untitled"
     ):
-        """Shorthand for creating marginchart. Similar to ``add_custom_scalars()``, but the only necessary argument
+        """
+        Shorthand for creating marginchart.
+        
+        Similar to ``add_custom_scalars()``, but the only necessary argument
         is *tags*, which should have exactly 3 elements.
 
         Args:
@@ -1147,8 +1188,11 @@ class SummaryWriter:
         self._get_file_writer().add_summary(custom_scalars(layout))
 
     def add_custom_scalars(self, layout):
-        """Create special chart by collecting charts tags in 'scalars'. Note that this function can only be called once
-        for each SummaryWriter() object. Because it only provides metadata to tensorboard, the function can be called
+        """
+        Create special chart by collecting charts tags in 'scalars'.
+        
+        NOTE: This function can only be called once for each SummaryWriter() object. 
+        Because it only provides metadata to tensorboard, the function can be called
         before or after the training loop.
 
         Args:
@@ -1178,11 +1222,13 @@ class SummaryWriter:
         global_step=None,
         walltime=None,
     ):
-        """Add meshes or 3D point clouds to TensorBoard. The visualization is based on Three.js,
-        so it allows users to interact with the rendered object. Besides the basic definitions
-        such as vertices, faces, users can further provide camera parameter, lighting condition, etc.
-        Please check https://threejs.org/docs/index.html#manual/en/introduction/Creating-a-scene for
-        advanced usage.
+        """
+        Add meshes or 3D point clouds to TensorBoard.
+        
+        The visualization is based on Three.js, so it allows users to interact with the rendered object. 
+        Besides the basic definitions such as vertices, faces, users can further provide camera parameter, 
+        lighting condition, etc. Please check https://threejs.org/docs/index.html#manual/en/introduction/Creating-a-scene 
+        for advanced usage.
 
         Args:
             tag (str): Data identifier
@@ -1234,7 +1280,9 @@ class SummaryWriter:
         )
 
     def flush(self):
-        """Flushes the event file to disk.
+        """
+        Flush the event file to disk.
+        
         Call this method to make sure that all pending events have been written to
         disk.
         """
@@ -1244,6 +1292,7 @@ class SummaryWriter:
             writer.flush()
 
     def close(self):
+        """Close the event file and release resources."""
         if self.all_writers is None:
             return  # ignore double close
         for writer in self.all_writers.values():
@@ -1252,7 +1301,9 @@ class SummaryWriter:
         self.file_writer = self.all_writers = None
 
     def __enter__(self):
+        """No-op for compatibility with Python's with syntax."""
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        """Flush the data and close the file on `with` exit."""
         self.close()


### PR DESCRIPTION
Fixes #112637 

Fixed pydocstyle errors. Also added a few missing docstrings for functions

Previous error count mentioned in #112637 
Current error count 

```
pydocstyle summary.py --count
0
```

```
pydocstyle _caffe2_graph.py --count
0
```

```
pydocstyle writer.py --count
0
```

```
pydocstyle _pytorch_graph.py --count
0
```

```
pydocstyle constants.py --count
0
```

```
pydocstyle _utils.py --count
0
```

```
pydocstyle _proto_graph.py --count
15
```

cc @svekars @carljparker