### PR TITLE
[FSDP] Fix FSDP submodule with DeviceMesh does not return DTensor state_dict error

### DIFF
--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -12,6 +12,7 @@ from typing import (
     Iterator,
     List,
     NamedTuple,
+    no_type_check,
     Optional,
     Sequence,
     Set,
@@ -46,7 +47,11 @@ from torch.distributed.fsdp._runtime_utils import (
     _lazy_init,
     _reset_flat_param_grad_info_if_needed,
 )
-from torch.distributed.fsdp.api import ShardingStrategy
+from torch.distributed.fsdp.api import (
+    ShardingStrategy,
+    StateDictSettings,
+    StateDictType,
+)
 from torch.utils._pytree import tree_map_only
 
 
@@ -2054,3 +2059,28 @@ def _get_fqn_to_fsdp_param_info(model: nn.Module) -> Dict[str, FSDPParamInfo]:
         [fqn for fqn, _ in _named_parameters_with_duplicates(model)],
         fqn_to_param_info,
     )
+
+
+@no_type_check
+def _set_optim_use_dtensor(
+    module: nn.Module,
+    state_dict_settings: StateDictSettings,
+) -> None:
+    # If device_mesh is passed in when initalizing FSDP, we automatically turn the
+    # _use_dtensor flag to be true for ShardedOptimStateDictConfig() if state_dict_type
+    # has to be set to SHARDED_STATE_DICT.
+    if getattr(module, "device_mesh", None):
+        state_dict_type = state_dict_settings.state_dict_type
+        if state_dict_type == StateDictType.LOCAL_STATE_DICT:
+            raise RuntimeError(
+                "Found state_dict_type LOCAL_STATE_DICT.",
+                "DeviceMesh is not compatible with LOCAL_STATE_DICT.",
+                "Please set state_dict_type to SHARDED_STATE_DICT to get DTensor state_dict.",
+            )
+        elif state_dict_type == StateDictType.FULL_STATE_DICT:
+            logger.warning(
+                "Found both state_dict_type FULL_STATE_DICT and device_mesh. "  # noqa: G004
+                "Please set state_dict_type to SHARDED_STATE_DICT to get DTensor state_dict."
+            )
+        else:
+            state_dict_settings.optim_state_dict_config._use_dtensor = True

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -90,6 +90,7 @@ from ._optim_utils import (
     _get_param_to_param_key,
     _optim_state_dict,
     _rekey_sharded_optim_state_dict,
+    _set_optim_use_dtensor,
 )
 from ._state_dict_utils import _register_all_state_dict_hooks
 from ._unshard_param_utils import (
@@ -768,6 +769,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
                     state_dict_config=submodule._state_dict_config,
                     optim_state_dict_config=submodule._optim_state_dict_config,
                 )
+                _set_optim_use_dtensor(submodule, state_dict_settings)
             else:
                 submodule_settings = StateDictSettings(
                     submodule._state_dict_type,
@@ -778,15 +780,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
                     "All FSDP modules must have the same state dict settings."
                     f"Got {submodule_settings} and {state_dict_settings}."
                 )
-
-            # If device_mesh is passed in when initalizing FSDP, we automatically turn the
-            # _use_dtensor flag to be true for ShardedOptimStateDictConfig().
-            if (
-                getattr(module, "device_mesh", None)
-                and state_dict_settings.state_dict_type
-                == StateDictType.SHARDED_STATE_DICT
-            ):
-                state_dict_settings.optim_state_dict_config._use_dtensor = True
+                _set_optim_use_dtensor(submodule, submodule_settings)
         return state_dict_settings
 
     @staticmethod


### PR DESCRIPTION
For scenarios where FSDP is not the root module, the `_use_dtensor` flag would not be switched on. This PR fixes it by checking whether the submodule has the `device_mesh` and turn `_use_dtensor` flag on accordingly. 

Test Plan:
```
python3 test/distributed/fsdp/test_hsdp_dtensor_state_dict.py -k test_root_module_is_not_FSDP
python3 test/distributed/fsdp/test_fsdp_dtensor_state_dict.py -k test_raises_warning_or_errors
```