### PR TITLE
Skip privateuse1's checkZeroPoints

### DIFF
--- a/aten/src/ATen/native/quantized/AffineQuantizer.cpp
+++ b/aten/src/ATen/native/quantized/AffineQuantizer.cpp
@@ -159,9 +159,10 @@ Tensor& quantize_tensor_per_channel_affine(
 
   AT_DISPATCH_QINT_TYPES(qtensor.scalar_type(), fn_name, [&]() {
     checkQuantizedTensor<scalar_t>(fn_name, qtensor);
-    if(qtensor.device().type() != c10::DeviceType::CUDA){
+    if (qtensor.device().type() != c10::DeviceType::CUDA &&
+        qtensor.device().type() != c10::DeviceType::PrivateUse1) {
       checkZeroPoints<underlying_t>(fn_name, zero_points);
-    }  // for cuda, this check will occur in the actual cuda function
+    }  // for cuda and privateuse1, this check will occur in the actual device function
   });
 
   TORCH_CHECK(
@@ -251,9 +252,10 @@ Tensor& dequantize_tensor_per_channel_affine(
 
   AT_DISPATCH_QINT_TYPES(qtensor.scalar_type(), fn_name, [&]() {
     checkQuantizedTensor<scalar_t>(fn_name, qtensor);
-    if(qtensor.device().type() != c10::DeviceType::CUDA){
+    if(qtensor.device().type() != c10::DeviceType::CUDA &&
+       qtensor.device().type() != c10::DeviceType::PrivateUse1){
       checkZeroPoints<underlying_t>(fn_name, zero_points);
-    }  // for cuda, this check will occur in the actual cuda function
+    }  // for cuda and privateuse1, this check will occur in the actual device function
   });
 
   TORCH_CHECK(


### PR DESCRIPTION
We want to use ``quantize_per_channel`` to create a quantized tensor, but we found that ``checkZeroPoints`` for ``privateuse1`` backend failed.

``quantize_tensor_per_channel_affine`` will ``checkZeroPoints`` for all backends expect ``CUDA``:
https://github.com/pytorch/pytorch/blob/140c54e6ccc5e97f1b7f1e0fcd3d8c6af7dd2ab2/aten/src/ATen/native/quantized/AffineQuantizer.cpp#L162-L164


However, our ``privateuse1`` backend will get a segmentation error if we try to cast our data to int64_t in ``checkZeroPoints``:
https://github.com/pytorch/pytorch/blob/140c54e6ccc5e97f1b7f1e0fcd3d8c6af7dd2ab2/aten/src/ATen/native/quantized/AffineQuantizer.cpp#L82-L88

So if we can skip ``privateuse1``'s ``checkZeroPoints`` and check this item in the actual device function? What do you think?