### PR TITLE
[CUDNN] RNNv6 API deprecation support

### DIFF
--- a/aten/src/ATen/cudnn/Descriptors.cpp
+++ b/aten/src/ATen/cudnn/Descriptors.cpp
@@ -31,7 +31,7 @@ inline cudnnDataType_t getDataType(const at::Tensor& t) {
 
 } // anonymous namespace
 
-void RNNDataDescriptor::set(const at::Tensor &t, cudnnRNNDataLayout_t layout, int maxSeqLength, int batchSize, int vectorSize, const int* seqLengthArray) {
+void RNNDataDescriptor::set(const at::Tensor &t, const cudnnRNNDataLayout_t layout, const int maxSeqLength, const int batchSize, const int vectorSize, const int* seqLengthArray) {
   set(getDataType(t), layout, maxSeqLength, batchSize, vectorSize, seqLengthArray);
 }
 

--- a/aten/src/ATen/cudnn/Descriptors.cpp
+++ b/aten/src/ATen/cudnn/Descriptors.cpp
@@ -31,6 +31,9 @@ inline cudnnDataType_t getDataType(const at::Tensor& t) {
 
 } // anonymous namespace
 
+void RNNDataDescriptor::set(const at::Tensor &t, cudnnRNNDataLayout_t layout, int maxSeqLength, int batchSize, int vectorSize, const int* seqLengthArray) {
+  set(getDataType(t), layout, maxSeqLength, batchSize, vectorSize, seqLengthArray);
+}
 
 void TensorDescriptor::set(const at::Tensor &t, at::MemoryFormat memory_format, size_t pad) {
   set(getDataType(t), t.sizes(), t.strides(), pad,

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -18,7 +18,7 @@
 #include <ATen/ops/empty.h>
 #endif
 
-#define RNNV8VERSION 9000
+#define RNNV8VERSION 8907
 
 namespace at { namespace native {
 
@@ -187,6 +187,7 @@ class TORCH_CUDA_CPP_API FilterDescriptor : public Descriptor<
   void print();
 private:
   void set(cudnnDataType_t dataType, int dim, int* size, cudnnTensorFormat_t filter_format) {
+    TORCH_WARN("CALLING CUDNNSET FILTER ND");
     AT_CUDNN_CHECK(cudnnSetFilterNdDescriptor(mut_desc(), dataType, filter_format, dim, size));
   }
 };
@@ -270,7 +271,11 @@ struct TORCH_CUDA_CPP_API RNNDescriptor : public Descriptor<
                                              &cudnnCreateRNNDescriptor,
                                              &cudnnDestroyRNNDescriptor> {
   DropoutDescriptor dropout_desc_;
-  void set(cudnnHandle_t handle, int hidden_size, int proj_size, int num_layers, DropoutDescriptor&& dropout_desc,
+  void set(cudnnHandle_t handle, 
+#if defined(CUDNN_VERSION) && CUDNN_VERSION >= RNNV8VERSION
+	   int input_size,
+#endif
+	   int hidden_size, int proj_size, int num_layers, DropoutDescriptor&& dropout_desc,
            cudnnRNNInputMode_t input_mode, cudnnDirectionMode_t bidirectional,
            cudnnRNNMode_t mode, cudnnDataType_t datatype, cudnnDataType_t input_type, cudnnRNNAlgo_t algo, bool allow_tf32) {
     dropout_desc_ = std::move(dropout_desc);
@@ -305,10 +310,10 @@ struct TORCH_CUDA_CPP_API RNNDescriptor : public Descriptor<
           CUDNN_RNN_DOUBLE_BIAS,
           bidirectional,
           input_mode,
+          input_type,
           datatype,
-          datatype == CUDNN_DATA_DOUBLE ? CUDNN_DATA_DOUBLE : CUDNN_DATA_FLOAT,
           allow_tf32 ? CUDNN_TENSOR_OP_MATH : CUDNN_DEFAULT_MATH,
-          hidden_size,
+          input_size,
           hidden_size,
           proj_size ? proj_size : hidden_size,
           num_layers,

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -18,7 +18,7 @@
 #include <ATen/ops/empty.h>
 #endif
 
-#if defined(CUDNN_VERSION) && CUDNN_VERSION >= 8907
+#if defined(CUDNN_VERSION) && CUDNN_VERSION >= 9000
 #define USE_CUDNN_RNN_V8_API
 #endif
 

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -123,9 +123,9 @@ private:
 };
 
 class TORCH_CUDA_CPP_API RNNDataDescriptor : public Descriptor<
-					       cudnnRNNDataStruct,
-					       &cudnnCreateRNNDataDescriptor,
-					       &cudnnDestroyRNNDataDescriptor> {
+                                       cudnnRNNDataStruct,
+                                       &cudnnCreateRNNDataDescriptor,
+                                       &cudnnDestroyRNNDataDescriptor> {
 public:
   void set(const at::Tensor &t, cudnnRNNDataLayout_t layout, int maxSeqLength, int batchSize, int vectorSize, const int* seqLengthArray);
 private:
@@ -273,10 +273,10 @@ struct TORCH_CUDA_CPP_API RNNDescriptor : public Descriptor<
   DropoutDescriptor dropout_desc_;
   void set(cudnnHandle_t handle,
 #if defined(USE_CUDNN_RNN_V8_API)
-	   int input_size,
-	   bool packed,
+       int input_size,
+       bool packed,
 #endif
-	   int hidden_size, int proj_size, int num_layers, DropoutDescriptor&& dropout_desc,
+       int hidden_size, int proj_size, int num_layers, DropoutDescriptor&& dropout_desc,
            cudnnRNNInputMode_t input_mode, cudnnDirectionMode_t bidirectional,
            cudnnRNNMode_t mode, cudnnDataType_t datatype, cudnnDataType_t input_type, cudnnRNNAlgo_t algo, bool allow_tf32) {
     dropout_desc_ = std::move(dropout_desc);

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -304,11 +304,13 @@ struct TORCH_CUDA_CPP_API RNNDescriptor : public Descriptor<
       if (input_type == CUDNN_DATA_HALF) {
         cudnnSetRNNMatrixMathType(mut_desc(), CUDNN_TENSOR_OP_MATH);
       }
-#if defined(CUDNN_VERSION) && CUDNN_VERSION >= 8000
+#endif
+#if !defined(USE_CUDNN_RNN_V8_API) && defined(CUDNN_VERSION) && CUDNN_VERSION >= 8000
       else if (input_type == CUDNN_DATA_FLOAT && !allow_tf32) {
         cudnnSetRNNMatrixMathType(mut_desc(), CUDNN_FMA_MATH);
       }
 #endif
+#ifndef USE_CUDNN_RNN_V8_API
       else {
         // Technically, as the default it's not necessary to explicitly
         // set this.

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -18,7 +18,7 @@
 #include <ATen/ops/empty.h>
 #endif
 
-#if defined(CUDNN_VERSION) && CUDNN_VERSION >= 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION >= 8907
 #define USE_CUDNN_RNN_V8_API
 #endif
 

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -118,6 +118,16 @@ private:
   std::unique_ptr<T, DescriptorDeleter<T, dtor>> desc_;
 };
 
+class TORCH_CUDA_CPP_API RNNDataDescriptor : public Descriptor<
+					       cudnnRNNDataStruct,
+					       &cudnnCreateRNNDataDescriptor,
+					       &cudnnDestroyRNNDataDescriptor> {
+  void set(const at::Tensor &t, cudnnRNNDataLayout_t layout, int maxSeqLength, int batchSize, int vectorSize, const int* seqLengthArray);
+  void set(cudnnDataType_t dataType, cudnnRNNDataLayout_t layout, int maxSeqLength, int batchSize, int vectorSize, const int* seqLengthArray) {
+    AT_CUDNN_CHECK(cudnnSetRNNDataDescriptor(mut_desc(), dataType, layout, maxSeqLength, batchSize, vectorSize, seqLengthArray, NULL));
+  }
+};
+
 class TORCH_CUDA_CPP_API TensorDescriptor : public Descriptor<
                                                cudnnTensorStruct,
                                                &cudnnCreateTensorDescriptor,

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -272,7 +272,7 @@ struct TORCH_CUDA_CPP_API RNNDescriptor : public Descriptor<
                                              &cudnnDestroyRNNDescriptor> {
   DropoutDescriptor dropout_desc_;
   void set(cudnnHandle_t handle,
-#if defined(USE_CUDNN_RNN_V8_API)
+#ifdef USE_CUDNN_RNN_V8_API
        int input_size,
        bool packed,
 #endif

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -18,7 +18,7 @@
 #include <ATen/ops/empty.h>
 #endif
 
-#define RNNV8VERSION 8907
+#define RNNV8VERSION 9000
 
 namespace at { namespace native {
 
@@ -274,6 +274,8 @@ struct TORCH_CUDA_CPP_API RNNDescriptor : public Descriptor<
            cudnnRNNInputMode_t input_mode, cudnnDirectionMode_t bidirectional,
            cudnnRNNMode_t mode, cudnnDataType_t datatype, cudnnDataType_t input_type, cudnnRNNAlgo_t algo, bool allow_tf32) {
     dropout_desc_ = std::move(dropout_desc);
+    TORCH_WARN("handle == 0? ", handle == nullptr);
+    TORCH_WARN("DATATYPEishalf? ", datatype == CUDNN_DATA_HALF);
 #if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
     AT_CUDNN_CHECK(cudnnSetRNNDescriptor_v6(
           handle,
@@ -296,7 +298,6 @@ struct TORCH_CUDA_CPP_API RNNDescriptor : public Descriptor<
 #else
     auto md = mut_desc();
     TORCH_WARN("md nullptr? ", md == nullptr);
-    TORCH_WARN("handle == 0? ", handle == nullptr);
     AT_CUDNN_CHECK(cudnnSetRNNDescriptor_v8(
           md,
           algo,

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -344,7 +344,7 @@ struct TORCH_CUDA_CPP_API CTCLossDescriptor
   void set(cudnnDataType_t datatype) {
     AT_CUDNN_CHECK(cudnnSetCTCLossDescriptor(mut_desc(), datatype));
   }
-#if CUDNN_VERSION >= 7600
+#if defined(CUDNN_VERSION) && CUDNN_VERSION >= 7600
   void setEx(
       cudnnDataType_t datatype,
       cudnnLossNormalizationMode_t normMode,

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -299,26 +299,6 @@ struct TORCH_CUDA_CPP_API RNNDescriptor : public Descriptor<
             /*recProjSize=*/proj_size,
             /*outProjSize=*/0));
     }
-#else
-    auto md = mut_desc();
-    AT_CUDNN_CHECK(cudnnSetRNNDescriptor_v8(
-          md,
-          algo,
-          mode,
-          CUDNN_RNN_DOUBLE_BIAS,
-          bidirectional,
-          input_mode,
-          input_type,
-          datatype,
-          allow_tf32 ? CUDNN_DEFAULT_MATH : CUDNN_FMA_MATH,
-          input_size,
-          hidden_size,
-          proj_size ? proj_size : hidden_size,
-          num_layers,
-          dropout_desc_.desc(),
-          packed ? CUDNN_RNN_PADDED_IO_DISABLED : CUDNN_RNN_PADDED_IO_ENABLED));
-#endif
-#ifndef USE_CUDNN_RNN_V8_API
     cudaDeviceProp* prop = at::cuda::getCurrentDeviceProperties();
     if (prop->major >= 7) {
       if (input_type == CUDNN_DATA_HALF) {
@@ -335,6 +315,23 @@ struct TORCH_CUDA_CPP_API RNNDescriptor : public Descriptor<
         cudnnSetRNNMatrixMathType(mut_desc(), CUDNN_DEFAULT_MATH);
       }
     }
+#else
+    AT_CUDNN_CHECK(cudnnSetRNNDescriptor_v8(
+          mut_desc(),
+          algo,
+          mode,
+          CUDNN_RNN_DOUBLE_BIAS,
+          bidirectional,
+          input_mode,
+          input_type,
+          datatype,
+          allow_tf32 ? CUDNN_DEFAULT_MATH : CUDNN_FMA_MATH,
+          input_size,
+          hidden_size,
+          proj_size ? proj_size : hidden_size,
+          num_layers,
+          dropout_desc_.desc(),
+          packed ? CUDNN_RNN_PADDED_IO_DISABLED : CUDNN_RNN_PADDED_IO_ENABLED));
 #endif
   }
 };

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -122,7 +122,9 @@ class TORCH_CUDA_CPP_API RNNDataDescriptor : public Descriptor<
 					       cudnnRNNDataStruct,
 					       &cudnnCreateRNNDataDescriptor,
 					       &cudnnDestroyRNNDataDescriptor> {
+public:
   void set(const at::Tensor &t, cudnnRNNDataLayout_t layout, int maxSeqLength, int batchSize, int vectorSize, const int* seqLengthArray);
+private:
   void set(cudnnDataType_t dataType, cudnnRNNDataLayout_t layout, int maxSeqLength, int batchSize, int vectorSize, const int* seqLengthArray) {
     AT_CUDNN_CHECK(cudnnSetRNNDataDescriptor(mut_desc(), dataType, layout, maxSeqLength, batchSize, vectorSize, seqLengthArray, NULL));
   }

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -1008,6 +1008,7 @@ namespace {
   }
 
   cudnnRNNAlgo_t get_algo(const RNNDescriptorParams& rnn, const TensorDescriptorListParams& tensors, const Tensor input, bool forward) {
+    return CUDNN_RNN_ALGO_STANDARD;
     // LSTM with projections only works with standard algorithm
     if (rnn.proj_size != 0) {
       return CUDNN_RNN_ALGO_STANDARD;
@@ -1694,7 +1695,7 @@ std::vector<Tensor> _cudnn_rnn_backward_weight(
         x_descs_arr.desc(), x.data_ptr(),
         descs.hx_desc.desc(), hx.data_ptr(),
         y_descs_arr.desc(), y.data_ptr(),
-        weight_buf.numel() * weight_buf.element_size(), weight_buf.data_ptr(),
+        weight_buf.numel() * weight_buf.element_size(), dw.data_ptr(),
         workspace.size(0), workspace.data_ptr(),
         fn_reserve.size(0), fn_reserve.data_ptr()));
 #endif

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -1008,7 +1008,6 @@ namespace {
   }
 
   cudnnRNNAlgo_t get_algo(const RNNDescriptorParams& rnn, const TensorDescriptorListParams& tensors, const Tensor input, bool forward) {
-    return CUDNN_RNN_ALGO_STANDARD;
     // LSTM with projections only works with standard algorithm
     if (rnn.proj_size != 0) {
       return CUDNN_RNN_ALGO_STANDARD;

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -160,13 +160,13 @@ namespace {
       this->algo = algo;
     }
 
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNN_V8_VERSION
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
     void set(int64_t mode, int64_t hidden_size, int64_t proj_size, int64_t num_layers, bool bidirectional, cudnnDataType_t datatype, cudnnDataType_t input_datatype) {
 #else
     void set(int64_t mode, int64_t input_size, bool packed, int64_t hidden_size, int64_t proj_size, int64_t num_layers, bool bidirectional, cudnnDataType_t datatype, cudnnDataType_t input_datatype) {
 #endif
       this->set_mode(mode);
-#if defined(CUDNN_VERSION) && CUDNN_VERSION >= RNN_V8_VERSION
+#if defined(CUDNN_VERSION) && CUDNN_VERSION >= RNNV8VERSION
       this->input_size = input_size;
       this->packed = packed;
 #endif
@@ -1299,7 +1299,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
     _copyParams(MatrixRef<Tensor>{weight, static_cast<size_t>(weight_stride0)},
                 MatrixRef<Tensor>{params, params_stride0});
   } else {
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8_VERSION
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
     w_desc.set(weight_buf, 3);
 #endif
   }

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -111,10 +111,10 @@ namespace {
   // RNNDescriptor
 
   struct RNNDescriptorParams {
-#ifdef USE_CUDNN_RNN_V8_API
-    int64_t input_size;
-    bool packed;
-#endif
+//#ifdef USE_CUDNN_RNN_V8_API
+//    int64_t input_size;
+//    bool packed;
+//#endif
     int64_t hidden_size;
     int64_t proj_size;
     int64_t num_layers;
@@ -160,16 +160,16 @@ namespace {
       this->algo = algo;
     }
 
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
     void set(int64_t mode, int64_t hidden_size, int64_t proj_size, int64_t num_layers, bool bidirectional, cudnnDataType_t datatype, cudnnDataType_t input_datatype) {
-#else
-    void set(int64_t mode, int64_t input_size, bool packed, int64_t hidden_size, int64_t proj_size, int64_t num_layers, bool bidirectional, cudnnDataType_t datatype, cudnnDataType_t input_datatype) {
-#endif
+//#else
+//    void set(int64_t mode, int64_t input_size, bool packed, int64_t hidden_size, int64_t proj_size, int64_t num_layers, bool bidirectional, cudnnDataType_t datatype, cudnnDataType_t input_datatype) {
+//#endif
       this->set_mode(mode);
-#ifdef USE_CUDNN_RNN_V8_API
-      this->input_size = input_size;
-      this->packed = packed;
-#endif
+//#ifdef USE_CUDNN_RNN_V8_API
+//      this->input_size = input_size;
+//      this->packed = packed;
+//#endif
       this->hidden_size = hidden_size;
       this->proj_size = proj_size;
       this->num_layers = num_layers;
@@ -180,11 +180,11 @@ namespace {
 
     RNNDescriptor descriptor(cudnnHandle_t handle, DropoutDescriptor&& dropout_desc) const {
       RNNDescriptor rnn_desc;
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
       rnn_desc.set(handle, hidden_size, proj_size, num_layers, std::move(dropout_desc), input_mode, bidirectional, mode, datatype, input_datatype, algo, at::globalContext().allowTF32CuDNN());
-#else
-      rnn_desc.set(handle, input_size, packed, hidden_size, proj_size, num_layers, std::move(dropout_desc), input_mode, bidirectional, mode, datatype, input_datatype, algo, at::globalContext().allowTF32CuDNN());
-#endif
+//#else
+//      rnn_desc.set(handle, input_size, packed, hidden_size, proj_size, num_layers, std::move(dropout_desc), input_mode, bidirectional, mode, datatype, input_datatype, algo, at::globalContext().allowTF32CuDNN());
+//#endif
       return rnn_desc;
     }
 
@@ -204,7 +204,7 @@ namespace {
   };
 
   // TensorDescriptor list
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
   std::vector<TensorDescriptor> rnn_descriptor_sequence(const Tensor& tensor, IntArrayRef batch_sizes) {
     std::vector<TensorDescriptor> descriptors(batch_sizes.size());
     size_t i = 0;
@@ -227,40 +227,40 @@ namespace {
     }
     return descriptors;
   }
-#else
-  auto rnn_descriptor_sequence(const Tensor& tensor, const int batch_size, IntArrayRef batch_sizes, const int seq_len, const int vector_size) { // packed case
-    RNNDataDescriptor r;
-    std::vector<int> seqLengthArray(batch_size, 1);
-    // cuDNN wants the sequence lenghts for a packed batch as if they
-    // were unpacked, e.g., for the
-    // Sequence 1: ABCD
-    // Sequence 2: EF
-    // Sequence 3: G
-    // case below, this would be [4, 2, 1] (has length == mini_batch)
-    // TODO(eqy): There's probably a smarter way to do this than O(SN)
-    for (auto it = batch_sizes.begin(); it != batch_sizes.end(); it++) {
-      // everyone starts at sequence length 1 so we skip an iteration
-      if (it == batch_sizes.begin()) {
-        continue;
-      }
-      for (int idx = 0; idx < *it; idx++) {
-        seqLengthArray[idx]++;
-      }
-    }
-    r.set(tensor, CUDNN_RNN_DATA_LAYOUT_SEQ_MAJOR_PACKED, seq_len, batch_size, vector_size, seqLengthArray.data());
-    return r;
-  }
-
-  auto rnn_descriptor(const Tensor& tensor, const int batch_size, const int seq_len, const int vector_size) {
-    RNNDataDescriptor r;
-    // NB: Looks like even if batch_first is true here we always want SEQ_MAJOR_UNPACKED, because the input
-    // appears to be transposed if it is barch-major
-    const auto layout = CUDNN_RNN_DATA_LAYOUT_SEQ_MAJOR_UNPACKED;
-    std::vector<int> seqLengthArray(batch_size, seq_len);
-    r.set(tensor, layout, seq_len, batch_size, vector_size, seqLengthArray.data());
-    return r;
-  }
-#endif
+//#else
+//  auto rnn_descriptor_sequence(const Tensor& tensor, const int batch_size, IntArrayRef batch_sizes, const int seq_len, const int vector_size) { // packed case
+//    RNNDataDescriptor r;
+//    std::vector<int> seqLengthArray(batch_size, 1);
+//    // cuDNN wants the sequence lenghts for a packed batch as if they
+//    // were unpacked, e.g., for the
+//    // Sequence 1: ABCD
+//    // Sequence 2: EF
+//    // Sequence 3: G
+//    // case below, this would be [4, 2, 1] (has length == mini_batch)
+//    // TODO(eqy): There's probably a smarter way to do this than O(SN)
+//    for (auto it = batch_sizes.begin(); it != batch_sizes.end(); it++) {
+//      // everyone starts at sequence length 1 so we skip an iteration
+//      if (it == batch_sizes.begin()) {
+//        continue;
+//      }
+//      for (int idx = 0; idx < *it; idx++) {
+//        seqLengthArray[idx]++;
+//      }
+//    }
+//    r.set(tensor, CUDNN_RNN_DATA_LAYOUT_SEQ_MAJOR_PACKED, seq_len, batch_size, vector_size, seqLengthArray.data());
+//    return r;
+//  }
+//
+//  auto rnn_descriptor(const Tensor& tensor, const int batch_size, const int seq_len, const int vector_size) {
+//    RNNDataDescriptor r;
+//    // NB: Looks like even if batch_first is true here we always want SEQ_MAJOR_UNPACKED, because the input
+//    // appears to be transposed if it is barch-major
+//    const auto layout = CUDNN_RNN_DATA_LAYOUT_SEQ_MAJOR_UNPACKED;
+//    std::vector<int> seqLengthArray(batch_size, seq_len);
+//    r.set(tensor, layout, seq_len, batch_size, vector_size, seqLengthArray.data());
+//    return r;
+//  }
+//#endif
 
   // The best way to understand the meaning of the values stored in
   // this struct is to consider each of the possible ways our

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -361,7 +361,7 @@ namespace {
         batch_sizes_sum = -1; // something bogus in case we access it
       }
     }
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
     // TODO: check x for consistency with input_size?
     std::vector<TensorDescriptor> descriptors(Tensor x) const {
       auto is_input_packed = batch_sizes.size() != 0;
@@ -371,16 +371,16 @@ namespace {
         return rnn_descriptor(x[0], seq_length);
       }
     }
-#else
-    auto descriptors(Tensor x) const {
-      auto is_input_packed = batch_sizes.size() != 0;
-      if (is_input_packed) {
-        return rnn_descriptor_sequence(x, mini_batch, batch_sizes, seq_length, x.size(-1));
-      } else {
-        return rnn_descriptor(x, mini_batch, seq_length, x.size(-1));
-      }
-    }
-#endif
+//#else
+//    auto descriptors(Tensor x) const {
+//      auto is_input_packed = batch_sizes.size() != 0;
+//      if (is_input_packed) {
+//        return rnn_descriptor_sequence(x, mini_batch, batch_sizes, seq_length, x.size(-1));
+//      } else {
+//        return rnn_descriptor(x, mini_batch, seq_length, x.size(-1));
+//      }
+//    }
+//#endif
   };
 
   // Everything together
@@ -396,13 +396,13 @@ namespace {
     RNNDescriptor rnn_desc;
     // NB: this won't actually lay out the tensor descriptor pointers
     // in the right way, so you'll have to preprocess them
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
     std::vector<TensorDescriptor> x_descs;
     std::vector<TensorDescriptor> y_descs;
-#else
-    RNNDataDescriptor x_descs;
-    RNNDataDescriptor y_descs;
-#endif
+//#else
+//    RNNDataDescriptor x_descs;
+//    RNNDataDescriptor y_descs;
+//#endif
     TensorDescriptor hx_desc;
     TensorDescriptor hy_desc;
     TensorDescriptor cx_desc;
@@ -430,7 +430,7 @@ namespace {
       }
       return r;
     }
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
     std::vector<cudnnTensorDescriptor_t> get_x_descs() {
       return get_descs(x_descs);
     }
@@ -438,20 +438,20 @@ namespace {
     std::vector<cudnnTensorDescriptor_t> get_y_descs() {
       return get_descs(y_descs);
     }
-#endif
+//#endif
   };
 
   int64_t get_num_weights(cudnnHandle_t handle, const RNNDescriptor& rnn_desc,
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
                           const TensorDescriptor& x_desc,
-#endif
+//#endif
                           cudnnDataType_t datatype) {
     size_t weight_size;
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
     AT_CUDNN_CHECK(cudnnGetRNNParamsSize(handle, rnn_desc.desc(), x_desc.desc(), &weight_size, datatype));
-#else
-    AT_CUDNN_CHECK(cudnnGetRNNWeightSpaceSize(handle, rnn_desc.desc(), &weight_size));
-#endif
+//#else
+//    AT_CUDNN_CHECK(cudnnGetRNNWeightSpaceSize(handle, rnn_desc.desc(), &weight_size));
+//#endif
     auto elem_size = dataSize(datatype);
     TORCH_INTERNAL_ASSERT(weight_size % elem_size == 0, "cudnnGetRNNParamsSize returned nonsensical weight_size");
     return weight_size / elem_size;
@@ -475,10 +475,10 @@ namespace {
   void add_projection_weights(
         cudnnHandle_t handle,
         const RNNDescriptor& rnn_desc,
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
         const TensorDescriptor& x_desc,
         const FilterDescriptor& w_desc,
-#endif
+//#endif
         const Tensor& weight_buf,
         int64_t layer,
         std::vector<Tensor>& params
@@ -486,7 +486,7 @@ namespace {
     void* matrix_pointer = nullptr;
     // assuming it's LSTM which has 8 "linear layers" (i.e. 4 weights and 4 biases)
     int64_t linear_id = 8;
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
     FilterDescriptor lin_layer_mat_desc;
     AT_CUDNN_CHECK(cudnnGetRNNLinLayerMatrixParams(
         /*handle=*/handle,
@@ -498,47 +498,47 @@ namespace {
         /*linLayerID=*/linear_id,
         /*linLayerMatDesc=*/lin_layer_mat_desc.mut_desc(),
         /*linLayerMat=*/&matrix_pointer));
-#else
-    void *unused_pointer;
-    TensorDescriptor unused_desc;
-    TensorDescriptor lin_layer_mat_desc;
-    AT_CUDNN_CHECK(cudnnGetRNNWeightParams(
-        /*handle=*/handle,
-        /*rnnDesc=*/rnn_desc.desc(),
-        /*layer=*/layer,
-        /*wDesc=*/weight_buf.numel() * weight_buf.element_size(),
-        /*w=*/weight_buf.data_ptr(),
-        /*linLayerID=*/linear_id,
-        /*linLayerMatDesc=*/lin_layer_mat_desc.mut_desc(),
-        /*linLayerMat=*/&matrix_pointer, unused_desc.mut_desc(), &unused_pointer));
-#endif
+//#else
+//    void *unused_pointer;
+//    TensorDescriptor unused_desc;
+//    TensorDescriptor lin_layer_mat_desc;
+//    AT_CUDNN_CHECK(cudnnGetRNNWeightParams(
+//        /*handle=*/handle,
+//        /*rnnDesc=*/rnn_desc.desc(),
+//        /*layer=*/layer,
+//        /*wDesc=*/weight_buf.numel() * weight_buf.element_size(),
+//        /*w=*/weight_buf.data_ptr(),
+//        /*linLayerID=*/linear_id,
+//        /*linLayerMatDesc=*/lin_layer_mat_desc.mut_desc(),
+//        /*linLayerMat=*/&matrix_pointer, unused_desc.mut_desc(), &unused_pointer));
+//#endif
 
     cudnnDataType_t data_type;
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
     cudnnTensorFormat_t format;
-#else
-    int stride_dim_a[5];
-#endif
+//#else
+//    int stride_dim_a[5];
+//#endif
     int nb_dims;
     constexpr int min_dim = 3;
     int filter_dim_a[min_dim];
     AT_CUDNN_CHECK(
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
       cudnnGetFilterNdDescriptor(
-#else
-      cudnnGetTensorNdDescriptor(
-#endif
+//#else
+//      cudnnGetTensorNdDescriptor(
+//#endif
           lin_layer_mat_desc.desc(),
           min_dim,
           &data_type,
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
           &format,
-#endif
+//#endif
           &nb_dims,
           filter_dim_a
-#ifdef USE_CUDNN_RNN_V8_API
-          ,stride_dim_a
-#endif
+//#ifdef USE_CUDNN_RNN_V8_API
+//          ,stride_dim_a
+//#endif
           ));
 
     TORCH_INTERNAL_ASSERT(nb_dims <= min_dim, "nb_dims = ", nb_dims, "; min_dim  = ", min_dim);
@@ -578,18 +578,18 @@ namespace {
       cudnnHandle_t handle,
       const RNNDescriptorParams& rnn,
       const RNNDescriptor& rnn_desc,
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
       const TensorDescriptor& x_desc,
       const FilterDescriptor& w_desc,
-#endif
+//#endif
       const Tensor& weight_buf,
       bool include_bias=true
   ) {
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
     auto cudnn_methods = { cudnnGetRNNLinLayerMatrixParams, cudnnGetRNNLinLayerBiasParams };
-#else
-    auto cudnn_methods = { true, false };
-#endif
+//#else
+//    auto cudnn_methods = { true, false };
+//#endif
     std::vector<Tensor> params;
     int64_t num_linear_layers = _num_linear_layers(rnn.mode);
     int64_t num_layers = rnn.num_directions() * rnn.num_layers;
@@ -600,7 +600,7 @@ namespace {
       for (auto cudnn_method : cudnn_methods) {
         for (const auto linear_id : c10::irange(num_linear_layers)) {
           void* matrix_pointer;
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
           FilterDescriptor lin_layer_mat_desc;
           AT_CUDNN_CHECK(cudnn_method(
                 handle,
@@ -613,66 +613,66 @@ namespace {
                 lin_layer_mat_desc.mut_desc(),
                 &matrix_pointer
                 ));
-#else
-          void *unused_pointer;
-          TensorDescriptor unused_desc;
-          TensorDescriptor lin_layer_mat_desc;
-          for (int stateless = 0; stateless < 100; stateless++) {
-          if (cudnn_method) { // matrix
-               AT_CUDNN_CHECK(cudnnGetRNNWeightParams(
-                   handle,
-                   rnn_desc.desc(),
-                   layer,
-                   weight_buf.numel() * weight_buf.element_size(),
-                   weight_buf.data_ptr(),
-                   linear_id,
-                   lin_layer_mat_desc.mut_desc(),
-                   &matrix_pointer,
-                   unused_desc.mut_desc(),
-                   &unused_pointer
-                   ));
-          } else { // bias
-               AT_CUDNN_CHECK(cudnnGetRNNWeightParams(
-                   handle,
-                   rnn_desc.desc(),
-                   layer,
-                   weight_buf.numel() * weight_buf.element_size(),
-                   weight_buf.data_ptr(),
-                   linear_id,
-                   unused_desc.mut_desc(),
-                   &unused_pointer,
-                   lin_layer_mat_desc.mut_desc(),
-                   &matrix_pointer
-                   ));
-          }
-          }
-#endif
+//#else
+//          void *unused_pointer;
+//          TensorDescriptor unused_desc;
+//          TensorDescriptor lin_layer_mat_desc;
+//          for (int stateless = 0; stateless < 100; stateless++) {
+//          if (cudnn_method) { // matrix
+//               AT_CUDNN_CHECK(cudnnGetRNNWeightParams(
+//                   handle,
+//                   rnn_desc.desc(),
+//                   layer,
+//                   weight_buf.numel() * weight_buf.element_size(),
+//                   weight_buf.data_ptr(),
+//                   linear_id,
+//                   lin_layer_mat_desc.mut_desc(),
+//                   &matrix_pointer,
+//                   unused_desc.mut_desc(),
+//                   &unused_pointer
+//                   ));
+//          } else { // bias
+//               AT_CUDNN_CHECK(cudnnGetRNNWeightParams(
+//                   handle,
+//                   rnn_desc.desc(),
+//                   layer,
+//                   weight_buf.numel() * weight_buf.element_size(),
+//                   weight_buf.data_ptr(),
+//                   linear_id,
+//                   unused_desc.mut_desc(),
+//                   &unused_pointer,
+//                   lin_layer_mat_desc.mut_desc(),
+//                   &matrix_pointer
+//                   ));
+//          }
+//          }
+//#endif
           cudnnDataType_t data_type;
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
           cudnnTensorFormat_t format;
-#else
-          int stride_dim_a[5];
-#endif
+//#else
+//          int stride_dim_a[5];
+//#endif
           int nb_dims;
           constexpr int min_dim = 3;
           int filter_dim_a[min_dim];
           AT_CUDNN_CHECK(
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
             cudnnGetFilterNdDescriptor(
-#else
-            cudnnGetTensorNdDescriptor(
-#endif
+//#else
+//            cudnnGetTensorNdDescriptor(
+//#endif
                 lin_layer_mat_desc.desc(),
                 min_dim,
                 &data_type,
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
                 &format,
-#endif
+//#endif
                 &nb_dims,
                 filter_dim_a
-#ifdef USE_CUDNN_RNN_V8_API
-                ,stride_dim_a
-#endif
+//#ifdef USE_CUDNN_RNN_V8_API
+//                ,stride_dim_a
+//#endif
                 ));
 
           TORCH_INTERNAL_ASSERT(nb_dims <= min_dim, "nb_dims = ", nb_dims, "; min_dim  = ", min_dim);
@@ -693,11 +693,11 @@ namespace {
             // I'd rather keep full cur_offset checks rather than save some CPU overhead by skipping the cudnn_method =
             // cudnnGetRNNLinLayerBiasParams iteration.
             if (include_bias ||
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
                     cudnn_method != cudnnGetRNNLinLayerBiasParams) {
-#else
-                    cudnn_method) {
-#endif
+//#else
+//                    cudnn_method) {
+//#endif
               // Generate a new parameter tensor which is a view into the weight_buf.
               std::initializer_list<int64_t> size = {
                 mat_numel * num_linear_layers / 2, 1};

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -514,31 +514,31 @@ namespace {
 #endif
 
     cudnnDataType_t data_type;
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
     cudnnTensorFormat_t format;
-#else
-    int stride_dim_a[5];
-#endif
+//#else
+//    int stride_dim_a[5];
+//#endif
     int nb_dims;
     constexpr int min_dim = 3;
     int filter_dim_a[min_dim];
     AT_CUDNN_CHECK(
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
       cudnnGetFilterNdDescriptor(
-#else
-      cudnnGetTensorNdDescriptor(
-#endif
+//#else
+//      cudnnGetTensorNdDescriptor(
+//#endif
           lin_layer_mat_desc.desc(),
           min_dim,
           &data_type,
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
           &format,
-#endif
+//#endif
           &nb_dims,
           filter_dim_a
-#ifdef USE_CUDNN_RNN_V8_API
-          ,stride_dim_a
-#endif
+//#ifdef USE_CUDNN_RNN_V8_API
+//          ,stride_dim_a
+//#endif
           ));
 
     TORCH_INTERNAL_ASSERT(nb_dims <= min_dim, "nb_dims = ", nb_dims, "; min_dim  = ", min_dim);

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -447,11 +447,11 @@ namespace {
 #endif
                           cudnnDataType_t datatype) {
     size_t weight_size;
-//#ifndef USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
     AT_CUDNN_CHECK(cudnnGetRNNParamsSize(handle, rnn_desc.desc(), x_desc.desc(), &weight_size, datatype));
-//#else
-//    AT_CUDNN_CHECK(cudnnGetRNNWeightSpaceSize(handle, rnn_desc.desc(), &weight_size));
-//#endif
+#else
+    AT_CUDNN_CHECK(cudnnGetRNNWeightSpaceSize(handle, rnn_desc.desc(), &weight_size));
+#endif
     auto elem_size = dataSize(datatype);
     TORCH_INTERNAL_ASSERT(weight_size % elem_size == 0, "cudnnGetRNNParamsSize returned nonsensical weight_size");
     return weight_size / elem_size;
@@ -475,10 +475,10 @@ namespace {
   void add_projection_weights(
         cudnnHandle_t handle,
         const RNNDescriptor& rnn_desc,
-//#ifndef USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
         const TensorDescriptor& x_desc,
         const FilterDescriptor& w_desc,
-//#endif
+#endif
         const Tensor& weight_buf,
         int64_t layer,
         std::vector<Tensor>& params
@@ -486,7 +486,7 @@ namespace {
     void* matrix_pointer = nullptr;
     // assuming it's LSTM which has 8 "linear layers" (i.e. 4 weights and 4 biases)
     int64_t linear_id = 8;
-//#ifndef USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
     FilterDescriptor lin_layer_mat_desc;
     AT_CUDNN_CHECK(cudnnGetRNNLinLayerMatrixParams(
         /*handle=*/handle,
@@ -498,47 +498,47 @@ namespace {
         /*linLayerID=*/linear_id,
         /*linLayerMatDesc=*/lin_layer_mat_desc.mut_desc(),
         /*linLayerMat=*/&matrix_pointer));
-//#else
-//    void *unused_pointer;
-//    TensorDescriptor unused_desc;
-//    TensorDescriptor lin_layer_mat_desc;
-//    AT_CUDNN_CHECK(cudnnGetRNNWeightParams(
-//        /*handle=*/handle,
-//        /*rnnDesc=*/rnn_desc.desc(),
-//        /*layer=*/layer,
-//        /*wDesc=*/weight_buf.numel() * weight_buf.element_size(),
-//        /*w=*/weight_buf.data_ptr(),
-//        /*linLayerID=*/linear_id,
-//        /*linLayerMatDesc=*/lin_layer_mat_desc.mut_desc(),
-//        /*linLayerMat=*/&matrix_pointer, unused_desc.mut_desc(), &unused_pointer));
-//#endif
+#else
+    void *unused_pointer;
+    TensorDescriptor unused_desc;
+    TensorDescriptor lin_layer_mat_desc;
+    AT_CUDNN_CHECK(cudnnGetRNNWeightParams(
+        /*handle=*/handle,
+        /*rnnDesc=*/rnn_desc.desc(),
+        /*layer=*/layer,
+        /*wDesc=*/weight_buf.numel() * weight_buf.element_size(),
+        /*w=*/weight_buf.data_ptr(),
+        /*linLayerID=*/linear_id,
+        /*linLayerMatDesc=*/lin_layer_mat_desc.mut_desc(),
+        /*linLayerMat=*/&matrix_pointer, unused_desc.mut_desc(), &unused_pointer));
+#endif
 
     cudnnDataType_t data_type;
-//#ifndef USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
     cudnnTensorFormat_t format;
-//#else
-//    int stride_dim_a[5];
-//#endif
+#else
+    int stride_dim_a[5];
+#endif
     int nb_dims;
     constexpr int min_dim = 3;
     int filter_dim_a[min_dim];
     AT_CUDNN_CHECK(
-//#ifndef USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
       cudnnGetFilterNdDescriptor(
-//#else
-//      cudnnGetTensorNdDescriptor(
-//#endif
+#else
+      cudnnGetTensorNdDescriptor(
+#endif
           lin_layer_mat_desc.desc(),
           min_dim,
           &data_type,
-//#ifndef USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
           &format,
-//#endif
+#endif
           &nb_dims,
           filter_dim_a
-//#ifdef USE_CUDNN_RNN_V8_API
-//          ,stride_dim_a
-//#endif
+#ifdef USE_CUDNN_RNN_V8_API
+          ,stride_dim_a
+#endif
           ));
 
     TORCH_INTERNAL_ASSERT(nb_dims <= min_dim, "nb_dims = ", nb_dims, "; min_dim  = ", min_dim);

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -578,10 +578,10 @@ namespace {
       cudnnHandle_t handle,
       const RNNDescriptorParams& rnn,
       const RNNDescriptor& rnn_desc,
-//#ifndef USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
       const TensorDescriptor& x_desc,
       const FilterDescriptor& w_desc,
-//#endif
+#endif
       const Tensor& weight_buf,
       bool include_bias=true
   ) {

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -321,7 +321,7 @@ namespace {
         batch_sizes_sum = input_sizes[0];
         input_size = input_sizes[1];
       } else {
-        if (batch_first) {
+        if (batch_first_) {
           seq_length = input_sizes[1];
           mini_batch = input_sizes[0];
         } else {
@@ -506,9 +506,9 @@ namespace {
           &format,
 #endif
           &nb_dims,
-          filter_dim_a,
+          filter_dim_a
 #if defined(CUDNN_VERSION) && CUDNN_VERSION >= 9000
-          stride_dim_a
+          ,stride_dim_a
 #endif
           ));
 
@@ -636,9 +636,9 @@ namespace {
                 &format,
 #endif
                 &nb_dims,
-                filter_dim_a,
+                filter_dim_a
 #if defined(CUDNN_VERSION) && CUDNN_VERSION >= 9000
-                stride_dim_a
+                ,stride_dim_a
 #endif
                 ));
 

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -514,11 +514,11 @@ namespace {
 #endif
 
     cudnnDataType_t data_type;
-//#ifndef USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
     cudnnTensorFormat_t format;
-//#else
-//    int stride_dim_a[5];
-//#endif
+#else
+    int stride_dim_a[5];
+#endif
     int nb_dims;
     constexpr int min_dim = 3;
     int filter_dim_a[min_dim];
@@ -585,11 +585,11 @@ namespace {
       const Tensor& weight_buf,
       bool include_bias=true
   ) {
-//#ifndef USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
     auto cudnn_methods = { cudnnGetRNNLinLayerMatrixParams, cudnnGetRNNLinLayerBiasParams };
-//#else
-//    auto cudnn_methods = { true, false };
-//#endif
+#else
+    auto cudnn_methods = { true, false };
+#endif
     std::vector<Tensor> params;
     int64_t num_linear_layers = _num_linear_layers(rnn.mode);
     int64_t num_layers = rnn.num_directions() * rnn.num_layers;
@@ -600,7 +600,7 @@ namespace {
       for (auto cudnn_method : cudnn_methods) {
         for (const auto linear_id : c10::irange(num_linear_layers)) {
           void* matrix_pointer;
-//#ifndef USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
           FilterDescriptor lin_layer_mat_desc;
           AT_CUDNN_CHECK(cudnn_method(
                 handle,
@@ -613,46 +613,46 @@ namespace {
                 lin_layer_mat_desc.mut_desc(),
                 &matrix_pointer
                 ));
-//#else
-//          void *unused_pointer;
-//          TensorDescriptor unused_desc;
-//          TensorDescriptor lin_layer_mat_desc;
-//          for (int stateless = 0; stateless < 100; stateless++) {
-//          if (cudnn_method) { // matrix
-//               AT_CUDNN_CHECK(cudnnGetRNNWeightParams(
-//                   handle,
-//                   rnn_desc.desc(),
-//                   layer,
-//                   weight_buf.numel() * weight_buf.element_size(),
-//                   weight_buf.data_ptr(),
-//                   linear_id,
-//                   lin_layer_mat_desc.mut_desc(),
-//                   &matrix_pointer,
-//                   unused_desc.mut_desc(),
-//                   &unused_pointer
-//                   ));
-//          } else { // bias
-//               AT_CUDNN_CHECK(cudnnGetRNNWeightParams(
-//                   handle,
-//                   rnn_desc.desc(),
-//                   layer,
-//                   weight_buf.numel() * weight_buf.element_size(),
-//                   weight_buf.data_ptr(),
-//                   linear_id,
-//                   unused_desc.mut_desc(),
-//                   &unused_pointer,
-//                   lin_layer_mat_desc.mut_desc(),
-//                   &matrix_pointer
-//                   ));
-//          }
-//          }
-//#endif
+#else
+          void *unused_pointer;
+          TensorDescriptor unused_desc;
+          TensorDescriptor lin_layer_mat_desc;
+          for (int stateless = 0; stateless < 100; stateless++) {
+          if (cudnn_method) { // matrix
+               AT_CUDNN_CHECK(cudnnGetRNNWeightParams(
+                   handle,
+                   rnn_desc.desc(),
+                   layer,
+                   weight_buf.numel() * weight_buf.element_size(),
+                   weight_buf.data_ptr(),
+                   linear_id,
+                   lin_layer_mat_desc.mut_desc(),
+                   &matrix_pointer,
+                   unused_desc.mut_desc(),
+                   &unused_pointer
+                   ));
+          } else { // bias
+               AT_CUDNN_CHECK(cudnnGetRNNWeightParams(
+                   handle,
+                   rnn_desc.desc(),
+                   layer,
+                   weight_buf.numel() * weight_buf.element_size(),
+                   weight_buf.data_ptr(),
+                   linear_id,
+                   unused_desc.mut_desc(),
+                   &unused_pointer,
+                   lin_layer_mat_desc.mut_desc(),
+                   &matrix_pointer
+                   ));
+          }
+          }
+#endif
           cudnnDataType_t data_type;
-//#ifndef USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
           cudnnTensorFormat_t format;
-//#else
-//          int stride_dim_a[5];
-//#endif
+#else
+          int stride_dim_a[5];
+#endif
           int nb_dims;
           constexpr int min_dim = 3;
           int filter_dim_a[min_dim];

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -180,11 +180,11 @@ namespace {
 
     RNNDescriptor descriptor(cudnnHandle_t handle, DropoutDescriptor&& dropout_desc) const {
       RNNDescriptor rnn_desc;
- #ifndef USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
       rnn_desc.set(handle, hidden_size, proj_size, num_layers, std::move(dropout_desc), input_mode, bidirectional, mode, datatype, input_datatype, algo, at::globalContext().allowTF32CuDNN());
- #else
+#else
       rnn_desc.set(handle, input_size, packed, hidden_size, proj_size, num_layers, std::move(dropout_desc), input_mode, bidirectional, mode, datatype, input_datatype, algo, at::globalContext().allowTF32CuDNN());
- #endif
+#endif
       return rnn_desc;
     }
 
@@ -1122,7 +1122,7 @@ copy_weights_to_flat_buf_views(
 #ifndef USE_CUDNN_RNN_V8_API
   FilterDescriptor w_desc;
   w_desc.set(weight_buf, 3);
-# endif
+#endif
 
   // Slice off views into weight_buf
   std::vector<Tensor> params_arr;
@@ -1328,7 +1328,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
   // this information.  Use 'train' as a proxy.
   if (fn_train) {
     size_t reserve_size;
- #ifndef USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
     AT_CUDNN_CHECK(cudnnGetRNNTrainingReserveSize(
           handle,
           descs.rnn_desc.desc(),

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -657,11 +657,11 @@ namespace {
           constexpr int min_dim = 3;
           int filter_dim_a[min_dim];
           AT_CUDNN_CHECK(
-//#ifndef USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
             cudnnGetFilterNdDescriptor(
-//#else
-//            cudnnGetTensorNdDescriptor(
-//#endif
+#else
+            cudnnGetTensorNdDescriptor(
+#endif
                 lin_layer_mat_desc.desc(),
                 min_dim,
                 &data_type,
@@ -693,11 +693,11 @@ namespace {
             // I'd rather keep full cur_offset checks rather than save some CPU overhead by skipping the cudnn_method =
             // cudnnGetRNNLinLayerBiasParams iteration.
             if (include_bias ||
-//#ifndef USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
                     cudnn_method != cudnnGetRNNLinLayerBiasParams) {
-//#else
-//                    cudnn_method) {
-//#endif
+#else
+                    cudnn_method) {
+#endif
               // Generate a new parameter tensor which is a view into the weight_buf.
               std::initializer_list<int64_t> size = {
                 mat_numel * num_linear_layers / 2, 1};

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -243,7 +243,7 @@ namespace {
       if (it == batch_sizes.begin()) {
         continue;
       }
-      for (int idx = 0; idx < *it; idx++) {
+      for (const auto idx : c10::irange(*it)) {
         seqLengthArray[idx]++;
       }
     }

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -993,7 +993,7 @@ namespace {
   inline bool use_rnn_persist_small_h(const RNNDescriptorParams& rnn,
                                             const TensorDescriptorListParams& tensors,
                                             bool forward) {
-#if CUDNN_VERSION >= 8201 // 8.2.1
+#if defined(CUDNN_VERSION) && CUDNN_VERSION >= 8201 // 8.2.1
     cudaDeviceProp* prop = at::cuda::getCurrentDeviceProperties();
     if (prop->major < 6) return false;
 
@@ -1030,7 +1030,7 @@ namespace {
     // https://docs.nvidia.com/deeplearning/cudnn/developer-guide/index.html#features-of-rnn-functions
     if (!tensors.is_input_packed()) {
       auto cudnnDataType = getCudnnDataType(input);
-#if CUDNN_VERSION >= 8201 // 8.2.1
+#if defined(CUDNN_VERSION) && CUDNN_VERSION >= 8201 // 8.2.1
       if (cudnnDataType != CUDNN_DATA_DOUBLE) {
         if (use_rnn_persist_small_h(rnn, tensors, forward)) {
           return CUDNN_RNN_ALGO_PERSIST_STATIC_SMALL_H;

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -232,7 +232,7 @@ namespace {
     RNNDataDescriptor r;
     std::vector<int> seqLengthArray(batch_size, 1);
     // cuDNN wants the sequence lenghts for a packed batch as if they
-    // were unpacked, e.g., for the 
+    // were unpacked, e.g., for the
     // Sequence 1: ABCD
     // Sequence 2: EF
     // Sequence 3: G
@@ -828,7 +828,7 @@ namespace {
               &matrix_pointer
               ));
 #else
-	void *unused_pointer;
+    void *unused_pointer;
         TensorDescriptor unused_desc;
         TensorDescriptor lin_layer_mat_desc;
 
@@ -1092,7 +1092,7 @@ copy_weights_to_flat_buf_views(
 #if defined(USE_CUDNN_RNN_V8_API)
       input_size,
       false, // eqy: bogus as we do not know if the input is packed here
-	     // but it should not affect the weights (what are are interested in)
+         // but it should not affect the weights (what are are interested in)
 #endif
       hidden_size,
       proj_size,
@@ -1964,7 +1964,7 @@ Tensor try_get_weight_buf(
 #else
   auto cudnn_input_size = input.size(-1);
   auto packed = false; // eqy: bogus as we do not know if the input is packed here
-		       // again, it should also not affect the weights
+               // again, it should also not affect the weights
   rnn.set(mode, cudnn_input_size, packed, hidden_size.guard_int(__FILE__, __LINE__), proj_size.guard_int(__FILE__, __LINE__), num_layers, bidirectional, promote_rnn_math_type(datatype), datatype);
 #endif
   RNNDescriptor rnn_desc = rnn.descriptor(handle);

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -231,6 +231,12 @@ namespace {
   auto rnn_descriptor_sequence(const Tensor& tensor, const int batch_size, IntArrayRef batch_sizes, const int seq_len, const int vector_size) { // packed case
     RNNDataDescriptor r;
     std::vector<int> seqLengthArray(batch_size, 1);
+    // cuDNN wants the sequence lenghts for a packed batch as if they
+    // were unpacked, e.g., for the 
+    // Sequence 1: ABCD
+    // Sequence 2: EF
+    // Sequence 3: G
+    // case below, this would be [4, 2, 1] (has length == mini_batch)
     // TODO(eqy): There's probably a smarter way to do this than O(SN)
     for (auto it = batch_sizes.begin(); it != batch_sizes.end(); it++) {
       // everyone starts at sequence length 1 so we skip an iteration

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -188,7 +188,7 @@ namespace {
   };
 
   // TensorDescriptor list
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
   std::vector<TensorDescriptor> rnn_descriptor_sequence(const Tensor& tensor, IntArrayRef batch_sizes) {
     std::vector<TensorDescriptor> descriptors(batch_sizes.size());
     size_t i = 0;
@@ -304,13 +304,13 @@ namespace {
       return batch_sizes.size() != 0;
     }
 
-#if defined(CUDNN_VERSION) && CUDNN_VERSION >= 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION >= RNNV8VERSION
     bool batch_first;
 #endif
 
     void set(IntArrayRef input_sizes, IntArrayRef batch_sizes_, bool batch_first_) {
       batch_sizes = batch_sizes_;
-#if defined(CUDNN_VERSION) && CUDNN_VERSION >= 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION >= RNNV8VERSION
       batch_first = batch_first_;
 #endif
       if (is_input_packed()) {
@@ -334,7 +334,7 @@ namespace {
         batch_sizes_sum = -1; // something bogus in case we access it
       }
     }
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
     // TODO: check x for consistency with input_size?
     std::vector<TensorDescriptor> descriptors(Tensor x) const {
       auto is_input_packed = batch_sizes.size() != 0;
@@ -369,7 +369,7 @@ namespace {
     RNNDescriptor rnn_desc;
     // NB: this won't actually lay out the tensor descriptor pointers
     // in the right way, so you'll have to preprocess them
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
     std::vector<TensorDescriptor> x_descs;
     std::vector<TensorDescriptor> y_descs;
 #else
@@ -403,7 +403,7 @@ namespace {
       }
       return r;
     }
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
     std::vector<cudnnTensorDescriptor_t> get_x_descs() {
       return get_descs(x_descs);
     }
@@ -415,12 +415,12 @@ namespace {
   };
 
   int64_t get_num_weights(cudnnHandle_t handle, const RNNDescriptor& rnn_desc,
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
                           const TensorDescriptor& x_desc,
 #endif
                           cudnnDataType_t datatype) {
     size_t weight_size;
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
     AT_CUDNN_CHECK(cudnnGetRNNParamsSize(handle, rnn_desc.desc(), x_desc.desc(), &weight_size, datatype));
 #else
     AT_CUDNN_CHECK(cudnnGetRNNWeightSpaceSize(handle, rnn_desc.desc(), &weight_size));
@@ -448,7 +448,7 @@ namespace {
   void add_projection_weights(
         cudnnHandle_t handle,
         const RNNDescriptor& rnn_desc,
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
         const TensorDescriptor& x_desc,
         const FilterDescriptor& w_desc,
 #endif
@@ -459,7 +459,7 @@ namespace {
     void* matrix_pointer = nullptr;
     // assuming it's LSTM which has 8 "linear layers" (i.e. 4 weights and 4 biases)
     int64_t linear_id = 8;
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
     FilterDescriptor lin_layer_mat_desc;
     AT_CUDNN_CHECK(cudnnGetRNNLinLayerMatrixParams(
         /*handle=*/handle,
@@ -485,7 +485,7 @@ namespace {
 #endif
 
     cudnnDataType_t data_type;
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
     cudnnTensorFormat_t format;
 #else
     int stride_dim_a[5];
@@ -494,7 +494,7 @@ namespace {
     constexpr int min_dim = 3;
     int filter_dim_a[min_dim];
     AT_CUDNN_CHECK(
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
       cudnnGetFilterNdDescriptor(
 #else
       cudnnGetTensorNdDescriptor(
@@ -502,12 +502,12 @@ namespace {
           lin_layer_mat_desc.desc(),
           min_dim,
           &data_type,
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
           &format,
 #endif
           &nb_dims,
           filter_dim_a
-#if defined(CUDNN_VERSION) && CUDNN_VERSION >= 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION >= RNNV8VERSION
           ,stride_dim_a
 #endif
           ));
@@ -549,14 +549,14 @@ namespace {
       cudnnHandle_t handle,
       const RNNDescriptorParams& rnn,
       const RNNDescriptor& rnn_desc,
-#if defined (CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined (CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
       const TensorDescriptor& x_desc,
       const FilterDescriptor& w_desc,
 #endif
       const Tensor& weight_buf,
       bool include_bias=true
   ) {
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
     auto cudnn_methods = { cudnnGetRNNLinLayerMatrixParams, cudnnGetRNNLinLayerBiasParams };
 #else
     auto cudnn_methods = { true, false };
@@ -571,7 +571,7 @@ namespace {
       for (auto cudnn_method : cudnn_methods) {
         for (const auto linear_id : c10::irange(num_linear_layers)) {
           void* matrix_pointer;
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
           FilterDescriptor lin_layer_mat_desc;
           AT_CUDNN_CHECK(cudnn_method(
                 handle,
@@ -585,7 +585,9 @@ namespace {
                 &matrix_pointer
                 ));
 #else
-        TensorDescriptor lin_layer_mat_desc;
+	  void *unused_pointer;
+	  TensorDescriptor unused_desc;
+          TensorDescriptor lin_layer_mat_desc;
           if (cudnn_method) { // matrix
                AT_CUDNN_CHECK(cudnnGetRNNWeightParams(
                    handle,
@@ -596,8 +598,8 @@ namespace {
                    linear_id,
                    lin_layer_mat_desc.mut_desc(),
                    &matrix_pointer,
-                   NULL,
-                   NULL
+                   unused_desc.mut_desc(),
+                   &unused_pointer
                    ));
           } else { // bias
                AT_CUDNN_CHECK(cudnnGetRNNWeightParams(
@@ -607,15 +609,15 @@ namespace {
                    weight_buf.numel() * weight_buf.element_size(),
                    weight_buf.data_ptr(),
                    linear_id,
-                   NULL,
-                   NULL,
+                   unused_desc.mut_desc(),
+                   &unused_pointer,
                    lin_layer_mat_desc.mut_desc(),
                    &matrix_pointer
                    ));
           }
 #endif
           cudnnDataType_t data_type;
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
           cudnnTensorFormat_t format;
 #else
           int stride_dim_a[5];
@@ -624,7 +626,7 @@ namespace {
           constexpr int min_dim = 3;
           int filter_dim_a[min_dim];
           AT_CUDNN_CHECK(
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
             cudnnGetFilterNdDescriptor(
 #else
             cudnnGetTensorNdDescriptor(
@@ -632,12 +634,12 @@ namespace {
                 lin_layer_mat_desc.desc(),
                 min_dim,
                 &data_type,
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
                 &format,
 #endif
                 &nb_dims,
                 filter_dim_a
-#if defined(CUDNN_VERSION) && CUDNN_VERSION >= 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION >= RNNV8VERSION
                 ,stride_dim_a
 #endif
                 ));
@@ -647,7 +649,10 @@ namespace {
           auto offset_bytes = (char*)matrix_pointer - (char*)weight_buf.data_ptr();
           TORCH_INTERNAL_ASSERT(offset_bytes % elem_size == 0, "offset_bytes = ", offset_bytes, "; elem_size = ", elem_size);
           size_t offset = offset_bytes / elem_size;
-
+	  TORCH_WARN("INCLUDE_BIAS? ", include_bias, " OFFSET BYTES ", offset_bytes, " ELEM_SIZE", elem_size, " OFFSET: ", offset);
+#if defined(CUDNN_VERSION) && CUDNN_VERSION >= RNNV8VERSION
+          TORCH_WARN("UNUSED OFFSET ", ((char *) unused_pointer - (char *)weight_buf.data_ptr()));
+#endif
           // for all the RNN types provided by CUDNN, all the ih weights
           // are the same size and are allocated in a contiguous chunk
           // (same for the hh weights, and the ih and hh biases).
@@ -661,7 +666,7 @@ namespace {
             // I'd rather keep full cur_offset checks rather than save some CPU overhead by skipping the cudnn_method =
             // cudnnGetRNNLinLayerBiasParams iteration.
             if (include_bias || 
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
                     cudnn_method != cudnnGetRNNLinLayerBiasParams) {
 #else
                     cudnn_method) {
@@ -680,7 +685,7 @@ namespace {
         }
       } // for cudnn_method
       if (rnn.proj_size != 0) {
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
         add_projection_weights(handle, rnn_desc, x_desc, w_desc, weight_buf, layer, params);
 #else
         add_projection_weights(handle, rnn_desc, weight_buf, layer, params);
@@ -704,7 +709,7 @@ namespace {
   std::vector<void*> get_expected_data_ptrs(
         const Tensor& weight_buf, cudnnHandle_t handle, const RNNDescriptorParams& rnn,
         const RNNDescriptor& rnn_desc, const TensorDescriptor& x_desc, cudnnDataType_t datatype) {
-#if defined (CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined (CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
     FilterDescriptor w_desc;
 #else
     TensorDescriptor w_desc;
@@ -713,7 +718,7 @@ namespace {
 
     int64_t num_linear_layers = _num_linear_layers(rnn.mode);
     int64_t num_dir_layers = rnn.num_directions() * rnn.num_layers;
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
     const auto cudnn_methods = { cudnnGetRNNLinLayerMatrixParams, cudnnGetRNNLinLayerBiasParams };
 #else
     const auto cudnn_methods = { true, false };
@@ -732,7 +737,7 @@ namespace {
         const std::array<int64_t, 2> linear_offsets = { 0, num_linear_layers / 2 };
         for (int64_t linear_id : linear_offsets) {
           void* matrix_pointer;
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
           FilterDescriptor lin_layer_mat_desc;
           AT_CUDNN_CHECK(cudnn_method(
                 handle,
@@ -782,7 +787,7 @@ namespace {
         // assuming it's LSTM which has 8 "linear layers" (i.e. 4 weights and 4 biases)
         int64_t linear_id = 8;
         void* matrix_pointer;
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
         FilterDescriptor lin_layer_mat_desc;
         AT_CUDNN_CHECK(cudnnGetRNNLinLayerMatrixParams(
               handle,
@@ -1072,7 +1077,7 @@ copy_weights_to_flat_buf_views(
   x_desc.set(flat_buf_datatype, x_geom.sizes(), x_geom.strides(), 5);
 
   auto num_weights =
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
       get_num_weights(handle, rnn_desc, x_desc, flat_buf_datatype);
 #else
       get_num_weights(handle, rnn_desc, flat_buf_datatype);
@@ -1086,7 +1091,7 @@ copy_weights_to_flat_buf_views(
   std::vector<Tensor> params_arr;
   size_t params_stride0;
   std::tie(params_arr, params_stride0) = get_parameters(
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
       handle, rnn, rnn_desc, x_desc, w_desc, weight_buf, include_bias);
 #else
       handle, rnn, rnn_desc, weight_buf, include_bias);
@@ -1228,7 +1233,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
 
   FilterDescriptor w_desc;
   if (!weight_buf.defined()) {
- #if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+ #if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
     auto num_weights = get_num_weights(handle, descs.rnn_desc, descs.x_descs[0], datatype);
  #else
     auto num_weights = get_num_weights(handle, descs.rnn_desc, datatype);
@@ -1238,7 +1243,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
     weight_buf.zero_();
     std::vector<Tensor> params;
     size_t params_stride0;
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
     std::tie(params, params_stride0) = get_parameters(handle, fn.rnn, descs.rnn_desc, descs.x_descs[0], w_desc, weight_buf);
 #else
     std::tie(params, params_stride0) = get_parameters(handle, fn.rnn, descs.rnn_desc, weight_buf);
@@ -1252,14 +1257,14 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
   TORCH_CHECK(!cx.defined() || cx.sizes().equals(cell_size),
           "Expected cell size ", IntArrayRef{cell_size}, ", got ", cx.sizes());
   size_t workspace_size;
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
   auto x_descs_arr = descs.get_x_descs();
   auto y_descs_arr = descs.get_y_descs();
 #else
   auto& x_descs_arr = descs.x_descs;
   auto& y_descs_arr = descs.y_descs;
 #endif
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
   AT_CUDNN_CHECK(cudnnGetRNNWorkspaceSize(
         handle,
         descs.rnn_desc.desc(),
@@ -1274,7 +1279,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
   // this information.  Use 'train' as a proxy.
   if (fn_train) {
     size_t reserve_size;
- #if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+ #if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
     AT_CUDNN_CHECK(cudnnGetRNNTrainingReserveSize(
           handle,
           descs.rnn_desc.desc(),
@@ -1294,7 +1299,9 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
 #endif
     workspace = at::empty(workspace_size, input.options().dtype(kByte));
     reserve = at::empty(reserve_size, input.options().dtype(kByte));
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+    TORCH_WARN("FORWARD!!!", CUDNN_VERSION);
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
+    TORCH_WARN("FORWARD OLD!!!");
     AT_CUDNN_CHECK(cudnnRNNForwardTraining(
           handle,
           descs.rnn_desc.desc(),
@@ -1310,6 +1317,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
           reserve.mutable_data_ptr(), reserve.size(0)
           ));
 #else
+    TORCH_WARN("FORWARD NEW!!!");
     AT_CUDNN_CHECK(cudnnRNNForward(
           handle,
           descs.rnn_desc.desc(),
@@ -1326,7 +1334,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
   } else { // inference
     workspace = at::empty(workspace_size, input.options().dtype(kByte));
     reserve = at::empty({0}, input.options().dtype(kByte));
-#if defined(CUDNN_VERSION) && CUDNN_VERSION >= 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION >= RNNV8VERSION
     AT_CUDNN_CHECK(cudnnGetRNNTempSpaceSizes(
           handle,
           descs.rnn_desc.desc(),
@@ -1336,7 +1344,8 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
           NULL
           ));
 #endif
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
+    TORCH_WARN("FORWARD NEW!!!");
     AT_CUDNN_CHECK(cudnnRNNForwardInference(
           handle,
           descs.rnn_desc.desc(),
@@ -1458,7 +1467,7 @@ std::tuple<Tensor, Tensor, Tensor> _cudnn_rnn_backward_input(
   w_desc.set(weight_buf, 3);
 
   size_t workspace_size;
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
   auto x_descs_arr = descs.get_x_descs();
   auto y_descs_arr = descs.get_y_descs();
   AT_CUDNN_CHECK(cudnnGetRNNWorkspaceSize(
@@ -1482,7 +1491,7 @@ std::tuple<Tensor, Tensor, Tensor> _cudnn_rnn_backward_input(
 #endif
   // TODO: put this in the correct device???
   Tensor workspace = at::empty(workspace_size, input.options().dtype(kByte));
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
   AT_CUDNN_CHECK(cudnnRNNBackwardData(
         handle,
         descs.rnn_desc.desc(),
@@ -1592,7 +1601,7 @@ std::vector<Tensor> _cudnn_rnn_backward_weight(
   w_desc.set(weight_buf, 3);
 
   size_t workspace_size;
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
   auto x_descs_arr = descs.get_x_descs();
   auto y_descs_arr = descs.get_y_descs();
   AT_CUDNN_CHECK(cudnnGetRNNWorkspaceSize(
@@ -1615,7 +1624,7 @@ std::vector<Tensor> _cudnn_rnn_backward_weight(
         ));
 #endif
   Tensor workspace = at::empty(workspace_size, input.options().dtype(kByte));
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
   AT_CUDNN_CHECK(cudnnRNNBackwardWeights(
         handle,
         descs.rnn_desc.desc(),
@@ -1644,7 +1653,7 @@ std::vector<Tensor> _cudnn_rnn_backward_weight(
 
   std::vector<Tensor> grad_params_arr;
   size_t grad_params_stride0;
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
   std::tie(grad_params_arr, grad_params_stride0) = get_parameters(handle, fn.rnn, descs.rnn_desc, descs.x_descs[0], w_desc, dw);
 #else
   std::tie(grad_params_arr, grad_params_stride0) = get_parameters(handle, fn.rnn, descs.rnn_desc, dw);
@@ -1899,7 +1908,7 @@ Tensor try_get_weight_buf(
   // for us to run it with input of the same datatype?"
   x_desc.set(datatype, x_geom.sizes(), x_geom.strides(), 5);
 
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 9000
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < RNNV8VERSION
   auto num_params = get_num_weights(handle, rnn_desc, x_desc, datatype);
 #else
   auto num_params = get_num_weights(handle, rnn_desc, datatype);

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -781,7 +781,7 @@ namespace {
                 &matrix_pointer
                 ));
 #else
-        void *unused_pointer;
+        void *unused_pointer = nullptr;
         TensorDescriptor unused_desc;
         TensorDescriptor lin_layer_mat_desc;
           if (cudnn_method) { // matrix

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -256,7 +256,7 @@ namespace {
     // NB: Looks like even if batch_first is true here we always want SEQ_MAJOR_UNPACKED, because the input
     // appears to be transposed if it is barch-major
     const auto layout = CUDNN_RNN_DATA_LAYOUT_SEQ_MAJOR_UNPACKED;
-    std::vector<int> seqLengthArray(batch_size, seq_len);
+    std::vector<in32_t> seqLengthArray(batch_size, seq_len);
     r.set(tensor, layout, seq_len, batch_size, vector_size, seqLengthArray.data());
     return r;
   }

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -657,11 +657,11 @@ namespace {
           constexpr int min_dim = 3;
           int filter_dim_a[min_dim];
           AT_CUDNN_CHECK(
-#ifndef USE_CUDNN_RNN_V8_API
+//#ifndef USE_CUDNN_RNN_V8_API
             cudnnGetFilterNdDescriptor(
-#else
-            cudnnGetTensorNdDescriptor(
-#endif
+//#else
+//            cudnnGetTensorNdDescriptor(
+//#endif
                 lin_layer_mat_desc.desc(),
                 min_dim,
                 &data_type,
@@ -692,11 +692,10 @@ namespace {
             // and informative check that all params are laid out the way we think they are.  If include_bias is false,
             // I'd rather keep full cur_offset checks rather than save some CPU overhead by skipping the cudnn_method =
             // cudnnGetRNNLinLayerBiasParams iteration.
-            if (include_bias ||
 #ifndef USE_CUDNN_RNN_V8_API
-                    cudnn_method != cudnnGetRNNLinLayerBiasParams) {
+            if (include_bias || cudnn_method != cudnnGetRNNLinLayerBiasParams) {
 #else
-                    cudnn_method) {
+            if (include_bias || cudnn_method) {
 #endif
               // Generate a new parameter tensor which is a view into the weight_buf.
               std::initializer_list<int64_t> size = {

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -111,7 +111,7 @@ namespace {
   // RNNDescriptor
 
   struct RNNDescriptorParams {
-#if defined(USE_CUDNN_RNN_V8_API)
+#ifdef USE_CUDNN_RNN_V8_API
     int64_t input_size;
     bool packed;
 #endif
@@ -166,7 +166,7 @@ namespace {
     void set(int64_t mode, int64_t input_size, bool packed, int64_t hidden_size, int64_t proj_size, int64_t num_layers, bool bidirectional, cudnnDataType_t datatype, cudnnDataType_t input_datatype) {
 #endif
       this->set_mode(mode);
-#if defined(USE_CUDNN_RNN_V8_API)
+#ifdef USE_CUDNN_RNN_V8_API
       this->input_size = input_size;
       this->packed = packed;
 #endif
@@ -536,7 +536,7 @@ namespace {
 #endif
           &nb_dims,
           filter_dim_a
-#if defined(USE_CUDNN_RNN_V8_API)
+#ifdef USE_CUDNN_RNN_V8_API
           ,stride_dim_a
 #endif
           ));
@@ -670,7 +670,7 @@ namespace {
 #endif
                 &nb_dims,
                 filter_dim_a
-#if defined(USE_CUDNN_RNN_V8_API)
+#ifdef USE_CUDNN_RNN_V8_API
                 ,stride_dim_a
 #endif
                 ));
@@ -1089,7 +1089,7 @@ copy_weights_to_flat_buf_views(
   RNNDescriptorParams rnn;
   rnn.set(
       mode,
-#if defined(USE_CUDNN_RNN_V8_API)
+#ifdef USE_CUDNN_RNN_V8_API
       input_size,
       false, // eqy: bogus as we do not know if the input is packed here
          // but it should not affect the weights (what are are interested in)
@@ -1378,7 +1378,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
           reserve.size(0), reserve.mutable_data_ptr()));
 #endif
   } else { // inference
-#if defined(USE_CUDNN_RNN_V8_API)
+#ifdef USE_CUDNN_RNN_V8_API
     AT_CUDNN_CHECK(cudnnGetRNNTempSpaceSizes(
           handle,
           descs.rnn_desc.desc(),

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -617,7 +617,7 @@ namespace {
                 &matrix_pointer
                 ));
 #else
-          void *unused_pointer;
+          void *unused_pointer = nullptr;
           TensorDescriptor unused_desc;
           TensorDescriptor lin_layer_mat_desc;
           for (int stateless = 0; stateless < 100; stateless++) {

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -111,7 +111,7 @@ namespace {
   // RNNDescriptor
 
   struct RNNDescriptorParams {
-#if USE_CUDNN_RNN_V8_API
+#if defined(USE_CUDNN_RNN_V8_API)
     int64_t input_size;
     bool packed;
 #endif
@@ -160,13 +160,13 @@ namespace {
       this->algo = algo;
     }
 
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
     void set(int64_t mode, int64_t hidden_size, int64_t proj_size, int64_t num_layers, bool bidirectional, cudnnDataType_t datatype, cudnnDataType_t input_datatype) {
 #else
     void set(int64_t mode, int64_t input_size, bool packed, int64_t hidden_size, int64_t proj_size, int64_t num_layers, bool bidirectional, cudnnDataType_t datatype, cudnnDataType_t input_datatype) {
 #endif
       this->set_mode(mode);
-#if USE_CUDNN_RNN_V8_API
+#if defined(USE_CUDNN_RNN_V8_API)
       this->input_size = input_size;
       this->packed = packed;
 #endif
@@ -180,7 +180,7 @@ namespace {
 
     RNNDescriptor descriptor(cudnnHandle_t handle, DropoutDescriptor&& dropout_desc) const {
       RNNDescriptor rnn_desc;
- #if !USE_CUDNN_RNN_V8_API
+ #ifndef USE_CUDNN_RNN_V8_API
       rnn_desc.set(handle, hidden_size, proj_size, num_layers, std::move(dropout_desc), input_mode, bidirectional, mode, datatype, input_datatype, algo, at::globalContext().allowTF32CuDNN());
  #else
       rnn_desc.set(handle, input_size, packed, hidden_size, proj_size, num_layers, std::move(dropout_desc), input_mode, bidirectional, mode, datatype, input_datatype, algo, at::globalContext().allowTF32CuDNN());
@@ -204,7 +204,7 @@ namespace {
   };
 
   // TensorDescriptor list
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
   std::vector<TensorDescriptor> rnn_descriptor_sequence(const Tensor& tensor, IntArrayRef batch_sizes) {
     std::vector<TensorDescriptor> descriptors(batch_sizes.size());
     size_t i = 0;
@@ -361,7 +361,7 @@ namespace {
         batch_sizes_sum = -1; // something bogus in case we access it
       }
     }
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
     // TODO: check x for consistency with input_size?
     std::vector<TensorDescriptor> descriptors(Tensor x) const {
       auto is_input_packed = batch_sizes.size() != 0;
@@ -396,7 +396,7 @@ namespace {
     RNNDescriptor rnn_desc;
     // NB: this won't actually lay out the tensor descriptor pointers
     // in the right way, so you'll have to preprocess them
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
     std::vector<TensorDescriptor> x_descs;
     std::vector<TensorDescriptor> y_descs;
 #else
@@ -430,7 +430,7 @@ namespace {
       }
       return r;
     }
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
     std::vector<cudnnTensorDescriptor_t> get_x_descs() {
       return get_descs(x_descs);
     }
@@ -442,12 +442,12 @@ namespace {
   };
 
   int64_t get_num_weights(cudnnHandle_t handle, const RNNDescriptor& rnn_desc,
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
                           const TensorDescriptor& x_desc,
 #endif
                           cudnnDataType_t datatype) {
     size_t weight_size;
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
     AT_CUDNN_CHECK(cudnnGetRNNParamsSize(handle, rnn_desc.desc(), x_desc.desc(), &weight_size, datatype));
 #else
     AT_CUDNN_CHECK(cudnnGetRNNWeightSpaceSize(handle, rnn_desc.desc(), &weight_size));
@@ -475,7 +475,7 @@ namespace {
   void add_projection_weights(
         cudnnHandle_t handle,
         const RNNDescriptor& rnn_desc,
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
         const TensorDescriptor& x_desc,
         const FilterDescriptor& w_desc,
 #endif
@@ -486,7 +486,7 @@ namespace {
     void* matrix_pointer = nullptr;
     // assuming it's LSTM which has 8 "linear layers" (i.e. 4 weights and 4 biases)
     int64_t linear_id = 8;
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
     FilterDescriptor lin_layer_mat_desc;
     AT_CUDNN_CHECK(cudnnGetRNNLinLayerMatrixParams(
         /*handle=*/handle,
@@ -514,7 +514,7 @@ namespace {
 #endif
 
     cudnnDataType_t data_type;
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
     cudnnTensorFormat_t format;
 #else
     int stride_dim_a[5];
@@ -523,7 +523,7 @@ namespace {
     constexpr int min_dim = 3;
     int filter_dim_a[min_dim];
     AT_CUDNN_CHECK(
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
       cudnnGetFilterNdDescriptor(
 #else
       cudnnGetTensorNdDescriptor(
@@ -531,12 +531,12 @@ namespace {
           lin_layer_mat_desc.desc(),
           min_dim,
           &data_type,
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
           &format,
 #endif
           &nb_dims,
           filter_dim_a
-#if USE_CUDNN_RNN_V8_API
+#if defined(USE_CUDNN_RNN_V8_API)
           ,stride_dim_a
 #endif
           ));
@@ -578,14 +578,14 @@ namespace {
       cudnnHandle_t handle,
       const RNNDescriptorParams& rnn,
       const RNNDescriptor& rnn_desc,
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
       const TensorDescriptor& x_desc,
       const FilterDescriptor& w_desc,
 #endif
       const Tensor& weight_buf,
       bool include_bias=true
   ) {
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
     auto cudnn_methods = { cudnnGetRNNLinLayerMatrixParams, cudnnGetRNNLinLayerBiasParams };
 #else
     auto cudnn_methods = { true, false };
@@ -600,7 +600,7 @@ namespace {
       for (auto cudnn_method : cudnn_methods) {
         for (const auto linear_id : c10::irange(num_linear_layers)) {
           void* matrix_pointer;
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
           FilterDescriptor lin_layer_mat_desc;
           AT_CUDNN_CHECK(cudnn_method(
                 handle,
@@ -648,7 +648,7 @@ namespace {
           }
 #endif
           cudnnDataType_t data_type;
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
           cudnnTensorFormat_t format;
 #else
           int stride_dim_a[5];
@@ -657,7 +657,7 @@ namespace {
           constexpr int min_dim = 3;
           int filter_dim_a[min_dim];
           AT_CUDNN_CHECK(
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
             cudnnGetFilterNdDescriptor(
 #else
             cudnnGetTensorNdDescriptor(
@@ -665,12 +665,12 @@ namespace {
                 lin_layer_mat_desc.desc(),
                 min_dim,
                 &data_type,
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
                 &format,
 #endif
                 &nb_dims,
                 filter_dim_a
-#if USE_CUDNN_RNN_V8_API
+#if defined(USE_CUDNN_RNN_V8_API)
                 ,stride_dim_a
 #endif
                 ));
@@ -693,7 +693,7 @@ namespace {
             // I'd rather keep full cur_offset checks rather than save some CPU overhead by skipping the cudnn_method =
             // cudnnGetRNNLinLayerBiasParams iteration.
             if (include_bias ||
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
                     cudnn_method != cudnnGetRNNLinLayerBiasParams) {
 #else
                     cudnn_method) {
@@ -712,7 +712,7 @@ namespace {
         }
       } // for cudnn_method
       if (rnn.proj_size != 0) {
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
         add_projection_weights(handle, rnn_desc, x_desc, w_desc, weight_buf, layer, params);
 #else
         add_projection_weights(handle, rnn_desc, weight_buf, layer, params);
@@ -736,14 +736,14 @@ namespace {
   std::vector<void*> get_expected_data_ptrs(
         const Tensor& weight_buf, cudnnHandle_t handle, const RNNDescriptorParams& rnn,
         const RNNDescriptor& rnn_desc, const TensorDescriptor& x_desc, cudnnDataType_t datatype) {
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
     FilterDescriptor w_desc;
     w_desc.set(weight_buf, 3);
 #endif
 
     int64_t num_linear_layers = _num_linear_layers(rnn.mode);
     int64_t num_dir_layers = rnn.num_directions() * rnn.num_layers;
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
     const auto cudnn_methods = { cudnnGetRNNLinLayerMatrixParams, cudnnGetRNNLinLayerBiasParams };
 #else
     const auto cudnn_methods = { true, false };
@@ -762,7 +762,7 @@ namespace {
         const std::array<int64_t, 2> linear_offsets = { 0, num_linear_layers / 2 };
         for (int64_t linear_id : linear_offsets) {
           void* matrix_pointer;
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
           FilterDescriptor lin_layer_mat_desc;
           AT_CUDNN_CHECK(cudnn_method(
                 handle,
@@ -814,7 +814,7 @@ namespace {
         // assuming it's LSTM which has 8 "linear layers" (i.e. 4 weights and 4 biases)
         int64_t linear_id = 8;
         void* matrix_pointer;
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
         FilterDescriptor lin_layer_mat_desc;
         AT_CUDNN_CHECK(cudnnGetRNNLinLayerMatrixParams(
               handle,
@@ -1089,7 +1089,7 @@ copy_weights_to_flat_buf_views(
   RNNDescriptorParams rnn;
   rnn.set(
       mode,
-#if USE_CUDNN_RNN_V8_API
+#if defined(USE_CUDNN_RNN_V8_API)
       input_size,
       false, // eqy: bogus as we do not know if the input is packed here
 	     // but it should not affect the weights (what are are interested in)
@@ -1112,14 +1112,14 @@ copy_weights_to_flat_buf_views(
   x_desc.set(flat_buf_datatype, x_geom.sizes(), x_geom.strides(), 5);
 
   auto num_weights =
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
       get_num_weights(handle, rnn_desc, x_desc, flat_buf_datatype);
 #else
       get_num_weights(handle, rnn_desc, flat_buf_datatype);
 #endif
   auto weight_buf = at::zeros(num_weights, flat_buf_options);
 
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
   FilterDescriptor w_desc;
   w_desc.set(weight_buf, 3);
 # endif
@@ -1128,7 +1128,7 @@ copy_weights_to_flat_buf_views(
   std::vector<Tensor> params_arr;
   size_t params_stride0;
   std::tie(params_arr, params_stride0) = get_parameters(
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
       handle, rnn, rnn_desc, x_desc, w_desc, weight_buf, include_bias);
 #else
       handle, rnn, rnn_desc, weight_buf, include_bias);
@@ -1226,7 +1226,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
   }
   RNNParams fn;
   auto datatype = getCudnnDataType(input);
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
   fn.rnn.set(fn_mode, fn_hidden_size, fn_proj_size, fn_num_layers, fn_bidirectional, promote_rnn_math_type(datatype), datatype);
 #else
   auto input_size = input_r.size(-1);
@@ -1274,23 +1274,23 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
   fn.rnn.set_algo(algo);
   RNNDescriptors descs(fn, handle, x, y, hx, cx);
 
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
   FilterDescriptor w_desc;
 #endif
   if (!weight_buf.defined()) {
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
     auto num_weights = get_num_weights(handle, descs.rnn_desc, descs.x_descs[0], datatype);
 #else
     auto num_weights = get_num_weights(handle, descs.rnn_desc, datatype);
 #endif
     weight_buf = at::empty(num_weights, x.options());
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
     w_desc.set(weight_buf, 3);
 #endif
     weight_buf.zero_();
     std::vector<Tensor> params;
     size_t params_stride0;
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
     std::tie(params, params_stride0) = get_parameters(handle, fn.rnn, descs.rnn_desc, descs.x_descs[0], w_desc, weight_buf);
 #else
     std::tie(params, params_stride0) = get_parameters(handle, fn.rnn, descs.rnn_desc, weight_buf);
@@ -1298,7 +1298,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
     _copyParams(MatrixRef<Tensor>{weight, static_cast<size_t>(weight_stride0)},
                 MatrixRef<Tensor>{params, params_stride0});
   } else {
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
     w_desc.set(weight_buf, 3);
 #endif
   }
@@ -1306,14 +1306,14 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
   TORCH_CHECK(!cx.defined() || cx.sizes().equals(cell_size),
           "Expected cell size ", IntArrayRef{cell_size}, ", got ", cx.sizes());
   size_t workspace_size;
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
   auto x_descs_arr = descs.get_x_descs();
   auto y_descs_arr = descs.get_y_descs();
 #else
   auto& x_descs_arr = descs.x_descs;
   auto& y_descs_arr = descs.y_descs;
 #endif
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
   AT_CUDNN_CHECK(cudnnGetRNNWorkspaceSize(
         handle,
         descs.rnn_desc.desc(),
@@ -1328,7 +1328,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
   // this information.  Use 'train' as a proxy.
   if (fn_train) {
     size_t reserve_size;
- #if !USE_CUDNN_RNN_V8_API
+ #ifndef USE_CUDNN_RNN_V8_API
     AT_CUDNN_CHECK(cudnnGetRNNTrainingReserveSize(
           handle,
           descs.rnn_desc.desc(),
@@ -1348,7 +1348,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
 #endif
     workspace = at::empty(workspace_size, input.options().dtype(kByte));
     reserve = at::empty(reserve_size, input.options().dtype(kByte));
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
     AT_CUDNN_CHECK(cudnnRNNForwardTraining(
           handle,
           descs.rnn_desc.desc(),
@@ -1378,7 +1378,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
           reserve.size(0), reserve.mutable_data_ptr()));
 #endif
   } else { // inference
-#if USE_CUDNN_RNN_V8_API
+#if defined(USE_CUDNN_RNN_V8_API)
     AT_CUDNN_CHECK(cudnnGetRNNTempSpaceSizes(
           handle,
           descs.rnn_desc.desc(),
@@ -1390,7 +1390,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
 #endif
     workspace = at::empty(workspace_size, input.options().dtype(kByte));
     reserve = at::empty({0}, input.options().dtype(kByte));
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
     AT_CUDNN_CHECK(cudnnRNNForwardInference(
           handle,
           descs.rnn_desc.desc(),
@@ -1444,7 +1444,7 @@ std::tuple<Tensor, Tensor, Tensor> _cudnn_rnn_backward_input(
 
   RNNParams fn;
   auto datatype = getCudnnDataType(input);
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
   fn.rnn.set(fn_mode, fn_hidden_size, fn_proj_size, fn_num_layers, fn_bidirectional, promote_rnn_math_type(datatype), datatype);
 #else
   auto cudnn_input_size = input_r.size(-1);
@@ -1514,13 +1514,13 @@ std::tuple<Tensor, Tensor, Tensor> _cudnn_rnn_backward_input(
   fn.rnn.set_algo(algo);
   RNNDescriptors descs(fn, handle, x, y, hx, cx);
 
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
   FilterDescriptor w_desc;
   w_desc.set(weight_buf, 3);
 #endif
 
   size_t workspace_size;
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
   auto x_descs_arr = descs.get_x_descs();
   auto y_descs_arr = descs.get_y_descs();
   AT_CUDNN_CHECK(cudnnGetRNNWorkspaceSize(
@@ -1544,7 +1544,7 @@ std::tuple<Tensor, Tensor, Tensor> _cudnn_rnn_backward_input(
 #endif
   // TODO: put this in the correct device???
   Tensor workspace = at::empty(workspace_size, input.options().dtype(kByte));
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
   AT_CUDNN_CHECK(cudnnRNNBackwardData(
         handle,
         descs.rnn_desc.desc(),
@@ -1606,7 +1606,7 @@ std::vector<Tensor> _cudnn_rnn_backward_weight(
 
   RNNParams fn;
   auto datatype = getCudnnDataType(input);
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
   fn.rnn.set(fn_mode, fn_hidden_size, fn_proj_size, fn_num_layers, fn_bidirectional, promote_rnn_math_type(datatype), datatype);
 #else
   auto cudnn_input_size = input_r.size(-1);
@@ -1656,13 +1656,13 @@ std::vector<Tensor> _cudnn_rnn_backward_weight(
   fn.rnn.set_algo(algo);
   RNNDescriptors descs(fn, handle, x, y, hx, cx);
 
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
   FilterDescriptor w_desc;
   w_desc.set(weight_buf, 3);
 #endif
 
   size_t workspace_size;
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
   auto x_descs_arr = descs.get_x_descs();
   auto y_descs_arr = descs.get_y_descs();
   AT_CUDNN_CHECK(cudnnGetRNNWorkspaceSize(
@@ -1685,7 +1685,7 @@ std::vector<Tensor> _cudnn_rnn_backward_weight(
         ));
 #endif
   Tensor workspace = at::empty(workspace_size, input.options().dtype(kByte));
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
   AT_CUDNN_CHECK(cudnnRNNBackwardWeights(
         handle,
         descs.rnn_desc.desc(),
@@ -1714,7 +1714,7 @@ std::vector<Tensor> _cudnn_rnn_backward_weight(
 
   std::vector<Tensor> grad_params_arr;
   size_t grad_params_stride0;
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
   std::tie(grad_params_arr, grad_params_stride0) = get_parameters(handle, fn.rnn, descs.rnn_desc, descs.x_descs[0], w_desc, dw);
 #else
   std::tie(grad_params_arr, grad_params_stride0) = get_parameters(handle, fn.rnn, descs.rnn_desc, dw);
@@ -1959,7 +1959,7 @@ Tensor try_get_weight_buf(
   // box handling for dynamic shapes, we could also hypothetically infer out
   // the relationships
   RNNDescriptorParams rnn;
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
   rnn.set(mode, hidden_size.guard_int(__FILE__, __LINE__), proj_size.guard_int(__FILE__, __LINE__), num_layers, bidirectional, promote_rnn_math_type(datatype), datatype);
 #else
   auto cudnn_input_size = input.size(-1);
@@ -1976,7 +1976,7 @@ Tensor try_get_weight_buf(
   // for us to run it with input of the same datatype?"
   x_desc.set(datatype, x_geom.sizes(), x_geom.strides(), 5);
 
-#if !USE_CUDNN_RNN_V8_API
+#ifndef USE_CUDNN_RNN_V8_API
   auto num_params = get_num_weights(handle, rnn_desc, x_desc, datatype);
 #else
   auto num_params = get_num_weights(handle, rnn_desc, datatype);

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -522,24 +522,27 @@ namespace {
     int nb_dims;
     constexpr int min_dim = 3;
     int filter_dim_a[min_dim];
+#ifndef USE_CUDNN_RNN_V8_API
     AT_CUDNN_CHECK(
-//#ifndef USE_CUDNN_RNN_V8_API
       cudnnGetFilterNdDescriptor(
-//#else
-//      cudnnGetTensorNdDescriptor(
-//#endif
           lin_layer_mat_desc.desc(),
           min_dim,
           &data_type,
-//#ifndef USE_CUDNN_RNN_V8_API
           &format,
-//#endif
           &nb_dims,
           filter_dim_a
-//#ifdef USE_CUDNN_RNN_V8_API
-//          ,stride_dim_a
-//#endif
           ));
+#else
+    AT_CUDNN_CHECK(
+      cudnnGetTensorNdDescriptor(
+          lin_layer_mat_desc.desc(),
+          min_dim,
+          &data_type,
+          &nb_dims,
+          filter_dim_a,
+          stride_dim_a
+          ));
+#endif
 
     TORCH_INTERNAL_ASSERT(nb_dims <= min_dim, "nb_dims = ", nb_dims, "; min_dim  = ", min_dim);
     auto elem_size = dataSize(getCudnnDataType(weight_buf));
@@ -656,24 +659,27 @@ namespace {
           int nb_dims;
           constexpr int min_dim = 3;
           int filter_dim_a[min_dim];
+#ifndef USE_CUDNN_RNN_V8_API
           AT_CUDNN_CHECK(
-//#ifndef USE_CUDNN_RNN_V8_API
             cudnnGetFilterNdDescriptor(
-//#else
-//            cudnnGetTensorNdDescriptor(
-//#endif
                 lin_layer_mat_desc.desc(),
                 min_dim,
                 &data_type,
-//#ifndef USE_CUDNN_RNN_V8_API
                 &format,
-//#endif
                 &nb_dims,
                 filter_dim_a
-//#ifdef USE_CUDNN_RNN_V8_API
-//                ,stride_dim_a
-//#endif
                 ));
+#else
+          AT_CUDNN_CHECK(
+            cudnnGetTensorNdDescriptor(
+                lin_layer_mat_desc.desc(),
+                min_dim,
+                &data_type,
+                &nb_dims,
+                filter_dim_a,
+                stride_dim_a
+                ));
+#endif
 
           TORCH_INTERNAL_ASSERT(nb_dims <= min_dim, "nb_dims = ", nb_dims, "; min_dim  = ", min_dim);
           auto elem_size = dataSize(getCudnnDataType(weight_buf));

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -228,7 +228,7 @@ namespace {
     return descriptors;
   }
 #else
-  auto rnn_descriptor_sequence(const Tensor& tensor, const int batch_size, IntArrayRef batch_sizes, const int seq_len, const int vector_size) { // packed case
+  auto rnn_descriptor_sequence(const Tensor& tensor, uint32_t batch_size, const IntArrayRef batch_sizes, uint32_t seq_len, uint32_t vector_size) { // packed case
     RNNDataDescriptor r;
     std::vector<int> seqLengthArray(batch_size, 1);
     // cuDNN wants the sequence lenghts for a packed batch as if they
@@ -251,12 +251,12 @@ namespace {
     return r;
   }
 
-  auto rnn_descriptor(const Tensor& tensor, const int batch_size, const int seq_len, const int vector_size) {
+  auto rnn_descriptor(const Tensor& tensor, uint32_t batch_size, uint32_t seq_len, uint32_t vector_size) {
     RNNDataDescriptor r;
     // NB: Looks like even if batch_first is true here we always want SEQ_MAJOR_UNPACKED, because the input
     // appears to be transposed if it is barch-major
     const auto layout = CUDNN_RNN_DATA_LAYOUT_SEQ_MAJOR_UNPACKED;
-    std::vector<in32_t> seqLengthArray(batch_size, seq_len);
+    std::vector<int32_t> seqLengthArray(batch_size, seq_len);
     r.set(tensor, layout, seq_len, batch_size, vector_size, seqLengthArray.data());
     return r;
   }

--- a/aten/src/ATen/native/cudnn/RNNUtils.h
+++ b/aten/src/ATen/native/cudnn/RNNUtils.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <ATen/cudnn/cudnn-wrapper.h>
 #include <ATen/cudnn/Descriptors.h>
 #include <ATen/cudnn/Types.h>


### PR DESCRIPTION
The cuDNN RNNv6 API has been deprecated and support will be dropped in a recent release; this PR migrates to the newer API to support newer cuDNN versions that would otherwise break the build.

Note that it may not be tested yet in upstream CI if the upstream CI cuDNN version is less than 8.9.7.

CC @ptrblck @malfet 

cc @csarofeen @ptrblck @xwang233 @zou3519 @mikaylagawarecki