### PR TITLE
[Export] Extract default value of strict mode as config

### DIFF
--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -35,6 +35,7 @@ from torch._functorch.eager_transforms import functionalize
 from torch._guards import detect_fake_mode
 from torch._ops import OpOverload
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+from torch.export import config
 from torch.export.exported_program import (
     ExportedProgram,
     ModuleCallEntry,
@@ -85,7 +86,7 @@ from .passes.replace_view_ops_with_view_copy_ops_pass import (
     ReplaceViewOpsWithViewCopyOpsPass,
 )
 from .wrappers import _wrap_submodules
-from torch._inductor import config
+from torch._inductor import config as inductor_config
 
 
 def export__RC__(
@@ -94,7 +95,7 @@ def export__RC__(
     kwargs: Optional[Dict[str, Any]] = None,
     *,
     dynamic_shapes: Optional[Union[Dict[str, Any], Tuple[Any]]] = None,
-    strict: bool = True,
+    strict: bool = config.strict_mode_default,
     preserve_module_call_signature: Tuple[str, ...] = (),
 ) -> ExportedProgram:
     """
@@ -245,7 +246,7 @@ def export(
     kwargs: Optional[Dict[str, Any]] = None,
     constraints: Optional[List[Constraint]] = None,
     *,
-    strict: bool = True,
+    strict: bool = config.strict_mode_default,
     preserve_module_call_signature: Tuple[str, ...] = (),
 ) -> ExportedProgram:
     from torch.export._trace import _export
@@ -358,7 +359,7 @@ def _export(
     kwargs: Optional[Dict[str, Any]] = None,
     constraints: Optional[List[Constraint]] = None,
     *,
-    strict: bool = True,
+    strict: bool = config.strict_mode_default,
     preserve_module_call_signature: Tuple[str, ...] = (),
 ) -> ExportedProgram:
     """
@@ -516,7 +517,7 @@ def aot_compile(
     if constraints is None:
         constraints = _process_dynamic_shapes(f, args, kwargs, dynamic_shapes)
 
-    if config.is_predispatch:
+    if inductor_config.is_predispatch:
         gm = capture_pre_autograd_graph(f, args, kwargs, constraints)
     else:
         # We want to export to Torch IR here to utilize the pre_grad passes in

--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -36,6 +36,8 @@ from torch.utils._pytree import (
     UnflattenFunc,
 )
 
+from . import config
+
 if TYPE_CHECKING:
     # Import the following modules during type checking to enable code intelligence features,
     # Do not import unconditionally, as they import sympy and importing sympy is very slow
@@ -74,7 +76,7 @@ def export(
     *,
     constraints: Optional[List[Constraint]] = None,
     dynamic_shapes: Optional[Union[Dict[str, Any], Tuple[Any]]] = None,
-    strict: bool = True,
+    strict: bool = config.strict_mode_default,
     preserve_module_call_signature: Tuple[str, ...] = (),
 ) -> ExportedProgram:
     """

--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -61,6 +61,7 @@ __all__ = [
 ]
 
 
+from . import config
 from .dynamic_shapes import Constraint, Dim, dims, dynamic_dim
 from .exported_program import ExportedProgram, ModuleCallEntry, ModuleCallSignature
 from .graph_signature import ExportBackwardSignature, ExportGraphSignature

--- a/torch/export/config.py
+++ b/torch/export/config.py
@@ -1,0 +1,3 @@
+# to configure export API env
+
+strict_mode_default = True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #115328
* __->__ #115327

Summary:
Strict mode is currently an argument of export API (serveral places)
and the default value is True, which is explicitly indicated in
the API signature. Shortcomings:
1. Maintenance issue: default values are scattered in external/
   internal places.
2. Dev test issue: we have to replicate the test cases for non-strict
   mode from the strict mode tests, which introduces code redundance and
   test case divergence.

To address it, config is a handy choice. It's also the choice that
dynamo choose and the test dev is easier to be supported by swtiching to
a different config treatment.