### PR TITLE
inductor hack: better nan/inf checking

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2137,7 +2137,7 @@ class TritonKernel(Kernel):
                 if before_calling_kernel and not is_read:
                     continue
                 before_or_after = 'before' if before_calling_kernel else 'after'
-                if before_or_after:
+                if before_calling_kernel:
                     if arg in ['buf100', 'buf95', 'primals_3', 'clone', 'buf4']:
                         import os
                         save_path_prefix = os.environ['inductor_nan_dump_dir']

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6965,6 +6965,19 @@ class ReduceScatterTensor(OutOfPlaceCollectiveKernel):
         return cls.create_output_nodes(packed, outputs)[0]
 
     def codegen_collective(self, wrapper, output_name, input_names):
+
+        wrapper.writeline(
+            f"if {output_name}_inputs[0].isnan().any().item():"
+        )
+        wrapper.writeline(
+            f"    assert False, 'input to reduce_scatter was NaN'"
+        )
+        wrapper.writeline(
+            f"if {output_name}_inputs[0].isnan().any().item():"
+        )
+        wrapper.writeline(
+            f"    assert False, 'input to reduce_scatter was inf'"
+        )
         wrapper.writeline(
             f"{output_name}_work = dist.reduce_scatter_tensor("
             f"{output_name}[0], {output_name}_inputs[0], "


### PR DESCRIPTION
not for landing

Although it might be useful to turn this PR into something landable that properly adds inf/nan checks to:

(1) the inputs to read-from pointers in each triton kernel (so we can tell if inputs were already nan/inf)

(2) all other ops that inductor can generate. mainly extern kernels like addmm and collectives

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #115674



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler