### PR TITLE
Fix index range check

### DIFF
--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -247,7 +247,7 @@ static inline Tensor applySelect(
 
     auto size = (*self_sizes)[dim];
     TORCH_CHECK_INDEX(
-        size >= -index && size > index,
+        size > -1 - index && size > index,
         "index ",
         index,
         " is out of bounds for dimension ",

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -246,6 +246,10 @@ static inline Tensor applySelect(
     }
 
     auto size = (*self_sizes)[dim];
+    // Note: `size >= -index` is not equivalent to `size > -1 - index` if index is INT64_MIN
+    // For std::numeric_limits<int64_t>::min() result of unary minus is undefined by the standard
+    // but in practice is equal to self. On the other hand, indexing wraping is valid for all
+    // negative int64_t values, as x[INT64_MIN] is the same as x[INT64_MAX]
     TORCH_CHECK_INDEX(
         size > -1 - index && size > index,
         "index ",

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -246,10 +246,11 @@ static inline Tensor applySelect(
     }
 
     auto size = (*self_sizes)[dim];
-    // Note: `size >= -index` is not equivalent to `size > -1 - index` if index is INT64_MIN
-    // For std::numeric_limits<int64_t>::min() result of unary minus is undefined by the standard
-    // but in practice is equal to self. On the other hand, indexing wraping is valid for all
-    // negative int64_t values, as x[INT64_MIN] is the same as x[INT64_MAX]
+    // Note: `size >= -index` is not equivalent to `size > -1 - index` if index
+    // is INT64_MIN For std::numeric_limits<int64_t>::min() result of unary
+    // minus is undefined by the standard but in practice is equal to self. On
+    // the other hand, indexing wraping is valid for all negative int64_t
+    // values, as x[INT64_MIN] is the same as x[INT64_MAX]
     TORCH_CHECK_INDEX(
         size > -1 - index && size > index,
         "index ",

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1828,7 +1828,11 @@ Tensor select_symint(const Tensor& self, int64_t dim, c10::SymInt index) {
   }
   dim = maybe_wrap_dim(dim, ndim);
   auto size = self.sym_sizes()[dim];
-  if (size < -index || size <= index) {
+  // Note: `size < -index` is not equivalent to `size <= -1 - index` if index is INT64_MIN
+  // For std::numeric_limits<int64_t>::min() result of unary minus is undefined by the standard
+  // but in practice is equal to self. On the other hand, indexing wraping is valid for all
+  // negative int64_t values, as x[INT64_MIN] is the same as x[INT64_MAX]
+  if (size <= -1 - index || size <= index) {
     if (self.has_names() && self.names()[dim] != Dimname::wildcard()) {
       TORCH_CHECK_INDEX(false, "select(): index ", index, " out of range for tensor of size ",
                      self.sizes(), " at dimension ", self.names()[dim]);

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1395,11 +1395,13 @@ class TestIndexing(TestCase):
             tensor_b[6] = 1.0
             self.assertEqual(tensor_a, tensor_b.cpu(), atol=0, rtol=0)
 
-    def test_minint_of_empty(self, device):
+    def test_index_limits(self, device):
         #  Regression test for https://github.com/pytorch/pytorch/issues/115415
         t = torch.tensor([], device=device)
-        idx = torch.iinfo(torch.int64).min
-        self.assertRaises(IndexError, lambda: t[idx])
+        idx_min = torch.iinfo(torch.int64).min
+        idx_max = torch.iinfo(torch.int64).max
+        self.assertRaises(IndexError, lambda: t[idx_min])
+        self.assertRaises(IndexError, lambda: t[idx_max])
 
 
 

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1397,9 +1397,9 @@ class TestIndexing(TestCase):
 
     def test_minint_of_empty(self, device):
         #  Regression test for https://github.com/pytorch/pytorch/issues/115415
-        t = torch.tensor([], device_device)
+        t = torch.tensor([], device=device)
         idx = torch.iinfo(torch.int64).min
-        self.assertRaises(RuntimeError, lambda: t[idx])
+        self.assertRaises(IndexError, lambda: t[idx])
 
 
 

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1395,6 +1395,13 @@ class TestIndexing(TestCase):
             tensor_b[6] = 1.0
             self.assertEqual(tensor_a, tensor_b.cpu(), atol=0, rtol=0)
 
+    def test_minint_of_empty(self, device):
+        #  Regression test for https://github.com/pytorch/pytorch/issues/115415
+        t = torch.tensor([], device_device)
+        idx = torch.iinfo(torch.int64).min
+        self.assertRaises(RuntimeError, lambda: t[idx])
+
+
 
 # The tests below are from NumPy test_indexing.py with some modifications to
 # make them compatible with PyTorch. It's licensed under the BDS license below:

--- a/torch/csrc/utils/python_numbers.h
+++ b/torch/csrc/utils/python_numbers.h
@@ -52,25 +52,25 @@ inline bool THPUtils_checkLong(PyObject* obj) {
 }
 
 inline int32_t THPUtils_unpackInt(PyObject* obj) {
-  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  int overflow;
+  int overflow = 1;
   long value = PyLong_AsLongAndOverflow(obj, &overflow);
   if (value == -1 && PyErr_Occurred()) {
     throw python_error();
   }
   if (overflow != 0) {
-    throw std::runtime_error("Overflow when unpacking long");
+    throw std::runtime_error("Overflow when unpacking int");
   }
+  // Note: int32_min is excluded from the range, as its the only value
+  // which does not have a defined behavior for unary minus operator
   if (value > std::numeric_limits<int32_t>::max() ||
-      value < std::numeric_limits<int32_t>::min()) {
-    throw std::runtime_error("Overflow when unpacking long");
+      value <= std::numeric_limits<int32_t>::min()) {
+    throw std::runtime_error("Overflow when unpacking int");
   }
-  return (int32_t)value;
+  return static_cast<int32_t>(value);
 }
 
 inline int64_t THPUtils_unpackLong(PyObject* obj) {
-  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  int overflow;
+  int overflow = 1;
   long long value = PyLong_AsLongLongAndOverflow(obj, &overflow);
   if (value == -1 && PyErr_Occurred()) {
     throw python_error();
@@ -78,7 +78,13 @@ inline int64_t THPUtils_unpackLong(PyObject* obj) {
   if (overflow != 0) {
     throw std::runtime_error("Overflow when unpacking long");
   }
-  return (int64_t)value;
+  // int64_min is weird, as its the only value where unary minus
+  // behavior is undefined, though many modern compilers belive
+  // that -int_min == int_min, see https://godbolt.org/z/Wxhh44ocr
+  if (value == std::numeric_limits<int64_t>::min()) {
+    throw std::runtime_error("Overflow when unpacking long");
+  }
+  return static_cast<int64_t>(value);
 }
 
 inline uint32_t THPUtils_unpackUInt32(PyObject* obj) {

--- a/torch/csrc/utils/python_numbers.h
+++ b/torch/csrc/utils/python_numbers.h
@@ -52,25 +52,25 @@ inline bool THPUtils_checkLong(PyObject* obj) {
 }
 
 inline int32_t THPUtils_unpackInt(PyObject* obj) {
-  int overflow = 1;
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+  int overflow;
   long value = PyLong_AsLongAndOverflow(obj, &overflow);
   if (value == -1 && PyErr_Occurred()) {
     throw python_error();
   }
   if (overflow != 0) {
-    throw std::runtime_error("Overflow when unpacking int");
+    throw std::runtime_error("Overflow when unpacking long");
   }
-  // Note: int32_min is excluded from the range, as its the only value
-  // which does not have a defined behavior for unary minus operator
   if (value > std::numeric_limits<int32_t>::max() ||
-      value <= std::numeric_limits<int32_t>::min()) {
-    throw std::runtime_error("Overflow when unpacking int");
+      value < std::numeric_limits<int32_t>::min()) {
+    throw std::runtime_error("Overflow when unpacking long");
   }
-  return static_cast<int32_t>(value);
+  return (int32_t)value;
 }
 
 inline int64_t THPUtils_unpackLong(PyObject* obj) {
-  int overflow = 1;
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+  int overflow;
   long long value = PyLong_AsLongLongAndOverflow(obj, &overflow);
   if (value == -1 && PyErr_Occurred()) {
     throw python_error();
@@ -78,13 +78,7 @@ inline int64_t THPUtils_unpackLong(PyObject* obj) {
   if (overflow != 0) {
     throw std::runtime_error("Overflow when unpacking long");
   }
-  // int64_min is weird, as its the only value where unary minus
-  // behavior is undefined, though many modern compilers belive
-  // that -int_min == int_min, see https://godbolt.org/z/Wxhh44ocr
-  if (value == std::numeric_limits<int64_t>::min()) {
-    throw std::runtime_error("Overflow when unpacking long");
-  }
-  return static_cast<int64_t>(value);
+  return (int64_t)value;
 }
 
 inline uint32_t THPUtils_unpackUInt32(PyObject* obj) {


### PR DESCRIPTION
Fixes incorrect range check when index is `std::numeric_limits<int64_t>::min()`, as result of unary minus operations for such values is undefined, but in practice is equal to self, see https://godbolt.org/z/Wxhh44ocr

Lower bound check was `size >= -index`, which was incorrect if `index` is `INT64_MIN`, with `-1 - index`, which for all int64_t values returns result that also fits into int64_t range. `- (index + 1)` is more readable and results in the identical optimized assembly, see https://godbolt.org/z/3vcnMYf9a , but its intermediate result for `INT64_MAX` is  outside of `int64_t` range, which leads to a similar problems as with `int64_min` in original example.

Added regression test.

Fixes https://github.com/pytorch/pytorch/issues/115415



cc @mruberry @rgommers @pmeier @asmeurer @leofang @AnirudhDagar @asi1024 @emcastillo @kmaehashi