### PR TITLE
[dynamo] Move graph breaks in for/while->skip after logging

### DIFF
--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -366,6 +366,7 @@ def generic_jump(truth_fn: typing.Callable[[object], bool], push: bool):
             isinstance(value, (TensorVariable)) and self.should_compile_partial_graph()
         ):
             # compile a partial subgraph prefix then jump into user code
+            breakpoint()
             if self.has_backedge():
                 msg = (
                     "Skipping frame because there is a graph break in a for/while loop\n"
@@ -461,14 +462,6 @@ def break_graph_if_unsupported(*, push):
                 )
                 return inner_fn(self, inst)
             except Unsupported as excp:
-                if self.should_compile_partial_graph() and self.has_backedge():
-                    msg = (
-                        "Skipping frame because there is a graph break in a for/while loop\n"
-                        f"{self.frame_summary()}"
-                    )
-                    log.info(msg)
-                    raise exc.SkipFrame(msg) from excp
-
                 if self.generic_context_manager_depth > 0:
                     # We don't support graph break under GenericContextWrappingVariable,
                     # If there is, we roll back to the checkpoint and fall back.
@@ -499,6 +492,14 @@ def break_graph_if_unsupported(*, push):
                         excp,
                         user_stack_formatted,
                     )
+
+                if self.has_backedge():
+                    msg = (
+                        "Skipping frame because there is a graph break in a for/while loop\n"
+                        f"{self.frame_summary()}"
+                    )
+                    log.info(msg)
+                    raise exc.SkipFrame(msg) from excp
 
                 excp.remove_from_stats()
                 excp.add_to_stats("graph_break")

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -366,7 +366,6 @@ def generic_jump(truth_fn: typing.Callable[[object], bool], push: bool):
             isinstance(value, (TensorVariable)) and self.should_compile_partial_graph()
         ):
             # compile a partial subgraph prefix then jump into user code
-            breakpoint()
             if self.has_backedge():
                 msg = (
                     "Skipping frame because there is a graph break in a for/while loop\n"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #116981

We were losing critical graph break info if the graph break came from a for or while loop.

Given:

```
def foo(x, y):
    z = x * y
    for i in range(10):
        z = z * y
        print(z)
    return z


a = torch.randn([2, 2])
b = torch.randn([2, 2])

foo = torch._dynamo.optimize('eager')(foo)

foo(a, b)
```

Before:

```
$ TORCH_LOGS=+graph_breaks python x.py 
tensor([[-0.1046, -0.1597],
        [-0.0006, -0.1327]])
tensor([[-4.2091e-02,  6.3045e-02],
        [-1.6759e-05,  4.0366e-02]])
tensor([[-1.6929e-02, -2.4892e-02],
        [-4.8690e-07, -1.2281e-02]])
tensor([[-6.8091e-03,  9.8278e-03],
        [-1.4146e-08,  3.7363e-03]])
tensor([[-2.7387e-03, -3.8803e-03],
        [-4.1097e-10, -1.1367e-03]])
tensor([[-1.1015e-03,  1.5320e-03],
        [-1.1940e-11,  3.4584e-04]])
tensor([[-4.4304e-04, -6.0488e-04],
        [-3.4688e-13, -1.0522e-04]])
tensor([[-1.7820e-04,  2.3882e-04],
        [-1.0078e-14,  3.2012e-05]])
tensor([[-7.1672e-05, -9.4293e-05],
        [-2.9279e-16, -9.7392e-06]])
tensor([[-2.8827e-05,  3.7229e-05],
        [-8.5063e-18,  2.9630e-06]])
```
After:

```
$ TORCH_LOGS=+graph_breaks python x.py 
[2024-01-08 11:14:49,372] [0/0] torch._dynamo.symbolic_convert.__graph_breaks: [DEBUG] Graph break: call_function BuiltinVariable(print) [TensorVariable()] {} from user code at:
[2024-01-08 11:14:49,372] [0/0] torch._dynamo.symbolic_convert.__graph_breaks: [DEBUG]   File "/data/users/voz/pytorch/x.py", line 32, in foo
[2024-01-08 11:14:49,372] [0/0] torch._dynamo.symbolic_convert.__graph_breaks: [DEBUG]     print(z)
[2024-01-08 11:14:49,372] [0/0] torch._dynamo.symbolic_convert.__graph_breaks: [DEBUG] 
tensor([[ 0.2065,  0.0766],
        [-2.0600,  1.8425]])
tensor([[-0.0617, -0.0698],
        [-3.5799,  2.2167]])
tensor([[ 0.0184,  0.0636],
        [-6.2212,  2.6669]])
tensor([[-5.5031e-03, -5.7971e-02],
        [-1.0811e+01,  3.2085e+00]])
tensor([[ 1.6437e-03,  5.2837e-02],
        [-1.8788e+01,  3.8601e+00]])
tensor([[-4.9093e-04, -4.8157e-02],
        [-3.2650e+01,  4.6441e+00]])
tensor([[ 1.4663e-04,  4.3891e-02],
        [-5.6741e+01,  5.5872e+00]])
tensor([[-4.3796e-05, -4.0004e-02],
        [-9.8605e+01,  6.7220e+00]])
tensor([[ 1.3081e-05,  3.6461e-02],
        [-1.7136e+02,  8.0871e+00]])
tensor([[-3.9070e-06, -3.3231e-02],
        [-2.9779e+02,  9.7296e+00]])
````        


cc @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng