### PR TITLE
Fixed docstring errors in embedding.py, _limiter_utils.py, _dynamo_utils.py, embedding_bag.py, tensor_ops.py, api.py, _internals.py, _common.py, init.py, _exec_order_utils.py, _traversal_utils.py, chunk_sharding_spec.py, _trace_utils.py

### DIFF
--- a/torch/distributed/_shard/sharded_tensor/_ops/_common.py
+++ b/torch/distributed/_shard/sharded_tensor/_ops/_common.py
@@ -58,7 +58,7 @@ def _register_sharded_op_on_local_shards(
     op, early_stop_func=None, extra_check=None, customized_func=None
 ):
     """
-    Handles ``__torch_function__`` dispatch for ops which are performed on
+    Handle ``__torch_function__`` dispatch for ops which are performed on
     each shard of the sharded tensor such as elementwise op like
     ``torch.nn.functional.gelu`` or ``torch.nn.functional.relu``.
 

--- a/torch/distributed/_shard/sharded_tensor/_ops/init.py
+++ b/torch/distributed/_shard/sharded_tensor/_ops/init.py
@@ -11,12 +11,12 @@ def validate_param(param, param_name):
 @_sharded_op_impl(torch.nn.init.uniform_)
 def uniform_(types, args=(), kwargs=None, pg=None):
     r"""
-    Fills the Tensor in tensor.local_shards with values drawn from the uniform
-    distribution :math:`\mathcal{U}(a, b)`.
+    Fill the Tensor in tensor.local_shards with values drawn from the uniform distribution :math:`\mathcal{U}(a, b)`.
+
     Args:
         tensor: tensor sharded across devices
         a: the lower bound of the uniform distribution
-        b: the upper bound of the uniform distribution
+        b: the upper bound of the uniform distribution.
     """
     validate_param(kwargs, "kwargs")
     sharded_tensor = kwargs["tensor"]
@@ -33,12 +33,12 @@ def uniform_(types, args=(), kwargs=None, pg=None):
 @_sharded_op_impl(torch.nn.init.normal_)
 def normal_(types, args=(), kwargs=None, pg=None):
     r"""
-    Fills the Tensors in tensor.local_shards with values drawn from the normal
+    Fill the Tensors in tensor.local_shards with values drawn from the normal
     distribution :math:`\mathcal{N}(\text{mean}, \text{std}^2)`.
     Args:
         tensor: tensor sharded across devices
         mean: the mean of the normal distribution
-        std: the standard deviation of the normal distribution
+        std: the standard deviation of the normal distribution.
     """
     validate_param(kwargs, "kwargs")
     sharded_tensor = kwargs["tensor"]
@@ -55,7 +55,7 @@ def normal_(types, args=(), kwargs=None, pg=None):
 @_sharded_op_impl(torch.nn.init.kaiming_uniform_)
 def kaiming_uniform_(types, args=(), kwargs=None, pg=None):
     r"""
-    Fills the Tensors in tensor.local_shards with values according to the method
+    Fill the Tensors in tensor.local_shards with values according to the method
     described in `Delving deep into rectifiers: Surpassing human-level
     performance on ImageNet classification` - He, K. et al. (2015), using a
     uniform distribution. The resulting tensor will have values sampled from
@@ -91,10 +91,11 @@ def kaiming_uniform_(types, args=(), kwargs=None, pg=None):
 @_sharded_op_impl(torch.nn.init.constant_)
 def constant_(types, args=(), kwargs=None, pg=None):
     r"""
-    Fills the input ShardedTensor with the value \text{val}val.
+    Fill the input ShardedTensor with the value \text{val}val.
+
     Args:
         tensor: tensor sharded across devices
-        val: the value to fill the tensor with
+        val: the value to fill the tensor with.
     """
     validate_param(kwargs, "kwargs")
     sharded_tensor = kwargs["tensor"]
@@ -119,7 +120,7 @@ def register_tensor_creation_op(op):
     @_sharded_op_impl(op)
     def tensor_creation_op(types, args=(), kwargs=None, pg=None):
         """
-        Handles ``__torch_function__`` dispatch for tensor creation ops that
+        Handle ``__torch_function__`` dispatch for tensor creation ops that
         takes a ShardedTensor as argument, such as ``torch.zeros_like`` or
         ``torch.full_like``.
         """

--- a/torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py
+++ b/torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py
@@ -58,8 +58,7 @@ def st_is_meta(types, args=(), kwargs=None, pg=None):
 
 def sharded_type_as_check(*args, **kwargs):
     """
-    Perform extra checks for the sharded_type_as op such as the input needs to
-    be either a Tensor or ShardedTensor.
+    Perform extra checks for the sharded_type_as op such as the input needs to be either a Tensor or ShardedTensor.
 
     Args: same as ``torch.Tensor.type_as``.
 
@@ -84,7 +83,7 @@ def same_dtype(*args, **kwargs):
 
 def sharded_type_as(args, kwargs, pg):
     """
-    Handles ``__torch_function__`` dispatch for the ``torch.Tensor.type_as`` op.
+    Handle ``__torch_function__`` dispatch for the ``torch.Tensor.type_as`` op.
 
     Args: same as ``torch.Tensor.type_as``.
 

--- a/torch/distributed/_shard/sharded_tensor/api.py
+++ b/torch/distributed/_shard/sharded_tensor/api.py
@@ -116,17 +116,14 @@ class ShardedTensorBase(torch.Tensor):
         return r
 
     def metadata(self) -> ShardedTensorMetadata:
-        """
-        Returns a :class:`ShardedTensorMetadata` object corresponding to the
-        metadata for the entire tensor.
-        """
+        """Return a :class:`ShardedTensorMetadata` object corresponding to the metadata for the entire tensor."""
         return self._metadata
 
     def local_shards(self) -> List[Shard]:
         """
-        Returns a list of :class:`Shard' corresponding to the
-        local shards for this rank. Returns an empty list if the current rank
-        does not host any shards for this Tensor.
+        Return a list of :class:`Shard' corresponding to the local shards for this rank.
+
+        Returns an empty list if the current rank does not host any shards for this Tensor.
         """
         return self._local_shards
 
@@ -138,11 +135,11 @@ class ShardedTensorBase(torch.Tensor):
         sharding_spec=None,
     ) -> ShardedTensorBase:
         """
-        Initialize a ShardedTensorBase with local shards and a global
-        ShardedTensorMetadata built on each rank.
+        Initialize a ShardedTensorBase with local shards and a global ShardedTensorMetadata built on each rank.
+
         Warning: This API is experimental and subject to change. It does
                  not do cross rank validations, and fully rely on the user
-                 for the correctness of sharded_tensor_metadata on each rank
+                 for the correctness of sharded_tensor_metadata on each rank.
         """
         shards_metadata = sharded_tensor_metadata.shards_metadata
         tensor_properties = sharded_tensor_metadata.tensor_properties
@@ -233,6 +230,7 @@ class ShardedTensor(ShardedTensorBase):
         individual GPU, via ``torch.cuda.set_device()``
 
     """
+
     def __new__(cls, sharding_spec: shard_spec.ShardingSpec, *size, **kwargs):
         self = super().__new__(cls, sharding_spec, *size, **kwargs)
         return self
@@ -361,7 +359,8 @@ class ShardedTensor(ShardedTensorBase):
     def _get_preferred_device(self) -> torch.device:
         """
         Return the preferred device to be used when creating tensors for collectives.
-        This method takes into account the associated process group
+
+        This method takes into account the associated process group.
         """
         if dist.get_backend(self._process_group) == dist.Backend.NCCL:
             return torch.device(torch.cuda.current_device())
@@ -375,8 +374,7 @@ class ShardedTensor(ShardedTensorBase):
         dtype: Optional[torch.dtype] = None,
     ) -> None:
         """
-        Creates a full :class:`Tensor` on rank ``dst`` by gathering all shards of the
-        sharded tensor.
+        Create a full :class:`Tensor` on rank ``dst`` by gathering all shards of the sharded tensor.
 
         The API needs to be called on all ranks in SPMD fashion. All ranks should have
         the same ``dst``. ``out`` should be a tensor of the same size as the overall
@@ -478,7 +476,7 @@ class ShardedTensor(ShardedTensorBase):
         process_group=None
     ) -> ShardedTensor:
         """
-        Returns a copy of this object in CPU memory.
+        Return a copy of this object in CPU memory.
 
         If this ShardedTensor is already on CPU memory, then no copy is
         performed and original object is returned.
@@ -535,7 +533,7 @@ class ShardedTensor(ShardedTensorBase):
         process_group=None
     ) -> ShardedTensor:
         """
