### PR TITLE
Add dist hooks support for custom device

### DIFF
--- a/torch/distributed/algorithms/ddp_comm_hooks/mixed_precision_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/mixed_precision_hooks.py
@@ -4,7 +4,7 @@ from torch.autograd import Variable
 
 from dataclasses import dataclass
 from typing import Any, no_type_check
-from torch.distributed.utils import _free_storage
+from torch.distributed.utils import _free_storage, _DeviceModule
 
 @dataclass
 class _AllreduceUpcastHookState:
@@ -16,8 +16,9 @@ class _AllreduceUpcastHookState:
     """
 
     ddp_weakref: Any
-    upcast_stream: torch.cuda.Stream
+    upcast_stream: torch.Stream
     wait_for_stream_enqueued: bool = False
+    device_module: _DeviceModule = torch.cuda  # type: ignore[assignment]
 
 @no_type_check
 def _reducer_allreduce_and_upcast_hook(
@@ -42,7 +43,7 @@ def _reducer_allreduce_and_upcast_hook(
     fut = reducer._run_allreduce_hook(bucket)
     ret_fut = torch.futures.Future()
     stream = hook_state.upcast_stream
-    with torch.cuda.stream(stream):
+    with hook_state.device_module.stream(stream):
         fut.wait()
         bucket.buffer().div_(process_group.size())
         ret_fut.set_result(bucket.buffer())
@@ -58,7 +59,7 @@ def _reducer_allreduce_and_upcast_hook(
 
     # enqueue a callback to wait for this stream at end of backward
     def wait_for_stream_cb():
-        torch.cuda.current_stream().wait_stream(stream)
+        hook_state.device_module.current_stream().wait_stream(stream)
         # Remove post-backward hooks since they are re-installed in next
         # iteration, similar to FSDP.
         # Parameters that don't require grad still needed to be casted since

--- a/torch/distributed/algorithms/model_averaging/utils.py
+++ b/torch/distributed/algorithms/model_averaging/utils.py
@@ -8,6 +8,7 @@ import torch.distributed as dist
 # USE_DISTRIBUTED compile flag. Make sure they raise import error
 # if we're trying to use them.
 from torch.distributed import ProcessGroup, group
+from torch._utils import _get_device_module
 
 __all__ = ["average_parameters", "get_params_to_average", "average_parameters_or_parameter_groups"]
 
@@ -32,8 +33,10 @@ def average_parameters(
     flat_params = torch.cat([p.data.reshape(-1) for p in params_it1])
     flat_params /= dist.get_world_size(group_to_use)
     # Make sure the allreduce will not conflict with any other ongoing process group.
-    if torch.cuda.is_available():
-        torch.cuda.synchronize()
+    device_type = dist.distributed_c10d._get_pg_default_device(group_to_use).type
+    device_module = _get_device_module(device_type)
+    if device_module.is_available():
+        device_module.synchronize()
     dist.all_reduce(flat_params, group=group_to_use)
 
     offset = 0

--- a/torch/distributed/utils.py
+++ b/torch/distributed/utils.py
@@ -1,10 +1,11 @@
 import dataclasses
 import traceback
-from typing import Any, Callable, Container, Dict, List, Optional, OrderedDict, Tuple, TypeVar, overload
+from contextlib import AbstractContextManager
+from typing import Any, Callable, Container, Dict, List, Optional, OrderedDict, Tuple, TypeVar, overload, Protocol
 
 import torch
 import torch.distributed as dist
-from torch import nn
+from torch import nn, Stream
 from torch.nn.parallel._functions import _get_stream
 from torch.nn.parallel.scatter_gather import _is_namedtuple
 from torch.nn.utils.rnn import PackedSequence
@@ -337,3 +338,11 @@ def _replace_by_prefix(
 
 def _data_ptr_allocated(tensor: torch.Tensor) -> bool:
     return tensor.untyped_storage().data_ptr() > 0
+
+
+class _DeviceModule(Protocol):  # noqa: PYI046
+    def stream(self, Stream) -> AbstractContextManager:
+        ...
+
+    def current_stream(self) -> Stream:
+        ...

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -39,7 +39,7 @@ if torch.distributed.rpc.is_available():
     RPC_AVAILABLE = True
     from torch.distributed.rpc import RRef
 
-from torch._utils import _get_device_index
+from torch._utils import _get_device_index, _get_device_module
 
 from ..modules import Module
 from .scatter_gather import gather, scatter_kwargs  # noqa: F401
@@ -694,7 +694,7 @@ class DistributedDataParallel(Module, Joinable):
             )
 
         self.device_type = next(iter(distinct_device_types))
-
+        _get_device_module(self.device_type)
         if (
             device_ids is None
             or len(device_ids) == 0  # For backward compatibility.
@@ -821,7 +821,7 @@ class DistributedDataParallel(Module, Joinable):
             _setup_mixed_precision_params(self.mixed_precision, self.module)
             _cast_buffers(self.mixed_precision, self.module)
             # Stream used for async low precision copies.
-            self._mp_stream = torch.cuda.Stream()
+            self._mp_stream = _get_device_module(self.device_type).Stream()
             self._submodule_to_event = defaultdict(deque)  # type: ignore[var-annotated]
             # Add forward pre-hook to root module to kick off copies to lower
             # precision.
@@ -847,7 +847,8 @@ class DistributedDataParallel(Module, Joinable):
 
             upcast_hook_state = _AllreduceUpcastHookState(
                 ddp_weakref=weakref.ref(self),
-                upcast_stream=torch.cuda.Stream(),
+                upcast_stream=_get_device_module(self.device_type).Stream(),
+                device_module=_get_device_module(self.device_type),
             )
             self.register_comm_hook(
                 upcast_hook_state,
@@ -995,7 +996,8 @@ class DistributedDataParallel(Module, Joinable):
             self.register_comm_hook(
                 ddp_weakref,
                 _apply_optim_in_backward_hook(
-                    gradient_is_bucket_view=self.gradient_as_bucket_view
+                    gradient_is_bucket_view=self.gradient_as_bucket_view,
+                    device_type=self.device_type,
                 ),
             )
 
@@ -1023,7 +1025,7 @@ class DistributedDataParallel(Module, Joinable):
         # may have populated some events for modules that didn't end up being
         # used.
         self._submodule_to_event = defaultdict(deque)  # type: ignore[var-annotated]
-        with torch.cuda.stream(self._mp_stream):
+        with _get_device_module(self.device_type).stream(self._mp_stream):
             for submodule in self.module.modules():
                 for param in submodule.parameters(recurse=False):
                     # Do not cast DDP ignored parameters.
@@ -1047,7 +1049,7 @@ class DistributedDataParallel(Module, Joinable):
                                 self.mixed_precision.param_dtype  # type: ignore[union-attr]
                             )
                     param.data = param._mp_param
-                copy_event = torch.cuda.Event()
+                copy_event = _get_device_module(self.device_type).Event()
                 copy_event.record()
                 self._submodule_to_event[submodule].append(copy_event)
 
@@ -1064,7 +1066,7 @@ class DistributedDataParallel(Module, Joinable):
             # copy event has already been waited on
             return
 
-        event.wait(stream=torch.cuda.current_stream())
+        event.wait(stream=_get_device_module(self.device_type).current_stream())
         for p in module.parameters(recurse=False):
             # Don't register hooks if param does not require grad
             if not p.requires_grad or (hasattr(p, "_ddp_ignored") and p._ddp_ignored):


### PR DESCRIPTION
Fixes #104389 

Try to add dist hooks support for custom device again due to original PR https://github.com/pytorch/pytorch/pull/104155 is marked with stale label.

original desc

> 1. Now for distributed hooks, there are some hard-code like cuda, we want to support these hooks for custom device( privateuse1 backend), so we use the abstract device-module to run some funcs. 
> 2. In torch/nn/parallel/distributed.py, I want to define a variable self.device_module = getattr(torch, self.device_type, None) so that we can reuse it, but it will cause an error in serialization, TypeError: cannot pickle 'module' object. So we call the func by getattr when needs.

 Function _get_device_module is landed in this PR https://github.com/pytorch/pytorch/pull/107289

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @kiukchung @lucasllc