### PR TITLE
[export] Add TORCH_LOGS=export

### DIFF
--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -697,6 +697,7 @@ exclusions = {
     "onnx_diagnostics",
     "guards",
     "verbose_guards",
+    "export",
 }
 for name in torch._logging._internal.log_registry.artifact_names:
     if name not in exclusions:

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -967,11 +967,13 @@ def rewrite_signature(
                     else:
                         raise AssertionError(
                             f"{candidate_desc} #{i+1}, of type {type(val)}, is not among {source_types}"
+                            'Set TORCH_LOGS="+export" for more information.'
                         )
                 else:
                     raise AssertionError(
                         f"{candidate_desc} #{i+1} is {val}, but only "
                         f"the following types are supported: {supported_types}"
+                        'Set TORCH_LOGS="+export" for more information.'
                     )
 
         return matched_elements_positions
@@ -1302,17 +1304,21 @@ def export(
                         f"{''.join(traceback.format_list(shape_env.var_to_stack[k]))}\n"
                         "It appears that you're trying to set a constraint on a "
                         f"value which we evaluated to have a static value of {k}. "
-                        "Scroll up to see where this constraint was set."
+                        'Set TORCH_LOGS="+export" for more information.'
                     )
         if constraint_violation_error:
             raise constraint_violation_error
 
         assert (
             graph is not None
-        ), "Failed to produce a graph during tracing. Tracing through 'f' must produce a single graph."
+        ), "Failed to produce a graph during tracing as no tensor operations were found."
         assert hasattr(graph, "_source_to_user_stacks")
         assert out_guards is not None, "Failed to produce guards during tracing"
         assert fake_mode is not None
+
+        log.info(
+            "Dynamo captured graph:\n\n%s", graph.print_readable(print_output=False)
+        )
 
         # This check need to happened before aten_graph
         # because placeholder's _source_node attribute is not preserved by make_fx

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -198,6 +198,7 @@ def set_logs(
     onnx_diagnostics: bool = False,
     fusion: bool = False,
     overlap: bool = False,
+    export: Optional[int] = None,
     modules: Optional[Dict[str, Union[int, bool]]] = None,
 ):
     """
@@ -342,6 +343,9 @@ def set_logs(
         overlap (:class:`bool`):
             Whether to emit detailed Inductor compute/comm overlap decisions. Default: ``False``
 
+        export (:class:`Optional[int]`):
+            The log level for export. Default: ``logging.WARN``
+
         modules (dict):
             This argument provides an alternate way to specify the above log
             component and artifact settings, in the format of a keyword args
@@ -440,6 +444,7 @@ def set_logs(
         onnx_diagnostics=onnx_diagnostics,
         fusion=fusion,
         overlap=overlap,
+        export=export,
     )
 
 

--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -23,6 +23,7 @@ register_log(
 )
 register_log("dist_fsdp", ["torch.distributed.fsdp"])
 register_log("onnx", "torch.onnx")
+register_log("export", ["torch._dynamo", "torch.export", *DYNAMIC])
 
 register_artifact(
     "guards",

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -1,6 +1,7 @@
 import copy
 import dataclasses
 import functools
+import logging
 import re
 from collections import OrderedDict
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -45,6 +46,9 @@ from .graph_signature import (
     SymIntArgument,
     TensorArgument,
 )
+
+
+log = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass
@@ -790,6 +794,7 @@ def _export(
         example_inputs=(args, kwargs),
         tensor_constants=tensor_constants,
     )
+    log.debug("Exported program from AOTAutograd:\n%s", exported_program)
 
     if len(range_constraints) > 0:
         exported_program = exported_program._transform_do_not_use(

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1521,7 +1521,7 @@ class DimConstraints:
                 debug_names.update(k.split(" = ")[0] for k in forced_specializations.keys())
                 buf += (
                     f"Specializations unexpectedly required ({', '.join(debug_names)})! "
-                    "For more information, run with TORCH_LOGS=dynamic.\n"
+                    "For more information, run with TORCH_LOGS=\"+dynamic\".\n"
                 )
                 for s, val in forced_specializations.items():
                     buf += f"  - {s} must be specialized to {val} because the guards generated for it are too complex.\n"
@@ -3018,7 +3018,7 @@ class ShapeEnv:
                 err = '\n'.join(error_msgs)
                 raise ConstraintViolationError(
                     f"Constraints violated ({debug_names})! "
-                    "For more information, run with TORCH_LOGS=dynamic.\n"
+                    "For more information, run with TORCH_LOGS=\"+dynamic\".\n"
                     f"{err}"
                 )
             elif len(warn_msgs) > 0:
@@ -3355,7 +3355,7 @@ class ShapeEnv:
             "It appears that you're trying to get a value out of symbolic int/float "
             "whose value is data-dependent (and thus we do not know the true value.)  "
             f"The expression we were trying to evaluate is {expr} (unhinted: {unhinted_expr}).  "
-            "Scroll up to see where each of these data-dependent accesses originally occurred."
+            "For more information, run with TORCH_LOGS=\"+dynamic\".\n"
             # TODO: Help text about how to use our runtime tests to fix this
             # problem
         )


### PR DESCRIPTION
Adds TORCH_LOGS=export which currently includes dynamo/dynamic logs. In the future if we add any logs under the torch/export directory it will also show up in the TORCH_LOGS=export


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng