### PR TITLE
[HigherOrderOp] track input mutations with tensor version

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -1679,7 +1679,7 @@ class ExportTests(torch._dynamo.test_case.TestCase):
                     return x + x
 
                 def false_fn(x):
-                    return x[:2]
+                    return x[:2].sin()
 
                 return cond(x.shape[0] <= 2, true_fn, false_fn, [x])
 
@@ -1689,7 +1689,7 @@ class ExportTests(torch._dynamo.test_case.TestCase):
                     return x + x
 
                 def false_fn(x):
-                    return x[:2]
+                    return x[:2].sin()
 
                 return cond(x.shape[0] <= 2, true_fn, false_fn, (x,))
 
@@ -1726,7 +1726,8 @@ def forward(self, l_x_):
 def forward(self, l_x_):
     l_x__1 = l_x_
     getitem = l_x__1[slice(None, 2, None)];  l_x__1 = None
-    return (getitem,)""",
+    sin = getitem.sin();  getitem = None
+    return (sin,)""",
             )
             with self.assertRaisesRegex(
                 torch._dynamo.exc.UncapturedHigherOrderOpError,
@@ -3156,7 +3157,9 @@ def forward(self, x):
 
     def test_cond_raise_user_error_on_branch_return_multiple_tensors(self):
         def f_branch_return_multiple_tensors(pred, x, y):
-            return cond(pred, lambda x: (x, x), lambda x: (x, x), [y])
+            return cond(
+                pred, lambda x: (x + 1, x - 1), lambda x: (x.sin(), x.cos()), [y]
+            )
 
         example_inputs = (torch.tensor(True), torch.randn(4), torch.randn(2))
         gm, _ = torch._dynamo.export(

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -1327,6 +1327,135 @@ def forward(self, getitem, const):
             },
         )
 
+    def _check_raise_uncaptured_hoo_error(self, fn, args):
+        with self.assertRaises(torch._dynamo.exc.UncapturedHigherOrderOpError):
+            fn(*args)
+
+        with self.assertRaises(torch._dynamo.exc.UncapturedHigherOrderOpError):
+            torch.compile(fn, backend="eager")(*args)
+
+    def test_cond_raise_error_when_mutating_buffer(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("buffer", torch.randn(4, 4))
+
+            def forward(self, x):
+                def true_fn(x):
+                    self.buffer.add_(5)
+                    return x.cos() + self.buffer.sum()
+
+                def false_fn(x):
+                    return x.sin()
+
+                a = torch.cond(x.shape[0] > 4, true_fn, false_fn, [x])
+                return (a + 3, a + 4)
+
+        inp = torch.randn(3, 4)
+        m = M()
+        self._check_raise_uncaptured_hoo_error(m, (inp,))
+        with torch.inference_mode():
+            self._check_raise_uncaptured_hoo_error(m, (inp,))
+
+    def test_cond_raise_error_when_mutating_input(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("buffer", torch.randn(4, 4))
+
+            def forward(self, x):
+                def true_fn(x):
+                    return x.cos_() + self.buffer.sum()
+
+                def false_fn(x):
+                    return x.sin_()
+
+                a = torch.cond(x.shape[0] > 4, true_fn, false_fn, [x])
+                return (a + 3, a + 4)
+
+        inp = torch.randn(3, 4)
+        m = M()
+        self._check_raise_uncaptured_hoo_error(m, (inp,))
+        with torch.inference_mode():
+            self._check_raise_uncaptured_hoo_error(m, (inp,))
+
+    def test_cond_raise_error_when_mutating_closure(self):
+        t = torch.randn(1)
+
+        def fn(x):
+            def true_fn(x):
+                t.sin_()
+                return x.cos() + t
+
+            def false_fn(x):
+                return x.sin()
+
+            a = torch.cond(x.shape[0] > 4, true_fn, false_fn, [x])
+            return (a + 3, a + 4)
+
+        inp = torch.randn(3, 4)
+        self._check_raise_uncaptured_hoo_error(fn, (inp,))
+        with torch.inference_mode():
+            self._check_raise_uncaptured_hoo_error(fn, (inp,))
+
+    def test_cond_raise_error_when_output_alias_input(self):
+        def alias_input(pred, x, y):
+            def true_fn(x):
+                return x[0] + 1, x[1].view(-1) + 1
+
+            def false_fn(x):
+                return x[0] + 1, x[1].view(-1)
+
+            return torch.cond(pred, true_fn, false_fn, ((x, y),))
+
+        inp = (torch.tensor(True), torch.ones(3, 3), torch.ones(3, 3))
+        self._check_raise_uncaptured_hoo_error(alias_input, inp)
+        with torch.inference_mode():
+            self._check_raise_uncaptured_hoo_error(alias_input, inp)
+
+    def test_cond_raise_error_when_output_alias_buffer(self):
+        class AliaseBufferM(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("buffer", torch.randn(4, 4))
+
+            def forward(self, x):
+                def true_fn(x):
+                    return x.cos(), self.buffer.view(-1)
+
+                def false_fn(x):
+                    return x.sin(), self.buffer.view(-1) + 1
+
+                return torch.cond(x.shape[0] > 4, true_fn, false_fn, [x])
+
+        inp = torch.randn(3, 4)
+        with self.assertRaises(torch._dynamo.exc.UncapturedHigherOrderOpError):
+            torch.compile(AliaseBufferM(), backend="eager")(inp)
+
+        with self.assertRaises(torch._dynamo.exc.UncapturedHigherOrderOpError):
+            with torch.inference_mode():
+                torch.compile(AliaseBufferM(), backend="eager")(inp)
+
+    def test_cond_raise_error_when_output_alias_closure(self):
+        y = torch.ones(3, 4)
+
+        def alias_closure(pred, x):
+            def true_fn(x):
+                return x.view(-1) + 1
+
+            def false_fn(x):
+                return y.view(-1)
+
+            return torch.cond(pred, true_fn, false_fn, [x])
+
+        inp = torch.randn(3, 4)
+        with self.assertRaises(torch._dynamo.exc.UncapturedHigherOrderOpError):
+            torch.compile(alias_closure, backend="eager")(torch.tensor(False), inp)
+
+        with self.assertRaises(torch._dynamo.exc.UncapturedHigherOrderOpError):
+            with torch.inference_mode():
+                torch.compile(alias_closure, backend="eager")(torch.tensor(False), inp)
+
     @torch._dynamo.config.patch(
         assume_static_by_default=True,
         dynamic_shapes=True,
@@ -1580,7 +1709,7 @@ def forward(self):
     def test_cond_with_constant_pred(self):
         def test(pred, x):
             def true_fn(x):
-                return x
+                return x + 1
 
             def false_fn(x):
                 return -x
@@ -3753,7 +3882,7 @@ class ActivationCheckpointingTests(torch._dynamo.test_case.TestCase):
 
         def test(pred, x):
             def true_fn(x):
-                return x
+                return x + 1
 
             def false_fn(x):
                 return -x

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -4910,7 +4910,7 @@ def fn():
         from functorch.experimental.control_flow import cond
 
         def true_fn(x):
-            return x
+            return x.clone()
 
         def false_fn(x):
             return x.sin()

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -474,10 +474,10 @@ class TestControlFlowTraced(TestCase):
         example_inputs = (torch.ones(5, 5),)
         functional_f = torch.func.functionalize(f)
 
-        with self.assertRaisesRegex(UnsupportedAliasMutationException, "One of torch.cond branch might be aliasing"):
+        with self.assertRaises(torch._dynamo.exc.UncapturedHigherOrderOpError):
             functional_f(*example_inputs)
 
-        with self.assertRaisesRegex(UnsupportedAliasMutationException, "One of torch.cond branch might be aliasing"):
+        with self.assertRaises(torch._dynamo.exc.UncapturedHigherOrderOpError):
             make_fx(torch.func.functionalize(f))(*example_inputs)
 
     def test_cond_functionalized_nested_input_mutation(self):
@@ -501,10 +501,10 @@ class TestControlFlowTraced(TestCase):
 
         example_inputs = (torch.ones(4, 5),)
         functional_f = torch.func.functionalize(f)
-        with self.assertRaisesRegex(UnsupportedAliasMutationException, "One of torch.cond branch"):
+        with self.assertRaises(torch._dynamo.exc.UncapturedHigherOrderOpError):
             functional_f(*example_inputs)
 
-        with self.assertRaisesRegex(UnsupportedAliasMutationException, "One of torch.cond branch"):
+        with self.assertRaises(torch._dynamo.exc.UncapturedHigherOrderOpError):
             make_fx(torch.func.functionalize(f))(*example_inputs)
 
     def test_cond_functionalized_nested_input_mutation_with_aot_func(self):
@@ -530,10 +530,10 @@ class TestControlFlowTraced(TestCase):
         try:
             example_input_func = to_fun_old(example_input)
             torch._enable_functionalization(reapply_views=False)
-            with self.assertRaisesRegex(UnsupportedAliasMutationException, "One of torch.cond branch"):
+            with self.assertRaises(torch._dynamo.exc.UncapturedHigherOrderOpError):
                 f(example_input_func)
 
-            with self.assertRaisesRegex(UnsupportedAliasMutationException, "One of torch.cond branch"):
+            with self.assertRaises(torch._dynamo.exc.UncapturedHigherOrderOpError):
                 make_fx(f)(example_input_func)
         finally:
             torch._disable_functionalization()
@@ -548,7 +548,7 @@ class TestControlFlowTraced(TestCase):
                     torch._disable_functionalization()
             return wrapper
 
-        with self.assertRaisesRegex(UnsupportedAliasMutationException, "One of torch.cond branch"):
+        with self.assertRaises(torch._dynamo.exc.UncapturedHigherOrderOpError):
             make_fx(f_wrapper(f))(example_input_func)
 
 
@@ -568,7 +568,7 @@ class TestControlFlowTraced(TestCase):
         try:
             example_input_func = to_fun_old(example_input)
             torch._enable_functionalization(reapply_views=False)
-            with self.assertRaisesRegex(UnsupportedAliasMutationException, "One of torch.cond branch might be aliasing"):
+            with self.assertRaises(torch._dynamo.exc.UncapturedHigherOrderOpError):
                 f(example_input_func)
         finally:
             torch._disable_functionalization()
@@ -587,7 +587,7 @@ class TestControlFlowTraced(TestCase):
                     torch._disable_functionalization()
             return wrapper
 
-        with self.assertRaisesRegex(UnsupportedAliasMutationException, "One of torch.cond branch might be aliasing"):
+        with self.assertRaises(torch._dynamo.exc.UncapturedHigherOrderOpError):
             make_fx(f_wrapper(f))(example_input)
 
     def test_cond_functionalized_aot_func_check_functional(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #116799

Replacement of https://github.com/pytorch/pytorch/pull/115451 due to ghimport issues. Copy the PR description there:

Fixes https://github.com/pytorch/pytorch/issues/115277 by banning tensor buffer, tensor input and tensor lifted clousures mutations and requiring users to rewrite their code for now. It implements the idea of using tensor._version to detect mutations from @zou3519. After this PR, speculate_subgraph will return input proxies that gets mutated. Different HOOs can choose different strategies to make use of this info.

We might be able to support these mutations for HOOs but need to wait for user requests and decide.

Test Plan:
Added new tests for cond. Also modify existing tests that aliasing inputs.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @aakhundov