### PR TITLE
[BE] Remove `arch -arch arm64`

### DIFF
--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -59,7 +59,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Print runner OS/HW info
-        shell: arch -arch arm64 bash {0}
         run: |
           sysctl machdep.cpu.brand_string kern.osproductversion
 
@@ -70,7 +69,6 @@ jobs:
           quiet-checkout: true
 
       - name: Clean checkout
-        shell: arch -arch arm64 bash {0}
         run: |
           git clean -fxd
 
@@ -99,7 +97,6 @@ jobs:
           CONTINUE_THROUGH_ERROR: ${{ needs.filter.outputs.keep-going }}
           PIP_REQUIREMENTS_FILE: .github/requirements/pip-requirements-${{ runner.os }}.txt
           REENABLED_ISSUES: ${{ needs.filter.outputs.reenabled-issues }}
-        shell: arch -arch arm64 bash {0}
         run: |
           # shellcheck disable=SC1090
           set -ex


### PR DESCRIPTION
It was needed back in a day when there were no arm64 runner daemon binaries, so the trick was needed to execute native arm64 tests when invoked from x86 runner daemon

Followup after  https://github.com/pytorch/pytorch/pull/116680

