### PR TITLE
[export] Improve verifier to not specialize on dialect.

### DIFF
--- a/test/export/test_pass_infra.py
+++ b/test/export/test_pass_infra.py
@@ -23,7 +23,7 @@ class TestPassInfra(TestCase):
         ep = export(f, (torch.ones(3, 2),))
         old_nodes = ep.graph.nodes
 
-        ep = ep._transform(NullPass())
+        ep = ep._transform_do_not_use(NullPass())
         new_nodes = ep.graph.nodes
 
         for node in new_nodes:
@@ -59,7 +59,7 @@ class TestPassInfra(TestCase):
         x = torch.tensor([2])
         y = torch.tensor([5])
         mod = M()
-        _ = export(mod, (torch.tensor(True), x, y))._transform(_ExportPassBase())
+        _ = export(mod, (torch.tensor(True), x, y))._transform_do_not_use(_ExportPassBase())
 
     def test_node_name_stability(self) -> None:
         # Tests that graph nodes stay the same for nodes that are not touched
@@ -90,7 +90,7 @@ class TestPassInfra(TestCase):
         ep_before = export(m, inps)
 
         # No op transformation that doesn't perform any meaningful changes to node
-        ep_after = ep_before._transform(_ExportPassBase())
+        ep_after = ep_before._transform_do_not_use(_ExportPassBase())
 
         for before_node, after_node in zip(ep_before.graph.nodes, ep_after.graph.nodes):
             self.assertEqual(before_node.name, after_node.name)
@@ -130,7 +130,7 @@ class TestPassInfra(TestCase):
             gm.recompile()
             return PassResult(gm, True)
 
-        ep_after = ep_before._transform(modify_input_output_pass)
+        ep_after = ep_before._transform_do_not_use(modify_input_output_pass)
         new_signature = ep_after.graph_signature
 
         for node_name in new_signature.user_outputs:

--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -181,7 +181,7 @@ class TestPasses(TestCase):
         ep = export(M(), (x,))
         self.assertEqual(count_call_function(ep.graph, torch.ops.aten.view.default), 1)
 
-        ep = ep._transform(ReplaceViewOpsWithViewCopyOpsPass())
+        ep = ep._transform_do_not_use(ReplaceViewOpsWithViewCopyOpsPass())
         self.assertEqual(count_call_function(ep.graph, torch.ops.aten.view.default), 0)
 
     def test_functionalization_with_view_copy(self) -> None:
@@ -193,7 +193,7 @@ class TestPasses(TestCase):
 
         x = torch.zeros(4, 2, 3)
 
-        ep = export(foo, (x,))._transform(ReplaceViewOpsWithViewCopyOpsPass())
+        ep = export(foo, (x,))._transform_do_not_use(ReplaceViewOpsWithViewCopyOpsPass())
         # After this pass, there shouldn't be any view nodes in the graph
         self.assertTrue(count_call_function(ep.graph, torch.ops.aten.view.default) == 0)
         self.assertTrue(count_call_function(ep.graph, torch.ops.aten.view_copy.default) > 0)
@@ -316,9 +316,6 @@ class TestPasses(TestCase):
             exactly=True,
         ).run(gm.code)
 
-        # TODO(ycao): ExportedProgram._transform() forbids changes to number
-        # of inputs/outputs for now. When it supports that better, change this
-        # back to using ExportedProgram._transform()
         gm = _FunctionalizeSideEffectfulOpsPass()(ep.graph_module).graph_module
 
         with self.assertRaisesRegex(

--- a/test/export/test_upgrade.py
+++ b/test/export/test_upgrade.py
@@ -104,7 +104,7 @@ def div__Scalar_mode_0_3(self: torch.Tensor, other: Any,  *, rounding_mode: Opti
         compiler_opset_version = {"aten": 4}
         model_opset_version = {"aten": 3}
         upgrader = GraphModuleOpUpgrader(compiler_opset_version, model_opset_version, TEST_UPGRADERS)
-        upgraded = ep._transform(*upgrader.upgrader_passes)
+        upgraded = ep._transform_do_not_use(*upgrader.upgrader_passes)
         upgraded.graph_module.print_readable()
 
         count = count_op(upgraded.graph, "aten::div.Scalar_mode")

--- a/torch/_export/serde/upgrade.py
+++ b/torch/_export/serde/upgrade.py
@@ -194,7 +194,7 @@ class GraphModuleOpUpgrader:
         assert kwargs == {}
 
         for _pass in self.upgrader_passes:
-            upgraded_program = exported_program._transform(_pass)
+            upgraded_program = exported_program._transform_do_not_use(_pass)
             # NB: we have to retrace the graph_module instead of ep because of some failure.
             exported_program = export(upgraded_program.module(), args, kwargs)
 

--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -133,9 +133,16 @@ class Verifier(metaclass=_VerifierMeta):
         try:
             _verify_exported_program_signature(ep)
         except SpecViolationError as e:
-            # TODO Remove this branch.
+            # TODO This hack is necessary until executorch can update their pin in pytorch CI.
             if ep.dialect == "EDGE":  # !!! Don't change this allowlist. !!!
-                pass
+                import os
+                if (
+                    os.environ.get("CI", None) == "true"
+                    and os.environ.get("GITHUB_ACTIONS", None) == "true"
+                ):
+                    pass
+                else:
+                    raise e
             else:
                 raise e
 

--- a/torch/distributed/_tensor/experimental/tp_transform.py
+++ b/torch/distributed/_tensor/experimental/tp_transform.py
@@ -47,7 +47,8 @@ def tensor_parallel_transformation(
     .. warning::
         This API is experimental and subject to change.
     """
-    return exported_program._transform(
+    # TODO Migrate this to plain function call.
+    return exported_program._transform_do_not_use(
         TensorParallelTransformPass(
             rank,
             world_size,

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -794,7 +794,7 @@ def _export(
     )
 
     if len(range_constraints) > 0 or len(equality_constraints) > 0:
-        exported_program = exported_program._transform(
+        exported_program = exported_program._transform_do_not_use(
             _AddRuntimeAssertionsForInlineConstraintsPass(
                 range_constraints, equality_constraints
             )


### PR DESCRIPTION
Summary:
Currently we have a very ugly specialization on edge dialect in verifier like the following:
```
 # TODO Remove this branch.
            if ep.dialect == "EDGE":  # !!! Don't change this allowlist. !!!
                pass
            else:
                raise e
```
In this diff we do some additional work to make signature checking also work in exir. We decouple the transformation stack in torch export and exir so that different layers of the stack can evolve in their own fashion and the team can divide and conquer them seperately.

Test Plan: CI

Differential Revision: D52499225




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225