### PR TITLE
[Quant][Inductor] Enable quantization linear pattern fusion for gelu inside inductor

### DIFF
--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -519,6 +519,10 @@ def _register_quantization_unary_fusion():
                 generate_pattern_with_unary(qlinear_pt2e_pattern, aten.relu.default),
                 dtype=original_pattern_output_dtype,
             ),
+            UnaryAttr("gelu", [], ""): generate_pattern_with_output_quant(
+                generate_pattern_with_unary(qlinear_pt2e_pattern, aten.gelu.default),
+                dtype=original_pattern_output_dtype,
+            ),
         }
 
         for unary_attr, patterns in linear_unary_replace_patterns.items():

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -134,6 +134,25 @@ qlinear_pt2e_pattern = CallFunction(
     KeywordArg("postop_algorithm"),
 )
 
+def get_qlinear(users=1):
+    return CallFunction(
+        torch.ops.onednn.qlinear_pointwise.default,
+        KeywordArg("x"),
+        KeywordArg("x_scale"),
+        KeywordArg("x_zp"),
+        KeywordArg("packed_weight"),
+        KeywordArg("w_scale"),
+        KeywordArg("w_zp"),
+        KeywordArg("b"),
+        KeywordArg("output_scale"),
+        KeywordArg("output_zero_point"),
+        KeywordArg("output_dtype"),
+        KeywordArg("postop_name"),
+        KeywordArg("postop_args"),
+        KeywordArg("postop_algorithm"),
+        _users=users,
+    )
+
 dequantize_accum_pattern = CallFunction(
     aten.mul.Tensor,
     CallFunction(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #114101
* #114100
* #114099

**Summary**
Enable QLinear Unary pattern for gelu with int8 

**Test plan**
python test/inductor/test_mkldnn_pattern_matcher.py -k test_qlinear_unary

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler