### PR TITLE
Fix missing dependency in torch.utils.tensorboard

### DIFF
--- a/torch/utils/tensorboard/__init__.py
+++ b/torch/utils/tensorboard/__init__.py
@@ -1,5 +1,5 @@
 import tensorboard
-from packaging.version import Version
+from torch._vendor.packaging.version import Version
 
 if not hasattr(tensorboard, "__version__") or Version(
     tensorboard.__version__

--- a/torch/utils/tensorboard/__init__.py
+++ b/torch/utils/tensorboard/__init__.py
@@ -1,12 +1,9 @@
 import tensorboard
-from packaging.version import Version
 
-if not hasattr(tensorboard, "__version__") or Version(
-    tensorboard.__version__
-) < Version("1.15"):
+
+if not hasattr(tensorboard, "__version__") or (tensorboard.__version__ < "1.15"):
     raise ImportError("TensorBoard logging requires TensorBoard version 1.15 or above")
 
-del Version
 del tensorboard
 
 from .writer import FileWriter, SummaryWriter  # noqa: F401

--- a/torch/utils/tensorboard/__init__.py
+++ b/torch/utils/tensorboard/__init__.py
@@ -1,9 +1,12 @@
 import tensorboard
+from packaging.version import Version
 
-
-if not hasattr(tensorboard, "__version__") or (tensorboard.__version__ < "1.15"):
+if not hasattr(tensorboard, "__version__") or Version(
+    tensorboard.__version__
+) < Version("1.15"):
     raise ImportError("TensorBoard logging requires TensorBoard version 1.15 or above")
 
+del Version
 del tensorboard
 
 from .writer import FileWriter, SummaryWriter  # noqa: F401


### PR DESCRIPTION
Fixes #114591 

Version package was removed in this pull request: #114108 but is still used in `torch.utils.tensorboard` causing import errors. The fix removes the import and uses a simpler check.