### PR TITLE
Fix missing dependency in torch.utils.tensorboard (#115598)

### DIFF
--- a/torch/utils/tensorboard/__init__.py
+++ b/torch/utils/tensorboard/__init__.py
@@ -1,5 +1,5 @@
 import tensorboard
-from packaging.version import Version
+from torch._vendor.packaging.version import Version
 
 if not hasattr(tensorboard, "__version__") or Version(
     tensorboard.__version__


### PR DESCRIPTION
Fixes #114591

Version package was removed in this pull request: #114108 but is still used in `torch.utils.tensorboard` causing import errors. The fix removes the import and uses a simpler check.
Pull Request resolved: https://github.com/pytorch/pytorch/pull/115598
Approved by: https://github.com/malfet

