### PR TITLE
Drop dynamo-specific type hints on Tensor in favor of type-ignores

### DIFF
--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -249,9 +249,9 @@ def mark_static_address(t, guard=True):
         raise TypeError(f"mark_static_address expects a tensor but recieved {type(t)}")
 
     if guard:
-        t._dynamo_static_input_type = "guarded"
+        t._dynamo_static_input_type = "guarded"  # type: ignore[attr-defined]
     else:
-        t._dynamo_static_input_type = "unguarded"
+        t._dynamo_static_input_type = "unguarded"  # type: ignore[attr-defined]
 
 
 # Note: this carefully avoids eagerly import einops.

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -635,7 +635,7 @@ def clone_input(x, *, dtype=None):
         if x.is_leaf and x.grad is not None:
             y.grad = clone_input(x.grad, dtype=dtype)
         if hasattr(x, "_dynamo_dynamic_indices"):
-            y._dynamo_dynamic_indices = x._dynamo_dynamic_indices.copy()
+            y._dynamo_dynamic_indices = x._dynamo_dynamic_indices.copy()  # type: ignore[attr-defined]
         return y
 
     with torch.no_grad():
@@ -668,7 +668,7 @@ def clone_input(x, *, dtype=None):
             # performing the operation.
             return torch_clone(x)
         if hasattr(x, "_dynamo_dynamic_indices"):
-            result._dynamo_dynamic_indices = x._dynamo_dynamic_indices.copy()
+            result._dynamo_dynamic_indices = x._dynamo_dynamic_indices.copy()  # type: ignore[attr-defined]
         return result
 
 

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -79,9 +79,6 @@ def _rebuild_from_type_v2(func, new_type, args, state):
 # torch/_C/__init__.pyi.in to add a type annotation for your method;
 # otherwise, it will not show up in autocomplete.
 class Tensor(torch._C.TensorBase):
-    _dynamo_static_input_type: str  # Set in `mark_static_address`
-    _dynamo_dynamic_indices: Set[int]  # Set in `mark_dynamic`
-
     def __deepcopy__(self, memo):
         if has_torch_function_unary(self):
             return handle_torch_function(Tensor.__deepcopy__, (self,), self, memo)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #113722
* #113721
* __->__ #113720
* #113610
* #113534

Per [this][1] discussion, plus some offline discussion. The summary:
@albanD considers the core PyTorch types like Tensor to be extremely
brittle, and does not think the risk of adding these typed attributes to
be worth it.

@eellison mentioned that we could use `WeakTensorKeyDictionary` instead.
However, based on the sparse usage of these bonus attributes, I think
that would be overkill. So I've opted to go with a few more type-ignore
comments instead.

[1]: https://github.com/pytorch/pytorch/pull/113610#discussion_r1392907367

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng