### PR TITLE
Disallow fp8 type promotion

### DIFF
--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -16,6 +16,7 @@
 #include <c10/util/quint4x2.h>
 #include <c10/util/quint8.h>
 
+#include <array>
 #include <complex>
 #include <cstdint>
 #include <ostream>
@@ -563,20 +564,17 @@ static inline ScalarType promoteTypes(ScalarType a, ScalarType b) {
   constexpr auto c8 = ScalarType::ComplexDouble;
   constexpr auto b1 = ScalarType::Bool;
   constexpr auto bf = ScalarType::BFloat16;
-  constexpr auto b8 = ScalarType::Float8_e5m2;
-  constexpr auto h8 = ScalarType::Float8_e4m3fn;
-  constexpr auto a8 = ScalarType::Float8_e5m2fnuz;
-  constexpr auto d8 = ScalarType::Float8_e4m3fnuz;
   constexpr auto ud = ScalarType::Undefined;
   if (a == ud || b == ud) {
     return ScalarType::Undefined;
   }
 
-  // For QInt types, we only allow exact match
-  if (isQIntType(a) && a == b) {
+  // If the two types are equal, return that type
+  if (a == b) {
     return a;
   }
 
+  // Handle identically equal types
   if (isQIntType(a) || isQIntType(b)) {
     TORCH_CHECK(
         false,
@@ -586,61 +584,81 @@ static inline ScalarType promoteTypes(ScalarType a, ScalarType b) {
         toString(b));
   }
 
-  if (isBitsType(a) && a == b) {
-    return a;
-  } else if (isBitsType(a) || isBitsType(b)) {
+  if (isBitsType(a) || isBitsType(b)) {
     return ScalarType::Undefined;
   }
 
-  // Bits and Quantized are 7 dtypes already handled and not included
-  // in the promotion table below. Therefore every dtype above them
-  // needs to be shifted down to account for that.
-  static constexpr int shift_distance =
-      static_cast<int>(ScalarType::Float8_e5m2) -
-      static_cast<int>(ScalarType::QUInt4x2);
-  static constexpr int shift_threshold = static_cast<int>(ScalarType::Bits16);
-
-  if (static_cast<int>(a) > shift_threshold) {
-    a = static_cast<ScalarType>(static_cast<int>(a) - shift_distance);
+  if (isFloat8Type(a) || isFloat8Type(b)) {
+    TORCH_CHECK(
+        false,
+        "Promotion for Float8 Types is not supported, attempted to promote ",
+        toString(a),
+        " and ",
+        toString(b));
   }
 
-  if (static_cast<int>(b) > shift_threshold) {
-    b = static_cast<ScalarType>(static_cast<int>(b) - shift_distance);
-  }
+  // Bits, Quantized and Float8 are 14 dtypes already handled and not included
+  // in the promotion table below.
+  static constexpr int num_bits_types = static_cast<int>(ScalarType::Bits16) -
+      static_cast<int>(ScalarType::Bits1x8) + 1;
 
-  // For the same reason the size of promotion table is decreased by 7
-  // comparing to the number of all dtypes.
+  static constexpr int num_float8_types =
+      static_cast<int>(ScalarType::Float8_e4m3fnuz) -
+      static_cast<int>(ScalarType::Float8_e5m2) + 1;
+
+  static constexpr int num_qint_types = static_cast<int>(ScalarType::QInt32) -
+      static_cast<int>(ScalarType::QInt8) + 1;
+
+  static constexpr int num_quint_types =
+      static_cast<int>(ScalarType::QUInt2x4) -
+      static_cast<int>(ScalarType::QUInt4x2) + 1;
+
+  static constexpr int num_quantized_types = num_qint_types + num_quint_types;
+
+  static constexpr int num_missing_types =
+      num_bits_types + num_float8_types + num_quantized_types;
+
+  // Bfloat16 is at position 15 in the ScalerType enum, There are three types
+  // below bf16 not included in the table, Qint8, QUInt8, QInt32. Every other
+  // type above bf16, i.e. {Bits, Quantized, Float8} are not included in the
+  // table.
+
+  // If either of the types is bf16, we need to shift the type down by the one
+  // missing section in the table that is less then bf16 i.e {QInt8, QUInt8,
+  // QInt32}
+  a = a == bf ? static_cast<ScalarType>(static_cast<int>(a) - num_qint_types)
+              : a;
+  b = b == bf ? static_cast<ScalarType>(static_cast<int>(b) - num_qint_types)
+              : b;
+
+  // We decrease the promotion table by the number of missing types -> 14
+  // and then subtract 1 more from the table since we don't store ud to ud
+  // mapping.
   static constexpr int NUM_PROMOTE_TYPES =
-      static_cast<int>(ScalarType::NumOptions) - shift_distance;
+      static_cast<int>(ScalarType::NumOptions) - num_missing_types - 1;
 
   // this matrix has to be consistent with
   // AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS undefined is used where we
   // are not sure about the correct value for type promotion.
   // clang-format off
-  static constexpr ScalarType _promoteTypesLookup[
-      NUM_PROMOTE_TYPES][NUM_PROMOTE_TYPES] = {
-      /*        u1  i1  i2  i4  i8  f2  f4  f8  c2  c4  c8  b1  q1  q2  q3  bf  b8  h8  a8  d8*/
-      /* u1 */ {u1, i2, i2, i4, i8, f2, f4, f8, c2, c4, c8, u1, ud, ud, ud, bf, b8, h8, a8, d8},
-      /* i1 */ {i2, i1, i2, i4, i8, f2, f4, f8, c2, c4, c8, i1, ud, ud, ud, bf, b8, h8, a8, d8},
-      /* i2 */ {i2, i2, i2, i4, i8, f2, f4, f8, c2, c4, c8, i2, ud, ud, ud, bf, b8, h8, a8, d8},
-      /* i4 */ {i4, i4, i4, i4, i8, f2, f4, f8, c2, c4, c8, i4, ud, ud, ud, bf, b8, h8, a8, d8},
-      /* i8 */ {i8, i8, i8, i8, i8, f2, f4, f8, c2, c4, c8, i8, ud, ud, ud, bf, b8, h8, a8, d8},
-      /* f2 */ {f2, f2, f2, f2, f2, f2, f4, f8, c2, c4, c8, f2, ud, ud, ud, f4, f4, f4, f4, f4},
-      /* f4 */ {f4, f4, f4, f4, f4, f4, f4, f8, c4, c4, c8, f4, ud, ud, ud, f4, f4, f4, f4, f4},
-      /* f8 */ {f8, f8, f8, f8, f8, f8, f8, f8, c8, c8, c8, f8, ud, ud, ud, f8, f8, f8, f8, f8},
-      /* c2 */ {c2, c2, c2, c2, c2, c2, c4, c8, c2, c4, c8, c2, ud, ud, ud, c4, c4, c4, c4, c4},
-      /* c4 */ {c4, c4, c4, c4, c4, c4, c4, c8, c4, c4, c8, c4, ud, ud, ud, c4, c4, c4, c4, c4},
-      /* c8 */ {c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, ud, ud, ud, c8, c8, c8, c8, c8},
-      /* b1 */ {u1, i1, i2, i4, i8, f2, f4, f8, c2, c4, c8, b1, ud, ud, ud, bf, b8, h8, a8, d8},
-      /* q1 */ {ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud},
-      /* q2 */ {ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud},
-      /* q3 */ {ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud},
-      /* bf */ {bf, bf, bf, bf, bf, f4, f4, f8, c4, c4, c8, bf, ud, ud, ud, bf, bf, bf, bf, bf},
-      /* b8 */ {b8, b8, b8, b8, b8, f4, f4, f8, c4, c4, c8, b8, ud, ud, ud, bf, b8, ud, a8, ud},
-      /* h8 */ {h8, h8, h8, h8, h8, f4, f4, f8, c4, c4, c8, h8, ud, ud, ud, bf, ud, h8, ud, d8},
-      /* a8 */ {a8, a8, a8, a8, a8, f4, f4, f8, c4, c4, c8, a8, ud, ud, ud, bf, a8, ud, a8, ud},
-      /* d8 */ {d8, d8, d8, d8, d8, f4, f4, f8, c4, c4, c8, d8, ud, ud, ud, bf, ud, d8, ud, d8},
-  };
+  static constexpr std::
+  array<std::array<ScalarType, NUM_PROMOTE_TYPES>, NUM_PROMOTE_TYPES>
+      _promoteTypesLookup = {{
+      /*        u1  i1  i2  i4  i8  f2  f4  f8  c2  c4  c8  b1  bf*/
+      /* u1 */ {u1, i2, i2, i4, i8, f2, f4, f8, c2, c4, c8, u1, bf},
+      /* i1 */ {i2, i1, i2, i4, i8, f2, f4, f8, c2, c4, c8, i1, bf},
+      /* i2 */ {i2, i2, i2, i4, i8, f2, f4, f8, c2, c4, c8, i2, bf},
+      /* i4 */ {i4, i4, i4, i4, i8, f2, f4, f8, c2, c4, c8, i4, bf},
+      /* i8 */ {i8, i8, i8, i8, i8, f2, f4, f8, c2, c4, c8, i8, bf},
+      /* f2 */ {f2, f2, f2, f2, f2, f2, f4, f8, c2, c4, c8, f2, f4},
+      /* f4 */ {f4, f4, f4, f4, f4, f4, f4, f8, c4, c4, c8, f4, f4},
+      /* f8 */ {f8, f8, f8, f8, f8, f8, f8, f8, c8, c8, c8, f8, f8},
+      /* c2 */ {c2, c2, c2, c2, c2, c2, c4, c8, c2, c4, c8, c2, c4},
+      /* c4 */ {c4, c4, c4, c4, c4, c4, c4, c8, c4, c4, c8, c4, c4},
+      /* c8 */ {c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8},
+      /* b1 */ {u1, i1, i2, i4, i8, f2, f4, f8, c2, c4, c8, b1, bf},
+      /* bf */ {bf, bf, bf, bf, bf, f4, f4, f8, c4, c4, c8, bf, bf},
+  }};
   // clang-format on
   return _promoteTypesLookup[static_cast<int>(a)][static_cast<int>(b)];
 }

--- a/test/quantization/core/experimental/test_float8.py
+++ b/test/quantization/core/experimental/test_float8.py
@@ -242,6 +242,23 @@ class TestFloat8Dtype(TestCase):
         for number in SPECIAL_NUMBERS[dtype]:
             compare_binary_with_decimal(*number, dtype, device)
 
+    @dtypes(*FLOAT8_DTYPES)
+    @dtypesIfCUDA(*CUDA_FLOAT8_DTYPES)
+    def test_type_promotion_fails(self, dtype, device):
+        """Test that float8 is not promoted to higher precision Float Type."""
+        for other_dtype in [
+            torch.float16,
+            torch.bfloat16,
+            torch.float32,
+            torch.float64,
+        ]:
+            x = torch.randn(8, device=device).to(dtype)
+            y = torch.randn(8, device=device).to(other_dtype)
+            with self.assertRaisesRegex(
+                RuntimeError, "Promotion for Float8 Types is not supported"
+            ):
+                x + y
+
 
 instantiate_device_type_tests(TestFloat8Dtype, globals())
 

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -678,8 +678,10 @@ class TestTypePromotion(TestCase):
         self.assertEqual(torch.promote_types(torch.float, torch.int), torch.float)
         self.assertEqual(torch.promote_types(torch.float, torch.double), torch.double)
         self.assertEqual(torch.promote_types(torch.int, torch.uint8), torch.int)
-        self.assertEqual(torch.promote_types(torch.float8_e5m2, torch.float), torch.float)
-        self.assertEqual(torch.promote_types(torch.float, torch.float8_e4m3fn), torch.float)
+        with self.assertRaisesRegex(RuntimeError, "Promotion for Float8 Types is not supported"):
+            self.assertEqual(torch.promote_types(torch.float8_e5m2, torch.float), torch.float)
+        with self.assertRaisesRegex(RuntimeError, "Promotion for Float8 Types is not supported"):
+            self.assertEqual(torch.promote_types(torch.float, torch.float8_e4m3fn), torch.float)
 
     @float_double_default_dtype
     def test_promote_self(self, device):


### PR DESCRIPTION
Fixes #113663

As well as updating the promotion logic to disallow automatic type promotion between fp8 types this PR also cleans up the table entries.
