### PR TITLE
[Quant] [PT2] Fix an issue in Conv Binary Quantization Annotation 

### DIFF
--- a/test/quantization/pt2e/test_x86inductor_quantizer.py
+++ b/test/quantization/pt2e/test_x86inductor_quantizer.py
@@ -304,13 +304,11 @@ class X86InductorQuantTestCase(QuantizationTestCase):
         # QAT Model failed to deepcopy
         export_model = m if is_qat else copy.deepcopy(m)
         m = prepare_qat_pt2e(m, quantizer) if is_qat else prepare_pt2e(m, quantizer)
-
         # Calibrate
         m(*example_inputs)
         prepare_model = copy.deepcopy(m)
         m = convert_pt2e(m, fold_quantize=True)
         convert_model = copy.deepcopy(m)
-
         pt2_quant_output = m(*example_inputs)
         node_occurrence = {
             ns.call_function(k): v for k, v in expected_node_occurrence.items()
@@ -451,7 +449,7 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
         Test Pattern:
             tmp = conv2d_1(x)
             tmp2 = conv2d_2(tmp)
-            return tmp+tmp2
+            return tmp + tmp2
         Since conv2d_1 has 2 users, we should annotate conv2d_2 for binary fusion instead of conv2d_1
         """
         example_inputs = (torch.randn(2, 3, 6, 6),)
@@ -463,10 +461,6 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
             for inplace_add in inplace_add_list:
                 m = TestHelperModules.Conv2dAddModule2(inplace_add=inplace_add).eval()
                 node_occurrence = {
-                    # one for input of the conv
-                    # one for input of another conv
-                    # 2 conv will share same input quant/dequant
-                    # one for extra input node of add
                     torch.ops.quantized_decomposed.quantize_per_tensor.default: 2,
                     torch.ops.quantized_decomposed.dequantize_per_tensor.default: 3,
                     # quantize_per_channel for weights are const propagated
@@ -1082,7 +1076,7 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
         Test qat Pattern:
             tmp = bn1(conv2d_1(x))
             tmp2 = bn2(conv2d_2(tmp))
-            return tmp+tmp2
+            return tmp + tmp2
         Since conv2d_1 has 2 users, we should annotate conv2d_2 for binary fusion instead of conv2d_1
         """
         example_inputs = (torch.randn(2, 3, 6, 6),)
@@ -1094,10 +1088,6 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
             for inplace_add in inplace_add_list:
                 m = TestHelperModules.Conv2dAddModule2(inplace_add=inplace_add)
                 node_occurrence = {
-                    # one for input of the conv
-                    # one for input of another conv
-                    # 2 conv will share same input quant/dequant
-                    # one for extra input node of add
                     torch.ops.quantized_decomposed.quantize_per_tensor.default: 3,
                     torch.ops.quantized_decomposed.dequantize_per_tensor.default: 4,
                     # quantize_per_channel for weights are const propagated

--- a/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
+++ b/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
@@ -446,6 +446,7 @@ class X86InductorQuantizer(Quantizer):
                 [conv_partition, bn_partition, binary_partition, unary_partition]
             )
             if len(bn_output_node.users) != 1:
+                # Conv BN pattern should only has 1 user.
                 continue
             (
                 bn_output_node_idx,
@@ -504,6 +505,7 @@ class X86InductorQuantizer(Quantizer):
                 [conv_partition, bn_partition, binary_partition]
             )
             if len(bn_output_node.users) != 1:
+                # Conv BN pattern should only has 1 user.
                 continue
             (
                 bn_output_node_idx,
@@ -637,6 +639,7 @@ class X86InductorQuantizer(Quantizer):
                 [conv_partition, binary_partition, unary_partition]
             )
             if len(conv_node.users) != 1:
+                # Conv Node should only has 1 user node
                 continue
             conv_node_idx, extra_input_node_idx = self._get_input_idx_for_binary_node(
                 conv_node, binary_node
@@ -681,6 +684,7 @@ class X86InductorQuantizer(Quantizer):
                 [conv_partition, binary_partition]
             )
             if len(conv_node.users) != 1:
+                # Conv Node should only has 1 user node
                 continue
             conv_node_idx, extra_input_node_idx = self._get_input_idx_for_binary_node(
                 conv_node, binary_node

--- a/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
+++ b/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
@@ -445,7 +445,8 @@ class X86InductorQuantizer(Quantizer):
             ) = self._get_output_nodes_of_partitions(
                 [conv_partition, bn_partition, binary_partition, unary_partition]
             )
-
+            if len(bn_output_node.users) != 1:
+                continue
             (
                 bn_output_node_idx,
                 extra_input_node_idx,
@@ -502,7 +503,8 @@ class X86InductorQuantizer(Quantizer):
             ) = self._get_output_nodes_of_partitions(
                 [conv_partition, bn_partition, binary_partition]
             )
-
+            if len(bn_output_node.users) != 1:
+                continue
             (
                 bn_output_node_idx,
                 extra_input_node_idx,
@@ -634,6 +636,8 @@ class X86InductorQuantizer(Quantizer):
             conv_node, binary_node, unary_node = self._get_output_nodes_of_partitions(
                 [conv_partition, binary_partition, unary_partition]
             )
+            if len(conv_node.users) != 1:
+                continue
             conv_node_idx, extra_input_node_idx = self._get_input_idx_for_binary_node(
                 conv_node, binary_node
             )
@@ -676,6 +680,8 @@ class X86InductorQuantizer(Quantizer):
             conv_node, binary_node = self._get_output_nodes_of_partitions(
                 [conv_partition, binary_partition]
             )
+            if len(conv_node.users) != 1:
+                continue
             conv_node_idx, extra_input_node_idx = self._get_input_idx_for_binary_node(
                 conv_node, binary_node
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #114580
* #114579
* #114578
* #114547
* #114541
* __->__ #114540

**Summary**
To annotate a conv-binary pattern, should skip the pattern if the conv node has more than one user.

**Test Plan**
```
python -m pytest test_x86inductor_quantizer.py -k test_conv2d_binary2
python -m pytest test_x86inductor_quantizer.py -k test_qat_conv2d_binary2
```
