### PR TITLE
[DTensor] Remove the assertion and allow number of ranks larger than total size

### DIFF
--- a/test/distributed/_tensor/test_utils.py
+++ b/test/distributed/_tensor/test_utils.py
@@ -79,6 +79,26 @@ class UtilTest(DTensorTestBase):
                 global_tensor[dim0_start:dim0_end],
             )
 
+            # Test when size < #ranks
+            global_tensor_small = torch.arange(16).view(4, 4)
+            global_shape_small = global_tensor_small.size()
+            dtensor_small = distribute_tensor(
+                global_tensor_small, device_mesh, placements
+            )
+            (
+                local_size_small,
+                global_offset_small,
+            ) = compute_local_shape_and_global_offset(
+                global_shape_small, device_mesh, placements
+            )
+
+            self.assertEqual(
+                dtensor_small.to_local(),
+                global_tensor_small[
+                    global_offset[0] : global_offset[0] + local_size[0]
+                ],
+            )
+
     @with_comms
     def test_compute_local_shape_and_global_offset_2D(self):
         two_d_placements_options = [Shard(0), Shard(1), Replicate()]
@@ -110,6 +130,28 @@ class UtilTest(DTensorTestBase):
             self.assertEqual(
                 dtensor.to_local(),
                 global_tensor[dim0_start:dim0_end, dim1_start:dim1_end],
+            )
+
+            # Test when size < #ranks
+            global_tensor_small = torch.arange(4).view(2, 2)
+            global_shape_small = global_tensor_small.size()
+            dtensor_small = distribute_tensor(
+                global_tensor_small, device_mesh, placements
+            )
+            (
+                local_size_small,
+                global_offset_small,
+            ) = compute_local_shape_and_global_offset(
+                global_shape_small, device_mesh, placements
+            )
+            self.assertEqual(
+                dtensor_small.to_local(),
+                global_tensor_small[
+                    global_offset_small[0] : global_offset_small[0]
+                    + local_size_small[0],
+                    global_offset_small[1] : global_offset_small[1]
+                    + local_size_small[1],
+                ],
             )
 
 

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -54,9 +54,6 @@ class Shard(Placement):
         assert (
             self.dim <= tensor.ndim
         ), f"Sharding dim {self.dim} greater than tensor ndim {tensor.ndim}"
-        assert (
-            tensor.size(self.dim) > 0
-        ), f"Tensor size along dim{self.dim} is 0. There is nothing to be sharded."
 
         # chunk tensor over dimension `dim` into n slices with padding if necessary
         tensor_list = list(torch.chunk(tensor, num_chunks, dim=self.dim))
@@ -123,10 +120,6 @@ class Shard(Placement):
         """
         returns the local shard size and offset on a given tensor dim
         """
-        assert (
-            size_on_dim >= num_chunks
-        ), f"Size to be sharded on dim {self.dim} must be at least as large as the number of devices in that dimension {num_chunks}"
-
         # Compute the chunk size inline with ``torch.chunk``
         full_chunk_size = (size_on_dim + num_chunks - 1) // num_chunks
 


### PR DESCRIPTION
Summary:
This diff removes the assertion and allow number of ranks larger than total size. When training with large-scale gpus, it happens that for some params, the total size is larger than the size of process group. Error: `AssertionError: Size to be sharded on dim 0 must be at least as large as the number of devices in that dimension 128`, where size = 16.

Verified that the logic works as expected in the case `size_on_dim <= num_chunks`.

Test Plan:
**PR**
CI tests

**Unit tests**:
`buck2 test mode/dev-nosan //caffe2/test/distributed/_tensor:utils`
- Passed

**WHEN model**:
- Verified that checkpoint can be saved and resumed successfully;
- Verified the accuracy with window_ne, which is on-par with baseline.
https://pxl.cl/3WkW9

Differential Revision: D51821717




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @kiukchung @d4l3k @lucasllc