### PR TITLE
Fix module: distributed labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -69,8 +69,8 @@
 - .ci/docker/ci_commit_pins/triton.txt
 
 "module: distributed":
-- /torch/csrc/distributed/**
-- /torch/distributed/**
-- /torch/nn/parallel/**
-- /test/distributed/**
-- /torch/testing/_internal/distributed/**
+- torch/csrc/distributed/**
+- torch/distributed/**
+- torch/nn/parallel/**
+- test/distributed/**
+- torch/testing/_internal/distributed/**


### PR DESCRIPTION
Removes preceding `/` which was preventing labeler from working.  (looks like a typo in the original PR)

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #114323
* __->__ #114324

