### PR TITLE
[cudagraphs] utilize input fakemode in faketensor propagation

### DIFF
--- a/torch/fx/passes/backends/cudagraphs.py
+++ b/torch/fx/passes/backends/cudagraphs.py
@@ -4,7 +4,6 @@ from torch.fx.passes.operator_support import OperatorSupport
 from torch.fx.passes.tools_common import CALLABLE_NODE_OPS
 from torch.fx.passes.fake_tensor_prop import FakeTensorProp
 from torch.utils import _pytree as pytree
-from torch._subclasses.fake_tensor import maybe_get_fake_mode
 
 import operator
 
@@ -46,6 +45,7 @@ def partition_cudagraphs(gm, inputs):
     CUDA graphs.  For a subgraph to be runnable under CUDA, all of the operations
     must involve CUDA tensors only/
     """
+    from torch._subclasses.fake_tensor import maybe_get_fake_mode
 
     flat_inputs = pytree.tree_leaves(inputs)
     fake_mode = next(

--- a/torch/fx/passes/backends/cudagraphs.py
+++ b/torch/fx/passes/backends/cudagraphs.py
@@ -49,7 +49,7 @@ def partition_cudagraphs(gm, inputs):
 
     flat_inputs = pytree.tree_leaves(inputs)
     fake_mode = next(
-        (mode for mode in map(lambda x: maybe_get_fake_mode(x), flat_inputs) if mode is not None), 
+        (mode for mode in map(lambda x: maybe_get_fake_mode(x), flat_inputs) if mode is not None),
         None
     )
 

--- a/torch/fx/passes/backends/cudagraphs.py
+++ b/torch/fx/passes/backends/cudagraphs.py
@@ -49,7 +49,7 @@ def partition_cudagraphs(gm, inputs):
 
     flat_inputs = pytree.tree_leaves(inputs)
     fake_mode = next(
-        (mode for mode in map(lambda x: maybe_get_fake_mode(x), flat_inputs) if mode is not None),
+        (mode for mode in (maybe_get_fake_mode(x) for x in flat_inputs) if mode is not None),
         None
     )
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/114525

Needs repro/test

But this fixes the original issue for me

cc @mcarilli @ezyang @eellison @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv