### PR TITLE
Move the shape env symint cache to a symbol cache, better routing for subclass fakification

### DIFF
--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1592,8 +1592,8 @@ def _automatic_dynamic(
 ) -> SymbolicContext:
     name = source.name()
     prior_policy = tx.output.tracing_context.tensor_to_context.get(e, None)
-    source_to_symbol_cache = (
-        prior_policy.source_to_symbol_cache if prior_policy else None
+    shape_env_to_source_to_symbol_cache = (
+        prior_policy.shape_env_to_source_to_symbol_cache if prior_policy else None
     )
 
     if is_traceable_wrapper_subclass(e) and not outer_only:
@@ -1617,7 +1617,7 @@ def _automatic_dynamic(
             dynamic_sizes=outer_context.dynamic_sizes,
             constraint_sizes=outer_context.constraint_sizes,
             tensor_source=outer_context.tensor_source,
-            source_to_symbol_cache=outer_context.source_to_symbol_cache,
+            shape_env_to_source_to_symbol_cache=outer_context.shape_env_to_source_to_symbol_cache,
             inner_contexts=inner_contexts,
         )
 
@@ -1626,7 +1626,7 @@ def _automatic_dynamic(
             dynamic_sizes=[DimDynamic.STATIC] * e.dim(),
             constraint_sizes=[None] * e.dim(),
             tensor_source=source,
-            source_to_symbol_cache=source_to_symbol_cache,
+            shape_env_to_source_to_symbol_cache=shape_env_to_source_to_symbol_cache,
         )
 
     # We preserve the dynamism of inputs. For example, when users call
@@ -1641,7 +1641,7 @@ def _automatic_dynamic(
             ],
             constraint_sizes=[None] * e.dim(),
             tensor_source=source,
-            source_to_symbol_cache=source_to_symbol_cache,
+            shape_env_to_source_to_symbol_cache=shape_env_to_source_to_symbol_cache,
         )
 
     # Prep for automatic dynamic
@@ -1781,7 +1781,7 @@ def _automatic_dynamic(
         dynamic_sizes=dynamic_dims,
         constraint_sizes=constraint_dims,
         tensor_source=source,
-        source_to_symbol_cache=source_to_symbol_cache,
+        shape_env_to_source_to_symbol_cache=shape_env_to_source_to_symbol_cache,
     )
 
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1592,8 +1592,8 @@ def _automatic_dynamic(
 ) -> SymbolicContext:
     name = source.name()
     prior_policy = tx.output.tracing_context.tensor_to_context.get(e, None)
-    source_to_symint_node_cache = (
-        prior_policy.source_to_symint_node_cache if prior_policy else None
+    source_to_symbol_cache = (
+        prior_policy.source_to_symbol_cache if prior_policy else None
     )
 
     if is_traceable_wrapper_subclass(e) and not outer_only:
@@ -1617,7 +1617,7 @@ def _automatic_dynamic(
             dynamic_sizes=outer_context.dynamic_sizes,
             constraint_sizes=outer_context.constraint_sizes,
             tensor_source=outer_context.tensor_source,
-            source_to_symint_node_cache=outer_context.source_to_symint_node_cache,
+            source_to_symbol_cache=outer_context.source_to_symbol_cache,
             inner_contexts=inner_contexts,
         )
 
@@ -1626,7 +1626,7 @@ def _automatic_dynamic(
             dynamic_sizes=[DimDynamic.STATIC] * e.dim(),
             constraint_sizes=[None] * e.dim(),
             tensor_source=source,
-            source_to_symint_node_cache=source_to_symint_node_cache,
+            source_to_symbol_cache=source_to_symbol_cache,
         )
 
     # We preserve the dynamism of inputs. For example, when users call
@@ -1641,7 +1641,7 @@ def _automatic_dynamic(
             ],
             constraint_sizes=[None] * e.dim(),
             tensor_source=source,
-            source_to_symint_node_cache=source_to_symint_node_cache,
+            source_to_symbol_cache=source_to_symbol_cache,
         )
 
     # Prep for automatic dynamic
@@ -1781,12 +1781,14 @@ def _automatic_dynamic(
         dynamic_sizes=dynamic_dims,
         constraint_sizes=constraint_dims,
         tensor_source=source,
-        source_to_symint_node_cache=source_to_symint_node_cache,
+        source_to_symbol_cache=source_to_symbol_cache,
     )
 
 
 # See note [Tensor Fakification and Symbol Caching]
-def wrap_to_fake_tensor_and_record(e, tx, *, source: Optional[Source], is_tensor: bool):
+def wrap_to_fake_tensor_and_record(
+    e, tx, *, source: Optional[Source], is_tensor: bool, parent_context=None
+):
     if (
         type(e) in (torch.Tensor, torch.nn.Parameter, FakeTensor)
         or isinstance(e, torch.Tensor)
@@ -1797,7 +1799,12 @@ def wrap_to_fake_tensor_and_record(e, tx, *, source: Optional[Source], is_tensor
             e, is_tensor, guard_source=source.guard_source()
         )
 
-        symbolic_context = _automatic_dynamic(e, tx, source, static_shapes)
+        if not parent_context:
+            symbolic_context = _automatic_dynamic(e, tx, source, static_shapes)
+        else:
+            assert isinstance(source, AttrSource)
+            inner_context_name = source.member
+            symbolic_context = parent_context.inner_contexts[inner_context_name]
 
         log.debug(
             "wrap_to_fake %s %s %s",
@@ -1820,17 +1827,14 @@ def wrap_to_fake_tensor_and_record(e, tx, *, source: Optional[Source], is_tensor
             for attr in attrs:
                 fake_inner = getattr(fake_e, attr)
                 inner = getattr(e, attr)
-                tracking_info.append(
-                    (
-                        fake_inner,
-                        inner,
-                        AttrSource(source, attr),
-                        symbolic_context.inner_contexts[attr],
-                    )
+                inner_source = AttrSource(source, attr)
+                wrap_to_fake_tensor_and_record(
+                    inner,
+                    tx,
+                    source=inner_source,
+                    is_tensor=isinstance(fake_inner, torch.Tensor),
+                    parent_context=symbolic_context,
                 )
-
-                # no need to fake-ify the inner tensors again later on
-                tx.fake_mode.fake_tensor_converter.set_tensor_memo(inner, fake_inner)
 
         for fake, real, source, symbolic_context in tracking_info:
             tx.output.tracing_context.tensor_to_context[real] = symbolic_context

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -373,6 +373,7 @@ class FakeTensorConverter:
         if maybe_memo is not None:
             return maybe_memo
         out = FakeTensor(fake_mode, t, device)
+        breakpoint()
         self.set_tensor_memo(t, out)
         return out
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -373,7 +373,6 @@ class FakeTensorConverter:
         if maybe_memo is not None:
             return maybe_memo
         out = FakeTensor(fake_mode, t, device)
-        breakpoint()
         self.set_tensor_memo(t, out)
         return out
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -2070,7 +2070,11 @@ class ShapeEnv:
         size = []
         for i, val in enumerate(tensor_size):
             size.append(self.create_symbol(
-                val, TensorPropertySource(source, TensorProperty.SIZE, i), dynamic_dims[i], constraint_dims[i], symbolic_context=symbolic_context
+                val,
+                TensorPropertySource(source, TensorProperty.SIZE, i),
+                dynamic_dims[i],
+                constraint_dims[i],
+                symbolic_context=symbolic_context
             ))
         return size
 
@@ -2238,7 +2242,6 @@ class ShapeEnv:
                 sym,
                 hint=hint,
                 source=TensorPropertySource(source, TensorProperty.SIZE, i),
-                symbolic_context=symbolic_context
             )
             for i, (sym, hint) in enumerate(zip(size, ex_size))
         ]
@@ -2248,18 +2251,17 @@ class ShapeEnv:
             # we computed
             assert stride_expr is not None
             sym_stride.append(self.create_symintnode(
-                stride_expr, hint=ex_stride[i], source=TensorPropertySource(source, TensorProperty.STRIDE, i),
-                symbolic_context=symbolic_context))
+                stride_expr, hint=ex_stride[i], source=TensorPropertySource(source, TensorProperty.STRIDE, i)))
         sym_storage_offset = self.create_symintnode(
             self.create_symbol(
                 ex_storage_offset,
                 TensorPropertySource(source, TensorProperty.STORAGE_OFFSET),
                 dynamic_dim=dynamic_strides_offset,
                 constraint_dim=None,
-                symbolic_context=symbolic_context,
+                symbolic_context=symbolic_context
             ),
             hint=ex_storage_offset,
-            source=TensorPropertySource(source, TensorProperty.STORAGE_OFFSET), symbolic_context=symbolic_context)
+            source=TensorPropertySource(source, TensorProperty.STORAGE_OFFSET))
         return tuple(sym_sizes), tuple(sym_stride), sym_storage_offset
 
     # If you know what the current hint value of the SymInt to be created
@@ -2272,7 +2274,6 @@ class ShapeEnv:
             *,
             hint: Optional[int],
             source: Optional[Source] = None,
-            symbolic_context: Optional[SymbolicContext] = None,
     ):
         source_name = source.name() if source else None
 
@@ -2370,7 +2371,14 @@ class ShapeEnv:
 
         # We don't want to specialize zero one val for unspecified symbol
         # so that we can always get a new symbol despite val.
-        return self.create_symbol(val, source, dynamic_dim, constraint_dim, positive=None, do_not_specialize_zero_one=True, symbolic_context=None)
+        return self.create_symbol(
+            val,
+            source,
+            dynamic_dim,
+            constraint_dim,
+            positive=None,
+            do_not_specialize_zero_one=True,
+            symbolic_context=None)
 
     @record_shapeenv_event()
     def create_symbol(
@@ -2385,10 +2393,13 @@ class ShapeEnv:
     ) -> "sympy.Expr":
         # see note [Tensor Fakification and Symbol Caching]
         source_name = source.name()
-        if isinstance(symbolic_context, StatefulSymbolicContext) and id(self) not in symbolic_context.shape_env_to_source_to_symbol_cache:
+        if (isinstance(symbolic_context, StatefulSymbolicContext)
+                and id(self) not in symbolic_context.shape_env_to_source_to_symbol_cache):
             symbolic_context.shape_env_to_source_to_symbol_cache[id(self)] = {}
 
-        if isinstance(symbolic_context, StatefulSymbolicContext) and source_name and source_name in symbolic_context.shape_env_to_source_to_symbol_cache[id(self)]:
+        if (isinstance(symbolic_context, StatefulSymbolicContext)
+                and source_name
+                and (source_name in symbolic_context.shape_env_to_source_to_symbol_cache[id(self)])):
             return symbolic_context.shape_env_to_source_to_symbol_cache[id(self)][source_name]
 
         if do_not_specialize_zero_one:

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -858,13 +858,13 @@ class StatefulSymbolicContext(StatelessSymbolicContext):
     w/r/t different shape_envs, clearing, etc.
     """
     tensor_source: Source = None
-    source_to_symbol_cache : Dict["TensorPropertySource", "sympy.Expr"] = None
+    shape_env_to_source_to_symbol_cache : Dict[int, Dict["TensorPropertySource", "sympy.Expr"]] = None
 
     def __post_init__(self):
         # The None default is annoying, but required because of dataclass limitations
         assert self.tensor_source is not None
-        if not self.source_to_symbol_cache:
-            object.__setattr__(self, 'source_to_symbol_cache', {})
+        if not self.shape_env_to_source_to_symbol_cache:
+            object.__setattr__(self, 'shape_env_to_source_to_symbol_cache', {})
 
 
 @dataclass(frozen=True)
@@ -2385,9 +2385,13 @@ class ShapeEnv:
     ) -> "sympy.Expr":
         # see note [Tensor Fakification and Symbol Caching]
         source_name = source.name()
-        if isinstance(symbolic_context, StatefulSymbolicContext) and source_name:
-            if source_name in symbolic_context.source_to_symbol_cache:
-                return symbolic_context.source_to_symbol_cache[source_name]
+        cache = None
+        if isinstance(symbolic_context, StatefulSymbolicContext) and id(self) not in symbolic_context.shape_env_to_source_to_symbol_cache:
+            symbolic_context.shape_env_to_source_to_symbol_cache[id(self)] = {}
+            cache = symbolic_context.shape_env_to_source_to_symbol_cache[id(self)]
+
+        if cache and source_name and source_name in cache:
+            return cache[source_name]
 
         if do_not_specialize_zero_one:
             specialize_zero_one = False
@@ -2404,8 +2408,8 @@ class ShapeEnv:
 
         if dynamic_dim is DimDynamic.STATIC:
             out = sympy.Integer(val)
-            if isinstance(symbolic_context, StatefulSymbolicContext) and source_name:
-                symbolic_context.source_to_symbol_cache[source_name] = out
+            if cache and source_name:
+                cache[source_name] = out
             return out
 
         elif dynamic_dim is DimDynamic.DUCK:
@@ -2483,8 +2487,8 @@ class ShapeEnv:
         if isinstance(r, sympy.Symbol):
             self.var_to_sources[r].append(source)
 
-        if isinstance(symbolic_context, StatefulSymbolicContext) and source_name:
-            symbolic_context.source_to_symbol_cache[source_name] = r
+        if cache and source_name:
+            cache[source_name] = r
         return r
 
     def debug_name(self, source):

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -2385,13 +2385,11 @@ class ShapeEnv:
     ) -> "sympy.Expr":
         # see note [Tensor Fakification and Symbol Caching]
         source_name = source.name()
-        cache = None
         if isinstance(symbolic_context, StatefulSymbolicContext) and id(self) not in symbolic_context.shape_env_to_source_to_symbol_cache:
             symbolic_context.shape_env_to_source_to_symbol_cache[id(self)] = {}
-            cache = symbolic_context.shape_env_to_source_to_symbol_cache[id(self)]
 
-        if cache and source_name and source_name in cache:
-            return cache[source_name]
+        if isinstance(symbolic_context, StatefulSymbolicContext) and source_name and source_name in symbolic_context.shape_env_to_source_to_symbol_cache[id(self)]:
+            return symbolic_context.shape_env_to_source_to_symbol_cache[id(self)][source_name]
 
         if do_not_specialize_zero_one:
             specialize_zero_one = False
@@ -2408,8 +2406,8 @@ class ShapeEnv:
 
         if dynamic_dim is DimDynamic.STATIC:
             out = sympy.Integer(val)
-            if cache and source_name:
-                cache[source_name] = out
+            if isinstance(symbolic_context, StatefulSymbolicContext) and source_name:
+                symbolic_context.shape_env_to_source_to_symbol_cache[id(self)][source_name] = out
             return out
 
         elif dynamic_dim is DimDynamic.DUCK:
@@ -2487,8 +2485,8 @@ class ShapeEnv:
         if isinstance(r, sympy.Symbol):
             self.var_to_sources[r].append(source)
 
-        if cache and source_name:
-            cache[source_name] = r
+        if isinstance(symbolic_context, StatefulSymbolicContext) and source_name:
+            symbolic_context.shape_env_to_source_to_symbol_cache[id(self)][source_name] = r
         return r
 
     def debug_name(self, source):

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -858,6 +858,15 @@ class StatefulSymbolicContext(StatelessSymbolicContext):
     w/r/t different shape_envs, clearing, etc.
     """
     tensor_source: Source = None
+    # Why is this keyd on int first?
+    # That integer is actually the id of the shape_env. This cache short-circuits symbol
+    # creation, and we must store it per shape env. Now, while tracing invariants are a single
+    # shape env per tracing context, and every new frame gets a new shape_env. So where would we have
+    # multiple shape envs? The answer lies in recording. When we are replaying, replay_shape_env_events
+    # is invoked, and creates a new shape_env. Replaying events against this new shape_env will
+    # cause it to fail with unknown symbols, as the symbols cached here will skip creation, and never
+    # get recorded in var_to_val, etc.
+    # TODO(voz): consider a weakref to the shape_env here
     shape_env_to_source_to_symbol_cache : Dict[int, Dict["TensorPropertySource", "sympy.Expr"]] = None
 
     def __post_init__(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #115227
* #114965
* #115212
* #114311

Context:

Joel sees that unless he manually writes to the fake tensor memo, fakification seems to produce spurious symbols! Voz (me) objects, saying that not only is directly writing to memo a bad pattern, recursively invoking fakification on tensor subclass elements in dynamo should suffice! Joel says that while he morally agrees, he has a test proving otherwise, a most perplexing situation.

Digging in, I figured out that while *we were* making fake tensors correctly, with properly cached symbols and the like, we were *also* incorrectly creating spurious symbols, leading the test to fail.

Before this PR, we would only cache source->symint. This was generally fine, but meant that you would create a symbol, then potentially throw it out due to symint cache. For example, the cache hit flow was:

make a symbol (ex: s2) -> use it to make a symint -> hit the cache (my_source-s1)

Now, in this example,  you have a symbol in your val_to_var/var_to_val (s2) that is unused. This is sound, but wasteful, and furthermore, misleading.

This was causing a test added in a PR in this stack to fail, specifically, because the test was using

```
curr_var_to_val = {
    str(k): v for k, v in context.fake_mode.shape_env.var_to_val.items()
}
````

To validate that no new symbols were being created (that is, that recursively creating fake tensors for subclasses was working).

The test is correct, but the implementation of caching would make (by this method of observation) cache hits look like cache misses.

So, the fix here is to move the cache up to be a general symbol cache, rather than only a cache for symints.

The initial implementation did that! But then, it ran into some interesting errors when it came to replay. When replaying symbol creation, behaviors would diverge in the new shape env! How could that be? The answer is because creating a new shape_env resulted in us replaying symbol creation... but with a cache from a different shape env! This was short circuiting symbol creation - and so, adding an extra layer to the cache for id(shape_env) fixes the problem. 


cc @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng