### PR TITLE
Add dynamo support for operator.abs

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -2136,6 +2136,17 @@ class DefaultsTests(torch._dynamo.test_case.TestCase):
                 x = torch.randn(10)
                 self.assertEqual(opt_fn(x), fn(x))
 
+    def test_unary_fold_op(self):
+        for op in (operator.abs, abs, operator.pos, operator.neg):
+            with self.subTest(op=op):
+
+                def fn():
+                    a = range(-10, 10)
+                    return list(map(op, a))
+
+                opt_fn = torch._dynamo.optimize(nopython=True)(fn)
+                self.assertEqual(opt_fn(), fn())
+
 
 instantiate_parametrized_tests(FunctionTests)
 

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -112,6 +112,7 @@ class BuiltinVariable(VariableTracker):
             str.format,
             sum,
             type,
+            operator.abs,
             operator.pos,
             operator.neg,
             operator.not_,
@@ -155,6 +156,7 @@ class BuiltinVariable(VariableTracker):
     @functools.lru_cache(None)
     def _fx_graph_functions():
         fns = {
+            operator.abs,
             operator.pos,
             operator.neg,
             operator.not_,


### PR DESCRIPTION
A test case for operator.abs and allows for constant folding with it. Partially applies to #116396 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng