### PR TITLE
Export `_C` in `torch/__init__.py` explicitly with `from . import`

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -238,7 +238,7 @@ else:
 # Appease the type checker; ordinarily this binding is inserted by the
 # torch._C module initialization code in C
 if TYPE_CHECKING:
-    import torch._C as _C
+    from . import _C as _C
 
 class SymInt:
     """


### PR DESCRIPTION
This is now required with mypy 1.7. See release blog post: https://mypy-lang.blogspot.com/2023/11/mypy-17-released.html under the heading "New Rules for Re-exports".

Under normal circumstances this isn't noticeable, but when the setting
```
implicit_reexport = false
```
is used in the mypy config file, then mypy can't find `torch._C` when only `torch` has been imported.