### PR TITLE
Update documentation to mention discrepancy between SDPA and Transformer/MHA mask definition

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -4967,6 +4967,13 @@ Computes scaled dot product attention on query, key and value tensors, using
 an optional attention mask if passed, and applying dropout if a probability
 greater than 0.0 is specified.
 
+.. note::
+
+    For a boolean `attn_mask`, a True value indicates that the corresponding key value 
+    will be **included** for the purpose of attention. This is different from 
+    :class:`~torch.nn.Transformer` and :class:`~torch.nn.MultiheadAttention`,
+    where a True value indicates that the corresponding element is **ignored**.
+    
 .. code-block:: python
 
     # Efficient implementation equivalent to the following:


### PR DESCRIPTION
Currently, `torch.nn.functional._canonical_mask` inverts the mask given input of type `torch.bool`, breaking all of the forward calls in `nn.Transformer`. This function seems to have been introduced in #92733.

Minimum repro example:
```
import torch
from torch.nn import functional as F

mask = torch.eye(2, 2, dtype=torch.bool)
print(mask)
canonincal_mask = F._canonical_mask(mask=mask, mask_name="mask", other_type=None, other_name=None, target_type=torch.float16)
print(canonincal_mask)
```
Output:
```
mask =
tensor([[ True, False],
        [False,  True]])
canonical_mask =
tensor([[-inf, 0.],
        [0., -inf]], dtype=torch.float16)
```

Expected:
```
tensor([[0., -inf],
        [-inf, 0.]], dtype=torch.float16)
```

Request: If someone could either add a test to prevent future regressions like this, or let me know where I could add one, that'd be great, thanks!