### PR TITLE
Print ghcr docker pull during build/test

### DIFF
--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -96,12 +96,11 @@ jobs:
       - name: Use following to pull public copy of the image
         id: print-ghcr-mirror
         env:
-          DOCKER_IMAGE_NAME: ${{ inputs.docker-image-name }}
           ECR_DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
         shell: bash
         run: |
-          tag=${ECR_DOCKER_IMAGE##*:}
-          echo "docker pull ghcr.io/pytorch/ci-image:${DOCKER_IMAGE_NAME}-${tag}"
+          tag=${${ECR_DOCKER_IMAGE##*/}/:/-}
+          echo "docker pull ghcr.io/pytorch/ci-image:${tag}"
 
       - name: Pull docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@main

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -99,8 +99,8 @@ jobs:
           ECR_DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
         shell: bash
         run: |
-          tag=${${ECR_DOCKER_IMAGE##*/}/:/-}
-          echo "docker pull ghcr.io/pytorch/ci-image:${tag}"
+          tag=${ECR_DOCKER_IMAGE##*/}
+          echo "docker pull ghcr.io/pytorch/ci-image:${tag/:/-}"
 
       - name: Pull docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@main

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -92,13 +92,14 @@ jobs:
         uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
         with:
           docker-image-name: ${{ inputs.docker-image-name }}
+
       - name: Use following to pull public copy of the image
         id: print-ghcr-mirror
         env:
           DOCKER_IMAGE_NAME: ${{ inputs.docker-image-name }}
           ECR_DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
         shell: bash
-        run:
+        run: |
           tag=${ECR_DOCKER_IMAGE##*:}
           echo "docker pull ghcr.io/pytorch/ci-image:${DOCKER_IMAGE_NAME}-${tag}"
 

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -92,6 +92,15 @@ jobs:
         uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
         with:
           docker-image-name: ${{ inputs.docker-image-name }}
+      - name: Use following to pull public copy of the image
+        id: print-ghcr-mirror
+        env:
+          DOCKER_IMAGE_NAME: ${{ inputs.docker-image-name }}
+          ECR_DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
+        shell: bash
+        run:
+          tag=${ECR_DOCKER_IMAGE##*:}
+          echo "docker pull ghcr.io/pytorch/ci-image:${DOCKER_IMAGE_NAME}-${tag}"
 
       - name: Pull docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@main

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -83,8 +83,8 @@ jobs:
           ECR_DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
         shell: bash
         run: |
-          tag=${${ECR_DOCKER_IMAGE##*/}/:/-}
-          echo "docker pull ghcr.io/pytorch/ci-image:${tag}"
+          tag=${ECR_DOCKER_IMAGE##*/}
+          echo "docker pull ghcr.io/pytorch/ci-image:${tag/:/-}"
 
       - name: Pull docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@main

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -80,12 +80,11 @@ jobs:
       - name: Use following to pull public copy of the image
         id: print-ghcr-mirror
         env:
-          DOCKER_IMAGE_NAME: ${{ inputs.docker-image }}
           ECR_DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
         shell: bash
         run: |
-          tag=${ECR_DOCKER_IMAGE##*:}
-          echo "docker pull ghcr.io/pytorch/ci-image:${DOCKER_IMAGE_NAME}-${tag}"
+          tag=${${ECR_DOCKER_IMAGE##*/}/:/-}
+          echo "docker pull ghcr.io/pytorch/ci-image:${tag}"
 
       - name: Pull docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@main

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -77,6 +77,16 @@ jobs:
         with:
           docker-image-name: ${{ inputs.docker-image }}
 
+      - name: Use following to pull public copy of the image
+        id: print-ghcr-mirror
+        env:
+          DOCKER_IMAGE_NAME: ${{ inputs.docker-image }}
+          ECR_DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
+        shell: bash
+        run: |
+          tag=${ECR_DOCKER_IMAGE##*:}
+          echo "docker pull ghcr.io/pytorch/ci-image:${DOCKER_IMAGE_NAME}-${tag}"
+
       - name: Pull docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@main
         with:


### PR DESCRIPTION
To make debugging easier to external devs

Test plan: Copy and run command from [`Use the following to pull public copy of the image`](https://github.com/pytorch/pytorch/actions/runs/7012511180/job/19077533416?pr=114510#step:6:9):
```
docker pull ghcr.io/pytorch/ci-image:pytorch-linux-jammy-py3.8-gcc11-0d0042fd2e432ea07301ad6f6a474d36a581f0dc

```
