### PR TITLE
[profiler] Fix description to use nelems rather than size

### DIFF
--- a/torch/csrc/distributed/c10d/ParamCommsUtils.cpp
+++ b/torch/csrc/distributed/c10d/ParamCommsUtils.cpp
@@ -10,8 +10,8 @@ namespace torch {
 ParamCommsDebugInfo::ParamCommsDebugInfo(
     int rank,
     std::string&& colName,
-    int inSize,
-    int outSize,
+    int inNelems,
+    int outNelems,
     at::ScalarType dType,
     std::vector<int64_t> inSplitSizes,
     std::vector<int64_t> outSplitSizes,
@@ -19,8 +19,8 @@ ParamCommsDebugInfo::ParamCommsDebugInfo(
     : rank_(rank),
       worldSize_(worldSize),
       columnName_(colName),
-      inMessageSize_(inSize),
-      outMessageSize_(outSize),
+      inMessageNelems_(inNelems),
+      outMessageNelems_(outNelems),
       dType_(dType),
       inputSplitSizes_(std::move(inSplitSizes)),
       outputSplitSizes_(std::move(outSplitSizes)) {}

--- a/torch/csrc/distributed/c10d/ParamCommsUtils.hpp
+++ b/torch/csrc/distributed/c10d/ParamCommsUtils.hpp
@@ -15,8 +15,8 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
   ParamCommsDebugInfo(
       int rank,
       std::string&& colName,
-      int inSize,
-      int outSize,
+      int inNelems,
+      int outNelems,
       at::ScalarType dType,
       std::vector<int64_t> inSplitSizes,
       std::vector<int64_t> outSplitSizes,
@@ -36,12 +36,12 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
     return columnName_;
   }
 
-  int getInMessageSize() const {
-    return inMessageSize_;
+  int getInMessageNelems() const {
+    return inMessageNelems_;
   }
 
-  int getOutMessageSize() const {
-    return outMessageSize_;
+  int getOutMessageNelems() const {
+    return outMessageNelems_;
   }
 
   at::ScalarType getDType() const {
@@ -60,8 +60,8 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
   int rank_{};
   int worldSize_{};
   std::string columnName_;
-  int inMessageSize_{};
-  int outMessageSize_{};
+  int inMessageNelems_{};
+  int outMessageNelems_{};
   at::ScalarType dType_ = at::kByte;
   std::vector<int64_t> inputSplitSizes_;
   std::vector<int64_t> outputSplitSizes_;
@@ -72,8 +72,8 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
     pg_ptr,                                                                    \
     rank,                                                                      \
     colName,                                                                   \
-    inSize,                                                                    \
-    outSize,                                                                   \
+    inNelems,                                                                  \
+    outNelems,                                                                 \
     dType,                                                                     \
     inSplitSizes,                                                              \
     outSplitSizes,                                                             \
@@ -81,8 +81,8 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
   auto paramCommsInfo = std::make_shared<torch::ParamCommsDebugInfo>(          \
       rank,                                                                    \
       colName,                                                                 \
-      inSize,                                                                  \
-      outSize,                                                                 \
+      inNelems,                                                                \
+      outNelems,                                                               \
       dType,                                                                   \
       inSplitSizes,                                                            \
       outSplitSizes,                                                           \
@@ -106,8 +106,8 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
     OutputTensors,                                                             \
     rank,                                                                      \
     colName,                                                                   \
-    inSize,                                                                    \
-    outSize,                                                                   \
+    inNelems,                                                                  \
+    outNelems,                                                                 \
     dType,                                                                     \
     inSplitSizes,                                                              \
     outSplitSizes,                                                             \
@@ -115,8 +115,8 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
   auto paramCommsInfo = std::make_shared<torch::ParamCommsDebugInfo>(          \
       rank,                                                                    \
       colName,                                                                 \
-      inSize,                                                                  \
-      outSize,                                                                 \
+      inNelems,                                                                \
+      outNelems,                                                               \
       dType,                                                                   \
       inSplitSizes,                                                            \
       outSplitSizes,                                                           \

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -620,8 +620,8 @@ bool ProcessGroupNCCL::WorkNCCL::wait(std::chrono::milliseconds timeout) {
       0, // process group ptr
       rank_, // rank
       "wait", // colName
-      0, // inSize
-      0, // outSize
+      0, // inNelems
+      0, // outNelems
       at::kByte, // dType
       std::vector<int64_t>(), // inSplitSizes
       std::vector<int64_t>(), // outSplitSizes
@@ -792,8 +792,8 @@ ProcessGroupNCCL::ProcessGroupNCCL(
       this->getID(),
       rank, // rank
       "init", // colName
-      0, // inSize
-      0, // outSize
+      0, // inNelems
+      0, // outNelems
       at::kByte, // dType
       std::vector<int64_t>(), // inSplitSizes
       std::vector<int64_t>(), // outSplitSizes
@@ -2592,8 +2592,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::allreduce(
       tensors, // outputTensors
       rank_, // rank
       "allreduce", // colName
-      tensor.numel(), // inSize
-      tensor.numel(), // outSize
+      tensor.numel(), // inNelems
+      tensor.numel(), // outNelems
       tensor.scalar_type(), // dType
       std::vector<int64_t>(), // inSplitSizes
       std::vector<int64_t>(), // outSplitSizes
@@ -2617,8 +2617,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::allreduce_coalesced(
       tensors, // outputTensors
       rank_, // rank
       "allreduce_coalesced", // colName
-      total_numel, // inSize
-      total_numel, // outSize
+      total_numel, // inNelems
+      total_numel, // outNelems
       tensors[0].scalar_type(), // dType
       // I'm not sure what in,outSplitSizes mean here.
       std::vector<int64_t>(), // inSplitSizes
@@ -2644,8 +2644,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::broadcast(
       tensors, // outputTensors
       rank_, // rank
       "broadcast", // colName
-      tensor.numel(), // inSize
-      tensor.numel(), // outSize
+      tensor.numel(), // inNelems
+      tensor.numel(), // outNelems
       tensor.scalar_type(), // dType
       std::vector<int64_t>(), // inSplitSizes
       std::vector<int64_t>(), // outSplitSizes
@@ -2707,8 +2707,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::_broadcast_oop(
       outputTensors, // outputTensors
       rank_, // rank
       "_broadcast_oop", // colName
-      tensor.numel(), // inSize
-      tensor.numel(), // outSize
+      tensor.numel(), // inNelems
+      tensor.numel(), // outNelems
       tensor.scalar_type(), // dType
       std::vector<int64_t>(), // inSplitSizes
       std::vector<int64_t>(), // outSplitSizes
@@ -2749,8 +2749,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::reduce(
       tensors, // outputTensors
       rank_, // rank
       "reduce", // colName
-      tensor.numel(), // inSize
-      tensor.numel(), // outSize
+      tensor.numel(), // inNelems
+      tensor.numel(), // outNelems
       tensor.scalar_type(), // dType
       std::vector<int64_t>(), // inSplitSizes
       std::vector<int64_t>(), // outSplitSizes
@@ -2813,8 +2813,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::_reduce_oop(
       outputTensors, // outputTensors
       rank_, // rank
       "_reduce_oop", // colName
-      tensor.numel(), // inSize
-      tensor.numel(), // outSize
+      tensor.numel(), // inNelems
+      tensor.numel(), // outNelems
       tensor.scalar_type(), // dType
       std::vector<int64_t>(), // inSplitSizes
       std::vector<int64_t>(), // outSplitSizes
@@ -2870,8 +2870,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::allgather(
         outputTensors, // outputTensors
         rank_, // rank
         "all_gather", // colName
-        tensor.numel(), // inSize
-        tensor.numel() * // outSize
+        tensor.numel(), // inNelems
+        tensor.numel() * // outNelems
             this->getSize(),
         tensor.scalar_type(), // dType
         std::vector<int64_t>(), // inSplitSizes
@@ -3014,8 +3014,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::reduce_scatter(
         outputTensors, // outputTensors
         rank_, // rank
         "reduce_scatter", // colName
-        tensor.numel() * this->getSize(), // inSize
-        tensor.numel(), // outSize
+        tensor.numel() * this->getSize(), // inNelems
+        tensor.numel(), // outNelems
         tensor.scalar_type(), // dType
         std::vector<int64_t>(), // inSplitSizes
         std::vector<int64_t>(), // outSplitSizes
@@ -3133,8 +3133,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::_reduce_scatter_base(
       outputTensor, // outputTensor
       rank_, // rank
       "_reduce_scatter_base", // colName
-      inputTensor.numel(), // inSize
-      tensor.numel(), // outSize
+      inputTensor.numel(), // inNelems
+      tensor.numel(), // outNelems
       tensor.scalar_type(), // dtype
       std::vector<int64_t>(), // inSplitSizes
       std::vector<int64_t>(), // outSplitSizes
@@ -3221,8 +3221,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::barrier(const BarrierOptions& opts) {
       this->getID(),
       rank_, // rank
       "barrier", // colName
-      0, // inSize
-      0, // outSize
+      0, // inNelems
+      0, // outNelems
       at::kByte, // dType
       std::vector<int64_t>(), // inSplitSizes
       std::vector<int64_t>(), // outSplitSizes
@@ -3302,8 +3302,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::alltoall_base(
         outputTensor, // outputTensor
         rank_, // rank
         "all_to_all", // colName
-        inputTensor.numel(), // inSize
-        outputTensor.numel(), // outSize
+        inputTensor.numel(), // inNelems
+        outputTensor.numel(), // outNelems
         inputTensor.scalar_type(), // dType
         std::vector<int64_t>(), // inSplitSizes
         std::vector<int64_t>(), // outSplitSizes
@@ -3344,8 +3344,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::alltoall_base(
         outputTensor, // outputTensor
         rank_, // rank
         "all_to_allv", // colName
-        inputTensor.numel(), // inSize
-        outputTensor.numel(), // outSize
+        inputTensor.numel(), // inNelems
+        outputTensor.numel(), // outNelems
         inputTensor.scalar_type(), // dType
         inputSplitSizes, // inSplitSizes
         outputSplitSizes, // outSplitSizes
@@ -3420,8 +3420,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::alltoall(
       outputTensors, // outputTensors
       rank_, // rank
       "all_to_all", // colName
-      total_numel, // inSize
-      total_numel, // outSize
+      total_numel, // inNelems
+      total_numel, // outNelems
       inputTensors.front().scalar_type(), // dType
       inSplitSizes, // inSplitSizes
       outSplitSizes, // outSplitSizes
@@ -3471,8 +3471,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::send(
       tensors, // outputTensors
       dstRank, // rank
       "send", // colName
-      tensor.numel(), // inSize
-      tensor.numel(), // outSize
+      tensor.numel(), // inNelems
+      tensor.numel(), // outNelems
       tensor.scalar_type(), // dType
       std::vector<int64_t>(), // inSplitSizes
       std::vector<int64_t>(), // outSplitSizes
@@ -3509,8 +3509,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::recv(
       tensors, // outputTensors
       srcRank, // rank
       "recv", // colName
-      tensor.numel(), // inSize
-      tensor.numel(), // outSize
+      tensor.numel(), // inNelems
+      tensor.numel(), // outNelems
       tensor.scalar_type(), // dType
       std::vector<int64_t>(), // inSplitSizes
       std::vector<int64_t>(), // outSplitSizes
@@ -3669,8 +3669,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::gather(
       outputTensors, // outputTensors
       rank_, // rank
       "gather", // colName
-      tensor.numel(), // inSize
-      tensor.numel() * this->getSize(), // outSize
+      tensor.numel(), // inNelems
+      tensor.numel() * this->getSize(), // outNelems
       tensor.scalar_type(), // dType
       std::vector<int64_t>(), // inSplitSizes
       std::vector<int64_t>(), // outSplitSize
@@ -3756,8 +3756,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::scatter(
       outputTensors, // outputTensors
       rank_, // rank
       "scatter", // colName
-      tensor.numel(), // inSize
-      tensor.numel() * this->getSize(), // outSize
+      tensor.numel(), // inNelems
+      tensor.numel() * this->getSize(), // outNelems
       tensor.scalar_type(), // dType
       std::vector<int64_t>(), // inSplitSizes
       std::vector<int64_t>(), // outSplitSize
@@ -3827,8 +3827,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::_allgather_base(
       output_tensor, // outputTensors
       rank_, // rank
       "_allgather_base", // colName
-      input_tensor.numel(), // inSize
-      tensor.numel(), // outSize
+      input_tensor.numel(), // inNelems
+      tensor.numel(), // outNelems
       tensor.scalar_type(), // dType
       std::vector<int64_t>(), // inSplitSizes
       std::vector<int64_t>(), // outSplitSize

--- a/torch/csrc/distributed/c10d/UCCTracing.cpp
+++ b/torch/csrc/distributed/c10d/UCCTracing.cpp
@@ -85,8 +85,8 @@ void CommTraceLogger::recordComms(
     const int world_size,
     const std::vector<at::Tensor>& inputTensors,
     const std::vector<at::Tensor>& outputTensors) {
-  auto inSize = (!inputTensors.empty()) ? inputTensors[0].numel() : 0;
-  auto outSize = (!outputTensors.empty()) ? outputTensors[0].numel() : 0;
+  auto inNelems = (!inputTensors.empty()) ? inputTensors[0].numel() : 0;
+  auto outNelems = (!outputTensors.empty()) ? outputTensors[0].numel() : 0;
   auto dtype =
       (!outputTensors.empty()) ? outputTensors[0].scalar_type() : at::kByte;
   auto devType = (!outputTensors.empty()) ? outputTensors[0].device().type()
@@ -116,14 +116,14 @@ void CommTraceLogger::recordComms(
       ",\n\t\t\"world_size\": ",
       world_size);
 
-  if (inSize > 0 || outSize > 0) {
+  if (inNelems > 0 || outNelems > 0) {
     // for most collectives - append msg sizes, data type, device type
     cur_trace_ = c10::str(
         cur_trace_,
         ",\n\t\t\"in_msg_size\": ",
-        inSize,
+        inNelems,
         ",\n\t\t\"out_msg_size\": ",
-        outSize,
+        outNelems,
         ",\n\t\t\"dtype\": \"",
         at::toString(dtype),
         "\",\n\t\t\"devType\": \"",
@@ -153,8 +153,8 @@ void CommTraceLogger::recordComms(
       0, // process group ptr
       rank,
       commName.c_str(),
-      inSize,
-      outSize,
+      inNelems,
+      outNelems,
       dtype,
       curInSplitSizes_,
       curOutSplitSizes_,

--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -340,8 +340,8 @@ std::vector<std::string> inputTypes(const at::RecordFunction& fn) {
 #ifdef USE_C10D
 static constexpr auto kCommuName = "Collective name";
 static constexpr auto kDtype = "dtype";
-static constexpr auto kInMsgSize = "In msg size";
-static constexpr auto kOutMsgSize = "Out msg size";
+static constexpr auto kInMsgNelems = "In msg nelems";
+static constexpr auto kOutMsgNelems = "Out msg nelems";
 static constexpr auto kInSplit = "In split size";
 static constexpr auto kOutSplit = "Out split size";
 static constexpr auto kGroupSize = "Group size";
@@ -365,8 +365,8 @@ std::unordered_map<std::string, std::string> saveNcclMeta(
   map.emplace(kCommuName, fmt::format("\"{}\"", debugInfo->getColumnName()));
   map.emplace(
       kDtype, fmt::format("\"{}\"", c10::toString(debugInfo->getDType())));
-  map.emplace(kInMsgSize, std::to_string(debugInfo->getInMessageSize()));
-  map.emplace(kOutMsgSize, std::to_string(debugInfo->getOutMessageSize()));
+  map.emplace(kInMsgNelems, std::to_string(debugInfo->getInMessageNelems()));
+  map.emplace(kOutMsgNelems, std::to_string(debugInfo->getOutMessageNelems()));
   auto& inSplitSizes = debugInfo->getInputSplitSizes();
   if (!inSplitSizes.empty() && inSplitSizes.size() <= kTruncatLength) {
     map.emplace(


### PR DESCRIPTION
We were storing the number of elements in the tensor, rather than the actual bytes.

Fixes #ISSUE_NUMBER


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @kiukchung @d4l3k @lucasllc