### PR TITLE
Add utility to get use_count of the TensorImpl a python tensor refers to

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5661,13 +5661,13 @@ else:
     @unittest.skipIf(TEST_WITH_TORCHDYNAMO, "Dynamo doesn't init AccumulateGrad nodes on forward")
     def test_tensor_use_count(self, device):
         t = torch.empty(2, 3, device=device)
-        self.assertEqual(torch._C._tensor_use_count(t._cdata), 1)
+        self.assertEqual(torch._C._tensor_use_count(t), 1)
 
         m = torch.nn.Linear(2, 3, device=device)
-        self.assertEqual(torch._C._tensor_use_count(m.weight._cdata), 1)
+        self.assertEqual(torch._C._tensor_use_count(m.weight), 1)
         inp = torch.randn(2, 2, device=device)
         out = m(inp)
-        self.assertEqual(torch._C._tensor_use_count(m.weight._cdata), 2)
+        self.assertEqual(torch._C._tensor_use_count(m.weight), 2)
 
 # Tests that compare a device's computation with the (gold-standard) CPU's.
 class TestDevicePrecision(TestCase):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5658,6 +5658,15 @@ else:
         actual = t_non_contig.masked_scatter_(mask_contig, source)
         self.assertEqual(actual, expected)
 
+    def test_tensor_use_count(self, device):
+        t = torch.empty(2, 3, device=device)
+        self.assertEqual(torch._C._tensor_use_count(t._cdata), 1)
+
+        m = torch.nn.Linear(2, 3, device=device)
+        self.assertEqual(torch._C._tensor_use_count(m.weight._cdata), 1)
+        inp = torch.randn(2, 2, device=device)
+        out = m(inp)
+        self.assertEqual(torch._C._tensor_use_count(m.weight._cdata), 2)
 
 # Tests that compare a device's computation with the (gold-standard) CPU's.
 class TestDevicePrecision(TestCase):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5658,6 +5658,7 @@ else:
         actual = t_non_contig.masked_scatter_(mask_contig, source)
         self.assertEqual(actual, expected)
 
+    @unittest.skipIf(TEST_WITH_TORCHDYNAMO, "Dynamo doesn't init AccumulateGrad nodes on forward")
     def test_tensor_use_count(self, device):
         t = torch.empty(2, 3, device=device)
         self.assertEqual(torch._C._tensor_use_count(t._cdata), 1)

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1172,6 +1172,7 @@ def _has_torch_function_variadic(
 ) -> _bool: ...  # THPModule_has_torch_function_variadic
 def _vmapmode_increment_nesting() -> _int: ...  # THPModule_vmapmode_increment_nesting
 def _vmapmode_decrement_nesting() -> _int: ...  # THPModule_vmapmode_decrement_nesting
+def _tensor_use_count(cdata: _int) -> _int: ...  # THPModule__tensor_use_count
 def _log_api_usage_once(str) -> None: ...  # LogAPIUsageOnceFromPython
 def _log_api_usage_metadata(event: str, metadata_map: Dict[str, str]) -> None: ...  # LogAPIUsageMetadataFromPython
 def _demangle(str) -> str: ...  # c10::demangle

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -331,6 +331,16 @@ PyObject* THPModule_setDefaultDtype(PyObject* _unused, PyObject* dtype) {
   END_HANDLE_TH_ERRORS
 }
 
+PyObject* THPModule__tensor_use_count(PyObject* _unused, PyObject* cdata) {
+  HANDLE_TH_ERRORS
+  auto tensor_impl_ptr = THPUtils_unpackLong(cdata);
+  // NOLINTNEXTLINE(performance-no-int-to-ptr)
+  auto tensor_impl = (c10::TensorImpl*)tensor_impl_ptr;
+  return THPUtils_packUInt64(
+      c10::raw::weak_intrusive_ptr::use_count(tensor_impl));
+  END_HANDLE_TH_ERRORS
+}
+
 PyObject* THPModule_swap_tensor_impl(PyObject* _unused, PyObject* args) {
   HANDLE_TH_ERRORS
   PyObject* a_ = nullptr;
@@ -1388,6 +1398,7 @@ static PyMethodDef TorchMethods[] = { // NOLINT
      (PyCFunction)(void (*)())THPModule_has_torch_function_variadic,
      METH_FASTCALL,
      nullptr},
+    {"_tensor_use_count", THPModule__tensor_use_count, METH_O, nullptr},
     {nullptr, nullptr, 0, nullptr}};
 
 void THCPStream_init(PyObject* module);

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -331,13 +331,10 @@ PyObject* THPModule_setDefaultDtype(PyObject* _unused, PyObject* dtype) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule__tensor_use_count(PyObject* _unused, PyObject* cdata) {
+PyObject* THPModule__tensor_use_count(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
-  auto tensor_impl_ptr = THPUtils_unpackLong(cdata);
-  // NOLINTNEXTLINE(performance-no-int-to-ptr)
-  auto tensor_impl = (c10::TensorImpl*)tensor_impl_ptr;
-  return THPUtils_packUInt64(
-      c10::raw::weak_intrusive_ptr::use_count(tensor_impl));
+  const auto& t = THPVariable_Unpack(arg);
+  return THPUtils_packUInt64(t.use_count());
   END_HANDLE_TH_ERRORS
 }
 


### PR DESCRIPTION
Mirroring `torch._C._storage_Use_Count`

https://github.com/pytorch/pytorch/blob/7e37f63e5e77a217a08d9261af49e63ddb51d306/torch/csrc/cuda/Module.cpp#L1139-L1142

The way I've implemented the above PR, we need this to check the `use_count` of the tensor to see whether the `swap_tensors` path is valid, otherwise we fall back to setting `.data`. If there is another utility that lets me access `use_count` of `TensorImpl` from python I am happy to close this and use that instead

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #117167
* __->__ #117166
* #116955

