### PR TITLE
Move autolabeler to "oncall: distributed" not "module:.."

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -73,7 +73,7 @@
 "ciflow/trunk":
 - .ci/docker/ci_commit_pins/triton.txt
 
-"module: distributed":
+"oncall: distributed":
 - torch/csrc/distributed/**
 - torch/distributed/**
 - torch/nn/parallel/**


### PR DESCRIPTION
Reasoning for the change is spelled out in this issue

https://github.com/pytorch/pytorch/issues/115168

