### PR TITLE
Fixed overflow issue when negating -INT64_MAX SymInt.

### DIFF
--- a/c10/core/SymInt.cpp
+++ b/c10/core/SymInt.cpp
@@ -134,6 +134,13 @@ bool SymInt::expect_size(const char* file, int64_t line) const {
 
 SymInt operator-(const SymInt& s) {
   if (auto ma = s.maybe_as_int()) {
+    if (C10_UNLIKELY(*ma == std::numeric_limits<int64_t>::min())) {
+      TORCH_CHECK(
+          false,
+          "SymInt with value ",
+          *ma,
+          " would overflow when negated. This might be caused by extremely large tensor indices.");
+    }
     return SymInt(-*ma);
   } else {
     return SymInt(s.toSymNodeImplUnowned()->neg());


### PR DESCRIPTION
Fixes #115415.

Adds a check for -INT64_MAX before negating. This is more of a stop-gap solution for the specific problem in the issue mentioned above. 