### PR TITLE
[MPS] Add Conv3D support for MPS

### DIFF
--- a/aten/src/ATen/native/mps/MPSGraphVenturaOps.h
+++ b/aten/src/ATen/native/mps/MPSGraphVenturaOps.h
@@ -1,7 +1,39 @@
 #pragma once
 #include <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
 
+@interface unsupported_MPSGraphConvolution3DOpDescriptor : NSObject<NSCopying>
+
+
+@property (readwrite, nonatomic) NSUInteger strideInX;
+@property (readwrite, nonatomic) NSUInteger strideInY;
+@property (readwrite, nonatomic) NSUInteger strideInZ;
+@property (readwrite, nonatomic) NSUInteger dilationRateInX;
+@property (readwrite, nonatomic) NSUInteger dilationRateInY;
+@property (readwrite, nonatomic) NSUInteger dilationRateInZ;
+
+@property (readwrite, nonatomic) NSUInteger paddingLeft;
+@property (readwrite, nonatomic) NSUInteger paddingRight;
+@property (readwrite, nonatomic) NSUInteger paddingTop;
+@property (readwrite, nonatomic) NSUInteger paddingBottom;
+@property (readwrite, nonatomic) NSUInteger paddingFront;
+@property (readwrite, nonatomic) NSUInteger paddingBack;
+
+@property (readwrite, nonatomic) MPSGraphPaddingStyle paddingStyle;
+@property (readwrite, nonatomic) MPSGraphTensorNamedDataLayout dataLayout;
+@property (readwrite, nonatomic) MPSGraphTensorNamedDataLayout weightsLayout;
+
+@property (readwrite, nonatomic) NSUInteger groups;
+
+@end
+
 // TODO: Remove me when moved to MacOS 13
+#if !defined(__MAC_13_0) && \
+    (!defined(MAC_OS_X_VERSION_13_0) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_13_0))
+
+@compatibility_alias MPSGraphConvolution3DOpDescriptor unsupported_MPSGraphConvolution3DOpDescriptor;
+
+#endif
+
 @interface MPSGraph (VenturaOps)
 
 #if !defined(__MAC_13_0) && \
@@ -16,7 +48,28 @@ typedef NS_ENUM(NSUInteger, MPSGraphResizeNearestRoundingMode)
     MPSGraphResizeNearestRoundingModeRoundToEven       =  4L,
     MPSGraphResizeNearestRoundingModeRoundToOdd        =  5L,
 };
+
+
+
 #endif
+
+- (MPSGraphTensor * _Nonnull) convolution3DWithSourceTensor:(MPSGraphTensor * _Nonnull) source
+                                    weightsTensor:(MPSGraphTensor * _Nonnull) weights
+                                       descriptor:(MPSGraphConvolution3DOpDescriptor * _Nonnull) descriptor
+                                                      name:(NSString * _Nullable) name;
+
+- (MPSGraphTensor * _Nonnull) convolution3DDataGradientWithIncomingGradientTensor:(MPSGraphTensor * _Nonnull) incomingGradient
+                                                          weightsTensor:(MPSGraphTensor * _Nonnull) weights
+                                                            outputShape:(MPSShape * _Nonnull) outputShape
+                                           forwardConvolutionDescriptor:(MPSGraphConvolution3DOpDescriptor * _Nonnull) forwardConvolutionDescriptor
+                                                                   name:(NSString * _Nullable) name;
+
+- (MPSGraphTensor * _Nonnull) convolution3DWeightsGradientWithIncomingGradientTensor:(MPSGraphTensor * _Nonnull) incomingGradient
+                                                            sourceTensor:(MPSGraphTensor * _Nonnull) source
+                                                            outputShape:(MPSShape * _Nonnull) outputShape
+                                           forwardConvolutionDescriptor:(MPSGraphConvolution3DOpDescriptor * _Nonnull) forwardConvolutionDescriptor
+                                                                   name:(NSString * _Nullable) name;
+
 
 - (MPSGraphTensor * _Nonnull)cumulativeSumWithTensor:(MPSGraphTensor * _Nonnull)tensor
                                                 axis:(NSInteger)axis

--- a/aten/src/ATen/native/mps/MPSGraphVenturaOps.h
+++ b/aten/src/ATen/native/mps/MPSGraphVenturaOps.h
@@ -1,38 +1,6 @@
 #pragma once
 #include <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
 
-@interface unsupported_MPSGraphConvolution3DOpDescriptor : NSObject<NSCopying>
-
-
-@property (readwrite, nonatomic) NSUInteger strideInX;
-@property (readwrite, nonatomic) NSUInteger strideInY;
-@property (readwrite, nonatomic) NSUInteger strideInZ;
-@property (readwrite, nonatomic) NSUInteger dilationRateInX;
-@property (readwrite, nonatomic) NSUInteger dilationRateInY;
-@property (readwrite, nonatomic) NSUInteger dilationRateInZ;
-
-@property (readwrite, nonatomic) NSUInteger paddingLeft;
-@property (readwrite, nonatomic) NSUInteger paddingRight;
-@property (readwrite, nonatomic) NSUInteger paddingTop;
-@property (readwrite, nonatomic) NSUInteger paddingBottom;
-@property (readwrite, nonatomic) NSUInteger paddingFront;
-@property (readwrite, nonatomic) NSUInteger paddingBack;
-
-@property (readwrite, nonatomic) MPSGraphPaddingStyle paddingStyle;
-@property (readwrite, nonatomic) MPSGraphTensorNamedDataLayout dataLayout;
-@property (readwrite, nonatomic) MPSGraphTensorNamedDataLayout weightsLayout;
-
-@property (readwrite, nonatomic) NSUInteger groups;
-
-@end
-
-// TODO: Remove me when moved to MacOS 13
-#if !defined(__MAC_13_0) && \
-    (!defined(MAC_OS_X_VERSION_13_0) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_13_0))
-
-@compatibility_alias MPSGraphConvolution3DOpDescriptor unsupported_MPSGraphConvolution3DOpDescriptor;
-
-#endif
 
 @interface MPSGraph (VenturaOps)
 
@@ -53,6 +21,7 @@ typedef NS_ENUM(NSUInteger, MPSGraphResizeNearestRoundingMode)
 
 #endif
 
+#ifdef MAC_OS_VERSION_13_2
 - (MPSGraphTensor * _Nonnull) convolution3DWithSourceTensor:(MPSGraphTensor * _Nonnull) source
                                     weightsTensor:(MPSGraphTensor * _Nonnull) weights
                                        descriptor:(MPSGraphConvolution3DOpDescriptor * _Nonnull) descriptor
@@ -69,7 +38,7 @@ typedef NS_ENUM(NSUInteger, MPSGraphResizeNearestRoundingMode)
                                                             outputShape:(MPSShape * _Nonnull) outputShape
                                            forwardConvolutionDescriptor:(MPSGraphConvolution3DOpDescriptor * _Nonnull) forwardConvolutionDescriptor
                                                                    name:(NSString * _Nullable) name;
-
+#endif
 
 - (MPSGraphTensor * _Nonnull)cumulativeSumWithTensor:(MPSGraphTensor * _Nonnull)tensor
                                                 axis:(NSInteger)axis

--- a/aten/src/ATen/native/mps/MPSGraphVenturaOps.h
+++ b/aten/src/ATen/native/mps/MPSGraphVenturaOps.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
 
-
+// TODO: Remove me when moved to MacOS 13
 @interface MPSGraph (VenturaOps)
 
 #if !defined(__MAC_13_0) && \
@@ -16,28 +16,6 @@ typedef NS_ENUM(NSUInteger, MPSGraphResizeNearestRoundingMode)
     MPSGraphResizeNearestRoundingModeRoundToEven       =  4L,
     MPSGraphResizeNearestRoundingModeRoundToOdd        =  5L,
 };
-
-
-
-#endif
-
-#ifdef MAC_OS_VERSION_13_2
-- (MPSGraphTensor * _Nonnull) convolution3DWithSourceTensor:(MPSGraphTensor * _Nonnull) source
-                                    weightsTensor:(MPSGraphTensor * _Nonnull) weights
-                                       descriptor:(MPSGraphConvolution3DOpDescriptor * _Nonnull) descriptor
-                                                      name:(NSString * _Nullable) name;
-
-- (MPSGraphTensor * _Nonnull) convolution3DDataGradientWithIncomingGradientTensor:(MPSGraphTensor * _Nonnull) incomingGradient
-                                                          weightsTensor:(MPSGraphTensor * _Nonnull) weights
-                                                            outputShape:(MPSShape * _Nonnull) outputShape
-                                           forwardConvolutionDescriptor:(MPSGraphConvolution3DOpDescriptor * _Nonnull) forwardConvolutionDescriptor
-                                                                   name:(NSString * _Nullable) name;
-
-- (MPSGraphTensor * _Nonnull) convolution3DWeightsGradientWithIncomingGradientTensor:(MPSGraphTensor * _Nonnull) incomingGradient
-                                                            sourceTensor:(MPSGraphTensor * _Nonnull) source
-                                                            outputShape:(MPSShape * _Nonnull) outputShape
-                                           forwardConvolutionDescriptor:(MPSGraphConvolution3DOpDescriptor * _Nonnull) forwardConvolutionDescriptor
-                                                                   name:(NSString * _Nullable) name;
 #endif
 
 - (MPSGraphTensor * _Nonnull)cumulativeSumWithTensor:(MPSGraphTensor * _Nonnull)tensor

--- a/aten/src/ATen/native/mps/MPSGraphVenturaOps.h
+++ b/aten/src/ATen/native/mps/MPSGraphVenturaOps.h
@@ -2,6 +2,35 @@
 #include <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
 
 // TODO: Remove me when moved to MacOS 13
+#if !defined(__MAC_13_2) && \
+    (!defined(MAC_OS_X_VERSION_13_2) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_13_2))
+
+@interface MPSGraphConvolution3DOpDescriptor : NSObject<NSCopying>
+
+@property (readwrite, nonatomic) NSUInteger strideInX;
+@property (readwrite, nonatomic) NSUInteger strideInY;
+@property (readwrite, nonatomic) NSUInteger strideInZ;
+@property (readwrite, nonatomic) NSUInteger dilationRateInX;
+@property (readwrite, nonatomic) NSUInteger dilationRateInY;
+@property (readwrite, nonatomic) NSUInteger dilationRateInZ;
+
+@property (readwrite, nonatomic) NSUInteger paddingLeft;
+@property (readwrite, nonatomic) NSUInteger paddingRight;
+@property (readwrite, nonatomic) NSUInteger paddingTop;
+@property (readwrite, nonatomic) NSUInteger paddingBottom;
+@property (readwrite, nonatomic) NSUInteger paddingFront;
+@property (readwrite, nonatomic) NSUInteger paddingBack;
+
+@property (readwrite, nonatomic) MPSGraphPaddingStyle paddingStyle;
+@property (readwrite, nonatomic) MPSGraphTensorNamedDataLayout dataLayout;
+@property (readwrite, nonatomic) MPSGraphTensorNamedDataLayout weightsLayout;
+
+@property (readwrite, nonatomic) NSUInteger groups;
+
+@end
+
+#endif
+
 @interface MPSGraph (VenturaOps)
 
 #if !defined(__MAC_13_0) && \
@@ -17,6 +46,23 @@ typedef NS_ENUM(NSUInteger, MPSGraphResizeNearestRoundingMode)
     MPSGraphResizeNearestRoundingModeRoundToOdd        =  5L,
 };
 #endif
+
+- (MPSGraphTensor * _Nonnull) convolution3DWithSourceTensor:(MPSGraphTensor * _Nonnull) source
+                                            weightsTensor:(MPSGraphTensor * _Nonnull) weights
+                                               descriptor:(MPSGraphConvolution3DOpDescriptor * _Nonnull) descriptor
+                                                     name:(NSString * _Nullable) name;
+
+- (MPSGraphTensor * _Nonnull) convolution3DDataGradientWithIncomingGradientTensor:(MPSGraphTensor * _Nonnull) incomingGradient
+                                                                  weightsTensor:(MPSGraphTensor * _Nonnull) weights
+                                                                    outputShape:(MPSShape * _Nonnull) outputShape
+                                                   forwardConvolutionDescriptor:(MPSGraphConvolution3DOpDescriptor * _Nonnull) forwardConvolutionDescriptor
+                                                                           name:(NSString * _Nullable) name;
+
+- (MPSGraphTensor * _Nonnull) convolution3DWeightsGradientWithIncomingGradientTensor:(MPSGraphTensor * _Nonnull) incomingGradient
+                                                                      sourceTensor:(MPSGraphTensor * _Nonnull) source
+                                                                       outputShape:(MPSShape * _Nonnull) outputShape
+                                                      forwardConvolutionDescriptor:(MPSGraphConvolution3DOpDescriptor * _Nonnull) forwardConvolutionDescriptor
+                                                                              name:(NSString * _Nullable) name;
 
 - (MPSGraphTensor * _Nonnull)cumulativeSumWithTensor:(MPSGraphTensor * _Nonnull)tensor
                                                 axis:(NSInteger)axis

--- a/aten/src/ATen/native/mps/MPSGraphVenturaOps.h
+++ b/aten/src/ATen/native/mps/MPSGraphVenturaOps.h
@@ -5,7 +5,7 @@
 #if !defined(__MAC_13_2) && \
     (!defined(MAC_OS_X_VERSION_13_2) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_13_2))
 
-@interface MPSGraphConvolution3DOpDescriptor : NSObject<NSCopying>
+@interface FakeMPSGraphConvolution3DOpDescriptor : NSObject<NSCopying>
 
 @property (readwrite, nonatomic) NSUInteger strideInX;
 @property (readwrite, nonatomic) NSUInteger strideInY;
@@ -28,6 +28,8 @@
 @property (readwrite, nonatomic) NSUInteger groups;
 
 @end
+
+@compatibility_alias MPSGraphConvolution3DOpDescriptor FakeMPSGraphConvolution3DOpDescriptor;
 
 #endif
 

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -7,17 +7,68 @@
 #include <ATen/ops/mps_convolution_backward_native.h>
 #include <ATen/ops/mps_convolution_transpose_backward_native.h>
 
-namespace at::native {
+#include <ATen/native/mps/MPSGraphVenturaOps.h>
 
+#if !defined(__MAC_13_0) && \
+    (!defined(MAC_OS_X_VERSION_13_0) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_13_0))
+
+@implementation MPSGraphConvolution3DOpDescriptor
+
+- (nonnull id)copyWithZone:(nullable NSZone *)zone {
+    return self;
+}
+
+@end
+
+#endif
+
+namespace at::native {
+//Create 3D convolution descriptor
+static void fill_conv3d_desc(MPSGraphConvolution3DOpDescriptor* descriptor_,
+                      NSUInteger strideInX,
+                      NSUInteger strideInY,
+                      NSUInteger strideInZ,
+                      NSUInteger dilationRateInX,
+                      NSUInteger dilationRateInY,
+                      NSUInteger dilationRateInZ,
+                      NSUInteger paddingHorizontal,
+                      NSUInteger paddingVertical,
+                      NSUInteger paddingDepth,
+                      NSUInteger groups) {
+    descriptor_.strideInX = strideInX;
+    descriptor_.strideInY = strideInY;
+    descriptor_.strideInZ = strideInZ;
+    descriptor_.dilationRateInX = dilationRateInX;
+    descriptor_.dilationRateInY = dilationRateInY;
+    descriptor_.dilationRateInZ = dilationRateInZ;
+    
+    // TODO: Program the padding style
+    descriptor_.paddingStyle = MPSGraphPaddingStyleExplicit;
+    
+    descriptor_.paddingLeft = paddingHorizontal;
+    descriptor_.paddingRight = paddingHorizontal;
+    descriptor_.paddingTop = paddingVertical;
+    descriptor_.paddingBottom = paddingVertical;
+    descriptor_.paddingFront = paddingDepth;
+    descriptor_.paddingBack = paddingDepth;
+    
+    // PyTorch always uses NCDHW memory layout for 3D tensors
+    descriptor_.dataLayout = (MPSGraphTensorNamedDataLayout)7L;//MPSGraphTensorNamedDataLayoutNCDHW;
+    
+    // PyTorch always uses OIDHW memory layout for 3D weights
+    descriptor_.weightsLayout = (MPSGraphTensorNamedDataLayout)9L;//MPSGraphTensorNamedDataLayoutOIDHW;
+    
+    descriptor_.groups = groups; //not yet tested in Xcode/C++
+}
 static void fill_depthwise_conv_desc(MPSGraphDepthwiseConvolution3DOpDescriptor* descriptor_,
-                                     NSUInteger strideInX,
-                                     NSUInteger strideInY,
-                                     NSUInteger dilationRateInX,
-                                     NSUInteger dilationRateInY,
-                                     NSUInteger paddingHorizontal,
-                                     NSUInteger paddingVertical,
-                                     c10::MemoryFormat memory_format,
-                                     NSUInteger groups) {
+                              NSUInteger strideInX,
+                              NSUInteger strideInY,
+                              NSUInteger dilationRateInX,
+                              NSUInteger dilationRateInY,
+                              NSUInteger paddingHorizontal,
+                              NSUInteger paddingVertical,
+                              c10::MemoryFormat memory_format,
+                              NSUInteger groups) {
   descriptor_.strides =
       @[ @1, [[NSNumber alloc] initWithInteger:strideInY], [[NSNumber alloc] initWithInteger:strideInX] ];
   descriptor_.dilationRates =
@@ -67,14 +118,18 @@ static void fill_conv_desc(MPSGraphConvolution2DOpDescriptor* descriptor_,
 }
 
 static Tensor _mps_convolution_impl(const Tensor& input_t,
-                                    const Tensor& weight_t,
-                                    const c10::optional<Tensor>& bias_opt,
-                                    IntArrayRef padding,
-                                    IntArrayRef stride,
-                                    IntArrayRef dilation,
-                                    int64_t groups,
-                                    c10::optional<IntArrayRef> input_shape) {
-  TORCH_CHECK(input_t.dim() < 5, "Conv3D is not supported on MPS");
+                             const Tensor& weight_t,
+                             const c10::optional<Tensor>& bias_opt,
+                             IntArrayRef padding,
+                             IntArrayRef stride,
+                             IntArrayRef dilation,
+                             int64_t groups,
+                             c10::optional<IntArrayRef> input_shape) {
+  const bool is_macOS_13_0_or_newer = is_macos_13_or_newer();
+    
+  TORCH_CHECK(((input_t.dim() < 5)|is_macOS_13_0_or_newer), "Conv3D is only supported on MPS for MacOS_13_2 or newer");
+  bool is3DConv = input_t.dim() == 5;
+
   TORCH_CHECK(isFloatingType(input_t.scalar_type()), "Convolution is supported only for Floating types");
 
   using namespace at::native::mps;
@@ -143,39 +198,60 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
       bias_shape_key = "nobias";
     }
 
-    string key = "mps_convolution:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" + to_string(dilation[0]) +
-        ":" + to_string(dilation[1]) + ":" + to_string(padding[0]) + ":" + to_string(padding[1]) + ":" +
-        to_string(groups) + ":" + mem_format_key + mps::getTensorsStringKey({input_t, weight_t}) + ":" +
-        to_string(bias_defined) + ":" + bias_shape_key;
+      string key;
+      if (is3DConv){
+          key = "mps_3d_convolution:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" + to_string(stride[2]) + ":" + to_string(dilation[0]) + ":" + to_string(dilation[1]) +
+          ":" + to_string(dilation[2]) + ":" + to_string(padding[0]) + ":" + to_string(padding[1]) + ":" + to_string(padding[2]) + ":" +
+          to_string(groups) + ":" + mem_format_key + mps::getTensorsStringKey({input_t, weight_t}) + ":" +
+          to_string(bias_defined) + ":" + bias_shape_key;
+          
+      } else {
+          key = "mps_convolution:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" + to_string(dilation[0]) +
+          ":" + to_string(dilation[1]) + ":" + to_string(padding[0]) + ":" + to_string(padding[1]) + ":" +
+          to_string(groups) + ":" + mem_format_key + mps::getTensorsStringKey({input_t, weight_t}) + ":" +
+          to_string(bias_defined) + ":" + bias_shape_key;
+      }
     MPSShape* inputShape = mps::getMPSShape(input_t, memory_format);
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
       MPSGraphConvolution2DOpDescriptor* conv2dDescriptor_ = [[MPSGraphConvolution2DOpDescriptor new] autorelease];
       MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
           [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
+      MPSGraphConvolution3DOpDescriptor* conv3dDescriptor_ =
+            [[MPSGraphConvolution3DOpDescriptor new] autorelease];
+
       MPSShape* weightShape = mps::getMPSShape(weight_t);
       bool isDepthwiseConv = ((groups > 1 && (weightShape[1].intValue == 1)) && inputShape.count >= 4 &&
                               weightShape.count >= 4 && !is_channels_last);
-      if (isDepthwiseConv) {
-        fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
-                                 stride[1],
-                                 stride[0],
-                                 dilation[1],
-                                 dilation[0],
-                                 padding[1],
-                                 padding[0],
-                                 memory_format,
-                                 groups);
-      } else {
-        fill_conv_desc(conv2dDescriptor_,
-                       stride[1],
-                       stride[0],
-                       dilation[1],
-                       dilation[0],
-                       padding[1],
-                       padding[0],
-                       memory_format,
-                       groups);
-      }
+        if (is3DConv){
+            fill_conv3d_desc(conv3dDescriptor_,
+                             stride[2],stride[1],stride[0],
+                             dilation[2],dilation[1],dilation[0],
+                             padding[2],padding[1],padding[0],
+                             groups);
+            
+        } else {
+            if (isDepthwiseConv) {
+                fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
+                                         stride[1],
+                                         stride[0],
+                                         dilation[1],
+                                         dilation[0],
+                                         padding[1],
+                                         padding[0],
+                                         memory_format,
+                                         groups);
+            } else {
+                fill_conv_desc(conv2dDescriptor_,
+                               stride[1],
+                               stride[0],
+                               dilation[1],
+                               dilation[0],
+                               padding[1],
+                               padding[0],
+                               memory_format,
+                               groups);
+            }
+        }
 
       MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(input_t), inputShape);
       MPSGraphTensor* weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, weight_t);
@@ -186,21 +262,30 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
       }
 
       MPSGraphTensor* outputTensor;
-      if (isDepthwiseConv) {
-        MPSGraphTensor* weightTransposeTensor = [mpsGraph transposeTensor:weightTensor
-                                                                dimension:-3
-                                                            withDimension:-4
-                                                                     name:nil];
-        outputTensor = [mpsGraph depthwiseConvolution3DWithSourceTensor:inputTensor
-                                                          weightsTensor:weightTransposeTensor
-                                                             descriptor:depthWiseConv3dDescriptor_
-                                                                   name:nil];
-      } else {
-        outputTensor = [mpsGraph convolution2DWithSourceTensor:inputTensor
-                                                 weightsTensor:weightTensor
-                                                    descriptor:conv2dDescriptor_
-                                                          name:nil];
-      }
+        if(is3DConv){
+            outputTensor = [mpsGraph convolution3DWithSourceTensor:inputTensor
+                                                     weightsTensor:weightTensor
+                                                        descriptor:conv3dDescriptor_
+                                                              name:nil];
+            
+        } else {
+            
+            if (isDepthwiseConv) {
+                MPSGraphTensor* weightTransposeTensor = [mpsGraph transposeTensor:weightTensor
+                                                                        dimension:-3
+                                                                    withDimension:-4
+                                                                             name:nil];
+                outputTensor = [mpsGraph depthwiseConvolution3DWithSourceTensor:inputTensor
+                                                                  weightsTensor:weightTransposeTensor
+                                                                     descriptor:depthWiseConv3dDescriptor_
+                                                                           name:nil];
+            } else {
+                outputTensor = [mpsGraph convolution2DWithSourceTensor:inputTensor
+                                                         weightsTensor:weightTensor
+                                                            descriptor:conv2dDescriptor_
+                                                                  name:nil];
+            }
+        }
 
       if (is_channels_last) {
         outputTensor = mps::convertNHWCtoNCHW(mpsGraph, outputTensor);
@@ -218,9 +303,14 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
     auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t, inputShape);
     auto weightsPlaceholder = Placeholder(cachedGraph->weightTensor_, weight_t);
     auto biasPlaceholder = Placeholder();
-    // Reshape the bias to be broadcastable with output of conv2d
-    if (bias_defined)
-      biasPlaceholder = Placeholder(cachedGraph->biasTensor_, (bias_opt.value()).view({1, bias_shape[0], 1, 1}));
+    // Reshape the bias to be broadcastable with output of conv2d or conv3d
+      if (bias_defined){
+          if (is3DConv) {
+              biasPlaceholder = Placeholder(cachedGraph->biasTensor_, (bias_opt.value()).view({1, bias_shape[0], 1, 1, 1}));
+          } else {
+              biasPlaceholder = Placeholder(cachedGraph->biasTensor_, (bias_opt.value()).view({1, bias_shape[0], 1, 1}));
+          }
+      }
     auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, *output);
 
     NSMutableDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds =
@@ -260,6 +350,8 @@ static Tensor mps_convolution_backward_input(IntArrayRef input_size,
                                              bool bias_defined) {
   using namespace at::native::mps;
   using namespace mps;
+  bool is3DConv = grad_output_t.dim() == 5;
+
   TORCH_CHECK(isFloatingType(grad_output_t.scalar_type()), "Convolution is supported only for Floating types");
   CheckedFrom c = "mps_convolution_backward_input";
   TensorArg grad_output{grad_output_t, "grad_output", 1}, weight{weight_t, "weight", 2};
@@ -300,42 +392,59 @@ static Tensor mps_convolution_backward_input(IntArrayRef input_size,
     MPSShape* gradOutputShape = getMPSShape(grad_output_t, memory_format);
     MPSShape* mps_input_shape = getMPSShape(input_size);
     NSString* ns_shape_key = [[gradOutputShape valueForKey:@"description"] componentsJoinedByString:@","];
-    string key = "mps_convolution_backward_input:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" +
-        to_string(dilation[0]) + ":" + to_string(dilation[1]) + ":" + to_string(padding[0]) + ":" +
-        to_string(padding[1]) + ":" + to_string(groups) + ":" + mem_format_key +
-        getTensorsStringKey({grad_output_t, weight_t}) + ":" + string([ns_shape_key UTF8String]);
-
+      string key;
+      if(is3DConv){
+          key = "mps_3d_convolution_backward_input:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" +  ":" + to_string(stride[2]) +
+          to_string(dilation[0]) + ":" + to_string(dilation[1]) + ":" + to_string(dilation[2]) + ":" + to_string(padding[0]) + ":" +
+          to_string(padding[1]) + ":" + to_string(padding[2]) + ":" + to_string(groups) + ":" + mem_format_key +
+          getTensorsStringKey({grad_output_t, weight_t}) + ":" + string([ns_shape_key UTF8String]);
+          
+      } else {
+          key = "mps_convolution_backward_input:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" +
+          to_string(dilation[0]) + ":" + to_string(dilation[1]) + ":" + to_string(padding[0]) + ":" +
+          to_string(padding[1]) + ":" + to_string(groups) + ":" + mem_format_key +
+          getTensorsStringKey({grad_output_t, weight_t}) + ":" + string([ns_shape_key UTF8String]);
+      }
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
       MPSGraphConvolution2DOpDescriptor* conv2dDescriptor_ = [[MPSGraphConvolution2DOpDescriptor new] autorelease];
       MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
           [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
+        MPSGraphConvolution3DOpDescriptor* conv3dDescriptor_ = [[MPSGraphConvolution3DOpDescriptor new] autorelease];
 
       MPSShape* weightOutputShape = mps::getMPSShape(weight_t);
       // Depthwise conv is input feature channels = groups. So I in OIHW has to be 1.
       bool isDepthwiseConv = ((groups > 1 && (weightOutputShape[1].intValue == 1)) && gradOutputShape.count >= 4 &&
                               weightOutputShape.count >= 4 && !is_channels_last);
 
-      if (isDepthwiseConv) {
-        fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
-                                 stride[1],
-                                 stride[0],
-                                 dilation[1],
-                                 dilation[0],
-                                 padding[1],
-                                 padding[0],
-                                 at::MemoryFormat::Contiguous,
-                                 groups);
-      } else {
-        fill_conv_desc(conv2dDescriptor_,
-                       stride[1],
-                       stride[0],
-                       dilation[1],
-                       dilation[0],
-                       padding[1],
-                       padding[0],
-                       at::MemoryFormat::Contiguous,
-                       groups);
-      }
+        if(is3DConv) {
+            fill_conv3d_desc(conv3dDescriptor_,
+                             stride[2],stride[1],stride[0],
+                             dilation[2],dilation[1],dilation[0],
+                             padding[2],padding[1],padding[0],
+                             groups);
+        } else {
+            if (isDepthwiseConv) {
+                fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
+                                         stride[1],
+                                         stride[0],
+                                         dilation[1],
+                                         dilation[0],
+                                         padding[1],
+                                         padding[0],
+                                         at::MemoryFormat::Contiguous,
+                                         groups);
+            } else {
+                fill_conv_desc(conv2dDescriptor_,
+                               stride[1],
+                               stride[0],
+                               dilation[1],
+                               dilation[0],
+                               padding[1],
+                               padding[0],
+                               at::MemoryFormat::Contiguous,
+                               groups);
+            }
+        }
 
       MPSGraphTensor* gradOutputTensor =
           mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(grad_output_t), gradOutputShape);
@@ -346,24 +455,33 @@ static Tensor mps_convolution_backward_input(IntArrayRef input_size,
         gradOutputTensorTranspose = mps::convertNHWCtoNCHW(mpsGraph, gradOutputTensorTranspose);
       }
       MPSGraphTensor* gradInputTensor;
-      if (isDepthwiseConv) {
-        MPSGraphTensor* weightTransposeTensor = [mpsGraph transposeTensor:weightTensor
-                                                                dimension:-3
-                                                            withDimension:-4
-                                                                     name:nil];
-        gradInputTensor =
-            [mpsGraph depthwiseConvolution3DDataGradientWithIncomingGradientTensor:gradOutputTensorTranspose
-                                                                     weightsTensor:weightTransposeTensor
-                                                                       outputShape:mps_input_shape
-                                                                        descriptor:depthWiseConv3dDescriptor_
-                                                                              name:nil];
-      } else {
-        gradInputTensor = [mpsGraph convolution2DDataGradientWithIncomingGradientTensor:gradOutputTensorTranspose
-                                                                          weightsTensor:weightTensor
-                                                                            outputShape:mps_input_shape
-                                                           forwardConvolutionDescriptor:conv2dDescriptor_
-                                                                                   name:nil];
-      }
+        if (is3DConv){
+            gradInputTensor = [mpsGraph convolution3DDataGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+                                                                              weightsTensor:weightTensor
+                                                                                outputShape:mps_input_shape
+                                                               forwardConvolutionDescriptor:conv3dDescriptor_
+                                                                                       name:nil];
+            
+        } else {
+            if (isDepthwiseConv) {
+                MPSGraphTensor* weightTransposeTensor = [mpsGraph transposeTensor:weightTensor
+                                                                        dimension:-3
+                                                                    withDimension:-4
+                                                                             name:nil];
+                gradInputTensor =
+                [mpsGraph depthwiseConvolution3DDataGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+                                                                         weightsTensor:weightTransposeTensor
+                                                                           outputShape:mps_input_shape
+                                                                            descriptor:depthWiseConv3dDescriptor_
+                                                                                  name:nil];
+            } else {
+                gradInputTensor = [mpsGraph convolution2DDataGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+                                                                                  weightsTensor:weightTensor
+                                                                                    outputShape:mps_input_shape
+                                                                   forwardConvolutionDescriptor:conv2dDescriptor_
+                                                                                           name:nil];
+            }
+        }
 
       newCachedGraph->gradOutputTensor_ = gradOutputTensor;
       newCachedGraph->weightTensor_ = weightTensor;
@@ -397,6 +515,7 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
                                                bool bias_defined) {
   using namespace at::native::mps;
   using namespace mps;
+  bool is3DConv = input_t.dim() == 5;
   TORCH_CHECK(isFloatingType(grad_output_t.scalar_type()), "Convolution is supported only for Floating types");
   CheckedFrom c = "mps_convolution_backward_weights";
   auto memory_format = grad_output_t.suggest_memory_format();
@@ -442,40 +561,56 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
     }
     MPSShape* mps_weight_shape = getMPSShape(weight_size);
     NSString* ns_shape_key = [[gradOutputShape valueForKey:@"description"] componentsJoinedByString:@","];
-    string key = "mps_convolution_backward_weights:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" +
+    string key;
+    if (is3DConv) {
+        key = "mps_3d_convolution_backward_weights:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" + to_string(stride[2]) + ":" +
+        to_string(dilation[0]) + ":" + to_string(dilation[1]) + ":" + to_string(dilation[2]) + ":" + to_string(padding[0]) + ":" +
+        to_string(padding[1]) + ":" + to_string(padding[2]) + ":" + to_string(groups) + ":" + mem_format_key +
+        getTensorsStringKey({grad_output_t, input_t}) + ":" + string([ns_shape_key UTF8String]);
+    } else {
+        key = "mps_convolution_backward_weights:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" +
         to_string(dilation[0]) + ":" + to_string(dilation[1]) + ":" + to_string(padding[0]) + ":" +
         to_string(padding[1]) + ":" + to_string(groups) + ":" + mem_format_key +
-        getTensorsStringKey({grad_output_t, input_t, grad_weight_t}) + ":" + string([ns_shape_key UTF8String]);
-
+        getTensorsStringKey({grad_output_t, input_t}) + ":" + string([ns_shape_key UTF8String]);
+    }
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
       MPSGraphConvolution2DOpDescriptor* conv2dDescriptor_ = [[MPSGraphConvolution2DOpDescriptor new] autorelease];
       MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
           [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
+        MPSGraphConvolution3DOpDescriptor* conv3dDescriptor_ = [[MPSGraphConvolution3DOpDescriptor new] autorelease];
+
       MPSShape* inputShape = mps::getMPSShape(input_t);
       bool isDepthwiseConv = ((groups > 1 && (mps_weight_shape[1].intValue == 1)) && inputShape.count >= 4 &&
                               mps_weight_shape.count >= 4 && !is_channels_last);
-
-      if (isDepthwiseConv) {
-        fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
-                                 stride[1],
-                                 stride[0],
-                                 dilation[1],
-                                 dilation[0],
-                                 padding[1],
-                                 padding[0],
-                                 at::MemoryFormat::Contiguous,
-                                 groups);
-      } else {
-        fill_conv_desc(conv2dDescriptor_,
-                       stride[1],
-                       stride[0],
-                       dilation[1],
-                       dilation[0],
-                       padding[1],
-                       padding[0],
-                       at::MemoryFormat::Contiguous,
-                       groups);
-      }
+        if (is3DConv) {
+            fill_conv3d_desc(conv3dDescriptor_,
+                             stride[2],stride[1],stride[0],
+                             dilation[2],dilation[1],dilation[0],
+                             padding[2],padding[1],padding[0],
+                             groups);
+        } else {
+            if (isDepthwiseConv) {
+                fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
+                                         stride[1],
+                                         stride[0],
+                                         dilation[1],
+                                         dilation[0],
+                                         padding[1],
+                                         padding[0],
+                                         at::MemoryFormat::Contiguous,
+                                         groups);
+            } else {
+                fill_conv_desc(conv2dDescriptor_,
+                               stride[1],
+                               stride[0],
+                               dilation[1],
+                               dilation[0],
+                               padding[1],
+                               padding[0],
+                               at::MemoryFormat::Contiguous,
+                               groups);
+            }
+        }
 
       MPSGraphTensor* gradOutputTensor =
           mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(grad_output_t), gradOutputShape);
@@ -487,23 +622,33 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
       }
 
       MPSGraphTensor* gradWeightTensor;
-      if (isDepthwiseConv) {
-        NSNumber* outputFeatChannelDim = mps_weight_shape[0];
-        MPSShape* weightShapeTranspose = @[ @1, outputFeatChannelDim, mps_weight_shape[2], mps_weight_shape[3] ];
-        MPSGraphTensor* gradWeightTensorTranspose =
-            [mpsGraph depthwiseConvolution3DWeightsGradientWithIncomingGradientTensor:gradOutputTensorTranspose
-                                                                         sourceTensor:inputTensor
-                                                                          outputShape:weightShapeTranspose
-                                                                           descriptor:depthWiseConv3dDescriptor_
-                                                                                 name:nil];
-        gradWeightTensor = [mpsGraph transposeTensor:gradWeightTensorTranspose dimension:-3 withDimension:-4 name:nil];
-      } else {
-        gradWeightTensor = [mpsGraph convolution2DWeightsGradientWithIncomingGradientTensor:gradOutputTensorTranspose
-                                                                               sourceTensor:inputTensor
-                                                                                outputShape:mps_weight_shape
-                                                               forwardConvolutionDescriptor:conv2dDescriptor_
-                                                                                       name:nil];
-      }
+        
+        if (is3DConv) {
+            gradWeightTensor =
+            [mpsGraph convolution3DWeightsGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+                                                                sourceTensor:inputTensor
+                                                                 outputShape:mps_weight_shape
+                                                forwardConvolutionDescriptor:conv3dDescriptor_
+                                                                        name:nil];
+        } else {
+            if (isDepthwiseConv) {
+                NSNumber* outputFeatChannelDim = mps_weight_shape[0];
+                MPSShape* weightShapeTranspose = @[ @1, outputFeatChannelDim, mps_weight_shape[2], mps_weight_shape[3] ];
+                MPSGraphTensor* gradWeightTensorTranspose =
+                [mpsGraph depthwiseConvolution3DWeightsGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+                                                                             sourceTensor:inputTensor
+                                                                              outputShape:weightShapeTranspose
+                                                                               descriptor:depthWiseConv3dDescriptor_
+                                                                                     name:nil];
+                gradWeightTensor = [mpsGraph transposeTensor:gradWeightTensorTranspose dimension:-3 withDimension:-4 name:nil];
+            } else {
+                gradWeightTensor = [mpsGraph convolution2DWeightsGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+                                                                                       sourceTensor:inputTensor
+                                                                                        outputShape:mps_weight_shape
+                                                                       forwardConvolutionDescriptor:conv2dDescriptor_
+                                                                                               name:nil];
+            }
+        }
       newCachedGraph->gradOutputTensor_ = gradOutputTensor;
       newCachedGraph->inputTensor_ = inputTensor;
       newCachedGraph->gradWeightTensor_ = gradWeightTensor;

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -548,12 +548,12 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
         key = "mps_3d_convolution_backward_weights:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" + to_string(stride[2]) + ":" +
         to_string(dilation[0]) + ":" + to_string(dilation[1]) + ":" + to_string(dilation[2]) + ":" + to_string(padding[0]) + ":" +
         to_string(padding[1]) + ":" + to_string(padding[2]) + ":" + to_string(groups) + ":" + mem_format_key +
-        getTensorsStringKey({grad_output_t, input_t}) + ":" + string([ns_shape_key UTF8String]);
+        getTensorsStringKey({grad_output_t, input_t, grad_weight_t}) + ":" + string([ns_shape_key UTF8String]);
     } else {
         key = "mps_convolution_backward_weights:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" +
         to_string(dilation[0]) + ":" + to_string(dilation[1]) + ":" + to_string(padding[0]) + ":" +
         to_string(padding[1]) + ":" + to_string(groups) + ":" + mem_format_key +
-        getTensorsStringKey({grad_output_t, input_t}) + ":" + string([ns_shape_key UTF8String]);
+        getTensorsStringKey({grad_output_t, input_t, grad_weight_t}) + ":" + string([ns_shape_key UTF8String]);
     }
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
 

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -12,53 +12,53 @@ namespace at::native {
 #ifdef MAC_OS_VERSION_13_2
 // Create 3D convolution descriptor
 static void fill_conv3d_desc(MPSGraphConvolution3DOpDescriptor* descriptor_,
-                      NSUInteger strideInX,
-                      NSUInteger strideInY,
-                      NSUInteger strideInZ,
-                      NSUInteger dilationRateInX,
-                      NSUInteger dilationRateInY,
-                      NSUInteger dilationRateInZ,
-                      NSUInteger paddingHorizontal,
-                      NSUInteger paddingVertical,
-                      NSUInteger paddingDepth,
-                      NSUInteger groups) {
-    descriptor_.strideInX = strideInX;
-    descriptor_.strideInY = strideInY;
-    descriptor_.strideInZ = strideInZ;
-    descriptor_.dilationRateInX = dilationRateInX;
-    descriptor_.dilationRateInY = dilationRateInY;
-    descriptor_.dilationRateInZ = dilationRateInZ;
+                             NSUInteger strideInX,
+                             NSUInteger strideInY,
+                             NSUInteger strideInZ,
+                             NSUInteger dilationRateInX,
+                             NSUInteger dilationRateInY,
+                             NSUInteger dilationRateInZ,
+                             NSUInteger paddingHorizontal,
+                             NSUInteger paddingVertical,
+                             NSUInteger paddingDepth,
+                             NSUInteger groups) {
+  descriptor_.strideInX = strideInX;
+  descriptor_.strideInY = strideInY;
+  descriptor_.strideInZ = strideInZ;
+  descriptor_.dilationRateInX = dilationRateInX;
+  descriptor_.dilationRateInY = dilationRateInY;
+  descriptor_.dilationRateInZ = dilationRateInZ;
 
-    // TODO: Program the padding style
-    descriptor_.paddingStyle = MPSGraphPaddingStyleExplicit;
+  // TODO: Program the padding style
+  descriptor_.paddingStyle = MPSGraphPaddingStyleExplicit;
 
-    descriptor_.paddingLeft = paddingHorizontal;
-    descriptor_.paddingRight = paddingHorizontal;
-    descriptor_.paddingTop = paddingVertical;
-    descriptor_.paddingBottom = paddingVertical;
-    descriptor_.paddingFront = paddingDepth;
-    descriptor_.paddingBack = paddingDepth;
+  descriptor_.paddingLeft = paddingHorizontal;
+  descriptor_.paddingRight = paddingHorizontal;
+  descriptor_.paddingTop = paddingVertical;
+  descriptor_.paddingBottom = paddingVertical;
+  descriptor_.paddingFront = paddingDepth;
+  descriptor_.paddingBack = paddingDepth;
 
-    // PyTorch always uses NCDHW memory layout for 3D tensors
-    descriptor_.dataLayout = (MPSGraphTensorNamedDataLayout)7L;//MPSGraphTensorNamedDataLayoutNCDHW;
+  // PyTorch always uses NCDHW memory layout for 3D tensors
+  descriptor_.dataLayout = (MPSGraphTensorNamedDataLayout)7L; // MPSGraphTensorNamedDataLayoutNCDHW;
 
-    // PyTorch always uses OIDHW memory layout for 3D weights
-    descriptor_.weightsLayout = (MPSGraphTensorNamedDataLayout)9L;//MPSGraphTensorNamedDataLayoutOIDHW;
+  // PyTorch always uses OIDHW memory layout for 3D weights
+  descriptor_.weightsLayout = (MPSGraphTensorNamedDataLayout)9L; // MPSGraphTensorNamedDataLayoutOIDHW;
 
-    descriptor_.groups = groups; //not yet tested in Xcode/C++
+  descriptor_.groups = groups; // not yet tested in Xcode/C++
 }
 
 #endif
 
 static void fill_depthwise_conv_desc(MPSGraphDepthwiseConvolution3DOpDescriptor* descriptor_,
-                              NSUInteger strideInX,
-                              NSUInteger strideInY,
-                              NSUInteger dilationRateInX,
-                              NSUInteger dilationRateInY,
-                              NSUInteger paddingHorizontal,
-                              NSUInteger paddingVertical,
-                              c10::MemoryFormat memory_format,
-                              NSUInteger groups) {
+                                     NSUInteger strideInX,
+                                     NSUInteger strideInY,
+                                     NSUInteger dilationRateInX,
+                                     NSUInteger dilationRateInY,
+                                     NSUInteger paddingHorizontal,
+                                     NSUInteger paddingVertical,
+                                     c10::MemoryFormat memory_format,
+                                     NSUInteger groups) {
   descriptor_.strides =
       @[ @1, [[NSNumber alloc] initWithInteger:strideInY], [[NSNumber alloc] initWithInteger:strideInX] ];
   descriptor_.dilationRates =
@@ -75,7 +75,6 @@ static void fill_depthwise_conv_desc(MPSGraphDepthwiseConvolution3DOpDescriptor*
   ];
   descriptor_.channelDimensionIndex = -3LL;
 }
-
 
 // Create convolution descriptor
 static void fill_conv_desc(MPSGraphConvolution2DOpDescriptor* descriptor_,
@@ -109,16 +108,17 @@ static void fill_conv_desc(MPSGraphConvolution2DOpDescriptor* descriptor_,
 }
 
 static Tensor _mps_convolution_impl(const Tensor& input_t,
-                             const Tensor& weight_t,
-                             const c10::optional<Tensor>& bias_opt,
-                             IntArrayRef padding,
-                             IntArrayRef stride,
-                             IntArrayRef dilation,
-                             int64_t groups,
-                             c10::optional<IntArrayRef> input_shape) {
+                                    const Tensor& weight_t,
+                                    const c10::optional<Tensor>& bias_opt,
+                                    IntArrayRef padding,
+                                    IntArrayRef stride,
+                                    IntArrayRef dilation,
+                                    int64_t groups,
+                                    c10::optional<IntArrayRef> input_shape) {
   const bool is_macOS_13_0_or_newer = is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_2_PLUS);
-    
-  TORCH_CHECK(( (input_t.dim() < 5) || is_macOS_13_0_or_newer), "Conv3D is only supported on MPS for MacOS_13_2 or newer");
+
+  TORCH_CHECK(((input_t.dim() < 5) || is_macOS_13_0_or_newer),
+              "Conv3D is only supported on MPS for MacOS_13_2 or newer");
   bool is3DConv = input_t.dim() == 5;
 
   TORCH_CHECK(isFloatingType(input_t.scalar_type()), "Convolution is supported only for Floating types");
@@ -189,23 +189,23 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
       bias_shape_key = "nobias";
     }
 
-      string key;
-      if (is3DConv){
-          key = "mps_3d_convolution:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" + to_string(stride[2]) + ":" + to_string(dilation[0]) + ":" + to_string(dilation[1]) +
-          ":" + to_string(dilation[2]) + ":" + to_string(padding[0]) + ":" + to_string(padding[1]) + ":" + to_string(padding[2]) + ":" +
-          to_string(groups) + ":" + mem_format_key + mps::getTensorsStringKey({input_t, weight_t}) + ":" +
-          to_string(bias_defined) + ":" + bias_shape_key;
-          
-      } else {
-          key = "mps_convolution:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" + to_string(dilation[0]) +
+    string key;
+    if (is3DConv) {
+      key = "mps_3d_convolution:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" + to_string(stride[2]) +
+          ":" + to_string(dilation[0]) + ":" + to_string(dilation[1]) + ":" + to_string(dilation[2]) + ":" +
+          to_string(padding[0]) + ":" + to_string(padding[1]) + ":" + to_string(padding[2]) + ":" + to_string(groups) +
+          ":" + mem_format_key + mps::getTensorsStringKey({input_t, weight_t}) + ":" + to_string(bias_defined) + ":" +
+          bias_shape_key;
+
+    } else {
+      key = "mps_convolution:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" + to_string(dilation[0]) +
           ":" + to_string(dilation[1]) + ":" + to_string(padding[0]) + ":" + to_string(padding[1]) + ":" +
           to_string(groups) + ":" + mem_format_key + mps::getTensorsStringKey({input_t, weight_t}) + ":" +
           to_string(bias_defined) + ":" + bias_shape_key;
-      }
+    }
 
     MPSShape* inputShape = mps::getMPSShape(input_t, memory_format);
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-
       MPSShape* weightShape = mps::getMPSShape(weight_t);
       bool isDepthwiseConv = ((groups > 1 && (weightShape[1].intValue == 1)) && inputShape.count >= 4 &&
                               weightShape.count >= 4 && !is_channels_last);
@@ -213,66 +213,69 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
       MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(input_t), inputShape);
       MPSGraphTensor* weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, weight_t);
       MPSGraphTensor* outputTensor;
-        if (is3DConv){
+      if (is3DConv) {
 #ifdef MAC_OS_VERSION_13_2
-          MPSGraphConvolution3DOpDescriptor* conv3dDescriptor_ =
-              [[MPSGraphConvolution3DOpDescriptor new] autorelease];
-            fill_conv3d_desc(conv3dDescriptor_,
-                             stride[2],stride[1],stride[0],
-                             dilation[2],dilation[1],dilation[0],
-                             padding[2],padding[1],padding[0],
-                             groups);
+        MPSGraphConvolution3DOpDescriptor* conv3dDescriptor_ = [[MPSGraphConvolution3DOpDescriptor new] autorelease];
+        fill_conv3d_desc(conv3dDescriptor_,
+                         stride[2],
+                         stride[1],
+                         stride[0],
+                         dilation[2],
+                         dilation[1],
+                         dilation[0],
+                         padding[2],
+                         padding[1],
+                         padding[0],
+                         groups);
 
-            outputTensor = [mpsGraph convolution3DWithSourceTensor:inputTensor
-                                                     weightsTensor:weightTensor
-                                                        descriptor:conv3dDescriptor_
-                                                              name:nil];
+        outputTensor = [mpsGraph convolution3DWithSourceTensor:inputTensor
+                                                 weightsTensor:weightTensor
+                                                    descriptor:conv3dDescriptor_
+                                                          name:nil];
 #endif
-        } else  if (isDepthwiseConv) {
-            MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
-                [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
-                fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
-                                         stride[1],
-                                         stride[0],
-                                         dilation[1],
-                                         dilation[0],
-                                         padding[1],
-                                         padding[0],
-                                         memory_format,
-                                         groups);
+      } else if (isDepthwiseConv) {
+        MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
+            [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
+        fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
+                                 stride[1],
+                                 stride[0],
+                                 dilation[1],
+                                 dilation[0],
+                                 padding[1],
+                                 padding[0],
+                                 memory_format,
+                                 groups);
 
-                MPSGraphTensor* weightTransposeTensor = [mpsGraph transposeTensor:weightTensor
-                                                                        dimension:-3
-                                                                    withDimension:-4
-                                                                             name:nil];
-                outputTensor = [mpsGraph depthwiseConvolution3DWithSourceTensor:inputTensor
-                                                                  weightsTensor:weightTransposeTensor
-                                                                     descriptor:depthWiseConv3dDescriptor_
-                                                                           name:nil];
-            } else {
-                MPSGraphConvolution2DOpDescriptor* conv2dDescriptor_ = [[MPSGraphConvolution2DOpDescriptor new] autorelease];
-                fill_conv_desc(
-                    conv2dDescriptor_,
-                    stride[1],
-                    stride[0],
-                    dilation[1],
-                    dilation[0],
-                    padding[1],
-                    padding[0],
-                    memory_format,
-                    groups);
+        MPSGraphTensor* weightTransposeTensor = [mpsGraph transposeTensor:weightTensor
+                                                                dimension:-3
+                                                            withDimension:-4
+                                                                     name:nil];
+        outputTensor = [mpsGraph depthwiseConvolution3DWithSourceTensor:inputTensor
+                                                          weightsTensor:weightTransposeTensor
+                                                             descriptor:depthWiseConv3dDescriptor_
+                                                                   name:nil];
+      } else {
+        MPSGraphConvolution2DOpDescriptor* conv2dDescriptor_ = [[MPSGraphConvolution2DOpDescriptor new] autorelease];
+        fill_conv_desc(conv2dDescriptor_,
+                       stride[1],
+                       stride[0],
+                       dilation[1],
+                       dilation[0],
+                       padding[1],
+                       padding[0],
+                       memory_format,
+                       groups);
 
-                outputTensor = [mpsGraph convolution2DWithSourceTensor:inputTensor
-                                                         weightsTensor:weightTensor
-                                                            descriptor:conv2dDescriptor_
-                                                                  name:nil];
-        }
+        outputTensor = [mpsGraph convolution2DWithSourceTensor:inputTensor
+                                                 weightsTensor:weightTensor
+                                                    descriptor:conv2dDescriptor_
+                                                          name:nil];
+      }
 
       MPSGraphTensor* biasTensor = nil;
       if (bias_defined) {
         biasTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(bias_opt.value()));
       }
-
 
       if (is_channels_last) {
         outputTensor = mps::convertNHWCtoNCHW(mpsGraph, outputTensor);
@@ -291,13 +294,13 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
     auto weightsPlaceholder = Placeholder(cachedGraph->weightTensor_, weight_t);
     auto biasPlaceholder = Placeholder();
     // Reshape the bias to be broadcastable with output of conv2d or conv3d
-      if (bias_defined){
-          if (is3DConv) {
-              biasPlaceholder = Placeholder(cachedGraph->biasTensor_, (bias_opt.value()).view({1, bias_shape[0], 1, 1, 1}));
-          } else {
-              biasPlaceholder = Placeholder(cachedGraph->biasTensor_, (bias_opt.value()).view({1, bias_shape[0], 1, 1}));
-          }
+    if (bias_defined) {
+      if (is3DConv) {
+        biasPlaceholder = Placeholder(cachedGraph->biasTensor_, (bias_opt.value()).view({1, bias_shape[0], 1, 1, 1}));
+      } else {
+        biasPlaceholder = Placeholder(cachedGraph->biasTensor_, (bias_opt.value()).view({1, bias_shape[0], 1, 1}));
       }
+    }
     auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, *output);
 
     NSMutableDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds =
@@ -379,89 +382,95 @@ static Tensor mps_convolution_backward_input(IntArrayRef input_size,
     MPSShape* gradOutputShape = getMPSShape(grad_output_t, memory_format);
     MPSShape* mps_input_shape = getMPSShape(input_size);
     NSString* ns_shape_key = [[gradOutputShape valueForKey:@"description"] componentsJoinedByString:@","];
-      string key;
-      if(is3DConv){
-          key = "mps_3d_convolution_backward_input:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" +  ":" + to_string(stride[2]) +
-          to_string(dilation[0]) + ":" + to_string(dilation[1]) + ":" + to_string(dilation[2]) + ":" + to_string(padding[0]) + ":" +
-          to_string(padding[1]) + ":" + to_string(padding[2]) + ":" + to_string(groups) + ":" + mem_format_key +
-          getTensorsStringKey({grad_output_t, weight_t}) + ":" + string([ns_shape_key UTF8String]);
-          
-      } else {
-          key = "mps_convolution_backward_input:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" +
+    string key;
+    if (is3DConv) {
+      key = "mps_3d_convolution_backward_input:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" + ":" +
+          to_string(stride[2]) + to_string(dilation[0]) + ":" + to_string(dilation[1]) + ":" + to_string(dilation[2]) +
+          ":" + to_string(padding[0]) + ":" + to_string(padding[1]) + ":" + to_string(padding[2]) + ":" +
+          to_string(groups) + ":" + mem_format_key + getTensorsStringKey({grad_output_t, weight_t}) + ":" +
+          string([ns_shape_key UTF8String]);
+
+    } else {
+      key = "mps_convolution_backward_input:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" +
           to_string(dilation[0]) + ":" + to_string(dilation[1]) + ":" + to_string(padding[0]) + ":" +
           to_string(padding[1]) + ":" + to_string(groups) + ":" + mem_format_key +
           getTensorsStringKey({grad_output_t, weight_t}) + ":" + string([ns_shape_key UTF8String]);
-      }
+    }
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-        MPSGraphTensor* gradOutputTensor =
-            mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(grad_output_t), gradOutputShape);
-        MPSGraphTensor* weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, weight_t);
+      MPSGraphTensor* gradOutputTensor =
+          mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(grad_output_t), gradOutputShape);
+      MPSGraphTensor* weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, weight_t);
 
-        MPSGraphTensor* gradOutputTensorTranspose = gradOutputTensor;
-        if (is_channels_last) {
-          gradOutputTensorTranspose = mps::convertNHWCtoNCHW(mpsGraph, gradOutputTensorTranspose);
-        }
-        MPSGraphTensor* gradInputTensor;
+      MPSGraphTensor* gradOutputTensorTranspose = gradOutputTensor;
+      if (is_channels_last) {
+        gradOutputTensorTranspose = mps::convertNHWCtoNCHW(mpsGraph, gradOutputTensorTranspose);
+      }
+      MPSGraphTensor* gradInputTensor;
       MPSShape* weightOutputShape = mps::getMPSShape(weight_t);
       // Depthwise conv is input feature channels = groups. So I in OIHW has to be 1.
       bool isDepthwiseConv = ((groups > 1 && (weightOutputShape[1].intValue == 1)) && gradOutputShape.count >= 4 &&
                               weightOutputShape.count >= 4 && !is_channels_last);
 
-        if(is3DConv) {
+      if (is3DConv) {
 #ifdef MAC_OS_VERSION_13_2
-          MPSGraphConvolution3DOpDescriptor* conv3dDescriptor_ = [[MPSGraphConvolution3DOpDescriptor new] autorelease];
-            fill_conv3d_desc(conv3dDescriptor_,
-                             stride[2],stride[1],stride[0],
-                             dilation[2],dilation[1],dilation[0],
-                             padding[2],padding[1],padding[0],
-                             groups);
-            gradInputTensor = [mpsGraph convolution3DDataGradientWithIncomingGradientTensor:gradOutputTensorTranspose
-                                                                              weightsTensor:weightTensor
-                                                                                outputShape:mps_input_shape
-                                                               forwardConvolutionDescriptor:conv3dDescriptor_
-                                                                                       name:nil];
+        MPSGraphConvolution3DOpDescriptor* conv3dDescriptor_ = [[MPSGraphConvolution3DOpDescriptor new] autorelease];
+        fill_conv3d_desc(conv3dDescriptor_,
+                         stride[2],
+                         stride[1],
+                         stride[0],
+                         dilation[2],
+                         dilation[1],
+                         dilation[0],
+                         padding[2],
+                         padding[1],
+                         padding[0],
+                         groups);
+        gradInputTensor = [mpsGraph convolution3DDataGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+                                                                          weightsTensor:weightTensor
+                                                                            outputShape:mps_input_shape
+                                                           forwardConvolutionDescriptor:conv3dDescriptor_
+                                                                                   name:nil];
 #endif
-        } else if (isDepthwiseConv) {
-            MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
-                [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
-                fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
-                                         stride[1],
-                                         stride[0],
-                                         dilation[1],
-                                         dilation[0],
-                                         padding[1],
-                                         padding[0],
-                                         at::MemoryFormat::Contiguous,
-                                         groups);
-                MPSGraphTensor* weightTransposeTensor = [mpsGraph transposeTensor:weightTensor
-                                                                        dimension:-3
-                                                                    withDimension:-4
-                                                                             name:nil];
-                gradInputTensor =
-                    [mpsGraph depthwiseConvolution3DDataGradientWithIncomingGradientTensor:gradOutputTensorTranspose
-                                                                             weightsTensor:weightTransposeTensor
-                                                                               outputShape:mps_input_shape
-                                                                                descriptor:depthWiseConv3dDescriptor_
-                                                                                      name:nil];
-            } else {
-                MPSGraphConvolution2DOpDescriptor* conv2dDescriptor_ = [[MPSGraphConvolution2DOpDescriptor new] autorelease];
-                fill_conv_desc(conv2dDescriptor_,
-                               stride[1],
-                               stride[0],
-                               dilation[1],
-                               dilation[0],
-                               padding[1],
-                               padding[0],
-                               at::MemoryFormat::Contiguous,
-                               groups);
+      } else if (isDepthwiseConv) {
+        MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
+            [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
+        fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
+                                 stride[1],
+                                 stride[0],
+                                 dilation[1],
+                                 dilation[0],
+                                 padding[1],
+                                 padding[0],
+                                 at::MemoryFormat::Contiguous,
+                                 groups);
+        MPSGraphTensor* weightTransposeTensor = [mpsGraph transposeTensor:weightTensor
+                                                                dimension:-3
+                                                            withDimension:-4
+                                                                     name:nil];
+        gradInputTensor =
+            [mpsGraph depthwiseConvolution3DDataGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+                                                                     weightsTensor:weightTransposeTensor
+                                                                       outputShape:mps_input_shape
+                                                                        descriptor:depthWiseConv3dDescriptor_
+                                                                              name:nil];
+      } else {
+        MPSGraphConvolution2DOpDescriptor* conv2dDescriptor_ = [[MPSGraphConvolution2DOpDescriptor new] autorelease];
+        fill_conv_desc(conv2dDescriptor_,
+                       stride[1],
+                       stride[0],
+                       dilation[1],
+                       dilation[0],
+                       padding[1],
+                       padding[0],
+                       at::MemoryFormat::Contiguous,
+                       groups);
 
-                gradInputTensor = [mpsGraph convolution2DDataGradientWithIncomingGradientTensor:gradOutputTensorTranspose
-                                                                                  weightsTensor:weightTensor
-                                                                                    outputShape:mps_input_shape
-                                                                   forwardConvolutionDescriptor:conv2dDescriptor_
-                                                                                           name:nil];
-        }
-
+        gradInputTensor = [mpsGraph convolution2DDataGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+                                                                          weightsTensor:weightTensor
+                                                                            outputShape:mps_input_shape
+                                                           forwardConvolutionDescriptor:conv2dDescriptor_
+                                                                                   name:nil];
+      }
 
       newCachedGraph->gradOutputTensor_ = gradOutputTensor;
       newCachedGraph->weightTensor_ = weightTensor;
@@ -543,19 +552,18 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
     NSString* ns_shape_key = [[gradOutputShape valueForKey:@"description"] componentsJoinedByString:@","];
     string key;
     if (is3DConv) {
-        key = "mps_3d_convolution_backward_weights:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" + to_string(stride[2]) + ":" +
-        to_string(dilation[0]) + ":" + to_string(dilation[1]) + ":" + to_string(dilation[2]) + ":" + to_string(padding[0]) + ":" +
-        to_string(padding[1]) + ":" + to_string(padding[2]) + ":" + to_string(groups) + ":" + mem_format_key +
-        getTensorsStringKey({grad_output_t, input_t, grad_weight_t}) + ":" + string([ns_shape_key UTF8String]);
+      key = "mps_3d_convolution_backward_weights:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" +
+          to_string(stride[2]) + ":" + to_string(dilation[0]) + ":" + to_string(dilation[1]) + ":" +
+          to_string(dilation[2]) + ":" + to_string(padding[0]) + ":" + to_string(padding[1]) + ":" +
+          to_string(padding[2]) + ":" + to_string(groups) + ":" + mem_format_key +
+          getTensorsStringKey({grad_output_t, input_t, grad_weight_t}) + ":" + string([ns_shape_key UTF8String]);
     } else {
-        key = "mps_convolution_backward_weights:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" +
-        to_string(dilation[0]) + ":" + to_string(dilation[1]) + ":" + to_string(padding[0]) + ":" +
-        to_string(padding[1]) + ":" + to_string(groups) + ":" + mem_format_key +
-        getTensorsStringKey({grad_output_t, input_t, grad_weight_t}) + ":" + string([ns_shape_key UTF8String]);
+      key = "mps_convolution_backward_weights:" + to_string(stride[0]) + ":" + to_string(stride[1]) + ":" +
+          to_string(dilation[0]) + ":" + to_string(dilation[1]) + ":" + to_string(padding[0]) + ":" +
+          to_string(padding[1]) + ":" + to_string(groups) + ":" + mem_format_key +
+          getTensorsStringKey({grad_output_t, input_t, grad_weight_t}) + ":" + string([ns_shape_key UTF8String]);
     }
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-
-
       MPSShape* inputShape = mps::getMPSShape(input_t);
       bool isDepthwiseConv = ((groups > 1 && (mps_weight_shape[1].intValue == 1)) && inputShape.count >= 4 &&
                               mps_weight_shape.count >= 4 && !is_channels_last);
@@ -570,61 +578,65 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
       }
 
       MPSGraphTensor* gradWeightTensor;
-        if (is3DConv) {
+      if (is3DConv) {
 #ifdef MAC_OS_VERSION_13_2
         MPSGraphConvolution3DOpDescriptor* conv3dDescriptor_ = [[MPSGraphConvolution3DOpDescriptor new] autorelease];
-            fill_conv3d_desc(conv3dDescriptor_,
-                             stride[2],stride[1],stride[0],
-                             dilation[2],dilation[1],dilation[0],
-                             padding[2],padding[1],padding[0],
-                             groups);
-            gradWeightTensor =
-                [mpsGraph convolution3DWeightsGradientWithIncomingGradientTensor:gradOutputTensorTranspose
-                                                                    sourceTensor:inputTensor
-                                                                     outputShape:mps_weight_shape
-                                                    forwardConvolutionDescriptor:conv3dDescriptor_
-                                                                            name:nil];
+        fill_conv3d_desc(conv3dDescriptor_,
+                         stride[2],
+                         stride[1],
+                         stride[0],
+                         dilation[2],
+                         dilation[1],
+                         dilation[0],
+                         padding[2],
+                         padding[1],
+                         padding[0],
+                         groups);
+        gradWeightTensor = [mpsGraph convolution3DWeightsGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+                                                                               sourceTensor:inputTensor
+                                                                                outputShape:mps_weight_shape
+                                                               forwardConvolutionDescriptor:conv3dDescriptor_
+                                                                                       name:nil];
 #endif
-        } else if (isDepthwiseConv) {
-            MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
-                [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
-                fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
-                                         stride[1],
-                                         stride[0],
-                                         dilation[1],
-                                         dilation[0],
-                                         padding[1],
-                                         padding[0],
-                                         at::MemoryFormat::Contiguous,
-                                         groups);
-                NSNumber* outputFeatChannelDim = mps_weight_shape[0];
-                MPSShape* weightShapeTranspose = @[ @1, outputFeatChannelDim, mps_weight_shape[2], mps_weight_shape[3] ];
-                MPSGraphTensor* gradWeightTensorTranspose =
-                    [mpsGraph depthwiseConvolution3DWeightsGradientWithIncomingGradientTensor:gradOutputTensorTranspose
-                                                                                 sourceTensor:inputTensor
-                                                                                  outputShape:weightShapeTranspose
-                                                                                   descriptor:depthWiseConv3dDescriptor_
-                                                                                         name:nil];
-                gradWeightTensor = [mpsGraph transposeTensor:gradWeightTensorTranspose dimension:-3 withDimension:-4 name:nil];
-            } else {
-                MPSGraphConvolution2DOpDescriptor* conv2dDescriptor_ = [[MPSGraphConvolution2DOpDescriptor new] autorelease];
-                fill_conv_desc(conv2dDescriptor_,
-                               stride[1],
-                               stride[0],
-                               dilation[1],
-                               dilation[0],
-                               padding[1],
-                               padding[0],
-                               at::MemoryFormat::Contiguous,
-                               groups);
+      } else if (isDepthwiseConv) {
+        MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
+            [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
+        fill_depthwise_conv_desc(depthWiseConv3dDescriptor_,
+                                 stride[1],
+                                 stride[0],
+                                 dilation[1],
+                                 dilation[0],
+                                 padding[1],
+                                 padding[0],
+                                 at::MemoryFormat::Contiguous,
+                                 groups);
+        NSNumber* outputFeatChannelDim = mps_weight_shape[0];
+        MPSShape* weightShapeTranspose = @[ @1, outputFeatChannelDim, mps_weight_shape[2], mps_weight_shape[3] ];
+        MPSGraphTensor* gradWeightTensorTranspose =
+            [mpsGraph depthwiseConvolution3DWeightsGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+                                                                         sourceTensor:inputTensor
+                                                                          outputShape:weightShapeTranspose
+                                                                           descriptor:depthWiseConv3dDescriptor_
+                                                                                 name:nil];
+        gradWeightTensor = [mpsGraph transposeTensor:gradWeightTensorTranspose dimension:-3 withDimension:-4 name:nil];
+      } else {
+        MPSGraphConvolution2DOpDescriptor* conv2dDescriptor_ = [[MPSGraphConvolution2DOpDescriptor new] autorelease];
+        fill_conv_desc(conv2dDescriptor_,
+                       stride[1],
+                       stride[0],
+                       dilation[1],
+                       dilation[0],
+                       padding[1],
+                       padding[0],
+                       at::MemoryFormat::Contiguous,
+                       groups);
 
-                gradWeightTensor = [mpsGraph convolution2DWeightsGradientWithIncomingGradientTensor:gradOutputTensorTranspose
-                                                                                       sourceTensor:inputTensor
-                                                                                        outputShape:mps_weight_shape
-                                                                       forwardConvolutionDescriptor:conv2dDescriptor_
-                                                                                               name:nil];
-
-        }
+        gradWeightTensor = [mpsGraph convolution2DWeightsGradientWithIncomingGradientTensor:gradOutputTensorTranspose
+                                                                               sourceTensor:inputTensor
+                                                                                outputShape:mps_weight_shape
+                                                               forwardConvolutionDescriptor:conv2dDescriptor_
+                                                                                       name:nil];
+      }
 
       newCachedGraph->gradOutputTensor_ = gradOutputTensor;
       newCachedGraph->inputTensor_ = inputTensor;

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -9,7 +9,6 @@
 
 namespace at::native {
 
-#ifdef MAC_OS_VERSION_13_2
 // Create 3D convolution descriptor
 static void fill_conv3d_desc(MPSGraphConvolution3DOpDescriptor* descriptor_,
                              NSUInteger strideInX,
@@ -47,8 +46,6 @@ static void fill_conv3d_desc(MPSGraphConvolution3DOpDescriptor* descriptor_,
 
   descriptor_.groups = groups; // not yet tested in Xcode/C++
 }
-
-#endif
 
 static void fill_depthwise_conv_desc(MPSGraphDepthwiseConvolution3DOpDescriptor* descriptor_,
                                      NSUInteger strideInX,
@@ -115,9 +112,9 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
                                     IntArrayRef dilation,
                                     int64_t groups,
                                     c10::optional<IntArrayRef> input_shape) {
-  const bool is_macOS_13_0_or_newer = is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_2_PLUS);
+  const bool is_macOS_13_2_or_newer = is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_2_PLUS);
 
-  TORCH_CHECK(((input_t.dim() < 5) || is_macOS_13_0_or_newer),
+  TORCH_CHECK(((input_t.dim() < 5) || is_macOS_13_2_or_newer),
               "Conv3D is only supported on MPS for MacOS_13_2 or newer");
   bool is3DConv = input_t.dim() == 5;
 
@@ -214,7 +211,6 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
       MPSGraphTensor* weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, weight_t);
       MPSGraphTensor* outputTensor;
       if (is3DConv) {
-#ifdef MAC_OS_VERSION_13_2
         MPSGraphConvolution3DOpDescriptor* conv3dDescriptor_ = [[MPSGraphConvolution3DOpDescriptor new] autorelease];
         fill_conv3d_desc(conv3dDescriptor_,
                          stride[2],
@@ -232,7 +228,6 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
                                                  weightsTensor:weightTensor
                                                     descriptor:conv3dDescriptor_
                                                           name:nil];
-#endif
       } else if (isDepthwiseConv) {
         MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
             [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
@@ -412,7 +407,6 @@ static Tensor mps_convolution_backward_input(IntArrayRef input_size,
                               weightOutputShape.count >= 4 && !is_channels_last);
 
       if (is3DConv) {
-#ifdef MAC_OS_VERSION_13_2
         MPSGraphConvolution3DOpDescriptor* conv3dDescriptor_ = [[MPSGraphConvolution3DOpDescriptor new] autorelease];
         fill_conv3d_desc(conv3dDescriptor_,
                          stride[2],
@@ -430,7 +424,6 @@ static Tensor mps_convolution_backward_input(IntArrayRef input_size,
                                                                             outputShape:mps_input_shape
                                                            forwardConvolutionDescriptor:conv3dDescriptor_
                                                                                    name:nil];
-#endif
       } else if (isDepthwiseConv) {
         MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
             [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
@@ -579,7 +572,6 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
 
       MPSGraphTensor* gradWeightTensor;
       if (is3DConv) {
-#ifdef MAC_OS_VERSION_13_2
         MPSGraphConvolution3DOpDescriptor* conv3dDescriptor_ = [[MPSGraphConvolution3DOpDescriptor new] autorelease];
         fill_conv3d_desc(conv3dDescriptor_,
                          stride[2],
@@ -597,7 +589,6 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
                                                                                 outputShape:mps_weight_shape
                                                                forwardConvolutionDescriptor:conv3dDescriptor_
                                                                                        name:nil];
-#endif
       } else if (isDepthwiseConv) {
         MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
             [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -9,7 +9,7 @@
 
 namespace at::native {
 
-#if MAC_OS_VERSION_13_2
+#ifdef MAC_OS_VERSION_13_2
 // Create 3D convolution descriptor
 static void fill_conv3d_desc(MPSGraphConvolution3DOpDescriptor* descriptor_,
                       NSUInteger strideInX,
@@ -116,9 +116,9 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
                              IntArrayRef dilation,
                              int64_t groups,
                              c10::optional<IntArrayRef> input_shape) {
-  const bool is_macOS_13_0_or_newer = is_macos_13_or_newer();
+  const bool is_macOS_13_0_or_newer = is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_2_PLUS);
     
-  TORCH_CHECK(((input_t.dim() < 5)|is_macOS_13_0_or_newer), "Conv3D is only supported on MPS for MacOS_13_2 or newer");
+  TORCH_CHECK(( (input_t.dim() < 5) || is_macOS_13_0_or_newer), "Conv3D is only supported on MPS for MacOS_13_2 or newer");
   bool is3DConv = input_t.dim() == 5;
 
   TORCH_CHECK(isFloatingType(input_t.scalar_type()), "Convolution is supported only for Floating types");

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -1,11 +1,23 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/native/ConvUtils.h>
+#include <ATen/native/mps/MPSGraphVenturaOps.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/ops/_mps_convolution_native.h>
 #include <ATen/ops/_mps_convolution_transpose_native.h>
 #include <ATen/ops/mps_convolution_backward_native.h>
 #include <ATen/ops/mps_convolution_transpose_backward_native.h>
+
+#if !defined(__MAC_13_2) && (!defined(MAC_OS_X_VERSION_13_2) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_13_2))
+
+@implementation MPSGraphConvolution3DOpDescriptor
+- (nonnull id)copyWithZone:(nullable NSZone*)zone {
+  return self;
+}
+
+@end
+
+#endif
 
 namespace at::native {
 

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -10,7 +10,7 @@
 
 #if !defined(__MAC_13_2) && (!defined(MAC_OS_X_VERSION_13_2) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_13_2))
 
-@implementation MPSGraphConvolution3DOpDescriptor
+@implementation FakeMPSGraphConvolution3DOpDescriptor
 - (nonnull id)copyWithZone:(nullable NSZone*)zone {
   return self;
 }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2672,7 +2672,7 @@ class TestMPS(TestCaseMPS):
         helper(3, layer='conv')
         helper(-1, layer='conv')
 
-        if float('.'.join(platform.mac_ver()[0].split('.')[:2])) > 13:
+        if product_version >= 13.2:
             # Conv3d is only available from MacOS 13 onwards
             helper(0, layer='conv3d')
             helper(1, layer='conv3d')
@@ -8376,10 +8376,9 @@ class TestNNMPS(NNTestCase):
         # This used to crash with MPSNDArrayConvolutionA14.mm:4352: failed assertion
         y2.sum().backward()
 
+    @unittest.skipIf(product_version < 13.2, "Skipped on macOS 12")
     def test_conv3d_backward_collision(self):
-        # Conv3D is only available from MacOS 13 onwards
-        if float('.'.join(platform.mac_ver()[0].split('.')[:2])) < 13:
-            return
+        # Conv3D is only available from MacOS 13.2 onwards
         x = torch.rand(1, 1, 10, 10, 20, device="mps", requires_grad=True)
         m1 = nn.Conv3d(1, 1, 3, stride=2, padding=1).to("mps")
         m2 = nn.Conv3d(1, 1, 4, stride=2, padding=1).to("mps")
@@ -9611,11 +9610,9 @@ class TestConvolutionMPS(TestCaseMPS):
             x_gpu = conv_gpu(y_gpu)
             self.assertEqual(x_cpu, x_gpu.cpu(), rtol=1e-03, atol=1e-05)
 
+    @unittest.skipIf(product_version < 13.2, "Skipped on macOS 12")
     def test_conv3d_single_stride(self):
-        # Conv3d is only available from MacOS 13 onwards
-        if float('.'.join(platform.mac_ver()[0].split('.')[:2])) < 13:
-            return
-
+        # Conv3d is only available from MacOS 13.2 onwards
         y_cpu = torch.randn(2, 2, 3, 6)
         y_gpu = y_cpu.to(device='mps')
         for stride in range(1, 4):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -44,7 +44,6 @@ import numpy as np
 import torch
 import torch.utils._pytree as pytree
 from itertools import product
-import platform
 
 test_consistency_op_db = copy.deepcopy(op_db)
 test_error_inputs_op_db = copy.deepcopy(op_db)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -44,6 +44,7 @@ import numpy as np
 import torch
 import torch.utils._pytree as pytree
 from itertools import product
+import platform
 
 test_consistency_op_db = copy.deepcopy(op_db)
 test_error_inputs_op_db = copy.deepcopy(op_db)
@@ -2616,8 +2617,38 @@ class TestMPS(TestCaseMPS):
                 cpu_norm = torch.nn.utils.weight_norm(cpu_conv, dim=dim)
                 norm = torch.nn.utils.weight_norm(conv, dim=dim)
 
-                cpu_out = cpu_conv(cpu_x)
-                out = conv(x)
+                cpu_out = cpu_norm(cpu_x)
+                out = norm(x)
+
+                self.assertEqual(cpu_out, out)
+
+                cpu_grad = torch.randn(cpu_out.shape)
+                grad = cpu_grad.to('mps')
+                cpu_out.backward(gradient=cpu_grad)
+                out.backward(gradient=grad)
+
+                self.assertEqual(cpu_conv.weight_g.grad, conv.weight_g.grad)
+                self.assertEqual(cpu_conv.weight_v.grad, conv.weight_v.grad)
+
+                self.assertEqual(x.grad, cpu_x.grad)
+
+                # conv layer
+            if layer == 'conv3d':
+                cpu_x = torch.randn((3, 5, 5, 4), device='cpu', dtype=dtype, requires_grad=True)
+                x = cpu_x.detach().clone().to('mps').requires_grad_()
+
+                cpu_conv = torch.nn.Conv3d(3, 3, 3, device='cpu')
+                conv = torch.nn.Conv3d(3, 3, 3, device='mps')
+
+                with torch.no_grad():
+                    conv.weight.copy_(cpu_conv.weight)
+                    conv.bias.copy_(cpu_conv.bias)
+
+                cpu_norm = torch.nn.utils.weight_norm(cpu_conv, dim=dim)
+                norm = torch.nn.utils.weight_norm(conv, dim=dim)
+
+                cpu_out = cpu_norm(cpu_x)
+                out = norm(x)
 
                 self.assertEqual(cpu_out, out)
 
@@ -2640,6 +2671,15 @@ class TestMPS(TestCaseMPS):
         helper(2, layer='conv')
         helper(3, layer='conv')
         helper(-1, layer='conv')
+
+        if float('.'.join(platform.mac_ver()[0].split('.')[:2])) > 13:
+            # Conv3d is only available from MacOS 13 onwards
+            helper(0, layer='conv3d')
+            helper(1, layer='conv3d')
+            helper(2, layer='conv3d')
+            helper(3, layer='conv3d')
+            helper(4, layer='conv3d')
+            helper(-1, layer='conv3d')
 
     # Test conv2d
     def test_conv2d_unit(self):
@@ -8336,6 +8376,18 @@ class TestNNMPS(NNTestCase):
         # This used to crash with MPSNDArrayConvolutionA14.mm:4352: failed assertion
         y2.sum().backward()
 
+    def test_conv3d_backward_collision(self):
+        # Conv3D is only available from MacOS 13 onwards
+        if float('.'.join(platform.mac_ver()[0].split('.')[:2])) < 13:
+            return
+        x = torch.rand(1, 1, 10, 10, 20, device="mps", requires_grad=True)
+        m1 = nn.Conv3d(1, 1, 3, stride=2, padding=1).to("mps")
+        m2 = nn.Conv3d(1, 1, 4, stride=2, padding=1).to("mps")
+        y1, y2 = m1(x), m2(x)
+        self.assertEqual(y1.shape, y2.shape)
+        y1.sum().backward()
+        # This used to crash with MPSNDArrayConvolutionA14.mm:4352: failed assertion
+        y2.sum().backward()
 
     def test_gemm_permute_transpose(self):
         batch_size = 32
@@ -9554,6 +9606,20 @@ class TestConvolutionMPS(TestCaseMPS):
         y_gpu = y_cpu.to(device='mps')
         for stride in range(1, 4):
             conv_cpu = torch.nn.Conv2d(in_channels=2, out_channels=2, kernel_size=3, stride=stride)
+            conv_gpu = copy.deepcopy(conv_cpu).to(device='mps')
+            x_cpu = conv_cpu(y_cpu)
+            x_gpu = conv_gpu(y_gpu)
+            self.assertEqual(x_cpu, x_gpu.cpu(), rtol=1e-03, atol=1e-05)
+
+    def test_conv3d_single_stride(self):
+        # Conv3d is only available from MacOS 13 onwards
+        if float('.'.join(platform.mac_ver()[0].split('.')[:2])) < 13:
+            return
+
+        y_cpu = torch.randn(2, 2, 3, 6)
+        y_gpu = y_cpu.to(device='mps')
+        for stride in range(1, 4):
+            conv_cpu = torch.nn.Conv3d(in_channels=2, out_channels=2, kernel_size=2, stride=stride)
             conv_gpu = copy.deepcopy(conv_cpu).to(device='mps')
             x_cpu = conv_cpu(y_cpu)
             x_gpu = conv_gpu(y_gpu)


### PR DESCRIPTION
Fixes #77818 


I saw that PR #99246 was approved, but no one fixed the rebase conflicts, so I am bringing this up again to be merged.
I am leveraging @mattiaspaul work. Quoting the description here:

> * this pull request enables 3D convolutions (forward/backward) for MPS (Apple Silicon) within the same Convolution.mm file as conv2d.
> * does not support channel_last (since pytorch doesn't implement channel_last for 3D tensors)
> * does not support conv3d_transpose and treats depth-separable convolutions not as normal case (there are no MPS kernels available for either of those so far)
> * requires MacOS >=13.2 (Ventura)

Please, let me know if there are any other changes needed and I'll be happy to implement them.


cc @kulinseth @albanD @malfet @DenisVieriu97 @razarmehr