### PR TITLE
[MPS] Mark `torch.[all|any]` as working with complex on MacOS14

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -325,6 +325,7 @@ def mps_ops_modifier(ops):
         'acos',
         'acosh',
         'all',
+        'any',
         'argwhere',
         'asin',
         'atan',

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -324,6 +324,7 @@ def mps_ops_modifier(ops):
         '__rdiv__',
         'acos',
         'acosh',
+        'all',
         'argwhere',
         'asin',
         'atan',


### PR DESCRIPTION
It was enabled by https://github.com/pytorch/pytorch/pulls/116457 but at the time PR was landed Sonoma testing was still not enabled
