### PR TITLE
Fix caffe2 c++20 / windows build problem

### DIFF
--- a/torch/csrc/jit/codegen/fuser/cpu/fused_kernel.cpp
+++ b/torch/csrc/jit/codegen/fuser/cpu/fused_kernel.cpp
@@ -148,7 +148,7 @@ void activate() {
 
 intptr_t run(const std::string& cmd) {
   // Getting the path of `cmd.exe`
-  wchar_t* comspec = _wgetenv(L"COMSPEC");
+  const wchar_t* comspec = _wgetenv(L"COMSPEC");
   if (!comspec) {
     comspec = L"C:\\Windows\\System32\\cmd.exe";
   }


### PR DESCRIPTION
Summary: - `stderr: D:\full-fbsource\xplat\caffe2\torch\csrc\jit\codegen\fuser\cpu\fused_kernel.cpp(155): error C2440: '=': cannot convert from 'const wchar_t [28]' to 'wchar_t *'`

Test Plan: - CI

Differential Revision: D50902536

