### PR TITLE
Handle the case when opening a reverted PR with deleted head branch

### DIFF
--- a/.github/scripts/github_utils.py
+++ b/.github/scripts/github_utils.py
@@ -187,3 +187,5 @@ def gh_update_pr_state(org: str, repo: str, pr_num: int, state: str = "open") ->
             warnings.warn(
                 f"Failed to open {pr_num} because its head branch has been deleted: {err}"
             )
+        else:
+            raise

--- a/.github/scripts/github_utils.py
+++ b/.github/scripts/github_utils.py
@@ -178,4 +178,12 @@ def gh_fetch_merge_base(org: str, repo: str, base: str, head: str) -> str:
 
 def gh_update_pr_state(org: str, repo: str, pr_num: int, state: str = "open") -> None:
     url = f"{GITHUB_API_URL}/repos/{org}/{repo}/pulls/{pr_num}"
-    gh_fetch_url(url, method="PATCH", data={"state": state})
+    try:
+        gh_fetch_url(url, method="PATCH", data={"state": state})
+    except HTTPError as err:
+        # When trying to open the pull request, error 422 means that the branch
+        # has been deleted and the API couldn't re-open it
+        if err.code == 422 and state == "open":
+            warnings.warn(
+                f"Failed to open {pr_num} because its head branch has been deleted: {err}"
+            )


### PR DESCRIPTION
When reopening a reverted PR, `422: Unprocessable Entity` is returned when the head branch has been deleted, for example https://github.com/pytorch/pytorch/pull/112889#issuecomment-1823216686

```
{
  "message": "Validation Failed",
  "errors": [
    {
      "resource": "PullRequest",
      "code": "custom",
      "field": "state",
      "message": "state cannot be changed. The commsplit branch has been deleted."
    }
  ],
  "documentation_url": "https://docs.github.com/rest/pulls/pulls#update-a-pull-request"
}
```

The revert still happens though, only reopening PR fails, which is ok to ignore in this case I think instead of going the complicated route of trying to restore the deleted branch by merge bot.