### PR TITLE
Fix scalar logic in masked_fill operator

### DIFF
--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5431,12 +5431,12 @@ def masked_fill(a: TensorLikeType, mask: TensorLikeType, value: TensorOrNumberLi
             value_ndim == 0,
             lambda: f"only supports a 0-dimensional value tensor, but got tensor with {value_ndim} dimension",
         )
-        # `masked_fill` allows cpu scalar to be moved to cuda and xpu but not otherwise.
-        is_cpu_scalar = a.device.type in ["cuda", "xpu"] and value.device.type == "cpu"
-        torch._check(
-            is_cpu_scalar or value.device == a.device,
-            lambda: "Expected `value` to be on same device as `a`",
-        )
+        # CPU scalars are not supported for MPS in certain cases.
+        if a.device.type != "mps":
+            torch._check(
+                    (value.device.type == "cpu") or (value.device == a.device),
+                    lambda: "Expected `value` to be on same device as `a`",
+                )
         value_type = utils.dtype_to_type(value.dtype)
 
     if value_type is complex:


### PR DESCRIPTION
The current logic only allows for cuda and xps backends to coerce the scalar value. This flips the logic to allow for other backends to coerce the scalar as well, with MPS being the exception. 

