### PR TITLE
Inductor cpp wrapper: fix buffer free in non-AOT mode

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1875,7 +1875,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
         return (
             ""
             if isinstance(buffer.get_layout(), ir.MultiOutputLayout)
-            or self.can_cache_buffer_in_thread_local(buffer)
+            or (V.graph.aot_mode and self.can_cache_buffer_in_thread_local(buffer))
             else f"{buffer.get_name()}.reset();"
         )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #114741

We found performance regression when using cpp wrapper in non-AOT mode due to the change in https://github.com/pytorch/pytorch/pull/110892.
https://github.com/pytorch/pytorch/pull/110892 only handles the buffer cache in AOT mode but removes the `reset` call without checking whether AOT mode is on or off. This PR updates the buffer free change to only happen when `V.graph.aot_mode is True`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler