### PR TITLE
[LLVM] Replaced getInt8PtrTy with getUnqual

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -514,7 +514,7 @@ LLVMCodeGenImpl::LLVMCodeGenImpl(
 #if LLVM_VERSION_MAJOR >= 15
   OpqPtrTy_ = llvm::PointerType::getUnqual(getContext());
 #else
-  Int8PtrTy_ = llvm::Type::getInt8PtrTy(getContext());
+  Int8PtrTy_ = llvm::PointerType::getUnqual(getContext());
 #endif
 
   {
@@ -612,7 +612,7 @@ void LLVMCodeGenImpl::emitWrapper(const std::vector<llvm::Type*>& params) {
       kernel_func_name_,
       module_.get());
 #else
-  auto voidPtrTy = llvm::Type::getInt8PtrTy(getContext());
+  auto voidPtrTy = llvm::PointerType::getUnqual(getContext());
   auto voidPtrPtrTy = voidPtrTy->getPointerTo();
   auto wrapper = llvm::Function::Create(
       llvm::FunctionType::get(IntTy_, {voidPtrPtrTy}, false),
@@ -1477,7 +1477,7 @@ void LLVMCodeGenImpl::visit(LoadPtr v) {
 TypedPointer LLVMCodeGenImpl::packFuncArgs(
     const std::vector<llvm::Value*>& func_args) {
   if (func_args.empty()) {
-    llvm::PointerType* VoidPtrType = llvm::Type::getInt8PtrTy(getContext());
+    llvm::PointerType* VoidPtrType = llvm::PointerType::getUnqual(getContext());
     return TypedPointer(
         VoidPtrType, llvm::ConstantPointerNull::get(VoidPtrType));
   }
@@ -1517,7 +1517,7 @@ std::vector<llvm::Value*> LLVMCodeGenImpl::unpackFuncArgs(
 llvm::Value* LLVMCodeGenImpl::packFuncArgs(
     const std::vector<llvm::Value*>& func_args) {
   if (func_args.empty()) {
-    llvm::PointerType* VoidPtrType = llvm::Type::getInt8PtrTy(getContext());
+    llvm::PointerType* VoidPtrType = llvm::PointerType::getUnqual(getContext());
     llvm::Constant* NullPtr = llvm::ConstantPointerNull::get(VoidPtrType);
     return NullPtr;
   }

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -514,7 +514,7 @@ LLVMCodeGenImpl::LLVMCodeGenImpl(
 #if LLVM_VERSION_MAJOR >= 15
   OpqPtrTy_ = llvm::PointerType::getUnqual(getContext());
 #else
-  Int8PtrTy_ = llvm::PointerType::getUnqual(getContext());
+  Int8PtrTy_ = llvm::Type::getInt8PtrTy((getContext());
 #endif
 
   {
@@ -612,7 +612,7 @@ void LLVMCodeGenImpl::emitWrapper(const std::vector<llvm::Type*>& params) {
       kernel_func_name_,
       module_.get());
 #else
-  auto voidPtrTy = llvm::PointerType::getUnqual(getContext());
+  auto voidPtrTy = llvm::Type::getInt8PtrTy(getContext());
   auto voidPtrPtrTy = voidPtrTy->getPointerTo();
   auto wrapper = llvm::Function::Create(
       llvm::FunctionType::get(IntTy_, {voidPtrPtrTy}, false),
@@ -1477,7 +1477,7 @@ void LLVMCodeGenImpl::visit(LoadPtr v) {
 TypedPointer LLVMCodeGenImpl::packFuncArgs(
     const std::vector<llvm::Value*>& func_args) {
   if (func_args.empty()) {
-    llvm::PointerType* VoidPtrType = llvm::PointerType::getUnqual(getContext());
+    llvm::PointerType* VoidPtrType = llvm::Type::getInt8PtrTy(getContext());
     return TypedPointer(
         VoidPtrType, llvm::ConstantPointerNull::get(VoidPtrType));
   }

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -514,7 +514,7 @@ LLVMCodeGenImpl::LLVMCodeGenImpl(
 #if LLVM_VERSION_MAJOR >= 15
   OpqPtrTy_ = llvm::PointerType::getUnqual(getContext());
 #else
-  Int8PtrTy_ = llvm::Type::getInt8PtrTy((getContext());
+  Int8PtrTy_ = llvm::Type::getInt8PtrTy(getContext());
 #endif
 
   {


### PR DESCRIPTION
[llvm-fb-staging] Build failed on pytorch jit due to llvm upstream API change. The fix should just replace `getInt8PtrTy` with `getUnqual`. The corresponding task - [T169468309](https://www.internalfb.com/tasks/?t=169468309).

cc: @wlei-llvm

cc @EikanWang @jgong5