### PR TITLE
[ROCm] Use MI210 CI runners for all trunk commits

### DIFF
--- a/.github/workflows/rocm.yml
+++ b/.github/workflows/rocm.yml
@@ -25,12 +25,12 @@ jobs:
       sync-tag: rocm-build
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 6, runner: "linux.rocm.gpu" },
-          { config: "default", shard: 2, num_shards: 6, runner: "linux.rocm.gpu" },
-          { config: "default", shard: 3, num_shards: 6, runner: "linux.rocm.gpu" },
-          { config: "default", shard: 4, num_shards: 6, runner: "linux.rocm.gpu" },
-          { config: "default", shard: 5, num_shards: 6, runner: "linux.rocm.gpu" },
-          { config: "default", shard: 6, num_shards: 6, runner: "linux.rocm.gpu" },
+          { config: "default", shard: 1, num_shards: 6, runner: "linux.rocm.gpu.2" },
+          { config: "default", shard: 2, num_shards: 6, runner: "linux.rocm.gpu.2" },
+          { config: "default", shard: 3, num_shards: 6, runner: "linux.rocm.gpu.2" },
+          { config: "default", shard: 4, num_shards: 6, runner: "linux.rocm.gpu.2" },
+          { config: "default", shard: 5, num_shards: 6, runner: "linux.rocm.gpu.2" },
+          { config: "default", shard: 6, num_shards: 6, runner: "linux.rocm.gpu.2" },
         ]}
 
   linux-focal-rocm5_7-py3_8-test:


### PR DESCRIPTION
As a follow-up to https://github.com/pytorch/pytorch/pull/115981

To make sure we catch any regressions/breakages related to flash attention/inductor/etc. functionality that is only enabled for MI210s, we would like to switch the trunk commit CI jobs to always run on MI210 runners. This should help us accurately identify the breaking commits for ROCm CI on the HUD.

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang