### PR TITLE
[c10d] Add extra sleep in waitForDumpOrTimeout to ensure enough time for all ranks dump debug info

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -70,6 +70,9 @@ static std::vector<std::string> TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC = {
 static std::vector<std::string> TORCH_NCCL_TRACE_BUFFER_SIZE = {
     "TORCH_NCCL_TRACE_BUFFER_SIZE"};
 
+static std::vector<std::string> TORCH_NCCL_WAIT_TIMEOUT_DUMP_SLEEP_MILSEC = {
+    "TORCH_NCCL_WAIT_TIMEOUT_DUMP_SLEEP_MILSEC"};
+
 constexpr const char* NCCL_BACKEND_NAME = "nccl";
 
 constexpr const char* TIMEOUT_DUMP = "timeout_dump";
@@ -750,6 +753,9 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // Logs on timeout, and asserts the future's status is as expected.
   void waitForDumpOrTimeout(std::future<bool>& fut, size_t timeout_sec = 30);
 
+  // Helper to have extra sleep so that dumps from all ranks finish.
+  void extraSleepForDumpWait();
+
   // When watchdog timeout, this function will be called and return debug info
   // for users. For now we only get information from retrieveDesyncReport.
   // We are working on enabling more useful debug information for watchdog
@@ -823,6 +829,9 @@ class TORCH_API ProcessGroupNCCL : public Backend {
 
   // The time interval used for deciding whether there is no watchdog heartbeat.
   int heartbeatTimeoutInSec_;
+
+  // Extra time of sleep when waiting for timeout dump to finish.
+  int waitTimeoutDumpSleepInMilSec_;
 
   // Size of ring buffer where we store NCCL Traces for debugging.
   int ncclTraceBufferSize_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #116660
* #116659
* #116658



cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @wz337 @tianyu-l @wconstab @yf225