### PR TITLE
[Easy][BE]: Fix none type comparison

### DIFF
--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -629,7 +629,7 @@ class Tracer(TracerBase):
                             out == x,
                             f"{name} has been specialized to have value {x} but got another value",
                         )
-                    elif type(x) == type(None):
+                    elif x is None:
                         args = (
                             out,
                             f"{name} has been specialized to have value None but got another value",


### PR DESCRIPTION
Simplifies type comparison, as it is unneeded since None is a singleton, and all objects are the same None object when they are set to None. 