### PR TITLE
[cherry-pick][tp] further fix the docs (#115974)

### DIFF
--- a/torch/distributed/tensor/parallel/api.py
+++ b/torch/distributed/tensor/parallel/api.py
@@ -62,10 +62,12 @@ def parallelize_module(  # type: ignore[return]
     Example::
         >>> # xdoctest: +SKIP("distributed")
         >>> from torch.distributed.tensor.parallel import parallelize_module, ColwiseParallel
+        >>> from torch.distributed.device_mesh import init_device_mesh
         >>>
         >>> # Define the module.
         >>> m = Model(...)
-        >>> m = parallelize_module(m, ColwiseParallel())
+        >>> tp_mesh = init_device_mesh("cuda", (8,))
+        >>> m = parallelize_module(m, tp_mesh, {"w1": ColwiseParallel(), "w2": RowwiseParallel()})
         >>>
 
     .. note:: For complex module architecture like Attention, MLP layers, we recommend composing

--- a/torch/distributed/tensor/parallel/style.py
+++ b/torch/distributed/tensor/parallel/style.py
@@ -61,7 +61,7 @@ class ColwiseParallel(ParallelStyle):
         >>> )
         >>> ...
 
-    ... note:: By default ``ColwiseParallel`` output is sharded on the last dimension if the ``output_layouts`` not
+    .. note:: By default ``ColwiseParallel`` output is sharded on the last dimension if the ``output_layouts`` not
         specified, if there're operators that require specific tensor shape (i.e. before the paired ``RowwiseParallel``),
         keep in mind that if the output is sharded the operator might need to be adjusted to the sharded size.
     """


### PR DESCRIPTION
some typo result in the note section not rendered properly, can't see this from the last PR directly as the last PR only show the first commit documentation :(

Also make the parallelize_module doc example more concrete

Pull Request resolved: https://github.com/pytorch/pytorch/pull/115974
Approved by: https://github.com/wz337

Fixes #ISSUE_NUMBER
