### PR TITLE
[C10D] Use future for flight recorder dump

### DIFF
--- a/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
@@ -188,10 +188,8 @@ class ProcessGroupNCCLNoHeartbeatCaught
   }
 
   void forceTryWriteDebugInfo() {
-    auto thread = tryWriteDebugInfo();
-    if (thread) {
-      thread->join();
-    }
+    auto& fut = tryWriteDebugInfo();
+    fut.wait();
   }
 
  protected:

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -938,15 +938,61 @@ void ProcessGroupNCCL::enableCollectivesTiming() {
   enableTiming_.store(true);
 }
 
-c10::optional<std::thread> ProcessGroupNCCL::tryWriteDebugInfo() {
+// TODO this bit should be generalized, maybe stuck as a general 'c10' helper
+// template <typename Function>
+// std::future<typename std::result_of<Function()>::type> launchAsync(Function&&
+// func) {
+//     using ReturnType = typename std::result_of<Function()>::type;
+
+//     // Create a promise and a future
+//     std::promise<ReturnType> resultPromise;
+//     std::future<ReturnType> resultFuture = resultPromise.get_future();
+
+//     // Launch a thread to perform the work
+//     std::thread workerThread([promise = std::move(resultPromise), func =
+//     std::forward<Function>(func)]() mutable {
+//         try {
+//             // Set the result in the promise
+//             promise.set_value(func());
+//         } catch (...) {
+//             // Handle exceptions if necessary
+//         }
+//     });
+
+//     // Detach the thread to allow it to run independently
+//     workerThread.detach();
+
+//     return resultFuture;
+// }
+std::future<bool> ProcessGroupNCCL::launchAsyncDebugDump() {
+  std::promise<bool> resultPromise;
+  std::future<bool> resultFuture = resultPromise.get_future();
+
+  std::thread workerThread(
+      [promise = std::move(resultPromise), this]() mutable {
+        try {
+          promise.set_value(dumpDebuggingInfo());
+        } catch (...) {
+          promise.set_exception(std::current_exception());
+        }
+      });
+
+  // Detach the thread to allow it to run independently
+  workerThread.detach();
+
+  return resultFuture;
+}
+/*
+1 create a future/promise that runs the debug dumper
+2 ensure only one dump attempt succeeds
+3 wait for a maximum time for the future to complete, but exit asap
+*/
+std::future<bool>& ProcessGroupNCCL::tryWriteDebugInfo() {
+  // TODO do we need the mutex or is static init thread safe?
   std::lock_guard<std::mutex> lock(writeDebugInfoMutex_);
-  if (writeDebugInfo_) {
-    return c10::nullopt;
-  }
-  // If we have not dumped the debugInfo return true and set the flag
-  writeDebugInfo_ = true;
-  return c10::optional<std::thread>(
-      std::thread(&ProcessGroupNCCL::dumpDebuggingInfo, this));
+  // TODO should we support multiple dumps per runtime?
+  static std::future<bool> dumpFuture = launchAsyncDebugDump();
+  return dumpFuture;
 }
 
 void abortCommsFromMap(
@@ -1051,7 +1097,7 @@ void ProcessGroupNCCL::registerDebugInfoWriter(
   debugInfoWriter_ = std::move(writer);
 }
 
-void ProcessGroupNCCL::dumpDebuggingInfo() {
+bool ProcessGroupNCCL::dumpDebuggingInfo() {
   LOG(ERROR) << "ProcessGroupNCCL preparing to dump debug info.";
   // TODO(whc) after rebase, make sure default bufsize is >0 for on-by-default
   if (ncclTraceBufferSize_ > 0) {
@@ -1066,7 +1112,9 @@ void ProcessGroupNCCL::dumpDebuggingInfo() {
       registerDebugInfoWriter(std::move(debugInfoWriterPtr));
     }
     debugInfoWriter_->write(ncclTrace);
+    return true;
   }
+  return false;
 }
 
 void ProcessGroupNCCL::terminateProcess(std::string errMsg) {
@@ -1103,7 +1151,7 @@ void ProcessGroupNCCL::heartbeatMonitor() {
 
   // Store debug info to storage if no other thread does it. (By default to
   // local disk)
-  auto maybeWriteDebugInfo = tryWriteDebugInfo();
+  auto& maybeWriteDebugInfo = tryWriteDebugInfo();
 
   // Create a error message reported from MonitorThread, so
   // we throw exception and make the whole process to be killed.
@@ -1123,8 +1171,7 @@ void ProcessGroupNCCL::heartbeatMonitor() {
   // Case two: desync might be slow or get stuck. Or we get stuck in
   // destructors, we will sleep for some time before calling std::abort() to
   // kill the whole process.
-  if ((terminateProcessGroup_.load() || collectiveDebugInfoMode_.load() ||
-       (maybeWriteDebugInfo && maybeWriteDebugInfo->joinable())) &&
+  if ((terminateProcessGroup_.load() || collectiveDebugInfoMode_.load()) &&
       !terminateHeartbeatMonitorThread_.load()) {
     // Leave another two mins for desync report generation or process group
     // destroy.
@@ -1136,9 +1183,11 @@ void ProcessGroupNCCL::heartbeatMonitor() {
   // thread, so We mark the thread detach and the dump of debug info becomes
   // "best effort". If the process exit normally, marking it detach also makes
   // sense because we don't really care about dumping the debug info.
-  if (maybeWriteDebugInfo && maybeWriteDebugInfo->joinable()) {
-    maybeWriteDebugInfo->detach();
-  }
+
+  // We already log completion inside the thread, so it may not be necessary to
+  // check the return value here.  We mainly use a future so we can exit early
+  // if done.
+  maybeWriteDebugInfo.wait_for(std::chrono::seconds(heartbeatTimeoutInSec_));
 
   if (!terminateHeartbeatMonitorThread_.load()) {
     const auto logMsg = c10::str(
@@ -1267,10 +1316,9 @@ void ProcessGroupNCCL::workCleanupLoop() {
               collectiveDebugInfoMode_.store(true);
             }
 
-            c10::optional<std::thread> dumpingDebugInfo;
             if (dumpOnTimeout_) {
               // Store debug info to storage. (By default to local disk)
-              dumpingDebugInfo = tryWriteDebugInfo();
+              tryWriteDebugInfo();
             }
 
             if (desyncDebug_) {
@@ -1280,15 +1328,9 @@ void ProcessGroupNCCL::workCleanupLoop() {
 
             if (dumpOnTimeout_) {
               // Store debug info to storage. (By default to local disk)
-              if (dumpingDebugInfo && dumpingDebugInfo->joinable()) {
-                std::this_thread::sleep_for(
-                    std::chrono::milliseconds(kWatchdogThreadSleepMillis * 30));
-                // At this point, we either have already waited for
-                // `kWatchdogThreadSleepMillis * 30` or the thread has finished
-                // so that we mark the thread detach and the dump of debug info
-                // becomes "best effort".
-                dumpingDebugInfo->detach();
-              }
+              auto& dumpingDebugInfo = tryWriteDebugInfo();
+              dumpingDebugInfo.wait_for(
+                  std::chrono::milliseconds(kWatchdogThreadSleepMillis * 30));
             }
 
           } catch (const std::exception& e) {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -3,6 +3,7 @@
 #ifdef USE_C10D_NCCL
 
 #include <chrono>
+#include <future>
 #include <iostream>
 #include <list>
 #include <mutex>
@@ -666,7 +667,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // In the timeout case and we will dump debug info such as the NCCL flight
   // recorder to storage. Down the road, if we have more complicated or blocking
   // operations, we might need to use a side thread to do it.
-  void dumpDebuggingInfo();
+  bool dumpDebuggingInfo();
 
   // Desync debug helper
   void logWorkStart(WorkNCCL& work);
@@ -685,10 +686,13 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // gets terminated.
   virtual void terminateProcess(std::string errMsg);
 
+  // Helper for kicking off a future/promise
+  std::future<bool> launchAsyncDebugDump();
+
   // Check the writeDebugInfo_ flag and if it is true, we do nothing.
   // If not, we first set the flag to be true and return a thread which will
   // get and write the debug info into storage.
-  c10::optional<std::thread> tryWriteDebugInfo();
+  std::future<bool>& tryWriteDebugInfo();
 
   // When watchdog timeout, this function will be called and return debug info
   // for users. For now we only get information from retrieveDesyncReport.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #114817
* #114615
* __->__ #115176

Replaces the "always sleep 30 sec before abort" with "wait up to 30 sec
for the future to complete then abort".  The difference in this case is
the abort happens as soon as the dump finishes up to a maximum, instead
of always waiting the maximum.

Allows multiple calls to dump, which will be serialized.

Renames `tryWriteDebugInfo` to `launchAsyncDebugDump` in spirit of the
change to support more than one launch and to always launch rather than
only launching on the first call.

Adds a test for dumping on timeout.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @yf225 @kiukchung @lucasllc