### PR TITLE
[Dynamo][Forward Fx] Put ao modules as call_module in FX graph

### DIFF
--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -288,7 +288,10 @@ class NNModuleVariable(VariableTracker):
             # If we are tracing the higher order op, we want Dynamo to step
             # inside the module call so that Dynamo can see the underlying
             # parameters and buffers and raise them as inputs to the graph.
-            if tx.output.is_root_tracer() and mod.__module__.startswith("torch.nn."):
+            if tx.output.is_root_tracer() and (
+                mod.__module__.startswith("torch.nn.")
+                or mod.__module__.startswith("torch.ao.")
+            ):
                 if nnmodule_has_hooks(
                     mod, check_forward_hooks=True, check_backward_hooks=True
                 ):


### PR DESCRIPTION
It seems ao modules were not in ```torch.nn``` folder, so we have to include them as well. This is found when #116312 was imported into fbcode, some executorch tests failed because of this.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng