### PR TITLE
Switch dependencies on tp2 benchmark to third-party/benchmark

### DIFF
--- a/benchmarks/cpp/tensorexpr/bench_concat.cpp
+++ b/benchmarks/cpp/tensorexpr/bench_concat.cpp
@@ -12,7 +12,7 @@ namespace {
 
 class ConcatBench : public benchmark::Fixture {
  public:
-  void init(const std::vector<std::vector<int>> input_sizes, int concat_dim) {
+  void init(const std::vector<std::vector<int64_t>> input_sizes, int concat_dim) {
     input_sizes_ = std::move(input_sizes);
     concat_dim_ = concat_dim;
     inputs_.resize(input_sizes_.size());
@@ -166,7 +166,7 @@ class ConcatBench : public benchmark::Fixture {
     }
   }
 
-  std::vector<std::vector<int>> input_sizes_;
+  std::vector<std::vector<int64_t>> input_sizes_;
   int concat_dim_;
   std::vector<at::Tensor> inputs_;
   std::vector<int> output_size_;

--- a/benchmarks/cpp/tensorexpr/bench_signed_log1p.cpp
+++ b/benchmarks/cpp/tensorexpr/bench_signed_log1p.cpp
@@ -139,7 +139,7 @@ class SignedLog1pBench : public benchmark::Fixture {
 
  private:
   std::vector<long> input_size_;
-  std::vector<int> input_size_int_;
+  std::vector<int64_t> input_size_int_;
   at::Tensor input_;
   at::Tensor output_;
   at::Tensor ref_;


### PR DESCRIPTION
Summary: Upgrade benchmark versions. This includes changes to accommodate the [switch from `int` to `int64_t`](https://github.com/google/benchmark/pull/548).

Test Plan: Sandcastle

Differential Revision: D50998199


