### PR TITLE
[CI] Add torch/_functorch/_aot_autograd to auto-label rule

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -23,8 +23,9 @@
 - torch/_subclasses/meta_utils.py
 - test/distributed/test_dynamo_distributed.py
 - test/distributed/test_inductor_collectives.py
-- torch/_functorch/partitioners.py
+- torch/_functorch/_aot_autograd/**
 - torch/_functorch/aot_autograd.py
+- torch/_functorch/partitioners.py
 - .ci/docker/ci_commit_pins/**
 - .github/ci_commit_pins/**
 - c10/core/Sym*


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #115283

