### PR TITLE
Use matrix generate script for docker release workflows

### DIFF
--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -16,6 +16,9 @@ from typing import Dict, List, Optional, Tuple
 CUDA_ARCHES = ["11.8", "12.1"]
 
 
+CUDA_ARCHES_FULL_VERSION =  {"11.8": "11.8.0", "12.1": "12.1.1"}
+
+
 ROCM_ARCHES = ["5.6", "5.7"]
 
 

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -16,10 +16,10 @@ from typing import Dict, List, Optional, Tuple
 CUDA_ARCHES = ["11.8", "12.1"]
 
 
-CUDA_ARCHES_FULL_VERSION =  {"11.8": "11.8.0", "12.1": "12.1.1"}
+CUDA_ARCHES_FULL_VERSION = {"11.8": "11.8.0", "12.1": "12.1.1"}
 
 
-CUDA_ARCHES_CUDNN_VERSION =  {"11.8": "8", "12.1": "8"}
+CUDA_ARCHES_CUDNN_VERSION = {"11.8": "8", "12.1": "8"}
 
 
 ROCM_ARCHES = ["5.6", "5.7"]

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -19,6 +19,9 @@ CUDA_ARCHES = ["11.8", "12.1"]
 CUDA_ARCHES_FULL_VERSION =  {"11.8": "11.8.0", "12.1": "12.1.1"}
 
 
+CUDA_ARCHES_CUDNN_VERSION =  {"11.8": "8", "12.1": "8"}
+
+
 ROCM_ARCHES = ["5.6", "5.7"]
 
 

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -24,6 +24,7 @@ CPU_CXX11_ABI_ARCH = ["cpu-cxx11-abi"]
 
 CPU_AARCH64_ARCH = ["cpu-aarch64"]
 
+
 PYTORCH_EXTRA_INSTALL_REQUIREMENTS = {
     "11.8": (
         "nvidia-cuda-nvrtc-cu11==11.8.89; platform_system == 'Linux' and platform_machine == 'x86_64' | "  # noqa: B950

--- a/.github/scripts/generate_docker_release_matrix.py
+++ b/.github/scripts/generate_docker_release_matrix.py
@@ -9,12 +9,11 @@ def generate_docker_matrix() -> List[Dict[str, str]]:
     ret: List[Dict[str, str]] = []
     for cuda in generate_binary_build_matrix.CUDA_ARCHES:
         for image in DOCKER_IMAGE_TYPES:
-            platform = "linux/arm64,linux/amd64" if image == "runtime" else "linux/amd6"
             ret.append(
                 {
                     "cuda": cuda,
                     "image_type": image,
-                    "platform": platform,
+                    "platform": "linux/arm64,linux/amd64",
                 }
             )
     return {"include": ret}

--- a/.github/scripts/generate_docker_release_matrix.py
+++ b/.github/scripts/generate_docker_release_matrix.py
@@ -7,11 +7,12 @@ DOCKER_IMAGE_TYPES = ["runtime", "devel"]
 
 def generate_docker_matrix() -> List[Dict[str, str]]:
     ret: List[Dict[str, str]] = []
-    for cuda in generate_binary_build_matrix.CUDA_ARCHES:
+    for cuda, version in generate_binary_build_matrix.CUDA_ARCHES_FULL_VERSION:
         for image in DOCKER_IMAGE_TYPES:
             ret.append(
                 {
                     "cuda": cuda,
+                    "cuda_full_version": version,
                     "image_type": image,
                     "platform": "linux/arm64,linux/amd64",
                 }

--- a/.github/scripts/generate_docker_release_matrix.py
+++ b/.github/scripts/generate_docker_release_matrix.py
@@ -18,6 +18,7 @@ import generate_binary_build_matrix
 
 DOCKER_IMAGE_TYPES = ["runtime", "devel"]
 
+
 def generate_docker_matrix() -> Dict[str, List[Dict[str, str]]]:
     ret: List[Dict[str, str]] = []
     for cuda, version in generate_binary_build_matrix.CUDA_ARCHES_FULL_VERSION.items():

--- a/.github/scripts/generate_docker_release_matrix.py
+++ b/.github/scripts/generate_docker_release_matrix.py
@@ -7,7 +7,7 @@ DOCKER_IMAGE_TYPES = ["runtime", "devel"]
 
 def generate_docker_matrix() -> List[Dict[str, str]]:
     ret: List[Dict[str, str]] = []
-    for cuda, version in generate_binary_build_matrix.CUDA_ARCHES_FULL_VERSION:
+    for cuda, version in generate_binary_build_matrix.CUDA_ARCHES_FULL_VERSION.items():
         for image in DOCKER_IMAGE_TYPES:
             ret.append(
                 {

--- a/.github/scripts/generate_docker_release_matrix.py
+++ b/.github/scripts/generate_docker_release_matrix.py
@@ -1,0 +1,25 @@
+
+import json
+import generate_binary_build_matrix
+from typing import Dict, List
+
+DOCKER_IMAGE_TYPES = ["runtime", "devel"]
+
+def generate_docker_matrix() -> List[Dict[str, str]]:
+    ret: List[Dict[str, str]] = []
+    for cuda in generate_binary_build_matrix.CUDA_ARCHES:
+        for image in DOCKER_IMAGE_TYPES:
+            platform = "linux/arm64,linux/amd64" if image == "runtime" else "linux/amd6"
+            ret.append(
+                {
+                    "cuda": cuda,
+                    "image_type": image,
+                    "platform": platform,
+                }
+            )
+    return ret
+
+
+if __name__ == "__main__":
+    build_matrix = generate_docker_matrix()
+    print(json.dumps(build_matrix))

--- a/.github/scripts/generate_docker_release_matrix.py
+++ b/.github/scripts/generate_docker_release_matrix.py
@@ -1,3 +1,15 @@
+#!/usr/bin/env python3
+
+"""Generates a matrix for docker releases through github actions
+
+Will output a condensed version of the matrix. Will include fllowing:
+    * CUDA version short
+    * CUDA full verison
+    * CUDNN version short
+    * Image type either runtime or devel
+    * Platform linux/arm64,linux/amd64
+
+"""
 
 import json
 import generate_binary_build_matrix

--- a/.github/scripts/generate_docker_release_matrix.py
+++ b/.github/scripts/generate_docker_release_matrix.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 
 DOCKER_IMAGE_TYPES = ["runtime", "devel"]
 
-def generate_docker_matrix() -> List[Dict[str, str]]:
+def generate_docker_matrix() -> Dict[str, List[Dict[str, str]]]:
     ret: List[Dict[str, str]] = []
     for cuda, version in generate_binary_build_matrix.CUDA_ARCHES_FULL_VERSION.items():
         for image in DOCKER_IMAGE_TYPES:
@@ -13,6 +13,7 @@ def generate_docker_matrix() -> List[Dict[str, str]]:
                 {
                     "cuda": cuda,
                     "cuda_full_version": version,
+                    "cudnn_version": generate_binary_build_matrix.CUDA_ARCHES_CUDNN_VERSION[cuda],
                     "image_type": image,
                     "platform": "linux/arm64,linux/amd64",
                 }

--- a/.github/scripts/generate_docker_release_matrix.py
+++ b/.github/scripts/generate_docker_release_matrix.py
@@ -17,7 +17,7 @@ def generate_docker_matrix() -> List[Dict[str, str]]:
                     "platform": platform,
                 }
             )
-    return ret
+    return {"include": ret}
 
 
 if __name__ == "__main__":

--- a/.github/scripts/generate_docker_release_matrix.py
+++ b/.github/scripts/generate_docker_release_matrix.py
@@ -12,8 +12,9 @@ Will output a condensed version of the matrix. Will include fllowing:
 """
 
 import json
-import generate_binary_build_matrix
 from typing import Dict, List
+
+import generate_binary_build_matrix
 
 DOCKER_IMAGE_TYPES = ["runtime", "devel"]
 
@@ -25,7 +26,9 @@ def generate_docker_matrix() -> Dict[str, List[Dict[str, str]]]:
                 {
                     "cuda": cuda,
                     "cuda_full_version": version,
-                    "cudnn_version": generate_binary_build_matrix.CUDA_ARCHES_CUDNN_VERSION[cuda],
+                    "cudnn_version": generate_binary_build_matrix.CUDA_ARCHES_CUDNN_VERSION[
+                        cuda
+                    ],
                     "image_type": image,
                     "platform": "linux/arm64,linux/amd64",
                 }

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -33,7 +33,7 @@ jobs:
     if: github.repository_owner == 'pytorch'
     runs-on: [self-hosted, linux.large]
     outputs:
-      release-matrix: ${{ steps.generate-matrix.outputs.release-matrix }}
+      generate_matrix: ${{ steps.generate-matrix.outputs.generate_matrix }}
     steps:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
@@ -54,7 +54,7 @@ jobs:
     timeout-minutes: 240
     needs: generate-matrix
     strategy:
-      matrix: ${{ fromJson(needs.generate-matrix.outputs.release-matrix) }}
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.generate_matrix) }}
       fail-fast: false
     env:
       BUILD_IMAGE_TYPE: ${{ matrix.image_type }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -33,7 +33,7 @@ jobs:
     if: github.repository_owner == 'pytorch'
     runs-on: [self-hosted, linux.large]
     outputs:
-      generate_matrix: ${{ steps.generate-matrix.outputs.generate_matrix }}
+      matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 1
           submodules: true
       - name: Get docker release matrix
-        id: generate_matrix
+        id: generate-matrix
         run: |
           MATRIX_BLOB="$(python3 .github/scripts/generate_docker_release_matrix.py)"
           echo "${MATRIX_BLOB}"
@@ -54,7 +54,7 @@ jobs:
     timeout-minutes: 240
     needs: generate-matrix
     strategy:
-      matrix: ${{ fromJson(needs.generate-matrix.outputs.generate_matrix) }}
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
       fail-fast: false
     env:
       BUILD_IMAGE_TYPE: ${{ matrix.image_type }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -59,8 +59,8 @@ jobs:
     env:
       BUILD_IMAGE_TYPE: ${{ matrix.image_type }}
       BUILD_PLATFORMS: ${{ matrix.platform }}
-      CUDA_VERSION: ${{ matrix.cuda }}
-      CUDA_FULL_VERSION: ${{ matrix.cuda_full_version }}
+      CUDA_VERSION: ${{ matrix.cuda_full_version }}
+      CUDNN_VERSION: ${{ matrix.cudnn_version }}
     steps:
       - name: Setup SSH (Click me for login details)
         uses: pytorch/test-infra/.github/actions/setup-ssh@main

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -29,22 +29,37 @@ env:
   WITH_PUSH: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || startsWith(github.event.ref, 'refs/tags/v')) }}
 
 jobs:
+   generate-matrix:
+    if: github.repository_owner == 'pytorch'
+    runs-on: [self-hosted, linux.large]
+    outputs:
+      release-matrix: ${{ steps.generate-matrix.outputs.release-matrix }}
+    steps:
+      - name: Checkout PyTorch
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
+        with:
+          fetch-depth: 1
+          submodules: false
+      - name: Get docker release matrix
+        id: generate_matrix
+        run: |
+          MATRIX_BLOB="$(python3 .githun/scripts/generate_docker_release_matrix.py)"
+          echo "${MATRIX_BLOB}"
+          echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
+
   build:
     if: ${{ github.repository == 'pytorch/pytorch' }}
     runs-on: [self-hosted, linux.2xlarge]
     environment: ${{ (github.ref == 'refs/heads/nightly' || startsWith(github.event.ref, 'refs/tags/v')) && 'docker-build' || '' }}
     timeout-minutes: 240
+    needs: generate-matrix
     strategy:
-      matrix:
-        include:
-          # nvidia specific images don't exist for arm64 so only build the runtime image
-          - image_type: runtime
-            platform: linux/arm64,linux/amd64
-          - image_type: devel
-            platform: linux/amd64
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.release-matrix) }}
+      fail-fast: false
     env:
       BUILD_IMAGE_TYPE: ${{ matrix.image_type }}
       BUILD_PLATFORMS: ${{ matrix.platform }}
+      CUDA_VERSION: ${{ matrix.cuda }}
     steps:
       - name: Setup SSH (Click me for login details)
         uses: pytorch/test-infra/.github/actions/setup-ssh@main

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -39,11 +39,10 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
         with:
           fetch-depth: 1
-          submodules: false
+          submodules: true
       - name: Get docker release matrix
         id: generate_matrix
         run: |
-          ls -las
           MATRIX_BLOB="$(python3 .github/scripts/generate_docker_release_matrix.py)"
           echo "${MATRIX_BLOB}"
           echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -60,6 +60,7 @@ jobs:
       BUILD_IMAGE_TYPE: ${{ matrix.image_type }}
       BUILD_PLATFORMS: ${{ matrix.platform }}
       CUDA_VERSION: ${{ matrix.cuda }}
+      CUDA_FULL_VERSION: ${{ matrix.cuda_full_version }}
     steps:
       - name: Setup SSH (Click me for login details)
         uses: pytorch/test-infra/.github/actions/setup-ssh@main

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Get docker release matrix
         id: generate_matrix
         run: |
+          ls -las
           MATRIX_BLOB="$(python3 .github/scripts/generate_docker_release_matrix.py)"
           echo "${MATRIX_BLOB}"
           echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -29,7 +29,7 @@ env:
   WITH_PUSH: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || startsWith(github.event.ref, 'refs/tags/v')) }}
 
 jobs:
-   generate-matrix:
+  generate-matrix:
     if: github.repository_owner == 'pytorch'
     runs-on: [self-hosted, linux.large]
     outputs:
@@ -43,7 +43,7 @@ jobs:
       - name: Get docker release matrix
         id: generate_matrix
         run: |
-          MATRIX_BLOB="$(python3 .githun/scripts/generate_docker_release_matrix.py)"
+          MATRIX_BLOB="$(python3 .github/scripts/generate_docker_release_matrix.py)"
           echo "${MATRIX_BLOB}"
           echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN --mount=type=cache,target=/opt/ccache \
 
 FROM conda as conda-installs
 ARG PYTHON_VERSION=3.8
-ARG CUDA_VERSION=11.7
+ARG CUDA_VERSION=12.1
 ARG CUDA_CHANNEL=nvidia
 ARG INSTALL_CHANNEL=pytorch-nightly
 # Automatically set by buildx

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -8,7 +8,7 @@ $(warning WARNING: No docker user found using results from whoami)
 DOCKER_ORG                = $(shell whoami)
 endif
 
-CUDA_VERSION			 ?= 12.1.1
+CUDA_VERSION             ?= 12.1.1
 CUDNN_VERSION            ?= 8
 BASE_RUNTIME              = ubuntu:22.04
 BASE_DEVEL                = nvidia/cuda:$(CUDA_VERSION)-cudnn$(CUDNN_VERSION)-devel-ubuntu22.04

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -8,10 +8,10 @@ $(warning WARNING: No docker user found using results from whoami)
 DOCKER_ORG                = $(shell whoami)
 endif
 
-CUDA_VERSION              = 12.1.1
+# CUDA_VERSION              = 12.1.1
 CUDNN_VERSION             = 8
 BASE_RUNTIME              = ubuntu:22.04
-BASE_DEVEL                = nvidia/cuda:$(CUDA_VERSION)-cudnn$(CUDNN_VERSION)-devel-ubuntu22.04
+BASE_DEVEL                = nvidia/cuda:$(CUDA_FULL_VERSION)-cudnn$(CUDNN_VERSION)-devel-ubuntu22.04
 CMAKE_VARS               ?=
 
 # The conda channel to use to install cudatoolkit
@@ -28,7 +28,7 @@ BUILD_PROGRESS           ?= auto
 TRITON_VERSION           ?=
 BUILD_ARGS                = --build-arg BASE_IMAGE=$(BASE_IMAGE) \
 							--build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
-							--build-arg CUDA_VERSION=$(CUDA_VERSION) \
+							--build-arg CUDA_VERSION=$(CUDA_FULL_VERSION) \
 							--build-arg CUDA_CHANNEL=$(CUDA_CHANNEL) \
 							--build-arg PYTORCH_VERSION=$(PYTORCH_VERSION) \
 							--build-arg INSTALL_CHANNEL=$(INSTALL_CHANNEL) \

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -8,8 +8,8 @@ $(warning WARNING: No docker user found using results from whoami)
 DOCKER_ORG                = $(shell whoami)
 endif
 
-CUDA_VERSION       		 ?= 12.1.1
-CUDNN_VERSION             = 8
+CUDA_VERSION			 ?= 12.1.1
+CUDNN_VERSION            ?= 8
 BASE_RUNTIME              = ubuntu:22.04
 BASE_DEVEL                = nvidia/cuda:$(CUDA_VERSION)-cudnn$(CUDNN_VERSION)-devel-ubuntu22.04
 CMAKE_VARS               ?=

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -8,10 +8,10 @@ $(warning WARNING: No docker user found using results from whoami)
 DOCKER_ORG                = $(shell whoami)
 endif
 
-# CUDA_VERSION              = 12.1.1
+CUDA_VERSION       		 ?= 12.1.1
 CUDNN_VERSION             = 8
 BASE_RUNTIME              = ubuntu:22.04
-BASE_DEVEL                = nvidia/cuda:$(CUDA_FULL_VERSION)-cudnn$(CUDNN_VERSION)-devel-ubuntu22.04
+BASE_DEVEL                = nvidia/cuda:$(CUDA_VERSION)-cudnn$(CUDNN_VERSION)-devel-ubuntu22.04
 CMAKE_VARS               ?=
 
 # The conda channel to use to install cudatoolkit
@@ -28,7 +28,7 @@ BUILD_PROGRESS           ?= auto
 TRITON_VERSION           ?=
 BUILD_ARGS                = --build-arg BASE_IMAGE=$(BASE_IMAGE) \
 							--build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
-							--build-arg CUDA_VERSION=$(CUDA_FULL_VERSION) \
+							--build-arg CUDA_VERSION=$(CUDA_VERSION) \
 							--build-arg CUDA_CHANNEL=$(CUDA_CHANNEL) \
 							--build-arg PYTORCH_VERSION=$(PYTORCH_VERSION) \
 							--build-arg INSTALL_CHANNEL=$(INSTALL_CHANNEL) \


### PR DESCRIPTION
Enable both supported CUDA version builds for docker release. Rather then building only 1 version.