### PR TITLE
Increase hub download chunk size

### DIFF
--- a/torch/hub.py
+++ b/torch/hub.py
@@ -82,7 +82,7 @@ ENV_XDG_CACHE_HOME = 'XDG_CACHE_HOME'
 DEFAULT_CACHE_DIR = '~/.cache'
 VAR_DEPENDENCY = 'dependencies'
 MODULE_HUBCONF = 'hubconf.py'
-READ_DATA_CHUNK = 8192
+READ_DATA_CHUNK = 131072
 _hub_dir = None
 
 
@@ -648,7 +648,7 @@ def download_url_to_file(url: str, dst: str, hash_prefix: Optional[str] = None,
         with tqdm(total=file_size, disable=not progress,
                   unit='B', unit_scale=True, unit_divisor=1024) as pbar:
             while True:
-                buffer = u.read(8192)
+                buffer = u.read(READ_DATA_CHUNK)
                 if len(buffer) == 0:
                     break
                 f.write(buffer)

--- a/torch/hub.py
+++ b/torch/hub.py
@@ -82,7 +82,7 @@ ENV_XDG_CACHE_HOME = 'XDG_CACHE_HOME'
 DEFAULT_CACHE_DIR = '~/.cache'
 VAR_DEPENDENCY = 'dependencies'
 MODULE_HUBCONF = 'hubconf.py'
-READ_DATA_CHUNK = 131072
+READ_DATA_CHUNK = 128 * 1024
 _hub_dir = None
 
 


### PR DESCRIPTION
This PR increases the read size for the `hub.download_url_to_file` function from 8,192 bytes to 131,072 bytes (128 * 1,024), as reading in larger chunks should be more efficient. The size could probably be larger still, at the expense of the progress bar not getting updated as often.

It re-introduces use of the `READ_DATA_CHUNK` constant that was originally used for this purpose in https://github.com/pytorch/pytorch/commit/4a3baec96158c14f0157ea5a5a8a3454b291ed34 and since forgotten.


cc @nairbv @NicolasHug @vmoens @jdsgomes @penguinwu