### PR TITLE
Fix pointer null issue by intrusive_ptr.

### DIFF
--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -270,6 +270,9 @@ class intrusive_ptr final {
   }
 
   void reset_() noexcept {
+    if(target_ == NULL) {
+      return;
+    }
     if (target_ != NullType::singleton() &&
         detail::atomic_refcount_decrement(target_->refcount_) == 0) {
       // See comment above about weakcount. As long as refcount>0,
@@ -705,6 +708,9 @@ class weak_intrusive_ptr final {
   }
 
   void reset_() noexcept {
+    if(target_ == NULL) {
+      return;
+    }
     if (target_ != NullType::singleton() &&
         detail::atomic_weakcount_decrement(target_->weakcount_) == 0) {
       // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDelete)


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
Fix pointer null issue by intrusive_ptr.
When debugging the privateuse1 function, an intrusive_ptr error occurred when using '.to(device)', and target_ was found to be NULL.

cc @ezyang @bhosmer @smessmer @ljk53 @bdhirsh