### PR TITLE
Update initializer path for ONNXProgram.save due to onnx.checker limitation

### DIFF
--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -1023,7 +1023,7 @@ class ONNXProgram:
             fx_serialization.save_model_with_external_data(
                 destination_path,
                 onnx_model_location,
-                onnx_model_location,  # When initializers >2GB, must be in the same folder as the model
+                "",  # When initializers >2GB, must be in the same folder as the model
                 tuple(_model_state_dict_files),
                 self.model_proto,
             )

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -1017,6 +1017,7 @@ class ONNXProgram:
                     "`destination` must be a string with a path when `model_state_dict` is specified."
                 )
             destination_path, destination_filename = os.path.split(destination)
+            destination_path = destination_path or os.getcwd()
             onnx_model_location = destination_filename
 
             # TODO: Should this be part of the serializer?

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -967,14 +967,12 @@ class ONNXProgram:
         Args:
             destination: The destination to save the ONNX model. It can be either a string or a file-like object.
                 When used with ``model_state_dict``, it must be a string with a full path to the destination.
-                In that case, besides saving the ONNX model, a folder with "_initializers" suffix (without extension)
-                will be created to store the each initializer of the ONNX model in a separate file. For example, if the
-                destination is "/path/model.onnx", the initializers will be saved in "/path/model_initializers/" folder.
+                In that case, besides saving the ONNX model into a file, each initializer of the ONNX model is stored
+                in a separate file in the same directory as the model. For example, if the
+                destination is "/path/model.onnx", the initializers will be saved in "/path/" folder.
             model_state_dict: The state_dict of the PyTorch model containing all weights on it.
-                It can be either a dict as returned by :meth:`model.state_dict`, or a string with a file name.
-                Required when :func:`enable_fake_mode` is used but real initializers are needed on the ONNX graph.
                 It can be either a string with the path to a checkpoint or a dictionary with the actual model state.
-
+                Required when :func:`enable_fake_mode` is used but real initializers are needed on the ONNX graph.
             serializer: The serializer to use. If not specified, the model will be serialized as Protobuf.
         """
 
@@ -1020,14 +1018,12 @@ class ONNXProgram:
                 )
             destination_path, destination_filename = os.path.split(destination)
             onnx_model_location = destination_filename
-            onnx_initializer_location = (
-                destination_filename.split(".")[0] + "_initializers"
-            )
+
             # TODO: Should this be part of the serializer?
             fx_serialization.save_model_with_external_data(
                 destination_path,
                 onnx_model_location,
-                onnx_initializer_location,
+                onnx_model_location,  # When initializers >2GB, must be in the same folder as the model
                 tuple(_model_state_dict_files),
                 self.model_proto,
             )

--- a/torch/onnx/_internal/fx/serialization.py
+++ b/torch/onnx/_internal/fx/serialization.py
@@ -103,10 +103,11 @@ def save_model_with_external_data(
         basepath: Base path of the external data file (e.g., "/tmp/large-onnx-model").
         model_location: Relative location of the ONNX model file.
             E.g., "model.onnx" so that the model file is saved to
-            "/tmp/large-onnx-model/model.onnx".
+            "<model_location>/model.onnx".
         initializer_location: Relative location of the ONNX initializer folder.
             E.g., "initializers" so that the initializers are saved to
-            "/tmp/large-onnx-model/initializers".
+            "<model_location>/initializers".
+            Note: When initializers are >2GB, must be the same as `model_location`.
         torch_load_paths: Files which containing serialized PyTorch tensors to be saved
             as ONNX initializers. They are loaded by torch.load.
         onnx_model: ONNX model to be saved with external initializers.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #117295
* __->__ #117294

According to https://github.com/onnx/onnx/blob/main/docs/ExternalData.md#large-models-2gb when initializers are larger than 2GB, `onnx.checker` requires the model to be in the same directory as the initializer.

Although not strictly necessary for the export and model save to succeed, it is desirable to have the `onnx.checker` to succeed when validation the resulting large model.