### PR TITLE
Add Dynamo test expected failure mechanism

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1384,12 +1384,11 @@ def skipIfTorchInductor(msg="test doesn't currently work with torchinductor",
     return decorator
 
 
-def unMarkDynamoStrictTest(cls):
+def unMarkDynamoStrictTest(cls=None):
     def decorator(cls):
         assert inspect.isclass(cls)
-        cls_or_func.dynamo_strict = False
-        cls_or_func.dynamo_strict_nopython = nopython
-        return cls_or_func
+        cls.dynamo_strict = False
+        return cls
 
     if cls is None:
         return decorator

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -77,6 +77,7 @@ from torch.nn import (
     ParameterList,
     Sequential,
 )
+from .dynamo_test_failures import dynamo_expected_failures
 from torch.onnx import (
     register_custom_op_symbolic,
     unregister_custom_op_symbolic,
@@ -1381,6 +1382,19 @@ def skipIfTorchInductor(msg="test doesn't currently work with torchinductor",
         return fn
 
     return decorator
+
+
+def unMarkDynamoStrictTest(cls):
+    def decorator(cls):
+        assert inspect.isclass(cls)
+        cls_or_func.dynamo_strict = False
+        cls_or_func.dynamo_strict_nopython = nopython
+        return cls_or_func
+
+    if cls is None:
+        return decorator
+    else:
+        return decorator(cls)
 
 
 def markDynamoStrictTest(cls_or_func=None, nopython=False):
@@ -2694,6 +2708,10 @@ This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0"""
             elif TEST_WITH_TORCHDYNAMO:
                 # TorchDynamo optimize annotation
                 super_run = torch._dynamo.optimize("eager", nopython=nopython)(super_run)
+                key = f"{self.__class__.__name__}.{self._testMethodName}"
+                if key in dynamo_expected_failures:
+                    method = getattr(self, self._testMethodName)
+                    unittest.expectedFailure(self)
 
             super_run(result=result)
 

--- a/torch/testing/_internal/dynamo_test_failures.py
+++ b/torch/testing/_internal/dynamo_test_failures.py
@@ -1,0 +1,5 @@
+# We generate unittest.expectedFailure for all of the following tests
+# when run under PYTORCH_TEST_WITH_DYNAMO=1.
+#
+# This lists exists so we can more easily add large numbers of failing tests,
+dynamo_expected_failures = {}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #115887
* #115885
* #115879
* #115871
* #115870
* #115858
* #115857
* #115856
* #115855
* __->__ #115845

Tests that are added to a list in dynamo_test_failures.py will
automatically be marked as expectedFailure when run with
PYTORCH_TEST_WITH_DYNAMO=1. I'm splitting this PR off on its own so that
I can test various things on top of it.

Also added an unMarkDynamoStrictTest that is not useful until we turn
on strict mode by default.

Test Plan:
- code reading