### PR TITLE
[inductor] Fix slice scatter shape calculation

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4948,6 +4948,30 @@ class CommonTemplate:
             ],
         )
 
+    def test_slice_scatter3(self):
+        def fn(a, b):
+            return aten.slice_scatter.default(a, b, 1, 1, 9223372036854775807, 2)
+
+        self.common(
+            fn,
+            [
+                torch.randn([1, 4]),
+                torch.randn([1, 2]),
+            ]
+        )
+
+    def test_slice_scatter4(self):
+        def fn(a, b):
+            return aten.slice_scatter.default(a, b, 1, 2, 9223372036854775807, 3)
+
+        self.common(
+            fn,
+            [
+                torch.randn([1, 9]),
+                torch.randn([1, 2]),
+            ]
+        )
+
     def test_scatter1(self):
         def fn(a, dim, index, b):
             return aten.scatter(a, dim, index, b)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4957,7 +4957,7 @@ class CommonTemplate:
             [
                 torch.randn([1, 4]),
                 torch.randn([1, 2]),
-            ]
+            ],
         )
 
     def test_slice_scatter4(self):
@@ -4969,7 +4969,7 @@ class CommonTemplate:
             [
                 torch.randn([1, 9]),
                 torch.randn([1, 3]),
-            ]
+            ],
         )
 
     def test_scatter1(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4968,7 +4968,7 @@ class CommonTemplate:
             fn,
             [
                 torch.randn([1, 9]),
-                torch.randn([1, 2]),
+                torch.randn([1, 3]),
             ]
         )
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2333,7 +2333,7 @@ def slice_scatter(x, src, dim=0, start=None, end=None, step=1):
         end = dim_size
 
     src_size = list(x.get_size())
-    src_size[dim] = FloorDiv(sympy.expand(end - start), sympy.expand(step))
+    src_size[dim] = FloorDiv(end - start + (step - 1), step)
     src = expand(src, src_size)
     src_loader = src.make_loader()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #113839
* __->__ #113838

Fixes #113641

As written, there is an off-by-one error whenever `end - start` doesn't evenly
divide into `step`. e.g. if `end - start = 1` and `step = 2` we should get a
single element but `1 // 2 == 0` so this wouldn't take anything from the slice.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler