### PR TITLE
[inductor test] enable dynamic loop for test_adaptive_avg_pool1d_argmax

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7505,7 +7505,7 @@ class CommonTemplate:
             x = torch.argmax(input=x)
             return x
 
-        x = torch.rand([3, 3, 3], dtype=torch.float64)
+        x = torch.rand([4, 4, 3], dtype=torch.float64)
         self.common(fn, (x,))
 
 

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -136,7 +136,6 @@ test_failures = {
     "test_zeros_dynamic_shapes": TestFailure(("cpu",)),
     "test_uint_dynamic_shapes": TestFailure(("cpu",)),
     "test_issue102546_dynamic_shapes": TestFailure(("cpu",)),
-    "test_adaptive_avg_pool1d_argmax_dynamic_shapes": TestFailure(("cpu",)),
     #
     # Failed to find for loop/triton kernel:
     #


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #113339
* #113168



cc @voznesenskym @penguinwu @EikanWang @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler