### PR TITLE
Make TORCH_LOGS="dist_ddp" include DDPOptimizer logs

### DIFF
--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -18,7 +18,9 @@ register_log("distributed", DISTRIBUTED)
 register_log(
     "dist_c10d", ["torch.distributed.distributed_c10d", "torch.distributed.rendezvous"]
 )
-register_log("dist_ddp", ["torch.nn.parallel.distributed"])
+register_log(
+    "dist_ddp", ["torch.nn.parallel.distributed", "torch._dynamo.backends.distributed"]
+)
 register_log("dist_fsdp", ["torch.distributed.fsdp"])
 register_log("onnx", "torch.onnx")
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #116794

Note: ddp_graphs is still 'separate' from log components since it is an
artifact.  Not sure it's possible to enable it by default when dist_ddp
is selected.

cc @mlazos @fduwjj