### PR TITLE
Fix buck OSS build after #115570

### DIFF
--- a/tools/build_defs/buck_helpers.bzl
+++ b/tools/build_defs/buck_helpers.bzl
@@ -14,12 +14,19 @@ IGNORED_ATTRIBUTES = [
     "contacts",
 ]
 
+# TODO (huydhn): PyTorch OSS is still built with old buck not buck2, and there
+# aren't available options https://buck.build/rule/cxx_library.html. This can
+# be removed when we migrate OSS to buck2
+ONLY_AVAILABLE_IN_BUCK2 = [
+    "supports_shlib_interfaces",
+]
+
 def filter_attributes(kwgs):
     keys = list(kwgs.keys())
 
     # drop unncessary attributes
     for key in keys:
-        if key in IGNORED_ATTRIBUTES:
+        if key in IGNORED_ATTRIBUTES or key in ONLY_AVAILABLE_IN_BUCK2:
             kwgs.pop(key)
         else:
             for invalid_prefix in IGNORED_ATTRIBUTE_PREFIX:


### PR DESCRIPTION
From #115570, `supports_shlib_interfaces` is only available in https://buck2.build/docs/api/rules/ not buck https://buck.build/rule/cxx_library.html.  The best way to fix this is probably to migrate OSS CI to buck2, so this is a temporary workaround because the fix from #115570 is only needed internally anyway