### PR TITLE
Remove hardcoding arch to arm64

### DIFF
--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -59,7 +59,6 @@ jobs:
       PR_BODY: ${{ github.event.pull_request.body }}
     steps:
       - name: Print runner OS/HW info
-        shell: arch -arch arm64 bash {0}
         run: |
           sysctl machdep.cpu.brand_string kern.osproductversion
 
@@ -78,8 +77,6 @@ jobs:
             echo "Cleaning up ${dir}"
             rm -rf "${dir}"
           done
-
-
 
       - name: Clean up disk space before running MacOS workflow
         uses: pytorch/test-infra/.github/actions/check-disk-space@main


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/116627 hardcodes arch to arm64 and it's failing on x86 GitHub runner (yup, they are still there on periodic, we haven't pulled the plug yet).

https://github.com/pytorch/pytorch/actions/runs/7392059632/job/20112760709#step:2:12 is an example failure.

There is no need to set the arch here because it has already been set earlier in the workflow https://github.com/pytorch/pytorch/blob/main/.github/workflows/_mac-test.yml#L47
