### PR TITLE
Pin the version of expecttest to 0.1.6 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Python dependencies required for development
 astunparse
-expecttest==0.1.6
+expecttest!=0.2.0
 hypothesis
 numpy
 psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Python dependencies required for development
 astunparse
-expecttest
+expecttest==0.1.6
 hypothesis
 numpy
 psutil


### PR DESCRIPTION
The version 0.2.0 of expecttest have removed `ACCEPT` variable by this [PR](https://github.com/ezyang/expecttest/pull/11), so when someone install python dependences using `pip install -r PyTorch_Root/requirements.txt`, the latest version of expecttest will be installed which will cuase failure in some PyTorch Tests. So Pin the version of expecttest to 0.1.6 like [this](https://github.com/pytorch/pytorch/blob/db35ccf46334164d0b02e5be9450193d881edb40/.ci/docker/requirements-ci.txt#L28) is needed.