### PR TITLE
Optimize batch_norm_cpu_collect_stats_channels_last_impl when N <= num_threads

### DIFF
--- a/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
@@ -311,7 +311,6 @@ batch_norm_cpu_collect_stats_channels_last_impl(
         for (const auto t : c10::irange(N)) {
           sum += input_data[t * n_channel + c];
         }
-        
         scalar_t mean = sum / N;
         mean_data[c] = mean;
       }

--- a/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
@@ -319,6 +319,9 @@ batch_norm_cpu_collect_stats_channels_last_impl(
     // The optimal THRESHOLD to tile was found empirically.
     // When C > THRESHOLD, C is large enough that the benefit from tiling and vectorization outweigh the synchronization overhead.
     // Wehn C <= TILE_SIZE, the problem size is small enough (C <= TILE_SIZE && NHW <= max_threads) that it's better to launch single thread with vectorization than C threads without vectorization.
+    //
+    // When num_threads == 1, always use Method 2 as there is no synchronization overhead.
+    //
     int64_t TILE_SIZE = 16;
     int64_t THRESHOLD = 2048;
 

--- a/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
@@ -349,27 +349,25 @@ batch_norm_cpu_collect_stats_channels_last_impl(
     // Method 2: parallel on tiles of C, vectorized vertical reduce on each tile
     else {
       // compute mean per input
-      Tensor sum = at::zeros({n_channel}, input.options());
-      scalar_t* sum_data = sum.data_ptr<scalar_t>();
+      mean.zero_();
       at::parallel_for(0, (n_channel + TILE_SIZE - 1) / TILE_SIZE, 1, [&](int64_t tile_idx_begin, int64_t tile_idx_end) {
         for (int64_t tile_idx = tile_idx_begin; tile_idx < tile_idx_end; tile_idx++) {
           int64_t jj_begin = tile_idx * TILE_SIZE;
           int64_t jj_end = std::min(jj_begin + TILE_SIZE, n_channel);
-          scalar_t* sum_ptr = sum_data + jj_begin;
           scalar_t* mean_ptr = mean_data + jj_begin;
           for (const auto i : c10::irange(N)) {
             const scalar_t* x_ptr = input_data + (i * n_channel + jj_begin);
             vec::map2<scalar_t>(
               [](Vec x, Vec y) { return x + y; },
-              sum_ptr,
+              mean_ptr,
               x_ptr,
-              sum_ptr,
+              mean_ptr,
               jj_end - jj_begin);
           }
           vec::map<scalar_t>(
             [N](Vec x) { return x / Vec(N); },
             mean_ptr,
-            sum_ptr,
+            mean_ptr,
             jj_end - jj_begin);
         }
       });

--- a/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
@@ -21,6 +21,7 @@
 #include <ATen/ops/ones.h>
 #include <ATen/ops/zeros.h>
 #endif
+
 namespace at::native {
 namespace {
 
@@ -220,6 +221,7 @@ template <typename scalar_t>
 typename std::enable_if_t<std::is_same_v<scalar_t, at::opmath_type<scalar_t>>, void>
 batch_norm_cpu_collect_stats_channels_last_impl(
     Tensor& mean, Tensor& var_sum, const Tensor& input) {
+
   using Vec = Vectorized<scalar_t>;
   // keep acc_type as opmath_type will use float type when scalar_t==float
   // while acc_type uses double for float.

--- a/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
@@ -244,11 +244,11 @@ batch_norm_cpu_collect_stats_channels_last_impl(
   // Normal size of C should fit in L1, otherwise consider blocking on C.
   //
   int num_threads = at::get_num_threads();
-  
+
   if (N > num_threads) {
     Tensor buffer = at::zeros({num_threads, n_channel}, input.options());
     scalar_t* buffer_data = buffer.data_ptr<scalar_t>();
-    
+
     // compute mean per input
     at::parallel_for(0, N, 1, [&](int64_t begin, int64_t end) {
       int tid = at::get_thread_num();
@@ -265,7 +265,7 @@ batch_norm_cpu_collect_stats_channels_last_impl(
             n_channel);
       }
     });
-  
+
     at::parallel_for(0, n_channel, 1, [&](int64_t begin, int64_t end) {
       for (const auto c : c10::irange(begin, end)) {
         accscalar_t sum = 0;
@@ -276,7 +276,7 @@ batch_norm_cpu_collect_stats_channels_last_impl(
         mean_data[c] = mean;
       }
     });
-    
+
     // compute variance per input, reuse the immediate buffer
     buffer.zero_();
     at::parallel_for(0, N, 1, [&](int64_t begin, int64_t end) {
@@ -294,7 +294,7 @@ batch_norm_cpu_collect_stats_channels_last_impl(
             n_channel);
       }
     });
-  
+
     at::parallel_for(0, n_channel, 1, [&](int64_t begin, int64_t end) {
       for (const auto c : c10::irange(begin, end)) {
         accscalar_t _var_sum = 0;
@@ -315,7 +315,7 @@ batch_norm_cpu_collect_stats_channels_last_impl(
         mean_data[c] = mean;
       }
     });
-    
+
     at::parallel_for(0, n_channel, 1, [&](int64_t begin, int64_t end) {
       for (const auto c : c10::irange(begin, end)) {
         accscalar_t _var_sum = 0;

--- a/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
@@ -330,7 +330,7 @@ batch_norm_cpu_collect_stats_channels_last_impl(
     */
 
     // Method 2: direct single reduction and vertical tile on n_channel when N <= num_threads
-    int64_t TILE_SIZE = 256;
+    int64_t TILE_SIZE = 16;
     // compute mean per input
     Tensor sum = at::zeros({n_channel}, input.options());
     scalar_t* sum_data = sum.data_ptr<scalar_t>();
@@ -358,6 +358,7 @@ batch_norm_cpu_collect_stats_channels_last_impl(
     });
 
     // compute variance per input
+    var_sum.zero_();
     at::parallel_for(0, (n_channel + TILE_SIZE - 1) / TILE_SIZE, 1, [&](int64_t tile_idx_begin, int64_t tile_idx_end) {
       for (int64_t tile_idx = tile_idx_begin; tile_idx < tile_idx_end; tile_idx++) {
         int64_t jj_begin = tile_idx * TILE_SIZE;

--- a/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
@@ -221,6 +221,7 @@ template <typename scalar_t>
 typename std::enable_if_t<std::is_same_v<scalar_t, at::opmath_type<scalar_t>>, void>
 batch_norm_cpu_collect_stats_channels_last_impl(
     Tensor& mean, Tensor& var_sum, const Tensor& input) {
+
   using Vec = Vectorized<scalar_t>;
   // keep acc_type as opmath_type will use float type when scalar_t==float
   // while acc_type uses double for float.
@@ -913,93 +914,74 @@ inline void batch_norm_cpu_collect_stats_channels_last_internal(
   param_t* var_sum_data = var_sum.data_ptr<param_t>();
 
   int num_threads = at::get_num_threads();
+  Tensor buffer = at::zeros({num_threads, n_channel}, input.options().dtype(kFloat));
+  opmath_t* buffer_data = buffer.data_ptr<opmath_t>();
 
-  if (N > num_threads) {
-    Tensor buffer = at::zeros({num_threads, n_channel}, input.options().dtype(kFloat));
-    opmath_t* buffer_data = buffer.data_ptr<opmath_t>();
-
-    at::parallel_for(0, N, 1, [&](int64_t begin, int64_t end) {
-      int tid = at::get_thread_num();
-      TORCH_CHECK(tid < num_threads, "expect thread id smaller than ", num_threads, ", got thread id ", tid);
-      opmath_t* buffer_ptr = buffer_data + tid * n_channel;
-      for (const auto i : c10::irange(begin, end)) {
-        const scalar_t* input_ptr = input_data + i * n_channel;
-        int64_t d = 0;
-        for (; d < n_channel - (n_channel % bVec::size()); d += bVec::size()) {
-          bVec data_bvec = bVec::loadu(input_ptr + d);
-          fVec data_fvec0, data_fvec1;
-          std::tie(data_fvec0, data_fvec1) = convert_to_float<scalar_t>(data_bvec);
-          fVec sum_fvec0 = fVec::loadu(buffer_ptr + d) + data_fvec0;
-          fVec sum_fvec1 = fVec::loadu(buffer_ptr + d + fVec::size()) + data_fvec1;
-          sum_fvec0.store(buffer_ptr + d);
-          sum_fvec1.store(buffer_ptr + d + fVec::size());
-        }
-        for (; d < n_channel; d++) {
-          buffer_ptr[d] += input_ptr[d];
-        }
+  at::parallel_for(0, N, 1, [&](int64_t begin, int64_t end) {
+    int tid = at::get_thread_num();
+    TORCH_CHECK(tid < num_threads, "expect thread id smaller than ", num_threads, ", got thread id ", tid);
+    opmath_t* buffer_ptr = buffer_data + tid * n_channel;
+    for (const auto i : c10::irange(begin, end)) {
+      const scalar_t* input_ptr = input_data + i * n_channel;
+      int64_t d = 0;
+      for (; d < n_channel - (n_channel % bVec::size()); d += bVec::size()) {
+        bVec data_bvec = bVec::loadu(input_ptr + d);
+        fVec data_fvec0, data_fvec1;
+        std::tie(data_fvec0, data_fvec1) = convert_to_float<scalar_t>(data_bvec);
+        fVec sum_fvec0 = fVec::loadu(buffer_ptr + d) + data_fvec0;
+        fVec sum_fvec1 = fVec::loadu(buffer_ptr + d + fVec::size()) + data_fvec1;
+        sum_fvec0.store(buffer_ptr + d);
+        sum_fvec1.store(buffer_ptr + d + fVec::size());
       }
-    });
-
-    for (const auto c : c10::irange(n_channel)) {
-      opmath_t sum = 0;
-      for (const auto t : c10::irange(num_threads)) {
-        sum += buffer_data[t * n_channel + c];
+      for (; d < n_channel; d++) {
+        buffer_ptr[d] += input_ptr[d];
       }
-      mean_data[c] = param_t(sum / N);
     }
+  });
 
-    buffer.zero_();
-    at::parallel_for(0, N, 1, [&](int64_t begin, int64_t end) {
-      int tid = at::get_thread_num();
-      TORCH_CHECK(tid < num_threads, "expect thread id smaller than ", num_threads, ", got thread id ", tid);
-      opmath_t* buffer_ptr = buffer_data + tid * n_channel;
-      for (const auto i : c10::irange(begin, end)) {
-        const scalar_t* input_ptr = input_data + i * n_channel;
-        int64_t d = 0;
-        for (; d < n_channel - (n_channel % bVec::size()); d += bVec::size()) {
-          bVec data_bvec = bVec::loadu(input_ptr + d);
-          fVec data_fvec0, data_fvec1;
-          std::tie(data_fvec0, data_fvec1) = convert_to_float<scalar_t>(data_bvec);
-          fVec mean_fvec0, mean_fvec1;
-          std::tie(mean_fvec0, mean_fvec1) = load2f(mean_data + d);
-          fVec var_fvec0 = fVec::loadu(buffer_ptr + d);
-          fVec var_fvec1 = fVec::loadu(buffer_ptr + d + fVec::size());
-          var_fvec0 += (data_fvec0 - mean_fvec0) * (data_fvec0 - mean_fvec0);
-          var_fvec1 += (data_fvec1 - mean_fvec1) * (data_fvec1 - mean_fvec1);
-          var_fvec0.store(buffer_ptr + d);
-          var_fvec1.store(buffer_ptr + d + fVec::size());
-        }
-        for (; d < n_channel; d++) {
-          opmath_t data_val = opmath_t(input_ptr[d]);
-          opmath_t mean_val = opmath_t(mean_data[d]);
-          buffer_ptr[d] += (data_val - mean_val) * (data_val - mean_val);
-        }
-      }
-    });
+  for (const auto c : c10::irange(n_channel)) {
+    opmath_t sum = 0;
+    for (const auto t : c10::irange(num_threads)) {
+      sum += buffer_data[t * n_channel + c];
+    }
+    mean_data[c] = param_t(sum / N);
+  }
 
-    for (const auto c : c10::irange(n_channel)) {
-      opmath_t _var_sum = 0;
-      for (const auto t : c10::irange(num_threads)) {
-        _var_sum += buffer_data[t * n_channel + c];
+  buffer.zero_();
+  at::parallel_for(0, N, 1, [&](int64_t begin, int64_t end) {
+    int tid = at::get_thread_num();
+    TORCH_CHECK(tid < num_threads, "expect thread id smaller than ", num_threads, ", got thread id ", tid);
+    opmath_t* buffer_ptr = buffer_data + tid * n_channel;
+    for (const auto i : c10::irange(begin, end)) {
+      const scalar_t* input_ptr = input_data + i * n_channel;
+      int64_t d = 0;
+      for (; d < n_channel - (n_channel % bVec::size()); d += bVec::size()) {
+        bVec data_bvec = bVec::loadu(input_ptr + d);
+        fVec data_fvec0, data_fvec1;
+        std::tie(data_fvec0, data_fvec1) = convert_to_float<scalar_t>(data_bvec);
+        fVec mean_fvec0, mean_fvec1;
+        std::tie(mean_fvec0, mean_fvec1) = load2f(mean_data + d);
+        fVec var_fvec0 = fVec::loadu(buffer_ptr + d);
+        fVec var_fvec1 = fVec::loadu(buffer_ptr + d + fVec::size());
+        var_fvec0 += (data_fvec0 - mean_fvec0) * (data_fvec0 - mean_fvec0);
+        var_fvec1 += (data_fvec1 - mean_fvec1) * (data_fvec1 - mean_fvec1);
+        var_fvec0.store(buffer_ptr + d);
+        var_fvec1.store(buffer_ptr + d + fVec::size());
       }
-      var_sum_data[c] = param_t(_var_sum);
-    }
-  } else {
-    for (const auto c : c10::irange(n_channel)) {
-      opmath_t sum = 0;
-      for (const auto t : c10::irange(N)) {
-        sum += input_data[t * n_channel + c];
+      for (; d < n_channel; d++) {
+        opmath_t data_val = opmath_t(input_ptr[d]);
+        opmath_t mean_val = opmath_t(mean_data[d]);
+        buffer_ptr[d] += (data_val - mean_val) * (data_val - mean_val);
       }
-      mean_data[c] = param_t(sum / N);
     }
+  });
 
-    for (const auto c : c10::irange(n_channel)) {
-      opmath_t _var_sum = 0;
-      for (const auto t : c10::irange(N)) {
-        _var_sum += (input_data[t * n_channel + c] - mean_data[c]) * (input_data[t * n_channel + c] - mean_data[c]);
-      }
-      var_sum_data[c] = param_t(_var_sum);
+  for (const auto c : c10::irange(n_channel)) {
+    opmath_t _var_sum = 0;
+    for (const auto t : c10::irange(num_threads)) {
+      _var_sum += buffer_data[t * n_channel + c];
     }
+    var_sum_data[c] = param_t(_var_sum);
   }
 }
 

--- a/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
@@ -21,7 +21,7 @@
 #include <ATen/ops/ones.h>
 #include <ATen/ops/zeros.h>
 #endif
-#include <iostream>
+
 namespace at::native {
 namespace {
 
@@ -244,12 +244,11 @@ batch_norm_cpu_collect_stats_channels_last_impl(
   // Normal size of C should fit in L1, otherwise consider blocking on C.
   //
   int num_threads = at::get_num_threads();
-
+  
   if (N > num_threads) {
-    std::cout << "=== N > num_threads ===" << std::endl;
     Tensor buffer = at::zeros({num_threads, n_channel}, input.options());
     scalar_t* buffer_data = buffer.data_ptr<scalar_t>();
-
+    
     // compute mean per input
     at::parallel_for(0, N, 1, [&](int64_t begin, int64_t end) {
       int tid = at::get_thread_num();
@@ -266,7 +265,7 @@ batch_norm_cpu_collect_stats_channels_last_impl(
             n_channel);
       }
     });
-
+  
     at::parallel_for(0, n_channel, 1, [&](int64_t begin, int64_t end) {
       for (const auto c : c10::irange(begin, end)) {
         accscalar_t sum = 0;
@@ -277,7 +276,7 @@ batch_norm_cpu_collect_stats_channels_last_impl(
         mean_data[c] = mean;
       }
     });
-
+    
     // compute variance per input, reuse the immediate buffer
     buffer.zero_();
     at::parallel_for(0, N, 1, [&](int64_t begin, int64_t end) {
@@ -295,7 +294,7 @@ batch_norm_cpu_collect_stats_channels_last_impl(
             n_channel);
       }
     });
-
+  
     at::parallel_for(0, n_channel, 1, [&](int64_t begin, int64_t end) {
       for (const auto c : c10::irange(begin, end)) {
         accscalar_t _var_sum = 0;
@@ -306,27 +305,22 @@ batch_norm_cpu_collect_stats_channels_last_impl(
       }
     });
   } else {
-    std::cout << "=== N <= num_threads ===" << std::endl;
     at::parallel_for(0, n_channel, 1, [&](int64_t begin, int64_t end) {
       for (const auto c : c10::irange(begin, end)) {
         accscalar_t sum = 0;
-        accscalar_t _var_sum = 0;
         for (const auto t : c10::irange(N)) {
-          const accscalar_t x = input_data[t * n_channel + c];
-          sum += x;
-          _var_sum += (x - (sum/N)) * (x - (sum/N));
+          sum += input_data[t * n_channel + c];
         }
-
         scalar_t mean = sum / N;
         mean_data[c] = mean;
       }
     });
-
+    
     at::parallel_for(0, n_channel, 1, [&](int64_t begin, int64_t end) {
       for (const auto c : c10::irange(begin, end)) {
         accscalar_t _var_sum = 0;
         for (const auto t : c10::irange(N)) {
-          _var_sum += (input_data[t * n_channel + c] - mean_data[c]) * ;
+          _var_sum += (input_data[t * n_channel + c] - mean_data[c]) * (input_data[t * n_channel + c] - mean_data[c]);
         }
         var_sum_data[c] = _var_sum;
       }

--- a/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
@@ -308,11 +308,8 @@ batch_norm_cpu_collect_stats_channels_last_impl(
     at::parallel_for(0, n_channel, 1, [&](int64_t begin, int64_t end) {
       for (const auto c : c10::irange(begin, end)) {
         accscalar_t sum = 0;
-        accscalar_t _var_sum = 0;
         for (const auto t : c10::irange(N)) {
-          const accscalar_t x = input_data[t * n_channel + c];
-          sum += x;
-          _var_sum += (x - (sum/N)) * (x - (sum/N));
+          sum += input_data[t * n_channel + c];
         }
         
         scalar_t mean = sum / N;


### PR DESCRIPTION
Currently `batch_norm_cpu_collect_stats_channels_last_impl` uses two-path reduction to vertical reduce from shape of `{NHW, C}` to `{C}`. First path is reduction from `{NHW, C}` to intermediate buffer `{num_threads, C}`. Second path is reduction from `{num_threads, C}` to `{C}`.

Optimization is as follows:
- Add if/else path. 

1. if `NHW > num_threads`, do the two-path reduction.  
2. else `NHW <= num_threads`, do single-path reduction -- `NHW` is small enough that there is no need to first reduce to intermediate buffer. 

- Moreover when `NHW <= num_threads`, use two methods, Method 1 and Method 2.
[Method 1](https://github.com/pytorch/pytorch/pull/113619/files#diff-e39a21a7125ac201b766a585b57ebf8429a7ac28cd723b09930aceb198fd25b0R372-R397): parallel on C, vertical reduce `{NHW, C} => {C}`
[Method 2](https://github.com/pytorch/pytorch/pull/113619/files#diff-e39a21a7125ac201b766a585b57ebf8429a7ac28cd723b09930aceb198fd25b0R325-R370): parallel on tiles of C, vectorized vertical reduce on each tile `{NHW, TILE_SIZE} => {TILE_SIZE}`

1. if `(num_threads == 1 || (C <= TILE_SIZE || C > THRESHOLD))`, use Method 2.
2. else, use Method 1. 

- When `num_threads == 1`, there is no thread synchronization overhead, so it is better to use Method 2 than Method 1. 
- When `C > THRESHOLD`, C is large enough that the benefit from tiling and vectorization outweigh the synchronization overhead.
- When `C <= TILE_SIZE`, the problem size is small enough (`C <= TILE_SIZE && NHW <= num_threads`) that it's better to launch single thread with vectorization than C threads without vectorization.
- `TILE_SIZE` is set to `16`.
- `THRESHOLD` is set to `2048`, it is an empirically found threshold to tile on C or not.

See comments for details.

### Performance

Perf data collected for C in range [2^1, 2^20], and (N,H,W) = (1,2,14) for all values of C. Values of (N,H,W)=(1,2,14) were arbitrarily chosen that satisfies the condition NHW <= num_threads = 28.
Tested on 28 physical cores/socket, 1 socket on Skylake.

| **(N, H, W) = (1, 2, 14)** 	|                                                            	|               	|                                        	|
|----------------------------	|------------------------------------------------------------	|---------------	|----------------------------------------	|
|                            	| **Avg Latency (ms)**                                       	|               	|                                        	|
| **n_channel**              	| **Baseline (original implementation): two-path reduction** 	| **Optimized** 	| **Speedup Ratio (Baseline/Optimized)** 	|
| 1048576                    	| 13.67034435                                                	| 3.059654236   	| 4.467937649                            	|
| 524288                     	| 5.230793953                                                	| 0.840408802   	| 6.224106578                            	|
| 262144                     	| 2.131233215                                                	| 0.353398323   	| 6.030682876                            	|
| 131072                     	| 0.990390778                                                	| 0.213630199   	| 4.636005491                            	|
| 65536                      	| 0.422859192                                                	| 0.107388496   	| 3.937658186                            	|
| 32768                      	| 0.224406719                                                	| 0.075747967   	| 2.962544459                            	|
| 16384                      	| 0.143647194                                                	| 0.049884319   	| 2.879606175                            	|
| 8192                       	| 0.10917902                                                 	| 0.031619072   	| 3.452948273                            	|
| 4096                       	| 0.08869648                                                 	| 0.024063587   	| 3.685920935                            	|
| 2048                       	| 0.075721741                                                	| 0.022127628   	| 3.422045038                            	|
| 1024                       	| 0.06685257                                                 	| 0.018239021   	| 3.665359477                            	|
| 512                        	| 0.051283836                                                	| 0.017580986   	| 2.917005696                            	|
| 256                        	| 0.043172836                                                	| 0.020868778   	| 2.06877642                             	|
| 128                        	| 0.042669773                                                	| 0.018148422   	| 2.351156069                            	|
| 64                         	| 0.038774014                                                	| 0.015704632   	| 2.468954                               	|
| 32                         	| 0.038630962                                                	| 0.013871193   	| 2.784977656                            	|
| 16                         	| 0.027766228                                                	| 0.008444786   	| 3.287972897                            	|
| 8                          	| 0.019891262                                                	| 0.007579327   	| 2.624410192                            	|
| 4                          	| 0.018217564                                                	| 0.008151531   	| 2.234863995                            	|
| 2                          	| 0.017716885                                                	| 0.008127689   	| 2.179818128                            	|

### Single Thread Performance
Perf data collected for C in range [2^1, 2^20], and (N,H,W) = (1,1,1) for all values of C. Values of (N,H,W)=(1,1,1) were chosen to satisfy the condition NHW <= num_threads = 1 for single thread performance.
Tested on 1 physical core/socket, 1 socket on Skylake.

| **(N, H, W) = (1, 1, 1)** 	|                                                            	|               	|                                        	|
|---------------------------	|------------------------------------------------------------	|---------------	|----------------------------------------	|
|                           	| **Avg Latency (ms)**                                       	|               	|                                        	|
| **n_channel**             	| **Baseline (original implementation): two-path reduction** 	| **Optimized** 	| **Speedup Ratio (Baseline/Optimized)** 	|
| 1048576                   	| 10.97419                                                   	| 8.390961      	| 1.307859                               	|
| 524288                    	| 4.860618                                                   	| 4.128075      	| 1.177454                               	|
| 262144                    	| 2.782302                                                   	| 1.981447      	| 1.404177                               	|
| 131072                    	| 2.105565                                                   	| 1.073592      	| 1.961234                               	|
| 65536                     	| 0.857651                                                   	| 0.523462      	| 1.63842                                	|
| 32768                     	| 0.309389                                                   	| 0.247979      	| 1.24764                                	|
| 16384                     	| 0.13869                                                    	| 0.098376      	| 1.409796                               	|
| 8192                      	| 0.072258                                                   	| 0.050876      	| 1.420263                               	|
| 4096                      	| 0.038414                                                   	| 0.027308      	| 1.40667                                	|
| 2048                      	| 0.021684                                                   	| 0.015688      	| 1.382219                               	|
| 1024                      	| 0.013294                                                   	| 0.009842      	| 1.350775                               	|
| 512                       	| 0.008659                                                   	| 0.006645      	| 1.303193                               	|
| 256                       	| 0.006964                                                   	| 0.005393      	| 1.291335                               	|
| 128                       	| 0.005918                                                   	| 0.00464       	| 1.275437                               	|
| 64                        	| 0.005324                                                   	| 0.004292      	| 1.240556                               	|
| 32                        	| 0.004981                                                   	| 0.004163      	| 1.196449                               	|
| 16                        	| 0.004833                                                   	| 0.003943      	| 1.225514                               	|
| 8                         	| 0.004768                                                   	| 0.003896      	| 1.22399                                	|
| 4                         	| 0.004828                                                   	| 0.003955      	| 1.220615                               	|
| 2                         	| 0.004776                                                   	| 0.003934      	| 1.213939                               	|

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10