### PR TITLE
introduce WeakscriptObjectRef

### DIFF
--- a/test/cpp/jit/test_custom_class_registrations.cpp
+++ b/test/cpp/jit/test_custom_class_registrations.cpp
@@ -53,6 +53,9 @@ struct Foo : torch::CustomClassHolder {
   int64_t combine(c10::intrusive_ptr<Foo> b) {
     return this->info() + b->info();
   }
+  bool eq(c10::intrusive_ptr<Foo> other) {
+    return this->x == other->x && this->y == other->y;
+  }
 };
 
 struct _StaticMethod : torch::CustomClassHolder {
@@ -314,6 +317,7 @@ TORCH_LIBRARY(_TorchScriptTesting, m) {
       .def("info", &Foo::info)
       .def("increment", &Foo::increment)
       .def("add", &Foo::add)
+      .def("__eq__", &Foo::eq)
       .def("combine", &Foo::combine);
 
   m.class_<FooGetterSetter>("_FooGetterSetter")

--- a/test/test_weak.py
+++ b/test/test_weak.py
@@ -8,8 +8,16 @@ import threading
 import unittest
 
 import torch
-from torch.testing._internal.common_utils import run_tests, TestCase
-from torch.utils.weak import WeakIdKeyDictionary
+from torch.testing._internal.common_utils import (
+    find_library_location,
+    IS_FBCODE,
+    IS_MACOS,
+    IS_SANDCASTLE,
+    IS_WINDOWS,
+    run_tests,
+    TestCase,
+)
+from torch.utils.weak import WeakIdKeyDictionary, WeakScriptObjectRef
 
 
 def C():
@@ -263,6 +271,339 @@ class WeakKeyDictionaryTestCase(TestCase):
         return x
 
     def __init__(self, *args, **kw):
+        unittest.TestCase.__init__(self, *args, **kw)
+        self.reference = self._reference().copy()
+
+        # A (key, value) pair not in the mapping
+        key, value = self.reference.popitem()
+        self.other = {key: value}
+
+        # A (key, value) pair in the mapping
+        key, value = self.reference.popitem()
+        self.inmapping = {key: value}
+        self.reference[key] = value
+
+    def test_read(self):
+        # Test for read only operations on mapping
+        p = self._empty_mapping()
+        p1 = dict(p)  # workaround for singleton objects
+        d = self._full_mapping(self.reference)
+        if d is p:
+            p = p1
+        # Indexing
+        for key, value in self.reference.items():
+            self.assertEqual(d[key], value)
+        knownkey = list(self.other.keys())[0]
+        self.assertRaises(KeyError, lambda: d[knownkey])
+        # len
+        self.assertEqual(len(p), 0)
+        self.assertEqual(len(d), len(self.reference))
+        # __contains__
+        for k in self.reference:
+            self.assertIn(k, d)
+        for k in self.other:
+            self.assertNotIn(k, d)
+        # cmp
+        self.assertTrue(
+            p == p
+        )  # NB: don't use assertEqual, that doesn't actually use ==
+        self.assertTrue(d == d)
+        self.assertTrue(p != d)
+        self.assertTrue(d != p)
+        # bool
+        if p:
+            self.fail("Empty mapping must compare to False")
+        if not d:
+            self.fail("Full mapping must compare to True")
+
+        # keys(), items(), iterkeys() ...
+        def check_iterandlist(iter, lst, ref):
+            self.assertTrue(hasattr(iter, "__next__"))
+            self.assertTrue(hasattr(iter, "__iter__"))
+            x = list(iter)
+            self.assertTrue(set(x) == set(lst) == set(ref))
+
+        check_iterandlist(iter(d.keys()), list(d.keys()), self.reference.keys())
+        check_iterandlist(iter(d), list(d.keys()), self.reference.keys())
+        check_iterandlist(iter(d.values()), list(d.values()), self.reference.values())
+        check_iterandlist(iter(d.items()), list(d.items()), self.reference.items())
+        # get
+        key, value = next(iter(d.items()))
+        knownkey, knownvalue = next(iter(self.other.items()))
+        self.assertEqual(d.get(key, knownvalue), value)
+        self.assertEqual(d.get(knownkey, knownvalue), knownvalue)
+        self.assertNotIn(knownkey, d)
+
+    def test_write(self):
+        # Test for write operations on mapping
+        p = self._empty_mapping()
+        # Indexing
+        for key, value in self.reference.items():
+            p[key] = value
+            self.assertEqual(p[key], value)
+        for key in self.reference.keys():
+            del p[key]
+            self.assertRaises(KeyError, lambda: p[key])
+        p = self._empty_mapping()
+        # update
+        p.update(self.reference)
+        self.assertEqual(dict(p), self.reference)
+        items = list(p.items())
+        p = self._empty_mapping()
+        p.update(items)
+        self.assertEqual(dict(p), self.reference)
+        d = self._full_mapping(self.reference)
+        # setdefault
+        key, value = next(iter(d.items()))
+        knownkey, knownvalue = next(iter(self.other.items()))
+        self.assertEqual(d.setdefault(key, knownvalue), value)
+        self.assertEqual(d[key], value)
+        self.assertEqual(d.setdefault(knownkey, knownvalue), knownvalue)
+        self.assertEqual(d[knownkey], knownvalue)
+        # pop
+        self.assertEqual(d.pop(knownkey), knownvalue)
+        self.assertNotIn(knownkey, d)
+        self.assertRaises(KeyError, d.pop, knownkey)
+        default = 909
+        d[knownkey] = knownvalue
+        self.assertEqual(d.pop(knownkey, default), knownvalue)
+        self.assertNotIn(knownkey, d)
+        self.assertEqual(d.pop(knownkey, default), default)
+        # popitem
+        key, value = d.popitem()
+        self.assertNotIn(key, d)
+        self.assertEqual(value, self.reference[key])
+        p = self._empty_mapping()
+        self.assertRaises(KeyError, p.popitem)
+
+    def test_constructor(self):
+        self.assertEqual(self._empty_mapping(), self._empty_mapping())
+
+    def test_bool(self):
+        self.assertTrue(not self._empty_mapping())
+        self.assertTrue(self.reference)
+        self.assertTrue(bool(self._empty_mapping()) is False)
+        self.assertTrue(bool(self.reference) is True)
+
+    def test_keys(self):
+        d = self._empty_mapping()
+        self.assertEqual(list(d.keys()), [])
+        d = self.reference
+        self.assertIn(list(self.inmapping.keys())[0], d.keys())
+        self.assertNotIn(list(self.other.keys())[0], d.keys())
+        self.assertRaises(TypeError, d.keys, None)
+
+    def test_values(self):
+        d = self._empty_mapping()
+        self.assertEqual(list(d.values()), [])
+
+        self.assertRaises(TypeError, d.values, None)
+
+    def test_items(self):
+        d = self._empty_mapping()
+        self.assertEqual(list(d.items()), [])
+
+        self.assertRaises(TypeError, d.items, None)
+
+    def test_len(self):
+        d = self._empty_mapping()
+        self.assertEqual(len(d), 0)
+
+    def test_getitem(self):
+        d = self.reference
+        self.assertEqual(
+            d[list(self.inmapping.keys())[0]], list(self.inmapping.values())[0]
+        )
+
+        self.assertRaises(TypeError, d.__getitem__)
+
+    def test_update(self):
+        # mapping argument
+        d = self._empty_mapping()
+        d.update(self.other)
+        self.assertEqual(list(d.items()), list(self.other.items()))
+
+        # No argument
+        d = self._empty_mapping()
+        d.update()
+        self.assertEqual(d, self._empty_mapping())
+
+        # item sequence
+        d = self._empty_mapping()
+        d.update(self.other.items())
+        self.assertEqual(list(d.items()), list(self.other.items()))
+
+        # Iterator
+        d = self._empty_mapping()
+        d.update(self.other.items())
+        self.assertEqual(list(d.items()), list(self.other.items()))
+
+        # FIXME: Doesn't work with UserDict
+        # self.assertRaises((TypeError, AttributeError), d.update, None)
+        self.assertRaises((TypeError, AttributeError), d.update, 42)
+
+        outerself = self
+
+        class SimpleUserDict:
+            def __init__(self):
+                self.d = outerself.reference
+
+            def keys(self):
+                return self.d.keys()
+
+            def __getitem__(self, i):
+                return self.d[i]
+
+        d.clear()
+        d.update(SimpleUserDict())
+        i1 = sorted((id(k), v) for k, v in d.items())
+        i2 = sorted((id(k), v) for k, v in self.reference.items())
+        self.assertEqual(i1, i2)
+
+        class Exc(Exception):
+            pass
+
+        d = self._empty_mapping()
+
+        class FailingUserDict:
+            def keys(self):
+                raise Exc
+
+        self.assertRaises(Exc, d.update, FailingUserDict())
+
+        d.clear()
+
+        class FailingUserDict:
+            def keys(self):
+                class BogonIter:
+                    def __init__(self):
+                        self.i = 1
+
+                    def __iter__(self):
+                        return self
+
+                    def __next__(self):
+                        if self.i:
+                            self.i = 0
+                            return "a"
+                        raise Exc
+
+                return BogonIter()
+
+            def __getitem__(self, key):
+                return key
+
+        self.assertRaises(Exc, d.update, FailingUserDict())
+
+        class FailingUserDict:
+            def keys(self):
+                class BogonIter:
+                    def __init__(self):
+                        self.i = ord("a")
+
+                    def __iter__(self):
+                        return self
+
+                    def __next__(self):
+                        if self.i <= ord("z"):
+                            rtn = chr(self.i)
+                            self.i += 1
+                            return rtn
+                        raise StopIteration
+
+                return BogonIter()
+
+            def __getitem__(self, key):
+                raise Exc
+
+        self.assertRaises(Exc, d.update, FailingUserDict())
+
+        d = self._empty_mapping()
+
+        class badseq:
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                raise Exc()
+
+        self.assertRaises(Exc, d.update, badseq())
+
+        self.assertRaises(ValueError, d.update, [(1, 2, 3)])
+
+    # no test_fromkeys or test_copy as both os.environ and selves don't support it
+
+    def test_get(self):
+        d = self._empty_mapping()
+        self.assertTrue(d.get(list(self.other.keys())[0]) is None)
+        self.assertEqual(d.get(list(self.other.keys())[0], 3), 3)
+        d = self.reference
+        self.assertTrue(d.get(list(self.other.keys())[0]) is None)
+        self.assertEqual(d.get(list(self.other.keys())[0], 3), 3)
+        self.assertEqual(
+            d.get(list(self.inmapping.keys())[0]), list(self.inmapping.values())[0]
+        )
+        self.assertEqual(
+            d.get(list(self.inmapping.keys())[0], 3), list(self.inmapping.values())[0]
+        )
+        self.assertRaises(TypeError, d.get)
+        self.assertRaises(TypeError, d.get, None, None, None)
+
+    def test_setdefault(self):
+        d = self._empty_mapping()
+        self.assertRaises(TypeError, d.setdefault)
+
+    def test_popitem(self):
+        d = self._empty_mapping()
+        self.assertRaises(KeyError, d.popitem)
+        self.assertRaises(TypeError, d.popitem, 42)
+
+    def test_pop(self):
+        d = self._empty_mapping()
+        k, v = list(self.inmapping.items())[0]
+        d[k] = v
+        self.assertRaises(KeyError, d.pop, list(self.other.keys())[0])
+
+        self.assertEqual(d.pop(k), v)
+        self.assertEqual(len(d), 0)
+
+        self.assertRaises(KeyError, d.pop, k)
+
+
+# Adapted from cpython/Lib/test/mapping_tests.py
+class WeakKeyDictionaryScriptObjectTestCase(TestCase):
+    def _reference(self):
+        self.__ref = {
+            torch.classes._TorchScriptTesting._Foo(1, 2): 1,
+            torch.classes._TorchScriptTesting._Foo(2, 3): 2,
+            torch.classes._TorchScriptTesting._Foo(3, 4): 3,
+        }
+        return self.__ref.copy()
+
+    def _empty_mapping(self):
+        """Return an empty mapping object"""
+        return WeakIdKeyDictionary(ref_type=WeakScriptObjectRef)
+
+    def _full_mapping(self, data):
+        """Return a mapping object with the value contained in data
+        dictionary"""
+        x = self._empty_mapping()
+        for key, value in data.items():
+            x[key] = value
+        return x
+
+    def __init__(self, *args, **kw):
+        if IS_MACOS:
+            raise unittest.SkipTest("non-portable load_library call used in test")
+
+        if IS_SANDCASTLE or IS_FBCODE:
+            torch.ops.load_library("//caffe2/test/cpp/jit:test_custom_class_registrations")
+        else:
+            lib_file_path = find_library_location("libtorchbind_test.so")
+            if IS_WINDOWS:
+                lib_file_path = find_library_location("torchbind_test.dll")
+            torch.ops.load_library(str(lib_file_path))
+
         unittest.TestCase.__init__(self, *args, **kw)
         self.reference = self._reference().copy()
 


### PR DESCRIPTION
Summary:
We would like weak dictionaries that have `torch.ScriptObject` keys. Similar to tensors, we need to override the behavior of the ref to dot he right thing under comparison.

This change also makes it so that WeakIdKeyDictionary works with a pluggable ref_type.

Test Plan: added a unit test

Differential Revision: D51828205


