### PR TITLE
Back out "Implement pass-through `state_dict` and `load_state_dict` for dynamo OptimizedModule (#113423)"

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -2294,51 +2294,6 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         generate(torch.randn(10, 10), 0)
         self.assertEqual(cnt.frame_count, 3)
 
-    def test_state_dict_pass_through(self):
-        mod = MockModule()
-        cnt = torch._dynamo.testing.CompileCounter()
-        opt_mod = torch._dynamo.optimize(cnt)(mod)
-        self.assertIsInstance(opt_mod, torch._dynamo.OptimizedModule)
-
-        # The state-dict doesn't contain the `_orig_mod` prefix
-        self.assertEqual(mod.state_dict(), opt_mod.state_dict())
-        self.assertEqual(opt_mod.state_dict(), opt_mod._orig_mod.state_dict())
-
-        # Load the state-dict of an `OptimizedModule` into a regular `nn.Module`
-        new_mod = MockModule()
-        self.assertNotEqual(list(new_mod.parameters()), list(mod.parameters()))
-        new_mod.load_state_dict(opt_mod.state_dict())
-        self.assertEqual(list(new_mod.parameters()), list(mod.parameters()))
-
-        # Load the state-dict of a regular `nn.Module` into an `OptimizedModule`
-        new_mod = MockModule()
-        self.assertNotEqual(list(new_mod.parameters()), list(opt_mod.parameters()))
-        opt_mod.load_state_dict(new_mod.state_dict())
-        self.assertEqual(list(new_mod.parameters()), list(opt_mod.parameters()))
-        self.assertEqual(
-            list(opt_mod.parameters()), list(opt_mod._orig_mod.parameters())
-        )
-
-        # For backward-compatibility, load a state-dict with keys prefixed with `_orig_mod`
-        old_mod = MockModule()
-        state_dict = old_mod.state_dict()
-        legacy_opt_state_dict = {("_orig_mod." + k): v for k, v in state_dict.items()}
-
-        new_mod = MockModule()
-        cnt = torch._dynamo.testing.CompileCounter()
-        opt_mod = torch._dynamo.optimize(cnt)(new_mod)
-        self.assertNotEqual(list(opt_mod.parameters()), list(old_mod.parameters()))
-        opt_mod.load_state_dict(legacy_opt_state_dict)
-        self.assertEqual(list(opt_mod.parameters()), list(old_mod.parameters()))
-        self.assertEqual(opt_mod.state_dict(), old_mod.state_dict())
-        self.assertEqual(old_mod.state_dict(), new_mod.state_dict())
-
-        # When only a submodule is an `OptimizedModule`
-        mod = MockModule()
-        cnt = torch._dynamo.testing.CompileCounter()
-        mod.linear = torch._dynamo.optimize(cnt)(mod.linear)
-        assert not any("_orig_mod" in key for key in mod.state_dict())
-
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -21,7 +21,6 @@ from typing import (
     Callable,
     Dict,
     List,
-    Mapping,
     NamedTuple,
     Optional,
     Set,
@@ -234,22 +233,6 @@ class OptimizedModule(torch.nn.Module):
         return orig_mod_attrs + [
             attr for attr in super().__dir__() if attr not in orig_mod_attrs
         ]
-
-    def state_dict(self, *args, **kwargs):
-        return self._orig_mod.state_dict(*args, **kwargs)
-
-    def load_state_dict(
-        self, state_dict: Mapping[str, Any], strict: bool = True, assign: bool = False
-    ):
-        # we strip away the '_orig_mod' prefix for backward-compatibility with old checkpoints
-        prefix = "_orig_mod."
-        processed_state_dict = {}
-        for key in state_dict:
-            clean_key = key[len(prefix) :] if key.startswith(prefix) else key
-            processed_state_dict[clean_key] = state_dict[key]
-        return self._orig_mod.load_state_dict(
-            state_dict=processed_state_dict, strict=strict, assign=assign
-        )
 
 
 def remove_from_cache(f):


### PR DESCRIPTION
Summary:
Original commit changeset: 2a9588cfd51b

Original Phabricator Diff: D52062368

Test Plan: In investigating S386328 and S382826, we found checkpoint loading succeed after backout D52062368: S386328_backout_1220_193648

Differential Revision: D52356011



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng