### PR TITLE
Add `bits` dtypes to `torch._C` stubs

### DIFF
--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -1264,10 +1264,10 @@ def gen_pyi(
             "bool",
             "quint4x2",
             "quint2x4",
-            "bits16",
             "bits1x8",
             "bits2x4",
             "bits4x2",
+            "bits8",
             "bits16",
         ]
     ]

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -1264,6 +1264,11 @@ def gen_pyi(
             "bool",
             "quint4x2",
             "quint2x4",
+            "bits16",
+            "bits1x8",
+            "bits2x4",
+            "bits4x2",
+            "bits16",
         ]
     ]
 


### PR DESCRIPTION
As defined https://github.com/pytorch/pytorch/blob/6ae0554d11b973930d7b8ec1e937b27ac961d7bf/c10/core/ScalarType.h#L54-L58

