### PR TITLE
Dockerfile; Add cuda bin to PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,6 +99,7 @@ ENV PATH /opt/conda/bin:$PATH
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
+ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:$PATH
 ENV PYTORCH_VERSION ${PYTORCH_VERSION}
 WORKDIR /workspace
 


### PR DESCRIPTION
We need this to execute `nvidia-smi` in the officially released containers. We have already it in the Docker CI

See
https://github.com/pytorch/pytorch/blob/94db6578ccee2551c986d92c245e0a0729b99449/.ci/docker/linter-cuda/Dockerfile#L35
