### PR TITLE
distributed support interface 'is_backend_available' for custom backend

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -247,6 +247,7 @@ class Backend(str):
         )
 
         setattr(Backend, name.upper(), name.lower())
+        setattr(torch.distributed, 'is_{}_available'.format(name.lower()), lambda: True)
         Backend.backend_list.append(name.lower())
         if devices is not None:
             for device in devices:

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -247,7 +247,7 @@ class Backend(str):
         )
 
         setattr(Backend, name.upper(), name.lower())
-        setattr(torch.distributed, 'is_{}_available'.format(name.lower()), lambda: True)
+        setattr(torch.distributed, f'is_{name.lower()}_available', lambda: True)
         Backend.backend_list.append(name.lower())
         if devices is not None:
             for device in devices:


### PR DESCRIPTION
We can register our custom backend on `torch.distributed.Backend` through interface `register_backend`. But we need a interface to show our backend is available like `is_nccl_available`. And I think it should be True if we register a custom backend to torch.


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225