### PR TITLE
Disallow python_type/as_python_constant on user defined variables

### DIFF
--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -44,12 +44,6 @@ class UserDefinedClassVariable(UserDefinedVariable):
         super().__init__(**kwargs)
         self.value = value
 
-    def as_python_constant(self):
-        return self.value
-
-    def python_type(self):
-        return type(self.value)
-
     def var_getattr(self, tx, name: str) -> "VariableTracker":
         from . import ConstantVariable
         from .builder import VariableBuilder
@@ -212,9 +206,6 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         ]:
             inner = str(getattr(self.value, "__name__", None))
         return f"{self.__class__.__name__}({inner})"
-
-    def python_type(self):
-        return self.value_type
 
     @staticmethod
     @functools.lru_cache(None)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #113360

I need to check how load bearing this is. I think these are wrong, because in Dynamo we have code that assumes that if you can fetch `python_type` on something, then it is OK to be a `ConstantVariable`. But this is definitely not OK for user defined variables!

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng