### PR TITLE
[AOTAutograd] fix aot autograd incorrectly assumes ambient `no_grad` even though output `requires_grad`

### DIFF
--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -800,6 +800,7 @@ class AotAutogradFallbackTests(torch._dynamo.test_case.TestCase):
                 decompositions=None,
                 num_params_buffers=param_and_buf_len,
                 no_tangents=True,
+                trace_joint=True,
             )
 
         # Walk all the nodes in fx graph.

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -3205,6 +3205,10 @@ def create_runtime_wrapper(
             for idx in indices_of_inps_to_detach:
                 if isinstance(args_[idx], torch.Tensor):
                     args_[idx] = args_[idx].detach()
+
+            # Ignores ambient no_grad if there is a joint graph.
+            # enable_grad is (in theory) required to correctly create the outputs
+            # that require_grad.
             with torch.enable_grad(), torch.autograd._force_original_view_tracking(True):
                 all_outs = call_func_with_args(
                     compiled_fn,

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -3205,7 +3205,7 @@ def create_runtime_wrapper(
             for idx in indices_of_inps_to_detach:
                 if isinstance(args_[idx], torch.Tensor):
                     args_[idx] = args_[idx].detach()
-            with torch.autograd._force_original_view_tracking(True):
+            with torch.enable_grad(), torch.autograd._force_original_view_tracking(True):
                 all_outs = call_func_with_args(
                     compiled_fn,
                     args_,
@@ -4458,7 +4458,7 @@ def create_aot_dispatcher_function(
 
         needs_autograd = (
             any(x.requires_grad for x in fake_flat_args if isinstance(x, Tensor))
-            and torch.is_grad_enabled()
+            or torch.is_grad_enabled()
         )
 
         with enable_python_dispatcher():

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1700,7 +1700,7 @@ class AOTConfig:
     inference_compiler: Optional[Callable] = None
     enable_log: bool = True
     # will attempt to create joint graph, unless no output requires grad
-    trace_joint: bool = True
+    allow_joint_graph: bool = True
 
 # This function takes in a tensor t, and returns one of t, t.view(), or t.clone().
 # When tracing the joint forward + backward, for any inputs in the graph that are mutated,
@@ -4462,7 +4462,7 @@ def create_aot_dispatcher_function(
 
         fake_flat_args = process_inputs(flat_args)
 
-        needs_autograd = aot_config.trace_joint and (
+        needs_autograd = aot_config.allow_joint_graph and (
             any(x.requires_grad for x in fake_flat_args if isinstance(x, Tensor))
             or torch.is_grad_enabled()
         )
@@ -5333,7 +5333,7 @@ def _aot_export_function(
         aot_autograd_arg_pos_to_source=None,
         is_export=True,
         no_tangents=no_tangents,
-        trace_joint=trace_joint,
+        allow_joint_graph=trace_joint,
     )
 
     fx_g, meta = create_aot_dispatcher_function(


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/114338

This is a hotfix, but it seems there is a nest of issues here potentially.

Not fixed:
1. Sister issue (not fixed): https://github.com/pytorch/pytorch/issues/114344
2. Note that there may also be another subtle issue in https://github.com/pytorch/pytorch/blob/4e4a6ad6ecd71a1aefde3992ecf7f77e37d2e264/torch/_functorch/aot_autograd.py#L4270
I suspect we need to change and to or / else rely on collected output metas to determine if any output requires_grad. This would require additional testing/exploration. (or maybe it is fine? It could just be to avoid nested grad)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng