### PR TITLE
[dynamo] Graph break on `setattr(Tensor, "data", Tensor)`

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -1539,6 +1539,69 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         self.assertGreaterEqual(torch._dynamo.utils.counters["frames"]["ok"], 2)
         self.assertGreaterEqual(torch._dynamo.utils.counters["frames"]["total"], 2)
 
+    def test_tensor_setattr_data_graph_breaks(self):
+        # https://github.com/pytorch/pytorch/issues/113030
+        def func1(x, y):
+            x.data = y
+            x.add_(1)
+            return x
+
+        def func2(x, y):
+            x.data = y
+            y.data = torch.zeros([0])
+            return x
+
+        for func in [func1, func2]:
+            a = torch.rand([6])
+            a1 = torch.clone(a)
+            b = torch.rand([6])
+            b1 = torch.clone(b)
+
+            cnt = torch._dynamo.testing.CompileCounter()
+
+            _ = func(a, b)
+            _ = torch.compile(func, backend=cnt)(a1, b1)
+
+            self.assertEqual(a, a1)
+            self.assertEqual(b, b1)
+
+    def test_tensor_untracked_setattr_data_graph_breaks(self):
+        # https://github.com/pytorch/pytorch/issues/113030
+        def func(y):
+            x = torch.tensor([0])
+            x.data = y  # Setattr for untracked tensors is unsupported
+            x.add_(1)
+            return x
+
+        a = torch.rand([6])
+        a1 = torch.clone(a)
+
+        cnt = torch._dynamo.testing.CompileCounter()
+
+        _ = func(a)
+        _ = torch.compile(func, backend=cnt)(a1)
+
+        self.assertEqual(a, a1)
+        self.assertEqual(cnt.frame_count, 2)  # graph breaks
+
+    def test_tensor_tracked_setattr_data_to_untracked_graph_breaks(self):
+        # https://github.com/pytorch/pytorch/issues/113030
+        def func(x):
+            y = torch.tensor([0])
+            x.data = y  # If we setattr to untracked tensor, it aliases a new tensor.
+            # we need to start tracking y even though it is created in graph
+            x.add_(1)
+            return x, y
+
+        a = torch.rand([6])
+        a1 = torch.clone(a)
+
+        cnt = torch._dynamo.testing.CompileCounter()
+
+        self.assertEqual(func(a), torch.compile(func, backend=cnt)(a1))
+        self.assertEqual(a, a1)
+        self.assertEqual(cnt.frame_count, 2)
+
     @torch._dynamo.config.patch("suppress_errors", True)
     def test_guard_fail_tensor_bool(self):
         @torch._dynamo.disable(recursive=False)

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -1564,6 +1564,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
 
             self.assertEqual(a, a1)
             self.assertEqual(b, b1)
+            self.assertEqual(cnt.frame_count, 2)  # graph breaks
 
     def test_tensor_untracked_setattr_data_graph_breaks(self):
         # https://github.com/pytorch/pytorch/issues/113030
@@ -1588,8 +1589,9 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         # https://github.com/pytorch/pytorch/issues/113030
         def func(x):
             y = torch.tensor([0])
-            x.data = y  # If we setattr to untracked tensor, it aliases a new tensor.
+            # If we setattr to untracked tensor, it aliases a new tensor.
             # we need to start tracking y even though it is created in graph
+            x.data = y
             x.add_(1)
             return x, y
 

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1160,6 +1160,7 @@ class BuiltinVariable(VariableTracker):
     ):
         from .distributed import PlacementVariable
 
+        print("SETATTR", obj, tx.output.side_effects.is_attribute_mutation(obj))
         if isinstance(
             obj,
             (
@@ -1173,7 +1174,18 @@ class BuiltinVariable(VariableTracker):
             tx.output.side_effects.is_attribute_mutation(obj)
             and name_var.is_python_constant()
         ):
-            tx.output.side_effects.store_attr(obj, name_var.as_python_constant(), val)
+            name = name_var.as_python_constant()
+            if name == "data" and all(
+                isinstance(t, variables.TensorVariable)
+                # and not (t.source is None or is_constant_source(t.source))
+                for t in [val, obj]
+            ):
+                unimplemented(
+                    ".data assignment to a tracked tensors can introduce aliasing, hence we "
+                    "need to graph break to apply the aliasing (or track new aliased tensors) "
+                    "to continue to trace the graph"
+                )
+            tx.output.side_effects.store_attr(obj, name, val)
             return val.add_options(self, obj, name_var)
         elif isinstance(obj, variables.UserDefinedObjectVariable):
             unimplemented(

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1160,7 +1160,6 @@ class BuiltinVariable(VariableTracker):
     ):
         from .distributed import PlacementVariable
 
-        print("SETATTR", obj, tx.output.side_effects.is_attribute_mutation(obj))
         if isinstance(
             obj,
             (


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/113030

Alias information needs to be applied in eager before we can continue to trace the graph.

----

Perhaps this is too strict - couldn't we fx trace through the in-graph (pointer) aliasing, and track mutations through fake tensors instead, and still apply the aliasing mutation epilogue for further mutations outside of graph? :thinking: 

Regardless, it didn't seem to work too well when I tried this. Seems that `Tensor.__setattr__` doesn't work well in fx graph.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng