### PR TITLE
Optimize `inspect.stack()` call in caffe2/torch/library.py

### DIFF
--- a/torch/library.py
+++ b/torch/library.py
@@ -6,6 +6,7 @@ import weakref
 import functools
 import inspect
 import re
+import sys
 
 __all__ = [
     'Library',
@@ -418,8 +419,8 @@ def impl_abstract(qualname, func=None, *, lib=None, _stacklevel=1):
 
     """
     source = torch._library.utils.get_source(_stacklevel + 1)
-    frame = inspect.stack()[_stacklevel]
-    caller_module = inspect.getmodule(frame[0])
+    frame = sys._getframe(_stacklevel)
+    caller_module = inspect.getmodule(frame)
     # Can be none if you call impl_abstract from somewhere there isn't a module
     # (e.g. __main__)
     caller_module_name = None if caller_module is None else caller_module.__name__


### PR DESCRIPTION
Summary: Same optimization as https://github.com/pytorch/pytorch/pull/105940.

Test Plan:
Wait for tests

Verify that the new code extracts the same module in a simple test case:
```
import inspect
import sys

def inside_frame() -> None:
    frame = inspect.stack()[0]
    print(f"Via inspect.stack(): {inspect.getmodule(frame[0])}, extracted frame = {frame[0]}")

    frame = sys._getframe(0)
    print(f"Via sys._getframe: {inspect.getmodule(frame)}, extracted frame = {frame}")

if __name__ == "__main__":
    inside_frame()
```

Output:
```
[jsd115@devbig1161 /tmp/test]$ python3 ./getmodule.py
Via inspect.stack(): <module '__main__' from './getmodule.py'>, extracted frame = <frame at 0x7fc9db9c4dd0, file './getmodule.py', line 6, code inside_frame>
Via sys._getframe: <module '__main__' from './getmodule.py'>, extracted frame = <frame at 0x7fc9db9c4dd0, file './getmodule.py', line 9, code inside_frame>
```

Differential Revision: D51629733


