### PR TITLE
Run docker release build on final tag (#117131)

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -11,8 +11,8 @@ on:
     branches:
       - nightly
     tags:
-      # Release candidate tags look like: v1.11.0-rc1
-      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+      # We want to run this build on final release tag
+      - v[0-9]+.[0-9]+.[0-9]+
       - ciflow/nightly/*
 
 concurrency:


### PR DESCRIPTION
To be successful, the docker release workflow needs to run on final tag, after the Release to conda and pypi are complete.

Please refer to: https://github.com/pytorch/pytorch/blob/main/Dockerfile#L76

Pull Request resolved: https://github.com/pytorch/pytorch/pull/117131
Approved by: https://github.com/huydhn, https://github.com/seemethere, https://github.com/malfet

