### PR TITLE
[pt-vulkan] Replace `c10::ScalarType` with native equivalent

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Adapter.cpp
+++ b/aten/src/ATen/native/vulkan/api/Adapter.cpp
@@ -1,6 +1,7 @@
 #include <ATen/native/vulkan/api/Adapter.h>
 
 #include <bitset>
+#include <cstring>
 #include <iomanip>
 #include <sstream>
 #include <utility>

--- a/aten/src/ATen/native/vulkan/api/Context.cpp
+++ b/aten/src/ATen/native/vulkan/api/Context.cpp
@@ -1,5 +1,7 @@
 #include <ATen/native/vulkan/api/Context.h>
 
+#include <cstring>
+#include <memory>
 #include <sstream>
 
 namespace at {

--- a/aten/src/ATen/native/vulkan/api/Context.h
+++ b/aten/src/ATen/native/vulkan/api/Context.h
@@ -238,21 +238,21 @@ class UniformParamsBuffer final {
 class StorageBuffer final {
  private:
   Context* context_p_;
-  c10::ScalarType dtype_;
+  ScalarType dtype_;
   size_t numel_;
   VulkanBuffer vulkan_buffer_;
 
  public:
   StorageBuffer(
       Context* context_p,
-      const c10::ScalarType dtype,
+      const ScalarType dtype,
       const size_t numel,
       const bool gpuonly = false)
       : context_p_(context_p),
         dtype_(dtype),
         numel_(numel),
         vulkan_buffer_(context_p_->adapter_ptr()->vma().create_storage_buffer(
-            c10::elementSize(dtype_) * numel_,
+            element_size(dtype_) * numel_,
             gpuonly)) {}
 
   StorageBuffer(const StorageBuffer&) = delete;
@@ -265,7 +265,7 @@ class StorageBuffer final {
     context_p_->register_buffer_cleanup(vulkan_buffer_);
   }
 
-  inline c10::ScalarType dtype() {
+  inline ScalarType dtype() {
     return dtype_;
   }
 

--- a/aten/src/ATen/native/vulkan/api/QueryPool.h
+++ b/aten/src/ATen/native/vulkan/api/QueryPool.h
@@ -2,6 +2,7 @@
 
 // @lint-ignore-every CLANGTIDY facebook-hte-BadMemberName
 
+#include <functional>
 #ifdef USE_VULKAN_API
 
 #include <ATen/native/vulkan/api/Adapter.h>

--- a/aten/src/ATen/native/vulkan/api/Resource.cpp
+++ b/aten/src/ATen/native/vulkan/api/Resource.cpp
@@ -1,71 +1,10 @@
 #include <ATen/native/vulkan/api/Adapter.h>
 #include <ATen/native/vulkan/api/Resource.h>
 
-#include <c10/core/ScalarTypeToTypeMeta.h>
-
 namespace at {
 namespace native {
 namespace vulkan {
 namespace api {
-
-//
-// Utility Functions
-//
-
-/*
- * This function is used to determine what image format to use for a given
- * dtype.
- *
- * TODO: enable proper format selection between kFloat and kHalf.
- *
- * Context: due to limitations of the shader compilation system, at the moment
- * it is not possible to support both 32 bit and 16 bit float formats since
- * shaders will have to specify the format qualifier of texture inputs. Right
- * now, shaders are compiled with either rgba16f or rgba32f qualifiers depending
- * on whether USE_VULKAN_FP16_INFERENCE is set. Therefore, textures must be
- * always created with the corresponding VkFormat. Consequently, kHalf tensors
- * are currently unsupported in favor of enforcing inputs to be of kFloat dtype.
- */
-VkFormat vk_format(const at::ScalarType dtype) {
-  switch (dtype) {
-    case c10::kBool:
-      return VK_FORMAT_R8G8B8A8_SINT;
-    case kFloat:
-#ifdef USE_VULKAN_FP16_INFERENCE
-      return VK_FORMAT_R16G16B16A16_SFLOAT;
-#else
-      return VK_FORMAT_R32G32B32A32_SFLOAT;
-#endif /* USE_VULKAN_FP16_INFERENCE */
-    case c10::kQUInt8:
-      return VK_FORMAT_R8G8B8A8_UINT;
-    case c10::kQInt8:
-      return VK_FORMAT_R8G8B8A8_SINT;
-    case c10::kQInt32:
-      return VK_FORMAT_R32G32B32A32_SINT;
-
-    default:
-      VK_THROW("No corresponding image format for dtype ", dtype);
-  }
-}
-
-/*
- * This function is used to map a texture format to a corresponding
- * c10::ScalarType. It is primarily used to set the data type of a
- * StorageBuffer object that will receive copied data from a texture.
- */
-c10::ScalarType c10_scalartype(const VkFormat image_format) {
-  switch (image_format) {
-    case VK_FORMAT_R32G32B32A32_SFLOAT:
-      return c10::kFloat;
-    case VK_FORMAT_R16G16B16A16_SFLOAT:
-      return c10::kHalf;
-    case VK_FORMAT_R8G8B8A8_UINT:
-      return c10::kQUInt8;
-
-    default:
-      VK_THROW("No corresponding scalar type for unknown VkFormat ");
-  }
-}
 
 //
 // MemoryBarrier

--- a/aten/src/ATen/native/vulkan/api/Resource.h
+++ b/aten/src/ATen/native/vulkan/api/Resource.h
@@ -5,11 +5,10 @@
 #ifdef USE_VULKAN_API
 
 #include <ATen/native/vulkan/api/Allocator.h>
+#include <ATen/native/vulkan/api/Types.h>
 #include <ATen/native/vulkan/api/Utils.h>
 
-#include <c10/core/ScalarType.h>
-#include <c10/util/typeid.h>
-
+#include <mutex>
 #include <stack>
 #include <unordered_map>
 
@@ -19,10 +18,6 @@ namespace vulkan {
 namespace api {
 
 using MemoryAccessFlags = uint8_t;
-
-VkFormat vk_format(const at::ScalarType dtype);
-
-c10::ScalarType c10_scalartype(const VkFormat image_format);
 
 constexpr VmaAllocationCreateFlags DEFAULT_ALLOCATION_STRATEGY =
     VMA_ALLOCATION_CREATE_STRATEGY_MIN_MEMORY_BIT;

--- a/aten/src/ATen/native/vulkan/api/Runtime.cpp
+++ b/aten/src/ATen/native/vulkan/api/Runtime.cpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #include <iostream>
 #include <sstream>
 

--- a/aten/src/ATen/native/vulkan/api/Runtime.h
+++ b/aten/src/ATen/native/vulkan/api/Runtime.h
@@ -2,6 +2,8 @@
 
 // @lint-ignore-every CLANGTIDY facebook-hte-BadMemberName
 
+#include <functional>
+#include <memory>
 #ifdef USE_VULKAN_API
 
 #include <ATen/native/vulkan/api/Adapter.h>

--- a/aten/src/ATen/native/vulkan/api/Tensor.cpp
+++ b/aten/src/ATen/native/vulkan/api/Tensor.cpp
@@ -366,7 +366,7 @@ api::UniformParamsBuffer make_metadata_uniform(
 vTensor::vTensor(
     api::Context* const context,
     const std::vector<int64_t>& sizes,
-    const c10::ScalarType dtype,
+    const api::ScalarType dtype,
     const api::StorageType storage_type,
     const api::GPUMemoryLayout memory_layout)
     : dtype_(dtype),
@@ -395,7 +395,7 @@ vTensor::vTensor(
     const std::vector<int64_t>& sizes,
     double q_scale,
     int64_t q_zero_point,
-    const c10::ScalarType dtype,
+    const api::ScalarType dtype,
     const api::StorageType storage_type,
     const api::GPUMemoryLayout memory_layout)
     : dtype_(dtype),
@@ -426,7 +426,7 @@ vTensor::vTensor(
 vTensor::vTensor(
     api::Context* const context,
     const std::vector<int64_t>& sizes,
-    const c10::ScalarType dtype,
+    const api::ScalarType dtype,
     const api::StorageType storage_type,
     const c10::MemoryFormat memory_format)
     : vTensor(
@@ -441,7 +441,7 @@ vTensor::vTensor(
     const std::vector<int64_t>& sizes,
     double q_scale,
     int64_t q_zero_point,
-    const c10::ScalarType dtype,
+    const api::ScalarType dtype,
     const api::StorageType storage_type,
     const c10::MemoryFormat memory_format)
     : vTensor(
@@ -544,7 +544,7 @@ api::VulkanBuffer allocate_buffer(
     api::Context* const context_ptr,
     const int64_t numel,
     const api::StorageType storage_type,
-    const c10::ScalarType dtype) {
+    const api::ScalarType dtype) {
   api::Adapter* adapter_ptr = context_ptr->adapter_ptr();
 
   switch (storage_type) {
@@ -556,7 +556,7 @@ api::VulkanBuffer allocate_buffer(
   }
 
   return adapter_ptr->vma().create_storage_buffer(
-      c10::elementSize(dtype) * numel, true);
+      api::element_size(dtype) * numel, true);
 }
 
 vTensorStorage::vTensorStorage(
@@ -564,7 +564,7 @@ vTensorStorage::vTensorStorage(
     const api::StorageType storage_type,
     const api::GPUMemoryLayout gpu_memory_layout,
     const std::vector<int64_t>& gpu_sizes,
-    const at::ScalarType dtype)
+    const api::ScalarType dtype)
     : context_(context),
       storage_type_{storage_type},
       extents_(
@@ -574,7 +574,7 @@ vTensorStorage::vTensorStorage(
           context_,
           extents_,
           storage_type_,
-          api::vk_format(dtype))),
+          api::to_vkformat(dtype))),
       buffer_(allocate_buffer(context_, buffer_length_, storage_type_, dtype)),
       last_access_{} {}
 

--- a/aten/src/ATen/native/vulkan/api/Tensor.h
+++ b/aten/src/ATen/native/vulkan/api/Tensor.h
@@ -5,6 +5,7 @@
 #ifdef USE_VULKAN_API
 
 #include <ATen/native/vulkan/api/Context.h>
+#include <ATen/native/vulkan/api/Types.h>
 #include <c10/core/MemoryFormat.h>
 
 namespace at {
@@ -35,7 +36,7 @@ class vTensorStorage final {
       const api::StorageType storage_type,
       const api::GPUMemoryLayout gpu_memory_layout,
       const std::vector<int64_t>& sizes,
-      const at::ScalarType dtype);
+      const api::ScalarType dtype);
 
   vTensorStorage(const vTensorStorage&) = delete;
   vTensorStorage& operator=(const vTensorStorage&) = delete;
@@ -89,7 +90,7 @@ class vTensor final {
   vTensor(
       api::Context* context,
       const std::vector<int64_t>& sizes,
-      const c10::ScalarType dtype,
+      const api::ScalarType dtype,
       const api::StorageType storage_type,
       const api::GPUMemoryLayout memory_layout);
 
@@ -99,7 +100,7 @@ class vTensor final {
       const std::vector<int64_t>& sizes,
       double q_scale,
       int64_t q_zero_point,
-      const c10::ScalarType dtype,
+      const api::ScalarType dtype,
       const api::StorageType storage_type,
       const api::GPUMemoryLayout memory_layout);
 
@@ -107,7 +108,7 @@ class vTensor final {
   vTensor(
       api::Context* context,
       const std::vector<int64_t>& sizes,
-      const c10::ScalarType dtype = c10::kFloat,
+      const api::ScalarType dtype = api::kFloat,
       const api::StorageType storage_type = api::StorageType::TEXTURE_3D,
       const c10::MemoryFormat memory_format = c10::MemoryFormat::Contiguous);
 
@@ -117,7 +118,7 @@ class vTensor final {
       const std::vector<int64_t>& sizes,
       double q_scale,
       int64_t q_zero_point,
-      const c10::ScalarType dtype = c10::kQUInt8,
+      const api::ScalarType dtype = api::kQUInt8,
       const api::StorageType storage_type = api::StorageType::TEXTURE_3D,
       const c10::MemoryFormat memory_format = c10::MemoryFormat::Contiguous);
 
@@ -141,7 +142,7 @@ class vTensor final {
 
  private:
   // Tensor Options
-  c10::ScalarType dtype_;
+  api::ScalarType dtype_;
 
   // GPU specific memory layout qualifier
   api::GPUMemoryLayout memory_layout_;
@@ -218,17 +219,18 @@ class vTensor final {
   }
 
   /*
-   * Extract a ScalarType from the TensorOptions member
+   * Extract an `api::ScalarType` from the TensorOptions member
    */
-  inline c10::ScalarType dtype() const {
+  inline api::ScalarType dtype() const {
     return dtype_;
   }
 
   /*
-   * Get a c10::ScalarType that corresponds to the image format of the texture
+   * Get an `api::ScalarType` that corresponds to the image format of the
+   * texture
    */
-  inline c10::ScalarType texture_dtype() const {
-    return api::c10_scalartype(view_->texture_format());
+  inline api::ScalarType texture_dtype() const {
+    return api::element_scalartype(view_->texture_format());
   }
 
   inline api::GPUMemoryLayout gpu_memory_layout() const {
@@ -306,7 +308,7 @@ class vTensor final {
   }
 
   inline size_t nbytes() const {
-    return c10::elementSize(dtype()) * numel();
+    return api::element_size(dtype()) * numel();
   }
 
   /*
@@ -320,7 +322,7 @@ class vTensor final {
    * Return nbytes but bnased on gpu_sizes_ instead of sizes_
    */
   inline VkDeviceSize gpu_nbytes() const {
-    return c10::elementSize(dtype()) * gpu_numel();
+    return api::element_size(dtype()) * gpu_numel();
   }
 };
 

--- a/aten/src/ATen/native/vulkan/api/Types.h
+++ b/aten/src/ATen/native/vulkan/api/Types.h
@@ -1,13 +1,151 @@
 #pragma once
 
+// @lint-ignore-every CLANGTIDY bugprone-branch-clone
+
 #ifdef USE_VULKAN_API
 
+#include <cstddef>
 #include <cstdint>
+
+#include <ATen/native/vulkan/api/Exception.h>
+
+#ifdef USE_VULKAN_FP16_INFERENCE
+#define VK_FORMAT_FLOAT4 VK_FORMAT_R16G16B16A16_SFLOAT
+#else
+#define VK_FORMAT_FLOAT4 VK_FORMAT_R32G32B32A32_SFLOAT
+#endif /* USE_VULKAN_FP16_INFERENCE */
+
+#define VK_FORALL_SCALAR_TYPES(_)                        \
+  _(uint8_t, VK_FORMAT_R8G8B8A8_UINT, Byte)              \
+  _(int8_t, VK_FORMAT_R8G8B8A8_SINT, Char)               \
+  _(int32_t, VK_FORMAT_R32G32B32A32_SINT, Int)           \
+  _(bool, VK_FORMAT_R8G8B8A8_SINT, Bool)                 \
+  _(unsigned short, VK_FORMAT_R16G16B16A16_SFLOAT, Half) \
+  _(float, VK_FORMAT_FLOAT4, Float)                      \
+  _(int8_t, VK_FORMAT_R8G8B8A8_SINT, QInt8)              \
+  _(uint8_t, VK_FORMAT_R8G8B8A8_UINT, QUInt8)            \
+  _(int32_t, VK_FORMAT_R32G32B32A32_SINT, QInt32)
 
 namespace at {
 namespace native {
 namespace vulkan {
 namespace api {
+
+//
+// Scalar Types
+//
+
+enum class ScalarType : int8_t {
+#define DEFINE_ENUM_VAL_(ctype, vkformat, name) name,
+  VK_FORALL_SCALAR_TYPES(DEFINE_ENUM_VAL_)
+#undef DEFINE_ENUM_VAL_
+      Undefined,
+  NumOptions
+};
+
+#define DEFINE_CONSTANT(ctype, vkformat, name) \
+  constexpr ScalarType k##name = ScalarType::name;
+
+VK_FORALL_SCALAR_TYPES(DEFINE_CONSTANT)
+#undef DEFINE_CONSTANT
+
+/*
+ * Given a `ScalarType`, return the corresponding `VkFormat` that should be used
+ * for image texture storage. The `ScalarType` to `VkFormat` mapping is dictated
+ * by the `VK_FORALL_SCALAR_TYPE` macro in `api/Types.h`
+ */
+inline VkFormat to_vkformat(const ScalarType t) {
+#define CASE_VK_FORMAT(ctype, vkformat, name) \
+  case ScalarType::name:                      \
+    return vkformat;
+
+  switch (t) {
+    VK_FORALL_SCALAR_TYPES(CASE_VK_FORMAT)
+    default:
+      VK_THROW("Unknown ScalarType");
+  }
+#undef CASE_VK_FORMAT
+}
+
+/*
+ * Given a `VkFormat`, return the `ScalarType` that best represents the data
+ * type of invidivual elements in an image texture of the `VkFormat`. Note that
+ * this mapping is different from the `to_vkformat()` function, since different
+ * `ScalarType`s may use the same `VkFormat`.
+ */
+inline ScalarType element_scalartype(const VkFormat vkformat) {
+  switch (vkformat) {
+    case VK_FORMAT_R8G8B8A8_SINT:
+      return kChar;
+    case VK_FORMAT_R8G8B8A8_UINT:
+      return kByte;
+    case VK_FORMAT_R32G32B32A32_SINT:
+      return kInt;
+    case VK_FORMAT_R32G32B32A32_SFLOAT:
+      return kFloat;
+    case VK_FORMAT_R16G16B16A16_SFLOAT:
+      return kHalf;
+    default:
+      VK_THROW("No corresponding scalar type for unknown VkFormat");
+  }
+}
+
+/*
+ * Given a ScalarType, return `sizeof(ctype)` where ctype is the C type
+ * corresponding to the ScalarType. The C type to ScalarType mapping is dictated
+ * by the VK_FORALL_SCALAR_TYPE macro in api/Types.h
+ */
+inline size_t element_size(const ScalarType t) {
+#define CASE_ELEMENTSIZE_CASE(ctype, vkformat, name) \
+  case ScalarType::name:                             \
+    return sizeof(ctype);
+
+  switch (t) {
+    VK_FORALL_SCALAR_TYPES(CASE_ELEMENTSIZE_CASE)
+    default:
+      VK_THROW("Unknown ScalarType");
+  }
+#undef CASE_ELEMENTSIZE_CASE
+}
+
+inline const char* to_string(const ScalarType t) {
+#define CASE_TO_STRING(ctype, vkformat, name) \
+  case ScalarType::name:                      \
+    return #name;
+
+  switch (t) {
+    VK_FORALL_SCALAR_TYPES(CASE_TO_STRING)
+    default:
+      return "UNKNOWN_SCALAR";
+  }
+#undef CASE_TO_STRING
+}
+
+inline std::ostream& operator<<(std::ostream& os, const ScalarType dtype) {
+  return os << to_string(dtype);
+}
+
+//
+// Map ScalarTypes to C++ types
+//
+
+template <ScalarType N>
+struct ScalarTypeToCType;
+
+#define SPECIALIZE_ScalarTypeToCType(ctype, vkformat, scalar_type) \
+  template <>                                                      \
+  struct ScalarTypeToCType<                                        \
+      ::at::native::vulkan::api::ScalarType::scalar_type> {        \
+    using type = ctype;                                            \
+  };
+
+VK_FORALL_SCALAR_TYPES(SPECIALIZE_ScalarTypeToCType)
+
+#undef SPECIALIZE_ScalarTypeToCPPType
+
+//
+// GPU Storage Options
+//
 
 /**
  * The enum below is used to describe what type of GPU memory will be used to

--- a/aten/src/ATen/native/vulkan/graph/Arithmetic.cpp
+++ b/aten/src/ATen/native/vulkan/graph/Arithmetic.cpp
@@ -44,7 +44,7 @@ ValueRef add_arithmetic_node(
     const float alpha,
     const arithmetic::OpType optype) {
   std::vector<int64_t> t1_sizes = graph.get_val_sizes(t1);
-  c10::ScalarType t1_dtype = graph.get_val_dtype(t1);
+  api::ScalarType t1_dtype = graph.get_val_dtype(t1);
 
   ValueRef out = graph.add_tensor(t1_sizes, t1_dtype);
   add_arithmetic_node(graph, t1, t2, out, alpha, optype);
@@ -66,7 +66,7 @@ void ArithmeticPrepack::encode_prepack(ComputeGraph* graph) const {
       graph->context(), packed.dtype(), packed.gpu_nbytes());
 
   size_t numel = api::utils::multiply_integers(tref.sizes);
-  size_t nbytes = numel * c10::elementSize(tref.dtype);
+  size_t nbytes = numel * api::element_size(tref.dtype);
   copy_ptr_to_staging(tref.data, staging, nbytes);
 
   encode_copy_to_vtensor(graph->context(), staging, packed);

--- a/aten/src/ATen/native/vulkan/graph/Constant.cpp
+++ b/aten/src/ATen/native/vulkan/graph/Constant.cpp
@@ -6,7 +6,7 @@ namespace vulkan {
 
 TensorRef::TensorRef(
     const std::vector<int64_t>& t_sizes,
-    c10::ScalarType t_dtype,
+    api::ScalarType t_dtype,
     const void* const t_data)
     : sizes{}, dtype{t_dtype}, data{t_data} {
   size_t ndim = t_sizes.size();

--- a/aten/src/ATen/native/vulkan/graph/Constant.h
+++ b/aten/src/ATen/native/vulkan/graph/Constant.h
@@ -15,12 +15,12 @@ namespace vulkan {
  */
 struct TensorRef final {
   std::vector<int64_t> sizes;
-  c10::ScalarType dtype;
+  api::ScalarType dtype;
   const void* data;
 
   explicit TensorRef(
       const std::vector<int64_t>& t_sizes,
-      c10::ScalarType t_dtype,
+      api::ScalarType t_dtype,
       const void* const t_data);
 
   TensorRef(const TensorRef&) = default;

--- a/aten/src/ATen/native/vulkan/graph/Copy.cpp
+++ b/aten/src/ATen/native/vulkan/graph/Copy.cpp
@@ -13,7 +13,7 @@ void add_copy_node(
 
 ValueRef add_copy_node(ComputeGraph& graph, const ValueRef from) {
   std::vector<int64_t> out_sizes = graph.get_val_sizes(from);
-  c10::ScalarType out_dtype = graph.get_val_dtype(from);
+  api::ScalarType out_dtype = graph.get_val_dtype(from);
   ValueRef to = graph.add_tensor(out_sizes, out_dtype);
   add_copy_node(graph, from, to);
   return to;

--- a/aten/src/ATen/native/vulkan/graph/Graph.cpp
+++ b/aten/src/ATen/native/vulkan/graph/Graph.cpp
@@ -29,7 +29,7 @@ ComputeGraph::~ComputeGraph() {
 
 ValueRef ComputeGraph::add_tensor(
     const std::vector<int64_t>& sizes,
-    const c10::ScalarType dtype) {
+    const api::ScalarType dtype) {
   ValueRef idx(static_cast<int>(values_.size()));
   values_.emplace_back(vTensor(context(), sizes, dtype));
   return idx;
@@ -37,7 +37,7 @@ ValueRef ComputeGraph::add_tensor(
 
 ValueRef ComputeGraph::add_tensorref(
     const std::vector<int64_t>& sizes,
-    const c10::ScalarType dtype,
+    const api::ScalarType dtype,
     const void* const data) {
   ValueRef idx(static_cast<int>(values_.size()));
   values_.emplace_back(TensorRef(sizes, dtype, data));
@@ -45,7 +45,7 @@ ValueRef ComputeGraph::add_tensorref(
 }
 
 ValueRef ComputeGraph::add_staging(
-    const c10::ScalarType dtype,
+    const api::ScalarType dtype,
     const size_t numel) {
   ValueRef idx(static_cast<int>(values_.size()));
   values_.emplace_back(api::StorageBuffer(context(), dtype, numel));
@@ -86,7 +86,7 @@ void ComputeGraph::copy_into_staging(
     const size_t numel) {
   Value& in_val = get_val(idx);
   api::StorageBuffer& staging = in_val.toStaging();
-  size_t nbytes = numel * c10::elementSize(staging.dtype());
+  size_t nbytes = numel * api::element_size(staging.dtype());
   copy_ptr_to_staging(data, staging, nbytes);
 }
 
@@ -96,7 +96,7 @@ void ComputeGraph::copy_from_staging(
     const size_t numel) {
   Value& out_val = get_val(idx);
   api::StorageBuffer& staging = out_val.toStaging();
-  size_t nbytes = numel * c10::elementSize(staging.dtype());
+  size_t nbytes = numel * api::element_size(staging.dtype());
   copy_staging_to_ptr(staging, data, nbytes);
 }
 

--- a/aten/src/ATen/native/vulkan/graph/Graph.h
+++ b/aten/src/ATen/native/vulkan/graph/Graph.h
@@ -6,6 +6,7 @@
 
 #include <ATen/native/vulkan/api/Context.h>
 #include <ATen/native/vulkan/api/Tensor.h>
+#include <ATen/native/vulkan/api/Types.h>
 
 #include <ATen/native/vulkan/graph/Config.h>
 #include <ATen/native/vulkan/graph/Value.h>
@@ -102,7 +103,7 @@ class ComputeGraph final {
     VK_THROW("Could not get sizes of value with type ", val.type());
   }
 
-  inline c10::ScalarType get_val_dtype(ValueRef idx) {
+  inline api::ScalarType get_val_dtype(ValueRef idx) {
     Value& val = get_val(idx);
     if (val.isTensor()) {
       return val.toTensor().dtype();
@@ -126,12 +127,12 @@ class ComputeGraph final {
 
   ValueRef add_tensor(
       const std::vector<int64_t>& sizes,
-      const c10::ScalarType dtype);
+      const api::ScalarType dtype);
   ValueRef add_tensorref(
       const std::vector<int64_t>& sizes,
-      const c10::ScalarType dtype,
+      const api::ScalarType dtype,
       const void* const data);
-  ValueRef add_staging(const c10::ScalarType dtype, const size_t numel);
+  ValueRef add_staging(const api::ScalarType dtype, const size_t numel);
 
   ValueRef set_input_tensor(const ValueRef idx, const bool use_staging = true);
   ValueRef set_output_tensor(const ValueRef idx, const bool use_staging = true);

--- a/aten/src/ATen/native/vulkan/graph/Staging.cpp
+++ b/aten/src/ATen/native/vulkan/graph/Staging.cpp
@@ -10,40 +10,36 @@ void memcpy_to_mapping(
     const void* src,
     api::MemoryMap& dst_mapping,
     const size_t nbytes,
-    const c10::ScalarType dtype) {
-  if (dtype == at::kFloat) {
-    memcpy_to_mapping_impl<float>(src, dst_mapping, nbytes);
-  } else if (dtype == at::kHalf) {
-    memcpy_to_mapping_impl<c10::Half>(src, dst_mapping, nbytes);
-  } else if (dtype == c10::kQUInt8) {
-    memcpy_to_mapping_impl<c10::quint8>(src, dst_mapping, nbytes);
-  } else if (dtype == c10::kQInt8) {
-    memcpy_to_mapping_impl<c10::qint8>(src, dst_mapping, nbytes);
-  } else if (dtype == c10::kQInt32) {
-    memcpy_to_mapping_impl<c10::qint32>(src, dst_mapping, nbytes);
-  } else {
-    VK_THROW("Unrecognized dtype!");
+    const api::ScalarType dtype) {
+#define DTYPE_CASE(ctype, vkformat, name)                    \
+  case api::ScalarType::name:                                \
+    memcpy_to_mapping_impl<ctype>(src, dst_mapping, nbytes); \
+    break;
+
+  switch (dtype) {
+    VK_FORALL_SCALAR_TYPES(DTYPE_CASE)
+    default:
+      VK_THROW("Unrecognized dtype!");
   }
+#undef DTYPE_CASE
 }
 
 void memcpy_from_mapping(
     api::MemoryMap& src_mapping,
     void* dst,
     const size_t nbytes,
-    const c10::ScalarType dtype) {
-  if (dtype == at::kFloat) {
-    memcpy_from_mapping_impl<float>(src_mapping, dst, nbytes);
-  } else if (dtype == at::kHalf) {
-    memcpy_from_mapping_impl<c10::Half>(src_mapping, dst, nbytes);
-  } else if (dtype == c10::kQUInt8) {
-    memcpy_from_mapping_impl<c10::quint8>(src_mapping, dst, nbytes);
-  } else if (dtype == c10::kQInt8) {
-    memcpy_from_mapping_impl<c10::qint8>(src_mapping, dst, nbytes);
-  } else if (dtype == c10::kQInt32) {
-    memcpy_from_mapping_impl<c10::qint32>(src_mapping, dst, nbytes);
-  } else {
-    VK_THROW("Unrecognized dtype!");
+    const api::ScalarType dtype) {
+#define DTYPE_CASE(ctype, vkformat, name)                      \
+  case api::ScalarType::name:                                  \
+    memcpy_from_mapping_impl<ctype>(src_mapping, dst, nbytes); \
+    break;
+
+  switch (dtype) {
+    VK_FORALL_SCALAR_TYPES(DTYPE_CASE)
+    default:
+      VK_THROW("Unrecognized dtype!");
   }
+#undef DTYPE_CASE
 }
 
 void copy_ptr_to_staging(

--- a/aten/src/ATen/native/vulkan/graph/Staging.h
+++ b/aten/src/ATen/native/vulkan/graph/Staging.h
@@ -16,12 +16,12 @@ void memcpy_to_mapping(
     const void* src,
     api::MemoryMap& dst_mapping,
     const size_t nbytes,
-    const c10::ScalarType dtype);
+    const api::ScalarType dtype);
 void memcpy_from_mapping(
     const api::MemoryMap& src_mapping,
     void* dst,
     const size_t nbytes,
-    const c10::ScalarType dtype);
+    const api::ScalarType dtype);
 
 //
 // Utility functions for memcpy

--- a/aten/src/ATen/native/vulkan/ops/Batchnorm.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Batchnorm.cpp
@@ -223,7 +223,7 @@ Tensor run_batchnorm_context(
   vTensor v_output{
       context,
       v_input.sizes(),
-      input_arg.scalar_type(),
+      v_input.dtype(),
   };
 
   batchnorm::record_op(

--- a/aten/src/ATen/native/vulkan/ops/BinaryOp.cpp
+++ b/aten/src/ATen/native/vulkan/ops/BinaryOp.cpp
@@ -25,7 +25,7 @@ Tensor binary_op_scalar(
   vTensor v_output{
       context,
       v_self.sizes(),
-      self_arg.scalar_type(),
+      v_self.dtype(),
   };
 
   const float other_val = alpha_arg ? other.to<float>() * alpha_arg->to<float>()
@@ -167,7 +167,7 @@ Tensor binary_op_tensor(
   vTensor v_output{
       context,
       utils::broadcast_size(self_arg, other_arg),
-      self_arg.scalar_type(),
+      v_self.dtype(),
   };
 
   const double alpha = alpha_arg ? alpha_arg->to<double>() : 1.0;
@@ -244,7 +244,7 @@ Tensor quantized_binary_op_tensor(
       utils::broadcast_size(self_arg, other_arg),
       scale,
       zero_point,
-      c10::kQUInt8,
+      api::kQUInt8,
   };
 
   const double scale1 = v_self.get_scale();

--- a/aten/src/ATen/native/vulkan/ops/Clamp.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Clamp.cpp
@@ -24,7 +24,7 @@ Tensor _clamp(
   vTensor v_output{
       context,
       v_self.sizes(),
-      self_arg.scalar_type(),
+      v_self.dtype(),
   };
 
   const struct Block final {
@@ -152,7 +152,7 @@ Tensor activation(
   vTensor v_output{
       context,
       v_self.sizes(),
-      self_arg.scalar_type(),
+      v_self.dtype(),
   };
 
   const struct Block final {
@@ -277,7 +277,7 @@ Tensor activation_scalar(
   vTensor v_output{
       context,
       v_self.sizes(),
-      self_arg.scalar_type(),
+      v_self.dtype(),
   };
 
   api::UniformParamsBuffer params;

--- a/aten/src/ATen/native/vulkan/ops/Concat.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Concat.cpp
@@ -305,7 +305,8 @@ Tensor cat(const at::ITensorListRef& tensors, const int64_t in_dim) {
   TORCH_INTERNAL_ASSERT(!result_size.empty(), "Accessing empty array");
   result_size[dim] = cat_dim_size;
 
-  vTensor v_output{api::context(), result_size, tensor.scalar_type()};
+  vTensor v_output{
+      api::context(), result_size, convert_dtype(tensor.scalar_type())};
 
   if (dim == ndim - 1) {
     return cat_width(materialized, v_output);

--- a/aten/src/ATen/native/vulkan/ops/Convert.h
+++ b/aten/src/ATen/native/vulkan/ops/Convert.h
@@ -4,6 +4,7 @@
 
 #include <ATen/native/vulkan/VulkanOpaqueTensorImpl.h>
 #include <ATen/native/vulkan/api/Tensor.h>
+#include <ATen/native/vulkan/api/Types.h>
 #include <c10/util/accumulate.h>
 
 namespace at {
@@ -11,12 +12,46 @@ namespace native {
 namespace vulkan {
 namespace ops {
 
+/*
+ * Converts a `c10::ScalarType` to an equivalent
+ * `::at::native::vulkan::api::ScalarType`.
+ */
+static inline api::ScalarType convert_dtype(const c10::ScalarType dtype) {
+#define DEFINE_CASE(ctype, vkformat, name) \
+  case c10::ScalarType::name:              \
+    return ::at::native::vulkan::api::ScalarType::name;
+
+  switch (dtype) {
+    VK_FORALL_SCALAR_TYPES(DEFINE_CASE)
+    default:
+      TORCH_CHECK(false, "Not a supported Vulkan ScalarType!");
+  }
+#undef DEFINE_CASE
+}
+
+/*
+ * Converts an `::at::native::vulkan::api::ScalarType` to an equivalent
+ * `c10::ScalarType`.
+ */
+static inline c10::ScalarType convert_dtype(const api::ScalarType dtype) {
+#define DEFINE_CASE(ctype, vkformat, name)          \
+  case ::at::native::vulkan::api::ScalarType::name: \
+    return c10::ScalarType::name;
+
+  switch (dtype) {
+    VK_FORALL_SCALAR_TYPES(DEFINE_CASE)
+    default:
+      TORCH_CHECK(false, "Not a supported c10::ScalarType!");
+  }
+#undef DEFINE_CASE
+}
+
 using vTensorImpl = VulkanOpaqueTensorImpl<vTensor>;
 
 inline Tensor convert(const vTensor& tensor) {
   return at::detail::make_tensor<vTensorImpl>(
       DispatchKeySet(DispatchKey::Vulkan),
-      c10::scalarTypeToTypeMeta(tensor.dtype()),
+      c10::scalarTypeToTypeMeta(convert_dtype(tensor.dtype())),
       at::Device(at::kVulkan),
       tensor,
       tensor.sizes(),
@@ -27,7 +62,7 @@ inline Tensor convert_quantized(const vTensor& tensor) {
   TORCH_CHECK(tensor.is_quantized(), "Not a Quantized Tensor");
   return at::detail::make_tensor<vTensorImpl>(
       DispatchKeySet(DispatchKey::Vulkan),
-      c10::scalarTypeToTypeMeta(tensor.dtype()),
+      c10::scalarTypeToTypeMeta(convert_dtype(tensor.dtype())),
       at::Device(at::kVulkan),
       tensor,
       tensor.sizes(),

--- a/aten/src/ATen/native/vulkan/ops/Convolution.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.cpp
@@ -531,7 +531,7 @@ vTensor pack_weights(
   vTensor v_weight{
       api::context(),
       weight_rearranged.sizes().vec(),
-      weight_arg.scalar_type(),
+      convert_dtype(weight_rearranged.scalar_type()),
       api::StorageType::TEXTURE_2D,
   };
 
@@ -556,7 +556,7 @@ vTensor pack_biases(
   vTensor v_bias{
       api::context(),
       bias_rearranged.sizes().vec(),
-      bias_rearranged.scalar_type(),
+      convert_dtype(bias_rearranged.scalar_type()),
       api::StorageType::TEXTURE_2D,
   };
 
@@ -903,7 +903,7 @@ Tensor conv1d(
           weight_out_channels,
           v_input_sizes[2] - kernel_size + 1,
       },
-      input_arg.scalar_type(),
+      v_input.dtype(),
   };
 
   const struct Block final {
@@ -1186,7 +1186,7 @@ Tensor run_conv2d_context_impl(
   vTensor v_output{
       context,
       output_size,
-      input_arg.scalar_type(),
+      v_input.dtype(),
   };
 
   if (quantized) {

--- a/aten/src/ATen/native/vulkan/ops/Copy.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Copy.cpp
@@ -66,7 +66,8 @@ void transfer_cpu_to_vulkan(const Tensor& src, vTensor& v_dst) {
   // Convert to dtype corresponding to the image format of the texture to
   // ensure that byte alignment is consistent when copying. In some cases
   // a 16 bit format will be used for at::kFloat.
-  Tensor src_nc4hw = utils::nchw_to_nc4hw(src).to(v_dst.texture_dtype());
+  Tensor src_nc4hw =
+      utils::nchw_to_nc4hw(src).to(convert_dtype(v_dst.texture_dtype()));
 
   api::StorageBuffer staging(context, v_dst.texture_dtype(), v_dst.gpu_numel());
   // Copy data into the staging buffer
@@ -118,7 +119,8 @@ void transfer_vulkan_to_cpu(vTensor& v_src, Tensor& dst) {
 
   context->fences().return_fence(fence);
 
-  dst = utils::nc4hw_to_nchw(dst_tmp, v_src.sizes()).to(v_src.dtype());
+  dst = utils::nc4hw_to_nchw(dst_tmp, v_src.sizes())
+            .to(convert_dtype(v_src.dtype()));
 }
 
 void transfer_vulkan_to_vulkan(vTensor& src, vTensor& dst) {
@@ -159,7 +161,7 @@ void pack_cpu_to_vulkan(const Tensor& src, vTensor& dst) {
   // of floats as input. GLSL/Vulkan does not natively support 16 bit arithmetic
   // types, so for now storage buffers created for compute shaders must define
   // floats as their base data type.
-  api::StorageBuffer staging(context, at::kFloat, dst.gpu_numel());
+  api::StorageBuffer staging(context, api::kFloat, dst.gpu_numel());
   {
     api::MemoryMap mapping(staging.buffer(), api::MemoryAccessType::WRITE);
 
@@ -184,7 +186,7 @@ void pack_vulkan_to_cpu(vTensor& src, Tensor& dst) {
 
   // Refer to the comment in pack_cpu_to_vulkan for why at::kFloat is specified
   // for the storage buffer below.
-  api::StorageBuffer staging(context, at::kFloat, src.gpu_numel());
+  api::StorageBuffer staging(context, api::kFloat, src.gpu_numel());
 
   api::VulkanFence fence = context->fences().get_fence();
 
@@ -278,7 +280,7 @@ vTensor to_vulkan(at::Tensor& src, const api::StorageType storage_type) {
   vTensor v_ret{
       api::context(),
       src.sizes().vec(),
-      src.scalar_type(),
+      convert_dtype(src.scalar_type()),
       storage_type,
       src.suggest_memory_format(),
   };
@@ -290,7 +292,7 @@ vTensor to_vulkan(at::Tensor& src, const api::StorageType storage_type) {
 
 at::Tensor from_vulkan(vTensor& v_src) {
   at::TensorOptions opt(at::kCPU);
-  opt = opt.dtype(v_src.dtype());
+  opt = opt.dtype(convert_dtype(v_src.dtype()));
 
   c10::MemoryFormat v_src_memory_format;
 

--- a/aten/src/ATen/native/vulkan/ops/Factory.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Factory.cpp
@@ -20,7 +20,7 @@ Tensor _empty_affine_quantized(
       sizes.vec(),
       scale,
       zero_point,
-      dtype ? *dtype : c10::kFloat,
+      convert_dtype(dtype ? *dtype : c10::kFloat),
       api::StorageType::TEXTURE_3D,
       memory_format ? *memory_format : c10::MemoryFormat::Contiguous,
   });
@@ -36,7 +36,7 @@ Tensor empty_memory_format(
   return convert(vTensor{
       api::context(),
       sizes.vec(),
-      dtype ? *dtype : c10::kFloat,
+      convert_dtype(dtype ? *dtype : c10::kFloat),
       api::StorageType::TEXTURE_3D,
       memory_format ? *memory_format : c10::MemoryFormat::Contiguous,
   });

--- a/aten/src/ATen/native/vulkan/ops/Flip.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Flip.cpp
@@ -26,7 +26,7 @@ Tensor flip(const at::Tensor& self, const IntArrayRef dim_list) {
   vTensor v_output{
       context,
       v_input.sizes(),
-      self.scalar_type(),
+      convert_dtype(self.scalar_type()),
   };
 
   // Required to determine how to insert memory barriers in the command buffer

--- a/aten/src/ATen/native/vulkan/ops/Glu.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Glu.cpp
@@ -31,7 +31,7 @@ Tensor glu(const at::Tensor& input_arg, const int64_t dim = -1) {
   vTensor v_output{
       context,
       {v_input_sizes[0], output_ch_size, v_input_sizes[2], v_input_sizes[3]},
-      input_arg.scalar_type(),
+      v_input.dtype(),
   };
 
   const struct Block final {

--- a/aten/src/ATen/native/vulkan/ops/Lerp.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Lerp.cpp
@@ -59,7 +59,7 @@ Tensor _lerp_scalar(
   vTensor v_output{
       context,
       v_start.sizes(),
-      start_arg.scalar_type(),
+      v_start.dtype(),
   };
 
   const float weight = weight_arg.to<float>();
@@ -184,7 +184,7 @@ Tensor _lerp_tensor(
   vTensor v_output{
       context,
       v_start.sizes(),
-      start_arg.scalar_type(),
+      v_start.dtype(),
   };
 
   const struct Block final {

--- a/aten/src/ATen/native/vulkan/ops/Mean.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Mean.cpp
@@ -54,7 +54,7 @@ Tensor mean_dim(
   vTensor v_output{
       context,
       output_size,
-      type,
+      convert_dtype(type),
   };
 
   // Required to determine how to insert memory barriers in the command buffer

--- a/aten/src/ATen/native/vulkan/ops/Mm.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Mm.cpp
@@ -128,7 +128,8 @@ vTensor pack_weights(const Tensor& weight_arg, const bool use_batch = false) {
       dst_kw_sz,
   };
 
-  vTensor v_weight{context, dst_vtensor_sizes, weight_arg.scalar_type()};
+  vTensor v_weight{
+      context, dst_vtensor_sizes, convert_dtype(weight_arg.scalar_type())};
 
   v_weight.set_is_quantized();
   v_weight.set_scale(weight_arg.q_scale());
@@ -342,7 +343,7 @@ Tensor run_quantized_addmm_context(
           input_arg_2d.sizes()[Layout::Parameter::height],
           unpacked_weight_sizes[Layout::Parameter::width],
       },
-      input_arg.scalar_type(),
+      v_input.dtype(),
   };
 
   v_output.set_is_quantized();
@@ -569,7 +570,7 @@ Tensor run_addmm_context(
           input_arg_2d.sizes()[Layout::Parameter::height],
           unpacked_weight_sizes[Layout::Parameter::width],
       },
-      input_arg.scalar_type(),
+      v_input.dtype(),
   };
 
   api::UniformParamsBuffer params;
@@ -695,7 +696,7 @@ Tensor run_baddbmm_context(
           packed_v_input.sizes()[Layout::BatchMatrices::height],
           unpacked_weight_sizes.back(), // "w" dimension in weight matrix
       },
-      input_arg.scalar_type(),
+      packed_v_input.dtype(),
   };
 
   const struct {

--- a/aten/src/ATen/native/vulkan/ops/Mm.h
+++ b/aten/src/ATen/native/vulkan/ops/Mm.h
@@ -27,7 +27,7 @@ void stage_pack_weights(
   const int64_t dst_plane_sz = dst_kw_sz * dst_kh_sz;
   const int64_t dst_matrix_sz = dst_plane_sz * 4;
   const T* const src_weight_ptr = weight.data_ptr<T>();
-  api::StorageBuffer staging(context, at::kFloat, v_weight.gpu_numel());
+  api::StorageBuffer staging(context, api::kFloat, v_weight.gpu_numel());
   {
     api::MemoryMap mapping(staging.buffer(), api::MemoryAccessType::WRITE);
 

--- a/aten/src/ATen/native/vulkan/ops/Padding.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Padding.cpp
@@ -52,7 +52,7 @@ Tensor pad2d(
   vTensor v_output{
       context,
       output_size,
-      self_arg.scalar_type(),
+      v_self.dtype(),
   };
 
   const struct Block final {

--- a/aten/src/ATen/native/vulkan/ops/Permute.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Permute.cpp
@@ -103,7 +103,11 @@ Tensor permute(const Tensor& self, IntArrayRef dims) {
   }
 
   IntArrayRef output_sizes(newSizes);
-  vTensor v_output{api::context(), output_sizes.vec(), self.scalar_type()};
+  vTensor v_output{
+      api::context(),
+      output_sizes.vec(),
+      convert_dtype(self.scalar_type()),
+  };
 
   return permute_4d(self, in_size, out_size, out_dims, v_output);
 }

--- a/aten/src/ATen/native/vulkan/ops/Pool.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Pool.cpp
@@ -30,7 +30,7 @@ Tensor adaptive_avg_pool2d(
           output_size[Layout::Activation4D::batch],
           output_size[Layout::Activation4D::channels],
       },
-      self_arg.scalar_type(),
+      v_self.dtype(),
   };
 
   const uvec3 v_output_size = v_output.extents();
@@ -159,7 +159,7 @@ Tensor pool2d(
           output_height,
           output_width,
       },
-      self_arg.scalar_type(),
+      v_self.dtype(),
   };
   if (v_self.is_quantized()) {
     v_output.set_is_quantized();

--- a/aten/src/ATen/native/vulkan/ops/QuantizedTensor.cpp
+++ b/aten/src/ATen/native/vulkan/ops/QuantizedTensor.cpp
@@ -39,7 +39,13 @@ Tensor quantize_per_tensor(
   const Tensor input = input_arg.is_vulkan() ? input_arg : input_arg.vulkan();
   const vTensor& v_input = convert(input);
 
-  vTensor v_output{context, v_input.sizes(), scale, zero_point, dtype};
+  vTensor v_output{
+      context,
+      v_input.sizes(),
+      scale,
+      zero_point,
+      convert_dtype(dtype),
+  };
 
   const struct Block final {
     uvec3 extents;
@@ -111,7 +117,7 @@ Tensor dequantize_helper(
   vTensor v_output{
       context,
       v_input.sizes(),
-      c10::kFloat,
+      api::kFloat,
   };
 
   const struct Block final {

--- a/aten/src/ATen/native/vulkan/ops/Select.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Select.cpp
@@ -18,7 +18,7 @@ Tensor select_batch_4d(const Tensor& input_arg, uint32_t index) {
   vTensor v_output{
       context,
       {v_input_sizes[1], v_input_sizes[2], v_input_sizes[3]},
-      input_arg.scalar_type(),
+      v_input.dtype(),
   };
   /*
   Input tensor: (n, c, h, w)
@@ -70,7 +70,7 @@ Tensor select_depth_3d(const Tensor& input_arg, uint32_t index) {
   vTensor v_output{
       context,
       {v_input_sizes[1], v_input_sizes[2]},
-      input_arg.scalar_type(),
+      v_input.dtype(),
   };
 
   const struct Block final {
@@ -117,7 +117,7 @@ Tensor select_depth_4d(const Tensor& input_arg, uint32_t index) {
   vTensor v_output{
       context,
       {v_input_sizes[0], v_input_sizes[2], v_input_sizes[3]},
-      input_arg.scalar_type(),
+      v_input.dtype(),
   };
   /*
   Input tensor: (n, c, h, w)
@@ -170,7 +170,7 @@ Tensor select_height_3d(const Tensor& input_arg, uint32_t index) {
   vTensor v_output{
       context,
       {v_input_sizes[0], v_input_sizes[2]},
-      input_arg.scalar_type(),
+      v_input.dtype(),
   };
   // Input tensor is a (c, h, w)
   // Output tensor is a (c, w)
@@ -229,7 +229,7 @@ Tensor select_height_4d(const Tensor& input_arg, uint32_t index) {
   vTensor v_output{
       context,
       {v_input_sizes[0], v_input_sizes[1], v_input_sizes[3]},
-      input_arg.scalar_type(),
+      v_input.dtype(),
   };
   /*
   Input tensor: (n, c, h, w)
@@ -283,7 +283,7 @@ Tensor select_width_3d(const Tensor& input_arg, uint32_t index) {
   vTensor v_output{
       context,
       {v_input_sizes[0], v_input_sizes[1]},
-      input_arg.scalar_type(),
+      v_input.dtype(),
   };
 
   const struct Block final {
@@ -343,7 +343,7 @@ Tensor select_width_4d(const Tensor& input_arg, uint32_t index) {
   vTensor v_output{
       context,
       {v_input_sizes[0], v_input_sizes[1], v_input_sizes[2]},
-      input_arg.scalar_type(),
+      v_input.dtype(),
   };
   /*
   Input tensor: (n, c, h, w)

--- a/aten/src/ATen/native/vulkan/ops/Shape.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Shape.cpp
@@ -20,7 +20,7 @@ Tensor view_internal(const Tensor& self_arg, const IntArrayRef shape) {
   vTensor v_output{
       context,
       output_size.vec(),
-      self_arg.scalar_type(),
+      v_self.dtype(),
   };
   if (v_self.is_quantized()) {
     v_output.set_is_quantized();
@@ -28,7 +28,7 @@ Tensor view_internal(const Tensor& self_arg, const IntArrayRef shape) {
     v_output.set_zero_point(v_self.get_zero_point());
   }
 
-  api::StorageBuffer buffer(context, at::kFloat, v_self.gpu_numel(), true);
+  api::StorageBuffer buffer(context, api::kFloat, v_self.gpu_numel(), true);
 
   utils::pack_vtensor_to_staging(v_self, buffer.buffer());
 

--- a/aten/src/ATen/native/vulkan/ops/Slice.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Slice.cpp
@@ -277,7 +277,8 @@ Tensor slice(
   dim += 4 - nDims;
 
   IntArrayRef output_sizes(newSizes);
-  vTensor v_output{api::context(), output_sizes.vec(), self.scalar_type()};
+  vTensor v_output{
+      api::context(), output_sizes.vec(), convert_dtype(self.scalar_type())};
 
   if (dim == 3) {
     slice_width(self, start_val, end_val, step, v_output);

--- a/aten/src/ATen/native/vulkan/ops/Softmax.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Softmax.cpp
@@ -107,7 +107,7 @@ Tensor softmax_internal(
   vTensor v_output{
       context,
       v_input.sizes(),
-      input_arg.scalar_type(),
+      v_input.dtype(),
   };
   const api::utils::uvec3 global_workgroup_extents = v_output.extents();
   api::utils::ivec4 input_shader_extents = {

--- a/aten/src/ATen/native/vulkan/ops/Sum.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Sum.cpp
@@ -43,7 +43,7 @@ Tensor sum_dim(
   vTensor v_output{
       context,
       output_size,
-      type,
+      convert_dtype(type),
   };
 
   // Required to determine how to insert memory barriers in the command buffer

--- a/aten/src/ATen/native/vulkan/ops/Transpose.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Transpose.cpp
@@ -122,7 +122,11 @@ Tensor transpose(const Tensor& self, int64_t index0, int64_t index1) {
   newSizes[new_index1] = oldSizes[new_index0];
 
   IntArrayRef output_size(newSizes);
-  vTensor v_output{api::context(), output_size.vec(), self.scalar_type()};
+  vTensor v_output{
+      api::context(),
+      output_size.vec(),
+      convert_dtype(self.scalar_type()),
+  };
 
   return transpose_4d(self, in_size, out_size, out_dims, v_output);
 }

--- a/aten/src/ATen/native/vulkan/ops/UnaryOp.cpp
+++ b/aten/src/ATen/native/vulkan/ops/UnaryOp.cpp
@@ -22,7 +22,7 @@ Tensor unary_op(
   vTensor v_output{
       context,
       v_self.sizes(),
-      self_arg.scalar_type(),
+      v_self.dtype(),
   };
 
   const struct Block final {

--- a/aten/src/ATen/native/vulkan/ops/Unsqueeze.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Unsqueeze.cpp
@@ -44,7 +44,7 @@ Tensor unsqueeze(const at::Tensor& self, int64_t dim) {
   vTensor v_output{
       context,
       output_size,
-      self.scalar_type(),
+      convert_dtype(self.scalar_type()),
   };
 
   // Required to determine how to insert memory barriers in the command buffer

--- a/aten/src/ATen/native/vulkan/ops/Upsample.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Upsample.cpp
@@ -32,7 +32,8 @@ Tensor upsample_nearest2d(
           output_sizes[Layout::Parameter::height],
           output_sizes[Layout::Parameter::width],
       },
-      input_arg.scalar_type()};
+      v_input.dtype(),
+  };
 
   if (v_input.is_quantized()) {
     v_output.set_is_quantized();
@@ -116,7 +117,7 @@ Tensor upsample_bilinear2d(
           output_sizes[Layout::Parameter::height],
           output_sizes[Layout::Parameter::width],
       },
-      input_arg.scalar_type(),
+      v_input.dtype(),
   };
 
   const api::utils::uvec3 output_extents = v_output.extents();

--- a/aten/src/ATen/native/vulkan/ops/Utils.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Utils.cpp
@@ -82,7 +82,8 @@ Tensor create_staging_tensor(const vTensor& v_in) {
   // the staging tensor matches the number of bytes in the image texture. Refer
   // to comments for api::vk_format()
   return at::empty(
-      {NC4, H, W, 4}, at::device(at::kCPU).dtype(v_in.texture_dtype()));
+      {NC4, H, W, 4},
+      at::device(at::kCPU).dtype(convert_dtype(v_in.texture_dtype())));
 }
 
 /*
@@ -328,10 +329,11 @@ api::utils::vec4 extract_texel(const Tensor& input, const ivec3& pos) {
   // x, y, z, w all using a single element tensor. We intend to pull
   // (0, 0, 0).x from each tensor. This allows us to isolate the effect
   // of most packing mechanism.
-  vTensor v_outputs_x{context, output_size, input.scalar_type()};
-  vTensor v_outputs_y{context, output_size, input.scalar_type()};
-  vTensor v_outputs_z{context, output_size, input.scalar_type()};
-  vTensor v_outputs_w{context, output_size, input.scalar_type()};
+  api::ScalarType dtype = convert_dtype(input.scalar_type());
+  vTensor v_outputs_x{context, output_size, dtype};
+  vTensor v_outputs_y{context, output_size, dtype};
+  vTensor v_outputs_z{context, output_size, dtype};
+  vTensor v_outputs_w{context, output_size, dtype};
 
   const struct Block final {
     ivec3 pos;

--- a/aten/src/ATen/native/vulkan/ops/Zero.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Zero.cpp
@@ -56,7 +56,7 @@ Tensor zeros(
   vTensor v_output{
       context,
       size.vec(),
-      ScalarType::Float,
+      api::ScalarType::Float,
   };
 
   // Required to determine how to insert memory barriers in the command buffer

--- a/aten/src/ATen/native/vulkan/ops/cumsum.cpp
+++ b/aten/src/ATen/native/vulkan/ops/cumsum.cpp
@@ -36,7 +36,7 @@ Tensor cumsum(
   vTensor v_output{
       context,
       v_input.sizes(),
-      input_arg.scalar_type(),
+      v_input.dtype(),
   };
 
   const struct Block final {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

## Context

This change is part of a set of changes that removes all references to the `c10` library in the `api/`, `graph/`, and `impl/` folders of the PyTorch Vulkan codebase. This is to ensure that these components can be built as a standalone library such that they can be used as the foundations of a Android GPU delegate for ExecuTorch.

## Notes for Reviewers

This changeset introduces `api::ScalarType` in `api/Types.h`, which is intended to function the same as `c10::ScalarType`; thus `api/Types.h` is the primary file of interest. The rest of the changes are straightforward replacements of `c10::ScalarType` with `api::ScalarType`.

Differential Revision: [D52662237](https://our.internmc.facebook.com/intern/diff/D52662237/)