### PR TITLE
[Inductor] Support ReinterpretView in inductor codegen

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -1989,12 +1989,17 @@ def forward(self, x_1, output_1):
 
     @requires_cuda()
     @skipIfRocm
-    def test_triton_kernel_None_arg(self):
+    def test_triton_kernel_various_args(self):
+        @triton.autotune(
+            configs=[triton.Config({"BLOCK_SIZE": 128})],
+            key=[],
+        )
         @triton.jit
         def pass_kernel(
             out_ptr,
-            dummy_None,
             n_elements,
+            dummy_None,
+            dummy_empty,
             BLOCK_SIZE: "tl.constexpr",
         ):
             pass
@@ -2003,7 +2008,7 @@ def forward(self, x_1, output_1):
         def call_triton(output):
             n_elements = output.numel()
             grid = (n_elements,)
-            pass_kernel[grid](output, None, n_elements, BLOCK_SIZE=16)
+            pass_kernel[grid](output, n_elements, None, torch.empty_like(output))
             return output
 
         output = torch.randn(5, device="cuda")

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -60,6 +60,8 @@ def config_of(args: List[Union[TensorArg, SizeArg]]) -> instance_descriptor:
         https://github.com/openai/triton/blob/5282ed890d453e10b9ee30076ef89115dd197761/python/triton/runtime/jit.py#L208-L222
         """
         if isinstance(x, TensorArg):
+            if x.buffer.startswith("reinterpret_tensor"):
+                return False
             if include_tensor:
                 return not V.graph.scheduler.is_unaligned_buffer(x.buffer)
             else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #114002
* __->__ #113967

Adding support for ReinterpretView in inductor so that jagged MRS kernels can use native triton kernels

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler