### PR TITLE
fsdp: Unit test for ModuleWrapPolicy as a Callable

### DIFF
--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -462,6 +462,15 @@ class TestAutoWrap(TestCase):
         )
         self._test_transformer_wrapping(auto_wrap_policy)
 
+    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    def test_module_wrap_policy_callable(self):
+        """Tests the ``ModuleWrapPolicy`` as a ``Callable``."""
+        auto_wrap_policy = ModuleWrapPolicy(
+            {TransformerEncoderLayer, TransformerDecoderLayer}
+        )
+        callable_policy = functools.partial(_or_policy, policies=[auto_wrap_policy])
+        self._test_transformer_wrapping(callable_policy)
+
     def _test_transformer_wrapping(self, auto_wrap_policy: Union[Callable, _Policy]):
         fsdp_kwargs = {"auto_wrap_policy": auto_wrap_policy}
         fsdp_model = TransformerWithSharedParams.init(


### PR DESCRIPTION
We use `_or_policy` as a `Callable` to wrap a `ModuleWrapPolicy` instance as a `Callable`.

Fixes https://github.com/pytorch/pytorch/issues/109266


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225