### PR TITLE
Fix a crash in sparse compressed tensor invariants check when nnz == 0

### DIFF
--- a/aten/src/ATen/native/sparse/ValidateCompressedIndicesCommon.h
+++ b/aten/src/ATen/native/sparse/ValidateCompressedIndicesCommon.h
@@ -335,10 +335,16 @@ void _validate_compressed_sparse_indices_kernel(
                 // NOTE: the implementation below is sync-less, but,
                 // unfortunately, work is not guaranteed to be well-balanced
                 // between different threads.
+                // Note: 5.6 should not be tested when
+                // nnz==0. Fortunately, the code below is no-op when
+                // nnz==0.
                 int64_t idx_offset = 0;
                 // assuming idx contiguity per batch:
-                int64_t tmp = batch_idx * idx_sizes[idx_ndims - 1];
-                for (int i = idx_ndims - 1; i >= 0; i--) {
+                int64_t tmp = batch_idx * nnz;
+                // `nnz == idx_sizes[idx_ndims - 1]` is checked above as `nnz == idx.size(-1)`
+                for (int i = idx_ndims - 1;
+                     i >= 0 && nnz > 0;  // break early when nnz==0
+                     i--) {
                   int64_t div = tmp / idx_sizes[i];
                   idx_offset += (tmp - div * idx_sizes[i]) * idx_strides[i];
                   tmp = div;

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -590,6 +590,11 @@ class TestSparseCompressed(TestCase):
                     layout
                 )
 
+            compressed_indices = torch.tensor([0, 0], dtype=index_dtype)
+            plain_indices = torch.tensor([], dtype=index_dtype)
+            torch._validate_compressed_sparse_indices(layout in {torch.sparse_csr, torch.sparse_bsr},
+                                                      compressed_indices, plain_indices, 1, 1, 0)
+
     def _generate_invalid_input(self, layout, device):
         from functools import partial
 


### PR DESCRIPTION
Fixes python crash example from https://github.com/pytorch/pytorch/issues/115755

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #115826
* __->__ #115825



cc @alexsamardzic @nikitaved @cpuhrsch @amjames @bhosmer @jcaip