### PR TITLE
[C10] Mark Complex::imag as C10_HOST_DEVICE

### DIFF
--- a/c10/util/complex.h
+++ b/c10/util/complex.h
@@ -320,7 +320,7 @@ struct alignas(sizeof(T) * 2) complex {
   constexpr void real(T value) {
     real_ = value;
   }
-  constexpr T imag() const {
+  C10_HOST_DEVICE constexpr T imag() const {
     return imag_;
   }
   constexpr void imag(T value) {


### PR DESCRIPTION
It feels weird that `real` is marked as such, but `imag` is not

Find while working on https://github.com/pytorch/pytorch/issues/116628
