### PR TITLE
fix inductor lowering cumsum and cumprod

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -4955,7 +4955,7 @@ def cumsum(x, axis=None, dtype=None):
     kwargs = _make_scan_inner(x, axis=axis, dtype=dtype)
     result = ir.Scan.create(**kwargs, combine_fn=ops.add, init=0)
     if result is None:
-        return fallback_cumsum(x, dim=axis, dtype=dtype)
+        return fallback_cumsum(x, axis, dtype=dtype)
     return result
 
 
@@ -4969,7 +4969,7 @@ def cumprod(x, axis=None, dtype=None):
     kwargs = _make_scan_inner(x, axis=axis, dtype=dtype)
     result = ir.Scan.create(**kwargs, combine_fn=ops.mul, init=1)
     if result is None:
-        return fallback_cumprod(x, dim=axis, dtype=dtype)
+        return fallback_cumprod(x, axis, dtype=dtype)
     return result
 
 


### PR DESCRIPTION
Summary:
From https://pytorch.org/docs/stable/generated/torch.cumsum.html , dim is arg but not kwarg. If we do `dim=axis`, it will try to treat `dim=axis` to the kwarg somewhere in inductor, so it does not end up with the place we want. if we remove `dim=`, it will change to arg

this diff also changed `cumprod` which fall into the same category https://pytorch.org/docs/stable/generated/torch.cumprod.html

Test Plan:
before
```
aoti_torch_proxy_executor_call_function(proxy_executor, 2, 1, std::vector<int64_t>{torch.int64}.data(), 2, std::vector<AtenTensorHandle>{buf702, buf708}.data());
```
after
```
aoti_torch_proxy_executor_call_function(proxy_executor, 2, 1, std::vector<int64_t>{0}.data(), 2, std::vector<AtenTensorHandle>{buf702, buf708}.data());
```
so `torch.int64` changed to `0`

Differential Revision: D52508264




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler