### PR TITLE
(WIP) [inductor][foreach] Horizontally fuse concat inputs that require copy kernels (#115217)

### DIFF
--- a/test/inductor/test_foreach.py
+++ b/test/inductor/test_foreach.py
@@ -549,6 +549,42 @@ class ForeachTests(TestCase):
         self.assertEqual(torch._inductor.metrics.generated_kernel_count, 2)
 
     @requires_cuda()
+    @torch._inductor.config.patch("max_pointwise_cat_inputs", 0)
+    def test_fuse_concat_extern_kernels(self):
+        def fn(x, w, nmatrices):
+            ms = [torch.bmm(x + i, w + i) for i in range(nmatrices)]
+            return torch.concat(ms)
+
+        x = torch.ones(2, 5, 2, device="cuda:0")
+        w = torch.ones(2, 2, 3, device="cuda:0")
+
+        # Case: num-operands < 10, don't create a foreach.
+        self.check_model_cuda(fn, (x, w, 5))
+        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 7)
+
+        # Case: num-operands ≥ 10, create a foreach node.
+        self.check_model_cuda(fn, (x, w, 10))
+        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 3)
+
+    @requires_cuda()
+    @torch._inductor.config.patch("max_pointwise_cat_inputs", 0)
+    def test_fuse_concat_non_input_views(self):
+        def fn(x, slice_sz):
+            x = x + 1  # Make it pointwise to avoid views on inputs.
+            views = torch.ops.aten.split.Tensor(x, slice_sz, dim=0)
+            return torch.ops.aten.cat(views)
+
+        x = torch.ones(10, device="cuda:0")
+
+        # Case: num-operands < 10, don't create a foreach.
+        self.check_model_cuda(fn, (x, 2))
+        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 5)
+
+        # Case: num-operands ≥ 10, create a foreach node.
+        self.check_model_cuda(fn, (x, 10))
+        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)
+
+    @requires_cuda()
     def test_zero_elems(self):
         def fn(a0, a1, b0, b1):
             return torch._foreach_add([a0, a1], [b0, b1])

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3442,21 +3442,17 @@ class ConcatKernel(NopKernel):
         )
         kernel = StorageBox(concat_kernel)
         buffer_names = []
-        for i in range(len(inputs)):
-            input_buffer = cls.realize_into(
-                inputs[i],
+        for i, input in enumerate(inputs):
+            input_buffer, copy_required = cls.realize_into(
+                input,
                 SliceView.create(kernel, dim, offsets_start[i], offsets_end[i]),
             )
             concat_kernel.inputs.append(input_buffer)
 
-            if isinstance(inputs[i].data, BaseView):
-                input_unwrapped = inputs[i].data.unwrap_view()
-            else:
-                input_unwrapped = inputs[i].data
-
             if (
-                input_unwrapped.is_input_buffer()
-                and inputs[i].get_device().type == "cuda"
+                copy_required
+                and len(inputs) >= 10
+                and input.get_device().type == "cuda"
                 and not is_dynamic(input_buffer)
             ):
                 buffer_names.append(input_buffer.get_name())
@@ -3480,7 +3476,7 @@ class ConcatKernel(NopKernel):
         )
 
     @classmethod
-    def realize_into(cls, src, dst):
+    def realize_into(cls, src, dst) -> (IRNode, bool):
         # Attempt to turn this into a ReinterpretView rather than assert.
         # This has concessions around layout, as as_storage_and_layout
         # can cause us to go from flexible to fixed layout.
@@ -3498,7 +3494,7 @@ class ConcatKernel(NopKernel):
             assert hasattr(src.data, "layout")
             if cls.can_realize_into_without_copy(src):
                 src.data.layout = AliasedLayout(dst)
-                return src.data
+                return src.data, False
         # introduce a copy
         pw = Pointwise.create(
             device=src.get_device(),
@@ -3509,7 +3505,8 @@ class ConcatKernel(NopKernel):
                 for a, b in zip(src.get_size(), dst.get_size())
             ],
         )
-        return cls.realize_into(pw, dst)
+        realized, _ = cls.realize_into(pw, dst)
+        return realized, True
 
     def should_allocate(self):
         return True


### PR DESCRIPTION
Summary:

Most Inductor IR will require a copy kernel (i.e. load + store) if it's an input of a `ConcatKernel`. The only exeception is when the input is a `Pointwise` or `Reduction`. In this case, just ask the input to write directly to the concat's output buffer.

Before this PR: Create a separate copy kernel for each input.

With this PR: Horizontally fuse copy kernels when there's more than 10 inputs.
* Note: fusing with fewer inputs will reduce launch overhead but might prohibit better fusion opportunities (?).

```
$ python test_foreach.py -k test/inductor/fuse_concat
----------------------------------------------------------------------
Ran 3 tests in 17.468s

OK
```




cc voznesenskym penguinwu EikanWang jgong5 Guobing-Chen XiaobingSuper zhuhaozhe blzheng wenzhe-nrv jiayisunx peterbell10 ipiszy yf225 chenyang78 kadeng muchulee8 aakhundov

imported-using-ghimport

Test Plan: Imported from OSS

Differential Revision: D52423531

Pulled By: ColinPeppler




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov