### PR TITLE
Refactor can_auto_functionalize

### DIFF
--- a/torch/_higher_order_ops/auto_functionalize.py
+++ b/torch/_higher_order_ops/auto_functionalize.py
@@ -68,14 +68,11 @@ auto_functionalized = AutoFunctionalized()
 def can_auto_functionalize(op: torch._ops.OperatorBase) -> bool:
     if not isinstance(op, torch._ops.OpOverload):
         return False
-    # Built-in operators should be handled via built-in codegen.
-    if op.namespace == "aten":
+    from torch._subclasses.fake_tensor import can_generate_trivial_abstract_impl
+
+    if not can_generate_trivial_abstract_impl(op):
         return False
     schema = op._schema
-    if not schema.is_mutable:
-        return False
-    if len(schema.returns) > 0:
-        return False
     for arg in schema.arguments:
         if arg.alias_info is None:
             continue

--- a/torch/_library/utils.py
+++ b/torch/_library/utils.py
@@ -64,6 +64,11 @@ def lookup_op(qualname: str) -> torch._ops.OpOverloadPacket:
     return getattr(packet, overload)
 
 
+def is_builtin(op: torch._ops.OpOverload) -> bool:
+    assert isinstance(op, torch._ops.OpOverload)
+    return op.namespace in {"aten", "prim", "prims"}
+
+
 def is_functional_schema(schema: Any) -> bool:
     """Check if the schema is functional.
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1684,11 +1684,7 @@ class FakeTensorMode(TorchDispatchMode):
             # We infer the meta of a custom ops that return None to just
             # return None. custom ops are not allowed to mutate metadata
             # of their inputs, so this is safe.
-            from torch._higher_order_ops.auto_functionalize import (
-                can_auto_functionalize,
-            )
-
-            if can_auto_functionalize(func):
+            if can_generate_trivial_abstract_impl(func):
                 return None
             # no meta kernel registered, fallback to kernel for the device
             if has_symbolic_sizes or not can_run_unsafe_fallback(func):
@@ -1960,6 +1956,22 @@ def run_fallback_kernel(
             return e
 
     return pytree.tree_map(map_out, r)
+
+
+def can_generate_trivial_abstract_impl(op: torch._ops.OpOverload) -> bool:
+    assert isinstance(op, torch._ops.OpOverload)
+    if torch._library.utils.is_builtin(op):
+        # We control the built-ins. These may (in rare cases)
+        # do input metadata mutation (which we have banned on custom ops)
+        return False
+    schema = op._schema
+    # It's suspicious if the op is not mutable but returns nothing, so we return False out of an abundance of caution
+    if not schema.is_mutable:
+        return False
+    if len(schema.returns) > 0:
+        return False
+    # If the op returns nothing, then it has a trivial abstract impl.
+    return True
 
 
 # Just for use to allow copying a module to fake tensors,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #115135
* __->__ #115134
* #114956
* #114955

In preparation for the next PR up in the stack, which is going to update
"can_auto_functionalize" to support more operators than just ones that
return nothing. We are unable to auto-generate FakeTensor kernels for
operators that do not return nothing, but we are able to generate
functionalization kernels for operators that return something.

Test Plan:
Existing tests

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng