### PR TITLE
[export][ez] Fix getting meta["val"]

### DIFF
--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -55,7 +55,7 @@ def _check_input_constraints_for_graph(
     # symbols with given input dimension values to check equality constraints.
     unification_map: "Dict[sympy.Symbol, Any]" = {}
     for arg, node in zip(args, input_placeholders):
-        node_val = node.meta["val"]
+        node_val = node.meta.get("val")
         if isinstance(node_val, FakeTensor):
             check(
                 isinstance(arg, torch.Tensor),


### PR DESCRIPTION
Summary: For integer inputs, they do not have a meta["val"].

Test Plan: `buck run @//mode/dev-nosan  //executorch/examples/portable/scripts:export -- -m emformer_predict` passes the export step

Differential Revision: D52716419


