### PR TITLE
[tp] Fix test_tp_transform_with_uncovered_op

### DIFF
--- a/test/distributed/_tensor/experimental/test_tp_transform.py
+++ b/test/distributed/_tensor/experimental/test_tp_transform.py
@@ -68,8 +68,9 @@ class TensorParallelTest(DTensorTestBase):
     @with_comms
     def test_tp_transform_with_uncovered_op(self):
         model = DummyModel().to(device=self.device_type)
-        inputs = (torch.randn(7, 3).to(device=self.device_type),)
-        res = model(*inputs)
+        inputs = (torch.randn(7, 3, requires_grad=False).to(device=self.device_type),)
+        with torch.no_grad():
+            res = model(*inputs)
         exported_program = torch._export.export(
             model,
             inputs,
@@ -83,7 +84,8 @@ class TensorParallelTest(DTensorTestBase):
             {"fc": ColwiseParallel},
         )
         tp_model = tp_exported_program.module()
-        tp_res = tp_model(*inputs)
+        with torch.no_grad():
+            tp_res = tp_model(*inputs)
         self.assertEqual(res, tp_res)
         # Expect all_gather to be inserted to distributed sharded fc resutls
         self.assert_has_c10d_ops(


### PR DESCRIPTION
Summary:
Test fails on CPU currently with some weird error when `wait_tensor = torch.ops.c10d_functional.wait_tensor.default(all_gather_into_tensor);` runs.
```
[rank2]:[2023-11-08 13:30:29,940] torch.testing._internal.common_distributed: [ERROR] RuntimeError: A view was created in no_grad mode and is being modified inplace with grad mode enabled. This view is the output of a function that returns multiple views. Such functions do not allow the output views to be modified inplace. You should replace the inplace operation by an out-of-place one.
```

https://www.internalfb.com/intern/test/562950070959214/

Test Plan: buck test mode/opt  -c fbcode.enable_gpu_sections=true //caffe2/test/distributed/_tensor/experimental:tp_transform

Reviewed By: weifengpy

Differential Revision: D51131676


