### PR TITLE
Add decomp for pad_sequence

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1979,6 +1979,43 @@ def forward(self, l_x_):
         self.assertEqual(a.size(), torch.Size([3, 4]))
         self.assertEqual(b.size(), torch.Size([3, 4]))
 
+    def test_pad_sequence(self):
+        class Module(torch.nn.Module):
+            def forward(self, x):
+                return torch._C._nn.pad_sequence([x])
+
+        m0 = Module()
+        inputs = (torch.randn(3, 2),)
+        ep = torch.export.export(m0, inputs, dynamic_shapes={"x": {0: Dim("batch_size")}})
+        self.assertEqual(ep(*inputs), m0(*inputs))
+
+        class ModuleBatchFirst(torch.nn.Module):
+            def forward(self, x):
+                return torch._C._nn.pad_sequence([x], batch_first=True)
+
+        m1 = ModuleBatchFirst()
+        inputs = (torch.randn(3, 2),)
+        ep = torch.export.export(m1, inputs, dynamic_shapes={"x": {0: Dim("batch_size")}})
+        self.assertEqual(ep(*inputs), m1(*inputs))
+
+        class ModuleMulti(torch.nn.Module):
+            def forward(self, x, y, z):
+                return torch._C._nn.pad_sequence([x, y, z])
+
+        m2 = ModuleMulti()
+        inputs = (torch.randn(5, 2), torch.randn(4, 2), torch.randn(3, 2))
+        ep = torch.export.export(m2, inputs, dynamic_shapes={"x": {0: Dim("batch_size")}, "y": {0: Dim("y")}, "z": {0: Dim("z")}})
+        self.assertEqual(ep(*inputs), m2(*inputs))
+
+        class ModuleMultiBatchFirst(torch.nn.Module):
+            def forward(self, x, y, z):
+                return torch._C._nn.pad_sequence([x, y, z], batch_first=True)
+
+        m3 = ModuleMulti()
+        inputs = (torch.randn(5, 2), torch.randn(4, 2), torch.randn(3, 2))
+        ep = torch.export.export(m2, inputs, dynamic_shapes={"x": {0: Dim("batch_size")}, "y": {0: Dim("y")}, "z": {0: Dim("z")}})
+        self.assertEqual(ep(*inputs), m3(*inputs))
+
     def test_export_then_compile_tensor_ctor(self):
         class M(torch.nn.Module):
             def __init__(self,):


### PR DESCRIPTION
Summary: currently pad_sequence caused symbolic shape specialization in export which is unintended. Adding a decomp seems to work to avoid the c++ kernel which caused the specialization.

Test Plan: buck test mode/opt caffe2/test:test_export -- -r pad_sequence

Reviewed By: SherlockNoMad

Differential Revision: D52345667


