### PR TITLE
Fix broken PyYAML 6.0 on MacOS x86

### DIFF
--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -46,7 +46,8 @@ runs:
         retry_wait_seconds: 30
         command: |
           set -eux
-          python3 -m pip install requests==2.26.0 pyyaml==6.0
+          # PyYAML 6.0 doesn't work with MacOS x86 anymore
+          python3 -m pip install requests==2.26.0 pyyaml==6.0.1
 
     - name: Parse ref
       id: parse-ref


### PR DESCRIPTION
May be we should just get rid of x86 jobs, but that's for another day.  This one should fix the broken build in trunk, i.e. https://github.com/pytorch/pytorch/actions/runs/7227220153/job/19694420117.

I guess that the failure looks flaky depending on the version of default python3 on the GitHub x86 runner.

The issue from PyYAML https://github.com/yaml/pyyaml/issues/601