### PR TITLE
Fix visualize_overlap for Inductor comm reordering

### DIFF
--- a/torch/_inductor/comms.py
+++ b/torch/_inductor/comms.py
@@ -291,11 +291,16 @@ def node_summary(snode):
     detail = ""
     if isinstance(snode.node, ir.ExternKernelOut):
         detail = f" ({snode.node.kernel})"
-    out_tensor_info = (
-        f" (size={snode.node.layout.size}, stride={snode.node.layout.stride})"
-    )
+    out_tensor_info = ""
+    if hasattr(snode.node, "layout") and hasattr(snode.node.layout, "size") and hasattr(snode.node.layout, "stride"):
+        out_tensor_info = (
+            f" (size={snode.node.layout.size}, stride={snode.node.layout.stride})"
+        )
+    node_name = ""
+    if hasattr(snode.node, "name"):
+        node_name = snode.node.name
     return (
-        f"{snode.node.__class__.__name__}{detail}{out_tensor_info} ({snode.node.name})"
+        f"{snode.node.__class__.__name__}{detail}{out_tensor_info} ({node_name})"
     )
 
 
@@ -317,7 +322,7 @@ def visualize_overlap(order):
         else:  # cur_comm_node is not None
             if isinstance(snode.node, ir.CollectiveKernel):
                 raise Exception(
-                    "Found two collectives running at the same time, which is unexpected. "
+                    "Found two collectives running at the same time. "
                     "`visualize_overlap` needs to be updated to handle this case"
                 )
             elif isinstance(snode.node, ir.Wait):  # end of this comm op
@@ -341,11 +346,17 @@ def reorder_compute_and_comm_for_overlap(
             overlap_log.debug(
                 f"==== Visualize overlap before reordering pass {p} ===="  # noqa: G004
             )
-            visualize_overlap(order)
+            try:
+                visualize_overlap(order)
+            except Exception as e:
+                overlap_log.debug(str(e))
         order = p(order)  # type: ignore[operator]
         if torch.distributed.get_rank() == 0:
             overlap_log.debug(
                 f"==== Visualize overlap after reordering pass {p} ===="  # noqa: G004
             )
-            visualize_overlap(order)
+            try:
+                visualize_overlap(order)
+            except Exception as e:
+                overlap_log.debug(str(e))
     return order

--- a/torch/_inductor/comms.py
+++ b/torch/_inductor/comms.py
@@ -292,16 +292,18 @@ def node_summary(snode):
     if isinstance(snode.node, ir.ExternKernelOut):
         detail = f" ({snode.node.kernel})"
     out_tensor_info = ""
-    if hasattr(snode.node, "layout") and hasattr(snode.node.layout, "size") and hasattr(snode.node.layout, "stride"):
+    if (
+        hasattr(snode.node, "layout")
+        and hasattr(snode.node.layout, "size")
+        and hasattr(snode.node.layout, "stride")
+    ):
         out_tensor_info = (
             f" (size={snode.node.layout.size}, stride={snode.node.layout.stride})"
         )
     node_name = ""
     if hasattr(snode.node, "name"):
         node_name = snode.node.name
-    return (
-        f"{snode.node.__class__.__name__}{detail}{out_tensor_info} ({node_name})"
-    )
+    return f"{snode.node.__class__.__name__}{detail}{out_tensor_info} ({node_name})"
 
 
 def visualize_overlap(order):


### PR DESCRIPTION
The following assumptions are not always valid and need checking:
1. `snode.node` exists
2. `snode.node.layout.size` exists
3. `snode.node.layout.stride` exists
4. `snode.node.name` exists

Also there is no guarantee that there won't be two collectives running at the same time. But it's hard to visualize the overlap in that case. So disable the visualization for that case for now.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler