### PR TITLE
[Inductor][fx pass] Normalize nodes created by users

### DIFF
--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -187,12 +187,16 @@ class BatchLinearLHSFusion(BatchFusion):
             split_sections.append(weight.meta["example_value"].shape[0])
 
         with graph.inserting_before(subset[0]):
-            cat_weights = graph.call_function(torch.cat, args=((batch_weights, 0)))
+            cat_weights = graph.call_function(
+                torch.cat, args=(batch_weights,), kwargs={"dim": 0}
+            )
             transposed_weights = graph.call_function(
                 torch.transpose, args=(cat_weights, 0, 1)
             )
             if len(batch_biases) > 0:
-                cat_biases = graph.call_function(torch.cat, args=((batch_biases, 0)))
+                cat_biases = graph.call_function(
+                    torch.cat, args=(batch_biases,), kwargs={"dim": 0}
+                )
                 fused_lhs = graph.call_function(
                     torch.addmm,
                     args=(cat_biases, batch_input, transposed_weights),
@@ -203,7 +207,7 @@ class BatchLinearLHSFusion(BatchFusion):
                     args=(batch_input, transposed_weights),
                 )
             fused_lhs_list = graph.call_function(
-                torch.split, args=((fused_lhs, split_sections, 1))
+                torch.split, args=(fused_lhs, split_sections), kwargs={"dim": 1}
             )
 
         for i, node in enumerate(batch_nodes):
@@ -279,8 +283,12 @@ class BatchLinearFusion(BatchFusion):
             batch_biases.append(get_arg_value(node, 2, "bias"))
 
         with graph.inserting_before(subset[0]):
-            stack_inputs = graph.call_function(torch.stack, args=(batch_inputs, 0))
-            stack_weights = graph.call_function(torch.stack, args=(batch_weights, 0))
+            stack_inputs = graph.call_function(
+                torch.stack, args=(batch_inputs,), kwargs={"dim": 0}
+            )
+            stack_weights = graph.call_function(
+                torch.stack, args=(batch_weights,), kwargs={"dim": 0}
+            )
             transpose_weight = graph.call_function(
                 torch.transpose, args=(stack_weights, 1, 2)
             )
@@ -290,7 +298,9 @@ class BatchLinearFusion(BatchFusion):
                     args=(stack_inputs, transpose_weight),
                 )
             else:
-                stack_biases = graph.call_function(torch.stack, args=(batch_biases, 0))
+                stack_biases = graph.call_function(
+                    torch.stack, args=(batch_biases,), kwargs={"dim": 0}
+                )
                 unsqueeze_biases = graph.call_function(
                     torch.unsqueeze, args=(stack_biases, 1)
                 )
@@ -346,7 +356,9 @@ class BatchTanhFusion(BatchFusion):
             batch_inputs.append(get_arg_value(node, 0, "input"))
 
         with graph.inserting_before(subset[0]):
-            stack_inputs = graph.call_function(torch.stack, args=(batch_inputs, 0))
+            stack_inputs = graph.call_function(
+                torch.stack, args=(batch_inputs,), kwargs={"dim": 0}
+            )
 
             batch_tanh = graph.call_function(
                 torch.tanh,
@@ -426,14 +438,18 @@ class BatchLayernormFusion(BatchFusion):
 
         with graph.inserting_before(subset[0]):
             stack_input = graph.call_function(
-                torch.stack, args=(group_inputs, stack_dim)
+                torch.stack, args=(group_inputs,), kwargs={"dim": stack_dim}
             )
             if group_weights is not None:
-                stack_weight = graph.call_function(torch.stack, args=(group_weights,))
+                stack_weight = graph.call_function(
+                    torch.stack, args=(group_weights,), kwargs={"dim": 0}
+                )
             else:
                 stack_weight = None
             if group_biases is not None:
-                stack_bias = graph.call_function(torch.stack, args=(group_biases,))
+                stack_bias = graph.call_function(
+                    torch.stack, args=(group_biases,), kwargs={"dim": 0}
+                )
             else:
                 stack_bias = None
 
@@ -512,7 +528,9 @@ class BatchReLUFusion(BatchFusion):
         # assume all the nodes to be batched have the same inplace
         inplace = subset[0].kwargs.get("inplace", False)
         with graph.inserting_before(subset[0]):
-            stack_inputs = graph.call_function(torch.stack, args=(batch_inputs, 0))
+            stack_inputs = graph.call_function(
+                torch.stack, args=(batch_inputs,), kwargs={"dim": 0}
+            )
 
             batch_relu = graph.call_function(
                 torch.nn.functional.relu,


### PR DESCRIPTION
Summary: We noticed that the nodes created by users are absent of example value, which could not be normalized in the normalization pass, thus we change the format to the normalization format for enable the split cat merge.

Test Plan: N/A

Differential Revision: D51058817




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler