### PR TITLE
[CUDNN] Add an option to force cuDNN usage

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -40,6 +40,17 @@ void Context::setUserEnabledCuDNN(bool e) {
   enabled_cudnn = e;
 }
 
+// NB: This method forces cuDNN to be used if it is enabled, even if the
+// requested operation will error out (useful for functionality and performance
+// testing)
+bool Context::userForceCuDNN() const {
+  return force_cudnn;
+}
+
+void Context::setUserForceCuDNN(bool f) {
+  force_cudnn = f;
+}
+
 bool Context::userEnabledMkldnn() const {
   return enabled_mkldnn;
 }

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -180,6 +180,11 @@ class TORCH_API Context {
   // to test this instead
   bool userEnabledCuDNN() const;
   void setUserEnabledCuDNN(bool e);
+  // NB: This method forces cuDNN to be used if it is enabled, even if the
+  // requested operation will error out (useful for functionality and
+  // performance testing)
+  bool userForceCuDNN() const;
+  void setUserForceCuDNN(bool f);
   bool userEnabledMkldnn() const;
   void setUserEnabledMkldnn(bool e);
   bool benchmarkCuDNN() const;
@@ -357,6 +362,7 @@ class TORCH_API Context {
   c10::once_flag th_mtia_init;
   c10::once_flag thp_init;
   bool enabled_cudnn = true;
+  bool force_cudnn = false;
   bool deterministic_cudnn = false;
   bool _deterministic_algorithms = false;
   bool _deterministic_algorithms_warn_only = false;

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -422,6 +422,9 @@ struct ConvParams {
   // cudnn and miopen are guaranteed not to be on mobile, and T102591915 / T110194934 suggest
   // that maybe the compiledWithCuDNN() check sometimes segfaults (though I can't imagine how)
 #if !defined(C10_MOBILE)
+    if (at::globalContext().userForceCuDNN()) {
+      return true;
+    }
     if (needs_64bit_indexing_no_split(input, weight)) {
       return false;
     }

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -492,7 +492,7 @@ BatchNormBackend _select_batch_norm_backend(
   bool cudnn_enabled = ctx.userEnabledCuDNN();
 
   if (
-      input.is_cuda() 
+      input.is_cuda()
       && (at::globalContext().userForceCuDNN() ||
       (input.scalar_type() != at::kBFloat16 && weight.scalar_type() != at::kBFloat16
       && (input.scalar_type() != at::kHalf

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -492,8 +492,9 @@ BatchNormBackend _select_batch_norm_backend(
   bool cudnn_enabled = ctx.userEnabledCuDNN();
 
   if (
-      input.is_cuda()
-      && input.scalar_type() != at::kBFloat16 && weight.scalar_type() != at::kBFloat16
+      input.is_cuda() 
+      && (at::globalContext().userForceCuDNN() ||
+      (input.scalar_type() != at::kBFloat16 && weight.scalar_type() != at::kBFloat16
       && (input.scalar_type() != at::kHalf
         || weight.scalar_type() == at::kFloat)
       && weight.defined() && bias.defined()
@@ -505,7 +506,7 @@ BatchNormBackend _select_batch_norm_backend(
       && detail::getCUDAHooks().compiledWithCuDNN()
       && eps >= detail::getCUDAHooks().batchnormMinEpsilonCuDNN()
       && cudnn_enabled && detail::getCUDAHooks().versionCuDNN() >= 5110L
-      && input.sym_numel() < std::numeric_limits<std::int32_t>::max() // some cuDNN kernels have 32-bit indexing limitations
+      && input.sym_numel() < std::numeric_limits<std::int32_t>::max())) // some cuDNN kernels have 32-bit indexing limitations
   ) {
     return BatchNormBackend::Cudnn;
   }

--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -89,7 +89,7 @@ bool _use_cudnn_ctc_loss(
   auto& ctx = at::globalContext();
 
   bool use_cudnn =
-      (log_probs.device().type() == at::kCUDA) && (ctx.userForceCuDNN() || 
+      (log_probs.device().type() == at::kCUDA) && (ctx.userForceCuDNN() ||
       (ctx.userEnabledCuDNN() && ((BLANK == 0) &&
       (targets.dim() == 1) && (log_probs.scalar_type() == at::kFloat) &&
       (targets.scalar_type() == at::kInt) &&

--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -88,6 +88,7 @@ bool _use_cudnn_ctc_loss(
     int64_t BLANK) {
   auto& ctx = at::globalContext();
 
+<<<<<<< HEAD
   bool use_cudnn =
       (log_probs.device().type() == at::kCUDA) && (ctx.userForceCuDNN() || 
       (ctx.userEnabledCuDNN() && ((BLANK == 0) &&
@@ -95,6 +96,12 @@ bool _use_cudnn_ctc_loss(
       (targets.scalar_type() == at::kInt) &&
       (targets.device().type() == at::kCPU) && (targets.is_contiguous()) &&
       (log_probs.dim() == 3))));
+=======
+  bool use_cudnn = ctx.userEnabledCuDNN() && (((BLANK == 0) &&
+      (targets.dim() == 1) && (log_probs.scalar_type() == at::kFloat) &&
+      (targets.scalar_type() == at::kInt)) || ctx.userForceCuDNN()) &&
+      (log_probs.device().type() == at::kCUDA);
+>>>>>>> aa4d7cd7c3e (clarify condition ordering)
 
   if (use_cudnn) {
     // we don't know that input_lengths and target_lengths have the same size

--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -88,12 +88,13 @@ bool _use_cudnn_ctc_loss(
     int64_t BLANK) {
   auto& ctx = at::globalContext();
 
-  bool use_cudnn = ctx.userEnabledCuDNN() && (BLANK == 0) &&
+  bool use_cudnn =
+      (log_probs.device().type() == at::kCUDA) && (ctx.userForceCuDNN() || 
+      (ctx.userEnabledCuDNN() && ((BLANK == 0) &&
       (targets.dim() == 1) && (log_probs.scalar_type() == at::kFloat) &&
       (targets.scalar_type() == at::kInt) &&
-      (log_probs.device().type() == at::kCUDA) &&
       (targets.device().type() == at::kCPU) && (targets.is_contiguous()) &&
-      (log_probs.dim() == 3);
+      (log_probs.dim() == 3))));
 
   if (use_cudnn) {
     // we don't know that input_lengths and target_lengths have the same size

--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -88,7 +88,6 @@ bool _use_cudnn_ctc_loss(
     int64_t BLANK) {
   auto& ctx = at::globalContext();
 
-<<<<<<< HEAD
   bool use_cudnn =
       (log_probs.device().type() == at::kCUDA) && (ctx.userForceCuDNN() || 
       (ctx.userEnabledCuDNN() && ((BLANK == 0) &&
@@ -96,12 +95,6 @@ bool _use_cudnn_ctc_loss(
       (targets.scalar_type() == at::kInt) &&
       (targets.device().type() == at::kCPU) && (targets.is_contiguous()) &&
       (log_probs.dim() == 3))));
-=======
-  bool use_cudnn = ctx.userEnabledCuDNN() && (((BLANK == 0) &&
-      (targets.dim() == 1) && (log_probs.scalar_type() == at::kFloat) &&
-      (targets.scalar_type() == at::kInt)) || ctx.userForceCuDNN()) &&
-      (log_probs.device().type() == at::kCUDA);
->>>>>>> aa4d7cd7c3e (clarify condition ordering)
 
   if (use_cudnn) {
     // we don't know that input_lengths and target_lengths have the same size

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -464,6 +464,29 @@ class TestCuda(TestCase):
         ):
             self.assertTrue(torch.backends.cudnn.allow_tf32)
 
+    def test_force_cudnn_conv(self):
+        # hack to workaround cuBLAS handles causing an edge case OOM if
+        # no handle was present before the first call
+        dummy = torch.randn(512, 512, dtype=torch.half, device='cuda')
+        torch.matmul(dummy, dummy)
+        # same for cuDNN
+        dummy = torch.randn(1, 1, 1, 1, dtype = torch.half, device='cuda')
+        torch.nn.functional.conv2d(dummy, dummy)
+
+        x = torch.randn(1, 3, 512, 512, 512, dtype=torch.half, device='cuda')
+        w = torch.randn(64, 3, 3, 3, 3, dtype=torch.half, device='cuda')
+        try:
+            with torch.backends.cudnn.flags(enabled=True, force=False):
+                o = torch.nn.functional.conv3d(x, w)
+        except RuntimeError as e:
+            self.assertTrue('CUDNN' not in str(e))
+        try:
+            with torch.backends.cudnn.flags(enabled=True, force=True):
+                o = torch.nn.functional.conv3d(x, w)
+        except RuntimeError as e:
+            self.assertTrue('CUDNN' in str(e))
+
+
     def test_type_conversions(self):
         x = torch.randn(5, 5)
         self.assertIsInstance(x.float(), torch.FloatTensor)

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1133,6 +1133,8 @@ def set_num_interop_threads(
 ) -> None: ...  # THPModule_setNumInteropThreads
 def _get_cudnn_enabled() -> _bool: ...  # THPModule_userEnabledCuDNN
 def _set_cudnn_enabled(arg: _bool) -> None: ...  # THPModule_setUserEnabledCuDNN
+def _get_force_cudnn() -> _bool: ...  # THPModule_userForceCuDNN
+def _set_force_cudnn(arg: _bool) -> None: ...  # THPModule_setUserForceCuDNN
 def _get_flash_sdp_enabled() -> _bool: ...  # THPModule_userEnabledFusedSDP
 def _set_sdp_use_flash(arg: _bool) -> None: ...  # THPModule_setSDPUseFlash
 def _get_mem_efficient_sdp_enabled() -> _bool: ...  # THPModule_userEnabledMathSDP

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -122,6 +122,7 @@ def is_acceptable(tensor):
 
 def set_flags(
     _enabled=None,
+    _force=None,
     _benchmark=None,
     _benchmark_limit=None,
     _deterministic=None,
@@ -129,6 +130,7 @@ def set_flags(
 ):
     orig_flags = (
         torch._C._get_cudnn_enabled(),
+        torch._C._get_force_cudnn(),
         torch._C._get_cudnn_benchmark(),
         None if not is_available() else torch._C._cuda_get_cudnn_benchmark_limit(),
         torch._C._get_cudnn_deterministic(),
@@ -136,6 +138,8 @@ def set_flags(
     )
     if _enabled is not None:
         torch._C._set_cudnn_enabled(_enabled)
+    if _force is not None:
+        torch._C._set_force_cudnn(_force)
     if _benchmark is not None:
         torch._C._set_cudnn_benchmark(_benchmark)
     if _benchmark_limit is not None and is_available():
@@ -150,6 +154,7 @@ def set_flags(
 @contextmanager
 def flags(
     enabled=False,
+    force=False,
     benchmark=False,
     benchmark_limit=10,
     deterministic=False,
@@ -157,7 +162,7 @@ def flags(
 ):
     with __allow_nonbracketed_mutation():
         orig_flags = set_flags(
-            enabled, benchmark, benchmark_limit, deterministic, allow_tf32
+            enabled, force, benchmark, benchmark_limit, deterministic, allow_tf32
         )
     try:
         yield
@@ -177,6 +182,7 @@ class CudnnModule(PropModule):
         super().__init__(m, name)
 
     enabled = ContextProp(torch._C._get_cudnn_enabled, torch._C._set_cudnn_enabled)
+    force = ContextProp(torch._C._get_force_cudnn, torch._C._set_force_cudnn)
     deterministic = ContextProp(
         torch._C._get_cudnn_deterministic, torch._C._set_cudnn_deterministic
     )
@@ -200,6 +206,7 @@ sys.modules[__name__] = CudnnModule(sys.modules[__name__], __name__)
 
 # Add type annotation for the replaced module
 enabled: bool
+force: bool
 deterministic: bool
 benchmark: bool
 allow_tf32: bool

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -785,7 +785,7 @@ PyObject* THPModule_userEnabledCuDNN(PyObject* _unused, PyObject* noargs) {
 }
 
 PyObject* THPModule_setUserForceCuDNN(PyObject* _unused, PyObject* arg) {
-  THPUtils_assert(
+  TORCH_CHECK(
       PyBool_Check(arg),
       "set_force_cudnn expects a bool, "
       "but got %s",

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -784,6 +784,23 @@ PyObject* THPModule_userEnabledCuDNN(PyObject* _unused, PyObject* noargs) {
     Py_RETURN_FALSE;
 }
 
+PyObject* THPModule_setUserForceCuDNN(PyObject* _unused, PyObject* arg) {
+  THPUtils_assert(
+      PyBool_Check(arg),
+      "set_force_cudnn expects a bool, "
+      "but got %s",
+      THPUtils_typename(arg));
+  at::globalContext().setUserForceCuDNN(arg == Py_True);
+  Py_RETURN_NONE;
+}
+
+PyObject* THPModule_userForceCuDNN(PyObject* _unused, PyObject* noargs) {
+  if (at::globalContext().userForceCuDNN())
+    Py_RETURN_TRUE;
+  else
+    Py_RETURN_FALSE;
+}
+
 PyObject* THPModule_setUserEnabledMkldnn(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
@@ -1340,6 +1357,8 @@ static PyMethodDef TorchMethods[] = { // NOLINT
     {"_set_sdp_use_cudnn", THPModule_setSDPUseCuDNN, METH_O, nullptr},
     {"_get_cudnn_enabled", THPModule_userEnabledCuDNN, METH_NOARGS, nullptr},
     {"_set_cudnn_enabled", THPModule_setUserEnabledCuDNN, METH_O, nullptr},
+    {"_get_force_cudnn", THPModule_userForceCuDNN, METH_NOARGS, nullptr},
+    {"_set_force_cudnn", THPModule_setUserForceCuDNN, METH_O, nullptr},
     {"_get_mkldnn_enabled", THPModule_userEnabledMkldnn, METH_NOARGS, nullptr},
     {"_set_mkldnn_enabled", THPModule_setUserEnabledMkldnn, METH_O, nullptr},
     {"_get_cudnn_allow_tf32", THPModule_allowTF32CuDNN, METH_NOARGS, nullptr},


### PR DESCRIPTION
We've accumulated a variety of magic number shape checks for deciding whether to dispatch to cuDNN (especially e.g., for depthwise convolutions), and these may be out-of-date with newer cuDNN versions, device architectures, etc. This PR adds "force cuDNN" as a way to force dispatching to cuDNN for functionality and perf. testing purposes without rebuilding PyTorch.

cc @csarofeen @ptrblck @xwang233 @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10