### PR TITLE
[ROCm] Enable float16/complex32 fft tests on ROCm

### DIFF
--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -83,8 +83,7 @@ ScalarType promote_type_fft(ScalarType type, bool require_complex, Device device
   const bool maybe_support_half = (
     // Only CUDA supports half precision, but since meta tensors don't have a
     // device we err on the side of accepting it
-    (device.is_cuda() || device.is_meta()) &&
-    !at::detail::getCUDAHooks().hasROCM()
+    device.is_cuda() || device.is_meta()
   );
   if (maybe_support_half) {
     TORCH_CHECK(type == kHalf || type == kFloat || type == kDouble, "Unsupported dtype ", type);

--- a/aten/src/ATen/native/cuda/CuFFTPlanCache.h
+++ b/aten/src/ATen/native/cuda/CuFFTPlanCache.h
@@ -123,11 +123,7 @@ static bool is_pow_of_two(int64_t x) {
   return (x & (x - 1)) == 0;
 }
 
-#if defined(USE_ROCM)
-    using cufft_size_type = int;
-#else
-    using cufft_size_type = long long int;
-#endif
+using cufft_size_type = long long int;
 
 using CuFFTDimVector = c10::SmallVector<cufft_size_type, at::kDimVectorStaticSize>;
 

--- a/aten/src/ATen/native/cuda/CuFFTPlanCache.h
+++ b/aten/src/ATen/native/cuda/CuFFTPlanCache.h
@@ -299,25 +299,6 @@ public:
     // See NOTE [ cuFFT Embedded Strides ] in native/cuda/SpectralOps.cu.
 
     const bool simple_layout = in_layout.simple && out_layout.simple;
-
-#if defined(USE_ROCM)
-    hipfftType exec_type = [&]{
-      if (dtype == kFloat) {
-        switch (fft_type) {
-          case CuFFTTransformType::C2C: return HIPFFT_C2C;
-          case CuFFTTransformType::R2C: return HIPFFT_R2C;
-          case CuFFTTransformType::C2R: return HIPFFT_C2R;
-        }
-      } else if (dtype == kDouble) {
-        switch (fft_type) {
-          case CuFFTTransformType::C2C: return HIPFFT_Z2Z;
-          case CuFFTTransformType::R2C: return HIPFFT_D2Z;
-          case CuFFTTransformType::C2R: return HIPFFT_Z2D;
-        }
-      }
-      TORCH_CHECK(false, "hipFFT doesn't support transforms of type: ", dtype);
-    }();
-#else
     cudaDataType itype, otype, exec_type;
     const auto complex_input = cufft_complex_input(fft_type);
     const auto complex_output = cufft_complex_output(fft_type);
@@ -336,7 +317,6 @@ public:
     } else {
       TORCH_CHECK(false, "cuFFT doesn't support tensor of type: ", dtype);
     }
-#endif
 
     // disable auto allocation of workspace to use THC allocator
     CUFFT_CHECK(cufftSetAutoAllocation(plan(), /* autoAllocate */ 0));
@@ -350,29 +330,15 @@ public:
       // by assuming istride = ostride = 1.
       //
       // See NOTE [ cuFFT Embedded Strides ] in native/cuda/SpectralOps.cu.
-#if defined(USE_ROCM)
-      CUFFT_CHECK(hipfftMakePlanMany(plan(), signal_ndim, signal_sizes.data(),
-        /* inembed */ nullptr, /* base_istride */ 1, /* idist */ 1,
-        /* onembed */ nullptr, /* base_ostride */ 1, /* odist */ 1,
-        exec_type, batch, &ws_size_t));
-#else
       CUFFT_CHECK(cufftXtMakePlanMany(plan(), signal_ndim, signal_sizes.data(),
         /* inembed */ nullptr, /* base_istride */ 1, /* idist */ 1, itype,
         /* onembed */ nullptr, /* base_ostride */ 1, /* odist */ 1, otype,
         batch, &ws_size_t, exec_type));
-#endif
     } else {
-#if defined(USE_ROCM)
-      CUFFT_CHECK(hipfftMakePlanMany(plan(), signal_ndim, signal_sizes.data(),
-        in_layout.embed.data(), in_layout.stride, in_layout.dist,
-        out_layout.embed.data(), out_layout.stride, out_layout.dist,
-        exec_type, batch, &ws_size_t));
-#else
       CUFFT_CHECK(cufftXtMakePlanMany(plan(), signal_ndim, signal_sizes.data(),
             in_layout.embed.data(), in_layout.stride, in_layout.dist, itype,
             out_layout.embed.data(), out_layout.stride, out_layout.dist, otype,
             batch, &ws_size_t, exec_type));
-#endif
     }
     ws_size = static_cast<int64_t>(ws_size_t);
   }

--- a/aten/src/ATen/native/cuda/SpectralOps.cpp
+++ b/aten/src/ATen/native/cuda/SpectralOps.cpp
@@ -38,52 +38,8 @@ using namespace at::native::detail;
 static void exec_cufft_plan(
     const CuFFTConfig &config, void* in_data, void* out_data, bool forward) {
   auto& plan = config.plan();
-#if defined(USE_ROCM)
-  auto value_type = config.data_type();
-  if (value_type == kFloat) {
-    switch (config.transform_type()) {
-      case CuFFTTransformType::C2C: {
-        CUFFT_CHECK(hipfftExecC2C(plan, static_cast<hipfftComplex*>(in_data),
-                                  static_cast<hipfftComplex*>(out_data),
-                                  forward ? HIPFFT_FORWARD : HIPFFT_BACKWARD));
-        return;
-      }
-      case CuFFTTransformType::R2C: {
-        CUFFT_CHECK(hipfftExecR2C(plan, static_cast<hipfftReal*>(in_data),
-                                  static_cast<hipfftComplex*>(out_data)));
-        return;
-      }
-      case CuFFTTransformType::C2R: {
-        CUFFT_CHECK(hipfftExecC2R(plan, static_cast<hipfftComplex*>(in_data),
-                                  static_cast<hipfftReal*>(out_data)));
-        return;
-      }
-    }
-  } else if (value_type == kDouble) {
-    switch (config.transform_type()) {
-      case CuFFTTransformType::C2C: {
-        CUFFT_CHECK(hipfftExecZ2Z(plan, static_cast<hipfftDoubleComplex*>(in_data),
-                                  static_cast<hipfftDoubleComplex*>(out_data),
-                                  forward ? HIPFFT_FORWARD : HIPFFT_BACKWARD));
-        return;
-      }
-      case CuFFTTransformType::R2C: {
-        CUFFT_CHECK(hipfftExecD2Z(plan, static_cast<hipfftDoubleReal*>(in_data),
-                                  static_cast<hipfftDoubleComplex*>(out_data)));
-        return;
-      }
-      case CuFFTTransformType::C2R: {
-        CUFFT_CHECK(hipfftExecZ2D(plan, static_cast<hipfftDoubleComplex*>(in_data),
-                                  static_cast<hipfftDoubleReal*>(out_data)));
-        return;
-      }
-    }
-  }
-  TORCH_CHECK(false, "hipFFT doesn't support transforms on type: ", value_type);
-#else
   CUFFT_CHECK(cufftXtExec(plan, in_data, out_data,
                           forward ? CUFFT_FORWARD : CUFFT_INVERSE));
-#endif
 }
 
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -34,6 +34,7 @@ from torch.testing._internal.common_utils import (
     suppress_warnings,
     noncontiguous_like,
     TEST_WITH_ASAN,
+    TEST_WITH_ROCM,
     TEST_WITH_TORCHDYNAMO,
     TEST_WITH_TORCHINDUCTOR,
     TEST_WITH_UBSAN,
@@ -484,6 +485,8 @@ class TestCommon(TestCase):
         # In this test, primTorch refs call into the refs namespace
         # For example, a ref with torch.foo in it will calls refs.foo instead
         # Direct calls to refs and prims are not affected
+        if TEST_WITH_ROCM and (op.name == "_refs.fft.ihfftn" or op.name == "_refs.fft.ihfft2") and dtype == torch.float16:
+            self.skipTest("Skipped on ROCm")
         self._ref_test_helper(lambda: TorchRefsMode(strict=True), device, dtype, op)
 
     # Tests that experimental Python References perform the same computation
@@ -496,6 +499,8 @@ class TestCommon(TestCase):
         # In this test, refs call into the torch namespace (after the initial invocation)
         # For example, a ref with torch.foo in it will call torch.foo instead of refs.foo
         # Direct calls to refs and prims are not translated
+        if TEST_WITH_ROCM and op.name == "_refs.fft.ihfftn" and dtype == torch.float16:
+            self.skipTest("Skipped on ROCm")
         self._ref_test_helper(contextlib.nullcontext, device, dtype, op)
 
     @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
@@ -504,6 +509,8 @@ class TestCommon(TestCase):
     @parametrize('executor', ['aten',])
     @skipIfTorchInductor("Takes too long for inductor")
     def test_python_ref_executor(self, device, dtype, op, executor):
+        if TEST_WITH_ROCM and (op.name == "_refs.fft.ihfftn" or op.name == "_refs.fft.ihfft2") and dtype == torch.float16:
+            self.skipTest("Skipped on ROCm")
         # skip zero-dim tensors for some composites of reduction operations and view
         skip_zero_dim_ops = [
             "_refs.logsumexp",

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -120,8 +120,6 @@ def skip_helper_for_fft(device, dtype):
 
     if device_type == 'cpu':
         raise unittest.SkipTest("half and complex32 are not supported on CPU")
-    #if TEST_WITH_ROCM:
-        #raise unittest.SkipTest("half and complex32 are not supported on ROCM")
     if not SM53OrLater:
         raise unittest.SkipTest("half and complex32 are only supported on CUDA device with SM>53")
 

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -120,8 +120,8 @@ def skip_helper_for_fft(device, dtype):
 
     if device_type == 'cpu':
         raise unittest.SkipTest("half and complex32 are not supported on CPU")
-    if TEST_WITH_ROCM:
-        raise unittest.SkipTest("half and complex32 are not supported on ROCM")
+    #if TEST_WITH_ROCM:
+        #raise unittest.SkipTest("half and complex32 are not supported on ROCM")
     if not SM53OrLater:
         raise unittest.SkipTest("half and complex32 are only supported on CUDA device with SM>53")
 

--- a/torch/_refs/fft.py
+++ b/torch/_refs/fft.py
@@ -66,7 +66,7 @@ def _promote_type_fft(
         dtype = torch.get_default_dtype()
 
     allowed_types = [torch.float32, torch.float64]
-    maybe_support_half = device.type in ["cuda", "meta"] and not torch.version.hip
+    maybe_support_half = device.type in ["cuda", "meta"]
 
     if maybe_support_half:
         allowed_types.append(torch.float16)

--- a/torch/testing/_internal/opinfo/definitions/fft.py
+++ b/torch/testing/_internal/opinfo/definitions/fft.py
@@ -128,11 +128,7 @@ op_db: List[OpInfo] = [
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
-            *(
-                ()
-                if (not SM53OrLater)
-                else (torch.half, torch.complex32)
-            ),
+            *(() if (not SM53OrLater) else (torch.half, torch.complex32)),
         ),
         sample_inputs_func=partial(sample_inputs_fft_with_min, min_size=1),
         error_inputs_func=error_inputs_fft,
@@ -153,11 +149,7 @@ op_db: List[OpInfo] = [
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
-            *(
-                ()
-                if (not SM53OrLater)
-                else (torch.half, torch.complex32)
-            ),
+            *(() if (not SM53OrLater) else (torch.half, torch.complex32)),
         ),
         sample_inputs_func=partial(sample_inputs_fft_with_min, min_size=(1, 1)),
         error_inputs_func=error_inputs_fftn,
@@ -168,6 +160,16 @@ op_db: List[OpInfo] = [
         # See https://github.com/pytorch/pytorch/pull/78358
         check_batched_forward_grad=False,
         decorators=[precisionOverride({torch.float: 1e-4, torch.cfloat: 1e-4})],
+        skips=(
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                "TestCommon",
+                "test_complex_half_reference_testing",
+                device_type="cuda",
+                dtypes=[torch.complex32],
+                active_if=TEST_WITH_ROCM,
+            ),
+        ),
     ),
     SpectralFuncInfo(
         "fft.fftn",
@@ -179,11 +181,7 @@ op_db: List[OpInfo] = [
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
-            *(
-                ()
-                if (not SM53OrLater)
-                else (torch.half, torch.complex32)
-            ),
+            *(() if (not SM53OrLater) else (torch.half, torch.complex32)),
         ),
         sample_inputs_func=partial(sample_inputs_fft_with_min, min_size=(1, 1)),
         error_inputs_func=error_inputs_fftn,
@@ -205,11 +203,7 @@ op_db: List[OpInfo] = [
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
-            *(
-                ()
-                if (not SM53OrLater)
-                else (torch.half, torch.complex32)
-            ),
+            *(() if (not SM53OrLater) else (torch.half, torch.complex32)),
         ),
         sample_inputs_func=partial(sample_inputs_fft_with_min, min_size=2),
         error_inputs_func=error_inputs_fft,
@@ -240,11 +234,7 @@ op_db: List[OpInfo] = [
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
-            *(
-                ()
-                if (not SM53OrLater)
-                else (torch.half, torch.complex32)
-            ),
+            *(() if (not SM53OrLater) else (torch.half, torch.complex32)),
         ),
         sample_inputs_func=partial(sample_inputs_fft_with_min, min_size=(2, 2)),
         error_inputs_func=error_inputs_fftn,
@@ -281,11 +271,7 @@ op_db: List[OpInfo] = [
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
-            *(
-                ()
-                if (not SM53OrLater)
-                else (torch.half, torch.complex32)
-            ),
+            *(() if (not SM53OrLater) else (torch.half, torch.complex32)),
         ),
         sample_inputs_func=partial(sample_inputs_fft_with_min, min_size=(2, 2)),
         error_inputs_func=error_inputs_fftn,
@@ -397,11 +383,7 @@ op_db: List[OpInfo] = [
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
-            *(
-                ()
-                if (not SM53OrLater)
-                else (torch.half, torch.complex32)
-            ),
+            *(() if (not SM53OrLater) else (torch.half, torch.complex32)),
         ),
     ),
     SpectralFuncInfo(
@@ -422,11 +404,7 @@ op_db: List[OpInfo] = [
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
-            *(
-                ()
-                if (not SM53OrLater)
-                else (torch.half, torch.complex32)
-            ),
+            *(() if (not SM53OrLater) else (torch.half, torch.complex32)),
         ),
         decorators=[
             DecorateInfo(
@@ -454,11 +432,7 @@ op_db: List[OpInfo] = [
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
-            *(
-                ()
-                if (not SM53OrLater)
-                else (torch.half, torch.complex32)
-            ),
+            *(() if (not SM53OrLater) else (torch.half, torch.complex32)),
         ),
         decorators=[
             DecorateInfo(
@@ -505,7 +479,7 @@ op_db: List[OpInfo] = [
         dtypes=all_types_and(torch.bool),
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and(
-            torch.bool, *(() if (not SM53OrLater) else (torch.half,))
+            torch.bool, *(() if (TEST_WITH_ROCM or not SM53OrLater) else (torch.half,))
         ),
         check_batched_grad=False,
         check_batched_gradgrad=False,
@@ -537,7 +511,7 @@ op_db: List[OpInfo] = [
         dtypes=all_types_and(torch.bool),
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archss
         dtypesIfCUDA=all_types_and(
-            torch.bool, *(() if (not SM53OrLater) else (torch.half,))
+            torch.bool, *(() if (TEST_WITH_ROCM or not SM53OrLater) else (torch.half,))
         ),
         check_batched_grad=False,
         check_batched_gradgrad=False,
@@ -569,11 +543,7 @@ op_db: List[OpInfo] = [
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
-            *(
-                ()
-                if (not SM53OrLater)
-                else (torch.half, torch.complex32)
-            ),
+            *(() if (not SM53OrLater) else (torch.half, torch.complex32)),
         ),
         check_batched_gradgrad=False,
     ),
@@ -595,11 +565,7 @@ op_db: List[OpInfo] = [
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
-            *(
-                ()
-                if (not SM53OrLater)
-                else (torch.half, torch.complex32)
-            ),
+            *(() if (not SM53OrLater) else (torch.half, torch.complex32)),
         ),
         check_batched_gradgrad=False,
         decorators=[
@@ -628,11 +594,7 @@ op_db: List[OpInfo] = [
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
-            *(
-                ()
-                if (not SM53OrLater)
-                else (torch.half, torch.complex32)
-            ),
+            *(() if (not SM53OrLater) else (torch.half, torch.complex32)),
         ),
         check_batched_gradgrad=False,
         decorators=[

--- a/torch/testing/_internal/opinfo/definitions/fft.py
+++ b/torch/testing/_internal/opinfo/definitions/fft.py
@@ -125,13 +125,12 @@ op_db: List[OpInfo] = [
         ref=np.fft.fft,
         ndimensional=SpectralFuncType.OneD,
         dtypes=all_types_and_complex_and(torch.bool),
-        # rocFFT doesn't support Half/Complex Half Precision FFT
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
             *(
                 ()
-                if (TEST_WITH_ROCM or not SM53OrLater)
+                if (not SM53OrLater)
                 else (torch.half, torch.complex32)
             ),
         ),
@@ -151,13 +150,12 @@ op_db: List[OpInfo] = [
         decomp_aten_name="_fft_c2c",
         ndimensional=SpectralFuncType.TwoD,
         dtypes=all_types_and_complex_and(torch.bool),
-        # rocFFT doesn't support Half/Complex Half Precision FFT
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
             *(
                 ()
-                if (TEST_WITH_ROCM or not SM53OrLater)
+                if (not SM53OrLater)
                 else (torch.half, torch.complex32)
             ),
         ),
@@ -178,13 +176,12 @@ op_db: List[OpInfo] = [
         ref=np.fft.fftn,
         ndimensional=SpectralFuncType.ND,
         dtypes=all_types_and_complex_and(torch.bool),
-        # rocFFT doesn't support Half/Complex Half Precision FFT
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
             *(
                 ()
-                if (TEST_WITH_ROCM or not SM53OrLater)
+                if (not SM53OrLater)
                 else (torch.half, torch.complex32)
             ),
         ),
@@ -205,13 +202,12 @@ op_db: List[OpInfo] = [
         ref=np.fft.hfft,
         ndimensional=SpectralFuncType.OneD,
         dtypes=all_types_and_complex_and(torch.bool),
-        # rocFFT doesn't support Half/Complex Half Precision FFT
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
             *(
                 ()
-                if (TEST_WITH_ROCM or not SM53OrLater)
+                if (not SM53OrLater)
                 else (torch.half, torch.complex32)
             ),
         ),
@@ -241,13 +237,12 @@ op_db: List[OpInfo] = [
         ref=scipy.fft.hfft2 if has_scipy_fft else None,
         ndimensional=SpectralFuncType.TwoD,
         dtypes=all_types_and_complex_and(torch.bool),
-        # rocFFT doesn't support Half/Complex Half Precision FFT
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
             *(
                 ()
-                if (TEST_WITH_ROCM or not SM53OrLater)
+                if (not SM53OrLater)
                 else (torch.half, torch.complex32)
             ),
         ),
@@ -283,13 +278,12 @@ op_db: List[OpInfo] = [
         ref=scipy.fft.hfftn if has_scipy_fft else None,
         ndimensional=SpectralFuncType.ND,
         dtypes=all_types_and_complex_and(torch.bool),
-        # rocFFT doesn't support Half/Complex Half Precision FFT
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
             *(
                 ()
-                if (TEST_WITH_ROCM or not SM53OrLater)
+                if (not SM53OrLater)
                 else (torch.half, torch.complex32)
             ),
         ),
@@ -325,10 +319,9 @@ op_db: List[OpInfo] = [
         ref=np.fft.rfft,
         ndimensional=SpectralFuncType.OneD,
         dtypes=all_types_and(torch.bool),
-        # rocFFT doesn't support Half/Complex Half Precision FFT
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and(
-            torch.bool, *(() if (TEST_WITH_ROCM or not SM53OrLater) else (torch.half,))
+            torch.bool, *(() if (not SM53OrLater) else (torch.half,))
         ),
         sample_inputs_func=partial(sample_inputs_fft_with_min, min_size=1),
         error_inputs_func=error_inputs_fft,
@@ -347,10 +340,9 @@ op_db: List[OpInfo] = [
         ref=np.fft.rfft2,
         ndimensional=SpectralFuncType.TwoD,
         dtypes=all_types_and(torch.bool),
-        # rocFFT doesn't support Half/Complex Half Precision FFT
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and(
-            torch.bool, *(() if (TEST_WITH_ROCM or not SM53OrLater) else (torch.half,))
+            torch.bool, *(() if (not SM53OrLater) else (torch.half,))
         ),
         sample_inputs_func=partial(sample_inputs_fft_with_min, min_size=(1, 1)),
         error_inputs_func=error_inputs_fftn,
@@ -371,10 +363,9 @@ op_db: List[OpInfo] = [
         ref=np.fft.rfftn,
         ndimensional=SpectralFuncType.ND,
         dtypes=all_types_and(torch.bool),
-        # rocFFT doesn't support Half/Complex Half Precision FFT
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and(
-            torch.bool, *(() if (TEST_WITH_ROCM or not SM53OrLater) else (torch.half,))
+            torch.bool, *(() if (not SM53OrLater) else (torch.half,))
         ),
         sample_inputs_func=partial(sample_inputs_fft_with_min, min_size=(1, 1)),
         error_inputs_func=error_inputs_fftn,
@@ -403,13 +394,12 @@ op_db: List[OpInfo] = [
         # See https://github.com/pytorch/pytorch/pull/78358
         check_batched_forward_grad=False,
         dtypes=all_types_and_complex_and(torch.bool),
-        # rocFFT doesn't support Half/Complex Half Precision FFT
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
             *(
                 ()
-                if (TEST_WITH_ROCM or not SM53OrLater)
+                if (not SM53OrLater)
                 else (torch.half, torch.complex32)
             ),
         ),
@@ -429,13 +419,12 @@ op_db: List[OpInfo] = [
         # See https://github.com/pytorch/pytorch/pull/78358
         check_batched_forward_grad=False,
         dtypes=all_types_and_complex_and(torch.bool),
-        # rocFFT doesn't support Half/Complex Half Precision FFT
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
             *(
                 ()
-                if (TEST_WITH_ROCM or not SM53OrLater)
+                if (not SM53OrLater)
                 else (torch.half, torch.complex32)
             ),
         ),
@@ -462,13 +451,12 @@ op_db: List[OpInfo] = [
         # See https://github.com/pytorch/pytorch/pull/78358
         check_batched_forward_grad=False,
         dtypes=all_types_and_complex_and(torch.bool),
-        # rocFFT doesn't support Half/Complex Half Precision FFT
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
             *(
                 ()
-                if (TEST_WITH_ROCM or not SM53OrLater)
+                if (not SM53OrLater)
                 else (torch.half, torch.complex32)
             ),
         ),
@@ -493,10 +481,9 @@ op_db: List[OpInfo] = [
         # See https://github.com/pytorch/pytorch/pull/78358
         check_batched_forward_grad=False,
         dtypes=all_types_and(torch.bool),
-        # rocFFT doesn't support Half/Complex Half Precision FFT
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and(
-            torch.bool, *(() if (TEST_WITH_ROCM or not SM53OrLater) else (torch.half,))
+            torch.bool, *(() if (not SM53OrLater) else (torch.half,))
         ),
         skips=(),
         check_batched_grad=False,
@@ -516,10 +503,9 @@ op_db: List[OpInfo] = [
         # See https://github.com/pytorch/pytorch/pull/78358
         check_batched_forward_grad=False,
         dtypes=all_types_and(torch.bool),
-        # rocFFT doesn't support Half/Complex Half Precision FFT
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and(
-            torch.bool, *(() if (TEST_WITH_ROCM or not SM53OrLater) else (torch.half,))
+            torch.bool, *(() if (not SM53OrLater) else (torch.half,))
         ),
         check_batched_grad=False,
         check_batched_gradgrad=False,
@@ -549,10 +535,9 @@ op_db: List[OpInfo] = [
         # See https://github.com/pytorch/pytorch/pull/78358
         check_batched_forward_grad=False,
         dtypes=all_types_and(torch.bool),
-        # rocFFT doesn't support Half/Complex Half Precision FFT
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archss
         dtypesIfCUDA=all_types_and(
-            torch.bool, *(() if (TEST_WITH_ROCM or not SM53OrLater) else (torch.half,))
+            torch.bool, *(() if (not SM53OrLater) else (torch.half,))
         ),
         check_batched_grad=False,
         check_batched_gradgrad=False,
@@ -581,13 +566,12 @@ op_db: List[OpInfo] = [
         # See https://github.com/pytorch/pytorch/pull/78358
         check_batched_forward_grad=False,
         dtypes=all_types_and_complex_and(torch.bool),
-        # rocFFT doesn't support Half/Complex Half Precision FFT
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
             *(
                 ()
-                if (TEST_WITH_ROCM or not SM53OrLater)
+                if (not SM53OrLater)
                 else (torch.half, torch.complex32)
             ),
         ),
@@ -608,13 +592,12 @@ op_db: List[OpInfo] = [
         # See https://github.com/pytorch/pytorch/pull/78358
         check_batched_forward_grad=False,
         dtypes=all_types_and_complex_and(torch.bool),
-        # rocFFT doesn't support Half/Complex Half Precision FFT
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
             *(
                 ()
-                if (TEST_WITH_ROCM or not SM53OrLater)
+                if (not SM53OrLater)
                 else (torch.half, torch.complex32)
             ),
         ),
@@ -642,13 +625,12 @@ op_db: List[OpInfo] = [
         # See https://github.com/pytorch/pytorch/pull/78358
         check_batched_forward_grad=False,
         dtypes=all_types_and_complex_and(torch.bool),
-        # rocFFT doesn't support Half/Complex Half Precision FFT
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
             *(
                 ()
-                if (TEST_WITH_ROCM or not SM53OrLater)
+                if (not SM53OrLater)
                 else (torch.half, torch.complex32)
             ),
         ),

--- a/torch/testing/_internal/opinfo/definitions/fft.py
+++ b/torch/testing/_internal/opinfo/definitions/fft.py
@@ -479,7 +479,7 @@ op_db: List[OpInfo] = [
         dtypes=all_types_and(torch.bool),
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and(
-            torch.bool, *(() if (TEST_WITH_ROCM or not SM53OrLater) else (torch.half,))
+            torch.bool, *(() if (not SM53OrLater) else (torch.half,))
         ),
         check_batched_grad=False,
         check_batched_gradgrad=False,
@@ -511,7 +511,7 @@ op_db: List[OpInfo] = [
         dtypes=all_types_and(torch.bool),
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archss
         dtypesIfCUDA=all_types_and(
-            torch.bool, *(() if (TEST_WITH_ROCM or not SM53OrLater) else (torch.half,))
+            torch.bool, *(() if (not SM53OrLater) else (torch.half,))
         ),
         check_batched_grad=False,
         check_batched_gradgrad=False,

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -7847,7 +7847,6 @@ CUDA_IDENTIFIER_MAP = collections.OrderedDict(
             "cufftSetAutoAllocation",
             ("hipfftSetAutoAllocation", CONV_MATH_FUNC, API_FFT),
         ),
-        # add new conversions here
         ("cufftXtExec", ("hipfftXtExec", CONV_MATH_FUNC, API_FFT)),
         ("cufftXtMakePlanMany", ("hipfftXtMakePlanMany", CONV_MATH_FUNC, API_FFT)),
         ("cufftExecC2C", ("hipfftExecC2C", CONV_MATH_FUNC, API_FFT)),

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -7847,6 +7847,9 @@ CUDA_IDENTIFIER_MAP = collections.OrderedDict(
             "cufftSetAutoAllocation",
             ("hipfftSetAutoAllocation", CONV_MATH_FUNC, API_FFT),
         ),
+        # add new conversions here
+        ("cufftXtExec", ("hipfftXtExec", CONV_MATH_FUNC, API_FFT)),
+        ("cufftXtMakePlanMany", ("hipfftXtMakePlanMany", CONV_MATH_FUNC, API_FFT)),
         ("cufftExecC2C", ("hipfftExecC2C", CONV_MATH_FUNC, API_FFT)),
         ("cufftExecR2C", ("hipfftExecR2C", CONV_MATH_FUNC, API_FFT)),
         ("cufftExecC2R", ("hipfftExecC2R", CONV_MATH_FUNC, API_FFT)),


### PR DESCRIPTION
This PR is to enable float16/complex32 fft tests on ROCm. 
Sample results are attached here: 
[test_spectral_ops_results.log](https://github.com/pytorch/pytorch/files/13908533/test_spectral_ops_results.log)

test_decomp::TestDecompCUDA::test_comprehensive_fft*
test_decomp::TestDecompCUDA::test_quick_fft*
test_jit_fuser_te::TestNNCOpInfoCUDA::test_nnc_correctness_fft*
test_meta::TestMetaCUDA::test_dispatch_meta_inplace_fft*
test_meta::TestMetaCUDA::test_dispatch_meta_outplace_fft*
test_meta::TestMetaCUDA::test_dispatch_symbolic_meta_inplace_fft*
test_meta::TestMetaCUDA::test_dispatch_symbolic_meta_outplace_fft*
test_meta::TestMetaCUDA::test_meta_inplace_fft*
test_meta::TestMetaCUDA::test_meta_outplace_fft*
test_ops::TestCommonCUDA::test_complex_half_reference_testing_fft*
test_ops::TestCommonCUDA::test_python_ref__refs_fft*
test_ops::TestCommonCUDA::test_python_ref_executor__refs_fft*
test_ops::TestCommonCUDA::test_python_ref_meta__refs*
test_ops::TestCommonCUDA::test_python_ref_torch_fallback__refs_fft*
test_schema_check::TestSchemaCheckModeOpInfoCUDA::test_schema_correctness_fft*
test_spectral_ops::TestFFTCUDA::test_empty_fft__refs_fft*
test_spectral_ops::TestFFTCUDA::test_empty_fft_fft*
test_spectral_ops::TestFFTCUDA::test_fft_half_and_chalf_not_power_of_two_error__refs_fft*
test_spectral_ops::TestFFTCUDA::test_fft_half_and_chalf_not_power_of_two_error_fft*
test_spectral_ops::TestFFTCUDA::test_fft_round_trip_cuda*
test_spectral_ops::TestFFTCUDA::test_fft_type_promotion_cuda*
test_spectral_ops::TestFFTCUDA::test_fftn_round_trip_cuda*
test_spectral_ops::TestFFTCUDA::test_hfftn_cuda_float16
test_spectral_ops::TestFFTCUDA::test_ihfftn_cuda_float16
test_utils::TestDeviceUtilsCUDA::test_device_mode_ops_fft

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang