### PR TITLE
[distributed] NCCLflight recorder timeout fix

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1315,7 +1315,7 @@ void ProcessGroupNCCL::workCleanupLoop() {
 
       // Clean up completed work
       if (work.isCompleted()) {
-        NCCLTraceBuffer::get()->complete(work.trace_id_);
+        NCCLTraceBuffer::get()->retire_id(work.trace_id_);
         if (onCompletionHook_) {
           // Move Work object to completedWorkList_ to be consumed by the hook
           // thread

--- a/torch/csrc/distributed/c10d/TraceUtils.h
+++ b/torch/csrc/distributed/c10d/TraceUtils.h
@@ -349,8 +349,8 @@ struct NCCLTraceBuffer {
     c10::SmallVector<int, 4> input_dims_;
     c10::SmallVector<int, 4> output_dims_;
     c10::SmallVector<int64_t, 8> sizes_; // flattened from inputs, outputs
-    bool retired_ = false; // is this work entry still in the workMetaList_?
-                           // a retired by not completed event has timed out
+    bool retired_ = false; // is this work entry no longer in the workMetaList_?
+                           // a retired but not completed event has timed out
   };
 
   bool enabled_ = false;

--- a/torch/csrc/distributed/c10d/TraceUtils.h
+++ b/torch/csrc/distributed/c10d/TraceUtils.h
@@ -349,6 +349,8 @@ struct NCCLTraceBuffer {
     c10::SmallVector<int, 4> input_dims_;
     c10::SmallVector<int, 4> output_dims_;
     c10::SmallVector<int64_t, 8> sizes_; // flattened from inputs, outputs
+    bool retired_ = false; // is this work entry still in the workMetaList_?
+                           // a retired by not completed event has timed out
   };
 
   bool enabled_ = false;
@@ -406,6 +408,36 @@ struct NCCLTraceBuffer {
     return id_++;
   }
 
+  void retire(Entry& r) {
+    r.retired_ = true;
+    if (r.start_ != nullptr) {
+      bool started = true;
+      for (auto& ev : *r.start_) {
+        if (!ev.query()) {
+          started = false;
+          break;
+        }
+      }
+      if (started) {
+        r.state_ = "started";
+      }
+      r.start_ = nullptr;
+    }
+    if (r.end_ != nullptr) {
+      bool completed = true;
+      for (auto& ev : *r.end_) {
+        if (!ev.query()) {
+          completed = false;
+          break;
+        }
+      }
+      if (completed) {
+        r.state_ = "completed";
+      }
+      r.end_ = nullptr;
+    }
+  }
+
   std::vector<Entry> dump_entries() {
     std::lock_guard<std::mutex> guard(mutex_);
     std::vector<Entry> result;
@@ -414,45 +446,19 @@ struct NCCLTraceBuffer {
     result.insert(result.end(), entries_.begin(), entries_.begin() + next_);
     // query any remaining events
     for (auto& r : result) {
-      if (r.start_ != nullptr) {
-        bool started = true;
-        for (auto& ev : *r.start_) {
-          if (!ev.query()) {
-            started = false;
-            break;
-          }
-        }
-        if (started) {
-          r.state_ = "started";
-        }
-        r.start_ = nullptr;
-      }
-      if (r.end_ != nullptr) {
-        bool completed = true;
-        for (auto& ev : *r.end_) {
-          if (!ev.query()) {
-            completed = false;
-            break;
-          }
-        }
-        if (completed) {
-          r.state_ = "completed";
-        }
-        r.end_ = nullptr;
-      }
+      retire(r);
     }
     return result;
   }
 
-  void complete(c10::optional<size_t> id) {
+  void retire_id(c10::optional<size_t> id) {
     if (!enabled_ || !id) {
       return;
     }
     std::lock_guard<std::mutex> guard(mutex_);
     auto& entry = entries_.at(*id % max_entries_);
     if (entry.id_ == *id) {
-      entry.state_ = "completed";
-      entry.start_ = entry.end_ = nullptr;
+      retire(entry);
     }
   }
 
@@ -470,6 +476,7 @@ struct NCCLTraceBuffer {
     c10::IValue line_s = "line";
     c10::IValue name_s = "name";
     c10::IValue filename_s = "filename";
+    c10::IValue retired_s = "retired";
 
     std::vector<torch::CapturedTraceback*> tracebacks;
     for (auto& e : result) {
@@ -510,6 +517,8 @@ struct NCCLTraceBuffer {
       dict.insert(input_sizes_s, read_sizes(e.input_dims_));
       dict.insert(output_sizes_s, read_sizes(e.output_dims_));
       dict.insert(state_s, e.state_);
+      dict.insert(retired_s, e.retired_);
+
       auto frames = new_list();
       for (int64_t frame : tb) {
         frames.push_back(all_frames.at(frame));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #114647
* __->__ #114804

Because isCompleted() returns true on an exception, a timeout exception
will cause the flight recorder to consider the event completed even though it timed out.

This changes the logic to explicitly query the completion events on "retirement"
when the work item leaves the workMetaList. We mark events as retired so
we can distinguish between an event still in the queue but not completed and one
that timed out.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @kiukchung @d4l3k @lucasllc