### PR TITLE
[buck2][win] fix caffe2 protobuf_rule

### DIFF
--- a/scripts/proto.ps1
+++ b/scripts/proto.ps1
@@ -13,5 +13,6 @@ $dir = (Get-Item $processed).DirectoryName
 copy $srcdir/caffe2/proto/caffe2.proto $srcdir/caffe2.proto
 Add-Content -Path $srcdir/caffe2.proto -Value "option optimize_for = LITE_RUNTIME;`n" -NoNewline
 
+$processed = (Get-Item $processed).Name
 $cmd = "$protoc -I${dir} --cpp_out=$out $processed"
 Invoke-Expression $cmd


### PR DESCRIPTION
Summary:
c2_protobuf_rule ([here](https://fburl.com/code/iyiulpmv)) is broken on buck2, ultimately due to the following error:

> .\./caffe2.proto: File does not reside within any path specified using --proto_path (or -I).  You must specify a --proto_path which encompasses this file.  Note that the proto_path must be an exact prefix of the .proto file names -- protoc is too dumb to figure out when two paths (e.g. absolute and relative) are equivalent (it's harder than you think).

The root cause is differences in how buck1 and buck2 handle `%SRCDIR%` (absolute versus relative paths). This diff fixes the build.

Test Plan:
# Before

```
buck2 build arvr/mode/win/opt //xplat/caffe2:caffe2.pb.h
```

```
More details at https://www.internalfb.com/intern/buck/build/c6550454-ae6d-479e-9d08-016e544ef050
BUILD SUCCEEDED
```

```
Action failed: fbsource//xplat/caffe2:caffe2.pb.h (genrule)
Remote command returned non-zero exit code <no exit code>
Reproduce locally: frecli cas download-action 5df17cf64b7e2fc5ab090c91e1129f2f3cad36dc72c7c182ab052af23d3f32aa:145
stdout:
stderr:
OUTMISS: Missing outputs: buck-out/v2/gen/fbsource/dd87aacb8683145b/xplat/caffe2/caffe2.pb.h/out/caffe2.pb.h
```

# After

Buck1 still works

```
buck1 build arvr/mode/win/opt //xplat/caffe2:caffe2.pb.h
```

Buck2 works

```
buck2 build arvr/mode/win/opt //xplat/caffe2:caffe2.pb.h
```

```
Buck UI: https://www.internalfb.com/buck2/e5dae607-325a-4eab-b0c9-66fe4e9a6254
BUILD SUCCEEDED
```

Differential Revision: D52218365


