### PR TITLE
Enable compiled Adam in the benchmarks

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/aot_eager_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/aot_eager_huggingface_training.csv
@@ -2,7 +2,7 @@ name,accuracy,graph_breaks
 
 
 
-AlbertForMaskedLM,pass,4
+AlbertForMaskedLM,pass,5
 
 
 
@@ -14,11 +14,11 @@ AllenaiLongformerBase,pass,8
 
 
 
-BartForCausalLM,pass,12
+BartForCausalLM,pass,13
 
 
 
-BartForConditionalGeneration,pass,24
+BartForConditionalGeneration,pass,25
 
 
 
@@ -34,11 +34,11 @@ BlenderbotForCausalLM,eager_fail_to_run,0
 
 
 
-BlenderbotSmallForCausalLM,pass,12
+BlenderbotSmallForCausalLM,pass,13
 
 
 
-BlenderbotSmallForConditionalGeneration,pass,24
+BlenderbotSmallForConditionalGeneration,pass,25
 
 
 
@@ -74,7 +74,7 @@ DistillGPT2,pass,4
 
 
 
-ElectraForCausalLM,pass,4
+ElectraForCausalLM,pass,5
 
 
 
@@ -98,15 +98,15 @@ LayoutLMForSequenceClassification,pass,6
 
 
 
-M2M100ForConditionalGeneration,pass,4
+M2M100ForConditionalGeneration,pass,5
 
 
 
-MBartForCausalLM,pass,12
+MBartForCausalLM,pass,13
 
 
 
-MBartForConditionalGeneration,pass,24
+MBartForConditionalGeneration,pass,25
 
 
 
@@ -122,31 +122,31 @@ MegatronBertForQuestionAnswering,pass,4
 
 
 
-MobileBertForMaskedLM,pass,4
+MobileBertForMaskedLM,pass,3
 
 
 
-MobileBertForQuestionAnswering,pass,4
+MobileBertForQuestionAnswering,pass,3
 
 
 
-OPTForCausalLM,pass,12
+OPTForCausalLM,pass,13
 
 
 
-PLBartForCausalLM,pass,12
+PLBartForCausalLM,pass,13
 
 
 
-PLBartForConditionalGeneration,pass,29
+PLBartForConditionalGeneration,pass,30
 
 
 
-PegasusForCausalLM,pass,12
+PegasusForCausalLM,pass,13
 
 
 
-PegasusForConditionalGeneration,pass,24
+PegasusForConditionalGeneration,pass,23
 
 
 
@@ -158,7 +158,7 @@ RobertaForQuestionAnswering,pass,4
 
 
 
-Speech2Text2ForCausalLM,pass,12
+Speech2Text2ForCausalLM,pass,13
 
 
 
@@ -170,11 +170,11 @@ T5Small,pass,4
 
 
 
-TrOCRForCausalLM,pass,12
+TrOCRForCausalLM,pass,13
 
 
 
-XGLMForCausalLM,pass,12
+XGLMForCausalLM,pass,13
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/aot_eager_timm_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/aot_eager_timm_training.csv
@@ -2,7 +2,7 @@ name,accuracy,graph_breaks
 
 
 
-adv_inception_v3,pass,6
+adv_inception_v3,pass,7
 
 
 
@@ -10,7 +10,7 @@ beit_base_patch16_224,pass,6
 
 
 
-botnet26t_256,pass,6
+botnet26t_256,pass,7
 
 
 
@@ -18,15 +18,15 @@ cait_m36_384,eager_fail_to_run,0
 
 
 
-coat_lite_mini,pass,6
+coat_lite_mini,pass,7
 
 
 
-convit_base,pass,6
+convit_base,pass,7
 
 
 
-convmixer_768_32,pass,6
+convmixer_768_32,pass,5
 
 
 
@@ -54,7 +54,7 @@ dm_nfnet_f0,pass,6
 
 
 
-dpn107,pass,6
+dpn107,pass,7
 
 
 
@@ -74,15 +74,15 @@ fbnetc_100,pass,6
 
 
 
-fbnetv3_b,pass,6
+fbnetv3_b,pass,7
 
 
 
-gernet_l,pass,6
+gernet_l,pass,7
 
 
 
-ghostnet_100,pass,6
+ghostnet_100,pass,7
 
 
 
@@ -90,7 +90,7 @@ gluon_inception_v3,pass,6
 
 
 
-gmixer_24_224,pass,6
+gmixer_24_224,pass,7
 
 
 
@@ -98,11 +98,11 @@ gmlp_s16_224,pass,6
 
 
 
-hrnet_w18,pass,6
+hrnet_w18,pass,5
 
 
 
-inception_v3,pass,6
+inception_v3,pass,7
 
 
 
@@ -110,7 +110,7 @@ jx_nest_base,pass,6
 
 
 
-lcnet_050,fail_accuracy,6
+lcnet_050,fail_accuracy,7
 
 
 
@@ -122,7 +122,7 @@ mixer_b16_224,pass,6
 
 
 
-mixnet_l,pass,6
+mixnet_l,pass,7
 
 
 
@@ -138,7 +138,7 @@ mobilenetv3_large_100,pass,6
 
 
 
-mobilevit_s,pass,6
+mobilevit_s,pass,7
 
 
 
@@ -150,15 +150,15 @@ pit_b_224,pass,6
 
 
 
-pnasnet5large,pass,6
+pnasnet5large,pass,5
 
 
 
-poolformer_m36,pass,6
+poolformer_m36,pass,7
 
 
 
-regnety_002,pass,6
+regnety_002,pass,7
 
 
 
@@ -166,23 +166,23 @@ repvgg_a2,pass,6
 
 
 
-res2net101_26w_4s,pass,6
+res2net101_26w_4s,pass,7
 
 
 
-res2net50_14w_8s,pass,6
+res2net50_14w_8s,pass,7
 
 
 
-res2next50,pass,6
+res2next50,pass,7
 
 
 
-resmlp_12_224,pass,6
+resmlp_12_224,pass,7
 
 
 
-resnest101e,pass,6
+resnest101e,pass,7
 
 
 
@@ -190,11 +190,11 @@ rexnet_100,pass,6
 
 
 
-sebotnet33ts_256,pass,6
+sebotnet33ts_256,pass,7
 
 
 
-selecsls42b,pass,6
+selecsls42b,pass,7
 
 
 
@@ -206,11 +206,11 @@ swin_base_patch4_window7_224,pass,6
 
 
 
-swsl_resnext101_32x16d,pass,6
+swsl_resnext101_32x16d,pass,7
 
 
 
-tf_efficientnet_b0,pass,6
+tf_efficientnet_b0,pass,7
 
 
 
@@ -218,7 +218,7 @@ tf_mixnet_l,pass,6
 
 
 
-tinynet_a,pass,6
+tinynet_a,pass,7
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/aot_eager_timm_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/aot_eager_timm_training.csv
@@ -50,7 +50,7 @@ dla102,pass,6
 
 
 
-dm_nfnet_f0,pass,6
+dm_nfnet_f0,pass,7
 
 
 
@@ -146,7 +146,7 @@ nfnet_l0,pass,6
 
 
 
-pit_b_224,pass,6
+pit_b_224,pass,7
 
 
 
@@ -214,7 +214,7 @@ tf_efficientnet_b0,pass,7
 
 
 
-tf_mixnet_l,pass,6
+tf_mixnet_l,pass,7
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/aot_eager_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/aot_eager_torchbench_training.csv
@@ -2,11 +2,11 @@ name,accuracy,graph_breaks
 
 
 
-torchrec_dlrm,pass,6
+torchrec_dlrm,pass,7
 
 
 
-BERT_pytorch,pass,6
+BERT_pytorch,pass,7
 
 
 
@@ -18,7 +18,7 @@ DALLE2_pytorch,eager_fail_to_run,0
 
 
 
-LearningToPaint,pass,6
+LearningToPaint,pass,7
 
 
 
@@ -26,7 +26,7 @@ Super_SloMo,pass,6
 
 
 
-alexnet,pass,6
+alexnet,pass,7
 
 
 
@@ -50,15 +50,15 @@ cm3leon_generate,eager_fail_to_run,0
 
 
 
-dcgan,pass,6
+dcgan,pass,7
 
 
 
-demucs,pass,9
+demucs,pass,10
 
 
 
-densenet121,pass,6
+densenet121,pass,7
 
 
 
@@ -70,7 +70,7 @@ detectron2_maskrcnn_r_50_c4,eager_fail_to_run,0
 
 
 
-dlrm,pass,6
+dlrm,pass,7
 
 
 
@@ -86,7 +86,7 @@ drq,pass,5
 
 
 
-fastNLP_Bert,pass,10
+fastNLP_Bert,pass,11
 
 
 
@@ -126,7 +126,7 @@ hf_Reformer,pass,25
 
 
 
-hf_T5_base,pass,5
+hf_T5_base,pass,6
 
 
 
@@ -158,7 +158,7 @@ mnasnet1_0,pass,6
 
 
 
-mobilenet_v2,pass,6
+mobilenet_v2,pass,7
 
 
 
@@ -170,7 +170,7 @@ mobilenet_v3_large,pass,6
 
 
 
-moco,pass,17
+moco,pass,18
 
 
 
@@ -186,19 +186,19 @@ opacus_cifar10,eager_fail_to_run,0
 
 
 
-phlippe_densenet,pass,6
+phlippe_densenet,pass,7
 
 
 
-phlippe_resnet,pass,6
+phlippe_resnet,pass,7
 
 
 
-pytorch_CycleGAN_and_pix2pix,pass,6
+pytorch_CycleGAN_and_pix2pix,pass,7
 
 
 
-pytorch_stargan,pass,6
+pytorch_stargan,pass,7
 
 
 
@@ -210,11 +210,11 @@ resnet152,pass,6
 
 
 
-resnet18,pass,6
+resnet18,pass,7
 
 
 
-resnet50,pass,6
+resnet50,pass,7
 
 
 
@@ -230,7 +230,7 @@ sam,eager_fail_to_run,0
 
 
 
-shufflenet_v2_x1_0,pass,6
+shufflenet_v2_x1_0,pass,7
 
 
 
@@ -238,15 +238,15 @@ soft_actor_critic,pass,5
 
 
 
-speech_transformer,pass,16
+speech_transformer,pass,17
 
 
 
-squeezenet1_1,pass,6
+squeezenet1_1,pass,7
 
 
 
-stable_diffusion_text_encoder,pass,5
+stable_diffusion_text_encoder,pass,6
 
 
 
@@ -258,7 +258,7 @@ timm_efficientnet,pass,6
 
 
 
-timm_regnet,pass,6
+timm_regnet,pass,7
 
 
 
@@ -266,7 +266,7 @@ timm_resnest,pass,6
 
 
 
-timm_vision_transformer,pass,6
+timm_vision_transformer,pass,7
 
 
 
@@ -274,7 +274,7 @@ timm_vision_transformer_large,pass_due_to_skip,0
 
 
 
-timm_vovnet,pass,6
+timm_vovnet,pass,7
 
 
 
@@ -286,11 +286,11 @@ tts_angular,pass,8
 
 
 
-vgg16,pass,6
+vgg16,pass,7
 
 
 
-vision_maskrcnn,pass,34
+vision_maskrcnn,pass,35
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_huggingface_training.csv
@@ -2,7 +2,7 @@ name,accuracy,graph_breaks
 
 
 
-AlbertForMaskedLM,pass,4
+AlbertForMaskedLM,pass,5
 
 
 
@@ -14,11 +14,11 @@ AllenaiLongformerBase,pass,8
 
 
 
-BartForCausalLM,pass,12
+BartForCausalLM,pass,13
 
 
 
-BartForConditionalGeneration,pass,24
+BartForConditionalGeneration,pass,25
 
 
 
@@ -34,11 +34,11 @@ BlenderbotForCausalLM,eager_fail_to_run,0
 
 
 
-BlenderbotSmallForCausalLM,pass,12
+BlenderbotSmallForCausalLM,pass,13
 
 
 
-BlenderbotSmallForConditionalGeneration,pass,24
+BlenderbotSmallForConditionalGeneration,pass,25
 
 
 
@@ -74,7 +74,7 @@ DistillGPT2,pass,4
 
 
 
-ElectraForCausalLM,pass,4
+ElectraForCausalLM,pass,5
 
 
 
@@ -98,15 +98,15 @@ LayoutLMForSequenceClassification,pass,6
 
 
 
-M2M100ForConditionalGeneration,pass,4
+M2M100ForConditionalGeneration,pass,5
 
 
 
-MBartForCausalLM,pass,12
+MBartForCausalLM,pass,13
 
 
 
-MBartForConditionalGeneration,pass,24
+MBartForConditionalGeneration,pass,25
 
 
 
@@ -122,31 +122,31 @@ MegatronBertForQuestionAnswering,pass,4
 
 
 
-MobileBertForMaskedLM,pass,4
+MobileBertForMaskedLM,pass,3
 
 
 
-MobileBertForQuestionAnswering,pass,4
+MobileBertForQuestionAnswering,pass,3
 
 
 
-OPTForCausalLM,pass,12
+OPTForCausalLM,pass,13
 
 
 
-PLBartForCausalLM,pass,12
+PLBartForCausalLM,pass,13
 
 
 
-PLBartForConditionalGeneration,pass,29
+PLBartForConditionalGeneration,pass,30
 
 
 
-PegasusForCausalLM,pass,12
+PegasusForCausalLM,pass,13
 
 
 
-PegasusForConditionalGeneration,pass,24
+PegasusForConditionalGeneration,pass,23
 
 
 
@@ -158,7 +158,7 @@ RobertaForQuestionAnswering,pass,4
 
 
 
-Speech2Text2ForCausalLM,pass,12
+Speech2Text2ForCausalLM,pass,13
 
 
 
@@ -170,11 +170,11 @@ T5Small,pass,4
 
 
 
-TrOCRForCausalLM,pass,12
+TrOCRForCausalLM,pass,13
 
 
 
-XGLMForCausalLM,pass,12
+XGLMForCausalLM,pass,13
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_timm_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_timm_training.csv
@@ -2,7 +2,7 @@ name,accuracy,graph_breaks
 
 
 
-adv_inception_v3,pass,6
+adv_inception_v3,pass,7
 
 
 
@@ -10,7 +10,7 @@ beit_base_patch16_224,pass,6
 
 
 
-botnet26t_256,pass,6
+botnet26t_256,pass,7
 
 
 
@@ -18,15 +18,15 @@ cait_m36_384,eager_fail_to_run,0
 
 
 
-coat_lite_mini,pass,6
+coat_lite_mini,pass,7
 
 
 
-convit_base,pass,6
+convit_base,pass,7
 
 
 
-convmixer_768_32,pass,6
+convmixer_768_32,pass,5
 
 
 
@@ -54,7 +54,7 @@ dm_nfnet_f0,pass,6
 
 
 
-dpn107,pass,6
+dpn107,pass,7
 
 
 
@@ -74,15 +74,15 @@ fbnetc_100,pass,6
 
 
 
-fbnetv3_b,pass,6
+fbnetv3_b,pass,7
 
 
 
-gernet_l,pass,6
+gernet_l,pass,7
 
 
 
-ghostnet_100,pass,6
+ghostnet_100,pass,7
 
 
 
@@ -90,7 +90,7 @@ gluon_inception_v3,pass,6
 
 
 
-gmixer_24_224,pass,6
+gmixer_24_224,pass,7
 
 
 
@@ -98,11 +98,11 @@ gmlp_s16_224,pass,6
 
 
 
-hrnet_w18,pass,6
+hrnet_w18,pass,5
 
 
 
-inception_v3,pass,6
+inception_v3,pass,7
 
 
 
@@ -110,7 +110,7 @@ jx_nest_base,pass,6
 
 
 
-lcnet_050,fail_accuracy,6
+lcnet_050,fail_accuracy,7
 
 
 
@@ -122,7 +122,7 @@ mixer_b16_224,pass,6
 
 
 
-mixnet_l,pass,6
+mixnet_l,pass,7
 
 
 
@@ -138,7 +138,7 @@ mobilenetv3_large_100,pass,6
 
 
 
-mobilevit_s,pass,6
+mobilevit_s,pass,7
 
 
 
@@ -150,15 +150,15 @@ pit_b_224,pass,6
 
 
 
-pnasnet5large,pass,6
+pnasnet5large,pass,5
 
 
 
-poolformer_m36,pass,6
+poolformer_m36,pass,7
 
 
 
-regnety_002,pass,6
+regnety_002,pass,7
 
 
 
@@ -166,23 +166,23 @@ repvgg_a2,pass,6
 
 
 
-res2net101_26w_4s,pass,6
+res2net101_26w_4s,pass,7
 
 
 
-res2net50_14w_8s,pass,6
+res2net50_14w_8s,pass,7
 
 
 
-res2next50,pass,6
+res2next50,pass,7
 
 
 
-resmlp_12_224,pass,6
+resmlp_12_224,pass,7
 
 
 
-resnest101e,pass,6
+resnest101e,pass,7
 
 
 
@@ -190,11 +190,11 @@ rexnet_100,pass,6
 
 
 
-sebotnet33ts_256,pass,6
+sebotnet33ts_256,pass,7
 
 
 
-selecsls42b,pass,6
+selecsls42b,pass,7
 
 
 
@@ -206,11 +206,11 @@ swin_base_patch4_window7_224,pass,6
 
 
 
-swsl_resnext101_32x16d,pass,6
+swsl_resnext101_32x16d,pass,7
 
 
 
-tf_efficientnet_b0,pass,6
+tf_efficientnet_b0,pass,7
 
 
 
@@ -218,7 +218,7 @@ tf_mixnet_l,pass,6
 
 
 
-tinynet_a,pass,6
+tinynet_a,pass,7
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_timm_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_timm_training.csv
@@ -50,7 +50,7 @@ dla102,pass,6
 
 
 
-dm_nfnet_f0,pass,6
+dm_nfnet_f0,pass,7
 
 
 
@@ -146,7 +146,7 @@ nfnet_l0,pass,6
 
 
 
-pit_b_224,pass,6
+pit_b_224,pass,7
 
 
 
@@ -214,7 +214,7 @@ tf_efficientnet_b0,pass,7
 
 
 
-tf_mixnet_l,pass,6
+tf_mixnet_l,pass,7
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_torchbench_training.csv
@@ -2,7 +2,7 @@ name,accuracy,graph_breaks
 
 
 
-BERT_pytorch,pass,6
+BERT_pytorch,pass,7
 
 
 
@@ -14,7 +14,7 @@ DALLE2_pytorch,eager_fail_to_run,0
 
 
 
-LearningToPaint,pass,6
+LearningToPaint,pass,7
 
 
 
@@ -22,7 +22,7 @@ Super_SloMo,pass,6
 
 
 
-alexnet,pass,6
+alexnet,pass,7
 
 
 
@@ -46,15 +46,15 @@ cm3leon_generate,eager_fail_to_run,0
 
 
 
-dcgan,pass,6
+dcgan,pass,7
 
 
 
-demucs,pass,9
+demucs,pass,10
 
 
 
-densenet121,pass,6
+densenet121,pass,7
 
 
 
@@ -66,7 +66,7 @@ detectron2_maskrcnn_r_50_c4,eager_fail_to_run,0
 
 
 
-dlrm,pass,6
+dlrm,pass,7
 
 
 
@@ -82,7 +82,7 @@ drq,pass,5
 
 
 
-fastNLP_Bert,pass,10
+fastNLP_Bert,pass,11
 
 
 
@@ -122,7 +122,7 @@ hf_Reformer,pass,25
 
 
 
-hf_T5_base,pass,5
+hf_T5_base,pass,6
 
 
 
@@ -154,7 +154,7 @@ mnasnet1_0,pass,6
 
 
 
-mobilenet_v2,pass,6
+mobilenet_v2,pass,7
 
 
 
@@ -166,7 +166,7 @@ mobilenet_v3_large,pass,6
 
 
 
-moco,pass,17
+moco,pass,18
 
 
 
@@ -182,19 +182,19 @@ opacus_cifar10,eager_fail_to_run,0
 
 
 
-phlippe_densenet,pass,6
+phlippe_densenet,pass,7
 
 
 
-phlippe_resnet,pass,6
+phlippe_resnet,pass,7
 
 
 
-pytorch_CycleGAN_and_pix2pix,pass,6
+pytorch_CycleGAN_and_pix2pix,pass,7
 
 
 
-pytorch_stargan,pass,6
+pytorch_stargan,pass,7
 
 
 
@@ -206,11 +206,11 @@ resnet152,pass,6
 
 
 
-resnet18,pass,6
+resnet18,pass,7
 
 
 
-resnet50,pass,6
+resnet50,pass,7
 
 
 
@@ -226,7 +226,7 @@ sam,eager_fail_to_run,0
 
 
 
-shufflenet_v2_x1_0,pass,6
+shufflenet_v2_x1_0,pass,7
 
 
 
@@ -234,11 +234,11 @@ soft_actor_critic,pass,5
 
 
 
-squeezenet1_1,pass,6
+squeezenet1_1,pass,7
 
 
 
-stable_diffusion_text_encoder,pass,5
+stable_diffusion_text_encoder,pass,6
 
 
 
@@ -250,7 +250,7 @@ timm_efficientnet,pass,6
 
 
 
-timm_regnet,pass,6
+timm_regnet,pass,7
 
 
 
@@ -258,7 +258,7 @@ timm_resnest,pass,6
 
 
 
-timm_vision_transformer,pass,6
+timm_vision_transformer,pass,7
 
 
 
@@ -266,7 +266,7 @@ timm_vision_transformer_large,pass_due_to_skip,0
 
 
 
-timm_vovnet,pass,6
+timm_vovnet,pass,7
 
 
 
@@ -278,11 +278,11 @@ tts_angular,pass,8
 
 
 
-vgg16,pass,6
+vgg16,pass,7
 
 
 
-vision_maskrcnn,pass,34
+vision_maskrcnn,pass,35
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_huggingface_training.csv
@@ -2,7 +2,7 @@ name,accuracy,graph_breaks
 
 
 
-AlbertForMaskedLM,pass,4
+AlbertForMaskedLM,pass,5
 
 
 
@@ -14,11 +14,11 @@ AllenaiLongformerBase,pass,8
 
 
 
-BartForCausalLM,pass,12
+BartForCausalLM,pass,13
 
 
 
-BartForConditionalGeneration,pass,24
+BartForConditionalGeneration,pass,25
 
 
 
@@ -34,11 +34,11 @@ BlenderbotForCausalLM,eager_fail_to_run,0
 
 
 
-BlenderbotSmallForCausalLM,pass,12
+BlenderbotSmallForCausalLM,pass,13
 
 
 
-BlenderbotSmallForConditionalGeneration,pass,24
+BlenderbotSmallForConditionalGeneration,pass,25
 
 
 
@@ -74,7 +74,7 @@ DistillGPT2,pass,4
 
 
 
-ElectraForCausalLM,pass,4
+ElectraForCausalLM,pass,5
 
 
 
@@ -98,15 +98,15 @@ LayoutLMForSequenceClassification,pass,6
 
 
 
-M2M100ForConditionalGeneration,pass,4
+M2M100ForConditionalGeneration,pass,5
 
 
 
-MBartForCausalLM,pass,12
+MBartForCausalLM,pass,13
 
 
 
-MBartForConditionalGeneration,pass,24
+MBartForConditionalGeneration,pass,25
 
 
 
@@ -122,31 +122,31 @@ MegatronBertForQuestionAnswering,pass,4
 
 
 
-MobileBertForMaskedLM,pass,4
+MobileBertForMaskedLM,pass,3
 
 
 
-MobileBertForQuestionAnswering,pass,4
+MobileBertForQuestionAnswering,pass,3
 
 
 
-OPTForCausalLM,pass,12
+OPTForCausalLM,pass,13
 
 
 
-PLBartForCausalLM,pass,12
+PLBartForCausalLM,pass,13
 
 
 
-PLBartForConditionalGeneration,pass,29
+PLBartForConditionalGeneration,pass,30
 
 
 
-PegasusForCausalLM,pass,12
+PegasusForCausalLM,pass,13
 
 
 
-PegasusForConditionalGeneration,pass,24
+PegasusForConditionalGeneration,pass,23
 
 
 
@@ -158,7 +158,7 @@ RobertaForQuestionAnswering,pass,4
 
 
 
-Speech2Text2ForCausalLM,pass,12
+Speech2Text2ForCausalLM,pass,13
 
 
 
@@ -170,11 +170,11 @@ T5Small,pass,4
 
 
 
-TrOCRForCausalLM,pass,12
+TrOCRForCausalLM,pass,13
 
 
 
-XGLMForCausalLM,pass,12
+XGLMForCausalLM,pass,13
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_timm_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_timm_training.csv
@@ -50,7 +50,7 @@ dla102,pass,6
 
 
 
-dm_nfnet_f0,pass,6
+dm_nfnet_f0,pass,7
 
 
 
@@ -146,7 +146,7 @@ nfnet_l0,pass,6
 
 
 
-pit_b_224,pass,6
+pit_b_224,pass,7
 
 
 
@@ -214,7 +214,7 @@ tf_efficientnet_b0,pass,7
 
 
 
-tf_mixnet_l,pass,6
+tf_mixnet_l,pass,7
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_timm_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_timm_training.csv
@@ -2,7 +2,7 @@ name,accuracy,graph_breaks
 
 
 
-adv_inception_v3,pass,6
+adv_inception_v3,pass,7
 
 
 
@@ -10,7 +10,7 @@ beit_base_patch16_224,pass,6
 
 
 
-botnet26t_256,pass,6
+botnet26t_256,pass,7
 
 
 
@@ -18,15 +18,15 @@ cait_m36_384,eager_fail_to_run,0
 
 
 
-coat_lite_mini,pass,6
+coat_lite_mini,pass,7
 
 
 
-convit_base,pass,6
+convit_base,pass,7
 
 
 
-convmixer_768_32,pass,6
+convmixer_768_32,pass,5
 
 
 
@@ -54,7 +54,7 @@ dm_nfnet_f0,pass,6
 
 
 
-dpn107,pass,6
+dpn107,pass,7
 
 
 
@@ -74,15 +74,15 @@ fbnetc_100,pass,6
 
 
 
-fbnetv3_b,pass,6
+fbnetv3_b,pass,7
 
 
 
-gernet_l,pass,6
+gernet_l,pass,7
 
 
 
-ghostnet_100,pass,6
+ghostnet_100,pass,7
 
 
 
@@ -90,7 +90,7 @@ gluon_inception_v3,pass,6
 
 
 
-gmixer_24_224,pass,6
+gmixer_24_224,pass,7
 
 
 
@@ -98,11 +98,11 @@ gmlp_s16_224,pass,6
 
 
 
-hrnet_w18,pass,6
+hrnet_w18,pass,5
 
 
 
-inception_v3,pass,6
+inception_v3,pass,7
 
 
 
@@ -110,7 +110,7 @@ jx_nest_base,pass,6
 
 
 
-lcnet_050,pass,6
+lcnet_050,pass,7
 
 
 
@@ -122,7 +122,7 @@ mixer_b16_224,pass,6
 
 
 
-mixnet_l,pass,6
+mixnet_l,pass,7
 
 
 
@@ -138,7 +138,7 @@ mobilenetv3_large_100,pass,6
 
 
 
-mobilevit_s,pass,6
+mobilevit_s,pass,7
 
 
 
@@ -150,15 +150,15 @@ pit_b_224,pass,6
 
 
 
-pnasnet5large,pass,6
+pnasnet5large,pass,5
 
 
 
-poolformer_m36,pass,6
+poolformer_m36,pass,7
 
 
 
-regnety_002,pass,6
+regnety_002,pass,7
 
 
 
@@ -166,23 +166,23 @@ repvgg_a2,pass,6
 
 
 
-res2net101_26w_4s,pass,6
+res2net101_26w_4s,pass,7
 
 
 
-res2net50_14w_8s,pass,6
+res2net50_14w_8s,pass,7
 
 
 
-res2next50,pass,6
+res2next50,pass,7
 
 
 
-resmlp_12_224,pass,6
+resmlp_12_224,pass,7
 
 
 
-resnest101e,pass,6
+resnest101e,pass,7
 
 
 
@@ -190,11 +190,11 @@ rexnet_100,pass,6
 
 
 
-sebotnet33ts_256,pass,6
+sebotnet33ts_256,pass,7
 
 
 
-selecsls42b,pass,6
+selecsls42b,pass,7
 
 
 
@@ -206,11 +206,11 @@ swin_base_patch4_window7_224,pass,6
 
 
 
-swsl_resnext101_32x16d,pass,6
+swsl_resnext101_32x16d,pass,7
 
 
 
-tf_efficientnet_b0,pass,6
+tf_efficientnet_b0,pass,7
 
 
 
@@ -218,7 +218,7 @@ tf_mixnet_l,pass,6
 
 
 
-tinynet_a,pass,6
+tinynet_a,pass,7
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_torchbench_training.csv
@@ -2,7 +2,7 @@ name,accuracy,graph_breaks
 
 
 
-BERT_pytorch,pass,6
+BERT_pytorch,pass,7
 
 
 
@@ -14,7 +14,7 @@ DALLE2_pytorch,eager_fail_to_run,0
 
 
 
-LearningToPaint,pass,6
+LearningToPaint,pass,7
 
 
 
@@ -22,7 +22,7 @@ Super_SloMo,pass,6
 
 
 
-alexnet,pass,6
+alexnet,pass,7
 
 
 
@@ -46,7 +46,7 @@ cm3leon_generate,eager_fail_to_run,0
 
 
 
-dcgan,pass,6
+dcgan,pass,7
 
 
 
@@ -54,7 +54,7 @@ demucs,fail_to_run,4
 
 
 
-densenet121,pass,6
+densenet121,pass,7
 
 
 
@@ -66,7 +66,7 @@ detectron2_maskrcnn_r_50_c4,eager_fail_to_run,0
 
 
 
-dlrm,pass,6
+dlrm,pass,7
 
 
 
@@ -82,7 +82,7 @@ drq,pass,5
 
 
 
-fastNLP_Bert,pass,10
+fastNLP_Bert,pass,11
 
 
 
@@ -154,7 +154,7 @@ mnasnet1_0,pass,6
 
 
 
-mobilenet_v2,pass,6
+mobilenet_v2,pass,7
 
 
 
@@ -166,7 +166,7 @@ mobilenet_v3_large,pass,6
 
 
 
-moco,pass,17
+moco,pass,18
 
 
 
@@ -182,19 +182,19 @@ opacus_cifar10,eager_fail_to_run,0
 
 
 
-phlippe_densenet,pass,6
+phlippe_densenet,pass,7
 
 
 
-phlippe_resnet,pass,6
+phlippe_resnet,pass,7
 
 
 
-pytorch_CycleGAN_and_pix2pix,pass,6
+pytorch_CycleGAN_and_pix2pix,pass,7
 
 
 
-pytorch_stargan,pass,6
+pytorch_stargan,pass,7
 
 
 
@@ -206,11 +206,11 @@ resnet152,pass,6
 
 
 
-resnet18,pass,6
+resnet18,pass,7
 
 
 
-resnet50,pass,6
+resnet50,pass,7
 
 
 
@@ -226,7 +226,7 @@ sam,eager_fail_to_run,0
 
 
 
-shufflenet_v2_x1_0,pass,6
+shufflenet_v2_x1_0,pass,7
 
 
 
@@ -234,11 +234,11 @@ soft_actor_critic,pass,5
 
 
 
-squeezenet1_1,pass,6
+squeezenet1_1,pass,7
 
 
 
-stable_diffusion_text_encoder,pass,5
+stable_diffusion_text_encoder,pass,6
 
 
 
@@ -250,7 +250,7 @@ timm_efficientnet,pass,6
 
 
 
-timm_regnet,pass,6
+timm_regnet,pass,7
 
 
 
@@ -258,7 +258,7 @@ timm_resnest,pass,6
 
 
 
-timm_vision_transformer,pass,6
+timm_vision_transformer,pass,7
 
 
 
@@ -266,7 +266,7 @@ timm_vision_transformer_large,pass_due_to_skip,0
 
 
 
-timm_vovnet,pass,6
+timm_vovnet,pass,7
 
 
 
@@ -278,11 +278,11 @@ tts_angular,pass,8
 
 
 
-vgg16,pass,6
+vgg16,pass,7
 
 
 
-vision_maskrcnn,pass,34
+vision_maskrcnn,pass,35
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_huggingface_training.csv
@@ -2,7 +2,7 @@ name,accuracy,graph_breaks
 
 
 
-AlbertForMaskedLM,pass,4
+AlbertForMaskedLM,pass,5
 
 
 
@@ -14,11 +14,11 @@ AllenaiLongformerBase,pass,8
 
 
 
-BartForCausalLM,pass,12
+BartForCausalLM,pass,13
 
 
 
-BartForConditionalGeneration,pass,24
+BartForConditionalGeneration,pass,25
 
 
 
@@ -34,11 +34,11 @@ BlenderbotForCausalLM,eager_fail_to_run,0
 
 
 
-BlenderbotSmallForCausalLM,pass,12
+BlenderbotSmallForCausalLM,pass,13
 
 
 
-BlenderbotSmallForConditionalGeneration,pass,24
+BlenderbotSmallForConditionalGeneration,pass,25
 
 
 
@@ -74,7 +74,7 @@ DistillGPT2,pass,4
 
 
 
-ElectraForCausalLM,pass,4
+ElectraForCausalLM,pass,5
 
 
 
@@ -98,15 +98,15 @@ LayoutLMForSequenceClassification,pass,6
 
 
 
-M2M100ForConditionalGeneration,pass,4
+M2M100ForConditionalGeneration,pass,5
 
 
 
-MBartForCausalLM,pass,12
+MBartForCausalLM,pass,13
 
 
 
-MBartForConditionalGeneration,pass,24
+MBartForConditionalGeneration,pass,25
 
 
 
@@ -122,31 +122,31 @@ MegatronBertForQuestionAnswering,pass,4
 
 
 
-MobileBertForMaskedLM,pass,4
+MobileBertForMaskedLM,pass,3
 
 
 
-MobileBertForQuestionAnswering,pass,4
+MobileBertForQuestionAnswering,pass,3
 
 
 
-OPTForCausalLM,pass,12
+OPTForCausalLM,pass,13
 
 
 
-PLBartForCausalLM,pass,12
+PLBartForCausalLM,pass,13
 
 
 
-PLBartForConditionalGeneration,pass,29
+PLBartForConditionalGeneration,pass,30
 
 
 
-PegasusForCausalLM,pass,12
+PegasusForCausalLM,pass,13
 
 
 
-PegasusForConditionalGeneration,pass,24
+PegasusForConditionalGeneration,pass,23
 
 
 
@@ -158,7 +158,7 @@ RobertaForQuestionAnswering,pass,4
 
 
 
-Speech2Text2ForCausalLM,pass,12
+Speech2Text2ForCausalLM,pass,13
 
 
 
@@ -170,11 +170,11 @@ T5Small,pass,4
 
 
 
-TrOCRForCausalLM,pass,12
+TrOCRForCausalLM,pass,13
 
 
 
-XGLMForCausalLM,pass,12
+XGLMForCausalLM,pass,13
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_timm_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_timm_training.csv
@@ -50,7 +50,7 @@ dla102,pass,6
 
 
 
-dm_nfnet_f0,pass,6
+dm_nfnet_f0,pass,7
 
 
 
@@ -146,7 +146,7 @@ nfnet_l0,pass,6
 
 
 
-pit_b_224,pass,6
+pit_b_224,pass,7
 
 
 
@@ -214,7 +214,7 @@ tf_efficientnet_b0,pass,7
 
 
 
-tf_mixnet_l,pass,6
+tf_mixnet_l,pass,7
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_timm_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_timm_training.csv
@@ -2,7 +2,7 @@ name,accuracy,graph_breaks
 
 
 
-adv_inception_v3,pass,6
+adv_inception_v3,pass,7
 
 
 
@@ -10,7 +10,7 @@ beit_base_patch16_224,pass,6
 
 
 
-botnet26t_256,pass,6
+botnet26t_256,pass,7
 
 
 
@@ -18,15 +18,15 @@ cait_m36_384,eager_fail_to_run,0
 
 
 
-coat_lite_mini,pass,6
+coat_lite_mini,pass,7
 
 
 
-convit_base,pass,6
+convit_base,pass,7
 
 
 
-convmixer_768_32,pass,6
+convmixer_768_32,pass,5
 
 
 
@@ -54,7 +54,7 @@ dm_nfnet_f0,pass,6
 
 
 
-dpn107,pass,6
+dpn107,pass,7
 
 
 
@@ -74,15 +74,15 @@ fbnetc_100,pass,6
 
 
 
-fbnetv3_b,pass,6
+fbnetv3_b,pass,7
 
 
 
-gernet_l,pass,6
+gernet_l,pass,7
 
 
 
-ghostnet_100,pass,6
+ghostnet_100,pass,7
 
 
 
@@ -90,7 +90,7 @@ gluon_inception_v3,pass,6
 
 
 
-gmixer_24_224,pass,6
+gmixer_24_224,pass,7
 
 
 
@@ -98,11 +98,11 @@ gmlp_s16_224,pass,6
 
 
 
-hrnet_w18,pass,6
+hrnet_w18,pass,5
 
 
 
-inception_v3,pass,6
+inception_v3,pass,7
 
 
 
@@ -110,7 +110,7 @@ jx_nest_base,pass,6
 
 
 
-lcnet_050,pass,6
+lcnet_050,pass,7
 
 
 
@@ -122,7 +122,7 @@ mixer_b16_224,pass,6
 
 
 
-mixnet_l,pass,6
+mixnet_l,pass,7
 
 
 
@@ -138,7 +138,7 @@ mobilenetv3_large_100,pass,6
 
 
 
-mobilevit_s,pass,6
+mobilevit_s,pass,7
 
 
 
@@ -150,15 +150,15 @@ pit_b_224,pass,6
 
 
 
-pnasnet5large,pass,6
+pnasnet5large,pass,5
 
 
 
-poolformer_m36,pass,6
+poolformer_m36,pass,7
 
 
 
-regnety_002,pass,6
+regnety_002,pass,7
 
 
 
@@ -166,23 +166,23 @@ repvgg_a2,pass,6
 
 
 
-res2net101_26w_4s,pass,6
+res2net101_26w_4s,pass,7
 
 
 
-res2net50_14w_8s,pass,6
+res2net50_14w_8s,pass,7
 
 
 
-res2next50,pass,6
+res2next50,pass,7
 
 
 
-resmlp_12_224,pass,6
+resmlp_12_224,pass,7
 
 
 
-resnest101e,pass,6
+resnest101e,pass,7
 
 
 
@@ -190,11 +190,11 @@ rexnet_100,pass,6
 
 
 
-sebotnet33ts_256,pass,6
+sebotnet33ts_256,pass,7
 
 
 
-selecsls42b,pass,6
+selecsls42b,pass,7
 
 
 
@@ -206,11 +206,11 @@ swin_base_patch4_window7_224,pass,6
 
 
 
-swsl_resnext101_32x16d,pass,6
+swsl_resnext101_32x16d,pass,7
 
 
 
-tf_efficientnet_b0,pass,6
+tf_efficientnet_b0,pass,7
 
 
 
@@ -218,7 +218,7 @@ tf_mixnet_l,pass,6
 
 
 
-tinynet_a,pass,6
+tinynet_a,pass,7
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_torchbench_training.csv
@@ -2,11 +2,11 @@ name,accuracy,graph_breaks
 
 
 
-torchrec_dlrm,pass,6
+torchrec_dlrm,pass,7
 
 
 
-BERT_pytorch,pass,6
+BERT_pytorch,pass,7
 
 
 
@@ -18,7 +18,7 @@ DALLE2_pytorch,eager_fail_to_run,0
 
 
 
-LearningToPaint,pass,6
+LearningToPaint,pass,7
 
 
 
@@ -26,7 +26,7 @@ Super_SloMo,pass,6
 
 
 
-alexnet,pass,6
+alexnet,pass,7
 
 
 
@@ -50,15 +50,15 @@ cm3leon_generate,eager_fail_to_run,0
 
 
 
-dcgan,pass,6
+dcgan,pass,7
 
 
 
-demucs,pass,9
+demucs,pass,10
 
 
 
-densenet121,pass,6
+densenet121,pass,7
 
 
 
@@ -70,7 +70,7 @@ detectron2_maskrcnn_r_50_c4,eager_fail_to_run,0
 
 
 
-dlrm,pass,6
+dlrm,pass,7
 
 
 
@@ -86,7 +86,7 @@ drq,pass,5
 
 
 
-fastNLP_Bert,pass,10
+fastNLP_Bert,pass,11
 
 
 
@@ -126,7 +126,7 @@ hf_Reformer,pass,25
 
 
 
-hf_T5_base,pass,5
+hf_T5_base,pass,6
 
 
 
@@ -158,7 +158,7 @@ mnasnet1_0,pass,6
 
 
 
-mobilenet_v2,pass,6
+mobilenet_v2,pass,7
 
 
 
@@ -170,7 +170,7 @@ mobilenet_v3_large,pass,6
 
 
 
-moco,pass,17
+moco,pass,18
 
 
 
@@ -186,19 +186,19 @@ opacus_cifar10,eager_fail_to_run,0
 
 
 
-phlippe_densenet,pass,6
+phlippe_densenet,pass,7
 
 
 
-phlippe_resnet,pass,6
+phlippe_resnet,pass,7
 
 
 
-pytorch_CycleGAN_and_pix2pix,pass,6
+pytorch_CycleGAN_and_pix2pix,pass,7
 
 
 
-pytorch_stargan,pass,6
+pytorch_stargan,pass,7
 
 
 
@@ -210,11 +210,11 @@ resnet152,pass,6
 
 
 
-resnet18,pass,6
+resnet18,pass,7
 
 
 
-resnet50,pass,6
+resnet50,pass,7
 
 
 
@@ -230,7 +230,7 @@ sam,eager_fail_to_run,0
 
 
 
-shufflenet_v2_x1_0,pass,6
+shufflenet_v2_x1_0,pass,7
 
 
 
@@ -238,15 +238,15 @@ soft_actor_critic,pass,5
 
 
 
-speech_transformer,pass,16
+speech_transformer,pass,17
 
 
 
-squeezenet1_1,pass,6
+squeezenet1_1,pass,7
 
 
 
-stable_diffusion_text_encoder,pass,5
+stable_diffusion_text_encoder,pass,6
 
 
 
@@ -258,7 +258,7 @@ timm_efficientnet,pass,6
 
 
 
-timm_regnet,pass,6
+timm_regnet,pass,7
 
 
 
@@ -266,7 +266,7 @@ timm_resnest,pass,6
 
 
 
-timm_vision_transformer,pass,6
+timm_vision_transformer,pass,7
 
 
 
@@ -274,7 +274,7 @@ timm_vision_transformer_large,pass_due_to_skip,0
 
 
 
-timm_vovnet,pass,6
+timm_vovnet,pass,7
 
 
 
@@ -286,11 +286,11 @@ tts_angular,pass,8
 
 
 
-vgg16,pass,6
+vgg16,pass,7
 
 
 
-vision_maskrcnn,pass,34
+vision_maskrcnn,pass,35
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_huggingface_training.csv
@@ -2,7 +2,7 @@ name,accuracy,graph_breaks
 
 
 
-AlbertForMaskedLM,pass,4
+AlbertForMaskedLM,pass,5
 
 
 
@@ -14,11 +14,11 @@ AllenaiLongformerBase,pass,8
 
 
 
-BartForCausalLM,pass,12
+BartForCausalLM,pass,13
 
 
 
-BartForConditionalGeneration,pass,24
+BartForConditionalGeneration,pass,25
 
 
 
@@ -34,11 +34,11 @@ BlenderbotForCausalLM,eager_fail_to_run,0
 
 
 
-BlenderbotSmallForCausalLM,pass,12
+BlenderbotSmallForCausalLM,pass,13
 
 
 
-BlenderbotSmallForConditionalGeneration,pass,24
+BlenderbotSmallForConditionalGeneration,pass,25
 
 
 
@@ -74,7 +74,7 @@ DistillGPT2,pass,4
 
 
 
-ElectraForCausalLM,pass,4
+ElectraForCausalLM,pass,5
 
 
 
@@ -98,15 +98,15 @@ LayoutLMForSequenceClassification,pass,6
 
 
 
-M2M100ForConditionalGeneration,pass,4
+M2M100ForConditionalGeneration,pass,5
 
 
 
-MBartForCausalLM,pass,12
+MBartForCausalLM,pass,13
 
 
 
-MBartForConditionalGeneration,pass,24
+MBartForConditionalGeneration,pass,25
 
 
 
@@ -122,31 +122,31 @@ MegatronBertForQuestionAnswering,pass,4
 
 
 
-MobileBertForMaskedLM,pass,4
+MobileBertForMaskedLM,pass,3
 
 
 
-MobileBertForQuestionAnswering,pass,4
+MobileBertForQuestionAnswering,pass,3
 
 
 
-OPTForCausalLM,pass,12
+OPTForCausalLM,pass,13
 
 
 
-PLBartForCausalLM,pass,12
+PLBartForCausalLM,pass,13
 
 
 
-PLBartForConditionalGeneration,pass,29
+PLBartForConditionalGeneration,pass,30
 
 
 
-PegasusForCausalLM,pass,12
+PegasusForCausalLM,pass,13
 
 
 
-PegasusForConditionalGeneration,pass,24
+PegasusForConditionalGeneration,pass,23
 
 
 
@@ -158,7 +158,7 @@ RobertaForQuestionAnswering,pass,4
 
 
 
-Speech2Text2ForCausalLM,pass,12
+Speech2Text2ForCausalLM,pass,13
 
 
 
@@ -170,11 +170,11 @@ T5Small,pass,4
 
 
 
-TrOCRForCausalLM,pass,12
+TrOCRForCausalLM,pass,13
 
 
 
-XGLMForCausalLM,pass,12
+XGLMForCausalLM,pass,13
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_timm_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_timm_training.csv
@@ -50,7 +50,7 @@ dla102,pass,6
 
 
 
-dm_nfnet_f0,pass,6
+dm_nfnet_f0,pass,7
 
 
 
@@ -146,7 +146,7 @@ nfnet_l0,pass,6
 
 
 
-pit_b_224,pass,6
+pit_b_224,pass,7
 
 
 
@@ -214,7 +214,7 @@ tf_efficientnet_b0,pass,7
 
 
 
-tf_mixnet_l,pass,6
+tf_mixnet_l,pass,7
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_timm_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_timm_training.csv
@@ -2,7 +2,7 @@ name,accuracy,graph_breaks
 
 
 
-adv_inception_v3,pass,6
+adv_inception_v3,pass,7
 
 
 
@@ -10,7 +10,7 @@ beit_base_patch16_224,pass,6
 
 
 
-botnet26t_256,pass,6
+botnet26t_256,pass,7
 
 
 
@@ -18,15 +18,15 @@ cait_m36_384,eager_fail_to_run,0
 
 
 
-coat_lite_mini,pass,6
+coat_lite_mini,pass,7
 
 
 
-convit_base,pass,6
+convit_base,pass,7
 
 
 
-convmixer_768_32,pass,6
+convmixer_768_32,pass,5
 
 
 
@@ -54,7 +54,7 @@ dm_nfnet_f0,pass,6
 
 
 
-dpn107,pass,6
+dpn107,pass,7
 
 
 
@@ -74,15 +74,15 @@ fbnetc_100,pass,6
 
 
 
-fbnetv3_b,pass,6
+fbnetv3_b,pass,7
 
 
 
-gernet_l,pass,6
+gernet_l,pass,7
 
 
 
-ghostnet_100,pass,6
+ghostnet_100,pass,7
 
 
 
@@ -90,7 +90,7 @@ gluon_inception_v3,pass,6
 
 
 
-gmixer_24_224,pass,6
+gmixer_24_224,pass,7
 
 
 
@@ -98,11 +98,11 @@ gmlp_s16_224,pass,6
 
 
 
-hrnet_w18,pass,6
+hrnet_w18,pass,5
 
 
 
-inception_v3,pass,6
+inception_v3,pass,7
 
 
 
@@ -110,7 +110,7 @@ jx_nest_base,pass,6
 
 
 
-lcnet_050,pass,6
+lcnet_050,pass,7
 
 
 
@@ -122,7 +122,7 @@ mixer_b16_224,pass,6
 
 
 
-mixnet_l,pass,6
+mixnet_l,pass,7
 
 
 
@@ -138,7 +138,7 @@ mobilenetv3_large_100,pass,6
 
 
 
-mobilevit_s,pass,6
+mobilevit_s,pass,7
 
 
 
@@ -150,15 +150,15 @@ pit_b_224,pass,6
 
 
 
-pnasnet5large,pass,6
+pnasnet5large,pass,5
 
 
 
-poolformer_m36,pass,6
+poolformer_m36,pass,7
 
 
 
-regnety_002,pass,6
+regnety_002,pass,7
 
 
 
@@ -166,23 +166,23 @@ repvgg_a2,pass,6
 
 
 
-res2net101_26w_4s,pass,6
+res2net101_26w_4s,pass,7
 
 
 
-res2net50_14w_8s,pass,6
+res2net50_14w_8s,pass,7
 
 
 
-res2next50,pass,6
+res2next50,pass,7
 
 
 
-resmlp_12_224,pass,6
+resmlp_12_224,pass,7
 
 
 
-resnest101e,pass,6
+resnest101e,pass,7
 
 
 
@@ -190,11 +190,11 @@ rexnet_100,pass,6
 
 
 
-sebotnet33ts_256,pass,6
+sebotnet33ts_256,pass,7
 
 
 
-selecsls42b,pass,6
+selecsls42b,pass,7
 
 
 
@@ -206,11 +206,11 @@ swin_base_patch4_window7_224,pass,6
 
 
 
-swsl_resnext101_32x16d,pass,6
+swsl_resnext101_32x16d,pass,7
 
 
 
