### PR TITLE
include stdint.h

### DIFF
--- a/torch/csrc/jit/operator_upgraders/utils.h
+++ b/torch/csrc/jit/operator_upgraders/utils.h
@@ -4,6 +4,7 @@
 #include <torch/csrc/jit/operator_upgraders/version_map.h>
 #include <string>
 #include <vector>
+#include <stdint.h>
 
 namespace torch::jit {
 


### PR DESCRIPTION
Fixes this build error
.../pytorch/torch/csrc/jit/operator_upgraders/utils.h:43:11: error: unknown type name 'uint64_t'
   43 | TORCH_API uint64_t getMaxOperatorVersion();
      |           ^

Fixes #ISSUE_NUMBER
