### PR TITLE
[AOTInductor] Support freezing model in aoti

### DIFF
--- a/aten/src/ATen/native/mkldnn/MKLDNNCommon.h
+++ b/aten/src/ATen/native/mkldnn/MKLDNNCommon.h
@@ -17,6 +17,8 @@ static inline ideep::tensor::data_type get_mkldnn_dtype(const Tensor& t) {
 // Construct aten MKL-DNN tensor given an ideep tensor
 TORCH_API Tensor new_with_itensor_mkldnn(ideep::tensor&& it, c10::optional<ScalarType> dtype, c10::optional<Device> device);
 
+TORCH_API int64_t data_ptr_from_mkldnn(const Tensor& mkldnn_tensor);
+
 // Retrieve `ideep::tensor` from MKL-DNN tensor
 TORCH_API ideep::tensor& itensor_from_mkldnn(const Tensor& mkldnn_tensor);
 

--- a/aten/src/ATen/native/mkldnn/RegisterMkldnnOpContextClass.cpp
+++ b/aten/src/ATen/native/mkldnn/RegisterMkldnnOpContextClass.cpp
@@ -69,6 +69,7 @@ TORCH_LIBRARY(mkldnn, m) {
       "mkldnn::_reorder_mkldnn_rnn_layer_weight(Tensor weight0, Tensor weight1, int hidden_size, bool reverse, bool has_biases, bool batch_first, int[]? input_size=None) -> Tensor[] Y"));
   m.def("_is_mkldnn_bf16_supported", &is_mkldnn_bf16_supported);
   m.def("_is_mkldnn_fp16_supported", &is_mkldnn_fp16_supported);
+  m.def("mkldnn::data_ptr(Tensor mkldnn_tensor) -> int");
 }
 
 TORCH_LIBRARY(mkldnn_prepacked, m) {

--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -467,6 +467,7 @@ inductor_core_resources = [
     "torch/csrc/inductor/aoti_model_container_runner.cpp",
     "torch/csrc/inductor/aoti_torch/shim_common.cpp",
     "torch/csrc/inductor/aoti_torch/tensor_converter.cpp",
+    "torch/csrc/inductor/aoti_torch/opaque_tensor.cpp",
     "torch/csrc/inductor/inductor_ops.cpp",
 ]
 

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1366,7 +1366,7 @@ copy_tests(
         "test_foreach_multiple_dynamic": TestFailure(("abi_compatible_cpu",)),
         # TODO: test_freezing_abi_compatible_cpu somehow fails on CI but not locally,
         #   NotImplementedError: Cannot access storage of OpaqueTensorImpl
-        "test_freezing": TestFailure(("abi_compatible_cpu",), is_skip=True),
+        # "test_freezing": TestFailure(("abi_compatible_cpu",), is_skip=True),
         # Need to support convolution
         "test_missing_cubin": TestFailure(("abi_compatible_cpu",)),
         "test_normal_functional": TestFailure(("abi_compatible_cpu",)),
@@ -1430,7 +1430,6 @@ copy_tests(
         ),
         # TODO: test_freezing_non_abi_compatible_cpu somehow fails on CI but not locally,
         #   NotImplementedError: Cannot access storage of OpaqueTensorImpl
-        "test_freezing": TestFailure(("non_abi_compatible_cpu",), is_skip=True),
     },
 )
 
@@ -1454,5 +1453,5 @@ if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 
     # cpp_extension N/A in fbcode
-    if HAS_CUDA and not TEST_WITH_ROCM:
+    if not TEST_WITH_ROCM:
         run_tests(needs="filelock")

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1610,6 +1610,13 @@ class AotCodeCache:
 
                         if t.numel() == 0:
                             return b""
+                        
+                        if t.is_mkldnn:
+                            raw_array = ctypes.cast(
+                                torch.ops.mkldnn.data_ptr(t),
+                                ctypes.POINTER(ctypes.c_ubyte * t.element_size() * t.numel()),
+                            )
+                            return bytes(raw_array.contents)
 
                         t_cpu = t.untyped_storage().cpu()
                         raw_array = ctypes.cast(

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -79,6 +79,11 @@ DTYPE_TO_ATEN = {
     torch.complex64: "at::kComplexFloat",
 }
 
+LAYOUT_TO_ATEN = {
+    torch.strided: "at::kStrided",
+    torch._mkldnn: "at::kMkldnn",
+}
+
 DEVICE_TO_ATEN = {
     "cpu": "at::kCPU",
     "cuda": "at::kCUDA",

--- a/torch/csrc/inductor/aoti_runtime/model.h
+++ b/torch/csrc/inductor/aoti_runtime/model.h
@@ -252,6 +252,7 @@ class AOTInductorModelBase {
       auto size = this->constant_shape(i);
       auto stride = this->constant_stride(i);
       auto offset = this->constant_offset(i);
+      auto layout = this->constant_layout(i);
 
       auto device_type = aoti_torch_device_type_cuda();
       if (is_cpu) {
@@ -270,6 +271,7 @@ class AOTInductorModelBase {
           stride,
           offset,
           dtype,
+          layout,
           device_type,
           device_idx,
           &tensor_handle));
@@ -363,6 +365,10 @@ class AOTInductorModelBase {
     return constants_info_.at(idx).dtype;
   }
 
+  int8_t constant_layout(int64_t idx) const {
+    return constants_info_.at(idx).layout;
+  }
+
   size_t constant_offset(int64_t idx) const {
     return constants_info_.at(idx).offset;
   }
@@ -440,6 +446,7 @@ class AOTInductorModelBase {
     int32_t dtype;
     int64_t offset;
     size_t data_size;
+    int8_t layout;
   };
 
   std::vector<ParamInfo> inputs_info_;

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -170,6 +170,7 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_create_tensor_from_blob(
     const int64_t* strides_ptr,
     int64_t storage_offset,
     int32_t dtype,
+    int8_t layout,
     int32_t device_type,
     int32_t device_index,
     AtenTensorHandle* ret // returns new reference

--- a/torch/csrc/inductor/aoti_torch/opaque_tensor.cpp
+++ b/torch/csrc/inductor/aoti_torch/opaque_tensor.cpp
@@ -1,0 +1,36 @@
+#include <ATen/Config.h>
+#include <torch/csrc/inductor/aoti_torch/opaque_tensor.h>
+
+#if AT_MKLDNN_ENABLED()
+#include <ideep.hpp>
+#include <ATen/native/mkldnn/MKLDNNCommon.h>
+#endif
+
+namespace torch {
+namespace aot_inductor {
+
+#if AT_MKLDNN_ENABLED()
+
+at::Tensor mkldnn_tensor_from_data_ptr(
+    void* data_ptr,
+    at::IntArrayRef dims,
+    at::ScalarType dtype,
+    at::Device device) {
+  auto a = ideep::tensor({dims.vec(), ideep::tensor::data_type::s8}, data_ptr);
+  return at::native::new_with_itensor_mkldnn(std::move(a), dtype, device);
+}
+
+#else
+
+at::Tensor mkldnn_tensor_from_data_ptr(
+    void* data_ptr,
+    at::IntArrayRef dims,
+    at::ScalarType dtype,
+    at::Device device) {
+  TORCH_CHECK(false, "MKL-DNN build is disabled");
+}
+
+#endif
+
+} // namespace aot_inductor
+} // namespace torch

--- a/torch/csrc/inductor/aoti_torch/opaque_tensor.h
+++ b/torch/csrc/inductor/aoti_torch/opaque_tensor.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <ATen/Tensor.h>
+
+namespace torch {
+namespace aot_inductor {
+
+at::Tensor mkldnn_tensor_from_data_ptr(
+    void* data_ptr,
+    at::IntArrayRef dims,
+    at::ScalarType dtype,
+    at::Device device);
+
+}
+} // namespace torch


### PR DESCRIPTION
Fixes #114450

This commit supports aotinductor processing opaque tensor, so we can enable freezing in aoti. Need help from the community to review and see if this is a suitable way.

Test on cpu only device:
```bash
python test_aot_inductor.py -k AOTInductorTestNonABICompatibleCpu.test_freezing_non_abi_compatible_cpu 
```

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang