### PR TITLE
Call triton bsr_dense_mm/bsr_dense_addmm kernels on mm/addmm float32 inputs when appropiate

### DIFF
--- a/aten/src/ATen/native/sparse/SparseBlasImpl.cpp
+++ b/aten/src/ATen/native/sparse/SparseBlasImpl.cpp
@@ -38,7 +38,8 @@ bool operands_support_triton_mm_kernel(const Tensor& compressed, const Tensor& s
        const auto blocksize = at::sparse_csr::getBlockSize(compressed);
        // Dtype and blocksize checks for potential Triton usage.
        return ((strided.scalar_type() == ScalarType::Half
-                || strided.scalar_type() == ScalarType::BFloat16)
+                || strided.scalar_type() == ScalarType::BFloat16
+                || strided.scalar_type() == ScalarType::Float)
                && compressed.scalar_type() == strided.scalar_type()
                && is_power_of_2(blocksize[0]) && is_power_of_2(blocksize[1])
                && (blocksize[0] >= 16) && (blocksize[1] >= 16)

--- a/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
+++ b/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
@@ -485,7 +485,9 @@ void block_sparse_mm(
   // NOTE: the code below allows arbitrary block sizes
   // and might be potentially faster than cuSPARSE implementation
   // especially for not very sparse inputs.
-  if (mat1.scalar_type() == ScalarType::Half || mat1.scalar_type() == ScalarType::BFloat16) {
+  if (mat1.scalar_type() == ScalarType::Half
+      || mat1.scalar_type() == ScalarType::BFloat16
+      || mat1.scalar_type() == ScalarType::Float) {
     at::native::sparse::impl::_compressed_row_strided_addmm_out(
         input,
         mat1,


### PR DESCRIPTION
As in the title.

In addition, this PR fixes a bug in `bsr_dense_mm` and `bsr_dense_addmm` return value handling where computations are performed on `make_triton_contiguous` return value while `bsr_dense_mm`/`bsr_dense_addmm` return a tensor that is an input to `make_triton_contiguous`. If `make_triton_contiguous` makes a copy of the input, the return values of `bsr_dense_mm`/`bsr_dense_addmm` will contain garbage.

The PR increases the performance of nn.linear as follows (float32, `NVIDIA A100-SXM4-80GB`):
- with 16x16 blocks, the average/maximal speed up is 67/78 %
- with 32x32 blocks, the average/maximal speed up is 72/79 %
- with 64x64 blocks, the average/maximal speed up is 71/79 %
- with 128x128 blocks, the average/maximal speed up is 62/76 %

The performance increase is illustrated also by the following sparsity-speedup graphs (before and after this PR):
<img src="https://github.com/pytorch/pytorch/assets/402156/55ce0bf7-8ef2-47ab-99e8-8878f159037d" width="48%"> <img src="https://github.com/pytorch/pytorch/assets/402156/df256175-a594-4bd7-b244-90867fb9a45e" width="48%">

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #114800
* __->__ #114757



cc @alexsamardzic @nikitaved @cpuhrsch @amjames @bhosmer