### PR TITLE
Pytest do not rewrite assertions by default

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,8 @@ addopts =
     --capture=sys
     # don't suppress warnings, but don't shove them all to the end either
     -p no:warnings
+    # don't rewrite assertions (usually not a problem in CI due to differences in imports, see #95844)
+    --assert=plain
 testpaths =
     test
 junit_logging_reruns = all


### PR DESCRIPTION
From https://pytest.org/en/7.4.x/how-to/assert.html#advanced-assertion-introspection
pytest only rewrites test modules directly discovered by its test collection process, so asserts in supporting modules which are not themselves test modules will not be rewritten.

In CI we usually call the test file (`python test_ops.py`), which then calls run_test which then calls pytest.main, so the test module is already imported as `__main__`, so pytest does not import the test module itself and relies on the already imported module.  (#95844)

However, calling `pytest test_ops.py` will rely on pytest to import the module, resulting in asserts being rewritten, so I add --assert=plain by default into the opts so we don't have to worry about this anymore.  Another way to make pytest stop assertion rewriting in a file is to include `PYTEST_DONT_REWRITE` somewhere in the file.