### PR TITLE
[BE] Use overloads rather than specialization

### DIFF
--- a/aten/src/ATen/NumericUtils.h
+++ b/aten/src/ATen/NumericUtils.h
@@ -45,18 +45,7 @@ inline C10_HOST_DEVICE bool _isnan(T val) {
   return std::isnan(val.real()) || std::isnan(val.imag());
 }
 
-template <
-    typename T,
-    typename std::enable_if<std::is_same<T, at::Half>::value, int>::type = 0>
-inline C10_HOST_DEVICE bool _isnan(T val) {
-  return at::_isnan(static_cast<float>(val));
-}
-
-template <
-    typename T,
-    typename std::enable_if<std::is_same<T, at::BFloat16>::value, int>::type =
-        0>
-inline C10_HOST_DEVICE bool _isnan(at::BFloat16 val) {
+inline C10_HOST_DEVICE bool _isnan(at::Half val) {
   return at::_isnan(static_cast<float>(val));
 }
 
@@ -64,19 +53,11 @@ inline C10_HOST_DEVICE bool _isnan(at::BFloat16 val) {
   return at::_isnan(static_cast<float>(val));
 }
 
-template <
-    typename T,
-    typename std::enable_if<std::is_same<T, at::Float8_e5m2>::value, int>::
-        type = 0>
-inline C10_HOST_DEVICE bool _isnan(T val) {
+inline C10_HOST_DEVICE bool _isnan(at::Float8_e5m2 val) {
   return val.isnan();
 }
 
-template <
-    typename T,
-    typename std::enable_if<std::is_same<T, at::Float8_e4m3fn>::value, int>::
-        type = 0>
-inline C10_HOST_DEVICE bool _isnan(T val) {
+inline C10_HOST_DEVICE bool _isnan(at::Float8_e4m3fn val) {
   return val.isnan();
 }
 


### PR DESCRIPTION
As they are shorter and easier to read

Inspired by https://github.com/pytorch/pytorch/pull/115214/files#r1433162424

Also, was quite surprised that `_isnan` for BFloat16 had both specialization and overload:
```cpp
template <
     typename T,
     typename std::enable_if<std::is_same<T, at::BFloat16>::value, int>::type =
         0>
 inline C10_HOST_DEVICE bool _isnan(at::BFloat16 val) {
   return at::_isnan(static_cast<float>(val));
 } 
 
 inline C10_HOST_DEVICE bool _isnan(at::BFloat16 val) {
   return at::_isnan(static_cast<float>(val));
 }
```