### PR TITLE
[dynamo] tie lifetime of cached backend to `GuardFn`/`GuardedCode`, not thread-local state which is brittle for multithread

### DIFF
--- a/docs/source/torch.compiler_deepdive.rst
+++ b/docs/source/torch.compiler_deepdive.rst
@@ -81,7 +81,7 @@ guards:
    hasattr(L['a'], '_dynamo_dynamic_indices') == False
    hasattr(L['b'], '_dynamo_dynamic_indices') == False
    utils_device.CURRENT_DEVICE == None
-   ___skip_backend_check() or ___current_backend() == ___lookup_backend(140355900538256)
+   ___skip_backend_check() or ___current_backend() == G['___dynamo_cached_backends'][140355900538256]
    check_tensor(L['a'], Tensor, DispatchKeySet(CPU, BackendSelect, ADInplaceOrView, AutogradCPU), torch.float32, device=None, requires_grad=False, size=[10], stride=[1])
    check_tensor(L['b'], Tensor, DispatchKeySet(CPU, BackendSelect, ADInplaceOrView, AutogradCPU), torch.float32, device=None, requires_grad=False, size=[10], stride=[1])
 
@@ -258,7 +258,7 @@ The output is:
    hasattr(L['a'], '_dynamo_dynamic_indices') == False
    hasattr(L['b'], '_dynamo_dynamic_indices') == False
    utils_device.CURRENT_DEVICE == None
-   ___skip_backend_check() or ___current_backend() == ___lookup_backend(140215810860528)
+   ___skip_backend_check() or ___current_backend() == G['___dynamo_cached_backends'][140355900538256]
    ___check_tensors(L['a'], L['b'], tensor_check_names=tensor_check_names)
 
 Only when all the conditions are satisfied, the guard function returns true, and the compiled code is executed.

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -101,20 +101,12 @@ def _maybe_init_guarded_backend_cache():
         guarded_backend_cache.skip_backend_check_for_run_only_mode = False
     if not hasattr(guarded_backend_cache, "current_backend"):
         guarded_backend_cache.current_backend = None
-    if not hasattr(guarded_backend_cache, "cached_backends"):
-        guarded_backend_cache.cached_backends = {}
 
 
 def _reset_guarded_backend_cache():
     _maybe_init_guarded_backend_cache()
     guarded_backend_cache.skip_backend_check_for_run_only_mode = False
     guarded_backend_cache.current_backend = None
-    cached_backends = guarded_backend_cache.cached_backends
-    for backend in cached_backends.values():
-        if hasattr(backend, "reset"):
-            backend.reset()
-    cached_backends.clear()
-    guarded_backend_cache.cached_backends = {}
 
 
 @contextlib.contextmanager
@@ -138,8 +130,6 @@ def backend_cache_wrapper(callback: DynamoCallback):
         def _set_current_backend(backend: CompilerFn):
             prev_backend = guarded_backend_cache.current_backend
             guarded_backend_cache.current_backend = backend
-            # Mapping id of a CompilerFn to itself
-            guarded_backend_cache.cached_backends[id(backend)] = backend
             return prev_backend
 
         prev_backend = _set_current_backend(backend)

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -199,8 +199,8 @@ class GuardBuilder(GuardBuilderBase):
         self.source_ref = source_ref
         self.lookup_weakrefs = lookup_weakrefs
         self.scope: Dict[str, Dict[str, object]] = {"L": local_scope, "G": global_scope}
-        self.scope["G"]["___cached_backends"] = self.scope["G"].get(
-            "___cached_backends", {}
+        self.scope["G"]["___dynamo_cached_backends"] = self.scope["G"].get(
+            "___dynamo_cached_backends", {}
         )
         self.scope["__builtins__"] = builtins.__dict__.copy()
         for (
@@ -594,9 +594,9 @@ class GuardBuilder(GuardBuilderBase):
         """Guard on backend matching based on id of current_backend"""
         assert guard.source is GuardSource.GLOBAL
         backend = torch._dynamo.eval_frame.guarded_backend_cache.current_backend
-        self.get("G['___cached_backends']")[id(backend)] = backend
+        self.get("G['___dynamo_cached_backends']")[id(backend)] = backend
         code = [
-            f"(___skip_backend_check() or ___current_backend() == G['___cached_backends'][{id(backend)}])"
+            f"(___skip_backend_check() or ___current_backend() == G['___dynamo_cached_backends'][{id(backend)}])"
         ]
         self._produce_guard_code(guard, code)
 

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -99,11 +99,6 @@ CLOSURE_VARS = {
     "___current_backend": (
         lambda: torch._dynamo.eval_frame.guarded_backend_cache.current_backend
     ),
-    "___lookup_backend": (
-        lambda backend_obj_id: torch._dynamo.eval_frame.guarded_backend_cache.cached_backends[
-            backend_obj_id
-        ]
-    ),
     "___skip_backend_check": (
         lambda: torch._dynamo.eval_frame.guarded_backend_cache.skip_backend_check_for_run_only_mode
     ),
@@ -204,6 +199,9 @@ class GuardBuilder(GuardBuilderBase):
         self.source_ref = source_ref
         self.lookup_weakrefs = lookup_weakrefs
         self.scope: Dict[str, Dict[str, object]] = {"L": local_scope, "G": global_scope}
+        self.scope["G"]["___cached_backends"] = self.scope["G"].get(
+            "___cached_backends", {}
+        )
         self.scope["__builtins__"] = builtins.__dict__.copy()
         for (
             name,
@@ -595,11 +593,10 @@ class GuardBuilder(GuardBuilderBase):
     def BACKEND_MATCH(self, guard: Guard):
         """Guard on backend matching based on id of current_backend"""
         assert guard.source is GuardSource.GLOBAL
-        backend_id = (
-            f"{id(torch._dynamo.eval_frame.guarded_backend_cache.current_backend)}"
-        )
+        backend = torch._dynamo.eval_frame.guarded_backend_cache.current_backend
+        self.get("G['___cached_backends']")[id(backend)] = backend
         code = [
-            f"(___skip_backend_check() or ___current_backend() == ___lookup_backend({backend_id}))"
+            f"(___skip_backend_check() or ___current_backend() == G['___cached_backends'][{id(backend)}])"
         ]
         self._produce_guard_code(guard, code)
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/114674

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng