### PR TITLE
Fix numpy warning when importing torch without numpy installed

### DIFF
--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -17,13 +17,17 @@ __all__ = ['Transformer', 'TransformerEncoder', 'TransformerDecoder', 'Transform
 
 def _generate_square_subsequent_mask(
         sz: int,
-        device: torch.device = torch.device(torch._C._get_default_device()),  # torch.device('cpu'),
-        dtype: torch.dtype = torch.get_default_dtype(),
+        device: Optional[torch.device] = None,
+        dtype: Optional[torch.dtype] = None,
 ) -> Tensor:
     r"""Generate a square causal mask for the sequence.
 
     The masked positions are filled with float('-inf'). Unmasked positions are filled with float(0.0).
     """
+    if device is None:
+        device = torch.device('cpu')
+    if dtype is None:
+        dtype = torch.float32
     return torch.triu(
         torch.full((sz, sz), float('-inf'), dtype=dtype, device=device),
         diagonal=1,
@@ -214,8 +218,8 @@ class Transformer(Module):
     @staticmethod
     def generate_square_subsequent_mask(
             sz: int,
-            device: torch.device = torch.device(torch._C._get_default_device()),  # torch.device('cpu'),
-            dtype: torch.dtype = torch.get_default_dtype(),
+            device: Optional[torch.device] = None,
+            dtype: Optional[torch.dtype] = None,
     ) -> Tensor:
         r"""Generate a square causal mask for the sequence.
 

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -25,7 +25,7 @@ def _generate_square_subsequent_mask(
     The masked positions are filled with float('-inf'). Unmasked positions are filled with float(0.0).
     """
     if device is None:
-        device = torch._C.get_default_device()
+        device = torch._C._get_default_device()
     if dtype is None:
         dtype = torch.get_default_dtype()
     return torch.triu(

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -25,9 +25,9 @@ def _generate_square_subsequent_mask(
     The masked positions are filled with float('-inf'). Unmasked positions are filled with float(0.0).
     """
     if device is None:
-        device = torch.device('cpu')
+        device = torch._C.get_default_device()
     if dtype is None:
-        dtype = torch.float32
+        dtype = torch.get_default_dtype()
     return torch.triu(
         torch.full((sz, sz), float('-inf'), dtype=dtype, device=device),
         diagonal=1,

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -25,9 +25,9 @@ def _generate_square_subsequent_mask(
     The masked positions are filled with float('-inf'). Unmasked positions are filled with float(0.0).
     """
     if device is None:
-        device = torch._C._get_default_device()
+        device = torch.device('cpu')
     if dtype is None:
-        dtype = torch.get_default_dtype()
+        dtype = torch.float32
     return torch.triu(
         torch.full((sz, sz), float('-inf'), dtype=dtype, device=device),
         diagonal=1,


### PR DESCRIPTION
Fixes #115638

I verified locally that with no numpy install the warning no longer occurs

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #115867




cc @albanD @mruberry @jbschlosser @walterddr