### PR TITLE
[PyTorch][ET] Collect Execution Traces in Chakra schema

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -426,7 +426,7 @@ class TestExecutionTrace(TestCase):
                 loop_count += 1
             # Check if tensor tuple representation size is correct.
             if n["name"] == "## TEST 2 ##":
-                assert len(n["inputs"][3][0]) == tensor_tuple_size
+                assert len(n["inputs"]["values"][3][0]) == tensor_tuple_size
         assert found_root_node
         assert loop_count == expected_loop_events
 

--- a/torch/csrc/profiler/standalone/execution_trace_observer.cpp
+++ b/torch/csrc/profiler/standalone/execution_trace_observer.cpp
@@ -277,26 +277,27 @@ static void writeJsonNode(
   out << fmt::format(
       R"JSON(
     {{
-      "name": "{}", "id": {}, "rf_id": {}, "parent": {}, "fw_parent": {}, "seq_id": {}, "scope": {}, "tid": {}, "fw_tid": {}, "op_schema": "{}",
-      "inputs": {}, "input_shapes": {}, "input_types": {},
-      "outputs": {}, "output_shapes": {}, "output_types": {}
+      "id": {}, "name": "{}", "ctrl_deps": {},
+      "inputs": {{"values": {}, "shapes": {}, "types": {}}},
+      "outputs": {{"values": {}, "shapes": {}, "types": {}}},
+      "attrs": [{{"name": "rf_id", "type": "uint64", "value": {}}}, {{"name": "fw_parent", "type": "uint64", "value": {}}}, {{"name": "seq_id", "type": "int64", "value": {}}}, {{"name": "scope", "type": "uint64", "value": {}}}, {{"name": "tid", "type": "uint64", "value": {}}}, {{"name": "fw_tid", "type": "uint64", "value": {}}}, {{"name": "op_schema", "type": "string", "value": "{}"}}]
     }})JSON",
-      name,
       id,
-      rf_id,
+      name,
       parent,
-      fw_parent,
-      seq_id,
-      scope,
-      tid,
-      fw_tid,
-      operator_schema,
       inputs,
       input_shapes,
       input_types,
       outputs,
       output_shapes,
-      output_types);
+      output_types,
+      rf_id,
+      fw_parent,
+      seq_id,
+      scope,
+      tid,
+      fw_tid,
+      operator_schema);
 }
 
 inline std::string timeString(const std::time_t timepoint) {
@@ -325,7 +326,7 @@ static bool initExecutionTraceStart(ExecutionTraceObserver& ob) {
 
   ob.out << fmt::format(
       R"JSON({{
-  "schema": "1.0.1", "pid": {}, "time": "{}", "start_ts": {},
+  "schema": "1.0.2-chakra.0.0.4", "pid": {}, "time": "{}", "start_ts": {},
   "nodes": [)JSON",
       ob.pid,
       ob.record_time,


### PR DESCRIPTION
Summary:
Collect execution traces in the Chakra schema

Created a new diff to change email address: D48030418

Test Plan:
```
$ cd ~/fbcode
$ binary_path=$(buck2 build //param_bench/train/compute/python:pytorch_run_benchmark --show-output | tail -1 | awk '{print $2}')
$ cd ~/fbsource
$ $binary_path -c ~/fbcode/param_bench/train/compute/python/examples/pytorch/configs/alex_net.json --et

$ cat ~/is_json.py
import json
import sys

def is_json_file(filename):
    try:
        with open(filename, 'r') as f:
            json.load(f)
        return True
    except Exception as e:
        return False

if len(sys.argv) != 2:
    print("Usage: python check_json.py [filename]")
    sys.exit(1)

filename = sys.argv[1] # get filename from command-line argument
print(is_json_file(filename))

$ python3 ~/is_json.py ~/fbsource/benchmark_result_2244333_1691065899_et.json
True
```

Differential Revision: D51662384


