### PR TITLE
Replace recursive stable_topological_sort() with iterative.

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -1082,22 +1082,22 @@ class TestPatternMatcher(TestCase):
             return a + b
 
         graph = torch.fx.Graph()
-        a = graph.placeholder('x')
-        b = graph.placeholder('y')
+        a = graph.placeholder("x")
+        b = graph.placeholder("y")
         c = graph.call_function(fn1, (a, b))
         stable_topological_sort(graph)
         self.assertEqual(list(graph.nodes), [a, b, c])
 
         graph = torch.fx.Graph()
-        b = graph.placeholder('y')
-        a = graph.placeholder('x')
+        b = graph.placeholder("y")
+        a = graph.placeholder("x")
         c = graph.call_function(fn1, (a, b))
         stable_topological_sort(graph)
         self.assertEqual(list(graph.nodes), [b, a, c])
 
         graph = torch.fx.Graph()
-        a = graph.placeholder('x')
-        b = graph.placeholder('y')
+        a = graph.placeholder("x")
+        b = graph.placeholder("y")
         c = graph.call_function(fn1, (b, a))
         c.append(a)
         stable_topological_sort(graph)

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -24,6 +24,7 @@ from torch._inductor.pattern_matcher import (
     PatternMatcherPass,
     PatternPrettyPrinter,
     register_graph_pattern,
+    stable_topological_sort,
 )
 from torch._inductor.utils import run_and_get_code
 from torch._inductor.virtualized import V
@@ -1075,6 +1076,32 @@ class TestPatternMatcher(TestCase):
                 actual = torch.compile(fn)(*copy.deepcopy(args))
                 self.assertEqual(counter, 1)
                 torch.testing.assert_close(actual, expected)
+
+    def test_stable_topological_sort(self):
+        def fn1(a, b):
+            return a + b
+
+        graph = torch.fx.Graph()
+        a = graph.placeholder('x')
+        b = graph.placeholder('y')
+        c = graph.call_function(fn1, (a, b))
+        stable_topological_sort(graph)
+        self.assertEqual(list(graph.nodes), [a, b, c])
+
+        graph = torch.fx.Graph()
+        b = graph.placeholder('y')
+        a = graph.placeholder('x')
+        c = graph.call_function(fn1, (a, b))
+        stable_topological_sort(graph)
+        self.assertEqual(list(graph.nodes), [b, a, c])
+
+        graph = torch.fx.Graph()
+        a = graph.placeholder('x')
+        b = graph.placeholder('y')
+        c = graph.call_function(fn1, (b, a))
+        c.append(a)
+        stable_topological_sort(graph)
+        self.assertEqual(list(graph.nodes), [b, a, c])
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -1290,25 +1290,38 @@ def _args(n: torch.fx.Node) -> List[torch.fx.node.Argument]:
 
 
 def stable_topological_sort(graph: torch.fx.Graph):
-    waiting = defaultdict(list)
-    ready = set()
-    cursor = None
+    # Nodes are in exactly one of these three collections:
 
-    def check(node):
+    # - Nodes in `pending` are waiting to be processed (in reverse order):
+    pending = list(reversed(graph.nodes))
+
+    # - Nodes in `ready` have been processed and are already in the correct
+    #   order.
+    ready = set()
+
+    # - `waiting` is a mapping from a dependency to nodes which depend on that
+    #   dependency.
+    waiting = defaultdict(list)
+
+    # The cursor indicates the last processed node so we can add new nodes
+    # after it.
+    cursor = None
+    while pending:
+        node = pending.pop()
         waiting_for = [x for x in _args(node) if x not in ready]
         if waiting_for:
-            # revisit this node when next input is ready
-            waiting[waiting_for[0]].append(node)
+            # We have unprocessed input nodes. Might as well wait for the last
+            # arg so an already sorted list will only recheck this node once.
+            waiting[waiting_for[-1]].append(node)
         else:
-            nonlocal cursor
-            cursor = node
             ready.add(node)
-            for other in waiting.pop(node, ()):
-                cursor.append(other)
-                check(other)
+            if cursor and cursor.next is not node:
+                cursor.append(node)
+            cursor = node
+            # Mark the nodes that have been waiting for this node to finish as
+            # ready to check again.
+            pending.extend(reversed(waiting.pop(node, ())))
 
-    for n in list(graph.nodes):
-        check(n)
     assert not waiting and len(ready) == len(graph.nodes)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #116761

Summary:
A graph with a deep set of nodes caused stable_topological_sort() to recurse and
pop the stack. Rewrite it to be iterative and avoid recursion.

Fixes #115506

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler