### PR TITLE
Add TorchFix to the CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -23,6 +23,9 @@ ignore =
     SIM105,SIM108,SIM110,SIM111,SIM113,SIM114,SIM115,SIM116,SIM117,SIM118,SIM119,SIM12,
     # flake8-simplify code styles
     SIM102,SIM103,SIM106,SIM112,
+    # TorchFix codes that don't make sense for PyTorch itself:
+    # removed functions and deprecated PyTorch functions.
+    TOR001,TOR101,
 per-file-ignores =
     __init__.py: F401
     torch/utils/cpp_extension.py: B950

--- a/.flake8
+++ b/.flake8
@@ -24,7 +24,7 @@ ignore =
     # flake8-simplify code styles
     SIM102,SIM103,SIM106,SIM112,
     # TorchFix codes that don't make sense for PyTorch itself:
-    # removed functions and deprecated PyTorch functions.
+    # removed and deprecated PyTorch functions.
     TOR001,TOR101,
 per-file-ignores =
     __init__.py: F401

--- a/.flake8
+++ b/.flake8
@@ -2,7 +2,7 @@
 # NOTE: **Mirror any changes** to this file the [tool.ruff] config in pyproject.toml
 # before we can fully move to use ruff
 enable-extensions = G
-select = B,C,E,F,G,P,SIM1,T4,W,B9
+select = B,C,E,F,G,P,SIM1,T4,W,B9,TOR0,TOR1,TOR2
 max-line-length = 120
 # C408 ignored because we like the dict keyword argument syntax
 # E501 is not flexible enough, we're using B950 instead

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -48,6 +48,7 @@ init_command = [
     'mccabe==0.7.0',
     'pycodestyle==2.10.0',
     'pyflakes==3.0.1',
+    'torchfix==0.1.1',
 ]
 
 

--- a/android/test_app/make_assets.py
+++ b/android/test_app/make_assets.py
@@ -1,21 +1,21 @@
 import torch
-import torchvision
+from torchvision import models
 
 print(torch.version.__version__)
 
-resnet18 = torchvision.models.resnet18(pretrained=True)
+resnet18 = models.resnet18(weights=models.ResNet18_Weights.IMAGENET1K_V1)
 resnet18.eval()
 resnet18_traced = torch.jit.trace(resnet18, torch.rand(1, 3, 224, 224)).save(
     "app/src/main/assets/resnet18.pt"
 )
 
-resnet50 = torchvision.models.resnet50(pretrained=True)
+resnet50 = models.resnet50(weights=models.ResNet50_Weights.IMAGENET1K_V1)
 resnet50.eval()
 torch.jit.trace(resnet50, torch.rand(1, 3, 224, 224)).save(
     "app/src/main/assets/resnet50.pt"
 )
 
-mobilenet2q = torchvision.models.quantization.mobilenet_v2(
+mobilenet2q = models.quantization.mobilenet_v2(
     pretrained=True, quantize=True
 )
 mobilenet2q.eval()

--- a/android/test_app/make_assets.py
+++ b/android/test_app/make_assets.py
@@ -15,9 +15,7 @@ torch.jit.trace(resnet50, torch.rand(1, 3, 224, 224)).save(
     "app/src/main/assets/resnet50.pt"
 )
 
-mobilenet2q = models.quantization.mobilenet_v2(
-    pretrained=True, quantize=True
-)
+mobilenet2q = models.quantization.mobilenet_v2(pretrained=True, quantize=True)
 mobilenet2q.eval()
 torch.jit.trace(mobilenet2q, torch.rand(1, 3, 224, 224)).save(
     "app/src/main/assets/mobilenet2q.pt"

--- a/android/test_app/make_assets_custom.py
+++ b/android/test_app/make_assets_custom.py
@@ -5,11 +5,11 @@ build script to create a tailored build which only contains these used ops.
 """
 
 import torch
-import torchvision
 import yaml
+from torchvision import models
 
 # Download and trace the model.
-model = torchvision.models.mobilenet_v2(pretrained=True)
+model = models.mobilenet_v2(weights=models.MobileNet_V2_Weights.IMAGENET1K_V1)
 model.eval()
 example = torch.rand(1, 3, 224, 224)
 # TODO: create script model with `torch.jit.script`

--- a/ios/TestApp/benchmark/coreml_backend.py
+++ b/ios/TestApp/benchmark/coreml_backend.py
@@ -1,7 +1,7 @@
 import torch
-import torchvision
 
 from torch.backends._coreml.preprocess import CompileSpec, CoreMLComputeUnit, TensorSpec
+from torchvision import models
 
 
 def mobilenetv2_spec():
@@ -24,7 +24,7 @@ def mobilenetv2_spec():
 
 
 def main():
-    model = torchvision.models.mobilenet_v2(pretrained=True)
+    model = models.mobilenet_v2(weights=models.MobileNet_V2_Weights.IMAGENET1K_V1)
     model.eval()
     example = torch.rand(1, 3, 224, 224)
     model = torch.jit.trace(model, example)

--- a/ios/TestApp/benchmark/trace_model.py
+++ b/ios/TestApp/benchmark/trace_model.py
@@ -1,8 +1,8 @@
 import torch
-import torchvision
 from torch.utils.mobile_optimizer import optimize_for_mobile
+from torchvision import models
 
-model = torchvision.models.mobilenet_v2(pretrained=True)
+model = models.mobilenet_v2(weights=models.MobileNet_V2_Weights.IMAGENET1K_V1)
 model.eval()
 example = torch.rand(1, 3, 224, 224)
 traced_script_module = torch.jit.trace(model, example)

--- a/ios/TestApp/custom_build/custom_build.py
+++ b/ios/TestApp/custom_build/custom_build.py
@@ -1,8 +1,8 @@
 import torch
-import torchvision
 import yaml
+from torchvision import models
 
-model = torchvision.models.mobilenet_v2(pretrained=True)
+model = models.mobilenet_v2(weights=models.MobileNet_V2_Weights.IMAGENET1K_V1)
 model.eval()
 example = torch.rand(1, 3, 224, 224)
 traced_script_module = torch.jit.trace(model, example)

--- a/requirements-flake8.txt
+++ b/requirements-flake8.txt
@@ -8,3 +8,4 @@ flake8-pyi==20.5.0
 mccabe==0.6.1
 pycodestyle==2.6.0
 pyflakes==2.2.0
+torchfix==0.1.1


### PR DESCRIPTION
Enable flake8 plugin for https://github.com/pytorch/test-infra/tree/main/tools/torchfix - TorchFix 0.1.1.
Disable TorchFix codes that don't make sense for PyTorch itself.
Update deprecated TorchVision APIs to make TorchFix pass.