### PR TITLE
[Dynamo] Handle (via graph break) .grad setting in the direct setattr input mutation case 

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -3549,6 +3549,20 @@ utils_device.CURRENT_DEVICE == None""".split(
         self.assertEqual(cnts.frame_count, 1)
         self.assertEqual(cnts.op_count, 2)
 
+    def test_set_grad_from_input_to_intermed(self):
+        param = torch.rand(2, 3, dtype=torch.float32, device="cuda")
+
+        def f(p):
+            p.grad = torch.rand_like(p)
+            p.grad = p.grad.to_sparse()
+            return p.grad
+
+        cnts = torch._dynamo.testing.CompileCounter()
+        compiled_f = torch._dynamo.optimize(cnts)(f)
+        compiled_f(param)
+        self.assertEqual(cnts.frame_count, 0)
+        self.assertEqual(cnts.op_count, 0)
+
     @skipIfNotPy311
     def test_linetable_311_writer1(self):
         def fn():

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -3550,7 +3550,7 @@ utils_device.CURRENT_DEVICE == None""".split(
         self.assertEqual(cnts.op_count, 2)
 
     def test_set_grad_from_input_to_intermed(self):
-        param = torch.rand(2, 3, dtype=torch.float32, device="cuda")
+        param = torch.rand(2, 3)
 
         def f(p):
             p.grad = torch.rand_like(p)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #117191

Today, .grad mutation works if an inplace op mutates grad: https://github.com/pytorch/pytorch/pull/112811

There are other kinds of grad mutation, that, when accessed - lead to a None! @janeyx99 pinged me saying that in a trivial program (turned into a test in this PR) grad was incorrectly None.

While it would be possible to track .grad setting here, we do not want setattrs in the graph at this time. As such, the best course of action is to graph break here until we decide how to fix it. 

cc @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @aakhundov