### PR TITLE
[TD] Fix metric emission for split test files

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1667,7 +1667,7 @@ def main():
     aggregated_heuristics: AggregatedHeuristics = AggregatedHeuristics(
         unranked_tests=selected_tests
     )
-    metrics_dict = {}
+
     if IS_CI:
         # downloading test cases configuration to local environment
         get_test_case_configs(dirpath=test_directory)
@@ -1675,14 +1675,6 @@ def main():
 
     test_prioritizations = aggregated_heuristics.get_aggregated_priorities()
     test_prioritizations.print_info()
-
-    if IS_CI:
-        metrics_dict = {
-            "high_relevance_tests": test_prioritizations.get_high_relevance_tests(),
-            "probable_relevance_tests": test_prioritizations.get_probable_relevance_tests(),
-            "unranked_relevance_tests": test_prioritizations.get_unranked_relevance_tests(),
-            "cpp": options.cpp,
-        }
 
     test_file_times_dict = load_test_file_times()
     test_class_times_dict = load_test_class_times()
@@ -1775,13 +1767,9 @@ def main():
             print_to_stderr(
                 f"With sharding, this batch will run {len(test_batch.sharded_tests)} tests"
             )
-            metrics_dict[f"{test_batch.name}_start_time"] = elapsed_time
             run_tests(
                 test_batch.sharded_tests, test_directory, options, test_batch.failures
             )
-            metrics_dict[f"{test_batch.name}_failures"] = [
-                str(x.test) for x in test_batch.failures
-            ]
 
     finally:
         if options.coverage:
@@ -1799,8 +1787,6 @@ def main():
         all_failures = [failure for batch in test_batches for failure in batch.failures]
 
         if IS_CI:
-            emit_metric("td_experiment_1", metrics_dict)
-
             num_tests = len(selected_tests)
             for test, _ in all_failures:
                 test_stats = aggregated_heuristics.get_test_stats(test)

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1777,7 +1777,13 @@ def main():
             )
             metrics_dict[f"{test_batch.name}_start_time"] = elapsed_time
             run_tests(
-                test_batch.sharded_tests, test_directory, options, [{"test": str(f.test), "message": f.message} for f in test_batch.failures]
+                test_batch.sharded_tests,
+                test_directory,
+                options,
+                [
+                    {"test": str(f.test), "message": f.message}
+                    for f in test_batch.failures
+                ],
             )
             metrics_dict[f"{test_batch.name}_failures"] = [
                 str(x.test) for x in test_batch.failures

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1777,13 +1777,7 @@ def main():
             )
             metrics_dict[f"{test_batch.name}_start_time"] = elapsed_time
             run_tests(
-                test_batch.sharded_tests,
-                test_directory,
-                options,
-                [
-                    {"test": str(f.test), "message": f.message}
-                    for f in test_batch.failures
-                ],
+                test_batch.sharded_tests, test_directory, options, test_batch.failures
             )
             metrics_dict[f"{test_batch.name}_failures"] = [
                 str(x.test) for x in test_batch.failures

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1777,7 +1777,7 @@ def main():
             )
             metrics_dict[f"{test_batch.name}_start_time"] = elapsed_time
             run_tests(
-                test_batch.sharded_tests, test_directory, options, test_batch.failures
+                test_batch.sharded_tests, test_directory, options, [{"test": str(f.test), "message": f.message} for f in test_batch.failures]
             )
             metrics_dict[f"{test_batch.name}_failures"] = [
                 str(x.test) for x in test_batch.failures

--- a/tools/stats/upload_metrics.py
+++ b/tools/stats/upload_metrics.py
@@ -163,7 +163,7 @@ def emit_metric(
             # We still raise the ValueErrors outside this try block since those indicate improperly configured metrics
             warn(f"Error uploading metric {metric_name} to DynamoDB: {e}")
             warn("Full metrics:")
-            for k, v in enumerate(metrics):
+            for k, v in metrics.items():
                 warn(f"  {k}: {v}")
             return
     else:

--- a/tools/stats/upload_metrics.py
+++ b/tools/stats/upload_metrics.py
@@ -162,6 +162,9 @@ def emit_metric(
             # We don't want to fail the job if we can't upload the metric.
             # We still raise the ValueErrors outside this try block since those indicate improperly configured metrics
             warn(f"Error uploading metric {metric_name} to DynamoDB: {e}")
+            warn("Full metrics:")
+            for k, v in enumerate(metrics):
+                warn(f"  {k}: {v}")
             return
     else:
         print(f"Not emitting metrics for {metric_name}. Boto wasn't imported.")

--- a/tools/stats/upload_metrics.py
+++ b/tools/stats/upload_metrics.py
@@ -162,10 +162,6 @@ def emit_metric(
             # We don't want to fail the job if we can't upload the metric.
             # We still raise the ValueErrors outside this try block since those indicate improperly configured metrics
             warn(f"Error uploading metric {metric_name} to DynamoDB: {e}")
-            error = "Full metrics:\n"
-            for k, v in metrics.items():
-                error += f"  {k}: {v}\n"
-            warn(error)
             return
     else:
         print(f"Not emitting metrics for {metric_name}. Boto wasn't imported.")

--- a/tools/stats/upload_metrics.py
+++ b/tools/stats/upload_metrics.py
@@ -162,9 +162,10 @@ def emit_metric(
             # We don't want to fail the job if we can't upload the metric.
             # We still raise the ValueErrors outside this try block since those indicate improperly configured metrics
             warn(f"Error uploading metric {metric_name} to DynamoDB: {e}")
-            warn("Full metrics:")
+            error = "Full metrics:\n"
             for k, v in metrics.items():
-                warn(f"  {k}: {v}")
+                error += f"  {k}: {v}\n"
+            warn(error)
             return
     else:
         print(f"Not emitting metrics for {metric_name}. Boto wasn't imported.")

--- a/tools/test/heuristics/test_heuristics.py
+++ b/tools/test/heuristics/test_heuristics.py
@@ -430,7 +430,7 @@ class TestAggregatedHeuristics(HeuristicsTestMixin):
         aggregator.add_heuristic_results(HEURISTICS[0], heuristic1)
         aggregator.add_heuristic_results(HEURISTICS[1], heuristic2)
 
-        # This should not throw an error
+        # These should not throw an error
         aggregator.get_test_stats(TestRun("test2::TestFooClass"))
         aggregator.get_test_stats(TestRun("test2"))
 

--- a/tools/test/heuristics/test_heuristics.py
+++ b/tools/test/heuristics/test_heuristics.py
@@ -3,7 +3,7 @@ import json
 import pathlib
 import sys
 import unittest
-from typing import Any, Dict, Set
+from typing import Any, Dict, List, Set
 from unittest import mock
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
@@ -18,6 +18,9 @@ try:
         TestPrioritizations,
     )
     from tools.testing.target_determination.heuristics import HEURISTICS
+    from tools.testing.target_determination.heuristics.interface import (
+        HeuristicInterface,
+    )
     from tools.testing.target_determination.heuristics.previously_failed_in_pr import (
         _get_previously_failing_tests,
     )
@@ -33,6 +36,22 @@ def mocked_file(contents: Dict[Any, Any]) -> io.IOBase:
     json.dump(contents, file_object)
     file_object.seek(0)
     return file_object
+
+
+class DummyHeuristicOne(HeuristicInterface):
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+
+    def get_test_priorities(self, tests: List[str]) -> TestPrioritizations:
+        return TestPrioritizations(tests_being_ranked=tests)
+
+    def get_prediction_confidence(self, tests: List[str]) -> Dict[str, float]:
+        return {test: 1 for test in tests}
+
+
+class DummyHeuristicTwo(DummyHeuristicOne):
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
 
 
 class TestParsePrevTests(HeuristicsTestMixin):
@@ -414,6 +433,28 @@ class TestAggregatedHeuristics(HeuristicsTestMixin):
             expected_probable_tests=expected_aggregated_probable_relevance,
             expected_unranked_tests=expected_aggregated_unranked_relevance,
         )
+
+    def test_add_test_mode_heuristics_with_class_granularity(self) -> None:
+        tests = ["test1", "test2", "test3", "test4", "test5"]
+        heuristic1 = TestPrioritizations(
+            tests_being_ranked=tests,
+            probable_relevance=["test2"],
+        )
+        heuristic2 = TestPrioritizations(
+            tests_being_ranked=tests,
+            high_relevance=["test2::TestFooClass"],
+        )
+
+        failing_test_run = TestRun(
+            "test2"
+        )  # Since the class level heuristic is a trial one, only the full test can fail
+
+        aggregator = AggregatedHeuristics(unranked_tests=tests)
+        aggregator.add_heuristic_results(DummyHeuristicOne(), heuristic1)
+        aggregator.add_heuristic_results(DummyHeuristicTwo(trial_mode=True), heuristic2)
+
+        # This should not throw an error
+        aggregator.get_test_stats(failing_test_run)
 
 
 if __name__ == "__main__":

--- a/tools/testing/target_determination/heuristics/__init__.py
+++ b/tools/testing/target_determination/heuristics/__init__.py
@@ -27,7 +27,7 @@ from tools.testing.target_determination.heuristics.profiling import Profiling
 HEURISTICS: List[HeuristicInterface] = [
     PreviouslyFailedInPR(),
     EditedByPR(),
-    # HistoricalClassFailurCorrelation(trial_mode=True),  TODO: https://github.com/pytorch/pytorch/pull/113497
+    HistoricalClassFailurCorrelation(trial_mode=True),
     CorrelatedWithHistoricalFailures(),
     HistorialEditedFiles(trial_mode=True),
     Profiling(trial_mode=True),

--- a/tools/testing/target_determination/heuristics/interface.py
+++ b/tools/testing/target_determination/heuristics/interface.py
@@ -263,41 +263,52 @@ class TestPrioritizations:
             _print_tests(f"{Relevance(relevance_group).name.title()} Relevance", tests)
 
     def _get_test_relevance_group(self, test_run: TestRun) -> Relevance:
-        """Returns the rank of the given test run."""
+        """
+        Returns the relevance of the given test run.
+        If the heuristic split this test run among multiple runs, then return the
+        highest relevance of any of the test runs.
+        """
         for relevance_group, tests in self._traverse_priorities():
-            if any(t.contains(test_run) for t in tests):
-                return Relevance(relevance_group)
-
-        print("holup, retry")
-        for relevance_group, tests in self._traverse_priorities():
-            if any(
-                t.contains(test_run) for t in tests
-            ):  # t could be the entire test_run or a superset
+            #  Different heuristics may result in a given test file being split
+            #  into different test runs, so look for the overlapping tests to
+            #  find the match
+            if any(t & test_run for t in tests):
                 return Relevance(relevance_group)
 
         raise ValueError(f"Test {test_run} not found in any relevance group")
 
     def _get_test_order(self, test_run: TestRun) -> int:
-        """Returns the rank this heuristic suggested for the test run."""
+        """
+        Returns the rank this heuristic suggested for the test run.
+        If the heuristic split this test run among multiple runs, then return the
+        highest relevance of any of the test runs.
+        """
         base_rank = 0
 
         for _, relevance_group_tests in self._traverse_priorities():
             for idx, test in enumerate(relevance_group_tests):
-                if test.contains(
-                    test_run
-                ):  # test could be the entire test_run or a superset
+                #  Different heuristics may result in a given test file being split
+                #  into different test runs, so look for the overlapping tests to
+                #  find the match
+                if test & test_run:
                     return base_rank + idx
             base_rank += len(relevance_group_tests)
 
         raise ValueError(f"Test {test_run} not found in any relevance group")
 
     def _get_test_order_within_relevance_group(self, test_run: TestRun) -> int:
-        """Returns the highest test order of any test class within the same relevance group."""
+        """
+        Returns the highest test order of any test class within the same relevance group.
+        If the heuristic split this test run among multiple runs, then return the
+        highest relevance of any of the test runs.
+        """
+        # Look for a complete match first
         for _, relevance_group_tests in self._traverse_priorities():
             for idx, test in enumerate(relevance_group_tests):
-                if test.contains(
-                    test_run
-                ):  # test could be the entire test_run or a superset
+                #  Different heuristics may result in a given test file being split
+                #  into different test runs, so look for the overlapping tests to
+                #  find the match
+                if test & test_run:
                     return idx
 
         raise ValueError(f"Test {test_run} not found in any relevance group")

--- a/tools/testing/target_determination/heuristics/interface.py
+++ b/tools/testing/target_determination/heuristics/interface.py
@@ -302,7 +302,6 @@ class TestPrioritizations:
         If the heuristic split this test run among multiple runs, then return the
         highest relevance of any of the test runs.
         """
-        # Look for a complete match first
         for _, relevance_group_tests in self._traverse_priorities():
             for idx, test in enumerate(relevance_group_tests):
                 #  Different heuristics may result in a given test file being split


### PR DESCRIPTION
Fixes a bug in TD metrics generation where it wouldn't be able to find the rank and relevance that a heuristic gave a test run if that heuristic had divided that test into multiple test runs.
