### PR TITLE
[MPS][BE] Refactor common code

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -323,4 +323,20 @@ inline bool is_dense_in_storage(const at::Tensor& t) {
   return compute_storage_numel_distance(t) == static_cast<size_t>(t.numel());
 }
 
+static inline void mtl_setBuffer(id<MTLComputeCommandEncoder> encoder, const Tensor& t, unsigned idx) {
+  [encoder setBuffer:getMTLBufferStorage(t)
+              offset:t.storage_offset() * t.element_size()
+             atIndex:idx];
+}
+
+static inline void mtl_dispatch1DJob(id<MTLComputeCommandEncoder> encoder,
+                                     id<MTLComputePipelineState> cplState,
+                                     uint32_t length) {
+  const uint32_t maxThreadsPerGroup = [cplState maxTotalThreadsPerThreadgroup];
+  auto size = MTLSizeMake(length, 1, 1);
+  auto threadGroupSize = MTLSizeMake(std::min(maxThreadsPerGroup, length), 1, 1);
+  [encoder dispatchThreads:size threadsPerThreadgroup:threadGroupSize];
+}
+
+
 } // namespace at::native::mps

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -338,5 +338,4 @@ static inline void mtl_dispatch1DJob(id<MTLComputeCommandEncoder> encoder,
   [encoder dispatchThreads:size threadsPerThreadgroup:threadGroupSize];
 }
 
-
 } // namespace at::native::mps

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -84,8 +84,6 @@ static bool dispatchIndexKernel(TensorIteratorBase& iter,
 
   const Tensor& inputTensor = iter.tensor(1);
   Tensor outputTensor = iter.tensor(0);
-  id<MTLBuffer> inputBuffer = getMTLBufferStorage(inputTensor);
-  id<MTLBuffer> outputBuffer = getMTLBufferStorage(outputTensor);
   MPSStream* mpsStream = getCurrentMPSStream();
   id<MTLDevice> device = MPSDevice::getInstance()->device();
 
@@ -126,13 +124,7 @@ static bool dispatchIndexKernel(TensorIteratorBase& iter,
       [computeEncoder setBytes:&nDim length:sizeof(uint32_t) atIndex:3];
       [computeEncoder setBytes:&nOffsets length:sizeof(uint32_t) atIndex:4];
 
-      NSUInteger kernelOffsetsTGSize = kernelDataOffsetsPSO.maxTotalThreadsPerThreadgroup;
-      if (kernelOffsetsTGSize > numThreads) {
-        kernelOffsetsTGSize = numThreads;
-      }
-
-      MTLSize kernelOffsetsThreadGroupSize = MTLSizeMake(kernelOffsetsTGSize, 1, 1);
-      [computeEncoder dispatchThreads:gridSize threadsPerThreadgroup:kernelOffsetsThreadGroupSize];
+      mtl_dispatch1DJob(computeEncoder, kernelDataOffsetsPSO, numThreads);
 
       std::string indexFunction =
           getIndexFunctionName(inputTensor.scalar_type(), index_select, accumulate, serial_index_put);
@@ -184,10 +176,8 @@ static bool dispatchIndexKernel(TensorIteratorBase& iter,
       [computeEncoder setBytes:index_size.data() length:sizeof(index_size[0]) * index_size.size() atIndex:1];
       [computeEncoder setBytes:index_stride.data() length:sizeof(index_stride[0]) * index_stride.size() atIndex:2];
       [computeEncoder setBuffer:kernelDataOffsets offset:0 atIndex:3];
-      [computeEncoder setBuffer:inputBuffer offset:inputTensor.storage_offset() * inputTensor.element_size() atIndex:4];
-      [computeEncoder setBuffer:outputBuffer
-                         offset:outputTensor.storage_offset() * outputTensor.element_size()
-                        atIndex:5];
+      mtl_setBuffer(computeEncoder, inputTensor, 4);
+      mtl_setBuffer(computeEncoder, outputTensor, 5);
       [computeEncoder setBytes:&num_indices length:sizeof(uint32_t) atIndex:6];
       if (serial_index_put) {
         [computeEncoder setBytes:&numIters length:sizeof(numIters) atIndex:7];

--- a/aten/src/ATen/native/mps/operations/RenormKernel.mm
+++ b/aten/src/ATen/native/mps/operations/RenormKernel.mm
@@ -111,19 +111,10 @@ void renorm_out_mps(const Tensor& self, const Scalar& p, int64_t dim, const Scal
       getMPSProfiler().beginProfileKernel(renormPSO, key, {norm});
 
       [computeEncoder setComputePipelineState:renormPSO];
-      [computeEncoder setBuffer:normBuffer offset:norm.storage_offset() * norm.element_size() atIndex:0];
-      [computeEncoder setBuffer:factorBuffer offset:factor.storage_offset() * factor.element_size() atIndex:1];
+      mtl_setBuffer(computeEncoder, norm, 0);
+      mtl_setBuffer(computeEncoder, factor, 1);
       [computeEncoder setBytes:&maxnorm_f length:sizeof(float) atIndex:2];
-
-      uint32_t numThreads = norm.numel();
-      MTLSize gridSize = MTLSizeMake(numThreads, 1, 1);
-      NSUInteger tgSize = renormPSO.maxTotalThreadsPerThreadgroup;
-      if (tgSize > numThreads) {
-        tgSize = numThreads;
-      }
-      MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
-
-      [computeEncoder dispatchThreads:gridSize threadsPerThreadgroup:threadGroupSize];
+      mtl_dispatch1DJob(computeEncoder, renormPSO, norm.numel());
 
       getMPSProfiler().endProfileKernel(renormPSO);
     }


### PR DESCRIPTION
Introduce `mtl_setBuffer` and `mps_dispatch1DJob` and use it to bind
Tensor to metal kernel as well as disptatch Metal job

This avoids potential typos/bugs when one tries to bind tensor to a
Metal kernel but forgets about storage offset

