### PR TITLE
follow up #115078, broken distributed tests

### DIFF
--- a/test/distributed/test_functional_api.py
+++ b/test/distributed/test_functional_api.py
@@ -597,6 +597,7 @@ class TestCollectivesWithNCCL(MultiProcessTestCase):
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
     def test_tracing_with_fakepg(self):
         exit_if_lt_x_gpu(self.world_size)
+
         def allreduce(t, pg):
             return ft_c.all_reduce(t, "sum", pg)
 

--- a/test/distributed/test_functional_api.py
+++ b/test/distributed/test_functional_api.py
@@ -26,7 +26,6 @@ from torch.testing._internal.common_distributed import (
     MultiProcessTestCase,
     MultiThreadedTestCase,
     requires_nccl,
-    skip_if_lt_x_gpu,
     TEST_SKIPS,
 )
 
@@ -427,6 +426,11 @@ BACKEND = dist.Backend.NCCL if torch.cuda.is_available() else dist.Backend.GLOO
 WORLD_SIZE = 2
 
 
+def exit_if_lt_x_gpu(x):
+    if BACKEND == dist.Backend.NCCL and torch.cuda.device_count() < x:
+        sys.exit(TEST_SKIPS[f"multi-gpu-{x}"].exit_code)
+
+
 def with_comms(func=None):
     if func is None:
         return partial(
@@ -480,7 +484,6 @@ class TestCollectivesWithNCCL(MultiProcessTestCase):
         dist.barrier()
         dist.destroy_process_group()
 
-    @skip_if_lt_x_gpu(WORLD_SIZE)
     @requires_nccl()
     @with_comms()
     def test_all_gather_into_tensor_coalesced(self):
@@ -582,7 +585,6 @@ class TestCollectivesWithNCCL(MultiProcessTestCase):
         self.assertEqual(y, expected)
 
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
-    @skip_if_lt_x_gpu(WORLD_SIZE)
     @requires_nccl()
     @with_comms()
     def test_tracing(self):
@@ -594,6 +596,7 @@ class TestCollectivesWithNCCL(MultiProcessTestCase):
 
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
     def test_tracing_with_fakepg(self):
+        exit_if_lt_x_gpu(self.world_size)
         def allreduce(t, pg):
             return ft_c.all_reduce(t, "sum", pg)
 
@@ -613,7 +616,6 @@ class TestNCCLCollectivesWithWorldSize4(TestCollectivesWithNCCL):
     def world_size(self):
         return 4
 
-    @skip_if_lt_x_gpu(4)
     @requires_nccl()
     @with_comms()
     def test_permute_tensor_with_sub_group(self):


### PR DESCRIPTION
ROCm distributed tests started failing after #115078.  This skips the new tests if the number of GPUs available isn't sufficient.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225