### PR TITLE
[AOTInductor] Add updaing constant buffer to active buffer.

### DIFF
--- a/test/cpp/aot_inductor/test.cpp
+++ b/test/cpp/aot_inductor/test.cpp
@@ -72,6 +72,74 @@ void test_aoti_script(const std::string& device) {
   }
 }
 
+void test_aoti_constants_update(const std::string& device) {
+  torch::NoGradGuard no_grad;
+
+  std::string data_path =
+      (std::filesystem::path(STRINGIZE(CMAKE_CURRENT_BINARY_DIR)) / "data.pt")
+           .string();
+
+  torch::jit::script::Module data_loader = torch::jit::load(data_path);
+  std::string path_attr = "model_so_path_" + device;
+  std::string inputs_attr = "inputs_" + device;
+  std::string outputs_attr = "outputs_" + device;
+  std::string weights_attr = "fc_weight_" + device;
+  std::string bias_attr = "fc_bias_" + device;
+  const auto& model_so_path = data_loader.attr(path_attr.c_str()).toStringRef();
+  const auto& input_tensors =
+      data_loader.attr(inputs_attr.c_str()).toTensorList().vec();
+  const auto& ref_output_tensors =
+      data_loader.attr(outputs_attr.c_str()).toTensorList().vec();
+
+  const auto& weight_tensors =
+      data_loader.attr(weights_attr.c_str()).toTensor();
+  const auto& bias_tensors = data_loader.attr(bias_attr.c_str()).toTensor();
+
+  torch::inductor::TensorConstantMap missing_map, rand_map, real_map;
+  missing_map.emplace(
+      "L__self___fc_weight", new at::Tensor(at::randn({10, 64})));
+  rand_map.emplace("L__self___fc_weight", new at::Tensor(at::randn({10, 64})));
+  rand_map.emplace("L__self___fc_bias", new at::Tensor(at::randn({10})));
+  real_map.emplace("L__self___fc_weight", new at::Tensor(weight_tensors));
+  real_map.emplace("L__self___fc_bias", new at::Tensor(bias_tensors));
+
+  std::unique_ptr<torch::inductor::AOTIModelContainerRunner> runner;
+  if (device == "cuda") {
+    runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCuda>(
+        model_so_path.c_str());
+  } else if (device == "cpu") {
+    runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCpu>(
+        model_so_path.c_str());
+  } else {
+    testing::AssertionFailure() << "unsupported device: " << device;
+  }
+  // By default, buffer #1 get loaded with burned in weights. Correct results.
+  auto actual_output_tensors = runner->run(input_tensors);
+  ASSERT_TRUE(torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
+
+  // Update with missing map which should throw.
+  EXPECT_THROW(
+      runner->update_constant_buffer(missing_map, false, true),
+      std::runtime_error);
+
+  // Update random weight to buffer #1.
+  runner->update_constant_buffer(missing_map, false, false);
+  actual_output_tensors = runner->run(input_tensors);
+  ASSERT_FALSE(
+      torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
+
+  // Update with real weight.
+  runner->update_constant_buffer(real_map, false, false);
+  actual_output_tensors = runner->run(input_tensors);
+  ASSERT_TRUE(torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
+
+  // Update with full random weight.
+  runner->update_constant_buffer(rand_map, false, true);
+  actual_output_tensors = runner->run(input_tensors);
+  ASSERT_FALSE(
+      torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
+}
+
 void test_aoti_double_buffering(const std::string& device) {
   torch::NoGradGuard no_grad;
 
@@ -163,6 +231,10 @@ TEST(AotInductorTest, BasicScriptTestCuda) {
 }
 
 TEST(AotInductorTest, UpdateConstantsCuda) {
+  test_aoti_constants_update("cuda");
+}
+
+TEST(AotInductorTest, UpdateInactiveConstantsCuda) {
   test_aoti_double_buffering("cuda");
 }
 #endif

--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -104,16 +104,28 @@ AOTIRuntimeError AOTInductorModelContainerRun(
   })
 }
 
-AOTIRuntimeError AOTInductorModelContainerUpdateInactiveConstantBuffer(
+AOTIRuntimeError AOTInductorModelContainerUpdateConstantBuffer(
     AOTInductorModelContainerHandle container_handle,
-    AOTInductorConstantMapHandle constant_map_handle) {
+    AOTInductorConstantMapHandle constant_map_handle,
+    bool use_inactive,
+    bool validate_full_update) {
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
   auto input_map = reinterpret_cast<std::unordered_map<std::string, AtenTensorHandle>*>(constant_map_handle);
   CONVERT_EXCEPTION_TO_ERROR_CODE({
-    container->update_inactive_constant_buffer(*input_map);
+    container->update_constant_buffer(
+        *input_map, use_inactive, validate_full_update);
   })
+}
+
+AOTIRuntimeError AOTInductorModelContainerUpdateInactiveConstantBuffer(
+    AOTInductorModelContainerHandle container_handle,
+    AOTInductorConstantMapHandle constant_map_handle) {
+  return AOTInductorModelContainerUpdateConstantBuffer(container_handle,
+          constant_map_handle,
+          /*use_inactive*/ true,
+          /*validate_full_update*/ true);
 }
 
 AOTIRuntimeError AOTInductorModelContainerSwapConstantBuffer(

--- a/torch/csrc/inductor/aoti_model_container_runner.cpp
+++ b/torch/csrc/inductor/aoti_model_container_runner.cpp
@@ -21,6 +21,9 @@ AOTIModelContainerRunner::AOTIModelContainerRunner(
       model_so_->sym("AOTInductorModelContainerGetNumOutputs"));
   run_func_ = reinterpret_cast<decltype(run_func_)>(
       model_so_->sym("AOTInductorModelContainerRun"));
+  update_constant_buffer_func_ =
+      reinterpret_cast<decltype(update_constant_buffer_func_)>(
+          model_so_->sym("AOTInductorModelContainerUpdateConstantBuffer"));
   update_inactive_constant_buffer_func_ =
       reinterpret_cast<decltype(update_inactive_constant_buffer_func_)>(
           model_so_->sym(
@@ -66,6 +69,17 @@ std::vector<at::Tensor> AOTIModelContainerRunner::run(
 
   return torch::aot_inductor::alloc_tensors_by_stealing_from_handles(
       output_handles.data(), output_handles.size());
+}
+
+void AOTIModelContainerRunner::update_constant_buffer(
+    const TensorConstantMap& const_map,
+    bool use_inactive,
+    bool check_full_update) {
+  AOTI_RUNTIME_ERROR_CODE_CHECK(update_constant_buffer_func_(
+      container_handle_,
+      (AOTInductorConstantMapHandle)&const_map,
+      use_inactive,
+      check_full_update));
 }
 
 void AOTIModelContainerRunner::update_inactive_constant_buffer(

--- a/torch/csrc/inductor/aoti_model_container_runner.h
+++ b/torch/csrc/inductor/aoti_model_container_runner.h
@@ -29,6 +29,10 @@ class TORCH_API AOTIModelContainerRunner {
       AOTIProxyExecutorHandle proxy_executor_handle = nullptr);
 
   void update_inactive_constant_buffer(const TensorConstantMap& const_map);
+  void update_constant_buffer(
+      const TensorConstantMap& const_map,
+      bool use_inactive,
+      bool validate_full_updates);
   void swap_constant_buffer();
 
   std::vector<const char*> get_call_spec();
@@ -46,6 +50,8 @@ class TORCH_API AOTIModelContainerRunner {
   decltype(&AOTInductorModelContainerGetNumOutputs) get_num_outputs_func_{
       nullptr};
   decltype(&AOTInductorModelContainerRun) run_func_{nullptr};
+  decltype(&AOTInductorModelContainerUpdateConstantBuffer)
+      update_constant_buffer_func_{nullptr};
   decltype(&AOTInductorModelContainerUpdateInactiveConstantBuffer)
       update_inactive_constant_buffer_func_{nullptr};
   decltype(&AOTInductorModelContainerSwapConstantBuffer)

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -70,6 +70,15 @@ AOTIRuntimeError AOTInductorModelContainerRun(
     AOTInductorStreamHandle stream_handle,
     AOTIProxyExecutorHandle proxy_executor_handle);
 
+// Setup the constant buffer in model container with provided ConstantMap
+// use_inactive should be set as true if the inactive buffer is to be updated.
+// validate_full_update checks if all constants are included in the ConstantMap
+AOTIRuntimeError AOTInductorModelContainerUpdateConstantBuffer(
+    AOTInductorModelContainerHandle container_handle,
+    AOTInductorConstantMapHandle constant_map_handle,
+    bool use_inactive,
+    bool validate_full_update);
+
 // Setup the inactive constant buffer in model container with provided
 // ConstantMap
 AOTIRuntimeError AOTInductorModelContainerUpdateInactiveConstantBuffer(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #116001

Summary:
Refactor update inactive constant buffer to allow updating with active
buffer.

Test Plan:
Existing test to test inactive buffer updates.
UpdateConstantsCuda in cpp test for active buffer updates.

Reviewers:

Subscribers:

Tasks:

Tags:

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @aakhundov @ColinPeppler