### PR TITLE
[Doc] Update `torch_cuda_memory.rst` to fix header ref in the doc page

### DIFF
--- a/docs/source/torch_cuda_memory.rst
+++ b/docs/source/torch_cuda_memory.rst
@@ -9,7 +9,7 @@ The generated snapshots can then be drag and dropped onto the interactiver viewe
 can be used to explore the snapshot.
 
 Generating a Snapshot
-=====================
+---------------------
 The common pattern for recording a snapshot is to enable memory history, run the code to be observed, and then save a file with a pickled snapshot:
 
 .. code-block:: python
@@ -22,14 +22,14 @@ The common pattern for recording a snapshot is to enable memory history, run the
    torch.cuda.memory._dump_snapshot("my_snapshot.pickle")
 
 Using the visualizer
-====================
+--------------------
 
 Open `pytorch.org/memory_viz <https://pytorch.org/memory_viz>`_ and drag/drop the pickled snapshot file into the visualizer.
 The visualizer is a javascript application that runs locally on your computer. It does not upload any snapshot data.
 
 
 Active Memory Timeline
-----------------------
+^^^^^^^^^^^^^^^^^^^^^^
 
 The Active Memory Timeline shows all the live tensors over time in the snapshot on a particular GPU. Pan/Zoom over the plot to look at smaller allocations.
 Mouse over allocated blocks to see a stack trace for when that block was allocated, and details like its address. The detail slider can be adjusted to
@@ -39,7 +39,7 @@ render fewer allocations and improve performance when there is a lot of data.
 
 
 Allocator State History
------------------------
+^^^^^^^^^^^^^^^^^^^^^^^
 
 The Allocator State History shows individual allocator events in a timeline on the left. Select an event in the timeline to see a visual summary of the
 allocator state at that event. This summary shows each individual segment returned from cudaMalloc and how it is split up into blocks of individual allocations
@@ -55,7 +55,7 @@ This unique string can be looked up in the Active Memory Timeline and searched
 in the Active State History to examine the memory state when a tensor was allocated or freed.
 
 Snapshot API Reference
-======================
+----------------------
 
 .. currentmodule:: torch.cuda.memory
 .. autofunction:: _record_memory_history


### PR DESCRIPTION
In the current (v2.1.0) doc web page, these headers should be under the `Understanding CUDA Memory Usage` section.

![image](https://github.com/yaox12/pytorch/assets/3831900/72d41f20-e6e5-4cab-860a-47ead0ce6a40)
