### PR TITLE
Vectorize CPU ATen mean kernel for BF16 & FP16 dtypes

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1361,9 +1361,6 @@ TORCH_IMPL_FUNC(mean_out)
             result_mut, self, opt_dim, keepdim, ScalarType::Float).div_(dim_prod);
 
         // Cast result_mut back to BF16 or FP16.
-        // A digression - the copy argument to TensorBase::to would be ignored,
-        // so it might as well have been true in both the TensorBase::to calls
-        // here.
         result_mut = result_mut.to(dtype);
         break;
       default:

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1339,9 +1339,9 @@ TORCH_IMPL_FUNC(mean_out)
     switch(dtype) {
       case kHalf:
       case kBFloat16:
-        // For accuracy reasons, BF16 mean should be computed by following
-        // this approach (FP16 would also use a similar approach):
-        //  cast_fp32 -> sum -> div -> cast_bf16
+        // For accuracy reasons, BF16/FP16 mean should be computed by the
+        // following approach:
+        //  cast_fp32 -> sum -> div -> cast_bf16_or_fp16
         //
         // Such an approach is necessary because if we were to choose the same
         // approach for BF16/FP16 as FP32 here, then it would have resulted in

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1364,7 +1364,7 @@ TORCH_IMPL_FUNC(mean_out)
         result_mut = result_mut.to(dtype);
         break;
       default:
-        // not BF16 & not FP16
+        // floating point or complex types
         at::sum_out(result_mut, self, opt_dim, keepdim, dtype).div_(dim_prod);
     }
   } else {

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1348,13 +1348,7 @@ TORCH_IMPL_FUNC(mean_out)
         // the following code-flow -
         // cast_fp32 -> sum -> cast_bf16 -> cast_fp32 -> div -> cast_bf16,
         // which, in turn, does not produce as accurate results.
-        result_mut = result_mut.to(ScalarType::Float,
-                                   result_mut.layout(),
-                                   result_mut.device(),
-                                   /*pin_memory=*/false,
-                                   /*non_blocking=*/false,
-                                   /*copy=*/false,
-                                   /*memory_format=*/at::MemoryFormat::Preserve);
+        result_mut = result_mut.to(ScalarType::Float);
 
         // self (input tensor) will initially be cast to FP32 in sum_out.
         // This results in having to read that FP32 tensor again, but maybe in
@@ -1362,20 +1356,15 @@ TORCH_IMPL_FUNC(mean_out)
         // that intermediate FP32 tensor. That approach would probably require
         // some modifications in binary_kernel_reduce_vec(),
         // TensorIteratorBase::for_each(), and
-        // TensorIteratorBase::serial_for_each().
+        // TensorIteratorBase::serial_for_each(), apart from sum kernel for CPU.
         at::sum_out(
             result_mut, self, opt_dim, keepdim, ScalarType::Float).div_(dim_prod);
 
         // Cast result_mut back to BF16 or FP16.
-        // A digression - the copy argument to at::native::to would be ignored,
-        // so it might as well have been true in both the at::native::to calls here.
-        result_mut = result_mut.to(dtype,
-                                   self.layout(),
-                                   self.device(),
-                                   /*pin_memory=*/false,
-                                   /*non_blocking=*/false,
-                                   /*copy=*/false,
-                                   /*memory_format=*/at::MemoryFormat::Preserve);
+        // A digression - the copy argument to TensorBase::to would be ignored,
+        // so it might as well have been true in both the TensorBase::to calls
+        // here.
+        result_mut = result_mut.to(dtype);
         break;
       default:
         // not BF16 & not FP16

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1356,7 +1356,7 @@ TORCH_IMPL_FUNC(mean_out)
                                    /*copy=*/false,
                                    /*memory_format=*/at::MemoryFormat::Preserve);
 
-        // self (input tensor) will initially be casted to FP32 in sum_out.
+        // self (input tensor) will initially be cast to FP32 in sum_out.
         // This results in having to read that FP32 tensor again, but maybe in
         // the future, we could revise the implementation to not materialize
         // that intermediate FP32 tensor. That approach would probably require

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1339,12 +1339,12 @@ TORCH_IMPL_FUNC(mean_out)
     }
     auto& result_mut = const_cast<Tensor&>(result);
     if  (dtype == kHalf || dtype == kBFloat16) {
-      // For accuracy reasons, BF16 mean should be computed by following
-      // this approach (FP16 would also use a similar approach):
-      //  cast_fp32->sum ->div-> cast_bf16
+      // For accuracy reasons, BF16/FP16 mean should be computed by following
+      // this approach:
+      //  cast_fp32->sum ->div-> cast_to_bf16_or_fp16
       //
       // This approach results in one extra pass over all the
-      // elements of the output tensor, but the overhead is amortized by
+      // elements of the output tensor, but the overhead may be amortized by
       // vectorization. Such an approach is necessary because
       // cast_fp32->sum-> cast_bf16->cast_fp32->div-> cast_bf16
       // does not produce as precise results.
@@ -1354,14 +1354,14 @@ TORCH_IMPL_FUNC(mean_out)
                                  /*pin_memory=*/false,
                                  /*non_blocking=*/false,
                                  /*copy=*/false,
-                                 c10::nullopt);
+                                 /*memory_format=*/c10::nullopt);
       // a copy of self (input tensor) will be implicitly cast to FP32.
-      // This results in an extra pass over the input array but maybe in the
+      // This results in an extra pass over the input tensor but maybe in the
       // future, temporal locality could be leveraged such that for computing
       // sum, the BF16/FP16 input tensor would be read only once.
       // That would probably require some templatization/special-casing in
       // binary_kernel_reduce_vec(), TensorIteratorBase::for_each(), and
-      // TensorIteratorBase::serial_for_each
+      // TensorIteratorBase::serial_for_each()
       at::sum_out(
           result_mut, self, opt_dim, keepdim, ScalarType::Float).div_(dim_prod);
       // cast result_mut back to BF16 or FP16
@@ -1371,7 +1371,7 @@ TORCH_IMPL_FUNC(mean_out)
                                  /*pin_memory=*/false,
                                  /*non_blocking=*/false,
                                  /*copy=*/false,
-                                 c10::nullopt);
+                                 /*memory_format=*/c10::nullopt);
     } else {
       at::sum_out(result_mut, self, opt_dim, keepdim, dtype).div_(dim_prod);
     }

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1339,7 +1339,7 @@ TORCH_IMPL_FUNC(mean_out)
     switch(dtype) {
       case kHalf:
       case kBFloat16:
-        // For accuracy reasons, BF16/FP16 mean should be computed by the
+        // For accuracy reasons, BF16/FP16 mean should be computed via the
         // following approach:
         //  cast_fp32 -> sum -> div -> cast_bf16_or_fp16
         //
@@ -1347,7 +1347,7 @@ TORCH_IMPL_FUNC(mean_out)
         // approach for BF16/FP16 as FP32 here, then it would have resulted in
         // the following code-flow -
         // cast_fp32 -> sum -> cast_bf16 -> cast_fp32 -> div -> cast_bf16,
-        // which does not produce as accurate results.
+        // which, in turn, does not produce as accurate results.
         result_mut = result_mut.to(ScalarType::Float,
                                    result_mut.layout(),
                                    result_mut.device(),

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -437,6 +437,9 @@ static void argmin_kernel_impl(TensorIterator &iter) {
 
 REGISTER_DISPATCH(std_var_stub, &std_var_kernel_impl);
 REGISTER_DISPATCH(prod_stub, &prod_kernel_impl);
+// mean implementation for CPU is in aten/src/ATen/native/ReduceOps.cpp
+// but mean_stub must be defined for CPU as well
+REGISTER_DISPATCH(mean_stub, nullptr);
 REGISTER_DISPATCH(norm_stub, &norm_kernel_tensor_iterator_impl);
 REGISTER_DISPATCH(and_stub, &and_kernel_impl);
 REGISTER_DISPATCH(or_stub, &or_kernel_impl);
@@ -448,9 +451,5 @@ REGISTER_DISPATCH(argmin_stub, &argmin_kernel_impl);
 REGISTER_DISPATCH(cumprod_stub, &cumprod_cpu_kernel);
 REGISTER_DISPATCH(cumsum_stub, &cumsum_cpu_kernel);
 REGISTER_DISPATCH(logcumsumexp_stub, &logcumsumexp_cpu_kernel);
-
-// mean implementation for CPU is in aten/src/ATen/native/ReduceOps.cpp
-// but mean_stub must be defined for CPU as well
-REGISTER_NO_CPU_DISPATCH(mean_stub);
 
 }  // namespace at::native

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -437,8 +437,6 @@ static void argmin_kernel_impl(TensorIterator &iter) {
 
 REGISTER_DISPATCH(std_var_stub, &std_var_kernel_impl);
 REGISTER_DISPATCH(prod_stub, &prod_kernel_impl);
-// mean implementation for CPU is in aten/src/ATen/native/ReduceOps.cpp
-REGISTER_DISPATCH(mean_stub, nullptr);
 REGISTER_DISPATCH(norm_stub, &norm_kernel_tensor_iterator_impl);
 REGISTER_DISPATCH(and_stub, &and_kernel_impl);
 REGISTER_DISPATCH(or_stub, &or_kernel_impl);
@@ -450,5 +448,9 @@ REGISTER_DISPATCH(argmin_stub, &argmin_kernel_impl);
 REGISTER_DISPATCH(cumprod_stub, &cumprod_cpu_kernel);
 REGISTER_DISPATCH(cumsum_stub, &cumsum_cpu_kernel);
 REGISTER_DISPATCH(logcumsumexp_stub, &logcumsumexp_cpu_kernel);
+
+// mean implementation for CPU is in aten/src/ATen/native/ReduceOps.cpp
+// but mean_stub must be defined for CPU as well
+REGISTER_NO_CPU_DISPATCH(mean_stub);
 
 }  // namespace at::native

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -136,19 +136,6 @@ static void logcumsumexp_cpu_kernel(Tensor& result, const Tensor& self, int64_t 
   });
 }
 
-static void mean_kernel_impl(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBFloat16, iter.dtype(), "mean_cpu", [&] {
-    using acc_t = at::opmath_type<scalar_t>;
-    using factor_t = typename c10::scalar_value_type<acc_t>::type;
-    factor_t factor = static_cast<factor_t>(iter.num_output_elements()) / iter.numel();
-    binary_kernel_reduce(
-      iter,
-      MeanOps<scalar_t, acc_t, factor_t, scalar_t> {factor},
-      acc_t(0)
-    );
-  });
-}
-
 static void std_var_kernel_impl(TensorIterator& iter, double correction, bool take_sqrt) {
   AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, iter.dtype(), "std_cpu", [&] {
     binary_kernel_reduce(
@@ -450,7 +437,6 @@ static void argmin_kernel_impl(TensorIterator &iter) {
 
 REGISTER_DISPATCH(std_var_stub, &std_var_kernel_impl);
 REGISTER_DISPATCH(prod_stub, &prod_kernel_impl);
-REGISTER_DISPATCH(mean_stub, &mean_kernel_impl);
 REGISTER_DISPATCH(norm_stub, &norm_kernel_tensor_iterator_impl);
 REGISTER_DISPATCH(and_stub, &and_kernel_impl);
 REGISTER_DISPATCH(or_stub, &or_kernel_impl);

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -136,6 +136,19 @@ static void logcumsumexp_cpu_kernel(Tensor& result, const Tensor& self, int64_t 
   });
 }
 
+static void mean_kernel_impl(TensorIterator& iter) {
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBFloat16, iter.dtype(), "mean_cpu", [&] {
+    using acc_t = at::opmath_type<scalar_t>;
+    using factor_t = typename c10::scalar_value_type<acc_t>::type;
+    factor_t factor = static_cast<factor_t>(iter.num_output_elements()) / iter.numel();
+    binary_kernel_reduce(
+      iter,
+      MeanOps<scalar_t, acc_t, factor_t, scalar_t> {factor},
+      acc_t(0)
+    );
+  });
+}
+
 static void std_var_kernel_impl(TensorIterator& iter, double correction, bool take_sqrt) {
   AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, iter.dtype(), "std_cpu", [&] {
     binary_kernel_reduce(
@@ -437,6 +450,7 @@ static void argmin_kernel_impl(TensorIterator &iter) {
 
 REGISTER_DISPATCH(std_var_stub, &std_var_kernel_impl);
 REGISTER_DISPATCH(prod_stub, &prod_kernel_impl);
+REGISTER_DISPATCH(mean_stub, &mean_kernel_impl);
 REGISTER_DISPATCH(norm_stub, &norm_kernel_tensor_iterator_impl);
 REGISTER_DISPATCH(and_stub, &and_kernel_impl);
 REGISTER_DISPATCH(or_stub, &or_kernel_impl);

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -136,19 +136,6 @@ static void logcumsumexp_cpu_kernel(Tensor& result, const Tensor& self, int64_t 
   });
 }
 
-static void mean_kernel_impl(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBFloat16, iter.dtype(), "mean_cpu", [&] {
-    using acc_t = at::opmath_type<scalar_t>;
-    using factor_t = typename c10::scalar_value_type<acc_t>::type;
-    factor_t factor = static_cast<factor_t>(iter.num_output_elements()) / iter.numel();
-    binary_kernel_reduce(
-      iter,
-      MeanOps<scalar_t, acc_t, factor_t, scalar_t> {factor},
-      acc_t(0)
-    );
-  });
-}
-
 static void std_var_kernel_impl(TensorIterator& iter, double correction, bool take_sqrt) {
   AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, iter.dtype(), "std_cpu", [&] {
     binary_kernel_reduce(
@@ -450,7 +437,8 @@ static void argmin_kernel_impl(TensorIterator &iter) {
 
 REGISTER_DISPATCH(std_var_stub, &std_var_kernel_impl);
 REGISTER_DISPATCH(prod_stub, &prod_kernel_impl);
-REGISTER_DISPATCH(mean_stub, &mean_kernel_impl);
+// mean implementation for CPU is in aten/src/ATen/native/ReduceOps.cpp
+REGISTER_DISPATCH(mean_stub, nullptr);
 REGISTER_DISPATCH(norm_stub, &norm_kernel_tensor_iterator_impl);
 REGISTER_DISPATCH(and_stub, &and_kernel_impl);
 REGISTER_DISPATCH(or_stub, &or_kernel_impl);


### PR DESCRIPTION
## Summary
Since #97351, CPU ATen kernel for `mean` for BF16 & FP16 dtypes has been unvectorized (it's not even implicitly vectorized).

This PR vectorizes `mean` for BF16 & FP16 on CPU in a `cast_fp32 -> sum -> div -> cast_bf16_or_fp16` fashion.

The perf benefit would be especially pronounced on machines with `AVX512_BF16` and/or `AVX512_FP16` ISA support.

## Benchmarking data for BF16 (collected before & after the change in this PR)

**Machine:** Intel&reg; Xeon&reg; (4th generation series, formerly codenamed Sapphire Rapids) Platinum 8468H
One socket (48 physical cores) - used `numactl --membind=0 --cpunodebind=0`
libtcmalloc & Intel OpenMP were preloaded

Environment variable used -
`KMP_AFFINITY=granularity=fine,compact,1,0 KMP_BLOCKTIME=1 KMP_SETTINGS=1 OMP_NUM_THREADS=48 MKL_NUM_THREADS=48`

**Workload:** E2E performance on BS 32 resnet50 (using BF16 via AMP) inference using oneDNN Graph JIT fuser (`mean` kernel is dispatched to eager mode ATen kernel, and is the bottleneck right now)

| **BEFORE:** Latency with unvectorized mean (lower is better)| **AFTER:** Latency with vectorized mean (lower is better)| Speedup due to vectorizing mean|
|----------------------------|-------------------------|------------|
|                19.1 ms           |                10.8  ms       | latency reduced by ~43.45%      |

**Benchmarking script for BF16 -**

 ```
import time
import torch
import torchvision

# enable oneDNN Graph JIT fuser
torch.jit.enable_onednn_fusion(True)
# AMP for JIT mode is enabled by default, and is divergent with its eager mode counterpart
torch._C._jit_set_autocast_mode(False)

# sample input should be of the same shape as expected inputs
example_input = torch.rand(32, 3, 224, 224)
# Using resnet50 from torchvision in this example for illustrative purposes,
# but the line below can indeed be modified to use custom models as well.
model = getattr(torchvision.models, "resnet50")().eval()

with torch.no_grad(), torch.cpu.amp.autocast(cache_enabled=False, dtype=torch.bfloat16):
    # Conv-BatchNorm folding for CNN-based Vision Models should be done with ``torch.fx.experimental.optimization.fuse`` when AMP is used
    import torch.fx.experimental.optimization as optimization
    # Please note that optimization.fuse need not be called when AMP is not used
    model = optimization.fuse(model)
    model = torch.jit.trace(model, (example_input))
    model = torch.jit.freeze(model)
    # a couple of warm-up runs
    model(example_input)
    model(example_input)
    # speedup would be observed in subsequent runs
    start = time.time()
    model(example_input)
    end = time.time()
    inference_time = (end - start) * 1000
    print("Inference time is ", inference_time)
```



cc @jgong5 @mingfeima @XiaobingSuper @ashokei @jingxu10