### PR TITLE
Update the expected accuracy value for demucs

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/aot_eager_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/aot_eager_torchbench_inference.csv
@@ -54,7 +54,7 @@ dcgan,pass,0
 
 
 
-demucs,eager_fail_to_run,0
+demucs,pass,3
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/aot_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/aot_inductor_torchbench_inference.csv
@@ -50,7 +50,7 @@ dcgan,pass,0
 
 
 
-demucs,eager_fail_to_run,0
+demucs,pass,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_torchbench_inference.csv
@@ -54,7 +54,7 @@ dcgan,pass,0
 
 
 
-demucs,eager_fail_to_run,0
+demucs,pass,3
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_torchbench_inference.csv
@@ -54,7 +54,7 @@ dcgan,pass,0
 
 
 
-demucs,eager_fail_to_run,0
+demucs,pass,3
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_torchbench_inference.csv
@@ -54,7 +54,7 @@ dcgan,pass,0
 
 
 
-demucs,eager_fail_to_run,0
+demucs,pass,3
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_inference.csv
@@ -54,7 +54,7 @@ dcgan,pass,0
 
 
 
-demucs,eager_fail_to_run,0
+demucs,pass,3
 
 
 


### PR DESCRIPTION
Update the expected value with `python benchmarks/dynamo/ci_expected_accuracy/update_expected.py b847290ddd9c6a5a598c70f8b660ee2b1e71dc95` as this is now failing in trunk after https://hud.pytorch.org/pytorch/pytorch/commit/95041829c8a76755d22df9bd711f25781e57e223

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng