### PR TITLE
Update triton ROCm version to 6.0

### DIFF
--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -37,7 +37,7 @@ jobs:
         device: ["cuda", "rocm"]
         include:
           - device: "rocm"
-            rocm_version: "5.7"
+            rocm_version: "6.0"
           - device: "cuda"
             rocm_version: ""
     timeout-minutes: 40


### PR DESCRIPTION
Related to PyTorch nightly wheels upgrade to ROCm6.0: https://github.com/pytorch/pytorch/pull/116983


cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang