### PR TITLE
[cpu] Modify inductor opt flag

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1182,7 +1182,9 @@ def cpp_wrapper_flags() -> str:
 
 def optimization_flags() -> str:
     base_flags = "-O0 -g" if config.aot_inductor.debug_compile else "-O3 -DNDEBUG"
-    base_flags += " -ffast-math -fno-unsafe-math-optimizations -fno-finite-math-only"
+    base_flags += " -ffast-math -fno-finite-math-only"
+    if not config.cpp.enable_unsafe_math_opt_flag:
+        base_flags += " -fno-unsafe-math-optimizations"
 
     if config.is_fbcode():
         # FIXME: passing `-fopenmp` adds libgomp.so to the generated shared library's dependencies.

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1182,7 +1182,7 @@ def cpp_wrapper_flags() -> str:
 
 def optimization_flags() -> str:
     base_flags = "-O0 -g" if config.aot_inductor.debug_compile else "-O3 -DNDEBUG"
-    base_flags += " -ffast-math -fno-finite-math-only"
+    base_flags += " -ffast-math -fno-unsafe-math-optimizations -fno-finite-math-only"
 
     if config.is_fbcode():
         # FIXME: passing `-fopenmp` adds libgomp.so to the generated shared library's dependencies.

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -414,6 +414,9 @@ class cpp:
     # using atomic_add.
     fallback_scatter_reduce_sum = True
 
+    # Use funsafe-math-optimizations when compiling
+    enable_unsafe_math_opt_flag = False
+
 
 # config specific to codegen/triton.py
 class triton:


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/113014, https://github.com/pytorch/pytorch/issues/113012, https://github.com/pytorch/pytorch/issues/93598.

For CPU inductor path, remove `-funsafe-math-optimizations` from optimization flags to fix functional issues.

### Validation on 3 benchmark suites

**FP32**
<img width="582" alt="image" src="https://github.com/pytorch/pytorch/assets/23010269/5a648497-a8e2-4057-8dd4-b322e9334456">

- No accuracy problem
- Slight geomean perf drop
- 3 outlier models (speed up < 0.8). Could be solved by adding vectorizations later.

**BF16**
<img width="583" alt="image" src="https://github.com/pytorch/pytorch/assets/23010269/ca1cbd34-5712-4d79-9238-0cc11dd279b1">

- No accuracy problem
- Slight geomean perf drop
- 4 outlier models (speed up < 0.8). Could be solved by adding vectorizations later.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler