### PR TITLE
Move release docker container builds to ubuntu22.04

### DIFF
--- a/docker.Makefile
+++ b/docker.Makefile
@@ -10,8 +10,8 @@ endif
 
 CUDA_VERSION              = 12.1.1
 CUDNN_VERSION             = 8
-BASE_RUNTIME              = ubuntu:20.04
-BASE_DEVEL                = nvidia/cuda:$(CUDA_VERSION)-cudnn$(CUDNN_VERSION)-devel-ubuntu20.04
+BASE_RUNTIME              = ubuntu:22.04
+BASE_DEVEL                = nvidia/cuda:$(CUDA_VERSION)-cudnn$(CUDNN_VERSION)-devel-ubuntu22.04
 CMAKE_VARS               ?=
 
 # The conda channel to use to install cudatoolkit


### PR DESCRIPTION
Move Official Docker builds for the release to :
nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04
