### PR TITLE
Unflake test_reference_numerics_large__refs_special_multigammaln_mvlgamma_p_1_cpu_bfloat16

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -20198,8 +20198,10 @@ python_ref_db = [
         torch_opinfo_variant_name="mvlgamma_p_1",
         skips=skips_mvlgamma(),
         decorators=(
-            torch.testing._internal.common_utils.markDynamoStrictTest,
-            torch.testing._internal.common_utils.xfailIfTorchDynamo,
+            DecorateInfo(torch.testing._internal.common_utils.markDynamoStrictTest, 'TestUnaryUfuncs',
+                         'test_reference_numerics_large'),
+            DecorateInfo(torch.testing._internal.common_utils.xfailIfTorchDynamo, 'TestUnaryUfuncs',
+                         'test_reference_numerics_large'),
         ),
     ),
     ElementwiseUnaryPythonRefInfo(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -20197,6 +20197,10 @@ python_ref_db = [
         torch_opinfo_name="mvlgamma",
         torch_opinfo_variant_name="mvlgamma_p_1",
         skips=skips_mvlgamma(),
+        decorators=(
+            torch.testing._internal.common_utils.markDynamoStrictTest,
+            torch.testing._internal.common_utils.xfailIfTorchDynamo,
+        ),
     ),
     ElementwiseUnaryPythonRefInfo(
         "_refs.special.multigammaln",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #116058

Run the test under markDynamoStrict mode and record an expected failure
under the Dynamo CI shard.

Test Plan:
- wait for CI