### PR TITLE
[dynamo] Simplify ODictGetItemSource index

### DIFF
--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -401,8 +401,6 @@ class ODictGetItemSource(ChainedSource):
         if isinstance(self.index, type):
             rep = f'__load_module("{self.index.__module__}").{self.index.__qualname__}'
             return f"___odict_getitem({self.base.name()}, {rep})"
-        elif isinstance(self.index, Source):
-            return f"___odict_getitem({self.base.name()}, {self.index.name()})"
         else:
             return f"___odict_getitem({self.base.name()}, {self.index!r})"
 

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -849,23 +849,24 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             raise ValueError("Trying to use a non-hashable key in a dict")
 
         # TODO(anijain2305) Is there a better way to insert guard than iterating through hashable variable trackers?
-        if isinstance(key, variables.ConstantVariable):
-            install_guard(key.source.make_guard(GuardBuilder.CONSTANT_MATCH))
-        elif isinstance(key, variables.BuiltinVariable):
-            install_guard(key.source.make_guard(GuardBuilder.BUILTIN_MATCH))
-        elif isinstance(
-            key,
-            (
-                variables.SymNodeVariable,
-                variables.user_defined.UserDefinedClassVariable,
-                variables.misc.SkipFilesVariable,
-                variables.misc.NumpyVariable,
-                variables.NNModuleVariable,
-            ),
-        ):
-            install_guard(key.source.make_guard(GuardBuilder.ID_MATCH))
-        else:
-            raise ValueError("Detected unhashable variable tracker in the dict key")
+        if key.source:
+            if isinstance(key, variables.ConstantVariable):
+                install_guard(key.source.make_guard(GuardBuilder.CONSTANT_MATCH))
+            elif isinstance(key, variables.BuiltinVariable):
+                install_guard(key.source.make_guard(GuardBuilder.BUILTIN_MATCH))
+            elif isinstance(
+                key,
+                (
+                    variables.SymNodeVariable,
+                    variables.user_defined.UserDefinedClassVariable,
+                    variables.misc.SkipFilesVariable,
+                    variables.misc.NumpyVariable,
+                    variables.NNModuleVariable,
+                ),
+            ):
+                install_guard(key.source.make_guard(GuardBuilder.ID_MATCH))
+            else:
+                raise ValueError("Detected unhashable variable tracker in the dict key")
 
         index = key.as_python_constant()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #117227

Goal is to keep the `index` of `ODictGetItemSource` capturable as Python value to help with Guard Tree refactor.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng