### PR TITLE
[usdt][torch] Sample dispatch operator integration

### DIFF
--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -308,6 +308,12 @@ private:
   static void runRecordFunction(at::RecordFunction& guard, at::RecordFunction::schema_ref_t schema_ref, DispatchKey dispatchKey);
   static void runRecordFunction(at::RecordFunction& guard, at::RecordFunction::schema_ref_t schema_ref, DispatchKey dispatchKey, c10::ArrayRef<const c10::IValue> args);
 
+  #ifdef FBCODE_CAFFE2
+  static bool profilingOperatorEvents();
+  static void fireOpStartUSDT(at::RecordFunction::schema_ref_t schema_ref);
+  static void fireOpEndUSDT(at::RecordFunction::schema_ref_t schema_ref);
+  #endif // FBCODE_CAFFE2
+
   OperatorHandle findOrRegisterSchema_(FunctionSchema&& schema);
   OperatorHandle findOrRegisterName_(const OperatorName& op_name);
 
@@ -670,7 +676,23 @@ C10_ALWAYS_INLINE_UNLESS_MOBILE Return Dispatcher::call(const TypedOperatorHandl
     return callWithDispatchKeySlowPath<Return, Args...>(op, *step_callbacks, dispatchKeySet, kernel, std::forward<Args>(args)...);
   }
 #endif  // PYTORCH_DISABLE_PER_OP_PROFILING
-  return kernel.template call<Return, Args...>(op, dispatchKeySet, std::forward<Args>(args)...);
+
+#ifdef FBCODE_CAFFE2
+  if(profilingOperatorEvents()) {
+    struct FireOpRAII {
+       FireOpRAII(at::RecordFunction::schema_ref_t schema_ref) : schema_ref_(schema_ref) {
+           fireOpStartUSDT(schema_ref);
+        }
+       ~FireOpRAII() { fireOpEndUSDT(schema_ref_); }
+       at::RecordFunction::schema_ref_t schema_ref_;
+    } event(op.schema());
+    return kernel.template call<Return, Args...>(op, dispatchKeySet, std::forward<Args>(args)...);
+  } else {
+    return kernel.template call<Return, Args...>(op, dispatchKeySet, std::forward<Args>(args)...);
+  }
+#else
+    return kernel.template call<Return, Args...>(op, dispatchKeySet, std::forward<Args>(args)...);
+#endif // FBCODE_CAFFE2
 }
 
 // See [Note: Argument forwarding in the dispatcher] for why Args doesn't use &&


### PR DESCRIPTION
Summary:
By default the instruction at the USDT is nop, when the tracepoint is attached (e.g. through bpftrace) the code inside the semaphore check is executed. Thus there should be no performance impact as long as the USDT is not attached from the tracepoint execution code itself, however the semaphore check itself `TORCH_SDT_IS_ENABLED` will incur the cost of a `read_global_volatile` operation.

https://github.com/dtrace4linux/linux/blob/master/doc/usdt.html for more info

Test Plan:
```
buck2  build  mode/opt caffe2/torch/fb/observers:strobelight_observer_runner --show-full-output
```

```
/data/users/rihams/fbsource/buck-out/v2/gen/fbcode/0bc8cf217a8cf352/caffe2/torch/fb/observers/__strobelight_observer_runner__/strobelight_observer_runner
```

```
sudo bpftrace -e 'usdt:/data/users/rihams/fbsource/buck-out/v2/gen/fbcode/6081734815403318/caffe2/torch/fb/observers/__strobelight_observer_runner__/strobelight_observer_runner:pytorch:operator_* { printf("%s --> %s\n", probe, str(arg0)); }' -v

usdt:<path>strobelight_observer_runner:pytorch:operator_start --> aten::empty_strided
usdt:<path>strobelight_observer_runner:pytorch:operator_end --> aten::empty_strided
usdt:<path>strobelight_observer_runner:pytorch:operator_end --> aten::empty_like
usdt:<path>strobelight_observer_runner:pytorch:operator_start --> aten::fill_
usdt:<path>strobelight_observer_runner:pytorch:operator_end --> aten::fill_
usdt:<path>strobelight_observer_runner:pytorch:operator_end --> aten::ones_like
usdt:<path>strobelight_observer_runner:pytorch:operator_start --> aten::mul
usdt:<path>strobelight_observer_runner:pytorch:operator_end --> aten::mul
usdt:<path>strobelight_observer_runner:pytorch:operator_start --> aten::add
usdt:<path>strobelight_observer_runner:pytorch:operator_end --> aten::add
usdt:<path>strobelight_observer_runner:pytorch:operator_start --> aten::detach
usdt:<path>strobelight_observer_runner:pytorch:operator_end --> aten::detach
usdt:<path>strobelight_observer_runner:pytorch:operator_start --> aten::randn
usdt:<path>strobelight_observer_runner:pytorch:operator_start --> aten::empty
usdt:<path>strobelight_observer_runner:pytorch:operator_end --> aten::empty
usdt:<path>strobelight_observer_runner:pytorch:operator_start --> aten::normal_
usdt:<path>strobelight_observer_runner:pytorch:operator_end --> aten::normal_
usdt:<path>strobelight_observer_runner:pytorch:operator_end --> aten::randn
usdt:<path>strobelight_observer_runner:pytorch:operator_start --> aten::to
usdt:<path>strobelight_observer_runner:pytorch:operator_start --> aten::_to_copy
usdt:<path>strobelight_observer_runner:pytorch:operator_start --> aten::empty_strided
usdt:<path>strobelight_observer_runner:pytorch:operator_end --> aten::empty_strided

```

Differential Revision: D44636587


