### PR TITLE
[5/N] Fixes clang-tidy warnings in c10/core/*.h

### DIFF
--- a/c10/core/Allocator.h
+++ b/c10/core/Allocator.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stddef.h>
+#include <cstddef>
 #include <memory>
 
 #include <c10/core/Device.h>

--- a/c10/core/ConstantSymNodeImpl.h
+++ b/c10/core/ConstantSymNodeImpl.h
@@ -11,7 +11,7 @@ namespace c10 {
 template <typename T>
 class C10_API ConstantSymNodeImpl : public SymNodeImpl {
   static_assert(
-      std::is_same<T, int64_t>::value || std::is_same<T, bool>::value,
+      std::is_same_v<T, int64_t> || std::is_same_v<T, bool>,
       "ConstantSymNodeImpl can only accept int64_t or bool types");
 
  public:
@@ -87,10 +87,10 @@ class C10_API ConstantSymNodeImpl : public SymNodeImpl {
   std::variant<int64_t, bool> value_;
 
   static constexpr bool is_int_() {
-    return std::is_same<T, int64_t>::value;
+    return std::is_same_v<T, int64_t>;
   }
   static constexpr bool is_bool_() {
-    return std::is_same<T, bool>::value;
+    return std::is_same_v<T, bool>;
   }
 };
 

--- a/c10/core/DefaultTensorOptions.h
+++ b/c10/core/DefaultTensorOptions.h
@@ -4,6 +4,7 @@
 #include <c10/core/Device.h>
 #include <c10/core/Layout.h>
 #include <c10/core/ScalarType.h>
+#include <c10/util/typeid.h>
 
 namespace c10 {
 

--- a/c10/core/DispatchKeySet.h
+++ b/c10/core/DispatchKeySet.h
@@ -190,6 +190,7 @@ class DispatchKeySet final {
   }
 
   constexpr explicit DispatchKeySet(DispatchKey k) {
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (k == DispatchKey::Undefined) {
       // Case 1: handle Undefined specifically
       repr_ = 0;
@@ -915,12 +916,12 @@ template <class FuncType>
 using remove_DispatchKeySet_arg_from_func = guts::make_function_traits_t<
     typename guts::infer_function_traits_t<FuncType>::return_type,
     typename std::conditional_t<
-        std::is_same<
+        std::is_same_v<
             DispatchKeySet,
             typename guts::typelist::head_with_default_t<
                 void,
                 typename guts::infer_function_traits_t<
-                    FuncType>::parameter_types>>::value,
+                    FuncType>::parameter_types>>,
         guts::typelist::drop_if_nonempty_t<
             typename guts::infer_function_traits_t<FuncType>::parameter_types,
             1>,

--- a/c10/core/MemoryFormat.h
+++ b/c10/core/MemoryFormat.h
@@ -249,6 +249,7 @@ inline bool is_channels_last_strides_2d(
   switch (sizes.size()) {
     case 4:
       return is_channels_last_strides_2d_s4(sizes, strides);
+      // NOLINTNEXTLINE(bugprone-branch-clone)
     case 3:
       // TODO dim == 3 case will be enabled once it is fully tested
       return false;
@@ -264,6 +265,7 @@ inline bool is_channels_last_strides_3d(
   switch (sizes.size()) {
     case 5:
       return is_channels_last_strides_3d_s5(sizes, strides);
+      // NOLINTNEXTLINE(bugprone-branch-clone)
     case 4:
       // TODO dim == 4 case will be enabled once it is fully tested
       return false;

--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
@@ -14,11 +14,6 @@
 #include <c10/util/Half.h>
 #include <c10/util/TypeCast.h>
 #include <c10/util/intrusive_ptr.h>
-
-C10_CLANG_DIAGNOSTIC_PUSH()
-#if C10_CLANG_HAS_WARNING("-Wimplicit-int-float-conversion")
-C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
-#endif
 
 namespace c10 {
 
@@ -66,16 +61,15 @@ class C10_API Scalar {
   // problem.
   template <
       typename T,
-      typename std::enable_if<std::is_same<T, bool>::value, bool>::type* =
-          nullptr>
+      typename std::enable_if_t<std::is_same_v<T, bool>, bool>* = nullptr>
   Scalar(T vv) : tag(Tag::HAS_b) {
     v.i = convert<int64_t, bool>(vv);
   }
 
   template <
       typename T,
-      typename std::enable_if<std::is_same<T, c10::SymBool>::value, bool>::
-          type* = nullptr>
+      typename std::enable_if_t<std::is_same_v<T, c10::SymBool>, bool>* =
+          nullptr>
   Scalar(T vv) : tag(Tag::HAS_sb) {
     v.i = convert<int64_t, c10::SymBool>(vv);
   }
@@ -208,7 +202,7 @@ class C10_API Scalar {
 
   template <
       typename T,
-      typename std::enable_if<!c10::is_complex<T>::value, int>::type = 0>
+      typename std::enable_if_t<!c10::is_complex<T>::value, int> = 0>
   bool equal(T num) const {
     if (isComplex()) {
       TORCH_INTERNAL_ASSERT(!isSymbolic());
@@ -231,7 +225,7 @@ class C10_API Scalar {
 
   template <
       typename T,
-      typename std::enable_if<c10::is_complex<T>::value, int>::type = 0>
+      typename std::enable_if_t<c10::is_complex<T>::value, int> = 0>
   bool equal(T num) const {
     if (isComplex()) {
       TORCH_INTERNAL_ASSERT(!isSymbolic());
@@ -343,25 +337,25 @@ class C10_API Scalar {
 
   template <
       typename T,
-      typename std::enable_if<
-          std::is_integral<T>::value && !std::is_same<T, bool>::value,
-          bool>::type* = nullptr>
+      typename std::enable_if_t<
+          std::is_integral_v<T> && !std::is_same_v<T, bool>,
+          bool>* = nullptr>
   Scalar(T vv, bool) : tag(Tag::HAS_i) {
     v.i = convert<decltype(v.i), T>(vv);
   }
 
   template <
       typename T,
-      typename std::enable_if<
-          !std::is_integral<T>::value && !c10::is_complex<T>::value,
-          bool>::type* = nullptr>
+      typename std::enable_if_t<
+          !std::is_integral_v<T> && !c10::is_complex<T>::value,
+          bool>* = nullptr>
   Scalar(T vv, bool) : tag(Tag::HAS_d) {
     v.d = convert<decltype(v.d), T>(vv);
   }
 
   template <
       typename T,
-      typename std::enable_if<c10::is_complex<T>::value, bool>::type* = nullptr>
+      typename std::enable_if_t<c10::is_complex<T>::value, bool>* = nullptr>
   Scalar(T vv, bool) : tag(Tag::HAS_z) {
     v.z = convert<decltype(v.z), T>(vv);
   }
@@ -379,5 +373,3 @@ AT_FORALL_SCALAR_TYPES_WITH_COMPLEX(DEFINE_TO)
 #undef DEFINE_TO
 
 } // namespace c10
-
-C10_CLANG_DIAGNOSTIC_POP()

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -17,7 +17,6 @@
 #include <c10/util/quint8.h>
 
 #include <array>
-#include <complex>
 #include <cstdint>
 #include <ostream>
 
@@ -441,15 +440,15 @@ static inline ScalarType toQIntType(ScalarType t) {
 static inline ScalarType toUnderlying(ScalarType t) {
   switch (t) {
     case ScalarType::QUInt8:
+      [[fallthrough]];
+    case ScalarType::QUInt4x2:
+      [[fallthrough]];
+    case ScalarType::QUInt2x4:
       return ScalarType::Byte;
     case ScalarType::QInt8:
       return ScalarType::Char;
     case ScalarType::QInt32:
       return ScalarType::Int;
-    case ScalarType::QUInt4x2:
-      return ScalarType::Byte;
-    case ScalarType::QUInt2x4:
-      return ScalarType::Byte;
     default:
       return t;
   }

--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -88,6 +88,7 @@ class C10_API SymInt {
     // https://stackoverflow.com/questions/42534749/signed-extension-from-24-bit-to-32-bit-in-c
     uint64_t extended_bits = (unextended_bits ^ sign_bit_mask) - sign_bit_mask;
     return static_cast<SymNodeImpl*>(
+        // NOLINTNEXTLINE(performance-no-int-to-ptr)
         reinterpret_cast<void*>(static_cast<uintptr_t>(extended_bits)));
   }
 
@@ -287,9 +288,9 @@ class C10_API SymInt {
 /// Sum of a list of SymInt; accumulates into the c10::SymInt expression
 template <
     typename C,
-    typename std::enable_if<
-        std::is_same<typename C::value_type, c10::SymInt>::value,
-        int>::type = 0>
+    typename std::enable_if_t<
+        std::is_same_v<typename C::value_type, c10::SymInt>,
+        int> = 0>
 inline c10::SymInt multiply_integers(const C& container) {
   return std::accumulate(
       container.begin(),
@@ -300,9 +301,9 @@ inline c10::SymInt multiply_integers(const C& container) {
 
 template <
     typename Iter,
-    typename = std::enable_if_t<std::is_same<
+    typename = std::enable_if_t<std::is_same_v<
         typename std::iterator_traits<Iter>::value_type,
-        c10::SymInt>::value>>
+        c10::SymInt>>>
 inline c10::SymInt multiply_integers(Iter begin, Iter end) {
   return std::accumulate(
       begin,

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -713,14 +713,14 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     if (C10_UNLIKELY(matches_policy(SizesStridesPolicy::CustomSizes))) {
       return dim_custom();
     }
-    return sizes_and_strides_.size();
+    return static_cast<int64_t>(sizes_and_strides_.size());
   }
 
   int64_t dim_default() const {
     if (has_symbolic_sizes_strides_) {
-      return symbolic_shape_meta().sizes_.size();
+      return static_cast<int64_t>(symbolic_shape_meta().sizes_.size());
     } else {
-      return sizes_and_strides_.size();
+      return static_cast<int64_t>(sizes_and_strides_.size());
     }
   }
 
@@ -2433,7 +2433,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
 
   template <
       typename T,
-      typename = typename std::enable_if<std::is_integral<T>::value>::type>
+      typename = typename std::enable_if_t<std::is_integral_v<T>>>
   bool SetDimsTemplate(ArrayRef<T> src) {
     TORCH_CHECK(
         !has_symbolic_sizes_strides_,

--- a/c10/core/impl/InlineDeviceGuard.h
+++ b/c10/core/impl/InlineDeviceGuard.h
@@ -78,8 +78,8 @@ class InlineDeviceGuard {
   /// device type is inferred from the template parameter T).
   template <
       typename U = T,
-      typename = typename std::enable_if<
-          !std::is_same<U, VirtualGuardImpl>::value>::type>
+      typename =
+          typename std::enable_if_t<!std::is_same_v<U, VirtualGuardImpl>>>
   explicit InlineDeviceGuard(DeviceIndex device_index)
       : InlineDeviceGuard(Device(U::static_type, device_index)) {}
 
@@ -87,8 +87,7 @@ class InlineDeviceGuard {
   /// DeviceGuardImplInterface pointer.
   template <
       typename U = T,
-      typename = typename std::enable_if<
-          std::is_same<U, VirtualGuardImpl>::value>::type>
+      typename = typename std::enable_if_t<std::is_same_v<U, VirtualGuardImpl>>>
   explicit InlineDeviceGuard(
       Device device,
       const DeviceGuardImplInterface* impl)
@@ -115,8 +114,7 @@ class InlineDeviceGuard {
   /// Sets the device to the given one.
   template <
       typename U = T,
-      typename std::enable_if<!std::is_same<U, VirtualGuardImpl>::value, int>::
-          type = 0>
+      typename std::enable_if_t<!std::is_same_v<U, VirtualGuardImpl>, int> = 0>
   void set_device(at::Device device) {
     AT_ASSERT(
         (U::static_type == DeviceType::HIP && device.is_cuda()) ||
@@ -132,8 +130,8 @@ class InlineDeviceGuard {
   /// current device to the passed device.  This is effectively equivalent to
   /// set_device when a guard supports only a single device type.
   template <typename U = T>
-  typename std::enable_if<!std::is_same<U, VirtualGuardImpl>::value>::type
-  reset_device(at::Device device) {
+  typename std::enable_if_t<!std::is_same_v<U, VirtualGuardImpl>> reset_device(
+      at::Device device) {
     set_device(device);
   }
 
@@ -155,8 +153,7 @@ class InlineDeviceGuard {
   ///
   /// Optional argument is for testing only.
   template <typename U = T>
-  typename std::enable_if<std::is_same<U, VirtualGuardImpl>::value>::type
-  reset_device(
+  typename std::enable_if_t<std::is_same_v<U, VirtualGuardImpl>> reset_device(
       at::Device device,
       const impl::DeviceGuardImplInterface* impl = nullptr) {
     auto index = device.index();
@@ -234,8 +231,8 @@ class InlineOptionalDeviceGuard {
   /// Set the current device to the passed DeviceIndex, if it is not nullopt.
   template <
       typename U = T,
-      typename = typename std::enable_if<
-          !std::is_same<U, VirtualGuardImpl>::value>::type>
+      typename =
+          typename std::enable_if_t<!std::is_same_v<U, VirtualGuardImpl>>>
   explicit InlineOptionalDeviceGuard(optional<DeviceIndex> device_index_opt)
       : guard_() { // See Note [Explicit initialization of optional fields]
     if (device_index_opt.has_value()) {
@@ -342,8 +339,8 @@ class InlineOptionalDeviceGuard {
   /// is not already initialized.
   template <
       typename U = T,
-      typename = typename std::enable_if<
-          !std::is_same<U, VirtualGuardImpl>::value>::type>
+      typename =
+          typename std::enable_if_t<!std::is_same_v<U, VirtualGuardImpl>>>
   void set_device(at::Device device) {
     if (!guard_.has_value()) {
       guard_.emplace(device);
@@ -361,8 +358,7 @@ class InlineOptionalDeviceGuard {
   /// Optional argument is for testing only.
   template <
       typename U = T,
-      typename = typename std::enable_if<
-          std::is_same<U, VirtualGuardImpl>::value>::type>
+      typename = typename std::enable_if_t<std::is_same_v<U, VirtualGuardImpl>>>
   void reset_device(
       at::Device device,
       const DeviceGuardImplInterface* impl = nullptr) {
@@ -379,8 +375,8 @@ class InlineOptionalDeviceGuard {
   /// when a guard supports only a single device type.
   template <
       typename U = T,
-      typename = typename std::enable_if<
-          !std::is_same<U, VirtualGuardImpl>::value>::type>
+      typename =
+          typename std::enable_if_t<!std::is_same_v<U, VirtualGuardImpl>>>
   void reset_device(at::Device device) {
     if (!guard_.has_value()) {
       guard_.emplace(device);
@@ -393,8 +389,8 @@ class InlineOptionalDeviceGuard {
   /// known.
   template <
       typename U = T,
-      typename = typename std::enable_if<
-          !std::is_same<U, VirtualGuardImpl>::value>::type>
+      typename =
+          typename std::enable_if_t<!std::is_same_v<U, VirtualGuardImpl>>>
   void set_index(DeviceIndex index) {
     if (!guard_.has_value()) {
       guard_.emplace(index);

--- a/c10/core/impl/InlineStreamGuard.h
+++ b/c10/core/impl/InlineStreamGuard.h
@@ -33,8 +33,7 @@ class InlineStreamGuard : private InlineDeviceGuard<T> {
   /// This constructor exists purely for testing
   template <
       typename U = T,
-      typename = typename std::enable_if<
-          std::is_same<U, VirtualGuardImpl>::value>::type>
+      typename = typename std::enable_if_t<std::is_same_v<U, VirtualGuardImpl>>>
   explicit InlineStreamGuard(
       Stream stream,
       const DeviceGuardImplInterface* impl)
@@ -222,9 +221,11 @@ class InlineMultiStreamGuard {
   InlineMultiStreamGuard(InlineMultiStreamGuard&& other) = delete;
   InlineMultiStreamGuard& operator=(InlineMultiStreamGuard&& other) = delete;
 
-  ~InlineMultiStreamGuard() {
-    for (const Stream& s : original_streams_) {
-      this->impl_->exchangeStream(s);
+  ~InlineMultiStreamGuard() noexcept {
+    if (this->impl_.has_value()) {
+      for (const Stream& s : original_streams_) {
+        this->impl_->exchangeStream(s);
+      }
     }
   }
 


### PR DESCRIPTION
This PR continues to fix clang-tidy warnings for headers in c10/core.
