### PR TITLE
Fix ONNXProgram.save to use torch.load(..., mmap=True) for large models

### DIFF
--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -1002,7 +1002,8 @@ class ONNXProgram:
                     # ignore duplicate
                     continue
                 try:
-                    extra_state_dict = torch.load(path)
+                    # Loads checkpoint using memory-map on CPU to succeed with large models
+                    extra_state_dict = torch.load(path, map_location="cpu", mmap=True, weights_only=True)
                     extra_state_dict_file = io.BytesIO()
                     torch.save(extra_state_dict, extra_state_dict_file)
                     extra_state_dict_file.seek(0)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #117295
* #117294

During ONNXProgram.save, the implicit/explicit state_dict passed in must
be loaded in memory in order to read each initializer and create an
external tensor proto with them

This PR ensures torch.load uses memory-map to support large models that
cannot fit in memory