### PR TITLE
[Inductor cutlass backend] Fixed workspace resize issue

### DIFF
--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -535,7 +535,9 @@ class GraphLowering(torch.fx.Interpreter):
             return None
         workspace_name = f"workspace_of_{buffer.get_name()}"
         if workspace_name in self.name_to_buffer:
-            return self.name_to_buffer[workspace_name]
+            res = self.name_to_buffer[workspace_name]
+            res.resize(workspace_size) # could have been changed via retuning
+            return res
         workspace_buffer = ir.WorkspaceBuffer.create(workspace_size, buffer)
         workspace_buffer.name = workspace_name
         self.buffers.append(workspace_buffer)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2947,6 +2947,14 @@ class WorkspaceBuffer(Buffer):
         res = cls(layout=layout, name=None, user_node=user_node)
         return res
 
+    def resize(self, workspace_size):
+        self.layout = FixedLayout(
+            self.get_device(),
+            torch.int8,
+            [workspace_size],
+            [1],
+        )
+
     def should_allocate(self):
         return True
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -134,7 +134,10 @@ class BaseSchedulerNode:
             str
         ] = set()  # buffers that won't be used after this kernel
         self.written = False
-        self.workspace_buffer = V.graph.get_workspace_buffer_for(self.node)
+
+    @property
+    def workspace_buffer(self):
+        return V.graph.get_workspace_buffer_for(self.node)
 
     def __repr__(self):
         return f"{type(self).__name__}(name={self.get_name()!r})"

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -863,6 +863,7 @@ class AlgorithmSelectorCache(PersistentCache):
         if (
             make_benchmark_fn.cache_info().currsize
             or log.getEffectiveLevel() == logging.DEBUG
+            or config.trace.log_autotuning_results
         ):
             self.log_results(name, input_nodes, timings, autotune_elapse)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #115877
* #115814
* #115813
* #115655
* #115654
* #112861
* #114687
* #115270
* #115174
* #115072
* #114606
* #114319
* #114075
* #113932
* #113891
* #113959
* #113890
* #113570
* #113569
* #113558
* #113399
* #113366
* #113365

When the workspace size is changed via retuning, the corresponding buffer allocation in the wrapper needs to use the updated size. This did
not work properly before, this diff fixes that.