### PR TITLE
Use get_mkldnn_enabled for decompositions

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1768,6 +1768,28 @@ def forward(self, l_x_):
         optimized_model = torch.compile(exported_model)
         optimized_model(tensor_cpu, mask_cpu)
 
+    def test_export_mkldnn_disabled(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lstm = torch.nn.LSTM(input_size=4, hidden_size=5, num_layers=1)
+
+            def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+                return self.lstm(inputs)
+
+        inp = (torch.ones(3, 4),)
+        torch._C._set_mkldnn_enabled(False)
+        ep = torch.export.export(M(), inp)
+        FileCheck().check_count(
+            "torch.ops.aten.mkldnn_rnn_layer.default", 0, exactly=True
+        ).run(ep.graph_module.code)
+
+        torch._C._set_mkldnn_enabled(True)
+        ep = torch.export.export(M(), inp)
+        FileCheck().check_count(
+            "torch.ops.aten.mkldnn_rnn_layer.default", 1, exactly=True
+        ).run(ep.graph_module.code)
+
     def test_export_input_mutation_static_shape(self):
         class MutationModel(torch.nn.Module):
             def forward(self, x, y):

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3054,7 +3054,7 @@ def one_layer_lstm_data(inp, hidden, params, has_biases, batch_sizes, reverse=Fa
 def select_one_layer_lstm_function(input, hx, params):
     r"""Check whether we could use decompose lstm with mkldnn_rnn_layer.
     All the below conditions need to be met:
-        * ``torch._C._has_mkldnn`` returns ``True``.
+        * ``torch._C._get_mkldnn_enabled()`` returns ``True``.
         * All the input args are on CPU.
         * The dtypes of args are either torch.float or torch.bfloat16.
         * Inference.
@@ -3067,7 +3067,7 @@ def select_one_layer_lstm_function(input, hx, params):
     """
 
     def use_mkldnn(input, hx, params):
-        if not torch._C._has_mkldnn:
+        if not torch._C._get_mkldnn_enabled():
             return False
 
         tensors = [input] + list(hx) + list(chain.from_iterable(params))


### PR DESCRIPTION
`torch._C.has_mkldnn` does not respect cases where users try to disable mkldnn using `torch._C._set_mkldnn_enabled()`. This is relevant to edge use cases, where they do not want decompositions to go to the ATen opset, and do not want the mkldnn operator to appear in the graph.