### PR TITLE
cholesky_solve_backward: speed up using output_mask

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2637,6 +2637,27 @@ class TestLinalg(TestCase):
             self.assertEqual(len(w), 1)
             self.assertTrue("An output with one or more elements was resized" in str(w[-1].message))
 
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @dtypes(torch.float, torch.double)
+    def test_cholesky_solve_backward(self, device, dtype):
+        from torch.testing._internal.common_utils import random_hermitian_pd_matrix
+
+        # A different code path runs depending on if we ask for the grad of A.
+        for requires_A_grad in (False, True):
+            b_dims = (5, 2)
+            A_dims = (5,)
+            upper = False
+
+            b = torch.randn(*b_dims, dtype=dtype, device=device, requires_grad=True)
+            A = random_hermitian_pd_matrix(*A_dims, dtype=dtype, device=device)
+            A.requires_grad = requires_A_grad
+            L = torch.linalg.cholesky(A, upper=upper)
+            (torch.cholesky_solve(b, L, upper=upper).sum()).backward()
+
+            expected_grad = torch.linalg.solve(A, torch.ones_like(b))
+            self.assertEqual(b.grad, expected_grad)
+
     @skipCUDAIfNoMagmaAndNoCusolver
     @skipCPUIfNoLapack
     @dtypes(*floating_and_complex_types())

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2643,15 +2643,14 @@ class TestLinalg(TestCase):
     def test_cholesky_solve_backward(self, device, dtype):
         b_dims = (5, 2)
         L_dims = (5, 5)
-        upper = False
 
         for test_L_grad in (False, True):
             b = torch.randn(*b_dims, dtype=dtype, device=device, requires_grad=True)
             L = torch.randn(*L_dims, dtype=dtype, device=device, requires_grad=test_L_grad)
             if test_L_grad:
-                torch.autograd.gradcheck(lambda b, L: torch.cholesky_solve(b, torch.tril(L), upper=upper), (b, L))
+                torch.autograd.gradcheck(lambda b, L: torch.cholesky_solve(b, torch.tril(L), upper=False), (b, L))
             else:
-                torch.autograd.gradcheck(lambda b: torch.cholesky_solve(b, L, upper=upper), (b,))
+                torch.autograd.gradcheck(lambda b: torch.cholesky_solve(b, L, upper=False), (b,))
 
     @skipCUDAIfNoMagmaAndNoCusolver
     @skipCPUIfNoLapack

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -402,7 +402,7 @@
   L: cholesky_jvp(self_t, L, upper)
 
 - name: cholesky_solve(Tensor self, Tensor input2, bool upper=False) -> Tensor
-  self, input2: cholesky_solve_backward(grad, self, input2, result, upper)
+  self, input2: cholesky_solve_backward(grad, self, input2, result, upper, grad_input_mask)
   result: cholesky_solve_jvp(result, input2_p, input2_t, self_t, upper)
 
 - name: cholesky_inverse(Tensor self, bool upper=False) -> Tensor

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -743,7 +743,8 @@ std::tuple<Tensor, Tensor> cholesky_solve_backward(
     const Tensor& self,
     const Tensor& input2,
     const Tensor& result,
-    const bool upper);
+    const bool upper,
+    std::array<bool, 2> output_mask);
 Tensor cholesky_solve_jvp(
     const Tensor& X,
     const Tensor& U,


### PR DESCRIPTION
Introduces a faster path for `cholesky_solve_backward` when the gradient with respect to the cholesky factor isn't required.

Adds test coverage in `test_linalg.py`.

# Example

## Setup

```py
import torch
torch.set_num_threads(1)
mat = torch.randn(500, 1000)
mat = mat @ mat.T
L = torch.linalg.cholesky(mat, upper=False)

rhs = torch.randn(500, 1)
rhs.requires_grad = True

sol = torch.cholesky_solve(rhs, L, upper=False).sum(dim=0)
```

## Before
```
%timeit torch.autograd.grad(sol, rhs, retain_graph=True)
2.61 ms ± 18.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

## After
```
%timeit torch.autograd.grad(sol, rhs, retain_graph=True)
109 µs ± 3.42 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```
