### PR TITLE
[BE]: Use exist_ok arg for os.makedirs calls

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -362,8 +362,7 @@ def reset_graph_break_dup_checker():
 
 def add_file_handler():
     log_path = os.path.join(get_debug_dir(), "torchdynamo")
-    if not os.path.exists(log_path):
-        os.makedirs(log_path)
+    os.makedirs(log_path, exist_ok=True)
 
     log_file_handler = logging.FileHandler(os.path.join(log_path, "debug.log"))
     logger = logging.getLogger("torch._dynamo")

--- a/torch/_functorch/compilers.py
+++ b/torch/_functorch/compilers.py
@@ -380,9 +380,7 @@ def _save_fx_default(current_name, folder_name, dump_example_input, gm, example_
 
         input_meta = get_input_meta(args)
 
-        isExist = os.path.exists(f"{folder_name}/{current_name}")
-        if not isExist:
-            os.makedirs(f"{folder_name}/{current_name}")
+        os.makedirs(f"{folder_name}/{current_name}", exist_ok=True)
         gm.to_folder(
             f"{folder_name}/{current_name}/{current_name}_{type_name}_{graph_index}"
         )

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1938,8 +1938,7 @@ class CppWrapperCodeCache:
     def load(cls, source_code: str, func_name: str, key: str, cuda: bool) -> CDLL:
         name = f"inline_extension_{key}"
         cpp_wrapper_dir = cpp_wrapper_cache_dir(name)
-        if not os.path.exists(cpp_wrapper_dir):
-            os.makedirs(cpp_wrapper_dir)
+        os.makedirs(cpp_wrapper_dir, exist_ok=True)
 
         ext = "so"
         filepath = os.path.join(cpp_wrapper_dir, f"{name}.{ext}")

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -273,8 +273,7 @@ def enable_aot_logging():
     stack.enter_context(patch("functorch.compile.config.debug_partitioner", True))
 
     path = os.path.join(get_debug_dir(), "torchinductor")
-    if not os.path.exists(path):
-        os.makedirs(path)
+    os.makedirs(path, exist_ok=True)
 
     fh = logging.FileHandler(
         os.path.join(

--- a/torch/ao/pruning/_experimental/data_sparsifier/benchmarks/evaluate_disk_savings.py
+++ b/torch/ao/pruning/_experimental/data_sparsifier/benchmarks/evaluate_disk_savings.py
@@ -55,8 +55,7 @@ def save_model_states(state_dict, sparsified_model_dump_path, save_file_name, sp
     model_state = state_dict['state_dict']
     model_state_path = os.path.join(folder_name, folder_str, save_file_name)
 
-    if not os.path.exists(os.path.dirname(model_state_path)):
-        os.makedirs(os.path.dirname(model_state_path))
+    os.makedirs(os.path.dirname(model_state_path), exist_ok=True)
     torch.save(model_state, model_state_path)
 
     if zip:

--- a/torch/hub.py
+++ b/torch/hub.py
@@ -201,8 +201,7 @@ def _validate_not_a_forked_repo(repo_owner, repo_name, ref):
 def _get_cache_or_reload(github, force_reload, trust_repo, calling_fn, verbose=True, skip_validation=False):
     # Setup hub_dir to save downloaded files
     hub_dir = get_dir()
-    if not os.path.exists(hub_dir):
-        os.makedirs(hub_dir)
+    os.makedirs(hub_dir, exist_ok=True)
     # Parse github repo information
     repo_owner, repo_name, ref = _parse_repo_info(github)
     # Github allows branch name with slash '/',
@@ -742,15 +741,7 @@ def load_state_dict_from_url(
         hub_dir = get_dir()
         model_dir = os.path.join(hub_dir, 'checkpoints')
 
-    try:
-        os.makedirs(model_dir)
-    except OSError as e:
-        if e.errno == errno.EEXIST:
-            # Directory already exists, ignore.
-            pass
-        else:
-            # Unexpected OSError, re-raise.
-            raise
+    os.makedirs(model_dir, exist_ok=True)
 
     parts = urlparse(url)
     filename = os.path.basename(parts.path)

--- a/torch/testing/_internal/optests/generate_tests.py
+++ b/torch/testing/_internal/optests/generate_tests.py
@@ -711,8 +711,7 @@ def generate_repro(
         unix_timestamp = datetime.datetime.timestamp(now) * 100000
         filepath = os.path.join(path, f"repro_{unix_timestamp}.pt")
         if not dry_run:
-            if not os.path.exists(path):
-                os.makedirs(path)
+            os.makedirs(path, exist_ok=True)
             torch.save((args, kwargs), filepath)
         args_kwargs = f'args, kwargs = torch.load("{filepath}")'
     else:


### PR DESCRIPTION
Optimize os.makedirs calls to use exist_ok parameter when possible to avoid unnecessary checks.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler