### PR TITLE
[Dynamo] Use isinstance rather than type to mitigate user defined object's __eq__ bug

### DIFF
--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -695,8 +695,9 @@ class VariableBuilder:
             istype(value, (types.ModuleType, replay_record.DummyModule))
             # type(torch.backends.cudnn) -> <class 'torch.backends.cudnn.CudnnModule'>
             # type(torch.ops) -> <class 'torch._ops._Ops'>
-            or value in [torch.backends.cudnn, torch.ops]
-            or isinstance(value, torch._ops._OpNamespace)
+            or isinstance(
+                value, (torch.backends.cudnn, torch.ops, torch._ops._OpNamespace)
+            )
         ):
             self.install_guards(GuardBuilder.FUNCTION_MATCH)
             return PythonModuleVariable(

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -696,7 +696,12 @@ class VariableBuilder:
             # type(torch.backends.cudnn) -> <class 'torch.backends.cudnn.CudnnModule'>
             # type(torch.ops) -> <class 'torch._ops._Ops'>
             or isinstance(
-                value, (torch.backends.cudnn, torch.ops, torch._ops._OpNamespace)
+                value,
+                (
+                    torch.backends.cudnn.CudnnModule,
+                    torch._ops._Ops,
+                    torch._ops._OpNamespace,
+                ),
             )
         ):
             self.install_guards(GuardBuilder.FUNCTION_MATCH)


### PR DESCRIPTION
This is to fix a issue from Meta internal use case, where third-party ```DictConfig``` has bug on [```__eq__```](https://github.com/omry/omegaconf/blob/fd730509ef10a074f97b1738c630720157ceeeab/omegaconf/dictconfig.py#L596) and triggers Dynamo failure.  


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng