### PR TITLE
[Inductor][fx pass] Fix a bug in the merge getitem cat pattern

### DIFF
--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -1174,6 +1174,10 @@ def merge_getitem_cat(match: Match, split_sections: List[int], dim: int):
                 indices.append(arg.args[1])
             # indices may not be necessarily sorted, we sort them first
             indices.sort()
+            # the gettitems to be merged must be consecutive, otherwise
+            # returned sliced tensor could be wrong
+            if indices[len(indices) - 1] - indices[0] + 1 != len(indices):
+                continue
             # update the arg of cat user, only keep the first getitem
             cat_user.update_arg(0, cat_user.args[0][0])
             # calculate the fused tensor sizes in the indices
@@ -1227,7 +1231,7 @@ def merge_getitem_cat(match: Match, split_sections: List[int], dim: int):
 #       /   ...    \             ...       /         \
 # getitem      getitem                 getitem     getitem -> user=1
 #    \           /
-#        stack (dim=0)  -> user=1
+#        stack (dim=0)  -> user=1, getitems to be consecutive
 #          |
 #         tahn  -> user=1
 #          |
@@ -1318,6 +1322,10 @@ def merge_stack_tahn_unbind(match: Match, split_sections: List[int], dim: int):
                 split_sections_for_unbind.append(split_sections[arg.args[1]])
             # indices may not be necessarily sorted, we sort them first
             indices.sort()
+            # the gettitems to be merged must be consecutive, otherwise
+            # returned sliced tensor could be wrong
+            if indices[len(indices) - 1] - indices[0] + 1 != len(indices):
+                continue
             # update the arg of stack user, only keep the first getitem
             user.update_arg(0, user.args[0][0])
             # calculate the fused tensor sizes in the indices


### PR DESCRIPTION
Summary: The split cat pattern in D50100667 may change the sliced node returned by split node if the getitem to be merged is not consecutive indices.

Test Plan:
```
buck2 test 'fbcode//mode/opt' fbcode//pytorch/benchmark/fb/test_gpu:run_test_gpu -- --exact 'pytorch/benchmark/fb/test_gpu:run_test_gpu - test_train_mimo_cmf_30x_inductor_accuracy (pytorch.benchmark.fb.test_gpu.test_gpu.TestBenchmarkFbGpu)' --run-disabled
```
Buck UI: https://www.internalfb.com/buck2/1fd8fa6a-83d1-4cfd-bf33-c7ddb28de5b5
Test UI: https://www.internalfb.com/intern/testinfra/testrun/6473924659080211
Network: Up: 1.3GiB  Down: 48MiB  (reSessionID-acaa2760-abff-442e-989f-3eefd1d1e034)
Jobs completed: 75. Time elapsed: 18:37.5s.
Cache hits: 0%. Commands: 68 (cached: 0, remote: 0, local: 68)
Tests finished: Pass 1. Fail 0. Fatal 0. Skip 0. Build failure 0

```
buck2 test 'fbcode//mode/opt' fbcode//pytorch/benchmark/fb/test_gpu:run_test_gpu -- --exact 'pytorch/benchmark/fb/test_gpu:run_test_gpu - test_train_mimo_cmf_30x_inductor_speedup (pytorch.benchmark.fb.test_gpu.test_gpu.TestBenchmarkFbGpu)'
```
Buck UI: https://www.internalfb.com/buck2/7de122c6-23e0-4f13-b2b4-934cf780b60b
Test UI: https://www.internalfb.com/intern/testinfra/testrun/16888498613412388
Network: Up: 90KiB  Down: 2.1MiB  (reSessionID-f75d6b7b-93ea-4d47-a52a-8d2429b30ad1)
Jobs completed: 6. Time elapsed: 17:28.0s.
Tests finished: Pass 1. Fail 0. Fatal 0. Skip 0. Build failure 0

Differential Revision: D51378532




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler