### PR TITLE
Pin pywavelets to 1.4.1 (scikit-image dependency)

### DIFF
--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -52,7 +52,6 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
 
   # Install PyTorch conda deps, as per https://github.com/pytorch/pytorch README
   CONDA_COMMON_DEPS="astunparse pyyaml mkl=2021.4.0 mkl-include=2021.4.0 setuptools"
-  # For numba issue see https://github.com/pytorch/pytorch/issues/51511
   if [ "$ANACONDA_PYTHON_VERSION" = "3.11" ]; then
     conda_install numpy=1.23.5 ${CONDA_COMMON_DEPS}
   else

--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -54,13 +54,7 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   CONDA_COMMON_DEPS="astunparse pyyaml mkl=2021.4.0 mkl-include=2021.4.0 setuptools"
   # For numba issue see https://github.com/pytorch/pytorch/issues/51511
   if [ "$ANACONDA_PYTHON_VERSION" = "3.11" ]; then
-    conda_install numpy=1.23.5 numba=0.58.0 ${CONDA_COMMON_DEPS}
-  elif [ "$ANACONDA_PYTHON_VERSION" = "3.10" ]; then
-    conda_install numpy=1.21.2 numba=0.55.2 ${CONDA_COMMON_DEPS}
-  elif [ "$ANACONDA_PYTHON_VERSION" = "3.9" ]; then
-    conda_install numpy=1.21.2 numba=0.54.1 ${CONDA_COMMON_DEPS}
-  elif [ "$ANACONDA_PYTHON_VERSION" = "3.8" ]; then
-    conda_install numpy=1.21.2 numba=0.49.0 ${CONDA_COMMON_DEPS}
+    conda_install numpy=1.23.5 ${CONDA_COMMON_DEPS}
   else
     conda_install numpy=1.21.2 ${CONDA_COMMON_DEPS}
   fi

--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -52,8 +52,15 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
 
   # Install PyTorch conda deps, as per https://github.com/pytorch/pytorch README
   CONDA_COMMON_DEPS="astunparse pyyaml mkl=2021.4.0 mkl-include=2021.4.0 setuptools"
+  # For numba issue see https://github.com/pytorch/pytorch/issues/51511
   if [ "$ANACONDA_PYTHON_VERSION" = "3.11" ]; then
-    conda_install numpy=1.23.5 ${CONDA_COMMON_DEPS}
+    conda_install numpy=1.23.5 numba=0.58.0 ${CONDA_COMMON_DEPS}
+  elif [ "$ANACONDA_PYTHON_VERSION" = "3.10" ]; then
+    conda_install numpy=1.21.2 numba=0.55.2 ${CONDA_COMMON_DEPS}
+  elif [ "$ANACONDA_PYTHON_VERSION" = "3.9" ]; then
+    conda_install numpy=1.21.2 numba=0.54.1 ${CONDA_COMMON_DEPS}
+  elif [ "$ANACONDA_PYTHON_VERSION" = "3.8" ]; then
+    conda_install numpy=1.21.2 numba=0.49.0 ${CONDA_COMMON_DEPS}
   else
     conda_install numpy=1.21.2 ${CONDA_COMMON_DEPS}
   fi

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -103,7 +103,7 @@ numba==0.55.2 ; python_version == "3.10"
 
 # This need to match with numba version above
 numpy==1.20.3 ; python_version <= "3.9"
-numpy==1.21.2 ; python_version >= "3.10"
+numpy==1.21.2 ; python_version == "3.10"
 #Description: Provides N-dimensional arrays and linear algebra
 #Pinned versions: 1.20.3, 1.21.2
 #test that import: test_view_ops.py, test_unary_ufuncs.py, test_type_promotion.py,

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -101,9 +101,9 @@ numba==0.55.2 ; python_version == "3.10"
 #test that import: test_numba_integration.py
 #For numba issue see https://github.com/pytorch/pytorch/issues/51511
 
-#numpy
+numpy==1.22.2
 #Description: Provides N-dimensional arrays and linear algebra
-#Pinned versions: 1.20
+#Pinned versions: 1.22.2
 #test that import: test_view_ops.py, test_unary_ufuncs.py, test_type_promotion.py,
 #test_type_info.py, test_torch.py, test_tensorexpr_pybind.py, test_tensorexpr.py,
 #test_tensorboard.py, test_tensor_creation_ops.py, test_static_runtime.py,

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -93,6 +93,14 @@ networkx==2.8.8
 #Pinned versions: 1.10.0.post1
 #test that import: run_test.py, test_cpp_extensions_aot.py,test_determination.py
 
+numba==0.49.0 ; python_version < "3.9"
+numba==0.54.1 ; python_version == "3.9"
+numba==0.55.2 ; python_version == "3.10"
+#Description: Just-In-Time Compiler for Numerical Functions
+#Pinned versions: 0.54.1, 0.49.0, <=0.49.1
+#test that import: test_numba_integration.py
+#For numba issue see https://github.com/pytorch/pytorch/issues/51511
+
 #numpy
 #Description: Provides N-dimensional arrays and linear algebra
 #Pinned versions: 1.20
@@ -284,3 +292,9 @@ tensorboard==2.13.0
 #Description: Also included in .ci/docker/requirements-docs.txt
 #Pinned versions:
 #test that import: test_tensorboard
+
+pywavelets=1.4.1
+#Description: This is a requirement of scikit-image, we need to pin
+# it here because 1.5.0 conflicts with numpy 1.21.2 used in CI
+#Pinned versions: 1.4.1
+#test that import:

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -293,7 +293,7 @@ tensorboard==2.13.0
 #Pinned versions:
 #test that import: test_tensorboard
 
-pywavelets=1.4.1
+pywavelets==1.4.1
 #Description: This is a requirement of scikit-image, we need to pin
 # it here because 1.5.0 conflicts with numpy 1.21.2 used in CI
 #Pinned versions: 1.4.1

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -101,9 +101,11 @@ numba==0.55.2 ; python_version == "3.10"
 #test that import: test_numba_integration.py
 #For numba issue see https://github.com/pytorch/pytorch/issues/51511
 
-numpy==1.22.2
+# This need to match with numba version above
+numpy==1.20.3 ; python_version <= "3.9"
+numpy==1.21.2 ; python_version >= "3.10"
 #Description: Provides N-dimensional arrays and linear algebra
-#Pinned versions: 1.22.2
+#Pinned versions: 1.20.3, 1.21.2
 #test that import: test_view_ops.py, test_unary_ufuncs.py, test_type_promotion.py,
 #test_type_info.py, test_torch.py, test_tensorexpr_pybind.py, test_tensorexpr.py,
 #test_tensorboard.py, test_tensor_creation_ops.py, test_static_runtime.py,

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -93,19 +93,9 @@ networkx==2.8.8
 #Pinned versions: 1.10.0.post1
 #test that import: run_test.py, test_cpp_extensions_aot.py,test_determination.py
 
-numba==0.49.0 ; python_version < "3.9"
-numba==0.54.1 ; python_version == "3.9"
-numba==0.55.2 ; python_version == "3.10"
-#Description: Just-In-Time Compiler for Numerical Functions
-#Pinned versions: 0.54.1, 0.49.0, <=0.49.1
-#test that import: test_numba_integration.py
-#For numba issue see https://github.com/pytorch/pytorch/issues/51511
-
-# This need to match with numba version above
-numpy==1.20.3 ; python_version <= "3.9"
-numpy==1.21.2 ; python_version == "3.10"
+#numpy
 #Description: Provides N-dimensional arrays and linear algebra
-#Pinned versions: 1.20.3, 1.21.2
+#Pinned versions: 1.20
 #test that import: test_view_ops.py, test_unary_ufuncs.py, test_type_promotion.py,
 #test_type_info.py, test_torch.py, test_tensorexpr_pybind.py, test_tensorexpr.py,
 #test_tensorboard.py, test_tensor_creation_ops.py, test_static_runtime.py,


### PR DESCRIPTION
This is to prevent pip from pulling in 1.22.4 and fails Docker image builds, for example, https://github.com/pytorch/pytorch/actions/runs/6923861547/job/18842791777

The new package was released on Nov 17th https://pypi.org/project/PyWavelets/1.5.0/