### PR TITLE
Defer DDPOptimizer to first runtime call, use inductor subgraph outputs

### DIFF
--- a/torch/_dynamo/backends/distributed.py
+++ b/torch/_dynamo/backends/distributed.py
@@ -403,15 +403,7 @@ or file a github issue."""
             # to match what aot_autograd expects. See Note: [Fake Modules and AOTAutograd]
             def run_node(self, n: Node) -> Any:
                 args, kwargs = self.fetch_args_kwargs_from_env(n)
-                new_args = []
-                assert fake_mode
-                for arg in args:
-                    if isinstance(arg, torch.Tensor) and not isinstance(
-                        arg, torch._subclasses.FakeTensor
-                    ):
-                        new_args.append(fake_mode.from_tensor(arg))
-                    else:
-                        new_args.append(arg)
+                assert not fake_mode
 
                 log.debug("run_node %s, %s got args %s", n.op, n.target, args_str(args))
                 assert isinstance(args, tuple)
@@ -428,12 +420,12 @@ or file a github issue."""
                         "\n---%s graph---\n%s", n.target, curr_submod.graph
                     )
 
-                    # When calling the compiler on the submod, inputs (new_args) are expected to
+                    # When calling the compiler on the submod, inputs (args) are expected to
                     # be FakeTensors already since Dynamo would have made them FakeTensors in the
                     # non-DDP flow.  However, the parameters are _not_ expected to be FakeTensors,
                     # since this wrapping happens during compilation
                     compiled_submod_real = self.compile_submod(
-                        real_mod, new_args, kwargs
+                        real_mod, args, kwargs
                     )
 
                     # We update the original (outer) graph with a call into the compiled module
@@ -444,17 +436,30 @@ or file a github issue."""
 
                     # Finally, we have to produce inputs for use compiling the next submodule,
                     # and these need to be FakeTensors, so we execute the module under fake_mode
-                    with fake_mode:
-                        return curr_submod(*new_args, **kwargs)
+                    return curr_submod(*args, **kwargs)
                 else:
                     # placeholder or output nodes don't need to get compiled, just executed
-                    return getattr(self, n.op)(n.target, new_args, kwargs)
+                    return getattr(self, n.op)(n.target, args, kwargs)
 
-        submod_compiler = SubmodCompiler(split_gm, self.backend_compile_fn)
-        submod_compiler.run(*example_inputs)
-        split_gm.recompile()
+        class DDPOptimizedModule(torch.nn.Module):
+            def __init__(self, split_gm):
+                super().__init__()
+                self.split_gm = split_gm
+                self.compiled = False
 
-        ddp_graph_log.debug(
-            "\n---final graph---\n%s\n---------------\n", split_gm.graph
-        )
+            def forward(self, *args):
+                if not self.compiled:
+                    submod_compiler = SubmodCompiler(split_gm, self.backend_compile_fn)
+                    out = submod_compiler.run(*args)
+                    split_gm.recompile()
+
+                    ddp_graph_log.debug(
+                        "\n---final graph---\n%s\n---------------\n", split_gm.graph
+                    )
+                    return out
+                else:
+                    return self.split_gm(*args)
+
+
+
         return split_gm


### PR DESCRIPTION
Work around issue where subgraphs compiled by inductor do not match strides with eager/faketensor prop.

(WIP - only tested briefly on toy)
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #113799



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng