### PR TITLE
[CPU] _vec_log_softmax_lastdim: fix CHUNK_SIZE to avoid unnecessarily large allocation

### DIFF
--- a/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
+++ b/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
@@ -42,10 +42,11 @@ inline void _vec_log_softmax_lastdim(
   // size of L1D cache on many processors. Some processors have 48 KB L1D cache
   // nowadays, so maybe in the future, we can leverage the knowledge of a
   // machine's L1D cache size.
-  int64_t CHUNK_SIZE = std::max<int64_t>(
+  int64_t MAX_CHUNK_SIZE = std::max<int64_t>(
       1,
       at::internal::GRAIN_SIZE / (sizeof(scalar_t) * dim_size));
-
+  int64_t CHUNK_SIZE = std::min<int64_t>(MAX_CHUNK_SIZE, outer_size);
+  
   int64_t grain_size = internal::GRAIN_SIZE / (16 * dim_size);
 
   parallel_for(0, outer_size, grain_size, [&](int64_t begin, int64_t end) {

--- a/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
+++ b/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
@@ -46,7 +46,7 @@ inline void _vec_log_softmax_lastdim(
       1,
       at::internal::GRAIN_SIZE / (sizeof(scalar_t) * dim_size));
   int64_t CHUNK_SIZE = std::min<int64_t>(MAX_CHUNK_SIZE, outer_size);
-  
+
   int64_t grain_size = internal::GRAIN_SIZE / (16 * dim_size);
 
   parallel_for(0, outer_size, grain_size, [&](int64_t begin, int64_t end) {


### PR DESCRIPTION
Given input shape of `[outer_size, dim_size]`, `_vec_log_softmax_lastdim` sets `CHUNK_SIZE` as 
```cpp
int64_t CHUNK_SIZE = std::max<int64_t>(
      1,
      at::internal::GRAIN_SIZE / (sizeof(scalar_t) * dim_size));
```
where `at::internal::GRAIN_SIZE / (sizeof(scalar_t) * dim_size)` computes the maximum number of rows that can fit into L1d cache size `(GRAIN_SIZE)`. 

Fix `CHUNK_SIZE` as the minimum between `CHUNK_SIZE` and `outer_size` to avoid unnecessarily large `CHUNK_SIZE` and unnecessarily large allocation for `max` and `tmp_sum` buffer. 
```cpp
auto tmp_sum_scalar = std::make_unique<scalar_t[]>(CHUNK_SIZE);
auto max_input_arr = std::make_unique<scalar_t[]>(CHUNK_SIZE);
```

### Performance

Perf data collected for `dim_size` in range [2^0, 2^9] and `outer_size` in range [2^0, 2^3]. To measure the benefit from avoiding unnecessarily large allocation, values of `outer_size` were chosen such that `outer_size` is less than `at::internal::GRAIN_SIZE / (sizeof(scalar_t) * dim_size)` for all values of `dim_size`.

Tested on 28 physical cores/socket, 1 socket on Skylake.

| **dim_size** 	| **at::internal::GRAIN_SIZE / (sizeof(scalar_t)   * dim_size)** 	| **input shape: (outer_size, dim_size)** 	| **Baseline (original implementation)** 	| **Optimized** 	| **Speedup Ratio (Baseline/Optimized)** 	|
|--------------	|----------------------------------------------------------------	|-----------------------------------------	|----------------------------------------	|---------------	|----------------------------------------	|
| 1            	| 8192                                                           	| (1, 1)                                  	| 0.006070137                            	| 0.003378391   	| **1.796754**                           	|
|              	|                                                                	| (2, 1)                                  	| 0.006327629                            	| 0.00361681    	| **1.749506**                           	|
|              	|                                                                	| (4, 1)                                  	| 0.006246567                            	| 0.00379324    	| **1.646763**                           	|
|              	|                                                                	| (8, 1)                                  	| 0.006320477                            	| 0.003941059   	| **1.603751**                           	|
| 2            	| 4096                                                           	| (1, 2)                                  	| 0.004889965                            	| 0.003342628   	| **1.46291**                            	|
|              	|                                                                	| (2, 2)                                  	| 0.005021095                            	| 0.003380775   	| **1.48519**                            	|
|              	|                                                                	| (4, 2)                                  	| 0.004897118                            	| 0.003535748   	| **1.38503**                            	|
|              	|                                                                	| (8, 2)                                  	| 0.005195141                            	| 0.003790855   	| **1.37044**                            	|
| 4            	| 2048                                                           	| (1, 4)                                  	| 0.004477501                            	| 0.003364086   	| **1.330971**                           	|
|              	|                                                                	| (2, 4)                                  	| 0.004198551                            	| 0.003452301   	| **1.21616**                            	|
|              	|                                                                	| (4, 4)                                  	| 0.004312992                            	| 0.003650188   	| **1.181581**                           	|
|              	|                                                                	| (8, 4)                                  	| 0.004432201                            	| 0.00399828    	| **1.108527**                           	|
| 8            	| 1024                                                           	| (1, 8)                                  	| 0.004155636                            	| 0.0035429     	| **1.172948**                           	|
|              	|                                                                	| (2, 8)                                  	| 0.003905296                            	| 0.003569126   	| **1.094188**                           	|
|              	|                                                                	| (4, 8)                                  	| 0.004405975                            	| 0.003864765   	| **1.140037**                           	|
|              	|                                                                	| (8, 8)                                  	| 0.004785061                            	| 0.004456043   	| **1.073836**                           	|
| 16           	| 512                                                            	| (1, 16)                                 	| 0.003867149                            	| 0.003504753   	| **1.103401**                           	|
|              	|                                                                	| (2, 16)                                 	| 0.003743172                            	| 0.003340244   	| **1.120628**                           	|
|              	|                                                                	| (4, 16)                                 	| 0.003614426                            	| 0.003519058   	| 1.0271                                 	|
|              	|                                                                	| (8, 16)                                 	| 0.00395298                             	| 0.003488064   	| **1.133288**                           	|
| 32           	| 256                                                            	| (1, 32)                                 	| 0.003900528                            	| 0.003421307   	| **1.14007**                            	|
|              	|                                                                	| (2, 32)                                 	| 0.003569126                            	| 0.003511906   	| 1.016293                               	|
|              	|                                                                	| (4, 32)                                 	| 0.003736019                            	| 0.003590584   	| 1.040505                               	|
|              	|                                                                	| (8, 32)                                 	| 0.003845692                            	| 0.003662109   	| **1.05013**                            	|
| 64           	| 128                                                            	| (1, 64)                                 	| 0.003652573                            	| 0.003437996   	| **1.062413**                           	|
|              	|                                                                	| (2, 64)                                 	| 0.003700256                            	| 0.003516674   	| **1.052203**                           	|
|              	|                                                                	| (4, 64)                                 	| 0.003783703                            	| 0.003638268   	| 1.039974                               	|
|              	|                                                                	| (8, 64)                                 	| 0.003993511                            	| 0.003809929   	| 1.048185                               	|
| 128          	| 64                                                             	| (1, 128)                                	| 0.003848076                            	| 0.003600121   	| **1.068874**                           	|
|              	|                                                                	| (2, 128)                                	| 0.003979206                            	| 0.003826618   	| 1.039875                               	|
|              	|                                                                	| (4, 128)                                	| 0.004360676                            	| 0.004224777   	| 1.032167                               	|
|              	|                                                                	| (8, 128)                                	| 0.005149841                            	| 0.004999638   	| 1.030043                               	|
| 256          	| 32                                                             	| (1, 256)                                	| 0.003943443                            	| 0.003738403   	| **1.054847**                           	|
|              	|                                                                	| (2, 256)                                	| 0.00420332                             	| 0.00408411    	| 1.029189                               	|
|              	|                                                                	| (4, 256)                                	| 0.004820824                            	| 0.00474453    	| 1.01608                                	|
|              	|                                                                	| (8, 256)                                	| 0.006194115                            	| 0.006067753   	| 1.020825                               	|
| 512          	| 16                                                             	| (1, 512)                                	| 0.004277229                            	| 0.004253387   	| 1.005605                               	|
|              	|                                                                	| (2, 512)                                	| 0.004863739                            	| 0.004782677   	| 1.016949                               	|
|              	|                                                                	| (4, 512)                                	| 0.006172657                            	| 0.00607729    	| 1.015692                               	|
|              	|                                                                	| (8, 512)                                	| 0.011193752                            	| 0.010819435   	| 1.034597                               	|

Bolded speedup ratio indicates greater than 5% speedup, to identify as significant speedup. Especially for smaller `dim_size` (1, 2, 4, 8, 16), we observe significant speedups as smaller the `dim_size`, larger the `at::internal::GRAIN_SIZE / (sizeof(scalar_t) * dim_size)`, hence larger the unnecessary allocation. 

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10