### PR TITLE
New feature in DataLoader: Balanced Sampler

### DIFF
--- a/torch/utils/data/__init__.py
+++ b/torch/utils/data/__init__.py
@@ -1,6 +1,7 @@
 # TODO(VitalyFedyunin): Rearranging this imports leads to crash,
 # need to cleanup dependencies and fix it
 from torch.utils.data.sampler import (
+    BalancedSampler,
     BatchSampler,
     RandomSampler,
     Sampler,
@@ -41,7 +42,8 @@ from torch.utils.data.datapipes._decorator import (
     runtime_validation_disabled,
 )
 
-__all__ = ['BatchSampler',
+__all__ = ['BalancedSampler',
+           'BatchSampler',
            'ChainDataset',
            'ConcatDataset',
            'DFIterDataPipe',


### PR DESCRIPTION
## 🚀 The feature

I added a new sampler called  `BalancedSampler` that, given a list of target classes (for example from a `Dataset` object), and a parameter called `strategy`, it automatically balance the data depending on given strategy as follows:

|Value| Description|
|---|---|
|`"oversample"`| the dataset will be balanced by yielding indexes of minority classes several times until the majority classes are equalized|
|`"undersample"` | the dataset will be balanced by yielding only a subset of indexes of majority classes with the cardinality of the set of minority classes indexes|

## Motivation, pitch

While working with an unbalanced dataset, I find extremely useful to balance it at runtime instead of copying/removing data in the filesystem.
In case of a images dataset, after a oversample balanced sampler is defined, you can also apply data augmentation when you define the data loader to not use the exact copy of the images and avoid overfitting.
## Test
I added tests for each strategy, and, since I wrote the class to take a random number generator as input, I added it to the test_sampler_reproducibility test.
