### PR TITLE
markDynamoStrictTest infinite cache size

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1402,9 +1402,15 @@ def markDynamoStrictTest(cls_or_func=None, nopython=False):
         @wraps(fn)
         def wrapper(*args, **kwargs):
             torch._dynamo.reset()
+            prev_cache_size_limit = torch._dynamo.config.cache_size_limit
+            prev_accumulated_cache_size_limit = torch._dynamo.config.accumulated_cache_size_limit
+            torch._dynamo.config.patch(cache_size_limit=1000000)
+            torch._dynamo.config.patch(accumulated_cache_size_limit=1000000)
             with unittest.mock.patch("torch._dynamo.config.suppress_errors", False):
                 fn(*args, **kwargs)
             torch._dynamo.reset()
+            torch._dynamo.config.patch(cache_size_limit=prev_cache_size_limit)
+            torch._dynamo.config.patch(accumulated_cache_size_limit=prev_accumulated_cache_size_limit)
         return wrapper
 
     if cls_or_func is None:


### PR DESCRIPTION
disclaimer: Not sure if this change is actually desirable.

The context was that if the test case overflowed the cache, it would just fall back to eager in the latter portion, which could lead to confusing behavior when debugging. However, I no longer have a use case where a test overflows the cache, so this point may be moot.

Curious about your thoughts anyway, feel free to close this PR.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #115934

