### PR TITLE
[AOTI] move model runner into a library

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -915,6 +915,7 @@ exclude_patterns = [
     'test/dynamo/test_compile.py',
     'test/dynamo/test_sources.py',
     'test/functorch/test_logging.py',
+    'test/inductor/test_aot_inductor_utils.py',
     'test/lazy/test_bindings.py',
     'test/lazy/test_extract_compiled_graph.py',
     'test/lazy/test_meta_kernel.py',

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -9,17 +9,15 @@ from typing import Dict
 import torch
 import torch._export
 import torch._inductor
-import torch.fx._pytree as fx_pytree
 from torch._dynamo.testing import same
 from torch._dynamo.utils import counters
 from torch._inductor import config
 from torch._inductor.exc import CppWrapperCodeGenError
-from torch._inductor.utils import aot_inductor_launcher, cache_dir
+from torch._inductor.utils import cache_dir
 
 from torch.testing import FileCheck
 from torch.testing._internal import common_utils
 from torch.testing._internal.common_quantization import skip_if_no_torchvision
-
 from torch.testing._internal.common_utils import (
     IS_CI,
     IS_FBCODE,
@@ -50,115 +48,15 @@ if IS_WINDOWS and IS_CI:
 
 try:
     try:
+        from .test_aot_inductor_utils import AOTInductorModelRunner
         from .test_torchinductor import copy_tests, requires_multigpu, TestFailure
     except ImportError:
+        from test_aot_inductor_utils import AOTInductorModelRunner
         from test_torchinductor import copy_tests, requires_multigpu, TestFailure
 except (unittest.SkipTest, ImportError) as e:
     if __name__ == "__main__":
         sys.exit(0)
     raise
-
-
-class AOTInductorModelRunner:
-    @classmethod
-    def compile(
-        cls,
-        model,
-        example_inputs,
-        options=None,
-        constraints=None,
-        disable_constraint_solver=False,
-    ):
-        # The exact API is subject to change
-        so_path = torch._export.aot_compile(
-            model,
-            example_inputs,
-            options=options,
-            constraints=constraints,
-            remove_runtime_assertions=True,
-            disable_constraint_solver=disable_constraint_solver,
-        )
-        return so_path
-
-    @classmethod
-    def load(cls, device, so_path, example_inputs):
-        if IS_FBCODE:
-            from .fb import test_aot_inductor_model_runner_pybind
-
-            module = test_aot_inductor_model_runner_pybind.Runner(
-                so_path, device == "cpu"
-            )
-
-            call_spec = module.get_call_spec()
-            in_spec = pytree.treespec_loads(call_spec[0])
-            out_spec = pytree.treespec_loads(call_spec[1])
-
-            def optimized(*args):
-                flat_inputs = fx_pytree.tree_flatten_spec((*args, {}), in_spec)
-                flat_outputs = module.run(flat_inputs)
-                return pytree.tree_unflatten(flat_outputs, out_spec)
-
-        else:
-            module = torch.utils.cpp_extension.load_inline(
-                name="aot_inductor",
-                cpp_sources=[aot_inductor_launcher(so_path, device)],
-                # use a unique build directory to avoid test interference
-                build_directory=tempfile.mkdtemp(dir=cache_dir()),
-                functions=["run", "get_call_spec"],
-                with_cuda=(device == "cuda"),
-            )
-
-            call_spec = module.get_call_spec()
-            in_spec = pytree.treespec_loads(call_spec[0])
-            out_spec = pytree.treespec_loads(call_spec[1])
-
-            def optimized(*args):
-                flat_inputs = fx_pytree.tree_flatten_spec((*args, {}), in_spec)
-                flat_outputs = module.run(flat_inputs)
-                return pytree.tree_unflatten(flat_outputs, out_spec)
-
-        return optimized
-
-    @classmethod
-    def run(
-        cls,
-        device,
-        model,
-        example_inputs,
-        options=None,
-        constraints=None,
-        disable_constraint_solver=False,
-    ):
-        so_path = AOTInductorModelRunner.compile(
-            model,
-            example_inputs,
-            options=options,
-            constraints=constraints,
-            disable_constraint_solver=disable_constraint_solver,
-        )
-        optimized = AOTInductorModelRunner.load(device, so_path, example_inputs)
-        return optimized(example_inputs)
-
-    @classmethod
-    def run_multiple(
-        cls,
-        device,
-        model,
-        list_example_inputs,
-        options=None,
-        constraints=None,
-    ):
-        so_path = AOTInductorModelRunner.compile(
-            model,
-            list_example_inputs[0],
-            options=options,
-            constraints=constraints,
-        )
-        optimized = AOTInductorModelRunner.load(device, so_path, list_example_inputs[0])
-        list_output_tensors = []
-        for example_inputs in list_example_inputs:
-            list_output_tensors.append(optimized(example_inputs))
-        return list_output_tensors
 
 
 def check_model(

--- a/test/inductor/test_aot_inductor_utils.py
+++ b/test/inductor/test_aot_inductor_utils.py
@@ -1,0 +1,114 @@
+# Owner(s): ["module: inductor"]
+import tempfile
+
+import torch
+import torch._export
+import torch._inductor
+import torch.fx._pytree as fx_pytree
+from torch._inductor.utils import aot_inductor_launcher, cache_dir
+
+from torch.testing._internal.common_utils import IS_FBCODE
+
+from torch.utils import _pytree as pytree
+
+
+class AOTInductorModelRunner:
+    @classmethod
+    def compile(
+        cls,
+        model,
+        example_inputs,
+        options=None,
+        constraints=None,
+        disable_constraint_solver=False,
+    ):
+        # The exact API is subject to change
+        so_path = torch._export.aot_compile(
+            model,
+            example_inputs,
+            options=options,
+            constraints=constraints,
+            remove_runtime_assertions=True,
+            disable_constraint_solver=disable_constraint_solver,
+        )
+        return so_path
+
+    @classmethod
+    def load(cls, device, so_path, example_inputs):
+        if IS_FBCODE:
+            from .fb import test_aot_inductor_model_runner_pybind
+
+            module = test_aot_inductor_model_runner_pybind.Runner(
+                so_path, device == "cpu"
+            )
+
+            call_spec = module.get_call_spec()
+            in_spec = pytree.treespec_loads(call_spec[0])
+            out_spec = pytree.treespec_loads(call_spec[1])
+
+            def optimized(*args):
+                flat_inputs = fx_pytree.tree_flatten_spec((*args, {}), in_spec)
+                flat_outputs = module.run(flat_inputs)
+                return pytree.tree_unflatten(flat_outputs, out_spec)
+
+        else:
+            module = torch.utils.cpp_extension.load_inline(
+                name="aot_inductor",
+                cpp_sources=[aot_inductor_launcher(so_path, device)],
+                # use a unique build directory to avoid test interference
+                build_directory=tempfile.mkdtemp(dir=cache_dir()),
+                functions=["run", "get_call_spec"],
+                with_cuda=(device == "cuda"),
+            )
+
+            call_spec = module.get_call_spec()
+            in_spec = pytree.treespec_loads(call_spec[0])
+            out_spec = pytree.treespec_loads(call_spec[1])
+
+            def optimized(*args):
+                flat_inputs = fx_pytree.tree_flatten_spec((*args, {}), in_spec)
+                flat_outputs = module.run(flat_inputs)
+                return pytree.tree_unflatten(flat_outputs, out_spec)
+
+        return optimized
+
+    @classmethod
+    def run(
+        cls,
+        device,
+        model,
+        example_inputs,
+        options=None,
+        constraints=None,
+        disable_constraint_solver=False,
+    ):
+        so_path = AOTInductorModelRunner.compile(
+            model,
+            example_inputs,
+            options=options,
+            constraints=constraints,
+            disable_constraint_solver=disable_constraint_solver,
+        )
+        optimized = AOTInductorModelRunner.load(device, so_path, example_inputs)
+        return optimized(example_inputs)
+
+    @classmethod
+    def run_multiple(
+        cls,
+        device,
+        model,
+        list_example_inputs,
+        options=None,
+        constraints=None,
+    ):
+        so_path = AOTInductorModelRunner.compile(
+            model,
+            list_example_inputs[0],
+            options=options,
+            constraints=constraints,
+        )
+        optimized = AOTInductorModelRunner.load(device, so_path, list_example_inputs[0])
+        list_output_tensors = []
+        for example_inputs in list_example_inputs:
+            list_output_tensors.append(optimized(example_inputs))
+        return list_output_tensors

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -200,6 +200,7 @@ TESTS = discover_tests(
         "distributed/test_c10d_spawn",
         "distributions/test_transforms",
         "distributions/test_utils",
+        "test/inductor/test_aot_inductor_utils",
         "onnx/test_pytorch_onnx_onnxruntime_cuda",
         "onnx/test_models",
         # These are not C++ tests


### PR DESCRIPTION
Summary: So that we can import it in fbcode and do some AOTI run in py env

Test Plan: existed AOTI tests

Reviewed By: chenyang78

Differential Revision: D51780021




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler