### PR TITLE
Align checks in `_use_cudnn_ctc_loss` with those in `_cudnn_ctc_loss`

### DIFF
--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -82,7 +82,9 @@ bool _use_cudnn_ctc_loss(
       (targets.dim() == 1) && (log_probs.scalar_type() == at::kFloat) &&
       (targets.scalar_type() == at::kInt) &&
       (log_probs.device().type() == at::kCUDA) &&
-      (targets.device().type() == at::kCPU);
+      (targets.device().type() == at::kCPU) &&
+      (targets.is_contiguous()) &&
+      (log_probs.dim() == 3);
 
   if (use_cudnn) {
     // we don't know that input_lengths and target_lengths have the same size

--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -81,7 +81,8 @@ bool _use_cudnn_ctc_loss(
   bool use_cudnn = ctx.userEnabledCuDNN() && (BLANK == 0) &&
       (targets.dim() == 1) && (log_probs.scalar_type() == at::kFloat) &&
       (targets.scalar_type() == at::kInt) &&
-      (log_probs.device().type() == at::kCUDA);
+      (log_probs.device().type() == at::kCUDA) &&
+      (targets.device().type() == at::kCPU);
 
   if (use_cudnn) {
     // we don't know that input_lengths and target_lengths have the same size


### PR DESCRIPTION
This PR is intended to fix the following problem:

When using `CTCLoss`, there is a cudnn path gated by a call to [`_use_cudnn_ctc_loss`](
https://github.com/pytorch/pytorch/blob/e91846137795e2d976b9e0ba2e1d886f34fcfb7a/aten/src/ATen/native/cudnn/LossCTC.cpp#L73-L101) which checks some conditions

https://github.com/pytorch/pytorch/blob/e91846137795e2d976b9e0ba2e1d886f34fcfb7a/aten/src/ATen/native/LossCTC.cpp#L486-L496

However, there are more checks in `_cudnn_ctc_loss`
https://github.com/pytorch/pytorch/blob/e91846137795e2d976b9e0ba2e1d886f34fcfb7a/aten/src/ATen/native/cudnn/LossCTC.cpp#L122-L130

some of which are not present in `_use_cudnn_ctc_loss` (e.g. the check that `targets` is on CPU which will cause a RuntimeError after dispatching to `_cudnn_ctc_loss`). Instead, these checks should be in `_use_cudnn_ctc_loss` so that the normal `_ctc_loss` path will be used if the checks are not met)

e.g. Before this PR

```python
>>> import torch
>>> ctcloss = torch.nn.CTCLoss()
>>> log_probs = torch.randn((50, 3, 15), device='cuda').log_softmax(2)
>>> target = torch.randint(1, 15, (30 + 25 + 20,), dtype = torch.int)
>>> input_lengths = torch.tensor((50, 50, 50), device='cuda')
>>> target_lengths = torch.tensor((30, 25, 20), device='cuda')
>>> ctcloss(log_probs, target, input_lengths, target_lengths)
tensor(4.1172, device='cuda:0')
>>> target = target.to('cuda')
>>> ctcloss(log_probs, target, input_lengths, target_lengths)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/data/users/mg1998/pytorch/torch/nn/modules/module.py", line 1511, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/data/users/mg1998/pytorch/torch/nn/modules/module.py", line 1520, in _call_impl
    return forward_call(*args, **kwargs)
  File "/data/users/mg1998/pytorch/torch/nn/modules/loss.py", line 1779, in forward
    return F.ctc_loss(log_probs, targets, input_lengths, target_lengths, self.blank, self.reduction,
  File "/data/users/mg1998/pytorch/torch/nn/functional.py", line 2660, in ctc_loss
    return torch.ctc_loss(
RuntimeError: Expected tensor to have CPU Backend, but got tensor with CUDA Backend (while checking arguments for cudnn_ctc_loss)
```

After this PR the above snippet runs without error.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #115584
* __->__ #115617

