### PR TITLE
[pytorch] Remove dot if no suffix

### DIFF
--- a/torch/cuda/nccl.py
+++ b/torch/cuda/nccl.py
@@ -37,7 +37,10 @@ def version():
     minor = (ver >> 16) & 65535
     patch = ver & 65535
     suffix = torch._C._nccl_version_suffix().decode("utf-8")
-    return (major, minor, patch, suffix)
+    if suffix == "":
+        return (major, minor, patch)
+    else:
+        return (major, minor, patch, suffix)
 
 
 def unique_id():


### PR DESCRIPTION
Summary: Add the suffix to the version string shouldn't happen if there is no suffix.

Test Plan:
```
/data/users/wbland/fbsource/buck-out/v2/gen/fbcode/param_bench/train/comms/pt/comms.par \
--backend nccl --device cuda --collective all_gather \
--master-ip <snip> --log INFO --b 256 --e 1K \
--num-coll-per-iteration 10 --mode comms--num_iters 5 --w 1 --z 1
...
I1108 07:58:33.852557 2344130 ProcessGroupNCCL.cpp:990] [Rank 0] ProcessGroupNCCL initialization options: NCCL version: 2.17.1, NCCL_ASYNC_ERROR_HANDLING: 3, NCCL_DESYNC_DEBUG: 0, NCCL_ENABLE_TIMING: 0, NCCL_BLOCKING_WAIT: 0, TIMEOUT(ms): 600000, USE_HIGH_PRIORITY_STREAM: 0, TORCH_DISTRIBUTED_DEBUG: OFF, NCCL_DEBUG: OFF, ID=139992854228992
...
```

Differential Revision: D51116095

