### PR TITLE
Fix docstring errors in _composable_state.py, remote_device.py, value_ranges.py, utils.py, run.py, rendezvous.py, launch.py, argparse_util.py, __init__.py, _cycles.py

### DIFF
--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -6,7 +6,9 @@ import torch
 
 def is_available() -> bool:
     """
-    Returns ``True`` if the distributed package is available. Otherwise,
+    Return ``True`` if the distributed package is available.
+
+    Otherwise,
     ``torch.distributed`` does not expose any other APIs. Currently,
     ``torch.distributed`` is available on Linux, MacOS and Windows. Set
     ``USE_DISTRIBUTED=1`` to enable it when building PyTorch from source.

--- a/torch/distributed/_composable_state.py
+++ b/torch/distributed/_composable_state.py
@@ -18,13 +18,14 @@ def _insert_module_state(module: nn.Module, state: _State) -> None:
 
 def _get_module_state(module: nn.Module) -> Optional[_State]:
     """
+    Return the ``_State`` in ``model``.
+
     Given a ``module``, this API finds out if the module is also a ``_State``
     instance or if the module is managed by a composable API. If the module
     is also a ``_State``, ``module`` will be casted to ``_State` and returned.
     If it is managed by a composable API, the corresponding ``_State`` will
     be returned.
     """
-
     global _module_state_mapping
     if isinstance(module, _State):
         return cast(_State, module)

--- a/torch/distributed/argparse_util.py
+++ b/torch/distributed/argparse_util.py
@@ -12,7 +12,7 @@ from argparse import Action
 class env(Action):
     """
     Get argument values from ``PET_{dest}`` before defaultingto the given ``default`` value.
-    
+
     For flags (e.g. ``--standalone``)
     use ``check_env`` instead.
 

--- a/torch/distributed/argparse_util.py
+++ b/torch/distributed/argparse_util.py
@@ -11,8 +11,9 @@ from argparse import Action
 
 class env(Action):
     """
-    Gets argument values from ``PET_{dest}`` before defaulting
-    to the given ``default`` value. For flags (e.g. ``--standalone``)
+    Get argument values from ``PET_{dest}`` before defaultingto the given ``default`` value.
+    
+    For flags (e.g. ``--standalone``)
     use ``check_env`` instead.
 
     .. note:: when multiple option strings are specified, ``dest`` is
@@ -20,7 +21,6 @@ class env(Action):
               the env var to set is ``PET_FOO`` not ``PET_F``)
 
     Example:
-
     ::
 
      parser.add_argument("-f", "--foo", action=env, default="bar")
@@ -59,8 +59,9 @@ class env(Action):
 
 class check_env(Action):
     """
-    For flags, checks whether the env var ``PET_{dest}`` exists
-    before defaulting to the given ``default`` value. Equivalent to
+    Check whether the env var ``PET_{dest}`` exists before defaulting to the given ``default`` value.
+
+    Equivalent to
     ``store_true`` argparse built-in action except that the argument can
     be omitted from the commandline if the env var is present and has a
     non-zero value.
@@ -70,7 +71,6 @@ class check_env(Action):
               when present and ``False`` otherwise.
 
     Example:
-
     ::
 
      parser.add_argument("--verbose", action=check_env)

--- a/torch/distributed/launch.py
+++ b/torch/distributed/launch.py
@@ -1,4 +1,6 @@
 r"""
+Module ``torch.distributed.launch``.
+
 ``torch.distributed.launch`` is a module that spawns up multiple distributed
 training processes on each of the training nodes.
 

--- a/torch/distributed/remote_device.py
+++ b/torch/distributed/remote_device.py
@@ -78,10 +78,7 @@ class _remote_device:
             return False
 
     def worker_name(self) -> Optional[str]:
-        """
-        Returns the name of remote worker representing the remote device.
-        Returns ``None`` if no worker name is available.
-        """
+        """Return the name of remote worker representing the remote device and ``None`` if no worker name is available."""
         return self._worker_name
 
     def rank(self) -> Optional[int]:
@@ -92,9 +89,7 @@ class _remote_device:
         return self._rank
 
     def device(self) -> torch.device:
-        """
-        Returns the local device on the remote worker.
-        """
+        """Return the local device on the remote worker."""
         return self._device  # type: ignore[return-value]
 
     def __repr__(self):

--- a/torch/distributed/rendezvous.py
+++ b/torch/distributed/rendezvous.py
@@ -20,7 +20,8 @@ _rendezvous_handlers = {}
 
 
 def register_rendezvous_handler(scheme, handler):
-    """Registers a new rendezvous handler.
+    """
+    Register a new rendezvous handler.
 
     Before we can run collective algorithms, participating processes
     need to find each other and exchange information to be able to
@@ -145,8 +146,9 @@ def _torchelastic_use_agent_store() -> bool:
 
 def _create_c10d_store(hostname, port, rank, world_size, timeout, use_libuv=False) -> Store:
     """
-    Smartly creates a c10d Store object on ``rank`` based on whether
-    we need to re-use agent store. The TCPStore server is assumed to be hosted
+    Smartly creates a c10d Store object on ``rank`` based on whether we need to re-use agent store.
+
+    The TCPStore server is assumed to be hosted
     on ``hostname:port``.
 
     If ``torchelastic_use_agent_store()`` is ``True``, then it is assumed that

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -7,6 +7,8 @@
 # LICENSE file in the root directory of this source tree.
 
 """
+Superset of ``torch.distributed.launch``.
+
 ``torchrun`` provides a superset of the functionality as ``torch.distributed.launch``
 with the following additional functionalities:
 
@@ -390,8 +392,7 @@ log = get_logger(__name__)
 
 
 def get_args_parser() -> ArgumentParser:
-    """Helper function parsing the command line options."""
-
+    """Parse the command line options."""
     parser = ArgumentParser(description="Torch Distributed Elastic Training Launcher")
 
     #
@@ -675,7 +676,8 @@ def get_rdzv_endpoint(args):
 
 def get_use_env(args) -> bool:
     """
-    Retrieves ``use_env`` from the args.
+    Retrieve ``use_env`` from the args.
+
     ``use_env`` is a legacy argument, if ``use_env`` is False, the
     ``--node-rank`` argument will be transferred to all worker processes.
     ``use_env`` is only used by the ``torch.distributed.launch`` and will
@@ -768,7 +770,8 @@ def config_from_args(args) -> Tuple[LaunchConfig, Union[Callable, str], List[str
 
 def run_script_path(training_script: str, *training_script_args: str):
     """
-    Runs the provided `training_script` from within this interpreter.
+    Run the provided `training_script` from within this interpreter.
+
     Usage: `script_as_function("/abs/path/to/script.py", "--arg1", "val1")`
     """
     import runpy

--- a/torch/distributed/utils.py
+++ b/torch/distributed/utils.py
@@ -14,7 +14,8 @@ __all__ = []  # type: ignore[var-annotated]
 
 def _pack_kwargs(*args: Any, **kwargs: Any) -> Tuple[Tuple[Any, ...], Tuple[str, ...]]:
     """
-    Turn argument list into separate key list and value list (unpack_kwargs does the opposite)
+    Turn argument list into separate key list and value list (unpack_kwargs does the opposite).
+
     Inspiration: https://github.com/facebookresearch/fairscale/blob/eeb6684/fairscale/internal/containers.py#L70
     Usage::
 
@@ -45,7 +46,8 @@ def _cast_forward_inputs(
     **kwargs: Any,
 ) -> Tuple[Any, Any]:
     """
-    Casts floating point tensors in ``args`` and ``kwargs`` to ``input_dtype``.
+    Cast floating point tensors in ``args`` and ``kwargs`` to ``input_dtype``.
+
     This respects the existing ``requires_grad`` on the tensors.
     """
     if dtype is None:
@@ -85,9 +87,7 @@ def _recursive_to(inputs: T, target_device: torch.device, use_side_stream_for_te
 
 
 def _recursive_to(inputs, target_device, use_side_stream_for_tensor_copies):
-    r"""
-    Recursively moves input to the target_device.
-    """
+    r"""Recursively moves input to the target_device."""
 
     def to_map(obj):
         if isinstance(obj, (torch.Tensor, PackedSequence)):
@@ -138,8 +138,7 @@ def _recursive_to(inputs, target_device, use_side_stream_for_tensor_copies):
 
 
 def _p_assert(cond: Any, s: str, raise_assertion_error: bool = True) -> None:
-    """This is used as an alternate to ``assert`` when in the backward context
-    to print the error message ``s`` since otherwise, it is swallowed."""
+    """Alternate to ``assert`` when in the backward context to print the error message ``s`` since otherwise, it is swallowed."""
     if not cond:
         print(s)
         traceback.print_stack()
@@ -273,6 +272,8 @@ def _sync_module_states(
     broadcast_buffers: bool = True,
 ) -> None:
     """
+    Sync ``module``'s parameters and buffers state.
+
     Syncs ``module``'s parameters and buffers state so that all ranks contain
     the same module state across all ranks. Note that this API assumes that all
     parameter shapes are consistent before running the synchronization. This can
@@ -297,10 +298,7 @@ def _sync_params_and_buffers(
     broadcast_bucket_size: int,
     src: int,
 ) -> None:
-    """
-    Synchronizes ``module_states`` (list of tensors) across all processes by
-    broadcasting them from rank 0.
-    """
+    """Synchronize ``module_states`` (list of tensors) across all processes by broadcasting them from rank 0."""
     if len(module_states) > 0:
         dist._broadcast_coalesced(
             process_group, module_states, broadcast_bucket_size, src

--- a/torch/utils/_sympy/value_ranges.py
+++ b/torch/utils/_sympy/value_ranges.py
@@ -126,19 +126,19 @@ class ValueRanges:
 
     @classmethod
     def increasing_map(cls, x, fn):
-        """Increasing: x <= y => f(x) <= f(y)"""
+        """Increasing: x <= y => f(x) <= f(y)."""
         x = cls.wrap(x)
         return ValueRanges(fn(x.lower), fn(x.upper))
 
     @classmethod
     def decreasing_map(cls, x, fn):
-        """Decreasing: x <= y => f(x) >= f(y)"""
+        """Decreasing: x <= y => f(x) >= f(y)."""
         x = cls.wrap(x)
         return ValueRanges(fn(x.upper), fn(x.lower))
 
     @classmethod
     def monotone_map(cls, x, fn):
-        """It's increasing or decreasing"""
+        """It's increasing or decreasing."""
         x = cls.wrap(x)
         l = fn(x.lower)
         u = fn(x.upper)
@@ -146,7 +146,7 @@ class ValueRanges:
 
     @classmethod
     def convex_min_zero_map(cls, x, fn):
-        """fn is convex and has a minimum at 0"""
+        """Fn is convex and has a minimum at 0."""
         x = ValueRanges.wrap(x)
         if 0 in x:
             return ValueRanges(0, max(fn(x.lower), fn(x.upper)))
@@ -156,7 +156,9 @@ class ValueRanges:
     @classmethod
     def coordinatewise_increasing_map(cls, x, y, fn):
         """
-        Increasing on each coordinate. Mathematically:
+        It's increasing on each coordinate.
+
+        Mathematically:
         For every 1 <= i <= n and x_i <= y_i we have that
         f(x1, .., xn) <= f(x1, , yi, ..., xn)
         """
@@ -168,7 +170,7 @@ class ValueRanges:
 
     @classmethod
     def coordinatewise_monotone_map(cls, x, y, fn):
-        """It's increasing or decreasing on each coordinate"""
+        """It's increasing or decreasing on each coordinate."""
         x, y = cls.wrap(x), cls.wrap(y)
         products = [
             fn(a, b)

--- a/torch/utils/viz/_cycles.py
+++ b/torch/utils/viz/_cycles.py
@@ -427,7 +427,7 @@ def observe_tensor_cycles(callback):
 
 def warn_tensor_cycles():
     """
-    Install a warning that is reports whenever a cycle that is holding CUDA memory is observed.
+    Install a warning that reports whenever a cycle that is holding CUDA memory is observed.
 
     The warning produces a html file that visualizes the cycle,
     and links it to the stack frame that allocted the CUDA tensor.

--- a/torch/utils/viz/_cycles.py
+++ b/torch/utils/viz/_cycles.py
@@ -429,7 +429,7 @@ def warn_tensor_cycles():
     """
     Install a warning that reports whenever a cycle that is holding CUDA memory is observed.
 
-    The warning produces a html file that visualizes the cycle,
+    The warning produces an .html file that visualizes the cycle,
     and links it to the stack frame that allocted the CUDA tensor.
 
     Reference cycles are freed by the cycle collector rather than being cleaned up

--- a/torch/utils/viz/_cycles.py
+++ b/torch/utils/viz/_cycles.py
@@ -205,9 +205,9 @@ FRAME_FILENAME_LIMIT = 32
 
 def object_annotation(obj):
     """
-    Return a string to be used for Graphviz nodes.  The string
-    should be short but as informative as possible.
+    Return a string to be used for Graphviz nodes.
 
+    The string should be short but as informative as possible.
     """
 
     def format_sequence(obj):
@@ -427,15 +427,16 @@ def observe_tensor_cycles(callback):
 
 def warn_tensor_cycles():
     """
+    Install a warning that is reports whenever a cycle that is holding CUDA memory is observed.
+
+    The warning produces a html file that visualizes the cycle,
+    and links it to the stack frame that allocted the CUDA tensor.
+
     Reference cycles are freed by the cycle collector rather than being cleaned up
     when the objects in the cycle first become unreachable. If a cycle points to a tensor,
     the CUDA memory for that tensor will not be freed until garbage collection runs.
     Accumulation of CUDA allocations can lead to out of memory errors (OOMs), as well as
     non-deterministic allocation behavior which is harder to debug.
-
-    This function installs a warning that is reports whenever a cycle that is holding CUDA
-    memory is observed. The warning produces a html file that visualizes the cycle,
-    and links it to the stack frame that allocted the CUDA tensor.
     """
     logger.info("Watching Python reference cycles for CUDA Tensors.")
 


### PR DESCRIPTION
Fixes #112639

```txt
 torch/utils/_sympy/value_ranges.py
 torch/utils/_sympy/value_ranges.py:60 in public class `ValueRanges`:
        D101: Missing docstring in public class
torch/utils/_sympy/value_ranges.py:68 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/_sympy/value_ranges.py:81 in public method `__contains__`:
        D105: Missing docstring in magic method
torch/utils/_sympy/value_ranges.py:86 in public method `tighten`:
        D400: First line should end with a period (not 'n')
torch/utils/_sympy/value_ranges.py:90 in public method `__and__`:
        D105: Missing docstring in magic method
torch/utils/_sympy/value_ranges.py:103 in public method `__or__`:
        D105: Missing docstring in magic method
torch/utils/_sympy/value_ranges.py:113 in public method `is_singleton`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:118 in public method `unknown`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:122 in public method `wrap`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:129 in public method `increasing_map`:
        D400: First line should end with a period (not ')')
torch/utils/_sympy/value_ranges.py:135 in public method `decreasing_map`:
        D400: First line should end with a period (not ')')
torch/utils/_sympy/value_ranges.py:141 in public method `monotone_map`:
        D400: First line should end with a period (not 'g')
torch/utils/_sympy/value_ranges.py:149 in public method `convex_min_zero_map`:
        D400: First line should end with a period (not '0')
torch/utils/_sympy/value_ranges.py:149 in public method `convex_min_zero_map`:
        D403: First word of the first line should be properly capitalized ('Fn', not 'fn')
torch/utils/_sympy/value_ranges.py:158 in public method `coordinatewise_increasing_map`:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/_sympy/value_ranges.py:158 in public method `coordinatewise_increasing_map`:
        D400: First line should end with a period (not ':')
torch/utils/_sympy/value_ranges.py:171 in public method `coordinatewise_monotone_map`:
        D400: First line should end with a period (not 'e')
torch/utils/_sympy/value_ranges.py:180 in private class `SymPyValueRangeAnalysis`:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/_sympy/value_ranges.py:180 in private class `SymPyValueRangeAnalysis`:
        D400: First line should end with a period (not 's')
torch/utils/_sympy/value_ranges.py:386 in private method `reciprocal`:
        D210: No whitespaces allowed surrounding docstring text
torch/utils/_sympy/value_ranges.py:386 in private method `reciprocal`:
        D400: First line should end with a period (not 'n')
torch/utils/_sympy/value_ranges.py:488 in public class `ValueRangeAnalysis`:
        D101: Missing docstring in public class
torch/utils/_sympy/value_ranges.py:489 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/_sympy/value_ranges.py:501 in public method `bool_handler`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:506 in public method `default_handler`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:511 in public method `load`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:514 in public method `store`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:517 in public method `reduction`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:520 in public method `index_expr`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:525 in public method `to_dtype`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:558 in public method `square`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:562 in public method `neg`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:566 in public method `truncdiv`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:577 in public method `sub`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:580 in public method `__getattr__`:
        D105: Missing docstring in magic method
torch/utils/_sympy/value_ranges.py:585 in public function `bound_sympy`:
        D103: Missing docstring in public function
36
torch/utils/_sympy/value_ranges.py:60 in public class `ValueRanges`:
        D101: Missing docstring in public class
torch/utils/_sympy/value_ranges.py:68 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/_sympy/value_ranges.py:81 in public method `__contains__`:
        D105: Missing docstring in magic method
torch/utils/_sympy/value_ranges.py:86 in public method `tighten`:
        D400: First line should end with a period (not 'n')
torch/utils/_sympy/value_ranges.py:90 in public method `__and__`:
        D105: Missing docstring in magic method
torch/utils/_sympy/value_ranges.py:103 in public method `__or__`:
        D105: Missing docstring in magic method
torch/utils/_sympy/value_ranges.py:113 in public method `is_singleton`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:118 in public method `unknown`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:122 in public method `wrap`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:182 in private class `SymPyValueRangeAnalysis`:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/_sympy/value_ranges.py:182 in private class `SymPyValueRangeAnalysis`:
        D400: First line should end with a period (not 's')
torch/utils/_sympy/value_ranges.py:388 in private method `reciprocal`:
        D210: No whitespaces allowed surrounding docstring text
torch/utils/_sympy/value_ranges.py:388 in private method `reciprocal`:
        D400: First line should end with a period (not 'n')
