### PR TITLE
[Quant] [Inductor] add input shape check for quantized conv binary lowering

### DIFF
--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -670,6 +670,36 @@ class TestPatternMatcher(TestPatternMatcherBase):
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN
     @skipIfRocm
+    def test_qconv2d_add_broadcast_shapes_cpu(self):
+        r"""
+        This testcase will quantize Conv2d->add pattern using broadcast shape inputs.
+        """
+
+        class M(torch.nn.Module):
+            def __init__(self, use_bias):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(32, 32, kernel_size=3, stride=1)
+
+            def forward(self, x1, x2):
+                return torch.add(self.conv(x1), x2)
+
+        bias_list = [True, False]
+        for bias in bias_list:
+            mod = M(bias).eval()
+            x1 = torch.randn((2, 32, 9, 9))
+            x2 = torch.randn((2, 32, 1, 1))
+
+            self._test_common(
+                mod,
+                (x1, x2),
+                3,
+                10,
+                check_quantization=True,
+            )
+
+    @skipIfNoDynamoSupport
+    @skipIfNoONEDNN
+    @skipIfRocm
     def test_qconv2d_add_2(self):
         r"""
         This testcase prevents this pattern be matched as a conv_binary fusion by mistake.

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -689,12 +689,21 @@ class TestPatternMatcher(TestPatternMatcherBase):
             x1 = torch.randn((2, 32, 9, 9))
             x2 = torch.randn((2, 32, 1, 1))
 
+            def matcher_check_fn():
+                # 1. Dequant-Conv2D pattern matched in quantization weight prepack * 1
+                self.assertEqual(
+                    counters["inductor"]["qconv2d_weight_prepack_matcher_count"], 1
+                )
+                # 2. Qconv2d Binary Unary fusion in post-grad fusion pass * 0
+                self.assertEqual(
+                    counters["inductor"]["qconv2d_binary_matcher_count"], 0
+                )
+
             self._test_common(
                 mod,
                 (x1, x2),
-                3,
-                10,
                 check_quantization=True,
+                matcher_check_fn=matcher_check_fn,
             )
 
     @skipIfNoDynamoSupport

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -673,6 +673,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
     def test_qconv2d_add_broadcast_shapes_cpu(self):
         r"""
         This testcase will quantize Conv2d->add pattern using broadcast shape inputs.
+        Conv2d->Add fusion will fail for the broadcast shape inputs case.
         """
 
         class M(torch.nn.Module):

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -429,7 +429,10 @@ def _is_valid_quantized_conv_binary_optimization_pattern(output_dtype):
                 iter(qconv2d_node_after_weight_prepack.users)
             ).args
             assert len(binary_node_inputs) == 2, "Expects binary node with 2 inputs"
-            if binary_node_inputs[0].meta["val"].size() != binary_node_inputs[1].meta["val"].size():
+            if (
+                binary_node_inputs[0].meta["val"].size()
+                != binary_node_inputs[1].meta["val"].size()
+            ):
                 return False
             extra_input_node = None
             for arg in binary_node_inputs:

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -417,6 +417,7 @@ def _is_valid_quantized_conv_binary_optimization_pattern(output_dtype):
     # Check if it's a valid Conv Binary Pattern:
     # * qconv2d_pointwise should only has one users
     # * Extra input of binary node comes from dequant pattern
+    # * the two inputs of binary node should have the same shape
     def fn(match):
         qconv2d_node_after_weight_prepack = filter_nodes(
             match.nodes, torch.ops.onednn.qconv2d_pointwise
@@ -428,6 +429,8 @@ def _is_valid_quantized_conv_binary_optimization_pattern(output_dtype):
                 iter(qconv2d_node_after_weight_prepack.users)
             ).args
             assert len(binary_node_inputs) == 2, "Expects binary node with 2 inputs"
+            if binary_node_inputs[0].meta["val"].size() != binary_node_inputs[1].meta["val"].size():
+                return False
             extra_input_node = None
             for arg in binary_node_inputs:
                 if arg != qconv2d_node_after_weight_prepack:


### PR DESCRIPTION
Add inputs shape check for quantized conv binary lowering, since qconv2d_pointwise.binary does not yet support the case of broadcasting shape inputs.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler