### PR TITLE
[BE]: Enable readability-redundant-function-ptr-dereference check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -55,6 +55,7 @@ readability-container-size-empty,
 readability-delete-null-pointer,
 readability-duplicate-include
 readability-misplaced-array-index,
+readability-redundant-function-ptr-dereference,
 readability-redundant-smartptr-get,
 readability-simplify-subscript-expr,
 readability-string-compare,


### PR DESCRIPTION
Enable an additional clang-tidy check to remove redundant function ptr dereferences to help make the code more readable.