### PR TITLE
`c10::DriverAPI` Try opening libcuda.so.1

### DIFF
--- a/c10/cuda/driver_api.cpp
+++ b/c10/cuda/driver_api.cpp
@@ -10,8 +10,8 @@ namespace cuda {
 namespace {
 
 DriverAPI create_driver_api() {
-  void* handle_0 = dlopen("libcuda.so", RTLD_LAZY | RTLD_NOLOAD);
-  TORCH_INTERNAL_ASSERT(handle_0, "Can't open libcuda.so: ", dlerror());
+  void* handle_0 = dlopen("libcuda.so.1", RTLD_LAZY | RTLD_NOLOAD);
+  TORCH_CHECK(handle_0, "Can't open libcuda.so.1: ", dlerror());
   void* handle_1 = DriverAPI::get_nvml_handle();
   DriverAPI r{};
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #112996
* #112995
* #112994

As `libcuda.so` is only installed on dev environment (i.e. when CUDAToolkit is installed), while `libcuda.so.1` is part of NVIDIA driver.
Also, this will keep it aligned with https://github.com/pytorch/pytorch/blob/a5cb8f75a7f991212fbc6d049e0bc2f9f48b07f8/aten/src/ATen/cuda/detail/LazyNVRTC.cpp#L16

Also, change `TORCH_INTERNAL_ASSERT` to `TORCH_CHECK` as one can legitimate fail to open one, if driver could not be found.

Fixes https://github.com/pytorch/pytorch/issues/112957