-        Returns a copy of this object in CUDA memory, if the original ShardedTensor
+        Return a copy of this object in CUDA memory, if the original ShardedTensor
         is on CPU, we will move the local shard to the current GPU device of each
         process in a SPMD fashion.
         If this ShardedTensor is already on CUDA memory and local shards on each rank are
@@ -851,8 +849,7 @@ class ShardedTensor(ShardedTensorBase):
         sharding_spec=None,
     ) -> ShardedTensor:
         """
-        Initialize a ShardedTensor with local shards and a global
-        ShardedTensorMetadata built on each rank.
+        Initialize a ShardedTensor with local shards and a global ShardedTensorMetadata built on each rank.
 
         Warning: This API is experimental and subject to change. It does
                  not do cross rank validations, and fully rely on the user
@@ -983,15 +980,12 @@ class ShardedTensor(ShardedTensorBase):
         return sharded_tensor
 
     def sharding_spec(self) -> shard_spec.ShardingSpec:
-        """
-        Returns the ShardingSpec for the tensor.
-        """
+        """Return the ShardingSpec for the tensor."""
         return self._sharding_spec
 
     def reshard(self, resharding_spec: shard_spec.ShardingSpec) -> ShardedTensor:
         """
-        Reshard a sharded tensor given the ``resharding_spec``. For now, we only support
-        single local shard.
+        Reshard a sharded tensor given the ``resharding_spec``. For now, we only support single local shard.
 
         If ``resharding_spec`` is same as the original one, this becomes a no-op.
         If only ``resharding_spec`` shares the same sharding dim with the original one,
@@ -1148,9 +1142,7 @@ class ShardedTensor(ShardedTensorBase):
             f"kwargs: {kwargs} not supported for ShardedTensor!")
 
     def is_pinned(self) -> bool:  # type: ignore[override]
-        """
-        Returns True if the sharded tensor (each local shard) resides in pinned memory.
-        """
+        """Return True if the sharded tensor (each local shard) resides in pinned memory."""
         return self._metadata.tensor_properties.pin_memory
 
     def _register_remote_shards(self, remote_shards: List[rpc.RRef[Shard]], rpc_rank: int):
@@ -1158,9 +1150,9 @@ class ShardedTensor(ShardedTensorBase):
 
     def remote_shards(self) -> Dict[int, List[rpc.RRef[Shard]]]:
         """
-        Returns a Dict[int, RRef] with keys being the RPC rank and values
-        being RRefs to shards on that rank. Need to initialize the
-        RPC framework for this functionality.
+        Return a Dict[int, RRef] with keys being the RPC rank and values being RRefs to shards on that rank.
+
+        Need to initialize the RPC framework for this functionality.
 
         Raises an exception if ShardedTensor was created with ``init_rrefs=False``
         """
@@ -1178,9 +1170,8 @@ class ShardedTensor(ShardedTensorBase):
 
     @dataclass
     class ProcessGroupState:
-        """
-        State for ser-de of process group
-        """
+        """State for ser-de of process group."""
+
         local_rank: int
         global_rank: int
         local_world_size: int
@@ -1238,7 +1229,7 @@ class ShardedTensor(ShardedTensorBase):
 
 
 def _create_tensor_from_params(*size, local_device, tensor_properties: TensorProperties):
-    """ Helper to construct tensor from size, device and common params. """
+    """Help construct tensor from size, device and common params."""
     dtype = tensor_properties.dtype
     layout = tensor_properties.layout
     requires_grad = tensor_properties.requires_grad

--- a/torch/distributed/_shard/sharding_plan/api.py
+++ b/torch/distributed/_shard/sharding_plan/api.py
@@ -10,8 +10,9 @@ from torch.distributed._shard.sharding_spec import ShardingSpec
 @dataclass
 class ShardingPlan:
     """
-    Representation of a sharding plan, describes how to shard a module
-    across hosts. `plan` is used to shard module parameters according to the spec provided,
+    Representation of a sharding plan, describes how to shard a module across hosts.
+
+    `plan` is used to shard module parameters according to the spec provided,
     `output_plan` and `return_local_tensor` are optional, they are used to specify the output
     layout of a module with a spec, and when to convert back to data parallel fashion.
 
@@ -61,21 +62,20 @@ class ShardingPlan:
         >>>    return_local_tensor=["fc2"]
         >>> )
     """
+
     plan: Dict[str, Union[ShardingSpec, Sharder]]
     output_plan: Optional[Dict[str, ShardingSpec]] = None
     return_local_tensor: Optional[List[str]] = None
 
 
 class ShardingPlanner(abc.ABC):
-    """
-    Default ShardingPlanner interface, can be extended and
-    implement advanced sharding strategies.
-    """
+    """Default ShardingPlanner interface, can be extended and implement advanced sharding strategies."""
+
     @abc.abstractmethod
     def build_plan(self, module: nn.Module) -> ShardingPlan:
         """
-        Given a nn.Module, define how to shard the module across
-        ranks, return a ShardingPlan
+        Given a nn.Module, define how to shard the module across ranks, return a ShardingPlan.
+
         Args:
             module (:class:`torch.nn.Module`):
                 The module to apply sharding to.

--- a/torch/distributed/_shard/sharding_spec/_internals.py
+++ b/torch/distributed/_shard/sharding_spec/_internals.py
@@ -4,10 +4,7 @@ from torch.distributed._shard.metadata import ShardMetadata
 
 
 def _check_shard_metadata_pair_overlap(shard1: ShardMetadata, shard2: ShardMetadata):
-    """
-    Checks if two shards overlap.
-    """
-
+    """Check if two shards overlap."""
     # For each dim of each shard, check if one shard resides on the other
     # end of second shard with respect to that dim. As an example for a 2D
     # shard, we would check if one shard is above or on the left of the
@@ -70,7 +67,7 @@ def _find_1d_overlapping_shards(
 
 def validate_non_overlapping_shards_metadata(shards: List[ShardMetadata]):
     """
-    Ensures none of the shards overlap with each other.
+    Ensure none of the shards overlap with each other.
 
     Args:
         shards(List[ShardMetadata]): List of :class:`ShardMetadata` objects representing
@@ -112,7 +109,7 @@ def validate_non_overlapping_shards_metadata(shards: List[ShardMetadata]):
 
 def check_tensor(shards_metadata, tensor_dims) -> None:
     """
-    Checks if the shards_metadata is compatible with the provided tensor dims.
+    Check if the shards_metadata is compatible with the provided tensor dims.
 
     Args:
         shards_metadata(List[ShardMetadata]): List of :class:`ShardMetadata`
@@ -121,7 +118,6 @@ def check_tensor(shards_metadata, tensor_dims) -> None:
     Raises:
         ``ValueError`` if not compatible.
     """
-
     # If the tensor's volume matches the total volume of all shards and
     # all shard boundaries are within tensor dims, we have a compatible
     # sharding spec for this tensor. Note that we have already verified
@@ -155,7 +151,7 @@ def check_tensor(shards_metadata, tensor_dims) -> None:
 
 def get_split_size(dim_size, chunks):
     """
-    Computes the split size inline with ``torch.chunk``
+    Compute the split size inline with ``torch.chunk``.
 
     Args:
         dim_size(int): Size of the dimension being chunked.
@@ -168,8 +164,7 @@ def get_split_size(dim_size, chunks):
 
 def get_chunked_dim_size(dim_size, split_size, idx):
     """
-    Computes the dim size of the chunk for provided ``idx`` given ``dim_size``
-    and ``split_size``.
+    Compute the dim size of the chunk for provided ``idx`` given ``dim_size`` and ``split_size``.
 
     Args:
         dim_size(int): Size of the dimension being chunked.
@@ -183,8 +178,7 @@ def get_chunked_dim_size(dim_size, split_size, idx):
 
 def get_chunk_sharding_params(sharding_dim_size, world_size, spec, rank):
     """
-    Generate the start pos and offset length for the current rank for
-    chunk sharding.
+    Generate the start pos and offset length for the current rank for chunk sharding.
 
     Args:
         sharding_dim_size(int): The dimension length which we shard on.

--- a/torch/distributed/_shard/sharding_spec/api.py
+++ b/torch/distributed/_shard/sharding_spec/api.py
@@ -23,10 +23,12 @@ if TYPE_CHECKING:
 
 class PlacementSpec(ABC):  # noqa: B024
     """
-    Base class representing the placement of an entity. Subclasses of this
-    class can be used to specify customized placements which might not be
+    Base class representing the placement of an entity.
+
+    Subclasses of this class can be used to specify customized placements which might not be
     covered by existing APIs.
     """
+
     pass
 
 
@@ -46,9 +48,8 @@ class DevicePlacementSpec(PlacementSpec):
             self.device = torch.distributed._remote_device(self.device)
 
 class ShardingSpec(ABC):
-    """
-    Base class representing sharding specifications.
-    """
+    """Base class representing sharding specifications."""
+
     @abstractmethod
     def build_metadata(self,
                        tensor_sizes: torch.Size,
@@ -90,16 +91,12 @@ class ShardingSpec(ABC):
 _CUSTOM_SHARDING_SPEC_OPS: Dict[str, Dict[Callable, Callable]] = {}
 
 def _has_custom_op(sharding_spec, op):
-    """
-    Returns whether or not the ShardingSpec has a custom op implementation.
-    """
+    """Return whether or not the ShardingSpec has a custom op implementation."""
     class_name = type(sharding_spec).__qualname__
     return class_name in _CUSTOM_SHARDING_SPEC_OPS and op in _CUSTOM_SHARDING_SPEC_OPS[class_name]
 
 def _dispatch_custom_op(sharding_spec, op: Callable, types, args, kwargs, process_group):
-    """
-    Calls the custom op for this ShardingSpec if it exists.
-    """
+    """Call the custom op for this ShardingSpec if it exists."""
     class_name = type(sharding_spec).__qualname__
     if not _has_custom_op(sharding_spec, op):
         raise RuntimeError(f'Custom op: {op} not registered for {class_name}')
@@ -109,9 +106,10 @@ def _dispatch_custom_op(sharding_spec, op: Callable, types, args, kwargs, proces
 def custom_sharding_spec_op(sharding_spec_class, func):
     """
     Decorator to allow custom registration of ops.
+
     Args:
         sharding_spec_class(type): The ShardingSpec for which we need to add this custom op.
-        func(Callable): The op to override (ex: torch.bmm)
+        func(Callable): The op to override (ex: torch.bmm).
     """
     class_name = sharding_spec_class.__qualname__
     if class_name not in _CUSTOM_SHARDING_SPEC_OPS:
@@ -169,6 +167,7 @@ class EnumerableShardingSpec(ShardingSpec):
 def _infer_sharding_spec_from_shards_metadata(shards_metadata):
     """
     Infer the sharding spec from the metadata of each shard of a ShardedTensor.
+
     If the tensor is sharded only on one dimension, we can then verify whether it's
     a ChunkShardingSpec or not. The way to verify it is to first get the total length
     and perform a chunk sharding with the given placements to see if we can have the

--- a/torch/distributed/_shard/sharding_spec/chunk_sharding_spec.py
+++ b/torch/distributed/_shard/sharding_spec/chunk_sharding_spec.py
@@ -112,6 +112,8 @@ class ChunkShardingSpec(ShardingSpec):
 
     def shard(self, tensor: torch.Tensor, src_rank: int = 0, process_group=None) -> "ShardedTensor":
         """
+        Shard a given tensor
+
         Args:
             src_rank: group rank relative to ``process_group``
 

--- a/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py
+++ b/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py
@@ -18,9 +18,7 @@ from torch.distributed.nn.functional import (
 
 
 def _chunk_sharding_spec_check(spec, op):
-    """
-    For the given op implementation check if the sharding spec is ChunkShardingSpec.
-    """
+    """For the given op implementation check if the sharding spec is ChunkShardingSpec."""
     if not isinstance(spec, ChunkShardingSpec):
         raise NotImplementedError(
             f"Only ChunkShardingSpec supported for '{op.__name__}'."
@@ -31,7 +29,7 @@ def _register_sharded_op_on_local_tensor(
     op, early_stop_func=None, extra_check=None, customized_func=None
 ):
     """
-    Handles ``__torch_function__`` dispatch for ops which are performed on
+    Handle ``__torch_function__`` dispatch for ops which are performed on
     the single local tensor of the sharded tensor such as op like
     ``torch.nn.functional.softmax`` or ``torch.Tensor.view``.
 
@@ -95,6 +93,7 @@ def _handle_col_wise_sharding_base(
 ):
     """
     For col-wise sharding of weight, lots of logic are common.
+
     So we extract the common logic and put in this function:
     Step 1. To get input from each rank and
     Step 2. To perform the op on the concatenated tensor.
@@ -158,8 +157,8 @@ def _handle_col_wise_sharding_base(
 
 def _result_distribute_with_col_rearrange(results, input, world_size, weight, pg):
     """
-    For col-wise sharding of weight, we need to distribute
-    results to each rank. We do them in this function.
+    Distribute results to each rank for col-wise sharding of weight.
+
     Note that, if the index in the Sharding Spec is not equal to
     the rank number, we need to do the rearrangement based on the
     order given by the Sharding Spec (placement).
@@ -229,8 +228,8 @@ def _handle_max_norm_col_wise(
     pg,
 ):
     """
-    For col-wise sharding of weight, we need to aggregate the
-    norm across all ranks before we can perform the proper re-norm.
+    Aggregate the norm across all ranks for col-wise sharding of weight before we can perform the proper re-norm.
+
     Note that, the max_norm logic is only applied to the embedding
     indices that are looked up and not the whole shard.
 
@@ -300,10 +299,10 @@ def _all_gather_base_input(input, pg):
 
 def _handle_row_wise_mask(gather_inp, padding_idx, weight, world_size, rank):
     """
-    Mask the input for embedding look-up for IDs which are not stored
-    on the current rank. This function also adjust the ``padding_idx``
-    so that it is only used on the rank where the corresponding row is
-    stored.
+    Mask the input for embedding look-up for IDs which are not stored on the current rank.
+
+    This function also adjust the ``padding_idx``
+    so that it is only used on the rank where the corresponding row is stored.
 
     Note that, with ``max_norm`` flag on, only weights of rows being
     looked up will be re-normed. So we need an extra row for masked ID

--- a/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding.py
+++ b/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding.py
@@ -17,7 +17,8 @@ from ._common import (
 @custom_sharding_spec_op(ChunkShardingSpec, torch.nn.functional.embedding)
 def sharded_embedding(types, args, kwargs, pg):
     """
-    Handles ``__torch_function__`` dispatch for ``torch.nn.functional.embedding``.
+    Handle ``__torch_function__`` dispatch for ``torch.nn.functional.embedding``.
+
     This method computes a sharded embedding lookup and has the following limitations:
 
     1. Supports only sharding of ``weight``.
@@ -138,7 +139,6 @@ def _validate_embedding_param(args, kwargs):
 
     Return: None.
     """
-
     input = args[0]
     weight = args[1]
     max_norm = kwargs.get("max_norm")
@@ -186,9 +186,10 @@ def _handle_col_wise_sharding(
     input, world_size, weight, local_shard, max_norm, norm_type, padding_idx, pg
 ):
     """
-    Entry-point function to handle the logic of col-wise sharding of weight
-    for embedding. (Detailed explanations of the logic can be found in
-    the comment for sharded_embedding.)
+    Entry-point function to handle the logic of col-wise sharding of weight for embedding.
+
+    (Detailed explanations of the logic can be found in
+    the comment for sharded_embedding.).
 
     Args:
         input: list of ID used for lookup and aggregation.
@@ -234,9 +235,10 @@ def _handle_row_wise_sharding(
     input, world_size, weight, local_shard, max_norm, norm_type, padding_idx, rank, pg
 ):
     """
-    Entry-point function to handle the logic of row-wise sharding of weight
-    for embedding. (Detailed explanations of the logic can be found in
-    the comment for sharded_embedding.)
+    Entry-point function to handle the logic of row-wise sharding of weight for embedding.
+
+    (Detailed explanations of the logic can be found in
+    the comment for sharded_embedding.).
 
     Args:
         input: list of ID used for lookup and aggregation.

--- a/torch/distributed/fsdp/_dynamo_utils.py
+++ b/torch/distributed/fsdp/_dynamo_utils.py
@@ -9,7 +9,7 @@ def _annotate_modules_for_dynamo(
     use_orig_params: bool,
 ):
     """
-    Annotates the submodules in ``module`` 's tree, except those in
+    Annotate the submodules in ``module`` 's tree, except those in
     ``ignored_modules``, indicating that the submodules are FSDP-managed and
     saving the ``use_orig_params`` setting passed to the FSDP constructor.
     """

--- a/torch/distributed/fsdp/_exec_order_utils.py
+++ b/torch/distributed/fsdp/_exec_order_utils.py
@@ -21,8 +21,9 @@ class _ExecOrderWarnStatus(Enum):
 
 class _ExecOrderData:
     """
-    This contains the data structures to track the execution order. We track
-    the pre-forward order on the *first* iteration for forward prefetching
+    This contains the data structures to track the execution order.
+
+    We track the pre-forward order on the *first* iteration for forward prefetching
     (which thus assumes static graph) and the post-forward order on *every*
     iteration for backward prefetching (which thus does not assume static
     graph but may be provide an incorrect order).
@@ -64,7 +65,8 @@ class _ExecOrderData:
         process_group: dist.ProcessGroup,
     ) -> None:
         """
-        Initializes the data structures needed for checking the forward order.
+        Initialize the data structures needed for checking the forward order.
+
         This should be called after a root FSDP instance has been set during
         lazy initialization.
         """
@@ -90,9 +92,9 @@ class _ExecOrderData:
         current_handle: FlatParamHandle,
     ) -> Optional[FlatParamHandle]:
         """
-        Returns a :class:`list` of the handles keys of the handles to backward
-        prefetch given the current handles key. If there are no valid handles
-        keys to prefetch, then this returns an empty :class:`list`.
+        Return a :class:`list` of the handles keys of the handles to backward prefetch given the current handles key.
+
+        If there are no valid handles keys to prefetch, then this returns an empty :class:`list`.
         """
         current_index = current_handle._post_forward_index
         if current_index is None:
@@ -111,9 +113,9 @@ class _ExecOrderData:
         current_handle: FlatParamHandle,
     ) -> Optional[FlatParamHandle]:
         """
-        Returns a :class:`list` of the handles keys of the handles to forward
-        prefetch given the current handles key. If there are no valid handles
-        keys to prefetch, then this returns an empty :class:`list`.
+        Return a :class:`list` of the handles keys of the handles to forward prefetch given the current handles key.
+
+        If there are no valid handles keys to prefetch, then this returns an empty :class:`list`.
         """
         current_index = current_handle._pre_forward_order_index
         if current_index is None:
@@ -129,7 +131,7 @@ class _ExecOrderData:
 
     def record_post_forward(self, handle: Optional[FlatParamHandle]) -> None:
         """
-        Records ``handles`` in the post-forward order, where ``handles`` should
+        Record ``handles`` in the post-forward order, where ``handles`` should
         be a group of handles used in the same module's forward. If ``handles``
         is empty, then it is omitted.
 
@@ -151,7 +153,7 @@ class _ExecOrderData:
         self, handle: Optional[FlatParamHandle], is_training: bool
     ) -> None:
         """
-        Records ``handles`` in the pre-forward order, where ``handles`` should
+        Record ``handles`` in the pre-forward order, where ``handles`` should
         be a group of handles used in the same module's forward. If ``handles``
         is empty, then it is omitted.
 
@@ -171,7 +173,7 @@ class _ExecOrderData:
 
     def _check_order(self, handle: FlatParamHandle, is_training: bool) -> None:
         """
-        Checks the forward execution order as long as ``is_training`` is
+        Check the forward execution order as long as ``is_training`` is
         ``True`` since checking in eval mode is not supported. This only checks
         if the distributed debug level is DETAIL.
 
@@ -308,7 +310,7 @@ class _ExecOrderData:
         handle: FlatParamHandle,
     ) -> Tuple[Optional[int], ...]:
         """
-        Returns the handle indices (i.e. indices into ``self.all_handles``)
+        Return the handle indices (i.e. indices into ``self.all_handles``)
         corresponding to the handles in ``handle``. An entry in the
         returned tuple is ``None`` if the handle is invalid.
         """
@@ -322,9 +324,9 @@ class _ExecOrderData:
         handle_indices: Tuple[int, ...],
     ) -> List[List[str]]:
         """
-        Returns a list of FQNs for each handle in ``handle_indices``. If a
-        handle index is invalid, then its FQNs are omitted from the returned
-        list.
+        Return a list of FQNs for each handle in ``handle_indices``.
+
+        If a handle index is invalid, then its FQNs are omitted from the returned list.
         """
         fqns: List[List[str]] = []
         for index in handle_indices:
@@ -340,8 +342,9 @@ class _ExecOrderData:
         handle: FlatParamHandle,
     ) -> List[List[str]]:
         """
-        Returns a list of FQNs for each handle in ``handles_key``. If a handle
-        is invalid, then its FQNs are omitted from the returned list.
+        Return a list of FQNs for each handle in ``handles_key``.
+
+        If a handle is invalid, then its FQNs are omitted from the returned list.
         """
         fqns: List[List[str]] = []
         if handle:
@@ -352,9 +355,9 @@ class _ExecOrderData:
 
     def next_iter(self):
         """
-        Advances the internal data structures per iteration. This should be
-        called in the post-backward callback since that marks the true end of
-        an iteration.
+        Advance the internal data structures per iteration.
+
+        This should be called in the post-backward callback since that marks the true end of an iteration.
         """
         self._iter += 1
         self.handles_post_forward_order.clear()

--- a/torch/distributed/fsdp/_limiter_utils.py
+++ b/torch/distributed/fsdp/_limiter_utils.py
@@ -6,8 +6,9 @@ import torch
 
 class _FreeEventQueue:
     """
-    This tracks all pending frees corresponding to inflight all-gathers. The
-    queueing pattern is iterative enqueues with a single dequeue per iteration
+    This tracks all pending frees corresponding to inflight all-gathers.
+
+    The queueing pattern is iterative enqueues with a single dequeue per iteration
     once the limit ``_max_num_inflight_all_gathers`` is reached.
     """
 

--- a/torch/distributed/fsdp/_trace_utils.py
+++ b/torch/distributed/fsdp/_trace_utils.py
@@ -33,8 +33,9 @@ class TracingConfig:
 
 class _ParamUsageInfo(NamedTuple):
     """
-    This is used for ``_ExecutionInfo.module_to_param_usage_infos`` to record
-    execution information. The ``dict`` maps modules to a list of these
+    This is used for ``_ExecutionInfo.module_to_param_usage_infos`` to record execution information.
+
+    The ``dict`` maps modules to a list of these
     ``_ParamUsageInfo`` instances, where each instance represents a group of
     parameters used together.
 
@@ -122,8 +123,9 @@ class _ExecOrderTracer:
         kwargs: Dict[str, Any],
     ) -> Any:
         """
-        Overrides ``call_module`` to save execution information to
-        ``exec_info``. Note that ``call_module`` is called during symbolic
+        Override ``call_module`` to save execution information to ``exec_info``.
+
+        Note that ``call_module`` is called during symbolic
         tracing for each non-root module.
 
         Args:
@@ -170,8 +172,9 @@ class _ExecOrderTracer:
         proxy_factory_fn: Optional[Callable[[torch.fx.Node], torch.fx.Proxy]] = None,
     ) -> torch.fx.Proxy:
         """
-        Overrides ``create_proxy`` to save execution information to
-        ``exec_info``. Note that ``create_proxy`` is called during symbolic
+        Override ``create_proxy`` to save execution information to ``exec_info``.
+
+        Note that ``create_proxy`` is called during symbolic
         tracing for each leaf function/method/module.
 
         Args:

--- a/torch/distributed/fsdp/_traversal_utils.py
+++ b/torch/distributed/fsdp/_traversal_utils.py
@@ -33,9 +33,7 @@ traversal, whereas ``nn.Module`` has ``nn.Module.modules()`` for traversal.
 
 
 def _composable(module: nn.Module) -> bool:
-    """
-    Returns if ``module`` can compose with ``fully_shard``.
-    """
+    """Return if ``module`` can compose with ``fully_shard``."""
     # TODO: Add any other composable APIs that are mutually exclusive.
     registry = _get_registry(module)
     if registry is None:
@@ -50,7 +48,7 @@ def _get_fsdp_states_with_modules(
     module: nn.Module,
 ) -> Tuple[List[_FSDPState], List[nn.Module]]:
     """
-    Returns a tuple containing:
+    Return a tuple containing:
     1. A list of the ``_FSDPState`` instances in the module tree rooted at
     ``module`` without any duplicates and following the ``module.modules()``
     traversal order (which is assumed to be depth-first).
@@ -102,7 +100,7 @@ def _get_fsdp_states(module: nn.Module) -> List[_FSDPState]:
 
 def _get_fsdp_handles(module: nn.Module) -> List:
     """
-    Returns all ``FlatParamHandle`` s in the module tree rooted at ``module``
+    Return all ``FlatParamHandle`` s in the module tree rooted at ``module``
     following the rules in :func:`_get_fsdp_state`.
     """
     handles = [


### PR DESCRIPTION
Fixes #113187

I have fixed the given docstring errors. The followings are the outputs with numbers before and after the changes:

`torch/distributed/_shard/sharded_tensor/api.py`

```
Before:
torch/distributed/_shard/sharded_tensor/api.py:72 in public class `ShardedTensorBase`:
        D101: Missing docstring in public class
torch/distributed/_shard/sharded_tensor/api.py:77 in public method `__new__`:
        D102: Missing docstring in public method
torch/distributed/_shard/sharded_tensor/api.py:119 in public method `metadata`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/api.py:119 in public method `metadata`:
        D400: First line should end with a period (not 'e')
torch/distributed/_shard/sharded_tensor/api.py:119 in public method `metadata`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/distributed/_shard/sharded_tensor/api.py:126 in public method `local_shards`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/api.py:126 in public method `local_shards`:
        D400: First line should end with a period (not 'e')
torch/distributed/_shard/sharded_tensor/api.py:126 in public method `local_shards`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/distributed/_shard/sharded_tensor/api.py:140 in private method `_init_from_local_shards_and_global_metadata`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/api.py:140 in private method `_init_from_local_shards_and_global_metadata`:
        D400: First line should end with a period (not 'l')
torch/distributed/_shard/sharded_tensor/api.py:182 in public method `__torch_dispatch__`:
        D105: Missing docstring in magic method
torch/distributed/_shard/sharded_tensor/api.py:189 in public class `ShardedTensor`:
        D204: 1 blank line required after class docstring (found 0)
torch/distributed/_shard/sharded_tensor/api.py:189 in public class `ShardedTensor`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/api.py:189 in public class `ShardedTensor`:
        D400: First line should end with a period (not 'd')
torch/distributed/_shard/sharded_tensor/api.py:236 in public method `__new__`:
        D102: Missing docstring in public method
torch/distributed/_shard/sharded_tensor/api.py:240 in public method `__init__`:
        D107: Missing docstring in __init__
torch/distributed/_shard/sharded_tensor/api.py:306 in public method `__del__`:
        D105: Missing docstring in magic method
torch/distributed/_shard/sharded_tensor/api.py:362 in private method `_get_preferred_device`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/api.py:377 in public method `gather`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/api.py:377 in public method `gather`:
        D400: First line should end with a period (not 'e')
torch/distributed/_shard/sharded_tensor/api.py:377 in public method `gather`:
        D401: First line should be in imperative mood (perhaps 'Create', not 'Creates')
torch/distributed/_shard/sharded_tensor/api.py:480 in public method `cpu`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/distributed/_shard/sharded_tensor/api.py:537 in public method `cuda`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/api.py:537 in public method `cuda`:
        D400: First line should end with a period (not 'r')
torch/distributed/_shard/sharded_tensor/api.py:537 in public method `cuda`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/distributed/_shard/sharded_tensor/api.py:594 in public method `to`:
        D102: Missing docstring in public method
torch/distributed/_shard/sharded_tensor/api.py:748 in private method `_init_from_local_tensor`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/api.py:748 in private method `_init_from_local_tensor`:
        D400: First line should end with a period (not 'r')
torch/distributed/_shard/sharded_tensor/api.py:853 in private method `_init_from_local_shards_and_global_metadata`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/api.py:853 in private method `_init_from_local_shards_and_global_metadata`:
        D400: First line should end with a period (not 'l')
torch/distributed/_shard/sharded_tensor/api.py:986 in public method `sharding_spec`:
        D200: One-line docstring should fit on one line with quotes (found 3)
torch/distributed/_shard/sharded_tensor/api.py:986 in public method `sharding_spec`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/distributed/_shard/sharded_tensor/api.py:992 in public method `reshard`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/api.py:992 in public method `reshard`:
        D400: First line should end with a period (not 't')
torch/distributed/_shard/sharded_tensor/api.py:1107 in public method `__torch_function__`:
        D105: Missing docstring in magic method
torch/distributed/_shard/sharded_tensor/api.py:1151 in public method `is_pinned`:
        D200: One-line docstring should fit on one line with quotes (found 3)
torch/distributed/_shard/sharded_tensor/api.py:1151 in public method `is_pinned`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/distributed/_shard/sharded_tensor/api.py:1160 in public method `remote_shards`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/api.py:1160 in public method `remote_shards`:
        D400: First line should end with a period (not 's')
torch/distributed/_shard/sharded_tensor/api.py:1160 in public method `remote_shards`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/distributed/_shard/sharded_tensor/api.py:1173 in public method `__hash__`:
        D105: Missing docstring in magic method
torch/distributed/_shard/sharded_tensor/api.py:1176 in public method `__repr__`:
        D105: Missing docstring in magic method
torch/distributed/_shard/sharded_tensor/api.py:1181 in public nested class `ProcessGroupState`:
        D200: One-line docstring should fit on one line with quotes (found 3)
torch/distributed/_shard/sharded_tensor/api.py:1181 in public nested class `ProcessGroupState`:
        D204: 1 blank line required after class docstring (found 0)
torch/distributed/_shard/sharded_tensor/api.py:1181 in public nested class `ProcessGroupState`:
        D400: First line should end with a period (not 'p')
torch/distributed/_shard/sharded_tensor/api.py:1189 in public method `__getstate__`:
        D105: Missing docstring in magic method
torch/distributed/_shard/sharded_tensor/api.py:1199 in public method `__setstate__`:
        D105: Missing docstring in magic method
torch/distributed/_shard/sharded_tensor/api.py:1241 in private function `_create_tensor_from_params`:
        D210: No whitespaces allowed surrounding docstring text
torch/distributed/_shard/sharded_tensor/api.py:1241 in private function `_create_tensor_from_params`:
        D401: First line should be in imperative mood; try rephrasing (found 'Helper')
49

After:
torch/distributed/_shard/sharded_tensor/api.py:72 in public class `ShardedTensorBase`:
        D101: Missing docstring in public class
torch/distributed/_shard/sharded_tensor/api.py:77 in public method `__new__`:
        D102: Missing docstring in public method
torch/distributed/_shard/sharded_tensor/api.py:179 in public method `__torch_dispatch__`:
        D105: Missing docstring in magic method
torch/distributed/_shard/sharded_tensor/api.py:186 in public class `ShardedTensor`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/api.py:186 in public class `ShardedTensor`:
        D400: First line should end with a period (not 'd')
torch/distributed/_shard/sharded_tensor/api.py:234 in public method `__new__`:
        D102: Missing docstring in public method
torch/distributed/_shard/sharded_tensor/api.py:238 in public method `__init__`:
        D107: Missing docstring in __init__
torch/distributed/_shard/sharded_tensor/api.py:304 in public method `__del__`:
        D105: Missing docstring in magic method
torch/distributed/_shard/sharded_tensor/api.py:535 in public method `cuda`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/api.py:535 in public method `cuda`:
        D400: First line should end with a period (not 'r')
torch/distributed/_shard/sharded_tensor/api.py:592 in public method `to`:
        D102: Missing docstring in public method
torch/distributed/_shard/sharded_tensor/api.py:746 in private method `_init_from_local_tensor`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/api.py:746 in private method `_init_from_local_tensor`:
        D400: First line should end with a period (not 'r')
torch/distributed/_shard/sharded_tensor/api.py:1101 in public method `__torch_function__`:
        D105: Missing docstring in magic method
torch/distributed/_shard/sharded_tensor/api.py:1165 in public method `__hash__`:
        D105: Missing docstring in magic method
torch/distributed/_shard/sharded_tensor/api.py:1168 in public method `__repr__`:
        D105: Missing docstring in magic method
torch/distributed/_shard/sharded_tensor/api.py:1180 in public method `__getstate__`:
        D105: Missing docstring in magic method
torch/distributed/_shard/sharded_tensor/api.py:1190 in public method `__setstate__`:
        D105: Missing docstring in magic method
18
```

`torch/distributed/_shard/sharded_tensor/_ops/_common.py`

```
Before:
==== torch/distributed/_shard/sharded_tensor/_ops/_common.py ====
torch/distributed/_shard/sharded_tensor/_ops/_common.py:10 in private function `_sharded_op_common`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/_ops/_common.py:10 in private function `_sharded_op_common`:
        D400: First line should end with a period (not 'e')
torch/distributed/_shard/sharded_tensor/_ops/_common.py:60 in private function `_register_sharded_op_on_local_shards`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/_ops/_common.py:60 in private function `_register_sharded_op_on_local_shards`:
        D400: First line should end with a period (not 'n')
torch/distributed/_shard/sharded_tensor/_ops/_common.py:60 in private function `_register_sharded_op_on_local_shards`:
        D401: First line should be in imperative mood (perhaps 'Handle', not 'Handles')
5

After:
torch/distributed/_shard/sharded_tensor/_ops/_common.py:10 in private function `_sharded_op_common`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/_ops/_common.py:10 in private function `_sharded_op_common`:
        D400: First line should end with a period (not 'e')
torch/distributed/_shard/sharded_tensor/_ops/_common.py:60 in private function `_register_sharded_op_on_local_shards`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/_ops/_common.py:60 in private function `_register_sharded_op_on_local_shards`:
        D400: First line should end with a period (not 'n')
4
```

`torch/distributed/_shard/sharded_tensor/_ops/init.py`
```
Before:
torch/distributed/_shard/sharded_tensor/_ops/init.py:7 in public function `validate_param`:
        D103: Missing docstring in public function
torch/distributed/_shard/sharded_tensor/_ops/init.py:13 in public function `uniform_`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/_ops/init.py:13 in public function `uniform_`:
        D400: First line should end with a period (not 'm')
torch/distributed/_shard/sharded_tensor/_ops/init.py:13 in public function `uniform_`:
        D401: First line should be in imperative mood (perhaps 'Fill', not 'Fills')
torch/distributed/_shard/sharded_tensor/_ops/init.py:35 in public function `normal_`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/_ops/init.py:35 in public function `normal_`:
        D400: First line should end with a period (not 'l')
torch/distributed/_shard/sharded_tensor/_ops/init.py:35 in public function `normal_`:
        D401: First line should be in imperative mood (perhaps 'Fill', not 'Fills')
torch/distributed/_shard/sharded_tensor/_ops/init.py:57 in public function `kaiming_uniform_`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/_ops/init.py:57 in public function `kaiming_uniform_`:
        D400: First line should end with a period (not 'd')
torch/distributed/_shard/sharded_tensor/_ops/init.py:57 in public function `kaiming_uniform_`:
        D401: First line should be in imperative mood (perhaps 'Fill', not 'Fills')
torch/distributed/_shard/sharded_tensor/_ops/init.py:93 in public function `constant_`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/_ops/init.py:93 in public function `constant_`:
        D401: First line should be in imperative mood (perhaps 'Fill', not 'Fills')
torch/distributed/_shard/sharded_tensor/_ops/init.py:118 in public function `register_tensor_creation_op`:
        D103: Missing docstring in public function
torch/distributed/_shard/sharded_tensor/_ops/init.py:121 in private nested function `tensor_creation_op`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/_ops/init.py:121 in private nested function `tensor_creation_op`:
        D400: First line should end with a period (not 't')
torch/distributed/_shard/sharded_tensor/_ops/init.py:121 in private nested function `tensor_creation_op`:
        D401: First line should be in imperative mood (perhaps 'Handle', not 'Handles')
16

After:
torch/distributed/_shard/sharded_tensor/_ops/init.py:7 in public function `validate_param`:
        D103: Missing docstring in public function
torch/distributed/_shard/sharded_tensor/_ops/init.py:35 in public function `normal_`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/_ops/init.py:35 in public function `normal_`:
        D400: First line should end with a period (not 'l')
torch/distributed/_shard/sharded_tensor/_ops/init.py:57 in public function `kaiming_uniform_`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/_ops/init.py:57 in public function `kaiming_uniform_`:
        D400: First line should end with a period (not 'd')
torch/distributed/_shard/sharded_tensor/_ops/init.py:119 in public function `register_tensor_creation_op`:
        D103: Missing docstring in public function
torch/distributed/_shard/sharded_tensor/_ops/init.py:122 in private nested function `tensor_creation_op`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/_ops/init.py:122 in private nested function `tensor_creation_op`:
        D400: First line should end with a period (not 't')
```

`torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py`
```
Before:
torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py:40 in public function `tensor_device`:
        D103: Missing docstring in public function
torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py:55 in public function `st_is_meta`:
        D103: Missing docstring in public function
torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py:60 in public function `sharded_type_as_check`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py:60 in public function `sharded_type_as_check`:
        D400: First line should end with a period (not 'o')
torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py:86 in public function `sharded_type_as`:
        D401: First line should be in imperative mood (perhaps 'Handle', not 'Handles')
torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py:115 in public function `sharded_deepcopy`:
        D103: Missing docstring in public function
torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py:134 in public function `sharded_inplace_copy`:
        D103: Missing docstring in public function
torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py:151 in public function `sharded_clone`:
        D103: Missing docstring in public function
torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py:173 in public function `sharded_detach`:
        D103: Missing docstring in public function
torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py:194 in public function `tensor_requires_grad_set`:
        D103: Missing docstring in public function
10

After:
torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py:40 in public function `tensor_device`:
        D103: Missing docstring in public function
torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py:55 in public function `st_is_meta`:
        D103: Missing docstring in public function
torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py:114 in public function `sharded_deepcopy`:
        D103: Missing docstring in public function
torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py:133 in public function `sharded_inplace_copy`:
        D103: Missing docstring in public function
torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py:150 in public function `sharded_clone`:
        D103: Missing docstring in public function
torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py:172 in public function `sharded_detach`:
        D103: Missing docstring in public function
torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py:193 in public function `tensor_requires_grad_set`:
        D103: Missing docstring in public function
7
```

`torch/distributed/_shard/sharding_spec/api.py`
```
Before:
torch/distributed/_shard/sharding_spec/api.py:25 in public class `PlacementSpec` (skipping B024):
        D204: 1 blank line required after class docstring (found 0)
torch/distributed/_shard/sharding_spec/api.py:25 in public class `PlacementSpec` (skipping B024):
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_spec/api.py:25 in public class `PlacementSpec` (skipping B024):
        D400: First line should end with a period (not 's')
torch/distributed/_shard/sharding_spec/api.py:44 in public method `__post_init__`:
        D105: Missing docstring in magic method
torch/distributed/_shard/sharding_spec/api.py:49 in public class `ShardingSpec`:
        D200: One-line docstring should fit on one line with quotes (found 3)
torch/distributed/_shard/sharding_spec/api.py:49 in public class `ShardingSpec`:
        D204: 1 blank line required after class docstring (found 0)
torch/distributed/_shard/sharding_spec/api.py:57 in public method `build_metadata`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_spec/api.py:57 in public method `build_metadata`:
        D400: First line should end with a period (not 'e')
torch/distributed/_shard/sharding_spec/api.py:73 in public method `shard`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_spec/api.py:73 in public method `shard`:
        D400: First line should end with a period (not 'r')
torch/distributed/_shard/sharding_spec/api.py:93 in private function `_has_custom_op`:
        D200: One-line docstring should fit on one line with quotes (found 3)
torch/distributed/_shard/sharding_spec/api.py:93 in private function `_has_custom_op`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/distributed/_shard/sharding_spec/api.py:100 in private function `_dispatch_custom_op`:
        D200: One-line docstring should fit on one line with quotes (found 3)
torch/distributed/_shard/sharding_spec/api.py:100 in private function `_dispatch_custom_op`:
        D401: First line should be in imperative mood (perhaps 'Call', not 'Calls')
torch/distributed/_shard/sharding_spec/api.py:110 in public function `custom_sharding_spec_op`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_spec/api.py:110 in public function `custom_sharding_spec_op`:
        D401: First line should be in imperative mood (perhaps 'Decorate', not 'Decorator')
torch/distributed/_shard/sharding_spec/api.py:128 in public class `EnumerableShardingSpec`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_spec/api.py:128 in public class `EnumerableShardingSpec`:
        D400: First line should end with a period (not 'c')
torch/distributed/_shard/sharding_spec/api.py:139 in public method `__post_init__`:
        D105: Missing docstring in magic method
torch/distributed/_shard/sharding_spec/api.py:152 in public method `build_metadata`:
        D102: Missing docstring in public method
torch/distributed/_shard/sharding_spec/api.py:164 in public method `shard`:
        D102: Missing docstring in public method
torch/distributed/_shard/sharding_spec/api.py:170 in private function `_infer_sharding_spec_from_shards_metadata`:
        D205: 1 blank line required between summary line and description (found 0)
22

After:
torch/distributed/_shard/sharding_spec/api.py:46 in public method `__post_init__`:
        D105: Missing docstring in magic method
torch/distributed/_shard/sharding_spec/api.py:58 in public method `build_metadata`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_spec/api.py:58 in public method `build_metadata`:
        D400: First line should end with a period (not 'e')
torch/distributed/_shard/sharding_spec/api.py:74 in public method `shard`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_spec/api.py:74 in public method `shard`:
        D400: First line should end with a period (not 'r')
torch/distributed/_shard/sharding_spec/api.py:107 in public function `custom_sharding_spec_op`:
        D401: First line should be in imperative mood (perhaps 'Decorate', not 'Decorator')
torch/distributed/_shard/sharding_spec/api.py:126 in public class `EnumerableShardingSpec`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_spec/api.py:126 in public class `EnumerableShardingSpec`:
        D400: First line should end with a period (not 'c')
torch/distributed/_shard/sharding_spec/api.py:137 in public method `__post_init__`:
        D105: Missing docstring in magic method
torch/distributed/_shard/sharding_spec/api.py:150 in public method `build_metadata`:
        D102: Missing docstring in public method
torch/distributed/_shard/sharding_spec/api.py:162 in public method `shard`:
        D102: Missing docstring in public method
11
```

`torch/distributed/_shard/sharding_spec/chunk_sharding_spec.py`
```
Before:
torch/distributed/_shard/sharding_spec/chunk_sharding_spec.py:27 in public class `ChunkShardingSpec`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_spec/chunk_sharding_spec.py:27 in public class `ChunkShardingSpec`:
        D400: First line should end with a period (not 'd')
torch/distributed/_shard/sharding_spec/chunk_sharding_spec.py:57 in public method `__post_init__`:
        D105: Missing docstring in magic method
torch/distributed/_shard/sharding_spec/chunk_sharding_spec.py:77 in public method `build_metadata`:
        D102: Missing docstring in public method
torch/distributed/_shard/sharding_spec/chunk_sharding_spec.py:114 in public method `shard`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_spec/chunk_sharding_spec.py:114 in public method `shard`:
        D400: First line should end with a period (not ':')
6

After:
torch/distributed/_shard/sharding_spec/chunk_sharding_spec.py:27 in public class `ChunkShardingSpec`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_spec/chunk_sharding_spec.py:27 in public class `ChunkShardingSpec`:
        D400: First line should end with a period (not 'd')
torch/distributed/_shard/sharding_spec/chunk_sharding_spec.py:57 in public method `__post_init__`:
        D105: Missing docstring in magic method
torch/distributed/_shard/sharding_spec/chunk_sharding_spec.py:77 in public method `build_metadata`:
        D102: Missing docstring in public method
torch/distributed/_shard/sharding_spec/chunk_sharding_spec.py:114 in public method `shard`:
        D400: First line should end with a period (not 'r')
5
```

`torch/distributed/_shard/sharding_spec/_internals.py`
```
Before:
torch/distributed/_shard/sharding_spec/_internals.py:7 in private function `_check_shard_metadata_pair_overlap`:
        D200: One-line docstring should fit on one line with quotes (found 3)
torch/distributed/_shard/sharding_spec/_internals.py:7 in private function `_check_shard_metadata_pair_overlap`:
        D202: No blank lines allowed after function docstring (found 1)
torch/distributed/_shard/sharding_spec/_internals.py:7 in private function `_check_shard_metadata_pair_overlap`:
        D401: First line should be in imperative mood (perhaps 'Check', not 'Checks')
torch/distributed/_shard/sharding_spec/_internals.py:72 in public function `validate_non_overlapping_shards_metadata`:
        D401: First line should be in imperative mood (perhaps 'Ensure', not 'Ensures')
torch/distributed/_shard/sharding_spec/_internals.py:114 in public function `check_tensor`:
        D202: No blank lines allowed after function docstring (found 1)
torch/distributed/_shard/sharding_spec/_internals.py:114 in public function `check_tensor`:
        D401: First line should be in imperative mood (perhaps 'Check', not 'Checks')
torch/distributed/_shard/sharding_spec/_internals.py:157 in public function `get_split_size`:
        D400: First line should end with a period (not '`')
torch/distributed/_shard/sharding_spec/_internals.py:157 in public function `get_split_size`:
        D401: First line should be in imperative mood (perhaps 'Compute', not 'Computes')
torch/distributed/_shard/sharding_spec/_internals.py:170 in public function `get_chunked_dim_size`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_spec/_internals.py:170 in public function `get_chunked_dim_size`:
        D400: First line should end with a period (not '`')
torch/distributed/_shard/sharding_spec/_internals.py:170 in public function `get_chunked_dim_size`:
        D401: First line should be in imperative mood (perhaps 'Compute', not 'Computes')
torch/distributed/_shard/sharding_spec/_internals.py:185 in public function `get_chunk_sharding_params`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_spec/_internals.py:185 in public function `get_chunk_sharding_params`:
        D400: First line should end with a period (not 'r')
13

After:
0
```

`torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py`
```
Before:
torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py:21 in private function `_chunk_sharding_spec_check`:
        D200: One-line docstring should fit on one line with quotes (found 3)
torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py:33 in private function `_register_sharded_op_on_local_tensor`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py:33 in private function `_register_sharded_op_on_local_tensor`:
        D400: First line should end with a period (not 'n')
torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py:33 in private function `_register_sharded_op_on_local_tensor`:
        D401: First line should be in imperative mood (perhaps 'Handle', not 'Handles')
torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py:96 in private function `_handle_col_wise_sharding_base`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py:160 in private function `_result_distribute_with_col_rearrange`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py:160 in private function `_result_distribute_with_col_rearrange`:
        D400: First line should end with a period (not 'e')
torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py:231 in private function `_handle_max_norm_col_wise`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py:231 in private function `_handle_max_norm_col_wise`:
        D400: First line should end with a period (not 'e')
torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py:302 in private function `_handle_row_wise_mask`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py:302 in private function `_handle_row_wise_mask`:
        D400: First line should end with a period (not 'd')
11

After:
torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py:31 in private function `_register_sharded_op_on_local_tensor`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py:31 in private function `_register_sharded_op_on_local_tensor`:
        D400: First line should end with a period (not 'n')
2
```

`torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding.py`
```
Before:
torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding.py:19 in public function `sharded_embedding`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding.py:19 in public function `sharded_embedding`:
        D401: First line should be in imperative mood (perhaps 'Handle', not 'Handles')
torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding.py:131 in private function `_validate_embedding_param`:
        D202: No blank lines allowed after function docstring (found 1)
torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding.py:188 in private function `_handle_col_wise_sharding`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding.py:188 in private function `_handle_col_wise_sharding`:
        D400: First line should end with a period (not 't')
torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding.py:236 in private function `_handle_row_wise_sharding`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding.py:236 in private function `_handle_row_wise_sharding`:
        D400: First line should end with a period (not 't')
7

After:
0
```

`torch/distributed/_shard/sharding_plan/api.py`
```
Before:
torch/distributed/_shard/sharding_plan/api.py:12 in public class `ShardingPlan`:
        D204: 1 blank line required after class docstring (found 0)
torch/distributed/_shard/sharding_plan/api.py:12 in public class `ShardingPlan`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_plan/api.py:12 in public class `ShardingPlan`:
        D400: First line should end with a period (not 'e')
torch/distributed/_shard/sharding_plan/api.py:70 in public class `ShardingPlanner`:
        D204: 1 blank line required after class docstring (found 0)
torch/distributed/_shard/sharding_plan/api.py:70 in public class `ShardingPlanner`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_plan/api.py:70 in public class `ShardingPlanner`:
        D400: First line should end with a period (not 'd')
torch/distributed/_shard/sharding_plan/api.py:76 in public method `build_plan`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/_shard/sharding_plan/api.py:76 in public method `build_plan`:
        D400: First line should end with a period (not 's')
8
After:
0
```

`torch/distributed/fsdp/_dynamo_utils.py`
```
Before:
torch/distributed/fsdp/_dynamo_utils.py:11 in private function `_annotate_modules_for_dynamo`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_dynamo_utils.py:11 in private function `_annotate_modules_for_dynamo`:
        D400: First line should end with a period (not 'n')
2

After:
torch/distributed/fsdp/_dynamo_utils.py:11 in private function `_annotate_modules_for_dynamo`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_dynamo_utils.py:11 in private function `_annotate_modules_for_dynamo`:
        D400: First line should end with a period (not 'n')
2
```

`torch/distributed/fsdp/_exec_order_utils.py`
```
Before:
torch/distributed/fsdp/_exec_order_utils.py:23 in private class `_ExecOrderData`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_exec_order_utils.py:23 in private class `_ExecOrderData`:
        D400: First line should end with a period (not 'k')
torch/distributed/fsdp/_exec_order_utils.py:66 in private method `init`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_exec_order_utils.py:66 in private method `init`:
        D401: First line should be in imperative mood (perhaps 'Initialize', not 'Initializes')
torch/distributed/fsdp/_exec_order_utils.py:92 in private method `get_handle_to_backward_prefetch`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_exec_order_utils.py:92 in private method `get_handle_to_backward_prefetch`:
        D400: First line should end with a period (not 'd')
torch/distributed/fsdp/_exec_order_utils.py:92 in private method `get_handle_to_backward_prefetch`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/distributed/fsdp/_exec_order_utils.py:113 in private method `get_handle_to_forward_prefetch`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_exec_order_utils.py:113 in private method `get_handle_to_forward_prefetch`:
        D400: First line should end with a period (not 'd')
torch/distributed/fsdp/_exec_order_utils.py:113 in private method `get_handle_to_forward_prefetch`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/distributed/fsdp/_exec_order_utils.py:131 in private method `record_post_forward`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_exec_order_utils.py:131 in private method `record_post_forward`:
        D400: First line should end with a period (not 'd')
torch/distributed/fsdp/_exec_order_utils.py:131 in private method `record_post_forward`:
        D401: First line should be in imperative mood (perhaps 'Record', not 'Records')
torch/distributed/fsdp/_exec_order_utils.py:153 in private method `record_pre_forward`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_exec_order_utils.py:153 in private method `record_pre_forward`:
        D400: First line should end with a period (not 'd')
torch/distributed/fsdp/_exec_order_utils.py:153 in private method `record_pre_forward`:
        D401: First line should be in imperative mood (perhaps 'Record', not 'Records')
torch/distributed/fsdp/_exec_order_utils.py:173 in private method `_check_order`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_exec_order_utils.py:173 in private method `_check_order`:
        D400: First line should end with a period (not 's')
torch/distributed/fsdp/_exec_order_utils.py:173 in private method `_check_order`:
        D401: First line should be in imperative mood (perhaps 'Check', not 'Checks')
torch/distributed/fsdp/_exec_order_utils.py:310 in private method `_get_handle_indices`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_exec_order_utils.py:310 in private method `_get_handle_indices`:
        D400: First line should end with a period (not ')')
torch/distributed/fsdp/_exec_order_utils.py:310 in private method `_get_handle_indices`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/distributed/fsdp/_exec_order_utils.py:324 in private method `_get_names_from_handle_indices`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_exec_order_utils.py:324 in private method `_get_names_from_handle_indices`:
        D400: First line should end with a period (not 'a')
torch/distributed/fsdp/_exec_order_utils.py:324 in private method `_get_names_from_handle_indices`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/distributed/fsdp/_exec_order_utils.py:342 in private method `_get_names_from_handles`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_exec_order_utils.py:342 in private method `_get_names_from_handles`:
        D400: First line should end with a period (not 'e')
torch/distributed/fsdp/_exec_order_utils.py:342 in private method `_get_names_from_handles`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/distributed/fsdp/_exec_order_utils.py:354 in private method `next_iter`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_exec_order_utils.py:354 in private method `next_iter`:
        D400: First line should end with a period (not 'e')
30

After:
torch/distributed/fsdp/_exec_order_utils.py:133 in private method `record_post_forward`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_exec_order_utils.py:133 in private method `record_post_forward`:
        D400: First line should end with a period (not 'd')
torch/distributed/fsdp/_exec_order_utils.py:155 in private method `record_pre_forward`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_exec_order_utils.py:155 in private method `record_pre_forward`:
        D400: First line should end with a period (not 'd')
torch/distributed/fsdp/_exec_order_utils.py:175 in private method `_check_order`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_exec_order_utils.py:175 in private method `_check_order`:
        D400: First line should end with a period (not 's')
torch/distributed/fsdp/_exec_order_utils.py:312 in private method `_get_handle_indices`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_exec_order_utils.py:312 in private method `_get_handle_indices`:
        D400: First line should end with a period (not ')')
8
```

`torch/distributed/fsdp/_limiter_utils.py`
```
Before:
torch/distributed/fsdp/_limiter_utils.py:8 in private class `_FreeEventQueue`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_limiter_utils.py:8 in private class `_FreeEventQueue`:
        D400: First line should end with a period (not 'e')
2

After:
0
```

`torch/distributed/fsdp/_trace_utils.py`
```
Before:
torch/distributed/fsdp/_trace_utils.py:35 in private class `_ParamUsageInfo`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_trace_utils.py:35 in private class `_ParamUsageInfo`:
        D400: First line should end with a period (not 'd')
torch/distributed/fsdp/_trace_utils.py:124 in private method `_patched_call_module`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_trace_utils.py:124 in private method `_patched_call_module`:
        D400: First line should end with a period (not 'o')
torch/distributed/fsdp/_trace_utils.py:124 in private method `_patched_call_module`:
        D401: First line should be in imperative mood (perhaps 'Override', not 'Overrides')
torch/distributed/fsdp/_trace_utils.py:172 in private method `_patched_create_proxy`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_trace_utils.py:172 in private method `_patched_create_proxy`:
        D400: First line should end with a period (not 'o')
torch/distributed/fsdp/_trace_utils.py:172 in private method `_patched_create_proxy`:
        D401: First line should be in imperative mood (perhaps 'Override', not 'Overrides')
8

After:
0
```

`torch/distributed/fsdp/_traversal_utils.py`
```
Before:
torch/distributed/fsdp/_traversal_utils.py:1 at module level:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_traversal_utils.py:1 at module level:
        D400: First line should end with a period (not 'e')
torch/distributed/fsdp/_traversal_utils.py:36 in private function `_composable`:
        D200: One-line docstring should fit on one line with quotes (found 3)
torch/distributed/fsdp/_traversal_utils.py:36 in private function `_composable`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/distributed/fsdp/_traversal_utils.py:52 in private function `_get_fsdp_states_with_modules`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_traversal_utils.py:52 in private function `_get_fsdp_states_with_modules`:
        D400: First line should end with a period (not ':')
torch/distributed/fsdp/_traversal_utils.py:52 in private function `_get_fsdp_states_with_modules`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
torch/distributed/fsdp/_traversal_utils.py:104 in private function `_get_fsdp_handles`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_traversal_utils.py:104 in private function `_get_fsdp_handles`:
        D400: First line should end with a period (not '`')
torch/distributed/fsdp/_traversal_utils.py:104 in private function `_get_fsdp_handles`:
        D401: First line should be in imperative mood (perhaps 'Return', not 'Returns')
10

After:
torch/distributed/fsdp/_traversal_utils.py:1 at module level:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_traversal_utils.py:1 at module level:
        D400: First line should end with a period (not 'e')
torch/distributed/fsdp/_traversal_utils.py:50 in private function `_get_fsdp_states_with_modules`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_traversal_utils.py:50 in private function `_get_fsdp_states_with_modules`:
        D400: First line should end with a period (not ':')
torch/distributed/fsdp/_traversal_utils.py:102 in private function `_get_fsdp_handles`:
        D205: 1 blank line required between summary line and description (found 0)
torch/distributed/fsdp/_traversal_utils.py:102 in private function `_get_fsdp_handles`:
        D400: First line should end with a period (not '`')
6
```



cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225