### PR TITLE
Remove TODOs to add docstrings

### DIFF
--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -347,6 +347,7 @@ aten = torch._ops.ops.aten
 # Note that the docstrings for the public methods from this file are in
 # torch/_torch_docs.py
 
+
 def is_noncontiguous_supported(device):
     if device is not None and device.type == "hpu":
         return False

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -344,6 +344,8 @@ Tensor = torch.Tensor
 DispatchKey = torch._C.DispatchKey  # type: ignore[attr-defined]
 aten = torch._ops.ops.aten
 
+# Note that the docstrings for the public methods from this file are in
+# torch/_torch_docs.py
 
 def is_noncontiguous_supported(device):
     if device is not None and device.type == "hpu":
@@ -1077,7 +1079,6 @@ def add(
     return handle_noncontiguous_outputs([a, b], output)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
     supports_lhs_python_scalar=False,
@@ -1087,7 +1088,6 @@ def atan2(a, b):
     return prims.atan2(a, b)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
 )
@@ -1095,7 +1095,6 @@ def bitwise_and(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
     return prims.bitwise_and(a, b)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
 )
@@ -1103,7 +1102,6 @@ def bitwise_left_shift(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
     return prims.shift_left(a, b)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
 )
@@ -1111,7 +1109,6 @@ def bitwise_or(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
     return prims.bitwise_or(a, b)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
 )
@@ -1119,7 +1116,6 @@ def bitwise_right_shift(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
     return prims.shift_right_arithmetic(a, b)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
 )
@@ -1127,7 +1123,6 @@ def bitwise_xor(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
     return prims.bitwise_xor(a, b)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
     supports_lhs_python_scalar=False,
@@ -1145,7 +1140,6 @@ def copysign(
     return where(signbit(b), neg(abs(a)), abs(a))
 
 
-# TODO: add docstring
 # complex =  _make_elementwise_binary_reference(prims.complex, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT)
 
 
@@ -1171,7 +1165,6 @@ def div(
         raise ValueError(msg)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL,
     supports_lhs_python_scalar=False,
@@ -1180,7 +1173,6 @@ def eq(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
     return prims.eq(a, b)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.BOOL_TO_LONG,
 )
@@ -1208,7 +1200,6 @@ def pow(
     return prims.pow(a, b)
 
 
-# TODO: add docstring
 # Float power has its own implementation because it has unique type promotion.
 # CompositeImplicitAutograd - don't register decomp
 @out_wrapper()
@@ -1266,7 +1257,6 @@ def float_power(
 # https://github.com/python/cpython/blob/ace008c531dd685a30c1dd68f9b5ba35f20171cf/Objects/floatobject.c#L636
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=utils.ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
     supports_two_python_scalars=True,
@@ -1338,7 +1328,6 @@ def _floor_divide_float(a: Tensor, b: Tensor) -> Tensor:
     return where(ne(b, 0), floor_div, basic_div)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
     supports_lhs_python_scalar=False,
@@ -1348,7 +1337,6 @@ def fmax(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
     return prims.fmax(a, b)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
     supports_lhs_python_scalar=False,
@@ -1358,7 +1346,6 @@ def fmin(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
     return prims.fmin(a, b)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
     supports_lhs_python_scalar=False,
@@ -1368,7 +1355,6 @@ def fmod(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
     return prims.fmod(a, b)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
     supports_lhs_python_scalar=False,
@@ -1378,7 +1364,6 @@ def gcd(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
     return prims.gcd(a, b)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL,
     supports_lhs_python_scalar=False,
@@ -1387,7 +1372,6 @@ def ge(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
     return prims.ge(a, b)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL,
     supports_lhs_python_scalar=False,
@@ -1501,7 +1485,6 @@ def isclose(
     return result
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
     supports_lhs_python_scalar=False,
@@ -1523,7 +1506,6 @@ def lcm(a: TensorLikeType, b: TensorLikeType):
     return res if not promote_to_int else prims.convert_element_type(res, dtype)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL,
     supports_lhs_python_scalar=False,
@@ -1581,7 +1563,6 @@ def logaddexp2(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
     return torch.where(inf_mask, a, result)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL,
 )
@@ -1593,7 +1574,6 @@ def logical_and(a: TensorLikeType, b: TensorLikeType):
     return a & b
 
 
-# TODO: add docstring
 @_make_elementwise_unary_reference(ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL)
 def logical_not(a: TensorLikeType):
     if not utils.is_boolean_dtype(a.dtype):
@@ -1601,7 +1581,6 @@ def logical_not(a: TensorLikeType):
     return ~a
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL,
 )
@@ -1613,7 +1592,6 @@ def logical_or(a: TensorLikeType, b: TensorLikeType):
     return bitwise_or(a, b)
 
 
-# TODO: add docstring
 # TODO: skip unnecessary conversion of long to float
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL,
@@ -1626,7 +1604,6 @@ def logical_xor(a: TensorLikeType, b: TensorLikeType):
     return a ^ b
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL,
     supports_lhs_python_scalar=False,
@@ -1635,7 +1612,6 @@ def lt(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
     return prims.lt(a, b)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
 )
@@ -1643,7 +1619,6 @@ def maximum(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
     return prims.maximum(a, b)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
 )
@@ -1651,7 +1626,6 @@ def minimum(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
     return prims.minimum(a, b)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
     supports_two_python_scalars=True,
@@ -1660,7 +1634,6 @@ def mul(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
     return prims.mul(a, b)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL,
     supports_lhs_python_scalar=False,
@@ -1669,7 +1642,6 @@ def ne(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
     return prims.ne(a, b)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.NO_OPMATH,
     supports_lhs_python_scalar=False,
@@ -1679,7 +1651,6 @@ def nextafter(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
     return prims.nextafter(a, b)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
 )
@@ -1700,7 +1671,6 @@ def rsub(
     return sub(b, a, alpha=alpha)
 
 
-# TODO: add docstring
 # TODO: consider refactoring this with add impl
 # sub has its own implementation because it has an alpha argument
 @register_decomposition(aten.sub)
@@ -1739,7 +1709,6 @@ def sub(
     return handle_noncontiguous_outputs([a, b], output)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
     name="true_divide",
@@ -1775,7 +1744,6 @@ def xlogy(a: Union[TensorLikeType, NumberType], b: Union[TensorLikeType, NumberT
     return torch.where(torch.isnan(b), float("nan"), rhs)
 
 
-# TODO: add docstring
 @_make_elementwise_binary_reference(
     type_promotion_kind=utils.ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
     aten_op=None,  # CompositeImplicitAutograd


### PR DESCRIPTION
Because the docstrings are actually defined in torch/_torch_docs.py.
