### PR TITLE
Fix _load_from_state_dict for num_batches_tracked in batchnorm

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5323,7 +5323,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with torch.device('meta'):
             meta_bn = torch.nn.BatchNorm2d(3)
         self.assertTrue(meta_bn.num_batches_tracked.device == torch.device('meta'))
-        state_dict.pop("num_batches_tracked")
         meta_bn.load_state_dict(empty_dict, assign=True, strict=False)
         self.assertEqual(meta_bn.state_dict()["num_batches_tracked"], torch.tensor(0))
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5312,7 +5312,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         self.assertEqual(bn.state_dict()["num_batches_tracked"], torch.tensor(0))
 
         bn.num_batches_tracked = torch.tensor(10)
-        state_dict = bn.state_dict()
         self.assertEqual(bn.state_dict()["num_batches_tracked"], torch.tensor(10))
 
         empty_dict = OrderedDict()
@@ -5327,7 +5326,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         state_dict.pop("num_batches_tracked")
         meta_bn.load_state_dict(empty_dict, assign=True, strict=False)
         self.assertEqual(meta_bn.state_dict()["num_batches_tracked"], torch.tensor(0))
-
 
     def test_pairwise_distance(self):
         input1 = torch.randn(4, 4, requires_grad=True, dtype=torch.double)

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -107,7 +107,7 @@ class _NormBase(Module):
             if num_batches_tracked_key not in state_dict:
                 state_dict[num_batches_tracked_key] = (
                     self.num_batches_tracked
-                    if self.num_batches_tracked is not None
+                    if self.num_batches_tracked is not None and self.num_batches_tracked.device != torch.device('meta')
                     else torch.tensor(0, dtype=torch.long)
                 )
 


### PR DESCRIPTION
I approved https://github.com/pytorch/pytorch/pull/110850 which did the following

Previously:
`num_batches_tracked` not in state_dict when doing `m.load_state_dict(state_dict)` --> always overwrite module's `num_batches_tracked` in `load_from_state_dict` with a 0 cpu tensor

Now:
`num_batches_tracked` not in state_dict loaded when doing `m.load_state_dict(state_dict)` --> only overwrite module's `num_batches_tracked`  in `load_from_state_dict` with a 0 cpu tensor if module does not have `num_batches_tracked`

This causes the following issue:

```
with torch.device('meta'):
     m = BatchNorm(...)
m.load_state_dict(state_dict, assign=True)
```

If `num_batches_tracked` is not in `state_dict`, since `modules's` `num_batches_tracked` is present on meta device, it is not overwritten with a 0 cpu tensor. When compiling, this error is raised

```
AssertionError: Does not support mixing cuda+meta
```     

I am not sure whether the explicit check for meta device makes sense as a fix, will add testing if this fix is ok


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #115285

