### PR TITLE
[inductor] fix cpp codegen `example_inputs` for CUDA path

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1465,6 +1465,23 @@ class AOTInductorTestsTemplate:
         inputs = (torch.rand(4, 4, 4, 4, device=self.device),)
         self.check_model(Model(4), inputs)
 
+    @requires_cuda()
+    def test_cpp_codegen_cuda(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(10, 10, device="cuda")
+
+            def forward(self, x):
+                return self.linear(x)
+
+        with torch.no_grad(), config.patch({"cpp_wrapper": True}):
+            model = Model()
+            model_opt = torch.compile(model)
+
+            inp = torch.zeros(10, device="cuda")
+            self.assertEqual(model_opt(inp), model(inp))
+
 
 common_utils.instantiate_parametrized_tests(AOTInductorTestsTemplate)
 

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -519,9 +519,7 @@ def fx_codegen_and_compile(
         graph = GraphLowering(
             gm,
             # example_inputs will be used by AOTInductor to dry-run the generated code for Triton kernel tuning.
-            # For the forward pass, we have the real inputs to be used as example_inputs. For the backward pass,
-            # we currently use fake tensors and defake them later.
-            example_inputs=V.real_inputs if is_inference else example_inputs,
+            example_inputs=example_inputs,
             shape_env=shape_env,
             num_static_inputs=num_fixed,
             graph_id=graph_id,


### PR DESCRIPTION
Fixes: https://github.com/pytorch/pytorch/issues/115035
Issue introduced in https://github.com/pytorch/pytorch/pull/114067

Root cause explained here: https://github.com/pytorch/pytorch/pull/114067#discussion_r1413293819
 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler