### PR TITLE
Change predispatch tracing API

### DIFF
--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -329,7 +329,7 @@ def aot_compile(
         constraints = _process_dynamic_shapes(f, args, kwargs, dynamic_shapes)
 
     if config.is_predispatch:
-        gm = capture_pre_autograd_graph(f, args, kwargs, constraints)
+        gm = torch.export._trace._export(f, args, kwargs, constraints, pre_dispatch=True).module()
     else:
         # We want to export to Torch IR here to utilize the pre_grad passes in
         # inductor, which run on Torch IR.


### PR DESCRIPTION
Summary: Change the API used in export for aotinductor

Test Plan: buck2 run mode/opt mode/inplace caffe2/test/inductor/fb:test_group_batch_fusion_fb

Differential Revision: D52678653


