### PR TITLE
[BE]: Enable RUF015 codebase wide

### DIFF
--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -130,7 +130,7 @@ def build_triton(
                 cwd=triton_basedir,
                 env=env,
             )
-            conda_path = list(Path(tmpdir).glob("linux-64/torchtriton*.bz2"))[0]
+            conda_path = next(iter(Path(tmpdir).glob("linux-64/torchtriton*.bz2")))
             shutil.copy(conda_path, Path.cwd())
             return Path.cwd() / conda_path.name
 
@@ -156,7 +156,7 @@ def build_triton(
             [sys.executable, "setup.py", "bdist_wheel"], cwd=triton_pythondir, env=env
         )
 
-        whl_path = list((triton_pythondir / "dist").glob("*.whl"))[0]
+        whl_path = next(iter((triton_pythondir / "dist").glob("*.whl")))
         shutil.copy(whl_path, Path.cwd())
 
         if build_rocm:

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -86,7 +86,9 @@ def get_nccl_wheel_version(arch_version: str) -> str:
     requirements = map(
         str.strip, re.split("[;|]", PYTORCH_EXTRA_INSTALL_REQUIREMENTS[arch_version])
     )
-    return [x for x in requirements if x.startswith("nvidia-nccl-cu")][0].split("==")[1]
+    return next(x for x in requirements if x.startswith("nvidia-nccl-cu")).split("==")[
+        1
+    ]
 
 
 def validate_nccl_dep_consistency(arch_version: str) -> None:

--- a/benchmarks/dynamo/summarize_perf.py
+++ b/benchmarks/dynamo/summarize_perf.py
@@ -130,7 +130,7 @@ def main(directory, amp, float32, perf_compare):
             print(f"## {descriptions[statistic]}")
 
             table = []
-            for row_name in data[list(data.keys())[0]]:
+            for row_name in data[next(iter(data.keys()))]:
                 row = [row_name]
                 for col_name in data:
                     row.append(round(data[col_name][row_name], 2))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ select = [
     "PT025",
     "PT026",
     "PYI",
+    "RUF015", # access first ele in constant time
     "RUF017",
     "TRY200",
     "TRY302",
@@ -115,11 +116,13 @@ select = [
 "test/jit/**" = [
     "PLR0133", # tests require this for JIT
     "PYI",
+    "RUF015",
     "UP", # We don't want to modify the jit test as they test specify syntax
 ]
 "test/test_jit.py" = [
     "PLR0133", # tests require this for JIT
     "PYI",
+    "RUF015",
     "UP", # We don't want to modify the jit test as they test specify syntax
 ]
 

--- a/test/distributed/_tensor/test_api.py
+++ b/test/distributed/_tensor/test_api.py
@@ -218,7 +218,7 @@ class DTensorAPITest(DTensorTestBase):
         input = torch.randn(10, 10, requires_grad=True)
         output = replica_model(input)
         output.sum().backward()
-        param_grad = list(replica_model.parameters())[0].grad
+        param_grad = next(iter(replica_model.parameters())).grad
         self.assertTrue(isinstance(param_grad, DTensor))
         self.assertTrue(isinstance(param_grad.placements[0], Replicate))
 

--- a/test/distributed/checkpoint/test_checkpoint.py
+++ b/test/distributed/checkpoint/test_checkpoint.py
@@ -270,7 +270,7 @@ class TestDistributedFailure(ShardedTensorTestBase):
         load_state_dict(state_dict, FaultyStorageReader(metadata, {}))
 
     def _test_dist_failure(self, callback, kwargs):
-        bad_ranks = list(kwargs.values())[0] if len(kwargs) > 0 else []
+        bad_ranks = next(iter(kwargs.values())) if len(kwargs) > 0 else []
 
         # Empty bad_ranks means it must work
         if len(bad_ranks) == 0:

--- a/test/distributed/pipeline/sync/skip/test_leak.py
+++ b/test/distributed/pipeline/sync/skip/test_leak.py
@@ -48,7 +48,7 @@ def test_delete_portal_tensor(train, checkpoint, setup_rpc):
             skip_tracker = current_skip_tracker()
 
         # Get the current portal.
-        portal = list(skip_tracker.portals.values())[0]
+        portal = next(iter(skip_tracker.portals.values()))
 
         if tensor_life == 0:
             return portal.tensor_life == 0 and portal.tensor is None

--- a/test/distributed/pipeline/sync/test_microbatch.py
+++ b/test/distributed/pipeline/sync/test_microbatch.py
@@ -137,8 +137,8 @@ def test_scatter_multiple_tensors():
 
     a, b = scatter(*ab, chunks=2)
 
-    assert list(a)[0].size() == (1, 1)
-    assert list(b)[0].size() == (1, 1)
+    assert next(iter(a)).size() == (1, 1)
+    assert next(iter(b)).size() == (1, 1)
     assert list(a)[1].size() == (2, 2)
     assert list(b)[1].size() == (2, 2)
 

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -3423,7 +3423,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
             compiled_opt_step()
 
         compiled_model_step(x)
-        param_grad_ref = weakref.ref(list(model.parameters())[0].grad)
+        param_grad_ref = weakref.ref(next(iter(model.parameters())).grad)
         optimizer.zero_grad(True)
         self.assertIsNone(param_grad_ref())
 

--- a/test/export/test_verifier.py
+++ b/test/export/test_verifier.py
@@ -196,7 +196,7 @@ class TestVerifier(TestCase):
         output_node.args = (
             (
                 output_node.args[0][0],
-                list(ep.graph.nodes)[0],
+                next(iter(ep.graph.nodes)),
                 output_node.args[0][1],
             ),
         )

--- a/test/lazy/test_ts_opinfo.py
+++ b/test/lazy/test_ts_opinfo.py
@@ -185,7 +185,7 @@ class TestLazyOpInfo(TestCase):
 
         global HAS_SYMINT_SUFFIX, FALLBACK_LIST
         samples = op.sample_inputs("lazy", dtype, requires_grad=False)
-        sample = list(samples)[0]
+        sample = next(iter(samples))
         args = [sample.input] + list(sample.args)
         kwargs = sample.kwargs
         torch._lazy.mark_step()

--- a/test/nn/test_pruning.py
+++ b/test/nn/test_pruning.py
@@ -337,13 +337,13 @@ class TestPruningNN(NNTestCase):
         """
         m = nn.Linear(5, 2, bias=False)
 
-        tensor_id = id(list(m.parameters())[0])
+        tensor_id = id(next(iter(m.parameters())))
 
         prune.random_unstructured(m, name="weight", amount=0.9)
-        self.assertEqual(tensor_id, id(list(m.parameters())[0]))
+        self.assertEqual(tensor_id, id(next(iter(m.parameters()))))
 
         prune.remove(m, "weight")
-        self.assertEqual(tensor_id, id(list(m.parameters())[0]))
+        self.assertEqual(tensor_id, id(next(iter(m.parameters()))))
 
     def test_random_pruning_pickle(self):
         modules = [nn.Linear(5, 7), nn.Conv3d(2, 2, 2)]

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -906,7 +906,7 @@ class TestOperators(common_utils.TestCase):
             def forward(self, x_in):
                 x_out = {}
                 x_out["test_key_out"] = torch.add(
-                    x_in[list(x_in.keys())[0]], list(x_in.keys())[0]
+                    x_in[list(x_in.keys())[0]], list(x_in.keys())[0]  # noqa: RUF015
                 )
                 return x_out
 

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -483,7 +483,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
             def forward(self, x_in):
                 x_out = {}
                 x_out["test_key_out"] = torch.add(
-                    x_in[list(x_in.keys())[0]], list(x_in.keys())[0]
+                    x_in[list(x_in.keys())[0]], list(x_in.keys())[0]  # noqa: RUF015
                 )
                 return x_out
 

--- a/test/quantization/fx/test_model_report_fx.py
+++ b/test/quantization/fx/test_model_report_fx.py
@@ -157,7 +157,7 @@ class TestFxModelReportDetector(QuantizationTestCase):
             # there should only be one conv there in this model
             self.assertEqual(per_channel_info["conv"]["backend"], torch.backends.quantized.engine)
             self.assertEqual(len(per_channel_info), 1)
-            self.assertEqual(list(per_channel_info)[0], "conv")
+            self.assertEqual(next(iter(per_channel_info)), "conv")
             self.assertEqual(
                 per_channel_info["conv"]["per_channel_quantization_supported"],
                 True,
@@ -198,7 +198,7 @@ class TestFxModelReportDetector(QuantizationTestCase):
                 DEFAULT_NO_OPTIMS_ANSWER_STRING.format(torch.backends.quantized.engine),
             )
             # pick a random key to look at
-            rand_key: str = list(per_channel_info.keys())[0]
+            rand_key: str = next(iter(per_channel_info.keys()))
             self.assertEqual(per_channel_info[rand_key]["backend"], torch.backends.quantized.engine)
             self.assertEqual(len(per_channel_info), 2)
 

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -2508,7 +2508,7 @@ class TestQuantizeFx(QuantizationTestCase):
         self.assertEqual(len(qconfig_mapping.module_name_object_type_order_qconfigs), 2)
         key1 = ("mod1", torch.nn.Linear, 0)
         key2 = ("mod2", torch.nn.ReLU, 1)
-        self.assertEqual(list(qconfig_mapping.module_name_object_type_order_qconfigs)[0], key1)
+        self.assertEqual(next(iter(qconfig_mapping.module_name_object_type_order_qconfigs)), key1)
         self.assertEqual(list(qconfig_mapping.module_name_object_type_order_qconfigs)[1], key2)
         self.assertEqual(qconfig_mapping.module_name_object_type_order_qconfigs[key1], qconfig1)
         self.assertEqual(qconfig_mapping.module_name_object_type_order_qconfigs[key2], qconfig2)
@@ -2519,7 +2519,7 @@ class TestQuantizeFx(QuantizationTestCase):
         # Override existing key
         qconfig_mapping.set_module_name_object_type_order("mod1", torch.nn.Linear, 0, qconfig3)
         self.assertEqual(len(qconfig_mapping.module_name_object_type_order_qconfigs), 2)
-        self.assertEqual(list(qconfig_mapping.module_name_object_type_order_qconfigs)[0], key1)
+        self.assertEqual(next(iter(qconfig_mapping.module_name_object_type_order_qconfigs)), key1)
         self.assertEqual(list(qconfig_mapping.module_name_object_type_order_qconfigs)[1], key2)
         self.assertEqual(qconfig_mapping.module_name_object_type_order_qconfigs[key1], qconfig3)
         self.assertEqual(qconfig_mapping.module_name_object_type_order_qconfigs[key2], qconfig2)
@@ -6515,7 +6515,7 @@ class TestQuantizeFx(QuantizationTestCase):
 
             # Match following quantize with the specific dtypes
             self.assertEqual(len(node.users), 1)
-            user = list(node.users.keys())[0]
+            user = next(iter(node.users.keys()))
             self.assertEqual(user.target, torch.quantize_per_tensor)
             self.assertEqual(user.args[-1], target_to_expected_dtypes[node.target])
 

--- a/test/quantization/jit/test_quantize_jit.py
+++ b/test/quantization/jit/test_quantize_jit.py
@@ -666,7 +666,7 @@ class TestQuantizeJitPasses(QuantizationTestCase):
         assert len(activation_dtypes) == 1, "Expected to have 1 activation dtype"
         assert len(weight_dtypes) == 1, "Expected to have 1 weight dtype"
         assert (
-            list(activation_dtypes)[0] != list(weight_dtypes)[0]
+            next(iter(activation_dtypes)) != next(iter(weight_dtypes))
         ), "Expected activation dtype to "
         " be different from wegiht dtype"
 

--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -773,7 +773,7 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
         conv_output_obs = []
         for n in m.graph.nodes:
             if n.op == "call_function" and n.target == torch.ops.aten.conv2d.default:
-                conv_output_obs.append(getattr(m, list(n.users)[0].target))
+                conv_output_obs.append(getattr(m, next(iter(n.users)).target))
             if n.op == "call_function" and n.target == torch.ops.aten.cat.default:
                 inputs = n.args[0]
                 input0 = inputs[0]
@@ -830,7 +830,7 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
         conv_output_obs = []
         for n in m.graph.nodes:
             if n.op == "call_function" and n.target == torch.ops.aten.conv2d.default:
-                conv_output_obs.append(getattr(m, list(n.users)[0].target))
+                conv_output_obs.append(getattr(m, next(iter(n.users)).target))
             if n.op == "call_function" and n.target == torch.ops.aten.cat.default:
                 inputs = n.args[0]
                 input0 = inputs[0]
@@ -841,7 +841,7 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
                 obs_ins1 = getattr(m, input1.target)
                 assert obs_ins0 == obs_ins1
 
-                output_obs = list(n.users)[0]
+                output_obs = next(iter(n.users))
                 assert output_obs.op == "call_module"
                 obs_ins2 = getattr(m, output_obs.target)
                 assert obs_ins0 == obs_ins2, "input observer does not match output"
@@ -1132,7 +1132,7 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
             if n.target == torch.ops.aten.add.Tensor:
                 input_obs1 = getattr(m, n.args[0].target)
                 input_obs2 = getattr(m, n.args[1].target)
-                output_obs = getattr(m, list(n.users)[0].target)
+                output_obs = getattr(m, next(iter(n.users)).target)
                 self.assertIs(input_obs1, input_obs2)
                 self.assertIs(input_obs1, output_obs)
                 observers.append(input_obs1)
@@ -1307,7 +1307,7 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
         )
         weight_meta = None
         for n in m.graph.nodes:
-            if n.op == "get_attr" and list(n.users)[0].target == torch.ops.aten.linear.default:
+            if n.op == "get_attr" and next(iter(n.users)).target == torch.ops.aten.linear.default:
                 weight_meta = n.meta
                 break
         assert weight_meta is not None, "Expect to find metadata for weight node"

--- a/test/quantization/pt2e/test_x86inductor_quantizer.py
+++ b/test/quantization/pt2e/test_x86inductor_quantizer.py
@@ -616,7 +616,7 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
                     prepare_model, single_op_node.args[0].target
                 )
                 output_obs_of_single_op = getattr(
-                    prepare_model, list(single_op_node.users)[0].target
+                    prepare_model, next(iter(single_op_node.users)).target
                 )
             elif (
                 node.op == "call_function"
@@ -722,7 +722,7 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
                     prepare_model, node.all_input_nodes[1].target
                 )
                 cat_out_obs = getattr(
-                    prepare_model, list(node.users)[0].target
+                    prepare_model, next(iter(node.users)).target
                 )
             elif (
                 node.op == "call_function"
@@ -733,7 +733,7 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
                     prepare_model, maxpool_node.args[0].target
                 )
                 output_obs_of_maxpool = getattr(
-                    prepare_model, list(maxpool_node.users)[0].target
+                    prepare_model, next(iter(maxpool_node.users)).target
                 )
         self.assertTrue(isinstance(cat_act_obs0, ObserverBase))
         self.assertTrue(isinstance(cat_act_obs1, ObserverBase))
@@ -794,7 +794,7 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
                     prepare_model, node.args[0][1].target
                 )
                 cat_out_obs = getattr(
-                    prepare_model, list(node.users)[0].target
+                    prepare_model, next(iter(node.users)).target
                 )
         self.assertTrue(isinstance(cat_act_obs0, ObserverBase))
         self.assertTrue(isinstance(cat_act_obs1, ObserverBase))
@@ -848,7 +848,7 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
                     prepare_model, node.args[0][0].target
                 )
                 cat_out_obs = getattr(
-                    prepare_model, list(node.users)[0].target
+                    prepare_model, next(iter(node.users)).target
                 )
         self.assertTrue(isinstance(cat_act_obs0, ObserverBase))
         self.assertTrue(isinstance(cat_out_obs, ObserverBase))
@@ -900,14 +900,14 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
                     prepare_model, avgpool_node.args[0].target
                 )
                 output_obs_of_avgpool = getattr(
-                    prepare_model, list(avgpool_node.users)[0].target
+                    prepare_model, next(iter(avgpool_node.users)).target
                 )
             elif (
                 node.op == "call_function"
                 and node.target is torch.ops.aten.conv2d.default
             ):
                 conv_node = node
-                output_obs_of_conv = getattr(prepare_model, list(conv_node.users)[0].target)
+                output_obs_of_conv = getattr(prepare_model, next(iter(conv_node.users)).target)
         self.assertTrue(isinstance(input_obs_of_avgpool, ObserverBase))
         self.assertTrue(isinstance(output_obs_of_avgpool, ObserverBase))
         self.assertTrue(isinstance(output_obs_of_conv, ObserverBase))

--- a/test/quantization/pt2e/test_xnnpack_quantizer.py
+++ b/test/quantization/pt2e/test_xnnpack_quantizer.py
@@ -436,7 +436,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
                 torch.ops.aten.hardtanh.default,
             ]:
                 input_act = getattr(m, n.args[0].target)
-                output_act = getattr(m, list(n.users)[0].target)
+                output_act = getattr(m, next(iter(n.users)).target)
                 self.assertIs(input_act, output_act)
 
         m = convert_pt2e(m, fold_quantize=True)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4284,7 +4284,7 @@ Done""")
                 y = x * 2 + 4
 
         function_events = p.function_events
-        foo_event = [event for event in function_events if "foo" in event.name][0]
+        foo_event = next(event for event in function_events if "foo" in event.name)
         self.assertEqual(foo_event.count, 1)
 
     def test_record_function_legacy(self):
@@ -4299,7 +4299,7 @@ Done""")
                 torch.ops.profiler._record_function_exit(handle)
 
         function_events = p.function_events
-        foo_event = [event for event in function_events if "bar" in event.name][0]
+        foo_event = next(event for event in function_events if "bar" in event.name)
         self.assertEqual(foo_event.count, 1)
 
     def test_profiler_aggregation_fake(self):

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -547,7 +547,7 @@ class TestForeach(TestCase):
     def test_unary_op_tensors_on_different_devices(self, device, dtype, op):
         method, ref, inplace_method, ref_inplace = self._get_funcs(op)
         # tensors: ['cuda', 'cpu]
-        tensors = list(op.sample_inputs(device, dtype, num_input_tensors=[2]))[0].input
+        tensors = next(iter(op.sample_inputs(device, dtype, num_input_tensors=[2]))).input
         tensors[1] = tensors[1].to("cpu")
         if not op.supports_out:
             try:
@@ -575,8 +575,8 @@ class TestForeach(TestCase):
     def test_binary_op_tensors_on_different_devices(self, device, dtype, op):
         # `tensors1`: ['cuda', 'cpu']
         # `tensors2`: ['cuda', 'cpu']
-        _cuda_tensors = list(op.sample_inputs(device, dtype, num_input_tensors=[2], same_size=True))[0].input
-        _cpu_tensors = list(op.sample_inputs("cpu", dtype, num_input_tensors=[2], same_size=True))[0].input
+        _cuda_tensors = next(iter(op.sample_inputs(device, dtype, num_input_tensors=[2], same_size=True))).input
+        _cpu_tensors = next(iter(op.sample_inputs("cpu", dtype, num_input_tensors=[2], same_size=True))).input
         tensors1, tensors2 = list(zip(_cuda_tensors, _cpu_tensors))
 
         foreach_op, foreach_op_ = op.method_variant, op.inplace_variant
@@ -607,7 +607,7 @@ class TestForeach(TestCase):
         _cuda_tensors = list(
             op.sample_inputs(device, dtype, num_input_tensors=[3], same_size=True)
         )[int(dtype == torch.float32)].input
-        _cpu_tensors = list(op.sample_inputs("cpu", dtype, num_input_tensors=[3], same_size=True))[0].input
+        _cpu_tensors = next(iter(op.sample_inputs("cpu", dtype, num_input_tensors=[3], same_size=True))).input
         tensors1, tensors2, tensors3 = list(zip(_cuda_tensors, _cpu_tensors))
 
         foreach_op, foreach_op_, native_op = op.method_variant, op.inplace_variant, op.ref
@@ -628,9 +628,7 @@ class TestForeach(TestCase):
         max_value = torch.finfo(dtype).max
         scaler = torch.tensor([max_value]).sqrt().to(device=device, dtype=dtype)
         inputs = ([
-            t * scaler for t in list(
-                op.sample_inputs(device, dtype, requries_grad=True, num_input_tensors=[N], low=1)
-            )[0].input
+            t * scaler for t in next(iter(op.sample_inputs(device, dtype, requries_grad=True, num_input_tensors=[N], low=1))).input
         ],)
         # make sure that the min. of squared L2 norm value per tensor is greater than the max value of `dtype`.
         self.assertTrue(scaler * scaler * N > max_value)
@@ -672,7 +670,7 @@ class TestForeach(TestCase):
         if inplace_op is None:
             self.skipTest("no in-place op available")
 
-        sample = list(op.sample_inputs(dtype=dtype, device=device, num_input_tensors=[2], same_size=True))[0]
+        sample = next(iter(op.sample_inputs(dtype=dtype, device=device, num_input_tensors=[2], same_size=True)))
         sample.input[0].requires_grad_(True)
         with self.assertRaisesRegex(RuntimeError, "a leaf Variable that requires grad"):
             inplace_op(sample.input, *sample.args)
@@ -696,7 +694,7 @@ class TestForeach(TestCase):
     )
     def test_outplace_with_invalid_grads(self, device, dtype, op):
         func, *_ = self._get_funcs(op)
-        sample = list(op.sample_inputs(dtype=dtype, device=device, requires_grad=True, num_input_tensors=[2], same_size=True))[0]
+        sample = next(iter(op.sample_inputs(dtype=dtype, device=device, requires_grad=True, num_input_tensors=[2], same_size=True)))
         self.assertTrue(all(t.requires_grad for t in sample.input))
         (out1, out2) = func([sample.input, *sample.args], is_cuda=False, expect_fastpath=False, **sample.kwargs)
         out1.backward(torch.ones_like(out1))

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2306,7 +2306,7 @@ class TestFX(JitTestCase):
         combined_graph = torch.fx.Graph()
         output_node = combined_graph.graph_copy(inline_into.graph, {})
 
-        input_node = list(to_inline.graph.nodes)[0]
+        input_node = next(iter(to_inline.graph.nodes))
         assert input_node and input_node.op == 'placeholder'
 
         val_map = {input_node : output_node}
@@ -3824,12 +3824,12 @@ def forward(self, args_list: List[torch.Tensor]){maybe_return_annotation}:
         self.assertEqual(len(output_node.args), r + 1)
         self.assertEqual(len(a.users), 1)
         self.assertIs(output_node.args[0], a)
-        self.assertIs(list(a.users.keys())[0], output_node)
+        self.assertIs(next(iter(a.users.keys())), output_node)
         output_node.insert_arg(2, a)
         self.assertEqual(len(output_node.args), r + 2)
         self.assertEqual(len(a.users), 1)
         self.assertIs(output_node.args[2], a)
-        self.assertIs(list(a.users.keys())[0], output_node)
+        self.assertIs(next(iter(a.users.keys())), output_node)
         m.graph.lint()
 
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -669,7 +669,7 @@ class TestCommon(TestCase):
         dtype = (
             torch.float32
             if torch.float32 in supported_dtypes
-            else list(supported_dtypes)[0]
+            else next(iter(supported_dtypes))
         )
 
         # Ops from python_ref_db point to python decomps that are potentially

--- a/test/test_weak.py
+++ b/test/test_weak.py
@@ -293,7 +293,7 @@ class WeakKeyDictionaryTestCase(TestCase):
         # Indexing
         for key, value in self.reference.items():
             self.assertEqual(d[key], value)
-        knownkey = list(self.other.keys())[0]
+        knownkey = next(iter(self.other.keys()))
         self.assertRaises(KeyError, lambda: d[knownkey])
         # len
         self.assertEqual(len(p), 0)
@@ -389,8 +389,8 @@ class WeakKeyDictionaryTestCase(TestCase):
         d = self._empty_mapping()
         self.assertEqual(list(d.keys()), [])
         d = self.reference
-        self.assertIn(list(self.inmapping.keys())[0], d.keys())
-        self.assertNotIn(list(self.other.keys())[0], d.keys())
+        self.assertIn(next(iter(self.inmapping.keys())), d.keys())
+        self.assertNotIn(next(iter(self.other.keys())), d.keys())
         self.assertRaises(TypeError, d.keys, None)
 
     def test_values(self):
@@ -412,7 +412,7 @@ class WeakKeyDictionaryTestCase(TestCase):
     def test_getitem(self):
         d = self.reference
         self.assertEqual(
-            d[list(self.inmapping.keys())[0]], list(self.inmapping.values())[0]
+            d[next(iter(self.inmapping.keys()))], next(iter(self.inmapping.values()))
         )
 
         self.assertRaises(TypeError, d.__getitem__)
@@ -535,16 +535,18 @@ class WeakKeyDictionaryTestCase(TestCase):
 
     def test_get(self):
         d = self._empty_mapping()
-        self.assertTrue(d.get(list(self.other.keys())[0]) is None)
-        self.assertEqual(d.get(list(self.other.keys())[0], 3), 3)
+        self.assertTrue(d.get(next(iter(self.other.keys()))) is None)
+        self.assertEqual(d.get(next(iter(self.other.keys())), 3), 3)
         d = self.reference
-        self.assertTrue(d.get(list(self.other.keys())[0]) is None)
-        self.assertEqual(d.get(list(self.other.keys())[0], 3), 3)
+        self.assertTrue(d.get(next(iter(self.other.keys()))) is None)
+        self.assertEqual(d.get(next(iter(self.other.keys())), 3), 3)
         self.assertEqual(
-            d.get(list(self.inmapping.keys())[0]), list(self.inmapping.values())[0]
+            d.get(next(iter(self.inmapping.keys()))),
+            next(iter(self.inmapping.values())),
         )
         self.assertEqual(
-            d.get(list(self.inmapping.keys())[0], 3), list(self.inmapping.values())[0]
+            d.get(next(iter(self.inmapping.keys())), 3),
+            next(iter(self.inmapping.values())),
         )
         self.assertRaises(TypeError, d.get)
         self.assertRaises(TypeError, d.get, None, None, None)
@@ -560,9 +562,9 @@ class WeakKeyDictionaryTestCase(TestCase):
 
     def test_pop(self):
         d = self._empty_mapping()
-        k, v = list(self.inmapping.items())[0]
+        k, v = next(iter(self.inmapping.items()))
         d[k] = v
-        self.assertRaises(KeyError, d.pop, list(self.other.keys())[0])
+        self.assertRaises(KeyError, d.pop, next(iter(self.other.keys())))
 
         self.assertEqual(d.pop(k), v)
         self.assertEqual(len(d), 0)
@@ -632,7 +634,7 @@ class WeakKeyDictionaryScriptObjectTestCase(TestCase):
         # Indexing
         for key, value in self.reference.items():
             self.assertEqual(d[key], value)
-        knownkey = list(self.other.keys())[0]
+        knownkey = next(iter(self.other.keys()))
         self.assertRaises(KeyError, lambda: d[knownkey])
         # len
         self.assertEqual(len(p), 0)
@@ -728,8 +730,8 @@ class WeakKeyDictionaryScriptObjectTestCase(TestCase):
         d = self._empty_mapping()
         self.assertEqual(list(d.keys()), [])
         d = self.reference
-        self.assertIn(list(self.inmapping.keys())[0], d.keys())
-        self.assertNotIn(list(self.other.keys())[0], d.keys())
+        self.assertIn(next(iter(self.inmapping.keys())), d.keys())
+        self.assertNotIn(next(iter(self.other.keys())), d.keys())
         self.assertRaises(TypeError, d.keys, None)
 
     def test_values(self):
@@ -751,7 +753,7 @@ class WeakKeyDictionaryScriptObjectTestCase(TestCase):
     def test_getitem(self):
         d = self.reference
         self.assertEqual(
-            d[list(self.inmapping.keys())[0]], list(self.inmapping.values())[0]
+            d[next(iter(self.inmapping.keys()))], next(iter(self.inmapping.values()))
         )
 
         self.assertRaises(TypeError, d.__getitem__)
@@ -874,16 +876,18 @@ class WeakKeyDictionaryScriptObjectTestCase(TestCase):
 
     def test_get(self):
         d = self._empty_mapping()
-        self.assertTrue(d.get(list(self.other.keys())[0]) is None)
-        self.assertEqual(d.get(list(self.other.keys())[0], 3), 3)
+        self.assertTrue(d.get(next(iter(self.other.keys()))) is None)
+        self.assertEqual(d.get(next(iter(self.other.keys())), 3), 3)
         d = self.reference
-        self.assertTrue(d.get(list(self.other.keys())[0]) is None)
-        self.assertEqual(d.get(list(self.other.keys())[0], 3), 3)
+        self.assertTrue(d.get(next(iter(self.other.keys()))) is None)
+        self.assertEqual(d.get(next(iter(self.other.keys())), 3), 3)
         self.assertEqual(
-            d.get(list(self.inmapping.keys())[0]), list(self.inmapping.values())[0]
+            d.get(next(iter(self.inmapping.keys()))),
+            next(iter(self.inmapping.values())),
         )
         self.assertEqual(
-            d.get(list(self.inmapping.keys())[0], 3), list(self.inmapping.values())[0]
+            d.get(next(iter(self.inmapping.keys())), 3),
+            next(iter(self.inmapping.values())),
         )
         self.assertRaises(TypeError, d.get)
         self.assertRaises(TypeError, d.get, None, None, None)
@@ -899,9 +903,9 @@ class WeakKeyDictionaryScriptObjectTestCase(TestCase):
 
     def test_pop(self):
         d = self._empty_mapping()
-        k, v = list(self.inmapping.items())[0]
+        k, v = next(iter(self.inmapping.items()))
         d[k] = v
-        self.assertRaises(KeyError, d.pop, list(self.other.keys())[0])
+        self.assertRaises(KeyError, d.pop, next(iter(self.other.keys())))
 
         self.assertEqual(d.pop(k), v)
         self.assertEqual(len(d), 0)

--- a/tools/linter/adapters/workflow_consistency_linter.py
+++ b/tools/linter/adapters/workflow_consistency_linter.py
@@ -52,7 +52,7 @@ def is_workflow(yaml: Any) -> bool:
 
 
 def print_lint_message(path: Path, job: Dict[str, Any], sync_tag: str) -> None:
-    job_id = list(job.keys())[0]
+    job_id = next(iter(job.keys()))
     with open(path) as f:
         lines = f.readlines()
     for i, line in enumerate(lines):

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -424,7 +424,9 @@ def _is_valid_quantized_conv_binary_optimization_pattern(output_dtype):
         if len(qconv2d_node_after_weight_prepack.users) != 1:
             return False
         if output_dtype is not None:
-            binary_node_inputs = list(qconv2d_node_after_weight_prepack.users)[0].args
+            binary_node_inputs = next(
+                iter(qconv2d_node_after_weight_prepack.users)
+            ).args
             assert len(binary_node_inputs) == 2, "Expects binary node with 2 inputs"
             extra_input_node = None
             for arg in binary_node_inputs:


### PR DESCRIPTION
Constant time access of first value in collection. This is a constant time operation instead of converting the item to a list to get the first item which is linear. The rule is turned on which automatically autofixes and enforces this.


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler