### PR TITLE
[CI] Use jemalloc for CUDA builds

### DIFF
--- a/.ci/docker/common/install_base.sh
+++ b/.ci/docker/common/install_base.sh
@@ -66,6 +66,7 @@ install_ubuntu() {
     libsndfile-dev \
     ${maybe_libomp_dev} \
     ${maybe_libnccl_dev} \
+    jemalloc2 \
     software-properties-common \
     wget \
     sudo \

--- a/.ci/docker/common/install_base.sh
+++ b/.ci/docker/common/install_base.sh
@@ -61,12 +61,12 @@ install_ubuntu() {
     ${maybe_libiomp_dev} \
     libyaml-dev \
     libz-dev \
+    libjemalloc2 \
     libjpeg-dev \
     libasound2-dev \
     libsndfile-dev \
     ${maybe_libomp_dev} \
     ${maybe_libnccl_dev} \
-    jemalloc2 \
     software-properties-common \
     wget \
     sudo \

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -28,6 +28,8 @@ echo "Environment variables:"
 env
 
 if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
+  # Use jemalloc during compilation to mitigate https://github.com/pytorch/pytorch/issues/116289
+  export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
   echo "NVCC version:"
   nvcc --version
 fi


### PR DESCRIPTION
According to @ptrblck it'll likely mitigate non-deterministic NVCC bug 
See https://github.com/pytorch/pytorch/issues/116289 for more detail

Test plan: ssh into one of the cuda builds and make sure that `LD_PRELOAD` is set for the top-level make command
