### PR TITLE
ci: Output runner OS / HW for macOS

### DIFF
--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -58,6 +58,11 @@ jobs:
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
       PR_BODY: ${{ github.event.pull_request.body }}
     steps:
+      - name: Print runner OS/HW info
+        shell: arch -arch arm64 bash {0}
+        run: |
+          sysctl machdep.cpu.brand_string kern.osproductversion
+
       - name: Clean up leftover processes on MacOS pet runner
         continue-on-error: true
         run: |


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #116627

It's difficult to debug these since there's no understanding of what the
OS / HW that we're running CI on so output it so we can have a better
understanding here.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>