### PR TITLE
Add Bfloat16 scalar support to gloo backend

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -56,6 +56,9 @@
     case ::at::ScalarType::Half:                 \
       func<gloo::float16>(__VA_ARGS__);          \
       break;                                     \
+    case ::at::ScalarType::BFloat16:             \
+      func<c10::BFloat16>(args);                 \
+      break;                                     \
     case ::at::ScalarType::Char:                 \
       func<int8_t>(__VA_ARGS__);                 \
       break;                                     \
@@ -85,6 +88,9 @@
       break;                                     \
     case ::at::ScalarType::Half:                 \
       func<gloo::float16>(args);                 \
+      break;                                     \
+    case ::at::ScalarType::BFloat16:             \
+      func<c10::BFloat16>(args);                 \
       break;                                     \
     case ::at::ScalarType::Char:                 \
       func<int8_t>(args);                        \

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -57,7 +57,7 @@
       func<gloo::float16>(__VA_ARGS__);          \
       break;                                     \
     case ::at::ScalarType::BFloat16:             \
-      func<c10::BFloat16>(args);                 \
+      func<c10::BFloat16>(__VA_ARGS__);          \
       break;                                     \
     case ::at::ScalarType::Char:                 \
       func<int8_t>(__VA_ARGS__);                 \


### PR DESCRIPTION
There was missing support for bfloat scalars. When I use gloo backend
`torch.distributed.init_process_group(backend='gloo')`
and run 
`torch.nn.parallel.DistributedDataParallel(model)`
and _model_ has Bfloat16 features I receive following error:
`RuntimeError: Invalid scalar type`

This change fix this issue. 
c10::BFloat16 defines conversions from/to float, so calculations are made on float for bfloat.




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu