### PR TITLE
Make V.graph properly typed

### DIFF
--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -12,7 +12,17 @@ from concurrent.futures import ThreadPoolExecutor
 from ctypes import byref, c_size_t, c_void_p
 from multiprocessing.process import BaseProcess
 from multiprocessing.queues import Queue
-from typing import Any, Callable, Dict, List, Optional, Sequence, TYPE_CHECKING, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    TYPE_CHECKING,
+    Union,
+)
 
 import torch
 from torch import multiprocessing
@@ -331,8 +341,8 @@ LayoutOrBuffer = Union[ir.Layout, ir.Buffer]
 class TensorMeta:
     device: torch.device
     dtype: torch.dtype
-    sizes: List[int]
-    strides: List[int]
+    sizes: torch._prims_common.ShapeType
+    strides: torch._prims_common.StrideType
     offset: int
 
     @classmethod
@@ -390,7 +400,7 @@ class BenchmarkRequest:
         kernel_name: str,
         input_tensor_meta: Union[TensorMeta, List[TensorMeta]],
         output_tensor_meta: Union[TensorMeta, List[TensorMeta]],
-        extra_args: Dict[str, Any],
+        extra_args: Iterable[Any],
     ):
         # the kernel name defined in the module
         self.kernel_name = kernel_name
@@ -478,7 +488,7 @@ class TritonBenchmarkRequest(BenchmarkRequest):
         kernel_name: str,
         input_tensor_meta: Union[TensorMeta, List[TensorMeta]],
         output_tensor_meta: Union[TensorMeta, List[TensorMeta]],
-        extra_args: Dict[str, Any],
+        extra_args: Iterable[Any],
         module_path: str,  # the path of the module defining the triton kernel
         module_cache_key: str,
         grid: List[int],
@@ -525,7 +535,7 @@ class CUDABenchmarkRequest(BenchmarkRequest):
         kernel_name: str,
         input_tensor_meta: Union[TensorMeta, List[TensorMeta]],
         output_tensor_meta: Union[TensorMeta, List[TensorMeta]],
-        extra_args: Dict[str, Any],
+        extra_args: Iterable[Any],
         source_code: str,
     ):
         super().__init__(kernel_name, input_tensor_meta, output_tensor_meta, extra_args)

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -6,7 +6,7 @@ import inspect
 import os
 import re
 from itertools import chain, count
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import sympy
 from sympy import Expr
@@ -359,7 +359,7 @@ class WrapperCodeGen(CodeGen):
                 self.write_constant(name, hashed)
 
         self.allocated = set()
-        self.freed = set()
+        self.freed: Set[str] = set()
 
         # maps from reusing buffer to reused buffer
         self.reuses = dict()
@@ -653,7 +653,9 @@ class WrapperCodeGen(CodeGen):
             f"{self.declare}{name}_stride = {name}.{self.stride}{self.ending}"
         )
 
-    def codegen_inputs(self, code: IndentedBuffer, graph_inputs: Dict[str, ir.Buffer]):
+    def codegen_inputs(
+        self, code: IndentedBuffer, graph_inputs: Dict[str, ir.TensorBox]
+    ):
         """Assign all symbolic shapes to locals"""
 
         @functools.lru_cache(None)

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -106,6 +106,10 @@ def is_magic_method(op):
 
 
 class GraphLowering(torch.fx.Interpreter):
+    current_node: torch.fx.Node
+    scheduler: "torch._inductor.scheduler.Scheduler"
+    wrapper_code: WrapperCodeGen
+
     def symbolic_sizes_strides(self, ex: torch.Tensor):
         """
         Support dynamic shapes and dynamic strides by assigning variables
@@ -193,11 +197,11 @@ class GraphLowering(torch.fx.Interpreter):
         self.sizevars = SizeVarAllocator(shape_env)
         self.graph_inputs: Dict[str, TensorBox] = {}
         self.graph_inputs_original: Dict[str, InputBuffer] = {}
-        self.graph_outputs: Optional[List[ir.IRNode]] = None
+        self.graph_outputs: List[ir.IRNode] = []
         self.device_types: Set[str] = set()
         self.device_idxs: Set[int] = set()
         self.cuda = False
-        self.buffers: List[ir.ComputedBuffer] = []
+        self.buffers: List[ir.Buffer] = []
         self.constants: Dict[str, torch.Tensor] = {}
         self.constant_reprs: Dict[str, str] = {}
         self.removed_buffers: Set[str] = set()
@@ -205,25 +209,22 @@ class GraphLowering(torch.fx.Interpreter):
         self.mutated_buffers: Set[str] = set()
         self.never_reuse_buffers: Set[str] = set()
         self.inplaced_to_remove: Set[str] = set()
-        self.wrapper_code: Optional[WrapperCodeGen] = None
         # See `ProxyExecutor Design Note` in ir.py for more details
         self.extern_kernel_nodes: List[ir.ExternKernelNode] = []
         self.extern_node_serializer: Optional[
             Callable[[List[ir.ExternKernelNode]], Any]
         ] = extern_node_serializer
-        self.current_node: Optional[torch.fx.Node] = None
         self.num_static_inputs = num_static_inputs
         self.lists: Dict[str, List[str]] = {}
         self.mutated_inputs: Set[str] = set()
         self.mutated_input_idxs: List[int] = []
-        self.name_to_buffer: Dict[str, ir.ComputedBuffer] = {}
+        self.name_to_buffer: Dict[str, ir.Buffer] = {}
         self.name_to_users: DefaultDict[str, List[ir.IRNode]] = defaultdict(list)
         self.creation_time = time.time()
         self.name = "GraphLowering"
         self.cpp_wrapper = cpp_wrapper
         self.aot_mode = aot_mode
         self.graph_id = graph_id
-        self.scheduler = None
         self.nodes_prefer_channels_last = (
             self.find_nodes_prefer_channels_last() if self.layout_opt else set()
         )
@@ -444,7 +445,7 @@ class GraphLowering(torch.fx.Interpreter):
     def run(self, *args):
         return super().run(*args)
 
-    def register_buffer(self, buffer: ir.ComputedBuffer):
+    def register_buffer(self, buffer: ir.Buffer):
         name = f"buf{len(self.buffers)}"
         self.buffers.append(buffer)
         self.name_to_buffer[name] = buffer
@@ -530,7 +531,7 @@ class GraphLowering(torch.fx.Interpreter):
             )
         )
 
-    def constant_name(self, name: str, device_override: torch.device):
+    def constant_name(self, name: str, device_override: Optional[torch.device]):
         """
         We AOT copy constants to the devices they are needed on.
         If device_override doesn't match the constant's device, then
@@ -705,7 +706,7 @@ class GraphLowering(torch.fx.Interpreter):
 
     @contextmanager
     def set_current_node(self, node: torch.fx.Node):
-        old = self.current_node
+        old = getattr(self, "current_node", None)
         try:
             self.current_node = node
             yield
@@ -927,10 +928,8 @@ class GraphLowering(torch.fx.Interpreter):
         self.init_wrapper_code()
 
         self.scheduler = Scheduler(self.buffers)
-        assert self.scheduler is not None  # mypy can't figure this out
         V.debug.draw_orig_fx_graph(self.orig_gm, self.scheduler.nodes)
         self.scheduler.codegen()
-        assert self.wrapper_code is not None
         return self.wrapper_code.generate(self.is_inference)
 
     def count_bytes(self):
@@ -1003,7 +1002,6 @@ class GraphLowering(torch.fx.Interpreter):
             return self.compile_to_module().call
 
     def get_output_names(self):
-        assert self.graph_outputs is not None
         return [
             node.get_name()
             for node in self.graph_outputs

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -201,6 +201,7 @@ def ir_node_to_tensor(x, guard_shape=True):
     if x is None:
         return None
 
+    shape_fn: Callable[[Expr], Union[int, Expr]]
     if not guard_shape:
         shape_fn = V.graph.sizevars.size_hint
     else:
@@ -314,6 +315,9 @@ class IRNode:
         """
         raise NotImplementedError(f"realize NYI on {type(self)}")
 
+    def codegen_reference(self, writer=None):
+        raise NotImplementedError(f"codegen_reference NYI on {type(self)}")
+
     # The abstract method declarations below serve to convince mypy that all IRNode instances have these functions
     # defined, while having no effect at runtime. We cannot create stub implementations here because other parts of
     # the code dynamically check for defined attributes.
@@ -326,7 +330,7 @@ class IRNode:
     has_exceeded_max_reads: Callable[[], bool]
     make_loader: Callable[[], Callable[[Any], Any]]
     make_indexer: Callable[[], Callable[[Any], Any]]
-    mark_reuse: Callable[[List[Any]], None]
+    mark_reuse: Callable[[int], None]
     realize_hint: Callable[[], None]
 
 
@@ -2573,7 +2577,7 @@ class Buffer(IRNode):
     def make_indexer(self):
         return self.layout.make_indexer()
 
-    def get_name(self):
+    def get_name(self) -> str:
         assert self.name
         return self.name
 
@@ -2768,19 +2772,22 @@ class InputBuffer(Buffer):
 
 
 class ConstantBuffer(InputBuffer):
-    override_device = None
+    override_device: Optional[torch.device] = None
 
     def make_loader(self):
         def loader(index):
             indexer = self.layout.make_indexer()
             return ops.load(
-                V.graph.constant_name(self.name, self.override_device), indexer(index)
+                V.graph.constant_name(self.get_name(), self.override_device),
+                indexer(index),
             )
 
         return loader
 
     def constant_to_device(self, device):
-        return ConstantBuffer(V.graph.constant_name(self.name, device), self.layout)
+        return ConstantBuffer(
+            V.graph.constant_name(self.get_name(), device), self.layout
+        )
 
 
 class NoneAsConstantBuffer(IRNode):
@@ -3380,7 +3387,7 @@ class ExternKernel(InputsKernel):
 
         is_arg_tensor = []
         tensor_args = []
-        non_tensor_args = []
+        non_tensor_args: List[Any] = []
         for arg in args_flat:
             is_arg_tensor.append(isinstance(arg, IRNode))
             if is_arg_tensor[-1]:
@@ -4194,8 +4201,9 @@ fbcode_use_proxy_executor = {
 }
 
 
-@dataclasses.dataclass
 class FallbackKernel(ExternKernelAlloc):
+    args_default_value: List[Dict[str, Any]]
+
     def __init__(
         self,
         layout,
@@ -6026,6 +6034,9 @@ class MutableBox(IRNode):
 
     def realize(self):
         return self.data.realize()
+
+    def codegen_reference(self, writer=None):
+        return self.data.codegen_reference(writer)
 
     @property
     def layout(self):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -5,7 +5,7 @@ import os
 import warnings
 from collections import defaultdict
 from collections.abc import Iterable
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import sympy
 
@@ -810,6 +810,8 @@ def repeat(x, repeats):
         return empty(new_size, dtype=x.get_dtype(), device=x.get_device())
     if all((a == 1 or b == 1) for a, b in zip(repeats, old_size)):
         return expand(x, new_size)
+
+    x_loader: Callable[[Any], Any]
 
     def inner_fn(index):
         assert len(index) == len(repeats)
@@ -3578,7 +3580,7 @@ def constant_pad_nd(x, padding, fill_value=0):
     n = len(sizes) - len(bounds)
 
     # if padding is a complicated expression, hoist it
-    bounds_precomp = []
+    bounds_precomp: List[Tuple[sympy.Symbol, Any]] = []
     for l, h in bounds:
         l_precomp = (
             V.graph.sizevars.lookup_precomputed_size(l)

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -1,7 +1,7 @@
 import functools
 import itertools
 import logging
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import sympy
 from sympy import Expr
@@ -393,7 +393,7 @@ class SizeVarAllocator:
 
     def size_hints(
         self,
-        exprs: List[Expr],
+        exprs: Iterable[Expr],
         *,
         fallback: Optional[int] = None,
     ) -> Tuple[int, ...]:

--- a/torch/_inductor/virtualized.py
+++ b/torch/_inductor/virtualized.py
@@ -4,7 +4,7 @@ import itertools
 from contextlib import contextmanager
 from itertools import chain
 from threading import local
-from typing import Any, Callable, Union
+from typing import Any, Callable, TYPE_CHECKING, Union
 from unittest.mock import patch
 
 import sympy
@@ -14,6 +14,9 @@ from torch._inductor.utils import IndentedBuffer
 from torch.fx.graph import inplace_methods, magic_methods
 
 from .utils import reduction_num_outputs, sympy_str, sympy_symbol
+
+if TYPE_CHECKING:
+    from torch._inductor.graph import GraphLowering
 
 threadlocal = local()
 
@@ -287,7 +290,7 @@ class _V:
 
     set_ops_handler: Callable[[Any], Any] = _ops._set_handler
     get_ops_handler: Callable[[], Any] = _ops._get_handler
-    set_graph_handler: Callable[[Any], Any] = _graph._set_handler
+    set_graph_handler: Callable[[GraphLowering], Any] = _graph._set_handler
     set_real_inputs: Callable[[Any], Any] = _real_inputs._set_handler
     get_real_inputs: Callable[[], Any] = _real_inputs._get_handler
     set_fake_mode: Callable[[Any], Any] = _fake_mode._set_handler
@@ -306,7 +309,7 @@ class _V:
         return _ops._get_handler()
 
     @property
-    def graph(self):
+    def graph(self) -> GraphLowering:
         """The graph currently being generated"""
         return _graph._get_handler()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #114160
* #114162
* #114161
* __->__ #114025
* #114013

Previously it lacked a type hint and so was treated as an Any type. This
resulted in a lot of untyped code downstream as V.graph is referenced in
many places in inductor code. I've typed it properly now as
GraphLowering, and fixed the numerous type errors this surfaced.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler