### PR TITLE
Update PowKernel.cu, Allow [int, boolean] combination for torch.pow when using cuda

### DIFF
--- a/aten/src/ATen/native/cuda/PowKernel.cu
+++ b/aten/src/ATen/native/cuda/PowKernel.cu
@@ -190,7 +190,7 @@ void pow_tensor_scalar_kernel(TensorIteratorBase& iter, const Scalar& exp_scalar
         return pow_(base, exp);
       });
     });
-  } else if (isFloatingType(iter.common_dtype()) || exp_scalar.isIntegral(false)) {
+  } else if (isFloatingType(iter.common_dtype()) || exp_scalar.isIntegral(false) || exp_scalar.isBoolean()) {
     AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, iter.common_dtype(), "pow_cuda", [&]() {
       const auto exp = exp_scalar.to<scalar_t>();
       pow_tensor_scalar_kernel_impl<scalar_t>(iter, exp);


### PR DESCRIPTION
Allow [int, boolean] combination for torch.pow when using cuda

>>> torch.pow(torch.tensor([1, 2]), True)
tensor([1, 2])
>>> torch.pow(torch.tensor([1, 2], device='cuda'), True)
tensor([1, 2], device='cuda:0')
>>> torch.pow(torch.tensor([1, 2]), False)
tensor([1, 1])
>>> torch.pow(torch.tensor([1, 2], device='cuda'), False)
tensor([1, 1], device='cuda:0')

Fixes #113198 @lezcano
