### PR TITLE
Added `_register_any_hook`

### DIFF
--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -521,6 +521,7 @@ known_failing_tests = {
     "test_inplace_on_view_backward",  # RuntimeError: compiled_autograd does not support create_graph
     "test_lobpcg",  # AttributeError: type object 'LOBPCGAutogradFunction' has no attribute '_compiled_autograd_key'
     "test_multi_grad_hooks",  # RuntimeError: specifying inputs= with .backward() not yet implemented for compiled autograd
+    "test_any_hook",  # torch._dynamo.exc.Unsupported: 'call_function _register_any_hook.<locals>.wrapped_fn in
     "test_naughty_autograd_function_stashing_ctx",  # AttributeError: type object 'Id' has no attribute '_compiled_autograd_key'
     "test_nested_anomaly_detect_nan",  # RuntimeError: compiled_autograd does not support create_graph
     "test_nested_anomaly_printstack_cleanup",  # RuntimeError: compiled_autograd does not support create_graph


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #115629
* __->__ #115628

This PR adds a function `_register_any_hook` that registers a backward tensor hook that runs when _any_ of the passed-in tensors' gradients are computed and becomes a no-op thereafter. This is used to implement the pre-backward hook in FSDP that all-gathers parameters needed for backward computation.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler