### PR TITLE
[ROCm] Add minimal inductor test to rocm-test workflow

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -195,4 +195,4 @@ jobs:
       build-environment: linux-focal-rocm5.7-py3.8
       docker-image: ${{ needs.linux-focal-rocm5_7-py3_8-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-rocm5_7-py3_8-build.outputs.test-matrix }}
-      tests-to-include: "test_nn test_torch test_cuda test_ops test_unary_ufuncs test_binary_ufuncs test_autograd"
+      tests-to-include: "test_nn test_torch test_cuda test_ops test_unary_ufuncs test_binary_ufuncs test_autograd inductor/test_torchinductor"


### PR DESCRIPTION
Adds the `inductor/test_torchinductor` to tests-to-include so we can have some PR-level test coverage for inductor tests on ROCm. This should help catch issues before merging (e.g. https://github.com/pytorch/pytorch/pull/114772)

This unit test takes ~6minutes

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang