### PR TITLE
[export] Refactor ExportPassBase.

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -23,7 +23,7 @@ from torch.export._trace import (
     DEFAULT_EXPORT_DYNAMO_CONFIG,
 )
 from torch._export import capture_pre_autograd_graph
-from torch._export.pass_base import _ExportPassBase
+from torch._export.pass_base import _ExportPassBaseDeprecatedDoNotUse
 from torch._export.utils import (
     get_buffer,
     get_param,
@@ -2221,7 +2221,7 @@ def forward(self, l_x_):
                 return x / torch.sym_sqrt(x.shape[0])
 
         ep = export(M(), (torch.ones(16, 4),), dynamic_shapes={'x': {0: Dim("dim")}})
-        _ExportPassBase()(ep.graph_module)
+        _ExportPassBaseDeprecatedDoNotUse()(ep.graph_module)
         FileCheck().check_count(
             "torch.sym_sqrt", 1, exactly=True
         ).run(ep.graph_module.code)

--- a/test/export/test_pass_infra.py
+++ b/test/export/test_pass_infra.py
@@ -6,7 +6,7 @@ import torch
 from functorch.experimental import control_flow
 from torch._dynamo.eval_frame import is_dynamo_supported
 from torch.export import export
-from torch._export.pass_base import _ExportPassBase
+from torch._export.pass_base import _ExportPassBaseDeprecatedDoNotUse
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
@@ -17,7 +17,7 @@ class TestPassInfra(TestCase):
             y = torch.cat([x, x])
             return torch.ops.aten.tensor_split.sections(y, 2)
 
-        class NullPass(_ExportPassBase):
+        class NullPass(_ExportPassBaseDeprecatedDoNotUse):
             pass
 
         ep = export(f, (torch.ones(3, 2),))
@@ -59,7 +59,7 @@ class TestPassInfra(TestCase):
         x = torch.tensor([2])
         y = torch.tensor([5])
         mod = M()
-        _ = export(mod, (torch.tensor(True), x, y))._transform_do_not_use(_ExportPassBase())
+        _ = export(mod, (torch.tensor(True), x, y))._transform_do_not_use(_ExportPassBaseDeprecatedDoNotUse())
 
     def test_node_name_stability(self) -> None:
         # Tests that graph nodes stay the same for nodes that are not touched
@@ -90,7 +90,7 @@ class TestPassInfra(TestCase):
         ep_before = export(m, inps)
 
         # No op transformation that doesn't perform any meaningful changes to node
-        ep_after = ep_before._transform_do_not_use(_ExportPassBase())
+        ep_after = ep_before._transform_do_not_use(_ExportPassBaseDeprecatedDoNotUse())
 
         for before_node, after_node in zip(ep_before.graph.nodes, ep_after.graph.nodes):
             self.assertEqual(before_node.name, after_node.name)

--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -14,7 +14,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing import FileCheck
 from torch._dynamo.eval_frame import is_dynamo_supported
 from torch.export import export
-from torch._export.pass_base import _ExportPassBase
+from torch._export.pass_base import _ExportPassBaseDeprecatedDoNotUse
 from torch._export.passes.replace_view_ops_with_view_copy_ops_pass import (
     is_view_op,
     get_view_copy_of_view_op,
@@ -345,7 +345,7 @@ class TestPasses(TestCase):
 
         x = torch.randn(1, dtype=torch.float32)
         ep = torch.export.export(func, args=(x,))
-        _ExportPassBase()(ep.graph_module)
+        _ExportPassBaseDeprecatedDoNotUse()(ep.graph_module)
 
 
 if __name__ == '__main__':

--- a/torch/_export/pass_base.py
+++ b/torch/_export/pass_base.py
@@ -20,7 +20,7 @@ from torch.fx.passes.shape_prop import _extract_tensor_metadata, TensorMetadata
 from torch.utils import _pytree as pytree
 
 
-__all__ = ["_ExportPassBase"]
+__all__ = ["_ExportPassBaseDeprecatedDoNotUse"]
 
 
 Argument = Any
@@ -43,7 +43,7 @@ class ExportPassBaseError(RuntimeError):
     pass
 
 
-class _ExportPassBase(PassBase):
+class _ExportPassBaseDeprecatedDoNotUse(PassBase):
     """
     Interpreter-based pass class to help users maintain the IR spec while writing
     transformations.
@@ -55,10 +55,7 @@ class _ExportPassBase(PassBase):
 
 
     class ExportTracer(PythonKeyTracer):
-        """
-        Tracer used to create nodes during the retracing part of the Expo_ExportPassBasertPassBase
-        """
-        def __init__(self, callback: "_ExportPassBase", codegen: CodeGen) -> None:
+        def __init__(self, callback: "_ExportPassBaseDeprecatedDoNotUse", codegen: CodeGen) -> None:
             super().__init__()
             self.callback = callback
             self.root = torch.nn.Module()
@@ -153,10 +150,7 @@ class _ExportPassBase(PassBase):
             node.meta["tensor_meta"] = pytree.tree_map(make_tensor_meta, value)
 
     class ExportInterpreter(fx.Interpreter):
-        """
-        Interpreter to callback on any _ExportPassBase functions
-        """
-        def __init__(self, callback: "_ExportPassBase", gm: fx.GraphModule) -> None:
+        def __init__(self, callback: "_ExportPassBaseDeprecatedDoNotUse", gm: fx.GraphModule) -> None:
             super().__init__(gm)
             self.callback = callback
             self.node: torch.fx.Node = next(iter(gm.graph.nodes))
@@ -440,3 +434,13 @@ class _ExportPassBase(PassBase):
             result = self.call_submodule(graph_module, tuple(inputs))
 
         return result
+
+# TODO This hack is necessary until executorch can update their pin in pytorch CI.
+import os
+
+if (
+    os.environ.get("CI", None) == "true"
+    and os.environ.get("GITHUB_ACTIONS", None) == "true"
+):
+    _ExportPassBase = _ExportPassBaseDeprecatedDoNotUse
+    __all__.append("_ExportPassBase")

--- a/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
+++ b/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
@@ -8,7 +8,7 @@ import sympy
 
 import torch
 import torch.fx
-from torch._export.pass_base import _ExportPassBase, ProxyValue, PassResult
+from torch._export.pass_base import _ExportPassBaseDeprecatedDoNotUse, ProxyValue, PassResult
 from torch.utils._sympy.value_ranges import ValueRanges
 
 
@@ -40,7 +40,7 @@ def _convert_range_to_int(range: ValueRanges):
     return min_val, max_val
 
 
-class _AddRuntimeAssertionsForInlineConstraintsPass(_ExportPassBase):
+class _AddRuntimeAssertionsForInlineConstraintsPass(_ExportPassBaseDeprecatedDoNotUse):
     def __init__(
         self,
         range_constraints: Dict[sympy.Symbol, ValueRanges],

--- a/torch/_export/passes/functionalize_side_effectful_ops_pass.py
+++ b/torch/_export/passes/functionalize_side_effectful_ops_pass.py
@@ -2,7 +2,7 @@ import copy
 from typing import Dict, Optional, Tuple, List
 
 import torch
-from torch._export.pass_base import _ExportPassBase, PassResult, Argument
+from torch._export.pass_base import _ExportPassBaseDeprecatedDoNotUse, PassResult, Argument
 from torch._export.pass_infra.node_metadata import NodeMetadata
 from torch._export.pass_infra.proxy_value import ProxyValue
 from torch._ops import OpOverload
@@ -15,7 +15,7 @@ _NON_FUNCTIONAL_TO_FUNCTIONAL_SIDE_EFFECTFUL_FUNCS: Dict[OpOverload, OpOverload]
 }
 
 
-class _FunctionalizeSideEffectfulOpsPass(_ExportPassBase):
+class _FunctionalizeSideEffectfulOpsPass(_ExportPassBaseDeprecatedDoNotUse):
     """
     Functionalize ops with side effect in graph module by replacing the op with
     functional version of it. A new dependency token (`dep_token`) will be

--- a/torch/_export/passes/replace_view_ops_with_view_copy_ops_pass.py
+++ b/torch/_export/passes/replace_view_ops_with_view_copy_ops_pass.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, Set
 import torch
 from torch._ops import OpOverload, OpOverloadPacket, HigherOrderOperator
 from torch._export.error import InternalError
-from torch._export.pass_base import _ExportPassBase
+from torch._export.pass_base import _ExportPassBaseDeprecatedDoNotUse
 
 
 __all__ = ["ReplaceViewOpsWithViewCopyOpsPass"]
@@ -49,7 +49,7 @@ def get_view_copy_of_view_op(schema: torch._C.FunctionSchema) -> Optional[OpOver
     return None
 
 
-class ReplaceViewOpsWithViewCopyOpsPass(_ExportPassBase):
+class ReplaceViewOpsWithViewCopyOpsPass(_ExportPassBaseDeprecatedDoNotUse):
     """
     Our backend expects pure functional operators. For efficiency
     purposes, we keep view ops around while functionalizing the exported

--- a/torch/_export/serde/upgrade.py
+++ b/torch/_export/serde/upgrade.py
@@ -4,7 +4,7 @@ from typing import Tuple, Dict, Optional, List
 
 import torch
 from torch._export import export
-from torch._export.pass_base import _ExportPassBase
+from torch._export.pass_base import _ExportPassBaseDeprecatedDoNotUse
 from torch._export.pass_infra.node_metadata import NodeMetadata
 from torch._export.pass_infra.proxy_value import ProxyValue
 from torch._subclasses import FakeTensor
@@ -74,7 +74,7 @@ class GraphModuleOpUpgrader:
     original TorchScript upgrader).
     """
 
-    class UpgraderPass(_ExportPassBase):
+    class UpgraderPass(_ExportPassBaseDeprecatedDoNotUse):
         def __init__(self, old_target: Target, new_target: Target):
             super().__init__()
             self.old_target = old_target

--- a/torch/ao/quantization/pt2e/duplicate_dq_pass.py
+++ b/torch/ao/quantization/pt2e/duplicate_dq_pass.py
@@ -1,7 +1,6 @@
 import logging
 
 import torch
-from torch._export.pass_base import _ExportPassBase
 
 from torch.ao.quantization.pt2e.utils import (
     _filter_sym_size_users,
@@ -9,7 +8,7 @@ from torch.ao.quantization.pt2e.utils import (
 )
 
 from torch.fx.node import map_arg
-from torch.fx.passes.infra.pass_base import PassResult
+from torch.fx.passes.infra.pass_base import PassBase, PassResult
 
 
 logger = logging.getLogger(__name__)
@@ -45,7 +44,7 @@ def _maybe_duplicate_dq(
         user.kwargs = new_kwargs
 
 
-class DuplicateDQPass(_ExportPassBase):
+class DuplicateDQPass(PassBase):
     def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
         for node in graph_module.graph.nodes:
             if node.op == "call_function" and node.target in _DEQUANTIZE_OPS:

--- a/torch/ao/quantization/pt2e/port_metadata_pass.py
+++ b/torch/ao/quantization/pt2e/port_metadata_pass.py
@@ -3,7 +3,6 @@ from typing import Optional
 
 import torch
 from torch._export.error import InternalError
-from torch._export.pass_base import _ExportPassBase
 
 from torch.ao.quantization.pt2e.utils import (
     _filter_sym_size_users,
@@ -13,7 +12,7 @@ from torch.ao.quantization.pt2e.utils import (
 
 from torch.ao.quantization.quantizer import QuantizationSpecBase
 
-from torch.fx.passes.infra.pass_base import PassResult
+from torch.fx.passes.infra.pass_base import PassBase, PassResult
 
 
 logger = logging.getLogger(__name__)
@@ -133,7 +132,7 @@ def _port_metadata_for_output_quant_nodes(
     _add_metadata(q_node, node)
 
 
-class PortNodeMetaForQDQ(_ExportPassBase):
+class PortNodeMetaForQDQ(PassBase):
     """
     Port metadata for nodes added by quantization flow.
     For static quant these are:


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/executorch/pull/1532

as title. This diff decouple the pass base library from torch export and exir, so that different layers can evolve in their own fashion, and we have more head room to divide and conquer in the future.

Test Plan: CI

Reviewed By: angelayi

Differential Revision: D52514517


