### PR TITLE
[DRAFT] [ROCm] Enable stream pipelining as default for ROCm triton configs

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -545,6 +545,11 @@ class triton:
     # Valid values: "compile_error", "runtime_error", "accuracy"
     inject_relu_bug_TESTING_ONLY = None
 
+    # Use a default num_stages for the majority of triton configs in PyTorch.
+    # This is mostly useful for ROCm as num_stages=0 is more performant
+    # as this enables stream pipeline mode for ROCm triton.
+    default_num_stages = 1 if not torch.version.hip else 0
+
 
 class aot_inductor:
     # AOTInductor output path

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -67,7 +67,7 @@ platform_configs = tuple(
 # On ROCm convert num_stages to 0 to enable stream pipelining
 if torch.version.hip:
     platform_configs = tuple(
-        (config[0], config[1], config[2], config.default_num_stages, config[4]) for config in platform_configs
+        (c[0], c[1], c[2], config.triton.default_num_stages, config[4]) for c in platform_configs
     )
 
 conv_configs = functools.partial(

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -64,10 +64,10 @@ platform_configs = tuple(
     if config["cond"]
 )
 
-# On ROCm convert num_stages to 1 as pipelining provides no benefit
+# On ROCm convert num_stages to 0 to enable stream pipelining
 if torch.version.hip:
     platform_configs = tuple(
-        (config[0], config[1], config[2], 1, config[4]) for config in platform_configs
+        (config[0], config[1], config[2], config.default_num_stages, config[4]) for config in platform_configs
     )
 
 conv_configs = functools.partial(

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -128,11 +128,11 @@ int8_platform_configs = tuple(
 # On ROCm convert num_stages to 0 to enable stream pipelining
 if torch.version.hip:
     mm_platform_configs = tuple(
-        (config[0], config[1], config[2], inductor_config.default_num_stages, config[4])
+        (config[0], config[1], config[2], inductor_config.triton.default_num_stages, config[4])
         for config in mm_platform_configs
     )
     int8_platform_configs = tuple(
-        (config[0], config[1], config[2], inductor_config.default_num_stages, config[4])
+        (config[0], config[1], config[2], inductor_config.triton.default_num_stages, config[4])
         for config in mm_platform_configs
     )
 

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -125,14 +125,14 @@ int8_platform_configs = tuple(
     if config["cond"]
 )
 
-# On ROCm convert num_stages to 1 as pipelining provides no benefit
+# On ROCm convert num_stages to 0 to enable stream pipelining
 if torch.version.hip:
     mm_platform_configs = tuple(
-        (config[0], config[1], config[2], 1, config[4])
+        (config[0], config[1], config[2], inductor_config.default_num_stages, config[4])
         for config in mm_platform_configs
     )
     int8_platform_configs = tuple(
-        (config[0], config[1], config[2], 1, config[4])
+        (config[0], config[1], config[2], inductor_config.default_num_stages, config[4])
         for config in mm_platform_configs
     )
 

--- a/torch/_inductor/kernel/mm_plus_mm.py
+++ b/torch/_inductor/kernel/mm_plus_mm.py
@@ -173,7 +173,7 @@ def mm_configs():
     # On ROCm convert num_stages to 0 to enable stream pipelining
     if torch.version.hip:
         filtered_configs = [
-            triton.Config(c["config"], num_stages=config.default_num_stages, num_warps=c["num_warps"])
+            triton.Config(c["config"], num_stages=config.triton.default_num_stages, num_warps=c["num_warps"])
             for c in mm_triton_configs
             if c["cond"]
         ]

--- a/torch/_inductor/kernel/mm_plus_mm.py
+++ b/torch/_inductor/kernel/mm_plus_mm.py
@@ -2,6 +2,7 @@ import functools
 
 import torch
 
+from .. import config
 from ..lowering import lowerings
 from ..select_algorithm import (
     autotune_select_algorithm,
@@ -169,10 +170,10 @@ def mm_configs():
     ]
 
     # Filter out configs in which cond evaluates to true
-    # On ROCm convert num_stages to 1 as pipelining provides no benefit
+    # On ROCm convert num_stages to 0 to enable stream pipelining
     if torch.version.hip:
         filtered_configs = [
-            triton.Config(c["config"], num_stages=1, num_warps=c["num_warps"])
+            triton.Config(c["config"], num_stages=config.default_num_stages, num_warps=c["num_warps"])
             for c in mm_triton_configs
             if c["cond"]
         ]

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -885,7 +885,7 @@ def triton_config(
     x,
     y=None,
     z=None,
-    num_stages=config.default_num_stages,
+    num_stages=config.triton.default_num_stages,
     num_elements_per_warp=256,
     min_elem_per_thread=0,
 ) -> Config:
@@ -975,7 +975,7 @@ def triton_config(
     return Config(cfg, num_warps=num_warps, num_stages=num_stages)
 
 
-def triton_config_reduction(size_hints, x, r, num_stages=config.default_num_stages, num_warps=None) -> Config:
+def triton_config_reduction(size_hints, x, r, num_stages=config.triton.default_num_stages, num_warps=None) -> Config:
     """
     Construct a reduction triton config with some adjustment heuristics
     based on size_hints. Size_hints is a tuple of numels in each tile
@@ -1004,7 +1004,7 @@ def triton_config_reduction(size_hints, x, r, num_stages=config.default_num_stag
     return Config(cfg, num_warps=num_warps, num_stages=num_stages)
 
 
-def triton_config_tiled_reduction(size_hints, x, y, r, num_stages=config.default_num_stages):
+def triton_config_tiled_reduction(size_hints, x, y, r, num_stages=config.triton.default_num_stages):
     """
     Construct a tile reduction triton config with some adjustment
     heuristics based on size_hints. Size_hints is a tuple of numels in
@@ -1321,7 +1321,7 @@ def foreach(triton_meta, num_warps, filename=None, inductor_meta=None):
     """
     return cached_autotune(
         None,
-        [triton.Config({}, num_stages=config.default_num_stages, num_warps=num_warps)],
+        [triton.Config({}, num_stages=config.triton.default_num_stages, num_warps=num_warps)],
         triton_meta=triton_meta,
         inductor_meta=inductor_meta,
         heuristic_type=HeuristicType.TEMPLATE,

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -885,7 +885,7 @@ def triton_config(
     x,
     y=None,
     z=None,
-    num_stages=1,
+    num_stages=config.default_num_stages,
     num_elements_per_warp=256,
     min_elem_per_thread=0,
 ) -> Config:
@@ -975,7 +975,7 @@ def triton_config(
     return Config(cfg, num_warps=num_warps, num_stages=num_stages)
 
 
-def triton_config_reduction(size_hints, x, r, num_stages=1, num_warps=None) -> Config:
+def triton_config_reduction(size_hints, x, r, num_stages=config.default_num_stages, num_warps=None) -> Config:
     """
     Construct a reduction triton config with some adjustment heuristics
     based on size_hints. Size_hints is a tuple of numels in each tile
@@ -1004,7 +1004,7 @@ def triton_config_reduction(size_hints, x, r, num_stages=1, num_warps=None) -> C
     return Config(cfg, num_warps=num_warps, num_stages=num_stages)
 
 
-def triton_config_tiled_reduction(size_hints, x, y, r, num_stages=1):
+def triton_config_tiled_reduction(size_hints, x, y, r, num_stages=config.default_num_stages):
     """
     Construct a tile reduction triton config with some adjustment
     heuristics based on size_hints. Size_hints is a tuple of numels in
@@ -1321,7 +1321,7 @@ def foreach(triton_meta, num_warps, filename=None, inductor_meta=None):
     """
     return cached_autotune(
         None,
-        [triton.Config({}, num_stages=1, num_warps=num_warps)],
+        [triton.Config({}, num_stages=config.default_num_stages, num_warps=num_warps)],
         triton_meta=triton_meta,
         inductor_meta=inductor_meta,
         heuristic_type=HeuristicType.TEMPLATE,


### PR DESCRIPTION
Uses `num_stages=0` as default for ROCm Triton configs as we saw a performance improvement enabling stream pipelining approaches.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang