### PR TITLE
More replacing assert with CUDA_KERNEL_ASSERT in kernels

### DIFF
--- a/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
@@ -117,10 +117,10 @@ __global__ void fractional_max_pool2d_backward_out_cuda_frame(
     int outputH = ourOutputPoint / gradOutput.size(3);
 
     int index = indices[batch][plane][outputH][outputW];
-    assert(index >= 0);
+    CUDA_KERNEL_ASSERT(index >= 0);
     int inputW = index % gradInput.size(3);
     int inputH = index / gradInput.size(3);
-    assert(inputH < gradInput.size(2));
+    CUDA_KERNEL_ASSERT(inputH < gradInput.size(2));
 
     gpuAtomicAddNoReturn(
       &gradInput[batch][plane][inputH][inputW],

--- a/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
@@ -11,8 +11,8 @@
 #include <ATen/TensorUtils.h>
 #include <ATen/Utils.h>
 #include <ATen/native/FractionalMaxPooling.h>
+#include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
-
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/NativeFunctions.h>
 #else

--- a/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
@@ -12,6 +12,7 @@
 #include <ATen/TensorUtils.h>
 #include <ATen/Utils.h>
 #include <ATen/native/FractionalMaxPooling.h>
+#include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS

--- a/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
@@ -136,13 +136,13 @@ __global__ void fractional_max_pool3d_backward_out_frame(
                       gradOutput.size(4));
 
     int64_t index = indices[batch][plane][outputT][outputH][outputW];
-    assert(index >= 0);
+    CUDA_KERNEL_ASSERT(index >= 0);
     int64_t inputW = index % gradInput.size(4);
     int64_t inputH = (index / gradInput.size(4)) %
       gradInput.size(3);
     int64_t inputT = index / (gradInput.size(3) *
       gradInput.size(4));
-    assert(inputT < gradInput.size(2));
+    CUDA_KERNEL_ASSERT(inputT < gradInput.size(2));
 
     gpuAtomicAddNoReturn(
       &gradInput[batch][plane][inputT][inputH][inputW],

--- a/aten/src/ATen/native/cuda/SortUtils.cuh
+++ b/aten/src/ATen/native/cuda/SortUtils.cuh
@@ -195,8 +195,8 @@ warpMergeSortKVInPlace(
 
   namespace cub = ROCM_HIPCUB(at_cuda_detail::cub);
 
-  assert(blockDim.x == C10_WARP_SIZE);
-  assert(blockDim.y <= max_block_dim_y);
+  CUDA_KERNEL_ASSERT(blockDim.x == C10_WARP_SIZE);
+  CUDA_KERNEL_ASSERT(blockDim.y <= max_block_dim_y);
   constexpr int items_per_thread = sort_size / C10_WARP_SIZE;
   static_assert(
       items_per_thread * C10_WARP_SIZE == sort_size,

--- a/aten/src/ATen/native/cuda/SortUtils.cuh
+++ b/aten/src/ATen/native/cuda/SortUtils.cuh
@@ -9,6 +9,7 @@
 #include <ATen/native/cuda/SortingCommon.cuh>
 #include <ATen/native/cuda/Sort.h>
 #include <ATen/native/StridedRandomAccessor.h>
+#include <c10/macros/Macros.h>
 
 #define HAS_WARP_MERGE_SORT() (CUDA_VERSION >= 110600)
 

--- a/aten/src/ATen/native/cuda/SortUtils.cuh
+++ b/aten/src/ATen/native/cuda/SortUtils.cuh
@@ -9,7 +9,6 @@
 #include <ATen/native/cuda/SortingCommon.cuh>
 #include <ATen/native/cuda/Sort.h>
 #include <ATen/native/StridedRandomAccessor.h>
-#include <c10/macros/Macros.h>
 
 #define HAS_WARP_MERGE_SORT() (CUDA_VERSION >= 110600)
 

--- a/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
+++ b/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
@@ -297,10 +297,7 @@ __device__ scalar_t findPattern(
   }
 
   // should not get here
-  // disable for ROCM platform as this caused build issue.
-#if !defined(USE_ROCM)
   CUDA_KERNEL_ASSERT(false);
-#endif
   return static_cast<scalar_t>(0);
 }
 

--- a/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
+++ b/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
@@ -296,7 +296,7 @@ __device__ scalar_t findPattern(
     }
   }
 
-  // should not get here 
+  // should not get here
   // disable for ROCM platform as this caused build issue.
 #if !defined(USE_ROCM)
   CUDA_KERNEL_ASSERT(false);

--- a/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
+++ b/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
@@ -2,6 +2,7 @@
 #include <ATen/cuda/Atomic.cuh>
 #include <ATen/cuda/DeviceUtils.cuh>
 #include <ATen/cuda/AsmUtils.cuh>
+#include <c10/macros/Macros.h>
 
 namespace at {
 namespace native {
@@ -295,8 +296,11 @@ __device__ scalar_t findPattern(
     }
   }
 
-  // should not get here
+  // should not get here 
+  // disable for ROCM platform as this caused build issue.
+#if !defined(USE_ROCM)
   CUDA_KERNEL_ASSERT(false);
+#endif
   return static_cast<scalar_t>(0);
 }
 

--- a/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
+++ b/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
@@ -131,7 +131,7 @@ struct TopKTypeConfig<at::Half> {
     RadixType mask = (x & 0x00008000) ? 0x0000ffff : 0x00008000;
     return (v == v) ? (x ^ mask) : 0xffff;
 #else
-    assert(false);
+    CUDA_KERNEL_ASSERT(false);
     return 0u;
 #endif
   }
@@ -141,7 +141,7 @@ struct TopKTypeConfig<at::Half> {
     RadixType mask = (v & 0x00008000) ? 0x00008000 : 0x0000ffff;
     return __ushort_as_half(v ^ mask);
 #else
-    assert(false);
+    CUDA_KERNEL_ASSERT(false);
     return static_cast<at::Half>(0);
 #endif
   }
@@ -296,7 +296,7 @@ __device__ scalar_t findPattern(
   }
 
   // should not get here
-  assert(false);
+  CUDA_KERNEL_ASSERT(false);
   return static_cast<scalar_t>(0);
 }
 

--- a/aten/src/ATen/native/cuda/reduction_template.cuh
+++ b/aten/src/ATen/native/cuda/reduction_template.cuh
@@ -8,7 +8,8 @@ const std::string reduction_template_0 = R"ESCAPE(
   #ifndef __forceinline__
   #define __forceinline__ inline __attribute__((always_inline))
   #endif
-  #define CUDA_KERNEL_ASSERT(expr) (static_cast<void>(0))
+  // until ROCm support for kernel asserts is restored
+  #define assert(expr) (static_cast<void>(0))
   #endif
 
   template <typename T>
@@ -289,7 +290,7 @@ struct ReduceJitOp {
   template <int output_vec_size>
   C10_DEVICE Array<arg_t, output_vec_size> thread_reduce(const scalar_t* data) const {
     if (config.vectorize_input) {
-      CUDA_KERNEL_ASSERT(output_vec_size == 1);
+      assert(output_vec_size == 1);
       // reduce at the header of input_slice where memory is not aligned,
       // so that thread_reduce will have an aligned memory to work on.
       return {input_vectorized_thread_reduce_impl(data)};
@@ -529,13 +530,13 @@ struct ReduceJitOp {
   C10_DEVICE out_scalar_t get_accumulated_output(
     out_scalar_t* out, arg_t value
   ) const {
-    CUDA_KERNEL_ASSERT(!final_output);
+    assert(!final_output);
     return (out_scalar_t)value;
   }
 
   template<class T>
   C10_DEVICE void set_results(const T x, const uint32_t base_offset) const {
-    CUDA_KERNEL_ASSERT(noutputs == 1);
+    assert(noutputs == 1);
     auto res = (out_scalar_t*)((char*)dst[0] + base_offset);
     *res = x;
   }
@@ -559,7 +560,7 @@ struct ReduceJitOp {
 
   template <int output_vec_size>
   C10_DEVICE void set_results_to_output(Array<arg_t, output_vec_size> value, Array<uint32_t, output_vec_size> base_offset) const {
-    CUDA_KERNEL_ASSERT(final_output);
+    assert(final_output);
     #pragma unroll
     for (int i = 0; i < output_vec_size; i++) {
       set_results(reducer::project(value[i]), base_offset[i]);

--- a/aten/src/ATen/native/cuda/reduction_template.cuh
+++ b/aten/src/ATen/native/cuda/reduction_template.cuh
@@ -8,8 +8,7 @@ const std::string reduction_template_0 = R"ESCAPE(
   #ifndef __forceinline__
   #define __forceinline__ inline __attribute__((always_inline))
   #endif
-  // until ROCm support for kernel asserts is restored
-  #define assert(expr) (static_cast<void>(0))
+  #define CUDA_KERNEL_ASSERT(expr) (static_cast<void>(0))
   #endif
 
   template <typename T>
@@ -290,7 +289,7 @@ struct ReduceJitOp {
   template <int output_vec_size>
   C10_DEVICE Array<arg_t, output_vec_size> thread_reduce(const scalar_t* data) const {
     if (config.vectorize_input) {
-      assert(output_vec_size == 1);
+      CUDA_KERNEL_ASSERT(output_vec_size == 1);
       // reduce at the header of input_slice where memory is not aligned,
       // so that thread_reduce will have an aligned memory to work on.
       return {input_vectorized_thread_reduce_impl(data)};
@@ -530,13 +529,13 @@ struct ReduceJitOp {
   C10_DEVICE out_scalar_t get_accumulated_output(
     out_scalar_t* out, arg_t value
   ) const {
-    assert(!final_output);
+    CUDA_KERNEL_ASSERT(!final_output);
     return (out_scalar_t)value;
   }
 
   template<class T>
   C10_DEVICE void set_results(const T x, const uint32_t base_offset) const {
-    assert(noutputs == 1);
+    CUDA_KERNEL_ASSERT(noutputs == 1);
     auto res = (out_scalar_t*)((char*)dst[0] + base_offset);
     *res = x;
   }
@@ -560,7 +559,7 @@ struct ReduceJitOp {
 
   template <int output_vec_size>
   C10_DEVICE void set_results_to_output(Array<arg_t, output_vec_size> value, Array<uint32_t, output_vec_size> base_offset) const {
-    assert(final_output);
+    CUDA_KERNEL_ASSERT(final_output);
     #pragma unroll
     for (int i = 0; i < output_vec_size; i++) {
       set_results(reducer::project(value[i]), base_offset[i]);


### PR DESCRIPTION
Fixes #103973

**Background:** 
After https://github.com/pytorch/pytorch/pull/113098, user verified that torch.sum() worked for environment where PCIe atomics was exposed as a problem for such operation.
 

**Goal:**
This is to expand the changes to other kernels where assert is called. The goal is the same so that we can disable kernel assertion easily for those users when the call sites consistently use CUDA_KERNEL_ASSERT.

**Test:**
We build wheels with these fixes for those users who had PCIe atomics issue, and users verified they can perform their workflow now with these fixes.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo