### PR TITLE
[release only] Pin disabled-test-condensed and slow-tests json

### DIFF
--- a/tools/stats/import_test_stats.py
+++ b/tools/stats/import_test_stats.py
@@ -98,7 +98,7 @@ def get_disabled_tests(
         return disabled_test_from_issues
 
     try:
-        url = "https://ossci-metrics.s3.amazonaws.com/disabled-tests-condensed.json"
+        url = "https://ossci-metrics.s3.amazonaws.com/disabled-tests-condensed.json?versionId=JMUOdxgUAeI4yXhzc.dJlCuxVrsfkZTj"
         return fetch_and_cache(dirpath, filename, url, process_disabled_test)
     except Exception:
         print("Couldn't download test skip set, leaving all tests enabled...")

--- a/tools/stats/import_test_stats.py
+++ b/tools/stats/import_test_stats.py
@@ -66,7 +66,7 @@ def fetch_and_cache(
 def get_slow_tests(
     dirpath: str, filename: str = SLOW_TESTS_FILE
 ) -> Optional[Dict[str, float]]:
-    url = "https://ossci-metrics.s3.amazonaws.com/slow-tests.json"
+    url = "https://ossci-metrics.s3.amazonaws.com/slow-tests.json?versionId=iWAOsEqlVH1mfs7w5A3KlyTalvubE4Ru"
     try:
         return fetch_and_cache(dirpath, filename, url, lambda x: x)
     except Exception:


### PR DESCRIPTION
This makes sure tests are pinned Nov 15 version (time of the release 2.1.1)