### PR TITLE
[dynamo] Fix UnspecializedNNModuleVariable's source

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/aot_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/aot_inductor_torchbench_inference.csv
@@ -250,8 +250,8 @@ vgg16,pass,0
 
 
 
-yolov3,fail_to_run,0
-
-
-
 vision_maskrcnn,fail_to_run,0
+
+
+
+yolov3,fail_to_run,0

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_timm_dynamic_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_timm_dynamic_training.csv
@@ -18,7 +18,7 @@ coat_lite_mini,pass,8
 
 
 
-convit_base,pass,9
+convit_base,pass,8
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_timm_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_timm_training.csv
@@ -18,7 +18,7 @@ coat_lite_mini,pass,8
 
 
 
-convit_base,pass,9
+convit_base,pass,8
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_inference.csv
@@ -246,7 +246,7 @@ vgg16,pass,0
 
 
 
-vision_maskrcnn,pass,18
+vision_maskrcnn,pass,17
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_training.csv
@@ -210,7 +210,7 @@ vgg16,pass,8
 
 
 
-vision_maskrcnn,fail_accuracy,37
+vision_maskrcnn,fail_accuracy,36
 
 
 

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1583,6 +1583,35 @@ def forward(self, arg0_1):
         # there is no functionalization.
         self.assertTrue(torch.allclose(ep(test_inp), Foo().forward(test_inp) + 4*4*4))
 
+    def test_issue_113041(self):
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = torch.tensor(1.0)
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x + self.a
+
+        def forward_hook(
+            module: torch.nn.Module, inputs, output
+        ) -> torch.Tensor:
+            return 2 * output
+
+        seq = torch.nn.Sequential(TestModule()).eval()
+        seq.b = torch.tensor(2)
+        handle = seq.register_forward_hook(forward_hook)
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.seq = seq
+
+            def forward(self, x):
+                return self.seq(x) + self.seq.b
+
+        inp = (torch.randn(2, 8),)
+        ep = export(M(), inp)  # This errors because dynamo adds an extra input
+
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -646,9 +646,6 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
                 kwargs["value_type"] = type(value)
 
         super().__init__(value=value, **kwargs)
-        if self.source and self.source.is_nn_module():
-            # force guard checks even when `not config.guard_nn_modules``
-            self.source = NotNNModuleSource(self.source)
 
     @staticmethod
     @functools.lru_cache(None)


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/113041

In the case where we have an object represented as an UnspecializedNNModuleVariable, the source of an attribute on that object is `AttrSource(base=NotNNModuleSource(base=NNModuleSource(base=AttrSource(base=LocalSource(local_name='self', cell_or_freevar=False), member='seq'))), member='b')`. This causes dynamo to add an extra attribute as it doesn't go to this [`register_attr` step](https://github.com/pytorch/pytorch/blob/eddce3c0544b16634e8dbae9adc69e2d15d60d17/torch/_dynamo/variables/builder.py#L955-L962).

However if we have an object represented as a UserDefinedObjectVariable, the source of an attribute on that object is `AttrSource(base=NNModuleSource(base=AttrSource(base=LocalSource(local_name='self', cell_or_freevar=False), member='seq')), member='b')`.

It seems that UnspecializedNNModuleVariables should behave in the same was as UserDefinedObjectVariables, but the source in these two cases are different. So, I removed the part that changes the source in the UnspecializedNNModuleVariables, and it seems to work! And CI is green (+ reduced graph breaks).

```
   def test_unspecialized_nnmodule(self):
        class TestModule(torch.nn.Module):
            def __init__(self):
                super().__init__()
                self.a = torch.tensor(1.0)

            def forward(self, x: torch.Tensor) -> torch.Tensor:
                return x + self.a

        def forward_hook(
            module: torch.nn.Module, inputs, output
        ) -> torch.Tensor:
            return 2 * output

        seq = torch.nn.Sequential(TestModule()).eval()
        seq.b = torch.tensor(2)
        handle = seq.register_forward_hook(forward_hook)

        class M(torch.nn.Module):
            def __init__(self):
                super().__init__()
                self.seq = seq

            def forward(self, x):
                # self.seq.b has source: AttrSource(base=NotNNModuleSource(base=NNModuleSource(base=AttrSource(base=LocalSource(local_name='self', cell_or_freevar=False), member='seq'))), member='b')
                return self.seq(x) + self.seq.b

        inp = (torch.randn(2, 8),)
        ep = export(M(), inp) 
```
```
    def test_user_defined_var(self):
        class TestModule(torch.nn.Module):
            def __init__(self):
                super().__init__()
                self.a = torch.tensor(1.0)

            def forward(self, x: torch.Tensor) -> torch.Tensor:
                return x + self.a

        class UserDefined:
            def __init__(self):
                self.test_module = TestModule()
                self.b = torch.tensor(2)

            def __call__(self, x):
                return self.test_module(x)

        class M(torch.nn.Module):
            def __init__(self):
                super().__init__()
                self.seq = UserDefined()

            def forward(self, x):
                # self.seq.b has source: AttrSource(base=NNModuleSource(base=AttrSource(base=LocalSource(local_name='self', cell_or_freevar=False), member='seq')), member='b')
                return self.seq(x) + self.seq.b

        inp = (torch.randn(2, 8),)
        ep = export(M(), inp) 
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan @suo @ydwu4