### PR TITLE
Consolidate sym/non-sym overloads for _make_wrapper_subclass

### DIFF
--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -35,6 +35,7 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FLASH_ATTENTION, PLATFORM_SUPPORTS_MEM_EFF_ATTENTION
 )
 from torch._dynamo.comptime import comptime
+from torch.distributed._functional_collectives import _maybe_wrap_tensor
 
 def reset_rng_state():
     torch.manual_seed(1337)
@@ -915,6 +916,17 @@ class TestSingleProc(DynamoDistributedSingleProcTestCase):
             self.assertEqual(cnt.frame_count, 1)
         for test_out in test_outs:
             self.assertEqual(test_out, ref_out)
+
+    def test_async_subclass_no_specialize(self):
+        cnt = torch._dynamo.testing.CompileCounterWithBackend("eager")
+        @torch.compile(backend=cnt, fullgraph=True, dynamic=True)
+        def f(x):
+            return x + 1
+
+        f(_maybe_wrap_tensor(torch.randn(10)))
+        f(_maybe_wrap_tensor(torch.randn(12)))
+
+        self.assertEqual(cnt.frame_count, 1)
 
 
 if __name__ == "__main__":

--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -919,6 +919,7 @@ class TestSingleProc(DynamoDistributedSingleProcTestCase):
 
     def test_async_subclass_no_specialize(self):
         cnt = torch._dynamo.testing.CompileCounterWithBackend("eager")
+
         @torch.compile(backend=cnt, fullgraph=True, dynamic=True)
         def f(x):
             return x + 1

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -750,7 +750,7 @@ $2: f32[1] = torch._ops.aten.detach.default($1)''')
         # return some virtual storage that is safe to work with
         x = LoggingTensor(torch.ones(1))
         storage = x.untyped_storage()
-        self.assertEqual(storage.data_ptr(), 0)
+        self.assertRaises(RuntimeError, lambda: storage.data_ptr())
 
     def test_make_wrapper_subclass_noalloc(self) -> None:
         # This is ludicrously big (8TB) and this should pass because wrapper

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -750,7 +750,7 @@ $2: f32[1] = torch._ops.aten.detach.default($1)''')
         # return some virtual storage that is safe to work with
         x = LoggingTensor(torch.ones(1))
         storage = x.untyped_storage()
-        storage.data_ptr()
+        self.assertEqual(storage.data_ptr(), 0)
 
     def test_make_wrapper_subclass_noalloc(self) -> None:
         # This is ludicrously big (8TB) and this should pass because wrapper

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -750,7 +750,7 @@ $2: f32[1] = torch._ops.aten.detach.default($1)''')
         # return some virtual storage that is safe to work with
         x = LoggingTensor(torch.ones(1))
         storage = x.untyped_storage()
-        self.assertRaises(RuntimeError, lambda: storage.data_ptr())
+        storage.data_ptr()
 
     def test_make_wrapper_subclass_noalloc(self) -> None:
         # This is ludicrously big (8TB) and this should pass because wrapper

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -652,11 +652,6 @@ static PyObject* THPVariable_make_wrapper_subclass(
   // NB: pin_memory doesn't actually do anything
   // TODO: strides variant?
   static PythonArgParser parser({
-      "_make_wrapper_subclass(PyObject* cls, IntArrayRef size, *, IntArrayRef? strides=None, "
-      "int64_t? storage_offset=None, MemoryFormat? memory_format=None, ScalarType dtype=None, "
-      "Layout layout=torch.strided, Device device=None, bool pin_memory=False, bool requires_grad=False, "
-      "c10::string_view? dispatch_sizes_strides_policy=None, bool dispatch_device=False, bool dispatch_layout=False, "
-      "DispatchKeySet _extra_dispatch_keys=None)",
       "_make_wrapper_subclass(PyObject* cls, SymIntArrayRef size, SymIntArrayRef strides, "
       "SymInt? storage_offset=None, MemoryFormat? memory_format=None, ScalarType dtype=None, "
       "Layout layout=torch.strided, Device device=None, bool pin_memory=False, bool requires_grad=False, "
@@ -702,61 +697,39 @@ static PyObject* THPVariable_make_wrapper_subclass(
   // TODO: for_blob produces non-resizable tensors, we might want this to be
   // resizable (have to define a custom allocator in that case)
   Tensor tensor;
-  if (r.idx == 0) {
-    TORCH_CHECK(
-        !r.toDispatchKeySetOptional(13),
-        "This overload of _make_wrapper_subclass does not support _extra_dispatch_keys");
-    tensor = at::for_blob(nullptr, r.intlist(1))
-                 .strides(r.intlistOptional(2))
-                 .storage_offset(r.toInt64Optional(3))
-                 .context(nullptr, [](void* ctx) {})
-                 .target_device(
-                     options.device()) // TODO: this shouldn't be necessary if
-                                       // it came from options
-                 .options(options)
-                 .allocator(c10::GetAllocator(c10::kMeta))
-                 .resizeable_storage()
-                 .make_tensor();
 
-    const auto sizes_strides_policy = r.stringViewOptional(10);
-    if (sizes_strides_policy.has_value()) {
-      tensor.unsafeGetTensorImpl()->set_python_custom_sizes_strides(
-          parseSizesStridesPolicyArgument(*sizes_strides_policy));
-    }
-  } else {
-    AutoDispatchBelowADInplaceOrView guard{}; // TODO: Remove.
-    tracer::impl::NoTracerDispatchMode tracer_guard{};
+  AutoDispatchBelowADInplaceOrView guard{}; // TODO: Remove.
+  tracer::impl::NoTracerDispatchMode tracer_guard{};
 
-    // We use storages **only** to track aliasing of subclasses during tracing.
-    // The actual data pointers are not valid.
-    Storage storage{
-        Storage::use_byte_size_t{},
-        0,
-        at::DataPtr{nullptr, r.device(7)},
-        /*allocator=*/c10::GetAllocator(c10::kMeta),
-        /*resizable=*/true};
+  // We use storages **only** to track aliasing of subclasses during tracing.
+  // The actual data pointers are not valid.
+  Storage storage{
+      Storage::use_byte_size_t{},
+      0,
+      at::DataPtr{nullptr, r.device(7)},
+      /*allocator=*/c10::GetAllocator(c10::kMeta),
+      /*resizable=*/true};
 
-    auto keys = c10::DispatchKeySet({options.computeDispatchKey()});
-    if (auto mb_extra_keys = r.toDispatchKeySetOptional(13)) {
-      keys = keys | *mb_extra_keys;
-    }
-    tensor = at::detail::make_tensor<TensorImpl>(
-        std::move(storage), keys, options.dtype());
+  auto keys = c10::DispatchKeySet({options.computeDispatchKey()});
+  if (auto mb_extra_keys = r.toDispatchKeySetOptional(13)) {
+    keys = keys | *mb_extra_keys;
+  }
+  tensor = at::detail::make_tensor<TensorImpl>(
+      std::move(storage), keys, options.dtype());
 
-    auto sym_sizes = r.symintlist(1);
-    auto sym_strides = r.symintlist(2);
-    auto sym_storage_offset = r.toSymIntOptional(3);
+  auto sym_sizes = r.symintlist(1);
+  auto sym_strides = r.symintlist(2);
+  auto sym_storage_offset = r.toSymIntOptional(3);
 
-    TensorImpl* tensor_impl = tensor.unsafeGetTensorImpl();
+  TensorImpl* tensor_impl = tensor.unsafeGetTensorImpl();
 
-    tensor_impl->set_sizes_and_strides(
-        sym_sizes, sym_strides, sym_storage_offset.value_or(0));
+  tensor_impl->set_sizes_and_strides(
+      sym_sizes, sym_strides, sym_storage_offset.value_or(0));
 
-    const auto sizes_strides_policy = r.stringViewOptional(10);
-    if (sizes_strides_policy.has_value()) {
-      tensor.unsafeGetTensorImpl()->set_python_custom_sizes_strides(
-          parseSizesStridesPolicyArgument(*sizes_strides_policy));
-    }
+  const auto sizes_strides_policy = r.stringViewOptional(10);
+  if (sizes_strides_policy.has_value()) {
+    tensor.unsafeGetTensorImpl()->set_python_custom_sizes_strides(
+        parseSizesStridesPolicyArgument(*sizes_strides_policy));
   }
 
   tensor.set_requires_grad(r.toBool(9));

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -694,8 +694,6 @@ static PyObject* THPVariable_make_wrapper_subclass(
 
   // don't bother releasing GIL here, as we are not allocating any nontrivial
   // data
-  // TODO: for_blob produces non-resizable tensors, we might want this to be
-  // resizable (have to define a custom allocator in that case)
   Tensor tensor;
 
   {

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -652,7 +652,7 @@ static PyObject* THPVariable_make_wrapper_subclass(
   // NB: pin_memory doesn't actually do anything
   // TODO: strides variant?
   static PythonArgParser parser({
-      "_make_wrapper_subclass(PyObject* cls, SymIntArrayRef size, SymIntArrayRef strides, "
+      "_make_wrapper_subclass(PyObject* cls, SymIntArrayRef size, SymIntArrayRef? strides=None, "
       "SymInt? storage_offset=None, MemoryFormat? memory_format=None, ScalarType dtype=None, "
       "Layout layout=torch.strided, Device device=None, bool pin_memory=False, bool requires_grad=False, "
       "c10::string_view? dispatch_sizes_strides_policy=None, bool dispatch_device=False, bool dispatch_layout=False, "
@@ -698,38 +698,46 @@ static PyObject* THPVariable_make_wrapper_subclass(
   // resizable (have to define a custom allocator in that case)
   Tensor tensor;
 
-  AutoDispatchBelowADInplaceOrView guard{}; // TODO: Remove.
-  tracer::impl::NoTracerDispatchMode tracer_guard{};
+  {
+    AutoDispatchBelowADInplaceOrView guard{}; // TODO: Remove.
+    tracer::impl::NoTracerDispatchMode tracer_guard{};
 
-  // We use storages **only** to track aliasing of subclasses during tracing.
-  // The actual data pointers are not valid.
-  Storage storage{
-      Storage::use_byte_size_t{},
-      0,
-      at::DataPtr{nullptr, r.device(7)},
-      /*allocator=*/c10::GetAllocator(c10::kMeta),
-      /*resizable=*/true};
+    // We use storages **only** to track aliasing of subclasses during tracing.
+    // The actual data pointers are not valid.
+    Storage storage{
+        Storage::use_byte_size_t{},
+        0,
+        at::DataPtr{nullptr, r.device(7)},
+        /*allocator=*/c10::GetAllocator(c10::kMeta),
+        /*resizable=*/true};
 
-  auto keys = c10::DispatchKeySet({options.computeDispatchKey()});
-  if (auto mb_extra_keys = r.toDispatchKeySetOptional(13)) {
-    keys = keys | *mb_extra_keys;
-  }
-  tensor = at::detail::make_tensor<TensorImpl>(
-      std::move(storage), keys, options.dtype());
+    auto keys = c10::DispatchKeySet({options.computeDispatchKey()});
+    if (auto mb_extra_keys = r.toDispatchKeySetOptional(13)) {
+      keys = keys | *mb_extra_keys;
+    }
+    tensor = at::detail::make_tensor<TensorImpl>(
+        std::move(storage), keys, options.dtype());
 
-  auto sym_sizes = r.symintlist(1);
-  auto sym_strides = r.symintlist(2);
-  auto sym_storage_offset = r.toSymIntOptional(3);
+    auto sym_sizes = r.symintlist(1);
+    auto sym_strides_own = r.symintlistOptional(2);
+    auto sym_strides = static_cast<c10::optional<c10::SymIntArrayRef>>(sym_strides_own);
+    auto sym_storage_offset = r.toSymIntOptional(3);
 
-  TensorImpl* tensor_impl = tensor.unsafeGetTensorImpl();
+    TensorImpl* tensor_impl = tensor.unsafeGetTensorImpl();
 
-  tensor_impl->set_sizes_and_strides(
-      sym_sizes, sym_strides, sym_storage_offset.value_or(0));
+    if (sym_strides.has_value()) {
+      tensor_impl->set_sizes_and_strides(
+          sym_sizes, sym_strides.value(), sym_storage_offset);
+    } else {
+      TORCH_INTERNAL_ASSERT(!sym_storage_offset.has_value());
+      tensor_impl->generic_set_sizes_contiguous(sym_sizes);
+    }
 
-  const auto sizes_strides_policy = r.stringViewOptional(10);
-  if (sizes_strides_policy.has_value()) {
-    tensor.unsafeGetTensorImpl()->set_python_custom_sizes_strides(
-        parseSizesStridesPolicyArgument(*sizes_strides_policy));
+    const auto sizes_strides_policy = r.stringViewOptional(10);
+    if (sizes_strides_policy.has_value()) {
+      tensor.unsafeGetTensorImpl()->set_python_custom_sizes_strides(
+          parseSizesStridesPolicyArgument(*sizes_strides_policy));
+    }
   }
 
   tensor.set_requires_grad(r.toBool(9));

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -12566,8 +12566,8 @@ op_db: List[OpInfo] = [
                # RuntimeError: This operator is not Composite Compliant: the
                # storage_offset of the tensor was modified directly without
                # going through the PyTorch dispatcher.
-               DecorateInfo(unittest.expectedFailure, 'TestCompositeCompliance'),
-
+               DecorateInfo(unittest.expectedFailure, 'TestCompositeCompliance', 'test_forward_ad'),
+               DecorateInfo(unittest.expectedFailure, 'TestCompositeCompliance', 'test_backward'),
 
                # These fail because the test changes the input's in-memory layout
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_complex_half_reference_testing'),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #114236

I'm not sure why we needed two overloads previously, let's find out! Removing the int overload is load bearing because it now forces specialization on SymInt arguments instead of falling through to the SymInt overload, see new test.

I decided NOT to allow storage offset simultaneously with None strides.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>