### PR TITLE
[BE] Use `__builtin_overflow_sub` when available

### DIFF
--- a/c10/core/SymInt.cpp
+++ b/c10/core/SymInt.cpp
@@ -3,6 +3,7 @@
 #include <c10/core/SymInt.h>
 #include <c10/core/SymNodeImpl.h>
 #include <c10/util/intrusive_ptr.h>
+#include <c10/util/safe_numerics.h>
 #include <functional>
 
 namespace c10 {
@@ -139,8 +140,16 @@ SymInt operator-(const SymInt& s) {
     // But on many platforms it equals to self + setting Carry/Overflow flags
     // Which in opimized code affects results of `check_range` condition
     // Workaround by using ternary that avoids alterning the flags
+#if C10_HAS_BUILTIN_OVERFLOW()
+   decltype(val) out = 0;
+   if (C10_UNLIKELY(__builtin_sub_overflow(out, val, &out))) {
+     return SymInt(val);
+   }
+   return SymInt(out);
+#else
     constexpr auto val_min = std::numeric_limits<decltype(val)>::min();
     return SymInt(val != val_min ? -val : val_min);
+#endif
   } else {
     return SymInt(s.toSymNodeImplUnowned()->neg());
   }

--- a/c10/core/SymInt.cpp
+++ b/c10/core/SymInt.cpp
@@ -141,11 +141,11 @@ SymInt operator-(const SymInt& s) {
     // Which in opimized code affects results of `check_range` condition
     // Workaround by using ternary that avoids alterning the flags
 #if C10_HAS_BUILTIN_OVERFLOW()
-   std::decay_t<decltype(val)> out = 0;
-   if (C10_UNLIKELY(__builtin_sub_overflow(out, val, &out))) {
-     return SymInt(val);
-   }
-   return SymInt(out);
+    std::decay_t<decltype(val)> out = 0;
+    if (C10_UNLIKELY(__builtin_sub_overflow(out, val, &out))) {
+      return SymInt(val);
+    }
+    return SymInt(out);
 #else
     constexpr auto val_min = std::numeric_limits<decltype(val)>::min();
     return SymInt(val != val_min ? -val : val_min);

--- a/c10/core/SymInt.cpp
+++ b/c10/core/SymInt.cpp
@@ -141,7 +141,7 @@ SymInt operator-(const SymInt& s) {
     // Which in opimized code affects results of `check_range` condition
     // Workaround by using ternary that avoids alterning the flags
 #if C10_HAS_BUILTIN_OVERFLOW()
-   decltype(val) out = 0;
+   std::decay_t<decltype(val)> out = 0;
    if (C10_UNLIKELY(__builtin_sub_overflow(out, val, &out))) {
      return SymInt(val);
    }


### PR DESCRIPTION
Which is faster then ternary.

Following script
```python
import torch
from timeit import default_timer

global_setup = """
"""
setup = """
c10::SymInt a = c10::SymInt(123);
"""
code = """
-a;
"""

from torch.utils.benchmark import Timer

t = Timer(stmt=code, setup=setup, global_setup=global_setup, language="c++", timer=default_timer)

print(t.blocked_autorange())
```

reports 4.17 ns median type before and 3.61 ns after on x86_64 Linux and 2.02 ns before and 1.91 ns after on Apple M1
