### PR TITLE
Fix  docstring errors in default_hooks.py, optimizer_overlap.py, checkpoint_wrapper.py, copy.py, benchmark_ddp_rpc.py, utils.py, dependency.py, phony.py, pipeline.py, checkpoint.py, worker.py, batchnorm.py, quantization.py

### DIFF
--- a/torch/distributed/algorithms/_checkpoint/checkpoint_wrapper.py
+++ b/torch/distributed/algorithms/_checkpoint/checkpoint_wrapper.py
@@ -21,6 +21,7 @@ class CheckpointImpl(Enum):
 class ActivationWrapper(torch.nn.Module):
     """
     Base class for Activation Checkpoint and Activation Offload.
+    
     Not meant to be instantiated directly.
     """
 
@@ -56,7 +57,8 @@ class ActivationWrapper(torch.nn.Module):
         **kwargs,
     ) -> Iterator[Tuple[str, torch.nn.Parameter]]:
         """
-        Overrides :meth:`named_parameters()` to intercept parameter names and
+        Override :meth:`named_parameters()` to intercept parameter names.
+        
         remove all occurrences of ``_CHECKPOINT_PREFIX``.
         """
         for param_name, param in super().named_parameters(*args, **kwargs):
@@ -70,12 +72,12 @@ class ActivationWrapper(torch.nn.Module):
         *args: Any,
     ) -> Dict[str, Any]:
         """
-        _post_state_dict_hook() is called after the state_dict() of this
-        FSDP module is executed. For ``checkpoint_wrapper``, it will strip
-        checkpoint-wrapped module prefix so that this module can be loaded into
-        non-checkpointed modules. It would still be able to be loaded into
-        checkpoint-wrapped modules as this class adds the prefix back before
-        loading the state_dict.
+        _post_state_dict_hook() is called after the state_dict() of this FSDP module is executed.
+
+        For ``checkpoint_wrapper``, it will strip checkpoint-wrapped module prefix,
+        so that this module can be loaded into non-checkpointed modules. 
+        It would still be able to be loaded into checkpoint-wrapped modules as this class,
+        adds the prefix back before loading the state_dict.
         """
         _replace_by_prefix(state_dict, f"{prefix}{_CHECKPOINT_PREFIX}", prefix)
         return state_dict
@@ -88,8 +90,9 @@ class ActivationWrapper(torch.nn.Module):
         *args: Any,
     ) -> None:
         """
-        ``_pre_state_dict_hook` is called before ``self._load_from_state_dict()``
-        is called. For ``checkpoint_wrapper``, it will add back the module
+        ``_pre_state_dict_hook` is called before ``self._load_from_state_dict()`` is called. 
+        
+        For ``checkpoint_wrapper``, it will add back the module
         prefix so that non-checkpointed modules can be loaded into
         checkpoint_wrapper modules properly.
         """
@@ -107,9 +110,10 @@ class OffloadWrapper(ActivationWrapper):
 
 class CheckpointWrapper(ActivationWrapper):
     """
-    An ``nn.Module`` that wraps another ``nn.Module`` with checkpointing. Note that this
-    module is not meant to be used directly, but instead it is to be used
-    through the ``checkpoint_wrapper`` function.
+    An ``nn.Module`` that wraps another ``nn.Module`` with checkpointing.
+     
+    Note that this module is not meant to be used directly but instead,
+    it is to be used through the ``checkpoint_wrapper`` function.
     """
 
     def __init__(
@@ -168,12 +172,13 @@ class CheckpointWrapper(ActivationWrapper):
 
 def offload_wrapper(module: torch.nn.Module) -> torch.nn.Module:
     """
-    A convenience wrapper for activation offloading to CPU. If the module is wrapped
-    with this function, all subsequent calls to the module will automatically
-    offload intermediate activations to the CPU. Wrappers with activation
-    offload can be composed with ones that do recomputation-based
+    Wrap a module for activation offloading to CPU.
+
+    Offloads intermediate activations to the CPU for modules wrapped with this function. 
+    Wrappers with activation offload can be composed with ones that do recomputation-based
     checkpoint to trade off increased compute versus increased CPU
     memory usage and additional H2D transfers.
+
     Usage::
         offloaded_module = offload_wrapper(module)
         outputs = checkpointed_module(inputs)
@@ -194,10 +199,11 @@ def checkpoint_wrapper(
     **checkpoint_fn_kwargs,
 ) -> torch.nn.Module:
     """
-    A convenience wrapper for activation checkpointing. If the module is wrapped
-    with this function, all subsequent calls to the module will automatically
-    perform checkpointing without the user having to explicitly call ``checkpoint``
-    function.
+    Wrap a module for activation checkpointing.
+   
+    If the module is wrapped with this function, all subsequent calls to the module will,
+    automatically perform checkpointing without the user having to explicitly call ``checkpoint`` function.
+    
     Usage::
         checkpointed_module = checkpoint_wrapper(module)
         outputs = checkpointed_module(inputs)
@@ -244,8 +250,9 @@ def apply_activation_checkpointing(
     auto_wrap_policy: Optional[Callable[[nn.Module, bool, int], bool]] = None,
 ):
     """
-    Applies :func:`checkpoint_wrapper` to modules within `model` based on a user-defined
-    configuration. For each module within `model`, the `check_fn` is used to decide
+    Apply :func:`checkpoint_wrapper` to modules within `model` based on a user-defined configuration.
+    
+    For each module within `model`, the `check_fn` is used to decide
     whether `module` should be wrapped with :func:`checkpoint_wrapper` or not.
 
     Note::

--- a/torch/distributed/algorithms/_checkpoint/checkpoint_wrapper.py
+++ b/torch/distributed/algorithms/_checkpoint/checkpoint_wrapper.py
@@ -21,7 +21,7 @@ class CheckpointImpl(Enum):
 class ActivationWrapper(torch.nn.Module):
     """
     Base class for Activation Checkpoint and Activation Offload.
-    
+
     Not meant to be instantiated directly.
     """
 
@@ -58,7 +58,7 @@ class ActivationWrapper(torch.nn.Module):
     ) -> Iterator[Tuple[str, torch.nn.Parameter]]:
         """
         Override :meth:`named_parameters()` to intercept parameter names.
-        
+
         remove all occurrences of ``_CHECKPOINT_PREFIX``.
         """
         for param_name, param in super().named_parameters(*args, **kwargs):
@@ -75,7 +75,7 @@ class ActivationWrapper(torch.nn.Module):
         _post_state_dict_hook() is called after the state_dict() of this FSDP module is executed.
 
         For ``checkpoint_wrapper``, it will strip checkpoint-wrapped module prefix,
-        so that this module can be loaded into non-checkpointed modules. 
+        so that this module can be loaded into non-checkpointed modules.
         It would still be able to be loaded into checkpoint-wrapped modules as this class,
         adds the prefix back before loading the state_dict.
         """
@@ -90,8 +90,8 @@ class ActivationWrapper(torch.nn.Module):
         *args: Any,
     ) -> None:
         """
-        ``_pre_state_dict_hook` is called before ``self._load_from_state_dict()`` is called. 
-        
+        ``_pre_state_dict_hook` is called before ``self._load_from_state_dict()`` is called.
+
         For ``checkpoint_wrapper``, it will add back the module
         prefix so that non-checkpointed modules can be loaded into
         checkpoint_wrapper modules properly.
@@ -111,7 +111,7 @@ class OffloadWrapper(ActivationWrapper):
 class CheckpointWrapper(ActivationWrapper):
     """
     An ``nn.Module`` that wraps another ``nn.Module`` with checkpointing.
-     
+
     Note that this module is not meant to be used directly but instead,
     it is to be used through the ``checkpoint_wrapper`` function.
     """
@@ -174,7 +174,7 @@ def offload_wrapper(module: torch.nn.Module) -> torch.nn.Module:
     """
     Wrap a module for activation offloading to CPU.
 
-    Offloads intermediate activations to the CPU for modules wrapped with this function. 
+    Offloads intermediate activations to the CPU for modules wrapped with this function.
     Wrappers with activation offload can be composed with ones that do recomputation-based
     checkpoint to trade off increased compute versus increased CPU
     memory usage and additional H2D transfers.
@@ -200,10 +200,10 @@ def checkpoint_wrapper(
 ) -> torch.nn.Module:
     """
     Wrap a module for activation checkpointing.
-   
+
     If the module is wrapped with this function, all subsequent calls to the module will,
     automatically perform checkpointing without the user having to explicitly call ``checkpoint`` function.
-    
+
     Usage::
         checkpointed_module = checkpoint_wrapper(module)
         outputs = checkpointed_module(inputs)
@@ -251,7 +251,7 @@ def apply_activation_checkpointing(
 ):
     """
     Apply :func:`checkpoint_wrapper` to modules within `model` based on a user-defined configuration.
-    
+
     For each module within `model`, the `check_fn` is used to decide
     whether `module` should be wrapped with :func:`checkpoint_wrapper` or not.
 

--- a/torch/distributed/algorithms/_comm_hooks/default_hooks.py
+++ b/torch/distributed/algorithms/_comm_hooks/default_hooks.py
@@ -148,7 +148,8 @@ def fp16_compress_hook(state: LowPrecisionState, grad: torch.Tensor, output: Opt
 
 def bf16_compress_hook(state: LowPrecisionState, grad: torch.Tensor, output: Optional[torch.Tensor] = None):
     r"""
-    Implement FSDP communication hook for a simple gradient compression approach that casts ``grad`` to half-precision floating-point format.
+    Implement FSDP communication hook for a simple gradient compression approach .
+    Casts ``grad`` to half-precision floating-point format.
 
     It also averages gradients by ``world_size`` in two steps: first it pre-divides gradients by a
     ``state.gradient_predivide_factor``, and after a communication step (``all_reduce`` or ``reduce_scatter``)

--- a/torch/distributed/algorithms/_comm_hooks/default_hooks.py
+++ b/torch/distributed/algorithms/_comm_hooks/default_hooks.py
@@ -6,8 +6,7 @@ from typing import Optional
 
 class DefaultState:
     r"""
-    Stores state needed to perform the default communication algorithm
-    within a communication hook.
+    Stores state needed to perform the default communication algorithm within a communication hook.
 
     Args:
         process_group (ProcessGroup): The process group to be used.
@@ -44,9 +43,10 @@ class DefaultState:
 
 class LowPrecisionState(DefaultState):
     r"""
-    Stores state needed to perform gradient communication in a lower precision
-    within a communication hook. Communication hook will cast gradients back
-    to the original parameter precision specified by ``parameter_type`` (default: torch.float32).
+    Stores state needed to perform gradient communication in a lower precision within a communication hook.
+     
+    Communication hook will cast gradients back to the original
+    parameter precision specified by ``parameter_type`` (default: torch.float32).
     Builds on top of the :class:`DefaultState`.
 
     Args:
@@ -69,8 +69,7 @@ class LowPrecisionState(DefaultState):
 
 def _decompress(state: LowPrecisionState, grad: torch.Tensor):
     """
-    Casts gradients back to full parameter precision so that
-    further computation happens in full precision.
+    Casts gradients back to full parameter precision so that further computation happens in full precision.
     """
     orig_grad_data = grad.data
     grad.data = grad.data.to(state.parameter_type)
@@ -79,8 +78,7 @@ def _decompress(state: LowPrecisionState, grad: torch.Tensor):
 
 def allreduce_hook(state: DefaultState, grad: torch.Tensor):
     r"""
-    This FSDP communication hook implements ``all_reduce`` algorithm
-    and a necessary pre- and post-division of gradients.
+    Implement the  FSDP communication hook for ``all_reduce`` algorithm and a necessary pre- and post-division of gradients.
 
     Args:
         state (DefaultState): State information, configures pre- and post-division factors.
@@ -98,8 +96,9 @@ def allreduce_hook(state: DefaultState, grad: torch.Tensor):
 
 def reduce_scatter_hook(state: DefaultState, grad: torch.Tensor, output: torch.Tensor):
     r"""
-    This FSDP communication hook implements ``reduce_scatter`` algorithm for
-    sharded FSDP strategies and a necessary pre- and post-division of gradients.
+    Implement the  FSDP communication hook for ``reduce_scatter`` algorithm.
+
+    For sharded FSDP strategies and a necessary pre- and post-division of gradients.
 
     Args:
         state (DefaultState): State information, configures pre- and post-division factors.
@@ -131,8 +130,9 @@ def _low_precision_hook(prec: torch.dtype, state: LowPrecisionState, grad: torch
 
 def fp16_compress_hook(state: LowPrecisionState, grad: torch.Tensor, output: Optional[torch.Tensor] = None):
     r"""
-    This FSDP communication hook implements a simple gradient compression
-    approach that casts ``grad`` to half-precision floating-point format (``torch.float16``).
+    Implement FSDP communication hook for a simple gradient compression approach. 
+    Casts ``grad`` to half-precision floating-point format (``torch.float16``).
+    
     It also averages gradients by ``world_size`` in two steps: first it pre-divides gradients by a
     ``state.gradient_predivide_factor``, and after a communication step (``all_reduce`` or ``reduce_scatter``)
     gradients are averaged by a ``state.gradient_postdivide_factor``.
@@ -148,8 +148,8 @@ def fp16_compress_hook(state: LowPrecisionState, grad: torch.Tensor, output: Opt
 
 def bf16_compress_hook(state: LowPrecisionState, grad: torch.Tensor, output: Optional[torch.Tensor] = None):
     r"""
-    This FSDP communication hook implements a simple gradient compression
-    approach that casts ``grad`` to half-precision floating-point format (``torch.float16``).
+    Implement FSDP communication hook for a simple gradient compression approach that casts ``grad`` to half-precision floating-point format.
+
     It also averages gradients by ``world_size`` in two steps: first it pre-divides gradients by a
     ``state.gradient_predivide_factor``, and after a communication step (``all_reduce`` or ``reduce_scatter``)
     gradients are averaged by a ``state.gradient_postdivide_factor``.

--- a/torch/distributed/algorithms/_comm_hooks/default_hooks.py
+++ b/torch/distributed/algorithms/_comm_hooks/default_hooks.py
@@ -44,7 +44,7 @@ class DefaultState:
 class LowPrecisionState(DefaultState):
     r"""
     Stores state needed to perform gradient communication in a lower precision within a communication hook.
-     
+
     Communication hook will cast gradients back to the original
     parameter precision specified by ``parameter_type`` (default: torch.float32).
     Builds on top of the :class:`DefaultState`.
@@ -130,9 +130,9 @@ def _low_precision_hook(prec: torch.dtype, state: LowPrecisionState, grad: torch
 
 def fp16_compress_hook(state: LowPrecisionState, grad: torch.Tensor, output: Optional[torch.Tensor] = None):
     r"""
-    Implement FSDP communication hook for a simple gradient compression approach. 
+    Implement FSDP communication hook for a simple gradient compression approach.
     Casts ``grad`` to half-precision floating-point format (``torch.float16``).
-    
+
     It also averages gradients by ``world_size`` in two steps: first it pre-divides gradients by a
     ``state.gradient_predivide_factor``, and after a communication step (``all_reduce`` or ``reduce_scatter``)
     gradients are averaged by a ``state.gradient_postdivide_factor``.

--- a/torch/distributed/algorithms/_optimizer_overlap/optimizer_overlap.py
+++ b/torch/distributed/algorithms/_optimizer_overlap/optimizer_overlap.py
@@ -34,7 +34,9 @@ def register_overlapped(optim_cls):
 class OverlappedOptimizer(ABC):
     def __init__(self, optim_cls: Type) -> None:
         """
-        OverlappedOptimizer is a base class that child classes can implement to
+        Initialize the OverlappedOptimizer.
+
+        Overlappedoptimizer is a base class that child classes can implement to
         specify how different optimizers will register themselves with DDP.
         """
         self.optim_cls = optim_cls
@@ -73,15 +75,13 @@ class _OverlappedStandardOptimizer(OverlappedOptimizer):
 
     # TODO: register_fsdp once FSDP supports communication hook.
     def register_fsdp(self, fsdp: FullyShardedDataParallel) -> None:
-        """Registers the overlapped optimizer with FSDP."""
+        """Register the overlapped optimizer with FSDP."""
         raise NotImplementedError(
             f"{self.__class__.__name__} does not support overlapped FSDP."
         )
 
 def _as_overlapped_optim(optim_cls: Type, params, *args, **kwargs):
-    """
-    Returns a new ``OverlappedOptimizer`` instance that supports ``optim_cls``.
-    """
+    """Return a new ``OverlappedOptimizer`` instance that supports ``optim_cls``."""
     for clz in inspect.getmro(optim_cls):
         try:
             return _registered_overlapped_optims[clz](optim_cls, params, *args, **kwargs)

--- a/torch/distributed/algorithms/_quantization/quantization.py
+++ b/torch/distributed/algorithms/_quantization/quantization.py
@@ -91,7 +91,7 @@ def _dequantize_tensor_list(tensor_list, qtype, quant_loss=None):
 def auto_quantize(func, qtype, quant_loss=None):
     """
     Quantize the input tensors, choose the precision types, and pass other necessary arguments and then dequantizes the output.
-    
+
     Currently it only supports:
         . FP16 and BFP16 quantization method supported for gloo and nccl backends
         . all_gather, all_to_all collective ops

--- a/torch/distributed/algorithms/_quantization/quantization.py
+++ b/torch/distributed/algorithms/_quantization/quantization.py
@@ -11,7 +11,9 @@ TORCH_HALF_MAX = torch.finfo(torch.float16).max
 
 class DQuantType(Enum):
     """
+
     Different quantization methods for auto_quantize API are identified here.
+
     auto_quantize API currently supports fp16 and bfp16 methods.
     """
     FP16 = "fp16",
@@ -88,8 +90,8 @@ def _dequantize_tensor_list(tensor_list, qtype, quant_loss=None):
 
 def auto_quantize(func, qtype, quant_loss=None):
     """
-    This is a prototype API that automatically quantize the input tensors, choose the precision types, and
-    pass other necessary arguments and then dequantizes the output.
+    Quantize the input tensors, choose the precision types, and pass other necessary arguments and then dequantizes the output.
+    
     Currently it only supports:
         . FP16 and BFP16 quantization method supported for gloo and nccl backends
         . all_gather, all_to_all collective ops

--- a/torch/distributed/algorithms/_quantization/quantization.py
+++ b/torch/distributed/algorithms/_quantization/quantization.py
@@ -11,7 +11,6 @@ TORCH_HALF_MAX = torch.finfo(torch.float16).max
 
 class DQuantType(Enum):
     """
-
     Different quantization methods for auto_quantize API are identified here.
 
     auto_quantize API currently supports fp16 and bfp16 methods.

--- a/torch/distributed/benchmarks/benchmark_ddp_rpc.py
+++ b/torch/distributed/benchmarks/benchmark_ddp_rpc.py
@@ -32,14 +32,15 @@ WARMUP_CYCLES = 5
 
 class HybridModel(torch.nn.Module):
     r"""
-   The model consists of a sparse part and a dense part. The dense part is an
-   nn.Linear module that is replicated across all trainers using
-   DistributedDataParallel. The sparse part has nn.EmbeddingBags stored on multiple
-   parameter servers.
+    The model consists of a sparse part and a dense part.
 
-   The model holds a Remote Reference to the embedding tables on the parameter
-   servers.
-   """
+    The dense part is an nn.Linear module that is replicated across all trainers using
+    DistributedDataParallel. The sparse part has nn.EmbeddingBags stored on multiple
+    parameter servers.
+
+    The model holds a Remote Reference to the embedding tables on the parameter
+    servers.
+    """
 
     def __init__(self, emb_rref_list, device):
         super().__init__()
@@ -117,13 +118,13 @@ def _run_printable(cmd):
 
 def _run_trainer(emb_rref_list, rank):
     r"""
-   Each trainer runs a forward pass which involves an embedding lookup on the
-   8 parameter servers and running nn.Linear locally. During the backward pass,
-   DDP is responsible for aggregating the gradients for the dense part
-   (nn.Linear) and distributed autograd ensures gradients updates are
-   propagated to the parameter servers.
-   """
-
+    Each trainer runs a forward pass which involves an embedding lookup on the 8 parameter servers,
+    and running nn.Linear locally. 
+    
+    During the backward pass, DDP is responsible for aggregating the gradients for the dense part
+    (nn.Linear) and distributed autograd ensures gradients updates are
+    propagated to the parameter servers.
+    """
     # Setup the model.
     model = HybridModel(emb_rref_list, rank)
 
@@ -199,10 +200,8 @@ def _run_trainer(emb_rref_list, rank):
 
 def run_worker(rank, world_size):
     r"""
-   A wrapper function that initializes RPC, calls the function, and shuts down
-   RPC.
-   """
-
+    Initialize RPC, calls the function, and shuts down RPC.
+    """
     # Using different port numbers in TCP init_method for init_rpc and
     # init_process_group to avoid port conflicts.
     rpc_backend_options = TensorPipeRpcBackendOptions()

--- a/torch/distributed/benchmarks/benchmark_ddp_rpc.py
+++ b/torch/distributed/benchmarks/benchmark_ddp_rpc.py
@@ -119,8 +119,8 @@ def _run_printable(cmd):
 def _run_trainer(emb_rref_list, rank):
     r"""
     Each trainer runs a forward pass which involves an embedding lookup on the 8 parameter servers,
-    and running nn.Linear locally. 
-    
+    and running nn.Linear locally.
+
     During the backward pass, DDP is responsible for aggregating the gradients for the dense part
     (nn.Linear) and distributed autograd ensures gradients updates are
     propagated to the parameter servers.

--- a/torch/distributed/pipeline/sync/batchnorm.py
+++ b/torch/distributed/pipeline/sync/batchnorm.py
@@ -21,9 +21,7 @@ TModule = TypeVar("TModule", bound=nn.Module)
 
 
 class DeferredBatchNorm(_BatchNorm):
-    """A BatchNorm layer tracks multiple micro-batches to update running
-    statistics per mini-batch.
-    """
+    """A BatchNorm layer tracks multiple micro-batches to update running statistics per mini-batch."""
 
     sum: Tensor
     sum_squares: Tensor
@@ -70,7 +68,7 @@ class DeferredBatchNorm(_BatchNorm):
         return self.tracked == self.chunks
 
     def _commit(self) -> None:
-        """Updates the running statistics of a mini-batch."""
+        """Update the running statistics of a mini-batch."""
         exponential_average_factor = 0.0
         self.num_batches_tracked += 1
         if self.momentum is None:  # use cumulative moving average
@@ -133,8 +131,7 @@ class DeferredBatchNorm(_BatchNorm):
 
     @classmethod
     def convert_deferred_batch_norm(cls, module: TModule, chunks: int = 1) -> TModule:
-        """Converts a :class:`nn.BatchNorm` or underlying
-        :class:`nn.BatchNorm`s into :class:`DeferredBatchNorm`::
+        """Converts a :class:`nn.BatchNorm` or underlying :class:`nn.BatchNorm`s into :class:`DeferredBatchNorm`::
 
             from torchvision.models.resnet import resnet101
             from torchpipe.batchnorm import DeferredBatchNorm

--- a/torch/distributed/pipeline/sync/checkpoint.py
+++ b/torch/distributed/pipeline/sync/checkpoint.py
@@ -68,7 +68,7 @@ class Function(Protocol):
 
 
 def checkpoint(function: Function, input):
-    """Makes a checkpoint with a simple interface like
+    """Make a checkpoint with a simple interface like
     :func:`torch.utils.checkpoint.checkpoint`. It's only used to test or debug
     :class:`Checkpoint` and :class:`Recompute` without boilerplate.
     """
@@ -94,7 +94,7 @@ class Checkpointing:
         self.rng_states: Deque[RNGStates] = deque(maxlen=1)
 
     def checkpoint(self) -> Batch:
-        """Returns a batch applied by :class:`Checkpoint`."""
+        """Return a batch applied by :class:`Checkpoint`."""
         input_atomic = self.batch.atomic
         inputs = tuple(self.batch)
 
@@ -112,7 +112,7 @@ class Checkpointing:
         return Batch(output)
 
     def recompute(self, batch: Batch) -> None:
-        """Applies :class:`Recompute` to the batch in place."""
+        """Apply :class:`Recompute` to the batch in place."""
         input_atomic = self.batch.atomic
         inputs = tuple(self.batch)
 
@@ -136,7 +136,7 @@ thread_local = ThreadLocal()
 
 @contextmanager
 def enable_checkpointing() -> Generator[None, None, None]:
-    """Makes :func:`is_checkpointing` return :data:`True` within a context."""
+    """Make :func:`is_checkpointing` return :data:`True` within a context."""
     orig = thread_local.is_checkpointing
     thread_local.is_checkpointing = True
     try:
@@ -167,8 +167,9 @@ def is_checkpointing() -> bool:
 
 
 def is_recomputing() -> bool:
-    """Whether the current forward propagation is under checkpoint
-    recomputation. Use this to prevent duplicated side-effects at forward
+    """Whether the current forward propagation is under checkpoint recomputation. 
+    
+    Use this to prevent duplicated side-effects at forward
     propagation::
 
         class Counter(nn.Module):
@@ -191,9 +192,7 @@ def is_recomputing() -> bool:
 
 
 class Context:
-    """The common interface between the :class:`Checkpoint` and
-    :class:`Recompute` context.
-    """
+    """The common interface between the :class:`Checkpoint` and :class:`Recompute` context."""
 
     recomputed: Deque[Recomputed]
     rng_states: Deque[RNGStates]
@@ -208,7 +207,10 @@ class Context:
 
 
 def save_rng_states(device: torch.device, rng_states: Deque[RNGStates],) -> None:
-    """:meth:`Checkpoint.forward` captures the current PyTorch's random number
+    """:
+    Capture the current random number generator states.
+
+    meth:`Checkpoint.forward` captures the current PyTorch's random number
     generator states at CPU and GPU to reuse in :meth:`Recompute.backward`.
 
     .. seealso:: :ref:`Referential Transparency`
@@ -227,7 +229,10 @@ def save_rng_states(device: torch.device, rng_states: Deque[RNGStates],) -> None
 
 @contextmanager
 def restore_rng_states(device: torch.device, rng_states: Deque[RNGStates],) -> Generator[None, None, None]:
-    """:meth:`Recompute.backward` restores the random number generator states
+    """:
+    Restore the random number generator state.
+
+    meth:`Recompute.backward` restores the random number generator states
     captured by :func:`save_rng_states` within its context.
 
     .. seealso:: :ref:`Referential Transparency`

--- a/torch/distributed/pipeline/sync/checkpoint.py
+++ b/torch/distributed/pipeline/sync/checkpoint.py
@@ -167,8 +167,8 @@ def is_checkpointing() -> bool:
 
 
 def is_recomputing() -> bool:
-    """Whether the current forward propagation is under checkpoint recomputation. 
-    
+    """Whether the current forward propagation is under checkpoint recomputation.
+
     Use this to prevent duplicated side-effects at forward
     propagation::
 

--- a/torch/distributed/pipeline/sync/copy.py
+++ b/torch/distributed/pipeline/sync/copy.py
@@ -4,8 +4,9 @@
 #
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
-"""Autograd functions for stream-aware CUDA copy. It is used to overlap copy
-and computation on the same GPU.
+"""Autograd functions for stream-aware CUDA copy.
+
+It is used to overlap copy and computation on the same GPU.
 """
 from collections import deque
 from typing import Deque, List, Optional, Tuple, Sequence

--- a/torch/distributed/pipeline/sync/dependency.py
+++ b/torch/distributed/pipeline/sync/dependency.py
@@ -37,7 +37,7 @@ class Fork(torch.autograd.Function):
 
 
 def join(input: Tensor, phony: Tensor) -> Tensor:
-    """Merges two autograd lanes."""
+    """Merge two autograd lanes."""
     if torch.is_grad_enabled() and (input.requires_grad or phony.requires_grad):
         input = Join.apply(input, phony)
 

--- a/torch/distributed/pipeline/sync/phony.py
+++ b/torch/distributed/pipeline/sync/phony.py
@@ -19,8 +19,8 @@ _phonies: Dict[Tuple[torch.device, bool], Tensor] = {}
 
 
 def get_phony(device: torch.device, *, requires_grad: bool) -> Tensor:
-    """Get a phony. Phony is tensor without space. 
-    
+    """Get a phony. Phony is tensor without space.
+
     It is useful to make arbitrary dependency in a autograd graph because it doesn't require any
     gradient accumulation.
 

--- a/torch/distributed/pipeline/sync/phony.py
+++ b/torch/distributed/pipeline/sync/phony.py
@@ -19,8 +19,9 @@ _phonies: Dict[Tuple[torch.device, bool], Tensor] = {}
 
 
 def get_phony(device: torch.device, *, requires_grad: bool) -> Tensor:
-    """Gets a phony. Phony is tensor without space. It is useful to make
-    arbitrary dependency in a autograd graph because it doesn't require any
+    """Get a phony. Phony is tensor without space. 
+    
+    It is useful to make arbitrary dependency in a autograd graph because it doesn't require any
     gradient accumulation.
 
     .. note::

--- a/torch/distributed/pipeline/sync/pipeline.py
+++ b/torch/distributed/pipeline/sync/pipeline.py
@@ -61,7 +61,7 @@ def _wait(batch: Batch, prev_stream: AbstractStream, next_stream: AbstractStream
 
 
 def _clock_cycles(m: int, n: int) -> Iterable[List[Tuple[int, int]]]:
-    """Generates schedules for each clock cycle."""
+    """Generate schedules for each clock cycle."""
     # m: number of micro-batches
     # n: number of partitions
     # i: index of micro-batch
@@ -119,9 +119,7 @@ class Pipeline:
     def fence(
         self, batches: List[Batch], schedule: List[Tuple[int, int]], skip_trackers: List[SkipTrackerThroughPotals],
     ) -> None:
-        """Copies micro-batches after computation for the previous
-        micro-batches.
-        """
+        """Copy micro-batches after computation for the previous micro-batches."""
         copy_streams = self.copy_streams
         skip_layout = self.skip_layout
 
@@ -144,7 +142,7 @@ class Pipeline:
     def compute(
         self, batches: List[Batch], schedule: List[Tuple[int, int]], skip_trackers: List[SkipTrackerThroughPotals],
     ) -> None:
-        """Runs tasks with synchronization to copy streams."""
+        """Run tasks with synchronization to copy streams."""
         partitions = self.partitions
         devices = self.devices
         copy_streams = self.copy_streams

--- a/torch/distributed/pipeline/sync/utils.py
+++ b/torch/distributed/pipeline/sync/utils.py
@@ -8,6 +8,8 @@ def partition_model(
         balance: List[int],
         devices: Optional[List[int]] = None):
     """
+    Partions the model accross multiple GPU devices.
+
     Given an :class:`nn.Sequential <torch.nn.Sequential>` module, partitions
     the model across multiple GPU devices according the provided ``balance``
     and ``devices``.

--- a/torch/distributed/pipeline/sync/worker.py
+++ b/torch/distributed/pipeline/sync/worker.py
@@ -67,7 +67,7 @@ class Task:
 
 
 def worker(in_queue: InQueue, out_queue: OutQueue, device: torch.device) -> None:
-    """The main loop of a worker thread."""
+    """Main loop of a worker thread."""
     with use_device(device):
         while True:
             task = in_queue.get()


### PR DESCRIPTION
Fixes #112645 

Updated the files by fixing the docstring errors.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @svekars @carljparker
