### PR TITLE
[ROCm] hipify mapping for cudaDevAttrMaxSharedMemoryPerBlockOptin

### DIFF
--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -4239,6 +4239,10 @@ CUDA_IDENTIFIER_MAP = collections.OrderedDict(
             ("hipDeviceAttributeMaxSharedMemoryPerBlock", CONV_TYPE, API_RUNTIME),
         ),
         (
+            "cudaDevAttrMaxSharedMemoryPerBlockOptin",
+            ("hipDeviceAttributeMaxSharedMemoryPerBlock", CONV_TYPE, API_RUNTIME),
+        ),
+        (
             "cudaDevAttrTotalConstantMemory",
             ("hipDeviceAttributeTotalConstantMemory", CONV_TYPE, API_RUNTIME),
         ),


### PR DESCRIPTION
Summary: Map `cudaDevAttrMaxSharedMemoryPerBlockOptin` to `hipDeviceAttributeMaxSharedMemoryPerBlock` to make it work for AMD GPUs.

Test Plan: CI

Differential Revision: D52558076




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang