### PR TITLE
Improvised the Introduction of Torch library api doc

### DIFF
--- a/docs/cpp/source/library.rst
+++ b/docs/cpp/source/library.rst
@@ -1,8 +1,7 @@
 Torch Library API
 =================
 
-The PyTorch C++ API provides capabilities for extending PyTorch's core library
-of operators with user defined operators and data types.  Extensions implemented
+The PyTorch C++ API allows users to add custom operators and data types to PyTorch's core library of operators. Extensions implemented
 using the Torch Library API are made available for use in both the PyTorch eager
 API as well as in TorchScript.
 


### PR DESCRIPTION
Changed the first line of the introduction into more simpler line

![before](https://github.com/pytorch/pytorch/assets/112613031/33a8ae49-04eb-4bea-8163-22d89d4a922e)

