### PR TITLE
Fix pool_size type in TaskThreadPool

### DIFF
--- a/c10/core/thread_pool.h
+++ b/c10/core/thread_pool.h
@@ -102,7 +102,7 @@ class C10_API ThreadPool : public c10::TaskThreadPoolBase {
 
 class C10_API TaskThreadPool : public c10::ThreadPool {
  public:
-  explicit TaskThreadPool(std::size_t pool_size, int numa_node_id = -1)
+  explicit TaskThreadPool(int pool_size, int numa_node_id = -1)
       : ThreadPool(pool_size, numa_node_id, [numa_node_id]() {
           setThreadName("CaffeTaskThread");
           NUMABind(numa_node_id);


### PR DESCRIPTION
As negative values of pool_size mean calling defaultNumThreads()
