### PR TITLE
remove compute capability 3.5 for CUDA 12

### DIFF
--- a/cmake/Modules_CUDA_fix/upstream/FindCUDA/select_compute_arch.cmake
+++ b/cmake/Modules_CUDA_fix/upstream/FindCUDA/select_compute_arch.cmake
@@ -75,6 +75,8 @@ endif()
 if(NOT CUDA_VERSION VERSION_LESS "12.0")
   list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "9.0a")
   list(APPEND CUDA_ALL_GPU_ARCHITECTURES "9.0a")
+  list(REMOVE_ITEM CUDA_COMMON_GPU_ARCHITECTURES "3.5")
+  list(REMOVE_ITEM CUDA_ALL_GPU_ARCHITECTURES "3.5")
 endif()
 
 ################################################################################################


### PR DESCRIPTION
CUDA 12 has removed compute capability 3.5. NVCC throws the error: `nvcc fatal   : Unsupported gpu architecture 'compute_35'`