### PR TITLE
[pt-vulkan] Add build time flag to control descriptor pool sizes

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Context.cpp
+++ b/aten/src/ATen/native/vulkan/api/Context.cpp
@@ -4,6 +4,14 @@
 #include <memory>
 #include <sstream>
 
+#ifndef VULKAN_DESCRIPTOR_POOL_SIZE
+#define VULKAN_DESCRIPTOR_POOL_SIZE 1024u
+#endif
+
+#ifndef VULKAN_QUERY_POOL_SIZE
+#define VULKAN_QUERY_POOL_SIZE 4096u
+#endif
+
 namespace at {
 namespace native {
 namespace vulkan {
@@ -112,16 +120,16 @@ Context* context() {
       };
 
       const DescriptorPoolConfig descriptor_pool_config{
-          1024u, // descriptorPoolMaxSets
-          1024u, // descriptorUniformBufferCount
-          1024u, // descriptorStorageBufferCount
-          1024u, // descriptorCombinedSamplerCount
-          1024u, // descriptorStorageImageCount
+          VULKAN_DESCRIPTOR_POOL_SIZE, // descriptorPoolMaxSets
+          VULKAN_DESCRIPTOR_POOL_SIZE, // descriptorUniformBufferCount
+          VULKAN_DESCRIPTOR_POOL_SIZE, // descriptorStorageBufferCount
+          VULKAN_DESCRIPTOR_POOL_SIZE, // descriptorCombinedSamplerCount
+          VULKAN_DESCRIPTOR_POOL_SIZE, // descriptorStorageImageCount
           32u, // descriptorPileSizes
       };
 
       const QueryPoolConfig query_pool_config{
-          4096u, // maxQueryCount
+          VULKAN_QUERY_POOL_SIZE, // maxQueryCount
           256u, // initialReserveSize
       };
 


### PR DESCRIPTION
Summary:
## Context

When running large models with a lot of operators, the default descriptor pool allocated by the Vulkan compute API may run out of descriptor sets. This changeset introduces the `VULKAN_DESCRIPTOR_POOL_SIZE` build variable (which will default to `1024u`) which can allow for a larger descriptor pool to be allocated if necessary.

## Notes for Reviewers

This is a simple stopgap solution until we have bandwidth to implement the more general solution, which would be to modify the `DescriptorPool` class defined in `api/Descriptor.[h,cpp]` to automatically allocate a new descriptor pool when memory runs out. However, I would consider this change to be low priority since with a delegate/graph mode of execution, the descriptor pool can often be allocated to exactly fit a model's requirements.

Test Plan:
There should be no functional changes under default build settings. Run `vulkan_api_test` to make sure everything works as before; CI should test for that as well.

```
# On devserver
LD_LIBRARY_PATH=/home/ssjia/Github/swiftshader_prebuilt/swiftshader/build/bin/ buck run fbcode/mode/dev-nosan //xplat/caffe2:pt_vulkan_api_test_bin -- --gtest_filter="*"
```

Reviewed By: yipjustin, jorgep31415

Differential Revision: D52742140


