### PR TITLE
 [Inductor Intel GPU backend Upstream]  Step 2: Generalizing device-bias runtime code

### DIFF
--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -154,6 +154,12 @@ class CachingAutotuner(KernelInterface):
         self.configs = configs
         self.heuristic_type = heuristic_type
 
+        # Align the default design that default as cuda
+        self.device_type = (
+            triton_meta["device_type"] if "device_type" in triton_meta else "cuda"
+        )
+        self.gpu_device = get_interface_for_device(self.device_type)
+
         if log.isEnabledFor(logging.DEBUG):
             log.debug("CachingAutotuner gets %d configs", len(self.configs))
             for c in self.configs:
@@ -202,8 +208,7 @@ class CachingAutotuner(KernelInterface):
 
             seen_configs = set(self.configs)
 
-            device_interface = get_interface_for_device("cuda")
-            device_prop = device_interface.Worker.get_device_properties(
+            device_prop = self.gpu_device.Worker.get_device_properties(
                 self.triton_meta["device"]
             )
             if (
@@ -290,18 +295,19 @@ class CachingAutotuner(KernelInterface):
         )
 
         # Setting device_type="hip" required on ROCm to pass down to triton
-        compile_meta["device_type"] = "cuda" if torch.version.hip is None else "hip"
+        compile_meta["device_type"] = (
+            self.device_type if torch.version.hip is None else "hip"
+        )
 
         if warm_cache_only_with_cc:
             cc = warm_cache_only_with_cc
         else:
             # Use device_type 'cuda' for both cuda and hip devices to retrieve
             # the compute capability.
-            device_type = "cuda"
+            device_type = self.device_type if torch.version.hip is None else "cuda"
             device_id = compile_meta["device"]
-            device_interface = get_interface_for_device(device_type)
             device = torch.device(device_type, device_id)
-            cc = device_interface.get_compute_capability(device)
+            cc = self.gpu_device.get_compute_capability(device)
 
         compile_meta["cc"] = cc
 
@@ -336,9 +342,9 @@ class CachingAutotuner(KernelInterface):
             )
 
         # load binary to the correct device
-        with torch.cuda.device(compile_meta["device"]):
+        with self.gpu_device.device(compile_meta["device"]):  # type: ignore[attr-defined]
             # need to initialize context
-            torch.cuda.synchronize(torch.cuda.current_device())
+            self.gpu_device.synchronize(self.gpu_device.current_device())
 
             binary = triton.compile(*compile_args, **compile_kwargs)
             binary._init_handles()
@@ -354,8 +360,8 @@ class CachingAutotuner(KernelInterface):
             "grid_meta": cfg.kwargs,
             "bin": binary,
             "torch": torch,
-            "set_device": torch.cuda.set_device,
-            "current_device": torch.cuda.current_device,
+            "set_device": self.gpu_device.set_device,
+            "current_device": self.gpu_device.current_device,
         }
 
         scope["runner"] = get_first_attr(binary, "run", "c_wrapper")
@@ -405,9 +411,9 @@ class CachingAutotuner(KernelInterface):
             )
             return float("inf")
 
-        from torch._C import _cuda_getCurrentRawStream as get_cuda_stream
-
-        stream = get_cuda_stream(torch.cuda.current_device())
+        stream = self.gpu_device.get_raw_stream(  # type: ignore[call-arg]
+            self.gpu_device.current_device()
+        )
 
         def kernel_call():
             if launcher.config.pre_hook is not None:


### PR DESCRIPTION
Right after the first PR https://github.com/pytorch/pytorch/pull/116020, this PR forcus on generalizing device-bias runtime code that used in the basic workflow including triton kernel generation, codecache, autotuning.


 Feature request: #114856



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler