### PR TITLE
Disable MPS tests on macos-m1-13 runners

### DIFF
--- a/.github/workflows/mac-mps.yml
+++ b/.github/workflows/mac-mps.yml
@@ -28,7 +28,8 @@ jobs:
       test-matrix: |
         { include: [
           { config: "mps", shard: 1, num_shards: 1, runner: "macos-m1-12" },
-          { config: "mps", shard: 1, num_shards: 1, runner: "macos-m1-13" },
+          # TODO: Revert me when those runners are back online
+          # { config: "mps", shard: 1, num_shards: 1, runner: "macos-m1-13" },
         ]}
 
   macos-12-py3-arm64-mps-test:


### PR DESCRIPTION
As all of them are down at the moment, see screenshot below from [HUD](https://hud.pytorch.org/metrics)
<img width="669" alt="image" src="https://github.com/pytorch/pytorch/assets/2453524/6c400791-ae7e-460a-9e77-55d454b587f3">
