### PR TITLE
[AOTAutograd / Functionalization] Fix incorrect `expand_copy_inverse`

### DIFF
--- a/aten/src/ATen/FunctionalInverses.cpp
+++ b/aten/src/ATen/FunctionalInverses.cpp
@@ -148,7 +148,7 @@ Tensor FunctionalInverses::diagonal_copy_inverse(const Tensor& base, const Tenso
 }
 
 Tensor FunctionalInverses::expand_copy_inverse(const Tensor& base, const Tensor& mutated_view, bool reapply_views, at::SymIntArrayRef size, bool implicit) {
-    return at::sum_to(mutated_view, base.sym_sizes(),/*always_return_non_view=*/!reapply_views);
+    return base + at::sum_to(mutated_view - base, base.sym_sizes(),/*always_return_non_view=*/!reapply_views);
 }
 
 Tensor FunctionalInverses::permute_copy_inverse(const Tensor& base, const Tensor& mutated_view, bool reapply_views, at::IntArrayRef dims) {

--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -1032,7 +1032,7 @@ SeqNr|OrigAten|SrcFn
         opt_res.sum().backward()
 
         self.assertEqual(x, x_opt)
-        self.assertEqual(x.grad, x_opt.grad)
+        self.assertEqual(z.grad, z_opt.grad)
 
     # We don't know how to catch multiple mutations to the same memory location
     @unittest.expectedFailure

--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: dynamo"]
 import re
+import unittest
 from textwrap import dedent
 from unittest.mock import patch
 
@@ -991,6 +992,36 @@ SeqNr|OrigAten|SrcFn
                     if x is not None
                 ),
             )
+
+    def test_aot_autograd_expand_mutation_functionalizes(self):
+        def fn(x):
+            y = x.expand(3, *x.shape)
+            y[0, 0].add_(5)
+            return y
+
+        opt_fn = torch.compile(fn, backend="aot_eager")
+
+        x = torch.arange(6)
+        x_opt = x.clone().detach()
+        self.assertEqual(fn(x), opt_fn(x_opt))
+        self.assertEqual(x, x_opt)
+
+    # We don't know how to catch multiple mutations to the same memory location
+    @unittest.expectedFailure
+    def test_aot_autograd_expand_mutation_error(self):
+        def fn(x):
+            y = x.expand(3, *x.shape)
+            y[0:3, 0].add_(5)
+            return y
+
+        opt_fn = torch.compile(fn, backend="aot_eager")
+
+        x = torch.arange(6)
+        x_opt = x.clone().detach()
+        with self.assertRaises(Exception):
+            fn(x)
+        with self.assertRaises(Exception):
+            opt_fn(x_opt)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/114302

Only partial fix, will be correct in all eager passing cases, but will fail to throw error when eager throws error.

---

Deferring to @bdhirsh on follow up on fixing the case when eager throws an error. IMO it's not a priority and I'm OK with not fixing.

---

If in long term we want to fix, I think it can be handled with an analysis similar to https://github.com/pytorch/pytorch/blob/bbdd9b059fa06404701f0d39abaae75ebab5d27f/torch/_functorch/aot_autograd.py#L2202

We can check if expand dims are simultaneously mutated after analyzing in an fx pass.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng