### PR TITLE
[aps] Sync thrift

### DIFF
--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -151,11 +151,15 @@ class Verifier(metaclass=_VerifierMeta):
                 assert not any(t is object for t in ret)
                 return ret
 
+            # TODO Remove this allowlist.
+            _allowed_torch_functions = (torch.autograd.grad_mode.set_grad_enabled,)
+
             if not isinstance(op, _allowed_op_types()):
-                if op not in _allowed_builtin_ops():
+                if op not in _allowed_builtin_ops() and op not in _allowed_torch_functions:
                     raise SpecViolationError(
                         f"Operator '{op}' is not an allowed operator type: {_allowed_op_types()}\n"
                         f"Valid builtin ops: {_allowed_builtin_ops()}"
+                        f"Valid torch functions: {_allowed_torch_functions}"
                     )
 
             if isinstance(op, OpOverload):


### PR DESCRIPTION
Summary:
Based on discussions with Sherlock + Zhengxu in D51118067, updated the internal thrift schema to match the OSS schema.

Verifier failures:
* Test contains a None as input, resulting in no meta["val"]
* Test contains torch.autograd.grad_mode.set_grad_enabled as an op, which also results in no meta["val"]
* torch.autograd.grad_mode.set_grad_enabled is also not a valid op
* Test adds a "parameter" to the state dict but the parameter is not an nn.Parameter, causing an assertion failure

So to bypass these failures I did the following hacks(?):
* Before creating the exported program in deserialization, populate nodes w/o meta["val"] with meta["val"] = None
* Add torch.autograd.grad_mode.set_grad_enabled to the skip opset
* Duplicated ExportGraphSignature into aot_export.py so that the graph signature checks will be skipped

Configerator changes in D51343615

Test Plan: CI

Reviewed By: zhxchen17

Differential Revision: D51342921




cc @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan @suo @ydwu4