### PR TITLE
[DTensor] Make DTensor `from_local` backward partial() to replicate() pass through

### DIFF
--- a/test/distributed/_tensor/test_redistribute.py
+++ b/test/distributed/_tensor/test_redistribute.py
@@ -129,11 +129,12 @@ class RedistributeTest(DTensorTestBase):
         )
 
         # test backward to have replicate grad on partial
+        # for from_local backward, we want the replicate() -> partial() to be
+        # pass through.
         global_partial_tensor.backward(torch.ones_like(global_partial_tensor))
         self.assertIsNotNone(partial_local.grad)
-        self.assertEqual(
-            partial_local.grad, torch.ones_like(partial_local) / self.world_size
-        )
+        self.assertEqual(partial_local.grad.size(), partial_local.size())
+        self.assertEqual(partial_local.grad, torch.ones_like(partial_local))
 
     @with_comms
     def test_replicate_to_partial(self):

--- a/torch/distributed/_tensor/redistribute.py
+++ b/torch/distributed/_tensor/redistribute.py
@@ -76,6 +76,7 @@ def redistribute_local_tensor(
     local_tensor: torch.Tensor,
     current_spec: DTensorSpec,
     target_spec: DTensorSpec,
+    is_backward: bool = False,
 ) -> torch.Tensor:
     """
     This redistribute the local tensor (torch.Tensor) from the current DTensorSpec to
@@ -159,9 +160,12 @@ def redistribute_local_tensor(
 
         elif target.is_partial():
             if current.is_replicate():
-                # For replicate -> partial, we perform division to num of chunks and generate
-                # parial, and recover it back when pending sum get cleared.
-                new_local_tensor = local_tensor / num_chunks
+                # For replicate -> partial forward pass we perform division to num of chunks
+                # and generate parial, and recover it back when pending sum get cleared.
+                # Skip/pass through when replicate -> partial is in backward pass.
+                new_local_tensor = (
+                    local_tensor / num_chunks if not is_backward else local_tensor
+                )
             else:
                 raise RuntimeError(
                     f"redistribute from {current_placements} to {target_placements} not supported yet"


### PR DESCRIPTION
Summary:
This change makes the `DTensor.from_local()` placements in backward pass from `Partial()` to `Replicate()` as pass through for following reasons:
1. When we run backward pass of DTensor.from_local, if the target placement is partial() (i.e. from user manual overwrite code instead of torch_dispatch) we keep the grad as replicate. This is because converting the gradients back to `Partial()` is meaningless.
2. The current div logic will lead to wrong numerical value in the above case.

Test Plan:
**CI**:
CI Tests

**Unit test**:
`buck2 test mode/dev-nosan //caffe2/test/distributed/_tensor:redistribute`
- Passed

**With model training**:
```
# We tested the case where input tensor is manually overwrite as Partial() and
# output tensor manually overwrite to Shard() then to local.

# Before the change: numerical value not correct
Forward pass:
    collective: ReduceScatter
backward pass:
    collective: AllGather + div by process group size


# After the change: div is removed as expected.
Forward pass:
    collective: ReduceScatter
Backward pas:
    collective: AllGather
```

Differential Revision: D52175709




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225