### PR TITLE
Fix dynamo test_logging handling of partial qnames

### DIFF
--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -248,7 +248,8 @@ LoweringException: AssertionError:
         for logger_qname in torch._logging._internal.log_registry.get_log_qnames():
             logger = logging.getLogger(logger_qname)
 
-            if logger_qname in dynamo_qnames:
+            # if logger_qname is a.b.c and dynamo_qnames contains a.b, it still matches dynamo's INFO setting
+            if any([logger_qname.find(d) == 0 for d in dynamo_qnames]):
                 self.assertEqual(
                     logger.getEffectiveLevel(),
                     logging.INFO,

--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -249,7 +249,7 @@ LoweringException: AssertionError:
             logger = logging.getLogger(logger_qname)
 
             # if logger_qname is a.b.c and dynamo_qnames contains a.b, it still matches dynamo's INFO setting
-            if any([logger_qname.find(d) == 0 for d in dynamo_qnames]):
+            if any(logger_qname.find(d) == 0 for d in dynamo_qnames):
                 self.assertEqual(
                     logger.getEffectiveLevel(),
                     logging.INFO,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #114376
* __->__ #114429
* #114428

if logger_qname is a.b.c and dynamo_qnames contains a.b, it still
matches dynamo's INFO setting

concretely, torch._dynamo.backends.distributed is implicitly part of
the dynamo namespace since it is covered by `torch._dynamo` which is
one of dynamo_qnames.  However, it is not an exact match for any
of dynamo_qnames, which made this test fail when adding a specific
qname for backends.distributed in the subsequent PR.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng