### PR TITLE
[Inductor][fx pass] Refactor code to easily add pointwise op to do the batch fusion

### DIFF
--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -198,7 +198,7 @@ class MyModule5(torch.nn.Module):
         return torch.sin(l1_out)
 
 
-class MyModule6(torch.nn.Module):
+class TestPoitwiseOps(torch.nn.Module):
     def __init__(self, device, has_bias=True):
         super().__init__()
         self.device = device
@@ -209,18 +209,11 @@ class MyModule6(torch.nn.Module):
         y_split = torch.split(inputs[1].to(self.device), 100, dim=1)
         tanh_1 = [torch.tanh(x_split[i]) for i in range(len(x_split))]
         tanh_2 = [torch.tanh(y_split[i]) for i in range(len(y_split))]
-        return torch.cat(tanh_1, dim=1) + torch.cat(tanh_2, dim=1)
-
-
-class MyModule7(torch.nn.Module):
-    def __init__(self, device, has_bias=True):
-        super().__init__()
-        self.device = device
-
-    def forward(self, x):
-        inputs = torch.unbind(x.to(self.device), dim=0)
-        relu = [torch.nn.functional.relu(inputs[i]) for i in range(len(inputs))]
-        return torch.stack(relu, dim=0)
+        sigmoid_1 = [torch.sigmoid(tanh_1[i]) for i in range(len(tanh_1))]
+        sigmoid_2 = [torch.sigmoid(tanh_2[i]) for i in range(len(tanh_2))]
+        relu_1 = [torch.nn.functional.relu(sigmoid_1[i]) for i in range(len(sigmoid_1))]
+        relu_2 = [torch.nn.functional.relu(sigmoid_2[i]) for i in range(len(sigmoid_2))]
+        return torch.cat(relu_1, dim=1) + torch.cat(relu_2, dim=1)
 
 
 @requires_cuda()
@@ -396,38 +389,23 @@ class TestGroupBatchFusion(TestCase):
             self.compare_gradients(module, traced, rtol=1e-8, atol=1e-8)
             counters.clear()
 
-    def test_batch_tanh_pre_grad_fusion(self):
+    def test_pointwise_op_pre_grad_fusion(self):
         counters.clear()
-        module = MyModule6("cuda")
+        module = TestPoitwiseOps("cuda")
         input = [torch.randn(50, 1000, requires_grad=True, device="cuda")]
         traced = torch.compile(module)
         ref = module(*input)
         res = traced(*input)
         self.compare_pred(module, traced, input)
-        self.assertEqual(counters["inductor"]["batch_fusion"], 2)
+        self.assertEqual(counters["inductor"]["batch_fusion"], 3)
         self.assertEqual(
             counters["inductor"]["scmerge_split_removed"],
-            2,
+            0,
         )
         self.assertEqual(
             counters["inductor"]["scmerge_cat_removed"],
-            2,
+            0,
         )
-        ref.sum().backward()
-        res.sum().backward()
-        self.compare_parameters(module, traced, rtol=1e-8, atol=1e-8)
-        self.compare_gradients(module, traced, rtol=1e-8, atol=1e-8)
-        counters.clear()
-
-    def test_batch_relu_pre_grad_fusion(self):
-        counters.clear()
-        module = MyModule7("cuda")
-        input = [torch.randn(20, 40, 60, requires_grad=True, device="cuda")]
-        traced = torch.compile(module)
-        ref = module(*input)
-        res = traced(*input)
-        self.compare_pred(module, traced, input)
-        self.assertEqual(counters["inductor"]["batch_fusion"], 1)
         ref.sum().backward()
         res.sum().backward()
         self.compare_parameters(module, traced, rtol=1e-8, atol=1e-8)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -99,6 +99,7 @@ pre_grad_fusion_options: Dict[str, Dict[str, Any]] = {
     "batch_layernorm": {},
     "batch_tanh": {},
     "batch_relu": {},
+    "batch_sigmoid": {},
 }
 
 # Post grad group/batch fusion and options, set to empty dict to disable fusion.

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -101,6 +101,12 @@ class BatchFusion(GroupBatchFusionBase):
     pass
 
 
+class BatchPointwiseOpsFusionFactory(BatchFusion):
+    def __init__(self, op, **kwargs):
+        super().__init__(**kwargs)
+        self.op = op
+
+
 @register_fusion("group_linear", pre_grad=False)
 class GroupLinearFusion(GroupFusion):
     def _addmm_node_can_be_fused(self, node: torch.fx.Node):
@@ -356,66 +362,6 @@ class BatchLinearFusion(BatchFusion):
                 graph.erase_node(linear)
 
 
-@register_fusion("batch_tanh")
-class BatchTanhFusion(BatchFusion):
-    """
-    Batch tanh fusion in pre grad pass.
-    We only fuse the tahn if the input is after same split node.
-    """
-
-    def _getitem_args(self, getitem_node: torch.fx.Node):
-        if getitem_node.target != operator.__getitem__ or (
-            getitem_node.op != "call_function"
-        ):
-            return None
-        return getitem_node.args[0]
-
-    def match(self, node: torch.fx.Node):
-        input = get_arg_value(node, 0, "input")
-        if (
-            CallFunctionVarArgs(torch.tanh).match(node)
-            and is_node_meta_valid(node)
-            and self._getitem_args(input) is not None
-        ):
-            group_key = (
-                "batch_tanh",
-                self._getitem_args(input),
-                str(input.meta["example_value"].shape),
-            )
-        else:
-            group_key = None
-        return group_key
-
-    def fuse(self, graph: torch.fx.GraphModule, subset: List[torch.fx.Node]):
-        batch_nodes = []
-        batch_inputs = []
-
-        for node in subset:
-            batch_nodes.append(node)
-            batch_inputs.append(get_arg_value(node, 0, "input"))
-
-        with graph.inserting_before(subset[0]):
-            stack_inputs = graph.call_function(
-                torch.stack, args=(batch_inputs,), kwargs={"dim": 0}
-            )
-
-            batch_tanh = graph.call_function(
-                torch.tanh,
-                args=(stack_inputs,),
-            )
-            unbind_tanh = graph.call_function(
-                torch.unbind, args=(batch_tanh,), kwargs={"dim": 0}
-            )
-            for i, node in enumerate(batch_nodes):
-                with graph.inserting_after(unbind_tanh):
-                    getitem = graph.call_function(
-                        operator.getitem, args=(unbind_tanh, i)
-                    )
-                node.replace_all_uses_with(getitem)
-                getitem.meta.update(node.meta)
-                graph.erase_node(node)
-
-
 @register_fusion("batch_layernorm")
 class BatchLayernormFusion(BatchFusion):
     """
@@ -528,31 +474,24 @@ class BatchLayernormFusion(BatchFusion):
             graph.erase_node(node)
 
 
-@register_fusion("batch_relu")
-class BatchReLUFusion(BatchFusion):
+class BatchPointwiseOpsPreGradFusion(BatchPointwiseOpsFusionFactory):
     """
-    Batch relu fusion in pre grad pass.
-    We only fuse the relu if the input is after same split/unbind node.
+    Batch poinwise ops (e.g., sigmoid, relu, tanh) fusion in pre grad pass.
+    We fuse it in random place, and the introduced stack node may be merged in split cat.
     """
 
-    def _getitem_args(self, getitem_node: torch.fx.Node):
-        if getitem_node.target != operator.__getitem__ or (
-            getitem_node.op != "call_function"
-        ):
-            return None
-        return getitem_node.args[0]
+    def __init__(self, op, **kwargs):
+        super().__init__(op, **kwargs)
+        self.op = op
 
     def match(self, node: torch.fx.Node):
         input = get_arg_value(node, 0, "input")
-        if (
-            CallFunctionVarArgs(torch.nn.functional.relu).match(node)
-            and is_node_meta_valid(node)
-            and self._getitem_args(input) is not None
-        ):
+        if CallFunctionVarArgs(self.op).match(node) and is_node_meta_valid(node):
+            # for relu op, we also use the inplace to construct the key
             group_key = (
-                "batch_relu",
-                self._getitem_args(input),
+                "batch_" + self.op.__name__.lower() + "_pre_grad",
                 str(input.meta["example_value"].shape),
+                str(node.kwargs.get("inplace", False)),
             )
         else:
             group_key = None
@@ -566,29 +505,48 @@ class BatchReLUFusion(BatchFusion):
             batch_nodes.append(node)
             batch_inputs.append(get_arg_value(node, 0, "input"))
 
-        # assume all the nodes to be batched have the same inplace
-        inplace = subset[0].kwargs.get("inplace", False)
         with graph.inserting_before(subset[0]):
             stack_inputs = graph.call_function(
                 torch.stack, args=(batch_inputs,), kwargs={"dim": 0}
             )
-
-            batch_relu = graph.call_function(
-                torch.nn.functional.relu,
-                args=(stack_inputs,),
-                kwargs={"inplace": inplace},
-            )
-            unbind_relu = graph.call_function(
-                torch.unbind, args=(batch_relu,), kwargs={"dim": 0}
+            if self.op == torch.nn.functional.relu:
+                batch_op = graph.call_function(
+                    self.op,
+                    args=(stack_inputs,),
+                    kwargs={"inplace": subset[0].kwargs.get("inplace", False)},
+                )
+            else:
+                batch_op = graph.call_function(
+                    self.op,
+                    args=(stack_inputs,),
+                )
+            unbind_op = graph.call_function(
+                torch.unbind, args=(batch_op,), kwargs={"dim": 0}
             )
             for i, node in enumerate(batch_nodes):
-                with graph.inserting_after(unbind_relu):
-                    getitem = graph.call_function(
-                        operator.getitem, args=(unbind_relu, i)
-                    )
+                with graph.inserting_after(unbind_op):
+                    getitem = graph.call_function(operator.getitem, args=(unbind_op, i))
                 node.replace_all_uses_with(getitem)
                 getitem.meta.update(node.meta)
                 graph.erase_node(node)
+
+
+@register_fusion("batch_tanh")
+class BatchTanhPreGradFusion(BatchPointwiseOpsPreGradFusion):
+    def __init__(self, **kwargs):
+        super().__init__(torch.tanh, **kwargs)
+
+
+@register_fusion("batch_sigmoid")
+class BatchSigmoidPreGradFusion(BatchPointwiseOpsPreGradFusion):
+    def __init__(self, **kwargs):
+        super().__init__(torch.sigmoid, **kwargs)
+
+
+@register_fusion("batch_relu")
+class BatchReLuPreGradFusion(BatchPointwiseOpsPreGradFusion):
+    def __init__(self, **kwargs):
+        super().__init__(torch.nn.functional.relu, **kwargs)
 
 
 def find_independent_subset_greedy(


### PR DESCRIPTION
Summary:
1. We refactor the code to have a unified API to add pointwise op

2. Add one more op sigmoid since we observed it in MC models

Test Plan:
# local reproduce for CMF

```
buck2 run mode/opt //scripts/jackiexu0313/pt2:local_model_with_pt2 -- --test_mode split_batch -c
```
P876977403
P876996776

diffing: https://www.internalfb.com/intern/diffing/?paste_number=876999623

Differential Revision: D51142990




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler