### PR TITLE
[C10D] Add time_created_us to flight recorder

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -13,7 +13,7 @@ import pickle
 import time
 import warnings
 from contextlib import contextmanager
-from datetime import timedelta
+from datetime import datetime, timedelta
 from itertools import chain, product
 from unittest import mock
 
@@ -3577,6 +3577,10 @@ class NCCLTraceTest(MultiProcessTestCase):
         self.assertEqual(last['input_sizes'], ((3, 4),))
         self.assertEqual(last['output_sizes'], ((3, 4),))
         self.assertEqual(last['seq_id'], 2)
+        now = datetime.now()
+        event_created_time = datetime.fromtimestamp(last['time_created_us'] / 1000000)
+        before_test = now - timedelta(minutes=1)
+        self.assertTrue(before_test < event_created_time < now)
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(torch.cuda.device_count() < 2, "NCCL test requires 2+ GPUs")

--- a/torch/csrc/distributed/c10d/TraceUtils.h
+++ b/torch/csrc/distributed/c10d/TraceUtils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/util/ApproximateClock.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/distributed/c10d/Store.hpp>
 #include <torch/csrc/distributed/c10d/Types.hpp>
@@ -343,6 +344,11 @@ struct NCCLTraceBuffer {
     // on reporting. However, once the event is completed, the call
     // to `complete` will clear these.
     EventList *start_, *end_;
+
+    // timestamp when the entry was created, likely close to the time the work
+    // was 'enqueued'- not necessarily started
+    uint64_t time_created_;
+
     const char* state_ = "scheduled";
 
     // size information for input/output tensors
@@ -374,6 +380,9 @@ struct NCCLTraceBuffer {
         torch::CapturedTraceback::gather(true, true, capture_cpp_stack_);
     std::lock_guard<std::mutex> guard(mutex_);
 
+    static c10::ApproximateClockToUnixTimeConverter clock_converter;
+    static auto tsc_to_ns = clock_converter.makeConverter();
+
     auto te = Entry{
         id_,
         pg_id,
@@ -381,7 +390,8 @@ struct NCCLTraceBuffer {
         profiling_name,
         std::move(traceback),
         std::move(start),
-        std::move(end)};
+        std::move(end),
+        uint64_t(tsc_to_ns(c10::getApproximateTime()) / 1000)};
 
     for (const auto& input : inputs) {
       c10::IntArrayRef sizes = input.sizes();
@@ -464,6 +474,7 @@ struct NCCLTraceBuffer {
     c10::IValue profiling_name_s = "profiling_name";
     c10::IValue input_sizes_s = "input_sizes";
     c10::IValue output_sizes_s = "output_sizes";
+    c10::IValue time_created_s = "time_created_us";
 
     c10::IValue frames_s = "frames";
     c10::IValue state_s = "state";
@@ -492,6 +503,7 @@ struct NCCLTraceBuffer {
       dict.insert(pg_id_s, int64_t(e.pg_id_));
       dict.insert(seq_id_s, int64_t(e.seq_id_));
       dict.insert(profiling_name_s, e.profiling_name_);
+      dict.insert(time_created_s, int64_t(e.time_created_));
 
       auto it = e.sizes_.begin();
       auto read_sizes = [&](const c10::SmallVector<int, 4>& dims) {

--- a/torch/csrc/distributed/c10d/TraceUtils.h
+++ b/torch/csrc/distributed/c10d/TraceUtils.h
@@ -347,7 +347,7 @@ struct NCCLTraceBuffer {
 
     // timestamp when the entry was created, likely close to the time the work
     // was 'enqueued'- not necessarily started
-    uint64_t time_created_;
+    c10::time_t time_created_;
 
     const char* state_ = "scheduled";
 
@@ -391,7 +391,7 @@ struct NCCLTraceBuffer {
         std::move(traceback),
         std::move(start),
         std::move(end),
-        uint64_t(tsc_to_ns(c10::getApproximateTime()) / 1000)};
+        c10::getTime()};
 
     for (const auto& input : inputs) {
       c10::IntArrayRef sizes = input.sizes();
@@ -503,7 +503,7 @@ struct NCCLTraceBuffer {
       dict.insert(pg_id_s, int64_t(e.pg_id_));
       dict.insert(seq_id_s, int64_t(e.seq_id_));
       dict.insert(profiling_name_s, e.profiling_name_);
-      dict.insert(time_created_s, int64_t(e.time_created_));
+      dict.insert(time_created_s, int64_t(e.time_created_ / 1000));
 
       auto it = e.sizes_.begin();
       auto read_sizes = [&](const c10::SmallVector<int, 4>& dims) {

--- a/torch/csrc/distributed/c10d/TraceUtils.h
+++ b/torch/csrc/distributed/c10d/TraceUtils.h
@@ -380,9 +380,6 @@ struct NCCLTraceBuffer {
         torch::CapturedTraceback::gather(true, true, capture_cpp_stack_);
     std::lock_guard<std::mutex> guard(mutex_);
 
-    static c10::ApproximateClockToUnixTimeConverter clock_converter;
-    static auto tsc_to_ns = clock_converter.makeConverter();
-
     auto te = Entry{
         id_,
         pg_id,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #114817
* #114615
* #114625
* __->__ #114810

time_created_us is the cpu-side epoch_time (in usec) when a flight-recorder
event was created. It loosely corresponds to the time the c10d collective
API was called and a work object was created.  It does NOT correspond to
the time the collective started on the GPU.

We follow the precedent of us epoch time from this PR adding timestamps
to the cuda caching allocator:
https://github.com/pytorch/pytorch/pull/112266

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @yf225 @kiukchung @d4l3k @lucasllc