### PR TITLE
[quant][pt2][be] Refactor QAT tests for future patterns

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e_qat.py
+++ b/test/quantization/pt2e/test_quantize_pt2e_qat.py
@@ -574,6 +574,7 @@ class BaseTestQuantizePT2EQAT_ConvBn(PT2EQATTestCase):
         """
         Test whether `source_fn_stack` is preserved after QAT fusion.
         """
+
         class M(torch.nn.Module):
             def __init__(self, conv_class, bn_class, backbone):
                 super().__init__()

--- a/test/quantization/pt2e/test_quantize_pt2e_qat.py
+++ b/test/quantization/pt2e/test_quantize_pt2e_qat.py
@@ -41,7 +41,6 @@ from torch.testing._internal.common_quantization import (
     QuantizationTestCase,
     skip_if_no_torchvision,
     skipIfNoQNNPACK,
-    TestHelperModules,
 )
 from torch.testing._internal.common_quantized import override_quantized_engine
 
@@ -334,11 +333,16 @@ class _BaseTestQuantizePT2EQAT(PT2EQATTestCase):
 
     def _get_model(
         self,
-        has_conv_bias: bool=True,
-        has_bn: bool=True,
-        has_relu: bool=False,
+        has_conv_bias: bool = True,
+        has_bn: bool = True,
+        has_relu: bool = False,
         **conv_kwargs,
     ):
+        """
+        Return an instance of a simple test model containing the
+        conv[-bn][-relu] pattern. By default, this returns a
+        conv-bn model with conv bias.
+        """
         return self._TestModel(
             self.conv_class,
             self.bn_class,

--- a/test/quantization/pt2e/test_quantize_pt2e_qat.py
+++ b/test/quantization/pt2e/test_quantize_pt2e_qat.py
@@ -2,7 +2,7 @@
 import copy
 import operator
 import unittest
-from typing import Any, Optional, Tuple
+from typing import Any, Optional, Tuple, Type
 
 import torch
 from torch._export import capture_pre_autograd_graph
@@ -304,34 +304,65 @@ class PT2EQATTestCase(QuantizationTestCase):
         self.assertEqual(eps, 1e-5)
 
 
-@skipIfNoQNNPACK
-class TestQuantizePT2EQAT(PT2EQATTestCase):
-    def test_qat_conv_no_bias(self):
-        class M(torch.nn.Module):
-            def __init__(self, has_relu: bool):
-                super().__init__()
-                self.conv = torch.nn.Conv2d(3, 3, 3, bias=False)
-                self.relu = torch.nn.ReLU() if has_relu else torch.nn.Identity()
+class _BaseTestQuantizePT2EQAT(PT2EQATTestCase):
+    """
+    Base TestCase to be used for all conv-bn[-relu] fusion patterns.
+    """
 
-            def forward(self, x):
-                x = self.conv(x)
+    class _TestModel(torch.nn.Module):
+        def __init__(
+            self,
+            conv_class: Type[torch.nn.Module],
+            bn_class: Type[torch.nn.Module],
+            has_conv_bias: bool,
+            has_bn: bool,
+            has_relu: bool,
+            **conv_kwargs,
+        ):
+            super().__init__()
+            self.conv = conv_class(3, 3, 3, bias=has_conv_bias, **conv_kwargs)
+            self.bn = bn_class(3) if has_bn else None
+            self.relu = torch.nn.ReLU() if has_relu else None
+
+        def forward(self, x):
+            x = self.conv(x)
+            if self.bn is not None:
+                x = self.bn(x)
+            if self.relu is not None:
                 x = self.relu(x)
-                return x
+            return x
 
-        example_inputs = (torch.randn(1, 3, 5, 5),)
-        self._verify_symmetric_xnnpack_qat_numerics(M(has_relu=False), example_inputs)
-        self._verify_symmetric_xnnpack_qat_numerics(M(has_relu=True), example_inputs)
+    def _get_model(
+        self,
+        has_conv_bias: bool=True,
+        has_bn: bool=True,
+        has_relu: bool=False,
+        **conv_kwargs,
+    ):
+        return self._TestModel(
+            self.conv_class,
+            self.bn_class,
+            has_conv_bias,
+            has_bn,
+            has_relu,
+            **conv_kwargs,
+        )
+
+    def test_qat_conv_no_bias(self):
+        m1 = self._get_model(has_conv_bias=False, has_bn=False, has_relu=True)
+        m2 = self._get_model(has_conv_bias=False, has_bn=False, has_relu=False)
+        self._verify_symmetric_xnnpack_qat_numerics(m1, self.example_inputs)
+        self._verify_symmetric_xnnpack_qat_numerics(m2, self.example_inputs)
 
     def test_qat_conv_bn_fusion(self):
-        m = TestHelperModules.ConvWithBNRelu(relu=False)
-        example_inputs = (torch.randn(1, 3, 5, 5),)
-        self._verify_symmetric_xnnpack_qat_graph(m, example_inputs, has_relu=False)
-        self._verify_symmetric_xnnpack_qat_numerics(m, example_inputs)
+        m = self._get_model()
+        self._verify_symmetric_xnnpack_qat_graph(m, self.example_inputs, has_relu=False)
+        self._verify_symmetric_xnnpack_qat_numerics(m, self.example_inputs)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_qat_conv_bn_fusion_cuda(self):
-        m = TestHelperModules.ConvWithBNRelu(relu=False).cuda()
-        example_inputs = (torch.randn(1, 3, 5, 5).cuda(),)
+        m = self._get_model().cuda()
+        example_inputs = (self.example_inputs[0].cuda(),)
         self._verify_symmetric_xnnpack_qat_graph(
             m,
             example_inputs,
@@ -340,6 +371,7 @@ class TestQuantizePT2EQAT(PT2EQATTestCase):
         )
         self._verify_symmetric_xnnpack_qat_numerics(m, example_inputs)
 
+    # TODO: generalize this to other conv dimensions
     def test_qat_conv_bn_fusion_literal_args(self):
         class M(torch.nn.Module):
             def __init__(self):
@@ -369,12 +401,12 @@ class TestQuantizePT2EQAT(PT2EQATTestCase):
             Mixed conv + BN with and without conv bias.
             """
 
-            def __init__(self):
+            def __init__(self, conv_class, bn_class):
                 super().__init__()
-                self.conv1 = torch.nn.Conv2d(3, 3, 3, bias=False)
-                self.bn1 = torch.nn.BatchNorm2d(3)
-                self.conv2 = torch.nn.Conv2d(3, 3, 3, bias=True)
-                self.bn2 = torch.nn.BatchNorm2d(3)
+                self.conv1 = conv_class(3, 3, 3, bias=False)
+                self.bn1 = bn_class(3)
+                self.conv2 = conv_class(3, 3, 3, bias=True)
+                self.bn2 = bn_class(3)
 
             def forward(self, x):
                 x = self.conv1(x)
@@ -383,7 +415,8 @@ class TestQuantizePT2EQAT(PT2EQATTestCase):
                 x = self.bn2(x)
                 return x
 
-        m1 = TestHelperModules.ConvWithBNRelu(relu=False, bias=False)
+        m1 = self._get_model(has_conv_bias=False)
+        m2 = M2(self.conv_class, self.bn_class)
         example_inputs = (torch.randn(3, 3, 5, 5),)
         self._verify_symmetric_xnnpack_qat_graph(
             m1,
@@ -392,18 +425,17 @@ class TestQuantizePT2EQAT(PT2EQATTestCase):
             has_bias=False,
         )
         self._verify_symmetric_xnnpack_qat_numerics(m1, example_inputs)
-        self._verify_symmetric_xnnpack_qat_numerics(M2(), example_inputs)
+        self._verify_symmetric_xnnpack_qat_numerics(m2, example_inputs)
 
     def test_qat_conv_bn_relu_fusion(self):
-        m = TestHelperModules.ConvWithBNRelu(relu=True)
-        example_inputs = (torch.randn(1, 3, 5, 5),)
-        self._verify_symmetric_xnnpack_qat_graph(m, example_inputs, has_relu=True)
-        self._verify_symmetric_xnnpack_qat_numerics(m, example_inputs)
+        m = self._get_model(has_relu=True)
+        self._verify_symmetric_xnnpack_qat_graph(m, self.example_inputs, has_relu=True)
+        self._verify_symmetric_xnnpack_qat_numerics(m, self.example_inputs)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_qat_conv_bn_relu_fusion_cuda(self):
-        m = TestHelperModules.ConvWithBNRelu(relu=True).cuda()
-        example_inputs = (torch.randn(1, 3, 5, 5).cuda(),)
+        m = self._get_model(has_relu=True).cuda()
+        example_inputs = (self.example_inputs[0].cuda(),)
         self._verify_symmetric_xnnpack_qat_graph(
             m,
             example_inputs,
@@ -413,21 +445,20 @@ class TestQuantizePT2EQAT(PT2EQATTestCase):
         self._verify_symmetric_xnnpack_qat_numerics(m, example_inputs)
 
     def test_qat_conv_bn_relu_fusion_no_conv_bias(self):
-        m = TestHelperModules.ConvWithBNRelu(relu=True, bias=False)
-        example_inputs = (torch.randn(3, 3, 5, 5),)
+        m = self._get_model(has_conv_bias=False, has_relu=True)
         self._verify_symmetric_xnnpack_qat_graph(
             m,
-            example_inputs,
+            self.example_inputs,
             has_relu=True,
             has_bias=False,
         )
-        self._verify_symmetric_xnnpack_qat_numerics(m, example_inputs)
+        self._verify_symmetric_xnnpack_qat_numerics(m, self.example_inputs)
 
     def test_qat_inplace_add_relu(self):
         class M(torch.nn.Module):
-            def __init__(self):
+            def __init__(self, conv_class):
                 super().__init__()
-                self.conv = torch.nn.Conv2d(1, 1, 1)
+                self.conv = conv_class(1, 1, 1)
                 self.relu = torch.nn.ReLU(inplace=True)
 
             def forward(self, x):
@@ -437,8 +468,9 @@ class TestQuantizePT2EQAT(PT2EQATTestCase):
                 x = self.relu(x)
                 return x
 
+        m = M(self.conv_class)
         example_inputs = (torch.randn(1, 1, 3, 3),)
-        self._verify_symmetric_xnnpack_qat_numerics(M(), example_inputs)
+        self._verify_symmetric_xnnpack_qat_numerics(m, example_inputs)
 
     def test_prepare_qat_conv_bn_fusion_getitem_placeholder(self):
         """
@@ -453,11 +485,11 @@ class TestQuantizePT2EQAT(PT2EQATTestCase):
         """
 
         class M(torch.nn.Module):
-            def __init__(self):
+            def __init__(self, conv_class, bn_class):
                 super().__init__()
-                self.bn1 = torch.nn.BatchNorm2d(3)
-                self.conv = torch.nn.Conv2d(3, 3, 3)
-                self.bn2 = torch.nn.BatchNorm2d(3)
+                self.bn1 = bn_class(3)
+                self.conv = conv_class(3, 3, 3)
+                self.bn2 = bn_class(3)
 
             def forward(self, x):
                 x = self.bn1(x)
@@ -490,11 +522,8 @@ class TestQuantizePT2EQAT(PT2EQATTestCase):
             return (unrelated_getitem_node, conv_bn_getitem_node)
 
         # Program capture
-        example_inputs = (torch.randn(1, 3, 5, 5),)
-        m = capture_pre_autograd_graph(
-            M(),
-            example_inputs,
-        )
+        m = M(self.conv_class, self.bn_class)
+        m = capture_pre_autograd_graph(m, self.example_inputs)
         m.graph.eliminate_dead_code()
         m.recompile()
         (_, original_conv_bn_getitem_node) = _get_getitem_nodes(m)
@@ -522,10 +551,10 @@ class TestQuantizePT2EQAT(PT2EQATTestCase):
         """
 
         class M(torch.nn.Module):
-            def __init__(self):
+            def __init__(self, conv_class, bn_class):
                 super().__init__()
-                self.conv = torch.nn.Conv2d(3, 3, 3)
-                self.bn = torch.nn.BatchNorm2d(3)
+                self.conv = conv_class(3, 3, 3)
+                self.bn = bn_class(3)
                 self.hardtanh = torch.nn.Hardtanh()
 
             def forward(self, x):
@@ -534,21 +563,20 @@ class TestQuantizePT2EQAT(PT2EQATTestCase):
                 x = self.hardtanh(x)
                 return x
 
-        example_inputs = (torch.randn(1, 3, 5, 5),)
-        self._verify_symmetric_xnnpack_qat_numerics(M(), example_inputs)
+        m = M(self.conv_class, self.bn_class)
+        self._verify_symmetric_xnnpack_qat_numerics(m, self.example_inputs)
 
     def test_qat_preserve_source_fn_stack(self):
         """
         Test whether `source_fn_stack` is preserved after QAT fusion.
         """
-
         class M(torch.nn.Module):
-            def __init__(self):
+            def __init__(self, conv_class, bn_class, backbone):
                 super().__init__()
-                self.conv = torch.nn.Conv2d(5, 3, 3)
-                self.bn = torch.nn.BatchNorm2d(3)
+                self.conv = conv_class(5, 3, 3)
+                self.bn = bn_class(3)
                 self.relu = torch.nn.ReLU()
-                self.backbone = TestHelperModules.ConvWithBNRelu(relu=True)
+                self.backbone = backbone
 
             def forward(self, x):
                 x = self.conv(x)
@@ -558,7 +586,8 @@ class TestQuantizePT2EQAT(PT2EQATTestCase):
                 return x
 
         # QAT prepare + convert
-        m = M()
+        backbone = self._get_model(has_relu=True)
+        m = M(self.conv_class, self.bn_class, backbone)
         example_inputs = (torch.randn(1, 5, 10, 10),)
         quantizer = XNNPACKQuantizer()
         quantizer.set_global(get_symmetric_quantization_config(is_qat=True))
@@ -616,8 +645,8 @@ class TestQuantizePT2EQAT(PT2EQATTestCase):
         self.assertTrue("backbone" in get_source_fn(second_relu))
 
     def test_qat_conv_bn_bias_derived_qspec(self):
-        m = TestHelperModules.ConvWithBNRelu(relu=False)
-        example_inputs = (torch.randn(1, 3, 5, 5),)
+        m = self._get_model()
+        example_inputs = self.example_inputs
         m = capture_pre_autograd_graph(m, example_inputs)
         quantizer = ConvBnDerivedBiasQuantizer()
         m = prepare_qat_pt2e(m, quantizer)
@@ -663,8 +692,8 @@ class TestQuantizePT2EQAT(PT2EQATTestCase):
         self.assertEqual(bias_dtype, torch.int32)
 
     def test_qat_per_channel_weight_custom_dtype(self):
-        m = TestHelperModules.ConvWithBNRelu(relu=False)
-        example_inputs = (torch.randn(1, 3, 5, 5),)
+        m = self._get_model()
+        example_inputs = self.example_inputs
         m = capture_pre_autograd_graph(m, example_inputs)
         quantizer = ConvBnInt32WeightQuantizer()
         m = prepare_qat_pt2e(m, quantizer)
@@ -697,6 +726,21 @@ class TestQuantizePT2EQAT(PT2EQATTestCase):
         self.assertEqual(dq_qmax, 2**31 - 1)
         self.assertEqual(q_dtype, torch.int32)
         self.assertEqual(dq_dtype, torch.int32)
+
+
+# TODO: enable this in the next PR
+@skipIfNoQNNPACK
+class _TestQuantizePT2EQAT_ConvBn1d(_BaseTestQuantizePT2EQAT):
+    example_inputs = (torch.randn(1, 3, 5),)
+    conv_class = torch.nn.Conv1d
+    bn_class = torch.nn.BatchNorm1d
+
+
+@skipIfNoQNNPACK
+class TestQuantizePT2EQAT_ConvBn2d(_BaseTestQuantizePT2EQAT):
+    example_inputs = (torch.randn(1, 3, 5, 5),)
+    conv_class = torch.nn.Conv2d
+    bn_class = torch.nn.BatchNorm2d
 
 
 def _get_conv_bn_getitem_nodes(model: torch.fx.GraphModule):

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -90,7 +90,9 @@ try:
     from quantization.pt2e.test_xnnpack_quantizer import TestXNNPACKQuantizer  # noqa: F401
     from quantization.pt2e.test_xnnpack_quantizer import TestXNNPACKQuantizerModels  # noqa: F401
     from quantization.pt2e.test_x86inductor_quantizer import TestQuantizePT2EX86Inductor  # noqa: F401
-    from quantization.pt2e.test_quantize_pt2e_qat import TestQuantizePT2EQAT  # noqa: F401
+    # TODO: enable this in the next PR
+    # from quantization.pt2e.test_quantize_pt2e_qat import TestQuantizePT2EQAT_ConvBn1d  # noqa: F401
+    from quantization.pt2e.test_quantize_pt2e_qat import TestQuantizePT2EQAT_ConvBn2d  # noqa: F401
     from quantization.pt2e.test_quantize_pt2e_qat import TestQuantizePT2EQATModels  # noqa: F401
 except ImportError as e:
     # In FBCode we separate PT2 out into a separate target for the sake of dev

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -90,6 +90,7 @@ try:
     from quantization.pt2e.test_xnnpack_quantizer import TestXNNPACKQuantizer  # noqa: F401
     from quantization.pt2e.test_xnnpack_quantizer import TestXNNPACKQuantizerModels  # noqa: F401
     from quantization.pt2e.test_x86inductor_quantizer import TestQuantizePT2EX86Inductor  # noqa: F401
+    # TODO: Figure out a way to merge all QAT tests in one TestCase
     # TODO: enable this in the next PR
     # from quantization.pt2e.test_quantize_pt2e_qat import TestQuantizePT2EQAT_ConvBn1d  # noqa: F401
     from quantization.pt2e.test_quantize_pt2e_qat import TestQuantizePT2EQAT_ConvBn2d  # noqa: F401


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #113714
* #113709
* __->__ #113658

Summary: Currently the QAT tests are very specific to conv-bn-2d.
This makes it difficult to test new patterns like conv-bn-1d if
we want to add them. This commit refactors these tests so we can
add and test future patterns easily.

Test Plan:
python test/test_quantization.py TestQuantizePT2EQAT_ConvBn2d

Reviewers: jerryzh168, kimishpatel

Subscribers: jerryzh168, kimishpatel, supriyar