### PR TITLE
[DTensor] Remove assert to allow tensor sharding dimension < Shard(x).ndim

### DIFF
--- a/test/distributed/_tensor/test_dtensor.py
+++ b/test/distributed/_tensor/test_dtensor.py
@@ -2,7 +2,6 @@
 # Owner(s): ["oncall: distributed"]
 
 import torch
-import torch.distributed as dist
 import torch.nn.functional as F
 from numpy.testing import assert_array_equal
 from torch.distributed._functional_collectives import AsyncCollectiveTensor
@@ -759,33 +758,33 @@ class TestDTensorPlacementTypes(DTensorTestBase):
             return tensor
 
     @with_comms
-    def test_split_tensor(self) -> None:
+    def test_split_tensor_1D(self) -> None:
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
         shard_placement = Shard(0)
 
         for size in range(8):
             tensor = self._create_tensor(size)
+            splitted_tensor_list, pad_sizes = shard_placement._split_tensor(
+                tensor,
+                mesh.size(),
+                with_padding=True,
+                contiguous=True,
+            )
             if size == 0:
-                with self.assertRaisesRegex(
-                    Exception,
-                    "Tensor size along dim0 is 0. There is nothing to be sharded.",
-                ):
-                    _, _ = shard_placement._split_tensor(
-                        tensor,
-                        mesh.size(),
-                        with_padding=True,
-                        contiguous=True,
-                    )
+                # when tensor size is 0, there is no padding needed for all the ranks.
+                expected_pad_sizes = [0] * self.world_size
+                assert_array_equal(expected_pad_sizes, pad_sizes)
+
+                is_tensor_empty = [
+                    False if splitted_tensor.numel() > 0 else True
+                    for splitted_tensor in splitted_tensor_list
+                ]
+                expected_is_tensor_empty = [True] * self.world_size
+                assert_array_equal(expected_is_tensor_empty, is_tensor_empty)
             else:
-                splitted_tensor_list, pad_sizes = shard_placement._split_tensor(
-                    tensor,
-                    mesh.size(),
-                    with_padding=True,
-                    contiguous=True,
-                )
                 expected_pad_sizes = [
                     0 if idx < size else 1
-                    for idx, _ in enumerate(range(dist.get_world_size()))
+                    for idx, _ in enumerate(range(self.world_size))
                 ]
                 assert_array_equal(expected_pad_sizes, pad_sizes)
 
@@ -797,7 +796,7 @@ class TestDTensorPlacementTypes(DTensorTestBase):
                 ]
                 expected_is_tensor_empty = [
                     False if idx < size else True
-                    for idx, _ in enumerate(range(dist.get_world_size()))
+                    for idx, _ in enumerate(range(self.world_size))
                 ]
                 is_tensor_empty = [
                     False if unpadded_tensor.numel() > 0 else True

--- a/test/distributed/_tensor/test_utils.py
+++ b/test/distributed/_tensor/test_utils.py
@@ -58,26 +58,31 @@ class UtilTest(DTensorTestBase):
         one_d_placements = [[Shard(0)], [Replicate()]]
 
         for placements in one_d_placements:
-            mesh_tensor = torch.arange(self.world_size)
-            device_mesh = DeviceMesh(self.device_type, mesh_tensor)
-            global_tensor = torch.arange(64).view(8, 8)
-            global_shape = global_tensor.size()
+            # When the placements is [Shard(0)], we test for three different scenarios:
+            # 1) sharding resulting in empty shards on all or some of the ranks
+            # 2) sharding resulting in shards of different size across different ranks
+            # 3) sharding resulting in non-empty shards of same size across all ranks
+            for size in range(self.world_size * 2 + 1):
+                mesh_tensor = torch.arange(self.world_size)
+                device_mesh = DeviceMesh(self.device_type, mesh_tensor)
+                global_tensor = torch.arange(size)
+                global_shape = global_tensor.size()
 
-            dtensor = distribute_tensor(global_tensor, device_mesh, placements)
-            local_size, global_offset = compute_local_shape_and_global_offset(
-                global_shape, device_mesh, placements
-            )
+                dtensor = distribute_tensor(global_tensor, device_mesh, placements)
+                local_size, global_offset = compute_local_shape_and_global_offset(
+                    global_shape, device_mesh, placements
+                )
 
-            # TODO: make this test cleaner and work for nD
-            dim0_start = global_offset[0]
-            dim0_end = global_offset[0] + local_size[0]
+                # TODO: make this test cleaner and work for nD
+                dim0_start = global_offset[0]
+                dim0_end = global_offset[0] + local_size[0]
 
-            # Check the local tensor of dtensor is exactly the same
-            # if we slice the global_tensor with local_size and global_offset
-            self.assertEqual(
-                dtensor.to_local(),
-                global_tensor[dim0_start:dim0_end],
-            )
+                # Check the local tensor of dtensor is exactly the same
+                # if we slice the global_tensor with local_size and global_offset
+                self.assertEqual(
+                    dtensor.to_local(),
+                    global_tensor[dim0_start:dim0_end],
+                )
 
     @with_comms
     def test_compute_local_shape_and_global_offset_2D(self):
@@ -88,29 +93,30 @@ class UtilTest(DTensorTestBase):
         )
 
         for placements in two_d_placements:
-            # mesh: 2 * 4
-            mesh_tensor = torch.arange(self.world_size).reshape(2, 4)
-            device_mesh = DeviceMesh(self.device_type, mesh_tensor)
-            global_tensor = torch.arange(64).view(8, 8)
-            global_shape = global_tensor.size()
+            for dim_0_size in (1, 2, 4, 8):
+                # mesh: 2 * 4
+                mesh_tensor = torch.arange(self.world_size).reshape(2, 4)
+                device_mesh = DeviceMesh(self.device_type, mesh_tensor)
+                global_tensor = torch.arange(64).view(dim_0_size, -1)
+                global_shape = global_tensor.size()
 
-            dtensor = distribute_tensor(global_tensor, device_mesh, placements)
-            local_size, global_offset = compute_local_shape_and_global_offset(
-                global_shape, device_mesh, placements
-            )
+                dtensor = distribute_tensor(global_tensor, device_mesh, placements)
+                local_size, global_offset = compute_local_shape_and_global_offset(
+                    global_shape, device_mesh, placements
+                )
 
-            # TODO: make this test cleaner and work for nD
-            dim0_start = global_offset[0]
-            dim0_end = global_offset[0] + local_size[0]
-            dim1_start = global_offset[1]
-            dim1_end = global_offset[1] + local_size[1]
+                # TODO: make this test cleaner and work for nD
+                dim0_start = global_offset[0]
+                dim0_end = global_offset[0] + local_size[0]
+                dim1_start = global_offset[1]
+                dim1_end = global_offset[1] + local_size[1]
 
-            # Check the local tensor of dtensor is exactly the same
-            # if we slice the global_tensor with local_size and global_offset
-            self.assertEqual(
-                dtensor.to_local(),
-                global_tensor[dim0_start:dim0_end, dim1_start:dim1_end],
-            )
+                # Check the local tensor of dtensor is exactly the same
+                # if we slice the global_tensor with local_size and global_offset
+                self.assertEqual(
+                    dtensor.to_local(),
+                    global_tensor[dim0_start:dim0_end, dim1_start:dim1_end],
+                )
 
 
 if __name__ == "__main__":

--- a/test/distributed/checkpoint/test_dtensor_resharding.py
+++ b/test/distributed/checkpoint/test_dtensor_resharding.py
@@ -243,8 +243,37 @@ class TestDTensorReshardMeshChange(DTensorTestBase):
                     global_tensor, state_dict_to_load["dtensor"].to_local()
                 )
 
+    @with_comms
+    @with_temp_dir
+    @skip_if_lt_x_gpu(2)
+    def test_dtensor_checkpoint_resharding_with_empty_shard(self):
+        """
+        Test dtensor checkpoint resharding with dtensor containing empty shards.
+        """
+        tensor = torch.rand(1).cuda()
+        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        dtensor = distribute_tensor(tensor, mesh, [Shard(0)])
+        ref_state_dict = {"dtensor": dtensor}
+
+        dist_cp.save_state_dict(
+            state_dict=ref_state_dict,
+            storage_writer=dist_cp.FileSystemWriter(path=self.temp_dir),
+        )
+
+        tensor = torch.rand(1).cuda()
+        mesh_2 = init_device_mesh(self.device_type, (2, self.world_size // 2))
+        dtensor = distribute_tensor(tensor, mesh_2, [Shard(0), Shard(0)])
+        state_dict = {"dtensor": dtensor}
+        dist_cp.load_state_dict(
+            state_dict=state_dict,
+            storage_reader=dist_cp.FileSystemReader(self.temp_dir),
+        )
+
+    # TODO: Add a assertEqual for ref_state_dict["dtensor"].full_tensor()
+    # and state_dict["dtensor"].full_tensor() after we fix the size mismatch
+    # issue for un-even sharding dtensor.
+
 
 # TODO: Add dtensor resharding test when world size changes.
-
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/_tensor/_utils.py
+++ b/torch/distributed/_tensor/_utils.py
@@ -70,6 +70,18 @@ def compute_local_shape_and_global_offset(
     rank4 -- local_shape:[1, 4], global_offset:[4, 0]
     rank6 -- local_shape:[1, 4], global_offset:[6, 0]
     rank7 -- local_shape:[1, 4], global_offset:[7, 0]
+
+    Let's say we distribute a global_tensor of shape (2) over the above DeviceMesh with
+    a placements of [Shard(0)]. We will not have non-empty local tensor for all the ranks.
+    The local shape and global offset will be as follows:
+    rank0 -- local_shape:[1,], global_offset:[0,]
+    rank1 -- local_shape:[1,], global_offset:[1,]
+    rank2 -- local_shape:[0,], global_offset:[2,]
+    rank5 -- local_shape:[0,], global_offset:[2,]
+    rank3 -- local_shape:[0,], global_offset:[2,]
+    rank4 -- local_shape:[0,], global_offset:[2,]
+    rank6 -- local_shape:[0,], global_offset:[2,]
+    rank7 -- local_shape:[0,], global_offset:[2,]
     """
     my_coordinate = mesh.get_coordinate()
 

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -473,6 +473,9 @@ class DTensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
 
         .. note:: `full_tensor` is differentiable.
         """
+
+        # TODO: fix issue with full_tensor() for uneven-sharded tensor
+        # https://github.com/pytorch/pytorch/issues/115310
         redist_res = self.redistribute(placements=[Replicate()] * self.device_mesh.ndim)
         return _ToTorchTensor.apply(redist_res, grad_placements, False)
 

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -54,9 +54,6 @@ class Shard(Placement):
         assert (
             self.dim <= tensor.ndim
         ), f"Sharding dim {self.dim} greater than tensor ndim {tensor.ndim}"
-        assert (
-            tensor.size(self.dim) > 0
-        ), f"Tensor size along dim{self.dim} is 0. There is nothing to be sharded."
 
         # chunk tensor over dimension `dim` into n slices with padding if necessary
         tensor_list = list(torch.chunk(tensor, num_chunks, dim=self.dim))
@@ -123,10 +120,6 @@ class Shard(Placement):
         """
         returns the local shard size and offset on a given tensor dim
         """
-        assert (
-            size_on_dim >= num_chunks
-        ), f"Size to be sharded on dim {self.dim} must be at least as large as the number of devices in that dimension {num_chunks}"
-
         # Compute the chunk size inline with ``torch.chunk``
         full_chunk_size = (size_on_dim + num_chunks - 1) // num_chunks
 


### PR DESCRIPTION
Consolidated by changes made by @yoyoyocmu. https://www.internalfb.com/diff/D51821717
Remove assert to allow tensor dimension < Shard(x).ndim. With the current padding, we do support this already.

Follow up: we will still need to fix the size mismatch and `full_tensor()` hang when tensor is uneven-sharded.
Created issue here: https://github.com/pytorch/pytorch/issues/115310

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @tianyu-l @wconstab @yf225 @kiukchung @lucasllc @d4l3k