### PR TITLE
Enable ruff rule PLW1510 codebase wide to check for subprocess.run without an explicit check argument

### DIFF
--- a/.github/scripts/update_commit_hashes.py
+++ b/.github/scripts/update_commit_hashes.py
@@ -98,6 +98,7 @@ def is_newer_hash(new_hash: str, old_hash: str, repo_name: str) -> bool:
                 f"git show --no-patch --no-notes --pretty=%ct {hash}".split(),
                 capture_output=True,
                 cwd=f"{repo_name}",
+                check=True,
             )
             .stdout.decode("utf-8")
             .strip()
@@ -133,24 +134,26 @@ def main() -> None:
             f"git rev-parse {args.branch}".split(),
             capture_output=True,
             cwd=f"{args.repo_name}",
+            check=True,
         )
         .stdout.decode("utf-8")
         .strip()
     )
     with open(f"{args.pin_folder}/{args.repo_name}.txt", "r+") as f:
         old_hash = f.read().strip()
-        subprocess.run(f"git checkout {old_hash}".split(), cwd=args.repo_name)
+        subprocess.run(f"git checkout {old_hash}".split(), cwd=args.repo_name, check=True)
         f.seek(0)
         f.truncate()
         f.write(f"{hash}\n")
     if is_newer_hash(hash, old_hash, args.repo_name):
         # if there was an update, push to branch
-        subprocess.run(f"git checkout -b {branch_name}".split())
-        subprocess.run(f"git add {args.pin_folder}/{args.repo_name}.txt".split())
+        subprocess.run(f"git checkout -b {branch_name}".split(), check=True)
+        subprocess.run(f"git add {args.pin_folder}/{args.repo_name}.txt".split(), check=True)
         subprocess.run(
-            "git commit -m".split() + [f"update {args.repo_name} commit hash"]
+            "git commit -m".split() + [f"update {args.repo_name} commit hash"],
+            check=True,
         )
-        subprocess.run(f"git push --set-upstream origin {branch_name} -f".split())
+        subprocess.run(f"git push --set-upstream origin {branch_name} -f".split(), check=True)
         print(f"changes pushed to branch {branch_name}")
         if pr_num is None:
             # no existing pr, so make a new one and approve it

--- a/benchmarks/distributed/ddp/benchmark.py
+++ b/benchmarks/distributed/ddp/benchmark.py
@@ -32,7 +32,7 @@ def allgather_object(obj):
 
 
 def allgather_run(cmd):
-    proc = subprocess.run(shlex.split(cmd), capture_output=True)
+    proc = subprocess.run(shlex.split(cmd), capture_output=True, check=False)
     assert proc.returncode == 0
     return allgather_object(proc.stdout.decode("utf-8"))
 

--- a/benchmarks/inference/server.py
+++ b/benchmarks/inference/server.py
@@ -208,7 +208,8 @@ if __name__ == "__main__":
             [
                 "wget",
                 "https://download.pytorch.org/models/resnet18-f37072fd.pth",
-            ]
+            ],
+            check=False,
         )
         if p.returncode == 0:
             downloaded_checkpoint = True

--- a/benchmarks/instruction_counts/execution/runner.py
+++ b/benchmarks/instruction_counts/execution/runner.py
@@ -260,6 +260,7 @@ class Runner:
                 stderr=subprocess.STDOUT,
                 encoding="utf-8",
                 executable=SHELL,
+                check=False,
             )
 
             if proc.returncode:

--- a/benchmarks/upload_scribe.py
+++ b/benchmarks/upload_scribe.py
@@ -40,7 +40,7 @@ class ScribeUploader:
         for m in messages:
             json_str = json.dumps(m)
             cmd = ["scribe_cat", self.category, json_str]
-            subprocess.run(cmd)
+            subprocess.run(cmd, check=True)
 
     def upload(self, messages):
         if os.environ.get("SCRIBE_INTERN"):

--- a/functorch/dim/magic_trace.py
+++ b/functorch/dim/magic_trace.py
@@ -21,9 +21,10 @@ def magic_trace(output="trace.fxt", magic_trace_cache="/tmp/magic-trace"):
                 magic_trace_cache,
                 "-q",
                 "https://github.com/janestreet/magic-trace/releases/download/v1.0.2/magic-trace",
-            ]
+            ],
+            check=True,
         )
-        subprocess.run(["chmod", "+x", magic_trace_cache])
+        subprocess.run(["chmod", "+x", magic_trace_cache], check=True)
     args = [magic_trace_cache, "attach", "-pid", str(pid), "-o", output]
     p = subprocess.Popen(args, stderr=subprocess.PIPE, encoding="utf-8")
     while True:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ select = [
     "TRY200",
     "TRY302",
     "UP",
+    "PLW1510", # subprocess-run-without-check
 ]
 
 [tool.ruff.per-file-ignores]

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -615,6 +615,7 @@ torch.cuda.synchronize()
                 cwd=os.path.dirname(os.path.realpath(__file__)),
                 capture_output=True,
                 text=True,
+                check=True,
             )
 
             output = p.stdout + '\n' + p.stderr

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -34,7 +34,7 @@ def remove_build_path():
         if IS_WINDOWS:
             # rmtree returns permission error: [WinError 5] Access is denied
             # on Windows, this is a word-around
-            subprocess.run(["rm", "-rf", default_build_root], stdout=subprocess.PIPE)
+            subprocess.run(["rm", "-rf", default_build_root], stdout=subprocess.PIPE, check=True)
         else:
             shutil.rmtree(default_build_root)
 
@@ -202,7 +202,7 @@ class TestCppExtensionJIT(common.TestCase):
             if IS_WINDOWS:
                 # rmtree returns permission error: [WinError 5] Access is denied
                 # on Windows, this is a word-around
-                subprocess.run(["rm", "-rf", temp_dir], stdout=subprocess.PIPE)
+                subprocess.run(["rm", "-rf", temp_dir], stdout=subprocess.PIPE, check=True)
             else:
                 shutil.rmtree(temp_dir)
 

--- a/test/test_functional_autograd_benchmark.py
+++ b/test/test_functional_autograd_benchmark.py
@@ -30,7 +30,7 @@ class TestFunctionalAutogradBenchmark(TestCase):
             if disable_gpu:
                 cmd += ['--gpu', '-1']
 
-            res = subprocess.run(cmd)
+            res = subprocess.run(cmd, check=False)
 
             self.assertTrue(res.returncode == 0)
             # Check that something was written to the file

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -762,6 +762,7 @@ class TestStandaloneCPPJIT(TestCase):
                     [exec_path],
                     shell=shell,
                     stdout=subprocess.PIPE,
+                    check=False,
                 )
                 self.assertEqual(r.returncode, 0)
                 self.assertEqual(

--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -30,6 +30,7 @@ def get_tag(pytorch_root: Union[str, Path]) -> str:
             cwd=pytorch_root,
             encoding="ascii",
             capture_output=True,
+            check=True,
         ).stdout.strip()
         if RELEASE_PATTERN.match(tag):
             return tag

--- a/tools/linter/adapters/actionlint_linter.py
+++ b/tools/linter/adapters/actionlint_linter.py
@@ -55,6 +55,7 @@ def run_command(
         return subprocess.run(
             args,
             capture_output=True,
+            check=True,
         )
     finally:
         end_time = time.monotonic()

--- a/tools/linter/adapters/cmake_linter.py
+++ b/tools/linter/adapters/cmake_linter.py
@@ -54,6 +54,7 @@ def run_command(
         return subprocess.run(
             args,
             capture_output=True,
+            check=True,
         )
     finally:
         end_time = time.monotonic()

--- a/tools/linter/adapters/grep_linter.py
+++ b/tools/linter/adapters/grep_linter.py
@@ -52,6 +52,7 @@ def run_command(
         return subprocess.run(
             args,
             capture_output=True,
+            check=True,
         )
     finally:
         end_time = time.monotonic()

--- a/tools/linter/adapters/lintrunner_version_linter.py
+++ b/tools/linter/adapters/lintrunner_version_linter.py
@@ -33,7 +33,7 @@ def toVersionString(version_tuple: Tuple[int, int, int]) -> str:
 
 if __name__ == "__main__":
     version_str = (
-        subprocess.run(["lintrunner", "-V"], stdout=subprocess.PIPE)
+        subprocess.run(["lintrunner", "-V"], stdout=subprocess.PIPE, check=True)
         .stdout.decode("utf-8")
         .strip()
     )

--- a/tools/linter/adapters/mypy_linter.py
+++ b/tools/linter/adapters/mypy_linter.py
@@ -80,6 +80,7 @@ def run_command(
         return subprocess.run(
             args,
             capture_output=True,
+            check=True,
         )
     finally:
         end_time = time.monotonic()

--- a/tools/linter/adapters/shellcheck_linter.py
+++ b/tools/linter/adapters/shellcheck_linter.py
@@ -40,6 +40,7 @@ def run_command(
         return subprocess.run(
             args,
             capture_output=True,
+            check=True,
         )
     finally:
         end_time = time.monotonic()

--- a/tools/linter/clang_tidy/generate_build_files.py
+++ b/tools/linter/clang_tidy/generate_build_files.py
@@ -9,6 +9,7 @@ def run_cmd(cmd: List[str]) -> None:
     result = subprocess.run(
         cmd,
         capture_output=True,
+        check=False,
     )
     stdout, stderr = (
         result.stdout.decode("utf-8").strip(),

--- a/tools/nvcc_fix_deps.py
+++ b/tools/nvcc_fix_deps.py
@@ -95,7 +95,7 @@ def extract_include_arg(include_dirs: List[Path], i: int, args: List[str]) -> No
 
 if __name__ == "__main__":
     ret = subprocess.run(
-        sys.argv[1:], stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr
+        sys.argv[1:], stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr, check=True
     )
 
     depfile_path = None

--- a/tools/testing/explicit_ci_jobs.py
+++ b/tools/testing/explicit_ci_jobs.py
@@ -96,7 +96,7 @@ def commit_ci(files: List[str], message: str) -> None:
     # Check that there are no other modified files than the ones edited by this
     # tool
     stdout = subprocess.run(
-        ["git", "status", "--porcelain"], stdout=subprocess.PIPE
+        ["git", "status", "--porcelain"], stdout=subprocess.PIPE, check=True
     ).stdout.decode()
     for line in stdout.split("\n"):
         if line == "":
@@ -107,8 +107,8 @@ def commit_ci(files: List[str], message: str) -> None:
             )
 
     # Make the commit
-    subprocess.run(["git", "add"] + files)
-    subprocess.run(["git", "commit", "-m", message])
+    subprocess.run(["git", "add"] + files, check=True)
+    subprocess.run(["git", "commit", "-m", message], check=True)
 
 
 if __name__ == "__main__":

--- a/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
+++ b/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
@@ -600,6 +600,7 @@ class _ValgrindWrapper:
                     args,
                     stdout=f_stdout_stderr,
                     stderr=subprocess.STDOUT,
+                    check=True,
                     **kwargs,
                 )
                 with open(stdout_stderr_log) as f:


### PR DESCRIPTION
Fixes #115016

This commit
1) adds ruff rule PLW1510 to pyproject.toml file, which checks for uses of subprocess.run without an explicit check argument. This can be verified using the command `lintrunner -a --all-files --take RUFF`.

2) modifies all the affected instances by adding check=True or check=False. Based on the discussion from #111682, check=False is added if the return code of subprocess.run is checked and check=True added if return code is not checked.


