### PR TITLE
[LLVM] Replaced getInt8PtrTy with getUnqual

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -1477,7 +1477,7 @@ void LLVMCodeGenImpl::visit(LoadPtr v) {
 TypedPointer LLVMCodeGenImpl::packFuncArgs(
     const std::vector<llvm::Value*>& func_args) {
   if (func_args.empty()) {
-    llvm::PointerType* VoidPtrType = llvm::Type::getInt8PtrTy(getContext());
+    llvm::PointerType* VoidPtrType = llvm::PointerType::getUnqual(getContext());
     return TypedPointer(
         VoidPtrType, llvm::ConstantPointerNull::get(VoidPtrType));
   }


### PR DESCRIPTION

[llvm-fb-staging] Build failed on pytorch jit due to llvm upstream API change. The fix should just replace getInt8PtrTy with getUnqual. The corresponding task - [T169468309](https://www.internalfb.com/tasks/?t=169468309).


cc: @DanilBaibak  

cc @EikanWang @jgong5
