### PR TITLE
[pt-vulkan][ez] Replace `ArrayRef` with `std::vector<T>&`

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Tensor.h
+++ b/aten/src/ATen/native/vulkan/api/Tensor.h
@@ -34,7 +34,7 @@ class vTensorStorage final {
       api::Context* context,
       const api::StorageType storage_type,
       const api::GPUMemoryLayout gpu_memory_layout,
-      const IntArrayRef sizes,
+      const std::vector<int64_t>& sizes,
       const at::ScalarType dtype);
 
   vTensorStorage(const vTensorStorage&) = delete;
@@ -88,7 +88,7 @@ class vTensor final {
   // Default constructor
   vTensor(
       api::Context* context,
-      IntArrayRef sizes,
+      const std::vector<int64_t>& sizes,
       const c10::ScalarType dtype,
       const api::StorageType storage_type,
       const api::GPUMemoryLayout memory_layout);
@@ -96,7 +96,7 @@ class vTensor final {
   // Default constructor for quantized vTensor
   vTensor(
       api::Context* const context,
-      const IntArrayRef sizes,
+      const std::vector<int64_t>& sizes,
       double q_scale,
       int64_t q_zero_point,
       const c10::ScalarType dtype,
@@ -106,7 +106,7 @@ class vTensor final {
   // Allows construction of vTensor from aten Tensor params
   vTensor(
       api::Context* context,
-      IntArrayRef sizes,
+      const std::vector<int64_t>& sizes,
       const c10::ScalarType dtype = c10::kFloat,
       const api::StorageType storage_type = api::StorageType::TEXTURE_3D,
       const c10::MemoryFormat memory_format = c10::MemoryFormat::Contiguous);
@@ -114,7 +114,7 @@ class vTensor final {
   // Allows construction of quantized vTensor from aten Tensor params
   vTensor(
       api::Context* const context,
-      const IntArrayRef sizes,
+      const std::vector<int64_t>& sizes,
       double q_scale,
       int64_t q_zero_point,
       const c10::ScalarType dtype = c10::kQUInt8,
@@ -239,19 +239,19 @@ class vTensor final {
     return static_cast<uint32_t>(memory_layout_);
   }
 
-  inline IntArrayRef sizes() const {
+  inline const std::vector<int64_t>& sizes() const {
     return sizes_;
   }
 
-  inline IntArrayRef strides() const {
+  inline const std::vector<int64_t>& strides() const {
     return strides_;
   }
 
-  inline IntArrayRef gpu_sizes() const {
+  inline const std::vector<int64_t>& gpu_sizes() const {
     return gpu_sizes_;
   }
 
-  inline IntArrayRef gpu_strides() const {
+  inline const std::vector<int64_t>& gpu_strides() const {
     return gpu_strides_;
   }
 

--- a/aten/src/ATen/native/vulkan/api/Utils.h
+++ b/aten/src/ATen/native/vulkan/api/Utils.h
@@ -2,7 +2,6 @@
 
 #include <numeric>
 
-#include <c10/util/ArrayRef.h>
 #include <c10/util/Half.h> // For c10::overflows
 
 #include <ATen/native/vulkan/api/Exception.h>
@@ -122,24 +121,27 @@ inline std::ostream& operator<<(std::ostream& os, const uvec3& v) {
 }
 
 //
-// IntArrayRef Handling
+// std::vector<T> Handling
 //
 
 /*
- * Utility function to perform indexing on an IntArrayRef. Negative indexing is
- * allowed. For instance, passing an index of -1 will retrieve the last element.
- * If the requested index is out of bounds, then 1u will be returned.
+ * Utility function to perform indexing on an std::vector<T>. Negative indexing
+ * is allowed. For instance, passing an index of -1 will retrieve the last
+ * element. If the requested index is out of bounds, then 1u will be returned.
  */
-inline uint32_t val_at(int32_t index, const IntArrayRef sizes) {
-  const int32_t ndim = static_cast<int32_t>(sizes.size());
+template <typename T>
+inline T val_at(const int64_t index, const std::vector<T>& sizes) {
+  const int64_t ndim = static_cast<int64_t>(sizes.size());
   if (index >= 0) {
-    return index >= ndim ? 1 : safe_downcast<uint32_t>(sizes[index]);
+    return index >= ndim ? 1 : sizes[index];
   } else {
-    return ndim + index < 0 ? 1 : safe_downcast<uint32_t>(sizes[ndim + index]);
+    return ndim + index < 0 ? 1 : sizes[ndim + index];
   }
 }
 
-inline ivec2 make_ivec2(IntArrayRef ints, bool reverse = false) {
+inline ivec2 make_ivec2(
+    const std::vector<int64_t>& ints,
+    bool reverse = false) {
   VK_CHECK_COND(ints.size() == 2);
   if (reverse) {
     return {safe_downcast<int32_t>(ints[1]), safe_downcast<int32_t>(ints[0])};
@@ -148,7 +150,9 @@ inline ivec2 make_ivec2(IntArrayRef ints, bool reverse = false) {
   }
 }
 
-inline ivec4 make_ivec4(IntArrayRef ints, bool reverse = false) {
+inline ivec4 make_ivec4(
+    const std::vector<int64_t>& ints,
+    bool reverse = false) {
   VK_CHECK_COND(ints.size() == 4);
   if (reverse) {
     return {
@@ -167,7 +171,7 @@ inline ivec4 make_ivec4(IntArrayRef ints, bool reverse = false) {
   }
 }
 
-inline ivec4 make_ivec4_prepadded1(IntArrayRef ints) {
+inline ivec4 make_ivec4_prepadded1(const std::vector<int64_t>& ints) {
   VK_CHECK_COND(ints.size() <= 4);
 
   ivec4 result = {1, 1, 1, 1};
@@ -187,14 +191,14 @@ inline ivec3 make_ivec3(uvec3 ints) {
 }
 
 /*
- * Given an IntArrayRef of up to 4 elements, constructs a uvec4 containing those
- * elements in reverse order.
+ * Given an vector of up to 4 int64_t representing the sizes of a tensor,
+ * constructs a uvec4 containing those elements in reverse order.
  */
-inline uvec4 make_nchw_uvec4(const IntArrayRef arr) {
-  uint32_t w = val_at(-1, arr);
-  uint32_t h = val_at(-2, arr);
-  uint32_t c = val_at(-3, arr);
-  uint32_t n = val_at(-4, arr);
+inline uvec4 make_nchw_uvec4(const std::vector<int64_t>& arr) {
+  uint32_t w = safe_downcast<uint32_t>(val_at(-1, arr));
+  uint32_t h = safe_downcast<uint32_t>(val_at(-2, arr));
+  uint32_t c = safe_downcast<uint32_t>(val_at(-3, arr));
+  uint32_t n = safe_downcast<uint32_t>(val_at(-4, arr));
 
   return {w, h, c, n};
 }
@@ -225,7 +229,7 @@ inline bool operator==(const utils::uvec3& _1, const utils::uvec3& _2) {
 
 inline VkOffset3D create_offset3d(const utils::uvec3& offsets) {
   return VkOffset3D{
-      static_cast<int32_t>(offsets.data[0u]),
+      utils::safe_downcast<int32_t>(offsets.data[0u]),
       static_cast<int32_t>(offsets.data[1u]),
       static_cast<int32_t>(offsets.data[2u])};
 }

--- a/aten/src/ATen/native/vulkan/graph/Arithmetic.cpp
+++ b/aten/src/ATen/native/vulkan/graph/Arithmetic.cpp
@@ -43,7 +43,7 @@ ValueRef add_arithmetic_node(
     const ValueRef t2,
     const float alpha,
     const arithmetic::OpType optype) {
-  IntArrayRef t1_sizes = graph.get_val_sizes(t1);
+  std::vector<int64_t> t1_sizes = graph.get_val_sizes(t1);
   c10::ScalarType t1_dtype = graph.get_val_dtype(t1);
 
   ValueRef out = graph.add_tensor(t1_sizes, t1_dtype);

--- a/aten/src/ATen/native/vulkan/graph/Constant.cpp
+++ b/aten/src/ATen/native/vulkan/graph/Constant.cpp
@@ -5,7 +5,7 @@ namespace native {
 namespace vulkan {
 
 TensorRef::TensorRef(
-    const IntArrayRef t_sizes,
+    const std::vector<int64_t>& t_sizes,
     c10::ScalarType t_dtype,
     const void* const t_data)
     : sizes{}, dtype{t_dtype}, data{t_data} {

--- a/aten/src/ATen/native/vulkan/graph/Constant.h
+++ b/aten/src/ATen/native/vulkan/graph/Constant.h
@@ -19,7 +19,7 @@ struct TensorRef final {
   const void* data;
 
   explicit TensorRef(
-      const IntArrayRef t_sizes,
+      const std::vector<int64_t>& t_sizes,
       c10::ScalarType t_dtype,
       const void* const t_data);
 

--- a/aten/src/ATen/native/vulkan/graph/Copy.cpp
+++ b/aten/src/ATen/native/vulkan/graph/Copy.cpp
@@ -12,7 +12,7 @@ void add_copy_node(
 }
 
 ValueRef add_copy_node(ComputeGraph& graph, const ValueRef from) {
-  IntArrayRef out_sizes = graph.get_val_sizes(from);
+  std::vector<int64_t> out_sizes = graph.get_val_sizes(from);
   c10::ScalarType out_dtype = graph.get_val_dtype(from);
   ValueRef to = graph.add_tensor(out_sizes, out_dtype);
   add_copy_node(graph, from, to);

--- a/aten/src/ATen/native/vulkan/graph/Graph.cpp
+++ b/aten/src/ATen/native/vulkan/graph/Graph.cpp
@@ -28,7 +28,7 @@ ComputeGraph::~ComputeGraph() {
 }
 
 ValueRef ComputeGraph::add_tensor(
-    const IntArrayRef sizes,
+    const std::vector<int64_t>& sizes,
     const c10::ScalarType dtype) {
   ValueRef idx(static_cast<int>(values_.size()));
   values_.emplace_back(vTensor(context(), sizes, dtype));
@@ -36,7 +36,7 @@ ValueRef ComputeGraph::add_tensor(
 }
 
 ValueRef ComputeGraph::add_tensorref(
-    const IntArrayRef sizes,
+    const std::vector<int64_t>& sizes,
     const c10::ScalarType dtype,
     const void* const data) {
   ValueRef idx(static_cast<int>(values_.size()));

--- a/aten/src/ATen/native/vulkan/graph/Graph.h
+++ b/aten/src/ATen/native/vulkan/graph/Graph.h
@@ -92,7 +92,7 @@ class ComputeGraph final {
     return values_[idx];
   }
 
-  inline IntArrayRef get_val_sizes(ValueRef idx) {
+  inline const std::vector<int64_t>& get_val_sizes(ValueRef idx) {
     Value& val = get_val(idx);
     if (val.isTensor()) {
       return val.toTensor().sizes();
@@ -124,9 +124,11 @@ class ComputeGraph final {
   // Graph Building
   //
 
-  ValueRef add_tensor(const IntArrayRef sizes, const c10::ScalarType dtype);
+  ValueRef add_tensor(
+      const std::vector<int64_t>& sizes,
+      const c10::ScalarType dtype);
   ValueRef add_tensorref(
-      const IntArrayRef sizes,
+      const std::vector<int64_t>& sizes,
       const c10::ScalarType dtype,
       const void* const data);
   ValueRef add_staging(const c10::ScalarType dtype, const size_t numel);

--- a/aten/src/ATen/native/vulkan/impl/Common.h
+++ b/aten/src/ATen/native/vulkan/impl/Common.h
@@ -61,7 +61,7 @@ struct DimTConv2DKernel {
  * these functions.
  */
 template <uint32_t N>
-uint32_t dim_at(const IntArrayRef sizes) {
+uint32_t dim_at(const std::vector<int64_t>& sizes) {
   const uint32_t dims = sizes.size();
   return dims < N ? 1 : api::utils::safe_downcast<uint32_t>(sizes[dims - N]);
 }

--- a/aten/src/ATen/native/vulkan/ops/Convolution.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.cpp
@@ -383,11 +383,11 @@ void record_op(
       0u,
       api::utils::make_ivec3(v_input.extents()),
       0u,
-      api::utils::make_ivec4(overlay_region, /*reverse=*/true),
-      api::utils::make_ivec2({kernel_size[3], kernel_size[2]}),
-      api::utils::make_ivec2(stride, /*reverse=*/true),
-      api::utils::make_ivec2(padding, /*reverse=*/true),
-      api::utils::make_ivec2(dilation, /*reverse=*/true),
+      utils::make_ivec4(overlay_region, /*reverse=*/true),
+      utils::make_ivec2({kernel_size[3], kernel_size[2]}),
+      utils::make_ivec2(stride, /*reverse=*/true),
+      utils::make_ivec2(padding, /*reverse=*/true),
+      utils::make_ivec2(dilation, /*reverse=*/true),
       {output_min, output_max},
   };
   api::UniformParamsBuffer params(context, block);
@@ -468,11 +468,11 @@ void record_quantized_op(
       0u,
       api::utils::make_ivec3(v_input.extents()),
       0u,
-      api::utils::make_ivec4(overlay_region, /*reverse=*/true),
-      api::utils::make_ivec2({kernel_size[3], kernel_size[2]}),
-      api::utils::make_ivec2(stride, /*reverse=*/true),
-      api::utils::make_ivec2(padding, /*reverse=*/true),
-      api::utils::make_ivec2(dilation, /*reverse=*/true),
+      utils::make_ivec4(overlay_region, /*reverse=*/true),
+      utils::make_ivec2({kernel_size[3], kernel_size[2]}),
+      utils::make_ivec2(stride, /*reverse=*/true),
+      utils::make_ivec2(padding, /*reverse=*/true),
+      utils::make_ivec2(dilation, /*reverse=*/true),
       {output_min, output_max},
   };
   api::UniformParamsBuffer params(context, block);
@@ -530,7 +530,7 @@ vTensor pack_weights(
 
   vTensor v_weight{
       api::context(),
-      weight_rearranged.sizes(),
+      weight_rearranged.sizes().vec(),
       weight_arg.scalar_type(),
       api::StorageType::TEXTURE_2D,
   };
@@ -555,7 +555,7 @@ vTensor pack_biases(
 
   vTensor v_bias{
       api::context(),
-      bias_rearranged.sizes(),
+      bias_rearranged.sizes().vec(),
       bias_rearranged.scalar_type(),
       api::StorageType::TEXTURE_2D,
   };

--- a/aten/src/ATen/native/vulkan/ops/Copy.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Copy.cpp
@@ -277,7 +277,7 @@ vTensor to_vulkan(at::Tensor& src, const api::StorageType storage_type) {
 
   vTensor v_ret{
       api::context(),
-      src.sizes(),
+      src.sizes().vec(),
       src.scalar_type(),
       storage_type,
       src.suggest_memory_format(),

--- a/aten/src/ATen/native/vulkan/ops/Factory.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Factory.cpp
@@ -17,7 +17,7 @@ Tensor _empty_affine_quantized(
     const optional<MemoryFormat> memory_format) {
   return convert_quantized(vTensor{
       api::context(),
-      sizes,
+      sizes.vec(),
       scale,
       zero_point,
       dtype ? *dtype : c10::kFloat,
@@ -35,7 +35,7 @@ Tensor empty_memory_format(
     const optional<MemoryFormat> memory_format) {
   return convert(vTensor{
       api::context(),
-      sizes,
+      sizes.vec(),
       dtype ? *dtype : c10::kFloat,
       api::StorageType::TEXTURE_3D,
       memory_format ? *memory_format : c10::MemoryFormat::Contiguous,

--- a/aten/src/ATen/native/vulkan/ops/Flip.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Flip.cpp
@@ -25,7 +25,7 @@ Tensor flip(const at::Tensor& self, const IntArrayRef dim_list) {
   // Create the output texture
   vTensor v_output{
       context,
-      self.sizes().vec(),
+      v_input.sizes(),
       self.scalar_type(),
   };
 

--- a/aten/src/ATen/native/vulkan/ops/Mean.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Mean.cpp
@@ -38,7 +38,7 @@ Tensor mean_dim(
   dim = utils::normalize(dim, self.dim());
 
   // Create the output texture
-  std::vector<int64_t> output_size = self.sizes().vec();
+  std::vector<int64_t> output_size = v_input.sizes();
   uint32_t dim_size = output_size[dim];
   if (keepdim) {
     output_size[dim] = 1;

--- a/aten/src/ATen/native/vulkan/ops/Padding.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Padding.cpp
@@ -38,7 +38,7 @@ Tensor pad2d(
   const Tensor self = self_arg.is_vulkan() ? self_arg : self_arg.vulkan();
   const vTensor& v_self = convert(self);
 
-  c10::SmallVector<int64_t, 4> output_size(input_dim);
+  std::vector<int64_t> output_size(input_dim);
   for (const auto d : c10::irange(input_dim)) {
     if (d == input_dim - 1) {
       output_size[d] = input_size[d] + pad_right + pad_left;

--- a/aten/src/ATen/native/vulkan/ops/Permute.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Permute.cpp
@@ -102,7 +102,8 @@ Tensor permute(const Tensor& self, IntArrayRef dims) {
     return self;
   }
 
-  vTensor v_output{api::context(), newSizes, self.scalar_type()};
+  IntArrayRef output_sizes(newSizes);
+  vTensor v_output{api::context(), output_sizes.vec(), self.scalar_type()};
 
   return permute_4d(self, in_size, out_size, out_dims, v_output);
 }

--- a/aten/src/ATen/native/vulkan/ops/QuantizedTensor.cpp
+++ b/aten/src/ATen/native/vulkan/ops/QuantizedTensor.cpp
@@ -39,7 +39,7 @@ Tensor quantize_per_tensor(
   const Tensor input = input_arg.is_vulkan() ? input_arg : input_arg.vulkan();
   const vTensor& v_input = convert(input);
 
-  vTensor v_output{context, input.sizes(), scale, zero_point, dtype};
+  vTensor v_output{context, v_input.sizes(), scale, zero_point, dtype};
 
   const struct Block final {
     uvec3 extents;
@@ -110,7 +110,7 @@ Tensor dequantize_helper(
 
   vTensor v_output{
       context,
-      input.sizes(),
+      v_input.sizes(),
       c10::kFloat,
   };
 

--- a/aten/src/ATen/native/vulkan/ops/Shape.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Shape.cpp
@@ -15,10 +15,11 @@ Tensor view_internal(const Tensor& self_arg, const IntArrayRef shape) {
   vTensor& v_self = convert(self);
 
   at::DimVector inferred_size = at::infer_size_dv(shape, self.numel());
+  IntArrayRef output_size(inferred_size);
 
   vTensor v_output{
       context,
-      inferred_size,
+      output_size.vec(),
       self_arg.scalar_type(),
   };
   if (v_self.is_quantized()) {

--- a/aten/src/ATen/native/vulkan/ops/Slice.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Slice.cpp
@@ -276,7 +276,8 @@ Tensor slice(
   }
   dim += 4 - nDims;
 
-  vTensor v_output{api::context(), newSizes, self.scalar_type()};
+  IntArrayRef output_sizes(newSizes);
+  vTensor v_output{api::context(), output_sizes.vec(), self.scalar_type()};
 
   if (dim == 3) {
     slice_width(self, start_val, end_val, step, v_output);

--- a/aten/src/ATen/native/vulkan/ops/Softmax.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Softmax.cpp
@@ -103,11 +103,10 @@ Tensor softmax_internal(
 
   const Tensor input = input_arg.is_vulkan() ? input_arg : input_arg.vulkan();
   const vTensor& v_input = convert(input);
-  const IntArrayRef v_input_sizes = v_input.sizes();
 
   vTensor v_output{
       context,
-      v_input_sizes,
+      v_input.sizes(),
       input_arg.scalar_type(),
   };
   const api::utils::uvec3 global_workgroup_extents = v_output.extents();
@@ -143,7 +142,7 @@ Tensor softmax_internal(
   set_softmax_kernel_params(
       input_arg.dim(),
       dim,
-      v_input_sizes,
+      v_input.sizes(),
       shader_descriptor,
       input_shader_extents,
       early_exit,

--- a/aten/src/ATen/native/vulkan/ops/Sum.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Sum.cpp
@@ -27,7 +27,7 @@ Tensor sum_dim(
   const vTensor& v_input = convert(input);
 
   // Create the output texture
-  std::vector<int64_t> output_size = self.sizes().vec();
+  std::vector<int64_t> output_size = v_input.sizes();
   uint32_t dim_size = output_size[dim];
   if (keepdim) {
     output_size[dim] = 1;

--- a/aten/src/ATen/native/vulkan/ops/Transpose.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Transpose.cpp
@@ -121,7 +121,8 @@ Tensor transpose(const Tensor& self, int64_t index0, int64_t index1) {
   newSizes[new_index0] = oldSizes[new_index1];
   newSizes[new_index1] = oldSizes[new_index0];
 
-  vTensor v_output{api::context(), newSizes, self.scalar_type()};
+  IntArrayRef output_size(newSizes);
+  vTensor v_output{api::context(), output_size.vec(), self.scalar_type()};
 
   return transpose_4d(self, in_size, out_size, out_dims, v_output);
 }

--- a/aten/src/ATen/native/vulkan/ops/Unsqueeze.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Unsqueeze.cpp
@@ -35,7 +35,7 @@ Tensor unsqueeze(const at::Tensor& self, int64_t dim) {
   const vTensor& v_input = convert(input);
 
   // Create the output texture. For unsqueeze, add a dimension.
-  std::vector<int64_t> output_size = self.sizes().vec();
+  std::vector<int64_t> output_size = v_input.sizes();
   if (dim < 0) {
     dim += (self.dim() + 1);
   }

--- a/aten/src/ATen/native/vulkan/ops/Utils.h
+++ b/aten/src/ATen/native/vulkan/ops/Utils.h
@@ -62,6 +62,42 @@ api::utils::vec4 extract_texel(
     const Tensor& tensor,
     const api::utils::ivec3& pos);
 
+inline api::utils::ivec2 make_ivec2(
+    const IntArrayRef ints,
+    bool reverse = false) {
+  VK_CHECK_COND(ints.size() == 2);
+  if (reverse) {
+    return {
+        api::utils::safe_downcast<int32_t>(ints[1]),
+        api::utils::safe_downcast<int32_t>(ints[0])};
+  } else {
+    return {
+        api::utils::safe_downcast<int32_t>(ints[0]),
+        api::utils::safe_downcast<int32_t>(ints[1])};
+  }
+}
+
+inline api::utils::ivec4 make_ivec4(
+    const IntArrayRef ints,
+    bool reverse = false) {
+  VK_CHECK_COND(ints.size() == 4);
+  if (reverse) {
+    return {
+        api::utils::safe_downcast<int32_t>(ints[3]),
+        api::utils::safe_downcast<int32_t>(ints[2]),
+        api::utils::safe_downcast<int32_t>(ints[1]),
+        api::utils::safe_downcast<int32_t>(ints[0]),
+    };
+  } else {
+    return {
+        api::utils::safe_downcast<int32_t>(ints[0]),
+        api::utils::safe_downcast<int32_t>(ints[1]),
+        api::utils::safe_downcast<int32_t>(ints[2]),
+        api::utils::safe_downcast<int32_t>(ints[3]),
+    };
+  }
+}
+
 } // namespace utils
 } // namespace ops
 } // namespace vulkan

--- a/aten/src/ATen/native/vulkan/ops/Zero.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Zero.cpp
@@ -55,7 +55,7 @@ Tensor zeros(
   // Create the output texture
   vTensor v_output{
       context,
-      size,
+      size.vec(),
       ScalarType::Float,
   };
 

--- a/aten/src/ATen/native/vulkan/ops/cumsum.cpp
+++ b/aten/src/ATen/native/vulkan/ops/cumsum.cpp
@@ -35,7 +35,7 @@ Tensor cumsum(
 
   vTensor v_output{
       context,
-      input_arg.sizes(),
+      v_input.sizes(),
       input_arg.scalar_type(),
   };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

## Context

This change is part of a set of changes that removes all references to the `c10` library in the `api/`, `graph/`, and `impl/` folders of the PyTorch Vulkan codebase. This is to ensure that these components can be built as a standalone library such that they can be used as the foundations of a Android GPU delegate for ExecuTorch.

## Notes for Reviewers

This changeset replaces all instances of `c10::ArrayRef<T>` with `std::vector<T>&` and all instances of`c10::IntArrayRef` with `std::vector<int64_t>&`. There are a lot of changes in this changeset but that is simply due to the large number of callsites. All the changes are straightforward replacements.

Differential Revision: [D52662235](https://our.internmc.facebook.com/intern/diff/D52662235/)