### PR TITLE
Add main in dynamo/test_compile.py

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -899,7 +899,6 @@ exclude_patterns = [
     'test/distributed/test_c10d_spawn.py',
     'test/distributed/test_collective_utils.py',
     'test/distributions/test_distributions.py',
-    'test/dynamo/test_compile.py',
     'test/dynamo/test_sources.py',
     'test/functorch/test_logging.py',
     'test/inductor/test_aot_inductor_utils.py',

--- a/test/dynamo/test_compile.py
+++ b/test/dynamo/test_compile.py
@@ -3,9 +3,9 @@
 import inspect
 import os
 import tempfile
-import unittest
 
 import torch
+from torch._dynamo.test_case import run_tests, TestCase
 from torch._dynamo.testing import CompileCounter
 
 
@@ -19,7 +19,7 @@ class ToyModel(torch.nn.Module):
         return self.relu(self.linear(x))
 
 
-class InPlaceCompilationTests(unittest.TestCase):
+class InPlaceCompilationTests(TestCase):
     def test_compilation(self):
         torch._dynamo.reset()
         model = ToyModel()
@@ -74,7 +74,7 @@ class InPlaceCompilationTests(unittest.TestCase):
 
 # The private variants of the below functions are extensively tested
 # So as long as the signatures match we're good
-class PublicTorchCompilerTests(unittest.TestCase):
+class PublicTorchCompilerTests(TestCase):
     def check_signature(self, public_fn_name, private_fn_name, private_namespace):
         public_fn = getattr(torch.compiler, public_fn_name)
         private_fn = getattr(private_namespace, private_fn_name)
@@ -99,3 +99,7 @@ class PublicTorchCompilerTests(unittest.TestCase):
 
         for fn_name in function_names:
             self.check_signature(fn_name, fn_name, torch._dynamo)
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
Need to verify that  it is dynamo's custom TestCase and run_tests instead of the general common_utils TestCase and run_tests

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng