### PR TITLE
[EZ] Fix typo in `USE_GLOO` var

### DIFF
--- a/caffe2/core/macros.h.in
+++ b/caffe2/core/macros.h.in
@@ -50,7 +50,7 @@
   {"USE_MPI", "${USE_MPI}"}, \
   {"USE_GFLAGS", "${USE_GFLAGS}"}, \
   {"USE_GLOG", "${USE_GLOG}"}, \
-  {"USE_GLOO", "${USE_GLOI}"}, \
+  {"USE_GLOO", "${USE_GLOO}"}, \
   {"USE_NNPACK", "${USE_NNPACK}"}, \
   {"USE_OPENMP", "${USE_OPENMP}"}, \
   {"FORCE_FALLBACK_CUDA_MPI", "${CAFFE2_FORCE_FALLBACK_CUDA_MPI}"}, \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #116213
* __->__ #116212

