### PR TITLE
[Execution Trace] record global rank in pg_config_info

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -558,7 +558,7 @@ class _World:
                     "pg_name": self.pg_names[pg],
                     "backend_id": pg._backend_id(backend_type),
                     "backend_config": self.pg_backend_config[pg],
-                    "ranks": list(ranks.values())
+                    "ranks": list(ranks.keys())
                     if len(ranks) != default_pg_size
                     else [],  # 'ranks' is an empty list when all ranks are involved in a pg
                     "group_size": len(ranks),


### PR DESCRIPTION
Summary:
pg_config_info is used to dump pg information in Execution Trace(ET). For trace analysis purpose and PARAM replay benchmark, global rank is more meaningful than group ranks.

p.s. ranks is a map of global rank: group rank

Test Plan: Tested in HPC

Differential Revision: D51136587


