### PR TITLE
fsdp_copy_out proof of concept

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -507,6 +507,7 @@ libtorch_distributed_base_sources = [
     "torch/csrc/distributed/c10d/quantization/quantization.cpp",
     "torch/csrc/distributed/c10d/reducer.cpp",
     "torch/csrc/distributed/c10d/sequence_num.cpp",
+    "torch/csrc/distributed/c10d/shuffle.cpp",
     "torch/csrc/distributed/c10d/socket.cpp",
     "torch/csrc/distributed/c10d/Work.cpp",
 ]
@@ -676,6 +677,7 @@ libtorch_cuda_distributed_extra_sources = [
     "torch/csrc/distributed/c10d/UCCUtils.cpp",
     "torch/csrc/distributed/rpc/tensorpipe_cuda.cpp",
     "torch/csrc/distributed/c10d/quantization/quantization_gpu.cu",
+    "torch/csrc/distributed/c10d/shuffle.cu",
 ]
 
 libtorch_cuda_distributed_sources = libtorch_cuda_distributed_base_sources + libtorch_cuda_distributed_extra_sources

--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -507,7 +507,6 @@ libtorch_distributed_base_sources = [
     "torch/csrc/distributed/c10d/quantization/quantization.cpp",
     "torch/csrc/distributed/c10d/reducer.cpp",
     "torch/csrc/distributed/c10d/sequence_num.cpp",
-    "torch/csrc/distributed/c10d/shuffle.cpp",
     "torch/csrc/distributed/c10d/socket.cpp",
     "torch/csrc/distributed/c10d/Work.cpp",
 ]
@@ -677,6 +676,7 @@ libtorch_cuda_distributed_extra_sources = [
     "torch/csrc/distributed/c10d/UCCUtils.cpp",
     "torch/csrc/distributed/rpc/tensorpipe_cuda.cpp",
     "torch/csrc/distributed/c10d/quantization/quantization_gpu.cu",
+    "torch/csrc/distributed/c10d/shuffle.cpp",
     "torch/csrc/distributed/c10d/shuffle.cu",
 ]
 

--- a/torch/csrc/distributed/c10d/shuffle.cpp
+++ b/torch/csrc/distributed/c10d/shuffle.cpp
@@ -1,25 +1,75 @@
+#include <ATen/ATen.h>
 #include <torch/library.h>
 
-void fsdpCopyOut(
-    std::vector<at::Tensor> outputs,
-    at::Tensor input,
+#ifdef USE_CUDA
+void fsdpAllGatherCopyOut(
+    std::vector<at::Tensor> params,
+    at::Tensor allGatherRes,
     int64_t worldSize);
+#endif
 
 namespace {
 
-void fsdp_copy_out(
-    std::vector<at::Tensor> outputs,
-    at::Tensor input,
+static inline int64_t divUp(int64_t a, int64_t b) {
+  return (a + b - 1) / b;
+}
+
+at::Tensor fsdp_all_gather_copy_in(
+    std::vector<at::Tensor> params,
+    at::ScalarType dtype) {
+  constexpr int64_t BYTES_PER_THREAD = 16;
+  const auto elemSize = elementSize(dtype);
+  const auto numelPerThread = BYTES_PER_THREAD / elemSize;
+  const auto device = params[0].device();
+
+  int64_t alignedTotalNumel = 0;
+  std::vector<int64_t> alignedOffsets{0};
+  for (size_t i = 0; i < params.size(); ++i) {
+    const auto& param = params[i];
+    TORCH_CHECK(param.device() == device);
+    const auto alignedNumel =
+        divUp(param.numel(), numelPerThread) * numelPerThread;
+    alignedTotalNumel += alignedNumel;
+    alignedOffsets.push_back(alignedOffsets[i] + alignedNumel);
+  }
+
+  auto allGatherInput = at::zeros(
+      {alignedTotalNumel}, at::TensorOptions().dtype(dtype).device(device));
+  for (size_t i = 0; i < params.size(); ++i) {
+    at::NoGradGuard no_grad;
+    const auto& param = params[i];
+    auto view = at::narrow(allGatherInput, 0, alignedOffsets[i], param.numel());
+    // TODO: don't materialize the intermediate
+    view.copy_(param.to(dtype));
+  }
+  return allGatherInput;
+}
+
+void fsdp_all_gather_copy_out(
+    std::vector<at::Tensor> params,
+    at::Tensor all_gather_res,
     int64_t world_size) {
-  return fsdpCopyOut(outputs, input, world_size);
+#ifdef USE_CUDA
+  return fsdpAllGatherCopyOut(params, all_gather_res, world_size);
+#else
+  C10_THROW_ERROR(NotImplementedError, "Not implemented for CPU");
+#endif
 }
 
 } // namespace
 
 TORCH_LIBRARY_FRAGMENT(c10d, m) {
   m.def(
-      "fsdp_copy_out(Tensor[] outputs, Tensor input, int world_size) -> ()",
+      "fsdp_all_gather_copy_in(Tensor[] params, ScalarType dtype) -> Tensor",
       torch::dispatch(
-          c10::DispatchKey::CompositeExplicitAutograd, ::fsdp_copy_out),
+          c10::DispatchKey::CompositeExplicitAutograd,
+          ::fsdp_all_gather_copy_in),
+      {at::Tag::pt2_compliant_tag});
+
+  m.def(
+      "fsdp_all_gather_copy_out(Tensor[] params, Tensor all_gather_res, int world_size) -> ()",
+      torch::dispatch(
+          c10::DispatchKey::CompositeExplicitAutograd,
+          ::fsdp_all_gather_copy_out),
       {at::Tag::pt2_compliant_tag});
 }

--- a/torch/csrc/distributed/c10d/shuffle.cpp
+++ b/torch/csrc/distributed/c10d/shuffle.cpp
@@ -5,87 +5,20 @@
 void fsdpAllGatherCopyOut(
     std::vector<at::Tensor> params,
     at::Tensor allGatherRes,
-    int64_t worldSize);
-
-void fsdpAllGatherCopyOut_no_align(
-    std::vector<at::Tensor> params,
-    at::Tensor allGatherRes,
-    int64_t worldSize);
-
-void fsdpAllGatherCopyOut_no_align_2(
-    std::vector<at::Tensor> params,
-    at::Tensor allGatherRes,
     int64_t worldSize,
-    int64_t warpsPerShard);
+    int64_t maxBlocksPerShard);
 #endif
 
 namespace {
 
-static inline int64_t divUp(int64_t a, int64_t b) {
-  return (a + b - 1) / b;
-}
-
-at::Tensor fsdp_all_gather_copy_in(
-    std::vector<at::Tensor> params,
-    at::ScalarType dtype) {
-  constexpr int64_t BYTES_PER_THREAD = 16;
-  const auto elemSize = elementSize(dtype);
-  const auto numelPerThread = BYTES_PER_THREAD / elemSize;
-  const auto device = params[0].device();
-
-  int64_t alignedTotalNumel = 0;
-  std::vector<int64_t> alignedOffsets{0};
-  for (size_t i = 0; i < params.size(); ++i) {
-    const auto& param = params[i];
-    TORCH_CHECK(param.device() == device);
-    const auto alignedNumel =
-        divUp(param.numel(), numelPerThread) * numelPerThread;
-    alignedTotalNumel += alignedNumel;
-    alignedOffsets.push_back(alignedOffsets[i] + alignedNumel);
-  }
-
-  auto allGatherInput = at::zeros(
-      {alignedTotalNumel}, at::TensorOptions().dtype(dtype).device(device));
-  for (size_t i = 0; i < params.size(); ++i) {
-    at::NoGradGuard no_grad;
-    const auto& param = params[i];
-    auto view = at::narrow(allGatherInput, 0, alignedOffsets[i], param.numel());
-    // TODO: don't materialize the intermediate
-    view.copy_(param.to(dtype));
-  }
-  return allGatherInput;
-}
-
 void fsdp_all_gather_copy_out(
     std::vector<at::Tensor> params,
     at::Tensor all_gather_res,
-    int64_t world_size) {
-#ifdef USE_CUDA
-  return fsdpAllGatherCopyOut(params, all_gather_res, world_size);
-#else
-  C10_THROW_ERROR(NotImplementedError, "Not implemented for CPU");
-#endif
-}
-
-void fsdp_all_gather_copy_out_no_align(
-    std::vector<at::Tensor> params,
-    at::Tensor all_gather_res,
-    int64_t world_size) {
-#ifdef USE_CUDA
-  return fsdpAllGatherCopyOut_no_align(params, all_gather_res, world_size);
-#else
-  C10_THROW_ERROR(NotImplementedError, "Not implemented for CPU");
-#endif
-}
-
-void fsdp_all_gather_copy_out_no_align_2(
-    std::vector<at::Tensor> params,
-    at::Tensor all_gather_res,
     int64_t world_size,
-    int64_t warps_per_shard) {
+    int64_t max_blocks_per_shard) {
 #ifdef USE_CUDA
-  return fsdpAllGatherCopyOut_no_align_2(
-      params, all_gather_res, world_size, warps_per_shard);
+  return fsdpAllGatherCopyOut(
+      params, all_gather_res, world_size, max_blocks_per_shard);
 #else
   C10_THROW_ERROR(NotImplementedError, "Not implemented for CPU");
 #endif
@@ -95,31 +28,10 @@ void fsdp_all_gather_copy_out_no_align_2(
 
 TORCH_LIBRARY_FRAGMENT(c10d, m) {
   m.def(
-      "fsdp_all_gather_copy_in(Tensor[] params, ScalarType dtype) -> Tensor",
-      torch::dispatch(
-          c10::DispatchKey::CompositeExplicitAutograd,
-          ::fsdp_all_gather_copy_in),
-      {at::Tag::pt2_compliant_tag});
-
-  m.def(
-      "fsdp_all_gather_copy_out(Tensor[] params, Tensor all_gather_res, int world_size) -> ()",
+      "fsdp_all_gather_copy_out("
+      "Tensor[] params, Tensor all_gather_res, int world_size, int max_blocks_per_shard=4) -> ()",
       torch::dispatch(
           c10::DispatchKey::CompositeExplicitAutograd,
           ::fsdp_all_gather_copy_out),
-      {at::Tag::pt2_compliant_tag});
-
-  m.def(
-      "fsdp_all_gather_copy_out_no_align(Tensor[] params, Tensor all_gather_res, int world_size) -> ()",
-      torch::dispatch(
-          c10::DispatchKey::CompositeExplicitAutograd,
-          ::fsdp_all_gather_copy_out_no_align),
-      {at::Tag::pt2_compliant_tag});
-
-  m.def(
-      "fsdp_all_gather_copy_out_no_align_2("
-      "Tensor[] params, Tensor all_gather_res, int world_size, int warps_per_shard=4) -> ()",
-      torch::dispatch(
-          c10::DispatchKey::CompositeExplicitAutograd,
-          ::fsdp_all_gather_copy_out_no_align_2),
       {at::Tag::pt2_compliant_tag});
 }

--- a/torch/csrc/distributed/c10d/shuffle.cpp
+++ b/torch/csrc/distributed/c10d/shuffle.cpp
@@ -15,7 +15,8 @@ void fsdpAllGatherCopyOut_no_align(
 void fsdpAllGatherCopyOut_no_align_2(
     std::vector<at::Tensor> params,
     at::Tensor allGatherRes,
-    int64_t worldSize);
+    int64_t worldSize,
+    int64_t warpsPerShard);
 #endif
 
 namespace {
@@ -80,9 +81,11 @@ void fsdp_all_gather_copy_out_no_align(
 void fsdp_all_gather_copy_out_no_align_2(
     std::vector<at::Tensor> params,
     at::Tensor all_gather_res,
-    int64_t world_size) {
+    int64_t world_size,
+    int64_t warps_per_shard) {
 #ifdef USE_CUDA
-  return fsdpAllGatherCopyOut_no_align_2(params, all_gather_res, world_size);
+  return fsdpAllGatherCopyOut_no_align_2(
+      params, all_gather_res, world_size, warps_per_shard);
 #else
   C10_THROW_ERROR(NotImplementedError, "Not implemented for CPU");
 #endif
@@ -113,7 +116,8 @@ TORCH_LIBRARY_FRAGMENT(c10d, m) {
       {at::Tag::pt2_compliant_tag});
 
   m.def(
-      "fsdp_all_gather_copy_out_no_align_2(Tensor[] params, Tensor all_gather_res, int world_size) -> ()",
+      "fsdp_all_gather_copy_out_no_align_2("
+      "Tensor[] params, Tensor all_gather_res, int world_size, int warps_per_shard=4) -> ()",
       torch::dispatch(
           c10::DispatchKey::CompositeExplicitAutograd,
           ::fsdp_all_gather_copy_out_no_align_2),

--- a/torch/csrc/distributed/c10d/shuffle.cpp
+++ b/torch/csrc/distributed/c10d/shuffle.cpp
@@ -5,8 +5,7 @@
 void fsdpAllGatherCopyOut(
     std::vector<at::Tensor> params,
     at::Tensor allGatherRes,
-    int64_t worldSize,
-    int64_t maxBlocksPerShard);
+    int64_t worldSize);
 #endif
 
 namespace {
@@ -14,11 +13,9 @@ namespace {
 void fsdp_all_gather_copy_out(
     std::vector<at::Tensor> params,
     at::Tensor all_gather_res,
-    int64_t world_size,
-    int64_t max_blocks_per_shard) {
+    int64_t world_size) {
 #ifdef USE_CUDA
-  return fsdpAllGatherCopyOut(
-      params, all_gather_res, world_size, max_blocks_per_shard);
+  return fsdpAllGatherCopyOut(params, all_gather_res, world_size);
 #else
   C10_THROW_ERROR(NotImplementedError, "Not implemented for CPU");
 #endif
@@ -29,7 +26,7 @@ void fsdp_all_gather_copy_out(
 TORCH_LIBRARY_FRAGMENT(c10d, m) {
   m.def(
       "fsdp_all_gather_copy_out("
-      "Tensor[] params, Tensor all_gather_res, int world_size, int max_blocks_per_shard=4) -> ()",
+      "Tensor[] params, Tensor all_gather_res, int world_size) -> ()",
       torch::dispatch(
           c10::DispatchKey::CompositeExplicitAutograd,
           ::fsdp_all_gather_copy_out),

--- a/torch/csrc/distributed/c10d/shuffle.cpp
+++ b/torch/csrc/distributed/c10d/shuffle.cpp
@@ -1,0 +1,25 @@
+#include <torch/library.h>
+
+void fsdpCopyOut(
+    std::vector<at::Tensor> outputs,
+    at::Tensor input,
+    int64_t worldSize);
+
+namespace {
+
+void fsdp_copy_out(
+    std::vector<at::Tensor> outputs,
+    at::Tensor input,
+    int64_t world_size) {
+  return fsdpCopyOut(outputs, input, world_size);
+}
+
+} // namespace
+
+TORCH_LIBRARY_FRAGMENT(c10d, m) {
+  m.def(
+      "fsdp_copy_out(Tensor[] outputs, Tensor input, int world_size) -> ()",
+      torch::dispatch(
+          c10::DispatchKey::CompositeExplicitAutograd, ::fsdp_copy_out),
+      {at::Tag::pt2_compliant_tag});
+}

--- a/torch/csrc/distributed/c10d/shuffle.cu
+++ b/torch/csrc/distributed/c10d/shuffle.cu
@@ -3,15 +3,17 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
 
+constexpr int64_t BLOCK_SIZE = 128;
 constexpr int64_t BYTES_PER_THREAD = 16;
-constexpr int64_t MAX_NUM_THREADS = 1024;
-constexpr int64_t MIN_NUM_THREADS = 128;
 constexpr int64_t WARP_SIZE = 32;
 
 template <typename T>
 __device__ inline void streamLoad128(uint4& val, const T* addr) {
 #if defined(USE_ROCM) || (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800))
-  CUDA_KERNEL_ASSERT(false);
+  val.x = reinterpret_cast<uint4*>(addr)->x;
+  val.y = reinterpret_cast<uint4*>(addr)->y;
+  val.z = reinterpret_cast<uint4*>(addr)->z;
+  val.w = reinterpret_cast<uint4*>(addr)->w;
 #else
   unsigned long long int low, high;
   asm("ld.global.nc.v2.u64 {%0, %1}, [%2];"
@@ -25,7 +27,10 @@ __device__ inline void streamLoad128(uint4& val, const T* addr) {
 template <typename T>
 __device__ inline void streamStore128(T* addr, const uint4& val) {
 #if defined(USE_ROCM) || (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800))
-  CUDA_KERNEL_ASSERT(false);
+  reinterpret_cast<uint4*>(addr)->x = val.x;
+  reinterpret_cast<uint4*>(addr)->y = val.y;
+  reinterpret_cast<uint4*>(addr)->z = val.z;
+  reinterpret_cast<uint4*>(addr)->w = val.w;
 #else
   unsigned long long int low, high;
   low = reinterpret_cast<const unsigned long long int*>(&val)[0];
@@ -38,82 +43,97 @@ static __host__ __device__ inline int64_t divUp(int64_t a, int64_t b) {
   return (a + b - 1) / b;
 }
 
-static __device__ inline bool isAligned(const void* ptr, size_t alignment) {
-  uintptr_t addr = reinterpret_cast<uintptr_t>(ptr);
-  return addr % alignment == 0;
+static __device__ inline bool isAligned(const void* addr, size_t alignment) {
+  return reinterpret_cast<uintptr_t>(addr) % alignment == 0;
+}
+
+static __device__ inline void read128(uint4& val, const char* addr) {
+  if (isAligned(addr, BYTES_PER_THREAD)) {
+    streamLoad128(val, addr);
+  } else if (isAligned(addr, sizeof(uint64_t))) {
+    for (size_t j = 0; j < BYTES_PER_THREAD / sizeof(uint64_t); ++j) {
+      reinterpret_cast<uint64_t*>(&val)[j] =
+          reinterpret_cast<const uint64_t*>(addr)[j];
+    }
+  } else if (isAligned(addr, sizeof(uint32_t))) {
+    for (size_t j = 0; j < BYTES_PER_THREAD / sizeof(uint32_t); ++j) {
+      reinterpret_cast<uint32_t*>(&val)[j] =
+          reinterpret_cast<const uint32_t*>(addr)[j];
+    }
+  } else if (isAligned(addr, sizeof(uint64_t))) {
+    for (size_t j = 0; j < BYTES_PER_THREAD / sizeof(uint64_t); ++j) {
+      reinterpret_cast<uint16_t*>(&val)[j] =
+          reinterpret_cast<const uint16_t*>(addr)[j];
+    }
+  } else {
+    for (size_t j = 0; j < BYTES_PER_THREAD; ++j) {
+      reinterpret_cast<char*>(&val)[j] = (addr)[j];
+    }
+  }
 }
 
 static __global__ void fsdpAllGatherCopyOutKernel(
-    void** paramPtrs,
-    void* allGatherResPtr,
+    char** params,
+    char* allGatherRes,
     int64_t totalSize,
     int64_t* blockOffsetToParamIdx,
     int64_t* blockCumSums,
-    int64_t* shardDimCumSums,
-    int64_t numParams,
-    int64_t shardDimSum,
+    int64_t* shardSizeCumSums,
     int64_t blockDimSum,
+    int64_t shardSizeSum,
     int64_t ranksPerBlock,
     int64_t worldSize) {
   const int64_t blockOffset = blockIdx.x % blockDimSum;
   const int64_t paramIdx = blockOffsetToParamIdx[blockOffset];
+  const int64_t shardBlockCount =
+      blockCumSums[paramIdx + 1] - blockCumSums[paramIdx];
+  const int64_t shardBlockId = blockOffset - blockCumSums[paramIdx];
+  const int64_t groupSize = shardBlockCount * blockDim.x;
+  const int64_t groupOff = shardBlockId * blockDim.x + threadIdx.x;
+  const int64_t shardBegin = shardSizeCumSums[paramIdx];
+  const int64_t shardEnd = shardSizeCumSums[paramIdx + 1];
+  const int64_t shardSize = shardEnd - shardBegin;
 
   for (int64_t rank = blockIdx.x / blockDimSum; rank < worldSize;
        rank += worldSize / ranksPerBlock) {
-    const int64_t shardBlockCount =
-        blockCumSums[paramIdx + 1] - blockCumSums[paramIdx];
-    const int64_t groupSize = shardBlockCount * blockDim.x;
-    const int64_t localTid =
-        (blockOffset - blockCumSums[paramIdx]) * blockDim.x + threadIdx.x;
+    const int64_t srcOff = rank * shardSizeSum + shardBegin;
+    const int64_t dstOff = rank * shardSize;
 
-    const int64_t shardBegin = shardDimCumSums[paramIdx];
-    const int64_t shardEnd = shardDimCumSums[paramIdx + 1];
-    const int64_t shardLen = shardEnd - shardBegin;
-    const int64_t srcOff = rank * shardDimSum + shardBegin;
-    const int64_t dstOff = rank * shardLen;
+    const char* src = allGatherRes + srcOff;
+    char* dst = params[paramIdx] + dstOff;
 
-    const char* srcPtr = reinterpret_cast<char*>(allGatherResPtr) + srcOff;
-    char* dstPtr = &reinterpret_cast<char*>(paramPtrs[paramIdx])[dstOff];
+    if (shardSize < blockDim.x) {
+      if (groupOff < shardSize) {
+        dst[groupOff] = src[groupOff];
+      }
+      continue;
+    }
 
-    const int64_t alignOff =
+    const int64_t vecBegin =
         divUp(dstOff, BYTES_PER_THREAD) * BYTES_PER_THREAD - dstOff;
-    const int64_t begin = alignOff + localTid * BYTES_PER_THREAD;
-    const int64_t end =
-        alignOff + (shardLen - alignOff) / BYTES_PER_THREAD * BYTES_PER_THREAD;
+    const int64_t vecEnd =
+        vecBegin + (shardSize - vecBegin) / BYTES_PER_THREAD * BYTES_PER_THREAD;
     const int64_t stride = groupSize * BYTES_PER_THREAD;
 
-    for (size_t i = begin; i < end; i += stride) {
+    for (size_t i = vecBegin + groupOff * BYTES_PER_THREAD; i < vecEnd;
+         i += stride) {
       uint4 val;
-      if (isAligned(srcPtr + i, 128)) {
-        streamLoad128(val, srcPtr + i);
-      } else {
-        for (size_t j = 0; j < BYTES_PER_THREAD; ++j) {
-          reinterpret_cast<char*>(&val)[j] = srcPtr[i + j];
-        }
-      }
-      streamStore128(&dstPtr[i], val);
+      read128(val, &src[i]);
+      streamStore128(&dst[i], val);
     }
-    if (localTid < alignOff && localTid < shardLen) {
-      dstPtr[localTid] = srcPtr[localTid];
+    if (groupOff < vecBegin && groupOff < shardSize) {
+      dst[groupOff] = src[groupOff];
     }
-    if (end + localTid < shardLen) {
-      dstPtr[end + localTid] = srcPtr[end + localTid];
+    if (vecEnd + groupOff < shardSize) {
+      dst[vecEnd + groupOff] = src[vecEnd + groupOff];
     }
   }
 }
 
-static int64_t geometricMean(const std::vector<int64_t>& numbers) {
-  TORCH_CHECK(numbers.size() > 0);
-  double logSum = 0.0;
-  for (double num : numbers) {
-    TORCH_CHECK(num > 0);
-    logSum += log(num);
-  }
-  double avgLog = logSum / numbers.size();
-  return exp(avgLog);
-}
-
-std::pair<at::Tensor, std::vector<int64_t*>> pack(
+/**
+ * Pack multiple std::vector<int64_t> into a single cuda tensor.
+ */
+std::pair<at::Tensor, std::vector<int64_t*>> packArgs(
     std::vector<std::vector<int64_t>> vecs,
     const at::Device& device) {
   int64_t numel = 0;
@@ -152,72 +172,69 @@ void fsdpAllGatherCopyOut(
   TORCH_CHECK(allGatherRes.is_cuda());
   TORCH_CHECK(allGatherRes.is_non_overlapping_and_dense());
 
-  std::vector<int64_t> paramPtrs;
-  std::vector<int64_t> shardDims; // In bytes
-  std::vector<int64_t> dimCumSums{0}; // In bytes
+  std::vector<int64_t> paramPtrs; // Param pointers stored as int64_t
+  std::vector<int64_t> shardSizes; // In bytes
+  std::vector<int64_t> shardSizeCumSums{0}; // In bytes
   for (size_t i = 0; i < params.size(); ++i) {
     const auto& param = params[i];
-    TORCH_CHECK(param.is_non_overlapping_and_dense());
     TORCH_CHECK(param.device() == device);
+    TORCH_CHECK(param.is_non_overlapping_and_dense());
     TORCH_CHECK(param.numel() > 0);
-    // All params are expected to be aligned at worldSize.
     TORCH_CHECK(param.numel() % worldSize == 0);
-    const auto shardDim = param.numel() * param.element_size() / worldSize;
+    // Deduce the shard size from the param size
+    const auto shardSize = param.numel() * param.element_size() / worldSize;
     paramPtrs.push_back(reinterpret_cast<int64_t>(param.data_ptr()));
-    shardDims.push_back(shardDim);
-    dimCumSums.push_back(dimCumSums[i] + shardDim);
+    shardSizes.push_back(shardSize);
+    shardSizeCumSums.push_back(shardSizeCumSums[i] + shardSize);
   }
 
   TORCH_CHECK(
-      dimCumSums.back() * worldSize == totalSize,
+      shardSizeCumSums.back() * worldSize == totalSize,
       "The total byte size must be identical between params and allGatherRes");
 
-  // To balance the throughput larger shards and waste on smaller shards, we
-  // use the geometric mean of the shard dims to determine the block size.
-  int64_t meanShardDim = geometricMean(shardDims);
-  int64_t blockSize = divUp(meanShardDim, BYTES_PER_THREAD);
-  blockSize = divUp(blockSize, WARP_SIZE) * WARP_SIZE;
-  blockSize = std::min(std::max(blockSize, MIN_NUM_THREADS), MAX_NUM_THREADS);
-
-  // TODO: this is only for A100
-  constexpr int64_t maxActiveBlocks = 32 * 108;
-  constexpr double smOverSubFactor = 1.75;
-
-  // Roughly estimate the amount of blocks needed for each rank, and calculate
-  // an iter factor to regularize SM over-subscription.
-  int64_t iterFactor = 1;
-  while (divUp(totalSize, blockSize * BYTES_PER_THREAD * iterFactor) >
-         (maxActiveBlocks * smOverSubFactor)) {
-    iterFactor += 1;
+  static int64_t numSMs = -1;
+  static int64_t maxThreadsPerSM = -1;
+  if (numSMs == -1) {
+    cudaDeviceProp deviceProp;
+    AT_CUDA_CHECK(cudaGetDeviceProperties(&deviceProp, device.index()));
+    numSMs = deviceProp.multiProcessorCount;
+    maxThreadsPerSM = deviceProp.maxThreadsPerMultiProcessor;
   }
+
+  // Calculate the amount of blocks needed if each thread only processes
+  // NUM_BYTES_PER_THREAD.
+  int64_t nBlks = 0;
+  for (const auto& shardSize : shardSizes) {
+    nBlks += divUp(shardSize, BLOCK_SIZE * BYTES_PER_THREAD);
+  }
+
+  // The kernel uses no shared memory and little registers.
+  const int64_t maxBlks = numSMs * maxThreadsPerSM * 4.0;
+  int64_t iterFactor = divUp(BLOCK_SIZE * nBlks * worldSize, maxBlks);
+  int64_t ranksPerBlock = std::ceil(std::sqrt(iterFactor));
+  ranksPerBlock = std::min(static_cast<int64_t>(worldSize), ranksPerBlock);
+  iterFactor = divUp(iterFactor, ranksPerBlock);
 
   std::vector<int64_t> blockOffsetToParamIdx;
   std::vector<int64_t> blockCumSums{0};
   for (int64_t paramIdx = 0; paramIdx < static_cast<int64_t>(params.size());
        ++paramIdx) {
     int64_t numBlocks =
-        divUp(shardDims[paramIdx], blockSize * BYTES_PER_THREAD * iterFactor);
+        divUp(shardSizes[paramIdx], BLOCK_SIZE * BYTES_PER_THREAD * iterFactor);
     blockOffsetToParamIdx.insert(
         blockOffsetToParamIdx.end(), numBlocks, paramIdx);
     blockCumSums.push_back(blockCumSums.back() + numBlocks);
   }
   const auto numBlocks = blockCumSums.back();
 
-  auto packed = pack(
-      {paramPtrs, blockOffsetToParamIdx, blockCumSums, dimCumSums}, device);
-
-  int64_t ranksPerBlock = 1;
-  while (numBlocks * (worldSize / ranksPerBlock) >
-             maxActiveBlocks * smOverSubFactor &&
-         ranksPerBlock < worldSize) {
-    ++ranksPerBlock;
-  }
+  auto packedArgs = packArgs(
+      {paramPtrs, blockOffsetToParamIdx, blockCumSums, shardSizeCumSums},
+      device);
 
   dim3 blocks(numBlocks * (worldSize / ranksPerBlock), 1, 1);
-  dim3 threads(blockSize, 1, 1);
+  dim3 threads(BLOCK_SIZE, 1, 1);
 
-  LOG(INFO) << "meanShardDim: " << meanShardDim
-            << ", iterFactor: " << iterFactor
+  LOG(INFO) << "iterFactor: " << iterFactor
             << ", ranksPerBlock: " << ranksPerBlock << ", blocks: " << blocks.x
             << ", threads: " << threads.x;
 
@@ -226,15 +243,14 @@ void fsdpAllGatherCopyOut(
       threads,
       0,
       at::cuda::getCurrentCUDAStream()>>>(
-      reinterpret_cast<void**>(packed.second[0]),
-      allGatherRes.data_ptr(),
+      /*paramPtrs=*/reinterpret_cast<char**>(packedArgs.second[0]),
+      reinterpret_cast<char*>(allGatherRes.data_ptr()),
       totalSize,
-      /*blockOffsetToParamIdx=*/packed.second[1],
-      /*blockCumSums=*/packed.second[2],
-      /*shardDimCumSums=*/packed.second[3],
-      params.size(),
-      dimCumSums.back(),
+      /*blockOffsetToParamIdx=*/packedArgs.second[1],
+      /*blockCumSums=*/packedArgs.second[2],
+      /*shardSizeCumSums=*/packedArgs.second[3],
       blockCumSums.back(),
+      shardSizeCumSums.back(),
       ranksPerBlock,
       worldSize);
   C10_CUDA_KERNEL_LAUNCH_CHECK();

--- a/torch/csrc/distributed/c10d/shuffle.cu
+++ b/torch/csrc/distributed/c10d/shuffle.cu
@@ -38,6 +38,9 @@ static inline int64_t divUp(int64_t a, int64_t b) {
   return (a + b - 1) / b;
 }
 
+///////////////////////////////////////////////////////////////////////////////
+// Requires shards to be 128-bit aligned with no gaps in-between shards.
+///////////////////////////////////////////////////////////////////////////////
 template <typename T>
 static __global__ void fsdpAllGatherCopyOutKernel(
     T** paramPtrs,
@@ -149,6 +152,259 @@ void fsdpAllGatherCopyOut(
                 params.size(),
                 worldSize,
                 shardDimCumSums.back());
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      });
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// No alignment requirements on shards.
+// Requires all_gather input to be prepared with fsdp_all_gather_copy_in
+// which aligns shards at 128-bit. There will be gaps in-between shards.
+///////////////////////////////////////////////////////////////////////////////
+template <typename T>
+static __global__ void fsdpAllGatherCopyOutKernel_no_align(
+    T** paramPtrs,
+    T* allGatherResPtr,
+    int64_t numel,
+    int64_t* alignedDimCumSums,
+    int64_t* unalignedDims,
+    int64_t numParams,
+    int64_t worldSize,
+    int64_t shardDimSum) {
+  const auto numelPerThread = BYTES_PER_THREAD / sizeof(T);
+  const auto tid = blockIdx.x * blockDim.x + threadIdx.x;
+  const auto srcOff = tid * numelPerThread;
+  const auto rankOff = srcOff % shardDimSum; // Offset within the rank
+  const auto rank = srcOff / shardDimSum;
+
+  if (srcOff >= numel) {
+    return;
+  }
+
+  __shared__ int64_t dimCumSums[MAX_NUM_PARAMS + 1];
+  __shared__ int64_t unalignedDims_[MAX_NUM_PARAMS];
+  if (threadIdx.x < numParams + 1) {
+    dimCumSums[threadIdx.x] = alignedDimCumSums[threadIdx.x];
+    unalignedDims_[threadIdx.x] = unalignedDims[threadIdx.x];
+  }
+  __syncthreads();
+
+  int paramIdx = 0;
+  for (size_t i = 1; i < numParams; ++i) {
+    // Threads in a warp are likely to take the same branch.
+    // So branching is beneficial here especially with large numParams.
+    if (rankOff < dimCumSums[i]) {
+      break;
+    }
+    paramIdx += 1;
+  }
+
+  const auto alignedShardBegin = dimCumSums[paramIdx];
+  const auto unalignedShardLen = unalignedDims_[paramIdx];
+  const auto paramOff = unalignedShardLen * rank + rankOff - alignedShardBegin;
+  const auto paramShardEnd = unalignedShardLen * (rank + 1);
+
+  for (size_t i = 0; i < numelPerThread; ++i) {
+    if (paramOff + i >= paramShardEnd) {
+      break;
+    }
+    paramPtrs[paramIdx][paramOff + i] = allGatherResPtr[srcOff + i];
+  }
+}
+
+void fsdpAllGatherCopyOut_no_align(
+    std::vector<at::Tensor> params,
+    at::Tensor allGatherRes,
+    int64_t worldSize) {
+  const auto numelPerThread = BYTES_PER_THREAD / allGatherRes.element_size();
+  const auto device = allGatherRes.device();
+  const auto scalarType = allGatherRes.scalar_type();
+
+  TORCH_CHECK(allGatherRes.is_cuda());
+  TORCH_CHECK(allGatherRes.is_non_overlapping_and_dense());
+  TORCH_CHECK(allGatherRes.numel() % worldSize == 0);
+  TORCH_CHECK(params.size() <= MAX_NUM_PARAMS);
+
+  std::vector<void*> paramPtrs;
+  std::vector<int64_t> alignedDimCumSums{0};
+  std::vector<int64_t> unalignedDims;
+  for (size_t i = 0; i < params.size(); ++i) {
+    const auto& param = params[i];
+    TORCH_CHECK(param.is_non_overlapping_and_dense());
+    TORCH_CHECK(param.device() == device);
+    TORCH_CHECK(param.scalar_type() == scalarType);
+    // All params are expected to be aligned at worldSize.
+    // But not neccessarily worldSize * numelPerThread.
+    TORCH_CHECK(param.numel() % worldSize == 0);
+    paramPtrs.push_back(param.data_ptr());
+    const auto alignedDim =
+        divUp(param.numel(), worldSize * numelPerThread) * numelPerThread;
+    alignedDimCumSums.push_back(alignedDimCumSums[i] + alignedDim);
+    unalignedDims.push_back(param.numel() / worldSize);
+  }
+
+  TORCH_CHECK(
+      alignedDimCumSums.back() * worldSize == allGatherRes.numel(),
+      "allGatherRes and params must contain the same number of elements.");
+
+  auto packed = at::empty(
+      {static_cast<int64_t>(
+          paramPtrs.size() + alignedDimCumSums.size() + unalignedDims.size())},
+      at::TensorOptions().dtype(at::kLong).pinned_memory(true));
+  memcpy(
+      packed.data_ptr(), paramPtrs.data(), sizeof(int64_t) * paramPtrs.size());
+  memcpy(
+      packed.data_ptr<int64_t>() + paramPtrs.size(),
+      alignedDimCumSums.data(),
+      sizeof(int64_t) * alignedDimCumSums.size());
+  memcpy(
+      packed.data_ptr<int64_t>() + paramPtrs.size() + alignedDimCumSums.size(),
+      unalignedDims.data(),
+      sizeof(int64_t) * unalignedDims.size());
+  packed = packed.to(device, /*non_blocking=*/true);
+  auto paramPtrsDev = packed.data_ptr();
+  auto shardDimCumSumsDev = packed.data_ptr<int64_t>() + paramPtrs.size();
+  auto unalignedDimsDev =
+      packed.data_ptr<int64_t>() + paramPtrs.size() + alignedDimCumSums.size();
+
+  dim3 blocks(0, 1, 1);
+  dim3 threads(0, 1, 1);
+
+  auto numThreadsRequired = allGatherRes.numel() / numelPerThread;
+  if (numThreadsRequired <= MAX_NUM_THREADS) {
+    blocks.x = 1;
+    threads.x = divUp(numThreadsRequired, WARP_SIZE) * WARP_SIZE;
+  } else {
+    blocks.x = divUp(numThreadsRequired, MAX_NUM_THREADS);
+    threads.x = MAX_NUM_THREADS;
+  }
+
+  TORCH_WARN_ONCE("blocks: ", blocks.x, ", threads: ", threads.x);
+
+  AT_DISPATCH_ALL_TYPES_AND(
+      at::ScalarType::BFloat16, scalarType, "fsdp_all_gather_copy_out", [&] {
+        fsdpAllGatherCopyOutKernel_no_align<scalar_t>
+            <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+                reinterpret_cast<scalar_t**>(paramPtrsDev),
+                allGatherRes.data_ptr<scalar_t>(),
+                allGatherRes.numel(),
+                shardDimCumSumsDev,
+                unalignedDimsDev,
+                params.size(),
+                worldSize,
+                alignedDimCumSums.back());
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      });
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// No requirement on alignment at any stage.
+///////////////////////////////////////////////////////////////////////////////
+template <typename T>
+static __global__ void fsdpAllGatherCopyOutKernel_no_align_2(
+    T** paramPtrs,
+    T* allGatherResPtr,
+    int64_t numel,
+    int64_t* shardDimCumSums,
+    int64_t numParams,
+    int64_t worldSize,
+    int64_t shardDimSum) {
+  const auto srcOff = blockIdx.x * blockDim.x + threadIdx.x;
+  const auto rankOff = srcOff % shardDimSum; // Offset within the rank
+  const auto rank = srcOff / shardDimSum;
+
+  __shared__ int64_t dimCumSums[MAX_NUM_PARAMS + 1];
+  if (threadIdx.x < numParams + 1) {
+    dimCumSums[threadIdx.x] = shardDimCumSums[threadIdx.x];
+  }
+  __syncthreads();
+
+  int paramIdx = 0;
+  for (size_t i = 1; i < numParams; ++i) {
+    // Threads in a warp are likely to take the same branch.
+    // So branching is beneficial here especially with large numParams.
+    if (rankOff < dimCumSums[i]) {
+      break;
+    }
+    paramIdx += 1;
+  }
+  const auto shardBegin = dimCumSums[paramIdx];
+  const auto shardEnd = dimCumSums[paramIdx + 1];
+  const auto shardLen = shardEnd - shardBegin;
+  const auto paramOff = shardLen * rank + rankOff - shardBegin;
+
+  if (srcOff < numel) {
+    paramPtrs[paramIdx][paramOff] = allGatherResPtr[srcOff];
+  }
+}
+
+void fsdpAllGatherCopyOut_no_align_2(
+    std::vector<at::Tensor> params,
+    at::Tensor allGatherRes,
+    int64_t worldSize) {
+  const auto device = allGatherRes.device();
+  const auto scalarType = allGatherRes.scalar_type();
+
+  TORCH_CHECK(allGatherRes.is_cuda());
+  TORCH_CHECK(allGatherRes.is_non_overlapping_and_dense());
+  TORCH_CHECK(allGatherRes.numel() % worldSize == 0);
+  TORCH_CHECK(params.size() <= MAX_NUM_PARAMS);
+
+  std::vector<void*> paramPtrs;
+  std::vector<int64_t> dimCumSums{0};
+  for (size_t i = 0; i < params.size(); ++i) {
+    const auto& param = params[i];
+    TORCH_CHECK(param.is_non_overlapping_and_dense());
+    TORCH_CHECK(param.device() == device);
+    TORCH_CHECK(param.scalar_type() == scalarType);
+    // All params are expected to be aligned at worldSize.
+    // But not neccessarily worldSize * numelPerThread.
+    TORCH_CHECK(param.numel() % worldSize == 0);
+    paramPtrs.push_back(param.data_ptr());
+    dimCumSums.push_back(dimCumSums[i] + param.numel() / worldSize);
+  }
+
+  TORCH_CHECK(
+      dimCumSums.back() * worldSize == allGatherRes.numel(),
+      "allGatherRes and params must contain the same number of elements.");
+
+  auto packed = at::empty(
+      {static_cast<int64_t>(paramPtrs.size() + dimCumSums.size())},
+      at::TensorOptions().dtype(at::kLong).pinned_memory(true));
+  memcpy(
+      packed.data_ptr(), paramPtrs.data(), sizeof(int64_t) * paramPtrs.size());
+  memcpy(
+      packed.data_ptr<int64_t>() + paramPtrs.size(),
+      dimCumSums.data(),
+      sizeof(int64_t) * dimCumSums.size());
+  packed = packed.to(device, /*non_blocking=*/true);
+  auto paramPtrsDev = packed.data_ptr();
+  auto shardDimCumSumsDev = packed.data_ptr<int64_t>() + paramPtrs.size();
+
+  dim3 blocks(0, 1, 1);
+  dim3 threads(0, 1, 1);
+
+  if (allGatherRes.numel() <= MAX_NUM_THREADS) {
+    blocks.x = 1;
+    threads.x = divUp(allGatherRes.numel(), WARP_SIZE) * WARP_SIZE;
+  } else {
+    blocks.x = divUp(allGatherRes.numel(), MAX_NUM_THREADS);
+    threads.x = MAX_NUM_THREADS;
+  }
+
+  TORCH_WARN_ONCE("blocks: ", blocks.x, ", threads: ", threads.x);
+
+  AT_DISPATCH_ALL_TYPES_AND(
+      at::ScalarType::BFloat16, scalarType, "fsdp_all_gather_copy_out", [&] {
+        fsdpAllGatherCopyOutKernel_no_align_2<scalar_t>
+            <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+                reinterpret_cast<scalar_t**>(paramPtrsDev),
+                allGatherRes.data_ptr<scalar_t>(),
+                allGatherRes.numel(),
+                shardDimCumSumsDev,
+                params.size(),
+                worldSize,
+                dimCumSums.back());
         C10_CUDA_KERNEL_LAUNCH_CHECK();
       });
 }

--- a/torch/csrc/distributed/c10d/shuffle.cu
+++ b/torch/csrc/distributed/c10d/shuffle.cu
@@ -43,11 +43,10 @@ static __device__ inline bool isAligned(const void* ptr, size_t alignment) {
   return addr % alignment == 0;
 }
 
-template <typename T>
 static __global__ void fsdpAllGatherCopyOutKernel(
-    T** paramPtrs,
-    T* allGatherResPtr,
-    int64_t numel,
+    void** paramPtrs,
+    void* allGatherResPtr,
+    int64_t totalSize,
     int64_t* blockOffsetToParamIdx,
     int64_t* blockCumSums,
     int64_t* shardDimCumSums,
@@ -56,8 +55,6 @@ static __global__ void fsdpAllGatherCopyOutKernel(
     int64_t blockDimSum,
     int64_t ranksPerBlock,
     int64_t worldSize) {
-  constexpr int64_t numelPerThread = BYTES_PER_THREAD / sizeof(T);
-
   const int64_t blockOffset = blockIdx.x % blockDimSum;
   const int64_t paramIdx = blockOffsetToParamIdx[blockOffset];
 
@@ -75,23 +72,23 @@ static __global__ void fsdpAllGatherCopyOutKernel(
     const int64_t srcOff = rank * shardDimSum + shardBegin;
     const int64_t dstOff = rank * shardLen;
 
-    const T* srcPtr = allGatherResPtr + srcOff;
-    T* dstPtr = &paramPtrs[paramIdx][dstOff];
+    const char* srcPtr = reinterpret_cast<char*>(allGatherResPtr) + srcOff;
+    char* dstPtr = &reinterpret_cast<char*>(paramPtrs[paramIdx])[dstOff];
 
     const int64_t alignOff =
-        divUp(dstOff, numelPerThread) * numelPerThread - dstOff;
-    const int64_t begin = alignOff + localTid * numelPerThread;
+        divUp(dstOff, BYTES_PER_THREAD) * BYTES_PER_THREAD - dstOff;
+    const int64_t begin = alignOff + localTid * BYTES_PER_THREAD;
     const int64_t end =
-        alignOff + (shardLen - alignOff) / numelPerThread * numelPerThread;
-    const int64_t stride = groupSize * numelPerThread;
+        alignOff + (shardLen - alignOff) / BYTES_PER_THREAD * BYTES_PER_THREAD;
+    const int64_t stride = groupSize * BYTES_PER_THREAD;
 
     for (size_t i = begin; i < end; i += stride) {
       uint4 val;
       if (isAligned(srcPtr + i, 128)) {
         streamLoad128(val, srcPtr + i);
       } else {
-        for (size_t j = 0; j < numelPerThread; ++j) {
-          reinterpret_cast<T*>(&val)[j] = srcPtr[i + j];
+        for (size_t j = 0; j < BYTES_PER_THREAD; ++j) {
+          reinterpret_cast<char*>(&val)[j] = srcPtr[i + j];
         }
       }
       streamStore128(&dstPtr[i], val);
@@ -105,8 +102,20 @@ static __global__ void fsdpAllGatherCopyOutKernel(
   }
 }
 
+static int64_t geometricMean(const std::vector<int64_t>& numbers) {
+  TORCH_CHECK(numbers.size() > 0);
+  double logSum = 0.0;
+  for (double num : numbers) {
+    TORCH_CHECK(num > 0);
+    logSum += log(num);
+  }
+  double avgLog = logSum / numbers.size();
+  return exp(avgLog);
+}
+
 std::pair<at::Tensor, std::vector<int64_t*>> pack(
-    std::vector<std::vector<int64_t>> vecs) {
+    std::vector<std::vector<int64_t>> vecs,
+    const at::Device& device) {
   int64_t numel = 0;
   for (const auto& vec : vecs) {
     numel += vec.size();
@@ -122,7 +131,7 @@ std::pair<at::Tensor, std::vector<int64_t*>> pack(
         sizeof(int64_t) * vec.size());
     offset += vec.size();
   }
-  packed = packed.cuda();
+  packed = packed.to(device, /*non_blocking=*/true);
 
   std::vector<int64_t*> ptrs;
   offset = 0;
@@ -136,63 +145,70 @@ std::pair<at::Tensor, std::vector<int64_t*>> pack(
 void fsdpAllGatherCopyOut(
     std::vector<at::Tensor> params,
     at::Tensor allGatherRes,
-    int64_t worldSize,
-    int64_t maxBlocksPerShard) {
+    int64_t worldSize) {
   const auto device = allGatherRes.device();
-  const auto scalarType = allGatherRes.scalar_type();
+  const auto totalSize = allGatherRes.numel() * allGatherRes.element_size();
 
   TORCH_CHECK(allGatherRes.is_cuda());
   TORCH_CHECK(allGatherRes.is_non_overlapping_and_dense());
-  TORCH_CHECK(allGatherRes.numel() % worldSize == 0);
 
   std::vector<int64_t> paramPtrs;
-  std::vector<int64_t> dimCumSums{0};
+  std::vector<int64_t> shardDims; // In bytes
+  std::vector<int64_t> dimCumSums{0}; // In bytes
   for (size_t i = 0; i < params.size(); ++i) {
     const auto& param = params[i];
     TORCH_CHECK(param.is_non_overlapping_and_dense());
     TORCH_CHECK(param.device() == device);
-    TORCH_CHECK(param.scalar_type() == scalarType);
+    TORCH_CHECK(param.numel() > 0);
     // All params are expected to be aligned at worldSize.
-    // But not neccessarily worldSize * numelPerThread.
     TORCH_CHECK(param.numel() % worldSize == 0);
+    const auto shardDim = param.numel() * param.element_size() / worldSize;
     paramPtrs.push_back(reinterpret_cast<int64_t>(param.data_ptr()));
-    dimCumSums.push_back(dimCumSums[i] + param.numel() / worldSize);
+    shardDims.push_back(shardDim);
+    dimCumSums.push_back(dimCumSums[i] + shardDim);
   }
 
   TORCH_CHECK(
-      dimCumSums.back() * worldSize == allGatherRes.numel(),
-      "allGatherRes and params must contain the same number of elements.");
+      dimCumSums.back() * worldSize == totalSize,
+      "The total byte size must be identical between params and allGatherRes");
 
-  // To balance the throughput larger shards and waste on smaller shards,
-  // determine the block size with the average shard length.
-  const int64_t numelPerThread = BYTES_PER_THREAD / params[0].element_size();
-  const int64_t avgShardLen = allGatherRes.numel() / worldSize / params.size();
-  int64_t blockSize = divUp(avgShardLen, numelPerThread);
+  // To balance the throughput larger shards and waste on smaller shards, we
+  // use the geometric mean of the shard dims to determine the block size.
+  int64_t meanShardDim = geometricMean(shardDims);
+  int64_t blockSize = divUp(meanShardDim, BYTES_PER_THREAD);
   blockSize = divUp(blockSize, WARP_SIZE) * WARP_SIZE;
   blockSize = std::min(std::max(blockSize, MIN_NUM_THREADS), MAX_NUM_THREADS);
 
-  // TODO: if the numBlocks produced at this stage far exceeds maxActiveBlocks,
-  // we should increase the iter factor here as well.
+  // TODO: this is only for A100
+  constexpr int64_t maxActiveBlocks = 32 * 108;
+  constexpr double smOverSubFactor = 1.75;
+
+  // Roughly estimate the amount of blocks needed for each rank, and calculate
+  // an iter factor to regularize SM over-subscription.
+  int64_t iterFactor = 1;
+  while (divUp(totalSize, blockSize * BYTES_PER_THREAD * iterFactor) >
+         (maxActiveBlocks * smOverSubFactor)) {
+    iterFactor += 1;
+  }
+
   std::vector<int64_t> blockOffsetToParamIdx;
   std::vector<int64_t> blockCumSums{0};
   for (int64_t paramIdx = 0; paramIdx < static_cast<int64_t>(params.size());
        ++paramIdx) {
-    const int64_t shardNumel = params[paramIdx].numel() / worldSize;
-    int64_t numBlocks = divUp(shardNumel, blockSize * numelPerThread);
-    numBlocks = std::min(numBlocks, maxBlocksPerShard);
+    int64_t numBlocks =
+        divUp(shardDims[paramIdx], blockSize * BYTES_PER_THREAD * iterFactor);
     blockOffsetToParamIdx.insert(
         blockOffsetToParamIdx.end(), numBlocks, paramIdx);
     blockCumSums.push_back(blockCumSums.back() + numBlocks);
   }
   const auto numBlocks = blockCumSums.back();
 
-  auto packed =
-      pack({paramPtrs, blockOffsetToParamIdx, blockCumSums, dimCumSums});
+  auto packed = pack(
+      {paramPtrs, blockOffsetToParamIdx, blockCumSums, dimCumSums}, device);
 
-  // TODO: this is only for A100
-  constexpr int64_t maxActiveBlocks = 32 * 108;
   int64_t ranksPerBlock = 1;
-  while (numBlocks * (worldSize / ranksPerBlock) < maxActiveBlocks &&
+  while (numBlocks * (worldSize / ranksPerBlock) >
+             maxActiveBlocks * smOverSubFactor &&
          ranksPerBlock < worldSize) {
     ++ranksPerBlock;
   }
@@ -200,25 +216,26 @@ void fsdpAllGatherCopyOut(
   dim3 blocks(numBlocks * (worldSize / ranksPerBlock), 1, 1);
   dim3 threads(blockSize, 1, 1);
 
-  LOG(INFO) << "blocks: " << blocks.x << ", threads: " << threads.x;
-  LOG(INFO) << "avgShardLen: " << avgShardLen
-            << ", ranksPerBlock: " << ranksPerBlock;
+  LOG(INFO) << "meanShardDim: " << meanShardDim
+            << ", iterFactor: " << iterFactor
+            << ", ranksPerBlock: " << ranksPerBlock << ", blocks: " << blocks.x
+            << ", threads: " << threads.x;
 
-  AT_DISPATCH_ALL_TYPES_AND(
-      at::ScalarType::BFloat16, scalarType, "fsdp_all_gather_copy_out", [&] {
-        fsdpAllGatherCopyOutKernel<scalar_t>
-            <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
-                reinterpret_cast<scalar_t**>(packed.second[0]),
-                allGatherRes.data_ptr<scalar_t>(),
-                allGatherRes.numel(),
-                /*blockOffsetToParamIdx=*/packed.second[1],
-                /*blockCumSums=*/packed.second[2],
-                /*shardDimCumSums=*/packed.second[3],
-                params.size(),
-                dimCumSums.back(),
-                blockCumSums.back(),
-                ranksPerBlock,
-                worldSize);
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
-      });
+  fsdpAllGatherCopyOutKernel<<<
+      blocks,
+      threads,
+      0,
+      at::cuda::getCurrentCUDAStream()>>>(
+      reinterpret_cast<void**>(packed.second[0]),
+      allGatherRes.data_ptr(),
+      totalSize,
+      /*blockOffsetToParamIdx=*/packed.second[1],
+      /*blockCumSums=*/packed.second[2],
+      /*shardDimCumSums=*/packed.second[3],
+      params.size(),
+      dimCumSums.back(),
+      blockCumSums.back(),
+      ranksPerBlock,
+      worldSize);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
 }

--- a/torch/csrc/distributed/c10d/shuffle.cu
+++ b/torch/csrc/distributed/c10d/shuffle.cu
@@ -4,8 +4,7 @@
 #include <c10/cuda/CUDAGuard.h>
 
 constexpr int64_t BYTES_PER_THREAD = 16;
-constexpr int64_t MAX_NUM_PARAMS = 1024;
-constexpr int64_t MAX_NUM_THREADS = 1024;
+constexpr int64_t MAX_NUM_THREADS = 512;
 constexpr int64_t WARP_SIZE = 32;
 
 template <typename T>
@@ -34,372 +33,118 @@ __device__ inline void streamStore128(T* addr, const uint4& val) {
 #endif
 }
 
-template <typename T>
-__device__ inline void streamLoad64(uint2& val, const T* addr) {
-  unsigned long long int* valPtr =
-      reinterpret_cast<unsigned long long int*>(&val);
-  asm("ld.global.nc.u64 %0, [%1];" : "=l"(*valPtr) : "l"(addr));
-}
-
-template <typename T>
-__device__ inline void streamStore64(T* addr, const uint2& val) {
-  unsigned long long int data;
-  data = reinterpret_cast<const unsigned long long int*>(&val)[0];
-  asm("st.global.cs.u64 [%0], %1;" : : "l"(addr), "l"(data));
-}
-
-static inline int64_t divUp(int64_t a, int64_t b) {
+static __host__ __device__ inline int64_t divUp(int64_t a, int64_t b) {
   return (a + b - 1) / b;
 }
 
-///////////////////////////////////////////////////////////////////////////////
-// Requires shards to be 128-bit aligned with no gaps in-between shards.
-///////////////////////////////////////////////////////////////////////////////
-template <typename T>
-static __global__ void fsdpAllGatherCopyOutKernel(
-    T** paramPtrs,
-    T* allGatherResPtr,
-    int64_t numel,
-    int64_t* shardDimCumSums,
-    int64_t numParams,
-    int64_t worldSize,
-    int64_t shardDimSum) {
-  const auto numelPerThread = BYTES_PER_THREAD / sizeof(T);
-  const auto tid = blockIdx.x * blockDim.x + threadIdx.x;
-  const auto srcOff = tid * numelPerThread;
-  const auto rankOff = srcOff % shardDimSum; // Offset within the rank
-  const auto rank = srcOff / shardDimSum;
-
-  __shared__ int64_t dimCumSums[MAX_NUM_PARAMS + 1];
-  if (threadIdx.x < numParams + 1) {
-    dimCumSums[threadIdx.x] = shardDimCumSums[threadIdx.x];
-  }
-  __syncthreads();
-
-  int paramIdx = 0;
-  for (size_t i = 1; i < numParams; ++i) {
-    // Threads in a warp are likely to take the same branch.
-    // So branching is beneficial here especially with large numParams.
-    if (rankOff < dimCumSums[i]) {
-      break;
-    }
-    paramIdx += 1;
-  }
-  const auto shardBegin = dimCumSums[paramIdx];
-  const auto shardEnd = dimCumSums[paramIdx + 1];
-  const auto shardLen = shardEnd - shardBegin;
-  const auto paramOff = shardLen * rank + rankOff - shardBegin;
-
-  if (srcOff < numel) {
-    uint4 val;
-    streamLoad128(val, allGatherResPtr + srcOff);
-    streamStore128(&paramPtrs[paramIdx][paramOff], val);
-  }
-}
-
-void fsdpAllGatherCopyOut(
-    std::vector<at::Tensor> params,
-    at::Tensor allGatherRes,
-    int64_t worldSize) {
-  const auto numelPerThread = BYTES_PER_THREAD / allGatherRes.element_size();
-  const auto device = allGatherRes.device();
-  const auto scalarType = allGatherRes.scalar_type();
-
-  TORCH_CHECK(allGatherRes.is_cuda());
-  TORCH_CHECK(allGatherRes.is_non_overlapping_and_dense());
-  TORCH_CHECK(allGatherRes.numel() % worldSize == 0);
-  TORCH_CHECK(params.size() <= MAX_NUM_PARAMS);
-
-  std::vector<void*> paramPtrs;
-  std::vector<int64_t> shardDimCumSums{0};
-  for (size_t i = 0; i < params.size(); ++i) {
-    const auto& param = params[i];
-    TORCH_CHECK(param.is_non_overlapping_and_dense());
-    TORCH_CHECK(param.device() == device);
-    TORCH_CHECK(param.scalar_type() == scalarType);
-    TORCH_CHECK(
-        param.numel() % (worldSize * numelPerThread) == 0,
-        "Shard must be 128-bit aligned");
-    paramPtrs.push_back(param.data_ptr());
-    shardDimCumSums.push_back(shardDimCumSums[i] + param.numel() / worldSize);
-  }
-
-  TORCH_CHECK(
-      shardDimCumSums.back() * worldSize == allGatherRes.numel(),
-      "allGatherRes and params must contain the same number of elements.");
-
-  auto packed = at::empty(
-      {static_cast<int64_t>(paramPtrs.size() + shardDimCumSums.size())},
-      at::TensorOptions().dtype(at::kLong).pinned_memory(true));
-  memcpy(
-      packed.data_ptr(), paramPtrs.data(), sizeof(int64_t) * paramPtrs.size());
-  memcpy(
-      packed.data_ptr<int64_t>() + paramPtrs.size(),
-      shardDimCumSums.data(),
-      sizeof(int64_t) * shardDimCumSums.size());
-  packed = packed.to(device, /*non_blocking=*/true);
-  auto paramPtrsDev = packed.data_ptr();
-  auto shardDimCumSumsDev = packed.data_ptr<int64_t>() + paramPtrs.size();
-
-  dim3 blocks(0, 1, 1);
-  dim3 threads(0, 1, 1);
-
-  auto numThreadsRequired = allGatherRes.numel() / numelPerThread;
-  if (numThreadsRequired <= MAX_NUM_THREADS) {
-    blocks.x = 1;
-    threads.x = divUp(numThreadsRequired, WARP_SIZE) * WARP_SIZE;
-  } else {
-    blocks.x = divUp(numThreadsRequired, MAX_NUM_THREADS);
-    threads.x = MAX_NUM_THREADS;
-  }
-
-  TORCH_WARN_ONCE("blocks: ", blocks.x, ", threads: ", threads.x);
-
-  AT_DISPATCH_ALL_TYPES_AND(
-      at::ScalarType::BFloat16, scalarType, "fsdp_all_gather_copy_out", [&] {
-        fsdpAllGatherCopyOutKernel<scalar_t>
-            <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
-                reinterpret_cast<scalar_t**>(paramPtrsDev),
-                allGatherRes.data_ptr<scalar_t>(),
-                allGatherRes.numel(),
-                shardDimCumSumsDev,
-                params.size(),
-                worldSize,
-                shardDimCumSums.back());
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
-      });
-}
-
-///////////////////////////////////////////////////////////////////////////////
-// No alignment requirements on shards.
-// Requires all_gather input to be prepared with fsdp_all_gather_copy_in
-// which aligns shards at 128-bit. There will be gaps in-between shards.
-///////////////////////////////////////////////////////////////////////////////
-template <typename T>
-static __global__ void fsdpAllGatherCopyOutKernel_no_align(
-    T** paramPtrs,
-    T* allGatherResPtr,
-    int64_t numel,
-    int64_t* alignedDimCumSums,
-    int64_t* unalignedDims,
-    int64_t numParams,
-    int64_t worldSize,
-    int64_t shardDimSum) {
-  const auto numelPerThread = BYTES_PER_THREAD / sizeof(T);
-  const auto tid = blockIdx.x * blockDim.x + threadIdx.x;
-  const auto srcOff = tid * numelPerThread;
-  const auto rankOff = srcOff % shardDimSum; // Offset within the rank
-  const auto rank = srcOff / shardDimSum;
-
-  if (srcOff >= numel) {
-    return;
-  }
-
-  __shared__ int64_t dimCumSums[MAX_NUM_PARAMS + 1];
-  __shared__ int64_t unalignedDims_[MAX_NUM_PARAMS];
-  if (threadIdx.x < numParams + 1) {
-    dimCumSums[threadIdx.x] = alignedDimCumSums[threadIdx.x];
-    unalignedDims_[threadIdx.x] = unalignedDims[threadIdx.x];
-  }
-  __syncthreads();
-
-  int paramIdx = 0;
-  for (size_t i = 1; i < numParams; ++i) {
-    // Threads in a warp are likely to take the same branch.
-    // So branching is beneficial here especially with large numParams.
-    if (rankOff < dimCumSums[i]) {
-      break;
-    }
-    paramIdx += 1;
-  }
-
-  const auto alignedShardBegin = dimCumSums[paramIdx];
-  const auto unalignedShardLen = unalignedDims_[paramIdx];
-  const auto paramOff = unalignedShardLen * rank + rankOff - alignedShardBegin;
-  const auto paramShardEnd = unalignedShardLen * (rank + 1);
-
-  for (size_t i = 0; i < numelPerThread; ++i) {
-    if (paramOff + i >= paramShardEnd) {
-      break;
-    }
-    paramPtrs[paramIdx][paramOff + i] = allGatherResPtr[srcOff + i];
-  }
-}
-
-void fsdpAllGatherCopyOut_no_align(
-    std::vector<at::Tensor> params,
-    at::Tensor allGatherRes,
-    int64_t worldSize) {
-  const auto numelPerThread = BYTES_PER_THREAD / allGatherRes.element_size();
-  const auto device = allGatherRes.device();
-  const auto scalarType = allGatherRes.scalar_type();
-
-  TORCH_CHECK(allGatherRes.is_cuda());
-  TORCH_CHECK(allGatherRes.is_non_overlapping_and_dense());
-  TORCH_CHECK(allGatherRes.numel() % worldSize == 0);
-  TORCH_CHECK(params.size() <= MAX_NUM_PARAMS);
-
-  std::vector<void*> paramPtrs;
-  std::vector<int64_t> alignedDimCumSums{0};
-  std::vector<int64_t> unalignedDims;
-  for (size_t i = 0; i < params.size(); ++i) {
-    const auto& param = params[i];
-    TORCH_CHECK(param.is_non_overlapping_and_dense());
-    TORCH_CHECK(param.device() == device);
-    TORCH_CHECK(param.scalar_type() == scalarType);
-    // All params are expected to be aligned at worldSize.
-    // But not neccessarily worldSize * numelPerThread.
-    TORCH_CHECK(param.numel() % worldSize == 0);
-    paramPtrs.push_back(param.data_ptr());
-    const auto alignedDim =
-        divUp(param.numel(), worldSize * numelPerThread) * numelPerThread;
-    alignedDimCumSums.push_back(alignedDimCumSums[i] + alignedDim);
-    unalignedDims.push_back(param.numel() / worldSize);
-  }
-
-  TORCH_CHECK(
-      alignedDimCumSums.back() * worldSize == allGatherRes.numel(),
-      "allGatherRes and params must contain the same number of elements.");
-
-  auto packed = at::empty(
-      {static_cast<int64_t>(
-          paramPtrs.size() + alignedDimCumSums.size() + unalignedDims.size())},
-      at::TensorOptions().dtype(at::kLong).pinned_memory(true));
-  memcpy(
-      packed.data_ptr(), paramPtrs.data(), sizeof(int64_t) * paramPtrs.size());
-  memcpy(
-      packed.data_ptr<int64_t>() + paramPtrs.size(),
-      alignedDimCumSums.data(),
-      sizeof(int64_t) * alignedDimCumSums.size());
-  memcpy(
-      packed.data_ptr<int64_t>() + paramPtrs.size() + alignedDimCumSums.size(),
-      unalignedDims.data(),
-      sizeof(int64_t) * unalignedDims.size());
-  packed = packed.to(device, /*non_blocking=*/true);
-  auto paramPtrsDev = packed.data_ptr();
-  auto shardDimCumSumsDev = packed.data_ptr<int64_t>() + paramPtrs.size();
-  auto unalignedDimsDev =
-      packed.data_ptr<int64_t>() + paramPtrs.size() + alignedDimCumSums.size();
-
-  dim3 blocks(0, 1, 1);
-  dim3 threads(0, 1, 1);
-
-  auto numThreadsRequired = allGatherRes.numel() / numelPerThread;
-  if (numThreadsRequired <= MAX_NUM_THREADS) {
-    blocks.x = 1;
-    threads.x = divUp(numThreadsRequired, WARP_SIZE) * WARP_SIZE;
-  } else {
-    blocks.x = divUp(numThreadsRequired, MAX_NUM_THREADS);
-    threads.x = MAX_NUM_THREADS;
-  }
-
-  TORCH_WARN_ONCE("blocks: ", blocks.x, ", threads: ", threads.x);
-
-  AT_DISPATCH_ALL_TYPES_AND(
-      at::ScalarType::BFloat16, scalarType, "fsdp_all_gather_copy_out", [&] {
-        fsdpAllGatherCopyOutKernel_no_align<scalar_t>
-            <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
-                reinterpret_cast<scalar_t**>(paramPtrsDev),
-                allGatherRes.data_ptr<scalar_t>(),
-                allGatherRes.numel(),
-                shardDimCumSumsDev,
-                unalignedDimsDev,
-                params.size(),
-                worldSize,
-                alignedDimCumSums.back());
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
-      });
-}
-
-///////////////////////////////////////////////////////////////////////////////
-// No requirement on alignment at any stage.
-///////////////////////////////////////////////////////////////////////////////
-__device__ inline bool isAligned(const void* ptr, size_t alignment) {
+static __device__ inline bool isAligned(const void* ptr, size_t alignment) {
   uintptr_t addr = reinterpret_cast<uintptr_t>(ptr);
   return addr % alignment == 0;
 }
 
 template <typename T>
-static __global__ void fsdpAllGatherCopyOutKernel_no_align_2(
+static __global__ void fsdpAllGatherCopyOutKernel(
     T** paramPtrs,
     T* allGatherResPtr,
     int64_t numel,
+    int64_t* blockOffsetToParamIdx,
+    int64_t* blockCumSums,
     int64_t* shardDimCumSums,
     int64_t numParams,
-    int64_t worldSize,
     int64_t shardDimSum,
-    int64_t groupSize) {
-  const auto tid = blockIdx.x * blockDim.x + threadIdx.x;
-  const auto warpId = tid / groupSize;
-  if (warpId >= numParams * worldSize) {
-    return;
-  }
-  // These values are the same across the group which is warp-aligned,
-  // so we can be
-  const auto memberId = tid % groupSize;
-  const auto rank = warpId / numParams;
-  const auto paramIdx = warpId % numParams;
-  const auto shardBegin = shardDimCumSums[paramIdx];
-  const auto shardEnd = shardDimCumSums[paramIdx + 1];
-  const auto shardLen = shardEnd - shardBegin;
-  const auto srcOff = rank * shardDimSum + shardBegin;
-  const auto dstOff = rank * shardLen;
-  const auto srcPtr = allGatherResPtr + srcOff;
-  auto dstPtr = &paramPtrs[paramIdx][dstOff];
+    int64_t blockDimSum,
+    int64_t ranksPerBlock,
+    int64_t worldSize) {
+  constexpr int64_t numelPerThread = BYTES_PER_THREAD / sizeof(T);
 
-  using Holder128 = uint4;
-  using Holder64 = uint2;
+  const int64_t blockOffset = blockIdx.x % blockDimSum;
+  const int64_t paramIdx = blockOffsetToParamIdx[blockOffset];
 
-#define TRY_VECTORIZE(alignment)                                          \
-  do {                                                                    \
-    /* Skip vectorization attempt */                                      \
-    if (sizeof(T) > alignment) {                                          \
-      break;                                                              \
-    }                                                                     \
-    constexpr size_t numelPerThread = alignment / 8 / sizeof(T);          \
-    const size_t stride = groupSize * numelPerThread;                     \
-    const size_t begin = memberId * numelPerThread;                       \
-    /* Check if vectorized store is possible */                           \
-    if (isAligned(dstPtr, alignment) && shardLen % numelPerThread == 0) { \
-      for (size_t i = begin; i < shardLen; i += stride) {                 \
-        Holder##alignment val;                                            \
-        /* Check if vectorized load is possible */                        \
-        if (isAligned(srcPtr, alignment)) {                               \
-          streamLoad##alignment(val, srcPtr + i);                         \
-        } else {                                                          \
-          for (size_t j = 0; j < numelPerThread; ++j) {                   \
-            reinterpret_cast<T*>(&val)[j] = srcPtr[i + j];                \
-          }                                                               \
-        }                                                                 \
-        streamStore##alignment(&dstPtr[i], val);                          \
-      }                                                                   \
-      return;                                                             \
-    }                                                                     \
-  } while (0)
+  for (int64_t rank = blockIdx.x / blockDimSum; rank < worldSize;
+       rank += worldSize / ranksPerBlock) {
+    const int64_t shardBlockCount =
+        blockCumSums[paramIdx + 1] - blockCumSums[paramIdx];
+    const int64_t groupSize = shardBlockCount * blockDim.x;
+    const int64_t localTid =
+        (blockOffset - blockCumSums[paramIdx]) * blockDim.x + threadIdx.x;
 
-  TRY_VECTORIZE(128);
-  TRY_VECTORIZE(64);
+    const int64_t shardBegin = shardDimCumSums[paramIdx];
+    const int64_t shardEnd = shardDimCumSums[paramIdx + 1];
+    const int64_t shardLen = shardEnd - shardBegin;
+    const int64_t srcOff = rank * shardDimSum + shardBegin;
+    const int64_t dstOff = rank * shardLen;
 
-  for (size_t i = memberId; i < shardLen; i += groupSize) {
-    paramPtrs[paramIdx][dstOff + i] = allGatherResPtr[srcOff + i];
+    const T* srcPtr = allGatherResPtr + srcOff;
+    T* dstPtr = &paramPtrs[paramIdx][dstOff];
+
+    const int64_t alignOff =
+        divUp(dstOff, numelPerThread) * numelPerThread - dstOff;
+    const int64_t begin = alignOff + localTid * numelPerThread;
+    const int64_t end =
+        alignOff + (shardLen - alignOff) / numelPerThread * numelPerThread;
+    const int64_t stride = groupSize * numelPerThread;
+
+    for (size_t i = begin; i < end; i += stride) {
+      uint4 val;
+      if (isAligned(srcPtr + i, 128)) {
+        streamLoad128(val, srcPtr + i);
+      } else {
+        for (size_t j = 0; j < numelPerThread; ++j) {
+          reinterpret_cast<T*>(&val)[j] = srcPtr[i + j];
+        }
+      }
+      streamStore128(&dstPtr[i], val);
+    }
+    if (localTid < alignOff && localTid < shardLen) {
+      dstPtr[localTid] = srcPtr[localTid];
+    }
+    if (end + localTid < shardLen) {
+      dstPtr[end + localTid] = srcPtr[end + localTid];
+    }
   }
 }
 
-void fsdpAllGatherCopyOut_no_align_2(
+std::pair<at::Tensor, std::vector<int64_t*>> pack(
+    std::vector<std::vector<int64_t>> vecs) {
+  int64_t numel = 0;
+  for (const auto& vec : vecs) {
+    numel += vec.size();
+  }
+
+  auto packed = at::empty(
+      {numel}, at::TensorOptions().dtype(at::kLong).pinned_memory(true));
+  size_t offset = 0;
+  for (const auto& vec : vecs) {
+    memcpy(
+        packed.data_ptr<int64_t>() + offset,
+        vec.data(),
+        sizeof(int64_t) * vec.size());
+    offset += vec.size();
+  }
+  packed = packed.cuda();
+
+  std::vector<int64_t*> ptrs;
+  offset = 0;
+  for (const auto& vec : vecs) {
+    ptrs.push_back(packed.data_ptr<int64_t>() + offset);
+    offset += vec.size();
+  }
+  return std::make_pair(packed, ptrs);
+}
+
+void fsdpAllGatherCopyOut(
     std::vector<at::Tensor> params,
     at::Tensor allGatherRes,
     int64_t worldSize,
-    int64_t warpsPerShard) {
+    int64_t maxBlocksPerShard) {
   const auto device = allGatherRes.device();
   const auto scalarType = allGatherRes.scalar_type();
 
-  TORCH_CHECK(warpsPerShard >= 1);
   TORCH_CHECK(allGatherRes.is_cuda());
   TORCH_CHECK(allGatherRes.is_non_overlapping_and_dense());
   TORCH_CHECK(allGatherRes.numel() % worldSize == 0);
-  TORCH_CHECK(params.size() <= MAX_NUM_PARAMS);
 
-  std::vector<void*> paramPtrs;
+  std::vector<int64_t> paramPtrs;
   std::vector<int64_t> dimCumSums{0};
   for (size_t i = 0; i < params.size(); ++i) {
     const auto& param = params[i];
@@ -409,7 +154,7 @@ void fsdpAllGatherCopyOut_no_align_2(
     // All params are expected to be aligned at worldSize.
     // But not neccessarily worldSize * numelPerThread.
     TORCH_CHECK(param.numel() % worldSize == 0);
-    paramPtrs.push_back(param.data_ptr());
+    paramPtrs.push_back(reinterpret_cast<int64_t>(param.data_ptr()));
     dimCumSums.push_back(dimCumSums[i] + param.numel() / worldSize);
   }
 
@@ -417,48 +162,46 @@ void fsdpAllGatherCopyOut_no_align_2(
       dimCumSums.back() * worldSize == allGatherRes.numel(),
       "allGatherRes and params must contain the same number of elements.");
 
-  auto packed = at::empty(
-      {static_cast<int64_t>(paramPtrs.size() + dimCumSums.size())},
-      at::TensorOptions().dtype(at::kLong).pinned_memory(true));
-  memcpy(
-      packed.data_ptr(), paramPtrs.data(), sizeof(int64_t) * paramPtrs.size());
-  memcpy(
-      packed.data_ptr<int64_t>() + paramPtrs.size(),
-      dimCumSums.data(),
-      sizeof(int64_t) * dimCumSums.size());
-  packed = packed.to(device, /*non_blocking=*/true);
-  auto paramPtrsDev = packed.data_ptr();
-  auto shardDimCumSumsDev = packed.data_ptr<int64_t>() + paramPtrs.size();
+  const int64_t numelPerThread = BYTES_PER_THREAD / params[0].element_size();
+  const int64_t avgShardLen = allGatherRes.numel() / worldSize / params.size();
+  const int64_t blockSize = std::min(
+      divUp(divUp(avgShardLen, numelPerThread), WARP_SIZE) * WARP_SIZE, MAX_NUM_THREADS);
 
-  dim3 blocks(0, 1, 1);
-  dim3 threads(0, 1, 1);
-
-  // Each group is responsible for copying one shard
-  const auto groupSize = warpsPerShard * WARP_SIZE;
-  const auto numWarpsRequired = params.size() * worldSize;
-  const auto numThreadsRequired = numWarpsRequired * groupSize;
-  if (allGatherRes.numel() <= MAX_NUM_THREADS) {
-    blocks.x = 1;
-    threads.x = numThreadsRequired;
-  } else {
-    blocks.x = divUp(numThreadsRequired, MAX_NUM_THREADS);
-    threads.x = MAX_NUM_THREADS;
+  std::vector<int64_t> blockOffsetToParamIdx;
+  std::vector<int64_t> blockCumSums{0};
+  for (int64_t paramIdx = 0; paramIdx < static_cast<int64_t>(params.size());
+       ++paramIdx) {
+    const int64_t shardNumel = params[paramIdx].numel() / worldSize;
+    int64_t numBlocks = divUp(shardNumel, blockSize * numelPerThread);
+    numBlocks = std::min(numBlocks, maxBlocksPerShard);
+    blockOffsetToParamIdx.insert(
+        blockOffsetToParamIdx.end(), numBlocks, paramIdx);
+    blockCumSums.push_back(blockCumSums.back() + numBlocks);
   }
 
-  TORCH_WARN_ONCE("blocks: ", blocks.x, ", threads: ", threads.x);
+  auto packed =
+      pack({paramPtrs, blockOffsetToParamIdx, blockCumSums, dimCumSums});
+
+  const int64_t ranksPerBlock = 4;
+  const int64_t numBlocks = blockCumSums.back() * worldSize / ranksPerBlock;
+  LOG(INFO) << "avgShardLen: " << avgShardLen;
+  LOG(INFO) << "blocks: " << numBlocks << ", threads: " << blockSize;
 
   AT_DISPATCH_ALL_TYPES_AND(
       at::ScalarType::BFloat16, scalarType, "fsdp_all_gather_copy_out", [&] {
-        fsdpAllGatherCopyOutKernel_no_align_2<scalar_t>
-            <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
-                reinterpret_cast<scalar_t**>(paramPtrsDev),
+        fsdpAllGatherCopyOutKernel<scalar_t>
+            <<<numBlocks, blockSize, 0, at::cuda::getCurrentCUDAStream()>>>(
+                reinterpret_cast<scalar_t**>(packed.second[0]),
                 allGatherRes.data_ptr<scalar_t>(),
                 allGatherRes.numel(),
-                shardDimCumSumsDev,
+                /*blockOffsetToParamIdx=*/packed.second[1],
+                /*blockCumSums=*/packed.second[2],
+                /*shardDimCumSums=*/packed.second[3],
                 params.size(),
-                worldSize,
                 dimCumSums.back(),
-                groupSize);
+                blockCumSums.back(),
+                ranksPerBlock,
+                worldSize);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
       });
 }

--- a/torch/csrc/distributed/c10d/shuffle.cu
+++ b/torch/csrc/distributed/c10d/shuffle.cu
@@ -1,0 +1,163 @@
+#include <ATen/ATen.h>
+#include <ATen/Dispatch.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+
+constexpr int64_t BYTES_PER_THREAD = 16;
+constexpr int64_t MAX_NUM_FEATURES = 512;
+constexpr int64_t MAX_NUM_THREADS = 1024;
+constexpr int64_t WARP_SIZE = 32;
+
+template <typename T>
+__device__ inline void streamLoad128(uint4& val, const T* addr) {
+#if defined(USE_ROCM) || (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800))
+  CUDA_KERNEL_ASSERT(false);
+#else
+  unsigned long long int low, high;
+  asm("ld.global.nc.v2.u64 {%0, %1}, [%2];"
+      : "=l"(low), "=l"(high)
+      : "l"(addr));
+  reinterpret_cast<unsigned long long int*>(&val)[0] = low;
+  reinterpret_cast<unsigned long long int*>(&val)[1] = high;
+#endif
+}
+
+template <typename T>
+__device__ inline void streamStore128(T* addr, const uint4& val) {
+#if defined(USE_ROCM) || (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800))
+  CUDA_KERNEL_ASSERT(false);
+#else
+  unsigned long long int low, high;
+  low = reinterpret_cast<const unsigned long long int*>(&val)[0];
+  high = reinterpret_cast<const unsigned long long int*>(&val)[1];
+  asm("st.global.cs.v2.u64 [%0], {%1, %2};" : : "l"(addr), "l"(low), "l"(high));
+#endif
+}
+
+static __global__ void fsdpCopyOutKernel(
+    at::BFloat16** outputPtrs,
+    at::BFloat16* inputPtr,
+    int64_t numel,
+    int64_t* shardDimCumSums,
+    int64_t numParams,
+    int64_t worldSize,
+    int64_t shardDimSum) {
+  // TODO: support all types
+  const auto numelPerThread = BYTES_PER_THREAD / 2;
+  auto tid = blockIdx.x * blockDim.x + threadIdx.x;
+  auto srcOff = tid * numelPerThread;
+  // Offset within the rank
+  auto rankOff = srcOff % shardDimSum;
+  auto rank = srcOff / shardDimSum;
+
+  __shared__ int64_t dimCumSums[MAX_NUM_FEATURES + 1];
+  if (threadIdx.x < numParams + 1) {
+    dimCumSums[threadIdx.x] = shardDimCumSums[threadIdx.x];
+  }
+  __syncthreads();
+
+  int paramIdx = 0;
+  for (size_t i = 1; i < numParams; ++i) {
+    // Threads in a warp are likely to take the same branch.
+    // So branching is beneficial here especially with large numParams.
+    if (rankOff < dimCumSums[i]) {
+      break;
+    }
+    paramIdx += 1;
+  }
+  auto shardBegin = dimCumSums[paramIdx];
+  auto shardEnd = dimCumSums[paramIdx + 1];
+  auto shardLen = shardEnd - shardBegin;
+  auto paramOff = shardLen * rank + rankOff - shardBegin;
+
+  if (srcOff < numel) {
+    uint4 val;
+    streamLoad128(val, inputPtr + srcOff);
+    streamStore128(&outputPtrs[paramIdx][paramOff], val);
+  }
+}
+
+static inline std::vector<int64_t> makeCumSums(
+    std::vector<int64_t> seq,
+    int worldSize) {
+  std::vector<int64_t> cumSums = {0};
+  int64_t acc = 0;
+  for (const auto& n : seq) {
+    acc += n;
+    cumSums.push_back(acc);
+  }
+  return cumSums;
+}
+
+static inline int64_t divUp(int64_t a, int64_t b) {
+  return (a + b - 1) / b;
+}
+
+template <typename T>
+at::Tensor toTensor(const std::vector<T>& vec) {
+  static_assert(sizeof(T) == sizeof(int64_t));
+  auto tensor = at::empty({static_cast<int64_t>(vec.size())}, at::kLong);
+  std::memcpy(tensor.data_ptr(), vec.data(), sizeof(T) * vec.size());
+  return tensor;
+}
+
+void fsdpCopyOut(
+    std::vector<at::Tensor> outputs,
+    at::Tensor input,
+    int64_t worldSize) {
+  const auto numelPerThread = BYTES_PER_THREAD / input.element_size();
+
+  TORCH_CHECK(input.is_cuda());
+  TORCH_CHECK(input.is_non_overlapping_and_dense());
+
+  int64_t outputNumel = 0;
+  std::vector<void*> outputPtrs;
+  std::vector<int64_t> shardDims;
+  for (auto& output : outputs) {
+    TORCH_CHECK(output.is_cuda());
+    TORCH_CHECK(output.is_non_overlapping_and_dense());
+    TORCH_CHECK(output.device() == input.device());
+    TORCH_CHECK(
+        output.numel() % (worldSize * numelPerThread) == 0,
+        "Shard must be 128-bit aligned");
+    outputNumel += output.numel();
+    outputPtrs.push_back(output.data_ptr());
+    shardDims.push_back(output.numel() / worldSize);
+  }
+
+  TORCH_CHECK(
+      outputNumel == input.numel(),
+      "Input and output must contain the same number of elements.");
+  TORCH_CHECK(input.numel() % worldSize == 0);
+  TORCH_CHECK(outputs.size() <= MAX_NUM_FEATURES);
+
+  const auto shardDimSum = std::accumulate(shardDims.begin(), shardDims.end(), 0);
+
+  // Instead of using cudaMalloc, put these in GPU tensors and leverage the
+  // caching allocator to manage their lifetime.
+  auto outputPtrsTensor = toTensor(outputPtrs).cuda();
+  auto shardDimCumSums = toTensor(makeCumSums(shardDims, worldSize)).cuda();
+
+  dim3 blocks(0, 1, 1);
+  dim3 threads(0, 1, 1);
+
+  auto numThreadsRequired = input.numel() / numelPerThread;
+  if (numThreadsRequired <= MAX_NUM_THREADS) {
+    blocks.x = 1;
+    threads.x = divUp(numThreadsRequired, WARP_SIZE) * WARP_SIZE;
+  } else {
+    blocks.x = divUp(numThreadsRequired, MAX_NUM_THREADS);
+    threads.x = MAX_NUM_THREADS;
+  }
+
+  TORCH_WARN_ONCE("blocks: ", blocks.x, ", threads: ", threads.x);
+
+  fsdpCopyOutKernel<<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+      reinterpret_cast<at::BFloat16**>(outputPtrsTensor.data_ptr()),
+      input.data_ptr<at::BFloat16>(),
+      input.numel(),
+      shardDimCumSums.data_ptr<int64_t>(),
+      outputs.size(),
+      worldSize,
+      shardDimSum);
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #115515

~Benchmark script: P901599447~
~\~500GB/s throughput for fsdp copy_out, straight from all_gather output to individual parameters, considering all overhead.~

~The approach requires padding individual parameters to align with 128 bits. Storage-wise, this comes at no extra cost because the minimum allocation size of CUDACachingAllocator is 512 bytes. Transportation-wise, the upper-bound increase in send size for bf16 is NUM_PARAMS * 7 elements. To put this in perspective, consider the benchmark script that test against a 0.15GB all_gather output; in this case, each device would only need to send an additional 302 bytes.~

No alignment requirement anymore. Can achieve 650-700GB/s on the tested sizes.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225