### PR TITLE
[ROCm][hipify] Resolve any ".." in the path using os.path.abspath

### DIFF
--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -1090,7 +1090,8 @@ def hipify(
     all_files_set = set(all_files)
     for f in extra_files:
         if not os.path.isabs(f):
-            f = os.path.join(output_directory, f)
+            # Resolve any ".." in the path using os.path.abspath
+            f = os.path.abspath(os.path.join(output_directory, f))
         if f not in all_files_set:
             all_files.append(f)
 
@@ -1101,6 +1102,8 @@ def hipify(
             header_include_dir_path = Path(header_include_dir)
         else:
             header_include_dir_path = Path(os.path.join(output_directory, header_include_dir))
+        # Resolve any ".." in the path using os.path.abspath
+        header_include_dir_path = os.path.abspath(header_include_dir_path)
         for path in header_include_dir_path.rglob('*'):
             if (
                 path.is_file()


### PR DESCRIPTION
This PR is to resolve any ".." in the file paths using os.path.abspath() during hipification. This is required to ensure all file paths  being processed by hipify code are properly resolved to ensure any file path matches etc. give the correct result.

This issue is found during JIT build of inference_core_ops extension in DeepSpeed, due to addition of ".." as prefix to the paths at
https://github.com/microsoft/DeepSpeed/blob/0ec2d3e4bfa2d0a5237e9747da1ef9d5e4a4453b/op_builder/inference_core_ops.py#L73
https://github.com/microsoft/DeepSpeed/blob/0ec2d3e4bfa2d0a5237e9747da1ef9d5e4a4453b/op_builder/inference_core_ops.py#L90



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang