### PR TITLE
[cpu] flash attention optimization

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
@@ -369,6 +369,9 @@ public:
   Vectorized<T> expm1() const {
     return map(Sleef_expm1f8_u10);
   }
+  Vectorized<T> exp_u20() const {
+    return exp();
+  }
   Vectorized<T> fmod(const Vectorized<T> & q) const {
     __m256 x_lo, x_hi;
     cvt_to_fp32<T>(values, x_lo, x_hi);

--- a/aten/src/ATen/cpu/vec/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_double.h
@@ -169,6 +169,9 @@ public:
   Vectorized<double> expm1() const {
     return Vectorized<double>(Sleef_expm1d4_u10(values));
   }
+  Vectorized<double> exp_u20() const {
+    return Vectorized<double>(Sleef_expd4_u10(values));
+  }
   Vectorized<double> fmod(const Vectorized<double>& q) const {
     return Vectorized<double>(Sleef_fmodd4(values, q));
   }

--- a/aten/src/ATen/cpu/vec/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_double.h
@@ -170,7 +170,7 @@ public:
     return Vectorized<double>(Sleef_expm1d4_u10(values));
   }
   Vectorized<double> exp_u20() const {
-    return Vectorized<double>(Sleef_expd4_u10(values));
+    return exp();
   }
   Vectorized<double> fmod(const Vectorized<double>& q) const {
     return Vectorized<double>(Sleef_fmodd4(values, q));

--- a/aten/src/ATen/cpu/vec/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float.h
@@ -204,6 +204,9 @@ public:
   Vectorized<float> expm1() const {
     return Vectorized<float>(Sleef_expm1f8_u10(values));
   }
+  Vectorized<float> exp_u20() const {
+    return Vectorized<float>(Sleef_expf8_u10(values));
+  }
   Vectorized<float> fmod(const Vectorized<float>& q) const {
     return Vectorized<float>(Sleef_fmodf8(values, q));
   }

--- a/aten/src/ATen/cpu/vec/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float.h
@@ -205,7 +205,66 @@ public:
     return Vectorized<float>(Sleef_expm1f8_u10(values));
   }
   Vectorized<float> exp_u20() const {
-    return Vectorized<float>(Sleef_expf8_u10(values));
+    // A faster version of exp with ULP=20
+    static __m256 vec_factorial_1 =
+        _mm256_set1_ps(0.999999701f); // 1/factorial(1)
+    static __m256 vec_factorial_2 =
+        _mm256_set1_ps(0.499991506f); // 1/factorial(2)
+    static __m256 vec_factorial_3 =
+        _mm256_set1_ps(0.166676521f); // 1/factorial(3)
+    static __m256 vec_factorial_4 =
+        _mm256_set1_ps(0.0418978221f); // 1/factorial(4)
+    static __m256 vec_factorial_5 =
+        _mm256_set1_ps(0.00828929059f); // 1/factorial(5)
+    static __m256 vec_exp_log2ef =
+        (__m256)_mm256_set1_epi32(0x3fb8aa3b); // log2(e)
+    static __m256 vec_half = _mm256_set1_ps(0.5f);
+    static __m256 vec_one = _mm256_set1_ps(1.f);
+    static __m256 vec_zero = _mm256_set1_ps(0.f);
+    static __m256 vec_two = _mm256_set1_ps(2.f);
+    static __m256 vec_ln2f = (__m256)_mm256_set1_epi32(0x3f317218); // ln(2)
+    static __m256 vec_ln_flt_min = (__m256)_mm256_set1_epi32(0xc2aeac50);
+    static __m256 vec_ln_flt_max = (__m256)_mm256_set1_epi32(0x42b17218);
+    static __m256i vec_127 = _mm256_set1_epi32(0x0000007f);
+    static int n_mantissa_bits = 23;
+
+    // exp(x) =
+    // = exp(n * ln(2) + r) // divide x by ln(2) and get quot and rem
+    // = 2^n * exp(r) // simplify the exp(n*ln(2)) expression
+
+    auto less_ln_flt_min_mask =
+        _mm256_cmp_ps(values, vec_ln_flt_min, 1 /*_CMP_LT_OS*/);
+    auto vec_src = _mm256_min_ps(values, vec_ln_flt_max);
+    vec_src = _mm256_max_ps(vec_src, vec_ln_flt_min);
+
+    // fx = floorf(x * log2ef + 0.5)
+    auto vec_fx = _mm256_fmadd_ps(vec_src, vec_exp_log2ef, vec_half);
+    vec_fx = _mm256_floor_ps(vec_fx);
+
+    // x = x - fx * ln2
+    auto vec_exp_poly = _mm256_fnmadd_ps(vec_fx, vec_ln2f, vec_src);
+
+    // compute polynomial
+    auto vec_res =
+        _mm256_fmadd_ps(vec_exp_poly, vec_factorial_5, vec_factorial_4);
+    vec_res = _mm256_fmadd_ps(vec_exp_poly, vec_res, vec_factorial_3);
+    vec_res = _mm256_fmadd_ps(vec_exp_poly, vec_res, vec_factorial_2);
+    vec_res = _mm256_fmadd_ps(vec_exp_poly, vec_res, vec_factorial_1);
+    vec_res = _mm256_fmadd_ps(vec_exp_poly, vec_res, vec_one);
+
+    // compute 2^(n-1)
+    auto vec_exp_number = _mm256_sub_ps(vec_fx, vec_one);
+    auto vec_exp_number_i = _mm256_cvtps_epi32(vec_exp_number);
+    auto vec_two_pow_n_i = _mm256_add_epi32(vec_exp_number_i, vec_127);
+    vec_two_pow_n_i = _mm256_slli_epi32(vec_two_pow_n_i, n_mantissa_bits);
+    auto vec_two_pow_n = (__m256)vec_two_pow_n_i;
+    vec_two_pow_n =
+        _mm256_blendv_ps(vec_two_pow_n, vec_zero, less_ln_flt_min_mask);
+
+    // y = y * 2^n
+    vec_res = _mm256_mul_ps(vec_res, vec_two_pow_n);
+    vec_res = _mm256_mul_ps(vec_res, vec_two);
+    return vec_res;
   }
   Vectorized<float> fmod(const Vectorized<float>& q) const {
     return Vectorized<float>(Sleef_fmodf8(values, q));

--- a/aten/src/ATen/cpu/vec/vec256/vec256_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float_neon.h
@@ -421,6 +421,9 @@ public:
       map(std::expm1)
     );
   }
+  Vectorized<float> exp_u20() const {
+    return exp();
+  }
   Vectorized<float> fmod(const Vectorized<float>& q) const {
     USE_SLEEF(
       {

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_double_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_double_vsx.h
@@ -249,6 +249,9 @@ class Vectorized<double> {
   Vectorized<double> expm1() const {
      return {Sleef_expm1d2_u10(_vec0), Sleef_expm1d2_u10(_vec1)};
   }
+  Vectorized<double> C10_ALWAYS_INLINE exp_u20() const {
+     return exp();
+  }
 
   Vectorized<double> lgamma() const __ubsan_ignore_undefined__ {
      return {Sleef_lgammad2_u10(_vec0), Sleef_lgammad2_u10(_vec1)};

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_float_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_float_vsx.h
@@ -312,6 +312,9 @@ class Vectorized<float> {
   Vectorized<float> expm1() const {
     return {Sleef_expm1f4_u10(_vec0), Sleef_expm1f4_u10(_vec1)};
   }
+  Vectorized<float> C10_ALWAYS_INLINE exp_u20() const {
+    return exp();
+  }
 
   Vectorized<float> C10_ALWAYS_INLINE log() const {
     return {Sleef_logf4_u10(_vec0), Sleef_logf4_u10(_vec1)};

--- a/aten/src/ATen/cpu/vec/vec256/zarch/vec256_zarch.h
+++ b/aten/src/ATen/cpu/vec/vec256/zarch/vec256_zarch.h
@@ -1072,6 +1072,9 @@ struct Vectorized<T, std::enable_if_t<is_zarch_implemented<T>()>> {
   Vectorized<T> expm1() const {
     return mapSleef(Sleef_expm1f4_u10, Sleef_expm1d2_u10);
   }
+  Vectorized<T> exp_u20() const {
+    return exp();
+  }
 
   Vectorized<T> log() const {
     return mapSleef(Sleef_logf4_u10, Sleef_logd2_u10);

--- a/aten/src/ATen/cpu/vec/vec512/vec512_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_bfloat16.h
@@ -458,6 +458,9 @@ public:
   Vectorized<T> expm1() const {
     return map(Sleef_expm1f16_u10);
   }
+  Vectorized<T> exp_u20() const {
+    return exp();
+  }
   Vectorized<T> fmod(const Vectorized<T> & q) const {
     __m512 x_lo, x_hi;
     cvt_to_fp32<T>(values, x_lo, x_hi);

--- a/aten/src/ATen/cpu/vec/vec512/vec512_double.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_double.h
@@ -190,6 +190,9 @@ public:
   Vectorized<double> expm1() const {
     return Vectorized<double>(Sleef_expm1d8_u10(values));
   }
+  Vectorized<double> exp_u20() const {
+    return Vectorized<double>(Sleef_expd8_u10(values));
+  }
   Vectorized<double> fmod(const Vectorized<double>& q) const {
     return Vectorized<double>(Sleef_fmodd8(values, q));
   }

--- a/aten/src/ATen/cpu/vec/vec512/vec512_double.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_double.h
@@ -191,7 +191,7 @@ public:
     return Vectorized<double>(Sleef_expm1d8_u10(values));
   }
   Vectorized<double> exp_u20() const {
-    return Vectorized<double>(Sleef_expd8_u10(values));
+    return exp();
   }
   Vectorized<double> fmod(const Vectorized<double>& q) const {
     return Vectorized<double>(Sleef_fmodd8(values, q));

--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -403,6 +403,9 @@ public:
   Vectorized<T> expm1() const {
     return map(std::expm1);
   }
+  Vectorized<T> exp_u20() const {
+    return map(std::exp);
+  }
   Vectorized<T> frac() const {
     return *this - this->trunc();
   }

--- a/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
+++ b/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
@@ -21,6 +21,8 @@ namespace at::native {
 
 namespace {
 
+// 1) out = exp(a - val)
+// 2) val = sum(out)
 template <typename scalar_t>
 inline void _exp_reduce_sum_fusion_kernel(
     scalar_t* a,
@@ -53,6 +55,7 @@ inline void _exp_reduce_sum_fusion_kernel(
   val = tmp_sum;
 }
 
+// out = a / sum
 template <typename T1, typename T2>
 inline void _normalization_kernel(
     const T1* a,
@@ -73,6 +76,8 @@ inline void _normalization_kernel(
   }
 }
 
+// 1) out = a * scale
+// 2) max = max(out)
 template <typename scalar_t>
 inline void _mul_reduce_max_fusion_kernel(
     const scalar_t* a,

--- a/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
+++ b/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
@@ -55,26 +55,26 @@ inline void _exp_reduce_sum_fusion_kernel(
   val = tmp_sum;
 }
 
-// // out = a / sum
-// template <typename T1, typename T2>
-// inline void _normalization_kernel(
-//     const T1* a,
-//     const T1& sum,
-//     const int& size,
-//     T2* out) {
-//   auto vec_size = vec::Vectorized<T1>::size();
-//   auto vec_sum = vec::Vectorized<T1>(sum);
-//   for (long i = 0; i < vec_size * (size / vec_size); i += vec_size) {
-//     auto tmp0 = vec::Vectorized<T1>::loadu(a + i);
-//     auto tmp1 = tmp0 / vec_sum;
-//     _store(out + i, tmp1);
-//   }
-//   for (long i = vec_size * (size / vec_size); i < size; i++) {
-//     auto tmp0 = a[i];
-//     auto tmp1 = tmp0 / sum;
-//     out[i] = tmp1;
-//   }
-// }
+// out = a / sum
+template <typename T1, typename T2>
+inline void _normalization_kernel(
+    const T1* a,
+    const T1& sum,
+    const int& size,
+    T2* out) {
+  auto vec_size = vec::Vectorized<T1>::size();
+  auto vec_sum = vec::Vectorized<T1>(sum);
+  for (long i = 0; i < vec_size * (size / vec_size); i += vec_size) {
+    auto tmp0 = vec::Vectorized<T1>::loadu(a + i);
+    auto tmp1 = tmp0 / vec_sum;
+    _store(out + i, tmp1);
+  }
+  for (long i = vec_size * (size / vec_size); i < size; i++) {
+    auto tmp0 = a[i];
+    auto tmp1 = tmp0 / sum;
+    out[i] = tmp1;
+  }
+}
 
 // 1) out = a * scale
 // 2) max = max(out)
@@ -255,7 +255,7 @@ void cpu_flash_attention(
             kvBlockSize,
             qBlockSize,
             headSize,
-            static_cast<accum_t>(1),
+            scaling_factor,
             k_data + i * kStrideB + j * kStrideH +
                 n * kStrideN,
             kStrideN,
@@ -280,7 +280,7 @@ void cpu_flash_attention(
         for (int64_t row = 0; row < qBlockSize; ++row) {
           sum_old = qk_sum_data[row];
           // scale and max per row
-          _mul_reduce_max_fusion_kernel(qk_data + row * kvBlockSize, scaling_factor, kvBlockSize,
+          _mul_reduce_max_fusion_kernel(qk_data + row * kvBlockSize, static_cast<accum_t>(1), kvBlockSize,
                 qk_data + row * kvBlockSize, tmp_max);
           tmp_max = qk_max_data[row] > tmp_max ? qk_max_data[row] : tmp_max;
           // qk <- exp(qk - max) and sum per row
@@ -294,17 +294,8 @@ void cpu_flash_attention(
           qk_max_data[row] = tmp_max;
           // qk <- qk / sum[row]
           accum_t sum_new = qk_sum_data[row];
-          // _normalization_kernel(qk_data + row * kvBlockSize, sum_new, kvBlockSize,
-          //       conditional_data_ptr(qk_data, qk_reduced_data) + row * kvBlockSize);
-          vec::map<accum_t>(
-            [sum_new](Vec x) { return x / Vec(sum_new); },
-            qk_data + row * kvBlockSize, qk_data + row * kvBlockSize, kvBlockSize);
-          if (is_reduced_type) {
-            convert<accum_t, scalar_t>(
-              qk_data + row * kvBlockSize,
-              qk_reduced_data + row * kvBlockSize,
-              kvBlockSize);
-          }
+          _normalization_kernel(qk_data + row * kvBlockSize, sum_new, kvBlockSize,
+                conditional_data_ptr(qk_data, qk_reduced_data) + row * kvBlockSize);
           // dst <- dst * sum_old / sum_new * exp_tmp
           if (n > 0) {
             accum_t sum_cor = sum_old / sum_new;

--- a/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
+++ b/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
@@ -255,7 +255,7 @@ void cpu_flash_attention(
             kvBlockSize,
             qBlockSize,
             headSize,
-            scaling_factor,
+            static_cast<accum_t>(1),
             k_data + i * kStrideB + j * kStrideH +
                 n * kStrideN,
             kStrideN,
@@ -280,7 +280,7 @@ void cpu_flash_attention(
         for (int64_t row = 0; row < qBlockSize; ++row) {
           sum_old = qk_sum_data[row];
           // scale and max per row
-          _mul_reduce_max_fusion_kernel(qk_data + row * kvBlockSize, static_cast<accum_t>(1), kvBlockSize,
+          _mul_reduce_max_fusion_kernel(qk_data + row * kvBlockSize, scaling_factor, kvBlockSize,
                 qk_data + row * kvBlockSize, tmp_max);
           tmp_max = qk_max_data[row] > tmp_max ? qk_max_data[row] : tmp_max;
           // qk <- exp(qk - max) and sum per row

--- a/aten/src/ATen/native/cpu/utils.h
+++ b/aten/src/ATen/native/cpu/utils.h
@@ -11,6 +11,16 @@
 namespace at {
 namespace native {
 
+template <typename T>
+inline void _store(T* dst, at::vec::Vectorized<T> src) {
+  src.store(dst);
+}
+
+inline void _store(at::BFloat16* dst, at::vec::Vectorized<float> src) {
+  auto res = at::vec::convert_float_bfloat16(src, src);
+  res.store(dst, at::vec::Vectorized<float>::size());
+}
+
 inline namespace CPU_CAPABILITY {
 
 template <typename T>

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1698,8 +1698,8 @@ class TestSDPA(NNTestCase):
         atol = 1e-5
         rtol = 5e-6
         if dtype is torch.bfloat16:
-            atol = 2e-2
-            rtol = 2e-2
+            atol = 5e-2
+            rtol = 5e-2
 
         n_embd = n_head * head_dim
         make_tensor = partial(rand_sdpa_tensor, type="dense", device=device, dtype=dtype, packed=True, requires_grad=False)


### PR DESCRIPTION
### Modifications
- **EXP**: Add a fast version with a reduced accuracy (ULP20) to vec exp `exp_u20` and use it in flash attention.
- **FUSION**: Do fusion for `softmax` ops.
- **SCALE**: Move the calculation of `scaling_factor` after `gemm`.

### Performance
_Model: Stable Diffusion V2.1_

| Version | BF16 Kernel latency (s) | BF16 speedup | FP32 Kernel latency (s) | FP32 speedup |
| ----- | ----- | ----- | ----- | ----- |
| PT | 15.865 |  | 35.362 |  |
| PT + EXP | 12.518 | 21.10% | 19.327 | 45.35% |
| PT + EXP + FUSION | 11.774 | 25.79% | 18.306 | 48.23% |
| PT + EXP + FUSION + SCALE | 11.053 | 30.33% | 18.360 | 48.08% |


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10