### PR TITLE
support bool as Scalar Type in TorchScript

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1678,6 +1678,13 @@ graph(%Ra, %Rb):
                   torch.bfloat16, torch.complex64, torch.complex128, torch.bool]:
             self.assertEqual(scr(x, t), foo(x, t))
 
+    def test_script_bool_literal_conversion(self):
+        def foo(x):
+            return torch.mul(x, True)
+        scr = torch.jit.script(foo)
+        x = torch.rand(3, 4)
+        self.assertEqual(scr(x), foo(x))
+
     def test_shape_analysis_masked_select(self):
         input_str = """graph(%0 : Float(),
           %1 : Bool()):

--- a/torch/csrc/jit/frontend/schema_matching.cpp
+++ b/torch/csrc/jit/frontend/schema_matching.cpp
@@ -143,6 +143,14 @@ Value* tryConvertToType(
       } else if (concrete_int) {
         value = graph.insert(aten::Int, {value}, {}, loc);
       }
+    } else if (*value->type() == *BoolType::get()) {
+      if (concrete_float) {
+        value = graph.insert(aten::Float, {value}, {}, loc);
+      } else if (concrete_int) {
+        value = graph.insert(aten::Int, {value}, {}, loc);
+      } else if (concrete_number) {
+        value = graph.insert(aten::Int, {value}, {}, loc);
+      }
     }
 
     // Convert strings to device

--- a/torch/csrc/jit/runtime/register_special_ops.cpp
+++ b/torch/csrc/jit/runtime/register_special_ops.cpp
@@ -292,19 +292,22 @@ RegisterOperators reg({
           aliasAnalysisFromSchema()),
 
     DEFINE_TORCH_TENSOR_OP(
-        float,
-        double,
-        at::native::scalar_tensor(
-            scalar_val,
-            typeMetaToScalarType(c10::get_default_dtype()),
-            c10::nullopt /* layout */,
-            at::kCPU,
-            c10::nullopt /* pin_memory*/))
-        DEFINE_TORCH_TENSOR_OP(int, int64_t, at::scalar_to_tensor(scalar_val))
+        bool,
+        bool,
+        at::empty({}, at::CPU(at::kBool).options()).fill_(scalar_val))
+        DEFINE_TORCH_TENSOR_OP(
+            float,
+            double,
+            at::native::scalar_tensor(
+                scalar_val,
+                typeMetaToScalarType(c10::get_default_dtype()),
+                c10::nullopt /* layout */,
+                at::kCPU,
+                c10::nullopt /* pin_memory*/))
             DEFINE_TORCH_TENSOR_OP(
-                bool,
-                bool,
-                at::empty({}, at::CPU(at::kBool).options()).fill_(scalar_val))
+                int,
+                int64_t,
+                at::scalar_to_tensor(scalar_val))
                 DEFINE_TORCH_TENSOR_OP(
                     complex,
                     c10::complex<double>,


### PR DESCRIPTION
Fixes #112402 
Fixes #75465 

From the description in #75465 , the bool type should subtype from the int. and `register_prim_ops.cpp` already supports converting from bool to int or float.
So this patch can fix bool as Scalar in TorchScirpt.


cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen