### PR TITLE
add length assertion to PrepareModuleInput and PrepareModuleOutput

### DIFF
--- a/test/distributed/tensor/parallel/test_tp_style.py
+++ b/test/distributed/tensor/parallel/test_tp_style.py
@@ -130,6 +130,20 @@ class TensorParallelStyleTest(DTensorTestBase):
             def forward(self, x, y):
                 return self.linear(x) + y
 
+        # Raise assertion error if input_layouts and desired_input_layouts do not have same length.
+        test_mod = TestModule().to(self.device_type)
+        with self.assertRaisesRegex(AssertionError, "input_layouts and desired_input_layouts should have same length!"):
+            prepare_inps_dimension_mismatch = PrepareModuleInput(input_layouts=Shard(0), desired_input_layouts=(Replicate(), None))
+        # Raise assertion error if module inputs and input_layouts do not have same length.
+        prepare_inps_short_dimension = PrepareModuleInput(input_layouts=Shard(0), desired_input_layouts=Replicate())
+        parallelize_module(test_mod.linear, mesh, ColwiseParallel())
+        parallelize_module(test_mod, mesh, prepare_inps_short_dimension)
+        with self.assertRaisesRegex(AssertionError, "module inputs and input_layouts should have same length!"):
+            output = test_mod(
+                torch.randn(2, 8, device=self.device_type),
+                torch.ones(self.world_size * 2, 8 // self.world_size, device=self.device_type)
+            )
+
         test_mod = TestModule().to(self.device_type)
         prepare_inps = PrepareModuleInput(input_layouts=(Shard(0), None), desired_input_layouts=(Replicate(), None))
 

--- a/torch/distributed/tensor/parallel/style.py
+++ b/torch/distributed/tensor/parallel/style.py
@@ -280,6 +280,8 @@ class PrepareModuleInput(ParallelStyle):
         prepared_inputs = []
         if not isinstance(inputs, tuple):
             inputs = (inputs,)
+        assert len(inputs) == len(self.input_layouts), \
+            "module inputs and input_layouts should have same length!"
         for inp, input_layout, desired_layout in zip(inputs, self.input_layouts, self.desired_input_layouts):
             if input_layout is not None:
                 if isinstance(inp, DTensor):
@@ -345,11 +347,15 @@ class PrepareModuleOutput(ParallelStyle):
         self.desired_output_layouts = \
             (desired_output_layouts,) if isinstance(desired_output_layouts, Placement) else desired_output_layouts
         self.use_local_output = use_local_output
+        assert len(self.output_layouts) == len(self.desired_output_layouts), \
+            "output_layouts and desired_output_layouts should have same length!"
 
     def _prepare_out_fn(self, outputs, device_mesh):
         prepared_outputs = []
         if not isinstance(outputs, tuple):
             outputs = (outputs,)
+        assert len(outputs) == len(self.output_layouts), \
+            "module outputs and output_layouts should have same length!"
         for out, out_layout, desired_out_layout in zip(outputs, self.output_layouts, self.desired_output_layouts):
             if out_layout is not None:
                 if isinstance(out, DTensor):


### PR DESCRIPTION
## summary

`zip(inputs, self.input_layouts, self.desired_input_layouts)` is used in `_prepare_input_fn`; similar for `_prepare_output_fn`. Without assertion, unmatched dimension in inputs/outputs will be lost, potentially causing unexpected behabiors.

## test plan
`python test/distributed/tensor/parallel/test_tp_style.py`


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #115957



cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @wconstab @yf225