### PR TITLE
Add dtensor and fsdp/2d tests to inductor_distributed CI

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -291,6 +291,8 @@ test_inductor_distributed() {
   pytest test/inductor/test_torchinductor.py -k test_multi_gpu
   pytest test/inductor/test_aot_inductor.py -k test_non_default_cuda_device
   pytest test/inductor/test_aot_inductor.py -k test_replicate_on_devices
+  pytest test/distributed/_tensor/test_dtensor_compile.py
+  pytest test/distributed/tensor/parallel/test_fsdp_2d_parallel.py
 
   # this runs on both single-gpu and multi-gpu instance. It should be smart about skipping tests that aren't supported
   # with if required # gpus aren't available

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -29,6 +29,10 @@
 - .github/ci_commit_pins/**
 - c10/core/Sym*
 - torch/fx/experimental/symbolic_shapes.py
+- test/distributed/_tensor/test_dtensor_compile.py
+- test/distributed/tensor/parallel/test_fsdp_2d_parallel.py
+- torch/distributed/_tensor/**
+- torch/distributed/fsdp/**
 
 "module: cpu":
 - aten/src/ATen/cpu/**


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #114642

Smuggle important and not too slow tests to run on this trunk job,
instead of just on the periodic job where they currently reside.
 - test_dtensor_compile took 70sec, test_fsdp_2d_parallel took 198sec
   locally

As a follow up, organize the distributed-mgpu tests better and maybe
rename this job to reflect its more 'general dist mgpu'

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @yf225 @kiukchung @d4l3k @lucasllc