### PR TITLE
Extend auto_functionalized to support ops that return Tensors

### DIFF
--- a/torch/_higher_order_ops/auto_functionalize.py
+++ b/torch/_higher_order_ops/auto_functionalize.py
@@ -15,22 +15,22 @@ from torch.fx.experimental.proxy_tensor import (
 
 
 # NOTE: [auto-functionalizing custom ops]
-# Users may wish to torch.compile custom ops that mutate their inputs
-# and return nothing (this is a common class of operators).
+# Users may wish to torch.compile custom ops that mutate their inputs.
 # torch.compile will automatically support this op without anyone needing
 # to provide a functionalization kernel for it. Here's how.
 #
-# Let's say we have a hypothetical mylib::sin_(Tensor(a!) x) -> None
-# op. First, when FakeTensor sees this op, it can just return None.
-# This is the case because custom ops are not allowed to mutate input
-# metadata, so the FakeTensor rule for one that returns None is trivial.
+# Let's say we have a hypothetical mylib::sin_(Tensor(a!) x) -> ()
+# op. First, when FakeTensor sees this op:
+# - If the schema says it returns nothing, we can generate a trivial
+#   FakeTensor rule for it (that returns nothing).
+# - Otherwise, the user needs to provide a FakeTensor rule (abstract impl)
 #
 # Next, when Python FunctionalTensor sees the op, it will functionalize
 # it by emitting a call to an auto_functionalize(op, ["x"], {"x": ...})
-# HOP and replacing the mutated inputs with the outputs of this HOP.
+# HOP and replacing the mutated inputs with corresponding outputs of this HOP.
 # This HOP effectively runs the functional version of the op when
 # called: it clones inputs that will be mutated, runs the op, and
-# then returns Tensors with the new values.
+# then returns (output, Tensors with the new values)
 
 
 class AutoFunctionalized(HigherOrderOperator):
@@ -39,10 +39,10 @@ class AutoFunctionalized(HigherOrderOperator):
     This HOP runs a "functional" version of op.
 
     Concretely, it clones kwargs that `op` mutates (specified by
-    mutated_args_names), runs `op(**kwargs)` with the cloned values,
-    and then returns a flat Tuple of the cloned values that were mutated.
+    mutated_args_names), runs `out = op(**kwargs)` with the cloned values,
+    and then returns (out, Tuple of the cloned values that were mutated).
 
-    We have some restrictions on `op`, most notably that it returns None.
+    We have some restrictions on `op`.
     See `can_auto_functionalize` for the restrictions. We can likely lift
     many of these if users request it.
     """
@@ -55,7 +55,7 @@ class AutoFunctionalized(HigherOrderOperator):
         op: torch._ops.OpOverload,
         mutated_args_names: List[str],
         kwargs: Dict[str, Any],
-    ) -> Tuple[Tensor, ...]:
+    ) -> Tuple[Any, Tuple[Tensor, ...]]:
         assert can_auto_functionalize(op)
         assert isinstance(mutated_args_names, list)
         assert isinstance(kwargs, dict)
@@ -68,11 +68,16 @@ auto_functionalized = AutoFunctionalized()
 def can_auto_functionalize(op: torch._ops.OperatorBase) -> bool:
     if not isinstance(op, torch._ops.OpOverload):
         return False
-    from torch._subclasses.fake_tensor import can_generate_trivial_abstract_impl
 
-    if not can_generate_trivial_abstract_impl(op):
+    if torch._library.utils.is_builtin(op):
+        # We control the built-ins. These may (in rare cases)
+        # do input metadata mutation (which we have banned on custom ops)
         return False
     schema = op._schema
+    if not schema.is_mutable:
+        return False
+    schema = op._schema
+
     for arg in schema.arguments:
         if arg.alias_info is None:
             continue
@@ -80,10 +85,20 @@ def can_auto_functionalize(op: torch._ops.OperatorBase) -> bool:
             continue
         if type(arg.type) is torch.TensorType:
             continue
-        if str(arg.type) == "Optional[Tensor]":
+        if (
+            type(arg.type) is torch.OptionalType
+            and type(arg.type.getElementType()) is torch.TensorType
+        ):
             continue
         # Not yet supported: other Tensor types. This includes things like
         # Tensor[], Tensor?[], Tensor[]?.
+        return False
+
+    # The returns must not alias anything
+    for ret in schema.returns:
+        if ret.alias_info is None and type(ret.type) is torch.TensorType:
+            continue
+        # Not yet supported: List[Tensor] return.
         return False
     return True
 
@@ -91,7 +106,7 @@ def can_auto_functionalize(op: torch._ops.OperatorBase) -> bool:
 @auto_functionalized.py_impl(DispatchKey.CompositeExplicitAutograd)
 def auto_functionalized_dense(
     op: torch._ops.OpOverload, mutated_args_names: List[str], kwargs: Dict[str, Any]
-) -> Tuple[Tensor, ...]:
+) -> Tuple[Any, Tuple[Tensor, ...]]:
     new_kwargs = dict(**kwargs)
     result = []
     for name in mutated_args_names:
@@ -100,8 +115,7 @@ def auto_functionalized_dense(
         )
         result.append(new_kwargs[name])
     out = op(**new_kwargs)
-    assert out is None
-    return tuple(result)
+    return out, tuple(result)
 
 
 @auto_functionalized.py_impl(FakeTensorMode)
@@ -110,7 +124,7 @@ def auto_functionalized_fake(
     op: torch._ops.OpOverload,
     mutated_args_names: List[str],
     kwargs: Dict[str, Any],
-) -> Tuple[Tensor, ...]:
+) -> Tuple[Any, Tuple[Tensor, ...]]:
     with mode:
         result = auto_functionalized_dense(op, mutated_args_names, kwargs)
         return result
@@ -122,7 +136,7 @@ def auto_functionalized_proxy(
     op: torch._ops.OpOverload,
     mutated_args_names: List[str],
     kwargs: Dict[str, Any],
-) -> Tuple[Tensor, ...]:
+) -> Tuple[Any, Tuple[Tensor, ...]]:
     if not mode.enable_tracing:
         return auto_functionalized(op, mutated_args_names, kwargs)
 
@@ -146,7 +160,7 @@ auto_functionalized.fallthrough(DispatchKey.AutogradCUDA)
 
 def do_auto_functionalize(
     op: torch._ops.OpOverload, args: Tuple[Any, ...], kwargs: Dict[str, Any]
-) -> None:
+) -> Any:
     """Functionalizes a call to op(*args, **kwargs) by emitting a call to
     `outs = auto_functionalized(op, mutated_args_names, normalized_kwargs)`
     and replacing the mutated (args, kwargs) with the corresponding outputs.
@@ -175,7 +189,7 @@ def do_auto_functionalize(
 
     unwrapped_kwargs = ctx.unwrap_tensors(normalized_kwargs)  # type: ignore[arg-type]
     with ctx.redispatch_to_next():
-        unwrapped_outs = auto_functionalized(
+        unwrapped_actual_out, unwrapped_outs = auto_functionalized(
             op, mutable_args_names, unwrapped_kwargs  # type: ignore[arg-type]
         )
     assert len(unwrapped_outs) == len(mutable_args_names)
@@ -189,4 +203,4 @@ def do_auto_functionalize(
         ctx.commit_update(orig_arg)
         ctx.sync(orig_arg)
 
-    return None
+    return ctx.wrap_tensors(unwrapped_actual_out)

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -444,7 +444,7 @@ class BaseFunctionalizeAPI(ABC):
 class PythonFunctionalizeAPI(BaseFunctionalizeAPI):
     def wrap_tensors(self, args: Tuple[Any]) -> Tuple[Any]:
         return torch.utils._pytree.tree_map_only(
-            FunctionalTensor, FunctionalTensor.to_functional, args
+            torch.Tensor, FunctionalTensor.to_functional, args
         )
 
     def unwrap_tensors(self, args: Tuple[Any]) -> Tuple[Any]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #115135
* #115134
* #114956
* #114955

We can auto-functionalize operators that mutate their inputs as long as
the outputs of the operator do not alias their inputs. The user needs
to provide an abstract impl for the operator if it has non-trivial
returns.
- We update can_auto_functionalize(op) to include ops that return (but
  do not alias) Tensors
- We update auto_functionalized(op, mutated_args_names, kwargs) to
  return (out, mutated_args), where `out = op(**kwargs)` and
  `mutated_args` are the new values of the inputs that would have been
  mutated.

Test Plan:
- new test

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng