### PR TITLE
[export] Do not copy state_dict in run_decomp

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1481,7 +1481,7 @@ class TestExport(TestCase):
         m = M()
         with unittest.mock.patch("torch._export.DECOMP_TABLE", None):
             ep = export(m, inp)
-
+        state_dict = ep.state_dict
 
         FileCheck().check_count(
             "torch.ops.aten.t.default", 1, exactly=True
@@ -1496,6 +1496,7 @@ class TestExport(TestCase):
             "torch.ops.aten.t.default", 0, exactly=True
         ).run(core_aten_ep.graph_module.code)
         self.assertTrue(torch.allclose(core_aten_ep(*inp), m(*inp)))
+        self.assertEqual(id(state_dict), id(ep.state_dict))
 
     def test_export_decomps_dynamic(self):
         class M(torch.nn.Module):

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -466,14 +466,13 @@ class ExportedProgram:
             for inp_dim1, inp_dim2 in self.equality_constraints
         ]
 
-        state_dict = self.state_dict.copy()
         lift_constant_tensor_pass(gm, new_graph_signature)
         _replace_sym_size_ops_pass(gm)
         exported_program = ExportedProgram(
             gm,
             gm.graph,
             new_graph_signature,
-            state_dict,
+            self.state_dict,
             new_range_constraints,
             new_equality_constraints,
             copy.deepcopy(self.module_call_graph),


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/114628

