### PR TITLE
[dtensor] refactor some existing test util to use comm mode

### DIFF
--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -1,14 +1,11 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 
-from contextlib import contextmanager
-from dataclasses import dataclass
 import itertools
 import sys
 from functools import wraps
 from typing import (
     Any,
     Callable,
-    Generator,
     Iterator,
     Tuple,
     Dict,
@@ -34,10 +31,8 @@ from torch.distributed._tensor import (
     Shard,
     Replicate,
     distribute_tensor,
-    redistribute,
 )
-from torch.distributed._tensor.api import DTensor
-from torch.distributed._tensor.placement_types import Placement, DTensorSpec
+from torch.distributed._tensor.placement_types import Placement
 
 DEVICE_TYPE = "cuda" if torch.cuda.is_available() and torch.cuda.device_count() > 1 else "cpu"
 PG_BACKEND = "nccl" if DEVICE_TYPE == "cuda" else "gloo"
@@ -79,35 +74,6 @@ def skip_unless_torch_gpu(method: T) -> T:
     """
     # The builtin @skip_if_no_gpu relies on os.environ['WORLD_SIZE'] being set.
     return cast(T, skip_if_lt_x_gpu(NUM_DEVICES)(method))
-
-
-@dataclass
-class RedistributeProfile:
-    num_calls: int
-
-
-@contextmanager
-def redistribute_profiler() -> Generator[RedistributeProfile, None, None]:
-
-    orig_redistribute_local_tensor = redistribute.redistribute_local_tensor
-    profile: RedistributeProfile = RedistributeProfile(num_calls=0)
-
-    # pyre-ignore[53]
-    def patched_redistribute_local_tensor(
-        local_tensor: torch.Tensor,
-        current_spec: DTensorSpec,
-        target_spec: DTensorSpec,
-    ) -> DTensor:
-        result = orig_redistribute_local_tensor(local_tensor, current_spec, target_spec)
-        profile.num_calls += 1
-        return result
-
-    try:
-        # pyre-ignore[9]
-        redistribute.redistribute_local_tensor = patched_redistribute_local_tensor
-        yield profile
-    finally:
-        redistribute.redistribute_local_tensor = orig_redistribute_local_tensor
 
 
 class DTensorTestBase(MultiProcessTestCase):
@@ -155,19 +121,13 @@ class DTensorTestBase(MultiProcessTestCase):
 
     # pyre-ignore[2]:
     def _test_op(self, mesh: DeviceMesh, op_call, *args, **kwargs) -> None:
-        with redistribute_profiler() as profile:
-            out = op_call(*args, **kwargs)
-            dtc = DTensorConverter(mesh, args, kwargs)
-            for d_args, d_kwargs in dtc:
-                # pyre can't find assertTrue anymore?
-                self.assertEqual(dtc.successful(), True)
-                d_out = op_call(*d_args, **d_kwargs)
-                self.assertEqual(
-                    d_out.redistribute(
-                        mesh, [Replicate()] * mesh.ndim
-                    ).to_local(),
-                    out,
-                )
+        out = op_call(*args, **kwargs)
+        dtc = DTensorConverter(mesh, args, kwargs)
+        for d_args, d_kwargs in dtc:
+            # pyre can't find assertTrue anymore?
+            self.assertEqual(dtc.successful(), True)
+            d_out = op_call(*d_args, **d_kwargs)
+            self.assertEqual(d_out.full_tensor(), out)
 
     def run_subtests(self, *args, **kwargs):
         return run_subtests(self, *args, **kwargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #114404
* #113592

As titled, This is just a test util refactor: 
redistributed profiler is not good to use and we should use
comm mode going forward



cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @fduwjj @wz337 @tianyu-l @wconstab @yf225 @kiukchung @d4l3k @lucasllc