### PR TITLE
[BE] Make `torch.cuda.has_magma` a build time check

### DIFF
--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1208,6 +1208,7 @@ has_mkl: _bool
 _has_mps: _bool
 has_lapack: _bool
 _has_cuda: _bool
+_has_magma: _bool
 _has_mkldnn: _bool
 _has_cudnn: _bool
 has_spectral: _bool

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1789,6 +1789,8 @@ Call this whenever a new thread is created in order to propagate values from
 #endif
 
   ASSERT_TRUE(set_module_attr("_has_cuda", has_cuda));
+  ASSERT_TRUE(
+      set_module_attr("_has_magma", at::hasMAGMA() ? Py_True : Py_False));
   ASSERT_TRUE(set_module_attr("_has_mps", has_mps));
   ASSERT_TRUE(
       set_module_attr("_has_mkldnn", at::hasMKLDNN() ? Py_True : Py_False));

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -873,6 +873,12 @@ PyObject* THCPModule_cudaGetSyncDebugMode(PyObject* self, PyObject* noargs) {
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject* THCPModule_hasMagma(PyObject* self, PyObject* noargs) {
+  HANDLE_TH_ERRORS
+  return at::hasMAGMA() ? Py_True : Py_False;
+  END_HANDLE_TH_ERRORS
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Cuda module initialization
 ////////////////////////////////////////////////////////////////////////////////
@@ -1285,8 +1291,6 @@ static PyObject* THCPModule_initExtension(PyObject* self, PyObject* noargs) {
     }
   };
 
-  set_module_attr("has_magma", at::hasMAGMA() ? Py_True : Py_False);
-
   auto num_gpus = c10::cuda::device_count();
   auto default_cuda_generators = PyTuple_New(static_cast<Py_ssize_t>(num_gpus));
   for (const auto i : c10::irange(num_gpus)) {
@@ -1517,6 +1521,7 @@ static struct PyMethodDef _THCPModule_methods[] = {
      THCPModule_rocm_is_backward_pass,
      METH_NOARGS,
      nullptr},
+    {"_cuda_hasMagma", THCPModule_hasMagma, METH_NOARGS, nullptr},
     {nullptr}};
 
 PyMethodDef* THCPModule_methods() {

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -873,12 +873,6 @@ PyObject* THCPModule_cudaGetSyncDebugMode(PyObject* self, PyObject* noargs) {
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject* THCPModule_hasMagma(PyObject* self, PyObject* noargs) {
-  HANDLE_TH_ERRORS
-  return at::hasMAGMA() ? Py_True : Py_False;
-  END_HANDLE_TH_ERRORS
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // Cuda module initialization
 ////////////////////////////////////////////////////////////////////////////////
@@ -1521,7 +1515,6 @@ static struct PyMethodDef _THCPModule_methods[] = {
      THCPModule_rocm_is_backward_pass,
      METH_NOARGS,
      nullptr},
-    {"_cuda_hasMagma", THCPModule_hasMagma, METH_NOARGS, nullptr},
     {nullptr}};
 
 PyMethodDef* THCPModule_methods() {

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -111,7 +111,7 @@ else:
 
 
 has_half: bool = True
-has_magma: bool = getattr(torch._C, "_cuda_hasMagma", lambda: False)()
+has_magma: bool = torch._C._has_magma
 
 default_generators: Tuple[torch._C.Generator] = ()  # type: ignore[assignment]
 

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -111,8 +111,8 @@ else:
 
 
 has_half: bool = True
-# Global variables dynamically populated by native code
-has_magma: bool = False
+has_magma: bool = getattr(torch._C, "_cuda_hasMagma", lambda: False)()
+
 default_generators: Tuple[torch._C.Generator] = ()  # type: ignore[assignment]
 
 


### PR DESCRIPTION
Perhaps originally one needed to query about GPU capability, but right now it's a simple check for a build time flag: https://github.com/pytorch/pytorch/blob/52f0457d7dc8e1ee6e25b6c97d11d3070d11263b/aten/src/ATen/cuda/detail/CUDAHooks.cpp#L165-L171

Alternative, to avoid `at::hasMAGMA()` call  one can implement it as follows:
```cpp
  const auto use_magma = caffe2::GetBuildOptions().at("USE_MAGMA");
  return PyBool_FromLong(use_magma == "1");
```

Make this check very similar to `_has_mkldnn`
https://github.com/pytorch/pytorch/blob/0978482afa69118da1a986a4edec3acea01d2c6d/torch/csrc/Module.cpp#L1793-L1794

Test plan:
 Run `lldb -- python3 -c "import torch;print(torch.cuda.has_magma)"` and make sure it returns True and that `cuInit` is not called
