### PR TITLE
[dynamo] Compile subgraphs for both branches of data-dependent control flow when testing on `SymNode`

### DIFF
--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -623,6 +623,8 @@ class GraphModule(torch.nn.Module):
             context = torch._guards.TracingContext.get()
             val_to_guards = list(context.fake_mode.shape_env.var_to_guards.values())
 
+            print("VAL TO GUARDS", val_to_guards)
+
             # Grab info on sources and guards from the shapeenv
             nonlocal lower_bound_str
             nonlocal upper_bound_str
@@ -642,10 +644,14 @@ class GraphModule(torch.nn.Module):
 
         @torch.compile(backend=backend)
         def fn(x):
-            if x.shape[0] < 10:
-                return torch.mul(x, x)
-            else:
-                return torch.div(x, x)
+            # try-finally to force not compiling both branches
+            try:
+                if x.shape[0] < 10:
+                    return torch.mul(x, x)
+                else:
+                    return torch.div(x, x)
+            finally:
+                pass
 
         inp = torch.ones(4, 4)
 

--- a/test/dynamo/test_subgraphs.py
+++ b/test/dynamo/test_subgraphs.py
@@ -389,8 +389,9 @@ class SubGraphTests(torch._dynamo.test_case.TestCase):
         x = torch.randn(2)
         y = torch.randn(3)
         self.assertEqual(opt_fn(x, x), fn(x, x))
-        self.assertEqual(opt_fn(x, y), fn(x, y))
         self.assertEqual(cnt_dynamic.frame_count, 2)
+        self.assertEqual(opt_fn(x, y), fn(x, y))
+        self.assertEqual(cnt_dynamic.frame_count, 4)
 
     def test_dynamic_order_dependence(self):
         def fn(a, b):

--- a/test/dynamo/test_subgraphs.py
+++ b/test/dynamo/test_subgraphs.py
@@ -429,8 +429,9 @@ class SubGraphTests(torch._dynamo.test_case.TestCase):
         x = torch.randn(0)
         y = torch.randn(2)
         self.assertEqual(opt_fn(y), fn(y))
-        self.assertEqual(opt_fn(x), fn(x))
         self.assertEqual(cnt_dynamic.frame_count, 2)
+        self.assertEqual(opt_fn(x), fn(x))
+        self.assertEqual(cnt_dynamic.frame_count, 3)  # no dynamic shape, only compile one graph
 
     @patch.object(torch._dynamo.config, "capture_scalar_outputs", True)
     def test_no_graph_break_on_item(self):

--- a/test/dynamo/test_subgraphs.py
+++ b/test/dynamo/test_subgraphs.py
@@ -431,7 +431,9 @@ class SubGraphTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(opt_fn(y), fn(y))
         self.assertEqual(cnt_dynamic.frame_count, 2)
         self.assertEqual(opt_fn(x), fn(x))
-        self.assertEqual(cnt_dynamic.frame_count, 3)  # no dynamic shape, only compile one graph
+        self.assertEqual(
+            cnt_dynamic.frame_count, 3
+        )  # no dynamic shape, only compile one graph
 
     @patch.object(torch._dynamo.config, "capture_scalar_outputs", True)
     def test_no_graph_break_on_item(self):

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -371,7 +371,8 @@ def generic_jump(truth_fn: typing.Callable[[object], bool], push: bool):
                 push and self.push(value)
                 self.jump(inst)
         elif (
-            isinstance(value, (TensorVariable)) and self.should_compile_partial_graph()
+            isinstance(value, (TensorVariable, SymNodeVariable))
+            and self.should_compile_partial_graph()
         ):
             # compile a partial subgraph prefix then jump into user code
             if self.has_backedge():


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/111918

We did not do this when jumping on `SymNodeVariable`s before.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng