### PR TITLE
[BE]: Enable a PLC0131, PLC0132, PLC0205. Fix PLC0132 bug.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,8 @@ select = [
     "PIE804",
     "PIE807",
     "PIE810",
+    "PLC0131", # type bivariance
+    "PLC0132", # type param mismatch
     "PLE",
     "PLR0133", # constant comparison
     "PLR0206", # property with params

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ select = [
     "PIE810",
     "PLC0131", # type bivariance
     "PLC0132", # type param mismatch
+    "PLC0205", # string as __slots__
     "PLE",
     "PLR0133", # constant comparison
     "PLR0206", # property with params

--- a/torch/_numpy/_normalizations.py
+++ b/torch/_numpy/_normalizations.py
@@ -17,7 +17,7 @@ ArrayLikeOrScalar = typing.Union[ArrayLike, Scalar]
 
 DTypeLike = typing.TypeVar("DTypeLike")
 AxisLike = typing.TypeVar("AxisLike")
-NDArray = typing.TypeVar("NDarray")
+NDArray = typing.TypeVar("NDArray")
 CastingModes = typing.TypeVar("CastingModes")
 KeepDims = typing.TypeVar("KeepDims")
 


### PR DESCRIPTION
Enable pylint rules `PLC0131` and `PLC0132`. There was a violation of the `PLC0132` so this commit also fixes it and enables the rules so the violation do not occur again. `PLC0205` checks accidentally setting your `__slots__` to a string which is almost always a bug.