### PR TITLE
Remove unused call to `inspect.stack()` in torch/_custom_op/impl.py

### DIFF
--- a/torch/_custom_op/impl.py
+++ b/torch/_custom_op/impl.py
@@ -409,7 +409,6 @@ class CustomOp:
         """
 
         def inner(f):
-            frame = inspect.stack()[1]
             self._check_doesnt_have_library_meta_impl()
             self._register_impl("abstract", f, stacklevel=_stacklevel)
             location = self._get_impl("abstract").location


### PR DESCRIPTION
Summary: Fetching the stack isn't free and this variable isn't used. Let's not do the work.

Test Plan: Wait for tests

Differential Revision: D51629732


