### PR TITLE
[codemod][lowrisk] Remove extra semi colon from caffe2/c10/util/Float8_e5m2.h

### DIFF
--- a/c10/util/Float8_e5m2.h
+++ b/c10/util/Float8_e5m2.h
@@ -129,7 +129,7 @@ struct alignas(1) Float8_e5m2 {
 
   Float8_e5m2() = default;
 
-  constexpr C10_HOST_DEVICE Float8_e5m2(uint8_t bits, from_bits_t) : x(bits){};
+  constexpr C10_HOST_DEVICE Float8_e5m2(uint8_t bits, from_bits_t) : x(bits) {}
   inline C10_HOST_DEVICE Float8_e5m2(float value);
   inline C10_HOST_DEVICE operator float() const;
   inline C10_HOST_DEVICE bool isnan() const;

--- a/c10/util/Float8_e5m2fnuz.h
+++ b/c10/util/Float8_e5m2fnuz.h
@@ -139,7 +139,7 @@ struct alignas(1) Float8_e5m2fnuz {
   Float8_e5m2fnuz() = default;
 
   constexpr C10_HOST_DEVICE Float8_e5m2fnuz(uint8_t bits, from_bits_t)
-      : x(bits){};
+      : x(bits) {}
   inline C10_HOST_DEVICE Float8_e5m2fnuz(float value);
   inline C10_HOST_DEVICE operator float() const;
   inline C10_HOST_DEVICE bool isnan() const;

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -341,7 +341,7 @@ struct alignas(2) Half {
   Half() = default;
 #endif
 
-  constexpr C10_HOST_DEVICE Half(unsigned short bits, from_bits_t) : x(bits){};
+  constexpr C10_HOST_DEVICE Half(unsigned short bits, from_bits_t) : x(bits) {}
   inline C10_HOST_DEVICE Half(float value);
   inline C10_HOST_DEVICE operator float() const;
 

--- a/c10/util/complex_math.h
+++ b/c10/util/complex_math.h
@@ -55,7 +55,7 @@ C10_API c10::complex<float> sqrt(const c10::complex<float>& in);
 C10_API c10::complex<double> sqrt(const c10::complex<double>& in);
 C10_API c10::complex<float> acos(const c10::complex<float>& in);
 C10_API c10::complex<double> acos(const c10::complex<double>& in);
-}; // namespace _detail
+} // namespace _detail
 #endif
 
 template <typename T>

--- a/caffe2/utils/conversions.h
+++ b/caffe2/utils/conversions.h
@@ -28,8 +28,8 @@ CONVERSIONS_DECL OUT Get(IN x) {
   return static_cast<OUT>(x);
 }
 
-}; // namespace convert
+} // namespace convert
 
-}; // namespace caffe2
+} // namespace caffe2
 
 #undef CONVERSIONS_DECL


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Test Plan: Sandcastle

Reviewed By: palmje

Differential Revision: D51995078


