### PR TITLE
Skip if the max element is 0 to avoid invalid config for CAT

### DIFF
--- a/aten/src/ATen/native/cuda/Shape.cu
+++ b/aten/src/ATen/native/cuda/Shape.cu
@@ -319,6 +319,9 @@ void parallel_cat(const Tensor &out, const MaterializedITensorListRef& inputs, i
         catMetaData.nElements[batchCounter]);
     }
 
+    // Skip if the tensor is empty. Otherwise, the grid dim is invalid
+    if (max_elements_per_tensor == 0)
+      continue;
 
     dim3 applyBlock, catGrid;
 


### PR DESCRIPTION
Summary:
We observe cuda invalid configuration during training. Here is an example log: https://www.internalfb.com/phabricator/paste/view/P876519113 It's actually caused by grid dim is 0

Here is an example failed job: https://www.internalfb.com/mlhub/pipelines/runs/mast/aps-zorror-996644c19c?version=0&env=PRODUCTION

Test Plan: unit test

Differential Revision: D51136494

