### PR TITLE
Back out "[Inductor] Fallback scatter when src dtype is bf16 (#113204)"

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -299,20 +299,6 @@ class CommonTemplate:
 
         self.common(fn, [torch.linspace(-10, 10, 41)])
 
-    def test_scatter_bf16(self):
-        def fn(inp, src, index):
-            return inp.scatter_add(0, index, src)
-
-        for dtype in [torch.int64, torch.bool, torch.bfloat16]:
-            self.common(
-                fn,
-                [
-                    torch.zeros(3, 5, dtype=dtype),
-                    torch.ones((2, 5), dtype=dtype),
-                    torch.tensor([[0, 1, 2, 0, 0]]),
-                ],
-            )
-
     def test_randn_generator(self):
         def fn(a, generator):
             torch.randn([20, 20], generator=generator, device=a.device)


### PR DESCRIPTION
Summary: Revert due to Llama 7b performance regression on Mi250x (83tok/s -> 79.5tok/s, ~4% regression)

Test Plan: CI

Differential Revision: D51287379




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler