### PR TITLE
[inductor max autotune] Flexible GEMM layout autotuning

### DIFF
--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -12,6 +12,7 @@ from typing import (
     Callable,
     ClassVar,
     Dict,
+    Generator,
     List,
     NamedTuple,
     Optional,
@@ -1190,7 +1191,9 @@ def jinja2_env():
     except ImportError:
         return None
 
+
 PrimitiveInfoType = Union[int, float, bool, str]
+
 
 class ChoiceCaller:
     """
@@ -1261,17 +1264,17 @@ class KernelTemplate:
         Maybe generates a new ChoiceCaller and appends it into existing choices.
 
         choices: A list of ChoiceCallers.
-        kwargs: Additional kwargs to be passed to self.generate() to generate a new ChoiceCaller.
+        kwargs: Additional kwargs to be passed to self.generate() to generate new ChoiceCallers.
         """
 
         try:
-            choices.append(self.generate(**kwargs))
+            choices.extend(self.generate(**kwargs))
         except NotImplementedError:
             pass
 
-    def generate(self, **kwargs) -> ChoiceCaller:
+    def generate(self, **kwargs) -> Generator[ChoiceCaller, None, None]:
         """
-        Generates a ChoiceCaller instance from the given arguments.
+        Generates a sequence of ChoiceCaller instances from the given arguments.
         """
 
         raise NotImplementedError()

--- a/torch/_inductor/codegen/cuda/cuda_template.py
+++ b/torch/_inductor/codegen/cuda/cuda_template.py
@@ -1,14 +1,23 @@
+import copy
 import functools
 import itertools
 import logging
-from typing import List, Optional
+from typing import Generator, List, Optional
 from unittest.mock import patch
 
 import sympy
 
 import torch
+from ... import ir
 from ...autotune_process import CUDABenchmarkRequest, TensorMeta
-from ...ir import Buffer, CUDATemplateBuffer, IRNode, Layout
+from ...ir import (
+    Buffer,
+    CUDATemplateBuffer,
+    FixedLayout,
+    FlexibleLayout,
+    IRNode,
+    Layout,
+)
 
 from ...utils import IndentedBuffer, unique
 from ...virtualized import V
@@ -48,7 +57,7 @@ class CUDATemplate(KernelTemplate):
     def generate(  # type: ignore[override]
         self,
         **kwargs,
-    ) -> CUDATemplateCaller:
+    ) -> Generator[CUDATemplateCaller, None, None]:
         """
         Generates the CUDA template caller object for the given GEMM template and operation. This CUDATemplateCaller
         may be used to call and benchmark the generated CUDA kernel in a standalone manner to enable Autotuning.
@@ -59,75 +68,138 @@ class CUDATemplate(KernelTemplate):
         Returns:
             A CUDATemplateCaller object representing the generated CUDA template caller.
         """
