### PR TITLE
[llvm][oncall] Fix build for llvm-18+

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -35,7 +35,11 @@
 #include <llvm/Passes/PassBuilder.h>
 #pragma GCC diagnostic pop
 
+#if LLVM_VERSION_MAJOR >= 18
+#include <llvm/TargetParser/Host.h>
+#else
 #include <llvm/Support/Host.h>
+#endif
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Transforms/IPO/AlwaysInliner.h>
 #include <llvm/Transforms/Scalar/DCE.h>

--- a/torch/csrc/jit/tensorexpr/llvm_jit.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_jit.cpp
@@ -28,7 +28,11 @@ C10_DIAGNOSTIC_POP()
 #include <llvm/IR/Mangler.h>
 #include <llvm/Support/CFGUpdate.h>
 #include <llvm/Support/DynamicLibrary.h>
+#if LLVM_VERSION_MAJOR >= 18
+#include <llvm/TargetParser/Host.h>
+#else
 #include <llvm/Support/Host.h>
+#endif
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Target/TargetMachine.h>
 


### PR DESCRIPTION
Summary:
https://reviews.llvm.org/D137838 moved Host.h and some other files under TargetParser.
https://github.com/llvm/llvm-project/pull/74261 Removed it from Support folder.




cc @EikanWang @jgong5