### PR TITLE
adapt to other acceleration devices

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -3080,7 +3080,7 @@ Tensor& linalg_eigvals_out(const Tensor& input, Tensor& values) {
 
   // because MAGMA's GEEV takes CPU inputs and returns CPU outputs
   // 'values' tensor that is on GPU device can't be used directly
-  values_tmp_needed |= values.is_cuda();
+  values_tmp_needed |= (!values.is_cpu());
 
   // determine the appropriate scalar_type for the temporary tensors
   ScalarType values_type = input.scalar_type();


### PR DESCRIPTION
Fixes #116504

When this API is invoked, a runtime error occurs. When the NPU acceleration device is used, the input tensor is not processed at a branch. As a result, some input tensors are on the CPU and some are on the NPU. As a result, an error is reported.
Here, I adapt to other acceleration devices and move the tensor on the acceleration device to the CPU. It's tested and feasible.

The details are in the issue：#116504
