### PR TITLE
[BE]: Enable clang-tidy check for readability-string-compare

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -52,6 +52,7 @@ modernize-*,
 -modernize-use-nodiscard,
 performance-*,
 readability-container-size-empty,
+readability-string-compare,
 '
 HeaderFilterRegex: '^(aten/|c10/|torch/).*$'
 AnalyzeTemporaryDtors: false

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -243,7 +243,7 @@ struct CollectiveFingerPrint {
     // Check op type
     auto other_op = opTypeToString(other.op_type_);
     auto this_op = opTypeToString(op_type_);
-    if (other_op.compare(this_op) != 0) {
+    if (other_op != this_op) {
       found_diff = true;
       ss << c10::str("  Op type: ", this_op, "vs ", other_op);
     }
@@ -258,7 +258,7 @@ struct CollectiveFingerPrint {
         return;
       }
       for (size_t i = 0; i < other.size(); ++i) {
-        if (other[i].compare(curr[i]) != 0) {
+        if (other[i] != curr[i]) {
           found_diff = true;
           ss << c10::str("  Tensor ", arg, ": ", curr, "vs ", other);
           return;


### PR DESCRIPTION
Adds a clang-tidy check to ensure string compare is not used unnecessarily in a way that is less efficient and less readable if an equality overload exists.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225