### PR TITLE
[Dynamo, ONNX] Run llama attention with onnxrt and dynamic shapes

### DIFF
--- a/test/onnx/dynamo/test_dynamo_with_onnxruntime_backend.py
+++ b/test/onnx/dynamo/test_dynamo_with_onnxruntime_backend.py
@@ -372,7 +372,10 @@ class TestDynamoWithONNXRuntime(onnx_test_common._TestONNXRuntime):
         class LlamaAttentionWrapper(torch.nn.Module):
             def __init__(self, config):
                 super().__init__()
-                self.attention = LlamaAttention(config)
+                try:
+                    self.attention = LlamaAttention(config, layer_idx=0)
+                except TypeError:
+                    self.attention = LlamaAttention(config)
 
             def forward(self, hidden_states, attention_mask, position_ids):
                 attn_output, _, _ = self.attention(
@@ -436,8 +439,6 @@ class TestDynamoWithONNXRuntime(onnx_test_common._TestONNXRuntime):
         ]
     )
     def test_llama_decoder_with_local_backend(self, test_local_backend: bool):
-        import inspect
-
         from transformers import LlamaConfig  # noqa: F811
         from transformers.models.llama.modeling_llama import (  # noqa: F811
             LlamaDecoderLayer,
@@ -459,9 +460,9 @@ class TestDynamoWithONNXRuntime(onnx_test_common._TestONNXRuntime):
         class LlamaDecoderWrapper(torch.nn.Module):
             def __init__(self, config):
                 super().__init__()
-                if len(inspect.signature(LlamaDecoderLayer).parameters) == 3:
-                    self.decoder = LlamaDecoderLayer(config, 0)
-                else:
+                try:
+                    self.decoder = LlamaDecoderLayer(config, layer_idx=0)
+                except TypeError:
                     self.decoder = LlamaDecoderLayer(config)
 
             def forward(self, hidden_states, attention_mask, position_ids):

--- a/test/onnx/dynamo/test_dynamo_with_onnxruntime_backend.py
+++ b/test/onnx/dynamo/test_dynamo_with_onnxruntime_backend.py
@@ -381,8 +381,10 @@ class TestDynamoWithONNXRuntime(onnx_test_common._TestONNXRuntime):
             def __init__(self, config):
                 super().__init__()
                 try:
+                    # New version of LlamaAttention has layer_idx argument.
                     self.attention = LlamaAttention(config, layer_idx=0)
                 except TypeError:
+                    # Fall back to old version of LlamaAttention.
                     self.attention = LlamaAttention(config)
 
             def forward(self, hidden_states, attention_mask, position_ids):
@@ -472,8 +474,10 @@ class TestDynamoWithONNXRuntime(onnx_test_common._TestONNXRuntime):
             def __init__(self, config):
                 super().__init__()
                 try:
+                    # New version of LlamaDecoderLayer has layer_idx argument.
                     self.decoder = LlamaDecoderLayer(config, layer_idx=0)
                 except TypeError:
+                    # Fall back to old version of LlamaDecoderLayer.
                     self.decoder = LlamaDecoderLayer(config)
 
             def forward(self, hidden_states, attention_mask, position_ids):

--- a/test/onnx/dynamo/test_dynamo_with_onnxruntime_backend.py
+++ b/test/onnx/dynamo/test_dynamo_with_onnxruntime_backend.py
@@ -127,6 +127,7 @@ class TestDynamoWithONNXRuntime(onnx_test_common._TestONNXRuntime):
         model,
         dynamo_backend,
         example_args_collection,
+        full_graph: bool = False,
     ):
         """Run original and compiled model and compare the results.
 
@@ -327,6 +328,93 @@ class TestDynamoWithONNXRuntime(onnx_test_common._TestONNXRuntime):
                 # Since dynamic shape is enabled, we should only have one ONNX model
                 # to support different batch sizes.
                 number_of_exported_onnx_models_for_all_graph_modules=(1, 1),
+            )
+
+    @parameterized.expand(
+        [
+            (True,),
+        ]
+    )
+    def test_llama_attention_with_local_backend(self, test_local_backend: bool):
+        from transformers import LlamaConfig  # noqa: F811
+        from transformers.models.llama.modeling_llama import (  # noqa: F811
+            LlamaAttention,
+        )
+
+        hidden_size = 16
+
+        config = LlamaConfig(
+            num_hidden_layers=1,
+            vocab_size=1024,
+            hidden_size=hidden_size,
+            intermediate_size=16,
+            max_position_embeddings=256,
+            num_attention_heads=2,
+            hidden_dropout_prob=0.0,
+            attention_dropout_prob=0.0,
+        )
+
+        class LlamaAttentionWrapper(torch.nn.Module):
+            def __init__(self, config):
+                super().__init__()
+                self.attention = LlamaAttention(config)
+
+            def forward(self, hidden_states, attention_mask, position_ids):
+                attn_output, _, _ = self.attention(
+                    hidden_states, attention_mask, position_ids
+                )
+                return attn_output
+
+        def generate_example_inputs(batch: int, seq: int, hidden_size: int):
+            # shape: batch x seq x hidden_size
+            hidden_state = torch.randn(batch, seq, hidden_size)
+            # [0.0000e+00, ..., 0.0000e+00, -3.4028e+38, ...]
+            # shape: batch x 1 x seq x seq
+            attention_mask = torch.zeros(batch, 1, seq, seq, dtype=torch.float)
+            position_ids = torch.arange(0, seq, dtype=torch.int64)
+            position_ids = position_ids.unsqueeze(0).view(-1, seq)
+
+            return hidden_state, attention_mask, position_ids
+
+        # Reason for using multiple example argument groups:
+        #  Export model to ONNX with one example argument group
+        #  and test it with other example argument groups.
+        example_args_collection = (
+            generate_example_inputs(2, 8, hidden_size),
+            generate_example_inputs(4, 7, hidden_size),
+            generate_example_inputs(9, 15, hidden_size),
+        )
+
+        if test_local_backend:
+            local_aot_ort, local_ort = make_aot_ort(dynamic=True)
+        else:
+            local_aot_ort, local_ort = "onnxrt", None
+
+        model = LlamaAttentionWrapper(config).eval()
+
+        self._test_model_numerically(
+            model,
+            local_aot_ort,
+            example_args_collection,
+            full_graph=True,
+        )
+
+        if test_local_backend:
+            assert local_ort is not None
+            self._assert_counting_information(
+                local_ort,
+                # The "3" comes from:
+                #   2 graph breaks and therefore 3 sub-graph runs with InferenceSession
+                #   per batch.
+                expected_execution_count=len(example_args_collection) * 3,
+                # Since this local_ort only compiled one function, there should be only two
+                # GraphModule's in its cached. One for batch sizes 2, 4, 6, 8 and the other
+                # for batch size 1.
+                number_of_cached_graph_modules=3,
+                # Since dynamic shape is enabled, we should only have one ONNX model
+                # to support different batch sizes.
+                # Should be (1, 1, 1)
+                number_of_exported_onnx_models_for_all_graph_modules=(1, 1, 1),
             )
 
 

--- a/test/onnx/dynamo/test_dynamo_with_onnxruntime_backend.py
+++ b/test/onnx/dynamo/test_dynamo_with_onnxruntime_backend.py
@@ -416,6 +416,90 @@ class TestDynamoWithONNXRuntime(onnx_test_common._TestONNXRuntime):
                 number_of_exported_onnx_models_for_all_graph_modules=(1,),
             )
 
+    @parameterized.expand(
+        [
+            (True,),
+        ]
+    )
+    def test_llama_decoder_with_local_backend(self, test_local_backend: bool):
+        from transformers import LlamaConfig  # noqa: F811
+        from transformers.models.llama.modeling_llama import (  # noqa: F811
+            LlamaDecoderLayer,
+        )
+
+        hidden_size = 16
+
+        config = LlamaConfig(
+            num_hidden_layers=1,
+            vocab_size=1024,
+            hidden_size=hidden_size,
+            intermediate_size=16,
+            max_position_embeddings=256,
+            num_attention_heads=2,
+            hidden_dropout_prob=0.0,
+            attention_dropout_prob=0.0,
+        )
+
+        class LlamaDecoderWrapper(torch.nn.Module):
+            def __init__(self, config):
+                super().__init__()
+                self.decoder = LlamaDecoderLayer(config, 0)
+
+            def forward(self, hidden_states, attention_mask, position_ids):
+                (decoder_output,) = self.decoder(
+                    hidden_states, attention_mask, position_ids
+                )
+                return decoder_output
+
+        def generate_example_inputs(batch: int, seq: int, hidden_size: int):
+            # shape: batch x seq x hidden_size
+            hidden_state = torch.randn(batch, seq, hidden_size)
+            # [0.0000e+00, ..., 0.0000e+00, -3.4028e+38, ...]
+            # shape: batch x 1 x seq x seq
+            attention_mask = torch.zeros(batch, 1, seq, seq, dtype=torch.float)
+            position_ids = torch.arange(0, seq, dtype=torch.int64)
+            position_ids = position_ids.unsqueeze(0).view(-1, seq)
+            return hidden_state, attention_mask, position_ids
+
+        # Reason for using multiple example argument groups:
+        #  Export model to ONNX with one example argument group
+        #  and test it with other example argument groups.
+        example_args_collection = (
+            generate_example_inputs(2, 8, hidden_size),
+            generate_example_inputs(4, 7, hidden_size),
+            generate_example_inputs(9, 15, hidden_size),
+        )
+
+        if test_local_backend:
+            local_aot_ort, local_ort = make_aot_ort(dynamic=True)
+        else:
+            local_aot_ort, local_ort = "onnxrt", None
+
+        model = LlamaDecoderWrapper(config).eval()
+
+        self._test_model_numerically(
+            model,
+            local_aot_ort,
+            example_args_collection,
+            fullgraph=True,
+        )
+
+        if test_local_backend:
+            assert local_ort is not None
+            self._assert_counting_information(
+                local_ort,
+                # The whole attention is captured and executed
+                # as a single graph. Thus, the # of test cases
+                # is the # of session runs.
+                expected_execution_count=len(example_args_collection),
+                # This should be one because there is no graph break.
+                # If you have 1 graph break, this value should be 2.
+                number_of_cached_graph_modules=1,
+                # Since dynamic shape is enabled, we should only have
+                # one ONNX model to support different batch sizes.
+                number_of_exported_onnx_models_for_all_graph_modules=(1,),
+            )
+
 
 if __name__ == "__main__":
     common_utils.run_tests()

--- a/torch/onnx/_internal/fx/fx_onnx_interpreter.py
+++ b/torch/onnx/_internal/fx/fx_onnx_interpreter.py
@@ -112,7 +112,7 @@ def _retrieve_or_adapt_input_to_graph_set(
         #    torch.jit.Value, fx_name_to_onnxscript_value[fx_node_arg.name],
         #    in TorchScript graph.
         return fx_name_to_onnxscript_value[onnx_tensor.name]
-    if isinstance(onnx_tensor, (tuple, list)) and any(
+    elif isinstance(onnx_tensor, (tuple, list)) and any(
         isinstance(node, torch.fx.Node)
         and fx_type_utils.is_torch_symbolic_type(node.meta.get("val"))
         for node in onnx_tensor

--- a/torch/onnx/_internal/fx/passes/type_promotion.py
+++ b/torch/onnx/_internal/fx/passes/type_promotion.py
@@ -8,7 +8,7 @@ import inspect
 import logging
 from types import ModuleType
 
-from typing import Any, Callable, Mapping, Optional, Sequence, Set
+from typing import Any, Callable, Mapping, Optional, Sequence, Set, Union
 
 import torch
 import torch._ops
@@ -70,7 +70,9 @@ class TypePromotionSnapshot:
 
 
 @_beartype.beartype
-def _fake_tensor_from_node_val(node: torch.fx.Node) -> fake_tensor.FakeTensor:
+def _fake_tensor_from_node_val(
+    node: torch.fx.Node,
+) -> Union[fake_tensor.FakeTensor, int, float, bool]:
     """Syntactic sugar for retrieving fake tensor from node.meta['val']."""
     val = node.meta.get("val", None)
     if isinstance(val, fake_tensor.FakeTensor):
@@ -1687,7 +1689,9 @@ class InsertTypePromotion(_pass.Transform):
             diagnostic_context, module, type_promotion_table or TypePromotionTable()
         )
 
-    def _fetch_fake_args(self) -> Sequence[Optional[fake_tensor.FakeTensor]]:
+    def _fetch_fake_args(
+        self,
+    ) -> Sequence[Optional[Union[fake_tensor.FakeTensor, float, int, bool]]]:
         """Fetch fake args from fx graph.
 
         For each argument, try to fetch fake tensor from the matching placeholder node.

--- a/torch/onnx/_internal/fx/passes/type_promotion.py
+++ b/torch/onnx/_internal/fx/passes/type_promotion.py
@@ -73,11 +73,14 @@ class TypePromotionSnapshot:
 def _fake_tensor_from_node_val(node: torch.fx.Node) -> fake_tensor.FakeTensor:
     """Syntactic sugar for retrieving fake tensor from node.meta['val']."""
     val = node.meta.get("val", None)
-    if not isinstance(val, fake_tensor.FakeTensor):
+    if isinstance(val, fake_tensor.FakeTensor):
+        return val
+    elif isinstance(val, (torch.SymInt, torch.SymFloat, torch.SymBool)):
+        return val.node.hint
+    else:
         raise RuntimeError(
             f"Cannot retrieve fake tensor from node {node}. Got type({type(val)}) instead."
         )
-    return val
 
 
 class TypePromotionRule(abc.ABC):

--- a/torch/onnx/_internal/fx/type_utils.py
+++ b/torch/onnx/_internal/fx/type_utils.py
@@ -79,6 +79,27 @@ def from_python_type_to_onnx_attribute_type(
     return _PYTHON_TYPE_TO_ONNX_ATTRIBUTE_TYPE.get(dtype)
 
 
+def from_python_type_to_onnx_tensor_element_type(type: type):
+    """
+    Converts a Python type to the corresponding ONNX tensor element type.
+    For example, `from_python_type_to_onnx_tensor_element_type(float)` returns
+    `onnx.TensorProto.FLOAT`.
+
+    Args:
+      type (type): The Python type to convert.
+
+    Returns:
+      int: The corresponding ONNX tensor element type.
+
+    """
+    _PYTHON_TYPE_TO_ONNX_TENSOR_ELEMENT_TYPE = {
+        float: onnx.TensorProto.FLOAT,  # type: ignore[attr-defined]
+        int: onnx.TensorProto.INT64,  # type: ignore[attr-defined]
+        bool: onnx.TensorProto.BOOL,  # type: ignore[attr-defined]
+    }
+    return _PYTHON_TYPE_TO_ONNX_TENSOR_ELEMENT_TYPE.get(type)
+
+
 def is_torch_symbolic_type(value: Any) -> bool:
     return isinstance(value, (torch.SymBool, torch.SymInt, torch.SymFloat))
 

--- a/torch/onnx/_internal/onnxruntime.py
+++ b/torch/onnx/_internal/onnxruntime.py
@@ -47,9 +47,9 @@ try:
     import torch.onnx._internal.fx.passes
     from torch.onnx._internal.fx import fx_onnx_interpreter
     from torch.onnx._internal.fx.type_utils import (
-        from_python_type_to_onnx_tensor_element_type,
         _TORCH_DTYPE_TO_NUMPY_DTYPE,
         _TORCH_DTYPE_TO_ONNX_TENSOR_ELEMENT_TYPE,
+        from_python_type_to_onnx_tensor_element_type,
     )
 
     _SUPPORT_ONNXRT = True

--- a/torch/onnx/_internal/onnxruntime.py
+++ b/torch/onnx/_internal/onnxruntime.py
@@ -386,7 +386,7 @@ def _adjust_scalar_from_fx_to_onnx(
         float,
         bool,
     ],
-    value_info: onnx.ValueInfoProto,
+    value_info: "onnx.ValueInfoProto",
 ) -> torch.Tensor:
     if (
         isinstance(dynamo_value, torch.Tensor)

--- a/torch/onnx/_internal/onnxruntime.py
+++ b/torch/onnx/_internal/onnxruntime.py
@@ -386,7 +386,7 @@ def _adjust_scalar_from_fx_to_onnx(
         float,
         bool,
     ],
-    value_info: "onnx.ValueInfoProto",
+    value_info: "onnx.ValueInfoProto",  # type: ignore[name-defined]
 ) -> torch.Tensor:
     if (
         isinstance(dynamo_value, torch.Tensor)
@@ -401,7 +401,8 @@ def _adjust_scalar_from_fx_to_onnx(
     elif isinstance(dynamo_value, bool):
         return torch.tensor(dynamo_value, dtype=torch.bool)
     else:
-        return dynamo_value
+        assert isinstance(dynamo_value, torch.Tensor)
+        return dynamo_value.contiguous()
 
 
 def _adjust_scalar_from_onnx_to_fx(
@@ -444,7 +445,6 @@ def _run_onnx_session_with_ortvaluevector(
     ],
 ) -> Tuple[Union[torch.Tensor, int, float, bool], ...]:
     _nvtx_range_push("contiguous")
-    inputs = tuple(a.contiguous() for a in inputs)
     inputs = tuple(
         _adjust_scalar_from_fx_to_onnx(arg, value_info)
         for arg, value_info in zip(inputs, input_value_infos)

--- a/torch/onnx/_internal/onnxruntime.py
+++ b/torch/onnx/_internal/onnxruntime.py
@@ -173,7 +173,7 @@ class OrtOperatorSupport(OperatorSupport):
             )
             return True
         logger.warning(
-            "extra_support_dict doesn't supports node.target: %s (type: %s)",
+            "extra_support_dict doesn't support node.target: %s (type: %s)",
             node.target,
             type(node.target),
         )
@@ -322,6 +322,8 @@ def _get_onnx_devices(
     ]
 ) -> Tuple["ORTC.OrtDevice", ...]:
     devices = tuple(value.device for value in values if isinstance(value, torch.Tensor))
+    if len(devices) == 0:
+        devices = (torch.device("cpu"),)
 
     def _device_id_or_zero(device_id: int) -> int:
         return device_id or 0
@@ -681,7 +683,12 @@ class OrtBackend:
 
         extra_support_dict: Dict[str, Any] = {
             "getattr": None,
+            # To send operator.getitem to ORT, add the corresponding string
+            # recognized by PyTorch's OperatorSupport class.
             "_operator.getitem": None,
+            # To send operator.mul to ORT, add the corresponding string
+            # recognized by PyTorch's OperatorSupport class.
+            "_operator.mul": None,
         }
 
         self._supported_ops = OrtOperatorSupport(support_dict, extra_support_dict)

--- a/torch/onnx/_internal/onnxruntime.py
+++ b/torch/onnx/_internal/onnxruntime.py
@@ -121,8 +121,8 @@ def _get_ort_device_type(device_type: str):
 
 logger = logging.getLogger(__name__)
 # Uncomment the following lines to print out development info.
-#logging.basicConfig(level=logging.WARNING)
-#logger.setLevel(logging.WARNING)
+# logging.basicConfig(level=logging.WARNING)
+# logger.setLevel(logging.WARNING)
 
 
 class OrtOperatorSupport(OperatorSupport):

--- a/torch/onnx/_internal/onnxruntime.py
+++ b/torch/onnx/_internal/onnxruntime.py
@@ -157,11 +157,6 @@ class OrtOperatorSupport(OperatorSupport):
                 type(node.target),
             )
             return True
-        logger.warning(
-            "support_dict doesn't support node.target: %s (type: %s)",
-            node.target,
-            type(node.target),
-        )
         # If node.target is not in support_dict, we still want to check if torch.jit.script
         # can convert it to ONNX equivalence. Let's use base mechanism to do this.
         # See extra_support_dict  for supported ops.
@@ -173,7 +168,7 @@ class OrtOperatorSupport(OperatorSupport):
             )
             return True
         logger.warning(
-            "extra_support_dict doesn't support node.target: %s (type: %s)",
+            "support_dict and extra_support_dict don't support node.target: %s (type: %s)",
             node.target,
             type(node.target),
         )

--- a/torch/onnx/_internal/onnxruntime.py
+++ b/torch/onnx/_internal/onnxruntime.py
@@ -770,6 +770,8 @@ class OrtBackend:
             # To send operator.mul to ORT, add the corresponding string
             # recognized by PyTorch's OperatorSupport class.
             "_operator.mul": None,
+            "_operator.add": None,
+            "_operator.sub": None,
         }
 
         self._supported_ops = OrtOperatorSupport(support_dict, extra_support_dict)

--- a/torch/onnx/_internal/onnxruntime.py
+++ b/torch/onnx/_internal/onnxruntime.py
@@ -121,8 +121,8 @@ def _get_ort_device_type(device_type: str):
 
 logger = logging.getLogger(__name__)
 # Uncomment the following lines to print out development info.
-logging.basicConfig(level=logging.WARNING)
-logger.setLevel(logging.WARNING)
+#logging.basicConfig(level=logging.WARNING)
+#logger.setLevel(logging.WARNING)
 
 
 class OrtOperatorSupport(OperatorSupport):

--- a/torch/onnx/_internal/onnxruntime.py
+++ b/torch/onnx/_internal/onnxruntime.py
@@ -121,8 +121,8 @@ def _get_ort_device_type(device_type: str):
 
 logger = logging.getLogger(__name__)
 # Uncomment the following lines to print out development info.
-# logging.basicConfig(level=logging.WARNING)
-# logger.setLevel(logging.WARNING)
+logging.basicConfig(level=logging.WARNING)
+logger.setLevel(logging.WARNING)
 
 
 class OrtOperatorSupport(OperatorSupport):
@@ -313,23 +313,44 @@ def _sort_eps(eps: Tuple[str, ...]) -> Tuple[str, ...]:
     return tuple(sorted(unique_eps, key=get_execution_provider_priority, reverse=True))
 
 
-def _get_onnx_devices(values: Tuple[torch.Tensor, ...]) -> Tuple["ORTC.OrtDevice", ...]:
-    assert all(
-        value.device == values[0].device for value in values
-    ), "All values must be on the same device."
+def _get_onnx_devices(
+    values: Tuple[
+        Union[
+            torch.Tensor, torch.SymInt, int, torch.SymFloat, float, torch.SymBool, bool
+        ],
+        ...,
+    ]
+) -> Tuple["ORTC.OrtDevice", ...]:
+    devices = tuple(value.device for value in values if isinstance(value, torch.Tensor))
 
     def _device_id_or_zero(device_id: int) -> int:
         return device_id or 0
 
-    devices: Tuple["ORTC.OrtDevice", ...] = tuple(
-        ORTC.OrtDevice(
-            _get_ort_device_type(value.device.type),
-            ORTC.OrtDevice.default_memory(),
-            _device_id_or_zero(value.device.index),
-        )
-        for value in values
+    def _map_tensor_or_sym_to_device(
+        value: Union[
+            torch.Tensor, torch.SymInt, int, torch.SymFloat, float, torch.SymBool, bool
+        ],
+        device: torch.device,
+    ) -> int:
+        if isinstance(value, torch.Tensor):
+            return ORTC.OrtDevice(
+                _get_ort_device_type(device.type),
+                ORTC.OrtDevice.default_memory(),
+                _device_id_or_zero(device.index),
+            )
+        elif isinstance(
+            value, (torch.SymInt, int, torch.SymFloat, float, torch.SymBool, bool)
+        ):
+            return ORTC.OrtDevice(
+                _get_ort_device_type("cpu"), ORTC.OrtDevice.default_memory(), 0
+            )
+        else:
+            raise ValueError("Unsupported value type: " + str(type(value)))
+
+    ort_devices = tuple(
+        _map_tensor_or_sym_to_device(value, devices[0]) for value in values
     )
-    return devices
+    return ort_devices
 
 
 def _get_ortvalues_from_torch_tensors(
@@ -469,8 +490,24 @@ class OrtExecutionInfoPerSession:
         if len(args) != len(self.input_value_infos):
             return False
         for arg, value_info in zip(args, self.input_value_infos):
-            if not isinstance(arg, torch.Tensor):
+            if not isinstance(arg, (torch.Tensor, float, int)):
                 return False
+
+            # Check Python scalars such as int, float, and bool.
+            scalar_to_dtype = {
+                float: _TORCH_DTYPE_TO_ONNX_TENSOR_ELEMENT_TYPE[torch.float],
+                int: _TORCH_DTYPE_TO_ONNX_TENSOR_ELEMENT_TYPE[torch.int64],
+                bool: _TORCH_DTYPE_TO_ONNX_TENSOR_ELEMENT_TYPE[torch.bool],
+            }
+            if isinstance(arg, (int, float, bool)):
+                onnx_dtype = scalar_to_dtype[type(arg)]
+                if onnx_dtype != value_info.type.tensor_type.elem_type:
+                    return False
+                if len(value_info.type.tensor_type.shape.dim) != 0:
+                    return False
+                continue
+
+            # Check tensor.
             onnx_dtype = _TORCH_DTYPE_TO_ONNX_TENSOR_ELEMENT_TYPE[arg.dtype]
             if onnx_dtype != value_info.type.tensor_type.elem_type:
                 return False
@@ -727,6 +764,8 @@ class OrtBackend:
             onnx_session = cached_execution_info_per_session.session
             input_names = cached_execution_info_per_session.input_names
             output_names = cached_execution_info_per_session.output_names
+            input_value_infos = cached_execution_info_per_session.input_value_infos
+            output_value_infos = cached_execution_info_per_session.output_value_infos
             input_devices = cached_execution_info_per_session.input_devices
             output_devices = cached_execution_info_per_session.output_devices
             prim_outputs = cached_execution_info_per_session.example_outputs
@@ -825,12 +864,15 @@ class OrtBackend:
             else:
                 output_devices = _get_onnx_devices((prim_outputs,))
 
+            input_value_infos = tuple(input for input in onnx_model.graph.input)
+            output_value_infos = tuple(output for output in onnx_model.graph.output)
+
             execution_info_per_session = OrtExecutionInfoPerSession(
                 session=onnx_session,
                 input_names=input_names,
-                input_value_infos=tuple(input for input in onnx_model.graph.input),
+                input_value_infos=input_value_infos,
                 output_names=output_names,
-                output_value_infos=tuple(output for output in onnx_model.graph.output),
+                output_value_infos=output_value_infos,
                 input_devices=input_devices,
                 output_devices=output_devices,
                 example_outputs=prim_outputs,
@@ -850,18 +892,76 @@ class OrtBackend:
             (prim_outputs,) if is_single_tensor_output else prim_outputs
         )
         assert isinstance(normalized_prim_outputs, tuple)
-        assert all(isinstance(elem, torch.Tensor) for elem in normalized_prim_outputs)
+        assert all(
+            isinstance(elem, (torch.Tensor, torch.SymInt, int))
+            for elem in normalized_prim_outputs
+        )
+
+        def adjust_scalar_from_fx_to_onnx(
+            dynamo_value: Union[
+                torch.Tensor,
+                int,
+                float,
+                bool,
+            ],
+            value_info: onnx.ValueInfoProto,
+        ) -> torch.Tensor:
+            if (
+                isinstance(dynamo_value, torch.Tensor)
+                and len(value_info.type.tensor_type.shape.dim) == 0
+                and dynamo_value.shape == (1,)
+            ):
+                return torch.squeeze(dynamo_value)
+            elif isinstance(dynamo_value, int):
+                return torch.tensor(dynamo_value, dtype=torch.int64)
+            elif isinstance(dynamo_value, float):
+                return torch.tensor(dynamo_value, dtype=torch.float32)
+            elif isinstance(dynamo_value, bool):
+                return torch.tensor(dynamo_value, dtype=torch.bool)
+            else:
+                return dynamo_value
+
+        def adjust_scalar_from_onnx_to_fx(
+            tensor: torch.Tensor,
+            prim_value: Union[
+                torch.Tensor,
+                torch.SymInt,
+                int,
+                torch.SymFloat,
+                float,
+                torch.SymBool,
+                bool,
+            ],
+        ) -> Union[torch.Tensor, int, float, bool,]:
+            assert isinstance(tensor, torch.Tensor), "ORT's output must be tensor."
+            if isinstance(
+                prim_value,
+                (torch.SymInt, int, torch.SymFloat, float, torch.SymBool, bool),
+            ):
+                # Convert tensor back to scalar to match Dynamo's expectation.
+                return tensor.item()
+            return tensor
 
         _nvtx_range_push("run_onnx_session_with_ortvaluevector")
+        onnx_args = tuple(
+            adjust_scalar_from_fx_to_onnx(arg, value_info)
+            for arg, value_info in zip(args, input_value_infos)
+        )
+
         onnx_outputs = self.run(
             onnx_session,
             input_names,
-            args,
+            onnx_args,
             input_devices,
             output_names,
             normalized_prim_outputs,
             output_devices,
             self._options.preallocate_output,
+        )
+
+        onnx_outputs = tuple(
+            adjust_scalar_from_onnx_to_fx(onnx_output, prim_output)
+            for onnx_output, prim_output in zip(onnx_outputs, normalized_prim_outputs)
         )
         _nvtx_range_pop()
         if self._assert_allclose_to_baseline:


### PR DESCRIPTION
As title. This PR enables dynamic shapes for running llama with ORT. Both forward and backward are captured as a single graph with this PR.

Summary of changes:
- Test llama attention, llama decoder, llama model to ensure (1) no graph breaks (2) models exported with dynamic shapes with onnxrt dynamo backend
- Reshape SymInt to tensor with shape (1,) to align with the cast done for int in fx_onnx_interpreter.py
- Create an util function to map Python types (e.g., float) to ONNX tensor element type (e.g., onnx.TensorProto.FLOAT).
- Return `hint` for torch.Sym* in type promotion pass.
- Remove _replace_to_copy_with_to since exporter supports aten::_to_copy it now.
- Modify _get_onnx_devices to return CPU device for torch.Sym*.
- Introduce _adjust_scalar_from_fx_to_onnx (e.g., change 0 to tensor(0)) and _adjust_scalar_from_onnx_to_fx (e.g., change tensor(0) to 0) for adjusting scalars when passing values to and receive values from ORT.
- Now, ValueInfoProto of graph inputs (i.e., input_value_infos) are stored and used as `ORT-expected type` when calling `_adjust_scalar_from_fx_to_onnx`.