### PR TITLE
[DTensor] Replaced neg dim normalization with assert in helper

### DIFF
--- a/torch/distributed/_tensor/_utils.py
+++ b/torch/distributed/_tensor/_utils.py
@@ -145,8 +145,10 @@ def compute_global_tensor_info(
         if placement.is_shard():
             shard_placement = cast(Shard, placement)
             if shard_placement.dim < 0:
-                # normalize shard dim to be positive
-                shard_placement.dim += len(tensor_shape)
+                raise AssertionError(
+                    "Shard placements should have negative dims normalized in "
+                    f"the user-facing APIs: {shard_placement}"
+                )
             shard_dim = shard_placement.dim
 
             assert (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #114140
* #113915
* __->__ #114141
* #113930
* #113925
* #114134
* #113924
* #113919

This is a replacement for https://github.com/pytorch/pytorch/pull/113922. I think we can still leave the check for negative shard dimension in `compute_local_shape_and_global_offset` and replace the normalization logic with an assert. This should provide us a stack trace to see which user-facing API did not normalize the dim as expected.