### PR TITLE
[export] Modify SDPA decomposition to decompose _scaled_dot_product_flash_attention_for_cpu

### DIFF
--- a/test/expect/HasDecompTest.test_aten_core_operators.expect
+++ b/test/expect/HasDecompTest.test_aten_core_operators.expect
@@ -15,6 +15,7 @@ aten::_native_batch_norm_legit
 aten::_native_batch_norm_legit.no_stats
 aten::_native_batch_norm_legit_functional
 aten::_native_batch_norm_legit_no_training
+aten::_scaled_dot_product_flash_attention_for_cpu
 aten::_softmax
 aten::_softmax.out
 aten::_to_copy

--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -467,6 +467,7 @@ aten::_sample_dirichlet
 aten::_sample_dirichlet.out
 aten::_scaled_dot_product_efficient_attention
 aten::_scaled_dot_product_efficient_attention_backward
+aten::_scaled_dot_product_flash_attention
 aten::_scaled_dot_product_flash_attention_backward
 aten::_scaled_dot_product_flash_attention_for_cpu_backward
 aten::_scaled_mm

--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -468,7 +468,6 @@ aten::_sample_dirichlet.out
 aten::_scaled_dot_product_efficient_attention
 aten::_scaled_dot_product_efficient_attention_backward
 aten::_scaled_dot_product_flash_attention_backward
-aten::_scaled_dot_product_flash_attention_for_cpu
 aten::_scaled_dot_product_flash_attention_for_cpu_backward
 aten::_scaled_mm
 aten::_scaled_mm.out

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -26,6 +26,7 @@ from torch.testing._internal.common_device_type import (
     onlyNativeDeviceTypes,
     ops,
     instantiate_device_type_tests,
+    onlyCPU,
     onlyCUDA,
 )
 from torch.testing._internal.common_methods_invocations import op_db, skip, skipOps, xfail
@@ -900,7 +901,7 @@ class DecompOneOffTests(TestCase):
         self.assertTrue(torch.allclose(ref[1], res[1]))
 
     @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
-    @onlyNativeDeviceTypes
+    @onlyCPU
     @skipIfCrossRef
     def test_sdpa(self, device):
         from torch.fx.experimental.proxy_tensor import make_fx

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -927,7 +927,7 @@ class DecompOneOffTests(TestCase):
             attention,
             decomposition_table=get_decompositions(
                 [
-                    torch.ops.aten._scaled_dot_product_flash_attention.default,
+                    torch.ops.aten._scaled_dot_product_flash_attention_for_cpu.default,
                 ]
             ),
         )(query_layer, key_layer, value_layer)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -4276,25 +4276,25 @@ def multilabel_margin_loss_forward(
 # it calls _scaled_dot_product_attention_math and
 # _scaled_dot_product_attention_math only has a CompositeImplicitAutograd
 # kernel. As a result it's decomposed into ops with finer granularity.
-# However recent PRs (#103826 #105131) added new logic in
+# However recent PRs (#103826 #105131 #115913) added new logic in
 # scaled_dot_product_attention and now it calls
-# _scaled_dot_product_flash_attention which contains a CPU kernel. This results
-# in _scaled_dot_product_flash_attention showing up in torch.export().
+# _scaled_dot_product_flash_attention_for_cpu in export path. This results
+# in _scaled_dot_product_flash_attention_for_cpu showing up in export result.
 # This decomposition ensures scaled_dot_product_attention is still decomposed
 # the same way as before, i.e., going through
 # _scaled_dot_product_attention_math. Notice that this decomp rule should be
 # excluded by inductor.
-@register_decomposition(aten._scaled_dot_product_flash_attention.default)
-def scaled_dot_product_flash_attention(
+@register_decomposition(aten._scaled_dot_product_flash_attention_for_cpu.default)
+def scaled_dot_product_flash_attention_for_cpu(
     query: Tensor,
     key: Tensor,
     value: Tensor,
     dropout_p: float = 0.0,
     is_causal: bool = False,
-    return_debug_mask: bool = False,
     *,
+    attn_mask: Optional[Tensor] = None,
     scale: Optional[float] = None,
-) -> Tuple[Tensor, Tensor, Tensor, Tensor, int, int, Tensor, Tensor, Tensor]:
+) -> Tuple[Tensor, Tensor]:
     dtype = query.dtype
     batchSize, num_head, qSize, headSize = (
         query.shape[0],
@@ -4318,25 +4318,8 @@ def scaled_dot_product_flash_attention(
         query.shape[3] == value.shape[3] and key.shape[3] == value.shape[3],
         lambda: "q, k, v should have the same head size",
     )
-    torch._check(
-        return_debug_mask is False, lambda: "return_debug_mask is not supported."
-    )
 
-    logsumexp = torch.empty([batchSize, qSize, num_head, headSize], dtype=torch.float)
-    cum_seq_q, cum_seq_k = torch.empty([], dtype=torch.long), torch.empty(
-        [], dtype=torch.long
-    )
-    max_q, max_k = 0, 0
-    philox_seed, philox_offset = torch.empty([], dtype=torch.long), torch.empty(
-        [], dtype=torch.long
-    )
-    debug_attn_mask = torch.empty(
-        [],
-        dtype=query.dtype,
-        device=query.device,
-        requires_grad=query.requires_grad,
-    )
-    output, _ = aten._scaled_dot_product_attention_math.default(
+    output, attn = aten._scaled_dot_product_attention_math.default(
         query, key, value, None, dropout_p, is_causal, None, scale=scale
     )
     # Why this change?
@@ -4373,17 +4356,7 @@ def scaled_dot_product_flash_attention(
     # pre-dispatch op-output and its decomposed representation must
     # return tensor with same view and dims
     output = output.transpose(1, 2).contiguous(memory_format=torch.contiguous_format)
-    return (
-        output.transpose(1, 2),
-        logsumexp,
-        cum_seq_q,
-        cum_seq_k,
-        max_q,
-        max_k,
-        philox_seed,
-        philox_offset,
-        debug_attn_mask,
-    )
+    return (output.transpose(1, 2), attn)
 
 
 def register_inplace(aten_op, outplace_op):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #117097

Summary: As titled. #115913 added
`_scaled_dot_product_flash_attention_for_cpu` and the export result of
`scaled_dot_product_attention` includes this op. Adding this
decomposition so that it's being decomposed the same way as
`_scaled_dot_product_attention_math`.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: