### PR TITLE
[inductor] Added non-integer expr support for floordiv in triton codegen

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1662,6 +1662,26 @@ class CommonTemplate:
                 ),
             )
 
+    def test_floordiv(self):
+        if self.device == "cpu":
+            raise unittest.SkipTest("Fails on CPU")
+
+        def fn_floor_input(a, i):
+            n = (i * 1.234) // 8.234
+            return a + n
+
+        self.common(
+            fn_floor_input, (make_tensor(10, device="cpu", dtype=torch.float32), 33)
+        )
+
+        def fn_int_input(a, i):
+            n = i // 8
+            return a + n
+
+        self.common(
+            fn_int_input, (make_tensor(10, device="cpu", dtype=torch.float32), 33)
+        )
+
     def test_both_scalars(self):
         def fn(a, b):
             return (

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -115,6 +115,15 @@ class TritonPrinter(PythonPrinter):
         assert len(expr.args) == 1
         return f"tl.abs({self._print(expr.args[0])})"
 
+    def _print_FloorDiv(self, expr):
+        if expr.is_integer:
+            return super()._print_FloorDiv(expr)
+
+        x, div = expr.args
+        x = self.paren(self.doprint(x))
+        div = self.paren(self.doprint(div))
+        return f"tl.math.floor({x} / {div})"
+
 
 texpr = TritonPrinter().doprint
 pexpr = PythonPrinter().doprint


### PR DESCRIPTION
Description:
- Added non-integer expr support for floordiv in triton codegen
- Added a test
  - cpp test is skipped as failing and https://github.com/pytorch/pytorch/pull/115647 may fix it

This PR is fixing compilation error with the following code:
```python
import torch

def func(x, a):
    n = (a * 1.234) // 8.234
    y = x + n
    return y

cfunc = torch.compile(func, dynamic=True, fullgraph=True)

device = "cuda"
x = torch.tensor(0, dtype=torch.float32, device=device)
a = 33

out = cfunc(x, a)
expected = func(x, a)
torch.testing.assert_close(out, expected)
```
Error message on Nightly:
```
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 389, in __get_result                                                                           
    raise self._exception                                                                                                                           
torch._dynamo.exc.BackendCompilerFailed: backend='compile_fx_wrapper' raised:                                                                                                                                                
CompilationError: at 7:38:def triton_(in_ptr0, out_ptr0, ks0, xnumel, XBLOCK : tl.constexpr):                                                                                                                                
    xoffset = tl.program_id(0) * XBLOCK                                                                                                                                                                                                                           
    xindex = xoffset + tl.arange(0, XBLOCK)[:]                                                                          
    xmask = xindex < xnumel                                                                                                                                                                                                                                       
    x0 = xindex                                                                                                                                                                                                                                                   
    tmp0 = tl.load(in_ptr0 + (x0), xmask)                                                                                               
    tmp1 = ((1.23400000000000*ks0) // 8.23400000000000)                                                                                         
                                      ^                                                                                                                                                                                                                          
AssertionError() 
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler