### PR TITLE
Fix broken lint after #117052

### DIFF
--- a/test/quantization/pt2e/test_xnnpack_quantizer.py
+++ b/test/quantization/pt2e/test_xnnpack_quantizer.py
@@ -181,11 +181,10 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
                 example_inputs,
                 quantizer,
                 node_occurrence,
-                [], # node_list
-                False, # executorch_backend_config() does not fuse linear-relu
+                [],  # node_list
+                False,  # executorch_backend_config() does not fuse linear-relu
                 qconfig_mapping,
             )
-
 
     def test_conv_linear_no_permute(self):
         quantizer = XNNPACKQuantizer()


### PR DESCRIPTION
https://hud.pytorch.org/pr/pytorch/pytorch/117052#20318344490 breaks lint, forward fixing with `lintrunner -a`