### PR TITLE
Fix docstring errors in reductions.py, spawn.py, pool.py, parameter.py, cpp.py, grad.py, __init__.py, profiler.py, queue.py, graph.py

### DIFF
--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -164,7 +164,7 @@ def get_gradient_edge(tensor):
 
 
 def increment_version(tensor):
-    """Notify autograd that the given Tensor was modified in place.
+    """Update autograd metadata tracking whether the given Tensor was modified in place.
 
     This is to enable more accurate error checking within the autograd engine.
     It is already done automatically by PyTorch functions and within custom Function
@@ -259,7 +259,7 @@ class saved_tensors_hooks:
 
 
 class save_on_cpu(saved_tensors_hooks):
-    """Context manager under which tensors saved by the forward pass will be stored on cpu, then retrieval for backward.
+    """Context manager under which tensors saved by the forward pass will be stored on cpu, then retrieved for backward.
 
     When performing operations within this context manager, intermediary
     results saved in the graph during the forward pass will be moved to CPU,

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -24,7 +24,7 @@ __all__ = [
 class Node(abc.ABC):
     @abc.abstractmethod
     def name(self) -> str:
-        r"""Returns the name.
+        r"""Return the name.
 
         Example::
 
@@ -44,7 +44,7 @@ class Node(abc.ABC):
 
     @abc.abstractmethod
     def metadata(self) -> dict:
-        r"""Returns the metadata."""
+        r"""Return the metadata."""
         ...
 
     @abc.abstractmethod
@@ -53,7 +53,7 @@ class Node(abc.ABC):
 
     @abc.abstractmethod
     def register_hook(self, fn: Callable[..., Any]) -> RemovableHandle:
-        r"""Registers a backward hook.
+        r"""Register a backward hook.
 
         The hook will be called every time a gradient with respect to the
         Node is computed. The hook should have the following signature::
@@ -91,7 +91,7 @@ class Node(abc.ABC):
 
     @abc.abstractmethod
     def register_prehook(self, fn: Callable[..., Any]) -> RemovableHandle:
-        r"""Registers a backward pre-hook.
+        r"""Register a backward pre-hook.
 
         The hook will be called every time a gradient with respect to the
         Node is computed. The hook should have the following signature::
@@ -144,8 +144,9 @@ you can do ``edge = autograd.graph.get_gradient_edge(tensor)``.
 
 
 def get_gradient_edge(tensor):
-    """This function can be used to get the gradient edge where the gradient of
-    the given Tensor will be computed. In particular, it is equivalent to call
+    """Get the gradient edge for computing the gradient of the given Tensor.
+
+    In particular, it is equivalent to call
     ``g = autograd.grad(loss, input)`` and ``g = autograd.grad(loss, get_gradient_edge(input))``.
     """
     if not tensor.requires_grad:
@@ -163,10 +164,10 @@ def get_gradient_edge(tensor):
 
 
 def increment_version(tensor):
-    """This function can be used to let autograd know that a given Tensor was modified
-    inplace to enable more accurate error checking within the autograd engine.
+    """Notify autograd about the given Tensor was modified inplace.
 
-    This is already done automatically by PyTorch functions and within custom Function
+    This is to enable more accurate error checking within the autograd engine.
+    It is already done automatically by PyTorch functions and within custom Function
     when mark_dirty() is called appropriately so you only need to call this explicitly
     if you are doing inplace operation on the Tensor data in a way that Pytorch doesn't
     know about. For example a custom kernel that reads the Tensor data_ptr and modifies
@@ -258,8 +259,7 @@ class saved_tensors_hooks:
 
 
 class save_on_cpu(saved_tensors_hooks):
-    """Context-manager under which tensors saved by the forward pass will be
-    stored on cpu, then retrieved for backward.
+    """Context-manager that saves tensors on CPU during forward pass then retrieval in backward.
 
     When performing operations within this context manager, intermediary
     results saved in the graph during the forward pass will be moved to CPU,
@@ -362,7 +362,7 @@ def register_multi_grad_hook(
     tensors: Sequence[torch.Tensor],
     fn: Callable[[Sequence[Optional[torch.Tensor]]], None],
 ):
-    r"""Registers a multi-grad backward hook.
+    r"""Register a multi-grad backward hook.
 
     The hook will be called after gradients with respect to every tensor in
     :attr:`tensors` have been computed. If a tensor is in :attr:`tensors` but
@@ -585,7 +585,7 @@ class _AllowMutationOnSavedContext:
 
 @contextlib.contextmanager
 def allow_mutation_on_saved_tensors():
-    """Context manager under which mutating tensors saved for backward is allowed
+    """Context manager under which mutating tensors saved for backward is allowed.
 
     Under this context manager, tensors saved for backward are cloned on mutation,
     so the original version can still be used during backward. Normally, mutating a tensor

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -164,7 +164,7 @@ def get_gradient_edge(tensor):
 
 
 def increment_version(tensor):
-    """Notify autograd about the given Tensor was modified inplace.
+    """Notify autograd that the given Tensor was modified in place.
 
     This is to enable more accurate error checking within the autograd engine.
     It is already done automatically by PyTorch functions and within custom Function
@@ -259,7 +259,7 @@ class saved_tensors_hooks:
 
 
 class save_on_cpu(saved_tensors_hooks):
-    """Context-manager that saves tensors on CPU during forward pass then retrieval in backward.
+    """Context manager under which tensors saved by the forward pass will be stored on cpu, then retrieval for backward.
 
     When performing operations within this context manager, intermediary
     results saved in the graph during the forward pass will be moved to CPU,

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -89,6 +89,7 @@ def _run_on_profiler_stop():
 
 class profile:
     """Context manager that manages autograd profiler state and holds a summary of results.
+
     Under the hood it just records events of functions being executed in C++ and
     exposes those events to Python. You can wrap any code into it and it will
     only report runtime of PyTorch functions.
@@ -374,8 +375,9 @@ class profile:
 
     @property
     def self_cpu_time_total(self):
-        """Returns total time spent on CPU obtained as a sum of
-        all self times across all the events.
+        """Returns total time spent on CPU.
+
+        The total time is a sum of all self times across all the events.
         """
         self._check_finish()
         assert self.function_events is not None
@@ -552,9 +554,9 @@ class profile:
 
 
 class record_function(_ContextDecorator):
-    """Context manager/function decorator that adds a label to a block of
-    Python code (or function) when running autograd profiler. It is
-    useful when tracing the code profile.
+    """Context manager that adds a label to a code block/function when running autograd profiler.
+
+    It is useful when tracing the code profile.
 
     Args:
         name (str): Label assigned to the block of code.
@@ -622,13 +624,12 @@ class record_function(_ContextDecorator):
             torch.ops.profiler._record_function_exit(record)
 
     def _call_end_callbacks_on_future(self, fut: Future[Any]) -> Future[Any]:
-        """
-        _call_end_callbacks_on_future is meant to be used for profiling async
-        calls that return a future. Calling this function will extend recording
-        beyond this scope, until the future is satisfied. It is useful for profiling
-        the end to end time of asynchronous calls. This function should only be called
-        once to attach the callback onto the future, and will throw if called multiple
-        times.
+        """Used for profiling async calls that return a future.
+
+        Calling this function will extend recording beyond this scope, until the future is
+        satisfied. It is useful for profiling the end to end time of asynchronous calls.
+        This function should only be called once to attach the callback onto the future, and
+        will throw if called multiple times.
 
         Args:
             fut: (torch._C.Future): future for which to schedule
@@ -860,7 +861,7 @@ class emit_nvtx:
 
 
 def load_nvprof(path):
-    """Opens an nvprof trace file and parses autograd annotations.
+    """Open an nvprof trace file and parses autograd annotations.
 
     Args:
         path (str): path to nvprof trace
@@ -949,6 +950,7 @@ def parse_nvprof_trace(path):
 
 class KinetoStepTracker:
     """Provides an abstraction for incrementing the step count globally.
+
     Previously, we only had one place to mark that a step() has occurred
     in the program via pytorch profiler step(). We will now add step hooks
     in the Optimizer class https://github.com/pytorch/pytorch/issues/88446
@@ -998,9 +1000,9 @@ class KinetoStepTracker:
     @classmethod
     def increment_step(cls, requester: str) -> int:
         """Increments the step count for the requester.
+
         Additionally if the max over all step counts has incremented then
-        trigger the _kineto_step()
-        returns global step count
+        trigger the _kineto_step() returns global step count
         """
         if requester not in cls._step_dict:
             cls.init_step_count(requester)

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -554,7 +554,7 @@ class profile:
 
 
 class record_function(_ContextDecorator):
-    """Context manager that adds a label to a code block/function when running autograd profiler.
+    """Context manager/function decorator that adds a label to a code block/function when running autograd profiler.
 
     It is useful when tracing the code profile.
 

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -624,7 +624,7 @@ class record_function(_ContextDecorator):
             torch.ops.profiler._record_function_exit(record)
 
     def _call_end_callbacks_on_future(self, fut: Future[Any]) -> Future[Any]:
-        """Used for profiling async calls that return a future.
+        """Use for profiling async calls that return a future.
 
         Calling this function will extend recording beyond this scope, until the future is
         satisfied. It is useful for profiling the end to end time of asynchronous calls.

--- a/torch/multiprocessing/__init__.py
+++ b/torch/multiprocessing/__init__.py
@@ -1,6 +1,6 @@
-"""
-torch.multiprocessing is a wrapper around the native :mod:`multiprocessing`
-module. It registers custom reducers, that use shared memory to provide shared
+"""torch.multiprocessing is a wrapper around the native :mod:`multiprocessing` module.
+
+It registers custom reducers, that use shared memory to provide shared
 views on the same data in different processes. Once the tensor/storage is moved
 to shared_memory (see :func:`~torch.Tensor.share_memory_`), it will be possible
 to send it to other processes without making any copies.
@@ -54,7 +54,7 @@ else:
 
 
 def set_sharing_strategy(new_strategy):
-    """Sets the strategy for sharing CPU tensors.
+    """Set the strategy for sharing CPU tensors.
 
     Args:
         new_strategy (str): Name of the selected strategy. Should be one of
@@ -66,12 +66,12 @@ def set_sharing_strategy(new_strategy):
 
 
 def get_sharing_strategy():
-    """Returns the current strategy for sharing CPU tensors."""
+    """Return the current strategy for sharing CPU tensors."""
     return _sharing_strategy
 
 
 def get_all_sharing_strategies():
-    """Returns a set of sharing strategies supported on a current system."""
+    """Return a set of sharing strategies supported on a current system."""
     return _all_sharing_strategies
 
 

--- a/torch/multiprocessing/pool.py
+++ b/torch/multiprocessing/pool.py
@@ -16,8 +16,10 @@ def clean_worker(*args, **kwargs):
 
 class Pool(multiprocessing.pool.Pool):
     """Pool implementation which uses our version of SimpleQueue.
+
     This lets us pass tensors in shared memory across processes instead of
-    serializing the underlying data."""
+    serializing the underlying data.
+    """
 
     def _setup_queues(self):
         self._inqueue = SimpleQueue()
@@ -26,8 +28,10 @@ class Pool(multiprocessing.pool.Pool):
         self._quick_get = self._outqueue._reader.recv
 
     def _repopulate_pool(self):
-        """Bring the number of pool processes up to the specified number,
-        for use after reaping workers which have exited.
+        """Increase the number of pool processes to the specified number.
+
+        Bring the number of pool processes up to the specified number, for use after
+        reaping workers which have exited.
         """
         for i in range(self._processes - len(self._pool)):
             # changed worker -> clean_worker

--- a/torch/multiprocessing/queue.py
+++ b/torch/multiprocessing/queue.py
@@ -5,7 +5,7 @@ from multiprocessing.reduction import ForkingPickler
 
 
 class ConnectionWrapper:
-    """Proxy class for _multiprocessing.Connection using ForkingPickler for object serialization."""
+    """Proxy class for _multiprocessing.Connection which uses ForkingPickler for object serialization."""
 
     def __init__(self, conn):
         self.conn = conn

--- a/torch/multiprocessing/queue.py
+++ b/torch/multiprocessing/queue.py
@@ -5,8 +5,7 @@ from multiprocessing.reduction import ForkingPickler
 
 
 class ConnectionWrapper:
-    """Proxy class for _multiprocessing.Connection which uses ForkingPickler to
-    serialize objects"""
+    """Proxy class for _multiprocessing.Connection using ForkingPickler for object serialization."""
 
     def __init__(self, conn):
         self.conn = conn

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -24,7 +24,8 @@ class StorageWeakRef:
     r"""A weak reference to a Storage.
 
     The cdata member is a Python number containing the integer representation of
-    the Storage pointer."""
+    the Storage pointer.
+    """
 
     __slots__ = ["cdata", "_free_weak_ref"]
 
@@ -57,7 +58,7 @@ class StorageWeakRef:
 
 
 class SharedCache(dict):
-    """dictionary from multiprocessing handles to StorageWeakRef"""
+    """Dictionary from multiprocessing handles to StorageWeakRef."""
 
     def __init__(self):
         # free_dead_references() is called if the len exceeds the current

--- a/torch/multiprocessing/spawn.py
+++ b/torch/multiprocessing/spawn.py
@@ -22,7 +22,7 @@ class ProcessException(Exception):
 
 
 class ProcessRaisedException(ProcessException):
-    """Exception raised when a process failed due to a code-induced exception."""
+    """Exception raised when a process failed due to an exception raised by the code."""
 
     def __init__(
         self,

--- a/torch/multiprocessing/spawn.py
+++ b/torch/multiprocessing/spawn.py
@@ -22,10 +22,7 @@ class ProcessException(Exception):
 
 
 class ProcessRaisedException(ProcessException):
-    """
-    Exception is thrown when the process failed due to exception
-    raised by the code.
-    """
+    """Exception raised when a process failed due to a code-induced exception."""
 
     def __init__(
         self,
@@ -37,10 +34,7 @@ class ProcessRaisedException(ProcessException):
 
 
 class ProcessExitedException(ProcessException):
-    """
-    Exception is thrown when the process failed due to signal
-    or exited with a specific code.
-    """
+    """Exception raised when a process failed due to signal or exited with a specific code."""
 
     __slots__ = ["exit_code"]
 
@@ -94,8 +88,9 @@ class ProcessContext:
         return [int(process.pid) for process in self.processes]
 
     def join(self, timeout=None):
-        r"""
-        Tries to join one or more processes in this spawn context.
+        r"""Join one or more processes within spawn context.
+
+        Attempt to join one or more processes in this spawn context.
         If one of them exited with a non-zero exit status, this function
         kills the remaining processes and raises an exception with the cause
         of the first process exiting.

--- a/torch/nn/__init__.py
+++ b/torch/nn/__init__.py
@@ -11,7 +11,8 @@ from . import utils
 
 
 def factory_kwargs(kwargs):
-    r"""
+    r"""Return a canonicalized dict of factory kwargs.
+
     Given kwargs, returns a canonicalized dict of factory kwargs that can be directly passed
     to factory functions like torch.empty, or errors if unrecognized kwargs are present.
 

--- a/torch/nn/cpp.py
+++ b/torch/nn/cpp.py
@@ -4,13 +4,13 @@ from torch import nn
 
 
 class OrderedDictWrapper:
-    """
-    A wrapper around a C++ OrderedDict that dynamically evaluates the
-    OrderedDict getter on a bound C++ module, such that new changes on the C++
-    side are picked up. Otherwise accessing e.g. ``cpp_module._parameters`` just
-    once would get a frozen copy of the parameters at the time of access.
-    ``torch.nn.Module`` accesses ``_parameters`` et al. via ``self.__dict__`` so
-    using properties does not work.
+    """A wrapper around a C++ OrderedDict.
+
+    It dynamically evaluates the OrderedDict getter on a bound C++ module, such
+    that new changes on the C++ side are picked up. Otherwise accessing e.g.
+    ``cpp_module._parameters`` just once would get a frozen copy of the parameters
+    at the time of access. ``torch.nn.Module`` accesses ``_parameters`` et al. via ``self.__dict__``
+    so using properties does not work.
     """
 
     def __init__(self, cpp_module, attr):
@@ -47,10 +47,7 @@ class OrderedDictWrapper:
 
 
 class ModuleWrapper(nn.Module):
-    """
-    A subclass of ``torch.nn.Module`` that wraps a C++ frontend module and
-    delegates all access.
-    """
+    """A subclass of ``torch.nn.Module`` that wraps a C++ frontend module and delegates all access."""
 
     def __init__(self, cpp_module):
         # Assign before the super class constructor so ``self.training`` can be

--- a/torch/nn/grad.py
+++ b/torch/nn/grad.py
@@ -1,12 +1,12 @@
-"""Gradient interface"""
+"""Gradient interface."""
 
 import torch
 from .modules.utils import _single, _pair, _triple
 
 
 def conv1d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=1, groups=1):
-    r"""
-    Computes the gradient of conv1d with respect to the input of the convolution.
+    r"""Compute the gradient of conv1d with respect to the input of the convolution.
+
     This is same as the 1D transposed convolution operator under the hood but requires
     the shape of the gradient w.r.t. input to be specified explicitly.
 
@@ -37,8 +37,7 @@ def conv1d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=
 
 
 def conv1d_weight(input, weight_size, grad_output, stride=1, padding=0, dilation=1, groups=1):
-    r"""
-    Computes the gradient of conv1d with respect to the weight of the convolution.
+    r"""Compute the gradient of conv1d with respect to the weight of the convolution.
 
     Args:
         input: input tensor of shape (minibatch x in_channels x iW)
@@ -68,8 +67,8 @@ def conv1d_weight(input, weight_size, grad_output, stride=1, padding=0, dilation
 
 
 def conv2d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=1, groups=1):
-    r"""
-    Computes the gradient of conv2d with respect to the input of the convolution.
+    r"""Compute the gradient of conv2d with respect to the input of the convolution.
+
     This is same as the 2D transposed convolution operator under the hood but requires
     the shape of the gradient w.r.t. input to be specified explicitly.
 
@@ -100,8 +99,7 @@ def conv2d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=
 
 
 def conv2d_weight(input, weight_size, grad_output, stride=1, padding=0, dilation=1, groups=1):
-    r"""
-    Computes the gradient of conv2d with respect to the weight of the convolution.
+    r"""Compute the gradient of conv2d with respect to the weight of the convolution.
 
     Args:
         input: input tensor of shape (minibatch x in_channels x iH x iW)
@@ -131,8 +129,8 @@ def conv2d_weight(input, weight_size, grad_output, stride=1, padding=0, dilation
 
 
 def conv3d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=1, groups=1):
-    r"""
-    Computes the gradient of conv3d with respect to the input of the convolution.
+    r"""Compute the gradient of conv3d with respect to the input of the convolution.
+
     This is same as the 3D transposed convolution operator under the hood but requires
     the shape of the gradient w.r.t. input to be specified explicitly.
 
@@ -163,8 +161,7 @@ def conv3d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=
 
 
 def conv3d_weight(input, weight_size, grad_output, stride=1, padding=0, dilation=1, groups=1):
-    r"""
-    Computes the gradient of conv3d with respect to the weight of the convolution.
+    r"""Compute the gradient of conv3d with respect to the weight of the convolution.
 
     Args:
         input: input tensor of shape (minibatch x in_channels x iT x iH x iW)

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -30,6 +30,7 @@ class Parameter(torch.Tensor, metaclass=_ParameterMeta):
             :class:`~no_grad` mode. See :ref:`locally-disable-grad-doc` for more
             details. Default: `True`
     """
+
     def __new__(cls, data=None, requires_grad=True):
         if data is None:
             data = torch.empty(0)
@@ -103,6 +104,7 @@ class UninitializedTensorMixin:
 
     def materialize(self, shape, device=None, dtype=None):
         r"""Create a Parameter or Tensor with the same properties of the uninitialized one.
+
         Given a shape, it materializes a parameter in the same device
         and with the same `dtype` as the current one or the specified ones in the
         arguments.


### PR DESCRIPTION
Fixes #112595 
- `torch/autograd/profiler.py` </br>
**Before: 37**

```
torch/autograd/profiler.py:1 at module level:
        D100: Missing docstring in public module
torch/autograd/profiler.py:91 in public class `profile`:
        D205: 1 blank line required between summary line and description (found 0)
torch/autograd/profiler.py:175 in public method `__init__`:
        D107: Missing docstring in __init__
torch/autograd/profiler.py:261 in public method `config`:
        D102: Missing docstring in public method
torch/autograd/profiler.py:272 in public method `__enter__`:
        D105: Missing docstring in magic method
torch/autograd/profiler.py:290 in public method `__exit__`:
        D105: Missing docstring in magic method
torch/autograd/profiler.py:308 in public method `__repr__`:
        D105: Missing docstring in magic method
torch/autograd/profiler.py:313 in public method `__str__`:
        D105: Missing docstring in magic method
torch/autograd/profiler.py:322 in public method `table`:
        D102: Missing docstring in public method
torch/autograd/profiler.py:346 in public method `export_chrome_trace`:
        D102: Missing docstring in public method
torch/autograd/profiler.py:355 in public method `export_stacks`:
        D102: Missing docstring in public method
torch/autograd/profiler.py:361 in public method `key_averages`:
        D102: Missing docstring in public method
torch/autograd/profiler.py:368 in public method `total_average`:
        D102: Missing docstring in public method
torch/autograd/profiler.py:377 in public method `self_cpu_time_total`:
        D205: 1 blank line required between summary line and description (found 0)
torch/autograd/profiler.py:377 in public method `self_cpu_time_total`:
        D400: First line should end with a period (not 'f')
torch/autograd/profiler.py:555 in public class `record_function`:
        D205: 1 blank line required between summary line and description (found 0)
torch/autograd/profiler.py:555 in public class `record_function`:
        D400: First line should end with a period (not 'f')
torch/autograd/profiler.py:591 in public method `__init__`:
        D107: Missing docstring in __init__
torch/autograd/profiler.py:602 in public method `__enter__`:
        D105: Missing docstring in magic method
torch/autograd/profiler.py:608 in public method `__exit__`:
        D105: Missing docstring in magic method
torch/autograd/profiler.py:625 in private method `_call_end_callbacks_on_future`:
        D205: 1 blank line required between summary line and description (found 0)
torch/autograd/profiler.py:625 in private method `_call_end_callbacks_on_future`:
        D400: First line should end with a period (not 'c')
torch/autograd/profiler.py:707 in public method `__init__`:
        D107: Missing docstring in __init__
torch/autograd/profiler.py:712 in public method `__enter__`:
        D105: Missing docstring in magic method
torch/autograd/profiler.py:733 in public method `__exit__`:
        D105: Missing docstring in magic method
torch/autograd/profiler.py:826 in public method `__init__`:
        D107: Missing docstring in __init__
torch/autograd/profiler.py:831 in public method `__enter__`:
        D105: Missing docstring in magic method
torch/autograd/profiler.py:853 in public method `__exit__`:
        D105: Missing docstring in magic method
torch/autograd/profiler.py:863 in public function `load_nvprof`:
        D401: First line should be in imperative mood (perhaps 'Open', not 'Opens')
torch/autograd/profiler.py:874 in public method `__init__`:
        D107: Missing docstring in __init__
torch/autograd/profiler.py:877 in public method `see`:
        D102: Missing docstring in public method
torch/autograd/profiler.py:883 in public function `parse_nvprof_trace`:
        D103: Missing docstring in public function
torch/autograd/profiler.py:951 in public class `KinetoStepTracker`:
        D205: 1 blank line required between summary line and description (found 0)
torch/autograd/profiler.py:991 in public method `init_step_count`:
        D102: Missing docstring in public method
torch/autograd/profiler.py:995 in public method `erase_step_count`:
        D102: Missing docstring in public method
torch/autograd/profiler.py:1000 in public method `increment_step`:
        D205: 1 blank line required between summary line and description (found 0)
torch/autograd/profiler.py:1023 in public method `current_step`:
        D102: Missing docstring in public method
37
```

**After: 27**

```
torch/autograd/profiler.py:1 at module level:
        D100: Missing docstring in public module
torch/autograd/profiler.py:176 in public method `__init__`:
        D107: Missing docstring in __init__
torch/autograd/profiler.py:262 in public method `config`:
        D102: Missing docstring in public method
torch/autograd/profiler.py:273 in public method `__enter__`:
        D105: Missing docstring in magic method
torch/autograd/profiler.py:291 in public method `__exit__`:
        D105: Missing docstring in magic method
torch/autograd/profiler.py:309 in public method `__repr__`:
        D105: Missing docstring in magic method
torch/autograd/profiler.py:314 in public method `__str__`:
        D105: Missing docstring in magic method
torch/autograd/profiler.py:323 in public method `table`:
        D102: Missing docstring in public method
torch/autograd/profiler.py:347 in public method `export_chrome_trace`:
        D102: Missing docstring in public method
torch/autograd/profiler.py:356 in public method `export_stacks`:
        D102: Missing docstring in public method
torch/autograd/profiler.py:362 in public method `key_averages`:
        D102: Missing docstring in public method
torch/autograd/profiler.py:369 in public method `total_average`:
        D102: Missing docstring in public method
torch/autograd/profiler.py:593 in public method `__init__`:
        D107: Missing docstring in __init__
torch/autograd/profiler.py:604 in public method `__enter__`:
        D105: Missing docstring in magic method
torch/autograd/profiler.py:610 in public method `__exit__`:
        D105: Missing docstring in magic method
torch/autograd/profiler.py:708 in public method `__init__`:
        D107: Missing docstring in __init__
torch/autograd/profiler.py:713 in public method `__enter__`:
        D105: Missing docstring in magic method
torch/autograd/profiler.py:734 in public method `__exit__`:
        D105: Missing docstring in magic method
torch/autograd/profiler.py:827 in public method `__init__`:
        D107: Missing docstring in __init__
torch/autograd/profiler.py:832 in public method `__enter__`:
        D105: Missing docstring in magic method
torch/autograd/profiler.py:854 in public method `__exit__`:
        D105: Missing docstring in magic method
torch/autograd/profiler.py:875 in public method `__init__`:
        D107: Missing docstring in __init__
torch/autograd/profiler.py:878 in public method `see`:
        D102: Missing docstring in public method
torch/autograd/profiler.py:884 in public function `parse_nvprof_trace`:
        D103: Missing docstring in public function
torch/autograd/profiler.py:993 in public method `init_step_count`:
        D102: Missing docstring in public method
torch/autograd/profiler.py:997 in public method `erase_step_count`:
        D102: Missing docstring in public method
torch/autograd/profiler.py:1025 in public method `current_step`:
        D102: Missing docstring in public method
27
```

- `torch/autograd/graph.py` </br>
**Before: 22**

```
torch/autograd/graph.py:1 at module level:
        D100: Missing docstring in public module
torch/autograd/graph.py:24 in public class `Node`:
        D101: Missing docstring in public class
torch/autograd/graph.py:27 in public method `name`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/autograd/graph.py:42 in public method `next_functions`:
        D102: Missing docstring in public method
torch/autograd/graph.py:47 in public method `metadata`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/autograd/graph.py:56 in public method `register_hook`:
        D401: First line should be in imperative mood (perhaps 'Register', not 'Registers')
torch/autograd/graph.py:94 in public method `register_prehook`:
        D401: First line should be in imperative mood (perhaps 'Register', not 'Registers')
torch/autograd/graph.py:129 in public method `__subclasshook__`:
        D105: Missing docstring in magic method
torch/autograd/graph.py:147 in public function `get_gradient_edge`:
        D205: 1 blank line required between summary line and description (found 0)
torch/autograd/graph.py:147 in public function `get_gradient_edge`:
        D400: First line should end with a period (not 'f')
torch/autograd/graph.py:147 in public function `get_gradient_edge`:
        D401: First line should be in imperative mood; try rephrasing (found 'This')
torch/autograd/graph.py:166 in public function `increment_version`:
        D205: 1 blank line required between summary line and description (found 0)
torch/autograd/graph.py:166 in public function `increment_version`:
        D400: First line should end with a period (not 'd')
torch/autograd/graph.py:166 in public function `increment_version`:
        D401: First line should be in imperative mood; try rephrasing (found 'This')
torch/autograd/graph.py:243 in public method `__init__`:
        D107: Missing docstring in __init__
torch/autograd/graph.py:251 in public method `__enter__`:
        D105: Missing docstring in magic method
torch/autograd/graph.py:256 in public method `__exit__`:
        D105: Missing docstring in magic method
torch/autograd/graph.py:261 in public class `save_on_cpu`:
        D205: 1 blank line required between summary line and description (found 0)
torch/autograd/graph.py:261 in public class `save_on_cpu`:
        D400: First line should end with a period (not 'e')
torch/autograd/graph.py:303 in public method `__init__`:
        D107: Missing docstring in __init__
torch/autograd/graph.py:365 in public function `register_multi_grad_hook`:
        D401: First line should be in imperative mood (perhaps 'Register', not 'Registers')
torch/autograd/graph.py:588 in public function `allow_mutation_on_saved_tensors`:
        D400: First line should end with a period (not 'd')
22
```

**After: 8**

```
torch/autograd/graph.py:1 at module level:
        D100: Missing docstring in public module
torch/autograd/graph.py:24 in public class `Node`:
        D101: Missing docstring in public class
torch/autograd/graph.py:42 in public method `next_functions`:
        D102: Missing docstring in public method
torch/autograd/graph.py:129 in public method `__subclasshook__`:
        D105: Missing docstring in magic method
torch/autograd/graph.py:244 in public method `__init__`:
        D107: Missing docstring in __init__
torch/autograd/graph.py:252 in public method `__enter__`:
        D105: Missing docstring in magic method
torch/autograd/graph.py:257 in public method `__exit__`:
        D105: Missing docstring in magic method
torch/autograd/graph.py:303 in public method `__init__`:
        D107: Missing docstring in __init__
8
```

- `torch/multiprocessing/pool.py` </br>
**Before: 6**

```
torch/multiprocessing/pool.py:1 at module level:
        D100: Missing docstring in public module
torch/multiprocessing/pool.py:7 in public function `clean_worker`:
        D103: Missing docstring in public function
torch/multiprocessing/pool.py:18 in public class `Pool`:
        D205: 1 blank line required between summary line and description (found 0)
torch/multiprocessing/pool.py:18 in public class `Pool`:
        D209: Multi-line docstring closing quotes should be on a separate line
torch/multiprocessing/pool.py:29 in private method `_repopulate_pool`:
        D205: 1 blank line required between summary line and description (found 0)
torch/multiprocessing/pool.py:29 in private method `_repopulate_pool`:
        D400: First line should end with a period (not ',')
6
```

**After: 2**

```
torch/multiprocessing/pool.py:1 at module level:
        D100: Missing docstring in public module
torch/multiprocessing/pool.py:7 in public function `clean_worker`:
        D103: Missing docstring in public function
2
```

- `torch/multiprocessing/queue.py` </br>
**Before: 11**

```
torch/multiprocessing/queue.py:1 at module level:
        D100: Missing docstring in public module
torch/multiprocessing/queue.py:8 in public class `ConnectionWrapper`:
        D205: 1 blank line required between summary line and description (found 0)
torch/multiprocessing/queue.py:8 in public class `ConnectionWrapper`:
        D209: Multi-line docstring closing quotes should be on a separate line
torch/multiprocessing/queue.py:8 in public class `ConnectionWrapper`:
        D400: First line should end with a period (not 'o')
torch/multiprocessing/queue.py:11 in public method `__init__`:
        D107: Missing docstring in __init__
torch/multiprocessing/queue.py:14 in public method `send`:
        D102: Missing docstring in public method
torch/multiprocessing/queue.py:19 in public method `recv`:
        D102: Missing docstring in public method
torch/multiprocessing/queue.py:23 in public method `__getattr__`:
        D105: Missing docstring in magic method
torch/multiprocessing/queue.py:29 in public class `Queue`:
        D101: Missing docstring in public class
torch/multiprocessing/queue.py:30 in public method `__init__`:
        D107: Missing docstring in __init__
torch/multiprocessing/queue.py:38 in public class `SimpleQueue`:
        D101: Missing docstring in public class
11
```

**After: 8**

```
torch/multiprocessing/queue.py:1 at module level:
        D100: Missing docstring in public module
torch/multiprocessing/queue.py:10 in public method `__init__`:
        D107: Missing docstring in __init__
torch/multiprocessing/queue.py:13 in public method `send`:
        D102: Missing docstring in public method
torch/multiprocessing/queue.py:18 in public method `recv`:
        D102: Missing docstring in public method
torch/multiprocessing/queue.py:22 in public method `__getattr__`:
        D105: Missing docstring in magic method
torch/multiprocessing/queue.py:28 in public class `Queue`:
        D101: Missing docstring in public class
torch/multiprocessing/queue.py:29 in public method `__init__`:
        D107: Missing docstring in __init__
torch/multiprocessing/queue.py:37 in public class `SimpleQueue`:
        D101: Missing docstring in public class
8
```

- `torch/multiprocessing/reductions.py` </br>
**Before: 31**

```
torch/multiprocessing/reductions.py:1 at module level:
        D100: Missing docstring in public module
torch/multiprocessing/reductions.py:24 in public class `StorageWeakRef`:
        D209: Multi-line docstring closing quotes should be on a separate line
torch/multiprocessing/reductions.py:31 in public method `__init__`:
        D107: Missing docstring in __init__
torch/multiprocessing/reductions.py:38 in public method `from_weakref`:
        D102: Missing docstring in public method
torch/multiprocessing/reductions.py:44 in public method `expired`:
        D102: Missing docstring in public method
torch/multiprocessing/reductions.py:47 in public method `__del__`:
        D105: Missing docstring in magic method
torch/multiprocessing/reductions.py:50 in public method `__hash__`:
        D105: Missing docstring in magic method
torch/multiprocessing/reductions.py:53 in public method `__eq__`:
        D105: Missing docstring in magic method
torch/multiprocessing/reductions.py:60 in public class `SharedCache`:
        D400: First line should end with a period (not 'f')
torch/multiprocessing/reductions.py:62 in public method `__init__`:
        D107: Missing docstring in __init__
torch/multiprocessing/reductions.py:75 in public method `get`:
        D102: Missing docstring in public method
torch/multiprocessing/reductions.py:79 in public method `__setitem__`:
        D105: Missing docstring in magic method
torch/multiprocessing/reductions.py:85 in public method `free_dead_references`:
        D102: Missing docstring in public method
torch/multiprocessing/reductions.py:99 in public function `rebuild_event`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:103 in public function `reduce_event`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:108 in public function `rebuild_tensor`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:121 in public function `rebuild_cuda_tensor`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:189 in public function `reduce_tensor`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:347 in public function `rebuild_nested_tensor`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:364 in public function `reduce_nested_tensor`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:389 in public function `fd_id`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:397 in public function `storage_from_cache`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:404 in public function `rebuild_storage_fd`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:417 in public function `rebuild_storage_filename`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:437 in public function `rebuild_storage_empty`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:441 in public function `rebuild_typed_storage`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:446 in public function `reduce_typed_storage`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:450 in public function `rebuild_typed_storage_child`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:455 in public function `reduce_typed_storage_child`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:459 in public function `reduce_storage`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:488 in public function `init_reductions`:
        D103: Missing docstring in public function
31
```

**After: 29**

```
torch/multiprocessing/reductions.py:1 at module level:
        D100: Missing docstring in public module
torch/multiprocessing/reductions.py:32 in public method `__init__`:
        D107: Missing docstring in __init__
torch/multiprocessing/reductions.py:39 in public method `from_weakref`:
        D102: Missing docstring in public method
torch/multiprocessing/reductions.py:45 in public method `expired`:
        D102: Missing docstring in public method
torch/multiprocessing/reductions.py:48 in public method `__del__`:
        D105: Missing docstring in magic method
torch/multiprocessing/reductions.py:51 in public method `__hash__`:
        D105: Missing docstring in magic method
torch/multiprocessing/reductions.py:54 in public method `__eq__`:
        D105: Missing docstring in magic method
torch/multiprocessing/reductions.py:63 in public method `__init__`:
        D107: Missing docstring in __init__
torch/multiprocessing/reductions.py:76 in public method `get`:
        D102: Missing docstring in public method
torch/multiprocessing/reductions.py:80 in public method `__setitem__`:
        D105: Missing docstring in magic method
torch/multiprocessing/reductions.py:86 in public method `free_dead_references`:
        D102: Missing docstring in public method
torch/multiprocessing/reductions.py:100 in public function `rebuild_event`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:104 in public function `reduce_event`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:109 in public function `rebuild_tensor`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:122 in public function `rebuild_cuda_tensor`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:190 in public function `reduce_tensor`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:348 in public function `rebuild_nested_tensor`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:365 in public function `reduce_nested_tensor`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:390 in public function `fd_id`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:398 in public function `storage_from_cache`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:405 in public function `rebuild_storage_fd`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:418 in public function `rebuild_storage_filename`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:438 in public function `rebuild_storage_empty`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:442 in public function `rebuild_typed_storage`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:447 in public function `reduce_typed_storage`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:451 in public function `rebuild_typed_storage_child`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:456 in public function `reduce_typed_storage_child`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:460 in public function `reduce_storage`:
        D103: Missing docstring in public function
torch/multiprocessing/reductions.py:489 in public function `init_reductions`:
        D103: Missing docstring in public function
29
```

- `torch/multiprocessing/spawn.py` </br>
**Before: 19**

```
torch/multiprocessing/spawn.py:1 at module level:
        D100: Missing docstring in public module
torch/multiprocessing/spawn.py:11 in public class `ProcessException`:
        D101: Missing docstring in public class
torch/multiprocessing/spawn.py:14 in public method `__init__`:
        D107: Missing docstring in __init__
torch/multiprocessing/spawn.py:20 in public method `__reduce__`:
        D105: Missing docstring in magic method
torch/multiprocessing/spawn.py:25 in public class `ProcessRaisedException`:
        D205: 1 blank line required between summary line and description (found 0)
torch/multiprocessing/spawn.py:25 in public class `ProcessRaisedException`:
        D400: First line should end with a period (not 'n')
torch/multiprocessing/spawn.py:30 in public method `__init__`:
        D107: Missing docstring in __init__
torch/multiprocessing/spawn.py:40 in public class `ProcessExitedException`:
        D205: 1 blank line required between summary line and description (found 0)
torch/multiprocessing/spawn.py:40 in public class `ProcessExitedException`:
        D400: First line should end with a period (not 'l')
torch/multiprocessing/spawn.py:47 in public method `__init__`:
        D107: Missing docstring in __init__
torch/multiprocessing/spawn.py:59 in public method `__reduce__`:
        D105: Missing docstring in magic method
torch/multiprocessing/spawn.py:85 in public class `ProcessContext`:
        D101: Missing docstring in public class
torch/multiprocessing/spawn.py:86 in public method `__init__`:
        D107: Missing docstring in __init__
torch/multiprocessing/spawn.py:93 in public method `pids`:
        D102: Missing docstring in public method
torch/multiprocessing/spawn.py:97 in public method `join`:
        D205: 1 blank line required between summary line and description (found 0)
torch/multiprocessing/spawn.py:97 in public method `join`:
        D401: First line should be in imperative mood (perhaps 'Try', not 'Tries')
torch/multiprocessing/spawn.py:166 in public class `SpawnContext`:
        D101: Missing docstring in public class
torch/multiprocessing/spawn.py:167 in public method `__init__`:
        D107: Missing docstring in __init__
torch/multiprocessing/spawn.py:180 in public function `start_processes`:
        D103: Missing docstring in public function
19
```

**After: 13**

```
torch/multiprocessing/spawn.py:1 at module level:
        D100: Missing docstring in public module
torch/multiprocessing/spawn.py:11 in public class `ProcessException`:
        D101: Missing docstring in public class
torch/multiprocessing/spawn.py:14 in public method `__init__`:
        D107: Missing docstring in __init__
torch/multiprocessing/spawn.py:20 in public method `__reduce__`:
        D105: Missing docstring in magic method
torch/multiprocessing/spawn.py:27 in public method `__init__`:
        D107: Missing docstring in __init__
torch/multiprocessing/spawn.py:41 in public method `__init__`:
        D107: Missing docstring in __init__
torch/multiprocessing/spawn.py:53 in public method `__reduce__`:
        D105: Missing docstring in magic method
torch/multiprocessing/spawn.py:79 in public class `ProcessContext`:
        D101: Missing docstring in public class
torch/multiprocessing/spawn.py:80 in public method `__init__`:
        D107: Missing docstring in __init__
torch/multiprocessing/spawn.py:87 in public method `pids`:
        D102: Missing docstring in public method
torch/multiprocessing/spawn.py:161 in public class `SpawnContext`:
        D101: Missing docstring in public class
torch/multiprocessing/spawn.py:162 in public method `__init__`:
        D107: Missing docstring in __init__
torch/multiprocessing/spawn.py:175 in public function `start_processes`:
        D103: Missing docstring in public function
13
```

- `torch/multiprocessing/__init__.py` </br>
**Before: 0**

```
torch/multiprocessing/__init__.py:1 at module level:
        D205: 1 blank line required between summary line and description (found 0)
torch/multiprocessing/__init__.py:1 at module level:
        D400: First line should end with a period (not '`')
torch/multiprocessing/__init__.py:57 in public function `set_sharing_strategy`:
        D401: First line should be in imperative mood (perhaps 'Set', not 'Sets')
torch/multiprocessing/__init__.py:69 in public function `get_sharing_strategy`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/multiprocessing/__init__.py:74 in public function `get_all_sharing_strategies`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
5
```

**After: 0**

- `torch/nn/__init__.py` </br>
**Before: 3**

```
torch/nn/__init__.py:1 at module level:
        D104: Missing docstring in public package
torch/nn/__init__.py:14 in public function `factory_kwargs`:
        D205: 1 blank line required between summary line and description (found 0)
torch/nn/__init__.py:14 in public function `factory_kwargs`:
        D400: First line should end with a period (not 'd')
3
```

**After: 1**

```
torch/nn/__init__.py:1 at module level:
        D104: Missing docstring in public package
1
```

- `torch/nn/cpp.py` </br>
**Before: 16**

```
torch/nn/cpp.py:7 in public class `OrderedDictWrapper`:
        D205: 1 blank line required between summary line and description (found 0)
torch/nn/cpp.py:7 in public class `OrderedDictWrapper`:
        D400: First line should end with a period (not 'e')
torch/nn/cpp.py:16 in public method `__init__`:
        D107: Missing docstring in __init__
torch/nn/cpp.py:21 in public method `cpp_dict`:
        D102: Missing docstring in public method
torch/nn/cpp.py:27 in public method `items`:
        D102: Missing docstring in public method
torch/nn/cpp.py:30 in public method `keys`:
        D102: Missing docstring in public method
torch/nn/cpp.py:33 in public method `values`:
        D102: Missing docstring in public method
torch/nn/cpp.py:36 in public method `__iter__`:
        D105: Missing docstring in magic method
torch/nn/cpp.py:39 in public method `__len__`:
        D105: Missing docstring in magic method
torch/nn/cpp.py:42 in public method `__contains__`:
        D105: Missing docstring in magic method
torch/nn/cpp.py:45 in public method `__getitem__`:
        D105: Missing docstring in magic method
torch/nn/cpp.py:50 in public class `ModuleWrapper`:
        D205: 1 blank line required between summary line and description (found 0)
torch/nn/cpp.py:50 in public class `ModuleWrapper`:
        D400: First line should end with a period (not 'd')
torch/nn/cpp.py:55 in public method `__init__`:
        D107: Missing docstring in __init__
torch/nn/cpp.py:83 in public method `training`:
        D102: Missing docstring in public method
torch/nn/cpp.py:90 in public method `__repr__`:
        D105: Missing docstring in magic method
16
```

**After: 12**

```
torch/nn/cpp.py:16 in public method `__init__`:
        D107: Missing docstring in __init__
torch/nn/cpp.py:21 in public method `cpp_dict`:
        D102: Missing docstring in public method
torch/nn/cpp.py:27 in public method `items`:
        D102: Missing docstring in public method
torch/nn/cpp.py:30 in public method `keys`:
        D102: Missing docstring in public method
torch/nn/cpp.py:33 in public method `values`:
        D102: Missing docstring in public method
torch/nn/cpp.py:36 in public method `__iter__`:
        D105: Missing docstring in magic method
torch/nn/cpp.py:39 in public method `__len__`:
        D105: Missing docstring in magic method
torch/nn/cpp.py:42 in public method `__contains__`:
        D105: Missing docstring in magic method
torch/nn/cpp.py:45 in public method `__getitem__`:
        D105: Missing docstring in magic method
torch/nn/cpp.py:52 in public method `__init__`:
        D107: Missing docstring in __init__
torch/nn/cpp.py:80 in public method `training`:
        D102: Missing docstring in public method
torch/nn/cpp.py:87 in public method `__repr__`:
        D105: Missing docstring in magic method
12
```

- `torch/nn/grad.py` </br>
**Before: 10**

```
torch/nn/grad.py:1 at module level:
        D400: First line should end with a period (not 'e')
torch/nn/grad.py:8 in public function `conv1d_input`:
        D205: 1 blank line required between summary line and description (found 0)
torch/nn/grad.py:8 in public function `conv1d_input`:
        D401: First line should be in imperative mood (perhaps 'Compute', not 'Computes')
torch/nn/grad.py:40 in public function `conv1d_weight`:
        D401: First line should be in imperative mood (perhaps 'Compute', not 'Computes')
torch/nn/grad.py:71 in public function `conv2d_input`:
        D205: 1 blank line required between summary line and description (found 0)
torch/nn/grad.py:71 in public function `conv2d_input`:
        D401: First line should be in imperative mood (perhaps 'Compute', not 'Computes')
torch/nn/grad.py:103 in public function `conv2d_weight`:
        D401: First line should be in imperative mood (perhaps 'Compute', not 'Computes')
torch/nn/grad.py:134 in public function `conv3d_input`:
        D205: 1 blank line required between summary line and description (found 0)
torch/nn/grad.py:134 in public function `conv3d_input`:
        D401: First line should be in imperative mood (perhaps 'Compute', not 'Computes')
torch/nn/grad.py:166 in public function `conv3d_weight`:
        D401: First line should be in imperative mood (perhaps 'Compute', not 'Computes')
10
```

**After: 0**

- `torch/nn/parameter.py` </br>
**Before: 17**

```
torch/nn/parameter.py:1 at module level:
        D100: Missing docstring in public module
torch/nn/parameter.py:14 in public class `Parameter`:
        D204: 1 blank line required after class docstring (found 0)
torch/nn/parameter.py:33 in public method `__new__`:
        D102: Missing docstring in public method
torch/nn/parameter.py:54 in public method `__deepcopy__`:
        D105: Missing docstring in magic method
torch/nn/parameter.py:62 in public method `__repr__`:
        D105: Missing docstring in magic method
torch/nn/parameter.py:65 in public method `__reduce_ex__`:
        D105: Missing docstring in magic method
torch/nn/parameter.py:84 in public class `UninitializedTensorMixin`:
        D101: Missing docstring in public class
torch/nn/parameter.py:105 in public method `materialize`:
        D205: 1 blank line required between summary line and description (found 0)
torch/nn/parameter.py:125 in public method `shape`:
        D102: Missing docstring in public method
torch/nn/parameter.py:132 in public method `share_memory_`:
        D102: Missing docstring in public method
torch/nn/parameter.py:138 in public method `__repr__`:
        D105: Missing docstring in magic method
torch/nn/parameter.py:141 in public method `__reduce_ex__`:
        D105: Missing docstring in magic method
torch/nn/parameter.py:149 in public method `__torch_function__`:
        D105: Missing docstring in magic method
torch/nn/parameter.py:164 in public function `is_lazy`:
        D103: Missing docstring in public function
torch/nn/parameter.py:186 in public method `__new__`:
        D102: Missing docstring in public method
torch/nn/parameter.py:191 in public method `__deepcopy__`:
        D105: Missing docstring in magic method
torch/nn/parameter.py:217 in public method `__new__`:
        D102: Missing docstring in public method
17
```

**After: 15**

```
torch/nn/parameter.py:1 at module level:
        D100: Missing docstring in public module
torch/nn/parameter.py:34 in public method `__new__`:
        D102: Missing docstring in public method
torch/nn/parameter.py:55 in public method `__deepcopy__`:
        D105: Missing docstring in magic method
torch/nn/parameter.py:63 in public method `__repr__`:
        D105: Missing docstring in magic method
torch/nn/parameter.py:66 in public method `__reduce_ex__`:
        D105: Missing docstring in magic method
torch/nn/parameter.py:85 in public class `UninitializedTensorMixin`:
        D101: Missing docstring in public class
torch/nn/parameter.py:127 in public method `shape`:
        D102: Missing docstring in public method
torch/nn/parameter.py:134 in public method `share_memory_`:
        D102: Missing docstring in public method
torch/nn/parameter.py:140 in public method `__repr__`:
        D105: Missing docstring in magic method
torch/nn/parameter.py:143 in public method `__reduce_ex__`:
        D105: Missing docstring in magic method
torch/nn/parameter.py:151 in public method `__torch_function__`:
        D105: Missing docstring in magic method
torch/nn/parameter.py:166 in public function `is_lazy`:
        D103: Missing docstring in public function
torch/nn/parameter.py:188 in public method `__new__`:
        D102: Missing docstring in public method
torch/nn/parameter.py:193 in public method `__deepcopy__`:
        D105: Missing docstring in magic method
torch/nn/parameter.py:219 in public method `__new__`:
        D102: Missing docstring in public method
15
```


cc @svekars @carljparker