### PR TITLE
[Autotune] Do not benchmark configs that will likely cause low occupancy.

### DIFF
--- a/speedup_inductor.csv
+++ b/speedup_inductor.csv
@@ -1,0 +1,5 @@
+dev,name,batch_size,speedup,abs_latency,compilation_latency,compression_ratio,eager_peak_mem,dynamo_peak_mem,calls_captured,unique_graphs,graph_breaks,unique_graph_breaks
+cuda,mixnet_l,128,1.342082,84.994877,179.986060,0.970316,7.853681,8.093938,677,2,9,7
+cuda,mixnet_l,128,1.342683,85.109425,48.141032,0.986967,7.853681,7.957386,677,2,9,7
+cuda,mixnet_l,128,1.331193,86.202919,86.225466,0.970316,7.853681,8.093938,677,2,9,7
+cuda,mixnet_l,128,1.336525,85.745968,88.567024,0.970316,7.853681,8.093938,677,2,9,7

--- a/speedup_inductor_compilation_metrics.csv
+++ b/speedup_inductor_compilation_metrics.csv
@@ -1,0 +1,5 @@
+dev,name,batch_size,_compile.<locals>.compile_inner,OutputGraph.call_user_compiler,create_aot_dispatcher_function,compile_fx.<locals>.fw_compiler_base,GraphLowering.run,GraphLowering.compile_to_module,Scheduler.__init__,Scheduler.codegen,WrapperCodeGen.generate,CachingAutotuner.benchmark_all_configs,compile_fx.<locals>.bw_compiler
+cuda,mixnet_l,128,85.239280,79.871346,76.884893,69.119815,4.983183,120.000243,5.908925,6.241815,0.427672,34.588001,59.748011
+cuda,mixnet_l,128,36.140603,30.529949,27.555470,19.700971,4.735759,22.352724,6.305416,5.794610,0.430007,11.572103,0
+cuda,mixnet_l,128,38.354682,26.930800,24.034539,16.344618,4.590603,21.313963,6.470510,5.426494,0.429965,34.395519,13.152729
+cuda,mixnet_l,128,39.771190,28.482663,25.633167,17.870349,4.582310,23.712005,6.436687,5.493674,0.428452,34.456806,13.969565

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -183,6 +183,7 @@ class CachingAutotuner(KernelInterface):
                 return
             self.launchers = []
             compiled_binaries = []
+            binary_launcher = {}
             for c in self.configs:
                 try:
                     compiled_binary, launcher = self._precompile_config(
@@ -193,6 +194,7 @@ class CachingAutotuner(KernelInterface):
                     continue
                 self.launchers.append(launcher)
                 compiled_binaries.append(compiled_binary)
+                binary_launcher[compiled_binary] = launcher
 
             if len(self.launchers) == 0:
                 raise RuntimeError(
@@ -270,6 +272,8 @@ class CachingAutotuner(KernelInterface):
                     self.launchers.append(
                         self._precompile_config(new_config, warm_cache_only_with_cc)[1]
                     )
+                    # No need to benchmark old config that will likely cause low occupancy.
+                    self.launchers.remove(binary_launcher[compiled_binary])
             self.configs = None
 
     def _precompile_config(self, cfg: Config, warm_cache_only_with_cc: Optional[int]):


### PR DESCRIPTION
Testing results (main, 11/16 vs hoy/autotune/lanucher 11/16) : https://hud.pytorch.org/benchmark/compilers 
- Compile time seems mixed
- Slight perf improvement



