### PR TITLE
Fix the meta of _scaled_dot_product_flash_attention.

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1363,6 +1363,17 @@ class TestExport(TestCase):
             _ = exported(torch.randn(4, 4), torch.randn(4), "floor")
         self.assertTrue(torch.allclose(exported(*inps), g(*inps)))
 
+    def test__scaled_dot_product_flash_attention(self):
+        class Module(torch.nn.Module):
+            def forward(self, q, k, v):
+                res = torch.ops.aten._scaled_dot_product_flash_attention.default(q, k, v)
+                return res[0]
+
+        m = Module()
+        inputs = (torch.randn(5, 4, 3, 2), torch.randn(5, 4, 3, 2), torch.randn(5, 4, 3, 2))
+        ep = torch.export.export(m, inputs)
+        self.assertEqual(ep(*inputs), m(*inputs))
+
     def test_to_module_with_mutated_buffer_multiple_update_sub_later(self):
 
         class Bar(torch.nn.Module):

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -5126,8 +5126,8 @@ def meta__scaled_dot_product_flash(
     return (
         attention,
         logsumexp,
-        None,
-        None,
+        torch.empty((), dtype=torch.long, device="meta"),
+        torch.empty((), dtype=torch.long, device="meta"),
         max_seqlen_batch_q,
         max_seqlen_batch_k,
         torch.empty((), dtype=torch.long, device="meta"),


### PR DESCRIPTION
Summary: According to the schema, we should return tensor types for cum_seq outputs, and currently they seem to be empty tensors.

Test Plan:
buck2 run mode/opt caffe2/torch/fb/model_transform/fx2trt/packaging:generate_merge_net_file -- --action=generate --lower_backend=aot_inductor_ep --input_file=/data/users/zhxchen17/fbsource/fbcode/local.merge --output_file=/tmp/409501788_66.predictor.disagg.gpu.merge

buck test mode/opt caffe2/test:test_export -- -r test__scaled_dot_product_flash_attention

Reviewed By: khabinov, SherlockNoMad

Differential Revision: D52345666


