### PR TITLE
[functorch] fix potential race condition while loading `vmap` decomposition library

### DIFF
--- a/torch/_functorch/vmap.py
+++ b/torch/_functorch/vmap.py
@@ -6,6 +6,7 @@
 
 import torch
 import functools
+import threading
 from torch import Tensor
 from typing import Any, Callable, Optional, Tuple, Union, List
 from torch.utils._pytree import (
@@ -219,6 +220,7 @@ def _get_name(func: Callable):
 
 
 DECOMPOSITIONS_LOADED = False
+DECOMPOSITIONS_LOCK = threading.Lock()
 VMAP_DECOMPOSITIONS_LIB = None
 
 # torch.package, Python 3.11, and torch.jit-less environments are unhappy with
@@ -227,35 +229,40 @@ def lazy_load_decompositions():
     global DECOMPOSITIONS_LOADED
     if DECOMPOSITIONS_LOADED:
         return
-    DECOMPOSITIONS_LOADED = True
 
-    if not (os.environ.get("PYTORCH_JIT", "1") == "1" and __debug__):
-        return
-    # use an alternate way to register an operator into the decomposition table
-    # _register_jit_decomposition doesn't work for some operators, e.g. addr,
-    #  because the Tensor types generated cannot be unioned by torchscript
-    # decomp should be type OpOverload
-    global VMAP_DECOMPOSITIONS_LIB
-    VMAP_DECOMPOSITIONS_LIB = torch.library.Library("aten", "IMPL", "FuncTorchBatched")
+    with DECOMPOSITIONS_LOCK:
+        if DECOMPOSITIONS_LOADED:
+            return
 
-    from torch._decomp import decomposition_table
+        if not (os.environ.get("PYTORCH_JIT", "1") == "1" and __debug__):
+            DECOMPOSITIONS_LOADED = True
+            return
 
-    def _register_python_decomposition_vmap(decomp):
-        if decomp in decomposition_table:
-            VMAP_DECOMPOSITIONS_LIB.impl(decomp, decomposition_table[decomp])
-        else:
-            raise RuntimeError(f"could not find decomposition for {decomp}")
+        # use an alternate way to register an operator into the decomposition table
+        # _register_jit_decomposition doesn't work for some operators, e.g. addr,
+        #  because the Tensor types generated cannot be unioned by torchscript
+        # decomp should be type OpOverload
+        global VMAP_DECOMPOSITIONS_LIB
+        VMAP_DECOMPOSITIONS_LIB = torch.library.Library("aten", "IMPL", "FuncTorchBatched")
 
+        from torch._decomp import decomposition_table
 
-    _register_python_decomposition_vmap(torch.ops.aten.mse_loss_backward.default)
-    _register_python_decomposition_vmap(torch.ops.aten.smooth_l1_loss_backward.default)
-    _register_python_decomposition_vmap(torch.ops.aten.huber_loss_backward.default)
-    _register_python_decomposition_vmap(torch.ops.aten.nll_loss_forward.default)
-    _register_python_decomposition_vmap(torch.ops.aten.nll_loss2d_forward.default)
-    _register_python_decomposition_vmap(torch.ops.aten.nll_loss_backward.default)
-    _register_python_decomposition_vmap(torch.ops.aten.nll_loss2d_backward.default)
-    _register_python_decomposition_vmap(torch.ops.aten.addr.default)
+        def _register_python_decomposition_vmap(decomp):
+            if decomp in decomposition_table:
+                VMAP_DECOMPOSITIONS_LIB.impl(decomp, decomposition_table[decomp])
+            else:
+                raise RuntimeError(f"could not find decomposition for {decomp}")
 
+        _register_python_decomposition_vmap(torch.ops.aten.mse_loss_backward.default)
+        _register_python_decomposition_vmap(torch.ops.aten.smooth_l1_loss_backward.default)
+        _register_python_decomposition_vmap(torch.ops.aten.huber_loss_backward.default)
+        _register_python_decomposition_vmap(torch.ops.aten.nll_loss_forward.default)
+        _register_python_decomposition_vmap(torch.ops.aten.nll_loss2d_forward.default)
+        _register_python_decomposition_vmap(torch.ops.aten.nll_loss_backward.default)
+        _register_python_decomposition_vmap(torch.ops.aten.nll_loss2d_backward.default)
+        _register_python_decomposition_vmap(torch.ops.aten.addr.default)
+
+        DECOMPOSITIONS_LOADED = True
 
 def vmap_impl(func, in_dims, out_dims, randomness, chunk_size, *args, **kwargs):
     lazy_load_decompositions()


### PR DESCRIPTION
There can be a potential race condition while loading the `vmap` decomposition library in multi-threading programs.

This PR adds a thread lock to avoid the case of registering the kernel multiple times.

```python
import threading
from torch._functorch.vmap import lazy_load_decompositions

threads = []
for i in range(10000):
    thread = threading.Thread(target=lazy_load_decompositions)
    threads.append(thread)
for thread in threads:
    thread.start()
for thread in threads:
    thread.join()
```

```text
RuntimeError: This is not allowed since there's already a kernel registered from python overriding mse_loss_backward's behavior for FuncTorchBatched dispatch key and aten namespace.
    VMAP_DECOMPOSITIONS_LIB.impl(decomp, decomposition_table[decomp])
RuntimeError: This is not allowed since there's already a kernel registered from python overriding mse_loss_backward's behavior for FuncTorchBatched dispatch key and aten namespace.
RuntimeError: This is not allowed since there's already a kernel registered from python overriding mse_loss_backward's behavior for FuncTorchBatched dispatch key and aten namespace.
RuntimeError: This is not allowed since there's already a kernel registered from python overriding mse_loss_backward's behavior for FuncTorchBatched dispatch key and aten namespace.
RuntimeError: This is not allowed since there's already a kernel registered from python overriding mse_loss_backward's behavior for FuncTorchBatched dispatch key and aten namespace.
```

cc @zou3519 @Chillee @samdow @kshitij12345 @janeyx99