### PR TITLE
Revert D51971661: Multisect successfully blamed "D51959097: [export] make UnflattenedModule not inherit from GraphModule" for otest failure

### DIFF
--- a/test/export/test_unflatten.py
+++ b/test/export/test_unflatten.py
@@ -290,56 +290,6 @@ class TestUnflatten(TestCase):
         with self.assertRaisesRegex(RuntimeError, ".shape\[1\] is specialized at 3"):
             unflattened(torch.randn(6, 6))
 
-    def test_unflatten_with_inplace_compile(self):
-        class NestedChild(torch.nn.Module):
-            def forward(self, x):
-                return x / x
-
-        class Child1(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.nested = NestedChild()
-                self.register_parameter(
-                    "child1param", torch.nn.Parameter(torch.ones(2, 3))
-                )
-
-            def forward(self, x):
-                x = self.nested(x)
-                return x + self.child1param
-
-        class Child2(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.register_buffer("child2buffer", torch.ones(2, 3))
-
-            def forward(self, x):
-                return x - self.child2buffer
-
-        class MyModule(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.foo = Child1()
-                self.bar = Child2()
-                self.register_parameter(
-                    "rootparam", torch.nn.Parameter(torch.ones(2, 3))
-                )
-
-            def forward(self, x):
-                x = x * self.rootparam
-                x = self.foo(x)
-                x = self.bar(x)
-                return x
-
-        orig_eager = MyModule()
-        export_module = torch.export.export(orig_eager, (torch.rand(2, 3),), {})
-        unflattened = export_module.module(flat=False)
-
-        # in-place compilation should work. Pass fullgraph to ensure no graph breaks.
-        unflattened.foo.compile(fullgraph=True)
-
-        inputs = (torch.rand(2, 3),)
-        self.compare_outputs(orig_eager, unflattened, inputs)
-
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/_export/unflatten.py
+++ b/torch/_export/unflatten.py
@@ -44,69 +44,6 @@ def _assign_attr(
         to_module.register_buffer(field, from_obj)
 
 
-class InterpreterModule(torch.nn.Module):
-    """A module that uses torch.fx.Interpreter to execute instead of the usual
-    codegen that GraphModule uses. This provides better stack trace information
-    and makes it easier to debug execution.
-    """
-
-    def __init__(
-        self,
-        graph: torch.fx.Graph,
-        module_call_signature: Optional[ModuleCallSignature],
-    ):
-        super().__init__()
-        self.graph = graph
-        self.graph.owning_module = self
-        self.module_call_signature = module_call_signature
-
-    def forward(self, *args, **kwargs):
-        assert self.graph_module is not None, "Didn't finalize this InterpreterModule"
-        if torch._dynamo.is_compiling():
-            # Dynamo cannot trace through torch.fx.Interpreter, so fall back to
-            # GraphModule codegen in this instance.
-            return self.graph_module(*args, **kwargs)
-        else:
-            if kwargs:
-                # Handle **kwargs. FX only natively supports positional
-                # arguments (through placeholders). So in order to pass in
-                # kwargs, we must correspond the names of the placeholders with
-                # the keys in the kwarg dict.
-                arg_list = list(args)
-                kwarg_names = self.arg_names[len(arg_list) :]
-                for kwarg_name in kwarg_names:
-                    if kwarg_name in kwargs:
-                        arg_list.append(kwargs[kwarg_name])
-
-                # Assert that the kwargs passed in exactly match the positional
-                # arguments specified by the GraphModule. This should be
-                # guaranteed by the unflattening process.
-                assert len(kwarg_names) == len(kwargs)
-                assert len(arg_list) == len(self.arg_names)
-                args = tuple(arg_list)
-
-            return torch.fx.Interpreter(self, graph=self.graph).run(
-                *args, enable_io_processing=False
-            )
-
-    def finalize(self):
-        # We need to "finalize" because GraphModule populates its own state_dict
-        # based on the get_attrs observed in the graph. So we need to fully
-        # construct the graph and call _sink_params before generating this
-        # GraphModule.
-
-        # need to set `graph_module` directly on the dict to avoid it getting
-        # registered as a submodule.
-        self.__dict__["graph_module"] = torch.fx.GraphModule(self, self.graph)
-        self.graph.lint()
-
-        # Cache arg names for kwarg handling (see forward())
-        self.arg_names = []
-        for node in self.graph.nodes:
-            if node.op == "placeholder":
-                self.arg_names.append(node.target)
-
-
 class _UnflattenedModule(torch.nn.Module):
     def __init__(self, export_module: ExportedProgram):
         super().__init__()
@@ -332,9 +269,19 @@ class ModuleFrame:
         if module is not None:
             self.module = module
         else:
-            self.module = InterpreterModule(
-                torch.fx.Graph(), module_call_graph.get(self.fqn)
+            # InterpreterModule doesn't work with torch.compile:
+            # 1. in-place compile: nn.Module compile the forward function, and if we overwrite __call__,
+            # in-place compile will not be effective
+            # 2. out-of-place compile: there are a lot of graph guard failures on "self" in the
+            # InterpreterModule
+            # self.module = InterpreterModule(
+            self.module = torch.fx.GraphModule(
+                {},
+                torch.fx.Graph(),
+                self.fqn,
             )
+            self.module.meta["module_call_signature"] = module_call_graph.get(self.fqn)
+
         if self.module_id in self.seen_modules:
             self.cached_graph_module = self.seen_modules[self.module_id]
         else:
@@ -494,6 +441,11 @@ class ModuleFrame:
         assert isinstance(graph_outputs, (list, torch.fx.Node))
 
         self.graph.output(graph_outputs)
+
+        # lint to ensure correctness
+        self.graph.lint()
+        if isinstance(self.module, torch.fx.GraphModule):
+            self.module.recompile()
 
         # Rewrite outputs in parent module
         if parent_out is None:
@@ -685,8 +637,9 @@ def _sink_params(
 
             node.replace_all_uses_with(new_node, propagate_meta=True)
         graph.erase_node(node)
-    if isinstance(module, InterpreterModule):
-        module.finalize()
+    if isinstance(module, torch.fx.GraphModule):
+        module.graph.lint()
+        module.recompile()
 
 
 def _recursive_getattr(obj, attr_path):


### PR DESCRIPTION
Summary:
This diff is reverting D51971661
D51959097: [export] make UnflattenedModule not inherit from GraphModule by suo has been identified to be causing the following test failure:

Tests affected:
- [aps_models/ads/icvr/tests:export_test - test_20x_icvr_export (aps_models.ads.icvr.tests.export_test.ExportTest)](https://www.internalfb.com/intern/test/562950050675262/)

Here's the Multisect link:
https://www.internalfb.com/multisect/3747993
Here are the tasks that are relevant to this breakage:


We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Test Plan: NA

Differential Revision: D52064414




cc @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan @angelayi @suo @ydwu4