### PR TITLE
[pytorch] add namespace for optTypeMetaToScalarType in codegen to avoid not declared when compile

### DIFF
--- a/tools/autograd/gen_trace_type.py
+++ b/tools/autograd/gen_trace_type.py
@@ -144,7 +144,7 @@ def format_trace_inputs(f: NativeFunction) -> str:
             name = "options"
             return [
                 ADD_TRACE_INPUT.substitute(
-                    name=name, input="optTypeMetaToScalarType(options.dtype_opt())"
+                    name=name, input="c10::optTypeMetaToScalarType(options.dtype_opt())"
                 ),
                 ADD_TRACE_INPUT.substitute(name=name, input="options.layout()"),
                 ADD_TRACE_INPUT.substitute(name=name, input="options.device()"),
@@ -205,7 +205,7 @@ def format_trace_inputs(f: NativeFunction) -> str:
             outplace = [
                 ADD_TRACE_INPUT.substitute(
                     name="out",
-                    input="optTypeMetaToScalarType(out.options().dtype_opt())",
+                    input="c10::optTypeMetaToScalarType(out.options().dtype_opt())",
                 ),
                 ADD_TRACE_INPUT.substitute(name="out", input="out.options().layout()"),
                 ADD_TRACE_INPUT.substitute(name="out", input="out.options().device()"),

--- a/torchgen/api/translate.py
+++ b/torchgen/api/translate.py
@@ -294,7 +294,7 @@ Check this module for more information.
         elif goal == NamedCType("dtype", OptionalCType(BaseCType(scalarTypeT))):
             try:
                 options = direct_solve(options_ctype)
-                return f"optTypeMetaToScalarType({options}.dtype_opt())"
+                return f"c10::optTypeMetaToScalarType({options}.dtype_opt())"
             except UnsatError:
                 out_tensor = direct_solve(out_tensor_ctype)
                 return f"{out_tensor}.scalar_type()"


### PR DESCRIPTION
Fixes compilation failure in some environment.
