### PR TITLE
Clean up optimizer imports in test_optim

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -6,7 +6,6 @@ import pickle
 from functools import partial
 
 import torch
-import torch.optim as optim
 import torch.nn.functional as F
 from torch.nn import Parameter
 from torch.optim import Adam, SGD
@@ -108,7 +107,7 @@ class TestLRScheduler(TestCase):
                     init_lr * (self.gamma**gamma_power) for init_lr in self.init_lr
                 ]
 
-        optimizer = torch.optim.SGD([torch.rand(1)], lr=1)
+        optimizer = SGD([torch.rand(1)], lr=1)
 
         with self.assertRaises(TypeError):
             scheduler = MultiStepLR(optimizer, gamma=1, milestones=[10, 20])
@@ -348,7 +347,7 @@ class TestLRScheduler(TestCase):
         from torch.nn import Parameter
 
         epochs = 10
-        optimizer = torch.optim.SGD(
+        optimizer = SGD(
             [Parameter(torch.randn(2, 2, requires_grad=True))], 0.1
         )
         targets = [[0.1] * 3 + [0.01] * 3 + [0.001] * 3 + [0.0001]]
@@ -729,7 +728,7 @@ class TestLRScheduler(TestCase):
         self._test(scheduler, targets, epochs)
 
     def test_sequentiallr4(self):
-        optimizer = torch.optim.SGD([torch.tensor(0.5)], lr=0.1)
+        optimizer = SGD([torch.tensor(0.5)], lr=0.1)
         prev_lr = optimizer.param_groups[0]["lr"]
 
         schedulers = [
@@ -1511,7 +1510,7 @@ class TestLRScheduler(TestCase):
 
     def test_cycle_lr_cycle_momentum_fail_with_momentumless_optimizer(self):
         with self.assertRaises(ValueError):
-            adam_opt = optim.Adam(self.net.parameters())
+            adam_opt = Adam(self.net.parameters())
             scheduler = CyclicLR(adam_opt, base_lr=1, max_lr=5, cycle_momentum=True)
 
     def test_cycle_lr_removed_after_out_of_scope(self):
@@ -1521,7 +1520,7 @@ class TestLRScheduler(TestCase):
         gc.disable()
 
         def test():
-            adam_opt = optim.Adam(self.net.parameters())
+            adam_opt = Adam(self.net.parameters())
             scheduler = CyclicLR(adam_opt, base_lr=1, max_lr=5, cycle_momentum=False)
             return weakref.ref(scheduler)
 
@@ -1530,7 +1529,7 @@ class TestLRScheduler(TestCase):
         gc.enable()
 
     def test_cycle_lr_state_dict_picklable(self):
-        adam_opt = optim.Adam(self.net.parameters())
+        adam_opt = Adam(self.net.parameters())
         scheduler = CyclicLR(adam_opt, base_lr=1, max_lr=5, cycle_momentum=False)
         self.assertIsInstance(scheduler._scale_fn_ref, types.FunctionType)
         state = scheduler.state_dict()
@@ -1538,7 +1537,7 @@ class TestLRScheduler(TestCase):
         pickle.dumps(state)
 
     def test_cycle_lr_scale_fn_restored_from_state_dict(self):
-        adam_opt = optim.Adam(self.net.parameters())
+        adam_opt = Adam(self.net.parameters())
 
         # Case 1: Built-in mode
         scheduler = CyclicLR(adam_opt, base_lr=1, max_lr=5, cycle_momentum=False, mode="triangular2")
@@ -1651,7 +1650,7 @@ class TestLRScheduler(TestCase):
 
     def test_cycle_lr_with_adam(self):
         old_opt = self.opt
-        self.opt = optim.Adam(
+        self.opt = Adam(
             [
                 {"params": self.net.conv1.parameters()},
                 {"params": self.net.conv2.parameters(), "lr": 0.5},
@@ -2195,7 +2194,7 @@ class TestLRScheduler(TestCase):
         optim_lr = 0.5
 
         model = torch.nn.Linear(2, 1)
-        optimizer = torch.optim.SGD(model.parameters(), lr=optim_lr)
+        optimizer = SGD(model.parameters(), lr=optim_lr)
         lr_scheduler_1 = torch.optim.lr_scheduler.CosineAnnealingLR(
             optimizer, T_max=20, eta_min=0.1
         )

--- a/test/optim/test_optim.py
+++ b/test/optim/test_optim.py
@@ -7,9 +7,10 @@ import itertools
 from copy import deepcopy
 
 import torch
-import torch.optim as optim
 from torch.nn import Parameter
-from torch.optim import Adam, SGD, Optimizer
+from torch.optim import (
+    Adadelta, Adagrad, Adam, Adamax, AdamW, ASGD, LBFGS, NAdam, RAdam, RMSprop, Rprop, SGD, SparseAdam, Optimizer
+)
 from torch.optim.lr_scheduler import (
     StepLR,
     ConstantLR,
@@ -474,14 +475,14 @@ class TestOptim(TestCase):
 
     def test_sgd(self):
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.SGD(
+            lambda weight, bias, maximize, foreach: SGD(
                 [weight, bias], lr=1e-3, maximize=maximize, foreach=foreach
             ),
             constructor_accepts_maximize=True,
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.SGD(
+            lambda weight, bias, maximize, foreach: SGD(
                 self._build_params_dict(weight, bias, lr=1e-2),
                 lr=1e-3,
                 maximize=maximize,
@@ -491,7 +492,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.SGD(
+            lambda weight, bias, maximize, foreach: SGD(
                 self._build_params_dict_single(weight, bias, lr=1e-2),
                 lr=1e-3,
                 maximize=maximize,
@@ -501,7 +502,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.SGD(
+            lambda weight, bias, maximize, foreach: SGD(
                 self._build_params_dict_single(weight, bias, lr=1e-2),
                 maximize=maximize,
                 foreach=foreach,
@@ -510,7 +511,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.SGD(
+            lambda weight, bias, maximize, foreach: SGD(
                 [weight, bias], lr=1e-3, maximize=maximize, foreach=foreach
             ),
             scheduler_constructors=[lambda opt: StepLR(opt, gamma=0.9, step_size=10)],
@@ -518,7 +519,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.SGD(
+            lambda weight, bias, maximize, foreach: SGD(
                 [weight, bias], lr=1e-3, maximize=maximize, foreach=foreach
             ),
             scheduler_constructors=[
@@ -530,7 +531,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.SGD(
+            lambda weight, bias, maximize, foreach: SGD(
                 [weight, bias], lr=1e-3, maximize=maximize, foreach=foreach
             ),
             scheduler_constructors=[lambda opt: ConstantLR(opt, factor=0.4, total_iters=4)],
@@ -538,7 +539,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.SGD(
+            lambda weight, bias, maximize, foreach: SGD(
                 [weight, bias], lr=1e-3, maximize=maximize, foreach=foreach
             ),
             scheduler_constructors=[lambda opt: PolynomialLR(opt, power=0.9, total_iters=4)],
@@ -546,7 +547,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.SGD(
+            lambda weight, bias, maximize, foreach: SGD(
                 [weight, bias], lr=1e-3, maximize=maximize, foreach=foreach
             ),
             scheduler_constructors=[
@@ -559,7 +560,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.SGD(
+            lambda weight, bias, maximize, foreach: SGD(
                 [weight, bias], lr=1e-3, maximize=maximize, foreach=foreach
             ),
             [
@@ -570,7 +571,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.SGD(
+            lambda weight, bias, maximize, foreach: SGD(
                 [weight, bias], lr=1e-3, maximize=maximize, foreach=foreach
             ),
             [
@@ -582,7 +583,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.SGD(
+            lambda weight, bias, maximize, foreach: SGD(
                 [weight, bias],
                 lr=1e-3,
                 momentum=0.5,
@@ -593,7 +594,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.SGD(
+            lambda weight, bias, maximize, foreach: SGD(
                 [weight, bias],
                 lr=1e-3,
                 momentum=0.5,
@@ -605,7 +606,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.SGD(
+            lambda weight, bias, maximize, foreach: SGD(
                 [weight, bias],
                 nesterov=True,
                 lr=1e-3,
@@ -618,16 +619,16 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         with self.assertRaisesRegex(ValueError, "Invalid momentum value: -0.5"):
-            optim.SGD(None, lr=1e-2, momentum=-0.5)
+            SGD(None, lr=1e-2, momentum=-0.5)
 
     def test_sgd_sparse(self):
         for foreach in (False, True):
             self._test_rosenbrock_sparse(
-                lambda params: optim.SGD(params, lr=4.8e-3, foreach=foreach),
+                lambda params: SGD(params, lr=4.8e-3, foreach=foreach),
                 multi_tensor=foreach,
             )
             self._test_rosenbrock_sparse(
-                lambda params: optim.SGD(params, lr=0.0048, foreach=foreach),
+                lambda params: SGD(params, lr=0.0048, foreach=foreach),
                 scheduler_constructors=[lambda opt: StepLR(opt, gamma=0.99999, step_size=300)],
                 multi_tensor=foreach,
             )
@@ -635,18 +636,18 @@ class TestOptim(TestCase):
     def test_sgd_complex(self):
         for foreach in (False, True):
             self._test_complex_optimizer(
-                lambda param: optim.SGD([param], lr=0.001, foreach=foreach)
+                lambda param: SGD([param], lr=0.001, foreach=foreach)
             )
             self._test_complex_optimizer(
-                lambda param: optim.SGD([param], lr=0.001, momentum=1, foreach=foreach)
+                lambda param: SGD([param], lr=0.001, momentum=1, foreach=foreach)
             )
             self._test_complex_optimizer(
-                lambda param: optim.SGD(
+                lambda param: SGD(
                     [param], lr=0.001, momentum=1, weight_decay=1, foreach=foreach
                 )
             )
             self._test_complex_optimizer(
-                lambda param: optim.SGD(
+                lambda param: SGD(
                     [param],
                     lr=0.001,
                     nesterov=True,
@@ -656,7 +657,7 @@ class TestOptim(TestCase):
                 )
             )
             self._test_complex_optimizer(
-                lambda param: optim.SGD(
+                lambda param: SGD(
                     [param],
                     lr=0.001,
                     momentum=1,
@@ -867,92 +868,92 @@ class TestOptim(TestCase):
     @property
     def _multi_tensor_optimizer_configs(self):
         return [
-            (optim.Adam, dict(weight_decay=1.0, amsgrad=False)),
-            (optim.Adam, dict(weight_decay=0.0, amsgrad=True)),
-            (optim.Adam, dict(weight_decay=0.0, amsgrad=False, maximize=True)),
-            (optim.Adam, dict(weight_decay=1.0, amsgrad=True, maximize=True)),
-            (optim.Adam, dict(weight_decay=0.0, amsgrad=False, capturable=True, maximize=True)),
-            (optim.Adam, dict(weight_decay=1.0, amsgrad=True, capturable=True, maximize=True)),
+            (Adam, dict(weight_decay=1.0, amsgrad=False)),
+            (Adam, dict(weight_decay=0.0, amsgrad=True)),
+            (Adam, dict(weight_decay=0.0, amsgrad=False, maximize=True)),
+            (Adam, dict(weight_decay=1.0, amsgrad=True, maximize=True)),
+            (Adam, dict(weight_decay=0.0, amsgrad=False, capturable=True, maximize=True)),
+            (Adam, dict(weight_decay=1.0, amsgrad=True, capturable=True, maximize=True)),
             (
-                optim.Adam,
+                Adam,
                 dict(lr=torch.tensor(.001), weight_decay=1.0, amsgrad=True,
                      capturable=True, maximize=True)
             ),
-            (optim.AdamW, dict(weight_decay=1.0, amsgrad=False)),
-            (optim.AdamW, dict(weight_decay=0.0, amsgrad=True)),
-            (optim.AdamW, dict(weight_decay=1.0, amsgrad=True, maximize=True)),
-            (optim.AdamW, dict(weight_decay=0.0, amsgrad=False, maximize=True)),
-            (optim.AdamW, dict(weight_decay=1.0, amsgrad=True, capturable=True, maximize=True)),
-            (optim.AdamW, dict(weight_decay=0.0, amsgrad=False, capturable=True, maximize=True)),
+            (AdamW, dict(weight_decay=1.0, amsgrad=False)),
+            (AdamW, dict(weight_decay=0.0, amsgrad=True)),
+            (AdamW, dict(weight_decay=1.0, amsgrad=True, maximize=True)),
+            (AdamW, dict(weight_decay=0.0, amsgrad=False, maximize=True)),
+            (AdamW, dict(weight_decay=1.0, amsgrad=True, capturable=True, maximize=True)),
+            (AdamW, dict(weight_decay=0.0, amsgrad=False, capturable=True, maximize=True)),
             (
-                optim.AdamW,
+                AdamW,
                 dict(lr=torch.tensor(.001), weight_decay=0.0, amsgrad=False,
                      capturable=True, maximize=True)
             ),
-            (optim.NAdam, dict(weight_decay=0.0, momentum_decay=6e-3)),
-            (optim.NAdam, dict(weight_decay=1.0, momentum_decay=6e-3)),
-            (optim.NAdam, dict(weight_decay=0.0, momentum_decay=4e-3)),
-            (optim.NAdam, dict(weight_decay=0.01, momentum_decay=4e-3)),
-            (optim.NAdam, dict(weight_decay=0.0, momentum_decay=6e-3, capturable=True)),
-            (optim.NAdam, dict(weight_decay=0.01, momentum_decay=4e-3, capturable=True)),
-            (optim.NAdam, dict(weight_decay=0.0, momentum_decay=4e-3, decoupled_weight_decay=True)),
+            (NAdam, dict(weight_decay=0.0, momentum_decay=6e-3)),
+            (NAdam, dict(weight_decay=1.0, momentum_decay=6e-3)),
+            (NAdam, dict(weight_decay=0.0, momentum_decay=4e-3)),
+            (NAdam, dict(weight_decay=0.01, momentum_decay=4e-3)),
+            (NAdam, dict(weight_decay=0.0, momentum_decay=6e-3, capturable=True)),
+            (NAdam, dict(weight_decay=0.01, momentum_decay=4e-3, capturable=True)),
+            (NAdam, dict(weight_decay=0.0, momentum_decay=4e-3, decoupled_weight_decay=True)),
             (
-                optim.NAdam,
+                NAdam,
                 dict(weight_decay=0.01, momentum_decay=4e-3, decoupled_weight_decay=True),
             ),
             (
-                optim.NAdam,
+                NAdam,
                 dict(weight_decay=0.01, momentum_decay=4e-3,
                      decoupled_weight_decay=True, capturable=True),
             ),
             (
-                optim.SGD,
+                SGD,
                 dict(lr=0.2, momentum=1, dampening=0, weight_decay=1, nesterov=True),
             ),
             (
-                optim.SGD,
+                SGD,
                 dict(lr=0.2, momentum=1, dampening=0.5, weight_decay=1, nesterov=False),
             ),
             (
-                optim.SGD,
+                SGD,
                 dict(lr=0.2, momentum=1, dampening=0, weight_decay=1, nesterov=True, maximize=True),
             ),
             (
-                optim.SGD,
+                SGD,
                 dict(lr=0.2, momentum=1, dampening=0.5, weight_decay=1, nesterov=False, maximize=True),
             ),
-            (optim.RAdam, dict(weight_decay=0, eps=1e-6)),
-            (optim.RAdam, dict(weight_decay=0)),
-            (optim.RAdam, dict(weight_decay=1, eps=1e-6)),
-            (optim.RAdam, dict(weight_decay=1)),
-            (optim.RAdam, dict(weight_decay=0, decoupled_weight_decay=True)),
-            (optim.RAdam, dict(weight_decay=1, decoupled_weight_decay=True)),
-            (optim.RMSprop, dict(weight_decay=1, momentum=1, centered=True)),
-            (optim.RMSprop, dict(weight_decay=1, momentum=0, centered=True)),
-            (optim.RMSprop, dict(weight_decay=1, momentum=1, centered=False)),
-            (optim.RMSprop, dict(weight_decay=0, momentum=1, centered=False)),
-            (optim.Rprop, dict(lr=1e-2, etas=(0.5, 1.2), step_sizes=(1e-6, 50))),
-            (optim.Rprop, dict(lr=1e-2, etas=(0.5, 1.2), step_sizes=(1e-6, 50), maximize=True)),
-            (optim.ASGD, dict(weight_decay=0)),
-            (optim.ASGD, dict(weight_decay=1)),
-            (optim.ASGD, dict(weight_decay=0, maximize=True)),
-            (optim.ASGD, dict(weight_decay=1, maximize=True)),
-            (optim.ASGD, dict(weight_decay=0, capturable=True)),
-            (optim.ASGD, dict(weight_decay=1, capturable=True)),
-            (optim.ASGD, dict(weight_decay=0, maximize=True, capturable=True)),
-            (optim.ASGD, dict(weight_decay=1, maximize=True, capturable=True)),
-            (optim.Adamax, dict(weight_decay=0)),
-            (optim.Adamax, dict(weight_decay=1)),
-            (optim.Adamax, dict(weight_decay=0, maximize=True)),
-            (optim.Adamax, dict(weight_decay=1, maximize=True)),
-            (optim.Adadelta, dict(weight_decay=0)),
-            (optim.Adadelta, dict(weight_decay=1)),
-            (optim.Adadelta, dict(weight_decay=0, maximize=True)),
-            (optim.Adadelta, dict(weight_decay=1, maximize=True)),
-            (optim.Adagrad, dict(weight_decay=0)),
-            (optim.Adagrad, dict(weight_decay=1)),
-            (optim.Adagrad, dict(weight_decay=0, maximize=True)),
-            (optim.Adagrad, dict(weight_decay=1, maximize=True)),
+            (RAdam, dict(weight_decay=0, eps=1e-6)),
+            (RAdam, dict(weight_decay=0)),
+            (RAdam, dict(weight_decay=1, eps=1e-6)),
+            (RAdam, dict(weight_decay=1)),
+            (RAdam, dict(weight_decay=0, decoupled_weight_decay=True)),
+            (RAdam, dict(weight_decay=1, decoupled_weight_decay=True)),
+            (RMSprop, dict(weight_decay=1, momentum=1, centered=True)),
+            (RMSprop, dict(weight_decay=1, momentum=0, centered=True)),
+            (RMSprop, dict(weight_decay=1, momentum=1, centered=False)),
+            (RMSprop, dict(weight_decay=0, momentum=1, centered=False)),
+            (Rprop, dict(lr=1e-2, etas=(0.5, 1.2), step_sizes=(1e-6, 50))),
+            (Rprop, dict(lr=1e-2, etas=(0.5, 1.2), step_sizes=(1e-6, 50), maximize=True)),
+            (ASGD, dict(weight_decay=0)),
+            (ASGD, dict(weight_decay=1)),
+            (ASGD, dict(weight_decay=0, maximize=True)),
+            (ASGD, dict(weight_decay=1, maximize=True)),
+            (ASGD, dict(weight_decay=0, capturable=True)),
+            (ASGD, dict(weight_decay=1, capturable=True)),
+            (ASGD, dict(weight_decay=0, maximize=True, capturable=True)),
+            (ASGD, dict(weight_decay=1, maximize=True, capturable=True)),
+            (Adamax, dict(weight_decay=0)),
+            (Adamax, dict(weight_decay=1)),
+            (Adamax, dict(weight_decay=0, maximize=True)),
+            (Adamax, dict(weight_decay=1, maximize=True)),
+            (Adadelta, dict(weight_decay=0)),
+            (Adadelta, dict(weight_decay=1)),
+            (Adadelta, dict(weight_decay=0, maximize=True)),
+            (Adadelta, dict(weight_decay=1, maximize=True)),
+            (Adagrad, dict(weight_decay=0)),
+            (Adagrad, dict(weight_decay=1)),
+            (Adagrad, dict(weight_decay=0, maximize=True)),
+            (Adagrad, dict(weight_decay=1, maximize=True)),
         ]
 
     def test_multi_tensor_optimizers(self):
@@ -968,7 +969,7 @@ class TestOptim(TestCase):
     def test_multi_tensor_optimizers_with_large_tensors(self):
         for optimizer_ctor, optimizer_params in self._multi_tensor_optimizer_configs:
             # note(crcrpar): H100 wasn't sufficient for Adamax, surprisingly
-            if optimizer_ctor == optim.Adamax:
+            if optimizer_ctor == Adamax:
                 continue
             params = [torch.ones(2 ** 32, device="cuda", dtype=torch.float16)]
             params[0].grad = torch.zeros_like(params[0])
@@ -987,7 +988,7 @@ class TestOptim(TestCase):
     @property
     def _fused_optimizer_configs(self):
         return tuple(itertools.product(
-            (optim.Adam, optim.AdamW),
+            (Adam, AdamW),
             (
                 dict(weight_decay=1., lr=torch.tensor(0.001), amsgrad=False, capturable=True, maximize=True),
                 dict(weight_decay=1., amsgrad=False, capturable=True, maximize=True),
@@ -1018,14 +1019,14 @@ class TestOptim(TestCase):
 
     def test_adam(self):
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adam(
+            lambda weight, bias, maximize, foreach: Adam(
                 [weight, bias], lr=1e-3, maximize=maximize, foreach=foreach
             ),
             constructor_accepts_maximize=True,
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adam(
+            lambda weight, bias, maximize, foreach: Adam(
                 self._build_params_dict(weight, bias, lr=1e-2),
                 lr=1e-3,
                 maximize=maximize,
@@ -1035,7 +1036,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adam(
+            lambda weight, bias, maximize, foreach: Adam(
                 [weight, bias],
                 lr=1e-3,
                 amsgrad=True,
@@ -1046,7 +1047,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adam(
+            lambda weight, bias, maximize, foreach: Adam(
                 [weight, bias],
                 lr=1e-3,
                 weight_decay=0.1,
@@ -1057,7 +1058,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adam(
+            lambda weight, bias, maximize, foreach: Adam(
                 self._build_params_dict(weight, bias, lr=1e-2),
                 lr=1e-3,
                 amsgrad=True,
@@ -1068,7 +1069,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adam(
+            lambda weight, bias, maximize, foreach: Adam(
                 self._build_params_dict(weight, bias, lr=1e-2),
                 lr=1e-3,
                 maximize=maximize,
@@ -1079,7 +1080,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adam(
+            lambda weight, bias, maximize, foreach: Adam(
                 self._build_params_dict(weight, bias, lr=1e-2),
                 lr=1e-3,
                 maximize=maximize,
@@ -1090,7 +1091,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adam(
+            lambda weight, bias, maximize, foreach: Adam(
                 self._build_params_dict(weight, bias, lr=1e-2),
                 lr=1e-3,
                 maximize=maximize,
@@ -1101,7 +1102,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adam(
+            lambda weight, bias, maximize, foreach: Adam(
                 [weight, bias],
                 lr=1e-3,
                 amsgrad=True,
@@ -1116,7 +1117,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adam(
+            lambda weight, bias, maximize, foreach: Adam(
                 [weight, bias],
                 lr=1e-3,
                 amsgrad=True,
@@ -1131,7 +1132,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adam(
+            lambda weight, bias, maximize, foreach: Adam(
                 self._build_params_dict(weight, bias, lr=1e-2),
                 lr=1e-3,
                 amsgrad=True,
@@ -1147,7 +1148,7 @@ class TestOptim(TestCase):
         )
 
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adam(
+            lambda weight, bias, maximize, foreach: Adam(
                 self._build_params_dict(weight, bias, lr=1e-2),
                 lr=1e-3,
                 maximize=maximize,
@@ -1158,7 +1159,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adam(
+            lambda weight, bias, maximize, foreach: Adam(
                 self._build_params_dict(weight, bias, lr=1e-2),
                 lr=torch.tensor(1e-3),
                 maximize=maximize,
@@ -1172,37 +1173,37 @@ class TestOptim(TestCase):
         with self.assertRaisesRegex(
             ValueError, "Invalid beta parameter at index 0: 1.0"
         ):
-            optim.Adam(None, lr=1e-2, betas=(1.0, 0.0))
+            Adam(None, lr=1e-2, betas=(1.0, 0.0))
 
         with self.assertRaisesRegex(ValueError, "Invalid weight_decay value: -1"):
-            optim.Adam(None, lr=1e-2, weight_decay=-1)
+            Adam(None, lr=1e-2, weight_decay=-1)
 
         with self.assertRaisesRegex(
             ValueError, "lr as a Tensor is not supported for capturable=False and foreach=True"
         ):
-            optim.Adam(None, lr=torch.tensor(0.001), foreach=True)
+            Adam(None, lr=torch.tensor(0.001), foreach=True)
 
     def test_adam_complex(self):
         for foreach in (False, True):
-            self._test_complex_2d(functools.partial(optim.Adam, foreach=foreach))
-            self._test_complex_2d(functools.partial(optim.Adam, foreach=foreach, amsgrad=True))
-            self._test_complex_2d(functools.partial(optim.Adam, foreach=foreach, weight_decay=0.2))
-            self._test_complex_2d(functools.partial(optim.Adam, foreach=foreach, weight_decay=0.2, amsgrad=True))
-        self._test_complex_2d(optim.Adam)
+            self._test_complex_2d(functools.partial(Adam, foreach=foreach))
+            self._test_complex_2d(functools.partial(Adam, foreach=foreach, amsgrad=True))
+            self._test_complex_2d(functools.partial(Adam, foreach=foreach, weight_decay=0.2))
+            self._test_complex_2d(functools.partial(Adam, foreach=foreach, weight_decay=0.2, amsgrad=True))
+        self._test_complex_2d(Adam)
         self._test_complex_2d(functools.partial(
-            optim.Adam, lr=torch.tensor(.001), weight_decay=0.2, amsgrad=True,
+            Adam, lr=torch.tensor(.001), weight_decay=0.2, amsgrad=True,
         ))
 
     def test_adamw(self):
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.AdamW(
+            lambda weight, bias, maximize, foreach: AdamW(
                 [weight, bias], lr=1e-3, maximize=maximize, foreach=foreach
             ),
             constructor_accepts_maximize=True,
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.AdamW(
+            lambda weight, bias, maximize, foreach: AdamW(
                 self._build_params_dict(weight, bias, lr=1e-2),
                 lr=1e-3,
                 maximize=maximize,
@@ -1212,7 +1213,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.AdamW(
+            lambda weight, bias, maximize, foreach: AdamW(
                 [weight, bias],
                 lr=1e-3,
                 weight_decay=1,
@@ -1223,7 +1224,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.AdamW(
+            lambda weight, bias, maximize, foreach: AdamW(
                 [weight, bias],
                 lr=1e-3,
                 weight_decay=1,
@@ -1235,7 +1236,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.AdamW(
+            lambda weight, bias, maximize, foreach: AdamW(
                 [weight, bias],
                 lr=torch.tensor(1e-3),
                 weight_decay=1,
@@ -1247,30 +1248,30 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         with self.assertRaisesRegex(ValueError, "Invalid weight_decay value: -1"):
-            optim.AdamW(None, lr=1e-2, weight_decay=-1)
+            AdamW(None, lr=1e-2, weight_decay=-1)
 
         with self.assertRaisesRegex(
             ValueError, "lr as a Tensor is not supported for capturable=False and foreach=True"
         ):
-            optim.AdamW(None, lr=torch.tensor(0.001), foreach=True)
+            AdamW(None, lr=torch.tensor(0.001), foreach=True)
 
     def test_adamw_complex(self):
-        self._test_complex_2d(optim.AdamW)
+        self._test_complex_2d(AdamW)
         self._test_complex_2d(functools.partial(
-            optim.AdamW, lr=torch.tensor(.001), weight_decay=0.2, amsgrad=True,
+            AdamW, lr=torch.tensor(.001), weight_decay=0.2, amsgrad=True,
         ))
         for foreach in (False, True):
-            self._test_complex_2d(functools.partial(optim.AdamW, foreach=foreach))
-            self._test_complex_2d(functools.partial(optim.AdamW, foreach=foreach, amsgrad=True))
-            self._test_complex_2d(functools.partial(optim.AdamW, foreach=foreach, weight_decay=0.2))
-            self._test_complex_2d(functools.partial(optim.AdamW, foreach=foreach, weight_decay=0.2, amsgrad=True))
+            self._test_complex_2d(functools.partial(AdamW, foreach=foreach))
+            self._test_complex_2d(functools.partial(AdamW, foreach=foreach, amsgrad=True))
+            self._test_complex_2d(functools.partial(AdamW, foreach=foreach, weight_decay=0.2))
+            self._test_complex_2d(functools.partial(AdamW, foreach=foreach, weight_decay=0.2, amsgrad=True))
 
     def test_sparse_adam(self):
         self._test_rosenbrock_sparse(
-            lambda params: optim.SparseAdam(params, lr=4e-2), [], True
+            lambda params: SparseAdam(params, lr=4e-2), [], True
         )
         self._test_rosenbrock_sparse(
-            lambda params: optim.SparseAdam(params, lr=4e-2, maximize=True),
+            lambda params: SparseAdam(params, lr=4e-2, maximize=True),
             scheduler_constructors=[],
             sparse_only=True,
             maximize=True,
@@ -1278,29 +1279,29 @@ class TestOptim(TestCase):
         with self.assertRaisesRegex(
             ValueError, "Invalid beta parameter at index 0: 1.0"
         ):
-            optim.SparseAdam(None, lr=1e-2, betas=(1.0, 0.0))
+            SparseAdam(None, lr=1e-2, betas=(1.0, 0.0))
         with self.assertRaisesRegex(
             ValueError, "SparseAdam requires dense parameter tensors"
         ):
-            optim.SparseAdam([torch.zeros(3, layout=torch.sparse_coo)])
+            SparseAdam([torch.zeros(3, layout=torch.sparse_coo)])
         with self.assertRaisesRegex(
             ValueError, "SparseAdam requires dense parameter tensors"
         ):
-            optim.SparseAdam([{"params": [torch.zeros(3, layout=torch.sparse_coo)]}])
+            SparseAdam([{"params": [torch.zeros(3, layout=torch.sparse_coo)]}])
 
     # ROCm precision is too low to pass this test
     def test_adadelta(self):
         # Handles https://github.com/pytorch/pytorch/issues/69698
         self.rel_tol = 4e-3
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adadelta(
+            lambda weight, bias, maximize, foreach: Adadelta(
                 [weight, bias], maximize=maximize, foreach=foreach
             ),
             constructor_accepts_maximize=True,
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adadelta(
+            lambda weight, bias, maximize, foreach: Adadelta(
                 self._build_params_dict(weight, bias, rho=0.95),
                 maximize=maximize,
                 foreach=foreach,
@@ -1309,7 +1310,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adadelta(
+            lambda weight, bias, maximize, foreach: Adadelta(
                 self._build_params_dict(weight, bias, rho=0.95),
                 maximize=maximize,
                 foreach=foreach,
@@ -1322,40 +1323,40 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adadelta(
+            lambda weight, bias, maximize, foreach: Adadelta(
                 [weight, bias], weight_decay=1, maximize=maximize, foreach=foreach
             ),
             constructor_accepts_maximize=True,
             constructor_accepts_foreach=True,
         )
         with self.assertRaisesRegex(ValueError, "Invalid rho value: 1.1"):
-            optim.Adadelta(None, lr=1e-2, rho=1.1)
+            Adadelta(None, lr=1e-2, rho=1.1)
 
     def test_adadelta_complex(self):
         # Handles https://github.com/pytorch/pytorch/issues/110606
         self.rel_tol = 2e-2
         for foreach in (False, True):
-            self._test_complex_optimizer(lambda weight: optim.Adadelta([weight], foreach=foreach))
-            self._test_complex_optimizer(lambda weight: optim.Adadelta([weight], rho=0.95, foreach=foreach))
+            self._test_complex_optimizer(lambda weight: Adadelta([weight], foreach=foreach))
+            self._test_complex_optimizer(lambda weight: Adadelta([weight], rho=0.95, foreach=foreach))
             self._test_complex_optimizer(
-                lambda weight: optim.Adadelta([weight], rho=0.95, weight_decay=1, foreach=foreach)
+                lambda weight: Adadelta([weight], rho=0.95, weight_decay=1, foreach=foreach)
             )
 
     def test_nadam(self):
         self._test_basic_cases(
-            lambda weight, bias, foreach: optim.NAdam(
+            lambda weight, bias, foreach: NAdam(
                 self._build_params_dict(weight, bias, lr=1e-2), lr=1e-3, foreach=foreach
             ),
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, foreach: optim.NAdam(
+            lambda weight, bias, foreach: NAdam(
                 [weight, bias], lr=1e-3, foreach=foreach
             ),
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, foreach: optim.NAdam(
+            lambda weight, bias, foreach: NAdam(
                 [weight, bias],
                 lr=1e-3,
                 weight_decay=0.1,
@@ -1365,7 +1366,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, foreach: optim.NAdam(
+            lambda weight, bias, foreach: NAdam(
                 [weight, bias],
                 lr=1e-3,
                 weight_decay=0.1,
@@ -1377,7 +1378,7 @@ class TestOptim(TestCase):
         )
         # NAdamW tests
         self._test_basic_cases(
-            lambda weight, bias, foreach: optim.NAdam(
+            lambda weight, bias, foreach: NAdam(
                 [weight, bias],
                 lr=1e-3,
                 weight_decay=0.1,
@@ -1388,7 +1389,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, foreach: optim.NAdam(
+            lambda weight, bias, foreach: NAdam(
                 [weight, bias],
                 lr=1e-3,
                 weight_decay=0.1,
@@ -1402,17 +1403,17 @@ class TestOptim(TestCase):
         with self.assertRaisesRegex(
             ValueError, "Invalid beta parameter at index 0: 1.0"
         ):
-            optim.NAdam(None, lr=1e-2, betas=(1.0, 0.0))
+            NAdam(None, lr=1e-2, betas=(1.0, 0.0))
         with self.assertRaisesRegex(ValueError, "Invalid momentum_decay value: -0.2"):
-            optim.NAdam(None, lr=1e-2, momentum_decay=-0.2)
+            NAdam(None, lr=1e-2, momentum_decay=-0.2)
 
     def test_nadam_complex(self):
         for foreach in (False, True):
             self._test_complex_optimizer(
-                lambda param: optim.NAdam([param], lr=1e-1, foreach=foreach)
+                lambda param: NAdam([param], lr=1e-1, foreach=foreach)
             )
             self._test_complex_optimizer(
-                lambda param: optim.NAdam(
+                lambda param: NAdam(
                     [param],
                     lr=1e-1,
                     weight_decay=0.01,
@@ -1420,7 +1421,7 @@ class TestOptim(TestCase):
                 )
             )
             self._test_complex_optimizer(
-                lambda param: optim.NAdam(
+                lambda param: NAdam(
                     [param],
                     lr=1e-1,
                     momentum_decay=0.01,
@@ -1430,14 +1431,14 @@ class TestOptim(TestCase):
 
     def test_adagrad(self):
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adagrad(
+            lambda weight, bias, maximize, foreach: Adagrad(
                 [weight, bias], lr=1e-1, maximize=maximize, foreach=foreach
             ),
             constructor_accepts_maximize=True,
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adagrad(
+            lambda weight, bias, maximize, foreach: Adagrad(
                 [weight, bias],
                 lr=1e-1,
                 initial_accumulator_value=0.1,
@@ -1448,7 +1449,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adagrad(
+            lambda weight, bias, maximize, foreach: Adagrad(
                 self._build_params_dict(weight, bias, lr=1e-2),
                 lr=1e-1,
                 maximize=maximize,
@@ -1458,7 +1459,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adagrad(
+            lambda weight, bias, maximize, foreach: Adagrad(
                 self._build_params_dict(weight, bias, lr=1e-2),
                 lr=1e-1,
                 maximize=maximize,
@@ -1469,7 +1470,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adagrad(
+            lambda weight, bias, maximize, foreach: Adagrad(
                 self._build_params_dict(weight, bias, lr=1e-2),
                 lr=1e-1,
                 maximize=maximize,
@@ -1483,16 +1484,16 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         with self.assertRaisesRegex(ValueError, "Invalid lr_decay value: -0.5"):
-            optim.Adagrad(None, lr=1e-2, lr_decay=-0.5)
+            Adagrad(None, lr=1e-2, lr_decay=-0.5)
 
     def test_adagrad_sparse(self):
         for foreach in (False, True):
             self._test_rosenbrock_sparse(
-                lambda params: optim.Adagrad(params, lr=1e-1, foreach=foreach),
+                lambda params: Adagrad(params, lr=1e-1, foreach=foreach),
                 multi_tensor=foreach,
             )
             self._test_rosenbrock_sparse(
-                lambda params: optim.Adagrad(params, lr=0.1, foreach=foreach),
+                lambda params: Adagrad(params, lr=0.1, foreach=foreach),
                 scheduler_constructors=[
                     lambda opt: StepLR(opt, gamma=1 - 1e-5, step_size=500),
                     lambda opt: ReduceLROnPlateau(opt, threshold=1e-4),
@@ -1503,10 +1504,10 @@ class TestOptim(TestCase):
     def test_adagrad_complex(self):
         for foreach in (False, True):
             self._test_complex_optimizer(
-                lambda param: optim.Adagrad([param], lr=1e-1, foreach=foreach)
+                lambda param: Adagrad([param], lr=1e-1, foreach=foreach)
             )
             self._test_complex_optimizer(
-                lambda param: optim.Adagrad(
+                lambda param: Adagrad(
                     [param],
                     lr=1e-1,
                     initial_accumulator_value=0.1,
@@ -1516,14 +1517,14 @@ class TestOptim(TestCase):
 
     def test_adamax(self):
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adamax(
+            lambda weight, bias, maximize, foreach: Adamax(
                 [weight, bias], lr=1e-1, maximize=maximize, foreach=foreach
             ),
             constructor_accepts_maximize=True,
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adamax(
+            lambda weight, bias, maximize, foreach: Adamax(
                 self._build_params_dict(weight, bias, lr=1e-2),
                 lr=1e-1,
                 maximize=maximize,
@@ -1533,7 +1534,7 @@ class TestOptim(TestCase):
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, maximize, foreach: optim.Adamax(
+            lambda weight, bias, maximize, foreach: Adamax(
                 [weight, bias],
                 lr=1e-1,
                 weight_decay=1,
@@ -1543,34 +1544,34 @@ class TestOptim(TestCase):
             constructor_accepts_maximize=True,
             constructor_accepts_foreach=True,
         )
-        self._test_complex_2d(optim.Adamax)
-        self._test_complex_2d(functools.partial(optim.Adamax, foreach=True))
+        self._test_complex_2d(Adamax)
+        self._test_complex_2d(functools.partial(Adamax, foreach=True))
         with self.assertRaisesRegex(
             ValueError, "Invalid beta parameter at index 1: 1.0"
         ):
-            optim.Adamax(None, lr=1e-2, betas=(0.0, 1.0))
+            Adamax(None, lr=1e-2, betas=(0.0, 1.0))
 
     def test_radam(self):
         self._test_basic_cases(
-            lambda weight, bias, foreach: optim.RAdam(
+            lambda weight, bias, foreach: RAdam(
                 [weight, bias], lr=1e-3, foreach=foreach
             ),
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, foreach: optim.RAdam(
+            lambda weight, bias, foreach: RAdam(
                 self._build_params_dict(weight, bias, lr=1e-2), lr=1e-3, foreach=foreach
             ),
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, foreach: optim.RAdam(
+            lambda weight, bias, foreach: RAdam(
                 [weight, bias], lr=1e-3, weight_decay=0.1, foreach=foreach
             ),
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, foreach: optim.RAdam(
+            lambda weight, bias, foreach: RAdam(
                 [weight, bias], lr=1e-3, foreach=foreach
             ),
             [
@@ -1581,13 +1582,13 @@ class TestOptim(TestCase):
         )
         # RAdamW tests
         self._test_basic_cases(
-            lambda weight, bias, foreach: optim.RAdam(
+            lambda weight, bias, foreach: RAdam(
                 [weight, bias], lr=1e-3, weight_decay=0.1, decoupled_weight_decay=True, foreach=foreach
             ),
             constructor_accepts_foreach=True,
         )
         self._test_basic_cases(
-            lambda weight, bias, foreach: optim.RAdam(
+            lambda weight, bias, foreach: RAdam(
                 [weight, bias], lr=1e-3, weight_decay=0.1, decoupled_weight_decay=True, foreach=foreach
             ),
             [
@@ -1599,18 +1600,18 @@ class TestOptim(TestCase):
         with self.assertRaisesRegex(
             ValueError, "Invalid beta parameter at index 0: 1.0"
         ):
-            optim.RAdam(None, lr=1e-2, betas=(1.0, 0.0))
+            RAdam(None, lr=1e-2, betas=(1.0, 0.0))
 
         with self.assertRaisesRegex(ValueError, "Invalid weight_decay value: -1"):
-            optim.RAdam(None, lr=1e-2, weight_decay=-1)
+            RAdam(None, lr=1e-2, weight_decay=-1)
 
     def test_radam_complex(self):
         for foreach in (False, True):
             self._test_complex_optimizer(
-                lambda param: optim.RAdam([param], lr=1e-1, foreach=foreach)
+                lambda param: RAdam([param], lr=1e-1, foreach=foreach)
             )
             self._test_complex_optimizer(
-                lambda param: optim.RAdam(
+                lambda param: RAdam(
                     [param],
                     lr=1e-1,
                     weight_decay=0.01,
@@ -1618,7 +1619,7 @@ class TestOptim(TestCase):
                 )
             )
             self._test_complex_optimizer(
-                lambda param: optim.RAdam(
+                lambda param: RAdam(
                     [param],
                     lr=1e-1,
                     weight_decay=0.01,
@@ -1630,14 +1631,14 @@ class TestOptim(TestCase):
     def test_rmsprop(self):
         for foreach in (False, True):
             self._test_basic_cases(
-                lambda weight, bias, maximize, foreach: optim.RMSprop(
+                lambda weight, bias, maximize, foreach: RMSprop(
                     [weight, bias], lr=1e-2, maximize=maximize, foreach=foreach
                 ),
                 constructor_accepts_maximize=True,
                 constructor_accepts_foreach=True,
             )
             self._test_basic_cases(
-                lambda weight, bias, maximize, foreach: optim.RMSprop(
+                lambda weight, bias, maximize, foreach: RMSprop(
                     self._build_params_dict(weight, bias, lr=1e-3),
                     lr=1e-2,
                     maximize=maximize,
@@ -1647,7 +1648,7 @@ class TestOptim(TestCase):
                 constructor_accepts_foreach=True,
             )
             self._test_basic_cases(
-                lambda weight, bias, maximize, foreach: optim.RMSprop(
+                lambda weight, bias, maximize, foreach: RMSprop(
                     self._build_params_dict(weight, bias, lr=1e-3),
                     lr=1e-2,
                     centered=True,
@@ -1658,7 +1659,7 @@ class TestOptim(TestCase):
                 constructor_accepts_foreach=True,
             )
             self._test_basic_cases(
-                lambda weight, bias, maximize, foreach: optim.RMSprop(
+                lambda weight, bias, maximize, foreach: RMSprop(
                     self._build_params_dict(weight, bias, lr=1e-3),
                     lr=1e-2,
                     centered=True,
@@ -1670,7 +1671,7 @@ class TestOptim(TestCase):
                 constructor_accepts_foreach=True,
             )
             self._test_basic_cases(
-                lambda weight, bias, maximize, foreach: optim.RMSprop(
+                lambda weight, bias, maximize, foreach: RMSprop(
                     self._build_params_dict(weight, bias, lr=1e-3),
                     lr=1e-2,
                     momentum=0.1,
@@ -1681,7 +1682,7 @@ class TestOptim(TestCase):
                 constructor_accepts_foreach=True,
             )
             self._test_basic_cases(
-                lambda weight, bias, maximize, foreach: optim.RMSprop(
+                lambda weight, bias, maximize, foreach: RMSprop(
                     self._build_params_dict(weight, bias, lr=1e-3),
                     lr=1e-2,
                     momentum=0.1,
@@ -1692,42 +1693,42 @@ class TestOptim(TestCase):
                 constructor_accepts_maximize=True,
                 constructor_accepts_foreach=True,
             )
-            self._test_complex_2d(lambda param: optim.RMSprop(param, foreach=foreach))
+            self._test_complex_2d(lambda param: RMSprop(param, foreach=foreach))
             self._test_complex_2d(
-                lambda param: optim.RMSprop(param, centered=True, foreach=foreach)
-            )
-            self._test_complex_2d(
-                lambda param: optim.RMSprop(param, momentum=0.1, foreach=foreach)
+                lambda param: RMSprop(param, centered=True, foreach=foreach)
             )
             self._test_complex_2d(
-                lambda param: optim.RMSprop(param, maximize=True, foreach=foreach)
+                lambda param: RMSprop(param, momentum=0.1, foreach=foreach)
+            )
+            self._test_complex_2d(
+                lambda param: RMSprop(param, maximize=True, foreach=foreach)
             )
             self._test_complex_optimizer(
-                lambda param: optim.RMSprop([param], foreach=foreach)
+                lambda param: RMSprop([param], foreach=foreach)
             )
             self._test_complex_optimizer(
-                lambda param: optim.RMSprop([param], centered=True, foreach=foreach)
+                lambda param: RMSprop([param], centered=True, foreach=foreach)
             )
             self._test_complex_optimizer(
-                lambda param: optim.RMSprop([param], momentum=0.1, foreach=foreach)
+                lambda param: RMSprop([param], momentum=0.1, foreach=foreach)
             )
             self._test_complex_optimizer(
-                lambda param: optim.RMSprop([param], maximize=True, foreach=foreach)
+                lambda param: RMSprop([param], maximize=True, foreach=foreach)
             )
             with self.assertRaisesRegex(ValueError, "Invalid momentum value: -1.0"):
-                optim.RMSprop(None, lr=1e-2, momentum=-1.0, foreach=foreach)
+                RMSprop(None, lr=1e-2, momentum=-1.0, foreach=foreach)
 
     def test_asgd(self):
         for foreach in (False, True):
             self._test_basic_cases(
-                lambda weight, bias, maximize, foreach: optim.ASGD(
+                lambda weight, bias, maximize, foreach: ASGD(
                     [weight, bias], lr=1e-3, t0=100, maximize=maximize, foreach=foreach
                 ),
                 constructor_accepts_maximize=True,
                 constructor_accepts_foreach=True,
             )
             self._test_basic_cases(
-                lambda weight, bias, maximize, foreach: optim.ASGD(
+                lambda weight, bias, maximize, foreach: ASGD(
                     self._build_params_dict(weight, bias, lr=1e-2),
                     lr=1e-3,
                     t0=100,
@@ -1738,7 +1739,7 @@ class TestOptim(TestCase):
                 constructor_accepts_foreach=True,
             )
             self._test_basic_cases(
-                lambda weight, bias, maximize, foreach: optim.ASGD(
+                lambda weight, bias, maximize, foreach: ASGD(
                     self._build_params_dict(weight, bias, lr=1e-2),
                     lr=1e-3,
                     weight_decay=1,
@@ -1751,23 +1752,23 @@ class TestOptim(TestCase):
             # Ref: https://github.com/pytorch/pytorch/issues/84560
             # self._test_complex_2d(optimizer)
             self._test_complex_optimizer(
-                lambda params: optim.ASGD([params], foreach=foreach)
+                lambda params: ASGD([params], foreach=foreach)
             )
             self._test_complex_optimizer(
-                lambda params: optim.ASGD([params], maximize=True, foreach=foreach)
+                lambda params: ASGD([params], maximize=True, foreach=foreach)
             )
             self._test_complex_optimizer(
-                lambda params: optim.ASGD(
+                lambda params: ASGD(
                     [params], maximize=True, weight_decay=0.9, foreach=foreach
                 )
             )
             self._test_complex_optimizer(
-                lambda params: optim.ASGD(
+                lambda params: ASGD(
                     [params], maximize=False, weight_decay=0.9, foreach=foreach
                 )
             )
             with self.assertRaisesRegex(ValueError, "Invalid weight_decay value: -0.5"):
-                optim.ASGD(None, lr=1e-2, weight_decay=-0.5, foreach=foreach)
+                ASGD(None, lr=1e-2, weight_decay=-0.5, foreach=foreach)
 
     @skipIfRocm
     @skipIfTorchDynamo()
@@ -1777,14 +1778,14 @@ class TestOptim(TestCase):
         ) == (8, 6)
         for foreach in (False, True):
             self._test_basic_cases(
-                lambda weight, bias, maximize, foreach: optim.Rprop(
+                lambda weight, bias, maximize, foreach: Rprop(
                     [weight, bias], lr=2e-4, maximize=maximize, foreach=foreach
                 ),
                 constructor_accepts_maximize=True,
                 constructor_accepts_foreach=True,
             )
             self._test_basic_cases(
-                lambda weight, bias, maximize, foreach: optim.Rprop(
+                lambda weight, bias, maximize, foreach: Rprop(
                     self._build_params_dict(weight, bias, lr=1e-2),
                     lr=2e-4,
                     maximize=maximize,
@@ -1795,24 +1796,24 @@ class TestOptim(TestCase):
                 atol=4e-5 if is_cuda_sm86 else None,
                 rtol=3e-5 if is_cuda_sm86 else None,
             )
-            self._test_complex_2d(lambda param: optim.Rprop(param, foreach=foreach))
+            self._test_complex_2d(lambda param: Rprop(param, foreach=foreach))
             self._test_complex_optimizer(
-                lambda param: optim.Rprop([param], lr=0.001, foreach=foreach)
+                lambda param: Rprop([param], lr=0.001, foreach=foreach)
             )
             self._test_complex_optimizer(
-                lambda param: optim.Rprop(
+                lambda param: Rprop(
                     [param], lr=0.001, maximize=True, foreach=foreach
                 )
             )
             with self.assertRaisesRegex(ValueError, "Invalid eta values: 1.0, 0.5"):
-                optim.Rprop(None, lr=1e-2, etas=(1.0, 0.5), foreach=foreach)
+                Rprop(None, lr=1e-2, etas=(1.0, 0.5), foreach=foreach)
 
     def test_lbfgs(self):
         self._test_basic_cases(
-            lambda weight, bias: optim.LBFGS([weight, bias]), ignore_multidevice=True
+            lambda weight, bias: LBFGS([weight, bias]), ignore_multidevice=True
         )
         self._test_basic_cases(
-            lambda weight, bias: optim.LBFGS(
+            lambda weight, bias: LBFGS(
                 [weight, bias], line_search_fn="strong_wolfe"
             ),
             ignore_multidevice=True,
@@ -1820,8 +1821,8 @@ class TestOptim(TestCase):
 
     def test_lbfgs_returns_consistent_type(self):
         params = [torch.randn(10, 5), torch.randn(10)]
-        opt1 = optim.LBFGS(params, 0.01, tolerance_grad=math.inf)
-        opt2 = optim.LBFGS(params, 0.01, tolerance_grad=-math.inf)
+        opt1 = LBFGS(params, 0.01, tolerance_grad=math.inf)
+        opt2 = LBFGS(params, 0.01, tolerance_grad=-math.inf)
 
         def closure():
             return torch.tensor([10])
@@ -1834,20 +1835,20 @@ class TestOptim(TestCase):
         self.assertRaisesRegex(
             TypeError,
             'params argument given to the optimizer should be an iterable of Tensors or dicts',
-            lambda: optim.LBFGS(Parameter(torch.randn(5, 5)))
+            lambda: LBFGS(Parameter(torch.randn(5, 5)))
         )
 
     def test_duplicate_params_in_one_param_group(self):
         param = Parameter(torch.randn(1))
         with self.assertWarnsOnceRegex(UserWarning, '.*a parameter group with duplicate parameters.*'):
-            optim.Adamax([param, param], lr=0.01)
+            Adamax([param, param], lr=0.01)
 
     def test_duplicate_params_across_param_groups(self):
         param = Parameter(torch.randn(1))
         self.assertRaisesRegex(
             ValueError,
             'some parameters appear in more than one parameter group',
-            lambda: optim.Adadelta([{'params': param}, {'params': param}])
+            lambda: Adadelta([{'params': param}, {'params': param}])
         )
 
     def test_step_is_noop_when_params_have_no_grad(self):
@@ -1858,18 +1859,18 @@ class TestOptim(TestCase):
             return torch.tensor([1])
 
         optimizer_list = [
-            optim.Adadelta,
-            optim.AdamW,
-            optim.Adam,
-            optim.RAdam,
-            optim.NAdam,
-            optim.Adagrad,
-            optim.Adamax,
-            optim.RMSprop,
-            optim.SGD,
-            optim.SparseAdam,
-            optim.ASGD,
-            optim.LBFGS
+            Adadelta,
+            AdamW,
+            Adam,
+            RAdam,
+            NAdam,
+            Adagrad,
+            Adamax,
+            RMSprop,
+            SGD,
+            SparseAdam,
+            ASGD,
+            LBFGS
         ]
         for optim_ctr in optimizer_list:
             opt = optim_ctr(params, lr=0.1)
@@ -1879,18 +1880,18 @@ class TestOptim(TestCase):
 
     def test_step_is_noop_for_empty_grads(self):
         optimizers = [
-            optim.Adadelta,
-            optim.AdamW,
-            optim.Adam,
-            optim.RAdam,
-            optim.NAdam,
-            optim.Adagrad,
-            optim.Adamax,
-            optim.RMSprop,
-            optim.SGD,
-            optim.SparseAdam,
-            optim.ASGD,
-            optim.LBFGS
+            Adadelta,
+            AdamW,
+            Adam,
+            RAdam,
+            NAdam,
+            Adagrad,
+            Adamax,
+            RMSprop,
+            SGD,
+            SparseAdam,
+            ASGD,
+            LBFGS
         ]
         param = torch.randn(5, 1, requires_grad=True)
         old_param = param.clone().detach()
@@ -1901,7 +1902,7 @@ class TestOptim(TestCase):
         for optimizer in optimizers:
             opt = optimizer([param], lr=1e-5)
             param.grad = torch.zeros_like(param)
-            if optimizer is optim.SparseAdam:
+            if optimizer is SparseAdam:
                 # Intentionally construct a multidimensional empty v for the sparse grad
                 # Single dim v passes the test while multidim correctly repros the issue
                 # https://github.com/pytorch/pytorch/issues/82486
@@ -1966,7 +1967,7 @@ class TestOptim(TestCase):
         # store checkpoints on CPU as CUDA memory is limited with torch.load(...map_location="cpu").
         # Since this is a unit test, it is more expedient to simulate what the state_dict
         # would look like, which is basically CPU tensors with fused/capturable flag = True.
-        for optimC, kwarg in itertools.product((Adam, optim.AdamW), ("fused", "capturable")):
+        for optimC, kwarg in itertools.product((Adam, AdamW), ("fused", "capturable")):
             input = torch.tensor([0.1, 0.2], dtype=torch.float32, device="cpu")
             optimizer = optimC([input])
             optimizer.zero_grad()
@@ -2084,7 +2085,7 @@ class TestOptim(TestCase):
     def test_fused_optimizer_raises(self):
         if not torch.cuda.is_available():
             self.skipTest("Requires CUDA devices")
-        for optimizer_ctor in (torch.optim.Adam, torch.optim.AdamW):
+        for optimizer_ctor in (Adam, AdamW):
             with self.assertRaisesRegex(RuntimeError, "`fused` and `foreach` cannot be `True` together."):
                 optimizer_ctor([torch.empty((), device="cuda")], foreach=True, fused=True)
             with self.assertRaisesRegex(RuntimeError, "`fused` does not support `differentiable`"):
@@ -2219,7 +2220,7 @@ class TestDifferentiableOptimizer(TestCase):
                 p,
                 grad,
                 state,
-                torch.optim.SGD,
+                SGD,
                 {"lr": 0.9, "differentiable": True},
                 *state.values(),
             ),
@@ -2245,7 +2246,7 @@ class TestDifferentiableOptimizer(TestCase):
                 p,
                 grad,
                 state,
-                torch.optim.Adam,
+                Adam,
                 {"lr": 0.9, "differentiable": True, "amsgrad": True},
                 *state.values(),
             ),
@@ -2271,7 +2272,7 @@ class TestDifferentiableOptimizer(TestCase):
                 p,
                 grad,
                 state,
-                torch.optim.RMSprop,
+                RMSprop,
                 {
                     "lr": 0.9,
                     "maximize": True,
@@ -2300,7 +2301,7 @@ class TestDifferentiableOptimizer(TestCase):
                 p,
                 grad,
                 state,
-                torch.optim.Adadelta,
+                Adadelta,
                 {"lr": 0.9, "weight_decay": 0.1, "differentiable": True},
                 *state.values(),
             ),
@@ -2321,7 +2322,7 @@ class TestDifferentiableOptimizer(TestCase):
                 p,
                 grad,
                 state,
-                torch.optim.Adagrad,
+                Adagrad,
                 {"lr": 0.9, "weight_decay": 0.1, "differentiable": True},
                 *state.values(),
             ),
@@ -2343,7 +2344,7 @@ class TestDifferentiableOptimizer(TestCase):
                 p,
                 grad,
                 state,
-                torch.optim.Adamax,
+                Adamax,
                 {"lr": 0.9, "weight_decay": 0.1, "differentiable": True},
                 *state.values(),
             ),
@@ -2369,7 +2370,7 @@ class TestDifferentiableOptimizer(TestCase):
                 p,
                 grad,
                 state,
-                torch.optim.ASGD,
+                ASGD,
                 {"lr": 0.9, "differentiable": True},
                 *state.values(),
             ),
@@ -2391,7 +2392,7 @@ class TestDifferentiableOptimizer(TestCase):
                 p,
                 grad,
                 state,
-                torch.optim.Rprop,
+                Rprop,
                 {"lr": 0.9, "differentiable": True},
                 *state.values(),
             ),
@@ -2416,7 +2417,7 @@ class TestDifferentiableOptimizer(TestCase):
                 p,
                 grad,
                 state,
-                torch.optim.AdamW,
+                AdamW,
                 {"lr": 0.9, "differentiable": True, "amsgrad": True},
                 *state.values(),
             ),
@@ -2439,7 +2440,7 @@ class TestDifferentiableOptimizer(TestCase):
                 p,
                 grad,
                 state,
-                torch.optim.NAdam,
+                NAdam,
                 {"lr": 0.9, "differentiable": True},
                 *state.values(),
             ),
@@ -2451,7 +2452,7 @@ class TestDifferentiableOptimizer(TestCase):
                 p,
                 grad,
                 state,
-                torch.optim.NAdam,
+                NAdam,
                 {"lr": 0.9, "decoupled_weight_decay": True, "differentiable": True},
                 *state.values(),
             ),
@@ -2473,7 +2474,7 @@ class TestDifferentiableOptimizer(TestCase):
                 p,
                 grad,
                 state,
-                torch.optim.RAdam,
+                RAdam,
                 {"lr": 0.9, "differentiable": True},
                 *state.values(),
             ),
@@ -2484,7 +2485,7 @@ class TestDifferentiableOptimizer(TestCase):
                 p,
                 grad,
                 state,
-                torch.optim.RAdam,
+                RAdam,
                 {"lr": 0.9, "weight_decay": 0.1, "decoupled_weight_decay": True, "differentiable": True},
                 *state.values(),
             ),
@@ -2494,17 +2495,17 @@ class TestDifferentiableOptimizer(TestCase):
     def test_defaults_changed_to_foreach(self):
         from torch.optim import (adam, adamw, nadam, sgd, radam, rmsprop, rprop,
                                  asgd, adamax, adadelta, adagrad)
-        multi_optims = ((optim.Adam, adam, "_multi_tensor_adam"),
-                        (optim.AdamW, adamw, "_multi_tensor_adamw"),
-                        (optim.NAdam, nadam, "_multi_tensor_nadam"),
-                        (optim.SGD, sgd, "_multi_tensor_sgd"),
-                        (optim.RAdam, radam, "_multi_tensor_radam"),
-                        (optim.RMSprop, rmsprop, "_multi_tensor_rmsprop"),
-                        (optim.Rprop, rprop, "_multi_tensor_rprop"),
-                        (optim.ASGD, asgd, "_multi_tensor_asgd"),
-                        (optim.Adamax, adamax, "_multi_tensor_adamax"),
-                        (optim.Adadelta, adadelta, "_multi_tensor_adadelta"),
-                        (optim.Adagrad, adagrad, "_multi_tensor_adagrad"),)
+        multi_optims = ((Adam, adam, "_multi_tensor_adam"),
+                        (AdamW, adamw, "_multi_tensor_adamw"),
+                        (NAdam, nadam, "_multi_tensor_nadam"),
+                        (SGD, sgd, "_multi_tensor_sgd"),
+                        (RAdam, radam, "_multi_tensor_radam"),
+                        (RMSprop, rmsprop, "_multi_tensor_rmsprop"),
+                        (Rprop, rprop, "_multi_tensor_rprop"),
+                        (ASGD, asgd, "_multi_tensor_asgd"),
+                        (Adamax, adamax, "_multi_tensor_adamax"),
+                        (Adadelta, adadelta, "_multi_tensor_adadelta"),
+                        (Adagrad, adagrad, "_multi_tensor_adagrad"),)
 
         model = torch.nn.Linear(5, 5)
         model.to(dtype=torch.float64, device="cuda")
@@ -2512,7 +2513,7 @@ class TestDifferentiableOptimizer(TestCase):
 
         for opt, mod, func in multi_optims:
             defaults = {}
-            if opt == optim.SGD:
+            if opt == SGD:
                 defaults["lr"] = 1e-2
             optimizer = opt(model.parameters(), **defaults)
             optimizer.zero_grad()


### PR DESCRIPTION
This is purely a cosmetic change to set up for my optimizer infos, which will benefit from not needing to type optim.SparseAdam or whatever.

The next step is actually adding the OptimizerInfos, similar to my attempt in https://github.com/pytorch/pytorch/pull/102774/files

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #113971

