### PR TITLE
Add at::sparse::full_coo_indices utility function.

### DIFF
--- a/aten/src/ATen/native/SparseTensorUtils.cpp
+++ b/aten/src/ATen/native/SparseTensorUtils.cpp
@@ -125,4 +125,21 @@ Tensor zeros_like_with_indices(const Tensor& t) {
       t.is_coalesced());
 }
 
+Tensor full_coo_indices(IntArrayRef sizes, TensorOptions options) {
+  const auto max_size = *std::max_element(sizes.begin(), sizes.end());
+  const auto max_size_arange = at::arange(max_size, options);
+  std::vector<Tensor> stack;
+  stack.reserve(sizes.size());
+  for (size_t i=0; i < sizes.size(); i++) {
+    Tensor a = max_size_arange.narrow(-1, 0, sizes[i]);
+    for (size_t j=0; j < sizes.size(); j++) {
+      if (i != j) {
+        a.unsqueeze_(j);
+      }
+    }
+    stack.push_back(a.expand(sizes));
+  }
+  return at::stack(stack).flatten(1, -1);
+}
+
 } // namespace at::sparse

--- a/aten/src/ATen/native/SparseTensorUtils.h
+++ b/aten/src/ATen/native/SparseTensorUtils.h
@@ -181,4 +181,10 @@ class TensorGeometryHolder<0> {
   geometry_holder_t t_strides;
 };
 
+// Return all indices of a tensor with the given shape.
+//
+// full_coo_indices(shape) is equivalent to
+// torch.ones(shape).nonzero().transpose(-2, -1) but much faster.
+TORCH_API Tensor full_coo_indices(IntArrayRef sizes, TensorOptions options);
+
 } // namespace at::sparse

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -525,10 +525,7 @@ Tensor sparse_broadcast_to(const Tensor& self, IntArrayRef size) {
   Tensor new_values = values.expand(broadcast_dense_sizes).repeat_interleave(nnz_factor, 0);
   Tensor new_indices = indices.new_empty(new_indices_size);
   if (!broadcast_sizes.empty()) {
-    // ones(broadcast_sizes).nonzero() is equivalent to
-    // product(map(arange, broadcast_sizes)) but avoids creating
-    // auxilary arange tensors
-    Tensor broadcast_indices = at::native::new_ones(indices, broadcast_sizes).nonzero().transpose(0, 1).tile(nnz);
+    Tensor broadcast_indices = at::sparse::full_coo_indices(broadcast_sizes, indices.options()).tile(nnz);
     new_indices.narrow(0, 0, sparse_extra_ndim).copy_(broadcast_indices.narrow(0, 0, sparse_extra_ndim));
     for (size_t i=0; i<broadcast_dims.size(); i++) {
       int64_t j=broadcast_dims[i];

--- a/aten/src/ATen/native/sparse/cuda/SparseCsrTensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCsrTensorMath.cu
@@ -109,9 +109,7 @@ void convert_indices_from_csr_to_coo_cuda(const Tensor& indices, const Tensor& c
   int64_t batch_ndim = crow_indices.dim() - 1;
   if (batch_ndim > 0) {
     auto batch_indices = indices.narrow(0, 0, batch_ndim);
-    batch_indices.copy_(batch_indices.new_ones(crow_indices.sizes().slice(0, batch_ndim))
-                        .nonzero()
-                        .transpose(0, 1)
+    batch_indices.copy_(at::sparse::full_coo_indices(crow_indices.sizes().slice(0, batch_ndim), indices.options())
                         .repeat_interleave(nnz, 1));
   }
 


### PR DESCRIPTION
As in the title.

`full_coo_indices(shape)` should be used instead of `ones(shape).nonzero().T` as `full_coo_indices` is exponentially more efficient.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #116352
* #116206



cc @alexsamardzic @nikitaved @cpuhrsch @amjames @bhosmer @jcaip