### PR TITLE
fix: docstring error in torch/distributed module

### DIFF
--- a/torch/distributed/_tensor/debug/op_coverage.py
+++ b/torch/distributed/_tensor/debug/op_coverage.py
@@ -21,6 +21,8 @@ def fwd_bwd_compiler(fx_g, _):
 
 def get_inductor_decomp_graphs(model: nn.Module, args, kwargs):
     """
+    Obtain forward and backward graphs of a model with inductor decompositions using tracing and aot_module.
+
     Convenient util to get the fwd and bwd graphs of an arbitrary model
     with inductor decompositions. Note that this would simply do tracing
     with aot_module and don't ensure correctness. This is useful to track
@@ -45,8 +47,9 @@ def get_inductor_decomp_graphs(model: nn.Module, args, kwargs):
 
 def print_op_coverage_summary(model: nn.Module, args, kwargs, *, output_csv=False):
     """
-    Util to print the operator coverage summary of a certain model with tabulute,
-    must have tabulate module installed
+    Util to print the operator coverage summary of a certain model with tabulute.
+
+    Must have tabulate module installed.
     """
     # python module required for summary
     import csv

--- a/torch/distributed/_tensor/ops/common_rules.py
+++ b/torch/distributed/_tensor/ops/common_rules.py
@@ -52,9 +52,9 @@ def einop_rule(
     enforce_sharding: Optional[Dict[str, int]] = None,
 ) -> OutputSharding:
     """
-    Propagate the sharding of inputs to output for ops whose data
-    moves according to einsum notation. This is mostly borrowed
-    from @zdevito's sharding simulator. Examples:
+    Propagate the sharding of inputs to output for ops whose data moves according to einsum notation.
+
+    This is mostly borrowed from @zdevito's sharding simulator. Examples:
         mk,kn->mn - einsum
         ij,ij->ij - addition
         ij,j->ij - broadcasted addition
