### PR TITLE
[nccl-pg] Store PG global rank information in tracing logs

### DIFF
--- a/torch/csrc/distributed/c10d/ParamCommsUtils.cpp
+++ b/torch/csrc/distributed/c10d/ParamCommsUtils.cpp
@@ -15,6 +15,8 @@ ParamCommsDebugInfo::ParamCommsDebugInfo(
     at::ScalarType dType,
     std::vector<int64_t> inSplitSizes,
     std::vector<int64_t> outSplitSizes,
+    int globalRankStart,
+    int globalRankStride,
     int worldSize)
     : rank_(rank),
       worldSize_(worldSize),
@@ -23,6 +25,8 @@ ParamCommsDebugInfo::ParamCommsDebugInfo(
       outMessageNelems_(outNelems),
       dType_(dType),
       inputSplitSizes_(std::move(inSplitSizes)),
-      outputSplitSizes_(std::move(outSplitSizes)) {}
+      outputSplitSizes_(std::move(outSplitSizes)),
+      globalRankStart_(globalRankStart),
+      globalRankStride_(globalRankStride) {}
 
 } // namespace torch

--- a/torch/csrc/distributed/c10d/ParamCommsUtils.hpp
+++ b/torch/csrc/distributed/c10d/ParamCommsUtils.hpp
@@ -20,6 +20,8 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
       at::ScalarType dType,
       std::vector<int64_t> inSplitSizes,
       std::vector<int64_t> outSplitSizes,
+      int globalRankStart,
+      int globalRankStride,
       int worldSize);
 
   ~ParamCommsDebugInfo() override = default;
@@ -30,6 +32,14 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
 
   int getWorldSize() const {
     return worldSize_;
+  }
+
+  int getGlobalRankStart() const {
+    return globalRankStart_;
+  }
+
+  int getGlobalRankStride() const {
+    return globalRankStride_;
   }
 
   const std::string getColumnName() const {
@@ -65,6 +75,8 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
   at::ScalarType dType_ = at::kByte;
   std::vector<int64_t> inputSplitSizes_;
   std::vector<int64_t> outputSplitSizes_;
+  int globalRankStart_;
+  int globalRankStride_;
 };
 
 #define RECORD_PARAM_COMMS(                                                    \
@@ -77,6 +89,8 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
     dType,                                                                     \
     inSplitSizes,                                                              \
     outSplitSizes,                                                             \
+    globalRankStart,                                                           \
+    globalRankStride,                                                          \
     worldSize)                                                                 \
   auto paramCommsInfo = std::make_shared<torch::ParamCommsDebugInfo>(          \
       rank,                                                                    \
@@ -86,6 +100,8 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
       dType,                                                                   \
       inSplitSizes,                                                            \
       outSplitSizes,                                                           \
+      globalRankStart,                                                         \
+      globalRankStride,                                                        \
       worldSize);                                                              \
   c10::DebugInfoGuard g(c10::DebugInfoKind::PARAM_COMMS_INFO, paramCommsInfo); \
   std::initializer_list<const c10::IValue> paramList = {                       \
@@ -95,6 +111,8 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
       colName,                                                                 \
       inSplitSizes,                                                            \
       outSplitSizes,                                                           \
+      globalRankStart,                                                         \
+      globalRankStride,                                                        \
       worldSize};                                                              \
   c10::ArrayRef<const c10::IValue> paramInputs(paramList);                     \
   RECORD_FUNCTION(at::kParamCommsCallName, paramInputs);
@@ -111,6 +129,8 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
     dType,                                                                     \
     inSplitSizes,                                                              \
     outSplitSizes,                                                             \
+    globalRankStart,                                                           \
+    globalRankStride,                                                          \
     worldSize)                                                                 \
   auto paramCommsInfo = std::make_shared<torch::ParamCommsDebugInfo>(          \
       rank,                                                                    \
@@ -120,6 +140,8 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
       dType,                                                                   \
       inSplitSizes,                                                            \
       outSplitSizes,                                                           \
+      globalRankStart,                                                         \
+      globalRankStride,                                                        \
       worldSize);                                                              \
   c10::DebugInfoGuard g(c10::DebugInfoKind::PARAM_COMMS_INFO, paramCommsInfo); \
   std::initializer_list<const c10::IValue> paramList = {                       \
@@ -130,6 +152,8 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
       colName,                                                                 \
       inSplitSizes,                                                            \
       outSplitSizes,                                                           \
+      globalRankStart,                                                         \
+      globalRankStride,                                                        \
       worldSize};                                                              \
   c10::ArrayRef<const c10::IValue> paramInputs(paramList);                     \
   RECORD_FUNCTION_WITH_INPUTS_OUTPUTS(                                         \

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -590,6 +590,9 @@ class TORCH_API ProcessGroupNCCL : public Backend {
       OpType opType);
 
  private:
+  int globalRankStart;
+  int globalRankStride;
+
   // Helper that encapsulates work shared across all collective communication
   // primitives.  The callbacks have the following signatures:
   //

--- a/torch/csrc/distributed/c10d/UCCTracing.cpp
+++ b/torch/csrc/distributed/c10d/UCCTracing.cpp
@@ -158,6 +158,8 @@ void CommTraceLogger::recordComms(
       dtype,
       curInSplitSizes_,
       curOutSplitSizes_,
+      -1,
+      -1,
       world_size);
 
   ++seqnum;

--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -344,6 +344,8 @@ static constexpr auto kInMsgNelems = "In msg nelems";
 static constexpr auto kOutMsgNelems = "Out msg nelems";
 static constexpr auto kInSplit = "In split size";
 static constexpr auto kOutSplit = "Out split size";
+static constexpr auto kGlobalRankStart = "Global rank start";
+static constexpr auto kGlobalRankStride = "Global rank stride";
 static constexpr auto kGroupSize = "Group size";
 static constexpr int32_t kTruncatLength = 30;
 #endif // USE_C10D
@@ -395,6 +397,10 @@ std::unordered_map<std::string, std::string> saveNcclMeta(
                 outSplitSizes.begin() + kTruncatLength,
                 ", ")));
   }
+  map.emplace(
+      kGlobalRankStart, std::to_string(debugInfo->getGlobalRankStart()));
+  map.emplace(
+      kGlobalRankStride, std::to_string(debugInfo->getGlobalRankStride()));
   map.emplace(kGroupSize, std::to_string(debugInfo->getWorldSize()));
 #endif // USE_C10D
 #endif // USE_DISTRIBUTED


### PR DESCRIPTION
Storing the list of global ranks associated with each PG allows us to correlate traces across different ranks.

Test Plan:

OSS CI


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225