### PR TITLE
enable test_linalg on arm

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -17,7 +17,7 @@ from torch.testing._internal.common_utils import \
     (TestCase, run_tests, TEST_SCIPY, IS_MACOS, IS_WINDOWS, slowTest,
      TEST_WITH_ROCM, IS_FBCODE, IS_REMOTE_GPU, iter_indices,
      make_fullrank_matrices_with_distinct_singular_values,
-     freeze_rng_state, IS_ARM64, IS_SANDCASTLE, TEST_OPT_EINSUM, parametrize, skipIfTorchDynamo,
+     freeze_rng_state, IS_SANDCASTLE, TEST_OPT_EINSUM, parametrize, skipIfTorchDynamo,
      setLinalgBackendsToDefaultFinally)
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, dtypes, has_cusolver, has_hipsolver,

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -41,7 +41,6 @@ if TEST_SCIPY:
     import scipy
 
 
-@unittest.skipIf(IS_ARM64, "Issue with numpy version on arm")
 class TestLinalg(TestCase):
     def setUp(self):
         super(self.__class__, self).setUp()


### PR DESCRIPTION
In my local environment, the numpy error on arm64 has been cleared. Merge if this passes the tests.