### PR TITLE
add predispatch_pass to hold pass functions to be run when config.is_predispatch is true

### DIFF
--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -34,6 +34,7 @@ split_cat_pass = PatternMatcherPass(prevent_match_across_mutations=True)
 unbind_stack_pass = PatternMatcherPass(prevent_match_across_mutations=True)
 efficient_conv_bn_eval_pass = PatternMatcherPass(prevent_match_across_mutations=True)
 merge_getitem_cat_pass = PatternMatcherPass(prevent_match_across_mutations=True)
+predispatch_pass = PatternMatcherPass(prevent_match_across_mutations=True)
 
 pattern_matcher_passes: List[PatternMatcherPass] = [
     normalization_pass,
@@ -71,6 +72,7 @@ def pre_grad_passes(gm: torch.fx.GraphModule, example_inputs):
         # explicitly run with predispatch atenIR based passes
         if config.is_predispatch:
             group_batch_fusion_passes(gm.graph, pre_grad=True)
+            predispatch_pass.apply(gm.graph)
         else:
             gm = fuse_fx(gm, example_inputs)
             numpy_compat_normalization(gm.graph)


### PR DESCRIPTION
Summary:
config.is_predispatch is a config to instruct inductor to enable predispatch
tracing (high level pre-dispatch IR).  Currently, there is no dedicated pass
for this config.

In this commit, for better pass function management, we created
`predispatch_pass` to hold the pass functions to be run on the high level
pre-dispatch IR-based graphs.

Test Plan: CI

Differential Revision: D52491332




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler