### PR TITLE
[dynamo] Fix incorrectly casting `SymNode` to `int` when input is `bool`

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -3582,8 +3582,8 @@ class ReproTests(torch._dynamo.test_case.TestCase):
 
         opt_fn = torch.compile(fn, backend="eager")
 
-        x = torch.ones(5, 1, 3, 4)
-        x2 = torch.ones(5, 1, 2, 3)
+        x = torch.ones(5, 1, 2, 3)
+        x2 = torch.ones(5, 1, 3, 4)
         self.assertEqual(fn(x), opt_fn(x))
         self.assertEqual(fn(x2), opt_fn(x2))
 

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -3573,6 +3573,16 @@ class ReproTests(torch._dynamo.test_case.TestCase):
             if isinstance(backend, CompileCounter):
                 self.assertEqual(backend.frame_count, 2)  # graph breaks
 
+    def test_dynamic_shapes_double_not_equal(self):
+        # https://github.com/pytorch/pytorch/issues/113393
+        def fn(x):
+            if x.size() != (5, 1, 2, 3):
+                return x.cos()
+            return x.sin()
+
+        torch.compile(fn, backend="eager")(torch.ones(5, 1, 3, 4))
+        torch.compile(fn, backend="eager")(torch.ones(5, 1, 2, 3))
+
     def test_inductor_no_recursionerror_on_for_loops(self):
         def forward(x):
             for _ in range(1000):

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -3580,8 +3580,18 @@ class ReproTests(torch._dynamo.test_case.TestCase):
                 return x.cos()
             return x.sin()
 
-        torch.compile(fn, backend="eager")(torch.ones(5, 1, 3, 4))
-        torch.compile(fn, backend="eager")(torch.ones(5, 1, 2, 3))
+        opt_fn = torch.compile(fn, backend="eager")
+
+        x = torch.ones(5, 1, 3, 4)
+        x2 = torch.ones(5, 1, 2, 3)
+        self.assertEqual(
+            fn(x),
+            opt_fn(x)
+        )
+        self.assertEqual(
+            fn(x2),
+            opt_fn(x2)
+        )
 
     def test_inductor_no_recursionerror_on_for_loops(self):
         def forward(x):

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -3584,14 +3584,8 @@ class ReproTests(torch._dynamo.test_case.TestCase):
 
         x = torch.ones(5, 1, 3, 4)
         x2 = torch.ones(5, 1, 2, 3)
-        self.assertEqual(
-            fn(x),
-            opt_fn(x)
-        )
-        self.assertEqual(
-            fn(x2),
-            opt_fn(x2)
-        )
+        self.assertEqual(fn(x), opt_fn(x))
+        self.assertEqual(fn(x2), opt_fn(x2))
 
     def test_inductor_no_recursionerror_on_for_loops(self):
         def forward(x):

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1509,6 +1509,10 @@ class BuiltinVariable(VariableTracker):
 
     # or_ is a constant fold function, so we only get here if constant fold is not valid
     def call_or_(self, tx, a, b):
+        if isinstance(a, ConstantVariable) and isinstance(b, ConstantVariable):
+            return ConstantVariable.create(
+                a.as_python_constant() or b.as_python_constant()
+            )
         if isinstance(a, (SymNodeVariable, ConstantVariable)) and isinstance(
             b, (SymNodeVariable, ConstantVariable)
         ):

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1490,6 +1490,10 @@ class BuiltinVariable(VariableTracker):
 
     # and_ is a constant fold function, so we only get here if constant fold is not valid
     def call_and_(self, tx, a, b):
+        if isinstance(a, ConstantVariable) and isinstance(b, ConstantVariable):
+            return ConstantVariable.create(
+                a.as_python_constant() and b.as_python_constant()
+            )
         if isinstance(a, (SymNodeVariable, ConstantVariable)) and isinstance(
             b, (SymNodeVariable, ConstantVariable)
         ):

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1488,12 +1488,10 @@ class BuiltinVariable(VariableTracker):
 
         _unimplemented()
 
-    # and_ is a constant fold function, so we only get here if constant fold is not valid
     def call_and_(self, tx, a, b):
+        # Rely on constant_handler
         if isinstance(a, ConstantVariable) and isinstance(b, ConstantVariable):
-            return ConstantVariable.create(
-                a.as_python_constant() and b.as_python_constant()
-            )
+            return None
         if isinstance(a, (SymNodeVariable, ConstantVariable)) and isinstance(
             b, (SymNodeVariable, ConstantVariable)
         ):
@@ -1507,12 +1505,10 @@ class BuiltinVariable(VariableTracker):
         # None no-ops this handler and lets the driving function proceed
         return None
 
-    # or_ is a constant fold function, so we only get here if constant fold is not valid
     def call_or_(self, tx, a, b):
+        # Rely on constant_handler
         if isinstance(a, ConstantVariable) and isinstance(b, ConstantVariable):
-            return ConstantVariable.create(
-                a.as_python_constant() or b.as_python_constant()
-            )
+            return None
         if isinstance(a, (SymNodeVariable, ConstantVariable)) and isinstance(
             b, (SymNodeVariable, ConstantVariable)
         ):

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -766,8 +766,9 @@ class SymNodeVariable(VariableTracker):
             sym_num = get_fake_value(proxy.node, tx)
         proxy.node.meta["example_value"] = sym_num
 
-        if isinstance(sym_num, (sympy.Integer, int)):
-            return ConstantVariable.create(int(sym_num))
+        if isinstance(sym_num, (sympy.Integer, int, bool)):
+            sym_num = int(sym_num) if isinstance(sym_num, sympy.Integer) else sym_num
+            return ConstantVariable.create(sym_num)
 
         return SymNodeVariable(proxy, sym_num, **options)
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/113393, https://github.com/pytorch/pytorch/pull/113848#issuecomment-1814624510

Incorrectly casting symnode type will cause it to take the wrong path in symbolic_shapes

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng