### PR TITLE
Update state_dict.py to propagate cpu offload

### DIFF
--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -229,7 +229,9 @@ def _verify_options(
             )
             state_dict_type = StateDictType.FULL_STATE_DICT
         else:
-            state_dict_config = ShardedStateDictConfig()
+            state_dict_config = ShardedStateDictConfig(
+                offload_to_cpu=options.cpu_offload,
+            )
             optim_state_dict_config = ShardedOptimStateDictConfig(
                 offload_to_cpu=options.cpu_offload,
             )


### PR DESCRIPTION
Update state_dict.py to propagate cpu offload. It looks like this flag is accidentally ignored?

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @LucasLLC