### PR TITLE
[TorchElastic] Support for overprovisioning in C10 based rendezvous

### DIFF
--- a/docs/source/elastic/rendezvous.rst
+++ b/docs/source/elastic/rendezvous.rst
@@ -35,6 +35,7 @@ Exceptions
 .. autoclass:: RendezvousTimeoutError
 .. autoclass:: RendezvousConnectionError
 .. autoclass:: RendezvousStateError
+.. autoclass:: RendezvousGracefulExitError
 
 Implementations
 ---------------

--- a/test/distributed/elastic/agent/server/test/api_test.py
+++ b/test/distributed/elastic/agent/server/test/api_test.py
@@ -12,21 +12,22 @@ import signal
 import unittest
 import uuid
 from typing import Any, Dict
-from unittest.mock import call, patch, MagicMock
+from unittest.mock import call, MagicMock, patch
 
 import torch.distributed.elastic.rendezvous.registry as rdzv_registry
 from torch.distributed.elastic.agent.server.api import (
+    _get_fq_hostname,
+    _RoleInstanceInfo,
     RunResult,
     SimpleElasticAgent,
     WorkerGroup,
     WorkerSpec,
     WorkerState,
-    _get_fq_hostname,
-    _RoleInstanceInfo,
 )
 from torch.distributed.elastic.multiprocessing import SignalException
 from torch.distributed.elastic.multiprocessing.errors import ProcessFailure
 from torch.distributed.elastic.rendezvous import RendezvousHandler, RendezvousParameters
+from torch.distributed.elastic.rendezvous.api import RendezvousGracefulExitError
 from torch.distributed.elastic.utils.distributed import get_free_port
 from torch.testing._internal.common_utils import run_tests
 
@@ -581,6 +582,15 @@ class SimpleElasticAgentTest(unittest.TestCase):
                 agent.run()
             args, _ = shutdown_mock.call_args
             self.assertEqual(signal.SIGTERM, args[0])
+
+    @patch("torch.distributed.elastic.agent.server.api.put_metric")
+    @patch.object(TestAgent, "_invoke_run")
+    def test_agent_process_handler_graceful_exception(self, invoke_run, _):
+        spec = self._get_worker_spec(max_restarts=0)
+        agent = TestAgent(spec)
+        invoke_run.side_effect = RendezvousGracefulExitError()
+        with patch.object(agent, "_shutdown"):
+            agent.run()
 
 
 if __name__ == "__main__":

--- a/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
@@ -15,9 +15,9 @@ import time
 from abc import ABC, abstractmethod
 from base64 import b64encode
 from datetime import datetime, timedelta
-from typing import Callable, Optional, Tuple, cast
+from typing import Callable, cast, Optional, Tuple
 from unittest import TestCase
-from unittest.mock import MagicMock, Mock, call, patch
+from unittest.mock import call, MagicMock, Mock, patch
 
 from torch.distributed import Store
 from torch.distributed.elastic.rendezvous import (
@@ -28,11 +28,6 @@ from torch.distributed.elastic.rendezvous import (
     RendezvousTimeoutError,
 )
 from torch.distributed.elastic.rendezvous.dynamic_rendezvous import (
-    DynamicRendezvousHandler,
-    RendezvousBackend,
-    RendezvousSettings,
-    RendezvousTimeout,
-    Token,
     _Action,
     _BackendRendezvousStateHolder,
     _DistributedRendezvousOpExecutor,
@@ -46,6 +41,11 @@ from torch.distributed.elastic.rendezvous.dynamic_rendezvous import (
     _RendezvousState,
     _RendezvousStateHolder,
     create_handler,
+    DynamicRendezvousHandler,
+    RendezvousBackend,
+    RendezvousSettings,
+    RendezvousTimeout,
+    Token,
 )
 
 
@@ -932,12 +932,30 @@ class TestRendezvousJoinOp(AbstractTestRendezvousOp, TestCase):
 
             self._assert_action(expected_action)
 
-    def test_waits_next_round_if_rendezvous_is_complete(self) -> None:
+    def test_treat_as_redundancy_for_next_rendezvous_if_rendezvous_is_complete(self) -> None:
+        self._max_nodes = 1
+
+        self._state.complete = True
+
+        self._assert_action(_Action.ADD_TO_REDUNDANCY_LIST)
+
+    def test_waits_next_round_if_rendezvous_is_complete_and_node_is_redundant(self) -> None:
+        self._state.redundancy_list.add(self._node)
+
         self._max_nodes = 1
 
         self._state.complete = True
 
         self._assert_waits_rendezvous_completion()
+
+    def test_remove_from_rednundancy_list(self) -> None:
+        self._state.redundancy_list.add(self._node)
+
+        self._max_nodes = 2
+
+        self._state.complete = True
+
+        self._assert_action(_Action.REMOVE_FROM_REDUNDANCY_LIST)
 
     def test_waits_next_round_if_rendezvous_is_complete_and_node_is_in_wait_list(self) -> None:
         self._state.wait_list.add(self._node)
@@ -1010,6 +1028,26 @@ class TestRendezvousJoinOp(AbstractTestRendezvousOp, TestCase):
         self._state.wait_list.add(self._node)
 
         self._assert_action(_Action.REMOVE_FROM_WAIT_LIST)
+
+    def test_no_timeout_for_redundant_node(self) -> None:
+        self._max_nodes = 1
+        self._deadline = 0
+        self._state.complete = True
+
+        self._state.redundancy_list.add(self._node)
+
+        self._assert_action(_Action.SYNC)
+
+    def test_keep_alive_for_redundant_node(self) -> None:
+        self._deadline = 0
+        self._max_nodes = 1
+        self._state.complete = True
+
+        self._state.redundancy_list.add(self._node)
+
+        keep_alive_time = self._now - self._keep_alive_interval
+        self._state.last_heartbeats[self._node] = keep_alive_time
+        self._assert_action(_Action.KEEP_ALIVE)
 
 
 class TestRendezvousCloseOp(AbstractTestRendezvousOp, TestCase):
@@ -1470,3 +1508,185 @@ class CreateHandlerTest(TestCase):
             with self.assertRaises(RendezvousError):
                 create_handler(self._store, self._backend, self._params)
                 record_mock.assert_called_once()
+
+
+def _ignore_exception(exception_type: Exception, fn: Callable):
+    try:
+        fn()
+    except exception_type as e:
+        pass
+
+def _wait_for(condition, timeout=10, interval=1, name=None):
+    def _wait_while():
+        while True:
+            if condition():
+                break
+            else:
+                time.sleep(interval)
+    wait_thread = threading.Thread(target=_wait_while, name=name)
+    wait_thread.start()
+    wait_thread.join(timeout=timeout)
+
+class _CapturingThread(threading.Thread):
+
+    def __init__(self, target=None, name=None, args=None, kwargs=None):
+        if args is None:
+            args = ()
+        if kwargs is None:
+            kwargs = {}
+        threading.Thread.__init__(self, target=target, args=args, kwargs=kwargs, name=name)
+        self._result = None
+
+    def run(self):
+        if self._target is not None:
+            self._result = self._target(*self._args, **self._kwargs)
+
+    def join(self, *args):
+        threading.Thread.join(self, *args)
+        return self._result
+
+class IntegrationTest(TestCase):
+    def setUp(self) -> None:
+        self._store = DummyStore()
+        self._handlers = []
+        self._backend = _InMemoryRendezvousBackend()
+
+    def tearDown(self) -> None:
+        for handler in self._handlers:
+            handler._stop_heartbeats()
+
+    def _create_handler(self, **kwargs) -> DynamicRendezvousHandler:
+        params = {
+            "backend": self._backend.name,
+            "endpoint": "dummy_endpoint",
+            "run_id": "dummy_run_id",
+            "min_nodes": 2,
+            "max_nodes": 2,
+            "join_timeout": "5",
+            "local_addr": f"address_{len(self._handlers)}",
+        }
+        params.update(**kwargs)
+
+        rzdv_params = RendezvousParameters(**params)
+
+        handler = create_handler(self._store, self._backend, rzdv_params)
+        self._handlers.append(handler)
+        return handler
+
+    def test_all_nodes_join_rendezvous(self) -> None:
+        handler1 = self._create_handler(min_nodes=2, max_nodes=2)
+        handler2 = self._create_handler(min_nodes=2, max_nodes=2)
+
+        handler1_thread = _CapturingThread(target=handler1.next_rendezvous)
+        handler2_thread = _CapturingThread(target=handler2.next_rendezvous)
+
+        handler1_thread.start()
+        handler2_thread.start()
+
+        store1, rank1, world_size1 = handler1_thread.join()
+        store2, rank2, world_size2 = handler2_thread.join()
+        self.assertEqual(store1.underlying_store, self._store)
+        self.assertEqual(store2.underlying_store, self._store)
+
+        self.assertNotEqual(rank1, rank2)
+
+        self.assertEqual(world_size1, 2)
+        self.assertEqual(world_size2, 2)
+
+    def test_redundancy_list(self) -> None:
+        handler1 = self._create_handler(min_nodes=2, max_nodes=2)
+        handler2 = self._create_handler(min_nodes=2, max_nodes=2)
+        handler3 = self._create_handler(min_nodes=2, max_nodes=2)
+
+        handler1_thread = _CapturingThread(target=handler1.next_rendezvous)
+        handler2_thread = _CapturingThread(target=handler2.next_rendezvous)
+        handler3_thread = _CapturingThread(
+            target=_ignore_exception,
+            args=(RendezvousTimeoutError, lambda: handler3.next_rendezvous()))
+
+        handler1_thread.start()
+        handler2_thread.start()
+
+        # establish successful rendezvous
+        handler1_thread.join()
+        handler2_thread.join()
+
+        # expect to register in redundancy list
+        handler3_thread.start()
+
+        # wait until the handler3 is registered in the redundancy list
+        _wait_for(lambda: pickle.loads(self._backend.get_state()[0]).redundancy_list)
+
+        state_and_token = self._backend.get_state()
+        state = pickle.loads(state_and_token[0])
+        addresses = [node.addr for node in state.redundancy_list]
+        self.assertListEqual(addresses, ["address_2"])
+
+    def test_redundancy_transition_to_wait_list_then_join_rendezvous(self) -> None:
+        handler1 = self._create_handler(
+            min_nodes=1,
+            max_nodes=2,
+        )
+        handler2 = self._create_handler(
+            min_nodes=1,
+            max_nodes=2,
+            keep_alive_interval=timedelta(seconds=1),
+        )
+        handler3 = self._create_handler(
+            min_nodes=1,
+            max_nodes=2,
+        )
+
+        handler1_thread = _CapturingThread(target=handler1.next_rendezvous)
+        handler2_thread = _CapturingThread(target=handler2.next_rendezvous)
+
+        handler3_thread = _CapturingThread(
+            target=_ignore_exception,
+            args=(RendezvousTimeoutError, lambda: handler3.next_rendezvous()))
+
+        handler1_thread.start()
+        handler2_thread.start()
+
+        # establish successful rendezvous
+        handler1_thread.join()
+        handler2_thread.join()
+
+        handler3_thread.start()
+
+        _wait_for(lambda: pickle.loads(self._backend.get_state()[0]).redundancy_list)
+
+        handler2._stop_heartbeats()
+
+        _wait_for(lambda: len(pickle.loads(self._backend.get_state()[0]).participants) == 1)
+        _wait_for(lambda: len(pickle.loads(self._backend.get_state()[0]).wait_list) == 1)
+
+
+class _InMemoryRendezvousBackend(RendezvousBackend):
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._state = None
+        self._token = None
+
+    @property
+    def name(self):
+        return "_in_memory_backend"
+
+    def get_state(self):
+        with self._lock:
+            if self._state is None:
+                return None
+            return (self._state, self._token)
+
+        return self._state
+
+    def set_state(self, state, token):
+        if state is None:
+            raise ValueError("State cannot be None.")
+        with self._lock:
+            if token is None and self._token is not None:
+                return None
+            if self._token != token:
+                return None
+
+            self._state = state
+            self._token = self._token + 1 if self._token is not None else 0

--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -145,6 +145,7 @@ class LocalElasticAgent(SimpleElasticAgent):
         self._start_method = start_method
         self._pcontext: Optional[PContext] = None
         rdzv_run_id = spec.rdzv_handler.get_run_id()
+        self._rdzv_handler = spec.rdzv_handler
         self._log_dir = self._make_log_dir(log_dir, rdzv_run_id)
         self._log_line_prefix_template = log_line_prefix_template
         self._worker_watchdog: Optional[timer.FileTimerServer] = None
@@ -309,6 +310,8 @@ class LocalElasticAgent(SimpleElasticAgent):
             self._worker_watchdog = None
         if self._pcontext:
             self._pcontext.close(death_sig)
+        if self._rdzv_handler:
+            self._rdzv_handler.shutdown()
 
     # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
     #  `torch.distributed.elastic.metrics.prof`.

--- a/torch/distributed/elastic/rendezvous/__init__.py
+++ b/torch/distributed/elastic/rendezvous/__init__.py
@@ -139,6 +139,7 @@ __all__ = [
     "RendezvousClosedError",
     "RendezvousConnectionError",
     "RendezvousError",
+    "RendezvousGracefulExitError",
     "RendezvousHandler",
     "RendezvousHandlerCreator",
     "RendezvousHandlerRegistry",

--- a/torch/distributed/elastic/rendezvous/api.py
+++ b/torch/distributed/elastic/rendezvous/api.py
@@ -29,6 +29,11 @@ class RendezvousConnectionError(RendezvousError):
 class RendezvousStateError(RendezvousError):
     """Raised when the state of a rendezvous is corrupt."""
 
+class RendezvousGracefulExitError(RendezvousError):
+    """Raised when node wasn't not included in rendezvous and gracefully exits.
+
+    Exception is a mechanism to exit the stack, however does not mean a failure.
+    """
 
 class RendezvousHandler(ABC):
     """Main rendezvous interface.

--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -16,17 +16,15 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, cast
+from typing import Any, Callable, cast, Dict, List, Optional, Set, Tuple
 
 from torch.distributed import PrefixStore, Store
-from torch.distributed.elastic.events import (
-    NodeState,
-    construct_and_record_rdzv_event,
-)
+from torch.distributed.elastic.events import construct_and_record_rdzv_event, NodeState
 
 from .api import (
     RendezvousClosedError,
     RendezvousError,
+    RendezvousGracefulExitError,
     RendezvousHandler,
     RendezvousParameters,
     RendezvousStateError,
@@ -275,6 +273,9 @@ class _RendezvousState:
         wait_list:
             A set of nodes that are waiting to participate in the next round of
             the rendezvous.
+        redundancy_list:
+            A set of nodes that are redundant in the current round and can join
+            the next rendezvous without triggering re-rendezvous.
         last_heartbeats:
             A dictionary containing each node's last heartbeat time.
     """
@@ -285,6 +286,7 @@ class _RendezvousState:
     closed: bool
     participants: Dict[_NodeDesc, int]
     wait_list: Set[_NodeDesc]
+    redundancy_list: Set[_NodeDesc]
     last_heartbeats: Dict[_NodeDesc, datetime]
 
     def __init__(self) -> None:
@@ -294,6 +296,7 @@ class _RendezvousState:
         self.closed = False
         self.participants = {}
         self.wait_list = set()
+        self.redundancy_list = set()
         self.last_heartbeats = {}
 
 
@@ -301,11 +304,18 @@ def _remove_participant_epilogue(state: _RendezvousState, settings: RendezvousSe
     if state.complete:
         # If we do not have any participants left, move to the next round.
         if not state.participants:
+            msg = "No participants left in the rendezvous, marking rendezvous as incomplete"
+            log.debug(msg)
             state.complete = False
 
             state.round += 1
     else:
         if len(state.participants) < settings.min_nodes:
+            msg = (
+                f"Number of participants {len(state.participants)}) less than"
+                f"min_nodes {settings.min_nodes}, clearning deadline in state"
+            )
+            log.debug(msg)
             state.deadline = None
 
 
@@ -457,6 +467,8 @@ class _BackendRendezvousStateHolder(_RendezvousStateHolder):
         participant_removed = False
 
         for dead_node in self._dead_nodes:
+            msg = f"Detected dead node '{dead_node}', removing it from the rendezvous"
+            log.debug(msg)
             del state.last_heartbeats[dead_node]
 
             try:
@@ -468,6 +480,11 @@ class _BackendRendezvousStateHolder(_RendezvousStateHolder):
 
             try:
                 state.wait_list.remove(dead_node)
+            except KeyError:
+                pass
+
+            try:
+                state.redundancy_list.remove(dead_node)
             except KeyError:
                 pass
 
@@ -493,14 +510,16 @@ class _Action(Enum):
     KEEP_ALIVE = 1
     ADD_TO_PARTICIPANTS = 2
     ADD_TO_WAIT_LIST = 3
-    REMOVE_FROM_PARTICIPANTS = 4
-    REMOVE_FROM_WAIT_LIST = 5
-    MARK_RENDEZVOUS_COMPLETE = 6
-    MARK_RENDEZVOUS_CLOSED = 7
-    SYNC = 8
-    ERROR_CLOSED = 9
-    ERROR_TIMEOUT = 10
-    FINISH = 11
+    ADD_TO_REDUNDANCY_LIST = 4
+    REMOVE_FROM_PARTICIPANTS = 5
+    REMOVE_FROM_WAIT_LIST = 6
+    REMOVE_FROM_REDUNDANCY_LIST = 7
+    MARK_RENDEZVOUS_COMPLETE = 8
+    MARK_RENDEZVOUS_CLOSED = 9
+    SYNC = 10
+    ERROR_CLOSED = 11
+    ERROR_TIMEOUT = 12
+    FINISH = 13
 
 
 class _RendezvousContext:
@@ -536,6 +555,7 @@ class _RendezvousOpExecutor(ABC):
         self,
         state_handler: Callable[[_RendezvousContext, float], _Action],
         deadline: float,
+        update_deadline: Optional[Callable[[timedelta], float]] = None,
     ) -> None:
         """Execute a rendezvous operation.
 
@@ -549,6 +569,9 @@ class _RendezvousOpExecutor(ABC):
             deadline:
                 The time, in seconds, at which the operation will be considered
                 timed-out.
+            update_deadline:
+                Function to generate a new operation deadline if the current
+                node may participate in the next rendezvous.
         """
 
 
@@ -596,10 +619,10 @@ class _DistributedRendezvousOpExecutor(_RendezvousOpExecutor):
         self,
         state_handler: Callable[[_RendezvousContext, float], _Action],
         deadline: float,
+        update_deadline: Optional[Callable[[timedelta], float]] = None,
     ) -> None:
         """See base class."""
         action = None
-
         while action != _Action.FINISH:
             # Reads or writes the latest rendezvous state shared by all nodes in
             # the rendezvous. Note that our local changes might get overridden
@@ -648,10 +671,17 @@ class _DistributedRendezvousOpExecutor(_RendezvousOpExecutor):
                     self._add_to_participants()
                 elif action == _Action.ADD_TO_WAIT_LIST:
                     self._add_to_wait_list()
+                elif action == _Action.ADD_TO_REDUNDANCY_LIST:
+                    self._add_to_redundancy_list()
                 elif action == _Action.REMOVE_FROM_PARTICIPANTS:
                     self._remove_from_participants()
                 elif action == _Action.REMOVE_FROM_WAIT_LIST:
                     self._remove_from_wait_list()
+                elif action == _Action.REMOVE_FROM_REDUNDANCY_LIST:
+                    self._remove_from_redundancy_list()
+                    # update deadline since the node may participate in rendezvous process
+                    if update_deadline:
+                        deadline = update_deadline(self._settings.timeout.join)
                 elif action == _Action.MARK_RENDEZVOUS_COMPLETE:
                     self._mark_rendezvous_complete()
                 elif action == _Action.MARK_RENDEZVOUS_CLOSED:
@@ -705,7 +735,21 @@ class _DistributedRendezvousOpExecutor(_RendezvousOpExecutor):
         self._record(message=msg)
         log.debug(msg)
 
+        if self._node in self._state.redundancy_list:
+            self._state.redundancy_list.remove(self._node)
         self._state.wait_list.add(self._node)
+
+        self._keep_alive()
+
+    def _add_to_redundancy_list(self) -> None:
+        msg = (
+            f"The node '{self._node}' added itself to the redundancy list of round "
+            f"{self._state.round + 1} of the rendezvous '{self._settings.run_id}'. Pending sync."
+        )
+        self._record(message=msg)
+        log.debug(msg)
+
+        self._state.redundancy_list.add(self._node)
 
         self._keep_alive()
 
@@ -736,6 +780,18 @@ class _DistributedRendezvousOpExecutor(_RendezvousOpExecutor):
         log.debug(msg)
 
         self._state.wait_list.remove(self._node)
+
+        del self._state.last_heartbeats[self._node]
+
+    def _remove_from_redundancy_list(self) -> None:
+        msg = (
+            f"The node '{self._node}' removed itself from the redunant list of round "
+            f"{self._state.round + 1} of the rendezvous '{self._settings.run_id}'. Pending sync."
+        )
+        self._record(message=msg)
+        log.debug(msg)
+
+        self._state.redundancy_list.remove(self._node)
 
         del self._state.last_heartbeats[self._node]
 
@@ -796,7 +852,25 @@ class _RendezvousJoinOp:
 
         # A closed rendezvous means that it no longer accepts new nodes.
         if state.closed:
+            if ctx.node in state.redundancy_list:
+                msg = f"The rendezvous '{ctx.settings.run_id}' is closed, terminating pending rendezvous."
+                raise RendezvousGracefulExitError(msg)
             return _Action.ERROR_CLOSED
+
+        if ctx.node in state.redundancy_list:
+            msg = f"The node {ctx.node} is in redunancy list"
+            log.debug(msg)
+            # don't apply the timeout logic here, since we want to allow the node to rejoin
+            if len(state.participants) == ctx.settings.max_nodes:
+                if _should_keep_alive(ctx):
+                    return _Action.KEEP_ALIVE
+                else:
+                    return _Action.SYNC
+            else:
+                # transition to waiting state that will respect timeouts.
+                msg = f"The node {ctx.node} is removed from redunancy list"
+                log.debug(msg)
+                return _Action.REMOVE_FROM_REDUNDANCY_LIST
 
         is_participant = ctx.node in state.participants
 
@@ -831,13 +905,28 @@ class _RendezvousJoinOp:
             if len(state.participants) < ctx.settings.max_nodes:
                 if ctx.node not in state.wait_list:
                     return _Action.ADD_TO_WAIT_LIST
+            elif len(state.participants) >= ctx.settings.max_nodes:
+                if ctx.node not in state.redundancy_list and ctx.node not in state.wait_list:
+                    return _Action.ADD_TO_REDUNDANCY_LIST
         elif is_participant:
             # If the rendezvous has enough number of participants including us,
             # check whether we have passed the rendezvous deadline. If yes,
             # complete it.
-            if len(state.participants) >= ctx.settings.min_nodes:
+            if len(state.participants) >= ctx.settings.min_nodes and \
+                    len(state.participants) <= ctx.settings.max_nodes:
                 if cast(datetime, state.deadline) < datetime.utcnow():
+                    msg = (
+                        f"The node '{ctx.node}' marking the rendezvous complete, "
+                        f"quorum established within deadline"
+                    )
+                    log.debug(msg)
                     return _Action.MARK_RENDEZVOUS_COMPLETE
+                else:
+                    msg = f"The node '{ctx.node}' can't complete rendezvous: deadline reached"
+                    log.debug(msg)
+            else:
+                msg = f"The node '{ctx.node}' can't complete rendezvous: not enough participants"
+                log.debug(msg)
         else:
             # The rendezvous is not complete yet and we are not part of it. Try
             # to join.
@@ -1023,9 +1112,11 @@ class DynamicRendezvousHandler(RendezvousHandler):
             join_op = _RendezvousJoinOp()
 
             deadline = self._get_deadline(self._settings.timeout.join)
-
             self._op_executor.run(exit_op, deadline)
-            self._op_executor.run(join_op, deadline)
+            self._op_executor.run(
+                join_op,
+                deadline,
+                self._get_deadline)
 
             self._start_heartbeats()
 


### PR DESCRIPTION
Summary:
Allow TorchElastic to manage more nodes than a maximum nnodes specifed in a job. It will be used as a spare capacity/warm nodes for schedulers that support elasticity.

RFC: https://github.com/pytorch/pytorch/issues/114097

Test Plan: Integration tests

Differential Revision: D52343874




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225