### PR TITLE
[ez] Don't retry onnx in shell

### DIFF
--- a/.ci/onnx/test.sh
+++ b/.ci/onnx/test.sh
@@ -3,11 +3,6 @@
 # shellcheck source=./common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
-# Use to retry ONNX test, only retry it twice
-retry () {
-    "$@" || (sleep 60 && "$@")
-}
-
 if [[ "$BUILD_ENVIRONMENT" == *onnx* ]]; then
   # TODO: This can be removed later once vision is also part of the Docker image
   pip install -q --user --no-use-pep517 "git+https://github.com/pytorch/vision.git@$(cat .github/ci_commit_pins/vision.txt)"
@@ -16,5 +11,5 @@ if [[ "$BUILD_ENVIRONMENT" == *onnx* ]]; then
   # NB: ONNX test is fast (~15m) so it's ok to retry it few more times to avoid any flaky issue, we
   # need to bring this to the standard PyTorch run_test eventually. The issue will be tracked in
   # https://github.com/pytorch/pytorch/issues/98626
-  retry "$ROOT_DIR/scripts/onnx/test.sh"
+  "$ROOT_DIR/scripts/onnx/test.sh"
 fi


### PR DESCRIPTION
is this important? not really, but the retries given by run_test.py on it's own should be enough