### PR TITLE
Use type check for also `is_not`

### DIFF
--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1655,10 +1655,10 @@ class BuiltinVariable(VariableTracker):
             ):
                 return ConstantVariable(op(left.value, right.value))
 
-        if op.__name__ == "is_":
-            # If the two objects are of different type, we can safely return False
+        if op.__name__.startswith("is_"):
+            # If the two objects are of different type, we can safely return False and True for `is` and `is not`, respectively
             if type(left) is not type(right):
-                return ConstantVariable.create(False)
+                return ConstantVariable.create(op.__name__ != "is_")
 
         if isinstance(left, BuiltinVariable) and isinstance(right, BuiltinVariable):
             return ConstantVariable.create(op(left.fn, right.fn))


### PR DESCRIPTION
Handle `is_not` for:

https://github.com/pytorch/pytorch/blob/9647a251cb760bffb08a7f5453e92220d0649629/torch/_dynamo/variables/builtin.py#L1314-L1317

I noticed https://github.com/pytorch/pytorch/issues/111713 exists, I think it's no harm to land this first.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @aakhundov