### PR TITLE
[9/N] Fixes clang-tidy warnings in c10/util/*.h

### DIFF
--- a/c10/core/impl/InlineDeviceGuard.h
+++ b/c10/core/impl/InlineDeviceGuard.h
@@ -4,10 +4,13 @@
 // InlineOptionalDeviceGuard.
 
 #include <c10/core/Device.h>
+#include <c10/core/DeviceType.h>
 #include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <c10/core/impl/VirtualGuardImpl.h>
-#include <c10/util/C++17.h>
+#include <c10/util/Exception.h>
 #include <c10/util/Optional.h>
+#include <type_traits>
+#include <utility>
 
 namespace c10::impl {
 

--- a/c10/util/AbortHandler.h
+++ b/c10/util/AbortHandler.h
@@ -1,9 +1,11 @@
+#include <c10/macros/Macros.h>
 #include <c10/util/Backtrace.h>
 #include <c10/util/env.h>
 #include <cstdlib>
 #include <exception>
 #include <iostream>
 #include <mutex>
+#include <optional>
 
 namespace c10 {
 class AbortHandlerHelper {
@@ -49,10 +51,9 @@ class AbortHandlerHelper {
 
 namespace detail {
 C10_ALWAYS_INLINE void terminate_handler() {
-  std::cout << "Unhandled exception caught in c10/util/AbortHandler.h"
-            << std::endl;
+  std::cout << "Unhandled exception caught in c10/util/AbortHandler.h" << '\n';
   auto backtrace = get_backtrace();
-  std::cout << backtrace << std::endl << std::flush;
+  std::cout << backtrace << '\n' << std::flush;
   auto prev_handler = AbortHandlerHelper::getInstance().getPrev();
   if (prev_handler) {
     prev_handler();
@@ -70,7 +71,7 @@ C10_ALWAYS_INLINE void set_terminate_handler() {
   use_custom_terminate = true;
 #endif // _WIN32
   auto result = c10::utils::check_env("TORCH_CUSTOM_TERMINATE");
-  if (result != c10::nullopt) {
+  if (result != std::nullopt) {
     use_custom_terminate = result.value();
   }
   if (use_custom_terminate) {

--- a/c10/util/ApproximateClock.h
+++ b/c10/util/ApproximateClock.h
@@ -2,17 +2,15 @@
 
 #pragma once
 
+#include <c10/macros/Export.h>
+#include <array>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
-#include <list>
-#include <string>
-#include <unordered_map>
-#include <vector>
+#include <functional>
+#include <type_traits>
 
-#include <c10/macros/Macros.h>
-#include <c10/util/Optional.h>
-#include <c10/util/hash.h>
+#include <ctime>
 
 #ifndef _WIN32
 #include <ctime>
@@ -40,10 +38,10 @@
 namespace c10 {
 
 using time_t = int64_t;
-using steady_clock_t = std::conditional<
+using steady_clock_t = std::conditional_t<
     std::chrono::high_resolution_clock::is_steady,
     std::chrono::high_resolution_clock,
-    std::chrono::steady_clock>::type;
+    std::chrono::steady_clock>;
 
 inline time_t getTimeSinceEpoch() {
   auto now = std::chrono::system_clock::now().time_since_epoch();
@@ -94,8 +92,8 @@ inline auto getApproximateTime() {
 
 using approx_time_t = decltype(getApproximateTime());
 static_assert(
-    std::is_same<approx_time_t, int64_t>::value ||
-        std::is_same<approx_time_t, uint64_t>::value,
+    std::is_same_v<approx_time_t, int64_t> ||
+        std::is_same_v<approx_time_t, uint64_t>,
     "Expected either int64_t (`getTime`) or uint64_t (some TSC reads).");
 
 // Convert `getCount` results to Nanoseconds since unix epoch.

--- a/c10/util/ArrayRef.h
+++ b/c10/util/ArrayRef.h
@@ -15,12 +15,18 @@
 
 #pragma once
 
+#include <c10/macros/Macros.h>
 #include <c10/util/Deprecated.h>
 #include <c10/util/Exception.h>
 #include <c10/util/SmallVector.h>
 
 #include <array>
+#include <cstddef>
+#include <cstdint>
+#include <initializer_list>
 #include <iterator>
+#include <ostream>
+#include <type_traits>
 #include <vector>
 
 namespace c10 {

--- a/c10/util/BFloat16-math.h
+++ b/c10/util/BFloat16-math.h
@@ -15,8 +15,7 @@ template <typename T>
 struct is_reduced_floating_point
     : std::integral_constant<
           bool,
-          std::is_same<T, c10::Half>::value ||
-              std::is_same<T, c10::BFloat16>::value> {};
+          std::is_same_v<T, c10::Half> || std::is_same_v<T, c10::BFloat16>> {};
 
 template <typename T>
 constexpr bool is_reduced_floating_point_v =

--- a/c10/util/Bitset.h
+++ b/c10/util/Bitset.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <c10/macros/Macros.h>
-#include <c10/util/C++17.h>
-#include <c10/util/Optional.h>
+#include <cstddef>
 #if defined(_MSC_VER)
 #include <intrin.h>
 #endif

--- a/c10/util/DeadlockDetection.h
+++ b/c10/util/DeadlockDetection.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/macros/Export.h>
 #include <c10/util/Exception.h>
 
 /// This file provides some simple utilities for detecting common deadlocks in
@@ -15,14 +16,12 @@
 /// to directly assert on PyGILState_Check (as it avoids a vcall and also
 /// works correctly with torchdeploy.)
 
-namespace c10 {
-
 #define TORCH_ASSERT_NO_GIL_WITHOUT_PYTHON_DEP() \
   TORCH_INTERNAL_ASSERT(                         \
       !c10::impl::check_python_gil(),            \
       "Holding GIL before a blocking operation!  Please release the GIL before blocking, or see https://github.com/pytorch/pytorch/issues/56297 for how to release the GIL for destructors of objects")
 
-namespace impl {
+namespace c10::impl {
 
 C10_API bool check_python_gil();
 
@@ -46,5 +45,4 @@ struct C10_API PythonGILHooksRegisterer {
   }
 };
 
-} // namespace impl
-} // namespace c10
+} // namespace c10::impl

--- a/c10/util/DimVector.h
+++ b/c10/util/DimVector.h
@@ -3,6 +3,7 @@
 #include <c10/core/SymInt.h>
 #include <c10/core/impl/SizesAndStrides.h>
 #include <c10/util/SmallVector.h>
+#include <cstddef>
 #include <cstdint>
 
 namespace c10 {

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -1,10 +1,11 @@
 #ifndef C10_UTIL_EXCEPTION_H_
 #define C10_UTIL_EXCEPTION_H_
 
+#include <c10/macros/Export.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/StringUtil.h>
 
-#include <cstddef>
+#include <cstdint>
 #include <exception>
 #include <string>
 #include <variant>

--- a/c10/util/Flags.h
+++ b/c10/util/Flags.h
@@ -30,9 +30,9 @@
  * general - that will allow Python to run without wrong flags.
  */
 
+#include <c10/macros/Export.h>
 #include <string>
 
-#include <c10/macros/Macros.h>
 #include <c10/util/Registry.h>
 
 namespace c10 {

--- a/c10/util/Half.cpp
+++ b/c10/util/Half.cpp
@@ -1,10 +1,11 @@
 #include <c10/util/Half.h>
 #include <iostream>
+#include <type_traits>
 
 namespace c10 {
 
 static_assert(
-    std::is_standard_layout<Half>::value,
+    std::is_standard_layout_v<Half>,
     "c10::Half must be standard layout.");
 
 std::ostream& operator<<(std::ostream& out, const Half& value) {

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -9,8 +9,8 @@
 /// If you are writing a compute bound kernel, you can use the CUDA half
 /// intrinsics directly on the Half type from device code.
 
+#include <c10/macros/Export.h>
 #include <c10/macros/Macros.h>
-#include <c10/util/C++17.h>
 #include <c10/util/TypeSafeSignMath.h>
 #include <c10/util/complex.h>
 #include <c10/util/floating_point_utils.h>
@@ -28,15 +28,10 @@
 #include <intrin.h>
 #endif
 
-#include <complex>
 #include <cstdint>
 #include <cstring>
 #include <iosfwd>
 #include <limits>
-#include <sstream>
-#include <stdexcept>
-#include <string>
-#include <utility>
 
 #ifdef __CUDACC__
 #include <cuda_fp16.h>
@@ -51,8 +46,6 @@
 #elif defined(SYCL_LANGUAGE_VERSION)
 #include <sycl/sycl.hpp> // for SYCL 2020
 #endif
-
-#include <typeinfo> // operator typeid
 
 namespace c10 {
 

--- a/c10/util/Registry.h
+++ b/c10/util/Registry.h
@@ -9,7 +9,6 @@
 // NB: This Registry works poorly when you have other namespaces.
 // Make all macro invocations from inside the at namespace.
 
-#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <functional>
@@ -20,6 +19,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <c10/macros/Export.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/Type.h>
 

--- a/c10/util/ScopeExit.h
+++ b/c10/util/ScopeExit.h
@@ -45,9 +45,8 @@ class scope_exit {
 //
 // Interface is specified by p0052r2.
 template <typename Callable>
-scope_exit<typename std::decay<Callable>::type> make_scope_exit(Callable&& F) {
-  return scope_exit<typename std::decay<Callable>::type>(
-      std::forward<Callable>(F));
+scope_exit<std::decay_t<Callable>> make_scope_exit(Callable&& F) {
+  return scope_exit<std::decay_t<Callable>>(std::forward<Callable>(F));
 }
 
 } // namespace c10

--- a/c10/util/Synchronized.h
+++ b/c10/util/Synchronized.h
@@ -2,8 +2,6 @@
 
 #include <mutex>
 
-#include <c10/util/C++17.h>
-
 namespace c10 {
 
 /**
@@ -28,7 +26,7 @@ class Synchronized final {
  public:
   Synchronized() = default;
   Synchronized(T const& data) : data_(data) {}
-  Synchronized(T&& data) : data_(data) {}
+  Synchronized(T&& data) : data_(std::move(data)) {}
 
   // Don't permit copy construction, move, assignment, or
   // move assignment, since the underlying std::mutex
@@ -44,9 +42,9 @@ class Synchronized final {
    * provided callback safely.
    */
   template <typename CB>
-  typename c10::invoke_result_t<CB, T&> withLock(CB cb) {
+  auto withLock(CB&& cb) {
     std::lock_guard<std::mutex> guard(this->mutex_);
-    return cb(this->data_);
+    return std::forward<CB>(cb)(this->data_);
   }
 
   /**
@@ -55,9 +53,9 @@ class Synchronized final {
    * the provided callback safely.
    */
   template <typename CB>
-  typename c10::invoke_result_t<CB, T const&> withLock(CB cb) const {
+  auto withLock(CB&& cb) const {
     std::lock_guard<std::mutex> guard(this->mutex_);
-    return cb(this->data_);
+    return std::forward<CB>(cb)(this->data_);
   }
 };
 } // end namespace c10

--- a/c10/util/ThreadLocalDebugInfo.h
+++ b/c10/util/ThreadLocalDebugInfo.h
@@ -2,8 +2,8 @@
 
 #include <c10/macros/Export.h>
 
+#include <cstdint>
 #include <memory>
-#include <string>
 
 namespace c10 {
 

--- a/c10/util/TypeIndex.h
+++ b/c10/util/TypeIndex.h
@@ -1,11 +1,13 @@
 #pragma once
 
-#include <c10/util/C++17.h>
 #include <c10/util/ConstexprCrc.h>
 #include <c10/util/IdWrapper.h>
 #include <c10/util/string_view.h>
-#include <cinttypes>
-#include <functional>
+#include <cstdint>
+#include <ostream>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
 
 namespace c10::util {
 

--- a/c10/util/TypeList.h
+++ b/c10/util/TypeList.h
@@ -3,6 +3,10 @@
 #include <c10/util/C++17.h>
 #include <c10/util/TypeTraits.h>
 #include <algorithm>
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+#include <utility>
 
 namespace c10::guts {
 

--- a/c10/util/TypeTraits.h
+++ b/c10/util/TypeTraits.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <c10/util/C++17.h>
+#include <functional>
+#include <type_traits>
 
 namespace c10::guts {
 
@@ -13,7 +14,7 @@ struct is_equality_comparable : std::false_type {};
 template <class T>
 struct is_equality_comparable<
     T,
-    void_t<decltype(std::declval<T&>() == std::declval<T&>())>>
+    std::void_t<decltype(std::declval<T&>() == std::declval<T&>())>>
     : std::true_type {};
 template <class T>
 using is_equality_comparable_t = typename is_equality_comparable<T>::type;
@@ -24,7 +25,7 @@ using is_equality_comparable_t = typename is_equality_comparable<T>::type;
 template <class T, class Enable = void>
 struct is_hashable : std::false_type {};
 template <class T>
-struct is_hashable<T, void_t<decltype(std::hash<T>()(std::declval<T&>()))>>
+struct is_hashable<T, std::void_t<decltype(std::hash<T>()(std::declval<T&>()))>>
     : std::true_type {};
 template <class T>
 using is_hashable_t = typename is_hashable<T>::type;

--- a/c10/util/UniqueVoidPtr.h
+++ b/c10/util/UniqueVoidPtr.h
@@ -1,6 +1,9 @@
 #pragma once
+#include <cstddef>
 #include <memory>
+#include <utility>
 
+#include <c10/macros/Export.h>
 #include <c10/macros/Macros.h>
 
 namespace c10 {

--- a/c10/util/env.h
+++ b/c10/util/env.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <c10/util/Exception.h>
-#include <c10/util/Optional.h>
+#include <cstdlib>
 #include <cstring>
+#include <optional>
 
 namespace c10 {
 namespace utils {
@@ -13,7 +14,7 @@ namespace utils {
 //
 // NB:
 // Issues a warning if the value of the environment variable is not 0 or 1.
-inline optional<bool> check_env(const char* name) {
+inline std::optional<bool> check_env(const char* name) {
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4996)
@@ -36,7 +37,7 @@ inline optional<bool> check_env(const char* name) {
         envar,
         "valid values are 0 or 1.");
   }
-  return c10::nullopt;
+  return std::nullopt;
 }
 } // namespace utils
 } // namespace c10

--- a/c10/util/hash.h
+++ b/c10/util/hash.h
@@ -1,8 +1,15 @@
 #pragma once
 
+#include <c10/util/Exception.h>
+#include <cstddef>
 #include <functional>
 #include <iomanip>
+#include <ios>
 #include <sstream>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 #include <c10/util/ArrayRef.h>
@@ -244,8 +251,7 @@ template <typename T>
 size_t simple_get_hash(const T& o);
 
 template <typename T, typename V>
-using type_if_not_enum =
-    typename std::enable_if<!std::is_enum<T>::value, V>::type;
+using type_if_not_enum = std::enable_if_t<!std::is_enum_v<T>, V>;
 
 // Use SFINAE to dispatch to std::hash if possible, cast enum types to int
 // automatically, and fall back to T::hash otherwise. NOTE: C++14 added support
@@ -259,9 +265,8 @@ auto dispatch_hash(const T& o)
 }
 
 template <typename T>
-typename std::enable_if<std::is_enum<T>::value, size_t>::type dispatch_hash(
-    const T& o) {
-  using R = typename std::underlying_type<T>::type;
+std::enable_if_t<std::is_enum_v<T>, size_t> dispatch_hash(const T& o) {
+  using R = std::underlying_type_t<T>;
   return std::hash<R>()(static_cast<R>(o));
 }
 

--- a/c10/util/irange.h
+++ b/c10/util/irange.h
@@ -6,8 +6,8 @@
 #include <c10/util/TypeSafeSignMath.h>
 
 #include <algorithm>
+#include <cstddef>
 #include <iterator>
-#include <limits>
 #include <type_traits>
 
 namespace c10 {

--- a/c10/util/numa.h
+++ b/c10/util/numa.h
@@ -2,7 +2,7 @@
 
 #include <c10/macros/Export.h>
 #include <c10/util/Flags.h>
-#include <stddef.h>
+#include <cstddef>
 
 C10_DECLARE_bool(caffe2_cpu_numa_enabled);
 

--- a/c10/util/safe_numerics.h
+++ b/c10/util/safe_numerics.h
@@ -1,10 +1,7 @@
 #pragma once
 #include <c10/macros/Macros.h>
-#include <c10/util/ArrayRef.h>
 
-#include <iterator>
-#include <numeric>
-#include <type_traits>
+#include <cstdint>
 
 // GCC has __builtin_mul_overflow from before it supported __has_builtin
 #ifdef _MSC_VER

--- a/c10/util/static_tracepoint_elfx86.h
+++ b/c10/util/static_tracepoint_elfx86.h
@@ -1,7 +1,6 @@
 #pragma once
 
 // clang-format off
-#include <cstddef>
 
 // Default constraint for the probe arguments as operands.
 #ifndef TORCH_SDT_ARG_CONSTRAINT

--- a/c10/util/strides.h
+++ b/c10/util/strides.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <c10/util/ArrayRef.h>
 #include <c10/util/DimVector.h>
+#include <algorithm>
 
 namespace c10 {
 

--- a/c10/util/string_view.h
+++ b/c10/util/string_view.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <algorithm>
+#include <cstddef>
 #include <cstring>
 #include <functional>
 #include <iterator>
 #include <limits>
+#include <ostream>
 #include <stdexcept>
 #include <string>
 #include <string_view>

--- a/c10/util/tempfile.h
+++ b/c10/util/tempfile.h
@@ -3,6 +3,7 @@
 #include <c10/macros/Export.h>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 
 namespace c10 {

--- a/c10/util/typeid.h
+++ b/c10/util/typeid.h
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -10,15 +11,17 @@
 #include <type_traits>
 #include <vector>
 
+#include <c10/macros/Export.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
+#include <c10/util/Half.h>
 #include <c10/util/IdWrapper.h>
 #include <c10/util/TypeIndex.h>
 #include <c10/util/TypeTraits.h>
+#include <c10/util/irange.h>
 #include <c10/util/string_view.h>
 
 #include <c10/core/ScalarType.h>
-#include <c10/util/irange.h>
 
 /*
  * TypeIdentifier is a small type containing an id.


### PR DESCRIPTION
Continued work to clean headers in c10/util.