### PR TITLE
[BE]: Enable Ruff + Flake8 G201,G202 logging format rule.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -18,7 +18,7 @@ ignore =
     # these ignores are from flake8-comprehensions; please fix!
     C407,
     # these ignores are from flake8-logging-format; please fix!
-    G100,G101,G200,G201,G202
+    G100,G101,G200,G202
     # these ignores are from flake8-simplify. please fix or ignore with commented reason
     SIM105,SIM108,SIM110,SIM111,SIM113,SIM114,SIM115,SIM116,SIM117,SIM118,SIM119,SIM12,
     # flake8-simplify code styles

--- a/.flake8
+++ b/.flake8
@@ -18,7 +18,7 @@ ignore =
     # these ignores are from flake8-comprehensions; please fix!
     C407,
     # these ignores are from flake8-logging-format; please fix!
-    G100,G101,G200,G202
+    G100,G101,G200
     # these ignores are from flake8-simplify. please fix or ignore with commented reason
     SIM105,SIM108,SIM110,SIM111,SIM113,SIM114,SIM115,SIM116,SIM117,SIM118,SIM119,SIM12,
     # flake8-simplify code styles

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ ignore = [
     "F841",
     # these ignores are from flake8-logging-format; please fix!
     "G101",
-    "G202",
     # these ignores are from RUFF perf; please fix!
     "PERF203", "PERF4",
     # these ignores are from PYI; please fix!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ ignore = [
     "F821",
     "F841",
     # these ignores are from flake8-logging-format; please fix!
-    "G101", "G201", "G202",
+    "G101",
+    "G202",
     # these ignores are from RUFF perf; please fix!
     "PERF203", "PERF4",
     # these ignores are from PYI; please fix!

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -1315,9 +1315,8 @@ def get_guard_fail_reason(
                 GuardFail(reason_str or "unknown reason", orig_code_map[code])
             )
     except Exception as e:
-        log.error(
+        log.exception(
             "Failure in guard_fail_fn callback - raising here will cause a NULL Error on guard eval",
-            exc_info=True,
         )
 
     return reason_str

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -400,7 +400,7 @@ def write_record_to_file(filename, exec_record):
             with open(filename, "wb") as f:
                 exec_record.dump(f)
     except Exception:
-        log.error("Unable to write execution record %s", filename, exc_info=True)
+        log.exception("Unable to write execution record %s", filename)
 
 
 def count_calls(g: fx.Graph):

--- a/torch/distributed/elastic/multiprocessing/api.py
+++ b/torch/distributed/elastic/multiprocessing/api.py
@@ -477,14 +477,13 @@ class MultiprocessContext(PContext):
             failed_proc = self._pc.processes[failed_local_rank]
             error_filepath = self.error_files[failed_local_rank]
 
-            log.error(
+            log.exception(
                 "failed (exitcode: %s)"
                 " local_rank: %s (pid: %s)"
                 " of fn: %s (start_method: %s)",
                 failed_proc.exitcode,
                 failed_local_rank, e.pid,
                 fn_name, self.start_method,
-                exc_info=True,
             )
 
             self.close()

--- a/torch/distributed/elastic/timer/api.py
+++ b/torch/distributed/elastic/timer/api.py
@@ -169,11 +169,10 @@ class TimerServer(abc.ABC):
         """
         try:
             return self._reap_worker(worker_id)
-        except Exception as e:
-            log.error(
+        except Exception:
+            log.exception(
                 "Uncaught exception thrown from _reap_worker(), "
                 "check that the implementation correctly catches exceptions",
-                exc_info=e,
             )
             return True
 
@@ -181,8 +180,8 @@ class TimerServer(abc.ABC):
         while not self._stop_signaled:
             try:
                 self._run_watchdog()
-            except Exception as e:
-                log.error("Error running watchdog", exc_info=e)
+            except Exception:
+                log.exception("Error running watchdog")
 
     def _run_watchdog(self):
         batch_size = max(1, self._request_queue.size())

--- a/torch/distributed/elastic/timer/file_based_local_timer.py
+++ b/torch/distributed/elastic/timer/file_based_local_timer.py
@@ -225,8 +225,8 @@ class FileTimerServer:
                     self._run_watchdog(fd)
                     if run_once:
                         break
-                except Exception as e:
-                    log.error("Error running watchdog", exc_info=e)
+                except Exception:
+                    log.exception("Error running watchdog")
 
     def _run_watchdog(self, fd: io.TextIOWrapper) -> None:
         timer_requests = self._get_requests(fd, self._max_interval)
@@ -328,6 +328,6 @@ class FileTimerServer:
         except ProcessLookupError:
             log.info("Process with pid=%s does not exist. Skipping", worker_pid)
             return True
-        except Exception as e:
-            log.error("Error terminating pid=%s", worker_pid, exc_info=e)
+        except Exception:
+            log.exception("Error terminating pid=%s", worker_pid)
         return False

--- a/torch/distributed/elastic/timer/local_timer.py
+++ b/torch/distributed/elastic/timer/local_timer.py
@@ -120,6 +120,6 @@ class LocalTimerServer(TimerServer):
         except ProcessLookupError:
             log.info("Process with pid=%s does not exist. Skipping", worker_id)
             return True
-        except Exception as e:
-            log.error("Error terminating pid=%s", worker_id, exc_info=e)
+        except Exception:
+            log.exception("Error terminating pid=%s", worker_id)
         return False


### PR DESCRIPTION
Standardizes logging calls to always use logging.exception instead of logging.error where appropriate and enforces it with a lint.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @kiukchung @d4l3k @lucasllc