### PR TITLE
Make DynamicShapes*Tests show up properly in the test failure repro string

### DIFF
--- a/test/dynamo/test_dynamic_shapes.py
+++ b/test/dynamo/test_dynamic_shapes.py
@@ -54,6 +54,7 @@ def make_dynamic_cls(cls):
     test_classes[test_class.__name__] = test_class
     # REMOVING THIS LINE WILL STOP TESTS FROM RUNNING
     globals()[test_class.__name__] = test_class
+    test_class.__module__ = __name__
     return test_class
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #114917
* __->__ #115019
* #115003

Set their `__module__` attributes so that Python thinks the test classes
are defined in test_dynamic_shapes and not in torch._dynamo.testing.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng