### PR TITLE
Fix `TensorIterator::is_scalar` for empty np-tensors

### DIFF
--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -797,6 +797,9 @@ bool TensorIteratorBase::is_contiguous() const {
 bool TensorIteratorBase::is_scalar(int arg) const {
   const auto& stride = operands_[arg].stride_bytes;
   for (const auto i : c10::irange(ndim())) {
+    if (shape_[i] == 0) {
+      return false;
+    }
     if (stride[i] != 0 && shape_[i] != 1) {
       return false;
     }

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -341,15 +341,19 @@ class TestForeach(TestCase):
                 expected = ref(ref_inputs, values=values)
                 self.assertEqual(expected, actual)
 
-    @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool))
+    @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16))
     def test_add_scalar_with_empty_list_and_empty_tensor(self, device, dtype):
         # TODO: enable empty list case
-        for tensors in [[torch.randn([0])]]:
+        for tensors in [[torch.randn([0], dtype=dtype, device=device)],
+                        [torch.empty_strided((0, 1), (0, 0), dtype=dtype, device=device)]]:
             res = torch._foreach_add(tensors, 1)
             self.assertEqual(res, tensors)
 
             torch._foreach_add_(tensors, 1)
             self.assertEqual(res, tensors)
+
+            # Regression test for https://github.com/pytorch/pytorch/issues/113156
+            torch._foreach_mul_(tensors, 1)
 
     @ops(
         filter(lambda op: not op.has_no_out_of_place, foreach_binary_op_db),

--- a/test/test_numpy_interop.py
+++ b/test/test_numpy_interop.py
@@ -481,6 +481,13 @@ class TestNumPyInterop(TestCase):
                     self.assertFalse(t == a)
                 else:
                     self.assertTrue(t == a)
+    @onlyCPU
+    def test_empty_tensors_interop(self, device):
+        x = torch.empty((8, 0), dtype=torch.float16)
+        y = torch.from_numpy(np.empty((0, 8, 0), dtype=np.float16))
+        # This used to segfault, see https://github.com/pytorch/pytorch/issues/113037
+        z = torch.div(x, y, rounding_mode='floor')
+        self.assertEqual(z.shape, y.shape)
 
 instantiate_device_type_tests(TestNumPyInterop, globals())
 


### PR DESCRIPTION
`TensorIteratorBase::is_scalar()` should return false for empty tensors, i.e. if any of the shapes of the tensor is 0, which it fails to do for tensors created as follows `torch.empty_strided((0, 1), (0, 0))`.


Fixes https://github.com/pytorch/pytorch/issues/113037 and https://github.com/pytorch/pytorch/issues/113156
