### PR TITLE
Update `BCEWithLogitsLoss` documentation regarding `pos_weight`

### DIFF
--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -660,7 +660,7 @@ class BCEWithLogitsLoss(_Loss):
     :math:`p_c > 1` increases the recall, :math:`p_c < 1` increases the precision.
 
     For example, if a dataset contains 100 positive and 300 negative examples of a single class,
-    then `pos_weight` for the class should be equal to :math:`\frac{300}{100}=3`.
+    then ``pos_weight`` for the class should be equal to :math:`\frac{300}{100}=3`.
     The loss would act as if the dataset contains :math:`3\times 100=300` positive examples.
 
     Examples::
@@ -672,8 +672,8 @@ class BCEWithLogitsLoss(_Loss):
         >>> criterion(output, target)  # -log(sigmoid(1.5))
         tensor(0.20...)
 
-    In the above example, the `pos_weight` tensor's elements correspond to the 64 distinct classes
-    in a multi-label binary classification scenario. Each element in `pos_weight` is designed to adjust the
+    In the above example, the ``pos_weight`` tensor's elements correspond to the 64 distinct classes
+    in a multi-label binary classification scenario. Each element in ``pos_weight`` is designed to adjust the
     loss function based on the imbalance between negative and positive samples for the respective class.
     This approach is useful in datasets with varying levels of class imbalance, ensuring that the loss
     calculation accurately accounts for the distribution in each class.

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -671,13 +671,13 @@ class BCEWithLogitsLoss(_Loss):
         >>> criterion = torch.nn.BCEWithLogitsLoss(pos_weight=pos_weight)
         >>> criterion(output, target)  # -log(sigmoid(1.5))
         tensor(0.20...)
-        
+
     In the above example, the `pos_weight` tensor's elements correspond to the 64 distinct classes
     in a multi-label binary classification scenario. Each element in `pos_weight` is designed to adjust the
     loss function based on the imbalance between negative and positive samples for the respective class.
     This approach is useful in datasets with varying levels of class imbalance, ensuring that the loss
-    calculation accurately accomodates the distribution in each class.
-    
+    calculation accurately accounts for the distribution in each class.
+
     Args:
         weight (Tensor, optional): a manual rescaling weight given to the loss
             of each batch element. If given, has to be a Tensor of size `nbatch`.

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -672,10 +672,10 @@ class BCEWithLogitsLoss(_Loss):
         >>> criterion(output, target)  # -log(sigmoid(1.5))
         tensor(0.20...)
         
-    In the above example, the `pos_weight` tensor's elements correspond to the 64 distinct classes 
-    in a multi-label binary classification scenario. Each element in `pos_weight` is designed to adjust the 
-    loss function based on the imbalance between negative and positive samples for the respective class. 
-    This approach is useful in datasets with varying levels of class imbalance, ensuring that the loss 
+    In the above example, the `pos_weight` tensor's elements correspond to the 64 distinct classes
+    in a multi-label binary classification scenario. Each element in `pos_weight` is designed to adjust the
+    loss function based on the imbalance between negative and positive samples for the respective class.
+    This approach is useful in datasets with varying levels of class imbalance, ensuring that the loss
     calculation accurately accomodates the distribution in each class.
     
     Args:

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -671,7 +671,13 @@ class BCEWithLogitsLoss(_Loss):
         >>> criterion = torch.nn.BCEWithLogitsLoss(pos_weight=pos_weight)
         >>> criterion(output, target)  # -log(sigmoid(1.5))
         tensor(0.20...)
-
+        
+    In the above example, the `pos_weight` tensor's elements correspond to the 64 distinct classes 
+    in a multi-label binary classification scenario. Each element in `pos_weight` is designed to adjust the 
+    loss function based on the imbalance between negative and positive samples for the respective class. 
+    This approach is useful in datasets with varying levels of class imbalance, ensuring that the loss 
+    calculation accurately accomodates the distribution in each class.
+    
     Args:
         weight (Tensor, optional): a manual rescaling weight given to the loss
             of each batch element. If given, has to be a Tensor of size `nbatch`.


### PR DESCRIPTION
Added clarification for the example provided for the pos_weight parameter in the BCEWithLogitsLoss class, particularly in multi-label binary classification context. This enhancement addresses potential misunderstandings about the application of 'binary' classification, which typically implies two classes, to scenarios involving multiple classes.
