### PR TITLE
[quant][pt2][be] Make `is_qat` a Quantizer property

### DIFF
--- a/test/quantization/pt2e/test_representation.py
+++ b/test/quantization/pt2e/test_representation.py
@@ -93,8 +93,7 @@ class TestPT2ERepresentation(QuantizationTestCase):
                 return self.linear(x)
 
         quantizer = XNNPACKQuantizer()
-        operator_config = get_symmetric_quantization_config(is_per_channel=False)
-        quantizer.set_global(operator_config)
+        quantizer.set_global_config(is_per_channel=False)
         example_inputs = (torch.randn(2, 5),)
 
         self._test_representation(
@@ -115,10 +114,7 @@ class TestPT2ERepresentation(QuantizationTestCase):
                 return self.linear(x)
 
         quantizer = XNNPACKQuantizer()
-        operator_config = get_symmetric_quantization_config(
-            is_per_channel=False, is_dynamic=True
-        )
-        quantizer.set_global(operator_config)
+        quantizer.set_global_config(is_per_channel=False, is_dynamic=True)
         example_inputs = (torch.randn(2, 5),)
 
         self._test_representation(
@@ -140,8 +136,7 @@ class TestPT2ERepresentation(QuantizationTestCase):
                 return self.conv2d(x)
 
         quantizer = XNNPACKQuantizer()
-        operator_config = get_symmetric_quantization_config(is_per_channel=False)
-        quantizer.set_global(operator_config)
+        quantizer.set_global_config(is_per_channel=False)
         example_inputs = (torch.randn(1, 3, 3, 3),)
 
         self._test_representation(
@@ -161,8 +156,7 @@ class TestPT2ERepresentation(QuantizationTestCase):
                 return x + y
 
         quantizer = XNNPACKQuantizer()
-        quantization_config = get_symmetric_quantization_config(is_per_channel=True)
-        quantizer.set_global(quantization_config)
+        quantizer.set_global_config(is_per_channel=True)
         m_eager = M().eval()
 
         example_inputs = (
@@ -189,8 +183,7 @@ class TestPT2ERepresentation(QuantizationTestCase):
                 return out
 
         quantizer = XNNPACKQuantizer()
-        operator_config = get_symmetric_quantization_config(is_per_channel=True)
-        quantizer.set_global(operator_config)
+        quantizer.set_global_config(is_per_channel=True)
 
         example_inputs = (
             torch.randn(1, 3, 3, 3),
@@ -210,8 +203,7 @@ class TestPT2ERepresentation(QuantizationTestCase):
 
     def test_maxpool2d(self):
         quantizer = XNNPACKQuantizer()
-        operator_config = get_symmetric_quantization_config(is_per_channel=True)
-        quantizer.set_global(operator_config)
+        quantizer.set_global_config(is_per_channel=True)
         m_eager = TestHelperModules.ConvMaxPool2d().eval()
 
         example_inputs = (torch.randn(1, 2, 2, 2),)
@@ -237,8 +229,7 @@ class TestPT2ERepresentation(QuantizationTestCase):
 
         quantizer = XNNPACKQuantizer()
         # use per channel quantization for weight
-        operator_config = get_symmetric_quantization_config(is_per_channel=True)
-        quantizer.set_global(operator_config)
+        quantizer.set_global_config(is_per_channel=True)
         m_eager = M().eval()
 
         inputs = [
@@ -286,8 +277,7 @@ class TestPT2ERepresentation(QuantizationTestCase):
                 return x + y
 
         quantizer = XNNPACKQuantizer()
-        quantization_config = get_symmetric_quantization_config(is_per_channel=True)
-        quantizer.set_global(quantization_config)
+        quantizer.set_global_config(is_per_channel=True)
         m_eager = M().eval()
 
         example_inputs = (

--- a/test/quantization/pt2e/test_xnnpack_quantizer.py
+++ b/test/quantization/pt2e/test_xnnpack_quantizer.py
@@ -45,8 +45,7 @@ from .test_quantize_pt2e import PT2EQuantizationTestCase
 class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
     def test_conv1d(self):
         quantizer = XNNPACKQuantizer()
-        quantization_config = get_symmetric_quantization_config(is_per_channel=True)
-        quantizer.set_global(quantization_config)
+        quantizer.set_global_config(is_per_channel=True)
         example_inputs = (torch.randn(1, 3, 5),)
         node_occurrence = {
             # input and output are using quantize_per_tensor and weight is using quantize_per_channel
@@ -70,8 +69,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
 
     def test_conv2d(self):
         quantizer = XNNPACKQuantizer()
-        quantization_config = get_symmetric_quantization_config(is_per_channel=True)
-        quantizer.set_global(quantization_config)
+        quantizer.set_global_config(is_per_channel=True)
         example_inputs = (torch.randn(1, 3, 5, 5),)
         node_occurrence = {
             # input and output are using quantize_per_tensor and weight is using quantize_per_channel
@@ -96,8 +94,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
 
     def test_conv1d_with_conv2d(self):
         quantizer = XNNPACKQuantizer()
-        quantization_config = get_symmetric_quantization_config(is_per_channel=True)
-        quantizer.set_global(quantization_config)
+        quantizer.set_global_config(is_per_channel=True)
         node_occurrence = {
             # input and output are using quantize_per_tensor and weight is using quantize_per_channel
             torch.ops.quantized_decomposed.quantize_per_tensor.default: 4,
@@ -124,8 +121,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
 
     def test_linear(self):
         quantizer = XNNPACKQuantizer()
-        quantization_config = get_symmetric_quantization_config(is_per_channel=True)
-        quantizer.set_global(quantization_config)
+        quantizer.set_global_config(is_per_channel=True)
         m_eager = TestHelperModules.TwoLinearModule().eval()
 
         # Test with 2d inputs
@@ -155,8 +151,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
 
     def test_conv_linear_no_permute(self):
         quantizer = XNNPACKQuantizer()
-        quantization_config = get_symmetric_quantization_config(is_per_channel=True)
-        quantizer.set_global(quantization_config)
+        quantizer.set_global_config(is_per_channel=True)
         node_occurrence = {
             # input and output are using quantize_per_tensor and weight is using quantize_per_channel
             torch.ops.quantized_decomposed.quantize_per_tensor.default: 5,
@@ -181,8 +176,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
 
     def test_conv_linear(self):
         quantizer = XNNPACKQuantizer()
-        quantization_config = get_symmetric_quantization_config(is_per_channel=True)
-        quantizer.set_global(quantization_config)
+        quantizer.set_global_config(is_per_channel=True)
 
         # Test with 2d inputs
         example_inputs = (torch.randn(2, 3, 4, 4),)
@@ -207,8 +201,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
 
     def test_linear_with_dynamic_shape(self):
         quantizer = XNNPACKQuantizer()
-        quantization_config = get_symmetric_quantization_config(is_per_channel=True)
-        quantizer.set_global(quantization_config)
+        quantizer.set_global_config(is_per_channel=True)
         m_eager = TestHelperModules.TwoLinearModule().eval()
 
         # Test with 2d inputs
@@ -236,8 +229,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
 
     def test_obs_sharing_ops(self):
         quantizer = XNNPACKQuantizer()
-        quantization_config = get_symmetric_quantization_config(is_per_channel=True)
-        quantizer.set_global(quantization_config)
+        quantizer.set_global_config(is_per_channel=True)
         m = TestHelperModules.Conv2dWithObsSharingOps().eval()
         example_inputs = (torch.randn(1, 3, 5, 5),)
         node_occurrence = {
@@ -288,8 +280,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
         m = M().eval()
         example_inputs = (torch.randn(3, 5),)
         quantizer = XNNPACKQuantizer()
-        quantization_config = get_symmetric_quantization_config(is_per_channel=True)
-        quantizer.set_module_name("sub", quantization_config)
+        quantizer.set_module_name_config("sub", is_per_channel=True)
         node_occurrence = {
             torch.ops.aten.linear.default: 2,
             # input and output for the second linear
@@ -331,8 +322,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
         m = M().eval()
         example_inputs = (torch.randn(3, 5),)
         quantizer = XNNPACKQuantizer()
-        quantization_config = get_symmetric_quantization_config(is_per_channel=True)
-        quantizer.set_module_type(Sub, quantization_config)
+        quantizer.set_module_type_config(Sub, is_per_channel=True)
         node_occurrence = {
             torch.ops.aten.linear.default: 2,
             # input and output for the second linear
@@ -394,9 +384,8 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
         m = M().eval()
         example_inputs = (torch.randn(1, 3, 16, 16),)
         quantizer = XNNPACKQuantizer()
-        quantization_config = get_symmetric_quantization_config(is_per_channel=True)
         # We only want to annotate Linear type
-        quantizer.set_module_type(torch.nn.Linear, quantization_config)
+        quantizer.set_module_type_config(torch.nn.Linear, is_per_channel=True)
         node_occurrence = {
             torch.ops.aten.conv2d.default: 3,
             torch.ops.aten.linear.default: 1,
@@ -416,8 +405,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
 
     def test_propagate_annotation(self):
         quantizer = XNNPACKQuantizer()
-        quantization_config = get_symmetric_quantization_config(is_per_channel=True)
-        quantizer.set_global(quantization_config)
+        quantizer.set_global_config(is_per_channel=True)
         m = TestHelperModules.Conv2dPropAnnotaton().eval()
         example_inputs = (torch.randn(1, 3, 5, 5),)
 
@@ -460,10 +448,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
 
     def test_dynamic_linear(self):
         quantizer = XNNPACKQuantizer()
-        quantization_config = get_symmetric_quantization_config(
-            is_per_channel=True, is_dynamic=True
-        )
-        quantizer.set_global(quantization_config)
+        quantizer.set_global_config(is_per_channel=True, is_dynamic=True)
         m_eager = TestHelperModules.TwoLinearModule().eval()
 
         node_occurrence = {
@@ -502,13 +487,8 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
             )
 
     def test_qat_dynamic_linear(self):
-        quantizer = XNNPACKQuantizer()
-        quantization_config = get_symmetric_quantization_config(
-            is_per_channel=True,
-            is_dynamic=True,
-            is_qat=True,
-        )
-        quantizer.set_global(quantization_config)
+        quantizer = XNNPACKQuantizer(is_qat=True)
+        quantizer.set_global_config(is_per_channel=True, is_dynamic=True)
         m_eager = TestHelperModules.TwoLinearModule().eval()
 
         node_occurrence = {
@@ -543,10 +523,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
 
     def test_dynamic_linear_with_conv(self):
         quantizer = XNNPACKQuantizer()
-        quantization_config = get_symmetric_quantization_config(
-            is_per_channel=False, is_dynamic=True
-        )
-        quantizer.set_global(quantization_config)
+        quantizer.set_global_config(is_per_channel=False, is_dynamic=True)
         m_eager = TestHelperModules.ConvLinearWPermute().eval()
 
         node_occurrence = {
@@ -636,10 +613,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
                     example_inputs,
                 )
             quantizer = XNNPACKQuantizer()
-            quantization_config = get_symmetric_quantization_config(
-                is_per_channel=False, is_dynamic=False
-            )
-            quantizer.set_global(quantization_config)
+            quantizer.set_global_config(is_per_channel=False, is_dynamic=False)
             model_graph = prepare_pt2e(model_graph, quantizer)
             model_graph(*example_inputs)
             model_graph = convert_pt2e(model_graph, fold_quantize=True)
@@ -700,10 +674,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
                     example_inputs,
                 )
             quantizer = XNNPACKQuantizer()
-            quantization_config = get_symmetric_quantization_config(
-                is_per_channel=False, is_dynamic=False
-            )
-            quantizer.set_global(quantization_config)
+            quantizer.set_global_config(is_per_channel=False, is_dynamic=False)
             model_graph = prepare_pt2e(model_graph, quantizer)
             model_graph(*example_inputs)
             model_graph = convert_pt2e(model_graph, fold_quantize=True)
@@ -711,8 +682,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
 
     def test_add_and_inplace_add(self):
         quantizer = XNNPACKQuantizer()
-        quantization_config = get_symmetric_quantization_config(is_per_channel=True)
-        quantizer.set_global(quantization_config)
+        quantizer.set_global_config(is_per_channel=True)
         example_inputs = (
             torch.randn(1, 3, 5, 5),
             torch.randn(1, 3, 5, 5),
@@ -741,8 +711,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
 
     def test_mul_and_inplace_mul(self):
         quantizer = XNNPACKQuantizer()
-        quantization_config = get_symmetric_quantization_config(is_per_channel=True)
-        quantizer.set_global(quantization_config)
+        quantizer.set_global_config(is_per_channel=True)
         example_inputs = (
             torch.randn(1, 3, 5, 5),
             torch.randn(1, 3, 5, 5),
@@ -771,8 +740,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
 
     def test_add_mul_scalar(self):
         quantizer = XNNPACKQuantizer()
-        quantization_config = get_symmetric_quantization_config(is_per_channel=True)
-        quantizer.set_global(quantization_config)
+        quantizer.set_global_config(is_per_channel=True)
         example_inputs = (torch.randn(1, 3, 5, 5),)
         node_occurrence = {
             # two input and one output for first add, and output for second add
@@ -808,8 +776,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
                 return x * 3.4028235e38
 
         quantizer = XNNPACKQuantizer()
-        quantization_config = get_symmetric_quantization_config(is_per_channel=True)
-        quantizer.set_global(quantization_config)
+        quantizer.set_global_config(is_per_channel=True)
         example_inputs = (torch.randn(1, 3, 5, 5),)
         # not quantized
         node_occurrence = {
@@ -839,8 +806,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
                 return x
 
         quantizer = XNNPACKQuantizer()
-        quantization_config = get_symmetric_quantization_config(is_per_channel=True)
-        quantizer.set_global(quantization_config)
+        quantizer.set_global_config(is_per_channel=True)
         example_inputs = (torch.randn(1, 3, 5, 5),)
         # not quantized
         node_occurrence = {
@@ -878,8 +844,7 @@ class TestXNNPACKQuantizerModels(PT2EQuantizationTestCase):
             )
 
             quantizer = XNNPACKQuantizer()
-            quantization_config = get_symmetric_quantization_config(is_per_channel=True)
-            quantizer.set_global(quantization_config)
+            quantizer.set_global_config(is_per_channel=True)
             m = prepare_pt2e(m, quantizer)
             # checking that we inserted observers correctly for maxpool operator (input and
             # output share observer instance)

--- a/torch/ao/quantization/quantize_pt2e.py
+++ b/torch/ao/quantization/quantize_pt2e.py
@@ -97,6 +97,8 @@ def prepare_pt2e(
         # calibrate(m, sample_inference_data)
     """
     torch._C._log_api_usage_once("quantization_api.quantize_pt2e.prepare_pt2e")
+    if quantizer.is_qat:
+        raise ValueError("Quantizer must be initialized with is_qat=False")
     original_graph_meta = model.meta
     node_name_to_scope = _get_node_name_to_scope(model)
     # TODO: check qconfig_mapping to make sure conv and bn are both configured
@@ -169,6 +171,9 @@ def prepare_qat_pt2e(
 
     """
     torch._C._log_api_usage_once("quantization_api.quantize_pt2e.prepare_qat_pt2e")
+    # TODO: unify with prepare_pt2e and just branch QAT logic based on quantizer.is_qat
+    if not quantizer.is_qat:
+        raise ValueError("Quantizer must be initialized with is_qat=True")
     original_graph_meta = model.meta
     node_name_to_scope = _get_node_name_to_scope(model)
     quantizer.transform_for_annotation(model)

--- a/torch/ao/quantization/quantizer/quantizer.py
+++ b/torch/ao/quantization/quantizer/quantizer.py
@@ -157,7 +157,6 @@ class QuantizationAnnotation:
 
 
 class Quantizer(ABC):
-    @abstractmethod
     def __init__(self, is_qat: bool = False):
         self._is_qat = is_qat
 

--- a/torch/ao/quantization/quantizer/quantizer.py
+++ b/torch/ao/quantization/quantizer/quantizer.py
@@ -157,6 +157,10 @@ class QuantizationAnnotation:
 
 
 class Quantizer(ABC):
+    @abstractmethod
+    def __init__(self, is_qat: bool = False):
+        self._is_qat = is_qat
+
     def transform_for_annotation(
         self, model: torch.fx.GraphModule
     ) -> torch.fx.GraphModule:
@@ -181,3 +185,7 @@ class Quantizer(ABC):
     @abstractmethod
     def validate(self, model: torch.fx.GraphModule) -> None:
         pass
+
+    @property
+    def is_qat(self) -> bool:
+        return self._is_qat

--- a/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
+++ b/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
@@ -24,6 +24,7 @@ from torch.ao.quantization.quantizer.quantizer import (
 )
 from torch.ao.quantization.quantizer.xnnpack_quantizer_utils import (
     _is_annotated,
+    _quantization_config_is_qat,
     get_bias_qspec,
     get_input_act_qspec,
     get_output_act_qspec,
@@ -211,7 +212,6 @@ def get_default_x86_inductor_quantization_config(is_qat: bool = False):
         act_quantization_spec,
         weight_quantization_spec,
         bias_quantization_spec,
-        is_qat,
     )
     return quantization_config
 
@@ -390,7 +390,7 @@ class X86InductorQuantizer(Quantizer):
         config = self.global_config
 
         # Step1: Recipe of fusion patterns like conv/linear.
-        if config.is_qat:
+        if _quantization_config_is_qat(config):
             # Annotate QAT specific pattern: mainly due to BN not folded in prepare_qat
             self._annotate_qat_conv2d_fusion_pattern(model, config)
 

--- a/torch/ao/quantization/quantizer/xnnpack_quantizer.py
+++ b/torch/ao/quantization/quantizer/xnnpack_quantizer.py
@@ -328,7 +328,6 @@ class XNNPACKQuantizer(Quantizer):
         is_per_channel: bool,
         is_dynamic: bool = False,
     ) -> XNNPACKQuantizer:
-        self._verify_quantization_config(quantization_config)
         self.operator_type_config[operator_type] = get_symmetric_quantization_config(
             is_per_channel=is_per_channel,
             is_qat=self.is_qat,
@@ -346,7 +345,6 @@ class XNNPACKQuantizer(Quantizer):
         quantizer.set_module_name(Sub) or quantizer.set_module_name(nn.Linear), it will quantize all supported operator/operator
         patterns in the submodule with this module type with the given `quantization_config`
         """
-        self._verify_quantization_config(quantization_config)
         self.module_type_config[module_type] = get_symmetric_quantization_config(
             is_per_channel=is_per_channel,
             is_qat=self.is_qat,
@@ -367,7 +365,6 @@ class XNNPACKQuantizer(Quantizer):
         assert (
             quantization_config is not None
         ), " quantization_config == None is not supported yet"
-        self._verify_quantization_config(quantization_config)
         self.module_name_config[module_name] = get_symmetric_quantization_config(
             is_per_channel=is_per_channel,
             is_qat=self.is_qat,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #115455

Summary: This has two important benefits. First, it solves the
problem in `XNNPACKQuantizer` where the user may forget to
explicitly specify `is_qat=True` in the quantization config
when using QAT. In this case, the user will not have fake
quantizes inserted. This is a silent correctness error.

Second, in the future this will allow us to unify the
`prepare_pt2e` and `prepare_qat_pt2e` APIs. The new unified
API can just branch on `quantizer.is_qat` to decide whether
to run QAT specific logic.

TODO(andrew): add bc-breaking notes

Test Plan:
python test/test_quantization.py TestQuantizePT2E
python test/test_quantization.py TestQuantizePT2EQAT

Reviewers: jerryzh168, kimishpatel

Subscribers: jerryzh168, kimishpatel, supriyar