### PR TITLE
fix(conv_v8): optimize lru cache in conv v8

### DIFF
--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -221,22 +221,8 @@ cudnn_frontend::ExecutionPlan* find(const KeyType& key) {
     return nullptr;
   }
   if (lru_cache_limit) {
-    TORCH_INTERNAL_ASSERT(*(it->second.second) == key, "CUDNN V8 LRU Cache Corrupted (found key mismatches list). Please report a bug to PyTorch.");
-    auto engine_cache_order_size = engine_cache_order.size();
-    auto engine_cache_size = engine_cache.size();
-    TORCH_INTERNAL_ASSERT(engine_cache_order_size == engine_cache_size, "CUDNN V8 LRU Cache Corrupted (found list vs. map size mismatch). Please report a bug to PyTorch.");
     // update most recently accessed
-    auto plan = it->second.first;
-    engine_cache_order.erase(it->second.second);
-    engine_cache_order.push_back(key);
-    engine_cache.erase(key);
-    engine_cache.emplace(key, std::make_pair(plan, --engine_cache_order.end()));
-    // iterator was invalidated by the erase, so we grab it again
-    it = engine_cache.find(key);
-    TORCH_INTERNAL_ASSERT(it->first == *(it->second.second), "CUDNN V8 LRU Cache Corrupted (refresh list vs. map key mismatch). Please report a bug to PyTorch.");
-    TORCH_INTERNAL_ASSERT((long) engine_cache_order.size() <= lru_cache_limit, "CUDNN V8 LRU Cache Corrupted (refresh size exceeds limit: ", lru_cache_limit, " please report a bug to PyTorch.");
-    TORCH_INTERNAL_ASSERT(engine_cache_order.size() == engine_cache_order_size, "CUDNN V8 LRU Cache Corrupted (list size unexpectedly changed). Please report a bug to PyTorch.");
-    TORCH_INTERNAL_ASSERT(engine_cache.size() == engine_cache.size(), "CUDNN V8 LRU Cache Corrupted (cache size unexpectedly changed). Please report a bug to PyTorch.");
+    engine_cache_order.splice(engine_cache_order.begin(), engine_cache_order, it->second.second);
   }
   return &(it->second.first);
 }
@@ -248,24 +234,18 @@ void update(const KeyType& key, T& results) {
   } else if (lru_cache_limit) {
     auto it = engine_cache.find(key);
     if (it == engine_cache.end()) {
-      auto engine_cache_order_size = engine_cache_order.size();
-      auto engine_cache_size = engine_cache.size();
-      TORCH_INTERNAL_ASSERT(engine_cache_order_size == engine_cache_size, "CUDNN V8 LRU Cache Corrupted (list vs. map size mismatch). Please report a bug to PyTorch.");
-      if ((long) engine_cache_order_size >= lru_cache_limit) {
-        // need to perform eviction
-        TORCH_INTERNAL_ASSERT(engine_cache.find(engine_cache_order.front()) != engine_cache.end(), "CUDNN V8 LRU Cache Corrupted (eviction key not in map). Please report a bug to PyTorch.");
-        engine_cache.erase(engine_cache_order.front());
-        engine_cache_order.pop_front();
+      if ((long) engine_cache.size() >= lru_cache_limit) {
+        auto erase_count = engine_cache.erase(engine_cache_order.back());
+        TORCH_INTERNAL_ASSERT(erase_count == 1, "CUDNN V8 LRU Cache Corrupted (eviction key not in map). Please report a bug to PyTorch.");
+        engine_cache_order.pop_back();
       }
+      engine_cache_order.emplace_front(key);
+      engine_cache.emplace(key, std::make_pair(results, engine_cache_order.begin()));
     } else {
-      TORCH_INTERNAL_ASSERT(*(it->second.second) == key, "CUDNN V8 LRU Cache Corrupted (list iterator key mismatch). Please report a bug to PyTorch.");
-      engine_cache_order.erase(it->second.second);
+      it->second.first = results;
+      // update most recently accessed
+      engine_cache_order.splice(engine_cache_order.begin(), engine_cache_order, it->second.second);
     }
-    engine_cache_order.push_back(key);
-    engine_cache.erase(key);
-    engine_cache.emplace(key, std::make_pair(results, --engine_cache_order.end()));
-    TORCH_INTERNAL_ASSERT(engine_cache.find(key)->first == *(engine_cache.find(key)->second.second), "CUDNN V8 LRU Cache Corrupted (updated list vs. map key mismatch). Please report a bug to PyTorch.");
-    TORCH_INTERNAL_ASSERT((long) engine_cache_order.size() <= lru_cache_limit, "CUDNN V8 LRU Cache Corrupted (updated size exceeds limit: ", lru_cache_limit, " please report a bug to PyTorch.");
   } else {
     engine_cache.erase(key);
     engine_cache.emplace(key, std::make_pair(results, engine_cache_order.end())); // dummy iterator


### PR DESCRIPTION
Fixes #108474 

the main issue is due to GCC's dual abi.

https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html
> requires lists to keep track of their size.

seems like in GCC's old abi, std::list::size is linear

other optimization is:
* `splice` instead of erase then push, will save some memory and time.

more perf benchmark is coming...

cc @csarofeen @ptrblck @xwang233