### PR TITLE
[export] Add meta to params

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1422,6 +1422,14 @@ def export(
                         case_name="cond_operands",
                     )
 
+            for node in graph.graph.nodes:
+                if node.op == "get_attr" and isinstance(
+                    getattr(graph, node.target), torch.Tensor
+                ):
+                    node.meta["val"] = fake_mode.from_tensor(
+                        getattr(graph, node.target), static_shapes=True
+                    )
+
         if same_signature:
             flat_args_dynamic_dims = [
                 {c.dim for c in (constraints or ()) if c.w_tensor() is x}


### PR DESCRIPTION
The graph from `capture_pre_autograd_graph` doesn't have `meta["val"]` on the param nodes.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng