### PR TITLE
[nccl-pg] Migrate to getCvar* functions for env variable checking

### DIFF
--- a/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
@@ -269,7 +269,7 @@ class ProcessGroupNCCLErrorsTest : public ::testing::Test {
   }
 
   void TearDown() override {
-    ASSERT_TRUE(setenv(c10d::NCCL_BLOCKING_WAIT, "0", 1) == 0);
+    ASSERT_TRUE(setenv(c10d::NCCL_BLOCKING_WAIT[0].c_str(), "0", 1) == 0);
   }
 
   std::vector<at::Tensor> tensors_;
@@ -281,7 +281,7 @@ TEST_F(ProcessGroupNCCLErrorsTest, testNCCLErrorsBlocking) {
     return;
   }
 
-  ASSERT_TRUE(setenv(c10d::NCCL_BLOCKING_WAIT, "1", 1) == 0);
+  ASSERT_TRUE(setenv(c10d::NCCL_BLOCKING_WAIT[0].c_str(), "1", 1) == 0);
   auto options = c10d::ProcessGroupNCCL::Options::create();
   options->timeout = std::chrono::milliseconds(1000);
   ProcessGroupNCCLSimulateErrors pg(store_, 0, 1, options);
@@ -309,7 +309,7 @@ TEST_F(ProcessGroupNCCLErrorsTest, testNCCLTimedoutErrorsBlocking) {
     return;
   }
 
-  ASSERT_TRUE(setenv(c10d::NCCL_BLOCKING_WAIT, "1", 1) == 0);
+  ASSERT_TRUE(setenv(c10d::NCCL_BLOCKING_WAIT[0].c_str(), "1", 1) == 0);
   auto options = c10d::ProcessGroupNCCL::Options::create();
   options->timeout = std::chrono::milliseconds(3000);
   ProcessGroupNCCLTimedOutErrors pg(store_, 0, 1, options);
