### PR TITLE
[Quant][PT2E] Enable linear and linear-unary post-op quant recipe for x86 inductor quantizer

### DIFF
--- a/test/quantization/pt2e/test_x86inductor_quantizer.py
+++ b/test/quantization/pt2e/test_x86inductor_quantizer.py
@@ -851,11 +851,12 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
         """
         use_bias_list = [True, False]
         inplace_list = [True, False]
-        postop_list = [nn.ReLU, nn.LeakyReLU]  # only test two to save time
+        postop_list = [nn.ReLU, nn.LeakyReLU, nn.GELU]  # only test three to save time
         cases = itertools.product(use_bias_list, inplace_list, postop_list)
         post_op_map = {
             nn.ReLU: [torch.ops.aten.relu_.default, torch.ops.aten.relu.default],
             nn.LeakyReLU: [torch.ops.aten.leaky_relu_.default, torch.ops.aten.leaky_relu.default],
+            nn.GELU: [torch.ops.aten.gelu_.default, torch.ops.aten.gelu.default],
         }
         with override_quantized_engine("x86"), torch.no_grad():
             for use_bias, inplace, postop in cases:

--- a/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
+++ b/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
@@ -932,6 +932,7 @@ class X86InductorQuantizer(Quantizer):
             torch.nn.ReLU,
             torch.nn.LeakyReLU,
             torch.nn.Tanh,
+            torch.nn.GELU,
         ]
         fused_partitions: List[tuple] = []
         for postop in postop_list:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #113827
* __->__ #113826
* #113825

**Summary**
Add Gelu for linear-unary post-op quantization recipe to x86 inductor quantizer. 

**Test plan**
python test/test_quantization.py -k test_linear_unary_with_quantizer_api