### PR TITLE
[BE] Set `torch.cuda.has_half` to True

### DIFF
--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1275,8 +1275,6 @@ static PyObject* THCPModule_initExtension(PyObject* self, PyObject* noargs) {
   if (!m)
     throw python_error();
 
-  bool has_half = true;
-
   auto set_module_attr = [&](const char* name, PyObject* v) {
     // PyObject_SetAttrString doesn't steal reference. So no need to incref.
     if (PyObject_SetAttrString(m, name, v) < 0) {
@@ -1285,7 +1283,6 @@ static PyObject* THCPModule_initExtension(PyObject* self, PyObject* noargs) {
   };
 
   set_module_attr("has_magma", at::hasMAGMA() ? Py_True : Py_False);
-  set_module_attr("has_half", has_half ? Py_True : Py_False);
 
   auto num_gpus = c10::cuda::device_count();
   auto default_cuda_generators = PyTuple_New(static_cast<Py_ssize_t>(num_gpus));

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -110,9 +110,9 @@ else:
         raise RuntimeError("PyTorch was compiled without CUDA support")
 
 
+has_half: bool = True
 # Global variables dynamically populated by native code
 has_magma: bool = False
-has_half: bool = False
 default_generators: Tuple[torch._C.Generator] = ()  # type: ignore[assignment]
 
 


### PR DESCRIPTION
This check was introduced by https://github.com/pytorch/pytorch/pull/5417 and then turned into a tautology by https://github.com/pytorch/pytorch/pull/10147
 
So I guess it's time to let go of all that dynamic initialization (and may be just delete it in 2.3?)
