### PR TITLE
Add more info to error message of split

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1225,7 +1225,7 @@ def split_with_sizes(
     torch._check_with(
         ValueError,
         sum(split_sizes) == self.shape[dim],
-        lambda: "Split sizes don't add up to the tensor's size in the given dimension",
+        lambda: f"Split sizes add up to {sum(split_sizes)} but got the tensor's size of {self.shape[dim]}",
     )
     num_splits = len(split_sizes)
     splits = []


### PR DESCRIPTION
Summary: Add sum up size and tensor's size to the error message when splitting tensor, which will help to determine the supposed size.

Test Plan:
## Test Cpmmand:
```
buck2 run mode/opt //ai_codesign/nonprod/lydialyu/draft_repo:infer_shape
```

## Result:
P878847769

Differential Revision: D51435146


