### PR TITLE
[BE] Add friendly error message if you compile_fx_inner but not return tuple/list

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -345,6 +345,10 @@ def compile_fx_inner(
     if dynamo_utils.count_calls(gm.graph) == 0 and not aot_mode:
         return make_boxed_func(gm.forward)
 
+    assert isinstance(
+        next(iter(reversed(gm.graph.nodes))).args[0], tuple
+    ), f"inductor can only compile FX graphs which return tuples, but got {gm.graph}"
+
     if config.save_args:
         save_args_for_compile_fx_inner(
             gm,

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -346,8 +346,8 @@ def compile_fx_inner(
         return make_boxed_func(gm.forward)
 
     assert isinstance(
-        next(iter(reversed(gm.graph.nodes))).args[0], tuple
-    ), f"inductor can only compile FX graphs which return tuples, but got {gm.graph}"
+        next(iter(reversed(gm.graph.nodes))).args[0], (tuple, list)
+    ), f"inductor can only compile FX graphs which return a tuple/list, but got {gm.graph}"
 
     if config.save_args:
         save_args_for_compile_fx_inner(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #113451

Previously it would fail here:

```
  File "/data/users/ezyang/a/pytorch/torch/_inductor/fx_passes/post_grad.py", line 597, in remove_noop_ops
    for out in tuple(graph.nodes)[-1].args[0]:
```

Now you'll trigger this assert instead.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler