### PR TITLE
[inductor] add a config to specify the shape attribute for the generated svg graphs

### DIFF
--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -14,7 +14,7 @@ import itertools
 import sympy
 from collections import defaultdict
 from torch.fx.passes import graph_drawer
-from typing import List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 from .compile_utils import fx_graph_cse, get_aten_target
 from . import config
 import functools
@@ -921,6 +921,7 @@ def draw_graph(
     clear_meta: bool = True,
     prog: Union[str, List[str]] = None,
     parse_stack_trace: bool = False,
+    dot_graph_shape: Optional[str] = None,
 ) -> None:
     if clear_meta:
         new_graph = copy.deepcopy(traced.graph)
@@ -931,7 +932,12 @@ def draw_graph(
     if not ext:
         ext = ".svg"
     print(f"Writing FX graph to file: {base}{ext}")
-    g = graph_drawer.FxGraphDrawer(traced, figname, parse_stack_trace=parse_stack_trace)
+    g = graph_drawer.FxGraphDrawer(
+        traced,
+        figname,
+        parse_stack_trace=parse_stack_trace,
+        dot_graph_shape=dot_graph_shape,
+    )
     x = g.get_main_dot_graph()
     write_method = getattr(x, "write_" + ext.lstrip("."))
     fname = f"{base}{ext}"
@@ -941,6 +947,11 @@ def draw_graph(
         write_method(fname, prog=prog)
 
 
-def draw_joint_graph(graph, joint_inputs, file_name="full_graph.png"):
-    draw_graph(graph, file_name)
+def draw_joint_graph(
+    graph: torch.fx.GraphModule,
+    joint_inputs,
+    file_name: str = "full_graph.png",
+    dot_graph_shape: Optional[str] = None,
+):
+    draw_graph(graph, file_name, dot_graph_shape=dot_graph_shape)
     return default_partition(graph, joint_inputs)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -627,6 +627,16 @@ class trace:
     # SVG figure showing fx with fusion
     draw_orig_fx_graph = os.environ.get("INDUCTOR_ORIG_FX_SVG", "0") == "1"
 
+    # We draw our fx graphs with the "record" shape attribute by default.
+    # Sometimes, when the graph is very complex, we may hit dot errors like below:
+    #   "flat edge between adjacent nodes one of which has a record shape -
+    #    replace records with HTML-like labels"
+    # and thus fail to generate a graph. So, let's give the user an option
+    # to specify the shape attribute for the dot graph. For example, passing
+    # INDUCTOR_DOT_GRAPH_SHAPE_SVG = "none" would let us generate HTML-like lables
+    # to workaround the above failure.
+    dot_graph_shape = os.environ.get("INDUCTOR_DOT_GRAPH_SHAPE_SVG", None)
+
     # Store cProfile (see snakeviz to view)
     compile_profile = False
 

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -89,7 +89,9 @@ def draw_buffers(nodes: List[BaseSchedulerNode], print_graph=False, fname=None):
     gm = GraphModule({}, graph)
     legalize_graph(gm)
     gm.graph.lint()
-    draw_graph(gm, fname, clear_meta=False)
+    draw_graph(
+        gm, fname, clear_meta=False, dot_graph_shape=config.trace.dot_graph_shape
+    )
 
 
 def create_fx_from_snodes(snodes: List[BaseSchedulerNode]) -> fx.Graph:
@@ -474,6 +476,7 @@ class DebugFormatter:
             clear_meta=False,
             prog=GRAPHVIZ_COMMAND_SCALABLE,
             parse_stack_trace=True,
+            dot_graph_shape=config.trace.dot_graph_shape,
         )
 
     def output_code(self, filename):

--- a/torch/fx/passes/graph_drawer.py
+++ b/torch/fx/passes/graph_drawer.py
@@ -2,7 +2,7 @@
 import hashlib
 import torch
 import torch.fx
-from typing import Dict, Any, TYPE_CHECKING
+from typing import Any, Dict, Optional, TYPE_CHECKING
 from torch.fx.node import _get_qualified_name, _format_arg
 from torch.fx.graph import _parse_stack_trace
 from torch.fx.passes.shape_prop import TensorMetadata
@@ -44,7 +44,6 @@ _HASH_COLOR_MAP = [
 ]
 
 _WEIGHT_TEMPLATE = {
-    "shape": "record",
     "fillcolor": "Salmon",
     "style": '"filled,rounded"',
     "fontcolor": "#000000",
@@ -68,8 +67,14 @@ if HAS_PYDOT:
             ignore_parameters_and_buffers: bool = False,
             skip_node_names_in_args: bool = True,
             parse_stack_trace: bool = False,
+            dot_graph_shape: Optional[str] = None,
         ):
             self._name = name
+            self.dot_graph_shape = (
+                dot_graph_shape if dot_graph_shape is not None else "record"
+            )
+            _WEIGHT_TEMPLATE["shape"] = self.dot_graph_shape
+
             self._dot_graphs = {
                 name: self._to_dot(
                     graph_module, name, ignore_getattr, ignore_parameters_and_buffers, skip_node_names_in_args, parse_stack_trace
@@ -133,8 +138,9 @@ if HAS_PYDOT:
             return self._dot_graphs
 
         def _get_node_style(self, node: torch.fx.Node) -> Dict[str, str]:
+
             template = {
-                "shape": "record",
+                "shape": self.dot_graph_shape,
                 "fillcolor": "#CAFFE3",
                 "style": '"filled,rounded"',
                 "fontcolor": "#000000",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #114811

We draw our fx graphs with the "record" shape attribute by default.
Sometimes, when the graph is very complex, we may hit dot errors like below:
  "flat edge between adjacent nodes one of which has a record shape -
   replace records with HTML-like labels"
and thus fail to generate a graph. So, let's give the user an option
to specify the shape attribute for the dot graph. For example, passing
INDUCTOR_DOT_GRAPH_SHAPE_SVG = "none" would let us generate HTML-like lables
to workaround the above failure.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @kadeng @muchulee8 @aakhundov @ColinPeppler