### PR TITLE
Bring docstring to .pyi file

### DIFF
--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -606,11 +606,10 @@ def gather_docstrs() -> Dict[str, str]:
 
 
 def add_docstr_to_hint(docstr: str, hint: str) -> str:
+    docstr = docstr.strip().replace("\ ", " ").replace("\\", "\\\\")
     if "..." in hint:  # function or method
         assert hint.endswith("...")
-        return "\n    ".join(
-            [hint[:-3], 'r"""'] + docstr.strip().split("\n") + ['"""', "..."]
-        )
+        return "\n    ".join([hint[:-3], '"""'] + docstr.split("\n") + ['"""', "..."])
     else:  # attribute or property
         return f'{hint}\n"""{docstr}"""\n'
 

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -1,6 +1,8 @@
 import argparse
 import collections
+import importlib
 import sys
+
 from pprint import pformat
 from typing import Dict, List, Sequence
 from unittest.mock import Mock, patch
@@ -585,7 +587,7 @@ def gen_nn_functional(fm: FileManager) -> None:
 def generate_docstrings() -> Dict[str, str]:
     docstrings = {}
 
-    def mock_add_docstr(func, docstr):
+    def mock_add_docstr(func: Mock, docstr: str) -> None:
         docstrings[func._extract_mock_name()] = docstr
 
     with patch.dict(
@@ -595,8 +597,8 @@ def generate_docstrings() -> Dict[str, str]:
             "torch._C": Mock(_add_docstr=mock_add_docstr),
         },
     ):
-        sys.path.append("torch")  # bypassing torch/__init__.py
-        import _torch_docs
+        sys.path.append("torch")
+        importlib.import_module(name="_torch_docs", package="torch")
 
     return docstrings
 
@@ -1005,7 +1007,7 @@ def gen_pyi(
             if docstr is not None:
                 l, r = hint.rsplit("...", 1)
                 hint = "\n    ".join(
-                    [l, '"""'] + docstr.strip().split("\n") + ['"""', "...", r]
+                    [l, 'r"""'] + docstr.strip().split("\n") + ['"""', "...", r]
                 )
             new_hints.append(hint)
         function_hints += new_hints

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -596,9 +596,9 @@ def gather_docstrs() -> Dict[str, str]:
     }
     with patch.dict(sys.modules, patch_dict):
         sys.path.append("torch")  # allows submodules of `torch` to be imported
-        _torch_docs = importlib.import_module(name="_torch_docs", package="torch")
+        _torch_docs = importlib.import_module("_torch_docs")
         with patch.dict(sys.modules, {"torch._torch_docs": _torch_docs}):
-            importlib.import_module(name="_tensor_docs", package="torch")
+            importlib.import_module("_tensor_docs")
     return docstrs
 
 

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -615,7 +615,7 @@ def gather_docstrs() -> Dict[str, str]:
 def add_docstr_to_hint(docstr: str, hint: str) -> str:
     if "..." in hint:  # function or method
         assert hint.endswith("..."), f"Hint `{hint}` does not end with '...'"
-        hint = hint.rstrip("...")
+        hint = hint[:-3]  # remove "..."
         return "\n    ".join([hint, 'r"""'] + docstr.split("\n") + ['"""', "..."])
     else:  # attribute or property
         return f'{hint}\nr"""{docstr}"""\n'

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -588,7 +588,7 @@ def gather_docstrs() -> Dict[str, str]:
     docstrs = {}
 
     def mock_add_docstr(func: Mock, docstr: str) -> None:
-        docstrs[func._extract_mock_name()] = docstr
+        docstrs[func._extract_mock_name()] = docstr.strip()
 
     sys.path.append("torch")
     patch_dict = {
@@ -606,12 +606,11 @@ def gather_docstrs() -> Dict[str, str]:
 
 
 def add_docstr_to_hint(docstr: str, hint: str) -> str:
-    docstr = docstr.strip().replace("\ ", " ").replace("\\", "\\\\")
     if "..." in hint:  # function or method
-        assert hint.endswith("...")
-        return "\n    ".join([hint[:-3], '"""'] + docstr.split("\n") + ['"""', "..."])
+        assert hint.endswith("..."), f"Hint `{hint}` does not end with '...'"
+        return "\n    ".join([hint[:-3], 'r"""'] + docstr.split("\n") + ['"""', "..."])
     else:  # attribute or property
-        return f'{hint}\n"""{docstr}"""\n'
+        return f'{hint}\nr"""{docstr}"""\n'
 
 
 def gen_pyi(

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -590,11 +590,10 @@ def gather_docstrs() -> Dict[str, str]:
     def mock_add_docstr(func: Mock, docstr: str) -> None:
         docstrs[func._extract_mock_name()] = docstr.strip()
 
-    patch_dict = {
-        "torch": Mock(name="torch"),
-        "torch._C": Mock(_add_docstr=mock_add_docstr),
-    }
-    with patch.dict(sys.modules, patch_dict):
+    with patch.dict(
+        sys.modules,
+        {"torch": Mock(name="torch"), "torch._C": Mock(_add_docstr=mock_add_docstr)},
+    ):
         sys.path.append("torch")  # allows submodules of `torch` to be imported
         _torch_docs = importlib.import_module("_torch_docs")
         with patch.dict(sys.modules, {"torch._torch_docs": _torch_docs}):

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -590,18 +590,15 @@ def gather_docstrs() -> Dict[str, str]:
     def mock_add_docstr(func: Mock, docstr: str) -> None:
         docstrs[func._extract_mock_name()] = docstr.strip()
 
-    sys.path.append("torch")
     patch_dict = {
         "torch": Mock(name="torch"),
         "torch._C": Mock(_add_docstr=mock_add_docstr),
     }
-
     with patch.dict(sys.modules, patch_dict):
+        sys.path.append("torch")  # allows submodules of `torch` to be imported
         _torch_docs = importlib.import_module(name="_torch_docs", package="torch")
-        patch_dict["torch._torch_docs"] = _torch_docs
-        with patch.dict(sys.modules, patch_dict):
+        with patch.dict(sys.modules, {"torch._torch_docs": _torch_docs}):
             importlib.import_module(name="_tensor_docs", package="torch")
-
     return docstrs
 
 

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2,7 +2,7 @@
 
 import torch._C
 from torch._C import _add_docstr as add_docstr
-from ._torch_docs import parse_kwargs, reproducibility_notes
+from torch._torch_docs import parse_kwargs, reproducibility_notes
 
 
 def add_docstr_all(method, docstr):

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -11104,7 +11104,7 @@ always be real-valued, even if :attr:`input` is complex.
 .. warning:: If the distance between any two singular values is close to zero, the gradients with respect to
              `U` and `V` will be numerically unstable, as they depends on
              :math:`\frac{1}{\min_{i \neq j} \sigma_i^2 - \sigma_j^2}`. The same happens when the matrix
-             has small singular values, as these gradients also depend on `S⁻¹`.
+             has small singular values, as these gradients also depend on `S^{-1}`.
 
 .. warning:: For complex-valued :attr:`input` the singular value decomposition is not unique,
              as `U` and `V` may be multiplied by an arbitrary phase factor :math:`e^{i \phi}` on every column.


### PR DESCRIPTION
Fixes #37762

Since the original issue hasn't been making progress for more than 3 years, I am attempting to make this PR to at least make some progress forward. 

This PR attempts to add docstring to the `.pyi` files. The docstrings are read from [`_torch_docs`](https://github.com/pytorch/pytorch/blob/main/torch/_torch_docs.py) by mocking [`_add_docstr`](https://github.com/pytorch/pytorch/blob/9f073ae304263f13168a661a0608149a2eb5b8cc/torch/csrc/Module.cpp#L329), which is the only function used to add docstring.

Luckily, `_torch_docs` has no dependencies for other components of PyTorch, and can be imported without compiling `torch._C` with `_add_docstr` mocked. 

The generated `.pyi` file looks something like the following: 

[_VariableFunctions.pyi.txt](https://github.com/pytorch/pytorch/files/13494263/_VariableFunctions.pyi.txt)


<img width="787" alt="image" src="https://github.com/pytorch/pytorch/assets/6421097/73c2e884-f06b-4529-8301-0ca0b9de173c">

And the docstring can be picked up by VSCode:

<img width="839" alt="image" src="https://github.com/pytorch/pytorch/assets/6421097/1999dc89-a591-4c7a-80ac-aa3456672af4">

<img width="908" alt="image" src="https://github.com/pytorch/pytorch/assets/6421097/ecf3fa92-9822-4a3d-9263-d224d87ac288">

