### PR TITLE
[pt2][quant] Enable _fold_conv_bn_qat with BN in eval mode

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e_qat.py
+++ b/test/quantization/pt2e/test_quantize_pt2e_qat.py
@@ -159,6 +159,7 @@ class PT2EQATTestCase(QuantizationTestCase):
         self.assertEqual(after_prepare_result_pt2e, after_prepare_result_fx)
 
         if verify_convert:
+            # We don't want to impose any ordering requirements between move_exported_model_to_eval and convert_pt2e
             torch.ao.quantization.move_exported_model_to_eval(model_pt2e)
             model_pt2e = convert_pt2e(model_pt2e)
             quant_result_pt2e = model_pt2e(*example_inputs)

--- a/test/quantization/pt2e/test_quantize_pt2e_qat.py
+++ b/test/quantization/pt2e/test_quantize_pt2e_qat.py
@@ -160,9 +160,7 @@ class PT2EQATTestCase(QuantizationTestCase):
 
         if verify_convert:
             torch.ao.quantization.move_exported_model_to_eval(model_pt2e)
-            # print("model_pt2e is: {}".format(model_pt2e), flush=True)
             model_pt2e = convert_pt2e(model_pt2e)
-            # torch.ao.quantization.move_exported_model_to_eval(model_pt2e)
             quant_result_pt2e = model_pt2e(*example_inputs)
             model_fx.eval()
             model_fx = _convert_to_reference_decomposed_fx(

--- a/test/quantization/pt2e/test_quantize_pt2e_qat.py
+++ b/test/quantization/pt2e/test_quantize_pt2e_qat.py
@@ -159,8 +159,10 @@ class PT2EQATTestCase(QuantizationTestCase):
         self.assertEqual(after_prepare_result_pt2e, after_prepare_result_fx)
 
         if verify_convert:
-            model_pt2e = convert_pt2e(model_pt2e)
             torch.ao.quantization.move_exported_model_to_eval(model_pt2e)
+            # print("model_pt2e is: {}".format(model_pt2e), flush=True)
+            model_pt2e = convert_pt2e(model_pt2e)
+            # torch.ao.quantization.move_exported_model_to_eval(model_pt2e)
             quant_result_pt2e = model_pt2e(*example_inputs)
             model_fx.eval()
             model_fx = _convert_to_reference_decomposed_fx(

--- a/torch/ao/quantization/pt2e/qat_utils.py
+++ b/torch/ao/quantization/pt2e/qat_utils.py
@@ -180,6 +180,7 @@ def _get_quantized_qat_conv_bn_pattern(
     has_bias: bool,
     bias_is_quantized: bool,
     conv_fn: Callable,
+    bn_is_training: bool,
 ) -> Callable:
     """
     Return the quantized version of QAT conv + BN pattern.
@@ -218,7 +219,7 @@ def _get_quantized_qat_conv_bn_pattern(
         x = x / scale_factor.reshape(bias_shape)
         if has_bias:
             x = x + kwargs["conv_bias"].reshape(bias_shape)
-        x = F.batch_norm(x, bn_running_mean, bn_running_var, bn_weight, bn_bias, training=True, eps=bn_eps)
+        x = F.batch_norm(x, bn_running_mean, bn_running_var, bn_weight, bn_bias, training=bn_is_training, eps=bn_eps)
         return x
     return _quantized_qat_conv_bn_pattern
 
@@ -227,6 +228,7 @@ def _get_folded_quantized_qat_conv_bn_pattern(
     has_bias: bool,
     bias_is_quantized: bool,
     conv_fn: Callable,
+    bn_is_training: bool,
 ) -> Callable:
     """
     Quantized QAT conv - bn pattern with bn weights being folded into conv.
@@ -251,7 +253,7 @@ def _get_folded_quantized_qat_conv_bn_pattern(
         else:
             bias = None
         x = conv_fn(x, conv_weight, bias)
-        x = F.batch_norm(x, bn_running_mean, bn_running_var, bn_weight, bn_bias, training=True, eps=bn_eps)
+        x = F.batch_norm(x, bn_running_mean, bn_running_var, bn_weight, bn_bias, training=bn_is_training, eps=bn_eps)
         return x
     return _folded_quantized_qat_conv_bn_pattern
 
@@ -322,7 +324,7 @@ def _get_conv_bn_pattern_nodes(r: ReplacedPatterns) -> Dict[str, Tuple[Node, Nod
             if _is_conv(n):
                 assert conv_node is None
                 conv_node = n
-            if _is_supported_batch_norm_for_training(n):
+            if _is_supported_batch_norm_for_training(n) or n.target == torch.ops.aten._native_batch_norm_legit_no_training.default:
                 assert bn_node is None
                 bn_node = n
             if n.target == operator.getitem:
@@ -715,19 +717,20 @@ def _fold_conv_bn_qat_helper(
         [True, False],  # is_per_channel
         [True, False],  # has_bias
         [True, False],  # bias_is_quantized
+        [True, False],  # bn_is_training
     )
-    for is_per_channel, has_bias, bias_is_quantized in replacement_options:
+    for is_per_channel, has_bias, bias_is_quantized, bn_is_training in replacement_options:
         # For the cases without bias, `bias_is_quantized` is irrelevant, so here we arbitrarily
         # filter out one of the values for this flag to avoid having duplicate patterns
         if not has_bias and bias_is_quantized:
             continue
         kwargs = _get_quantized_conv_bn_example_inputs_kwargs(is_per_channel, has_bias, is_cuda)
         match_pattern = _get_quantized_qat_conv_bn_pattern(
-            is_per_channel, has_bias, bias_is_quantized, conv_fn,
+            is_per_channel, has_bias, bias_is_quantized, conv_fn, bn_is_training
         )
         match_pattern = get_aten_graph_module(match_pattern, example_inputs, is_cuda, **kwargs)
         replacement_pattern = _get_folded_quantized_qat_conv_bn_pattern(
-            is_per_channel, has_bias, bias_is_quantized, conv_fn
+            is_per_channel, has_bias, bias_is_quantized, conv_fn, bn_is_training
         )
         replacement_pattern = get_aten_graph_module(replacement_pattern, example_inputs, is_cuda, **kwargs)
         replacements.extend(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #114927

**Summary**
Draft a fix as discussed in https://github.com/pytorch/pytorch/pull/114547#discussion_r1411559586, since we don't want to impose any ordering requirements between `move_exported_model_to_eval` and `convert_pt2e`

**Test Plan**
```
python -u -m pytest -s -v test_quantize_pt2e_qat.py -k test_qat_resnet18
```
