### PR TITLE
Replace assert with CUDA_KERNEL_ASSERT in Reduce.cuh for consistency (#113098)

### DIFF
--- a/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
@@ -11,8 +11,8 @@
 #include <ATen/TensorUtils.h>
 #include <ATen/Utils.h>
 #include <ATen/native/FractionalMaxPooling.h>
+#include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
-
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/NativeFunctions.h>
 #else
@@ -117,10 +117,10 @@ __global__ void fractional_max_pool2d_backward_out_cuda_frame(
     int outputH = ourOutputPoint / gradOutput.size(3);
 
     int index = indices[batch][plane][outputH][outputW];
-    assert(index >= 0);
+    CUDA_KERNEL_ASSERT(index >= 0);
     int inputW = index % gradInput.size(3);
     int inputH = index / gradInput.size(3);
-    assert(inputH < gradInput.size(2));
+    CUDA_KERNEL_ASSERT(inputH < gradInput.size(2));
 
     gpuAtomicAddNoReturn(
       &gradInput[batch][plane][inputH][inputW],

--- a/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
@@ -12,6 +12,7 @@
 #include <ATen/TensorUtils.h>
 #include <ATen/Utils.h>
 #include <ATen/native/FractionalMaxPooling.h>
+#include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -136,13 +137,13 @@ __global__ void fractional_max_pool3d_backward_out_frame(
                       gradOutput.size(4));
 
     int64_t index = indices[batch][plane][outputT][outputH][outputW];
-    assert(index >= 0);
+    CUDA_KERNEL_ASSERT(index >= 0);
     int64_t inputW = index % gradInput.size(4);
     int64_t inputH = (index / gradInput.size(4)) %
       gradInput.size(3);
     int64_t inputT = index / (gradInput.size(3) *
       gradInput.size(4));
-    assert(inputT < gradInput.size(2));
+    CUDA_KERNEL_ASSERT(inputT < gradInput.size(2));
 
     gpuAtomicAddNoReturn(
       &gradInput[batch][plane][inputT][inputH][inputW],

--- a/aten/src/ATen/native/cuda/PersistentSoftmax.cuh
+++ b/aten/src/ATen/native/cuda/PersistentSoftmax.cuh
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <assert.h>
 #include <cfloat>
 #include <limits>
 #include <stdint.h>

--- a/aten/src/ATen/native/cuda/SortUtils.cuh
+++ b/aten/src/ATen/native/cuda/SortUtils.cuh
@@ -195,8 +195,8 @@ warpMergeSortKVInPlace(
 
   namespace cub = ROCM_HIPCUB(at_cuda_detail::cub);
 
-  assert(blockDim.x == C10_WARP_SIZE);
-  assert(blockDim.y <= max_block_dim_y);
+  CUDA_KERNEL_ASSERT(blockDim.x == C10_WARP_SIZE);
+  CUDA_KERNEL_ASSERT(blockDim.y <= max_block_dim_y);
   constexpr int items_per_thread = sort_size / C10_WARP_SIZE;
   static_assert(
       items_per_thread * C10_WARP_SIZE == sort_size,

--- a/aten/src/ATen/native/cuda/SortingCommon.cuh
+++ b/aten/src/ATen/native/cuda/SortingCommon.cuh
@@ -2,7 +2,6 @@
 #include <ATen/core/TensorBase.h>
 #include <ATen/ceil_div.h>
 #include <ATen/NumericUtils.h>
-#include <assert.h>
 #include <c10/macros/Macros.h>
 #include <stdlib.h>
 #include <ATen/cuda/detail/IndexUtils.cuh>

--- a/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
+++ b/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
@@ -2,6 +2,7 @@
 #include <ATen/cuda/Atomic.cuh>
 #include <ATen/cuda/DeviceUtils.cuh>
 #include <ATen/cuda/AsmUtils.cuh>
+#include <c10/macros/Macros.h>
 
 namespace at {
 namespace native {
@@ -131,7 +132,7 @@ struct TopKTypeConfig<at::Half> {
     RadixType mask = (x & 0x00008000) ? 0x0000ffff : 0x00008000;
     return (v == v) ? (x ^ mask) : 0xffff;
 #else
-    assert(false);
+    CUDA_KERNEL_ASSERT(false);
     return 0u;
 #endif
   }
@@ -141,7 +142,7 @@ struct TopKTypeConfig<at::Half> {
     RadixType mask = (v & 0x00008000) ? 0x00008000 : 0x0000ffff;
     return __ushort_as_half(v ^ mask);
 #else
-    assert(false);
+    CUDA_KERNEL_ASSERT(false);
     return static_cast<at::Half>(0);
 #endif
   }
@@ -296,7 +297,7 @@ __device__ scalar_t findPattern(
   }
 
   // should not get here
-  assert(false);
+  CUDA_KERNEL_ASSERT(false);
   return static_cast<scalar_t>(0);
 }
 

--- a/c10/cuda/CUDADeviceAssertion.h
+++ b/c10/cuda/CUDADeviceAssertion.h
@@ -90,6 +90,8 @@ static __device__ void dsa_add_new_assertion_failure(
       return;                                                            \
     }                                                                    \
   } while (false)
+#elif defined(USE_ROCM)
+#define CUDA_KERNEL_ASSERT2(condition)
 #else
 #define CUDA_KERNEL_ASSERT2(condition) assert(condition)
 #endif

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -396,7 +396,7 @@ __host__ __device__
 #endif // __SYCL_DEVICE_ONLY__
 }
 #endif // NDEBUG
-// ROCm disable kernel assert by default 
+// ROCm disable kernel assert by default
 #if defined(TORCH_DISABLE_GPU_ASSERTS) && defined(USE_ROCM)
 #define CUDA_KERNEL_ASSERT(cond)
 #define SYCL_KERNEL_ASSERT(cond)

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -393,18 +393,14 @@ __host__ __device__
         unsigned int line,
         const char* function) noexcept __attribute__((__noreturn__));
 
-#if (defined(__HIP_ARCH__) || defined(__HIP__)) && \
-    !defined(TORCH_DISABLE_GPU_ASSERTS)
-// ROCm supports __assert_fail only as a device side function.
-__device__ __attribute__((noinline)) __attribute__((weak)) void __assert_fail(
-    const char* assertion,
-    const char* file,
-    unsigned int line,
-    const char* function);
-#endif // defined(__HIP_ARCH__) || defined(__HIP__)
 #endif // __SYCL_DEVICE_ONLY__
 }
 #endif // NDEBUG
+
+#if defined(TORCH_DISABLE_GPU_ASSERTS)
+#define CUDA_KERNEL_ASSERT(cond)
+#define SYCL_KERNEL_ASSERT(cond)
+#else
 #define CUDA_KERNEL_ASSERT(cond)                                         \
   if (C10_UNLIKELY(!(cond))) {                                           \
     __assert_fail(                                                       \
@@ -415,6 +411,7 @@ __device__ __attribute__((noinline)) __attribute__((weak)) void __assert_fail(
     __assert_fail(                                                       \
         #cond, __FILE__, static_cast<unsigned int>(__LINE__), __func__); \
   }
+#endif //  TORCH_DISABLE_GPU_ASSERTS
 #endif // __APPLE__
 
 #ifdef __APPLE__

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -396,8 +396,8 @@ __host__ __device__
 #endif // __SYCL_DEVICE_ONLY__
 }
 #endif // NDEBUG
-
-#if defined(TORCH_DISABLE_GPU_ASSERTS)
+// ROCm disable kernel assert by default 
+#if defined(TORCH_DISABLE_GPU_ASSERTS) && defined(USE_ROCM)
 #define CUDA_KERNEL_ASSERT(cond)
 #define SYCL_KERNEL_ASSERT(cond)
 #else
@@ -411,7 +411,7 @@ __host__ __device__
     __assert_fail(                                                       \
         #cond, __FILE__, static_cast<unsigned int>(__LINE__), __func__); \
   }
-#endif //  TORCH_DISABLE_GPU_ASSERTS
+#endif //  TORCH_DISABLE_GPU_ASSERTS && USE_ROCM
 #endif // __APPLE__
 
 #ifdef __APPLE__

--- a/c10/macros/cmake_macros.h.in
+++ b/c10/macros/cmake_macros.h.in
@@ -9,5 +9,6 @@
 #cmakedefine C10_USE_GFLAGS
 #cmakedefine C10_USE_NUMA
 #cmakedefine C10_USE_MSVC_STATIC_RUNTIME
+#cmakedefine TORCH_DISABLE_GPU_ASSERTS
 
 #endif // C10_MACROS_CMAKE_MACROS_H_


### PR DESCRIPTION
Also includes "More replacing assert with CUDA_KERNEL_ASSERT in kernels (#113563)"

Cherry-picked from #113098 and #113563: this change is needed to ensure correct functionality when using ROCm builds of PyTorch on certain systems.

====================================

Related to Fixes #94891

**Problem:**
We are trying to disable `printf` in kernels for Pytorch build on ROCm to fix the `torch.sum()` issues for certain community users by disabling `CUDA_KERNEL_ASSERT`, but found that there are still hostcall printf happening in `ReduceSumProdKernel`  used by `torch.sum`.

**Reason:**
The reason is that there are `assert` function calls inside `Reduce.cuh`, (  defined as `__assert_fail` ) which caused `printf`.

**Fix:**
This pull request is to change `assert` to `CUDA_KERNEL_ASSERT` so that we can consistently disable assertion/printf in cuda/hip kernel code.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/113098
Approved by: https://github.com/ezyang

(cherry picked from commit b30f178d09b6bbc967087beba7b51c625cde1478)

====================================

Fixes https://github.com/pytorch/pytorch/issues/103973

Background:
After https://github.com/pytorch/pytorch/pull/113098, user verified that torch.sum() worked for environment where PCIe atomics was exposed as a problem for such operation.

Goal:
This is to expend the changes to other kernels where assert is called. The goal is the same so that we can disable kernel assertion easily for those users when the call sites consistently use CUDA_KERNEL_ASSERT.

Test:
We build wheels with these fixes for those users who had PCIe atomics issue, and users verified they can perform their workflow now with these fixes.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/113563
Approved by: https://github.com/jeffdaily, https://github.com/ezyang

(cherry picked from commit https://github.com/pytorch/pytorch/commit/16da1355507b3b359bd0f9398f45a0ce8663f269)
