### PR TITLE
Fix NaN bug in torch.signal.windows.kaiser

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -2759,6 +2759,41 @@ class TestTensorCreation(TestCase):
         for num_test in range(50):
             self._test_signal_window_functions('kaiser', dtype, device, beta=random.random() * 30)
 
+    def _test_signal_windows_functions(self, name, dtype, device, **kwargs):
+        import scipy.signal as signal
+
+        torch_method = getattr(torch.signal.windows, name)
+        if not dtype.is_floating_point:
+            with self.assertRaisesRegex(RuntimeError, r'floating point'):
+                torch_method(3, dtype=dtype)
+            return
+        for size in [0, 1, 2, 5, 10, 50, 100, 1024, 2048]:
+            for periodic in [True, False]:
+                res = torch_method(size, sym=not periodic, **kwargs, device=device, dtype=dtype)
+                # NB: scipy always returns a float64 result
+                ref = torch.from_numpy(signal.get_window((name, *(kwargs.values())), size, fftbins=periodic))
+                self.assertEqual(res, ref, exact_dtype=False)
+        self.assertTrue(torch_method(3, requires_grad=True).requires_grad)
+        self.assertFalse(torch_method(3).requires_grad)
+
+    # torch.signal.windows functions (except any with extra parameters)
+    @onlyNativeDeviceTypes
+    @unittest.skipIf(not TEST_SCIPY, "Scipy not found")
+    @skipIfTorchDynamo("Not a TorchDynamo suitable test")
+    @dtypes(torch.float, torch.double)
+    @parametrize("window", ['bartlett', 'blackman', 'cosine', 'hamming', 'hann', 'nuttall'])
+    def test_signal_windows_functions(self, device, dtype, window):
+        self._test_signal_windows_functions(window, dtype, device)
+
+    # torch.signal.windows.kaiser
+    @onlyNativeDeviceTypes
+    @unittest.skipIf(not TEST_SCIPY, "Scipy not found")
+    @skipIfTorchDynamo("TorchDynamo fails with unknown reason")
+    @dtypes(torch.float, torch.double)
+    def test_kaiser(self, device, dtype):
+        for num_test in range(50):
+            self._test_signal_windows_functions('kaiser', dtype, device, beta=random.random() * 30)
+
     def test_tensor_factories_empty(self, device):
         # ensure we can create empty tensors from each factory function
         shapes = [(5, 0, 1), (0,), (0, 0, 1, 0, 2, 0, 0)]

--- a/torch/signal/windows/windows.py
+++ b/torch/signal/windows/windows.py
@@ -366,18 +366,22 @@ def kaiser(
     if M == 1:
         return torch.ones((1,), dtype=dtype, layout=layout, device=device, requires_grad=requires_grad)
 
+    # Avoid NaNs by casting `beta` to the appropriate dtype.
+    beta = torch.tensor(beta, dtype=dtype, device=device)
+
     start = -beta
     constant = 2.0 * beta / (M if not sym else M - 1)
+    end = torch.minimum(beta, start + (M - 1) * constant)
 
     k = torch.linspace(start=start,
-                       end=start + (M - 1) * constant,
+                       end=end,
                        steps=M,
                        dtype=dtype,
                        layout=layout,
                        device=device,
                        requires_grad=requires_grad)
 
-    return torch.i0(torch.sqrt(beta * beta - torch.pow(k, 2))) / torch.i0(torch.tensor(beta, device=device))
+    return torch.i0(torch.sqrt(beta * beta - torch.pow(k, 2))) / torch.i0(beta)
 
 
 @_add_docstr(


### PR DESCRIPTION
Fixes #115595

As an aside, there are currently no tests checking the output of `torch.signal.windows.kaiser` against the output of scipy's implementation, which is what is done with `torch.kaiser_window`. The same goes for the other window functions in `torch.signal.windows`. I did some tests on my end, but I'm not sure what the best practice is, so I haven't included them for now.

@gchanan @mruberry