### PR TITLE
[pytorch-vulkan][1/n] Enable Packing for Vulkan Tensors

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/extract_texel.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/extract_texel.glsl
@@ -1,0 +1,28 @@
+#version 450 core
+#define PRECISION $precision
+#define FORMAT $format
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3D uOutputX;
+layout(set = 0, binding = 1, FORMAT) uniform PRECISION restrict writeonly image3D uOutputY;
+layout(set = 0, binding = 2, FORMAT) uniform PRECISION restrict writeonly image3D uOutputZ;
+layout(set = 0, binding = 3, FORMAT) uniform PRECISION restrict writeonly image3D uOutputW;
+
+layout(set = 0, binding = 4) uniform PRECISION sampler3D uInput;
+
+layout(set = 0, binding = 5) uniform PRECISION restrict Block {
+  ivec3 pos;
+} uBlock;
+
+void main() {
+    vec4 texel = texelFetch(uInput, uBlock.pos, 0);
+
+    ivec3 out_pos = ivec3(0, 0, 0);
+
+    imageStore(uOutputX, out_pos, vec4(texel.x, 0.0, 0.0, 0.0));
+    imageStore(uOutputY, out_pos, vec4(texel.y, 0.0, 0.0, 0.0));
+    imageStore(uOutputZ, out_pos, vec4(texel.z, 0.0, 0.0, 0.0));
+    imageStore(uOutputW, out_pos, vec4(texel.w, 0.0, 0.0, 0.0));
+}

--- a/aten/src/ATen/native/vulkan/ops/Utils.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Utils.cpp
@@ -17,6 +17,8 @@ namespace ops {
 
 namespace utils {
 
+using namespace api::utils;
+
 /*
  * This function formats an input tensor in NCHW layout to NC4HW layout such
  * that the buffer of the formatted tensor can be directly copied into a GPU
@@ -311,6 +313,67 @@ std::vector<int64_t> broadcast_size(const Tensor& t1, const Tensor& t2) {
   }
 
   return out;
+}
+
+api::utils::vec4 extract_texel(const Tensor& input, const ivec3& pos) {
+  api::Context* const context = api::context();
+
+  TORCH_CHECK(input.is_vulkan());
+  const vTensor& v_input = convert(input);
+
+  api::PipelineBarrier pipeline_barrier{};
+
+  std::vector<int64_t> output_size{1, 1, 1};
+
+  // x, y, z, w all using a single element tensor. We intend to pull
+  // (0, 0, 0).x from each tensor. This allows us to isolate the effect
+  // of most packing mechanism.
+  vTensor v_outputs_x{context, output_size, input.scalar_type()};
+  vTensor v_outputs_y{context, output_size, input.scalar_type()};
+  vTensor v_outputs_z{context, output_size, input.scalar_type()};
+  vTensor v_outputs_w{context, output_size, input.scalar_type()};
+
+  const struct Block final {
+    ivec3 pos;
+  } block{
+      pos,
+  };
+
+  api::UniformParamsBuffer params(context, block);
+
+  context->submit_compute_job(
+      VK_KERNEL(extract_texel),
+      pipeline_barrier,
+      {1, 1, 1},
+      {1, 1, 1},
+      VK_NULL_HANDLE,
+      v_outputs_x.image(
+          pipeline_barrier,
+          api::PipelineStage::COMPUTE,
+          api::MemoryAccessType::WRITE),
+      v_outputs_y.image(
+          pipeline_barrier,
+          api::PipelineStage::COMPUTE,
+          api::MemoryAccessType::WRITE),
+      v_outputs_z.image(
+          pipeline_barrier,
+          api::PipelineStage::COMPUTE,
+          api::MemoryAccessType::WRITE),
+      v_outputs_w.image(
+          pipeline_barrier,
+          api::PipelineStage::COMPUTE,
+          api::MemoryAccessType::WRITE),
+      v_input.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      params.buffer());
+
+  vec4 rv = {
+      convert(v_outputs_x).cpu().data_ptr<float>()[0],
+      convert(v_outputs_y).cpu().data_ptr<float>()[0],
+      convert(v_outputs_z).cpu().data_ptr<float>()[0],
+      convert(v_outputs_w).cpu().data_ptr<float>()[0],
+  };
+
+  return rv;
 }
 
 } // namespace utils

--- a/aten/src/ATen/native/vulkan/ops/Utils.h
+++ b/aten/src/ATen/native/vulkan/ops/Utils.h
@@ -54,6 +54,14 @@ bool pack_vtensor_to_staging(
 void is_broadcastable(const Tensor& input1, const Tensor& input2);
 std::vector<int64_t> broadcast_size(const Tensor& t1, const Tensor& t2);
 
+// This function returns the value of the underlying texel at pos of the given
+// tensor. It is useful for debugging and unit test at which we want to verify
+// the actual tensor layout. This function is very slow as it involves a fench
+// to extract just one value.
+api::utils::vec4 extract_texel(
+    const Tensor& tensor,
+    const api::utils::ivec3& pos);
+
 } // namespace utils
 } // namespace ops
 } // namespace vulkan

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -3298,6 +3298,24 @@ TEST_F(VulkanAPITest, mm) {
   ASSERT_TRUE(check);
 }
 
+TEST_F(VulkanAPITest, DISABLED_mm_m2_vulkan) {
+  const auto m1_cpu = at::rand({179, 67}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto m2_cpu = at::rand({67, 163}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto out_cpu = m1_cpu.mm(m2_cpu);
+
+  const auto m1_vulkan = m1_cpu.vulkan();
+  // When m2 is a vulkan, the current implementation forgot
+  // to pre-pack the m2 tensor, yielding wrong results.
+  const auto out_vulkan = m1_vulkan.mm(m2_cpu.vulkan());
+
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
 TEST_F(VulkanAPITest, mm_error) {
   // mismatched dimensions of m1 and m2.
   const auto m1_cpu = at::rand({179, 99}, at::device(at::kCPU).dtype(at::kFloat));
@@ -4765,7 +4783,7 @@ TEST_F(VulkanAPITest, normal_) {
 
 TEST_F(VulkanAPITest, normal_large) {
   float a_mean = 1.0;
-  float a_std = 0.001;
+  float a_std = 0.01;
 
   auto a_vulkan =
       at::zeros({30, 40, 50, 60}, at::device(at::kCPU).dtype(at::kFloat)).vulkan();

--- a/aten/src/ATen/test/vulkan_quantized_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_quantized_api_test.cpp
@@ -4,6 +4,7 @@
 #include <ATen/core/dispatch/Dispatcher.h>
 #include <ATen/native/quantized/cpu/QuantUtils.h>
 #include <ATen/native/vulkan/api/api.h>
+#include <ATen/native/vulkan/api/Utils.h>
 #include <ATen/native/vulkan/ops/Common.h>
 #include <ATen/native/vulkan/ops/Copy.h>
 #include <ATen/native/vulkan/ops/Factory.h>
@@ -13,6 +14,8 @@
 #include <gtest/gtest.h>
 #include <cstring>
 #include <random>
+#include <math.h>
+#include <iostream>
 #include <ATen/native/quantized/PackedParams.h>
 
 #include <cstdio>
@@ -27,6 +30,12 @@ using namespace at::native::vulkan::api::utils;
  */
 
 namespace {
+
+#ifdef USE_VULKAN_FP16_INFERENCE
+  constexpr float kTolerance = 1e-2;
+#else
+  constexpr float kTolerance = 1e-5;
+#endif
 
 bool checkRtol(
     const at::Tensor& diff,
@@ -125,6 +134,27 @@ inline std::vector<c10::IValue> callOpByName(
   assert(op_handle.has_value());
   return callOpByHandle(op_handle.value(), std::forward<Args>(args)...);
 }
+
+using namespace at::native::vulkan;
+using at::native::vulkan::api::utils::vec4;
+using at::native::vulkan::api::utils::ivec3;
+using at::native::vulkan::api::utils::ivec4;
+
+std::ostream& operator<<(std::ostream& os, const vec4& v) {
+  os << "(" << v.data[0u] << ", " << v.data[1u] << ", " << v.data[2u] << ", " << v.data[3u] << ")";
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const ivec3& v) {
+  os << "(" << v.data[0u] << ", " << v.data[1u] << ", " << v.data[2u] << ")";
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const ivec4& v) {
+  os << "(" << v.data[0u] << ", " << v.data[1u] << ", " << v.data[2u] << ")";
+  return os;
+}
+
 
 } // namespace
 
@@ -3301,6 +3331,78 @@ TEST_F(VulkanAPITest, linear_4d_large) {
   test_quantized_linear({9, 13, 11, 17}, {23, 17}, {23});
 }
 
+// The following code is not directly releated to quantization. We put it here
+// since we are not able to run this test on GH's CI: for some unknown reason,
+// we are not able to reference symbols in the vulkan directory, hence the build
+// on GH fails. Moving the test here so we are still able to run it on
+// internally on devserver and laptops.
+
+bool texel_almost_equal(int expected, float actual) {
+  // -1 is a don't care value.
+  return (expected == -1) || (fabs(expected - actual) < kTolerance);
+}
+
+bool texel_almost_equal(const ivec4& expected, const vec4& actual) {
+  return (
+      texel_almost_equal(expected.data[0], actual.data[0]) &&
+      texel_almost_equal(expected.data[1], actual.data[1]) &&
+      texel_almost_equal(expected.data[2], actual.data[2]) &&
+      texel_almost_equal(expected.data[3], actual.data[3]));
+}
+
+TEST_F(VulkanAPITest, extract_texel_test) {
+  int n = 3;
+  int c = 5;
+  int h = 6;
+  int w = 7;
+  int hw = h * w;
+  int chw = c * h * w;
+
+  // The input tensor is a consecutive range of whole numbers from [0, n * c * h
+  // * w)
+  auto cpu =
+      at::range(0, n * c * h * w - 1, at::device(at::kCPU).dtype(at::kFloat))
+          .reshape({n, c, h, w});
+  auto vk = cpu.vulkan();
+
+  // By default, we are using channel-packed 3d tensors.
+  // The x and y are typical plane.
+  // The z channel is packed with batch and channel, e.g. every 4 channels are
+  // packed into one texel. Hence, to access a tensor at batch nn and channel
+  // cc, we will calculate the z coordinate = nn * ceil(c / 4) + cc / 4, where c
+  // is the channel count.
+  // We always start a new batch on a new z. Hence, when c cannot be divided by
+  // 4, there are some undefined values in the padding area. We use -1 to
+  // indicate that we are not performing comparsion on those values.
+  std::tuple<ivec3, ivec4> test_cases[]{
+      {{0, 0, 0}, {0, hw, 2 * hw, 3 * hw}},
+      {{1, 0, 0}, {1, hw + 1, 2 * hw + 1, 3 * hw + 1}},
+      {{0, 0, 1}, {4 * hw, -1, -1, -1}},
+      {{0, 0, 2}, {chw, chw + hw, chw + 2 * hw, chw + 3 * hw}},
+      {{0, 1, 2}, {chw + w, chw + hw + w, chw + 2 * hw + w, chw + 3 * hw + w}},
+      {{0, 0, 3}, {chw + 4 * hw, -1, -1, -1}},
+      {{0, 1, 3}, {chw + 4 * hw + w, -1, -1, -1}},
+      {{0, 0, 4}, {2 * chw, 2 * chw + hw, 2 * chw + 2 * hw, 2 * chw + 3 * hw}},
+      {{0, 1, 4},
+       {2 * chw + w,
+        2 * chw + hw + w,
+        2 * chw + 2 * hw + w,
+        2 * chw + 3 * hw + w}},
+  };
+
+  bool has_failure = false;
+  for (const auto& test_case : test_cases) {
+    const auto [loc, expected] = test_case;
+
+    vec4 actual = ops::utils::extract_texel(vk, loc);
+    if (!texel_almost_equal(expected, actual)) {
+      std::cout << "On loc: " << loc << " expected: " << expected
+                << " actual: " << actual << std::endl;
+      has_failure = true;
+    }
+  }
+  ASSERT_FALSE(has_failure);
+}
 } // namespace
 
 #endif /* USE_VULKAN_API */


### PR DESCRIPTION
Summary:
The new implementation of mat-mul missed a critical step that does width-packing on GPU: see T169764697.

The existing implementation of mat-mul also missed a case when the "B" matrix is already in vulkan, it fails to do packing, leading to wrong results. (I have added a disabled unittest to reflect the issue).

We will take multiple steps to enable (width / height) packing and transformation between different packing on Vulkan.

This is a first diff that enable a critical toolset: It allows development to fetch values from the underlying tensor, making it possible to implement tests for the transformation shaders.

Test Plan:
P882053410,
P882053410

Differential Revision: D51291737


