### PR TITLE
[BE] Use precompiled headers to speedup clang-tidy

### DIFF
--- a/tools/linter/clang_tidy/generate_build_files.py
+++ b/tools/linter/clang_tidy/generate_build_files.py
@@ -27,6 +27,7 @@ def update_submodules() -> None:
 
 def gen_compile_commands() -> None:
     os.environ["USE_NCCL"] = "0"
+    os.environ["USE_PRECOMPILED_HEADERS"] = "1"
     os.environ["CC"] = "clang"
     os.environ["CXX"] = "clang++"
     run_cmd([sys.executable, "setup.py", "--cmake-only", "build"])


### PR DESCRIPTION
This brings the time down by 30% (from [30](https://github.com/pytorch/pytorch/actions/runs/7412899917/job/20170674075#step:11:64) min to [20](https://github.com/pytorch/pytorch/actions/runs/7413082213/job/20171286833?pr=116780#step:11:64) min)