### PR TITLE
Use specific pytorch version

### DIFF
--- a/.github/scripts/generate_pytorch_version.py
+++ b/.github/scripts/generate_pytorch_version.py
@@ -128,7 +128,7 @@ def main() -> None:
     except NoGitTagException:
         if args.channel == "test":
             print(version_obj.get_test_version())
-        else
+        else:
             print(version_obj.get_nightly_version())
 
 

--- a/.github/scripts/generate_pytorch_version.py
+++ b/.github/scripts/generate_pytorch_version.py
@@ -26,11 +26,16 @@ def get_pytorch_root() -> Path:
     )
 
 
-def get_tag() -> str:
+def get_tag(channel: str = "release") -> str:
     root = get_pytorch_root()
     try:
+        # For test channel we want to get last tag available on branch
+        exact_param = "--exact"
+        if(channel == "test"):
+            exact_param = ""
+
         dirty_tag = (
-            subprocess.check_output(["git", "describe", "--tags", "--exact"], cwd=root)
+            subprocess.check_output(["git", "describe", "--tags", exact_param], cwd=root)
             .decode("ascii")
             .strip()
         )

--- a/.github/scripts/generate_pytorch_version.py
+++ b/.github/scripts/generate_pytorch_version.py
@@ -86,6 +86,10 @@ class PytorchVersion:
         build_suffix = self.get_post_build_suffix()
         return f"{get_base_version()}.dev{date_str}{build_suffix}"
 
+    def get_test_version(self) -> str:
+        date_str = datetime.today().strftime("%Y%m%d")
+        build_suffix = self.get_post_build_suffix()
+        return f"{get_base_version()}{build_suffix}"
 
 def main() -> None:
     parser = argparse.ArgumentParser(
@@ -109,6 +113,12 @@ def main() -> None:
         help="GPU arch version, typically (10.2, 4.0), leave blank for CPU",
         default=os.environ.get("GPU_ARCH_VERSION", ""),
     )
+    parser.add_argument(
+        "--channel",
+        type=str,
+        help="Channel for the version",
+        default="release",
+    )
     args = parser.parse_args()
     version_obj = PytorchVersion(
         args.gpu_arch_type, args.gpu_arch_version, args.no_build_suffix
@@ -116,7 +126,10 @@ def main() -> None:
     try:
         print(version_obj.get_release_version())
     except NoGitTagException:
-        print(version_obj.get_nightly_version())
+        if args.channel == "test":
+            print(version_obj.get_test_version())
+        else
+            print(version_obj.get_nightly_version())
 
 
 if __name__ == "__main__":

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -92,7 +92,11 @@ jobs:
           # To get QEMU binaries in our PATH
           echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
           # Generate PyTorch version to use without suffix
-          echo "PYTORCH_VERSION=$(python3 .github/scripts/generate_pytorch_version.py --no-build-suffix)" >> "${GITHUB_ENV}"
+          if [[ ${CHANNEL} == "release" ]]; then
+            echo "PYTORCH_VERSION=$(python3 .github/scripts/generate_pytorch_version.py --no-build-suffix)" >> "${GITHUB_ENV}"
+          else
+            echo "PYTORCH_VERSION=$(python3 .github/scripts/generate_pytorch_version.py --no-build-suffix --channel "test")" >> "${GITHUB_ENV}"
+          fi
 
       - name: Setup release specific variables
         run: |

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -98,8 +98,10 @@ jobs:
         run: |
           {
             echo "INSTALL_CHANNEL=pytorch-test";
+            echo "WHL_INSTALL_PATH=whl/test/cpu/";
             if [[ ${CHANNEL} == "release" ]]; then
               echo "INSTALL_CHANNEL=pytorch";
+              echo "WHL_INSTALL_PATH=whl/cpu/";
             fi
             echo "TRITON_VERSION=$(cut -f 1 .ci/docker/triton_version.txt)+$(cut -c -10 .ci/docker/ci_commit_pins/triton.txt)";
           } >> "${GITHUB_ENV}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ FROM dev-base as conda
 ARG PYTHON_VERSION=3.8
 # Automatically set by buildx
 ARG TARGETPLATFORM
+
 # translating Docker's TARGETPLATFORM into miniconda arches
 RUN case ${TARGETPLATFORM} in \
          "linux/arm64")  MINICONDA_ARCH=aarch64  ;; \
@@ -66,15 +67,17 @@ ARG PYTHON_VERSION=3.8
 ARG CUDA_VERSION=11.7
 ARG CUDA_CHANNEL=nvidia
 ARG INSTALL_CHANNEL=pytorch-nightly
+ARG WHL_INSTALL_PATH="whl/cpu/"
 ARG PYTORCH_VERSION
 # Automatically set by buildx
 # Note conda needs to be pinned to 23.5.2 see: https://github.com/pytorch/pytorch/issues/106470
 RUN /opt/conda/bin/conda install -c "${INSTALL_CHANNEL}" -y python=${PYTHON_VERSION} conda=23.5.2
 ARG TARGETPLATFORM
 
+
 # On arm64 we can only install wheel packages.
 RUN case ${TARGETPLATFORM} in \
-         "linux/arm64")  pip install --extra-index-url https://download.pytorch.org/whl/cpu/ "torch==${PYTORCH_VERSION}" torchvision torchaudio ;; \
+         "linux/arm64")  pip install --extra-index-url "https://download.pytorch.org/${WHL_INSTALL_PATH}" "torch==${PYTORCH_VERSION}" torchvision torchaudio ;; \
          *)              /opt/conda/bin/conda install -c "${INSTALL_CHANNEL}" -c "${CUDA_CHANNEL}" -y "python=${PYTHON_VERSION}" "pytorch=${PYTORCH_VERSION}" torchvision torchaudio "pytorch-cuda=$(echo $CUDA_VERSION | cut -d'.' -f 1-2)"  ;; \
     esac && \
     /opt/conda/bin/conda clean -ya

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ ARG PYTHON_VERSION=3.8
 ARG CUDA_VERSION=11.7
 ARG CUDA_CHANNEL=nvidia
 ARG INSTALL_CHANNEL=pytorch-nightly
+ARG PYTORCH_VERSION
 # Automatically set by buildx
 # Note conda needs to be pinned to 23.5.2 see: https://github.com/pytorch/pytorch/issues/106470
 RUN /opt/conda/bin/conda install -c "${INSTALL_CHANNEL}" -y python=${PYTHON_VERSION} conda=23.5.2
@@ -73,8 +74,8 @@ ARG TARGETPLATFORM
 
 # On arm64 we can only install wheel packages.
 RUN case ${TARGETPLATFORM} in \
-         "linux/arm64")  pip install --extra-index-url https://download.pytorch.org/whl/cpu/ torch torchvision torchaudio ;; \
-         *)              /opt/conda/bin/conda install -c "${INSTALL_CHANNEL}" -c "${CUDA_CHANNEL}" -y "python=${PYTHON_VERSION}" pytorch torchvision torchaudio "pytorch-cuda=$(echo $CUDA_VERSION | cut -d'.' -f 1-2)"  ;; \
+         "linux/arm64")  pip install --extra-index-url https://download.pytorch.org/whl/cpu/ "torch==${PYTORCH_VERSION}" torchvision torchaudio ;; \
+         *)              /opt/conda/bin/conda install -c "${INSTALL_CHANNEL}" -c "${CUDA_CHANNEL}" -y "python=${PYTHON_VERSION}" "pytorch=${PYTORCH_VERSION}" torchvision torchaudio "pytorch-cuda=$(echo $CUDA_VERSION | cut -d'.' -f 1-2)"  ;; \
     esac && \
     /opt/conda/bin/conda clean -ya
 RUN /opt/conda/bin/pip install torchelastic

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -33,6 +33,7 @@ BUILD_ARGS                = --build-arg BASE_IMAGE=$(BASE_IMAGE) \
 							--build-arg CUDA_CHANNEL=$(CUDA_CHANNEL) \
 							--build-arg PYTORCH_VERSION=$(PYTORCH_VERSION) \
 							--build-arg INSTALL_CHANNEL=$(INSTALL_CHANNEL) \
+							--build-arg WHL_INSTALL_PATH=$(WHL_INSTALL_PATH) \
 							--build-arg TRITON_VERSION=$(TRITON_VERSION) \
 							--build-arg CMAKE_VARS="$(CMAKE_VARS)"
 EXTRA_DOCKER_BUILD_FLAGS ?=

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -18,6 +18,7 @@ CMAKE_VARS               ?=
 CUDA_CHANNEL              = nvidia
 # The conda channel to use to install pytorch / torchvision
 INSTALL_CHANNEL          ?= pytorch
+WHL_INSTALL_PATH         ?= "whl/cpu/"
 
 PYTHON_VERSION           ?= 3.10
 PYTORCH_VERSION          ?= $(shell git describe --tags --always)


### PR DESCRIPTION
Use pytorch version when building Docker release. This is required when building in test channel to select appropriate release.
This PR is to test docker release before actually releasing pytorch: https://github.com/pytorch/pytorch/actions/runs/7184650844/job/19566196460#step:10:1102

However I realize now, we should probably not merge it. Will post this against main instead