### PR TITLE
[BE]: ruff enable SLOT checks and add fixes

### DIFF
--- a/.github/scripts/pytest_caching_utils.py
+++ b/.github/scripts/pytest_caching_utils.py
@@ -28,6 +28,8 @@ UNZIPPED_CACHES = "unzipped-caches"
 # Since the pr identifier can be based on include user defined text (like a branch name)
 # we hash it to sanitize the input and avoid corner cases
 class PRIdentifier(str):
+    __slots__ = ()
+
     def __new__(cls, value: str) -> "PRIdentifier":
         md5 = hashlib.md5(value.encode("utf-8")).hexdigest()
         return super().__new__(cls, md5)

--- a/functorch/dim/reference.py
+++ b/functorch/dim/reference.py
@@ -156,7 +156,7 @@ class llist(isin, list):
 
 
 class ltuple(isin, tuple):
-    pass
+    __slots__ = ()
 
 
 empty_dict = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ select = [
     "PT026",
     "PYI",
     "RUF017",
+    "SLOT",
     "TRY200",
     "TRY302",
     "UP",

--- a/test/torch_np/numpy_tests/core/test_indexing.py
+++ b/test/torch_np/numpy_tests/core/test_indexing.py
@@ -414,8 +414,8 @@ class TestIndexing(TestCase):
         arr = np.ones((5, 5))
 
         # A tuple subclass should also be an nd-index
-        class TupleSubclass(tuple):  # noqa: SLOT001
-            pass
+        class TupleSubclass(tuple):
+            __slots__ = ()
 
         index = ([1], [1])
         index = TupleSubclass(index)

--- a/test/torch_np/numpy_tests/core/test_indexing.py
+++ b/test/torch_np/numpy_tests/core/test_indexing.py
@@ -414,7 +414,7 @@ class TestIndexing(TestCase):
         arr = np.ones((5, 5))
 
         # A tuple subclass should also be an nd-index
-        class TupleSubclass(tuple):
+        class TupleSubclass(tuple):  # noqa: SLOT001
             pass
 
         index = ([1], [1])

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -682,6 +682,7 @@ def render_call(fn, args, kwargs):
 
 class KeyErrorMessage(str):
     r"""str subclass that returns itself in repr"""
+    __slots__ = ()
 
     def __repr__(self):
         return self

--- a/torch/ao/quantization/fx/_equalize.py
+++ b/torch/ao/quantization/fx/_equalize.py
@@ -223,6 +223,8 @@ class EqualizationQConfig(namedtuple('EqualizationQConfig', ['input_activation',
     my_qconfig = EqualizationQConfig(input_activation=_InputEqualizationObserver.with_args(dtype=torch.qint8),
                                     weight=_WeightEqualizationObserver.with_args(dtype=torch.qint8))
     """
+    __slots__ = ()
+
     def __new__(cls, input_activation=torch.nn.Identity, weight=torch.nn.Identity):
         if isinstance(input_activation, nn.Module) or isinstance(weight, nn.Module):
             raise ValueError("EqualizationQConfig received observer instance, please pass observer class instead. " +

--- a/torch/ao/quantization/qconfig.py
+++ b/torch/ao/quantization/qconfig.py
@@ -98,6 +98,8 @@ class QConfig(namedtuple('QConfig', ['activation', 'weight'])):
           weight=default_observer.with_args(dtype=torch.qint8))
 
     """
+    __slots__ = ()
+
     def __new__(cls, activation, weight):
         # catch common mistakes
         if isinstance(activation, nn.Module) or isinstance(weight, nn.Module):
@@ -122,6 +124,8 @@ class QConfigDynamic(namedtuple('QConfigDynamic', ['activation', 'weight'])):
 
       my_qconfig = QConfigDynamic(weight=default_observer.with_args(dtype=torch.qint8))
     """
+    __slots__ = ()
+
     def __new__(cls, activation=torch.nn.Identity, weight=torch.nn.Identity):
         # catch common mistakes
         if isinstance(weight, nn.Module):

--- a/torch/fx/passes/infra/pass_base.py
+++ b/torch/fx/passes/infra/pass_base.py
@@ -15,6 +15,8 @@ class PassResult(namedtuple("PassResult", ["graph_module", "modified"])):
         graph_module: The modified graph module
         modified: A flag for if the pass has modified the graph module
     """
+    __slots__ = ()
+
     def __new__(cls, graph_module, modified):
         return super().__new__(cls, graph_module, modified)
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -27,6 +27,8 @@ T = TypeVar('T', bound='Module')
 
 
 class _IncompatibleKeys(namedtuple('IncompatibleKeys', ['missing_keys', 'unexpected_keys'])):
+    __slots__ = ()
+
     def __repr__(self):
         if not self.missing_keys and not self.unexpected_keys:
             return '<All keys matched successfully>'

--- a/torch/testing/_internal/common_dtype.py
+++ b/torch/testing/_internal/common_dtype.py
@@ -15,6 +15,7 @@ def _validate_dtypes(*dtypes):
 # class for tuples corresponding to a PyTorch dispatch macro
 class _dispatch_dtypes(tuple):
     __slots__ = ()
+
     def __add__(self, other):
         assert isinstance(other, tuple)
         return _dispatch_dtypes(tuple.__add__(self, other))

--- a/torch/testing/_internal/common_dtype.py
+++ b/torch/testing/_internal/common_dtype.py
@@ -13,7 +13,7 @@ def _validate_dtypes(*dtypes):
     return dtypes
 
 # class for tuples corresponding to a PyTorch dispatch macro
-class _dispatch_dtypes(tuple):
+class _dispatch_dtypes(tuple):  # noqa: SLOT001
     def __add__(self, other):
         assert isinstance(other, tuple)
         return _dispatch_dtypes(tuple.__add__(self, other))

--- a/torch/testing/_internal/common_dtype.py
+++ b/torch/testing/_internal/common_dtype.py
@@ -13,7 +13,8 @@ def _validate_dtypes(*dtypes):
     return dtypes
 
 # class for tuples corresponding to a PyTorch dispatch macro
-class _dispatch_dtypes(tuple):  # noqa: SLOT001
+class _dispatch_dtypes(tuple):
+    __slots__ = ()
     def __add__(self, other):
         assert isinstance(other, tuple)
         return _dispatch_dtypes(tuple.__add__(self, other))

--- a/torch/testing/_internal/jit_metaprogramming_utils.py
+++ b/torch/testing/_internal/jit_metaprogramming_utils.py
@@ -30,8 +30,8 @@ def unpack_variables(args):
     else:
         return args
 
-class dont_convert(tuple):  # noqa: SLOT001
-    pass
+class dont_convert(tuple):
+    __slots__ = ()
 
 non_differentiable = collections.namedtuple('non_differentiable', ['tensor'])
 

--- a/torch/testing/_internal/jit_metaprogramming_utils.py
+++ b/torch/testing/_internal/jit_metaprogramming_utils.py
@@ -30,7 +30,7 @@ def unpack_variables(args):
     else:
         return args
 
-class dont_convert(tuple):
+class dont_convert(tuple):  # noqa: SLOT001
     pass
 
 non_differentiable = collections.namedtuple('non_differentiable', ['tensor'])

--- a/torch/torch_version.py
+++ b/torch/torch_version.py
@@ -22,6 +22,8 @@ class TorchVersion(str):
             TorchVersion('1.10.0a') > '1.2'
             TorchVersion('1.10.0a') > '1.2.1'
     """
+    __slots__ = ()
+
     # fully qualified type names here to appease mypy
     def _convert_to_version(self, inp: Any) -> Any:
         if isinstance(inp, Version):


### PR DESCRIPTION
Enable ruff `SLOT` rules and fixes all offending classes. Makes subclasses more efficient at the cost adding an additional line to the class.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan @angelayi @suo @ydwu4 @kiukchung @d4l3k @lucasllc