### PR TITLE
improve mkldnn_linear_pointwise performance for contiguous tensor with non default contiguous strides

### DIFF
--- a/aten/src/ATen/native/mkldnn/Linear.cpp
+++ b/aten/src/ATen/native/mkldnn/Linear.cpp
@@ -3,7 +3,6 @@
 #include <ATen/Parallel.h>
 #include <ATen/core/Tensor.h>
 #include <torch/library.h>
-#include <c10/util/strides.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -192,12 +191,7 @@ static Tensor mkldnn_linear_pointwise(
   auto input_size = input.sizes();
 
   // Make sure input has default contiguous strides if it's contiguous tensors for better performance.
-  // For example, for tensor of size = [1, 1280], stride = [0, 1], we'll convert it to size = [1, 1280], stride = [1280, 1]
-  // before calling oneDNN for better performance.
-  IntArrayRef input_default_contiguous_strides = c10::contiguous_strides(input_size);
-  if (input.is_contiguous() && input.strides() != input_default_contiguous_strides) {
-     input = input.as_strided(input_size, input_default_contiguous_strides);
-  }
+  input = may_convert_to_default_contiguous_strides(input);
 
   const int64_t dim = input.dim();
   auto input_reshaped =

--- a/aten/src/ATen/native/mkldnn/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/Matmul.cpp
@@ -251,18 +251,8 @@ void mkldnn_matmul(
   Tensor mat1_ = is_mkldnn_optimized_format(mat1_unsqueezed) ? mat1_unsqueezed : mat1_unsqueezed.contiguous();
   Tensor mat2_ = is_mkldnn_optimized_format(mat2_unsqueezed) ? mat2_unsqueezed : mat2_unsqueezed.contiguous();
   // Make sure mat1 and mat2 have default contiguous strides if they are contiguous tensors for better performance.
-  auto mat1_sizes = mat1_.sizes();
-  auto mat1_default_contiguous_strides = c10::contiguous_strides(mat1_sizes);
-  if (mat1_.is_contiguous() &&
-      mat1_.strides() != c10::IntArrayRef(mat1_default_contiguous_strides)) {
-     mat1_ = mat1_.as_strided(mat1_sizes, mat1_default_contiguous_strides);
-  }
-  auto mat2_sizes = mat2_.sizes();
-  auto mat2_default_contiguous_strides = c10::contiguous_strides(mat2_sizes);
-  if (mat2_.is_contiguous() &&
-      mat2_.strides() != c10::IntArrayRef(mat2_default_contiguous_strides)) {
-    mat2_ = mat2_.as_strided(mat2_sizes, mat2_default_contiguous_strides);
-  }
+  mat1_ = may_convert_to_default_contiguous_strides(mat1_);
+  mat2_ = may_convert_to_default_contiguous_strides(mat2_);
 
   // mkldnn_matmul only proceed CPU tensor
   const ideep::tensor x = itensor_view_from_dense(mat1_);

--- a/aten/src/ATen/native/mkldnn/Utils.h
+++ b/aten/src/ATen/native/mkldnn/Utils.h
@@ -62,8 +62,9 @@ static inline std::vector<int64_t> padding_r(
 // before calling oneDNN for better performance.
 static inline Tensor may_convert_to_default_contiguous_strides(const Tensor& input) {
   auto input_size = input.sizes();
+  auto input_stride = input.strides();
   IntArrayRef input_default_contiguous_strides = c10::contiguous_strides(input_size);
-  if (input.is_contiguous() && input.strides() != input_default_contiguous_strides) {
+  if (input.is_contiguous() && input_stride != input_default_contiguous_strides) {
      return input.as_strided(input_size, input_default_contiguous_strides);
   }
   return input;

--- a/aten/src/ATen/native/mkldnn/Utils.h
+++ b/aten/src/ATen/native/mkldnn/Utils.h
@@ -61,8 +61,8 @@ static inline std::vector<int64_t> padding_r(
 // For example, for tensor of size = [1, 1280], stride = [0, 1], we'll convert it to size = [1, 1280], stride = [1280, 1]
 // before calling oneDNN for better performance.
 static inline Tensor may_convert_to_default_contiguous_strides(const Tensor& input) {
-  auto input_size = input.sizes();
-  auto input_stride = input.strides();
+  auto input_size = input.sizes().vec();
+  auto input_stride = input.strides().vec();
   IntArrayRef input_default_contiguous_strides = c10::contiguous_strides(input_size);
   if (input.is_contiguous() && input_stride != input_default_contiguous_strides) {
      return input.as_strided(input_size, input_default_contiguous_strides);

--- a/aten/src/ATen/native/mkldnn/Utils.h
+++ b/aten/src/ATen/native/mkldnn/Utils.h
@@ -63,8 +63,8 @@ static inline std::vector<int64_t> padding_r(
 static inline Tensor may_convert_to_default_contiguous_strides(const Tensor& input) {
   auto input_size = input.sizes().vec();
   auto input_stride = input.strides().vec();
-  IntArrayRef input_default_contiguous_strides = c10::contiguous_strides(input_size);
-  if (input.is_contiguous() && input_stride != input_default_contiguous_strides) {
+  auto input_default_contiguous_strides = c10::contiguous_strides(input_size);
+  if (input.is_contiguous() && input_stride != c10::IntArrayRef(input_default_contiguous_strides)) {
      return input.as_strided(input_size, input_default_contiguous_strides);
   }
   return input;

--- a/aten/src/ATen/native/mkldnn/Utils.h
+++ b/aten/src/ATen/native/mkldnn/Utils.h
@@ -4,6 +4,7 @@
 #include <ATen/core/List.h>
 #include <ATen/core/Tensor.h>
 #include <c10/util/ArrayRef.h>
+#include <c10/util/strides.h>
 #if !defined(__s390x__) && !defined(__powerpc__)
 #include <cpuinfo.h>
 #endif
@@ -54,6 +55,18 @@ static inline std::vector<int64_t> padding_r(
     pad_r[d] = padding[d] - output_padding[d];
   }
   return pad_r;
+}
+
+// Make sure input has default contiguous strides if it's contiguous tensors for better performance.
+// For example, for tensor of size = [1, 1280], stride = [0, 1], we'll convert it to size = [1, 1280], stride = [1280, 1]
+// before calling oneDNN for better performance.
+static inline Tensor may_convert_to_default_contiguous_strides(const Tensor& input) {
+  auto input_size = input.sizes();
+  IntArrayRef input_default_contiguous_strides = c10::contiguous_strides(input_size);
+  if (input.is_contiguous() && input.strides() != input_default_contiguous_strides) {
+     return input.as_strided(input_size, input_default_contiguous_strides);
+  }
+  return input;
 }
 
 #if AT_MKLDNN_ENABLED()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #114939

This PR will convert the stride to the default contiguous stride in `mkldnn_linear_pointwise` before calling oneDNN to run into an optimization path similar to https://github.com/pytorch/pytorch/pull/99511. Also refactored the code to provide a common utility function.

https://github.com/pytorch/pytorch/pull/111976 will ignore Dims of value 1 in Require_Stride_order. For a tensor with `size = [1, 1280]`, `stride = [0, 1]`:
**Before the above PR**, it is considered as non-contiguous, thus in the below call, it is converted to `size = [1, 1280]`, `stride = [1280,1]`:
https://github.com/pytorch/pytorch/blob/25b83521be3174e91da8ce60123b4811c3d78a75/torch/_inductor/ir.py#L5263

**While after the above PR**, dims of value 1 are ignored so this tensor is already contiguous and we'll feed a tensor with `stride = [0, 1]` to oneDNN, which results in poor performance.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10