### PR TITLE
[CI] Test that cuInit is not called during import (#117010)

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3394,11 +3394,22 @@ exit(2)
     @unittest.skipIf(TEST_MULTIGPU, "Testing on one GPU is sufficient")
     def test_lazy_init(self):
         """ Validate that no CUDA calls are made during `import torch` call"""
-        from subprocess import check_output
+        def check_output(script: str) -> str:
+            return subprocess.check_output([sys.executable, "-c", script]).decode("ascii").strip()
+
         VISIBLE_DEVICES = "HIP_VISIBLE_DEVICES" if TEST_WITH_ROCM else "CUDA_VISIBLE_DEVICES"
         test_script = f"import os; import torch;os.environ['{VISIBLE_DEVICES}']='32';print(torch.cuda.device_count())"
-        rc = check_output([sys.executable, '-c', test_script]).decode("ascii").strip()
+        rc = check_output(test_script)
         self.assertEqual(rc, "0")
+        if not TEST_WITH_ROCM:
+            # Check that `cuInit` was not called during the import
+            # By using ctypes and calling cuDeviceCountGet() and expect CUDA_ERROR_NOT_INITIALIZED == 3
+            # See https://github.com/pytorch/pytorch/issues/116276 for more details
+            cuda_driver_api_call = "ctypes.CDLL('libcuda.so.1').cuDeviceGetCount(ctypes.byref(x))"
+            rc = check_output(f"import torch; import ctypes;x=ctypes.c_int(-1);print({cuda_driver_api_call})")
+            self.assertEqual(rc, "3")
+
+
 
 
 class TestCudaMallocAsync(TestCase):


### PR DESCRIPTION
By making a driver API call in subprocess and expecting it to return `CUDA_ERROR_NOT_INITIALIZED`

Test Plan: run it on nighties before https://github.com/pytorch/pytorch/pull/116201 got reverted and observe the failure

This is very important for lots of distributed launchers

Fixes https://github.com/pytorch/pytorch/issues/116276

Pull Request resolved: https://github.com/pytorch/pytorch/pull/117010
Approved by: https://github.com/albanD
