### PR TITLE
[DeviceMesh] add torch.distributed.device_mesh to public_allowlist

### DIFF
--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -321,6 +321,7 @@ class TestPublicBindings(TestCase):
             "torch.distributed.algorithms.model_averaging.utils",
             "torch.distributed.checkpoint",
             "torch.distributed.constants",
+            "torch.distributed.device_mesh",
             "torch.distributed.distributed_c10d",
             "torch.distributed.elastic.agent.server",
             "torch.distributed.elastic.rendezvous",


### PR DESCRIPTION
Forward fix for the MacOS test_modules_can_be_imported failure due to  https://github.com/pytorch/pytorch/pull/115099?fbclid=IwAR1DjyVgOfjl2pgX40Gv6iBLb9vMV7giu1aA4ZDfdgseUHMXgfh2p3GkjRc