### PR TITLE
Deprecate primTorch module, replace it with decompositions in module Owners

### DIFF
--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -1,4 +1,4 @@
-# Owner(s): ["module: primTorch", "module: decompositions"]
+# Owner(s): ["module: decompositions"]
 
 from collections import defaultdict
 from torch import Tensor

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -1,4 +1,4 @@
-# Owner(s): ["module: decomposition"]
+# Owner(s): ["module: decompositions"]
 
 import itertools
 import torch

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -1,4 +1,4 @@
-# Owner(s): ["module: primTorch"]
+# Owner(s): ["module: decomposition"]
 
 import itertools
 import torch

--- a/test/test_prims.py
+++ b/test/test_prims.py
@@ -1,4 +1,4 @@
-# Owner(s): ["module: primTorch"]
+# Owner(s): ["module: decomposition"]
 
 from functools import partial
 from itertools import product

--- a/test/test_prims.py
+++ b/test/test_prims.py
@@ -1,4 +1,4 @@
-# Owner(s): ["module: decomposition"]
+# Owner(s): ["module: decompositions"]
 
 from functools import partial
 from itertools import product


### PR DESCRIPTION
Context: pt2 oncall is revamping its labeling system. One of the guidelines is to remove duplicate labeling in our system. Both primTorch and decomposition labels are referring to the same thing. primTorch was the legacy name (and we no longer have a primTorch project), so using decomposition as the label name makes more sense. 

Right now, the only open issues that use "module: primTorch" are the ones generated by the DISABLED bots. Once we replace the label in the bot, we can safely remove the primTorch label.

Here an example of the issue that has primTorch label :
https://github.com/pytorch/pytorch/issues/112719

Torchbot uses following logic to auto extract module owners:
https://github.com/pytorch/test-infra/blob/main/torchci/pages/api/flaky-tests/disable.ts#L391

cc @penguinwu @malfet @huydhn 
