### PR TITLE
ci: Add clickable PR link to trymerge

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1927,7 +1927,8 @@ def merge(
     ignore_current: bool = False,
 ) -> None:
     initial_commit_sha = pr.last_commit()["oid"]
-    print(f"Attempting merge of {initial_commit_sha}")
+    pr_link = f"https://github.com/{pr.org}/{pr.project}/pull/{pr.pr_num}"
+    print(f"Attempting merge of {initial_commit_sha} ({pr_link})")
 
     if MERGE_IN_PROGRESS_LABEL not in pr.get_labels():
         gh_add_labels(pr.org, pr.project, pr.pr_num, [MERGE_IN_PROGRESS_LABEL])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #113712

Adds a link to trymerge so that you can quickly click through the job to
the pull request for debugging.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>