### PR TITLE
[AOTI] add float support of triton

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -2006,6 +2006,7 @@ def forward(self, x_1, output_1):
             n_elements,
             dummy_None,
             dummy_empty,
+            dummy_float,
             BLOCK_SIZE: "tl.constexpr",
             RANDOM_SIZE: "tl.constexpr",
         ):
@@ -2020,6 +2021,7 @@ def forward(self, x_1, output_1):
                 n_elements,
                 None,
                 torch.empty_like(output),
+                3.1415926,
                 RANDOM_SIZE=0,
             )
             return output

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -34,6 +34,8 @@ def signature_of(arg: Union[TensorArg, SizeArg], *, size_dtype: str) -> str:
             # From triton/runtime/jit.py
             # `None` is nullptr.  Implicitly convert to *i8.
             return "*i8"
+        elif isinstance(arg.expr, float):
+            return "fp32"
         if size_dtype == "tl.int32":
             return "i32"
         elif size_dtype == "tl.int64":
@@ -72,6 +74,8 @@ def config_of(args: List[Union[TensorArg, SizeArg]]) -> instance_descriptor:
             if x.name.startswith("load_seed_offset"):
                 return False
             if x.expr is None:
+                return False
+            if isinstance(x.expr, float):
                 return False
             return V.graph.sizevars.statically_known_multiple_of(x.expr, alignment)
         raise NotImplementedError(f"unhandled {type(x)}: {x}")


### PR DESCRIPTION
Summary: As the title

Test Plan: buck2 test 'fbcode//mode/opt' fbcode//caffe2/test/dynamo:test_dynamo -- --exact 'caffe2/test/dynamo:test_dynamo - test_functions.py::DefaultsTests::test_triton_kernel_None_arg' --print-passing-details

Differential Revision: D51421325




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler