### PR TITLE
Quantize bias for conv2d quantized op during setup

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Convolution.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.cpp
@@ -548,7 +548,10 @@ vTensor pack_biases(
     const Tensor& weight,
     const bool transposed,
     const bool quantized) {
-  at::Tensor bias_rearranged = conv2d::rearrange_bias(bias, weight, transposed);
+  at::Tensor bias_arg = conv2d::rearrange_bias(bias, weight, transposed);
+  at::Tensor bias_rearranged = (quantized && bias_arg.scalar_type() == kFloat)
+      ? at::quantize_per_tensor(bias_arg, weight.q_scale(), 0, c10::kQInt32)
+      : bias_arg;
 
   vTensor v_bias{
       api::context(),
@@ -557,7 +560,7 @@ vTensor pack_biases(
       quantized ? api::StorageType::TEXTURE_3D : api::StorageType::TEXTURE_2D,
   };
 
-  if (quantized && bias->scalar_type() != c10::kFloat) {
+  if (quantized) {
     v_bias.set_is_quantized();
     v_bias.set_scale(bias_rearranged.q_scale());
     v_bias.set_zero_point(bias_rearranged.q_zero_point());
@@ -1136,11 +1139,6 @@ Tensor run_conv2d_context_impl(
 
   Tensor bias =
       conv_context->get_val(Conv2dPackedContext::Packed::Bias).toTensor();
-  if (quantized && bias.scalar_type() == c10::kFloat) {
-    bias = at::quantize_per_tensor(
-        bias, v_weight.get_scale() * v_input.get_scale(), 0, c10::kQInt32);
-    conv_context->set_val(Conv2dPackedContext::Packed::Bias, bias);
-  }
 
   const vTensor& v_bias = convert(bias);
 

--- a/aten/src/ATen/test/vulkan_quantized_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_quantized_api_test.cpp
@@ -1397,7 +1397,7 @@ TEST_F(VulkanAPITest, quantized_add_dif_params) {
   ASSERT_TRUE(check);
 }
 
-TEST_F(VulkanAPITest, conv2d) {
+void test_conv2d(bool bias_quantized) {
   constexpr int64_t groups = 1;
   constexpr std::array<int64_t, 2u> stride{2, 2};
   constexpr std::array<int64_t, 2u> padding{1, 1};
@@ -1476,7 +1476,7 @@ TEST_F(VulkanAPITest, conv2d) {
   const auto output_vulkan = at::native::vulkan::ops::quantized_conv2d(
       out_vulkan,
       weight_q,
-      bias_q,
+      bias_quantized ? bias_q : bias_cpu,
       stride,
       padding,
       dilation,
@@ -1499,6 +1499,11 @@ TEST_F(VulkanAPITest, conv2d) {
   }
 
   ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, conv2d) {
+  test_conv2d(false);
+  test_conv2d(true);
 }
 
 TEST_F(VulkanAPITest, conv2d_pw) {


### PR DESCRIPTION
Summary: Quantize bias in setup step so that we do not incur additional time on quantizing bias in the first iteration.

Test Plan:
Ensure all vulkan quantize tests pass:
buck2 run --target-platforms ovr_configplatform/macos:arm64-fbsourcexplat/caffe2:pt_vulkan_quantized_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1 --show-output"
.....
[----------] Global test environment tear-down
[==========] 78 tests from 1 test suite ran. (1519 ms total)
[  PASSED  ] 78 tests.

  YOU HAVE 8 DISABLED TESTS

buck2 run --target-platforms ovr_config//platform/macos:arm64-fbsource  //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1 --show-output"

Running main() from third-party/googletest/1.11.0/googletest/googletest/src/gtest_main.cc
[==========] Running 395 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 395 tests from VulkanAPITest
[----------] 395 tests from VulkanAPITest (6515 ms total)
.....
[----------] Global test environment tear-down
[==========] 395 tests from 1 test suite ran. (6515 ms total)
[  PASSED  ] 394 tests.
[  SKIPPED ] 1 test, listed below:
[  SKIPPED ] VulkanAPITest.querypool_flushed_shader_log

  YOU HAVE 5 DISABLED TESTS

Reviewed By: yipjustin, copyrightly

Differential Revision: D50997531


