### PR TITLE
Fix up triton builds

### DIFF
--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -29,6 +29,19 @@ def check_and_replace(inp: str, src: str, dst: str) -> str:
     return inp.replace(src, dst)
 
 
+def patch_setup_py(path: Path, *, version: str, name: str = "triton") -> None:
+    with open(path) as f:
+        orig = f.read()
+    # Replace name
+    orig = check_and_replace(orig, 'name="triton",', f'name="{name}",')
+    # Replace version
+    orig = check_and_replace(
+        orig, f'version="{read_triton_version()}",', f'version="{version}",'
+    )
+    with open(path, "w") as f:
+        f.write(orig)
+
+
 def patch_init_py(path: Path, *, version: str) -> None:
     with open(path) as f:
         orig = f.read()
@@ -130,6 +143,12 @@ def build_triton(
         )
 
         if build_rocm:
+            # TODO: Remove me when ROCM triton is updated
+            patch_setup_py(
+                triton_pythondir / "setup.py",
+                name=triton_pkg_name,
+                version=f"{version}",
+            )
             check_call("scripts/amd/setup_rocm_libs.sh", cwd=triton_basedir, shell=True)
             print("ROCm libraries setup for triton installation...")
 

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - nightly
     tags:
       # NOTE: Binary build pipelines should only get triggered on release candidate builds
       # Release candidate tags look like: v1.11.0-rc1
@@ -134,7 +133,7 @@ jobs:
     needs: build-wheel
     container:
       image: continuumio/miniconda3:4.12.0
-    environment: ${{ (github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v'))) && 'conda-aws-upload' || '' }}
+    environment: ${{ (github.event_name == 'push' && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v'))) && 'conda-aws-upload' || '' }}
     steps:
       - uses: actions/checkout@v3
 
@@ -145,7 +144,7 @@ jobs:
           path: ${{ runner.temp }}/artifacts/
 
       - name: Set DRY_RUN (only for tagged pushes)
-        if: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || (startsWith(github.event.ref, 'refs/tags/v'))) }}
+        if: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/main' || (startsWith(github.event.ref, 'refs/tags/v'))) }}
         shell: bash
         run: |
           echo "DRY_RUN=disabled" >> "$GITHUB_ENV"


### PR DESCRIPTION
Follow ups after https://github.com/pytorch/pytorch/pull/114772 and https://github.com/pytorch/pytorch/pull/108187

- Triton builds should be published from `main` rather than `nightly` branch, as:
   - They are independent of any PyTorch changes
   - Every nightly is pinned to a specific commit therefore publishing updated triton binaries will not affect previous nightlies
   - If this is not the case, nightly promotion will never happen as binary builds on main will continue to fail in perpetuity searching for new triton binary
- `patch_setup_py` is still needed to modify name of the package for ROCm builds

