### PR TITLE
[export] Use argument shapes when tracing

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -649,6 +649,16 @@ class TestExport(TestCase):
         roundtrip_spec = treespec_loads(treespec_dumps(spec))
         self.assertEqual(roundtrip_spec, spec)
 
+    def test_changing_shapes(self):
+        def f(x, y):
+            return x + y
+
+        gm = capture_pre_autograd_graph(f, (torch.randn(3, 3), torch.randn(3, 3)))
+        ep = export(gm, (torch.randn(2, 3), torch.randn(2, 3)))
+        for node in ep.graph.nodes:
+            if node.op == "placeholder":
+                self.assertEqual(node.meta["val"].shape[0], 2)
+
     def test_pytree_register_nested_data_class(self):
 
         @dataclass


### PR DESCRIPTION
There's a issue if a user calls capture_pre_autograd_graph with a set of inputs with batch size = 2, does quantization, and then calls export with a set of inputs with batch size = 1. In this case, the graph still has the original inputs (with batch size 2) in the metadata. This seems like a bug to me? We should be retracing with the shapes that were passed in, right?

cc @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan @suo @ydwu4