### PR TITLE
[decomp] Fix _scaled_dot_product_flash_attention decomposition bug

### DIFF
--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -897,6 +897,45 @@ class DecompOneOffTests(TestCase):
         self.assertTrue(torch.allclose(ref[0], res[0]))
         self.assertTrue(torch.allclose(ref[1], res[1]))
 
+    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
+    @onlyNativeDeviceTypes
+    @skipIfCrossRef
+    def test_sdpa(self, device):
+        from torch.fx.experimental.proxy_tensor import make_fx
+        from torch._decomp import get_decompositions
+        from torch.nn import functional as F
+
+        class ScaledDotProductAttention(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, query_layer, key_layer, value_layer):
+                attn_output = F.scaled_dot_product_attention(
+                    query_layer, key_layer, value_layer, None, dropout_p=0.0, is_causal=True
+                )
+                return attn_output
+
+
+        query_layer = torch.randn(1, 128, 100, 64, device=device)
+        key_layer = torch.randn(1, 128, 100, 64, device=device)
+        value_layer = torch.randn(1, 128, 100, 64, device=device)
+
+        attention = ScaledDotProductAttention()
+
+        fx_g = make_fx(
+            attention,
+            decomposition_table=get_decompositions(
+                [
+                    torch.ops.aten._scaled_dot_product_flash_attention.default,
+                ]
+            ),
+        )(query_layer, key_layer, value_layer)
+
+        eager_res = F.scaled_dot_product_attention(
+            query_layer, key_layer, value_layer, None, dropout_p=0.0, is_causal=True
+        )
+        self.assertTrue(torch.allclose(fx_g[0], eager_res[0]))
+
 
 instantiate_device_type_tests(DecompOneOffTests, globals())
 

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -921,7 +921,6 @@ class DecompOneOffTests(TestCase):
         value_layer = torch.randn(1, 128, 100, 64, device=device)
 
         attention = ScaledDotProductAttention()
-
         fx_g = make_fx(
             attention,
             decomposition_table=get_decompositions(
@@ -931,10 +930,11 @@ class DecompOneOffTests(TestCase):
             ),
         )(query_layer, key_layer, value_layer)
 
+        compiled_res = fx_g(query_layer, key_layer, value_layer)
         eager_res = F.scaled_dot_product_attention(
             query_layer, key_layer, value_layer, None, dropout_p=0.0, is_causal=True
         )
-        self.assertTrue(torch.allclose(fx_g[0], eager_res[0]))
+        self.assertTrue(torch.allclose(compiled_res, eager_res, atol=1e-6, rtol=1e-5))
 
 
 instantiate_device_type_tests(DecompOneOffTests, globals())

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -4091,7 +4091,6 @@ def scaled_dot_product_flash_attention(
     query: Tensor,
     key: Tensor,
     value: Tensor,
-    attn_mask: Optional[Tensor] = None,
     dropout_p: float = 0.0,
     is_causal: bool = False,
     return_debug_mask: bool = False,
@@ -4140,7 +4139,7 @@ def scaled_dot_product_flash_attention(
         requires_grad=query.requires_grad,
     )
     output, _ = aten._scaled_dot_product_attention_math.default(
-        query, key, value, attn_mask, dropout_p, is_causal, None, scale=scale
+        query, key, value, None, dropout_p, is_causal, None, scale=scale
     )
     # Why this change?
     # In pre-dispatch export scaled_dot_product_attention is executed via

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -4112,9 +4112,11 @@ def scaled_dot_product_flash_attention(
     )
     torch._check(
         query.dim() == 4 and key.dim() == 4 and value.dim() == 4,
-        lambda: "q, k, v must be a 4 dimensional tensor",
+        lambda: f"q, k, v must be a 4 dimensional tensor, got {query.dim()}, {key.dim()}, {value.dim()}",
     )
-    torch._check(dropout_p == 0.0, lambda: "dropout probability must be zero")
+    torch._check(
+        dropout_p == 0.0, lambda: f"dropout probability must be zero, got {dropout_p}"
+    )
     torch._check(
         query.shape[3] == value.shape[3] and key.shape[3] == value.shape[3],
         lambda: "q, k, v should have the same head size",

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -82,7 +82,7 @@ std::pair<py::object, py::dict> parseIValuesToPyArgsKwargs(
   auto is_default = [&](size_t idx) -> bool {
     const auto& arg = schema.arguments()[idx];
     if (!arg.default_value().has_value()) {
-      return arguments[idx].isNone();
+      return false;
     }
     const auto& default_ivalue = *arg.default_value();
     const auto& ivalue = arguments[idx];

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -82,7 +82,7 @@ std::pair<py::object, py::dict> parseIValuesToPyArgsKwargs(
   auto is_default = [&](size_t idx) -> bool {
     const auto& arg = schema.arguments()[idx];
     if (!arg.default_value().has_value()) {
-      return false;
+      return arguments[idx].isNone();
     }
     const auto& default_ivalue = *arg.default_value();
     const auto& ivalue = arguments[idx];


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #113102

For `_scaled_dot_product_flash_attention` we don't have

`Tensor? attn_mask=None`

but `scaled_dot_product_attention` has. In the original decomp there's a
mixup where I added this argument to
`_scaled_dot_product_flash_attention`.

Fix it so that `_scaled_dot_product_flash_attention` is being decomposed correctly.

Summary:

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: