### PR TITLE
[wip] fix llama regression

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1234,25 +1234,27 @@ class WrapperCodeGen(CodeGen):
 
         # can be freed but not reused
         if isinstance(buffer, ir.InputBuffer):
-            def _check(_input_buffer, _output_buffer):
-                # Fix a failure in UT:
-                # python -u -m pytest -s -v test_torchinductor.py -k test_add_inplace_permuted
-                # since we will return InputBuffer in above example after fix,
-                # We need prevent it from deleted:
-                # Case 1: output_buffer is exactly same as input_buffer
-                # Case 2: _output_buffer's layout is a MutationLayout, target of which is the input buffer
-                if (
-                    _input_buffer == _output_buffer
-                    or (
-                       isinstance(_output_buffer.layout, ir.MutationLayout)
-                       and  _output_buffer.layout.get_buffer().get_name() == _input_buffer.get_name()
-                    )
-                ):
-                    return True
-                return False
+            # def _check(_input_buffer, _output_buffer):
+            #     # Fix a failure in UT:
+            #     # python -u -m pytest -s -v test_torchinductor.py -k test_add_inplace_permuted
+            #     # since we will return InputBuffer in above example after fix,
+            #     # We need prevent it from deleted:
+            #     # Case 1: output_buffer is exactly same as input_buffer
+            #     # Case 2: _output_buffer's layout is a MutationLayout, target of which is the input buffer
+            #     if (
+            #         _input_buffer == _output_buffer
+            #         or (
+            #            isinstance(_output_buffer.layout, ir.MutationLayout)
+            #            and  _output_buffer.layout.get_buffer().get_name() == _input_buffer.get_name()
+            #         )
+            #     ):
+            #         return True
+            #     return False
 
-            if not any(_check(buffer, output) for output in V.graph.graph_outputs):
-                self.writeline(self.make_buffer_free(buffer))
+            # if not any(_check(buffer, output) for output in V.graph.graph_outputs):
+            #     self.writeline(self.make_buffer_free(buffer))
+            
+            self.writeline(self.make_buffer_free(buffer))
             return
 
         if not self.can_reuse(buffer):

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1234,15 +1234,18 @@ class WrapperCodeGen(CodeGen):
 
         # can be freed but not reused
         if isinstance(buffer, ir.InputBuffer):
-            def _check(_check_buffer, _output_buffer):
+            def _check(_input_buffer, _output_buffer):
                 # Fix a failure in UT:
                 # python -u -m pytest -s -v test_torchinductor.py -k test_add_inplace_permuted
-                # since we will return InputBuffer in above example, we need prevent it from deleted
+                # since we will return InputBuffer in above example after fix,
+                # We need prevent it from deleted:
+                # Case 1: output_buffer is exactly same as input_buffer
+                # Case 2: _output_buffer's layout is a MutationLayout, target of which is the input buffer
                 if (
-                    _check_buffer == _output_buffer
+                    _input_buffer == _output_buffer
                     or (
                        isinstance(_output_buffer.layout, ir.MutationLayout)
-                       and  _check_buffer.get_name() == _output_buffer.layout.get_buffer().get_name()
+                       and  _output_buffer.layout.get_buffer().get_name() = _input_buffer.get_name()
                     )
                 ):
                     return True

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1245,7 +1245,7 @@ class WrapperCodeGen(CodeGen):
                     _input_buffer == _output_buffer
                     or (
                        isinstance(_output_buffer.layout, ir.MutationLayout)
-                       and  _output_buffer.layout.get_buffer().get_name() = _input_buffer.get_name()
+                       and  _output_buffer.layout.get_buffer().get_name() == _input_buffer.get_name()
                     )
                 ):
                     return True

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -544,45 +544,45 @@ def fx_codegen_and_compile(
                     else:
                         output_strides.append(None)
 
-            for buffer in graph.buffers:
-                from .ir import MutationLayout, Pointwise, FlexibleLayout
+            # for buffer in graph.buffers:
+            #     from .ir import MutationLayout, Pointwise, FlexibleLayout
 
-                # Here we say this buffer is created by of the src.data:
-                # src.data.layout = MutationLayout(dst)
-                # https://github.com/pytorch/pytorch/blob/34fe850d0083688abf0a27f3e864723f0858aab1/torch/_inductor/ir.py#L2709-L2711
-                if isinstance(buffer.layout, MutationLayout):
-                    # mutation_names = [dst_name]
-                    mutation_names = buffer.get_mutation_names()
-                    for mutation_name in mutation_names:
-                        # mutation_buf is dst
-                        mutation_buf = graph.get_buffer(mutation_name)
-                        # TODO<Leslie> how to we know whether we need to do the lazy copy of this buffer? Can we say:
-                        # we care if any mutation_buf_user created after src.data.layout = MutationLayout(dst)
-                        if graph.name_to_users_snapshot[mutation_name] != graph.name_to_users[mutation_name]:
-                            # if mutation_name has users added after we mark src.data.layout = MutationLayout(dst)
-                            # 2.1 Do the lazy copies
-                            src = buffer
-                            dst = mutation_buf
-                            src = Pointwise.create(
-                                device=src.get_device(),
-                                dtype=src.get_dtype(),
-                                inner_fn=src.make_loader(),
-                                ranges=[
-                                    graph.sizevars.guard_equals(a, b)
-                                    for a, b in zip(src.get_size(), dst.get_size())
-                                ],
-                            ).data
-                            src.realize()
+            #     # Here we say this buffer is created by of the src.data:
+            #     # src.data.layout = MutationLayout(dst)
+            #     # https://github.com/pytorch/pytorch/blob/34fe850d0083688abf0a27f3e864723f0858aab1/torch/_inductor/ir.py#L2709-L2711
+            #     if isinstance(buffer.layout, MutationLayout):
+            #         # mutation_names = [dst_name]
+            #         mutation_names = buffer.get_mutation_names()
+            #         for mutation_name in mutation_names:
+            #             # mutation_buf is dst
+            #             mutation_buf = graph.get_buffer(mutation_name)
+            #             # TODO<Leslie> how to we know whether we need to do the lazy copy of this buffer? Can we say:
+            #             # we care if any mutation_buf_user created after src.data.layout = MutationLayout(dst)
+            #             if graph.name_to_users_snapshot[mutation_name] != graph.name_to_users[mutation_name]:
+            #                 # if mutation_name has users added after we mark src.data.layout = MutationLayout(dst)
+            #                 # 2.1 Do the lazy copies
+            #                 src = buffer
+            #                 dst = mutation_buf
+            #                 src = Pointwise.create(
+            #                     device=src.get_device(),
+            #                     dtype=src.get_dtype(),
+            #                     inner_fn=src.make_loader(),
+            #                     ranges=[
+            #                         graph.sizevars.guard_equals(a, b)
+            #                         for a, b in zip(src.get_size(), dst.get_size())
+            #                     ],
+            #                 ).data
+            #                 src.realize()
 
-                            # Set the copied buf's layout to MutationLayout
-                            src.data.layout = MutationLayout(dst)
+            #                 # Set the copied buf's layout to MutationLayout
+            #                 src.data.layout = MutationLayout(dst)
 
-                            # 2.3 reset original buffer's layout to FlexibleLayout
-                            buffer.data.layout = FlexibleLayout(
-                                device=src.get_device(),
-                                dtype=src.get_dtype(),
-                                size=src.get_size(),
-                            )
+            #                 # 2.3 reset original buffer's layout to FlexibleLayout
+            #                 buffer.data.layout = FlexibleLayout(
+            #                     device=src.get_device(),
+            #                     dtype=src.get_dtype(),
+            #                     size=src.get_size(),
+            #                 )
                             
 
             compiled_fn = graph.compile_to_fn()

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -236,6 +236,9 @@ class GraphLowering(torch.fx.Interpreter):
         self.mutated_input_idxs: List[int] = []
         self.name_to_buffer: Dict[str, ir.Buffer] = {}
         self.name_to_users: DefaultDict[str, List[ir.IRNode]] = defaultdict(list)
+
+        self.name_to_users_snapshot: DefaultDict[str, List[ir.IRNode]] = defaultdict(list)
+
         self.creation_time = time.time()
         self.name = "GraphLowering"
         self.cpp_wrapper = cpp_wrapper

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2687,28 +2687,33 @@ class MutationLayout(Layout):
         if isinstance(src, TensorBox):
             src = src.data
 
-        # We copy the contents of src into dst. In most cases this should
-        # be fused into a single kernel by the scheduler.
-        # NOTE: We cannot change src's layout to mutate dst directly as this
-        # would alias src to dst, which is not correct as further mutations to
-        # dst would effect users of src. However if there are no more users of
-        # dst, we can alias src to dst.
-        src.realize_hint()
+        # # We copy the contents of src into dst. In most cases this should
+        # # be fused into a single kernel by the scheduler.
+        # # NOTE: We cannot change src's layout to mutate dst directly as this
+        # # would alias src to dst, which is not correct as further mutations to
+        # # dst would effect users of src. However if there are no more users of
+        # # dst, we can alias src to dst.
+        # src.realize_hint()
 
-        if not unsafe_alias:
-            src = Pointwise.create(
-                device=src.get_device(),
-                dtype=src.get_dtype(),
-                inner_fn=src.make_loader(),
-                ranges=[
-                    V.graph.sizevars.guard_equals(a, b)
-                    for a, b in zip(src.get_size(), dst.get_size())
-                ],
-            ).data
+        # if not unsafe_alias:
+        #     src = Pointwise.create(
+        #         device=src.get_device(),
+        #         dtype=src.get_dtype(),
+        #         inner_fn=src.make_loader(),
+        #         ranges=[
+        #             V.graph.sizevars.guard_equals(a, b)
+        #             for a, b in zip(src.get_size(), dst.get_size())
+        #         ],
+        #     ).data
+
+        # TODO<leslie> fix the zero_element_mutation issue as: 
+        # python -u -m pytest -s -v test_torchinductor.py -k test_zero_element_mutation
 
         src.realize()
         assert isinstance(src.data.layout, FlexibleLayout)
         src.data.layout = MutationLayout(dst)
+        assert dst.get_name() not in V.graph.name_to_users_snapshot, "TODO: can we mutate src twice?"
+        V.graph.name_to_users_snapshot[dst.get_name()] = V.graph.name_to_users[dst.get_name()]
         return src.data
 
     def as_fixed(self):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2805,15 +2805,15 @@ class Buffer(IRNode):
         return False
 
     def codegen_reference(self, writer=None):
-        if isinstance(self.layout, MutationLayout):
-            # Fix a failure in UT:
-            # python -u -m pytest -s -v test_torchinductor.py -k test_add_inplace_permuted
-            # def test(x1, x2):
-            #   buf0 = x1 + x2
-            #   copy_(x1, buf0)
-            #   return buf0
-            # In this case, we found buf0 didn't generate, so return the mutation buffer (x1) instead
-            return self.layout.get_buffer().get_name()
+        # if isinstance(self.layout, MutationLayout):
+        #     # Fix a failure in UT:
+        #     # python -u -m pytest -s -v test_torchinductor.py -k test_add_inplace_permuted
+        #     # def test(x1, x2):
+        #     #   buf0 = x1 + x2
+        #     #   copy_(x1, buf0)
+        #     #   return buf0
+        #     # In this case, we found buf0 didn't generate, so return the mutation buffer (x1) instead
+        #     return self.layout.get_buffer().get_name()
         return self.get_name()
 
     def decide_layout(self):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2808,7 +2808,11 @@ class Buffer(IRNode):
         if isinstance(self.layout, MutationLayout):
             # Fix a failure in UT:
             # python -u -m pytest -s -v test_torchinductor.py -k test_add_inplace_permuted
-            # We found buf0 didn't generate, so return the mutation buffer instead
+            # def test(x1, x2):
+            #   buf0 = x1 + x2
+            #   copy_(x1, buf0)
+            #   return buf0
+            # In this case, we found buf0 didn't generate, so return the mutation buffer (x1) instead
             return self.layout.get_buffer().get_name()
         return self.get_name()
 


### PR DESCRIPTION
Fixes [#109874](https://github.com/pytorch/pytorch/issues/109874)
**Summary**

Change the implementation of `MutationLayout.realize_into`

## Current implementation of `MutationLayout.realize_into`
1. Eager copy `src_buf` into `src_buf2`
2. Mark `src_buf2.data.layout = MutationLayout(dst)`

## Proposed optimized implementation
1. Do lazy copy of src_buf into src_buf2 when dst has been changed
    TODO<Leslie>: Can we say dst has extra users if `graph.name_to_users[dst]` increased after `src.data.layout = MutationLayout(dst)`, then we should do the lazy copy of src? 
2. Do the lazy copy
    2.1 Find all the alais/mutation buffer of dst
    2.2 Do the copy of the alais/mutation buffer into alais/mutation buffer2, set `buffer2.data.layout = mutation_layout(dst)`
    2.3 Reset these original alais/mutation buffer to FlexibleLayout

**TODO**
Fix the known issue of fix the zero_element_mutation issue as:  `python -u -m pytest -s -v test_torchinductor.py -k test_zero_element_mutation`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler