### PR TITLE
[BE][Easy]: Enable clang-tidy check readability-misplaced-array-index

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -54,6 +54,7 @@ performance-*,
 readability-container-size-empty,
 readability-delete-null-pointer,
 readability-duplicate-include
+readability-misplaced-array-index,
 readability-string-compare,
 '
 HeaderFilterRegex: '^(aten/|c10/|torch/).*$'


### PR DESCRIPTION
Enable clang-tidy check readability which checks for a bizarre C++ construct that is usually indicative of an error: https://clang.llvm.org/extra/clang-tidy/checks/readability/misplaced-array-index.html (indexing a number by a pointer, which surprisingly inverts the operands).