### PR TITLE
[Dynamo] Use isinstance rather than istype when check if python module type

### DIFF
--- a/test/test_expanded_weights.py
+++ b/test/test_expanded_weights.py
@@ -13,7 +13,7 @@ from torch.testing._internal.common_cuda import TEST_CUDA, tf32_off
 from torch.testing._internal.common_device_type import OpDTypes, instantiate_device_type_tests, ops
 from torch.testing._internal.common_modules import module_db, modules
 from torch.testing._internal.common_nn import TestBase, module_tests, new_module_tests
-from torch.testing._internal.common_utils import TestCase, freeze_rng_state, make_tensor, run_tests, parametrize
+from torch.testing._internal.common_utils import TestCase, freeze_rng_state, make_tensor, run_tests, parametrize, skipIfTorchDynamo
 from torch.testing._internal.common_methods_invocations import SampleInput, op_db
 from torch.nn.utils._expanded_weights import ExpandedWeight
 from torch.nn.utils._expanded_weights.expanded_weights_utils import forward_helper, set_grad_sample_if_exists, \
@@ -78,6 +78,7 @@ class TestExpandedWeightHelperFunction(TestCase):
                 expanded_args, expanded_kwargs = standard_kwargs(('bias',), (input, maybe_batched_weight, maybe_batched_bias))
                 forward_helper(nn.functional.linear, expanded_args, expanded_kwargs)
 
+    @skipIfTorchDynamo("Not a Dynamo suitable test")
     def test_set_grad_sample_if_exists(self, device):
         def test_fn(a):
             return grad_sample

--- a/test/test_expanded_weights.py
+++ b/test/test_expanded_weights.py
@@ -13,7 +13,7 @@ from torch.testing._internal.common_cuda import TEST_CUDA, tf32_off
 from torch.testing._internal.common_device_type import OpDTypes, instantiate_device_type_tests, ops
 from torch.testing._internal.common_modules import module_db, modules
 from torch.testing._internal.common_nn import TestBase, module_tests, new_module_tests
-from torch.testing._internal.common_utils import TestCase, freeze_rng_state, make_tensor, run_tests, parametrize
+from torch.testing._internal.common_utils import TestCase, freeze_rng_state, make_tensor, run_tests, parametrize, skipIfTorchDynamo
 from torch.testing._internal.common_methods_invocations import SampleInput, op_db
 from torch.nn.utils._expanded_weights import ExpandedWeight
 from torch.nn.utils._expanded_weights.expanded_weights_utils import forward_helper, set_grad_sample_if_exists, \
@@ -203,6 +203,7 @@ class TestExpandedWeightFunctional(TestCase):
 
             self._compare_ew_and_for_loop_per_sample_grads(op, sample_input, torch.mean)
 
+    @skipIfTorchDynamo("Checking error message doesn't work with dynamo")
     @ops(filter(lambda op: op.supports_expanded_weight, op_db), dtypes=OpDTypes.supported, allowed_dtypes=(torch.double,))
     def test_unsupported_expand_weights(self, device, dtype, op):
         sample_inputs = op.sample_inputs(device, dtype, requires_grad=True)

--- a/test/test_expanded_weights.py
+++ b/test/test_expanded_weights.py
@@ -13,7 +13,7 @@ from torch.testing._internal.common_cuda import TEST_CUDA, tf32_off
 from torch.testing._internal.common_device_type import OpDTypes, instantiate_device_type_tests, ops
 from torch.testing._internal.common_modules import module_db, modules
 from torch.testing._internal.common_nn import TestBase, module_tests, new_module_tests
-from torch.testing._internal.common_utils import TestCase, freeze_rng_state, make_tensor, run_tests, parametrize, skipIfTorchDynamo
+from torch.testing._internal.common_utils import TestCase, freeze_rng_state, make_tensor, run_tests, parametrize
 from torch.testing._internal.common_methods_invocations import SampleInput, op_db
 from torch.nn.utils._expanded_weights import ExpandedWeight
 from torch.nn.utils._expanded_weights.expanded_weights_utils import forward_helper, set_grad_sample_if_exists, \
@@ -78,7 +78,6 @@ class TestExpandedWeightHelperFunction(TestCase):
                 expanded_args, expanded_kwargs = standard_kwargs(('bias',), (input, maybe_batched_weight, maybe_batched_bias))
                 forward_helper(nn.functional.linear, expanded_args, expanded_kwargs)
 
-    @skipIfTorchDynamo("Not a Dynamo suitable test")
     def test_set_grad_sample_if_exists(self, device):
         def test_fn(a):
             return grad_sample

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -697,13 +697,7 @@ class VariableBuilder:
             return trace_rules.lookup(value).create_with_source(
                 value, source=self.source
             )
-        elif (
-            istype(value, (types.ModuleType, replay_record.DummyModule))
-            # type(torch.backends.cudnn) -> <class 'torch.backends.cudnn.CudnnModule'>
-            # type(torch.ops) -> <class 'torch._ops._Ops'>
-            or any(value is obj for obj in (torch.backends.cudnn, torch.ops))
-            or isinstance(value, torch._ops._OpNamespace)
-        ):
+        elif isinstance(value, (types.ModuleType, replay_record.DummyModule)):
             self.install_guards(GuardBuilder.FUNCTION_MATCH)
             return PythonModuleVariable(
                 value,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -697,6 +697,9 @@ class VariableBuilder:
             return trace_rules.lookup(value).create_with_source(
                 value, source=self.source
             )
+        # Don't use istype, since some python modules are not subclasses of types.ModuleType directly.
+        # E.g, type(torch.ops) -> <class 'torch._ops._Ops'>,
+        # type(torch.backends.cudnn) -> <class 'torch.backends.cudnn.CudnnModule'>
         elif isinstance(value, (types.ModuleType, replay_record.DummyModule)):
             self.install_guards(GuardBuilder.FUNCTION_MATCH)
             return PythonModuleVariable(

--- a/torch/testing/_internal/dynamo_test_failures.py
+++ b/torch/testing/_internal/dynamo_test_failures.py
@@ -2144,6 +2144,7 @@ dynamo_expected_failures = {
     "TestExpandedWeightFunctionalCPU.test_expanded_weight_per_sample_grad_mean_nn_functional_conv1d_cpu_float64",  # test_expanded_weights  # noqa: B950
     "TestExpandedWeightFunctionalCPU.test_expanded_weight_per_sample_grad_mean_nn_functional_layer_norm_cpu_float64",  # test_expanded_weights  # noqa: B950
     "TestExpandedWeightFunctionalCPU.test_expanded_weights_per_sample_grad_input_no_grad_nn_functional_conv2d_cpu_float64",  # test_expanded_weights  # noqa: B950
+    "TestExpandedWeightFunctionalCPU.test_unsupported_expand_weights_nn_functional_conv1d_cpu_float64",  # test_expanded_weights  # noqa: B950
     "TestTorchDlPackCPU.test_dlpack_export_non_strided_cpu",  # test_dlpack
     "TestIterDataPipeGraphFastForward.test_simple_snapshot_custom_self_next",  # test_datapipe
     "TestIterDataPipeGraphFastForward.test_simple_snapshot_custom_non_generator",  # test_datapipe

--- a/torch/testing/_internal/dynamo_test_failures.py
+++ b/torch/testing/_internal/dynamo_test_failures.py
@@ -2144,7 +2144,6 @@ dynamo_expected_failures = {
     "TestExpandedWeightFunctionalCPU.test_expanded_weight_per_sample_grad_mean_nn_functional_conv1d_cpu_float64",  # test_expanded_weights  # noqa: B950
     "TestExpandedWeightFunctionalCPU.test_expanded_weight_per_sample_grad_mean_nn_functional_layer_norm_cpu_float64",  # test_expanded_weights  # noqa: B950
     "TestExpandedWeightFunctionalCPU.test_expanded_weights_per_sample_grad_input_no_grad_nn_functional_conv2d_cpu_float64",  # test_expanded_weights  # noqa: B950
-    "TestExpandedWeightFunctionalCPU.test_unsupported_expand_weights_nn_functional_conv1d_cpu_float64",  # test_expanded_weights  # noqa: B950
     "TestTorchDlPackCPU.test_dlpack_export_non_strided_cpu",  # test_dlpack
     "TestIterDataPipeGraphFastForward.test_simple_snapshot_custom_self_next",  # test_datapipe
     "TestIterDataPipeGraphFastForward.test_simple_snapshot_custom_non_generator",  # test_datapipe

--- a/torch/testing/_internal/dynamo_test_failures.py
+++ b/torch/testing/_internal/dynamo_test_failures.py
@@ -863,7 +863,6 @@ dynamo_expected_failures = {
     "TestEinsum.test_different_paths_dtype_e",  # torch_np/numpy_tests/core/test_einsum
     "TestEinsum.test_different_paths_dtype_B",  # torch_np/numpy_tests/core/test_einsum
     "TestEinsum.test_different_paths_dtype_b",  # torch_np/numpy_tests/core/test_einsum
-    "TestMisc.test_f16_on_cuda",
     "TestDLPack.test_dtype_passthrough_dtype4",  # torch_np/numpy_tests/core/test_dlpack
     "TestDLPack.test_higher_dims_ndim_23",  # torch_np/numpy_tests/core/test_dlpack
     "TestDLPack.test_higher_dims_ndim_12",  # torch_np/numpy_tests/core/test_dlpack


### PR DESCRIPTION
This is to fix a issue from Meta internal use case, where third-party ```DictConfig``` has bug on [```__eq__```](https://github.com/omry/omegaconf/blob/fd730509ef10a074f97b1738c630720157ceeeab/omegaconf/dictconfig.py#L596) and it triggers Dynamo error because we are using ```obj in [x, y]``` check. Then I found we can use ```isinstance``` to cover all and removing these special cases. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng