### PR TITLE
[WIP] [3/4] Intel GPU Runtime Upstreaming for Device

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -268,6 +268,7 @@ exclude_patterns = [
     'torch/csrc/lazy/**/*',
     'torch/csrc/onnx/init.cpp',
     'torch/csrc/mps/**/*',
+    'torch/csrc/xpu/**',
 ]
 init_command = [
     'python3',

--- a/aten/src/ATen/test/xpu_device_test.cpp
+++ b/aten/src/ATen/test/xpu_device_test.cpp
@@ -1,0 +1,71 @@
+#include <gtest/gtest.h>
+
+#include <aten/src/ATen/xpu/XPUContext.h>
+#include <aten/src/ATen/xpu/XPUDevice.h>
+#include <c10/xpu/XPUFunctions.h>
+#include <torch/torch.h>
+
+#define ASSERT_EQ_XPU(X, Y) \
+  {                         \
+    bool _isEQ = X == Y;    \
+    ASSERT_TRUE(_isEQ);     \
+  }
+
+TEST(XpuDeviceTest, getDeviceProperties) {
+  ASSERT_EQ_XPU(at::xpu::is_available(), torch::xpu::is_available());
+  if (!at::xpu::is_available()) {
+    return;
+  }
+
+  c10::xpu::DeviceProp* cur_device_prop = at::xpu::getCurrentDeviceProperties();
+  c10::xpu::DeviceProp* device_prop = at::xpu::getDeviceProperties(0);
+
+  ASSERT_EQ_XPU(cur_device_prop->device_name, device_prop->device_name);
+  ASSERT_EQ_XPU(cur_device_prop->platform_name, device_prop->platform_name);
+  ASSERT_EQ_XPU(cur_device_prop->gpu_eu_count, device_prop->gpu_eu_count);
+}
+
+TEST(XpuDeviceTest, getDeviceFromPtr) {
+  if (!at::xpu::is_available()) {
+    return;
+  }
+
+  sycl::device& raw_device = at::xpu::get_raw_device(0);
+  void* ptr = sycl::malloc_device(8, raw_device, at::xpu::get_device_context());
+
+  at::Device device = at::xpu::getDeviceFromPtr(ptr);
+  sycl::free(ptr, at::xpu::get_device_context());
+  ASSERT_EQ_XPU(device.index(), 0);
+  ASSERT_EQ_XPU(device.type(), at::kXPU);
+
+  int dummy = 0;
+  ASSERT_THROW(at::xpu::getDeviceFromPtr(&dummy), c10::Error);
+}
+
+TEST(XpuDeviceTest, getGlobalIdFromDevice) {
+  if (!at::xpu::is_available()) {
+    return;
+  }
+
+  int target_device = 0;
+  int global_id = at::xpu::getGlobalIdFromDevice(target_device);
+  auto devices = sycl::device::get_devices();
+  ASSERT_EQ_XPU(devices[global_id], at::xpu::get_raw_device(target_device));
+
+  void* ptr = sycl::malloc_device(8, devices[global_id], at::xpu::get_device_context());
+  at::Device device = at::xpu::getDeviceFromPtr(ptr);
+  sycl::free(ptr, at::xpu::get_device_context());
+  ASSERT_EQ_XPU(device.index(), target_device);
+  ASSERT_EQ_XPU(device.type(), at::kXPU);
+
+  if (at::xpu::device_count() == 1) {
+    return;
+  }
+  // Test the last device.
+  target_device = at::xpu::device_count() - 1;
+  global_id = at::xpu::getGlobalIdFromDevice(target_device);
+  ASSERT_EQ_XPU(devices[global_id], at::xpu::get_raw_device(target_device));
+
+  target_device = at::xpu::device_count();
+  ASSERT_THROW(at::xpu::getGlobalIdFromDevice(target_device), c10::Error);
+}

--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -745,6 +745,7 @@ torch_cpp_srcs = [
     "torch/csrc/api/src/optim/schedulers/step_lr.cpp",
     "torch/csrc/api/src/serialize/input-archive.cpp",
     "torch/csrc/api/src/serialize/output-archive.cpp",
+    "torch/csrc/api/src/xpu.cpp",
 ]
 
 libtorch_python_cuda_core_sources = [
@@ -763,6 +764,10 @@ libtorch_python_cuda_sources = libtorch_python_cuda_core_sources + [
     "torch/csrc/cuda/python_nccl.cpp",
     "torch/csrc/cuda/shared/cudnn.cpp",
     "torch/csrc/cuda/Tensor.cpp",
+]
+
+libtorch_python_xpu_sources = [
+    "torch/csrc/xpu/Module.cpp",
 ]
 
 libtorch_python_core_sources = [

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -764,6 +764,7 @@ if(NOT NO_API AND NOT BUILD_LITE_INTERPRETER)
     ${TORCH_SRC_DIR}/csrc/api/src/optim/schedulers/reduce_on_plateau_scheduler.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/serialize/input-archive.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/serialize/output-archive.cpp
+    ${TORCH_SRC_DIR}/csrc/api/src/xpu.cpp
   )
 endif()
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -68,6 +68,7 @@ Features described in this documentation are classified by release status:
    cuda
    torch.cuda.memory <torch_cuda_memory>
    mps
+   xpu
    torch.backends <backends>
    torch.export <export>
    torch.distributed <distributed>

--- a/docs/source/xpu.rst
+++ b/docs/source/xpu.rst
@@ -1,0 +1,18 @@
+torch.xpu
+===================================
+.. automodule:: torch.xpu
+.. currentmodule:: torch.xpu
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    current_device
+    device
+    device_count
+    device_of
+    get_device_capability
+    get_device_name
+    get_device_properties
+    is_available
+    set_device

--- a/setup.py
+++ b/setup.py
@@ -1251,6 +1251,7 @@ def main():
         "include/torch/csrc/lazy/core/ops/*.h",
         "include/torch/csrc/lazy/python/python_util.h",
         "include/torch/csrc/lazy/ts_backend/*.h",
+        "include/torch/csrc/xpu/*.h",
         "include/pybind11/*.h",
         "include/pybind11/detail/*.h",
         "include/pybind11/eigen/*.h",

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -1,0 +1,43 @@
+# Owner(s): ["module: intel"]
+
+import sys
+import unittest
+
+import torch
+from torch.testing._internal.common_utils import NoTest, run_tests, TEST_XPU, TestCase
+
+if not TEST_XPU:
+    print("XPU not available, skipping tests", file=sys.stderr)
+    TestCase = NoTest  # noqa: F811
+
+TEST_MULTIXPU = torch.xpu.device_count() > 1
+
+
+class TestXpu(TestCase):
+    def test_device_behavior(self):
+        current_device = torch.xpu.current_device()
+        torch.xpu.set_device(current_device)
+        self.assertEqual(current_device, torch.xpu.current_device())
+
+    @unittest.skipIf(not TEST_MULTIXPU, "only one GPU detected")
+    def test_multi_device_behavior(self):
+        current_device = torch.xpu.current_device()
+        target_device = (current_device + 1) % torch.xpu.device_count()
+
+        with torch.xpu.device(target_device):
+            self.assertEqual(target_device, torch.xpu.current_device())
+        self.assertEqual(current_device, torch.xpu.current_device())
+
+        with torch.xpu._DeviceGuard(target_device):
+            self.assertEqual(target_device, torch.xpu.current_device())
+        self.assertEqual(current_device, torch.xpu.current_device())
+
+    def test_get_device_name(self):
+        current_device = torch.xpu.current_device()
+        device_name = torch.xpu.get_device_name(current_device)
+        self.assertEqual(device_name, torch.xpu.get_device_name(None))
+        self.assertEqual(device_name, torch.xpu.get_device_name())
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -145,6 +145,13 @@ if(USE_ROCM)
     list(APPEND TORCH_PYTHON_LINK_LIBRARIES ${ROCM_ROCTX_LIB})
 endif()
 
+if(USE_XPU)
+    include(${TORCH_ROOT}/cmake/public/xpu.cmake)
+    append_filelist("libtorch_python_xpu_sources" TORCH_PYTHON_SRCS)
+
+    list(APPEND TORCH_PYTHON_COMPILE_DEFINITIONS USE_XPU)
+endif()
+
 if(USE_EXPERIMENTAL_CUDNN_V8_API)
     list(APPEND TORCH_PYTHON_COMPILE_DEFINITIONS USE_EXPERIMENTAL_CUDNN_V8_API)
 endif()

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1209,6 +1209,7 @@ _has_mps: _bool
 has_lapack: _bool
 _has_cuda: _bool
 _has_magma: _bool
+_has_xpu: _bool
 _has_mkldnn: _bool
 _has_cudnn: _bool
 has_spectral: _bool
@@ -1762,6 +1763,26 @@ class _CudaDeviceProperties:
     is_multi_gpu_board: _int
     max_threads_per_multi_processor: _int
     gcnArchName: str
+
+# Defined in torch/csrc/xpu/Module.cpp
+def _xpu_setDevice(device: _int) -> None: ...
+def _xpu_exchangeDevice(device: _int) -> _int: ...
+def _xpu_maybeExchangeDevice(device: _int) -> _int: ...
+def _xpu_getDevice() -> _int: ...
+def _xpu_getDeviceCount() -> _int: ...
+def _xpu_init() -> None: ...
+
+class _XpuDeviceProperties:
+    name: str
+    platform_name: str
+    total_memory: _int
+    max_compute_units: _int
+    gpu_eu_count: _int
+    gpu_subslice_count: _int
+    max_work_group_size: _int
+    max_num_sub_groups: _int
+    sub_group_sizes: List[_int]
+    type: str
 
 # Functions related to SDPA
 class _SDPAParams:

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1537,6 +1537,7 @@ def _assert(condition, message):
 from torch import cuda as cuda
 from torch import cpu as cpu
 from torch import mps as mps
+from torch import xpu as xpu
 from torch import autograd as autograd
 from torch.autograd import (
     no_grad as no_grad,

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -708,7 +708,7 @@ class ExceptionWrapper:
 def _get_available_device_type():
     if torch.cuda.is_available():
         return "cuda"
-    if hasattr(torch, "xpu") and torch.xpu.is_available():  # type: ignore[attr-defined]
+    if torch.xpu.is_available():
         return "xpu"
     custom_backend_name = torch._C._get_privateuse1_backend_name()
     custom_device_mod = getattr(torch, custom_backend_name, None)
@@ -723,7 +723,7 @@ def _get_device_attr(get_member):
     if device_type and device_type.lower() == "cuda":
         return get_member(torch.cuda)
     if device_type and device_type.lower() == "xpu":
-        return get_member(torch.xpu)  # type: ignore[attr-defined]
+        return get_member(torch.xpu)
     if device_type == torch._C._get_privateuse1_backend_name():
         return get_member(getattr(torch, device_type))
     # add more available device types here

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1344,6 +1344,13 @@ void initModule(PyObject* module);
 } // namespace torch::cuda
 #endif
 
+#ifdef USE_XPU
+PyMethodDef* THXPModule_methods();
+namespace torch::xpu {
+void initModule(PyObject* module);
+} // namespace torch::xpu
+#endif
+
 #ifdef USE_ITT
 namespace torch::profiler {
 void initIttBindings(PyObject* module);
@@ -1403,6 +1410,9 @@ PyObject* initModule() {
 #ifdef USE_CUDA
   THPUtils_addPyMethodDefs(methods, THCPModule_methods());
 #endif
+#ifdef USE_XPU
+  THPUtils_addPyMethodDefs(methods, THXPModule_methods());
+#endif
 #if defined(USE_DISTRIBUTED) && defined(USE_C10D)
   THPUtils_addPyMethodDefs(
       methods, torch::distributed::c10d::python_functions());
@@ -1460,6 +1470,9 @@ PyObject* initModule() {
 #endif
 #ifdef USE_CUDA
   torch::cuda::initModule(module);
+#endif
+#ifdef USE_XPU
+  torch::xpu::initModule(module);
 #endif
   torch::cpu::initModule(module);
   torch::initVerboseBindings(module);
@@ -1788,10 +1801,17 @@ Call this whenever a new thread is created in order to propagate values from
   PyObject* has_mps = Py_False;
 #endif
 
+#ifdef USE_XPU
+  PyObject* has_xpu = Py_True;
+#else
+  PyObject* has_xpu = Py_False;
+#endif
+
   ASSERT_TRUE(set_module_attr("_has_cuda", has_cuda));
   ASSERT_TRUE(
       set_module_attr("_has_magma", at::hasMAGMA() ? Py_True : Py_False));
   ASSERT_TRUE(set_module_attr("_has_mps", has_mps));
+  ASSERT_TRUE(set_module_attr("_has_xpu", has_xpu));
   ASSERT_TRUE(
       set_module_attr("_has_mkldnn", at::hasMKLDNN() ? Py_True : Py_False));
 

--- a/torch/csrc/api/include/torch/all.h
+++ b/torch/csrc/api/include/torch/all.h
@@ -21,3 +21,4 @@
 #include <torch/types.h>
 #include <torch/utils.h>
 #include <torch/version.h>
+#include <torch/xpu.h>

--- a/torch/csrc/api/include/torch/xpu.h
+++ b/torch/csrc/api/include/torch/xpu.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <torch/csrc/Export.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace torch {
+namespace xpu {
+
+/// Returns the number of XPU devices available.
+size_t TORCH_API device_count();
+
+/// Returns true if at least one XPU device is available.
+bool TORCH_API is_available();
+
+} // namespace xpu
+} // namespace torch

--- a/torch/csrc/api/src/xpu.cpp
+++ b/torch/csrc/api/src/xpu.cpp
@@ -1,0 +1,19 @@
+#include <torch/xpu.h>
+
+#include <ATen/Context.h>
+
+#include <cstddef>
+
+namespace torch {
+namespace xpu {
+
+size_t device_count() {
+  return at::detail::getXPUHooks().getNumGPUs();
+}
+
+bool is_available() {
+  return xpu::device_count() > 0;
+}
+
+} // namespace xpu
+} // namespace torch

--- a/torch/csrc/xpu/Module.cpp
+++ b/torch/csrc/xpu/Module.cpp
@@ -1,0 +1,187 @@
+#include <ATen/ATen.h>
+#include <ATen/xpu/XPUContext.h>
+#include <c10/util/CallOnce.h>
+#include <c10/xpu/XPUFunctions.h>
+#include <torch/csrc/Module.h>
+#include <torch/csrc/THP.h>
+#include <torch/csrc/utils/python_numbers.h>
+#include <torch/csrc/utils/python_strings.h>
+
+using namespace torch;
+
+// XPU management methods
+
+PyObject* THXPModule_setDevice_wrap(PyObject* self, PyObject* arg) {
+  HANDLE_TH_ERRORS
+  THPUtils_assert(THPUtils_checkLong(arg), "invalid argument to set_device");
+
+  int device = THPUtils_unpackInt(arg);
+  c10::xpu::set_device(static_cast<c10::DeviceIndex>(device));
+
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+PyObject* THXPModule_exchangeDevice_wrap(PyObject* self, PyObject* arg) {
+  HANDLE_TH_ERRORS
+  TORCH_CHECK(THPUtils_checkLong(arg), "invalid argument to exchange_device");
+
+  int device = THPUtils_unpackInt(arg);
+  if (device < 0) {
+    return THPUtils_packInt32(-1);
+  }
+  int current_device = c10::xpu::exchange_device(device);
+
+  return THPUtils_packInt32(current_device);
+  END_HANDLE_TH_ERRORS
+}
+
+PyObject* THXPModule_maybeExchangeDevice_wrap(PyObject* self, PyObject* arg) {
+  HANDLE_TH_ERRORS
+  TORCH_CHECK(
+      THPUtils_checkLong(arg), "invalid argument to maybe_exchange_device");
+
+  int device = THPUtils_unpackInt(arg);
+  if (device < 0) {
+    return THPUtils_packInt32(-1);
+  }
+  int current_device = c10::xpu::maybe_exchange_device(device);
+
+  return THPUtils_packInt32(current_device);
+  END_HANDLE_TH_ERRORS
+}
+
+PyObject* THXPModule_getDevice_wrap(PyObject* self, PyObject* noargs) {
+  HANDLE_TH_ERRORS
+
+  // NOLINTNEXTLINE(bugprone-signed-char-misuse)
+  auto device = static_cast<int32_t>(c10::xpu::current_device());
+
+  return THPUtils_packInt32(device);
+  END_HANDLE_TH_ERRORS
+}
+
+PyObject* THXPModule_getDeviceCount_wrap(PyObject* self, PyObject* noargs) {
+  HANDLE_TH_ERRORS
+
+  return THPUtils_packUInt64(at::xpu::device_count());
+  END_HANDLE_TH_ERRORS
+}
+
+// XPU module initialization
+
+static void registerXpuDeviceProperties(PyObject* module) {
+  // Add _xpuDevicePropertires class to torch._C
+  using namespace c10::xpu;
+  auto get_device_type = [](const DeviceProp& prop) {
+    std::ostringstream stream;
+    using namespace sycl::info;
+    switch (prop.device_type) {
+      case device_type::cpu:
+        stream << "cpu";
+        break;
+      case device_type::gpu:
+        stream << "gpu";
+        break;
+      case device_type::accelerator:
+        stream << "accelerator";
+        break;
+      case device_type::host:
+        stream << "host";
+        break;
+      default:
+        stream << "unknown device type:"
+               << static_cast<typename std::underlying_type<device_type>::type>(
+                      prop.device_type);
+        break;
+    }
+    return stream.str();
+  };
+  auto gpu_subslice_count = [](const DeviceProp& prop) {
+    return (prop.gpu_eu_count / prop.gpu_eu_count_per_subslice);
+  };
+  auto m = py::handle(module).cast<py::module>();
+  py::class_<DeviceProp>(m, "_XpuDeviceProperties")
+      .def_readonly("name", &DeviceProp::device_name)
+      .def_readonly("platform_name", &DeviceProp::platform_name)
+      .def_readonly("total_memory", &DeviceProp::global_mem_size)
+      .def_readonly("max_compute_units", &DeviceProp::max_compute_units)
+      .def_readonly("gpu_eu_count", &DeviceProp::gpu_eu_count)
+      .def_property_readonly("gpu_subslice_count", gpu_subslice_count)
+      .def_readonly("max_work_group_size", &DeviceProp::max_work_group_size)
+      .def_readonly("max_num_sub_groups", &DeviceProp::max_num_sub_groups)
+      .def_readonly("sub_group_sizes", &DeviceProp::sub_group_sizes)
+      .def_property_readonly("type", get_device_type)
+      .def(
+          "__repr__",
+          [&get_device_type, &gpu_subslice_count](const DeviceProp& prop) {
+            std::ostringstream stream;
+            stream << "_XpuDeviceProperties(name='" << prop.device_name
+                   << "', platform_name='" << prop.platform_name << "', type='"
+                   << get_device_type(prop)
+                   << ", total_memory=" << prop.global_mem_size / (1024 * 1024)
+                   << "MB, max_compute_units=" << prop.max_compute_units
+                   << ", gpu_eu_count=" << prop.gpu_eu_count
+                   << ", gpu_subslice_count=" << gpu_subslice_count(prop)
+                   << ", max_work_group_size=" << prop.max_work_group_size
+                   << ", max_num_sub_groups=" << prop.max_num_sub_groups
+                   << ", sub_group_sizes=[" << prop.sub_group_sizes << "])";
+            return stream.str();
+          });
+}
+
+static void bindGetDeviceProperties(PyObject* module) {
+  // Add method to torch.xpu
+  auto m = py::handle(module).cast<py::module>();
+  m.def(
+      "_get_device_properties",
+      [](int device) -> c10::xpu::DeviceProp* {
+        return at::xpu::getDeviceProperties(device);
+      },
+      py::return_value_policy::reference);
+}
+
+// Callback for python part. Used for additional initialization of python
+// classes
+static PyObject* THXPModule_initExtension(PyObject* self, PyObject* noargs) {
+  HANDLE_TH_ERRORS
+
+  auto m = THPObjectPtr(PyImport_ImportModule("torch.xpu"));
+  if (!m)
+    throw python_error();
+
+  bindGetDeviceProperties(m);
+
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+// NOLINTNEXTLINE(modernize-avoid-c-arrays,
+// cppcoreguidelines-avoid-non-const-global-variables,
+// cppcoreguidelines-avoid-c-arrays)
+static struct PyMethodDef _THXPModule_methods[] = {
+    {"_xpu_init", THXPModule_initExtension, METH_NOARGS, nullptr},
+    {"_xpu_setDevice", THXPModule_setDevice_wrap, METH_O, nullptr},
+    {"_xpu_exchangeDevice", THXPModule_exchangeDevice_wrap, METH_O, nullptr},
+    {"_xpu_maybeExchangeDevice",
+     THXPModule_maybeExchangeDevice_wrap,
+     METH_O,
+     nullptr},
+    {"_xpu_getDevice", THXPModule_getDevice_wrap, METH_NOARGS, nullptr},
+    {"_xpu_getDeviceCount",
+     THXPModule_getDeviceCount_wrap,
+     METH_NOARGS,
+     nullptr},
+    {nullptr}};
+
+PyMethodDef* THXPModule_methods() {
+  return _THXPModule_methods;
+}
+
+namespace torch::xpu {
+
+void initModule(PyObject* module) {
+  registerXpuDeviceProperties(module);
+}
+
+} // namespace torch::xpu

--- a/torch/csrc/xpu/Module.h
+++ b/torch/csrc/xpu/Module.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <torch/csrc/python_headers.h>
+
+PyMethodDef* THXPModule_methods();
+
+namespace torch::xpu {
+
+void initModule(PyObject* module);
+
+} // namespace torch::xpu

--- a/torch/random.py
+++ b/torch/random.py
@@ -43,9 +43,6 @@ def manual_seed(seed) -> torch._C.Generator:
     if not torch.mps._is_in_bad_fork():
         torch.mps.manual_seed(seed)
 
-    if hasattr(torch, 'xpu') and not torch.xpu._is_in_bad_fork():
-        torch.xpu.manual_seed_all(seed)
-
     _seed_custom_device(seed)
 
     return default_generator.manual_seed(seed)
@@ -64,9 +61,6 @@ def seed() -> int:
     import torch.mps
     if not torch.mps._is_in_bad_fork():
         torch.mps.manual_seed(seed)
-
-    if hasattr(torch, 'xpu') and not torch.xpu._is_in_bad_fork():
-        torch.xpu.manual_seed_all(seed)
 
     _seed_custom_device(seed)
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1240,6 +1240,7 @@ TEST_SCIPY = _check_module_exists('scipy')
 TEST_MKL = torch.backends.mkl.is_available()
 TEST_MPS = torch.backends.mps.is_available()
 TEST_CUDA = torch.cuda.is_available()
+TEST_XPU = torch.xpu.is_available()
 custom_device_mod = getattr(torch, torch._C._get_privateuse1_backend_name(), None)
 TEST_PRIVATEUSE1 = True if (hasattr(custom_device_mod, "is_available") and custom_device_mod.is_available()) else False
 TEST_NUMBA = _check_module_exists('numba')

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -1,0 +1,200 @@
+from functools import lru_cache
+
+from typing import Any, Dict, Optional, Union
+
+import torch
+import torch._C
+from .. import device as _device
+from ._utils import _dummy_type, _get_device_index
+
+_device_t = Union[_device, str, int, None]
+has_half: bool = True
+
+
+def _is_compiled() -> bool:
+    r"""Return true if compile with XPU support."""
+    return torch._C._has_xpu
+
+
+if _is_compiled():
+    _XpuDeviceProperties = torch._C._XpuDeviceProperties
+    _exchange_device = torch._C._xpu_exchangeDevice
+    _maybe_exchange_device = torch._C._xpu_maybeExchangeDevice
+else:
+    # Define dummy if PyTorch was compiled without XPU
+    _XpuDeviceProperties = _dummy_type("_XpuDeviceProperties")  # type: ignore[assignment, misc]
+
+    def _exchange_device(device: int) -> int:
+        raise NotImplementedError("PyTorch was compiled without XPU support")
+
+    def _maybe_exchange_device(device: int) -> int:
+        raise NotImplementedError("PyTorch was compiled without XPU support")
+
+
+# TODO: Enable lazy init.
+if _is_compiled():
+    torch._C._xpu_init()
+
+
+@lru_cache(maxsize=1)
+def device_count() -> int:
+    r"""Return the number of XPU device available."""
+    if not _is_compiled():
+        return 0
+    return torch._C._xpu_getDeviceCount()
+
+
+def is_available() -> bool:
+    r"""Return a bool indicating if XPU is currently available."""
+    # This function nerver throws.
+    return device_count() > 0
+
+
+def is_bf16_supported():
+    r"""Return a bool indicating if the current XPU device supports dtype bfloat16."""
+    return True
+
+
+class _DeviceGuard:
+    def __init__(self, index: int):
+        self.idx = index
+        self.prev_idx = -1
+
+    def __enter__(self):
+        self.prev_idx = torch.xpu._exchange_device(self.idx)
+
+    def __exit__(self, type: Any, value: Any, traceback: Any):
+        self.idx = torch.xpu._maybe_exchange_device(self.prev_idx)
+        return False
+
+
+class device:
+    r"""Context-manager that changes the selected device.
+
+    Args:
+        device (torch.device or int or str): device index to select. It's a no-op if
+            this argument is a negative integer or ``None``.
+    """
+
+    def __init__(self, device: Any):
+        self.idx = _get_device_index(device, optional=True)
+        self.prev_idx = -1
+
+    def __enter__(self):
+        self.prev_idx = torch.xpu._exchange_device(self.idx)
+
+    def __exit__(self, type: Any, value: Any, traceback: Any):
+        self.idx = torch.xpu._maybe_exchange_device(self.prev_idx)
+        return False
+
+
+class device_of(device):
+    r"""Context-manager that changes the current device to that of given object.
+
+    You can use both tensors and storages as arguments. If a given object is
+    not allocated on a XPU, this is a no-op.
+
+    Args:
+        obj (Tensor or Storage): object allocated on the selected device.
+    """
+
+    def __init__(self, obj):
+        idx = obj.get_device() if obj.is_xpu else -1
+        super().__init__(idx)
+
+
+def set_device(device: _device_t) -> None:
+    r"""Set the current device.
+
+    Args:
+        device (torch.device or int or str): selected device. This function is a
+            no-op if this argument is negative.
+    """
+    device = _get_device_index(device)
+    if device >= 0:
+        torch._C._xpu_setDevice(device)
+
+
+def get_device_name(device: Optional[_device_t] = None) -> str:
+    r"""Get the name of a device.
+
+    Args:
+        device (torch.device or int or str, optional): device for which to
+            return the name. This function is a no-op if this argument is a
+            negative integer. It uses the current device, given by :func:`~torch.xpu.current_device`,
+            if :attr:`device` is ``None`` (default).
+
+    Returns:
+        str: the name of the device
+    """
+    return get_device_properties(device).name
+
+
+def get_device_capability(device: Optional[_device_t] = None) -> Dict[str, Any]:
+    r"""Get the xpu capability of a device.
+
+    Args:
+        device (torch.device or int or str, optional): device for which to
+            return the device capability. This function is a no-op if this
+            argument is a negative integer. It uses the current device, given by
+            :func:`~torch.xpu.current_device`, if :attr:`device` is ``None``
+            (default).
+
+    Returns:
+        Dict[str, Any]: the xpu capability dictionary of the device
+    """
+    prop = get_device_properties(device)
+    return {
+        "max_work_group_size": prop.max_work_group_size,
+        "max_num_sub_groups": prop.max_num_sub_groups,
+        "sub_group_sizes": prop.sub_group_sizes,
+    }
+
+
+def get_device_properties(device: _device_t) -> _XpuDeviceProperties:
+    r"""Get the properties of a device.
+
+    Args:
+        device (torch.device or int or str): device for which to return the
+            properties of the device.
+
+    Returns:
+        _XpuDeviceProperties: the properties of the device
+    """
+    device = _get_device_index(device, optional=True)
+    if device < 0 or device >= device_count():
+        raise AssertionError("Invalid device id")
+    return _get_device_properties(device)  # type: ignore[name-defined]
+
+
+def current_device() -> int:
+    r"""Return the index of a currently selected device."""
+    return torch._C._xpu_getDevice()
+
+
+def _get_device(device: Union[int, str, torch.device]) -> torch.device:
+    r"""Return the torch.device type object from the passed in device.
+
+    Args:
+        device (torch.device or int or str): selected device.
+    """
+    if isinstance(device, str):
+        device = torch.device(device)
+    elif isinstance(device, int):
+        device = torch.device("xpu", device)
+    return device
+
+
+__all__ = [
+    "current_device",
+    "device",
+    "device_of",
+    "device_count",
+    "get_device_capability",
+    "get_device_name",
+    "get_device_properties",
+    "has_half",
+    "is_available",
+    "is_bf16_supported",
+    "set_device",
+]

--- a/torch/xpu/_utils.py
+++ b/torch/xpu/_utils.py
@@ -1,0 +1,55 @@
+from typing import Any
+
+import torch
+
+# The _get_device_index has been moved to torch.utils._get_device_index
+from torch._utils import _get_device_index as _torch_get_device_index
+
+
+def _get_device_index(
+    device: Any, optional: bool = False, allow_cpu: bool = False
+) -> int:
+    r"""Get the device index from :attr:`device`, which can be a torch.device
+    object, a Python integer, or ``None``.
+
+    If :attr:`device` is a torch.device object, returns the device index if it
+    is a XPU device. Note that for a XPU device without a specified index,
+    i.e., ``torch.device('xpu')``, this will return the current default XPU
+    device if :attr:`optional` is ``True``. If :attr:`allow_cpu` is ``True``,
+    CPU devices will be accepted and ``-1`` will be returned in this case.
+
+    If :attr:`device` is a Python integer, it is returned as is.
+
+    If :attr:`device` is ``None``, this will return the current default XPU
+    device if :attr:`optional` is ``True``.
+    """
+    if isinstance(device, int):
+        return device
+    if isinstance(device, str):
+        device = torch.device(device)
+    if isinstance(device, torch.device):
+        if allow_cpu:
+            if device.type not in ["xpu", "cpu"]:
+                raise ValueError(f"Expected a xpu or cpu device, but got: {device}")
+        elif device.type != "xpu":
+            raise ValueError(f"Expected a xpu device, but got: {device}")
+    if not torch.jit.is_scripting():
+        if isinstance(device, torch.xpu.device):
+            return device.idx
+    return _torch_get_device_index(device, optional, allow_cpu)
+
+
+def _dummy_type(name: str) -> type:
+    def get_err_fn(is_init: bool):
+        def err_fn(obj, *args, **kwargs):
+            if is_init:
+                class_name = obj.__class__.__name__
+            else:
+                class_name = obj.__name__
+            raise RuntimeError(f"Tried to instantiate dummy base class {class_name}")
+
+        return err_fn
+
+    return type(
+        name, (object,), {"__init__": get_err_fn(True), "__new__": get_err_fn(False)}
+    )


### PR DESCRIPTION
# Motivation
According to [[1/4] Intel GPU Runtime Upstreaming for Device](https://github.com/pytorch/pytorch/pull/116019), and [[2/4] Intel GPU Runtime Upstreaming for Device](https://github.com/pytorch/pytorch/pull/116321), the third PR  covers the changes under `libtorch_python` and depends on the first two ones.

# Design
This PR primarily offers device-related APIs in python frontend, including
- `torch.xpu.is_available`
- `torch.xpu.device_count`
- `torch.xpu.current_device`
- `torch.xpu.set_device`
- `torch.xpu._DeviceGuard`
- `torch.xpu.device`
- `torch.xpu.device_of`
- `torch.xpu.get_device_name`
- `torch.xpu.get_device_capability`
- `torch.xpu.get_device_properties`

# Additional Context
We will implement the support of lazy initialization in the next PR. In this PR, we refactor `torch._utils._get_device_index` and `torch._utils._dummy_type` to make it can be shared between CUDA and XPU.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng