### PR TITLE
Separate unshard stream for each process group with FSDP

### DIFF
--- a/torch/cpu/__init__.py
+++ b/torch/cpu/__init__.py
@@ -58,6 +58,7 @@ class Stream:
     """
 
     def __init__(self, priority: int = -1):
+        self.priority = priority
         pass
 
     def wait_stream(self, stream) -> None:

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -145,6 +145,7 @@ class _FSDPState(_State):
         # All following attributes should only be used for root states:
         # Save these static lists to avoid the repeated tree traversals
         self._all_fsdp_states: List[_FSDPState] = []
+        self._all_unshard_streams: set[torch.Stream] = set()
         self._all_handles: List[flat_param_file.FlatParamHandle] = []
         self._fsdp_extension: Optional[FSDPExtensions] = None
 

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -145,7 +145,7 @@ class _FSDPState(_State):
         # All following attributes should only be used for root states:
         # Save these static lists to avoid the repeated tree traversals
         self._all_fsdp_states: List[_FSDPState] = []
-        self._all_unshard_streams: set[torch.Stream] = set()
+        self._all_unshard_streams: Set[torch.Stream] = set()
         self._all_handles: List[flat_param_file.FlatParamHandle] = []
         self._fsdp_extension: Optional[FSDPExtensions] = None
 

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -303,7 +303,6 @@ def _share_state_and_init_handle_attrs(
         fsdp_state._default_stream = root_state._default_stream
         fsdp_state._exec_order_data = root_state._exec_order_data
         fsdp_state._free_event_queue = root_state._free_event_queue
-        fsdp_state._device_mesh = root_state._device_mesh
         handle = fsdp_state._handle
         if handle:
             handle.init_flat_param_attributes()

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -638,7 +638,7 @@ def _root_pre_forward(
             for handle in handles:
                 handle._needs_pre_forward_unshard = True
                 handle._prefetched = False
-        
+
         _wait_for_computation_stream(
             state._device_handle.current_stream(),
             state,

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -52,6 +52,36 @@ class _PrefetchMode(Enum):
     BACKWARD = auto()
     FORWARD = auto()
 
+def fsdp_state_has_default_pg(state: _FSDPState) -> bool:
+    """Indicates whether FlatParamHandle has the default process group.
+
+    Args:
+        handle (_FSDPState): FSDP State object
+
+    Returns:
+        bool: True if the ProcessGroup of the _FSDPState object is the default process group. False
+            otherwise.
+    """
+    from torch.distributed.distributed_c10d import get_process_group_ranks
+    if state.process_group is None:
+        # If no process group is attached to the _FSDPState, assume it uses default process group.
+        return True
+    return len(get_process_group_ranks(
+        state.process_group)) == dist.get_world_size()
+
+
+def fsdp_state_pg_ranks(state: _FSDPState) -> Tuple[int]:
+    """Gets the ranks included in the ProcessGroup of an _FSDPState.
+
+    Args:
+        state (_FSDPState): FSDP State object
+
+    Returns:
+        Tuple[int]: Ranks for the FSDP State's process group.
+    """
+    from torch.distributed.distributed_c10d import get_process_group_ranks
+    return tuple(get_process_group_ranks(state.process_group))
+
 
 def _get_fsdp_root_states_with_modules(
     module: nn.Module,
@@ -200,11 +230,14 @@ def _share_state_and_init_handle_attrs(
     root_state: _FSDPState,
     root_module: nn.Module,
 ) -> None:
-    """
-    Shares data structure state from the ``root_state`` to all FSDP states in
-    ``root_module`` 's module tree, and initializes handle attributes. These
-    are done together to require a single loop over the states.
-    """
+    """Shares data structure state from the ``root_state`` to all FSDP states in
+    ``root_module`` 's module tree, and initializes handle attributes. These are
+    done together to require a single loop over the states."""
+    from torch.distributed.fsdp._runtime_utils import (
+        HOMOGENEOUS_ATTR_NAMES, _init_device_mesh,
+        _validate_and_get_hybrid_shard_state)
+    from torch.distributed.utils import _p_assert
+
     handle = root_state._handle
     if handle:
         handle.init_flat_param_attributes()
@@ -213,23 +246,25 @@ def _share_state_and_init_handle_attrs(
     for attr_name in HOMOGENEOUS_ATTR_NAMES:
         attr_name_to_values[attr_name] = set()
     root_state._all_handles = root_state._exec_order_data.all_handles  # share reference
+    root_state._device_mesh = _init_device_mesh(root_state)
     # Update _has_optim_in_backward for each handle.
     for handle in root_state._all_handles:
         flat_param = handle.flat_param
-        if hasattr(flat_param, "_in_backward_optimizers"):
+        if hasattr(flat_param, '_in_backward_optimizers'):
             raise RuntimeError(
-                "FSDP optimizer in backward only supported with use_orig_params=True!"
+                'FSDP optimizer in backward only supported with use_orig_params=True!'
             )
         handle._has_optim_in_backward = flat_param._params is not None and any(
-            hasattr(param, "_in_backward_optimizers") for param in flat_param._params
-        )
-        if handle._has_optim_in_backward:
-            torch._C._log_api_usage_once("fsdp.optimizer_in_backward")
+            hasattr(param, '_in_backward_optimizers')
+            for param in flat_param._params)
+    # Keep track of any new unshard streams we may have to add for specific process groups.
+    fsdp_pg_unshard_streams = {}
+    unshard_priority = root_state._unshard_stream.priority
     for fsdp_state in root_state._all_fsdp_states:
         for attr_name in HOMOGENEOUS_ATTR_NAMES:
             _p_assert(
                 hasattr(fsdp_state, attr_name),
-                f"FSDP state missing attribute {attr_name}",
+                f'FSDP state missing attribute {attr_name}',
             )
             attr_name_to_values[attr_name].add(getattr(fsdp_state, attr_name))
         if fsdp_state is root_state:
@@ -240,23 +275,43 @@ def _share_state_and_init_handle_attrs(
         _p_assert(
             fsdp_state._is_root is None or not fsdp_state._is_root,
             "Non-root FSDP instance's `_is_root` should not have been "
-            "set yet or should have been set to `False`",
+            'set yet or should have been set to `False`',
         )
         fsdp_state._is_root = False
-        fsdp_state._unshard_stream = root_state._unshard_stream
+
+        # Take care of any new unshard streams we have to create for non-default process groups.
+        if fsdp_state_has_default_pg(fsdp_state):
+            # If using default process group, unshard stream is the same as root fsdp instance.
+            fsdp_state._unshard_stream = root_state._unshard_stream
+        else:
+            # Otherwise, unshard stream is separate.
+            state_pg_ranks = fsdp_state_pg_ranks(fsdp_state)
+            if state_pg_ranks in fsdp_pg_unshard_streams:
+                # We have created the unshard stream for this process group already. Use it.
+                fsdp_state._unshard_stream = fsdp_pg_unshard_streams[
+                    state_pg_ranks]
+            else:
+                # We don't have an unshard stream for this process group yet. Make it.
+                fsdp_state._unshard_stream = fsdp_state._device_handle.Stream(
+                    priority=unshard_priority)
+                fsdp_pg_unshard_streams[
+                    state_pg_ranks] = fsdp_state._unshard_stream
+
+        # All other stream assignments stay common across all of FSDP.
         fsdp_state._post_backward_stream = root_state._post_backward_stream
         fsdp_state._pre_unshard_stream = root_state._pre_unshard_stream
         fsdp_state._all_reduce_stream = root_state._all_reduce_stream
         fsdp_state._default_stream = root_state._default_stream
         fsdp_state._exec_order_data = root_state._exec_order_data
         fsdp_state._free_event_queue = root_state._free_event_queue
+        fsdp_state._device_mesh = root_state._device_mesh
         handle = fsdp_state._handle
         if handle:
             handle.init_flat_param_attributes()
     for attr_name, attr_values in attr_name_to_values.items():
         if len(attr_values) != 1:
             raise ValueError(
-                f"Expects one homogeneous value for {attr_name} but got {attr_values}"
+                f'Expects one homogeneous value for {attr_name} but got {attr_values}'
             )
 
 


### PR DESCRIPTION
This PR gives each `_FSDPState` with a separate process group its own unshard stream. This addresses an issue we have been seeing with overlapping communication and computation when doing 2D parallelism with FSDP.

Essentially, the whole model is sharded across all ranks, and communication is done over the default process group which contains all ranks. We 2D parallelize the model by sharding a subset of the parameters over distinct process groups. For example, with 16 GPUs, most of the model is sharded across all 16 GPUs, but some parameters are sharded across groups of 4 GPUs, and replicated 4 times. So GPU 0 will be part of the default process group, but also another process group that includes ranks 0, 1, 2, 3. For these parameters, all-gathers and reduce-scatters are done with this new process group. We FSDP wrap the parent class with the default process group, but also wrap these parameters with the new process group.

The issue arises because FSDP normally sets the same unshard stream for all `_FSDPState` objects, meaning that the default computation stream will wait on any communication kernels that are currently in the unshard stream. As far as I understand, with just one process group, this is necessary because we need to wait for parameters to be all-gathered before proceeding with computation. However, with >1 process group, we find that computation will wait for parameters to be unsharded even when those parameters are not needed for that computation. In both the forwards and backwards passes, this results in the computation stream excessively waiting for all-gathers that do not need to be waited on.

This PR has a solution to the above issue. For each process group attached to any `_FSDPState`, we assign a new unshard stream. With this, the computation stream only waits on all-gather ops that are actually necessary for that computation to proceed. With 2D parallelism, computation that requires unsharding parameters from all ranks (using the default process group) will only wait on all-gathers that use the default process group, while computation that requires unsharding parameters from ranks in the custom process group will only wait on all-gathers from the custom process group. This eliminates bubbles where computation and communication overlap, and according to our tests, improves training efficiency by up to 25% at scale.

There are definitely many ways to address this so we wanted to get input on how to best solve this, and how this can be addressed in the upcoming FSDP rewrite and in support for 2D parallelism. Given the discussions [here](https://github.com/NVIDIA/nccl/issues/195) and [here](https://github.com/NVIDIA/nccl/issues/195) there may be some risks involved in the current approach with using multiple NCCL communicators concurrently, since each process group may have its own NCCL communicator (unsure about this though). FWIW in our testing we have not seen any hangs and training has been identical before and after the change. It also may be possible to FSDP wrap our model differently to make sure that communications are queued at the right time.

Looking forward to discussing this further and helping with a fix!

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen