### PR TITLE
[dynamo] Fix user defined object sourceless callable

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -3611,6 +3611,19 @@ class ReproTests(torch._dynamo.test_case.TestCase):
             same(torch.compile(forward)(torch.tensor([1.0])), torch.tensor([1.0]))
         )
 
+    def test_user_defined_object_callable(self):
+        # https://github.com/pytorch/pytorch/issues/114019
+        class MyCallable:
+            def __call__(self, x):
+                return x + 1
+
+        def fn(x):
+            # Create in graph - will not have source
+            return MyCallable()(x)
+
+        fn_opt = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(fn_opt(torch.zeros(1)), fn(torch.zeros(1)))
+
     def test_numpy_not_ndarray_recompiles(self):
         import torch
 

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -390,7 +390,8 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 tx, partial_args, partial_kwargs
             )
         elif callable(self.value):
-            install_guard(self.source.make_guard(GuardBuilder.FUNCTION_MATCH))
+            if self.source:
+                install_guard(self.source.make_guard(GuardBuilder.FUNCTION_MATCH))
             return self.call_method(tx, "__call__", args, kwargs)
 
         return super().call_function(tx, args, kwargs)


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/114019
We do not need to guard on callable user object defined instantiated in graph


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng