### PR TITLE
Reduce pytest prints

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -162,11 +162,6 @@ pytest-xdist==3.3.1
 #Pinned versions:
 #test that import:
 
-pytest-shard==0.1.2
-#Description: plugin spliting up tests in pytest
-#Pinned versions:
-#test that import:
-
 pytest-flakefinder==1.1.0
 #Description: plugin for rerunning tests a fixed number of times in pytest
 #Pinned versions: 1.1.0

--- a/.github/requirements/pip-requirements-macOS.txt
+++ b/.github/requirements/pip-requirements-macOS.txt
@@ -16,7 +16,6 @@ pytest==7.3.2
 pytest-xdist==3.3.1
 pytest-rerunfailures==10.3
 pytest-flakefinder==1.1.0
-pytest-shard==0.1.2
 scipy==1.10.1
 sympy==1.11.1
 unittest-xml-reporting<=3.2.0,>=2.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -225,7 +225,7 @@ jobs:
           cache: pip
       - name: Install dependencies
         run: |
-          pip install pytest-rerunfailures==11.1.* pytest-shard==0.1.* pytest-flakefinder==1.1.* pytest-xdist==3.3.* expecttest==0.1.* numpy==1.24.*
+          pip install pytest-rerunfailures==11.1.* pytest-flakefinder==1.1.* pytest-xdist==3.3.* expecttest==0.1.* numpy==1.24.*
           pip install torch --pre --index-url https://download.pytorch.org/whl/nightly/cpu/
       - name: Run run_test.py (nonretryable)
         run: |

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,8 @@ addopts =
     --capture=sys
     # don't suppress warnings, but don't shove them all to the end either
     -p no:warnings
+    # Use custom pytest shard located in test/pytest_shard_custom.py instead
+    -p no:pytest-shard
     # don't rewrite assertions (usually not a problem in CI due to differences in imports, see #95844)
     --assert=plain
 testpaths =

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -19,6 +19,7 @@ import copy
 import json
 import re
 from collections import defaultdict
+from pytest_shard_custom import PytestShardPlugin, pytest_addoptions as shard_addoptions
 
 # a lot of this file is copied from _pytest.junitxml and modified to get rerun info
 
@@ -84,6 +85,7 @@ def pytest_addoption(parser: Parser) -> None:
         "Emit XML for schema: one of legacy|xunit1|xunit2",
         default="xunit2",
     )
+    shard_addoptions(parser)
 
 
 def pytest_configure(config: Config) -> None:
@@ -105,6 +107,8 @@ def pytest_configure(config: Config) -> None:
         config.option.stepcurrent = config.getoption("stepcurrent_skip")
     if config.getoption("stepcurrent"):
         config.pluginmanager.register(StepcurrentPlugin(config), "stepcurrentplugin")
+    if config.getoption("num_shards"):
+        config.pluginmanager.register(PytestShardPlugin(config), "pytestshardplugin")
 
 
 def pytest_unconfigure(config: Config) -> None:

--- a/test/pytest_shard_custom.py
+++ b/test/pytest_shard_custom.py
@@ -24,7 +24,7 @@ def pytest_addoptions(parser: Parser):
     )
     group.addoption(
         "--print-items",
-        dest="shard_verbose",
+        dest="print_items",
         action="store_true",
         default=False,
         help="Print out the items being tested in this shard.",

--- a/test/pytest_shard_custom.py
+++ b/test/pytest_shard_custom.py
@@ -6,6 +6,7 @@ Modifications:
 * option for printing items in shard
 """
 import hashlib
+
 from _pytest.config.argparsing import Parser
 
 

--- a/test/pytest_shard_custom.py
+++ b/test/pytest_shard_custom.py
@@ -1,0 +1,66 @@
+"""
+Custom pytest shard plugin
+https://github.com/AdamGleave/pytest-shard/blob/64610a08dac6b0511b6d51cf895d0e1040d162ad/pytest_shard/pytest_shard.py#L1
+Modifications:
+* shards are now 1 indexed instead of 0 indexed
+* option for printing items in shard
+"""
+import hashlib
+from _pytest.config.argparsing import Parser
+
+
+def pytest_addoptions(parser: Parser):
+    """Add options to control sharding."""
+    group = parser.getgroup("shard")
+    group.addoption(
+        "--shard-id", dest="shard_id", type=int, default=1, help="Number of this shard."
+    )
+    group.addoption(
+        "--num-shards",
+        dest="num_shards",
+        type=int,
+        default=1,
+        help="Total number of shards.",
+    )
+    group.addoption(
+        "--print-items",
+        dest="shard_verbose",
+        action="store_true",
+        default=False,
+        help="Print out the items being tested in this shard.",
+    )
+
+
+class PytestShardPlugin:
+    def __init__(self, config):
+        self.config = config
+
+    def pytest_report_collectionfinish(self, config, items) -> str:
+        """Log how many and which items are tested in this shard."""
+        msg = f"Running {len(items)} items in this shard"
+        if config.getoption("print_items"):
+            msg += ": " + ", ".join([item.nodeid for item in items])
+        return msg
+
+    def sha256hash(self, x: str) -> int:
+        return int.from_bytes(hashlib.sha256(x.encode()).digest(), "little")
+
+    def filter_items_by_shard(self, items, shard_id: int, num_shards: int):
+        """Computes `items` that should be tested in `shard_id` out of `num_shards` total shards."""
+        new_items = [
+            item
+            for item in items
+            if self.sha256hash(item.nodeid) % num_shards == shard_id - 1
+        ]
+        return new_items
+
+    def pytest_collection_modifyitems(self, config, items):
+        """Mutate the collection to consist of just items to be tested in this shard."""
+        shard_id = config.getoption("shard_id")
+        shard_total = config.getoption("num_shards")
+        if shard_id < 1 or shard_id > shard_total:
+            raise ValueError(
+                f"{shard_id} is not a valid shard ID out of {shard_total} total shards"
+            )
+
+        items[:] = self.filter_items_by_shard(items, shard_id, shard_total)

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1654,7 +1654,7 @@ def check_pip_packages() -> None:
         "pytest-flakefinder",
         "pytest-xdist",
     ]
-    installed_packages = [i.key for i in pk_resources.working_set]
+    installed_packages = [i.key for i in pkg_resources.working_set]
     for package in packages:
         if package not in installed_packages:
             print_to_stderr(

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -520,11 +520,11 @@ def run_test(
     else:
         unittest_args.extend(
             [
-                f"--shard-id={test_module.shard - 1}",
+                f"--shard-id={test_module.shard}",
                 f"--num-shards={test_module.num_shards}",
             ]
         )
-        stepcurrent_key = f"{test_file}_{test_module.shard - 1}_{os.urandom(8).hex()}"
+        stepcurrent_key = f"{test_file}_{test_module.shard}_{os.urandom(8).hex()}"
 
     if options.verbose:
         unittest_args.append(f'-{"v"*options.verbose}')  # in case of pytest
@@ -543,7 +543,6 @@ def run_test(
         unittest_args.extend(
             get_pytest_args(
                 options,
-                stepcurrent_key,
                 is_cpp_test=is_cpp_test,
                 is_distributed_test=is_distributed_test,
             )
@@ -626,12 +625,19 @@ def run_test(
         if IS_CI:
             output = stack.enter_context(open(log_path, "w"))
 
-        if options.continue_through_error and "--subprocess" not in command:
+        if "--subprocess" not in command:
             # I think subprocess is better handled by common_utils? but it's not working atm
-            ret_code, was_rerun = run_test_continue_through_error(
-                command, test_directory, env, timeout, stepcurrent_key, output
+            ret_code, was_rerun = run_test_retries(
+                command,
+                test_directory,
+                env,
+                timeout,
+                stepcurrent_key,
+                output,
+                options.continue_through_error
             )
         else:
+            command.append(f"--sc={stepcurrent_key}")
             ret_code, was_rerun = retry_shell(
                 command,
                 test_directory,
@@ -658,23 +664,31 @@ def run_test(
     return ret_code
 
 
-def run_test_continue_through_error(
-    command, test_directory, env, timeout, stepcurrent_key, output
+def run_test_retries(
+    command, test_directory, env, timeout, stepcurrent_key, output, continue_through_error
 ):
     # Run the test with -x to stop at first failure. Try again, skipping the
     # previously run tests, repeating this until there is a test that fails 3
-    # times (same number of rVetries we typically give).  Then we skip that
-    # test, and keep going. Basically if the same test fails 3 times in a row,
-    # skip the test on the next run, but still fail in the end. I take advantage
-    # of the value saved in stepcurrent to keep track of the most recently run
-    # test (which is the one that failed if there was a failure).
+    # times (same number of rVetries we typically give).
+    #
+    # If continue through error is not set, then we fail fast.
+    #
+    # If continue through error is set, then we skip that test, and keep going.
+    # Basically if the same test fails 3 times in a row, skip the test on the
+    # next run, but still fail in the end. I take advantage of the value saved
+    # in stepcurrent to keep track of the most recently run test (which is the
+    # one that failed if there was a failure).
+
+    def print_to_file(s):
+        print(s, file=output, flush=True)
 
     num_failures = defaultdict(int)
 
+    print_items = ["--print-items"]
     sc_command = f"--sc={stepcurrent_key}"
     while True:
         ret_code = shell(
-            command + [sc_command],
+            command + [sc_command] + print_items,
             test_directory,
             stdout=output,
             stderr=output,
@@ -685,11 +699,7 @@ def run_test_continue_through_error(
         if ret_code == 0:
             break  # Got to the end of the test suite successfully
         signal_name = f" ({SIGNALS_TO_NAMES_DICT[-ret_code]})" if ret_code < 0 else ""
-        print(
-            f"Got exit code {ret_code}{signal_name}, retrying...",
-            file=output,
-            flush=True,
-        )
+        print_to_file(f"Got exit code {ret_code}{signal_name}, retrying...")
 
         # Read what just failed
         with open(
@@ -699,25 +709,23 @@ def run_test_continue_through_error(
 
         num_failures[current_failure] += 1
         if num_failures[current_failure] >= 3:
+            if not continue_through_error:
+                print_to_file("Stopping at first consistent failure")
+                break
             sc_command = f"--scs={stepcurrent_key}"
         else:
             sc_command = f"--sc={stepcurrent_key}"
+        print_items = []  # do not continue printing them, massive waste of space
 
     consistent_failures = [x[1:-1] for x in num_failures.keys() if num_failures[x] >= 3]
     flaky_failures = [x[1:-1] for x in num_failures.keys() if 0 < num_failures[x] < 3]
     if len(flaky_failures) > 0:
-        print(
+        print_to_file(
             "The following tests failed flakily (had to be rerun in a new process,"
             + f" doesn't include reruns froms same process): {flaky_failures}",
-            file=output,
-            flush=True,
         )
     if len(consistent_failures) > 0:
-        print(
-            f"The following tests failed consistently: {consistent_failures}",
-            file=output,
-            flush=True,
-        )
+        print_to_file(f"The following tests failed consistently: {consistent_failures}")
         return 1, True
     return 0, any(x > 0 for x in num_failures.values())
 
@@ -1044,7 +1052,7 @@ def handle_log_file(
 
 
 def get_pytest_args(
-    options, stepcurrent_key, is_cpp_test=False, is_distributed_test=False
+    options, is_cpp_test=False, is_distributed_test=False
 ):
     if RERUN_DISABLED_TESTS:
         # Distributed tests are too slow, so running them x50 will cause the jobs to timeout after
@@ -1067,8 +1075,6 @@ def get_pytest_args(
     if not is_cpp_test:
         # C++ tests need to be run with pytest directly, not via python
         pytest_args.extend(["-p", "no:xdist", "--use-pytest"])
-        if not options.continue_through_error and IS_CI:
-            pytest_args.append(f"--sc={stepcurrent_key}")
     else:
         # Use pytext-dist to run C++ tests in parallel as running them sequentially using run_test
         # is much slower than running them directly
@@ -1641,7 +1647,6 @@ def run_tests(
 def check_pip_packages() -> None:
     packages = [
         "pytest-rerunfailures",
-        "pytest-shard",
         "pytest-flakefinder",
         "pytest-xdist",
     ]

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1077,7 +1077,8 @@ def get_pytest_args(options, is_cpp_test=False, is_distributed_test=False):
     ]
     if not is_cpp_test:
         # C++ tests need to be run with pytest directly, not via python
-        pytest_args.extend(["-p", "no:xdist", "--use-pytest"])
+        # We have a custom pytest shard that conflicts with the normal plugin
+        pytest_args.extend(["-p", "no:xdist", "no:pytest-shard", "--use-pytest"])
     else:
         # Use pytext-dist to run C++ tests in parallel as running them sequentially using run_test
         # is much slower than running them directly
@@ -1653,7 +1654,7 @@ def check_pip_packages() -> None:
         "pytest-flakefinder",
         "pytest-xdist",
     ]
-    installed_packages = [i.key for i in pkg_resources.working_set]
+    installed_packages = [i.key for i in pk_resources.working_set]
     for package in packages:
         if package not in installed_packages:
             print_to_stderr(

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -636,7 +636,7 @@ def run_test(
                 options.continue_through_error,
             )
         else:
-            command.append(f"--sc={stepcurrent_key}")
+            command.extend([f"--sc={stepcurrent_key}", "--print-items"])
             ret_code, was_rerun = retry_shell(
                 command,
                 test_directory,

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -691,13 +691,14 @@ def run_test_retries(
     print_items = ["--print-items"]
     sc_command = f"--sc={stepcurrent_key}"
     while True:
-        ret_code = shell(
+        ret_code = retry_shell(
             command + [sc_command] + print_items,
             test_directory,
             stdout=output,
             stderr=output,
             env=env,
             timeout=timeout,
+            retries=0,  # no retries here, we do it ourselves, this is because it handles timeout exceptions well
         )
         ret_code = 0 if ret_code == 5 or ret_code == 4 else ret_code
         if ret_code == 0:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -605,7 +605,7 @@ def run_test(
         os.close(log_fd)
 
     command = (launcher_cmd or []) + executable + argv
-    should_retry = not "--subprocess" in command and not RERUN_DISABLED_TESTS
+    should_retry = "--subprocess" not in command and not RERUN_DISABLED_TESTS
     is_slow = "slow" in os.environ.get("TEST_CONFIG", "") or "slow" in os.environ.get(
         "BUILD_ENVRIONMENT", ""
     )

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -634,7 +634,7 @@ def run_test(
                 timeout,
                 stepcurrent_key,
                 output,
-                options.continue_through_error
+                options.continue_through_error,
             )
         else:
             command.append(f"--sc={stepcurrent_key}")
@@ -665,7 +665,13 @@ def run_test(
 
 
 def run_test_retries(
-    command, test_directory, env, timeout, stepcurrent_key, output, continue_through_error
+    command,
+    test_directory,
+    env,
+    timeout,
+    stepcurrent_key,
+    output,
+    continue_through_error,
 ):
     # Run the test with -x to stop at first failure. Try again, skipping the
     # previously run tests, repeating this until there is a test that fails 3
@@ -1051,9 +1057,7 @@ def handle_log_file(
     os.remove(file_path)
 
 
-def get_pytest_args(
-    options, is_cpp_test=False, is_distributed_test=False
-):
+def get_pytest_args(options, is_cpp_test=False, is_distributed_test=False):
     if RERUN_DISABLED_TESTS:
         # Distributed tests are too slow, so running them x50 will cause the jobs to timeout after
         # 3+ hours. So, let's opt for less number of reruns. We need at least 150 instances of the

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -691,7 +691,7 @@ def run_test_retries(
     print_items = ["--print-items"]
     sc_command = f"--sc={stepcurrent_key}"
     while True:
-        ret_code = retry_shell(
+        ret_code, _ = retry_shell(
             command + [sc_command] + print_items,
             test_directory,
             stdout=output,

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1078,7 +1078,7 @@ def get_pytest_args(options, is_cpp_test=False, is_distributed_test=False):
     if not is_cpp_test:
         # C++ tests need to be run with pytest directly, not via python
         # We have a custom pytest shard that conflicts with the normal plugin
-        pytest_args.extend(["-p", "no:xdist", "no:pytest-shard", "--use-pytest"])
+        pytest_args.extend(["-p", "no:xdist", "--use-pytest"])
     else:
         # Use pytext-dist to run C++ tests in parallel as running them sequentially using run_test
         # is much slower than running them directly

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -100,7 +100,6 @@ class TestCheckpoint(TestCase):
     # Test whether checkpoint is being triggered or not. For this, we check
     # the number of times forward pass happens
     def test_checkpoint_trigger(self):
-        self.assertEqual(1 == 2)
 
         class Net(nn.Module):
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -100,6 +100,7 @@ class TestCheckpoint(TestCase):
     # Test whether checkpoint is being triggered or not. For this, we check
     # the number of times forward pass happens
     def test_checkpoint_trigger(self):
+        self.assertEqual(1, 2)
 
         class Net(nn.Module):
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -100,7 +100,6 @@ class TestCheckpoint(TestCase):
     # Test whether checkpoint is being triggered or not. For this, we check
     # the number of times forward pass happens
     def test_checkpoint_trigger(self):
-        self.assertEqual(1, 2)
 
         class Net(nn.Module):
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -100,6 +100,7 @@ class TestCheckpoint(TestCase):
     # Test whether checkpoint is being triggered or not. For this, we check
     # the number of times forward pass happens
     def test_checkpoint_trigger(self):
+        self.assertEqual(1 == 2)
 
         class Net(nn.Module):
 


### PR DESCRIPTION
* custom pytest-shard so I can control the verbosity (also index by 1 since it's confusing)
* normal runs (not keep-going) always rerun each failed test 9 times (3 per process, 3 processes).  Previously it would only run the entire test file 3 times, so if a test before you segfaulted, you only got 2 tries

Example of quieter log https://github.com/pytorch/pytorch/actions/runs/7481334046/job/20363147497
"items in shard" only gets printed once at the beginning, and the reruns just say how many got skipped.