### PR TITLE
Disables denormal floating numbers on ARM CPU

### DIFF
--- a/aten/src/ATen/cpu/FlushDenormal.cpp
+++ b/aten/src/ATen/cpu/FlushDenormal.cpp
@@ -28,6 +28,45 @@ bool set_flush_denormal(bool on) {
   }
   return false;
 }
+#elif defined(__ARM_FP) && (__ARM_FP > 0)
+// Imported from TensorFlow, tensorflow/third_party/xla/third_party/tsl/tsl/platform/denormal.cc
+// Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+// Flush-to-zero bit on the ARM floating-point control register.
+#define ARM_FPCR_FZ   (1 << 24)
+
+static inline void ArmSetFloatingPointControlRegister(uint32_t fpcr) {
+#if defined(__aarch64__)
+  __asm__ __volatile__("msr fpcr, %[fpcr]"
+                       :
+                       : [fpcr] "r"(static_cast<uint64_t>(fpcr)));
+#else
+  __asm__ __volatile__("vmsr fpscr, %[fpcr]" : : [fpcr] "r"(fpcr));
+#endif
+}
+
+static inline uint32_t ArmGetFloatingPointControlRegister() {
+  uint32_t fpcr;
+#if defined(__aarch64__)
+  uint64_t fpcr64;
+  __asm__ __volatile__("mrs %[fpcr], fpcr" : [fpcr] "=r"(fpcr64));
+  fpcr = static_cast<uint32_t>(fpcr64);
+#else
+  __asm__ __volatile__("vmrs %[fpcr], fpscr" : [fpcr] "=r"(fpcr));
+#endif
+  return fpcr;
+}
+
+bool set_flush_denormal(bool on) {
+    uint32_t fpcr = ArmGetFloatingPointControlRegister();
+    if (on) {
+      fpcr |= ARM_FPCR_FZ;
+    } else {
+      fpcr &= ~ ARM_FPCR_FZ;
+    }
+    ArmSetFloatingPointControlRegister(fpcr);
+    return true;
+}
 #else
 bool set_flush_denormal(bool on) {
   return false;


### PR DESCRIPTION
**Motivation:** 
Denormal numbers are used to store extremely small numbers that are close to 0. Denormal numbers can incur extra computational cost. To solve the low performance issue caused by denormal numbers, Pytorch supports flushing denormal numbers and it successfully configures flush denormal mode

Currently set_flush_denormal() is only supported on x86 architectures supporting SSE3 ([https://pytorch.org/docs/stable/generated/torch.set_flush_denormal.html (Opens in new window or tab)](https://pytorch.org/docs/stable/generated/torch.set_flush_denormal.html) and now we want to extend this functionality for ARM architecture.

**This PR:**
->Supports set_flush_denormal() on ARM.
->Datatypes supported and tested: FP64, FP32, BFloat16

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10