### PR TITLE
[GHF] Implement stacked revert

### DIFF
--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -153,7 +153,7 @@ class GitRepo:
             if include_remote
             else self._run_git("branch", "--contains", ref)
         )
-        return [x.strip() for x in rc.split("\n")] if len(rc) > 0 else []
+        return [x.strip() for x in rc.split("\n") if x.strip()] if len(rc) > 0 else []
 
     def current_branch(self) -> str:
         return self._run_git("symbolic-ref", "--short", "HEAD").strip()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #116447
* #116446

By adding `get_ghstack_dependent_prs` that using `git branch --contains`
finds all PRs containing stacked branch, selecting longest one (in
terms of distance between origin and default branch) and skipping all
open PRs

Please note, that reverts should be applied in a reversed order with the
one how PRs were landed originally.

Use a bit of a defensive programming, i.e. revert single PR if attempt to fetch dependencies fails for some reason.

Test plan: 
 - Lint
 -  ```
    >>> from trymerge import GitRepo, GitHubPR, get_ghstack_prs, get_ghstack_dependent_prs
    >>> pr=GitHubPR("pytorch", "pytorch", 115188)
    >>> pr1=GitHubPR("pytorch", "pytorch", 115210)
    >>> repo=GitRepo("/Users/nshulga/git/pytorch/pytorch")
    >>> get_ghstack_dependent_prs(repo, pr1)
    [('22742d93a5357c9b5b45a74f91a6dc5599c9c266', <trymerge.GitHubPR object at 0x100f32f40>)]
    >>> get_ghstack_dependent_prs(repo, pr)
    [('22742d93a5357c9b5b45a74f91a6dc5599c9c266', <trymerge.GitHubPR object at 0x10102eaf0>), ('76b1d44d576c20be79295810904c589241ca1bd2', <trymerge.GitHubPR object at 0x10102eb50>)]
    >>> rc=get_ghstack_dependent_prs(repo, pr)
    rc[0]>>> rc[0][1].pr_num
    115210
    >>> rc[1][1].pr_num
    115188
    ```
 - see: https://github.com/malfet/deleteme/pull/59#issuecomment-1869904714 and https://github.com/malfet/deleteme/pull/74#issuecomment-1870542702

Fixes https://github.com/pytorch/test-infra/issues/4845