### PR TITLE
[C10D] FlightRecorder don't compute duration inside dump()

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -3710,6 +3710,10 @@ class NCCLTraceTest(NCCLTraceTestBase):
             f = pg.allreduce(a)
         f.wait()
         torch.cuda.synchronize(device=device)
+
+        # gah ok so now the duration_ms is populated best-effort since it can only happen outside "dump()" api
+        time.sleep(1)
+
         t = pickle.loads(torch._C._distributed_c10d._dump_nccl_trace())
         self.assertEqual(len(t), 2)
         last = t[-1]

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -3837,11 +3837,6 @@ class NCCLTraceTest(NCCLTraceTestBase):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     @parametrize("timing_enabled", [True, False])
     def test_trace_while_stuck(self, timing_enabled):
-        if timing_enabled:
-            self.skipTest(
-                "This test is expected to hang with timing enabled,"
-                " becuase gather_trace()->dump() ends up calling cudaEventQuery which hangs."
-            )
         if self.rank == self.MAIN_PROCESS_RANK:
             for c in self.children_pipes:
                 self.assertEqual(c.recv(), 'next')

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1569,7 +1569,7 @@ void ProcessGroupNCCL::watchdogHandler() {
 
       // Clean up completed work
       if (work.isCompleted()) {
-        NCCLTraceBuffer::get()->retire_id(work.trace_id_);
+        NCCLTraceBuffer::get()->retire_id(work.trace_id_, true);
         if (onCompletionHook_) {
           // Move Work object to completedWorkList_ to be consumed by the hook
           // thread

--- a/torch/csrc/distributed/c10d/TraceUtils.h
+++ b/torch/csrc/distributed/c10d/TraceUtils.h
@@ -474,9 +474,6 @@ struct NCCLTraceBuffer {
       }
       if (completed) {
         r.state_ = "completed";
-        if (r.start_ != nullptr) {
-          r.duration_ = getDurationFromFirstEvent(*r.start_, *r.end_);
-        }
       }
     }
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #116909
* #116905
* #114817

Computing duration can lead to a hang due to calling cudaEventQuery when
the cuda driver queue is full.

We don't ever want dump() api to hang, since we might want dump to help
debug a hang.  Watchdog may already hang due to cuda event queries, and
we have the monitor to kill and dump if watchdog hangs.

Perhaps we should use a separate thread for computing durations..

And this still doesn't fix test_trace_while_stuck?

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @yf225