### PR TITLE
Handle -1 in jagged layout NT view ops

### DIFF
--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -124,7 +124,11 @@ def check_ragged_dim_same(
 # match those of the specified size
 def raggedness_matches(nt, size):
     end = nt._ragged_idx + 1
-    return all(ns == s or s == -1 for ns, s in zip(nt._size[:end], size[:end]))
+    nt_ragged = nt._size[:end]
+    size_ragged = size[:end]
+    return len(nt_ragged) == len(size_ragged) and (
+        all(ns == s or s == -1 for ns, s in zip(nt_ragged, size_ragged))
+    )
 
 
 def squeeze_leading_ones(t):

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -124,7 +124,7 @@ def check_ragged_dim_same(
 # match those of the specified size
 def raggedness_matches(nt, size):
     end = nt._ragged_idx + 1
-    return list(nt._size[:end]) == list(size[:end])
+    return all(ns == s or s == -1 for ns, s in zip(nt._size[:end], size[:end]))
 
 
 def squeeze_leading_ones(t):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #115842
* #115192
* #115191
* __->__ #115843
* #115636

Allows for inheriting the ragged and batch dims via -1:
```python
nt.view(-1, -1, D)
nt.expand(B, -1, D)
```