### PR TITLE
[dynamo] Add guards for `traceable_tensor_subclass` ctx metadata

### DIFF
--- a/test/distributed/_tensor/test_dtensor_compile.py
+++ b/test/distributed/_tensor/test_dtensor_compile.py
@@ -6,9 +6,9 @@ import functools
 
 import torch
 import torch._dynamo
-from torch._dynamo.testing import CompileCounter
 import torch.distributed as dist
 import torch.nn as nn
+from torch._dynamo.testing import CompileCounter
 from torch.distributed._tensor import (
     DeviceMesh,
     DTensor,
@@ -140,8 +140,6 @@ class TestDTensorCompile(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnt.frame_count, 1)
         self.assertEqual(fn(x3), opt_fn(x3))
         self.assertEqual(cnt.frame_count, 2)
-
-
 
     def test_dynamo_dtensor_from_local(self):
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -743,7 +743,7 @@ class GuardBuilder(GuardBuilderBase):
             if is_traceable_wrapper_subclass(value) and not isinstance(
                 value, NestedTensor
             ):
-                ctx = value.__tensor_flatten__()[1]
+                ctx = value.__tensor_flatten__()[1]  # type: ignore[attr-defined]
                 if ctx is not None:
                     # Assume that the ctx obeys object equality
                     obj_store = self.get("G['___stored_objs_by_id']")

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import builtins
 import collections
+import copy
 import dataclasses
 import enum
 import functools
@@ -746,7 +747,7 @@ class GuardBuilder(GuardBuilderBase):
                 if ctx is not None:
                     # Assume that the ctx obeys object equality
                     obj_store = self.get("G['___stored_objs_by_id']")
-                    obj_store[id(ctx)] = ctx
+                    obj_store[id(ctx)] = copy.deepcopy(ctx)
                     code.append(
                         f"{tensor_name}.__tensor_flatten__()[1] == G['___stored_objs_by_id'][{id(ctx)}]"
                     )

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -747,7 +747,9 @@ class GuardBuilder(GuardBuilderBase):
                     # Assume that the ctx obeys object equality
                     obj_store = self.get("G['___stored_objs_by_id']")
                     obj_store[id(ctx)] = ctx
-                    code.append(f"{tensor_name}.__tensor_flatten__()[1] == G['___stored_objs_by_id'][{id(ctx)}]")
+                    code.append(
+                        f"{tensor_name}.__tensor_flatten__()[1] == G['___stored_objs_by_id'][{id(ctx)}]"
+                    )
 
             # A frame is valid for reuse with dynamic dimensions if the new dynamic dimensions are a
             # strict subset of the old.

--- a/torch/nested/_internal/nested_tensor.py
+++ b/torch/nested/_internal/nested_tensor.py
@@ -111,9 +111,7 @@ class NestedTensor(torch.Tensor):
 
     def __repr__(self):
         # We should implement this in torch/_tensor_str.py instead
-        grad_fn_str = (
-            f", requires_grad={self.requires_grad}" if self.requires_grad else ""
-        )
+        grad_fn_str = ", requires_grad=True" if self.requires_grad else ""
         if self.grad_fn:
             grad_fn_str = f", grad_fn={self.grad_fn}"
         return f"NestedTensor(size={self._size}, offsets={self._offsets}{grad_fn_str}, contiguous={self._lengths is None})"


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/114405

- Add a new storage to the guard function globals: `___stored_objs_by_id`, which stores arbitrary objects to perform `==` testing on.
- Store a deep copy of the `__tensor_flatten__` ctx in `___stored_objs_by_id`, to perform equality testing with input tensor's


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @rohan-varma @aakhundov @kiukchung @lucasllc