### PR TITLE
[CI] Set permissions for stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,6 +22,9 @@ jobs:
   stale:
     if: ${{ github.repository == 'pytorch/pytorch' }}
     runs-on: linux.large.arc
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - uses: actions/github-script@v6


### PR DESCRIPTION
Hopefully should fix failures one observes in HUD as default permissions for the repo were changed to read-only
<img width="232" alt="image" src="https://github.com/pytorch/pytorch/assets/2453524/4047472c-ca3c-4288-add7-97f0ce43106a">
