### PR TITLE
Add warning when trying to use nccl version while not compiled with nccl

### DIFF
--- a/torch/cuda/nccl.py
+++ b/torch/cuda/nccl.py
@@ -32,9 +32,8 @@ def is_available(tensors):
 
 
 def version():
-    # check if nccl is supported. If not found
-    # return invalid version
-    if not (hasattr(torch._C, "_nccl_version")):
+    if not hasattr(torch._C, "_nccl_version"):
+        warnings.warn("PyTorch is not compiled with NCCL support")
         return (-1, -1, -1)
 
     ver = torch._C._nccl_version()

--- a/torch/cuda/nccl.py
+++ b/torch/cuda/nccl.py
@@ -33,7 +33,7 @@ def is_available(tensors):
 
 def version():
     if not hasattr(torch._C, "_nccl_version"):
-        warnings.warn("PyTorch is not compiled with NCCL support")
+        warnings.warn("PyTorch is not compiled with NCCL support", stacklevel=2)
         return (-1, -1, -1)
 
     ver = torch._C._nccl_version()

--- a/torch/cuda/nccl.py
+++ b/torch/cuda/nccl.py
@@ -32,6 +32,11 @@ def is_available(tensors):
 
 
 def version():
+    # check if nccl is supported. If not found
+    # return invalid version
+    if not (hasattr(torch._C, "_nccl_version")):
+        return (-1, -1, -1)
+
     ver = torch._C._nccl_version()
     major = ver >> 32
     minor = (ver >> 16) & 65535


### PR DESCRIPTION
Trying to get nccl version on windows return an exception:

```
AttributeError: module 'torch._C' has no attribute '_nccl_version'
```

Here is error:
```
Traceback (most recent call last):
  File "./test/smoke_test/smoke_test.py", line 317, in <module>
    main()
  File "./test/smoke_test/smoke_test.py", line 313, in main
    smoke_test_cuda(options.package, options.runtime_error_check)
  File "./test/smoke_test/smoke_test.py", line 166, in smoke_test_cuda
    print(f"torch nccl version: {torch.cuda.nccl.version()}" )
  File "C:\Jenkins\Miniconda3\envs\conda-env-7450624690\lib\site-packages\torch\cuda\nccl.py", line 35, in version
    ver = torch._C._nccl_version()
AttributeError: module 'torch._C' has no attribute '_nccl_version'
```



Test:
```
>>> import torch
>>> print(f"torch nccl version: {torch.cuda.nccl.version()}" )
C:\Jenkins\Miniconda3\envs\conda-env-7453139523\lib\site-packages\torch\cuda\nccl.py:36: UserWarning: PyTorch is not compiled with NCCL support
  warnings.warn("PyTorch is not compiled with NCCL support")
torch nccl version: (-1, -1, -1)
```
