### PR TITLE
Cache dfs path in propose_partitions and re-use that later when trying to find cycles in the graph

### DIFF
--- a/torch/fx/passes/infra/partitioner.py
+++ b/torch/fx/passes/infra/partitioner.py
@@ -1,15 +1,15 @@
-from typing import Dict, List, Set, Iterable, Sequence, Optional, Deque
-
 from torch.fx.passes.utils.fuser_utils import fuse_by_partitions
+import collections
+import itertools
+import logging
+
+from copy import copy
+from typing import Dict, Iterable, List, Optional, Sequence, Set
 
 from torch.fx.graph_module import GraphModule
 from torch.fx.node import Node, _get_qualified_name
 from torch.fx.passes.operator_support import OperatorSupportBase
 
-import logging
-import itertools
-from copy import copy
-from collections import deque
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
@@ -31,6 +31,29 @@ class Partition:
     def size(self):
         return len(self.nodes)
 
+class _DependencyViewer:
+    def __init__(self, graph_module: GraphModule):
+        self.upstreams = collections.defaultdict(set)
+        self.downstreams = collections.defaultdict(set)
+
+        for node in graph_module.graph.nodes:
+            for input_node in node.all_input_nodes:
+                # add input_node and input_node's upstream dependency
+                self.upstreams[node].add(input_node)
+                self.upstreams[node].update(self.upstreams[input_node])
+
+        for node in reversed(graph_module.graph.nodes):
+            for output_node in node.users:
+                # add output_node and output_node's downstream dependency
+                self.downstreams[node].add(output_node)
+                self.downstreams[node].update(self.downstreams[output_node])
+
+    def downstreams_of(self, node: Node) -> Set[Node]:
+        return self.downstreams[node]
+
+    def upstreams_of(self, node: Node) -> Set[Node]:
+        return self.upstreams[node]
+
 class CapabilityBasedPartitioner:
 
     def __init__(self,
@@ -49,6 +72,7 @@ class CapabilityBasedPartitioner:
             if allowed_single_node_partition_ops is not None
             else []
         )
+        self.dependency_viewer = _DependencyViewer(graph_module)
 
     def __is_node_supported(self, node: Node) -> bool:
         return (
@@ -56,6 +80,11 @@ class CapabilityBasedPartitioner:
         )
 
     def propose_partitions(self) -> List[Partition]:
+        # partition_map is a mapping from partition id to a set of partition id's.
+        # The value set contains all the partition ids that can be reached by doing a
+        # DFS starting from the partition id in the key.
+        partition_map : Dict[int, Set] = collections.defaultdict(set)
+
         # assumptions: nodes in candidate list is sorted in topological order
         assignment: Dict[Node, int] = {}   # mapping from node to partition_id
         partitions_by_id: Dict[int, Partition] = {}  # mapping from partition_id to partition
@@ -69,48 +98,46 @@ class CapabilityBasedPartitioner:
             merged_nodes = copy(partitions_by_id[self_id].nodes)
             merged_nodes.update(partitions_by_id[other_id].nodes)
 
-            # Note it's ok to use `set` here, since we are only query if a node
-            # has been visited. We are NEVER going to iterate on nodes inside
-            # the set.
-            visited: Set[Node] = set()
+            def dfs_iter_find_cycle(all_user_nodes: List[Node]):
+                for user_node in all_user_nodes:
+                    visited_partition_ids = set()
 
-            def dfs_iter_find_cycle(root_node):
-                stack : Deque[Node] = deque()
-                stack.append(root_node)
+                    for path_node in self.dependency_viewer.downstreams_of(user_node):
+                        # If any of the nodes in the dfs path of this node are in the merged_nodes
+                        # list then there is a cycle in the graph.
+                        if path_node in merged_nodes:
+                            return True
 
-                while stack:
-                    node = stack.pop()
+                        # If any of the nodes in the dfs path of this node are in the assignment
+                        # map then we have to make sure that the partitions that these nodes belong
+                        # to do not form a cycle with the current partitions being merged. This means
+                        # iterating through all the nodes in all the parititons that are traversed in
+                        # the dfs path and checking if they are in the merged_nodes list.
+                        if path_node in assignment:
+                            partition_id = assignment[path_node]
+                            # If the partition id has already been visited then we know that it doesn't
+                            # form a cycle with the current partitions being merged.
+                            if partition_id in visited_partition_ids:
+                                continue
+                            p_map = partition_map[partition_id]
+                            if self_id in p_map or other_id in p_map:
+                                return True
 
-                    if node in visited:
-                        continue
-                    if node in merged_nodes:
-                        return True  # found cycle, return
-
-                    # branching on hitting partition or not
-                    if node in assignment:
-                        # Since partition is not merged in the graph yet, when we
-                        # hit a node in a partition through DFS, we need to
-                        # traverse all nodes in the partition to properly reflect
-                        # dependencies after the fusion
-                        for p_node in partitions_by_id[assignment[node]].nodes:
-                            for user_node in p_node.users:
-                                if user_node not in partitions_by_id[assignment[node]].nodes:
-                                    stack.append(user_node)
-                    else:
-                        for user_node in node.users:
-                            stack.append(user_node)
-
-                    visited.add(node)
+                            visited_partition_ids.add(partition_id)
 
                 return False
 
             # check if merge would create cyclic dependency.
+            all_user_nodes = []
             for node in merged_nodes:
                 for user_node in node.users:
-                    if user_node not in merged_nodes and dfs_iter_find_cycle(user_node):
-                        # return false indicating cyclic dependency found and
-                        # merge is aborted
-                        return False
+                    if user_node not in merged_nodes:
+                        all_user_nodes.append(user_node)
+
+            if dfs_iter_find_cycle(all_user_nodes):
+                # return false indicating cyclic dependency found and
+                # merge is aborted
+                return False
 
             # no cyclic dependency found, move forward with the merge
             # updating partition nodes
@@ -121,9 +148,31 @@ class CapabilityBasedPartitioner:
             # delete other partition
             del partitions_by_id[other_id]
 
+            partition_map[self_id] = partition_map[self_id].union(partition_map[other_id])
+            del partition_map[other_id]
+
             return True
 
         def merge_single_node(node: Node, id: Optional[int]):
+            def _update_partition_map(node: Node, id: int):
+                # Iterate through all the downstream nodes of this node and update the partition map
+                # to indicate that there is a path from the partition id of this node to the target
+                # partition id.
+                downstream_nodes = self.dependency_viewer.downstreams_of(node)
+                for curr_node in downstream_nodes:
+                    target_id = assignment.get(curr_node, None)
+                    if target_id is not None:
+                        partition_map[id].add(target_id)
+
+                # Iterate through all the upstream nodes of this node and update the partition map
+                # to indicate that there is a path from the partition id of the upstream node to the
+                # current node's partition id.
+                upstream_nodes = self.dependency_viewer.upstreams_of(node)
+                for curr_node in upstream_nodes:
+                    source_id = assignment.get(curr_node, None)
+                    if source_id is not None:
+                        partition_map[source_id].add(id)
+
             if node in assignment:
                 partitions_by_id[assignment[node]].remove_node(node)
 
@@ -132,9 +181,11 @@ class CapabilityBasedPartitioner:
             elif id not in partitions_by_id:
                 assignment[node] = id
                 partitions_by_id[id] = Partition(id=id, nodes=[node])
+                _update_partition_map(node, id)
             else:
                 assignment[node] = id
                 partitions_by_id[id].add_node(node)
+                _update_partition_map(node, id)
 
         logger.debug("Proposing partitions...")
 


### PR DESCRIPTION
Summary:
This diff introduces a caching mechanism to improve the performance of the partitioner in PyTorch. The changes involve adding a cache to store the DFS path of each node in the graph, which can be reused later when trying to find cycles in the graph.

This shows significant improvements for the edge use cases where the ASR model (which is around 6000+ nodes) used to take 26 minutes, but after this it takes around 8 minutes.

Test Plan: Relying on the existing ExecuTorch CI tests that heavily use this partitioning mechanism and also tested out locally via Bento notebooks.

Differential Revision: D51289200


