### PR TITLE
[CUDA] Include `<thrust/swap.h>` in `LinearAlgebra.cu`

### DIFF
--- a/aten/src/ATen/native/cuda/LinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/LinearAlgebra.cu
@@ -9,6 +9,8 @@
 #include <ATen/native/ReduceOps.h>
 #include <c10/core/Scalar.h>
 
+#include <thrust/swap.h>
+
 namespace at::native {
 
 namespace {


### PR DESCRIPTION
Fixes build against the latest `NVIDIA/cccl`.

CC @malfet @xwang233 @ptrblck 

cc @ptrblck @jianyuh @nikitaved @pearu @mruberry @walterddr @xwang233 @Lezcano