### PR TITLE
[3/N] Fixes clang-tidy warnings in header files

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1674,7 +1674,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     storage_ = {};
     set_storage_access_should_throw();
     get_extra_meta().custom_data_ptr_error_msg_ = s;
-    get_extra_meta().custom_storage_error_msg_ = s;
+    get_extra_meta().custom_storage_error_msg_ = std::move(s);
   }
 
  protected:

--- a/c10/util/BFloat16.h
+++ b/c10/util/BFloat16.h
@@ -67,6 +67,7 @@ inline C10_HOST_DEVICE uint16_t round_to_nearest_even(float src) {
 #endif
     return UINT16_C(0x7FC0);
   } else {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
     union {
       uint32_t U32;
       float F32;

--- a/c10/util/Float8_e5m2fnuz-inl.h
+++ b/c10/util/Float8_e5m2fnuz-inl.h
@@ -12,9 +12,8 @@ namespace c10 {
 
 /// Constructors
 
-C10_HOST_DEVICE inline Float8_e5m2fnuz::Float8_e5m2fnuz(float value) {
-  x = detail::fp8e5m2fnuz_from_fp32_value(value);
-}
+C10_HOST_DEVICE inline Float8_e5m2fnuz::Float8_e5m2fnuz(float value)
+    : x(detail::fp8e5m2fnuz_from_fp32_value(value)) {}
 
 /// Implicit conversions
 

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -231,7 +231,7 @@ C10_HOST_DEVICE inline float fp16_ieee_to_fp32_value(uint16_t h) {
   constexpr uint32_t exp_offset = UINT32_C(0xE0) << 23;
   // const float exp_scale = 0x1.0p-112f;
   constexpr uint32_t scale_bits = (uint32_t)15 << 23;
-  float exp_scale_val;
+  float exp_scale_val = 0;
   std::memcpy(&exp_scale_val, &scale_bits, sizeof(exp_scale_val));
   const float exp_scale = exp_scale_val;
   const float normalized_value =
@@ -302,7 +302,7 @@ inline uint16_t fp16_ieee_from_fp32_value(float f) {
   // const float scale_to_zero = 0x1.0p-110f;
   constexpr uint32_t scale_to_inf_bits = (uint32_t)239 << 23;
   constexpr uint32_t scale_to_zero_bits = (uint32_t)17 << 23;
-  float scale_to_inf_val, scale_to_zero_val;
+  float scale_to_inf_val = 0, scale_to_zero_val = 0;
   std::memcpy(&scale_to_inf_val, &scale_to_inf_bits, sizeof(scale_to_inf_val));
   std::memcpy(
       &scale_to_zero_val, &scale_to_zero_bits, sizeof(scale_to_zero_val));

--- a/c10/util/hash.h
+++ b/c10/util/hash.h
@@ -109,8 +109,8 @@ struct sha1 {
     unsigned int e = h_[4];
 
     for (std::size_t i = 0; i < 80; ++i) {
-      unsigned int f;
-      unsigned int k;
+      unsigned int f = 0;
+      unsigned int k = 0;
 
       if (i < 20) {
         f = (b & c) | (~b & d);
@@ -226,11 +226,11 @@ struct sha1 {
     digest[4] = h_[4];
   }
 
-  unsigned int h_[5];
-  unsigned char block_[64];
-  std::size_t block_byte_index_;
-  std::size_t bit_count_low;
-  std::size_t bit_count_high;
+  unsigned int h_[5]{};
+  unsigned char block_[64]{};
+  std::size_t block_byte_index_{};
+  std::size_t bit_count_low{};
+  std::size_t bit_count_high{};
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/c10/util/llvmMathExtras.h
+++ b/c10/util/llvmMathExtras.h
@@ -609,6 +609,7 @@ inline uint64_t GreatestCommonDivisor64(uint64_t A, uint64_t B) {
 
 /// This function takes a 64-bit integer and returns the bit equivalent double.
 inline double BitsToDouble(uint64_t Bits) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   double D;
   static_assert(sizeof(uint64_t) == sizeof(double), "Unexpected type sizes");
   memcpy(&D, &Bits, sizeof(Bits));
@@ -625,6 +626,7 @@ inline float BitsToFloat(uint32_t Bits) {
 /// Note that copying doubles around changes the bits of NaNs on some hosts,
 /// notably x86, so this routine cannot be used if these bits are needed.
 inline uint64_t DoubleToBits(double Double) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   uint64_t Bits;
   static_assert(sizeof(uint64_t) == sizeof(double), "Unexpected type sizes");
   memcpy(&Bits, &Double, sizeof(Double));
@@ -635,6 +637,7 @@ inline uint64_t DoubleToBits(double Double) {
 /// Note that copying floats around changes the bits of NaNs on some hosts,
 /// notably x86, so this routine cannot be used if these bits are needed.
 inline uint32_t FloatToBits(float Float) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   uint32_t Bits;
   static_assert(sizeof(uint32_t) == sizeof(float), "Unexpected type sizes");
   memcpy(&Bits, &Float, sizeof(Float));
@@ -818,6 +821,7 @@ typename std::enable_if<std::is_unsigned<T>::value, T>::type SaturatingAdd(
     T X,
     T Y,
     bool* ResultOverflowed = nullptr) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   bool Dummy;
   bool& Overflowed = ResultOverflowed ? *ResultOverflowed : Dummy;
   // Hacker's Delight, p. 29
@@ -837,6 +841,7 @@ typename std::enable_if<std::is_unsigned<T>::value, T>::type SaturatingMultiply(
     T X,
     T Y,
     bool* ResultOverflowed = nullptr) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   bool Dummy;
   bool& Overflowed = ResultOverflowed ? *ResultOverflowed : Dummy;
 
@@ -883,6 +888,7 @@ typename std::enable_if<std::is_unsigned<T>::value, T>::type SaturatingMultiply(
 template <typename T>
 typename std::enable_if<std::is_unsigned<T>::value, T>::type
 SaturatingMultiplyAdd(T X, T Y, T A, bool* ResultOverflowed = nullptr) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   bool Dummy;
   bool& Overflowed = ResultOverflowed ? *ResultOverflowed : Dummy;
 

--- a/torch/csrc/utils/object_ptr.h
+++ b/torch/csrc/utils/object_ptr.h
@@ -8,9 +8,7 @@ class TORCH_PYTHON_API THPPointer {
  public:
   THPPointer() : ptr(nullptr){};
   explicit THPPointer(T* ptr) noexcept : ptr(ptr){};
-  THPPointer(THPPointer&& p) noexcept {
-    free();
-    ptr = p.ptr;
+  THPPointer(THPPointer&& p) noexcept : ptr(p.ptr) {
     p.ptr = nullptr;
   };
 

--- a/torch/csrc/utils/object_ptr.h
+++ b/torch/csrc/utils/object_ptr.h
@@ -2,15 +2,14 @@
 
 #include <torch/csrc/Export.h>
 #include <torch/csrc/python_headers.h>
+#include <utility>
 
 template <class T>
 class TORCH_PYTHON_API THPPointer {
  public:
   THPPointer() : ptr(nullptr){};
   explicit THPPointer(T* ptr) noexcept : ptr(ptr){};
-  THPPointer(THPPointer&& p) noexcept : ptr(p.ptr) {
-    p.ptr = nullptr;
-  };
+  THPPointer(THPPointer&& p) noexcept : ptr(std::exchange(p.ptr, nullptr)) {}
 
   ~THPPointer() {
     free();


### PR DESCRIPTION
This PR series tries to enable clang-tidy for headers in torch/csrc and c10/util.