### PR TITLE
Docs: Fixes for FDSP Files

### DIFF
--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -919,7 +919,9 @@ def _accumulate_sharded_grad(
 @no_type_check
 def _reduce_grad_no_shard(state: _FSDPState, handle: FlatParamHandle) -> None:
     """
-    For no-shard, this runs gradient reduction (which directly covers any gradient accumulation implicitly) and the post-reduction callback.
+    For no-shard, this runs gradient reduction and the post-reduction callback.
+
+    This method directly covers any gradient accumulation implicitly.
     """
     flat_param = handle.flat_param
     if state._comm_hook is None:  # default path
@@ -1551,7 +1553,8 @@ def _get_buffers_and_dtypes_for_computation(
     Return all buffers in the module tree rooted at ``root_module``.
 
     The method also returns a corresponding list of the buffer dtypes for
-    computation. Each buffer dtype is either ``None`` if buffer mixed precision is not enabled or the buffer low precision dtype otherwise.
+    computation. Each buffer dtype is either ``None`` if buffer mixed
+    precision is not enabled or the buffer low precision dtype otherwise.
     """
     _p_assert(state._is_root, "Expects the root to cast buffers")
     buffers: List[torch.Tensor] = []

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -885,8 +885,7 @@ def _accumulate_sharded_grad(
     handle: FlatParamHandle,
     sharded_grad: torch.Tensor,
 ) -> torch.Tensor:
-    """
-    Accumulate the reduce-scattered sharded gradient with any existing sharded gradient if needed.
+    """Accumulate the reduce-scattered sharded gradient with any existing sharded gradient if needed.
 
     The method returns the gradient to offload (if CPU offloading is enabled).
     """

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -56,8 +56,7 @@ class _PrefetchMode(Enum):
 def _get_fsdp_root_states_with_modules(
     module: nn.Module,
 ) -> Tuple[List[_FSDPState], List[nn.Module]]:
-    """
-    Retrieve the root states along with the corresponding modules from a FSDP instance.
+    """Retrieve the root states along with the corresponding modules from a FSDP instance.
 
     Returns a tuple containing:
 
@@ -95,8 +94,7 @@ def _get_fsdp_root_states(module: nn.Module) -> List[_FSDPState]:
 
 
 def _is_fsdp_root(state: _FSDPState, module: nn.Module) -> bool:
-    """
-    Return if ``state`` corresponds to that of an FSDP root.
+    """Return if ``state`` corresponds to that of an FSDP root.
 
     For the wrapper code path, ``state`` and ``module`` should be the same. For
     the non-wrapper code path, ``state`` should be ``module`` 's state.
@@ -144,8 +142,7 @@ def _lazy_init(
     state: _FSDPState,
     root_module: nn.Module,
 ) -> _FSDPState:
-    """
-    Perform initialization lazily, typically right before the first forward pass.
+    """Perform initialization lazily, typically right before the first forward pass.
 
     The laziness is needed to ensure that the parameter device/dtype and
     the FSDP hierarchy have finalized. This method's actual logic only runs on
@@ -176,8 +173,7 @@ def _lazy_init(
 
 
 def _check_flat_params_on_expected_device(state: _FSDPState, module: nn.Module):
-    """
-    Check if all ``FlatParameter`` are on the expected device.
+    """Check if all ``FlatParameter`` are on the expected device.
 
     Checks that all ``FlatParameter``s in ``module`` 's tree managed by
     ``state`` are on the expected device for *lazy initialization*.
@@ -206,8 +202,7 @@ def _share_state_and_init_handle_attrs(
     root_state: _FSDPState,
     root_module: nn.Module,
 ) -> None:
-    """
-    Share data structure state from the ``root_state`` to all FSDP states in ``root_module`` 's module tree.
+    """Share data structure state from the ``root_state`` to all FSDP states in ``root_module`` 's module tree.
 
     The method also initializes handle attributes. These are done together to require a single
     loop over the states.
@@ -276,8 +271,7 @@ def _share_state_and_init_handle_attrs(
 def _init_streams(
     state: _FSDPState,
 ) -> None:
-    """
-    Initialize CUDA streams for overlapping communication, computation, and data transfers.
+    """Initialize CUDA streams for overlapping communication, computation, and data transfers.
 
     The streams should be shared across FSDP instances.
     """
@@ -314,8 +308,7 @@ def _unshard(
     unshard_stream: torch.Stream,
     pre_unshard_stream: torch.Stream,
 ) -> None:
-    """
-    Unshard the handles in ``handles``.
+    """Unshard the handles in ``handles``.
 
     If the handles are in :meth:`summon_full_params` and are
     using mixed precision, then they are forced to full precision.
@@ -347,8 +340,7 @@ def _reshard(
     handle: FlatParamHandle,
     free_unsharded_flat_param: bool,
 ):
-    """
-    Reshards the handle.
+    """Reshards the handle.
 
     ``free_unsharded_flat_param`` indicates whether to free the handle's padded unsharded flat parameter.
     """
@@ -393,8 +385,7 @@ def _pre_forward(
     Run the pre-forward logic.
 
     This includes an opportunity to unshard currently sharded parameters
-    such as those for the current forward and
-    registering post-backward
+    such as those for the current forward and registering post-backward
     hooks for these current parameters. This function also converts forward
     ``args`` and ``kwargs`` to the given precision.
 
@@ -475,11 +466,9 @@ def _post_forward(
     input: Any,
     output: Any,
 ) -> Any:
-    """
-    Run the post-forward logic.
+    """Run the post-forward logic.
 
-    This includes an opportunity to reshard
-    currently unsharded parameters
+    This includes an opportunity to reshard currently unsharded parameters
     such as those used in the current forward and registering pre-backward
     hooks on the forward outputs.
 
@@ -542,8 +531,7 @@ def _root_pre_forward(
     args,
     kwargs,
 ) -> None:
-    """
-    Run pre-forward logic specific to the root FSDP instance.
+    """Run pre-forward logic specific to the root FSDP instance.
 
     The method should run before any individual module's pre-forward. This starts with
     an attempt at lazy initialization (which only runs non-vacuously once).
@@ -662,8 +650,7 @@ def _pre_backward_hook(
     handle: FlatParamHandle,
     *unused: Any,
 ) -> Any:
-    """
-    Prepare ``_handle`` 's ``FlatParameter`` s for gradient computation.
+    """Prepare ``_handle`` 's ``FlatParameter`` s for gradient computation.
 
     Args:
         module (nn.Module): Fully sharded module (see [Note: Fully Sharded
@@ -920,8 +907,7 @@ def _accumulate_sharded_grad(
 
 @no_type_check
 def _reduce_grad_no_shard(state: _FSDPState, handle: FlatParamHandle) -> None:
-    """
-    For no-shard, this runs gradient reduction and the post-reduction callback.
+    """For no-shard, this runs gradient reduction and the post-reduction callback.
 
     This method directly covers any gradient accumulation implicitly.
     """
@@ -947,8 +933,7 @@ def _post_reduce_grad_callback(
     # Additional arguments needed for the callback logic
     grad_to_offload: torch.Tensor,
 ):
-    """
-    Callback captures any logic to run after the gradient reduction
+    """Callback captures any logic to run after the gradient reduction
     finishes.
 
     Currently, this offloads the gradient to CPU if
@@ -1026,8 +1011,7 @@ def _cast_grad_to_param_dtype(
     sharded_grad: torch.Tensor,
     param: FlatParameter,
 ):
-    """
-    Cast ``sharded_grad`` back to the full parameter dtype.
+    """Cast ``sharded_grad`` back to the full parameter dtype.
 
     The method is applied so that the optimizer step runs with that dtype.
     This performs an actual cast if
@@ -1081,8 +1065,7 @@ def _post_backward_final_callback(
     state: _FSDPState,
     module: nn.Module,
 ):
-    """
-    Wait for the post-backward to finish and perform some final cleanup.
+    """Wait for the post-backward to finish and perform some final cleanup.
 
     This runs at the end of the entire backward pass and should only be called
     on the root FSDP instance.
@@ -1127,8 +1110,7 @@ def _post_backward_final_callback(
 def _catch_all_reshard(
     state: _FSDPState,
 ) -> None:
-    """
-    Reshard the parameters that may not have been resharded in the post-backward hook.
+    """Reshard the parameters that may not have been resharded in the post-backward hook.
 
     This can happen when a module's output is used in the
     forward pass, meaning that its pre-backward hook runs (unsharding the
@@ -1202,8 +1184,7 @@ def _prefetch_handle(
     current_handle: Optional[FlatParamHandle],
     prefetch_mode: _PrefetchMode,
 ) -> None:
-    """
-    Prefetche the next handles if needed (without synchronization).
+    """Prefetche the next handles if needed (without synchronization).
 
     An empty handles key cannot prefetch.
     """
@@ -1233,13 +1214,11 @@ def _get_handle_to_prefetch(
     state: _FSDPState,
     current_handle: FlatParamHandle,
 ) -> FlatParamHandle:
-    r"""
-    Return a :class:`list` of the handles keys to prefetch for the next module(s).
+    r"""Return a :class:`list` of the handles keys to prefetch for the next module(s).
 
-    Here ``current_handle`` represents the current module. "Prefetching"
-    refers to running the unshard logic early (withoutcsynchronization),
-    and the "next" modules depend on the recorded execution order and
-    the current training state.
+    Here ``current_handle`` represents the current module. "Prefetching"refers
+    to running the unshard logic early (withoutcsynchronization),and the "next"
+    modules depend on the recorded execution order and the current training state.
     """
     training_state = _get_training_state(current_handle)
     valid_training_states = (
@@ -1315,8 +1294,7 @@ def _register_post_forward_hook(
     state: _FSDPState,
     module: nn.Module,
 ) -> None:
-    """
-    Register a post-forward hook on ``module``.
+    """Register a post-forward hook on ``module``.
 
     Even if the module has no handles, we should register the hook
     since it will register the module's pre-backward hook.
@@ -1339,8 +1317,7 @@ def _register_root_pre_forward_hook(
     state: _FSDPState,
     module: nn.Module,
 ):
-    """
-    Register root pre-forward hook on ``module``, which should be the local FSDP root.
+    """Register root pre-forward hook on ``module``, which should be the local FSDP root.
 
     NOTE: For the current composable FSDP design, we have each application of
     ``fully_shard()`` to a module to indicate that that module is the local
@@ -1364,8 +1341,7 @@ def _register_pre_backward_hooks(
     outputs: Any,
     handle: FlatParamHandle,
 ) -> None:
-    """
-    Register pre-backward hooks on the tensors.
+    """Register pre-backward hooks on the tensors.
 
     The hooks are registered on tensors that require gradients in the
     forward pass outputs ``outputs``, which were computed using the
@@ -1408,8 +1384,7 @@ def _register_post_backward_hook(
     state: _FSDPState,
     handle: Optional[FlatParamHandle],
 ) -> None:
-    """
-    Register post-backward hooks on the ``FlatParameter`` s' ``AccumulateGrad`` objects.
+    """Register post-backward hooks on the ``FlatParameter`` s' ``AccumulateGrad`` objects.
 
     The hooks are required to reshard and to reduce-scatter gradients.
     The ``AccumulateGrad`` object represents the last function that finalizes
@@ -1457,8 +1432,7 @@ def _register_post_backward_reshard_only_hook(
     args: Tuple[Any, ...],
     kwargs: Dict[str, Any],
 ) -> None:
-    """
-    Register post-backward hooks to reshard flat parameters that do not require gradient.
+    """Register post-backward hooks to reshard flat parameters that do not require gradient.
 
     We register these using multi-post-grad hooks on the input activations
     to ensure that all gradients that may depend on the parameters have been
@@ -1517,8 +1491,7 @@ def _wait_for_computation_stream(
     unshard_stream: torch.Stream,
     pre_unshard_stream: torch.Stream,
 ):
-    """
-    Make the unshard and pre-unshard streams wait for the computation stream.
+    """Make the unshard and pre-unshard streams wait for the computation stream.
 
     For example, this should be called in the FSDP root's pre-forward to
     respect optimizer step computation.
@@ -1533,8 +1506,7 @@ def _wait_for_computation_stream(
 def _reset_flat_param_grad_info_if_needed(
     handles: List[FlatParamHandle],
 ):
-    """
-    Clear the original parameters' gradients if needed.
+    """Clear the original parameters' gradients if needed.
 
     This method's CPU overhead is minimal, so we may call it throughout FSDP
     methods, which serve as callsites to free the gradient memory earlier.
@@ -1551,8 +1523,7 @@ def _get_buffers_and_dtypes_for_computation(
     state: _FSDPState,
     root_module: nn.Module,
 ) -> Tuple[List[torch.Tensor], List[Optional[torch.dtype]]]:
-    """
-    Return all buffers in the module tree rooted at ``root_module``.
+    """Return all buffers in the module tree rooted at ``root_module``.
 
     The method also returns a corresponding list of the buffer dtypes for
     computation. Each buffer dtype is either ``None`` if buffer mixed
@@ -1603,8 +1574,7 @@ def _cast_buffers_to_dtype_and_device(
     buffer_dtypes: List[Optional[torch.dtype]],
     device: torch.device,
 ) -> None:
-    """
-    Cast ``buffers`` to the dtypes given by ``buffer_dtypes`` and moves themto ``device``.
+    """Cast ``buffers`` to the dtypes given by ``buffer_dtypes`` and moves themto ``device``.
 
     If an element in ``buffer_dtypes`` is ``None``, then the
     corresponding buffer is only moved to ``device``.

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -57,7 +57,9 @@ def _get_fsdp_root_states_with_modules(
     module: nn.Module,
 ) -> Tuple[List[_FSDPState], List[nn.Module]]:
     """
-    Return a tuple with the following conditions.
+    Retrieve the root states along with the corresponding modules from a FSDP instance.
+
+    Returns a tuple containing:
 
     1. A list of the root ``_FSDPState`` instances in the module tree rooted at
     ``module`` without any duplicates and following the ``module.modules()``

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -1183,7 +1183,7 @@ def _prefetch_handle(
     current_handle: Optional[FlatParamHandle],
     prefetch_mode: _PrefetchMode,
 ) -> None:
-    """Prefetche the next handles if needed (without synchronization).
+    """Prefetch the next handles if needed (without synchronization).
 
     An empty handles key cannot prefetch.
     """

--- a/torch/distributed/fsdp/_shard_utils.py
+++ b/torch/distributed/fsdp/_shard_utils.py
@@ -32,8 +32,10 @@ def _create_chunk_sharded_tensor(
     device: Optional[torch.device] = None,
 ) -> ShardedTensor:
     """
-    Shard a tensor to chunks along the first dimension. The local rank will gets its
-    corresponding chunk as the local shard to create a ShardedTensor.
+    Shard a tensor to chunks along the first dimension.
+
+    The local rank will gets its corresponding chunk as the local shard
+    to create a ShardedTensor.
     """
     chunks = tensor.chunk(world_size, dim=0)
     if len(chunks) > rank:
@@ -87,8 +89,10 @@ def _create_chunk_dtensor(
     device_mesh: DeviceMesh,
 ) -> DTensor:
     """
-    Shard a tensor to chunks along the first dimension. The local rank will gets its
-    corresponding chunk as the local tensor to create a DTensor.
+    Shard a tensor to chunks along the first dimension.
+
+    The local rank will gets its corresponding chunk as
+    the local tensor to create a DTensor.
     """
     # We need to explicitly call .detach() to return a new tensor detached from the current graph.
     tensor = tensor.clone().detach()
@@ -109,9 +113,7 @@ def _all_gather_dtensor(
     tensor: DTensor,
     parent_mesh: Optional[DeviceMesh],
 ) -> torch.Tensor:
-    """
-    All gather a DTensor in its sharded dimension and return the local tensor.
-    """
+    """All gather a DTensor in its sharded dimension and return the local tensor."""
     assert parent_mesh is None
 
     placements = list(copy.deepcopy(tensor.placements))

--- a/torch/distributed/fsdp/_shard_utils.py
+++ b/torch/distributed/fsdp/_shard_utils.py
@@ -31,8 +31,7 @@ def _create_chunk_sharded_tensor(
     pg: dist.ProcessGroup,
     device: Optional[torch.device] = None,
 ) -> ShardedTensor:
-    """
-    Shard a tensor to chunks along the first dimension.
+    """Shard a tensor to chunks along the first dimension.
 
     The local rank will gets its corresponding chunk as the local shard
     to create a ShardedTensor.
@@ -88,8 +87,7 @@ def _create_chunk_dtensor(
     rank: int,
     device_mesh: DeviceMesh,
 ) -> DTensor:
-    """
-    Shard a tensor to chunks along the first dimension.
+    """Shard a tensor to chunks along the first dimension.
 
     The local rank will gets its corresponding chunk as
     the local tensor to create a DTensor.

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -557,7 +557,8 @@ def _sharded_post_state_dict_hook(
     """
     Replace the unshared parameters to sharded parameters.
 
-    The hook replaces the unflattened, unsharded parameter in the state_dict with a unflattened, sharded parameter (a ShardedTensor).
+    The hook replaces the unflattened, unsharded parameter in the
+    state_dict with a unflattened, sharded parameter (a ShardedTensor).
     """
 
     def param_hook(state_dict: Dict[str, Any], prefix: str, fqn: str):
@@ -603,7 +604,11 @@ def _sharded_pre_load_state_dict_hook(
     state_dict: Dict[str, Any],
     prefix: str,
 ) -> None:
-    """Combine the unflattened, sharded parameters (ShardedTensor) to a new FlatParameter and shards the new FlatParameter to the local chunk."""
+    """
+    Combine the unflattened, sharded parameters (ShardedTensor) to a new FlatParameter.
+
+    The method also shards the new FlatParameter to the local chunk.
+    """
     _lazy_init(fsdp_state, module)
     if not _is_composable(fsdp_state):
         _replace_by_prefix(state_dict, prefix, prefix + f"{FSDP_PREFIX}")

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -99,8 +99,7 @@ def _enter_unshard_params_ctx(
     offload_to_cpu: bool = False,
     with_grads: bool = False,
 ) -> None:
-    """
-    Enter the context for `_unshard_fsdp_state_params`.
+    """Enter the context for `_unshard_fsdp_state_params`.
 
     state_dict hooks cannot use the pure context call as the checkpoint flow
     requires to enter the context in the pre-hook but leave the context in the
@@ -147,8 +146,7 @@ def _common_unshard_pre_state_dict_hook(
     offload_to_cpu: bool,
     rank0_only: bool,
 ) -> None:
-    """
-    Perform the pre-state_dict tasks shared by all state_dict types that require ``_unshard_fsdp_state_params()``.
+    """Perform the pre-state_dict tasks shared by all state_dict types that require ``_unshard_fsdp_state_params()``.
 
     FULL_STATE_DICT and SHARDED_STATE_DICT use this hook.
     """
@@ -175,8 +173,7 @@ def _common_unshard_post_state_dict_hook(
     prefix: str,
     param_hook: Callable,
 ) -> Dict[str, Any]:
-    """
-    Share post-state_dict flow to all state_dict types that require ``_unshard_fsdp_state_params()``.
+    """Share post-state_dict flow to all state_dict types that require ``_unshard_fsdp_state_params()``.
 
     FULL_STATE_DICT and SHARDED_STATE_DICT use this
     hook.
@@ -287,8 +284,7 @@ def _full_pre_state_dict_hook(
     *args,
     **kwargs,
 ) -> None:
-    """
-    Run before model.state_dict() is called.
+    """Run before model.state_dict() is called.
 
     pre-state_dict hook is
     not actually supported by ``nn.Module``. As a result, this API is called
@@ -320,8 +316,7 @@ def _full_post_state_dict_hook(
     state_dict: Dict[str, Any],
     prefix: str,
 ) -> Dict[str, Any]:
-    """
-    Run after model.state_dict() is called and before returning result to user.
+    """Run after model.state_dict() is called and before returning result to user.
 
     For FSDP, we may have to clone the tensors in state_dict as params go
     back to sharded version after _unshard_fsdp_state_params ends, and also remove
@@ -395,8 +390,7 @@ def _local_pre_state_dict_hook(
     *args,
     **kwargs,
 ) -> None:
-    """
-    Run before model.state_dict() is called.
+    """Run before model.state_dict() is called.
 
     Right now, pre-state_dict hook is not supported by the PyTorch core.
     So this API is called from `_local_post_state_dict_hook()` to simulate the case.
@@ -419,8 +413,7 @@ def _local_post_state_dict_hook(
     state_dict: Dict[str, Any],
     prefix: str,
 ) -> Dict[str, Any]:
-    r"""
-    Create a ``ShardedTensor`` from the local flat_param.
+    r"""Create a ``ShardedTensor`` from the local flat_param.
 
     Then, method replaces the state_dict[f"{prefix}{FLAT_PARAM}] with the ``ShardedTensor``.
     No copy will happen. The underlying storage is the same.
@@ -474,8 +467,7 @@ def _local_pre_load_state_dict_hook(
     state_dict: Dict[str, Any],
     prefix: str,
 ) -> None:
-    r"""
-    Find the local flat_param for this FSDP module from the state_dict.
+    r"""Find the local flat_param for this FSDP module from the state_dict.
 
     The flat_param should be a ``ShardedTensor``. This hook converts the ``ShardedTensor``
     to a tensor. No copy happen unless padding is required.
@@ -523,8 +515,7 @@ def _sharded_pre_state_dict_hook(
     *args,
     **kwargs,
 ) -> None:
-    r"""
-    Run before model.state_dict() is called.
+    r"""Run before model.state_dict() is called.
 
     Check ``_full_pre_load_state_dict_hook`` for the detail.
     """
@@ -554,8 +545,7 @@ def _sharded_post_state_dict_hook(
     state_dict: Dict[str, Any],
     prefix: str,
 ) -> Dict[str, Any]:
-    """
-    Replace the unshared parameters to sharded parameters.
+    """Replace the unshared parameters to sharded parameters.
 
     The hook replaces the unflattened, unsharded parameter in the
     state_dict with a unflattened, sharded parameter (a ShardedTensor).
@@ -604,8 +594,7 @@ def _sharded_pre_load_state_dict_hook(
     state_dict: Dict[str, Any],
     prefix: str,
 ) -> None:
-    """
-    Combine the unflattened, sharded parameters (ShardedTensor) to a new FlatParameter.
+    """Combine the unflattened, sharded parameters (ShardedTensor) to a new FlatParameter.
 
     The method also shards the new FlatParameter to the local chunk.
     """
@@ -718,8 +707,7 @@ def _post_state_dict_hook(
     prefix: str,
     *args: Any,
 ) -> Dict[str, Any]:
-    r"""
-    Call after the state_dict() of this FSDP module is executed.
+    r"""Call after the state_dict() of this FSDP module is executed.
 
     ``fsdp_state._state_dict_type`` is used to decide
     what postprocessing will be done.
@@ -776,8 +764,7 @@ def _pre_state_dict_hook(
     *args,
     **kwargs,
 ) -> None:
-    """
-    Call before the core state dict saving logic of ``module``.
+    """Call before the core state dict saving logic of ``module``.
 
     ``fsdp_state._state_dict_type`` is used to decide what
     postprocessing will be done.
@@ -826,8 +813,7 @@ def _pre_load_state_dict_hook(
     prefix: str,
     *args: Any,
 ) -> None:
-    """
-    Call before ``module._load_from_state_dict()``.
+    """Call before ``module._load_from_state_dict()``.
 
     ``fsdp_state._state_dict_type`` is used to decide what preprocessing will
     be done.
@@ -917,7 +903,7 @@ def _register_state_dict_hooks_base(
     hook: Callable,
     hook_registration_fn_kwargs: Dict[str, Any],
 ) -> None:
-    """Register ``hook``(s) using ``hook_registration_fn``."""
+    """Register ``hook`` using ``hook_registration_fn``."""
     if not _is_composable(state):
         getattr(state, hook_registration_fn_name)(hook, **hook_registration_fn_kwargs)
     else:

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -412,7 +412,7 @@ def _local_post_state_dict_hook(
     state_dict: Dict[str, Any],
     prefix: str,
 ) -> Dict[str, Any]:
-    r"""Define a hook that creates a ``ShardedTensor`` from the local flat_param.
+    """Define a hook that creates a ShardedTensor from the local flat_param.
 
     Then, method replaces the state_dict[f"{prefix}{FLAT_PARAM}] with the ``ShardedTensor``.
     No copy will happen. The underlying storage is the same.
@@ -466,9 +466,9 @@ def _local_pre_load_state_dict_hook(
     state_dict: Dict[str, Any],
     prefix: str,
 ) -> None:
-    r"""Define a hook that finds the local flat_param for this FSDP module from the state_dict.
+    """Define a hook that finds the local flat_param for this FSDP module from the state_dict.
 
-    The flat_param should be a ``ShardedTensor``. This hook converts the ``ShardedTensor``
+    The flat_param should be a ShardedTensor. This hook converts the ShardedTensor
     to a tensor. No copy happen unless padding is required.
     """
     _lazy_init(fsdp_state, module)

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -122,7 +122,7 @@ def _enter_unshard_params_ctx(
 
 @no_type_check
 def _exit_unshard_params_ctx(module: nn.Module, fsdp_state: _FSDPState) -> None:
-    """Call a helper function to exit ``_unshard_fsdp_state_params`` context."""
+    """Create a helper function to exit ``_unshard_fsdp_state_params`` context."""
     fsdp_state._unshard_params_ctx[module].__exit__(None, None, None)
     fsdp_state._unshard_params_ctx.pop(module)
 
@@ -284,13 +284,12 @@ def _full_pre_state_dict_hook(
     *args,
     **kwargs,
 ) -> None:
-    """Run before model.state_dict() is called.
+    """Define a hook that runs before model.state_dict() is called.
 
-    pre-state_dict hook is
-    not actually supported by ``nn.Module``. As a result, this API is called
-    from ``_full_post_state_dict_hook()`` to simulate the case. Once pre-state_dict
-    is supported in ``nn.Module``, this hook will be registered as a hook in
-    ``nn.Module``.
+    pre-state_dict hook is not actually supported by ``nn.Module``. As a result,
+    this API is called from ``_full_post_state_dict_hook()`` to simulate the case.
+    Once pre-state_dict is supported in ``nn.Module``, this hook will be registered
+    as a hook in ``nn.Module``.
     """
     if getattr(fsdp_state, "_device_mesh", False):
         parent_mesh = _mesh_resources.get_parent_mesh(fsdp_state._device_mesh)
@@ -316,7 +315,7 @@ def _full_post_state_dict_hook(
     state_dict: Dict[str, Any],
     prefix: str,
 ) -> Dict[str, Any]:
-    """Run after model.state_dict() is called and before returning result to user.
+    """Define a hook that runs after model.state_dict() is called and before returning result to user.
 
     For FSDP, we may have to clone the tensors in state_dict as params go
     back to sharded version after _unshard_fsdp_state_params ends, and also remove
@@ -390,7 +389,7 @@ def _local_pre_state_dict_hook(
     *args,
     **kwargs,
 ) -> None:
-    """Run before model.state_dict() is called.
+    """Define a hook that runs before model.state_dict() is called.
 
     Right now, pre-state_dict hook is not supported by the PyTorch core.
     So this API is called from `_local_post_state_dict_hook()` to simulate the case.
@@ -413,7 +412,7 @@ def _local_post_state_dict_hook(
     state_dict: Dict[str, Any],
     prefix: str,
 ) -> Dict[str, Any]:
-    r"""Create a ``ShardedTensor`` from the local flat_param.
+    r"""Define a hook that creates a ``ShardedTensor`` from the local flat_param.
 
     Then, method replaces the state_dict[f"{prefix}{FLAT_PARAM}] with the ``ShardedTensor``.
     No copy will happen. The underlying storage is the same.
@@ -467,7 +466,7 @@ def _local_pre_load_state_dict_hook(
     state_dict: Dict[str, Any],
     prefix: str,
 ) -> None:
-    r"""Find the local flat_param for this FSDP module from the state_dict.
+    r"""Define a hook that finds the local flat_param for this FSDP module from the state_dict.
 
     The flat_param should be a ``ShardedTensor``. This hook converts the ``ShardedTensor``
     to a tensor. No copy happen unless padding is required.
@@ -515,7 +514,7 @@ def _sharded_pre_state_dict_hook(
     *args,
     **kwargs,
 ) -> None:
-    r"""Run before model.state_dict() is called.
+    r"""Define a hook that runs before model.state_dict() is called.
 
     Check ``_full_pre_load_state_dict_hook`` for the detail.
     """
@@ -545,7 +544,7 @@ def _sharded_post_state_dict_hook(
     state_dict: Dict[str, Any],
     prefix: str,
 ) -> Dict[str, Any]:
-    """Replace the unshared parameters to sharded parameters.
+    """Define a hook that replaces the unshared parameters to sharded parameters.
 
     The hook replaces the unflattened, unsharded parameter in the
     state_dict with a unflattened, sharded parameter (a ShardedTensor).
@@ -594,7 +593,7 @@ def _sharded_pre_load_state_dict_hook(
     state_dict: Dict[str, Any],
     prefix: str,
 ) -> None:
-    """Combine the unflattened, sharded parameters (ShardedTensor) to a new FlatParameter.
+    """Define a hook that combines the unflattened, sharded parameters (ShardedTensor) to a new FlatParameter.
 
     The method also shards the new FlatParameter to the local chunk.
     """
@@ -709,8 +708,8 @@ def _post_state_dict_hook(
 ) -> Dict[str, Any]:
     r"""Call after the state_dict() of this FSDP module is executed.
 
-    ``fsdp_state._state_dict_type`` is used to decide
-    what postprocessing will be done.
+    ``fsdp_state._state_dict_type`` is used to decide what
+    postprocessing will be done.
     """
     fsdp_state = _get_module_fsdp_state_if_fully_sharded_module(module)
     if fsdp_state.sharding_strategy == ShardingStrategy.NO_SHARD:


### PR DESCRIPTION
Fixes #113190 

Fixed the docstrings for FDSP files 


```
> pydocstyle torch/distributed/fsdp/_runtime_utils.py --count
Before: 87 
After: 8

> pydocstyle '/Users/guptaaryan16/Desktop/OSS/pytorch/torch/distributed/fsdp/_shard_utils.py' --count
Before: 5
After: 0

> pydocstyle '/Users/guptaaryan16/Desktop/OSS/pytorch/torch/distributed/fsdp/_state_dict_utils.py' --count
Before: 45
After: 0
```

cc @zhaojuanmao @mrshenli @rohan-varma @awgu @fegin @penguinwu @kwen2501 @svekars @carljparker 