### PR TITLE
Fix buck build after recent clang-tidy updates

### DIFF
--- a/torch/csrc/jit/operator_upgraders/utils.h
+++ b/torch/csrc/jit/operator_upgraders/utils.h
@@ -2,6 +2,7 @@
 #include <c10/macros/Export.h>
 #include <c10/util/Optional.h>
 #include <torch/csrc/jit/operator_upgraders/version_map.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Broken after either https://github.com/pytorch/pytorch/pull/116486 or https://github.com/pytorch/pytorch/pull/116353 I think.  Here is an example build failure https://hud.pytorch.org/pytorch/pytorch/commit/0bc21c6a6be5697861c966f82eab223d99951eef