### PR TITLE
[Quant][Inductor] Enable quantization linear pattern fusion Gelu inside inductor

### DIFF
--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -456,6 +456,9 @@ def _register_quantization_unary_fusion():
         UnaryAttr("relu", [], ""): generate_pattern_with_output_quant(
             generate_pattern_with_unary(qlinear_pt2e_pattern, aten.relu.default)
         ),
+        UnaryAttr("gelu", [], ""): generate_pattern_with_output_quant(
+            generate_pattern_with_unary(qlinear_pt2e_pattern, aten.gelu.default)
+        ),
     }
 
     for unary_attr, patterns in linear_unary_replace_patterns.items():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #113827
* #113826
* #113825

**Summary**
Enable lowering of quantized linear in Inductor

**Test plan**
python test/inductor/test_mkldnn_pattern_matcher.py -k test_qlinear_unary

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler