### PR TITLE
[easy] encapsulate fb changes from OSS

### DIFF
--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -49,7 +49,7 @@ def lazy_init():
     from . import efficient_conv_bn_eval, split_cat  # noqa: F401  # noqa: F401
 
     if config.is_fbcode():
-        from .fb import split_cat as split_cat_fb  # type: ignore[import]  # noqa: F401
+        from . import fb  # type: ignore[import]  # noqa: F401
 
 
 def pre_grad_passes(gm: torch.fx.GraphModule, example_inputs):


### PR DESCRIPTION
Summary:
encapsulate fb changes into `torch._inductor.fx_passes.fb`, so that adding new passes (`fb.xxx`) won't need to touch OSS code like so:

```
# in torch/_inductor/fx_passes/pre_grad.py
if config.is_fbcode():
 from .fb import xxx  # every new fb/xxx.py would have needed this change in OSS code base
```

Test Plan: CI

Differential Revision: D51315193



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler