### PR TITLE
Back out "[Kineto] Initialize libkineto profilers during torch init process during pybind set-up (#112623)" (#116201)

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -18,7 +18,7 @@ import torch
 
 from torch.testing import make_tensor
 from torch.testing._internal.common_utils import \
-    (IS_FBCODE, IS_JETSON, IS_LINUX, IS_MACOS, IS_SANDCASTLE, IS_WINDOWS, TestCase, run_tests, slowTest,
+    (IS_FBCODE, IS_JETSON, IS_MACOS, IS_SANDCASTLE, IS_WINDOWS, TestCase, run_tests, slowTest,
      parametrize, subtest, instantiate_parametrized_tests, dtype_name, TEST_WITH_ROCM, decorateIf)
 from torch.testing._internal.common_device_type import \
     (PYTORCH_TESTING_DEVICE_EXCEPT_FOR_KEY, PYTORCH_TESTING_DEVICE_ONLY_FOR_KEY, dtypes,
@@ -2317,15 +2317,6 @@ class TestImports(TestCase):
         ]
         out = self._check_python_output("; ".join(commands))
         self.assertEqual(out.strip(), expected)
-
-    @unittest.skipIf(TEST_WITH_ROCM, "On-demand profiling early init not supported on ROCm")
-    @unittest.skipIf(not IS_LINUX, "On-demand profiling not supported outside of Linux")
-    def test_libkineto_profiler_is_initialized(self) -> None:
-        # Check that the profiler is initialized at import time.
-        out = self._check_python_output("""import sys; import torch;
-print(torch._C._autograd._isProfilerInitialized() if torch._C._autograd._is_use_kineto_defined() else 'True')
-""")
-        self.assertEqual(out.strip(), "True")
 
 class TestOpInfos(TestCase):
     def test_sample_input(self) -> None:

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -35,10 +35,6 @@
 #include <torch/csrc/utils/python_raii.h>
 #include <torch/csrc/utils/python_torch_function_mode.h>
 
-#ifdef USE_KINETO
-#include <libkineto.h>
-#endif
-
 #include <set>
 #include <unordered_set>
 #include <utility>
@@ -133,30 +129,6 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
   ParameterClass = PyObject_GetAttrString(parameter_module, "Parameter");
   if (!ParameterClass)
     return nullptr;
-
-#if defined(USE_KINETO) && defined(__linux__) && !defined(USE_ROCM)
-  // Initialize the Kineto profilers, if they have not already.
-  // DO NOT REMOVE, this is needed for on-demand profiling.
-  if (!libkineto::api().isProfilerRegistered()) {
-    libkineto_init(
-        /*cpuOnly=*/!(at::hasCUDA() || at::hasXPU() || at::hasMTIA()),
-        /*logOnError=*/true);
-    libkineto::api().suppressLogMessages();
-  }
-  libkineto::api().initProfilerIfRegistered();
-
-  // Used for unit test to check profiler was initialized.
-  m.def("_isProfilerInitialized", []() {
-    return libkineto::api().isProfilerInitialized();
-  });
-#endif
-
-  m.def("_is_use_kineto_defined", []() -> bool {
-#ifdef USE_KINETO
-    return true;
-#endif
-    return false;
-  });
 
   py::class_<LegacyEvent>(m, "ProfilerEvent")
       .def("kind", &LegacyEvent::kindStr)


### PR DESCRIPTION
Summary:
This diff needs to be backed out because TorchBench llama_v2_7b_16h has a cublas init error.
https://github.com/pytorch/benchmark/actions/runs/7266269668/job/19797677485?pr=2095

Test Plan: CI

Differential Revision: D52339142

Pull Request resolved: https://github.com/pytorch/pytorch/pull/116201
Approved by: https://github.com/xuzhao9

(cherry picked from commit a357a0f31519f96cff9839c1672a112539ba98ff)

Fixes #ISSUE_NUMBER
