### PR TITLE
[CPU] _vec_softmax_backward, _vec_log_softmax_backward, _vec_logsoftmax: fix CHUNK_SIZE to avoid unnecessarily large allocation

### DIFF
--- a/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
+++ b/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
@@ -42,9 +42,10 @@ inline void _vec_log_softmax_lastdim(
   // size of L1D cache on many processors. Some processors have 48 KB L1D cache
   // nowadays, so maybe in the future, we can leverage the knowledge of a
   // machine's L1D cache size.
-  int64_t CHUNK_SIZE = std::max<int64_t>(
+  int64_t MAX_CHUNK_SIZE = std::max<int64_t>(
       1,
       at::internal::GRAIN_SIZE / (sizeof(scalar_t) * dim_size));
+  int64_t CHUNK_SIZE = std::min<int64_t>(MAX_CHUNK_SIZE, outer_size);
 
   int64_t grain_size = internal::GRAIN_SIZE / (16 * dim_size);
 
@@ -271,9 +272,10 @@ _vec_softmax_backward(
   using Vec = vec::Vectorized<scalar_t>;
   int64_t outer_stride = dim_size * inner_size;
   int64_t BLOCK_SIZE = 128 * 1024;
-  int64_t CHUNK_SIZE = std::max<int64_t>(
+  int64_t MAX_CHUNK_SIZE = std::max<int64_t>(
       BLOCK_SIZE / dim_size / sizeof(scalar_t), Vec::size());
-  CHUNK_SIZE = CHUNK_SIZE / Vec::size() * Vec::size();
+  MAX_CHUNK_SIZE = MAX_CHUNK_SIZE / Vec::size() * Vec::size();
+  int64_t CHUNK_SIZE = std::min<int64_t>(MAX_CHUNK_SIZE, inner_size);
   int64_t num_chunks = divup(inner_size, CHUNK_SIZE);
   int64_t grain_size = internal::GRAIN_SIZE / (16 * dim_size * CHUNK_SIZE);
   parallel_for(
@@ -355,9 +357,10 @@ _vec_softmax_backward(
   using fVec = vec::Vectorized<float>;
   int64_t outer_stride = dim_size * inner_size;
   int64_t BLOCK_SIZE = 128 * 1024;
-  int64_t CHUNK_SIZE = std::max<int64_t>(
+  int64_t MAX_CHUNK_SIZE = std::max<int64_t>(
       BLOCK_SIZE / dim_size / sizeof(scalar_t), Vec::size());
-  CHUNK_SIZE = CHUNK_SIZE / Vec::size() * Vec::size();
+  MAX_CHUNK_SIZE = MAX_CHUNK_SIZE / Vec::size() * Vec::size();
+  int64_t CHUNK_SIZE = std::min<int64_t>(MAX_CHUNK_SIZE, inner_size);
   int64_t num_chunks = divup(inner_size, CHUNK_SIZE);
   int64_t grain_size = internal::GRAIN_SIZE / (16 * dim_size * CHUNK_SIZE);
   parallel_for(
@@ -480,9 +483,10 @@ _vec_log_softmax_backward(
   using Vec = vec::Vectorized<scalar_t>;
   int64_t outer_stride = dim_size * inner_size;
   int64_t BLOCK_SIZE = 128 * 1024;
-  int64_t CHUNK_SIZE = std::max<int64_t>(
+  int64_t MAX_CHUNK_SIZE = std::max<int64_t>(
       BLOCK_SIZE / dim_size / sizeof(scalar_t), Vec::size());
-  CHUNK_SIZE = CHUNK_SIZE / Vec::size() * Vec::size();
+  MAX_CHUNK_SIZE = MAX_CHUNK_SIZE / Vec::size() * Vec::size();
+  int64_t CHUNK_SIZE = std::min<int64_t>(MAX_CHUNK_SIZE, inner_size);
   int64_t num_chunks = divup(inner_size, CHUNK_SIZE);
   int64_t grain_size = internal::GRAIN_SIZE / (16 * dim_size * CHUNK_SIZE);
   parallel_for(
@@ -563,9 +567,10 @@ _vec_log_softmax_backward(
   using fVec = vec::Vectorized<float>;
   int64_t outer_stride = dim_size * inner_size;
   int64_t BLOCK_SIZE = 128 * 1024;
-  int64_t CHUNK_SIZE = std::max<int64_t>(
+  int64_t MAX_CHUNK_SIZE = std::max<int64_t>(
       BLOCK_SIZE / dim_size / sizeof(scalar_t), Vec::size());
-  CHUNK_SIZE = CHUNK_SIZE / Vec::size() * Vec::size();
+  MAX_CHUNK_SIZE = MAX_CHUNK_SIZE / Vec::size() * Vec::size();
+  int64_t CHUNK_SIZE = std::min<int64_t>(MAX_CHUNK_SIZE, inner_size);
   int64_t num_chunks = divup(inner_size, CHUNK_SIZE);
   int64_t grain_size = internal::GRAIN_SIZE / (16 * dim_size * CHUNK_SIZE);
   parallel_for(
@@ -894,8 +899,9 @@ _vec_logsoftmax(
     int64_t dim_size) {
   using Vec = vec::Vectorized<scalar_t>;
   int64_t BLOCK_SIZE = 128 * 1024;
-  int64_t CHUNK_SIZE = std::max<int64_t>(BLOCK_SIZE / dim_size / sizeof(scalar_t), Vec::size());
-  CHUNK_SIZE = CHUNK_SIZE / Vec::size() * Vec::size();
+  int64_t MAX_CHUNK_SIZE = std::max<int64_t>(BLOCK_SIZE / dim_size / sizeof(scalar_t), Vec::size());
+  MAX_CHUNK_SIZE = MAX_CHUNK_SIZE / Vec::size() * Vec::size();
+  int64_t CHUNK_SIZE = std::min<int64_t>(MAX_CHUNK_SIZE, inner_size);
   int64_t num_chunks = divup(inner_size, CHUNK_SIZE);
 
   int64_t grain_size = internal::GRAIN_SIZE / (16 * dim_size * CHUNK_SIZE);
@@ -999,8 +1005,9 @@ _vec_logsoftmax(
   using Vec = vec::Vectorized<scalar_t>;
   using fVec = vec::Vectorized<float>;
   int64_t BLOCK_SIZE = 128 * 1024;
-  int64_t CHUNK_SIZE = std::max<int64_t>(BLOCK_SIZE / dim_size / sizeof(scalar_t), Vec::size());
-  CHUNK_SIZE = CHUNK_SIZE / Vec::size() * Vec::size();
+  int64_t MAX_CHUNK_SIZE = std::max<int64_t>(BLOCK_SIZE / dim_size / sizeof(scalar_t), Vec::size());
+  MAX_CHUNK_SIZE = MAX_CHUNK_SIZE / Vec::size() * Vec::size();
+  int64_t CHUNK_SIZE = std::min<int64_t>(MAX_CHUNK_SIZE, inner_size);
   int64_t num_chunks = divup(inner_size, CHUNK_SIZE);
 
   int64_t grain_size = internal::GRAIN_SIZE / (16 * dim_size * CHUNK_SIZE);

--- a/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
+++ b/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
@@ -42,10 +42,9 @@ inline void _vec_log_softmax_lastdim(
   // size of L1D cache on many processors. Some processors have 48 KB L1D cache
   // nowadays, so maybe in the future, we can leverage the knowledge of a
   // machine's L1D cache size.
-  int64_t MAX_CHUNK_SIZE = std::max<int64_t>(
+  int64_t CHUNK_SIZE = std::max<int64_t>(
       1,
       at::internal::GRAIN_SIZE / (sizeof(scalar_t) * dim_size));
-  int64_t CHUNK_SIZE = std::min<int64_t>(MAX_CHUNK_SIZE, outer_size);
 
   int64_t grain_size = internal::GRAIN_SIZE / (16 * dim_size);
 


### PR DESCRIPTION
Similar to https://github.com/pytorch/pytorch/pull/116990, fixes `CHUNK_SIZE` in `_vec_softmax_backward`, `_vec_log_softmax_backward`, `_vec_logsoftmax`, where `CHUNK_SIZE` is set as 
```cpp
int64_t BLOCK_SIZE = 128 * 1024;
int64_t CHUNK_SIZE = std::max<int64_t>(BLOCK_SIZE / dim_size / sizeof(scalar_t), Vec::size());
CHUNK_SIZE = CHUNK_SIZE / Vec::size() * Vec::size();
```
where `BLOCK_SIZE / dim_size / sizeof(scalar_t)` computes the maximum number of inner dim that can fit into L2 cache, assuming L2 cache = 128KB, and `CHUNK_SIZE / Vec::size() * Vec::size()` is to make `CHUNK_SIZE` a multiple of `Vec::size()`.

Fix `CHUNK_SIZE` as the minimum between `CHUNK_SIZE` and `inner_size` to avoid unnecessarily large `CHUNK_SIZE` and unnecessarily large allocation for `max` and `tmp_sum` buffer.
```cpp
auto buffer = std::make_unique<scalar_t []>(CHUNK_SIZE * 2);
scalar_t* input_max_data = buffer.get();
scalar_t* tmp_sum_data = buffer.get() + CHUNK_SIZE;
```

### Performance

Perf data of `_vec_logsoftmax` collected for `dim_size` in range [2^0, 2^9] and `outer_size` in range [2^0, 2^3]. To measure the benefit from avoiding unnecessarily large allocation, values of `outer_size` were chosen such that `outer_size` is less than `BLOCK_SIZE / dim_size / sizeof(scalar_t)` for all values of `outer_size`.

Tested on 28 physical cores/socket, 1 socket on Skylake.

| **dim_size** 	| **BLOCK_SIZE / dim_size / sizeof(scalar_t)** 	| **input shape: (dim_size, inner_size)** 	| **Baseline (original implementation)** 	| **Optimized** 	| **Speedup Ratio (Baseline/Optimized)** 	|
|--------------	|----------------------------------------------	|-----------------------------------------	|----------------------------------------	|---------------	|----------------------------------------	|
| 1            	| 32768                                        	| (1, 1)                                  	| 0.012578964                            	| 0.003523827   	| **3.569689**                           	|
|              	|                                              	| (1, 2)                                  	| 0.012645721                            	| 0.003550053   	| **3.562122**                           	|
|              	|                                              	| (1, 4)                                  	| 0.01303196                             	| 0.003521442   	| **3.700745**                           	|
|              	|                                              	| (1, 8)                                  	| 0.01275301                             	| 0.003552437   	| **3.589933**                           	|
| 2            	| 16384                                        	| (2, 1)                                  	| 0.008230209                            	| 0.003688335   	| **2.231416**                           	|
|              	|                                              	| (2, 2)                                  	| 0.00821352                             	| 0.003502369   	| **2.345133**                           	|
|              	|                                              	| (2, 4)                                  	| 0.008280277                            	| 0.003442764   	| **2.405125**                           	|
|              	|                                              	| (2, 8)                                  	| 0.0086236                              	| 0.003490448   	| **2.470628**                           	|
| 4            	| 8192                                         	| (4, 1)                                  	| 0.005865097                            	| 0.003454685   	| **1.697723**                           	|
|              	|                                              	| (4, 2)                                  	| 0.005846024                            	| 0.003490448   	| **1.674863**                           	|
|              	|                                              	| (4, 4)                                  	| 0.006036758                            	| 0.0035429     	| **1.703903**                           	|
|              	|                                              	| (4, 8)                                  	| 0.005993843                            	| 0.003669262   	| **1.633528**                           	|
| 8            	| 4096                                         	| (8, 1)                                  	| 0.00469923                             	| 0.003535748   	| **1.329063**                           	|
|              	|                                              	| (8, 2)                                  	| 0.004696846                            	| 0.003600121   	| **1.304636**                           	|
|              	|                                              	| (8, 4)                                  	| 0.005483627                            	| 0.003721714   	| **1.473414**                           	|
|              	|                                              	| (8, 8)                                  	| 0.005180836                            	| 0.00389576    	| **1.329865**                           	|
| 16           	| 2048                                         	| (16, 1)                                 	| 0.00446558                             	| 0.003738403   	| **1.194515**                           	|
|              	|                                              	| (16, 2)                                 	| 0.004258156                            	| 0.00382185    	| **1.114161**                           	|
|              	|                                              	| (16, 4)                                 	| 0.004422665                            	| 0.004007816   	| **1.10351**                            	|
|              	|                                              	| (16, 8)                                 	| 0.004923344                            	| 0.004308224   	| **1.142778**                           	|
| 32           	| 1024                                         	| (32 , 1)                                	| 0.004467964                            	| 0.00402689    	| **1.109532**                           	|
|              	|                                              	| (32, 2)                                 	| 0.004336834                            	| 0.004196167   	| 1.033523                               	|
|              	|                                              	| (32, 4)                                 	| 0.004661083                            	| 0.004513264   	| 1.032752                               	|
|              	|                                              	| (32, 8)                                 	| 0.005385876                            	| 0.005121231   	| **1.051676**                           	|
| 64           	| 512                                          	| (64, 1)                                 	| 0.004725456                            	| 0.00462532    	| 1.021649                               	|
|              	|                                              	| (64, 2)                                 	| 0.005085468                            	| 0.004930496   	| 1.031431                               	|
|              	|                                              	| (64, 4)                                 	| 0.005791187                            	| 0.005600452   	| 1.034057                               	|
|              	|                                              	| (64, 8)                                 	| 0.007030964                            	| 0.006783009   	| 1.036555                               	|
| 128          	| 256                                          	| (128, 1)                                	| 0.005710125                            	| 0.005786419   	| _0.986815_                             	|
|              	|                                              	| (128, 2)                                	| 0.006377697                            	| 0.006473064   	| _0.985267_                             	|
|              	|                                              	| (128, 4)                                	| 0.00754118                             	| 0.007488728   	| 1.007004                               	|
|              	|                                              	| (128, 8)                                	| 0.009772778                            	| 0.009725094   	| 1.004903                               	|
| 256          	| 128                                          	| (256 , 1)                               	| 0.007708073                            	| 0.007715225   	| _0.999073_                             	|
|              	|                                              	| (256, 2)                                	| 0.008938313                            	| 0.009071827   	| _0.985283_                             	|
|              	|                                              	| (256, 4)                                	| 0.011227131                            	| 0.011045933   	| 1.016404                               	|
|              	|                                              	| (256, 8)                                	| 0.016131401                            	| 0.016396046   	| _0.983859_                             	|
| 512          	| 64                                           	| (512, 1)                                	| 0.011544228                            	| 0.011487007   	| 1.004981                               	|
|              	|                                              	| (512, 2)                                	| 0.014071465                            	| 0.014281273   	| _0.985309_                             	|
|              	|                                              	| (512, 4)                                	| 0.019016266                            	| 0.018930435   	| 1.004534                               	|
|              	|                                              	| (512, 8)                                	| 0.028913021                            	| 0.028159618   	| 1.026755                               	|

Bolded speedup ratio indicates greater than 5% speedup, to identify as significant speedup. Especially for smaller `dim_size` (1, 2, 4, 8, 16, 32), we observe significant speedups (greater than 5% better, **bolded**)  as smaller the `dim_size`, larger the `BLOCK_SIZE / dim_size / sizeof(scalar_t)`, hence larger the unnecessary allocation. 

For larger `dim_size` (64, 128, 256, 512), we also observe insignificantly better (less than 5% better, unbolded) performance. 
For some shapes such as {128, 1}, we also observe insignificantly worse (less than 5% worse, _italicized_) performance. 

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10