### PR TITLE
Defer DDPOptimizer to first runtime call, use inductor subgraph outputs

### DIFF
--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -553,7 +553,6 @@ class TestSingleProc(DynamoDistributedSingleProcTestCase):
         @torch._dynamo.optimize(check_splits_compiler.compile_fn)
         def opt_fn(inputs):
             return ddp_m(inputs)
-
         opt_outputs = opt_fn(inputs)
         self.assertTrue(same(correct_outputs, opt_outputs))
         self.assertEqual(check_splits_compiler.compiler_called, 3)

--- a/torch/_dynamo/backends/distributed.py
+++ b/torch/_dynamo/backends/distributed.py
@@ -343,7 +343,7 @@ or file a github issue."""
                 """
                 assert len(kwargs) == 0, "We assume only args for these modules"
 
-                class WrapperModule(torch.nn.Module):
+                class UnwrapperModule(torch.nn.Module):
                     def __init__(self, submod, unwrap_singleton_tuple):
                         super().__init__()
                         self.submod = submod
@@ -375,11 +375,13 @@ or file a github issue."""
                         traceback.FrameSummary(__file__, 0, DDPOptimizer),
                     ],
                 )
-                wrapper = WrapperModule(
-                    self.compiler(input_mod, args),
-                    unwrap_singleton_tuple,
-                )
-                return wrapper
+
+                # we must let 'input_mod' return a tuple, to make AOT happy.
+                # (aot_autograd compile_fn literally requires that the output of a graph it compiles is a tuple).
+                # however, we don't acutally want this tuple to be returned, since the fx logic that calls the submod
+                # will again wrap outputs from the submod in a tuple.  So we unwrap it, and count on it being re-wrapped
+                compiled = self.compiler(input_mod, args)
+                return UnwrapperModule(compiled, unwrap_singleton_tuple)
 
             # Note:
             #
@@ -435,7 +437,11 @@ or file a github issue."""
 
                     # Finally, we have to produce inputs for use compiling the next submodule,
                     # and these need to be Real, so inductor strides are faithfully captured
-                    return curr_submod(*args, **kwargs)
+
+                    # previously called 'curr_submod(*args, **kwargs) But it wrapped an additional
+                    # tuple around the result, which caused problems when trying to pass the result to the next submod
+                    # also, maybe i was just not using the updated curr_submod after compile??
+                    return compiled_submod_real(*args, **kwargs)
                 else:
                     # placeholder or output nodes don't need to get compiled, just executed
                     return getattr(self, n.op)(n.target, args, kwargs)

--- a/torch/_dynamo/backends/distributed.py
+++ b/torch/_dynamo/backends/distributed.py
@@ -5,6 +5,7 @@ from typing import Any, List, Optional
 
 import torch
 from torch import fx
+from torch._dynamo.eval_frame import OptimizedModule
 from torch._dynamo.output_graph import GraphCompileReason
 from torch._dynamo.utils import deepcopy_to_fake_tensor, detect_fake_mode
 from torch.fx.node import Node
@@ -403,17 +404,7 @@ or file a github issue."""
             # to match what aot_autograd expects. See Note: [Fake Modules and AOTAutograd]
             def run_node(self, n: Node) -> Any:
                 args, kwargs = self.fetch_args_kwargs_from_env(n)
-                new_args = []
-                assert fake_mode
-                for arg in args:
-                    if isinstance(arg, torch.Tensor) and not isinstance(
-                        arg, torch._subclasses.FakeTensor
-                    ):
-                        new_args.append(
-                            torch._dynamo.utils.to_fake_tensor(arg, fake_mode)
-                        )
-                    else:
-                        new_args.append(arg)
+                assert not fake_mode
 
                 log.debug("run_node %s, %s got args %s", n.op, n.target, args_str(args))
                 assert isinstance(args, tuple)
@@ -430,13 +421,11 @@ or file a github issue."""
                         "\n---%s graph---\n%s", n.target, curr_submod.graph
                     )
 
-                    # When calling the compiler on the submod, inputs (new_args) are expected to
+                    # When calling the compiler on the submod, inputs (args) are expected to
                     # be FakeTensors already since Dynamo would have made them FakeTensors in the
                     # non-DDP flow.  However, the parameters are _not_ expected to be FakeTensors,
                     # since this wrapping happens during compilation
-                    compiled_submod_real = self.compile_submod(
-                        real_mod, new_args, kwargs
-                    )
+                    compiled_submod_real = self.compile_submod(real_mod, args, kwargs)
 
                     # We update the original (outer) graph with a call into the compiled module
                     # instead of the uncompiled one.
@@ -446,17 +435,29 @@ or file a github issue."""
 
                     # Finally, we have to produce inputs for use compiling the next submodule,
                     # and these need to be FakeTensors, so we execute the module under fake_mode
-                    with fake_mode:
-                        return curr_submod(*new_args, **kwargs)
+                    return curr_submod(*args, **kwargs)
                 else:
                     # placeholder or output nodes don't need to get compiled, just executed
-                    return getattr(self, n.op)(n.target, new_args, kwargs)
+                    return getattr(self, n.op)(n.target, args, kwargs)
 
-        submod_compiler = SubmodCompiler(split_gm, self.backend_compile_fn)
-        submod_compiler.run(*example_inputs)
-        split_gm.recompile()
+        class DDPOptimizedModule(OptimizedModule):
+            def __init__(self, split_gm):
+                super().__init__()
+                self.split_gm = split_gm
+                self.compiled = False
 
-        ddp_graph_log.debug(
-            "\n---final graph---\n%s\n---------------\n", split_gm.graph
-        )
+            def forward(self, *args):
+                if not self.compiled:
+                    submod_compiler = SubmodCompiler(split_gm, self.backend_compile_fn)
+                    out = submod_compiler.run(*args)
+                    split_gm.recompile()
+
+                    ddp_graph_log.debug(
+                        "\n---final graph---\n%s\n---------------\n", split_gm.graph
+                    )
+                    self.compiled = True
+                    return out
+                else:
+                    return self.split_gm(*args)
+
         return split_gm


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #114186

Work around issue where subgraphs compiled by inductor do not match
strides with eager/faketensor prop.

(WIP - only tested briefly on toy)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng