### PR TITLE
`c10::DriverAPI` Try opening libcuda.so.1

### DIFF
--- a/c10/cuda/driver_api.cpp
+++ b/c10/cuda/driver_api.cpp
@@ -10,7 +10,7 @@ namespace {
 DriverAPI create_driver_api() {
 #define OPEN_LIBRARIES(name, n)               \
   void* handle_##n = dlopen(name, RTLD_LAZY); \
-  TORCH_INTERNAL_ASSERT(handle_##n);
+  TORCH_INTERNAL_ASSERT(handle_##n, "Can't open ", #name, ": ", dlerror());
 
   C10_FORALL_DRIVER_LIBRARIES(OPEN_LIBRARIES)
 #undef OPEN_LIBRARIES
@@ -18,7 +18,7 @@ DriverAPI create_driver_api() {
 
 #define LOOKUP_ENTRY(name, n)                              \
   r.name##_ = ((decltype(&name))dlsym(handle_##n, #name)); \
-  TORCH_INTERNAL_ASSERT(r.name##_)
+  TORCH_INTERNAL_ASSERT(r.name##_, "Can't find ", #name, ": ", dlerror())
   C10_FORALL_DRIVER_API(LOOKUP_ENTRY)
 #undef LOOKUP_ENTRY
   return r;

--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -19,7 +19,7 @@
   } while (0)
 
 #define C10_FORALL_DRIVER_LIBRARIES(_) \
-  _("libcuda.so", 0)                   \
+  _("libcuda.so.1", 0)                 \
   _("libnvidia-ml.so.1", 1)
 
 #define C10_FORALL_DRIVER_API(_)         \


### PR DESCRIPTION
As `libcuda.so` is only installed on dev environment (i.e. when CUDAToolkit is installed), while `libcuda.so.1` is part of NVIDIA driver.
Also, this will keep it aligned with https://github.com/pytorch/pytorch/blob/a5cb8f75a7f991212fbc6d049e0bc2f9f48b07f8/aten/src/ATen/cuda/detail/LazyNVRTC.cpp#L16
Better errors in `c10::DriverAPI` on `dlopn`/`dlsym` failures
    
Cherry-pick of  following PR into release/2.1 branch
- Better errors in `c10::DriverAPI` on `dl` failure (#112995)
- `c10::DriverAPI` Try opening libcuda.so.1 (#112996)

(cherry picked from commit 3be0e1cd587ece8fa54a3a4da8ae68225b9cbb9b)
(cherry picked from commit d0a80f8af19625cbd0b3eb74a1970ac5b7c5439a)

