### PR TITLE
[inductor] fix tests due to extra warmup argument

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -1971,7 +1971,9 @@ def forward(self, x_1, output_1):
 
             tmp = torch.add(x, 1)
             grid = (x.numel(),)
-            add_kernel.run(x, y, output, n_elements, grid=grid, BLOCK_SIZE=16)
+            add_kernel.run(
+                x, y, output, n_elements, warmup=False, grid=grid, BLOCK_SIZE=16
+            )
 
             return output, tmp
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4036,6 +4036,11 @@ class UserDefinedTritonKernel(ExternKernel):
         inputs = []
         kwargs = dict()
         constant_args = []
+
+        if "warmup" in kernel_args:
+            assert kernel_args["warmup"] is False
+            kernel_args.pop("warmup")
+
         for k, v in kernel_args.items():
             if isinstance(v, TensorBox):
                 t = InputsKernel.unwrap_storage_for_input(self.realize_input(v))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #115881
* __->__ #116232
* #115878


I missed some test failures in the previous PR. Some (testing) code calls JITFunction.run directly and need to pass in the warmup argument which becomes required recently.

I'm not sure if my change in UserDefinedTritonKernel is legit or not. cc @oulgen 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler