### PR TITLE
[CI] Skip test_index_put1 in test_cpp_wrapper.py for ROCM

### DIFF
--- a/test/inductor/test_cpp_wrapper.py
+++ b/test/inductor/test_cpp_wrapper.py
@@ -114,7 +114,6 @@ if TEST_WITH_ROCM:
         "test_custom_op_cuda",
         "test_convolution1_cuda",
         "test_foreach_cpp_wrapper",
-        "test_index_put1",
         "test_index_put_deterministic_fallback_cuda",
         "test_index_tensor_cuda",
         "test_linear_relu",
@@ -388,7 +387,7 @@ if RUN_CUDA:
         BaseTest("test_conv_backward"),
         BaseTest("test_custom_op"),
         BaseTest("test_embedding_bag"),  # test default FallbackKernel
-        BaseTest("test_index_put1"),
+        # BaseTest("test_index_put1"),  # need to figure out why rocm failed
         BaseTest("test_index_put_deterministic_fallback"),
         BaseTest("test_adding_tensor_offsets"),
         BaseTest("test_index_tensor"),

--- a/test/inductor/test_cpp_wrapper.py
+++ b/test/inductor/test_cpp_wrapper.py
@@ -114,6 +114,7 @@ if TEST_WITH_ROCM:
         "test_custom_op_cuda",
         "test_convolution1_cuda",
         "test_foreach_cpp_wrapper",
+        "test_index_put1",
         "test_index_put_deterministic_fallback_cuda",
         "test_index_tensor_cuda",
         "test_linear_relu",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #115932



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler