### PR TITLE
[doc] scale parameter notation for torch.Tensor.cauchy_ is misleading

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1085,7 +1085,12 @@ Fills the tensor with numbers drawn from the Cauchy distribution:
 
 .. math::
 
-    f(x) = \dfrac{1}{\pi} \dfrac{\sigma}{(x - \text{median})^2 + \sigma^2}
+    f(x) = \dfrac{1}{\pi} \dfrac{\gamma}{(x - \text{median})^2 + \gamma^2}
+
+.. note::
+  Sigma is usually used to denote square root of varaince (or sometimes standard devation).
+  Gamma is preferred notation for the scale parameter in Cauchy distribution. 
+  Also note that mean and variance are undefined in Cauchy distribution.
 """,
 )
 

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1088,10 +1088,7 @@ Fills the tensor with numbers drawn from the Cauchy distribution:
     f(x) = \dfrac{1}{\pi} \dfrac{\sigma}{(x - \text{median})^2 + \sigma^2}
 
 .. note::
-  Although sigma (:math:`\sigma`) is usually used to denote square root of varaince,
-  sigma (:math:`\sigma`) here denotes the scale parameter in Cauchy distribution.
-  
-  Also note that mean and variance are undefined in Cauchy distribution.
+  Sigma (:math:`\sigma`) is used to denote the scale parameter in Cauchy distribution.
 """,
 )
 

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1085,11 +1085,12 @@ Fills the tensor with numbers drawn from the Cauchy distribution:
 
 .. math::
 
-    f(x) = \dfrac{1}{\pi} \dfrac{\gamma}{(x - \text{median})^2 + \gamma^2}
+    f(x) = \dfrac{1}{\pi} \dfrac{\sigma}{(x - \text{median})^2 + \sigma^2}
 
 .. note::
-  Sigma is usually used to denote square root of varaince (or sometimes standard devation).
-  Gamma is preferred notation for the scale parameter in Cauchy distribution. 
+  Although sigma (:math:`\sigma`) is usually used to denote square root of varaince,
+  sigma (:math:`\sigma`) here denotes the scale parameter in Cauchy distribution.
+  
   Also note that mean and variance are undefined in Cauchy distribution.
 """,
 )


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/113426.

Scale parameter notation currently used for `torch.Tensor.cauchy_` is misleading. 
Sigma (σ) is usually used to denote square root of variance. Variance is undefined in Cauchy distribution. 
Replace sigma (σ) with gamma (γ). 

Background: https://github.com/pytorch/pytorch/pull/37984#discussion_r1059551749

cc @svekars @carljparker
