### PR TITLE
Add back non standard shapes test samples for SDPA in common_methods_…

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8446,6 +8446,7 @@ def sample_inputs_scaled_dot_product_attention(op_info, device, dtype, requires_
         is_causal=is_causal,
         dropout_p=dropout_p
     )
+    samples.append(diff_v_head_dim)
 
     # Add an attn_mask
     samples.append(
@@ -8512,7 +8513,8 @@ def sample_inputs_efficient_attention_forward(op_info, device, dtype, requires_g
         causal_diagonal=None,
         seqlen_k=None
     )
-
+    samples.append(diff_v_head_dim)
+    
     # Add an attn_mask
     samples.append(
         SampleInput(


### PR DESCRIPTION
…invocations

These samples probably were accidentally dropped in the older PR

Fixes #ISSUE_NUMBER
