### PR TITLE
[ROCm] int64_t added for JIT codegen

### DIFF
--- a/torch/csrc/jit/codegen/fuser/codegen.cpp
+++ b/torch/csrc/jit/codegen/fuser/codegen.cpp
@@ -677,6 +677,23 @@ std::string generateKernel(
   // Still need the key defined, but empty.
   env.s("RuntimeHeader", R"()");
 #endif
+
+#if ROCM_VERSION >= 60000
+  env.s("DataTypedef", R"(
+typedef long long int int64_t;
+)");
+#else
+  env.s("DataTypedef", R"()");
+#endif
+
+#else // else case of defined(USE_ROCM)
+  env.s("DataTypedef", R"(
+typedef unsigned char uint8_t;
+typedef signed char int8_t;
+typedef short int  int16_t;
+typedef long long int int64_t;
+typedef unsigned long long int uint64_t;
+)");
 #endif
   // clang-format on
 

--- a/torch/csrc/jit/codegen/fuser/cuda/resource_strings.h
+++ b/torch/csrc/jit/codegen/fuser/cuda/resource_strings.h
@@ -16,6 +16,7 @@ cases*/
 #if defined(USE_ROCM)
 static auto type_declarations_template = at::jit::CodeTemplate(R"(
 ${RuntimeHeader}
+${DataTypedef}
 ${HalfHeader}
 ${BFloat16Header}
 ${RandHeader}
@@ -38,11 +39,7 @@ struct TensorInfo<T, 0> {
 )");
 #else
 static auto type_declarations_template = at::jit::CodeTemplate(R"(
-typedef unsigned char uint8_t;
-typedef signed char int8_t;
-typedef short int  int16_t;
-typedef long long int int64_t;
-typedef unsigned long long int uint64_t;
+${DataTypedef}
 ${HalfHeader}
 ${BFloat16Header}
 ${RandHeader}


### PR DESCRIPTION
- Application needs to define int64_t datatype


cc @jeffdaily @sunway513 @jithunnair-amd @ROCmSupport @dllehr-amd @jataylo @hongxiayang