### PR TITLE
[Release/2.1] Fix chrome trace entry format

### DIFF
--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -253,7 +253,7 @@ class EventList(list):
                         '"pid": "CPU functions", '
                         f'"id": {next_id}, '
                         f'"cat": "cpu_to_{device_name}", '
-                        '"args": {{}}}}, '
+                        '"args": {}}, '
                     )
                     # Note: use torch.profiler to get device kernel trace
                     next_id += 1


### PR DESCRIPTION
Fix regression introduced by https://github.com/pytorch/pytorch/pull/107519

`'"args": {{}}}}, '` was part of format string, when curly braces a duplicated to get them printed single time, but ruff change left the string format as is

Fixes https://github.com/pytorch/pytorch/issues/113756

Cherrypick of https://github.com/pytorch/pytorch/pull/113763 into release/2.1 branch

(cherry picked from commit e100ff42fd087d7a1696cb52c216507d45b8fb85)

