### PR TITLE
Introduce cmake variable USE_SYSTEM_ROCM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,7 @@ option(USE_CUDA "Use CUDA" ON)
 cmake_dependent_option(
      BUILD_LAZY_CUDA_LINALG "Build cuda linalg ops as separate library" ON "USE_CUDA AND LINUX AND BUILD_PYTHON" OFF)
 cmake_dependent_option(USE_ROCM "Use ROCm" ON "LINUX" OFF)
+cmake_dependent_option(USE_SYSTEM_ROCM "Use System ROCm" OFF "USE_ROCM" ON)
 option(CAFFE2_STATIC_LINK_CUDA "Statically link CUDA libraries" OFF)
 cmake_dependent_option(
     USE_CUDNN "Use cuDNN" ON

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -1,154 +1,168 @@
-set(PYTORCH_FOUND_HIP FALSE)
-
-if(NOT DEFINED ENV{ROCM_PATH})
-  set(ROCM_PATH /opt/rocm)
-else()
-  set(ROCM_PATH $ENV{ROCM_PATH})
-endif()
-if(NOT DEFINED ENV{ROCM_INCLUDE_DIRS})
-  set(ROCM_INCLUDE_DIRS ${ROCM_PATH}/include)
-else()
-  set(ROCM_INCLUDE_DIRS $ENV{ROCM_INCLUDE_DIRS})
-endif()
-
-if(NOT EXISTS ${ROCM_PATH})
-  return()
-endif()
-
-# MAGMA_HOME
-if(NOT DEFINED ENV{MAGMA_HOME})
-  set(MAGMA_HOME ${ROCM_PATH}/magma)
-  set(ENV{MAGMA_HOME} ${ROCM_PATH}/magma)
-else()
-  set(MAGMA_HOME $ENV{MAGMA_HOME})
-endif()
-
-torch_hip_get_arch_list(PYTORCH_ROCM_ARCH)
-if(PYTORCH_ROCM_ARCH STREQUAL "")
-  message(FATAL_ERROR "No GPU arch specified for ROCm build. Please use PYTORCH_ROCM_ARCH environment variable to specify GPU archs to build for.")
-endif()
-message("Building PyTorch for GPU arch: ${PYTORCH_ROCM_ARCH}")
-
-# Add HIP to the CMAKE Module Path
-set(CMAKE_MODULE_PATH ${ROCM_PATH}/lib/cmake/hip ${CMAKE_MODULE_PATH})
-
 macro(find_package_and_print_version PACKAGE_NAME)
   find_package("${PACKAGE_NAME}" ${ARGN})
   message("${PACKAGE_NAME} VERSION: ${${PACKAGE_NAME}_VERSION}")
 endmacro()
 
-# Find the HIP Package
-find_package_and_print_version(HIP 1.0)
+if (NOT USE_SYSTEM_ROCM)
+  set(PYTORCH_FOUND_HIP FALSE)
 
-if(HIP_FOUND)
+  if(NOT DEFINED ENV{ROCM_PATH})
+    set(ROCM_PATH /opt/rocm)
+  else()
+    set(ROCM_PATH $ENV{ROCM_PATH})
+  endif()
+  if(NOT DEFINED ENV{ROCM_INCLUDE_DIRS})
+    set(ROCM_INCLUDE_DIRS ${ROCM_PATH}/include)
+  else()
+    set(ROCM_INCLUDE_DIRS $ENV{ROCM_INCLUDE_DIRS})
+  endif()
+
+  if(NOT EXISTS ${ROCM_PATH})
+    return()
+  endif()
+
+  # MAGMA_HOME
+  if(NOT DEFINED ENV{MAGMA_HOME})
+    set(MAGMA_HOME ${ROCM_PATH}/magma)
+    set(ENV{MAGMA_HOME} ${ROCM_PATH}/magma)
+  else()
+    set(MAGMA_HOME $ENV{MAGMA_HOME})
+  endif()
+
+  # Add HIP to the CMAKE Module Path
+  set(CMAKE_MODULE_PATH ${ROCM_PATH}/lib/cmake/hip ${CMAKE_MODULE_PATH})
+
+  # Find the HIP Package
+  find_package_and_print_version(HIP 1.0)
+
+  if(HIP_FOUND)
+    set(PYTORCH_FOUND_HIP TRUE)
+    set(FOUND_ROCM_VERSION_H FALSE)
+
+    set(PROJECT_RANDOM_BINARY_DIR "${PROJECT_BINARY_DIR}")
+    set(file "${PROJECT_BINARY_DIR}/detect_rocm_version.cc")
+
+    # Find ROCM version for checks
+    # ROCM 5.0 and later will have header api for version management
+    if(EXISTS ${ROCM_INCLUDE_DIRS}/rocm_version.h)
+      set(FOUND_ROCM_VERSION_H TRUE)
+      file(WRITE ${file} ""
+	"#include <rocm_version.h>\n"
+      )
+    elseif(EXISTS ${ROCM_INCLUDE_DIRS}/rocm-core/rocm_version.h)
+      set(FOUND_ROCM_VERSION_H TRUE)
+      file(WRITE ${file} ""
+	"#include <rocm-core/rocm_version.h>\n"
+      )
+    else()
+      message("********************* rocm_version.h couldnt be found ******************\n")
+    endif()
+
+    if(FOUND_ROCM_VERSION_H)
+      file(APPEND ${file} ""
+	"#include <cstdio>\n"
+
+	"#ifndef ROCM_VERSION_PATCH\n"
+	"#define ROCM_VERSION_PATCH 0\n"
+	"#endif\n"
+	"#define STRINGIFYHELPER(x) #x\n"
+	"#define STRINGIFY(x) STRINGIFYHELPER(x)\n"
+	"int main() {\n"
+	"  printf(\"%d.%d.%s\", ROCM_VERSION_MAJOR, ROCM_VERSION_MINOR, STRINGIFY(ROCM_VERSION_PATCH));\n"
+	"  return 0;\n"
+	"}\n"
+      )
+
+      try_run(run_result compile_result ${PROJECT_RANDOM_BINARY_DIR} ${file}
+	CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${ROCM_INCLUDE_DIRS}"
+	RUN_OUTPUT_VARIABLE rocm_version_from_header
+	COMPILE_OUTPUT_VARIABLE output_var
+      )
+      # We expect the compile to be successful if the include directory exists.
+      if(NOT compile_result)
+	message(FATAL_ERROR "Caffe2: Couldn't determine version from header: " ${output_var})
+      endif()
+      message(STATUS "Caffe2: Header version is: " ${rocm_version_from_header})
+      set(ROCM_VERSION_DEV_RAW ${rocm_version_from_header})
+      message("\n***** ROCm version from rocm_version.h ****\n")
+    endif()
+
+    string(REGEX MATCH "^([0-9]+)\.([0-9]+)\.([0-9]+).*$" ROCM_VERSION_DEV_MATCH ${ROCM_VERSION_DEV_RAW})
+
+    if(ROCM_VERSION_DEV_MATCH)
+      set(ROCM_VERSION_DEV_MAJOR ${CMAKE_MATCH_1})
+      set(ROCM_VERSION_DEV_MINOR ${CMAKE_MATCH_2})
+      set(ROCM_VERSION_DEV_PATCH ${CMAKE_MATCH_3})
+      set(ROCM_VERSION_DEV "${ROCM_VERSION_DEV_MAJOR}.${ROCM_VERSION_DEV_MINOR}.${ROCM_VERSION_DEV_PATCH}")
+      math(EXPR ROCM_VERSION_DEV_INT "(${ROCM_VERSION_DEV_MAJOR}*10000) + (${ROCM_VERSION_DEV_MINOR}*100) + ${ROCM_VERSION_DEV_PATCH}")
+    endif()
+
+    message("ROCM_VERSION_DEV: ${ROCM_VERSION_DEV}")
+    message("ROCM_VERSION_DEV_MAJOR: ${ROCM_VERSION_DEV_MAJOR}")
+    message("ROCM_VERSION_DEV_MINOR: ${ROCM_VERSION_DEV_MINOR}")
+    message("ROCM_VERSION_DEV_PATCH: ${ROCM_VERSION_DEV_PATCH}")
+    message("ROCM_VERSION_DEV_INT:   ${ROCM_VERSION_DEV_INT}")
+
+    math(EXPR TORCH_HIP_VERSION "(${HIP_VERSION_MAJOR} * 100) + ${HIP_VERSION_MINOR}")
+    message("HIP_VERSION_MAJOR: ${HIP_VERSION_MAJOR}")
+    message("HIP_VERSION_MINOR: ${HIP_VERSION_MINOR}")
+    message("TORCH_HIP_VERSION: ${TORCH_HIP_VERSION}")
+
+    message("\n***** Library versions from dpkg *****\n")
+    execute_process(COMMAND dpkg -l COMMAND grep rocm-dev COMMAND awk "{print $2 \" VERSION: \" $3}")
+    execute_process(COMMAND dpkg -l COMMAND grep rocm-libs COMMAND awk "{print $2 \" VERSION: \" $3}")
+    execute_process(COMMAND dpkg -l COMMAND grep hsakmt-roct COMMAND awk "{print $2 \" VERSION: \" $3}")
+    execute_process(COMMAND dpkg -l COMMAND grep rocr-dev COMMAND awk "{print $2 \" VERSION: \" $3}")
+    execute_process(COMMAND dpkg -l COMMAND grep -w hcc COMMAND awk "{print $2 \" VERSION: \" $3}")
+    execute_process(COMMAND dpkg -l COMMAND grep hip-base COMMAND awk "{print $2 \" VERSION: \" $3}")
+    execute_process(COMMAND dpkg -l COMMAND grep hip_hcc COMMAND awk "{print $2 \" VERSION: \" $3}")
+
+    message("\n***** Library versions from cmake find_package *****\n")
+
+    set(hip_DIR ${ROCM_PATH}/lib/cmake/hip)
+    set(hsa-runtime64_DIR ${ROCM_PATH}/lib/cmake/hsa-runtime64)
+    set(AMDDeviceLibs_DIR ${ROCM_PATH}/lib/cmake/AMDDeviceLibs)
+    set(amd_comgr_DIR ${ROCM_PATH}/lib/cmake/amd_comgr)
+    set(rocrand_DIR ${ROCM_PATH}/lib/cmake/rocrand)
+    set(hiprand_DIR ${ROCM_PATH}/lib/cmake/hiprand)
+    set(rocblas_DIR ${ROCM_PATH}/lib/cmake/rocblas)
+    set(hipblas_DIR ${ROCM_PATH}/lib/cmake/hipblas)
+    set(hipblaslt_DIR ${ROCM_PATH}/lib/cmake/hipblaslt)
+    set(miopen_DIR ${ROCM_PATH}/lib/cmake/miopen)
+    set(rocfft_DIR ${ROCM_PATH}/lib/cmake/rocfft)
+    set(hipfft_DIR ${ROCM_PATH}/lib/cmake/hipfft)
+    set(hipsparse_DIR ${ROCM_PATH}/lib/cmake/hipsparse)
+    set(rccl_DIR ${ROCM_PATH}/lib/cmake/rccl)
+    set(rocprim_DIR ${ROCM_PATH}/lib/cmake/rocprim)
+    set(hipcub_DIR ${ROCM_PATH}/lib/cmake/hipcub)
+    set(rocthrust_DIR ${ROCM_PATH}/lib/cmake/rocthrust)
+    set(hipsolver_DIR ${ROCM_PATH}/lib/cmake/hipsolver)
+
+    find_package_and_print_version(hip REQUIRED)
+  endif()
+else()
   set(PYTORCH_FOUND_HIP TRUE)
   set(FOUND_ROCM_VERSION_H FALSE)
 
-  set(PROJECT_RANDOM_BINARY_DIR "${PROJECT_BINARY_DIR}")
-  set(file "${PROJECT_BINARY_DIR}/detect_rocm_version.cc")
-
-  # Find ROCM version for checks
-  # ROCM 5.0 and later will have header api for version management
-  if(EXISTS ${ROCM_INCLUDE_DIRS}/rocm_version.h)
-    set(FOUND_ROCM_VERSION_H TRUE)
-    file(WRITE ${file} ""
-      "#include <rocm_version.h>\n"
-      )
-  elseif(EXISTS ${ROCM_INCLUDE_DIRS}/rocm-core/rocm_version.h)
-    set(FOUND_ROCM_VERSION_H TRUE)
-    file(WRITE ${file} ""
-      "#include <rocm-core/rocm_version.h>\n"
-      )
-  else()
-    message("********************* rocm_version.h couldnt be found ******************\n")
-  endif()
-
-  if(FOUND_ROCM_VERSION_H)
-    file(APPEND ${file} ""
-      "#include <cstdio>\n"
-
-      "#ifndef ROCM_VERSION_PATCH\n"
-      "#define ROCM_VERSION_PATCH 0\n"
-      "#endif\n"
-      "#define STRINGIFYHELPER(x) #x\n"
-      "#define STRINGIFY(x) STRINGIFYHELPER(x)\n"
-      "int main() {\n"
-      "  printf(\"%d.%d.%s\", ROCM_VERSION_MAJOR, ROCM_VERSION_MINOR, STRINGIFY(ROCM_VERSION_PATCH));\n"
-      "  return 0;\n"
-      "}\n"
-      )
-
-    try_run(run_result compile_result ${PROJECT_RANDOM_BINARY_DIR} ${file}
-      CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${ROCM_INCLUDE_DIRS}"
-      RUN_OUTPUT_VARIABLE rocm_version_from_header
-      COMPILE_OUTPUT_VARIABLE output_var
-      )
-    # We expect the compile to be successful if the include directory exists.
-    if(NOT compile_result)
-      message(FATAL_ERROR "Caffe2: Couldn't determine version from header: " ${output_var})
-    endif()
-    message(STATUS "Caffe2: Header version is: " ${rocm_version_from_header})
-    set(ROCM_VERSION_DEV_RAW ${rocm_version_from_header})
-    message("\n***** ROCm version from rocm_version.h ****\n")
-  endif()
-
-  string(REGEX MATCH "^([0-9]+)\.([0-9]+)\.([0-9]+).*$" ROCM_VERSION_DEV_MATCH ${ROCM_VERSION_DEV_RAW})
-
-  if(ROCM_VERSION_DEV_MATCH)
-    set(ROCM_VERSION_DEV_MAJOR ${CMAKE_MATCH_1})
-    set(ROCM_VERSION_DEV_MINOR ${CMAKE_MATCH_2})
-    set(ROCM_VERSION_DEV_PATCH ${CMAKE_MATCH_3})
-    set(ROCM_VERSION_DEV "${ROCM_VERSION_DEV_MAJOR}.${ROCM_VERSION_DEV_MINOR}.${ROCM_VERSION_DEV_PATCH}")
-    math(EXPR ROCM_VERSION_DEV_INT "(${ROCM_VERSION_DEV_MAJOR}*10000) + (${ROCM_VERSION_DEV_MINOR}*100) + ${ROCM_VERSION_DEV_PATCH}")
-  endif()
-
-  message("ROCM_VERSION_DEV: ${ROCM_VERSION_DEV}")
-  message("ROCM_VERSION_DEV_MAJOR: ${ROCM_VERSION_DEV_MAJOR}")
-  message("ROCM_VERSION_DEV_MINOR: ${ROCM_VERSION_DEV_MINOR}")
-  message("ROCM_VERSION_DEV_PATCH: ${ROCM_VERSION_DEV_PATCH}")
-  message("ROCM_VERSION_DEV_INT:   ${ROCM_VERSION_DEV_INT}")
-
+  find_package(ROCM CONFIG REQUIRED)
+  find_package(HIP MODULE REQUIRED)
+  message("HIP Version: ${HIP_VERSION}")
   math(EXPR TORCH_HIP_VERSION "(${HIP_VERSION_MAJOR} * 100) + ${HIP_VERSION_MINOR}")
-  message("HIP_VERSION_MAJOR: ${HIP_VERSION_MAJOR}")
-  message("HIP_VERSION_MINOR: ${HIP_VERSION_MINOR}")
-  message("TORCH_HIP_VERSION: ${TORCH_HIP_VERSION}")
+  math(EXPR ROCM_VERSION_DEV_INT "(${HIP_VERSION_MAJOR} * 1000) + ${HIP_VERSION_MINOR} * 100")
+  set(ROCM_VERSION_DEV "${HIP_VERSION_MAJOR}.${HIP_VERSION_MINOR}.0")
+endif()
 
-  message("\n***** Library versions from dpkg *****\n")
-  execute_process(COMMAND dpkg -l COMMAND grep rocm-dev COMMAND awk "{print $2 \" VERSION: \" $3}")
-  execute_process(COMMAND dpkg -l COMMAND grep rocm-libs COMMAND awk "{print $2 \" VERSION: \" $3}")
-  execute_process(COMMAND dpkg -l COMMAND grep hsakmt-roct COMMAND awk "{print $2 \" VERSION: \" $3}")
-  execute_process(COMMAND dpkg -l COMMAND grep rocr-dev COMMAND awk "{print $2 \" VERSION: \" $3}")
-  execute_process(COMMAND dpkg -l COMMAND grep -w hcc COMMAND awk "{print $2 \" VERSION: \" $3}")
-  execute_process(COMMAND dpkg -l COMMAND grep hip-base COMMAND awk "{print $2 \" VERSION: \" $3}")
-  execute_process(COMMAND dpkg -l COMMAND grep hip_hcc COMMAND awk "{print $2 \" VERSION: \" $3}")
+if (PYTORCH_FOUND_HIP)
+  torch_hip_get_arch_list(PYTORCH_ROCM_ARCH)
+  if(PYTORCH_ROCM_ARCH STREQUAL "")
+    message(FATAL_ERROR "No GPU arch specified for ROCm build. Please use PYTORCH_ROCM_ARCH environment variable to specify GPU archs to build for.")
+  endif()
+  message("Building PyTorch for GPU arch: ${PYTORCH_ROCM_ARCH}")
 
-  message("\n***** Library versions from cmake find_package *****\n")
-
-  set(CMAKE_HIP_CLANG_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
-  set(CMAKE_HIP_CLANG_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
+  set(CMAKE_HCC_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
+  set(CMAKE_HCC_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
   ### Remove setting of Flags when FindHIP.CMake PR #558 is accepted.###
 
-  set(hip_DIR ${ROCM_PATH}/lib/cmake/hip)
-  set(hsa-runtime64_DIR ${ROCM_PATH}/lib/cmake/hsa-runtime64)
-  set(AMDDeviceLibs_DIR ${ROCM_PATH}/lib/cmake/AMDDeviceLibs)
-  set(amd_comgr_DIR ${ROCM_PATH}/lib/cmake/amd_comgr)
-  set(rocrand_DIR ${ROCM_PATH}/lib/cmake/rocrand)
-  set(hiprand_DIR ${ROCM_PATH}/lib/cmake/hiprand)
-  set(rocblas_DIR ${ROCM_PATH}/lib/cmake/rocblas)
-  set(hipblas_DIR ${ROCM_PATH}/lib/cmake/hipblas)
-  set(hipblaslt_DIR ${ROCM_PATH}/lib/cmake/hipblaslt)
-  set(miopen_DIR ${ROCM_PATH}/lib/cmake/miopen)
-  set(rocfft_DIR ${ROCM_PATH}/lib/cmake/rocfft)
-  set(hipfft_DIR ${ROCM_PATH}/lib/cmake/hipfft)
-  set(hipsparse_DIR ${ROCM_PATH}/lib/cmake/hipsparse)
-  set(rccl_DIR ${ROCM_PATH}/lib/cmake/rccl)
-  set(rocprim_DIR ${ROCM_PATH}/lib/cmake/rocprim)
-  set(hipcub_DIR ${ROCM_PATH}/lib/cmake/hipcub)
-  set(rocthrust_DIR ${ROCM_PATH}/lib/cmake/rocthrust)
-  set(hipsolver_DIR ${ROCM_PATH}/lib/cmake/hipsolver)
-
-
-  find_package_and_print_version(hip REQUIRED)
   find_package_and_print_version(hsa-runtime64 REQUIRED)
   find_package_and_print_version(amd_comgr REQUIRED)
   find_package_and_print_version(rocrand REQUIRED)
@@ -165,12 +179,20 @@ if(HIP_FOUND)
     find_package_and_print_version(rocfft REQUIRED)
   endif()
   find_package_and_print_version(hipsparse REQUIRED)
-  find_package_and_print_version(rccl)
+  if (USE_NCCL)
+    find_package_and_print_version(rccl REQUIRED)
+    # TODO: rccl_LIBRARIES should return fullpath to the library file,
+    # however currently it's just the lib name
+    if(TARGET ${rccl_LIBRARIES})
+      set(PYTORCH_RCCL_LIBRARIES ${rccl_LIBRARIES})
+    else()
+      find_library(PYTORCH_RCCL_LIBRARIES ${rccl_LIBRARIES} HINTS ${ROCM_PATH}/lib)
+    endif()
+  endif()
   find_package_and_print_version(rocprim REQUIRED)
   find_package_and_print_version(hipcub REQUIRED)
   find_package_and_print_version(rocthrust REQUIRED)
   find_package_and_print_version(hipsolver REQUIRED)
-
 
   find_library(PYTORCH_HIP_LIBRARIES amdhip64 HINTS ${ROCM_PATH}/lib)
   # TODO: miopen_LIBRARIES should return fullpath to the library file,
@@ -179,13 +201,6 @@ if(HIP_FOUND)
     set(PYTORCH_MIOPEN_LIBRARIES ${miopen_LIBRARIES})
   else()
     find_library(PYTORCH_MIOPEN_LIBRARIES ${miopen_LIBRARIES} HINTS ${ROCM_PATH}/lib)
-  endif()
-  # TODO: rccl_LIBRARIES should return fullpath to the library file,
-  # however currently it's just the lib name
-  if(TARGET ${rccl_LIBRARIES})
-    set(PYTORCH_RCCL_LIBRARIES ${rccl_LIBRARIES})
-  else()
-    find_library(PYTORCH_RCCL_LIBRARIES ${rccl_LIBRARIES} HINTS ${ROCM_PATH}/lib)
   endif()
   find_library(ROCM_HIPRTC_LIB hiprtc HINTS ${ROCM_PATH}/lib)
   # roctx is part of roctracer
@@ -200,7 +215,7 @@ if(HIP_FOUND)
       "    hipblasltDatatype_t bar = HIPBLASLT_R_16F;\n"
       "    return 0;\n"
       "}\n"
-      )
+    )
 
     try_compile(hipblaslt_compile_result ${PROJECT_RANDOM_BINARY_DIR} ${file}
       CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${ROCM_INCLUDE_DIRS}"
@@ -225,7 +240,7 @@ if(HIP_FOUND)
       "    hipblasLtComputeType_t baz = HIPBLASLT_COMPUTE_F32;\n"
       "    return 0;\n"
       "}\n"
-      )
+    )
 
     try_compile(hipblaslt_compile_result ${PROJECT_RANDOM_BINARY_DIR} ${file}
       CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${ROCM_INCLUDE_DIRS}"
@@ -242,5 +257,4 @@ if(HIP_FOUND)
       message("hipblaslt is NOT using custom compute type")
     endif()
   endif()
-
 endif()


### PR DESCRIPTION
Fedora has native system ROCm support.  So the various ROCm packages can be treated as normal packages and do not require special handling.

So introduce the cmake variable USE_SYSTEM_ROCM and turn it off by default.  Then add minimal logic in LoadHIP to use it.

Fixes #ISSUE_NUMBER


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang