### PR TITLE
[ez] Hash update to reuse issues again

### DIFF
--- a/.github/scripts/update_commit_hashes.py
+++ b/.github/scripts/update_commit_hashes.py
@@ -115,7 +115,7 @@ def main() -> None:
     # query to see if a pr already exists
     params = {
         "q": f"is:pr is:open in:title author:pytorchupdatebot repo:{OWNER}/{REPO} {args.repo_name} hash update",
-        "sort": "created"
+        "sort": "created",
     }
     response = git_api("/search/issues", params)
     if response["total_count"] != 0:

--- a/.github/scripts/update_commit_hashes.py
+++ b/.github/scripts/update_commit_hashes.py
@@ -114,7 +114,8 @@ def main() -> None:
 
     # query to see if a pr already exists
     params = {
-        "q": f"is:pr is:open in:title author:pytorchmergebot repo:{OWNER}/{REPO} {args.repo_name} hash update"
+        "q": f"is:pr is:open in:title author:pytorchupdatebot repo:{OWNER}/{REPO} {args.repo_name} hash update",
+        "sort": "created"
     }
     response = git_api("/search/issues", params)
     if response["total_count"] != 0:


### PR DESCRIPTION
The bot that creates the issue got changed, but the search did not, so it wasn't finding old PRs and was just making new ones.

This PR makes it reuse PRs again instead of making a new one everytime.