### PR TITLE
enable fp16 mkldnn fusion/prepack in inductor

### DIFF
--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -118,20 +118,33 @@ class TestPatternMatcherBase(TestCase):
         matcher_nodes=None,
         atol=1e-5,
         rtol=1.3e-6,
-        check_autocast=False,
+        check_autocast=torch.float32,
         check_quantization=False,
         is_qat=False,
         matcher_check_fn=None,
+        dtype=None,
     ):
         counters.clear()
         torch._dynamo.reset()
-        maybe_autocast = contextlib.nullcontext()
         assert matcher_check_fn is not None or (
             matcher_count is not None and matcher_nodes is not None
         )
-        if check_autocast and torch.ops.mkldnn._is_mkldnn_bf16_supported():
-            maybe_autocast = torch.cpu.amp.autocast()
+        if (
+            check_autocast == torch.bfloat16
+            and torch.ops.mkldnn._is_mkldnn_bf16_supported()
+        ):
+            maybe_autocast = torch.cpu.amp.autocast(dtype=torch.bfloat16)
             atol, rtol = 1e-2, 1e-2
+        elif (
+            check_autocast == torch.float16
+            and torch.ops.mkldnn._is_mkldnn_fp16_supported()
+        ):
+            maybe_autocast = torch.cpu.amp.autocast(dtype=torch.float16)
+            atol, rtol = 1e-2, 1e-2
+        else:
+            assert check_autocast == torch.float32
+            maybe_autocast = contextlib.nullcontext()
+
         if check_quantization:
             convert_model = self._generate_qdq_quantized_model(mod, inputs, is_qat)
             with torch.no_grad(), maybe_autocast:
@@ -208,16 +221,23 @@ class TestPatternMatcher(TestPatternMatcherBase):
                 x = self.conv(x)
                 return self.unary_fn(x)
 
+        dtypes = [
+            torch.float,
+        ]
+        if torch.ops.mkldnn._is_mkldnn_bf16_supported():
+            dtypes.append(torch.bfloat16)
+        if torch.ops.mkldnn._is_mkldnn_fp16_supported():
+            dtypes.append(torch.float16)
         options = itertools.product(
             unary_list.keys(),
             [torch.contiguous_format, torch.channels_last],
-            [True, False] if torch.ops.mkldnn._is_mkldnn_bf16_supported() else [False],
+            dtypes,
         )
 
         for (
             unary_fn,
             memory_format,
-            check_autocast,
+            dtype,
         ) in options:
             x_shape = (1, 3, 56, 56)
             mod = M(unary_fn).to(memory_format=memory_format).eval()
@@ -229,10 +249,13 @@ class TestPatternMatcher(TestPatternMatcherBase):
             )
             # Add 1 for weight packing pass.
             match_nodes = unary_list[unary_fn] + 1
-            if check_autocast and self._check_unary_is_decomposed(unary_fn):
+            if dtype in (
+                torch.float16,
+                torch.bfloat16,
+            ) and self._check_unary_is_decomposed(unary_fn):
                 # Has extra dtype conversion nodes for autocast.
                 match_nodes += 2
-            self._test_common(mod, (v,), 2, match_nodes, check_autocast=check_autocast)
+            self._test_common(mod, (v,), 2, match_nodes, check_autocast=dtype)
 
     def test_linear_unary(self):
         class M(torch.nn.Module):
@@ -257,24 +280,27 @@ class TestPatternMatcher(TestPatternMatcherBase):
                 x = self.linear(x)
                 return self.unary_fn(x)
 
-        options = itertools.product(unary_list, [True, False])
-        dtype = torch.bfloat16
+        dtypes = []
         if torch.ops.mkldnn._is_mkldnn_bf16_supported():
-            for unary_fn, bias in options:
-                mod = M(unary_fn, 10, 30, bias=bias).eval()
-                # only fuse for linear when the dtype is bf16
-                mod = mod.to(dtype)
-                v = torch.randn(2, 10).to(dtype)
-                # packing pass + unary fusion.
-                matcher_count = 2
-                # Add 1 for weight packing pass.
-                matcher_nodes = unary_list[unary_fn] + 1
-                if self._check_unary_is_decomposed(unary_fn):
-                    # Has extra dtype conversion nodes for autocast.
-                    matcher_nodes += 2
-                self._test_common(
-                    mod, (v,), matcher_count, matcher_nodes, check_autocast=True
-                )
+            dtypes.append(torch.bfloat16)
+        if torch.ops.mkldnn._is_mkldnn_fp16_supported():
+            dtypes.append(torch.float16)
+        options = itertools.product(unary_list, [True, False], dtypes)
+        for unary_fn, bias, dtype in options:
+            mod = M(unary_fn, 10, 30, bias=bias).eval()
+            # only fuse for linear when the dtype is bf16
+            mod = mod
+            v = torch.randn(2, 10)
+            # packing pass + unary fusion.
+            matcher_count = 2
+            # Add 1 for weight packing pass.
+            matcher_nodes = unary_list[unary_fn] + 1
+            if self._check_unary_is_decomposed(unary_fn):
+                # Has extra dtype conversion nodes for autocast.
+                matcher_nodes += 2
+            self._test_common(
+                mod, (v,), matcher_count, matcher_nodes, check_autocast=dtype
+            )
 
     @unittest.skipIf(not TEST_MKL, "Test requires MKL")
     def test_linear_fp32(self):
@@ -311,13 +337,21 @@ class TestPatternMatcher(TestPatternMatcherBase):
                 x = self.conv_transpose2d(x)
                 return self.unary_fn(x)
 
+        dtypes = [
+            torch.float,
+        ]
+        if torch.ops.mkldnn._is_mkldnn_bf16_supported():
+            dtypes.append(torch.bfloat16)
+        if torch.ops.mkldnn._is_mkldnn_fp16_supported():
+            dtypes.append(torch.float16)
+
         options = itertools.product(
             unary_list,
             [torch.contiguous_format, torch.channels_last],
-            [True, False] if torch.ops.mkldnn._is_mkldnn_bf16_supported() else [False],
+            dtypes,
         )
 
-        for unary_fn, memory_format, check_autocast in options:
+        for unary_fn, memory_format, dtype in options:
             x_shape = (1, 3, 28, 28)
             mod = M(unary_fn).eval()
 
@@ -326,10 +360,13 @@ class TestPatternMatcher(TestPatternMatcherBase):
             )
             # Add 1 for weight packing pass.
             match_nodes = unary_list[unary_fn] + 1
-            if check_autocast and self._check_unary_is_decomposed(unary_fn):
+            if dtype in (
+                torch.float16,
+                torch.bfloat16,
+            ) and self._check_unary_is_decomposed(unary_fn):
                 # Has extra dtype conversion nodes for autocast.
                 match_nodes += 2
-            self._test_common(mod, (v,), 2, match_nodes, check_autocast=check_autocast)
+            self._test_common(mod, (v,), 2, match_nodes, check_autocast=dtype)
 
     def test_conv2d_binary(self):
         class M(torch.nn.Module):
@@ -392,27 +429,32 @@ class TestPatternMatcher(TestPatternMatcherBase):
                 x = self.binary_fn(x, y.clone())
                 return x
 
-        options = itertools.product(binary_list, [[2, 3, 10], [2, 10]], [True, False])
-        dtype = torch.bfloat16
-        out_feature = 30
+        dtypes = []
         if torch.ops.mkldnn._is_mkldnn_bf16_supported():
-            for binary_fn, input_shape, bias in options:
-                torch._dynamo.reset()
-                # addmm(mm) + (linear+add)
-                match_count = 2
-                match_nodes = 3
-                if len(input_shape) == 3:
-                    is_inplace = binary_list[binary_fn][2]
-                    # view + linear + view(joint_graph+freeze pass)
-                    match_count = match_count + 5 if is_inplace else match_count + 3
-                    match_nodes = match_nodes + 7 if is_inplace else match_nodes + 5
-                mod = M(binary_fn, input_shape[-1], out_feature, bias).to(dtype).eval()
-                v = torch.randn(input_shape).to(dtype)
-                other = torch.randn(input_shape[:-1] + [out_feature]).to(dtype)
-                mod_c = torch.compile(mod)
-                out, code = run_and_get_code(mod_c, v, other)
-                self.assertEqual(out, mod(v, other), rtol=1e-2, atol=1e-2)
-                # TODO - assert fusions work code
+            dtypes.append(torch.bfloat16)
+        if torch.ops.mkldnn._is_mkldnn_fp16_supported():
+            dtypes.append(torch.float16)
+        options = itertools.product(
+            binary_list, [[2, 3, 10], [2, 10]], [True, False], dtypes
+        )
+        out_feature = 30
+        for binary_fn, input_shape, bias, dtype in options:
+            torch._dynamo.reset()
+            # addmm(mm) + (linear+add)
+            match_count = 2
+            match_nodes = 3
+            if len(input_shape) == 3:
+                is_inplace = binary_list[binary_fn][2]
+                # view + linear + view(joint_graph+freeze pass)
+                match_count = match_count + 5 if is_inplace else match_count + 3
+                match_nodes = match_nodes + 7 if is_inplace else match_nodes + 5
+            mod = M(binary_fn, input_shape[-1], out_feature, bias).to(dtype).eval()
+            v = torch.randn(input_shape).to(dtype)
+            other = torch.randn(input_shape[:-1] + [out_feature]).to(dtype)
+            mod_c = torch.compile(mod)
+            out, code = run_and_get_code(mod_c, v, other)
+            self.assertEqual(out, mod(v, other), rtol=1e-2, atol=1e-2)
+            # TODO - assert fusions work code
 
     def test_multi_linear_share_same_input(self):
         # llama pattern.
@@ -427,9 +469,14 @@ class TestPatternMatcher(TestPatternMatcherBase):
             def forward(self, x):
                 return F.silu(self.w1(x)) * F.relu(self.w2(x))
 
-        mod = M().to(torch.bfloat16).eval()
+        dtypes = []
         if torch.ops.mkldnn._is_mkldnn_bf16_supported():
-            v = torch.randn(2, 4, 16).to(torch.bfloat16)
+            dtypes.append(torch.bfloat16)
+        if torch.ops.mkldnn._is_mkldnn_fp16_supported():
+            dtypes.append(torch.float16)
+        for dtype in dtypes:
+            mod = M().to(dtype).eval()
+            v = torch.randn(2, 4, 16).to(dtype)
             # 1. view(match_count=4, match_nodes=4).
             # 2. mm to packed linear(match_count=2, match_nodes=2).
             # 3. view+linear+view to linear(match_count=2, match_nodes=6).
@@ -473,7 +520,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
             mod,
             (v,),
             check_quantization=True,
-            check_autocast=int8_mixed_bf16,
+            check_autocast=torch.bfloat16 if int8_mixed_bf16 else torch.float,
             matcher_check_fn=matcher_check_fn,
         )
 
@@ -531,7 +578,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
             mod,
             (v,),
             check_quantization=True,
-            check_autocast=int8_mixed_bf16,
+            check_autocast=torch.bfloat16 if int8_mixed_bf16 else torch.float,
             matcher_check_fn=matcher_check_fn,
         )
 
@@ -637,7 +684,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
                 mod,
                 (v,),
                 check_quantization=True,
-                check_autocast=int8_mixed_bf16,
+                check_autocast=torch.bfloat16 if int8_mixed_bf16 else torch.float,
                 matcher_check_fn=matcher_check_fn,
             )
 
@@ -1152,7 +1199,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
         self._test_common(
             mod,
             inputs,
-            check_autocast=int8_mixed_bf16,
+            check_autocast=torch.bfloat16 if int8_mixed_bf16 else torch.float,
             check_quantization=True,
             matcher_check_fn=matcher_check_fn
             if matcher_check_fn is not None
@@ -1289,7 +1336,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
             self._test_common(
                 mod,
                 inputs,
-                check_autocast=int8_mixed_bf16,
+                check_autocast=torch.bfloat16 if int8_mixed_bf16 else torch.float,
                 check_quantization=True,
                 matcher_check_fn=matcher_check_fn,
             )
@@ -1367,7 +1414,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
         self._test_common(
             mod,
             inputs,
-            check_autocast=int8_mixed_bf16,
+            check_autocast=torch.bfloat16 if int8_mixed_bf16 else torch.float,
             check_quantization=True,
             matcher_check_fn=matcher_check_fn,
         )
@@ -2009,9 +2056,14 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
             def forward(self, x):
                 return F.silu(self.w1(x)) * F.relu(self.w2(x))
 
-        mod = M().to(torch.bfloat16).eval()
+        dtypes = []
         if torch.ops.mkldnn._is_mkldnn_bf16_supported():
-            v = torch.randn(2, 4, 16).to(torch.bfloat16)
+            dtypes.append(torch.bfloat16)
+        if torch.ops.mkldnn._is_mkldnn_fp16_supported():
+            dtypes.append(torch.float16)
+        for dtype in dtypes:
+            mod = M().to(dtype).eval()
+            v = torch.randn(2, 4, 16).to(dtype)
             # 1. view(match_count=4, match_nodes=4).
             # 2. mm to packed linear(match_count=2, match_nodes=2).
             # 3. view+linear+view to linear(match_count=2, match_nodes=6).

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -68,13 +68,26 @@ if torch._C._has_mkldnn:
             _users=1,
         )
 
-    def _unary_fusion_pattern(unary_fusion, call_fn, users, is_bf16):
-        # only insert to_dtype if is_bf16 is True
+    def _to_fp16(input_call):
+        return CallFunction(
+            prims.convert_element_type.default,
+            input_call,
+            KeywordArg("to_fp16"),
+            _users=1,
+        )
+
+    def _unary_fusion_pattern(unary_fusion, call_fn, users, lp_dtype):
+        # only insert to_dtype if lp_dtype is True
         computation_call = (
-            _to_float(call_fn(), users=users) if is_bf16 else call_fn(users=users)
+            _to_float(call_fn(), users=users) if lp_dtype else call_fn(users=users)
         )
         out = unary_fusion(computation_call)
-        return _to_bf16(out) if is_bf16 else out
+        if lp_dtype == torch.bfloat16:
+            return _to_bf16(out)
+        elif lp_dtype == torch.float16:
+            return _to_fp16(out)
+        else:
+            return out
 
     def _gelu_fusion_1(computation_call):
         return CallFunction(
@@ -194,11 +207,11 @@ if torch._C._has_mkldnn:
 
         return fn
 
-    def _is_valid_computation_unary_fusion(computation_op, is_bf16=False):
+    def _is_valid_computation_unary_fusion(computation_op, lp_dtype=None):
         def fn(match):
             matched = _is_single_computation_op(computation_op)(match)
             computation_node = filter_nodes(match.nodes, computation_op)[0]
-            if is_bf16:
+            if lp_dtype:
                 conversion_dtype_nodes = filter_nodes(
                     match.nodes, prims.convert_element_type.default
                 )
@@ -207,23 +220,21 @@ if torch._C._has_mkldnn:
                 # fusion pattern is always in the form of computation_op + to_float32 + unary_op + to_bfloat16
                 if computation_node == conversion_dtype_nodes[0].args[0]:
                     to_float = conversion_dtype_nodes[0].args[1]
-                    to_bf16 = conversion_dtype_nodes[1].args[1]
+                    to_lp = conversion_dtype_nodes[1].args[1]
                 else:
                     to_float = conversion_dtype_nodes[1].args[1]
-                    to_bf16 = conversion_dtype_nodes[0].args[1]
-                matched = (
-                    matched and to_float == torch.float and to_bf16 == torch.bfloat16
-                )
+                    to_lp = conversion_dtype_nodes[0].args[1]
+                matched = matched and to_float == torch.float and to_lp == lp_dtype
             return matched
 
         return fn
 
     def _register_unary_fusion_lowering(
-        pattern, unary_attr, computation_op, is_bf16=False
+        pattern, unary_attr, computation_op, lp_dtype=None
     ):
         @register_lowering_pattern(
             pattern,
-            extra_check=_is_valid_computation_unary_fusion(computation_op, is_bf16),
+            extra_check=_is_valid_computation_unary_fusion(computation_op, lp_dtype),
         )
         def fn(match, *args, **kwargs):
             computation_args = list(args)[:-3] + [
@@ -235,7 +246,7 @@ if torch._C._has_mkldnn:
 
         return fn
 
-    def _register_leaky_relu_fusion_lowering(pattern, computation_op, is_bf16=False):
+    def _register_leaky_relu_fusion_lowering(pattern, computation_op, lp_dtype=None):
         @register_lowering_pattern(
             pattern, extra_check=_is_single_computation_op(computation_op)
         )
@@ -245,10 +256,14 @@ if torch._C._has_mkldnn:
                 matched = False
             else:  # inp is a Number
                 matched = True
-            if is_bf16:
+            if lp_dtype:
                 dtype1 = kwargs.get("to_float")
-                dtype2 = kwargs.get("to_bf16")
-                matched = matched and dtype1 == torch.float and dtype2 == torch.bfloat16
+                dtype2 = (
+                    kwargs.get("to_bf16")
+                    if lp_dtype == torch.bfloat16
+                    else kwargs.get("to_fp16")
+                )
+                matched = matched and dtype1 == torch.float and dtype2 == lp_dtype
             computation_args = list(args)
             if matched:
                 computation_args = computation_args[:-3] + [
@@ -260,22 +275,20 @@ if torch._C._has_mkldnn:
             else:
                 # computation_args += ["none", [], ""]
                 out = L[computation_op](*computation_args)
-                if is_bf16:
+                if lp_dtype:
                     out = L[prims.convert_element_type.default](out, dtype=torch.float)
                 out = L[aten.where](
                     L[aten.gt](out, 0),
                     out,
                     L[aten.mul](out, negative_slope),
                 )
-                if is_bf16:
-                    out = L[prims.convert_element_type.default](
-                        out, dtype=torch.bfloat16
-                    )
+                if lp_dtype:
+                    out = L[prims.convert_element_type.default](out, dtype=dtype2)
                 return out
 
         return fn
 
-    def _register_hardtanh_fusion_lowering(pattern, computation_op, is_bf16=False):
+    def _register_hardtanh_fusion_lowering(pattern, computation_op, lp_dtype=None):
         @register_lowering_pattern(
             pattern, extra_check=_is_single_computation_op(computation_op)
         )
@@ -289,10 +302,14 @@ if torch._C._has_mkldnn:
             else:  # inp is a Number
                 assert max_value is not None
                 matched = min_value <= max_value
-            if is_bf16:
+            if lp_dtype:
                 dtype1 = kwargs.get("to_float")
-                dtype2 = kwargs.get("to_bf16")
-                matched = matched and dtype1 == torch.float and dtype2 == torch.bfloat16
+                dtype2 = (
+                    kwargs.get("to_bf16")
+                    if lp_dtype == torch.bfloat16
+                    else kwargs.get("to_fp16")
+                )
+                matched = matched and dtype1 == torch.float and dtype2 == lp_dtype
             computation_args = list(args)
             if matched:
                 computation_args = computation_args[:-3] + [
@@ -303,13 +320,11 @@ if torch._C._has_mkldnn:
                 return L[computation_op](*computation_args)
             else:
                 out = L[computation_op](*computation_args)
-                if is_bf16:
+                if lp_dtype:
                     out = L[prims.convert_element_type.default](out, dtype=torch.float)
                 out = L[aten.clamp_max](L[aten.clamp_min](out, min_value), max_value)
-                if is_bf16:
-                    out = L[prims.convert_element_type.default](
-                        out, dtype=torch.bfloat16
-                    )
+                if lp_dtype:
+                    out = L[prims.convert_element_type.default](out, dtype=dtype2)
                 return out
 
         return fn
@@ -527,30 +542,30 @@ if torch._C._has_mkldnn:
     def _register_unary_fusion():
         computation_call_fns = [_conv_call, _linear_call, _conv_transpose_call]
 
-        def _unary_fusion_patterns(is_bf16):
+        def _unary_fusion_patterns(lp_dtype):
             replacement_unary_fusion_patterns = {
                 UnaryAttr("gelu", algorithm_attr="tanh"): [
-                    _unary_fusion_pattern(_gelu_fusion_2, call_fn, 4, is_bf16)
+                    _unary_fusion_pattern(_gelu_fusion_2, call_fn, 4, lp_dtype)
                     for call_fn in computation_call_fns
                 ],
                 UnaryAttr("gelu", algorithm_attr="none"): [
-                    _unary_fusion_pattern(_gelu_fusion_1, call_fn, 2, is_bf16)
+                    _unary_fusion_pattern(_gelu_fusion_1, call_fn, 2, lp_dtype)
                     for call_fn in computation_call_fns
                 ],
                 UnaryAttr("hardswish"): [
-                    _unary_fusion_pattern(_hardswish_fusion, call_fn, 2, is_bf16)
+                    _unary_fusion_pattern(_hardswish_fusion, call_fn, 2, lp_dtype)
                     for call_fn in computation_call_fns
                 ],
                 UnaryAttr("hardsigmoid"): [
-                    _unary_fusion_pattern(_hardsigmoid_fusion, call_fn, 1, is_bf16)
+                    _unary_fusion_pattern(_hardsigmoid_fusion, call_fn, 1, lp_dtype)
                     for call_fn in computation_call_fns
                 ],
                 UnaryAttr("swish"): [
-                    _unary_fusion_pattern(_silu_fusion, call_fn, 2, is_bf16)
+                    _unary_fusion_pattern(_silu_fusion, call_fn, 2, lp_dtype)
                     for call_fn in computation_call_fns
                 ],
             }
-            if not is_bf16:
+            if not lp_dtype:
                 call_user1 = [call_fn(users=1) for call_fn in computation_call_fns]
                 replacement_unary_fusion_patterns.update(
                     {
@@ -568,30 +583,30 @@ if torch._C._has_mkldnn:
 
             return replacement_unary_fusion_patterns
 
-        for is_bf16 in [True, False]:
-            replace_patterns = _unary_fusion_patterns(is_bf16)
+        for lp_dtype in [torch.bfloat16, torch.float16, None]:
+            replace_patterns = _unary_fusion_patterns(lp_dtype)
             for unary_attr, patterns in replace_patterns.items():
                 _register_unary_fusion_lowering(
-                    patterns[0], unary_attr, computation_ops[0], is_bf16
+                    patterns[0], unary_attr, computation_ops[0], lp_dtype
                 )
                 _register_unary_fusion_lowering(
-                    patterns[1], unary_attr, computation_ops[1], is_bf16
+                    patterns[1], unary_attr, computation_ops[1], lp_dtype
                 )
                 _register_unary_fusion_lowering(
-                    patterns[2], unary_attr, computation_ops[2], is_bf16
+                    patterns[2], unary_attr, computation_ops[2], lp_dtype
                 )
             _leaky_relu_patterns = [
-                _unary_fusion_pattern(_leaky_relu_fusion, call_fn, 3, is_bf16)
+                _unary_fusion_pattern(_leaky_relu_fusion, call_fn, 3, lp_dtype)
                 for call_fn in computation_call_fns
             ]
             for pattern, computation_op in zip(_leaky_relu_patterns, computation_ops):
-                _register_leaky_relu_fusion_lowering(pattern, computation_op, is_bf16)
+                _register_leaky_relu_fusion_lowering(pattern, computation_op, lp_dtype)
             hardtanh_patterns = [
-                _unary_fusion_pattern(_hardtanh_fusion, call_fn, 1, is_bf16)
+                _unary_fusion_pattern(_hardtanh_fusion, call_fn, 1, lp_dtype)
                 for call_fn in computation_call_fns
             ]
             for pattern, computation_op in zip(hardtanh_patterns, computation_ops):
-                _register_hardtanh_fusion_lowering(pattern, computation_op, is_bf16)
+                _register_hardtanh_fusion_lowering(pattern, computation_op, lp_dtype)
 
     def _register_inplace_fusion():
         binary_ops = [aten.add, ops.add]
@@ -816,6 +831,12 @@ if torch._C._has_mkldnn:
             for POS_ARG in POS_ARGS
         ):
             return False
+        if any(
+            lstm_node.args[POS_ARG].meta.get("val").dtype == torch.float16
+            and not mkldnn._is_mkldnn_fp16_supported()
+            for POS_ARG in POS_ARGS
+        ):
+            return False
 
         return True
 
@@ -843,6 +864,12 @@ if torch._C._has_mkldnn:
             or weight_meta_value.dtype == torch.bfloat16
         ):
             if not mkldnn._is_mkldnn_bf16_supported():
+                return False
+        if (
+            input_meta_value.dtype == torch.float16
+            or weight_meta_value.dtype == torch.float16
+        ):
+            if not mkldnn._is_mkldnn_fp16_supported():
                 return False
         is_transposed = conv_node.args[-3]
         if is_transposed:
@@ -878,11 +905,14 @@ if torch._C._has_mkldnn:
         if input_meta_value is None or weight_meta_value is None:
             return False
         batch_size = input_meta_value.shape[0]
-        is_bf16_weight = weight_meta_value.dtype == torch.bfloat16
+        is_lp_weight = weight_meta_value.dtype in (
+            torch.bfloat16,
+            torch.float16,
+        )
         # on x86, for fp32, mkl should be enabled and batch_size should not be a free symbol.
         # on aarch64, use mkldnn op for fp32 as well if acl is enabled
         if (
-            not is_bf16_weight
+            not is_lp_weight
             and not mkldnn._is_mkldnn_acl_supported()
             and ((not torch._C.has_mkl) or has_free_symbols(batch_size))
         ):
@@ -909,6 +939,12 @@ if torch._C._has_mkldnn:
             or weight_meta_value.dtype == torch.bfloat16
         ):
             if not mkldnn._is_mkldnn_bf16_supported():
+                return False
+        if (
+            input_meta_value.dtype == torch.float16
+            or weight_meta_value.dtype == torch.float16
+        ):
+            if not mkldnn._is_mkldnn_fp16_supported():
                 return False
         return True
 
@@ -1055,12 +1091,15 @@ if torch._C._has_mkldnn:
                     "call_function", aten.permute.default, (weight, (1, 0))
                 )
                 weight_dtype = weight.meta.get("val").dtype
-                is_bf16_weight = weight_dtype == torch.bfloat16
+                is_lp_weight = weight_dtype in (
+                    torch.bfloat16,
+                    torch.float16,
+                )
                 batch_size = input.meta.get("val").shape[0]
                 if has_free_symbols(batch_size):
                     assert (
-                        is_bf16_weight or mkldnn._is_mkldnn_acl_supported()
-                    ), f"only bf16 weight prepacking supports dynamic shape inputs but got {weight_dtype}"
+                        is_lp_weight or mkldnn._is_mkldnn_acl_supported()
+                    ), f"only bf16/fp16 weight prepacking supports dynamic shape inputs but got {weight_dtype}"
                 # For bfloat16 dynamic shape path, using input size hint to pack weight for a better performance.
                 packed_weight_inputs = (
                     transpose_weight_node,
@@ -1070,7 +1109,7 @@ if torch._C._has_mkldnn:
                 )
                 packed_weight_op = (
                     mkldnn._reorder_linear_weight
-                    if (is_bf16_weight or mkldnn._is_mkldnn_acl_supported())
+                    if (is_lp_weight or mkldnn._is_mkldnn_acl_supported())
                     else torch.ops.mkl._mkl_reorder_linear_weight
                 )
                 packed_weight_node = graph.create_node(
@@ -1078,7 +1117,7 @@ if torch._C._has_mkldnn:
                 )
 
                 packed_linear_inputs: Tuple[Any, ...] = (input, packed_weight_node)
-                if is_bf16_weight or mkldnn._is_mkldnn_acl_supported():
+                if is_lp_weight or mkldnn._is_mkldnn_acl_supported():
                     packed_linear_inputs += (bias, "none", [], "")
                     packed_linear_op = mkldnn._linear_pointwise.default
                 else:


### PR DESCRIPTION
- Extend `linear/conv/rnn` packable with `float16`.
- Extend `Unary fusion` to support `float16`.

Test Case:
    Extend bfloat16 related test in `test_cpu_repro.py` and `test_mkldnn_pattern_matcher.py` to test both `fp16` and `bf16`.



Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #117206



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler