### PR TITLE
[FSDP] Passed `TORCH_NCCL_DESYNC_DEBUG` instead of `NCCL_DESYNC_DEBUG`

### DIFF
--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -868,7 +868,7 @@ class FSDPTest(MultiProcessTestCase):
         # Set NCCL_DESYNC_DEBUG=0 to disable the NCCL `workCleanupLoop()`,
         # which can cause unit test flakiness:
         # https://github.com/pytorch/pytorch/issues/90848
-        os.environ["NCCL_DESYNC_DEBUG"] = "0"
+        os.environ["TORCH_NCCL_DESYNC_DEBUG"] = "0"
         self._spawn_processes()
 
     @property

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -865,7 +865,7 @@ class FSDPTestMultiThread(MultiThreadedTestCase):
 class FSDPTest(MultiProcessTestCase):
     def setUp(self):
         super().setUp()
-        # Set NCCL_DESYNC_DEBUG=0 to disable the NCCL `workCleanupLoop()`,
+        # Set TORCH_NCCL_DESYNC_DEBUG=0 to disable the NCCL `workCleanupLoop()`,
         # which can cause unit test flakiness:
         # https://github.com/pytorch/pytorch/issues/90848
         os.environ["TORCH_NCCL_DESYNC_DEBUG"] = "0"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #114432

This is to silence some warnings like:
```
[rank0]:[W Utils.hpp:164] Warning: Environment variable NCCL_DESYNC_DEBUG is deprecated; use TORCH_NCCL_DESYNC_DEBUG instead (function getCvarBool)
[rank3]:[W Utils.hpp:164] Warning: Environment variable NCCL_DESYNC_DEBUG is deprecated; use TORCH_NCCL_DESYNC_DEBUG instead (function getCvarBool)
[rank1]:[W Utils.hpp:164] Warning: Environment variable NCCL_DESYNC_DEBUG is deprecated; use TORCH_NCCL_DESYNC_DEBUG instead (function getCvarBool)
[rank2]:[W Utils.hpp:164] Warning: Environment variable NCCL_DESYNC_DEBUG is deprecated; use TORCH_NCCL_DESYNC_DEBUG instead (function getCvarBool)
```