### PR TITLE
[BE]: Enable RUFF PERF402 and apply fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,9 @@ ignore = [
     # these ignores are from ruff NPY; please fix!
     "NPY002",
     # these ignores are from ruff PERF; please fix!
-    "PERF203", "PERF4",
+    "PERF203", 
+    "PERF401",
+    "PERF403",
     # these ignores are from PYI; please fix!
     "PYI019",
     "PYI024",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ ignore = [
     # these ignores are from ruff NPY; please fix!
     "NPY002",
     # these ignores are from ruff PERF; please fix!
-    "PERF203", 
+    "PERF203",
     "PERF401",
     "PERF403",
     # these ignores are from PYI; please fix!

--- a/test/ao/sparsity/test_structured_sparsifier.py
+++ b/test/ao/sparsity/test_structured_sparsifier.py
@@ -178,7 +178,7 @@ class TestBaseStructuredSparsifier(TestCase):
             modules = []
             if type(config["module"]) is tuple:
                 for module in config["module"]:
-                    modules.append(module)
+                    modules.append(module)  # noqa: PERF402
             else:
                 module = config["module"]
                 modules.append(module)
@@ -191,7 +191,7 @@ class TestBaseStructuredSparsifier(TestCase):
             modules = []
             if type(config["module"]) is tuple:
                 for module in config["module"]:
-                    modules.append(module)
+                    modules.append(module)  # noqa: PERF402
             else:
                 module = config["module"]
                 modules.append(module)

--- a/test/ao/sparsity/test_structured_sparsifier.py
+++ b/test/ao/sparsity/test_structured_sparsifier.py
@@ -177,8 +177,7 @@ class TestBaseStructuredSparsifier(TestCase):
         for config in pruner.groups:
             modules = []
             if type(config["module"]) is tuple:
-                for module in config["module"]:
-                    modules.append(module)  # noqa: PERF402
+                modules.extend(config["module"])
             else:
                 module = config["module"]
                 modules.append(module)
@@ -190,8 +189,7 @@ class TestBaseStructuredSparsifier(TestCase):
         for config in pruner.groups:
             modules = []
             if type(config["module"]) is tuple:
-                for module in config["module"]:
-                    modules.append(module)  # noqa: PERF402
+                modules.extend(config["module"])
             else:
                 module = config["module"]
                 modules.append(module)

--- a/test/functorch/common_utils.py
+++ b/test/functorch/common_utils.py
@@ -118,8 +118,7 @@ def get_bdim_choices(num_tensors):
 
     # All permutations of (-1, None)
     options = (-1, None)
-    for choice in itertools.product(options, repeat=num_tensors):
-        choices.append(choice)  # noqa: PERF402
+    choices.extend(itertools.product(options, repeat=num_tensors))
 
     assert choices[-1] == (None,) * num_tensors
     return tuple(choices[:-1])

--- a/test/functorch/common_utils.py
+++ b/test/functorch/common_utils.py
@@ -119,7 +119,7 @@ def get_bdim_choices(num_tensors):
     # All permutations of (-1, None)
     options = (-1, None)
     for choice in itertools.product(options, repeat=num_tensors):
-        choices.append(choice)
+        choices.append(choice)  # noqa: PERF402
 
     assert choices[-1] == (None,) * num_tensors
     return tuple(choices[:-1])

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5902,7 +5902,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
                 split_list: List[Tensor] = input.split(split_sizes)
 
                 for ob in split_list:
-                    out.append(ob)
+                    out.append(ob)  # noqa: PERF402
                 return torch.cat(out, dim=0)
 
         x = torch.randn(6, 4, 3)

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -967,7 +967,7 @@ def _test_get_worker_info():
     it = iter(dataloader)
     data = []
     for d in it:
-        data.append(d)
+        data.append(d)  # noqa: PERF402
     worker_pids = [w.pid for w in it._workers]
     data = torch.cat(data, 0)
     for d in data:

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -2926,9 +2926,7 @@ class TestSharding(TestCase):
 
         dp0 = self._get_pipeline().sharding_filter()
         dl = DataLoader(dp0, batch_size=1, shuffle=False, num_workers=2)
-        items = []
-        for i in dl:
-            items.append(i)  # noqa: PERF402
+        items = list(dl)
 
         self.assertEqual(sorted(expected), sorted(items))
 
@@ -2939,9 +2937,7 @@ class TestSharding(TestCase):
         dp0 = self._get_pipeline()
         dp0 = CustomShardingIterDataPipe(dp0)
         dl = DataLoader(dp0, batch_size=1, shuffle=False, num_workers=2)
-        items = []
-        for i in dl:
-            items.append(i)  # noqa: PERF402
+        items = list(dl)
 
         self.assertEqual(sorted(expected), sorted(items))
 

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -2928,7 +2928,7 @@ class TestSharding(TestCase):
         dl = DataLoader(dp0, batch_size=1, shuffle=False, num_workers=2)
         items = []
         for i in dl:
-            items.append(i)
+            items.append(i)  # noqa: PERF402
 
         self.assertEqual(sorted(expected), sorted(items))
 
@@ -2941,7 +2941,7 @@ class TestSharding(TestCase):
         dl = DataLoader(dp0, batch_size=1, shuffle=False, num_workers=2)
         items = []
         for i in dl:
-            items.append(i)
+            items.append(i)  # noqa: PERF402
 
         self.assertEqual(sorted(expected), sorted(items))
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15775,7 +15775,7 @@ dedent """
             # type: (Dict[str, int]) -> List[int]
             out = [1]
             for i in range(d["hi"] if "hi" in d else 6):
-                out.append(i)
+                out.append(i)  # noqa: PERF402
             return out
 
         self.checkScript(fn, ({'hi': 2, 'bye': 3},))

--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -2043,7 +2043,7 @@ class TestTEFuser(JitTestCase):
         sets = []
         for i in range(0, len(indices) + 1):
             for subset in combinations(indices, i):
-                sets.append(subset)
+                sets.append(subset)  # noqa: PERF402
 
         for set in sets:
             size = [2, 3, 4, 5]

--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -1462,9 +1462,7 @@ class TestMkldnn(TestCase):
             "training": [False, True]
         }
 
-        params_list = []
-        for value in params_dict.values():
-            params_list.append(value)  # noqa: PERF402
+        params_list = list(params_dict.values())
         return params_list
 
     def _cast_dtype(self, input, bf16):

--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -1464,7 +1464,7 @@ class TestMkldnn(TestCase):
 
         params_list = []
         for value in params_dict.values():
-            params_list.append(value)
+            params_list.append(value)  # noqa: PERF402
         return params_list
 
     def _cast_dtype(self, input, bf16):

--- a/tools/code_analyzer/gen_oplist.py
+++ b/tools/code_analyzer/gen_oplist.py
@@ -17,10 +17,7 @@ from torchgen.selective_build.selector import (
 
 
 def extract_all_operators(selective_builder: SelectiveBuilder) -> Set[str]:
-    ops = []
-    for op_name in selective_builder.operators.keys():
-        ops.append(op_name)
-    return set(ops)
+    return set(selective_builder.operators.keys())
 
 
 def extract_training_operators(selective_builder: SelectiveBuilder) -> Set[str]:

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -274,8 +274,7 @@ def default_partition(
             # Since we can't save tuple of tensor values, we need to flatten out what we're saving
             users = node.users
             assert all(user.target == operator.getitem for user in users)
-            for user in users:
-                saved_values.append(user)
+            saved_values.extend(users)
         else:
             backward_usages = [n for n in node.users if n.name not in forward_node_names]
             if 'tensor_meta' in node.meta and all(is_sym_node(n) for n in backward_usages):
@@ -287,8 +286,7 @@ def default_partition(
                 # If the user mutated an input in the forward and uses its sizes/strides in the backward,
                 # then we would be obligated to clone the input before saving it to appease autograd.
                 # (This is how we originally found this bug).
-                for user in backward_usages:
-                    saved_sym_nodes.append(user)
+                saved_sym_nodes.extend(backward_usages)
             else:
                 saved_values.append(node)
     saved_values = list({k: None for k in saved_values}.keys())

--- a/torch/_inductor/comms.py
+++ b/torch/_inductor/comms.py
@@ -29,8 +29,7 @@ def sink_waits(
                     new_order.append(wait)
                     cur_waits.remove(wait)
             new_order.append(snode)
-    for snode in tuple_sorted(cur_waits):
-        new_order.append(snode)
+    new_order.extend(tuple_sorted(cur_waits))
     return new_order
 
 
@@ -61,8 +60,7 @@ def raise_comms(
                 new_order_reversed.append(comm)
             new_order_reversed.append(snode)
     assert len(cur_comms) <= 1
-    for snode in tuple_sorted(cur_comms):
-        new_order_reversed.append(snode)
+    new_order_reversed.extend(cur_comms)
     return new_order_reversed[::-1]
 
 

--- a/torch/_inductor/comms.py
+++ b/torch/_inductor/comms.py
@@ -60,7 +60,7 @@ def raise_comms(
                 new_order_reversed.append(comm)
             new_order_reversed.append(snode)
     assert len(cur_comms) <= 1
-    new_order_reversed.extend(cur_comms)
+    new_order_reversed.extend(tuple_sorted(cur_comms))
     return new_order_reversed[::-1]
 
 

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -809,8 +809,7 @@ class SplitCatSimplifier:
     ):
         to_remove = [split_node]
         counters["inductor"]["scmerge_split_removed"] += 1
-        for getitem_node in split_node.users.keys():
-            to_remove.append(getitem_node)
+        to_remove.extend(split_node.users.keys())
         for next_user in next_users:
             if next_user.target not in {torch.cat, torch.stack}:
                 continue

--- a/torch/_inductor/fx_utils.py
+++ b/torch/_inductor/fx_utils.py
@@ -138,8 +138,7 @@ class FakeTensorUpdater:
                 # tests - add a test
                 existing_storages[get_node_storage(new_fake_tensor)] += 1
                 processed.add(updating_node)
-                for user in updating_node.users:
-                    processing.append(user)
+                processing.extend(updating_node.users)
 
                 self.processed_hashes.add(self.hash_node(updating_node))
 

--- a/torch/ao/ns/fx/n_shadows_utils.py
+++ b/torch/ao/ns/fx/n_shadows_utils.py
@@ -544,9 +544,8 @@ def create_one_transformed_and_logged_copy_of_subgraph(
                 if isinstance(old_kwarg, Node):
                     new_kwargs[name] = old_kwarg
                 elif isinstance(old_kwarg, (list, tuple)) and len(old_kwarg):
-                    for inner_old_kwarg in old_kwarg:
-                        # TODO(future PR): clarify why we are adding kwargs to args
-                        new_args.append(inner_old_kwarg)
+                    # TODO(future PR): clarify why we are adding kwargs to args
+                    new_args.extend(old_kwargs)
 
             new_args = tuple(new_args)  # type: ignore[assignment]
 

--- a/torch/ao/ns/fx/n_shadows_utils.py
+++ b/torch/ao/ns/fx/n_shadows_utils.py
@@ -545,7 +545,7 @@ def create_one_transformed_and_logged_copy_of_subgraph(
                     new_kwargs[name] = old_kwarg
                 elif isinstance(old_kwarg, (list, tuple)) and len(old_kwarg):
                     # TODO(future PR): clarify why we are adding kwargs to args
-                    new_args.extend(old_kwargs)
+                    new_args.extend(old_kwarg)
 
             new_args = tuple(new_args)  # type: ignore[assignment]
 

--- a/torch/backends/_nnapi/serializer.py
+++ b/torch/backends/_nnapi/serializer.py
@@ -945,9 +945,7 @@ class _NnapiSerializer:
     def add_tuple_construct(self, node):
         assert node.outputsSize() == 1
         output = node.outputsAt(0)
-        values = []
-        for inp in node.inputs():
-            values.append(inp)
+        values = list(node.inputs())
         self.add_tensor_sequence(output, values)
 
     def add_unsqueeze(self, node):

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1018,10 +1018,9 @@ def _get_param_id_to_param_from_optim_input(
             'A parameter group should map "params" to a list of the '
             "parameters in the group"
         )
-        for param in param_group["params"]:  # type: ignore[index]
-            # Implicitly map `flat_param_id` (current length of the list) to
-            # `param`
-            param_id_to_param.append(param)
+        # Implicitly map `flat_param_id` (current length of the list) to
+        # `param`
+        param_id_to_param.extend(param_group["params"])  # type: ignore[index]
     return dict(enumerate(param_id_to_param))
 
 

--- a/torch/distributed/optim/named_optimizer.py
+++ b/torch/distributed/optim/named_optimizer.py
@@ -244,9 +244,7 @@ class _NamedOptimizer(optim.Optimizer):
 
         src_group_map = {}
         for group in src_param_groups:
-            param_keys = []
-            for param_key in group["params"]:
-                param_keys.append(param_key)
+            param_keys = list(group["params"])
             src_group_map[_gen_param_group_key(param_keys)] = group
         new_group_map = {}
         for new_group in new_param_groups:

--- a/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
@@ -1261,9 +1261,7 @@ class ConstraintGenerator:
 
             if isinstance(t, torch.Tensor):
                 if len(t.shape) > 0:
-                    res = []
-                    for d in t.shape:
-                        res.append(d)
+                    res = list(t.shape)
                     attr_type = TensorType(res)
                     output, counter = gen_tvar(counter)
                     self.symbol_dict[n] = output

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -671,8 +671,7 @@ class {module_name}(torch.nn.Module):
                 # modules. For example, if we have the target
                 # `foo.bar.baz`, we'll add `foo`, `foo.bar`, and
                 # `foo.bar.baz` to the list.
-                for path in itertools.accumulate(fullpath, join_fn):
-                    used.append(path)
+                used.extend(itertools.accumulate(fullpath, join_fn))
 
                 # For a `call_module` node, also register all recursive submodules
                 # as used

--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -416,8 +416,7 @@ class FlopCounterMode(TorchDispatchMode):
                 continue
 
             cur_values = process_mod(mod, mod_depth - 1)
-            for value in cur_values:
-                values.append(value)
+            values.extend(cur_values)
 
         # We do a bit of messing around here to only output the "Global" value
         # if there are any FLOPs in there that aren't already fully contained by

--- a/torch/utils/tensorboard/_onnx_graph.py
+++ b/torch/utils/tensorboard/_onnx_graph.py
@@ -14,12 +14,10 @@ def load_onnx_graph(fname):
 
 
 def parse(graph):
-    nodes_proto = []
     nodes = []
     import itertools
 
-    for node in itertools.chain(graph.input, graph.output):
-        nodes_proto.append(node)
+    nodes_proto = list(itertools.chain(graph.input, graph.output))
 
     for node in nodes_proto:
         print(node.name)

--- a/torchgen/api/structured.py
+++ b/torchgen/api/structured.py
@@ -129,8 +129,7 @@ def impl_arguments(g: NativeFunctionsGroup) -> List[Binding]:
             if isinstance(a, Argument) and a.name in g.out.precomputed.replace:
                 # If a is in precompute.replace, append the parameters
                 # that should replace it onto non_out_args_replaced.
-                for replacement in g.out.precomputed.replace[a.name]:
-                    non_out_args_replaced.append(replacement)
+                non_out_args_replaced.extend(g.out.precomputed.replace[a.name])
             else:
                 # If not, push a as it is.
                 non_out_args_replaced.append(a)

--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -1383,8 +1383,7 @@ def get_grouped_by_view_native_functions(
             )
         # Take the remaining functions that weren't part of the view group
         # and emit them separately
-        for func in d.values():
-            funcs.append(func)
+        funcs.extend(d.values())
         return funcs
 
     grouped_by_views: Dict[


### PR DESCRIPTION
* Enable PERF402. Makes code more efficient and succinct by removing useless list copies that could be accomplished either via a list constructor or extend call. All test cases have noqa added since performance is not as sensitive in that folder.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler