### PR TITLE
[reland] unflatten_tensor on compute stream for DTensorExtension

### DIFF
--- a/test/distributed/fsdp/test_fsdp_tp_integration.py
+++ b/test/distributed/fsdp/test_fsdp_tp_integration.py
@@ -373,6 +373,14 @@ class TestTPFSDPIntegration(FSDPTest):
         self.assertEqual(comm_counts[funcol.all_gather_into_tensor], 2)
         self.assertEqual(comm_counts[funcol.all_reduce], 1)
 
+        grads = [p.grad for p in fsdp_2d_model.parameters() if p.grad is not None]
+
+        for grad in grads:
+            if isinstance(grad, DTensor):
+                grad = grad.full_tensor()
+
+            self.assertFalse(grad.isnan().any().item())
+
 
 instantiate_parametrized_tests(TestTPFSDPIntegration)
 

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -513,7 +513,7 @@ def _init_extension(state: _FSDPState, device_mesh: DeviceMesh = None) -> _FSDPS
     # TODO: we need to add additional check once we support FSDP + PiPPy.
     # This check is currently sufficient, since we only support FSDP + TP.
     if device_mesh and _mesh_resources.get_parent_mesh(state._device_mesh) is not None:
-        state._fsdp_extension = DTensorExtensions()
+        state._fsdp_extension = DTensorExtensions(state._device_handle)
     else:
         # We need to explicilty set _fsdp_extension to None.
         # Otherwise, we will run into an infinite recursion when getting the attribute.

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -250,6 +250,8 @@ def _share_state_and_init_handle_attrs(
         fsdp_state._default_stream = root_state._default_stream
         fsdp_state._exec_order_data = root_state._exec_order_data
         fsdp_state._free_event_queue = root_state._free_event_queue
+        if fsdp_state._fsdp_extension is not None:
+            fsdp_state._fsdp_extension.compute_stream = root_state._default_stream
         handle = fsdp_state._handle
         if handle:
             handle.init_flat_param_attributes()
@@ -279,6 +281,10 @@ def _init_streams(
     high_priority = -1 if state.limit_all_gathers and uses_hybrid_sharding else 0
     # Default stream for computation
     state._default_stream = state._device_handle.current_stream()
+    if state._fsdp_extension is not None:
+        # set the compute stream to the FSDP extension
+        state._fsdp_extension.compute_stream = state._default_stream
+
     # Stream for unshard logic, including allocating the all-gather destination
     # tensors and the all-gathers themselves
     state._unshard_stream = state._device_handle.Stream(priority=high_priority)

--- a/torch/distributed/tensor/parallel/fsdp.py
+++ b/torch/distributed/tensor/parallel/fsdp.py
@@ -18,7 +18,7 @@ from torch.distributed._shard.sharding_spec.chunk_sharding_spec import ChunkShar
 from torch.distributed._tensor import DeviceMesh, DTensor, Replicate, Shard as DShard
 from torch.distributed.device_mesh import _mesh_resources
 
-from torch.distributed.fsdp._common_utils import _set_fsdp_flattened
+from torch.distributed.fsdp._common_utils import _set_fsdp_flattened, _FSDPState
 from torch.distributed.fsdp._fsdp_extensions import FSDPExtensions
 from torch.distributed.fsdp._shard_utils import _create_chunk_sharded_tensor
 from torch.distributed.remote_device import _remote_device
@@ -320,6 +320,10 @@ class DTensorExtensions(FSDPExtensions):
     This is the implementation for FSDPExtensions defined in
     https://github.com/pytorch/pytorch/blob/main/torch/distributed/fsdp/_fsdp_extensions.py
     """
+    def __init__(self, device_handle) -> None:
+        super().__init__()
+        self.compute_stream = None
+        self.device_handle = device_handle
 
     def pre_flatten_transform(
         self,
@@ -330,9 +334,23 @@ class DTensorExtensions(FSDPExtensions):
     def post_unflatten_transform(
         self, tensor: torch.Tensor, param_extension: Any
     ) -> torch.Tensor:
-        result = _unflatten_tensor(tensor, param_extension)
-        _set_fsdp_flattened(result)
-        return result
+        if self.compute_stream is not None:
+            # runtime we put the unflattened tensor call on the compute stream since
+            # the unflattened tensor might contain computations in fwd/bwd where we
+            # need to sync properly.
+            # TODO: this is a short term fix and we should make the get_unflat_views
+            # directly happen in the compute stream.
+            with self.device_handle.stream(self.compute_stream):
+                result = _unflatten_tensor(tensor, param_extension)
+                _set_fsdp_flattened(result)
+                return result
+        else:
+            # this would only happen in the FSDP initialization, where we
+            # don't have the compute stream yet.
+            result = _unflatten_tensor(tensor, param_extension)
+            _set_fsdp_flattened(result)
+            return result
+
 
     def chunk_tensor(
         self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #117018

reland of PR https://github.com/pytorch/pytorch/pull/116559, which was
reverted by internal.

The underlying reason for the revert is because of the
`torch.dynamo.disable` was not usable by the pytorch codebase, because
it's conflicting with some torch::deploy issues, although the later one
only run some inference, but it somehow take that weird dependency on
fsdp..

verified internally that after removing `torch.dynamo.disable` the test
passed again

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @fduwjj @wz337 @tianyu-l @wconstab @yf225