### PR TITLE
[RelEng] Tag docker images for release, pin unstable and disabled jobs, apply release only changes

### DIFF
--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -10,8 +10,8 @@ architectures:
     * Latest ROCM
 """
 
-from typing import Dict, List, Optional, Tuple
 import os
+from typing import Dict, List, Optional, Tuple
 
 CUDA_ARCHES = ["11.8", "12.1"]
 
@@ -37,6 +37,7 @@ PYTORCH_EXTRA_INSTALL_REQUIREMENTS = (
     "nvidia-nccl-cu12==2.19.3; platform_system == 'Linux' and platform_machine == 'x86_64' | "
     "nvidia-nvtx-cu12==12.1.105; platform_system == 'Linux' and platform_machine == 'x86_64'"
 )
+
 
 def get_nccl_submodule_version() -> str:
     from pathlib import Path
@@ -91,6 +92,7 @@ def arch_type(arch_version: str) -> str:
         return "cpu-aarch64"
     else:  # arch_version should always be "cpu" in this case
         return "cpu"
+
 
 # This can be updated to the release version when cutting release branch, i.e. 2.1
 DEFAULT_TAG = os.getenv("RELEASE_VERSION_TAG", "main")
@@ -156,6 +158,7 @@ LIBTORCH_CONTAINER_IMAGES: Dict[Tuple[str, str], str] = {
 }
 
 FULL_PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
+
 
 def translate_desired_cuda(gpu_arch_type: str, gpu_arch_version: str) -> str:
     return {

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -92,13 +92,8 @@ def arch_type(arch_version: str) -> str:
     else:  # arch_version should always be "cpu" in this case
         return "cpu"
 
-
 # This can be updated to the release version when cutting release branch, i.e. 2.1
-DEFAULT_TAG = "main"
-release_version = os.getenv("RELEASE_VERSION_TAG")
-# if release_version is specified, use it to validate the packages
-if(release_version):
-    DEFAULT_TAG = release_version
+DEFAULT_TAG = os.getenv("RELEASE_VERSION_TAG", "main")
 
 WHEEL_CONTAINER_IMAGES = {
     **{
@@ -161,31 +156,6 @@ LIBTORCH_CONTAINER_IMAGES: Dict[Tuple[str, str], str] = {
 }
 
 FULL_PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
-
-def get_DEFAULT_TAG() -> str:
-    """
-    Returns the default tag used by the manylinux builder images.
-    """
-    return DEFAULT_TAG
-
-def get_CONDA_CONTAINER_IMAGES() -> Dict[str, str]:
-    """
-    Returns a dict of GPU architecture to container image name.
-    """
-    return CONDA_CONTAINER_IMAGES
-
-def get_LIBTORCH_CONTAINER_IMAGES() -> Dict[Tuple[str, str], str]:
-    """
-    Returns a dict of (GPU architecture, ABI) to container image name.
-    """
-    return LIBTORCH_CONTAINER_IMAGES
-
-def get_WHEEL_CONTAINER_IMAGES() -> Dict[str, str]:
-    """
-    Returns a dict of GPU architecture to container image name.
-    """
-    return WHEEL_CONTAINER_IMAGES
-
 
 def translate_desired_cuda(gpu_arch_type: str, gpu_arch_version: str) -> str:
     return {

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -11,7 +11,7 @@ architectures:
 """
 
 from typing import Dict, List, Optional, Tuple
-
+import os
 
 CUDA_ARCHES = ["11.8", "12.1"]
 
@@ -37,7 +37,6 @@ PYTORCH_EXTRA_INSTALL_REQUIREMENTS = (
     "nvidia-nccl-cu12==2.19.3; platform_system == 'Linux' and platform_machine == 'x86_64' | "
     "nvidia-nvtx-cu12==12.1.105; platform_system == 'Linux' and platform_machine == 'x86_64'"
 )
-
 
 def get_nccl_submodule_version() -> str:
     from pathlib import Path
@@ -96,6 +95,10 @@ def arch_type(arch_version: str) -> str:
 
 # This can be updated to the release version when cutting release branch, i.e. 2.1
 DEFAULT_TAG = "main"
+release_version = os.getenv("RELEASE_VERSION_TAG")
+# if release_version is specified, use it to validate the packages
+if(release_version):
+    DEFAULT_TAG = release_version
 
 WHEEL_CONTAINER_IMAGES = {
     **{
@@ -158,6 +161,30 @@ LIBTORCH_CONTAINER_IMAGES: Dict[Tuple[str, str], str] = {
 }
 
 FULL_PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
+
+def get_DEFAULT_TAG() -> str:
+    """
+    Returns the default tag used by the manylinux builder images.
+    """
+    return DEFAULT_TAG
+
+def get_CONDA_CONTAINER_IMAGES() -> Dict[str, str]:
+    """
+    Returns a dict of GPU architecture to container image name.
+    """
+    return CONDA_CONTAINER_IMAGES
+
+def get_LIBTORCH_CONTAINER_IMAGES() -> Dict[Tuple[str, str], str]:
+    """
+    Returns a dict of (GPU architecture, ABI) to container image name.
+    """
+    return LIBTORCH_CONTAINER_IMAGES
+
+def get_WHEEL_CONTAINER_IMAGES() -> Dict[str, str]:
+    """
+    Returns a dict of GPU architecture to container image name.
+    """
+    return WHEEL_CONTAINER_IMAGES
 
 
 def translate_desired_cuda(gpu_arch_type: str, gpu_arch_version: str) -> str:

--- a/.github/scripts/tag_docker_images_for_release.py
+++ b/.github/scripts/tag_docker_images_for_release.py
@@ -5,15 +5,16 @@ import argparse
 from typing import Dict
 
 def tag_image( image: str, default_tag: str, release_version: str, dry_run: str, tagged_images: Dict[str, bool]) -> None:
-    if image not in tagged_images:
-        release_image = image.replace(f'-{default_tag}', f'-{release_version}')
-        print(f"Tagging {image} to {release_image} , dry_run: {dry_run}")
-        if dry_run == 'disabled':
-            subprocess.check_call(["docker", "pull", image])
-            subprocess.check_call(["docker", "tag", image, release_image])
-            subprocess.check_call(["docker", "push", release_image])
-
-        tagged_images[image] = True
+    if image in tagged_images:
+        return
+    release_image = image.replace(f'-{default_tag}', f'-{release_version}')
+    print(f"Tagging {image} to {release_image} , dry_run: {dry_run}")
+    
+    if dry_run == 'disabled':
+        subprocess.check_call(["docker", "pull", image])
+        subprocess.check_call(["docker", "tag", image, release_image])
+        subprocess.check_call(["docker", "push", release_image])
+    tagged_images[image] = True
 
 def main() -> None:
     parser = argparse.ArgumentParser()

--- a/.github/scripts/tag_docker_images_for_release.py
+++ b/.github/scripts/tag_docker_images_for_release.py
@@ -1,0 +1,51 @@
+
+import generate_binary_build_matrix
+import os
+import subprocess
+import argparse
+
+def tag_image( image, default_tag, release_version, dry_run, tagged_images):
+    if image not in tagged_images:
+        release_image = image.replace(f'-{default_tag}', f'-{release_version}')
+        print(f"Tagging {image} to {release_image} , dry_run: {dry_run}")
+        if dry_run == 'disabled':
+            subprocess.run(["docker", "pull", image])
+            subprocess.run(["docker", "tag", image, release_image])
+            subprocess.run(["docker", "push", release_image])
+
+        tagged_images[image] = True
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--version",
+        help="Version to tag",
+        type=str,
+    )
+    parser.add_argument(
+        "--dry-run",
+        help="No Runtime Error check",
+        type=str,
+        choices=["enabled", "disabled"],
+        default="enabled",
+    )
+
+    options = parser.parse_args()
+    tagged_images = {}
+    wheel_images = generate_binary_build_matrix.WHEEL_CONTAINER_IMAGES
+    libtorch_images = generate_binary_build_matrix.LIBTORCH_CONTAINER_IMAGES
+    conda_images = generate_binary_build_matrix.CONDA_CONTAINER_IMAGES
+    default_tag = generate_binary_build_matrix.DEFAULT_TAG
+
+    for arch in libtorch_images.keys():
+        tag_image(libtorch_images[arch], default_tag, options.version, options.dry_run, tagged_images)
+
+    for arch in wheel_images.keys():
+        tag_image(wheel_images[arch], default_tag, options.version, options.dry_run, tagged_images)
+
+    for arch in conda_images.keys():
+        tag_image(conda_images[arch], default_tag, options.version, options.dry_run, tagged_images)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/tag_docker_images_for_release.py
+++ b/.github/scripts/tag_docker_images_for_release.py
@@ -1,20 +1,28 @@
-import generate_binary_build_matrix
-import os
-import subprocess
 import argparse
+import subprocess
 from typing import Dict
 
-def tag_image( image: str, default_tag: str, release_version: str, dry_run: str, tagged_images: Dict[str, bool]) -> None:
+import generate_binary_build_matrix
+
+
+def tag_image(
+    image: str,
+    default_tag: str,
+    release_version: str,
+    dry_run: str,
+    tagged_images: Dict[str, bool],
+) -> None:
     if image in tagged_images:
         return
-    release_image = image.replace(f'-{default_tag}', f'-{release_version}')
+    release_image = image.replace(f"-{default_tag}", f"-{release_version}")
     print(f"Tagging {image} to {release_image} , dry_run: {dry_run}")
-    
-    if dry_run == 'disabled':
+
+    if dry_run == "disabled":
         subprocess.check_call(["docker", "pull", image])
         subprocess.check_call(["docker", "tag", image, release_image])
         subprocess.check_call(["docker", "push", release_image])
     tagged_images[image] = True
+
 
 def main() -> None:
     parser = argparse.ArgumentParser()
@@ -33,17 +41,24 @@ def main() -> None:
     )
 
     options = parser.parse_args()
-    tagged_images = {}
+    tagged_images: Dict[str, bool] = dict()
     platform_images = [
         generate_binary_build_matrix.WHEEL_CONTAINER_IMAGES,
         generate_binary_build_matrix.LIBTORCH_CONTAINER_IMAGES,
-        generate_binary_build_matrix.CONDA_CONTAINER_IMAGES
-        ]
+        generate_binary_build_matrix.CONDA_CONTAINER_IMAGES,
+    ]
     default_tag = generate_binary_build_matrix.DEFAULT_TAG
 
-    for platform_image in platform_images:
-        for arch in platform_image.keys():
-            tag_image(platform_image[arch], default_tag, options.version, options.dry_run, tagged_images)
+    for platform_image in platform_images:  # type: ignore[attr-defined]
+        for arch in platform_image.keys():  # type: ignore[attr-defined]
+            tag_image(
+                platform_image[arch],  # type: ignore[index]
+                default_tag,
+                options.version,
+                options.dry_run,
+                tagged_images,
+            )
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/release/apply-release-changes.sh
+++ b/scripts/release/apply-release-changes.sh
@@ -39,6 +39,12 @@ sed -i -e s#.*#r"${RELEASE_VERSION}"# .github/ci_commit_pins/xla.txt
 export RELEASE_VERSION_TAG=${RELEASE_VERSION}
 ./.github/regenerate.sh
 
+# Pin Unstable and disabled jobs
+UNSTABLE_VER=$(aws s3api list-object-versions --bucket ossci-metrics --prefix unstable-jobs.json --query 'Versions[?IsLatest].[VersionId]' --output text)
+DISABLED_VER=$(aws s3api list-object-versions --bucket ossci-metrics --prefix disabled-jobs.json --query 'Versions[?IsLatest].[VersionId]' --output text)
+sed -i -e s#unstable-jobs.json#"unstable-jobs.json?versionid=${UNSTABLE_VER}"# .github/scripts/filter_test_configs.py
+sed -i -e s#disabled-jobs.json#"disabled-jobs.json?versionid=${DISABLED_VER}"# .github/scripts/filter_test_configs.py
+
 # Optional
 # git commit -m "[RELEASE-ONLY CHANGES] Branch Cut for Release {RELEASE_VERSION}"
 # git push origin "${RELEASE_BRANCH}"


### PR DESCRIPTION
1. This tags docker images using docker pull/tag/push for current release
2. Sets RELEASE_VERSION_TAG var and regenerates the workflows using the new docker tag
3. Remove conda token setting and Binary tests release changes these are already automated
4. Pin unstable and disabled jobs, autumate: https://github.com/pytorch/pytorch/pull/111675

Test:
```
RELEASE_VERSION=2.2 ./scripts/release/apply-release-changes.sh
Tagging pytorch/manylinux-builder:cuda11.8-main to pytorch/manylinux-builder:cuda11.8-2.2 , dry_run: enabled
Tagging pytorch/manylinux-builder:cuda12.1-main to pytorch/manylinux-builder:cuda12.1-2.2 , dry_run: enabled
Tagging pytorch/libtorch-cxx11-builder:cuda11.8-main to pytorch/libtorch-cxx11-builder:cuda11.8-2.2 , dry_run: enabled
Tagging pytorch/libtorch-cxx11-builder:cuda12.1-main to pytorch/libtorch-cxx11-builder:cuda12.1-2.2 , dry_run: enabled
Tagging pytorch/manylinux-builder:rocm5.6-main to pytorch/manylinux-builder:rocm5.6-2.2 , dry_run: enabled
Tagging pytorch/manylinux-builder:rocm5.7-main to pytorch/manylinux-builder:rocm5.7-2.2 , dry_run: enabled
Tagging pytorch/libtorch-cxx11-builder:rocm5.6-main to pytorch/libtorch-cxx11-builder:rocm5.6-2.2 , dry_run: enabled
Tagging pytorch/libtorch-cxx11-builder:rocm5.7-main to pytorch/libtorch-cxx11-builder:rocm5.7-2.2 , dry_run: enabled
Tagging pytorch/manylinux-builder:cpu-main to pytorch/manylinux-builder:cpu-2.2 , dry_run: enabled
Tagging pytorch/libtorch-cxx11-builder:cpu-main to pytorch/libtorch-cxx11-builder:cpu-2.2 , dry_run: enabled
Tagging pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi-main to pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi-2.2 , dry_run: enabled
Tagging pytorch/manylinuxaarch64-builder:cpu-aarch64-main to pytorch/manylinuxaarch64-builder:cpu-aarch64-2.2 , dry_run: enabled
Tagging pytorch/conda-builder:cuda11.8-main to pytorch/conda-builder:cuda11.8-2.2 , dry_run: enabled
Tagging pytorch/conda-builder:cuda12.1-main to pytorch/conda-builder:cuda12.1-2.2 , dry_run: enabled
Tagging pytorch/conda-builder:cpu-main to pytorch/conda-builder:cpu-2.2 , dry_run: enabled
/data/users/atalman/pytorch/.github/workflows/generated-linux-binary-manywheel-nightly.yml
/data/users/atalman/pytorch/.github/workflows/generated-linux-binary-conda-nightly.yml
/data/users/atalman/pytorch/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
/data/users/atalman/pytorch/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
/data/users/atalman/pytorch/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
/data/users/atalman/pytorch/.github/workflows/generated-linux-binary-manywheel-main.yml
/data/users/atalman/pytorch/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-main.yml
/data/users/atalman/pytorch/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-main.yml
/data/users/atalman/pytorch/.github/workflows/generated-windows-binary-wheel-nightly.yml
/data/users/atalman/pytorch/.github/workflows/generated-windows-binary-conda-nightly.yml
/data/users/atalman/pytorch/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
/data/users/atalman/pytorch/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
/data/users/atalman/pytorch/.github/workflows/generated-windows-binary-libtorch-release-main.yml
/data/users/atalman/pytorch/.github/workflows/generated-windows-binary-libtorch-debug-main.yml
/data/users/atalman/pytorch/.github/workflows/generated-macos-binary-wheel-nightly.yml
/data/users/atalman/pytorch/.github/workflows/generated-macos-binary-conda-nightly.yml
/data/users/atalman/pytorch/.github/workflows/generated-macos-binary-libtorch-cxx11-abi-nightly.yml
/data/users/atalman/pytorch/.github/workflows/generated-macos-arm64-binary-libtorch-cxx11-abi-nightly.yml
/data/users/atalman/pytorch/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
/data/users/atalman/pytorch/.github/workflows/generated-macos-arm64-binary-conda-nightly.yml
````

Result of pinning unstable and disabled jobs:
```
# The link to the published list of disabled jobs
DISABLED_JOBS_URL = "https://ossci-metrics.s3.amazonaws.com/disabled-jobs.json?versionid=kKJlAXdrUbk3CilXbKu.6OwNTGQB8a.B"
# and unstable jobs
UNSTABLE_JOBS_URL = "https://ossci-metrics.s3.amazonaws.com/unstable-jobs.json?versionid=vzaicOxSsh55iXBXwgGrW6dFeVtPfrhr"
```