### PR TITLE
[codemod][lowrisk] Remove extra semi colon from caffe2/caffe2/opt/optimizer.cc

### DIFF
--- a/caffe2/opt/optimizer.cc
+++ b/caffe2/opt/optimizer.cc
@@ -11,6 +11,7 @@ void workspaceOptimizations(nom::repr::NNModule* nn, Workspace* ws, int level) {
   switch (level) {
     case 1:
       opt::fuseConvBN(nn, ws);
+      break;
     case 0:
     default:
       break;


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Test Plan: Sandcastle

Reviewed By: dmm-fb

Differential Revision: D51777924


