### PR TITLE
Add more alias and mutation check for other input of Conv Binary Inplace fusion

### DIFF
--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -1779,22 +1779,39 @@ class TestPatternMatcher(TestPatternMatcherBase):
                 res = res + other2
                 return res
 
+        # Written buffer is an ReinterpretView, we can't fuse inplace.
+        class Model_v4(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(3, 32, 3, padding=1, bias=True)
+                self.linear = torch.nn.Linear(32 * 28, 32 * 28)
+                self.relu = torch.nn.ReLU()
+
+            def forward(self, x, y):
+                x = self.conv(self.relu(x))
+                y = self.linear(y)
+                y = torch.cat((y, y), 1)
+                y = torch.ops.aten.permute.default(y, [0, 2, 1]).reshape(1, 32, 28, 28)
+                return x + y
+
         input = torch.randn(1, 3, 28, 28).to(memory_format=torch.channels_last)
         others = [
             torch.randn(1, 32, 28, 28).to(memory_format=torch.channels_last),
             torch.randn(2, 32, 28, 28).to(memory_format=torch.channels_last),
             torch.randn(1, 32, 28, 28).to(memory_format=torch.channels_last),
+            torch.randn(1, 14, 32 * 28),
         ]
         mod_v1 = Model_v1().to(memory_format=torch.channels_last).eval()
         mod_v2 = Model_v2().to(memory_format=torch.channels_last).eval()
         mod_v3 = Model_v3().to(memory_format=torch.channels_last).eval()
+        mod_v4 = Model_v4().to(memory_format=torch.channels_last).eval()
 
         if include_ops is None:
             include_ops = ["mkldnn._convolution_pointwise.binary"]
         if exclude_ops is None:
             exclude_ops = ["mkldnn._convolution_pointwise_.binary"]
 
-        for other, mod in zip(others, [mod_v1, mod_v2, mod_v3]):
+        for other, mod in zip(others, [mod_v1, mod_v2, mod_v3, mod_v4]):
             self._test_code_common(mod, (input, other), include_ops, exclude_ops)
 
     def test_conv2d_binary_fusion_failed(self):

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -513,7 +513,6 @@ if torch._C._has_mkldnn:
                     computation_args += [1.0, None, [], None]
             # Make sure the other is not an alias or mutation(fx side doesn't has such info).
             other.realize()
-
             if not _can_be_inplace(other):
                 return L[outplace_fusion_op](*computation_args)
             return L[inplace_fusion_op](*computation_args)

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -536,6 +536,13 @@ def _register_quantized_conv_binary_lowering(
         o_inv_scale = kwargs["o_inv_scale"] if output_dtype is None else 1.0
         o_zero_point = kwargs["o_zp"] if output_dtype is None else 0
 
+        accum.realize()
+        from .mkldnn_fusion import _can_be_inplace
+
+        assert _can_be_inplace(
+            accum
+        ), "QConv Binary Inplace Fusion requires accum is not an alias or mutation."
+
         computation_args = (
             x,
             x_scale,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #117331
* __->__ #117330

**Summary**
Fix the issue: https://github.com/pytorch/pytorch/issues/117108.
Use the outplace conv binary fusion when other input is with type `TensorBox(View(ReinterpretView()))` since other input is a view of some other tensor.

**Test Plan**
```
python -u -m pytest -s -v test_mkldnn_pattern_matcher.py -k test_conv2d_binary_inplace_fusion_failed_cpu
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler