### PR TITLE
remove jit from dynamo benchmark

### DIFF
--- a/benchmarks/dynamo/dist_util.py
+++ b/benchmarks/dynamo/dist_util.py
@@ -95,7 +95,7 @@ def get_model(args):
         )
         benchmark_cls = getattr(module, "Model", None)
         bm = benchmark_cls(
-            test="train", device=args.device, jit=False, batch_size=args.batch_size
+            test="train", device=args.device, batch_size=args.batch_size
         )
         model, inputs = bm.get_module()
     elif args.toy_model:

--- a/benchmarks/dynamo/dist_util.py
+++ b/benchmarks/dynamo/dist_util.py
@@ -94,9 +94,7 @@ def get_model(args):
             f"torchbenchmark.models.{args.torchbench_model}"
         )
         benchmark_cls = getattr(module, "Model", None)
-        bm = benchmark_cls(
-            test="train", device=args.device, batch_size=args.batch_size
-        )
+        bm = benchmark_cls(test="train", device=args.device, batch_size=args.batch_size)
         model, inputs = bm.get_module()
     elif args.toy_model:
         model = ToyModel()


### PR DESCRIPTION
Continuous of https://github.com/pytorch/pytorch/pull/106071, without this dynamo dist cannot run at the moment.

Related to https://github.com/pytorch/benchmark/pull/1787

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng