### PR TITLE
[BE]: enable readability-delete-null-pointer clang-tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -52,6 +52,7 @@ modernize-*,
 -modernize-use-nodiscard,
 performance-*,
 readability-container-size-empty,
+readability-delete-null-pointer,
 readability-string-compare,
 '
 HeaderFilterRegex: '^(aten/|c10/|torch/).*$'


### PR DESCRIPTION
* Enables an additional clang-tidy check that remove unnecessary nullptr checks around delete statements.
