### PR TITLE
Adds tool to visualize sharding

### DIFF
--- a/torch/distributed/_tensor/debug/visualize_sharding.py
+++ b/torch/distributed/_tensor/debug/visualize_sharding.py
@@ -1,0 +1,44 @@
+
+
+def create_visualization(dtensor):
+    """
+    Tool of visualize sharding of 1D or 2D torch tensors
+    """
+
+    from tabulate import tabulate
+
+    device_mesh = dtensor.device_mesh.mesh.tolist()
+    # WIP: What happens when there are more than 1 placements in the tuple?
+    placement_type = dtensor.placements[0].dim
+    tensor_size = dtensor.shape
+    num_devices = len(device_mesh)
+    rows, cols = tensor_size
+
+    table = []
+
+    if placement_type == 0:
+        split_size = rows // num_devices
+        remainder = rows % num_devices
+        row_start = 0
+        for i, device in enumerate(device_mesh):
+            row_end = row_start + split_size + (1 if i < remainder else 0)
+            table.append([f"Row {row_start}-{row_end}", f"Device: {device}"])   
+            row_start = row_end     
+        print(tabulate(table, headers=["Row Range", "Device"], tablefmt="grid"))
+
+    else:
+        split_size = cols // num_devices
+        remainder = cols % num_devices
+        header = []
+        row = []
+        header.append(f"Col Range")
+        row.append(f"Device")
+        col_start = 0
+        for i, device in enumerate(device_mesh):
+            col_end = col_start + split_size + (1 if i < remainder else 0)
+            header.append(f"Col {col_start}-{col_end}")
+            row.append(f"Device: {device}")
+            col_start = col_end
+        
+        table.append(row)
+        print(tabulate([row], headers=header, tablefmt="grid"))

--- a/torch/distributed/_tensor/debug/visualize_sharding.py
+++ b/torch/distributed/_tensor/debug/visualize_sharding.py
@@ -1,44 +1,160 @@
+import torch
+from torch.distributed._tensor import DeviceMesh, Shard, Replicate, distribute_tensor
+import os
+
+def shard_or_replicate(curr_ranges, placements, num_splits, idx, grid, device_mesh):
+    if len(placements) == idx:
+        assert not isinstance(device_mesh, list)
+        for i in curr_ranges['row']:
+            for j in curr_ranges['col']:
+                grid[i][j] = f"Device:{str(device_mesh)}" if grid[i][j] == "" else grid[i][j] + f", Device:{str(device_mesh)}"
+        return curr_ranges
+
+    placement = placements[idx]
+
+    next_ranges = []
+    if placement.is_shard():
+        curr_dim = 'row' if placement.dim == 0 else 'col'
+        other_dim = 'row' if placement.dim == 1 else 'col'
+
+        chunk_size, extra = divmod(len(curr_ranges[curr_dim]), num_splits[idx])
+        start_entry_index = 0
+        for part_idx in range(num_splits[idx]):
+            curr_chunk = chunk_size + (1 if part_idx < extra else 0)
+            new_range = {curr_dim: curr_ranges[curr_dim][start_entry_index:start_entry_index + curr_chunk], other_dim: curr_ranges[other_dim]}
+            next_ranges.append(shard_or_replicate(new_range, placements, num_splits, idx+1, grid, device_mesh[part_idx]))
+            start_entry_index += curr_chunk
+    elif placement.is_replicate():
+        for part_idx in range(num_splits[idx]):
+            next_ranges.append(shard_or_replicate(curr_ranges, placements, num_splits, idx+1, grid, device_mesh[part_idx]))
+    else:
+        raise RuntimeError
+    return next_ranges
 
 
-def create_visualization(dtensor):
-    """
-    Tool of visualize sharding of 1D or 2D torch tensors
-    """
+def find_unique_blocks(grid):
+    rows = len(grid)
+    columns = len(grid[0]) if rows > 0 else 0
+    compact_blocks = []
 
+    for i in range(rows):
+        for j in range(columns):
+            # Check if cell is the top-left corner of a new block
+            if (i == 0 or grid[i][j] != grid[i-1][j]) and (j == 0 or grid[i][j] != grid[i][j-1]):
+                value = grid[i][j]
+                block_rows, block_cols = 1, 1
+
+                # Determine the size of the block
+                while i + block_rows < rows and grid[i + block_rows][j] == value:
+                    block_rows += 1
+                while j + block_cols < columns and grid[i][j + block_cols] == value:
+                    block_cols += 1
+
+                # Add block information to the list
+                compact_blocks.append({
+                    'row_range': (i, i + block_rows - 1),
+                    'column_range': (j, j + block_cols - 1),
+                    'value': value
+                })
+
+    return compact_blocks
+
+def create_table(blocks):
     from tabulate import tabulate
 
+    # Extract unique row and column ranges
+    row_ranges = sorted(set([block['row_range'] for block in blocks]))
+    col_ranges = sorted(set([block['column_range'] for block in blocks]))
+
+    # Create a matrix initialized with empty strings
+    matrix = [['' for _ in col_ranges] for _ in row_ranges]
+
+    # Fill the matrix with values
+    for block in blocks:
+        row_index = row_ranges.index(block['row_range'])
+        col_index = col_ranges.index(block['column_range'])
+        matrix[row_index][col_index] = block['value']
+
+    # Prepare headers
+    row_headers = [f"Row {r[0]}-{r[1]}" for r in row_ranges]
+    col_headers = [f"Col {c[0]}-{c[1]}" for c in col_ranges]
+
+    return tabulate(matrix, headers=col_headers, showindex=row_headers)
+
+def visualize_sharding(dtensor):
+    placements = dtensor.placements
     device_mesh = dtensor.device_mesh.mesh.tolist()
-    # WIP: What happens when there are more than 1 placements in the tuple?
-    placement_type = dtensor.placements[0].dim
-    tensor_size = dtensor.shape
-    num_devices = len(device_mesh)
-    rows, cols = tensor_size
 
-    table = []
+    # Find number of devices per level for nested device_mesh
+    num_splits = []
+    curr_devices = device_mesh.copy()
+    while isinstance(curr_devices, list):
+        num_splits.append(len(curr_devices))
+        curr_devices = curr_devices[0]
 
-    if placement_type == 0:
-        split_size = rows // num_devices
-        remainder = rows % num_devices
-        row_start = 0
-        for i, device in enumerate(device_mesh):
-            row_end = row_start + split_size + (1 if i < remainder else 0)
-            table.append([f"Row {row_start}-{row_end}", f"Device: {device}"])   
-            row_start = row_end     
-        print(tabulate(table, headers=["Row Range", "Device"], tablefmt="grid"))
+    # We decide splits based on range
+    start_range = {'row': list(range(dtensor.shape[0])), 'col': list(range(dtensor.shape[1]))}
 
-    else:
-        split_size = cols // num_devices
-        remainder = cols % num_devices
-        header = []
-        row = []
-        header.append(f"Col Range")
-        row.append(f"Device")
-        col_start = 0
-        for i, device in enumerate(device_mesh):
-            col_end = col_start + split_size + (1 if i < remainder else 0)
-            header.append(f"Col {col_start}-{col_end}")
-            row.append(f"Device: {device}")
-            col_start = col_end
-        
-        table.append(row)
-        print(tabulate([row], headers=header, tablefmt="grid"))
+    # Initialize the visualization grid assuming 2D tensor
+    grid = [["" for _ in range(dtensor.shape[1])] for _ in range(dtensor.shape[0])]
+    shard_or_replicate(start_range, placements, num_splits, 0, grid, device_mesh)
+    # The grid is now 2D array containing device names, we need to make it compact to remove redundancy
+    blocks = find_unique_blocks(grid)
+    # Finally create the desired table
+    print(create_table(blocks))
+
+if __name__ == "__main__":
+    world_size = int(os.environ['WORLD_SIZE'])
+    
+    # Example 1
+    tensor = torch.randn(4, 4)
+    mesh = DeviceMesh("cuda", list(range(world_size)))
+    dtensor = distribute_tensor(tensor, mesh, [Shard(dim=1)])
+    if int(os.environ['LOCAL_RANK']) == 0:
+        visualize_sharding(dtensor)
+        '''
+                 Col 0-0    Col 1-1    Col 2-2    Col 3-3
+        -------  ---------  ---------  ---------  ---------
+        Row 0-3  Device:0   Device:1   Device:2   Device:3
+        '''
+    
+    # Example 2
+    tensor = torch.randn(4, 4)
+    mesh = DeviceMesh("cuda", list(range(world_size)))
+    dtensor = distribute_tensor(tensor, mesh, [Shard(dim=0)])
+    if int(os.environ['LOCAL_RANK']) == 0:
+        visualize_sharding(dtensor)
+        '''
+                 Col 0-3
+        -------  ---------
+        Row 0-0  Device:0
+        Row 1-1  Device:1
+        Row 2-2  Device:2
+        Row 3-3  Device:3
+        '''
+    
+    # Example 3
+    tensor = torch.randn(4, 4)
+    mesh = DeviceMesh("cuda", [[0, 1], [2, 3]])
+    dtensor = distribute_tensor(tensor, mesh, [Shard(dim=0), Replicate()])
+    if int(os.environ['LOCAL_RANK']) == 0:
+        visualize_sharding(dtensor)
+        '''
+                 Col 0-3
+        -------  ------------------
+        Row 0-1  Device:0, Device:1
+        Row 2-3  Device:2, Device:3
+        '''
+
+    # Example 4
+    tensor = torch.randn(4, 4)
+    mesh = DeviceMesh("cuda", [[0, 1], [2, 3]])
+    dtensor = distribute_tensor(tensor, mesh, [Replicate(), Shard(dim=0)])
+    if int(os.environ['LOCAL_RANK']) == 0:
+        visualize_sharding(dtensor)
+        '''
+                 Col 0-3
+        -------  ------------------
+        Row 0-1  Device:0, Device:2
+        Row 2-3  Device:1, Device:3
+        '''

--- a/torch/distributed/_tensor/debug/visualize_sharding.py
+++ b/torch/distributed/_tensor/debug/visualize_sharding.py
@@ -1,66 +1,60 @@
-import torch
-from torch.distributed._tensor import DeviceMesh, Shard, Replicate, distribute_tensor
-import os
+from typing import List, Sequence, Tuple
+from torch._prims_common import ShapeType
+from torch.distributed._tensor import DeviceMesh, Shard
+from torch.distributed._tensor.placement_types import (
+    Placement,
+    Shard,
+)
+import numpy as np
 
-def shard_or_replicate(curr_ranges, placements, num_splits, idx, grid, device_mesh):
-    if len(placements) == idx:
-        assert not isinstance(device_mesh, list)
-        for i in curr_ranges['row']:
-            for j in curr_ranges['col']:
-                grid[i][j] = f"Device:{str(device_mesh)}" if grid[i][j] == "" else grid[i][j] + f", Device:{str(device_mesh)}"
-        return curr_ranges
+def _mesh_to_coordinate(mesh, device_type):
+    '''
+    Given a n-dimensional list of device mesh, this function creates a map of
+    device and its coordinate
+    '''
+    # Convert the n-dimensional list to a NumPy array
+    np_mesh = np.array(mesh.mesh.tolist())
 
-    placement = placements[idx]
+    # Create a dictionary to map each value to its coordinate
+    device_to_coordinate_map = {}
+    for coord, value in np.ndenumerate(np_mesh):
+        # device is unique in device_mesh
+        device_to_coordinate_map[f"{device_type}:{str(value)}"] = list(coord)
 
-    next_ranges = []
-    if placement.is_shard():
-        curr_dim = 'row' if placement.dim == 0 else 'col'
-        other_dim = 'row' if placement.dim == 1 else 'col'
+    return device_to_coordinate_map
 
-        chunk_size, extra = divmod(len(curr_ranges[curr_dim]), num_splits[idx])
-        start_entry_index = 0
-        for part_idx in range(num_splits[idx]):
-            curr_chunk = chunk_size + (1 if part_idx < extra else 0)
-            new_range = {curr_dim: curr_ranges[curr_dim][start_entry_index:start_entry_index + curr_chunk], other_dim: curr_ranges[other_dim]}
-            next_ranges.append(shard_or_replicate(new_range, placements, num_splits, idx+1, grid, device_mesh[part_idx]))
-            start_entry_index += curr_chunk
-    elif placement.is_replicate():
-        for part_idx in range(num_splits[idx]):
-            next_ranges.append(shard_or_replicate(curr_ranges, placements, num_splits, idx+1, grid, device_mesh[part_idx]))
-    else:
-        raise RuntimeError
-    return next_ranges
+def _convert_offset_to_ranges(all_offsets):
+    '''
+    Using tabulate package to create a table is easier when we specify row and col ranges
+    This function converts offsets to ranges.
+    '''
+    converted_blocks = []
 
+    for offset in all_offsets:
+        shape, offset, value = offset
 
-def find_unique_blocks(grid):
-    rows = len(grid)
-    columns = len(grid[0]) if rows > 0 else 0
-    compact_blocks = []
+        # Calculate row_range and column_range
+        row_range = (offset[0], offset[0] + shape[0] - 1)
+        column_range = (offset[1], offset[1] + shape[1] - 1)
 
-    for i in range(rows):
-        for j in range(columns):
-            # Check if cell is the top-left corner of a new block
-            if (i == 0 or grid[i][j] != grid[i-1][j]) and (j == 0 or grid[i][j] != grid[i][j-1]):
-                value = grid[i][j]
-                block_rows, block_cols = 1, 1
+        # Convert value to string to match your desired format
+        converted_block = {
+            'row_range': row_range, 
+            'column_range': column_range, 
+            'value': str(value)
+        }
+        converted_blocks.append(converted_block)
 
-                # Determine the size of the block
-                while i + block_rows < rows and grid[i + block_rows][j] == value:
-                    block_rows += 1
-                while j + block_cols < columns and grid[i][j + block_cols] == value:
-                    block_cols += 1
+    return converted_blocks
 
-                # Add block information to the list
-                compact_blocks.append({
-                    'row_range': (i, i + block_rows - 1),
-                    'column_range': (j, j + block_cols - 1),
-                    'value': value
-                })
-
-    return compact_blocks
-
-def create_table(blocks):
-    from tabulate import tabulate
+def _create_table(blocks):
+    '''
+    Creates a tabulate table given row and column ranges with device name
+    '''
+    try:
+        from tabulate import tabulate
+    except ImportError:
+        raise ImportError("tabulate package is required to visualize sharding")
 
     # Extract unique row and column ranges
     row_ranges = sorted(set([block['row_range'] for block in blocks]))
@@ -73,7 +67,10 @@ def create_table(blocks):
     for block in blocks:
         row_index = row_ranges.index(block['row_range'])
         col_index = col_ranges.index(block['column_range'])
-        matrix[row_index][col_index] = block['value']
+        if matrix[row_index][col_index] == '':
+            matrix[row_index][col_index] = block['value']
+        else:
+            matrix[row_index][col_index] += ', ' + block['value']
 
     # Prepare headers
     row_headers = [f"Row {r[0]}-{r[1]}" for r in row_ranges]
@@ -81,80 +78,92 @@ def create_table(blocks):
 
     return tabulate(matrix, headers=col_headers, showindex=row_headers)
 
+def compute_local_shape_and_global_offset(
+    global_shape: ShapeType, mesh: DeviceMesh, placements: Sequence[Placement], my_coordinate: List[int]
+) -> Tuple[Tuple[int, ...], Tuple[int, ...]]:
+    """
+    Same as torch.distributed._tensor._utils.compute_local_shape_and_global_offset but
+    with custom my_coordinate input
+
+    Compute the local tensor shape and the global offsets into the original tensor
+    of a DTensor on its current global rank. This is useful for checkpointing purpose.
+
+    Example (2 host with 4GPUs each):
+    # Below is a DeviceMesh with mesh_shape of (2, 4)
+    mesh = DeviceMesh(device_type="cuda",
+                        mesh=[
+                        [0, 1, 2, 3],
+                        [4, 5, 6, 7]
+                        ],
+    )
+
+    Let's say we distribute a global_tensor of shape (8,4) over the above DeviceMesh
+    with a placements of [Shard(0), Shard(0)].
+    The local shape and global offset will be as follows:
+    rank0 -- local_shape:[1, 4], global_offset:[0, 0]
+    rank1 -- local_shape:[1, 4], global_offset:[1, 0]
+    rank2 -- local_shape:[1, 4], global_offset:[2, 0]
+    rank5 -- local_shape:[1, 4], global_offset:[5, 0]
+    rank3 -- local_shape:[1, 4], global_offset:[3, 0]
+    rank4 -- local_shape:[1, 4], global_offset:[4, 0]
+    rank6 -- local_shape:[1, 4], global_offset:[6, 0]
+    rank7 -- local_shape:[1, 4], global_offset:[7, 0]
+    """
+
+    if my_coordinate is None:
+        # if rank not in the mesh, return empty offset
+        return ((), ())
+    else:
+        local_shape = list(global_shape)
+        global_offset = [0] * len(global_shape)
+
+        for idx, placement in enumerate(placements):
+            mesh_dim_size = mesh.size(idx)
+            if isinstance(placement, Shard):
+                shard_dim = placement.dim
+                local_offset = [0] * len(global_shape)
+                assert shard_dim < len(
+                    local_shape
+                ), f"Sharding dim {shard_dim} greater than tensor ndim {len(local_shape)}"
+                shard_size, shard_offset = placement._local_shard_size_on_dim(
+                    local_shape[shard_dim],
+                    mesh_dim_size,
+                    my_coordinate[idx],
+                    return_offset=True,
+                )
+
+                local_shape[shard_dim] = shard_size
+                local_offset[shard_dim] = shard_offset
+
+                # On a given dimension, if the local_offset[shard_dim] is smaller than global_offset[shard_dim],
+                # it means that this dimension has been already sharded in previous placement.
+                # Therefore, we cannot simply replace the global_offset[shard_dim] with local_offset[shard_dim].
+                # Instead, for the given shard_dim, we need to add local_offset[shard_dim] to existing global_offset[shard_dim].
+                if global_offset[shard_dim] <= local_offset[shard_dim]:
+                    global_offset[shard_dim] = local_offset[shard_dim]
+                else:
+                    global_offset[shard_dim] += local_offset[shard_dim]
+
+        return tuple(local_shape), tuple(global_offset)
+
 def visualize_sharding(dtensor):
+    '''
+    Visualizes sharding in 1D-2D dtensors
+    Requires tabulate, install with `pip install tabulate`
+    '''
+    if len(dtensor.shape) >= 3:
+        raise RuntimeError("visualize sharding is only implemented for 1D or 2D dtensor")
     placements = dtensor.placements
-    device_mesh = dtensor.device_mesh.mesh.tolist()
+    device_mesh = dtensor.device_mesh
+    device_type = dtensor.device_mesh.device_type
 
-    # Find number of devices per level for nested device_mesh
-    num_splits = []
-    curr_devices = device_mesh.copy()
-    while isinstance(curr_devices, list):
-        num_splits.append(len(curr_devices))
-        curr_devices = curr_devices[0]
-
-    # We decide splits based on range
-    start_range = {'row': list(range(dtensor.shape[0])), 'col': list(range(dtensor.shape[1]))}
-
-    # Initialize the visualization grid assuming 2D tensor
-    grid = [["" for _ in range(dtensor.shape[1])] for _ in range(dtensor.shape[0])]
-    shard_or_replicate(start_range, placements, num_splits, 0, grid, device_mesh)
-    # The grid is now 2D array containing device names, we need to make it compact to remove redundancy
-    blocks = find_unique_blocks(grid)
-    # Finally create the desired table
-    print(create_table(blocks))
-
-if __name__ == "__main__":
-    world_size = int(os.environ['WORLD_SIZE'])
+    device_map = _mesh_to_coordinate(device_mesh, device_type)
+    all_offsets = []
+    for device in device_map:
+        local_shape, global_offset = compute_local_shape_and_global_offset(dtensor.shape, device_mesh, placements, device_map[device])
+        all_offsets.append([local_shape, global_offset, device])
     
-    # Example 1
-    tensor = torch.randn(4, 4)
-    mesh = DeviceMesh("cuda", list(range(world_size)))
-    dtensor = distribute_tensor(tensor, mesh, [Shard(dim=1)])
-    if int(os.environ['LOCAL_RANK']) == 0:
-        visualize_sharding(dtensor)
-        '''
-                 Col 0-0    Col 1-1    Col 2-2    Col 3-3
-        -------  ---------  ---------  ---------  ---------
-        Row 0-3  Device:0   Device:1   Device:2   Device:3
-        '''
-    
-    # Example 2
-    tensor = torch.randn(4, 4)
-    mesh = DeviceMesh("cuda", list(range(world_size)))
-    dtensor = distribute_tensor(tensor, mesh, [Shard(dim=0)])
-    if int(os.environ['LOCAL_RANK']) == 0:
-        visualize_sharding(dtensor)
-        '''
-                 Col 0-3
-        -------  ---------
-        Row 0-0  Device:0
-        Row 1-1  Device:1
-        Row 2-2  Device:2
-        Row 3-3  Device:3
-        '''
-    
-    # Example 3
-    tensor = torch.randn(4, 4)
-    mesh = DeviceMesh("cuda", [[0, 1], [2, 3]])
-    dtensor = distribute_tensor(tensor, mesh, [Shard(dim=0), Replicate()])
-    if int(os.environ['LOCAL_RANK']) == 0:
-        visualize_sharding(dtensor)
-        '''
-                 Col 0-3
-        -------  ------------------
-        Row 0-1  Device:0, Device:1
-        Row 2-3  Device:2, Device:3
-        '''
-
-    # Example 4
-    tensor = torch.randn(4, 4)
-    mesh = DeviceMesh("cuda", [[0, 1], [2, 3]])
-    dtensor = distribute_tensor(tensor, mesh, [Replicate(), Shard(dim=0)])
-    if int(os.environ['LOCAL_RANK']) == 0:
-        visualize_sharding(dtensor)
-        '''
-                 Col 0-3
-        -------  ------------------
-        Row 0-1  Device:0, Device:2
-        Row 2-3  Device:1, Device:3
-        '''
+    # Convert offsets to blocks with row_ranges for tabulate
+    blocks = _convert_offset_to_ranges(all_offsets)
+    if device_mesh.get_rank() == 0:
+        print(_create_table(blocks))

--- a/torch/distributed/_tensor/debug/visualize_sharding.py
+++ b/torch/distributed/_tensor/debug/visualize_sharding.py
@@ -83,31 +83,7 @@ def compute_local_shape_and_global_offset(
 ) -> Tuple[Tuple[int, ...], Tuple[int, ...]]:
     """
     Same as torch.distributed._tensor._utils.compute_local_shape_and_global_offset but
-    with custom my_coordinate input
-
-    Compute the local tensor shape and the global offsets into the original tensor
-    of a DTensor on its current global rank. This is useful for checkpointing purpose.
-
-    Example (2 host with 4GPUs each):
-    # Below is a DeviceMesh with mesh_shape of (2, 4)
-    mesh = DeviceMesh(device_type="cuda",
-                        mesh=[
-                        [0, 1, 2, 3],
-                        [4, 5, 6, 7]
-                        ],
-    )
-
-    Let's say we distribute a global_tensor of shape (8,4) over the above DeviceMesh
-    with a placements of [Shard(0), Shard(0)].
-    The local shape and global offset will be as follows:
-    rank0 -- local_shape:[1, 4], global_offset:[0, 0]
-    rank1 -- local_shape:[1, 4], global_offset:[1, 0]
-    rank2 -- local_shape:[1, 4], global_offset:[2, 0]
-    rank5 -- local_shape:[1, 4], global_offset:[5, 0]
-    rank3 -- local_shape:[1, 4], global_offset:[3, 0]
-    rank4 -- local_shape:[1, 4], global_offset:[4, 0]
-    rank6 -- local_shape:[1, 4], global_offset:[6, 0]
-    rank7 -- local_shape:[1, 4], global_offset:[7, 0]
+    with custom my_coordinate input. This is the modified implementation for visualize_sharding.
     """
 
     if my_coordinate is None:

--- a/torch/distributed/_tensor/examples/visualize_sharding_example.py
+++ b/torch/distributed/_tensor/examples/visualize_sharding_example.py
@@ -1,0 +1,59 @@
+import torch
+from torch.distributed._tensor.debug.visualize_sharding import visualize_sharding
+from torch.distributed._tensor import DeviceMesh, Shard, Replicate, distribute_tensor
+
+import os
+world_size = int(os.environ['WORLD_SIZE'])
+
+# Example 1
+tensor = torch.randn(4, 4)
+mesh = DeviceMesh("cuda", list(range(world_size)))
+dtensor = distribute_tensor(tensor, mesh, [Shard(dim=1)])
+if int(os.environ['LOCAL_RANK']) == 0:
+    visualize_sharding(dtensor)
+    '''
+                Col 0-0    Col 1-1    Col 2-2    Col 3-3
+    -------  ---------  ---------  ---------  ---------
+    Row 0-3  cuda:0   cuda:1   cuda:2   cuda:3
+    '''
+
+# Example 2
+tensor = torch.randn(4, 4)
+mesh = DeviceMesh("cuda", list(range(world_size)))
+dtensor = distribute_tensor(tensor, mesh, [Shard(dim=0)])
+if int(os.environ['LOCAL_RANK']) == 0:
+    visualize_sharding(dtensor)
+    '''
+                Col 0-3
+    -------  ---------
+    Row 0-0  cuda:0
+    Row 1-1  cuda:1
+    Row 2-2  cuda:2
+    Row 3-3  cuda:3
+    '''
+
+# Example 3
+tensor = torch.randn(4, 4)
+mesh = DeviceMesh("cuda", [[0, 1], [2, 3]])
+dtensor = distribute_tensor(tensor, mesh, [Shard(dim=0), Replicate()])
+if int(os.environ['LOCAL_RANK']) == 0:
+    visualize_sharding(dtensor)
+    '''
+                Col 0-3
+    -------  ------------------
+    Row 0-1  cuda:0, cuda:1
+    Row 2-3  cuda:2, cuda:3
+    '''
+
+# Example 4
+tensor = torch.randn(4, 4)
+mesh = DeviceMesh("cuda", [[0, 1], [2, 3]])
+dtensor = distribute_tensor(tensor, mesh, [Replicate(), Shard(dim=0)])
+if int(os.environ['LOCAL_RANK']) == 0:
+    visualize_sharding(dtensor)
+    '''
+                Col 0-3
+    -------  ------------------
+    Row 0-1  cuda:0, cuda:2
+    Row 2-3  cuda:1, cuda:3
+    '''

--- a/torch/distributed/_tensor/examples/visualize_sharding_example.py
+++ b/torch/distributed/_tensor/examples/visualize_sharding_example.py
@@ -1,59 +1,60 @@
-import torch
-from torch.distributed._tensor.debug.visualize_sharding import visualize_sharding
-from torch.distributed._tensor import DeviceMesh, Shard, Replicate, distribute_tensor
-
 import os
-world_size = int(os.environ['WORLD_SIZE'])
+
+import torch
+from torch.distributed._tensor import DeviceMesh, distribute_tensor, Replicate, Shard
+from torch.distributed._tensor.debug.visualize_sharding import visualize_sharding
+
+world_size = int(os.environ["WORLD_SIZE"])
 
 # Example 1
 tensor = torch.randn(4, 4)
 mesh = DeviceMesh("cuda", list(range(world_size)))
 dtensor = distribute_tensor(tensor, mesh, [Shard(dim=1)])
-if int(os.environ['LOCAL_RANK']) == 0:
+if int(os.environ["LOCAL_RANK"]) == 0:
     visualize_sharding(dtensor)
-    '''
+    """
              Col 0-0    Col 1-1    Col 2-2    Col 3-3
     -------  ---------  ---------  ---------  ---------
     Row 0-3  cuda:0   cuda:1   cuda:2   cuda:3
-    '''
+    """
 
 # Example 2
 tensor = torch.randn(4, 4)
 mesh = DeviceMesh("cuda", list(range(world_size)))
 dtensor = distribute_tensor(tensor, mesh, [Shard(dim=0)])
-if int(os.environ['LOCAL_RANK']) == 0:
+if int(os.environ["LOCAL_RANK"]) == 0:
     visualize_sharding(dtensor)
-    '''
+    """
              Col 0-3
     -------  ---------
     Row 0-0  cuda:0
     Row 1-1  cuda:1
     Row 2-2  cuda:2
     Row 3-3  cuda:3
-    '''
+    """
 
 # Example 3
 tensor = torch.randn(4, 4)
 mesh = DeviceMesh("cuda", [[0, 1], [2, 3]])
 dtensor = distribute_tensor(tensor, mesh, [Shard(dim=0), Replicate()])
-if int(os.environ['LOCAL_RANK']) == 0:
+if int(os.environ["LOCAL_RANK"]) == 0:
     visualize_sharding(dtensor)
-    '''
+    """
              Col 0-3
     -------  ------------------
     Row 0-1  cuda:0, cuda:1
     Row 2-3  cuda:2, cuda:3
-    '''
+    """
 
 # Example 4
 tensor = torch.randn(4, 4)
 mesh = DeviceMesh("cuda", [[0, 1], [2, 3]])
 dtensor = distribute_tensor(tensor, mesh, [Replicate(), Shard(dim=0)])
-if int(os.environ['LOCAL_RANK']) == 0:
+if int(os.environ["LOCAL_RANK"]) == 0:
     visualize_sharding(dtensor)
-    '''
+    """
              Col 0-3
     -------  ------------------
     Row 0-1  cuda:0, cuda:2
     Row 2-3  cuda:1, cuda:3
-    '''
+    """

--- a/torch/distributed/_tensor/examples/visualize_sharding_example.py
+++ b/torch/distributed/_tensor/examples/visualize_sharding_example.py
@@ -12,7 +12,7 @@ dtensor = distribute_tensor(tensor, mesh, [Shard(dim=1)])
 if int(os.environ['LOCAL_RANK']) == 0:
     visualize_sharding(dtensor)
     '''
-                Col 0-0    Col 1-1    Col 2-2    Col 3-3
+             Col 0-0    Col 1-1    Col 2-2    Col 3-3
     -------  ---------  ---------  ---------  ---------
     Row 0-3  cuda:0   cuda:1   cuda:2   cuda:3
     '''
@@ -24,7 +24,7 @@ dtensor = distribute_tensor(tensor, mesh, [Shard(dim=0)])
 if int(os.environ['LOCAL_RANK']) == 0:
     visualize_sharding(dtensor)
     '''
-                Col 0-3
+             Col 0-3
     -------  ---------
     Row 0-0  cuda:0
     Row 1-1  cuda:1
@@ -39,7 +39,7 @@ dtensor = distribute_tensor(tensor, mesh, [Shard(dim=0), Replicate()])
 if int(os.environ['LOCAL_RANK']) == 0:
     visualize_sharding(dtensor)
     '''
-                Col 0-3
+             Col 0-3
     -------  ------------------
     Row 0-1  cuda:0, cuda:1
     Row 2-3  cuda:2, cuda:3
@@ -52,7 +52,7 @@ dtensor = distribute_tensor(tensor, mesh, [Replicate(), Shard(dim=0)])
 if int(os.environ['LOCAL_RANK']) == 0:
     visualize_sharding(dtensor)
     '''
-                Col 0-3
+             Col 0-3
     -------  ------------------
     Row 0-1  cuda:0, cuda:2
     Row 2-3  cuda:1, cuda:3


### PR DESCRIPTION
This pull request adds a tool to visualize sharding. It uses the device_mesh and placement details to construct a visualization of the split of a torch dtensor.

Things to fix:

- [x] This implementation only uses the first element of the placement tuple, when can there be more than one elements?
- [x] The calculation of the split is happening here but maybe it is already done somewhere internally in Shard class and can we directly call that here?

Fixes #108746 


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @kiukchung @lucasllc