### PR TITLE
[export] Remove inline constraint assertions

### DIFF
--- a/aten/src/ATen/native/Constraints.cpp
+++ b/aten/src/ATen/native/Constraints.cpp
@@ -42,9 +42,9 @@ void sym_constrain_range(
 
     TORCH_CHECK(
       min_val <= size_as_int && size_as_int <= max_val,
-      "Invalid value range for ",
+      "Input ",
       size_as_int,
-      " between [",
+      " is outside of specified dynamic range [",
       min_val,
       ", ",
       max_val,

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -69,9 +69,6 @@ from .exported_program import (
     CallSpec,
     combine_args_kwargs,
 )
-from .passes.add_runtime_assertions_for_constraints_pass import (
-    _AddRuntimeAssertionsForInlineConstraintsPass,
-)
 from .passes.lift_constant_tensor_pass import lift_constant_tensor_pass
 from .passes.remove_runtime_assertions import _RemoveRuntimeAssertionsPass
 from .passes.replace_sym_size_ops_pass import _replace_sym_size_ops_pass
@@ -823,11 +820,6 @@ def _export(
         [ModuleCallEntry(fqn, sig) for fqn, sig in module_call_signatures.items()],
         (args, kwargs),
     )
-
-    if len(range_constraints) > 0 or len(equality_constraints) > 0:
-        exported_program = exported_program._transform(
-            _AddRuntimeAssertionsForInlineConstraintsPass(range_constraints, equality_constraints)
-        )
 
     return exported_program
 

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -322,7 +322,6 @@ class ExportedProgram:
         """
         from torch._decomp import core_aten_decompositions
         from torch._export.passes.add_runtime_assertions_for_constraints_pass import (
-            _AddRuntimeAssertionsForInlineConstraintsPass,
             InputDim,
         )
         from torch._export.passes.lift_constant_tensor_pass import (
@@ -465,13 +464,6 @@ class ExportedProgram:
             self.example_inputs,
             self.verifier,
         )
-
-        if len(new_range_constraints) > 0 or len(new_equality_constraints) > 0:
-            exported_program = exported_program._transform(
-                _AddRuntimeAssertionsForInlineConstraintsPass(
-                    new_range_constraints, new_equality_constraints
-                )
-            )
 
         return exported_program
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -368,7 +368,6 @@ def _constrain_range_for_size(a, min: Optional[int] = None, max: Optional[int] =
     """
     This function is NOT INTENDED to be used by itself.
     """
-
     if isinstance(a, (SymFloat, SymBool)):
         raise ValueError("Constraining SymFloat/SymBool is nyi")
 


### PR DESCRIPTION
I was looking at some code with constraints, and realized that since we now have an `aten.sym_constrain_range_for_size`, maybe we could remove the inline constraint assertions from the graph, and directly put them into the `aten.sym_constrain_range_for_size` operator. This will declutter the graph as the assertions add a lot of extraneous nodes to the graph.

Original graph:
```
graph():
    %arg0_1 : [num_users=2] = placeholder[target=arg0_1]
    %max_1 : [num_users=1] = call_function[target=torch.ops.aten.max.default](args = (%arg0_1,), kwargs = {})
    %_local_scalar_dense : [num_users=4] = call_function[target=torch.ops.aten._local_scalar_dense.default](args = (%max_1,), kwargs = {})
    %ge : [num_users=1] = call_function[[target=operator.ge](http://target=operator.ge/)](args = (%_local_scalar_dense, 0), kwargs = {})
    %scalar_tensor : [num_users=1] = call_function[target=torch.ops.aten.scalar_tensor.default](args = (%ge,), kwargs = {})
    %_assert_async : [num_users=0] = call_function[target=torch.ops.aten._assert_async.msg](args = (%scalar_tensor, _local_scalar_dense is outside of inline constraint [0, 5].), kwargs = {})
    %le : [num_users=1] = call_function[target=operator.le](args = (%_local_scalar_dense, 5), kwargs = {})
    %scalar_tensor_1 : [num_users=1] = call_function[target=torch.ops.aten.scalar_tensor.default](args = (%le,), kwargs = {})
    %_assert_async_1 : [num_users=0] = call_function[target=torch.ops.aten._assert_async.msg](args = (%scalar_tensor_1, _local_scalar_dense is outside of inline constraint [0, 5].), kwargs = {})
    %sym_constrain_range_for_size : [num_users=0] = call_function[target=torch.ops.aten.sym_constrain_range_for_size.default](args = (%_local_scalar_dense,), kwargs = {max: 5})
...
```

New graph:
```
graph():
    %arg0_1 : [num_users=2] = placeholder[target=arg0_1]
    %max_1 : [num_users=1] = call_function[target=torch.ops.aten.max.default](args = (%arg0_1,), kwargs = {})
    %_local_scalar_dense : [num_users=4] = call_function[target=torch.ops.aten._local_scalar_dense.default](args = (%max_1,), kwargs = {})
    %sym_constrain_range_for_size : [num_users=0] = call_function[target=torch.ops.aten.sym_constrain_range_for_size.default](args = (%_local_scalar_dense,), kwargs = {max: 5})
...
```

However, after looking into the code for `sym_constrain_range_for_size`, I realized we already have [assertions](https://github.com/pytorch/pytorch/blob/4da5d4b2ef7c8f89a6e76faef0bebb4b387f3dd6/aten/src/ATen/native/Constraints.cpp#L43-L52) in there. So I removed it, modified the error message, and it seems to be doing fine.

Test code:
```
    def test_constrain_size_in_eager(self):
        def fn(x, y):
            n = x.max().item()
            torch._constrain_as_size(n, max=5)
            return y + n

        ep = export(fn, (torch.randint(1, 2, (2, 2)), torch.randint(3, 5, (2, 3))))
        ep(torch.randint(6, 7, (2, 2)), torch.randint(3, 5, (2, 3)))
```

Error message looks like:
```
======================================================================
ERROR: test_constrain_size_in_eager (__main__.TestExport)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/data/users/angelayi/pytorch/torch/testing/_internal/common_utils.py", line 2528, in wrapper
    method(*args, **kwargs)
  File "/data/users/angelayi/pytorch/test/export/test_export.py", line 864, in test_constrain_size_in_eager
    ep(torch.randint(6, 7, (2, 2)), torch.randint(3, 5, (2, 3)))
  File "/data/users/angelayi/pytorch/torch/export/exported_program.py", line 239, in __call__
    res = torch.fx.Interpreter(self.graph_module).run(
  File "/data/users/angelayi/pytorch/torch/fx/interpreter.py", line 138, in run
    self.env[node] = self.run_node(node)
  File "/data/users/angelayi/pytorch/torch/fx/interpreter.py", line 195, in run_node
    return getattr(self, n.op)(n.target, args, kwargs)
  File "/data/users/angelayi/pytorch/torch/fx/interpreter.py", line 267, in call_function
    return target(*args, **kwargs)
  File "/data/users/angelayi/pytorch/torch/_ops.py", line 513, in __call__
    return self._op(*args, **kwargs or {})
RuntimeError: Input 6 is outside of specified dynamic range [0, 5].

While executing %sym_constrain_range_for_size : [num_users=0] = call_function[target=torch.ops.aten.sym_constrain_range_for_size.default](args = (%_local_scalar_dense,), kwargs = {max: 5})
Original traceback:
  File "/data/users/angelayi/pytorch/test/export/test_export.py", line 856, in fn
    torch._constrain_as_size(n, max=5)


To execute this test, run the following from the base repo dir:
     python test/export/test_export.py -k test_constrain_size_in_eager

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
```

cc @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan @suo @ydwu4