### PR TITLE
[caffe2/tests][re-test] opt in bunch of test to run on RE (#114977)

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 import weakref
 from dataclasses import dataclass, field
 from typing import List, Optional
+import pkg_resources
 
 import expecttest
 import subprocess
@@ -78,7 +79,6 @@ except ImportError:
 import pickle
 
 from torch._C._profiler import _ExperimentalConfig, _ExtraFields_PyCall
-
 
 @unittest.skipIf(not HAS_PSUTIL, "Requires psutil to run")
 @unittest.skipIf(TEST_WITH_ASAN, "Cannot test with ASAN")
@@ -2754,9 +2754,7 @@ class TestExperimentalUtils(TestCase):
     @staticmethod
     def load_mock_profile():
         accept = expecttest.ACCEPT
-        json_file_path = os.path.join(
-            os.path.dirname(os.path.realpath(__file__)),
-            "profiler_utils_mock_events.json")
+        json_file_path = pkg_resources.resource_filename(__name__, "profiler_utils_mock_events.json")
         if accept and torch.cuda.is_available():
 
             def garbage_code(x):


### PR DESCRIPTION
Summary:

try to solve timeouts and OOMs by running those tests on RE

the normal test targets were partially manually codemoded via:
```
arc buildozer 'set_if_absent remote_execution re_test_utils.remote_execution_linux_default()' fbcode//"${target}"
```

Test Plan:
CI

running canary since the job is disabled. Downloaded spec of https://www.internalfb.com/sandcastle/workflow/3413728517548300372, updated hash to be this diff and ran the canary with the new spec.
```
scutil get-spec 3413728517548300372  > 3413728517548300372.json
scutil canary --parameters-file 3413728517548300372.json
```

https://www.internalfb.com/intern/sandcastle/job/22517999248048598


also checked the modified test:
```
buck2 test 'fbcode//mode/dev' fbcode//caffe2/test:profiler -- --exact 'caffe2/test:profiler - test_utils_get_optimizable_events (profiler.test_profiler.TestExperimentalUtils)'
```

Differential Revision: D51769614


