### PR TITLE
[c10d][libuv] add partial read test for libuv backend and fix an error which only happens when partially reading a buffer

### DIFF
--- a/test/cpp/c10d/TCPStoreTest.cpp
+++ b/test/cpp/c10d/TCPStoreTest.cpp
@@ -206,14 +206,14 @@ TEST(TCPStoreTest, testCleanShutdown) {
 }
 
 TEST(TCPStoreTest, testLibUVPartialRead) {
-  int numWorkers = 2;
+  int numWorkers = 2; // thread 0 creates both server and client
 
   // server part
   c10d::TCPStoreOptions server_opts{
       0,
       true, // is master
       numWorkers,
-      false, // wait workers
+      false, // don't wait otherwise client thread won't spawn
       std::chrono::seconds(defaultTimeout)};
   server_opts.useLibUV = true;
 

--- a/test/cpp/c10d/TCPStoreTest.cpp
+++ b/test/cpp/c10d/TCPStoreTest.cpp
@@ -210,32 +210,29 @@ TEST(TCPStoreTest, testLibUVPartialRead) {
 
   // server part
   c10d::TCPStoreOptions server_opts{
-    0,
-    true,  // is master
-    numWorkers,
-    false,  // wait workers
-    std::chrono::seconds(defaultTimeout)
-  };
+      0,
+      true, // is master
+      numWorkers,
+      false, // wait workers
+      std::chrono::seconds(defaultTimeout)};
   server_opts.useLibUV = true;
 
-  auto serverTCPStore = std::make_unique<c10d::TCPStore>(
-    "127.0.0.1",
-    server_opts);
+  auto serverTCPStore =
+      std::make_unique<c10d::TCPStore>("127.0.0.1", server_opts);
 
   // client part
   c10d::TCPStoreOptions client_opts{
-    serverTCPStore->getPort(),
-    false,  // is master
-    numWorkers,
-    false,  // wait workers
-    std::chrono::seconds(defaultTimeout)
-  };
+      serverTCPStore->getPort(),
+      false, // is master
+      numWorkers,
+      false, // wait workers
+      std::chrono::seconds(defaultTimeout)};
   client_opts.useLibUV = true;
-  auto clientTCPStore = c10::make_intrusive<c10d::TCPStore>(
-    "127.0.0.1",
-    client_opts);
+  auto clientTCPStore =
+      c10::make_intrusive<c10d::TCPStore>("127.0.0.1", client_opts);
   auto clientThread = std::thread([&clientTCPStore] {
-    std::string key("/default_pg/0//b7dc24de75e482ba2ceb9f9ee20732c25c0166d8//cuda//0");
+    std::string key(
+        "/default_pg/0//b7dc24de75e482ba2ceb9f9ee20732c25c0166d8//cuda//0");
     std::string value("v");
     std::vector<uint8_t> valueBuf(value.begin(), value.end());
 

--- a/test/cpp/c10d/TCPStoreTest.cpp
+++ b/test/cpp/c10d/TCPStoreTest.cpp
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <future>
 #include <iostream>
+#include <string>
 #include <system_error>
 #include <thread>
 
@@ -196,6 +197,50 @@ TEST(TCPStoreTest, testCleanShutdown) {
 
   auto clientThread = std::thread([&clientTCPStore] {
     EXPECT_THROW(clientTCPStore->get("invalid_key"), c10::DistNetworkError);
+  });
+
+  // start server shutdown during a client request
+  serverTCPStore = nullptr;
+
+  clientThread.join();
+}
+
+TEST(TCPStoreTest, testLibUVPartialRead) {
+  int numWorkers = 2;
+
+  // server part
+  c10d::TCPStoreOptions server_opts{
+    0,
+    true,  // is master
+    numWorkers,
+    false,  // wait workers
+    std::chrono::seconds(defaultTimeout)
+  };
+  server_opts.useLibUV = true;
+
+  auto serverTCPStore = std::make_unique<c10d::TCPStore>(
+    "127.0.0.1",
+    server_opts);
+
+  // client part
+  c10d::TCPStoreOptions client_opts{
+    serverTCPStore->getPort(),
+    false,  // is master
+    numWorkers,
+    false,  // wait workers
+    std::chrono::seconds(defaultTimeout)
+  };
+  client_opts.useLibUV = true;
+  auto clientTCPStore = c10::make_intrusive<c10d::TCPStore>(
+    "127.0.0.1",
+    client_opts);
+  auto clientThread = std::thread([&clientTCPStore] {
+    std::string key("/default_pg/0//b7dc24de75e482ba2ceb9f9ee20732c25c0166d8//cuda//0");
+    std::string value("v");
+    std::vector<uint8_t> valueBuf(value.begin(), value.end());
+
+    // split store->set(key, valueBuf) into two requests
+    clientTCPStore->_splitSet(key, valueBuf);
   });
 
   // start server shutdown during a client request

--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -403,6 +403,7 @@ void TCPStore::_splitSet(
   detail::SendBuffer buffer(*client_, detail::QueryType::SET);
   buffer.appendString(keyPrefix_ + key);
   buffer.flush();
+  sleep(1);
   buffer.appendBytes(data);
   buffer.flush();
 }

--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -396,7 +396,9 @@ void TCPStore::validate(void) {
   buffer.flush();
 }
 
-void TCPStore::_splitSet(const std::string& key, const std::vector<uint8_t>& data) {
+void TCPStore::_splitSet(
+    const std::string& key,
+    const std::vector<uint8_t>& data) {
   const std::lock_guard<std::mutex> lock(activeOpLock_);
   detail::SendBuffer buffer(*client_, detail::QueryType::SET);
   buffer.appendString(keyPrefix_ + key);

--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -332,6 +332,7 @@ TCPStore::TCPStore(std::string host, const TCPStoreOptions& opts)
     std::random_device rd;
     std::mt19937 gen(rd());
     std::uniform_int_distribution<> distrib(1, *numWorkers_);
+    // TODO (xilunwu): this wait logic may be removed after fixing read_offset
     // stagger connecting to the store when there are too many ranks to
     // avoid causing a DDoS
     std::this_thread::sleep_for(std::chrono::milliseconds(distrib(gen)));
@@ -403,7 +404,7 @@ void TCPStore::_splitSet(
   detail::SendBuffer buffer(*client_, detail::QueryType::SET);
   buffer.appendString(keyPrefix_ + key);
   buffer.flush();
-  sleep(1);
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
   buffer.appendBytes(data);
   buffer.flush();
 }

--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -396,6 +396,15 @@ void TCPStore::validate(void) {
   buffer.flush();
 }
 
+void TCPStore::_splitSet(const std::string& key, const std::vector<uint8_t>& data) {
+  const std::lock_guard<std::mutex> lock(activeOpLock_);
+  detail::SendBuffer buffer(*client_, detail::QueryType::SET);
+  buffer.appendString(keyPrefix_ + key);
+  buffer.flush();
+  buffer.appendBytes(data);
+  buffer.flush();
+}
+
 void TCPStore::set(const std::string& key, const std::vector<uint8_t>& data) {
   detail::timing_guard tguard(clientCounters_["set"]);
   const std::lock_guard<std::mutex> lock(activeOpLock_);

--- a/torch/csrc/distributed/c10d/TCPStore.hpp
+++ b/torch/csrc/distributed/c10d/TCPStore.hpp
@@ -135,6 +135,9 @@ class TORCH_API TCPStore : public Store {
     return usingLibUv_;
   }
 
+  // note(xilunwu): this function is only for internal testing
+  void _splitSet(const std::string& key, const std::vector<uint8_t>& data);
+
  private:
   int64_t incrementValueBy(const std::string& key, int64_t delta);
 

--- a/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
@@ -468,6 +468,7 @@ class ChunkedStream {
         }
       }
     }
+    read_offset += size;
     return true;
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #116180
* __->__ #116141

**Test Plan**
1. build pytorch
2. execute `TORCH_CPP_LOG_LEVEL=INFO build/bin/TCPStoreTest --gtest_filter=TCPStoreTest.testLibUVPartialRead` from the pytorch root directory.

without the change:
<img width="761" alt="image" src="https://github.com/pytorch/pytorch/assets/12968408/1942e3c2-a9c1-4fe4-87e8-7e21f4d8f9aa">


with the change:
<img width="747" alt="image" src="https://github.com/pytorch/pytorch/assets/12968408/f3e96a5b-0ed1-49bd-9184-bb8a5ebebc33">


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225