@@ -229,7 +229,9 @@ def einop_rule(
 
 def pointwise_rule(op_schema: OpSchema, linearity: bool = False) -> OutputSharding:
     """
-    Propagate the sharding for pointwise operations. Examples:
+    Propagate the sharding for pointwise operations.
+
+    Examples:
         ij,ij->ij - addition/mul
         ij,j->ij - broadcasted addition
     """

--- a/torch/distributed/_tensor/ops/tensor_ops.py
+++ b/torch/distributed/_tensor/ops/tensor_ops.py
@@ -131,9 +131,7 @@ def new_factory_strategy(mesh: DeviceMesh, _) -> StrategyType:
 
 @register_op_strategy(aten.bucketize.Tensor)
 def gen_bucketize_strategy(mesh: DeviceMesh, op_schema: OpSchema) -> StrategyType:
-    """
-    Just propagate input sharding, but expect replicated for boundaries input.
-    """
+    """Just propagate input sharding, but expect replicated for boundaries input."""
     input_strategy = op_schema.args_schema[0]
     bucketize_strategy = OpStrategy([])
     assert isinstance(input_strategy, OpStrategy)
@@ -151,9 +149,7 @@ def gen_bucketize_strategy(mesh: DeviceMesh, op_schema: OpSchema) -> StrategyTyp
 
 @register_op_strategy(aten.slice.Tensor, schema_info=RuntimeSchemaInfo(1))
 def gen_slice_strategy(mesh: DeviceMesh, op_schema: OpSchema) -> StrategyType:
-    """
-    forwards all shardings except the slice dimension.
-    """
+    """Forward all shardings except the slice dimension."""
     defaults = (None, 0, None, None, 1)
     input_strategy, dim, start, end, step = (
         op_schema.args_schema + defaults[len(op_schema.args_schema) :]
@@ -202,7 +198,7 @@ def gen_slice_strategy(mesh: DeviceMesh, op_schema: OpSchema) -> StrategyType:
 def unshard_tensor_dim(
     placements: Sequence[Placement], dim: int
 ) -> Tuple[Placement, ...]:
-    """Disallow the given tensor dimension to be sharded"""
+    """Disallow the given tensor dimension to be sharded."""
     return tuple(
         p if (not isinstance(p, Shard) or p.dim != dim) else Replicate()
         for p in placements
@@ -212,7 +208,7 @@ def unshard_tensor_dim(
 def replicate_tensor_dim(
     placements: Sequence[Placement], dim: int
 ) -> Tuple[Placement, ...]:
-    """Force the given tensor dimension to be replicated"""
+    """Force the given tensor dimension to be replicated."""
     # Not using p.is_shard() to avoid mypy complain about Placement not having
     # attribute dim.
     return tuple(
@@ -268,7 +264,7 @@ def gen_slice_scatter_strategy(mesh: DeviceMesh, op_schema: OpSchema) -> Strateg
 
 @register_op_strategy(aten._local_scalar_dense.default)
 def replica_only_strategy(mesh: DeviceMesh, op_schema: OpSchema) -> StrategyType:
-    """Only allow replication on the input/ouput"""
+    """Only allow replication on the input/ouput."""
     replicate_spec = DTensorSpec(mesh, tuple([Replicate()] * mesh.ndim))
     return OpStrategy([PlacementStrategy(replicate_spec)])
 
@@ -308,6 +304,7 @@ def prop_index_select(op_schema: OpSchema) -> OutputSharding:
 def prop_index(op_schema: OpSchema) -> OutputSharding:
     """
     Expect replicated on the first input; _mostly_ pointwise on the second input.
+
     TODO: exception: when the dtype of second input is "bool", then a torch.nonzero needs to be triggered first.
     """
     # Current sharding constraints:

--- a/torch/distributed/_tensor/ops/utils.py
+++ b/torch/distributed/_tensor/ops/utils.py
@@ -63,10 +63,7 @@ def normalize_dim(dim: int, ndim: int) -> int:
 
 
 def normalize_dims(dims: Union[int, Sequence[int]], ndim: int) -> Sequence[int]:
-    """
-    normalize a dim or a sequence of dims, so that they
-    are all positive.
-    """
+    """Normalize a dim or a sequence of dims, so that they are all positive."""
     if isinstance(dims, int):
         dims = (normalize_dim(dims, ndim),)
     elif isinstance(dims, list):
@@ -81,9 +78,7 @@ def prod(xs: Iterable[int]) -> int:
 
 
 def is_tensor_shardable(shape: Sequence[int], spec: DTensorSpec) -> bool:
-    """
-    Check if the shape is shardable according to the spec.
-    """
+    """Check if the shape is shardable according to the spec."""
     # number of shards in each tensor dimension
     shards_map = [1] * len(shape)
     for i, placement in enumerate(spec.placements):
@@ -101,12 +96,12 @@ def is_tensor_shardable(shape: Sequence[int], spec: DTensorSpec) -> bool:
 
 
 def is_tensor_dim_sharded(spec: DTensorSpec, dim: int) -> bool:
-    """Return True if tensor dim is sharded"""
+    """Return True if tensor dim is sharded."""
     return any(p.is_shard(dim) for p in spec.placements)
 
 
 def is_tensor_partial(spec: DTensorSpec) -> bool:
-    """Return True if tensor is partial on the mesh"""
+    """Return True if tensor is partial on the mesh."""
     return any(p.is_partial() for p in spec.placements)
 
 
@@ -129,9 +124,7 @@ def map_placements_after_broadcast(
     shape: torch.Size,
     broadcast_dims_map: List[int],
 ) -> Tuple[Placement, ...]:
-    """
-    Map each placement based on the output shape after broadcast.
-    """
+    """Map each placement based on the output shape after broadcast."""
     new_placements: List[Placement] = []
     for placement in placements:
         if isinstance(placement, (Replicate, _Partial)):

--- a/torch/distributed/_tensor/ops/view_ops.py
+++ b/torch/distributed/_tensor/ops/view_ops.py
@@ -42,7 +42,7 @@ DimMap = Tuple[DimSpec, ...]
 
 @dataclass
 class Singleton(DimSpec):
-    """Output dimension is a singleton"""
+    """Output dimension is a singleton."""
 
     pass
 
@@ -103,10 +103,7 @@ class Repeat(DimSpec):
 
 @dataclass
 class Flatten(DimSpec):
-    """
-    Output dimension is a set of input dimensions flattened, keeping
-    right-most adjacent elements adjacent in the output.
-    """
+    """Flatten a set of input dimensions, ensuring right-most adjacent elements remain adjacent in the output."""
 
     input_dims: Sequence[DimSpec]
 
@@ -129,6 +126,7 @@ class Flatten(DimSpec):
 class Split(DimSpec):
     """
     This dimension is a member of a decomposition of the input dim.
+
     Note that input_dim itself could be a Flattened set of input dims.
     """
 
@@ -177,7 +175,7 @@ def dim_atleast_3d(ndim: int) -> DimMap:
 
 
 def expand(input_shape: Shape, shape: Shape) -> DimMap:
-    """Implements broadcast on multiple dimensions"""
+    """Implement broadcast on multiple dimensions."""
     assert len(shape) >= len(input_shape)
 
     # 1. create padded input dimensions
@@ -259,6 +257,7 @@ def dim_repeat(ndim: int, sizes: Shape) -> DimMap:
 def infer_size(total_size: int, sizes: Shape) -> Shape:
     """
     One dimension input to view may be "-1".
+
     Infer the size of this dimension given the total_size.
     """
     infers = [i for i, s in enumerate(sizes) if s == -1]
@@ -277,6 +276,8 @@ def infer_size(total_size: int, sizes: Shape) -> Shape:
 
 def view_groups(from_size: Shape, to_size: Shape) -> DimMap:
     """
+    Decompose a reshape operation into forwarding, flattening, or splitting dimensions for each output dimension.
+
     A view or reshape operation can be decomposed into a set of 3 types of smaller operations:
     1) Forward a dimension from input to output
     2) Flatten a set of dimensions into a single dimension
@@ -408,6 +409,7 @@ def dim_reduction(
 ) -> DimMap:
     """
     General fallback for reduction ops where _Partial() does not apply.
+
     This will cause incoming tensor to be replicated on the reducing dimensions.
     """
     if dim_or_dims is None:
@@ -476,6 +478,8 @@ def propagate_shape_and_sharding(
     mesh_sizes: Shape,
 ) -> Tuple[Shape, Optional[Sequence[Placement]], torch.Tensor]:
     """
+    Determine output sharding and tensor shape based on given global tensor shape and input sharding.
+
     Takes as input the global shape of the tensor, and the input sharding,
     and produce corresponding output sharding and shape of the output tensor.
 

--- a/torch/distributed/checkpoint/_fsspec_filesystem.py
+++ b/torch/distributed/checkpoint/_fsspec_filesystem.py
@@ -49,9 +49,7 @@ __all__ = [
 
 @dataclass
 class _StorageInfo:
-    """
-    This is the per entry storage info
-    """
+    """This is the per entry storage info."""
 
     relative_path: str
     offset: int
@@ -330,7 +328,7 @@ class FsspecWriter(StorageWriter):
         per_thread_copy_ahead: int = 10_000_000,
     ) -> None:
         """
-        Initialize the writer pointing to `path`
+        Initialize the writer pointing to `path`.
 
         Args:
             path: diretory where the checkpoint will be writen to.

--- a/torch/distributed/checkpoint/_nested_dict.py
+++ b/torch/distributed/checkpoint/_nested_dict.py
@@ -29,6 +29,7 @@ def flatten_state_dict(
 ) -> Tuple[STATE_DICT_TYPE, FLATTEN_MAPPING]:
     """
     Flatten ``state_dict`` made of nested dicts and lists into a top level dictionary.
+
     Use ``unflatten_state_dict`` to revert this process.
     Returns:
         A tuple with the flatten state_dict and a mapping from original to new state_dict.
@@ -52,9 +53,7 @@ def flatten_state_dict(
 def unflatten_state_dict(
     state_dict: STATE_DICT_TYPE, mapping: FLATTEN_MAPPING
 ) -> STATE_DICT_TYPE:
-    """
-    Restore the original nested state_dict according to ``mapping`` and the flattened ``state_dict``
-    """
+    """Restore the original nested state_dict according to ``mapping`` and the flattened ``state_dict``."""
     nested: STATE_DICT_TYPE = {}
     for key, value in state_dict.items():
         set_element(nested, mapping[key], value)

--- a/torch/distributed/checkpoint/_sharded_tensor_utils.py
+++ b/torch/distributed/checkpoint/_sharded_tensor_utils.py
@@ -32,7 +32,7 @@ from .utils import _element_wise_add, _normalize_device_info
 # TODO: We need to refactor this code.
 def _flatten_sharded_tensors(state_dict: STATE_DICT_TYPE) -> STATE_DICT_TYPE:
     r"""
-    Transforms ``state_dict`` by flattening all nested ShardedTensor instances found.
+    Transform ``state_dict`` by flattening all nested ShardedTensor instances found.
 
     The resulting ShardedTensor instances are only correct regarding the local shard and
     MUST not be used for any other purpose but checkpointing, as no operator will work with them.

--- a/torch/distributed/checkpoint/_traverse.py
+++ b/torch/distributed/checkpoint/_traverse.py
@@ -41,6 +41,7 @@ def traverse_state_dict(
 ) -> None:
     """
     Invoke ``visitor`` for each value recursively in ``state_dict``.
+
     Traversal is short-circuited when if finds a collection for which ``keep_visiting_tensors`` evaluates
     to false for all elements.
     By default, all collections with at least one ``torch.Tensor`` element are traversed.
@@ -80,9 +81,7 @@ def traverse_state_dict(
 def set_element(
     root_dict: STATE_DICT_TYPE, path: OBJ_PATH, value: STATE_DICT_ITEM
 ) -> None:
-    """
-    Set ``value`` in ``root_dict`` along the ``path`` object path.
-    """
+    """Set ``value`` in ``root_dict`` along the ``path`` object path."""
     cur_container = cast(CONTAINER_TYPE, root_dict)
 
     def extend_list(lst: List[STATE_DICT_ITEM], idx: int) -> None:
@@ -116,9 +115,7 @@ def get_element(
     path: OBJ_PATH,
     default_value: Optional[T] = None,
 ) -> Optional[T]:
-    """
-    Retrieve the value at ``path``from ``root_dict``, returning ``default_value`` if not found.
-    """
+    """Retrieve the value at ``path``from ``root_dict``, returning ``default_value`` if not found."""
     cur_value = cast(CONTAINER_TYPE, root_dict)
     for part in path:
         if type(part) is int:
@@ -163,7 +160,8 @@ def print_tensor(
     print_fun: Callable[[str], None] = print,
 ) -> None:
     """
-    Callback that can be used with traverse_state_dict to print its content.
+    Use this callback with traverse_state_dict to print its content.
+
     By default the content is printed using the builtin ``print`` but this can
     be change by passing a different ``print_fun` callable.
     """

--- a/torch/distributed/checkpoint/api.py
+++ b/torch/distributed/checkpoint/api.py
@@ -21,9 +21,7 @@ def _is_wrapped_exception(obj: Any) -> bool:
 
 
 class CheckpointException(BaseException):
-    """
-    Exception raised if failure was detected as part of a checkpoint load or save.
-    """
+    """Exception raised if failure was detected as part of a checkpoint load or save."""
 
     def __init__(self, msg: str, failures: Dict[int, WRAPPED_EXCEPTION]):
         super().__init__(msg, failures)
@@ -31,11 +29,7 @@ class CheckpointException(BaseException):
 
     @property
     def failures(self) -> Dict[int, WRAPPED_EXCEPTION]:
-        """
-        Returns:
-            Dict of failed nodes and their associated exception.
-              Keys are node ranks and values are exceptions
-        """
+        """Return a dictionary mapping node ranks to their associated exceptions in case of failure."""
         return self._failures
 
     def __str__(self):

--- a/torch/distributed/checkpoint/default_planner.py
+++ b/torch/distributed/checkpoint/default_planner.py
@@ -137,15 +137,11 @@ class DefaultSavePlanner(SavePlanner):
         return self.transform_object(write_item, object)
 
     def lookup_object(self, index: MetadataIndex) -> Any:
-        """
-        This is an extension from the planner interface to make it easy to extend the default planner
-        """
+        """Extension from the planner interface to make it easy to extend the default planner."""
         return find_state_dict_object(self.state_dict, index)
 
     def transform_object(self, write_item: WriteItem, object: Any):
-        """
-        This is an extension from the planner interface to make it easy to extend the default planner
-        """
+        """Extension from the planner interface to make it easy to extend the default planner."""
         if write_item.type == WriteItemType.BYTE_IO:
             bytes = io.BytesIO()
             torch.save(object, bytes)
@@ -221,15 +217,11 @@ class DefaultLoadPlanner(LoadPlanner):
         pass
 
     def lookup_tensor(self, index: MetadataIndex) -> torch.Tensor:
-        """
-        This is an extension from the planner interface to make it easy to extend the default planner
-        """
+        """Extension from the planner interface to make it easy to extend the default planner."""
         return find_state_dict_object(self.state_dict, index)
 
     def transform_tensor(self, read_item: ReadItem, tensor: torch.Tensor):
-        """
-        This is an extension from the planner interface to make it easy to extend the default planner
-        """
+        """Extension from the planner interface to make it easy to extend the default planner."""
         return narrow_tensor_by_index(
             tensor, read_item.dest_offsets, read_item.lengths
         )
@@ -355,9 +347,7 @@ def create_default_global_save_plan(
 
 
 def _create_default_local_metadata(state_dict: STATE_DICT_TYPE) -> Metadata:
-    """
-    Return the ``Metadata`` if DefaultSavePlanner was used to checkpoint ``state_dict``.
-    """
+    """Return the ``Metadata`` if DefaultSavePlanner was used to checkpoint ``state_dict``."""
     plan = _create_default_metadata_only_plan(state_dict)
     _, md = create_default_global_save_plan([plan])
     return md
@@ -366,10 +356,7 @@ def _create_default_local_metadata(state_dict: STATE_DICT_TYPE) -> Metadata:
 def _check_box_overlap(
     box0: ChunkStorageMetadata, box1: ChunkStorageMetadata
 ) -> bool:
-    """
-    Checks if two boxes overlap. Tuples are (offset, lengths)
-    """
-
+    """Check if two boxes overlap. Tuples are (offset, lengths)."""
     # For each dim of each shard, check if one shard resides on the other
     # end of second shard with respect to that dim. As an example for a 2D
     # shard, we would check if one shard is above or on the left of the

--- a/torch/distributed/checkpoint/examples/fsdp_checkpoint_example.py
+++ b/torch/distributed/checkpoint/examples/fsdp_checkpoint_example.py
@@ -1,8 +1,9 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 
 """
-The following example demonstrates how to use Pytorch Distributed Checkpoint
-to save a FSDP model. This is the current recommended way to checkpoint FSDP.
+The following example demonstrates how to use Pytorch Distributed Checkpoint to save a FSDP model.
+
+This is the current recommended way to checkpoint FSDP.
 torch.save() and torch.load() is not recommended when checkpointing sharded models.
 """
 

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -49,9 +49,7 @@ __all__ = [
 
 @dataclass
 class _StorageInfo:
-    """
-    This is the per entry storage info
-    """
+    """This is the per entry storage info."""
 
     relative_path: str
     offset: int
@@ -330,7 +328,7 @@ class FileSystemWriter(StorageWriter):
         per_thread_copy_ahead: int = 10_000_000,
     ) -> None:
         """
-        Initialize the writer pointing to `path`
+        Initialize the writer pointing to `path`.
 
         Args:
             path: directory where the checkpoint will be written to.

--- a/torch/distributed/checkpoint/metadata.py
+++ b/torch/distributed/checkpoint/metadata.py
@@ -18,9 +18,7 @@ __all__ = [
 
 @dataclass
 class ChunkStorageMetadata:
-    """
-    Each chunk is expected to have the same properties of the TensorStorageMetadata that includes it.
-    """
+    """Each chunk is expected to have the same properties of the TensorStorageMetadata that includes it."""
 
     offsets: torch.Size
     sizes: torch.Size
@@ -53,9 +51,7 @@ class Metadata:
 
 @dataclass(frozen=True)
 class MetadataIndex:
-    """
-    This class represents a lookup key for items in a state dict or Metadata.
-    """
+    """This class represents a lookup key for items in a state dict or Metadata."""
 
     fqn: str
     """Fully Qualified Name of the object"""

--- a/torch/distributed/checkpoint/optimizer.py
+++ b/torch/distributed/checkpoint/optimizer.py
@@ -116,7 +116,8 @@ def _get_state_dict_2d_layout(
     state_dict: STATE_DICT_TYPE,
 ) -> Tuple[STATE_DICT_2D_LAYOUT, Optional[dist.ProcessGroup]]:
     """
-    We have to load the right TP slice of the optimizer state.
+    Load the right TP slice of the optimizer state.
+
     This is not easy since the per-tensor slicing can't be inferred from checkpoint metadata.
     We take advantage of the model state_dict producing a sliced ST to figure out what we need to load.
     This is pretty fragile and it might be easier for FSDP to compute this info for us.
@@ -217,7 +218,8 @@ def load_sharded_optimizer_state_dict(
     planner: Optional[LoadPlanner] = None,
 ) -> STATE_DICT_TYPE:
     """
-    Loads a state_dict in conjunction with FSDP sharded optimizer state.
+    Load a state_dict in conjunction with FSDP sharded optimizer state.
+
     This is the current recommended way to checkpoint FSDP.
     >>> # xdoctest: +SKIP
     >>> import torch.distributed.checkpoint as dist_cp

--- a/torch/distributed/checkpoint/planner.py
+++ b/torch/distributed/checkpoint/planner.py
@@ -194,6 +194,7 @@ class SavePlanner(abc.ABC):
     def create_local_plan(self) -> SavePlan:
         """
         Compute the save plan for the current rank.
+
         This will be aggregated and passed to create_global_plan.
         Planner specific data can be passed through SavePlan::planner_data.
 
@@ -226,6 +227,8 @@ class SavePlanner(abc.ABC):
         self, write_item: WriteItem
     ) -> Union[torch.Tensor, io.BytesIO]:
         """
+        Transform and prepare ``write_item`` from ``state_dict`` for storage, ensuring idempotency and thread-safety.
+
         Lookup the object associated with ``write_item`` in ``state_dict`` and apply any
         transformation (such as serialization) prior to the storage layer consuming it.
 
@@ -320,7 +323,7 @@ class LoadPlanner:
         is_coordinator: bool,
     ) -> None:
         """
-        Initialize this instance to load data into ``state_dict``
+        Initialize this instance to load data into ``state_dict``.
 
         . N.B. This is called on every rank.
         """
@@ -346,9 +349,7 @@ class LoadPlanner:
 
     @abc.abstractmethod
     def finish_plan(self, central_plan: LoadPlan) -> LoadPlan:
-        """
-        Accept the plan from coordinator and return final LoadPlan.
-        """
+        """Accept the plan from coordinator and return final LoadPlan."""
         pass
 
     @abc.abstractmethod
@@ -377,7 +378,7 @@ class LoadPlanner:
     @abc.abstractmethod
     def commit_tensor(self, read_item: ReadItem, tensor: torch.Tensor) -> None:
         """
-        This method is called once the StorageReader finished loading data into ``tensor``.
+        Call once the StorageReader finished loading data into ``tensor``.
 
         The provided tensor is the same one returned by the call to ``resolve_tensor``.
         This method is only needed if this LoadPlanner needs to post process ``tensor`` prior to

--- a/torch/distributed/checkpoint/planner_helpers.py
+++ b/torch/distributed/checkpoint/planner_helpers.py
@@ -141,7 +141,7 @@ def create_read_items_for_chunk_list(
     local_chunks: List[ChunkStorageMetadata],
 ) -> List[ReadItem]:
     """
-    Creates a list of ``ReadItem`` based on the checkpoint and local chunks.
+    Create a list of ``ReadItem`` based on the checkpoint and local chunks.
 
     This applies the resharding algorithm and computes the reads needed
     to satisfy ``local_chunks`` with a checkpoint described by ``checkpoint_md``.

--- a/torch/distributed/checkpoint/resharding.py
+++ b/torch/distributed/checkpoint/resharding.py
@@ -7,10 +7,7 @@ from torch.distributed.checkpoint.metadata import (
 __all__: List[str] = []
 
 def _check_shard_metadata_pair_overlap(shard1: ChunkStorageMetadata, shard2: ChunkStorageMetadata):
-    """
-    Checks if two shards overlap.
-    """
-
+    """Check if two shards overlap."""
     # For each dim of each shard, check if one shard resides on the other
     # end of second shard with respect to that dim. As an example for a 2D
     # shard, we would check if one shard is above or on the left of the
@@ -29,6 +26,7 @@ def _shards_get_overlap_region_wrt_saved_tensor(
 ) -> List[Tuple[int, int, int, int]]:
     """
     Return the overlapping region between saved_shard and current_shard.
+
     There returned list has the same number of elements as the tensor's dimension.
     For each element, we produce a tuple with the following contents:
         (dimension, `saved_shard` offset, `current_shard` offset, length)

--- a/torch/distributed/checkpoint/state_dict_loader.py
+++ b/torch/distributed/checkpoint/state_dict_loader.py
@@ -23,7 +23,7 @@ def load_state_dict(
     planner: Optional[LoadPlanner] = None,
 ) -> None:
     """
-    Loads a distributed ``state_dict`` in SPMD style.
+    Load a distributed ``state_dict`` in SPMD style.
 
     Each rank will try to read the least amount of data necessary
     to fullfill the requested `state_dict`. When loading :class:`ShardedTensor`
@@ -85,7 +85,6 @@ def load_state_dict(
         and it is the user's responsibility to ensure that this is set so that each
         rank has an individual GPU, via ``torch.cuda.set_device()``.
     """
-
     torch._C._log_api_usage_once("torch.distributed.checkpoint.load_state_dict")
 
     distW = _DistWrapper(process_group, not no_dist, coordinator_rank)

--- a/torch/distributed/checkpoint/state_dict_saver.py
+++ b/torch/distributed/checkpoint/state_dict_saver.py
@@ -25,7 +25,7 @@ def save_state_dict(
     planner: Optional[SavePlanner] = None,
 ) -> Metadata:
     """
-    Saves a distributed model in SPMD style.
+    Save a distributed model in SPMD style.
 
     This function is different from ``torch.save()`` as it handles
     ``ShardedTensor`` by having each rank only save their local shards.
@@ -82,7 +82,6 @@ def save_state_dict(
         and it is the user's responsibility to ensure that this is set so that
         each rank has an individual GPU, via ``torch.cuda.set_device()``.
     """
-
     torch._C._log_api_usage_once("torch.distributed.checkpoint.save_state_dict")
 
     distW = _DistWrapper(process_group, not no_dist, coordinator_rank)

--- a/torch/distributed/checkpoint/storage.py
+++ b/torch/distributed/checkpoint/storage.py
@@ -119,7 +119,7 @@ class StorageWriter(abc.ABC):
         self, metadata: Metadata, results: List[List[WriteResult]]
     ) -> None:
         """
-        Writes the metadata and marks the current checkpoint as successful.
+        Write the metadata and marks the current checkpoint as successful.
 
         The actual format/schema used for serializing `metadata` is an
         implementation detail. The only requirement is that it's recoverable
@@ -155,7 +155,7 @@ class StorageReader(abc.ABC):
     @abc.abstractmethod
     def read_metadata(self) -> Metadata:
         """
-        Reads the checkpoint metadata.
+        Read the checkpoint metadata.
 
         Returns:
             The metadata object associated with the checkpoint being loaded.
@@ -212,7 +212,7 @@ class StorageReader(abc.ABC):
     @abc.abstractmethod
     def read_data(self, plan: LoadPlan, planner: LoadPlanner) -> Future[None]:
         """
-        Reads all items from ``plan`` using ``planner`` to resolve the data.
+        Read all items from ``plan`` using ``planner`` to resolve the data.
 
         A subclass should call ``LoadPlanner::load_bytes`` to deserialize a BytesIO
         object into the right place.

--- a/torch/distributed/checkpoint/utils.py
+++ b/torch/distributed/checkpoint/utils.py
@@ -82,9 +82,7 @@ class _DistWrapper:
         return 1
 
     def broadcast_object(self, object: Optional[T]) -> T:
-        """
-        Same as c10d::broadcast_object_list but works without distributed enabled.
-        """
+        """Implement functionality similar to c10d::broadcast_object_list but without distributed enabled."""
         object_list = [object]
         if self.use_dist:
             dist.broadcast_object_list(
@@ -95,9 +93,7 @@ class _DistWrapper:
         return cast(T, object_list[0])
 
     def gather_object(self, object: T) -> Optional[List[T]]:
-        """
-        Same as c10d::gather_object but works without distributed enabled.
-        """
+        """Implement functionality similar to c10d::gather_object but without distributed enabled."""
         if self.use_dist:
             gather_objs = (
                 cast(List[T], [None] * dist.get_world_size(self.group))
@@ -117,9 +113,7 @@ class _DistWrapper:
         return result
 
     def all_gather_object(self, object: T) -> List[T]:
-        """
-        Same as c10d::all_gather_object but works without distributed enabled.
-        """
+        """Implement functionality similar to c10d::all_gather_object but without distributed enabled."""
         if self.use_dist:
             gather_objs = cast(
                 List[T], [None] * dist.get_world_size(self.group)
@@ -133,9 +127,7 @@ class _DistWrapper:
         return gather_objs
 
     def scatter_object(self, object_list: Optional[List[T]]) -> T:
-        """
-        Same as c10d::scatter_object but works without distributed enabled.
-        """
+        """Implement functionality similar to c10d::scatter_object but without distributed enabled."""
         if self.use_dist:
             gather_result = cast(List[T], [None])
             dist.scatter_object_list(
@@ -394,9 +386,7 @@ def _create_file_view(file: io.IOBase, offset: int, length: int) -> io.IOBase:
 
 
 def _normalize_device_info(device_type: str, device_id: int) -> str:
-    """
-    Device info normalization.
-    """
+    """Device info normalization."""
     if device_type == "cpu":
         return "cpu"
     return f"{device_type}:{device_id}"

--- a/torch/distributed/tensor/parallel/_utils.py
+++ b/torch/distributed/tensor/parallel/_utils.py
@@ -24,10 +24,10 @@ LayoutsType = Union[Placement, Tuple[Placement, ...]]
 
 def _deprecate_warnings(func_name: str, extra_msg: str) -> None:
     """
-    Inject common validation logics for `_prepare_input` funcs via this
-    decorator, including verifying that input needs to be either
-    a :class:`Tensor` or :class:`DTensor` and only 1D :class:`DeviceMesh`
-    is passed in.
+    Inject common validation logics for `_prepare_input` funcs via this decorator.
+
+    Include verifying that input needs to be either a :class:`Tensor` or :class:`DTensor`
+    and only 1D :class:`DeviceMesh` is passed in.
     """
     # TODO: Will follow up with dynamo POC to make warnings.warn working with dynamo.
     if not is_torchdynamo_compiling():
@@ -38,8 +38,9 @@ def _prepare_input_validate(
     _prepare_input_func: _PrepareInputType,
 ) -> _PrepareInputType:
     """
-    Inject common validation logics for `_prepare_input` funcs via this
-    decorator, including verifying that input needs to be either
+    Inject common validation logics for `_prepare_input` funcs via this decorator.
+
+    Include verifying that input needs to be either
     a :class:`Tensor` or :class:`DTensor` and only 1D :class:`DeviceMesh`
     is passed in.
 
@@ -61,7 +62,6 @@ def _prepare_input_validate(
         >>> dtensor = make_input_shard_1d(input, device_mesh, 1)
         >>> # This will call '_prepare_input_validate' first
     """
-
     @functools.wraps(_prepare_input_func)
     def wrapper(*args, **kwargs):  # pyre-ignore[2, 3]
         assert len(args) >= 1, "_prepare_input needs at least one arg."
@@ -91,8 +91,9 @@ def _prepare_output_validate(
     _prepare_output_func: _PrepareOutputType,
 ) -> _PrepareOutputType:
     """
-    Inject common validation logics for _prepare_output funcs via this
-    decorator, including verifying that output needs to be a DTensor
+    Inject common validation logics for _prepare_output funcs via this decorator.
+
+    Include verifying that output needs to be a DTensor
     and only 1D Device Mesh is passed in.
 
     Example::
@@ -112,7 +113,6 @@ def _prepare_output_validate(
     Return:
         func (Callable): Same input func with validation logic added.
     """
-
     @functools.wraps(_prepare_output_func)
     def wrapper(*args, **kwargs):  # pyre-ignore[2, 3]
         assert len(args) >= 1, "_prepare_output needs at least one arg."
@@ -138,8 +138,7 @@ def _prepare_output_validate(
 
 def _create_1d_device_mesh(device_mesh: DeviceMesh, tp_mesh_dim: int = 0) -> DeviceMesh:
     """
-    This function converts a N-D ``device_mesh`` into a 1D ``device_mesh``
-    for 1D Tensor Parallelism.
+    Convert a N-D ``device_mesh`` into a 1D ``device_mesh`` for 1D Tensor Parallelism.
 
     Args:
         device_mesh (DeviceMesh):

--- a/torch/distributed/tensor/parallel/_view_with_dim_change.py
+++ b/torch/distributed/tensor/parallel/_view_with_dim_change.py
@@ -17,7 +17,8 @@ def _view_with_sharding_dim_change(
     tensor: Union[torch.Tensor, DT], sharding_dim: int, shape: Tuple[int, ...]
 ) -> Union[torch.Tensor, DT]:
     """
-    We change the implicit sharding dim for a distributed tensor without comms.
+    Change the implicit sharding dim for a distributed tensor without comms.
+
     Because if we don't change sharding dim, we will ended up having more comms that are not necessary.
     Note that this op will produce invalid DTensor, you will need to call this op in pair to recover
     it back to a valid DTensor.
@@ -33,9 +34,7 @@ def _view_with_sharding_dim_change(
 def _infer_dtensor_stride(
     local_tensor: torch.Tensor, mesh: DeviceMesh, placements: Sequence[Placement]
 ) -> Tuple[int, ...]:
-    """
-    infer the dtensor stride from a local tensor
-    """
+    """Infer the dtensor stride from a local tensor."""
     tensor_stride = list(local_tensor.stride())
     for idx, placement in enumerate(placements):
         if placement.is_shard():

--- a/torch/distributed/tensor/parallel/api.py
+++ b/torch/distributed/tensor/parallel/api.py
@@ -38,8 +38,9 @@ def parallelize_module(  # type: ignore[return]
     tp_mesh_dim: int = 0,
 ) -> nn.Module:
     """
-    The API to apply Tensor Parallelism (TP) in PyTorch. We parallelize module
-    or sub_modules based on a parallelize_plan. The parallelize_plan contains
+    Apply Tensor Parallelism (TP) in PyTorch by parallelizing modules or sub-modules based on a user-specified plan.
+
+    We parallelize module or sub_modules based on a parallelize_plan. The parallelize_plan contains
     :class:`ParallelStyle`, which indicates how user wants the module or sub_module
     to be parallelized.
 
@@ -80,7 +81,6 @@ def parallelize_module(  # type: ignore[return]
         We recommend users to try ``ColwiseParallel`` and ``RowwiseParallel`` for each parameter
         or submodule and there might be some code changes needed now.
     """
-
     torch._C._log_api_usage_once("torch.distributed.tensor.parallel.parallelize_module")
 
     # instantiate a TP RNG state tracker if it's not there
@@ -148,8 +148,9 @@ def parallelize_module(  # type: ignore[return]
 
 def _is_mlp_for_pairwise_parallel(module: nn.Module) -> bool:
     """
-    Traverse through all the immediate children of the given module and count the
-    number of Linear module. If the number is more than one, we return True.
+    Traverse through all the immediate children of the given module and count the number of Linear module.
+
+    If the number is more than one, we return True.
 
     Args:
         module (:class:`nn.Module`):
@@ -173,8 +174,7 @@ def _rowwise_parallelize_linear_fn(
     device_mesh: DeviceMesh,
 ) -> None:
     """
-    This function parallelizes the input :class:`nn.Linear` module in
-    :class:`RowwiseParallel` style.
+    Parallelize the input :class:`nn.Linear` module in :class:`RowwiseParallel` style.
 
     Args:
         name (str):
@@ -187,7 +187,6 @@ def _rowwise_parallelize_linear_fn(
     Returns:
         None
     """
-
     for name, param in module.named_parameters():
         dist_spec = (
             [Shard(1)] if name == "weight" else [Replicate()]  # type: ignore[list-item]
@@ -213,8 +212,7 @@ def _colwise_parallelize_linear_fn(
     sharding_dim: int = 0,
 ) -> None:
     """
-    This function parallelizes the input :class:`nn.Linear` or :class:`nn.Embedding`
-    module in :class:`ColwiseParallel` style.
+    Parallelize the input :class:`nn.Linear` or :class:`nn.Embedding` module in :class:`ColwiseParallel` style.
 
     Args:
         name (str):
@@ -227,7 +225,6 @@ def _colwise_parallelize_linear_fn(
     Returns:
         None
     """
-
     for name, param in module.named_parameters():
         dist_param = torch.nn.Parameter(
             distribute_tensor(param, device_mesh, [Shard(sharding_dim)])
@@ -242,6 +239,8 @@ def _parallelize_linear_like_module(
     tp_mesh_dim: int = 0,
 ) -> nn.Module:
     """
+    Parallelize an nn.Linear module over a 1-d DeviceMesh based on a specified ParallelStyle for Tensor Parallelism.
+
     This function requires that the input module be an object
     of :class:`nn.Linear`.
     The module will be parallelized over a 1-d :class:`DeviceMesh`
@@ -270,7 +269,6 @@ def _parallelize_linear_like_module(
     Return:
         A :class:`nn.Module` object parallelized.
     """
-
     if not isinstance(module, (nn.Linear, nn.Embedding)):
         raise RuntimeError(
             f"Expect a torch.nn.Linear or a torch.nn.Embedding module but received {type(module)}!"
@@ -321,6 +319,8 @@ def _parallelize_mlp(
     tp_mesh_dim: int = 0,
 ) -> nn.Module:
     """
+    Parallelize a sequence of nn.Linear modules over a 1-d DeviceMesh based on a specified ParallelStyle.
+
     This function assumes the input module is a sequence of nn.Linear
     and we parallelize the module based on the given parallel style.
     We don't change the FQN of each sub-module and replace each parameter

--- a/torch/distributed/tensor/parallel/fsdp.py
+++ b/torch/distributed/tensor/parallel/fsdp.py
@@ -227,8 +227,9 @@ def _chunk_dtensor(
     device_mesh: DeviceMesh,
 ) -> DTensor:
     """
-    Shard a tensor to chunks along the first dimension. The local rank will gets its
-    corresponding chunk as the local tensor to create a DTensor.
+    Shard a tensor to chunks along the first dimension.
+
+    The local rank will gets its corresponding chunk as the local tensor to create a DTensor.
     """
     parent_mesh = _mesh_resources.get_parent_mesh(device_mesh)
     if parent_mesh is None:
@@ -299,9 +300,7 @@ def _all_gather_dtensor(
     tensor: DTensor,
     parent_mesh: Optional[DeviceMesh],
 ) -> torch.Tensor:
-    """
-    All gather a DTensor in its FSDP dimension and return the local tensor.
-    """
+    """All gather a DTensor in its FSDP dimension and return the local tensor."""
     assert parent_mesh == tensor.device_mesh
 
     placements = list(copy.deepcopy(tensor.placements))
@@ -318,6 +317,7 @@ def _all_gather_dtensor(
 class DTensorExtensions(FSDPExtensions):
     """
     DTensorExtension is the TensorFlattener extension needed for 2D FSDP + TP.
+
     This is the implementation for FSDPExtensions defined in
     https://github.com/pytorch/pytorch/blob/main/torch/distributed/fsdp/_fsdp_extensions.py
     """
@@ -371,15 +371,14 @@ class DTensorExtensions(FSDPExtensions):
 # TODO: remove enable_2d_with_fsdp() once we roll out the new 2D flow.
 def enable_2d_with_fsdp() -> bool:
     """
-    The API registers the extension which is needed for Tensor Parallelism (TP)
-    to work with FullyShardedDataParallel (FSDP). We first parallelize parameters
-    within one module or sub_modules based on a parallelize_plan and will let FSDP
+    Register the extension which is needed for Tensor Parallelism (TP) to work with FullyShardedDataParallel (FSDP).
+
+    We first parallelize parameters within one module or sub_modules based on a parallelize_plan and will let FSDP
     reshard the local tensor of distributed parameter which is essentially a DTensor.
 
     Return:
         A `bool` indicated whether extension registration succeeds or not.
     """
-
     torch._C._log_api_usage_once(
         "torch.distributed.tensor.parallel.enable_2d_with_fsdp"
     )

--- a/torch/distributed/tensor/parallel/input_reshard.py
+++ b/torch/distributed/tensor/parallel/input_reshard.py
@@ -16,6 +16,8 @@ def input_reshard(
     input_reshard_dim: Optional[int] = None,
 ) -> torch.nn.Module:
     """
+    Register hooks to an nn.Module for input resharding, enabling sharding and restoration during backward computation.
+
     Register hooks to an nn.Module with input resharding so that we can shard
     per the given `tp_device_mesh` and `input_reshard_dim` and restore the
     input back when recomputing the activations in the backward. The reason
@@ -58,11 +60,8 @@ def input_reshard(
     return module
 
 
-def _pack_hook_tp(mesh: DeviceMesh, input_reshard_dim: int, x: torch.Tensor) -> Any:
-    """
-    Hook functions called after FWD to shard input.
-    """
-
+def _pack_hook_tp(mesh: DeviceMesh, input_reshard_dim: int, x: torch.Tensor) -> Any:  # noqa: D401
+    """Hook function called after FWD to shard input."""
     if isinstance(x, DTensor) and all(p.is_replicate() for p in x._spec.placements):
         return x.redistribute(device_mesh=mesh, placements=[Shard(input_reshard_dim)])
     elif (
@@ -79,11 +78,8 @@ def _pack_hook_tp(mesh: DeviceMesh, input_reshard_dim: int, x: torch.Tensor) -> 
         return x
 
 
-def _unpack_hook_tp(mesh: DeviceMesh, input_reshard_dim: int, x: Any) -> torch.Tensor:
-    """
-    Hook functions called before activation recomputing in BWD to restore input.
-    """
-
+def _unpack_hook_tp(mesh: DeviceMesh, input_reshard_dim: int, x: Any) -> torch.Tensor:  # noqa: D401
+    """Hook function called before activation recomputing in BWD to restore input."""
     if (
         isinstance(x, DTensor)
         and len(x._spec.placements) == 1

--- a/torch/distributed/tensor/parallel/style.py
+++ b/torch/distributed/tensor/parallel/style.py
@@ -37,6 +37,7 @@ __all__ = [
 class ParallelStyle(ABC):
     """
     The parallel style user wants the module or submodule to be parallelized.
+
     Users can extend this class to build their own parallel style with customized input/output preparations.
 
     .. warning::
@@ -69,8 +70,9 @@ class ParallelStyle(ABC):
 
 class PairwiseParallel(ParallelStyle):
     """
-    PairwiseParallel concatenate colwise and rowwise styles as a fixed
-    pair like what Megatron-LM(https://arxiv.org/abs/1909.08053) is doing.
+    PairwiseParallel concatenate colwise and rowwise styles as a fixed pair.
+
+    Similar to what Megatron-LM(https://arxiv.org/abs/1909.08053) is doing.
     We assume both input and output need to be replicate DTensors.
 
     .. warning::
@@ -108,9 +110,9 @@ class PairwiseParallel(ParallelStyle):
 
 class SequenceParallel(PairwiseParallel):
     """
-    SequenceParallel concatenate colwise and rowwise styles as a fixed
-    pair together with sequence parallel like what Megatron-LM Sequence parallel
-    (https://arxiv.org/pdf/2205.05198.pdf) is doing.
+    SequenceParallel concatenate colwise and rowwise styles as a fixed pair together with sequence parallel.
+
+    Similar to what Megatron-LM Sequence parallel(https://arxiv.org/pdf/2205.05198.pdf) is doing.
     We assume both input and output need to be sharded DTensors.
 
     .. warning::
@@ -145,7 +147,7 @@ def make_input_shard_1d(
     input: Union[torch.Tensor, DTensor],
     device_mesh: Optional[DeviceMesh] = None,
     dim: int = 0,
-) -> DTensor:
+) -> DTensor:  # noqa: D205, D400
     """
     .. warning::
         This method was deprecated and please specify ``input_layouts`` instead.
@@ -167,7 +169,7 @@ def make_input_shard_1d(
 def make_input_shard_1d_last_dim(
     input: Union[torch.Tensor, DTensor],
     device_mesh: Optional[DeviceMesh] = None,
-) -> DTensor:
+) -> DTensor:  # noqa: D205, D400
     """
     .. warning::
         This method was deprecated and please specify ``input_layouts`` instead.
@@ -182,7 +184,7 @@ def make_input_shard_1d_last_dim(
 def make_input_reshard_replicate(
     input: torch.Tensor,
     device_mesh: DeviceMesh,
-) -> DTensor:
+) -> DTensor:  # noqa: D205, D400
     """
     .. warning::
         This method was deprecated and please specify ``input_layouts`` instead.
@@ -199,7 +201,7 @@ def make_input_reshard_replicate(
 def make_input_replicate_1d(
     input: Union[torch.Tensor, DTensor],
     device_mesh: Optional[DeviceMesh] = None,
-) -> DTensor:
+) -> DTensor:  # noqa: D205, D400
     """
     .. warning::
         This method was deprecated and please specify ``input_layouts`` instead.
@@ -220,7 +222,7 @@ def make_input_replicate_1d(
 @_prepare_output_validate  # type: ignore[arg-type] # pyre-ignore[56]
 def make_output_shard_1d(
     output: DTensor, device_mesh: Optional[DeviceMesh] = None, dim: int = 0
-) -> DTensor:
+) -> DTensor:  # noqa: D205, D400
     """
     .. warning::
         This method was deprecated and please specify ``output_layouts`` instead.
@@ -232,7 +234,7 @@ def make_output_shard_1d(
 @_prepare_output_validate  # type: ignore[arg-type] # pyre-ignore[56]
 def make_output_replicate_1d(
     output: DTensor, device_mesh: Optional[DeviceMesh] = None
-) -> DTensor:
+) -> DTensor:  # noqa: D205, D400
     """
     .. warning::
         This method was deprecated and please specify ``output_layouts`` instead.
@@ -244,7 +246,7 @@ def make_output_replicate_1d(
 @_prepare_output_validate  # type: ignore[arg-type] # pyre-ignore[56]
 def make_output_tensor(
     output: DTensor, device_mesh: Optional[DeviceMesh] = None
-) -> torch.Tensor:
+) -> torch.Tensor:  # noqa: D205, D400
     """
     .. warning::
         This method was deprecated and please specify ``output_layouts`` instead.
@@ -258,7 +260,7 @@ def make_output_tensor(
 @_prepare_output_validate  # type: ignore[arg-type] # pyre-ignore[56]
 def make_sharded_output_tensor(
     output: DTensor, _device_mesh: Optional[DeviceMesh] = None
-) -> torch.Tensor:
+) -> torch.Tensor:  # noqa: D205, D400
     """
     .. warning::
         This method was deprecated and please specify ``output_layouts`` instead.
@@ -271,7 +273,7 @@ def make_sharded_output_tensor(
 def make_output_reshard_tensor(
     output: DTensor,
     device_mesh: Optional[DeviceMesh] = None,
-) -> torch.Tensor:
+) -> torch.Tensor:  # noqa: D205, D400
     """
     .. warning::
         This method was deprecated and please specify ``output_layouts`` instead.
@@ -314,7 +316,8 @@ def _redistribute_per_layout(layout, use_local_output, t, device_mesh):
 
 class RowwiseParallel(ParallelStyle):
     """
-    Partitioning the row of a module.
+    Partition the row of a module.
+
     We assume the input to be a sharded :class:`DTensor` and output to be a :class:`torch.Tensor`.
 
     Args:
@@ -404,7 +407,8 @@ class RowwiseParallel(ParallelStyle):
 
 class ColwiseParallel(ParallelStyle):
     """
-    Partitioning the column of a tensor or module.
+    Partition the column of a tensor or module.
+
     We assume the input to be a replicated :class:`DTensor` and output to be a sharded :class:`torch.Tensor`.
 
     Args:
@@ -493,6 +497,8 @@ class ColwiseParallel(ParallelStyle):
 
 class PrepareModuleInput(ParallelStyle):
     """
+    Annotate Tensor inputs with layouts for conversion to DTensor, redistributing based on specified output layouts.
+
     :class:`PrepareModuleInput` enables users to annotate :class:`torch.Tensor` or :class:`DTensor`
     inputs with ``input_layouts`` and ``output_layouts`` so that each input can be converted to
     :class:`DTensor` based on the annotation. Specifically, a DTensor will be created
@@ -524,7 +530,7 @@ class PrepareModuleInput(ParallelStyle):
         input_layouts: LayoutsType = Shard(0),
         output_layouts: LayoutsType = Replicate(),
         use_local_output: bool = False,
-    ) -> None:
+    ) -> None:  # noqa: D205, D400
         """
         Args:
             input_layouts (Union[Placement, Tuple[Placement, ...]]):
@@ -562,9 +568,7 @@ class PrepareModuleInput(ParallelStyle):
         inputs: Tuple[Any, ...],
         device_mesh: Optional[DeviceMesh] = None,
     ) -> Optional[Any]:
-        """
-        Redistribute inputs over a device mesh.
-        """
+        """Redistribute inputs over a device mesh."""
         # Always assume layouts are tuples.
         results = []
         for input, input_layout, output_layout in zip(
@@ -583,6 +587,8 @@ class PrepareModuleInput(ParallelStyle):
 
 class PrepareModuleOutput(ParallelStyle):
     """
+    Enable annotation of DTensor outputs for flexible conversion to torch.Tensor based on specified layouts.
+
     :class:`PrepareModuleOutput` enables users to annotate :class:`DTensor` outputs
     with ``output_layouts`` and ``use_local_output`` so that each output can be converted to
     :class:`DTensor` or :class:`torch.Tensor` based on the annotation. Specifically, a DTensor
@@ -614,7 +620,7 @@ class PrepareModuleOutput(ParallelStyle):
         input_layouts: LayoutsType = Replicate(),
         output_layouts: LayoutsType = Shard(0),
         use_local_output: bool = True,
-    ) -> None:
+    ) -> None:  # noqa: D205, D400
         """
         Args:
             input_layouts (Union[Placement, Tuple[Placement, ...]]):


### PR DESCRIPTION
Fixes: #113193

`pydocstyle <all_files_in_issue> --count`

- Before: 345
- After: 130

For deprecated methods, I have added a `noqa` to ignore them. I was not able to find the file `torch/distributed/tensor/parallel/multihead_attention_tp.py`, so I've ignored it for this PR.

cc @svekars @carljparker