### PR TITLE
[Quant][PT2E] Enable linear and linear-unary post-op gelu quant recipe for x86 inductor quantizer

### DIFF
--- a/torch/ao/quantization/pt2e/prepare.py
+++ b/torch/ao/quantization/pt2e/prepare.py
@@ -346,6 +346,7 @@ def _maybe_insert_input_observers_for_node(
     assert (
         node.target == torch.ops.aten.clone.default or
         node.target == torch.ops.aten.zeros_like.default or
+        node.target == torch.ops.aten.gelu.default or
         len(node.kwargs) == 0
     ), " expecting kwargs for aten op IR to be empty"
 

--- a/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
+++ b/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
@@ -932,6 +932,7 @@ class X86InductorQuantizer(Quantizer):
             torch.nn.ReLU,
             torch.nn.LeakyReLU,
             torch.nn.Tanh,
+            torch.nn.GELU,
         ]
         fused_partitions: List[tuple] = []
         for postop in postop_list:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #114101
* __->__ #114100
* #114099

**Summary**
Add Gelu for linear-unary post-op quantization recipe to x86 inductor quantizer. 

**Test plan**
python -m pytest test/quantization/pt2e/test_x86inductor_quantizer.py -k test_linear_unary_gelu
python test/test_quantization.py -k test_linear_unary_with_quantizer_api