### PR TITLE
Add `reset_storage` method to FunctionalTensorWrapper (#115235)

### DIFF
--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -149,6 +149,7 @@ FunctionalTensorWrapper::FunctionalTensorWrapper(const Tensor& view_value, const
   storage_ = base->storage_; // alias this tensor's storage with the base tensor's
 }
 
+
 functionalization::FunctionalStorageImpl* FunctionalTensorWrapper::functional_storage_impl() const {
   return static_cast<functionalization::FunctionalStorageImpl*>(storage_.unsafeGetStorageImpl());
 }
@@ -309,6 +310,14 @@ void FunctionalTensorWrapper::maybe_replace_storage(const Tensor& other) {
   has_metadata_mutation_ = true;
 }
 
+void FunctionalTensorWrapper::_unsafe_reset_storage() {
+  // Reset the storage with the current value_ tensor as the base
+  storage_ = c10::Storage(c10::make_intrusive<functionalization::FunctionalStorageImpl>(value_));
+  // Reset the generation so that it matches the new storage
+  generation_ = 0;
+  // Clear any pre-existing view metas so that base and value_ are semantically the same
+  view_metas_.clear();
+}
 
 void FunctionalTensorWrapper::sync_() {
   if (is_up_to_date()) {
@@ -566,6 +575,11 @@ void commit_update(ITensorListRef functional_tensor) {
   for (const auto& t : functional_tensor) {
     commit_update(t);
   }
+}
+
+void unsafe_reset_storage(const Tensor& functional_tensor) {
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(isFunctionalTensor(functional_tensor));
+  unsafeGetFunctionalWrapper(functional_tensor)->_unsafe_reset_storage();
 }
 
 void mark_mutation_hidden_from_autograd(const Tensor& functional_tensor) {

--- a/aten/src/ATen/FunctionalTensorWrapper.h
+++ b/aten/src/ATen/FunctionalTensorWrapper.h
@@ -165,6 +165,13 @@ struct TORCH_API FunctionalTensorWrapper : public c10::TensorImpl {
   // See Note[resize_() in functionalization pass]
   void maybe_replace_storage(const Tensor& other);
 
+  // Replaces the storage with a new functional storage,
+  // and clears the view_metas_ stack.
+  // WARNING: Calling this function will sever the aliasing relationship between
+  // the current FunctionalTensorWrapper and any of its outstanding aliases.
+  // Please only call if you know what you're doing.
+  void _unsafe_reset_storage();
+
   c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(
       const c10::VariableVersion& version_counter,
       bool allow_tensor_metadata_change) const override;
@@ -274,6 +281,8 @@ TORCH_API void replace_(
 
 TORCH_API void commit_update(const Tensor& functional_tensor);
 TORCH_API void commit_update(ITensorListRef functional_tensor);
+
+TORCH_API void unsafe_reset_storage(const Tensor& functional_tensor);
 
 TORCH_API void mark_mutation_hidden_from_autograd(
     const Tensor& functional_tensor);

--- a/test/lazy/test_functionalization.py
+++ b/test/lazy/test_functionalization.py
@@ -1,0 +1,61 @@
+# Owner(s): ["oncall: jit"]
+
+import torch
+import torch._lazy.metrics as metrics
+import torch._lazy.ts_backend
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+torch._lazy.ts_backend.init()
+
+
+class LazyFuncionalizationTest(TestCase):
+    def test_lazy_init_with_view(self):
+        def f(device, reset_storage=False):
+            torch.manual_seed(2023)
+
+            if device == "lazy":
+                metrics.reset()
+
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.fc1 = torch.nn.Linear(4, 2, bias=False)
+
+                def forward(self, x):
+                    return x @ self.fc1.weight.transpose(0, 1)
+
+            with torch.device(device):
+                model = Model()
+
+                if device == "lazy":
+                    if reset_storage:
+                        torch._C._unsafe_reset_storage(model.fc1.weight)
+
+                    torch._lazy.mark_step()
+
+                    sync_tensors = metrics.counter_value("SyncedTensorsWithIR")
+                    if reset_storage:
+                        assert sync_tensors == 1
+                    else:
+                        # There is an extra tensor being unnecessarily synced if
+                        # the functional storage is not reset.
+                        assert sync_tensors == 2
+
+                x = torch.ones(4)
+                out = model(x)
+
+                if device == "lazy":
+                    torch._lazy.mark_step()
+
+                return out
+
+        cpu_out = f("cpu")
+        lazy_out_1 = f("lazy", reset_storage=False)
+        lazy_out_2 = f("lazy", reset_storage=True)
+
+        self.assertEqual(cpu_out, lazy_out_1.to("cpu"))
+        self.assertEqual(cpu_out, lazy_out_2.to("cpu"))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/csrc/lazy/core/lazy_graph_executor.cpp
+++ b/torch/csrc/lazy/core/lazy_graph_executor.cpp
@@ -602,6 +602,7 @@ LazyGraphExecutor::SyncTensorCollection LazyGraphExecutor::CollectSyncTensors(
       Value ir_value = tensors[i]->CurrentIrValue();
       if (ir_value) {
         if (ShouldSyncTensor(tensors[i])) {
+          TORCH_LAZY_COUNTER("SyncedTensorsWithIR", 1);
           // Add only tensors which need to be synced.
           coll.hash = HashCombine(coll.hash, ir_value.hash());
           coll.indices.push_back(i);

--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -787,6 +787,9 @@ void initDispatchBindings(PyObject* module) {
   m.def("_commit_update", [](const at::Tensor& a) {
     return at::functionalization::impl::commit_update(a);
   });
+  m.def("_unsafe_reset_storage", [](const at::Tensor& a) {
+    return at::functionalization::impl::unsafe_reset_storage(a);
+  });
 
   m.def("_dispatch_key_for_device", [](const std::string& device_type) {
     auto device = c10::Device(device_type);


### PR DESCRIPTION
In certain edge cases when using lazy tensors, the base tensor stored in the `FunctionalStorageImpl` and the `value_` tensor stored in the `FunctionalTensorWrapper` diverge. For instance, take this simple example
```python
class Model(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.fc1 = torch.nn.Linear(4, 2, bias=False)

    def forward(self, x):
        return x @ self.fc1.weight.transpose(0, 1)

with torch.device("lazy"):
    model = Model()

    x = torch.ones(4)
    out = model(x)
```
The call to `transpose` on the lazily initialized weight `fc1.weight` applies a view op on the functional tensor which only gets propagated to the functional tensor wrapper and not the base tensor in the storage. Thus, causing them to diverge.

To fix this behaviour, we need to reset the functional tensor's storage. To facilitate this, we add a `_unsafe_reset_storage` method to `FunctionalTensorWrapper` which clears away the old storage and view metas.

Porting over PR from https://github.com/pytorch/pytorch/pull/115235
Cherry-picked: 73c0035160e7b2c5772417bb7206b316bdf34044

CC: @bdhirsh @malfet 
