### PR TITLE
[BE] update errors to be more descriptive

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -844,18 +844,21 @@ def _check_single_tensor(param, param_name) -> None:
     """Check that the parameter ``param_name`` is a single tensor."""
     if not isinstance(param, torch.Tensor):
         raise TypeError(
-            f"Invalid function argument. Expected parameter `{param_name}` to be of type torch.Tensor."
+            f"Invalid function argument. Expected parameter `{param_name}` of type torch.Tensor but got {type(param)} instead."
         )
 
 
 def _check_tensor_list(param, param_name) -> None:
     """Check that the parameter ``param_name`` is a list of tensors."""
-    if not isinstance(param, list) or not all(
-        isinstance(p, torch.Tensor) for p in param
-    ):
+    if not isinstance(param, list):
         raise TypeError(
-            f"Invalid function argument. Expected parameter `{param_name}` to be of type List[torch.Tensor]."
+            f"Invalid function argument. Expected parameter `{param_name}` of type List[torch.Tensor], but got {type(param)} instead."
         )
+    elif not all(isinstance(p, torch.Tensor) for p in param):
+        raise TypeError(
+            f"Invalid function argument. Expected parameter `{param_name}` of type List[torch.Tensor], but got {type(param)} with elements of type {[type(p) for p in param]}."
+        )
+
 
 def _as_iterable(obj) -> collections.abc.Iterable:
     return obj if isinstance(obj, list) else (obj,)

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -844,7 +844,8 @@ def _check_single_tensor(param, param_name) -> None:
     """Check that the parameter ``param_name`` is a single tensor."""
     if not isinstance(param, torch.Tensor):
         raise TypeError(
-            f"Invalid function argument. Expected parameter `{param_name}` of type torch.Tensor but got {type(param)} instead."
+            f"""Invalid function argument. Expected parameter `{param_name}` of type torch.Tensor
+             but got {type(param)} instead."""
         )
 
 
@@ -852,11 +853,13 @@ def _check_tensor_list(param, param_name) -> None:
     """Check that the parameter ``param_name`` is a list of tensors."""
     if not isinstance(param, list):
         raise TypeError(
-            f"Invalid function argument. Expected parameter `{param_name}` of type List[torch.Tensor], but got {type(param)} instead."
+            f"""Invalid function argument. Expected parameter `{param_name}` of type List[torch.Tensor]
+             but got {type(param)} instead."""
         )
     elif not all(isinstance(p, torch.Tensor) for p in param):
         raise TypeError(
-            f"Invalid function argument. Expected parameter `{param_name}` of type List[torch.Tensor], but got {type(param)} with elements of type {[type(p) for p in param]}."
+            f"""Invalid function argument. Expected parameter `{param_name}` of type List[torch.Tensor]
+             but got {type(param)} with elements of type {[type(p) for p in param]}."""
         )
 
 


### PR DESCRIPTION
we call `_check_single_tensor` and `_check_tensor_list` as validation but don't print out the param types that were invalid


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @kiukchung @lucasllc