### PR TITLE
[BE] Don't mutate torch.compile global config in tests

### DIFF
--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -188,8 +188,8 @@ class C10DFunctionalNativeTest(MultiProcessTestCase):
             assert output.eq(self.rank * i).all()
 
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
+    @torch._inductor.config.patch(debug=True)
     def test_inductor_all_reduce_single(self):
-        torch._inductor.config.debug = True
         self._init_process_group()
 
         def func(arg: torch.Tensor) -> torch.Tensor:
@@ -224,8 +224,8 @@ class C10DFunctionalNativeTest(MultiProcessTestCase):
         assert same(out, correct), f"{out} va {correct}"
 
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
+    @torch._inductor.config.patch(debug=True)
     def test_inductor_all_reduce_coalesced(self):
-        torch._inductor.config.debug = True
         self._init_process_group()
 
         def func(args: List[torch.Tensor]) -> torch.Tensor:
@@ -274,8 +274,8 @@ class C10DFunctionalNativeTest(MultiProcessTestCase):
         assert same(out, correct), f"{out} va {correct}"
 
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
+    @torch._inductor.config.patch(debug=True)
     def test_inductor_reuse_buffer_after_inplace_collective(self):
-        torch._inductor.config.debug = True
         self._init_process_group()
 
         def func(arg: torch.Tensor) -> torch.Tensor:
@@ -313,8 +313,8 @@ class C10DFunctionalNativeTest(MultiProcessTestCase):
         assert same(out, correct), f"{out} va {correct}"
 
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
+    @torch._inductor.config.patch(debug=True)
     def test_inductor_all_gather_into_tensor_single(self):
-        torch._inductor.config.debug = True
         self._init_process_group()
 
         def func(arg: torch.Tensor) -> torch.Tensor:
@@ -342,8 +342,8 @@ class C10DFunctionalNativeTest(MultiProcessTestCase):
         assert same(out, correct), f"{out} va {correct}"
 
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
+    @torch._inductor.config.patch(debug=True)
     def test_inductor_all_gather_into_tensor_coalesced(self):
-        torch._inductor.config.debug = True
         self._init_process_group()
 
         def func(args: List[torch.Tensor]) -> torch.Tensor:
@@ -380,8 +380,8 @@ class C10DFunctionalNativeTest(MultiProcessTestCase):
         assert same(out, correct), f"{out} va {correct}"
 
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
+    @torch._inductor.config.patch(debug=True)
     def test_inductor_reduce_scatter_tensor_single(self):
-        torch._inductor.config.debug = True
         self._init_process_group()
 
         def func(arg: torch.Tensor) -> torch.Tensor:
@@ -409,8 +409,8 @@ class C10DFunctionalNativeTest(MultiProcessTestCase):
         assert same(out, correct), f"{out} va {correct}"
 
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
+    @torch._inductor.config.patch(debug=True)
     def test_inductor_reduce_scatter_tensor_coalesced(self):
-        torch._inductor.config.debug = True
         self._init_process_group()
 
         def func(args: List[torch.Tensor]) -> torch.Tensor:

--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -508,8 +508,8 @@ class TestCollectivesInductor(DynamoDistributedSingleProcTestCase):
         }
 
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
+    @torch._inductor.config.patch(debug=True)
     def test_inductor_single_op(self):
-        torch._inductor.config.debug = True
 
         def func(inp, *, tag, ranks, group_size):
             ar = torch.ops.c10d_functional.all_reduce(inp, "sum", tag, ranks, group_size)
@@ -536,12 +536,12 @@ class TestCollectivesInductor(DynamoDistributedSingleProcTestCase):
         self.assertTrue(same(out, correct))
 
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
+    @torch._inductor.config.patch(debug=True)
     def test_inductor_steal_buffer(self):
         """
         it's ok and optimal if inductor allreduce mutates the buffer of an intermediate
         that isn't going to be used again
         """
-        torch._inductor.config.debug = True
 
         def func(inp, *, tag, ranks, group_size):
             x = inp + 1
@@ -573,12 +573,11 @@ class TestCollectivesInductor(DynamoDistributedSingleProcTestCase):
         self.assertTrue(same(out, correct))
 
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
-    @patch.object(torch._inductor.config.triton, "descriptive_names", False)
+    @torch._inductor.config.patch({"debug": True, "triton.descriptive_names": False})
     def test_inductor_doesnt_mutate_shared(self):
         """
         make sure that an intermediate that's going to be reuse isn't mutated unless copied
         """
-        torch._inductor.config.debug = True
 
         def func(inp, *, tag, ranks, group_size):
             x = inp + 1
@@ -815,12 +814,11 @@ class TestCollectivesInductor(DynamoDistributedSingleProcTestCase):
         self.assertEqual(x.size(), out.size())
 
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
-    @patch.object(torch._inductor.config.triton, "descriptive_names", False)
+    @torch._inductor.config.patch({"debug": True, "triton.descriptive_names": False})
     def test_inductor_all_gather_coalesced(self):
         """
         make sure that an intermediate that's going to be reuse isn't mutated unless copied
         """
-        torch._inductor.config.debug = True
 
         def func(inp, *, tag, ranks, group_size):
             x = inp + 1
@@ -862,12 +860,11 @@ class TestCollectivesInductor(DynamoDistributedSingleProcTestCase):
         assert same(out, correct), f"{out} va {correct}"
 
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
-    @patch.object(torch._inductor.config.triton, "descriptive_names", False)
+    @torch._inductor.config.patch({"debug": True, "triton.descriptive_names": False})
     def test_inductor_reduce_scatter_coalesced(self):
         """
         make sure that an intermediate that's going to be reuse isn't mutated unless copied
         """
-        torch._inductor.config.debug = True
 
         def func(inp, *, tag, ranks, group_size):
             x = inp + 1

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -2012,9 +2012,9 @@ utils_device.CURRENT_DEVICE == None""",
         self.assertEqual(res, [np.array([0]), np.array([1]), np.array([2])])
         self.assertEqual(cnts.frame_count, 1)
 
+    # cache size limit needs to be larger than the `dtypes` list size
+    @torch._dynamo.config.patch(cache_size_limit=12)
     def test_dtypes_no_graphbreaks(self):
-        # cache size limit needs to be larger than the `dtypes` list size
-        torch._dynamo.config.cache_size_limit = 12
 
         dtypes = [
             # floats
@@ -2045,10 +2045,10 @@ utils_device.CURRENT_DEVICE == None""",
 
             self.assertEqual(cnts.frame_count, 1)  # no graph break
 
+    # setting the config value makes the PRNG identical to numpy's
+    # NB this may involve a graph break
+    @torch._dynamo.config.patch(use_numpy_random_stream=True)
     def test_numpy_random_config_to_numpy(self):
-        # setting the config value makes the PRNG identical to numpy's
-        # NB this may involve a graph break
-        torch._dynamo.config.use_numpy_random_stream = True
 
         @torch.compile
         def fn():
@@ -4496,13 +4496,17 @@ def fn():
         def count_graph_break_msgs(msgs):
             return sum(msg.find("Graph break") != -1 for msg in msgs)
 
-        with self.assertLogs(logger="torch._dynamo", level=logging.DEBUG) as log:
-            torch._dynamo.config.verbose = True
+        with (
+            self.assertLogs(logger="torch._dynamo", level=logging.DEBUG) as log,
+            torch._dynamo.config.patch(verbose=True),
+        ):
             f1(torch.randn(10), torch.randn(10))
             self.assertGreater(count_graph_break_msgs(log.output), 1)
 
-        with self.assertLogs(logger="torch._dynamo", level=logging.DEBUG) as log:
-            torch._dynamo.config.verbose = False
+        with (
+            self.assertLogs(logger="torch._dynamo", level=logging.DEBUG) as log,
+            torch._dynamo.config.patch(verbose=False),
+        ):
             g1(torch.randn(10), torch.randn(10))
             self.assertEqual(count_graph_break_msgs(log.output), 1)
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -2015,7 +2015,6 @@ utils_device.CURRENT_DEVICE == None""",
     # cache size limit needs to be larger than the `dtypes` list size
     @torch._dynamo.config.patch(cache_size_limit=12)
     def test_dtypes_no_graphbreaks(self):
-
         dtypes = [
             # floats
             float,
@@ -2049,7 +2048,6 @@ utils_device.CURRENT_DEVICE == None""",
     # NB this may involve a graph break
     @torch._dynamo.config.patch(use_numpy_random_stream=True)
     def test_numpy_random_config_to_numpy(self):
-
         @torch.compile
         def fn():
             return np.random.uniform(size=13)
@@ -4496,17 +4494,15 @@ def fn():
         def count_graph_break_msgs(msgs):
             return sum(msg.find("Graph break") != -1 for msg in msgs)
 
-        with (
-            self.assertLogs(logger="torch._dynamo", level=logging.DEBUG) as log,
-            torch._dynamo.config.patch(verbose=True),
-        ):
+        with self.assertLogs(
+            logger="torch._dynamo", level=logging.DEBUG
+        ) as log, torch._dynamo.config.patch(verbose=True):
             f1(torch.randn(10), torch.randn(10))
             self.assertGreater(count_graph_break_msgs(log.output), 1)
 
-        with (
-            self.assertLogs(logger="torch._dynamo", level=logging.DEBUG) as log,
-            torch._dynamo.config.patch(verbose=False),
-        ):
+        with self.assertLogs(
+            logger="torch._dynamo", level=logging.DEBUG
+        ) as log, torch._dynamo.config.patch(verbose=False):
             g1(torch.randn(10), torch.randn(10))
             self.assertEqual(count_graph_break_msgs(log.output), 1)
 

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -2901,10 +2901,9 @@ class ReproTests(torch._dynamo.test_case.TestCase):
 
         self.assertTrue(same(fn(torch.ones(4)), torch.ones(4).sin() + 15))
 
+    @torch._dynamo.config.patch(verbose=True)
     def test_graph_break_unsupported_fake(self):
         counter = torch._dynamo.testing.CompileCounter()
-
-        torch._dynamo.config.verbose = True
 
         @torch._dynamo.optimize(counter)
         def f(x):

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -41,14 +41,13 @@ class MyModel(torch.nn.Module):
 
 
 def _run_codecache_test(start_method):
-    torch._inductor.config.worker_start_method = start_method
-    torch._inductor.config.compile_threads = 16
-    AsyncCompile.warm_pool()
+    with torch._inductor.config.patch(start_method=start_method, compile_threads=16):
+        AsyncCompile.warm_pool()
 
-    model = MyModel().cuda()
-    model = torch.compile(model)
-    inp = torch.rand(10, 10).cuda()
-    model(inp).sum().backward()
+        model = MyModel().cuda()
+        model = torch.compile(model)
+        inp = torch.rand(10, 10).cuda()
+        model(inp).sum().backward()
 
 
 @requires_cuda()

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -41,7 +41,9 @@ class MyModel(torch.nn.Module):
 
 
 def _run_codecache_test(start_method):
-    with torch._inductor.config.patch(start_method=start_method, compile_threads=16):
+    with torch._inductor.config.patch(
+        worker_start_method=start_method, compile_threads=16
+    ):
         AsyncCompile.warm_pool()
 
         model = MyModel().cuda()

--- a/test/inductor/test_custom_post_grad_passes.py
+++ b/test/inductor/test_custom_post_grad_passes.py
@@ -120,11 +120,11 @@ class TestPostGradCustomPrePostPass(TestCustomPassBase):
 
     def test_custom_pre_pass(self):
         with config.patch(
-                # leave custom pass only in post_grad_passes()
-                pattern_matcher=False,
-                post_grad_custom_pre_pass=self._CustomPass(),
-                # define pattern match as custom post grad opt pass
-                post_grad_custom_post_pass=None,
+            # leave custom pass only in post_grad_passes()
+            pattern_matcher=False,
+            post_grad_custom_pre_pass=self._CustomPass(),
+            # define pattern match as custom post grad opt pass
+            post_grad_custom_post_pass=None,
         ):
             # init mkldnn fusion on custom_matcher
             self._register_mkldnn_conv_relu_fusion(config.post_grad_custom_pre_pass)
@@ -137,16 +137,19 @@ class TestPostGradCustomPrePostPass(TestCustomPassBase):
             other_match_count = 1  # conv prepack weight
             other_match_nodes = 1  # conv prepack weight
             self._test_common(
-                mod, (x,), match_count + other_match_count, match_nodes + other_match_nodes
+                mod,
+                (x,),
+                match_count + other_match_count,
+                match_nodes + other_match_nodes,
             )
 
     def test_custom_post_pass(self):
         with config.patch(
-                # leave custom pass only in post_grad_passes()
-                pattern_matcher=False,
-                # define pattern match as custom post grad opt pass
-                post_grad_custom_pre_pass=None,
-                post_grad_custom_post_pass=self._CustomPass()
+            # leave custom pass only in post_grad_passes()
+            pattern_matcher=False,
+            # define pattern match as custom post grad opt pass
+            post_grad_custom_pre_pass=None,
+            post_grad_custom_post_pass=self._CustomPass(),
         ):
             # init mkldnn fusion on custom_matcher
             self._register_mkldnn_conv_relu_fusion(config.post_grad_custom_post_pass)
@@ -159,7 +162,10 @@ class TestPostGradCustomPrePostPass(TestCustomPassBase):
             other_match_count = 1  # conv prepack weight
             other_match_nodes = 1  # conv prepack weight
             self._test_common(
-                mod, (x,), match_count + other_match_count, match_nodes + other_match_nodes
+                mod,
+                (x,),
+                match_count + other_match_count,
+                match_nodes + other_match_nodes,
             )
 
 

--- a/test/inductor/test_custom_post_grad_passes.py
+++ b/test/inductor/test_custom_post_grad_passes.py
@@ -119,52 +119,48 @@ class TestPostGradCustomPrePostPass(TestCustomPassBase):
             return x1.relu()
 
     def test_custom_pre_pass(self):
-        # leave custom pass only in post_grad_passes()
-        dafault_pattern_matcher = config.pattern_matcher
-        config.pattern_matcher = False
-        # define pattern match as custom post grad opt pass
-        config.post_grad_custom_pre_pass = self._CustomPass()
-        config.post_grad_custom_post_pass = None
-        # init mkldnn fusion on custom_matcher
-        self._register_mkldnn_conv_relu_fusion(config.post_grad_custom_pre_pass)
+        with config.patch(
+                # leave custom pass only in post_grad_passes()
+                pattern_matcher=False,
+                post_grad_custom_pre_pass=self._CustomPass(),
+                # define pattern match as custom post grad opt pass
+                post_grad_custom_post_pass=None,
+        ):
+            # init mkldnn fusion on custom_matcher
+            self._register_mkldnn_conv_relu_fusion(config.post_grad_custom_pre_pass)
 
-        mod = self._ConvReLU(16, 16).eval()
-        x = torch.randn((1, 16, 56, 56), dtype=torch.float32)
+            mod = self._ConvReLU(16, 16).eval()
+            x = torch.randn((1, 16, 56, 56), dtype=torch.float32)
 
-        match_count = 1
-        match_nodes = 2
-        other_match_count = 1  # conv prepack weight
-        other_match_nodes = 1  # conv prepack weight
-        self._test_common(
-            mod, (x,), match_count + other_match_count, match_nodes + other_match_nodes
-        )
-
-        # restore default pattern_matcher
-        config.pattern_matcher = dafault_pattern_matcher
+            match_count = 1
+            match_nodes = 2
+            other_match_count = 1  # conv prepack weight
+            other_match_nodes = 1  # conv prepack weight
+            self._test_common(
+                mod, (x,), match_count + other_match_count, match_nodes + other_match_nodes
+            )
 
     def test_custom_post_pass(self):
-        # leave custom pass only in post_grad_passes()
-        dafault_pattern_matcher = config.pattern_matcher
-        config.pattern_matcher = False
-        # define pattern match as custom post grad opt pass
-        config.post_grad_custom_pre_pass = None
-        config.post_grad_custom_post_pass = self._CustomPass()
-        # init mkldnn fusion on custom_matcher
-        self._register_mkldnn_conv_relu_fusion(config.post_grad_custom_post_pass)
+        with config.patch(
+                # leave custom pass only in post_grad_passes()
+                pattern_matcher=False,
+                # define pattern match as custom post grad opt pass
+                post_grad_custom_pre_pass=None,
+                post_grad_custom_post_pass=self._CustomPass()
+        ):
+            # init mkldnn fusion on custom_matcher
+            self._register_mkldnn_conv_relu_fusion(config.post_grad_custom_post_pass)
 
-        mod = self._ConvReLU(16, 16).eval()
-        x = torch.randn((1, 16, 56, 56), dtype=torch.float32)
+            mod = self._ConvReLU(16, 16).eval()
+            x = torch.randn((1, 16, 56, 56), dtype=torch.float32)
 
-        match_count = 1
-        match_nodes = 2
-        other_match_count = 1  # conv prepack weight
-        other_match_nodes = 1  # conv prepack weight
-        self._test_common(
-            mod, (x,), match_count + other_match_count, match_nodes + other_match_nodes
-        )
-
-        # restore default pattern_matcher
-        config.pattern_matcher = dafault_pattern_matcher
+            match_count = 1
+            match_nodes = 2
+            other_match_count = 1  # conv prepack weight
+            other_match_nodes = 1  # conv prepack weight
+            self._test_common(
+                mod, (x,), match_count + other_match_count, match_nodes + other_match_nodes
+            )
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -589,7 +589,6 @@ class TestPatternMatcher(TestCase):
     # Turn it back on for test
     @inductor_config.patch(joint_graph_constant_folding=True)
     def test_pointless_cumsum(self):
-
         def fn1():
             ones = torch.full(
                 [1, 128], 1, layout=torch.strided, dtype=torch.float32

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -585,10 +585,10 @@ class TestPatternMatcher(TestCase):
         joint_graph.joint_graph_passes(gm)
         self.assertEqual(count_calls(gm.graph), 2)
 
+    # Constant folding was explicitly turned off due to issue #108388
+    # Turn it back on for test
+    @inductor_config.patch(joint_graph_constant_folding=True)
     def test_pointless_cumsum(self):
-        # Constant folding was explicitly turned off due to issue #108388
-        # Turn it back on for test
-        torch._inductor.config.joint_graph_constant_folding = True
 
         def fn1():
             ones = torch.full(

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3711,13 +3711,12 @@ class CommonTemplate:
         )
 
     @skipCUDAIf(not SM80OrLater, "uses bfloat16 which requires SM >= 80")
+    # Constant folding was explicitly turned off due to issue #108388
+    # Turn it back on for test
+    @torch._inductor.config.patch(joint_graph_constant_folding=True)
     def test_remove_no_ops(self):
         def matmul_with_op(x, y, fn):
             return fn(x @ y)
-
-        # Constant folding was explicitly turned off due to issue #108388
-        # Turn it back on for test
-        torch._inductor.config.joint_graph_constant_folding = True
 
         foo_opt = torch.compile(matmul_with_op)
 
@@ -4789,8 +4788,8 @@ class CommonTemplate:
         for ref, test in zip(refs, tests):
             torch.testing.assert_close(ref, test)
 
+    @torch._dynamo.config.patch(cache_size_limit=10)
     def test_tensor_index_put_slice(self):
-        torch._dynamo.config.cache_size_limit = 10
 
         def fn(a, version):
             x = torch.tensor([1, 2], device=self.device, dtype=torch.int32)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4790,7 +4790,6 @@ class CommonTemplate:
 
     @torch._dynamo.config.patch(cache_size_limit=10)
     def test_tensor_index_put_slice(self):
-
         def fn(a, version):
             x = torch.tensor([1, 2], device=self.device, dtype=torch.int32)
             y = torch.tensor([2, 3], device=self.device, dtype=torch.int32)

--- a/test/quantization/pt2e/test_xnnpack_quantizer.py
+++ b/test/quantization/pt2e/test_xnnpack_quantizer.py
@@ -526,11 +526,11 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
             model_fx(*example_inputs)
             model_fx = _convert_to_reference_decomposed_fx(model_fx)
 
-            torchdynamo.config.allow_rnn = True
-            model_graph = capture_pre_autograd_graph(
-                model_graph,
-                example_inputs,
-            )
+            with torchdynamo.config.patch(allow_rnn=True):
+                model_graph = capture_pre_autograd_graph(
+                    model_graph,
+                    example_inputs,
+                )
             quantizer = XNNPACKQuantizer()
             quantization_config = get_symmetric_quantization_config(
                 is_per_channel=False, is_dynamic=False
@@ -590,11 +590,11 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
             model_fx(*example_inputs)
             model_fx = _convert_to_reference_decomposed_fx(model_fx)
 
-            torchdynamo.config.allow_rnn = True
-            model_graph = capture_pre_autograd_graph(
-                model_graph,
-                example_inputs,
-            )
+            with torchdynamo.config.patch(allow_rnn=True):
+                model_graph = capture_pre_autograd_graph(
+                    model_graph,
+                    example_inputs,
+                )
             quantizer = XNNPACKQuantizer()
             quantization_config = get_symmetric_quantization_config(
                 is_per_channel=False, is_dynamic=False

--- a/test/torch_np/test_random.py
+++ b/test/torch_np/test_random.py
@@ -24,12 +24,8 @@ from torch.testing._internal.common_utils import (
 
 @contextmanager
 def control_stream(use_numpy=False):
-    oldstate = config.use_numpy_random_stream
-    config.use_numpy_random_stream = use_numpy
-    try:
+    with config.patch(use_numpy_random_stream=use_numpy):
         yield
-    finally:
-        config.use_numpy_random_stream = oldstate
 
 
 @instantiate_parametrized_tests


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #113882

We should uniformly use `config.patch` so the configuration changes don't effect
different tests.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler