### PR TITLE
[Reference Cycle Detector] Ignore FakeTensor in cycle leak detection

### DIFF
--- a/torch/utils/viz/_cycles.py
+++ b/torch/utils/viz/_cycles.py
@@ -310,7 +310,7 @@ def escape(n):
 
 
 def is_cuda_tensor(obj):
-    return isinstance(obj, torch.Tensor) and obj.is_cuda
+    return isinstance(obj, torch.Tensor) and obj.is_cuda and not isinstance(obj, torch._subclasses.FakeTensor)
 
 def cuda_allocation_context():
     snapshot = torch.cuda.memory._snapshot()


### PR DESCRIPTION
Summary: Skip FakeTensors since these tensors are not actually using GPU memory. Reference Cycle Detector does not need to generate plots for these tensors.

Test Plan: CI and internal testing.

Differential Revision: D52637209


