### PR TITLE
[ONNX][dynamo_export] Extend expected fx output types for int, float, bool

### DIFF
--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -556,6 +556,24 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             additional_test_inputs=[((x2,),)],
         )
 
+    def test__scaled_dot_product_flash_attention(self):
+        def func(x):
+            (
+                output,
+                _,
+                _,
+                _,
+                _,
+                _,
+                _,
+                _,
+                _,
+            ) = torch.ops.aten._scaled_dot_product_flash_attention(x, x, x)
+            return output
+
+        x = torch.randn(1, 1, 1, 32)
+        self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(func, (x,))
+
     # NOTE:The test was meant to test the empty bounding box case, but it is not
     # supported. When we have vision model examples, we will have a better test case
     # to demonstrate in FX and FX exporter.

--- a/torch/onnx/_internal/fx/fx_onnx_interpreter.py
+++ b/torch/onnx/_internal/fx/fx_onnx_interpreter.py
@@ -249,8 +249,9 @@ def _fill_tensor_shape_type(
             )
             onnxscript_value.shape = torch.Size([1])
         elif isinstance(expected_value, (int, float, bool)):
-            # These are onnx constants, skip setting dtype/shape.
-            onnxscript_value.dtype = fx_type_utils.from_scalar_type_to_torch_dtype(type(expected_value))
+            onnxscript_value.dtype = fx_type_utils.from_scalar_type_to_torch_dtype(
+                type(expected_value)
+            )
             onnxscript_value.shape = torch.Size([])
         elif fx_type_utils.is_torch_complex_dtype(expected_value.dtype):
             # Like torch.view_as_real, we flatten complex tensors to real tensors with

--- a/torch/onnx/_internal/fx/fx_onnx_interpreter.py
+++ b/torch/onnx/_internal/fx/fx_onnx_interpreter.py
@@ -248,6 +248,10 @@ def _fill_tensor_shape_type(
                 expected_value
             )
             onnxscript_value.shape = torch.Size([1])
+        elif isinstance(expected_value, (int, float, bool)):
+            # These are onnx constants, skip setting dtype/shape.
+            onnxscript_value.dtype = fx_type_utils.from_scalar_type_to_torch_dtype(type(expected_value))
+            onnxscript_value.shape = torch.Size([])
         elif fx_type_utils.is_torch_complex_dtype(expected_value.dtype):
             # Like torch.view_as_real, we flatten complex tensors to real tensors with
             # additional last dimension of 2

--- a/torch/onnx/_internal/fx/type_utils.py
+++ b/torch/onnx/_internal/fx/type_utils.py
@@ -192,7 +192,7 @@ _TORCH_DTYPE_TO_ONNX_TENSOR_ELEMENT_TYPE = {
 }
 
 SYM_VALUE_TYPE = Union[torch.SymInt, torch.SymFloat, torch.SymBool]
-META_VALUE_TYPE = Union[fake_tensor.FakeTensor, SYM_VALUE_TYPE]
+META_VALUE_TYPE = Union[fake_tensor.FakeTensor, SYM_VALUE_TYPE, int, float, bool]
 # NOTE: Belows are from torch/fx/node.py
 BaseArgumentTypes = Union[
     str,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #115431

Fixes exporting ops, such as `aten::_scaled_dot_product_flash_attention` that returns int, float, bool typed outputs.
