### PR TITLE
Replaced deprecated pkg_resources.packaging with packaging module

### DIFF
--- a/tools/dynamo/verify_dynamo.py
+++ b/tools/dynamo/verify_dynamo.py
@@ -5,10 +5,8 @@ import sys
 import traceback
 import warnings
 
-import packaging.version
-
-MIN_CUDA_VERSION = packaging.version.parse("11.6")
-MIN_ROCM_VERSION = packaging.version.parse("5.4")
+MIN_CUDA_VERSION = (11, 6)
+MIN_ROCM_VERSION = (5, 4)
 MIN_PYTHON_VERSION = (3, 8)
 
 
@@ -28,12 +26,13 @@ def check_python():
 def check_torch():
     import torch
 
-    return packaging.version.parse(torch.__version__)
+    return torch.__version__
 
 
 # based on torch/utils/cpp_extension.py
 def get_cuda_version():
     from torch.utils import cpp_extension
+    from torch.torch_version import Version
 
     CUDA_HOME = cpp_extension._find_cuda_home()
     if not CUDA_HOME:
@@ -50,11 +49,12 @@ def get_cuda_version():
         raise VerifyDynamoError("CUDA version not found in `nvcc --version` output")
 
     cuda_str_version = cuda_version.group(1)
-    return packaging.version.parse(cuda_str_version)
+    return Version(cuda_str_version)
 
 
 def get_rocm_version():
     from torch.utils import cpp_extension
+    from torch.torch_version import Version
 
     ROCM_HOME = cpp_extension._find_rocm_home()
     if not ROCM_HOME:
@@ -75,16 +75,17 @@ def get_rocm_version():
 
     hip_str_version = hip_version.group(1)
 
-    return packaging.version.parse(hip_str_version)
+    return Version(hip_str_version)
 
 
 def check_cuda():
     import torch
+    from torch.torch_version import Version
 
     if not torch.cuda.is_available() or torch.version.hip is not None:
         return None
 
-    torch_cuda_ver = packaging.version.parse(torch.version.cuda)
+    torch_cuda_ver = Version(torch.version.cuda)
 
     # check if torch cuda version matches system cuda version
     cuda_ver = get_cuda_version()
@@ -112,14 +113,13 @@ def check_cuda():
 
 def check_rocm():
     import torch
+    from torch.torch_version import Version
 
     if not torch.cuda.is_available() or torch.version.hip is None:
         return None
 
     # Extracts main ROCm version from full string
-    torch_rocm_ver = packaging.version.parse(
-        ".".join(list(torch.version.hip.split(".")[0:2]))
-    )
+    torch_rocm_ver = Version(".".join(list(torch.version.hip.split(".")[0:2])))
 
     # check if torch rocm version matches system rocm version
     rocm_ver = get_rocm_version()

--- a/tools/dynamo/verify_dynamo.py
+++ b/tools/dynamo/verify_dynamo.py
@@ -5,7 +5,7 @@ import sys
 import traceback
 import warnings
 
-from pkg_resources import packaging
+import packaging
 
 MIN_CUDA_VERSION = packaging.version.parse("11.6")
 MIN_ROCM_VERSION = packaging.version.parse("5.4")

--- a/tools/dynamo/verify_dynamo.py
+++ b/tools/dynamo/verify_dynamo.py
@@ -5,7 +5,7 @@ import sys
 import traceback
 import warnings
 
-import packaging
+import packaging.version
 
 MIN_CUDA_VERSION = packaging.version.parse("11.6")
 MIN_ROCM_VERSION = packaging.version.parse("5.4")

--- a/tools/dynamo/verify_dynamo.py
+++ b/tools/dynamo/verify_dynamo.py
@@ -5,8 +5,8 @@ import sys
 import traceback
 import warnings
 
-MIN_CUDA_VERSION = (11, 6)
-MIN_ROCM_VERSION = (5, 4)
+MIN_CUDA_VERSION = "11.6"
+MIN_ROCM_VERSION = "5.4"
 MIN_PYTHON_VERSION = (3, 8)
 
 
@@ -31,8 +31,8 @@ def check_torch():
 
 # based on torch/utils/cpp_extension.py
 def get_cuda_version():
+    from torch.torch_version import TorchVersion
     from torch.utils import cpp_extension
-    from torch.torch_version import Version
 
     CUDA_HOME = cpp_extension._find_cuda_home()
     if not CUDA_HOME:
@@ -49,12 +49,12 @@ def get_cuda_version():
         raise VerifyDynamoError("CUDA version not found in `nvcc --version` output")
 
     cuda_str_version = cuda_version.group(1)
-    return Version(cuda_str_version)
+    return TorchVersion(cuda_str_version)
 
 
 def get_rocm_version():
+    from torch.torch_version import TorchVersion
     from torch.utils import cpp_extension
-    from torch.torch_version import Version
 
     ROCM_HOME = cpp_extension._find_rocm_home()
     if not ROCM_HOME:
@@ -75,17 +75,17 @@ def get_rocm_version():
 
     hip_str_version = hip_version.group(1)
 
-    return Version(hip_str_version)
+    return TorchVersion(hip_str_version)
 
 
 def check_cuda():
     import torch
-    from torch.torch_version import Version
+    from torch.torch_version import TorchVersion
 
     if not torch.cuda.is_available() or torch.version.hip is not None:
         return None
 
-    torch_cuda_ver = Version(torch.version.cuda)
+    torch_cuda_ver = TorchVersion(torch.version.cuda)
 
     # check if torch cuda version matches system cuda version
     cuda_ver = get_cuda_version()
@@ -113,13 +113,13 @@ def check_cuda():
 
 def check_rocm():
     import torch
-    from torch.torch_version import Version
+    from torch.torch_version import TorchVersion
 
     if not torch.cuda.is_available() or torch.version.hip is None:
         return None
 
     # Extracts main ROCm version from full string
-    torch_rocm_ver = Version(".".join(list(torch.version.hip.split(".")[0:2])))
+    torch_rocm_ver = TorchVersion(".".join(list(torch.version.hip.split(".")[0:2])))
 
     # check if torch rocm version matches system rocm version
     rocm_ver = get_rocm_version()

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -25,7 +25,7 @@ from typing import Dict, List, Optional, Union, Tuple
 from torch.torch_version import TorchVersion
 
 from setuptools.command.build_ext import build_ext
-from pkg_resources import packaging  # type: ignore[attr-defined]
+import packaging
 
 IS_WINDOWS = sys.platform == 'win32'
 IS_MACOS = sys.platform.startswith('darwin')

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1449,7 +1449,7 @@ def _check_and_build_extension_h_precompiler_headers(
         except subprocess.CalledProcessError as e:
             raise RuntimeError(f"Compile PreCompile Header fail, command: {pch_cmd}") from e
 
-    extra_cflags_str = listToString(extra_cflags)    
+    extra_cflags_str = listToString(extra_cflags)
     extra_include_paths_str = (
         "" if extra_include_paths is None else " ".join([f"-I{include}" for include in extra_include_paths])
     )

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -404,6 +404,9 @@ def _check_cuda_version(compiler_name: str, compiler_version: TorchVersion) -> N
 
     cuda_str_version = cuda_version.group(1)
     cuda_ver = packaging.version.parse(cuda_str_version)
+    if torch.version.cuda is None:
+        return
+
     torch_cuda_version = packaging.version.parse(torch.version.cuda)
     if cuda_ver != torch_cuda_version:
         # major/minor attributes are only available in setuptools>=49.4.0
@@ -2345,8 +2348,7 @@ def _write_ninja_file(path,
         # Compilation will work on earlier CUDA versions but header file
         # dependencies are not correctly computed.
         required_cuda_version = packaging.version.parse('11.0')
-        has_cuda_version = torch.version.cuda is not None
-        if has_cuda_version and packaging.version.parse(torch.version.cuda) >= required_cuda_version:
+        if torch.version.cuda is not None and packaging.version.parse(torch.version.cuda) >= required_cuda_version:
             cuda_compile_rule.append('  depfile = $out.d')
             cuda_compile_rule.append('  deps = gcc')
             # Note: non-system deps with nvcc are only supported

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -25,7 +25,7 @@ from typing import Dict, List, Optional, Union, Tuple
 from torch.torch_version import TorchVersion
 
 from setuptools.command.build_ext import build_ext
-import packaging
+import packaging.version
 
 IS_WINDOWS = sys.platform == 'win32'
 IS_MACOS = sys.platform.startswith('darwin')

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -22,10 +22,9 @@ from ._cpp_extension_versioner import ExtensionVersioner
 from .hipify import hipify_python
 from .hipify.hipify_python import GeneratedFileCleaner
 from typing import Dict, List, Optional, Union, Tuple
-from torch.torch_version import TorchVersion
+from torch.torch_version import TorchVersion, Version
 
 from setuptools.command.build_ext import build_ext
-import packaging.version
 
 IS_WINDOWS = sys.platform == 'win32'
 IS_MACOS = sys.platform.startswith('darwin')
@@ -403,11 +402,11 @@ def _check_cuda_version(compiler_name: str, compiler_version: TorchVersion) -> N
         return
 
     cuda_str_version = cuda_version.group(1)
-    cuda_ver = packaging.version.parse(cuda_str_version)
+    cuda_ver = Version(cuda_str_version)
     if torch.version.cuda is None:
         return
 
-    torch_cuda_version = packaging.version.parse(torch.version.cuda)
+    torch_cuda_version = Version(torch.version.cuda)
     if cuda_ver != torch_cuda_version:
         # major/minor attributes are only available in setuptools>=49.4.0
         if getattr(cuda_ver, "major", None) is None:
@@ -1136,7 +1135,7 @@ def CUDAExtension(name, sources, *args, **kwargs):
         extra_compile_args_dlink += [f'-L{x}' for x in library_dirs]
         extra_compile_args_dlink += [f'-l{x}' for x in dlink_libraries]
 
-        if (torch.version.cuda is not None) and packaging.version.parse(torch.version.cuda) >= packaging.version.parse('11.2'):
+        if (torch.version.cuda is not None) and Version(torch.version.cuda) >= '11.2':
             extra_compile_args_dlink += ['-dlto']   # Device Link Time Optimization started from cuda 11.2
 
         extra_compile_args['nvcc_dlink'] = extra_compile_args_dlink
@@ -2347,8 +2346,8 @@ def _write_ninja_file(path,
         # --generate-dependencies-with-compile was added in CUDA 10.2.
         # Compilation will work on earlier CUDA versions but header file
         # dependencies are not correctly computed.
-        required_cuda_version = packaging.version.parse('11.0')
-        if torch.version.cuda is not None and packaging.version.parse(torch.version.cuda) >= required_cuda_version:
+        required_cuda_version = '11.0'
+        if torch.version.cuda is not None and Version(torch.version.cuda) >= required_cuda_version:
             cuda_compile_rule.append('  depfile = $out.d')
             cuda_compile_rule.append('  deps = gcc')
             # Note: non-system deps with nvcc are only supported


### PR DESCRIPTION
Usage of `from pkg_resources import packaging` leads to a deprecation warning:
```
DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
```
and in strict tests where warnings are errors, this leads to CI breaks, e.g.: https://github.com/pytorch/vision/pull/8092

Replacing `pkg_resources.package` with `package` as it is now a pytorch dependency: 
https://github.com/pytorch/pytorch/blob/fa9045a8725214c05ae4dcec5a855820b861155e/requirements.txt#L19