### PR TITLE
[dtensor] add foreach_zero_ support

### DIFF
--- a/test/distributed/_tensor/test_optimizers.py
+++ b/test/distributed/_tensor/test_optimizers.py
@@ -59,27 +59,25 @@ class TestDTensorOptimizer(DTensorTestBase):
         dist_optim,
         inputs,
     ):
-        # run forward/backward/optim for original model
-        out = model(inputs)
-        loss = out.sum()
-        loss.backward()
-        optim.step()
-        optim.zero_grad(set_to_none=False)
+        for iter_idx in range(2):
+            # run forward/backward/optim for original model
+            optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
+            out = model(inputs)
+            loss = out.sum()
+            loss.backward()
+            optim.step()
 
-        # run forward/backward/optim for distributed model
-        dist_out = dist_model(inputs)
-        # dist_out = dist_out.redistribute(placements=[Replicate()] * mesh.ndim)
-        dist_loss = dist_out.sum()
-        dist_loss.backward()
-        dist_optim.step()
-        dist_optim.zero_grad(set_to_none=False)
+            # run forward/backward/optim for distributed model
+            dist_optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
+            dist_out = dist_model(inputs)
+            dist_loss = dist_out.sum()
+            dist_loss.backward()
+            dist_optim.step()
 
-        # check that the optimizer update parameters with same numerics
-        for p1, p2 in zip(model.parameters(), dist_model.parameters()):
-            # turn p2 to full replication for comparison
-            p2 = p2.redistribute(placements=[Replicate()] * mesh.ndim)
-            p2 = p2.to_local()
-            self.assertEqual(p1, p2)
+            # check that the optimizer update parameters with same numerics
+            for p1, p2 in zip(model.parameters(), dist_model.parameters()):
+                p2 = p2.full_tensor()
+                self.assertEqual(p1, p2)
 
     @with_comms
     def test_adam_1d_sharding(self):

--- a/test/distributed/_tensor/test_optimizers.py
+++ b/test/distributed/_tensor/test_optimizers.py
@@ -60,19 +60,19 @@ class TestDTensorOptimizer(DTensorTestBase):
         inputs,
     ):
         # run forward/backward/optim for original model
-        optim.zero_grad()
         out = model(inputs)
         loss = out.sum()
         loss.backward()
         optim.step()
+        optim.zero_grad(set_to_none=False)
 
         # run forward/backward/optim for distributed model
-        dist_optim.zero_grad()
         dist_out = dist_model(inputs)
         # dist_out = dist_out.redistribute(placements=[Replicate()] * mesh.ndim)
         dist_loss = dist_out.sum()
         dist_loss.backward()
         dist_optim.step()
+        dist_optim.zero_grad(set_to_none=False)
 
         # check that the optimizer update parameters with same numerics
         for p1, p2 in zip(model.parameters(), dist_model.parameters()):

--- a/torch/distributed/_tensor/ops/pointwise_ops.py
+++ b/torch/distributed/_tensor/ops/pointwise_ops.py
@@ -532,6 +532,7 @@ for_each_ops = [
     aten._foreach_sub_.Scalar,
     aten._foreach_sqrt.default,
     aten._foreach_sqrt_.default,
+    aten._foreach_zero_.default,
 ]
 
 for_each_linearity_ops = [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #113897

This PR add foreach_zero_ op support, to fix when
optim.zero_grad(set_to_none=False) hit this op and erroring out the
device mesh not found issue.

Also move the test to use zero_grad as the last step as that's when we
going to have dtensor as grads

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @fduwjj @wz337 @tianyu-l @wconstab @yf225 @kiukchung @d4l3k @lucasllc