### PR TITLE
[RelEng] Missing signal for release branches

### DIFF
--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release/*
     tags:
       - ciflow/inductor/*
   workflow_dispatch:

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -12,6 +12,8 @@ on:
   push:
     tags:
       - ciflow/periodic/*
+    branches:
+      - release/*
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -10,6 +10,8 @@ on:
   push:
     tags:
       - ciflow/slow/*
+    branches:
+      - release/*
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Run slow/periodic and inductor workflows on push to release branches

Right now there are no signal from those jobs on release branches at all.
This will run periodic jobs on every commit to release branch, which is fine, as they are short lived and have a much lower traffic that a regular jobs
