### PR TITLE
[pt-vulkan][ez] Miscellaneous small c10 deprecations (`c10::irange`, `C10_LIKELY`, `c10::SmallVector`, etc.)

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Adapter.cpp
+++ b/aten/src/ATen/native/vulkan/api/Adapter.cpp
@@ -1,5 +1,4 @@
 #include <ATen/native/vulkan/api/Adapter.h>
-#include <c10/util/irange.h>
 
 #include <bitset>
 #include <iomanip>
@@ -28,7 +27,7 @@ PhysicalDevice::PhysicalDevice(VkPhysicalDevice physical_device_handle)
   // DEVICE_LOCAL property flags
   const VkMemoryPropertyFlags unified_memory_flags =
       VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
-  for (const uint32_t i : c10::irange(memory_properties.memoryTypeCount)) {
+  for (size_t i = 0; i < memory_properties.memoryTypeCount; ++i) {
     if (memory_properties.memoryTypes[i].propertyFlags | unified_memory_flags) {
       has_unified_memory = true;
       break;
@@ -44,8 +43,7 @@ PhysicalDevice::PhysicalDevice(VkPhysicalDevice physical_device_handle)
       handle, &queue_family_count, queue_families.data());
 
   // Find the total number of compute queues
-  for (const uint32_t family_i : c10::irange(queue_families.size())) {
-    const VkQueueFamilyProperties& properties = queue_families[family_i];
+  for (const VkQueueFamilyProperties& properties : queue_families) {
     // Check if this family has compute capability
     if (properties.queueFlags & VK_QUEUE_COMPUTE_BIT) {
       num_compute_queues += properties.queueCount;
@@ -96,8 +94,8 @@ VkDevice create_logical_device(
   queues_to_get.reserve(num_queues_to_create);
 
   uint32_t remaining_queues = num_queues_to_create;
-  for (const uint32_t family_i :
-       c10::irange(physical_device.queue_families.size())) {
+  for (uint32_t family_i = 0; family_i < physical_device.queue_families.size();
+       ++family_i) {
     const VkQueueFamilyProperties& queue_properties =
         physical_device.queue_families.at(family_i);
     // Check if this family has compute capability
@@ -115,7 +113,7 @@ VkDevice create_logical_device(
           queue_priorities.data(), // pQueuePriorities
       });
 
-      for (const uint32_t queue_i : c10::irange(queues_to_init)) {
+      for (size_t queue_i = 0; queue_i < queues_to_init; ++queue_i) {
         // Use this to get the queue handle once device is created
         queues_to_get.emplace_back(family_i, queue_i);
       }
@@ -249,7 +247,7 @@ DeviceHandle::DeviceHandle(DeviceHandle&& other) noexcept
 }
 
 DeviceHandle::~DeviceHandle() {
-  if C10_LIKELY (VK_NULL_HANDLE == handle_) {
+  if (VK_NULL_HANDLE == handle_) {
     return;
   }
   vkDestroyDevice(handle_, nullptr);
@@ -287,7 +285,7 @@ Adapter::Queue Adapter::request_queue() {
 
   uint32_t min_usage = UINT32_MAX;
   uint32_t min_used_i = 0;
-  for (const uint32_t i : c10::irange(queues_.size())) {
+  for (size_t i = 0; i < queues_.size(); ++i) {
     if (queue_usage_[i] < min_usage) {
       min_used_i = i;
       min_usage = queue_usage_[i];
@@ -299,7 +297,7 @@ Adapter::Queue Adapter::request_queue() {
 }
 
 void Adapter::return_queue(Adapter::Queue& compute_queue) {
-  for (const uint32_t i : c10::irange(queues_.size())) {
+  for (size_t i = 0; i < queues_.size(); ++i) {
     if ((queues_[i].family_index == compute_queue.family_index) &&
         (queues_[i].queue_index == compute_queue.queue_index)) {
       std::lock_guard<std::mutex> lock(queue_usage_mutex_);
@@ -395,7 +393,7 @@ std::string Adapter::stringize() const {
 
   ss << "  Memory Info {" << std::endl;
   ss << "    Memory Types [" << std::endl;
-  for (const auto i : c10::irange(mem_props.memoryTypeCount)) {
+  for (size_t i = 0; i < mem_props.memoryTypeCount; ++i) {
     ss << "      "
        << " [Heap " << mem_props.memoryTypes[i].heapIndex << "] "
        << get_memory_properties_str(mem_props.memoryTypes[i].propertyFlags)
@@ -403,7 +401,7 @@ std::string Adapter::stringize() const {
   }
   ss << "    ]" << std::endl;
   ss << "    Memory Heaps [" << std::endl;
-  for (const auto i : c10::irange(mem_props.memoryHeapCount)) {
+  for (size_t i = 0; i < mem_props.memoryHeapCount; ++i) {
     ss << "      " << mem_props.memoryHeaps[i].size << std::endl;
   }
   ss << "    ]" << std::endl;

--- a/aten/src/ATen/native/vulkan/api/Command.cpp
+++ b/aten/src/ATen/native/vulkan/api/Command.cpp
@@ -125,13 +125,15 @@ void CommandBuffer::insert_barrier(const PipelineBarrier& pipeline_barrier) {
       "is not DESCRIPTORS_BOUND or RECORDING.");
 
   if (pipeline_barrier) {
-    c10::SmallVector<VkBufferMemoryBarrier, 4u> buffer_memory_barriers;
+    std::vector<VkBufferMemoryBarrier> buffer_memory_barriers;
+    buffer_memory_barriers.reserve(pipeline_barrier.buffers.size());
     for (const api::BufferMemoryBarrier& memory_barrier :
          pipeline_barrier.buffers) {
       buffer_memory_barriers.push_back(memory_barrier.handle);
     }
 
-    c10::SmallVector<VkImageMemoryBarrier, 4u> image_memory_barriers;
+    std::vector<VkImageMemoryBarrier> image_memory_barriers;
+    image_memory_barriers.reserve(pipeline_barrier.images.size());
     for (const api::ImageMemoryBarrier& memory_barrier :
          pipeline_barrier.images) {
       image_memory_barriers.push_back(memory_barrier.handle);

--- a/aten/src/ATen/native/vulkan/api/Command.h
+++ b/aten/src/ATen/native/vulkan/api/Command.h
@@ -9,7 +9,6 @@
 #include <ATen/native/vulkan/api/Pipeline.h>
 #include <ATen/native/vulkan/api/Resource.h>
 #include <ATen/native/vulkan/api/Shader.h>
-#include <c10/util/ArrayRef.h>
 
 namespace at {
 namespace native {

--- a/aten/src/ATen/native/vulkan/api/Context.h
+++ b/aten/src/ATen/native/vulkan/api/Context.h
@@ -300,7 +300,7 @@ inline void arg_is_empty(bool& any_is_empty, const VulkanImage& image) {
 template <typename... Arguments>
 inline bool any_arg_is_empty(Arguments&&... arguments) {
   bool any_is_empty = false;
-  C10_UNUSED const int _[]{
+  const int _[]{
       0,
       (arg_is_empty(any_is_empty, std::forward<Arguments>(arguments)), 0)...,
   };
@@ -313,7 +313,7 @@ inline void bind(
     DescriptorSet& descriptor_set,
     const std::index_sequence<Indices...>&,
     Arguments&&... arguments) {
-  C10_UNUSED const int _[]{
+  const int _[]{
       0,
       (descriptor_set.bind(Indices, std::forward<Arguments>(arguments)), 0)...,
   };

--- a/aten/src/ATen/native/vulkan/api/Descriptor.cpp
+++ b/aten/src/ATen/native/vulkan/api/Descriptor.cpp
@@ -76,7 +76,7 @@ DescriptorSet& DescriptorSet::bind(
 }
 
 VkDescriptorSet DescriptorSet::get_bind_handle() const {
-  c10::SmallVector<VkWriteDescriptorSet, 6u> write_descriptor_sets;
+  std::vector<VkWriteDescriptorSet> write_descriptor_sets;
 
   for (const ResourceBinding& binding : bindings_) {
     VkWriteDescriptorSet write{
@@ -194,7 +194,7 @@ DescriptorPool::DescriptorPool(
       config_(config),
       mutex_{},
       piles_{} {
-  c10::SmallVector<VkDescriptorPoolSize, 4u> type_sizes{
+  std::vector<VkDescriptorPoolSize> type_sizes{
       {
           VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
           config_.descriptorUniformBufferCount,

--- a/aten/src/ATen/native/vulkan/api/Descriptor.h
+++ b/aten/src/ATen/native/vulkan/api/Descriptor.h
@@ -41,7 +41,7 @@ class DescriptorSet final {
   VkDevice device_;
   VkDescriptorSet handle_;
   ShaderLayout::Signature shader_layout_signature_;
-  c10::SmallVector<ResourceBinding, 6u> bindings_;
+  std::vector<ResourceBinding> bindings_;
 
  public:
   DescriptorSet& bind(const uint32_t, const VulkanBuffer&);

--- a/aten/src/ATen/native/vulkan/api/Pipeline.cpp
+++ b/aten/src/ATen/native/vulkan/api/Pipeline.cpp
@@ -125,7 +125,7 @@ PipelineLayout::PipelineLayout(PipelineLayout&& other) noexcept
 }
 
 PipelineLayout::~PipelineLayout() {
-  if C10_LIKELY (VK_NULL_HANDLE == handle_) {
+  if (VK_NULL_HANDLE == handle_) {
     return;
   }
   vkDestroyPipelineLayout(device_, handle_, nullptr);
@@ -216,7 +216,7 @@ ComputePipeline::ComputePipeline(ComputePipeline&& other) noexcept
 }
 
 ComputePipeline::~ComputePipeline() {
-  if C10_LIKELY (VK_NULL_HANDLE == handle_) {
+  if (VK_NULL_HANDLE == handle_) {
     return;
   }
   vkDestroyPipeline(device_, handle_, nullptr);
@@ -264,7 +264,7 @@ VkPipelineLayout PipelineLayoutCache::retrieve(
   std::lock_guard<std::mutex> lock(cache_mutex_);
 
   auto it = cache_.find(key);
-  if C10_UNLIKELY (cache_.cend() == it) {
+  if (cache_.cend() == it) {
     it = cache_.insert({key, PipelineLayoutCache::Value(device_, key)}).first;
   }
 
@@ -311,7 +311,7 @@ ComputePipelineCache::ComputePipelineCache(
 ComputePipelineCache::~ComputePipelineCache() {
   purge();
 
-  if C10_LIKELY (VK_NULL_HANDLE == pipeline_cache_) {
+  if (VK_NULL_HANDLE == pipeline_cache_) {
     return;
   }
   vkDestroyPipelineCache(device_, pipeline_cache_, nullptr);
@@ -323,7 +323,7 @@ VkPipeline ComputePipelineCache::retrieve(
   std::lock_guard<std::mutex> lock(cache_mutex_);
 
   auto it = cache_.find(key);
-  if C10_UNLIKELY (cache_.cend() == it) {
+  if (cache_.cend() == it) {
     it = cache_
              .insert(
                  {key,

--- a/aten/src/ATen/native/vulkan/api/Pipeline.h
+++ b/aten/src/ATen/native/vulkan/api/Pipeline.h
@@ -7,7 +7,6 @@
 #include <ATen/native/vulkan/api/Common.h>
 #include <ATen/native/vulkan/api/Resource.h>
 #include <ATen/native/vulkan/api/Shader.h>
-#include <c10/util/SmallVector.h>
 #include <c10/util/flat_hash_map.h>
 
 #include <mutex>
@@ -23,8 +22,8 @@ struct PipelineBarrier final {
     VkPipelineStageFlags dst;
   } stage;
 
-  c10::SmallVector<BufferMemoryBarrier, 4u> buffers;
-  c10::SmallVector<ImageMemoryBarrier, 4u> images;
+  std::vector<BufferMemoryBarrier> buffers;
+  std::vector<ImageMemoryBarrier> images;
 
   inline operator bool() const {
     return (0u != stage.src) || (0u != stage.dst) || !buffers.empty() ||

--- a/aten/src/ATen/native/vulkan/api/Resource.cpp
+++ b/aten/src/ATen/native/vulkan/api/Resource.cpp
@@ -203,7 +203,7 @@ MemoryMap::MemoryMap(MemoryMap&& other) noexcept
 }
 
 MemoryMap::~MemoryMap() {
-  if (C10_UNLIKELY(!data_)) {
+  if (!data_) {
     return;
   }
 
@@ -296,7 +296,7 @@ ImageSampler::ImageSampler(ImageSampler&& other) noexcept
 }
 
 ImageSampler::~ImageSampler() {
-  if C10_LIKELY (VK_NULL_HANDLE == handle_) {
+  if (VK_NULL_HANDLE == handle_) {
     return;
   }
   vkDestroySampler(device_, handle_, nullptr);
@@ -533,7 +533,7 @@ VkSampler SamplerCache::retrieve(const SamplerCache::Key& key) {
   std::lock_guard<std::mutex> lock(cache_mutex_);
 
   auto it = cache_.find(key);
-  if C10_UNLIKELY (cache_.cend() == it) {
+  if (cache_.cend() == it) {
     it = cache_.insert({key, SamplerCache::Value(device_, key)}).first;
   }
 
@@ -590,7 +590,7 @@ MemoryAllocator::MemoryAllocator(MemoryAllocator&& other) noexcept
 }
 
 MemoryAllocator::~MemoryAllocator() {
-  if C10_LIKELY (VK_NULL_HANDLE == allocator_) {
+  if (VK_NULL_HANDLE == allocator_) {
     return;
   }
   vmaDestroyAllocator(allocator_);
@@ -739,7 +739,7 @@ VulkanFence& VulkanFence::operator=(VulkanFence&& other) noexcept {
 }
 
 VulkanFence::~VulkanFence() {
-  if C10_LIKELY (VK_NULL_HANDLE == handle_) {
+  if (VK_NULL_HANDLE == handle_) {
     return;
   }
   vkDestroyFence(device_, handle_, nullptr);

--- a/aten/src/ATen/native/vulkan/api/Runtime.cpp
+++ b/aten/src/ATen/native/vulkan/api/Runtime.cpp
@@ -1,9 +1,8 @@
+#include <iostream>
+#include <sstream>
+
 #include <ATen/native/vulkan/api/Adapter.h>
 #include <ATen/native/vulkan/api/Runtime.h>
-#include <c10/util/Logging.h>
-#include <c10/util/irange.h>
-
-#include <sstream>
 
 namespace at {
 namespace native {
@@ -139,21 +138,13 @@ VKAPI_ATTR VkBool32 VKAPI_CALL debug_report_callback_fn(
     const char* const layer_prefix,
     const char* const message,
     void* const /* user_data */) {
+  (void)flags;
+
   std::stringstream stream;
   stream << layer_prefix << " " << message_code << " " << message << std::endl;
   const std::string log = stream.str();
 
-  if (flags & VK_DEBUG_REPORT_ERROR_BIT_EXT) {
-    LOG(ERROR) << log;
-  } else if (flags & VK_DEBUG_REPORT_WARNING_BIT_EXT) {
-    LOG(WARNING) << log;
-  } else if (flags & VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT) {
-    LOG(WARNING) << "Performance:" << log;
-  } else if (flags & VK_DEBUG_REPORT_INFORMATION_BIT_EXT) {
-    LOG(INFO) << log;
-  } else if (flags & VK_DEBUG_REPORT_DEBUG_BIT_EXT) {
-    LOG(INFO) << "Debug: " << log;
-  }
+  std::cout << log;
 
   return VK_FALSE;
 }
@@ -208,7 +199,7 @@ uint32_t select_first(const std::vector<Runtime::DeviceMapping>& devices) {
   }
 
   // Select the first adapter that has compute capability
-  for (const uint32_t i : c10::irange(devices.size())) {
+  for (size_t i = 0; i < devices.size(); ++i) {
     if (devices[i].first.num_compute_queues > 0) {
       return i;
     }
@@ -313,7 +304,7 @@ Runtime::Runtime(const RuntimeConfiguration config)
 }
 
 Runtime::~Runtime() {
-  if C10_LIKELY (VK_NULL_HANDLE == instance_) {
+  if (VK_NULL_HANDLE == instance_) {
     return;
   }
 

--- a/aten/src/ATen/native/vulkan/api/Shader.cpp
+++ b/aten/src/ATen/native/vulkan/api/Shader.cpp
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include <ATen/native/vulkan/api/Shader.h>
 
 namespace at {
@@ -19,19 +21,19 @@ ShaderInfo::ShaderInfo(
     std::string name,
     const uint32_t* const spirv_bin,
     const uint32_t size,
-    const std::vector<VkDescriptorType>& layout)
+    std::vector<VkDescriptorType>  layout)
     : src_code{
           spirv_bin,
           size,
       },
       kernel_name{std::move(name)},
-      kernel_layout{layout} {}
+      kernel_layout{std::move(layout)} {}
 
 ShaderInfo::ShaderInfo(
     std::string name,
     const uint32_t* const spirv_bin,
     const uint32_t size,
-    const std::vector<VkDescriptorType>& layout,
+    std::vector<VkDescriptorType>  layout,
     const std::vector<uint32_t>& tile_size,
     const StorageType bias_storage_type,
     const StorageType weight_storage_type)
@@ -40,7 +42,7 @@ ShaderInfo::ShaderInfo(
           size,
       },
       kernel_name{std::move(name)},
-      kernel_layout{layout},
+      kernel_layout{std::move(layout)},
       tile_size(tile_size),
       bias_storage_type(bias_storage_type),
       weight_storage_type(weight_storage_type) {
@@ -63,7 +65,7 @@ ShaderLayout::ShaderLayout(
     VkDevice device,
     const ShaderLayout::Signature& signature)
     : device_(device), handle_{VK_NULL_HANDLE} {
-  c10::SmallVector<VkDescriptorSetLayoutBinding, 6u> bindings;
+  std::vector<VkDescriptorSetLayoutBinding> bindings;
 
   uint32_t binding_num = 0u;
   for (const VkDescriptorType type : signature) {
@@ -94,7 +96,7 @@ ShaderLayout::ShaderLayout(ShaderLayout&& other) noexcept
 }
 
 ShaderLayout::~ShaderLayout() {
-  if C10_LIKELY (VK_NULL_HANDLE == handle_) {
+  if (VK_NULL_HANDLE == handle_) {
     return;
   }
   vkDestroyDescriptorSetLayout(device_, handle_, nullptr);
@@ -139,7 +141,7 @@ ShaderModule::ShaderModule(ShaderModule&& other) noexcept
 }
 
 ShaderModule::~ShaderModule() {
-  if C10_LIKELY (VK_NULL_HANDLE == handle_) {
+  if (VK_NULL_HANDLE == handle_) {
     return;
   }
   vkDestroyShaderModule(device_, handle_, nullptr);
@@ -178,7 +180,7 @@ VkDescriptorSetLayout ShaderLayoutCache::retrieve(
   std::lock_guard<std::mutex> lock(cache_mutex_);
 
   auto it = cache_.find(key);
-  if C10_UNLIKELY (cache_.cend() == it) {
+  if (cache_.cend() == it) {
     it = cache_.insert({key, ShaderLayoutCache::Value(device_, key)}).first;
   }
 
@@ -210,7 +212,7 @@ VkShaderModule ShaderCache::retrieve(const ShaderCache::Key& key) {
   std::lock_guard<std::mutex> lock(cache_mutex_);
 
   auto it = cache_.find(key);
-  if C10_UNLIKELY (cache_.cend() == it) {
+  if (cache_.cend() == it) {
     it = cache_.insert({key, ShaderCache::Value(device_, key)}).first;
   }
 

--- a/aten/src/ATen/native/vulkan/api/Shader.h
+++ b/aten/src/ATen/native/vulkan/api/Shader.h
@@ -19,7 +19,7 @@ namespace api {
 
 class ShaderLayout final {
  public:
-  using Signature = c10::SmallVector<VkDescriptorType, 6u>;
+  using Signature = std::vector<VkDescriptorType>;
 
   explicit ShaderLayout(VkDevice, const Signature&);
 
@@ -58,7 +58,7 @@ struct ShaderInfo final {
   // Shader Metadata
   utils::uvec3 out_tile_size{1u, 1u, 1u};
 
-  c10::SmallVector<uint32_t, 4> tile_size;
+  std::vector<uint32_t> tile_size;
   StorageType bias_storage_type{StorageType::UNKNOWN};
   StorageType weight_storage_type{StorageType::UNKNOWN};
 
@@ -68,12 +68,12 @@ struct ShaderInfo final {
       std::string,
       const uint32_t*,
       const uint32_t,
-      const std::vector<VkDescriptorType>&);
+      std::vector<VkDescriptorType>);
   explicit ShaderInfo(
       std::string,
       const uint32_t*,
       const uint32_t,
-      const std::vector<VkDescriptorType>&,
+      std::vector<VkDescriptorType>,
       const std::vector<uint32_t>& tile_size,
       const StorageType bias_storage_type,
       const StorageType weight_storage_type);

--- a/aten/src/ATen/native/vulkan/api/Tensor.h
+++ b/aten/src/ATen/native/vulkan/api/Tensor.h
@@ -6,7 +6,6 @@
 
 #include <ATen/native/vulkan/api/Context.h>
 #include <c10/core/MemoryFormat.h>
-#include <c10/util/accumulate.h>
 
 namespace at {
 namespace native {
@@ -148,13 +147,13 @@ class vTensor final {
   api::GPUMemoryLayout memory_layout_;
 
   // Sizes and Strides
-  c10::SmallVector<int64_t, 6u> sizes_;
-  c10::SmallVector<int64_t, 6u> strides_;
+  std::vector<int64_t> sizes_;
+  std::vector<int64_t> strides_;
 
   // Storage Dimensions. When stored on the GPU, one dimension will be aligned
   // to the next multiple of 4 in order to take advantage of vec4 data types.
-  c10::SmallVector<int64_t, 6u> gpu_sizes_;
-  c10::SmallVector<int64_t, 6u> gpu_strides_;
+  std::vector<int64_t> gpu_sizes_;
+  std::vector<int64_t> gpu_strides_;
 
   // A Vulkan uniform buffer containing sizes and strides of the GPU buffer that
   // can be passed into a shader.
@@ -303,7 +302,7 @@ class vTensor final {
   }
 
   inline size_t numel() const {
-    return c10::multiply_integers(sizes());
+    return api::utils::multiply_integers(sizes());
   }
 
   inline size_t nbytes() const {

--- a/aten/src/ATen/native/vulkan/api/Utils.h
+++ b/aten/src/ATen/native/vulkan/api/Utils.h
@@ -4,6 +4,7 @@
 #include <c10/util/Half.h> // For c10::overflows
 
 #include <ATen/native/vulkan/api/Common.h>
+#include <numeric>
 
 #ifdef USE_VULKAN_API
 
@@ -182,6 +183,22 @@ inline uvec4 make_nchw_uvec4(const IntArrayRef arr) {
   uint32_t n = val_at(-4, arr);
 
   return {w, h, c, n};
+}
+
+/*
+ * Wrapper around std::accumulate that accumulates values of a container of
+ * integral types into int64_t. Taken from `multiply_integers` in
+ * <c10/util/accumulate.h>
+ */
+template <
+    typename C,
+    std::enable_if_t<std::is_integral_v<typename C::value_type>, int> = 0>
+inline int64_t multiply_integers(const C& container) {
+  return std::accumulate(
+      container.begin(),
+      container.end(),
+      static_cast<int64_t>(1),
+      std::multiplies<>());
 }
 
 } // namespace utils

--- a/aten/src/ATen/native/vulkan/graph/Arithmetic.cpp
+++ b/aten/src/ATen/native/vulkan/graph/Arithmetic.cpp
@@ -65,7 +65,7 @@ void ArithmeticPrepack::encode_prepack(ComputeGraph* graph) const {
   api::StorageBuffer staging(
       graph->context(), packed.dtype(), packed.gpu_nbytes());
 
-  size_t numel = c10::multiply_integers(tref.sizes);
+  size_t numel = api::utils::multiply_integers(tref.sizes);
   size_t nbytes = numel * c10::elementSize(tref.dtype);
   copy_ptr_to_staging(tref.data, staging, nbytes);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

## Context

This change is part of a set of changes that removes all references to the `c10` library in the `api/`, `graph/`, and `impl/` folders of the PyTorch Vulkan codebase. This is to ensure that these components can be built as a standalone library such that they can be used as the foundations of a Android GPU delegate for ExecuTorch.

## Notes for Reviewers

This changeset deprecates various easy-to-replace symbols from the `c10` library with either C++ STL equivalents or by using copying those `c10` symbols as native equivalents. The symbols that were impacted are:

* `c10::irange`
  * removed and replaced with standard for loops
* `C10_LIKELY` and `C10_UNLIKELY`
  * These macros allow for some branch re-ordering compiler optimizations when building with GCC. They aren't strictly necessary and their impact is likely minimal so these have simply been removed.
* `c10::SmallVector<T, N>`
  * My understanding is that `c10::SmallVector<T, N>` is essentially a wrapper around `std::vector<T>` that is optimized for array sizes up to `N`. I don't believe that this optimization is worth creating a native equivalent, so I replaced instances this symbol with replaced with `std::vector<T>`
* `c10::multiply_integers`
  * This function is simply a convenient wrapper around `std::accumulate`, so I copied it as a native equivalent in `api/Utils.h`

This changeset comprises entirely of the replacements described above.

Differential Revision: [D52662232](https://our.internmc.facebook.com/intern/diff/D52662232/)