### PR TITLE
[DTensor] force re-compute sharding when normalized_shape differs in fwd layer norm

### DIFF
--- a/test/distributed/_tensor/test_math_ops.py
+++ b/test/distributed/_tensor/test_math_ops.py
@@ -161,12 +161,19 @@ class DistMathOpsTest(DTensorTestBase):
         x = torch.rand(batch, sentence_length, embedding_dim, device=self.device_type)
         norm_shape_idx_list = list(range(x.ndim))
         shard_dims = [-1, 0, 1, 2]
-        test_config_list = list(itertools.product(shard_dims, norm_shape_idx_list))
+        elementwise_affine_list = [False, True]
+        test_config_list = list(
+            itertools.product(shard_dims, norm_shape_idx_list, elementwise_affine_list)
+        )
 
         # normalized shape is a torch.Size object
-        for shard_dim, norm_idx in test_config_list:
+        for shard_dim, norm_idx, elementwise_affine in test_config_list:
             normalized_shape = x.shape[norm_idx:]
-            layer_norm = torch.nn.LayerNorm(normalized_shape)
+            layer_norm = torch.nn.LayerNorm(
+                normalized_shape,
+                elementwise_affine=elementwise_affine,
+                device=self.device_type,
+            )
             layer_norm_local = copy.deepcopy(layer_norm).to(self.device_type)
 
             def _replicate_fn(name, module, device_mesh):

--- a/torch/distributed/_tensor/ops/math_ops.py
+++ b/torch/distributed/_tensor/ops/math_ops.py
@@ -257,7 +257,7 @@ def softmax_bwd_rule(op_schema: OpSchema) -> OutputSharding:
 
 @register_op_strategy(
     [aten.native_layer_norm.default],
-    schema_info=RuntimeSchemaInfo(),
+    schema_info=RuntimeSchemaInfo(1),
 )
 def layer_norm_strategy(mesh: DeviceMesh, op_schema: OpSchema) -> OpStrategy:
     # args must be: input, normalized_shape, weight, bias, eps

--- a/torch/distributed/_tensor/sharding_prop.py
+++ b/torch/distributed/_tensor/sharding_prop.py
@@ -41,9 +41,6 @@ class ShardingPropagator:
         # op map to save static argnum to decide to reuse sharding prop cache or re-run sharding prop
         self.op_to_schema_info: Dict[OpOverload, RuntimeSchemaInfo] = {}
         self.propagate_op_sharding = lru_cache(None)(self.propagate_op_sharding_non_cached)  # type: ignore[method-assign]
-        self._implicit_dynamic_shape_ops = {
-            aten.native_layer_norm.default,
-        }
 
     def register_sharding_prop_rule(
         self,
@@ -160,14 +157,7 @@ class ShardingPropagator:
         # because SymInts are not hashable.
         # This is generally ok because this only happens during tracing in torch.compile,
         # and tracing does not need to be as fast as eagermode DTensor usages.
-        # One exception is implicit dynamic shape ops like native_layer_norm. When weight
-        # and bias are not None, the dynamic shape characteristic can be captured; when
-        # weight and bias are None, the dynamic shape characteristic cannot be captured
-        # because the not-None input args only have static shape.
-        if (
-            op_info.schema.has_symints
-            or op_info.schema.op in self._implicit_dynamic_shape_ops
-        ):
+        if op_info.schema.has_symints:
             output_sharding = self.propagate_op_sharding_non_cached(op_info.schema)
         else:
             output_sharding = self.propagate_op_sharding(op_info.schema)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #115250

**Summary**:
#114174 did not test the case where `elementwise_affine=False` (i.e. `weight` and `bias` are `None`) and this test would fail due to cached sharding propagation. The difference on sharding prop between these cases is, when `weight` and `bias` are None, the forward layer norm op will be recognized as a "static shape op" and `propagate_op_sharding` will be applied rather than `propagate_op_sharding_non_cached`. A fix is to force re-compute sharding when `normalized_shape` changes by setting op schema's `RuntimeSchemaInfo`'s `static_argnum` to include `normalized_shape` (i.e. 1)

**Test**:
pytest test/distributed/_tensor/test_math_ops.py -s -k layer_norm


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @kiukchung @lucasllc