### PR TITLE
[Inductor UT] fix unreachable code

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2048,14 +2048,14 @@ class CommonTemplate:
                 .sub(8),
             )
 
-            self.common(
-                fn,
-                (
-                    torch.randn(8, 8),
-                    torch.randint(0, 255, (4, 8), dtype=torch.uint8),
-                ),
-                check_lowp=True,
-            )
+        self.common(
+            fn,
+            (
+                torch.randn(8, 8),
+                torch.randint(0, 255, (4, 8), dtype=torch.uint8),
+            ),
+            check_lowp=True,
+        )
 
     def test_mm_mixed_dtype(self):
         def fn(a, b):


### PR DESCRIPTION
The testcase test_uint4x2_mixed_mm has indentation error. This pr make testcode reachable.

test result:
```
pytest test_torchinductor.py -k test_uint4x2_mixed_mm -v
=========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.10.12, pytest-7.4.2, pluggy-1.3.0 -- /usr/bin/python
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/workspace/pytorch/test/inductor/.hypothesis/examples')
rootdir: /workspace/pytorch
configfile: pytest.ini
plugins: shard-0.1.2, xdoctest-1.0.2, flakefinder-1.1.0, xdist-3.3.1, rerunfailures-12.0, hypothesis-5.35.1
collected 964 items / 962 deselected / 2 selected                                                                                                                                                         
Running 2 items in this shard: test/inductor/test_torchinductor.py::CpuTests::test_uint4x2_mixed_mm_cpu, test/inductor/test_torchinductor.py::CudaTests::test_uint4x2_mixed_mm_cuda

test_torchinductor.py::CpuTests::test_uint4x2_mixed_mm_cpu PASSED [2.2136s]                                                                                                                         [ 50%]
test_torchinductor.py::CudaTests::test_uint4x2_mixed_mm_cuda PASSED [1.9466s]                                                                                                                       [100%]

=================================================================================== 2 passed, 962 deselected in 15.70s ====================================================================================

```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler