### PR TITLE
Improve torch.unique docs

### DIFF
--- a/torch/functional.py
+++ b/torch/functional.py
@@ -762,7 +762,7 @@ def _unique_impl(input: Tensor, sorted: bool = True,
     .. note:: This function is different from :func:`torch.unique_consecutive` in the sense that
         this function also eliminates non-consecutive duplicate values.
 
-    .. note:: Currently in the CUDA implementation and the CPU implementation when dim is specified,
+    .. note:: Currently in the CUDA implementation and the CPU implementation,
         `torch.unique` always sort the tensor at the beginning regardless of the `sort` argument.
         Sorting could be slow, so if your input tensor is already sorted, it is recommended to use
         :func:`torch.unique_consecutive` which avoids the sorting.


### PR DESCRIPTION
Related issue: https://github.com/pytorch/pytorch/issues/105742.
In fact, `torch.unique` always sort the tensor at the beginning regardless of the `sort` argument and the `dim` argument .

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #113424
* #113420



cc @albanD