### PR TITLE
[CUDA] Raise `softmax_forward_64bit_indexing` GPU memory requirement

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12583,7 +12583,7 @@ if __name__ == '__main__':
 
     # reference issue: https://github.com/pytorch/pytorch/issues/111484
     @onlyCUDA
-    @largeTensorTest("41GB" if TEST_WITH_ROCM else "30GB", "cuda")
+    @largeTensorTest("42GB", "cuda")
     def test_softmax_forward_64bit_indexing(self, device):
         batch_size = 70
         seq_len = 2048


### PR DESCRIPTION
printing `torch.cuda.memory_summary()` shows ~41GiB reserved at the end of this test, not sure how it was passing previously on CUDA.

CC @ptrblck @malfet

cc @ptrblck