### PR TITLE
[CUDA] Fix V100 expected failures in `test_mm_decomp` and `test_linalg`

### DIFF
--- a/test/inductor/test_mmdecomp.py
+++ b/test/inductor/test_mmdecomp.py
@@ -5,6 +5,7 @@ import unittest
 from typing import List, Tuple, Union
 
 import torch
+from torch.testing._internal.common_cuda import SM80OrLater
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_nn import NNTestCase
 from torch.testing._internal.common_utils import (
@@ -13,7 +14,6 @@ from torch.testing._internal.common_utils import (
     run_tests,
     TEST_CUDA,
 )
-from torch.testing._internal.common_cuda import SM80OrLater
 from torch.utils._triton import has_triton
 
 
@@ -116,7 +116,9 @@ class TestDecomp(NNTestCase):
             run_comp_nocomp(torch_addmm, tadd, t1, t2, rtol=rtol, atol=atol)
 
     @unittest.skipIf(TEST_CUDA and not has_triton(), "CUDA tests require triton")
-    @parametrize("dtype", [torch.float, torch.bfloat16] if SM80OrLater else [torch.float])
+    @parametrize(
+        "dtype", [torch.float, torch.bfloat16] if SM80OrLater else [torch.float]
+    )
     @parametrize("bs", [1, 2, 4, 10])
     def test_batched_mm(self, device, dtype, bs):
         fudge = 3

--- a/test/inductor/test_mmdecomp.py
+++ b/test/inductor/test_mmdecomp.py
@@ -13,6 +13,7 @@ from torch.testing._internal.common_utils import (
     run_tests,
     TEST_CUDA,
 )
+from torch.testing._internal.common_cuda import SM80OrLater
 from torch.utils._triton import has_triton
 
 
@@ -115,7 +116,7 @@ class TestDecomp(NNTestCase):
             run_comp_nocomp(torch_addmm, tadd, t1, t2, rtol=rtol, atol=atol)
 
     @unittest.skipIf(TEST_CUDA and not has_triton(), "CUDA tests require triton")
-    @parametrize("dtype", [torch.float, torch.bfloat16])
+    @parametrize("dtype", [torch.float, torch.bfloat16] if SM80OrLater else [torch.float])
     @parametrize("bs", [1, 2, 4, 10])
     def test_batched_mm(self, device, dtype, bs):
         fudge = 3

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5710,9 +5710,10 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         # NOTE: We're just exercising terrible failures here.
         version = _get_torch_cuda_version()
         SM80OrLater = torch.cuda.is_available() and torch.cuda.get_device_capability() >= (8, 0)
+        SM70 = torch.cuda.is_available() and torch.cuda.get_device_capability() == (7, 0)
         if version >= (11, 7):
             if not use_transpose_a and use_transpose_b:
-                if SM80OrLater:
+                if SM80OrLater or (version >= (12, 3) and SM70):
                     _test(17, k, n, use_transpose_a, use_transpose_b, version > (11, 7))
                 else:
                     with self.assertRaisesRegex(RuntimeError,
@@ -5730,7 +5731,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
                     _test(17, k, n, use_transpose_a, use_transpose_b)
 
             if not use_transpose_a and not use_transpose_b:
-                if SM80OrLater:
+                if SM80OrLater or (version >= (12, 3) and SM70):
                     _test(17, k, n, use_transpose_a, use_transpose_b)
                 else:
                     with self.assertRaisesRegex(RuntimeError,


### PR DESCRIPTION
BFloat16 isn't supported on sm70 and we get an unexpected cuBLAS success in 12.3+

cc @ptrblck @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @malfet @Aidyn-A 
