### PR TITLE
[inductor] Add ABI shim function for torch.scatter_reduce

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1330,6 +1330,27 @@ class AOTInductorTestsTemplate:
 
         self.check_model(Model(), inputs)
 
+    def test_scatter_reduce_fallback(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(
+                self,
+                inp: torch.Tensor,
+                index: torch.Tensor,
+                src: torch.Tensor,
+            ):
+                return torch.scatter_reduce(inp, 0, index, src, reduce="sum")
+
+        inputs = (
+            torch.tensor([1, 10, 100, 1000], device=self.device, dtype=torch.int64),
+            torch.tensor([0, 1, 0, 1, 2, 1], device=self.device, dtype=torch.int64),
+            torch.tensor([1, 2, 3, 4, 5, 6], device=self.device, dtype=torch.int64),
+        )
+
+        self.check_model(Model(), inputs)
+
     def test_convolution(self):
         class Model(torch.nn.Module):
             def __init__(self):
@@ -1515,7 +1536,8 @@ CPU_TEST_FAILURES = {
     # There is a double-free issue which will be fixed in another PR
     "test_repeat_output": fail_with_and_without_stack_allocation(is_skip=True),
     # the test segfaults
-    "test_scatter_fallback": fail_with_and_without_stack_allocation(is_skip=True),
+    "test_scatter_fallback": fail_stack_allocation(is_skip=True),
+    "test_scatter_reduce_fallback": fail_stack_allocation(is_skip=True),
     # Minimal arrayref interface doesn't support bfloat16 yet.
     "test_sdpa": fail_minimal_arrayref_interface(is_skip=True),
     # Minimal arrayref interface doesn't support bfloat16 yet.

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -322,6 +322,15 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_scatter_out(
     AtenTensorHandle index,
     AtenTensorHandle src);
 
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_scatter_reduce_out(
+    AtenTensorHandle out,
+    AtenTensorHandle self,
+    int64_t dim,
+    AtenTensorHandle index,
+    AtenTensorHandle src,
+    const char* reduce,
+    int32_t include_self);
+
 #ifdef USE_CUDA
 
 struct CUDAStreamGuardOpaque;

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -28,6 +28,7 @@
 #include <ATen/ops/mm.h>
 #include <ATen/ops/nonzero.h>
 #include <ATen/ops/scatter.h>
+#include <ATen/ops/scatter_reduce.h>
 
 #endif
 
@@ -610,6 +611,30 @@ AOTITorchError aoti_torch_scatter_out(
     at::Tensor* index_tensor = tensor_handle_to_tensor_pointer(index);
     at::Tensor* src_tensor = tensor_handle_to_tensor_pointer(src);
     at::scatter_out(*out_tensor, *self_tensor, dim, *index_tensor, *src_tensor);
+  });
+}
+
+AOTITorchError aoti_torch_scatter_reduce_out(
+    AtenTensorHandle out,
+    AtenTensorHandle self,
+    int64_t dim,
+    AtenTensorHandle index,
+    AtenTensorHandle src,
+    const char* reduce,
+    int32_t include_self) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    at::Tensor* out_tensor = tensor_handle_to_tensor_pointer(out);
+    at::Tensor* self_tensor = tensor_handle_to_tensor_pointer(self);
+    at::Tensor* index_tensor = tensor_handle_to_tensor_pointer(index);
+    at::Tensor* src_tensor = tensor_handle_to_tensor_pointer(src);
+    at::scatter_reduce_out(
+        *out_tensor,
+        *self_tensor,
+        dim,
+        *index_tensor,
+        *src_tensor,
+        reduce,
+        (bool)include_self);
   });
 }
 


### PR DESCRIPTION
Ran into the following exception during C++ file compilation.
```
error: use of undeclared identifier 'aoti_torch_scatter_reduce_out'
    aoti_torch_scatter_reduce_out(buf12, buf12,0,buf13,buf14, "sum",1);
    ^
```

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #116700



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov