### PR TITLE
FSDP + DTensor state dict fix to support mix torch.Tensor and DTensor

### DIFF
--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -301,7 +301,9 @@ def _unflatten_communicated_optim_state(
             optim_state: Union[torch.Tensor, ShardedTensor, DTensor] = next(views)
             if shard_state:
                 osd_config = fsdp_state._optim_state_dict_config
-                if getattr(osd_config, "_use_dtensor", False):
+                if getattr(osd_config, "_use_dtensor", False) and hasattr(
+                    fsdp_state, "_device_mesh"
+                ):
                     assert fsdp_state._device_mesh is not None
                     optim_state = _ext_chunk_dtensor(
                         optim_state,
@@ -1467,7 +1469,9 @@ def _unflatten_orig_param_states(
 
         if shard_state:
             osd_config = fsdp_state._optim_state_dict_config
-            if getattr(osd_config, "_use_dtensor", False):
+            if getattr(osd_config, "_use_dtensor", False) and hasattr(
+                fsdp_state, "_device_mesh"
+            ):
                 assert fsdp_state._device_mesh is not None
                 value = _ext_chunk_dtensor(
                     value,

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -551,7 +551,9 @@ def _sharded_post_state_dict_hook(
 
     def param_hook(state_dict: Dict[str, Any], prefix: str, fqn: str):
         param = state_dict[fqn]
-        if not fsdp_state._state_dict_config._use_dtensor:
+        if (not fsdp_state._state_dict_config._use_dtensor) or (
+            not hasattr(fsdp_state, "_device_mesh")
+        ):
             sharded_tensor = _ext_chunk_tensor(
                 tensor=param,
                 rank=fsdp_state.rank,
@@ -627,7 +629,9 @@ def _sharded_pre_load_state_dict_hook(
             continue  # TODO: Improve unittesting for state_dict finetuning
             # cases: https://github.com/pytorch/pytorch/issues/109134
 
-        if not fsdp_state._state_dict_config._use_dtensor:
+        if not fsdp_state._state_dict_config._use_dtensor or (
+            not hasattr(fsdp_state, "_device_mesh")
+        ):
             # All-gather the param (ShardedTensor)
             param, shards = _ext_pre_load_state_dict_transform(
                 param, fsdp_state._fsdp_extension


### PR DESCRIPTION
Summary:
This is a fix to make sure that the attribute `_device_mesh` always exists before calling it.

When using together with `FSDP.state_dict_type` (i.e. during checkpointing) it is possible that the FSDP module contains both torch.tensor and DTensor.

Test Plan:
**CI**
Rely on CI test result.

**Test with WHEN model**:
Checkpoint can be saved and loaded successfully.

Differential Revision: D51419762


