### PR TITLE
Preserve strides of custom Triton kernel args

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -2427,6 +2427,29 @@ def forward(self, x_1, output_1):
         python_out = torch.mm(torch.ones(4, 4, device="cuda"), x) + 10
         self.assertEqual(torch_out, python_out)
 
+    @requires_cuda()
+    def test_triton_kernel_strided_input(self):
+        def f(inp):
+            left, right = torch.split(inp, [128, 128], dim=1)
+            out = torch.empty_like(left)
+            X_BLOCK_SIZE, Y_BLOCK_SIZE = 32, 16
+            grid = (left.size(1) // X_BLOCK_SIZE, left.size(0) // Y_BLOCK_SIZE)
+            double_strided_kernel[grid](
+                in_ptr=left,
+                out_ptr=out,
+                in_y_stride=left.stride(0),
+                out_y_stride=out.stride(0),
+                X_BLOCK_SIZE=X_BLOCK_SIZE,
+                Y_BLOCK_SIZE=Y_BLOCK_SIZE,
+            )
+            return out
+
+        inp = torch.randn(64, 256, device="cuda")
+
+        eager_out = f(inp)
+        compiled_out = torch.compile(f)(inp)
+        self.assertEqual(compiled_out, eager_out)
+
     def test_dataclass_factory(self):
         @dataclass
         class Output:

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -2430,6 +2430,7 @@ def forward(self, x_1, output_1):
     @requires_cuda()
     def test_triton_kernel_strided_input(self):
         def f(inp):
+            # left has strides [256, 1]
             left, right = torch.split(inp, [128, 128], dim=1)
             out = torch.empty_like(left)
             X_BLOCK_SIZE, Y_BLOCK_SIZE = 32, 16
@@ -2438,6 +2439,30 @@ def forward(self, x_1, output_1):
                 in_ptr=left,
                 out_ptr=out,
                 in_y_stride=left.stride(0),
+                out_y_stride=out.stride(0),
+                X_BLOCK_SIZE=X_BLOCK_SIZE,
+                Y_BLOCK_SIZE=Y_BLOCK_SIZE,
+            )
+            return out
+
+        inp = torch.randn(64, 256, device="cuda")
+
+        eager_out = f(inp)
+        compiled_out = torch.compile(f)(inp)
+        self.assertEqual(compiled_out, eager_out)
+
+    @requires_cuda()
+    def test_triton_kernel_strided_input_nonzero_offset(self):
+        def f(inp):
+            # right has strides [256, 1] and storage offset 128
+            left, right = torch.split(inp, [128, 128], dim=1)
+            out = torch.empty_like(right)
+            X_BLOCK_SIZE, Y_BLOCK_SIZE = 32, 16
+            grid = (right.size(1) // X_BLOCK_SIZE, right.size(0) // Y_BLOCK_SIZE)
+            double_strided_kernel[grid](
+                in_ptr=right,
+                out_ptr=out,
+                in_y_stride=right.stride(0),
                 out_y_stride=out.stride(0),
                 X_BLOCK_SIZE=X_BLOCK_SIZE,
                 Y_BLOCK_SIZE=Y_BLOCK_SIZE,

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3681,7 +3681,7 @@ class ExternKernel(InputsKernel):
         if isinstance(x, TensorBox):
             return cls.realize_input(x.data)
         if isinstance(x, ReinterpretView):
-            return x
+            return cls.realize_input(x.data)
         if isinstance(x, BaseView):
             x.realize()
             if is_storage_and_layout(x.unwrap_view()):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3681,7 +3681,7 @@ class ExternKernel(InputsKernel):
         if isinstance(x, TensorBox):
             return cls.realize_input(x.data)
         if isinstance(x, ReinterpretView):
-            return cls.realize_input(x.data)
+            return ReinterpretView(cls.realize_input(x.data), x.get_layout())
         if isinstance(x, BaseView):
             x.realize()
             if is_storage_and_layout(x.unwrap_view()):

--- a/torch/testing/_internal/triton_utils.py
+++ b/torch/testing/_internal/triton_utils.py
@@ -163,3 +163,23 @@ if HAS_CUDA:
             mul2_inplace_kernel(in_ptr0, n_elements, BLOCK_SIZE=BLOCK_SIZE)
         x = tl.load(in_ptr0 + offsets, mask=mask)
         tl.store(out_ptr + offsets, x, mask=mask)
+
+    @triton.jit
+    def double_strided_kernel(
+        in_ptr,
+        out_ptr,
+        in_y_stride,
+        out_y_stride,
+        X_BLOCK_SIZE: "tl.constexpr",
+        Y_BLOCK_SIZE: "tl.constexpr",
+    ):
+        xid = tl.program_id(axis=0)
+        yid = tl.program_id(axis=1)
+        x_start = xid * X_BLOCK_SIZE
+        y_start = yid * Y_BLOCK_SIZE
+        x_offsets = x_start + tl.arange(0, X_BLOCK_SIZE)
+        y_offsets = y_start + tl.arange(0, Y_BLOCK_SIZE)
+        src_offsets = y_offsets[:, None] * in_y_stride + x_offsets[None, :]
+        dst_offsets = y_offsets[:, None] * out_y_stride + x_offsets[None, :]
+        src = tl.load(in_ptr + src_offsets)
+        tl.store(out_ptr + dst_offsets, src * 2.0)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #116219

Summary: Currently, we [`clone`](https://github.com/pytorch/pytorch/blob/19207b9183baced683d675c341b7da051cd16440/torch/_inductor/lowering.py#L5273) every `TensorBox` argument of custom Triton kernels while lowering them to the Inductor IR, during which the stride information of the kernel inputs is lost. This is problematic in the common case when the strides of a `torch.Tensor` argument are passed as scalars to a custom Triton kernel alongside the tensor itself (due to the underlying Triton code interpreting the tensors as raw pointers, so the contained stride semantics of the `torch.Tensor` is lost).

In this PR, we add an extended version of the existing [`clone` lowering](https://github.com/pytorch/pytorch/blob/19207b9183baced683d675c341b7da051cd16440/torch/_inductor/lowering.py#L2289)---`clone_preserve_reinterpret_view`---which carries over the `ir.ReinterpretVew` layers (if any) from the source `TensorBox` to the cloned one. The rationale behind adding a new function (and switching to it in the `triton_kernel_wrap` only for now) as opposed to extending the existing `clone` is keeping the semantics of the latter untouched, as it is a lowering of `torch.clone` (albeit incomplete, as the `memory_format` is currently ignored). Changing the existing `clone` would change the semantics which is not necessarily desirable in general. Open to suggestions, though.

Test Plan:

```
$ python test/dynamo/test_functions.py -k test_triton_kernel_strided_input
...
----------------------------------------------------------------------
Ran 1 test in 5.568s

OK
```

Reviewers:

Subscribers:

Tasks:

Tags:

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler