### PR TITLE
 [Reland] [11/N] Enable clang-tidy warnings on c10/util/*.h

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -258,6 +258,7 @@ exclude_patterns = [
     '**/cuda/*pp',
     'c10/util/complex_math.h',
     'c10/util/complex_utils.h',
+    'c10/util/flat_hash_map.h',
     'c10/util/Float8*.h',
     'c10/util/logging*.h',
     'c10/util/hash.h',

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -245,6 +245,7 @@ include_patterns = [
     'aten/src/ATen/core/*.cpp',
     'c10/**/*.cpp',
     'c10/core/**/*.h',
+    'c10/util/**/*.h',
     'torch/csrc/**/*.cpp',
 ]
 exclude_patterns = [
@@ -255,6 +256,15 @@ exclude_patterns = [
     '**/*pb.h',
     '**/*CUDA*',
     '**/cuda/*pp',
+    'c10/util/complex_math.h',
+    'c10/util/complex_utils.h',
+    'c10/util/Float8*.h',
+    'c10/util/logging*.h',
+    'c10/util/hash.h',
+    'c10/util/strong_type.h',
+    'c10/util/SmallVector.h',
+    'c10/util/win32-headers.h',
+    'c10/util/*inl.h',
     'aten/src/ATen/core/TensorImpl_test.cpp',
     'third_party/**/*',
     'torch/csrc/api/**',

--- a/c10/util/ApproximateClock.h
+++ b/c10/util/ApproximateClock.h
@@ -7,9 +7,9 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <ctime>
 #include <functional>
 #include <type_traits>
-#include <ctime>
 
 #if defined(C10_IOS) && defined(C10_MOBILE)
 #include <sys/time.h> // for gettimeofday()

--- a/c10/util/ApproximateClock.h
+++ b/c10/util/ApproximateClock.h
@@ -9,12 +9,8 @@
 #include <cstdint>
 #include <functional>
 #include <type_traits>
-
 #include <ctime>
 
-#ifndef _WIN32
-#include <ctime>
-#endif
 #if defined(C10_IOS) && defined(C10_MOBILE)
 #include <sys/time.h> // for gettimeofday()
 #endif

--- a/c10/util/ArrayRef.h
+++ b/c10/util/ArrayRef.h
@@ -125,7 +125,7 @@ class ArrayRef final {
 
   /// Construct an ArrayRef from a C array.
   template <size_t N>
-    // NOLINTNEXTLINE(*c-arrays*)
+  // NOLINTNEXTLINE(*c-arrays*)
   /* implicit */ constexpr ArrayRef(const T (&Arr)[N]) : Data(Arr), Length(N) {}
 
   /// Construct an ArrayRef from a std::initializer_list.

--- a/c10/util/ArrayRef.h
+++ b/c10/util/ArrayRef.h
@@ -125,6 +125,7 @@ class ArrayRef final {
 
   /// Construct an ArrayRef from a C array.
   template <size_t N>
+    // NOLINTNEXTLINE(*c-arrays*)
   /* implicit */ constexpr ArrayRef(const T (&Arr)[N]) : Data(Arr), Length(N) {}
 
   /// Construct an ArrayRef from a std::initializer_list.
@@ -238,6 +239,7 @@ class ArrayRef final {
   /// continues to select the move assignment operator.
   template <typename U>
   std::enable_if_t<std::is_same_v<U, T>, ArrayRef<T>>& operator=(
+      // NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
       U&& Temporary) = delete;
 
   /// Disallow accidental assignment from a temporary.
@@ -330,6 +332,7 @@ ArrayRef<T>& makeArrayRef(ArrayRef<T>& Vec) {
 
 /// Construct an ArrayRef from a C array.
 template <typename T, size_t N>
+// NOLINTNEXTLINE(*c-arrays*)
 ArrayRef<T> makeArrayRef(const T (&Arr)[N]) {
   return ArrayRef<T>(Arr);
 }

--- a/c10/util/ConstexprCrc.h
+++ b/c10/util/ConstexprCrc.h
@@ -8,6 +8,7 @@
 namespace c10::util {
 
 namespace detail {
+// NOLINTNEXTLINE(*c-arrays*)
 constexpr uint64_t crc64_table[] = {
     0x0000000000000000, 0x7ad870c830358979, 0xf5b0e190606b12f2,
     0x8f689158505e9b8b, 0xc038e5739841b68f, 0xbae095bba8743ff6,

--- a/c10/util/ExclusivelyOwned.h
+++ b/c10/util/ExclusivelyOwned.h
@@ -55,10 +55,7 @@ struct ExclusivelyOwnedTraits;
 template <typename T>
 class ExclusivelyOwned {
   using EOT = ExclusivelyOwnedTraits<T>;
-  union {
-    char dummy_;
-    typename ExclusivelyOwnedTraits<T>::repr_type repr_;
-  };
+  typename ExclusivelyOwnedTraits<T>::repr_type repr_;
 
  public:
   ExclusivelyOwned() : repr_(EOT::nullRepr()) {}

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -18,10 +18,8 @@
 
 #if defined(__cplusplus) && (__cplusplus >= 201103L)
 #include <cmath>
-#include <cstdint>
 #elif !defined(__OPENCL_VERSION__)
 #include <math.h>
-#include <stdint.h>
 #endif
 
 #ifdef _MSC_VER

--- a/c10/util/IdWrapper.h
+++ b/c10/util/IdWrapper.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <c10/macros/Macros.h>
 #include <cstddef>
 #include <functional>
 #include <utility>

--- a/c10/util/MaybeOwned.h
+++ b/c10/util/MaybeOwned.h
@@ -126,6 +126,7 @@ class MaybeOwned final {
   }
 
   MaybeOwned(MaybeOwned&& rhs) noexcept(
+      // NOLINTNEXTLINE(*-noexcept-move-*)
       std::is_nothrow_move_constructible_v<T> &&
       std::is_nothrow_move_assignable_v<borrow_type>)
       : isBorrowed_(rhs.isBorrowed_) {
@@ -140,6 +141,7 @@ class MaybeOwned final {
       std::is_nothrow_move_assignable_v<T> &&
       std::is_nothrow_move_assignable_v<borrow_type> &&
       std::is_nothrow_move_constructible_v<T> &&
+      // NOLINTNEXTLINE(*-noexcept-move-*)
       std::is_nothrow_destructible_v<T> &&
       std::is_nothrow_destructible_v<borrow_type>) {
     if (this == &rhs) {
@@ -180,6 +182,7 @@ class MaybeOwned final {
   }
 
   ~MaybeOwned() noexcept(
+      // NOLINTNEXTLINE(*-noexcept-destructor)
       std::is_nothrow_destructible_v<T> &&
       std::is_nothrow_destructible_v<borrow_type>) {
     if (C10_UNLIKELY(!isBorrowed_)) {

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -7,14 +7,17 @@
 // Macros.h is not needed, but it does namespace shenanigans that lots
 // of downstream code seems to rely on. Feel free to remove it and fix
 // up builds.
-#include <c10/macros/Macros.h>
-#include <c10/util/Metaprogramming.h>
 
 namespace c10 {
+// NOLINTNEXTLINE(misc-unused-using-decls)
 using std::bad_optional_access;
+// NOLINTNEXTLINE(misc-unused-using-decls)
 using std::make_optional;
+// NOLINTNEXTLINE(misc-unused-using-decls)
 using std::nullopt;
+// NOLINTNEXTLINE(misc-unused-using-decls)
 using std::nullopt_t;
+// NOLINTNEXTLINE(misc-unused-using-decls)
 using std::optional;
 
 namespace detail_ {

--- a/c10/util/OptionalArrayRef.h
+++ b/c10/util/OptionalArrayRef.h
@@ -110,13 +110,13 @@ class OptionalArrayRef final {
     return *this;
   }
 
-  template <typename U = ArrayRef<T>>
-  constexpr std::enable_if_t<
-      !std::is_same_v<std::decay_t<U>, OptionalArrayRef> &&
+  template <
+      typename U = ArrayRef<T>,
+      typename = std::enable_if_t<
+          !std::is_same_v<std::decay_t<U>, OptionalArrayRef> &&
           std::is_constructible_v<ArrayRef<T>, U&&> &&
-          std::is_assignable_v<ArrayRef<T>&, U&&>,
-      OptionalArrayRef&>
-  operator=(U&& value) noexcept(
+          std::is_assignable_v<ArrayRef<T>&, U&&>>>
+  constexpr OptionalArrayRef& operator=(U&& value) noexcept(
       std::is_nothrow_constructible_v<ArrayRef<T>, U&&> &&
       std::is_nothrow_assignable_v<ArrayRef<T>&, U&&>) {
     wrapped_opt_array_ref = std::forward<U>(value);

--- a/c10/util/ScopeExit.h
+++ b/c10/util/ScopeExit.h
@@ -15,9 +15,7 @@ class scope_exit {
 
  public:
   template <typename Fp>
-  // constructor accepting a forwarding reference can hide the
-  // move constructor
-  // @lint-ignore CLANGTIDY
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   explicit scope_exit(Fp&& F) : ExitFunction(std::forward<Fp>(F)) {}
 
   scope_exit(scope_exit&& Rhs) noexcept

--- a/c10/util/StringUtil.h
+++ b/c10/util/StringUtil.h
@@ -9,12 +9,6 @@
 #include <ostream>
 #include <sstream>
 #include <string>
-#include <vector>
-
-C10_CLANG_DIAGNOSTIC_PUSH()
-#if C10_CLANG_HAS_WARNING("-Wshorten-64-to-32")
-C10_CLANG_DIAGNOSTIC_IGNORE("-Wshorten-64-to-32")
-#endif
 
 namespace c10 {
 
@@ -41,6 +35,7 @@ struct CanonicalizeStrTypes {
 };
 
 template <size_t N>
+// NOLINTNEXTLINE(*c-arrays*)
 struct CanonicalizeStrTypes<char[N]> {
   using type = const char*;
 };
@@ -181,11 +176,15 @@ inline void printQuotedString(std::ostream& stmt, const string_view str) {
         } else {
           // C++ io has stateful formatting settings. Messing with
           // them is probably worse than doing this manually.
+          // NOLINTNEXTLINE(*c-arrays*)
           char buf[4] = "000";
+          // NOLINTNEXTLINE(*narrowing-conversions)
           buf[2] += s % 8;
           s /= 8;
+          // NOLINTNEXTLINE(*narrowing-conversions)
           buf[1] += s % 8;
           s /= 8;
+          // NOLINTNEXTLINE(*narrowing-conversions)
           buf[0] += s;
           stmt << "\\" << buf;
         }
@@ -196,7 +195,5 @@ inline void printQuotedString(std::ostream& stmt, const string_view str) {
 }
 
 } // namespace c10
-
-C10_CLANG_DIAGNOSTIC_POP()
 
 #endif // C10_UTIL_STRINGUTIL_H_

--- a/c10/util/StringUtil.h
+++ b/c10/util/StringUtil.h
@@ -10,6 +10,11 @@
 #include <sstream>
 #include <string>
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wshorten-64-to-32")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wshorten-64-to-32")
+#endif
+
 namespace c10 {
 
 namespace detail {
@@ -195,5 +200,7 @@ inline void printQuotedString(std::ostream& stmt, const string_view str) {
 }
 
 } // namespace c10
+
+C10_CLANG_DIAGNOSTIC_POP()
 
 #endif // C10_UTIL_STRINGUTIL_H_

--- a/c10/util/TypeCast.h
+++ b/c10/util/TypeCast.h
@@ -6,16 +6,9 @@
 #include <c10/util/Float8_e5m2.h>
 #include <c10/util/Float8_e5m2fnuz.h>
 #include <c10/util/Half.h>
+#include <c10/util/complex.h>
 
 #include <type_traits>
-
-C10_CLANG_DIAGNOSTIC_PUSH()
-#if C10_CLANG_HAS_WARNING("-Wimplicit-float-conversion")
-C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-float-conversion")
-#endif
-#if C10_CLANG_HAS_WARNING("-Wimplicit-int-float-conversion")
-C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
-#endif
 
 namespace c10 {
 
@@ -162,7 +155,5 @@ To checked_convert(From f, const char* name) {
 }
 
 } // namespace c10
-
-C10_CLANG_DIAGNOSTIC_POP()
 
 // Trigger tests for D25440771. TODO: Remove this line any time you want.

--- a/c10/util/TypeCast.h
+++ b/c10/util/TypeCast.h
@@ -10,6 +10,14 @@
 
 #include <type_traits>
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wimplicit-float-conversion")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-float-conversion")
+#endif
+#if C10_CLANG_HAS_WARNING("-Wimplicit-int-float-conversion")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
+#endif
+
 namespace c10 {
 
 template <typename dest_t, typename src_t>
@@ -155,5 +163,7 @@ To checked_convert(From f, const char* name) {
 }
 
 } // namespace c10
+
+C10_CLANG_DIAGNOSTIC_POP()
 
 // Trigger tests for D25440771. TODO: Remove this line any time you want.

--- a/c10/util/TypeSafeSignMath.h
+++ b/c10/util/TypeSafeSignMath.h
@@ -4,14 +4,6 @@
 #include <limits>
 #include <type_traits>
 
-C10_CLANG_DIAGNOSTIC_PUSH()
-#if C10_CLANG_HAS_WARNING("-Wstring-conversion")
-C10_CLANG_DIAGNOSTIC_IGNORE("-Wstring-conversion")
-#endif
-#if C10_CLANG_HAS_WARNING("-Wimplicit-int-float-conversion")
-C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
-#endif
-
 namespace c10 {
 
 /// Returns false since we cannot have x < 0 if x is unsigned.
@@ -140,5 +132,3 @@ inline constexpr bool less_than_lowest(const T& x) {
 }
 
 } // namespace c10
-
-C10_CLANG_DIAGNOSTIC_POP()

--- a/c10/util/TypeSafeSignMath.h
+++ b/c10/util/TypeSafeSignMath.h
@@ -4,6 +4,14 @@
 #include <limits>
 #include <type_traits>
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wstring-conversion")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wstring-conversion")
+#endif
+#if C10_CLANG_HAS_WARNING("-Wimplicit-int-float-conversion")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
+#endif
+
 namespace c10 {
 
 /// Returns false since we cannot have x < 0 if x is unsigned.
@@ -132,3 +140,5 @@ inline constexpr bool less_than_lowest(const T& x) {
 }
 
 } // namespace c10
+
+C10_CLANG_DIAGNOSTIC_POP()

--- a/c10/util/accumulate.h
+++ b/c10/util/accumulate.h
@@ -2,13 +2,13 @@
 
 #pragma once
 
+#include <c10/util/Exception.h>
 #include <cstdint>
 #include <functional>
 #include <iterator>
 #include <numeric>
 #include <type_traits>
 #include <utility>
-#include <c10/util/Exception.h>
 
 namespace c10 {
 

--- a/c10/util/accumulate.h
+++ b/c10/util/accumulate.h
@@ -2,11 +2,13 @@
 
 #pragma once
 
-#include <c10/util/ArrayRef.h>
-
+#include <cstdint>
+#include <functional>
 #include <iterator>
 #include <numeric>
 #include <type_traits>
+#include <utility>
+#include <c10/util/Exception.h>
 
 namespace c10 {
 

--- a/c10/util/flat_hash_map.h
+++ b/c10/util/flat_hash_map.h
@@ -176,7 +176,8 @@ struct sherwood_v3_entry {
 };
 
 inline int8_t log2(uint64_t value) {
-  static constexpr std::array<int8_t, 64> table = {
+  // NOLINTNEXTLINE(*c-arrays*)
+  static constexpr int8_t table[64] = {
       63, 0,  58, 1,  59, 47, 53, 2,  60, 39, 48, 27, 54, 33, 42, 3,
       61, 51, 37, 40, 49, 18, 28, 20, 55, 30, 34, 11, 43, 14, 22, 4,
       62, 57, 46, 52, 38, 26, 32, 41, 50, 36, 17, 19, 29, 10, 13, 21,

--- a/c10/util/flat_hash_map.h
+++ b/c10/util/flat_hash_map.h
@@ -8,6 +8,7 @@
 // - make sherwood_v3_table::convertible_to_iterator public because GCC5 seems
 // to have issues with it otherwise
 // - fix compiler warnings in operator templated_iterator<const value_type>
+// - make use of 'if constexpr' and eliminate AssignIfTrue template
 
 //          Copyright Malte Skarupke 2017.
 // Distributed under the Boost Software License, Version 1.0.
@@ -25,11 +26,6 @@
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
-
-C10_CLANG_DIAGNOSTIC_PUSH()
-#if C10_CLANG_HAS_WARNING("-Wimplicit-int-float-conversion")
-C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
-#endif
 
 #if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(push)
@@ -2093,8 +2089,6 @@ struct power_of_two_std_hash : std::hash<T> {
 };
 
 } // end namespace ska
-
-C10_CLANG_DIAGNOSTIC_POP()
 
 #if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(pop)

--- a/c10/util/flat_hash_map.h
+++ b/c10/util/flat_hash_map.h
@@ -27,6 +27,11 @@
 #include <type_traits>
 #include <utility>
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wimplicit-int-float-conversion")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
+#endif
+
 #if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(push)
 #pragma warning(disable : 4624) // destructor was implicitly defined as deleted
@@ -2089,6 +2094,8 @@ struct power_of_two_std_hash : std::hash<T> {
 };
 
 } // end namespace ska
+
+C10_CLANG_DIAGNOSTIC_POP()
 
 #if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(pop)

--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -388,8 +388,7 @@ class intrusive_ptr final {
     if (this == &rhs) {
       return *this;
     }
-    // NOLINTNEXTLINE(misc-unconventional-assign-operator,
-    // cppcoreguidelines-c-copy-assignment-signature)
+    // NOLINTNEXTLINE(*assign-operator, *assignment-signature)
     return operator= <TTarget, NullType>(rhs);
   }
 

--- a/c10/util/llvmMathExtras.h
+++ b/c10/util/llvmMathExtras.h
@@ -283,7 +283,8 @@ T findLastSet(T Val, ZeroBehavior ZB = ZB_Max) {
 /// Macro compressed bit reversal table for 256 bits.
 ///
 /// http://graphics.stanford.edu/~seander/bithacks.html#BitReverseTable
-static const unsigned char BitReverseTable256[256] = {
+/// NOLINTNEXTLINE(*c-arrays*)
+static constexpr unsigned char BitReverseTable256[256] = {
 #define R2(n) n, n + 2 * 64, n + 1 * 64, n + 3 * 64
 #define R4(n) R2(n), R2(n + 2 * 16), R2(n + 1 * 16), R2(n + 3 * 16)
 #define R6(n) R4(n), R4(n + 2 * 4), R4(n + 1 * 4), R4(n + 3 * 4)
@@ -299,7 +300,9 @@ static const unsigned char BitReverseTable256[256] = {
 /// Reverse the bits in \p Val.
 template <typename T>
 T reverseBits(T Val) {
+  // NOLINTNEXTLINE(*c-arrays*)
   unsigned char in[sizeof(Val)];
+  // NOLINTNEXTLINE(*c-arrays*)
   unsigned char out[sizeof(Val)];
   std::memcpy(in, &Val, sizeof(Val));
   for (unsigned i = 0; i < sizeof(Val); ++i)
@@ -420,7 +423,7 @@ inline uint64_t maxUIntN(uint64_t N) {
 /// Gets the minimum value for a N-bit signed integer.
 inline int64_t minIntN(int64_t N) {
   assert(N > 0 && N <= 64 && "integer width out of range");
-
+  // NOLINTNEXTLINE(*-narrowing-conversions)
   return -(UINT64_C(1) << (N - 1));
 }
 
@@ -434,6 +437,7 @@ inline int64_t maxIntN(int64_t N) {
 
   // This relies on two's complement wraparound when N == 64, so we convert to
   // int64_t only at the very end to avoid UB.
+  // NOLINTNEXTLINE(*-narrowing-conversions)
   return (UINT64_C(1) << (N - 1)) - 1;
 }
 

--- a/c10/util/order_preserving_flat_hash_map.h
+++ b/c10/util/order_preserving_flat_hash_map.h
@@ -139,10 +139,12 @@ struct KeyOrValueEquality : functor_storage<bool, key_equal> {
 static constexpr int8_t min_lookups = 4;
 template <typename T>
 struct sherwood_v3_entry {
-  sherwood_v3_entry() = default;
+  // NOLINTNEXTLINE(modernize-use-equals-default)
+  sherwood_v3_entry() {}
   sherwood_v3_entry(int8_t distance_from_desired)
       : distance_from_desired(distance_from_desired) {}
-  ~sherwood_v3_entry() = default;
+  // NOLINTNEXTLINE(modernize-use-equals-default)
+  ~sherwood_v3_entry() {}
 
   bool has_value() const {
     return distance_from_desired >= 0;

--- a/c10/util/order_preserving_flat_hash_map.h
+++ b/c10/util/order_preserving_flat_hash_map.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <c10/macros/Macros.h>
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -187,21 +188,6 @@ inline int8_t log2(uint64_t value) {
   value |= value >> 32;
   return table[((value - (value >> 1)) * 0x07EDD5E59A4E28C2) >> 58];
 }
-
-template <typename T, bool>
-struct AssignIfTrue {
-  void operator()(T& lhs, const T& rhs) {
-    lhs = rhs;
-  }
-  void operator()(T& lhs, T&& rhs) {
-    lhs = std::move(rhs);
-  }
-};
-template <typename T>
-struct AssignIfTrue<T, false> {
-  void operator()(T&, const T&) {}
-  void operator()(T&, T&&) {}
-};
 
 inline uint64_t next_power_of_two(uint64_t i) {
   --i;
@@ -383,15 +369,13 @@ class sherwood_v3_table : private EntryAlloc, private Hasher, private Equal {
       return *this;
 
     clear();
-    if (AllocatorTraits::propagate_on_container_copy_assignment::value) {
+    if constexpr (AllocatorTraits::propagate_on_container_copy_assignment::
+                      value) {
       if (static_cast<EntryAlloc&>(*this) !=
           static_cast<const EntryAlloc&>(other)) {
         reset_to_empty_state();
       }
-      AssignIfTrue<
-          EntryAlloc,
-          AllocatorTraits::propagate_on_container_copy_assignment::value>()(
-          *this, other);
+      static_cast<EntryAlloc&>(*this) = other;
     }
     _max_load_factor = other._max_load_factor;
     static_cast<Hasher&>(*this) = other;
@@ -403,13 +387,11 @@ class sherwood_v3_table : private EntryAlloc, private Hasher, private Equal {
   sherwood_v3_table& operator=(sherwood_v3_table&& other) noexcept {
     if (this == std::addressof(other))
       return *this;
-    else if (AllocatorTraits::propagate_on_container_move_assignment::value) {
+    else if constexpr (AllocatorTraits::propagate_on_container_move_assignment::
+                           value) {
       clear();
       reset_to_empty_state();
-      AssignIfTrue<
-          EntryAlloc,
-          AllocatorTraits::propagate_on_container_move_assignment::value>()(
-          *this, std::move(other));
+      static_cast<EntryAlloc&>(*this) = std::move(other);
       swap_pointers(other);
     } else if (
         static_cast<EntryAlloc&>(*this) == static_cast<EntryAlloc&>(other)) {

--- a/c10/util/order_preserving_flat_hash_map.h
+++ b/c10/util/order_preserving_flat_hash_map.h
@@ -139,10 +139,10 @@ struct KeyOrValueEquality : functor_storage<bool, key_equal> {
 static constexpr int8_t min_lookups = 4;
 template <typename T>
 struct sherwood_v3_entry {
-  sherwood_v3_entry() {}
+  sherwood_v3_entry() = default;
   sherwood_v3_entry(int8_t distance_from_desired)
       : distance_from_desired(distance_from_desired) {}
-  ~sherwood_v3_entry() {}
+  ~sherwood_v3_entry() = default;
 
   bool has_value() const {
     return distance_from_desired >= 0;

--- a/c10/util/order_preserving_flat_hash_map.h
+++ b/c10/util/order_preserving_flat_hash_map.h
@@ -18,7 +18,6 @@
 
 #pragma once
 
-#include <c10/macros/Macros.h>
 #include <algorithm>
 #include <array>
 #include <cmath>

--- a/c10/util/order_preserving_flat_hash_map.h
+++ b/c10/util/order_preserving_flat_hash_map.h
@@ -8,6 +8,7 @@
 // - make sherwood_v3_table::convertible_to_iterator public because GCC5 seems
 // to have issues with it otherwise
 // - fix compiler warnings in operator templated_iterator<const value_type>
+// - make use of 'if constexpr' and eliminate AssignIfTrue template
 
 //          Copyright Malte Skarupke 2017.
 // Distributed under the Boost Software License, Version 1.0.

--- a/c10/util/signal_handler.h
+++ b/c10/util/signal_handler.h
@@ -98,6 +98,7 @@ class C10_API FatalSignalHandler {
     struct sigaction previous;
   };
 
+  // NOLINTNEXTLINE(*c-arrays*)
   static signal_handler kSignalHandlers[];
 };
 

--- a/c10/util/string_utils.h
+++ b/c10/util/string_utils.h
@@ -4,10 +4,15 @@
 
 namespace c10 {
 
+// NOLINTNEXTLINE(misc-unused-using-decls)
 using std::stod;
+// NOLINTNEXTLINE(misc-unused-using-decls)
 using std::stoi;
+// NOLINTNEXTLINE(misc-unused-using-decls)
 using std::stoll;
+// NOLINTNEXTLINE(misc-unused-using-decls)
 using std::stoull;
+// NOLINTNEXTLINE(misc-unused-using-decls)
 using std::to_string;
 
 } // namespace c10

--- a/torch/csrc/lazy/core/ir_metadata.h
+++ b/torch/csrc/lazy/core/ir_metadata.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <c10/util/Optional.h>
+#include <c10/macros/Macros.h>
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
Reland of #116353 with C++ diagnostic macros restored.

cc @izaitsevfb 
