### PR TITLE
[export] use dynamo's fake_mode in result_capturing_wrapper

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1179,13 +1179,7 @@ def export(
                 named_parameters = dict(graph.named_parameters(remove_duplicate=False))
                 named_buffers = dict(graph.named_buffers(remove_duplicate=False))
 
-                ambient_fake_mode = (
-                    _guards.detect_fake_mode(graph_inputs)
-                    if _guards.detect_fake_mode(graph_inputs) is not None
-                    else fake_mode
-                )
-
-                with ambient_fake_mode, enable_python_dispatcher():
+                with fake_mode, enable_python_dispatcher():
                     params_and_buffers = {
                         **dict(named_parameters),
                         **dict(named_buffers),
@@ -1193,12 +1187,12 @@ def export(
                     fake_params_buffers = dict()
 
                     for name, value in params_and_buffers.items():
-                        fake_params_buffers[name] = ambient_fake_mode.from_tensor(
+                        fake_params_buffers[name] = fake_mode.from_tensor(
                             value, static_shapes=True
                         )
 
                     fake_graph_inputs = pytree.tree_map(
-                        ambient_fake_mode.from_tensor, graph_inputs
+                        fake_mode.from_tensor, graph_inputs
                     )
                     graph_captured_result = torch.func.functional_call(
                         graph, fake_params_buffers, fake_graph_inputs


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #113680

From the discussion in https://github.com/pytorch/pytorch/pull/107271, it seems that uniformity of the fake_mode is desirable (i.e. we should use dynamo's fake_mode through the export stack). This PR changes the result_capturing_wrapper to use dynamo's fake_mode instead of user's fake_mode.

Test Plan:
existing tests.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng