### PR TITLE
ensure parameter deepcopy transfers __dict__

### DIFF
--- a/test/nn/test_parametrization.py
+++ b/test/nn/test_parametrization.py
@@ -1545,6 +1545,13 @@ class TestNNParametrization(NNTestCase):
         input = torch.randn(3, 4)
         self.assertEqual(m(input), m2(input))
 
+    def test_param_new_attr_deepcopy(self):
+        p = nn.Parameter(torch.randn(3, 4))
+        p.new_attr = "xyz"
+        p_copy = deepcopy(p)
+        self.assertTrue(hasattr(p_copy, "new_attr"))
+        self.assertTrue(p_copy.new_attr == "xyz")
+
 
 class TestNNParametrizationDevice(NNTestCase):
     def test_weight_norm_parametrization(self, device):

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -1,7 +1,7 @@
 import torch
 from torch._C import _disabled_torch_function_impl
 from collections import OrderedDict
-from copy import deepcopy
+import copy
 
 # Metaclass to combine _TensorMeta and the instance check override for Parameter.
 class _ParameterMeta(torch._C._TensorMeta):
@@ -59,7 +59,7 @@ class Parameter(torch.Tensor, metaclass=_ParameterMeta):
         else:
             result = type(self)(self.data.clone(memory_format=torch.preserve_format), self.requires_grad)
             if not isinstance(result.data, torch._subclasses.FakeTensor):
-                result.__dict__ = deepcopy(self.__dict__, memo)
+                result.__dict__ = copy.deepcopy(self.__dict__, memo)
             memo[id(self)] = result
             return result
 
@@ -198,7 +198,7 @@ class UninitializedParameter(UninitializedTensorMixin, Parameter):
             return memo[id(self)]
         else:
             result = type(self)(self.requires_grad, self.data.device, self.data.dtype)
-            result.__dict__ = deepcopy(self.__dict__, memo)
+            result.__dict__ = copy.deepcopy(self.__dict__, memo)
             memo[id(self)] = result
             return result
 

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -58,8 +58,9 @@ class Parameter(torch.Tensor, metaclass=_ParameterMeta):
             return memo[id(self)]
         else:
             result = type(self)(self.data.clone(memory_format=torch.preserve_format), self.requires_grad)
+            if not isinstance(result.data, torch._subclasses.FakeTensor):
+                result.__dict__ = deepcopy(self.__dict__, memo)
             memo[id(self)] = result
-            result.__dict__ = deepcopy(self.__dict__, memo)
             return result
 
     def __repr__(self):
@@ -197,7 +198,7 @@ class UninitializedParameter(UninitializedTensorMixin, Parameter):
             return memo[id(self)]
         else:
             result = type(self)(self.requires_grad, self.data.device, self.data.dtype)
-            result.__dict__ = deepcopy(self.__dict__, memo)
+            # result.__dict__ = deepcopy(self.__dict__, memo)
             memo[id(self)] = result
             return result
 

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -1,6 +1,7 @@
 import torch
 from torch._C import _disabled_torch_function_impl
 from collections import OrderedDict
+from copy import deepcopy
 
 # Metaclass to combine _TensorMeta and the instance check override for Parameter.
 class _ParameterMeta(torch._C._TensorMeta):
@@ -58,6 +59,7 @@ class Parameter(torch.Tensor, metaclass=_ParameterMeta):
         else:
             result = type(self)(self.data.clone(memory_format=torch.preserve_format), self.requires_grad)
             memo[id(self)] = result
+            result.__dict__ = deepcopy(self.__dict__, memo)
             return result
 
     def __repr__(self):
@@ -195,6 +197,7 @@ class UninitializedParameter(UninitializedTensorMixin, Parameter):
             return memo[id(self)]
         else:
             result = type(self)(self.requires_grad, self.data.device, self.data.dtype)
+            result.__dict__ = deepcopy(self.__dict__, memo)
             memo[id(self)] = result
             return result
 

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -198,7 +198,7 @@ class UninitializedParameter(UninitializedTensorMixin, Parameter):
             return memo[id(self)]
         else:
             result = type(self)(self.requires_grad, self.data.device, self.data.dtype)
-            # result.__dict__ = deepcopy(self.__dict__, memo)
+            result.__dict__ = deepcopy(self.__dict__, memo)
             memo[id(self)] = result
             return result
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/117275

- deepcopy of dict in nn.Parameter and nn.UninitializedParameter
- test added to test/nn/test_parameterization
