### PR TITLE
Make c10::SymInt typecaster support scalar-like fake tensor

### DIFF
--- a/torch/csrc/utils/pybind.cpp
+++ b/torch/csrc/utils/pybind.cpp
@@ -23,8 +23,7 @@ bool type_caster<c10::SymInt>::load(py::handle src, bool) {
   if (THPVariable_Check(raw_obj)) {
     auto& var = THPVariable_Unpack(raw_obj);
     if (var.numel() == 1 &&
-        at::isIntegralType(
-            var.dtype().toScalarType(), /*include_bool*/ true)) {
+        at::isIntegralType(var.dtype().toScalarType(), /*include_bool*/ true)) {
       auto scalar = var.item();
       TORCH_INTERNAL_ASSERT(scalar.isIntegral(/*include bool*/ false));
       value = scalar.toSymInt();

--- a/torch/csrc/utils/pybind.cpp
+++ b/torch/csrc/utils/pybind.cpp
@@ -19,6 +19,19 @@ bool type_caster<c10::SymInt>::load(py::handle src, bool) {
   }
 
   auto raw_obj = src.ptr();
+
+  if (THPVariable_Check(raw_obj)) {
+    auto& var = THPVariable_Unpack(raw_obj);
+    if (var.numel() == 1 &&
+        at::isIntegralType(
+            var.dtype().toScalarType(), /*include_bool*/ true)) {
+      auto scalar = var.item();
+      TORCH_INTERNAL_ASSERT(scalar.isIntegral(/*include bool*/ false));
+      value = scalar.toSymInt();
+      return true;
+    }
+  }
+
   if (THPUtils_checkIndex(raw_obj)) {
     value = c10::SymInt{THPUtils_unpackIndex(raw_obj)};
     return true;

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -950,7 +950,6 @@ inline int64_t PythonArgs::toInt64(int i) {
 }
 
 inline c10::SymInt PythonArgs::toSymInt(int i) {
-  PyObject* obj = args[i];
   if (!args[i]) {
     return c10::SymInt(signature.params[i].default_int);
   }

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -961,28 +961,6 @@ inline c10::SymInt PythonArgs::toSymInt(int i) {
         signature.params[i].name, idx, var, c10::IntType::get());
   }
 
-  // convert FakeTensor to SymInt
-  // expect empty sizes, numel = 1
-  // and ScalarType::Int
-  if (is_dynamo_compiling && THPVariable_Check(obj)) {
-    auto& var = THPVariable_Unpack(obj);
-
-    if (var.numel() != 1 || !var.sizes().empty() ||
-        !at::isIntegralType(
-            var.dtype().toScalarType(), /*include_bool*/ true)) {
-      throw TypeError(
-          "%s(): argument '%s' must be %s, failed to convert %s with sizes.empty()=%d",
-          signature.name.c_str(),
-          signature.params[i].name.c_str(),
-          signature.params[i].type_name().c_str(),
-          Py_TYPE(obj)->tp_name,
-          var.sizes().empty());
-    }
-    auto scalar = var.item();
-    TORCH_CHECK(scalar.isIntegral(/*include bool*/ false));
-    return scalar.toSymInt();
-  }
-
   return py::cast<c10::SymInt>(py::handle(args[i]));
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #117455
* __->__ #117454
* #117452
* #117451

We can use `__index__` to do this conversion because that will trigger a
guard on data dependent SymInt if the tensor is a fake tensor, but if
we fetch item directly and put it in the Scalar, we may still be able to
make it work out.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>