### PR TITLE
Added example regarding weight_decay distinction with per-parameter API

### DIFF
--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -53,7 +53,7 @@ This means that ``model.base``'s parameters will use the default learning rate o
 Also consider the following example related to the distinct penalization of parameters.
 Remember that :func:`~torch.nn.Module.parameters` returns an iterable that 
 contains all learnable parameters, including biases and other 
-parameters that may need distinct penalization. To address this, one can specify
+parameters that may prefer distinct penalization. To address this, one can specify
 individual penalization weights for each parameter group::
 
     bias_params = [p for name,p in self.named_parameters() if 'bias' in name]

--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -49,7 +49,6 @@ Finally a momentum of ``0.9`` will be used for all parameters.
     only want to vary a single option, while keeping all others consistent
     between parameter groups.
 
-
 Also consider the following example related to the distinct penalization of parameters.
 Remember that :func:`~torch.nn.Module.parameters` returns an iterable that 
 contains all learnable parameters, including biases and other 
@@ -67,6 +66,7 @@ individual penalization weights for each parameter group::
 In this manner, bias terms are isolated from non-bias terms, and a ``weight_decay``
 of ``0`` is set specifically for the bias terms, as to avoid any penalization for
 this group.
+
 
 Taking an optimization step
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -59,7 +59,7 @@ individual penalization weights for each parameter group::
     others = [p for name, p in self.named_parameters() if 'bias' not in name]
 
     optim.SGD([
-                    {'params': others },
+                    {'params': others},
                     {'params': bias_params, 'weight_decay': 0}
                 ], weight_decay=1e-2, lr=1e-2)
 

--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -64,7 +64,7 @@ individual penalization weights for each parameter group::
                     {'params': bias_params, 'weight_decay': 0}
                 ], weight_decay=1e-3, lr=1e-2)
 
-In this manner, bias terms are isolated from non-bias terms, and a ``weigth_decay``
+In this manner, bias terms are isolated from non-bias terms, and a ``weight_decay``
 of ``0`` is set specifically for the bias terms, as to avoid any penalization for
 this group.
 

--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -50,7 +50,7 @@ This means that ``model.base``'s parameters will use the default learning rate o
     between parameter groups.
 
 
-Consider the following example related to the distinct penalization of parameters.
+Also consider the following example related to the distinct penalization of parameters.
 Remember that :func:`~torch.nn.Module.parameters` returns an iterable that 
 contains all learnable parameters, including biases and other 
 parameters that may need distinct penalization. To address this, one can specify

--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -31,13 +31,6 @@ a ``params`` key, containing a list of parameters belonging to it. Other keys
 should match the keyword arguments accepted by the optimizers, and will be used
 as optimization options for this group.
 
-.. note::
-
-    You can still pass options as keyword arguments. They will be used as
-    defaults, in the groups that didn't override them. This is useful when you
-    only want to vary a single option, while keeping all others consistent
-    between parameter groups.
-
 For example, this is very useful when one wants to specify per-layer learning rates::
 
     optim.SGD([
@@ -48,6 +41,14 @@ For example, this is very useful when one wants to specify per-layer learning ra
 This means that ``model.base``'s parameters will use the default learning rate of ``1e-2``,
 ``model.classifier``'s parameters will use a learning rate of ``1e-3``, and a momentum of
 ``0.9`` will be used for all parameters.
+
+.. note::
+
+    You can still pass options as keyword arguments. They will be used as
+    defaults, in the groups that didn't override them. This is useful when you
+    only want to vary a single option, while keeping all others consistent
+    between parameter groups.
+
 
 Consider the following example related to the distinct penalization of parameters.
 Remember that :func:`~torch.nn.Module.parameters` returns an iterable that 

--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -38,7 +38,6 @@ as optimization options for this group.
     only want to vary a single option, while keeping all others consistent
     between parameter groups.
 
-
 For example, this is very useful when one wants to specify per-layer learning rates::
 
     optim.SGD([
@@ -49,6 +48,24 @@ For example, this is very useful when one wants to specify per-layer learning ra
 This means that ``model.base``'s parameters will use the default learning rate of ``1e-2``,
 ``model.classifier``'s parameters will use a learning rate of ``1e-3``, and a momentum of
 ``0.9`` will be used for all parameters.
+
+Consider the following example related to the distinct penalization of parameters.
+Remember that :func:`~torch.nn.Module.parameters` returns an iterable that 
+contains all learnable parameters, including biases and other 
+parameters that may need distinct penalization. To address this, one can specify
+individual penalization weights for each parameter group::
+
+    bias_params = [p for name,p in self.named_parameters() if 'bias' in name]
+    others = [p for name,p in self.named_parameters() if 'bias' not in name]
+
+    optim.SGD([
+                    {'params': others },
+                    {'params': bias_params, 'weight_decay': 0}
+                ], weight_decay=1e-3, lr=1e-2)
+
+In this manner, bias terms are isolated from non-bias terms, and a ``weigth_decay``
+of ``0`` is set specifically for the bias terms, as to avoid any penalization for
+this group.
 
 Taking an optimization step
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -38,9 +38,9 @@ For example, this is very useful when one wants to specify per-layer learning ra
                     {'params': model.classifier.parameters()}
                 ], lr=1e-3, momentum=0.9)
 
-This means that ``model.base``'s parameters will use a learning rate of ``1e-3``,
-``model.classifier``'s parameters will use the default learning rate of ``1e-3``, and a momentum of
-``0.9`` will be used for all parameters.
+This means that ``model.base``'s parameters will use a learning rate of ``1e-2``, whereas
+``model.classifier``'s parameters will stick to the default learning rate of ``1e-3``. 
+Finally a momentum of ``0.9`` will be used for all parameters.
 
 .. note::
 
@@ -62,7 +62,7 @@ individual penalization weights for each parameter group::
     optim.SGD([
                     {'params': others },
                     {'params': bias_params, 'weight_decay': 0}
-                ], weight_decay=1e-3, lr=1e-2)
+                ], weight_decay=1e-2, lr=1e-2)
 
 In this manner, bias terms are isolated from non-bias terms, and a ``weight_decay``
 of ``0`` is set specifically for the bias terms, as to avoid any penalization for

--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -34,12 +34,12 @@ as optimization options for this group.
 For example, this is very useful when one wants to specify per-layer learning rates::
 
     optim.SGD([
-                    {'params': model.base.parameters()},
-                    {'params': model.classifier.parameters(), 'lr': 1e-3}
-                ], lr=1e-2, momentum=0.9)
+                    {'params': model.base.parameters(), 'lr': 1e-2},
+                    {'params': model.classifier.parameters()}
+                ], lr=1e-3, momentum=0.9)
 
-This means that ``model.base``'s parameters will use the default learning rate of ``1e-2``,
-``model.classifier``'s parameters will use a learning rate of ``1e-3``, and a momentum of
+This means that ``model.base``'s parameters will use a learning rate of ``1e-3``,
+``model.classifier``'s parameters will use the default learning rate of ``1e-3``, and a momentum of
 ``0.9`` will be used for all parameters.
 
 .. note::

--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -39,7 +39,7 @@ For example, this is very useful when one wants to specify per-layer learning ra
                 ], lr=1e-3, momentum=0.9)
 
 This means that ``model.base``'s parameters will use a learning rate of ``1e-2``, whereas
-``model.classifier``'s parameters will stick to the default learning rate of ``1e-3``. 
+``model.classifier``'s parameters will stick to the default learning rate of ``1e-3``.
 Finally a momentum of ``0.9`` will be used for all parameters.
 
 .. note::
@@ -50,8 +50,8 @@ Finally a momentum of ``0.9`` will be used for all parameters.
     between parameter groups.
 
 Also consider the following example related to the distinct penalization of parameters.
-Remember that :func:`~torch.nn.Module.parameters` returns an iterable that 
-contains all learnable parameters, including biases and other 
+Remember that :func:`~torch.nn.Module.parameters` returns an iterable that
+contains all learnable parameters, including biases and other
 parameters that may prefer distinct penalization. To address this, one can specify
 individual penalization weights for each parameter group::
 

--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -56,8 +56,8 @@ contains all learnable parameters, including biases and other
 parameters that may prefer distinct penalization. To address this, one can specify
 individual penalization weights for each parameter group::
 
-    bias_params = [p for name,p in self.named_parameters() if 'bias' in name]
-    others = [p for name,p in self.named_parameters() if 'bias' not in name]
+    bias_params = [p for name, p in self.named_parameters() if 'bias' in name]
+    others = [p for name, p in self.named_parameters() if 'bias' not in name]
 
     optim.SGD([
                     {'params': others },


### PR DESCRIPTION
Added new example and description regarding per-parameter `weight_decay` distinction for bias and non-bias terms. 

Fixes #115935 
