### PR TITLE
Speed up triu_tril_kernel

### DIFF
--- a/aten/src/ATen/native/cuda/TriangularOps.cu
+++ b/aten/src/ATen/native/cuda/TriangularOps.cu
@@ -23,29 +23,38 @@ namespace at::native {
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ triu/tril ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-template <typename scalar_t, typename IndexType, bool upper>
-C10_LAUNCH_BOUNDS_1(cuda::getApplyBlockSize())
+constexpr static int block_size = 128;
+
+template <typename scalar_t, typename IndexType, bool upper, int elements_per_thread, bool inplace>
+C10_LAUNCH_BOUNDS_1(block_size)
 __global__ void triu_tril_kernel(
     cuda::detail::TensorInfo<scalar_t, IndexType> result_info,
     const cuda::detail::TensorInfo<scalar_t, IndexType> self_info,
     const int64_t k,
-    const int64_t N) {
-  int64_t linear_idx = blockIdx.x * blockDim.x + threadIdx.x;
-  if (linear_idx >= N) {
+    const int64_t N_padded,
+    const IndexType last_dim_padded) {
+  int64_t linear_idx = (blockIdx.x * blockDim.x + threadIdx.x) * elements_per_thread;
+  if (linear_idx >= N_padded) {
     return;
   }
 
   auto dims = self_info.dims;
 
+  // Compute column index amd row index
+  IndexType col = linear_idx % last_dim_padded;
+  linear_idx /= last_dim_padded;
+  IndexType row = linear_idx % self_info.sizes[dims - 2];
+
+  if constexpr (inplace) {
+    bool mask_all_true = upper ? (col - row >= k) : (col + elements_per_thread - row <= k);
+    if (mask_all_true)
+      return;
+  }
+
+  // Compute offset
   IndexType self_offset = 0, result_offset = 0;
-  // Compute column index and corresponding offset
-  IndexType col = linear_idx % self_info.sizes[dims - 1];
-  linear_idx /= self_info.sizes[dims - 1];
   self_offset += self_info.strides[dims - 1] * col;
   result_offset += result_info.strides[dims - 1] * col;
-
-  // Compute row index and corresponding offset
-  IndexType row = linear_idx % self_info.sizes[dims - 2];
   linear_idx /= self_info.sizes[dims - 2];
   self_offset += self_info.strides[dims - 2] * row;
   result_offset += result_info.strides[dims - 2] * row;
@@ -60,48 +69,85 @@ __global__ void triu_tril_kernel(
     result_offset += running_index * result_info.strides[i];
   }
 
-  bool mask = upper ? (col - row >= k) : (col - row <= k);
-  result_info.data[result_offset] = mask ? self_info.data[self_offset] : scalar_t(0);
+  if constexpr (inplace) {
+    #pragma unroll
+    for (int i = 0; i < elements_per_thread && col + i < self_info.sizes[dims - 1]; i++) {
+      bool mask = upper ? (col + i - row >= k) : (col + i - row <= k);
+      if (!mask)
+        result_info.data[result_offset + i * result_info.strides[dims - 1]] = scalar_t(0);
+    }
+  } else {
+    scalar_t frag[elements_per_thread] = {};
+    bool has_mask = (upper && col + elements_per_thread - row >= k) || (!upper && col - row <= k);
+    if (has_mask) {
+      #pragma unroll
+      for (int i = 0; i < elements_per_thread && col + i < self_info.sizes[dims - 1]; i++)
+        frag[i] = self_info.data[self_offset + i * self_info.strides[dims - 1]];
+
+      #pragma unroll
+      for (int i = 0; i < elements_per_thread; i++) {
+        bool mask = upper ? (col + i - row >= k) : (col + i - row <= k);
+        frag[i] = mask ? frag[i] : scalar_t(0);
+      }
+    }
+
+    #pragma unroll
+    for (int i = 0; i < elements_per_thread && col + i < self_info.sizes[dims - 1]; i++)
+      result_info.data[result_offset + i * result_info.strides[dims - 1]] = frag[i];
+  }
 }
 
-template <bool upper>
+template <bool upper, bool inplace>
 void triu_tril_cuda_template(const Tensor& result, const Tensor& self, int64_t k, const char* name) {
-  int64_t N = self.numel();
-  dim3 dim_block = cuda::getApplyBlock();
-  dim3 dim_grid((N + dim_block.x - 1) / dim_block.x);
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND4(
       at::ScalarType::ComplexHalf,
       at::ScalarType::Half,
       at::ScalarType::BFloat16,
       at::ScalarType::Bool,
       self.scalar_type(), "triu_tril_cuda_template", [&] {
+    constexpr int elements_per_thread = sizeof(scalar_t) < 8 ? 8 / sizeof(scalar_t) : 1;
+    auto sizes = self.sizes();
+    int64_t last_dim_padded = round_up<int64_t>(sizes.back(), elements_per_thread);
+    int64_t N_padded = c10::multiply_integers(sizes.begin(), sizes.end() - 1) * last_dim_padded;
+    dim3 dim_block = block_size;
+    dim3 dim_grid((N_padded / elements_per_thread + dim_block.x - 1) / dim_block.x);
     if (cuda::detail::canUse32BitIndexMath(result) && cuda::detail::canUse32BitIndexMath(self)) {
       auto result_info = cuda::detail::getTensorInfo<scalar_t, int32_t>(result);
       auto self_info = cuda::detail::getTensorInfo<scalar_t, int32_t>(self);
-      triu_tril_kernel<scalar_t, int32_t, upper>
+      triu_tril_kernel<scalar_t, int32_t, upper, elements_per_thread, inplace>
         <<<dim_grid, dim_block, 0, at::cuda::getCurrentCUDAStream()>>>(
-          result_info, self_info, k, N);
+          result_info, self_info, k, N_padded, last_dim_padded);
       C10_CUDA_KERNEL_LAUNCH_CHECK();
     } else {
       auto result_info = cuda::detail::getTensorInfo<scalar_t, int64_t>(result);
       auto self_info = cuda::detail::getTensorInfo<scalar_t, int64_t>(self);
-      triu_tril_kernel<scalar_t, int64_t, upper>
+      triu_tril_kernel<scalar_t, int64_t, upper, elements_per_thread, inplace>
         <<<dim_grid, dim_block, 0, at::cuda::getCurrentCUDAStream()>>>(
-          result_info, self_info, k, N);
+          result_info, self_info, k, N_padded, last_dim_padded);
       C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
   });
 }
 
 TORCH_IMPL_FUNC(tril_cuda)(const Tensor& self, int64_t k, const Tensor &result) {
+  bool inplace = &result == &self;
   if (self.numel() != 0) {
-    triu_tril_cuda_template<false>(result, self, k, "tril");
+    if (inplace) {
+      triu_tril_cuda_template<false, true>(result, self, k, "tril");
+    } else {
+      triu_tril_cuda_template<false, false>(result, self, k, "tril");
+    }
   }
 }
 
 TORCH_IMPL_FUNC(triu_cuda)(const Tensor& self, int64_t k, const Tensor &result) {
+  bool inplace = &result == &self;
   if (self.numel() != 0) {
-    triu_tril_cuda_template<true>(result, self, k, "triu");
+    if (inplace) {
+      triu_tril_cuda_template<true, true>(result, self, k, "triu");
+    } else {
+      triu_tril_cuda_template<true, false>(result, self, k, "triu");
+    }
   }
 }
 


### PR DESCRIPTION
1. Batch Processing: Enhance kernel efficiency by having each thread handle multiple elements, reducing the frequency of offset calculations.
2. Inplace Operation Optimization: For inplace functions, eliminate unnecessary copying to enhance performance.

Up to 5x speed up compared to torch 2.1.1

# Benchmark
Test on NVIDIA RTX 3080, WSL, CUDA 12.1. Peak performance is recorded.


  | function | dtype | shape | k | torch 2.1.1 | this PR | speed up
-- | -- | -- | -- | -- | -- | -- | --
various   dtype |   |   |   |   |   |  
  | triu_ | int8 | [1, 3072, 3072] | 0 | 0.107 | 0.028 | 3.76x
  | triu_ | float16 | [1, 3072, 3072] | 0 | 0.108 | 0.029 | 3.79x
  | triu_ | float32 | [1, 3072, 3072] | 0 | 0.114 | 0.045 | 2.52x
  | triu_ | float64 | [1, 3072, 3072] | 0 | 0.172 | 0.082 | 2.11x
  | triu | int8 | [1, 3072, 3072] | 0 | 0.111 | 0.056 | 2.00x
  | triu | float16 | [1, 3072, 3072] | 0 | 0.108 | 0.049 | 2.22x
  | triu | float32 | [1, 3072, 3072] | 0 | 0.116 | 0.091 | 1.27x
  | triu | float64 | [1, 3072, 3072] | 0 | 0.175 | 0.176 | 1.00x
various   shape |   |   |   |   |   |  
  | triu_ | float32 | [1, 8192, 8192] | 0 | 0.798 | 0.311 | 2.56x
  | triu_ | float32 | [4, 1024, 1024] | 0 | 0.054 | 0.023 | 2.37x
  | triu_ | float32 | [4, 1021, 1021] | 0 | 0.054 | 0.023 | 2.33x
  | triu_ | float32 | [256, 128, 256] | 0 | 0.111 | 0.038 | 2.92x
  | triu_ | float32 | [128, 257, 125] | 0 | 0.051 | 0.029 | 1.77x
  | triu_ | float32 | [20480, 16, 16] | 0 | 0.072 | 0.036 | 1.97x
  | triu | float32 | [1, 8192, 8192] | 0 | 0.797 | 0.611 | 1.31x
  | triu | float32 | [4, 1024, 1024] | 0 | 0.056 | 0.042 | 1.32x
  | triu | float32 | [4, 1021, 1021] | 0 | 0.058 | 0.044 | 1.32x
  | triu | float32 | [256, 128, 256] | 0 | 0.114 | 0.093 | 1.22x
  | triu | float32 | [128, 257, 125] | 0 | 0.051 | 0.036 | 1.43x
  | triu | float32 | [20480, 16, 16] | 0 | 0.075 | 0.061 | 1.23x
various dim |   |   |   |   |   |  
  | triu_ | float32 | [3072, 3072] | 0 | 0.093 | 0.037 | 2.49x
  | triu_ | float32 | [1, 3072, 3072] | 0 | 0.114 | 0.045 | 2.52x
  | triu_ | float32 | [1, 1, 3072, 3072] | 0 | 0.138 | 0.053 | 2.60x
  | triu | float32 | [3072, 3072] | 0 | 0.097 | 0.091 | 1.07x
  | triu | float32 | [1, 3072, 3072] | 0 | 0.116 | 0.091 | 1.27x
  | triu | float32 | [1, 1, 3072, 3072] | 0 | 0.140 | 0.090 | 1.55x
various k |   |   |   |   |   |   |  
  | triu_ | float16 | [1, 3072, 3072] | 0 | 0.108 | 0.029 | 3.79x
  | triu_ | float16 | [1, 3072, 3072] | 1536 | 0.103 | 0.042 | 2.44x
  | triu_ | float16 | [1, 3072, 3072] | -1536 | 0.114 | 0.020 | 5.68x
  | triu | float16 | [1, 3072, 3072] | 0 | 0.108 | 0.049 | 2.22x
  | triu | float16 | [1, 3072, 3072] | 1536 | 0.104 | 0.039 | 2.65x
  | triu | float16 | [1, 3072, 3072] | -1536 | 0.115 | 0.058 | 2.00x

# Benchmark Code

```python3
import time
import torch


torch.manual_seed(42)


def timeit(f, run_times=1000):
    torch.cuda.synchronize()
    t1 = time.time()
    for _ in range(run_times):
        f()
    torch.cuda.synchronize()
    t2 = time.time()
    return (t2 - t1) / run_times


for dtype in [torch.int8, torch.float16, torch.float32, torch.float64]:
    for shape in [
        [1, 8192, 8192],
        [3072, 3072],
        [1, 3072, 3072],
        [1, 1, 3072, 3072],
        [4, 1024, 1024],
        [4, 1021, 1021],
        [256, 128, 256],
        [128, 257, 125],
        [20480, 16, 16],
    ]:
        for k in [0, shape[-1] // 2, -shape[-1] // 2]:
            a = torch.empty(shape, dtype=dtype, device="cuda")
            for _ in range(4):
                t_triu = timeit(lambda: a.triu(k))
                t_triu_ = timeit(lambda: a.triu_(k))
                t_clone = timeit(lambda: a.clone())
                print(dtype, shape, f"{k=}", f"triu_ {t_triu_ * 1000:.6f} ({t_triu_ / t_clone:.2f}xMemcpy)", f"triu {t_triu * 1000:.6f} ({t_triu / t_clone:.2f}xMemcpy)")

            a = torch.rand(shape, device="cuda")
            a = (a * 10).to(dtype)
            assert (a.triu(k) == a.cpu().triu(k).cuda()).all()
            assert (a.tril(k) == a.cpu().tril(k).cuda()).all()
            assert (a.clone().triu_(k) == a.triu(k)).all()
            assert (a.clone().tril_(k) == a.tril(k)).all()
```

cc @ptrblck