### PR TITLE
[GHF] Fix gh_get_labels for small repos

### DIFF
--- a/.github/scripts/label_utils.py
+++ b/.github/scripts/label_utils.py
@@ -44,6 +44,10 @@ def get_last_page_num_from_header(header: Any) -> int:
     # Link info looks like: <https://api.github.com/repositories/65600975/labels?per_page=100&page=2>;
     # rel="next", <https://api.github.com/repositories/65600975/labels?per_page=100&page=3>; rel="last"
     link_info = header["link"]
+    # Docs does not specify that it should be present for projects with just few labels
+    # And https://github.com/malfet/deleteme/actions/runs/7334565243/job/19971396887 it's not the case
+    if link_info is None:
+        return 1
     prefix = "&page="
     suffix = ">;"
     return int(


### PR DESCRIPTION
Not sure if this is recent API change or what but  `gh_get_labels('malfet', 'deleteme')` used to raise an exception (see https://github.com/malfet/deleteme/actions/runs/7334535266/job/19971328673#step:6:37 )
```
  File "/home/runner/work/deleteme/deleteme/.github/scripts/label_utils.py", line 50, in get_last_page_num_from_header
    link_info[link_info.rindex(prefix) + len(prefix) : link_info.rindex(suffix)]
AttributeError: 'NoneType' object has no attribute 'rindex'
```

And with this fix it returns the expected list
