### PR TITLE
[dynamo] Enforce lifetime of output fx graph and its metadata 

### DIFF
--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -930,8 +930,7 @@ class OutputGraph(Checkpointable[OutputGraphState]):
         assert self.should_exit
         nodes = list(self.graph.nodes)
         for node in nodes:
-            if "creation_timestamp" in node.meta:
-                del node.meta["creation_timestamp"]
+            node.meta.pop("creation_timestamp", None)
 
         grad_enabled = torch.is_grad_enabled()
         for node1, node2 in zip(nodes, nodes[1:]):

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1000,6 +1000,7 @@ class OutputGraph(Checkpointable[OutputGraphState]):
         call that generated code.
         """
         from .decorators import disable
+
         assert self.should_exit
 
         assert isinstance(rv, list)

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1194,7 +1194,6 @@ class OutputGraph(Checkpointable[OutputGraphState]):
         self.cleanups.append(CleanupHook.create(self.global_scope, name, value))
 
     def cleanup(self) -> None:
-        assert self.should_exit
         # There is a reference cycle between tracer and OutputGraph, causing
         # some of the tensor objects to be held alive for longer than necessary.
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/113516

Also asserts that by the time we modify the output's graph nodes, we are in the irreversible state of `should_exit`.

Remove `creation_timestamp` from graph as it is only consumed by dynamo for checkpoint restore.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng