### PR TITLE
[CPU] Disable floating-point contraction when compiling

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1194,6 +1194,8 @@ def optimization_flags() -> str:
     base_flags += " -ffast-math -fno-finite-math-only"
     if not config.cpp.enable_unsafe_math_opt_flag:
         base_flags += " -fno-unsafe-math-optimizations"
+    if not config.cpp.enable_floating_point_contract_flag:
+        base_flags += " -ffp-contract=off"
 
     if config.is_fbcode():
         # FIXME: passing `-fopenmp` adds libgomp.so to the generated shared library's dependencies.

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -455,6 +455,9 @@ class cpp:
     # Use funsafe-math-optimizations when compiling
     enable_unsafe_math_opt_flag = False
 
+    # Use ffp-contract when compiling
+    enable_floating_point_contract_flag = False
+
 
 # config specific to codegen/triton.py
 class triton:


### PR DESCRIPTION
Fixes #100775.

For CPU inductor path, disable -ffp-contract, such as fma, from optimization flags to fix functional issues.

### Validation
Validation on 3 benchmark suites.

- [x] FP32: Negligible geomean change; No outlier models.

<img width="582" alt="image" src="https://github.com/pytorch/pytorch/assets/23010269/7c14a8b8-eb6c-4794-bff9-2e1ae3a22781">

- [x] BF16: Negligible geomean change; No outlier models.

<img width="589" alt="image" src="https://github.com/pytorch/pytorch/assets/23010269/cf558737-8cb2-411f-8761-27b9f8fc43af">

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler