### PR TITLE
Fixed some failing inductor tests with exact_dtype=True

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -2708,8 +2708,7 @@ class CPUReproTests(TestCase):
         m = M().eval()
         with torch.no_grad():
             metrics.reset()
-            # FIXME: returns the wrong dtype
-            self.common(m, (idx, x), exact_dtype=False)
+            self.common(m, (idx, x))
             assert metrics.generated_cpp_vec_kernel_count == 1
 
         # we are doing direct load/store, make sure we do not generate

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1645,7 +1645,8 @@ class CommonTemplate:
                 a // b,
             )
 
-        self.common(fn, (1024, 100))
+        # FIXME: returns the wrong dtype
+        self.common(fn, (1024, 100), exact_dtype=False)
 
     def test_div9(self):
         def fn(x):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -279,7 +279,6 @@ def check_model(
     ref_inputs = [clone_preserve_strides(x) for x in example_inputs]
     ref_kwargs = kwargs
     has_lowp_args = False
-    original_lowp_dtype = torch.half
 
     if reference_in_float and exact_dtype:
         # Store expected dtypes so we can check actual result gives the correct types
@@ -297,6 +296,7 @@ def check_model(
         ]
         del eager_result
 
+    orig_model = None
     if reference_in_float:
         # check_lowp is ignored here, it's kept just to be able to call `common` with extra arg
         def upcast_fn(x):
@@ -309,25 +309,19 @@ def check_model(
             else:
                 return x
 
-        def get_original_lowp_dtype(example_inputs):
-            dtypes = [x.dtype for x in example_inputs if isinstance(x, torch.Tensor)]
-            dtype_set = set(dtypes)
-            return dtype_set.pop() if len(dtype_set) == 1 else torch.half
-
         ref_inputs = list(map(upcast_fn, example_inputs))
         ref_kwargs = {k: upcast_fn(v) for k, v in kwargs.items()}
-        if has_lowp_args:
-            original_lowp_dtype = get_original_lowp_dtype(example_inputs)
-            if hasattr(model, "to"):
-                model = model.to(torch.float)
+        if has_lowp_args and hasattr(model, "to"):
+            orig_model = copy.deepcopy(model)
+            model = model.to(torch.float)
 
     torch.manual_seed(0)
 
     correct = model(*ref_inputs, **ref_kwargs)
     # downcast the model back if needed
-    if reference_in_float and has_lowp_args:
-        if hasattr(model, "to"):
-            model = model.to(original_lowp_dtype)
+    if reference_in_float and has_lowp_args and hasattr(model, "to"):
+        assert orig_model is not None
+        model = orig_model
 
     torch._inductor.metrics.reset()
 
@@ -1651,8 +1645,7 @@ class CommonTemplate:
                 a // b,
             )
 
-        # FIXME: returns the wrong dtype
-        self.common(fn, (1024, 100), exact_dtype=False)
+        self.common(fn, (1024, 100))
 
     def test_div9(self):
         def fn(x):


### PR DESCRIPTION
Addresses point 1 from #115742: fixing  CPUReproTest.test_embedding_vec_bf16


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler