### PR TITLE
[DeviceMesh] Reuse sub_group pg if exists

### DIFF
--- a/test/distributed/_tensor/test_init.py
+++ b/test/distributed/_tensor/test_init.py
@@ -199,7 +199,7 @@ class DTensorConstructorTest(DTensorTestBase):
         # default world_size is 4
         # construct a cuda device 1d mesh, with no sub pg initialized
         sub_mesh_list = [0, 3]
-        mesh = DeviceMesh(self.device_type, sub_mesh_list, _init_process_groups=False)
+        mesh = DeviceMesh(self.device_type, sub_mesh_list)
         placements = [Shard(0)]
         size = [32, 3]
         dist_tensor = zeros(size, device_mesh=mesh, placements=placements)
@@ -235,7 +235,7 @@ class DTensorConstructorTest(DTensorTestBase):
 
         # construct a cuda device 2d mesh, with no subpg initialized
         sub_mesh_list = [[0], [3]]
-        mesh = DeviceMesh(self.device_type, sub_mesh_list, _init_process_groups=False)
+        mesh = DeviceMesh(self.device_type, sub_mesh_list)
         placements = [Shard(0), Shard(1)]
         size = [32, 3]
         dist_tensor = zeros(size, device_mesh=mesh, placements=placements)

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -1,7 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 # Owner(s): ["oncall: distributed"]
 import os
-from copy import deepcopy
 
 import torch
 import torch.distributed._functional_collectives as funcol
@@ -203,14 +202,6 @@ class DeviceMeshTest(DTensorTestBase):
                 dim_ranks[0] if self.rank in dim_ranks[0] else dim_ranks[1]
             )
             self.assertEqual(global_ranks, current_rank_expected_group_ranks)
-
-    @with_comms
-    def test_lazy_init_device_mesh(self):
-        # what is the expected behavior in this situation?
-        mesh = DeviceMesh(self.device_type, [1])
-
-        with self.assertRaisesRegex(RuntimeError, "process groups not initialized!"):
-            mesh.get_group()
 
     def test_fake_pg_device_mesh(self):
         fake_store = FakeStore()

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -1,6 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 # Owner(s): ["oncall: distributed"]
 import os
+from copy import deepcopy
 
 import torch
 import torch.distributed._functional_collectives as funcol
@@ -14,11 +15,15 @@ from torch.distributed._tensor.placement_types import _Partial, Shard
 from torch.distributed.device_mesh import _mesh_resources, DeviceMesh, init_device_mesh
 
 from torch.distributed.distributed_c10d import (
+    _get_process_group_name,
+    _world,
     get_global_rank,
+    get_process_group_ranks,
     get_world_size,
     init_process_group,
     is_initialized,
     is_nccl_available,
+    new_group,
     ProcessGroup,
 )
 from torch.testing._internal.common_utils import run_tests
@@ -61,6 +66,71 @@ class DeviceMeshTest(DTensorTestBase):
         DeviceMesh(device_type, mesh_tensor)
         self.assertTrue(is_initialized())
         self.destroy_pg()
+
+    def _get_tags_to_pg_name(self, tags_to_pg):
+        tags_to_pg_name = {}
+        for tag_name, groups in tags_to_pg.items():
+            tags_to_pg_name[tag_name] = []
+            for group in groups:
+                tags_to_pg_name[tag_name].append(_get_process_group_name(group))
+        return tags_to_pg_name
+
+    @with_comms
+    def test_reuse_process_group(self):
+        # Manually create new_group.
+        tp_group_0 = new_group([0, 1])
+        tp_group_1 = new_group([2, 3])
+        dp_group_0 = new_group([0, 2])
+        dp_group_1 = new_group([1, 3])
+
+        # Record the pg tags_to_pg_name so we can check whether init_device_mesh create new pg.
+        # We cannot do a deepcopy of ProcessGroup for comparison,
+        # since we cannot pickle 'torch._C._distributed_c10d.ProcessGroup' object.
+        # Therefore, we rely on the tags_to_pg_name for comparison to make sure
+        # before/after init_device_mesh, tags_to_pg in the current world does not change.
+        ref_tags_to_pg = _world.tags_to_pg
+        ref_tags_to_pg_name = self._get_tags_to_pg_name(ref_tags_to_pg)
+
+        mesh_shape = (2, self.world_size // 2)
+        mesh_dim_names = ("DP", "TP")
+        mesh_2d = init_device_mesh(
+            self.device_type, mesh_shape, mesh_dim_names=mesh_dim_names
+        )
+        tags_to_pg = _world.tags_to_pg
+        tags_to_pg_name = self._get_tags_to_pg_name(tags_to_pg)
+
+        # Check before/after init_device_mesh, tags_to_pg in the current world does not change.
+        self.assertEqual(ref_tags_to_pg_name, tags_to_pg_name)
+
+        # For each rank, there should be 4 tags_to_pg, including tags:
+        #   1) default tag for user PGs (which contains all the pgs on a particular rank)
+        #   2) tag for world size pg
+        #   3) tag for tp pg
+        #   4) tag for dp pg
+        self.assertEqual(len(tags_to_pg), 4)
+        # "" is the default tag for user PGs, and the default tag should only
+        # contain 3 pgs, since we re-use pgs, whenever possible. The 3 pgs are:
+        #   1) pg for the whole world
+        #   2) pg for tp_group
+        #   3) pg for dp_group
+        self.assertEqual(len(tags_to_pg[""]), 3)
+
+        default_user_pgs = tags_to_pg[""]
+        dp_dim = 0
+        tp_dim = 1
+        for idx, group in enumerate(default_user_pgs):
+            # world size pg
+            if idx == 0:
+                self.assertEqual(get_process_group_ranks(group), range(self.world_size))
+            # tp pg
+            if idx == 1:
+                # rank0 - mesh_2d._dim_group_infos is: [('ptd:3', [0, 2]), ('ptd:1', [0, 1])]
+                tp_group_ranks = mesh_2d._dim_group_infos[tp_dim][-1]
+                self.assertEqual(get_process_group_ranks(group), tp_group_ranks)
+            # dp pg
+            if idx == 2:
+                dp_group_ranks = mesh_2d._dim_group_infos[dp_dim][-1]
+                self.assertEqual(get_process_group_ranks(group), dp_group_ranks)
 
     @with_comms
     def test_get_group(self):
@@ -136,7 +206,8 @@ class DeviceMeshTest(DTensorTestBase):
 
     @with_comms
     def test_lazy_init_device_mesh(self):
-        mesh = DeviceMesh(self.device_type, [1], _init_process_groups=False)
+        # what is the expected behavior in this situation?
+        mesh = DeviceMesh(self.device_type, [1])
 
         with self.assertRaisesRegex(RuntimeError, "process groups not initialized!"):
             mesh.get_group()

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -298,7 +298,7 @@ else:
                                     f"in {subgroup_ranks}!"
                                 )
                             dim_group_infos.append(
-                                (not_none(_get_group_tag(dim_group)), subgroup_ranks)
+                                (_get_group_tag(not_none(dim_group)), subgroup_ranks)
                             )
             self._dim_group_infos = dim_group_infos
 

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -81,7 +81,6 @@ else:
                     device_mesh.device_type,
                     mesh_1d,
                     mesh_dim_names=(mesh_dim_name,),
-                    _init_process_groups=False,
                 )
                 if cur_rank in mesh_1d:
                     res_sub_mesh = sub_mesh
@@ -134,7 +133,7 @@ else:
                     f"Mesh dimension '{mesh_dim_name}' does not exist.",
                     f"Available mesh dimensions are: mesh_dim_names={device_mesh.mesh_dim_names}",
                 )
-            return device_mesh.mesh_dim_names.index(mesh_dim_name)  # type: ignore[union-attr]
+            return not_none(device_mesh.mesh_dim_names.index(mesh_dim_name))
 
     _mesh_resources: _MeshEnv = _MeshEnv()
 
@@ -197,7 +196,6 @@ else:
             mesh: Union[torch.Tensor, "ArrayLike"],
             *,
             mesh_dim_names: Optional[Tuple[str, ...]] = None,
-            _init_process_groups: bool = True,
         ) -> None:
             self.device_type = device_type
             self.mesh = (
@@ -218,8 +216,7 @@ else:
                 # already. The world pg is used for device mesh identity (rank) on each
                 # process (we need to know if the current global rank is in the mesh or not).
                 self._get_or_create_default_group()
-                if _init_process_groups:
-                    self._init_process_groups()
+                self._init_process_groups()
 
         def _get_or_create_default_group(self):
             default_initialized = is_initialized()
@@ -283,10 +280,16 @@ else:
                     # for each dim and append the groups
                     for dim_mesh in pg_ranks_by_dim:
                         subgroup_ranks = dim_mesh.tolist()
-                        # call new_group regardless of the current rank in the
-                        # pg or not, it's required that all ranks participate
-                        # in subgroup construction
-                        dim_group = new_group(ranks=subgroup_ranks)
+                        # if dim_group exists for given subgroup_ranks, we re-use it.
+                        # "" is the default tag for user PGs, and it contains all pgs for a given rank.
+                        dim_group = _find_pg_by_ranks_and_tag(
+                            tag="", ranks=subgroup_ranks
+                        )
+                        if not dim_group:
+                            # call new_group regardless of the current rank in the
+                            # pg or not, it's required that all ranks participate
+                            # in subgroup construction
+                            dim_group = new_group(ranks=subgroup_ranks)
                         # only add to dim_groups if the current rank in the subgroup
                         if self.get_rank() in subgroup_ranks:
                             if len(dim_group_infos) > dim:
@@ -295,7 +298,7 @@ else:
                                     f"in {subgroup_ranks}!"
                                 )
                             dim_group_infos.append(
-                                (_get_group_tag(dim_group), subgroup_ranks)
+                                (not_none(_get_group_tag(dim_group)), subgroup_ranks)
                             )
             self._dim_group_infos = dim_group_infos
 
@@ -384,6 +387,7 @@ else:
                 a DeviceMesh with more than 1 dimension; otherwise, returns a single
                 :class:`ProcessGroup` object.
             """
+            print(f"{self._dim_group_infos=}")
             if not hasattr(self, "_dim_group_infos"):
                 raise RuntimeError("DeviceMesh process groups not initialized!")
 
@@ -459,11 +463,11 @@ else:
             elif mesh_dim is None:
                 mesh_dim = 0
 
-            mesh_dim_group = self.get_group(mesh_dim)  # type: ignore[arg-type]
+            mesh_dim_group = not_none(self.get_group(mesh_dim))
             assert isinstance(
                 mesh_dim_group, ProcessGroup
             ), "We expect ProcessGroup before calling `get_rank`!"
-            return get_rank(mesh_dim_group)  # type: ignore[arg-type]
+            return not_none(get_rank(mesh_dim_group))
 
         def get_coordinate(self) -> Optional[List[int]]:
             """

--- a/torch/distributed/tensor/parallel/_utils.py
+++ b/torch/distributed/tensor/parallel/_utils.py
@@ -167,7 +167,7 @@ def _create_1d_device_mesh(device_mesh: DeviceMesh, tp_mesh_dim: int = 0) -> Dev
         -1, device_mesh.mesh.size(tp_mesh_dim)
     )
     for mesh_1d in pg_ranks_by_dim:
-        sub_mesh = DeviceMesh(device_mesh.device_type, mesh_1d, _init_process_groups=False)
+        sub_mesh = DeviceMesh(device_mesh.device_type, mesh_1d)
         if cur_rank in mesh_1d:
             res_sub_mesh = sub_mesh
 


### PR DESCRIPTION
Currently, we create new_group for sub_group pg during mesh initialization. The PR changes this so we will:
1) re-use sub_group pg if it exsits,
2) create new sub_group pg if it does not exist.


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @tianyu-l @wconstab @yf225