### PR TITLE
[ONNX] Dump sarif diagnostics for failed onnx exports in benchmark

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1578,6 +1578,12 @@ def optimize_onnx_ctx(
                 output_csv(
                     output_error_filename, parsed_error.headers, parsed_error.row
                 )
+            nonlocal context
+            if context.onnx_model is not None:
+                e.onnx_program.save_diagnostics(
+                    f"{context.onnx_model.model_dir}/"
+                    f"{current_onnx_compiler}_{current_name}_{current_device}.sarif"
+                )
 
             # Check also the raw exception that caused export failure.
             # Skip if it is already analyzed by diagnostics.

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1578,7 +1578,6 @@ def optimize_onnx_ctx(
                 output_csv(
                     output_error_filename, parsed_error.headers, parsed_error.row
                 )
-            nonlocal context
             if context.onnx_model is not None:
                 e.onnx_program.save_diagnostics(
                     f"{context.onnx_model.model_dir}/"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #115773
* __->__ #115673
* #115670



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng