### PR TITLE
The permission id-token write needs to be set on rocm-test callers

### DIFF
--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -28,6 +28,8 @@ jobs:
         ]}
 
   linux-focal-rocm5_7-py3_8-inductor-test:
+    permissions:
+      id-token: write
     name: rocm5.7-py3.8-inductor
     uses: ./.github/workflows/_rocm-test.yml
     needs: linux-focal-rocm5_7-py3_8-inductor-build

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -30,6 +30,7 @@ jobs:
   linux-focal-rocm5_7-py3_8-inductor-test:
     permissions:
       id-token: write
+      contents: read
     name: rocm5.7-py3.8-inductor
     uses: ./.github/workflows/_rocm-test.yml
     needs: linux-focal-rocm5_7-py3_8-inductor-build

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -209,6 +209,8 @@ jobs:
         ]}
 
   linux-focal-rocm5_7-py3_8-test:
+    permissions:
+      id-token: write
     name: linux-focal-rocm5.7-py3.8
     uses: ./.github/workflows/_rocm-test.yml
     needs: linux-focal-rocm5_7-py3_8-build

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -211,6 +211,7 @@ jobs:
   linux-focal-rocm5_7-py3_8-test:
     permissions:
       id-token: write
+      contents: read
     name: linux-focal-rocm5.7-py3.8
     uses: ./.github/workflows/_rocm-test.yml
     needs: linux-focal-rocm5_7-py3_8-build

--- a/.github/workflows/rocm.yml
+++ b/.github/workflows/rocm.yml
@@ -36,6 +36,8 @@ jobs:
         ]}
 
   linux-focal-rocm5_7-py3_8-test:
+    permissions:
+      id-token: write
     name: linux-focal-rocm5.7-py3.8
     uses: ./.github/workflows/_rocm-test.yml
     needs: linux-focal-rocm5_7-py3_8-build

--- a/.github/workflows/rocm.yml
+++ b/.github/workflows/rocm.yml
@@ -38,6 +38,7 @@ jobs:
   linux-focal-rocm5_7-py3_8-test:
     permissions:
       id-token: write
+      contents: read
     name: linux-focal-rocm5.7-py3.8
     uses: ./.github/workflows/_rocm-test.yml
     needs: linux-focal-rocm5_7-py3_8-build

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -100,6 +100,8 @@ jobs:
         ]}
 
   linux-focal-rocm5_6-py3_8-test:
+    permissions:
+      id-token: write
     name: linux-focal-rocm5.6-py3.8
     uses: ./.github/workflows/_rocm-test.yml
     needs: linux-focal-rocm5_6-py3_8-build

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -102,6 +102,7 @@ jobs:
   linux-focal-rocm5_6-py3_8-test:
     permissions:
       id-token: write
+      contents: read
     name: linux-focal-rocm5.6-py3.8
     uses: ./.github/workflows/_rocm-test.yml
     needs: linux-focal-rocm5_6-py3_8-build

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -190,6 +190,8 @@ jobs:
         ]}
 
   linux-focal-rocm5_7-py3_8-test:
+    permissions:
+      id-token: write
     name: linux-focal-rocm5.7-py3.8
     uses: ./.github/workflows/_rocm-test.yml
     needs: linux-focal-rocm5_7-py3_8-build

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -192,6 +192,7 @@ jobs:
   linux-focal-rocm5_7-py3_8-test:
     permissions:
       id-token: write
+      contents: read
     name: linux-focal-rocm5.7-py3.8
     uses: ./.github/workflows/_rocm-test.yml
     needs: linux-focal-rocm5_7-py3_8-build


### PR DESCRIPTION
All these workflows lack the necessary permission to run `_rocm-test` job after https://github.com/pytorch/pytorch/pull/117160, for example https://github.com/pytorch/pytorch/actions/runs/7508520071

### Testing

Confirm that trunk is back https://github.com/pytorch/pytorch/actions/runs/7508830196.  Other workflows would be the same, i.e. rocm https://github.com/pytorch/pytorch/actions/runs/7508830137/job/20444989127.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang