### PR TITLE
[c10d] Polish NCCL PG monitor thread log message

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1208,6 +1208,7 @@ void ProcessGroupNCCL::heartbeatMonitor() {
 
   // Create a error message reported from MonitorThread, so
   // we throw exception and make the whole process to be killed.
+  // TODO(fduwjj): After having a hang debug wiki, we need to update the wiki url here.
   const auto exitMsg = c10::str(
       logPrefix(),
       "ProcessGroupNCCL's watchdog got stuck for ",
@@ -1220,7 +1221,7 @@ void ProcessGroupNCCL::heartbeatMonitor() {
       "you can either increase the timeout (TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC) to a larger value "
       "or disable the heartbeat monitor (TORCH_NCCL_ENABLE_MONITORING=0)."
       "If either of aforementioned helps, feel free to file an issue to PyTorch about the short timeout "
-      "or false positive abort; otherwise, please report a watchdog hang bug to PyTorch.");
+      "or false positive abort; otherwise, please attempt to debug the hang.");
 
   // There are two possible cases for the watchdog thread exit:
   // Case one: desync report runs quickly, and it follows the step:

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1213,7 +1213,10 @@ void ProcessGroupNCCL::heartbeatMonitor() {
       "NCCL monitor thread timeout. Basically, this could ",
       "be due to CUDA or NCCL calls being unexpectedly blocking, ",
       "especially when your program enters a deadlock state in watchdog "
-      "or destructors. If you see this error, please file a bug to PyTorch.");
+      "or destructors. If you don't believe this is the base, you can turn"
+      "off monitor thread by set TORCH_NCCL_ENABLE_MONITORING=0 or increase"
+      "timeout by set TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC=1800 (30 mins)"
+      "If this turns out to be a real error, please file a bug to PyTorch.");
 
   // There are two possible cases for the watchdog thread exit:
   // Case one: desync report runs quickly, and it follows the step:

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1208,7 +1208,8 @@ void ProcessGroupNCCL::heartbeatMonitor() {
 
   // Create a error message reported from MonitorThread, so
   // we throw exception and make the whole process to be killed.
-  // TODO(fduwjj): After having a hang debug wiki, we need to update the wiki url here.
+  // TODO(fduwjj): After having a hang debug wiki, we need to update the wiki
+  // url here.
   const auto exitMsg = c10::str(
       logPrefix(),
       "ProcessGroupNCCL's watchdog got stuck for ",

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1213,13 +1213,14 @@ void ProcessGroupNCCL::heartbeatMonitor() {
       "ProcessGroupNCCL's watchdog got stuck for ",
       heartbeatTimeoutInSec_,
       "seconds without making progress in monitoring enqueued collectives. ",
-      "This typically indicates a nccl/cuda API hang blocking the watchdog, ",
+      "This typically indicates a NCCL/CUDA API hang blocking the watchdog, ",
       "and could be triggered by another thread holding the GIL inside a ",
-      "cuda api, or other deadlock-prone behaviors.",
+      "CUDA api, or other deadlock-prone behaviors.",
       "If you suspect the watchdog is not actually stuck and a longer timeout would help, ",
-      "you can either increase the timeout(TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC) to a larger value "
-      "or disable the heartbeat monitor(TORCH_NCCL_ENABLE_MONITORING=0)"
-      "If neither does not help, please file a bug to PyTorch.");
+      "you can either increase the timeout (TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC) to a larger value "
+      "or disable the heartbeat monitor (TORCH_NCCL_ENABLE_MONITORING=0)."
+      "If either of aforementioned helps, feel free to file an issue to PyTorch about the short timeout "
+      "or false positive abort; otherwise, please report a watchdog hang bug to PyTorch.");
 
   // There are two possible cases for the watchdog thread exit:
   // Case one: desync report runs quickly, and it follows the step:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #115888

We turned on monitor thread by default in https://github.com/pytorch/pytorch/pull/112518, and we want the error message that is displayed when the monitor kills the process to be more informative.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @wz337 @tianyu-l @wconstab @yf225