torch/utils/_sympy/value_ranges.py:490 in public class `ValueRangeAnalysis`:
        D101: Missing docstring in public class
torch/utils/_sympy/value_ranges.py:491 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/_sympy/value_ranges.py:503 in public method `bool_handler`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:508 in public method `default_handler`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:513 in public method `load`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:516 in public method `store`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:519 in public method `reduction`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:522 in public method `index_expr`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:527 in public method `to_dtype`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:560 in public method `square`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:564 in public method `neg`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:568 in public method `truncdiv`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:579 in public method `sub`:
        D102: Missing docstring in public method
torch/utils/_sympy/value_ranges.py:582 in public method `__getattr__`:
        D105: Missing docstring in magic method
torch/utils/_sympy/value_ranges.py:587 in public function `bound_sympy`:
        D103: Missing docstring in public function
28

torch/utils/viz/_cycles.py
torch/utils/viz/_cycles.py:14 in public function `observe_garbage`:
        D103: Missing docstring in public function
torch/utils/viz/_cycles.py:207 in public function `object_annotation`:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/viz/_cycles.py:207 in public function `object_annotation`:
        D400: First line should end with a period (not 'g')
torch/utils/viz/_cycles.py:256 in public class `Node`:
        D101: Missing docstring in public class
torch/utils/viz/_cycles.py:262 in public function `create_graph`:
        D103: Missing docstring in public function
torch/utils/viz/_cycles.py:308 in public function `escape`:
        D103: Missing docstring in public function
torch/utils/viz/_cycles.py:312 in public function `is_cuda_tensor`:
        D103: Missing docstring in public function
torch/utils/viz/_cycles.py:315 in public function `cuda_allocation_context`:
        D103: Missing docstring in public function
torch/utils/viz/_cycles.py:335 in public function `to_dot`:
        D103: Missing docstring in public function
torch/utils/viz/_cycles.py:406 in public function `to_html`:
        D103: Missing docstring in public function
torch/utils/viz/_cycles.py:416 in public function `observe_tensor_cycles`:
        D103: Missing docstring in public function
torch/utils/viz/_cycles.py:429 in public function `warn_tensor_cycles`:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/viz/_cycles.py:429 in public function `warn_tensor_cycles`:
        D400: First line should end with a period (not 'p')
torch/utils/viz/_cycles.py:429 in public function `warn_tensor_cycles`:
        D401: First line should be in imperative mood; try rephrasing (found 'Reference')
14
torch/utils/viz/_cycles.py:14 in public function `observe_garbage`:
        D103: Missing docstring in public function
torch/utils/viz/_cycles.py:256 in public class `Node`:
        D101: Missing docstring in public class
torch/utils/viz/_cycles.py:262 in public function `create_graph`:
        D103: Missing docstring in public function
torch/utils/viz/_cycles.py:308 in public function `escape`:
        D103: Missing docstring in public function
torch/utils/viz/_cycles.py:312 in public function `is_cuda_tensor`:
        D103: Missing docstring in public function
torch/utils/viz/_cycles.py:315 in public function `cuda_allocation_context`:
        D103: Missing docstring in public function
torch/utils/viz/_cycles.py:335 in public function `to_dot`:
        D103: Missing docstring in public function
torch/utils/viz/_cycles.py:406 in public function `to_html`:
        D103: Missing docstring in public function
torch/utils/viz/_cycles.py:416 in public function `observe_tensor_cycles`:
        D103: Missing docstring in public function
9

torch/distributed/argparse_util.py
torch/distributed/argparse_util.py:1 at module level:
        D100: Missing docstring in public module
torch/distributed/argparse_util.py:13 in public class `env`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/argparse_util.py:13 in public class `env`:
        D400: First line should end with a period (not 'g')
torch/distributed/argparse_util.py:13 in public class `env`:
        D412: No blank lines allowed between a section header and its content ('Example')
torch/distributed/argparse_util.py:43 in public method `__init__`:
        D107: Missing docstring in __init__
torch/distributed/argparse_util.py:56 in public method `__call__`:
        D102: Missing docstring in public method
torch/distributed/argparse_util.py:61 in public class `check_env`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/argparse_util.py:61 in public class `check_env`:
        D400: First line should end with a period (not 's')
torch/distributed/argparse_util.py:61 in public class `check_env`:
        D412: No blank lines allowed between a section header and its content ('Example')
torch/distributed/argparse_util.py:97 in public method `__init__`:
        D107: Missing docstring in __init__
torch/distributed/argparse_util.py:102 in public method `__call__`:
        D102: Missing docstring in public method
11
torch/distributed/argparse_util.py:1 at module level:
        D100: Missing docstring in public module
torch/distributed/argparse_util.py:43 in public method `__init__`:
        D107: Missing docstring in __init__
torch/distributed/argparse_util.py:56 in public method `__call__`:
        D102: Missing docstring in public method
torch/distributed/argparse_util.py:97 in public method `__init__`:
        D107: Missing docstring in __init__
torch/distributed/argparse_util.py:102 in public method `__call__`:
        D102: Missing docstring in public method
5

torch/distributed/_composable_state.py
torch/distributed/_composable_state.py:20 in private function `_get_module_state`:
        D202: No blank lines allowed after function docstring (found 1)
torch/distributed/_composable_state.py:20 in private function `_get_module_state`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_composable_state.py:20 in private function `_get_module_state`:
        D400: First line should end with a period (not '`')
3
0

torch/distributed/launch.py
torch/distributed/launch.py:1 at module level:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/launch.py:1 at module level:
        D400: First line should end with a period (not 'd')
torch/distributed/launch.py:156 in public function `parse_args`:
        D103: Missing docstring in public function
torch/distributed/launch.py:171 in public function `launch`:
        D103: Missing docstring in public function
torch/distributed/launch.py:180 in public function `main`:
        D103: Missing docstring in public function
5
torch/distributed/launch.py:157 in public function `parse_args`:
        D103: Missing docstring in public function
torch/distributed/launch.py:172 in public function `launch`:
        D103: Missing docstring in public function
torch/distributed/launch.py:181 in public function `main`:
        D103: Missing docstring in public function
3

torch/distributed/remote_device.py
torch/distributed/remote_device.py:1 at module level:
        D100: Missing docstring in public module
torch/distributed/remote_device.py:81 in private method `worker_name`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/remote_device.py:81 in private method `worker_name`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/distributed/remote_device.py:88 in private method `rank`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/remote_device.py:88 in private method `rank`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/distributed/remote_device.py:95 in private method `device`:
        D200: One-line docstring should fit on one line with quotes (found 3)
torch/distributed/remote_device.py:95 in private method `device`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
7
torch/distributed/remote_device.py:1 at module level:
        D100: Missing docstring in public module
torch/distributed/remote_device.py:85 in private method `rank`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/remote_device.py:85 in private method `rank`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
3

torch/distributed/rendezvous.py
torch/distributed/rendezvous.py:1 at module level:
        D100: Missing docstring in public module
torch/distributed/rendezvous.py:23 in public function `register_rendezvous_handler`:
        D401: First line should be in imperative mood (perhaps 'Register', not 'Registers')
torch/distributed/rendezvous.py:88 in public function `rendezvous`:
        D103: Missing docstring in public function
torch/distributed/rendezvous.py:147 in private function `_create_c10d_store`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/rendezvous.py:147 in private function `_create_c10d_store`:
        D400: First line should end with a period (not 'r')
5
torch/distributed/rendezvous.py:1 at module level:
        D100: Missing docstring in public module
torch/distributed/rendezvous.py:89 in public function `rendezvous`:
        D103: Missing docstring in public function
2

torch/distributed/run.py
torch/distributed/run.py:9 at module level:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/run.py:9 at module level:
        D400: First line should end with a period (not '`')
torch/distributed/run.py:393 in public function `get_args_parser`:
        D202: No blank lines allowed after function docstring (found 1)
torch/distributed/run.py:393 in public function `get_args_parser`:
        D401: First line should be in imperative mood; try rephrasing (found 'Helper')
torch/distributed/run.py:610 in public function `parse_args`:
        D103: Missing docstring in public function
torch/distributed/run.py:615 in public function `parse_min_max_nnodes`:
        D103: Missing docstring in public function
torch/distributed/run.py:629 in public function `determine_local_world_size`:
        D103: Missing docstring in public function
torch/distributed/run.py:670 in public function `get_rdzv_endpoint`:
        D103: Missing docstring in public function
torch/distributed/run.py:677 in public function `get_use_env`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/run.py:677 in public function `get_use_env`:
        D401: First line should be in imperative mood (perhaps 'Retrieve', not 'Retrieves')
torch/distributed/run.py:689 in public function `config_from_args`:
        D103: Missing docstring in public function
torch/distributed/run.py:770 in public function `run_script_path`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/run.py:770 in public function `run_script_path`:
        D401: First line should be in imperative mood (perhaps 'Run', not 'Runs')
torch/distributed/run.py:781 in public function `run`:
        D103: Missing docstring in public function
torch/distributed/run.py:804 in public function `main`:
        D103: Missing docstring in public function
15
torch/distributed/run.py:611 in public function `parse_args`:
        D103: Missing docstring in public function
torch/distributed/run.py:616 in public function `parse_min_max_nnodes`:
        D103: Missing docstring in public function
torch/distributed/run.py:630 in public function `determine_local_world_size`:
        D103: Missing docstring in public function
torch/distributed/run.py:671 in public function `get_rdzv_endpoint`:
        D103: Missing docstring in public function
torch/distributed/run.py:691 in public function `config_from_args`:
        D103: Missing docstring in public function
torch/distributed/run.py:784 in public function `run`:
        D103: Missing docstring in public function
torch/distributed/run.py:807 in public function `main`:
        D103: Missing docstring in public function
7

torch/distributed/__init__.py
torch/distributed/__init__.py:1 at module level:
        D104: Missing docstring in public package
torch/distributed/__init__.py:8 in public function `is_available`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/__init__.py:8 in public function `is_available`:
        D400: First line should end with a period (not ',')
torch/distributed/__init__.py:8 in public function `is_available`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
4
torch/distributed/__init__.py:1 at module level:
        D104: Missing docstring in public package
1

torch/distributed/utils.py:1 at module level:
        D100: Missing docstring in public module
torch/distributed/utils.py:16 in private function `_pack_kwargs`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/utils.py:16 in private function `_pack_kwargs`:
        D400: First line should end with a period (not ')')
torch/distributed/utils.py:47 in private function `_cast_forward_inputs`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/utils.py:88 in private function `_recursive_to`:
        D200: One-line docstring should fit on one line with quotes (found 3)
torch/distributed/utils.py:141 in private function `_p_assert`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/utils.py:141 in private function `_p_assert`:
        D209: Multi-line docstring closing quotes should be on a separate line
torch/distributed/utils.py:141 in private function `_p_assert`:
        D400: First line should end with a period (not 't')
torch/distributed/utils.py:141 in private function `_p_assert`:
        D401: First line should be in imperative mood; try rephrasing (found 'This')
torch/distributed/utils.py:275 in private function `_sync_module_states`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/utils.py:275 in private function `_sync_module_states`:
        D400: First line should end with a period (not 'n')
torch/distributed/utils.py:275 in private function `_sync_module_states`:
        D401: First line should be in imperative mood (perhaps 'Sync', not 'Syncs')
torch/distributed/utils.py:300 in private function `_sync_params_and_buffers`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/utils.py:300 in private function `_sync_params_and_buffers`:
        D400: First line should end with a period (not 'y')
torch/distributed/utils.py:300 in private function `_sync_params_and_buffers`:
        D401: First line should be in imperative mood (perhaps 'Synchronize', not 'Synchronizes')
15
torch/distributed/utils.py:1 at module level:
        D100: Missing docstring in public module
1
```

cc @svekars @carljparker