### PR TITLE
[AOTInductor] Remove caches of AOTInductorModel from AOTInductorModelContainer

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -22,12 +22,7 @@ class AOTInductorModelContainer {
       bool is_cpu = false,
       std::optional<std::string> cubin_dir = std::nullopt) {
     constants_ = std::make_shared<ConstantMap>();
-    models_.reserve(num_models);
-    available_models_.reserve(num_models);
-    for (size_t i = 0; i < num_models; ++i) {
-      models_.push_back(AOTInductorModel::Create(constants_, cubin_dir));
-      available_models_.push_back(models_.back().get());
-    }
+    model_ = AOTInductorModel::Create(constants_, cubin_dir);
 
     // Note that the all following fields (input_names_, output_names,
     // etc) can be filled in by the AOT
@@ -37,30 +32,27 @@ class AOTInductorModelContainer {
     //   * reduce information fragmentation and duplication
     //   * the initialization process below is done only once when the container
     //     is constructed, so it would have little performance impact
-    auto* model = available_models_[0];
-    size_t num_inputs = model->num_inputs();
+    size_t num_inputs = model_->num_inputs();
     input_names_.reserve(num_inputs);
     for (size_t i = 0; i < num_inputs; i++) {
-      input_names_.push_back(model->input_name(i));
+      input_names_.push_back(model_->input_name(i));
     }
 
-    size_t num_outputs = model->num_outputs();
+    size_t num_outputs = model_->num_outputs();
     output_names_.reserve(num_outputs);
     for (size_t i = 0; i < num_outputs; i++) {
-      output_names_.push_back(model->output_name(i));
+      output_names_.push_back(model_->output_name(i));
     }
 
-    model->load_constants(is_cpu);
+    model_->load_constants(is_cpu);
 #ifdef USE_CUDA
-    constant_blob_ = model->release_constant_blob();
+    constant_blob_ = model_->release_constant_blob();
 #endif
 
-    for (auto& model : models_) {
-      model->update_constants_map(constants_);
-    }
+    model_->update_constants_map(constants_);
 
-    in_spec_ = model->get_in_spec();
-    out_spec_ = model->get_out_spec();
+    in_spec_ = model_->get_in_spec();
+    out_spec_ = model_->get_out_spec();
   }
 
   void run(
@@ -73,20 +65,11 @@ class AOTInductorModelContainer {
                           // borrowed
       DeviceStreamType stream,
       AOTIProxyExecutorHandle proxy_executor) {
-    auto* model = get_available_model();
     try {
-      model->run(input_handles, output_handles, stream, proxy_executor);
+      model_->run(input_handles, output_handles, stream, proxy_executor);
     } catch (...) {
-      std::lock_guard lk(models_mutex_);
-      available_models_.push_back(model);
       throw;
     }
-
-    {
-      std::lock_guard lk(models_mutex_);
-      pending_models_.push_back(model);
-    }
-    pending_models_available_.notify_one();
   }
 
   size_t num_inputs() const {
@@ -106,7 +89,7 @@ class AOTInductorModelContainer {
   }
 
   size_t num_models() const {
-    return models_.size();
+    return 1;
   }
 
   const char* get_in_spec() const {
@@ -134,66 +117,8 @@ class AOTInductorModelContainer {
   std::shared_ptr<ConstantMap> constants_;
 
   // Holds all the AOTInductorModel instances owned by this container.
-  std::vector<std::unique_ptr<AOTInductorModel>> models_;
+  std::unique_ptr<AOTInductorModel> model_;
 
-  // Holds the AOTInductorModel instances available for inference.
-  std::vector<AOTInductorModel*> available_models_;
-
-  // Holds the AOTInductorModel instances that have started running
-  // inference and can be placed onto available_models_ upon their
-  // completion.
-  std::deque<AOTInductorModel*> pending_models_;
-
-  // Protects available_models_ and pending_models_.
-  std::mutex models_mutex_;
-
-  // Notified whenever a model is placed onto pending_models_.
-  std::condition_variable pending_models_available_;
-
-  AOTInductorModel* get_available_model() {
-    std::unique_lock lk(models_mutex_);
-    if (available_models_.empty()) {
-      reclaim_finished_models(lk);
-    }
-    auto* result = available_models_.back();
-    available_models_.pop_back();
-    return result;
-  }
-
-  void reclaim_finished_models(std::unique_lock<std::mutex>& lk) {
-    // push finished model instances to the end of pending_models_
-    auto it = std::stable_partition(
-        pending_models_.begin(),
-        pending_models_.end(),
-        [](AOTInductorModel* m) { return !m->is_finished(); });
-
-    if (it != pending_models_.end()) {
-      // We have finished model instances that can be pushed into
-      // available_models_ so that we don't have to be blocked on waiting
-      // the pending_models_available_ condition.
-      available_models_.insert(
-          available_models_.end(), it, pending_models_.end());
-      pending_models_.erase(it, pending_models_.end());
-      return;
-    }
-
-    pending_models_available_.wait(
-        lk, [this]() { return !pending_models_.empty(); });
-    // Let's make the schedule simple first. We always wait on the first
-    // pending_models_ to be complete.
-    auto* model = pending_models_.front();
-    pending_models_.pop_front();
-    lk.unlock();
-    try {
-      model->wait_for_completion();
-    } catch (...) {
-      lk.lock();
-      available_models_.push_back(model);
-      throw;
-    }
-    lk.lock();
-    available_models_.push_back(model);
-  }
 };
 
 } // namespace aot_inductor


### PR DESCRIPTION
Summary:
It's likely that AOTInductorModel::run() is thread-safe. In that case, AOTInductorModelContainer doesn't need to cache multiple AOTInductorModels and switch between them.

Let's see what CI says.

Test Plan: CI

Differential Revision: D51771282


