### PR TITLE
Fix docstring errors in __init__.py, _tensor_docs.py, _meta_registrations.py, _tensor.py

### DIFF
--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -1923,7 +1923,7 @@ def calc_conv_nd_return_shape(
 ):
     def _formula(ln: int, p: int, d: int, k: int, s: int) -> int:
         """
-        Formula to apply to calculate the length of some dimension of the output
+        Formula to apply to calculate the length of some dimension of the output.
 
         See: https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html
 

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1,4 +1,4 @@
-"""Adds docstrings to Tensor functions"""
+"""Adds docstrings to Tensor functions."""
 
 import torch._C
 from torch._C import _add_docstr as add_docstr


### PR DESCRIPTION
Fixes #112587

Hello @svekars and @carljparker,

I've come across some inconsistencies that I need your assistance with, relating to the pydocstyle counts we're seeing. Below are the counts I obtained when running the command:

```
pydocstyle __init__.py --count 
144

pydocstyle _tensor_docs.py --count
2

pydocstyle _meta_registrations.py --count
236

pydocstyle _tensor.py --count
59
```

These numbers differ significantly from those @svekars reported in the original post for issue #112587:

```
pydocstyle __init__.py --count 
66

pydocstyle _tensor_docs.py --count
1

pydocstyle _meta_registrations.py --count
5

pydocstyle _tensor.py --count
27
```

Could you shed some light on what might be causing these discrepancies? Your insights would be greatly appreciated.

cc @svekars @brycebortree @carljparker