-        kernel_name = f"cuda_{self.name}"
-        with patch.object(
-            V.graph, "get_dtype", self._fake_get_dtype(self.output_node)
-        ), CUDATemplateKernel(
-            kernel_name=kernel_name,
-        ) as kernel:
-            code = self.render(kernel=kernel, **kwargs)
-            _, call_args, _ = kernel.args.python_argdefs()
-            log.debug("Generated Code:\n%s", code)
+
+        # Generate Row-Major and Column-Major variants of all flexible input tensor layouts
+        input_layout_alternatives: List[List[TensorMeta]] = []
+        for input_node in self.input_nodes:
+            unchanged_variant = TensorMeta.from_irnodes(input_node)
+            input_tensor_meta_variants = [unchanged_variant]
+            if (
+                hasattr(input_node, "layout")
+                and isinstance(input_node.layout, FlexibleLayout)
+                and len(input_node.layout.stride) >= 2
+            ):
+                layout_variant = copy.deepcopy(unchanged_variant)
+                # switch the last two strides
+                tmp = layout_variant.strides[-1]
+                # we can't mutate the strides tuple directly
+                new_strides = list(layout_variant.strides)
+                new_strides[-1] = layout_variant.strides[-2]
+                new_strides[-2] = tmp
+                layout_variant.strides = tuple(new_strides)
+                input_tensor_meta_variants.append(layout_variant)
+            input_layout_alternatives.append(input_tensor_meta_variants)
+        all_variant_combinations = list(itertools.product(*input_layout_alternatives))
+        if len(all_variant_combinations) != 1:
             log.debug(
-                "Args: cpp_argdefs: %s, python_argdefs: %s",
-                kernel.args.cpp_argdefs(),
-                kernel.args.python_argdefs(),
+                "Generating %d input layout variants of %s",
+                len(all_variant_combinations),
+                str(self),
+            )
+        for kernel_idx, input_tensor_meta in enumerate(all_variant_combinations):
+            kernel_name = f"cuda_{self.name}_{kernel_idx}"
+            with patch.object(
+                V.graph, "get_dtype", self._fake_get_dtype(self.output_node)
+            ), CUDATemplateKernel(
+                kernel_name=kernel_name,
+            ) as kernel:
+                original_layouts = [
+                    getattr(input_node, "layout", None)
+                    for input_node in self.input_nodes
+                ]
+                try:
+                    # temporarily set the strides of input nodes with FlexibleLayouts
+                    # to the strides of the input_tensor_meta
+                    for input_node, input_tensor_meta_variant in zip(
+                        self.input_nodes, input_tensor_meta
+                    ):
+                        if isinstance(input_node.layout, FlexibleLayout):
+                            lo = input_node.layout
+                            new_layout = FixedLayout(
+                                lo.device,
+                                lo.dtype,
+                                lo.size,
+                                input_tensor_meta_variant.strides,
+                                lo.offset,
+                            )
+                            if isinstance(input_node, ir.MutableBox):
+                                input_node.data.layout = new_layout
+                            else:
+                                input_node.layout = new_layout
+                    code = self.render(kernel=kernel, **kwargs)
+                finally:
+                    # restore the original (still flexible until Autotuning has been resolved) strides
+                    for input_node, original_layout in zip(
+                        self.input_nodes, original_layouts
+                    ):
+                        if isinstance(original_layout, FlexibleLayout):
+                            if isinstance(input_node, ir.MutableBox):
+                                input_node.data.layout = original_layout
+                            else:
+                                input_node.layout = original_layout
+
+                _, call_args, _ = kernel.args.python_argdefs()
+                log.debug("Generated Code:\n%s", code)
+                log.debug(
+                    "Args: cpp_argdefs: %s, python_argdefs: %s",
+                    kernel.args.cpp_argdefs(),
+                    kernel.args.python_argdefs(),
+                )
+
+            input_reorder = (
+                self.input_reorder
+                if self.input_reorder is not None
+                else list(range(len(self.input_nodes)))
+            )
+            expected_args = list(
+                unique(self.input_nodes[idx].get_name() for idx in input_reorder)
+            )
+            expected_args.extend([self.output_node.get_name()])
+            assert list(call_args)[: len(expected_args)] == expected_args, (
+                call_args,
+                expected_args,
+            )
+            extra_args = V.graph.sizevars.size_hints(
+                map(sympy.expand, call_args[len(expected_args) :])
             )
 
-        input_reorder = (
-            self.input_reorder
-            if self.input_reorder is not None
-            else list(range(len(self.input_nodes)))
-        )
-        expected_args = list(
-            unique(self.input_nodes[idx].get_name() for idx in input_reorder)
-        )
-        expected_args.extend([self.output_node.get_name()])
-        assert list(call_args)[: len(expected_args)] == expected_args, (
-            call_args,
-            expected_args,
-        )
-        extra_args = V.graph.sizevars.size_hints(
-            map(sympy.expand, call_args[len(expected_args) :])
-        )
+            kernel_hash_name = f"cuda_{self.name}_{next(self.index_counter)}"
 
-        kernel_hash_name = f"cuda_{self.name}_{next(self.index_counter)}"
+            def make_kernel_render(
+                template_node: CUDATemplateBuffer,
+                epilogue_nodes: Optional[List[IRNode]] = None,
+            ):
+                kernel = CUDATemplateKernel(
+                    kernel_name="KERNEL_NAME",
+                )
+                render = functools.partial(
+                    self.render,
+                    kernel=kernel,
+                    template_buffer_node=template_node,
+                    epilogue_nodes=epilogue_nodes,
+                    **kwargs,  # includes "op" argument in case of CUTLASSGemmTemplate
+                )
+                return kernel, render
 
-        # create the BenchmarkRequest
-        bmreq = CUDABenchmarkRequest(
-            kernel_name=kernel_name,
-            input_tensor_meta=TensorMeta.from_irnodes(self.input_nodes),
-            output_tensor_meta=TensorMeta.from_irnodes(self.output_node),
-            extra_args=extra_args,
-            source_code=code,
-        )
-
-        def make_kernel_render(
-            template_node: CUDATemplateBuffer,
-            epilogue_nodes: Optional[List[IRNode]] = None,
-        ):
-            kernel = CUDATemplateKernel(
-                kernel_name="KERNEL_NAME",
+            # create the BenchmarkRequest
+            bmreq = CUDABenchmarkRequest(
+                kernel_name=kernel_name,
+                input_tensor_meta=input_tensor_meta,
+                output_tensor_meta=TensorMeta.from_irnodes(self.output_node),
+                extra_args=extra_args,
+                source_code=code,
             )
-            render = functools.partial(
-                self.render,
-                kernel=kernel,
-                template_buffer_node=template_node,
-                epilogue_nodes=epilogue_nodes,
-                **kwargs,  # includes "op" argument in case of CUTLASSGemmTemplate
-            )
-            return kernel, render
 
-        return CUDATemplateCaller(
-            kernel_hash_name,
-            self.name,
-            self.input_nodes,
-            self.output_node.get_layout(),
-            make_kernel_render,
-            bmreq,
-            self,
-            kwargs,
-        )
+            yield CUDATemplateCaller(
+                kernel_hash_name,
+                self.name,
+                self.input_nodes,
+                self.output_node.get_layout(),
+                make_kernel_render,
+                bmreq,
+                self,
+                kwargs,
+            )
 
     def are_inputs_layout_compatible(self, layouts: List[Layout]) -> bool:
         raise NotImplementedError()

--- a/torch/_inductor/codegen/cuda/gemm_template.py
+++ b/torch/_inductor/codegen/cuda/gemm_template.py
@@ -803,6 +803,8 @@ class CUTLASSGemmTemplate(CUTLASSTemplate):
 
         assert len(self.input_nodes) >= 2 and self.output_node is not None
         X, W = self.input_nodes[0], self.input_nodes[1]
+        assert isinstance(X.layout, FixedLayout), "X.layout is not fixed"
+        assert isinstance(W.layout, FixedLayout), "W.layout is not fixed"
         Y = self.output_node
         Bias = None if len(self.input_nodes) == 2 else self.input_nodes[2]
         if (

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3153,6 +3153,18 @@ class CUDATemplateBuffer(TemplateBuffer):
     def get_workspace_size(self):
         return self.workspace_size if self.workspace_size is not None else 0
 
+    def get_read_writes(self):
+        with patch.object(FlexibleLayout, "allow_indexing", True):
+            return super().get_read_writes()
+
+    def normalized_read_writes(self):
+        with patch.object(FlexibleLayout, "allow_indexing", True):
+            return super().normalized_read_writes()
+
+    def decide_layout(self):
+        if isinstance(self.layout, FlexibleLayout):
+            self.freeze_layout()
+
 
 @dataclasses.dataclass
 class InputsKernel(Buffer):

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -9,7 +9,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from io import StringIO
 
-from typing import Any, Callable, Dict, List, Optional, Type, Union
+from typing import Any, Callable, Dict, Generator, List, Optional, Type, Union
 from unittest.mock import patch
 
 import sympy
@@ -430,7 +430,7 @@ class TritonTemplate(KernelTemplate):
         suffix_args=0,
         epilogue_fn=identity,
         **kwargs,
-    ):
+    ) -> Generator[ChoiceCaller, None, None]:
         assert self.template, "requires jinja2"
         defines = StringIO()
         for name, val in kwargs.items():
@@ -539,7 +539,7 @@ class TritonTemplate(KernelTemplate):
             output_tensor_meta=TensorMeta.from_irnodes(layout),
         )
 
-        return TritonTemplateCaller(
+        yield TritonTemplateCaller(
             kernel_hash_name,
             input_nodes,
             layout,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #114312
* #114075
* #113932
* #112861
* #113891
* #113959
* #113890
* #113570
* #113569
* #113558
* #113399
* #113367
* #113366
* #113365

This diff introduces memory layout autotuning and
flexibilizes memory layouts that are accepted and
written by the Cutlass GEMM Kernels.

During autotuning, if Cutlass GEMM Kernels have
inputs with Flexible Layouts, all possible combinations
of row-major or column major layouts are tried during
autotuning.

Test Plan:

 * Additional Unit test(s) (more tbd)
 * CI