### PR TITLE
Add file name and size to the serialization metadata logging

### DIFF
--- a/caffe2/serialize/inline_container_test.cc
+++ b/caffe2/serialize/inline_container_test.cc
@@ -1,5 +1,6 @@
 #include <array>
 #include <cstdio>
+#include <cstring>
 #include <string>
 
 #include <gtest/gtest.h>
@@ -408,9 +409,13 @@ TEST(PytorchStreamWriterAndReader, LogAPIUsageMetadata) {
   ASSERT_EQ(logs.size(), 2);
   std::map<std::string, std::map<std::string, std::string>> expected_logs = {
       {"pytorch.stream.writer.metadata",
-       {{"serialization_id", writer.serializationId()}}},
+       {{"serialization_id", writer.serializationId()},
+       {"file_name", "archive"},
+       {"file_size", str(oss.str().length())}}},
       {"pytorch.stream.reader.metadata",
-       {{"serialization_id", writer.serializationId()}}}
+       {{"serialization_id", writer.serializationId()},
+       {"file_name", "archive"},
+       {"file_size", str(iss.str().length())}}}
   };
   ASSERT_EQ(expected_logs, logs);
 

--- a/torch/package/package_importer.py
+++ b/torch/package/package_importer.py
@@ -101,7 +101,10 @@ class PackageImporter(Importer):
 
         torch._C._log_api_usage_metadata(
             "torch.package.PackageImporter.metadata",
-            {"serialization_id": self.zip_reader.serialization_id()},
+            {
+                "serialization_id": self.zip_reader.serialization_id(),
+                "file_name": self.filename,
+            },
         )
 
         self.root = _PackageNode(None)


### PR DESCRIPTION
Summary:
To be able to get more info on serialization/deserialization events, adding these two files to the metadata logging.
- file_name
- file_size

Test Plan: buck2 test mode/dev caffe2/caffe2/serialize:inline_container_test

Reviewed By: davidberard98

Differential Revision: D51040426


