### PR TITLE
[TD] Disable HistoricalClassFailurCorrelation

### DIFF
--- a/tools/testing/target_determination/heuristics/__init__.py
+++ b/tools/testing/target_determination/heuristics/__init__.py
@@ -27,7 +27,7 @@ from tools.testing.target_determination.heuristics.profiling import Profiling
 HEURISTICS: List[HeuristicInterface] = [
     PreviouslyFailedInPR(),
     EditedByPR(),
-    HistoricalClassFailurCorrelation(trial_mode=True),
+    # HistoricalClassFailurCorrelation(trial_mode=True),
     CorrelatedWithHistoricalFailures(),
     HistorialEditedFiles(trial_mode=True),
     Profiling(trial_mode=True),

--- a/tools/testing/target_determination/heuristics/__init__.py
+++ b/tools/testing/target_determination/heuristics/__init__.py
@@ -27,7 +27,7 @@ from tools.testing.target_determination.heuristics.profiling import Profiling
 HEURISTICS: List[HeuristicInterface] = [
     PreviouslyFailedInPR(),
     EditedByPR(),
-    # HistoricalClassFailurCorrelation(trial_mode=True),
+    # HistoricalClassFailurCorrelation(trial_mode=True),  TODO: https://github.com/pytorch/pytorch/pull/113497
     CorrelatedWithHistoricalFailures(),
     HistorialEditedFiles(trial_mode=True),
     Profiling(trial_mode=True),


### PR DESCRIPTION
Ex. https://github.com/pytorch/pytorch/actions/runs/6829618325/job/18576593307
```
  File "test/run_test.py", line 1806, in main
    test_stats = aggregated_heuristics.get_test_stats(test)
  File "/var/lib/jenkins/pytorch/tools/testing/target_determination/heuristics/interface.py", line 391, in get_test_stats
    metrics = heuristic_results.get_priority_info_for_test(test)
  File "/var/lib/jenkins/pytorch/tools/testing/target_determination/heuristics/interface.py", line 307, in get_priority_info_for_test
    relevance = self._get_test_relevance_group(test_run)
  File "/var/lib/jenkins/pytorch/tools/testing/target_determination/heuristics/interface.py", line 278, in _get_test_relevance_group
    raise ValueError(f"Test {test_run} not found in any relevance group")
ValueError: Test test_cuda_expandable_segments not found in any relevance group
```
I believe that the root cause is that HistoricalClassFailurCorrelation splits `test_cuda_expandable_segments` into two sets: one with a class and one without the class.  Then, when the entire `test_cuda_expandable_segments` fails (because we currently don't do class level granularity in TD), it is unable to find what HistoricalClassFailurCorrelation ranked the test as since it's split into two.

I don't think this is that important for normal CI users since this code only runs if a test failed in the first place.  However, it does mean that we can't gather TD stats, so I am going to disable it for now.

One possible solution is to switch the contains call and take the worst or best of the bunch, which I think is what https://github.com/pytorch/pytorch/blob/main/tools/testing/target_determination/heuristics/interface.py#L272 is trying to do? unclear

cc @ZainRizvi 