### PR TITLE
Move instruction translator stack references to TC, step toward getting `tx` wherever

### DIFF
--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -812,7 +812,7 @@ class InstructionTranslatorBase(Checkpointable[InstructionTranslatorGraphState])
     def run(self):
         with self.run_ctx_mgr():
             try:
-                self.output.push_tx(self)
+                self.output.tracing_context.push_tx(self)
                 while (
                     self.instruction_pointer is not None
                     and not self.output.should_exit
@@ -826,7 +826,7 @@ class InstructionTranslatorBase(Checkpointable[InstructionTranslatorGraphState])
                     e.exec_record = self.exec_recorder.get_record()  # type: ignore[attr-defined]
                 raise
             finally:
-                self.output.pop_tx()
+                self.output.tracing_context.pop_tx()
                 # Cleanup the outputGraph to delete the held tensors. We perform the
                 # cleanup only for InstructionTranslator and not
                 # InliningInstructionTranslator. The InliningInstructionTranslator

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -4,7 +4,6 @@ import dataclasses
 import enum
 import functools
 import logging
-import threading
 import weakref
 from abc import ABC, abstractmethod
 from typing import (

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1151,7 +1151,7 @@ def compile_fx(
     )
     tracing_context = (
         torch._tracing_context.TracingContext.try_get()
-        or torch._tracing_context.TracingContext(fake_mode)
+        or torch._tracing_context.TracingContext(fake_mode, None)
     )
 
     if V.aot_compilation is True:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #114316
* __->__ #114318
* #114317

Lint

[WIP] wip

cc @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler