### PR TITLE
upgrade lintrunner to the lowest supported versions on python 3.12

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -161,7 +161,7 @@ init_command = [
     'python3',
     'tools/linter/adapters/pip_init.py',
     '--dry-run={{DRYRUN}}',
-    'numpy==1.24.3',
+    'numpy==1.26.0',
     'expecttest==0.1.6',
     'mypy==1.6.0',
     'types-requests==2.27.25',
@@ -173,7 +173,7 @@ init_command = [
     'junitparser==2.1.1',
     'rich==10.9.0',
     'pyyaml==6.0',
-    'optree==0.9.1',
+    'optree==0.10.0',
 ]
 
 [[linter]]

--- a/mypy.ini
+++ b/mypy.ini
@@ -140,43 +140,13 @@ ignore_errors = True
 [mypy-caffe2.core.nomnigraph.op_gen]
 ignore_errors = True
 
-[mypy-caffe2.contrib.playground.*]
-ignore_errors = True
-
-[mypy-caffe2.contrib.gloo.gloo_test]
-ignore_errors = True
-
-[mypy-caffe2.contrib.warpctc.ctc_ops_test]
-ignore_errors = True
-
-[mypy-caffe2.contrib.prof.cuda_profile_ops_test]
-ignore_errors = True
-
-[mypy-caffe2.contrib.nccl.nccl_ops_test]
-ignore_errors = True
-
 [mypy-caffe2.distributed.store_ops_test_util]
 ignore_errors = True
 
-[mypy-caffe2.experiments.python.device_reduce_sum_bench]
+[mypy-caffe2.experiments.*]
 ignore_errors = True
 
-[mypy-caffe2.experiments.python.SparseTransformer]
-ignore_errors = True
-
-[mypy-caffe2.experiments.python.convnet_benchmarks]
-ignore_errors = True
-
-[mypy-caffe2.contrib.aten.aten_test]
-ignore_errors = True
-
-[mypy-caffe2.contrib.aten.docs.sample]
-ignore_errors = True
-
-[mypy-caffe2.contrib.tensorboard.tensorboard_exporter]
-ignore_errors = True
-
-[mypy-caffe2.contrib.tensorboard.tensorboard_exporter_test]
+[mypy-caffe2.contrib.*]
 ignore_errors = True
 
 [mypy-caffe2.quantization.server.*]

--- a/torch/ao/quantization/experimental/linear.py
+++ b/torch/ao/quantization/experimental/linear.py
@@ -136,7 +136,7 @@ class LinearAPoT(WeightedQuantizedModule):
         weight_rows = self.weight_transposed.size()[0]
         weight_cols = self.weight_transposed.size()[1]
 
-        decomposed_weight = np.empty(shape=(weight_rows, weight_cols), dtype=object)
+        decomposed_weight: np.ndarray = np.empty(shape=(weight_rows, weight_cols), dtype=object)
         for row in range(weight_rows):
             for col in range(weight_cols):
                 decomposed_weight[row][col] = self.decompose_APoT(bin(self.weight_transposed[row][col]))

--- a/torch/utils/tensorboard/_utils.py
+++ b/torch/utils/tensorboard/_utils.py
@@ -20,7 +20,7 @@ def figure_to_image(figures, close=True):
     def render_to_rgb(figure):
         canvas = plt_backend_agg.FigureCanvasAgg(figure)
         canvas.draw()
-        data = np.frombuffer(canvas.buffer_rgba(), dtype=np.uint8)
+        data: np.ndarray = np.frombuffer(canvas.buffer_rgba(), dtype=np.uint8)
         w, h = figure.canvas.get_width_height()
         image_hwc = data.reshape([h, w, 4])[:, :, 0:3]
         image_chw = np.moveaxis(image_hwc, source=2, destination=0)


### PR DESCRIPTION
As per title, the current versions fail to install on 3.12.

The failures are related to https://github.com/numpy/numpy/issues/25147
They are fixed by adding manual annotations for the code in PyTorch and ignoring them on caffe2 as discussed with @malfet.