### PR TITLE
Sort the output of TORCH_LOGS=help

### DIFF
--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -514,11 +514,11 @@ def help_message(verbose=False):
         heading = "Visible registered names (use TORCH_LOGS='+help' for full list)"
     lines = (
         ["all"]
-        + list(log_registry.log_alias_to_log_qnames.keys())
-        + [
+        + sorted(log_registry.log_alias_to_log_qnames.keys())
+        + sorted([
             f"{pad_to(name)}\t{log_registry.artifact_descriptions[name]}"
             for name in printed_artifacts
-        ]
+        ])
     )
     setting_info = "  " + "\n  ".join(lines)
     examples = """

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -515,10 +515,12 @@ def help_message(verbose=False):
     lines = (
         ["all"]
         + sorted(log_registry.log_alias_to_log_qnames.keys())
-        + sorted([
-            f"{pad_to(name)}\t{log_registry.artifact_descriptions[name]}"
-            for name in printed_artifacts
-        ])
+        + sorted(
+            [
+                f"{pad_to(name)}\t{log_registry.artifact_descriptions[name]}"
+                for name in printed_artifacts
+            ]
+        )
     )
     setting_info = "  " + "\n  ".join(lines)
     examples = """


### PR DESCRIPTION
Previously the order was random because it was based on the order of dictionary keys.
