### PR TITLE
[dynamo] Make decorators.py pass follow-import typechecking

### DIFF
--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -76,9 +76,11 @@ def _rebuild_from_type_v2(func, new_type, args, state):
 # to define a ForkingPickler serialization mode for the class.
 #
 # NB: If you add a new method to Tensor, you must update
-# torch/__init__.py.in to add a type annotation for your method;
+# torch/_C/__init__.pyi.in to add a type annotation for your method;
 # otherwise, it will not show up in autocomplete.
 class Tensor(torch._C.TensorBase):
+    _dynamo_static_input_type: str  # Set in `mark_static_address`
+
     def __deepcopy__(self, memo):
         if has_torch_function_unary(self):
             return handle_torch_function(Tensor.__deepcopy__, (self,), self, memo)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #113307
* #113306
* #113305
* __->__ #113304

I am trying to turn on `follow_imports=silent` for MYPYNOFOLLOW.
However, this requires a huge number of changes, so I am breaking it
down to a per-file basis.

Unfortunately, we will not be able to turn on `follow_imports` until all
files are fixed, so there is no way to stop regressions. So I hope to get
these fixes in as fast as possible.