### PR TITLE
[export] correctly query `__getstate__` in custom class serialization

### DIFF
--- a/test/cpp/jit/test_custom_class_registrations.cpp
+++ b/test/cpp/jit/test_custom_class_registrations.cpp
@@ -274,6 +274,10 @@ struct ReLUClass : public torch::CustomClassHolder {
   }
 };
 
+at::Tensor take_another_instance(
+    const c10::intrusive_ptr<ElementwiseInterpreter>& instance){
+    return torch::zeros({2, 3})}
+
 TORCH_LIBRARY(_TorchScriptTesting, m) {
   m.class_<ScalarTypeClass>("_ScalarTypeClass")
       .def(torch::init<at::ScalarType>())
@@ -414,6 +418,9 @@ TORCH_LIBRARY(_TorchScriptTesting, m) {
   // test that schema inference is ok too
   m.def("take_an_instance_inferred", take_an_instance);
 
+  m.def(
+      "take_another_instance(__torch__.torch.classes._TorchScriptTesting._ElementwiseInterpreter x) -> Tensor Y",
+      take_another_instance);
   m.class_<ElementwiseInterpreter>("_ElementwiseInterpreter")
       .def(torch::init<>())
       .def("set_instructions", &ElementwiseInterpreter::setInstructions)

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -653,11 +653,11 @@ class GraphModuleSerializer:
             return Argument.create(as_layout=_TORCH_TO_SERIALIZE_LAYOUT[arg])
         elif isinstance(arg, torch._C.ScriptObject):
             if not (
-                hasattr(type(arg), "__getstate__") and
-                hasattr(type(arg), "__setstate__")
+                arg._has_method("__getstate__") and
+                arg._has_method("__setstate__")
             ):
                 raise SerializeError(
-                    f"Unable to serialize ScriptObject {arg}. Please define "
+                    f"Unable to serialize custom class '{arg}'. Please define "
                     "serialization methods via def_pickle()."
                 )
             # Custom objects through torchind are serializable with pickle,


### PR DESCRIPTION
Summary: the existing check always return true; I'm not sure why. Anyway ScriptObject has a `_has_method` method for cases like this.

Test Plan: added a unit test

Differential Revision: D51332101




cc @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan @angelayi @ydwu4