### PR TITLE
update build guide to use mkl-static.

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ pip install -r requirements.txt
 **On Linux**
 
 ```bash
-conda install mkl mkl-include
+conda install intel::mkl-static intel::mkl-include
 # CUDA only: Add LAPACK support for the GPU if needed
 conda install -c pytorch magma-cuda110  # or the magma-cuda* that matches your CUDA version from https://anaconda.org/pytorch/repo
 
@@ -207,7 +207,7 @@ make triton
 
 ```bash
 # Add this package on intel x86 processor machines only
-conda install mkl mkl-include
+conda install intel::mkl-static intel::mkl-include
 # Add these packages if torch.distributed is needed
 conda install pkg-config libuv
 ```
@@ -215,7 +215,7 @@ conda install pkg-config libuv
 **On Windows**
 
 ```bash
-conda install mkl mkl-include
+conda install intel::mkl-static intel::mkl-include
 # Add these packages if torch.distributed is needed.
 # Distributed package support on Windows is a prototype feature and is subject to changes.
 conda install -c conda-forge libuv=1.39


### PR DESCRIPTION
# Background: 
We found current build guide use mkl dynamic link. It may trigger a mkl link issue.
 
Detailed: 
In build environment, libtorch_cpu.so will dynamic link to system mkl binaries by default.
If users install another version mkl library, it may lead to mkl symbol conflict.

I also checked released pytorch binary it use static mkl link. The build script shows it: https://github.com/pytorch/builder/blob/main/common/install_mkl.sh#L10

# Solution:
Update build guide to use mkl static link. And it is aligned to build script.

Conda install command docs:
https://anaconda.org/intel/mkl-static
https://anaconda.org/intel/mkl-include

# Validation
No mkl libraries dependencing, after use `conda install intel::mkl-static intel::mkl-include`.
## Windows
![image](https://github.com/pytorch/pytorch/assets/8433590/cc554ded-d827-4de5-81c6-cc3039155580)

## Linux
<img width="959" alt="image" src="https://github.com/pytorch/pytorch/assets/8433590/79766ad8-4ba2-4ff1-adc9-63affd8d419a">


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10