### PR TITLE
[Inductor Intel GPU backend Upstream] Step 3: Add Intel GPU Inductor backend.

### DIFF
--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -105,6 +105,10 @@ def get_device_op_overrides(device: str):
         from .cuda.device_op_overrides import CUDADeviceOpOverrides
 
         return CUDADeviceOpOverrides()
+    elif device == "xpu":
+        from .xpu.device_op_overrides import XPUDeviceOpOverrides
+
+        return XPUDeviceOpOverrides()
 
     return DeviceOpOverrides()
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2928,7 +2928,8 @@ class TritonScheduling(BaseScheduling):
             compile_wrapper = IndentedBuffer()
             compile_wrapper.writeline(f"async_compile.triton({subs_name!r}, '''")
             compile_wrapper.splice(src_code, strip=True)
-            compile_wrapper.writeline("''')")
+            # set device_type argument for function AsyncCompile.triton
+            compile_wrapper.writeline(f"''', \"{V.graph.scheduler.current_device.type}\")")
 
             metadata_comment = f"# kernel path: {kernel_path}"
             origins, detailed_origins = get_kernel_metadata(node_schedule, wrapper)

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1015,7 +1015,8 @@ class WrapperCodeGen(CodeGen):
 
         traverse(kernel)
 
-        compile_wrapper.writeline("''')")
+        # set device_type argument for function AsyncCompile.triton
+        compile_wrapper.writeline(f"''', \"{V.graph.scheduler.current_device.type}\")")
         _, lineno = inspect.getsourcelines(kernel.fn)
         srcfile = inspect.getsourcefile(kernel.fn)
         metadata = f"# Original path: {srcfile}:{lineno}"

--- a/torch/_inductor/codegen/xpu/device_op_overrides.py
+++ b/torch/_inductor/codegen/xpu/device_op_overrides.py
@@ -1,0 +1,15 @@
+from ..common import DeviceOpOverrides
+
+
+class XPUDeviceOpOverrides(DeviceOpOverrides):
+    def import_get_raw_stream_as(self, name):
+        return f"from torch._C import _xpu_getCurrentRawStream as {name}"
+
+    def set_device(self, device_idx):
+        return f"torch.xpu.set_device({device_idx})"
+
+    def synchronize(self):
+        return "torch.xpu.synchronize()"
+
+    def device_guard(self, device_idx):
+        return f"torch.xpu._DeviceGuard({device_idx})"

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -175,6 +175,12 @@ class GraphLowering(torch.fx.Interpreter):
             # CUDACombinedScheduling combines Triton and CUDA C++ scheduling for CUDA devices via delegation
             register_backend_for_device("cuda", CUDACombinedScheduling, WrapperCodeGen)
 
+        if get_scheduling_for_device("xpu") is None:
+            from .codegen.triton import TritonScheduling
+
+            # Intel GPU Backend registration
+            register_backend_for_device("xpu", TritonScheduling, WrapperCodeGen)
+
     def __init__(
         self,
         gm: torch.fx.GraphModule,

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -39,6 +39,7 @@ from .sizevars import SimplifyIndexing
 from .utils import (
     cache_on_self,
     cmp,
+    device_need_guard,
     free_symbol_has,
     get_device_tflops,
     get_dtype_size,
@@ -2242,13 +2243,13 @@ class Scheduler:
                 ):
                     self.flush()
                 if device != self.current_device:
-                    if device.type == "cuda":
-                        if self.current_device and self.current_device.type == "cuda":
-                            V.graph.wrapper_code.codegen_device_guard_exit()
+                    if self.current_device and device_need_guard(
+                        self.current_device.type
+                    ):
+                        V.graph.wrapper_code.codegen_device_guard_exit()
+                    if device_need_guard(device.type):
                         assert device.index is not None, "device should have an index"
                         V.graph.wrapper_code.codegen_device_guard_enter(device.index)
-                    elif self.current_device and self.current_device.type == "cuda":
-                        V.graph.wrapper_code.codegen_device_guard_exit()
                     self.current_device = device
 
             self.buffer_names_to_free.update(node.last_usage)

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1228,3 +1228,10 @@ def aot_inductor_launcher(so_path: str, device: str):
         """
     else:
         raise RuntimeError(f"Unsupported device: {device}")
+
+
+def device_need_guard(device: str):
+    assert isinstance(device, str)
+    if device in ["cuda", "xpu"]:
+        return True
+    return False


### PR DESCRIPTION
Following the design in RFC https://github.com/pytorch/pytorch/issues/114856 , We register and add Intel GPU Inductor backend in this PR. It contains the following parts:
- Reuse `WrapperCodegen` and `TritonScheduling` for python wrapper and kernel code generation. And implenented device-specific code generation in `XPUDeviceOpOverrides`
- Reuse codecache, triton kernel auto-tuning, and compilation.


 
Feature request: #114856


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler