### PR TITLE
Fix test assertions in test_min_max_nodes_parse.

### DIFF
--- a/test/distributed/launcher/run_test.py
+++ b/test/distributed/launcher/run_test.py
@@ -452,11 +452,11 @@ class ElasticLaunchTest(unittest.TestCase):
 
     def test_min_max_nodes_parse(self):
         min_nodes, max_nodes = launch.parse_min_max_nnodes("1")
-        self.assertTrue(min_nodes, max_nodes)
-        self.assertTrue(1, min_nodes)
+        self.assertEqual(min_nodes, max_nodes)
+        self.assertEqual(1, min_nodes)
         min_nodes, max_nodes = launch.parse_min_max_nnodes("2:20")
-        self.assertTrue(2, min_nodes)
-        self.assertTrue(20, max_nodes)
+        self.assertEqual(2, min_nodes)
+        self.assertEqual(20, max_nodes)
         with self.assertRaises(RuntimeError):
             launch.parse_min_max_nnodes("2:20:30")
 


### PR DESCRIPTION
Calls to `assertTrue` corrected to be `assertEqual` in `ElasticLaunchTest test_min_max_nodes_parse`.

As originally written, the `assertTrue` statements will always pass, not actually asserting anything of value for the test.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @kiukchung @d4l3k @lucasllc