### PR TITLE
[export][fix] Add back export strict argument

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -120,8 +120,6 @@ class TestExport(TestCase):
         inp = ([torch.ones(1, 3)], torch.ones(1, 3))
         self._test_export_same_as_eager(f, inp)
 
-    # TODO: torch._dynamo.exc.Unsupported: call_function UserDefinedObjectVariable(add) [TensorVariable()] {}
-    @unittest.expectedFailure
     def test_external_call_non_strict_real_tensor(self):
         class ExternalMethod:
             def add(self, x):

--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -189,6 +189,7 @@ def export(
         args,
         kwargs,
         constraints,
+        strict=strict,
         preserve_module_call_signature=preserve_module_call_signature,
     )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #115703
* #115413
* #115402
* #115399
* __->__ #115668

Summary:
\#115556 omitted strict argument, which is necessary for non-strict mode
dev.

Test Plan:
python test/export/test_export.py