### PR TITLE
[caffe2] Add non-x86 stub definition for `libraryFor` too

### DIFF
--- a/torch/csrc/profiler/unwind/unwind.cpp
+++ b/torch/csrc/profiler/unwind/unwind.cpp
@@ -10,6 +10,12 @@ std::vector<void*> unwind() {
       "record_context_cpp is not support on non-linux non-x86_64 platforms");
 }
 
+c10::optional<std::pair<std::string, uint64_t>> libraryFor(void* addr) {
+  TORCH_CHECK(
+      false,
+      "record_context_cpp is not support on non-linux non-x86_64 platforms");
+}
+
 #ifndef FBCODE_CAFFE2
 std::vector<Frame> symbolize(const std::vector<void*>& frames) {
   TORCH_CHECK(


### PR DESCRIPTION
Summary: Fix non-x86 build errors with missing `libraryFor` symbol.

Test Plan:
```
$ buck2 build -c fbcode.arch=aarch64 fbcode//admarket/adfinder:adfinder
```

Reviewed By: malfet

Differential Revision: D51444766


