### PR TITLE
[torch] Reduce the memory usage by adding flags to clearing intermediate graphs used for optimization during the ineference.

### DIFF
--- a/torch/csrc/jit/runtime/graph_executor.cpp
+++ b/torch/csrc/jit/runtime/graph_executor.cpp
@@ -53,6 +53,11 @@
 #include <utility>
 #include <vector>
 
+C10_DEFINE_bool(
+    torch_jit_execution_plan_reuse_code_graph,
+    false,
+    "Directly reuse the preprocessed graph in the CodeImpl to reduce the memory consumption. This is aggressive memory saving, and please be cautious!");
+
 namespace torch::jit {
 
 EnableProfilingGuard::EnableProfilingGuard() {

--- a/torch/csrc/jit/runtime/graph_executor.h
+++ b/torch/csrc/jit/runtime/graph_executor.h
@@ -11,6 +11,8 @@
 
 C10_DECLARE_bool(torch_jit_enable_new_executor);
 
+C10_DECLARE_bool(torch_jit_execution_plan_reuse_code_graph);
+
 namespace torch::jit {
 struct GraphExecutorState;
 struct Code;
@@ -23,7 +25,11 @@ enum ExecutorExecutionMode {
 struct ExecutionPlan {
   ExecutionPlan() = default;
   ExecutionPlan(std::shared_ptr<Graph> graph, std::string function_name)
-      : code(graph, std::move(function_name)), graph(std::move(graph)) {}
+      : code(graph, std::move(function_name)),
+        graph(
+            FLAGS_torch_jit_execution_plan_reuse_code_graph
+                ? code.graph()
+                : std::move(graph)) {}
 
   operator bool() const {
     return static_cast<bool>(graph);

--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -1165,6 +1165,10 @@ size_t Code::register_size() const {
   return pImpl->register_size_;
 }
 
+std::shared_ptr<Graph> Code::graph() const {
+  return pImpl->preprocess_.graph;
+}
+
 InterpreterState::InterpreterState(const Code& code, TaskLauncher taskLauncher)
     : pImpl(c10::make_intrusive<InterpreterStateImpl>(
           code,

--- a/torch/csrc/jit/runtime/interpreter.h
+++ b/torch/csrc/jit/runtime/interpreter.h
@@ -68,6 +68,7 @@ struct TORCH_API Code {
   const std::vector<Node*>& instructions_source() const;
   void request_bailout(size_t index);
   size_t register_size() const;
+  std::shared_ptr<Graph> graph() const;
 
  private:
   std::shared_ptr<interpreter::CodeImpl> pImpl;

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -35,6 +35,7 @@
 #include <torch/csrc/jit/passes/tensorexpr_fuser.h>
 #include <torch/csrc/jit/passes/update_differentiable_graph_requires_grad.h>
 #include <torch/csrc/jit/passes/utils/subgraph_utils.h>
+#include <chrono>
 #include <mutex>
 
 C10_DEFINE_bool(
@@ -57,6 +58,16 @@ C10_DEFINE_bool(
     false,
     "fuse on 12 dynamic compilations");
 
+C10_DEFINE_bool(
+    torch_jit_release_profiling_graph_after_optimization,
+    false,
+    "After getOptimizedPlanFor release the optimization record for reduction of memory in inference. This is aggressive memory saving, and please be cautious!");
+
+C10_DEFINE_int32(
+    torch_jit_release_profiling_graph_delay_in_seconds,
+    60,
+    "How long to wait before releasing the profiling graph after optimizaiton is done. Only used if torch_jit_release_profiling_graph_after_optimization is set to true.");
+
 constexpr size_t kDefaultNumProfiledRuns = 1;
 constexpr size_t kDefaultBailoutDepth = 20;
 
@@ -70,6 +81,15 @@ C10_DEFINE_int64(
     "Number of re-specializations");
 
 namespace torch::jit {
+
+namespace {
+int32_t getNowInSecs() {
+  auto currentTimePoint = std::chrono::system_clock::now();
+  auto durationSinceEpoch = std::chrono::duration_cast<std::chrono::seconds>(
+      currentTimePoint.time_since_epoch());
+  return static_cast<int32_t>(durationSinceEpoch.count());
+}
+} // namespace
 
 #if defined(C10_MOBILE)
 static std::atomic<bool> executor_mode{true};
@@ -631,14 +651,17 @@ const ExecutionPlan& ProfilingGraphExecutorImpl::getOptimizedPlanFor(
     runProfilingInsensitiveOptimizations(copy);
     GRAPH_DUMP("Optimized SimpleExecutor Graph: ", copy);
     optimized_plan_ = ExecutionPlan(copy, function_name_);
+    time_optimized_plan_created_ = getNowInSecs();
     return *optimized_plan_;
   }
 
+  bool profiling_record_created_in_this_call = false;
   // if a profiling graph hasn't been created yet
   if (!pr_) {
     auto copy = graph->copy();
     runProfilingInsensitiveOptimizations(copy);
     pr_ = ProfilingRecord::instrumentGraph(copy);
+    profiling_record_created_in_this_call = true;
     // `InsertProfileNodesForSpecializeAutogradZero` profiles a definition vs a
     // use and it doesn't expect any profile nodes between a graph input and its
     // consumer, `aten::_grad_sum_to_size`. This means we need to run it first,
@@ -665,6 +688,13 @@ const ExecutionPlan& ProfilingGraphExecutorImpl::getOptimizedPlanFor(
   CheckStrictFusion(copy);
   GRAPH_DUMP("Optimized Graph: ", copy);
   optimized_plan_ = ExecutionPlan(copy, function_name_);
+  time_optimized_plan_created_ = getNowInSecs();
+  // If the profiled graph was created in this call, then we can release it
+  // right.
+  if (FLAGS_torch_jit_release_profiling_graph_after_optimization &&
+      profiling_record_created_in_this_call) {
+    clearTheGraphCompilationIntermediateGraphs();
+  }
   return *optimized_plan_;
 }
 
@@ -676,6 +706,14 @@ const ExecutionPlan& ProfilingGraphExecutorImpl::getPlanFor(
   // IMPORTANT: This is a hot path of calling a torchscript function. Try not to
   // add any code above this.
   if (optimized_plan_) {
+    if (FLAGS_torch_jit_release_profiling_graph_after_optimization &&
+        !is_graph_extra_memory_released_) {
+      int32_t now = getNowInSecs();
+      if ((now - time_optimized_plan_created_) >
+          FLAGS_torch_jit_release_profiling_graph_delay_in_seconds) {
+        clearTheGraphCompilationIntermediateGraphs();
+      }
+    }
     return *optimized_plan_;
   }
   // if depth is not set, use
@@ -764,6 +802,29 @@ void ProfilingGraphExecutorImpl::replaceFallbackGraphWithFallbackFunction(
 void ProfilingGraphExecutorImpl::runFinalOptimizations(
     std::shared_ptr<Graph>& graph) {
   AddIfThenElseOp(graph);
+}
+
+void ProfilingGraphExecutorImpl::debugFlushCompilationCache() {
+  std::lock_guard<std::mutex> lock(compile_mutex);
+  pr_.reset();
+  fallback_plan_.reset();
+  profiling_plan_.reset();
+  optimized_plan_.reset();
+  // prevent memory leaks
+  fallback_functions_.clear();
+  remaining_bailout_depth_.reset();
+  // TODO - would be nice to have it initialized in subsequent use
+  fusion_strategy_ = getFusionStrategy();
+  time_optimized_plan_created_ = 0;
+  is_graph_extra_memory_released_ = false;
+}
+
+void ProfilingGraphExecutorImpl::clearTheGraphCompilationIntermediateGraphs() {
+  is_graph_extra_memory_released_ = true;
+  profiling_plan_.reset();
+  fallback_plan_.reset();
+  graph.reset();
+  pr_.reset();
 }
 
 } // namespace torch::jit


### PR DESCRIPTION
Summary: During the inference time the intermediate graphs for optimization are not used so the Executor's graph is the only graph we need to keep around these two flags

Test Plan:
the FLAGS are all off by default

baseline
```
buck run mode/opt-clang  sigrid/predictor/client/localnet:run_model -- --model_id_to_load=951679039 --model_snapshot_to_load=244 --torch_jit_do_not_store_optimized_graph=true
I1212 10:24:20.407408 401092 SigridPredictorLocalModelFactory.cpp:32] Memory usage for 951679039_244 is 182863 Kb
```
```
buck run mode/opt-clang  sigrid/predictor/client/localnet:run_model -- --model_id_to_load=951679039 --model_snapshot_to_load=244 --torch_jit_do_not_store_optimized_graph=true --torch_jit_release_profiling_graph_after_optimization=true
I1212 10:31:37.663487 464000 SigridPredictorLocalModelFactory.cpp:32] Memory usage for 951679039_244 is 186127 Kb
```
```
buck run mode/opt-clang  sigrid/predictor/client/localnet:run_model -- --model_id_to_load=951679039 --model_snapshot_to_load=244 --torch_jit_do_not_store_optimized_graph=true --torch_jit_release_profiling_graph_after_optimization=true --torch_jit_execution_plan_avoid_extra_graph_copy=true
I1212 10:29:42.848093 447218 SigridPredictorLocalModelFactory.cpp:32] Memory usage for 951679039_244 is 129451 Kb```

Differential Revision: D52081631


