### PR TITLE
add device=p.device to Adam optimizer when creating zero tensor, fix tensors not on the same device issue.

### DIFF
--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -105,7 +105,7 @@ class Adam(Optimizer):
                     state['step'] = (
                         torch.zeros((), dtype=torch.float, device=p.device)
                         if group['capturable'] or group['fused']
-                        else torch.tensor(0.)
+                        else torch.tensor(0., device=p.device)
                     )
                     # Exponential moving average of gradient values
                     state['exp_avg'] = torch.zeros_like(p, memory_format=torch.preserve_format)


### PR DESCRIPTION
Fixes #113758
