### PR TITLE
Fixed docstring errors inside torch/cuda/ and torch/optim/ (Docathon H2)

### DIFF
--- a/torch/cuda/amp/autocast_mode.py
+++ b/torch/cuda/amp/autocast_mode.py
@@ -15,8 +15,8 @@ __all__ = ["autocast", "custom_fwd", "custom_bwd"]
 
 
 class autocast(torch.amp.autocast_mode.autocast):
-    r"""
-    See :class:`torch.autocast`.
+    r"""See :class:`torch.autocast`.
+
     ``torch.cuda.amp.autocast(args...)`` is equivalent to ``torch.autocast("cuda", args...)``
     """
 
@@ -87,9 +87,10 @@ def _cast(value, dtype):
 #     @custom_fwd(cast_inputs=torch.float)
 #     def forward(...):
 def custom_fwd(fwd=None, *, cast_inputs=None):
-    """
-    Helper decorator for ``forward`` methods of custom autograd functions (subclasses of
-    :class:`torch.autograd.Function`).  See the :ref:`example page<amp-custom-examples>` for more detail.
+    """Create a helper decorator for ``forward`` methods of custom autograd functions.
+    
+    Autograd functions are subclasses of :class:`torch.autograd.Function`.
+    See the :ref:`example page<amp-custom-examples>` for more detail.
 
     Args:
         cast_inputs (:class:`torch.dtype` or None, optional, default=None):  If not ``None``,
@@ -127,9 +128,9 @@ def custom_fwd(fwd=None, *, cast_inputs=None):
 # cast_inputs argument on custom_bwd is unnecessary and could cause errors if it doesn't match
 # cast_inputs supplied to custom_fwd.
 def custom_bwd(bwd):
-    """
-    Helper decorator for backward methods of custom autograd functions (subclasses of
-    :class:`torch.autograd.Function`).
+    """Create a helper decorator for backward methods of custom autograd functions.
+    
+    Autograd functions are subclasses of :class:`torch.autograd.Function`.
     Ensures that ``backward`` executes with the same autocast state as ``forward``.
     See the :ref:`example page<amp-custom-examples>` for more detail.
     """

--- a/torch/cuda/amp/autocast_mode.py
+++ b/torch/cuda/amp/autocast_mode.py
@@ -87,8 +87,9 @@ def _cast(value, dtype):
 #     @custom_fwd(cast_inputs=torch.float)
 #     def forward(...):
 def custom_fwd(fwd=None, *, cast_inputs=None):
-    """Create a helper decorator for ``forward`` methods of custom autograd functions.
-    
+    """
+    Create a helper decorator for ``forward`` methods of custom autograd functions.
+
     Autograd functions are subclasses of :class:`torch.autograd.Function`.
     See the :ref:`example page<amp-custom-examples>` for more detail.
 
@@ -129,7 +130,7 @@ def custom_fwd(fwd=None, *, cast_inputs=None):
 # cast_inputs supplied to custom_fwd.
 def custom_bwd(bwd):
     """Create a helper decorator for backward methods of custom autograd functions.
-    
+
     Autograd functions are subclasses of :class:`torch.autograd.Function`.
     Ensures that ``backward`` executes with the same autocast state as ``forward``.
     See the :ref:`example page<amp-custom-examples>` for more detail.

--- a/torch/cuda/amp/grad_scaler.py
+++ b/torch/cuda/amp/grad_scaler.py
@@ -354,7 +354,7 @@ class GradScaler:
         self, optimizer: torch.optim.Optimizer, *args: Any, **kwargs: Any
     ) -> Optional[float]:
         """Invoke ``unscale_(optimizer)`` followed by parameter update, if gradients are not infs/NaN.
- 
+
         :meth:`step` carries out the following two operations:
 
         1.  Internally invokes ``unscale_(optimizer)`` (unless :meth:`unscale_` was explicitly called for ``optimizer``

--- a/torch/cuda/amp/grad_scaler.py
+++ b/torch/cuda/amp/grad_scaler.py
@@ -14,8 +14,9 @@ __all__ = ["OptState", "GradScaler"]
 
 
 class _MultiDeviceReplicator:
-    """
-    Lazily serves copies of a tensor to requested devices.  Copies are cached per-device.
+    """Lazily serves copies of a tensor to requested devices.
+    
+    Copies are cached per-device.
     """
 
     def __init__(self, master_tensor: torch.Tensor) -> None:
@@ -47,8 +48,9 @@ def _refresh_per_optimizer_state() -> Dict[str, Any]:
 
 
 class GradScaler:
-    """
-    An instance ``scaler`` of :class:`GradScaler` helps perform the steps of gradient scaling
+    """An instance ``scaler`` of :class:`GradScaler`.
+    
+    Helps perform the steps of gradient scaling
     conveniently.
 
     * ``scaler.scale(loss)`` multiplies a given loss by ``scaler``'s current scale factor.
@@ -351,7 +353,8 @@ class GradScaler:
     def step(
         self, optimizer: torch.optim.Optimizer, *args: Any, **kwargs: Any
     ) -> Optional[float]:
-        """
+        """Invoke ``unscale_(optimizer)`` followed by parameter update, if gradients are not infs/NaN.
+        
         :meth:`step` carries out the following two operations:
 
         1.  Internally invokes ``unscale_(optimizer)`` (unless :meth:`unscale_` was explicitly called for ``optimizer``
@@ -453,8 +456,7 @@ class GradScaler:
         return retval
 
     def update(self, new_scale: Optional[Union[float, torch.Tensor]] = None) -> None:
-        """
-        Updates the scale factor.
+        """Update the scale factor.
 
         If any optimizer steps were skipped the scale is multiplied by ``backoff_factor``
         to reduce it. If ``growth_interval`` unskipped iterations occurred consecutively,
@@ -526,8 +528,7 @@ class GradScaler:
         return self._scale
 
     def get_scale(self) -> float:
-        """
-        Returns a Python float containing the current scale, or 1.0 if scaling is disabled.
+        """Return a Python float containing the current scale, or 1.0 if scaling is disabled.
 
         .. warning::
             :meth:`get_scale` incurs a CPU-GPU sync.
@@ -541,39 +542,36 @@ class GradScaler:
         return 1.0
 
     def get_growth_factor(self) -> float:
-        r"""
-        Returns a Python float containing the scale growth factor.
-        """
+        r"""Return a Python float containing the scale growth factor."""
         return self._growth_factor
 
     def set_growth_factor(self, new_factor: float) -> None:
-        r"""
+        r"""Set new scale growth factor.
+
         Args:
             new_scale (float):  Value to use as the new scale growth factor.
         """
         self._growth_factor = new_factor
 
     def get_backoff_factor(self) -> float:
-        r"""
-        Returns a Python float containing the scale backoff factor.
-        """
+        r"""Return a Python float containing the scale backoff factor."""
         return self._backoff_factor
 
     def set_backoff_factor(self, new_factor: float) -> None:
-        r"""
+        r"""Set new scale backoff factor.
+
         Args:
             new_scale (float):  Value to use as the new scale backoff factor.
         """
         self._backoff_factor = new_factor
 
     def get_growth_interval(self) -> int:
-        r"""
-        Returns a Python int containing the growth interval.
-        """
+        r"""Return a Python int containing the growth interval."""
         return self._growth_interval
 
     def set_growth_interval(self, new_interval: int) -> None:
-        r"""
+        r"""Set new growth interval.
+
         Args:
             new_interval (int):  Value to use as the new growth interval.
         """
@@ -589,14 +587,13 @@ class GradScaler:
         return 0
 
     def is_enabled(self) -> bool:
-        r"""
-        Returns a bool indicating whether this instance is enabled.
-        """
+        r"""Return a bool indicating whether this instance is enabled."""
         return self._enabled
 
     def state_dict(self) -> Dict[str, Any]:
-        r"""
-        Returns the state of the scaler as a :class:`dict`.  It contains five entries:
+        r"""Return the state of the scaler as a :class:`dict`.
+
+        It contains five entries:
 
         * ``"scale"`` - a Python float containing the current scale
         * ``"growth_factor"`` - a Python float containing the current growth factor
@@ -621,8 +618,9 @@ class GradScaler:
         return {}
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
-        r"""
-        Loads the scaler state.  If this instance is disabled, :meth:`load_state_dict` is a no-op.
+        r"""Load the scaler state.
+        
+        If this instance is disabled, :meth:`load_state_dict` is a no-op.
 
         Args:
            state_dict(dict): scaler state.  Should be an object returned from a call to :meth:`state_dict`.

--- a/torch/cuda/amp/grad_scaler.py
+++ b/torch/cuda/amp/grad_scaler.py
@@ -49,7 +49,7 @@ def _refresh_per_optimizer_state() -> Dict[str, Any]:
 
 class GradScaler:
     """An instance ``scaler`` of :class:`GradScaler`.
-    
+
     Helps perform the steps of gradient scaling
     conveniently.
 
@@ -354,7 +354,7 @@ class GradScaler:
         self, optimizer: torch.optim.Optimizer, *args: Any, **kwargs: Any
     ) -> Optional[float]:
         """Invoke ``unscale_(optimizer)`` followed by parameter update, if gradients are not infs/NaN.
-        
+ 
         :meth:`step` carries out the following two operations:
 
         1.  Internally invokes ``unscale_(optimizer)`` (unless :meth:`unscale_` was explicitly called for ``optimizer``
@@ -619,7 +619,7 @@ class GradScaler:
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
         r"""Load the scaler state.
-        
+
         If this instance is disabled, :meth:`load_state_dict` is a no-op.
 
         Args:

--- a/torch/cuda/amp/grad_scaler.py
+++ b/torch/cuda/amp/grad_scaler.py
@@ -546,7 +546,7 @@ class GradScaler:
         return self._growth_factor
 
     def set_growth_factor(self, new_factor: float) -> None:
-        r"""Set new scale growth factor.
+        r"""Set a new scale growth factor.
 
         Args:
             new_scale (float):  Value to use as the new scale growth factor.
@@ -558,7 +558,7 @@ class GradScaler:
         return self._backoff_factor
 
     def set_backoff_factor(self, new_factor: float) -> None:
-        r"""Set new scale backoff factor.
+        r"""Set a new scale backoff factor.
 
         Args:
             new_scale (float):  Value to use as the new scale backoff factor.
@@ -570,7 +570,7 @@ class GradScaler:
         return self._growth_interval
 
     def set_growth_interval(self, new_interval: int) -> None:
-        r"""Set new growth interval.
+        r"""Set a new growth interval.
 
         Args:
             new_interval (int):  Value to use as the new growth interval.

--- a/torch/cuda/amp/grad_scaler.py
+++ b/torch/cuda/amp/grad_scaler.py
@@ -15,7 +15,7 @@ __all__ = ["OptState", "GradScaler"]
 
 class _MultiDeviceReplicator:
     """Lazily serves copies of a tensor to requested devices.
-    
+
     Copies are cached per-device.
     """
 

--- a/torch/cuda/random.py
+++ b/torch/cuda/random.py
@@ -18,7 +18,7 @@ __all__ = [
 
 
 def get_rng_state(device: Union[int, str, torch.device] = "cuda") -> Tensor:
-    r"""Returns the random number generator state of the specified GPU as a ByteTensor.
+    r"""Return the random number generator state of the specified GPU as a ByteTensor.
 
     Args:
         device (torch.device or int, optional): The device to return the RNG state of.
@@ -40,8 +40,7 @@ def get_rng_state(device: Union[int, str, torch.device] = "cuda") -> Tensor:
 
 
 def get_rng_state_all() -> List[Tensor]:
-    r"""Returns a list of ByteTensor representing the random number states of all devices."""
-
+    r"""Return a list of ByteTensor representing the random number states of all devices."""
     results = []
     for i in range(device_count()):
         results.append(get_rng_state(i))
@@ -51,7 +50,7 @@ def get_rng_state_all() -> List[Tensor]:
 def set_rng_state(
     new_state: Tensor, device: Union[int, str, torch.device] = "cuda"
 ) -> None:
-    r"""Sets the random number generator state of the specified GPU.
+    r"""Set the random number generator state of the specified GPU.
 
     Args:
         new_state (torch.ByteTensor): The desired state
@@ -76,16 +75,18 @@ def set_rng_state(
 
 
 def set_rng_state_all(new_states: Iterable[Tensor]) -> None:
-    r"""Sets the random number generator state of all devices.
+    r"""Set the random number generator state of all devices.
 
     Args:
-        new_states (Iterable of torch.ByteTensor): The desired state for each device"""
+        new_states (Iterable of torch.ByteTensor): The desired state for each device.
+    """
     for i, state in enumerate(new_states):
         set_rng_state(state, i)
 
 
 def manual_seed(seed: int) -> None:
-    r"""Sets the seed for generating random numbers for the current GPU.
+    r"""Set the seed for generating random numbers for the current GPU.
+    
     It's safe to call this function if CUDA is not available; in that
     case, it is silently ignored.
 
@@ -107,7 +108,8 @@ def manual_seed(seed: int) -> None:
 
 
 def manual_seed_all(seed: int) -> None:
-    r"""Sets the seed for generating random numbers on all GPUs.
+    r"""Set the seed for generating random numbers on all GPUs.
+    
     It's safe to call this function if CUDA is not available; in that
     case, it is silently ignored.
 
@@ -125,7 +127,8 @@ def manual_seed_all(seed: int) -> None:
 
 
 def seed() -> None:
-    r"""Sets the seed for generating random numbers to a random number for the current GPU.
+    r"""Set the seed for generating random numbers to a random number for the current GPU.
+    
     It's safe to call this function if CUDA is not available; in that
     case, it is silently ignored.
 
@@ -143,7 +146,8 @@ def seed() -> None:
 
 
 def seed_all() -> None:
-    r"""Sets the seed for generating random numbers to a random number on all GPUs.
+    r"""Set the seed for generating random numbers to a random number on all GPUs.
+    
     It's safe to call this function if CUDA is not available; in that
     case, it is silently ignored.
     """
@@ -164,7 +168,7 @@ def seed_all() -> None:
 
 
 def initial_seed() -> int:
-    r"""Returns the current random seed of the current GPU.
+    r"""Return the current random seed of the current GPU.
 
     .. warning::
         This function eagerly initializes CUDA.

--- a/torch/cuda/random.py
+++ b/torch/cuda/random.py
@@ -86,7 +86,7 @@ def set_rng_state_all(new_states: Iterable[Tensor]) -> None:
 
 def manual_seed(seed: int) -> None:
     r"""Set the seed for generating random numbers for the current GPU.
-    
+
     It's safe to call this function if CUDA is not available; in that
     case, it is silently ignored.
 
@@ -109,7 +109,7 @@ def manual_seed(seed: int) -> None:
 
 def manual_seed_all(seed: int) -> None:
     r"""Set the seed for generating random numbers on all GPUs.
-    
+
     It's safe to call this function if CUDA is not available; in that
     case, it is silently ignored.
 
@@ -128,7 +128,7 @@ def manual_seed_all(seed: int) -> None:
 
 def seed() -> None:
     r"""Set the seed for generating random numbers to a random number for the current GPU.
-    
+
     It's safe to call this function if CUDA is not available; in that
     case, it is silently ignored.
 
@@ -147,7 +147,7 @@ def seed() -> None:
 
 def seed_all() -> None:
     r"""Set the seed for generating random numbers to a random number on all GPUs.
-    
+
     It's safe to call this function if CUDA is not available; in that
     case, it is silently ignored.
     """

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1366,9 +1366,8 @@ def dropout2d(input: Tensor, p: float = 0.5, training: bool = True, inplace: boo
 
 
 def dropout3d(input: Tensor, p: float = 0.5, training: bool = True, inplace: bool = False) -> Tensor:
-    r"""
+    r"""Randomly zero out entire channels (a channel is a 3D feature map.
     
-    Randomly zero out entire channels (a channel is a 3D feature map.
     E.g., the :math:`j`-th channel of the :math:`i`-th sample in the
     batched input is a 3D tensor :math:`\text{input}[i, j]`) of the input tensor).
     Each channel will be zeroed out independently on every forward call with
@@ -1406,9 +1405,8 @@ def dropout3d(input: Tensor, p: float = 0.5, training: bool = True, inplace: boo
 
 
 def feature_alpha_dropout(input: Tensor, p: float = 0.5, training: bool = False, inplace: bool = False) -> Tensor:
-    r"""
+    r"""Randomly masks out entire channels (a channel is a feature map.
     
-    Randomly masks out entire channels (a channel is a feature map.
     E.g. the :math:`j`-th channel of the :math:`i`-th sample in the batch input
     is a tensor :math:`\text{input}[i, j]`) of the input tensor). Instead of
     setting activations to zero, as in regular Dropout, the activations are set
@@ -1436,7 +1434,7 @@ def feature_alpha_dropout(input: Tensor, p: float = 0.5, training: bool = False,
 
 
 def _threshold(input: Tensor, threshold: float, value: float, inplace: bool = False) -> Tensor:
-    r"""Thresholds each element of the input Tensor.
+    r"""Threshold each element of the input Tensor.
 
     See :class:`~torch.nn.Threshold` for more details.
     """
@@ -1465,11 +1463,8 @@ In-place version of :func:`~threshold`.
 
 
 def relu(input: Tensor, inplace: bool = False) -> Tensor:
-    r"""
+    r"""Apply the rectified linear unit function element-wise. 
     
-    relu(input, inplace=False) -> Tensor
-
-    Applies the rectified linear unit function element-wise. 
     See :class:`~torch.nn.ReLU` for more details.
     """
     if has_torch_function_unary(input):
@@ -1492,12 +1487,10 @@ In-place version of :func:`~relu`.
 
 
 def glu(input: Tensor, dim: int = -1) -> Tensor:
-    r"""
+    r"""The gated linear unit.
     
-    glu(input, dim=-1) -> Tensor.
 
-    The gated linear unit. Computes:
-
+    Computes:
     .. math ::
         \text{GLU}(a, b) = a \otimes \sigma(b)
 
@@ -1518,10 +1511,9 @@ def glu(input: Tensor, dim: int = -1) -> Tensor:
 
 
 def hardtanh(input: Tensor, min_val: float = -1., max_val: float = 1., inplace: bool = False) -> Tensor:
-    r"""
-    hardtanh(input, min_val=-1., max_val=1., inplace=False) -> Tensor
-
-    Applies the HardTanh function element-wise. See :class:`~torch.nn.Hardtanh` for more
+    r"""Apply the HardTanh function element-wise.
+    
+    See :class:`~torch.nn.Hardtanh` for more
     details.
     """
     if has_torch_function_unary(input):
@@ -1544,7 +1536,7 @@ In-place version of :func:`~hardtanh`.
 
 
 def relu6(input: Tensor, inplace: bool = False) -> Tensor:
-    r"""relu6(input, inplace=False) -> Tensor
+    r"""Modification of the ReLU with activation limited to maximum size of 6. 
 
     Applies the element-wise function :math:`\text{ReLU6}(x) = \min(\max(0,x), 6)`.
 
@@ -1560,7 +1552,7 @@ def relu6(input: Tensor, inplace: bool = False) -> Tensor:
 
 
 def elu(input: Tensor, alpha: float = 1.0, inplace: bool = False) -> Tensor:
-    r"""Applies the Exponential Linear Unit (ELU) function element-wise.
+    r"""Apply the Exponential Linear Unit (ELU) function element-wise.
 
     See :class:`~torch.nn.ELU` for more details.
     """
@@ -1584,7 +1576,7 @@ In-place version of :func:`~elu`.
 
 
 def selu(input: Tensor, inplace: bool = False) -> Tensor:
-    r"""selu(input, inplace=False) -> Tensor
+    r"""Apply the Scaled Exponential Linear Unit (ELU) function element-wise.
 
     Applies element-wise,
     :math:`\text{SELU}(x) = scale * (\max(0,x) + \min(0, \alpha * (\exp(x) - 1)))`,
@@ -1613,11 +1605,14 @@ In-place version of :func:`~selu`.
 
 
 def celu(input: Tensor, alpha: float = 1.0, inplace: bool = False) -> Tensor:
-    r"""celu(input, alpha=1., inplace=False) -> Tensor
+    r"""Apply CELU, a continously differentiable ELU.
 
     Applies element-wise,
     :math:`\text{CELU}(x) = \max(0,x) + \min(0, \alpha * (\exp(x/\alpha) - 1))`.
 
+    Refer paper for further information:
+    `Continuously Differentiable Exponential Linear Units`_.
+    
     See :class:`~torch.nn.CELU` for more details.
     """
     if has_torch_function_unary(input):
@@ -1640,10 +1635,8 @@ In-place version of :func:`~celu`.
 
 
 def leaky_relu(input: Tensor, negative_slope: float = 0.01, inplace: bool = False) -> Tensor:
-    r"""
-    leaky_relu(input, negative_slope=0.01, inplace=False) -> Tensor
-
-    Applies element-wise,
+    r"""Apply LeakyReLU element-wise.
+    
     :math:`\text{LeakyReLU}(x) = \max(0, x) + \text{negative\_slope} * \min(0, x)`
 
     See :class:`~torch.nn.LeakyReLU` for more details.
@@ -1690,9 +1683,7 @@ See :class:`~torch.nn.PReLU` for more details.
 def rrelu(
     input: Tensor, lower: float = 1.0 / 8, upper: float = 1.0 / 3, training: bool = False, inplace: bool = False
 ) -> Tensor:
-    r"""rrelu(input, lower=1./8, upper=1./3, training=False, inplace=False) -> Tensor
-
-    Randomized leaky ReLU.
+    r"""Randomized leaky ReLU.
 
     See :class:`~torch.nn.RReLU` for more details.
     """
@@ -1757,9 +1748,9 @@ See :class:`~torch.nn.Hardshrink` for more details.
 
 
 def tanhshrink(input):
-    r"""tanhshrink(input) -> Tensor
+    r"""Apply the following function element-wise.
 
-    Applies element-wise, :math:`\text{Tanhshrink}(x) = x - \text{Tanh}(x)`
+    Function :math:`\text{Tanhshrink}(x) = x - \text{Tanh}(x)`
 
     See :class:`~torch.nn.Tanhshrink` for more details.
     """
@@ -1769,9 +1760,9 @@ def tanhshrink(input):
 
 
 def softsign(input):
-    r"""softsign(input) -> Tensor
+    r"""Apply the following function element-wise.
 
-    Applies element-wise, the function :math:`\text{SoftSign}(x) = \frac{x}{1 + |x|}`
+    Function :math:`\text{SoftSign}(x) = \frac{x}{1 + |x|}`
 
     See :class:`~torch.nn.Softsign` for more details.
     """
@@ -1808,7 +1799,7 @@ def _get_softmax_dim(name: str, ndim: int, stacklevel: int) -> int:
 
 
 def softmin(input: Tensor, dim: Optional[int] = None, _stacklevel: int = 3, dtype: Optional[DType] = None) -> Tensor:
-    r"""Applies a softmin function.
+    r"""Apply a softmin function.
 
     Note that :math:`\text{Softmin}(x) = \text{Softmax}(-x)`. See softmax definition for mathematical formula.
 
@@ -1834,7 +1825,7 @@ def softmin(input: Tensor, dim: Optional[int] = None, _stacklevel: int = 3, dtyp
 
 
 def softmax(input: Tensor, dim: Optional[int] = None, _stacklevel: int = 3, dtype: Optional[DType] = None) -> Tensor:
-    r"""Applies a softmax function.
+    r"""Apply a softmax function.
 
     Softmax is defined as:
 
@@ -1871,7 +1862,7 @@ def softmax(input: Tensor, dim: Optional[int] = None, _stacklevel: int = 3, dtyp
 
 def gumbel_softmax(logits: Tensor, tau: float = 1, hard: bool = False, eps: float = 1e-10, dim: int = -1) -> Tensor:
     r"""
-    Samples from the Gumbel-Softmax distribution (`Link 1`_  `Link 2`_) and optionally discretizes.
+    Sample from the Gumbel-Softmax distribution (`Link 1`_  `Link 2`_) and optionally discretizes.
 
     Args:
       logits: `[..., num_features]` unnormalized log probabilities
@@ -1932,7 +1923,7 @@ def gumbel_softmax(logits: Tensor, tau: float = 1, hard: bool = False, eps: floa
 
 
 def log_softmax(input: Tensor, dim: Optional[int] = None, _stacklevel: int = 3, dtype: Optional[DType] = None) -> Tensor:
-    r"""Applies a softmax followed by a logarithm.
+    r"""Apply a softmax followed by a logarithm.
 
     While mathematically equivalent to log(softmax(x)), doing these two
     operations separately is slower and numerically unstable. This function
@@ -1971,9 +1962,9 @@ See :class:`~torch.nn.Softshrink` for more details.
 
 
 def tanh(input):
-    r"""tanh(input) -> Tensor
-
-    Applies element-wise,
+    r"""Apply hyperbolic tangent (tanh) function element-wise.
+    
+    tanh defined as - 
     :math:`\text{Tanh}(x) = \tanh(x) = \frac{\exp(x) - \exp(-x)}{\exp(x) + \exp(-x)}`
 
     See :class:`~torch.nn.Tanh` for more details.
@@ -1982,7 +1973,7 @@ def tanh(input):
 
 
 def sigmoid(input):
-    r"""sigmoid(input) -> Tensor
+    r""" Compute sigmoid element wise.
 
     Applies the element-wise function :math:`\text{Sigmoid}(x) = \frac{1}{1 + \exp(-x)}`
 
@@ -1992,7 +1983,7 @@ def sigmoid(input):
 
 
 def hardsigmoid(input: Tensor, inplace: bool = False) -> Tensor:
-    r"""Applies the element-wise function
+    r"""Apply the Hardsigmoid function element-wise.
 
     .. math::
         \text{Hardsigmoid}(x) = \begin{cases}
@@ -2059,7 +2050,8 @@ Shape:
 
 
 def silu(input: Tensor, inplace: bool = False) -> Tensor:
-    r"""Applies the Sigmoid Linear Unit (SiLU) function, element-wise.
+    r"""Apply the Sigmoid Linear Unit (SiLU) function, element-wise.
+    
     The SiLU function is also known as the swish function.
 
     .. math::
@@ -2083,7 +2075,8 @@ def silu(input: Tensor, inplace: bool = False) -> Tensor:
 
 
 def mish(input: Tensor, inplace: bool = False) -> Tensor:
-    r"""Applies the Mish function, element-wise.
+    r"""Apply the Mish function, element-wise.
+    
     Mish: A Self Regularized Non-Monotonic Neural Activation Function.
 
     .. math::
@@ -2102,8 +2095,9 @@ def mish(input: Tensor, inplace: bool = False) -> Tensor:
 
 
 def hardswish(input: Tensor, inplace: bool = False) -> Tensor:
-    r"""Applies the hardswish function, element-wise, as described in the paper:
-
+    r"""Apply hardswish function, element-wise.
+    
+    Follows implementation as described in the paper:
     `Searching for MobileNetV3`_.
 
     .. math::
@@ -2138,7 +2132,7 @@ def embedding(
     scale_grad_by_freq: bool = False,
     sparse: bool = False,
 ) -> Tensor:
-    r"""A simple lookup table that looks up embeddings in a fixed dictionary and size.
+    r"""Simple lookup table that looks up embeddings in a fixed dictionary and size.
 
     This module is often used to retrieve word embeddings using indices.
     The input to the module is a list of indices, and the embedding matrix,
@@ -2207,7 +2201,6 @@ def embedding(
                  [ 0.0000,  0.0000,  0.0000],
                  [ 0.6262,  0.2438,  0.7471]]])
     """
-
     if has_torch_function_variadic(input, weight):
         return handle_torch_function(
             embedding,
@@ -2256,7 +2249,7 @@ def embedding_bag(
     include_last_offset: bool = False,
     padding_idx: Optional[int] = None,
 ) -> Tensor:
-    r"""Computes sums, means or maxes of `bags` of embeddings, without instantiating the
+    r"""Compute sums, means or maxes of `bags` of embeddings, without instantiating the
     intermediate embeddings.
 
     See :class:`torch.nn.EmbeddingBag` for more details.
@@ -2464,7 +2457,7 @@ def batch_norm(
     momentum: float = 0.1,
     eps: float = 1e-5,
 ) -> Tensor:
-    r"""Applies Batch Normalization for each channel across a batch of data.
+    r"""Apply Batch Normalization for each channel across a batch of data.
 
     See :class:`~torch.nn.BatchNorm1d`, :class:`~torch.nn.BatchNorm2d`,
     :class:`~torch.nn.BatchNorm3d` for details.
@@ -2509,8 +2502,7 @@ def instance_norm(
     momentum: float = 0.1,
     eps: float = 1e-5,
 ) -> Tensor:
-    r"""Applies Instance Normalization for each channel in each data sample in a
-    batch.
+    r"""Apply Instance Normalization independently for each channel in every data sample within a batch.
 
     See :class:`~torch.nn.InstanceNorm1d`, :class:`~torch.nn.InstanceNorm2d`,
     :class:`~torch.nn.InstanceNorm3d` for details.
@@ -2542,7 +2534,7 @@ def layer_norm(
     bias: Optional[Tensor] = None,
     eps: float = 1e-5,
 ) -> Tensor:
-    r"""Applies Layer Normalization for last certain number of dimensions.
+    r"""Apply Layer Normalization for last certain number of dimensions.
 
     See :class:`~torch.nn.LayerNorm` for details.
     """
@@ -2556,7 +2548,7 @@ def layer_norm(
 def group_norm(
     input: Tensor, num_groups: int, weight: Optional[Tensor] = None, bias: Optional[Tensor] = None, eps: float = 1e-5
 ) -> Tensor:
-    r"""Applies Group Normalization for last certain number of dimensions.
+    r"""Apply Group Normalization for last certain number of dimensions.
 
     See :class:`~torch.nn.GroupNorm` for details.
     """
@@ -2569,9 +2561,10 @@ def group_norm(
 
 
 def local_response_norm(input: Tensor, size: int, alpha: float = 1e-4, beta: float = 0.75, k: float = 1.0) -> Tensor:
-    r"""Applies local response normalization over an input signal composed of
-    several input planes, where channels occupy the second dimension.
-    Applies normalization across channels.
+    r"""Apply local response normalization over an input signal.
+    
+    Input ignal is composed of several input planes, where channels occupy the second dimension.
+    Normalization is applied across channels.
 
     See :class:`~torch.nn.LocalResponseNorm` for details.
     """
@@ -2897,7 +2890,9 @@ def kl_div(
     reduction: str = "mean",
     log_target: bool = False,
 ) -> Tensor:
-    r"""The `Kullback-Leibler divergence Loss
+    r"""Calculate KL Divergence loss.
+    
+    Refer - The `Kullback-Leibler divergence Loss
     <https://en.wikipedia.org/wiki/Kullback-Leibler_divergence>`__
 
     See :class:`~torch.nn.KLDivLoss` for details.
@@ -2980,7 +2975,7 @@ def cross_entropy(
     reduction: str = "mean",
     label_smoothing: float = 0.0,
 ) -> Tensor:
-    r"""This criterion computes the cross entropy loss between input logits and target.
+    r"""Compute the cross entropy loss between input logits and target.
 
     See :class:`~torch.nn.CrossEntropyLoss` for details.
 
@@ -3071,8 +3066,7 @@ def binary_cross_entropy(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""Function that measures the Binary Cross Entropy between the target and input
-    probabilities.
+    r"""Calculate Binary Cross Entropy between the target and input probabilities.
 
     See :class:`~torch.nn.BCELoss` for details.
 
@@ -3141,8 +3135,7 @@ def binary_cross_entropy_with_logits(
     reduction: str = "mean",
     pos_weight: Optional[Tensor] = None,
 ) -> Tensor:
-    r"""Function that measures Binary Cross Entropy between target and input
-    logits.
+    r"""Caculate Binary Cross Entropy between target and input logits.
 
     See :class:`~torch.nn.BCEWithLogitsLoss` for details.
 
@@ -3441,7 +3434,11 @@ def soft_margin_loss(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""soft_margin_loss(input, target, size_average=None, reduce=None, reduction='mean') -> Tensor
+    r"""
+    Creates a criterion that optimizes a two-class classification logistic loss between input tensor 
+x and target tensor 
+y (containing 1 or -1).
+    soft_margin_loss(input, target, size_average=None, reduce=None, reduction='mean') -> Tensor
 
     See :class:`~torch.nn.SoftMarginLoss` for details.
     """

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1283,7 +1283,7 @@ def alpha_dropout(input: Tensor, p: float = 0.5, training: bool = False, inplace
 def dropout1d(input: Tensor, p: float = 0.5, training: bool = True, inplace: bool = False) -> Tensor:
     r"""Randomly zero out entire channels a channel is a 1D feature map.
     
-    E.g., the :math:`j`-th channel of the :math:`i`-th sample in the
+    For example, the :math:`j`-th channel of the :math:`i`-th sample in the
     batched input is a 1D tensor :math:`\text{input}[i, j]`) of the input tensor).
     Each channel will be zeroed out independently on every forward call with
     probability :attr:`p` using samples from a Bernoulli distribution.

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1029,7 +1029,6 @@ def lp_pool2d(
     ceil_mode: bool = False
 ) -> Tensor:
     r"""
-    
     Apply a 2D power-average pooling over an input signal composed of several input planes.
     
     If the sum of all inputs to the power of `p` is

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1028,8 +1028,9 @@ def lp_pool2d(
     stride: Optional[BroadcastingList2[int]] = None,
     ceil_mode: bool = False
 ) -> Tensor:
-    r"""Apply a 2D power-average pooling over an input signal composed of
-    several input planes.
+    r"""
+    
+    Apply a 2D power-average pooling over an input signal composed of several input planes.
     
     If the sum of all inputs to the power of `p` is
     zero, the gradient is set to zero as well.
@@ -1055,8 +1056,7 @@ def lp_pool1d(
     stride: Optional[BroadcastingList1[int]] = None,
     ceil_mode: bool = False
 ) -> Tensor:
-    r"""Apply a 1D power-average pooling over an input signal composed of
-    several input planes.
+    r"""Apply a 1D power-average pooling over an input signal composed of several input planes.
     
     If the sum of all inputs to the power of `p` is
     zero, the gradient is set to zero as well.
@@ -1120,8 +1120,7 @@ def adaptive_max_pool2d_with_indices(
     input: Tensor, output_size: BroadcastingList2[int],
     return_indices: bool = False
 ) -> Tuple[Tensor, Tensor]:
-    r"""
-    adaptive_max_pool2d(input, output_size, return_indices=False).
+    r"""adaptive_max_pool2d(input, output_size, return_indices=False).
 
     Applies a 2D adaptive max pooling over an input signal composed of
     several input planes.
@@ -1221,10 +1220,7 @@ Args:
 
 
 def adaptive_avg_pool2d(input: Tensor, output_size: BroadcastingList2[int]) -> Tensor:
-    r"""
-    
-    Apply a 2D adaptive average pooling over an input signal composed of
-    several input planes.
+    r"""Apply a 2D adaptive average pooling over an input signal composed of several input planes.
 
     See :class:`~torch.nn.AdaptiveAvgPool2d` for details and output shape.
 
@@ -1239,10 +1235,7 @@ def adaptive_avg_pool2d(input: Tensor, output_size: BroadcastingList2[int]) -> T
 
 
 def adaptive_avg_pool3d(input: Tensor, output_size: BroadcastingList3[int]) -> Tensor:
-    r"""
-    
-    Apply a 3D adaptive average pooling over an input signal composed of
-    several input planes.
+    r"""Apply a 3D adaptive average pooling over an input signal composed of several input planes.
 
     See :class:`~torch.nn.AdaptiveAvgPool3d` for details and output shape.
 
@@ -1258,11 +1251,9 @@ def adaptive_avg_pool3d(input: Tensor, output_size: BroadcastingList3[int]) -> T
 
 # Activation functions
 def dropout(input: Tensor, p: float = 0.5, training: bool = True, inplace: bool = False) -> Tensor:
-    r"""
+    r"""During training, randomly zeroes some elements of the input tensor with probability :attr:`p`.
     
-    During training, randomly zeroes some of the elements of the input
-    tensor with probability :attr:`p` using samples from a Bernoulli
-    distribution.
+    Uses samples from a Bernoulli distribution.
 
     See :class:`~torch.nn.Dropout` for details.
 
@@ -1378,7 +1369,7 @@ def dropout3d(input: Tensor, p: float = 0.5, training: bool = True, inplace: boo
     r"""
     
     Randomly zero out entire channels (a channel is a 3D feature map.
-    e.g., the :math:`j`-th channel of the :math:`i`-th sample in the
+    E.g., the :math:`j`-th channel of the :math:`i`-th sample in the
     batched input is a 3D tensor :math:`\text{input}[i, j]`) of the input tensor).
     Each channel will be zeroed out independently on every forward call with
     probability :attr:`p` using samples from a Bernoulli distribution.

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1,4 +1,4 @@
-"""Functional interface."""
+"""Functional interface"""
 from typing import Callable, List, Optional, Tuple, Union
 import math
 import warnings
@@ -436,7 +436,7 @@ def fractional_max_pool2d_with_indices(
     _random_samples: Optional[Tensor] = None
 ) -> Tuple[Tensor, Tensor]:
     r"""
-    fractional_max_pool2d(input, kernel_size, output_size=None, output_ratio=None, return_indices=False, _random_samples=None).
+    fractional_max_pool2d(input, kernel_size, output_size=None, output_ratio=None, return_indices=False, _random_samples=None)
 
     Applies 2D fractional max pooling over an input signal composed of several input planes.
 
@@ -535,7 +535,7 @@ def fractional_max_pool3d_with_indices(
     _random_samples: Optional[Tensor] = None
 ) -> Tuple[Tensor, Tensor]:
     r"""
-    fractional_max_pool3d(input, kernel_size, output_size=None, output_ratio=None, return_indices=False, _random_samples=None).
+    fractional_max_pool3d(input, kernel_size, output_size=None, output_ratio=None, return_indices=False, _random_samples=None)
 
     Applies 3D fractional max pooling over an input signal composed of several input planes.
 
@@ -644,7 +644,7 @@ def max_pool1d_with_indices(
     return_indices: bool = False
 ) -> Tuple[Tensor, Tensor]:
     r"""
-    max_pool1d(input, kernel_size, stride=None, padding=0, dilation=1, ceil_mode=False, return_indices=False).
+    max_pool1d(input, kernel_size, stride=None, padding=0, dilation=1, ceil_mode=False, return_indices=False)
 
     Applies a 1D max pooling over an input signal composed of several input
     planes.
@@ -730,7 +730,7 @@ def max_pool2d_with_indices(
     return_indices: bool = False
 ) -> Tuple[Tensor, Tensor]:
     r"""
-    max_pool2d(input, kernel_size, stride=None, padding=0, dilation=1, ceil_mode=False, return_indices=False).
+    max_pool2d(input, kernel_size, stride=None, padding=0, dilation=1, ceil_mode=False, return_indices=False)
 
     Applies a 2D max pooling over an input signal composed of several input
     planes.
@@ -816,7 +816,7 @@ def max_pool3d_with_indices(
     return_indices: bool = False
 ) -> Tuple[Tensor, Tensor]:
     r"""
-    max_pool3d(input, kernel_size, stride=None, padding=0, dilation=1, ceil_mode=False, return_indices=False).
+    max_pool3d(input, kernel_size, stride=None, padding=0, dilation=1, ceil_mode=False, return_indices=False)
 
     Applies a 3D max pooling over an input signal composed of several input
     planes.
@@ -929,7 +929,7 @@ def max_unpool1d(
     padding: BroadcastingList1[int] = 0,
     output_size: Optional[BroadcastingList1[int]] = None
 ) -> Tensor:
-    r"""Compute a partial inverse of :class:`MaxPool1d`.
+    r"""Computes a partial inverse of :class:`MaxPool1d`.
 
     See :class:`~torch.nn.MaxUnpool1d` for details.
     """
@@ -965,7 +965,7 @@ def max_unpool2d(
     padding: BroadcastingList2[int] = 0,
     output_size: Optional[BroadcastingList2[int]] = None
 ) -> Tensor:
-    r"""Compute a partial inverse of :class:`MaxPool2d`.
+    r"""Computes a partial inverse of :class:`MaxPool2d`.
 
     See :class:`~torch.nn.MaxUnpool2d` for details.
     """
@@ -997,7 +997,7 @@ def max_unpool3d(
     padding: BroadcastingList3[int] = 0,
     output_size: Optional[BroadcastingList3[int]] = None
 ) -> Tensor:
-    r"""Compute a partial inverse of :class:`MaxPool3d`.
+    r"""Computes a partial inverse of :class:`MaxPool3d`.
 
     See :class:`~torch.nn.MaxUnpool3d` for details.
     """
@@ -1028,10 +1028,8 @@ def lp_pool2d(
     stride: Optional[BroadcastingList2[int]] = None,
     ceil_mode: bool = False
 ) -> Tensor:
-    r"""
-    Apply a 2D power-average pooling over an input signal composed of several input planes.
-    
-    If the sum of all inputs to the power of `p` is
+    r"""Applies a 2D power-average pooling over an input signal composed of
+    several input planes. If the sum of all inputs to the power of `p` is
     zero, the gradient is set to zero as well.
 
     See :class:`~torch.nn.LPPool2d` for details.
@@ -1055,9 +1053,8 @@ def lp_pool1d(
     stride: Optional[BroadcastingList1[int]] = None,
     ceil_mode: bool = False
 ) -> Tensor:
-    r"""Apply a 1D power-average pooling over an input signal composed of several input planes.
-    
-    If the sum of all inputs to the power of `p` is
+    r"""Applies a 1D power-average pooling over an input signal composed of
+    several input planes. If the sum of all inputs to the power of `p` is
     zero, the gradient is set to zero as well.
 
     See :class:`~torch.nn.LPPool1d` for details.
@@ -1078,7 +1075,7 @@ def adaptive_max_pool1d_with_indices(
     input: Tensor, output_size: BroadcastingList1[int], return_indices: bool = False
 ) -> Tuple[Tensor, Tensor]:
     r"""
-    adaptive_max_pool1d(input, output_size, return_indices=False).
+    adaptive_max_pool1d(input, output_size, return_indices=False)
 
     Applies a 1D adaptive max pooling over an input signal composed of
     several input planes.
@@ -1119,7 +1116,8 @@ def adaptive_max_pool2d_with_indices(
     input: Tensor, output_size: BroadcastingList2[int],
     return_indices: bool = False
 ) -> Tuple[Tensor, Tensor]:
-    r"""adaptive_max_pool2d(input, output_size, return_indices=False).
+    r"""
+    adaptive_max_pool2d(input, output_size, return_indices=False)
 
     Applies a 2D adaptive max pooling over an input signal composed of
     several input planes.
@@ -1163,7 +1161,7 @@ def adaptive_max_pool3d_with_indices(
     return_indices: bool = False
 ) -> Tuple[Tensor, Tensor]:
     r"""
-    adaptive_max_pool3d(input, output_size, return_indices=False).
+    adaptive_max_pool3d(input, output_size, return_indices=False)
 
     Applies a 3D adaptive max pooling over an input signal composed of
     several input planes.
@@ -1205,7 +1203,7 @@ adaptive_max_pool3d = boolean_dispatch(
 adaptive_avg_pool1d = _add_docstr(
     torch.adaptive_avg_pool1d,
     r"""
-adaptive_avg_pool1d(input, output_size) -> Tensor.
+adaptive_avg_pool1d(input, output_size) -> Tensor
 
 Applies a 1D adaptive average pooling over an input signal composed of
 several input planes.
@@ -1219,7 +1217,9 @@ Args:
 
 
 def adaptive_avg_pool2d(input: Tensor, output_size: BroadcastingList2[int]) -> Tensor:
-    r"""Apply a 2D adaptive average pooling over an input signal composed of several input planes.
+    r"""
+    Applies a 2D adaptive average pooling over an input signal composed of
+    several input planes.
 
     See :class:`~torch.nn.AdaptiveAvgPool2d` for details and output shape.
 
@@ -1234,7 +1234,9 @@ def adaptive_avg_pool2d(input: Tensor, output_size: BroadcastingList2[int]) -> T
 
 
 def adaptive_avg_pool3d(input: Tensor, output_size: BroadcastingList3[int]) -> Tensor:
-    r"""Apply a 3D adaptive average pooling over an input signal composed of several input planes.
+    r"""
+    Applies a 3D adaptive average pooling over an input signal composed of
+    several input planes.
 
     See :class:`~torch.nn.AdaptiveAvgPool3d` for details and output shape.
 
@@ -1250,9 +1252,10 @@ def adaptive_avg_pool3d(input: Tensor, output_size: BroadcastingList3[int]) -> T
 
 # Activation functions
 def dropout(input: Tensor, p: float = 0.5, training: bool = True, inplace: bool = False) -> Tensor:
-    r"""During training, randomly zeroes some elements of the input tensor with probability :attr:`p`.
-    
-    Uses samples from a Bernoulli distribution.
+    r"""
+    During training, randomly zeroes some of the elements of the input
+    tensor with probability :attr:`p` using samples from a Bernoulli
+    distribution.
 
     See :class:`~torch.nn.Dropout` for details.
 
@@ -1269,7 +1272,7 @@ def dropout(input: Tensor, p: float = 0.5, training: bool = True, inplace: bool 
 
 
 def alpha_dropout(input: Tensor, p: float = 0.5, training: bool = False, inplace: bool = False) -> Tensor:
-    r"""Apply alpha dropout to the input.
+    r"""Applies alpha dropout to the input.
 
     See :class:`~torch.nn.AlphaDropout` for details.
     """
@@ -1281,10 +1284,10 @@ def alpha_dropout(input: Tensor, p: float = 0.5, training: bool = False, inplace
 
 
 def dropout1d(input: Tensor, p: float = 0.5, training: bool = True, inplace: bool = False) -> Tensor:
-    r"""Randomly zero out entire channels (a channel is a 1D feature map).
-    
-    For example, the :math:`j`-th channel of the :math:`i`-th sample in the
-    batched input is a 1D tensor :math:`\text{input}[i, j]` of the input tensor.
+    r"""
+    Randomly zero out entire channels (a channel is a 1D feature map,
+    e.g., the :math:`j`-th channel of the :math:`i`-th sample in the
+    batched input is a 1D tensor :math:`\text{input}[i, j]`) of the input tensor).
     Each channel will be zeroed out independently on every forward call with
     probability :attr:`p` using samples from a Bernoulli distribution.
 
@@ -1319,10 +1322,10 @@ def dropout1d(input: Tensor, p: float = 0.5, training: bool = True, inplace: boo
 
 
 def dropout2d(input: Tensor, p: float = 0.5, training: bool = True, inplace: bool = False) -> Tensor:
-    r"""Randomly zero out entire channels (a channel is a 2D feature map).
-    
-    For example, the :math:`j`-th channel of the :math:`i`-th sample in the
-    batched input is a 2D tensor :math:`\text{input}[i, j]` of the input tensor.
+    r"""
+    Randomly zero out entire channels (a channel is a 2D feature map,
+    e.g., the :math:`j`-th channel of the :math:`i`-th sample in the
+    batched input is a 2D tensor :math:`\text{input}[i, j]`) of the input tensor).
     Each channel will be zeroed out independently on every forward call with
     probability :attr:`p` using samples from a Bernoulli distribution.
 
@@ -1363,10 +1366,10 @@ def dropout2d(input: Tensor, p: float = 0.5, training: bool = True, inplace: boo
 
 
 def dropout3d(input: Tensor, p: float = 0.5, training: bool = True, inplace: bool = False) -> Tensor:
-    r"""Randomly zero out entire channels (a channel is a 3D feature map).
-    
-    For example, the :math:`j`-th channel of the :math:`i`-th sample in the
-    batched input is a 3D tensor :math:`\text{input}[i, j]` of the input tensor.
+    r"""
+    Randomly zero out entire channels (a channel is a 3D feature map,
+    e.g., the :math:`j`-th channel of the :math:`i`-th sample in the
+    batched input is a 3D tensor :math:`\text{input}[i, j]`) of the input tensor).
     Each channel will be zeroed out independently on every forward call with
     probability :attr:`p` using samples from a Bernoulli distribution.
 
@@ -1402,10 +1405,10 @@ def dropout3d(input: Tensor, p: float = 0.5, training: bool = True, inplace: boo
 
 
 def feature_alpha_dropout(input: Tensor, p: float = 0.5, training: bool = False, inplace: bool = False) -> Tensor:
-    r"""Randomly masks out entire channels (a channel is a feature map).
-    
-    For example, the :math:`j`-th channel of the :math:`i`-th sample in the batch input
-    is a tensor :math:`\text{input}[i, j]` of the input tensor. Instead of
+    r"""
+    Randomly masks out entire channels (a channel is a feature map,
+    e.g. the :math:`j`-th channel of the :math:`i`-th sample in the batch input
+    is a tensor :math:`\text{input}[i, j]`) of the input tensor). Instead of
     setting activations to zero, as in regular Dropout, the activations are set
     to the negative saturation value of the SELU activation function.
 
@@ -1431,7 +1434,7 @@ def feature_alpha_dropout(input: Tensor, p: float = 0.5, training: bool = False,
 
 
 def _threshold(input: Tensor, threshold: float, value: float, inplace: bool = False) -> Tensor:
-    r"""Apply a threshold to each element of the input Tensor.
+    r"""Thresholds each element of the input Tensor.
 
     See :class:`~torch.nn.Threshold` for more details.
     """
@@ -1460,9 +1463,10 @@ In-place version of :func:`~threshold`.
 
 
 def relu(input: Tensor, inplace: bool = False) -> Tensor:
-    r"""Apply the rectified linear unit function element-wise.
-    
-    See :class:`~torch.nn.ReLU` for more details.
+    r"""relu(input, inplace=False) -> Tensor
+
+    Applies the rectified linear unit function element-wise. See
+    :class:`~torch.nn.ReLU` for more details.
     """
     if has_torch_function_unary(input):
         return handle_torch_function(relu, (input,), input, inplace=inplace)
@@ -1484,9 +1488,11 @@ In-place version of :func:`~relu`.
 
 
 def glu(input: Tensor, dim: int = -1) -> Tensor:
-    r"""Apply the gated linear unit function.
-    
-    Computes:
+    r"""
+    glu(input, dim=-1) -> Tensor
+
+    The gated linear unit. Computes:
+
     .. math ::
         \text{GLU}(a, b) = a \otimes \sigma(b)
 
@@ -1507,9 +1513,10 @@ def glu(input: Tensor, dim: int = -1) -> Tensor:
 
 
 def hardtanh(input: Tensor, min_val: float = -1., max_val: float = 1., inplace: bool = False) -> Tensor:
-    r"""Apply the HardTanh function element-wise.
-    
-    See :class:`~torch.nn.Hardtanh` for more
+    r"""
+    hardtanh(input, min_val=-1., max_val=1., inplace=False) -> Tensor
+
+    Applies the HardTanh function element-wise. See :class:`~torch.nn.Hardtanh` for more
     details.
     """
     if has_torch_function_unary(input):
@@ -1532,7 +1539,7 @@ In-place version of :func:`~hardtanh`.
 
 
 def relu6(input: Tensor, inplace: bool = False) -> Tensor:
-    r"""Modification of the ReLU with activation limited to maximum size of 6.
+    r"""relu6(input, inplace=False) -> Tensor
 
     Applies the element-wise function :math:`\text{ReLU6}(x) = \min(\max(0,x), 6)`.
 
@@ -1548,7 +1555,7 @@ def relu6(input: Tensor, inplace: bool = False) -> Tensor:
 
 
 def elu(input: Tensor, alpha: float = 1.0, inplace: bool = False) -> Tensor:
-    r"""Apply the Exponential Linear Unit (ELU) function element-wise.
+    r"""Applies the Exponential Linear Unit (ELU) function element-wise.
 
     See :class:`~torch.nn.ELU` for more details.
     """
@@ -1572,7 +1579,7 @@ In-place version of :func:`~elu`.
 
 
 def selu(input: Tensor, inplace: bool = False) -> Tensor:
-    r"""Apply the Scaled Exponential Linear Unit (ELU) function element-wise.
+    r"""selu(input, inplace=False) -> Tensor
 
     Applies element-wise,
     :math:`\text{SELU}(x) = scale * (\max(0,x) + \min(0, \alpha * (\exp(x) - 1)))`,
@@ -1601,11 +1608,11 @@ In-place version of :func:`~selu`.
 
 
 def celu(input: Tensor, alpha: float = 1.0, inplace: bool = False) -> Tensor:
-    r"""Apply CELU, a continously differentiable ELU.
-    
+    r"""celu(input, alpha=1., inplace=False) -> Tensor
+
     Applies element-wise,
     :math:`\text{CELU}(x) = \max(0,x) + \min(0, \alpha * (\exp(x/\alpha) - 1))`.
-    
+
     See :class:`~torch.nn.CELU` for more details.
     """
     if has_torch_function_unary(input):
@@ -1628,8 +1635,10 @@ In-place version of :func:`~celu`.
 
 
 def leaky_relu(input: Tensor, negative_slope: float = 0.01, inplace: bool = False) -> Tensor:
-    r"""Apply LeakyReLU element-wise.
-    
+    r"""
+    leaky_relu(input, negative_slope=0.01, inplace=False) -> Tensor
+
+    Applies element-wise,
     :math:`\text{LeakyReLU}(x) = \max(0, x) + \text{negative\_slope} * \min(0, x)`
 
     See :class:`~torch.nn.LeakyReLU` for more details.
@@ -1676,7 +1685,9 @@ See :class:`~torch.nn.PReLU` for more details.
 def rrelu(
     input: Tensor, lower: float = 1.0 / 8, upper: float = 1.0 / 3, training: bool = False, inplace: bool = False
 ) -> Tensor:
-    r"""Randomized leaky ReLU.
+    r"""rrelu(input, lower=1./8, upper=1./3, training=False, inplace=False) -> Tensor
+
+    Randomized leaky ReLU.
 
     See :class:`~torch.nn.RReLU` for more details.
     """
@@ -1741,9 +1752,9 @@ See :class:`~torch.nn.Hardshrink` for more details.
 
 
 def tanhshrink(input):
-    r"""Apply the TanhShrink function element-wise.
+    r"""tanhshrink(input) -> Tensor
 
-    Function :math:`\text{Tanhshrink}(x) = x - \text{Tanh}(x)`
+    Applies element-wise, :math:`\text{Tanhshrink}(x) = x - \text{Tanh}(x)`
 
     See :class:`~torch.nn.Tanhshrink` for more details.
     """
@@ -1753,9 +1764,9 @@ def tanhshrink(input):
 
 
 def softsign(input):
-    r"""Apply the SoftSign function element-wise.
+    r"""softsign(input) -> Tensor
 
-    Function :math:`\text{SoftSign}(x) = \frac{x}{1 + |x|}`
+    Applies element-wise, the function :math:`\text{SoftSign}(x) = \frac{x}{1 + |x|}`
 
     See :class:`~torch.nn.Softsign` for more details.
     """
@@ -1792,7 +1803,7 @@ def _get_softmax_dim(name: str, ndim: int, stacklevel: int) -> int:
 
 
 def softmin(input: Tensor, dim: Optional[int] = None, _stacklevel: int = 3, dtype: Optional[DType] = None) -> Tensor:
-    r"""Apply a softmin function.
+    r"""Applies a softmin function.
 
     Note that :math:`\text{Softmin}(x) = \text{Softmax}(-x)`. See softmax definition for mathematical formula.
 
@@ -1818,7 +1829,7 @@ def softmin(input: Tensor, dim: Optional[int] = None, _stacklevel: int = 3, dtyp
 
 
 def softmax(input: Tensor, dim: Optional[int] = None, _stacklevel: int = 3, dtype: Optional[DType] = None) -> Tensor:
-    r"""Apply a softmax function.
+    r"""Applies a softmax function.
 
     Softmax is defined as:
 
@@ -1855,7 +1866,7 @@ def softmax(input: Tensor, dim: Optional[int] = None, _stacklevel: int = 3, dtyp
 
 def gumbel_softmax(logits: Tensor, tau: float = 1, hard: bool = False, eps: float = 1e-10, dim: int = -1) -> Tensor:
     r"""
-    Sample from the Gumbel-Softmax distribution (`Link 1`_  `Link 2`_) and optionally discretize.
+    Samples from the Gumbel-Softmax distribution (`Link 1`_  `Link 2`_) and optionally discretizes.
 
     Args:
       logits: `[..., num_features]` unnormalized log probabilities
@@ -1916,7 +1927,7 @@ def gumbel_softmax(logits: Tensor, tau: float = 1, hard: bool = False, eps: floa
 
 
 def log_softmax(input: Tensor, dim: Optional[int] = None, _stacklevel: int = 3, dtype: Optional[DType] = None) -> Tensor:
-    r"""Apply a softmax followed by a logarithm.
+    r"""Applies a softmax followed by a logarithm.
 
     While mathematically equivalent to log(softmax(x)), doing these two
     operations separately is slower and numerically unstable. This function
@@ -1955,9 +1966,10 @@ See :class:`~torch.nn.Softshrink` for more details.
 
 
 def tanh(input):
-    r"""Apply hyperbolic tangent (tanh) function element-wise.
-    
-     Applies :math:`\text{Tanh}(x) = \tanh(x) = \frac{\exp(x) - \exp(-x)}{\exp(x) + \exp(-x)}`
+    r"""tanh(input) -> Tensor
+
+    Applies element-wise,
+    :math:`\text{Tanh}(x) = \tanh(x) = \frac{\exp(x) - \exp(-x)}{\exp(x) + \exp(-x)}`
 
     See :class:`~torch.nn.Tanh` for more details.
     """
@@ -1965,7 +1977,7 @@ def tanh(input):
 
 
 def sigmoid(input):
-    r"""Compute sigmoid element-wise.
+    r"""sigmoid(input) -> Tensor
 
     Applies the element-wise function :math:`\text{Sigmoid}(x) = \frac{1}{1 + \exp(-x)}`
 
@@ -1975,7 +1987,7 @@ def sigmoid(input):
 
 
 def hardsigmoid(input: Tensor, inplace: bool = False) -> Tensor:
-    r"""Apply the Hardsigmoid function element-wise.
+    r"""Applies the element-wise function
 
     .. math::
         \text{Hardsigmoid}(x) = \begin{cases}
@@ -2042,8 +2054,7 @@ Shape:
 
 
 def silu(input: Tensor, inplace: bool = False) -> Tensor:
-    r"""Apply the Sigmoid Linear Unit (SiLU) function, element-wise.
-    
+    r"""Applies the Sigmoid Linear Unit (SiLU) function, element-wise.
     The SiLU function is also known as the swish function.
 
     .. math::
@@ -2067,8 +2078,7 @@ def silu(input: Tensor, inplace: bool = False) -> Tensor:
 
 
 def mish(input: Tensor, inplace: bool = False) -> Tensor:
-    r"""Apply the Mish function, element-wise.
-    
+    r"""Applies the Mish function, element-wise.
     Mish: A Self Regularized Non-Monotonic Neural Activation Function.
 
     .. math::
@@ -2087,9 +2097,8 @@ def mish(input: Tensor, inplace: bool = False) -> Tensor:
 
 
 def hardswish(input: Tensor, inplace: bool = False) -> Tensor:
-    r"""Apply hardswish function, element-wise.
-    
-    Follows implementation as described in the paper:
+    r"""Applies the hardswish function, element-wise, as described in the paper:
+
     `Searching for MobileNetV3`_.
 
     .. math::
@@ -2124,7 +2133,7 @@ def embedding(
     scale_grad_by_freq: bool = False,
     sparse: bool = False,
 ) -> Tensor:
-    r"""Generate a simple lookup table that looks up embeddings in a fixed dictionary and size.
+    r"""A simple lookup table that looks up embeddings in a fixed dictionary and size.
 
     This module is often used to retrieve word embeddings using indices.
     The input to the module is a list of indices, and the embedding matrix,
@@ -2193,6 +2202,7 @@ def embedding(
                  [ 0.0000,  0.0000,  0.0000],
                  [ 0.6262,  0.2438,  0.7471]]])
     """
+
     if has_torch_function_variadic(input, weight):
         return handle_torch_function(
             embedding,
@@ -2241,9 +2251,9 @@ def embedding_bag(
     include_last_offset: bool = False,
     padding_idx: Optional[int] = None,
 ) -> Tensor:
-    r"""Directly compute sums, means or maxes of `bags` of embeddings.
-    
-    Calculation done without instantiating the intermediate embeddings.
+    r"""Computes sums, means or maxes of `bags` of embeddings, without instantiating the
+    intermediate embeddings.
+
     See :class:`torch.nn.EmbeddingBag` for more details.
 
     Note:
@@ -2449,7 +2459,7 @@ def batch_norm(
     momentum: float = 0.1,
     eps: float = 1e-5,
 ) -> Tensor:
-    r"""Apply Batch Normalization for each channel across a batch of data.
+    r"""Applies Batch Normalization for each channel across a batch of data.
 
     See :class:`~torch.nn.BatchNorm1d`, :class:`~torch.nn.BatchNorm2d`,
     :class:`~torch.nn.BatchNorm3d` for details.
@@ -2494,7 +2504,8 @@ def instance_norm(
     momentum: float = 0.1,
     eps: float = 1e-5,
 ) -> Tensor:
-    r"""Apply Instance Normalization independently for each channel in every data sample within a batch.
+    r"""Applies Instance Normalization for each channel in each data sample in a
+    batch.
 
     See :class:`~torch.nn.InstanceNorm1d`, :class:`~torch.nn.InstanceNorm2d`,
     :class:`~torch.nn.InstanceNorm3d` for details.
@@ -2526,7 +2537,7 @@ def layer_norm(
     bias: Optional[Tensor] = None,
     eps: float = 1e-5,
 ) -> Tensor:
-    r"""Apply Layer Normalization for last certain number of dimensions.
+    r"""Applies Layer Normalization for last certain number of dimensions.
 
     See :class:`~torch.nn.LayerNorm` for details.
     """
@@ -2540,7 +2551,7 @@ def layer_norm(
 def group_norm(
     input: Tensor, num_groups: int, weight: Optional[Tensor] = None, bias: Optional[Tensor] = None, eps: float = 1e-5
 ) -> Tensor:
-    r"""Apply Group Normalization for last certain number of dimensions.
+    r"""Applies Group Normalization for last certain number of dimensions.
 
     See :class:`~torch.nn.GroupNorm` for details.
     """
@@ -2553,10 +2564,9 @@ def group_norm(
 
 
 def local_response_norm(input: Tensor, size: int, alpha: float = 1e-4, beta: float = 0.75, k: float = 1.0) -> Tensor:
-    r"""Apply local response normalization over an input signal.
-    
-    Input signal is composed of several input planes, where channels occupy the second dimension.
-    Normalization is applied across channels.
+    r"""Applies local response normalization over an input signal composed of
+    several input planes, where channels occupy the second dimension.
+    Applies normalization across channels.
 
     See :class:`~torch.nn.LocalResponseNorm` for details.
     """
@@ -2598,7 +2608,7 @@ def ctc_loss(
     reduction: str = "mean",
     zero_infinity: bool = False,
 ) -> Tensor:
-    r"""Apply the Connectionist Temporal Classification loss.
+    r"""The Connectionist Temporal Classification loss.
 
     See :class:`~torch.nn.CTCLoss` for details.
 
@@ -2666,7 +2676,7 @@ def nll_loss(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""Apply the negative log likelihood loss.
+    r"""The negative log likelihood loss.
 
     See :class:`~torch.nn.NLLLoss` for details.
 
@@ -2882,9 +2892,7 @@ def kl_div(
     reduction: str = "mean",
     log_target: bool = False,
 ) -> Tensor:
-    r"""Calculate KL Divergence loss.
-    
-    Refer - The `Kullback-Leibler divergence Loss
+    r"""The `Kullback-Leibler divergence Loss
     <https://en.wikipedia.org/wiki/Kullback-Leibler_divergence>`__
 
     See :class:`~torch.nn.KLDivLoss` for details.
@@ -2967,7 +2975,7 @@ def cross_entropy(
     reduction: str = "mean",
     label_smoothing: float = 0.0,
 ) -> Tensor:
-    r"""Compute the cross entropy loss between input logits and target.
+    r"""This criterion computes the cross entropy loss between input logits and target.
 
     See :class:`~torch.nn.CrossEntropyLoss` for details.
 
@@ -3058,7 +3066,8 @@ def binary_cross_entropy(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""Measure Binary Cross Entropy between the target and input probabilities.
+    r"""Function that measures the Binary Cross Entropy between the target and input
+    probabilities.
 
     See :class:`~torch.nn.BCELoss` for details.
 
@@ -3127,7 +3136,8 @@ def binary_cross_entropy_with_logits(
     reduction: str = "mean",
     pos_weight: Optional[Tensor] = None,
 ) -> Tensor:
-    r"""Caculate Binary Cross Entropy between target and input logits.
+    r"""Function that measures Binary Cross Entropy between target and input
+    logits.
 
     See :class:`~torch.nn.BCEWithLogitsLoss` for details.
 
@@ -3198,9 +3208,7 @@ def smooth_l1_loss(
     reduction: str = "mean",
     beta: float = 1.0,
 ) -> Tensor:
-    r"""Calculate Smooth L1 loss.
-    
-    Function uses a squared term if the absolute
+    r"""Function that uses a squared term if the absolute
     element-wise error falls below beta and an L1 term otherwise.
 
     See :class:`~torch.nn.SmoothL1Loss` for details.
@@ -3240,14 +3248,9 @@ def huber_loss(
     reduction: str = 'mean',
     delta: float = 1.0,
 ) -> Tensor:
-    r"""Calculate Huber loss.
-    
-    Function uses a squared term if the absolute
+    r"""Function that uses a squared term if the absolute
     element-wise error falls below delta and a delta-scaled L1 term otherwise.
-    
-    When delta equals 1, this loss is equivalent to SmoothL1Loss. 
-    In general, Huber loss differs from SmoothL1Loss by a factor of delta (AKA beta in Smooth L1).
-    
+
     See :class:`~torch.nn.HuberLoss` for details.
     """
     if has_torch_function_variadic(input, target):
@@ -3276,7 +3279,9 @@ def l1_loss(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""Calculate the mean element-wise absolute value difference.
+    r"""l1_loss(input, target, size_average=None, reduce=None, reduction='mean') -> Tensor
+
+    Function that takes the mean element-wise absolute value difference.
 
     See :class:`~torch.nn.L1Loss` for details.
     """
@@ -3305,7 +3310,9 @@ def mse_loss(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""Measure the element-wise mean squared error.
+    r"""mse_loss(input, target, size_average=None, reduce=None, reduction='mean') -> Tensor
+
+    Measures the element-wise mean squared error.
 
     See :class:`~torch.nn.MSELoss` for details.
     """
@@ -3336,7 +3343,10 @@ def margin_ranking_loss(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""See :class:`~torch.nn.MarginRankingLoss` for details."""
+    r"""margin_ranking_loss(input1, input2, target, margin=0, size_average=None, reduce=None, reduction='mean') -> Tensor
+
+    See :class:`~torch.nn.MarginRankingLoss` for details.
+    """
     if has_torch_function_variadic(input1, input2, target):
         return handle_torch_function(
             margin_ranking_loss,
@@ -3369,11 +3379,7 @@ def hinge_embedding_loss(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""Measure the loss given an input tensor x and a labels tensor y (containing 1 or -1).
-
-    Usually used for measuring whether two inputs are similar or dissimilar, 
-    e.g. using the L1 pairwise distance as x, 
-    and is typically used for learning nonlinear embeddings or semi-supervised learning.
+    r"""hinge_embedding_loss(input, target, margin=1.0, size_average=None, reduce=None, reduction='mean') -> Tensor
 
     See :class:`~torch.nn.HingeEmbeddingLoss` for details.
     """
@@ -3402,7 +3408,10 @@ def multilabel_margin_loss(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""See :class:`~torch.nn.MultiLabelMarginLoss` for details."""
+    r"""multilabel_margin_loss(input, target, size_average=None, reduce=None, reduction='mean') -> Tensor
+
+    See :class:`~torch.nn.MultiLabelMarginLoss` for details.
+    """
     if has_torch_function_variadic(input, target):
         return handle_torch_function(
             multilabel_margin_loss,
@@ -3427,9 +3436,8 @@ def soft_margin_loss(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""
-    Optimize a two-class classification logistic loss between input tensor x and target tensor y (containing 1 or -1).
-    
+    r"""soft_margin_loss(input, target, size_average=None, reduce=None, reduction='mean') -> Tensor
+
     See :class:`~torch.nn.SoftMarginLoss` for details.
     """
     if has_torch_function_variadic(input, target):
@@ -3451,9 +3459,7 @@ def multilabel_soft_margin_loss(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""Optimize a multi-label one-versus-all loss based on max-entropy.
-
-    Creates a criterion between input x and target y of size (N,C) for optimisation.
+    r"""multilabel_soft_margin_loss(input, target, weight=None, size_average=None, reduce=None, reduction='mean') -> Tensor
 
     See :class:`~torch.nn.MultiLabelSoftMarginLoss` for details.
     """
@@ -3501,12 +3507,7 @@ def cosine_embedding_loss(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""Calculate Cosine Embedding loss.
-    
-    Creates a criterion that measures the loss given input tensors x1,x2
-    and a Tensor label y with values 1 or -1. 
-    Used for measuring whether two inputs are similar or dissimilar, using the cosine similarity, 
-    and is typically used for learning nonlinear embeddings or semi-supervised learning.
+    r"""cosine_embedding_loss(input1, input2, target, margin=0, size_average=None, reduce=None, reduction='mean') -> Tensor
 
     See :class:`~torch.nn.CosineEmbeddingLoss` for details.
     """
@@ -3539,7 +3540,10 @@ def multi_margin_loss(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""See :class:`~torch.nn.MultiMarginLoss` for details."""
+    r"""multi_margin_loss(input, target, p=1, margin=1, weight=None, size_average=None, reduce=None, reduction='mean') -> Tensor
+
+    See :class:`~torch.nn.MultiMarginLoss` for details.
+    """
     if has_torch_function_variadic(input, target, weight):
         return handle_torch_function(
             multi_margin_loss,
@@ -3711,9 +3715,7 @@ def upsample(input: Tensor, size: Optional[List[int]] = None, scale_factor: Opti
 
 
 def upsample(input, size=None, scale_factor=None, mode="nearest", align_corners=None):  # noqa: F811
-    r"""Upsample input.
-    
-    Provided tensor is upsampled to either the given :attr:`size` or the given
+    r"""Upsamples the input to either the given :attr:`size` or the given
     :attr:`scale_factor`
 
     .. warning::
@@ -3779,7 +3781,6 @@ if upsample.__doc__:
 
 def _is_integer(x) -> bool:
     r"""Type check the input number is an integer.
-    
     Will return True for int, SymInt, Numpy integers and Tensors with integer elements.
     """
     if isinstance(x, (int, torch.SymInt)):
@@ -3817,9 +3818,7 @@ def interpolate(  # noqa: F811
     pass
 
 def interpolate(input: Tensor, size: Optional[int] = None, scale_factor: Optional[List[float]] = None, mode: str = 'nearest', align_corners: Optional[bool] = None, recompute_scale_factor: Optional[bool] = None, antialias: bool = False) -> Tensor:  # noqa: F811,B950
-    r"""Down/up samples the input.
-    
-    Tensor interpolated to either the given :attr:`size` or the given
+    r"""Down/up samples the input to either the given :attr:`size` or the given
     :attr:`scale_factor`
 
     The algorithm used for interpolation is determined by :attr:`mode`.
@@ -4172,9 +4171,7 @@ def grid_sample(
     padding_mode: str = "zeros",
     align_corners: Optional[bool] = None,
 ) -> Tensor:
-    r"""Compute grid sample.
-    
-    Given an :attr:`input` and a flow-field :attr:`grid`, computes the
+    r"""Given an :attr:`input` and a flow-field :attr:`grid`, computes the
     ``output`` using :attr:`input` values and pixel locations from :attr:`grid`.
 
     Currently, only spatial (4-D) and volumetric (5-D) :attr:`input` are
@@ -4315,7 +4312,8 @@ def grid_sample(
 
 
 def affine_grid(theta: Tensor, size: List[int], align_corners: Optional[bool] = None) -> Tensor:
-    r"""Generate 2D or 3D flow field (sampling grid), given a batch of affine matrices :attr:`theta`.
+    r"""Generates a 2D or 3D flow field (sampling grid), given a batch of
+    affine matrices :attr:`theta`.
 
     .. note::
         This function is often used in conjunction with :func:`grid_sample`
@@ -4607,9 +4605,8 @@ def triplet_margin_loss(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""Measure triplet loss between given input tensors and a margin greater than 0.
-    
-    See :class:`~torch.nn.TripletMarginLoss` for details.
+    r"""
+    See :class:`~torch.nn.TripletMarginLoss` for details
     """
     if has_torch_function_variadic(anchor, positive, negative):
         return handle_torch_function(
@@ -4643,8 +4640,7 @@ def triplet_margin_with_distance_loss(
     swap: bool = False,
     reduction: str = "mean"
 ) -> Tensor:
-    r"""Compute the triplet margin loss for input tensors using a custom distance function.
-    
+    r"""
     See :class:`~torch.nn.TripletMarginWithDistanceLoss` for details.
     """
     if torch.jit.is_scripting():
@@ -4706,7 +4702,7 @@ def triplet_margin_with_distance_loss(
 
 
 def normalize(input: Tensor, p: float = 2.0, dim: int = 1, eps: float = 1e-12, out: Optional[Tensor] = None) -> Tensor:
-    r"""Perform :math:`L_p` normalization of inputs over specified dimension.
+    r"""Performs :math:`L_p` normalization of inputs over specified dimension.
 
     For a tensor :attr:`input` of sizes :math:`(n_0, ..., n_{dim}, ..., n_k)`, each
     :math:`n_{dim}` -element vector :math:`v` along dimension :attr:`dim` is transformed as
@@ -4744,7 +4740,7 @@ def unfold(
     padding: BroadcastingList2[int] = 0,
     stride: BroadcastingList2[int] = 1
 ) -> Tensor:
-    r"""Extract sliding local blocks from a batched input tensor.
+    r"""Extracts sliding local blocks from a batched input tensor.
 
     .. warning::
         Currently, only 4-D input tensors (batched image-like tensors) are
@@ -4774,8 +4770,9 @@ def fold(
     padding: BroadcastingList2[int] = 0,
     stride: BroadcastingList2[int] = 1
 ) -> Tensor:
-    r"""Combine an array of sliding local blocks into a large containing tensor.
-    
+    r"""Combines an array of sliding local blocks into a large containing
+    tensor.
+
     .. warning::
         Currently, only unbatched (3D) or batched (4D) image-like output tensors are supported.
 
@@ -4800,8 +4797,8 @@ def _in_projection_packed(
     w: Tensor,
     b: Optional[Tensor] = None,
 ) -> List[Tensor]:
-    r"""Perform the in-projection step of the attention operation, using packed weights.
-    
+    r"""
+    Performs the in-projection step of the attention operation, using packed weights.
     Output is a triple containing projection tensors for query, key and value.
 
     Args:
@@ -4867,10 +4864,9 @@ def _in_projection(
     b_k: Optional[Tensor] = None,
     b_v: Optional[Tensor] = None,
 ) -> Tuple[Tensor, Tensor, Tensor]:
-    r"""Perform the in-projection step of the attention operation.
-    
-    This is simply a triple of linear projections,
-    with shape constraints on the weights which
+    r"""
+    Performs the in-projection step of the attention operation. This is simply
+    a triple of linear projections, with shape constraints on the weights which
     ensure embedding dimension uniformity in the projected outputs.
     Output is a triple containing projection tensors for query, key and value.
 
@@ -4979,6 +4975,7 @@ Note:
     {cudnn_reproducibility_note}
 """.format(**reproducibility_notes)
     + r"""
+
 Args:
     query (Tensor): Query tensor; shape :math:`(N, ..., L, E)`.
     key (Tensor): Key tensor; shape :math:`(N, ..., S, E)`.
@@ -5128,10 +5125,7 @@ def multi_head_attention_forward(
     average_attn_weights: bool = True,
     is_causal: bool = False,
 ) -> Tuple[Tensor, Optional[Tensor]]:
-    r"""Foward method for MultiHeadAttention.
-    
-    See :class:`torch.nn.MultiheadAttention` for details.
-    
+    r"""
     Args:
         query, key, value: map a query and a set of key-value pairs to an output.
             See "Attention Is All You Need" for more details.

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1282,9 +1282,8 @@ def alpha_dropout(input: Tensor, p: float = 0.5, training: bool = False, inplace
 
 
 def dropout1d(input: Tensor, p: float = 0.5, training: bool = True, inplace: bool = False) -> Tensor:
-    r"""
+    r"""Randomly zero out entire channels (a channel is a 1D feature map.
     
-    Randomly zero out entire channels (a channel is a 1D feature map.
     E.g., the :math:`j`-th channel of the :math:`i`-th sample in the
     batched input is a 1D tensor :math:`\text{input}[i, j]`) of the input tensor).
     Each channel will be zeroed out independently on every forward call with
@@ -1321,9 +1320,8 @@ def dropout1d(input: Tensor, p: float = 0.5, training: bool = True, inplace: boo
 
 
 def dropout2d(input: Tensor, p: float = 0.5, training: bool = True, inplace: bool = False) -> Tensor:
-    r"""
+    r"""Randomly zero out entire channels (a channel is a 2D feature map.
     
-    Randomly zero out entire channels (a channel is a 2D feature map.
     E.g., the :math:`j`-th channel of the :math:`i`-th sample in the
     batched input is a 2D tensor :math:`\text{input}[i, j]`) of the input tensor).
     Each channel will be zeroed out independently on every forward call with
@@ -1463,7 +1461,7 @@ In-place version of :func:`~threshold`.
 
 
 def relu(input: Tensor, inplace: bool = False) -> Tensor:
-    r"""Apply the rectified linear unit function element-wise. 
+    r"""Apply the rectified linear unit function element-wise.
     
     See :class:`~torch.nn.ReLU` for more details.
     """
@@ -1487,7 +1485,7 @@ In-place version of :func:`~relu`.
 
 
 def glu(input: Tensor, dim: int = -1) -> Tensor:
-    r"""The gated linear unit.
+    r"""Apply the gated linear unit function.
     
 
     Computes:
@@ -1536,7 +1534,7 @@ In-place version of :func:`~hardtanh`.
 
 
 def relu6(input: Tensor, inplace: bool = False) -> Tensor:
-    r"""Modification of the ReLU with activation limited to maximum size of 6. 
+    r"""Modification of the ReLU with activation limited to maximum size of 6.
 
     Applies the element-wise function :math:`\text{ReLU6}(x) = \min(\max(0,x), 6)`.
 
@@ -1973,7 +1971,7 @@ def tanh(input):
 
 
 def sigmoid(input):
-    r""" Compute sigmoid element wise.
+    r"""Compute sigmoid element-wise.
 
     Applies the element-wise function :math:`\text{Sigmoid}(x) = \frac{1}{1 + \exp(-x)}`
 
@@ -2132,7 +2130,7 @@ def embedding(
     scale_grad_by_freq: bool = False,
     sparse: bool = False,
 ) -> Tensor:
-    r"""Simple lookup table that looks up embeddings in a fixed dictionary and size.
+    r"""Lookup table that looks up embeddings in a fixed dictionary and size.
 
     This module is often used to retrieve word embeddings using indices.
     The input to the module is a list of indices, and the embedding matrix,
@@ -2606,7 +2604,7 @@ def ctc_loss(
     reduction: str = "mean",
     zero_infinity: bool = False,
 ) -> Tensor:
-    r"""The Connectionist Temporal Classification loss.
+    r"""Apply the Connectionist Temporal Classification loss.
 
     See :class:`~torch.nn.CTCLoss` for details.
 
@@ -2674,7 +2672,7 @@ def nll_loss(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""The negative log likelihood loss.
+    r"""Apply the negative log likelihood loss.
 
     See :class:`~torch.nn.NLLLoss` for details.
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1321,7 +1321,7 @@ def dropout1d(input: Tensor, p: float = 0.5, training: bool = True, inplace: boo
 def dropout2d(input: Tensor, p: float = 0.5, training: bool = True, inplace: bool = False) -> Tensor:
     r"""Randomly zero out entire channels a channel is a 2D feature map.
     
-    E.g., the :math:`j`-th channel of the :math:`i`-th sample in the
+    For example, the :math:`j`-th channel of the :math:`i`-th sample in the
     batched input is a 2D tensor :math:`\text{input}[i, j]`) of the input tensor).
     Each channel will be zeroed out independently on every forward call with
     probability :attr:`p` using samples from a Bernoulli distribution.

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1,4 +1,4 @@
-"""Functional interface"""
+"""Functional interface."""
 from typing import Callable, List, Optional, Tuple, Union
 import math
 import warnings
@@ -436,7 +436,7 @@ def fractional_max_pool2d_with_indices(
     _random_samples: Optional[Tensor] = None
 ) -> Tuple[Tensor, Tensor]:
     r"""
-    fractional_max_pool2d(input, kernel_size, output_size=None, output_ratio=None, return_indices=False, _random_samples=None)
+    fractional_max_pool2d(input, kernel_size, output_size=None, output_ratio=None, return_indices=False, _random_samples=None).
 
     Applies 2D fractional max pooling over an input signal composed of several input planes.
 
@@ -535,7 +535,7 @@ def fractional_max_pool3d_with_indices(
     _random_samples: Optional[Tensor] = None
 ) -> Tuple[Tensor, Tensor]:
     r"""
-    fractional_max_pool3d(input, kernel_size, output_size=None, output_ratio=None, return_indices=False, _random_samples=None)
+    fractional_max_pool3d(input, kernel_size, output_size=None, output_ratio=None, return_indices=False, _random_samples=None).
 
     Applies 3D fractional max pooling over an input signal composed of several input planes.
 
@@ -644,7 +644,7 @@ def max_pool1d_with_indices(
     return_indices: bool = False
 ) -> Tuple[Tensor, Tensor]:
     r"""
-    max_pool1d(input, kernel_size, stride=None, padding=0, dilation=1, ceil_mode=False, return_indices=False)
+    max_pool1d(input, kernel_size, stride=None, padding=0, dilation=1, ceil_mode=False, return_indices=False).
 
     Applies a 1D max pooling over an input signal composed of several input
     planes.
@@ -730,7 +730,7 @@ def max_pool2d_with_indices(
     return_indices: bool = False
 ) -> Tuple[Tensor, Tensor]:
     r"""
-    max_pool2d(input, kernel_size, stride=None, padding=0, dilation=1, ceil_mode=False, return_indices=False)
+    max_pool2d(input, kernel_size, stride=None, padding=0, dilation=1, ceil_mode=False, return_indices=False).
 
     Applies a 2D max pooling over an input signal composed of several input
     planes.
@@ -816,7 +816,7 @@ def max_pool3d_with_indices(
     return_indices: bool = False
 ) -> Tuple[Tensor, Tensor]:
     r"""
-    max_pool3d(input, kernel_size, stride=None, padding=0, dilation=1, ceil_mode=False, return_indices=False)
+    max_pool3d(input, kernel_size, stride=None, padding=0, dilation=1, ceil_mode=False, return_indices=False).
 
     Applies a 3D max pooling over an input signal composed of several input
     planes.
@@ -929,7 +929,7 @@ def max_unpool1d(
     padding: BroadcastingList1[int] = 0,
     output_size: Optional[BroadcastingList1[int]] = None
 ) -> Tensor:
-    r"""Computes a partial inverse of :class:`MaxPool1d`.
+    r"""Compute a partial inverse of :class:`MaxPool1d`.
 
     See :class:`~torch.nn.MaxUnpool1d` for details.
     """
@@ -965,7 +965,7 @@ def max_unpool2d(
     padding: BroadcastingList2[int] = 0,
     output_size: Optional[BroadcastingList2[int]] = None
 ) -> Tensor:
-    r"""Computes a partial inverse of :class:`MaxPool2d`.
+    r"""Compute a partial inverse of :class:`MaxPool2d`.
 
     See :class:`~torch.nn.MaxUnpool2d` for details.
     """
@@ -997,7 +997,7 @@ def max_unpool3d(
     padding: BroadcastingList3[int] = 0,
     output_size: Optional[BroadcastingList3[int]] = None
 ) -> Tensor:
-    r"""Computes a partial inverse of :class:`MaxPool3d`.
+    r"""Compute a partial inverse of :class:`MaxPool3d`.
 
     See :class:`~torch.nn.MaxUnpool3d` for details.
     """
@@ -1028,8 +1028,10 @@ def lp_pool2d(
     stride: Optional[BroadcastingList2[int]] = None,
     ceil_mode: bool = False
 ) -> Tensor:
-    r"""Applies a 2D power-average pooling over an input signal composed of
-    several input planes. If the sum of all inputs to the power of `p` is
+    r"""Apply a 2D power-average pooling over an input signal composed of
+    several input planes.
+    
+    If the sum of all inputs to the power of `p` is
     zero, the gradient is set to zero as well.
 
     See :class:`~torch.nn.LPPool2d` for details.
@@ -1053,8 +1055,10 @@ def lp_pool1d(
     stride: Optional[BroadcastingList1[int]] = None,
     ceil_mode: bool = False
 ) -> Tensor:
-    r"""Applies a 1D power-average pooling over an input signal composed of
-    several input planes. If the sum of all inputs to the power of `p` is
+    r"""Apply a 1D power-average pooling over an input signal composed of
+    several input planes.
+    
+    If the sum of all inputs to the power of `p` is
     zero, the gradient is set to zero as well.
 
     See :class:`~torch.nn.LPPool1d` for details.
@@ -1075,7 +1079,7 @@ def adaptive_max_pool1d_with_indices(
     input: Tensor, output_size: BroadcastingList1[int], return_indices: bool = False
 ) -> Tuple[Tensor, Tensor]:
     r"""
-    adaptive_max_pool1d(input, output_size, return_indices=False)
+    adaptive_max_pool1d(input, output_size, return_indices=False).
 
     Applies a 1D adaptive max pooling over an input signal composed of
     several input planes.
@@ -1117,7 +1121,7 @@ def adaptive_max_pool2d_with_indices(
     return_indices: bool = False
 ) -> Tuple[Tensor, Tensor]:
     r"""
-    adaptive_max_pool2d(input, output_size, return_indices=False)
+    adaptive_max_pool2d(input, output_size, return_indices=False).
 
     Applies a 2D adaptive max pooling over an input signal composed of
     several input planes.
@@ -1161,7 +1165,7 @@ def adaptive_max_pool3d_with_indices(
     return_indices: bool = False
 ) -> Tuple[Tensor, Tensor]:
     r"""
-    adaptive_max_pool3d(input, output_size, return_indices=False)
+    adaptive_max_pool3d(input, output_size, return_indices=False).
 
     Applies a 3D adaptive max pooling over an input signal composed of
     several input planes.
@@ -1203,7 +1207,7 @@ adaptive_max_pool3d = boolean_dispatch(
 adaptive_avg_pool1d = _add_docstr(
     torch.adaptive_avg_pool1d,
     r"""
-adaptive_avg_pool1d(input, output_size) -> Tensor
+adaptive_avg_pool1d(input, output_size) -> Tensor.
 
 Applies a 1D adaptive average pooling over an input signal composed of
 several input planes.
@@ -1218,7 +1222,8 @@ Args:
 
 def adaptive_avg_pool2d(input: Tensor, output_size: BroadcastingList2[int]) -> Tensor:
     r"""
-    Applies a 2D adaptive average pooling over an input signal composed of
+    
+    Apply a 2D adaptive average pooling over an input signal composed of
     several input planes.
 
     See :class:`~torch.nn.AdaptiveAvgPool2d` for details and output shape.
@@ -1235,7 +1240,8 @@ def adaptive_avg_pool2d(input: Tensor, output_size: BroadcastingList2[int]) -> T
 
 def adaptive_avg_pool3d(input: Tensor, output_size: BroadcastingList3[int]) -> Tensor:
     r"""
-    Applies a 3D adaptive average pooling over an input signal composed of
+    
+    Apply a 3D adaptive average pooling over an input signal composed of
     several input planes.
 
     See :class:`~torch.nn.AdaptiveAvgPool3d` for details and output shape.
@@ -1253,6 +1259,7 @@ def adaptive_avg_pool3d(input: Tensor, output_size: BroadcastingList3[int]) -> T
 # Activation functions
 def dropout(input: Tensor, p: float = 0.5, training: bool = True, inplace: bool = False) -> Tensor:
     r"""
+    
     During training, randomly zeroes some of the elements of the input
     tensor with probability :attr:`p` using samples from a Bernoulli
     distribution.
@@ -1272,7 +1279,7 @@ def dropout(input: Tensor, p: float = 0.5, training: bool = True, inplace: bool 
 
 
 def alpha_dropout(input: Tensor, p: float = 0.5, training: bool = False, inplace: bool = False) -> Tensor:
-    r"""Applies alpha dropout to the input.
+    r"""Apply alpha dropout to the input.
 
     See :class:`~torch.nn.AlphaDropout` for details.
     """
@@ -1285,8 +1292,9 @@ def alpha_dropout(input: Tensor, p: float = 0.5, training: bool = False, inplace
 
 def dropout1d(input: Tensor, p: float = 0.5, training: bool = True, inplace: bool = False) -> Tensor:
     r"""
-    Randomly zero out entire channels (a channel is a 1D feature map,
-    e.g., the :math:`j`-th channel of the :math:`i`-th sample in the
+    
+    Randomly zero out entire channels (a channel is a 1D feature map.
+    E.g., the :math:`j`-th channel of the :math:`i`-th sample in the
     batched input is a 1D tensor :math:`\text{input}[i, j]`) of the input tensor).
     Each channel will be zeroed out independently on every forward call with
     probability :attr:`p` using samples from a Bernoulli distribution.
@@ -1323,8 +1331,9 @@ def dropout1d(input: Tensor, p: float = 0.5, training: bool = True, inplace: boo
 
 def dropout2d(input: Tensor, p: float = 0.5, training: bool = True, inplace: bool = False) -> Tensor:
     r"""
-    Randomly zero out entire channels (a channel is a 2D feature map,
-    e.g., the :math:`j`-th channel of the :math:`i`-th sample in the
+    
+    Randomly zero out entire channels (a channel is a 2D feature map.
+    E.g., the :math:`j`-th channel of the :math:`i`-th sample in the
     batched input is a 2D tensor :math:`\text{input}[i, j]`) of the input tensor).
     Each channel will be zeroed out independently on every forward call with
     probability :attr:`p` using samples from a Bernoulli distribution.
@@ -1367,7 +1376,8 @@ def dropout2d(input: Tensor, p: float = 0.5, training: bool = True, inplace: boo
 
 def dropout3d(input: Tensor, p: float = 0.5, training: bool = True, inplace: bool = False) -> Tensor:
     r"""
-    Randomly zero out entire channels (a channel is a 3D feature map,
+    
+    Randomly zero out entire channels (a channel is a 3D feature map.
     e.g., the :math:`j`-th channel of the :math:`i`-th sample in the
     batched input is a 3D tensor :math:`\text{input}[i, j]`) of the input tensor).
     Each channel will be zeroed out independently on every forward call with
@@ -1406,8 +1416,9 @@ def dropout3d(input: Tensor, p: float = 0.5, training: bool = True, inplace: boo
 
 def feature_alpha_dropout(input: Tensor, p: float = 0.5, training: bool = False, inplace: bool = False) -> Tensor:
     r"""
-    Randomly masks out entire channels (a channel is a feature map,
-    e.g. the :math:`j`-th channel of the :math:`i`-th sample in the batch input
+    
+    Randomly masks out entire channels (a channel is a feature map.
+    E.g. the :math:`j`-th channel of the :math:`i`-th sample in the batch input
     is a tensor :math:`\text{input}[i, j]`) of the input tensor). Instead of
     setting activations to zero, as in regular Dropout, the activations are set
     to the negative saturation value of the SELU activation function.
@@ -1463,10 +1474,12 @@ In-place version of :func:`~threshold`.
 
 
 def relu(input: Tensor, inplace: bool = False) -> Tensor:
-    r"""relu(input, inplace=False) -> Tensor
+    r"""
+    
+    relu(input, inplace=False) -> Tensor
 
-    Applies the rectified linear unit function element-wise. See
-    :class:`~torch.nn.ReLU` for more details.
+    Applies the rectified linear unit function element-wise. 
+    See :class:`~torch.nn.ReLU` for more details.
     """
     if has_torch_function_unary(input):
         return handle_torch_function(relu, (input,), input, inplace=inplace)
@@ -1489,7 +1502,8 @@ In-place version of :func:`~relu`.
 
 def glu(input: Tensor, dim: int = -1) -> Tensor:
     r"""
-    glu(input, dim=-1) -> Tensor
+    
+    glu(input, dim=-1) -> Tensor.
 
     The gated linear unit. Computes:
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3512,7 +3512,7 @@ def cosine_embedding_loss(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""cosine_embedding_loss(input1, input2, target, margin=0, size_average=None, reduce=None, reduction='mean') -> Tensor
+    r"""cosine_embedding_loss(input1, input2, target, margin=0, size_average=None, reduce=None, reduction='mean').
 
     See :class:`~torch.nn.CosineEmbeddingLoss` for details.
     """
@@ -3720,7 +3720,9 @@ def upsample(input: Tensor, size: Optional[List[int]] = None, scale_factor: Opti
 
 
 def upsample(input, size=None, scale_factor=None, mode="nearest", align_corners=None):  # noqa: F811
-    r"""Upsamples the input to either the given :attr:`size` or the given
+    r"""Upsample input.
+    
+    Provided tensor is upsampled to either the given :attr:`size` or the given
     :attr:`scale_factor`
 
     .. warning::
@@ -3786,6 +3788,7 @@ if upsample.__doc__:
 
 def _is_integer(x) -> bool:
     r"""Type check the input number is an integer.
+    
     Will return True for int, SymInt, Numpy integers and Tensors with integer elements.
     """
     if isinstance(x, (int, torch.SymInt)):
@@ -3823,7 +3826,9 @@ def interpolate(  # noqa: F811
     pass
 
 def interpolate(input: Tensor, size: Optional[int] = None, scale_factor: Optional[List[float]] = None, mode: str = 'nearest', align_corners: Optional[bool] = None, recompute_scale_factor: Optional[bool] = None, antialias: bool = False) -> Tensor:  # noqa: F811,B950
-    r"""Down/up samples the input to either the given :attr:`size` or the given
+    r"""Down/up samples the input. 
+    
+    Tensor interpolated to either the given :attr:`size` or the given
     :attr:`scale_factor`
 
     The algorithm used for interpolation is determined by :attr:`mode`.
@@ -4176,7 +4181,9 @@ def grid_sample(
     padding_mode: str = "zeros",
     align_corners: Optional[bool] = None,
 ) -> Tensor:
-    r"""Given an :attr:`input` and a flow-field :attr:`grid`, computes the
+    r"""grid_sample(input, grid, mode, padding_mode, align_corners).
+    
+    Given an :attr:`input` and a flow-field :attr:`grid`, computes the
     ``output`` using :attr:`input` values and pixel locations from :attr:`grid`.
 
     Currently, only spatial (4-D) and volumetric (5-D) :attr:`input` are
@@ -4317,8 +4324,7 @@ def grid_sample(
 
 
 def affine_grid(theta: Tensor, size: List[int], align_corners: Optional[bool] = None) -> Tensor:
-    r"""Generates a 2D or 3D flow field (sampling grid), given a batch of
-    affine matrices :attr:`theta`.
+    r"""Generate 2D or 3D flow field (sampling grid), given a batch of affine matrices :attr:`theta`.
 
     .. note::
         This function is often used in conjunction with :func:`grid_sample`
@@ -4707,7 +4713,7 @@ def triplet_margin_with_distance_loss(
 
 
 def normalize(input: Tensor, p: float = 2.0, dim: int = 1, eps: float = 1e-12, out: Optional[Tensor] = None) -> Tensor:
-    r"""Performs :math:`L_p` normalization of inputs over specified dimension.
+    r"""Perform :math:`L_p` normalization of inputs over specified dimension.
 
     For a tensor :attr:`input` of sizes :math:`(n_0, ..., n_{dim}, ..., n_k)`, each
     :math:`n_{dim}` -element vector :math:`v` along dimension :attr:`dim` is transformed as
@@ -4745,7 +4751,7 @@ def unfold(
     padding: BroadcastingList2[int] = 0,
     stride: BroadcastingList2[int] = 1
 ) -> Tensor:
-    r"""Extracts sliding local blocks from a batched input tensor.
+    r"""Extract sliding local blocks from a batched input tensor.
 
     .. warning::
         Currently, only 4-D input tensors (batched image-like tensors) are
@@ -4775,8 +4781,8 @@ def fold(
     padding: BroadcastingList2[int] = 0,
     stride: BroadcastingList2[int] = 1
 ) -> Tensor:
-    r"""Combines an array of sliding local blocks into a large containing
-    tensor.
+    r"""
+    Combine an array of sliding local blocks into a large containing tensor.
 
     .. warning::
         Currently, only unbatched (3D) or batched (4D) image-like output tensors are supported.
@@ -4803,7 +4809,8 @@ def _in_projection_packed(
     b: Optional[Tensor] = None,
 ) -> List[Tensor]:
     r"""
-    Performs the in-projection step of the attention operation, using packed weights.
+    Perform the in-projection step of the attention operation, using packed weights.
+    
     Output is a triple containing projection tensors for query, key and value.
 
     Args:
@@ -4870,8 +4877,10 @@ def _in_projection(
     b_v: Optional[Tensor] = None,
 ) -> Tuple[Tensor, Tensor, Tensor]:
     r"""
-    Performs the in-projection step of the attention operation. This is simply
-    a triple of linear projections, with shape constraints on the weights which
+    Perform the in-projection step of the attention operation.
+    
+    This is simply a triple of linear projections,
+    with shape constraints on the weights which
     ensure embedding dimension uniformity in the projected outputs.
     Output is a triple containing projection tensors for query, key and value.
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1281,10 +1281,10 @@ def alpha_dropout(input: Tensor, p: float = 0.5, training: bool = False, inplace
 
 
 def dropout1d(input: Tensor, p: float = 0.5, training: bool = True, inplace: bool = False) -> Tensor:
-    r"""Randomly zero out entire channels a channel is a 1D feature map.
+    r"""Randomly zero out entire channels (a channel is a 1D feature map).
     
     For example, the :math:`j`-th channel of the :math:`i`-th sample in the
-    batched input is a 1D tensor :math:`\text{input}[i, j]`) of the input tensor).
+    batched input is a 1D tensor :math:`\text{input}[i, j]` of the input tensor.
     Each channel will be zeroed out independently on every forward call with
     probability :attr:`p` using samples from a Bernoulli distribution.
 
@@ -1319,10 +1319,10 @@ def dropout1d(input: Tensor, p: float = 0.5, training: bool = True, inplace: boo
 
 
 def dropout2d(input: Tensor, p: float = 0.5, training: bool = True, inplace: bool = False) -> Tensor:
-    r"""Randomly zero out entire channels a channel is a 2D feature map.
+    r"""Randomly zero out entire channels (a channel is a 2D feature map).
     
     For example, the :math:`j`-th channel of the :math:`i`-th sample in the
-    batched input is a 2D tensor :math:`\text{input}[i, j]`) of the input tensor).
+    batched input is a 2D tensor :math:`\text{input}[i, j]` of the input tensor.
     Each channel will be zeroed out independently on every forward call with
     probability :attr:`p` using samples from a Bernoulli distribution.
 
@@ -1363,10 +1363,10 @@ def dropout2d(input: Tensor, p: float = 0.5, training: bool = True, inplace: boo
 
 
 def dropout3d(input: Tensor, p: float = 0.5, training: bool = True, inplace: bool = False) -> Tensor:
-    r"""Randomly zero out entire channels (a channel is a 3D feature map.
+    r"""Randomly zero out entire channels (a channel is a 3D feature map).
     
-    E.g., the :math:`j`-th channel of the :math:`i`-th sample in the
-    batched input is a 3D tensor :math:`\text{input}[i, j]`) of the input tensor).
+    For example, the :math:`j`-th channel of the :math:`i`-th sample in the
+    batched input is a 3D tensor :math:`\text{input}[i, j]` of the input tensor.
     Each channel will be zeroed out independently on every forward call with
     probability :attr:`p` using samples from a Bernoulli distribution.
 
@@ -1402,10 +1402,10 @@ def dropout3d(input: Tensor, p: float = 0.5, training: bool = True, inplace: boo
 
 
 def feature_alpha_dropout(input: Tensor, p: float = 0.5, training: bool = False, inplace: bool = False) -> Tensor:
-    r"""Randomly masks out entire channels (a channel is a feature map.
+    r"""Randomly masks out entire channels (a channel is a feature map).
     
-    E.g. the :math:`j`-th channel of the :math:`i`-th sample in the batch input
-    is a tensor :math:`\text{input}[i, j]`) of the input tensor). Instead of
+    For example, the :math:`j`-th channel of the :math:`i`-th sample in the batch input
+    is a tensor :math:`\text{input}[i, j]` of the input tensor. Instead of
     setting activations to zero, as in regular Dropout, the activations are set
     to the negative saturation value of the SELU activation function.
 
@@ -1431,7 +1431,7 @@ def feature_alpha_dropout(input: Tensor, p: float = 0.5, training: bool = False,
 
 
 def _threshold(input: Tensor, threshold: float, value: float, inplace: bool = False) -> Tensor:
-    r"""Threshold each element of the input Tensor.
+    r"""Apply a threshold to each element of the input Tensor.
 
     See :class:`~torch.nn.Threshold` for more details.
     """
@@ -1602,12 +1602,9 @@ In-place version of :func:`~selu`.
 
 def celu(input: Tensor, alpha: float = 1.0, inplace: bool = False) -> Tensor:
     r"""Apply CELU, a continously differentiable ELU.
-
+    
     Applies element-wise,
     :math:`\text{CELU}(x) = \max(0,x) + \min(0, \alpha * (\exp(x/\alpha) - 1))`.
-
-    Refer paper for further information:
-    `Continuously Differentiable Exponential Linear Units`_.
     
     See :class:`~torch.nn.CELU` for more details.
     """
@@ -1744,7 +1741,7 @@ See :class:`~torch.nn.Hardshrink` for more details.
 
 
 def tanhshrink(input):
-    r"""Apply the following function element-wise.
+    r"""Apply the TanhShrink function element-wise.
 
     Function :math:`\text{Tanhshrink}(x) = x - \text{Tanh}(x)`
 
@@ -1756,7 +1753,7 @@ def tanhshrink(input):
 
 
 def softsign(input):
-    r"""Apply the following function element-wise.
+    r"""Apply the SoftSign function element-wise.
 
     Function :math:`\text{SoftSign}(x) = \frac{x}{1 + |x|}`
 
@@ -1858,7 +1855,7 @@ def softmax(input: Tensor, dim: Optional[int] = None, _stacklevel: int = 3, dtyp
 
 def gumbel_softmax(logits: Tensor, tau: float = 1, hard: bool = False, eps: float = 1e-10, dim: int = -1) -> Tensor:
     r"""
-    Sample from the Gumbel-Softmax distribution (`Link 1`_  `Link 2`_) and optionally discretizes.
+    Sample from the Gumbel-Softmax distribution (`Link 1`_  `Link 2`_) and optionally discretize.
 
     Args:
       logits: `[..., num_features]` unnormalized log probabilities
@@ -1960,8 +1957,7 @@ See :class:`~torch.nn.Softshrink` for more details.
 def tanh(input):
     r"""Apply hyperbolic tangent (tanh) function element-wise.
     
-    tanh defined as - 
-    :math:`\text{Tanh}(x) = \tanh(x) = \frac{\exp(x) - \exp(-x)}{\exp(x) + \exp(-x)}`
+     Applies :math:`\text{Tanh}(x) = \tanh(x) = \frac{\exp(x) - \exp(-x)}{\exp(x) + \exp(-x)}`
 
     See :class:`~torch.nn.Tanh` for more details.
     """
@@ -2128,7 +2124,7 @@ def embedding(
     scale_grad_by_freq: bool = False,
     sparse: bool = False,
 ) -> Tensor:
-    r"""Lookup table that looks up embeddings in a fixed dictionary and size.
+    r"""Generate a simple lookup table that looks up embeddings in a fixed dictionary and size.
 
     This module is often used to retrieve word embeddings using indices.
     The input to the module is a list of indices, and the embedding matrix,
@@ -2559,7 +2555,7 @@ def group_norm(
 def local_response_norm(input: Tensor, size: int, alpha: float = 1e-4, beta: float = 0.75, k: float = 1.0) -> Tensor:
     r"""Apply local response normalization over an input signal.
     
-    Input ignal is composed of several input planes, where channels occupy the second dimension.
+    Input signal is composed of several input planes, where channels occupy the second dimension.
     Normalization is applied across channels.
 
     See :class:`~torch.nn.LocalResponseNorm` for details.
@@ -3062,7 +3058,7 @@ def binary_cross_entropy(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""Calculate Binary Cross Entropy between the target and input probabilities.
+    r"""Measure Binary Cross Entropy between the target and input probabilities.
 
     See :class:`~torch.nn.BCELoss` for details.
 
@@ -4804,8 +4800,7 @@ def _in_projection_packed(
     w: Tensor,
     b: Optional[Tensor] = None,
 ) -> List[Tensor]:
-    r"""
-    Perform the in-projection step of the attention operation, using packed weights.
+    r"""Perform the in-projection step of the attention operation, using packed weights.
     
     Output is a triple containing projection tensors for query, key and value.
 
@@ -4872,8 +4867,7 @@ def _in_projection(
     b_k: Optional[Tensor] = None,
     b_v: Optional[Tensor] = None,
 ) -> Tuple[Tensor, Tensor, Tensor]:
-    r"""
-    Perform the in-projection step of the attention operation.
+    r"""Perform the in-projection step of the attention operation.
     
     This is simply a triple of linear projections,
     with shape constraints on the weights which
@@ -4985,7 +4979,6 @@ Note:
     {cudnn_reproducibility_note}
 """.format(**reproducibility_notes)
     + r"""
-
 Args:
     query (Tensor): Query tensor; shape :math:`(N, ..., L, E)`.
     key (Tensor): Key tensor; shape :math:`(N, ..., S, E)`.
@@ -5135,8 +5128,7 @@ def multi_head_attention_forward(
     average_attn_weights: bool = True,
     is_causal: bool = False,
 ) -> Tuple[Tensor, Optional[Tensor]]:
-    r"""
-    Foward method for MultiHeadAttention.
+    r"""Foward method for MultiHeadAttention.
     
     See :class:`torch.nn.MultiheadAttention` for details.
     

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1281,7 +1281,7 @@ def alpha_dropout(input: Tensor, p: float = 0.5, training: bool = False, inplace
 
 
 def dropout1d(input: Tensor, p: float = 0.5, training: bool = True, inplace: bool = False) -> Tensor:
-    r"""Randomly zero out entire channels (a channel is a 1D feature map.
+    r"""Randomly zero out entire channels a channel is a 1D feature map.
     
     E.g., the :math:`j`-th channel of the :math:`i`-th sample in the
     batched input is a 1D tensor :math:`\text{input}[i, j]`) of the input tensor).

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1319,7 +1319,7 @@ def dropout1d(input: Tensor, p: float = 0.5, training: bool = True, inplace: boo
 
 
 def dropout2d(input: Tensor, p: float = 0.5, training: bool = True, inplace: bool = False) -> Tensor:
-    r"""Randomly zero out entire channels (a channel is a 2D feature map.
+    r"""Randomly zero out entire channels a channel is a 2D feature map.
     
     E.g., the :math:`j`-th channel of the :math:`i`-th sample in the
     batched input is a 2D tensor :math:`\text{input}[i, j]`) of the input tensor).

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1487,7 +1487,6 @@ In-place version of :func:`~relu`.
 def glu(input: Tensor, dim: int = -1) -> Tensor:
     r"""Apply the gated linear unit function.
     
-
     Computes:
     .. math ::
         \text{GLU}(a, b) = a \otimes \sigma(b)
@@ -2247,9 +2246,9 @@ def embedding_bag(
     include_last_offset: bool = False,
     padding_idx: Optional[int] = None,
 ) -> Tensor:
-    r"""Compute sums, means or maxes of `bags` of embeddings, without instantiating the
-    intermediate embeddings.
-
+    r"""Directly compute sums, means or maxes of `bags` of embeddings.
+    
+    Calculation done without instantiating the intermediate embeddings.
     See :class:`torch.nn.EmbeddingBag` for more details.
 
     Note:
@@ -3204,7 +3203,9 @@ def smooth_l1_loss(
     reduction: str = "mean",
     beta: float = 1.0,
 ) -> Tensor:
-    r"""Function that uses a squared term if the absolute
+    r"""Calculate Smooth L1 loss.
+    
+    Function uses a squared term if the absolute
     element-wise error falls below beta and an L1 term otherwise.
 
     See :class:`~torch.nn.SmoothL1Loss` for details.
@@ -3244,9 +3245,14 @@ def huber_loss(
     reduction: str = 'mean',
     delta: float = 1.0,
 ) -> Tensor:
-    r"""Function that uses a squared term if the absolute
+    r"""Calculate Huber loss.
+    
+    Function uses a squared term if the absolute
     element-wise error falls below delta and a delta-scaled L1 term otherwise.
-
+    
+    When delta equals 1, this loss is equivalent to SmoothL1Loss. 
+    In general, Huber loss differs from SmoothL1Loss by a factor of delta (AKA beta in Smooth L1).
+    
     See :class:`~torch.nn.HuberLoss` for details.
     """
     if has_torch_function_variadic(input, target):
@@ -3275,9 +3281,7 @@ def l1_loss(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""l1_loss(input, target, size_average=None, reduce=None, reduction='mean') -> Tensor
-
-    Function that takes the mean element-wise absolute value difference.
+    r"""Calculate the mean element-wise absolute value difference.
 
     See :class:`~torch.nn.L1Loss` for details.
     """
@@ -3306,9 +3310,7 @@ def mse_loss(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""mse_loss(input, target, size_average=None, reduce=None, reduction='mean') -> Tensor
-
-    Measures the element-wise mean squared error.
+    r"""Measure the element-wise mean squared error.
 
     See :class:`~torch.nn.MSELoss` for details.
     """
@@ -3339,10 +3341,7 @@ def margin_ranking_loss(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""margin_ranking_loss(input1, input2, target, margin=0, size_average=None, reduce=None, reduction='mean') -> Tensor
-
-    See :class:`~torch.nn.MarginRankingLoss` for details.
-    """
+    r"""See :class:`~torch.nn.MarginRankingLoss` for details."""
     if has_torch_function_variadic(input1, input2, target):
         return handle_torch_function(
             margin_ranking_loss,
@@ -3375,7 +3374,11 @@ def hinge_embedding_loss(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""hinge_embedding_loss(input, target, margin=1.0, size_average=None, reduce=None, reduction='mean') -> Tensor
+    r"""Measure the loss given an input tensor x and a labels tensor y (containing 1 or -1).
+
+    Usually used for measuring whether two inputs are similar or dissimilar, 
+    e.g. using the L1 pairwise distance as x, 
+    and is typically used for learning nonlinear embeddings or semi-supervised learning.
 
     See :class:`~torch.nn.HingeEmbeddingLoss` for details.
     """
@@ -3404,10 +3407,7 @@ def multilabel_margin_loss(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""multilabel_margin_loss(input, target, size_average=None, reduce=None, reduction='mean') -> Tensor
-
-    See :class:`~torch.nn.MultiLabelMarginLoss` for details.
-    """
+    r"""See :class:`~torch.nn.MultiLabelMarginLoss` for details."""
     if has_torch_function_variadic(input, target):
         return handle_torch_function(
             multilabel_margin_loss,
@@ -3433,11 +3433,8 @@ def soft_margin_loss(
     reduction: str = "mean",
 ) -> Tensor:
     r"""
-    Creates a criterion that optimizes a two-class classification logistic loss between input tensor 
-x and target tensor 
-y (containing 1 or -1).
-    soft_margin_loss(input, target, size_average=None, reduce=None, reduction='mean') -> Tensor
-
+    Optimize a two-class classification logistic loss between input tensor x and target tensor y (containing 1 or -1).
+    
     See :class:`~torch.nn.SoftMarginLoss` for details.
     """
     if has_torch_function_variadic(input, target):
@@ -3459,7 +3456,9 @@ def multilabel_soft_margin_loss(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""multilabel_soft_margin_loss(input, target, weight=None, size_average=None, reduce=None, reduction='mean') -> Tensor
+    r"""Optimize a multi-label one-versus-all loss based on max-entropy.
+
+    Creates a criterion between input x and target y of size (N,C) for optimisation.
 
     See :class:`~torch.nn.MultiLabelSoftMarginLoss` for details.
     """
@@ -3507,7 +3506,12 @@ def cosine_embedding_loss(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""cosine_embedding_loss(input1, input2, target, margin=0, size_average=None, reduce=None, reduction='mean').
+    r"""Calculate Cosine Embedding loss.
+    
+    Creates a criterion that measures the loss given input tensors x1,x2
+    and a Tensor label y with values 1 or -1. 
+    Used for measuring whether two inputs are similar or dissimilar, using the cosine similarity, 
+    and is typically used for learning nonlinear embeddings or semi-supervised learning.
 
     See :class:`~torch.nn.CosineEmbeddingLoss` for details.
     """
@@ -3540,10 +3544,7 @@ def multi_margin_loss(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""multi_margin_loss(input, target, p=1, margin=1, weight=None, size_average=None, reduce=None, reduction='mean') -> Tensor
-
-    See :class:`~torch.nn.MultiMarginLoss` for details.
-    """
+    r"""See :class:`~torch.nn.MultiMarginLoss` for details."""
     if has_torch_function_variadic(input, target, weight):
         return handle_torch_function(
             multi_margin_loss,
@@ -3821,7 +3822,7 @@ def interpolate(  # noqa: F811
     pass
 
 def interpolate(input: Tensor, size: Optional[int] = None, scale_factor: Optional[List[float]] = None, mode: str = 'nearest', align_corners: Optional[bool] = None, recompute_scale_factor: Optional[bool] = None, antialias: bool = False) -> Tensor:  # noqa: F811,B950
-    r"""Down/up samples the input. 
+    r"""Down/up samples the input.
     
     Tensor interpolated to either the given :attr:`size` or the given
     :attr:`scale_factor`
@@ -4176,7 +4177,7 @@ def grid_sample(
     padding_mode: str = "zeros",
     align_corners: Optional[bool] = None,
 ) -> Tensor:
-    r"""grid_sample(input, grid, mode, padding_mode, align_corners).
+    r"""Compute grid sample.
     
     Given an :attr:`input` and a flow-field :attr:`grid`, computes the
     ``output`` using :attr:`input` values and pixel locations from :attr:`grid`.
@@ -4611,8 +4612,9 @@ def triplet_margin_loss(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""
-    See :class:`~torch.nn.TripletMarginLoss` for details
+    r"""Measure triplet loss between given input tensors and a margin greater than 0.
+    
+    See :class:`~torch.nn.TripletMarginLoss` for details.
     """
     if has_torch_function_variadic(anchor, positive, negative):
         return handle_torch_function(
@@ -4646,7 +4648,8 @@ def triplet_margin_with_distance_loss(
     swap: bool = False,
     reduction: str = "mean"
 ) -> Tensor:
-    r"""
+    r"""Compute the triplet margin loss for input tensors using a custom distance function.
+    
     See :class:`~torch.nn.TripletMarginWithDistanceLoss` for details.
     """
     if torch.jit.is_scripting():
@@ -4776,9 +4779,8 @@ def fold(
     padding: BroadcastingList2[int] = 0,
     stride: BroadcastingList2[int] = 1
 ) -> Tensor:
-    r"""
-    Combine an array of sliding local blocks into a large containing tensor.
-
+    r"""Combine an array of sliding local blocks into a large containing tensor.
+    
     .. warning::
         Currently, only unbatched (3D) or batched (4D) image-like output tensors are supported.
 
@@ -5135,6 +5137,10 @@ def multi_head_attention_forward(
     is_causal: bool = False,
 ) -> Tuple[Tensor, Optional[Tensor]]:
     r"""
+    Foward method for MultiHeadAttention.
+    
+    See :class:`torch.nn.MultiheadAttention` for details.
+    
     Args:
         query, key, value: map a query and a set of key-value pairs to an output.
             See "Attention Is All You Need" for more details.

--- a/torch/optim/__init__.py
+++ b/torch/optim/__init__.py
@@ -1,5 +1,6 @@
 """
 :mod:`torch.optim` is a package implementing various optimization algorithms.
+
 Most commonly used methods are already supported, and the interface is general
 enough, so that more sophisticated ones can also be easily integrated in the
 future.

--- a/torch/optim/_functional.py
+++ b/torch/optim/_functional.py
@@ -1,4 +1,4 @@
-r"""Functional interface"""
+r"""Functional interface."""
 import math
 from torch import Tensor
 from typing import List

--- a/torch/optim/adadelta.py
+++ b/torch/optim/adadelta.py
@@ -79,7 +79,7 @@ class Adadelta(Optimizer):
 
     @_use_grad_for_differentiable
     def step(self, closure=None):
-        """Performs a single optimization step.
+        """Perform a single optimization step.
 
         Args:
             closure (Callable, optional): A closure that reevaluates the model
@@ -194,7 +194,6 @@ def adadelta(
 
     See :class:`~torch.optim.Adadelta` for details.
     """
-
     # We still respect when the user inputs False for foreach.
     if foreach is None:
         _, foreach = _default_to_fused_or_foreach(params, differentiable, use_fused=False)

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -97,7 +97,7 @@ class Adagrad(Optimizer):
 
     @_use_grad_for_differentiable
     def step(self, closure=None):
-        """Performs a single optimization step.
+        """Perform a single optimization step.
 
         Args:
             closure (Callable, optional): A closure that reevaluates the model
@@ -202,7 +202,6 @@ def adagrad(
 
     See :class:`~torch.optim.Adagrad` for details.
     """
-
     if not all(isinstance(t, torch.Tensor) for t in state_steps):
         raise RuntimeError(
             "API has changed, `state_steps` argument must contain a list of singleton tensors"

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -279,7 +279,7 @@ def adam(params: List[Tensor],
          eps: float,
          maximize: bool):
     r"""Functional API that performs Adam algorithm computation.
-    
+  
     See :class:`~torch.optim.Adam` for details.
     """
     # Respect when the user inputs False/True for foreach or fused. We only want to change

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -132,7 +132,7 @@ class Adam(Optimizer):
 
     @_use_grad_for_differentiable
     def step(self, closure=None):
-        """Performs a single optimization step.
+        """Perform a single optimization step.
 
         Args:
             closure (Callable, optional): A closure that reevaluates the model
@@ -279,9 +279,9 @@ def adam(params: List[Tensor],
          eps: float,
          maximize: bool):
     r"""Functional API that performs Adam algorithm computation.
+    
     See :class:`~torch.optim.Adam` for details.
     """
-
     # Respect when the user inputs False/True for foreach or fused. We only want to change
     # the default when neither have been user-specified. Note that we default to foreach
     # and pass False to use_fused. This is not a mistake--we want to give the fused impl

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -279,7 +279,7 @@ def adam(params: List[Tensor],
          eps: float,
          maximize: bool):
     r"""Functional API that performs Adam algorithm computation.
-  
+
     See :class:`~torch.optim.Adam` for details.
     """
     # Respect when the user inputs False/True for foreach or fused. We only want to change

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -88,7 +88,7 @@ class Adamax(Optimizer):
 
     @_use_grad_for_differentiable
     def step(self, closure=None):
-        """Performs a single optimization step.
+        """Perform a single optimization step.
 
         Args:
             closure (Callable, optional): A closure that reevaluates the model
@@ -204,7 +204,6 @@ def adamax(
 
     See :class:`~torch.optim.Adamax` for details.
     """
-
     if not all(isinstance(t, torch.Tensor) for t in state_steps):
         raise RuntimeError(
             "API has changed, `state_steps` argument must contain a list of singleton tensors"

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -150,7 +150,7 @@ class AdamW(Optimizer):
 
     @_use_grad_for_differentiable
     def step(self, closure=None):
-        """Performs a single optimization step.
+        """Perform a single optimization step.
 
         Args:
             closure (Callable, optional): A closure that reevaluates the model
@@ -305,7 +305,6 @@ def adamw(
 
     See :class:`~torch.optim.AdamW` for details.
     """
-
     if not torch._utils.is_compiling() and not all(isinstance(t, torch.Tensor) for t in state_steps):
         raise RuntimeError(
             "API has changed, `state_steps` argument must contain a list of singleton tensors"

--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -104,7 +104,7 @@ class ASGD(Optimizer):
 
     @_use_grad_for_differentiable
     def step(self, closure=None):
-        """Performs a single optimization step.
+        """Perform a single optimization step.
 
         Args:
             closure (Callable, optional): A closure that reevaluates the model
@@ -196,7 +196,6 @@ def asgd(
 
     See :class:`~torch.optim.ASGD` for details.
     """
-
     if foreach is None:
         _, foreach = _default_to_fused_or_foreach(params, differentiable, use_fused=False)
 

--- a/torch/optim/lbfgs.py
+++ b/torch/optim/lbfgs.py
@@ -182,8 +182,10 @@ def _strong_wolfe(obj_func,
 
 
 class LBFGS(Optimizer):
-    """Implements L-BFGS algorithm, heavily inspired by `minFunc
-    <https://www.cs.ubc.ca/~schmidtm/Software/minFunc.html>`_.
+    """Implements L-BFGS algorithm.
+    
+    Heavily inspired by
+    `minFunc<https://www.cs.ubc.ca/~schmidtm/Software/minFunc.html>`_.
 
     .. warning::
         This optimizer doesn't support per-parameter options and parameter
@@ -282,7 +284,7 @@ class LBFGS(Optimizer):
 
     @torch.no_grad()
     def step(self, closure):
-        """Performs a single optimization step.
+        """Perform a single optimization step.
 
         Args:
             closure (Callable): A closure that reevaluates the model

--- a/torch/optim/lbfgs.py
+++ b/torch/optim/lbfgs.py
@@ -183,7 +183,7 @@ def _strong_wolfe(obj_func,
 
 class LBFGS(Optimizer):
     """Implements L-BFGS algorithm.
-    
+
     Heavily inspired by
     `minFunc<https://www.cs.ubc.ca/~schmidtm/Software/minFunc.html>`_.
 

--- a/torch/optim/lbfgs.py
+++ b/torch/optim/lbfgs.py
@@ -184,8 +184,8 @@ def _strong_wolfe(obj_func,
 class LBFGS(Optimizer):
     """Implements L-BFGS algorithm.
 
-    Heavily inspired by
-    `minFunc<https://www.cs.ubc.ca/~schmidtm/Software/minFunc.html>`_.
+    Heavily inspired by `minFunc
+    <https://www.cs.ubc.ca/~schmidtm/Software/minFunc.html>`_.
 
     .. warning::
         This optimizer doesn't support per-parameter options and parameter

--- a/torch/optim/sparse_adam.py
+++ b/torch/optim/sparse_adam.py
@@ -37,7 +37,7 @@ class SparseAdam(Optimizer):
 
     @torch.no_grad()
     def step(self, closure=None):
-        """Performs a single optimization step.
+        """Perform a single optimization step.
 
         Args:
             closure (Callable, optional): A closure that reevaluates the model


### PR DESCRIPTION
Fixes #112592 
1) **File: torch/cuda/random.py**
```
Before:
/content/pytorch/torch/cuda/random.py:1 at module level:
        D100: Missing docstring in public module
/content/pytorch/torch/cuda/random.py:21 in public function `get_rng_state`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
/content/pytorch/torch/cuda/random.py:43 in public function `get_rng_state_all`:
        D202: No blank lines allowed after function docstring (found 1)
/content/pytorch/torch/cuda/random.py:43 in public function `get_rng_state_all`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
/content/pytorch/torch/cuda/random.py:54 in public function `set_rng_state`:
        D401: First line should be in imperative mood (perhaps 'Set', not 'Sets')
/content/pytorch/torch/cuda/random.py:79 in public function `set_rng_state_all`:
        D208: Docstring is over-indented
/content/pytorch/torch/cuda/random.py:79 in public function `set_rng_state_all`:
        D209: Multi-line docstring closing quotes should be on a separate line
/content/pytorch/torch/cuda/random.py:79 in public function `set_rng_state_all`:
        D401: First line should be in imperative mood (perhaps 'Set', not 'Sets')
/content/pytorch/torch/cuda/random.py:79 in public function `set_rng_state_all`:
        D414: Section has no content ('Args')
/content/pytorch/torch/cuda/random.py:88 in public function `manual_seed`:
        D205: 1 blank line required between summary line and description (found 0)
/content/pytorch/torch/cuda/random.py:88 in public function `manual_seed`:
        D401: First line should be in imperative mood (perhaps 'Set', not 'Sets')
/content/pytorch/torch/cuda/random.py:110 in public function `manual_seed_all`:
        D205: 1 blank line required between summary line and description (found 0)
/content/pytorch/torch/cuda/random.py:110 in public function `manual_seed_all`:
        D401: First line should be in imperative mood (perhaps 'Set', not 'Sets')
/content/pytorch/torch/cuda/random.py:128 in public function `seed`:
        D205: 1 blank line required between summary line and description (found 0)
/content/pytorch/torch/cuda/random.py:128 in public function `seed`:
        D401: First line should be in imperative mood (perhaps 'Set', not 'Sets')
/content/pytorch/torch/cuda/random.py:146 in public function `seed_all`:
        D205: 1 blank line required between summary line and description (found 0)
/content/pytorch/torch/cuda/random.py:146 in public function `seed_all`:
        D401: First line should be in imperative mood (perhaps 'Set', not 'Sets')
/content/pytorch/torch/cuda/random.py:167 in public function `initial_seed`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
18
```

```
After:
/content/pytorch/torch/cuda/random.py:1 at module level:
        D100: Missing docstring in public module
1

```
2) **File: torch/cuda/amp/autocast_mode.py**
```
Before: /content/pytorch/torch/cuda/amp/autocast_mode.py:1 at module level:
        D100: Missing docstring in public module
/content/pytorch/torch/cuda/amp/autocast_mode.py:18 in public class `autocast`:
        D205: 1 blank line required between summary line and description (found 0)
/content/pytorch/torch/cuda/amp/autocast_mode.py:23 in public method `__init__`:
        D107: Missing docstring in __init__
/content/pytorch/torch/cuda/amp/autocast_mode.py:38 in public method `__enter__`:
        D105: Missing docstring in magic method
/content/pytorch/torch/cuda/amp/autocast_mode.py:44 in public method `__exit__`:
        D105: Missing docstring in magic method
/content/pytorch/torch/cuda/amp/autocast_mode.py:49 in public method `__call__`:
        D102: Missing docstring in public method
/content/pytorch/torch/cuda/amp/autocast_mode.py:90 in public function `custom_fwd`:
        D205: 1 blank line required between summary line and description (found 0)
/content/pytorch/torch/cuda/amp/autocast_mode.py:90 in public function `custom_fwd`:
        D400: First line should end with a period (not 'f')
/content/pytorch/torch/cuda/amp/autocast_mode.py:90 in public function `custom_fwd`:
        D401: First line should be in imperative mood; try rephrasing (found 'Helper')
/content/pytorch/torch/cuda/amp/autocast_mode.py:130 in public function `custom_bwd`:
        D205: 1 blank line required between summary line and description (found 0)
/content/pytorch/torch/cuda/amp/autocast_mode.py:130 in public function `custom_bwd`:
        D400: First line should end with a period (not 'f')
/content/pytorch/torch/cuda/amp/autocast_mode.py:130 in public function `custom_bwd`:
        D401: First line should be in imperative mood; try rephrasing (found 'Helper')
12
```
```
After:
/content/pytorch/torch/cuda/amp/autocast_mode.py:1 at module level:
        D100: Missing docstring in public module
/content/pytorch/torch/cuda/amp/autocast_mode.py:23 in public method `__init__`:
        D107: Missing docstring in __init__
/content/pytorch/torch/cuda/amp/autocast_mode.py:38 in public method `__enter__`:
        D105: Missing docstring in magic method
/content/pytorch/torch/cuda/amp/autocast_mode.py:44 in public method `__exit__`:
        D105: Missing docstring in magic method
/content/pytorch/torch/cuda/amp/autocast_mode.py:49 in public method `__call__`:
        D102: Missing docstring in public method
5
```

3)  **File: torch/cuda/amp/grad_scaler.py**
```
Before: /content/pytorch/torch/cuda/amp/grad_scaler.py:1 at module level:
        D100: Missing docstring in public module
/content/pytorch/torch/cuda/amp/grad_scaler.py:17 in private class `_MultiDeviceReplicator`:
        D200: One-line docstring should fit on one line with quotes (found 3)
/content/pytorch/torch/cuda/amp/grad_scaler.py:39 in public class `OptState`:
        D101: Missing docstring in public class
/content/pytorch/torch/cuda/amp/grad_scaler.py:50 in public class `GradScaler`:
        D205: 1 blank line required between summary line and description (found 0)
/content/pytorch/torch/cuda/amp/grad_scaler.py:50 in public class `GradScaler`:
        D400: First line should end with a period (not 'g')
/content/pytorch/torch/cuda/amp/grad_scaler.py:115 in public method `__init__`:
        D107: Missing docstring in __init__
/content/pytorch/torch/cuda/amp/grad_scaler.py:354 in public method `step`:
        D400: First line should end with a period (not ':')
/content/pytorch/torch/cuda/amp/grad_scaler.py:456 in public method `update`:
        D401: First line should be in imperative mood (perhaps 'Update', not 'Updates')
/content/pytorch/torch/cuda/amp/grad_scaler.py:529 in public method `get_scale`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
/content/pytorch/torch/cuda/amp/grad_scaler.py:544 in public method `get_growth_factor`:
        D200: One-line docstring should fit on one line with quotes (found 3)
/content/pytorch/torch/cuda/amp/grad_scaler.py:544 in public method `get_growth_factor`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
/content/pytorch/torch/cuda/amp/grad_scaler.py:550 in public method `set_growth_factor`:
        D205: 1 blank line required between summary line and description (found 0)
/content/pytorch/torch/cuda/amp/grad_scaler.py:550 in public method `set_growth_factor`:
        D400: First line should end with a period (not ':')
/content/pytorch/torch/cuda/amp/grad_scaler.py:557 in public method `get_backoff_factor`:
        D200: One-line docstring should fit on one line with quotes (found 3)
/content/pytorch/torch/cuda/amp/grad_scaler.py:557 in public method `get_backoff_factor`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
/content/pytorch/torch/cuda/amp/grad_scaler.py:563 in public method `set_backoff_factor`:
        D205: 1 blank line required between summary line and description (found 0)
/content/pytorch/torch/cuda/amp/grad_scaler.py:563 in public method `set_backoff_factor`:
        D400: First line should end with a period (not ':')
/content/pytorch/torch/cuda/amp/grad_scaler.py:570 in public method `get_growth_interval`:
        D200: One-line docstring should fit on one line with quotes (found 3)
/content/pytorch/torch/cuda/amp/grad_scaler.py:570 in public method `get_growth_interval`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
/content/pytorch/torch/cuda/amp/grad_scaler.py:576 in public method `set_growth_interval`:
        D205: 1 blank line required between summary line and description (found 0)
/content/pytorch/torch/cuda/amp/grad_scaler.py:576 in public method `set_growth_interval`:
        D400: First line should end with a period (not ':')
/content/pytorch/torch/cuda/amp/grad_scaler.py:592 in public method `is_enabled`:
        D200: One-line docstring should fit on one line with quotes (found 3)
/content/pytorch/torch/cuda/amp/grad_scaler.py:592 in public method `is_enabled`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
/content/pytorch/torch/cuda/amp/grad_scaler.py:598 in public method `state_dict`:
        D400: First line should end with a period (not ':')
/content/pytorch/torch/cuda/amp/grad_scaler.py:598 in public method `state_dict`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
/content/pytorch/torch/cuda/amp/grad_scaler.py:624 in public method `load_state_dict`:
        D401: First line should be in imperative mood (perhaps 'Load', not 'Loads')
/content/pytorch/torch/cuda/amp/grad_scaler.py:649 in public method `__getstate__`:
        D105: Missing docstring in magic method
/content/pytorch/torch/cuda/amp/grad_scaler.py:665 in public method `__setstate__`:
        D105: Missing docstring in magic method
28
```
```
After:
/content/pytorch/torch/cuda/amp/grad_scaler.py:1 at module level:
        D100: Missing docstring in public module
/content/pytorch/torch/cuda/amp/grad_scaler.py:40 in public class `OptState`:
        D101: Missing docstring in public class
/content/pytorch/torch/cuda/amp/grad_scaler.py:117 in public method `__init__`:
        D107: Missing docstring in __init__
/content/pytorch/torch/cuda/amp/grad_scaler.py:647 in public method `__getstate__`:
        D105: Missing docstring in magic method
/content/pytorch/torch/cuda/amp/grad_scaler.py:663 in public method `__setstate__`:
        D105: Missing docstring in magic method
5
```
4) **File: torch/optim/_functional.py**
```
Before:
/content/pytorch/torch/optim/_functional.py:1 at module level:
        D400: First line should end with a period (not 'e')
1
```
```
After:
0

```
5) **File: torch/optim/__init__.py**
```
Before:
/content/pytorch/torch/optim/__init__.py:1 at module level:
        D205: 1 blank line required between summary line and description (found 0)
1
```
```
After:
0

```
6) **File: torch/optim/lbfgs.py**
```
Before:
/content/pytorch/torch/optim/lbfgs.py:1 at module level:
        D100: Missing docstring in public module
/content/pytorch/torch/optim/lbfgs.py:185 in public class `LBFGS`:
        D205: 1 blank line required between summary line and description (found 0)
/content/pytorch/torch/optim/lbfgs.py:185 in public class `LBFGS`:
        D400: First line should end with a period (not 'c')
/content/pytorch/torch/optim/lbfgs.py:215 in public method `__init__`:
        D107: Missing docstring in __init__
/content/pytorch/torch/optim/lbfgs.py:285 in public method `step`:
        D401: First line should be in imperative mood (perhaps 'Perform', not 'Performs')
5
```
```
After:
/content/pytorch/torch/optim/lbfgs.py:1 at module level:
        D100: Missing docstring in public module
/content/pytorch/torch/optim/lbfgs.py:217 in public method `__init__`:
        D107: Missing docstring in __init__
2
```
7)**File: torch/optim/sparse_adam.py**
```
Before: /content/pytorch/torch/optim/sparse_adam.py:1 at module level:
        D100: Missing docstring in public module
/content/pytorch/torch/optim/sparse_adam.py:7 in public class `SparseAdam`:
        D101: Missing docstring in public class
/content/pytorch/torch/optim/sparse_adam.py:8 in public method `__init__`:
        D107: Missing docstring in __init__
/content/pytorch/torch/optim/sparse_adam.py:40 in public method `step`:
        D401: First line should be in imperative mood (perhaps 'Perform', not 'Performs')
4
```
```
After:
/content/pytorch/torch/optim/sparse_adam.py:1 at module level:
        D100: Missing docstring in public module
/content/pytorch/torch/optim/sparse_adam.py:7 in public class `SparseAdam`:
        D101: Missing docstring in public class
/content/pytorch/torch/optim/sparse_adam.py:8 in public method `__init__`:
        D107: Missing docstring in __init__
3
```
8) **File:torch/optim/adadelta.py**
```
Before:
/content/pytorch/torch/optim/adadelta.py:1 at module level:
        D100: Missing docstring in public module
/content/pytorch/torch/optim/adadelta.py:11 in public class `Adadelta`:
        D101: Missing docstring in public class
/content/pytorch/torch/optim/adadelta.py:12 in public method `__init__`:
        D107: Missing docstring in __init__
/content/pytorch/torch/optim/adadelta.py:44 in public method `__setstate__`:
        D105: Missing docstring in magic method
/content/pytorch/torch/optim/adadelta.py:82 in public method `step`:
        D401: First line should be in imperative mood (perhaps 'Perform', not 'Performs')
/content/pytorch/torch/optim/adadelta.py:193 in public function `adadelta`:
        D202: No blank lines allowed after function docstring (found 1)
6
```
```
After:
/content/pytorch/torch/optim/adadelta.py:1 at module level:
        D100: Missing docstring in public module
/content/pytorch/torch/optim/adadelta.py:11 in public class `Adadelta`:
        D101: Missing docstring in public class
/content/pytorch/torch/optim/adadelta.py:12 in public method `__init__`:
        D107: Missing docstring in __init__
/content/pytorch/torch/optim/adadelta.py:44 in public method `__setstate__`:
        D105: Missing docstring in magic method
4
```
9) **File: torch/optim/adagrad.py**
```
Before:
/content/pytorch/torch/optim/adagrad.py:1 at module level:
        D100: Missing docstring in public module
/content/pytorch/torch/optim/adagrad.py:11 in public class `Adagrad`:
        D101: Missing docstring in public class
/content/pytorch/torch/optim/adagrad.py:12 in public method `__init__`:
        D107: Missing docstring in __init__
/content/pytorch/torch/optim/adagrad.py:63 in public method `__setstate__`:
        D105: Missing docstring in magic method
/content/pytorch/torch/optim/adagrad.py:78 in public method `share_memory`:
        D102: Missing docstring in public method
/content/pytorch/torch/optim/adagrad.py:100 in public method `step`:
        D401: First line should be in imperative mood (perhaps 'Perform', not 'Performs')
/content/pytorch/torch/optim/adagrad.py:201 in public function `adagrad`:
        D202: No blank lines allowed after function docstring (found 1)
7
```
```
After:
/content/pytorch/torch/optim/adagrad.py:1 at module level:
        D100: Missing docstring in public module
/content/pytorch/torch/optim/adagrad.py:11 in public class `Adagrad`:
        D101: Missing docstring in public class
/content/pytorch/torch/optim/adagrad.py:12 in public method `__init__`:
        D107: Missing docstring in __init__
/content/pytorch/torch/optim/adagrad.py:63 in public method `__setstate__`:
        D105: Missing docstring in magic method
/content/pytorch/torch/optim/adagrad.py:78 in public method `share_memory`:
        D102: Missing docstring in public method
5
```
10) **File: torch/optim/adam.py**
```
Before:
/content/pytorch/torch/optim/adam.py:1 at module level:
        D100: Missing docstring in public module
/content/pytorch/torch/optim/adam.py:14 in public class `Adam`:
        D101: Missing docstring in public class
/content/pytorch/torch/optim/adam.py:15 in public method `__init__`:
        D107: Missing docstring in __init__
/content/pytorch/torch/optim/adam.py:65 in public method `__setstate__`:
        D105: Missing docstring in magic method
/content/pytorch/torch/optim/adam.py:135 in public method `step`:
        D401: First line should be in imperative mood (perhaps 'Perform', not 'Performs')
/content/pytorch/torch/optim/adam.py:281 in public function `adam`:
        D202: No blank lines allowed after function docstring (found 1)
/content/pytorch/torch/optim/adam.py:281 in public function `adam`:
        D205: 1 blank line required between summary line and description (found 0)
7
```
```
After:
/content/pytorch/torch/optim/adam.py:1 at module level:
        D100: Missing docstring in public module
/content/pytorch/torch/optim/adam.py:14 in public class `Adam`:
        D101: Missing docstring in public class
/content/pytorch/torch/optim/adam.py:15 in public method `__init__`:
        D107: Missing docstring in __init__
/content/pytorch/torch/optim/adam.py:65 in public method `__setstate__`:
        D105: Missing docstring in magic method
4

```
11) **File: torch/optim/adamax.py**
```
Before:
/content/pytorch/torch/optim/adamax.py:1 at module level:
        D100: Missing docstring in public module
/content/pytorch/torch/optim/adamax.py:12 in public class `Adamax`:
        D101: Missing docstring in public class
/content/pytorch/torch/optim/adamax.py:13 in public method `__init__`:
        D107: Missing docstring in __init__
/content/pytorch/torch/optim/adamax.py:47 in public method `__setstate__`:
        D105: Missing docstring in magic method
/content/pytorch/torch/optim/adamax.py:91 in public method `step`:
        D401: First line should be in imperative mood (perhaps 'Perform', not 'Performs')
/content/pytorch/torch/optim/adamax.py:203 in public function `adamax`:
        D202: No blank lines allowed after function docstring (found 1)
6
```
```
After:
/content/pytorch/torch/optim/adamax.py:1 at module level:
        D100: Missing docstring in public module
/content/pytorch/torch/optim/adamax.py:12 in public class `Adamax`:
        D101: Missing docstring in public class
/content/pytorch/torch/optim/adamax.py:13 in public method `__init__`:
        D107: Missing docstring in __init__
/content/pytorch/torch/optim/adamax.py:47 in public method `__setstate__`:
        D105: Missing docstring in magic method
4
```
12) **File: torch/optim/adamw.py**
```
Before:
/content/pytorch/torch/optim/adamw.py:1 at module level:
        D100: Missing docstring in public module
/content/pytorch/torch/optim/adamw.py:12 in public class `AdamW`:
        D101: Missing docstring in public class
/content/pytorch/torch/optim/adamw.py:13 in public method `__init__`:
        D107: Missing docstring in __init__
/content/pytorch/torch/optim/adamw.py:73 in public method `__setstate__`:
        D105: Missing docstring in magic method
/content/pytorch/torch/optim/adamw.py:153 in public method `step`:
        D401: First line should be in imperative mood (perhaps 'Perform', not 'Performs')
/content/pytorch/torch/optim/adamw.py:304 in public function `adamw`:
        D202: No blank lines allowed after function docstring (found 1)
6

```
```
After:
/content/pytorch/torch/optim/adamw.py:1 at module level:
        D100: Missing docstring in public module
/content/pytorch/torch/optim/adamw.py:12 in public class `AdamW`:
        D101: Missing docstring in public class
/content/pytorch/torch/optim/adamw.py:13 in public method `__init__`:
        D107: Missing docstring in __init__
/content/pytorch/torch/optim/adamw.py:73 in public method `__setstate__`:
        D105: Missing docstring in magic method
4

```
13) **File: torch/optim/asgd.py**
```
Before:
/content/pytorch/torch/optim/asgd.py:1 at module level:
        D100: Missing docstring in public module
/content/pytorch/torch/optim/asgd.py:17 in public class `ASGD`:
        D101: Missing docstring in public class
/content/pytorch/torch/optim/asgd.py:18 in public method `__init__`:
        D107: Missing docstring in __init__
/content/pytorch/torch/optim/asgd.py:52 in public method `__setstate__`:
        D105: Missing docstring in magic method
/content/pytorch/torch/optim/asgd.py:107 in public method `step`:
        D401: First line should be in imperative mood (perhaps 'Perform', not 'Performs')
/content/pytorch/torch/optim/asgd.py:195 in public function `asgd`:
        D202: No blank lines allowed after function docstring (found 1)
6
```
```
After:
/content/pytorch/torch/optim/asgd.py:1 at module level:
        D100: Missing docstring in public module
/content/pytorch/torch/optim/asgd.py:17 in public class `ASGD`:
        D101: Missing docstring in public class
/content/pytorch/torch/optim/asgd.py:18 in public method `__init__`:
        D107: Missing docstring in __init__
/content/pytorch/torch/optim/asgd.py:52 in public method `__setstate__`:
        D105: Missing docstring in magic method
4
```
Resolved docstring errors as listed. I initially changed in the main branch of forked repo which caused changes to appear in my PR to other issue. I have fixed that and hope this PR won't have any conflicts.
Kindly review @svekars @jbschlosser.
In case of any other issues please let me know. Thanks!





cc @svekars @carljparker