### PR TITLE
[7/N] Fixes clang-tidy warnings in c10/{core,util}/*.h

### DIFF
--- a/aten/src/ATen/core/SingletonSymNodeImpl.h
+++ b/aten/src/ATen/core/SingletonSymNodeImpl.h
@@ -1,9 +1,13 @@
 #pragma once
 
 #include <c10/core/ConstantSymNodeImpl.h>
-#include <c10/core/SymBool.h>
 #include <c10/core/SymNodeImpl.h>
-#include <iostream>
+#include <c10/macros/Export.h>
+#include <c10/util/Exception.h>
+#include <c10/util/Optional.h>
+#include <c10/util/intrusive_ptr.h>
+#include <cstdint>
+#include <string>
 
 namespace c10 {
 

--- a/c10/core/Allocator.h
+++ b/c10/core/Allocator.h
@@ -2,9 +2,13 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
+#include <utility>
 
 #include <c10/core/Device.h>
+#include <c10/core/DeviceType.h>
+#include <c10/macros/Export.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
 #include <c10/util/ThreadLocalDebugInfo.h>

--- a/c10/core/CPUAllocator.h
+++ b/c10/core/CPUAllocator.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <cstdint>
 #include <cstring>
 #include <mutex>
 #include <unordered_map>
 
 #include <c10/core/Allocator.h>
+#include <c10/macros/Export.h>
 #include <c10/util/Flags.h>
 
 // TODO: rename to c10

--- a/c10/core/CompileTimeFunctionPointer.h
+++ b/c10/core/CompileTimeFunctionPointer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <c10/util/TypeTraits.h>
+#include <type_traits>
 
 namespace c10 {
 

--- a/c10/core/ConstantSymNodeImpl.h
+++ b/c10/core/ConstantSymNodeImpl.h
@@ -1,6 +1,11 @@
 #pragma once
 
 #include <c10/core/SymNodeImpl.h>
+#include <c10/macros/Export.h>
+#include <c10/util/Exception.h>
+#include <c10/util/Optional.h>
+#include <cstdint>
+#include <string>
 #include <variant>
 
 namespace c10 {

--- a/c10/core/CopyBytes.h
+++ b/c10/core/CopyBytes.h
@@ -2,6 +2,7 @@
 
 #include <c10/core/Device.h>
 #include <c10/core/DeviceType.h>
+#include <c10/macros/Export.h>
 #include <c10/macros/Macros.h>
 #include <cstddef>
 

--- a/c10/core/DeviceArray.h
+++ b/c10/core/DeviceArray.h
@@ -1,5 +1,8 @@
 #include <c10/core/Allocator.h>
+#include <c10/util/Exception.h>
 #include <cstddef>
+#include <cstdint>
+#include <type_traits>
 
 namespace c10 {
 

--- a/c10/core/DeviceGuard.h
+++ b/c10/core/DeviceGuard.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <c10/core/Device.h>
+#include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <c10/core/impl/InlineDeviceGuard.h>
+#include <c10/core/impl/VirtualGuardImpl.h>
+#include <c10/util/Optional.h>
 
 namespace c10 {
 

--- a/c10/core/DeviceType.h
+++ b/c10/core/DeviceType.h
@@ -7,8 +7,11 @@
 
 #include <c10/macros/Export.h>
 
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <ostream>
+#include <string>
 
 namespace c10 {
 

--- a/c10/core/DispatchKey.h
+++ b/c10/core/DispatchKey.h
@@ -2,7 +2,9 @@
 
 #include <c10/core/DeviceType.h>
 #include <c10/macros/Export.h>
+#include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <ostream>
 #include <string>
 

--- a/c10/core/DispatchKeySet.h
+++ b/c10/core/DispatchKeySet.h
@@ -1,10 +1,20 @@
 #pragma once
 #include <c10/core/DispatchKey.h>
+#include <c10/macros/Export.h>
+#include <c10/macros/Macros.h>
+#include <c10/util/C++17.h>
 #include <c10/util/Exception.h>
 #include <c10/util/Metaprogramming.h>
+#include <c10/util/TypeList.h>
 #include <c10/util/llvmMathExtras.h>
 #include <array>
+#include <cstddef>
+#include <cstdint>
+#include <initializer_list>
+#include <iterator>
 #include <ostream>
+#include <string>
+#include <type_traits>
 
 namespace c10 {
 

--- a/c10/core/Event.h
+++ b/c10/core/Event.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <c10/core/Device.h>
+#include <c10/core/DeviceType.h>
+#include <c10/core/Stream.h>
+#include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <c10/core/impl/InlineEvent.h>
 #include <c10/core/impl/VirtualGuardImpl.h>
 

--- a/c10/core/InferenceMode.h
+++ b/c10/core/InferenceMode.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <c10/core/AutogradState.h>
+#include <c10/core/DispatchKey.h>
+#include <c10/core/DispatchKeySet.h>
 #include <c10/core/impl/LocalDispatchKeySet.h>
 #include <c10/macros/Export.h>
 

--- a/c10/core/Layout.h
+++ b/c10/core/Layout.h
@@ -3,6 +3,7 @@
 #include <c10/core/Backend.h>
 #include <c10/util/Exception.h>
 
+#include <cstdint>
 #include <ostream>
 
 namespace c10 {

--- a/c10/core/MemoryFormat.h
+++ b/c10/core/MemoryFormat.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <c10/core/Backend.h>
 #include <c10/util/ArrayRef.h>
 #include <c10/util/Exception.h>
 
+#include <cstdint>
 #include <ostream>
+#include <vector>
 
 // Memory format is not the property of a Tensor. It is the way to tell an
 // operator how the result should be organized in memory and nothing more. That

--- a/c10/core/PyHandleCache.h
+++ b/c10/core/PyHandleCache.h
@@ -2,6 +2,7 @@
 
 #include <c10/core/impl/PyInterpreter.h>
 #include <c10/macros/Macros.h>
+#include <c10/util/Exception.h>
 #include <c10/util/python_stub.h>
 
 #include <atomic>

--- a/c10/core/QEngine.h
+++ b/c10/core/QEngine.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <c10/core/DeviceType.h>
-#include <c10/core/DispatchKey.h>
 #include <c10/util/Exception.h>
+#include <cstdint>
+#include <string>
 
 namespace c10 {
 

--- a/c10/core/QScheme.h
+++ b/c10/core/QScheme.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <c10/core/DeviceType.h>
 #include <c10/util/Exception.h>
+#include <cstdint>
+#include <string>
 
 namespace c10 {
 

--- a/c10/core/RefcountedDeleter.h
+++ b/c10/core/RefcountedDeleter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <c10/core/Storage.h>
+#include <c10/macros/Export.h>
 #include <c10/util/UniqueVoidPtr.h>
 
 #include <atomic>

--- a/c10/core/SafePyObject.h
+++ b/c10/core/SafePyObject.h
@@ -3,6 +3,7 @@
 #include <c10/core/impl/PyInterpreter.h>
 #include <c10/macros/Export.h>
 #include <c10/util/python_stub.h>
+#include <utility>
 
 namespace c10 {
 

--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -7,12 +7,17 @@
 
 #include <c10/core/OptionalRef.h>
 #include <c10/core/ScalarType.h>
+#include <c10/core/SymBool.h>
 #include <c10/core/SymFloat.h>
 #include <c10/core/SymInt.h>
+#include <c10/core/SymNodeImpl.h>
+#include <c10/macros/Export.h>
 #include <c10/macros/Macros.h>
+#include <c10/util/Deprecated.h>
 #include <c10/util/Exception.h>
 #include <c10/util/Half.h>
 #include <c10/util/TypeCast.h>
+#include <c10/util/complex.h>
 #include <c10/util/intrusive_ptr.h>
 
 namespace c10 {

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -17,8 +17,11 @@
 #include <c10/util/quint8.h>
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <ostream>
+#include <type_traits>
 
 namespace c10 {
 

--- a/c10/core/Storage.h
+++ b/c10/core/Storage.h
@@ -1,7 +1,18 @@
 #pragma once
 
+#include <c10/core/Allocator.h>
+#include <c10/core/Device.h>
+#include <c10/core/DeviceType.h>
 #include <c10/core/StorageImpl.h>
+#include <c10/core/SymInt.h>
+#include <c10/macros/Export.h>
+#include <c10/util/Exception.h>
 #include <c10/util/ExclusivelyOwned.h>
+#include <c10/util/MaybeOwned.h>
+#include <c10/util/UniqueVoidPtr.h>
+#include <c10/util/intrusive_ptr.h>
+#include <cstddef>
+#include <utility>
 
 namespace c10 {
 

--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -1,10 +1,16 @@
 #pragma once
 
 #include <c10/core/Allocator.h>
+#include <c10/core/Device.h>
+#include <c10/core/DeviceType.h>
 #include <c10/core/SymInt.h>
 #include <c10/core/impl/PyObjectSlot.h>
-
+#include <c10/macros/Export.h>
+#include <c10/util/Exception.h>
+#include <c10/util/UniqueVoidPtr.h>
 #include <c10/util/intrusive_ptr.h>
+#include <cstddef>
+#include <utility>
 
 namespace c10 {
 

--- a/c10/core/Stream.h
+++ b/c10/core/Stream.h
@@ -1,6 +1,13 @@
 #pragma once
 
 #include <c10/core/Device.h>
+#include <c10/core/DeviceType.h>
+#include <c10/macros/Export.h>
+#include <c10/util/Exception.h>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <ostream>
 
 namespace c10 {
 

--- a/c10/core/StreamGuard.h
+++ b/c10/core/StreamGuard.h
@@ -1,6 +1,11 @@
 #pragma once
 
+#include <c10/core/Device.h>
+#include <c10/core/Stream.h>
 #include <c10/core/impl/InlineStreamGuard.h>
+#include <c10/core/impl/VirtualGuardImpl.h>
+#include <c10/util/ArrayRef.h>
+#include <c10/util/Optional.h>
 
 namespace c10 {
 

--- a/c10/core/SymBool.h
+++ b/c10/core/SymBool.h
@@ -1,9 +1,13 @@
 #pragma once
 
 #include <c10/core/SymNodeImpl.h>
-#include <c10/macros/Macros.h>
+#include <c10/macros/Export.h>
 #include <c10/util/Exception.h>
+#include <c10/util/Optional.h>
 #include <c10/util/intrusive_ptr.h>
+#include <cstdint>
+#include <ostream>
+#include <utility>
 
 namespace c10 {
 

--- a/c10/core/SymFloat.h
+++ b/c10/core/SymFloat.h
@@ -2,11 +2,15 @@
 
 #include <c10/core/SymBool.h>
 #include <c10/core/SymNodeImpl.h>
+#include <c10/macros/Export.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
 #include <c10/util/intrusive_ptr.h>
 
+#include <cstdint>
 #include <limits>
+#include <ostream>
+#include <utility>
 
 namespace c10 {
 

--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -2,11 +2,15 @@
 
 #include <c10/core/SymBool.h>
 #include <c10/core/SymNodeImpl.h>
+#include <c10/macros/Export.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
 #include <c10/util/Optional.h>
 
+#include <cstdint>
+#include <iterator>
 #include <numeric>
+#include <ostream>
 #include <type_traits>
 
 namespace c10 {

--- a/c10/core/SymIntArrayRef.h
+++ b/c10/core/SymIntArrayRef.h
@@ -4,6 +4,7 @@
 #include <c10/util/ArrayRef.h>
 #include <c10/util/Exception.h>
 #include <c10/util/Optional.h>
+#include <cstdint>
 
 namespace c10 {
 using SymIntArrayRef = ArrayRef<SymInt>;

--- a/c10/core/SymNodeImpl.h
+++ b/c10/core/SymNodeImpl.h
@@ -5,6 +5,9 @@
 #include <c10/util/Exception.h>
 #include <c10/util/Optional.h>
 #include <c10/util/intrusive_ptr.h>
+#include <cstdint>
+#include <ostream>
+#include <string>
 
 namespace c10 {
 

--- a/c10/core/SymbolicShapeMeta.h
+++ b/c10/core/SymbolicShapeMeta.h
@@ -1,10 +1,14 @@
 #pragma once
 #include <c10/core/SymBool.h>
 #include <c10/core/SymInt.h>
+#include <c10/macros/Export.h>
+#include <c10/macros/Macros.h>
 #include <c10/util/DimVector.h>
 
 #include <atomic>
+#include <cstdint>
 #include <mutex>
+#include <utility>
 
 namespace c10 {
 

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1,17 +1,26 @@
 #pragma once
 
+#include <c10/core/Allocator.h>
+#include <c10/core/Device.h>
+#include <c10/core/DeviceType.h>
+#include <c10/core/DispatchKey.h>
 #include <c10/core/DispatchKeySet.h>
 #include <c10/core/InferenceMode.h>
+#include <c10/core/Layout.h>
 #include <c10/core/MemoryFormat.h>
+#include <c10/core/ScalarType.h>
 #include <c10/core/ScalarTypeToTypeMeta.h>
 #include <c10/core/Storage.h>
 #include <c10/core/SymBool.h>
+#include <c10/core/SymInt.h>
 #include <c10/core/SymIntArrayRef.h>
 #include <c10/core/SymbolicShapeMeta.h>
 #include <c10/core/WrapDimMinimal.h>
 #include <c10/core/impl/PyObjectSlot.h>
 #include <c10/core/impl/SizesAndStrides.h>
+#include <c10/macros/Export.h>
 #include <c10/macros/Macros.h>
+#include <c10/util/ArrayRef.h>
 #include <c10/util/DimVector.h>
 #include <c10/util/Exception.h>
 #include <c10/util/Flags.h>
@@ -24,10 +33,14 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <memory>
+#include <string>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 // A global boolean variable to control whether we free memory when a Tensor
 // is shrunk to a smaller size. As a result, a Tensor is always going to
@@ -43,11 +56,6 @@ C10_DECLARE_bool(caffe2_keep_on_shrink);
 // is larger than this flag in bytes.  This only applies to functions which
 // respect caffe2_keep_on_shrink.
 C10_DECLARE_int64(caffe2_max_keep_on_shrink_memory);
-
-C10_CLANG_DIAGNOSTIC_PUSH()
-#if C10_CLANG_HAS_WARNING("-Wimplicit-int-float-conversion")
-C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
-#endif
 
 namespace at {
 class Tensor;
@@ -3227,5 +3235,3 @@ static_assert(
 #undef C10_GCC_VERSION_MINOR
 
 } // namespace c10
-
-C10_CLANG_DIAGNOSTIC_POP()

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -3,15 +3,22 @@
 #include <c10/core/Backend.h>
 #include <c10/core/DefaultDtype.h>
 #include <c10/core/Device.h>
+#include <c10/core/DeviceType.h>
+#include <c10/core/DispatchKey.h>
 #include <c10/core/Layout.h>
 #include <c10/core/MemoryFormat.h>
 #include <c10/core/ScalarType.h>
 #include <c10/core/ScalarTypeToTypeMeta.h>
 
+#include <c10/macros/Export.h>
 #include <c10/macros/Macros.h>
+#include <c10/util/Exception.h>
 #include <c10/util/Optional.h>
 
+#include <cstdint>
 #include <iosfwd>
+#include <string>
+#include <type_traits>
 #include <utility>
 
 namespace c10 {

--- a/c10/core/UndefinedTensorImpl.h
+++ b/c10/core/UndefinedTensorImpl.h
@@ -1,6 +1,11 @@
 #pragma once
 
+#include <c10/core/MemoryFormat.h>
+#include <c10/core/SymIntArrayRef.h>
 #include <c10/core/TensorImpl.h>
+#include <c10/macros/Export.h>
+#include <c10/util/ArrayRef.h>
+#include <cstdint>
 
 namespace c10 {
 

--- a/c10/core/WrapDimMinimal.h
+++ b/c10/core/WrapDimMinimal.h
@@ -1,6 +1,10 @@
 #pragma once
 
 #include <c10/core/SymInt.h>
+#include <c10/macros/Export.h>
+#include <c10/macros/Macros.h>
+#include <cstdint>
+#include <utility>
 
 namespace c10 {
 

--- a/c10/core/impl/PyInterpreter.h
+++ b/c10/core/impl/PyInterpreter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <c10/core/Device.h>
+#include <c10/core/DispatchKeySet.h>
 #include <c10/core/Layout.h>
 #include <c10/core/MemoryFormat.h>
 #include <c10/core/SymIntArrayRef.h>

--- a/c10/core/thread_pool.h
+++ b/c10/core/thread_pool.h
@@ -2,12 +2,16 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <cstddef>
 #include <functional>
 #include <mutex>
 #include <queue>
 #include <thread>
 #include <utility>
+#include <vector>
 
+#include <c10/macros/Export.h>
+#include <c10/util/Registry.h>
 #include <c10/util/numa.h>
 #include <c10/util/thread_name.h>
 

--- a/c10/util/ArrayRef.h
+++ b/c10/util/ArrayRef.h
@@ -92,9 +92,9 @@ class ArrayRef final {
 
   template <
       typename Container,
-      typename = std::enable_if_t<std::is_same<
+      typename = std::enable_if_t<std::is_same_v<
           std::remove_const_t<decltype(std::declval<Container>().data())>,
-          T*>::value>>
+          T*>>>
   /* implicit */ ArrayRef(const Container& container)
       : Data(container.data()), Length(container.size()) {
     debugCheckNullptrInvariant();
@@ -231,16 +231,16 @@ class ArrayRef final {
   /// The declaration here is extra complicated so that "arrayRef = {}"
   /// continues to select the move assignment operator.
   template <typename U>
-  typename std::enable_if<std::is_same<U, T>::value, ArrayRef<T>>::type&
-  operator=(U&& Temporary) = delete;
+  std::enable_if_t<std::is_same_v<U, T>, ArrayRef<T>>& operator=(
+      U&& Temporary) = delete;
 
   /// Disallow accidental assignment from a temporary.
   ///
   /// The declaration here is extra complicated so that "arrayRef = {}"
   /// continues to select the move assignment operator.
   template <typename U>
-  typename std::enable_if<std::is_same<U, T>::value, ArrayRef<T>>::type&
-  operator=(std::initializer_list<U>) = delete;
+  std::enable_if_t<std::is_same_v<U, T>, ArrayRef<T>>& operator=(
+      std::initializer_list<U>) = delete;
 
   /// @}
   /// @name Expensive Operations

--- a/c10/util/MaybeOwned.h
+++ b/c10/util/MaybeOwned.h
@@ -127,7 +127,7 @@ class MaybeOwned final {
 
   MaybeOwned(MaybeOwned&& rhs) noexcept(
       std::is_nothrow_move_constructible_v<T>&&
-      std::is_nothrow_move_assignable_v<borrow_type>)
+          std::is_nothrow_move_assignable_v<borrow_type>)
       : isBorrowed_(rhs.isBorrowed_) {
     if (C10_LIKELY(rhs.isBorrowed_)) {
       MaybeOwnedTraits<T>::assignBorrow(borrow_, rhs.borrow_);
@@ -137,11 +137,10 @@ class MaybeOwned final {
   }
 
   MaybeOwned& operator=(MaybeOwned&& rhs) noexcept(
-      std::is_nothrow_move_assignable_v<T> &&
-      std::is_nothrow_move_assignable_v<borrow_type> &&
-      std::is_nothrow_move_constructible_v<T> &&
-      std::is_nothrow_destructible_v<T> &&
-      std::is_nothrow_destructible_v<borrow_type>) {
+      std::is_nothrow_move_assignable_v<T>&& std::is_nothrow_move_assignable_v<
+          borrow_type>&& std::is_nothrow_move_constructible_v<T>&&
+          std::is_nothrow_destructible_v<T>&&
+              std::is_nothrow_destructible_v<borrow_type>) {
     if (this == &rhs) {
       return *this;
     }
@@ -179,9 +178,8 @@ class MaybeOwned final {
     return MaybeOwned(std::in_place, std::forward<Args>(args)...);
   }
 
-  ~MaybeOwned() noexcept(
-      std::is_nothrow_destructible_v<T> &&
-      std::is_nothrow_destructible_v<borrow_type>) {
+  ~MaybeOwned() noexcept(std::is_nothrow_destructible_v<T>&&
+                             std::is_nothrow_destructible_v<borrow_type>) {
     if (C10_UNLIKELY(!isBorrowed_)) {
       own_.~T();
     } else {

--- a/c10/util/MaybeOwned.h
+++ b/c10/util/MaybeOwned.h
@@ -77,8 +77,7 @@ class MaybeOwned final {
       : isBorrowed_(true), borrow_(MaybeOwnedTraits<T>::createBorrow(t)) {}
 
   /// Don't use this; use owned() instead.
-  explicit MaybeOwned(T&& t) noexcept(
-      std::is_nothrow_move_constructible_v<T>)
+  explicit MaybeOwned(T&& t) noexcept(std::is_nothrow_move_constructible_v<T>)
       : isBorrowed_(false), own_(std::move(t)) {}
 
   /// Don't use this; use owned() instead.
@@ -127,7 +126,7 @@ class MaybeOwned final {
   }
 
   MaybeOwned(MaybeOwned&& rhs) noexcept(
-      std::is_nothrow_move_constructible_v<T> &&
+      std::is_nothrow_move_constructible_v<T>&&
       std::is_nothrow_move_assignable_v<borrow_type>)
       : isBorrowed_(rhs.isBorrowed_) {
     if (C10_LIKELY(rhs.isBorrowed_)) {

--- a/c10/util/MaybeOwned.h
+++ b/c10/util/MaybeOwned.h
@@ -126,8 +126,8 @@ class MaybeOwned final {
   }
 
   MaybeOwned(MaybeOwned&& rhs) noexcept(
-      std::is_nothrow_move_constructible_v<T>&&
-          std::is_nothrow_move_assignable_v<borrow_type>)
+      std::is_nothrow_move_constructible_v<T> &&
+      std::is_nothrow_move_assignable_v<borrow_type>)
       : isBorrowed_(rhs.isBorrowed_) {
     if (C10_LIKELY(rhs.isBorrowed_)) {
       MaybeOwnedTraits<T>::assignBorrow(borrow_, rhs.borrow_);
@@ -137,10 +137,11 @@ class MaybeOwned final {
   }
 
   MaybeOwned& operator=(MaybeOwned&& rhs) noexcept(
-      std::is_nothrow_move_assignable_v<T>&& std::is_nothrow_move_assignable_v<
-          borrow_type>&& std::is_nothrow_move_constructible_v<T>&&
-          std::is_nothrow_destructible_v<T>&&
-              std::is_nothrow_destructible_v<borrow_type>) {
+      std::is_nothrow_move_assignable_v<T> &&
+      std::is_nothrow_move_assignable_v<borrow_type> &&
+      std::is_nothrow_move_constructible_v<T> &&
+      std::is_nothrow_destructible_v<T> &&
+      std::is_nothrow_destructible_v<borrow_type>) {
     if (this == &rhs) {
       return *this;
     }
@@ -178,8 +179,9 @@ class MaybeOwned final {
     return MaybeOwned(std::in_place, std::forward<Args>(args)...);
   }
 
-  ~MaybeOwned() noexcept(std::is_nothrow_destructible_v<T>&&
-                             std::is_nothrow_destructible_v<borrow_type>) {
+  ~MaybeOwned() noexcept(
+      std::is_nothrow_destructible_v<T> &&
+      std::is_nothrow_destructible_v<borrow_type>) {
     if (C10_UNLIKELY(!isBorrowed_)) {
       own_.~T();
     } else {

--- a/c10/util/MaybeOwned.h
+++ b/c10/util/MaybeOwned.h
@@ -78,7 +78,7 @@ class MaybeOwned final {
 
   /// Don't use this; use owned() instead.
   explicit MaybeOwned(T&& t) noexcept(
-      std::is_nothrow_move_constructible<T>::value)
+      std::is_nothrow_move_constructible_v<T>)
       : isBorrowed_(false), own_(std::move(t)) {}
 
   /// Don't use this; use owned() instead.
@@ -171,7 +171,7 @@ class MaybeOwned final {
   }
 
   static MaybeOwned owned(T&& t) noexcept(
-      std::is_nothrow_move_constructible<T>::value) {
+      std::is_nothrow_move_constructible_v<T>) {
     return MaybeOwned(std::move(t));
   }
 

--- a/c10/util/Metaprogramming.h
+++ b/c10/util/Metaprogramming.h
@@ -17,7 +17,7 @@ namespace guts {
 template <class Func>
 struct function_traits {
   static_assert(
-      !std::is_same<Func, Func>::value,
+      !std::is_same_v<Func, Func>,
       "In function_traits<Func>, Func must be a plain function type.");
 };
 template <class Result, class... Args>

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -28,7 +28,7 @@ constexpr U convert(U v) {
 template <class T, class F>
 constexpr T value_or_else(const optional<T>& v, F&& func) {
   static_assert(
-      std::is_convertible<typename std::invoke_result_t<F>, T>::value,
+      std::is_convertible_v<typename std::invoke_result_t<F>, T>,
       "func parameters must be a callable that returns a type convertible to the value stored in the optional");
   return v.has_value() ? *v : detail_::convert<T>(std::forward<F>(func)());
 }
@@ -36,7 +36,7 @@ constexpr T value_or_else(const optional<T>& v, F&& func) {
 template <class T, class F>
 constexpr T value_or_else(optional<T>&& v, F&& func) {
   static_assert(
-      std::is_convertible<typename std::invoke_result_t<F>, T>::value,
+      std::is_convertible_v<typename std::invoke_result_t<F>, T>,
       "func parameters must be a callable that returns a type convertible to the value stored in the optional");
   return v.has_value() ? constexpr_move(std::move(v).contained_val())
                        : detail_::convert<T>(std::forward<F>(func)());

--- a/c10/util/OptionalArrayRef.h
+++ b/c10/util/OptionalArrayRef.h
@@ -117,8 +117,8 @@ class OptionalArrayRef final {
           std::is_assignable_v<ArrayRef<T>&, U&&>,
       OptionalArrayRef&>
   operator=(U&& value) noexcept(
-      std::is_nothrow_constructible_v<ArrayRef<T>, U&&> &&
-      std::is_nothrow_assignable_v<ArrayRef<T>&, U&&>) {
+      std::is_nothrow_constructible_v<ArrayRef<T>, U&&>&&
+          std::is_nothrow_assignable_v<ArrayRef<T>&, U&&>) {
     wrapped_opt_array_ref = std::forward<U>(value);
     return *this;
   }

--- a/c10/util/OptionalArrayRef.h
+++ b/c10/util/OptionalArrayRef.h
@@ -13,6 +13,10 @@
 
 #include <c10/util/ArrayRef.h>
 #include <c10/util/Optional.h>
+#include <cstdint>
+#include <initializer_list>
+#include <type_traits>
+#include <utility>
 
 namespace c10 {
 
@@ -33,7 +37,7 @@ class OptionalArrayRef final {
       : wrapped_opt_array_ref(other) {}
 
   constexpr OptionalArrayRef(optional<ArrayRef<T>>&& other) noexcept
-      : wrapped_opt_array_ref(other) {}
+      : wrapped_opt_array_ref(std::move(other)) {}
 
   constexpr OptionalArrayRef(const T& value) noexcept
       : wrapped_opt_array_ref(value) {}
@@ -41,40 +45,40 @@ class OptionalArrayRef final {
   template <
       typename U = ArrayRef<T>,
       std::enable_if_t<
-          !std::is_same<std::decay_t<U>, OptionalArrayRef>::value &&
-              !std::is_same<std::decay_t<U>, std::in_place_t>::value &&
-              std::is_constructible<ArrayRef<T>, U&&>::value &&
-              std::is_convertible<U&&, ArrayRef<T>>::value &&
-              !std::is_convertible<U&&, T>::value,
+          !std::is_same_v<std::decay_t<U>, OptionalArrayRef> &&
+              !std::is_same_v<std::decay_t<U>, std::in_place_t> &&
+              std::is_constructible_v<ArrayRef<T>, U&&> &&
+              std::is_convertible_v<U&&, ArrayRef<T>> &&
+              !std::is_convertible_v<U&&, T>,
           bool> = false>
   constexpr OptionalArrayRef(U&& value) noexcept(
-      std::is_nothrow_constructible<ArrayRef<T>, U&&>::value)
-      : wrapped_opt_array_ref(value) {}
+      std::is_nothrow_constructible_v<ArrayRef<T>, U&&>)
+      : wrapped_opt_array_ref(std::forward<U>(value)) {}
 
   template <
       typename U = ArrayRef<T>,
       std::enable_if_t<
-          !std::is_same<std::decay_t<U>, OptionalArrayRef>::value &&
-              !std::is_same<std::decay_t<U>, std::in_place_t>::value &&
-              std::is_constructible<ArrayRef<T>, U&&>::value &&
-              !std::is_convertible<U&&, ArrayRef<T>>::value,
+          !std::is_same_v<std::decay_t<U>, OptionalArrayRef> &&
+              !std::is_same_v<std::decay_t<U>, std::in_place_t> &&
+              std::is_constructible_v<ArrayRef<T>, U&&> &&
+              !std::is_convertible_v<U&&, ArrayRef<T>>,
           bool> = false>
   constexpr explicit OptionalArrayRef(U&& value) noexcept(
-      std::is_nothrow_constructible<ArrayRef<T>, U&&>::value)
-      : wrapped_opt_array_ref(value) {}
+      std::is_nothrow_constructible_v<ArrayRef<T>, U&&>)
+      : wrapped_opt_array_ref(std::forward<U>(value)) {}
 
   template <typename... Args>
   constexpr explicit OptionalArrayRef(
       std::in_place_t ip,
       Args&&... args) noexcept
-      : wrapped_opt_array_ref(ip, args...) {}
+      : wrapped_opt_array_ref(ip, std::forward<Args>(args)...) {}
 
   template <typename U, typename... Args>
   constexpr explicit OptionalArrayRef(
       std::in_place_t ip,
       std::initializer_list<U> il,
       Args&&... args)
-      : wrapped_opt_array_ref(ip, il, args...) {}
+      : wrapped_opt_array_ref(ip, il, std::forward<Args>(args)...) {}
 
   constexpr OptionalArrayRef(const std::initializer_list<T>& Vec)
       : wrapped_opt_array_ref(ArrayRef<T>(Vec)) {}
@@ -102,20 +106,20 @@ class OptionalArrayRef final {
 
   constexpr OptionalArrayRef& operator=(
       optional<ArrayRef<T>>&& other) noexcept {
-    wrapped_opt_array_ref = other;
+    wrapped_opt_array_ref = std::move(other);
     return *this;
   }
 
   template <typename U = ArrayRef<T>>
   constexpr std::enable_if_t<
-      !std::is_same<std::decay_t<U>, OptionalArrayRef>::value &&
-          std::is_constructible<ArrayRef<T>, U&&>::value &&
-          std::is_assignable<ArrayRef<T>&, U&&>::value,
+      !std::is_same_v<std::decay_t<U>, OptionalArrayRef> &&
+          std::is_constructible_v<ArrayRef<T>, U&&> &&
+          std::is_assignable_v<ArrayRef<T>&, U&&>,
       OptionalArrayRef&>
   operator=(U&& value) noexcept(
-      std::is_nothrow_constructible<ArrayRef<T>, U&&>::value &&
-      std::is_nothrow_assignable<ArrayRef<T>&, U&&>::value) {
-    wrapped_opt_array_ref = value;
+      std::is_nothrow_constructible_v<ArrayRef<T>, U&&> &&
+      std::is_nothrow_assignable_v<ArrayRef<T>&, U&&>) {
+    wrapped_opt_array_ref = std::forward<U>(value);
     return *this;
   }
 
@@ -171,16 +175,16 @@ class OptionalArrayRef final {
 
   template <typename U>
   constexpr std::
-      enable_if_t<std::is_convertible<U&&, ArrayRef<T>>::value, ArrayRef<T>>
+      enable_if_t<std::is_convertible_v<U&&, ArrayRef<T>>, ArrayRef<T>>
       value_or(U&& default_value) const& {
-    return wrapped_opt_array_ref.value_or(default_value);
+    return wrapped_opt_array_ref.value_or(std::forward<U>(default_value));
   }
 
   template <typename U>
   constexpr std::
-      enable_if_t<std::is_convertible<U&&, ArrayRef<T>>::value, ArrayRef<T>>
+      enable_if_t<std::is_convertible_v<U&&, ArrayRef<T>>, ArrayRef<T>>
       value_or(U&& default_value) && {
-    return wrapped_opt_array_ref.value_or(default_value);
+    return wrapped_opt_array_ref.value_or(std::forward<U>(default_value));
   }
 
   // Modifiers
@@ -194,19 +198,18 @@ class OptionalArrayRef final {
   }
 
   template <typename... Args>
-  constexpr std::enable_if_t<
-      std::is_constructible<ArrayRef<T>, Args&&...>::value,
-      ArrayRef<T>&>
-  emplace(Args&&... args) noexcept(
-      std::is_nothrow_constructible<ArrayRef<T>, Args&&...>::value) {
-    return wrapped_opt_array_ref.emplace(args...);
+  constexpr std::
+      enable_if_t<std::is_constructible_v<ArrayRef<T>, Args&&...>, ArrayRef<T>&>
+      emplace(Args&&... args) noexcept(
+          std::is_nothrow_constructible_v<ArrayRef<T>, Args&&...>) {
+    return wrapped_opt_array_ref.emplace(std::forward<Args>(args)...);
   }
 
   template <typename U, typename... Args>
   constexpr ArrayRef<T>& emplace(
       std::initializer_list<U> il,
       Args&&... args) noexcept {
-    return wrapped_opt_array_ref.emplace(il, args...);
+    return wrapped_opt_array_ref.emplace(il, std::forward<Args>(args)...);
   }
 
  private:

--- a/c10/util/OptionalArrayRef.h
+++ b/c10/util/OptionalArrayRef.h
@@ -117,8 +117,8 @@ class OptionalArrayRef final {
           std::is_assignable_v<ArrayRef<T>&, U&&>,
       OptionalArrayRef&>
   operator=(U&& value) noexcept(
-      std::is_nothrow_constructible_v<ArrayRef<T>, U&&>&&
-          std::is_nothrow_assignable_v<ArrayRef<T>&, U&&>) {
+      std::is_nothrow_constructible_v<ArrayRef<T>, U&&> &&
+      std::is_nothrow_assignable_v<ArrayRef<T>&, U&&>) {
     wrapped_opt_array_ref = std::forward<U>(value);
     return *this;
   }

--- a/c10/util/Registry.h
+++ b/c10/util/Registry.h
@@ -56,8 +56,7 @@ class Registry {
  public:
   typedef std::function<ObjectPtrType(Args...)> Creator;
 
-  Registry(bool warning = true)
-      : registry_(), priority_(), terminate_(true), warning_(warning) {}
+  Registry(bool warning = true) : registry_(), priority_(), warning_(warning) {}
 
   void Register(
       const SrcType& key,
@@ -156,7 +155,7 @@ class Registry {
  private:
   std::unordered_map<SrcType, Creator> registry_;
   std::unordered_map<SrcType, RegistryPriority> priority_;
-  bool terminate_;
+  bool terminate_{true};
   const bool warning_;
   std::unordered_map<SrcType, std::string> help_message_;
   std::mutex register_mutex_;

--- a/c10/util/SmallVector.h
+++ b/c10/util/SmallVector.h
@@ -1019,7 +1019,7 @@ class SmallVectorImpl : public SmallVectorTemplateBase<T> {
 
   SmallVectorImpl& operator=(SmallVectorImpl&& RHS) noexcept(
       std::is_nothrow_move_constructible_v<T>&&
-std::is_nothrow_destructible_v<T>);
+          std::is_nothrow_destructible_v<T>);
 
   bool operator==(const SmallVectorImpl& RHS) const {
     if (this->size() != RHS.size())
@@ -1125,9 +1125,8 @@ SmallVectorImpl<T>& SmallVectorImpl<T>::operator=(
 
 template <typename T>
 SmallVectorImpl<T>& SmallVectorImpl<T>::operator=(
-    SmallVectorImpl<T>&& RHS) noexcept(
-    std::is_nothrow_move_constructible_v<T>&&
-std::is_nothrow_destructible_v<T>) {
+    SmallVectorImpl<T>&& RHS) noexcept(std::is_nothrow_move_constructible_v<T>&&
+                                           std::is_nothrow_destructible_v<T>) {
   // Avoid self-assignment.
   if (this == &RHS)
     return *this;

--- a/c10/util/SmallVector.h
+++ b/c10/util/SmallVector.h
@@ -1018,8 +1018,8 @@ class SmallVectorImpl : public SmallVectorTemplateBase<T> {
   SmallVectorImpl& operator=(const SmallVectorImpl& RHS);
 
   SmallVectorImpl& operator=(SmallVectorImpl&& RHS) noexcept(
-      std::is_nothrow_move_constructible_v<T> &&
-      std::is_nothrow_destructible_v<T>);
+      std::is_nothrow_move_constructible_v<T>&&
+std::is_nothrow_destructible_v<T>);
 
   bool operator==(const SmallVectorImpl& RHS) const {
     if (this->size() != RHS.size())
@@ -1124,10 +1124,10 @@ SmallVectorImpl<T>& SmallVectorImpl<T>::operator=(
 }
 
 template <typename T>
-SmallVectorImpl<T>& SmallVectorImpl<T>::
-operator=(SmallVectorImpl<T>&& RHS) noexcept(
-    std::is_nothrow_move_constructible_v<T> &&
-    std::is_nothrow_destructible_v<T>) {
+SmallVectorImpl<T>& SmallVectorImpl<T>::operator=(
+    SmallVectorImpl<T>&& RHS) noexcept(
+    std::is_nothrow_move_constructible_v<T>&&
+std::is_nothrow_destructible_v<T>) {
   // Avoid self-assignment.
   if (this == &RHS)
     return *this;

--- a/c10/util/SmallVector.h
+++ b/c10/util/SmallVector.h
@@ -34,7 +34,6 @@
 #include <iterator>
 #include <limits>
 #include <memory>
-#include <new>
 #include <ostream>
 #include <type_traits>
 #include <utility>
@@ -107,8 +106,8 @@ class C10_API SmallVectorBase {
 };
 
 template <class T>
-using SmallVectorSizeType = typename std::
-    conditional<sizeof(T) < 4 && sizeof(void*) >= 8, uint64_t, uint32_t>::type;
+using SmallVectorSizeType =
+    std::conditional_t<sizeof(T) < 4 && sizeof(void*) >= 8, uint64_t, uint32_t>;
 
 /// Figure out the offset of the first element.
 template <class T, typename = void>
@@ -217,9 +216,8 @@ class SmallVectorTemplateCommon
   }
   template <
       class ItTy,
-      std::enable_if_t<
-          !std::is_same<std::remove_const_t<ItTy>, T*>::value,
-          bool> = false>
+      std::enable_if_t<!std::is_same_v<std::remove_const_t<ItTy>, T*>, bool> =
+          false>
   void assertSafeToReferenceAfterClear(ItTy, ItTy) {}
 
   /// Check whether any part of the range will be invalidated by growing.
@@ -231,9 +229,8 @@ class SmallVectorTemplateCommon
   }
   template <
       class ItTy,
-      std::enable_if_t<
-          !std::is_same<std::remove_const_t<ItTy>, T*>::value,
-          bool> = false>
+      std::enable_if_t<!std::is_same_v<std::remove_const_t<ItTy>, T*>, bool> =
+          false>
   void assertSafeToAddRange(ItTy, ItTy) {}
 
   /// Reserve enough space to add one element, and return the updated element
@@ -376,9 +373,9 @@ class SmallVectorTemplateCommon
 /// note
 template <
     typename T,
-    bool = (std::is_trivially_copy_constructible<T>::value) &&
-        (std::is_trivially_move_constructible<T>::value) &&
-        std::is_trivially_destructible<T>::value>
+    bool = (std::is_trivially_copy_constructible_v<T>)&&(
+        std::is_trivially_move_constructible_v<
+            T>)&&std::is_trivially_destructible_v<T>>
 class SmallVectorTemplateBase : public SmallVectorTemplateCommon<T> {
   friend class SmallVectorTemplateCommon<T>;
 
@@ -538,8 +535,7 @@ class SmallVectorTemplateBase<T, true> : public SmallVectorTemplateCommon<T> {
 
   /// Either const T& or T, depending on whether it's cheap enough to take
   /// parameters by value.
-  using ValueParamT =
-      typename std::conditional<TakesParamByValue, T, const T&>::type;
+  using ValueParamT = std::conditional_t<TakesParamByValue, T, const T&>;
 
   SmallVectorTemplateBase(size_t Size) : SmallVectorTemplateCommon<T>(Size) {}
 
@@ -569,8 +565,7 @@ class SmallVectorTemplateBase<T, true> : public SmallVectorTemplateCommon<T> {
       T1* I,
       T1* E,
       T2* Dest,
-      std::enable_if_t<
-          std::is_same<typename std::remove_const<T1>::type, T2>::value>* =
+      std::enable_if_t<std::is_same_v<std::remove_const_t<T1>, T2>>* =
           nullptr) {
     // Use memcpy for PODs iterated by pointers (which includes SmallVector
     // iterators): std::uninitialized_copy optimizes to memmove, but we can
@@ -723,14 +718,14 @@ class SmallVectorImpl : public SmallVectorTemplateBase<T> {
     return Result;
   }
 
-  void swap(SmallVectorImpl& RHS);
+  void swap(SmallVectorImpl& RHS) noexcept;
 
   /// Add the specified range to the end of the SmallVector.
   template <
       typename in_iter,
-      typename = std::enable_if_t<std::is_convertible<
+      typename = std::enable_if_t<std::is_convertible_v<
           typename std::iterator_traits<in_iter>::iterator_category,
-          std::input_iterator_tag>::value>>
+          std::input_iterator_tag>>>
   void append(in_iter in_start, in_iter in_end) {
     this->assertSafeToAddRange(in_start, in_end);
     size_type NumInputs = std::distance(in_start, in_end);
@@ -775,9 +770,9 @@ class SmallVectorImpl : public SmallVectorTemplateBase<T> {
 
   template <
       typename in_iter,
-      typename = std::enable_if_t<std::is_convertible<
+      typename = std::enable_if_t<std::is_convertible_v<
           typename std::iterator_traits<in_iter>::iterator_category,
-          std::input_iterator_tag>::value>>
+          std::input_iterator_tag>>>
   void assign(in_iter in_start, in_iter in_end) {
     this->assertSafeToReferenceAfterClear(in_start, in_end);
     clear();
@@ -941,9 +936,9 @@ class SmallVectorImpl : public SmallVectorTemplateBase<T> {
 
   template <
       typename ItTy,
-      typename = std::enable_if_t<std::is_convertible<
+      typename = std::enable_if_t<std::is_convertible_v<
           typename std::iterator_traits<ItTy>::iterator_category,
-          std::input_iterator_tag>::value>>
+          std::input_iterator_tag>>>
   iterator insert(iterator I, ItTy From, ItTy To) {
     // Convert iterator to elt# to avoid invalidating iterator when we reserve()
     size_t InsertElt = I - this->begin();
@@ -1042,7 +1037,7 @@ class SmallVectorImpl : public SmallVectorTemplateBase<T> {
 };
 
 template <typename T>
-void SmallVectorImpl<T>::swap(SmallVectorImpl<T>& RHS) {
+void SmallVectorImpl<T>::swap(SmallVectorImpl<T>& RHS) noexcept {
   if (this == &RHS)
     return;
 
@@ -1303,9 +1298,9 @@ class /* LLVM_GSL_OWNER */ SmallVector : public SmallVectorImpl<T>,
 
   template <
       typename ItTy,
-      typename = std::enable_if_t<std::is_convertible<
+      typename = std::enable_if_t<std::is_convertible_v<
           typename std::iterator_traits<ItTy>::iterator_category,
-          std::input_iterator_tag>::value>>
+          std::input_iterator_tag>>>
   SmallVector(ItTy S, ItTy E) : SmallVectorImpl<T>(N) {
     this->append(S, E);
   }
@@ -1315,16 +1310,16 @@ class /* LLVM_GSL_OWNER */ SmallVector : public SmallVectorImpl<T>,
   template <
       typename Container,
       std::enable_if_t<
-          std::is_convertible<
+          std::is_convertible_v<
               typename std::iterator_traits<
                   decltype(std::declval<Container>()
                                .begin())>::iterator_category,
-              std::input_iterator_tag>::value &&
-              std::is_convertible<
+              std::input_iterator_tag> &&
+              std::is_convertible_v<
                   typename std::iterator_traits<
                       decltype(std::declval<Container>()
                                    .end())>::iterator_category,
-                  std::input_iterator_tag>::value,
+                  std::input_iterator_tag>,
           int> = 0>
   explicit SmallVector(Container&& c) : SmallVectorImpl<T>(N) {
     this->append(c.begin(), c.end());
@@ -1356,16 +1351,16 @@ class /* LLVM_GSL_OWNER */ SmallVector : public SmallVectorImpl<T>,
   template <
       typename Container,
       std::enable_if_t<
-          std::is_convertible<
+          std::is_convertible_v<
               typename std::iterator_traits<
                   decltype(std::declval<Container>()
                                .begin())>::iterator_category,
-              std::input_iterator_tag>::value &&
-              std::is_convertible<
+              std::input_iterator_tag> &&
+              std::is_convertible_v<
                   typename std::iterator_traits<
                       decltype(std::declval<Container>()
                                    .end())>::iterator_category,
-                  std::input_iterator_tag>::value,
+                  std::input_iterator_tag>,
           int> = 0>
   SmallVector& operator=(const Container& RHS) {
     this->assign(RHS.begin(), RHS.end());
@@ -1396,16 +1391,16 @@ class /* LLVM_GSL_OWNER */ SmallVector : public SmallVectorImpl<T>,
   template <
       typename Container,
       std::enable_if_t<
-          std::is_convertible<
+          std::is_convertible_v<
               typename std::iterator_traits<
                   decltype(std::declval<Container>()
                                .begin())>::iterator_category,
-              std::input_iterator_tag>::value &&
-              std::is_convertible<
+              std::input_iterator_tag> &&
+              std::is_convertible_v<
                   typename std::iterator_traits<
                       decltype(std::declval<Container>()
                                    .end())>::iterator_category,
-                  std::input_iterator_tag>::value,
+                  std::input_iterator_tag>,
           int> = 0>
   SmallVector& operator=(Container&& C) {
     this->assign(C.begin(), C.end());
@@ -1437,9 +1432,8 @@ std::ostream& operator<<(std::ostream& out, const SmallVector<T, N>& list) {
 }
 
 template <typename RangeType>
-using ValueTypeFromRangeType =
-    typename std::remove_const<typename std::remove_reference<
-        decltype(*std::begin(std::declval<RangeType&>()))>::type>::type;
+using ValueTypeFromRangeType = std::remove_const_t<
+    std::remove_reference_t<decltype(*std::begin(std::declval<RangeType&>()))>>;
 
 /// Given a range of type R, iterate the entire range and return a
 /// SmallVector with elements of the vector.  This is useful, for example,
@@ -1463,13 +1457,17 @@ namespace std {
 
 /// Implement std::swap in terms of SmallVector swap.
 template <typename T>
-inline void swap(c10::SmallVectorImpl<T>& LHS, c10::SmallVectorImpl<T>& RHS) {
+inline void swap(
+    c10::SmallVectorImpl<T>& LHS,
+    c10::SmallVectorImpl<T>& RHS) noexcept {
   LHS.swap(RHS);
 }
 
 /// Implement std::swap in terms of SmallVector swap.
 template <typename T, unsigned N>
-inline void swap(c10::SmallVector<T, N>& LHS, c10::SmallVector<T, N>& RHS) {
+inline void swap(
+    c10::SmallVector<T, N>& LHS,
+    c10::SmallVector<T, N>& RHS) noexcept {
   LHS.swap(RHS);
 }
 

--- a/c10/util/SmallVector.h
+++ b/c10/util/SmallVector.h
@@ -1018,8 +1018,8 @@ class SmallVectorImpl : public SmallVectorTemplateBase<T> {
   SmallVectorImpl& operator=(const SmallVectorImpl& RHS);
 
   SmallVectorImpl& operator=(SmallVectorImpl&& RHS) noexcept(
-      std::is_nothrow_move_constructible_v<T>&&
-          std::is_nothrow_destructible_v<T>);
+      std::is_nothrow_move_constructible_v<T> &&
+      std::is_nothrow_destructible_v<T>);
 
   bool operator==(const SmallVectorImpl& RHS) const {
     if (this->size() != RHS.size())
@@ -1124,9 +1124,10 @@ SmallVectorImpl<T>& SmallVectorImpl<T>::operator=(
 }
 
 template <typename T>
-SmallVectorImpl<T>& SmallVectorImpl<T>::operator=(
-    SmallVectorImpl<T>&& RHS) noexcept(std::is_nothrow_move_constructible_v<T>&&
-                                           std::is_nothrow_destructible_v<T>) {
+SmallVectorImpl<T>& SmallVectorImpl<T>::
+operator=(SmallVectorImpl<T>&& RHS) noexcept(
+    std::is_nothrow_move_constructible_v<T> &&
+    std::is_nothrow_destructible_v<T>) {
   // Avoid self-assignment.
   if (this == &RHS)
     return *this;

--- a/c10/util/TypeCast.h
+++ b/c10/util/TypeCast.h
@@ -155,7 +155,7 @@ C10_API void report_overflow(const char* name);
 template <typename To, typename From>
 To checked_convert(From f, const char* name) {
   // Converting to bool can't overflow so we exclude this case from checking.
-  if (!std::is_same<To, bool>::value && overflows<To, From>(f)) {
+  if (!std::is_same_v<To, bool> && overflows<To, From>(f)) {
     report_overflow(name);
   }
   return convert<To, From>(f);

--- a/c10/util/TypeList.h
+++ b/c10/util/TypeList.h
@@ -172,12 +172,12 @@ template <class Type, class Head, class... Tail>
 struct contains<
     typelist<Head, Tail...>,
     Type,
-    std::enable_if_t<std::is_same<Head, Type>::value>> : std::true_type {};
+    std::enable_if_t<std::is_same_v<Head, Type>>> : std::true_type {};
 template <class Type, class Head, class... Tail>
 struct contains<
     typelist<Head, Tail...>,
     Type,
-    std::enable_if_t<!std::is_same<Head, Type>::value>>
+    std::enable_if_t<!std::is_same_v<Head, Type>>>
     : contains<typelist<Tail...>, Type> {};
 } // namespace detail
 template <class TypeList, class Type>
@@ -339,7 +339,7 @@ struct last<typelist<Head>> final {
 };
 template <class TypeList>
 using last_t = typename last<TypeList>::type;
-static_assert(std::is_same<int, last_t<typelist<double, float, int>>>::value);
+static_assert(std::is_same_v<int, last_t<typelist<double, float, int>>>);
 
 /**
  * Take/drop a number of arguments from a typelist.

--- a/c10/util/accumulate.h
+++ b/c10/util/accumulate.h
@@ -13,9 +13,7 @@ namespace c10 {
 /// Sum of a list of integers; accumulates into the int64_t datatype
 template <
     typename C,
-    typename std::enable_if<
-        std::is_integral<typename C::value_type>::value,
-        int>::type = 0>
+    std::enable_if_t<std::is_integral_v<typename C::value_type>, int> = 0>
 inline int64_t sum_integers(const C& container) {
   // std::accumulate infers return type from `init` type, so if the `init` type
   // is not large enough to hold the result, computation can overflow. We use
@@ -28,10 +26,9 @@ inline int64_t sum_integers(const C& container) {
 /// int64_t datatype
 template <
     typename Iter,
-    typename std::enable_if<
-        std::is_integral<
-            typename std::iterator_traits<Iter>::value_type>::value,
-        int>::type = 0>
+    std::enable_if_t<
+        std::is_integral_v<typename std::iterator_traits<Iter>::value_type>,
+        int> = 0>
 inline int64_t sum_integers(Iter begin, Iter end) {
   // std::accumulate infers return type from `init` type, so if the `init` type
   // is not large enough to hold the result, computation can overflow. We use
@@ -42,9 +39,7 @@ inline int64_t sum_integers(Iter begin, Iter end) {
 /// Product of a list of integers; accumulates into the int64_t datatype
 template <
     typename C,
-    typename std::enable_if<
-        std::is_integral<typename C::value_type>::value,
-        int>::type = 0>
+    std::enable_if_t<std::is_integral_v<typename C::value_type>, int> = 0>
 inline int64_t multiply_integers(const C& container) {
   // std::accumulate infers return type from `init` type, so if the `init` type
   // is not large enough to hold the result, computation can overflow. We use
@@ -60,10 +55,9 @@ inline int64_t multiply_integers(const C& container) {
 /// int64_t datatype
 template <
     typename Iter,
-    typename std::enable_if<
-        std::is_integral<
-            typename std::iterator_traits<Iter>::value_type>::value,
-        int>::type = 0>
+    std::enable_if_t<
+        std::is_integral_v<typename std::iterator_traits<Iter>::value_type>,
+        int> = 0>
 inline int64_t multiply_integers(Iter begin, Iter end) {
   // std::accumulate infers return type from `init` type, so if the `init` type
   // is not large enough to hold the result, computation can overflow. We use
@@ -76,9 +70,7 @@ inline int64_t multiply_integers(Iter begin, Iter end) {
 /// Returns 1 if k>=dims.size()
 template <
     typename C,
-    typename std::enable_if<
-        std::is_integral<typename C::value_type>::value,
-        int>::type = 0>
+    std::enable_if_t<std::is_integral_v<typename C::value_type>, int> = 0>
 inline int64_t numelements_from_dim(const int k, const C& dims) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(k >= 0);
 
@@ -95,9 +87,7 @@ inline int64_t numelements_from_dim(const int k, const C& dims) {
 /// Throws an error if k>dims.size()
 template <
     typename C,
-    typename std::enable_if<
-        std::is_integral<typename C::value_type>::value,
-        int>::type = 0>
+    std::enable_if_t<std::is_integral_v<typename C::value_type>, int> = 0>
 inline int64_t numelements_to_dim(const int k, const C& dims) {
   TORCH_INTERNAL_ASSERT(0 <= k);
   TORCH_INTERNAL_ASSERT((unsigned)k <= dims.size());
@@ -111,9 +101,7 @@ inline int64_t numelements_to_dim(const int k, const C& dims) {
 /// dims[l]) k and l may be supplied in either order
 template <
     typename C,
-    typename std::enable_if<
-        std::is_integral<typename C::value_type>::value,
-        int>::type = 0>
+    std::enable_if_t<std::is_integral_v<typename C::value_type>, int> = 0>
 inline int64_t numelements_between_dim(int k, int l, const C& dims) {
   TORCH_INTERNAL_ASSERT(0 <= k);
   TORCH_INTERNAL_ASSERT(0 <= l);

--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -368,7 +368,7 @@ class intrusive_ptr final {
   }
 
   intrusive_ptr& operator=(intrusive_ptr&& rhs) & noexcept {
-    return operator= <TTarget, NullType>(std::move(rhs));
+    return operator=<TTarget, NullType>(std::move(rhs));
   }
 
   template <class From, class FromNullType>
@@ -385,7 +385,7 @@ class intrusive_ptr final {
     if (this == &rhs) {
       return *this;
     }
-    return operator= <TTarget, NullType>(rhs);
+    return operator=<TTarget, NullType>(rhs);
   }
 
   template <class From, class FromNullType>
@@ -753,7 +753,7 @@ class weak_intrusive_ptr final {
   }
 
   weak_intrusive_ptr& operator=(weak_intrusive_ptr&& rhs) & noexcept {
-    return operator= <TTarget, NullType>(std::move(rhs));
+    return operator=<TTarget, NullType>(std::move(rhs));
   }
 
   template <class From, class FromNullType>
@@ -771,7 +771,7 @@ class weak_intrusive_ptr final {
     if (this == &rhs) {
       return *this;
     }
-    return operator= <TTarget, NullType>(rhs);
+    return operator=<TTarget, NullType>(rhs);
   }
 
   weak_intrusive_ptr& operator=(

--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -235,10 +235,9 @@ class intrusive_ptr final {
       "NullType must have a constexpr singleton() method");
 #endif
   static_assert(
-      std::is_base_of<
+      std::is_base_of_v<
           TTarget,
-          typename std::remove_pointer<decltype(NullType::singleton())>::type>::
-          value,
+          std::remove_pointer_t<decltype(NullType::singleton())>>,
       "NullType::singleton() must return a element_type* pointer");
 
   TTarget* target_;
@@ -670,7 +669,7 @@ template <
 class weak_intrusive_ptr final {
  private:
   static_assert(
-      std::is_base_of<intrusive_ptr_target, TTarget>::value,
+      std::is_base_of_v<intrusive_ptr_target, TTarget>,
       "intrusive_ptr can only be used for classes that inherit from intrusive_ptr_target.");
 #ifndef _WIN32
   // This static_assert triggers on MSVC
@@ -680,10 +679,9 @@ class weak_intrusive_ptr final {
       "NullType must have a constexpr singleton() method");
 #endif
   static_assert(
-      std::is_base_of<
+      std::is_base_of_v<
           TTarget,
-          typename std::remove_pointer<decltype(NullType::singleton())>::type>::
-          value,
+          std::remove_pointer_t<decltype(NullType::singleton())>>,
       "NullType::singleton() must return a element_type* pointer");
 
   TTarget* target_;

--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -368,7 +368,7 @@ class intrusive_ptr final {
   }
 
   intrusive_ptr& operator=(intrusive_ptr&& rhs) & noexcept {
-    return operator=<TTarget, NullType>(std::move(rhs));
+    return operator= <TTarget, NullType>(std::move(rhs));
   }
 
   template <class From, class FromNullType>
@@ -385,7 +385,7 @@ class intrusive_ptr final {
     if (this == &rhs) {
       return *this;
     }
-    return operator=<TTarget, NullType>(rhs);
+    return operator= <TTarget, NullType>(rhs);
   }
 
   template <class From, class FromNullType>
@@ -753,7 +753,7 @@ class weak_intrusive_ptr final {
   }
 
   weak_intrusive_ptr& operator=(weak_intrusive_ptr&& rhs) & noexcept {
-    return operator=<TTarget, NullType>(std::move(rhs));
+    return operator= <TTarget, NullType>(std::move(rhs));
   }
 
   template <class From, class FromNullType>
@@ -771,7 +771,7 @@ class weak_intrusive_ptr final {
     if (this == &rhs) {
       return *this;
     }
-    return operator=<TTarget, NullType>(rhs);
+    return operator= <TTarget, NullType>(rhs);
   }
 
   weak_intrusive_ptr& operator=(

--- a/c10/util/llvmMathExtras.h
+++ b/c10/util/llvmMathExtras.h
@@ -366,14 +366,12 @@ constexpr inline bool isShiftedInt(int64_t x) {
 /// to keep MSVC from (incorrectly) warning on isUInt<64> that we're shifting
 /// left too many places.
 template <unsigned N>
-constexpr inline std::enable_if_t<(N < 64), bool>isUInt(
-    uint64_t X) {
+constexpr inline std::enable_if_t<(N < 64), bool> isUInt(uint64_t X) {
   static_assert(N > 0, "isUInt<0> doesn't make sense");
   return X < (UINT64_C(1) << (N));
 }
 template <unsigned N>
-constexpr inline std::enable_if_t<N >= 64, bool>isUInt(
-    uint64_t /*X*/) {
+constexpr inline std::enable_if_t<N >= 64, bool> isUInt(uint64_t /*X*/) {
   return true;
 }
 
@@ -807,9 +805,7 @@ inline int64_t SignExtend64(uint64_t X, unsigned B) {
 /// Subtract two unsigned integers, X and Y, of type T and return the absolute
 /// value of the result.
 template <typename T>
-std::enable_if_t<std::is_unsigned_v<T>, T>AbsoluteDifference(
-    T X,
-    T Y) {
+std::enable_if_t<std::is_unsigned_v<T>, T> AbsoluteDifference(T X, T Y) {
   return std::max(X, Y) - std::min(X, Y);
 }
 
@@ -817,7 +813,7 @@ std::enable_if_t<std::is_unsigned_v<T>, T>AbsoluteDifference(
 /// maximum representable value of T on overflow.  ResultOverflowed indicates if
 /// the result is larger than the maximum representable value of type T.
 template <typename T>
-std::enable_if_t<std::is_unsigned_v<T>, T>SaturatingAdd(
+std::enable_if_t<std::is_unsigned_v<T>, T> SaturatingAdd(
     T X,
     T Y,
     bool* ResultOverflowed = nullptr) {
@@ -837,7 +833,7 @@ std::enable_if_t<std::is_unsigned_v<T>, T>SaturatingAdd(
 /// maximum representable value of T on overflow.  ResultOverflowed indicates if
 /// the result is larger than the maximum representable value of type T.
 template <typename T>
-std::enable_if_t<std::is_unsigned_v<T>, T>SaturatingMultiply(
+std::enable_if_t<std::is_unsigned_v<T>, T> SaturatingMultiply(
     T X,
     T Y,
     bool* ResultOverflowed = nullptr) {
@@ -886,8 +882,11 @@ std::enable_if_t<std::is_unsigned_v<T>, T>SaturatingMultiply(
 /// overflow. ResultOverflowed indicates if the result is larger than the
 /// maximum representable value of type T.
 template <typename T>
-std::enable_if_t<std::is_unsigned_v<T>, T>
-SaturatingMultiplyAdd(T X, T Y, T A, bool* ResultOverflowed = nullptr) {
+std::enable_if_t<std::is_unsigned_v<T>, T> SaturatingMultiplyAdd(
+    T X,
+    T Y,
+    T A,
+    bool* ResultOverflowed = nullptr) {
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   bool Dummy;
   bool& Overflowed = ResultOverflowed ? *ResultOverflowed : Dummy;

--- a/c10/util/llvmMathExtras.h
+++ b/c10/util/llvmMathExtras.h
@@ -236,7 +236,7 @@ T findFirstSet(T Val, ZeroBehavior ZB = ZB_Max) {
 /// bits set to 0.  Only unsigned types are allowed.
 template <typename T>
 T maskTrailingOnes(unsigned N) {
-  static_assert(std::is_unsigned<T>::value, "Invalid type!");
+  static_assert(std::is_unsigned_v<T>, "Invalid type!");
   const unsigned Bits = CHAR_BIT * sizeof(T);
   assert(N <= Bits && "Invalid bit index");
   return N == 0 ? 0 : (T(-1) >> (Bits - N));
@@ -366,13 +366,13 @@ constexpr inline bool isShiftedInt(int64_t x) {
 /// to keep MSVC from (incorrectly) warning on isUInt<64> that we're shifting
 /// left too many places.
 template <unsigned N>
-constexpr inline typename std::enable_if<(N < 64), bool>::type isUInt(
+constexpr inline std::enable_if_t<(N < 64), bool>isUInt(
     uint64_t X) {
   static_assert(N > 0, "isUInt<0> doesn't make sense");
   return X < (UINT64_C(1) << (N));
 }
 template <unsigned N>
-constexpr inline typename std::enable_if<N >= 64, bool>::type isUInt(
+constexpr inline std::enable_if_t<N >= 64, bool>isUInt(
     uint64_t /*X*/) {
   return true;
 }
@@ -807,7 +807,7 @@ inline int64_t SignExtend64(uint64_t X, unsigned B) {
 /// Subtract two unsigned integers, X and Y, of type T and return the absolute
 /// value of the result.
 template <typename T>
-typename std::enable_if<std::is_unsigned<T>::value, T>::type AbsoluteDifference(
+std::enable_if_t<std::is_unsigned_v<T>, T>AbsoluteDifference(
     T X,
     T Y) {
   return std::max(X, Y) - std::min(X, Y);
@@ -817,7 +817,7 @@ typename std::enable_if<std::is_unsigned<T>::value, T>::type AbsoluteDifference(
 /// maximum representable value of T on overflow.  ResultOverflowed indicates if
 /// the result is larger than the maximum representable value of type T.
 template <typename T>
-typename std::enable_if<std::is_unsigned<T>::value, T>::type SaturatingAdd(
+std::enable_if_t<std::is_unsigned_v<T>, T>SaturatingAdd(
     T X,
     T Y,
     bool* ResultOverflowed = nullptr) {
@@ -837,7 +837,7 @@ typename std::enable_if<std::is_unsigned<T>::value, T>::type SaturatingAdd(
 /// maximum representable value of T on overflow.  ResultOverflowed indicates if
 /// the result is larger than the maximum representable value of type T.
 template <typename T>
-typename std::enable_if<std::is_unsigned<T>::value, T>::type SaturatingMultiply(
+std::enable_if_t<std::is_unsigned_v<T>, T>SaturatingMultiply(
     T X,
     T Y,
     bool* ResultOverflowed = nullptr) {
@@ -886,7 +886,7 @@ typename std::enable_if<std::is_unsigned<T>::value, T>::type SaturatingMultiply(
 /// overflow. ResultOverflowed indicates if the result is larger than the
 /// maximum representable value of type T.
 template <typename T>
-typename std::enable_if<std::is_unsigned<T>::value, T>::type
+std::enable_if_t<std::is_unsigned_v<T>, T>
 SaturatingMultiplyAdd(T X, T Y, T A, bool* ResultOverflowed = nullptr) {
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   bool Dummy;


### PR DESCRIPTION
This PR continues to fix clang-tidy warnings for headers in c10/core and c10/util.