### PR TITLE
[easy][aotinductor] fix typos & add static typing

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -9,9 +9,9 @@ from itertools import chain, count
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import sympy
-from sympy import Expr
 
 import torch
+from sympy import Expr
 from torch._dynamo.utils import counters, dynamo_timed
 from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols, SymTypes
 
@@ -70,7 +70,7 @@ def is_float(s: str):
     return True
 
 
-def convert_arg_type(python_type):
+def convert_arg_type(python_type: str):
     from .cpp import CONTAINER_PYTHON_TO_CPP, PYTHON_TO_CPP
 
     if python_type == "Tensor":
@@ -94,7 +94,7 @@ def convert_arg_type(python_type):
     raise AssertionError(f"unsupport python_type: {python_type}")
 
 
-def convert_return_type(python_type):
+def convert_return_type(python_type: str):
     # TODO: support alias
     python_to_cpp = {
         "Tensor": "at::Tensor",
@@ -112,12 +112,12 @@ def get_cpp_op_schema(kernel):
     arg_names = [x.name for x in kernel._schema.arguments]
     returns = [repr(x.real_type) for x in kernel._schema.returns]
 
-    num_retunrs = len(returns)
-    assert num_retunrs > 0, "must have at least one return value"
+    num_returns = len(returns)
+    assert num_returns > 0, "must have at least one return value"
 
-    if num_retunrs == 1:
+    if num_returns == 1:
         cpp_return_value = convert_return_type(returns[0])
-    elif num_retunrs > 1:
+    elif num_returns > 1:
         tuple_returns = ", ".join([convert_return_type(r) for r in returns])
         cpp_return_value = f"std::tuple<{tuple_returns}>"
 

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -9,9 +9,9 @@ from itertools import chain, count
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import sympy
+from sympy import Expr
 
 import torch
-from sympy import Expr
 from torch._dynamo.utils import counters, dynamo_timed
 from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols, SymTypes
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4282,9 +4282,9 @@ class FallbackKernel(ExternKernelAlloc):
         ), f"{kernel.__name__} with alias_info returns is not supported with cpp_wrapper"
 
         self.cpp_kernel = kernel._schema.name
-        self.cpp_kernel_overlad_name = kernel._schema.overload_name
+        self.cpp_kernel_overload_name = kernel._schema.overload_name
         self.cpp_kernel_key = (
-            f"{self.cpp_kernel.replace('::', '_')}_{self.cpp_kernel_overlad_name}"
+            f"{self.cpp_kernel.replace('::', '_')}_{self.cpp_kernel_overload_name}"
         )
 
         self.cpp_op_schema = get_cpp_op_schema(kernel)
@@ -4513,7 +4513,7 @@ class FallbackKernel(ExternKernelAlloc):
                 args,
                 self.cpp_op_schema,
                 self.cpp_kernel_key,
-                self.cpp_kernel_overlad_name,
+                self.cpp_kernel_overload_name,
                 self.op_overload,
                 exported_args,
                 self.outputs,
@@ -4990,7 +4990,7 @@ class ConvolutionBinary(ExternKernelAlloc):
             kernel="torch.ops.mkldnn._convolution_pointwise.binary",
             cpp_kernel="mkldnn::_convolution_pointwise",
         )
-        self.cpp_kernel_overlad_name = "binary"
+        self.cpp_kernel_overload_name = "binary"
         self.cpp_kernel_key = "convolution_pointwise_binary"
         self.cpp_op_schema = """
             at::Tensor(
@@ -5016,7 +5016,7 @@ class ConvolutionBinary(ExternKernelAlloc):
             self.codegen_args(),
             self.cpp_op_schema,
             self.cpp_kernel_key,
-            self.cpp_kernel_overlad_name,
+            self.cpp_kernel_overload_name,
         )
         if isinstance(self.layout, Layout):
             self.codegen_size_asserts(wrapper)
@@ -5080,7 +5080,7 @@ class ConvolutionBinaryInplace(ExternKernelAlloc):
             kernel="torch.ops.mkldnn._convolution_pointwise_.binary",
             cpp_kernel="mkldnn::_convolution_pointwise_",
         )
-        self.cpp_kernel_overlad_name = "binary"
+        self.cpp_kernel_overload_name = "binary"
         self.cpp_kernel_key = "convolution_pointwise_binary_"
         # TODO: op.call: input[0] should be at::Tensor&
         self.cpp_op_schema = """
@@ -5106,7 +5106,7 @@ class ConvolutionBinaryInplace(ExternKernelAlloc):
             self.codegen_args(),
             self.cpp_op_schema,
             self.cpp_kernel_key,
-            self.cpp_kernel_overlad_name,
+            self.cpp_kernel_overload_name,
         )
 
     def get_mutation_names(self):
@@ -5291,7 +5291,7 @@ class LinearBinary(ExternKernelAlloc):
             kernel="torch.ops.mkldnn._linear_pointwise.binary",
             cpp_kernel="mkldnn::_linear_pointwise",
         )
-        self.cpp_kernel_overlad_name = "binary"
+        self.cpp_kernel_overload_name = "binary"
         self.cpp_kernel_key = "linear_pointwise_binary"
         self.cpp_op_schema = """
             at::Tensor(
@@ -5309,7 +5309,7 @@ class LinearBinary(ExternKernelAlloc):
             self.codegen_args(),
             self.cpp_op_schema,
             self.cpp_kernel_key,
-            self.cpp_kernel_overlad_name,
+            self.cpp_kernel_overload_name,
         )
 
     @classmethod
@@ -5732,7 +5732,7 @@ class QConvPointWiseBinaryPT2E(ExternKernelAlloc):
             kernel="torch.ops.onednn.qconv2d_pointwise.binary",
             cpp_kernel="onednn::qconv2d_pointwise",
         )
-        self.cpp_kernel_overlad_name = "binary"
+        self.cpp_kernel_overload_name = "binary"
         self.cpp_kernel_key = "qconv2d_pointwise_binary"
         self.cpp_op_schema = """
             at::Tensor(
@@ -5817,7 +5817,7 @@ class QConvPointWiseBinaryPT2E(ExternKernelAlloc):
             conv_args,
             self.cpp_op_schema,
             self.cpp_kernel_key,
-            self.cpp_kernel_overlad_name,
+            self.cpp_kernel_overload_name,
         )
         if isinstance(self.layout, Layout):
             self.codegen_size_asserts(wrapper)
@@ -7002,9 +7002,9 @@ class _CollectiveKernel(FallbackKernel):
         from .codegen.wrapper import get_cpp_op_schema
 
         self.cpp_kernel = kernel._schema.name
-        self.cpp_kernel_overlad_name = kernel._schema.overload_name
+        self.cpp_kernel_overload_name = kernel._schema.overload_name
         self.cpp_kernel_key = (
-            f"{self.cpp_kernel.replace('::', '_')}_{self.cpp_kernel_overlad_name}"
+            f"{self.cpp_kernel.replace('::', '_')}_{self.cpp_kernel_overload_name}"
         )
 
         self.cpp_op_schema = get_cpp_op_schema(kernel)


### PR DESCRIPTION
```
// check all references
$ grep -rl 'cpp_kernel_overlad_name' *
ir.py
```

```
$ lintrunner --take MYPYINDUCTOR torch/_inductor/codegen/wrapper.py torch/_inductor/ir.py
ok No lint issues.
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov