### PR TITLE
Fix typo in `https://pytorch.org/docs/stable/sparse.html`

### DIFF
--- a/docs/source/sparse.rst
+++ b/docs/source/sparse.rst
@@ -15,7 +15,7 @@ torch.sparse
 Why and when to use sparsity
 ++++++++++++++++++++++++++++
 
-By default PyTorch stores :class:`torch.Tensor` elements contiguously
+By default PyTorch stores :class:`torch.Tensor` elements contiguously in
 physical memory. This leads to efficient implementations of various array
 processing algorithms that require fast access to elements.
 

--- a/docs/source/sparse.rst
+++ b/docs/source/sparse.rst
@@ -15,7 +15,7 @@ torch.sparse
 Why and when to use sparsity
 ++++++++++++++++++++++++++++
 
-By default PyTorch stores :class:`torch.Tensor` stores elements contiguously
+By default PyTorch stores :class:`torch.Tensor` elements contiguously
 physical memory. This leads to efficient implementations of various array
 processing algorithms that require fast access to elements.
 

--- a/docs/source/sparse.rst
+++ b/docs/source/sparse.rst
@@ -15,7 +15,7 @@ torch.sparse
 Why and when to use sparsity
 ++++++++++++++++++++++++++++
 
-By default PyTorch stores :class:`torch.Tensor` elements contiguously in
+By default, PyTorch stores :class:`torch.Tensor` elements contiguously in
 physical memory. This leads to efficient implementations of various array
 processing algorithms that require fast access to elements.
 


### PR DESCRIPTION
Fixes #111473


cc @svekars @carljparker