### PR TITLE
[Triton] Replace triton.runtime.jit.get_cuda_stream with torch.cuda.c…

### DIFF
--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -19,7 +19,7 @@ import torch
 import torch.autograd.profiler as autograd_profiler
 from torch._dynamo.device_interface import get_interface_for_device
 from torch._dynamo.utils import dynamo_timed
-from torch.utils._triton import has_triton, has_triton_package
+from torch.utils._triton import has_triton_package
 
 from . import config
 from .codecache import cache_dir, CudaKernelParamCache
@@ -49,11 +49,6 @@ else:
     triton = None
     KernelInterface = object
     OutOfResources = object
-
-if has_triton():
-    from triton.runtime.jit import get_cuda_stream
-else:
-    get_cuda_stream = None
 
 
 _NUM_THREADS_PER_WARP = 32
@@ -371,7 +366,7 @@ class CachingAutotuner(KernelInterface):
             )
             return float("inf")
 
-        stream = get_cuda_stream(torch.cuda.current_device())
+        stream = torch.cuda.current_stream(torch.cuda.current_device()).cuda_stream
 
         def kernel_call():
             if launcher.config.pre_hook is not None:

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -366,7 +366,9 @@ class CachingAutotuner(KernelInterface):
             )
             return float("inf")
 
-        stream = torch.cuda.current_stream(torch.cuda.current_device()).cuda_stream
+        from torch._C import _cuda_getCurrentRawStream as get_cuda_stream
+
+        stream = get_cuda_stream(torch.cuda.current_device())
 
         def kernel_call():
             if launcher.config.pre_hook is not None:


### PR DESCRIPTION
triton.runtime.jit.get_cuda_stream was removed in https://github.com/openai/triton/pull/2756


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler