### PR TITLE
[export] Undo "module: export" labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,10 +8,6 @@
 - torch/_inductor/**
 - test/inductor/**
 
-"module: export":
-- torch/_export/**
-- test/export/**
-
 "ciflow/inductor":
 - torch/_decomp/**
 - torch/_dynamo/**


### PR DESCRIPTION
Delete the auto-labeling of "module: export" as this is not really used, and we want to delete the "module: export" label.