### PR TITLE
Update ruff to v0.1.4

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -2662,7 +2662,7 @@ init_command = [
     'python3',
     'tools/linter/adapters/pip_init.py',
     '--dry-run={{DRYRUN}}',
-    'ruff==0.1.1',
+    'ruff==0.1.4',
 ]
 is_formatter = true
 

--- a/tools/linter/adapters/ruff_linter.py
+++ b/tools/linter/adapters/ruff_linter.py
@@ -149,7 +149,7 @@ def add_default_options(parser: argparse.ArgumentParser) -> None:
 
 def explain_rule(code: str) -> str:
     proc = run_command(
-        ["ruff", "rule", "--format=json", code],
+        ["ruff", "rule", "--output-format=json", code],
         check=True,
     )
     rule = json.loads(str(proc.stdout, "utf-8").strip())


### PR DESCRIPTION
Updates ruff which fixes some bugs and updates an API to be used more consistently `rule now takes --output-format with the old argname deprecated`. A lot of rule bugfixes and autofixes have been added to the pydocstyle rules which will be useful for the docathon.