### PR TITLE
[C10] cpuinfo error handling

### DIFF
--- a/c10/core/thread_pool.cpp
+++ b/c10/core/thread_pool.cpp
@@ -9,10 +9,11 @@ namespace c10 {
 size_t TaskThreadPoolBase::defaultNumThreads() {
   size_t num_threads = 0;
 #if !defined(__powerpc__) && !defined(__s390x__)
-  cpuinfo_initialize();
-  num_threads = cpuinfo_get_processors_count();
-  if (num_threads > 0) {
-    return num_threads;
+  if (cpuinfo_initialize()) {
+    num_threads = cpuinfo_get_processors_count();
+    if (num_threads > 0) {
+      return num_threads;
+    }
   }
 #endif
   num_threads = std::thread::hardware_concurrency();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #113771

If `cpuinfo_initalize` returns false, call to subsequent cpuinfo functions may result in `abort()`
Also, `defaultNumThreads()` method is assumption if one method fails then try another, and finally return 1.

Alas there are no good way to test it on x86 platform, but on ARM one can replicate it by running `sudo chmod 750 /sys` and then `python3 -c "import torch;torch._C.profiler.gather_traceback(True, True, True)"`

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4d942e8</samp>

> _`cpuinfo` fails_
> _avoid undefined behavior_
> _check before you count_

Partially addresses https://github.com/pytorch/pytorch/issues/113568