### PR TITLE
Fix compiler warnings in cuda code

### DIFF
--- a/torch/csrc/distributed/c10d/intra_node_comm.cu
+++ b/torch/csrc/distributed/c10d/intra_node_comm.cu
@@ -659,7 +659,8 @@ AllReduceAlgo selectAllReduceAlgo(
     size_t worldSize) {
   // Only support bf16 for now
   if (input.dtype() != at::kBFloat16 ||
-      input.numel() * input.element_size() > kMaxIntraNodeSize) {
+      static_cast<size_t>(input.numel() * input.element_size()) >
+          kMaxIntraNodeSize) {
     return AllReduceAlgo::NONE;
   }
   const auto numel = input.numel();


### PR DESCRIPTION
Fixes compiler warnings about comparison between signed and unsigned data types


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225