### PR TITLE
[dynamo] use APIs to use device interface instead of raw object in dynamo capture

### DIFF
--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -42,7 +42,7 @@ from ..allowed_functions import (
     is_user_defined_allowed,
 )
 
-from ..device_interface import device_interfaces
+from ..device_interface import get_registered_device_interfaces
 from ..exc import InternalTorchDynamoError, unimplemented
 from ..guards import GuardBuilder, make_dupe_guard
 from ..side_effects import SideEffects
@@ -1572,7 +1572,8 @@ def wrap_fx_proxy_cls(
         inspect.isclass(proxy.node.target)
         and issubclass(proxy.node.target, _StreamBase)
     ) or proxy.node.target in [
-        interface_elem.current_stream for interface_elem in device_interfaces.values()
+        device_interface.current_stream
+        for _, device_interface in get_registered_device_interfaces()
     ]:
         proxy.node.meta["example_value"] = example_value
         return StreamVariable(
@@ -1581,7 +1582,8 @@ def wrap_fx_proxy_cls(
     elif (
         inspect.isclass(proxy.node.target) and issubclass(proxy.node.target, _EventBase)
     ) or proxy.node.target in [
-        interface_elem.Event for interface_elem in device_interfaces.values()
+        device_interface.Event
+        for _, device_interface in get_registered_device_interfaces()
     ]:
         proxy.node.meta["example_value"] = example_value
         return EventVariable(proxy, example_value, **options)

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -23,7 +23,7 @@ from torch._dynamo.variables import UserFunctionVariable
 
 from .. import config, variables
 from ..allowed_functions import torch_get_name
-from ..device_interface import device_interfaces
+from ..device_interface import get_registered_device_interfaces
 from ..exc import unimplemented
 from ..guards import GuardBuilder
 from ..utils import (
@@ -458,7 +458,8 @@ class TorchVariable(VariableTracker):
         elif any(
             self.value is method
             for method in [
-                interface_elem.stream for interface_elem in device_interfaces.values()
+                device_interface.stream
+                for _, device_interface in get_registered_device_interfaces()
             ]
         ):
             assert len(args) == 1


### PR DESCRIPTION
This PR makes up for the https://github.com/pytorch/pytorch/pull/108312.
This PR uses the _get_registered_device_interfaces_ to get the device interface, instead of using raw objects.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @arthuryuan1987 @jansel 