### PR TITLE
Update ruff linter to v0.1.5

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -2667,7 +2667,7 @@ init_command = [
     'python3',
     'tools/linter/adapters/pip_init.py',
     '--dry-run={{DRYRUN}}',
-    'ruff==0.1.4',
+    'ruff==0.1.5',
 ]
 is_formatter = true
 


### PR DESCRIPTION
Update ruff linter to v0.1.5. Mainly bugfixes, primarily for autofixes, but good to include since there is at least one pydocstyle autofix update in their as people prepare their pydocstyle PRs.