### PR TITLE
Change PrivateUse1's resize_bytes to PrivateUse1HooksInterface

### DIFF
--- a/aten/src/ATen/detail/PrivateUse1HooksInterface.h
+++ b/aten/src/ATen/detail/PrivateUse1HooksInterface.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <ATen/ATen.h>
 #include <ATen/core/Generator.h>
 #include <c10/core/Device.h>
+#include <c10/core/StorageImpl.h>
 #include <c10/util/Exception.h>
 namespace at {
 
@@ -20,6 +22,31 @@ struct TORCH_API PrivateUse1HooksInterface {
   }
 
   virtual void initPrivateUse1() const {}
+  virtual void resizePrivateUse1Bytes(at::Storage &storage, size_t newsize) const {
+    ptrdiff_t size_bytes_i = newsize;
+    TORCH_CHECK(
+        !c10::overflows<int64_t>(size_bytes_i),
+        "Requested storage size (",
+        size_bytes_i,
+        ") cannot be represented as a int64_t");
+    const auto size_bytes = static_cast<int64_t>(size_bytes_i);
+    void* original_data_ptr = storage.data_ptr().get();
+
+    auto src_option =
+        c10::TensorOptions().device(storage.device()).dtype(at::kByte);
+    auto src_tensor = at::empty({0}, {}, src_option).set_(storage);
+    src_tensor.resize_({size_bytes});
+
+    if (original_data_ptr == src_tensor.storage().data_ptr().get()) {
+      auto new_tensor = at::empty(src_tensor.sizes(), src_tensor.options());
+      new_tensor.copy_(src_tensor);
+      storage.set_data_ptr_noswap(
+          std::move(new_tensor.storage().mutable_data_ptr()));
+      storage.unsafeGetStorageImpl()->set_allocator(
+          new_tensor.storage().unsafeGetStorageImpl()->allocator());
+      storage.set_nbytes(new_tensor.storage().nbytes());
+    }
+  }
 };
 
 struct TORCH_API PrivateUse1HooksArgs {};

--- a/torch/csrc/StorageMethods.cpp
+++ b/torch/csrc/StorageMethods.cpp
@@ -32,6 +32,7 @@
 #endif
 
 #include <ATen/native/Resize.h>
+#include <ATen/detail/PrivateUse1HooksInterface.h>
 
 #ifdef _MSC_VER
 #define LSEEK _lseeki64
@@ -149,7 +150,7 @@ static PyObject* THPStorage_resize_(PyObject* self, PyObject* number_arg) {
 #endif
   } else if (device_type == at::kMeta) {
     at::native::resize_bytes_meta(storage.unsafeGetStorageImpl(), newsize);
-  } else if (device_type == at::kXPU || device_type == at::kPrivateUse1) {
+  } else if (device_type == at::kXPU) {
     ptrdiff_t size_bytes_i = newsize;
     TORCH_CHECK(
         !c10::overflows<int64_t>(size_bytes_i),
@@ -176,6 +177,10 @@ static PyObject* THPStorage_resize_(PyObject* self, PyObject* number_arg) {
       storage.unsafeGetStorageImpl()->set_allocator(
           new_tensor.storage().unsafeGetStorageImpl()->allocator());
       storage.set_nbytes(new_tensor.storage().nbytes());
+    }
+  } else if (device_type == at::kPrivateUse1) {
+    if (at::isPrivateUse1HooksRegistered()) {
+      at::GetPrivateUse1HooksInterface()->resizePrivateUse1Bytes(storage, newsize);
     }
   } else {
     TORCH_CHECK(


### PR DESCRIPTION
I found that the old way to resize ``privateuse1`` backend will failed for some special data. Could ``privateuse1``'s resize_bytes method changed to PrivateUse1HooksInterface so that I can register my own function