### PR TITLE
cmake: Include `CheckCXXCompilerFlag` where it is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,6 @@ if(LINUX)
   else()
     # Please note this is required in order to ensure compatibility between gcc 9 and gcc 7
     # This could be removed when all Linux PyTorch binary builds are compiled by the same toolchain again
-    include(CheckCXXCompilerFlag)
     append_cxx_flag_if_supported("-fabi-version=11" CMAKE_CXX_FLAGS)
   endif()
 endif()

--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -527,6 +527,8 @@ function(torch_update_find_cuda_flags)
   endif()
 endfunction()
 
+include(CheckCXXCompilerFlag)
+
 ##############################################################################
 # CHeck if given flag is supported and append it to provided outputvar
 # Also define HAS_UPPER_CASE_FLAG_NAME variable


### PR DESCRIPTION
Move the `include(CheckCXXCompilerFlag)` above the `append_cxx_flag_if_supported` function that uses it to avoid depending on the caller to have it already included.