### PR TITLE
[easy] Only start polling GPU utilization after completing warmup request in inference benchmark

### DIFF
--- a/benchmarks/inference/server.py
+++ b/benchmarks/inference/server.py
@@ -127,6 +127,9 @@ class FrontendWorker(mp.Process):
 
         requests_thread.start()
         metrics_thread.start()
+
+        # only start polling GPU utilization after the warmup request is complete
+        self.warmup_event.wait()
         gpu_utilization_thread.start()
 
         requests_thread.join()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #115840
* #115839
* __->__ #115838
* #115837
* #115836
* #115286

