### PR TITLE
Export ReduleL1/ReduceL2 ONNX ops for aten::linalg_vector_norm(ord={1,2})

### DIFF
--- a/test/onnx/expect/TestOperators.test_frobenius_norm.expect
+++ b/test/onnx/expect/TestOperators.test_frobenius_norm.expect
@@ -4,80 +4,20 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     input: "x"
-    output: "onnx::Pow_1"
-    name: "Abs_3"
-    op_type: "Abs"
-  }
-  node {
-    output: "onnx::Pow_2"
-    name: "Constant_4"
-    op_type: "Constant"
+    output: "1"
+    name: "ReduceL2_0"
+    op_type: "ReduceL2"
     attribute {
-      name: "value"
-      t {
-        data_type: 1
-        raw_data: "\000\000\000@"
-      }
-      type: TENSOR
+      name: "axes"
+      ints: 0
+      ints: 1
+      type: INTS
     }
-  }
-  node {
-    input: "onnx::Pow_1"
-    input: "onnx::Pow_2"
-    output: "onnx::ReduceSum_3"
-    name: "Pow_5"
-    op_type: "Pow"
-  }
-  node {
-    output: "onnx::ReduceSum_4"
-    name: "Constant_6"
-    op_type: "Constant"
-    attribute {
-      name: "value"
-      t {
-        dims: 2
-        data_type: 7
-        raw_data: "\000\000\000\000\000\000\000\000\001\000\000\000\000\000\000\000"
-      }
-      type: TENSOR
-    }
-  }
-  node {
-    input: "onnx::ReduceSum_3"
-    input: "onnx::ReduceSum_4"
-    output: "onnx::Pow_5"
-    name: "ReduceSum_7"
-    op_type: "ReduceSum"
     attribute {
       name: "keepdims"
       i: 1
       type: INT
     }
-    attribute {
-      name: "noop_with_empty_axes"
-      i: 0
-      type: INT
-    }
-  }
-  node {
-    output: "onnx::Pow_10"
-    name: "Constant_8"
-    op_type: "Constant"
-    attribute {
-      name: "value"
-      t {
-        data_type: 1
-        raw_data: "\000\000\000?"
-      }
-      type: TENSOR
-    }
-  }
-  node {
-    input: "onnx::Pow_5"
-    input: "onnx::Pow_10"
-    output: "9"
-    name: "Pow_9"
-    op_type: "Pow"
   }
   name: "main_graph"
   input {
@@ -100,7 +40,7 @@ graph {
     }
   }
   output {
-    name: "9"
+    name: "1"
     type {
       tensor_type {
         elem_type: 1

--- a/test/onnx/expect/TestOperators.test_norm_p1.expect
+++ b/test/onnx/expect/TestOperators.test_norm_p1.expect
@@ -3,85 +3,24 @@ producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
   node {
-    input: "onnx::Abs_0"
-    output: "onnx::Pow_1"
-    name: "Abs_3"
-    op_type: "Abs"
-  }
-  node {
-    output: "onnx::Pow_2"
-    name: "Constant_4"
-    op_type: "Constant"
+    input: "onnx::ReduceL1_0"
+    output: "1"
+    name: "ReduceL1_0"
+    op_type: "ReduceL1"
     attribute {
-      name: "value"
-      t {
-        data_type: 1
-        raw_data: "\000\000\200?"
-      }
-      type: TENSOR
+      name: "axes"
+      ints: 2
+      type: INTS
     }
-  }
-  node {
-    input: "onnx::Pow_1"
-    input: "onnx::Pow_2"
-    output: "onnx::ReduceSum_3"
-    name: "Pow_5"
-    op_type: "Pow"
-  }
-  node {
-    output: "onnx::ReduceSum_4"
-    name: "Constant_6"
-    op_type: "Constant"
-    attribute {
-      name: "value"
-      t {
-        dims: 1
-        data_type: 7
-        raw_data: "\002\000\000\000\000\000\000\000"
-      }
-      type: TENSOR
-    }
-  }
-  node {
-    input: "onnx::ReduceSum_3"
-    input: "onnx::ReduceSum_4"
-    output: "onnx::Pow_5"
-    name: "ReduceSum_7"
-    op_type: "ReduceSum"
     attribute {
       name: "keepdims"
       i: 0
       type: INT
     }
-    attribute {
-      name: "noop_with_empty_axes"
-      i: 0
-      type: INT
-    }
-  }
-  node {
-    output: "onnx::Pow_10"
-    name: "Constant_8"
-    op_type: "Constant"
-    attribute {
-      name: "value"
-      t {
-        data_type: 1
-        raw_data: "\000\000\200?"
-      }
-      type: TENSOR
-    }
-  }
-  node {
-    input: "onnx::Pow_5"
-    input: "onnx::Pow_10"
-    output: "9"
-    name: "Pow_9"
-    op_type: "Pow"
   }
   name: "main_graph"
   input {
-    name: "onnx::Abs_0"
+    name: "onnx::ReduceL1_0"
     type {
       tensor_type {
         elem_type: 1
@@ -103,7 +42,7 @@ graph {
     }
   }
   output {
-    name: "9"
+    name: "1"
     type {
       tensor_type {
         elem_type: 1

--- a/test/onnx/expect/TestOperators.test_norm_p2.expect
+++ b/test/onnx/expect/TestOperators.test_norm_p2.expect
@@ -3,85 +3,24 @@ producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
   node {
-    input: "onnx::Abs_0"
-    output: "onnx::Pow_1"
-    name: "Abs_3"
-    op_type: "Abs"
-  }
-  node {
-    output: "onnx::Pow_2"
-    name: "Constant_4"
-    op_type: "Constant"
+    input: "onnx::ReduceL2_0"
+    output: "1"
+    name: "ReduceL2_0"
+    op_type: "ReduceL2"
     attribute {
-      name: "value"
-      t {
-        data_type: 1
-        raw_data: "\000\000\000@"
-      }
-      type: TENSOR
+      name: "axes"
+      ints: 2
+      type: INTS
     }
-  }
-  node {
-    input: "onnx::Pow_1"
-    input: "onnx::Pow_2"
-    output: "onnx::ReduceSum_3"
-    name: "Pow_5"
-    op_type: "Pow"
-  }
-  node {
-    output: "onnx::ReduceSum_4"
-    name: "Constant_6"
-    op_type: "Constant"
-    attribute {
-      name: "value"
-      t {
-        dims: 1
-        data_type: 7
-        raw_data: "\002\000\000\000\000\000\000\000"
-      }
-      type: TENSOR
-    }
-  }
-  node {
-    input: "onnx::ReduceSum_3"
-    input: "onnx::ReduceSum_4"
-    output: "onnx::Pow_5"
-    name: "ReduceSum_7"
-    op_type: "ReduceSum"
     attribute {
       name: "keepdims"
       i: 0
       type: INT
     }
-    attribute {
-      name: "noop_with_empty_axes"
-      i: 0
-      type: INT
-    }
-  }
-  node {
-    output: "onnx::Pow_10"
-    name: "Constant_8"
-    op_type: "Constant"
-    attribute {
-      name: "value"
-      t {
-        data_type: 1
-        raw_data: "\000\000\000?"
-      }
-      type: TENSOR
-    }
-  }
-  node {
-    input: "onnx::Pow_5"
-    input: "onnx::Pow_10"
-    output: "9"
-    name: "Pow_9"
-    op_type: "Pow"
   }
   name: "main_graph"
   input {
-    name: "onnx::Abs_0"
+    name: "onnx::ReduceL2_0"
     type {
       tensor_type {
         elem_type: 1
@@ -103,7 +42,7 @@ graph {
     }
   }
   output {
-    name: "9"
+    name: "1"
     type {
       tensor_type {
         elem_type: 1

--- a/test/onnx/test_fx_op_consistency.py
+++ b/test/onnx/test_fx_op_consistency.py
@@ -142,8 +142,10 @@ TESTED_OPS: frozenset[str] = frozenset(
         "nn.functional.max_pool2d",
         "nn.functional.max_pool3d",
         "nn.functional.nll_loss",
+        "nn.functional.normalize",
         # "nn.functional.scaled_dot_product_attention"  non-deterministic
         "nonzero",
+        "linalg.vector_norm",
         "scatter_add",
         "scatter_reduce",
         "square",

--- a/test/onnx/test_fx_to_onnx.py
+++ b/test/onnx/test_fx_to_onnx.py
@@ -1,6 +1,8 @@
 # Owner(s): ["module: onnx"]
 from __future__ import annotations
 
+import io
+
 import tempfile
 
 import onnx
@@ -551,6 +553,18 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
             exported_program,
             x,
         )
+
+    def test_aten_linalg_vector_norm_with_reducel2(self):
+        class Net(nn.Module):
+            def forward(self, x):
+                x = F.normalize(x)
+                return x
+
+        f = io.BytesIO()
+        torch.onnx.export(Net(), (torch.randn(1, 2, 2),), f)
+        onnx_model = onnx.load_from_string(f.getvalue())
+        onnx_nodes = [n.op_type for n in onnx_model.graph.node]
+        self.assertTrue("ReduceL2" in onnx_nodes)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
After #84624, aten::linalg_vector_norm started being used instead of aten::norm. In the ONNX exporter, the latter leveraged Reduce{L1,L2} when p={1,2}, which resulted in more optimized code in the ONNX Runtime

This PR extends aten::linal_vector_norm to also use Reduce{L1,L2} when ord={1,2}, producing an equivalent ONNX subgraph



This PR is a WIP. Pending work include checking argument equivalence between `aten::norm` and `aten::linalg_vector_norm` and maybe re-enable tests disabled by #84624