### PR TITLE
[WIP][TESTING] _set_symbolic_storage_offset on meta tensors

### DIFF
--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -545,6 +545,7 @@ class MetaConverter:
                                 device="meta",
                             )
                         )
+                        torch._C._set_symbolic_storage_offset(r, storage_offset)
                     assert safe_is_leaf(r), "the callback you passed in doesn't detach"
                     if t.requires_grad:
                         r.requires_grad = t.requires_grad

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1009,6 +1009,15 @@ void initJITBindings(PyObject* module) {
             using namespace torch::jit::tensorexpr;
             getOptConditionals() = opt_conds;
           })
+      .def("_set_symbolic_storage_offset",
+          // TODO: (testing - if we keep this, move it somewhere else)
+          [](at::Tensor& t, const at::SymInt& offset) {
+            TORCH_INTERNAL_ASSERT(t.defined());
+            auto impl = t.unsafeGetTensorImpl();
+            const auto& sizes = impl->sym_sizes();
+            const auto& strides = impl->sym_strides();
+            impl->set_sizes_and_strides(sizes, strides, offset);
+          })
       .def(
           "_llvm_enabled",
           []() {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #114424
* #114010

Previously, the symbolic storage offset is not actually used if the tensor is not a view. That's because the empty tensor construction (just above the change in meta_utils.py in this PR) doesn't take the storage offset as a parameter.

Note, this is not ready to land. There's some failures (e.g. in test_adv_index_batch) that need to be investigated. Submitting this to see CI.