### PR TITLE
[sparse] update cslt to 0.5.2.1

### DIFF
--- a/.ci/docker/common/install_cusparselt.sh
+++ b/.ci/docker/common/install_cusparselt.sh
@@ -4,8 +4,14 @@ set -ex
 
 # cuSPARSELt license: https://docs.nvidia.com/cuda/cusparselt/license.html
 mkdir tmp_cusparselt && cd tmp_cusparselt
-CUSPARSELT_NAME="libcusparse_lt-linux-x86_64-0.4.0.7-archive"
-curl --retry 3 -OLs https://developer.download.nvidia.com/compute/cusparselt/redist/libcusparse_lt/linux-x86_64/${CUSPARSELT_NAME}.tar.xz
+
+if [[ ${CUDA_VERSION:0:4} == "12.1" ]]; then
+    CUSPARSELT_NAME="libcusparse_lt-linux-x86_64-0.4.0.7-archive"
+    curl --retry 3 -OLs https://developer.download.nvidia.com/compute/cusparselt/redist/libcusparse_lt/linux-x86_64/${CUSPARSELT_NAME}.tar.xz
+elif [[ ${CUDA_VERSION:0:4} == "11.8" ]]; then
+    CUSPARSELT_NAME="libcusparse_lt-linux-x86_64-0.5.2.1-archive"
+    curl --retry 3 -OLs https://developer.download.nvidia.com/compute/cusparselt/redist/libcusparse_lt/linux-x86_64/${CUSPARSELT_NAME}.tar.xz
+fi
 
 tar xf ${CUSPARSELT_NAME}.tar.xz
 cp -a ${CUSPARSELT_NAME}/include/* /usr/local/cuda/include/

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -135,6 +135,25 @@ std::tuple<int64_t, at::Tensor> _cslt_sparse_mm_impl(
         compute_type = CUSPARSE_COMPUTE_32I;
         compression_factor = 10;
         break;
+// cuSPARSELt v0.5.2 onwards changes CUSPARSE_COMPUTE_TF32, CUSPARES_COMPUT_16F to CUSPARSE_COMPUTE_32F
+#if defined(CUSPARSELT_VERSION) && CUSPARSELT_VERSION >= 502
+    case at::ScalarType::Half:
+        input_type = CUDA_R_16F;
+        output_type = CUDA_R_16F;
+        compute_type = CUSPARSE_COMPUTE_32F;
+        break;
+    case at::ScalarType::BFloat16:
+        input_type = CUDA_R_16BF;
+        output_type = CUDA_R_16BF;
+        compute_type = CUSPARSE_COMPUTE_32F;
+        break;
+    case at::ScalarType::Float:
+        input_type = CUDA_R_32F;
+        output_type = CUDA_R_32F;
+        compute_type = CUSPARSE_COMPUTE_32F;
+        break;
+// cuSPARSELt <= v0.5.2 uses CUSPARSE_COMPUTE_TF32, CUSPARES_COMPUTE_16F
+#else
     case at::ScalarType::Half:
         input_type = CUDA_R_16F;
         output_type = CUDA_R_16F;
@@ -150,6 +169,7 @@ std::tuple<int64_t, at::Tensor> _cslt_sparse_mm_impl(
         output_type = CUDA_R_32F;
         compute_type = CUSPARSE_COMPUTE_TF32;
         break;
+#endif
     default:
         TORCH_CHECK(false, "Unsupported dtype for cuSPARSELt compressed matrix multiplication.");
         break;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #115988
* #115369

Summary:

- update install_cusparselt to download 0.5.2.1 for 12.1
- add ifdef for new compute_type changes

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

cc @alexsamardzic @nikitaved @pearu @cpuhrsch @amjames @bhosmer