### PR TITLE
Fix failing test_mkldnn_pattern_matcher if built without MKL

### DIFF
--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -24,7 +24,7 @@ from torch.testing._internal.common_quantization import (
     skipIfNoONEDNN,
     skipIfNoONEDNNBF16,
 )
-from torch.testing._internal.common_utils import IS_LINUX, TEST_MKL, skipIfRocm
+from torch.testing._internal.common_utils import IS_LINUX, skipIfRocm, TEST_MKL
 from torch.testing._internal.inductor_utils import _check_has_dynamic_shape, HAS_CPU
 
 

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 import contextlib
 import itertools
+import unittest
 
 import torch
 import torch.ao.quantization.quantizer.x86_inductor_quantizer as xiq
@@ -23,7 +24,7 @@ from torch.testing._internal.common_quantization import (
     skipIfNoONEDNN,
     skipIfNoONEDNNBF16,
 )
-from torch.testing._internal.common_utils import IS_LINUX, skipIfRocm
+from torch.testing._internal.common_utils import IS_LINUX, TEST_MKL, skipIfRocm
 from torch.testing._internal.inductor_utils import _check_has_dynamic_shape, HAS_CPU
 
 
@@ -274,6 +275,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
                     mod, (v,), matcher_count, matcher_nodes, check_autocast=True
                 )
 
+    @unittest.skipIf(not TEST_MKL, "Test requires MKL")
     def test_linear_fp32(self):
         class M(torch.nn.Module):
             def __init__(self, bias):


### PR DESCRIPTION
The test checks for the `mkldnn_fusion.linear` pass which checks `_is_packable_linear` that depends on `torch._C.has_mkl`. So skip the test as it would fail due to no pattern matches counted.

See https://github.com/pytorch/pytorch/blob/main/torch/_inductor/fx_passes/mkldnn_fusion.py#L827

CC @XiaobingSuper as the author of the test.

Not sure how many other test are affected by similar issues but this is the one in pattern matcher I see failing.

Strangely the first part of the test succeeds where `bias = True` as it finds a match for `unfuse_bias_add_to_pointwise` (torch/_inductor/fx_passes/post_grad.py) 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler