### PR TITLE
[Inductor][AOTI] Fix item() + unsqeeze

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -542,7 +542,7 @@ def fx_codegen_and_compile(
                     if hasattr(out, "layout"):
                         output_strides.append(
                             tuple(
-                                V.graph.sizevars.size_hint(s) for s in out.layout.stride
+                                V.graph.sizevars.size_hint(s, fallback=2) for s in out.layout.stride
                             )
                         )
                     else:

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -108,7 +108,7 @@ def functional_assert_async_msg_decomp(tensor, msg):
 
 @register_decomposition([aten.sym_constrain_range_for_size.default])
 def sym_constrain_range_for_size(symbol, *, min=None, max=None):
-    return
+    return NotImplemented
 
 
 @register_decomposition([aten.clamp])

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -5248,6 +5248,13 @@ def sym_constrain_range(a, min, max):
     return a
 
 
+@register_lowering(aten.sym_constrain_range_for_size)
+def sym_constrain_range_for_size(a, min, max):
+    # AOTInductor not under tracing context, so TracingContext is not used.
+    assert a in V.graph.fake_mode.shape_env.var_to_range
+    return a
+
+
 @register_lowering(aten.sym_size.int)
 def sym_size(a, dim):
     val = V.graph.current_node.meta["val"]


### PR DESCRIPTION
Fixes #113002

This PR https://github.com/pytorch/pytorch/pull/115175 fixes the problem of item() codegen under AOTI, Thus I just add the tests under AOTI.

Test:
```bash
python test_torchinductor_dynamic_shapes.py -k test_item_unsqueeze_nobreak 
python test_torchinductor_dynamic_shapes.py -k test_mask_mul_nobreak

python test_aot_inductor.py -k test_item_unsqueeze_with_constraints_non_abi_compatible_cpu
python test_aot_inductor.py -k test_mask_mul_with_constraints_non_abi_compatible_cpu
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov