### PR TITLE
[Reland] [13/N] Enable clang-tidy on headers of torch/csrc

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -246,6 +246,7 @@ include_patterns = [
     'c10/**/*.cpp',
     'c10/core/**/*.h',
     'c10/util/**/*.h',
+    # Enable coverage of headers in torch/csrc and excluding sub-directories for now.
     'torch/csrc/*.h',
     'torch/csrc/**/*.cpp',
 ]

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -246,6 +246,7 @@ include_patterns = [
     'c10/**/*.cpp',
     'c10/core/**/*.h',
     'c10/util/**/*.h',
+    'torch/csrc/*.h',
     'torch/csrc/**/*.cpp',
 ]
 exclude_patterns = [

--- a/torch/csrc/CudaIPCTypes.h
+++ b/torch/csrc/CudaIPCTypes.h
@@ -79,9 +79,8 @@ struct CudaIPCRefCountersFile final {
       std::string handle,
       uint64_t size,
       at::DataPtr data_ptr)
-      : next_offset_(0),
-        size_(size),
-        used_slots_(0),
+      : size_(size),
+
         handle_(std::move(handle)),
         refcounted_shared_mem_(std::move(data_ptr)) {}
 
@@ -119,9 +118,9 @@ struct CudaIPCRefCountersFile final {
   }
 
  private:
-  uint64_t next_offset_;
+  uint64_t next_offset_{0};
   uint64_t size_;
-  uint64_t used_slots_;
+  uint64_t used_slots_{0};
   std::string handle_;
   at::DataPtr refcounted_shared_mem_;
 };

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -384,9 +384,11 @@ auto wrap_pybind_function_impl_(
     HANDLE_TH_ERRORS
     if (release_gil) {
       py::gil_scoped_release no_gil;
-      return c10::guts::invoke(std::move(f), std::forward<Arg<Func, Is>>(args)...);
+      return c10::guts::invoke(
+          std::move(f), std::forward<Arg<Func, Is>>(args)...);
     } else {
-      return c10::guts::invoke(std::move(f), std::forward<Arg<Func, Is>>(args)...);
+      return c10::guts::invoke(
+          std::move(f), std::forward<Arg<Func, Is>>(args)...);
     }
     END_HANDLE_TH_ERRORS_PYBIND
   };

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -2,13 +2,10 @@
 
 #include <exception>
 #include <memory>
-#include <mutex>
-#include <queue>
 #include <string>
 #include <system_error>
 
 #include <ATen/detail/FunctionTraits.h>
-#include <c10/util/C++17.h>
 #include <c10/util/Exception.h>
 #include <c10/util/StringUtil.h>
 #include <pybind11/pybind11.h>
@@ -145,7 +142,7 @@ extern PyObject *THPException_FatalError, *THPException_LinAlgError,
 // Throwing this exception means that the python error flags have been already
 // set and control should be immediately returned to the interpreter.
 struct python_error : public std::exception {
-  python_error() {}
+  python_error() = default;
 
   python_error(const python_error& other)
       : type(other.type),

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -384,9 +384,9 @@ auto wrap_pybind_function_impl_(
     HANDLE_TH_ERRORS
     if (release_gil) {
       py::gil_scoped_release no_gil;
-      return c10::guts::invoke(f, std::forward<Arg<Func, Is>>(args)...);
+      return c10::guts::invoke(std::move(f), std::forward<Arg<Func, Is>>(args)...);
     } else {
-      return c10::guts::invoke(f, std::forward<Arg<Func, Is>>(args)...);
+      return c10::guts::invoke(std::move(f), std::forward<Arg<Func, Is>>(args)...);
     }
     END_HANDLE_TH_ERRORS_PYBIND
   };

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -6,6 +6,7 @@
 #include <system_error>
 
 #include <ATen/detail/FunctionTraits.h>
+#include <c10/util/C++17.h>
 #include <c10/util/Exception.h>
 #include <c10/util/StringUtil.h>
 #include <pybind11/pybind11.h>
@@ -370,6 +371,7 @@ using Arg = typename invoke_traits<Func>::template arg<i>::type;
 
 template <typename Func, size_t... Is>
 auto wrap_pybind_function_impl_(
+    // NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
     Func&& f,
     std::index_sequence<Is...>,
     bool release_gil) {

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -375,20 +375,19 @@ auto wrap_pybind_function_impl_(
     Func&& f,
     std::index_sequence<Is...>,
     bool release_gil) {
-  using result_type = typename invoke_traits<Func>::result_type;
   namespace py = pybind11;
 
   // f=f is needed to handle function references on older compilers
   return [f = std::forward<Func>(f),
-          release_gil](Arg<Func, Is>... args) -> result_type {
+          release_gil](Arg<Func, Is>... args) {
     HANDLE_TH_ERRORS
     if (release_gil) {
       py::gil_scoped_release no_gil;
       return c10::guts::invoke(
-          std::move(f), std::forward<Arg<Func, Is>>(args)...);
+          f, std::forward<Arg<Func, Is>>(args)...);
     } else {
       return c10::guts::invoke(
-          std::move(f), std::forward<Arg<Func, Is>>(args)...);
+          f, std::forward<Arg<Func, Is>>(args)...);
     }
     END_HANDLE_TH_ERRORS_PYBIND
   };

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -378,16 +378,13 @@ auto wrap_pybind_function_impl_(
   namespace py = pybind11;
 
   // f=f is needed to handle function references on older compilers
-  return [f = std::forward<Func>(f),
-          release_gil](Arg<Func, Is>... args) {
+  return [f = std::forward<Func>(f), release_gil](Arg<Func, Is>... args) {
     HANDLE_TH_ERRORS
     if (release_gil) {
       py::gil_scoped_release no_gil;
-      return c10::guts::invoke(
-          f, std::forward<Arg<Func, Is>>(args)...);
+      return c10::guts::invoke(f, std::forward<Arg<Func, Is>>(args)...);
     } else {
-      return c10::guts::invoke(
-          f, std::forward<Arg<Func, Is>>(args)...);
+      return c10::guts::invoke(f, std::forward<Arg<Func, Is>>(args)...);
     }
     END_HANDLE_TH_ERRORS_PYBIND
   };

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -80,7 +80,7 @@ std::atomic<Engine::compiled_autograd_fn> the_compiled_autograd = nullptr;
   reinterpret_cast<Engine::compiled_autograd_fn>(1)
 std::atomic<int32_t> num_threads_in_backwards;
 struct CompiledAutogradThreadingDebugCheck {
-  CompiledAutogradThreadingDebugCheck()  {
+  CompiledAutogradThreadingDebugCheck() {
     num_threads_in_backwards++;
   }
   ~CompiledAutogradThreadingDebugCheck() {

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -80,7 +80,7 @@ std::atomic<Engine::compiled_autograd_fn> the_compiled_autograd = nullptr;
   reinterpret_cast<Engine::compiled_autograd_fn>(1)
 std::atomic<int32_t> num_threads_in_backwards;
 struct CompiledAutogradThreadingDebugCheck {
-  CompiledAutogradThreadingDebugCheck() : incremented(true) {
+  CompiledAutogradThreadingDebugCheck()  {
     num_threads_in_backwards++;
   }
   ~CompiledAutogradThreadingDebugCheck() {
@@ -93,7 +93,7 @@ struct CompiledAutogradThreadingDebugCheck {
   }
 
  private:
-  bool incremented;
+  bool incremented{true};
 };
 
 } // namespace

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -15,13 +15,10 @@
 #include <ATen/MemoryOverlap.h>
 #include <c10/util/Exception.h>
 
-#include <iostream>
-#include <list>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
 #include <string>
-#include <typeinfo>
 #include <utility>
 #include <vector>
 

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -16,7 +16,6 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
-#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>

--- a/torch/csrc/copy_utils.h
+++ b/torch/csrc/copy_utils.h
@@ -2,6 +2,7 @@
 
 #include <torch/csrc/Types.h>
 #include <torch/csrc/python_headers.h>
+#include <torch/csrc/utils.h>
 #include <functional>
 #include <vector>
 

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -1,6 +1,5 @@
 #include <torch/csrc/distributed/rpc/request_callback_impl.h>
 
-#include <c10/util/C++17.h>
 #include <torch/csrc/autograd/profiler.h>
 #include <torch/csrc/distributed/autograd/context/container.h>
 #include <torch/csrc/distributed/autograd/context/context.h>

--- a/torch/csrc/distributed/rpc/script_remote_call.cpp
+++ b/torch/csrc/distributed/rpc/script_remote_call.cpp
@@ -1,7 +1,6 @@
 #include <torch/csrc/distributed/rpc/rpc_agent.h>
 #include <torch/csrc/distributed/rpc/script_remote_call.h>
 
-#include <c10/util/C++17.h>
 #include <torch/csrc/jit/serialization/pickle.h>
 
 namespace torch {

--- a/torch/csrc/jit/resource_guard.h
+++ b/torch/csrc/jit/resource_guard.h
@@ -6,11 +6,11 @@ namespace jit {
 
 class ResourceGuard {
   std::function<void()> _destructor;
-  bool _released;
+  bool _released{false};
 
  public:
   ResourceGuard(std::function<void()> destructor)
-      : _destructor(std::move(destructor)), _released(false) {}
+      : _destructor(std::move(destructor)) {}
 
   // NOLINTNEXTLINE(bugprone-exception-escape)
   ~ResourceGuard() {

--- a/torch/csrc/serialization.h
+++ b/torch/csrc/serialization.h
@@ -1,6 +1,8 @@
 #ifndef THP_SERIALIZATION_INC
 #define THP_SERIALIZATION_INC
 
+#include <c10/core/StorageImpl.h>
+#include <c10/util/intrusive_ptr.h>
 template <class io>
 void doRead(io fildes, void* buf, size_t nbytes);
 

--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -184,18 +184,14 @@ template <typename _real, typename = void>
 struct mod_traits {};
 
 template <typename _real>
-struct mod_traits<
-    _real,
-    typename std::enable_if<std::is_floating_point<_real>::value>::type> {
+struct mod_traits<_real, std::enable_if_t<std::is_floating_point_v<_real>>> {
   static _real mod(_real a, _real b) {
     return fmod(a, b);
   }
 };
 
 template <typename _real>
-struct mod_traits<
-    _real,
-    typename std::enable_if<std::is_integral<_real>::value>::type> {
+struct mod_traits<_real, std::enable_if_t<std::is_integral_v<_real>>> {
   static _real mod(_real a, _real b) {
     return a % b;
   }


### PR DESCRIPTION
Reland of #116560 and fixes the issued reported by #116695

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @izaitsevfb