### PR TITLE
Relax constraints on `test_cast_round_trip`

### DIFF
--- a/test/quantization/core/experimental/test_float8.py
+++ b/test/quantization/core/experimental/test_float8.py
@@ -219,7 +219,7 @@ class TestFloat8Dtype(TestCase):
         x = torch.cat((x, -x))
         x8 = x.to(dtype)
         x8_simulated = simulate_fp8_precision(x, dtype)
-        self.assertEqual(x8_simulated, x8.float(), atol=0, rtol=0)
+        self.assertEqual(x8_simulated, x8.float())
 
     @dtypes(*FLOAT8_DTYPES)
     @dtypesIfCUDA(*CUDA_FLOAT8_DTYPES)


### PR DESCRIPTION
Results of float point operation can be affected by execution order and compiler is not guaranteed to make trivial optimization that might result in lost off precision while compiling in debug mode

Fixes https://github.com/pytorch/pytorch/issues/113829

