### PR TITLE
[codemod][lowrisk] Remove unused exception parameter from caffe2/c10/mobile/CPUCachingAllocator.cpp

### DIFF
--- a/c10/mobile/CPUCachingAllocator.cpp
+++ b/c10/mobile/CPUCachingAllocator.cpp
@@ -16,7 +16,7 @@ inline void* CPUCachingAllocator::allocate_and_cache(const size_t bytes) {
   void* ptr;
   try {
     ptr = c10::alloc_cpu(bytes);
-  } catch (c10::Error& e) {
+  } catch (c10::Error& ) {
     // If allocation fails, try freeing cached available blocks.
     // For now free all available cached blocks.
     free_cached();


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Test Plan: Sandcastle

Reviewed By: kimishpatel, palmje

