### PR TITLE
[c10d] Use Store check/set no prefix in NCCLPG watchdog

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1530,7 +1530,8 @@ void ProcessGroupNCCL::watchdogHandler() {
       if (timeSinceLastWorkListUpdate >= kWatchdogThreadSleepMillis &&
           timeSinceLastPollStore >= heartbeatTimeoutInSec_ * 1000) {
         lastTimePollStore = currentTime;
-        if (store_->check({std::string(TIMEOUT_DUMP)}) && !optAsyncDebugDump) {
+        if (store_->checkNoPrefix({std::string(TIMEOUT_DUMP)}) &&
+            !optAsyncDebugDump) {
           optAsyncDebugDump = launchAsyncDebugDump();
           waitForDumpOrTimeout(*optAsyncDebugDump);
           const auto exitMsg = c10::str(
@@ -1566,7 +1567,7 @@ void ProcessGroupNCCL::watchdogHandler() {
               // abort process immediately.
               collectiveDebugInfoMode_.store(true);
               std::vector<uint8_t> vec(1);
-              store_->set(std::string(TIMEOUT_DUMP), vec);
+              store_->setNoPrefix(std::string(TIMEOUT_DUMP), vec);
             }
 
             if (dumpOnTimeout_ && !optAsyncDebugDump) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #116316
* #116545
* __->__ #117050
* #117049

https://github.com/pytorch/pytorch/pull/117049 added setNoPrefix and checkNoPrefix for TCPStore, this PR uses them in watchdog timeout dump. (More detailed can be seen in the description of https://github.com/pytorch/pytorch/pull/117049)

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @wz337 @tianyu-l @wconstab @yf225