### PR TITLE
[export] Minor fixes to serialization

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -40,21 +40,10 @@ from torch.testing._internal.common_utils import (
 
 
 def get_filtered_export_db_tests():
-    unsupported_test_names = {
-        "dynamic_shape_constructor",  # 'NoneType' object has no attribute 'from_tensor'
-        "dictionary",  # Graph output must be a tuple()
-        "fn_with_kwargs",  # export doesn't support kwargs yet
-        "scalar_output",  # Tracing through 'f' must produce a single graph
-        "user_input_mutation",  # TODO(zhxchen17) Support serializing user inputs mutation.
-    }
-
     return [
         (name, case)
         for name, case in all_examples().items()
-        if (
-            case.support_level == SupportLevel.SUPPORTED and
-            name not in unsupported_test_names
-        )
+        if case.support_level == SupportLevel.SUPPORTED
     ]
 
 
@@ -573,6 +562,21 @@ class TestOpVersioning(TestCase):
 
 unittest.expectedFailure(
     TestDeserialize.test_exportdb_supported_case_tensor_setattr
+)
+
+# We didn't set up kwargs input yet
+unittest.expectedFailure(
+    TestDeserialize.test_exportdb_supported_case_fn_with_kwargs
+)
+
+# Failed to produce a graph during tracing. Tracing through 'f' must produce a single graph.
+unittest.expectedFailure(
+    TestDeserialize.test_exportdb_supported_case_scalar_output
+)
+
+# TODO(zhxchen17) Support serializing user inputs mutation.
+unittest.expectedFailure(
+    TestDeserialize.test_exportdb_supported_case_user_input_mutation
 )
 
 


### PR DESCRIPTION
* Checks that the input to torch.export.save is an ExportedProgram (https://github.com/pytorch/pytorch/issues/116952)
* Fixes naming for serialized state dict from `serialized_state_dict.json` to `serialized_state_dict.pt` (https://github.com/pytorch/pytorch/issues/116949)
* Moves some tests to be expectFailure rather than blocklisted