### PR TITLE
Merge merging rules of CPU inductor and x86 CPU quantization

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -352,21 +352,6 @@
   - Lint
   - pull
 
-- name: x86 CPU quantization
-  patterns:
-  - aten/src/ATen/native/quantized/cpu/**
-  - torch/ao/quantization/quantizer/x86_inductor_quantizer.py
-  - torch/_inductor/fx_passes/quantization.py
-  - test/quantization/core/test_quantized_op.py
-  - test/quantization/pt2e/test_x86inductor_quantizer.py
-  approved_by:
-  - leslie-fang-intel
-  - jgong5
-  mandatory_checks_name:
-  - EasyCLA
-  - Lint
-  - pull
-
 - name: CPU inductor
   patterns:
   - torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -374,6 +359,11 @@
   - test/inductor/test_mkldnn_pattern_matcher.py
   - test/inductor/test_cpu_repo.py
   - test/inductor/test_cpu_cpp_wrapper.py
+  - aten/src/ATen/native/quantized/cpu/**
+  - torch/ao/quantization/quantizer/x86_inductor_quantizer.py
+  - torch/_inductor/fx_passes/quantization.py
+  - test/quantization/core/test_quantized_op.py
+  - test/quantization/pt2e/test_x86inductor_quantizer.py
   approved_by:
   - leslie-fang-intel
   - jgong5

--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -355,14 +355,14 @@
 - name: CPU inductor
   patterns:
   - torch/_inductor/fx_passes/mkldnn_fusion.py
+  - torch/_inductor/fx_passes/quantization.py
   - torch/_inductor/codegen/cpp.py
   - test/inductor/test_mkldnn_pattern_matcher.py
   - test/inductor/test_cpu_repo.py
   - test/inductor/test_cpu_cpp_wrapper.py
   - aten/src/ATen/native/quantized/cpu/**
-  - torch/ao/quantization/quantizer/x86_inductor_quantizer.py
-  - torch/_inductor/fx_passes/quantization.py
   - test/quantization/core/test_quantized_op.py
+  - torch/ao/quantization/quantizer/x86_inductor_quantizer.py
   - test/quantization/pt2e/test_x86inductor_quantizer.py
   approved_by:
   - leslie-fang-intel


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #116604
* #116599
* __->__ #116937

**Summary**
Following the discussion at https://github.com/pytorch/pytorch/pull/116599#issuecomment-1878757581, due to the limitation of the current merging rules that prevent cross-checking all files among different merge groups, it is proposed to merge the groups `x86 CPU quantization` and `CPU inductor` since they are closely related.