-tf_efficientnet_b0,pass,6
+tf_efficientnet_b0,pass,7
 
 
 
@@ -218,7 +218,7 @@ tf_mixnet_l,pass,6
 
 
 
-tinynet_a,pass,6
+tinynet_a,pass,7
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_training.csv
@@ -2,11 +2,11 @@ name,accuracy,graph_breaks
 
 
 
-torchrec_dlrm,pass,6
+torchrec_dlrm,pass,7
 
 
 
-BERT_pytorch,pass,6
+BERT_pytorch,pass,7
 
 
 
@@ -18,7 +18,7 @@ DALLE2_pytorch,eager_fail_to_run,0
 
 
 
-LearningToPaint,pass,6
+LearningToPaint,pass,7
 
 
 
@@ -26,7 +26,7 @@ Super_SloMo,pass,6
 
 
 
-alexnet,pass,6
+alexnet,pass,7
 
 
 
@@ -50,15 +50,15 @@ cm3leon_generate,eager_fail_to_run,0
 
 
 
-dcgan,pass,6
+dcgan,pass,7
 
 
 
-demucs,pass,9
+demucs,pass,10
 
 
 
-densenet121,pass,6
+densenet121,pass,7
 
 
 
@@ -70,7 +70,7 @@ detectron2_maskrcnn_r_50_c4,eager_fail_to_run,0
 
 
 
-dlrm,pass,6
+dlrm,pass,7
 
 
 
@@ -86,7 +86,7 @@ drq,pass,5
 
 
 
-fastNLP_Bert,pass,10
+fastNLP_Bert,pass,11
 
 
 
@@ -158,7 +158,7 @@ mnasnet1_0,pass,6
 
 
 
-mobilenet_v2,pass,6
+mobilenet_v2,pass,7
 
 
 
@@ -170,7 +170,7 @@ mobilenet_v3_large,pass,6
 
 
 
-moco,pass,17
+moco,pass,18
 
 
 
@@ -186,19 +186,19 @@ opacus_cifar10,eager_fail_to_run,0
 
 
 
-phlippe_densenet,pass,6
+phlippe_densenet,pass,7
 
 
 
-phlippe_resnet,pass,6
+phlippe_resnet,pass,7
 
 
 
-pytorch_CycleGAN_and_pix2pix,pass,6
+pytorch_CycleGAN_and_pix2pix,pass,7
 
 
 
-pytorch_stargan,pass,6
+pytorch_stargan,pass,7
 
 
 
@@ -210,11 +210,11 @@ resnet152,pass,6
 
 
 
-resnet18,pass,6
+resnet18,pass,7
 
 
 
-resnet50,pass,6
+resnet50,pass,7
 
 
 
@@ -230,7 +230,7 @@ sam,eager_fail_to_run,0
 
 
 
-shufflenet_v2_x1_0,pass,6
+shufflenet_v2_x1_0,pass,7
 
 
 
@@ -238,15 +238,15 @@ soft_actor_critic,pass,5
 
 
 
-speech_transformer,pass,16
+speech_transformer,pass,17
 
 
 
-squeezenet1_1,pass,6
+squeezenet1_1,pass,7
 
 
 
-stable_diffusion_text_encoder,pass,5
+stable_diffusion_text_encoder,pass,6
 
 
 
@@ -258,7 +258,7 @@ timm_efficientnet,pass,6
 
 
 
-timm_regnet,pass,6
+timm_regnet,pass,7
 
 
 
@@ -266,7 +266,7 @@ timm_resnest,pass,6
 
 
 
-timm_vision_transformer,pass,6
+timm_vision_transformer,pass,7
 
 
 
@@ -274,7 +274,7 @@ timm_vision_transformer_large,pass_due_to_skip,0
 
 
 
-timm_vovnet,pass,6
+timm_vovnet,pass,7
 
 
 
@@ -286,11 +286,11 @@ tts_angular,pass,8
 
 
 
-vgg16,pass,6
+vgg16,pass,7
 
 
 
-vision_maskrcnn,pass,34
+vision_maskrcnn,pass,35
 
 
 

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2139,7 +2139,6 @@ class BenchmarkRunner:
         else:
             mod.zero_grad(True)
 
-    @torch._disable_dynamo(recursive=True)
     def optimizer_step(self):
         if self.optimizer is not None:
             self.optimizer.step()

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1948,7 +1948,9 @@ class BenchmarkRunner:
             if (name in CI_USE_SGD and self.args.ci) or name in BENCHMARK_USE_SGD:
                 self.optimizer = torch.optim.SGD(params, lr=0.01, foreach=True)
             else:
-                self.optimizer = torch.optim.Adam(params, lr=0.01, foreach=True)
+                self.optimizer = torch.optim.Adam(
+                    params, lr=0.01, capturable=True, foreach=True
+                )
         else:
             self.optimizer = None
 

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -238,6 +238,9 @@ CI_USE_SGD = {
     "resmlp_12_224",
     "dlrm",
     "resnet50",
+    "dm_nfnet_f0",
+    "pit_b_224",
+    "tf_mixnet_l",
 }
 
 

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1946,11 +1946,9 @@ class BenchmarkRunner:
     def init_optimizer(self, name, device, params):
         if device == "cuda" and self.args.training and name not in CI_SKIP_OPTIMIZER:
             if (name in CI_USE_SGD and self.args.ci) or name in BENCHMARK_USE_SGD:
-                self.optimizer = torch.optim.SGD(params, lr=0.01, foreach=True)
+                self.optimizer = torch.optim.SGD(params, foreach=True)
             else:
-                self.optimizer = torch.optim.Adam(
-                    params, lr=0.01, capturable=True, foreach=True
-                )
+                self.optimizer = torch.optim.Adam(params, capturable=True, foreach=True)
         else:
             self.optimizer = None
 

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1949,9 +1949,11 @@ class BenchmarkRunner:
     def init_optimizer(self, name, device, params):
         if device == "cuda" and self.args.training and name not in CI_SKIP_OPTIMIZER:
             if (name in CI_USE_SGD and self.args.ci) or name in BENCHMARK_USE_SGD:
-                self.optimizer = torch.optim.SGD(params, foreach=True)
+                self.optimizer = torch.optim.SGD(params, lr=0.01, foreach=True)
             else:
-                self.optimizer = torch.optim.Adam(params, capturable=True, foreach=True)
+                self.optimizer = torch.optim.Adam(
+                    params, lr=0.01, capturable=True, foreach=True
+                )
         else:
             self.optimizer = None
 

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -236,6 +236,8 @@ CI_USE_SGD = {
     "pytorch_CycleGAN_and_pix2pix",
     "vision_maskrcnn",
     "resmlp_12_224",
+    "dlrm",
+    "resnet50",
 }
 
 

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -235,6 +235,7 @@ CI_USE_SGD = {
     "mobilevit_s",
     "pytorch_CycleGAN_and_pix2pix",
     "vision_maskrcnn",
+    "resmlp_12_224",
 }
 
 


### PR DESCRIPTION
Commit b697bcc583 of mlazos/compiled-adam2 at https://hud.pytorch.org/benchmark/compilers
is an initial benchmark run

Increases compile time by 20s for torchbench and HF, and 30s for TIMM

I expect the compile time to come down significantly with fake tensor prop caching

cc @albanD @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng