### PR TITLE
[LLVM/TensorExpr] Update for an API change in LLVM 18.

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -2754,7 +2754,11 @@ void LLVMCodeGenImpl::optimize(llvm::Module& M) {
   // options.
   llvm::PassBuilder PB(&TM);
 
+#if LLVM_VERSION_MAJOR >= 18
+  TM.registerPassBuilderCallbacks(PB, false /* PopulateClassToPassNames */);
+#else
   TM.registerPassBuilderCallbacks(PB);
+#endif
 
   // Register all the basic analyses with the managers.
   PB.registerModuleAnalyses(MAM);


### PR DESCRIPTION
`registerPassBuilderCallbacks` takes now an extra bool argument to print extra information. Currently initialized to false to not change functional behaviour.

Relevant LLVM commit:
https://github.com/llvm/llvm-project/commit/ffb1f20e0d8db5cd2c2a0fa2db9951e97f215b92

cc @EikanWang @jgong5