### PR TITLE
[dynamo] support `dict.fromkeys()` / `OrderedDict.fromkeys()` / `defaultdict.fromkeys()`

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -805,9 +805,10 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
     @make_test
     def test_dict_fromkeys(x, y):
         lst = ["a", "b"]
-        d1 = dict.fromkeys(lst)
-        d2 = collections.defaultdict.fromkeys(iter(d1), x)
-        d3 = collections.OrderedDict.fromkeys(d2, value=y)
+        d = dict.fromkeys(lst)
+        d1 = dict.fromkeys(d, x + 1)
+        d2 = collections.defaultdict.fromkeys(iter(d1), x - 2)
+        d3 = collections.OrderedDict.fromkeys(tuple(lst), value=y)
         return d1["a"] * d2["b"] + d2["a"] + d1["b"] + d3["a"] + d3["b"] + 1
 
     @make_test

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -803,6 +803,14 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         return d1["a"] + d2["c"] + 1
 
     @make_test
+    def test_dict_fromkeys(x, y):
+        lst = ["a", "b"]
+        d1 = dict.fromkeys(lst)
+        d2 = collections.defaultdict.fromkeys(iter(d1), x)
+        d3 = collections.OrderedDict.fromkeys(d2, value=y)
+        return d1["a"] * d2["b"] + d2["a"] + d1["b"] + d3["a"] + d3["b"] + 1
+
+    @make_test
     def test_min_max(a, b):
         c = a + b
         a = a.sum()

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -787,6 +787,16 @@ utils_device.CURRENT_DEVICE == None""".split(
         self.assertTrue(same(r1, r2))
         self.assertTrue(same(r1, r3))
 
+    def test_dict_fromkeys(self):
+        def fn(x, y):
+            lst = ["a", "b", x.shape[0]]
+            d1 = dict.fromkeys(lst)
+            d2 = collections.defaultdict.fromkeys(iter(d1), x)
+            d3 = collections.OrderedDict.fromkeys(d2, value=y)
+            return d3["a"] + d3["b"]
+
+        torch._dynamo.testing.standard_test(self, fn, 2, expected_ops=1)
+
     def test_min_max_over_iterable(self):
         def get_test_fn(func):
             def _fn(a, b, func=func):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -787,16 +787,6 @@ utils_device.CURRENT_DEVICE == None""".split(
         self.assertTrue(same(r1, r2))
         self.assertTrue(same(r1, r3))
 
-    def test_dict_fromkeys(self):
-        def fn(x, y):
-            lst = ["a", "b", x.shape[0]]
-            d1 = dict.fromkeys(lst)
-            d2 = collections.defaultdict.fromkeys(iter(d1), x)
-            d3 = collections.OrderedDict.fromkeys(d2, value=y)
-            return d3["a"] + d3["b"]
-
-        torch._dynamo.testing.standard_test(self, fn, 2, expected_ops=1)
-
     def test_min_max_over_iterable(self):
         def get_test_fn(func):
             def _fn(a, b, func=func):

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -947,6 +947,7 @@ class BuiltinVariable(VariableTracker):
             keys = [DictVariableType.get_key(x) for x in arg.unpack_var_sequence(tx)]
             items = user_cls.fromkeys(keys, value)
             return DictVariableType(items, user_cls, mutable_local=MutableLocal())
+        unimplemented(f"{user_cls.__name__}.fromkeys(): {args} {kwargs}")
 
     def call_zip(self, tx, *args, **kwargs):
         if kwargs:

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -909,7 +909,7 @@ class BuiltinVariable(VariableTracker):
             return variables.ConstDictVariable(
                 dict(kwargs), user_cls=user_cls, mutable_local=MutableLocal()
             )
-        unimplemented(f"dict(): {args} {kwargs}")
+        unimplemented(f"{user_cls.__name__}(): {args} {kwargs}")
 
     @staticmethod
     def call_custom_dict_fromkeys(tx, user_cls, *args, **kwargs):

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -972,6 +972,24 @@ class SkipFilesVariable(VariableTracker):
             msg += f"', {self.reason}'" if self.reason else ""
             unimplemented(msg)
 
+    def call_method(
+        self,
+        tx,
+        name,
+        args: "List[VariableTracker]",
+        kwargs: "Dict[str, VariableTracker]",
+    ) -> "VariableTracker":
+        if (
+            self.value in {collections.OrderedDict, collections.defaultdict}
+            and name == "fromkeys"
+        ):
+            from .builtin import BuiltinVariable
+
+            return BuiltinVariable.call_custom_dict_fromkeys(
+                tx, self.value, *args, **kwargs
+            )
+        return super().call_method(tx, name, args, kwargs)
+
 
 class TypingVariable(VariableTracker):
     def __init__(self, value, **kwargs):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #114947
* #115012
* #115011
* __->__ #115010

Add support for `dict.fromkeys`, `OrderedDict.fromkeys`, and `defaultdict.fromkeys`.

Fixes #114963

- #114963

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng