### PR TITLE
Skip all OpInfo-based test when running with PYTORCH_TEST_WITH_DYNAMO

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -843,10 +843,11 @@ def _serialize_sample(sample_input):
 
 class ops(_TestParametrizer):
     def __init__(self, op_list, *, dtypes: Union[OpDTypes, Sequence[torch.dtype]] = OpDTypes.supported,
-                 allowed_dtypes: Optional[Sequence[torch.dtype]] = None):
+                 allowed_dtypes: Optional[Sequence[torch.dtype]] = None, skip_if_dynamo=True):
         self.op_list = list(op_list)
         self.opinfo_dtypes = dtypes
         self.allowed_dtypes = set(allowed_dtypes) if allowed_dtypes is not None else None
+        self.skip_if_dynamo = skip_if_dynamo
 
     def _parametrize_test(self, test, generic_cls, device_cls):
         """ Parameterizes the given test function across each op and its associated dtypes. """
@@ -927,6 +928,9 @@ class ops(_TestParametrizer):
                             raise e
                         finally:
                             clear_tracked_input()
+
+                    if self.skip_if_dynamo:
+                        test_wrapper = skipIfTorchDynamo("Policy: we don't run OpInfo tests w/ Dynamo")(test_wrapper)
 
                     # Initialize info for the last input seen. This is useful for tracking
                     # down which inputs caused a test failure. Note that TrackedInputIter is


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #117219
* #117218
* #117139
* #117133
* __->__ #117129
* #117128
* #117127
* #117114

This is a policy decision. These tests:
- are flaky, and fixing the flakiness is unfeasible at the moment
- are highly redundant