### PR TITLE
Fix to wrap jagged dims for split() / split_with_sizes()

### DIFF
--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -494,7 +494,7 @@ def split_tensor(func, *args, **kwargs):
 
     inp = new_kwargs.pop("input")
 
-    _wrap_jagged_dim(inp.dim(), new_kwargs["dim"], "split")
+    new_kwargs["dim"] = _wrap_jagged_dim(inp.dim(), new_kwargs["dim"], "split")
 
     return tuple(
         NestedTensor(values=x, **extract_kwargs(inp))
@@ -512,7 +512,7 @@ def split_with_sizes_default(func, *args, **kwargs):
 
     inp = new_kwargs.pop("input")
 
-    _wrap_jagged_dim(inp.dim(), new_kwargs["dim"], "split_with_sizes")
+    new_kwargs["dim"] = _wrap_jagged_dim(inp.dim(), new_kwargs["dim"], "split_with_sizes")
 
     return [
         NestedTensor(values=x, **extract_kwargs(inp))

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -512,7 +512,9 @@ def split_with_sizes_default(func, *args, **kwargs):
 
     inp = new_kwargs.pop("input")
 
-    new_kwargs["dim"] = _wrap_jagged_dim(inp.dim(), new_kwargs["dim"], "split_with_sizes")
+    new_kwargs["dim"] = _wrap_jagged_dim(
+        inp.dim(), new_kwargs["dim"], "split_with_sizes"
+    )
 
     return [
         NestedTensor(values=x, **extract_kwargs(inp))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #113591

Still need OpInfo-style tests to catch things like this.

cc @cpuhrsch @bhosmer @drisspg @soulitzer