### PR TITLE
[nested tensor]add split and layer_norm_backward operations

### DIFF
--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -473,6 +473,24 @@ def prod_dim_int(func, *args, **kwargs):
 
 
 @register_jagged_func(
+    torch.ops.aten.split.Tensor, "self: jt, split_size: any, dim: any"
+)
+def split_tensor(func, *args, **kwargs):
+    _, new_kwargs = normalize_function(
+        func, args=args, kwargs=kwargs, normalize_to_only_use_kwargs=True
+    )
+
+    inp = new_kwargs.pop("input")
+
+    _wrap_jagged_dim(inp.dim(), new_kwargs["dim"], "split")
+
+    return tuple(
+        NestedTensor(values=x, **extract_kwargs(inp))
+        for x in func(inp._values, **new_kwargs)
+    )
+
+
+@register_jagged_func(
     torch.ops.aten.split_with_sizes.default, "self: jt, split_sizes: any, dim: any"
 )
 def split_with_sizes_default(func, *args, **kwargs):
@@ -481,19 +499,12 @@ def split_with_sizes_default(func, *args, **kwargs):
     )
 
     inp = new_kwargs.pop("input")
-    values = inp._values
 
-    # hack to split on the last dim
-    dim = new_kwargs["dim"]
-    if dim != -1:
-        raise RuntimeError(
-            "split_with_sizes(): only supported for NestedTensor on dim = -1 for now"
-        )
+    _wrap_jagged_dim(inp.dim(), new_kwargs["dim"], "split_with_sizes")
 
-    split_sizes = new_kwargs["split_sizes"]
     return [
         NestedTensor(values=x, **extract_kwargs(inp))
-        for x in torch.split(values, split_sizes, -1)
+        for x in func(inp._values, **new_kwargs)
     ]
 
 
@@ -728,6 +739,23 @@ def native_layer_norm_default(func, *args, **kwargs):
 
     output, mean, std = func(inp._values, **new_kwargs)
     return (NestedTensor(output, **extract_kwargs(inp)), mean, std)
+
+
+@register_jagged_func(
+    torch.ops.aten.native_layer_norm_backward.default,
+    "grad_out: jt, input: jt, normalized_shape: any, mean: any, rstd: any, weight: any?, bias: any?, output_mask: any",
+)
+def native_layer_norm_backward_default(func, *args, **kwargs):
+    _, new_kwargs = normalize_function(
+        func, args=args, kwargs=kwargs, normalize_to_only_use_kwargs=True
+    )
+    grad_out = new_kwargs.pop("grad_out")
+    inp = new_kwargs.pop("input")
+    d_input, d_gamma, d_beta = func(grad_out._values, inp._values, **new_kwargs)
+    if d_input is None:
+        return (None, d_gamma, d_beta)
+
+    return (NestedTensor(d_input, **extract_kwargs(inp)), d_gamma, d_beta)
 
 
 @register_jagged_func(torch.ops.aten.select.int, "self: jt, dim: any, index: any")


### PR DESCRIPTION
Summary:
Add split and layer_norm_backward.

Note: It is non trivial to support split_with_sizes backward so adding the split operation to support the use case in the model.

Test Plan: unit tests

Differential Revision: D51052966


