### PR TITLE
[iOS][PTMCoreMLCompiler] Refactor use of deprecated writeToFile:atomically:

### DIFF
--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.mm
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.mm
@@ -115,7 +115,7 @@ static NSString *gVersionExtension = @"version";
 #if TARGET_OS_IPHONE
   NSURL *versionURL = [PTMCoreMLCompiler _cacheURLForModel:modelName extension:gVersionExtension];
   NSString *currentOSVer = [UIDevice currentDevice].systemVersion;
-  [currentOSVer writeToFile:versionURL.path atomically:YES];
+  [currentOSVer writeToFile:versionURL.path atomically:YES encoding:NSUTF8StringEncoding error:NULL];
 #endif
 
   return YES;


### PR DESCRIPTION
Summary:
The NSString writeToFile:atomically: method was deprecated in iOS 2.0.
This diff replaces it with a call to writeToFile:atomically:encoding:error:

duplicate of D51003188 to fix gh permissions

Test Plan: ci

Differential Revision: D51164941


