### PR TITLE
[DeviceMesh] Rename get_dim_groups to get_group (#114708)

### DIFF
--- a/test/distributed/_spmd/test_tracing.py
+++ b/test/distributed/_spmd/test_tracing.py
@@ -46,7 +46,7 @@ class TraceDeviceMeshTestBase:
         local_tensor = torch.ones(3, 3, device=self.device_type) * self.rank
 
         # check all dim groups
-        dim_to_subgroups = mesh.get_dim_groups()
+        dim_to_subgroups = mesh.get_group()
         for dim, dim_group in enumerate(dim_to_subgroups):
             dim_group_size = get_world_size(dim_group)
             global_ranks = [
@@ -71,7 +71,7 @@ class TraceDeviceMeshTestBase:
         mesh = DeviceMesh(self.device_type, mesh_tensor)
 
         # check all dim groups
-        dim_to_subgroups = mesh.get_dim_groups()
+        dim_to_subgroups = mesh.get_group()
         for dim, dim_group in enumerate(dim_to_subgroups):
             dim_group_size = get_world_size(dim_group)
             global_ranks = [
@@ -98,7 +98,7 @@ class TraceDeviceMeshTestBase:
         mesh = DeviceMesh(self.device_type, mesh_tensor)
 
         # check all dim groups
-        dim_to_subgroups = mesh.get_dim_groups()
+        dim_to_subgroups = mesh.get_group()
         for dim, dim_group in enumerate(dim_to_subgroups):
             dim_group_size = get_world_size(dim_group)
             global_ranks = [
@@ -129,7 +129,7 @@ class TraceDeviceMeshTestBase:
         # each rank have its own tensor, all_gather gives a big tensor
         local_tensor = torch.ones(3, 3, device=self.device_type) * self.rank
 
-        dim_to_subgroups = mesh.get_dim_groups()
+        dim_to_subgroups = mesh.get_group()
         for dim, dim_group in enumerate(dim_to_subgroups):
             dim_group_size = get_world_size(dim_group)
             global_ranks = [

--- a/test/distributed/_tensor/test_dtensor_compile.py
+++ b/test/distributed/_tensor/test_dtensor_compile.py
@@ -252,7 +252,7 @@ class TestDTensorCompileE2E(DTensorTestBase):
             mesh_dim_names=["dp", "tp"],
         )
 
-        fsdp_pg = twod_mesh.get_dim_groups()[0]
+        fsdp_pg = twod_mesh.get_group(mesh_dim=0)
 
         inp = torch.rand(20, 10, device=self.device_type)
         parallelize_plan = {

--- a/test/distributed/fsdp/test_fsdp_tp_integration.py
+++ b/test/distributed/fsdp/test_fsdp_tp_integration.py
@@ -104,8 +104,8 @@ class TestTPFSDPIntegration(FSDPTest):
             mesh=torch.arange(0, self.world_size).view(-1, tensor_parallel_size),
         )
 
-        fsdp_pg = twod_mesh.get_dim_groups()[0]
-        tp_pg = twod_mesh.get_dim_groups()[1]
+        fsdp_pg = twod_mesh.get_group(mesh_dim=0)
+        tp_pg = twod_mesh.get_group(mesh_dim=1)
         return twod_mesh, fsdp_pg, tp_pg
 
     def _get_chunk_sharding_spec(self, tp_world_size: int, tp_pg: dist.ProcessGroup):
@@ -251,7 +251,7 @@ class TestTPFSDPIntegration(FSDPTest):
             mesh_2d["tp"],
             SequenceParallel(),
         )
-        tp_pg = mesh_2d["tp"].get_dim_groups(mesh_dim=0)
+        tp_pg = mesh_2d["tp"].get_group(mesh_dim=0)
         assert isinstance(tp_fsdp_model.net1.weight, DT)
         assert isinstance(tp_fsdp_model.net2.weight, DT)
         tp_fsdp_model = FSDP(
@@ -259,7 +259,7 @@ class TestTPFSDPIntegration(FSDPTest):
             cpu_offload=cpu_offload,
             device_mesh=mesh_2d["dp"],
         )
-        fsdp_pg = mesh_2d["dp"].get_dim_groups(mesh_dim=0)
+        fsdp_pg = mesh_2d["dp"].get_group(mesh_dim=0)
 
         # Check the forward by checking output equality
         fsdp_out = fsdp_model(inp)

--- a/test/distributed/fsdp/test_hsdp_dtensor_state_dict.py
+++ b/test/distributed/fsdp/test_hsdp_dtensor_state_dict.py
@@ -77,8 +77,8 @@ class TestHSDPWithDeviceMeshAndDTensor(DTensorTestBase):
             )
         else:
             mesh_2d = init_device_mesh(self.device_type, (2, self.world_size // 2))
-            intra_node_pg = mesh_2d.get_dim_groups(mesh_dim=1)
-            inter_node_pg = mesh_2d.get_dim_groups(mesh_dim=0)
+            intra_node_pg = mesh_2d.get_group(mesh_dim=1)
+            inter_node_pg = mesh_2d.get_group(mesh_dim=0)
             model = FSDP(
                 DenseModel().cuda(),
                 process_group=(intra_node_pg, inter_node_pg),

--- a/test/distributed/tensor/parallel/test_ddp_2d_parallel.py
+++ b/test/distributed/tensor/parallel/test_ddp_2d_parallel.py
@@ -36,7 +36,7 @@ def init_model(device_type, model_parallel_size=TP_DEGREE):
         mesh=torch.arange(0, world_size).view(-1, model_parallel_size),
     )
 
-    dp_pg = twod_mesh.get_dim_groups()[0]
+    dp_pg = twod_mesh.get_group(mesh_dim=0)
 
     twod_model = parallelize_module(
         twod_model, twod_mesh, PairwiseParallel(), tp_mesh_dim=1

--- a/test/distributed/tensor/parallel/test_fsdp_2d_parallel.py
+++ b/test/distributed/tensor/parallel/test_fsdp_2d_parallel.py
@@ -165,7 +165,7 @@ class TestNew2dParallelTraining(DTensorTestBase):
         for i in range(5):
             # Ensure all input across TP ranks are same.
             # TODO: add a get_group_rank() to DeviceMesh.
-            torch.manual_seed(i + dist.get_rank(dp_mesh.get_dim_groups()[0]))
+            torch.manual_seed(i + dist.get_rank(dp_mesh.get_group(mesh_dim=0)))
             input = torch.rand(4, 5).cuda(self.rank)
             output = model(input)
             output_2d = model_2d(input)

--- a/test/distributed/tensor/parallel/test_parallelize_api.py
+++ b/test/distributed/tensor/parallel/test_parallelize_api.py
@@ -55,21 +55,21 @@ class TensorParallelAPITests(DTensorTestBase):
         mesh = DeviceMesh(self.device_type, mesh_shape)
         # When 1D dim is 1.
         one_dimention_mesh_shape = mesh_shape[self.rank // dim_one_size, :]
-        pg = mesh.get_dim_groups()[1]
+        pg = mesh.get_group(mesh_dim=1)
         new_mesh = _create_1d_device_mesh(mesh, 1)
         expected_mesh = one_dimention_mesh_shape
 
         self.assertEqual(new_mesh.mesh, expected_mesh)
         self.assertEqual(new_mesh.device_type, self.device_type)
-        self.assertEqual(new_mesh.get_dim_groups(), [pg])
+        self.assertEqual(new_mesh.get_group(), pg)
         # When 1D dim is 0.
         one_dimention_mesh_shape = mesh_shape[:, self.rank % dim_one_size]
-        pg = mesh.get_dim_groups()[0]
+        pg = mesh.get_group(mesh_dim=0)
         new_mesh = _create_1d_device_mesh(mesh, 0)
         expected_mesh = one_dimention_mesh_shape
         self.assertEqual(new_mesh.mesh, expected_mesh)
         self.assertEqual(new_mesh.device_type, self.device_type)
-        self.assertEqual(new_mesh.get_dim_groups(), [pg])
+        self.assertEqual(new_mesh.get_group(), pg)
 
     @with_comms
     def test_create_1d_device_mesh_error(self):

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -66,13 +66,33 @@ class DeviceMeshTest(DTensorTestBase):
         self.destroy_pg()
 
     @with_comms
+    def test_get_group(self):
+        mesh_shape = (2, self.world_size // 2)
+        mesh_2d = init_device_mesh(
+            self.device_type, mesh_shape, mesh_dim_names=("dp", "tp")
+        )
+
+        tp_mesh = mesh_2d["tp"]
+        dp_mesh = mesh_2d["dp"]
+
+        self.assertEqual(len(mesh_2d.get_group()), 2)
+        self.assertEqual(mesh_2d.get_group()[0], mesh_2d.get_group("dp"))
+        self.assertEqual(mesh_2d.get_group()[1], mesh_2d.get_group("tp"))
+
+        self.assertEqual(mesh_2d.get_group(0), mesh_2d.get_group("dp"))
+        self.assertEqual(mesh_2d.get_group(1), mesh_2d.get_group("tp"))
+
+        self.assertEqual(mesh_2d.get_group("dp"), dp_mesh.get_group())
+        self.assertEqual(mesh_2d.get_group("tp"), tp_mesh.get_group())
+
+    @with_comms
     def test_device_mesh_2d(self):
         mesh_tensor = torch.arange(4).reshape(2, 2)
         # construct a cuda device mesh
         mesh = DeviceMesh(self.device_type, mesh_tensor)
 
         # check all dim groups
-        dim_to_subgroups = mesh.get_dim_groups()
+        dim_to_subgroups = mesh.get_group()
 
         expected_ranks_by_dim = [[[0, 2], [1, 3]], [[0, 1], [2, 3]]]
         for dim, dim_group in enumerate(dim_to_subgroups):
@@ -95,7 +115,7 @@ class DeviceMeshTest(DTensorTestBase):
         mesh = DeviceMesh(self.device_type, [1], _init_process_groups=False)
 
         with self.assertRaisesRegex(RuntimeError, "process groups not initialized!"):
-            mesh.get_dim_groups()
+            mesh.get_group()
 
     def test_fake_pg_device_mesh(self):
         fake_store = FakeStore()
@@ -122,7 +142,7 @@ class DeviceMeshTestNDim(DTensorTestBase):
         mesh = DeviceMesh(self.device_type, mesh_tensor)
 
         # check all dim groups
-        dim_to_subgroups = mesh.get_dim_groups()
+        dim_to_subgroups = mesh.get_group()
 
         for dim, dim_group in enumerate(dim_to_subgroups):
             self.assertTrue(dim < mesh_tensor.ndim)
@@ -459,7 +479,7 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
         local_tensor = torch.ones(3, 3, device=self.device_type) * self.rank
 
         # check all dim groups
-        dim_to_subgroups = mesh.get_dim_groups()
+        dim_to_subgroups = mesh.get_group()
         for dim, dim_group in enumerate(dim_to_subgroups):
             dim_group_size = get_world_size(dim_group)
             global_ranks = [
@@ -476,7 +496,7 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
         mesh = DeviceMesh(self.device_type, mesh_tensor)
 
         # check all dim groups
-        dim_to_subgroups = mesh.get_dim_groups()
+        dim_to_subgroups = mesh.get_group()
         for dim, dim_group in enumerate(dim_to_subgroups):
             dim_group_size = get_world_size(dim_group)
             global_ranks = [
@@ -525,7 +545,7 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
         mesh = DeviceMesh(self.device_type, mesh_tensor)
         tensor_shape = [3, 3, 3]
         # check all dim groups
-        dim_to_subgroups = mesh.get_dim_groups()
+        dim_to_subgroups = mesh.get_group()
         for dim, dim_group in enumerate(dim_to_subgroups):
             my_coordinate = mesh.get_coordinate()[dim]
             dim_group_size = get_world_size(dim_group)

--- a/test/distributed/test_functional_api.py
+++ b/test/distributed/test_functional_api.py
@@ -121,13 +121,13 @@ class TestExpand(MultiThreadedTestCase):
     def test_expand_device_mesh(self):
         mesh = dt.DeviceMesh("cpu", torch.arange(4))
         tag, rankset, group_size = ft_c._expand_group(mesh)
-        self.assertEqual(c10d._get_group_tag(mesh.get_dim_groups()[0]), tag)
+        self.assertEqual(c10d._get_group_tag(mesh.get_group(mesh_dim=0)), tag)
         self.assertEqual([0, 1, 2, 3], rankset)
         self.assertEqual(4, group_size)
 
         mesh = dt.DeviceMesh("cpu", torch.arange(4))
         tag, rankset, group_size = ft_c._expand_group(mesh)
-        self.assertEqual(c10d._get_group_tag(mesh.get_dim_groups()[0]), tag)
+        self.assertEqual(c10d._get_group_tag(mesh.get_group(mesh_dim=0)), tag)
         self.assertEqual([0, 1, 2, 3], rankset)
         self.assertEqual(4, group_size)
 
@@ -137,14 +137,14 @@ class TestExpand(MultiThreadedTestCase):
             tag, rankset, group_size = ft_c._expand_group(mesh)
 
         tag, rankset, group_size = ft_c._expand_group((mesh, 0))
-        self.assertEqual(c10d._get_group_tag(mesh.get_dim_groups()[0]), tag)
+        self.assertEqual(c10d._get_group_tag(mesh.get_group(mesh_dim=0)), tag)
         expected_rankset = [0, 2] if dist.get_rank() in [0, 2] else [1, 3]
         self.assertEqual(expected_rankset, rankset)
         self.assertEqual(2, group_size)
 
         tag, rankset, group_size = ft_c._expand_group((mesh, 1))
         expected_rankset = [0, 1] if dist.get_rank() in [0, 1] else [2, 3]
-        self.assertEqual(c10d._get_group_tag(mesh.get_dim_groups()[1]), tag)
+        self.assertEqual(c10d._get_group_tag(mesh.get_group(mesh_dim=1)), tag)
         self.assertEqual(expected_rankset, rankset)
         self.assertEqual(2, group_size)
 

--- a/torch/distributed/_device_mesh.py
+++ b/torch/distributed/_device_mesh.py
@@ -81,7 +81,7 @@ class _MeshEnv:
             ), "The child mesh can only be a 1D mesh."
             child_mesh_dim_name = child_mesh_dim_names[0]
             if parent_mesh.mesh_dim_names:
-                return parent_mesh.mesh_dim_names.index(child_mesh_dim_name)
+                return parent_mesh._get_mesh_dim_by_name(child_mesh_dim_name)
         return None
 
     @staticmethod
@@ -324,33 +324,42 @@ class DeviceMesh:
             raise RuntimeError(
                 f"Cannot slice a DeviceMesh with {self.mesh.ndim} dimension."
             )
-        if self.mesh_dim_names is None:
-            raise KeyError(
-                "No `mesh_dim_names` found.",
-                "To slice the device mesh, please call `init_device_mesh` with `mesh_dim_names`.",
-            )
-        if mesh_dim_name not in self.mesh_dim_names:
-            raise KeyError(
-                f"Mesh dimension '{mesh_dim_name}' does not exist.",
-                f"Available mesh dimensions are: {self.mesh_dim_names}",
-            )
-        mesh_dim = self.mesh_dim_names.index(mesh_dim_name)
+        mesh_dim = self._get_mesh_dim_by_name(mesh_dim_name)
         submesh = _mesh_resources.create_child_mesh(self, mesh_dim, mesh_dim_name)
 
         return submesh
 
-    def get_dim_groups(
-        self, mesh_dim: Optional[int] = None
+    def get_group(
+        self, mesh_dim: Optional[Union[int, str]] = None
     ) -> Union[ProcessGroup, List[ProcessGroup]]:
+        """
+        Returns a list of ProcessGroups corresponding to the mesh dimensions, or
+        returns a single ProcessGroup if mesh_dim is specified or the given mesh has
+        only one mesh dimension.
+
+        Optional Args:
+            mesh_dim (str/int): it can be the name of the mesh dimension or the index
+            of the mesh dimension. Default is None.
+        Returns:
+            A list of :class:`ProcessGroup` object when `mesh_dim` is not specified for
+            a DeviceMesh with more than 1 dimension; otherwise, returns a single
+            :class:`ProcessGroup` object.
+        """
         if not hasattr(self, "_dim_group_infos"):
             raise RuntimeError("DeviceMesh process groups not initialized!")
+
+        if self.mesh.ndim == 1:
+            return _find_pg_by_ranks_and_tag(*self._dim_group_infos[0])
+
         if mesh_dim is not None:
+            if isinstance(mesh_dim, str):
+                mesh_dim = self._get_mesh_dim_by_name(mesh_dim)
             return _find_pg_by_ranks_and_tag(*self._dim_group_infos[mesh_dim])
         else:
             dim_groups = []
-            for mesh_dim in range(self.mesh.ndim):
+            for ith_dim in range(self.mesh.ndim):
                 dim_groups.append(
-                    _find_pg_by_ranks_and_tag(*self._dim_group_infos[mesh_dim])
+                    _find_pg_by_ranks_and_tag(*self._dim_group_infos[ith_dim])
                 )
             return dim_groups
 
@@ -374,6 +383,18 @@ class DeviceMesh:
         dimensions of the mesh. If this rank is not part of the mesh, return None.
         """
         return self._coordinate_on_dim if self._coordinate_on_dim else None
+
+    def _get_mesh_dim_by_name(self, mesh_dim_name: str) -> int:
+        if self.mesh_dim_names is None or len(self.mesh_dim_names) == 0:
+            raise KeyError(
+                "No `mesh_dim_names` found.",
+            )
+        if mesh_dim_name not in self.mesh_dim_names:
+            raise KeyError(
+                f"Mesh dimension '{mesh_dim_name}' does not exist.",
+                f"Available mesh dimensions are: {self.mesh_dim_names}",
+            )
+        return self.mesh_dim_names.index(mesh_dim_name)  # type: ignore[union-attr]
 
 
 def init_device_mesh(

--- a/torch/distributed/_tensor/_collective_utils.py
+++ b/torch/distributed/_tensor/_collective_utils.py
@@ -54,7 +54,7 @@ def mesh_scatter(
     # remove the check below once that is done.
     if output.is_meta:
         return None
-    dim_group = mesh.get_dim_groups(mesh_dim)
+    dim_group = mesh.get_group(mesh_dim)
     assert isinstance(dim_group, ProcessGroup)
     # src need to be global rank
     src_for_dim = 0
@@ -110,7 +110,7 @@ def mesh_broadcast(
     # remove the check below once that is done.
     if tensor.is_meta:
         return None
-    dim_group = mesh.get_dim_groups(mesh_dim)
+    dim_group = mesh.get_group(mesh_dim)
     assert isinstance(dim_group, ProcessGroup)
     # src need to be global rank
     src_for_dim = 0
@@ -128,7 +128,7 @@ def mesh_all_to_all(
     mesh_dim: int = 0,
     async_op: bool = False,
 ) -> Optional[Work]:
-    dim_group = mesh.get_dim_groups(mesh_dim)
+    dim_group = mesh.get_group(mesh_dim)
     assert isinstance(dim_group, ProcessGroup)
 
     work = None

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -124,7 +124,7 @@ def _init_process_group_state(
     else:
         if device_mesh:
             state._device_mesh = device_mesh
-            state.process_group = device_mesh.get_dim_groups(mesh_dim=0)
+            state.process_group = device_mesh.get_group(mesh_dim=0)
         else:
             state.process_group = (
                 process_group if process_group is not None else _get_default_group()
@@ -157,12 +157,12 @@ def _init_process_group_state_for_hybrid_shard(
             state._device_mesh = device_mesh
             # We currently only allow _inter_node_pg to be the outermost dimension, and the
             # process_group(intra_node) to be the innermost dimension.
-            state._inter_node_pg = device_mesh.get_dim_groups(mesh_dim=0)
-            state.process_group = device_mesh.get_dim_groups(mesh_dim=1)
+            state._inter_node_pg = device_mesh.get_group(mesh_dim=0)
+            state.process_group = device_mesh.get_group(mesh_dim=1)
         else:
             raise ValueError(
                 "Expected device_mesh to have ndim=2 "
-                f"but got {len(device_mesh.get_dim_groups())}"
+                f"but got {len(device_mesh.get_group())}"
             )
     elif process_group is None:
         default_group = _get_default_group()

--- a/torch/distributed/tensor/parallel/fsdp.py
+++ b/torch/distributed/tensor/parallel/fsdp.py
@@ -112,7 +112,7 @@ def _create_sharded_tensor_md_from_dt(
 def _get_dt_pg(dt: DTensor) -> c10d.ProcessGroup:
     mesh = dt.device_mesh
     assert mesh.ndim == 1, "Only 1D DeviceMeshes currently handled"
-    dim_groups = mesh.get_dim_groups()
+    dim_groups = mesh.get_group()
     assert isinstance(dim_groups, list)
     return dim_groups[0]
 

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -737,7 +737,7 @@ class DistributedDataParallel(Module, Joinable):
                     f"Only 1D device mesh is supported, but got {device_mesh}."
                 )
             self.device_mesh = device_mesh
-            self.process_group = device_mesh.get_dim_groups(mesh_dim=0)
+            self.process_group = device_mesh.get_group(mesh_dim=0)
 
         self.static_graph = False
         self.dim = dim

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -10055,7 +10055,7 @@ class DistributedTest:
             model = TwoLinLayerNet().cuda()
             ddp_model = torch.nn.parallel.DistributedDataParallel(model, device_mesh=device_mesh)
             self.assertEqual(ddp_model.device_mesh, device_mesh)
-            self.assertEqual(ddp_model.device_mesh.get_dim_groups(mesh_dim=0), pg)
+            self.assertEqual(ddp_model.device_mesh.get_group(mesh_dim=0), pg)
 
             with self.assertRaisesRegex(
                 RuntimeError, "Cannot specify both process_group and device_mesh arguments."


### PR DESCRIPTION
Summary:

Rename get_dim_groups to get_group and update all callsites.
ghstack-source-id: 208606443
exported-using-ghexport

Test Plan: CI

Reviewed By: wanchaol

Differential Revision: D51629801




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @tianyu-l @wconstab @yf225 @kiukchung @d4l3k @lucasllc