### PR TITLE
Allow cpu scalar to be moved to HPU in masked_fill decomposition

### DIFF
--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5482,8 +5482,8 @@ def masked_fill(a: TensorLikeType, mask: TensorLikeType, value: TensorOrNumberLi
             value_ndim == 0,
             lambda: f"only supports a 0-dimensional value tensor, but got tensor with {value_ndim} dimension",
         )
-        # `masked_fill` allows cpu scalar to be moved to cuda and xpu but not otherwise.
-        is_cpu_scalar = a.device.type in ["cuda", "xpu"] and value.device.type == "cpu"
+        # `masked_fill` allows cpu scalar to be moved to hpu, cuda and xpu but not otherwise.
+        is_cpu_scalar = a.device.type in ["hpu", "cuda", "xpu"] and value.device.type == "cpu"
         torch._check(
             is_cpu_scalar or value.device == a.device,
             lambda: "Expected `value` to be on same device as `a`",


### PR DESCRIPTION
Extension of the condition allowing the cpu scalar to be moved to specific devices.

This fixes an HPU specific error:
```
torch._dynamo.exc.BackendCompilerFailed: backend='aot_hpu_training_backend' raised:
RuntimeError: Expected `value` to be on same device as `a`While executing %masked_fill : [num_users=1] = call_method[target=masked_fill](args = (%matmul, %expand_as, %tensor), kwargs = {})
```