### PR TITLE
Log pt2_compliant custom ops used with torch.compile

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -685,7 +685,9 @@ def _compile(
                     "backend_compile", None
                 )
                 non_compliant_ops = {op.__qualname__ for op in output.non_compliant_ops}
-                compliant_custom_ops = {op.__qualname__ for op in output.compliant_custom_ops}
+                compliant_custom_ops = {
+                    op.__qualname__ for op in output.compliant_custom_ops
+                }
             else:
                 guard_count = None
                 graph_op_count = None

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -685,6 +685,7 @@ def _compile(
                     "backend_compile", None
                 )
                 non_compliant_ops = {op.__qualname__ for op in output.non_compliant_ops}
+                compliant_custom_ops = {op.__qualname__ for op in output.compliant_custom_ops}
             else:
                 guard_count = None
                 graph_op_count = None
@@ -693,6 +694,7 @@ def _compile(
                 entire_frame_compile_time = None
                 backend_compile_time = None
                 non_compliant_ops = set({})
+                compliant_custom_ops = set({})
             metrics = CompilationMetrics(
                 frame_key,
                 code.co_name,
@@ -708,6 +710,7 @@ def _compile(
                 backend_compile_time,
                 fail_reason,
                 non_compliant_ops,
+                compliant_custom_ops,
             )
             log_compilation_event(metrics)
 

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -115,6 +115,7 @@ class OutputGraphState(NamedTuple):
     side_effects: SideEffects
     timestamp: int
     non_compliant_ops: Set[torch._ops.OpOverload]
+    compliant_custom_ops: Set[torch._ops.OpOverload]
 
     def diff(self, other: "OutputGraphState", *, prefix: str = "") -> Optional[str]:
         for k in self._fields:
@@ -351,6 +352,10 @@ class OutputGraph(Checkpointable[OutputGraphState]):
         # This information is useful for logging.
         self.non_compliant_ops: Set[torch._ops.OpOverload] = set({})
 
+        # Tracks a list of called custom ops that were tagged with "pt2_compliant_tag".
+        # This information is useful for logging.
+        self.compliant_custom_ops: Set[torch._ops.OpOverload] = set({})
+
         # We save the global torch state here to be restored in case of graph
         # breaks. The relevant issue is seen here
         # https://github.com/pytorch/pytorch/pull/100570#issuecomment-1543427086
@@ -538,6 +543,7 @@ class OutputGraph(Checkpointable[OutputGraphState]):
             self.side_effects.clone(),
             self.timestamp,
             set(self.non_compliant_ops),
+            set(self.compliant_custom_ops),
         )
         self.timestamp += 1
         return state
@@ -555,6 +561,7 @@ class OutputGraph(Checkpointable[OutputGraphState]):
             self.side_effects,
             self.timestamp,
             self.non_compliant_ops,
+            self.compliant_custom_ops,
         ) = state
         self.tracing_context.guards_context.restore_graphstate(guards_state)
         self.tracing_context.module_context.restore_graphstate(module_state)
@@ -1402,6 +1409,11 @@ def check_pt2_compliant_op(output_graph, kind, target, args, kwargs):
     if kind != "call_function":
         return
 
+    def encountered_compliant_op(target):
+        if func.namespace in {"prim", "prims", "aten"}:
+            return
+        output_graph.compliant_custom_ops.add(target)
+
     def encountered_non_compliant_op(target, msg):
         output_graph.non_compliant_ops.add(target)
         if config.only_allow_pt2_compliant_ops:
@@ -1409,6 +1421,7 @@ def check_pt2_compliant_op(output_graph, kind, target, args, kwargs):
 
     if isinstance(target, torch._ops.OpOverload):
         if torch.Tag.pt2_compliant_tag in target.tags:
+            encountered_compliant_op(target)
             return
         encountered_non_compliant_op(
             target,
@@ -1424,6 +1437,7 @@ def check_pt2_compliant_op(output_graph, kind, target, args, kwargs):
         if len(overloads) == 1:
             op = getattr(target, overloads[0])
             if torch.Tag.pt2_compliant_tag in op.tags:
+                encountered_compliant_op(target)
                 return
             encountered_non_compliant_op(
                 op,
@@ -1444,7 +1458,9 @@ def check_pt2_compliant_op(output_graph, kind, target, args, kwargs):
             unimplemented(str(e))
 
         op = getattr(target, overload)
-        if torch.Tag.pt2_compliant_tag not in op.tags:
+        if torch.Tag.pt2_compliant_tag in op.tags:
+            encountered_compliant_op(op)
+        else:
             encountered_non_compliant_op(
                 op,
                 f"Encountered the torch.ops.OpOverloadPacket {target} "

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1437,7 +1437,7 @@ def check_pt2_compliant_op(output_graph, kind, target, args, kwargs):
         if len(overloads) == 1:
             op = getattr(target, overloads[0])
             if torch.Tag.pt2_compliant_tag in op.tags:
-                encountered_compliant_op(target)
+                encountered_compliant_op(op)
                 return
             encountered_non_compliant_op(
                 op,

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1410,7 +1410,7 @@ def check_pt2_compliant_op(output_graph, kind, target, args, kwargs):
         return
 
     def encountered_compliant_op(target):
-        if func.namespace in {"prim", "prims", "aten"}:
+        if target.namespace in {"prim", "prims", "aten"}:
             return
         output_graph.compliant_custom_ops.add(target)
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -580,6 +580,7 @@ class CompilationMetrics:
     backend_compile_time_s: Optional[float]
     fail_reason: Optional[str]
     non_compliant_ops: Set[str]
+    compliant_custom_ops: Set[str]
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #115083

Summary:
We already log non-pt2_compliant ops. This PR extends the logging to
include pt2_compliant custom ops. We do not log all pt2_compliant ops
(i.e. including builtin ops) because it would probably take too much
memory

Test Plan:
Tested locally

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng