### PR TITLE
[inductor] Relax symbolic guard for sizevars.evaluate_min

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6896,10 +6896,9 @@ class CommonTemplate:
         # If assume_static_by_default is set, the calls above will trigger
         # 3 function compilation:
         #   1. assuming 'n' is static (equals 2)
-        #   2. making 'n' dynamic, but with the guard 'end < x.shape[0]'
+        #   2. making 'n' dynamic, but with the guard 'end <= x.shape[0]'
         #      (from: torch._inductor.ir.SliceView.create)
-        #   3. when 'n' equals 6 (the above guard is violated)
-        frame_count = 3 if torch._dynamo.config.assume_static_by_default else 2
+        frame_count = 2 if torch._dynamo.config.assume_static_by_default else 1
         self.assertEqual(cnts.frame_count, frame_count)
 
         # Negative index triggers new compilation.

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -344,14 +344,10 @@ class SizeVarAllocator:
         """return the smaller of left and right, and guard on that choice"""
         lv = self.size_hint(left)
         rv = self.size_hint(right)
-        if lv == rv:
-            return self.guard_equals(left, right)
-        elif lv < rv:
-            self.guard_lt(left, right)
-            return left
+        if lv <= rv:
+            return self.guard_leq(left, right)
         else:
-            self.guard_lt(right, left)
-            return right
+            return self.guard_leq(right, left)
 
     def evaluate_static_shape(self, left: Expr) -> int:
         right = self.size_hint(left)

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -346,10 +346,10 @@ class SizeVarAllocator:
         rv = self.size_hint(right)
         if lv <= rv:
             self.guard_leq(left, right)
-            return lv
+            return left
         else:
             self.guard_leq(right, left)
-            return rv
+            return right
 
     def evaluate_static_shape(self, left: Expr) -> int:
         right = self.size_hint(left)

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -345,9 +345,11 @@ class SizeVarAllocator:
         lv = self.size_hint(left)
         rv = self.size_hint(right)
         if lv <= rv:
-            return self.guard_leq(left, right)
+            self.guard_leq(left, right)
+            return lv
         else:
-            return self.guard_leq(right, left)
+            self.guard_leq(right, left)
+            return rv
 
     def evaluate_static_shape(self, left: Expr) -> int:
         right = self.size_hint(left)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #113406
* __->__ #113841

We should shorten two conditional guards (guard_equals, guard_lt)
into only one (guard_leq). Then we can save re-compilation for
access-the-last-element-of-the-tensor op. [test_torchinductor.test_setitem_with_int_parameter](https://github.com/pytorch/pytorch/blob/8efa6ad1fc0e6994a5644dd1f0e5a73b487ceedf/test/inductor/test_torchinductor.py#L6896C1-L6902)
will become `frame_count = 2 if torch._dynamo.config.assume_static_by_default else 1`.

Test plan:
`python test/inductor/test_torchinductor.py -k test_setitem_with_int_parameter_cpu`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler