### PR TITLE
Prune more unnecessary includes from CUDA transformers

### DIFF
--- a/aten/src/ATen/cuda/CUDAContext.h
+++ b/aten/src/ATen/cuda/CUDAContext.h
@@ -1,85 +1,9 @@
 #pragma once
 
-#include <cstdint>
+#include <ATen/cuda/CUDAContextLight.h>
 
-#include <cuda_runtime_api.h>
-#include <cusparse.h>
-#include <cublas_v2.h>
-
-#ifdef CUDART_VERSION
-#include <cusolverDn.h>
-#endif
-
-#if defined(USE_ROCM) && ROCM_VERSION >= 50300
-#include <hipsolver/hipsolver.h>
-#endif
-
-#include <ATen/core/ATenGeneral.h>
+// Preserved for BC, as may files depend on these includes
 #include <ATen/Context.h>
 #include <c10/cuda/CUDAStream.h>
-#include <c10/cuda/CUDAFunctions.h>
 #include <c10/util/Logging.h>
 #include <ATen/cuda/Exceptions.h>
-
-namespace at::cuda {
-
-/*
-A common CUDA interface for ATen.
-
-This interface is distinct from CUDAHooks, which defines an interface that links
-to both CPU-only and CUDA builds. That interface is intended for runtime
-dispatch and should be used from files that are included in both CPU-only and
-CUDA builds.
-
-CUDAContext, on the other hand, should be preferred by files only included in
-CUDA builds. It is intended to expose CUDA functionality in a consistent
-manner.
-
-This means there is some overlap between the CUDAContext and CUDAHooks, but
-the choice of which to use is simple: use CUDAContext when in a CUDA-only file,
-use CUDAHooks otherwise.
-
-Note that CUDAContext simply defines an interface with no associated class.
-It is expected that the modules whose functions compose this interface will
-manage their own state. There is only a single CUDA context/state.
-*/
-
-/**
- * DEPRECATED: use device_count() instead
- */
-inline int64_t getNumGPUs() {
-    return c10::cuda::device_count();
-}
-
-/**
- * CUDA is available if we compiled with CUDA, and there are one or more
- * devices.  If we compiled with CUDA but there is a driver problem, etc.,
- * this function will report CUDA is not available (rather than raise an error.)
- */
-inline bool is_available() {
-    return c10::cuda::device_count() > 0;
-}
-
-TORCH_CUDA_CPP_API cudaDeviceProp* getCurrentDeviceProperties();
-
-TORCH_CUDA_CPP_API int warp_size();
-
-TORCH_CUDA_CPP_API cudaDeviceProp* getDeviceProperties(int64_t device);
-
-TORCH_CUDA_CPP_API bool canDeviceAccessPeer(
-    int64_t device,
-    int64_t peer_device);
-
-TORCH_CUDA_CPP_API Allocator* getCUDADeviceAllocator();
-
-/* Handles */
-TORCH_CUDA_CPP_API cusparseHandle_t getCurrentCUDASparseHandle();
-TORCH_CUDA_CPP_API cublasHandle_t getCurrentCUDABlasHandle();
-
-TORCH_CUDA_CPP_API void clearCublasWorkspaces();
-
-#if defined(CUDART_VERSION) || defined(USE_ROCM) && ROCM_VERSION >= 50300
-TORCH_CUDA_CPP_API cusolverDnHandle_t getCurrentCUDASolverDnHandle();
-#endif
-
-} // namespace at::cuda

--- a/aten/src/ATen/cuda/CUDAContext.h
+++ b/aten/src/ATen/cuda/CUDAContext.h
@@ -2,7 +2,7 @@
 
 #include <ATen/cuda/CUDAContextLight.h>
 
-// Preserved for BC, as may files depend on these includes
+// Preserved for BC, as many files depend on these includes
 #include <ATen/Context.h>
 #include <c10/cuda/CUDAStream.h>
 #include <c10/util/Logging.h>

--- a/aten/src/ATen/cuda/CUDAContextLight.h
+++ b/aten/src/ATen/cuda/CUDAContextLight.h
@@ -1,0 +1,86 @@
+#pragma once
+// Light-weight version of CUDAContext.h with fewer transitive includes
+
+#include <cstdint>
+
+#include <cuda_runtime_api.h>
+#include <cusparse.h>
+#include <cublas_v2.h>
+
+#ifdef CUDART_VERSION
+#include <cusolverDn.h>
+#endif
+
+#if defined(USE_ROCM) && ROCM_VERSION >= 50300
+#include <hipsolver/hipsolver.h>
+#endif
+
+#include <c10/core/Allocator.h>
+#include <c10/cuda/CUDAFunctions.h>
+
+namespace c10 {
+struct Allocator;
+}
+
+namespace at::cuda {
+
+/*
+A common CUDA interface for ATen.
+
+This interface is distinct from CUDAHooks, which defines an interface that links
+to both CPU-only and CUDA builds. That interface is intended for runtime
+dispatch and should be used from files that are included in both CPU-only and
+CUDA builds.
+
+CUDAContext, on the other hand, should be preferred by files only included in
+CUDA builds. It is intended to expose CUDA functionality in a consistent
+manner.
+
+This means there is some overlap between the CUDAContext and CUDAHooks, but
+the choice of which to use is simple: use CUDAContext when in a CUDA-only file,
+use CUDAHooks otherwise.
+
+Note that CUDAContext simply defines an interface with no associated class.
+It is expected that the modules whose functions compose this interface will
+manage their own state. There is only a single CUDA context/state.
+*/
+
+/**
+ * DEPRECATED: use device_count() instead
+ */
+inline int64_t getNumGPUs() {
+    return c10::cuda::device_count();
+}
+
+/**
+ * CUDA is available if we compiled with CUDA, and there are one or more
+ * devices.  If we compiled with CUDA but there is a driver problem, etc.,
+ * this function will report CUDA is not available (rather than raise an error.)
+ */
+inline bool is_available() {
+    return c10::cuda::device_count() > 0;
+}
+
+TORCH_CUDA_CPP_API cudaDeviceProp* getCurrentDeviceProperties();
+
+TORCH_CUDA_CPP_API int warp_size();
+
+TORCH_CUDA_CPP_API cudaDeviceProp* getDeviceProperties(int64_t device);
+
+TORCH_CUDA_CPP_API bool canDeviceAccessPeer(
+    int64_t device,
+    int64_t peer_device);
+
+TORCH_CUDA_CPP_API c10::Allocator* getCUDADeviceAllocator();
+
+/* Handles */
+TORCH_CUDA_CPP_API cusparseHandle_t getCurrentCUDASparseHandle();
+TORCH_CUDA_CPP_API cublasHandle_t getCurrentCUDABlasHandle();
+
+TORCH_CUDA_CPP_API void clearCublasWorkspaces();
+
+#if defined(CUDART_VERSION) || defined(USE_ROCM) && ROCM_VERSION >= 50300
+TORCH_CUDA_CPP_API cusolverDnHandle_t getCurrentCUDASolverDnHandle();
+#endif
+
+} // namespace at::cuda

--- a/aten/src/ATen/cuda/CUDAGeneratorImpl.h
+++ b/aten/src/ATen/cuda/CUDAGeneratorImpl.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <ATen/core/Generator.h>
-#include <ATen/cuda/detail/PhiloxCudaStateRaw.cuh>
+#include <ATen/cuda/PhiloxCudaState.h>
 #include <ATen/Context.h>
 #include <limits>
 #include <atomic>

--- a/aten/src/ATen/cuda/CUDAGraphsUtils.cuh
+++ b/aten/src/ATen/cuda/CUDAGraphsUtils.cuh
@@ -2,7 +2,7 @@
 
 #include <ATen/cuda/CUDAGeneratorImpl.h>
 #include <ATen/cuda/CUDAEvent.h>
-#include <ATen/cuda/detail/UnpackRaw.cuh>
+#include <ATen/cuda/PhiloxUtils.cuh>
 #include <ATen/cuda/detail/CUDAHooks.h>
 #include <ATen/detail/CUDAHooksInterface.h>
 #include <c10/core/StreamGuard.h>

--- a/aten/src/ATen/cuda/PhiloxCudaState.h
+++ b/aten/src/ATen/cuda/PhiloxCudaState.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <cstdint>
+
+#include <ATen/cuda/detail/PhiloxCudaStateRaw.cuh>

--- a/aten/src/ATen/cuda/PhiloxUtils.cuh
+++ b/aten/src/ATen/cuda/PhiloxUtils.cuh
@@ -1,0 +1,4 @@
+#pragma once
+
+#include <ATen/cuda/PhiloxCudaState.h>
+#include <ATen/cuda/detail/UnpackRaw.cuh>

--- a/aten/src/ATen/cuda/detail/PhiloxCudaStateRaw.cuh
+++ b/aten/src/ATen/cuda/detail/PhiloxCudaStateRaw.cuh
@@ -1,6 +1,6 @@
 // No "#pragma once" because this is a raw definition that can be copied by jit codegen.
 // Eager mode clients should not include this file directly, instead,
-// they should #include <ATen/cuda/CUDAGeneratorImpl.h>, which has a #pragma once.
+// they should #include <ATen/cuda/PhiloxCudaState.h>, which has a #pragma once.
 
 // Stores RNG state values. Passed as a kernel argument.
 // See Note [CUDA Graph-safe RNG states].

--- a/aten/src/ATen/cuda/detail/UnpackRaw.cuh
+++ b/aten/src/ATen/cuda/detail/UnpackRaw.cuh
@@ -1,6 +1,6 @@
 // No "#pragma once" because this is a raw definition that can be copied by jit codegen.
 // Eager mode clients should not include this file directly, instead,
-// they should #include <ATen/cuda/CUDAGraphsUtils.cuh>, which has a #pragma once.
+// they should #include <ATen/cuda/PhiloxUtils.cuh>, which has a #pragma once.
 
 namespace at::cuda::philox {
 

--- a/aten/src/ATen/native/transformers/cuda/attention_backward.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention_backward.cu
@@ -6,6 +6,7 @@
 #include <ATen/TensorOperators.h>
 
 #include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAGraphsUtils.cuh>
 #include <c10/cuda/CUDAMathCompat.h>
 #include <c10/util/Exception.h>
 #include <c10/util/bit_cast.h>

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/flash.h
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/flash.h
@@ -7,8 +7,7 @@
 #include <cuda.h>
 #include <vector>
 
-#include <ATen/cuda/CUDAGeneratorImpl.h>
-#include <ATen/cuda/CUDAGraphsUtils.cuh>
+#include <ATen/cuda/PhiloxUtils.cuh>
 
 namespace pytorch_flash{
 

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/flash_bwd_kernel.h
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/flash_bwd_kernel.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <ATen/cuda/PhiloxUtils.cuh>
+
 #include <cute/algorithm/copy.hpp>
 #include <cute/algorithm/gemm.hpp>
 

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/flash_bwd_launch_template.h
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/flash_bwd_launch_template.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
 
 #include <ATen/native/transformers/cuda/flash_attn/static_switch.h>
 #include <ATen/native/transformers/cuda/flash_attn/flash.h>

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/flash_fwd_launch_template.h
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/flash_fwd_launch_template.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAContextLight.h>
 
 #include <ATen/native/transformers/cuda/flash_attn/flash.h>
 #include <ATen/native/transformers/cuda/flash_attn/static_switch.h>

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/kernel_traits.h
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/kernel_traits.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <ATen/cuda/CUDAContext.h>
-
 #include <cute/algorithm/copy.hpp>
 
 #include <cutlass/cutlass.h>

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/kernel_traits_sm90.h
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/kernel_traits_sm90.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <ATen/cuda/CUDAContext.h>
-
 #include <cute/algorithm/copy.hpp>
 
 #include <cutlass/cutlass.h>

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/philox.cuh
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/philox.cuh
@@ -2,7 +2,7 @@
 #pragma once
 // Philox CUDA.
 
-#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/PhiloxUtils.cuh>
 
 namespace pytorch_flash{
 

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/softmax.h
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/softmax.h
@@ -28,7 +28,6 @@
 #pragma once
 
 #include <cmath>
-#include <ATen/cuda/CUDAContext.h>
 #include <cuda_fp16.h>
 #include <ATen/native/transformers/cuda/flash_attn/philox.cuh>
 #include <ATen/native/transformers/cuda/flash_attn/utils.h>

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/utils.h
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/utils.h
@@ -8,8 +8,6 @@
 #include <cstdint>
 #include <cstdlib>
 
-#include <ATen/cuda/CUDAContext.h>
-
 #include <cuda_fp16.h>
 
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/epilogue/epilogue_pipelined.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/epilogue/epilogue_pipelined.h
@@ -50,8 +50,6 @@
 #include <cassert>
 #endif
 
-#include <ATen/cuda/CUDAContext.h>
-
 #include <cutlass/aligned_buffer.h>
 #include <cutlass/array.h>
 #include <cutlass/cutlass.h>

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/epilogue/epilogue_rescale_output.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/epilogue/epilogue_rescale_output.h
@@ -18,8 +18,6 @@
 #include <cassert>
 #endif
 
-#include <ATen/cuda/CUDAContext.h>
-
 #include <cutlass/aligned_buffer.h>
 #include <cutlass/array.h>
 #include <cutlass/cutlass.h>

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/epilogue/epilogue_thread_apply_logsumexp.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/epilogue/epilogue_thread_apply_logsumexp.h
@@ -35,8 +35,6 @@
 
 #pragma once
 
-#include <ATen/cuda/CUDAContext.h>
-
 #include <cuda_fp16.h>
 
 #include <cutlass/array.h>

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_backward.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_backward.h
@@ -14,11 +14,7 @@
 #include <cuda_fp16.h>
 #include <curand_kernel.h>
 
-#include <ATen/cuda/CUDAContext.h>
-#include <ATen/cuda/CUDAGeneratorImpl.h>
-#include <c10/cuda/CUDAGuard.h>
-#include <ATen/cuda/CUDAGraphsUtils.cuh>
-
+#include <ATen/cuda/PhiloxUtils.cuh>
 #include <cutlass/cutlass.h>
 #include <cutlass/epilogue/thread/linear_combination.h>
 #include <cutlass/epilogue/thread/scale_type.h>

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h
@@ -7,8 +7,8 @@
  */
 #pragma once
 
-#include <ATen/cuda/CUDAGeneratorImpl.h>
-#include <ATen/cuda/CUDAGraphsUtils.cuh>
+#include <ATen/cuda/PhiloxUtils.cuh>
+#include <c10/util/Exception.h>
 
 #include <curand_kernel.h>
 #include <cmath>

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/pytorch_utils.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/pytorch_utils.h
@@ -7,8 +7,7 @@
  */
 #pragma once
 
-#include <ATen/core/TensorBody.h>
-#include <c10/util/Exception.h>
+#include <c10/core/ScalarType.h>
 
 #include <cutlass/bfloat16.h>
 #include <cutlass/half.h>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #113493

These kernels are incredibly slow to compile and for the most part are
completely independant of ATen/c10 yet they still end up including
half of `c10` transitively through `CUDAGeneratorImpl.h` and
`CUDAContext.h`.

This trims the fat so `mem_eff_attention` doesn't depend on ATen/c10 at all,
and `flash_attn` now only depends on `PhiloxUtils.cuh` (split out from
`CUDAGeneratorImpl.h`) and `CUDAContextLight.h` which doesn't transitively
include `TensorImpl.h`.