### PR TITLE
[PyTorch] AOTI: Emit CACHED_TORCH_TYPE only as needed

### DIFF
--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -234,17 +234,6 @@ AOTIRuntimeError AOTInductorModelUpdateConstantsMap(
 
 #define CACHE_TORCH_DTYPE(typename) static auto cached_torch_dtype_##typename = aoti_torch_dtype_##typename()
 
-  CACHE_TORCH_DTYPE(bfloat16);
-  CACHE_TORCH_DTYPE(float16);
-  CACHE_TORCH_DTYPE(float32);
-  CACHE_TORCH_DTYPE(float64);
-  CACHE_TORCH_DTYPE(uint8);
-  CACHE_TORCH_DTYPE(int8);
-  CACHE_TORCH_DTYPE(int16);
-  CACHE_TORCH_DTYPE(int32);
-  CACHE_TORCH_DTYPE(int64);
-  CACHE_TORCH_DTYPE(bool);
-
   static auto cached_torch_device_type_cpu = aoti_torch_device_type_cpu();
   static auto cached_torch_device_type_cuda = aoti_torch_device_type_cuda();
 } // extern "C"

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -611,6 +611,7 @@ class WrapperCodeGen(CodeGen):
             self.generate_return(output_refs)
 
         self.append_precomputed_sizes_to_prefix()
+        self.finalize_prefix()
         result.splice(self.prefix)
 
         with result.indent():
@@ -709,6 +710,9 @@ class WrapperCodeGen(CodeGen):
                 self.prefix.writeline(
                     f"{self.declare}{sym} = {self.expr_printer(expr)}{self.ending}"
                 )
+
+    def finalize_prefix(self):
+        pass
 
     def codegen_python_sizevar(self, x: Expr) -> str:
         return pexpr(V.graph.sizevars.simplify(x))
@@ -1228,6 +1232,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
         self.declared_int_array_vars = set()
         self.tmp_tensor_id = count()  # for tmp tensor local variable declarations
         self.arg_var_id = count()
+        self.used_cached_dtypes = set()
 
         from .cpp import cexpr, CppPrinter
 
@@ -1590,6 +1595,14 @@ class CppWrapperCodeGen(WrapperCodeGen):
         self.write_wrapper_decl()
         return super().generate(is_inference)
 
+    def finalize_prefix(self):
+        cached_dtypes_buffer = IndentedBuffer()
+        if config.aot_inductor.abi_compatible:
+            for dtype in self.used_cached_dtypes:
+                cached_dtypes_buffer.writeline(f"CACHE_TORCH_DTYPE({dtype});")
+        cached_dtypes_buffer.splice(self.prefix)
+        self.prefix = cached_dtypes_buffer
+
     def define_kernel(
         self, name: str, kernel: str, metadata: Optional[str] = None, cuda=False
     ):
@@ -1888,7 +1901,9 @@ class CppWrapperCodeGen(WrapperCodeGen):
 
     def codegen_dtype(self, dtype):
         if config.aot_inductor.abi_compatible:
-            return f"cached_torch_dtype_{str(dtype).split('.')[-1]}"
+            dtype_str = str(dtype).split('.')[-1]
+            self.used_cached_dtypes.add(dtype_str)
+            return f"cached_torch_dtype_{dtype_str}"
         else:
             from .cpp import DTYPE_TO_ATEN
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Avoids potential compatibility issues where a new dtype is supported by the DSO but not the binary loading it.

Differential Revision: [D51434335](https://our.internmc.facebook.com/intern/diff/D51434335/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler