### PR TITLE
[doc] torch.tensor.geometric_, torch.tensor.uniform_ fix PMF vs PDF

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2103,7 +2103,7 @@ Fills :attr:`self` tensor with elements drawn from the geometric distribution:
 
 .. math::
 
-    f(X=k) = (1 - p)^{k - 1} p
+    P(X=k) = (1 - p)^{k - 1} p
 
 """,
 )
@@ -6032,7 +6032,7 @@ Fills :attr:`self` tensor with numbers sampled from the continuous uniform
 distribution:
 
 .. math::
-    P(x) = \dfrac{1}{\text{to} - \text{from}}
+    f(x) = \dfrac{1}{\text{to} - \text{from}}
 """,
 )
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/pull/113109. 

- Geometric distribution is discrete, fix to PMF (probability mass function)
- Continuous uniform distribution is continuous, fix to PDF (probability density function)

cc @svekars @carljparker