### PR TITLE
Fix elastic multiprocessing in case a child does exit(0)

### DIFF
--- a/torch/multiprocessing/spawn.py
+++ b/torch/multiprocessing/spawn.py
@@ -92,6 +92,9 @@ class ProcessContext:
             process.sentinel: index for index, process in enumerate(processes)
         }
 
+    def alive_pids(self):
+        return [int(process.pid) for process in self.processes if process.is_alive()]
+
     def pids(self):
         return [int(process.pid) for process in self.processes]
 


### PR DESCRIPTION
Summary: Fix elastic multiprocessing in case a child does exit(0)

Test Plan: We got into an edge case where child process calls exit(0) this isn't handled well in elastic multiprocessing and we end up deadlocking. This change take care of the same. The issue is that torch.multiprocessing considers only non-zero exit codes as errors while elastic logic assumes unless there is an error we would get the return info in the queue.

Differential Revision: D52348727




cc @mrshenli @pritamdamania87 @zhaojuanmao @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225