### PR TITLE
Fix missing meta for proxy.node

### DIFF
--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -134,6 +134,8 @@ def extract_val(val):
                 return torch.empty_strided(val.shape, val.stride(), device=val.device, dtype=val.dtype)
         else:
             return None
+    elif isinstance(val, (int, float, bool)):
+        return val
 
 # What invariants do we have for the 'val' set on the FX node?  It has accurate
 # metadata... but only for metadata that exists "below" all other subsystems


### PR DESCRIPTION
Hello community, 

There is node like SDPA which has basic type meta field that extract_val failed to capture. Otherwise some third-party modules plugged in Dynamo which trying to analyse node.meta['val'] will fail. See https://github.com/nod-ai/SHARK-Turbine/issues/206

Thanks !