### PR TITLE
[c10d] Add check and set no prefix API in TPCStore and PrefixStore

### DIFF
--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -443,6 +443,15 @@ class PrefixTCPStoreTest(TestCase, StoreTestBase):
     def num_keys_total(self):
         return 6
 
+    def test_no_prefix(self):
+        store = self._create_store()
+        self.tcpstore._set_no_prefix("key", "value")
+        self.assertTrue(store._check_no_prefix(["key"]))
+        store._set_no_prefix("key2", "value2")
+        self.assertTrue(self.tcpstore._check_no_prefix(["key2"]))
+        store.set("key3", "value3")
+        self.assertFalse(self.tcpstore._check_no_prefix(["key3"]))
+
 class MyPythonStore(dist.Store):
     def __init__(self):
         super().__init__()

--- a/torch/csrc/distributed/c10d/PrefixStore.cpp
+++ b/torch/csrc/distributed/c10d/PrefixStore.cpp
@@ -26,6 +26,12 @@ void PrefixStore::set(
   store_->set(joinKey(key), value);
 }
 
+void PrefixStore::setNoPrefix(
+    const std::string& key,
+    const std::vector<uint8_t>& value) {
+  store_->setNoPrefix(key, value);
+}
+
 std::vector<uint8_t> PrefixStore::compareSet(
     const std::string& key,
     const std::vector<uint8_t>& expectedValue,
@@ -52,6 +58,10 @@ int64_t PrefixStore::getNumKeys() {
 bool PrefixStore::check(const std::vector<std::string>& keys) {
   auto joinedKeys = joinKeys(keys);
   return store_->check(joinedKeys);
+}
+
+bool PrefixStore::checkNoPrefix(const std::vector<std::string>& keys) {
+  return store_->checkNoPrefix(keys);
 }
 
 void PrefixStore::wait(const std::vector<std::string>& keys) {

--- a/torch/csrc/distributed/c10d/PrefixStore.hpp
+++ b/torch/csrc/distributed/c10d/PrefixStore.hpp
@@ -12,6 +12,9 @@ class TORCH_API PrefixStore : public Store {
   using Store::set;
   void set(const std::string& key, const std::vector<uint8_t>& value) override;
 
+  void setNoPrefix(const std::string& key, const std::vector<uint8_t>& value)
+      override;
+
   using Store::compareSet;
   std::vector<uint8_t> compareSet(
       const std::string& key,
@@ -27,6 +30,8 @@ class TORCH_API PrefixStore : public Store {
   int64_t getNumKeys() override;
 
   bool check(const std::vector<std::string>& keys) override;
+
+  bool checkNoPrefix(const std::vector<std::string>& keys) override;
 
   void wait(const std::vector<std::string>& keys) override;
 

--- a/torch/csrc/distributed/c10d/Store.hpp
+++ b/torch/csrc/distributed/c10d/Store.hpp
@@ -39,6 +39,12 @@ class TORCH_API Store : public torch::CustomClassHolder {
       const std::string& key,
       const std::vector<uint8_t>& value) = 0;
 
+  virtual void setNoPrefix(
+      const std::string& key,
+      const std::vector<uint8_t>& value) {
+    TORCH_INTERNAL_ASSERT(false, "Not implemented.");
+  }
+
   std::string compareSet(
       const std::string& key,
       const std::string& currentValue,
@@ -60,6 +66,10 @@ class TORCH_API Store : public torch::CustomClassHolder {
   virtual bool deleteKey(const std::string& key) = 0;
 
   virtual bool check(const std::vector<std::string>& keys) = 0;
+
+  virtual bool checkNoPrefix(const std::vector<std::string>& keys) {
+    TORCH_INTERNAL_ASSERT(false, "Not implemented.");
+  }
 
   virtual int64_t getNumKeys() = 0;
 

--- a/torch/csrc/distributed/c10d/TCPStore.hpp
+++ b/torch/csrc/distributed/c10d/TCPStore.hpp
@@ -82,6 +82,9 @@ class TORCH_API TCPStore : public Store {
 
   void set(const std::string& key, const std::vector<uint8_t>& value) override;
 
+  void setNoPrefix(const std::string& key, const std::vector<uint8_t>& value)
+      override;
+
   std::vector<uint8_t> compareSet(
       const std::string& key,
       const std::vector<uint8_t>& expectedValue,
@@ -94,6 +97,8 @@ class TORCH_API TCPStore : public Store {
   bool deleteKey(const std::string& key) override;
 
   bool check(const std::vector<std::string>& keys) override;
+
+  bool checkNoPrefix(const std::vector<std::string>& keys) override;
 
   int64_t getNumKeys() override;
 
@@ -148,6 +153,13 @@ class TORCH_API TCPStore : public Store {
   void doWait(
       c10::ArrayRef<std::string> keys,
       std::chrono::milliseconds timeout);
+
+  void doSet(
+      const std::string& key,
+      const std::vector<uint8_t>& value,
+      bool usePrefix);
+
+  bool doCheck(const std::vector<std::string>& keys, bool usePrefix);
 
   detail::SocketAddress addr_;
   std::shared_ptr<detail::TCPServer> server_;

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -946,6 +946,9 @@ Inserts the key-value pair into the store based on the supplied ``key`` and
 ``value``. If ``key`` already exists in the store, it will overwrite the old
 value with the new supplied ``value``.
 
+Note: if the store is wrapped with PrefixStore, a prefix will be added to
+the key implicitly when performing set.
+
 Arguments:
     key (str): The key to be added to the store.
     value (str): The value associated with ``key`` to be added to the store.
@@ -957,6 +960,24 @@ Example::
     >>> store.set("first_key", "first_value")
     >>> # Should return "first_value"
     >>> store.get("first_key")
+)")
+          .def(
+              "_set_no_prefix",
+              [](::c10d::Store& store,
+                 const std::string& key,
+                 const std::string& value) {
+                std::vector<uint8_t> value_(value.begin(), value.end());
+                store.setNoPrefix(key, value_);
+              },
+              py::call_guard<py::gil_scoped_release>(),
+              R"(
+Inserts the key-value pair into the store based on the supplied ``key`` and
+``value`` like set. The only difference here is that no prefix will be added
+to the ``key`` when insert.
+
+Arguments:
+    key (str): The exact key to be added to the store.
+    value (str): The value associated with ``key`` to be added to the store.
 )")
           .def(
               "compare_set",
@@ -1062,6 +1083,9 @@ from some edge deadlock cases, e.g, calling check after TCPStore has been destro
 Calling :meth:`~torch.distributed.store.check` with a list of keys that
 one wants to check whether stored in the store or not.
 
+Note: if the store is wrapped with PrefixStore, a prefix will be added to
+keys implicitly when performing check.
+
 Arguments:
     keys (lisr[str]): The keys to query whether stored in the store.
 
@@ -1073,6 +1097,18 @@ Example::
     >>> store.add("first_key", 1)
     >>> # Should return 7
     >>> store.check(["first_key"])
+)")
+          .def(
+              "_check_no_prefix",
+              &::c10d::Store::checkNoPrefix,
+              py::call_guard<py::gil_scoped_release>(),
+              R"(
+The call to check whether a given list of ``keys`` have value stored in
+the store like check. The only difference here is that no prefix will be
+added to keys when performing check.
+
+Arguments:
+    keys (lisr[str]): The exact keys to query whether stored in the store.
 )")
           .def(
               "delete_key",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #116316
* #116545
* #117050
* __->__ #117049

In c10d PG initialization, we wrap TCPStore with multiple layers of PrefixStore which adds layers of prefix.

One example is: 
"default_pg/0//cuda//timeout_dump"
When initialized the default PG, because there is no store passed. We first add the prefix "default_pg" to the TCPStore returned from rendezvous:

https://github.com/pytorch/pytorch/blob/bdeaaad70ccc5a34ef6244b6454d01ca2c582645/torch/distributed/distributed_c10d.py#L1240

We then add pg_name (aka 0) https://github.com/pytorch/pytorch/blob/bdeaaad70ccc5a34ef6244b6454d01ca2c582645/torch/distributed/distributed_c10d.py#L1376 and device (aka cuda) https://github.com/pytorch/pytorch/blob/bdeaaad70ccc5a34ef6244b6454d01ca2c582645/torch/distributed/distributed_c10d.py#L1387

to the prefix. Then when we call store_->set("timeout_dump"). The actual key used for writing into TCPStore is "default_pg/0//cuda//timeout_dump".

For sub-PG, things get even interesting, we put the store wrapped with default pg name to a cache:
https://github.com/pytorch/pytorch/blob/bdeaaad70ccc5a34ef6244b6454d01ca2c582645/torch/distributed/distributed_c10d.py#L1517

And when creating each subPG, it is append its PG name right after the cached store. The example keys are:
'default_pg/0//10//cuda//timeout_dump', 'default_pg/0//12//cuda//timeout_dump', 'default_pg/0//38//cuda//timeout_dump', 'default_pg/0//39//cuda//timeout_dump'. (10, 12, 38 and 39 are all PG names of each subPG created)

The reason why the number in the name is bumped up so high is because for each subPG creation, all ranks have to call the API together and the global variable used for PG name will be bumped up monolithically:

https://github.com/pytorch/pytorch/blob/bdeaaad70ccc5a34ef6244b6454d01ca2c582645/torch/distributed/distributed_c10d.py#L3666

Similar things happen for using hashing for PG names.

This has a potential issue, because each sub-PG has an instance of ProcessGroupNCCL, and if we want to set something global to notify all sub-PGs (and all ranks). This added prefix causes bugs. For example, if on sub-PG 1, we set a value to TCPStore with key ('default_pg/0//1//cuda//timeout_dump'), while we use the default PG instances to check the TCPStore, which are using the key ('default_pg/0//cuda//timeout_dump'), default PG instances will never get the notified signals. So in this PR, we added two APIs for Store, setNoPrefix and checkNoPrefix so that no Prefix will be added for set and check and all sub-PGs across ranks use the same keys for communication.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @wz337 @tianyu-l @wconstab @yf225