### PR TITLE
[dtensor] enables tensor metadata check across ranks when run_check=True

### DIFF
--- a/test/distributed/_tensor/test_dtensor.py
+++ b/test/distributed/_tensor/test_dtensor.py
@@ -804,7 +804,24 @@ class TestDTensorPlacementTypes(DTensorTestBase):
                     for unpadded_tensor in unpadded_list
                 ]
                 assert_array_equal(expected_is_tensor_empty, is_tensor_empty)
+    @with_comms
+    def test_metadata_consistency_check(self):
+        device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
+        placements = [Shard(0)]
 
+        # Create a local tensor with specific metadata
+        local_tensor = torch.randn(3, 3, requires_grad=True, dtype=torch.float32)
+
+        if self.rank == 0:
+            local_tensor = local_tensor.to(dtype=torch.float64)
+
+        with self.assertRaises(ValueError):
+            DTensor.from_local(local_tensor, device_mesh, placements, run_check=True)
+
+        try:
+            DTensor.from_local(local_tensor, device_mesh, placements, run_check=False)
+        except ValueError:
+            self.fail("Unexpected ValueError raised with run_check=False")
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/_tensor/test_dtensor.py
+++ b/test/distributed/_tensor/test_dtensor.py
@@ -804,12 +804,13 @@ class TestDTensorPlacementTypes(DTensorTestBase):
                     for unpadded_tensor in unpadded_list
                 ]
                 assert_array_equal(expected_is_tensor_empty, is_tensor_empty)
+
     @with_comms
     def test_metadata_consistency_check(self):
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
         placements = [Shard(0)]
 
-        # Create a local tensor with specific metadata
+        # Create a local tensor with specific metadata and check dtype change
         local_tensor = torch.randn(3, 3, requires_grad=True, dtype=torch.float32)
 
         if self.rank == 0:
@@ -822,6 +823,35 @@ class TestDTensorPlacementTypes(DTensorTestBase):
             DTensor.from_local(local_tensor, device_mesh, placements, run_check=False)
         except ValueError:
             self.fail("Unexpected ValueError raised with run_check=False")
+
+        # Create a local tensor with specific metadata and check requires_grad change
+        local_tensor = torch.randn(3, 3, requires_grad=True, dtype=torch.float32)
+
+        if self.rank == 0:
+            local_tensor.requires_grad = False
+
+        with self.assertRaises(ValueError):
+            DTensor.from_local(local_tensor, device_mesh, placements, run_check=True)
+
+        try:
+            DTensor.from_local(local_tensor, device_mesh, placements, run_check=False)
+        except ValueError:
+            self.fail("Unexpected ValueError raised with run_check=False")
+
+        # Create a local tensor with specific metadata and check stride change
+        local_tensor = torch.randn(3, 4, requires_grad=True, dtype=torch.float32)
+
+        if self.rank == 0:
+            local_tensor = local_tensor.transpose()  # transpose changes the stride
+
+        with self.assertRaises(ValueError):
+            DTensor.from_local(local_tensor, device_mesh, placements, run_check=True)
+
+        try:
+            DTensor.from_local(local_tensor, device_mesh, placements, run_check=False)
+        except ValueError:
+            self.fail("Unexpected ValueError raised with run_check=False")
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/_tensor/_collective_utils.py
+++ b/torch/distributed/_tensor/_collective_utils.py
@@ -286,17 +286,17 @@ def redistribute_cost(
 
     return cost
 
+
 def check_tensor_meta(local_tensor, check_shape_stride=False):
     local_metadata = {
-        'dtype': local_tensor.dtype,
-        'requires_grad': local_tensor.requires_grad
+        "dtype": local_tensor.dtype,
+        "requires_grad": local_tensor.requires_grad,
     }
 
     if check_shape_stride:
-        local_metadata.update({
-            'shape': local_tensor.shape,
-            'stride': local_tensor.stride()
-        })
+        local_metadata.update(
+            {"shape": local_tensor.shape, "stride": local_tensor.stride()}
+        )
 
     gathered_metadata = [None for _ in range(torch.distributed.get_world_size())]
     torch.distributed.all_gather_object(gathered_metadata, local_metadata)

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -8,8 +8,10 @@ import torch.distributed._functional_collectives as funcol
 import torch.distributed._tensor.dispatch as op_dispatch
 import torch.distributed._tensor.random as random
 import torch.nn as nn
-from torch.distributed._tensor._collective_utils import mesh_broadcast
-from torch.distributed._tensor._collective_utils import check_tensor_meta
+from torch.distributed._tensor._collective_utils import (
+    check_tensor_meta,
+    mesh_broadcast,
+)
 from torch.distributed._tensor._utils import compute_global_tensor_info
 from torch.distributed._tensor.device_mesh import _mesh_resources, DeviceMesh
 from torch.distributed._tensor.placement_types import (
@@ -108,6 +110,7 @@ class _ToTorchTensor(torch.autograd.Function):
             None,
         )
 
+
 class _FromTorchTensor(torch.autograd.Function):
     @staticmethod
     def forward(  # type: ignore[override]
@@ -147,8 +150,11 @@ class _FromTorchTensor(torch.autograd.Function):
             # TODO: See if we need to make this run_check logic
             # have a corresponding backward.
 
-            if not check_tensor_meta(input, check_shape_stride=True):
-                    raise ValueError("Inconsistent tensor metadata (including shape and stride) across ranks.")
+            check_shape_stride = not shape and not stride
+            if not check_tensor_meta(input, check_shape_stride=check_shape_stride):
+                raise ValueError(
+                    "Inconsistent tensor metadata (including shape and stride) across ranks."
+                )
 
             for idx, placement in enumerate(placements):
                 if placement.is_replicate():


### PR DESCRIPTION
Fixes #108742 

Implements metadata check using `dist.allgather_object` 


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @kiukchung @lucasllc