### PR TITLE
Support OptionalTensor type in Output

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -14440,7 +14440,7 @@
   variants: function
   tags: nondeterministic_seeded
 
-- func: _scaled_dot_product_flash_attention(Tensor query, Tensor key, Tensor value, float dropout_p=0.0, bool is_causal=False, bool return_debug_mask=False, *, float? scale=None) -> (Tensor output, Tensor logsumexp, Tensor cum_seq_q, Tensor cum_seq_k, SymInt max_q, SymInt max_k, Tensor philox_seed, Tensor philox_offset, Tensor debug_attn_mask)
+- func: _scaled_dot_product_flash_attention(Tensor query, Tensor key, Tensor value, float dropout_p=0.0, bool is_causal=False, bool return_debug_mask=False, *, float? scale=None) -> (Tensor output, Tensor logsumexp, Tensor? cum_seq_q, Tensor? cum_seq_k, SymInt max_q, SymInt max_k, Tensor philox_seed, Tensor philox_offset, Tensor debug_attn_mask)
   dispatch:
     CPU: _scaled_dot_product_flash_attention_cpu
     CUDA: _scaled_dot_product_flash_attention_cuda

--- a/aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cpp
+++ b/aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cpp
@@ -1,6 +1,7 @@
 #include <numeric>
 #include <algorithm>
 #include <type_traits>
+#include "c10/util/Optional.h"
 #include <c10/util/Exception.h>
 
 #include <ATen/ATen.h>
@@ -218,8 +219,8 @@ Tensor NestedTensor_to_padded_tensor_cuda(
 std::tuple<
     Tensor,
     Tensor,
-    Tensor,
-    Tensor,
+    c10::optional<Tensor>,
+    c10::optional<Tensor>,
     c10::SymInt,
     c10::SymInt,
     Tensor,

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -747,8 +747,8 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math(
 std::tuple<
     at::Tensor,
     at::Tensor,
-    at::Tensor,
-    at::Tensor,
+    c10::optional<at::Tensor>,
+    c10::optional<at::Tensor>,
     c10::SymInt,
     c10::SymInt,
     at::Tensor,

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -668,7 +668,7 @@ std::tuple<Tensor, Tensor> native_multi_head_attention_cuda(
   }
   return std::make_tuple(std::move(proj), std::move(qkt));
 }
-std::tuple<Tensor, Tensor, Tensor, Tensor, c10::SymInt, c10::SymInt, Tensor, Tensor, Tensor> _scaled_dot_product_flash_attention_cuda(
+std::tuple<Tensor, Tensor, c10::optional<Tensor>, c10::optional<Tensor>, c10::SymInt, c10::SymInt, Tensor, Tensor, Tensor> _scaled_dot_product_flash_attention_cuda(
     const Tensor& query,
     const Tensor& key,
     const Tensor& value,

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2770,7 +2770,7 @@
   output_differentiability: [True, False, False, False]
   query, key, value, attn_bias: _scaled_dot_product_efficient_attention_backward(grad, query, key, value, attn_bias, output, log_sumexp, philox_seed, philox_offset, dropout_p, grad_input_mask, is_causal, scale)
 
-- name: _scaled_dot_product_flash_attention(Tensor query, Tensor key, Tensor value, float dropout_p=0.0, bool is_causal=False, bool return_debug_mask=False, *, float? scale=None) -> (Tensor output, Tensor logsumexp, Tensor cum_seq_q, Tensor cum_seq_k, SymInt max_q, SymInt max_k, Tensor philox_seed, Tensor philox_offset, Tensor debug_attn_mask)
+- name: _scaled_dot_product_flash_attention(Tensor query, Tensor key, Tensor value, float dropout_p=0.0, bool is_causal=False, bool return_debug_mask=False, *, float? scale=None) -> (Tensor output, Tensor logsumexp, Tensor? cum_seq_q, Tensor? cum_seq_k, SymInt max_q, SymInt max_k, Tensor philox_seed, Tensor philox_offset, Tensor debug_attn_mask)
   output_differentiability: [True, False, False, False, False, False, False, False, False]
   query, key, value: _scaled_dot_product_flash_attention_backward_symint(grad, query, key, value, output, logsumexp, cum_seq_q, cum_seq_k, max_q, max_k, dropout_p, is_causal, philox_seed, philox_offset, scale)
 

--- a/torch/csrc/autograd/utils/wrap_outputs.h
+++ b/torch/csrc/autograd/utils/wrap_outputs.h
@@ -70,6 +70,14 @@ inline PyObject* wrap(at::Tensor tensor) {
   return THPVariable_Wrap(Variable(std::move(tensor)));
 }
 
+inline PyObject* wrap(c10::optional<at::Tensor> tensor) {
+  if (tensor.has_value()) {
+    return THPVariable_Wrap(Variable(std::move(tensor.value())));
+  } else {
+    Py_RETURN_NONE;
+  }
+}
+
 inline PyObject* wrap(const at::Scalar& scalar) {
   return wrap(scalar_to_tensor(scalar));
 }

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -269,12 +269,12 @@ AOTITorchError aoti_torch__scaled_dot_product_flash_attention(
     at::Tensor* ret1_tensor = new at::Tensor(std::move(r1));
     *ret1 = tensor_pointer_to_tensor_handle(ret1_tensor);
     // ret2 and ret3 may be null
-    if (ret2) {
-      at::Tensor* ret2_tensor = new at::Tensor(std::move(r2));
+    if (r2.has_value()) {
+      at::Tensor* ret2_tensor = new at::Tensor(std::move(r2.value()));
       *ret2 = tensor_pointer_to_tensor_handle(ret2_tensor);
     }
-    if (ret3) {
-      at::Tensor* ret3_tensor = new at::Tensor(std::move(r3));
+    if (r3.has_value()) {
+      at::Tensor* ret3_tensor = new at::Tensor(std::move(r3.value()));
       *ret3 = tensor_pointer_to_tensor_handle(ret3_tensor);
     }
     *ret4 = r4.expect_int();

--- a/torchgen/api/cpp.py
+++ b/torchgen/api/cpp.py
@@ -254,6 +254,10 @@ def returntype_type(t: Type, *, mutable: bool, symint: bool = False) -> CType:
         elem = returntype_type(t.elem, mutable=False)
         assert t.size is None, f"fixed size list returns not supported: {t}"
         return VectorCType(elem)
+    elif isinstance(t, OptionalType):
+        elem = returntype_type(t.elem, mutable=mutable)
+        if str(t.elem) == "Tensor":
+            return OptionalCType(elem)
 
     raise AssertionError(f"unrecognized return type {t}")
 

--- a/torchgen/api/python.py
+++ b/torchgen/api/python.py
@@ -1130,6 +1130,7 @@ SUPPORTED_RETURN_TYPES = {
     "::std::vector<at::Tensor>",
     # Needed for flash attention forw/backward
     "::std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor,c10::SymInt,c10::SymInt,at::Tensor,at::Tensor,at::Tensor>",
+    "::std::tuple<at::Tensor,at::Tensor,c10::optional<at::Tensor>,c10::optional<at::Tensor>,c10::SymInt,c10::SymInt,at::Tensor,at::Tensor,at::Tensor>",
     "at::Scalar",
     "bool",
     "int64_t",


### PR DESCRIPTION
Summary:
Support OptionalTensor type in operator output

See
https://docs.google.com/document/d/1k1IATCCbN0ai0bdMCIu3ZtevP6UTsAz3-7HKdlzwF-M/edit?usp=sharing

This is based on https://github.com/pytorch/pytorch/pull/112938 

Test Plan: OSS CI

Differential Revision: D51007214


