### PR TITLE
[MacOS] Embed libomp.dylib/omp.h into MacOS wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -521,8 +521,8 @@ def check_pydep(importname, module):
 
 
 class build_ext(setuptools.command.build_ext.build_ext):
-    # Copy libiomp5.dylib inside the wheel package on OS X
-    def _embed_libiomp(self):
+    def _embed_libomp(self):
+        # Copy libiomp5.dylib/libomp.dylib inside the wheel package on MacOS
         lib_dir = os.path.join(self.build_lib, "torch", "lib")
         libtorch_cpu_path = os.path.join(lib_dir, "libtorch_cpu.dylib")
         if not os.path.exists(libtorch_cpu_path):
@@ -545,17 +545,31 @@ class build_ext(setuptools.command.build_ext.build_ext):
                 assert rpath.startswith("path ")
                 rpaths.append(rpath.split(" ", 1)[1].rsplit("(", 1)[0][:-1])
 
-        omp_lib_name = "libiomp5.dylib"
+        omp_lib_name = (
+            "libomp.dylib" if os.uname().machine == "arm64" else "libiomp5.dylib"
+        )
         if os.path.join("@rpath", omp_lib_name) not in libs:
             return
 
-        # Copy libiomp5 from rpath locations
+        # Copy libomp/libiomp5 from rpath locations
         for rpath in rpaths:
             source_lib = os.path.join(rpath, omp_lib_name)
             if not os.path.exists(source_lib):
                 continue
             target_lib = os.path.join(self.build_lib, "torch", "lib", omp_lib_name)
             self.copy_file(source_lib, target_lib)
+            break
+
+        # Copy omp.h from OpenMP_C_FLAGS and copy it into include folder
+        omp_cflags = get_cmake_cache_vars()["OpenMP_C_FLAGS"]
+        if not omp_cflags:
+            return
+        for include_dir in [f[2:] for f in omp_cflags.split(" ") if f.startswith("-I")]:
+            omp_h = os.path.join(include_dir, "omp.h")
+            if not os.path.exists(omp_h):
+                continue
+            target_omp_h = os.path.join(self.build_lib, "torch", "include", "omp.h")
+            self.copy_file(omp_h, target_omp_h)
             break
 
     def run(self):
@@ -650,7 +664,7 @@ class build_ext(setuptools.command.build_ext.build_ext):
         setuptools.command.build_ext.build_ext.run(self)
 
         if IS_DARWIN and package_type != "conda":
-            self._embed_libiomp()
+            self._embed_libomp()
 
         # Copy the essential export library to compile C++ extensions.
         if IS_WINDOWS:


### PR DESCRIPTION
To keep them on par with what we do on x86
And `omp.h` as it is needed for `torch.compile` on CPU

