### PR TITLE
Forward fix D51468211

### DIFF
--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -426,7 +426,7 @@ def _convert_input_to_fake(gm, args, kwargs):
     # TODO properly use the cached fake tensor
     fake_kwargs = pytree.tree_map_only(torch.Tensor, fake_mode.from_tensor, kwargs)
     fake_params_buffers = pytree.tree_map_only(torch.Tensor,
-                                               fake_mode.from_tensor,
+                                               functools.partial(fake_mode.from_tensor, static_shapes=True),
                                                {**dict(gm.named_parameters(remove_duplicate=False)),
                                                 **dict(gm.named_buffers(remove_duplicate=False))})
     return fake_args, fake_kwargs, fake_params_buffers, fake_mode


### PR DESCRIPTION
Summary:
Forward fix test failures caused by D51468211.

The root cause is that when converting the param_buffer into fake_tensor, we didn't set the static_shapes=True, this causes the shape_env to have more symbols than expected. The current status is that we assume all param and buffers are constant sizes.

Test Plan: buck2 test 'fbcode//mode/opt' fbcode//aps_models/ads/icvr/tests:export_test_cpu -- --exact 'aps_models/ads/icvr/tests:export_test_cpu - test_20x_icvr_export (aps_models.ads.icvr.tests.export_test.ExportTest)'

Reviewed By: hongtansun-meta

Differential Revision: D51531279




cc @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan @angelayi @suo