### PR TITLE
[dynamo] Support kwargs for lazy module call.

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1527,6 +1527,20 @@ def forward(self, arg0_1):
         ):
             ep(*test_inp)
 
+    def test_lazy_module_kwargs(self):
+        class LazyModule(torch.nn.modules.lazy.LazyModuleMixin, torch.nn.Module):
+            def initialize_parameters(self, *args, **kwargs):
+                pass
+
+            def forward(self, x, y):
+                return x + y
+
+        m = LazyModule()
+        ep = torch.export.export(m, (), {'x': torch.randn(3, 3), 'y': torch.randn(3, 3)})
+        inputs = {'x': torch.randn(3, 3), 'y': torch.randn(3, 3)}
+        self.assertEqual(ep(**inputs), m(**inputs))
+
+
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -216,8 +216,7 @@ class OptimizedModule(torch.nn.Module):
             # the pre-hooks which initialize it.
             # Afterwards, lazy module deletes its pre-hooks
             # to avoid treating it as lazy on subsequent recompile.
-            assert len(kwargs) == 0
-            self._orig_mod._infer_parameters(self._orig_mod, args)
+            self._orig_mod._infer_parameters(self._orig_mod, args, kwargs)
         return self._forward(*args, **kwargs)
 
     def __dir__(self):


### PR DESCRIPTION
Summary: Seems like we already support kwargs in _infer_argument, so we don't need the extra assertion here.

Test Plan: buck test caffe2/test:test_export -- -r lazy_module_kwargs

Differential Revision: D51170339




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @avikchaudhuri @gmagogsfm @tugsbayasgalan @angelayi @suo @ydwu4