### PR TITLE
support wrapper tensor to shard local_tensor storage

### DIFF
--- a/test/distributed/_tensor/test_dtensor.py
+++ b/test/distributed/_tensor/test_dtensor.py
@@ -115,6 +115,8 @@ class DTensorTest(DTensorTestBase):
         local_tensor = torch.randn(4, 8)
         dist_tensor = DTensor.from_local(local_tensor, device_mesh, shard0_spec)
         self.assertEqual(dist_tensor.data_ptr(), dist_tensor._local_tensor.data_ptr())
+        local_tensor = dist_tensor.to_local()
+        self.assertEqual(dist_tensor.data_ptr(), local_tensor.data_ptr())
 
     @with_comms
     def test_modules_w_meta_dtensor(self):

--- a/test/distributed/_tensor/test_dtensor.py
+++ b/test/distributed/_tensor/test_dtensor.py
@@ -109,6 +109,14 @@ class DTensorTest(DTensorTestBase):
             self.assertEqual(meta_dtensor.to_local(), value_tensor)
 
     @with_comms
+    def test_dtensor_local_tensor_storage(self):
+        device_mesh = self.build_device_mesh()
+        shard0_spec = [Shard(0)]
+        local_tensor = torch.randn(4, 8)
+        dist_tensor = DTensor.from_local(local_tensor, device_mesh, shard0_spec)
+        self.assertEqual(dist_tensor.data_ptr(), dist_tensor._local_tensor.data_ptr())
+
+    @with_comms
     def test_modules_w_meta_dtensor(self):
         model = DummyMLP("meta")
         device_mesh = self.build_device_mesh()

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -106,7 +106,7 @@ class Tensor(torch._C.TensorBase):
                     not torch._C._has_storage(self)
                     and self.device.type == torch._C._get_privateuse1_backend_name()
                 )
-                or (type(self) is not Tensor and self.data_ptr() == 0)
+                or (type(self) is not Tensor)
             ):
                 new_tensor = self.clone()
                 if type(new_tensor) is not type(self):

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -106,7 +106,8 @@ class Tensor(torch._C.TensorBase):
                     not torch._C._has_storage(self)
                     and self.device.type == torch._C._get_privateuse1_backend_name()
                 )
-                or (type(self) is not Tensor)
+                or (type(self) is not Tensor and self.data_ptr() == 0)
+                or type(self).__name__ == "DTensor"
             ):
                 new_tensor = self.clone()
                 if type(new_tensor) is not type(self):

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -728,6 +728,7 @@ static PyObject* THPVariable_make_wrapper_subclass(
         /*resizable=*/true};
     auto data_ptr = r.toSymIntOptional(14);
     if (data_ptr.value_or(0) != 0) {
+      // NOLINTNEXTLINE(performance-no-int-to-ptr)
       void* p = reinterpret_cast<void*>(
           static_cast<uintptr_t>(data_ptr->expect_int()));
       storage.set_data_ptr_noswap(at::DataPtr{p, r.device(7)});

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -726,7 +726,6 @@ static PyObject* THPVariable_make_wrapper_subclass(
         size_bytes,
         /*allocator=*/c10::GetAllocator(c10::kMeta),
         /*resizable=*/true};
-    // TODO: constructor should probably accept data pointer
     auto data_ptr = r.toSymIntOptional(14);
     if (data_ptr.value_or(0) != 0) {
       void* p = reinterpret_cast<void*>(

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -242,6 +242,7 @@ class DTensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
             device=local_tensor.device,
             layout=local_tensor.layout,
             requires_grad=requires_grad,
+            data_ptr=local_tensor.data_ptr(),
         )
 
         tensor_meta = TensorMeta(shape, stride, dtype)


### PR DESCRIPTION
Fixes #116683

hi , i fix this with given the wrapper tensor the data_ptr to share it's own storage, then it can be call in any custom op

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang