### PR TITLE
[fbgemm_gpu] add pt2_compliant tag to some ops

### DIFF
--- a/torch/library.h
+++ b/torch/library.h
@@ -87,6 +87,8 @@ namespace torch {
 struct NoInferSchemaTag {};
 #endif
 
+#define HAS_PT2_COMPLIANT_TAG
+
 // For multipy/torchdeploy use case
 enum class _RegisterOrVerify { REGISTER, VERIFY };
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/FBGEMM/pull/2119

Logs show these ops are being used with PT2, so we are grandfathering in these
ops to the pt2_compliant tag. Most of these ops are tested, some aren't.

Test Plan: - existing tests

Differential Revision: D51076460


