### PR TITLE
Better error message for misconfigured torchbench model

### DIFF
--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -377,6 +377,9 @@ class TorchBenchmarkRunner(BenchmarkRunner):
         else:
             raise ImportError(f"could not import any of {candidates}")
         benchmark_cls = getattr(module, "Model", None)
+        if benchmark_cls is None:
+            raise NotImplementedError(f"{model_name}.Model is None")
+
         if not hasattr(benchmark_cls, "name"):
             benchmark_cls.name = model_name
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #114827

```
  File "/home/jansel/pytorch/./benchmarks/dynamo/torchbench.py", line 381, in load_model
    benchmark_cls.name = model_name
AttributeError: 'NoneType' object has no attribute 'name
```
becomes
```
  File "/home/jansel/pytorch/./benchmarks/dynamo/torchbench.py", line 381, in load_model
    raise NotImplementedError(f"{model_name}.Model is None")
NotImplementedError: torchrec_dlrm.Model is None
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng