### PR TITLE
[nested_tensor]Python subclass NT overhead improvement (2/n): avoid getting from WeakTensorKeyDictionary twice during __init__

### DIFF
--- a/torch/nested/_internal/nested_tensor.py
+++ b/torch/nested/_internal/nested_tensor.py
@@ -13,12 +13,12 @@ _tensor_symint_registry = WeakTensorKeyDictionary()
 
 def get_tensor_symint(tensor, *, coeff=1):
     global _tensor_id_counter
-    if tensor not in _tensor_symint_registry:
-        _tensor_symint_registry[tensor] = torch._C._get_singleton_int(
-            _tensor_id_counter, coeff
-        )
+    tensor_symint = _tensor_symint_registry.get(tensor)
+    if tensor_symint is None:
+        tensor_symint = torch._C._get_singleton_int(_tensor_id_counter, coeff)
         _tensor_id_counter += 1
-    return _tensor_symint_registry[tensor]
+        _tensor_symint_registry[tensor] = tensor_symint
+    return tensor_symint
 
 
 # SDPA metadata; max / min seqlens are needed for e.g. flash

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -385,8 +385,6 @@ def linear_default(func, *args, **kwargs):
     )
 
     inp = new_kwargs.pop("input")
-    weight = new_kwargs["weight"]
-    bias = new_kwargs["bias"]
 
     return NestedTensor(func(inp._values, **new_kwargs), **extract_kwargs(inp))
 
@@ -567,7 +565,6 @@ def unsqueeze_default(func, *args, **kwargs):
 
     inp = new_kwargs.pop("input")
     values = inp._values
-    offsets = inp.offsets
 
     # Account for collapsed jagged dim
     dim = new_kwargs["dim"]


### PR DESCRIPTION
Summary:
Most NT operations end with creating a new NestedTensor, which is time-consuming. Trying to reduce overhead during the NestedTensor creation.

The ops return a new NestedTensor with the same offsets, so "tensor not in _tensor_symint_registry" would be false in most case. The "in" (__contain__) function takes ~8 us. If we use the "get" directly, then we save a few us for most NT operations.

Test Plan:
Before:
get_tensor_symint take 15us
https://pxl.cl/3XF83
After
get_tensor_symint take 10us
https://pxl.cl/3XFc9

Differential Revision: D51992836


