### PR TITLE
[MPS] Fix `sum` and `prod` for complex types

### DIFF
--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -220,6 +220,7 @@ static void reduction_out_mps(const Tensor& input_t,
            (dtype.value() == kLong && macOS13_3_plus))) {
         inputCastType = getMPSDataType(dtype.value());
       } else if (inputScalarType != kInt && inputScalarType != kHalf && inputScalarType != kFloat &&
+                 inputScalarType != kComplexFloat && inputScalarType != kComplexHalf &&
                  (inputScalarType != kLong || !macOS13_3_plus)) {
         inputCastType = getMPSDataType(kFloat);
       } else if (!is_macos_13_or_newer() && inputScalarType == kHalf) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #115514
* __->__ #115554
* #115513
* #115512

By not force-casting dtype to float

Test plan: `python -c "import torch;print(torch.linspace(-3.0, 3.0, 50, dtype=torch.cfloat, device='mps').sqrt().sin().sum())"`

Before:
```
tensor(21.1778+0.j, device='mps:0')
```
After
```
tensor(21.1778+39.1377j, device='mps:0')
```