### PR TITLE
[c10] signal_handler: atomically exchange the signal count to fix data race in ExecuteStepRecursive()

### DIFF
--- a/c10/util/signal_handler.cpp
+++ b/c10/util/signal_handler.cpp
@@ -323,18 +323,16 @@ SignalHandler::~SignalHandler() {
 // function was called.
 bool SignalHandler::GotSIGINT() {
   uint64_t count = sigintCount;
-  bool result = (count != my_sigint_count_);
-  my_sigint_count_ = count;
-  return result;
+  uint64_t localCount = my_sigint_count_.exchange(count);
+  return (localCount != count);
 }
 
 // Return true iff a SIGHUP has been received since the last time this
 // function was called.
 bool SignalHandler::GotSIGHUP() {
   uint64_t count = sighupCount;
-  bool result = (count != my_sighup_count_);
-  my_sighup_count_ = count;
-  return result;
+  uint64_t localCount = my_sighup_count_.exchange(count);
+  return (localCount != count);
 }
 
 SignalHandler::Action SignalHandler::CheckForSignals() {

--- a/c10/util/signal_handler.h
+++ b/c10/util/signal_handler.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <csignal>
+#include <cstdint>
 #include <mutex>
 
 #include <c10/macros/Export.h>
@@ -34,8 +35,8 @@ class C10_API SignalHandler {
 
   Action SIGINT_action_;
   Action SIGHUP_action_;
-  unsigned long my_sigint_count_;
-  unsigned long my_sighup_count_;
+  std::atomic<uint64_t> my_sigint_count_;
+  std::atomic<uint64_t> my_sighup_count_;
 };
 
 #if defined(C10_SUPPORTS_FATAL_SIGNAL_HANDLERS)


### PR DESCRIPTION
Summary:
`CheckForSignals()` can be called from multiple threads concurrently, e.g. from within `ExecuteStepRecursive()`. This means that `my_sigint_count_` and `my_sighup_count_` can be written concurrently, causing data races.

To fix, use atomic exchange which writes the new value and returns the old value in one atomic operation.

Test Plan: Running TSAN tests that failed before and now pass

Differential Revision: D52018963




cc @ezyang @bhosmer @smessmer @ljk53 @bdhirsh