### PR TITLE
[torchgen] Add logic in custom ops to return empty tensor

### DIFF
--- a/tools/test/test_executorch_custom_ops.py
+++ b/tools/test/test_executorch_custom_ops.py
@@ -64,11 +64,33 @@ at::Tensor wrapper_CPU_Tensor_foo(const at::Tensor & self) {
         self._test_function_schema_generates_correct_kernel(obj, expected)
 
     def test_function_schema_generates_correct_kernel_no_return(self) -> None:
-        obj = {"func": "custom::foo(Tensor self, *, Tensor(a!)[] out) -> ()"}
+        obj = {"func": "custom::foo.out(Tensor self, *, Tensor(a!)[] out) -> ()"}
         expected = f"""
-void wrapper_CPU__foo_out(const at::Tensor & self, at::TensorList out) {{
+void wrapper_CPU_out_foo_out(const at::Tensor & self, at::TensorList out) {{
 {SPACES}
 }}
+    """
+        self._test_function_schema_generates_correct_kernel(obj, expected)
+
+    def test_function_schema_generates_correct_kernel_3_returns(self) -> None:
+        obj = {
+            "func": "custom::foo(Tensor self, Tensor[] other) -> (Tensor, Tensor, Tensor)"
+        }
+        expected = """
+::std::tuple<at::Tensor,at::Tensor,at::Tensor> wrapper_CPU__foo(const at::Tensor & self, at::TensorList other) {
+    return ::std::tuple<at::Tensor, at::Tensor, at::Tensor>(
+                at::Tensor(), at::Tensor(), at::Tensor()
+            );
+}
+    """
+        self._test_function_schema_generates_correct_kernel(obj, expected)
+
+    def test_function_schema_generates_correct_kernel_1_return_no_out(self) -> None:
+        obj = {"func": "custom::foo(Tensor[] a) -> Tensor"}
+        expected = """
+at::Tensor wrapper_CPU__foo(at::TensorList a) {
+    return at::Tensor();
+}
     """
         self._test_function_schema_generates_correct_kernel(obj, expected)
 


### PR DESCRIPTION
Summary: Add two logic:

1. If the custom op is returning a `Tensor` but also doesn't have an out tensor as input, return an empty tensor.
2. If the custom op is returning more than one Tensor and the number of out tensors is not the same as return Tensor, return a tuple of empty tensors.

Test Plan: Rely on new unit tests

Differential Revision: D51471651


