### PR TITLE
[CUDA][FP8] Skip `test_dtypes` on FP8 `_scaled_mm`

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14224,7 +14224,11 @@ op_db: List[OpInfo] = [
         supports_forward_ad=False,
         supports_autograd=False,
         decorators=[skipCUDAIf(not SM90OrLater or TEST_WITH_ROCM, 'Requires CUDA SM >= 9.0')],
-        skips=()
+        skips=(
+            # Sample inputs isn't really parametrized on dtype
+            DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes',
+                device_type='cuda'),
+        )
     ),
     OpInfo(
         'nn.functional.scaled_dot_product_attention',

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14227,7 +14227,7 @@ op_db: List[OpInfo] = [
         skips=(
             # Sample inputs isn't really parametrized on dtype
             DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes',
-                device_type='cuda'),
+                         device_type='cuda'),
         )
     ),
     OpInfo(


### PR DESCRIPTION
This test isn't actually parametrized by `dtype` so it seems to surface bogus failures where "unsupported" types "work" but in reality fp8 is used every time.

CC @drisspg I'm guessing this doesn't surface in upstream CI because there are no SM9.0 runners yet?


cc @ptrblck