@@ -395,11 +395,14 @@ TEST_F(ProcessGroupNCCLErrorsTest, testNCCLErrorsNoHeartbeat) {
 
   int heartBeatIntervalInSec = 2;
   std::string timeInterval = std::to_string(heartBeatIntervalInSec);
-  ASSERT_TRUE(setenv(c10d::NCCL_BLOCKING_WAIT, "1", 1) == 0);
+  ASSERT_TRUE(setenv(c10d::NCCL_BLOCKING_WAIT[0].c_str(), "1", 1) == 0);
   ASSERT_TRUE(
-      setenv(c10d::TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC, timeInterval.c_str(), 1) ==
-      0);
-  ASSERT_TRUE(setenv(c10d::TORCH_NCCL_ENABLE_MONITORING, "1", 1) == 0);
+      setenv(
+          c10d::TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC[0].c_str(),
+          timeInterval.c_str(),
+          1) == 0);
+  ASSERT_TRUE(
+      setenv(c10d::TORCH_NCCL_ENABLE_MONITORING[0].c_str(), "1", 1) == 0);
   auto tempFilename = c10::str(
       std::filesystem::temp_directory_path().string(), "/nccl_trace_rank_");
   ASSERT_TRUE(
@@ -450,17 +453,20 @@ class ProcessGroupNCCLWatchdogTimeoutTest : public ProcessGroupNCCLErrorsTest {
   void SetUp() override {
     ProcessGroupNCCLErrorsTest::SetUp();
     std::string timeInterval = std::to_string(heartBeatIntervalInSec);
-    ASSERT_TRUE(setenv(c10d::NCCL_BLOCKING_WAIT, "1", 1) == 0);
+    ASSERT_TRUE(setenv(c10d::NCCL_BLOCKING_WAIT[0].c_str(), "1", 1) == 0);
     ASSERT_TRUE(
         setenv(
-            c10d::TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC, timeInterval.c_str(), 1) ==
-        0);
-    ASSERT_TRUE(setenv(c10d::TORCH_NCCL_ENABLE_MONITORING, "1", 1) == 0);
-    ASSERT_TRUE(setenv(c10d::NCCL_DESYNC_DEBUG, "1", 1) == 0);
+            c10d::TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC[0].c_str(),
+            timeInterval.c_str(),
+            1) == 0);
+    ASSERT_TRUE(
+        setenv(c10d::TORCH_NCCL_ENABLE_MONITORING[0].c_str(), "1", 1) == 0);
+    ASSERT_TRUE(setenv(c10d::NCCL_DESYNC_DEBUG[0].c_str(), "1", 1) == 0);
     // We cannot capture the exception thrown in watchdog thread without making
     // lots of changes to the code. So we don't let the watchdog throw
     // exception.
-    ASSERT_TRUE(setenv(c10d::NCCL_ASYNC_ERROR_HANDLING, "0", 1) == 0);
+    ASSERT_TRUE(
+        setenv(c10d::NCCL_ASYNC_ERROR_HANDLING[0].c_str(), "0", 1) == 0);
     options_ = c10d::ProcessGroupNCCL::Options::create();
     // Set a super short watchdog timeout.
     options_->timeout = std::chrono::milliseconds(100);

--- a/test/cpp/c10d/ProcessGroupNCCLTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLTest.cpp
@@ -41,7 +41,7 @@ class NCCLTestBase {
     c10::intrusive_ptr<c10d::ProcessGroupNCCL::Options> opts =
         c10::make_intrusive<c10d::ProcessGroupNCCL::Options>();
     opts->timeout = pgTimeout_;
-    setenv("ENABLE_NCCL_HEALTH_CHECK", "1", /* overwrite */ 1);
+    setenv(c10d::ENABLE_NCCL_HEALTH_CHECK[0].c_str(), "1", /* overwrite */ 1);
     pg_ = std::unique_ptr<::c10d::ProcessGroupNCCL>(
         new ::c10d::ProcessGroupNCCL(store, rank, size, std::move(opts)));
   }
@@ -749,7 +749,7 @@ class ProcessGroupNCCLTest : public ::testing::Test {
 
   void TearDown() override {
     // Reset NCCL_BLOCKING_WAIT environment variable after each run.
-    ASSERT_TRUE(setenv(c10d::NCCL_BLOCKING_WAIT, "0", 1) == 0);
+    ASSERT_TRUE(setenv(c10d::NCCL_BLOCKING_WAIT[0].c_str(), "0", 1) == 0);
   }
 
   bool skipTest() {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -28,27 +28,29 @@
 namespace c10d {
 // Environment variable which controls whether we perform a NCCL healt check
 // which ensures communicators are healthy at the beginning of init.
-constexpr const char* ENABLE_NCCL_HEALTH_CHECK = "ENABLE_NCCL_HEALTH_CHECK";
+static std::vector<std::string> ENABLE_NCCL_HEALTH_CHECK = {
+    "ENABLE_NCCL_HEALTH_CHECK"};
 
 // Environment variable which controls whether or not wait() is blocking or
 // non-blocking.
-constexpr const char* NCCL_BLOCKING_WAIT = "NCCL_BLOCKING_WAIT";
+static std::vector<std::string> NCCL_BLOCKING_WAIT = {"NCCL_BLOCKING_WAIT"};
 
 // Environment variable which controls whether or not we perform Async Error
 // Handling with NCCL.
-constexpr const char* NCCL_ASYNC_ERROR_HANDLING = "NCCL_ASYNC_ERROR_HANDLING";
+static std::vector<std::string> NCCL_ASYNC_ERROR_HANDLING = {
+    "NCCL_ASYNC_ERROR_HANDLING"};
 
 // Environment Variable to control whether Desync Debug is enabled.
 // This variable must be set together with NCCL_ASYNC_ERROR_HANDLING.
-constexpr const char* NCCL_DESYNC_DEBUG = "NCCL_DESYNC_DEBUG";
+static std::vector<std::string> NCCL_DESYNC_DEBUG = {"NCCL_DESYNC_DEBUG"};
 
-constexpr const char* NCCL_ENABLE_TIMING = "NCCL_ENABLE_TIMING";
+static std::vector<std::string> NCCL_ENABLE_TIMING = {"NCCL_ENABLE_TIMING"};
 
-constexpr const char* TORCH_NCCL_ENABLE_MONITORING =
-    "TORCH_NCCL_ENABLE_MONITORING";
+static std::vector<std::string> TORCH_NCCL_ENABLE_MONITORING = {
+    "TORCH_NCCL_ENABLE_MONITORING"};
 
-constexpr const char* TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC =
-    "TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC";
+static std::vector<std::string> TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC = {
+    "TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC"};
 
 constexpr const char* NCCL_BACKEND_NAME = "nccl";
 
@@ -79,14 +81,14 @@ enum ErrorHandlingMode {
 // Instead, it stashes live references to those tensors until after
 // user-facing streams are synced with comm streams.
 // See stashed_for_allocator_safety_ below.
-constexpr const char* TORCH_NCCL_AVOID_RECORD_STREAMS =
-    "TORCH_NCCL_AVOID_RECORD_STREAMS";
+static std::vector<std::string> TORCH_NCCL_AVOID_RECORD_STREAMS = {
+    "TORCH_NCCL_AVOID_RECORD_STREAMS"};
 
 // If set, ProcessGroupNCCL registers postAlloc and preFree hooks to cuda cache
 // allocator so that whenever a tensor is allocated or freed, ProcessGroupNCCL
 // can register/deregister the tensor on all available NCCL communicators.
-constexpr const char* NCCL_USE_TENSOR_REGISTER_ALLOCATOR_HOOK =
-    "NCCL_USE_TENSOR_REGISTER_ALLOCATOR_HOOK";
+static std::vector<std::string> NCCL_USE_TENSOR_REGISTER_ALLOCATOR_HOOK = {
+    "NCCL_USE_TENSOR_REGISTER_ALLOCATOR_HOOK"};
 
 // ProcessGroupNCCL implements NCCL bindings for c10d.
 //

--- a/torch/csrc/distributed/c10d/Utils.cpp
+++ b/torch/csrc/distributed/c10d/Utils.cpp
@@ -8,15 +8,6 @@
 
 namespace c10d {
 
-std::string parse_env(const char* env_var_name) {
-  char* stringValue = std::getenv(env_var_name);
-  std::string res = "N/A";
-  if (stringValue != nullptr) {
-    res = stringValue;
-  }
-  return res;
-}
-
 std::vector<at::Tensor> getTensorShapes(
     const std::vector<at::Tensor>& tensors) {
   std::vector<at::Tensor> shapeTensors;

--- a/torch/csrc/distributed/c10d/Utils.hpp
+++ b/torch/csrc/distributed/c10d/Utils.hpp
@@ -33,8 +33,6 @@ typedef SSIZE_T ssize_t;
 
 namespace c10d {
 
-TORCH_API std::string parse_env(const char* env_var_name);
-
 // Retrieve tensor shapes from a given tensor.
 TORCH_API std::vector<at::Tensor> getTensorShapes(
     const std::vector<at::Tensor>& tensors);
@@ -87,50 +85,110 @@ inline std::vector<std::string> split(
   return pieces;
 }
 
-inline int parseEnvVarInt(const char* envVarName) {
-  char* stringValue = std::getenv(envVarName);
-  if (stringValue != nullptr) {
-    int val;
-    try {
-      val = std::stoi(stringValue);
-    } catch (std::exception& e) {
-      TORCH_CHECK(
-          false,
-          "Invalid value for environment variable: " + std::string(envVarName));
+inline std::string getCvarString(
+    const std::vector<std::string>& env,
+    const char* def) {
+  const char* ret = def;
+
+  if (env.empty()) {
+    TORCH_CHECK(false, "No environment variables passed");
+    return ret;
+  }
+
+  /* parse environment variable in reverse order, so the early
+   * versions of a variable get higher priority than the latter
+   * versions of the same variable */
+  for (int i = env.size() - 1; i >= 0; i--) {
+    const char* val = std::getenv(env[i].c_str());
+    if (val == nullptr) {
+      continue;
+    } else if (i) {
+      TORCH_WARN(
+          "Environment variable " + env[i] + " is deprecated; use " + env[0] +
+          " instead");
     }
-    return val;
+
+    ret = val;
   }
-  return C10D_ENV_NOT_SET;
+
+  return ret;
 }
 
-inline const char* parseEnvVarString(
-    const char* envVarName,
-    const char* default_val) {
-  const char* val = std::getenv(envVarName);
-  if (val == nullptr) {
-    val = default_val;
+inline int getCvarInt(const std::vector<std::string>& env, int def) {
+  int ret = def;
+
+  if (env.empty()) {
+    TORCH_CHECK(false, "No environment variables passed");
+    return ret;
   }
-  return val;
+
+  /* parse environment variable in reverse order, so the early
+   * versions of a variable get higher priority than the latter
+   * versions of the same variable */
+  for (int i = env.size() - 1; i >= 0; i--) {
+    char* val = std::getenv(env[i].c_str());
+    if (val == nullptr) {
+      continue;
+    } else if (i) {
+      TORCH_WARN(
+          "Environment variable " + env[i] + " is deprecated; use " + env[0] +
+          " instead");
+    }
+
+    try {
+      ret = std::stoi(val);
+    } catch (std::exception& e) {
+      TORCH_CHECK(false, "Invalid value for environment variable: " + env[i]);
+    }
+  }
+
+  return ret;
 }
 
-inline int parseEnvVarIntDefault(const char* envVarName, int defaultVal) {
-  int val = parseEnvVarInt(envVarName);
-  if (val == C10D_ENV_NOT_SET)
-    return defaultVal;
-  return val;
+inline bool getCvarBool(const std::vector<std::string>& env, bool def) {
+  bool ret = def;
+
+  if (env.empty()) {
+    TORCH_CHECK(false, "No environment variables passed");
+    return ret;
+  }
+
+  /* parse environment variable in reverse order, so the early
+   * versions of a variable get higher priority than the latter
+   * versions of the same variable */
+  for (int i = env.size() - 1; i >= 0; i--) {
+    char* val_ = std::getenv(env[i].c_str());
+    if (val_ == nullptr) {
+      continue;
+    } else if (i) {
+      TORCH_WARN(
+          "Environment variable " + env[i] + " is deprecated; use " + env[0] +
+          " instead");
+    }
+
+    std::string val = std::string(val_);
+    for (auto& x : val) {
+      x = std::tolower(x);
+    }
+
+    if (val == "y" || val == "yes" || val == "1" || val == "t" ||
+        val == "true") {
+      ret = true;
+    } else if (
+        val == "n" || val == "no" || val == "0" || val == "f" ||
+        val == "false") {
+      ret = false;
+    } else {
+      TORCH_CHECK(false, "Invalid value for environment variable: " + env[i]);
+      return ret;
+    }
+  }
+
+  return ret;
 }
 
 inline bool parseEnvVarFlag(const char* envVarName) {
-  int val = parseEnvVarInt(envVarName);
-  if (val == 1) {
-    return true;
-  } else if (val == 0 || val == C10D_ENV_NOT_SET) {
-    return false;
-  }
-  TORCH_CHECK(
-      false,
-      "Invalid value for environment variable: " + std::string(envVarName));
-  return false;
+  return getCvarBool({envVarName}, false);
 }
 
 inline void assertSameSizes(

--- a/torch/csrc/distributed/c10d/logger.cpp
+++ b/torch/csrc/distributed/c10d/logger.cpp
@@ -67,29 +67,33 @@ void Logger::log_if_graph_static(bool is_static) {
 
 // Environment variables
 void Logger::set_env_variables() {
-  ddp_logging_data_->strs_map["master_port"] = parse_env("MASTER_PORT");
-  ddp_logging_data_->strs_map["master_addr"] = parse_env("MASTER_ADDR");
+  ddp_logging_data_->strs_map["master_port"] =
+      getCvarString({"MASTER_PORT"}, "N/A");
+  ddp_logging_data_->strs_map["master_addr"] =
+      getCvarString({"MASTER_ADDR"}, "N/A");
   ddp_logging_data_->strs_map["torch_distributed_debug"] =
-      parse_env("TORCH_DISTRIBUTED_DEBUG");
+      getCvarString({"TORCH_DISTRIBUTED_DEBUG"}, "N/A");
   ddp_logging_data_->strs_map["cuda_visible_devices"] =
-      parse_env("CUDA_VISIBLE_DEVICES");
+      getCvarString({"CUDA_VISIBLE_DEVICES"}, "N/A");
   if (reducer_->process_group_->getBackendName() == "nccl") {
     ddp_logging_data_->strs_map["nccl_socket_ifname"] =
-        parse_env("NCCL_SOCKET_IFNAME");
+        getCvarString({"NCCL_SOCKET_IFNAME"}, "N/A");
     ddp_logging_data_->strs_map["nccl_blocking_wait"] =
-        parse_env("NCCL_BLOCKING_WAIT");
+        getCvarString({"NCCL_BLOCKING_WAIT"}, "N/A");
     ddp_logging_data_->strs_map["nccl_async_error_handling"] =
-        parse_env("NCCL_ASYNC_ERROR_HANDLING");
-    ddp_logging_data_->strs_map["nccl_debug"] = parse_env("NCCL_DEBUG");
-    ddp_logging_data_->strs_map["nccl_nthreads"] = parse_env("NCCL_NTHREADS");
+        getCvarString({"NCCL_ASYNC_ERROR_HANDLING"}, "N/A");
+    ddp_logging_data_->strs_map["nccl_debug"] =
+        getCvarString({"NCCL_DEBUG"}, "N/A");
+    ddp_logging_data_->strs_map["nccl_nthreads"] =
+        getCvarString({"NCCL_NTHREADS"}, "N/A");
     ddp_logging_data_->strs_map["nccl_ib_timeout"] =
-        parse_env("NCCL_IB_TIMEOUT");
+        getCvarString({"NCCL_IB_TIMEOUT"}, "N/A");
   }
   if (reducer_->process_group_->getBackendName() == "gloo") {
     ddp_logging_data_->strs_map["gloo_socket_ifname"] =
-        parse_env("GLOO_SOCKET_IFNAME");
+        getCvarString({"GLOO_SOCKET_IFNAME"}, "N/A");
     ddp_logging_data_->strs_map["gloo_device_transport"] =
-        parse_env("GLOO_DEVICE_TRANSPORT");
+        getCvarString({"GLOO_DEVICE_TRANSPORT"}, "N/A");
 
 #ifdef USE_C10D_GLOO
     auto gloo_pg = static_cast<c10d::ProcessGroupGloo*>(

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -1782,7 +1782,7 @@ bool Reducer::rebuild_buckets() {
   bucket_size_limits.push_back(bucket_bytes_cap_);
   std::vector<size_t> per_bucket_size_limits;
   auto ddp_set_last_bucket_as_small =
-      (parse_env("DDP_SET_LAST_BUCKET_CAP") == "1");
+      (getCvarString({"DDP_SET_LAST_BUCKET_CAP"}, "N/A") == "1");
 
   if (ddp_set_last_bucket_as_small) {
     // Reverse so that first_bucket_bytes_cap_ (smaller bucket) becomes the last


### PR DESCRIPTION
Summary:
The getCvar* functions allow us to provide multiple environment variables for the same value.  This allows us to deprecate some variables in favor of others, while still allowing users to temporarily use the old variables for some time.

Test Plan: OSS CI

Reviewed By: fduwjj, XilunWu

Differential Revision: D51225487

Fixes #ISSUE_NUMBER
