### PR TITLE
Fix cuInit test on Windows

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3405,7 +3405,8 @@ exit(2)
             # Check that `cuInit` was not called during the import
             # By using ctypes and calling cuDeviceCountGet() and expect CUDA_ERROR_NOT_INITIALIZED == 3
             # See https://github.com/pytorch/pytorch/issues/116276 for more details
-            cuda_driver_api_call = "ctypes.CDLL('libcuda.so.1').cuDeviceGetCount(ctypes.byref(x))"
+            libcuda_name = "libcuda.so.1" if not IS_WINDOWS else "nvcuda.dll"
+            cuda_driver_api_call = f"ctypes.CDLL('{libcuda_name}').cuDeviceGetCount(ctypes.byref(x))"
             rc = check_output(f"import torch; import ctypes;x=ctypes.c_int(-1);print({cuda_driver_api_call})")
             self.assertEqual(rc, "3")
 


### PR DESCRIPTION
By changing library name from `libcuda.so.1` to `nvcuda.dll` on Windows

Cherry pick of https://github.com/pytorch/pytorch/pull/117055 into release/2.2 branch

(cherry picked from commit a6325ad86c1d539320748144d85c7701ca623396)


