### PR TITLE
Canonicalize runtime asserts

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -974,6 +974,7 @@ coverage_ignore_functions = [
     "parallel_and",
     "parallel_or",
     "sym_eq",
+    "canonicalize_bool_expr",
     # torch.fx.experimental.unification.core
     "reify",
     # torch.fx.experimental.unification.match

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -497,7 +497,7 @@ def forward(self, x_1):
         self.assertTrue(expect_true(i0 <= s0))
         self.assertExpectedInline(
             str([ra.expr for ra in shape_env.deferred_runtime_asserts[i0.node.expr]]),
-            """[i0 <= s0]"""
+            """[i0 - s0 <= 0]"""
         )
         self.assertTrue(i0 <= s0)
         self.assertFalse(i0 > s0)

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -60,7 +60,7 @@ aten = torch._ops.ops.aten  # type: ignore[has-type]
 
 __all__ = [
     "has_symbolic_sizes_strides", "create_contiguous", "ShapeEnv", "is_concrete_int",
-    "guard_int", "guard_float", "guard_scalar",
+    "guard_int", "guard_float", "guard_scalar", "canonicalize_bool_expr",
     "hint_int", "SYMPY_INTERP", "free_symbols", "is_symbol_binding_fx_node",
     "is_concrete_bool", "SHAPEENV_EVENT_KEY", "CURRENT_NODE_KEY",
     "has_free_symbols", "sym_eq", "CreateSymbolicPolicy", "FreshCreateSymbolicPolicy",
@@ -138,30 +138,39 @@ def is_concrete_int(a: Union[int, SymInt]):
 
     return False
 
-def rel_canonical(expr: sympy.Expr):
+def canonicalize_bool_expr(expr: sympy.Expr):
+    r""" Canonicalize a boolean expression by transforming it into a lt / le
+    inequality and moving all the non-constant terms to the rhs.
+    We canonicalize And / Ors / Not via cnf and then canonicalize their subexpr
+    recursively
+    nb. sympy.Rel.canonical is not good enough https://github.com/sympy/sympy/issues/25924
+
+    Args:
+        expr (sympy.Expr): Expression to canonicalize
+    """
     # Canonicalise an inequality by transforming it into a lt / le
     # inequality and moving all the non-constant terms to the rhs
+    # We canonicalise And / Ors / Not via cnf
     # nb. Relational.canonical in sympy is broken
     # https://github.com/sympy/sympy/issues/25924
 
+    if not isinstance(expr, (sympy.Rel, sympy.And, sympy.Or, sympy.Not, sympy.Eq, sympy.Ne)):
+        return expr
+
     if isinstance(expr, (sympy.And, sympy.Or, sympy.Not)):
         expr = sympy.logic.boolalg.to_cnf(expr)
-    return _rel_canonical_impl(expr)
+    return _canonicalize_bool_expr_impl(expr)
 
-def _rel_canonical_impl(expr: sympy.Expr):
+def _canonicalize_bool_expr_impl(expr: sympy.Expr):
     if isinstance(expr, (sympy.And, sympy.Or)):
-        return type(expr)(*map(rel_canonical, expr.args))
+        return type(expr)(*map(canonicalize_bool_expr, expr.args))
 
-    assert isinstance(expr, sympy.core.relational.Relational), (type(expr), expr)
-    # We don't canonicalise these yet, albeit we cou ld
-    if isinstance(expr, (sympy.Eq, sympy.Ne)):
-        return expr
     opposite = {sympy.Gt: sympy.Lt, sympy.Ge: sympy.Le}
     if isinstance(expr, tuple(opposite.keys())):
         lhs = expr.rhs - expr.lhs
         t = opposite[type(expr)]
     else:
-        assert isinstance(expr, (sympy.Lt, sympy.Le))
+        assert isinstance(expr, (sympy.Lt, sympy.Le, sympy.Eq, sympy.Ne))
         lhs = expr.lhs - expr.rhs
         t = type(expr)
     rhs = 0
@@ -176,7 +185,6 @@ def _rel_canonical_impl(expr: sympy.Expr):
         lhs = sympy.Add(*variables)
         rhs = -sympy.Add(*cts)
     return t(lhs, rhs)
-
 
 def is_concrete_bool(a: Union[bool, SymBool]):
     r""" Utility to check if underlying object
@@ -1131,7 +1139,6 @@ class DimConstraints:
             self._inconsistencies.append(f"{orig_expr} is inconsistent!")
         free_symbols = expr.free_symbols
         assert free_symbols, f"Did not expect constraint with no free variables: {expr}"
-
         if len(free_symbols) > 1:
             # multivariate: record and move on
             self._multivariate_inequalities.add(expr)
@@ -3016,8 +3023,7 @@ class ShapeEnv:
         if compute_hint:
             expr = expr.xreplace(self.var_to_val)
 
-        if isinstance(expr, (sympy.Rel, sympy.And, sympy.Or)):
-            expr = rel_canonical(expr)
+        expr = canonicalize_bool_expr(expr)
 
         symbols = list(expr.free_symbols)
 
@@ -3027,17 +3033,20 @@ class ShapeEnv:
             if s in self.var_to_val:
                 continue
             subst = {}
-            if s in self.deferred_runtime_asserts:
-                for ra in self.deferred_runtime_asserts[s]:
-                    if compute_hint:
-                        e = ra.expr.xreplace(self.var_to_val)
-                    else:
-                        e = ra.expr
-                    subst[e] = sympy.true
-                    subst[rel_canonical(sympy.Not(e))] = sympy.false
-                    # NB: this doesn't match relations if they're flipped; e.g.,
-                    # if you have x < 5, we won't get 5 > x.  Holler if this is
-                    # a problem
+            for ra in self.deferred_runtime_asserts.get(s, ()):
+                if compute_hint:
+                    e = canonicalize_bool_expr(ra.expr.xreplace(self.var_to_val))
+                else:
+                    e = ra.expr
+                # e is already canonical
+                subst[e] = sympy.true
+                subst[canonicalize_bool_expr(sympy.Not(e))] = sympy.false
+                if isinstance(e, sympy.Eq):
+                    subst[sympy.Le(e.lhs, e.rhs)] = sympy.true
+                    subst[sympy.Le(-e.lhs, -e.rhs)] = sympy.true
+                    subst[sympy.Lt(e.lhs, e.rhs)] = sympy.false
+                    subst[sympy.Lt(-e.lhs, -e.rhs)] = sympy.false
+
             # NB: this helps us deal with And/Or connectives
             expr = expr.subs(subst)
 
@@ -3599,8 +3608,7 @@ class ShapeEnv:
 
         if not self._suppress_guards_tls():
             # canonicalise to remove equations that are trivially equal
-            if isinstance(expr, (sympy.Rel, sympy.And, sympy.Or)):
-                expr = rel_canonical(expr)
+            expr = canonicalize_bool_expr(expr)
             stack = CapturedTraceback.extract(skip=1)
             ra = RuntimeAssert(expr, msg, stack)
             # TODO: Do this in a way that is less janky than int(s.name[1:])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #114509

This allows us to remove quite a few redundant runtime asserts, and potentially a number of guards as well.

On
```
python test/dynamo/test_subclasses.py -k test_unbind
```
we go from
```
inserting runtime assert i0 <= s0
inserting runtime assert 0 <= -i0 + s0
inserting runtime assert i0 + i1 <= s0
inserting runtime assert i0 <= -i1 + s0
inserting runtime assert i0 + i1 + i2 <= s0
inserting runtime assert i0 + i1 <= -i2 + s0
inserting runtime assert Eq(i0 + i1 + i2 + i3, s0)
inserting runtime assert i0 + i1 + i2 + i3 <= s0
inserting runtime assert i0 + i1 + i2 <= -i3 + s0
```
to
```
inserting runtime assert i0 - s0 <= 0
inserting runtime assert i0 + i1 - s0 <= 0
inserting runtime assert i0 + i1 + i2 - s0 <= 0
inserting runtime assert Eq(i0 + i1 + i2 + i3, s0)
```

cc @ezyang