### PR TITLE
Build PyTorch without relaxed-constexpr rule

### DIFF
--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -383,9 +383,6 @@ elseif(CUDA_DEVICE_DEBUG)
   list(APPEND CUDA_NVCC_FLAGS "-g" "-G")  # -G enables device code debugging symbols
 endif()
 
-# Set expt-relaxed-constexpr to suppress Eigen warnings
-list(APPEND CUDA_NVCC_FLAGS "--expt-relaxed-constexpr")
-
 # Set expt-extended-lambda to support lambda on device
 list(APPEND CUDA_NVCC_FLAGS "--expt-extended-lambda")
 


### PR DESCRIPTION
We are not doing it internally, we should not be doing it in OSS

Keeping this option allows one to add GPU function that calls CPU function which is not something we want to do in ATen in general

Fixes https://github.com/pytorch/pytorch/issues/116628
