### PR TITLE
[RFC] Add unique error codes for all graph breaks

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -340,7 +340,7 @@ def convert_frame_assert(
             return None
 
         if is_generator(code):
-            unimplemented("generator")
+            unimplemented("generator", "U0001")
         if exceeds_cache_size_limit(cache_size):
 
             def format_func_info(code):
@@ -374,7 +374,7 @@ def convert_frame_assert(
                     format_func_info(code),
                     troubleshooting_url,
                 )
-            unimplemented("cache_size_limit reached")
+            unimplemented("cache_size_limit reached", "U0002")
 
         if not has_tensor_in_frame(frame):
             return None
@@ -548,7 +548,7 @@ def _compile(
                     LazyString(format_traceback_short, e.__traceback__),
                 )
                 if attempt > 100:
-                    unimplemented("100+ RestartAnalysis() calls")
+                    unimplemented("100+ RestartAnalysis() calls", "U0003")
             except exc.SkipFrame as e:
                 log.debug(
                     "Skipping frame %s %s \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #113005

This proposes assigning a unique error code U0001, U0002, etc for every unimplemented call in Dynamo. The necessity for this identifier was identified by @yanboliang in https://github.com/pytorch/pytorch/pull/111779/ where we want some way to aggregate and count error sites, but file:line is bad because they will not be stable over time.

This PR is not complete; the MVP probably is to also add a lint rule ensuring that these codes are unique in the codebase. There are other bells and whistles like documenting the codes, but this is probably enough to be useful.

After doing this, we should also do all other exception sites in Dynamo.

Comments and bikeshed colors appreciated.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng