### PR TITLE
Perf improvements for eager GridSampler

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256.h
@@ -83,6 +83,11 @@ inline Vectorized<double> cast<double, float>(const Vectorized<float>& src) {
   return _mm256_castps_pd(src);
 }
 
+template<>
+inline Vectorized<float> cast<float, int32_t>(const Vectorized<int32_t>& src) {
+  return _mm256_cvtepi32_ps(src);
+}
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GATHER ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 template<int64_t scale = 1>
@@ -102,14 +107,14 @@ inline gather(const float* base_addr, const Vectorized<int32_t>& vindex) {
 template<int64_t scale = 1>
 std::enable_if_t<scale == 1 || scale == 2 || scale == 4 || scale == 8, Vectorized<double>>
 inline mask_gather(const Vectorized<double>& src, const double* base_addr,
-                   const Vectorized<int64_t>& vindex, const Vectorized<double>& mask) {
+                   const Vectorized<int64_t>& vindex, Vectorized<double>& mask) {
   return _mm256_mask_i64gather_pd(src, base_addr, vindex, mask, scale);
 }
 
 template<int64_t scale = 1>
 std::enable_if_t<scale == 1 || scale == 2 || scale == 4 || scale == 8, Vectorized<float>>
 inline mask_gather(const Vectorized<float>& src, const float* base_addr,
-                   const Vectorized<int32_t>& vindex, const Vectorized<float>& mask) {
+                   const Vectorized<int32_t>& vindex, Vectorized<float>& mask) {
   return _mm256_mask_i32gather_ps(src, base_addr, vindex, mask, scale);
 }
 

--- a/aten/src/ATen/cpu/vec/vec256/vec256.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256.h
@@ -85,7 +85,12 @@ inline Vectorized<double> cast<double, float>(const Vectorized<float>& src) {
 
 template<>
 inline Vectorized<float> cast<float, int32_t>(const Vectorized<int32_t>& src) {
-  return _mm256_cvtepi32_ps(src);
+  return _mm256_castsi256_ps(src);
+}
+
+template<>
+inline Vectorized<double> cast<double, int64_t>(const Vectorized<int64_t>& src) {
+  return _mm256_castsi256_pd(src);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GATHER ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/aten/src/ATen/cpu/vec/vec512/vec512.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512.h
@@ -71,12 +71,12 @@ inline Vectorized<double> cast<double, float>(const Vectorized<float>& src) {
 
 template<>
 inline Vectorized<float> cast<float, int32_t>(const Vectorized<int32_t>& src) {
-  return _mm512_cvtepi32_ps(src);
+  return _mm512_castsi512_ps(src);
 }
 
 template<>
 inline Vectorized<double> cast<double, int64_t>(const Vectorized<int64_t>& src) {
-  return _mm512_cvtepi64_pd(src);
+  return _mm512_castsi512_pd(src);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GATHER ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/aten/src/ATen/cpu/vec/vec512/vec512.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512.h
@@ -69,6 +69,16 @@ inline Vectorized<double> cast<double, float>(const Vectorized<float>& src) {
   return _mm512_castps_pd(src);
 }
 
+template<>
+inline Vectorized<float> cast<float, int32_t>(const Vectorized<int32_t>& src) {
+  return _mm512_cvtepi32_ps(src);
+}
+
+template<>
+inline Vectorized<double> cast<double, int64_t>(const Vectorized<int64_t>& src) {
+  return _mm512_cvtepi64_pd(src);
+}
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GATHER ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 template<int64_t scale = 1>
@@ -88,7 +98,7 @@ inline gather(const float* base_addr, const Vectorized<int32_t>& vindex) {
 template<int64_t scale = 1>
 std::enable_if_t<scale == 1 || scale == 2 || scale == 4 || scale == 8, Vectorized<double>>
 inline mask_gather(const Vectorized<double>& src, const double* base_addr,
-                   const Vectorized<int64_t>& vindex, const Vectorized<double>& mask) {
+                   const Vectorized<int64_t>& vindex, Vectorized<double>& mask) {
   auto all_ones = _mm512_castsi512_pd(_mm512_set1_epi64(0xFFFFFFFFFFFFFFFF));
   auto mask_ = _mm512_cmp_pd_mask(all_ones, mask.values, _CMP_EQ_OQ);
   return _mm512_mask_i64gather_pd(src, mask_, vindex, base_addr, scale);
@@ -97,7 +107,7 @@ inline mask_gather(const Vectorized<double>& src, const double* base_addr,
 template<int64_t scale = 1>
 std::enable_if_t<scale == 1 || scale == 2 || scale == 4 || scale == 8, Vectorized<float>>
 inline mask_gather(const Vectorized<float>& src, const float* base_addr,
-                   const Vectorized<int32_t>& vindex, const Vectorized<float>& mask) {
+                   const Vectorized<int32_t>& vindex, Vectorized<float>& mask) {
   auto all_ones = _mm512_castsi512_ps(_mm512_set1_epi32(0xFFFFFFFF));
   auto mask_ = _mm512_cmp_ps_mask(all_ones, mask.values, _CMP_EQ_OQ);
   return _mm512_mask_i32gather_ps(src, mask_, vindex, base_addr, scale);


### PR DESCRIPTION
Description:
- Added vectorized `cast` and fixed `mask_gather` signature bug to be used in GridSampler


Perf speed-up results:
- CPU capability usage: AVX2
```
[--------------------------------------------------------------------------------------- Affine grid sampling, cpu ----------------------------------------------------------------------------------------]
                                                                                                          |  Eager (2.2.0a0+git971a50e) PR  |  Eager (2.2.0a0+git3ca81ae) nightly  |  Speed-up PR vs Nightly
1 threads: -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      Input: (1, 3, 500, 400) torch.float32, torch.contiguous_format, align_corners=True, mode=nearest    |        698.871 (+-42.998)       |         1196.590 (+-16.223)          |     1.712 (+-0.000)    
      Input: (1, 3, 500, 400) torch.float64, torch.contiguous_format, align_corners=True, mode=nearest    |       1363.909 (+-49.798)       |         2658.933 (+-62.208)          |     1.949 (+-0.000)    
      Input: (1, 3, 500, 400) torch.float32, torch.channels_last, align_corners=True, mode=nearest        |        542.857 (+-3.547)        |         1166.259 (+-13.349)          |     2.148 (+-0.000)    
      Input: (1, 3, 500, 400) torch.float64, torch.channels_last, align_corners=True, mode=nearest        |       1110.957 (+-173.044)      |         2472.511 (+-37.322)          |     2.226 (+-0.000)    
      Input: (1, 3, 500, 400) torch.float32, torch.contiguous_format, align_corners=False, mode=nearest   |        666.702 (+-3.624)        |         1211.040 (+-15.933)          |     1.816 (+-0.000)    
      Input: (1, 3, 500, 400) torch.float64, torch.contiguous_format, align_corners=False, mode=nearest   |       1383.907 (+-52.735)       |         2680.096 (+-72.214)          |     1.937 (+-0.000)    
      Input: (1, 3, 500, 400) torch.float32, torch.channels_last, align_corners=False, mode=nearest       |        552.020 (+-4.574)        |         1165.713 (+-13.829)          |     2.112 (+-0.000)    
      Input: (1, 3, 500, 400) torch.float64, torch.channels_last, align_corners=False, mode=nearest       |       1195.561 (+-43.627)       |         2479.525 (+-37.279)          |     2.074 (+-0.000)    
      Input: (1, 3, 500, 400) torch.float32, torch.contiguous_format, align_corners=True, mode=bilinear   |       1434.594 (+-18.829)       |         3713.318 (+-53.087)          |     2.588 (+-0.000)    
      Input: (1, 3, 500, 400) torch.float64, torch.contiguous_format, align_corners=True, mode=bilinear   |       2584.424 (+-61.646)       |         6266.618 (+-70.403)          |     2.425 (+-0.000)    
      Input: (1, 3, 500, 400) torch.float32, torch.channels_last, align_corners=True, mode=bilinear       |       1064.318 (+-17.605)       |         3689.232 (+-35.200)          |     3.466 (+-0.000)    
      Input: (1, 3, 500, 400) torch.float64, torch.channels_last, align_corners=True, mode=bilinear       |       2227.200 (+-46.111)       |         6053.448 (+-43.859)          |     2.718 (+-0.000)    
      Input: (1, 3, 500, 400) torch.float32, torch.contiguous_format, align_corners=False, mode=bilinear  |       1479.566 (+-23.023)       |         3695.113 (+-48.203)          |     2.497 (+-0.000)    
      Input: (1, 3, 500, 400) torch.float64, torch.contiguous_format, align_corners=False, mode=bilinear  |       2551.005 (+-58.898)       |         6244.574 (+-66.058)          |     2.448 (+-0.000)    
      Input: (1, 3, 500, 400) torch.float32, torch.channels_last, align_corners=False, mode=bilinear      |       1081.029 (+-13.911)       |         3680.292 (+-35.145)          |     3.404 (+-0.000)    
      Input: (1, 3, 500, 400) torch.float64, torch.channels_last, align_corners=False, mode=bilinear      |       2209.528 (+-61.779)       |         6073.101 (+-99.366)          |     2.749 (+-0.000)    
      Input: (1, 3, 500, 400) torch.float32, torch.contiguous_format, align_corners=True, mode=bicubic    |       4607.162 (+-40.688)       |        14703.326 (+-564.378)         |     3.191 (+-0.000)    
      Input: (1, 3, 500, 400) torch.float64, torch.contiguous_format, align_corners=True, mode=bicubic    |      30132.017 (+-679.033)      |        38338.429 (+-768.288)         |     1.272 (+-0.000)    
      Input: (1, 3, 500, 400) torch.float32, torch.channels_last, align_corners=True, mode=bicubic        |       4274.459 (+-33.603)       |        14766.649 (+-260.509)         |     3.455 (+-0.000)    
      Input: (1, 3, 500, 400) torch.float64, torch.channels_last, align_corners=True, mode=bicubic        |      29137.615 (+-617.591)      |        37420.822 (+-785.526)         |     1.284 (+-0.000)    
      Input: (1, 3, 500, 400) torch.float32, torch.contiguous_format, align_corners=False, mode=bicubic   |       4954.048 (+-79.199)       |        14704.016 (+-330.618)         |     2.968 (+-0.000)    
      Input: (1, 3, 500, 400) torch.float64, torch.contiguous_format, align_corners=False, mode=bicubic   |      30068.414 (+-792.686)      |        38409.600 (+-691.079)         |     1.277 (+-0.000)    
      Input: (1, 3, 500, 400) torch.float32, torch.channels_last, align_corners=False, mode=bicubic       |       4274.381 (+-35.679)       |        14756.324 (+-236.034)         |     3.452 (+-0.000)    
      Input: (1, 3, 500, 400) torch.float64, torch.channels_last, align_corners=False, mode=bicubic       |      29148.286 (+-780.277)      |        37389.990 (+-663.702)         |     1.283 (+-0.000)    

      Input: (8, 3, 500, 400) torch.float32, torch.contiguous_format, align_corners=True, mode=nearest    |       9656.722 (+-66.127)       |        13726.028 (+-112.412)         |     1.421 (+-0.000)    
      Input: (8, 3, 500, 400) torch.float64, torch.contiguous_format, align_corners=True, mode=nearest    |      19947.575 (+-108.492)      |        41501.452 (+-327.186)         |     2.081 (+-0.000)    
      Input: (8, 3, 500, 400) torch.float32, torch.channels_last, align_corners=True, mode=nearest        |       7597.021 (+-52.866)       |         10839.269 (+-93.029)         |     1.427 (+-0.000)    
      Input: (8, 3, 500, 400) torch.float64, torch.channels_last, align_corners=True, mode=nearest        |      28164.663 (+-179.955)      |        34985.201 (+-350.970)         |     1.242 (+-0.000)    
      Input: (8, 3, 500, 400) torch.float32, torch.contiguous_format, align_corners=False, mode=nearest   |       9703.983 (+-154.907)      |        13858.466 (+-128.411)         |     1.428 (+-0.000)    
      Input: (8, 3, 500, 400) torch.float64, torch.contiguous_format, align_corners=False, mode=nearest   |      34086.142 (+-212.213)      |        41104.817 (+-433.195)         |     1.206 (+-0.000)    
      Input: (8, 3, 500, 400) torch.float32, torch.channels_last, align_corners=False, mode=nearest       |       7626.922 (+-56.371)       |         10916.952 (+-96.023)         |     1.431 (+-0.000)    
      Input: (8, 3, 500, 400) torch.float64, torch.channels_last, align_corners=False, mode=nearest       |      28277.855 (+-228.616)      |        34851.453 (+-260.788)         |     1.232 (+-0.000)    
      Input: (8, 3, 500, 400) torch.float32, torch.contiguous_format, align_corners=True, mode=bilinear   |      14180.691 (+-184.150)      |        36243.299 (+-350.811)         |     2.556 (+-0.000)    
      Input: (8, 3, 500, 400) torch.float64, torch.contiguous_format, align_corners=True, mode=bilinear   |      40699.798 (+-234.600)      |        68053.260 (+-1057.869)        |     1.672 (+-0.000)    
      Input: (8, 3, 500, 400) torch.float32, torch.channels_last, align_corners=True, mode=bilinear       |      11190.905 (+-103.419)      |        30729.080 (+-381.639)         |     2.746 (+-0.000)    
      Input: (8, 3, 500, 400) torch.float64, torch.channels_last, align_corners=True, mode=bilinear       |      35965.958 (+-298.474)      |        63030.143 (+-390.692)         |     1.752 (+-0.000)    
      Input: (8, 3, 500, 400) torch.float32, torch.contiguous_format, align_corners=False, mode=bilinear  |      14461.459 (+-120.555)      |        36150.986 (+-293.416)         |     2.500 (+-0.000)    
      Input: (8, 3, 500, 400) torch.float64, torch.contiguous_format, align_corners=False, mode=bilinear  |      40891.653 (+-195.887)      |        67757.076 (+-991.072)         |     1.657 (+-0.000)    
      Input: (8, 3, 500, 400) torch.float32, torch.channels_last, align_corners=False, mode=bilinear      |      11437.092 (+-100.145)      |        30465.192 (+-282.936)         |     2.664 (+-0.000)    
      Input: (8, 3, 500, 400) torch.float64, torch.channels_last, align_corners=False, mode=bilinear      |      36112.937 (+-306.527)      |        63729.695 (+-678.976)         |     1.765 (+-0.000)    
      Input: (8, 3, 500, 400) torch.float32, torch.contiguous_format, align_corners=True, mode=bicubic    |      39512.380 (+-368.172)      |       129854.028 (+-1635.314)        |     3.286 (+-0.000)    
      Input: (8, 3, 500, 400) torch.float64, torch.contiguous_format, align_corners=True, mode=bicubic    |     283835.203 (+-2166.425)     |       352072.211 (+-3178.250)        |     1.240 (+-0.000)    
      Input: (8, 3, 500, 400) torch.float32, torch.channels_last, align_corners=True, mode=bicubic        |      35804.934 (+-341.254)      |       126762.714 (+-1740.266)        |     3.540 (+-0.000)    
      Input: (8, 3, 500, 400) torch.float64, torch.channels_last, align_corners=True, mode=bicubic        |     275862.511 (+-2549.251)     |       341804.886 (+-2974.238)        |     1.239 (+-0.000)    
      Input: (8, 3, 500, 400) torch.float32, torch.contiguous_format, align_corners=False, mode=bicubic   |      39514.504 (+-307.814)      |       130436.644 (+-3081.411)        |     3.301 (+-0.000)    
      Input: (8, 3, 500, 400) torch.float64, torch.contiguous_format, align_corners=False, mode=bicubic   |     283929.198 (+-2373.485)     |       353432.316 (+-3600.725)        |     1.245 (+-0.000)    
      Input: (8, 3, 500, 400) torch.float32, torch.channels_last, align_corners=False, mode=bicubic       |      35776.293 (+-267.109)      |       126884.936 (+-1718.414)        |     3.547 (+-0.000)    
      Input: (8, 3, 500, 400) torch.float64, torch.channels_last, align_corners=False, mode=bicubic       |     276278.294 (+-2150.899)     |       326207.948 (+-2578.309)        |     1.181 (+-0.000)    

Times are in microseconds (us).
```
[Source](https://github.com/vfdev-5/pth-grid-sampler/blob/master/output/20231109-161300-pr_vs_nightly-speedup.md)


TODO: 
- [ ] Add AVX512 benchmark results (I have no access to a cpu with avx512 capabilities anymore)


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10