### PR TITLE
Adds ability to further configure `state_dict` and `load_state_dict` during `DCP.save/load` [4/n]

### DIFF
--- a/torch/distributed/checkpoint/state_dict_saver.py
+++ b/torch/distributed/checkpoint/state_dict_saver.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Dict
 import warnings
 
 import torch
@@ -42,6 +42,7 @@ def save(
     coordinator_rank: int = 0,
     no_dist: bool = False,
     planner: Optional[SavePlanner] = None,
+    state_dict_kwargs: Dict = None,
 ) -> Metadata:
     """
     Save a distributed model in SPMD style.
@@ -106,11 +107,11 @@ def save(
     """
     torch._C._log_api_usage_once("torch.distributed.checkpoint.save")
 
-    torch._C._log_api_usage_once("torch.distributed.checkpoint.save")
+    state_dict_kwargs = state_dict_kwargs or {}
 
     dumpable_state_dict = {}
     for key, elem in state_dict.items():
-        dumpable_state_dict[key] = elem.state_dict() if isinstance(elem, Stateful) else elem
+        dumpable_state_dict[key] = elem.state_dict(**state_dict_kwargs) if isinstance(elem, Stateful) else elem
 
     return _save_state_dict(
         dumpable_state_dict,

--- a/torch/distributed/checkpoint/stateful.py
+++ b/torch/distributed/checkpoint/stateful.py
@@ -8,10 +8,10 @@ __all__ = ["Stateful", "StatefulT"]
 
 @runtime_checkable
 class Stateful(Protocol):
-    def state_dict(self) -> Dict[str, Any]:
+    def state_dict(self, **kwargs) -> Dict[str, Any]:
         ...
 
-    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+    def load_state_dict(self, state_dict: Dict[str, Any], **kwargs) -> None:
         ...
 
 


### PR DESCRIPTION
Seeking some early feedback on some options for passing further configurations to `state_dict` and `load_state_dict` when calling save and load. This issue exists because `save` and `load` provide an abstraction over `get_state_dict` and `load_state_dict`. I believe this usage is extra relevant in situations where users may sometime want to pass `StateDictOptions` and request a partial or full state dict (such as fine tuning).
  
Two options we have here:

1. `state_dict_kwargs` and `load_state_dict_kwargs` exists as  a dict to `save`/`load`. Users can customize `state_dict` & `load_state_dict`, and these are params are passed as kwargs from `save`/`load` to `state_dict`/`load_state_dict` to **every stateful object**
    This is a little risky since it forces every object to be 'compliant' with supplied kwargs.


2. `state_dict_kwargs` and `load_state_dict_kwargs` are passed in as a dictionary of kwargs, where each key matches an entry in `state_dict`, and the value is the kwargs for that object. This is probably the better option, but still a bit hacky.


```
#option1:
DCP.save(
	state_dict={...},
	state_dict_options={
		"options": StateDictOptions(...)		# passed everywhere
	}
)

DCP.load(
	state_dict={...},
	state_dict_options={
		"options": StateDictOptions(...)	    # passed everywhere
	},
	load_state_dict_options={
		"options": StateDictOptions(...)		# passed everywhere
	},
)


#option2:
DCP.save(
	state_dict={
		"model": ...
	},
	state_dict_options={
		"model": {
			"options": StateDictOptions(...)    # only passed to model
		}
	}
)

DCP.load(
	state_dict={
		"model": ...
	},
	state_dict_options={
		"model": {
			"options": StateDictOptions(...)    # only passed to model
		}
	}
	load_state_dict_options={
		"model": {
			"options": StateDictOptions(...)
		}
	},
)

```

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @kiukchung @d4l3k @lucasllc