### PR TITLE
[TorchElastic] [easy] fail early when rdzv endpoint isn't specified on multinode jobs

### DIFF
--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -221,6 +221,17 @@ class CreateBackendTest(TestCase):
                 ):
                     create_backend(self._params)
 
+    def test_create_backend_raises_error_if_endpoint_is_missing_and_more_than_one_node(self) -> None:
+        self._params.endpoint = None
+        self._params.min_nodes = 2
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"^Rendezvous endpoint is required when using TCPStore based rendezvous "
+            r"for multinode jobs.$",
+        ):
+            create_backend(self._params)
+
     def test_create_backend_raises_error_if_store_type_is_invalid(self) -> None:
         self._params.config["store_type"] = "dummy_store_type"
 

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -131,6 +131,10 @@ class C10dRendezvousBackend(RendezvousBackend):
 
 
 def _create_tcp_store(params: RendezvousParameters) -> TCPStore:
+    if not params.endpoint and params.min_nodes > 1:
+        raise ValueError(
+            "Rendezvous endpoint is required when using TCPStore based rendezvous for multinode jobs."
+        )
     host, port = parse_rendezvous_endpoint(params.endpoint, default_port=29400)
 
     cfg_is_host = params.get_as_bool("is_host")


### PR DESCRIPTION
Communicate to users that rendezvous using C10 based store requires rdzv endpoint early.

Right now it will assume 'localhost' and timeout with not valuable information. 

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225