### PR TITLE
[inductor][fx pass] Fix a bug for the merge_stack_tahn_unbind pattern

### DIFF
--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -1270,6 +1270,8 @@ def merge_stack_tahn_unbind(match: Match, split_sections: List[int], dim: int):
             for arg in user.args[0]:
                 indices.append(arg.args[1])
                 split_sections_for_unbind.append(split_sections[arg.args[1]])
+            # indices may not be necessarily sorted, we sort them first
+            indices.sort()
             # update the arg of stack user, only keep the first getitem
             user.update_arg(0, user.args[0][0])
             # calculate the fused tensor sizes in the indices


### PR DESCRIPTION
Summary:
Context:
https://fb.workplace.com/groups/1075192433118967/permalink/1328366351134906/

Test Plan:
local reproduce igctr:
```
buck2 run mode/opt //scripts/jackiexu0313/pt2:local_model_with_pt2 -- --test_mode split_batch-group
```
P874994427

Differential Revision: D51052304




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler