### PR TITLE
cleanup test parametrization

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -2851,13 +2851,14 @@ def forward(self, x):
         with self.assertRaisesRegex(RuntimeError, "Shape must be more than 4"):
             gm(torch.randn(3, 4, 5))
 
-    @common_utils.parametrize("type_access", ["builtin", "class"])
-    def test_access_class_method_from_user_class(self, type_access):
-        if type_access == "builtin":
-            type_fn = type
-        elif type_access == "class":
-            type_fn = lambda obj: obj.__class__  # noqa: E731
-
+    @common_utils.parametrize(
+        "type_fn",
+        [
+            common_utils.subtest(type, name="builtin"),
+            common_utils.subtest(lambda obj: obj.__class__, name="attr"),
+        ],
+    )
+    def test_access_class_method_from_user_class(self, type_fn):
         class A:
             @classmethod
             def func(cls):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #113856
* __->__ #113855

Cleanup from https://github.com/pytorch/pytorch/pull/113340#issuecomment-1814020469.

```
❯ pytest test/dynamo/test_export.py -k test_access_class_method_from_user_class --co -q
test/dynamo/test_export.py::ExportTests::test_access_class_method_from_user_class_attr
test/dynamo/test_export.py::ExportTests::test_access_class_method_from_user_class_builtin
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng