### PR TITLE
[BE][RelEng] Remove `dynamo` extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1040,50 +1040,6 @@ def configure_extension_build():
     return extensions, cmdclass, packages, entry_points, extra_install_requires
 
 
-def add_triton(install_requires, extras_require) -> None:
-    """
-    Add triton package as a dependency when it's needed
-    """
-    # NB: If the installation requirments list already includes triton dependency,
-    # there is no need to add it one more time as an extra dependency. In nightly
-    # or when release PyTorch, that is done by setting PYTORCH_EXTRA_INSTALL_REQUIREMENTS
-    # environment variable on pytorch/builder
-    has_triton = any("triton" in pkg for pkg in install_requires)
-    if has_triton:
-        return
-
-    cmake_cache_vars = get_cmake_cache_vars()
-    use_rocm = cmake_cache_vars["USE_ROCM"]
-    use_cuda = cmake_cache_vars["USE_CUDA"]
-
-    # Triton is only needed for CUDA or ROCm
-    if not use_rocm and not use_cuda:
-        return
-
-    if use_rocm:
-        triton_text_file = "triton-rocm.txt"
-        triton_package_name = "pytorch-triton-rocm"
-    else:
-        triton_text_file = "triton.txt"
-        triton_package_name = "pytorch-triton"
-    triton_pin_file = os.path.join(
-        cwd, ".ci", "docker", "ci_commit_pins", triton_text_file
-    )
-    triton_version_file = os.path.join(cwd, ".ci", "docker", "triton_version.txt")
-
-    if os.path.exists(triton_pin_file) and os.path.exists(triton_version_file):
-        with open(triton_pin_file) as f:
-            triton_pin = f.read().strip()
-        with open(triton_version_file) as f:
-            triton_version = f.read().strip()
-
-        if "dynamo" not in extras_require:
-            extras_require["dynamo"] = []
-        extras_require["dynamo"].append(
-            triton_package_name + "==" + triton_version + "+" + triton_pin[:10]
-        )
-
-
 # post run, warnings, printed at the end to make them more visible
 build_update_message = """
     It is no longer necessary to use the 'build' or 'rebuild' targets
@@ -1146,10 +1102,6 @@ def main():
         "optree": ["optree>=0.9.1"],
         "opt-einsum": ["opt-einsum>=3.3"],
     }
-    # Triton is only available on Linux atm
-    if platform.system() == "Linux":
-        extras_require["dynamo"] = ["jinja2"]
-        add_triton(install_requires=install_requires, extras_require=extras_require)
 
     # Read in README.md for our long_description
     with open(os.path.join(cwd, "README.md"), encoding="utf-8") as f:


### PR DESCRIPTION
As all dynamo dependencies are part of the default requirements, see
```
% curl -s https://pypi.org/pypi/torch/2.1.1/json | jq '.info.requires_dist'
[
  "filelock",
  "typing-extensions",
  "sympy",
  "networkx",
  "jinja2",
  "fsspec",
  "nvidia-cuda-nvrtc-cu12 (==12.1.105) ; platform_system == \"Linux\" and platform_machine == \"x86_64\"",
  "nvidia-cuda-runtime-cu12 (==12.1.105) ; platform_system == \"Linux\" and platform_machine == \"x86_64\"",
  "nvidia-cuda-cupti-cu12 (==12.1.105) ; platform_system == \"Linux\" and platform_machine == \"x86_64\"",
  "nvidia-cudnn-cu12 (==8.9.2.26) ; platform_system == \"Linux\" and platform_machine == \"x86_64\"",
  "nvidia-cublas-cu12 (==12.1.3.1) ; platform_system == \"Linux\" and platform_machine == \"x86_64\"",
  "nvidia-cufft-cu12 (==11.0.2.54) ; platform_system == \"Linux\" and platform_machine == \"x86_64\"",
  "nvidia-curand-cu12 (==10.3.2.106) ; platform_system == \"Linux\" and platform_machine == \"x86_64\"",
  "nvidia-cusolver-cu12 (==11.4.5.107) ; platform_system == \"Linux\" and platform_machine == \"x86_64\"",
  "nvidia-cusparse-cu12 (==12.1.0.106) ; platform_system == \"Linux\" and platform_machine == \"x86_64\"",
  "nvidia-nccl-cu12 (==2.18.1) ; platform_system == \"Linux\" and platform_machine == \"x86_64\"",
  "nvidia-nvtx-cu12 (==12.1.105) ; platform_system == \"Linux\" and platform_machine == \"x86_64\"",
  "triton (==2.1.0) ; platform_system == \"Linux\" and platform_machine == \"x86_64\"",
  "jinja2 ; extra == 'dynamo'",
  "opt-einsum (>=3.3) ; extra == 'opt-einsum'"
]
```
