### PR TITLE
[export] Allow None as the meta value for tensor output.

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -2138,6 +2138,17 @@ def forward(self, l_x_):
         self.assertEqual(inputs[0][0] * 2.0, inputs_model[0][0])
         self.assertEqual(inputs[0][0] * 2.0, inputs_export[0][0])
 
+    def test__scaled_dot_product_flash_attention(self):
+        class Module(torch.nn.Module):
+            def forward(self, q, k, v):
+                res = torch.ops.aten._scaled_dot_product_flash_attention.default(q, k, v)
+                return res[0]
+
+        m = Module()
+        inputs = (torch.randn(5, 4, 3, 2), torch.randn(5, 4, 3, 2), torch.randn(5, 4, 3, 2))
+        ep = export(m, inputs)
+        self.assertEqual(ep(*inputs), m(*inputs))
+
     @testing.expectedFailureSerDer  # symfloat nyi
     @testing.expectedFailureRetraceability
     def test_sym_sqrt(self):

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -859,7 +859,9 @@ class GraphModuleSerializer:
         output_arguments = []
         for idx, (meta, return_schema) in enumerate(zip(meta_val, returns)):
             if meta is None:
-                assert isinstance(return_schema.real_type, torch.OptionalType)
+                assert isinstance(return_schema.real_type, (torch.OptionalType, torch.TensorType))
+                # When the return type is annoated as Tensor type, the op can also return an
+                # undefined Tensor which will be implicitly converted to None in Python.
                 output_arguments.append(Argument.create(as_none=()))
             elif isinstance(meta, torch._subclasses.fake_tensor.FakeTensor):
                 assert isinstance(return_schema.real_type, torch.TensorType)


### PR DESCRIPTION
Summary: Sometimes we will get a None value from ops which returns Tensor type in the schema. Allow this case during serialization.

Test Plan: test__scaled_dot_product_flash_attention

Differential Revision: D52491668


