### PR TITLE
[dynamo] Log shape_env_guard_count separately from guard_count

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -630,6 +630,7 @@ def _compile(
                     and frame_key in frame_phase_timing
                 ):
                     guard_count = len(output.guards)
+                    shape_env_guard_count = len(output.shape_env.guards)
                     graph_op_count = output.count_calls()
                     graph_node_count = len(output.graph.nodes)
                     graph_input_count = len(output.placeholders)
@@ -647,6 +648,7 @@ def _compile(
                     }
                 else:
                     guard_count = None
+                    shape_env_guard_count = None
                     graph_op_count = None
                     graph_node_count = None
                     graph_input_count = None
@@ -662,6 +664,7 @@ def _compile(
                     cache_size.num_cache_entries_with_same_id_matched_objs,
                     cache_size.num_cache_entries,
                     guard_count,
+                    shape_env_guard_count,
                     graph_op_count,
                     graph_node_count,
                     graph_input_count,

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -586,6 +586,7 @@ class CompilationMetrics:
     cache_size: int
     accumulated_cache_size: int
     guard_count: Optional[int]
+    shape_env_guard_count: Optional[int]
     graph_op_count: Optional[int]
     graph_node_count: Optional[int]
     graph_input_count: Optional[int]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #115793
* #115788
* __->__ #115776

guard_count counts all the shape_env guards as a single guard; log the shape_env_guard_count separately so those metrics can be used.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng