### PR TITLE
[dynamo] Support cuda stream and stream context reconstruction

### DIFF
--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -178,6 +178,28 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnts.op_count, 9)
 
     @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
+    def test_cuda_stream_context_manager_graph_break(self):
+        def fn(x):
+            s = torch.cuda.Stream()
+            x = torch.mul(x, 5)
+            x = torch.add(x, 2)
+            print(x)
+            with torch.cuda.stream(s):
+                x = torch.relu(x)
+            x = torch.add(x, 1)
+            x = torch.cos(x)
+            return x
+
+        x = torch.randn((2, 2), device="cuda")
+        ref = fn(x)
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch._dynamo.optimize(cnts)(fn)
+        res = opt_fn(x)
+        self.assertEqual(ref, res)
+        self.assertEqual(cnts.frame_count, 2)
+        self.assertEqual(cnts.op_count, 9)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
     def test_cuda_stream_context_manager2(self):
         def fn(x, s):
             x = torch.mul(x, 5)

--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -200,6 +200,30 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnts.op_count, 9)
 
     @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
+    def test_cuda_stream_context_manager_graph_break_named(self):
+        def fn(x):
+            s = torch.cuda.Stream()
+            x = torch.mul(x, 5)
+            x = torch.add(x, 2)
+
+            tcs = torch.cuda.stream(s)
+            print("foo")
+            with tcs:
+                x = torch.relu(x)
+            x = torch.add(x, 1)
+            x = torch.cos(x)
+            return x
+
+        x = torch.randn((2, 2), device="cuda")
+        ref = fn(x)
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch._dynamo.optimize(cnts)(fn)
+        res = opt_fn(x)
+        self.assertEqual(ref, res)
+        self.assertEqual(cnts.frame_count, 2)
+        self.assertEqual(cnts.op_count, 10)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
     def test_cuda_stream_context_manager2(self):
         def fn(x, s):
             x = torch.mul(x, 5)

--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -20,6 +20,7 @@ from .exc import unimplemented
 from .source import AttrSource, Source
 from .utils import is_safe_constant, rot_n_helper
 from .variables.base import VariableTracker
+from .variables.ctx_manager import StreamVariable
 from .variables.nn_module import NNModuleVariable
 from .variables.tensor import (
     NumpyNdarrayVariable,
@@ -136,6 +137,7 @@ class PyCodegen:
                 SymNodeVariable,
                 UnspecializedPythonVariable,
                 NumpyNdarrayVariable,
+                StreamVariable,
             ),
         ):
             graph_outputs_key = self.add_graph_output(value)

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -815,7 +815,6 @@ class InstructionTranslatorBase(Checkpointable[InstructionTranslatorGraphState])
 
     def LOAD_FAST(self, inst):
         name = inst.argval
-
         if name in self.f_locals and config.replay_record_enabled:
             self.exec_recorder.add_local_var(name, self.f_locals[name])
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -575,7 +575,7 @@ class VariableBuilder:
             return StreamVariable(
                 None,
                 value,
-                value.device.type,
+                value.device,
                 source=self.source,
             )
         elif isinstance(value, _EventBase):
@@ -1501,7 +1501,7 @@ def wrap_fx_proxy_cls(
     ]:
         proxy.node.meta["example_value"] = example_value
         return StreamVariable(
-            proxy, example_value, example_value.device.type, **options
+            proxy, example_value, example_value.device, **options
         )
     elif (
         inspect.isclass(proxy.node.target) and issubclass(proxy.node.target, _EventBase)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -576,12 +576,13 @@ class VariableBuilder:
             return StreamContextVariable.create_from_existing_context(self.tx, value)
         elif isinstance(value, _StreamBase):
             self.install_guards(GuardBuilder.ID_MATCH)
-            return StreamVariable(
+            stream_var = StreamVariable(
                 None,
                 value,
                 value.device,
                 source=self.source,
             )
+            return self.tx.output.side_effects.track_object_existing(value, stream_var)
         elif isinstance(value, _EventBase):
             self.install_guards(GuardBuilder.ID_MATCH)
             return EventVariable(

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -573,7 +573,9 @@ class VariableBuilder:
             return TorchHigherOrderOperatorVariable.make(value, source=self.source)
         elif isinstance(value, torch.cuda.StreamContext):
             self.install_guards(GuardBuilder.ID_MATCH)
-            return StreamContextVariable.create_from_existing_context(self.tx, value)
+            stream_source = AttrSource(self.source, "stream")
+            stream_var = VariableBuilder(self.tx, stream_source)(value.stream)
+            return StreamContextVariable.create_from_stream(self.tx, stream_var)
         elif isinstance(value, _StreamBase):
             self.install_guards(GuardBuilder.ID_MATCH)
             stream_var = StreamVariable(

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -485,30 +485,9 @@ class StreamContextVariable(ContextWrappingVariable):
 
     @staticmethod
     def create_from_existing_context(tx, target_value, **kwargs):
-        from .builder import wrap_fx_proxy_cls
-
-        device = target_value.stream.device
-        interface = get_interface_for_device(device)
-
-        current_stream_method = interface.current_stream
-
-        target_stream = StreamVariable(
-            None, target_value.stream, target_value.stream.device
-        )
-        current_stream = wrap_fx_proxy_cls(
-            StreamVariable,
+        return StreamContextVariable.create_from_stream(
             tx,
-            tx.output.create_proxy(
-                "call_function",
-                current_stream_method,
-                (None,),
-                {},
-            ),
-        )
-        return StreamContextVariable(
-            target_values=[target_stream],
-            initial_values=[current_stream],
-            device=device,
+            StreamVariable(None, target_value.stream, target_value.stream.device),
             **kwargs,
         )
 

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -483,14 +483,6 @@ class StreamContextVariable(ContextWrappingVariable):
             **kwargs,
         )
 
-    @staticmethod
-    def create_from_existing_context(tx, target_value, **kwargs):
-        return StreamContextVariable.create_from_stream(
-            tx,
-            StreamVariable(None, target_value.stream, target_value.stream.device),
-            **kwargs,
-        )
-
     def __init__(self, target_values, device, initial_values=None, **kwargs):
         super().__init__(
             target_values=target_values, initial_values=initial_values, **kwargs

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -532,7 +532,7 @@ class StreamContextVariable(ContextWrappingVariable):
     def reconstruct(self, codegen):
         codegen.load_import_from("torch", "cuda.stream")
         assert len(self.target_values) == 1
-        self.target_values[0].reconstruct(codegen)
+        codegen(self.target_values[0])
         codegen.extend_output(create_call_function(1, False))
         return []
 
@@ -597,12 +597,6 @@ class StreamVariable(VariableTracker):
 
     def as_proxy(self):
         return self.proxy
-
-    def reconstruct(self, codegen):
-        codegen.load_import_from("torch", "cuda.Stream")
-        codegen.extend_output([codegen.create_load_const(str(self.device))])
-        codegen.extend_output(create_call_function(1, False))
-        return []
 
 
 class EventVariable(VariableTracker):

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -554,7 +554,6 @@ class StreamContextVariable(ContextWrappingVariable):
         codegen.load_import_from("torch", "cuda.stream")
         assert len(self.target_values) == 1
         self.target_values[0].reconstruct(codegen)
-        # codegen.extend_output([codegen.create_load_const(str(self.device))])
         codegen.extend_output(create_call_function(1, False))
         return []
 

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -344,7 +344,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             ]
         ):
             assert len(args) == 1
-            return StreamContextVariable.create(tx, args[0])
+            return StreamContextVariable.create_from_stream(tx, args[0])
         elif self.value is torch.from_numpy:
             if not config.trace_numpy:
                 unimplemented("torch.from_numpy. config.trace_numpy is False")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #115410
* __->__ #117008
* #117006
* #116723

In dynamo, today, stream context reconstruction is using the generic reconstruction code, which was not correctly reconstruction the stream context with the user defined stream input. This PR:

1) Fixes the stream context to correctly reconstruct (as tested by test_cuda_stream_context_manager_graph_break_named) - we can now pass a stream context across a graph break and correctly enter it.

2) Add reconstruction support for streams by utilizing existing proxy-able object support (as tested by test_cuda_stream_context_manager_graph_break) - we can now pass a stream across graph breaks and use it, in the case of our test, we make a context with it and enter it. Note: This means that streams can be graph inputs and outputs now. 


cc @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng