### PR TITLE
[Sparse] Re-enable `test_sampled_addmm_zero_sized`

### DIFF
--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -2468,7 +2468,6 @@ class TestSparseCSR(TestCase):
 
     @skipCUDAIfRocm
     @onlyCUDA
-    @skipCUDAIf(True, "Causes CUDA memory exception, see https://github.com/pytorch/pytorch/issues/72177")
     @skipCUDAIf(
         not _check_cusparse_sddmm_available(),
         "cuSparse Generic API SDDMM is not available"


### PR DESCRIPTION
That was disabled due to https://github.com/pytorch/pytorch/issues/72177 , that supposed to be fixed more than a year ago

Will close the PR and re-open the issue if it starts to fail