### PR TITLE
Add bfloat16 support to torch.sparse.addmm for CPU

### DIFF
--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -1308,7 +1308,7 @@ static Tensor& s_addmm_out_sparse_dense_cpu(
   Tensor indices = sparse_._indices();
   Tensor values      = sparse_._values();
 
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX(
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(kBFloat16,
       values.scalar_type(), "addmm_sparse_dense", [&] {
         s_addmm_out_sparse_dense_worker<scalar_t>(nnz, dim_i, dim_j, dim_k, r, beta, t, alpha, indices, values, dense);
       }


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/73145.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #115536
* __->__ #115535



cc @alexsamardzic @nikitaved @cpuhrsch @amjames @bhosmer @jcaip