### PR TITLE
Fixed docstring errors in _fuser.py, _state.py, __init__.py, _freeze.py, _async.py, _recursive.py, _tensorboard_vis.py, _trace.py, _await.py, _check.py, _serialization.py, _script.py, annotations.py, _monkeytype_config.py

### DIFF
--- a/torch/contrib/_tensorboard_vis.py
+++ b/torch/contrib/_tensorboard_vis.py
@@ -51,7 +51,7 @@ def visualize(graph, name_prefix='', pb_graph=None, executors_it=None):
 
 
 def visualize_graph_executor(state, name_prefix, pb_graph, inline_graph):
-    """Appends the state of a given GraphExecutor to the graph protobuf.
+    """Append the state of a given GraphExecutor to the graph protobuf.
 
     Args:
         state (GraphExecutor or GraphExecutorState): GraphExecutor to display.

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -104,7 +104,9 @@ _set_fusion_strategy = set_fusion_strategy
 
 def export_opnames(m):
     r"""
-    Generate new bytecode for a Script module and returns what the op list would be for a Script Module based off the current code base.
+    Generate new bytecode for a Script module.
+
+    Returns what the op list would be for a Script Module based off the current code base.
 
     If you have a LiteScriptModule and want to get the currently present
     list of ops call _export_operator_list instead.

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -104,9 +104,9 @@ _set_fusion_strategy = set_fusion_strategy
 
 def export_opnames(m):
     r"""
-    Generates new bytecode for a Script module and returns what the op list
-    would be for a Script Module based off the current code base. If you
-    have a LiteScriptModule and want to get the currently present
+    Generate new bytecode for a Script module and returns what the op list would be for a Script Module based off the current code base.
+
+    If you have a LiteScriptModule and want to get the currently present
     list of ops call _export_operator_list instead.
     """
     return torch._C._export_opnames(m._c)
@@ -122,7 +122,8 @@ Error.__qualname__ = "Error"
 
 # for use in python if using annotate
 def annotate(the_type, the_value):
-    """
+    """Use to give type of `the_value` in TorchScript compiler.
+
     This method is a pass-through function that returns `the_value`, used to hint TorchScript
     compiler the type of `the_value`. It is a no-op when running outside of TorchScript.
 
@@ -170,8 +171,9 @@ def annotate(the_type, the_value):
 
 def script_if_tracing(fn):
     """
-    Compiles ``fn`` when it is first called during tracing. ``torch.jit.script``
-    has a non-negligible start up time when it is first called due to
+    Compiles ``fn`` when it is first called during tracing.
+
+    ``torch.jit.script`` has a non-negligible start up time when it is first called due to
     lazy-initializations of many compiler builtins. Therefore you should not use
     it in library code. However, you may want to have parts of your library work
     in tracing even if they use control flow. In these cases, you should use
@@ -185,15 +187,15 @@ def script_if_tracing(fn):
         If called during tracing, a :class:`ScriptFunction` created by `torch.jit.script` is returned.
         Otherwise, the original function `fn` is returned.
     """
-
     return _script_if_tracing(fn)
 
 
 # for torch.jit.isinstance
 def isinstance(obj, target_type):
     """
-    This function provides for container type refinement in TorchScript. It can refine
-    parameterized containers of the List, Dict, Tuple, and Optional types. E.g. ``List[str]``,
+    Provide container type refinement in TorchScript.
+
+    It can refine parameterized containers of the List, Dict, Tuple, and Optional types. E.g. ``List[str]``,
     ``Dict[str, List[torch.Tensor]]``, ``Optional[Tuple[int,str,int]]``. It can also
     refine basic types such as bools and ints that are available in TorchScript.
 
@@ -234,11 +236,9 @@ def isinstance(obj, target_type):
 
 class strict_fusion:
     """
-    This class errors if not all nodes have been fused in
-    inference, or symbolically differentiated in training.
+    Give errors if not all nodes have been fused in inference, or symbolically differentiated in training.
 
     Example:
-
     Forcing fusion of additions.
 
     .. code-block:: python
@@ -276,17 +276,12 @@ def _hide_source_ranges() -> Iterator[None]:
 
 
 def enable_onednn_fusion(enabled: bool):
-    """
-    Enables or disables onednn JIT fusion based on the parameter `enabled`.
-    """
-
+    """Enable or disables onednn JIT fusion based on the parameter `enabled`."""
     torch._C._jit_set_llga_enabled(enabled)
 
 
 def onednn_fusion_enabled():
-    """
-    Returns whether onednn JIT fusion is enabled
-    """
+    """Return whether onednn JIT fusion is enabled."""
     return torch._C._jit_llga_enabled()
 
 

--- a/torch/jit/_async.py
+++ b/torch/jit/_async.py
@@ -1,4 +1,5 @@
-"""Async API
+"""Async API.
+
 This module contains the API for parallelism in TorchScript, notably:
     * torch.jit.fork
     * torch.jit.wait
@@ -18,9 +19,9 @@ set_module(Future, "torch.jit")
 
 def fork(func, *args, **kwargs):
     r"""
-    Creates an asynchronous task executing `func` and a reference to the value
-    of the result of this execution. `fork` will return immediately,
-    so the return value of `func` may not have been computed yet. To force completion
+    Create an asynchronous task executing `func` and a reference to the value of the result of this execution.
+
+    `fork` will return immediately, so the return value of `func` may not have been computed yet. To force completion
     of the task and access the return value invoke `torch.jit.wait` on the Future. `fork` invoked
     with a `func` which returns `T` is typed as `torch.jit.Future[T]`. `fork` calls can be arbitrarily
     nested, and may be invoked with positional and keyword arguments.
@@ -86,8 +87,9 @@ def fork(func, *args, **kwargs):
 
 def wait(future):
     r"""
-    Forces completion of a `torch.jit.Future[T]` asynchronous task, returning the
-    result of the task. See :func:`~fork` for docs and examples.
+    Force completion of a `torch.jit.Future[T]` asynchronous task, returning the result of the task.
+
+    See :func:`~fork` for docs and examples.
     Args:
         future (torch.jit.Future[T]): an asynchronous task reference, created through `torch.jit.fork`
     Returns:

--- a/torch/jit/_await.py
+++ b/torch/jit/_await.py
@@ -8,25 +8,17 @@ set_module(_Await, "torch.jit")
 
 
 def _awaitable(func, *args, **kwargs):
-    r"""
-    Creates Await object that will call specified functioni with specified args,
-    when it is requested for the result.
-    """
+    r"""Create Await object that will call specified functioni with specified args, when it is requested for the result."""
     return torch._C._awaitable(func, *args, **kwargs)
 
 
 def _awaitable_wait(aw):
-    r"""
-    Requests await the result of execution, if Await is not completed yet,
-    the func will be called immediately.
-    """
+    r"""Request await the result of execution, if Await is not completed yet, the func will be called immediately."""
     return torch._C._awaitable_wait(aw)
 
 
 def _awaitable_nowait(o):
-    r"""
-    Creates completed Await with specified result.
-    """
+    r"""Create completed Await with specified result."""
     return torch._C._awaitable_nowait(o)
 
 

--- a/torch/jit/_check.py
+++ b/torch/jit/_check.py
@@ -7,7 +7,9 @@ import torch
 
 
 class AttributeTypeIsSupportedChecker(ast.NodeVisitor):
-    """Check the ``__init__`` method of a given ``nn.Module`` to ensure that all instance-level attributes can be properly initialized.
+    """Check the ``__init__`` method of a given ``nn.Module``.
+
+    It ensures that all instance-level attributes can be properly initialized.
 
     Specifically, we do type inference based on attribute values...even
     if the attribute in question has already been typed using
@@ -127,7 +129,9 @@ class AttributeTypeIsSupportedChecker(ast.NodeVisitor):
         self.visiting_class_level_ann = False
 
     def visit_AnnAssign(self, node):
-        """Visit an AnnAssign node in an ``nn.Module``'s ``__init__`` method and see if it conforms to our attribute annotation rules."""
+        """Visit an AnnAssign node in an ``nn.Module``'s ``__init__`` method.
+
+        It checks if it conforms to our attribute annotation rules."""
         # If we have a local variable
         try:
             if node.target.value.id != "self":

--- a/torch/jit/_check.py
+++ b/torch/jit/_check.py
@@ -7,9 +7,7 @@ import torch
 
 
 class AttributeTypeIsSupportedChecker(ast.NodeVisitor):
-    """
-    Checks the ``__init__`` method of a given ``nn.Module`` to ensure
-    that all instance-level attributes can be properly initialized.
+    """Check the ``__init__`` method of a given ``nn.Module`` to ensure that all instance-level attributes can be properly initialized.
 
     Specifically, we do type inference based on attribute values...even
     if the attribute in question has already been typed using
@@ -32,7 +30,6 @@ class AttributeTypeIsSupportedChecker(ast.NodeVisitor):
     won't catch it.
 
     Example:
-
         .. code-block:: python
 
             class M(torch.nn.Module):
@@ -107,7 +104,8 @@ class AttributeTypeIsSupportedChecker(ast.NodeVisitor):
         return True
 
     def visit_Assign(self, node):
-        """
+        """Store assignment state when assigning to a Call Node.
+
         If we're visiting a Call Node (the right-hand side of an
         assignment statement), we won't be able to check the variable
         that we're assigning to (the left-hand side of an assignment).
@@ -129,10 +127,7 @@ class AttributeTypeIsSupportedChecker(ast.NodeVisitor):
         self.visiting_class_level_ann = False
 
     def visit_AnnAssign(self, node):
-        """
-        Visit an AnnAssign node in an ``nn.Module``'s ``__init__``
-        method and see if it conforms to our attribute annotation rules.
-        """
+        """Visit an AnnAssign node in an ``nn.Module``'s ``__init__`` method and see if it conforms to our attribute annotation rules."""
         # If we have a local variable
         try:
             if node.target.value.id != "self":
@@ -184,7 +179,8 @@ class AttributeTypeIsSupportedChecker(ast.NodeVisitor):
         )
 
     def visit_Call(self, node):
-        """
+        """Determine if a Call node is 'torch.jit.annotate' in __init__.
+
         Visit a Call node in an ``nn.Module``'s ``__init__``
         method and determine if it's ``torch.jit.annotate``. If so,
         see if it conforms to our attribute annotation rules.

--- a/torch/jit/_freeze.py
+++ b/torch/jit/_freeze.py
@@ -1,4 +1,4 @@
-"""Freezing
+"""Freezing.
 
 This is not intended to be imported directly; please use the exposed
 functionalities in `torch.jit`.
@@ -13,7 +13,8 @@ from torch.jit._script import RecursiveScriptModule, ScriptModule
 def freeze(
     mod, preserved_attrs: Optional[List[str]] = None, optimize_numerics: bool = True
 ):
-    r"""
+    r"""Freeze ScriptModule, inline submodules, and attributes as constants.
+
     Freezing a :class:`ScriptModule` will clone it and attempt to inline the cloned
     module's submodules, parameters, and attributes as constants in the TorchScript IR Graph.
     By default, `forward` will be preserved, as well as attributes & methods specified in
@@ -125,7 +126,8 @@ def run_frozen_optimizations(
     mod, optimize_numerics: bool = True, preserved_methods: Optional[List[str]] = None
 ):
     r"""
-    Runs a series of optimizations looking for patterns that occur in frozen graphs.
+    Run a series of optimizations looking for patterns that occur in frozen graphs.
+
     The current set of optimizations includes:
         - Dropout Removal
         - Pretranspose Linear Layers
@@ -180,8 +182,9 @@ def optimize_for_inference(
     mod: ScriptModule, other_methods: Optional[List[str]] = None
 ) -> ScriptModule:
     """
-    Performs a set of optimization passes to optimize a model for the
-    purposes of inference. If the model is not already frozen, optimize_for_inference
+    Perform a set of optimization passes to optimize a model for the purposes of inference.
+
+    If the model is not already frozen, optimize_for_inference
     will invoke `torch.jit.freeze` automatically.
 
     In addition to generic optimizations that should speed up your model regardless

--- a/torch/jit/_fuser.py
+++ b/torch/jit/_fuser.py
@@ -6,10 +6,7 @@ import torch
 
 @contextlib.contextmanager
 def optimized_execution(should_optimize):
-    """
-    A context manager that controls whether the JIT's executor will run
-    optimizations before executing a function.
-    """
+    """Context manager that controls whether the JIT's executor will run optimizations before executing a function."""
     stored_flag = torch._C._get_graph_executor_optimize()
     torch._C._set_graph_executor_optimize(should_optimize)
     try:
@@ -20,9 +17,7 @@ def optimized_execution(should_optimize):
 
 @contextlib.contextmanager
 def fuser(name):
-    """
-    A context manager that facilitates switching between
-    backend fusers.
+    """Context manager that facilitates switching between backend fusers.
 
     Valid names:
     * ``fuser0`` - enables only legacy fuser
@@ -133,8 +128,7 @@ def _script_method_graph_for(self, parent, *args, **kwargs):
 
 
 def set_fusion_strategy(strategy: List[Tuple[str, int]]):
-    """
-    Sets the type and number of specializations that can occur during fusion.
+    """Set the type and number of specializations that can occur during fusion.
 
     Usage: provide a list of pairs (type, depth) where type is one of "STATIC" or "DYNAMIC"
     and depth is an integer.

--- a/torch/jit/_monkeytype_config.py
+++ b/torch/jit/_monkeytype_config.py
@@ -37,9 +37,7 @@ def is_torch_native_class(cls):
 
 
 def get_type(type):
-    """
-    Helper function which converts the given type to a torchScript acceptable format.
-    """
+    """Convert the given type to a torchScript acceptable format."""
     if isinstance(type, str):
         return type
     elif inspect.getmodule(type) == typing:
@@ -59,7 +57,8 @@ def get_type(type):
 
 
 def get_optional_of_element_type(types):
-    """
+    """Extract element type, return as `Optional[element type]` from consolidated types.
+
     Helper function to extracts the type of the element to be annotated to Optional
     from the list of consolidated types and returns `Optional[element type]`.
     TODO: To remove this check once Union support lands.
@@ -145,10 +144,7 @@ if _IS_MONKEYTYPE_INSTALLED:
             self.s = s
 
         def trace_logger(self) -> JitTypeTraceStoreLogger:
-            """
-            Returns a JitCallTraceStoreLogger that logs to the configured
-            trace store.
-            """
+            """Return a JitCallTraceStoreLogger that logs to the configured trace store."""
             return JitTypeTraceStoreLogger(self.trace_store())
 
         def trace_store(self) -> CallTraceStore:
@@ -176,8 +172,8 @@ else:
 
 
 def jit_code_filter(code: CodeType) -> bool:
-    """
-    Custom CodeFilter for Torchscript to trace forward calls.
+    """Codefilter for Torchscript to trace forward calls.
+
     The custom CodeFilter is required while scripting a FX Traced forward calls.
     FX Traced forward calls have `code.co_filename` start with '<' which is used
     to exclude tracing of stdlib and site-packages in the default code filter.

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -969,7 +969,8 @@ def interface_script(mod_interface, nn_module):
     def infer_interface_methods_to_compile(nn_module):
         """Rule to infer the methods from the interface type.
 
-        It is used to know which methods need to act as starting points for compilation."""
+        It is used to know which methods need to act as starting points for compilation.
+        """
         stubs = []
         for method in mod_interface.getMethodNames():
             stubs.append(make_stub_from_method(nn_module, method))

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -967,7 +967,9 @@ def interface_script(mod_interface, nn_module):
     check_module_initialized(nn_module)
 
     def infer_interface_methods_to_compile(nn_module):
-        """Rule to infer the methods from the interface type to know which methods need to act as starting points for compilation."""
+        """Rule to infer the methods from the interface type.
+
+        It is used to know which methods need to act as starting points for compilation."""
         stubs = []
         for method in mod_interface.getMethodNames():
             stubs.append(make_stub_from_method(nn_module, method))

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -184,8 +184,9 @@ def get_annotations(obj):
 
 def infer_concrete_type_builder(nn_module, share_types=True):
     """
-    Build a ConcreteModuleTypeBuilder from an nn.Module. This
-    ConcreteModuleType doesn't have a JIT type associated with it yet, it
+    Build a ConcreteModuleTypeBuilder from an nn.Module.
+
+    This ConcreteModuleType doesn't have a JIT type associated with it yet, it
     must be filled in by the caller.
     """
     concrete_type_builder = torch._C.ConcreteModuleTypeBuilder(type(nn_module))
@@ -431,10 +432,7 @@ class ConcreteTypeStore:
         self.methods_compiled = set()
 
     def get_or_create_concrete_type(self, nn_module):
-        """
-        Infer a ConcreteType from this `nn.Module` instance. Underlying JIT
-        types are re-used if possible.
-        """
+        """Infer a ConcreteType from this `nn.Module` instance. Underlying JIT types are re-used if possible."""
         concrete_type_builder = infer_concrete_type_builder(nn_module)
 
         nn_module_type = type(nn_module)
@@ -483,9 +481,10 @@ def create_hooks_from_stubs(concrete_type, hook_stubs, pre_hook_stubs):
 
 def get_module_concrete_type(nn_module, share_types=True):
     """
-    Gets a concrete type for nn_modules. If share_types is True, the concrete
-    type is fetched from concrete_type_store. If it is False, a new concrete type
-    is created without first searching concrete_type_store.
+    Get a concrete type for nn_modules.
+
+    If share_types is True, the concrete type is fetched from concrete_type_store.
+    If it is False, a new concrete type is created without first searching concrete_type_store.
 
     Args:
         nn_module:  The original Python nn.Module that we are creating a ScriptModule for.
@@ -537,7 +536,7 @@ def create_script_class(obj):
 
 def create_script_module(nn_module, stubs_fn, share_types=True, is_tracing=False):
     """
-    Creates a new ScriptModule from an nn.Module
+    Create a new ScriptModule from an nn.Module.
 
     Args:
         nn_module:  The original Python nn.Module that we are creating a ScriptModule for.
@@ -839,9 +838,9 @@ def check_module_initialized(mod):
 
 
 def infer_methods_to_compile(nn_module):
-    """
-    Implements the default rules for which methods should act as starting
-    points for compilation (TODO add a link when the rules are published).
+    """Implement the default rules for which methods should act as starting points for compilation.
+
+    (TODO add a link when the rules are published).
     """
     check_module_initialized(nn_module)
     user_annotated_ignored_attributes = getattr(
@@ -901,9 +900,7 @@ def infer_methods_to_compile(nn_module):
 
 
 def get_hook_stubs(nn_module):
-    """
-    Returns forward hook and pre_hook ScriptModuleStubs
-    """
+    """Return forward hook and pre_hook ScriptModuleStubs."""
     check_module_initialized(nn_module)
     hook_map: Dict = {}
 
@@ -937,10 +934,7 @@ def get_hook_stubs(nn_module):
 
 
 def get_property_stubs(nn_module):
-    """
-    Create property stubs for the properties of the module by creating method
-    stubs for the getter and setter.
-    """
+    """Create property stubs for the properties of the module by creating method stubs for the getter and setter."""
     module_ty = type(nn_module)
     properties_asts = get_class_properties(module_ty, self_name="RecursiveScriptModule")
     rcbs = {}
@@ -961,8 +955,7 @@ def get_property_stubs(nn_module):
 
 def interface_script(mod_interface, nn_module):
     """
-    Makes a ScriptModule from an nn.Module, using the interface methods rule for
-    determining which methods to compile.
+    Make a ScriptModule from an nn.Module, using the interface methods rule for determining which methods to compile.
 
     Args:
         mod_interface: the interface type that the module have
@@ -974,10 +967,7 @@ def interface_script(mod_interface, nn_module):
     check_module_initialized(nn_module)
 
     def infer_interface_methods_to_compile(nn_module):
-        """
-        Rule to infer the methods from the interface type to know which
-        methods need to act as starting points for compilation.
-        """
+        """Rule to infer the methods from the interface type to know which methods need to act as starting points for compilation."""
         stubs = []
         for method in mod_interface.getMethodNames():
             stubs.append(make_stub_from_method(nn_module, method))
@@ -1011,16 +1001,12 @@ def try_compile_fn(fn, loc):
 
 
 def wrap_cpp_class(cpp_class):
-    """
-    Wrap this torch._C.Object in a Python RecursiveScriptClass.
-    """
+    """Wrap this torch._C.Object in a Python RecursiveScriptClass."""
     return torch.jit.RecursiveScriptClass(cpp_class)
 
 
 def wrap_cpp_module(cpp_module):
-    """
-    Wrap this torch._C.ScriptModule in a Python ScriptModule, recursively for all submodules
-    """
+    """Wrap this torch._C.ScriptModule in a Python ScriptModule, recursively for all submodules."""
 
     def init_fn(script_module):
         for name, cpp_module in torch._C.ModuleDict(script_module._c).items():
@@ -1050,10 +1036,10 @@ def compile_unbound_method(concrete_type, fn):
 
 def lazy_bind(concrete_type, unbound_method):
     """
-    Returns a function that lazily binds `unbound_method` to a provided
-    Module IValue, then invokes the method. We do this so that any Python
-    shenanigans that will poison type sharing are impossible at compile
-    time.
+    Return a function that lazily binds `unbound_method` to a provided Module IValue, then invokes the method.
+
+    We do this so that any Python shenanigans that
+    will poison type sharing are impossible at compile time.
     """
 
     def lazy_binding_method(cpp_module, *args):

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -1,4 +1,4 @@
-"""TorchScript
+"""TorchScript.
 
 This module contains functionality to support the JIT's scripting frontend, notably:
     - torch.jit.script
@@ -374,7 +374,8 @@ def unpackage_script_module(
     importer: PackageImporter, script_module_id: str
 ) -> torch.nn.Module:
     """
-    Called by ``torch.package.PackageImporter``'s Pickler's ``persistent_load`` function.
+    Call by ``torch.package.PackageImporter``'s Pickler's ``persistent_load`` function.
+    
     Performs work of loading and returning a ScriptModule from a ``torch.package`` archive.
     """
     if not isinstance(importer.zip_reader, torch._C.PyTorchFileReader):
@@ -426,7 +427,8 @@ if _enabled:
     ]
 
     class RecursiveScriptClass:
-        """
+        """Wrapper for a TorchScript class instance for use in Python.
+
         An analogue of RecursiveScriptModule for regular objects that are not modules.
         This class is a wrapper around a torch._C.ScriptObject that represents an instance
         of a TorchScript class and allows it to be used in Python.
@@ -503,11 +505,13 @@ if _enabled:
     # which always throws an exception.
 
     class ScriptModule(Module, metaclass=ScriptMeta):
-        r"""
+        r"""Wrapper for C++ torch::jit::Module with methods, attributes, and parameters.
+
         A wrapper around C++ ``torch::jit::Module``. ``ScriptModule``\s
         contain methods, attributes, parameters, and
         constants. These can be accessed the same way as on a normal ``nn.Module``.
         """
+
         __jit_unused_properties__ = [
             "code",
             "code_with_constants",
@@ -572,7 +576,8 @@ if _enabled:
             return self._actual_script_module._replicate_for_data_parallel()
 
         def __reduce_package__(self, exporter: PackageExporter):
-            """
+            """Save a ScriptModule inside of a ``torch.package`` archive.
+
             Called by ``torch.package.PackageExporter``'s Pickler's ``persistent_id`` when
             saving TorchScript objects. Performs act of saving a ScriptModule inside of
             a ``torch.package`` archive.
@@ -588,7 +593,8 @@ if _enabled:
         # XXX: RecursiveScriptModule inherits from ScriptModule for the sole
         # reason that it retains the existing isinstance(ScriptModule)
         # behavior.
-        r"""
+        r"""Retain the existing isinstance(ScriptModule) behavior.
+
         The core data structure in TorchScript is the ``ScriptModule``. It is an
         analogue of torch's ``nn.Module`` and represents an entire model as a tree of
         submodules. Like normal modules, each individual module in a ``ScriptModule`` can
@@ -610,6 +616,7 @@ if _enabled:
           and compiles it to TorchScript. Scripting allows the use of many `types`_ of values and supports dynamic control flow.
           Many, but not all features of Python are supported by the compiler, so changes to the source code may be necessary.
         """
+
         _disable_script_meta = True
 
         def __init__(self, cpp_module):
@@ -624,8 +631,9 @@ if _enabled:
         @staticmethod
         def _construct(cpp_module, init_fn):
             """
-            Construct a RecursiveScriptModule that's ready for use. PyTorch
-            code should use this to construct a RecursiveScriptModule instead
+            Construct a RecursiveScriptModule that's ready for use.
+
+            PyTorch code should use this to construct a RecursiveScriptModule instead
             of instead of calling `__init__` directly, as it makes sure the
             object is properly finalized (and in the future, we may take
             control of how the RecursiveScriptModule instance is created).
@@ -690,17 +698,18 @@ if _enabled:
 
         @property
         def graph(self):
-            r"""
-            Returns a string representation of the internal graph for the
-            ``forward`` method. See :ref:`interpreting-graphs` for details.
+            r"""Return a string representation of the internal graph for the ``forward`` method.
+
+            See :ref:`interpreting-graphs` for details.
             """
             return self._c._get_method("forward").graph
 
         @property
         def inlined_graph(self):
             r"""
-            Returns a string representation of the internal graph for the
-            ``forward`` method. This graph will be preprocessed to inline all function and method calls.
+            Return a string representation of the internal graph for the ``forward`` method.
+
+            This graph will be preprocessed to inline all function and method calls.
             See :ref:`interpreting-graphs` for details.
             """
             return self.forward.inlined_graph  # type: ignore[attr-defined]
@@ -708,15 +717,16 @@ if _enabled:
         @property
         def code(self):
             r"""
-            Returns a pretty-printed representation (as valid Python syntax) of
-            the internal graph for the ``forward`` method. See
-            :ref:`inspecting-code` for details.
+            Return a pretty-printed representation (as valid Python syntax) of the internal graph for the ``forward`` method.
+
+            See :ref:`inspecting-code` for details.
             """
             return self.forward.code  # type: ignore[attr-defined]
 
         @property
         def code_with_constants(self):
-            r"""
+            r"""Return a tuple.
+
             Returns a tuple of:
 
             [0] a pretty-printed representation (as valid Python syntax) of
@@ -730,7 +740,8 @@ if _enabled:
             return (r[0], ConstMap(r[1]))
 
         def save(self, f, **kwargs):
-            r"""
+            r"""Save with a file-like object.
+
             save(f, _extra_files={})
 
             See :func:`torch.jit.save <torch.jit.save>` witch accepts a file-like object.
@@ -740,10 +751,11 @@ if _enabled:
             return self._c.save(str(f), **kwargs)
 
         def _save_for_lite_interpreter(self, *args, **kwargs):
-            r"""
+            r"""Add (or update) the bytecode session to the script model.
+
             _save_for_lite_interpreter(f)
 
-            Add (or update) the bytecode session to the script model. The updated model is used
+            The updated model is used
             in lite interpreter for mobile applications.
 
             Args:
@@ -1054,6 +1066,7 @@ def create_script_dict(obj):
 def create_script_list(obj, type_hint=None):
     """
     Create a ``torch._C.ScriptList`` instance with the data from ``obj``.
+
     Args:
         obj (dict): The Python list that is used to initialize the ``ScriptList``
                     returned by this function.
@@ -1072,7 +1085,8 @@ def script(
     _rcb=None,
     example_inputs: Union[List[Tuple], Dict[Callable, List[Tuple]], None] = None,
 ):
-    r"""
+    r"""Script the function.
+
     Scripting a function or ``nn.Module`` will inspect the source code, compile
     it as TorchScript code using the TorchScript compiler, and return a :class:`ScriptModule` or
     :class:`ScriptFunction`. TorchScript itself is a subset of the Python language, so not all
@@ -1468,7 +1482,8 @@ def _check_directly_compile_overloaded(obj):
 
 
 def interface(obj):
-    r"""
+    r"""Decorate to annotate classes or modules of different types.
+
     This decorator can be used to define an interface that can be used to annotate
     classes or modules of different types. This can be used for to annotate a submodule
     or attribute class that could have different types that implement the same
@@ -1479,7 +1494,6 @@ def interface(obj):
     an interface but whose implementations differ and which can be swapped out.
 
     Example:
-
     .. testcode::
 
         import torch

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -375,7 +375,7 @@ def unpackage_script_module(
 ) -> torch.nn.Module:
     """
     Call by ``torch.package.PackageImporter``'s Pickler's ``persistent_load`` function.
-    
+
     Performs work of loading and returning a ScriptModule from a ``torch.package`` archive.
     """
     if not isinstance(importer.zip_reader, torch._C.PyTorchFileReader):

--- a/torch/jit/_serialization.py
+++ b/torch/jit/_serialization.py
@@ -1,4 +1,4 @@
-"""Serialization
+"""Serialization.
 
 This module contains functionality for serializing TorchScript modules, notably:
     * torch.jit.save
@@ -17,8 +17,9 @@ from torch.serialization import validate_cuda_device
 
 def save(m, f, _extra_files=None):
     r"""
-    Save an offline version of this module for use in a separate process. The
-    saved module serializes all of the methods, submodules, parameters, and
+    Save an offline version of this module for use in a separate process.
+
+    The saved module serializes all of the methods, submodules, parameters, and
     attributes of this module. It can be loaded into the C++ API using
     ``torch::jit::load(filename)`` or into the Python API with
     :func:`torch.jit.load <torch.jit.load>`.
@@ -49,7 +50,6 @@ def save(m, f, _extra_files=None):
         replicate the 1.6 behavior.
 
     Example:
-
     .. testcode::
 
         import torch
@@ -85,8 +85,7 @@ def save(m, f, _extra_files=None):
 
 def load(f, map_location=None, _extra_files=None, _restore_shapes=False):
     r"""
-    Load a :class:`ScriptModule` or :class:`ScriptFunction` previously
-    saved with :func:`torch.jit.save <torch.jit.save>`
+    Load a :class:`ScriptModule` or :class:`ScriptFunction` previously saved with :func:`torch.jit.save <torch.jit.save>`.
 
     All previously saved modules, no matter their device, are first loaded onto CPU,
     and then are moved to the devices they were saved from. If this fails (e.g.
@@ -108,7 +107,6 @@ def load(f, map_location=None, _extra_files=None, _restore_shapes=False):
         A :class:`ScriptModule` object.
 
     Example:
-
     .. testcode::
 
         import torch
@@ -146,7 +144,6 @@ def load(f, map_location=None, _extra_files=None, _restore_shapes=False):
         import os
         os.remove("scriptmodule.pt")
     """
-
     if isinstance(f, str):
         if not os.path.exists(f):  # type: ignore[type-var]
             raise ValueError(f"The provided filename {f} does not exist")  # type: ignore[str-bytes-safe]
@@ -194,8 +191,9 @@ def jit_module_from_flatbuffer(f):
 
 def save_jit_module_to_flatbuffer(m, f, _extra_files=None):
     r"""
-    Save an offline version of this module for use in a separate process. The
-    saved module serializes all of the methods, submodules, parameters, and
+    Save an offline version of this module for use in a separate process.
+
+    The saved module serializes all of the methods, submodules, parameters, and
     attributes of this module. It can be loaded into the C++ API using
     ``torch::jit::load_jit_module_from_file(filename)`` or into the Python API with
     :func:`torch.jit.jit_module_from_flatbuffer<torch.jit.jit_module_from_flatbuffer>`.
@@ -215,7 +213,6 @@ def save_jit_module_to_flatbuffer(m, f, _extra_files=None):
 
 
     Example:
-
     .. testcode::
 
         import torch
@@ -230,7 +227,6 @@ def save_jit_module_to_flatbuffer(m, f, _extra_files=None):
         # Save to file
         torch.jit.save_jit_module_to_flatbuffer(m, 'scriptmodule.ff')
     """
-
     extra_files = _extra_files
     if extra_files is None:
         extra_files = {}
@@ -245,7 +241,6 @@ def save_jit_module_to_flatbuffer(m, f, _extra_files=None):
 
 def get_flatbuffer_module_info(path_or_file):
     r"""Get some information regarding a model file in flatbuffer format.
-
 
     Args:
         path_or_file: Either str, Path or file like object (BytesIO OK).

--- a/torch/jit/_state.py
+++ b/torch/jit/_state.py
@@ -1,4 +1,4 @@
-"""JIT-related state
+"""JIT-related state.
 
 This module stores various pieces of Python-global state relating to the JIT.
 

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -1119,7 +1119,8 @@ def trace_module(
 def is_tracing():
     """Return a boolean value.
 
-    Returns ``True`` in tracing (if a function is called during the tracing of code with ``torch.jit.trace``) and ``False`` otherwise."""
+    Returns ``True`` in tracing (if a function is called during the tracing of code with ``torch.jit.trace``) and ``False`` otherwise.
+    """
     if is_scripting():
         return False
     return torch._C._is_tracing()

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -1117,7 +1117,9 @@ def trace_module(
 
 
 def is_tracing():
-    """Return ``True`` in tracing (if a function is called during the tracing of code with ``torch.jit.trace``) and ``False`` otherwise."""
+    """Return a boolean value.
+
+    Returns ``True`` in tracing (if a function is called during the tracing of code with ``torch.jit.trace``) and ``False`` otherwise."""
     if is_scripting():
         return False
     return torch._C._is_tracing()

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -1119,7 +1119,8 @@ def trace_module(
 def is_tracing():
     """Return a boolean value.
 
-    Returns ``True`` in tracing (if a function is called during the tracing of code with ``torch.jit.trace``) and ``False`` otherwise.
+    Returns ``True`` in tracing (if a function is called during the
+    tracing of code with ``torch.jit.trace``) and ``False`` otherwise.
     """
     if is_scripting():
         return False

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -1,4 +1,4 @@
-"""Tracing
+"""Tracing.
 
 This module contains functionality to support the JIT's tracing frontend, notably:
     * torch.jit.trace
@@ -198,9 +198,10 @@ def _time(trace_name, name, time=True):
 
 def verify(model, args, loss_fn=torch.sum, devices=None):
     """
-    Verify that a JIT compiled model has the same behavior as its uncompiled
-    version along with its backwards pass.  If your model returns multiple
-    outputs, you must also specify a `loss_fn` to produce a loss for which
+    Verify that a JIT compiled model has the same behavior as its uncompiled version along with its backwards pass.
+
+    If your model returns multiple outputs,
+    you must also specify a `loss_fn` to produce a loss for which
     the backwards will be computed.
 
     This function has side-effects (e.g., it executes your model / saves and loads
@@ -636,10 +637,11 @@ def trace(
     example_kwarg_inputs=None,
     _store_inputs=True,
 ):
-    """
-    Trace a function and return an executable  or :class:`ScriptFunction`
-    that will be optimized using just-in-time compilation. Tracing is ideal for
-    code that operates only on ``Tensor``\\s and lists, dictionaries, and
+    r"""
+    Trace a function and return an executable  or :class:`ScriptFunction` that will be optimized using just-in-time compilation.
+
+    Tracing is ideal for code that operates only on
+    ``Tensor``\\s and lists, dictionaries, and
     tuples of ``Tensor``\\s.
 
     Using `torch.jit.trace` and `torch.jit.trace_module`, you can turn an
@@ -929,8 +931,9 @@ def trace_module(
     _store_inputs=True,
 ):
     """
-    Trace a module and return an executable :class:`ScriptModule` that will be optimized
-    using just-in-time compilation. When a module is passed to :func:`torch.jit.trace <torch.jit.trace>`, only
+    Trace a module and return an executable :class:`ScriptModule` that will be optimized using just-in-time compilation.
+
+    When a module is passed to :func:`torch.jit.trace <torch.jit.trace>`, only
     the ``forward`` method is run and traced. With ``trace_module``, you can specify a dictionary of
     method names to example inputs to trace (see the ``inputs``) argument below.
 
@@ -1114,10 +1117,7 @@ def trace_module(
 
 
 def is_tracing():
-    """
-    Returns ``True`` in tracing (if a function is called during the tracing of
-    code with ``torch.jit.trace``) and ``False`` otherwise.
-    """
+    """Return ``True`` in tracing (if a function is called during the tracing of code with ``torch.jit.trace``) and ``False`` otherwise."""
     if is_scripting():
         return False
     return torch._C._is_tracing()
@@ -1253,7 +1253,8 @@ def _get_trace_graph(
     return_inputs=False,
     _return_inputs_states=False,
 ):
-    """
+    """Return a tuple on tracing a function or model.
+
     .. warning::
         This function is internal-only and should only be used by the ONNX
         exporter. If you are trying to get a graph through tracing, please go

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -198,7 +198,7 @@ def check_fn(fn, loc):
 
 
 def _eval_no_call(stmt, glob, loc):
-    """Evaluate statement as long as it does not contain any method/function calls"""
+    """Evaluate statement as long as it does not contain any method/function calls."""
     bytecode = compile(stmt, "", mode="eval")
     for insn in dis.get_instructions(bytecode):
         if "CALL" in insn.opname:
@@ -209,7 +209,7 @@ def _eval_no_call(stmt, glob, loc):
 
 
 def parse_type_line(type_line, rcb, loc):
-    """Parses a type annotation specified as a comment.
+    """Parse a type annotation specified as a comment.
 
     Example inputs:
         # type: (Tensor, torch.Tensor) -> Tuple[Tensor]
@@ -239,7 +239,7 @@ def parse_type_line(type_line, rcb, loc):
 
 
 def get_type_line(source):
-    """Tries to find the line containing a comment with the type annotation."""
+    """Try to find the line containing a comment with the type annotation."""
     type_comment = "# type:"
 
     lines = source.split("\n")
@@ -306,7 +306,7 @@ def get_type_line(source):
 
 
 def split_type_line(type_line):
-    """Splits the comment with the type annotation into parts for argument and return types.
+    """Split the comment with the type annotation into parts for argument and return types.
 
     For example, for an input of:
         # type: (Tensor, torch.Tensor) -> Tuple[Tensor, Tensor]
@@ -326,7 +326,7 @@ def split_type_line(type_line):
 
 
 def try_real_annotations(fn, loc):
-    """Tries to use the Py3.5+ annotation syntax to get the type."""
+    """Try to use the Py3.5+ annotation syntax to get the type."""
     try:
         # Note: anything annotated as `Optional[T]` will automatically
         # be returned as `Union[T, None]` per

--- a/torch/jit/mobile/__init__.py
+++ b/torch/jit/mobile/__init__.py
@@ -9,8 +9,7 @@ from torch.jit._serialization import validate_map_location
 
 def _load_for_lite_interpreter(f, map_location=None):
     r"""
-    Load a :class:`LiteScriptModule`
-    saved with :func:`torch.jit._save_for_lite_interpreter`
+    Load a :class:`LiteScriptModule` saved with :func:`torch.jit._save_for_lite_interpreter`.
 
     Args:
         f: a file-like object (has to implement read, readline, tell, and seek),
@@ -75,15 +74,13 @@ class LiteScriptModule:
 
 
 def _export_operator_list(module: LiteScriptModule):
-    r"""
-    return a set of root operator names (with overload name) that are used by any method
-    in this mobile module.
-    """
+    r"""Return a set of root operator names (with overload name) that are used by any method in this mobile module."""
     return torch._C._export_operator_list(module._c)
 
 
 def _get_model_bytecode_version(f_input) -> int:
-    r"""
+    r"""Take a file-like object to return an integer.
+
     Args:
         f_input: a file-like object (has to implement read, readline, tell, and seek),
             or a string containing a file name
@@ -93,7 +90,6 @@ def _get_model_bytecode_version(f_input) -> int:
             will show in the log.
 
     Example:
-
     .. testcode::
 
         from torch.jit.mobile import _get_model_bytecode_version
@@ -115,7 +111,8 @@ def _get_model_bytecode_version(f_input) -> int:
 
 
 def _get_mobile_model_contained_types(f_input) -> int:
-    r"""
+    r"""Take a file-like object and return a set of string, like ("int", "Optional").
+
     Args:
         f_input: a file-like object (has to implement read, readline, tell, and seek),
             or a string containing a file name
@@ -146,7 +143,8 @@ def _get_mobile_model_contained_types(f_input) -> int:
 
 
 def _backport_for_mobile(f_input, f_output, to_version):
-    r"""
+    r"""Take a input string containing a file name (file-like object) and a new destination to return a boolean.
+
     Args:
         f_input: a file-like object (has to implement read, readline, tell, and seek),
             or a string containing a file name
@@ -172,7 +170,8 @@ def _backport_for_mobile(f_input, f_output, to_version):
 
 
 def _backport_for_mobile_to_buffer(f_input, to_version):
-    r"""
+    r"""Take a string containing a file name (file-like object).
+
     Args:
         f_input: a file-like object (has to implement read, readline, tell, and seek),
             or a string containing a file name
@@ -193,9 +192,9 @@ def _backport_for_mobile_to_buffer(f_input, to_version):
 
 
 def _get_model_ops_and_info(f_input):
-    r"""
-    A function to retrieve the root (top level) operators of a model and their corresponding
-    compatibility info. These root operators can call other operators within them (traced ops), and
+    r"""Retrieve the root (top level) operators of a model and their corresponding compatibility info.
+
+    These root operators can call other operators within them (traced ops), and
     a root op can call many different traced ops depending on internal code paths in the root op.
     These traced ops are not returned by this function. Those operators are abstracted into the
     runtime as an implementation detail (and the traced ops themselves can also call other operators)

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -391,45 +391,45 @@ Specifying a positive offset::
 class check_sparse_tensor_invariants:
     """A tool to control checking sparse tensor invariants.
 
-    The following options exists to manage sparsr tensor invariants
-    checking in sparse tensor construction:
+The following options exists to manage sparsr tensor invariants
+checking in sparse tensor construction:
 
-    1. Using a context manager:
+1. Using a context manager:
 
-    .. code:: python
+   .. code:: python
 
-        with torch.sparse.check_sparse_tensor_invariants():
-            run_my_model()
+       with torch.sparse.check_sparse_tensor_invariants():
+           run_my_model()
 
-    2. Using a procedural approach:
+2. Using a procedural approach:
 
-    .. code:: python
+   .. code:: python
 
-        prev_checks_enabled = torch.sparse.check_sparse_tensor_invariants.is_enabled()
-        torch.sparse.check_sparse_tensor_invariants.enable()
+       prev_checks_enabled = torch.sparse.check_sparse_tensor_invariants.is_enabled()
+       torch.sparse.check_sparse_tensor_invariants.enable()
 
-        run_my_model()
+       run_my_model()
 
-        if not prev_checks_enabled:
-            torch.sparse.check_sparse_tensor_invariants.disable()
+       if not prev_checks_enabled:
+           torch.sparse.check_sparse_tensor_invariants.disable()
 
-    3. Using function decoration:
+3. Using function decoration:
 
-    .. code:: python
+   .. code:: python
 
-        @torch.sparse.check_sparse_tensor_invariants()
-        def run_my_model():
-            ...
+       @torch.sparse.check_sparse_tensor_invariants()
+       def run_my_model():
+           ...
 
-        run_my_model()
+       run_my_model()
 
-    4. Using ``check_invariants`` keyword argument in sparse tensor constructor call.
-    For example:
+4. Using ``check_invariants`` keyword argument in sparse tensor constructor call.
+   For example:
 
-    >>> torch.sparse_csr_tensor([0, 1, 3], [0, 1], [1, 2], check_invariants=True)
-    Traceback (most recent call last):
-        File "<stdin>", line 1, in <module>
-    RuntimeError: `crow_indices[..., -1] == nnz` is not satisfied.
+   >>> torch.sparse_csr_tensor([0, 1, 3], [0, 1], [1, 2], check_invariants=True)
+   Traceback (most recent call last):
+     File "<stdin>", line 1, in <module>
+   RuntimeError: `crow_indices[..., -1] == nnz` is not satisfied.
     """
 
     @staticmethod

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -438,9 +438,9 @@ class check_sparse_tensor_invariants:
 
         .. note::
 
-        Use :func:`torch.sparse.check_sparse_tensor_invariants.enable` or
-        :func:`torch.sparse.check_sparse_tensor_invariants.disable` to
-        manage the state of the sparse tensor invariants checks.
+            Use :func:`torch.sparse.check_sparse_tensor_invariants.enable` or
+            :func:`torch.sparse.check_sparse_tensor_invariants.disable` to
+            manage the state of the sparse tensor invariants checks.
         """
         return torch._C._check_sparse_tensor_invariants()
 
@@ -450,14 +450,14 @@ class check_sparse_tensor_invariants:
 
         .. note::
 
-        By default, the sparse tensor invariants checks are disabled. Use
-        :func:`torch.sparse.check_sparse_tensor_invariants.is_enabled` to
-        retrieve the current state of sparse tensor invariants checking.
+            By default, the sparse tensor invariants checks are disabled. Use
+            :func:`torch.sparse.check_sparse_tensor_invariants.is_enabled` to
+            retrieve the current state of sparse tensor invariants checking.
 
         .. note::
 
-        The sparse tensor invariants check flag is effective to all sparse
-        tensor constructors, both in Python and ATen.
+            The sparse tensor invariants check flag is effective to all sparse
+            tensor constructors, both in Python and ATen.
 
         The flag can be locally overridden by the ``check_invariants``
         optional argument of the sparse tensor constructor functions.

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -518,7 +518,8 @@ def as_sparse_gradcheck(gradcheck):
     """
 
     def gradcheck_with_sparse_support(func, inputs, **kwargs):
-        """Create gradcheck with support for sparse tensors.
+        """
+        Create gradcheck with support for sparse tensors.
 
         Same as :func:`torch.autograd.gradcheck` but with sparse tensors inputs and outputs support.
         """

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -180,7 +180,8 @@ Examples::
 
 def sum(input: Tensor, dim: DimOrDims = None,
         dtype: Optional[DType] = None) -> Tensor:
-    r"""
+    r"""Return the sum of each row of the given sparse tensor.
+
     Returns the sum of each row of the sparse tensor :attr:`input` in the given
     dimensions :attr:`dim`. If :attr:`dim` is a list of dimensions,
     reduce over all of them. When sum over all ``sparse_dim``, this method
@@ -390,56 +391,56 @@ Specifying a positive offset::
 class check_sparse_tensor_invariants:
     """A tool to control checking sparse tensor invariants.
 
-The following options exists to manage sparsr tensor invariants
-checking in sparse tensor construction:
+    The following options exists to manage sparsr tensor invariants
+    checking in sparse tensor construction:
 
-1. Using a context manager:
+    1. Using a context manager:
 
-   .. code:: python
+    .. code:: python
 
-       with torch.sparse.check_sparse_tensor_invariants():
-           run_my_model()
+        with torch.sparse.check_sparse_tensor_invariants():
+            run_my_model()
 
-2. Using a procedural approach:
+    2. Using a procedural approach:
 
-   .. code:: python
+    .. code:: python
 
-       prev_checks_enabled = torch.sparse.check_sparse_tensor_invariants.is_enabled()
-       torch.sparse.check_sparse_tensor_invariants.enable()
+        prev_checks_enabled = torch.sparse.check_sparse_tensor_invariants.is_enabled()
+        torch.sparse.check_sparse_tensor_invariants.enable()
 
-       run_my_model()
+        run_my_model()
 
-       if not prev_checks_enabled:
-           torch.sparse.check_sparse_tensor_invariants.disable()
+        if not prev_checks_enabled:
+            torch.sparse.check_sparse_tensor_invariants.disable()
 
-3. Using function decoration:
+    3. Using function decoration:
 
-   .. code:: python
+    .. code:: python
 
-       @torch.sparse.check_sparse_tensor_invariants()
-       def run_my_model():
-           ...
+        @torch.sparse.check_sparse_tensor_invariants()
+        def run_my_model():
+            ...
 
-       run_my_model()
+        run_my_model()
 
-4. Using ``check_invariants`` keyword argument in sparse tensor constructor call.
-   For example:
+    4. Using ``check_invariants`` keyword argument in sparse tensor constructor call.
+    For example:
 
-   >>> torch.sparse_csr_tensor([0, 1, 3], [0, 1], [1, 2], check_invariants=True)
-   Traceback (most recent call last):
-     File "<stdin>", line 1, in <module>
-   RuntimeError: `crow_indices[..., -1] == nnz` is not satisfied.
+    >>> torch.sparse_csr_tensor([0, 1, 3], [0, 1], [1, 2], check_invariants=True)
+    Traceback (most recent call last):
+        File "<stdin>", line 1, in <module>
+    RuntimeError: `crow_indices[..., -1] == nnz` is not satisfied.
     """
 
     @staticmethod
     def is_enabled():
-        r"""Returns True if the sparse tensor invariants checking is enabled.
+        r"""Return True if the sparse tensor invariants checking is enabled.
 
-.. note::
+        .. note::
 
-    Use :func:`torch.sparse.check_sparse_tensor_invariants.enable` or
-    :func:`torch.sparse.check_sparse_tensor_invariants.disable` to
-    manage the state of the sparse tensor invariants checks.
+        Use :func:`torch.sparse.check_sparse_tensor_invariants.enable` or
+        :func:`torch.sparse.check_sparse_tensor_invariants.disable` to
+        manage the state of the sparse tensor invariants checks.
         """
         return torch._C._check_sparse_tensor_invariants()
 
@@ -447,19 +448,19 @@ checking in sparse tensor construction:
     def enable():
         r"""Enable sparse tensor invariants checking in sparse tensor constructors.
 
-.. note::
+        .. note::
 
-    By default, the sparse tensor invariants checks are disabled. Use
-    :func:`torch.sparse.check_sparse_tensor_invariants.is_enabled` to
-    retrieve the current state of sparse tensor invariants checking.
+        By default, the sparse tensor invariants checks are disabled. Use
+        :func:`torch.sparse.check_sparse_tensor_invariants.is_enabled` to
+        retrieve the current state of sparse tensor invariants checking.
 
-.. note::
+        .. note::
 
-    The sparse tensor invariants check flag is effective to all sparse
-    tensor constructors, both in Python and ATen.
+        The sparse tensor invariants check flag is effective to all sparse
+        tensor constructors, both in Python and ATen.
 
-    The flag can be locally overridden by the ``check_invariants``
-    optional argument of the sparse tensor constructor functions.
+        The flag can be locally overridden by the ``check_invariants``
+        optional argument of the sparse tensor constructor functions.
         """
         torch._C._set_check_sparse_tensor_invariants(True)
 
@@ -467,7 +468,7 @@ checking in sparse tensor construction:
     def disable():
         r"""Disable sparse tensor invariants checking in sparse tensor constructors.
 
-See :func:`torch.sparse.check_sparse_tensor_invariants.enable` for more information.
+        See :func:`torch.sparse.check_sparse_tensor_invariants.enable` for more information.
         """
         torch._C._set_check_sparse_tensor_invariants(False)
 
@@ -499,7 +500,9 @@ See :func:`torch.sparse.check_sparse_tensor_invariants.enable` for more informat
 
 
 def as_sparse_gradcheck(gradcheck):
-    """Decorator for torch.autograd.gradcheck or its functools.partial
+    """Decorate function, to extend gradcheck for sparse tensors.
+
+    Decorator for torch.autograd.gradcheck or its functools.partial
     variants that extends the gradcheck function with support to input
     functions that operate on or/and return sparse tensors.
 
@@ -515,8 +518,9 @@ def as_sparse_gradcheck(gradcheck):
     """
 
     def gradcheck_with_sparse_support(func, inputs, **kwargs):
-        """Same as :func:`torch.autograd.gradcheck` but with sparse tensors
-        inputs and outputs support.
+        """Create gradcheck with support for sparse tensors.
+
+        Same as :func:`torch.autograd.gradcheck` but with sparse tensors inputs and outputs support.
         """
         masked = kwargs.pop('masked', False)
         sparse_layouts = {torch.sparse_coo, torch.sparse_csr, torch.sparse_csc, torch.sparse_bsr, torch.sparse_bsc}
@@ -525,9 +529,7 @@ def as_sparse_gradcheck(gradcheck):
         STRIDED_REPRESENTATION = '__STRIDED_REPRESENTATION__'
 
         def convert_to_strided_representation(args):
-            """Convert differentiable non-strided tensors to a representation
-            containing differentiable strided tensors.
-            """
+            """Convert differentiable non-strided tensors to a representation containing differentiable strided tensors."""
             if not isinstance(args, (list, tuple)):
                 args = args,
             new_args: List[Any] = []
@@ -556,9 +558,7 @@ def as_sparse_gradcheck(gradcheck):
             return tuple(new_args)
 
         def restore_from_strided_representation(args):
-            """Restore non-strided differentiable tensosr from their strided
-            representations.
-            """
+            """Restore non-strided differentiable tensosr from their strided representations."""
             new_args = []
             args = list(args)
             while args:

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -391,45 +391,45 @@ Specifying a positive offset::
 class check_sparse_tensor_invariants:
     """A tool to control checking sparse tensor invariants.
 
-The following options exists to manage sparsr tensor invariants
-checking in sparse tensor construction:
+    The following options exists to manage sparsr tensor invariants
+    checking in sparse tensor construction:
 
-1. Using a context manager:
+    1. Using a context manager:
 
-   .. code:: python
+       .. code:: python
 
-       with torch.sparse.check_sparse_tensor_invariants():
+           with torch.sparse.check_sparse_tensor_invariants():
+               run_my_model()
+
+    2. Using a procedural approach:
+
+       .. code:: python
+
+           prev_checks_enabled = torch.sparse.check_sparse_tensor_invariants.is_enabled()
+           torch.sparse.check_sparse_tensor_invariants.enable()
+
            run_my_model()
 
-2. Using a procedural approach:
+           if not prev_checks_enabled:
+               torch.sparse.check_sparse_tensor_invariants.disable()
 
-   .. code:: python
+    3. Using function decoration:
 
-       prev_checks_enabled = torch.sparse.check_sparse_tensor_invariants.is_enabled()
-       torch.sparse.check_sparse_tensor_invariants.enable()
+       .. code:: python
 
-       run_my_model()
+           @torch.sparse.check_sparse_tensor_invariants()
+           def run_my_model():
+               ...
 
-       if not prev_checks_enabled:
-           torch.sparse.check_sparse_tensor_invariants.disable()
+           run_my_model()
 
-3. Using function decoration:
+    4. Using ``check_invariants`` keyword argument in sparse tensor constructor call.
+       For example:
 
-   .. code:: python
-
-       @torch.sparse.check_sparse_tensor_invariants()
-       def run_my_model():
-           ...
-
-       run_my_model()
-
-4. Using ``check_invariants`` keyword argument in sparse tensor constructor call.
-   For example:
-
-   >>> torch.sparse_csr_tensor([0, 1, 3], [0, 1], [1, 2], check_invariants=True)
-   Traceback (most recent call last):
-     File "<stdin>", line 1, in <module>
-   RuntimeError: `crow_indices[..., -1] == nnz` is not satisfied.
+       >>> torch.sparse_csr_tensor([0, 1, 3], [0, 1], [1, 2], check_invariants=True)
+       Traceback (most recent call last):
+         File "<stdin>", line 1, in <module>
+       RuntimeError: `crow_indices[..., -1] == nnz` is not satisfied.
     """
 
     @staticmethod


### PR DESCRIPTION
Fixes #113194

docstrings updated.

Here are the outputs with the number before and after:-

1) torch/sparse/__init__.py

Before:
```
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:1 at module level:
        D104: Missing docstring in public package
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:183 in public function `sum`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:183 in public function `sum`:
        D400: First line should end with a period (not 'n')
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:183 in public function `sum`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:391 in public class `check_sparse_tensor_invariants`:
        D207: Docstring is under-indented
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:436 in public method `is_enabled`:
        D207: Docstring is under-indented
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:436 in public method `is_enabled`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:448 in public method `enable`:
        D207: Docstring is under-indented
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:468 in public method `disable`:
        D207: Docstring is under-indented
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:475 in public method `__init__`:
        D107: Missing docstring in __init__
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:479 in public method `__enter__`:
        D105: Missing docstring in magic method
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:486 in public method `__exit__`:
        D105: Missing docstring in magic method
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:492 in public method `__call__`:
        D102: Missing docstring in public method
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:502 in public function `as_sparse_gradcheck`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:502 in public function `as_sparse_gradcheck`:
        D400: First line should end with a period (not 'l')
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:502 in public function `as_sparse_gradcheck`:
        D401: First line should be in imperative mood (perhaps 'Decorate', not 'Decorator')
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:518 in private nested function `gradcheck_with_sparse_support`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:518 in private nested function `gradcheck_with_sparse_support`:
        D400: First line should end with a period (not 's')
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:518 in private nested function `gradcheck_with_sparse_support`:
        D401: First line should be in imperative mood; try rephrasing (found 'Same')
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:528 in private nested function `convert_to_strided_representation`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:528 in private nested function `convert_to_strided_representation`:
        D400: First line should end with a period (not 'n')
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:559 in private nested function `restore_from_strided_representation`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:559 in private nested function `restore_from_strided_representation`:
        D400: First line should end with a period (not 'd')
23
```
After:
```
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:1 at module level:
        D104: Missing docstring in public package
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:476 in public method `__init__`:
        D107: Missing docstring in __init__
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:480 in public method `__enter__`:
        D105: Missing docstring in magic method
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:487 in public method `__exit__`:
        D105: Missing docstring in magic method
/home/ubuntu/Desktop/Docathon/pytorch/torch/sparse/__init__.py:493 in public method `__call__`:
        D102: Missing docstring in public method
5
```
2) torch/contrib/_tensorboard_vis.py

Before:
```
/home/ubuntu/Desktop/Docathon/pytorch/torch/contrib/_tensorboard_vis.py:21 in public function `dump_tensorboard_summary`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/contrib/_tensorboard_vis.py:54 in public function `visualize_graph_executor`:
        D401: First line should be in imperative mood (perhaps 'Append', not 'Appends')
2
```
After:
```
/home/ubuntu/Desktop/Docathon/pytorch/torch/contrib/_tensorboard_vis.py:21 in public function `dump_tensorboard_summary`:
        D103: Missing docstring in public function
1
```
3) torch/jit/_state.py

Before:
```
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_state.py:1 at module level:
        D400: First line should end with a period (not 'e')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_state.py:20 in public method `__init__`:
        D107: Missing docstring in __init__
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_state.py:25 in public method `parse_env`:
        D102: Missing docstring in public method
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_state.py:41 in public method `__bool__`:
        D105: Missing docstring in magic method
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_state.py:48 in public function `disable`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_state.py:52 in public function `enable`:
        D103: Missing docstring in public function
6
```
After:
```
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_state.py:20 in public method `__init__`:
        D107: Missing docstring in __init__
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_state.py:25 in public method `parse_env`:
        D102: Missing docstring in public method
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_state.py:41 in public method `__bool__`:
        D105: Missing docstring in magic method
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_state.py:48 in public function `disable`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_state.py:52 in public function `enable`:
        D103: Missing docstring in public function
5
```
4) torch/jit/_monkeytype_config.py

Before:
```
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:27 in public function `is_torch_native_class`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:40 in public function `get_type`:
        D200: One-line docstring should fit on one line with quotes (found 3)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:40 in public function `get_type`:
        D401: First line should be in imperative mood; try rephrasing (found 'Helper')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:62 in public function `get_optional_of_element_type`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:62 in public function `get_optional_of_element_type`:
        D400: First line should end with a period (not 'l')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:62 in public function `get_optional_of_element_type`:
        D401: First line should be in imperative mood; try rephrasing (found 'Helper')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:75 in public function `get_qualified_name`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:84 in public method `__init__`:
        D107: Missing docstring in __init__
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:87 in public method `log`:
        D102: Missing docstring in public method
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:90 in public class `JitTypeTraceStore`:
        D101: Missing docstring in public class
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:91 in public method `__init__`:
        D107: Missing docstring in __init__
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:98 in public method `add`:
        D102: Missing docstring in public method
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:103 in public method `filter`:
        D102: Missing docstring in public method
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:111 in public method `analyze`:
        D102: Missing docstring in public method
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:122 in public method `consolidate_types`:
        D102: Missing docstring in public method
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:139 in public method `get_args_types`:
        D102: Missing docstring in public method
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:142 in public class `JitTypeTraceConfig`:
        D101: Missing docstring in public class
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:143 in public method `__init__`:
        D107: Missing docstring in __init__
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:148 in public method `trace_logger`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:148 in public method `trace_logger`:
        D400: First line should end with a period (not 'd')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:148 in public method `trace_logger`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:154 in public method `trace_store`:
        D102: Missing docstring in public method
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:157 in public method `code_filter`:
        D102: Missing docstring in public method
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:163 in public class `JitTypeTraceStoreLogger`:
        D101: Missing docstring in public class
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:164 in public method `__init__`:
        D107: Missing docstring in __init__
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:167 in public class `JitTypeTraceStore`:
        D101: Missing docstring in public class
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:168 in public method `__init__`:
        D107: Missing docstring in __init__
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:171 in public class `JitTypeTraceConfig`:
        D101: Missing docstring in public class
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:172 in public method `__init__`:
        D107: Missing docstring in __init__
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:179 in public function `jit_code_filter`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:179 in public function `jit_code_filter`:
        D401: First line should be in imperative mood; try rephrasing (found 'Custom')
31
```
After:
```
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:27 in public function `is_torch_native_class`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:74 in public function `get_qualified_name`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:83 in public method `__init__`:
        D107: Missing docstring in __init__
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:86 in public method `log`:
        D102: Missing docstring in public method
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:89 in public class `JitTypeTraceStore`:
        D101: Missing docstring in public class
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:90 in public method `__init__`:
        D107: Missing docstring in __init__
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:97 in public method `add`:
        D102: Missing docstring in public method
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:102 in public method `filter`:
        D102: Missing docstring in public method
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:110 in public method `analyze`:
        D102: Missing docstring in public method
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:121 in public method `consolidate_types`:
        D102: Missing docstring in public method
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:138 in public method `get_args_types`:
        D102: Missing docstring in public method
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:141 in public class `JitTypeTraceConfig`:
        D101: Missing docstring in public class
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:142 in public method `__init__`:
        D107: Missing docstring in __init__
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:150 in public method `trace_store`:
        D102: Missing docstring in public method
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:153 in public method `code_filter`:
        D102: Missing docstring in public method
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:159 in public class `JitTypeTraceStoreLogger`:
        D101: Missing docstring in public class
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:160 in public method `__init__`:
        D107: Missing docstring in __init__
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:163 in public class `JitTypeTraceStore`:
        D101: Missing docstring in public class
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:164 in public method `__init__`:
        D107: Missing docstring in __init__
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:167 in public class `JitTypeTraceConfig`:
        D101: Missing docstring in public class
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_monkeytype_config.py:168 in public method `__init__`:
        D107: Missing docstring in __init__
21
```
5) torch/jit/_fuser.py

Before:
```
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_fuser.py:9 in public function `optimized_execution`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_fuser.py:9 in public function `optimized_execution`:
        D400: First line should end with a period (not 'n')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_fuser.py:9 in public function `optimized_execution`:
        D401: First line should be in imperative mood; try rephrasing (found 'A')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_fuser.py:23 in public function `fuser`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_fuser.py:23 in public function `fuser`:
        D400: First line should end with a period (not 'n')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_fuser.py:23 in public function `fuser`:
        D401: First line should be in imperative mood; try rephrasing (found 'A')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_fuser.py:136 in public function `set_fusion_strategy`:
        D401: First line should be in imperative mood (perhaps 'Set', not 'Sets')
7
```
After:
```
0
```
6) torch/jit/_async.py

Before:
```
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_async.py:1 at module level:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_async.py:1 at module level:
        D400: First line should end with a period (not 'I')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_async.py:20 in public function `fork`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_async.py:20 in public function `fork`:
        D400: First line should end with a period (not 'e')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_async.py:20 in public function `fork`:
        D401: First line should be in imperative mood (perhaps 'Create', not 'Creates')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_async.py:88 in public function `wait`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_async.py:88 in public function `wait`:
        D400: First line should end with a period (not 'e')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_async.py:88 in public function `wait`:
        D401: First line should be in imperative mood (perhaps 'Force', not 'Forces')
8
```
After:
```
0
```
7) torch/jit/_await.py

Before:
```
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_await.py:11 in private function `_awaitable`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_await.py:11 in private function `_awaitable`:
        D400: First line should end with a period (not ',')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_await.py:11 in private function `_awaitable`:
        D401: First line should be in imperative mood (perhaps 'Create', not 'Creates')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_await.py:19 in private function `_awaitable_wait`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_await.py:19 in private function `_awaitable_wait`:
        D400: First line should end with a period (not ',')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_await.py:19 in private function `_awaitable_wait`:
        D401: First line should be in imperative mood (perhaps 'Request', not 'Requests')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_await.py:27 in private function `_awaitable_nowait`:
        D200: One-line docstring should fit on one line with quotes (found 3)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_await.py:27 in private function `_awaitable_nowait`:
        D401: First line should be in imperative mood (perhaps 'Create', not 'Creates')
8
```
After:
```
0
```
8) torch/jit/_check.py

Before:
```
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_check.py:10 in public class `AttributeTypeIsSupportedChecker`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_check.py:10 in public class `AttributeTypeIsSupportedChecker`:
        D400: First line should end with a period (not 'e')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_check.py:10 in public class `AttributeTypeIsSupportedChecker`:
        D412: No blank lines allowed between a section header and its content ('Example')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_check.py:61 in public method `check`:
        D102: Missing docstring in public method
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_check.py:110 in public method `visit_Assign`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_check.py:110 in public method `visit_Assign`:
        D400: First line should end with a period (not 'n')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_check.py:132 in public method `visit_AnnAssign`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_check.py:132 in public method `visit_AnnAssign`:
        D400: First line should end with a period (not '`')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_check.py:187 in public method `visit_Call`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_check.py:187 in public method `visit_Call`:
        D400: First line should end with a period (not '`')
10
```
After:
```
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_check.py:58 in public method `check`:
        D102: Missing docstring in public method
1
```
9) torch/jit/_freeze.py

Before:
```
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_freeze.py:1 at module level:
        D400: First line should end with a period (not 'g')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_freeze.py:16 in public function `freeze`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_freeze.py:16 in public function `freeze`:
        D400: First line should end with a period (not 'd')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_freeze.py:127 in public function `run_frozen_optimizations`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_freeze.py:127 in public function `run_frozen_optimizations`:
        D401: First line should be in imperative mood (perhaps 'Run', not 'Runs')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_freeze.py:182 in public function `optimize_for_inference`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_freeze.py:182 in public function `optimize_for_inference`:
        D400: First line should end with a period (not 'e')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_freeze.py:182 in public function `optimize_for_inference`:
        D401: First line should be in imperative mood (perhaps 'Perform', not 'Performs')
8
```
After:
```
0
```
10) torch/jit/_recursive.py

Before:
```
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:69 in public function `make_stub`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:75 in public function `make_stub_from_method`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:90 in public function `make_stubs_from_exported_methods`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:103 in public function `jit_ignored_properties`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:155 in public class `SourceContext`:
        D101: Missing docstring in public class
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:156 in public method `__init__`:
        D107: Missing docstring in __init__
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:160 in public function `get_annotations`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:186 in public function `infer_concrete_type_builder`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:186 in public function `infer_concrete_type_builder`:
        D400: First line should end with a period (not 's')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:423 in public class `ConcreteTypeStore`:
        D101: Missing docstring in public class
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:427 in public method `__init__`:
        D107: Missing docstring in __init__
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:434 in public method `get_or_create_concrete_type`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:434 in public method `get_or_create_concrete_type`:
        D400: First line should end with a period (not 'T')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:459 in public function `create_methods_and_properties_from_stubs`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:474 in public function `create_hooks_from_stubs`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:485 in public function `get_module_concrete_type`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:485 in public function `get_module_concrete_type`:
        D400: First line should end with a period (not 'e')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:485 in public function `get_module_concrete_type`:
        D401: First line should be in imperative mood (perhaps 'Get', not 'Gets')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:539 in public function `create_script_module`:
        D400: First line should end with a period (not 'e')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:539 in public function `create_script_module`:
        D401: First line should be in imperative mood (perhaps 'Create', not 'Creates')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:725 in public function `script_model_defines_attr`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:735 in public function `add_python_attr_to_scripted_model`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:740 in public function `get_overload_annotations`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:772 in public function `get_overload_name_mapping`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:797 in public function `make_stubs_for_overloads`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:816 in public function `check_module_initialized`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:842 in public function `infer_methods_to_compile`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:842 in public function `infer_methods_to_compile`:
        D400: First line should end with a period (not 'g')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:842 in public function `infer_methods_to_compile`:
        D401: First line should be in imperative mood (perhaps 'Implement', not 'Implements')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:904 in public function `get_hook_stubs`:
        D200: One-line docstring should fit on one line with quotes (found 3)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:904 in public function `get_hook_stubs`:
        D400: First line should end with a period (not 's')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:904 in public function `get_hook_stubs`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:940 in public function `get_property_stubs`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:940 in public function `get_property_stubs`:
        D400: First line should end with a period (not 'd')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:963 in public function `interface_script`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:963 in public function `interface_script`:
        D400: First line should end with a period (not 'r')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:963 in public function `interface_script`:
        D401: First line should be in imperative mood (perhaps 'Make', not 'Makes')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:977 in private nested function `infer_interface_methods_to_compile`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:977 in private nested function `infer_interface_methods_to_compile`:
        D400: First line should end with a period (not 'h')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:989 in public function `try_compile_fn`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:1014 in public function `wrap_cpp_class`:
        D200: One-line docstring should fit on one line with quotes (found 3)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:1021 in public function `wrap_cpp_module`:
        D200: One-line docstring should fit on one line with quotes (found 3)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:1021 in public function `wrap_cpp_module`:
        D400: First line should end with a period (not 's')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:1040 in public function `compile_unbound_method`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:1052 in public function `lazy_bind`:
        D205: 1 blank line required between summary line and description (found 0)
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:1052 in public function `lazy_bind`:
        D400: First line should end with a period (not 'd')
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:1052 in public function `lazy_bind`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
47
```
After:
```
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:69 in public function `make_stub`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:75 in public function `make_stub_from_method`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:90 in public function `make_stubs_from_exported_methods`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:103 in public function `jit_ignored_properties`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:155 in public class `SourceContext`:
        D101: Missing docstring in public class
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:156 in public method `__init__`:
        D107: Missing docstring in __init__
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:160 in public function `get_annotations`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:424 in public class `ConcreteTypeStore`:
        D101: Missing docstring in public class
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:428 in public method `__init__`:
        D107: Missing docstring in __init__
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:457 in public function `create_methods_and_properties_from_stubs`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:472 in public function `create_hooks_from_stubs`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:724 in public function `script_model_defines_attr`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:734 in public function `add_python_attr_to_scripted_model`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:739 in public function `get_overload_annotations`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:771 in public function `get_overload_name_mapping`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:796 in public function `make_stubs_for_overloads`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:815 in public function `check_module_initialized`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:979 in public function `try_compile_fn`:
        D103: Missing docstring in public function
/home/ubuntu/Desktop/Docathon/pytorch/torch/jit/_recursive.py:1026 in public function `compile_unbound_method`:
        D103: Missing docstring in public function
19
```

@svekars 
cc @carljparker
