### PR TITLE
Add tune_bsr_dense_addmm as an API to find optimal triton kernel parameters for bsr_dense_addmm

### DIFF
--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -4000,6 +4000,47 @@ class TestSparseCompressedTritonKernels(TestCase):
                 result = operation(*args, **kwargs)
                 self.assertEqual(result, expected)
 
+    @parametrize("op", ['bsr_dense_addmm'])
+    @onlyCUDA
+    @skipIfRocm
+    @dtypes(torch.half, torch.bfloat16, torch.float)
+    @dtypesIfCUDA(torch.half, *[torch.bfloat16] if SM80OrLater else [], torch.float)
+    @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "Test requires Triton")
+    def test_triton_tune(self, op, device, dtype):
+        from torch.sparse._triton_ops import bsr_dense_addmm
+        from torch.sparse._triton_ops_meta import (create_blocked_tensor, tune_bsr_dense_addmm, get_meta)
+
+        operation = dict(bsr_dense_addmm=bsr_dense_addmm)[op]
+        tuner = dict(bsr_dense_addmm=tune_bsr_dense_addmm)[op]
+
+        M, K, N = 16, 16, 32
+        sparsity = 1.0
+        blocksize = (16, 16)
+        bsr = create_blocked_tensor(0, M, K, blocksize, sparsity, dtype, device).to_sparse_bsr(blocksize)
+        sparsity = 1 - bsr._nnz() * blocksize[0] * blocksize[1] / (M * K)
+        input = make_tensor(K, N, dtype=dtype, device=device)
+        dense = make_tensor(K, N, dtype=dtype, device=device)
+
+        if op == 'bsr_dense_addmm':
+            args = (input, bsr, dense)
+
+            def get_current_meta():
+                version = (0, dtype, sparsity)
+                meta_key = (M, K, N, *blocksize, False, True, True)
+                return get_meta(op, meta_key, version=version, exact=True)
+        else:
+            raise NotImplementedError(op)
+
+        self.assertEqual(get_current_meta(), None)
+
+        meta = tuner(*args, **dict(store=True, verbose=False))
+        self.assertEqual(get_current_meta(), meta)
+
+        expected = operation(*args)
+        result = operation(*args, **dict(meta=meta))
+        self.assertEqual(result, expected)
+
+
 # e.g., TestSparseCSRCPU and TestSparseCSRCUDA
 instantiate_device_type_tests(TestSparseCSR, globals())
 instantiate_device_type_tests(TestSparseCompressed, globals())

--- a/torch/sparse/_triton_ops.py
+++ b/torch/sparse/_triton_ops.py
@@ -556,18 +556,23 @@ def scatter_mm_meta(M, K, N, Ms, Ks,
 
 
 def bsr_dense_addmm_meta(M, K, N, Ms, Ks, beta, alpha,
-                         SPLIT_N=None, GROUP_SIZE_ROW=None, num_warps=None, num_stages=None, dtype=None, **extra):
+                         SPLIT_N=None, GROUP_SIZE_ROW=None, num_warps=None, num_stages=None, sparsity=None, dtype=None, **extra):
     if dtype is None:
         dtype = torch.float16
+    if sparsity is None:
+        sparsity = 0.5
     if {SPLIT_N, num_warps, num_stages, GROUP_SIZE_ROW} == {None}:
         device_name = torch.cuda.get_device_name()
         key = (M, K, N, Ms, Ks, beta == 0, beta == 1, alpha == 1)
         meta = get_meta('bsr_dense_addmm', key,
-                        device_name, version=(0, dtype, 0.5))
+                        device_name, version=(0, dtype, sparsity))
+        if meta is None and sparsity != 0.5:
+            meta = get_meta('bsr_dense_addmm', key,
+                            device_name, version=(0, dtype, 0.5))
         if meta is not None:
             meta.update(**extra)
             return meta
-    SPLIT_N = SPLIT_N or 1
+    SPLIT_N = SPLIT_N or max(N // Ms, 1)
     GROUP_SIZE_ROW = GROUP_SIZE_ROW or 4
     num_stages = num_stages or 1
     num_warps = num_warps or 4
@@ -832,8 +837,8 @@ def bsr_dense_addmm(
         return out
 
     if meta is None:
-        meta = bsr_dense_addmm_meta(M, K, N, blocksize[0], blocksize[1], beta, alpha, dtype=out.dtype)
-
+        sparsity = round(1 - bsr._nnz() * blocksize[0] * blocksize[1] / (M * K), 2)
+        meta = bsr_dense_addmm_meta(M, K, N, blocksize[0], blocksize[1], beta, alpha, sparsity=sparsity, dtype=out.dtype)
     out_backup = out
 
     crow_indices, col_indices, values, input, dense, out = prepare_inputs(bsr, input, dense, out)


### PR DESCRIPTION
As in the title.

In addition:
- improve the algorithm for finding a minima of operation timings: break the inner loop early when a next minima candidate is found
- add tests and fix bugs

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #115504
* __->__ #115499



cc @alexsamardzic @nikitaved @cpuhrsch @amjames @bhosmer @jcaip