### PR TITLE
[BE][JIT] Do not wrap shared_ptr with optional

### DIFF
--- a/torch/csrc/jit/api/function_impl.cpp
+++ b/torch/csrc/jit/api/function_impl.cpp
@@ -94,18 +94,18 @@ const c10::FunctionSchema& GraphFunction::getSchema() const {
 
 std::shared_ptr<Graph> GraphFunction::optimized_graph() const {
   std::lock_guard<std::recursive_mutex> lock(compile_mutex);
-  decltype(optimized_graphs_)::value_type opt_graph;
-  auto& opt_graph_ref = !FLAGS_torch_jit_do_not_store_optimized_graph
+  decltype(optimized_graphs_)::value_type graph;
+  auto& graph_ref = !FLAGS_torch_jit_do_not_store_optimized_graph
       ? optimized_graphs_[currentSpecialization()]
-      : opt_graph;
-  if (opt_graph_ref) {
-    return opt_graph_ref.value();
+      : graph;
+  if (graph_ref) {
+    return graph_ref;
   }
-  opt_graph_ref = graph_->copy();
+  graph_ref = graph_->copy();
   if (getGraphExecutorOptimize()) {
-    preoptimizeGraph(opt_graph_ref.value(), force_no_amp_);
+    preoptimizeGraph(graph_ref, force_no_amp_);
   }
-  return opt_graph_ref.value();
+  return graph_ref;
 }
 
 GraphFunction::SpecializationKey GraphFunction::currentSpecialization() const {

--- a/torch/csrc/jit/api/function_impl.h
+++ b/torch/csrc/jit/api/function_impl.h
@@ -115,7 +115,7 @@ struct TORCH_API GraphFunction : public Function {
   }
 
   void clear_optimized_graphs() {
-    optimized_graphs_.fill(c10::nullopt);
+    optimized_graphs_.fill(nullptr);
   }
 
  private:
@@ -146,7 +146,7 @@ struct TORCH_API GraphFunction : public Function {
   mutable bool force_no_amp_ = false;
   // Optimized graph, computed lazily. Used for inlining.
   mutable std::array<
-      c10::optional<std::shared_ptr<Graph>>,
+      std::shared_ptr<Graph>,
       SpecializationKey::TotalCount>
       optimized_graphs_;
 

--- a/torch/csrc/jit/api/function_impl.h
+++ b/torch/csrc/jit/api/function_impl.h
@@ -145,9 +145,7 @@ struct TORCH_API GraphFunction : public Function {
   // don't invoke amp pass
   mutable bool force_no_amp_ = false;
   // Optimized graph, computed lazily. Used for inlining.
-  mutable std::array<
-      std::shared_ptr<Graph>,
-      SpecializationKey::TotalCount>
+  mutable std::array<std::shared_ptr<Graph>, SpecializationKey::TotalCount>
       optimized_graphs_;
 
   // GraphFunctions are invokable from multiple threads, so this lock needs to


### PR DESCRIPTION
While reviewing https://github.com/pytorch/pytorch/pull/115381 noticed that `torch::jit::GraphFunction::optimized_graph_` is an `std::array<c10::optional<std::shared_ptr<Graph>>, N>`, which feels excessive as `shared_ptr` is already nullable and have `operator bool()`. Looking at https://github.com/pytorch/pytorch/pull/26488 that introduced the change, also does not hint that this indirection is necessary.

Test plan: CI

