### PR TITLE
Switch ROCm CI jobs to use Github Actions group linux.rocm.gpu.group

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -18,6 +18,7 @@ self-hosted-runner:
     - windows.g5.4xlarge.nvidia.gpu
     - bm-runner
     - linux.rocm.gpu
+    - linux.rocm.gpu.2
     - macos-m1-12
     - macos-m1-13
     - macos-12-xl

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -78,8 +78,6 @@ jobs:
       {%- if "aarch64" in build_environment %}
       runs_on: linux.arm64.2xlarge
       ALPINE_IMAGE: "arm64v8/alpine"
-      {%- elif config["gpu_arch_type"] == "rocm" %}
-      runs_on: linux.rocm.gpu
       {%- elif config["gpu_arch_type"] == "cuda" %}
       runs_on: linux.4xlarge.nvidia.gpu
       {%- else %}
@@ -88,7 +86,8 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 {%- else %}
-    runs-on: linux.rocm.gpu
+    runs-on:
+      group: linux.rocm.gpu.group
     timeout-minutes: !{{ common.timeout_minutes }}
     !{{ upload.binary_env(config) }}
     steps:

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -50,7 +50,8 @@ jobs:
       matrix: ${{ fromJSON(inputs.test-matrix) }}
       fail-fast: false
     timeout-minutes: ${{ matrix.mem_leak_check == 'mem_leak_check' && 600 || inputs.timeout-minutes }}
-    runs-on: ${{ matrix.runner }}
+    runs-on:
+      group: ${{ matrix.group }}
     steps:
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -52,6 +52,7 @@ jobs:
     timeout-minutes: ${{ matrix.mem_leak_check == 'mem_leak_check' && 600 || inputs.timeout-minutes }}
     runs-on:
       group: ${{ matrix.group }}
+      labels: linux.rocm.gpu.2
     steps:
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -235,7 +235,7 @@ jobs:
         if: always() && steps.test.conclusion && steps.test.conclusion != 'skipped'
         with:
           use-gha: true
-          file-suffix: ${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}_${{ steps.get-job-id.outputs.job-id }}
+          file-suffix: ${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.group }}_${{ steps.get-job-id.outputs.job-id }}
 
       - name: Collect backtraces from coredumps (if any)
         if: always()
@@ -247,7 +247,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: coredumps-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}
+          name: coredumps-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.group }}
           retention-days: 14
           if-no-files-found: ignore
           path: ./**/core.[1-9]*

--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
@@ -247,7 +247,8 @@ jobs:
   libtorch-rocm5_6-shared-with-deps-cxx11-abi-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: libtorch-rocm5_6-shared-with-deps-cxx11-abi-build
-    runs-on: linux.rocm.gpu
+    runs-on:
+      group: linux.rocm.gpu.group
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -352,7 +353,8 @@ jobs:
   libtorch-rocm5_7-shared-with-deps-cxx11-abi-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: libtorch-rocm5_7-shared-with-deps-cxx11-abi-build
-    runs-on: linux.rocm.gpu
+    runs-on:
+      group: linux.rocm.gpu.group
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch

--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
@@ -247,7 +247,8 @@ jobs:
   libtorch-rocm5_6-shared-with-deps-pre-cxx11-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: libtorch-rocm5_6-shared-with-deps-pre-cxx11-build
-    runs-on: linux.rocm.gpu
+    runs-on:
+      group: linux.rocm.gpu.group
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -352,7 +353,8 @@ jobs:
   libtorch-rocm5_7-shared-with-deps-pre-cxx11-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: libtorch-rocm5_7-shared-with-deps-pre-cxx11-build
-    runs-on: linux.rocm.gpu
+    runs-on:
+      group: linux.rocm.gpu.group
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -300,7 +300,8 @@ jobs:
   manywheel-py3_8-rocm5_6-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: manywheel-py3_8-rocm5_6-build
-    runs-on: linux.rocm.gpu
+    runs-on:
+      group: linux.rocm.gpu.group
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -402,7 +403,8 @@ jobs:
   manywheel-py3_8-rocm5_7-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: manywheel-py3_8-rocm5_7-build
-    runs-on: linux.rocm.gpu
+    runs-on:
+      group: linux.rocm.gpu.group
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -747,7 +749,8 @@ jobs:
   manywheel-py3_9-rocm5_6-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: manywheel-py3_9-rocm5_6-build
-    runs-on: linux.rocm.gpu
+    runs-on:
+      group: linux.rocm.gpu.group
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -849,7 +852,8 @@ jobs:
   manywheel-py3_9-rocm5_7-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: manywheel-py3_9-rocm5_7-build
-    runs-on: linux.rocm.gpu
+    runs-on:
+      group: linux.rocm.gpu.group
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -1194,7 +1198,8 @@ jobs:
   manywheel-py3_10-rocm5_6-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: manywheel-py3_10-rocm5_6-build
-    runs-on: linux.rocm.gpu
+    runs-on:
+      group: linux.rocm.gpu.group
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -1296,7 +1301,8 @@ jobs:
   manywheel-py3_10-rocm5_7-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: manywheel-py3_10-rocm5_7-build
-    runs-on: linux.rocm.gpu
+    runs-on:
+      group: linux.rocm.gpu.group
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -1641,7 +1647,8 @@ jobs:
   manywheel-py3_11-rocm5_6-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: manywheel-py3_11-rocm5_6-build
-    runs-on: linux.rocm.gpu
+    runs-on:
+      group: linux.rocm.gpu.group
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -1743,7 +1750,8 @@ jobs:
   manywheel-py3_11-rocm5_7-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: manywheel-py3_11-rocm5_7-build
-    runs-on: linux.rocm.gpu
+    runs-on:
+      group: linux.rocm.gpu.group
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -2088,7 +2096,8 @@ jobs:
   manywheel-py3_12-rocm5_6-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: manywheel-py3_12-rocm5_6-build
-    runs-on: linux.rocm.gpu
+    runs-on:
+      group: linux.rocm.gpu.group
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch
@@ -2190,7 +2199,8 @@ jobs:
   manywheel-py3_12-rocm5_7-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: manywheel-py3_12-rocm5_7-build
-    runs-on: linux.rocm.gpu
+    runs-on:
+      group: linux.rocm.gpu.group
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -228,8 +228,8 @@ jobs:
       docker-image-name: pytorch-linux-focal-rocm-n-py3
       test-matrix: |
         { include: [
-          { config: "distributed", shard: 1, num_shards: 2, runner: "linux.rocm.gpu" },
-          { config: "distributed", shard: 2, num_shards: 2, runner: "linux.rocm.gpu" },
+          { config: "distributed", shard: 1, num_shards: 2, group: "linux.rocm.gpu" },
+          { config: "distributed", shard: 2, num_shards: 2, group: "linux.rocm.gpu" },
         ]}
 
   linux-focal-rocm5_7-py3_8-test:

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -228,8 +228,8 @@ jobs:
       docker-image-name: pytorch-linux-focal-rocm-n-py3
       test-matrix: |
         { include: [
-          { config: "distributed", shard: 1, num_shards: 2, group: "linux.rocm.gpu" },
-          { config: "distributed", shard: 2, num_shards: 2, group: "linux.rocm.gpu" },
+          { config: "distributed", shard: 1, num_shards: 2, group: "linux.rocm.gpu.group" },
+          { config: "distributed", shard: 2, num_shards: 2, group: "linux.rocm.gpu.group" },
         ]}
 
   linux-focal-rocm5_7-py3_8-test:

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -364,9 +364,9 @@ jobs:
       sync-tag: rocm-build
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 3, runner: "linux.rocm.gpu" },
-          { config: "default", shard: 2, num_shards: 3, runner: "linux.rocm.gpu" },
-          { config: "default", shard: 3, num_shards: 3, runner: "linux.rocm.gpu" },
+          { config: "default", shard: 1, num_shards: 3, group: "linux.rocm.gpu" },
+          { config: "default", shard: 2, num_shards: 3, group: "linux.rocm.gpu" },
+          { config: "default", shard: 3, num_shards: 3, group: "linux.rocm.gpu" },
         ]}
 
   linux-focal-cuda12_1-py3_10-gcc9-sm86-build:

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -364,9 +364,9 @@ jobs:
       sync-tag: rocm-build
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 3, group: "linux.rocm.gpu" },
-          { config: "default", shard: 2, num_shards: 3, group: "linux.rocm.gpu" },
-          { config: "default", shard: 3, num_shards: 3, group: "linux.rocm.gpu" },
+          { config: "default", shard: 1, num_shards: 3, group: "linux.rocm.gpu.group" },
+          { config: "default", shard: 2, num_shards: 3, group: "linux.rocm.gpu.group" },
+          { config: "default", shard: 3, num_shards: 3, group: "linux.rocm.gpu.group" },
         ]}
 
   linux-focal-cuda12_1-py3_10-gcc9-sm86-build:

--- a/.github/workflows/rocm.yml
+++ b/.github/workflows/rocm.yml
@@ -25,9 +25,9 @@ jobs:
       sync-tag: rocm-build
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 3, runner: "linux.rocm.gpu" },
-          { config: "default", shard: 2, num_shards: 3, runner: "linux.rocm.gpu" },
-          { config: "default", shard: 3, num_shards: 3, runner: "linux.rocm.gpu" },
+          { config: "default", shard: 1, num_shards: 3, group: "linux.rocm.gpu" },
+          { config: "default", shard: 2, num_shards: 3, group: "linux.rocm.gpu" },
+          { config: "default", shard: 3, num_shards: 3, group: "linux.rocm.gpu" },
         ]}
 
   linux-focal-rocm5_7-py3_8-test:

--- a/.github/workflows/rocm.yml
+++ b/.github/workflows/rocm.yml
@@ -25,9 +25,9 @@ jobs:
       sync-tag: rocm-build
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 3, group: "linux.rocm.gpu" },
-          { config: "default", shard: 2, num_shards: 3, group: "linux.rocm.gpu" },
-          { config: "default", shard: 3, num_shards: 3, group: "linux.rocm.gpu" },
+          { config: "default", shard: 1, num_shards: 3, group: "linux.rocm.gpu.group" },
+          { config: "default", shard: 2, num_shards: 3, group: "linux.rocm.gpu.group" },
+          { config: "default", shard: 3, num_shards: 3, group: "linux.rocm.gpu.group" },
         ]}
 
   linux-focal-rocm5_7-py3_8-test:

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -92,7 +92,7 @@ jobs:
       docker-image-name: pytorch-linux-focal-rocm-n-py3
       test-matrix: |
         { include: [
-          { config: "slow", shard: 1, num_shards: 1, group: "linux.rocm.gpu" },
+          { config: "slow", shard: 1, num_shards: 1, group: "linux.rocm.gpu.group" },
         ]}
 
   linux-focal-rocm5_6-py3_8-test:

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -92,7 +92,7 @@ jobs:
       docker-image-name: pytorch-linux-focal-rocm-n-py3
       test-matrix: |
         { include: [
-          { config: "slow", shard: 1, num_shards: 1, runner: "linux.rocm.gpu" },
+          { config: "slow", shard: 1, num_shards: 1, group: "linux.rocm.gpu" },
         ]}
 
   linux-focal-rocm5_6-py3_8-test:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -184,7 +184,7 @@ jobs:
       sync-tag: rocm-build
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 1, group: "linux.rocm.gpu" },
+          { config: "default", shard: 1, num_shards: 1, group: "linux.rocm.gpu.group" },
         ]}
 
   linux-focal-rocm5_7-py3_8-test:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -184,7 +184,7 @@ jobs:
       sync-tag: rocm-build
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 1, runner: "linux.rocm.gpu" },
+          { config: "default", shard: 1, num_shards: 1, group: "linux.rocm.gpu" },
         ]}
 
   linux-focal-rocm5_7-py3_8-test:


### PR DESCRIPTION
As we are adding some MI210 GHA runners to CI with `linux.rocm.gpu.2` label, using a group allows us to target both MI210 and non-MI210 runners (having label `linux.rocm.gpu`).

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang