### PR TITLE
BUG: fix np.ndarray.resize under dynamo

### DIFF
--- a/test/torch_np/numpy_tests/core/test_multiarray.py
+++ b/test/torch_np/numpy_tests/core/test_multiarray.py
@@ -4423,7 +4423,6 @@ class TestResize(TestCase):
         assert_raises(ValueError, x.resize, (5, 1))
         del y  # avoid pyflakes unused variable warning.
 
-    @xfailIfTorchDynamo  # https://github.com/pytorch/pytorch/issues/113539
     @_no_tracing
     def test_int_shape(self):
         x = np.eye(3)
@@ -4458,7 +4457,6 @@ class TestResize(TestCase):
         assert_raises(TypeError, np.eye(3).resize, order=1)
         assert_raises((NotImplementedError, TypeError), np.eye(3).resize, refcheck="hi")
 
-    @xfailIfTorchDynamo  # https://github.com/pytorch/pytorch/issues/113539
     @_no_tracing
     def test_freeform_shape(self):
         x = np.eye(3)
@@ -4468,7 +4466,6 @@ class TestResize(TestCase):
             x.resize(3, 2, 1)
         assert_(x.shape == (3, 2, 1))
 
-    @xfailIfTorchDynamo  # https://github.com/pytorch/pytorch/issues/113539
     @_no_tracing
     def test_zeros_appended(self):
         x = np.eye(3)

--- a/torch/_numpy/_ndarray.py
+++ b/torch/_numpy/_ndarray.py
@@ -298,14 +298,12 @@ class ndarray:
 
     def resize(self, *new_shape, refcheck=False):
         a = self.tensor
-        # TODO(Lezcano) This is not done in-place
         # implementation of ndarray.resize.
         # NB: differs from np.resize: fills with zeros instead of making repeated copies of input.
         if refcheck:
             raise NotImplementedError(
                 f"resize(..., refcheck={refcheck} is not implemented."
             )
-
         if new_shape in [(), (None,)]:
             return
 
@@ -325,10 +323,10 @@ class ndarray:
             # shrink
             ret = a[:new_numel].reshape(new_shape)
         else:
-            b = torch.zeros(new_numel)
+            b = torch.zeros(new_numel, dtype=a.dtype)
             b[: a.numel()] = a
             ret = b.reshape(new_shape)
-        self.tensor = ret
+        self.tensor.set_(ret)
 
     def view(self, dtype):
         torch_dtype = _dtypes.dtype(dtype).torch_dtype

--- a/torch/_numpy/_ndarray.py
+++ b/torch/_numpy/_ndarray.py
@@ -297,8 +297,6 @@ class ndarray:
         return torch.flatten(self)
 
     def resize(self, *new_shape, refcheck=False):
-        a = self.tensor
-        # implementation of ndarray.resize.
         # NB: differs from np.resize: fills with zeros instead of making repeated copies of input.
         if refcheck:
             raise NotImplementedError(
@@ -313,20 +311,18 @@ class ndarray:
         if isinstance(new_shape, int):
             new_shape = (new_shape,)
 
-        a = a.flatten()
-
         if builtins.any(x < 0 for x in new_shape):
             raise ValueError("all elements of `new_shape` must be non-negative")
 
-        new_numel = math.prod(new_shape)
-        if new_numel < a.numel():
-            # shrink
-            ret = a[:new_numel].reshape(new_shape)
-        else:
-            b = torch.zeros(new_numel, dtype=a.dtype)
-            b[: a.numel()] = a
-            ret = b.reshape(new_shape)
-        self.tensor.set_(ret)
+        new_numel, old_numel = math.prod(new_shape), self.tensor.numel()
+
+        self.tensor.resize_(new_shape)
+
+        if new_numel >= old_numel:
+            # zero-fill new elements
+            assert self.tensor.is_contiguous()
+            b = self.tensor.flatten()  # does not copy
+            b[old_numel:].zero_()
 
     def view(self, dtype):
         torch_dtype = _dtypes.dtype(dtype).torch_dtype


### PR DESCRIPTION
Make sure ndarray.resize actually works in-place, so that dynamo does the right thing tracking the result.

Fixes #113539


cc @mruberry @rgommers @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng