### PR TITLE
[dynamo] skip test_internal_error_suppress_errors in fbcode

### DIFF
--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -10,7 +10,7 @@ import torch._dynamo.test_case
 from torch._dynamo.comptime import comptime
 from torch._dynamo.exc import Unsupported
 from torch.testing._internal.common_device_type import skipIf
-from torch.testing._internal.common_utils import munge_exc, TEST_Z3
+from torch.testing._internal.common_utils import IS_FBCODE, munge_exc, TEST_Z3
 from torch.testing._internal.logging_utils import LoggingTestCase, make_logging_test
 
 
@@ -43,6 +43,7 @@ from user code:
 
     @torch._dynamo.config.patch(verbose=True, suppress_errors=True)
     @make_logging_test()
+    @unittest.skipIf(IS_FBCODE, "stack trace slightly different in fbcode")
     def test_internal_error_suppress_errors(self, records):
         def fn001(x):
             def f(ctx):


### PR DESCRIPTION
Summary: This test generates a different stack trace in fbcode and seems to have been failing for a while.

Test Plan: sandcastle

Differential Revision: D51210355




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng