### PR TITLE
[PyTorch] Fix attr cleanup after constant folding

### DIFF
--- a/torch/_inductor/constant_folding.py
+++ b/torch/_inductor/constant_folding.py
@@ -178,7 +178,8 @@ def constant_fold(gm, constraint_fn: Optional[Callable[[torch.fx.Node], bool]] =
     erased_params = []
     for node in gm.graph.nodes:
         if node.op == "get_attr" and len(node.users) == 0:
-            delattr(gm, node.target)
+            if hasattr(gm, node.target):
+                delattr(gm, node.target)
             erased_params.append(node)
 
     for node in erased_params:


### PR DESCRIPTION
Summary:
Two nodes can point to the same attribute via node.target.

This makes sure,
    - we don't try to delete already deleted attribute, i.e. delete attr only once
    - we do delete all the nodes pointing to the attribute

Test Plan:
```
buck run fbcode//mode/dev-nosan fbcode//executorch/backends/xnnpack/test:test_xnnpack_passes -- executorch.backends.xnnpack.test.passes.test_batch_norm_fusion.TestBatchNormFusion.test_q8_batch_norm_fusion
```

Differential Revision: D51419442




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler