### PR TITLE
Switched the test cases to use threads instead of processes

### DIFF
--- a/test/distributed/_tensor/test_embedding_ops.py
+++ b/test/distributed/_tensor/test_embedding_ops.py
@@ -12,8 +12,7 @@ from torch.distributed.tensor.parallel import (
 )
 from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
 from torch.testing._internal.distributed._tensor.common_dtensor import (
-    DTensorTestBase,
-    with_comms,
+    DTensorOpTestBase,
 )
 
 if TEST_WITH_DEV_DBG_ASAN:
@@ -24,7 +23,7 @@ if TEST_WITH_DEV_DBG_ASAN:
     sys.exit(0)
 
 
-class TestEmbeddingOp(DTensorTestBase):
+class TestEmbeddingOp(DTensorOpTestBase):
     def _run_embedding_op_test(
         self,
         shard_dim,
@@ -112,7 +111,7 @@ class TestEmbeddingOp(DTensorTestBase):
         )
         self.assertEqual(local_output, sharded_output.full_tensor())
 
-    @with_comms
+    
     def test_sharded_embedding_colwise(self):
         self._run_embedding_op_test(1, [5, 4], 17, 12)
         self._run_embedding_op_test(1, [6, 7, 6], 21, 11)
@@ -122,7 +121,7 @@ class TestEmbeddingOp(DTensorTestBase):
         self._run_embedding_op_test(1, [34], 15, 14, padding_idx=10)
         self._run_embedding_op_test(1, [8, 6, 5, 4], 23, 13, padding_idx=12)
 
-    @with_comms
+    
     def test_sharded_embedding_colwise_errors(self):
         with self.assertRaisesRegex(
             NotImplementedError,
@@ -132,7 +131,7 @@ class TestEmbeddingOp(DTensorTestBase):
                 1, [8, 6, 5, 4], 23, 13, padding_idx=12, max_norm=2.0
             )
 
-    @with_comms
+    
     def test_sharded_embedding_rowwise(self):
         with self.assertRaisesRegex(
             NotImplementedError,

--- a/test/distributed/_tensor/test_math_ops.py
+++ b/test/distributed/_tensor/test_math_ops.py
@@ -9,13 +9,13 @@ from torch.distributed._tensor import DeviceMesh, distribute_tensor
 from torch.distributed._tensor.placement_types import Replicate, Shard
 from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
-    DTensorTestBase,
+    DTensorOpTestBase,
     skip_unless_torch_gpu,
     with_comms,
 )
 
 
-class DistMathOpsTest(DTensorTestBase):
+class DistMathOpsTest(DTensorOpTestBase):
     def linear_op_reductions(self, op_str):
         device_mesh = self.build_device_mesh()
         shard_spec = [Shard(0)]
@@ -44,18 +44,18 @@ class DistMathOpsTest(DTensorTestBase):
         dt_full_reduced = op_dt().full_tensor()
         self.assertEqual(dt_full_reduced, full_reduced_tensor)
 
-    @with_comms
+    
     def test_linear_op_reductions(self):
         for op_str in ("all", "sum", "prod", "max", "min"):
             self.linear_op_reductions(op_str)
 
-    @with_comms
+    
     @skip_unless_torch_gpu
     def test_mean(self):
         self.linear_op_reductions("mean")
 
     # TODO: forward test can be removed once test_softmax_with_bwd passes on CPU
-    @with_comms
+    
     def test_softmax_fwd(self):
         device_mesh = self.build_device_mesh()
 
@@ -88,7 +88,7 @@ class DistMathOpsTest(DTensorTestBase):
     # TODO: get test_softmax_with_bwd pass on CPU
     # DTensor's _softmax_backward_data produces wrong result on CPU on certain dimension.
     # fail_on_cpu_list = [(0, -1), (1, -1)]
-    @with_comms
+    
     @skip_unless_torch_gpu
     def test_softmax_with_bwd(self):
         device_mesh = self.build_device_mesh()
@@ -126,7 +126,7 @@ class DistMathOpsTest(DTensorTestBase):
                 self.assertIsNotNone(dist_x.grad)
                 self.assertEqual(dist_x.grad.full_tensor(), x.grad)
 
-    @with_comms
+    
     def test_full_shard_math_ops(self):
         mesh_shape = (2, self.world_size // 2)
         mesh = DeviceMesh(


### PR DESCRIPTION
I made some modifications to the test cases, switching from processors to using MultithreadTestCase with `DTensorOpTestBase`. Additionally, I replaced `device_mesh` with `self.build_mesh` and eliminated the `with_comms` wrapper, as per your suggestions in other discussions.

Fixes #108744


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @kiukchung @lucasllc @d4l3k