### PR TITLE
[DeviceMesh] Rename _device_mesh.py to device_mesh.py to prepare for beta

### DIFF
--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -177,12 +177,14 @@ Initialization
 --------------
 
 The package needs to be initialized using the :func:`torch.distributed.init_process_group`
-function before calling any other methods. This blocks until all processes have
-joined.
+or :func:`torch.distributed.init_device_mesh` function before calling any other methods.
+Both block until all processes have joined.
 
 .. autofunction:: is_available
 
 .. autofunction:: init_process_group
+
+.. autofunction:: init_device_mesh
 
 .. autofunction:: is_initialized
 
@@ -338,6 +340,18 @@ an opaque group handle that can be given as a ``group`` argument to all collecti
 .. autofunction:: get_global_rank
 
 .. autofunction:: get_process_group_ranks
+
+
+DeviceMesh
+----------
+
+DeviceMesh is a higher level abstraction that manages process groups (or NCCL communicators).
+It allows user to easily create inter node and intra node process groups without worrying about
+how to set up the ranks correctly for different sub process groups, and it helps manage those
+distributed process group easily. :func:`~torch.distributed.init_device_mesh` function can be
+used to create new DeviceMesh, with a mesh shape describing the device topology.
+
+.. autoclass:: DeviceMesh
 
 Point-to-point communication
 ----------------------------
@@ -846,6 +860,7 @@ If you are running single node training, it may be convenient to interactively b
 .. py:module:: torch.distributed.checkpoint.utils
 .. py:module:: torch.distributed.collective_utils
 .. py:module:: torch.distributed.constants
+.. py:module:: torch.distributed.device_mesh
 .. py:module:: torch.distributed.distributed_c10d
 .. py:module:: torch.distributed.elastic.agent.server.api
 .. py:module:: torch.distributed.elastic.agent.server.local_elastic_agent

--- a/test/distributed/_tensor/test_utils.py
+++ b/test/distributed/_tensor/test_utils.py
@@ -8,8 +8,8 @@ from torch.distributed._tensor._utils import (
     compute_local_shape,
     compute_local_shape_and_global_offset,
 )
-from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.distributed._tensor.placement_types import Replicate, Shard
+from torch.distributed.device_mesh import DeviceMesh
 
 from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (

--- a/test/distributed/fsdp/test_fsdp_dtensor_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_dtensor_state_dict.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 from torch.distributed._shard.sharded_tensor import ShardedTensor
 
 from torch.distributed._tensor import DTensor, Shard
-from torch.distributed._tensor.device_mesh import init_device_mesh
+from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.api import (
     ShardedOptimStateDictConfig,

--- a/test/distributed/fsdp/test_hsdp_dtensor_state_dict.py
+++ b/test/distributed/fsdp/test_hsdp_dtensor_state_dict.py
@@ -9,7 +9,7 @@ import torch.nn as nn
 from torch.distributed._shard.sharded_tensor import ShardedTensor
 
 from torch.distributed._tensor import DTensor, Replicate, Shard
-from torch.distributed._tensor.device_mesh import _mesh_resources, init_device_mesh
+from torch.distributed.device_mesh import _mesh_resources, init_device_mesh
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.api import (
     ShardedOptimStateDictConfig,

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -9,12 +9,8 @@ from torch.distributed._tensor._collective_utils import (
     mesh_broadcast,
     mesh_scatter,
 )
-from torch.distributed._tensor.device_mesh import (
-    _mesh_resources,
-    DeviceMesh,
-    init_device_mesh,
-)
 from torch.distributed._tensor.placement_types import Shard
+from torch.distributed.device_mesh import _mesh_resources, DeviceMesh, init_device_mesh
 
 from torch.distributed.distributed_c10d import (
     get_global_rank,

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -292,7 +292,6 @@ class TestPublicBindings(TestCase):
             "torch.backends._coreml.preprocess",
             "torch.contrib._tensorboard_vis",
             "torch.distributed._composable",
-            "torch.distributed._device_mesh",
             "torch.distributed._functional_collectives",
             "torch.distributed._functional_collectives_impl",
             "torch.distributed._shard",

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -183,7 +183,7 @@ if torch.distributed.is_available():
     LEGACY_MOD_INLINELIST |= {
         "torch.distributed._tensor.api",
         "torch.distributed._tensor.device_mesh",
-        "torch.distributed._device_mesh",
+        "torch.distributed.device_mesh",
         "torch.distributed.algorithms._checkpoint.checkpoint_wrapper",
         "torch.distributed.tensor.parallel._data_parallel_utils",
         "torch.distributed.tensor.parallel._utils",

--- a/torch/_dynamo/variables/distributed.py
+++ b/torch/_dynamo/variables/distributed.py
@@ -140,7 +140,7 @@ class DeviceMeshVariable(DistributedVariable):
         if not DistributedVariable.is_available():
             return False
 
-        from torch.distributed._tensor.device_mesh import DeviceMesh
+        from torch.distributed.device_mesh import DeviceMesh
 
         return istype(value, DeviceMesh)
 

--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -92,6 +92,7 @@ if is_available():
         )
 
     from .distributed_c10d import *  # noqa: F403
+    from .device_mesh import *  # noqa: F403
 
     # Variables prefixed with underscore are not auto imported
     # See the comment in `distributed_c10d.py` above `_backend` on why we expose

--- a/torch/distributed/_tensor/__init__.py
+++ b/torch/distributed/_tensor/__init__.py
@@ -7,13 +7,9 @@ import torch.distributed._tensor.ops
 import torch.distributed._tensor.random as random
 from torch.distributed._tensor._utils import compute_local_shape
 from torch.distributed._tensor.api import distribute_module, distribute_tensor, DTensor
-from torch.distributed._tensor.device_mesh import (
-    _mesh_resources,
-    DeviceMesh,
-    init_device_mesh,
-)
 from torch.distributed._tensor.ops.utils import normalize_to_torch_size
 from torch.distributed._tensor.placement_types import Placement, Replicate, Shard
+from torch.distributed.device_mesh import _mesh_resources, DeviceMesh, init_device_mesh
 
 # All public APIs from dtensor package
 __all__ = [

--- a/torch/distributed/_tensor/_collective_utils.py
+++ b/torch/distributed/_tensor/_collective_utils.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 import torch
 import torch.distributed._tensor.placement_types as placement_types
-from torch.distributed._tensor.device_mesh import _mesh_resources, DeviceMesh
+from torch.distributed.device_mesh import _mesh_resources, DeviceMesh
 from torch.distributed.distributed_c10d import (
     all_to_all,
     broadcast,

--- a/torch/distributed/_tensor/_utils.py
+++ b/torch/distributed/_tensor/_utils.py
@@ -2,13 +2,13 @@ from typing import cast, List, Sequence, Tuple
 
 import torch
 from torch._prims_common import ShapeType
-from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.distributed._tensor.placement_types import (
     _Partial,
     Placement,
     Replicate,
     Shard,
 )
+from torch.distributed.device_mesh import DeviceMesh
 
 
 # TODO: audit existing code base to see if we can safely remove this API.

--- a/torch/distributed/_tensor/_xla.py
+++ b/torch/distributed/_tensor/_xla.py
@@ -6,8 +6,8 @@ from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union
 import torch
 
 import torch.nn as nn
-from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.distributed._tensor.placement_types import Placement, Replicate
+from torch.distributed.device_mesh import DeviceMesh
 
 log = logging.getLogger(__name__)
 

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -10,7 +10,6 @@ import torch.distributed._tensor.random as random
 import torch.nn as nn
 from torch.distributed._tensor._collective_utils import mesh_broadcast
 from torch.distributed._tensor._utils import compute_global_tensor_info
-from torch.distributed._tensor.device_mesh import _mesh_resources, DeviceMesh
 from torch.distributed._tensor.placement_types import (
     DTensorSpec,
     Placement,
@@ -26,6 +25,7 @@ from torch.distributed._tensor.redistribute import (
     Redistribute,
     redistribute_local_tensor,
 )
+from torch.distributed.device_mesh import _mesh_resources, DeviceMesh
 
 
 __all__ = ["DTensor", "distribute_tensor", "distribute_module"]

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -1,4 +1,4 @@
-from torch.distributed._device_mesh import (  # noqa: F401
+from torch.distributed.device_mesh import (  # noqa: F401
     _get_device_handle,
     _mesh_resources,
     DeviceMesh,

--- a/torch/distributed/_tensor/dispatch.py
+++ b/torch/distributed/_tensor/dispatch.py
@@ -8,7 +8,6 @@ import torch
 import torch.distributed as dist
 import torch.distributed._tensor.api as dtensor
 import torch.distributed._tensor.random as random
-from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.distributed._tensor.op_schema import (
     _is_inplace_op,
     _is_out_variant_op,
@@ -24,6 +23,7 @@ from torch.distributed._tensor.tp_conv import (
     convolution_backward_handler,
     convolution_handler,
 )
+from torch.distributed.device_mesh import DeviceMesh
 
 try:
     from torch.utils import _cxx_pytree as pytree

--- a/torch/distributed/_tensor/op_schema.py
+++ b/torch/distributed/_tensor/op_schema.py
@@ -3,8 +3,8 @@ from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import torch
 from torch._ops import OpOverload
-from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.distributed._tensor.placement_types import DTensorSpec
+from torch.distributed.device_mesh import DeviceMesh
 
 try:
     from torch.utils._cxx_pytree import tree_map_only, TreeSpec

--- a/torch/distributed/_tensor/ops/basic_strategy.py
+++ b/torch/distributed/_tensor/ops/basic_strategy.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 
 from typing import List, Tuple
 
-from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.distributed._tensor.op_schema import OpStrategy, PlacementStrategy
 from torch.distributed._tensor.placement_types import (
     _Partial,
@@ -12,6 +11,8 @@ from torch.distributed._tensor.placement_types import (
     Replicate,
     Shard,
 )
+
+from torch.distributed.device_mesh import DeviceMesh
 
 
 @dataclass

--- a/torch/distributed/_tensor/ops/math_ops.py
+++ b/torch/distributed/_tensor/ops/math_ops.py
@@ -4,7 +4,6 @@ from typing import cast, List, Optional, Sequence, Tuple
 import torch
 
 import torch.distributed.distributed_c10d as c10d
-from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.distributed._tensor.op_schema import (
     OpSchema,
     OpStrategy,
@@ -28,6 +27,7 @@ from torch.distributed._tensor.placement_types import (
     Replicate,
     Shard,
 )
+from torch.distributed.device_mesh import DeviceMesh
 
 
 aten = torch.ops.aten

--- a/torch/distributed/_tensor/ops/matrix_ops.py
+++ b/torch/distributed/_tensor/ops/matrix_ops.py
@@ -1,8 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 # implement matrix related ops for distributed tensor
 import torch
-
-from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.distributed._tensor.op_schema import OpSchema, OpStrategy, OutputSharding
 from torch.distributed._tensor.ops.basic_strategy import gen_einsum_strategies
 from torch.distributed._tensor.ops.common_rules import einop_rule
@@ -15,6 +13,8 @@ from torch.distributed._tensor.ops.utils import (
     register_prop_rule,
 )
 from torch.distributed._tensor.placement_types import DTensorSpec
+
+from torch.distributed.device_mesh import DeviceMesh
 
 aten = torch.ops.aten
 

--- a/torch/distributed/_tensor/ops/pointwise_ops.py
+++ b/torch/distributed/_tensor/ops/pointwise_ops.py
@@ -2,7 +2,6 @@
 from typing import List, Tuple
 
 import torch
-from torch.distributed._tensor.device_mesh import DeviceMesh
 
 from torch.distributed._tensor.op_schema import (
     _is_inplace_op,
@@ -30,6 +29,7 @@ from torch.distributed._tensor.placement_types import (
     Replicate,
     Shard,
 )
+from torch.distributed.device_mesh import DeviceMesh
 
 
 aten = torch.ops.aten

--- a/torch/distributed/_tensor/ops/random_ops.py
+++ b/torch/distributed/_tensor/ops/random_ops.py
@@ -1,7 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import torch
-
-from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.distributed._tensor.op_schema import (
     OpSchema,
     OpStrategy,
@@ -9,6 +7,8 @@ from torch.distributed._tensor.op_schema import (
     StrategyType,
 )
 from torch.distributed._tensor.ops.utils import is_tensor_partial, register_op_strategy
+
+from torch.distributed.device_mesh import DeviceMesh
 
 aten = torch.ops.aten
 

--- a/torch/distributed/_tensor/ops/tensor_ops.py
+++ b/torch/distributed/_tensor/ops/tensor_ops.py
@@ -4,7 +4,6 @@ from typing import cast, List, Optional, Sequence, Tuple
 import torch
 
 from torch.distributed._tensor._utils import compute_local_shape
-from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.distributed._tensor.op_schema import (
     OpSchema,
     OpStrategy,
@@ -29,6 +28,7 @@ from torch.distributed._tensor.placement_types import (
     Replicate,
     Shard,
 )
+from torch.distributed.device_mesh import DeviceMesh
 
 
 aten = torch.ops.aten

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -8,7 +8,7 @@ import torch.distributed._functional_collectives as funcol
 import torch.distributed.distributed_c10d as c10d
 
 from torch.distributed._tensor._collective_utils import mesh_broadcast, mesh_scatter
-from torch.distributed._tensor.device_mesh import DeviceMesh
+from torch.distributed.device_mesh import DeviceMesh
 
 
 class Placement:

--- a/torch/distributed/_tensor/random.py
+++ b/torch/distributed/_tensor/random.py
@@ -7,8 +7,8 @@ import torch
 import torch.distributed as dist
 
 from torch import Tensor
-from torch.distributed._tensor.device_mesh import _get_device_handle, DeviceMesh
 from torch.distributed._tensor.placement_types import DTensorSpec, Shard
+from torch.distributed.device_mesh import _get_device_handle, DeviceMesh
 
 
 _rng_tracker: Optional["RNGStateTracker"] = None

--- a/torch/distributed/_tensor/redistribute.py
+++ b/torch/distributed/_tensor/redistribute.py
@@ -3,7 +3,6 @@ from typing import cast, Dict, List, Tuple
 
 import torch
 import torch.distributed._tensor.api as dtensor
-from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.distributed._tensor.placement_types import (
     _Partial,
     DTensorSpec,
@@ -11,6 +10,7 @@ from torch.distributed._tensor.placement_types import (
     Replicate,
     Shard,
 )
+from torch.distributed.device_mesh import DeviceMesh
 
 
 _PlacementItem = Tuple[int, Tuple[Placement, Placement]]

--- a/torch/distributed/_tensor/sharding_prop.py
+++ b/torch/distributed/_tensor/sharding_prop.py
@@ -5,7 +5,6 @@ from typing import Callable, cast, Dict, List, Optional, Sequence, Tuple, Union
 import torch
 from torch._ops import OpOverload
 from torch._subclasses import FakeTensorMode
-from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.distributed._tensor.op_schema import (
     DTensorSpec,
     OpInfo,
@@ -19,6 +18,7 @@ from torch.distributed._tensor.op_schema import (
     TupleStrategy,
 )
 from torch.distributed._tensor.placement_types import TensorMeta
+from torch.distributed.device_mesh import DeviceMesh
 
 aten = torch.ops.aten
 

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -18,6 +18,9 @@ from torch.distributed.distributed_c10d import (
 )
 
 
+__all__ = ["init_device_mesh", "DeviceMesh"]
+
+
 logger = logging.getLogger(__name__)
 
 # only import numpy typing when type checking
@@ -131,29 +134,25 @@ class DeviceMesh:
         Inconsistent `mesh` will lead to silent hang.
 
     Args:
-        device_type (str): device type of the mesh. Currently supports: cpu, cuda/cuda-like.
-        mesh (ndarray): could be a multi-dimension array or an integer tensor that
-            describes the layout of devices, the ids are global ids of the
-            default process group.
+        device_type (str): The device type of the mesh. Currently supports: "cpu", "cuda/cuda-like".
+        mesh (ndarray): A multi-dimensional array or an integer tensor describing the layout
+            of devices, where the IDs are global IDs of the default process group.
 
     Returns:
-        A :class:`DeviceMesh` object
+        DeviceMesh: A :class:`DeviceMesh` object representing the device layout.
 
     Example (2 host with 4 GPUs each):
-        ```
-        # The following program runs on each process/rank in SPMD manner.
-        # initialize device mesh as (2, 4) to represent the topology
-        # of cross-host(dim 0), and within-host (dim 1)
-        mesh = DeviceMesh(device_type="cuda",
-                          mesh=[
-                            [0, 1, 2, 3],
-                            [4, 5, 6, 7]
-                          ])
-        ```
+        The following program runs on each process/rank in an SPMD manner:
+        >>> # xdoctest: +SKIP("no rank")
+        >>>
+        >>> from torch.distributed import DeviceMesh
+        >>> # Initialize device mesh as (2, 4) to represent the topology
+        >>> # of cross-host(dim 0), and within-host (dim 1).
+        >>> mesh = DeviceMesh(device_type="cuda", mesh=[[0, 1, 2, 3],[4, 5, 6, 7]])
+
         A reduction over the first dimension of mesh will reduce across
         columns (0, 4), .. and (3, 7), a reduction over the second dimension
-        of mesh reduces across rows (0, 1, 2, 3) and (4, 5, 6, 7)
-
+        of mesh reduces across rows (0, 1, 2, 3) and (4, 5, 6, 7).
     """
 
     device_type: str
@@ -303,22 +302,21 @@ class DeviceMesh:
             A :class:`DeviceMesh` object
 
         Example (2 host with 4 GPUs each):
-        ```
-        # Below is a DeviceMesh with mesh_shape of (2, 4) and mesh_dim_name of ("dp", "tp")
-        mesh = DeviceMesh(device_type="cuda",
-                          mesh=[
-                            [0, 1, 2, 3],
-                            [4, 5, 6, 7]
-                          ],
-                          mesh_dim_names=["dp", "tp"])
-                          )
-        ```
+            The following program runs on each process/rank in an SPMD manner:
+            >>> # xdoctest: +SKIP("no rank")
+            >>>
+            >>> from torch.distributed import DeviceMesh
+            >>> # Initialize device mesh as (2, 4) to represent the topology
+            >>> # of cross-host(dim 0), and within-host (dim 1).
+            >>> mesh = DeviceMesh(device_type="cuda", mesh=[[0, 1, 2, 3],[4, 5, 6, 7]])
+
         Calling mesh["tp"] on rank 0, 1, 2, 3 would return a 1D child DeviceMesh:([0, 1, 2, 3]).
         Calling mesh["tp"] on rank 4, 5, 6, 7 would return a 1D child DeviceMesh:([4, 5, 6, 7]).
         Calling mesh["dp"] on rank 0, 4 would return a 1D child DeviceMesh:([0, 4]).
         Calling mesh["dp"] on rank 1, 5 would return a 1D child DeviceMesh:([1, 5]).
         Calling mesh["dp"] on rank 2, 6 would return a 1D child DeviceMesh:([2, 6]).
         Calling mesh["dp"] on rank 3, 7 would return a 1D child DeviceMesh:([3, 7]).
+
         """
         if self.mesh.ndim <= 1:
             raise RuntimeError(
@@ -337,9 +335,10 @@ class DeviceMesh:
         returns a single ProcessGroup if mesh_dim is specified or the given mesh has
         only one mesh dimension.
 
-        Optional Args:
-            mesh_dim (str/int): it can be the name of the mesh dimension or the index
+        Args:
+            mesh_dim (str/int, optional): it can be the name of the mesh dimension or the index
             of the mesh dimension. Default is None.
+
         Returns:
             A list of :class:`ProcessGroup` object when `mesh_dim` is not specified for
             a DeviceMesh with more than 1 dimension; otherwise, returns a single
@@ -384,29 +383,29 @@ class DeviceMesh:
         """
         Returns the local rank of the given mesh_dim of the DeviceMesh.
 
-        Optional Args:
-            mesh_dim (str/int): it can be the name of the mesh dimension or the index
+        Args:
+            mesh_dim (str/int, optional): it can be the name of the mesh dimension or the index
             of the mesh dimension. Default is None.
 
         Returns:
             An integer denotes the local rank.
 
         Example (2 host with 4 GPUs each):
-            ```
-            # Let's initialize device mesh with mesh_shape = (2, 4) to represent
-            # the topology of cross-host(dim 0), and within-host (dim 1).
-            mesh_2d = DeviceMesh(device_type="cuda",
-                            mesh=[
-                                [0, 1, 2, 3],
-                                [4, 5, 6, 7]
-                            ])
-            ```
+            The following program runs on each process/rank in an SPMD manner:
+            >>> # xdoctest: +SKIP("no rank")
+            >>>
+            >>> from torch.distributed import DeviceMesh
+            >>> # Initialize device mesh as (2, 4) to represent the topology
+            >>> # of cross-host(dim 0), and within-host (dim 1).
+            >>> mesh = DeviceMesh(device_type="cuda", mesh=[[0, 1, 2, 3],[4, 5, 6, 7]])
+
             Calling mesh_2d.get_local_rank(mesh_dim=0) on rank 0, 1, 2, 3 would return 0.
             Calling mesh_2d.get_local_rank(mesh_dim=0) on rank 4, 5, 6, 7 would return 1.
             Calling mesh_2d.get_local_rank(mesh_dim=1) on rank 0, 4 would return 0.
             Calling mesh_2d.get_local_rank(mesh_dim=1) on rank 1, 5 would return 1.
             Calling mesh_2d.get_local_rank(mesh_dim=1) on rank 2, 6 would return 2.
             Calling mesh_2d.get_local_rank(mesh_dim=1) on rank 3, 7 would return 3.
+
         """
         if self.ndim > 1 and mesh_dim is None:
             raise RuntimeError(
@@ -450,34 +449,32 @@ def init_device_mesh(
 ) -> DeviceMesh:
     """
     Initializes a `DeviceMesh` based on `device_type`, `mesh_shape`, and `mesh_dim_names` parameters.
-    This creates a DeviceMesh with a mesh layout of n-d dimensional array, n being the len(mesh_shape)
-    and ith dimension being in size mesh_shape[i]. If mesh_dim_names is provided, each dimension is
-    labeled as mesh_dim_names[i].
+
+    This creates a DeviceMesh with an n-dimensional array layout, where `n` is the length of `mesh_shape`.
+    If `mesh_dim_names` is provided, each dimension is labeled as `mesh_dim_names[i]`.
 
     .. note::
-        `init_device_mesh` follows SPMD programming model, which means the same PyTorch Python program
-        is running on all processes/ranks in the cluster. Therefore, users need to make sure the `mesh_shape`
-        tuple (the dimension of the nD array that describes the layout of devices) should be identical across
-        all ranks. Inconsistent `mesh_shape` will lead to silent hang.
+        `init_device_mesh` follows SPMD programming model, meaning the same PyTorch Python program
+        runs on all processes/ranks in the cluster. Ensure `mesh_shape` (the dimensions of the nD array
+        describing device layout) is identical across all ranks. Inconsistent `mesh_shape` may lead to hanging.
 
     Args:
-        device_type (str): device type of the mesh. Currently supports: cpu, cuda/cuda-like.
-        mesh_shape: Tuple[int]: A tuple defines the dimension of the multi-dimesnion array
-        that describes the layout of devices.
-    Kwargs:
-        mesh_dim_names: Optional[Tuple[str]]: A tuple of mesh dim names to be assigned to each dimension
-        of the multi-dimensional array that describes the layout of devices. Its length must match the length
-        of `mesh_shape`. Each string in mesh_dim_names must be unique.
+        device_type (str): The device type of the mesh. Currently supports: "cpu", "cuda/cuda-like".
+        mesh_shape (Tuple[int]): A tuple defining the dimensions of the multi-dimensional array
+            describing the layout of devices.
+        mesh_dim_names (Tuple[str], optional): A tuple of mesh dimension names to assign to each dimension
+            of the multi-dimensional array describing the layout of devices. Its length must match the length
+            of `mesh_shape`. Each string in `mesh_dim_names` must be unique.
 
     Returns:
-        A :class:`DeviceMesh` object
+        DeviceMesh: A :class:`DeviceMesh` object representing the initialized device layout.
 
     .. note: If no process group is found, init_device_mesh will initialize distributed process group/groups
-    behind the scene, which are required for distributed communications.
+      required for distributed communications behind the scene.
 
     Example:
-        >>> # xdoctest: +SKIP
-        >>> from torch.distributed._tensor.device_mesh import init_device_mesh
+        >>> # xdoctest: +SKIP("no rank")
+        >>> from torch.distributed import init_device_mesh
         >>>
         >>> mesh_1d = init_device_mesh("cuda", mesh_shape=(8,))
         >>> mesh_2d = init_device_mesh("cuda", mesh_shape=(2, 8), mesh_dim_names=("dp", "tp"))

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -24,8 +24,8 @@ import torch.distributed.fsdp._exec_order_utils as exec_order_utils
 import torch.distributed.fsdp._traversal_utils as traversal_utils
 import torch.distributed.fsdp.fully_sharded_data_parallel as fsdp_file
 import torch.nn as nn
-from torch.distributed._tensor.device_mesh import _mesh_resources, DeviceMesh
 from torch.distributed.algorithms._comm_hooks import default_hooks
+from torch.distributed.device_mesh import _mesh_resources, DeviceMesh
 from torch.distributed.distributed_c10d import _get_default_group
 from torch.distributed.fsdp._common_utils import (
     _FSDPDeviceHandle,

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -17,7 +17,7 @@ from torch.distributed._shard.sharded_tensor import (
     ShardedTensor,
 )
 from torch.distributed._tensor import DTensor
-from torch.distributed._tensor.device_mesh import _mesh_resources
+from torch.distributed.device_mesh import _mesh_resources
 
 from torch.distributed.fsdp._common_utils import (
     _FSDPState,

--- a/torch/distributed/tensor/parallel/_utils.py
+++ b/torch/distributed/tensor/parallel/_utils.py
@@ -1,11 +1,11 @@
 import functools
 import warnings
-from typing import Callable, Tuple, Optional, Union
+from typing import Callable, Optional, Tuple, Union
 
 import torch
 from torch.distributed._tensor import DeviceMesh, DTensor
-from torch.distributed._tensor.device_mesh import _mesh_resources
 from torch.distributed._tensor.placement_types import Placement
+from torch.distributed.device_mesh import _mesh_resources
 try:
     from torch._dynamo.external_utils import is_compiling as is_torchdynamo_compiling
 except Exception:

--- a/torch/distributed/tensor/parallel/fsdp.py
+++ b/torch/distributed/tensor/parallel/fsdp.py
@@ -16,7 +16,7 @@ from torch.distributed._shard.sharded_tensor import (
 from torch.distributed._shard.sharding_spec import ShardMetadata
 from torch.distributed._shard.sharding_spec.chunk_sharding_spec import ChunkShardingSpec
 from torch.distributed._tensor import DeviceMesh, DTensor, Replicate, Shard as DShard
-from torch.distributed._tensor.device_mesh import _mesh_resources
+from torch.distributed.device_mesh import _mesh_resources
 
 from torch.distributed.fsdp._common_utils import _set_fsdp_flattened
 from torch.distributed.fsdp._fsdp_extensions import FSDPExtensions

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -10046,7 +10046,7 @@ class DistributedTest:
             """
             world_size = int(os.environ["WORLD_SIZE"])
 
-            from torch.distributed._device_mesh import init_device_mesh
+            from torch.distributed.device_mesh import init_device_mesh
             device_mesh = init_device_mesh("cuda", (world_size,))
 
             pg = _get_default_group()


### PR DESCRIPTION
Summary:
Rename _device_mesh.py to device_mesh.py, update all callsites, adds documentation.

Original diff reverted: D51629761
Original PR reverted: https://github.com/pytorch/pytorch/pull/114991
It was failing because failing a public module binding tests in MacOS, and this is due to the change in import order for torch/distributed/fsdp/_common_utils.py. Since this original import would still work, we remove the changes in this file.

Test Plan: CI.

Differential Revision: D51825114



cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @tianyu-l @wconstab @yf225 @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @kiukchung @d4l3k @lucasllc