### PR TITLE
Fix `torch.inductor._utils.get_device_tflops` on ROCm 

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1110,9 +1110,20 @@ def blue_text(msg):
 
 @functools.lru_cache(None)
 def get_device_tflops(dtype):
-    from triton.testing import get_max_simd_tflops, get_max_tensorcore_tflops, nvsmi
-
+    from triton.testing import get_max_simd_tflops, get_max_tensorcore_tflops
     assert dtype in (torch.float16, torch.bfloat16, torch.float32)
+    if torch.version.hip:
+
+        if dtype in (torch.float16, torch.bfloat16):
+            return get_max_tensorcore_tflops(dtype)
+
+        if torch.backends.cuda.matmul.allow_tf32:
+            return get_max_tensorcore_tflops(torch.float32)
+        else:
+            return get_max_simd_tflops(torch.float32)
+
+    from triton.testing import nvsmi
+
     cur_sm_clock = nvsmi(["clocks.current.sm"])[0]
     if dtype in (torch.float16, torch.bfloat16):
         return get_max_tensorcore_tflops(dtype, cur_sm_clock)

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1111,9 +1111,9 @@ def blue_text(msg):
 @functools.lru_cache(None)
 def get_device_tflops(dtype):
     from triton.testing import get_max_simd_tflops, get_max_tensorcore_tflops
+
     assert dtype in (torch.float16, torch.bfloat16, torch.float32)
     if torch.version.hip:
-
         if dtype in (torch.float16, torch.bfloat16):
             return get_max_tensorcore_tflops(dtype)
 


### PR DESCRIPTION
That caused numerous test regressions after https://github.com/pytorch/pytorch/pull/114772 changed triton APIs a bit to use `nvsmi` function, which is not available on `hip` platform

Fixes https://github.com/pytorch/pytorch/issues/115087

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler