### PR TITLE
Fixed a segfault issue when passing an empty kernel to quantized_max_…

### DIFF
--- a/aten/src/ATen/native/MaxPooling.cpp
+++ b/aten/src/ATen/native/MaxPooling.cpp
@@ -5,7 +5,6 @@
 #include <ATen/core/grad_mode.h>
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/MaxPooling.h>
-#include <ATen/native/Pool.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -20,64 +19,6 @@
 namespace at::native {
 
 DEFINE_DISPATCH(max_pool1d_stub);
-
-namespace {
-
-static void check_max_pool1d(
-    const Tensor& self,
-    IntArrayRef kernel_size,
-    IntArrayRef stride,
-    IntArrayRef padding,
-    IntArrayRef dilation,
-    bool ceil_mode) {
-
-  TORCH_CHECK(
-      self.dim() == 2 || self.dim() == 3,
-      "max_pool1d() Expected 2D or 3D input tensor, but got ", self.sym_sizes());
-  TORCH_CHECK(
-      kernel_size.size() == 1,
-      "max_pool1d() kernel_size must be an int, list of ints or tuple of ints of size 1 but got size ",
-      kernel_size.size());
-  TORCH_CHECK(
-      stride.empty() || stride.size() == 1,
-      "max_pool1d() stride must be None, an int, list of ints, or tuple of ints of size 1 but got size ",
-      stride.size());
-  TORCH_CHECK(
-      padding.size() == 1,
-      "max_pool1d() padding must be an int, list of ints, or tuple of ints of size 1 but got size ",
-      padding.size());
-  TORCH_CHECK(
-      dilation.size() == 1,
-      "max_pool1d() dilation must be an int, list of ints or tuple of ints of size 1 but got size ",
-      dilation.size());
-
-  // If stride=None then set it to kernel_size
-  if (stride.empty()) {
-    stride = kernel_size;
-  }
-
-  TORCH_CHECK(
-      kernel_size[0] > 0,
-      "max_pool1d() kernel_size must be greater than zero, but got ",
-      kernel_size[0]);
-  TORCH_CHECK(
-      stride[0] > 0, "max_pool1d() stride must be greater than zero, but got ", stride[0]);
-  TORCH_CHECK(
-      padding[0] >= 0, "max_pool1d() padding must be non-negative, but got ", padding[0]);
-  TORCH_CHECK(
-      padding[0] <= kernel_size[0] / 2,
-      "max_pool1d() padding should be at most half of kernel size, but got padding=",
-      padding[0],
-      " and kernel_size=",
-      kernel_size[0]);
-  TORCH_CHECK(
-      dilation[0] > 0, "max_pool1d() dilation must be greater than zero, but got ", dilation[0]);
-
-  const int64_t OW = pooling_output_shape(self.sym_size(-1).guard_int(__FILE__, __LINE__), kernel_size[0], padding[0], stride[0], dilation[0], ceil_mode);
-  TORCH_CHECK(OW > 0, "max_pool1d() Invalid computed output size: ", OW);
-}
-
-} // namespace
 
 namespace {
 

--- a/aten/src/ATen/native/MaxPooling.h
+++ b/aten/src/ATen/native/MaxPooling.h
@@ -7,8 +7,6 @@
 
 namespace at::native {
 
-namespace {
-
 static void check_max_pool1d(
     const Tensor& self,
     IntArrayRef kernel_size,
@@ -62,8 +60,6 @@ static void check_max_pool1d(
   const int64_t OW = pooling_output_shape(self.sym_size(-1).guard_int(__FILE__, __LINE__), kernel_size[0], padding[0], stride[0], dilation[0], ceil_mode);
   TORCH_CHECK(OW > 0, "max_pool1d() Invalid computed output size: ", OW);
 }
-
-} // anonymous namespace
 
 // TODO(Heitor) Template by dimension
 struct PoolingParams1D {

--- a/aten/src/ATen/native/MaxPooling.h
+++ b/aten/src/ATen/native/MaxPooling.h
@@ -3,8 +3,67 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/Parallel.h>
 #include <ATen/native/DispatchStub.h>
+#include <ATen/native/Pool.h>
 
 namespace at::native {
+
+namespace {
+
+static void check_max_pool1d(
+    const Tensor& self,
+    IntArrayRef kernel_size,
+    IntArrayRef stride,
+    IntArrayRef padding,
+    IntArrayRef dilation,
+    bool ceil_mode) {
+
+  TORCH_CHECK(
+      self.dim() == 2 || self.dim() == 3,
+      "max_pool1d() Expected 2D or 3D input tensor, but got ", self.sym_sizes());
+  TORCH_CHECK(
+      kernel_size.size() == 1,
+      "max_pool1d() kernel_size must be an int, list of ints or tuple of ints of size 1 but got size ",
+      kernel_size.size());
+  TORCH_CHECK(
+      stride.empty() || stride.size() == 1,
+      "max_pool1d() stride must be None, an int, list of ints, or tuple of ints of size 1 but got size ",
+      stride.size());
+  TORCH_CHECK(
+      padding.size() == 1,
+      "max_pool1d() padding must be an int, list of ints, or tuple of ints of size 1 but got size ",
+      padding.size());
+  TORCH_CHECK(
+      dilation.size() == 1,
+      "max_pool1d() dilation must be an int, list of ints or tuple of ints of size 1 but got size ",
+      dilation.size());
+
+  // If stride=None then set it to kernel_size
+  if (stride.empty()) {
+    stride = kernel_size;
+  }
+
+  TORCH_CHECK(
+      kernel_size[0] > 0,
+      "max_pool1d() kernel_size must be greater than zero, but got ",
+      kernel_size[0]);
+  TORCH_CHECK(
+      stride[0] > 0, "max_pool1d() stride must be greater than zero, but got ", stride[0]);
+  TORCH_CHECK(
+      padding[0] >= 0, "max_pool1d() padding must be non-negative, but got ", padding[0]);
+  TORCH_CHECK(
+      padding[0] <= kernel_size[0] / 2,
+      "max_pool1d() padding should be at most half of kernel size, but got padding=",
+      padding[0],
+      " and kernel_size=",
+      kernel_size[0]);
+  TORCH_CHECK(
+      dilation[0] > 0, "max_pool1d() dilation must be greater than zero, but got ", dilation[0]);
+
+  const int64_t OW = pooling_output_shape(self.sym_size(-1).guard_int(__FILE__, __LINE__), kernel_size[0], padding[0], stride[0], dilation[0], ceil_mode);
+  TORCH_CHECK(OW > 0, "max_pool1d() Invalid computed output size: ", OW);
+}
+
+} // anonymous namespace
 
 // TODO(Heitor) Template by dimension
 struct PoolingParams1D {

--- a/aten/src/ATen/native/quantized/cpu/Pooling.cpp
+++ b/aten/src/ATen/native/quantized/cpu/Pooling.cpp
@@ -5,6 +5,7 @@
 #include <ATen/Parallel.h>
 #include <torch/library.h>
 #include <ATen/native/Pool.h>
+#include <ATen/native/MaxPooling.h>
 #include <ATen/quantized/Quantizer.h>
 #include <ATen/native/quantized/cpu/QuantizedOps.h>
 #include <ATen/native/quantized/cpu/init_qnnpack.h>
@@ -702,6 +703,7 @@ Tensor quantized_max_pool1d(
     IntArrayRef padding,
     IntArrayRef dilation,
     bool ceil_mode) {
+  check_max_pool1d(qx, kernel_size, stride, padding, dilation, ceil_mode);
   // (C, L) -> (C, 1, L) => kSqueezeDim = 1
   // (N, C, L) -> (N, C, 1, L) => kSqueezeDim = 2
   const int32_t kSqueezeDim = qx.dim() - 1;

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -380,6 +380,7 @@ class TestPoolingNN(NNTestCase):
 
     def test_quantized_max_pool1d_empty_kernel(self):
         # This used to segfault when called with an empty kernel
+        # see https://github.com/pytorch/pytorch/issues/116323
         base = torch.randn(1)
         temp_tensor = torch.quantize_per_tensor(base, 0.1, 10, torch.quint2x4)
         with self.assertRaises(RuntimeError):

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -378,6 +378,13 @@ class TestPoolingNN(NNTestCase):
         with self.assertRaises(RuntimeError):
             F.max_unpool3d(x, torch.zeros(x.shape, dtype=int), [1, 1])
 
+    def test_quantized_max_pool1d_empty_kernel(self):
+        # This used to segfault when called with an empty kernel
+        base = torch.randn(1)
+        temp_tensor = torch.quantize_per_tensor(base, 0.1, 10, torch.quint2x4)
+        with self.assertRaises(RuntimeError):
+            torch.quantized_max_pool1d(temp_tensor, [])
+
 class TestPoolingNNDeviceType(NNTestCase):
     @onlyNativeDeviceTypes
     @dtypes(torch.float, torch.double)


### PR DESCRIPTION
…pool1d.

Fixes #116323.

Reused the same check as for `max_pool1d`. 


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10