### PR TITLE
[C10D] Improve Heartbeat Monitor exit logs

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1237,23 +1237,16 @@ void ProcessGroupNCCL::heartbeatMonitor() {
   // local disk)
   std::future<bool> asyncDebugDump = launchAsyncDebugDump();
 
-  // Create a error message reported from MonitorThread, so
-  // we throw exception and make the whole process to be killed.
-  // TODO(fduwjj): After having a hang debug wiki, we need to update the wiki
-  // url here.
-  const auto exitMsg = c10::str(
+  const auto logMsg = c10::str(
       logPrefix(),
-      "ProcessGroupNCCL's watchdog got stuck for ",
-      heartbeatTimeoutInSec_,
-      "seconds without making progress in monitoring enqueued collectives. ",
-      "This typically indicates a NCCL/CUDA API hang blocking the watchdog, ",
-      "and could be triggered by another thread holding the GIL inside a ",
-      "CUDA api, or other deadlock-prone behaviors.",
-      "If you suspect the watchdog is not actually stuck and a longer timeout would help, ",
-      "you can either increase the timeout (TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC) to a larger value "
-      "or disable the heartbeat monitor (TORCH_NCCL_ENABLE_MONITORING=0)."
-      "If either of aforementioned helps, feel free to file an issue to PyTorch about the short timeout "
-      "or false positive abort; otherwise, please attempt to debug the hang.");
+      "Heartbeat monitor timed out! Process will be terminated after dumping debug info.",
+      " terminateProcessGroup_=",
+      terminateProcessGroup_,
+      ", collectiveDebugInfoMode_=",
+      collectiveDebugInfoMode_,
+      ", workMetaList_.size()=",
+      workMetaList_.size());
+  LOG(ERROR) << logMsg;
 
   // There are two possible cases for the watchdog thread exit:
   // Case one: desync report runs quickly, and it follows the step:
@@ -1282,14 +1275,23 @@ void ProcessGroupNCCL::heartbeatMonitor() {
   waitForDumpOrTimeout(asyncDebugDump);
 
   if (!terminateHeartbeatMonitorThread_.load()) {
-    const auto logMsg = c10::str(
+    // Create a error message reported from MonitorThread, so
+    // we throw exception and make the whole process to be killed.
+    // TODO(fduwjj): After having a hang debug wiki, we need to update the wiki
+    // url here.
+    const auto exitMsg = c10::str(
         logPrefix(),
-        "monitoring thread detects no heartbeat and will finally kill the process!",
-        " terminateProcessGroup_",
-        terminateProcessGroup_,
-        " collectiveDebugInfoMode_",
-        collectiveDebugInfoMode_);
-    LOG(ERROR) << logMsg;
+        "ProcessGroupNCCL's watchdog got stuck for ",
+        heartbeatTimeoutInSec_,
+        "seconds without making progress in monitoring enqueued collectives. ",
+        "This typically indicates a NCCL/CUDA API hang blocking the watchdog, ",
+        "and could be triggered by another thread holding the GIL inside a ",
+        "CUDA api, or other deadlock-prone behaviors.",
+        "If you suspect the watchdog is not actually stuck and a longer timeout would help, ",
+        "you can either increase the timeout (TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC) to a larger value "
+        "or disable the heartbeat monitor (TORCH_NCCL_ENABLE_MONITORING=0)."
+        "If either of aforementioned helps, feel free to file an issue to PyTorch about the short timeout "
+        "or false positive abort; otherwise, please attempt to debug the hang.");
     terminateProcess(exitMsg);
   }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #116268
* #116267

- add workMetaList_.size() so we know how many outstanding works there
  were when killing
- Print our first log before debuginfo dump instead of after, since it
  is clearer when reading the logs that we time out and then dump
- Organize the log strings- put them near where they are used

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @yf225

Differential Revision: [D52369167](https://our.internmc.facebook.com/intern/diff/D52369167)