### PR TITLE
[CI] Fix docker builds (#116549)

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -298,3 +298,8 @@ pywavelets==1.4.1
 # it here because 1.5.0 conflicts with numpy 1.21.2 used in CI
 #Pinned versions: 1.4.1
 #test that import:
+
+lxml==4.9.4
+#Description: This is a requirement of unittest-xml-reporting
+# have to pin to 4.9.4 because 5.0.0 release on Dec 29th missing
+# Python-3.9 binaries


### PR DESCRIPTION
By pinning lxml to 4.9.4 as 5.0.0 is missing Python-3.9 binaries, see https://pypi.org/project/lxml/5.0.0/#files
<img width="568" alt="image" src="https://github.com/pytorch/pytorch/assets/2453524/fbd64512-b788-4bf6-9c1f-084dcedfd082">

Pull Request resolved: https://github.com/pytorch/pytorch/pull/116549
Approved by: https://github.com/houseroad, https://github.com/aakhundov

(cherry picked from commit bd7d26bb964ef08354771d19fa7d70d539f97c81)

Fixes #ISSUE_NUMBER
