### PR TITLE
Fixed a segfault when calling topk on a quantized scalar tensor.

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -2395,6 +2395,8 @@ void qtopk_kernel(Tensor& values,
   auto mode_values_stride = values.strides()[dim];
   auto mode_indices_stride = indices.strides()[dim];
   auto tmp_values_stride = self.strides()[dim];
+  // If sizes is empty, the tensor is scalar. This prevents accessing an empty array.
+  auto dim_size = sizes.empty() ? 1 : sizes[dim];
 
   AT_DISPATCH_QINT_TYPES(self.scalar_type(), "qtopk_cpu", [&] {
     auto loop = [&](char** data, const int64_t* strides, int64_t n) {
@@ -2402,7 +2404,7 @@ void qtopk_kernel(Tensor& values,
       static_assert(sizeof(scalar_t) == sizeof(underlying_t), "");
       return topk_impl_loop<underlying_t, underlying_t>(
           mode_values_stride, mode_indices_stride, tmp_values_stride,
-          k, sizes[dim], largest, sorted, data, strides, n);
+          k, dim_size, largest, sorted, data, strides, n);
     };
 
     int64_t grain_size = internal::GRAIN_SIZE / std::max(int64_t{1}, sizes[dim]);

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -439,7 +439,8 @@ class TestSortAndSelect(TestCase):
         compare(t, 2000, 1, False)
 
     def test_topk_quantized_scalar_input(self):
-        # This used to segfault
+        # Calling topk on a quantized scalar input used to segfault,
+        # see https://github.com/pytorch/pytorch/issues/116324
         x = torch.quantize_per_tensor(torch.randn(()), 0.1, 10, torch.qint8)
         x.topk(1)
 

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -438,6 +438,11 @@ class TestSortAndSelect(TestCase):
         compare(t, 2000, 1, True)
         compare(t, 2000, 1, False)
 
+    def test_topk_quantized_scalar_input(self):
+        # This used to segfault
+        x = torch.quantize_per_tensor(torch.randn(()), 0.1, 10, torch.qint8)
+        x.topk(1)
+
     def test_topk_arguments(self, device):
         q = torch.randn(10, 2, 10, device=device)
         # Make sure True isn't mistakenly taken as the 2nd dimension (interpreted as 1)


### PR DESCRIPTION
Fixes #116324.

Added an extra check for empty sizes (=scalars) when running `topk` on quantized tensors. Added a test.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10