### PR TITLE
[6/N] Fixes clang-tidy warnings in c10/{core,util}/*.h

### DIFF
--- a/c10/core/Allocator.h
+++ b/c10/core/Allocator.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 
 #include <c10/core/Device.h>
+#include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
 #include <c10/util/ThreadLocalDebugInfo.h>
 #include <c10/util/UniqueVoidPtr.h>

--- a/c10/core/CopyBytes.h
+++ b/c10/core/CopyBytes.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <cstddef>
 #include <c10/core/Device.h>
 #include <c10/core/DeviceType.h>
 #include <c10/macros/Macros.h>
+#include <cstddef>
 
 namespace c10 {
 

--- a/c10/core/CopyBytes.h
+++ b/c10/core/CopyBytes.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <cstddef>
 #include <c10/core/Device.h>
+#include <c10/core/DeviceType.h>
+#include <c10/macros/Macros.h>
 
 namespace c10 {
 

--- a/c10/core/DefaultTensorOptions.h
+++ b/c10/core/DefaultTensorOptions.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <c10/core/Backend.h>
 #include <c10/core/Device.h>
+#include <c10/core/DeviceType.h>
 #include <c10/core/Layout.h>
 #include <c10/core/ScalarType.h>
 #include <c10/util/typeid.h>

--- a/c10/core/Device.h
+++ b/c10/core/Device.h
@@ -5,6 +5,7 @@
 #include <c10/util/Exception.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <iosfwd>
 #include <string>

--- a/c10/core/DeviceArray.h
+++ b/c10/core/DeviceArray.h
@@ -1,5 +1,5 @@
-#include <cstddef>
 #include <c10/core/Allocator.h>
+#include <cstddef>
 
 namespace c10 {
 

--- a/c10/core/DeviceArray.h
+++ b/c10/core/DeviceArray.h
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <c10/core/Allocator.h>
 
 namespace c10 {

--- a/c10/core/PyHandleCache.h
+++ b/c10/core/PyHandleCache.h
@@ -36,7 +36,7 @@ namespace c10 {
 // not be a way to conveniently index based on the object.)
 class PyHandleCache {
  public:
-  PyHandleCache() : pyinterpreter_(nullptr), data_(nullptr) {}
+  PyHandleCache() : pyinterpreter_(nullptr) {}
 
   // Attempt to fetch the pointer from the cache, if the PyInterpreter
   // matches.  If it doesn't exist, or the cache entry is not valid,
@@ -69,7 +69,7 @@ class PyHandleCache {
 
  private:
   mutable std::atomic<impl::PyInterpreter*> pyinterpreter_;
-  mutable PyObject* data_;
+  mutable PyObject* data_{nullptr};
 };
 
 } // namespace c10

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -149,7 +149,7 @@ struct C10_API TensorOptions {
   /// See NOTE [ TensorOptions Constructors ] on why this is templatized.
   template <
       typename T,
-      typename = std::enable_if_t<std::is_same<std::decay_t<T>, Device>::value>>
+      typename = std::enable_if_t<std::is_same_v<std::decay_t<T>, Device>>>
   /* implicit */ TensorOptions(T&& device) : TensorOptions() {
     this->set_device(std::forward<T>(device));
   }
@@ -165,7 +165,7 @@ struct C10_API TensorOptions {
   template <
       typename... Args,
       typename =
-          std::enable_if_t<std::is_constructible<Device, Args&&...>::value>>
+          std::enable_if_t<std::is_constructible_v<Device, Args&&...>>>
   /* implicit */ TensorOptions(Args&&... args)
       : TensorOptions(Device(std::forward<Args>(args)...)) {}
 

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -164,8 +164,7 @@ struct C10_API TensorOptions {
   ///     constructors too.
   template <
       typename... Args,
-      typename =
-          std::enable_if_t<std::is_constructible_v<Device, Args&&...>>>
+      typename = std::enable_if_t<std::is_constructible_v<Device, Args&&...>>>
   /* implicit */ TensorOptions(Args&&... args)
       : TensorOptions(Device(std::forward<Args>(args)...)) {}
 

--- a/c10/core/impl/InlineEvent.h
+++ b/c10/core/impl/InlineEvent.h
@@ -23,7 +23,7 @@ struct InlineEvent final {
   // Move constructor and move assignment operator
   InlineEvent(InlineEvent&& other) noexcept
       : event_(other.event_),
-        backend_(std::move(other).backend_),
+        backend_(std::move(other.backend_)),
         device_type_(other.device_type_),
         device_index_(other.device_index_),
         flag_(other.flag_),
@@ -31,13 +31,13 @@ struct InlineEvent final {
     other.event_ = nullptr;
   }
   InlineEvent& operator=(InlineEvent&& other) noexcept {
-    swap(std::move(other));
+    swap(other);
     return *this;
   }
 
-  void swap(InlineEvent&& other) noexcept {
+  void swap(InlineEvent& other) noexcept {
     std::swap(event_, other.event_);
-    std::swap(backend_, std::move(other).backend_);
+    std::swap(backend_, other.backend_);
     std::swap(device_type_, other.device_type_);
     std::swap(device_index_, other.device_index_);
     std::swap(flag_, other.flag_);

--- a/c10/core/impl/InlineEvent.h
+++ b/c10/core/impl/InlineEvent.h
@@ -22,17 +22,22 @@ struct InlineEvent final {
 
   // Move constructor and move assignment operator
   InlineEvent(InlineEvent&& other) noexcept
-      : InlineEvent(other.device_type_, other.flag_) {
-    swap(std::move(other));
+      : event_(other.event_),
+        backend_(std::move(other).backend_),
+        device_type_(other.device_type_),
+        device_index_(other.device_index_),
+        flag_(other.flag_),
+        was_marked_for_recording_(other.was_marked_for_recording_) {
+    other.event_ = nullptr;
   }
   InlineEvent& operator=(InlineEvent&& other) noexcept {
     swap(std::move(other));
     return *this;
   }
 
-  void swap(InlineEvent&& other) {
+  void swap(InlineEvent&& other) noexcept {
     std::swap(event_, other.event_);
-    std::swap(backend_, other.backend_);
+    std::swap(backend_, std::move(other).backend_);
     std::swap(device_type_, other.device_type_);
     std::swap(device_index_, other.device_index_);
     std::swap(flag_, other.flag_);

--- a/c10/core/impl/LocalDispatchKeySet.h
+++ b/c10/core/impl/LocalDispatchKeySet.h
@@ -51,7 +51,7 @@ struct C10_API PODLocalDispatchKeySet {
   }
 };
 static_assert(
-    std::is_trivial<PODLocalDispatchKeySet>::value,
+    std::is_trivial_v<PODLocalDispatchKeySet>,
     "PODLocalDispatchKeySet must be a POD type.");
 
 struct C10_API LocalDispatchKeySet {

--- a/c10/core/impl/SizesAndStrides.h
+++ b/c10/core/impl/SizesAndStrides.h
@@ -30,7 +30,7 @@ class C10_API SizesAndStrides {
   using strides_iterator = int64_t*;
   using strides_const_iterator = const int64_t*;
 
-  SizesAndStrides() : size_(1) {
+  SizesAndStrides() {
     size_at_unchecked(0) = 0;
     stride_at_unchecked(0) = 1;
   }
@@ -297,7 +297,7 @@ class C10_API SizesAndStrides {
     memcpy(outOfLineStorage_, rhs.outOfLineStorage_, storageBytes(rhs.size_));
   }
 
-  size_t size_;
+  size_t size_{1};
   union {
     int64_t* outOfLineStorage_;
     int64_t inlineStorage_[C10_SIZES_AND_STRIDES_MAX_INLINE_SIZE * 2]{};

--- a/c10/core/thread_pool.h
+++ b/c10/core/thread_pool.h
@@ -11,11 +11,6 @@
 #include <c10/util/numa.h>
 #include <c10/util/thread_name.h>
 
-C10_CLANG_DIAGNOSTIC_PUSH()
-#if C10_CLANG_HAS_WARNING("-Wshorten-64-to-32")
-C10_CLANG_DIAGNOSTIC_IGNORE("-Wshorten-64-to-32")
-#endif
-
 namespace c10 {
 
 class C10_API TaskThreadPoolBase {
@@ -43,7 +38,9 @@ class C10_API ThreadPool : public c10::TaskThreadPoolBase {
  protected:
   struct task_element_t {
     bool run_with_id;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
     const std::function<void()> no_id;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
     const std::function<void(std::size_t)> with_id;
 
     explicit task_element_t(std::function<void()> f)
@@ -117,5 +114,3 @@ C10_DECLARE_SHARED_REGISTRY(
     bool);
 
 } // namespace c10
-
-C10_CLANG_DIAGNOSTIC_POP()

--- a/c10/util/C++17.h
+++ b/c10/util/C++17.h
@@ -65,10 +65,10 @@ constexpr bool is_pod_v = is_pod<T>::value;
 namespace guts {
 
 template <typename Base, typename Child, typename... Args>
-typename std::enable_if<
-    !std::is_array<Base>::value && !std::is_array<Child>::value &&
-        std::is_base_of<Base, Child>::value,
-    std::unique_ptr<Base>>::type
+std::enable_if_t<
+    !std::is_array_v<Base> && !std::is_array_v<Child> &&
+        std::is_base_of_v<Base, Child>,
+    std::unique_ptr<Base>>
 make_unique_base(Args&&... args) {
   return std::unique_ptr<Base>(new Child(std::forward<Args>(args)...));
 }
@@ -188,17 +188,17 @@ CUDA_HOST_DEVICE constexpr decltype(auto) apply(F&& f, Tuple&& t) {
 #undef CUDA_HOST_DEVICE
 
 template <typename Functor, typename... Args>
-typename std::enable_if<
-    std::is_member_pointer<typename std::decay<Functor>::type>::value,
-    typename c10::invoke_result_t<Functor, Args...>>::type
+std::enable_if_t<
+    std::is_member_pointer_v<std::decay_t<Functor>>,
+    typename c10::invoke_result_t<Functor, Args...>>
 invoke(Functor&& f, Args&&... args) {
   return std::mem_fn(std::forward<Functor>(f))(std::forward<Args>(args)...);
 }
 
 template <typename Functor, typename... Args>
-typename std::enable_if<
-    !std::is_member_pointer<typename std::decay<Functor>::type>::value,
-    typename c10::invoke_result_t<Functor, Args...>>::type
+std::enable_if_t<
+    !std::is_member_pointer_v<std::decay_t<Functor>>,
+    typename c10::invoke_result_t<Functor, Args...>>
 invoke(Functor&& f, Args&&... args) {
   return std::forward<Functor>(f)(std::forward<Args>(args)...);
 }

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -438,16 +438,13 @@ C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-float-conversion")
 // `error: comparison of constant '255' with boolean expression is always false`
 // for `f > limit::max()` below
 template <typename To, typename From>
-std::enable_if_t<std::is_same_v<From, bool>, bool>overflows(
-    From /*f*/) {
+std::enable_if_t<std::is_same_v<From, bool>, bool> overflows(From /*f*/) {
   return false;
 }
 
 // skip isnan and isinf check for integral types
 template <typename To, typename From>
-std::enable_if_t<
-    std::is_integral_v<From> && !std::is_same_v<From, bool>,
-    bool>
+std::enable_if_t<std::is_integral_v<From> && !std::is_same_v<From, bool>, bool>
 overflows(From f) {
   using limit = std::numeric_limits<typename scalar_value_type<To>::type>;
   if (!limit::is_signed && std::numeric_limits<From>::is_signed) {
@@ -462,8 +459,7 @@ overflows(From f) {
 }
 
 template <typename To, typename From>
-std::enable_if_t<std::is_floating_point_v<From>, bool>
-overflows(From f) {
+std::enable_if_t<std::is_floating_point_v<From>, bool> overflows(From f) {
   using limit = std::numeric_limits<typename scalar_value_type<To>::type>;
   if (limit::has_infinity && std::isinf(static_cast<double>(f))) {
     return false;
@@ -481,7 +477,7 @@ C10_CLANG_DIAGNOSTIC_POP()
 #endif
 
 template <typename To, typename From>
-std::enable_if_t<is_complex<From>::value, bool>overflows(From f) {
+std::enable_if_t<is_complex<From>::value, bool> overflows(From f) {
   // casts from complex to real are considered to overflow if the
   // imaginary component is non-zero
   if (!is_complex<To>::value && f.imag() != 0) {

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -438,16 +438,16 @@ C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-float-conversion")
 // `error: comparison of constant '255' with boolean expression is always false`
 // for `f > limit::max()` below
 template <typename To, typename From>
-typename std::enable_if<std::is_same<From, bool>::value, bool>::type overflows(
+std::enable_if_t<std::is_same_v<From, bool>, bool>overflows(
     From /*f*/) {
   return false;
 }
 
 // skip isnan and isinf check for integral types
 template <typename To, typename From>
-typename std::enable_if<
-    std::is_integral<From>::value && !std::is_same<From, bool>::value,
-    bool>::type
+std::enable_if_t<
+    std::is_integral_v<From> && !std::is_same_v<From, bool>,
+    bool>
 overflows(From f) {
   using limit = std::numeric_limits<typename scalar_value_type<To>::type>;
   if (!limit::is_signed && std::numeric_limits<From>::is_signed) {
@@ -462,7 +462,7 @@ overflows(From f) {
 }
 
 template <typename To, typename From>
-typename std::enable_if<std::is_floating_point<From>::value, bool>::type
+std::enable_if_t<std::is_floating_point_v<From>, bool>
 overflows(From f) {
   using limit = std::numeric_limits<typename scalar_value_type<To>::type>;
   if (limit::has_infinity && std::isinf(static_cast<double>(f))) {
@@ -481,7 +481,7 @@ C10_CLANG_DIAGNOSTIC_POP()
 #endif
 
 template <typename To, typename From>
-typename std::enable_if<is_complex<From>::value, bool>::type overflows(From f) {
+std::enable_if_t<is_complex<From>::value, bool>overflows(From f) {
   // casts from complex to real are considered to overflow if the
   // imaginary component is non-zero
   if (!is_complex<To>::value && f.imag() != 0) {

--- a/c10/util/TypeTraits.h
+++ b/c10/util/TypeTraits.h
@@ -101,7 +101,7 @@ namespace detail {
 template <class LambdaType, class FuncType>
 struct is_stateless_lambda__ final {
   static_assert(
-      !std::is_same<LambdaType, LambdaType>::value,
+      !std::is_same_v<LambdaType, LambdaType>,
       "Base case shouldn't be hit");
 };
 // implementation idea: According to the C++ standard, stateless lambdas are
@@ -137,7 +137,7 @@ template <template <class> class C>
 struct is_type_condition<
     C,
     std::enable_if_t<
-        std::is_same<bool, std::remove_cv_t<decltype(C<int>::value)>>::value>>
+        std::is_same_v<bool, std::remove_cv_t<decltype(C<int>::value)>>>>
     : std::true_type {};
 
 /**

--- a/c10/util/bit_cast.h
+++ b/c10/util/bit_cast.h
@@ -13,13 +13,13 @@ namespace c10 {
 // information as well as the source of our implementations.
 template <class To, class From>
 std::enable_if_t<
-    sizeof(To) == sizeof(From) && std::is_trivially_copyable<From>::value &&
-        std::is_trivially_copyable<To>::value,
+    sizeof(To) == sizeof(From) && std::is_trivially_copyable_v<From> &&
+        std::is_trivially_copyable_v<To>,
     To>
 // constexpr support needs compiler magic
 bit_cast(const From& src) noexcept {
   static_assert(
-      std::is_trivially_constructible<To>::value,
+      std::is_trivially_constructible_v<To>,
       "This implementation additionally requires "
       "destination type to be trivially constructible");
 

--- a/c10/util/complex.h
+++ b/c10/util/complex.h
@@ -168,13 +168,11 @@ struct alignas(sizeof(T) * 2) complex {
   // c10::complex<double>
   template <typename U = T>
   C10_HOST_DEVICE explicit constexpr complex(
-      const std::enable_if_t<std::is_same_v<U, float>, complex<double>>&
-          other)
+      const std::enable_if_t<std::is_same_v<U, float>, complex<double>>& other)
       : real_(other.real_), imag_(other.imag_) {}
   template <typename U = T>
   C10_HOST_DEVICE constexpr complex(
-      const std::enable_if_t<std::is_same_v<U, double>, complex<float>>&
-          other)
+      const std::enable_if_t<std::is_same_v<U, double>, complex<float>>& other)
       : real_(other.real_), imag_(other.imag_) {}
 
   constexpr complex<T>& operator=(T re) {

--- a/c10/util/complex.h
+++ b/c10/util/complex.h
@@ -168,12 +168,12 @@ struct alignas(sizeof(T) * 2) complex {
   // c10::complex<double>
   template <typename U = T>
   C10_HOST_DEVICE explicit constexpr complex(
-      const std::enable_if_t<std::is_same<U, float>::value, complex<double>>&
+      const std::enable_if_t<std::is_same_v<U, float>, complex<double>>&
           other)
       : real_(other.real_), imag_(other.imag_) {}
   template <typename U = T>
   C10_HOST_DEVICE constexpr complex(
-      const std::enable_if_t<std::is_same<U, double>::value, complex<float>>&
+      const std::enable_if_t<std::is_same_v<U, double>, complex<float>>&
           other)
       : real_(other.real_), imag_(other.imag_) {}
 
@@ -332,19 +332,19 @@ struct alignas(sizeof(T) * 2) complex {
 
 namespace complex_literals {
 
-constexpr complex<float> operator"" _if(long double imag) {
+constexpr complex<float> operator""_if(long double imag) {
   return complex<float>(0.0f, static_cast<float>(imag));
 }
 
-constexpr complex<double> operator"" _id(long double imag) {
+constexpr complex<double> operator""_id(long double imag) {
   return complex<double>(0.0, static_cast<double>(imag));
 }
 
-constexpr complex<float> operator"" _if(unsigned long long imag) {
+constexpr complex<float> operator""_if(unsigned long long imag) {
   return complex<float>(0.0f, static_cast<float>(imag));
 }
 
-constexpr complex<double> operator"" _id(unsigned long long imag) {
+constexpr complex<double> operator""_id(unsigned long long imag) {
   return complex<double>(0.0, static_cast<double>(imag));
 }
 

--- a/c10/util/irange.h
+++ b/c10/util/irange.h
@@ -17,7 +17,7 @@ namespace detail {
 template <
     typename I,
     bool one_sided = false,
-    typename std::enable_if<std::is_integral<I>::value, int>::type = 0>
+    std::enable_if_t<std::is_integral_v<I>, int> = 0>
 struct integer_iterator {
   using iterator_category = std::input_iterator_tag;
   using value_type = I;
@@ -78,7 +78,7 @@ struct integer_iterator {
 template <
     typename I,
     bool one_sided = false,
-    typename std::enable_if<std::is_integral<I>::value, bool>::type = true>
+    std::enable_if_t<std::is_integral_v<I>, bool> = true>
 struct integer_range {
  public:
   integer_range(I begin, I end) : begin_(begin), end_(end) {}
@@ -102,9 +102,9 @@ struct integer_range {
 template <
     typename Integer1,
     typename Integer2,
-    typename std::enable_if<std::is_integral<Integer1>::value, bool>::type =
+    std::enable_if_t<std::is_integral_v<Integer1>, bool> =
         true,
-    typename std::enable_if<std::is_integral<Integer2>::value, bool>::type =
+    std::enable_if_t<std::is_integral_v<Integer2>, bool> =
         true>
 integer_range<Integer2> irange(Integer1 begin, Integer2 end) {
   // If end<=begin then the range is empty; we can achieve this effect by
@@ -118,7 +118,7 @@ integer_range<Integer2> irange(Integer1 begin, Integer2 end) {
 /// If end<=begin, then the range is empty
 template <
     typename Integer,
-    typename std::enable_if<std::is_integral<Integer>::value, bool>::type =
+    std::enable_if_t<std::is_integral_v<Integer>, bool> =
         true>
 integer_range<Integer, true> irange(Integer end) {
   return {Integer(), end};

--- a/c10/util/irange.h
+++ b/c10/util/irange.h
@@ -102,10 +102,8 @@ struct integer_range {
 template <
     typename Integer1,
     typename Integer2,
-    std::enable_if_t<std::is_integral_v<Integer1>, bool> =
-        true,
-    std::enable_if_t<std::is_integral_v<Integer2>, bool> =
-        true>
+    std::enable_if_t<std::is_integral_v<Integer1>, bool> = true,
+    std::enable_if_t<std::is_integral_v<Integer2>, bool> = true>
 integer_range<Integer2> irange(Integer1 begin, Integer2 end) {
   // If end<=begin then the range is empty; we can achieve this effect by
   // choosing the larger of {begin, end} as the loop terminator
@@ -118,8 +116,7 @@ integer_range<Integer2> irange(Integer1 begin, Integer2 end) {
 /// If end<=begin, then the range is empty
 template <
     typename Integer,
-    std::enable_if_t<std::is_integral_v<Integer>, bool> =
-        true>
+    std::enable_if_t<std::is_integral_v<Integer>, bool> = true>
 integer_range<Integer, true> irange(Integer end) {
   return {Integer(), end};
 }

--- a/c10/util/string_view.h
+++ b/c10/util/string_view.h
@@ -40,7 +40,7 @@ class basic_string_view final {
 
   static constexpr size_type npos = size_type(-1);
 
-  constexpr basic_string_view() noexcept : begin_(nullptr), size_(0) {}
+  constexpr basic_string_view() noexcept : begin_(nullptr) {}
 
   explicit constexpr basic_string_view(const_pointer str, size_type count)
       : begin_(str), size_(count) {}
@@ -580,7 +580,7 @@ inline std::basic_ostream<CharT>& operator<<(
 template <class CharT>
 constexpr inline void swap(
     basic_string_view<CharT>& lhs,
-    basic_string_view<CharT>& rhs) {
+    basic_string_view<CharT>& rhs) noexcept {
   lhs.swap(rhs);
 }
 

--- a/c10/util/typeid.h
+++ b/c10/util/typeid.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <atomic>
 #include <cstdint>
 #include <memory>
@@ -300,7 +301,7 @@ class _Uninitialized final {};
 //
 
 // item sizes for TypeMeta::itemsize() fast path
-static constexpr uint8_t scalarTypeItemSizes[NumScalarTypes] = {
+static constexpr std::array<uint8_t, NumScalarTypes> scalarTypeItemSizes = {
 #define SCALAR_TYPE_SIZE(T, name) sizeof(T),
     AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS(SCALAR_TYPE_SIZE)
 #undef SCALAR_TYPE_SIZE

--- a/c10/util/typeid.h
+++ b/c10/util/typeid.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <atomic>
-#include <cstdlib>
+#include <cstdint>
 #include <memory>
 #include <mutex>
+#include <ostream>
+#include <string>
 #include <type_traits>
 #include <vector>
 
@@ -12,6 +14,7 @@
 #include <c10/util/IdWrapper.h>
 #include <c10/util/TypeIndex.h>
 #include <c10/util/TypeTraits.h>
+#include <c10/util/string_view.h>
 
 #include <c10/core/ScalarType.h>
 #include <c10/util/irange.h>
@@ -175,19 +178,19 @@ inline void _PlacementNewNotDefault(void* /*ptr*/, size_t /*n*/) {
 
 template <
     typename T,
-    std::enable_if_t<std::is_default_constructible<T>::value>* = nullptr>
+    std::enable_if_t<std::is_default_constructible_v<T>>* = nullptr>
 inline constexpr TypeMetaData::PlacementNew* _PickPlacementNew() {
-  return (c10::guts::is_fundamental<T>::value || std::is_pointer<T>::value)
+  return (c10::guts::is_fundamental<T>::value || std::is_pointer_v<T>)
       ? nullptr
       : &_PlacementNew<T>;
 }
 
 template <
     typename T,
-    std::enable_if_t<!std::is_default_constructible<T>::value>* = nullptr>
+    std::enable_if_t<!std::is_default_constructible_v<T>>* = nullptr>
 inline constexpr TypeMetaData::PlacementNew* _PickPlacementNew() {
   static_assert(
-      !c10::guts::is_fundamental<T>::value && !std::is_pointer<T>::value,
+      !c10::guts::is_fundamental<T>::value && !std::is_pointer_v<T>,
       "this should have picked the other SFINAE case");
   return &_PlacementNewNotDefault<T>;
 }
@@ -206,14 +209,14 @@ inline void* _NewNotDefault() {
 
 template <
     typename T,
-    std::enable_if_t<std::is_default_constructible<T>::value>* = nullptr>
+    std::enable_if_t<std::is_default_constructible_v<T>>* = nullptr>
 inline constexpr TypeMetaData::New* _PickNew() {
   return &_New<T>;
 }
 
 template <
     typename T,
-    std::enable_if_t<!std::is_default_constructible<T>::value>* = nullptr>
+    std::enable_if_t<!std::is_default_constructible_v<T>>* = nullptr>
 inline constexpr TypeMetaData::New* _PickNew() {
   return &_NewNotDefault<T>;
 }
@@ -240,21 +243,19 @@ inline void _CopyNotAllowed(const void* /*src*/, void* /*dst*/, size_t /*n*/) {
       " does not allow assignment.");
 }
 
-template <
-    typename T,
-    std::enable_if_t<std::is_copy_assignable<T>::value>* = nullptr>
+template <typename T, std::enable_if_t<std::is_copy_assignable_v<T>>* = nullptr>
 inline constexpr TypeMetaData::Copy* _PickCopy() {
-  return (c10::guts::is_fundamental<T>::value || std::is_pointer<T>::value)
+  return (c10::guts::is_fundamental<T>::value || std::is_pointer_v<T>)
       ? nullptr
       : &_Copy<T>;
 }
 
 template <
     typename T,
-    std::enable_if_t<!std::is_copy_assignable<T>::value>* = nullptr>
+    std::enable_if_t<!std::is_copy_assignable_v<T>>* = nullptr>
 inline constexpr TypeMetaData::Copy* _PickCopy() {
   static_assert(
-      !c10::guts::is_fundamental<T>::value && !std::is_pointer<T>::value,
+      !c10::guts::is_fundamental<T>::value && !std::is_pointer_v<T>,
       "this should have picked the other SFINAE case");
   return &_CopyNotAllowed<T>;
 }
@@ -272,7 +273,7 @@ inline void _PlacementDelete(void* ptr, size_t n) {
 
 template <typename T>
 inline constexpr TypeMetaData::PlacementDelete* _PickPlacementDelete() {
-  return (c10::guts::is_fundamental<T>::value || std::is_pointer<T>::value)
+  return (c10::guts::is_fundamental<T>::value || std::is_pointer_v<T>)
       ? nullptr
       : &_PlacementDelete<T>;
 }
@@ -693,7 +694,7 @@ template <class T>
 class _guard_long_unique_dummy final {};
 template <class T>
 using _guard_long_unique = std::conditional_t<
-    std::is_same<long, int32_t>::value || std::is_same<long, int64_t>::value,
+    std::is_same_v<long, int32_t> || std::is_same_v<long, int64_t>,
     _guard_long_unique_dummy<T>,
     T>;
 } // namespace detail


### PR DESCRIPTION
This PR continues to fix clang-tidy warnings for headers in c10/core and c10/util.