### PR TITLE
[Kineto] Fix the Chrome trace loading issue with all_to_all input split length > 30

### DIFF
--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -368,12 +368,13 @@ std::unordered_map<std::string, std::string> saveNcclMeta(
   map.emplace(kOutMsgSize, std::to_string(debugInfo->getOutMessageSize()));
   auto& inSplitSizes = debugInfo->getInputSplitSizes();
   if (!inSplitSizes.empty() && inSplitSizes.size() <= kTruncatLength) {
-    map.emplace(kInSplit, fmt::format("[{}]", fmt::join(inSplitSizes, ", ")));
+    map.emplace(
+        kInSplit, fmt::format("\"[{}]\"", fmt::join(inSplitSizes, ", ")));
   } else if (inSplitSizes.size() > kTruncatLength) {
     map.emplace(
         kInSplit,
         fmt::format(
-            "[{}, ...]",
+            "\"[{}, ...]\"",
             fmt::join(
                 inSplitSizes.begin(),
                 inSplitSizes.begin() + kTruncatLength,
@@ -381,12 +382,13 @@ std::unordered_map<std::string, std::string> saveNcclMeta(
   }
   auto& outSplitSizes = debugInfo->getOutputSplitSizes();
   if (!outSplitSizes.empty() && outSplitSizes.size() <= kTruncatLength) {
-    map.emplace(kOutSplit, fmt::format("[{}]", fmt::join(outSplitSizes, ", ")));
+    map.emplace(
+        kOutSplit, fmt::format("\"[{}]\"", fmt::join(outSplitSizes, ", ")));
   } else if (outSplitSizes.size() > kTruncatLength) {
     map.emplace(
         kOutSplit,
         fmt::format(
-            "[{}, ...]",
+            "\"[{}, ...]\"",
             fmt::join(
                 outSplitSizes.begin(),
                 outSplitSizes.begin() + kTruncatLength,


### PR DESCRIPTION
Summary:
This change fixes the Chrome trace loading issue with all_to_all input split length > 30.

Now when the `all_to_all` input split size is larger than 30 we truncate the content and adding `...` at the end, which caused trouble when loading with Chrome trace.

Test Plan:
**Trace with length = 2**:
- Link: https://fburl.com/perfdoctor/b94u4x82
 {F1145436735}

**Looking into the json file**:
```
Before:
"In split size": [6058496, 5942784]

After
"In split size": "[6058496, 5942784]"
```

Reviewed By: aaronenyeshi

Differential Revision: D51167843


