### PR TITLE
Guard when fetching non-symbolic value out of Scalar

### DIFF
--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -92,11 +92,14 @@ class C10_API Scalar {
     } else if (Tag::HAS_i == tag) {                                   \
       return checked_convert<type, int64_t>(v.i, #type);              \
     } else if (Tag::HAS_si == tag) {                                  \
-      TORCH_CHECK(false, "tried to get " #name " out of SymInt")      \
+      return checked_convert<type, int64_t>(                          \
+          toSymInt().guard_int(__FILE__, __LINE__), #type);           \
     } else if (Tag::HAS_sd == tag) {                                  \
-      TORCH_CHECK(false, "tried to get " #name " out of SymFloat")    \
+      return checked_convert<type, int64_t>(                          \
+          toSymFloat().guard_float(__FILE__, __LINE__), #type);       \
     } else if (Tag::HAS_sb == tag) {                                  \
-      TORCH_CHECK(false, "tried to get " #name " out of SymBool")     \
+      return checked_convert<type, int64_t>(                          \
+          toSymBool().guard_bool(__FILE__, __LINE__), #type);         \
     }                                                                 \
     TORCH_CHECK(false)                                                \
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #113921
* #113452
* __->__ #113911
* #113877

Signed-off-by: Edward Z. Yang <ezyang@meta.com>