### PR TITLE
Generate exhaustive compiled optimizer tests

### DIFF
--- a/test/inductor/test_compiled_optimizers.py
+++ b/test/inductor/test_compiled_optimizers.py
@@ -174,6 +174,17 @@ def make_test(optim_cls, closure=None, kernel_count=2, device="cuda:0", **kwargs
             rtol=2e-5,
         )
 
+        # currently we don't mutate step properly until
+        # we resolve
+        # https://github.com/pytorch/pytorch/issues/115679
+        if optim_cls not in (Adadelta, Rprop, RMSprop):
+            for p_eager, p_compiled in zip(
+                model_eager.parameters(), model_compiled.parameters()
+            ):
+                self.assertEqual(
+                    opt_eager.state[p_eager], opt_compiled.state[p_compiled]
+                )
+
         if self.check_kernel_count:
             # currently, we compile the step and the rest of the computation
             # separately because the step is a single element tensor


### PR DESCRIPTION
Generates tests for all permutations of arguments using the existing optimizer infos. 
Covers capturable, cpu/gpu, single/multitensor and optimizer specific constants like rho/etas, etc.

[new test list](https://gist.github.com/mlazos/d3404383e7c3d490cbb51b7d6c750629)
[old test list](https://gist.github.com/mlazos/e0043aee1b6a0962d2f3ac8193aa62f8)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler