### PR TITLE
[Dynamo] Remove ExecutionRecorder.MOD_EXCLUDES during replay & record

### DIFF
--- a/torch/_dynamo/replay_record.py
+++ b/torch/_dynamo/replay_record.py
@@ -40,7 +40,6 @@ class ExecutionRecord:
 
 @dataclasses.dataclass
 class ExecutionRecorder:
-    MOD_EXCLUDES = ["torch", "torch.fx", "torch.fx.passes"]
     LOCAL_MOD_PREFIX = "___local_mod_"
 
     code: CodeType
@@ -52,30 +51,22 @@ class ExecutionRecorder:
 
     def add_local_var(self, name, var):
         if isinstance(var, ModuleType):
-            if self._is_excl(var):
-                return
             self.locals[name] = self._add_mod(var)
         else:
             self.locals[name] = var
 
     def add_global_var(self, name, var):
         if isinstance(var, ModuleType):
-            if self._is_excl(var):
-                return
             self.globals[name] = self._add_mod(var)
         else:
             self.globals[name] = var
 
     def add_local_mod(self, name, mod):
         assert isinstance(mod, ModuleType)
-        if self._is_excl(mod):
-            return
 
         self.add_global_var(name, mod)
 
     def record_module_access(self, mod, name, val):
-        if self._is_excl(mod):
-            return
         if isinstance(val, ModuleType):
             self.name_to_modrec[mod.__name__].accessed_attrs[name] = self._add_mod(val)
             return
@@ -97,10 +88,6 @@ class ExecutionRecorder:
             self.name_to_modrec[mod.__name__] = ModuleRecord(mod)
 
         return self.name_to_modrec[mod.__name__]
-
-    @classmethod
-    def _is_excl(cls, mod):
-        return any(mod.__name__ == excl for excl in cls.MOD_EXCLUDES)
 
     # Convert ModuleRecords -> DummyModule tree
     @classmethod


### PR DESCRIPTION
Remove ```ExecutionRecorder.MOD_EXCLUDES``` since now torch python modules are wrapped as ```PythonModuleVariable``` after #115724.
This is reported from Meta internal user cases, where it triggers failure when replay & record is enabled. But the enablement was triggered by ```TORCH_COMPILE_DEBUG=1``` rather than they really need this. Actually they are not using it according the conversation with the team members. I think we don't maintain replay & record well, so probably we can remove them from our codebase to avoid such issues in the future.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng