### PR TITLE
Fix test_add_scalar_with_empty_list_tensor

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -342,7 +342,7 @@ class TestForeach(TestCase):
                 expected = ref(ref_inputs, values=values)
                 self.assertEqual(expected, actual)
 
-    @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool))
+    @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16))
     def test_add_scalar_with_empty_list_and_empty_tensor(self, device, dtype):
         # TODO: enable empty list case
         for tensors in [[torch.randn([0], device=device, dtype=dtype)]]:

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -345,7 +345,7 @@ class TestForeach(TestCase):
     @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool))
     def test_add_scalar_with_empty_list_and_empty_tensor(self, device, dtype):
         # TODO: enable empty list case
-        for tensors in [[torch.randn([0])]]:
+        for tensors in [[torch.randn([0], device=device, dtype=dtype)]]:
             res = torch._foreach_add(tensors, 1)
             self.assertEqual(res, tensors)
 


### PR DESCRIPTION
By actually instantiating test method to a different types and devices rather than always creating it on CPU.
Also, remove `bool` from the list, as adding 1 to bool is not supported.
