### PR TITLE
[HigherOrderOp] remove _deprecated_global_ns (#112757)

### DIFF
--- a/functorch/experimental/_map.py
+++ b/functorch/experimental/_map.py
@@ -34,7 +34,7 @@ class MapWrapper(HigherOrderOperator):
         return map_wrapper(xs, *args)
 
 
-map = MapWrapper("map", _deprecated_global_ns=True)
+map = MapWrapper("map")
 map_impl = HigherOrderOperator("map_impl")
 
 dummy_aot_config = AOTConfig(

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -216,7 +216,7 @@ class TestDeserialize(TestCase):
         def _check_graph_nodes(gm1, gm2, _check_meta=True):
             # TODO: The _check_meta flag bypasses checking for
             # source_fn/nn_module_stack as there is an issue with
-            # roundtripping the source_fn value on torch.ops.map nodes
+            # roundtripping the source_fn value on torch.ops.higher_order.map_impl nodes
             # original source_fn: <functorch.experimental._map.MapWrapper object at 0x7f80a0549930>
             # deserialized source_fn: 'functorch.experimental._map.map'
 

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -231,7 +231,6 @@ def resolve_key(op: OperatorBase, k: DispatchKey):  # type: ignore[valid-type]
     raise NotImplementedError(f"could not find kernel for {op} at dispatch key {k}")
 
 
-_global_higher_order_ops = {}
 _higher_order_ops = {}
 
 _HIGHER_ORDER_OP_DEFAULT_FALLTHROUGH_DISPATCH_KEYS = [
@@ -245,25 +244,19 @@ _HIGHER_ORDER_OP_DEFAULT_FALLTHROUGH_DISPATCH_KEYS = [
 
 
 class HigherOrderOperator(OperatorBase):
-    # _deprecated_global_ns: Whether or not the HigherOrderOperator appears as:
-    # (True) torch.ops.{name}
-    # (False) torch.ops.higher_order.{name}
+    # The HigherOrderOperator will appear as torch.ops.higher_order.{name}
     #
     # If you're creating a new HigherOrderOperator, please do not change the
     # default. Adding operators to the global torch.ops namespace is a bad
     # practice due to name collisions.
-    def __init__(self, name, *, _deprecated_global_ns=False):
+    def __init__(self, name):
         super().__init__()
         self._name = name
 
         # Make _OPNamespace not scream, this whole name based association needs a good hard look
         self.__name__ = name
-        if _deprecated_global_ns:
-            _global_higher_order_ops[name] = self
-            self._ns = None
-        else:
-            _higher_order_ops[name] = self
-            self._ns = "higher_order"
+        _higher_order_ops[name] = self
+        self._ns = "higher_order"
 
         # For a normal HigherOrderOperator instance, we will change its __module__ from torch._ops to
         # torch._ops.higher_order.
@@ -871,9 +864,6 @@ class _Ops(types.ModuleType):
     def __init__(self):
         super().__init__("torch.ops")
         self.loaded_libraries = set()
-        self._global_higher_order_op_namespace = _PyOpNamespace(
-            "torch.ops", _global_higher_order_ops
-        )
         self._higher_order_op_namespace = _PyOpNamespace(
             "torch.ops.higher_order", _higher_order_ops
         )
@@ -881,8 +871,6 @@ class _Ops(types.ModuleType):
 
     def __getattr__(self, name):
         # Check if the name is a HigherOrderOperator
-        if name in self._global_higher_order_op_namespace._ops:
-            return getattr(self._global_higher_order_op_namespace, name)
         if name == "higher_order":
             return self._higher_order_op_namespace
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/executorch/pull/1167




As titled.

Test Plan:
existing test.


cc zou3519

imported-using-ghimport

Differential Revision: D51032385

Pulled By: ydwu4




cc @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan @angelayi @suo