### PR TITLE
[sigmoid] Remove workaround for constant output.

### DIFF
--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -958,6 +958,9 @@ class ExportedProgramSerializer:
         Args:
             exported_program: Exported Program to serialize
         """
+        if type(self) == ExportedProgramSerializer:
+            exported_program._validate()
+
         gm_serializer = GraphModuleSerializer(
             exported_program.graph_signature,
             exported_program.module_call_graph
@@ -1664,7 +1667,6 @@ def serialize(
     exported_program: ep.ExportedProgram,
     opset_version: Optional[Dict[str, int]] = None,
 ) -> SerializedArtifact:
-    exported_program._validate()
     serialized_artifact = (
         ExportedProgramSerializer(opset_version).serialize(exported_program)
     )


### PR DESCRIPTION
Summary: no more workaround_export_bug_constant_buffer_output

Test Plan:
buck2 run mode/dev-nosan //scripts/ads_pt2_inference:pt2_cli -- --src_model manifold://ads_storage_fblearner/tree/user/facebook/fblearner/predictor/473164617/6/gpu_lowering/input.predictor.disagg.gpu.merge

buck2 run mode/opt caffe2/torch/fb/model_transform/fx2trt/packaging:generate_merge_net_file -- --action=generate --lower_backend=aot_inductor_ep --input_file=/data/users/zhxchen17/fbsource/fbcode/input.predictor.disagg.gpu.merge --output_file=/tmp/409501788_66.predictor.disagg.gpu.merge

buck2 run mode/opt -c fbcode.nvcc_arch=a100 caffe2/torch/fb/model_transform/fx2trt/packaging:load_merge_net_predictor -- --loadMode=Normal --inputMergeNetFile=/tmp/409501788_66.predictor.disagg.gpu.merge --pytorch_predictor_sigmoid_enabled=true

Reviewed By: khabinov, SherlockNoMad

Differential Revision: D52210429


