### PR TITLE
Fix implicit conversion to double

### DIFF
--- a/c10/util/order_preserving_flat_hash_map.h
+++ b/c10/util/order_preserving_flat_hash_map.h
@@ -582,8 +582,9 @@ class sherwood_v3_table : private EntryAlloc, private Hasher, private Equal {
   void rehash(uint64_t num_buckets) {
     num_buckets = std::max(
         num_buckets,
-        static_cast<uint64_t>(
-            std::ceil(num_elements / static_cast<double>(_max_load_factor))));
+        static_cast<uint64_t>(std::ceil(
+            static_cast<double>(num_elements) /
+            static_cast<double>(_max_load_factor))));
     if (num_buckets == 0) {
       reset_to_empty_state();
       return;
@@ -904,8 +905,9 @@ class sherwood_v3_table : private EntryAlloc, private Hasher, private Equal {
       Args&&... args) {
     using std::swap;
     if (num_slots_minus_one == 0 || distance_from_desired == max_lookups ||
-        num_elements + 1 >
-            (num_slots_minus_one + 1) * static_cast<double>(_max_load_factor)) {
+        static_cast<double>(num_elements + 1) >
+            static_cast<double>(num_slots_minus_one + 1) *
+                static_cast<double>(_max_load_factor)) {
       grow();
       return emplace(std::forward<Key>(key), std::forward<Args>(args)...);
     } else if (current_entry->is_empty()) {


### PR DESCRIPTION
Summary:
Forward fix for https://github.com/pytorch/pytorch/pull/116185 / D52390113

Error:
```
xplat/caffe2/c10/util/order_preserving_flat_hash_map.h:602:23: error: implicit conversion from 'uint64_t' (aka 'unsigned long long') to 'double' may lose precision [-Werror,-Wimplicit-int-float-conversion]
[CONTEXT]             std::ceil(num_elements / static_cast<double>(_max_load_factor))));
[CONTEXT]                       ^~~~~~~~~~~~ ~
xplat/caffe2/c10/util/order_preserving_flat_hash_map.h:923:22: error: implicit conversion from 'uint64_t' (aka 'unsigned long long') to 'double' may lose precision [-Werror,-Wimplicit-int-float-conversion]
[CONTEXT]         num_elements + 1 >
[CONTEXT]         ~~~~~~~~~~~~~^~~ ~
xplat/caffe2/c10/util/order_preserving_flat_hash_map.h:924:34: error: implicit conversion from 'uint64_t' (aka 'unsigned long long') to 'double' may lose precision [-Werror,-Wimplicit-int-float-conversion]
[CONTEXT]             (num_slots_minus_one + 1) * static_cast<double>(_max_load_factor)) {
[CONTEXT]              ~~~~~~~~~~~~~~~~~~~~^~~  ~
xplat/caffe2/c10/util/order_preserving_flat_hash_map.h:923:22: error: implicit conversion from 'uint64_t' (aka 'unsigned long long') to 'double' may lose precision [-Werror,-Wimplicit-int-float-conversion]
[CONTEXT]         num_elements + 1 >
[CONTEXT]         ~~~~~~~~~~~~~^~~ ~
xplat/caffe2/c10/util/order_preserving_flat_hash_map.h:924:34: error: implicit conversion from 'uint64_t' (aka 'unsigned long long') to 'double' may lose precision [-Werror,-Wimplicit-int-float-conversion]
[CONTEXT]             (num_slots_minus_one + 1) * static_cast<double>(_max_load_factor)) {
[CONTEXT]              ~~~~~~~~~~~~~~~~~~~~^~~  ~
xplat/caffe2/c10/util/order_preserving_flat_hash_map.h:923:22: error: implicit conversion from 'uint64_t' (aka 'unsigned long long') to 'double' may lose precision [-Werror,-Wimplicit-int-float-conversion]
[CONTEXT]         num_elements + 1 >
[CONTEXT]         ~~~~~~~~~~~~~^~~ ~
xplat/caffe2/c10/util/order_preserving_flat_hash_map.h:924:34: error: implicit conversion from 'uint64_t' (aka 'unsigned long long') to 'double' may lose precision [-Werror,-Wimplicit-int-float-conversion]
[CONTEXT]             (num_slots_minus_one + 1) * static_cast<double>(_max_load_factor)) {
```

Fixed by casting int parts to double explicitly.

Test Plan: SC

Differential Revision: D52482968

