### PR TITLE
Adopt binary workflows to extract release information when building binaries

### DIFF
--- a/.github/actions/get-build-branch/action.yml
+++ b/.github/actions/get-build-branch/action.yml
@@ -1,0 +1,21 @@
+name: Get Build Branch
+
+description: Get build branch to use
+
+runs:
+  using: composite
+  steps:
+    - name: Get branch to use for building
+      id: check_step
+      shell: bash -e -l {0}
+      run: |
+        if [[ "${GITHUB_EVENT_NAME}" == 'push' && "${GITHUB_REF_NAME}" == *-rc[0-9]* ]]; then
+          raw=$(git branch -r --contains "${GITHUB_REF_NAME}")
+          REPO_BRANCH=${raw##*/}
+          echo "REPO_BRANCH=release/${REPO_BRANCH}" >> $GITHUB_ENV
+          echo "Branch is release/$REPO_BRANCH."
+        elif [[ "${GITHUB_EVENT_NAME}" == 'push' && "${GITHUB_REF_NAME}" == *ciflow* ]]; then
+          echo "REPO_BRANCH=$(python3 ${GITHUB_ACTION_PATH}/../../scripts/get_ciflow_base_ref.py)" >> "${GITHUB_ENV}"
+        else
+          echo "REPO_BRANCH=main" >> $GITHUB_ENV
+        fi

--- a/.github/actions/get-build-branch/action.yml
+++ b/.github/actions/get-build-branch/action.yml
@@ -14,8 +14,9 @@ runs:
           REPO_BRANCH=${raw##*/}
           echo "REPO_BRANCH=release/${REPO_BRANCH}" >> $GITHUB_ENV
           echo "Branch is release/$REPO_BRANCH."
-        elif [[ "${GITHUB_EVENT_NAME}" == 'push' && "${GITHUB_REF_NAME}" == *ciflow* ]]; then
-          echo "REPO_BRANCH=$(python3 ${GITHUB_ACTION_PATH}/../../scripts/get_ciflow_base_ref.py)" >> "${GITHUB_ENV}"
+        elif [[ "${GITHUB_EVENT_NAME}" == 'push' && "${GITHUB_REF_NAME}" == *ciflow* ]] ||
+             [[ "${GITHUB_EVENT_NAME}" == 'pull_request' && "${GITHUB_REF_NAME}" == *merge* ]]; then
+          echo "REPO_BRANCH=$(python3 ${GITHUB_ACTION_PATH}/../../scripts/get_base_branch.py)" >> "${GITHUB_ENV}"
         else
           echo "REPO_BRANCH=main" >> $GITHUB_ENV
         fi

--- a/.github/scripts/get_base_branch.py
+++ b/.github/scripts/get_base_branch.py
@@ -58,9 +58,17 @@ def find_base_branch() -> Any:
     pull = ""
     # GITHUB_REF_NAME for ciflow is defined as follows: ciflow/binaries/<pull request>
     # GITHUB_REF_NAME for pull request defined as follows: <pull request>/merge
-    if GITHUB_EVENT_NAME == "push" and GITHUB_REF_NAME != "" and "ciflow" in GITHUB_REF_NAME:
+    if (
+        GITHUB_EVENT_NAME == "push"
+        and GITHUB_REF_NAME != ""
+        and "ciflow" in GITHUB_REF_NAME
+    ):
         pull = GITHUB_REF_NAME.rsplit("/", 1)[-1]
-    elif GITHUB_EVENT_NAME == "pull_request"  and GITHUB_REF_NAME != "" and "merge" in GITHUB_REF_NAME:
+    elif (
+        GITHUB_EVENT_NAME == "pull_request"
+        and GITHUB_REF_NAME != ""
+        and "merge" in GITHUB_REF_NAME
+    ):
         pull = GITHUB_REF_NAME.rsplit("/", 1)[0]
     else:
         return "main"

--- a/.github/scripts/get_base_branch.py
+++ b/.github/scripts/get_base_branch.py
@@ -54,9 +54,14 @@ def fetch_base_ref(url: str, headers: Dict[str, str]) -> Any:
 def find_base_branch() -> Any:
     # From https://docs.github.com/en/actions/learn-github-actions/environment-variables
     GITHUB_REF_NAME = os.environ.get("GITHUB_REF_NAME", "")
+    GITHUB_EVENT_NAME = os.environ.get("GITHUB_EVENT_NAME", "")
     pull = ""
-    if GITHUB_REF_NAME != "" and "ciflow" in GITHUB_REF_NAME:
+    # GITHUB_REF_NAME for ciflow is defined as follows: ciflow/binaries/<pull request>
+    # GITHUB_REF_NAME for pull request defined as follows: <pull request>/merge
+    if GITHUB_EVENT_NAME == "push" and GITHUB_REF_NAME != "" and "ciflow" in GITHUB_REF_NAME:
         pull = GITHUB_REF_NAME.rsplit("/", 1)[-1]
+    elif GITHUB_EVENT_NAME == "pull_request"  and GITHUB_REF_NAME != "" and "merge" in GITHUB_REF_NAME:
+        pull = GITHUB_REF_NAME.rsplit("/", 1)[0]
     else:
         return "main"
 

--- a/.github/scripts/get_ciflow_base_ref.py
+++ b/.github/scripts/get_ciflow_base_ref.py
@@ -8,7 +8,7 @@ import time
 import urllib
 import urllib.parse
 
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
 from urllib.request import Request, urlopen
 
 def parse_json_and_links(conn: Any) -> Tuple[Any, Dict[str, Dict[str, str]]]:
@@ -64,7 +64,7 @@ def fetch_url(
         )
         raise RuntimeError(exception_message) from err
 
-def fetch_base_ref(url: str, headers: Dict[str, str]) -> str:
+def fetch_base_ref(url: str, headers: Dict[str, str]) -> Any:
     response, links = fetch_url(url, headers=headers, reader=parse_json_and_links)
     return response["base"]["ref"]
 

--- a/.github/scripts/get_ciflow_base_ref.py
+++ b/.github/scripts/get_ciflow_base_ref.py
@@ -1,0 +1,104 @@
+# Helper to get the base reference of a PR if its ciflow workflow was triggered
+
+import json
+import os
+import re
+import sys
+import time
+import urllib
+import urllib.parse
+
+from typing import Any, Callable, Dict, List, Optional, Tuple
+from urllib.request import Request, urlopen
+
+def parse_json_and_links(conn: Any) -> Tuple[Any, Dict[str, Dict[str, str]]]:
+    links = {}
+    # Extract links which GH uses for pagination
+    # see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link
+    if "Link" in conn.headers:
+        for elem in re.split(", *<", conn.headers["Link"]):
+            try:
+                url, params_ = elem.split(";", 1)
+            except ValueError:
+                continue
+            url = urllib.parse.unquote(url.strip("<> "))
+            qparams = urllib.parse.parse_qs(params_.strip(), separator=";")
+            params = {
+                k: v[0].strip('"')
+                for k, v in qparams.items()
+                if type(v) is list and len(v) > 0
+            }
+            params["url"] = url
+            if "rel" in params:
+                links[params["rel"]] = params
+
+    return json.load(conn), links
+
+def fetch_url(
+    url: str,
+    *,
+    headers: Optional[Dict[str, str]] = None,
+    reader: Callable[[Any], Any] = lambda x: x.read(),
+    retries: Optional[int] = 3,
+    backoff_timeout: float = 0.5,
+) -> Any:
+    if headers is None:
+        headers = {}
+    try:
+        with urlopen(Request(url, headers=headers)) as conn:
+            return reader(conn)
+    except urllib.error.HTTPError as err:
+        if isinstance(retries, (int, float)) and retries > 0:
+            time.sleep(backoff_timeout)
+            return fetch_url(
+                url,
+                headers=headers,
+                reader=reader,
+                retries=retries - 1,
+                backoff_timeout=backoff_timeout,
+            )
+        exception_message = (
+            "Is github alright?",
+            f"Recieved status code '{err.code}' when attempting to retrieve {url}:\n",
+            f"{err.reason}\n\nheaders={err.headers}",
+        )
+        raise RuntimeError(exception_message) from err
+
+def fetch_base_ref(url: str, headers: Dict[str, str]) -> str:
+    response, links = fetch_url(url, headers=headers, reader=parse_json_and_links)
+    return response["base"]["ref"]
+
+
+def find_base_branch() -> str:
+    # From https://docs.github.com/en/actions/learn-github-actions/environment-variables
+    GITHUB_REF_NAME = os.environ.get("GITHUB_REF_NAME", "")
+    pull = 0
+    if GITHUB_REF_NAME != "" and "ciflow" in GITHUB_REF_NAME:
+        pull = GITHUB_REF_NAME.rsplit('/', 1)[-1]
+    else:
+        return "main"
+
+    PYTORCH_REPO = os.environ.get("GITHUB_REPOSITORY", "pytorch/pytorch")
+    PYTORCH_GITHUB_API = f"https://api.github.com/repos/{PYTORCH_REPO}"
+    GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+    REQUEST_HEADERS = {
+        "Accept": "application/vnd.github.v3+json",
+        "Authorization": "token " + GITHUB_TOKEN,
+    }
+
+    url = f"{PYTORCH_GITHUB_API}/pulls/{pull}"
+    base_ref = fetch_base_ref(url, REQUEST_HEADERS)
+    if base_ref.startswith("release/"):
+        return base_ref
+
+    return "main"
+
+def main() -> None:
+    try:
+        print(find_base_branch())
+    except Exception as e:
+        print(repr(e), file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/get_ciflow_base_ref.py
+++ b/.github/scripts/get_ciflow_base_ref.py
@@ -10,8 +10,10 @@ import urllib.parse
 from typing import Any, Callable, Dict, Optional
 from urllib.request import Request, urlopen
 
+
 def parse_json(conn: Any) -> Any:
     return json.load(conn)
+
 
 def fetch_url(
     url: str,
@@ -43,6 +45,7 @@ def fetch_url(
         )
         raise RuntimeError(exception_message) from err
 
+
 def fetch_base_ref(url: str, headers: Dict[str, str]) -> Any:
     response = fetch_url(url, headers=headers, reader=parse_json)
     return response["base"]["ref"]
@@ -71,6 +74,7 @@ def find_base_branch() -> Any:
         return base_ref
 
     return "main"
+
 
 def main() -> None:
     try:

--- a/.github/scripts/get_ciflow_base_ref.py
+++ b/.github/scripts/get_ciflow_base_ref.py
@@ -53,7 +53,7 @@ def find_base_branch() -> Any:
     GITHUB_REF_NAME = os.environ.get("GITHUB_REF_NAME", "")
     pull = ""
     if GITHUB_REF_NAME != "" and "ciflow" in GITHUB_REF_NAME:
-        pull = GITHUB_REF_NAME.rsplit('/', 1)[-1]
+        pull = GITHUB_REF_NAME.rsplit("/", 1)[-1]
     else:
         return "main"
 

--- a/.github/scripts/get_ciflow_base_ref.py
+++ b/.github/scripts/get_ciflow_base_ref.py
@@ -2,13 +2,12 @@
 
 import json
 import os
-import re
 import sys
 import time
 import urllib
 import urllib.parse
 
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Optional
 from urllib.request import Request, urlopen
 
 def parse_json(conn: Any) -> Any:
@@ -49,10 +48,10 @@ def fetch_base_ref(url: str, headers: Dict[str, str]) -> Any:
     return response["base"]["ref"]
 
 
-def find_base_branch() -> str:
+def find_base_branch() -> Any:
     # From https://docs.github.com/en/actions/learn-github-actions/environment-variables
     GITHUB_REF_NAME = os.environ.get("GITHUB_REF_NAME", "")
-    pull = 0
+    pull = ""
     if GITHUB_REF_NAME != "" and "ciflow" in GITHUB_REF_NAME:
         pull = GITHUB_REF_NAME.rsplit('/', 1)[-1]
     else:

--- a/.github/scripts/get_ciflow_base_ref.py
+++ b/.github/scripts/get_ciflow_base_ref.py
@@ -11,28 +11,8 @@ import urllib.parse
 from typing import Any, Callable, Dict, Optional, Tuple
 from urllib.request import Request, urlopen
 
-def parse_json_and_links(conn: Any) -> Tuple[Any, Dict[str, Dict[str, str]]]:
-    links = {}
-    # Extract links which GH uses for pagination
-    # see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link
-    if "Link" in conn.headers:
-        for elem in re.split(", *<", conn.headers["Link"]):
-            try:
-                url, params_ = elem.split(";", 1)
-            except ValueError:
-                continue
-            url = urllib.parse.unquote(url.strip("<> "))
-            qparams = urllib.parse.parse_qs(params_.strip(), separator=";")
-            params = {
-                k: v[0].strip('"')
-                for k, v in qparams.items()
-                if type(v) is list and len(v) > 0
-            }
-            params["url"] = url
-            if "rel" in params:
-                links[params["rel"]] = params
-
-    return json.load(conn), links
+def parse_json(conn: Any) -> Any:
+    return json.load(conn)
 
 def fetch_url(
     url: str,
@@ -65,7 +45,7 @@ def fetch_url(
         raise RuntimeError(exception_message) from err
 
 def fetch_base_ref(url: str, headers: Dict[str, str]) -> Any:
-    response, links = fetch_url(url, headers=headers, reader=parse_json_and_links)
+    response = fetch_url(url, headers=headers, reader=parse_json)
     return response["base"]["ref"]
 
 

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -6,7 +6,7 @@
 {%- set timeout_minutes = 240 -%}
 
 # NOTE: If testing pytorch/builder changes you can change this variable to change what pytorch/builder reference
-#       the binary builds will check out
+#       the binary builds will check out. For release builder_branch must be set to release/version branch
 {%- set builder_repo = "pytorch/builder" -%}
 {%- set builder_branch = "main" -%}
 

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -99,8 +99,13 @@ jobs:
         with:
           name: !{{ config["build_name"] }}
           path: "${{ runner.temp }}/artifacts/"
+      {%- if "release" in common.builder_branch %}
+      !{{ common.checkout(deep_clone=False, directory="pytorch", branch=common.builder_branch, checkout_pr_head=False) }}
+      !{{ common.checkout(deep_clone=False, directory="builder", repository=common.builder_repo, branch=common.builder_branch, checkout_pr_head=False) }}
+      {%- else %}
       !{{ common.checkout(deep_clone=False, directory="pytorch") }}
       !{{ common.checkout(deep_clone=False, directory="builder", repository=common.builder_repo, branch=common.builder_branch) }}
+      {%- endif %}
       - name: ROCm set GPU_FLAG
         run: |
           echo "GPU_FLAG=--device=/dev/mem --device=/dev/kfd --device=/dev/dri --group-add video --group-add daemon" >> "${GITHUB_ENV}"

--- a/.github/templates/macos_binary_build_workflow.yml.j2
+++ b/.github/templates/macos_binary_build_workflow.yml.j2
@@ -81,8 +81,13 @@ jobs:
           elif [ -d "/Applications/Xcode_13.3.1.app" ]; then
             echo "DEVELOPER_DIR=/Applications/Xcode_13.3.1.app/Contents/Developer" >> "${GITHUB_ENV}"
           fi
+      {%- if "release" in common.builder_branch %}
+      !{{ common.checkout(deep_clone=False, directory="pytorch", branch=common.builder_branch, checkout_pr_head=False) }}
+      !{{ common.checkout(deep_clone=False, directory="builder", repository=common.builder_repo, branch=common.builder_branch, checkout_pr_head=False) }}
+      {%- else %}
       !{{ common.checkout(deep_clone=False, directory="pytorch") }}
       !{{ common.checkout(deep_clone=False, directory="builder", repository=common.builder_repo, branch=common.builder_branch) }}
+      {%- endif %}
       - name: Install sccache (only for non-forked PRs, and pushes to trunk)
         uses: nick-fields/retry@v2.8.2
         if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/templates/windows_binary_build_workflow.yml.j2
+++ b/.github/templates/windows_binary_build_workflow.yml.j2
@@ -65,8 +65,13 @@ jobs:
     steps:
       !{{ common.setup_ec2_windows() }}
       !{{ set_runner_specific_vars() }}
+      {%- if "release" in common.builder_branch %}
+      !{{ common.checkout(deep_clone=False, directory="pytorch", branch=common.builder_branch, checkout_pr_head=False) }}
+      !{{ common.checkout(deep_clone=False, directory="builder", repository=common.builder_repo, branch=common.builder_branch, checkout_pr_head=False) }}
+      {%- else %}
       !{{ common.checkout(deep_clone=False, directory="pytorch") }}
       !{{ common.checkout(deep_clone=False, directory="builder", repository=common.builder_repo, branch=common.builder_branch) }}
+      {%- endif %}
       - name: Populate binary env
         shell: bash
         run: |
@@ -105,8 +110,13 @@ jobs:
         with:
           name: !{{ config["build_name"] }}
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
+      {%- if "release" in common.builder_branch %}
+      !{{ common.checkout(deep_clone=False, directory="pytorch", branch=common.builder_branch, checkout_pr_head=False) }}
+      !{{ common.checkout(deep_clone=False, directory="builder", repository=common.builder_repo, branch=common.builder_branch, checkout_pr_head=False) }}
+      {%- else %}
       !{{ common.checkout(deep_clone=False, directory="pytorch") }}
       !{{ common.checkout(deep_clone=False, directory="builder", repository=common.builder_repo, branch=common.builder_branch) }}
+      {%- endif %}
       - name: Populate binary env
         shell: bash
         run: |

--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -148,6 +148,8 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
         with:
           no-sudo: ${{ inputs.build_environment == 'linux-aarch64-binary-manywheel' }}
+      - name: Get Build Branch
+        uses: ./.github/actions/get-build-branch
 
       - name: Setup Linux
         uses: ./.github/actions/setup-linux
@@ -187,10 +189,19 @@ jobs:
       - name: Checkout pytorch/builder to builder dir
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: ${{ env.REPO_BRANCH }}
           submodules: recursive
           repository: pytorch/builder
           path: builder
+          quiet-checkout: true
+
+      - name: Checkout pytorch/test-infra to test-infra dir
+        uses: malfet/checkout@silent-checkout
+        with:
+          ref: ${{ env.REPO_BRANCH }}
+          submodules: recursive
+          repository: pytorch/test-infra
+          path: test-infra
           quiet-checkout: true
 
       - name: Clean pytorch/builder checkout
@@ -213,7 +224,7 @@ jobs:
 
       - name: Pull Docker image
         if: ${{ steps.filter.outputs.is-test-matrix-empty == 'False' }}
-        uses: pytorch/test-infra/.github/actions/pull-docker-image@main
+        uses: ./test-infra/.github/actions/pull-docker-image
         with:
           docker-image: ${{ inputs.DOCKER_IMAGE }}
 
@@ -270,7 +281,7 @@ jobs:
 
       - name: Teardown Linux
         if: always()
-        uses: pytorch/test-infra/.github/actions/teardown-linux@main
+        uses: ./test-infra/.github/actions/teardown-linux
 
       - name: Chown workspace
         if: always()

--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -148,6 +148,7 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
         with:
           no-sudo: ${{ inputs.build_environment == 'linux-aarch64-binary-manywheel' }}
+
       - name: Get Build Branch
         uses: ./.github/actions/get-build-branch
 

--- a/.github/workflows/_binary-test-linux.yml
+++ b/.github/workflows/_binary-test-linux.yml
@@ -175,6 +175,7 @@ jobs:
           submodules: recursive
           repository: pytorch/builder
           path: builder
+
       - name: Checkout pytorch/test-infra to test-infra dir
         uses: malfet/checkout@silent-checkout
         with:

--- a/.github/workflows/_binary-test-linux.yml
+++ b/.github/workflows/_binary-test-linux.yml
@@ -138,6 +138,9 @@ jobs:
         with:
           no-sudo: ${{ inputs.build_environment == 'linux-aarch64-binary-manywheel' }}
 
+      - name: Get Build Branch
+        uses: ./.github/actions/get-build-branch
+
       - name: Setup Linux
         uses: ./.github/actions/setup-linux
 
@@ -168,10 +171,18 @@ jobs:
       - name: Checkout pytorch/builder to builder dir
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: ${{ env.REPO_BRANCH }}
           submodules: recursive
           repository: pytorch/builder
           path: builder
+      - name: Checkout pytorch/test-infra to test-infra dir
+        uses: malfet/checkout@silent-checkout
+        with:
+          ref: ${{ env.REPO_BRANCH }}
+          submodules: recursive
+          repository: pytorch/test-infra
+          path: test-infra
+          quiet-checkout: true
 
       - name: Clean pytorch/builder checkout
         run: |
@@ -199,12 +210,12 @@ jobs:
           path: "${{ runner.temp }}/artifacts/"
 
       - name: Install nvidia driver, nvidia-docker runtime, set GPU_FLAG
-        uses: pytorch/test-infra/.github/actions/setup-nvidia@main
+        uses: ./test-infra/.github/actions/setup-nvidia
         if: ${{ inputs.GPU_ARCH_TYPE == 'cuda' && steps.filter.outputs.is-test-matrix-empty == 'False' }}
 
       - name: Pull Docker image
         if: ${{ steps.filter.outputs.is-test-matrix-empty == 'False' }}
-        uses: pytorch/test-infra/.github/actions/pull-docker-image@main
+        uses: ./test-infra/.github/actions/pull-docker-image
         with:
           docker-image: ${{ inputs.DOCKER_IMAGE }}
 
@@ -214,7 +225,7 @@ jobs:
 
       - name: Teardown Linux
         if: always()
-        uses: pytorch/test-infra/.github/actions/teardown-linux@main
+        uses: ./test-infra/.github/actions/teardown-linux@main
 
       - name: Chown workspace
         if: always()

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -84,17 +84,29 @@ jobs:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
 
+      - name: Get Build Branch
+        uses: ./.github/actions/get-build-branch
+
       - name: Setup Linux
         uses: ./.github/actions/setup-linux
 
+      - name: Checkout pytorch/test-infra to test-infra dir
+        uses: malfet/checkout@silent-checkout
+        with:
+          ref: ${{ env.REPO_BRANCH }}
+          submodules: recursive
+          repository: pytorch/test-infra
+          path: test-infra
+          quiet-checkout: true
+
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
+        uses: ./test-infra/.github/actions/calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image-name }}
 
       - name: Pull docker image
-        uses: pytorch/test-infra/.github/actions/pull-docker-image@main
+        uses: ./test-infra/.github/actions/pull-docker-image
         with:
           docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
 
@@ -200,5 +212,5 @@ jobs:
           path: sccache-stats-*.json
 
       - name: Teardown Linux
-        uses: pytorch/test-infra/.github/actions/teardown-linux@main
+        uses: ./test-infra/.github/actions/teardown-linux
         if: always()

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -68,23 +68,35 @@ jobs:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
 
+      - name: Get Build Branch
+        uses: ./.github/actions/get-build-branch
+
       - name: Setup Linux
         uses: ./.github/actions/setup-linux
 
+      - name: Checkout pytorch/test-infra to test-infra dir
+        uses: malfet/checkout@silent-checkout
+        with:
+          ref: ${{ env.REPO_BRANCH }}
+          submodules: recursive
+          repository: pytorch/test-infra
+          path: test-infra
+          quiet-checkout: true
+
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
+        uses: ./test-infra/.github/actions/calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image }}
 
       - name: Pull docker image
-        uses: pytorch/test-infra/.github/actions/pull-docker-image@main
+        uses: ./test-infra/.github/actions/pull-docker-image
         with:
           docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
 
       - name: Install nvidia driver, nvidia-docker runtime, set GPU_FLAG
         id: install-nvidia-driver
-        uses: pytorch/test-infra/.github/actions/setup-nvidia@main
+        uses: ./test-infra/.github/actions/setup-nvidia
         if: contains(inputs.build-environment, 'cuda') && !contains(matrix.config, 'nogpu')
 
       - name: Lock NVIDIA A100 40GB Frequency
@@ -291,7 +303,7 @@ jobs:
           path: ./**/core.[1-9]*
 
       - name: Teardown Linux
-        uses: pytorch/test-infra/.github/actions/teardown-linux@main
+        uses: ./test-infra/.github/actions/teardown-linux
         if: always()
 
       # NB: We are currently having an intermittent GPU-related issue on G5 runners with

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -77,6 +77,18 @@ jobs:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
 
+      - name: Get Build Branch
+        uses: ./.github/actions/get-build-branch
+
+      - name: Checkout pytorch/test-infra to test-infra dir
+        uses: malfet/checkout@silent-checkout
+        with:
+          ref: ${{ env.REPO_BRANCH }}
+          submodules: recursive
+          repository: pytorch/test-infra
+          path: test-infra
+          quiet-checkout: true
+
       - name: Set xcode version
         env:
           XCODE_VERSION: ${{ inputs.xcode-version }}
@@ -87,7 +99,7 @@ jobs:
 
       - name: Setup miniconda
         if: inputs.environment-file == ''
-        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
+        uses: ./test-infra/.github/actions/setup-miniconda
         with:
           python-version: ${{ inputs.python-version }}
           environment-file: .github/requirements/conda-env-${{ runner.os }}-${{ runner.arch }}
@@ -97,7 +109,7 @@ jobs:
       # environment even though the arch is x86-64
       - name: Setup miniconda using the provided environment file
         if: inputs.environment-file != ''
-        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
+        uses: ./test-infra/.github/actions/setup-miniconda
         with:
           python-version: ${{ inputs.python-version }}
           environment-file: ${{ inputs.environment-file }}
@@ -207,4 +219,4 @@ jobs:
       - name: Clean up disk space
         if: always()
         continue-on-error: true
-        uses: pytorch/test-infra/.github/actions/check-disk-space@main
+        uses: ./test-infra/.github/actions/check-disk-space

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -79,8 +79,20 @@ jobs:
           name: ${{ inputs.build-environment }}
           use-gha: true
 
+      - name: Get Build Branch
+        uses: ./.github/actions/get-build-branch
+
+      - name: Checkout pytorch/test-infra to test-infra dir
+        uses: malfet/checkout@silent-checkout
+        with:
+          ref: ${{ env.REPO_BRANCH }}
+          submodules: recursive
+          repository: pytorch/test-infra
+          path: test-infra
+          quiet-checkout: true
+
       - name: Setup miniconda
-        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
+        uses: ./test-infra/.github/actions/setup-miniconda
         with:
           python-version: ${{ inputs.python-version }}
           environment-file: .github/requirements/conda-env-${{ runner.os }}-${{ runner.arch }}
@@ -158,4 +170,4 @@ jobs:
       - name: Clean up disk space
         if: always()
         continue-on-error: true
-        uses: pytorch/test-infra/.github/actions/check-disk-space@main
+        uses: ./test-infra/.github/actions/check-disk-space

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -75,6 +75,18 @@ jobs:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
 
+      - name: Get Build Branch
+        uses: ./.github/actions/get-build-branch
+
+      - name: Checkout pytorch/test-infra to test-infra dir
+        uses: malfet/checkout@silent-checkout
+        with:
+          ref: ${{ env.REPO_BRANCH }}
+          submodules: recursive
+          repository: pytorch/test-infra
+          path: test-infra
+          quiet-checkout: true
+
       - name: Download build artifacts
         uses: ./.github/actions/download-build-artifacts
         with:
@@ -82,7 +94,7 @@ jobs:
           use-gha: true
 
       - name: Setup miniconda
-        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
+        uses: ./test-infra/.github/actions/setup-miniconda
         with:
           python-version: ${{ inputs.python-version }}
           environment-file: .github/requirements/conda-env-${{ runner.os }}-${{ runner.arch }}
@@ -208,4 +220,4 @@ jobs:
       - name: Clean up disk space
         if: always()
         continue-on-error: true
-        uses: pytorch/test-infra/.github/actions/check-disk-space@main
+        uses: ./test-infra/.github/actions/check-disk-space

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -58,17 +58,29 @@ jobs:
         with:
           no-sudo: true
 
+      - name: Get Build Branch
+        uses: ./.github/actions/get-build-branch
+
+      - name: Checkout pytorch/test-infra to test-infra dir
+        uses: malfet/checkout@silent-checkout
+        with:
+          ref: ${{ env.REPO_BRANCH }}
+          submodules: recursive
+          repository: pytorch/test-infra
+          path: test-infra
+          quiet-checkout: true
+
       - name: Setup ROCm
         uses: ./.github/actions/setup-rocm
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
+        uses: ./test-infra/.github/actions/calculate-docker-image
         with:
           docker-image-name: ${{ inputs.docker-image }}
 
       - name: Pull docker image
-        uses: pytorch/test-infra/.github/actions/pull-docker-image@main
+        uses: ./test-infra/.github/actions/pull-docker-image
         with:
           docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
 

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -57,11 +57,23 @@ jobs:
         with:
           submodules: false
 
+      - name: Get Build Branch
+        uses: ./.github/actions/get-build-branch
+
+      - name: Checkout pytorch/test-infra to test-infra dir
+        uses: malfet/checkout@silent-checkout
+        with:
+          ref: ${{ env.REPO_BRANCH }}
+          submodules: recursive
+          repository: pytorch/test-infra
+          path: test-infra
+          quiet-checkout: true
+
       - name: Setup Linux
         uses: ./.github/actions/setup-linux
 
       - name: Pull Docker image
-        uses: pytorch/test-infra/.github/actions/pull-docker-image@main
+        uses: ./test-infra/.github/actions/pull-docker-image
         with:
           docker-image: ${{ env.DOCKER_IMAGE }}
 
@@ -126,7 +138,7 @@ jobs:
           path: ${{ runner.temp }}/artifacts/*
 
       - name: Teardown Linux
-        uses: pytorch/test-infra/.github/actions/teardown-linux@main
+        uses: ./test-infra/.github/actions/teardown-linux
         if: always()
 
   upload-wheel:
@@ -202,8 +214,20 @@ jobs:
       - name: Setup Linux
         uses: ./.github/actions/setup-linux
 
+      - name: Get Build Branch
+        uses: ./.github/actions/get-build-branch
+
+      - name: Checkout pytorch/test-infra to test-infra dir
+        uses: malfet/checkout@silent-checkout
+        with:
+          ref: ${{ env.REPO_BRANCH }}
+          submodules: recursive
+          repository: pytorch/test-infra
+          path: test-infra
+          quiet-checkout: true
+
       - name: Pull Docker image
-        uses: pytorch/test-infra/.github/actions/pull-docker-image@main
+        uses: ./test-infra/.github/actions/pull-docker-image
         with:
           docker-image: ${{ env.DOCKER_IMAGE }}
 
@@ -239,7 +263,7 @@ jobs:
           path: ${{ runner.temp }}/artifacts/*
 
       - name: Teardown Linux
-        uses: pytorch/test-infra/.github/actions/teardown-linux@main
+        uses: ./test-infra/.github/actions/teardown-linux
         if: always()
 
   upload-conda:

--- a/scripts/release/apply-release-changes.sh
+++ b/scripts/release/apply-release-changes.sh
@@ -13,22 +13,9 @@ set -eou pipefail
 DRY_RUN=${DRY_RUN:-enabled}
 python3 .github/scripts/tag_docker_images_for_release.py --version ${RELEASE_VERSION} --dry-run ${DRY_RUN}
 
-# Change all GitHub Actions to reference the test-infra release branch
-# as opposed to main.
-echo "Applying to workflows"
-for i in .github/workflows/*.yml; do
-    sed -i -e s#@main#@"release/${RELEASE_VERSION}"# $i;
-done
-
-# Change all checkout step in templates to not add ref to checkout
-echo "Applying to templates"
-for i in .github/templates/*.yml.j2; do
-    sed -i 's#common.checkout(\(.*\))#common.checkout(\1, checkout_pr_head=False)#' $i;
-done
-
-# Triton wheel
-echo "Triton Changes"
-sed -i -e s#-\ main#"-\ release\/${RELEASE_VERSION}"# .github/workflows/build-triton-wheel.yml
+# Apply
+echo "Applying to common template"
+sed -i -e s#main#"release\/${RELEASE_VERSION}"# .github/templates/common.yml.j2
 
 # XLA related changes
 echo "XLA Changes"


### PR DESCRIPTION
This PR automates release only change, replacing main branch with release/version branch. We extract release branch from rc tag on tag, ciflow/binaries/PR number for the ciflow tags. 

Test in pyotrch-canary: https://github.com/pytorch/pytorch-canary/actions/runs/7008520412

Note: Still draft, covers linux binary builds only for now. ToDo: Extend this logic for trunk tests
