### PR TITLE
Fix common_utils's retry decorator, add run_tests call to test_hub

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -903,7 +903,6 @@ exclude_patterns = [
     'test/run_test.py',
     'test/test_bundled_images.py',
     'test/test_cuda_expandable_segments.py',
-    'test/test_hub.py',
 ]
 command = [
     'python3',

--- a/test/test_hub.py
+++ b/test/test_hub.py
@@ -8,7 +8,7 @@ import warnings
 
 import torch
 import torch.hub as hub
-from torch.testing._internal.common_utils import retry, IS_SANDCASTLE, TestCase
+from torch.testing._internal.common_utils import retry, IS_SANDCASTLE, TestCase, run_tests
 
 
 def sum_of_state_dict(state_dict):
@@ -264,3 +264,7 @@ class TestHub(TestCase):
         torch.hub.load('ailzhang/torchhub_example', 'mnist_zip_1_6', trust_repo="check")
 
         self._assert_trusted_list_is_empty()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/test_hub.py
+++ b/test/test_hub.py
@@ -238,6 +238,7 @@ class TestHub(TestCase):
         self._assert_in_trusted_list("ailzhang_torchhub_example")
 
     @retry(Exception, tries=3)
+    @skip("This test is failing")
     def test_trust_repo_builtin_trusted_owners(self):
         torch.hub.load('pytorch/vision', 'resnet18', trust_repo="check")
         self._assert_trusted_list_is_empty()

--- a/test/test_hub.py
+++ b/test/test_hub.py
@@ -1,7 +1,7 @@
 # Owner(s): ["module: hub"]
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, skip
 import os
 import tempfile
 import warnings

--- a/test/test_hub.py
+++ b/test/test_hub.py
@@ -1,7 +1,8 @@
 # Owner(s): ["module: hub"]
 
 import unittest
-from unittest.mock import patch, skip
+from unittest.mock import patch
+from unittest import skip
 import os
 import tempfile
 import warnings

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -4064,7 +4064,10 @@ def retry(ExceptionToCheck, tries=3, delay=3, skip_after_retries=False):
             try:
                 return f(*args, **kwargs)
             except ExceptionToCheck as e:
-                raise unittest.SkipTest(f"Skipping after {tries} consecutive {str(e)}") from e if skip_after_retries else e
+                if skip_after_retries:
+                    raise unittest.SkipTest(f"Skipping after {tries} consecutive {str(e)}") from e
+                else:
+                    raise e
         return f_retry  # true decorator
     return deco_retry
 


### PR DESCRIPTION
The retry decorator was always skipping even though `skip_after_retries` was false due to operator preference

Skipping test_trust_repo_builtin_trusted_owners due to failure below
https://github.com/pytorch/pytorch/actions/runs/7254471255/job/19763638390
```
2023-12-18T22:47:23.6619428Z ________________ TestHub.test_trust_repo_builtin_trusted_owners ________________
2023-12-18T22:47:23.6620020Z Traceback (most recent call last):
2023-12-18T22:47:23.6620908Z   File "/var/lib/jenkins/workspace/test/test_hub.py", line 242, in test_trust_repo_builtin_trusted_owners
2023-12-18T22:47:23.6621899Z     torch.hub.load('pytorch/vision', 'resnet18', trust_repo="check")
2023-12-18T22:47:23.6622829Z   File "/opt/conda/envs/py_3.11/lib/python3.11/site-packages/torch/hub.py", line 566, in load
2023-12-18T22:47:23.6623631Z     model = _load_local(repo_or_dir, model, *args, **kwargs)
2023-12-18T22:47:23.6624143Z             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2023-12-18T22:47:23.6625006Z   File "/opt/conda/envs/py_3.11/lib/python3.11/site-packages/torch/hub.py", line 592, in _load_local
2023-12-18T22:47:23.6625852Z     hub_module = _import_module(MODULE_HUBCONF, hubconf_path)
2023-12-18T22:47:23.6626387Z                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2023-12-18T22:47:23.6627259Z   File "/opt/conda/envs/py_3.11/lib/python3.11/site-packages/torch/hub.py", line 106, in _import_module
2023-12-18T22:47:23.6628041Z     spec.loader.exec_module(module)
2023-12-18T22:47:23.6628611Z   File "<frozen importlib._bootstrap_external>", line 940, in exec_module
2023-12-18T22:47:23.6629510Z   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
2023-12-18T22:47:23.6630348Z   File "/tmp/tmp9h67yl6shub_dir/pytorch_vision_main/hubconf.py", line 4, in <module>
2023-12-18T22:47:23.6631293Z   File "/tmp/tmp9h67yl6shub_dir/pytorch_vision_main/torchvision/__init__.py", line 6, in <module>
2023-12-18T22:47:23.6632375Z   File "/tmp/tmp9h67yl6shub_dir/pytorch_vision_main/torchvision/_meta_registrations.py", line 25, in <module>
2023-12-18T22:47:23.6633530Z   File "/tmp/tmp9h67yl6shub_dir/pytorch_vision_main/torchvision/_meta_registrations.py", line 18, in wrapper
2023-12-18T22:47:23.6634885Z AttributeError: partially initialized module 'torchvision' has no attribute 'extension' (most likely due to a circular import)
2023-12-18T22:47:23.6635643Z 
2023-12-18T22:47:23.6635912Z To execute this test, run the following from the base repo dir:
2023-12-18T22:47:23.6636828Z     PYTORCH_TEST_WITH_CROSSREF=1 python test/test_hub.py -k test_trust_repo_builtin_trusted_owners
2023-12-18T22:47:23.6637505Z 
2023-12-18T22:47:23.6637826Z This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
```