### PR TITLE
[OAT] toggle for forcing matmul precision matching

### DIFF
--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -97,7 +97,7 @@ def tuned_bmm(mat1, mat2, *, layout=None):
                 choices,
                 input_nodes=(mat1, mat2),
                 layout=layout,
-                **mm_options(config, k, layout),
+                **mm_options(config, m, n, k, layout),
             )
 
     return autotune_select_algorithm("bmm", choices, [mat1, mat2], layout)
@@ -120,7 +120,7 @@ def tuned_baddbmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
                 choices,
                 input_nodes=(inp, mat1, mat2),
                 layout=layout,
-                **mm_options(config, k, layout),
+                **mm_options(config, m, n, k, layout),
                 prefix_args=1,
                 epilogue_fn=addmm_epilogue(layout.dtype, alpha, beta),
             )

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -130,7 +130,7 @@ def tuned_mm(mat1, mat2, *, layout=None):
                 choices,
                 input_nodes=(mat1, mat2),
                 layout=layout,
-                **mm_options(config, k, layout),
+                **mm_options(config, m, n, k, layout),
             )
 
     if m * n != 0 and use_cutlass_template(layout):
@@ -171,7 +171,7 @@ def tuned_int_mm(mat1, mat2, *, layout=None):
                 choices,
                 input_nodes=(mat1, mat2),
                 layout=layout,
-                **mm_options(config, k, layout),
+                **mm_options(config, m, n, k, layout),
             )
     return autotune_select_algorithm("int_mm", choices, [mat1, mat2], layout)
 
@@ -231,7 +231,7 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
                 choices,
                 input_nodes=(inp_expanded, mat1, mat2),
                 layout=layout,
-                **mm_options(config, k, layout),
+                **mm_options(config, m, n, k, layout),
                 prefix_args=1,
                 epilogue_fn=addmm_epilogue(layout.dtype, alpha, beta),
             )
@@ -274,7 +274,7 @@ def tuned_mixed_mm(mat1, mat2, mat2_dtype):
             choices,
             input_nodes=(mat1, mat2),
             layout=layout,
-            **mm_options(config, k, layout, b_prologue_cast_type),
+            **mm_options(config, m, n, k, layout, b_prologue_cast_type),
         )
     return autotune_select_algorithm("mixed_mm", choices, [mat1, mat2], layout)
 
@@ -298,7 +298,7 @@ def tuned_fused_int_mm_mul(mat1, mat2, mat3, out_dtype, *, layout=None):
             choices,
             input_nodes=(mat1, mat2, mat3),
             layout=layout,
-            **dict(mm_options(config, k, layout), ACC_TYPE="tl.int32"),
+            **dict(mm_options(config, m, n, k, layout), ACC_TYPE="tl.int32"),
             suffix_args=1,
             epilogue_fn=V.ops.mul,
         )

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -8,6 +8,7 @@ import torch
 from torch._inductor.select_algorithm import realize_inputs
 from torch._inductor.virtualized import V
 
+from .. import config as inductor_config
 from ..utils import ceildiv as cdiv, next_power_of_2
 
 log = logging.getLogger(__name__)
@@ -159,7 +160,7 @@ def acc_type(dtype):
     return f"tl.{dtype}".replace("torch.", "")
 
 
-def mm_options(config, sym_k, layout, b_prologue_cast_type=None):
+def mm_options(config, sym_m, sym_n, sym_k, layout, b_prologue_cast_type=None):
     """
     Common options to matmul triton templates.
     """
@@ -168,10 +169,14 @@ def mm_options(config, sym_k, layout, b_prologue_cast_type=None):
         sympy.gcd(sym_k, config.kwargs["BLOCK_K"])
         == config.kwargs["BLOCK_K"]
     )
+    allow_tf32 = torch.backends.cuda.matmul.allow_tf32 and (
+        not inductor_config.force_same_precision
+        or ((sym_m % 16) == 0 and (sym_n % 16) == 0 and (sym_k % 8) == 0)
+    )
     return dict(
         GROUP_M=8,
         EVEN_K=even_k_symbolic,
-        ALLOW_TF32=torch.backends.cuda.matmul.allow_tf32,
+        ALLOW_TF32=allow_tf32,
         ACC_TYPE=acc_type(layout.dtype),
         B_PROLOGUE_CAST_TYPE=b_prologue_cast_type,
         num_stages=config.num_stages,

--- a/torch/_inductor/kernel/mm_plus_mm.py
+++ b/torch/_inductor/kernel/mm_plus_mm.py
@@ -231,7 +231,7 @@ def tuned_mm_plus_mm(mat1, mat2, mat3, mat4, *, layout=None):
                     choices,
                     input_nodes=(mat1, mat2, mat3, mat4),
                     layout=layout1,
-                    **mm_options(config, k1, layout1),
+                    **mm_options(config, m1, n1, k1, layout1),
                 )
 
     return autotune_select_algorithm(

--- a/torch/_inductor/kernel/unpack_mixed_mm.py
+++ b/torch/_inductor/kernel/unpack_mixed_mm.py
@@ -77,6 +77,6 @@ def tuned_uint4x2_mixed_mm(mat1, mat2, mat2_mm_shape, mat2_dtype):
             choices,
             input_nodes=(mat1, mat2),
             layout=layout,
-            **mm_options(config, k, layout, b_prologue_cast_type),
+            **mm_options(config, m, n, k, layout, b_prologue_cast_type),
         )
     return autotune_select_algorithm("uint4x2_mixed_mm", choices, [mat1, mat2], layout)


### PR DESCRIPTION
Summary: Add a toggle to inductor config that will force matmul precision dtypes to match between cublas and triton backends for addmm, bmm, and mm operations.

Test Plan: CI + model launches

Reviewed By: jansel

Differential Revision: D51442001




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler