### PR TITLE
[DTensorTestbase] Add run_subtests to DTensorTestbase and fix test_ddp checkpoint test error

### DIFF
--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -32,8 +32,11 @@ from torch.testing._internal.common_dist_composable import (
     UnitModule,
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_fsdp import FSDPTest
 from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    DTensorTestBase,
+    with_comms,
+)
 
 
 if not dist.is_available():
@@ -48,7 +51,7 @@ if TEST_WITH_DEV_DBG_ASAN:
     sys.exit(0)
 
 
-class TestStateDict(FSDPTest):
+class TestStateDict(DTensorTestBase):
     """Tests state_dict and load_state_dict"""
 
     @property
@@ -265,6 +268,7 @@ class TestStateDict(FSDPTest):
 
         self._test_save_load(init_model_optim)
 
+    @with_comms
     @skip_if_lt_x_gpu(2)
     def test_fsdp(self) -> None:
         self.run_subtests(
@@ -290,6 +294,7 @@ class TestStateDict(FSDPTest):
 
         self._test_save_load(init_model_optim)
 
+    @with_comms
     @skip_if_lt_x_gpu(2)
     def test_ddp(self) -> None:
         self.run_subtests(
@@ -337,6 +342,7 @@ class TestStateDict(FSDPTest):
 
         self._test_save_load(init_model_optim, test_frozen)
 
+    @with_comms
     @skip_if_lt_x_gpu(2)
     def test_fsdp_ddp(self) -> None:
         self.run_subtests(
@@ -344,12 +350,14 @@ class TestStateDict(FSDPTest):
             self._test_fsdp_ddp,
         )
 
+    @with_comms
     @skip_if_lt_x_gpu(2)
     def test_frozen_parameters(self) -> None:
         self._test_fsdp_ddp(use_composable=False, test_frozen=True)
 
     # TODO: enable use_dtensor once 2D device_mesh support is fully landed.
     """
+    @with_comms
     @skip_if_lt_x_gpu(2)
     def test_use_dtensor(self) -> None:
         self._test_fsdp_ddp(use_composable=False, use_dtensor=True)
@@ -359,6 +367,7 @@ class TestStateDict(FSDPTest):
     # Disable this test as it is broken after
     # https://github.com/pytorch/pytorch/pull/108298.
     """
+    @with_comms
     @skip_if_lt_x_gpu(2)
     def test_apply_optimizer_in_backward(self) -> None:
         self.run_subtests(
@@ -368,6 +377,7 @@ class TestStateDict(FSDPTest):
         )
     """
 
+    @with_comms
     @skip_if_lt_x_gpu(1)
     def test_single_gpu(self) -> None:
         def init_model_optim():
@@ -380,6 +390,7 @@ class TestStateDict(FSDPTest):
 
         self._test_save_load(init_model_optim)
 
+    @with_comms
     @skip_if_lt_x_gpu(1)
     def test_strict(self) -> None:
         model = CompositeParamModel(device=torch.device("cuda"))
@@ -401,6 +412,7 @@ class TestStateDict(FSDPTest):
         with self.assertRaisesRegex(RuntimeError, "Missing key"):
             set_model_state_dict(model, model_state_dict=model_state_dict)
 
+    @with_comms
     @skip_if_lt_x_gpu(1)
     def test_partial(self) -> None:
         model = CompositeParamModel(device=torch.device("cuda"))

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -169,6 +169,9 @@ class DTensorTestBase(MultiProcessTestCase):
                     out,
                 )
 
+    def run_subtests(self, *args, **kwargs):
+        return run_subtests(self, *args, **kwargs)
+
 
 TestFunc = Callable[[object], object]
 
@@ -191,6 +194,38 @@ def with_comms(func: TestFunc) -> TestFunc:
         self.destroy_pg()
 
     return wrapper
+
+
+def run_subtests(
+    cls_inst,
+    subtest_config: Dict[str, List[Any]],
+    test_fn: Callable,
+    *test_args,
+    **test_kwargs: Any,
+):
+    """
+    Runs a test function given by ``test_fn`` as a subtest according to the
+    configurations specified by ``subtest_config``. This amortizes the
+    costly setup overhead (including process spawn and initializing the
+    process group) over the subtests.
+
+    Args:
+        subtest_config (Dict[str, List[Any]]): A mapping from subtest
+            keyword argument name to a list of its possible values.
+        test_fn (Callable): A callable that runs the actual test.
+        test_args: Positional arguments to pass to ``test_fn``.
+        test_kwargs: Keyword arguments to pass to ``test_fn``.
+    """
+    # Convert the config mapping to a list to have a fixed order
+    subtest_config_items: List[Tuple[str, List[Any]]] = list(subtest_config.items())
+    subtest_config_keys: List[str] = [item[0] for item in subtest_config_items]
+    subtest_config_values: List[List[Any]] = [item[1] for item in subtest_config_items]
+    for values in itertools.product(*subtest_config_values):
+        # Map keyword to chosen value
+        subtest_kwargs = dict(zip(subtest_config_keys, values))
+        with cls_inst.subTest(**subtest_kwargs):
+            test_fn(*test_args, **test_kwargs, **subtest_kwargs)
+        dist.barrier()
 
 
 class DTensorOpTestBase(MultiThreadedTestCase):


### PR DESCRIPTION
This PR: 

1. Adds  `run_subtests` to `DTensorTestbase`, which runs test functions given by `test_fn` as subtests. This amortizes the costly dist setup. 
2. Update `test/distributed/checkpoint/test_state_dict.py` to use `DTensorTestbase`. This fixes the "Duplicate GPU detected: rank 0 and rank 1 both on CUDA device 11000" when running on 1 GPU, as the skip_if_lt_x_gpu is currently happening after dist setup.  