### PR TITLE
[Inductor] Avoid duplicated NodeUser in name_to_users

### DIFF
--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1372,9 +1372,18 @@ class Scheduler:
             return reachable_names
 
         def add_user(used_by_name, user_node, can_inplace=False, is_weak=False):
-            name_to_users[rename(used_by_name)].append(
-                NodeUser(user_node, can_inplace, is_weak)
-            )
+            if not any(
+                (
+                    _node.node == user_node
+                    and _node.can_inplace == can_inplace
+                    and _node.is_weak == is_weak
+                )
+                for _node in name_to_users[rename(used_by_name)]
+            ):
+                # Only create and push a NodeUser to name_to_users when it's not in name_to_users
+                name_to_users[rename(used_by_name)].append(
+                    NodeUser(user_node, can_inplace, is_weak)
+                )
 
         unbacked_symbol_to_origin_node = {}
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #115613
* #115153
* __->__ #115723
* #115329

**Summary**
`Resnet152` has 50 `Conv-Add` patterns which can be lowered into `ConvolutionBinaryInplace`. https://github.com/pytorch/pytorch/blob/cc28f61fa31029466153bacc2f42a05ccdf84d45/torch/_inductor/ir.py#L5268
We enable this optimization in https://github.com/pytorch/pytorch/pull/115153.
However, we found `compute_dependencies` inside scheduler is extremally slow after we enabling this optimization which due to lots of duplicated `NodeUser` in `name_to_users`. Enable this PR to remove duplicated `NodeUser` in `name_to_users`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler