### PR TITLE
[PT-D] Made `_get_registry` return `None` if no APIs applied

### DIFF
--- a/test/distributed/_composable/test_contract.py
+++ b/test/distributed/_composable/test_contract.py
@@ -132,6 +132,8 @@ class TestContract(TestCase):
         model = api2(model)
         self.assertEqual(2, len(_get_registry(model)))
         self.assertTrue([_get_registry(model).keys()], ["api1", "api2"])
+        self.assertEqual(None, _get_registry(model.seq1))
+        self.assertEqual(None, _get_registry(model.seq2))
 
         with self.assertRaisesRegex(AssertionError, "api1 has already been applied"):
             model = api1(model)

--- a/torch/distributed/_composable/contract.py
+++ b/torch/distributed/_composable/contract.py
@@ -185,16 +185,10 @@ def contract(state_cls: Type[_State] = _State):
     return inner
 
 
-def _get_registry(module: nn.Module) -> Dict[str, RegistryItem]:
+def _get_registry(module: nn.Module) -> Optional[Dict[str, RegistryItem]]:
     r"""
     Get an ``OrderedDict`` of composable APIs that have been applied to the
-    ``module``, indexed by the API name.
+    ``module``, indexed by the API name. If no API has been applied, then this
+    returns ``None``.
     """
-    registry = getattr(module, REGISTRY_KEY, None)
-    if registry is None:
-        # https://github.com/pytorch/pytorch/issues/107054
-        default_registry: Dict[str, RegistryItem] = OrderedDict()
-        setattr(module, REGISTRY_KEY, default_registry)
-        return default_registry
-    else:
-        return registry
+    return getattr(module, REGISTRY_KEY, None)

--- a/torch/distributed/_composable/replicate.py
+++ b/torch/distributed/_composable/replicate.py
@@ -139,4 +139,7 @@ def replicate(
 
 def _is_fully_sharded(module: nn.Module) -> bool:
     r"""Check if module is marked with fully_shard."""
-    return "fully_shard" in _get_registry(module)
+    registry = _get_registry(module)
+    if registry is None:
+        return False
+    return "fully_shard" in registry

--- a/torch/distributed/fsdp/_traversal_utils.py
+++ b/torch/distributed/fsdp/_traversal_utils.py
@@ -37,7 +37,10 @@ def _composable(module: nn.Module) -> bool:
     Returns if ``module`` can compose with ``fully_shard``.
     """
     # TODO: Add any other composable APIs that are mutually exclusive.
-    return "replicate" not in _get_registry(module)
+    registry = _get_registry(module)
+    if registry is None:
+        return True
+    return "replicate" not in registry
 
 
 # TODO (awgu): We may be able to remove this function if we retired the


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #112625
* __->__ #113654

I prefer to not modify the module if it does not have any of our APIs applied. The side effect of inserting a registry on the module when calling a getter is non-intuitive to me.