### PR TITLE
[MPS] Add support for 64-bit index operations

### DIFF
--- a/aten/src/ATen/mps/IndexKernels.h
+++ b/aten/src/ATen/mps/IndexKernels.h
@@ -20,7 +20,7 @@ struct IndexAB {
 
 #endif
 
-template<typename T>
+template<typename T, typename OffsetsT>
 kernel void index_select(
 #if __METAL_VERSION__ >= 300
     constant IndexAB  * indexAB           [[buffer(0)]],
@@ -29,7 +29,7 @@ kernel void index_select(
 #endif
     constant void     * indexSizes        [[buffer(1)]],
     constant void     * indexStrides      [[buffer(2)]],
-    constant uint3    * offsets           [[buffer(3)]],
+    constant OffsetsT * offsets           [[buffer(3)]],
     constant void     * inputData         [[buffer(4)]],
     device   void     * outputData        [[buffer(5)]],
     constant uint32_t & num_indices       [[buffer(6)]],
@@ -54,7 +54,7 @@ kernel void index_select(
     *out = *in;
 }
 
-template<typename T>
+template<typename T, typename OffsetsT>
 void index_put_impl(
 #if __METAL_VERSION__ >= 300
     constant IndexAB  * indexAB,
@@ -63,12 +63,11 @@ void index_put_impl(
 #endif
     constant int64_t  * index_sizes,
     constant int64_t  * index_strides,
-    constant uint3    * offsets,
+    constant OffsetsT * offsets,
     constant void     * inputData,
     device   void     * outputData,
     constant uint32_t & num_indices,
-    uint thread_index
-){
+    uint thread_index) {
     int64_t offset = 0;
     for (uint32_t i = 0; i < num_indices; i++) {
 #if __METAL_VERSION__ >= 300
@@ -88,7 +87,7 @@ void index_put_impl(
     *out = *in;
 }
 
-template<typename T>
+template<typename T, typename OffsetsT>
 kernel void index_put_serial(
 #if __METAL_VERSION__ >= 300
     constant IndexAB  * indexAB           [[buffer(0)]],
@@ -97,7 +96,7 @@ kernel void index_put_serial(
 #endif
     constant void     * indexSizes        [[buffer(1)]],
     constant void     * indexStrides      [[buffer(2)]],
-    constant uint3    * offsets           [[buffer(3)]],
+    constant OffsetsT * offsets           [[buffer(3)]],
     constant void     * inputData         [[buffer(4)]],
     device   void     * outputData        [[buffer(5)]],
     constant uint32_t & num_indices       [[buffer(6)]],
@@ -112,7 +111,7 @@ kernel void index_put_serial(
     }
 }
 
-template<typename T>
+template<typename T, typename OffsetsT>
 kernel void index_put(
 #if __METAL_VERSION__ >= 300
     constant IndexAB  * indexAB           [[buffer(0)]],
@@ -121,7 +120,7 @@ kernel void index_put(
 #endif
     constant void     * indexSizes        [[buffer(1)]],
     constant void     * indexStrides      [[buffer(2)]],
-    constant uint3    * offsets           [[buffer(3)]],
+    constant OffsetsT * offsets           [[buffer(3)]],
     constant void     * inputData         [[buffer(4)]],
     device   void     * outputData        [[buffer(5)]],
     constant uint32_t & num_indices       [[buffer(6)]],
@@ -133,77 +132,85 @@ kernel void index_put(
 }
 
 #if __METAL_VERSION__ < 300
-#define REGISTER_INDEX_OP(DTYPE_SIZE, DTYPE, INDEX_OP_TYPE)     \
-template                                                        \
-[[host_name("index_" #INDEX_OP_TYPE "_" #DTYPE_SIZE)]]          \
-kernel void index_ ## INDEX_OP_TYPE<DTYPE>(                     \
-    constant IndexAB & indexAB           [[buffer(0)]],         \
-    constant void    * indexSizes        [[buffer(1)]],         \
-    constant void    * indexStrides      [[buffer(2)]],         \
-    constant uint3   * offsets           [[buffer(3)]],         \
-    constant void    * inputData         [[buffer(4)]],         \
-    device   void    * outputData        [[buffer(5)]],         \
-    constant uint32_t & num_indices      [[buffer(6)]],         \
+#define REGISTER_INDEX_OP(DTYPE_SIZE, IDX_SIZE, DTYPE, INDEX_OP_TYPE, IDX_DTYPE)   \
+template                                                                           \
+[[host_name("index_" #INDEX_OP_TYPE "_" #DTYPE_SIZE "_" #IDX_SIZE)]]               \
+kernel void index_ ## INDEX_OP_TYPE<DTYPE, IDX_DTYPE>(                             \
+    constant IndexAB & indexAB           [[buffer(0)]],                            \
+    constant void    * indexSizes        [[buffer(1)]],                            \
+    constant void    * indexStrides      [[buffer(2)]],                            \
+    constant IDX_DTYPE   * offsets           [[buffer(3)]],                        \
+    constant void    * inputData         [[buffer(4)]],                            \
+    device   void    * outputData        [[buffer(5)]],                            \
+    constant uint32_t & num_indices      [[buffer(6)]],                            \
     uint thread_index [[thread_position_in_grid]]);
 #else
-#define REGISTER_INDEX_OP(DTYPE_SIZE, DTYPE, INDEX_OP_TYPE)     \
-template                                                        \
-[[host_name("index_" #INDEX_OP_TYPE "_" #DTYPE_SIZE)]]          \
-kernel void index_ ## INDEX_OP_TYPE<DTYPE>(                     \
-    constant IndexAB * indexAB           [[buffer(0)]],         \
-    constant void    * indexSizes        [[buffer(1)]],         \
-    constant void    * indexStrides      [[buffer(2)]],         \
-    constant uint3   * offsets           [[buffer(3)]],         \
-    constant void    * inputData         [[buffer(4)]],         \
-    device   void    * outputData        [[buffer(5)]],         \
-    constant uint32_t & num_indices      [[buffer(6)]],         \
+#define REGISTER_INDEX_OP(DTYPE_SIZE, IDX_SIZE, DTYPE, INDEX_OP_TYPE, IDX_DTYPE)   \
+template                                                                           \
+[[host_name("index_" #INDEX_OP_TYPE "_" #DTYPE_SIZE "_" #IDX_SIZE)]]               \
+kernel void index_ ## INDEX_OP_TYPE<DTYPE, IDX_DTYPE>(                             \
+    constant IndexAB * indexAB           [[buffer(0)]],                            \
+    constant void    * indexSizes        [[buffer(1)]],                            \
+    constant void    * indexStrides      [[buffer(2)]],                            \
+    constant IDX_DTYPE   * offsets           [[buffer(3)]],                        \
+    constant void    * inputData         [[buffer(4)]],                            \
+    device   void    * outputData        [[buffer(5)]],                            \
+    constant uint32_t & num_indices      [[buffer(6)]],                            \
     uint thread_index [[thread_position_in_grid]]);
 #endif
 
 #define REGISTER_INDEX_OP_ALL_DTYPES(INDEX_OP_TYPE)     \
-    REGISTER_INDEX_OP(8bit,  char,  INDEX_OP_TYPE);     \
-    REGISTER_INDEX_OP(16bit, short, INDEX_OP_TYPE);     \
-    REGISTER_INDEX_OP(32bit, int,   INDEX_OP_TYPE);     \
-    REGISTER_INDEX_OP(64bit, long,  INDEX_OP_TYPE);
+    REGISTER_INDEX_OP(8bit,  idx32, char,  INDEX_OP_TYPE, uint3);     \
+    REGISTER_INDEX_OP(8bit,  idx64, char,  INDEX_OP_TYPE, ulong3);    \
+    REGISTER_INDEX_OP(16bit, idx32, short, INDEX_OP_TYPE, uint3);     \
+    REGISTER_INDEX_OP(16bit, idx64, short, INDEX_OP_TYPE, ulong3);    \
+    REGISTER_INDEX_OP(32bit, idx32, int,   INDEX_OP_TYPE, uint3);     \
+    REGISTER_INDEX_OP(32bit, idx64, int,   INDEX_OP_TYPE, ulong3);    \
+    REGISTER_INDEX_OP(64bit, idx32, long,  INDEX_OP_TYPE, uint3);     \
+    REGISTER_INDEX_OP(64bit, idx64, long,  INDEX_OP_TYPE, ulong3);
 
 REGISTER_INDEX_OP_ALL_DTYPES(select);
 REGISTER_INDEX_OP_ALL_DTYPES(put);
 
 #if __METAL_VERSION__ < 300
-#define REGISTER_SINGLE_THREADED_INDEX_OP(DTYPE_SIZE, DTYPE, INDEX_OP_TYPE)     \
-template                                                        \
-[[host_name("index_" #INDEX_OP_TYPE "_" #DTYPE_SIZE)]]          \
-kernel void index_ ## INDEX_OP_TYPE<DTYPE>(                     \
-    constant IndexAB & indexAB           [[buffer(0)]],         \
-    constant void    * indexSizes        [[buffer(1)]],         \
-    constant void    * indexStrides      [[buffer(2)]],         \
-    constant uint3   * offsets           [[buffer(3)]],         \
-    constant void    * inputData         [[buffer(4)]],         \
-    device   void    * outputData        [[buffer(5)]],         \
-    constant uint32_t & num_indices       [[buffer(6)]],        \
-    constant uint    * numIters          [[buffer(7)]],         \
+#define REGISTER_SINGLE_THREADED_INDEX_OP(DTYPE_SIZE, IDX_SIZE, DTYPE, INDEX_OP_TYPE, IDX_DTYPE)   \
+template                                                                                           \
+[[host_name("index_" #INDEX_OP_TYPE "_" #DTYPE_SIZE "_" #IDX_SIZE)]]                               \
+kernel void index_ ## INDEX_OP_TYPE<DTYPE, IDX_DTYPE>(                                             \
+    constant IndexAB   & indexAB           [[buffer(0)]],                                          \
+    constant void      * indexSizes        [[buffer(1)]],                                          \
+    constant void      * indexStrides      [[buffer(2)]],                                          \
+    constant IDX_DTYPE * offsets           [[buffer(3)]],                                          \
+    constant void      * inputData         [[buffer(4)]],                                          \
+    device   void      * outputData        [[buffer(5)]],                                          \
+    constant uint32_t  & num_indices       [[buffer(6)]],                                          \
+    constant uint      * numIters          [[buffer(7)]],                                          \
     uint thread_index [[thread_position_in_grid]]);
 #else
-#define REGISTER_SINGLE_THREADED_INDEX_OP(DTYPE_SIZE, DTYPE, INDEX_OP_TYPE)     \
-template                                                        \
-[[host_name("index_" #INDEX_OP_TYPE "_" #DTYPE_SIZE)]]          \
-kernel void index_ ## INDEX_OP_TYPE<DTYPE>(                     \
-    constant IndexAB * indexAB           [[buffer(0)]],         \
-    constant void    * indexSizes        [[buffer(1)]],         \
-    constant void    * indexStrides      [[buffer(2)]],         \
-    constant uint3   * offsets           [[buffer(3)]],         \
-    constant void    * inputData         [[buffer(4)]],         \
-    device   void    * outputData        [[buffer(5)]],         \
-    constant uint32_t & num_indices       [[buffer(6)]],        \
-    constant uint    * numIters          [[buffer(7)]],         \
+#define REGISTER_SINGLE_THREADED_INDEX_OP(DTYPE_SIZE, IDX_SIZE, DTYPE, INDEX_OP_TYPE, IDX_DTYPE)   \
+template                                                                                           \
+[[host_name("index_" #INDEX_OP_TYPE "_" #DTYPE_SIZE "_" #IDX_SIZE)]]                               \
+kernel void index_ ## INDEX_OP_TYPE<DTYPE, IDX_DTYPE>(                                             \
+    constant IndexAB   * indexAB           [[buffer(0)]],                                          \
+    constant void      * indexSizes        [[buffer(1)]],                                          \
+    constant void      * indexStrides      [[buffer(2)]],                                          \
+    constant IDX_DTYPE * offsets           [[buffer(3)]],                                          \
+    constant void      * inputData         [[buffer(4)]],                                          \
+    device   void      * outputData        [[buffer(5)]],                                          \
+    constant uint32_t  & num_indices       [[buffer(6)]],                                          \
+    constant uint      * numIters          [[buffer(7)]],                                          \
     uint thread_index [[thread_position_in_grid]]);
 #endif
 
-#define REGISTER_SINGLE_THREADED_INDEX_OP_ALL_DTYPES(INDEX_OP_TYPE)     \
-    REGISTER_SINGLE_THREADED_INDEX_OP(8bit,  char,  INDEX_OP_TYPE);     \
-    REGISTER_SINGLE_THREADED_INDEX_OP(16bit, short, INDEX_OP_TYPE);     \
-    REGISTER_SINGLE_THREADED_INDEX_OP(32bit, int,   INDEX_OP_TYPE);     \
-    REGISTER_SINGLE_THREADED_INDEX_OP(64bit, long,  INDEX_OP_TYPE);
+#define REGISTER_SINGLE_THREADED_INDEX_OP_ALL_DTYPES(INDEX_OP_TYPE)                   \
+    REGISTER_SINGLE_THREADED_INDEX_OP(8bit,  idx32, char,  INDEX_OP_TYPE, uint3);     \
+    REGISTER_SINGLE_THREADED_INDEX_OP(8bit,  idx64, char,  INDEX_OP_TYPE, ulong3);    \
+    REGISTER_SINGLE_THREADED_INDEX_OP(16bit, idx32, short, INDEX_OP_TYPE, uint3);     \
+    REGISTER_SINGLE_THREADED_INDEX_OP(16bit, idx64, short, INDEX_OP_TYPE, ulong3);    \
+    REGISTER_SINGLE_THREADED_INDEX_OP(32bit, idx32, int,   INDEX_OP_TYPE, uint3);     \
+    REGISTER_SINGLE_THREADED_INDEX_OP(32bit, idx64, int,   INDEX_OP_TYPE, ulong3);    \
+    REGISTER_SINGLE_THREADED_INDEX_OP(64bit, idx32, long,  INDEX_OP_TYPE, uint3);     \
+    REGISTER_SINGLE_THREADED_INDEX_OP(64bit, idx64, long,  INDEX_OP_TYPE, ulong3);
 
 REGISTER_SINGLE_THREADED_INDEX_OP_ALL_DTYPES(put_serial);
 
@@ -224,10 +231,19 @@ kernel void kernel_index_offset(constant StridesT * strides         [[buffer(0)]
 }
 
 template
-[[host_name("kernel_index_offsets")]]
+[[host_name("kernel_index_offsets_32")]]
 kernel void kernel_index_offset<packed_uint3, uint3>(
                 constant packed_uint3 * strides         [[buffer(0)]],
                 device uint3          * data_offsets    [[buffer(1)]],
+                constant uint         * iter_shape      [[buffer(2)]],
+                constant uint         & num_dimensions  [[buffer(3)]],
+                uint thread_index [[thread_position_in_grid]]);
+
+template
+[[host_name("kernel_index_offsets_64")]]
+kernel void kernel_index_offset<packed_uint3, ulong3>(
+                constant packed_uint3 * strides         [[buffer(0)]],
+                device ulong3          * data_offsets    [[buffer(1)]],
                 constant uint         * iter_shape      [[buffer(2)]],
                 constant uint         & num_dimensions  [[buffer(3)]],
                 uint thread_index [[thread_position_in_grid]]);
@@ -241,19 +257,19 @@ kernel void kernel_index_offset<uint, uint>(
                 constant uint         & num_dimensions  [[buffer(3)]],
                 uint thread_index [[thread_position_in_grid]]);
 
-template<typename T, typename E>
+template<typename T, typename E, typename OffsetsT>
 kernel void index_put_accumulate_native_dtypes(
 #if __METAL_VERSION__ >= 300
     constant IndexAB  * indexAB     [[buffer(0)]],
 #else
     constant IndexAB  & indexAB     [[buffer(0)]],
 #endif
-    constant void    * indexSizes   [[buffer(1)]],
-    constant void    * indexStrides [[buffer(2)]],
-    constant uint3   * offsets      [[buffer(3)]],
-    constant void    * inputData    [[buffer(4)]],
-    device void      * outputData   [[buffer(5)]],
-    constant uint32_t& num_indices  [[buffer(6)]],
+    constant void     * indexSizes   [[buffer(1)]],
+    constant void     * indexStrides [[buffer(2)]],
+    constant OffsetsT * offsets      [[buffer(3)]],
+    constant void     * inputData    [[buffer(4)]],
+    device void       * outputData   [[buffer(5)]],
+    constant uint32_t & num_indices  [[buffer(6)]],
     uint thread_index [[thread_position_in_grid]]) {
     constant int64_t * index_sizes   = (constant int64_t *)indexSizes;
     constant int64_t * index_strides = (constant int64_t *)indexStrides;
@@ -285,19 +301,19 @@ __attribute__((__always_inline__)) void atomic_fetch_add_relaxed(device void * a
     }
 }
 
-template<typename T>
+template<typename T, typename OffsetsT>
 kernel void atomic_index_put_accumulate(
 #if __METAL_VERSION__ >= 300
-    constant IndexAB * indexAB           [[buffer(0)]],
+    constant IndexAB  * indexAB           [[buffer(0)]],
 #else
-    constant IndexAB & indexAB           [[buffer(0)]],
+    constant IndexAB  & indexAB           [[buffer(0)]],
 #endif
-    constant void    * indexSizes        [[buffer(1)]],
-    constant void    * indexStrides      [[buffer(2)]],
-    constant uint3   * offsets           [[buffer(3)]],
-    constant void    * inputData         [[buffer(4)]],
-    device   void    * outputData        [[buffer(5)]],
-    constant uint32_t& num_indices       [[buffer(6)]],
+    constant void     * indexSizes        [[buffer(1)]],
+    constant void     * indexStrides      [[buffer(2)]],
+    constant OffsetsT * offsets           [[buffer(3)]],
+    constant void     * inputData         [[buffer(4)]],
+    device   void     * outputData        [[buffer(5)]],
+    constant uint32_t & num_indices       [[buffer(6)]],
     uint thread_index [[thread_position_in_grid]]) {
     constant int64_t * index_sizes   = (constant int64_t *)indexSizes;
     constant int64_t * index_strides = (constant int64_t *)indexStrides;
@@ -320,35 +336,67 @@ kernel void atomic_index_put_accumulate(
 }
 
 template
-[[host_name("index_put_accumulate_32bit_float")]]
-kernel void atomic_index_put_accumulate<float>(
+[[host_name("index_put_accumulate_32bit_float_idx32")]]
+kernel void atomic_index_put_accumulate<float, uint3>(
 #if __METAL_VERSION__ >= 300
     constant IndexAB  * indexAB     [[buffer(0)]],
 #else
     constant IndexAB  & indexAB     [[buffer(0)]],
 #endif
-    constant void    * indexSizes   [[buffer(1)]],
-    constant void    * indexStrides [[buffer(2)]],
-    constant uint3   * offsets      [[buffer(3)]],
-    constant void    * inputData    [[buffer(4)]],
-    device   void    * outputData   [[buffer(5)]],
-    constant uint32_t& num_indices  [[buffer(6)]],
+    constant void     * indexSizes   [[buffer(1)]],
+    constant void     * indexStrides [[buffer(2)]],
+    constant uint3    * offsets      [[buffer(3)]],
+    constant void     * inputData    [[buffer(4)]],
+    device   void     * outputData   [[buffer(5)]],
+    constant uint32_t & num_indices  [[buffer(6)]],
     uint thread_index [[thread_position_in_grid]]);
 
 template
-[[host_name("index_put_accumulate_32bit_int")]]
-kernel void index_put_accumulate_native_dtypes<atomic_int, int>(
+[[host_name("index_put_accumulate_32bit_float_idx64")]]
+kernel void atomic_index_put_accumulate<float, ulong3>(
 #if __METAL_VERSION__ >= 300
     constant IndexAB  * indexAB     [[buffer(0)]],
 #else
     constant IndexAB  & indexAB     [[buffer(0)]],
 #endif
-    constant void    * indexSizes   [[buffer(1)]],
-    constant void    * indexStrides [[buffer(2)]],
-    constant uint3   * offsets      [[buffer(3)]],
-    constant void    * inputData    [[buffer(4)]],
-    device   void    * outputData   [[buffer(5)]],
-    constant uint32_t& num_indices [[buffer(6)]],
+    constant void     * indexSizes   [[buffer(1)]],
+    constant void     * indexStrides [[buffer(2)]],
+    constant ulong3   * offsets      [[buffer(3)]],
+    constant void     * inputData    [[buffer(4)]],
+    device   void     * outputData   [[buffer(5)]],
+    constant uint32_t & num_indices  [[buffer(6)]],
+    uint thread_index [[thread_position_in_grid]]);
+
+template
+[[host_name("index_put_accumulate_32bit_int_idx32")]]
+kernel void index_put_accumulate_native_dtypes<atomic_int, int, uint3>(
+#if __METAL_VERSION__ >= 300
+    constant IndexAB  * indexAB     [[buffer(0)]],
+#else
+    constant IndexAB  & indexAB     [[buffer(0)]],
+#endif
+    constant void     * indexSizes   [[buffer(1)]],
+    constant void     * indexStrides [[buffer(2)]],
+    constant uint3    * offsets      [[buffer(3)]],
+    constant void     * inputData    [[buffer(4)]],
+    device   void     * outputData   [[buffer(5)]],
+    constant uint32_t & num_indices [[buffer(6)]],
+    uint thread_index [[thread_position_in_grid]]);
+
+template
+[[host_name("index_put_accumulate_32bit_int_idx64")]]
+kernel void index_put_accumulate_native_dtypes<atomic_int, int, ulong3>(
+#if __METAL_VERSION__ >= 300
+    constant IndexAB  * indexAB     [[buffer(0)]],
+#else
+    constant IndexAB  & indexAB     [[buffer(0)]],
+#endif
+    constant void     * indexSizes   [[buffer(1)]],
+    constant void     * indexStrides [[buffer(2)]],
+    constant ulong3   * offsets      [[buffer(3)]],
+    constant void     * inputData    [[buffer(4)]],
+    device   void     * outputData   [[buffer(5)]],
+    constant uint32_t & num_indices [[buffer(6)]],
     uint thread_index [[thread_position_in_grid]]);
 )INDEX_METAL";
 

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -342,6 +342,6 @@ static inline void mtl_dispatch1DJob(id<MTLComputeCommandEncoder> encoder,
   [encoder dispatchThreads:size threadsPerThreadgroup:threadGroupSize];
 }
 
-id<MTLBuffer> generateKernelDataOffsets(id<MTLComputeCommandEncoder> commandEncoder, const TensorIteratorBase& iter);
+id<MTLBuffer> generateKernelDataOffsets(id<MTLComputeCommandEncoder> commandEncoder, const TensorIteratorBase& iter, bool use_64bit_index = false);
 
 } // namespace at::native::mps

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -549,7 +549,9 @@ class MPSGraphCacheCallback : public IMpsAllocatorCallback {
 
 REGISTER_MPS_ALLOCATOR_CALLBACK("mps_graph_cache_callback", MPSGraphCacheCallback);
 
-id<MTLBuffer> generateKernelDataOffsets(id<MTLComputeCommandEncoder> commandEncoder, const TensorIteratorBase& iter) {
+id<MTLBuffer> generateKernelDataOffsets(id<MTLComputeCommandEncoder> commandEncoder,
+                                        const TensorIteratorBase& iter,
+                                        bool use_64bit_index) {
   constexpr uint32_t nOffsets = 3;
   uint32_t numThreads = iter.numel();
   const uint32_t nDim = iter.ndim();
@@ -557,7 +559,7 @@ id<MTLBuffer> generateKernelDataOffsets(id<MTLComputeCommandEncoder> commandEnco
   std::vector<uint32_t> iterShapeData(iterShape.size());
   std::vector<std::array<uint32_t, nOffsets>> strides(nDim);
   TORCH_INTERNAL_ASSERT(iter.ntensors() == nOffsets);
-  TORCH_CHECK(iter.can_use_32bit_indexing(), "Can't be indexed using 32-bit iterator");
+  TORCH_CHECK(use_64bit_index || iter.can_use_32bit_indexing(), "Can't be indexed using 32-bit iterator");
 
   for (const auto i : c10::irange(iterShape.size())) {
     iterShapeData[i] = static_cast<uint32_t>(iterShape[i]);
@@ -569,8 +571,10 @@ id<MTLBuffer> generateKernelDataOffsets(id<MTLComputeCommandEncoder> commandEnco
     }
   }
 
-  id<MTLComputePipelineState> kernelDataOffsetsPSO = MPSDevice::getInstance()->metalIndexingPSO("kernel_index_offsets");
-  id<MTLBuffer> kernelDataOffsets = (id<MTLBuffer>)getIMPSAllocator()->allocate(numThreads * sizeof(simd_uint3)).get();
+  id<MTLComputePipelineState> kernelDataOffsetsPSO = MPSDevice::getInstance()->metalIndexingPSO(
+      use_64bit_index ? "kernel_index_offsets_64" : "kernel_index_offsets_32");
+  const auto elementSize = use_64bit_index ? sizeof(simd_ulong3) : sizeof(simd_uint3);
+  id<MTLBuffer> kernelDataOffsets = (id<MTLBuffer>)getIMPSAllocator()->allocate(numThreads * elementSize).get();
 
   [commandEncoder setComputePipelineState:kernelDataOffsetsPSO];
   [commandEncoder setBytes:strides.data() length:sizeof(uint32_t) * nDim * nOffsets atIndex:0];

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6851,6 +6851,22 @@ class TestMPS(TestCaseMPS):
         # test float16
         helper((2,), 0, [1], (1,), 6.0, x_dtype=torch.float16)
 
+    def test_index_64bit(self):
+        """ Test that index operations work for 4Gb+ tensors """
+        # Cleanup memory
+        gc.collect()
+        torch.mps.empty_cache()
+        # Check that index operations work for 4+GB tensors
+        x = torch.rand(16000, 67120, device="mps")
+        self.assertGreater(x.element_size() * x.numel(), 2**32)
+        idx = torch.arange(0, 2, device="mps")
+        x_sampled = x[:, idx]
+        self.assertEqual(x[:, 0], x_sampled[:, 0])
+        # Reclaim memory after running the tests
+        del x
+        gc.collect()
+        torch.mps.empty_cache()
+
     # Test flip
     def test_flip(self):
         def helper(shape, dims):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #117037
* __->__ #116942
* #116940
* #116915
* #116904
* #116903

But enable it only if `iter.can_use_32bit_indexing()` is False. add test for index_select, but enable it only on Sonoma, as all attempts to create 4Gb+ tensor on Ventura and older fail