### PR TITLE
[DTensor] Added `op_call` in no-mesh dispatch assert message

### DIFF
--- a/torch/distributed/_tensor/dispatch.py
+++ b/torch/distributed/_tensor/dispatch.py
@@ -163,7 +163,7 @@ class OpDispatcher:
                 kwargs_schema[k] = v
                 local_kwargs[k] = v
 
-        assert mesh is not None, "found no DeviceMesh from dtensor args!"
+        assert mesh is not None, f"found no DeviceMesh from dtensor args for {op_call}!"
         op_info = OpInfo(
             mesh,
             OpSchema(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #113903
* #113654

This helps debug, e.g. when there is an unsupported op.