### PR TITLE
Grandfather autogen'ed ops as pt2_compliant

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -1697,6 +1697,11 @@ def forward(self, x_1):
         for op in [torch.ops.aten.sin.default, torch.ops.aten.sum.dim_IntList]:
             self.assertIn(torch.Tag.pt2_compliant_tag, op.tags)
 
+    def test_autogen_aten_ops_are_pt2_compliant(self):
+        for op in [torch.ops.aten._foreach_copy.default, torch.ops.aten.fill.Tensor_out]:
+            self.assertIn(torch.Tag.generated, op.tags)
+            self.assertIn(torch.Tag.pt2_compliant_tag, op.tags)
+
     def test_resolve_packet(self):
         x = torch.randn(3)
         result = torch._C._jit_resolve_packet("aten::sum", x)

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -1698,7 +1698,10 @@ def forward(self, x_1):
             self.assertIn(torch.Tag.pt2_compliant_tag, op.tags)
 
     def test_autogen_aten_ops_are_pt2_compliant(self):
-        for op in [torch.ops.aten._foreach_copy.default, torch.ops.aten.fill.Tensor_out]:
+        for op in [
+            torch.ops.aten._foreach_copy.default,
+            torch.ops.aten.fill.Tensor_out,
+        ]:
             self.assertIn(torch.Tag.generated, op.tags)
             self.assertIn(torch.Tag.pt2_compliant_tag, op.tags)
 

--- a/torchgen/native_function_generation.py
+++ b/torchgen/native_function_generation.py
@@ -323,7 +323,9 @@ def generate_function(
             )
         }
     }
-    tags = {"generated"} | set(f.tags & {"nondeterministic_seeded", "view_copy", "pt2_compliant_tag"})
+    tags = {"generated"} | set(
+        f.tags & {"nondeterministic_seeded", "view_copy", "pt2_compliant_tag"}
+    )
 
     return (
         NativeFunction(

--- a/torchgen/native_function_generation.py
+++ b/torchgen/native_function_generation.py
@@ -323,7 +323,7 @@ def generate_function(
             )
         }
     }
-    tags = {"generated"} | set(f.tags & {"nondeterministic_seeded", "view_copy"})
+    tags = {"generated"} | set(f.tags & {"nondeterministic_seeded", "view_copy", "pt2_compliant_tag"})
 
     return (
         NativeFunction(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #113061
* #113050
* #113049
* __->__ #113036

Summary:
I missed this when I grandfathered torchgen'ed aten ops as pt2_compliant.

Test Plan:
New test.

Reviewers:

Subscribers:

Tasks:

Tags: