### PR TITLE
Added more descriptive error message for MultiMarginLoss as mentioned in #106251.

### DIFF
--- a/aten/src/ATen/native/cuda/MultiMarginLoss.cu
+++ b/aten/src/ATen/native/cuda/MultiMarginLoss.cu
@@ -148,7 +148,7 @@ void multi_margin_loss_shape_check(
 
     TORCH_CHECK(
         target.dim() <= 1 && target.numel() == nframe,
-        "inconsistent target size, expected ", nframe, " but got ",
+        "MultiMarginLoss: The size of input tensor ", nframe, " must match the size of target tensor ",
         target.sizes());
     if (weight && weight->defined()) {
       TORCH_CHECK(

--- a/aten/src/ATen/native/cuda/MultiMarginLoss.cu
+++ b/aten/src/ATen/native/cuda/MultiMarginLoss.cu
@@ -148,7 +148,7 @@ void multi_margin_loss_shape_check(
 
     TORCH_CHECK(
         target.dim() <= 1 && target.numel() == nframe,
-        "MultiMarginLoss: The size of input tensor ", nframe, " must match the size of target tensor ",
+        "MultiMarginLoss: The  batch size of input tensor, ", nframe, ", must match the size of target tensor, but got target of size",
         target.sizes());
     if (weight && weight->defined()) {
       TORCH_CHECK(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1522,7 +1522,7 @@ def error_inputs_multi_margin_loss(op, device, **kwargs):
                      error_regex=r'Expected non-empty vector or matrix with optional 0-dim batch size, but got: \[0\]')
     # invalid target
     yield ErrorInput(SampleInput(make_input(5, 4), args=(make_input(5, 4),), kwargs={}),
-                     error_type=RuntimeError, error_regex=r'inconsistent target size, expected 5 but got \[5, 4\]')
+                     error_type=RuntimeError, error_regex=r'MultiMarginLoss: The size of input tensor, , must match the size of target tensor, \[4, 5\]')
     # invalid target dtype
     yield ErrorInput(SampleInput(make_input(5, 4), args=(make_input(5,),), kwargs={}),
                      error_type=RuntimeError, error_regex='expected scalar type Long but found Float')

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1522,7 +1522,7 @@ def error_inputs_multi_margin_loss(op, device, **kwargs):
                      error_regex=r'Expected non-empty vector or matrix with optional 0-dim batch size, but got: \[0\]')
     # invalid target
     yield ErrorInput(SampleInput(make_input(5, 4), args=(make_input(5, 4),), kwargs={}),
-                     error_type=RuntimeError, error_regex=r'MultiMarginLoss: The size of input tensor, , must match the size of target tensor, \[4, 5\]')
+                     error_type=RuntimeError, error_regex=r'MultiMarginLoss: The size of input tensor, 4, must match the size of target tensor, \[4, 5\]')
     # invalid target dtype
     yield ErrorInput(SampleInput(make_input(5, 4), args=(make_input(5,),), kwargs={}),
                      error_type=RuntimeError, error_regex='expected scalar type Long but found Float')


### PR DESCRIPTION
Fixes #106251 with more descriptive error message in aten/src/ATen/native/cuda/MultiMarginLoss.cu.
