### PR TITLE
[BE] Do not use AT_ERROR

### DIFF
--- a/torch/csrc/jit/runtime/vararg_functions.cpp
+++ b/torch/csrc/jit/runtime/vararg_functions.cpp
@@ -106,8 +106,10 @@ void tupleUnpack(Stack& stack) {
 }
 
 void format(Stack& stack, size_t num_inputs) {
-  TORCH_CHECK(num_inputs > 0 && num_inputs <= stack.size(), 
-      "Invalid number of inputs for format string: ", num_inputs);
+  TORCH_CHECK(
+      num_inputs > 0 && num_inputs <= stack.size(),
+      "Invalid number of inputs for format string: ",
+      num_inputs);
 
   // static const std::regex unsupported_options("\\{(.*?)\\}");
   auto format = peek(stack, 0, num_inputs).toStringRef();

--- a/torch/csrc/jit/runtime/vararg_functions.cpp
+++ b/torch/csrc/jit/runtime/vararg_functions.cpp
@@ -106,9 +106,8 @@ void tupleUnpack(Stack& stack) {
 }
 
 void format(Stack& stack, size_t num_inputs) {
-  if (num_inputs == 0 || num_inputs > stack.size()) {
-    AT_ERROR("Invalid number of inputs for format string: ", num_inputs);
-  }
+  TORCH_CHECK(num_inputs > 0 && num_inputs > stack.size(), 
+      "Invalid number of inputs for format string: ", num_inputs);
 
   // static const std::regex unsupported_options("\\{(.*?)\\}");
   auto format = peek(stack, 0, num_inputs).toStringRef();

--- a/torch/csrc/jit/runtime/vararg_functions.cpp
+++ b/torch/csrc/jit/runtime/vararg_functions.cpp
@@ -106,7 +106,7 @@ void tupleUnpack(Stack& stack) {
 }
 
 void format(Stack& stack, size_t num_inputs) {
-  TORCH_CHECK(num_inputs > 0 && num_inputs > stack.size(), 
+  TORCH_CHECK(num_inputs > 0 && num_inputs <= stack.size(), 
       "Invalid number of inputs for format string: ", num_inputs);
 
   // static const std::regex unsupported_options("\\{(.*?)\\}");


### PR DESCRIPTION
As later is just an alias to `TORCH_CHECK(false,)`

Proposed as suggestion to https://github.com/pytorch/pytorch/pull/110303 but it wasn't noticed
