### PR TITLE
Check for None attributes in repr of base Distribution class

### DIFF
--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -330,7 +330,7 @@ class Distribution:
         args_string = ", ".join(
             [
                 f"{p}: {self.__dict__[p] if self.__dict__[p].numel() == 1 else self.__dict__[p].size()}"
-                for p in param_names
+                for p in param_names if self.__dict__[p] is not None
             ]
         )
         return self.__class__.__name__ + "(" + args_string + ")"


### PR DESCRIPTION
When custom distributions subclass from `torch.distributions.Distribution` and have optional arguments that are set to `None` (_e.g._ for distributions that can be parametrized in various ways), this leads to an `AttributeError` when calling `__repr__`.

Representative and reproducible code snippet here:
```
from torch.distributions import Distribution, constraints

class MyDist(Distribution):

    arg_constraints = {
        "optional_arg1": constraints.greater_than(0),
        "optional_arg2": constraints.greater_than(0),
    }
    support = constraints.positive

    def __init__(
        self,
        optional_arg1: float | None = None, 
        optional_arg2: float | None = None,
        validate_args: bool = False,
    ):
        self.optional_arg1 = optional_arg1
        self.optional_arg2 = optional_arg2
        super().__init__(validate_args=validate_args)


print(MyDist(optional_arg1=1.0))
```
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[4], line 1
----> 1 print(MyDist(optional_arg1=1.0))

File ~/.../lib/python3.11/site-packages/torch/distributions/distribution.py:331, in Distribution.__repr__(self)
    328 def __repr__(self) -> str:
    329     param_names = [k for k, _ in self.arg_constraints.items() if k in self.__dict__]
    330     args_string = ", ".join(
--> 331         [
    332             f"{p}: {self.__dict__[p] if self.__dict__[p].numel() == 1 else self.__dict__[p].size()}"
    333             for p in param_names
    334         ]
    335     )
    336     return self.__class__.__name__ + "(" + args_string + ")"

File ~/.../lib/python3.11/site-packages/torch/distributions/distribution.py:332, in <listcomp>(.0)
    328 def __repr__(self) -> str:
    329     param_names = [k for k, _ in self.arg_constraints.items() if k in self.__dict__]
    330     args_string = ", ".join(
    331         [
--> 332             f"{p}: {self.__dict__[p] if self.__dict__[p].numel() == 1 else self.__dict__[p].size()}"
    333             for p in param_names
    334         ]
    335     )
    336     return self.__class__.__name__ + "(" + args_string + ")"

AttributeError: 'float' object has no attribute 'numel'
```