### PR TITLE
[c10d] Move class definition of DebugInfoWriter to TraceUtil as well

### DIFF
--- a/torch/csrc/distributed/c10d/NCCLUtils.hpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.hpp
@@ -174,17 +174,6 @@ std::string getNcclErrorDetailStr(
     ncclResult_t error,
     c10::optional<std::string> processGroupFailureReason = c10::nullopt);
 
-// Write NCCL debug info to local disk or any storage users define.
-class TORCH_API DebugInfoWriter {
- public:
-  DebugInfoWriter(int rank);
-  virtual ~DebugInfoWriter();
-  virtual void write(const std::string& ncclTrace);
-
- protected:
-  std::string filename_;
-};
-
 // RAII wrapper for NCCL communicator
 class NCCLComm {
  public:

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -22,6 +22,7 @@
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
 
+#include <torch/csrc/distributed/c10d/TraceUtils.h>
 #include <torch/custom_class.h>
 
 namespace c10d {

--- a/torch/csrc/distributed/c10d/TraceUtils.h
+++ b/torch/csrc/distributed/c10d/TraceUtils.h
@@ -10,6 +10,7 @@
 #include <sys/types.h>
 
 #include <cstdlib>
+#include <fstream>
 #include <string>
 #include <system_error>
 #include <vector>
@@ -268,6 +269,17 @@ inline std::string retrieveDesyncReport(
  * wasn't done that way, so isn't expected to be fully general at the moment) */
 
 #ifdef USE_C10D_NCCL
+
+// Write NCCL debug info to local disk or any storage users define.
+class TORCH_API DebugInfoWriter {
+ public:
+  DebugInfoWriter(int rank);
+  virtual ~DebugInfoWriter();
+  virtual void write(const std::string& ncclTrace);
+
+ protected:
+  std::string filename_;
+};
 
 DebugInfoWriter::DebugInfoWriter(int rank) {
   std::string fileName = getCvarString(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #114926
* __->__ #114901

Since we moved the implementation of the class to TraceUtils in https://github.com/pytorch/pytorch/pull/114367, maybe we also want to move the implementation here as well.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @wz337 @tianyu-l @wconstab @yf225 @kiukchung @d4l3k @lucasllc