### PR TITLE
[Quant] Add int8 linear op gelu for quantization PT2E with Inductor. input is an int8 CPU tensor; weight is an int8 MdkldnnCPU tensor

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
+++ b/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
@@ -112,13 +112,15 @@ enum PostOps {
   Relu,
   LeakyRelu,
   Tanh,
+  Gelu,
 };
 
 static std::unordered_map<std::string, PostOps> POST_OP_TABLE = {
   {"none", NoPostOp},
   {"relu", Relu},
   {"leaky_relu", LeakyRelu},
-  {"tanh", Tanh}
+  {"tanh", Tanh},
+  {"gelu", Gelu}
 };
 
 struct PackedLinearWeightsOnednn : public LinearPackedParamsBase {
@@ -316,7 +318,8 @@ namespace onednn_utils {
 
 static ideep::attr_t create_attr_by_post_op(
     const std::string& post_op_name,
-    const torch::List<c10::optional<at::Scalar>>& post_op_args) {
+    const torch::List<c10::optional<at::Scalar>>& post_op_args,
+    const dnnl::algorithm post_algorithm) {
   using ideep::tensor;
   PostOps post_op = POST_OP_TABLE[post_op_name];
   if (post_op == Relu) {
@@ -325,6 +328,8 @@ static ideep::attr_t create_attr_by_post_op(
     return ideep::attr_t::fuse_relu_v2(/*alpha=*/post_op_args[0].value().to<float>());
   } else if (post_op == Tanh) {
     return ideep::attr_t::fuse_tanh();
+  }else if (post_op == Gelu) {
+    return ideep::attr_t::fuse_gelu_v2(0.f, 0.f, post_algorithm);
   }
   return ideep::attr_t();
 }

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -967,7 +967,16 @@ static at::Tensor linear_int8_with_onednn_weight(
   auto bias_desc = with_bias ?
       tensor::desc(onednn_bias.value().get_dims(), ideep::data_type::f32, ideep::format_tag::any) :
       tensor::desc();
-  auto op_attr = onednn_utils::create_attr_by_post_op(post_op_name, post_op_args);
+
+  dnnl::algorithm post_op_algo;
+  if (post_op_algorithm == "None"){
+    post_op_algo = dnnl::algorithm::eltwise_gelu_erf;
+  }
+  if (post_op_algorithm == "tanh"){
+    post_op_algo = dnnl::algorithm::eltwise_gelu_tanh;
+  }
+
+  auto op_attr = onednn_utils::create_attr_by_post_op(post_op_name, post_op_args, post_op_algo);
   if (input_scale != 1.0f) {
     op_attr.set_scales_mask(DNNL_ARG_SRC, 0);
   }

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -4223,6 +4223,82 @@ class TestQuantizedLinear(TestCase):
                     y_s: {y_scale}, y_zp: {y_zp}""",
                 )
 
+    @skipIfNoONEDNN
+    def test_qlinear_pt2e_gelu(self):
+        qlinear_prepack = torch.ops.onednn.qlinear_prepack
+        qlinear = torch.ops.onednn.qlinear_pointwise
+
+        qlinear_prepack_ref = torch.ops.quantized.linear_prepack
+        post_op_algorithm = ['none', 'tanh']
+        in_channels_list = [4, 8]
+        out_channels_list = [16, 32]
+        batch_size = 1
+        use_bias_list = [True, False]
+        supported_post_ops = 'gelu'
+        weight_quant_per_channel_list = [True, False]
+        # fp32_output_list = [True, False]
+        output_dtype_list = [None, torch.float32, torch.bfloat16]
+        x_scale, x_zp = 1.2, 1
+        w_scale, w_zp = 0.8, 0
+        y_scale, y_zp = 4.7, 2
+        post_op_args = []
+        cases = itertools.product(
+            in_channels_list, out_channels_list, use_bias_list,
+            supported_post_ops, weight_quant_per_channel_list, output_dtype_list, post_op_algorithm)
+        with override_quantized_engine('onednn'):
+            for ic, oc, use_bias, post_op, weight_quant_per_channel, output_dtype, post_op_algo in cases:
+                used_y_scale = y_scale
+                used_y_zp = y_zp
+                fp32_out = output_dtype == torch.float32
+                bfloat16_out = output_dtype == torch.bfloat16
+                if fp32_out or bfloat16_out:
+                    used_y_scale, used_y_zp = 1.0, 0
+                x = torch.rand(batch_size, ic) * 10
+                w = torch.rand(oc, ic) * 10
+                qx = torch.quantize_per_tensor(x, x_scale, x_zp, torch.quint8)
+                if weight_quant_per_channel:
+                    w_scales = torch.Tensor([w_scale] * oc)
+                    w_zps = torch.zeros(oc).to(dtype=torch.int)
+                    qw = torch.quantize_per_channel(w, w_scales, w_zps, 0, torch.qint8)
+                else:
+                    w_scales = torch.Tensor([w_scale])
+                    w_zps = torch.Tensor([w_zp]).to(dtype=torch.int)
+                    qw = torch.quantize_per_tensor(w, w_scale, w_zp, torch.qint8)
+                if use_bias:
+                    b = torch.rand(oc) * 10
+                else:
+                    b = None
+
+                # compute with CPU tensors
+                qx_cpu = qx.int_repr()
+                qw_cpu = qw.int_repr()
+                qw_packed = qlinear_prepack(qw_cpu, x.shape)
+                qy_cpu = qlinear(qx_cpu, x_scale, x_zp, qw_packed, w_scales, w_zps,
+                                 b, 1.0 / used_y_scale, used_y_zp, output_dtype, post_op, post_op_args, post_op_algo)
+
+                # Reference
+                qw_packed_ref = qlinear_prepack_ref(qw, b)
+                qlinear_ref = torch.ops.quantized.linear(qx, qw_packed_ref, used_y_scale, used_y_zp)
+                qy_ref = torch.nn.functional.gelu(qlinear_ref, approximate=post_op_algo)
+
+                # Compare results
+                if fp32_out or bfloat16_out:
+                    qy_cpu = torch.quantize_per_tensor(
+                        qy_cpu.to(torch.float32),
+                        used_y_scale,
+                        used_y_zp, dtype=torch.quint8
+                    ).int_repr()
+
+                np.testing.assert_array_almost_equal(
+                    qy_ref.int_repr().cpu().numpy(),
+                    qy_cpu.cpu().numpy(),
+                    decimal=0,
+                    err_msg=f"""X: {x}, W: {w}, b: {b},
+                    x_s: {x_scale}, x_zp: {x_zp},
+                    w_s: {w_scale}, w_zp: {w_zp},
+                    y_s: {y_scale}, y_zp: {y_zp}""",
+                )
+
 @unittest.skipIf(IS_MACOS, "Known test failure on Mac.")
 class TestQuantizedEmbeddingOps(TestCase):
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #114099

**Summary**
Enable Int8 Linear Gelu post operator fusions for Stock PyTorch Inductor. The input is an int8 CPU tensor and weight is an int8 MkldnnCPU tensor.

**Test plan**
python test/test_quantization.py -k test_qlinear_gelu_pt2e

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10