### PR TITLE
[Distributed] Add finer granularity tag for distributed submodule

### DIFF
--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -173,6 +173,9 @@ def set_logs(
     dynamic: Optional[int] = None,
     inductor: Optional[int] = None,
     distributed: Optional[int] = None,
+    dist_c10d: Optional[int] = None,
+    dist_ddp: Optional[int] = None,
+    dist_fsdp: Optional[int] = None,
     onnx: Optional[int] = None,
     bytecode: bool = False,
     aot_graphs: bool = False,
@@ -252,6 +255,18 @@ def set_logs(
 
         distributed (:class:`Optional[int]`):
             Whether to log communication operations and other debug info from pytorch distributed components.
+            Default: ``logging.WARN``
+
+        dist_c10d (:class:`Optional[int]`):
+            Whether to log communication operations related debug info in pytorch distributed components.
+            Default: ``logging.WARN``
+
+        dist_ddp (:class:`Optional[int]`):
+            Whether to log debug info related to ``DistributedDataParallel``(DDP) from pytorch distributed components.
+            Default: ``logging.WARN``
+
+        dist_fsdp (:class:`Optional[int]`):
+            Whether to log debug info related to ``FullyShardedDataParallel``(FSDP) in pytorch distributed components.
             Default: ``logging.WARN``
 
         onnx (:class:`Optional[int]`):
@@ -404,6 +419,9 @@ def set_logs(
         aot_joint_graph=aot_joint_graph,
         ddp_graphs=ddp_graphs,
         distributed=distributed,
+        dist_c10d=dist_c10d,
+        dist_ddp=dist_ddp,
+        dist_fsdp=dist_fsdp,
         graph=graph,
         graph_code=graph_code,
         graph_breaks=graph_breaks,

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -254,19 +254,19 @@ def set_logs(
             The log level for dynamic shapes. Default: ``logging.WARN``
 
         distributed (:class:`Optional[int]`):
-            Whether to log communication operations and other debug info from pytorch distributed components.
+            Whether to log communication operations and other debug info from PyTorch Distributed components.
             Default: ``logging.WARN``
 
         dist_c10d (:class:`Optional[int]`):
-            Whether to log communication operations related debug info in pytorch distributed components.
+            Whether to log communication operations related debug info in PyTorch Distributed components.
             Default: ``logging.WARN``
 
         dist_ddp (:class:`Optional[int]`):
-            Whether to log debug info related to ``DistributedDataParallel``(DDP) from pytorch distributed components.
+            Whether to log debug info related to ``DistributedDataParallel``(DDP) from PyTorch Distributed components.
             Default: ``logging.WARN``
 
         dist_fsdp (:class:`Optional[int]`):
-            Whether to log debug info related to ``FullyShardedDataParallel``(FSDP) in pytorch distributed components.
+            Whether to log debug info related to ``FullyShardedDataParallel``(FSDP) in PyTorch Distributed components.
             Default: ``logging.WARN``
 
         onnx (:class:`Optional[int]`):

--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -2,7 +2,11 @@
 from ._internal import register_artifact, register_log
 
 DYNAMIC = ["torch.fx.experimental.symbolic_shapes", "torch.fx.experimental.sym_node"]
-DISTRIBUTED = ["torch.distributed", "torch._dynamo.backends.distributed"]
+DISTRIBUTED = [
+    "torch.distributed",
+    "torch._dynamo.backends.distributed",
+    "torch.nn.parallel.distributed",
+]
 
 register_log("dynamo", ["torch._dynamo", *DYNAMIC])
 register_log("aot", ["torch._functorch.aot_autograd", "torch._functorch._aot_autograd"])
@@ -11,6 +15,11 @@ register_log("inductor", "torch._inductor")
 register_log("dynamic", DYNAMIC)
 register_log("torch", "torch")
 register_log("distributed", DISTRIBUTED)
+register_log(
+    "dist_c10d", ["torch.distributed.distributed_c10d", "torch.distributed.rendezvous"]
+)
+register_log("dist_ddp", ["torch.nn.parallel.distributed"])
+register_log("dist_fsdp", ["torch.distributed.fsdp"])
 register_log("onnx", "torch.onnx")
 
 register_artifact(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #116434

This PR is the start to enable the integrate pytorch distributed logs in Torch LOGs. We now already have one tag "distributed" for all distributed components but distributed is a very large component and we want to have some hierarchy and give users options to only turn on logs for certain submodules. So we also added tags starting with "dist_*" for each submodule. (This PR only adds some of them and we are going to add more down the road)

Related discussions can be found here: https://github.com/pytorch/pytorch/issues/113544

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @wz337 @tianyu-l @wconstab @yf225 @fritzo @neerajprad @alicanb @nikitaved