### PR TITLE
[Inductor][fx pass] Fix a bug in batch linear fusion in the post grad (#115061)

### DIFF
--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -129,7 +129,12 @@ class PostGradBatchLinearFusion(BatchFusion):
         )
 
     def _is_input_2d(self, input: torch.fx.Node) -> bool:
-        return len(input.meta["tensor_meta"].shape) == 2
+        input_shapes = input.meta["tensor_meta"].shape
+        return (
+            len(input_shapes) == 2
+            and isinstance(input_shapes[0], int)
+            and isinstance(input_shapes[1], int)
+        )
 
     def match(self, node: torch.fx.Node) -> Optional[Tuple[str, int, int, int, bool]]:
         if CallFunctionVarArgs(aten.mm).match(node):
@@ -705,8 +710,7 @@ def get_fusion_candidates(
             continue
 
         key = rule.match(node)
-        # SymInt is not hashable, so we need to skip it
-        if key is not None and not isinstance(key, torch.SymInt):
+        if key is not None:
             candidate_nodes = candidate_dict[key]
             if node not in candidate_nodes:
                 candidate_nodes.append(node)


### PR DESCRIPTION
Summary:

Titled

Test Plan:
```
buck2 test 'fbcode//mode/dev-nosan' fbcode//caffe2/test/inductor:group_batch_fusion
```
Buck UI: https://www.internalfb.com/buck2/ab4b918c-9ffa-4d00-a747-880521a27851
Test UI: https://www.internalfb.com/intern/testinfra/testrun/16607023638890043
Network: Up: 11MiB  Down: 117MiB  (reSessionID-079402d0-8fd7-4797-9ed5-dd0f778dce1a)
Jobs completed: 189430. Time elapsed: 2:02.5s.
Cache hits: 99%. Commands: 77000 (cached: 76995, remote: 5, local: 0)
Tests finished: Pass 7. Fail 0. Fatal 0. Skip 0. Build failure 0

Reviewed By: mengluy0125

Differential Revision: D51796899




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler