### PR TITLE
[Inductor] Refactor group/batch fusion to support user defined execution order and configs

### DIFF
--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -224,7 +224,7 @@ class MyModule7(torch.nn.Module):
 
 
 @requires_cuda()
-@torch._inductor.config.patch(group_fusion=True, batch_fusion=True)
+@torch._inductor.config.patch(post_grad_fusion_options={"group_linear": {}})
 class TestGroupBatchFusion(TestCase):
     def compare_dict_tensors(self, ref_dict, res_dict, rtol=1e-3, atol=1e-3):
         if len(set(ref_dict.keys())) != len(set(res_dict.keys())):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -85,11 +85,25 @@ split_cat_fx_passes = True
 # Optimize conv-batchnorm if batchnorm is in eval mode. Slightly reduces numerical stability.
 efficient_conv_bn_eval_fx_passes = False
 
-# enable pattern match with group fusion (using fbgemm)
+# Deprecated
 group_fusion = False
 
-# enable pattern match with batch fusion (using torch op)
+# Deprecated
 batch_fusion = True
+
+# Pre grad group/batch fusion and options in order, set to empty dict to disable fusion.
+# Call `torch._inductor.fx_passes.group_batch_fusion.list_group_batch_fusions()` to see available fusions.
+pre_grad_fusion_options = {
+    "batch_linear": {},
+    "batch_linear_lhs": {},
+    "batch_layernorm": {},
+    "batch_tanh": {},
+    "batch_relu": {},
+}
+
+# Post grad group/batch fusion and options, set to empty dict to disable fusion.
+# Call `torch._inductor.fx_passes.group_batch_fusion.list_group_batch_fusions(False)` to see available fusions.
+post_grad_fusion_options = {}
 
 # enable reordering pass for improving memory locality
 reorder_for_locality = True

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1,6 +1,6 @@
 import os  # noqa: C101
 import sys
-from typing import TYPE_CHECKING
+from typing import Any, Dict, TYPE_CHECKING
 
 import torch
 
@@ -93,7 +93,7 @@ batch_fusion = True
 
 # Pre grad group/batch fusion and options in order, set to empty dict to disable fusion.
 # Call `torch._inductor.fx_passes.group_batch_fusion.list_group_batch_fusions()` to see available fusions.
-pre_grad_fusion_options = {
+pre_grad_fusion_options: Dict[str, Dict[str, Any]] = {
     "batch_linear": {},
     "batch_linear_lhs": {},
     "batch_layernorm": {},
@@ -103,7 +103,7 @@ pre_grad_fusion_options = {
 
 # Post grad group/batch fusion and options, set to empty dict to disable fusion.
 # Call `torch._inductor.fx_passes.group_batch_fusion.list_group_batch_fusions(False)` to see available fusions.
-post_grad_fusion_options = {}
+post_grad_fusion_options: Dict[str, Dict[str, Any]] = {}
 
 # enable reordering pass for improving memory locality
 reorder_for_locality = True

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -80,9 +80,9 @@ def register_fusion(name: str, pre_grad=True):
 
 def list_group_batch_fusions(pre_grad=True) -> List[str]:
     if pre_grad:
-        return PRE_GRAD_FUSIONS.keys()
+        return list(PRE_GRAD_FUSIONS.keys())
     else:
-        return POST_GRAD_FUSIONS.keys()
+        return list(POST_GRAD_FUSIONS.keys())
 
 
 class GroupFusion(GroupBatchFusionBase):
@@ -714,7 +714,7 @@ def generate_fusion_from_config(config_options: Dict[str, Any], pre_grad=True):
         fusion_cls = PRE_GRAD_FUSIONS[name] if pre_grad else POST_GRAD_FUSIONS[name]
         _options = graph_search_options.copy()
         _options.update(options)
-        fusions.append(fusion_cls(graph_search_options=_options))  # type: ignore
+        fusions.append(fusion_cls(graph_search_options=_options))  # type: ignore[operator]
     return fusions
 
 

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -1,7 +1,7 @@
 import collections
 import logging
 import operator
-from typing import Any, DefaultDict, Deque, Iterator, List, Optional, Set, Tuple
+from typing import Any, DefaultDict, Deque, Dict, Iterator, List, Optional, Set, Tuple
 
 import torch
 from torch._dynamo.utils import counters
@@ -40,12 +40,49 @@ MAX_FUSE_TENSOR_SIZE_GROUP_LINEAR = 4096
 SEARCH_EXCLUSIONS = {operator.getitem}
 
 
+default_graph_search_options = {
+    "min_fuse_set_size": MIN_FUSE_SET_SIZE,
+    "max_fuse_set_size": MAX_FUSE_SET_SIZE,
+    "max_fuse_search_depth": MAX_FUSE_SEARCH_DEPTH,
+    "max_fuse_tensor_size_group_linear": MAX_FUSE_TENSOR_SIZE_GROUP_LINEAR,
+}
+
+graph_search_options = default_graph_search_options
+
+
 class GroupBatchFusionBase:
+    def __init__(self, **kwargs):
+        self.graph_search_options = kwargs.pop(
+            "graph_search_options", default_graph_search_options
+        )
+
     def match(self, node):
         raise NotImplementedError("match called on base")
 
     def fuse(self, graph, subset):
         raise NotImplementedError("fuse called on base")
+
+
+PRE_GRAD_FUSIONS: Dict[str, GroupBatchFusionBase] = dict()
+POST_GRAD_FUSIONS: Dict[str, GroupBatchFusionBase] = dict()
+
+
+def register_fusion(name: str, pre_grad=True):
+    def decorator(fusion_cls: GroupBatchFusionBase):
+        if pre_grad:
+            PRE_GRAD_FUSIONS[name] = fusion_cls
+        else:
+            POST_GRAD_FUSIONS[name] = fusion_cls
+        return fusion_cls
+
+    return decorator
+
+
+def list_group_batch_fusions(pre_grad=True) -> List[str]:
+    if pre_grad:
+        return [x for x in PRE_GRAD_FUSIONS.keys()]
+    else:
+        return [x for x in POST_GRAD_FUSIONS.keys()]
 
 
 class GroupFusion(GroupBatchFusionBase):
@@ -64,6 +101,7 @@ class BatchFusion(GroupBatchFusionBase):
     pass
 
 
+@register_fusion("group_linear", pre_grad=False)
 class GroupLinearFusion(GroupFusion):
     def _addmm_node_can_be_fused(self, node: torch.fx.Node):
         input_shape = node.args[1].meta["tensor_meta"].shape
@@ -75,7 +113,7 @@ class GroupLinearFusion(GroupFusion):
             and len(weight_shape) == 2
             and all(x % 2 == 0 for x in input_shape + weight_shape)
             and all(
-                shape <= MAX_FUSE_TENSOR_SIZE_GROUP_LINEAR
+                shape <= self.graph_search_options["max_fuse_tensor_size_group_linear"]
                 for shape in input_shape + weight_shape
             )
         )
@@ -88,7 +126,7 @@ class GroupLinearFusion(GroupFusion):
             and len(weight_shape) == 2
             and all(x % 2 == 0 for x in input_shape + weight_shape)
             and all(
-                shape <= MAX_FUSE_TENSOR_SIZE_GROUP_LINEAR
+                shape <= self.graph_search_options["max_fuse_tensor_size_group_linear"]
                 for shape in input_shape + weight_shape
             )
         )
@@ -143,6 +181,7 @@ class GroupLinearFusion(GroupFusion):
             graph.erase_node(original_mm)
 
 
+@register_fusion("batch_linear_lhs")
 class BatchLinearLHSFusion(BatchFusion):
     """
     Batch linear left-hand side fusion. This pass tries to fuse the following patterns:
@@ -238,6 +277,7 @@ def is_linear_node_can_be_fused(node: torch.fx.Node):
     )
 
 
+@register_fusion("batch_linear")
 class BatchLinearFusion(BatchFusion):
     """
     Batch linear fusion in pre grad pass.
@@ -316,6 +356,7 @@ class BatchLinearFusion(BatchFusion):
                 graph.erase_node(linear)
 
 
+@register_fusion("batch_tanh")
 class BatchTanhFusion(BatchFusion):
     """
     Batch tanh fusion in pre grad pass.
@@ -375,6 +416,7 @@ class BatchTanhFusion(BatchFusion):
                 graph.erase_node(node)
 
 
+@register_fusion("batch_layernorm")
 class BatchLayernormFusion(BatchFusion):
     """
     Batch layer norm fusion in pre grad pass
@@ -486,6 +528,7 @@ class BatchLayernormFusion(BatchFusion):
             graph.erase_node(node)
 
 
+@register_fusion("batch_relu")
 class BatchReLUFusion(BatchFusion):
     """
     Batch relu fusion in pre grad pass.
@@ -550,6 +593,7 @@ class BatchReLUFusion(BatchFusion):
 
 def find_independent_subset_greedy(
     node_list: List[torch.fx.Node],
+    graph_search_options: Dict[str, Any],
 ) -> Iterator[List[torch.fx.Node]]:
     """
     Return a list of subset from node_list, all nodes in each subset are independent with each other and can be fused together.
@@ -572,7 +616,7 @@ def find_independent_subset_greedy(
         subset_deps: Set[torch.fx.Node] = set()
 
         for node in node_list:
-            if len(subset) >= MAX_FUSE_SET_SIZE:
+            if len(subset) >= graph_search_options["max_fuse_set_size"]:
                 break
 
             visited_node_set.clear()
@@ -583,7 +627,7 @@ def find_independent_subset_greedy(
                 subset.append(node)
                 subset_deps.update(dep_set)
 
-        if len(subset) >= MIN_FUSE_SET_SIZE:
+        if len(subset) >= graph_search_options["min_fuse_set_size"]:
             yield subset
 
         next_round_node_list = [node for node in node_list if node not in subset]
@@ -595,7 +639,7 @@ def get_fusion_candidates(
 ) -> DefaultDict[Any, List[torch.fx.Node]]:
     """
     Search fusion candidates for a specific rule using BFS starting from the root node.
-    We only search the subgraph within MAX_FUSE_SEARCH_DEPTH.
+    We only search the subgraph within graph_search_options["max_fuse_search_depth"].
     """
     q: Deque[Tuple[int, torch.fx.Node]] = collections.deque()
 
@@ -624,7 +668,7 @@ def get_fusion_candidates(
             if node not in candidate_nodes:
                 candidate_nodes.append(node)
         else:
-            if depth < MAX_FUSE_SEARCH_DEPTH:
+            if depth < rule.graph_search_options["max_fuse_search_depth"]:
                 for next_node in node.all_input_nodes:
                     if next_node not in visited_set:
                         visited_set.add(next_node)
@@ -644,7 +688,9 @@ def apply_group_batch_fusion(graph: torch.fx.GraphModule, rule: GroupBatchFusion
             if len(candidate_nodes) < MIN_FUSE_SET_SIZE:
                 continue
 
-            for subset in find_independent_subset_greedy(candidate_nodes):
+            for subset in find_independent_subset_greedy(
+                candidate_nodes, rule.graph_search_options
+            ):
                 rule.fuse(graph, subset)
                 fused_set.update(subset)
                 if isinstance(rule, GroupFusion):
@@ -662,29 +708,29 @@ def print_graph(graph: torch.fx.Graph, msg: str):
         log.info("%s Print graph: %s", msg, get_everpaste_url(str(graph)))  # noqa: F401
 
 
-def group_batch_fusion_post_grad_passes(graph: torch.fx.Graph):
+def generate_fusion_from_config(config_options: Dict[str, Any], pre_grad=True):
+    fusions: List[GroupBatchFusionBase] = []
+    for name, options in config_options.items():
+        fusion_cls = PRE_GRAD_FUSIONS[name] if pre_grad else POST_GRAD_FUSIONS[name]
+        _options = graph_search_options.copy()
+        _options.update(options)
+        fusions.append(fusion_cls(graph_search_options=_options))
+    return fusions
+
+
+def group_batch_fusion_passes(graph: torch.fx.Graph, pre_grad=True):
     print_graph(graph, "Before group_batch fusion in post grads pass.")
     fusions: List[GroupBatchFusionBase] = []
 
-    if config.group_fusion and has_fbgemm:
-        fusions += [GroupLinearFusion()]
+    if pre_grad:
+        fusions = generate_fusion_from_config(
+            config.pre_grad_fusion_options, pre_grad=True
+        )
+    elif has_fbgemm:  # Only group fusion (which needs fbgemm) in post grad.
+        fusions = generate_fusion_from_config(
+            config.pre_grad_fusion_options, pre_grad=False
+        )
 
-    for rule in fusions:
-        apply_group_batch_fusion(graph, rule)
-        print_graph(graph, f"Apply fusion {rule.__class__.__name__}.")
-
-
-def group_batch_fusion_pre_grad_passes(graph: torch.fx.Graph):
-    print_graph(graph, "Before group_batch fusion in pre grads pass.")
-    fusions: List[GroupBatchFusionBase] = []
-    if config.batch_fusion:
-        fusions += [
-            BatchLinearFusion(),
-            BatchLinearLHSFusion(),
-            BatchLayernormFusion(),
-            BatchTanhFusion(),
-            BatchReLUFusion(),
-        ]
     for rule in fusions:
         apply_group_batch_fusion(graph, rule)
         print_graph(graph, f"Apply fusion {rule.__class__.__name__}.")

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -80,9 +80,9 @@ def register_fusion(name: str, pre_grad=True):
 
 def list_group_batch_fusions(pre_grad=True) -> List[str]:
     if pre_grad:
-        return [x for x in PRE_GRAD_FUSIONS.keys()]
+        return PRE_GRAD_FUSIONS.keys()
     else:
-        return [x for x in POST_GRAD_FUSIONS.keys()]
+        return POST_GRAD_FUSIONS.keys()
 
 
 class GroupFusion(GroupBatchFusionBase):
@@ -714,7 +714,7 @@ def generate_fusion_from_config(config_options: Dict[str, Any], pre_grad=True):
         fusion_cls = PRE_GRAD_FUSIONS[name] if pre_grad else POST_GRAD_FUSIONS[name]
         _options = graph_search_options.copy()
         _options.update(options)
-        fusions.append(fusion_cls(graph_search_options=_options))
+        fusions.append(fusion_cls(graph_search_options=_options))  # type: ignore
     return fusions
 
 

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -728,7 +728,7 @@ def group_batch_fusion_passes(graph: torch.fx.Graph, pre_grad=True):
         )
     elif has_fbgemm:  # Only group fusion (which needs fbgemm) in post grad.
         fusions = generate_fusion_from_config(
-            config.pre_grad_fusion_options, pre_grad=False
+            config.post_grad_fusion_options, pre_grad=False
         )
 
     for rule in fusions:

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -39,7 +39,7 @@ from ..pattern_matcher import (
 )
 from ..utils import decode_device, is_pointwise_use
 from ..virtualized import V
-from .group_batch_fusion import group_batch_fusion_post_grad_passes
+from .group_batch_fusion import group_batch_fusion_passes
 
 
 log = logging.getLogger(__name__)
@@ -78,7 +78,7 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
     if config.pattern_matcher:
         lazy_init()
 
-        group_batch_fusion_post_grad_passes(gm.graph)
+        group_batch_fusion_passes(gm.graph, False)
         remove_noop_ops(gm.graph)
 
         for patterns in pass_patterns:

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -78,7 +78,7 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
     if config.pattern_matcher:
         lazy_init()
 
-        group_batch_fusion_passes(gm.graph, False)
+        group_batch_fusion_passes(gm.graph, pre_grad=False)
         remove_noop_ops(gm.graph)
 
         for patterns in pass_patterns:

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -68,12 +68,8 @@ def pre_grad_passes(gm: torch.fx.GraphModule, example_inputs):
     if config.pattern_matcher:
         lazy_init()
         gm = fuse_fx(gm, example_inputs)
-<<<<<<< HEAD
         numpy_compat_normalization(gm.graph)
-        group_batch_fusion_pre_grad_passes(gm.graph)
-=======
-        group_batch_fusion_passes(gm.graph, True)
->>>>>>> 273280b1df ([Inductor] Refactor group/batch fusion to support user defined execution order and configs)
+        group_batch_fusion_passes(gm.graph, pre_grad=True)
         for pattern_matcher_pass in pattern_matcher_passes:
             pattern_matcher_pass.apply(gm.graph)
 

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -22,7 +22,7 @@ from ..pattern_matcher import (
     stable_topological_sort,
 )
 from ..utils import is_cpu_device
-from .group_batch_fusion import group_batch_fusion_pre_grad_passes
+from .group_batch_fusion import group_batch_fusion_passes
 from .misc_patterns import numpy_compat_normalization
 
 log = logging.getLogger(__name__)
@@ -68,8 +68,12 @@ def pre_grad_passes(gm: torch.fx.GraphModule, example_inputs):
     if config.pattern_matcher:
         lazy_init()
         gm = fuse_fx(gm, example_inputs)
+<<<<<<< HEAD
         numpy_compat_normalization(gm.graph)
         group_batch_fusion_pre_grad_passes(gm.graph)
+=======
+        group_batch_fusion_passes(gm.graph, True)
+>>>>>>> 273280b1df ([Inductor] Refactor group/batch fusion to support user defined execution order and configs)
         for pattern_matcher_pass in pattern_matcher_passes:
             pattern_matcher_pass.apply(gm.graph)
 


### PR DESCRIPTION
Meta internal customers need more flexible configs on these group/batch fusion's execution order and parameters, I'd like to provide a new inductor config that users can fine and auto tune these group/batch fusions for different models.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler