### PR TITLE
Remove memory_format check for native_group_norm_backward

### DIFF
--- a/aten/src/ATen/native/group_norm.cpp
+++ b/aten/src/ATen/native/group_norm.cpp
@@ -118,9 +118,6 @@ std::tuple<Tensor, Tensor, Tensor> native_group_norm_backward(
       at::borrow_from_optional_tensor(gamma_opt);
   const Tensor& gamma = *gamma_maybe_owned;
   TORCH_CHECK(
-      X.suggest_memory_format() == dY.suggest_memory_format(),
-      "Expected memory formats of X and dY are same.");
-  TORCH_CHECK(
       X.scalar_type() == dY.scalar_type(),
       "Expected scalar types of X and dY are same.");
   bool mixed_type = is_mixed_type(X, mean, rstd);


### PR DESCRIPTION
To fix https://github.com/pytorch/pytorch/issues/115940.
Remove memory_format check for native_group_norm_backward.
