### PR TITLE
Fix aliasing annotation for aten.dropout

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -296,7 +296,7 @@
 
 - func: _shape_as_tensor(Tensor self) -> Tensor
 
-- func: dropout(Tensor input, float p, bool train) -> Tensor
+- func: dropout(Tensor(a) input, float p, bool train) -> Tensor(a)
   tags: nondeterministic_seeded
 
 - func: dropout_(Tensor(a!) self, float p, bool train) -> Tensor(a!)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #116998

It can return an alias to its input:
```python
>>> import torch
>>> x = torch.randn(100)
>>> torch.ops.aten.dropout(x, train=False, p=0.0) is x
True
>>> 
```