### PR TITLE
ci: Set core dump size limit to 1GB

### DIFF
--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -230,6 +230,7 @@ jobs:
             -e DASHBOARD_TAG \
             --env-file="/tmp/github_env_${GITHUB_RUN_ID}" \
             --ulimit stack=10485760:83886080 \
+            --ulimit core=1073741824 \
             --security-opt seccomp=unconfined \
             --cap-add=SYS_PTRACE \
             --ipc=host \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #116514

To avoid runaway test suites from blowing up the runners with core dumps.

Potentially fixes https://github.com/pytorch/pytorch/issues/116510

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>