### PR TITLE
[HigherOrderOp] Remove additional get item calls in MapHigherOrder.

### DIFF
--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -1163,7 +1163,7 @@ class GraphModule(torch.nn.Module):
         self.assertEqual(ref, res)
         self.assertEqual(cnt.frame_count, 1)
 
-        # We increase the number of ops to 3 and 4 for top-level graph because of an additional
+        # We increase the number of ops to 2 and 3 for top-level graph because of an additional
         # get_item call created by the flatten/unflatten logic in HOP speculation.
         self.assertEqual(cnt.op_count, ifdynstaticdefault(2, 3))
 
@@ -1186,9 +1186,6 @@ class GraphModule(torch.nn.Module):
         if check_dynamic_shape_capture():
             return
 
-        # TODO(yidi): remove the getitem = l_x_.__getitem__(0) call. It's
-        # created accidently when we create sample inputs based on the 0-th slice
-        # before specualting the f in MapHigherOrder.
         self.assertExpectedInline(
             graph.code.strip(),
             """\

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -1193,8 +1193,8 @@ def forward(self, L_x_ : torch.Tensor):
     l_x_ = L_x_
     map_body_0 = self.map_body_0
     map_impl = torch.ops.higher_order.map_impl(map_body_0, 1, l_x_, 3);  map_body_0 = l_x_ = None
-    getitem_3 = map_impl[0];  map_impl = None
-    return (getitem_3,)""",
+    getitem_1 = map_impl[0];  map_impl = None
+    return (getitem_1,)""",
         )
 
     def test_cond_subgraph_name_is_valid(self):

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -1165,7 +1165,7 @@ class GraphModule(torch.nn.Module):
 
         # We increase the number of ops to 3 and 4 for top-level graph because of an additional
         # get_item call created by the flatten/unflatten logic in HOP speculation.
-        self.assertEqual(cnt.op_count, ifdynstaticdefault(3, 4))
+        self.assertEqual(cnt.op_count, ifdynstaticdefault(2, 3))
 
     def test_map_lowers_to_graph(self):
         backend = EagerAndRecordGraphs()
@@ -1194,11 +1194,10 @@ class GraphModule(torch.nn.Module):
             """\
 def forward(self, L_x_ : torch.Tensor):
     l_x_ = L_x_
-    getitem = l_x_.__getitem__(0)
     map_body_0 = self.map_body_0
     map_impl = torch.ops.higher_order.map_impl(map_body_0, 1, l_x_, 3);  map_body_0 = l_x_ = None
-    getitem_1 = map_impl[0];  map_impl = None
-    return (getitem_1,)""",
+    getitem_3 = map_impl[0];  map_impl = None
+    return (getitem_3,)""",
         )
 
     def test_cond_subgraph_name_is_valid(self):

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -730,12 +730,7 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
     def call_function(
         self, tx, args: List[VariableTracker], kwargs: Dict[str, VariableTracker]
     ) -> VariableTracker:
-        from . import (
-            ConstantVariable,
-            NestedUserFunctionVariable,
-            TensorVariable,
-            UserFunctionVariable,
-        )
+        from . import NestedUserFunctionVariable, TensorVariable, UserFunctionVariable
 
         if len(kwargs) > 0:
             unimplemented(
@@ -759,9 +754,10 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
         # To get the example output from map() we will need to provide at least one sample to
         # the loop body. In our case we will always use xs[0], and our map() won't support zero
         # sized tensor during tracing.
-        first_dim = args[1].call_method(
-            tx, "__getitem__", args=[ConstantVariable.create(0)], kwargs={}
-        )
+        # first_dim = args[1].call_method(
+        #     tx, "__getitem__", args=[ConstantVariable.create(0)], kwargs={}
+        # )
+        first_dim = args[1].unpack_var_sequence(tx)[0]
 
         # TODO: Support kwargs
         (

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -731,6 +731,7 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
         self, tx, args: List[VariableTracker], kwargs: Dict[str, VariableTracker]
     ) -> VariableTracker:
         from . import NestedUserFunctionVariable, TensorVariable, UserFunctionVariable
+        from .builder import wrap_fx_proxy_cls
 
         if len(kwargs) > 0:
             unimplemented(
@@ -754,10 +755,9 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
         # To get the example output from map() we will need to provide at least one sample to
         # the loop body. In our case we will always use xs[0], and our map() won't support zero
         # sized tensor during tracing.
-        # first_dim = args[1].call_method(
-        #     tx, "__getitem__", args=[ConstantVariable.create(0)], kwargs={}
-        # )
-        first_dim = args[1].unpack_var_sequence(tx)[0]
+        first_dim = wrap_fx_proxy_cls(
+            target_cls=TensorVariable, tx=tx, proxy=args[1].as_proxy()[0]
+        )
 
         # TODO: Support kwargs
         (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #115207
* #115205
* #115204
* #115115

As titled, this PR removes the unnessecary getitem call from the graph that's manipulated in MapHigherOrder, where we want to get the first dim slice of original tensor for specualtion but using call_method will accidentally create a get_item call in the graph, so want to avoid it by calling  wrap_fx_proxy_cls on input tensor.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng