### PR TITLE
remove aot_config.keep_inference_input_mutations from assert_functional_graph

### DIFF
--- a/torch/_functorch/_aot_autograd/dispatch_and_compile_graph.py
+++ b/torch/_functorch/_aot_autograd/dispatch_and_compile_graph.py
@@ -82,16 +82,12 @@ def aot_dispatch_base_graph(
 
     # As long as we opted to remove input mutations, then
     # there should be *NO* mutating ops in the graph at this point.
-    copy_count = assert_functional_graph(
-        fw_module.graph, allow_input_mutations=aot_config.keep_inference_input_mutations
-    )
+    copy_count = assert_functional_graph(fw_module.graph)
 
     fw_module.graph.eliminate_dead_code()
     fw_module.recompile()
 
-    copy_count2 = assert_functional_graph(
-        fw_module.graph, allow_input_mutations=aot_config.keep_inference_input_mutations
-    )
+    copy_count2 = assert_functional_graph(fw_module.graph)
 
     assert copy_count == copy_count2
 
@@ -159,9 +155,7 @@ def aot_dispatch_autograd_graph(
     fx_g = _create_graph(joint_fn_to_trace, updated_joint_inputs, aot_config=aot_config)
 
     # There should be *NO* mutating ops in the graph at this point.
-    assert_functional_graph(
-        fx_g.graph, allow_input_mutations=aot_config.keep_inference_input_mutations
-    )
+    assert_functional_graph(fx_g.graph)
 
     # Redundant with the check above, but worth having in case tracing introduced
     # a fake tensor. Unlikely.

--- a/torch/_functorch/_aot_autograd/functional_utils.py
+++ b/torch/_functorch/_aot_autograd/functional_utils.py
@@ -313,9 +313,7 @@ def was_tensor_metadata_updated(arg, new_arg):
 
 
 # Returns the number of detected copy_
-def assert_functional_graph(
-    fx_g: torch.fx.Graph, *, allow_input_mutations: bool = False
-) -> int:
+def assert_functional_graph(fx_g: torch.fx.Graph) -> int:
     placeholders = set()
     copy_count = 0
     # NB: It would also be nice to verify that the mutations all happen at the
@@ -325,7 +323,7 @@ def assert_functional_graph(
         if n.op == "placeholder":
             placeholders.add(n)
         if isinstance(n.target, torch._ops.OpOverload):
-            if n.target is torch.ops.aten.copy_.default and allow_input_mutations:
+            if n.target is torch.ops.aten.copy_.default:
                 suffix = True
                 # Can only copy_ into an input, and can only do so once
                 assert n.args[0] in placeholders


### PR DESCRIPTION
We technically allow backends to aot_autograd to pass a config saying "yes I am ok with seeing input mutations in my graph".

With https://github.com/pytorch/pytorch/pull/112906 though, there can be input mutations that show up in the backward (that we need to handle for correctness), that are a large pain to keep out of the graph. The meta-point is that it's been ~a year since we added the config, and it almost always makes sense for backends to support input mutations for performance reasons (inductor does). So I just allow these input mutations in the graph in this rare backward situation, even if the backend didn't explicitly use the config.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #115195

