### PR TITLE
[Inductor] We re-enable the batch_fusion and group_fusion flags in order not to disturb the current production model implementation

### DIFF
--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -217,9 +217,9 @@ class TestPoitwiseOps(torch.nn.Module):
 
 
 @requires_cuda()
-@torch._inductor.config.patch(
-    post_grad_fusion_options={"group_linear": {"require_fbgemm": True}}
-)
+@torch._inductor.config.patch(post_grad_fusion_options={})
+@torch._inductor.config.patch(pre_grad_fusion_options={})
+@torch._inductor.config.patch(group_fusion=True, batch_fusion=True)
 class TestGroupBatchFusion(TestCase):
     def compare_dict_tensors(self, ref_dict, res_dict, rtol=1e-3, atol=1e-3):
         if len(set(ref_dict.keys())) != len(set(res_dict.keys())):
@@ -433,9 +433,7 @@ class TestBMMFusionModule(torch.nn.Module):
 
 
 @requires_cuda()
-@torch._inductor.config.patch(
-    post_grad_fusion_options={"batch_linear": {"require_fbgemm": False}}
-)
+@torch._inductor.config.patch(post_grad_fusion_options={"batch_linear_post_grad": {}})
 class TestPostGradBatchLinearFusion(TestCase):
     def test_batch_linear_post_grad_fusion(self):
         pt1_module = TestBMMFusionModule().cuda()


### PR DESCRIPTION
Summary:
We did two things:
1. We add back the batch_fusion and group_fusion flags to keep the current production model implementation

2. We tell batch and group fusion in the post grad since group need fbgemm.

Test Plan:
```
buck2 test 'fbcode//mode/dev-nosan' fbcode//caffe2/test/inductor:group_batch_fusion
```
Buck UI: https://www.internalfb.com/buck2/13d152d2-5d4d-4c7a-ab88-51f8e8218942
Test UI: https://www.internalfb.com/intern/testinfra/testrun/1125900253044737
Network: Up: 376KiB  Down: 44KiB  (reSessionID-c508aedc-8cc2-434a-8c17-bbe075a05562)
Jobs completed: 17. Time elapsed: 1:23.1s.
Cache hits: 0%. Commands: 1 (cached: 0, remote: 0, local: 1)
Tests finished: Pass 6. Fail 0. Fatal 0. Skip 0. Build failure 0

Differential Revision: D51695982




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler