### PR TITLE
empty input

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1820,5 +1820,21 @@ def forward(self, l_x_):
         ep.run_decompositions(decomp_table=torch._decomp.decomposition_table)
         self.assertEqual(ep(t, dim, index, src), output)
 
+    def test_empty_input(self):
+        def g():
+            return torch.zeros(1, 2)
+
+        pre_autograd_graph = torch._export.capture_pre_autograd_graph(g, ())
+        export_graph = torch.export.export(g, ())
+
+    def test_scalar_input(self):
+        def g(x):
+            return torch.zeros(1, x)
+
+        pre_autograd_graph = torch._export.capture_pre_autograd_graph(g, (2, ))
+        # TODO: enable this following test case
+        # export_graph = torch.export.export(g, (2, ))
+
+
 if __name__ == '__main__':
     run_tests()

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1827,5 +1827,21 @@ def forward(self, l_x_):
         ep.run_decompositions(decomp_table=torch._decomp.decomposition_table)
         self.assertEqual(ep(t, dim, index, src), output)
 
+    def test_empty_input(self):
+        def g():
+            return torch.zeros(1, 2)
+
+        pre_autograd_graph = torch._export.capture_pre_autograd_graph(g, ())
+        export_graph = torch.export.export(g, ())
+
+    def test_scalar_input(self):
+        def g(x):
+            return torch.zeros(1, x)
+
+        pre_autograd_graph = torch._export.capture_pre_autograd_graph(g, (2, ))
+        # TODO: enable this following test case
+        # export_graph = torch.export.export(g, (2, ))
+
+
 if __name__ == '__main__':
     run_tests()

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -385,7 +385,7 @@ def capture_pre_autograd_graph(
             k: v
             for k, v in fake_mode.shape_env.runtime_var_to_range.items()
             if re.match(r"^[if]\d+$", str(k))
-        }
+        } if fake_mode else {}
 
         flat_args, _ = pytree.tree_flatten((args, kwargs or {}))
         range_constraints, equality_constraints = _process_constraints(m, 0, flat_args)
@@ -414,7 +414,8 @@ def _convert_input_to_fake(gm, args, kwargs):
     if detected_fake_mode := detect_fake_mode(fake_inps):
         fake_mode = detected_fake_mode
 
-    assert fake_mode is not None, "Cannot find fake_mode attatched to the graph's placeholders."
+    if fake_mode is None:
+        return [], {}, {}, None
 
     count = 0
 

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -205,7 +205,7 @@ def capture_pre_autograd_graph(
             k: v
             for k, v in fake_mode.shape_env.runtime_var_to_range.items()
             if re.match(r"^[if]\d+$", str(k))
-        }
+        } if fake_mode else {}
 
         flat_args, _ = pytree.tree_flatten((args, kwargs or {}))
         range_constraints, equality_constraints = _process_constraints(m, 0, flat_args)

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -76,9 +76,8 @@ def _convert_input_to_fake(gm, args, kwargs):
     if detected_fake_mode := detect_fake_mode(fake_inps):
         fake_mode = detected_fake_mode
 
-    assert (
-        fake_mode is not None
-    ), "Cannot find fake_mode attatched to the graph's placeholders."
+    if fake_mode is None:
+        return [], {}, {}, None
 
     count = 0
 


### PR DESCRIPTION
Summary:
asr model in executorch is failing and looks like we miss this case
```
def g():
    return torch.zeros(1, 2)

exported_module = torch._export.capture_pre_autograd_graph(g, ())
```

Test Plan:
```
 buck run mode/dev-nosan //pye/model_inventory/asr_models/milan_dictation:export_models -- --dqlinear_qconfig_flavor symmetric_xnnpack  --output_path /data/sandcastle/boxes/fbsource/fbcode/pye/model_inventory/asr_models/milan_dictation/asr.pte
```


re-launch skycastle job
```
chenlai@168417.od /data/sandcastle/boxes/fbsource/fbcode (071a6201d)]$ arc skycastle schedule //tools/skycastle/workflows2/pytorch_edge/executorch_transcribe_bin.sky:main

19:51:41.081 [INFO] Invocation ID: l8BuIotf
19:51:41.084 [INFO] Version: 55680ae1ec0746ceecae3459f3a40c00378ec9cf
19:51:41.084 [INFO] Protocol: 8
19:51:41.084 [INFO] Build date: 20231204_035433
19:51:41.088 [INFO] Debug log: /var/tmp/skycastle/invocations/1701748301_l8BuIotf/logs/skycastle.log
19:51:41.516 [WARN] Add JVM option for faster UTF-8 validation. --add-opens java.base/java.lang=ALL-UNNAMED
19:51:42.869 [INFO] Feature 'use_new_thrift_over_interngraph_client' evaluated to: false
19:51:47.667 [INFO] Successfully scheduled workflow

Success!
    Duration: 6 secs
    Invocation ID: l8BuIotf
    Debug logs:
        /var/tmp/skycastle/invocations/1701748301_l8BuIotf/logs/skycastle.log
        /var/tmp/skycastle/invocations/1701748301_l8BuIotf/logs/starlark.log
    Workflow run ID: 58546795169668403
    Workflow run URL: https://www.internalfb.com/sandcastle/workflow/58546795169668403
    Workflow Name: pytorch-edge-run-executorch-transcribe-bin
    Workflow Oncall: executorch
    Execution Platform: sandcastle
    Execution Job(s): https://www.internalfb.com/intern/sandcastle/job/36028798147194184/
    Sandcastle nonce: 4258238068229021
```

Reviewed By: tugsbayasgalan, ydwu4

Differential Revision: D51837625




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @kiukchung @lucasllc