### PR TITLE
[DTensor] Add DTensor experimental op for LayerNorm backward sharding rule propogation

### DIFF
--- a/torch/distributed/_tensor/ops/experimental_ops.py
+++ b/torch/distributed/_tensor/ops/experimental_ops.py
@@ -7,7 +7,12 @@ import numpy as np
 import torch
 from torch.distributed._tensor.op_schema import OpSchema, OutputSharding
 from torch.distributed._tensor.ops.utils import register_prop_rule
-from torch.distributed._tensor.placement_types import DTensorSpec, TensorMeta
+from torch.distributed._tensor.placement_types import (
+    _Partial,
+    DTensorSpec,
+    Replicate,
+    TensorMeta,
+)
 
 aten = torch.ops.aten
 
@@ -88,3 +93,51 @@ def nll_loss_backward_rules(op_schema: OpSchema) -> OutputSharding:
     input_spec = op_schema.args_schema[1]
     assert isinstance(input_spec, DTensorSpec)
     return OutputSharding(input_spec)
+
+
+@register_prop_rule(aten.native_layer_norm_backward.default)
+def _prop_native_layer_norm_backward(op_schema: OpSchema) -> OutputSharding:
+    (
+        grad,
+        input,
+        normalized_shape,
+        result1,
+        result2,
+        weight,
+        bias,
+        grad_input_mask,
+    ) = op_schema.args_schema
+    assert isinstance(grad, DTensorSpec)
+    assert isinstance(grad_input_mask, (list, tuple))
+    if weight is not None:
+        assert isinstance(weight, DTensorSpec)
+        assert all(isinstance(s, Replicate) for s in weight.placements)
+    if bias is not None:
+        assert isinstance(bias, DTensorSpec)
+        assert all(isinstance(s, Replicate) for s in bias.placements)
+
+    weight_grad = (
+        DTensorSpec(
+            mesh=weight.mesh,
+            placements=tuple([_Partial()] * weight.mesh.ndim),
+        )
+        if weight
+        else None
+    )
+    bias_grad = (
+        DTensorSpec(
+            mesh=bias.mesh,
+            placements=tuple([_Partial()] * bias.mesh.ndim),
+        )
+        if bias
+        else None
+    )
+    return OutputSharding(
+        # NOTE: type errors below are legit. This is because DTensor currently
+        # doesn't support Optional return values. Need to be fixed in DTensor repo.
+        output_spec=(
+            grad if grad_input_mask[0] else None,
+            weight_grad if grad_input_mask[1] else None,
+            bias_grad if grad_input_mask[2] else None,
+        ),
+    )


### PR DESCRIPTION
Summary: This diff is only for prototype to unblock the TP work. PyTorch distributed team is working on a more generic backward op for `aten.layer_norm`. Will remove this op from the experimental file once it is ready.

Test Plan:
**Local Test**:
Accuracy:
- Dtensor + Checkpoint: first run loss: P884569822 (on-par with baseline: P884213363)
- 2nd by loading saved checkpoint: P884583429 (on-par with baseline: P884271869)

Trace:
- Collective functions are inserted automatically.
- Example: https://fburl.com/perfdoctor/l567ww1x

**MAST Test**:
With: trainer = 128, batch_size=512
- NE on-par:
(see: 4441_ep_bs512_2fsdp_tp_sp_dtensor)
 {F1155318138}

Differential Revision: D51490868




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @kiukchung @lucasllc