### PR TITLE
[GHF] Refactors

### DIFF
--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -145,6 +145,16 @@ class GitRepo:
         rc = self._run_git("rev-list", revision_range, "--", ".").strip()
         return rc.split("\n") if len(rc) > 0 else []
 
+    def branches_containing_ref(
+        self, ref: str, *, include_remote: bool = True
+    ) -> List[str]:
+        rc = (
+            self._run_git("branch", "--remote", "--contains", ref)
+            if include_remote
+            else self._run_git("branch", "--contains", ref)
+        )
+        return [x.strip() for x in rc.split("\n")] if len(rc) > 0 else []
+
     def current_branch(self) -> str:
         return self._run_git("symbolic-ref", "--short", "HEAD").strip()
 

--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -153,7 +153,7 @@ class GitRepo:
             if include_remote
             else self._run_git("branch", "--contains", ref)
         )
-        return [x.strip() for x in rc.split("\n")] if len(rc) > 0 else []
+        return [x.strip() for x in rc.split("\n") if x.strip()] if len(rc) > 0 else []
 
     def current_branch(self) -> str:
         return self._run_git("symbolic-ref", "--short", "HEAD").strip()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #116447
* __->__ #116446

Prep change for allowing stacked reverts

This is a no-op that factors out some helper function that would be
useful later:
 - `get_pr_commit_sha` finds a committed sha for a given PR
 - `_revlist_to_prs` converts a revlist to GitHubPRs conditionally
   filtering some out
 - `do_revert_prs` reverts multiple PRs in a batch, but so far is
   invoked with only one PR