### PR TITLE
Make input contiguous for DTensor reduce scatter to fix the incorrect numerical values

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -4,12 +4,13 @@ import os
 
 import torch
 import torch.distributed._functional_collectives as funcol
+from torch.distributed._tensor import DTensor
 from torch.distributed._tensor._collective_utils import (
     mesh_all_to_all,
     mesh_broadcast,
     mesh_scatter,
 )
-from torch.distributed._tensor.placement_types import Shard
+from torch.distributed._tensor.placement_types import _Partial, Shard
 from torch.distributed.device_mesh import _mesh_resources, DeviceMesh, init_device_mesh
 
 from torch.distributed.distributed_c10d import (
@@ -453,6 +454,48 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
 
             self.assertEqual(all_gathered_tensor.size(), tensor_to_split.size())
             self.assertEqual(all_gathered_tensor, tensor_to_split)
+
+    @with_comms
+    def test_reduce_scatter_contiguous(self):
+        device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
+        my_rank = device_mesh.get_rank()
+
+        # Init the tensor
+        step = self.world_size * 2
+        total_elem = step**2
+        tensor = torch.arange(0, total_elem).view(step, -1).to(device=self.device_type)
+        tensor = tensor * (my_rank + 1)
+
+        # Get non-contiguous tensor by slicing
+        tensor_to_reduce = tensor[::2, :2]
+        tensor_contiguous = tensor_to_reduce.clone().contiguous()
+
+        # Partial to Shard to trigger reduce_scatter
+        tensor_to_reduce = DTensor.from_local(
+            tensor_to_reduce, device_mesh, [_Partial()]
+        )
+        tensor_contiguous = DTensor.from_local(
+            tensor_contiguous, device_mesh, [_Partial()]
+        )
+        new_tensor = tensor_to_reduce.redistribute(device_mesh, [Shard(0)])
+        new_tensor_contiguous = tensor_contiguous.redistribute(device_mesh, [Shard(0)])
+
+        # The output for contiguous and non-contiguous tensors of the same value
+        # should return the same reducescatter value.
+        new_tensor_local = new_tensor._local_tensor
+        new_tensor_contiguous_local = new_tensor_contiguous._local_tensor
+        self.assertEqual(new_tensor_local, new_tensor_contiguous_local)
+        self.assertEqual(list(new_tensor_local.size()), [1, 2])
+
+        # Check the reduce numerical value
+        sum_base = (1 + self.world_size) * self.world_size / 2
+        first_elem = my_rank * sum_base * step * 2
+        expected_tensor = torch.tensor(
+            [[first_elem, first_elem + sum_base]],
+            dtype=new_tensor_local.dtype,
+            device=self.device_type,
+        )
+        self.assertEqual(new_tensor_local, expected_tensor)
 
     @with_comms
     def test_reduce_scatter_uneven(self):

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -192,6 +192,8 @@ class Shard(Placement):
                 tensor, num_chunks, with_padding=True, contiguous=True
             )
             tensor = torch.cat(scattered_list, dim=self.dim)
+        elif not tensor.is_contiguous():
+            tensor = tensor.contiguous()
 
         output = funcol.reduce_scatter_tensor(
             tensor, reduce_op.name, scatter_dim=self.dim, group=(mesh, mesh_dim)


### PR DESCRIPTION
Summary:
This change is to make the input tensor contiguous for DTensor reduce scatter in the case no padding is needed.

There's no exception thrown during training, but we ran into numerical value correctness issue without the change.

Test Plan:
**CI**
CI test

**WHEN model test**:
- Verified loss for each iteration within the expected range.
- Verified NE on-par with this change with 4B training data.

Differential Revision: D52170822




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225