### PR TITLE
[inductor] Pass None and skip constexpr in custom Triton kernel calls from C++

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -2350,8 +2350,10 @@ class CppWrapperCodeGen(WrapperCodeGen):
     def val_to_arg_str(self, val):
         if val is None:
             # When None is passed as an argument, it represents an optional that does not contain a value.
-            # TODO: add abi-compatible support
-            return "c10::nullopt"
+            if config.aot_inductor.abi_compatible:
+                return "nullptr"
+            else:
+                return "c10::nullopt"
         elif isinstance(val, bool):
             if config.aot_inductor.abi_compatible:
                 return "1" if val else "0"
@@ -2532,6 +2534,10 @@ class CudaWrapperCodeGen(CppWrapperCodeGen):
                 self.writeline(f"float {var_name} = {arg};")
             elif any(str(arg) == s.name for s in dynamic_symbols):
                 self.writeline(f"auto {var_name} = {arg};")
+            elif arg == "nullptr":
+                self.writeline(f"auto {var_name} = nullptr;")
+            elif arg == "c10::nullopt":
+                self.writeline(f"auto {var_name} = c10::nullopt;")
             else:
                 if config.aot_inductor.abi_compatible:
                     self.writeline(f"CUdeviceptr {var_name};")

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3835,7 +3835,7 @@ class UserDefinedTritonKernel(ExternKernel):
             from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
 
             # in C++ wrapper, we don't pass constexpr args, as they don't
-            # get added asparameters to the PTX code compiled from the
+            # get added as parameters to the PTX code compiled from the
             # user-defined Triton kernel (only non-constexpr args do)
             kernel = kernel_side_table.get_kernel(self.kernel_idx)
             args = [arg for i, arg in enumerate(args) if i not in kernel.constexprs]

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3832,15 +3832,15 @@ class UserDefinedTritonKernel(ExternKernel):
 
         args = self.codegen_kwargs()
         if V.graph.cpp_wrapper:
-            # in C++ wrapper, we don't pass constexpr args, as they don't
-            # get added as parameters to the PTX code compiled from the
-            # user-defined Triton kernel (only non-constexpr args do)
-            from triton.runtime.jit import JITFunction
             from triton.runtime.autotuner import Autotuner
+            from triton.runtime.jit import JITFunction
 
             if isinstance(kernel, Autotuner):
                 kernel = kernel.fn
             assert isinstance(kernel, JITFunction), str(kernel)
+            # in C++ wrapper, we don't pass constexpr args, as they don't
+            # get added as parameters to the PTX code compiled from the
+            # user-defined Triton kernel (only non-constexpr args do)
             args = [arg for i, arg in enumerate(args) if i not in kernel.constexprs]
 
         # Call to kernel

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3832,12 +3832,6 @@ class UserDefinedTritonKernel(ExternKernel):
 
         args = self.codegen_kwargs()
         if V.graph.cpp_wrapper:
-            from triton.runtime.autotuner import Autotuner
-            from triton.runtime.jit import JITFunction
-
-            if isinstance(kernel, Autotuner):
-                kernel = kernel.fn
-            assert isinstance(kernel, JITFunction), str(kernel)
             # in C++ wrapper, we don't pass constexpr args, as they don't
             # get added as parameters to the PTX code compiled from the
             # user-defined Triton kernel (only non-constexpr args do)

--- a/torch/testing/_internal/triton_utils.py
+++ b/torch/testing/_internal/triton_utils.py
@@ -27,6 +27,27 @@ if HAS_CUDA:
         output = x + y
         tl.store(out_ptr + offsets, output, mask=mask)
 
+    @triton.jit
+    def add_kernel_with_optional_param(
+        in_ptr0,
+        in_ptr1,
+        out_ptr,
+        n_elements,
+        ARGS_PASSED: "tl.constexpr",
+        BLOCK_SIZE: "tl.constexpr",
+    ):
+        pid = tl.program_id(axis=0)
+        block_start = pid * BLOCK_SIZE
+        offsets = block_start + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        x = tl.load(in_ptr0 + offsets, mask=mask)
+        if ARGS_PASSED == "two":
+            y = tl.load(in_ptr1 + offsets, mask=mask)
+            output = x + y
+        else:
+            output = x
+        tl.store(out_ptr + offsets, output, mask=mask)
+
     @triton.autotune(
         configs=[
             triton.Config({"BLOCK_SIZE": 128}, num_stages=3, num_warps=8),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #114475

Summary: `None` arguments are codegened as `*i8` in the `triton_meta` of the generated or user-defined Triton kernels:

https://github.com/pytorch/pytorch/blob/85aa3723749e0d06aa5fd34215b9b93529a60995/torch/_inductor/codegen/triton_utils.py#L33-L36

Due to this, in contrary to the conventional Triton, we actually should pass `nullptr` to the Triton kernels in C++ wrapper codegen instead of passing nothing (as normally `None` doesn't make it to the generated PTX parameters, just like `tl.constexpr` args).

This PR adds two things:

1. Proper C++ wrapper codegening (ABI and non-ABI) of `nullptr` and `c10::nullopt`, as the prior way codegening `c10::nullopt` as tensor breaks (also `c10` breaks in the ABI mode).

2. Skipping `tl.constexpr` args when calling the loaded-from-cubin compiled Triton kernel in the C++ wrapper codegen. As a side effect, this also resolves an issue with string arguments: now they are simply omitted in the C++ wrapper codegen.

Test Plan:

```
$ python test/inductor/test_aot_inductor.py -k test_triton_kernel_with_none_input
...
----------------------------------------------------------------------
Ran 4 tests in 40.364s

OK (skipped=2)
```

Reviewers:

Subscribers:

Tasks:

Tags:

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler