### PR TITLE
[BE] Use static local variable instead of `call_once`

### DIFF
--- a/c10/cuda/driver_api.cpp
+++ b/c10/cuda/driver_api.cpp
@@ -33,11 +33,8 @@ DriverAPI create_driver_api() {
 } // namespace
 
 void* DriverAPI::get_nvml_handle() {
-  static c10::once_flag once;
-  static void* handle_1;
-  c10::call_once(
-      once, [] { handle_1 = dlopen("libnvidia-ml.so.1", RTLD_LAZY); });
-  return handle_1;
+  static void* nvml_hanle = dlopen("libnvidia-ml.so.1", RTLD_LAZY);
+  return nvml_hanle;
 }
 
 DriverAPI* DriverAPI::get() {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #112996
* #112995
* __->__ #112994

See https://en.cppreference.com/w/cpp/language/storage_duration#Static_local_variables

And also, it's weird to mix two paradigms together, as static local variable is used to initialize `DriverAPI::get()` singleton mere 3 lines below