### PR TITLE
[inductor] Take trition annotations from kernel.signature

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -873,9 +873,11 @@ class WrapperCodeGen(CodeGen):
         signature: List[Union[TensorArg, SizeArg]] = []
         constants = {}
         for key, arg in kwargs.items():
+            assert key in kernel.signature.parameters, f"Unknown argument name {key}"
+            param = kernel.signature.parameters[key]
             if (
-                key in kernel.__annotations__
-                and "constexpr" in kernel.__annotations__[key]
+                param.annotation is not inspect.Parameter.empty
+                and "constexpr" in param.annotation
             ):
                 constants[key] = arg
                 continue


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #110913
* #110912
* #110911
* #109132
* #106581
* #109601
* __->__ #113596

In newer triton versions `kernel.__annotations__` doesn't hold the right
annotations but we can just use the signature attribute instead.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler