### PR TITLE
[Nested Tensor]Support SDPA math fallback for jagged layout nested tensor

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -34,6 +34,7 @@ from torch.testing._internal.common_utils import (
     markDynamoStrictTest,
     xfailIfTorchDynamo,
     subtest,
+    TEST_WITH_ROCM,
     TestCase,
 )
 
@@ -3509,8 +3510,13 @@ class TestNestedTensorSubclass(TestCase):
         with self.assertRaisesRegex(ValueError, "expected .* to be a contiguous jagged layout"):
             clone = transposed.clone()
 
-    # Note: Math fallback doesn't work with bfloat16 on CUDA
+    # Note 1: Math fallback doesn't work with bfloat16 on CUDA
+    # Note 2: ROCm doesn't support flash attention or mem_efficient attention for NT
     @xfailIfTorchDynamo
+    @unittest.skipIf(
+        TEST_WITH_ROCM,
+        "ROCm doesn't support flash attention or mem_efficient attention for NT",
+    )
     @parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32] if
                  SM80OrLater else [torch.float16, torch.float32])
     def test_sdpa(self, device, dtype):

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -34,7 +34,6 @@ from torch.testing._internal.common_utils import (
     markDynamoStrictTest,
     xfailIfTorchDynamo,
     subtest,
-    TEST_WITH_ROCM,
     TestCase,
 )
 
@@ -3510,15 +3509,6 @@ class TestNestedTensorSubclass(TestCase):
         with self.assertRaisesRegex(ValueError, "expected .* to be a contiguous jagged layout"):
             clone = transposed.clone()
 
-    # Note 1: CPU Fused kernels do not support nested, Math is missing ops to work with NT jagged
-    # Note 2: Unless running on newer GPUs, only mem-effn or math are available, and mem-effn
-    # will fail with gradients and math has ops that aren't implemented. Therefore, in
-    # order to get some kernel to work with most GPUs, we have to disable gradients in
-    # this more general test
-    # Note 3: ROCm only supports the math kernel, which doesn't work with jagged NTs
-    @xfailIfTorchDynamo
-    @onlyCUDA
-    @unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support device side asserts")
     @parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32] if
                  SM80OrLater else [torch.float16, torch.float32])
     def test_sdpa(self, device, dtype):
@@ -3622,14 +3612,12 @@ class TestNestedTensorSubclass(TestCase):
         check_forward_backward()
 
         # Test dispatcher works by calling only mem-effn and math (as they are safe for all devices)
-        with torch.backends.cuda.sdp_kernel(enable_flash=False, enable_mem_efficient=True, enable_math=False):
+        with torch.backends.cuda.sdp_kernel(enable_flash=False, enable_mem_efficient=True, enable_math=True):
             check_forward_backward()
 
-        # Will fail bc unsupported ops
-        # TODO: Add remaining ops, or implement a different math dispatch for jagged
+        # Test math fallback
         with torch.backends.cuda.sdp_kernel(enable_flash=False, enable_mem_efficient=False, enable_math=True):
-            with self.assertRaises(RuntimeError):
-                attn_nt = torch.nn.functional.scaled_dot_product_attention(q_nt_t, k_nt_t, v_nt_t).transpose(1, 2)
+            check_forward_backward()
 
 
     # This requires NT -> NT views to work in inductor, which is a TODO

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -3621,8 +3621,7 @@ class TestNestedTensorSubclass(TestCase):
         with torch.backends.cuda.sdp_kernel(enable_flash=False, enable_mem_efficient=False, enable_math=True):
             # Math fallback doesn't work with bfloat16 on CUDA because
             # "group_gemm_dispatch" not implemented for 'BFloat16'
-            if not (device == "cuda" and dtype == torch.bfloat16):
-                print(f"device is {device}, dtype is {dtype}")
+            if not (str(device).startswith("cuda") and dtype == torch.bfloat16):
                 check_forward_backward()
 
 

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -3622,6 +3622,7 @@ class TestNestedTensorSubclass(TestCase):
             # Math fallback doesn't work with bfloat16 on CUDA because
             # "group_gemm_dispatch" not implemented for 'BFloat16'
             if not (device == "cuda" and dtype == torch.bfloat16):
+                print(f"device is {device}, dtype is {dtype}")
                 check_forward_backward()
 
 

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -3515,7 +3515,7 @@ class TestNestedTensorSubclass(TestCase):
                  SM80OrLater else [torch.float16, torch.float32])
     def test_sdpa(self, device, dtype):
         batch_size = 1
-        emb_dims = 64
+        emb_dims = 128
         n_heads = 8
         head_dims = emb_dims // n_heads
 

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -3509,6 +3509,7 @@ class TestNestedTensorSubclass(TestCase):
         with self.assertRaisesRegex(ValueError, "expected .* to be a contiguous jagged layout"):
             clone = transposed.clone()
 
+    @xfailIfTorchDynamo
     @parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32] if
                  SM80OrLater else [torch.float16, torch.float32])
     def test_sdpa(self, device, dtype):

--- a/torch/nested/_internal/sdpa.py
+++ b/torch/nested/_internal/sdpa.py
@@ -757,7 +757,7 @@ def jagged_scaled_dot_product_attention(
             query, key, value, attn_mask, dropout_p, is_causal, scale=scale
         )[0]
 
-        # convert strider layout Nested Tensor back to jagged layout Nested Tensor
+        # convert strided layout Nested Tensor back to jagged layout Nested Tensor
         attn_out = attn_out.transpose(1, 2).contiguous().values()
         attn_out = attn_out.view(-1, shape[-3], shape[-1])
         attn_out = ViewNestedFromBuffer.apply(attn_out, offsets)

--- a/torch/nested/_internal/sdpa.py
+++ b/torch/nested/_internal/sdpa.py
@@ -736,18 +736,22 @@ def jagged_scaled_dot_product_attention(
             attention.squeeze(0), output_nt_info["offsets"]
         ).transpose(1, 2)
     elif backend_choice == SDPBackend.MATH:
+        # save the offsets and shape of the inputs, so we can reshape the final output
+        # query @ key = attn: [B, D1, j0, D'] @ [B, D1, D' j1] = [B, D1, j0, j1]
+        # attn @ value = out: [B, D1, j0, j1] @ [B, D1, j1, D2] = [B, D1, j0, D2]
+        offsets = query.offsets()
+        d1 = query._size[1]
+        d2 = value._size[-1]
+
         # convert jagged layout Nested Tensor to strided layout Nested Tensor
         # which support the math implementation of SDPA
-        offsets = query.offsets()
-        shape = query._size
-
         def get_strided_layout_nested_tensor(jagged_layout_nt):
             lengths = jagged_layout_nt._offsets[1:] - jagged_layout_nt._offsets[:-1]
             transpose = torch.transpose(jagged_layout_nt, 1, 2)
             tensor_list = buffer_from_jagged(transpose).split(list(lengths), dim=0)
-            c_nt = torch.nested.as_nested_tensor(list(tensor_list))
-            c_nt = c_nt.transpose(1, 2).contiguous()
-            return c_nt
+            strided_nt = torch.nested.as_nested_tensor(list(tensor_list))
+            strided_nt = strided_nt.transpose(1, 2).contiguous()
+            return strided_nt
 
         query = get_strided_layout_nested_tensor(query)
         key = get_strided_layout_nested_tensor(key)
@@ -759,7 +763,7 @@ def jagged_scaled_dot_product_attention(
 
         # convert strided layout Nested Tensor back to jagged layout Nested Tensor
         attn_out = attn_out.transpose(1, 2).contiguous().values()
-        attn_out = attn_out.view(-1, shape[-3], shape[-1])
+        attn_out = attn_out.view(-1, d1, d2)
         attn_out = ViewNestedFromBuffer.apply(attn_out, offsets)
         attn_out = attn_out.transpose(1, 2)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #116445


Support this fallback by converting the jagged layout NT to strided layout NT, and the convert the result back to jagged layout NT. 
This fallback might not be efficient since it uses unbind, contiguous and split.

