### PR TITLE
Configures distributed_checkpoint label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -79,3 +79,7 @@
 - torch/nn/parallel/**
 - test/distributed/**
 - torch/testing/_internal/distributed/**
+
+"module: distributed_checkpoint":
+- torch/distributed/checkpoint/**
+- test/distributed/checkpoint/**


### PR DESCRIPTION
Configures the existing `module: distributed_checkpoint` label