### PR TITLE
[BE][dynamo]: Add operator is and is not tests to dynamo tests

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -2047,15 +2047,14 @@ class DefaultsTests(torch._dynamo.test_case.TestCase):
             operator.is_,
             operator.is_not,
         ]:
-            with self.subTest(op=op):
 
-                def fn(x):
-                    return op(-10, x)
+            def fn(x):
+                return op(-10, x)
 
-                opt_fn = torch.compile(fullgraph=True)(fn)
+            opt_fn = torch.compile(fullgraph=True)(fn)
 
-                x = torch.randn(10)
-                self.assertEqual(opt_fn(x), fn(x))
+            x = torch.randn(10)
+            self.assertEqual(opt_fn(x), fn(x))
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -2047,14 +2047,15 @@ class DefaultsTests(torch._dynamo.test_case.TestCase):
             operator.is_,
             operator.is_not,
         ]:
+            with self.subTest(op=op):
 
-            def fn(x):
-                return op(-10, x)
+                def fn(x):
+                    return op(-10, x)
 
-            opt_fn = torch.compile(fullgraph=True)(fn)
+                opt_fn = torch.compile(fullgraph=True)(fn)
 
-            x = torch.randn(10)
-            self.assertEqual(opt_fn(x), fn(x))
+                x = torch.randn(10)
+                self.assertEqual(opt_fn(x), fn(x))
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -2044,6 +2044,8 @@ class DefaultsTests(torch._dynamo.test_case.TestCase):
             operator.ge,
             operator.ne,
             operator.eq,
+            operator.is_,
+            operator.is_not,
         ]:
 
             def fn(x):

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1560,12 +1560,11 @@ class BuiltinVariable(VariableTracker):
         if isinstance(left, TensorVariable) or isinstance(right, TensorVariable):
             from .builder import wrap_fx_proxy_cls
 
-            if (op is operator.is_ 
-                and isinstance(left, TensorVariable)
-                and isinstance(right, TensorVariable)
-            ):
+            if op is operator.is_:
                 return ConstantVariable.create(
-                    id(extract_fake_example_value(left.as_proxy().node))
+                    isinstance(left, TensorVariable)
+                    and isinstance(right, TensorVariable)
+                    and id(extract_fake_example_value(left.as_proxy().node))
                     == id(extract_fake_example_value(right.as_proxy().node))
                 )
 

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1561,15 +1561,12 @@ class BuiltinVariable(VariableTracker):
             from .builder import wrap_fx_proxy_cls
 
             if op is operator.is_:
-                if isinstance(left, TensorVariable) or isinstance(
-                    right, TensorVariable
-                ):
-                    return ConstantVariable.create(
-                        isinstance(left, TensorVariable)
-                        and isinstance(right, TensorVariable)
-                        and id(extract_fake_example_value(left.as_proxy().node))
-                        == id(extract_fake_example_value(right.as_proxy().node))
-                    )
+                return ConstantVariable.create(
+                    isinstance(left, TensorVariable)
+                    and isinstance(right, TensorVariable)
+                    and id(extract_fake_example_value(left.as_proxy().node))
+                    == id(extract_fake_example_value(right.as_proxy().node))
+                )
 
             if op not in supported_tensor_comparison_ops.values():
                 _unimplemented()

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1560,12 +1560,16 @@ class BuiltinVariable(VariableTracker):
         if isinstance(left, TensorVariable) or isinstance(right, TensorVariable):
             from .builder import wrap_fx_proxy_cls
 
-            if op is operator.is_ and isinstance(right, TensorVariable):
-                return ConstantVariable.create(
-                    isinstance(left, TensorVariable)
-                    and id(extract_fake_example_value(left.as_proxy().node))
-                    == id(extract_fake_example_value(right.as_proxy().node))
-                )
+            if op is operator.is_:
+                if isinstance(left, TensorVariable) or isinstance(
+                    right, TensorVariable
+                ):
+                    return ConstantVariable.create(
+                        isinstance(left, TensorVariable)
+                        and isinstance(right, TensorVariable)
+                        and id(extract_fake_example_value(left.as_proxy().node))
+                        == id(extract_fake_example_value(right.as_proxy().node))
+                    )
 
             if op not in supported_tensor_comparison_ops.values():
                 _unimplemented()

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1561,8 +1561,6 @@ class BuiltinVariable(VariableTracker):
             from .builder import wrap_fx_proxy_cls
 
             if op is operator.is_:
-                # note: technically, this does support if someone
-                # overrides "is_" in a subclass
                 return ConstantVariable.create(
                     isinstance(left, TensorVariable)
                     and isinstance(right, TensorVariable)

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1560,13 +1560,12 @@ class BuiltinVariable(VariableTracker):
         if isinstance(left, TensorVariable) or isinstance(right, TensorVariable):
             from .builder import wrap_fx_proxy_cls
 
-            if op is operator.is_:
-                # note: technically, this does support if someone
-                # overrides "is_" in a subclass
+            if (op is operator.is_ 
+                and isinstance(left, TensorVariable)
+                and isinstance(right, TensorVariable)
+            ):
                 return ConstantVariable.create(
-                    isinstance(left, TensorVariable)
-                    and isinstance(right, TensorVariable)
-                    and id(extract_fake_example_value(left.as_proxy().node))
+                    id(extract_fake_example_value(left.as_proxy().node))
                     == id(extract_fake_example_value(right.as_proxy().node))
                 )
 

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1562,7 +1562,8 @@ class BuiltinVariable(VariableTracker):
 
             if op is operator.is_ and isinstance(right, TensorVariable):
                 return ConstantVariable.create(
-                    id(extract_fake_example_value(left.as_proxy().node))
+                    isinstance(left, TensorVariable)
+                    and id(extract_fake_example_value(left.as_proxy().node))
                     == id(extract_fake_example_value(right.as_proxy().node))
                 )
 

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1561,6 +1561,8 @@ class BuiltinVariable(VariableTracker):
             from .builder import wrap_fx_proxy_cls
 
             if op is operator.is_:
+                # note: technically, this does support if someone
+                # overrides "is_" in a subclass
                 return ConstantVariable.create(
                     isinstance(left, TensorVariable)
                     and isinstance(right, TensorVariable)


### PR DESCRIPTION
Adds an operator that was unit not tested in our test suite - improves coverage. Inspired by looking into https://github.com/pytorch/pytorch/pull/116397 after @XuehaiPan brought up some issues with builtins in #116389 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng