### PR TITLE
Use `test_vulkan` to validate run_test without boto3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -228,8 +228,8 @@ jobs:
           pip install torch --pre --index-url https://download.pytorch.org/whl/nightly/cpu/
       - name: Run run_test.py (nonretryable)
         run: |
-          # Run test_weak, which is very fast
-          python3 test/run_test.py --include test_weak --verbose
+          # Run test_vulkan, which is a fast noop on Linux
+          python3 test/run_test.py --include test_vulkan --verbose
 
   test_collect_env:
     if: ${{ github.repository == 'pytorch/pytorch' }}


### PR DESCRIPTION
As `test_weak` can undergo some changes, but `test_vulkan` is a no-op for CPU builds