### PR TITLE
[MPS] Fix test_copy_cast_no_leak

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -317,6 +317,8 @@ RUN_PARALLEL_BLOCKLIST = [
     "test_cuda_nvml_based_avail",
     # temporarily sets a global config
     "test_autograd_fallback",
+    # Runs memory leak tess
+    "test_mps",
 ] + FSDP_TEST
 
 # Test files that should always be run serially with other test files,
@@ -357,7 +359,6 @@ CI_SERIAL_LIST = [
     "test_autocast",  # OOM
     "test_native_mha",  # OOM
     "test_module_hooks",  # OOM
-    "test_mps", # Need to run sequentially to test for memory leaks
     "inductor/test_max_autotune",  # Testing, probably revert later
 ]
 # A subset of onnx tests that cannot run in parallel due to high memory usage.

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -357,6 +357,7 @@ CI_SERIAL_LIST = [
     "test_autocast",  # OOM
     "test_native_mha",  # OOM
     "test_module_hooks",  # OOM
+    "test_mps", # Need to run sequentially to test for memory leaks
     "inductor/test_max_autotune",  # Testing, probably revert later
 ]
 # A subset of onnx tests that cannot run in parallel due to high memory usage.

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -317,8 +317,6 @@ RUN_PARALLEL_BLOCKLIST = [
     "test_cuda_nvml_based_avail",
     # temporarily sets a global config
     "test_autograd_fallback",
-    # Runs memory leak tess
-    "test_mps",
 ] + FSDP_TEST
 
 # Test files that should always be run serially with other test files,

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1055,10 +1055,15 @@ class TestMemoryLeak(TestCaseMPS):
 
     def test_copy_cast_no_leak(self):
         a = torch.randn(128, 128, device='mps', dtype=torch.float16)
+        def step(x):
+            x = x.to(device='cpu', dtype=torch.float32)
+            x = x.to(device='mps', dtype=torch.float16)
+
+        # Warm up / prebuild MPS shaders (otherwise check fails on 13.2)
+        step(a)
         torch.mps.empty_cache()
         driver_before = torch.mps.driver_allocated_memory()
-        a = a.to(device='cpu', dtype=torch.float32)
-        a = a.to(device='mps', dtype=torch.float16)
+        step(a)
         torch.mps.empty_cache()
         driver_after = torch.mps.driver_allocated_memory()
         self.assertTrue(driver_before == driver_after, f"Detected {driver_after-driver_before} bytes leak of GPU memory")

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1054,11 +1054,12 @@ class TestMemoryLeak(TestCaseMPS):
             leak_gpu0()
 
     def test_copy_cast_no_leak(self):
-        a = torch.randn(128, 128, device='mps', dtype=torch.float16)
+
         def step(x):
             x = x.to(device='cpu', dtype=torch.float32)
             x = x.to(device='mps', dtype=torch.float16)
 
+        a = torch.randn(128, 128, device='mps', dtype=torch.float16)
         # Warm up / prebuild MPS shaders (otherwise check fails on 13.2)
         step(a)
         torch.mps.empty_cache()


### PR DESCRIPTION
When running on MacOS-13.2 test always fails on first run, but succeeds on the second as presumably it reserves some memory to cache f32->f16 graph. Make it resilient against such failures by adding a warmup step when one conversion is performed before recording driver memory utilization. 

Fixes https://github.com/pytorch/pytorch/issues/114305