### PR TITLE
Add aten/src/ATen/native/quantized/cpu/ path to CPU quantization merge rule

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -353,6 +353,7 @@
 
 - name: x86 CPU quantization
   patterns:
+  - aten/src/ATen/native/quantized/cpu/**
   - torch/ao/quantization/quantizer/x86_inductor_quantizer.py
   - torch/_inductor/fx_passes/quantization.py
   - test/quantization/core/test_quantized_op.py


### PR DESCRIPTION
Observing following PR: https://github.com/pytorch/pytorch/pull/115329
Comment from author: https://github.com/pytorch/pytorch/pull/115329#issuecomment-1851339555

pytorchbot merge failed. 
Reason is this logic, we expect all files in PR to match one merge rule:
https://github.com/pytorch/pytorch/blob/110339a310e5c6bc0aef04b6b1d848976d10013e/.github/scripts/trymerge.py#L1310-L1324

This should mitigate the issue, followup will post a PR to refactor this code to allow cross rule matching of approvers