### PR TITLE
[dynamo, test] add test for backend registration API

### DIFF
--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -215,6 +215,79 @@ class TestExplainWithBackend(torch._dynamo.test_case.TestCase):
         self.assertEqual(8, explain_output.op_count)
 
 
+class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
+    """Test APIs documented by https://pytorch.org/docs/main/torch.compiler_custom_backends.html"""
+
+    def test_register_backend_api(self):
+        from torch._dynamo import register_backend
+
+        backend_run = False
+
+        @register_backend
+        def my_custom_backend(gm, example_inputs):
+            nonlocal backend_run
+            backend_run = True
+            return gm.forward
+
+        def f(x):
+            return torch.relu(x)
+
+        opt_f = torch.compile(f, backend="my_custom_backend")
+        opt_f(torch.randn(3, 3))
+        self.assertTrue(backend_run)
+
+    def test_aot_autograd_api(self):
+        from functorch.compile import make_boxed_func
+        from torch._dynamo.backends.common import aot_autograd
+
+        backend_run = False
+
+        def my_compiler(gm, example_inputs):
+            nonlocal backend_run
+            backend_run = True
+            return make_boxed_func(gm.forward)
+
+        my_backend = aot_autograd(fw_compiler=my_compiler)
+
+        def f(x):
+            return torch.relu(x)
+
+        opt_f = torch.compile(f, backend=my_backend)
+        opt_f(torch.randn(3, 3))
+        self.assertTrue(backend_run)
+
+    def test_lookup_backend(self):
+        from torch._dynamo import list_backends, lookup_backend
+
+        backends = list_backends()
+        backend_run = False
+
+        def my_compiler(gm, example_inputs):
+            nonlocal backend_run
+            backend_run = True
+            try:
+                trt_compiled = lookup_backend("tensorrt")(gm, example_inputs)
+                if trt_compiled is not None:
+                    return trt_compiled
+            except Exception:
+                pass
+            # first backend failed, try something else...
+            try:
+                inductor_compiled = lookup_backend("inductor")(gm, example_inputs)
+                if inductor_compiled is not None:
+                    return inductor_compiled
+            except Exception:
+                pass
+            return gm.forward
+
+        def f(x):
+            return torch.relu(x)
+
+        opt_f = torch.compile(f, backend=my_compiler)
+        opt_f(torch.randn(3, 3))
+        self.assertTrue(backend_run)
+
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #114908
* #114820

Add tests for backend registration API, per https://github.com/pytorch/pytorch/pull/114820.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng