### PR TITLE
[Easy][BE]: Enable RUF008 and RUF016 checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,9 @@ select = [
     "PT025",
     "PT026",
     "PYI",
+    "RUF008", # mutable dataclass default
     "RUF015", # access first ele in constant time
+    "RUF016", # type error non-integer index
     "RUF017",
     "TRY200",
     "TRY302",

--- a/torch/distributed/fsdp/_trace_utils.py
+++ b/torch/distributed/fsdp/_trace_utils.py
@@ -1,6 +1,6 @@
 import functools
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set, Tuple
 
 import torch
@@ -27,7 +27,7 @@ class TracingConfig:
             in :meth:`~torch.fx.Tracer.trace`.
     """
 
-    tracer: torch.fx.Tracer = torch.fx.Tracer()
+    tracer: torch.fx.Tracer = field(default_factory=torch.fx.Tracer)
     concrete_args: Optional[Dict[str, Any]] = None
 
 


### PR DESCRIPTION
Enables a few more static linting checks for mutable defaults in dataclasses and for detecting a common type error.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225