### PR TITLE
[GHF] Abort merge on rebase failure

### DIFF
--- a/.github/scripts/tryrebase.py
+++ b/.github/scripts/tryrebase.py
@@ -119,6 +119,7 @@ def rebase_ghstack_onto(
 
     if dry_run:
         print("Don't know how to dry-run ghstack")
+        return False
     else:
         ghstack_result = subprocess.run(["ghstack"], capture_output=True, check=True)
         push_result = ghstack_result.stdout.decode("utf-8")

--- a/.github/scripts/tryrebase.py
+++ b/.github/scripts/tryrebase.py
@@ -51,7 +51,7 @@ def post_already_uptodate(
 
 def rebase_onto(
     pr: GitHubPR, repo: GitRepo, onto_branch: str, dry_run: bool = False
-) -> None:
+) -> bool:
     branch = f"pull/{pr.pr_num}/head"
     remote_url = f"https://github.com/{pr.info['headRepository']['nameWithOwner']}.git"
     refspec = f"{branch}:{pr.head_ref()}"
@@ -68,6 +68,7 @@ def rebase_onto(
         push_result = repo._run_git("push", "-f", remote_url, refspec)
     if "Everything up-to-date" in push_result:
         post_already_uptodate(pr, repo, onto_branch, dry_run)
+        return False
     else:
         gh_post_comment(
             pr.org,
@@ -78,11 +79,12 @@ def rebase_onto(
             + "git pull --rebase`)",
             dry_run=dry_run,
         )
+        return True
 
 
 def rebase_ghstack_onto(
     pr: GitHubPR, repo: GitRepo, onto_branch: str, dry_run: bool = False
-) -> None:
+) -> bool:
     if (
         subprocess.run(
             [sys.executable, "-m", "ghstack", "--help"],
@@ -168,6 +170,8 @@ def rebase_ghstack_onto(
             in push_result
         ):
             post_already_uptodate(pr, repo, onto_branch, dry_run)
+            return False
+        return True
 
 
 def additional_rebase_failure_info(e: Exception) -> str:
@@ -224,9 +228,10 @@ def main() -> None:
     try:
         if pr.is_ghstack_pr():
             with git_config_guard(repo):
-                rebase_ghstack_onto(pr, repo, onto_branch, dry_run=args.dry_run)
+                rc = rebase_ghstack_onto(pr, repo, onto_branch, dry_run=args.dry_run)
         else:
-            rebase_onto(pr, repo, onto_branch, dry_run=args.dry_run)
+            rc = rebase_onto(pr, repo, onto_branch, dry_run=args.dry_run)
+        sys.exit(0 if rc else 1)
 
     except Exception as e:
         msg = f"Rebase failed due to {e}"

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -43,9 +43,13 @@ jobs:
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
           DRCI_BOT_KEY: ${{ secrets.DRCI_BOT_KEY }}
         run: |
-          set -ex
+          set -x
           if [ -n "${REBASE}" ]; then
             python3 .github/scripts/tryrebase.py "${PR_NUM}" --branch "${REBASE}"
+            if [ $? != 1 ]; then
+              python3 .github/scripts/comment_on_pr.py "${PR_NUM}" "merge"
+              exit 0
+            fi
             git checkout main
             git fetch -p
             # give github some time between the push and start workflows so that Github's messages
@@ -76,7 +80,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
           PR_NUM: ${{ github.event.client_payload.pr_num }}
         run: |
-          set -ex
+          set -x
           python3 .github/scripts/comment_on_pr.py "${PR_NUM}" "merge"
 
 # We want newer merge commands to supercede old ones

--- a/.github/workflows/tryrebase.yml
+++ b/.github/workflows/tryrebase.yml
@@ -38,7 +38,7 @@ jobs:
           PR_NUM: ${{ github.event.client_payload.pr_num }}
           BRANCH: ${{ github.event.client_payload.branch }}
         run: |
-          set -ex
+          set -x
           if [ -n "${BRANCH}" ]; then
             python3 .github/scripts/tryrebase.py "${PR_NUM}" --branch "${BRANCH}"
           else


### PR DESCRIPTION
Abort merges invoked with `-r` if there is nothing to rebase

Make `rebase_onto`/`rebase_ghstack_onto` return False if rebase is no-op and abort merge in that case

Remove `-e` option from both trymerge and tryrebase workflows as  one should never report failures on workflow dispatch
