### PR TITLE
Update audio pinned commit nightly

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -74,6 +74,7 @@
 
 - name: OSS CI / pytorchbot
   patterns:
+  - .github/ci_commit_pins/audio.txt
   - .github/ci_commit_pins/vision.txt
   - .github/ci_commit_pins/torchdynamo.txt
   - .ci/docker/ci_commit_pins/triton.txt

--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -85,6 +85,7 @@
   - EasyCLA
   - Lint
   - pull
+  - inductor
 
 - name: OSS CI /pytorchbot / Executorch
   patterns:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,6 +53,23 @@ jobs:
           updatebot-token: ${{ secrets.UPDATEBOT_TOKEN }}
           pytorchbot-token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
 
+  update-audio-commit-hash:
+    runs-on: ubuntu-latest
+    environment: update-commit-hash
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: update-audio-commit-hash
+        uses: ./.github/actions/update-commit-hash
+        if: ${{ github.event_name == 'schedule' }}
+        with:
+          repo-name: audio
+          branch: main
+          updatebot-token: ${{ secrets.UPDATEBOT_TOKEN }}
+          pytorchbot-token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
+
   update-executorch-commit-hash:
     runs-on: ubuntu-latest
     environment: update-commit-hash


### PR DESCRIPTION
I think we could have this pinned commit being update nightly like what we have with vision.  This will avoid having an outdated audio pinned commit that needs to be updated manually, i.e. https://github.com/pytorch/pytorch/pull/114393