### PR TITLE
[AOTI] Remove caching for compiled model.so

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1532,6 +1532,28 @@ class AOTInductorTestsTemplate:
 
         self.check_model(MyModule(), (torch.randn(2, 3, device=self.device),))
 
+    def test_model_modified_weights(self):
+        class Model(torch.nn.Module):
+            def __init__(self, n, k, device):
+                super().__init__()
+                self.weight = torch.randn(n, k, device=device)
+                self.bias = torch.randn(n, device=device)
+
+            def forward(self, a):
+                return torch.nn.functional.linear(a, self.weight, self.bias)
+
+        M = 16
+        N = 10
+        K = 128
+        batch = 8
+        example_inputs = (torch.randn(2, M, K, device=self.device),)
+        model = Model(N, K, self.device)
+        self.check_model(model, example_inputs)
+        # Update model weights, after this AOTInductor should re-generate model.so
+        # if weights are stored in the model.so
+        model.weight += 1
+        self.check_model(model, example_inputs)
+
 
 common_utils.instantiate_parametrized_tests(AOTInductorTestsTemplate)
 
@@ -1670,6 +1692,9 @@ if not IS_FBCODE:
             "test_empty_graph": fail_minimal_arrayref_interface(is_skip=True),
             "test_large": fail_minimal_arrayref_interface(is_skip=True),
             "test_missing_output": fail_minimal_arrayref_interface(is_skip=True),
+            "test_model_modified_weights": fail_minimal_arrayref_interface(
+                is_skip=True
+            ),
             "test_output_path_1": fail_minimal_arrayref_interface(is_skip=True),
             "test_repeat_interleave": fail_minimal_arrayref_interface(is_skip=True),
             "test_return_constant": fail_minimal_arrayref_interface(is_skip=True),

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1536,10 +1536,7 @@ class CudaKernelParamCache:
         return cls.cache.get(key, None)
 
 
-class AotCodeCache:
-    cache: Dict[str, str] = dict()
-    clear = staticmethod(cache.clear)
-
+class AotCodeCompiler:
     @classmethod
     def compile(
         cls,
@@ -1579,139 +1576,124 @@ class AotCodeCache:
             specified_dir=specified_output_path,
         )
 
-        if key not in cls.cache or (
-            specified_output_path
-            and os.path.dirname(cls.cache[key]) != specified_output_path
-            or specified_so_name
-            and os.path.basename(cls.cache[key]) != specified_so_name
-        ):
-            from filelock import FileLock
+        from filelock import FileLock
 
-            lock_dir = get_lock_dir()
-            lock = FileLock(os.path.join(lock_dir, key + ".lock"), timeout=LOCK_TIMEOUT)
-            with lock:
-                # Currently, this only support serializing extern nodes in fbcode
-                # Eventually, we should also have a serializer for OSS.
-                if config.is_fbcode() and serialized_extern_kernel_nodes:
-                    output_json = os.path.splitext(input_path)[0] + ".json"
-                    with open(output_json, "w") as f:
-                        f.write(serialized_extern_kernel_nodes)
+        lock_dir = get_lock_dir()
+        lock = FileLock(os.path.join(lock_dir, key + ".lock"), timeout=LOCK_TIMEOUT)
+        with lock:
+            # Currently, this only support serializing extern nodes in fbcode
+            # Eventually, we should also have a serializer for OSS.
+            if config.is_fbcode() and serialized_extern_kernel_nodes:
+                output_json = os.path.splitext(input_path)[0] + ".json"
+                with open(output_json, "w") as f:
+                    f.write(serialized_extern_kernel_nodes)
 
-                output_so = (
-                    config.aot_inductor.output_path
-                    if specified_so_name
-                    else os.path.splitext(input_path)[0] + ".so"
+            output_so = (
+                config.aot_inductor.output_path
+                if specified_so_name
+                else os.path.splitext(input_path)[0] + ".so"
+            )
+
+            output_o = os.path.splitext(input_path)[0] + ".o"
+            cmd = cpp_compile_command(
+                input=input_path,
+                output=output_o,
+                vec_isa=picked_vec_isa,
+                cuda=cuda,
+                aot_mode=graph.aot_mode,
+                compile_only=True,
+                use_absolute_path=use_absolute_path,
+            )
+            log.debug("aot compilation command: %s", cmd)
+            if fbcode_aot_cpu_re:
+                compile_file(input_path, output_o, cmd.split())
+                os.chmod(output_o, 0o644)
+            else:
+                run_command_and_check(cmd)
+
+            def _to_bytes(t: torch.Tensor) -> bytes:
+                # This serializes the tensor's untyped_storage to bytes by accessing
+                # the raw data of the underlying structure.
+                import ctypes
+
+                if t.numel() == 0:
+                    return b""
+
+                t_cpu = t.untyped_storage().cpu()
+                raw_array = ctypes.cast(
+                    t_cpu.data_ptr(),
+                    ctypes.POINTER(ctypes.c_ubyte * t_cpu.nbytes()),
                 )
 
-                if not os.path.exists(output_so):
-                    output_o = os.path.splitext(input_path)[0] + ".o"
-                    cmd = cpp_compile_command(
-                        input=input_path,
-                        output=output_o,
-                        vec_isa=picked_vec_isa,
-                        cuda=cuda,
-                        aot_mode=graph.aot_mode,
-                        compile_only=True,
-                        use_absolute_path=use_absolute_path,
-                    )
-                    log.debug("aot compilation command: %s", cmd)
-                    if fbcode_aot_cpu_re:
-                        compile_file(input_path, output_o, cmd.split())
-                        os.chmod(output_o, 0o644)
-                    else:
-                        run_command_and_check(cmd)
+                return bytes(raw_array.contents)
 
-                    def _to_bytes(t: torch.Tensor) -> bytes:
-                        # This serializes the tensor's untyped_storage to bytes by accessing
-                        # the raw data of the underlying structure.
-                        import ctypes
+            aot_constants = b"".join(
+                _to_bytes(tensor) for tensor in graph.constants.values()
+            )
 
-                        if t.numel() == 0:
-                            return b""
+            _, consts_path = write(
+                aot_constants,
+                "bin",
+                specified_dir=specified_output_path,
+            )
 
-                        t_cpu = t.untyped_storage().cpu()
-                        raw_array = ctypes.cast(
-                            t_cpu.data_ptr(),
-                            ctypes.POINTER(ctypes.c_ubyte * t_cpu.nbytes()),
-                        )
+            consts_o = os.path.splitext(consts_path)[0] + ".o"
+            if fbcode_aot_cpu_re:
+                cmd = f"{ld_command} -r -b binary -o {os.path.basename(consts_o)} {os.path.basename(consts_path)}"
+                compile_file(consts_path, consts_o, cmd.split())
+                os.chmod(consts_o, 0o644)
+            else:
+                cmd = f"{ld_command} -r -b binary -o {consts_o} {consts_path}"
+                run_command_and_check(cmd)
+            log.debug("aot constant binary command: %s", cmd)
 
-                        return bytes(raw_array.contents)
+            cmd = (
+                f"{objcopy_command} --rename-section"
+                " .data=.lrodata,alloc,load,readonly,data,contents"
+                f" {consts_o} {consts_o}"
+            )
+            log.debug("aot constant obj command: %s", cmd)
+            run_command_and_check(cmd)
 
-                    aot_constants = b"".join(
-                        _to_bytes(tensor) for tensor in graph.constants.values()
-                    )
+            cmd = f"rm {consts_path}"
+            log.debug("aot constant bin removal command: %s", cmd)
+            run_command_and_check(cmd)
 
-                    consts_key, consts_path = write(
-                        aot_constants,
-                        "bin",
-                        specified_dir=specified_output_path,
-                    )
+            if fbcode_aot_cpu_re:
+                body = re.sub(r"[\W]", "_", os.path.basename(consts_path))
+            else:
+                body = re.sub(r"[\W]", "_", consts_path)
 
-                    consts_o = os.path.splitext(consts_path)[0] + ".o"
-                    if fbcode_aot_cpu_re:
-                        cmd = f"{ld_command} -r -b binary -o {os.path.basename(consts_o)} {os.path.basename(consts_path)}"
-                        compile_file(consts_path, consts_o, cmd.split())
-                        os.chmod(consts_o, 0o644)
-                    else:
-                        cmd = f"{ld_command} -r -b binary -o {consts_o} {consts_path}"
-                        run_command_and_check(cmd)
-                    log.debug("aot constant binary command: %s", cmd)
+            symbol_list = []
+            symbol_list.append(
+                f"{objcopy_command} --redefine-sym _binary_{body}_start=_binary_constants_bin_start {consts_o}"
+            )
+            symbol_list.append(
+                f"{objcopy_command} --redefine-sym _binary_{body}_size=_binary_constants_bin_size {consts_o}"
+            )
+            symbol_list.append(
+                f"{objcopy_command} --redefine-sym _binary_{body}_end=_binary_constants_bin_end {consts_o}"
+            )
+            log.debug("aot constant binary redefine symbol: %s", " ".join(symbol_list))
+            for cmd in symbol_list:
+                run_command_and_check(cmd)
 
-                    cmd = (
-                        f"{objcopy_command} --rename-section"
-                        " .data=.lrodata,alloc,load,readonly,data,contents"
-                        f" {consts_o} {consts_o}"
-                    )
-                    log.debug("aot constant obj command: %s", cmd)
-                    run_command_and_check(cmd)
+            cmd = cpp_compile_command(
+                input=[output_o, consts_o],
+                output=output_so,
+                vec_isa=picked_vec_isa,
+                cuda=cuda,
+                aot_mode=graph.aot_mode,
+                use_absolute_path=use_absolute_path,
+            )
+            log.debug("aot linkage command: %s", cmd)
+            if fbcode_aot_cpu_re:
+                compile_file([output_o, consts_o], output_so, cmd.split())
+                os.chmod(output_so, 0o755)
+            else:
+                run_command_and_check(cmd)
 
-                    cmd = f"rm {consts_path}"
-                    log.debug("aot constant bin removal command: %s", cmd)
-                    run_command_and_check(cmd)
-
-                    if fbcode_aot_cpu_re:
-                        body = re.sub(r"[\W]", "_", os.path.basename(consts_path))
-                    else:
-                        body = re.sub(r"[\W]", "_", consts_path)
-
-                    symbol_list = []
-                    symbol_list.append(
-                        f"{objcopy_command} --redefine-sym _binary_{body}_start=_binary_constants_bin_start {consts_o}"
-                    )
-                    symbol_list.append(
-                        f"{objcopy_command} --redefine-sym _binary_{body}_size=_binary_constants_bin_size {consts_o}"
-                    )
-                    symbol_list.append(
-                        f"{objcopy_command} --redefine-sym _binary_{body}_end=_binary_constants_bin_end {consts_o}"
-                    )
-                    log.debug(
-                        "aot constant binary redefine symbol: %s", " ".join(symbol_list)
-                    )
-                    for cmd in symbol_list:
-                        run_command_and_check(cmd)
-
-                    cmd = cpp_compile_command(
-                        input=[output_o, consts_o],
-                        output=output_so,
-                        vec_isa=picked_vec_isa,
-                        cuda=cuda,
-                        aot_mode=graph.aot_mode,
-                        use_absolute_path=use_absolute_path,
-                    )
-                    log.debug("aot linkage command: %s", cmd)
-                    if fbcode_aot_cpu_re:
-                        compile_file([output_o, consts_o], output_so, cmd.split())
-                        os.chmod(output_so, 0o755)
-                    else:
-                        run_command_and_check(cmd)
-                else:
-                    log.debug(
-                        "aot_inductor dynamic library already exist: %s", output_so
-                    )
-
-                cls.cache[key] = output_so
-
-        return cls.cache[key]
+        return output_so
 
 
 # Putting this fn in cpp.py (unfortunately) causes a deadlock, which is why it's in codecache.py.

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1129,7 +1129,7 @@ class GraphLowering(torch.fx.Interpreter):
 
     def compile_to_fn(self):
         if self.aot_mode:
-            from .codecache import AotCodeCache
+            from .codecache import AotCodeCompiler
 
             assert self.cpp_wrapper, "AOT mode only supports C++ wrapper"
             code, linemap = self.codegen_with_cpp_wrapper()
@@ -1150,7 +1150,7 @@ class GraphLowering(torch.fx.Interpreter):
                 )
 
             # Directly return the file path with the compiled code
-            return AotCodeCache.compile(
+            return AotCodeCompiler.compile(
                 self, code, serialized_extern_kernel_nodes, cuda=self.cuda
             )
         else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #117085

Summary: Oleg found the model.so caching does not compute the hash key with model weights included, which can cause incorrect model.so reuse. Since caching is not really necessary in the AOT mode, let's just remove it.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler