### PR TITLE
[AOTInductor] Add AOTInductorModelRunner

### DIFF
--- a/test/cpp/aot_inductor/test.cpp
+++ b/test/cpp/aot_inductor/test.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include <torch/csrc/inductor/aoti_model_container_runner.h>
+#include <torch/csrc/inductor/aoti_model_runner.h>
 #ifdef USE_CUDA
 #include <torch/csrc/inductor/aoti_model_container_runner_cuda.h>
 #endif
@@ -15,6 +16,7 @@
 
 namespace {
 
+template <typename RunnerT>
 void test_aoti(const std::string& device) {
   torch::NoGradGuard no_grad;
 
@@ -31,16 +33,7 @@ void test_aoti(const std::string& device) {
   const auto& ref_output_tensors =
       data_loader.attr(outputs_attr.c_str()).toTensorList().vec();
 
-  std::unique_ptr<torch::inductor::AOTIModelContainerRunner> runner;
-  if (device == "cuda") {
-    runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCuda>(
-        model_so_path.c_str());
-  } else if (device == "cpu") {
-    runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCpu>(
-        model_so_path.c_str());
-  } else {
-    testing::AssertionFailure() << "unsupported device: " << device;
-  }
+  auto runner = std::make_unique<RunnerT>(model_so_path.c_str());
   auto actual_output_tensors = runner->run(input_tensors);
   ASSERT_TRUE(torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
 }
@@ -77,8 +70,12 @@ void test_aoti_script(const std::string& device) {
 namespace torch {
 namespace inductor {
 
-TEST(AotInductorTest, BasicTestCpu) {
-  test_aoti("cpu");
+TEST(AotInductorTest, BasicModelContainerTestCpu) {
+  test_aoti<torch::inductor::AOTIModelContainerRunnerCpu>("cpu");
+}
+
+TEST(AotInductorTest, BasicModelTestCpu) {
+  test_aoti<torch::inductor::AOTIModelRunnerCpu>("cpu");
 }
 
 TEST(AotInductorTest, BasicScriptTestCpu) {
@@ -86,8 +83,8 @@ TEST(AotInductorTest, BasicScriptTestCpu) {
 }
 
 #ifdef USE_CUDA
-TEST(AotInductorTest, BasicTestCuda) {
-  test_aoti("cuda");
+TEST(AotInductorTest, BasicModelContainerTestCuda) {
+  test_aoti<torch::inductor::AOTIModelContainerRunnerCuda>("cuda");
 }
 
 TEST(AotInductorTest, BasicScriptTestCuda) {

--- a/torch/csrc/inductor/aoti_model_container_runner.cpp
+++ b/torch/csrc/inductor/aoti_model_container_runner.cpp
@@ -36,7 +36,7 @@ AOTIModelContainerRunner::~AOTIModelContainerRunner() {
 
 std::vector<at::Tensor> AOTIModelContainerRunner::run(
     std::vector<at::Tensor> inputs,
-    AOTInductorStreamHandle cuda_stream_handle,
+    AOTInductorStreamHandle stream_handle,
     AOTIProxyExecutorHandle proxy_executor_handle) {
   auto input_handles =
       torch::aot_inductor::unsafe_alloc_new_handles_from_tensors(inputs);
@@ -54,7 +54,7 @@ std::vector<at::Tensor> AOTIModelContainerRunner::run(
       input_handles.size(),
       output_handles.data(),
       output_handles.size(),
-      cuda_stream_handle,
+      stream_handle,
       proxy_executor_handle));
 
   return torch::aot_inductor::alloc_tensors_by_stealing_from_handles(

--- a/torch/csrc/inductor/aoti_model_container_runner.h
+++ b/torch/csrc/inductor/aoti_model_container_runner.h
@@ -24,7 +24,7 @@ class TORCH_API AOTIModelContainerRunner {
 
   std::vector<at::Tensor> run(
       std::vector<at::Tensor> inputs,
-      AOTInductorStreamHandle cuda_stream_handle = nullptr,
+      AOTInductorStreamHandle stream_handle = nullptr,
       AOTIProxyExecutorHandle proxy_executor_handle = nullptr);
 
   std::vector<const char*> get_call_spec();

--- a/torch/csrc/inductor/aoti_model_runner.cpp
+++ b/torch/csrc/inductor/aoti_model_runner.cpp
@@ -1,0 +1,52 @@
+#if !defined(C10_MOBILE) && !defined(ANDROID)
+#include <ATen/DynamicLibrary.h>
+
+#include <torch/csrc/inductor/aoti_model_container_runner.h>
+#include <torch/csrc/inductor/aoti_model_runner.h>
+#include <torch/csrc/inductor/aoti_torch/tensor_converter.h>
+
+namespace torch::inductor {
+
+AOTIModelRunner::AOTIModelRunner(const char* model_path) {
+  model_so_ = std::make_unique<at::DynamicLibrary>(model_path);
+  TORCH_CHECK(model_so_, "Failed to load model: ", model_path);
+  create_func_ = reinterpret_cast<decltype(create_func_)>(
+      model_so_->sym("AOTInductorModelCreate"));
+  delete_func_ = reinterpret_cast<decltype(delete_func_)>(
+      model_so_->sym("AOTInductorModelDelete"));
+  get_num_outputs_func_ = reinterpret_cast<decltype(get_num_outputs_func_)>(
+      model_so_->sym("AOTInductorModelGetNumOutputs"));
+  run_func_ = reinterpret_cast<decltype(run_func_)>(
+      model_so_->sym("AOTInductorModelRun"));
+
+  AOTI_RUNTIME_ERROR_CODE_CHECK(create_func_(&model_handle_, nullptr));
+}
+
+AOTIModelRunner::~AOTIModelRunner() {
+  AOTIRuntimeError result = delete_func_(model_handle_);
+  TORCH_CHECK(result == AOTI_RUNTIME_SUCCESS, "AOTInductorModelDelete failed");
+}
+
+std::vector<at::Tensor> AOTIModelRunner::run(
+    std::vector<at::Tensor> inputs,
+    AOTInductorStreamHandle stream_handle,
+    AOTIProxyExecutorHandle proxy_executor_handle) {
+  auto input_handles =
+      torch::aot_inductor::unsafe_alloc_new_handles_from_tensors(inputs);
+
+  // For outputs, we only allocate a vector to hold returned tensor handles,
+  // not allocating the actual output tensor storage here
+  size_t num_outputs = 0;
+  AOTI_RUNTIME_ERROR_CODE_CHECK(
+      get_num_outputs_func_(model_handle_, &num_outputs));
+  std::vector<AtenTensorHandle> output_handles(num_outputs);
+
+  AOTI_RUNTIME_ERROR_CODE_CHECK(
+      run_func_(model_handle_, input_handles.data(), output_handles.data()));
+
+  return torch::aot_inductor::alloc_tensors_by_stealing_from_handles(
+      output_handles.data(), output_handles.size());
+}
+
+} // namespace torch::inductor
+#endif

--- a/torch/csrc/inductor/aoti_model_runner.h
+++ b/torch/csrc/inductor/aoti_model_runner.h
@@ -1,0 +1,51 @@
+#if !defined(C10_MOBILE) && !defined(ANDROID)
+#pragma once
+
+#include <ATen/Tensor.h>
+#include <torch/csrc/inductor/aoti_runtime/interface.h>
+
+// Forward declare DynamicLibrary
+namespace at {
+struct DynamicLibrary;
+}
+
+namespace torch::inductor {
+
+class TORCH_API AOTIModelRunner {
+ public:
+  AOTIModelRunner() = delete;
+  AOTIModelRunner(const AOTIModelRunner& other) = delete;
+  AOTIModelRunner(AOTIModelRunner&& other) = delete;
+  AOTIModelRunner& operator=(const AOTIModelRunner& other) = delete;
+  AOTIModelRunner& operator=(AOTIModelRunner&& other) = delete;
+  ~AOTIModelRunner();
+
+  std::vector<at::Tensor> run(
+      std::vector<at::Tensor> inputs,
+      AOTInductorStreamHandle stream_handle = nullptr,
+      AOTIProxyExecutorHandle proxy_executor_handle = nullptr);
+
+  AOTIModelRunner(const char* model_path);
+
+ protected:
+  std::unique_ptr<at::DynamicLibrary> model_so_;
+  decltype(&AOTInductorModelCreate) create_func_{nullptr};
+  decltype(&AOTInductorModelDelete) delete_func_{nullptr};
+  decltype(&AOTInductorModelGetNumOutputs) get_num_outputs_func_{nullptr};
+  decltype(&AOTInductorModelRun) run_func_{nullptr};
+  AOTInductorModelHandle model_handle_ = nullptr;
+};
+
+class TORCH_API AOTIModelRunnerCpu : public AOTIModelRunner {
+ public:
+  AOTIModelRunnerCpu(const char* model_path) : AOTIModelRunner(model_path) {}
+
+  std::vector<at::Tensor> run(
+      std::vector<at::Tensor> inputs,
+      AOTIProxyExecutorHandle proxy_executor_handle = nullptr) {
+    return AOTIModelRunner::run(inputs, nullptr, proxy_executor_handle);
+  }
+};
+
+} // namespace torch::inductor
+#endif


### PR DESCRIPTION
Summary:
Add AOTIModel standalone runner (which doesn't require model container)
This diff only support and tests CPU. GPU would come later.

Test Plan: Included in commit.

Differential Revision: D51438306

