### PR TITLE
[export] Update schema version

### DIFF
--- a/torch/_export/serde/schema.py
+++ b/torch/_export/serde/schema.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional, Tuple
 
 
 # NOTE: Please update this value if any modifications are made to the schema
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 TREESPEC_VERSION = 1
 
 # TODO (zhxchen17) Move to a separate file.


### PR DESCRIPTION
Since pytorch 2.1 release we've made some BC breaking changes to the serialized schema. We should update it in time for the 2.2 release. Some of the changes include:

* https://github.com/pytorch/pytorch/pull/114371 - custom class objects / pybinded objects are no longer saved directly to the `ExportedProgram` structure. Instead, the name is serialized inside of the program, and the actual bytes are stored. in a separate location from the exported program, allowing it to be saved to a different location.
* https://github.com/pytorch/pytorch/pull/111204 - `GraphSignature` structure changed and `call_spec` is removed from the `GraphModule` schema
* https://github.com/pytorch/pytorch/pull/111407 - `loss_outout` -> `loss_output`
* https://github.com/pytorch/pytorch/pull/113075 - `example_inputs` removed from the `ExportedProgram` structure (this originally did not store anything), `dialect` added to the `ExportedProgram` structure.
* https://github.com/pytorch/pytorch/pull/113689 - tensor constants are now lifted as inputs to the graph, and their locations are stored in the `GraphSignature`
* https://github.com/pytorch/pytorch/pull/114172 - removed `equality_constraints` and added a `SymExprHint` for all symbolic expressions.