### PR TITLE
[skylight][caffe2][buck2][ondemand] Disable avx2 temporary for OnDemand x86_64 builds

### DIFF
--- a/c2_defs.bzl
+++ b/c2_defs.bzl
@@ -9,6 +9,7 @@ load("@fbsource//tools/build_defs:fbsource_utils.bzl", "is_arvr_mode", "is_fbcod
 load("@fbsource//tools/build_defs:platform_defs.bzl", "ANDROID", "APPLE", "CXX", "IOS", "MACOSX", "WINDOWS")
 load("@fbsource//tools/build_defs/apple:build_mode_defs.bzl", "is_production_build")
 load("@fbsource//tools/build_defs/apple:config_utils_defs.bzl", "STATIC_LIBRARY_IOS_CONFIG", "STATIC_LIBRARY_MAC_CONFIG", "fbobjc_configs")
+load("@fbsource//xplat/caffe2:buckbuild.bzl", "read_bool")
 load("@fbsource//xplat/pfh/Msgr/Mobile/ProductInfra:DEFS.bzl", "Msgr_Mobile_ProductInfra")
 
 def get_c2_expose_op_to_c10():
@@ -326,6 +327,9 @@ def get_c2_aten_cpu_fbobjc_macosx_deps():
         "ovr_config//os:macos-x86_64": ["fbsource//xplat/deeplearning/fbgemm:fbgemm"],
     }) if is_arvr_mode() else []
 
+def build_cpukernel_avx2():
+    return read_bool("caffe2", "build_cpukernel_avx2", not is_arvr_mode())
+
 def get_c2_aten_cpu_fbobjc_macosx_platform_deps():
     return compose_platform_setting_list([
         {
@@ -334,7 +338,7 @@ def get_c2_aten_cpu_fbobjc_macosx_platform_deps():
                 "fbsource//xplat/deeplearning/fbgemm:fbgemmAppleMac",
             ] + ([
                 "fbsource//xplat/caffe2:cpukernel_avx2AppleMac",
-            ] if not is_arvr_mode() else []),
+            ] if build_cpukernel_avx2() else []),
             "os": "macosx",
         },
         {


### PR DESCRIPTION
Summary:
arm64 bianries on Mac needs codesign for execution. While the Jackalope doesn't support codesigning, the OnDemand workflow couldn't support arm64 builds well yet. And we then suggest people to use x86_64 with the OnDemand workflow.

Then since buck2 handles target platforms properly, the `cpukernel_avx2` target is now included in the x86_64 build of Skylight ... while [Apple doesn't support AVX instruction set in Rosetta2](https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment#What-Cant-Be-Translated) - The built x86_64 binary from OnDemand would crash with `EXC_BAD_INSTRUCTION` when running on Apple Silicon Macs with Rosetta2

{F1174425839}
{P904967978}
```
debug map object file "buck-out/v2/gen/fbsource/82f15bd60d86085e/xplat/compphoto/ocean/__ocean_baseAppleMac__/libocean_baseAppleMac.pic.a(Maintenance.cpp.pic.o)" containing debug info does not exist, debug info will not be loaded
debug map object file "buck-out/v2/gen/fbsource/82f15bd60d86085e/xplat/caffe2/__cpukernel_avx2AppleMac__/libcpukernel_avx2AppleMac.pic.a(SortingKernel.cpp.pic.o)" containing debug info does not exist, debug info will not be loaded
```

The proper and better fix is to make the OnDemand workflow to support arm64 codesign (T162550933, Q1 2024), and then we don't need to ask people to build x86_64 and run with Rosetta2.

But for now, to unblock, we add a buck config `caffe2.build_cpukernel_avx2` here to exclude avx2 code when building Skylight in OnDemand. (assuming most of SWE are now using Apple Silicon Macs)

Test Plan:
- Build Skylight with buck1 and buck2 and see it launches good with both buck versions
{F1174429403}

Reviewed By: florihupf

Differential Revision: D52156099


