### PR TITLE
Fix docstring errors in `torch/utils`

### DIFF
--- a/torch/utils/_sympy/interp.py
+++ b/torch/utils/_sympy/interp.py
@@ -1,6 +1,6 @@
 """
-This is a simple interpreter for Sympy expressions that dispatches to
-classes following the torch._inductor.virtualized calling convention.
+Simple interpreter for Sympy expressions using torch._inductor.virtualized.
+
 For directness, the interpreter takes the handler directly rather than
 consulting the TLS.  It does not use most of the methods on the full
 handler; only those with corresponding Sympy expressions.  To see an example

--- a/torch/utils/benchmark/examples/blas_compare_setup.py
+++ b/torch/utils/benchmark/examples/blas_compare_setup.py
@@ -79,7 +79,7 @@ SUB_ENVS = {
 
 
 def conda_run(*args):
-    """Convenience method."""
+    """Run a conda command."""
     stdout, stderr, retcode = conda.cli.python_api.run_command(*args)
     if retcode:
         raise OSError(f"conda error: {str(args)}  retcode: {retcode}\n{stderr}")

--- a/torch/utils/benchmark/examples/compare.py
+++ b/torch/utils/benchmark/examples/compare.py
@@ -1,4 +1,4 @@
-"""Example of Timer and Compare APIs:
+"""Example of Timer and Compare APIs.
 
 $ python -m examples.compare
 """
@@ -19,6 +19,7 @@ class FauxTorch:
     writing serialized measurements, but this simplifies that model to
     make the example clearer.
     """
+
     def __init__(self, real_torch, extra_ns_per_element):
         self._real_torch = real_torch
         self._extra_ns_per_element = extra_ns_per_element

--- a/torch/utils/benchmark/examples/fuzzer.py
+++ b/torch/utils/benchmark/examples/fuzzer.py
@@ -1,4 +1,4 @@
-"""Example of the Timer and Fuzzer APIs:
+"""Example of the Timer and Fuzzer APIs.
 
 $ python -m examples.fuzzer
 """

--- a/torch/utils/benchmark/examples/op_benchmark.py
+++ b/torch/utils/benchmark/examples/op_benchmark.py
@@ -16,6 +16,7 @@ _MEASURE_TIME = 1.0
 
 def assert_dicts_equal(dict_0, dict_1):
     """Builtin dict comparison will not compare numpy arrays.
+
     e.g.
         x = {"a": np.ones((2, 1))}
         x == x  # Raises ValueError

--- a/torch/utils/benchmark/examples/simple_timeit.py
+++ b/torch/utils/benchmark/examples/simple_timeit.py
@@ -1,4 +1,4 @@
-"""Trivial use of Timer API:
+"""Trivial use of Timer API.
 
 $ python -m examples.simple_timeit
 """

--- a/torch/utils/benchmark/examples/sparse/compare.py
+++ b/torch/utils/benchmark/examples/sparse/compare.py
@@ -1,4 +1,4 @@
-"""Example of Timer and Compare APIs:
+"""Example of Timer and Compare APIs.
 
 $ python -m examples.sparse.compare
 """
@@ -18,6 +18,7 @@ class FauxTorch:
     writing serialized measurements, but this simplifies that model to
     make the example clearer.
     """
+
     def __init__(self, real_torch, extra_ns_per_element):
         self._real_torch = real_torch
         self._extra_ns_per_element = extra_ns_per_element
@@ -43,7 +44,8 @@ class FauxTorch:
             return self.extra_overhead(self._real_torch.sparse.mm(*args, **kwargs))
 
 def generate_coo_data(size, sparse_dim, nnz, dtype, device):
-    """
+    """Generate random COO sparse tensor data.
+
     Parameters
     ----------
     size : tuple

--- a/torch/utils/benchmark/examples/sparse/fuzzer.py
+++ b/torch/utils/benchmark/examples/sparse/fuzzer.py
@@ -1,4 +1,4 @@
-"""Example of the Timer and Sparse Fuzzer APIs:
+"""Example of the Timer and Sparse Fuzzer APIs.
 
 $ python -m examples.sparse.fuzzer
 """

--- a/torch/utils/benchmark/examples/sparse/op_benchmark.py
+++ b/torch/utils/benchmark/examples/sparse/op_benchmark.py
@@ -14,6 +14,7 @@ _MEASURE_TIME = 1.0
 
 def assert_dicts_equal(dict_0, dict_1):
     """Builtin dict comparison will not compare numpy arrays.
+
     e.g.
         x = {"a": np.ones((2, 1))}
         x == x  # Raises ValueError

--- a/torch/utils/benchmark/examples/spectral_ops_fuzz_test.py
+++ b/torch/utils/benchmark/examples/spectral_ops_fuzz_test.py
@@ -1,4 +1,4 @@
-"""Microbenchmarks for the torch.fft module"""
+"""Microbenchmarks for the torch.fft module."""
 from argparse import ArgumentParser
 from collections import namedtuple
 from collections.abc import Iterable

--- a/torch/utils/benchmark/utils/_stubs.py
+++ b/torch/utils/benchmark/utils/_stubs.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Dict, Protocol, runtime_checkable
 
 class TimerClass(Protocol):
     """This is the portion of the `timeit.Timer` API used by benchmark utils."""
+
     def __init__(
         self,
         stmt: str,
@@ -20,6 +21,7 @@ class TimerClass(Protocol):
 @runtime_checkable
 class TimeitModuleType(Protocol):
     """Modules generated from `timeit_template.cpp`."""
+
     def timeit(self, number: int) -> float:
         ...
 
@@ -30,6 +32,7 @@ class CallgrindModuleType(Protocol):
     These bindings are used to collect Callgrind profiles on earlier versions
     of PyTorch and will eventually be removed.
     """
+
     __file__: str
     __name__: str
 

--- a/torch/utils/benchmark/utils/common.py
+++ b/torch/utils/benchmark/utils/common.py
@@ -29,7 +29,8 @@ _IQR_GROSS_WARN_THRESHOLD = 0.25
 
 @dataclasses.dataclass(init=True, repr=False, eq=True, frozen=True)
 class TaskSpec:
-    """Container for information used to define a Timer. (except globals)"""
+    """Container for information used to define a Timer. (except globals)."""
+
     stmt: str
     setup: str
     global_setup: str = ""
@@ -78,6 +79,7 @@ class Measurement:
     serializable and provides several convenience methods
     (including a detailed __repr__) for downstream consumers.
     """
+
     number_per_run: int
     raw_times: List[float]
     task_spec: TaskSpec
@@ -200,7 +202,8 @@ class Measurement:
         return self.sub_label or self.stmt or "[Unknown]"
 
     def __repr__(self) -> str:
-        """
+        """Generate a representation of a measurement.
+
         Example repr:
             <utils.common.Measurement object at 0x7f395b6ac110>
               Broadcasting add (4x8)
@@ -228,7 +231,7 @@ class Measurement:
 
     @staticmethod
     def merge(measurements: Iterable["Measurement"]) -> List["Measurement"]:
-        """Convenience method for merging replicates.
+        """Merge replicates of measurements.
 
         Merge will extrapolate times to `number_per_run=1` and will not
         transfer any metadata. (Since it might differ between replicates)
@@ -274,7 +277,7 @@ def unit_to_english(u: str) -> str:
 
 
 def trim_sigfig(x: float, n: int) -> float:
-    """Trim `x` to `n` significant figures. (e.g. 3.14159, 2 -> 3.10000)"""
+    """Trim `x` to `n` significant figures. (e.g. 3.14159, 2 -> 3.10000)."""
     assert n == int(n)
     magnitude = int(torch.tensor(x).abs().log10().ceil().item())
     scale = 10 ** (magnitude - n)

--- a/torch/utils/benchmark/utils/compile.py
+++ b/torch/utils/benchmark/utils/compile.py
@@ -76,9 +76,7 @@ if HAS_TABULATE:
         optimizer: Optional[torch.optim.Optimizer] = None,
         loss_fn : Union[torch.nn.Module, Callable, None] = None,
     ):
-        """
-        Use this utility to benchmark torch.compile
-        """
+        """Use this utility to benchmark torch.compile."""
         if backend:
             try:
                 torch._dynamo.reset()
@@ -120,10 +118,11 @@ if HAS_TABULATE:
         loss_fn : Union[torch.nn.Module, Callable, None] = None,
     ):
         """
-        This is a simple utility that can be used to benchmark torch.compile
+        Benchmark torch.compile with this simple utility.
+
         In particular it ensures that your GPU is setup to use tensor cores if it supports its
         It also tries out all the main backends and prints a table of results so you can easily compare them all
-        Many of the backendds have their own optional dependencies so please pip install them seperately
+        Many of the backendds have their own optional dependencies so please pip install them seperately.
 
         You will get one table for inference and another for training
         If you'd like to leverage this utility for training make sure to pass in a torch.optim.Optimizer

--- a/torch/utils/benchmark/utils/fuzzer.py
+++ b/torch/utils/benchmark/utils/fuzzer.py
@@ -21,6 +21,7 @@ _DISTRIBUTIONS = (
 
 class FuzzedParameter:
     """Specification for a parameter to be generated during fuzzing."""
+
     def __init__(
         self,
         name: str,
@@ -29,7 +30,8 @@ class FuzzedParameter:
         distribution: Optional[Union[str, Dict[Any, float]]] = None,
         strict: bool = False,
     ):
-        """
+        """Initialize a parameter for fuzzing.
+
         Args:
             name:
                 A string name with which to identify the parameter.
@@ -151,6 +153,7 @@ class ParameterAlias:
 
     Chains of alias' are allowed, but may not contain cycles.
     """
+
     def __init__(self, alias_to):
         self.alias_to = alias_to
 
@@ -192,7 +195,8 @@ class FuzzedTensor:
         cuda=False,
         tensor_constructor: Optional[Callable] = None
     ):
-        """
+        """Initialize a tensor parameter for fuzzing.
+
         Args:
             name:
                 A string identifier for the generated Tensor.
@@ -348,7 +352,8 @@ class Fuzzer:
         constraints: Optional[List[Callable]] = None,
         seed: Optional[int] = None
     ):
-        """
+        """Initialize a Fuzzer with parameters, tensors, constraints, and a seed.
+
         Args:
             parameters:
                 List of FuzzedParameters which provide specifications

--- a/torch/utils/benchmark/utils/sparse_fuzzer.py
+++ b/torch/utils/benchmark/utils/sparse_fuzzer.py
@@ -19,7 +19,8 @@ class FuzzedSparseTensor(FuzzedTensor):
         dtype=torch.float32,
         cuda=False
     ):
-        """
+        """Initialize a FuzzedSparseTensor object.
+
         Args:
             name:
                 A string identifier for the generated Tensor.

--- a/torch/utils/benchmark/utils/timer.py
+++ b/torch/utils/benchmark/utils/timer.py
@@ -264,7 +264,9 @@ class Timer:
         return max(self._timer.timeit(number), 1e-9)
 
     def timeit(self, number: int = 1000000) -> common.Measurement:
-        """Mirrors the semantics of timeit.Timer.timeit().
+        """Mirrors the semantics of timeit method.
+
+        timeit.Timer.timeit()
 
         Execute the main statement (`stmt`) `number` times.
         https://docs.python.org/3/library/timeit.html#timeit.Timer.timeit

--- a/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
+++ b/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
@@ -46,6 +46,7 @@ class FunctionCounts:
         4) Two higher order methods (`filter` and `transform`) for custom
            manipulation.
     """
+
     _data: Tuple[FunctionCount, ...]
     inclusive: bool
     truncate_rows: bool = True
@@ -134,7 +135,8 @@ class FunctionCounts:
         instructions involve unicode to dictionary lookups which Python uses to
         map variable names. FunctionCounts is generally a content agnostic
         container, however this is sufficiently important for obtaining
-        reliable results to warrant an exception."""
+        reliable results to warrant an exception.
+        """
         return self.filter(lambda fn: "dictobject.c:lookdict_unicode" not in fn)
 
     def _merge(
@@ -167,6 +169,7 @@ class CallgrindStats:
     methods are provided as well; the most significant is
     `CallgrindStats.as_standardized()`.
     """
+
     task_spec: common.TaskSpec
     number_per_run: int
     built_with_debug_symbols: bool
@@ -195,7 +198,7 @@ class CallgrindStats:
         return output
 
     def stats(self, inclusive: bool = False) -> FunctionCounts:
-        """Returns detailed function counts.
+        """Return detailed function counts.
 
         Conceptually, the FunctionCounts returned can be thought of as a tuple
         of (count, path_and_function_name) tuples.
@@ -209,7 +212,7 @@ class CallgrindStats:
         return self.stmt_inclusive_stats if inclusive else self.stmt_exclusive_stats
 
     def counts(self, *, denoise: bool = False) -> int:
-        """Returns the total number of instructions executed.
+        """Return the total number of instructions executed.
 
         See `FunctionCounts.denoise()` for an explanation of the `denoise` arg.
         """
@@ -308,6 +311,7 @@ class CopyIfCallgrind:
 
     See `GlobalsBridge` for why this matters.
     """
+
     def __init__(self, value: Any, *, setup: Optional[str] = None):
         for method, supported_types in _GLOBALS_ALLOWED_TYPES.items():
             if any(isinstance(value, t) for t in supported_types):
@@ -754,7 +758,7 @@ class _ValgrindWrapper:
         bindings: Optional[CallgrindModuleType],
     ) -> str:
         def block_stmt(stmt: str, indent: int = 0) -> str:
-            """Partially unroll benchmark loop.
+            """Partial unroll benchmark loop.
 
             The naive template looks something like:
                 "for _ in range({number}): {stmt}"

--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-""" The Python Hipify script.
+"""The Python Hipify script.
+
 ##
 # Copyright (c) 2015-2016 Advanced Micro Devices, Inc. All rights reserved.
 #               2017-2018 Advanced Micro Devices, Inc. and
@@ -105,7 +106,8 @@ class bcolors:
 # not recompile unchanged files), but in cases where you don't want to
 # keep them (e.g. in the CI), this can be used to remove files.
 class GeneratedFileCleaner:
-    """Context Manager to clean up generated files"""
+    """Context Manager to clean up generated files."""
+
     def __init__(self, keep_intermediates=False):
         self.keep_intermediates = keep_intermediates
         self.files_to_clean = set()
@@ -138,7 +140,7 @@ class GeneratedFileCleaner:
 
 
 def match_extensions(filename: str, extensions: Iterable) -> bool:
-    """Helper method to see if filename ends with certain extension"""
+    """Check to see if filename ends with certain extension."""
     return any(filename.endswith(e) for e in extensions)
 
 
@@ -229,7 +231,7 @@ def compute_stats(stats):
 
 
 def add_dim3(kernel_string, cuda_kernel):
-    '''adds dim3() to the second and third arguments in the kernel launch'''
+    """Add dim3() to the second and third arguments in the kernel launch."""
     count = 0
     closure = 0
     kernel_string = kernel_string.replace("<<<", "").replace(">>>", "")
@@ -267,7 +269,7 @@ RE_KERNEL_LAUNCH = re.compile(r'([ ]+)(detail?)::[ ]+\\\n[ ]+')
 
 
 def processKernelLaunches(string, stats):
-    """ Replace the CUDA style Kernel launches with the HIP style kernel launches."""
+    """Replace the CUDA style Kernel launches with the HIP style kernel launches."""
     # Concat the namespace with the kernel names. (Find cleaner way of doing this later).
     string = RE_KERNEL_LAUNCH.sub(lambda inp: f"{inp.group(1)}{inp.group(2)}::", string)
 
@@ -331,7 +333,7 @@ def processKernelLaunches(string, stats):
                         return [(pos["kernel_name"]), (pos["template"]), (pos["kernel_launch"])]
 
     def find_kernel_bounds(string):
-        """Finds the starting and ending points for all kernel launches in the string."""
+        """Find the starting and ending points for all kernel launches in the string."""
         kernel_end = 0
         kernel_positions = []
 
@@ -421,7 +423,7 @@ def processKernelLaunches(string, stats):
 
 
 def find_closure_group(input_string, start, group):
-    """Generalization for finding a balancing closure group
+    """Generalization for finding a balancing closure group.
 
          if group = ["(", ")"], then finds the first balanced parentheses.
          if group = ["{", "}"], then finds the first balanced bracket.
@@ -433,7 +435,6 @@ def find_closure_group(input_string, start, group):
         >>> find_closure_group("(hi)", 0, ["(", ")"])
         (0, 3)
     """
-
     inside_parenthesis = False
     parens = 0
     pos = start
@@ -459,12 +460,12 @@ def find_closure_group(input_string, start, group):
 
 
 def find_bracket_group(input_string, start):
-    """Finds the first balanced parantheses."""
+    """Find the first balanced parantheses."""
     return find_closure_group(input_string, start, group=["{", "}"])
 
 
 def find_parentheses_group(input_string, start):
-    """Finds the first balanced bracket."""
+    """Find the first balanced bracket."""
     return find_closure_group(input_string, start, group=["(", ")"])
 
 
@@ -472,12 +473,12 @@ RE_ASSERT = re.compile(r"\bassert[ ]*\(")
 
 
 def replace_math_functions(input_string):
-    """FIXME: Temporarily replace std:: invocations of math functions
-        with non-std:: versions to prevent linker errors NOTE: This
-        can lead to correctness issues when running tests, since the
-        correct version of the math function (exp/expf) might not get
-        called.  Plan is to remove this function once HIP supports
-        std:: math function calls inside device code
+    """FIXME: Temporarily replace std:: invocations of math functions with non-std:: versions to prevent linker errors.
+
+    NOTE: This can lead to correctness issues when running tests,
+    since the correct version of the math function (exp/expf) might not get
+    called.  Plan is to remove this function once HIP supports
+    std:: math function calls inside device code.
 
     """
     output_string = input_string
@@ -491,12 +492,11 @@ RE_SYNCTHREADS = re.compile(r":?:?\b(__syncthreads)\b(\w*\()")
 
 
 def hip_header_magic(input_string):
-    """If the file makes kernel builtin calls and does not include the cuda_runtime.h header,
-    then automatically add an #include to match the "magic" includes provided by NVCC.
+    """Add hip/hip_runtime.h header to a file that makes kernel builtin calls but does not include the cuda_runtime.h header.
+
     TODO:
         Update logic to ignore cases where the cuda_runtime.h is included by another file.
     """
-
     # Copy the input.
     output_string = input_string
 
@@ -524,10 +524,12 @@ RE_EXTERN_SHARED = re.compile(r"extern\s+([\w\(\)]+)?\s*__shared__\s+([\w:<>\s]+
 
 def replace_extern_shared(input_string):
     """Match extern __shared__ type foo[]; syntax and use HIP_DYNAMIC_SHARED() MACRO instead.
-       https://github.com/ROCm-Developer-Tools/HIP/blob/master/docs/markdown/hip_kernel_language.md#__shared__
+
+    https://github.com/ROCm-Developer-Tools/HIP/blob/master/docs/markdown/hip_kernel_language.md#__shared__
+
     Example:
         "extern __shared__ char smemChar[];" => "HIP_DYNAMIC_SHARED( char, smemChar)"
-        "extern __shared__ unsigned char smem[];" => "HIP_DYNAMIC_SHARED( unsigned char, my_smem)"
+        "extern __shared__ unsigned char smem[];" => "HIP_DYNAMIC_SHARED( unsigned char, my_smem)".
     """
     output_string = input_string
     output_string = RE_EXTERN_SHARED.sub(
@@ -537,9 +539,7 @@ def replace_extern_shared(input_string):
 
 
 def get_hip_file_path(rel_filepath, is_pytorch_extension=False):
-    """
-    Returns the new name of the hipified file
-    """
+    """Return the new name of the hipified file."""
     # At the moment, some PyTorch source files are HIPified in place.  The predicate
     # is_out_of_place tells us if this is the case or not.
     assert not os.path.isabs(rel_filepath)
@@ -663,7 +663,9 @@ def is_caffe2_gpu_file(rel_filepath):
 # Cribbed from https://stackoverflow.com/questions/42742810/speed-up-millions-of-regex-replacements-in-python-3/42789508#42789508
 class Trie:
     """Regex::Trie in Python. Creates a Trie out of a list of words. The trie can be exported to a Regex pattern.
-    The corresponding Regex should match much faster than a simple Regex union."""
+
+    The corresponding Regex should match much faster than a simple Regex union.
+    """
 
     def __init__(self):
         self.data = {}
@@ -782,7 +784,7 @@ def preprocessor(
         is_pytorch_extension: bool,
         clean_ctx: GeneratedFileCleaner,
         show_progress: bool) -> HipifyResult:
-    """ Executes the CUDA -> HIP conversion on the specified file. """
+    """Execute the CUDA -> HIP conversion on the specified file."""
     fin_path = os.path.abspath(os.path.join(output_directory, filepath))
     hipify_result = HIPIFY_FINAL_RESULT[fin_path]
     if filepath not in all_files:
@@ -980,7 +982,7 @@ def file_add_header(filepath, header):
 
 
 def fix_static_global_kernels(in_txt):
-    """Static global kernels in HIP results in a compilation error."""
+    """Fix static global kernels in HIP results in a compilation error."""
     in_txt = in_txt.replace(" __global__ static", "__global__")
     return in_txt
 
@@ -989,16 +991,16 @@ RE_INCLUDE = re.compile(r"#include .*\n")
 
 
 def extract_arguments(start, string):
-    """ Return the list of arguments in the upcoming function parameter closure.
-        Example:
-        string (input): '(blocks, threads, 0, THCState_getCurrentStream(state))'
-        arguments (output):
-            '[{'start': 1, 'end': 7},
-            {'start': 8, 'end': 16},
-            {'start': 17, 'end': 19},
-            {'start': 20, 'end': 53}]'
-    """
+    """Return the list of arguments in the upcoming function parameter closure.
 
+    Example:
+    string (input): '(blocks, threads, 0, THCState_getCurrentStream(state))'
+    arguments (output):
+    '[{'start': 1, 'end': 7},
+    {'start': 8, 'end': 16},
+    {'start': 17, 'end': 19},
+    {'start': 20, 'end': 53}]'.
+    """
     arguments = []
     closures = {
         "<": 0,
@@ -1035,8 +1037,11 @@ def extract_arguments(start, string):
 
 
 def str2bool(v):
-    """ArgumentParser doesn't support type=bool. Thus, this helper method will convert
-    from possible string types to True / False."""
+    """Argumentparser doesn't support type=bool.
+
+    Thus, this helper method will convert
+    from possible string types to True / False.
+    """
     if v.lower() in ('yes', 'true', 't', 'y', '1'):
         return True
     elif v.lower() in ('no', 'false', 'f', 'n', '0'):

--- a/torch/utils/model_dump/__init__.py
+++ b/torch/utils/model_dump/__init__.py
@@ -194,7 +194,6 @@ def get_model_info(
     The result is suitable for being saved as model_info.json,
     or passed to burn_in_info.
     """
-
     if isinstance(path_or_file, os.PathLike):
         default_title = os.fspath(path_or_file)
         file_size = path_or_file.stat().st_size  # type: ignore[attr-defined]
@@ -357,7 +356,6 @@ def get_inline_skeleton():
     The returned HTML page has no external network dependencies for code.
     It can load model_info.json over HTTP, or be passed to burn_in_info.
     """
-
     import importlib.resources
 
     skeleton = importlib.resources.read_text(__package__, "skeleton.html")
@@ -376,7 +374,6 @@ def burn_in_info(skeleton, info):
     The result will render the hard-coded model info and
     have no external network dependencies for code or data.
     """
-
     # Note that Python's json serializer does not escape slashes in strings.
     # Since we're inlining this JSON directly into a script tag, a string
     # containing "</script>" would end the script prematurely and


### PR DESCRIPTION
Fixes #112638, and from this issue there is no file named **end_to_end.py** in `torch/utils/benchmark/examples/end_to_end.py` 

1. `torch/utils/_sympy/interp.py`
Before - 4
```
torch/utils/_sympy/interp.py:1 at module level:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/_sympy/interp.py:1 at module level:
        D400: First line should end with a period (not 'o')
torch/utils/_sympy/interp.py:33 in public function `handlers`:
        D103: Missing docstring in public function
torch/utils/_sympy/interp.py:77 in public function `sympy_interp`:
        D103: Missing docstring in public function
4
```
After - 2
```
torch/utils/_sympy/interp.py:33 in public function `handlers`:
        D103: Missing docstring in public function
torch/utils/_sympy/interp.py:77 in public function `sympy_interp`:
        D103: Missing docstring in public function
2
```
2. `torch/utils/benchmark/examples/blas_compare_setup.py`
Before - 3
```
torch/utils/benchmark/examples/blas_compare_setup.py:1 at module level:
        D100: Missing docstring in public module
torch/utils/benchmark/examples/blas_compare_setup.py:82 in public function `conda_run`:
        D401: First line should be in imperative mood; try rephrasing (found 'Convenience')
torch/utils/benchmark/examples/blas_compare_setup.py:90 in public function `main`:
        D103: Missing docstring in public function
3
```
After - 2
```
torch/utils/benchmark/examples/blas_compare_setup.py:1 at module level:
        D100: Missing docstring in public module
torch/utils/benchmark/examples/blas_compare_setup.py:90 in public function `main`:
        D103: Missing docstring in public function
2
```
3. `torch/utils/benchmark/examples/compare.py`
Before - 9
```
torch/utils/benchmark/examples/compare.py:1 at module level:
        D400: First line should end with a period (not ':')
torch/utils/benchmark/examples/compare.py:16 in public class `FauxTorch`:
        D204: 1 blank line required after class docstring (found 0)
torch/utils/benchmark/examples/compare.py:22 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/benchmark/examples/compare.py:26 in public method `extra_overhead`:
        D102: Missing docstring in public method
torch/utils/benchmark/examples/compare.py:34 in public method `add`:
        D102: Missing docstring in public method
torch/utils/benchmark/examples/compare.py:37 in public method `mul`:
        D102: Missing docstring in public method
torch/utils/benchmark/examples/compare.py:40 in public method `cat`:
        D102: Missing docstring in public method
torch/utils/benchmark/examples/compare.py:43 in public method `matmul`:
        D102: Missing docstring in public method
torch/utils/benchmark/examples/compare.py:47 in public function `main`:
        D103: Missing docstring in public function
9
```
After - 7
```
torch/utils/benchmark/examples/compare.py:23 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/benchmark/examples/compare.py:27 in public method `extra_overhead`:
        D102: Missing docstring in public method
torch/utils/benchmark/examples/compare.py:35 in public method `add`:
        D102: Missing docstring in public method
torch/utils/benchmark/examples/compare.py:38 in public method `mul`:
        D102: Missing docstring in public method
torch/utils/benchmark/examples/compare.py:41 in public method `cat`:
        D102: Missing docstring in public method
torch/utils/benchmark/examples/compare.py:44 in public method `matmul`:
        D102: Missing docstring in public method
torch/utils/benchmark/examples/compare.py:48 in public function `main`:
        D103: Missing docstring in public function
7
```
4. `torch/utils/benchmark/examples/fuzzer.py`
Before - 2
```
torch/utils/benchmark/examples/fuzzer.py:1 at module level:
        D400: First line should end with a period (not ':')
torch/utils/benchmark/examples/fuzzer.py:11 in public function `main`:
        D103: Missing docstring in public function
2
```
After - 1
```
torch/utils/benchmark/examples/fuzzer.py:11 in public function `main`:
        D103: Missing docstring in public function
1
```
5. `torch/utils/benchmark/examples/op_benchmark.py`
Before - 3
```
torch/utils/benchmark/examples/op_benchmark.py:18 in public function `assert_dicts_equal`:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/benchmark/examples/op_benchmark.py:27 in public function `run`:       
        D103: Missing docstring in public function
torch/utils/benchmark/examples/op_benchmark.py:96 in public function `main`:      
        D103: Missing docstring in public function
3
```
After - 2
```
torch/utils/benchmark/examples/op_benchmark.py:28 in public function `run`:
        D103: Missing docstring in public function
torch/utils/benchmark/examples/op_benchmark.py:97 in public function `main`:
        D103: Missing docstring in public function
2
```
6. `torch/utils/benchmark/examples/simple_timeit.py`
Before - 2
```
torch/utils/benchmark/examples/simple_timeit.py:1 at module level:
        D400: First line should end with a period (not ':')
torch/utils/benchmark/examples/simple_timeit.py:11 in public function `main`:
        D103: Missing docstring in public function
2
```
After - 1
```
torch/utils/benchmark/examples/simple_timeit.py:11 in public function `main`:
        D103: Missing docstring in public function
1
```
7. `torch/utils/benchmark/examples/sparse/compare.py`
Before - 12
```
torch/utils/benchmark/examples/sparse/compare.py:1 at module level:
        D400: First line should end with a period (not ':')
torch/utils/benchmark/examples/sparse/compare.py:15 in public class `FauxTorch`:
        D204: 1 blank line required after class docstring (found 0)
torch/utils/benchmark/examples/sparse/compare.py:21 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/benchmark/examples/sparse/compare.py:26 in public method `sparse`:
        D102: Missing docstring in public method
torch/utils/benchmark/examples/sparse/compare.py:29 in public nested class `Sparse`:
        D106: Missing docstring in public nested class
torch/utils/benchmark/examples/sparse/compare.py:30 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/benchmark/examples/sparse/compare.py:34 in public method `extra_overhead`:
        D102: Missing docstring in public method
torch/utils/benchmark/examples/sparse/compare.py:42 in public method `mm`:
        D102: Missing docstring in public method
torch/utils/benchmark/examples/sparse/compare.py:46 in public function `generate_coo_data`:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/benchmark/examples/sparse/compare.py:46 in public function `generate_coo_data`:
        D400: First line should end with a period (not 's')
torch/utils/benchmark/examples/sparse/compare.py:68 in public function `gen_sparse`:
        D103: Missing docstring in public function
torch/utils/benchmark/examples/sparse/compare.py:74 in public function `main`:
        D103: Missing docstring in public function
12
```
After - 8
```
torch/utils/benchmark/examples/sparse/compare.py:22 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/benchmark/examples/sparse/compare.py:27 in public method `sparse`:
        D102: Missing docstring in public method
torch/utils/benchmark/examples/sparse/compare.py:30 in public nested class `Sparse`:
        D106: Missing docstring in public nested class
torch/utils/benchmark/examples/sparse/compare.py:31 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/benchmark/examples/sparse/compare.py:35 in public method `extra_overhead`:
        D102: Missing docstring in public method
torch/utils/benchmark/examples/sparse/compare.py:43 in public method `mm`:
        D102: Missing docstring in public method
torch/utils/benchmark/examples/sparse/compare.py:70 in public function `gen_sparse`:
        D103: Missing docstring in public function
torch/utils/benchmark/examples/sparse/compare.py:76 in public function `main`:
        D103: Missing docstring in public function
8
```
8. `torch/utils/benchmark/examples/sparse/fuzzer.py`
Before - 2
```
torch/utils/benchmark/examples/sparse/fuzzer.py:1 at module level:
        D400: First line should end with a period (not ':')
torch/utils/benchmark/examples/sparse/fuzzer.py:10 in public function `main`:
        D103: Missing docstring in public function
2
```
After - 1
```
torch/utils/benchmark/examples/sparse/fuzzer.py:10 in public function `main`:
        D103: Missing docstring in public function
1
```
9. `torch/utils/benchmark/examples/sparse/op_benchmark.py`
Before - 3
```
torch/utils/benchmark/examples/sparse/op_benchmark.py:16 in public function `assert_dicts_equal`:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/benchmark/examples/sparse/op_benchmark.py:24 in public function `run`:
        D103: Missing docstring in public function
torch/utils/benchmark/examples/sparse/op_benchmark.py:91 in public function `main`:
        D103: Missing docstring in public function
3
```
After - 2
```
torch/utils/benchmark/examples/sparse/op_benchmark.py:25 in public function `run`:
        D103: Missing docstring in public function
torch/utils/benchmark/examples/sparse/op_benchmark.py:92 in public function `main`:
        D103: Missing docstring in public function
2
```
10. `torch/utils/benchmark/examples/spectral_ops_fuzz_test.py`
Before - 2
```
torch/utils/benchmark/examples/spectral_ops_fuzz_test.py:1 at module level:
        D400: First line should end with a period (not 'e')
torch/utils/benchmark/examples/spectral_ops_fuzz_test.py:22 in public function `run_benchmark`:
        D103: Missing docstring in public function
2
```
After - 1
```
torch/utils/benchmark/examples/spectral_ops_fuzz_test.py:22 in public function `run_benchmark`:
        D103: Missing docstring in public function
1
```
11. `torch/utils/benchmark/utils/_stubs.py`
Before - 6
```
torch/utils/benchmark/utils/_stubs.py:5 in public class `TimerClass`:
        D204: 1 blank line required after class docstring (found 0)
torch/utils/benchmark/utils/_stubs.py:6 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/benchmark/utils/_stubs.py:16 in public method `timeit`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/_stubs.py:22 in public class `TimeitModuleType`:
        D204: 1 blank line required after class docstring (found 0)
torch/utils/benchmark/utils/_stubs.py:23 in public method `timeit`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/_stubs.py:28 in public class `CallgrindModuleType`:
        D204: 1 blank line required after class docstring (found 0)
6
```
After - 3
```
torch/utils/benchmark/utils/_stubs.py:7 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/benchmark/utils/_stubs.py:17 in public method `timeit`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/_stubs.py:25 in public method `timeit`:
        D102: Missing docstring in public method
3
```
12. `torch/utils/benchmark/utils/common.py`
Before - 23
```
torch/utils/benchmark/utils/common.py:32 in public class `TaskSpec`:
        D204: 1 blank line required after class docstring (found 0)
torch/utils/benchmark/utils/common.py:32 in public class `TaskSpec`:
        D400: First line should end with a period (not ')')
torch/utils/benchmark/utils/common.py:54 in public method `setup_str`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/common.py:75 in public class `Measurement`:
        D204: 1 blank line required after class docstring (found 0)
torch/utils/benchmark/utils/common.py:86 in public method `__post_init__`:
        D105: Missing docstring in magic method
torch/utils/benchmark/utils/common.py:94 in public method `__getattr__`:
        D105: Missing docstring in magic method
torch/utils/benchmark/utils/common.py:110 in public method `times`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/common.py:114 in public method `median`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/common.py:119 in public method `mean`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/common.py:124 in public method `iqr`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/common.py:158 in public method `has_warnings`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/common.py:184 in public method `meets_confidence`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/common.py:188 in public method `title`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/common.py:192 in public method `env`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/common.py:199 in public method `as_row_name`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/common.py:203 in public method `__repr__`:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/benchmark/utils/common.py:203 in public method `__repr__`:
        D400: First line should end with a period (not ':')
torch/utils/benchmark/utils/common.py:203 in public method `__repr__`:
        D401: First line should be in imperative mood; try rephrasing (found 'Example')
torch/utils/benchmark/utils/common.py:231 in public method `merge`:
        D401: First line should be in imperative mood; try rephrasing (found 'Convenience')
torch/utils/benchmark/utils/common.py:267 in public function `unit_to_english`:
        D103: Missing docstring in public function
torch/utils/benchmark/utils/common.py:277 in public function `trim_sigfig`:
        D400: First line should end with a period (not ')')
torch/utils/benchmark/utils/common.py:284 in public function `ordered_unique`:
        D103: Missing docstring in public function
torch/utils/benchmark/utils/common.py:289 in public function `set_torch_threads`:
        D103: Missing docstring in public function
23
```
After - 15
```
torch/utils/benchmark/utils/common.py:55 in public method `setup_str`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/common.py:88 in public method `__post_init__`:
        D105: Missing docstring in magic method
torch/utils/benchmark/utils/common.py:96 in public method `__getattr__`:
        D105: Missing docstring in magic method
torch/utils/benchmark/utils/common.py:112 in public method `times`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/common.py:116 in public method `median`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/common.py:121 in public method `mean`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/common.py:126 in public method `iqr`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/common.py:160 in public method `has_warnings`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/common.py:186 in public method `meets_confidence`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/common.py:190 in public method `title`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/common.py:194 in public method `env`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/common.py:201 in public method `as_row_name`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/common.py:270 in public function `unit_to_english`:
        D103: Missing docstring in public function
torch/utils/benchmark/utils/common.py:287 in public function `ordered_unique`:
        D103: Missing docstring in public function
torch/utils/benchmark/utils/common.py:292 in public function `set_torch_threads`:
        D103: Missing docstring in public function
15
```
13. `torch/utils/benchmark/utils/compile.py`
Before - 6
```
torch/utils/benchmark/utils/compile.py:1 at module level:
        D100: Missing docstring in public module
torch/utils/benchmark/utils/compile.py:79 in public function `benchmark_compile`:
        D200: One-line docstring should fit on one line with quotes (found 3)
torch/utils/benchmark/utils/compile.py:79 in public function `benchmark_compile`:
        D400: First line should end with a period (not 'e')
torch/utils/benchmark/utils/compile.py:122 in public function `bench_all`:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/benchmark/utils/compile.py:122 in public function `bench_all`:
        D400: First line should end with a period (not 'e')
torch/utils/benchmark/utils/compile.py:122 in public function `bench_all`:
        D401: First line should be in imperative mood; try rephrasing (found 'This')
6
```
After - 1
```
torch/utils/benchmark/utils/compile.py:1 at module level:
        D100: Missing docstring in public module
1
```
14. `torch/utils/benchmark/utils/fuzzer.py`
Before - 20
```
torch/utils/benchmark/utils/fuzzer.py:1 at module level:
        D100: Missing docstring in public module
torch/utils/benchmark/utils/fuzzer.py:23 in public class `FuzzedParameter`:
        D204: 1 blank line required after class docstring (found 0)
torch/utils/benchmark/utils/fuzzer.py:32 in public method `__init__`:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/benchmark/utils/fuzzer.py:32 in public method `__init__`:
        D400: First line should end with a period (not ':')
torch/utils/benchmark/utils/fuzzer.py:80 in public method `name`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/fuzzer.py:83 in public method `sample`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/fuzzer.py:130 in public class `ParameterAlias`:
        D204: 1 blank line required after class docstring (found 0)
torch/utils/benchmark/utils/fuzzer.py:154 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/benchmark/utils/fuzzer.py:157 in public method `__repr__`:
        D105: Missing docstring in magic method
torch/utils/benchmark/utils/fuzzer.py:179 in public class `FuzzedTensor`:
        D101: Missing docstring in public class
torch/utils/benchmark/utils/fuzzer.py:195 in public method `__init__`:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/benchmark/utils/fuzzer.py:195 in public method `__init__`:
        D400: First line should end with a period (not ':')
torch/utils/benchmark/utils/fuzzer.py:257 in public method `name`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/fuzzer.py:261 in public method `default_tensor_constructor`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/fuzzer.py:323 in public method `satisfies_constraints`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/fuzzer.py:343 in public class `Fuzzer`:
        D101: Missing docstring in public class
torch/utils/benchmark/utils/fuzzer.py:351 in public method `__init__`:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/benchmark/utils/fuzzer.py:351 in public method `__init__`:
        D400: First line should end with a period (not ':')
torch/utils/benchmark/utils/fuzzer.py:393 in public method `take`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/fuzzer.py:407 in public method `rejection_rate`:
        D102: Missing docstring in public method
20
```
After - 12
```
torch/utils/benchmark/utils/fuzzer.py:1 at module level:
        D100: Missing docstring in public module
torch/utils/benchmark/utils/fuzzer.py:82 in public method `name`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/fuzzer.py:85 in public method `sample`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/fuzzer.py:157 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/benchmark/utils/fuzzer.py:160 in public method `__repr__`:
        D105: Missing docstring in magic method
torch/utils/benchmark/utils/fuzzer.py:182 in public class `FuzzedTensor`:
        D101: Missing docstring in public class
torch/utils/benchmark/utils/fuzzer.py:261 in public method `name`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/fuzzer.py:265 in public method `default_tensor_constructor`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/fuzzer.py:327 in public method `satisfies_constraints`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/fuzzer.py:347 in public class `Fuzzer`:
        D101: Missing docstring in public class
torch/utils/benchmark/utils/fuzzer.py:398 in public method `take`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/fuzzer.py:412 in public method `rejection_rate`:
        D102: Missing docstring in public method
12
```
15. `torch/utils/benchmark/utils/sparse_fuzzer.py`
Before - 4
```
torch/utils/benchmark/utils/sparse_fuzzer.py:1 at module level:
        D100: Missing docstring in public module
torch/utils/benchmark/utils/sparse_fuzzer.py:7 in public class `FuzzedSparseTensor`:
        D101: Missing docstring in public class
torch/utils/benchmark/utils/sparse_fuzzer.py:22 in public method `__init__`:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/benchmark/utils/sparse_fuzzer.py:22 in public method `__init__`:
        D400: First line should end with a period (not ':')
4
```
After - 2
```
torch/utils/benchmark/utils/sparse_fuzzer.py:1 at module level:
        D100: Missing docstring in public module
torch/utils/benchmark/utils/sparse_fuzzer.py:7 in public class `FuzzedSparseTensor`:
        D101: Missing docstring in public class
2
```
16. `torch/utils/benchmark/utils/timer.py`
Before - 9
```
torch/utils/benchmark/utils/timer.py:17 in public function `timer`:
        D103: Missing docstring in public function
torch/utils/benchmark/utils/timer.py:24 in public function `timer`:
        D103: Missing docstring in public function
torch/utils/benchmark/utils/timer.py:32 in public class `Language`:
        D101: Missing docstring in public class
torch/utils/benchmark/utils/timer.py:185 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/benchmark/utils/timer.py:267 in public method `timeit`:
        D402: First line should not be the function's "signature"
torch/utils/benchmark/utils/timer.py:282 in public method `repeat`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/timer.py:285 in public method `autorange`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/timer.py:399 in public method `adaptive_autorange`:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/benchmark/utils/timer.py:399 in public method `adaptive_autorange`:
        D400: First line should end with a period (not 's')
9
```
After - 8
```
torch/utils/benchmark/utils/timer.py:17 in public function `timer`:
        D103: Missing docstring in public function
torch/utils/benchmark/utils/timer.py:24 in public function `timer`:
        D103: Missing docstring in public function
torch/utils/benchmark/utils/timer.py:32 in public class `Language`:
        D101: Missing docstring in public class
torch/utils/benchmark/utils/timer.py:185 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/benchmark/utils/timer.py:284 in public method `repeat`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/timer.py:287 in public method `autorange`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/timer.py:401 in public method `adaptive_autorange`:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/benchmark/utils/timer.py:401 in public method `adaptive_autorange`:
        D400: First line should end with a period (not 's')
8
```
17. `torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py`
Before - 22
```
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:31 in public class `FunctionCount`:
        D101: Missing docstring in public class
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:39 in public class `FunctionCounts`:
        D204: 1 blank line required after class docstring (found 0)
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:57 in public method `__iter__`:     
        D105: Missing docstring in magic method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:60 in public method `__len__`:      
        D105: Missing docstring in magic method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:63 in public method `__getitem__`:  
        D105: Missing docstring in magic method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:70 in public method `__repr__`:     
        D105: Missing docstring in magic method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:93 in public method `__add__`:      
        D105: Missing docstring in magic method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:99 in public method `__sub__`:
        D105: Missing docstring in magic method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:105 in public method `__mul__`:
        D105: Missing docstring in magic method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:127 in public method `sum`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:131 in public method `denoise`:
        D209: Multi-line docstring closing quotes should be on a separate line
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:163 in public class `CallgrindStats`:
        D204: 1 blank line required after class docstring (found 0)
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:179 in public method `__repr__`:
        D105: Missing docstring in magic method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:198 in public method `stats`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:212 in public method `counts`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:307 in public class `CopyIfCallgrind`:
        D204: 1 blank line required after class docstring (found 0)
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:311 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:330 in public method `value`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:334 in public method `setup`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:338 in public method `serialization`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:342 in public method `unwrap_all`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:756 in private nested function `block_stmt`:
        D401: First line should be in imperative mood (perhaps 'Partial', not 'Partially')
22
```
After - 15
```
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:31 in public class `FunctionCount`:
        D101: Missing docstring in public class
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:58 in public method `__iter__`:
        D105: Missing docstring in magic method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:61 in public method `__len__`:
        D105: Missing docstring in magic method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:64 in public method `__getitem__`:
        D105: Missing docstring in magic method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:71 in public method `__repr__`:
        D105: Missing docstring in magic method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:94 in public method `__add__`:
        D105: Missing docstring in magic method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:100 in public method `__sub__`:
        D105: Missing docstring in magic method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:106 in public method `__mul__`:
        D105: Missing docstring in magic method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:128 in public method `sum`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:182 in public method `__repr__`:
        D105: Missing docstring in magic method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:315 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:334 in public method `value`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:338 in public method `setup`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:342 in public method `serialization`:
        D102: Missing docstring in public method
torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py:346 in public method `unwrap_all`:
        D102: Missing docstring in public method
15
```
18. `torch/utils/hipify/hipify_python.py`
Before - 69
```
torch/utils/hipify/hipify_python.py:2 at module level:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/hipify/hipify_python.py:2 at module level:
        D210: No whitespaces allowed surrounding docstring text
torch/utils/hipify/hipify_python.py:41 in public class `CurrentState`:
        D101: Missing docstring in public class
torch/utils/hipify/hipify_python.py:45 in public class `HipifyResult`:
        D101: Missing docstring in public class
torch/utils/hipify/hipify_python.py:46 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/hipify/hipify_python.py:51 in public method `__str__`:
        D105: Missing docstring in magic method
torch/utils/hipify/hipify_python.py:72 in public class `InputError`:
        D101: Missing docstring in public class
torch/utils/hipify/hipify_python.py:75 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/hipify/hipify_python.py:79 in public method `__str__`:
        D105: Missing docstring in magic method
torch/utils/hipify/hipify_python.py:83 in public function `openf`:
        D103: Missing docstring in public function
torch/utils/hipify/hipify_python.py:88 in public class `bcolors`:
        D101: Missing docstring in public class
torch/utils/hipify/hipify_python.py:108 in public class `GeneratedFileCleaner`:
        D204: 1 blank line required after class docstring (found 0)
torch/utils/hipify/hipify_python.py:108 in public class `GeneratedFileCleaner`:
        D400: First line should end with a period (not 's')
torch/utils/hipify/hipify_python.py:109 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/hipify/hipify_python.py:114 in public method `__enter__`:
        D105: Missing docstring in magic method
torch/utils/hipify/hipify_python.py:117 in public method `open`:
        D102: Missing docstring in public method
torch/utils/hipify/hipify_python.py:122 in public method `makedirs`:
        D102: Missing docstring in public method
torch/utils/hipify/hipify_python.py:132 in public method `__exit__`:
        D105: Missing docstring in magic method
torch/utils/hipify/hipify_python.py:141 in public function `match_extensions`:
        D400: First line should end with a period (not 'n')
torch/utils/hipify/hipify_python.py:141 in public function `match_extensions`:
        D401: First line should be in imperative mood; try rephrasing (found 'Helper')
torch/utils/hipify/hipify_python.py:149 in public function `matched_files_iter`:
        D103: Missing docstring in public function
torch/utils/hipify/hipify_python.py:193 in public function `preprocess_file_and_save_result`:
        D103: Missing docstring in public function
torch/utils/hipify/hipify_python.py:218 in public function `compute_stats`:
        D103: Missing docstring in public function
torch/utils/hipify/hipify_python.py:232 in public function `add_dim3`:
        D300: Use """triple double quotes""" (found '''-quotes)
torch/utils/hipify/hipify_python.py:232 in public function `add_dim3`:
        D400: First line should end with a period (not 'h')
torch/utils/hipify/hipify_python.py:232 in public function `add_dim3`:
        D401: First line should be in imperative mood (perhaps 'Add', not 'adds')
torch/utils/hipify/hipify_python.py:232 in public function `add_dim3`:
        D403: First word of the first line should be properly capitalized ('Adds', not 'adds')
torch/utils/hipify/hipify_python.py:270 in public function `processKernelLaunches`:
        D210: No whitespaces allowed surrounding docstring text
torch/utils/hipify/hipify_python.py:334 in private nested function `find_kernel_bounds`:
        D401: First line should be in imperative mood (perhaps 'Find', not 'Finds')
torch/utils/hipify/hipify_python.py:424 in public function `find_closure_group`:
        D202: No blank lines allowed after function docstring (found 1)
torch/utils/hipify/hipify_python.py:424 in public function `find_closure_group`:
        D400: First line should end with a period (not 'p')
torch/utils/hipify/hipify_python.py:462 in public function `find_bracket_group`:
        D401: First line should be in imperative mood (perhaps 'Find', not 'Finds')
torch/utils/hipify/hipify_python.py:467 in public function `find_parentheses_group`:
        D401: First line should be in imperative mood (perhaps 'Find', not 'Finds')
torch/utils/hipify/hipify_python.py:475 in public function `replace_math_functions`:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/hipify/hipify_python.py:475 in public function `replace_math_functions`:
        D208: Docstring is over-indented
torch/utils/hipify/hipify_python.py:475 in public function `replace_math_functions`:
        D400: First line should end with a period (not 's')
torch/utils/hipify/hipify_python.py:494 in public function `hip_header_magic`:
        D202: No blank lines allowed after function docstring (found 1)
torch/utils/hipify/hipify_python.py:494 in public function `hip_header_magic`:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/hipify/hipify_python.py:494 in public function `hip_header_magic`:
        D400: First line should end with a period (not ',')
torch/utils/hipify/hipify_python.py:526 in public function `replace_extern_shared`:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/hipify/hipify_python.py:540 in public function `get_hip_file_path`:
        D200: One-line docstring should fit on one line with quotes (found 3)
torch/utils/hipify/hipify_python.py:540 in public function `get_hip_file_path`:
        D400: First line should end with a period (not 'e')
torch/utils/hipify/hipify_python.py:540 in public function `get_hip_file_path`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/utils/hipify/hipify_python.py:611 in public function `is_out_of_place`:
        D103: Missing docstring in public function
torch/utils/hipify/hipify_python.py:623 in public function `is_pytorch_file`:
        D103: Missing docstring in public function
torch/utils/hipify/hipify_python.py:638 in public function `is_cusparse_file`:
        D103: Missing docstring in public function
torch/utils/hipify/hipify_python.py:644 in public function `is_special_file`:
        D103: Missing docstring in public function
torch/utils/hipify/hipify_python.py:654 in public function `is_caffe2_gpu_file`:
        D103: Missing docstring in public function
torch/utils/hipify/hipify_python.py:665 in public class `Trie`:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/hipify/hipify_python.py:665 in public class `Trie`:
        D209: Multi-line docstring closing quotes should be on a separate line
torch/utils/hipify/hipify_python.py:668 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/hipify/hipify_python.py:671 in public method `add`:
        D102: Missing docstring in public method
torch/utils/hipify/hipify_python.py:678 in public method `dump`:
        D102: Missing docstring in public method
torch/utils/hipify/hipify_python.py:681 in public method `quote`:
        D102: Missing docstring in public method
torch/utils/hipify/hipify_python.py:721 in public method `pattern`:
        D102: Missing docstring in public method
torch/utils/hipify/hipify_python.py:785 in public function `preprocessor`:
        D210: No whitespaces allowed surrounding docstring text
torch/utils/hipify/hipify_python.py:785 in public function `preprocessor`:
        D401: First line should be in imperative mood (perhaps 'Execute', not 'Executes')
torch/utils/hipify/hipify_python.py:959 in public function `file_specific_replacement`:
        D103: Missing docstring in public function
torch/utils/hipify/hipify_python.py:971 in public function `file_add_header`:
        D103: Missing docstring in public function
torch/utils/hipify/hipify_python.py:983 in public function `fix_static_global_kernels`:
        D401: First line should be in imperative mood; try rephrasing (found 'Static')
torch/utils/hipify/hipify_python.py:992 in public function `extract_arguments`:
        D202: No blank lines allowed after function docstring (found 1)
torch/utils/hipify/hipify_python.py:992 in public function `extract_arguments`:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/hipify/hipify_python.py:992 in public function `extract_arguments`:
        D208: Docstring is over-indented
torch/utils/hipify/hipify_python.py:992 in public function `extract_arguments`:
        D210: No whitespaces allowed surrounding docstring text
torch/utils/hipify/hipify_python.py:1038 in public function `str2bool`:
        D205: 1 blank line required between summary line and description (found 0)
torch/utils/hipify/hipify_python.py:1038 in public function `str2bool`:
        D209: Multi-line docstring closing quotes should be on a separate line
torch/utils/hipify/hipify_python.py:1038 in public function `str2bool`:
        D400: First line should end with a period (not 't')
torch/utils/hipify/hipify_python.py:1038 in public function `str2bool`:
        D403: First word of the first line should be properly capitalized ('Argumentparser', not 'ArgumentParser')
torch/utils/hipify/hipify_python.py:1048 in public function `hipify`:
        D103: Missing docstring in public function
69
```
After - 30
```
torch/utils/hipify/hipify_python.py:42 in public class `CurrentState`:
        D101: Missing docstring in public class
torch/utils/hipify/hipify_python.py:46 in public class `HipifyResult`:
        D101: Missing docstring in public class
torch/utils/hipify/hipify_python.py:47 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/hipify/hipify_python.py:52 in public method `__str__`:
        D105: Missing docstring in magic method
torch/utils/hipify/hipify_python.py:73 in public class `InputError`:
        D101: Missing docstring in public class
torch/utils/hipify/hipify_python.py:76 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/hipify/hipify_python.py:80 in public method `__str__`:
        D105: Missing docstring in magic method
torch/utils/hipify/hipify_python.py:84 in public function `openf`:
        D103: Missing docstring in public function
torch/utils/hipify/hipify_python.py:89 in public class `bcolors`:
        D101: Missing docstring in public class
torch/utils/hipify/hipify_python.py:111 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/hipify/hipify_python.py:116 in public method `__enter__`:
        D105: Missing docstring in magic method
torch/utils/hipify/hipify_python.py:119 in public method `open`:
        D102: Missing docstring in public method
torch/utils/hipify/hipify_python.py:124 in public method `makedirs`:
        D102: Missing docstring in public method
torch/utils/hipify/hipify_python.py:134 in public method `__exit__`:
        D105: Missing docstring in magic method
torch/utils/hipify/hipify_python.py:151 in public function `matched_files_iter`:
        D103: Missing docstring in public function
torch/utils/hipify/hipify_python.py:195 in public function `preprocess_file_and_save_result`:
        D103: Missing docstring in public function
torch/utils/hipify/hipify_python.py:220 in public function `compute_stats`:
        D103: Missing docstring in public function
torch/utils/hipify/hipify_python.py:612 in public function `is_out_of_place`:
        D103: Missing docstring in public function
torch/utils/hipify/hipify_python.py:624 in public function `is_pytorch_file`:
        D103: Missing docstring in public function
torch/utils/hipify/hipify_python.py:639 in public function `is_cusparse_file`:
        D103: Missing docstring in public function
torch/utils/hipify/hipify_python.py:645 in public function `is_special_file`:
        D103: Missing docstring in public function
torch/utils/hipify/hipify_python.py:655 in public function `is_caffe2_gpu_file`:
        D103: Missing docstring in public function
torch/utils/hipify/hipify_python.py:671 in public method `__init__`:
        D107: Missing docstring in __init__
torch/utils/hipify/hipify_python.py:674 in public method `add`:
        D102: Missing docstring in public method
torch/utils/hipify/hipify_python.py:681 in public method `dump`:
        D102: Missing docstring in public method
torch/utils/hipify/hipify_python.py:684 in public method `quote`:
        D102: Missing docstring in public method
torch/utils/hipify/hipify_python.py:724 in public method `pattern`:
        D102: Missing docstring in public method
torch/utils/hipify/hipify_python.py:962 in public function `file_specific_replacement`:
        D103: Missing docstring in public function
torch/utils/hipify/hipify_python.py:974 in public function `file_add_header`:
        D103: Missing docstring in public function
torch/utils/hipify/hipify_python.py:1053 in public function `hipify`:
        D103: Missing docstring in public function
30
```
19. `torch/utils/model_dump/__init__.py`
Before - 6
```
torch/utils/model_dump/__init__.py:90 in public function `get_storage_info`:
        D103: Missing docstring in public function
torch/utils/model_dump/__init__.py:108 in public function `hierarchical_pickle`:
        D103: Missing docstring in public function
torch/utils/model_dump/__init__.py:192 in public function `get_model_info`:
        D202: No blank lines allowed after function docstring (found 1)
torch/utils/model_dump/__init__.py:355 in public function `get_inline_skeleton`:
        D202: No blank lines allowed after function docstring (found 1)
torch/utils/model_dump/__init__.py:374 in public function `burn_in_info`:
        D202: No blank lines allowed after function docstring (found 1)
torch/utils/model_dump/__init__.py:389 in public function `get_info_and_burn_skeleton`:
        D103: Missing docstring in public function
6
```
After - 3
```
torch/utils/model_dump/__init__.py:90 in public function `get_storage_info`:
        D103: Missing docstring in public function
torch/utils/model_dump/__init__.py:108 in public function `hierarchical_pickle`:
        D103: Missing docstring in public function
torch/utils/model_dump/__init__.py:386 in public function `get_info_and_burn_skeleton`:
        D103: Missing docstring in public function
3
```