### PR TITLE
inductor: dont specialize dynamic shapes in the noop removal pass even if we have hints

### DIFF
--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -501,13 +501,13 @@ def same_meta(node1: torch.fx.Node, node2: torch.fx.Node):
     return (
         val1 is not None
         and val2 is not None
-        and definitely_true(sym_eq(val1.size(), val2.size()))
+        and definitely_true(sym_eq(val1.size(), val2.size()), never_guard=True)
         and val1.layout == val2.layout
         and val1.dtype == val2.dtype
         and val1.device == val2.device
         and (
             val1.layout != torch.strided
-            or definitely_true(sym_eq(val1.stride(), val2.stride()))
+            or definitely_true(sym_eq(val1.stride(), val2.stride()), never_guard=True)
         )
     )
 


### PR DESCRIPTION
Need to add a test before landing.

This issue came from @bertmaher - when running export on llama 2, we wanted to explicitly mark the sequence length as dynamic:
```
    x = torch.randint(0, config.vocab_size, (1, config.max_seq_len // 2))
    constraints = [
        torch._export.dynamic_dim(x, 1),
        torch._export.dynamic_dim(x, 1) <= config.max_seq_len,
        torch._export.dynamic_dim(x, 1) >= 1,
    ]
    so_path = torch._export.aot_compile(
        model,
        (x,),
        constraints=constraints,
        options={"aot_inductor.output_path": args.filepath},
    )
```

However - when printing the dynamic shapes logs, we get:
```
 [INFO] eval Ne(s0, 256) [guard added] (_inductor/fx_passes/post_grad.py:504 in same_meta)
```

This comes from inductor's no-op removal pass, which tried to remove a potential no-op in the graph, that is only sound to remove for certain shapes. From some discussion with dynamic shapes folks, it seems like it would be **wrong** to implicitly specialize here, since export explicitly asked for a graph with a dynamic sequence length, and specializing will require us to guard because the resulting graph (where we removed the nop) is incorrect for other shapes.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #115555
* #115548



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames