### PR TITLE
Reland "[export] Support user input mutation. [1/2]" (#114496)

### DIFF
--- a/test/export/test_db.py
+++ b/test/export/test_db.py
@@ -1,14 +1,15 @@
 # Owner(s): ["module: dynamo"]
 
+import copy
 import unittest
 
 import torch._dynamo as torchdynamo
-from torch.export import export
 from torch._export.db.case import ExportCase, normalize_inputs, SupportLevel
 from torch._export.db.examples import (
     filter_examples_by_support_level,
     get_rewrite_cases,
 )
+from torch.export import export
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -28,18 +29,19 @@ class ExampleTests(TestCase):
     def test_exportdb_supported(self, name: str, case: ExportCase) -> None:
         model = case.model
 
-        inputs = normalize_inputs(case.example_inputs)
+        inputs_export = normalize_inputs(case.example_inputs)
+        inputs_model = copy.deepcopy(inputs_export)
         exported_program = export(
             model,
-            inputs.args,
-            inputs.kwargs,
+            inputs_export.args,
+            inputs_export.kwargs,
             dynamic_shapes=case.dynamic_shapes,
         )
         exported_program.graph_module.print_readable()
 
         self.assertEqual(
-            exported_program(*inputs.args, **inputs.kwargs),
-            model(*inputs.args, **inputs.kwargs),
+            exported_program(*inputs_export.args, **inputs_export.kwargs),
+            model(*inputs_model.args, **inputs_model.kwargs),
         )
 
         if case.extra_inputs is not None:

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -44,6 +44,7 @@ def get_filtered_export_db_tests():
         "dictionary",  # Graph output must be a tuple()
         "fn_with_kwargs",  # export doesn't support kwargs yet
         "scalar_output",  # Tracing through 'f' must produce a single graph
+        "user_input_mutation",  # TODO(zhxchen17) Support serializing user inputs mutation.
     }
 
     return [

--- a/test/export/test_unflatten.py
+++ b/test/export/test_unflatten.py
@@ -277,11 +277,11 @@ class TestUnflatten(TestCase):
                 return a
 
         export_module = torch.export.export(Mod(), (torch.randn((2, 3)),))
-        with self.assertRaisesRegex(RuntimeError, "Input arg4_1.shape"):
+        with self.assertRaisesRegex(RuntimeError, ".shape\[1\] is specialized at 3"):
             export_module(torch.randn(6, 6))
 
         unflattened = export_module.module(flat=False)
-        with self.assertRaisesRegex(RuntimeError, "Input arg4_1.shape"):
+        with self.assertRaisesRegex(RuntimeError, ".shape\[1\] is specialized at 3"):
             unflattened(torch.randn(6, 6))
 
 

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -30,28 +30,28 @@ from torch._dispatch.python import enable_python_dispatcher
 from torch._dynamo.exc import UserError, UserErrorType
 from torch._dynamo.source import ConstantSource
 from torch._export.passes.collect_tracepoints_pass import CollectTracepointsPass
-from torch._functorch.aot_autograd import aot_export_module
+from torch._functorch.aot_autograd import aot_export_module, GraphSignature
 from torch._functorch.eager_transforms import functionalize
 from torch._guards import detect_fake_mode
 from torch._ops import OpOverload
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch.export import _create_constraint, _Dim, Constraint
-from torch.export.graph_signature import (
-    ExportGraphSignature,
-    _sig_to_specs,
-    ArgumentSpec,
-    ConstantArgument,
-    InputKind,
-    OutputKind,
-    OutputSpec,
-    SymIntArgument,
-    TensorArgument,
-    InputSpec
-)
 from torch.export.exported_program import (
     ExportedProgram,
     ModuleCallEntry,
     ModuleCallSignature,
+)
+from torch.export.graph_signature import (
+    _sig_to_specs,
+    ArgumentSpec,
+    ConstantArgument,
+    ExportGraphSignature,
+    InputKind,
+    InputSpec,
+    OutputKind,
+    OutputSpec,
+    SymIntArgument,
+    TensorArgument,
 )
 from torch.fx import traceback as fx_traceback
 from torch.fx._compatibility import compatibility
@@ -559,6 +559,88 @@ def export(
         preserve_module_call_signature=preserve_module_call_signature,
     )
 
+
+def _prepare_module(
+    gm_torch_level: torch.fx.GraphModule,
+    aot_export_args
+) -> List[str]:
+    flat_args = pytree.tree_leaves(aot_export_args)
+    user_input_names = []
+    with gm_torch_level.graph.inserting_before():
+        for i, (arg, node) in enumerate(zip(flat_args, gm_torch_level.graph.nodes)):
+            assert node.op == "placeholder"
+            user_input_names.append(node.name)
+            if isinstance(arg, torch.Tensor):
+                assert not hasattr(gm_torch_level, node.name)
+                gm_torch_level.register_buffer(node.name, arg)
+                get_attr = gm_torch_level.graph.get_attr(node.name)
+                node.replace_all_uses_with(get_attr)
+                get_attr.meta = copy.copy(node.meta)
+
+    for node in list(gm_torch_level.graph.nodes):
+        if node.op == "placeholder":
+            assert len(node.users) == 0
+            gm_torch_level.graph.erase_node(node)
+    gm_torch_level.recompile()
+    return user_input_names
+
+
+def _unwrap_user_inputs(
+    gm: torch.fx.GraphModule,
+    graph_signature: GraphSignature,
+    user_input_names: List[str]
+) -> Dict[str, str]:
+    assert len(graph_signature.user_inputs) == 0
+    assert graph_signature.backward_signature is None
+    names = set(user_input_names)
+
+    placeholders = [node for node in gm.graph.nodes if node.op == "placeholder"]
+    # user inputs are always added in the end
+    start = len(graph_signature.parameters)
+    end = start + len(graph_signature.buffers)
+    buffer_nodes = placeholders[start:end]
+    last_placeholder_node = placeholders[-1] if len(placeholders) > 0 else None
+    old_nodes: Dict[str, torch.fx.Node] = {}
+    for node in buffer_nodes:
+        buffer_name = graph_signature.inputs_to_buffers[node.name]
+        if buffer_name not in names:
+            continue
+        old_nodes[buffer_name] = node
+    replaces = {}
+    new_node_names: Dict[str, str] = {}
+    with gm.graph.inserting_after(last_placeholder_node):
+        for name in reversed(user_input_names):
+            new_node = gm.graph.placeholder(name)
+            new_node.target = new_node.name
+            new_node_names[name] = new_node.name
+            if name in old_nodes:
+                old_node = old_nodes[name]
+                new_node.meta = copy.copy(old_node.meta)
+                old_node.replace_all_uses_with(new_node)
+                replaces[old_node.name] = new_node.name
+
+    for old_node in old_nodes.values():
+        gm.graph.erase_node(old_node)
+
+    gm.recompile()
+
+    graph_signature.buffers = [b for b in graph_signature.buffers if b not in names]
+    graph_signature.inputs_to_buffers = {
+        i: b for i, b in graph_signature.inputs_to_buffers.items() if b not in names
+    }
+    user_inputs_to_mutate = {
+        o: b for o, b in graph_signature.buffers_to_mutate.items() if b in names
+    }
+    graph_signature.buffers_to_mutate = {
+        o: b for o, b in graph_signature.buffers_to_mutate.items() if b not in names
+    }
+    graph_signature.user_inputs = list(reversed(new_node_names.values()))  # type: ignore[arg-type]
+    graph_signature.user_outputs = [
+        replaces[o] if o in replaces else o for o in graph_signature.user_outputs
+    ]
+    return user_inputs_to_mutate  # type: ignore[return-value]
+
+
 def _disable_prexisiting_fake_mode(fn):
 
     @functools.wraps(fn)
@@ -703,6 +785,10 @@ def _export(
     if isinstance(f, torch.nn.Module):
         _normalize_nn_module_stack(gm_torch_level, type(f))
 
+    aot_export_args = (*fake_args, *_reorder_kwargs_by_names(orig_args, fake_args, fake_kwargs).values())
+
+    user_input_names = _prepare_module(gm_torch_level, aot_export_args)
+
     # Note: aot_export_module doesn't accept kwargs, we'd like to reorder the kwargs as an OrderedDict
     # to follow the order in orig_args and correctly call gm_torch_level
 
@@ -712,9 +798,10 @@ def _export(
     with torch.nn.utils.stateless._reparametrize_module(gm_torch_level, fake_params_buffers):
         gm, graph_signature = aot_export_module(
             gm_torch_level,
-            (*fake_args, *_reorder_kwargs_by_names(orig_args, fake_args, fake_kwargs).values()),
+            (),
             trace_joint=False
         )
+    user_inputs_to_mutate = _unwrap_user_inputs(gm, graph_signature, user_input_names)
 
     def to_str_list(sig_component: List[Any]):
         return [str(v) for v in sig_component]
@@ -771,6 +858,7 @@ def _export(
     is_joint = graph_signature.backward_signature is not None
 
     def make_argument_spec(node) -> ArgumentSpec:
+        assert "val" in node.meta, f"{node} has no 'val' metadata field"
         val = node.meta["val"]
         if isinstance(val, FakeTensor):
             return TensorArgument(name=node.name)
@@ -784,6 +872,7 @@ def _export(
         inputs_to_buffers=graph_signature.inputs_to_buffers,  # type: ignore[arg-type]
         user_outputs=set(graph_signature.user_outputs),  # type: ignore[arg-type]
         buffer_mutations=graph_signature.buffers_to_mutate,  # type: ignore[arg-type]
+        user_input_mutations=user_inputs_to_mutate,  # type: ignore[arg-type]
         grad_params=graph_signature.backward_signature.gradients_to_parameters if is_joint else {},  # type: ignore[arg-type, union-attr]
         grad_user_inputs=graph_signature.backward_signature.gradients_to_user_inputs if is_joint else {},  # type: ignore[arg-type, union-attr]
         loss_output=graph_signature.backward_signature.loss_output if is_joint else None,  # type: ignore[arg-type, union-attr]

--- a/torch/_export/db/examples/user_input_mutation.py
+++ b/torch/_export/db/examples/user_input_mutation.py
@@ -6,11 +6,11 @@ from torch._export.db.case import export_case, SupportLevel
 @export_case(
     example_inputs=(torch.ones(3, 2),),
     tags={"torch.mutation"},
-    support_level=SupportLevel.NOT_SUPPORTED_YET,
+    support_level=SupportLevel.SUPPORTED,
 )
 class UserInputMutation(torch.nn.Module):
     """
-    Can't directly mutate user input in forward
+    Directly mutate user input in forward
     """
 
     def forward(self, x):

--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -230,12 +230,6 @@ def _verify_exported_program_signature(exported_program) -> None:
     # Check ExportedProgram signature matches
     gs = exported_program.graph_signature
 
-    bs_grad_to_param = {}
-    bs_grad_to_user_inputs = {}
-    if gs.backward_signature is not None:
-        bs_grad_to_param = gs.backward_signature.gradients_to_parameters
-        bs_grad_to_user_inputs = gs.backward_signature.gradients_to_user_inputs
-
     # Check every node in the signature exists in the graph
     input_node_names = [node.name for node in exported_program.graph.nodes if node.op == "placeholder"]
 
@@ -324,19 +318,28 @@ def _verify_exported_program_signature(exported_program) -> None:
             f"Number of user outputs: {len(gs.user_outputs)}. \n"
         )
 
-    buffer_mutate_nodes = output_nodes[:len(gs.buffers_to_mutate)]
-    user_output_nodes = output_nodes[len(gs.buffers_to_mutate):len(gs.user_outputs) + len(gs.buffers_to_mutate)]
+    end = len(gs.buffers_to_mutate) + len(gs.user_inputs_to_mutate)
+    mutate_nodes: List[str] = output_nodes[:end]
+    user_output_nodes = output_nodes[end:end + len(gs.user_outputs)]
 
-    for buffer_node in buffer_mutate_nodes:
-        if (
-            buffer_node not in gs.buffers_to_mutate or
-            gs.buffers_to_mutate[buffer_node] not in gs.buffers
-        ):
+    for mutation_node in mutate_nodes:
+        if mutation_node in gs.buffers_to_mutate:
+            if gs.buffers_to_mutate[mutation_node] not in gs.buffers:
+                raise SpecViolationError(
+                    f"Buffer output {mutation_node} does not point to a buffer that exists. \n"
+                    f"Dict of buffers that are mutated, in order: {gs.buffers_to_mutate} \n"
+                    f"Buffer nodes available: {gs.buffers} \n"
+                )
+        elif mutation_node in gs.user_inputs_to_mutate:
+            if gs.user_inputs_to_mutate[mutation_node] not in gs.user_inputs:
+                raise SpecViolationError(
+                    f"User input output {mutation_node} does not point to a user input that exists. \n"
+                    f"Dict of user inputs that are mutated, in order: {gs.user_inputs_to_mutate} \n"
+                    f"User input nodes available: {gs.user_inputs} \n")
+        else:
             raise SpecViolationError(
-                f"Buffer output {buffer_node} is not in buffer mutation dictionary "
-                "or, it does not point to a buffer that exists. \n"
-                f"Dict of buffers that are mutated, in order: {gs.buffers_to_mutate} \n"
-                f"Buffer nodes available: {gs.buffers} \n"
+                f"Mutation node {mutation_node} is neither a buffer nor a user input. "
+                f"Buffers to mutate: {gs.buffers_to_mutate}, User inputs to mutate: {gs.user_inputs_to_mutate}"
             )
 
     for user_output_node, user_output_name in zip(user_output_nodes, gs.user_outputs):

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -277,9 +277,10 @@ class ExportedProgram:
         )
 
         if self.call_spec.out_spec is not None:
-            mutation = self.graph_signature.buffers_to_mutate
-            num_mutated = len(mutation)
-            mutated_buffers = res[:num_mutated]
+            buffer_mutation = self.graph_signature.buffers_to_mutate
+            user_input_mutation = self.graph_signature.user_inputs_to_mutate
+            num_mutated = len(buffer_mutation) + len(user_input_mutation)
+            mutated_values = res[:num_mutated]
 
             # Exclude dependency token from final result.
             assertion_dep_token = self.graph_signature.assertion_dep_token
@@ -299,10 +300,27 @@ class ExportedProgram:
                     f"{received_spec}"
                 )
             finally:
-                ix = 0
-                for buffer in self.graph_signature.buffers_to_mutate.values():
-                    self.state_dict[buffer] = mutated_buffers[ix]
-                    ix += 1
+                user_inputs = [
+                    spec
+                    for spec in self.graph_signature.input_specs
+                    if spec.kind == InputKind.USER_INPUT
+                ]
+                for i, value in enumerate(mutated_values):
+                    output_spec = self.graph_signature.output_specs[i]
+                    if output_spec.kind == OutputKind.BUFFER_MUTATION:
+                        assert output_spec.target is not None
+                        self.state_dict[output_spec.target] = value
+                    elif output_spec.kind == OutputKind.USER_INPUT_MUTATION:
+                        assert output_spec.target is not None
+                        index = next(
+                            i
+                            for i, spec in enumerate(user_inputs)
+                            if spec.arg.name == output_spec.target
+                        )
+                        args[index].copy_(value)
+                    else:
+                        raise AssertionError(f"Unexpected kind: {output_spec.kind}")
+
         return res
 
     def __str__(self) -> str:
@@ -365,7 +383,6 @@ class ExportedProgram:
         decomp_table = decomp_table or core_aten_decompositions()
 
         old_placeholders = _get_placeholders(self.graph_module)
-        old_outputs = list(self.graph.nodes)[-1].args[0]
         fake_args = [node.meta["val"] for node in old_placeholders]
 
         buffers_to_remove = [name for name, _ in self.graph_module.named_buffers()]

--- a/torch/export/graph_signature.py
+++ b/torch/export/graph_signature.py
@@ -57,6 +57,7 @@ class OutputKind(Enum):
     BUFFER_MUTATION = auto()
     GRADIENT_TO_PARAMETER = auto()
     GRADIENT_TO_USER_INPUT = auto()
+    USER_INPUT_MUTATION = auto()
 
 
 @dataclasses.dataclass
@@ -76,6 +77,7 @@ def _sig_to_specs(
     inputs_to_buffers: Mapping[str, str],
     user_outputs: Set[str],
     buffer_mutations: Mapping[str, str],
+    user_input_mutations: Mapping[str, str],
     grad_params: Mapping[str, str],
     grad_user_inputs: Mapping[str, str],
     loss_output: Optional[str],
@@ -101,37 +103,49 @@ def _sig_to_specs(
         else:
             raise AssertionError(f"Unknown tensor input kind: {name}")
 
-    def to_output_spec(o: ArgumentSpec) -> OutputSpec:
+    def to_output_spec(idx: int, o: ArgumentSpec) -> OutputSpec:
         if not isinstance(o, TensorArgument):
             return OutputSpec(kind=OutputKind.USER_OUTPUT, arg=o, target=None)
         name = o.name
-        if name in user_outputs:
-            return OutputSpec(kind=OutputKind.USER_OUTPUT, arg=o, target=None)
-        elif name in buffer_mutations:
-            return OutputSpec(
-                kind=OutputKind.BUFFER_MUTATION,
-                arg=o,
-                target=buffer_mutations[name],
-            )
-        elif name in grad_params:
-            return OutputSpec(
-                kind=OutputKind.GRADIENT_TO_PARAMETER,
-                arg=o,
-                target=grad_params[name],
-            )
-        elif name in grad_user_inputs:
-            return OutputSpec(
-                kind=OutputKind.GRADIENT_TO_USER_INPUT,
-                arg=o,
-                target=grad_user_inputs[name],
-            )
-        elif name == loss_output:
-            return OutputSpec(kind=OutputKind.LOSS_OUTPUT, arg=o, target=None)
+        if idx < len(buffer_mutations) + len(user_input_mutations):
+            if name in buffer_mutations:
+                return OutputSpec(
+                    kind=OutputKind.BUFFER_MUTATION,
+                    arg=o,
+                    target=buffer_mutations[name],
+                )
+            elif name in user_input_mutations:
+                return OutputSpec(
+                    kind=OutputKind.USER_INPUT_MUTATION,
+                    arg=o,
+                    target=user_input_mutations[name],
+                )
+            else:
+                raise AssertionError(f"Unknown tensor mutation kind: {name}")
         else:
-            raise AssertionError(f"Unknown tensor output kind: {name}")
+            if name in user_outputs:
+                return OutputSpec(kind=OutputKind.USER_OUTPUT, arg=o, target=None)
+
+            elif name in grad_params:
+                return OutputSpec(
+                    kind=OutputKind.GRADIENT_TO_PARAMETER,
+                    arg=o,
+                    target=grad_params[name],
+                )
+            elif name in grad_user_inputs:
+                return OutputSpec(
+                    kind=OutputKind.GRADIENT_TO_USER_INPUT,
+                    arg=o,
+                    target=grad_user_inputs[name],
+                )
+            elif name == loss_output:
+                return OutputSpec(kind=OutputKind.LOSS_OUTPUT, arg=o, target=None)
+
+            else:
+                raise AssertionError(f"Unknown tensor output kind: {name}")
 
     input_specs = [to_input_spec(i) for i in inputs]
-    output_specs = [to_output_spec(o) for o in outputs]
+    output_specs = [to_output_spec(idx, o) for idx, o in enumerate(outputs)]
     return input_specs, output_specs
 
 
@@ -300,6 +314,16 @@ class ExportGraphSignature:
             s.arg.name: s.target
             for s in self.output_specs
             if s.kind == OutputKind.BUFFER_MUTATION
+            and isinstance(s.arg, TensorArgument)
+            and isinstance(s.target, str)
+        }
+
+    @property
+    def user_inputs_to_mutate(self) -> Mapping[str, str]:
+        return {
+            s.arg.name: s.target
+            for s in self.output_specs
+            if s.kind == OutputKind.USER_INPUT_MUTATION
             and isinstance(s.arg, TensorArgument)
             and isinstance(s.target, str)
         }

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -776,8 +776,8 @@ class ONNXProgram:
                     InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='arg3_1'), target='fc2.weight'),
                     InputSpec(kind=<InputKind.BUFFER: 3>, arg=TensorArgument(name='arg4_1'), target='my_buffer2'),
                     InputSpec(kind=<InputKind.BUFFER: 3>, arg=TensorArgument(name='arg5_1'), target='my_buffer1'),
-                    InputSpec(kind=<InputKind.USER_INPUT: 1>, arg=TensorArgument(name='arg6_1'), target=None),
-                    InputSpec(kind=<InputKind.USER_INPUT: 1>, arg=TensorArgument(name='arg7_1'), target=None)
+                    InputSpec(kind=<InputKind.USER_INPUT: 1>, arg=TensorArgument(name='l_x_'), target=None),
+                    InputSpec(kind=<InputKind.USER_INPUT: 1>, arg=TensorArgument(name='arg1'), target=None)
                 ],
                 output_specs=[
                     OutputSpec(kind=<OutputKind.BUFFER_MUTATION: 3>, arg=TensorArgument(name='add'), target='my_buffer2'),


### PR DESCRIPTION
Summary:

Serialization not implemented yet. Will do in the next diff.

Resolving Github issues:
https://github.com/pytorch/pytorch/issues/112429
https://github.com/pytorch/pytorch/issues/114142

Test Plan:
onnx doc test
```
python -m xdoctest /opt/conda/envs/py_3.8/lib/python3.8/site-packages/torch/onnx/_internal/exporter.py ONNXProgram.model_signature:0
```

Differential Revision: D51588558




cc @avikchaudhuri @gmagogsfm @tugsbayasgalan @angelayi @suo @ydwu4