### PR TITLE
[inductor][cpu]disable pointwise_cat on CPU

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -2708,7 +2708,7 @@ class CPUReproTests(TestCase):
         y = torch.randn(32, 120)
         metrics.reset()
         self.common(fn, (x, y))
-        assert metrics.generated_cpp_vec_kernel_count == 1
+        assert metrics.generated_cpp_vec_kernel_count == 3
 
     def test_expr_vec_non_contiguous(self):
         def fn(x):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1092,7 +1092,8 @@ def cat(inputs, dim=0):
 
         return False
 
-    # TODO enable pointwise_cat on CPU when we support vectorization on index_expr.
+    # TODO: We observed negative performance impact of pointwise_cat optimization on CPU so disabled it.
+    #             We will revisit this later after enabling vectorization on index_expr.
     if (
         len(inputs) <= config.max_pointwise_cat_inputs
         and inputs[0].get_device().type != "cpu"

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1092,7 +1092,11 @@ def cat(inputs, dim=0):
 
         return False
 
-    if len(inputs) <= config.max_pointwise_cat_inputs:
+    # TODO enable pointwise_cat on CPU when we support vectorization on index_expr.
+    if (
+        len(inputs) <= config.max_pointwise_cat_inputs
+        and inputs[0].get_device().type != "cpu"
+    ):
         pointwise_uses = all(is_pointwise_use(use) for use in V.current_node.users)
         all_pointwise_inputs = all(should_lower_cat_input(inp) for inp in inputs)
         any_pointwise_inputs = any(should_lower_cat_input(inp) for inp in inputs)


### PR DESCRIPTION
We observed negative performance impact of pointwise_cat optimization on CPU so disabled it. We will revisit this later after enabling vectorization on index_expr.

This PR fix the following three regression issues:
https://github.com/pytorch/pytorch/issues/115827
https://github.com/pytorch/pytorch/issues/112139
https://github.com/pytorch/pytorch/issues/114495

and cause performance regression of pytorch_unet again. Related issue: https://github.com/pytorch/pytorch/issues/115343



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler