### PR TITLE
Abstract common helpers from CUDA implementation for code reusing in upcoming SYCL kernels

### DIFF
--- a/aten/src/ATen/cuda/jiterator_impl.h
+++ b/aten/src/ATen/cuda/jiterator_impl.h
@@ -4,7 +4,7 @@
 #if AT_USE_JITERATOR()
 
 #include <ATen/native/TensorIterator.h>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/native/cuda/jit_utils.h>
 #include <ATen/native/cuda/MemoryAccess.cuh>
 #include <ATen/native/cuda/JitLoops.cuh>

--- a/aten/src/ATen/detail/ElementwiseInvoke.h
+++ b/aten/src/ATen/detail/ElementwiseInvoke.h
@@ -1,0 +1,67 @@
+#pragma once
+
+// Element-wise invoke. Invoking data load (`data`) and custom function (`f`)
+// for an element specified by a logical index (`i`). Return the result of
+// custom function. Custom function is a user-defined functor for
+// scalar calculation.
+
+#include <type_traits>
+
+#include <ATen/detail/FunctionTraits.h>
+#include <c10/macros/Macros.h>
+#include <c10/core/DynamicCast.h>
+#include <c10/core/ScalarType.h>
+
+template <typename traits, typename func_t, typename index_t, size_t... INDEX>
+C10_HOST_DEVICE typename traits::result_type invoke_impl(
+    const func_t& f,
+    char* const C10_RESTRICT data[],
+    const index_t strides[],
+    int i,
+    std::index_sequence<INDEX...>) {
+  (void)strides;
+  (void)i;
+  return f(c10::load<typename traits::template arg<INDEX>::type>(
+      data[INDEX] + i * strides[INDEX])...);
+}
+
+template <
+    typename func_t,
+    typename index_t,
+    typename traits = function_traits<func_t>>
+C10_HOST_DEVICE typename traits::result_type invoke(
+    const func_t& f,
+    char* const C10_RESTRICT data[],
+    const index_t strides[],
+    int i) {
+  using Indices = std::make_index_sequence<traits::arity>;
+  return invoke_impl<traits>(f, data, strides, i, Indices{});
+}
+
+template <typename traits, typename func_t, typename index_t, size_t... I>
+C10_HOST_DEVICE typename traits::result_type invoke_impl(
+    const func_t& f,
+    char* const C10_RESTRICT data[],
+    const index_t strides[],
+    const c10::ScalarType dtypes[],
+    int i,
+    std::index_sequence<I...>) {
+  (void)strides;
+  (void)i;
+  return f(c10::fetch_and_cast<typename traits::template arg<I>::type>(
+      dtypes[I], data[I] + i * strides[I])...);
+}
+
+template <
+    typename func_t,
+    typename index_t,
+    typename traits = function_traits<func_t>>
+C10_HOST_DEVICE typename traits::result_type invoke(
+    const func_t& f,
+    char* const C10_RESTRICT data[],
+    const index_t strides[],
+    const c10::ScalarType dtypes[],
+    int i) {
+  using Indices = std::make_index_sequence<traits::arity>;
+  return invoke_impl<traits>(f, data, strides, dtypes, i, Indices{});
+}

--- a/aten/src/ATen/detail/IntegerDivider.h
+++ b/aten/src/ATen/detail/IntegerDivider.h
@@ -5,7 +5,7 @@
 #include <cuda_runtime.h>
 #endif
 
-namespace at::cuda::detail {
+namespace at::detail {
 
 // A utility class to implement integer division by multiplication, given a fixed
 // divisor.
@@ -121,4 +121,4 @@ struct IntDivider<unsigned int> {
   unsigned int shift;  // Shift amounts.
 };
 
-}  // namespace at::cuda::detail
+}  // namespace at::detail

--- a/aten/src/ATen/detail/MemoryAccessUtils.h
+++ b/aten/src/ATen/detail/MemoryAccessUtils.h
@@ -1,0 +1,173 @@
+#pragma once
+
+#include <c10/core/DynamicCast.h>
+#include <c10/macros/Macros.h>
+#include <ATen/core/Array.h>
+#include <ATen/native/TensorIterator.h>
+
+#include <thrust/tuple.h>
+
+namespace at { namespace native { namespace memory {
+
+namespace detail {
+
+// What does the `static_unroll` do?
+//
+// We want to do something like:
+//
+//    using args_t = typename traits::ArgsTuple;
+//    args_t args;
+//    #pragma unroll
+//    for (int i = 0; i < traits::arity; i++) {
+//      std::get<i>(args) = ....
+//    }
+//
+// but unfortunately the above code does not work because
+// the template argument has to be a compile time constant
+// so `static_unroll` is created to simulate `#pragma unroll`
+// using template metaprogramming.
+
+template<template<int i> typename func, int end, int current=0>
+struct static_unroll {
+  template<typename... Args>
+  static inline C10_HOST_DEVICE void with_args(Args&&... args) {
+    func<current>::apply(std::forward<Args>(args)...);
+    static_unroll<func, end, current+1>::with_args(args...);
+  }
+};
+
+template<template<int i> typename func, int end>
+struct static_unroll<func, end, end> {
+  template<typename... Args>
+  static inline C10_HOST_DEVICE void with_args(Args... args) {}
+};
+
+// helper structs to be used with static_unroll to load arguments
+// one by one
+
+template<int arg_index>
+struct vectorized_load_helper {
+  template <typename args_t, typename policy_t, typename offset_t>
+  static C10_DEVICE void apply(policy_t &self, args_t *args, offset_t offset) {
+    using arg_t = std::tuple_element_t<arg_index, args_t>;
+    // `data` hold the data_ptr for tensors [output, input0, input1, ...], so we
+    // need a +1 offset to get the input
+    auto ptr = reinterpret_cast<arg_t *>(self.data[arg_index + 1]) + offset;
+    auto args_accessor = [&args] C10_DEVICE (int thread_unroll_idx) -> arg_t & { return std::get<arg_index>(args[thread_unroll_idx]); };
+    self.load_single_arg(args_accessor, ptr);
+  }
+};
+
+template<int arg_index>
+struct unroll_load_helper {
+  template <typename args_t, typename policy_t, typename offset_t, typename loader_t>
+  static C10_DEVICE void apply(policy_t &self, args_t *args, offset_t offset, loader_t loader, int j, int num_outputs) {
+    using arg_t = std::tuple_element_t<arg_index, args_t>;
+    // `data` hold the data_ptr for tensors [output, input0, input1, ...], so we
+    // need a +1 offset to get the input
+    std::get<arg_index>(args[j]) = loader.template load<arg_t>(self.data[arg_index + num_outputs], offset[arg_index], arg_index);
+  }
+};
+
+template <int current>
+struct multi_outputs_store_helper {
+  template<int ntensors, int num_outputs, typename ...Args>
+  C10_HOST_DEVICE static void apply(
+      at::detail::Array<char*, ntensors> data,
+      at::detail::Array<uint32_t, num_outputs> offsets,
+      thrust::tuple<Args...> ret) {
+    using T = typename thrust::tuple_element<current, thrust::tuple<Args...>>::type;
+    T *to = reinterpret_cast<T *>(data[current]) + offsets[current];
+    *to = thrust::get<current>(ret);
+  }
+};
+
+}  // namespace detail
+
+struct LoadWithoutCast {
+  template<typename scalar_t>
+  C10_DEVICE scalar_t load(char *base_ptr, uint32_t offset, int arg) {
+    return c10::load(reinterpret_cast<scalar_t *>(base_ptr) + offset);
+  }
+};
+
+template <int N>
+struct LoadWithCast {
+  using array_t = at::detail::Array<at::ScalarType, std::max<int>(N, 1)>;
+  using size_array_t = at::detail::Array<uint32_t, std::max<int>(N, 1)>;
+
+  array_t dtypes;
+  size_array_t element_sizes;
+
+  LoadWithCast(const TensorIteratorBase& iter) {
+    assert(iter.ninputs() == N);
+    #pragma unroll
+    for (auto i = 0; i < N; ++i) {
+      this->dtypes[i] = iter.dtype(i + iter.noutputs());
+      element_sizes[i] = c10::elementSize(iter.dtype(i + iter.noutputs()));
+    }
+  }
+
+  template<typename scalar_t>
+  C10_DEVICE scalar_t load(char *base_ptr, uint32_t offset, int arg) {
+    void *ptr = base_ptr + element_sizes[arg] * offset;
+    return c10::fetch_and_cast<scalar_t>(dtypes[arg], ptr);
+  }
+};
+
+struct StoreWithoutCast {
+  template<typename scalar_t>
+  C10_DEVICE void store(scalar_t value, char *base_ptr, uint32_t offset, int arg = 0) {
+    *(reinterpret_cast<scalar_t *>(base_ptr) + offset) = value;
+  }
+};
+
+template <int N = 1>
+struct StoreWithCast {
+  using array_t = at::detail::Array<at::ScalarType, std::max<int>(N, 1)>;
+  using size_array_t = at::detail::Array<uint32_t, std::max<int>(N, 1)>;
+
+  array_t dtypes;
+  size_array_t element_sizes;
+
+  StoreWithCast(const TensorIteratorBase& iter) {
+    assert(iter.noutputs() == N);
+    #pragma unroll
+    for (auto i = 0; i < N; ++i) {
+      this->dtypes[i] = iter.dtype(i);
+      element_sizes[i] = c10::elementSize(iter.dtype(i));
+    }
+  }
+
+  template<typename scalar_t>
+  C10_DEVICE void store(scalar_t value, char *base_ptr, uint32_t offset, int arg = 0) {
+    void *ptr = base_ptr + element_sizes[arg] * offset;
+    c10::cast_and_store<scalar_t>(dtypes[arg], ptr, value);
+  }
+};
+
+// aligned vector generates vectorized load/store on CUDA
+template<typename scalar_t, int vec_size>
+struct alignas(sizeof(scalar_t) * vec_size) aligned_vector {
+  scalar_t val[vec_size];
+};
+
+template <int vec_size, typename scalar_t>
+C10_DEVICE aligned_vector<scalar_t, vec_size> load_vector(const scalar_t *base_ptr, uint32_t offset) {
+  using vec_t = aligned_vector<scalar_t, vec_size>;
+  auto *from = reinterpret_cast<const vec_t *>(base_ptr);
+  return from[offset];
+}
+
+template <int vec_size>
+C10_DEVICE aligned_vector<bool, vec_size> load_vector(const bool *base_ptr, uint32_t offset) {
+  // See NOTE [Loading boolean values]
+  auto tmp = load_vector<vec_size>(reinterpret_cast<const uint8_t*>(base_ptr), offset);
+  aligned_vector<bool, vec_size> ret;
+  for (int i = 0; i < vec_size; ++i) {
+    ret.val[i] = bool(tmp.val[i]);
+  }
+  return ret;
+}
+
+}}} // namespace at::native::memory

--- a/aten/src/ATen/detail/OffsetCalculator.h
+++ b/aten/src/ATen/detail/OffsetCalculator.h
@@ -5,8 +5,8 @@
 #include <type_traits>
 #include <c10/macros/Macros.h>
 #include <ATen/core/Array.h>
+#include <ATen/detail/IntegerDivider.h>
 #include <ATen/native/TensorIterator.h>
-#include <ATen/cuda/detail/IntegerDivider.cuh>
 
 // If element_sizes is nullptr, then the strides will be in bytes, otherwise
 // the strides will be in # of elements.
@@ -36,7 +36,7 @@ struct OffsetCalculator {
   OffsetCalculator(int dims, const int64_t* sizes, const int64_t* const* strides, const int64_t* element_sizes=nullptr) : dims(dims) {
     TORCH_CHECK(dims <= MAX_DIMS, "tensor has too many (>", MAX_DIMS, ") dims");
     for (int i=0; i < dims; i++){
-      sizes_[i] = at::cuda::detail::IntDivider<index_t>(sizes[i]);
+      sizes_[i] = at::detail::IntDivider<index_t>(sizes[i]);
       for (int arg = 0; arg < NARGS; arg++) {
         int64_t element_size = (element_sizes == nullptr ? 1LL : element_sizes[arg]);
         strides_[i][arg] = strides[arg][i] / element_size;
@@ -69,7 +69,7 @@ struct OffsetCalculator {
   }
 
   int dims;
-  at::cuda::detail::IntDivider<index_t> sizes_[MAX_DIMS];
+  at::detail::IntDivider<index_t> sizes_[MAX_DIMS];
   stride_t strides_[MAX_DIMS][std::max<int>(NARGS, 1)];
 };
 

--- a/aten/src/ATen/native/cuda/ActivationEluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationEluKernel.cu
@@ -13,7 +13,7 @@
 #include <c10/core/Scalar.h>
 #include <c10/cuda/CUDAMathCompat.h>
 #include <ATen/cuda/ApplyGridUtils.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/native/cuda/Loops.cuh>
 
 namespace at::native {

--- a/aten/src/ATen/native/cuda/ActivationGeluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationGeluKernel.cu
@@ -13,7 +13,7 @@
 #include <c10/core/Scalar.h>
 #include <c10/cuda/CUDAMathCompat.h>
 #include <ATen/cuda/ApplyGridUtils.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/native/cuda/Loops.cuh>
 
 namespace at::native {

--- a/aten/src/ATen/native/cuda/ActivationGluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationGluKernel.cu
@@ -13,7 +13,7 @@
 #include <c10/core/Scalar.h>
 #include <c10/cuda/CUDAMathCompat.h>
 #include <ATen/cuda/ApplyGridUtils.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/native/cuda/Loops.cuh>
 
 namespace at::native {

--- a/aten/src/ATen/native/cuda/ActivationHardshrinkKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationHardshrinkKernel.cu
@@ -13,7 +13,7 @@
 #include <c10/core/Scalar.h>
 #include <c10/cuda/CUDAMathCompat.h>
 #include <ATen/cuda/ApplyGridUtils.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/native/cuda/Loops.cuh>
 
 namespace at::native {

--- a/aten/src/ATen/native/cuda/ActivationHardsigmoidKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationHardsigmoidKernel.cu
@@ -13,7 +13,7 @@
 #include <c10/core/Scalar.h>
 #include <c10/cuda/CUDAMathCompat.h>
 #include <ATen/cuda/ApplyGridUtils.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/native/cuda/Loops.cuh>
 
 namespace at::native {

--- a/aten/src/ATen/native/cuda/ActivationHardswishKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationHardswishKernel.cu
@@ -13,7 +13,7 @@
 #include <c10/core/Scalar.h>
 #include <c10/cuda/CUDAMathCompat.h>
 #include <ATen/cuda/ApplyGridUtils.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/native/cuda/Loops.cuh>
 
 namespace at::native {

--- a/aten/src/ATen/native/cuda/ActivationHardtanhKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationHardtanhKernel.cu
@@ -13,7 +13,7 @@
 #include <c10/core/Scalar.h>
 #include <c10/cuda/CUDAMathCompat.h>
 #include <ATen/cuda/ApplyGridUtils.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/native/cuda/Loops.cuh>
 
 namespace at::native {

--- a/aten/src/ATen/native/cuda/ActivationLeakyReluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationLeakyReluKernel.cu
@@ -13,7 +13,7 @@
 #include <c10/core/Scalar.h>
 #include <c10/cuda/CUDAMathCompat.h>
 #include <ATen/cuda/ApplyGridUtils.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/native/cuda/Loops.cuh>
 
 namespace at::native {

--- a/aten/src/ATen/native/cuda/ActivationLogSigmoidKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationLogSigmoidKernel.cu
@@ -13,7 +13,7 @@
 #include <c10/core/Scalar.h>
 #include <c10/cuda/CUDAMathCompat.h>
 #include <ATen/cuda/ApplyGridUtils.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/native/cuda/Loops.cuh>
 
 namespace at::native {

--- a/aten/src/ATen/native/cuda/ActivationMishKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationMishKernel.cu
@@ -13,7 +13,7 @@
 #include <c10/core/Scalar.h>
 #include <c10/cuda/CUDAMathCompat.h>
 #include <ATen/cuda/ApplyGridUtils.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/native/cuda/Loops.cuh>
 
 namespace at::native {

--- a/aten/src/ATen/native/cuda/ActivationPreluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationPreluKernel.cu
@@ -13,7 +13,7 @@
 #include <c10/core/Scalar.h>
 #include <c10/cuda/CUDAMathCompat.h>
 #include <ATen/cuda/ApplyGridUtils.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/native/cuda/Loops.cuh>
 
 namespace at::native {

--- a/aten/src/ATen/native/cuda/ActivationSiluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationSiluKernel.cu
@@ -13,7 +13,7 @@
 #include <c10/core/Scalar.h>
 #include <c10/cuda/CUDAMathCompat.h>
 #include <ATen/cuda/ApplyGridUtils.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/native/cuda/Loops.cuh>
 #include <c10/util/complex.h>
 

--- a/aten/src/ATen/native/cuda/ActivationSoftplusKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationSoftplusKernel.cu
@@ -13,7 +13,7 @@
 #include <c10/core/Scalar.h>
 #include <c10/cuda/CUDAMathCompat.h>
 #include <ATen/cuda/ApplyGridUtils.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/native/cuda/Loops.cuh>
 
 namespace at::native {

--- a/aten/src/ATen/native/cuda/ActivationSoftshrinkKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationSoftshrinkKernel.cu
@@ -13,7 +13,7 @@
 #include <c10/core/Scalar.h>
 #include <c10/cuda/CUDAMathCompat.h>
 #include <ATen/cuda/ApplyGridUtils.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/native/cuda/Loops.cuh>
 
 namespace at::native {

--- a/aten/src/ATen/native/cuda/ActivationThresholdKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationThresholdKernel.cu
@@ -13,7 +13,7 @@
 #include <c10/core/Scalar.h>
 #include <c10/cuda/CUDAMathCompat.h>
 #include <ATen/cuda/ApplyGridUtils.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/native/cuda/Loops.cuh>
 
 namespace at::native {

--- a/aten/src/ATen/native/cuda/CUDAJitLoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDAJitLoops.cuh
@@ -8,7 +8,7 @@
 #include <ATen/TensorIterator.h>
 #include <ATen/core/Array.h>
 #include <ATen/cuda/CUDAContext.h>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/native/cuda/jit_utils.h>
 #include <ATen/native/cuda/MemoryAccess.cuh>
 #include <ATen/native/cuda/thread_constants.h>

--- a/aten/src/ATen/native/cuda/DistributionTemplates.h
+++ b/aten/src/ATen/native/cuda/DistributionTemplates.h
@@ -10,7 +10,7 @@
 #include <c10/util/Half.h>
 #include <ATen/cuda/CUDAApplyUtils.cuh>
 #include <ATen/cuda/CUDAContext.h>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/cuda/CUDAGraphsUtils.cuh>
 #include <ATen/detail/FunctionTraits.h>
 #include <ATen/core/DistributionsHelper.h>

--- a/aten/src/ATen/native/cuda/FlattenIndicesKernel.cu
+++ b/aten/src/ATen/native/cuda/FlattenIndicesKernel.cu
@@ -3,7 +3,7 @@
 #include <ATen/native/sparse/FlattenIndicesCommon.h>
 #include <ATen/native/cuda/Loops.cuh>
 #include <ATen/native/cuda/KernelUtils.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/AccumulateType.h>
 
 namespace at::native {

--- a/aten/src/ATen/native/cuda/FunctionOfAMatrixUtilsKernel.cu
+++ b/aten/src/ATen/native/cuda/FunctionOfAMatrixUtilsKernel.cu
@@ -3,7 +3,7 @@
 
 #include <ATen/Dispatch.h>
 #include <ATen/native/cuda/Loops.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/cuda/Atomic.cuh>
 #include <ATen/cuda/CUDAContext.h>
 

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -9,7 +9,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/cub.h>
 #include <ATen/cuda/detail/IndexUtils.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/native/cuda/Loops.cuh>
 #include <ATen/native/cuda/KernelUtils.cuh>
 #include <ATen/native/quantized/IndexKernel.h>

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <ATen/detail/FunctionTraits.h>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/TensorIteratorDynamicCasting.h>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/OpMathType.h>
 #include <ATen/native/cuda/thread_constants.h>
 

--- a/aten/src/ATen/native/cuda/MemoryAccess.cuh
+++ b/aten/src/ATen/native/cuda/MemoryAccess.cuh
@@ -8,7 +8,8 @@
 #include <c10/macros/Macros.h>
 #include <ATen/core/Array.h>
 #include <ATen/detail/FunctionTraits.h>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/MemoryAccessUtils.h>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/native/cuda/thread_constants.h>
 
 #include <thrust/tuple.h>
@@ -17,168 +18,6 @@
 // https://devblogs.nvidia.com/cuda-pro-tip-increase-performance-with-vectorized-memory-access/
 
 namespace at { namespace native { namespace memory {
-
-namespace detail {
-
-// What does the `static_unroll` do?
-//
-// We want to do something like:
-//
-//    using args_t = typename traits::ArgsTuple;
-//    args_t args;
-//    #pragma unroll
-//    for (int i = 0; i < traits::arity; i++) {
-//      std::get<i>(args) = ....
-//    }
-//
-// but unfortunately the above code does not work because
-// the template argument has to be a compile time constant
-// so `static_unroll` is created to simulate `#pragma unroll`
-// using template metaprogramming.
-
-template<template<int i> typename func, int end, int current=0>
-struct static_unroll {
-  template<typename... Args>
-  static inline C10_HOST_DEVICE void with_args(Args&&... args) {
-    func<current>::apply(std::forward<Args>(args)...);
-    static_unroll<func, end, current+1>::with_args(args...);
-  }
-};
-
-template<template<int i> typename func, int end>
-struct static_unroll<func, end, end> {
-  template<typename... Args>
-  static inline C10_HOST_DEVICE void with_args(Args... args) {}
-};
-
-// helper structs to be used with static_unroll to load arguments
-// one by one
-
-template<int arg_index>
-struct vectorized_load_helper {
-  template <typename args_t, typename policy_t>
-  static __device__ void apply(policy_t &self, args_t *args, int idx) {
-    using arg_t = std::tuple_element_t<arg_index, args_t>;
-    // `data` hold the data_ptr for tensors [output, input0, input1, ...], so we
-    // need a +1 offset to get the input
-    auto ptr = reinterpret_cast<arg_t *>(self.data[arg_index + 1]) + block_work_size() * idx;
-    auto args_accessor = [&args] __device__ (int thread_unroll_idx) -> arg_t & { return std::get<arg_index>(args[thread_unroll_idx]); };
-    self.load_single_arg(args_accessor, ptr);
-  }
-};
-
-template<int arg_index>
-struct unroll_load_helper {
-  template <typename args_t, typename policy_t, typename offset_t, typename loader_t>
-  static __device__ void apply(policy_t &self, args_t *args, offset_t offset, loader_t loader, int j, int num_outputs) {
-    using arg_t = std::tuple_element_t<arg_index, args_t>;
-    // `data` hold the data_ptr for tensors [output, input0, input1, ...], so we
-    // need a +1 offset to get the input
-    std::get<arg_index>(args[j]) = loader.template load<arg_t>(self.data[arg_index + num_outputs], offset[arg_index], arg_index);
-  }
-};
-
-template <int current>
-struct multi_outputs_store_helper {
-  template<int ntensors, int num_outputs, typename ...Args>
-  C10_HOST_DEVICE static void apply(
-      at::detail::Array<char*, ntensors> data,
-      at::detail::Array<uint32_t, num_outputs> offsets,
-      thrust::tuple<Args...> ret) {
-    using T = typename thrust::tuple_element<current, thrust::tuple<Args...>>::type;
-    T *to = reinterpret_cast<T *>(data[current]) + offsets[current];
-    *to = thrust::get<current>(ret);
-  }
-};
-
-}  // namespace detail
-
-struct LoadWithoutCast {
-  template<typename scalar_t>
-  __device__ scalar_t load(char *base_ptr, uint32_t offset, int arg) {
-    return c10::load(reinterpret_cast<scalar_t *>(base_ptr) + offset);
-  }
-};
-
-template <int N>
-struct LoadWithCast {
-  using array_t = at::detail::Array<at::ScalarType, std::max<int>(N, 1)>;
-  using size_array_t = at::detail::Array<uint32_t, std::max<int>(N, 1)>;
-
-  array_t dtypes;
-  size_array_t element_sizes;
-
-  LoadWithCast(const TensorIteratorBase& iter) {
-    assert(iter.ninputs() == N);
-    #pragma unroll
-    for (auto i = 0; i < N; ++i) {
-      this->dtypes[i] = iter.dtype(i + iter.noutputs());
-      element_sizes[i] = c10::elementSize(iter.dtype(i + iter.noutputs()));
-    }
-  }
-
-  template<typename scalar_t>
-  __device__ scalar_t load(char *base_ptr, uint32_t offset, int arg) {
-    void *ptr = base_ptr + element_sizes[arg] * offset;
-    return c10::fetch_and_cast<scalar_t>(dtypes[arg], ptr);
-  }
-};
-
-struct StoreWithoutCast {
-  template<typename scalar_t>
-  __device__ void store(scalar_t value, char *base_ptr, uint32_t offset, int arg = 0) {
-    *(reinterpret_cast<scalar_t *>(base_ptr) + offset) = value;
-  }
-};
-
-template <int N = 1>
-struct StoreWithCast {
-  using array_t = at::detail::Array<at::ScalarType, std::max<int>(N, 1)>;
-  using size_array_t = at::detail::Array<uint32_t, std::max<int>(N, 1)>;
-
-  array_t dtypes;
-  size_array_t element_sizes;
-
-  StoreWithCast(const TensorIteratorBase& iter) {
-    assert(iter.noutputs() == N);
-    #pragma unroll
-    for (auto i = 0; i < N; ++i) {
-      this->dtypes[i] = iter.dtype(i);
-      element_sizes[i] = c10::elementSize(iter.dtype(i));
-    }
-  }
-
-  template<typename scalar_t>
-  __device__ void store(scalar_t value, char *base_ptr, uint32_t offset, int arg = 0) {
-    void *ptr = base_ptr + element_sizes[arg] * offset;
-    c10::cast_and_store<scalar_t>(dtypes[arg], ptr, value);
-  }
-};
-
-// aligned vector generates vectorized load/store on CUDA
-template<typename scalar_t, int vec_size>
-struct alignas(sizeof(scalar_t) * vec_size) aligned_vector {
-  scalar_t val[vec_size];
-};
-
-template <int vec_size, typename scalar_t>
-__device__ aligned_vector<scalar_t, vec_size> load_vector(const scalar_t *base_ptr, uint32_t offset) {
-  using vec_t = aligned_vector<scalar_t, vec_size>;
-  auto *from = reinterpret_cast<const vec_t *>(base_ptr);
-  return from[offset];
-}
-
-template <int vec_size>
-__device__ aligned_vector<bool, vec_size> load_vector(const bool *base_ptr, uint32_t offset) {
-  // See NOTE [Loading boolean values]
-  auto tmp = load_vector<vec_size>(reinterpret_cast<const uint8_t*>(base_ptr), offset);
-  aligned_vector<bool, vec_size> ret;
-  for (int i = 0; i < vec_size; ++i) {
-    ret.val[i] = bool(tmp.val[i]);
-  }
-  return ret;
-}
-
 namespace policies {
 
 // Assumption:
@@ -269,7 +108,7 @@ struct vectorized {
   template<typename args_t>
   __device__ inline void load(args_t *args, int idx) {
     constexpr int arity = std::tuple_size<args_t>::value;
-    detail::static_unroll<detail::vectorized_load_helper, arity>::with_args(*this, args, idx);
+    detail::static_unroll<detail::vectorized_load_helper, arity>::with_args(*this, args, block_work_size() * idx);
   }
 
   template<typename scalar_t>

--- a/aten/src/ATen/native/cuda/Nonzero.cu
+++ b/aten/src/ATen/native/cuda/Nonzero.cu
@@ -5,7 +5,7 @@
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <ATen/cuda/EmptyTensor.h>
 #include <ATen/cuda/detail/KernelUtils.h>
-#include <ATen/cuda/detail/OffsetCalculator.cuh> //for MAX_DIMS
+#include <ATen/detail/OffsetCalculator.h> //for MAX_DIMS
 #include <ATen/cuda/cub.cuh>
 
 #ifndef AT_PER_OPERATOR_HEADERS

--- a/aten/src/ATen/native/cuda/ROCmLoops.cuh
+++ b/aten/src/ATen/native/cuda/ROCmLoops.cuh
@@ -32,7 +32,7 @@
 
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/core/Array.h>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/detail/FunctionTraits.h>
 #include <ATen/native/TensorIterator.h>
 #include <c10/macros/Macros.h>

--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -3,7 +3,7 @@
 #include <ATen/core/Array.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/DeviceUtils.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/detail/FunctionTraits.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cuda/thread_constants.h>

--- a/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
+++ b/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
@@ -11,7 +11,7 @@
 
 #include <ATen/native/cuda/Loops.cuh>
 #include <ATen/native/cuda/KernelUtils.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/cuda/Atomic.cuh>
 #include <ATen/cuda/CUDAContext.h>
 

--- a/aten/src/ATen/native/cuda/Sort.cu
+++ b/aten/src/ATen/native/cuda/Sort.cu
@@ -6,7 +6,7 @@
 #include <ATen/cuda/cub.cuh>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/detail/KernelUtils.h>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/cuda/NumericLimits.cuh>
 #include <ATen/native/cuda/SortUtils.cuh>
 #include <ATen/native/cuda/SortingCommon.cuh>

--- a/aten/src/ATen/native/cuda/SparseBinaryOpIntersectionKernel.cu
+++ b/aten/src/ATen/native/cuda/SparseBinaryOpIntersectionKernel.cu
@@ -3,7 +3,7 @@
 #include <ATen/native/sparse/SparseBinaryOpIntersectionCommon.h>
 #include <ATen/native/cuda/Loops.cuh>
 #include <ATen/native/cuda/KernelUtils.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/AccumulateType.h>
 
 namespace at::native {

--- a/aten/src/ATen/native/cuda/SpectralOps.cu
+++ b/aten/src/ATen/native/cuda/SpectralOps.cu
@@ -3,7 +3,7 @@
 #include <ATen/Config.h>
 #include <ATen/Dispatch.h>
 #include <ATen/cuda/detail/KernelUtils.h>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/detail/CUDAHooksInterface.h>
 #include <ATen/native/SpectralOpsUtils.h>
 
@@ -20,7 +20,7 @@ struct HermitianSymmetryOffsetCalculator {
   using offset_type = at::detail::Array<index_t, 1>;
   using dim_type = std::remove_cv_t<decltype(MAX_DIMS)>;
   dim_type dims;
-  at::cuda::detail::IntDivider<index_t> sizes_[MAX_DIMS];
+  at::detail::IntDivider<index_t> sizes_[MAX_DIMS];
   index_t strides_[MAX_DIMS];
   uint32_t mirror_dim_;  // bit mask
   static_assert(MAX_DIMS < 32, "Need a bigger mask type");
@@ -32,7 +32,7 @@ struct HermitianSymmetryOffsetCalculator {
     TORCH_INTERNAL_ASSERT(sizes.size() <= MAX_DIMS);
     dims = sizes.size();
 
-    using at::cuda::detail::IntDivider;
+    using at::detail::IntDivider;
     for (dim_type i = 0; i < MAX_DIMS; ++i) {
       if (i < dims) {
         sizes_[i] = IntDivider<index_t>(sizes[i]);

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -5,7 +5,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/detail/TensorInfo.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/cuda/ScanUtils.cuh>
 #include <ATen/cuda/AsmUtils.cuh>
 #include <ATen/cuda/DeviceUtils.cuh>

--- a/aten/src/ATen/native/cuda/UnfoldBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/UnfoldBackwardKernel.cu
@@ -3,7 +3,7 @@
 
 #include <ATen/Dispatch.h>
 #include <ATen/native/cuda/Loops.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/cuda/CUDAContext.h>
 
 #include <vector>

--- a/aten/src/ATen/native/cuda/jit_utils.cpp
+++ b/aten/src/ATen/native/cuda/jit_utils.cpp
@@ -5,7 +5,7 @@
 #include <c10/util/Optional.h>
 #include <ATen/jit_macros.h>
 #include <ATen/cuda/CUDAContext.h>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/cuda/nvrtc_stub/ATenNVRTC.h>
 #include <ATen/code_template.h>
 #include <ATen/OpMathType.h>
@@ -171,7 +171,7 @@ const std::string jit_common_types = R"ESCAPE(
   #define ERROR_UNSUPPORTED_CAST ;
   // corresponds to aten/src/ATen/native/cuda/thread_constants.h
   #define CUDA_OR_ROCM_NUM_THREADS 256
-  // corresponds to aten/src/ATen/cuda/detail/OffsetCalculator.cuh
+  // corresponds to aten/src/ATen/detail/OffsetCalculator.h
   #define MAX_DIMS 16
   #ifndef __forceinline__
   #define __forceinline__ inline __attribute__((always_inline))

--- a/aten/src/ATen/native/sparse/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/sparse/cuda/SoftMax.cu
@@ -41,7 +41,7 @@
 
 #include <c10/cuda/CUDAMathCompat.h>
 #include <ATen/cuda/detail/IndexUtils.cuh>
-#include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/detail/OffsetCalculator.h>
 #include <ATen/native/cuda/Loops.cuh>
 
 #include <c10/macros/Macros.h>

--- a/aten/src/ATen/test/cuda_integer_divider_test.cu
+++ b/aten/src/ATen/test/cuda_integer_divider_test.cu
@@ -9,11 +9,11 @@
 #include <vector>
 
 #include <ATen/cuda/CUDAContext.h>
-#include <ATen/cuda/detail/IntegerDivider.cuh>
+#include <ATen/detail/IntegerDivider.h>
 
 using std::vector;
-using at::cuda::detail::IntDivider;
-using at::cuda::detail::DivMod;
+using at::detail::IntDivider;
+using at::detail::DivMod;
 
 template<typename Value>
 struct TestCase {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #117225

e.g. OffsetCalculator, IntegerDivider, MemoryAccess, ElementwiseInvoke.

feature: https://github.com/pytorch/pytorch/issues/114835

Signed-off-by: Feng Yuan <feng1.yuan@intel.com>