### PR TITLE
Fail Conv Binary Inplace check when act and accum are same tensor

### DIFF
--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -420,20 +420,19 @@ if torch._C._has_mkldnn:
                 _compute_index = 1 if (_other_index == 0) else 0
                 return _binary_node.args[_compute_index]
 
-            # print("_get_compute_node(n, other_index) is: {}".format(_get_compute_node(binary_nodes[0], other_index)), flush=True)
-
-            if any(
-                (
+            def _check_other_users(_binary_node, _other_index):
+                _compute_node = _get_compute_node(_binary_node, _other_index)
+                return (
                     len(
                         _get_remaining_users(
-                            n.args[other_index], _get_compute_node(n, other_index)
+                            _binary_node.args[_other_index], _compute_node
                         )
                     )
                     > 1
-                    or n.args[other_index] == _get_compute_node(n, other_index).args[0]
+                    or _binary_node.args[_other_index] == _compute_node.args[0]
                 )
-                for n in binary_nodes
-            ):
+
+            if any(_check_other_users(n, other_index) for n in binary_nodes):
                 return False
             if any(
                 n.args[other_index].op in ["placeholder", "output"]

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -420,13 +420,18 @@ if torch._C._has_mkldnn:
                 _compute_index = 1 if (_other_index == 0) else 0
                 return _binary_node.args[_compute_index]
 
+            # print("_get_compute_node(n, other_index) is: {}".format(_get_compute_node(binary_nodes[0], other_index)), flush=True)
+
             if any(
-                len(
-                    _get_remaining_users(
-                        n.args[other_index], _get_compute_node(n, other_index)
+                (
+                    len(
+                        _get_remaining_users(
+                            n.args[other_index], _get_compute_node(n, other_index)
+                        )
                     )
+                    > 1
+                    or n.args[other_index] == _get_compute_node(n, other_index).args[0]
                 )
-                > 1
                 for n in binary_nodes
             ):
                 return False

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -494,6 +494,7 @@ def _is_valid_quantized_conv_binary_optimization_pattern(output_dtype):
                 )
             )
             > 1
+            or extra_input_of_pattern == compute_node.args[0]
         ):
             return False
         return True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #117331
* #117330

**Summary**
When a tensor is used as the act of conv and extra input of the binary add node, we shouldn't do conv binary inplace fusion. 
```
      a
    /   \
 conv
   \ 
     add
```

**TestPlan**
```
python -u -m pytest -s -v test_mkldnn_pattern_matcher.py -k test_conv2d_binary_inplace_fusion_failed_cpu
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler