### PR TITLE
[Inductor][Optimus]Move group/batch fusion logic out of inductor

### DIFF
--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -763,23 +763,6 @@ def group_batch_fusion_passes(graph: torch.fx.Graph, pre_grad=True):
     fusions: List[GroupBatchFusionBase] = []
     # we keep all current pre grad fusions to keep
     # current implementation, will remove this later
-    # TODO: deperate batch_fusion and group_fusion flags
-    if config.batch_fusion:
-        config.pre_grad_fusion_options = {
-            "batch_linear": {},
-            "batch_linear_lhs": {},
-            "batch_layernorm": {},
-            "batch_tanh": {},
-            "batch_relu": {},
-            "batch_sigmoid": {},
-        }
-        # config.post_grad_fusion_options = {
-        #     "batch_linear_post_grad": {},
-        # }
-    if config.group_fusion:
-        config.post_grad_fusion_options = {
-            "group_linear": {"require_fbgemm": True},
-        }
     if pre_grad:
         fusions += generate_fusion_from_config(
             config.pre_grad_fusion_options, pre_grad=True


### PR DESCRIPTION
Summary:
As discussed D51695982, fusion may not be always good. We want to let the user customize the fx passes.

Some example for new configs:
* Use batch_fusion config: this will automatically use the following batch fusions, including batch linear, layernorm, relu, tanh, sigmoid and post grad batch linear fusion
* use config:
```
"pre_grad_fusion_options": {
            "batch_linear": {"min_fuse_set_size": 10},
            "batch_linear_lhs": {},
            "batch_layernorm": {"max_fuse_search_depth": 100},
            "batch_tanh": {},
            "batch_relu": {},
            "batch_sigmoid": {}
          },
```

Test Plan:
with flag: f509168388

with config: f509168595

Reviewed By: frank-wei, mengluy0125

Differential Revision: D51817314




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler