### PR TITLE
[DeviceMesh] Make our mesh_dim kwarg naming consistent

### DIFF
--- a/test/distributed/_tensor/test_dtensor.py
+++ b/test/distributed/_tensor/test_dtensor.py
@@ -209,7 +209,7 @@ class DTensorTest(DTensorTestBase):
         shard_placement = Shard(0)
         tensor_list, _ = shard_placement._split_tensor(
             global_tensor,
-            device_mesh.size(dim=0),
+            device_mesh.size(mesh_dim=0),
             with_padding=False,
             contiguous=True,
         )
@@ -235,7 +235,7 @@ class DTensorTest(DTensorTestBase):
         shard_placement = Shard(0)
         tensor_list, _ = shard_placement._split_tensor(
             global_tensor,
-            device_mesh.size(dim=0),
+            device_mesh.size(mesh_dim=0),
             with_padding=False,
             contiguous=True,
         )

--- a/torch/distributed/_device_mesh.py
+++ b/torch/distributed/_device_mesh.py
@@ -354,8 +354,8 @@ class DeviceMesh:
                 )
             return dim_groups
 
-    def size(self, dim: Optional[int] = None) -> int:
-        return self.mesh.numel() if dim is None else self.mesh.size(dim)
+    def size(self, mesh_dim: Optional[int] = None) -> int:
+        return self.mesh.numel() if mesh_dim is None else self.mesh.size(mesh_dim)
 
     @property
     def ndim(self) -> int:

--- a/torch/distributed/_spmd/data_parallel.py
+++ b/torch/distributed/_spmd/data_parallel.py
@@ -598,7 +598,7 @@ def _partition_val(val: Any, spec: DTensorSpec) -> Any:
         for idx, placement in enumerate(spec.placements):
             if placement.is_shard():
                 placement = cast(Shard, placement)
-                num_chunks = spec.mesh.size(dim=idx)
+                num_chunks = spec.mesh.size(mesh_dim=idx)
                 my_coord = spec.mesh.get_coordinate()
                 assert my_coord is not None, "current rank not in mesh!"
                 my_coord_on_mesh_dim = my_coord[idx]

--- a/torch/distributed/_tensor/experimental/tp_transform.py
+++ b/torch/distributed/_tensor/experimental/tp_transform.py
@@ -410,7 +410,7 @@ def _partition_val(val: Any, spec: DTensorSpec) -> Any:
         for idx, placement in enumerate(spec.placements):
             if placement.is_shard():
                 placement = cast(Shard, placement)
-                num_chunks = spec.mesh.size(dim=idx)
+                num_chunks = spec.mesh.size(mesh_dim=idx)
                 my_coord = spec.mesh.get_coordinate()
                 assert my_coord is not None, "current rank not in mesh!"
                 my_coord_on_mesh_dim = my_coord[idx]

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -155,7 +155,7 @@ class Shard(Placement):
         0 on the mesh dimension as source of truth)
         """
         my_coordinate = mesh.get_coordinate()
-        num_chunks = mesh.size(dim=mesh_dim)
+        num_chunks = mesh.size(mesh_dim=mesh_dim)
 
         if my_coordinate is None:
             # if rank is not part of mesh, we simply return an empty tensor
@@ -185,7 +185,7 @@ class Shard(Placement):
         reduce and scatter a tensor on a mesh dimension
         """
         my_coordinate = mesh.get_coordinate()
-        num_chunks = mesh.size(dim=mesh_dim)
+        num_chunks = mesh.size(mesh_dim=mesh_dim)
 
         if my_coordinate is None:
             # if rank is not part of mesh, we simply return local_tensor,
@@ -219,7 +219,7 @@ class Shard(Placement):
         is replicated on the previously sharded mesh dimension
         """
         my_coordinate = mesh.get_coordinate()
-        num_chunks = mesh.size(dim=mesh_dim)
+        num_chunks = mesh.size(mesh_dim=mesh_dim)
 
         if my_coordinate is None:
             # if rank is not part of mesh, we simply return local_tensor,

--- a/torch/distributed/_tensor/redistribute.py
+++ b/torch/distributed/_tensor/redistribute.py
@@ -99,7 +99,7 @@ def redistribute_local_tensor(
 
     for i, (current, target) in sorted_placements:
         my_coordinate = device_mesh.get_coordinate()
-        num_chunks = device_mesh.size(dim=i)
+        num_chunks = device_mesh.size(mesh_dim=i)
 
         if my_coordinate is None:
             # if rank is not part of mesh, we simply return local_tensor,

--- a/torch/distributed/tensor/parallel/_view_with_dim_change.py
+++ b/torch/distributed/tensor/parallel/_view_with_dim_change.py
@@ -80,7 +80,7 @@ class _ViewAndRedistribute(torch.autograd.Function):
                 sharding_dim += self.dim()
 
             device_mesh = self.device_mesh
-            world_size = device_mesh.size(dim=0)
+            world_size = device_mesh.size(mesh_dim=0)
             new_sharding_placement = [Shard(sharding_dim)]
 
             # Fix shape

--- a/torch/distributed/tensor/parallel/fsdp.py
+++ b/torch/distributed/tensor/parallel/fsdp.py
@@ -36,7 +36,7 @@ def _get_box(tensor: DTensor) -> Tuple[torch.Size, torch.Size]:
 
     placement = tensor.placements[0]
     offsets = [0] * len(tensor.size())
-    num_chunks = device_mesh.size(dim=0)
+    num_chunks = device_mesh.size(mesh_dim=0)
 
     if tensor.placements[0].is_shard():
         shard_dim = cast(DShard, placement).dim


### PR DESCRIPTION
Changing `size(self, dim: Optional[int] = None)` to `def size(self, mesh_dim: Optional[int] = None)` so it is consistent with the rest of our APIs.