### PR TITLE
[Optimus] fix batch layernorm numerical issue

### DIFF
--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -611,7 +611,10 @@ class BatchLayernormFusion(BatchFusion):
 
             if group_weights is not None and group_biases is not None:
                 batch_layer_norm = graph.call_function(
-                    torch.addcmul, args=(stack_bias, stack_weight, batch_layer_norm)
+                    torch.mul, args=(stack_weight, batch_layer_norm)
+                )
+                batch_layer_norm = graph.call_function(
+                    torch.add, args=(stack_bias, batch_layer_norm)
                 )
             elif group_weights is not None and group_biases is None:
                 batch_layer_norm = graph.call_function(


### PR DESCRIPTION
Summary:
Fix the numerical issue with addcmul.

Found that torch.addcmul will generate different value from torch.add+torch.mul with 32 bit check. Mini repro: N4823658

Change addcmul tp torch.add+torch.mm

Test Plan:
buck test

before change
```
the diff index is:  0
the diff index is:  1
the diff index is:  6
```

after change numeric on par

Differential Revision: D52745671




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler