### PR TITLE
[aot_inductor][pass] fuse parallel linear based on pre grad aten IR

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -90,6 +90,9 @@ split_cat_fx_passes = True
 # Optimize conv-batchnorm if batchnorm is in eval mode. Slightly reduces numerical stability.
 efficient_conv_bn_eval_fx_passes = False
 
+# Enable predispatch aten IR for export
+is_predispatch = False
+
 # Deprecated
 group_fusion = False
 

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -732,7 +732,7 @@ def apply_group_batch_fusion(graph: torch.fx.GraphModule, rule: GroupBatchFusion
         candidates = get_fusion_candidates(rule, node, fused_set)
 
         for key, candidate_nodes in candidates.items():
-            if len(candidate_nodes) < MIN_FUSE_SET_SIZE:
+            if len(candidate_nodes) < rule.graph_search_options["min_fuse_set_size"]:
                 continue
 
             for subset in find_independent_subset_greedy(


### PR DESCRIPTION
Summary:
This work is for PT2 inference. Since the IR from Export will change to pre-grad aten IR in a few months. We need to start this work from now on. Here is what I do in this diff:
1) Copy the fuse parallel linear pass to fb folder and adapt it to aten IR. We still want to keep the original `group_batch_fusion.py` because it is still used in training. In future at certain time point when PT2 training decided to retire the torch IR based group_batch_fusion, we can remove it. But right now, it's better to have torch IR and aten IR version seperately.

Our plan is to gradually transform the existing and important pre-grad passes to aten IR based passes.



Differential Revision: D51017854




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler