### PR TITLE
[WIP] upsample_linear1d MPS op development

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6227,7 +6227,7 @@ class TestNLLLoss(TestCaseMPS):
             self.assertEqual(inputCPU.grad, inputMPS.grad)
 
         # 1D interpolation
-        for mode in ['nearest', 'nearest-exact']:
+        for mode in ['nearest', 'nearest-exact', 'linear']:
             helper([2, 3, 4], [3], None, mode)  # downsample with size
             helper([2, 3, 4], [6], None, mode)  # upsample with size
             helper([2, 3, 4], None, [0.6], mode)  # downsample with scale factor


### PR DESCRIPTION
I'm working on mps ops for upsample_linear1d since it was a high-priority issue on #77764 and I've been wanting to use it in a model. 

The difficulty in implementing upsample_linear1d is that mps doesn't natively have a resizeLinear function like they have [resizeBilinear](https://developer.apple.com/documentation/metalperformanceshadersgraph/mpsgraph/4057339-resizebilinear) or [resizeNearest](https://developer.apple.com/documentation/metalperformanceshadersgraph/mpsgraph/4057343-resizenearest). This will likely require a custom op implementation of linear upsampling.

I've added a preliminary "shell" in Upsample.mm, although this will likely need quite a few tweaks as I figure out how to link a custom implementation. If anyone has some advice on how to get started on this(possibly in terms of the implementation of linear upsampling or linking that implementation to Upsample.mm), I'd love to hear it.