### PR TITLE
correct typo by replacing cudagraph_trees.mark_step_begin with cudagr…

### DIFF
--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -117,4 +117,4 @@ def cudagraph_mark_step_begin():
     """
     import torch._inductor
 
-    torch._inductor.cudagraph_trees.mark_step_begin()
+    torch._inductor.cudagraph_mark_step_begin()


### PR DESCRIPTION
…aph_mark_step_begin

Fixes #ISSUE_NUMBER
