### PR TITLE
Clean up macOS x86 CI build and test jobs

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -158,34 +158,6 @@ jobs:
           { config: "default", shard: 1, num_shards: 1, runner: "ubuntu-latest" },
         ]}
 
-  macos-12-py3-x86-64-build:
-    name: macos-12-py3-x86-64
-    if: github.event_name != 'schedule' || github.event.schedule == '45 4,12,20 * * 1-5' || github.event.schedule == '45 12 * * 0,6' || github.event.schedule == '29 8 * * *'
-
-    uses: ./.github/workflows/_mac-build.yml
-    with:
-      build-environment: macos-12-py3-x86-64
-      xcode-version: "13.3.1"
-      runner-type: macos-12-xl
-      build-generates-artifacts: true
-      sccache-use-gha: true
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 4, runner: "macos-12" },
-          { config: "default", shard: 2, num_shards: 4, runner: "macos-12" },
-          { config: "default", shard: 3, num_shards: 4, runner: "macos-12" },
-          { config: "default", shard: 4, num_shards: 4, runner: "macos-12" },
-        ]}
-
-  macos-12-py3-x86-64-test:
-    name: macos-12-py3-x86-64
-    uses: ./.github/workflows/_mac-test.yml
-    needs: macos-12-py3-x86-64-build
-    with:
-      build-environment: macos-12-py3-x86-64
-      test-matrix: ${{ needs.macos-12-py3-x86-64-build.outputs.test-matrix }}
-      arch: x86_64
-
   android-emulator-build-test:
     name: android-emulator-build-test
     uses: ./.github/workflows/_run_android_tests.yml


### PR DESCRIPTION
We're ready to pull the plug on MacOX x86 build and test jobs on CI.

* [x] https://github.com/pytorch/pytorch/pull/116725
* [ ] https://github.com/pytorch/pytorch/pull/116726

More details is at https://github.com/pytorch/pytorch/issues/114602