### PR TITLE
[export] Refactor export() and separate the non-strict part.

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -8,9 +8,8 @@ from dataclasses import dataclass
 
 import torch
 import torch._dynamo as torchdynamo
-from functorch.experimental.control_flow import map, cond
+from functorch.experimental.control_flow import cond, map
 from torch import Tensor
-from torch.export import Constraint, Dim, export
 from torch._export import DEFAULT_EXPORT_DYNAMO_CONFIG, dynamic_dim, capture_pre_autograd_graph, _export
 from torch._export.pass_base import _ExportPassBase
 from torch._export.utils import (
@@ -20,6 +19,8 @@ from torch._export.utils import (
     is_param,
     register_dataclass_as_pytree_node,
 )
+from torch._subclasses import FakeTensorMode
+from torch.export import Constraint, Dim, export
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing import FileCheck
 from torch.testing._internal.common_utils import run_tests, TestCase
@@ -29,8 +30,8 @@ from torch.utils._pytree import (
     tree_map,
     tree_unflatten,
     TreeSpec,
+    treespec_dumps,
     treespec_loads,
-    treespec_dumps
 )
 
 
@@ -111,6 +112,37 @@ class TestExport(TestCase):
 
         inp = ([torch.ones(1, 3)], torch.ones(1, 3))
         self._test_export_same_as_eager(f, inp)
+
+    def test_basic_non_strict_real_tensor(self):
+        class Basic(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.param = torch.nn.Parameter(torch.randn(1, 3))
+
+            def forward(self, x, y):
+                return x[0] + y - self.param
+
+        f = Basic()
+        args = ([torch.randn(1, 3)], torch.randn(1, 3))
+        ep = export(f, args, strict=False)
+        self.assertEqual(ep(*args), f(*args))
+
+    def test_basic_non_strict_fake_tensor(self):
+        class Basic(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.param = torch.nn.Parameter(torch.randn(3, 2))
+
+            def forward(self, x, y):
+                return x[0] + y - self.param
+
+        fake_mode = FakeTensorMode()
+        f = Basic()
+        with fake_mode:
+            args = ([torch.empty(3, 2)], torch.empty(3, 2))
+        ep = export(f, args, strict=False)
+        inputs = ([torch.randn(3, 2)], torch.randn(3, 2))
+        self.assertEqual(ep(*inputs), f(*inputs))
 
     def test_raise_user_error_when_guard_on_data_dependent_operation(self):
         def fn_ddo(x):

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -233,6 +233,7 @@ def export__RC__(
     kwargs: Optional[Dict[str, Any]] = None,
     *,
     dynamic_shapes: Optional[Union[Dict[str, Any], Tuple[Any]]] = None,
+    strict: bool = True,
     preserve_module_call_signature: Tuple[str, ...] = (),
 ) -> ExportedProgram:
     """
@@ -260,6 +261,7 @@ def export__RC__(
         args,
         kwargs,
         constraints=constraints,
+        strict=strict,
         preserve_module_call_signature=preserve_module_call_signature
     )
 
@@ -540,6 +542,7 @@ def export(
     kwargs: Optional[Dict[str, Any]] = None,
     constraints: Optional[List[Constraint]] = None,
     *,
+    strict: bool = True,
     preserve_module_call_signature: Tuple[str, ...] = (),
 ) -> ExportedProgram:
 
@@ -556,11 +559,12 @@ def export(
         args,
         kwargs,
         constraints,
+        strict=strict,
         preserve_module_call_signature=preserve_module_call_signature,
     )
 
 
-def _prepare_module(
+def _unlift_user_inputs_to_buffers(
     gm_torch_level: torch.fx.GraphModule,
     aot_export_args
 ) -> List[str]:
@@ -585,7 +589,7 @@ def _prepare_module(
     return user_input_names
 
 
-def _unwrap_user_inputs(
+def _lift_buffers_to_user_inputs(
     gm: torch.fx.GraphModule,
     graph_signature: GraphSignature,
     user_input_names: List[str]
@@ -618,7 +622,7 @@ def _unwrap_user_inputs(
                 new_node.meta = copy.copy(old_node.meta)
                 old_node.replace_all_uses_with(new_node)
                 replaces[old_node.name] = new_node.name
-
+    new_node_names = dict(reversed(new_node_names.items()))
     for old_node in old_nodes.values():
         gm.graph.erase_node(old_node)
 
@@ -634,11 +638,94 @@ def _unwrap_user_inputs(
     graph_signature.buffers_to_mutate = {
         o: b for o, b in graph_signature.buffers_to_mutate.items() if b not in names
     }
-    graph_signature.user_inputs = list(reversed(new_node_names.values()))  # type: ignore[arg-type]
+    graph_signature.user_inputs.extend(new_node_names.values())  # type: ignore[arg-type]
     graph_signature.user_outputs = [
         replaces[o] if o in replaces else o for o in graph_signature.user_outputs
     ]
     return user_inputs_to_mutate  # type: ignore[return-value]
+
+
+def _export_non_strict(
+    mod,
+    fake_args,
+    fake_kwargs,
+    fake_params_buffers,
+    *,
+    transform=lambda x: x  # TODO(zhxchen17) Revisit if this is needed later.
+):
+    # This _reparametrize_module makes sure inputs and module.params/buffers have the same fake_mode,
+    # otherwise aot_export_module will error out because it sees a mix of fake_modes.
+    # And we want aot_export_module to use the fake_tensor mode in dynamo to keep the pipeline easy to reason about.
+    with torch.nn.utils.stateless._reparametrize_module(mod, fake_params_buffers):
+        gm, graph_signature = transform(aot_export_module)(
+            mod,
+            (*fake_args, *fake_kwargs.values()),
+            trace_joint=False
+        )
+
+    # NOTE: aot_export adds symint metadata for placeholders with int values;
+    # since these become specialized, we replace such metadata with the original values
+    flat_args = pytree.tree_leaves((fake_args, fake_kwargs))
+    index = 0
+    total_param_buffers = len(graph_signature.parameters) + len(graph_signature.buffers)
+    for node in gm.graph.nodes:
+        if node.op == "placeholder":
+            if index >= total_param_buffers:
+                user_arg = flat_args[index - total_param_buffers]
+                if not isinstance(user_arg, torch.Tensor):
+                    node.meta["val"] = user_arg
+            index += 1
+
+    is_joint = graph_signature.backward_signature is not None
+
+    def make_argument_spec(node) -> ArgumentSpec:
+        assert "val" in node.meta, f"{node} has no 'val' metadata field"
+        val = node.meta["val"]
+        if isinstance(val, FakeTensor):
+            return TensorArgument(name=node.name)
+        elif isinstance(val, torch.SymInt):
+            return SymIntArgument(name=node.name)
+        else:
+            return ConstantArgument(value=val)
+
+    input_specs, output_specs = _sig_to_specs(
+        user_inputs=set(graph_signature.user_inputs),
+        inputs_to_parameters=graph_signature.inputs_to_parameters,  # type: ignore[arg-type]
+        inputs_to_buffers=graph_signature.inputs_to_buffers,  # type: ignore[arg-type]
+        user_outputs=set(graph_signature.user_outputs),  # type: ignore[arg-type]
+        buffer_mutations=graph_signature.buffers_to_mutate,  # type: ignore[arg-type]
+        user_input_mutations=gm.meta.get("user_inputs_to_mutate", {}),  # type: ignore[arg-type]
+        grad_params=graph_signature.backward_signature.gradients_to_parameters if is_joint else {},  # type: ignore[arg-type, union-attr]
+        grad_user_inputs=graph_signature.backward_signature.gradients_to_user_inputs if is_joint else {},  # type: ignore[arg-type, union-attr]
+        loss_output=graph_signature.backward_signature.loss_output if is_joint else None,  # type: ignore[arg-type, union-attr]
+        inputs=[make_argument_spec(node) for node in gm.graph.nodes if node.op == "placeholder"],
+        outputs=[make_argument_spec(node) for node in pytree.tree_leaves(next(iter(reversed(gm.graph.nodes))).args)],
+    )
+    export_graph_signature = ExportGraphSignature(input_specs=input_specs, output_specs=output_specs)
+
+    tensor_constants = lift_constant_tensor_pass(gm, export_graph_signature)
+
+    @dataclasses.dataclass
+    class _ExportedProgramNonStrict:
+        gm: torch.fx.GraphModule
+        sig: ExportGraphSignature
+        tensor_constants: Dict[str, torch.Tensor]
+
+    return _ExportedProgramNonStrict(
+        gm,
+        export_graph_signature,
+        tensor_constants,
+    )
+
+
+def _get_params_buffers(mod: torch.nn.Module) -> Dict[str, torch.Tensor]:
+    params_buffers: Dict[str, torch.Tensor] = {}
+    for name, param in mod.named_parameters(remove_duplicate=False):
+        params_buffers[name] = param
+
+    for name, buffer in mod.named_buffers(remove_duplicate=False):
+        params_buffers[name] = buffer
+    return params_buffers
 
 
 @_disable_prexisiting_fake_mode
@@ -648,6 +735,7 @@ def _export(
     kwargs: Optional[Dict[str, Any]] = None,
     constraints: Optional[List[Constraint]] = None,
     *,
+    strict: bool = True,
     preserve_module_call_signature: Tuple[str, ...] = (),
 ) -> ExportedProgram:
     """
@@ -673,6 +761,52 @@ def _export(
     constraints = constraints or []
     kwargs = kwargs or {}
 
+    if not strict:
+        assert isinstance(f, torch.nn.Module)
+        assert len(preserve_module_call_signature) == 0
+        assert len(constraints) == 0, "dynamic shape NYI"
+        assert len(kwargs) == 0, "keyword arguments NYI"
+        out_spec = None
+
+        def _tuplify_outputs(aot_export):
+            def _aot_export_non_strict(mod, args, **kwargs):
+                class Wrapper(torch.nn.Module):
+                    def __init__(self, mod):
+                        super().__init__()
+                        self._export_root = mod
+
+                    def forward(self, *args, **kwargs):
+                        nonlocal out_spec
+                        flat_outs, out_spec = pytree.tree_flatten(self._export_root(*args, **kwargs))
+                        return tuple(flat_outs)
+
+                gm, sig = aot_export(Wrapper(mod), args, **kwargs)
+
+                def strip_root(x):
+                    return x[len('_export_root.'):] if x.startswith('_export_root.') else x
+
+                sig.parameters = pytree.tree_map(strip_root, sig.parameters)
+                sig.buffers = pytree.tree_map(strip_root, sig.buffers)
+                sig.inputs_to_buffers = pytree.tree_map(strip_root, sig.inputs_to_buffers)
+                sig.inputs_to_parameters = pytree.tree_map(strip_root, sig.inputs_to_parameters)
+                sig.buffers_to_mutate = pytree.tree_map(strip_root, sig.buffers_to_mutate)
+                return gm, sig
+            return _aot_export_non_strict
+        ep_non_strict = _export_non_strict(f, args, {}, f.state_dict(), transform=_tuplify_outputs)
+        assert out_spec is not None
+        return ExportedProgram(
+            ep_non_strict.gm,
+            ep_non_strict.gm.graph,
+            ep_non_strict.sig,
+            _get_params_buffers(f),
+            {},
+            [],
+            [ModuleCallEntry("", ModuleCallSignature([], [], pytree.tree_flatten((args, {}))[1], out_spec))],
+            (args, kwargs),
+            tensor_constants=ep_non_strict.tensor_constants,
+        )
+
+
     gm_torch_level = _export_to_torch_ir(
         f,
         args,
@@ -681,12 +815,7 @@ def _export(
         preserve_module_call_signature=preserve_module_call_signature,
     )
 
-    params_buffers: Dict[str, Union[torch.Tensor, torch.nn.Parameter]] = {}
-    for name, param in gm_torch_level.named_parameters(remove_duplicate=False):
-        params_buffers[name] = param
-
-    for name, buffer in gm_torch_level.named_buffers(remove_duplicate=False):
-        params_buffers[name] = buffer
+    params_buffers = _get_params_buffers(gm_torch_level)
 
     # We detect the fake_mode by looking at gm_torch_level's placeholders, this is the fake_mode created in dynamo.
     fake_args, fake_kwargs, fake_params_buffers, dynamo_fake_mode = _convert_input_to_fake(gm_torch_level, args, kwargs)
@@ -775,48 +904,50 @@ def _export(
     if isinstance(f, torch.nn.Module):
         _normalize_nn_module_stack(gm_torch_level, type(f))
 
-    aot_export_args = (*fake_args, *_reorder_kwargs_by_names(orig_args, fake_args, fake_kwargs).values())
+    def _process_user_inputs(aot_export):
+        def _aot_export_strict(gm_torch_level: torch.fx.GraphModule, args, **kwargs):
+            user_input_names = _unlift_user_inputs_to_buffers(gm_torch_level, args)
+            gm, graph_signature = aot_export(gm_torch_level, (), **kwargs)
+            user_inputs_to_mutate = _lift_buffers_to_user_inputs(gm, graph_signature, user_input_names)
+            # TODO unfortunately preserving graph-level metadata is not
+            # working well with aot_export. So we manually copy it.
+            # (The node-level meta is addressed above.)
+            gm.meta.update(gm_torch_level.meta)
+            assert "user_inputs_to_mutate" not in gm.meta
+            gm.meta["user_inputs_to_mutate"] = user_inputs_to_mutate
+            return gm, graph_signature
 
-    user_input_names = _prepare_module(gm_torch_level, aot_export_args)
+        return _aot_export_strict
 
     # Note: aot_export_module doesn't accept kwargs, we'd like to reorder the kwargs as an OrderedDict
-    # to follow the order in orig_args and correctly call gm_torch_level
+    # to follow the order in orig_args and correctly call module
+    ep_non_strict = _export_non_strict(
+        gm_torch_level,
+        fake_args,
+        _reorder_kwargs_by_names(orig_args, fake_args, fake_kwargs),
+        fake_params_buffers,
+        transform=_process_user_inputs
+    )
 
-    # This _reparametrize_module makes sure inputs and gm_torch_level.params/buffers have the same fake_mode,
-    # otherwise aot_export_module will error out because it sees a mix of fake_modes.
-    # And we want aot_export_module to use the fake_tensor mode in dynamo to keep the pipeline easy to reason about.
-    with torch.nn.utils.stateless._reparametrize_module(gm_torch_level, fake_params_buffers):
-        gm, graph_signature = aot_export_module(
-            gm_torch_level,
-            (),
-            trace_joint=False
-        )
-    user_inputs_to_mutate = _unwrap_user_inputs(gm, graph_signature, user_input_names)
+    gm = ep_non_strict.gm
+    export_graph_signature = ep_non_strict.sig
+    tensor_constants = ep_non_strict.tensor_constants
 
-    def to_str_list(sig_component: List[Any]):
-        return [str(v) for v in sig_component]
-
-    def to_str_dict(sig_component: Dict[Any, Any]):
-        return {str(k): str(v) for k, v in sig_component.items()}
-
-    # NOTE: aot_export adds symint metadata for placeholders with int values;
-    # since these become specialized, we replace such metadata with the original values
-    flat_args, in_spec = pytree.tree_flatten((args, kwargs or {}))
-    _, orig_in_spec = pytree.tree_flatten((args, kwargs))
-    index = 0
-    total_param_buffers = len(graph_signature.parameters) + len(graph_signature.buffers)
+    # After aot_export, set the param/buffer metadata back into placeholders
+    # Technically, users can still construct this data from param names
+    # without relying on this metadata
     for node in gm.graph.nodes:
         if node.op == "placeholder":
-            if index >= total_param_buffers:
-                user_arg = flat_args[index - total_param_buffers]
-                if not isinstance(user_arg, torch.Tensor):
-                    node.meta["val"] = user_arg
-            index += 1
-
-    # TODO unfortunately preserving graph-level metadata is not
-    # working well with aot_export. So we manually copy it.
-    # (The node-level meta is addressed above.)
-    gm.meta.update(gm_torch_level.meta)
+            if node.target in export_graph_signature.inputs_to_parameters:
+                param_name = export_graph_signature.inputs_to_parameters[node.target]
+                if param_name in params_buffers_to_node_meta:
+                    for k, v in params_buffers_to_node_meta[param_name].items():
+                        node.meta[k] = v
+            if node.target in export_graph_signature.inputs_to_buffers:
+                buffer_name = export_graph_signature.inputs_to_buffers[node.target]
+                if buffer_name in params_buffers_to_node_meta:
+                    for k, v in params_buffers_to_node_meta[buffer_name].items():
+                        node.meta[k] = v
 
     # The unbacked symint symbols are updated in aot_export
     # so we serialize them here instead of inside dynamo
@@ -829,52 +960,13 @@ def _export(
             if re.match(r"^[if]\d+$", str(k))
         }
 
-    # After aot_export, set the param/buffer metadata back into placeholders
-    # Technically, users can still construct this data from param names
-    # without relying on this metadata
-    for node in gm.graph.nodes:
-        if node.op == "placeholder":
-            if node.target in graph_signature.inputs_to_parameters:
-                param_name = graph_signature.inputs_to_parameters[node.target]
-                if param_name in params_buffers_to_node_meta:
-                    for k, v in params_buffers_to_node_meta[param_name].items():
-                        node.meta[k] = v
-            if node.target in graph_signature.inputs_to_buffers:
-                buffer_name = graph_signature.inputs_to_buffers[node.target]
-                if buffer_name in params_buffers_to_node_meta:
-                    for k, v in params_buffers_to_node_meta[buffer_name].items():
-                        node.meta[k] = v
-
-    is_joint = graph_signature.backward_signature is not None
-
-    def make_argument_spec(node) -> ArgumentSpec:
-        assert "val" in node.meta, f"{node} has no 'val' metadata field"
-        val = node.meta["val"]
-        if isinstance(val, FakeTensor):
-            return TensorArgument(name=node.name)
-        elif isinstance(val, torch.SymInt):
-            return SymIntArgument(name=node.name)
-        else:
-            return ConstantArgument(value=val)
-    input_specs, output_specs = _sig_to_specs(
-        user_inputs=set(graph_signature.user_inputs),
-        inputs_to_parameters=graph_signature.inputs_to_parameters,  # type: ignore[arg-type]
-        inputs_to_buffers=graph_signature.inputs_to_buffers,  # type: ignore[arg-type]
-        user_outputs=set(graph_signature.user_outputs),  # type: ignore[arg-type]
-        buffer_mutations=graph_signature.buffers_to_mutate,  # type: ignore[arg-type]
-        user_input_mutations=user_inputs_to_mutate,  # type: ignore[arg-type]
-        grad_params=graph_signature.backward_signature.gradients_to_parameters if is_joint else {},  # type: ignore[arg-type, union-attr]
-        grad_user_inputs=graph_signature.backward_signature.gradients_to_user_inputs if is_joint else {},  # type: ignore[arg-type, union-attr]
-        loss_output=graph_signature.backward_signature.loss_output if is_joint else None,  # type: ignore[arg-type, union-attr]
-        inputs=[make_argument_spec(node) for node in gm.graph.nodes if node.op == "placeholder"],
-        outputs=[make_argument_spec(node) for node in pytree.tree_leaves(next(iter(reversed(gm.graph.nodes))).args)],
+    num_lifted = next(
+        (i for i, s in enumerate(export_graph_signature.input_specs) if s.kind == InputKind.USER_INPUT), 0
     )
-    export_graph_signature = ExportGraphSignature(input_specs=input_specs, output_specs=output_specs)
-    num_params_buffers = len(graph_signature.parameters) + len(graph_signature.buffers)
-
+    flat_args, orig_in_spec = pytree.tree_flatten((args, kwargs))
     range_constraints, equality_constraints = _process_constraints(
         gm,
-        num_params_buffers,
+        num_lifted,
         flat_args,
     )
 
@@ -893,8 +985,6 @@ def _export(
         gm = res.graph_module
 
     assert orig_out_spec is not None
-    tensor_constants = lift_constant_tensor_pass(gm, export_graph_signature, params_buffers)
-    _replace_sym_size_ops_pass(gm)
     exported_program = ExportedProgram(
         gm,
         gm.graph,
@@ -922,7 +1012,7 @@ def _reorder_kwargs_by_names(arg_names: List[str], args: Tuple[Any], kwargs: Dic
         f"Total number of arg names is expected to be {len(arg_names)} "
         f"but got {len(args)} positional args, {len(kwargs)} kwargs."
     )
-    return OrderedDict({kw_name: kwargs[kw_name] for kw_name in arg_names[len(args):]})
+    return {kw_name: kwargs[kw_name] for kw_name in arg_names[len(args):]}
 
 
 def save(

--- a/torch/_export/exported_program.py
+++ b/torch/_export/exported_program.py
@@ -84,7 +84,7 @@ def _unlift(gm, inp_pos_to_param_buffer_name, in_spec, out_spec, state_dict, ten
                     assert buffer_node_name in buffer_name_to_node
                     buffer_node = buffer_name_to_node[buffer_node_name]
                     with gm.graph.inserting_before(node):
-                        buffer_update_node = gm.graph.call_function(
+                        gm.graph.call_function(
                             torch.ops.aten.copy_.default, (buffer_node, return_node)
                         )
                 else:

--- a/torch/_export/passes/lift_constant_tensor_pass.py
+++ b/torch/_export/passes/lift_constant_tensor_pass.py
@@ -5,9 +5,7 @@ from torch._guards import detect_fake_mode
 from torch.export.exported_program import InputKind, InputSpec, TensorArgument
 
 
-def lift_constant_tensor_pass(
-    gm, graph_signature, state_dict
-) -> Dict[str, torch.Tensor]:
+def lift_constant_tensor_pass(gm, graph_signature) -> Dict[str, torch.Tensor]:
     """
     Takes an ExportedProgram and returns the ExportedProgram modified in-place,
     with the constant tensors as buffers.

--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -349,6 +349,7 @@ def export(
     *,
     constraints: Optional[List[Constraint]] = None,
     dynamic_shapes: Optional[Union[Dict[str, Any], Tuple[Any]]] = None,
+    strict: bool = True,
     preserve_module_call_signature: Tuple[str, ...] = (),
 ) -> ExportedProgram:
     """
@@ -421,6 +422,16 @@ def export(
          are denoted by None. Arguments that are dicts or tuples / lists of tensors are
          recursively specified by using mappings or sequences of contained specifications.
 
+        strict: When enabled (default), the export function will trace the program through
+         TorchDynamo which will ensure the soundness of the resulting graph. Otherwise, the
+         exported program will not validate the implicit assumptions baked into the graph and
+         may cause behavior divergence between the original model and the exported one. This is
+         useful when users need to workaround bugs in the tracer, or simply want incrementally
+         enable safety in their models. Note that this does not affect the resulting IR spec
+         to be different and the model will be serialized in the same way regardless of what value
+         is passed here.
+         WARNING: This option is experimental and use this at your own risk.
+
     Returns:
         An :class:`ExportedProgram` containing the traced callable.
 
@@ -443,6 +454,7 @@ def export(
             args,
             kwargs,
             constraints,
+            strict=strict,
             preserve_module_call_signature=preserve_module_call_signature,
         )
     else:
@@ -451,6 +463,7 @@ def export(
             args,
             kwargs,
             dynamic_shapes=dynamic_shapes,
+            strict=strict,
             preserve_module_call_signature=preserve_module_call_signature,
         )
 

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -467,7 +467,7 @@ class ExportedProgram:
         ]
 
         state_dict = self.state_dict.copy()
-        lift_constant_tensor_pass(gm, new_graph_signature, state_dict)
+        lift_constant_tensor_pass(gm, new_graph_signature)
         _replace_sym_size_ops_pass(gm)
         exported_program = ExportedProgram(
             gm,


### PR DESCRIPTION
Summary: Refactor torch.export to separate strict part and non strict part. Adding an option to torch.export called `strict=True`.

Test Plan: buck2 test mode/opt caffe2/test:test_export -- -r non_strict




cc @avikchaudhuri @gmagogsfm @tugsbayasgalan @angelayi @suo @ydwu4