### PR TITLE
Enable clang-tidy in torch/csrc/quantized and some fixes

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -266,7 +266,6 @@ exclude_patterns = [
     'torch/csrc/jit/serialization/export.cpp',
     'torch/csrc/lazy/**/*',
     'torch/csrc/onnx/init.cpp',
-    'torch/csrc/quantized/**/*',
     'torch/csrc/mps/**/*',
 ]
 init_command = [


### PR DESCRIPTION
This PR enables clang-tidy checks in torch/csrc/quantized/  