### PR TITLE
[BE][easy]: Update ruff to 0.1.6

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -2646,7 +2646,7 @@ init_command = [
     'python3',
     'tools/linter/adapters/pip_init.py',
     '--dry-run={{DRYRUN}}',
-    'ruff==0.1.5',
+    'ruff==0.1.6',
 ]
 is_formatter = true
 


### PR DESCRIPTION
Updates ruff to 0.1.6 for more bugfixes, less false positives / false negatives, and support for more rules.
