### PR TITLE
Boolean masking backwards doesn't work even with dynamic output shape ops, break accordingly

### DIFF
--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -589,13 +589,12 @@ class TensorVariable(VariableTracker):
                     return False
 
             if (
-                not config.capture_dynamic_output_shape_ops
-                and has_bool_key(key)
+                has_bool_key(key)
                 and isinstance(value, TensorVariable)
                 and value.requires_grad
             ):
                 unimplemented(
-                    "boolean masking setitem backwards requires dynamic shapes"
+                    "boolean masking setitem backwards, see https://github.com/pytorch/pytorch/issues/114123"
                 )
             tx.output.create_proxy(
                 "call_function",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #114126

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng