### PR TITLE
Fix hard-coded `cuda` device in `ConstructorMoverPass`.

### DIFF
--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1156,7 +1156,7 @@ class ConstructorMoverPass:
                 if (
                     self.allow_cpu_device(user)
                     and node_device
-                    and node_device.type == "cuda"
+                    and node_device.type == self.target
                 ):
                     del cpu_indeg[user]
                 else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #114932
* #114626



cc @bdhirsh @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler