### PR TITLE
[EZ] [CD] Enable Triton 3.12 conda builds

### DIFF
--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -182,7 +182,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py_vers: [ "3.8", "3.9", "3.10", "3.11" ]
+        py_vers: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
     timeout-minutes: 40
     env:
       DOCKER_IMAGE: pytorch/conda-builder:cpu


### PR DESCRIPTION
Currently there is a chicken and egg problem with enabling triton builds for the platform, as package depends on `torch`, so I can only submit this change few days after https://github.com/pytorch/pytorch/pull/114819
