### PR TITLE
[MPS] Fix addmm

### DIFF
--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -269,8 +269,8 @@ static Tensor& addmm_out_mps_impl(const Tensor& bias,
   };
 
   @autoreleasepool {
-    string key = "addmm_out_mps_impl" + getTensorsStringKey({self, other, *bias_}) + ":" +
-        to_string(beta.toDouble()) + ":" + to_string(alpha.toDouble());
+    string key = "addmm_out_mps_impl" + getTensorsStringKey({self, other, *bias_}) + ":" + to_string(beta.toDouble()) +
+        ":" + to_string(alpha.toDouble());
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
       MPSGraphTensor* selfTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, self);
       MPSGraphTensor* otherTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, other);

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -22,76 +22,6 @@
 
 namespace at::native {
 namespace mps {
-/*
- * Helper functions to be used for mm/addmm for detecting the Transpositions
- * when doing Batched GEMM operations.
- */
-
-static Tensor prepare_batch_matrix_by_transposing(const Tensor& tensor,
-                                                  bool& transpose_tensor,
-                                                  int64_t& ld_tensor,
-                                                  bool transpose_result,
-                                                  int64_t m,
-                                                  int64_t n) {
-  IntArrayRef tensor_strides = tensor.strides();
-  Tensor tensor_;
-  int fast_dim = transpose_result ? 2 : 1;
-  int leading_dim = transpose_result ? 1 : 2;
-
-  if (tensor_strides[fast_dim] == 1 && (tensor_strides[leading_dim] >= std::max<int64_t>(1, m))) {
-    transpose_tensor = false;
-    tensor_ = tensor;
-    ld_tensor = tensor_strides[leading_dim];
-  } else if ((tensor_strides[leading_dim] == 1) && (tensor_strides[fast_dim] >= std::max<int64_t>(1, n))) {
-    transpose_tensor = true;
-    tensor_ = tensor;
-    ld_tensor = tensor_strides[fast_dim];
-  } else {
-    transpose_tensor = !transpose_result;
-    // gemm call requires leading dimension and stride parameters to be non-zero
-    bool is_stride_non_zero = tensor.stride(1) != 0 && tensor.stride(2) != 0;
-    if (tensor.is_contiguous() && is_stride_non_zero) {
-      tensor_ = tensor;
-    } else {
-      tensor_ = tensor.clone(at::MemoryFormat::Contiguous);
-    }
-    ld_tensor = tensor_.stride(1);
-  }
-
-  return tensor_;
-}
-
-/*
- * Helper functions to be used for mm/addmm for detecting the Transpositions
- * when doing GEMM operations.
- */
-static void prepare_matrices_for_broadcasting(const Tensor* bias,
-                                              const Tensor& self,
-                                              const Tensor& other,
-                                              const Scalar* beta,
-                                              bool* transpose_mat1_times_mat2,
-                                              bool& transpose_mat1,
-                                              bool& transpose_mat2) {
-  TORCH_CHECK(self.dim() == 2 && other.dim() == 2, "tensors must be 2-D");
-  if (bias && beta->toDouble() != 0.0f) {
-    TORCH_CHECK(bias->dim() == 2, "tensors must be 2-D");
-  }
-
-  std::pair<int64_t, int64_t> mat1_sizes;
-  std::pair<int64_t, int64_t> mat2_sizes;
-
-  mat1_sizes = std::make_pair(self.sizes()[0], self.sizes()[1]);
-  mat2_sizes = std::make_pair(other.sizes()[0], other.sizes()[1]);
-
-  if (mat1_sizes == mat2_sizes) {
-    transpose_mat2 = true;
-    std::swap(mat2_sizes.first, mat2_sizes.second);
-  }
-  if (bias && beta && transpose_mat1_times_mat2) {
-    if (beta->toDouble() != 0.0f && mat1_sizes.first == bias->sizes()[1] && mat2_sizes.second == bias->sizes()[0])
-      *transpose_mat1_times_mat2 = true;
-  }
-}
 
 enum LinearAlgebraOpType { ADDBMM_OP_TYPE, BADDBMM_OP_TYPE };
 
@@ -328,13 +258,7 @@ static Tensor& addmm_out_mps_impl(const Tensor& bias,
 
   MPSStream* stream = getCurrentMPSStream();
 
-  bool transpose_mat1_times_mat2 = false;
-  bool transpose_mat1 = false;
-  bool transpose_mat2 = false;
   bool is_beta_non_zero = beta.toDouble() != 0.0;
-
-  prepare_matrices_for_broadcasting(
-      &(*bias_), self, other, &beta, &transpose_mat1_times_mat2, transpose_mat1, transpose_mat2);
 
   struct CachedGraph : public mps::MPSCachedGraph {
     CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
@@ -345,30 +269,17 @@ static Tensor& addmm_out_mps_impl(const Tensor& bias,
   };
 
   @autoreleasepool {
-    string key = "addmm_out_mps_impl" + getTensorsStringKey({self, other, *bias_}) + ":" + to_string(transpose_mat1) +
-        ":" + to_string(transpose_mat2) + ":" + to_string(beta.toDouble()) + ":" + to_string(alpha.toDouble());
+    string key = "addmm_out_mps_impl" + getTensorsStringKey({self, other, *bias_}) + ":" +
+        to_string(beta.toDouble()) + ":" + to_string(alpha.toDouble());
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
       MPSGraphTensor* selfTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, self);
       MPSGraphTensor* otherTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, other);
       MPSGraphTensor* biasTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, *bias_);
 
-      MPSGraphTensor* t1 = nil;
-      MPSGraphTensor* t2 = nil;
-
-      if (transpose_mat1)
-        t1 = [mpsGraph transposeTensor:selfTensor dimension:-1 withDimension:-2 name:nil];
-      else
-        t1 = selfTensor;
-
-      if (transpose_mat2)
-        t2 = [mpsGraph transposeTensor:otherTensor dimension:-1 withDimension:-2 name:nil];
-      else
-        t2 = otherTensor;
-
       // TODO: Use alpha and beta here with fill_.Scalar and mul
       // Intermediate as placeholder
-      MPSGraphTensor* productTensor = [mpsGraph matrixMultiplicationWithPrimaryTensor:t1
-                                                                      secondaryTensor:t2
+      MPSGraphTensor* productTensor = [mpsGraph matrixMultiplicationWithPrimaryTensor:selfTensor
+                                                                      secondaryTensor:otherTensor
                                                                                  name:@"MM/(mat1@mat2)"];
 
       // Intermediates for beta and alpha
@@ -387,9 +298,6 @@ static Tensor& addmm_out_mps_impl(const Tensor& bias,
                                                         secondaryTensor:betaTensor
                                                                    name:@"MM/beta*input"];
       }
-
-      if (transpose_mat1_times_mat2)
-        biasTimesBetaTensor = [mpsGraph transposeTensor:biasTimesBetaTensor dimension:-1 withDimension:-2 name:nil];
 
       MPSGraphTensor* outputTensor = productTimesAlphaTensor;
       if (is_beta_non_zero) {

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1145,8 +1145,8 @@ def sample_inputs_addmm(op_info, device, dtype, requires_grad, **kwargs):
         ((2, 3), (2, 2), (2, 3), False)
     ]
     tests_with_lhs_broadcasting = [
-        ((1,), (2, 2), (2, 3), True),
-        ((), (2, 2), (2, 3), True)
+        ((1,), (2, 2), (2, 2), True),
+        ((), (2, 2), (2, 3), True),
     ]
     test_cases = tests_list + tests_with_lhs_broadcasting  # type: ignore[operator]
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #116548
* __->__ #116547

Remove weird logic for designating matrices as transposed if sizes match(which always true if square matrices are multiplied with each other), which resulted in `torch.addmm` returns transposed matrix compared to `torch.mm`, see below:
```
% python -c "import torch;torch.set_default_device('mps');a=torch.eye(2);b=torch.arange(4.0).reshape(2, 2);print(a@b);print(torch.addmm(torch.zeros(2, 2), a,b))"
tensor([[0., 1.],
        [2., 3.]], device='mps:0')
tensor([[0., 2.],
        [1., 3.]], device='mps:0')
```

Fixes introduced to `torch.mm` in https://github.com/pytorch/pytorch/pull/77462 suggests that this is not needed

Modify `sample_inputs_addmm` to test `torch.addmm` with square matrices, but skip this config for `test_autograd_dense_output_addmm`, see https://github.com/pytorch/pytorch/issues/116565


TODO: probably tweak tolerances, as `test_output_match_addmm_cpu_float16` fails with 2x2 matrices, but passes using 3x3 ones with errors slightly exceeding the tolerance

Fixes https://github.com/pytorch/pytorch/issues/116331