### PR TITLE
[pt-vulkan][ez] Remove reference to c10::MemoryFormat from `api/` folder

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Tensor.h
+++ b/aten/src/ATen/native/vulkan/api/Tensor.h
@@ -6,7 +6,6 @@
 
 #include <ATen/native/vulkan/api/Context.h>
 #include <ATen/native/vulkan/api/Types.h>
-#include <c10/core/MemoryFormat.h>
 
 namespace at {
 namespace native {
@@ -91,8 +90,9 @@ class vTensor final {
       api::Context* context,
       const std::vector<int64_t>& sizes,
       const api::ScalarType dtype,
-      const api::StorageType storage_type,
-      const api::GPUMemoryLayout memory_layout);
+      const api::StorageType storage_type = api::StorageType::TEXTURE_3D,
+      const api::GPUMemoryLayout memory_layout =
+          api::GPUMemoryLayout::TENSOR_CHANNELS_PACKED);
 
   // Default constructor for quantized vTensor
   vTensor(
@@ -101,26 +101,9 @@ class vTensor final {
       double q_scale,
       int64_t q_zero_point,
       const api::ScalarType dtype,
-      const api::StorageType storage_type,
-      const api::GPUMemoryLayout memory_layout);
-
-  // Allows construction of vTensor from aten Tensor params
-  vTensor(
-      api::Context* context,
-      const std::vector<int64_t>& sizes,
-      const api::ScalarType dtype = api::kFloat,
       const api::StorageType storage_type = api::StorageType::TEXTURE_3D,
-      const c10::MemoryFormat memory_format = c10::MemoryFormat::Contiguous);
-
-  // Allows construction of quantized vTensor from aten Tensor params
-  vTensor(
-      api::Context* const context,
-      const std::vector<int64_t>& sizes,
-      double q_scale,
-      int64_t q_zero_point,
-      const api::ScalarType dtype = api::kQUInt8,
-      const api::StorageType storage_type = api::StorageType::TEXTURE_3D,
-      const c10::MemoryFormat memory_format = c10::MemoryFormat::Contiguous);
+      const api::GPUMemoryLayout memory_layout =
+          api::GPUMemoryLayout::TENSOR_CHANNELS_PACKED);
 
   // Copy Constructor and Assignment; Ideally copying  would be disabled
   // (see the reasoning for move assignment below) but it is required for

--- a/aten/src/ATen/native/vulkan/graph/Staging.h
+++ b/aten/src/ATen/native/vulkan/graph/Staging.h
@@ -2,6 +2,8 @@
 
 #ifdef USE_VULKAN_API
 
+#include <string.h>
+
 #include <ATen/native/vulkan/graph/Graph.h>
 
 namespace at {

--- a/aten/src/ATen/native/vulkan/ops/Common.h
+++ b/aten/src/ATen/native/vulkan/ops/Common.h
@@ -2,6 +2,8 @@
 
 #ifdef USE_VULKAN_API
 
+#include <c10/util/ArrayRef.h>
+
 #include <ATen/core/List.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/native/vulkan/api/api.h>

--- a/aten/src/ATen/native/vulkan/ops/Copy.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Copy.cpp
@@ -282,7 +282,7 @@ vTensor to_vulkan(at::Tensor& src, const api::StorageType storage_type) {
       src.sizes().vec(),
       convert_dtype(src.scalar_type()),
       storage_type,
-      src.suggest_memory_format(),
+      get_gpu_memory_layout(storage_type, src.suggest_memory_format()),
   };
 
   ops::pack_cpu_to_vulkan(src, v_ret);

--- a/aten/src/ATen/native/vulkan/ops/Factory.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Factory.cpp
@@ -15,14 +15,16 @@ Tensor _empty_affine_quantized(
     const double scale,
     const int64_t zero_point,
     const optional<MemoryFormat> memory_format) {
+  api::StorageType storage_type = api::StorageType::TEXTURE_3D;
   return convert_quantized(vTensor{
       api::context(),
       sizes.vec(),
       scale,
       zero_point,
       convert_dtype(dtype ? *dtype : c10::kFloat),
-      api::StorageType::TEXTURE_3D,
-      memory_format ? *memory_format : c10::MemoryFormat::Contiguous,
+      storage_type,
+      memory_format ? get_gpu_memory_layout(storage_type, *memory_format)
+                    : api::GPUMemoryLayout::TENSOR_CHANNELS_PACKED,
   });
 }
 
@@ -33,12 +35,14 @@ Tensor empty_memory_format(
     const c10::optional<Device> device,
     const c10::optional<bool> pin_memory,
     const optional<MemoryFormat> memory_format) {
+  api::StorageType storage_type = api::StorageType::TEXTURE_3D;
   return convert(vTensor{
       api::context(),
       sizes.vec(),
       convert_dtype(dtype ? *dtype : c10::kFloat),
-      api::StorageType::TEXTURE_3D,
-      memory_format ? *memory_format : c10::MemoryFormat::Contiguous,
+      storage_type,
+      memory_format ? get_gpu_memory_layout(storage_type, *memory_format)
+                    : api::GPUMemoryLayout::TENSOR_CHANNELS_PACKED,
   });
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

## Context

This change is part of a set of changes that removes all references to the `c10` library in the `api/`, `graph/`, and `impl/` folders of the PyTorch Vulkan codebase. This is to ensure that these components can be built as a standalone library such that they can be used as the foundations of a Android GPU delegate for ExecuTorch.

## Notes for Reviewers

This changeset removes references to `c10::MemoryFormat` in `api/Tensor.[h,cpp]`; when constructing a `vTensor`, the `api::StorageType` (i.e. whether the tensor will be backed by buffer or texture storage) and `api::GPUMemoryLayout` (i.e. which dimension will be the fastest moving dimension) must be specified directly.

Differential Revision: [D52662234](https://our.internmc.facebook.com/intern/diff/D52662234/)