### PR TITLE
[BE] Remove stale CUDA version check from cpp_extension.py

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -2344,17 +2344,12 @@ def _write_ninja_file(path,
     if with_cuda:
         cuda_compile_rule = ['rule cuda_compile']
         nvcc_gendeps = ''
-        # --generate-dependencies-with-compile was added in CUDA 10.2.
-        # Compilation will work on earlier CUDA versions but header file
-        # dependencies are not correctly computed.
-        required_cuda_version = '11.0'
-        if torch.version.cuda is not None and TorchVersion(torch.version.cuda) >= required_cuda_version:
-            cuda_compile_rule.append('  depfile = $out.d')
-            cuda_compile_rule.append('  deps = gcc')
-            # Note: non-system deps with nvcc are only supported
-            # on Linux so use --generate-dependencies-with-compile
-            # to make this work on Windows too.
-            nvcc_gendeps = '--generate-dependencies-with-compile --dependency-output $out.d'
+        cuda_compile_rule.append('  depfile = $out.d')
+        cuda_compile_rule.append('  deps = gcc')
+        # Note: non-system deps with nvcc are only supported
+        # on Linux so use --generate-dependencies-with-compile
+        # to make this work on Windows too.
+        nvcc_gendeps = '--generate-dependencies-with-compile --dependency-output $out.d'
         cuda_compile_rule.append(
             f'  command = $nvcc {nvcc_gendeps} $cuda_cflags -c $in -o $out $cuda_post_cflags')
 

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -2344,11 +2344,8 @@ def _write_ninja_file(path,
     if with_cuda:
         cuda_compile_rule = ['rule cuda_compile']
         nvcc_gendeps = ''
-        # --generate-dependencies-with-compile was added in CUDA 10.2.
-        # Compilation will work on earlier CUDA versions but header file
-        # dependencies are not correctly computed.
-        required_cuda_version = '11.0'
-        if torch.version.cuda is not None and TorchVersion(torch.version.cuda) >= required_cuda_version:
+        # --generate-dependencies-with-compile is not supported by ROCm
+        if torch.version.cuda is not None:
             cuda_compile_rule.append('  depfile = $out.d')
             cuda_compile_rule.append('  deps = gcc')
             # Note: non-system deps with nvcc are only supported

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -2344,12 +2344,17 @@ def _write_ninja_file(path,
     if with_cuda:
         cuda_compile_rule = ['rule cuda_compile']
         nvcc_gendeps = ''
-        cuda_compile_rule.append('  depfile = $out.d')
-        cuda_compile_rule.append('  deps = gcc')
-        # Note: non-system deps with nvcc are only supported
-        # on Linux so use --generate-dependencies-with-compile
-        # to make this work on Windows too.
-        nvcc_gendeps = '--generate-dependencies-with-compile --dependency-output $out.d'
+        # --generate-dependencies-with-compile was added in CUDA 10.2.
+        # Compilation will work on earlier CUDA versions but header file
+        # dependencies are not correctly computed.
+        required_cuda_version = '11.0'
+        if torch.version.cuda is not None and TorchVersion(torch.version.cuda) >= required_cuda_version:
+            cuda_compile_rule.append('  depfile = $out.d')
+            cuda_compile_rule.append('  deps = gcc')
+            # Note: non-system deps with nvcc are only supported
+            # on Linux so use --generate-dependencies-with-compile
+            # to make this work on Windows too.
+            nvcc_gendeps = '--generate-dependencies-with-compile --dependency-output $out.d'
         cuda_compile_rule.append(
             f'  command = $nvcc {nvcc_gendeps} $cuda_cflags -c $in -o $out $cuda_post_cflags')
 


### PR DESCRIPTION
As at least CUDA-11.x is needed to build PyTorch on latest trunk.
But still skip `--generate-dependencies-with-compile` if running on ROCm

