### PR TITLE
MPS: Fix off by one error when computing view_numel in getMPSGraphTensorDataForView causing [MPSNDArrayDescriptor sliceDimension:withSubrange] to fail

### DIFF
--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -539,7 +539,7 @@ MPSGraphTensorData* getMPSGraphTensorDataForView(const Tensor& src, MPSShape* mp
   }
 
   int64_t view_numel = 1;
-  for (const auto i : c10::irange(firstDimToSlice + 1, src_base_shape.size())) {
+  for (const auto i : c10::irange(firstDimToSlice, src_base_shape.size())) {
     view_numel *= src_base_shape[i];
   }
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -3194,6 +3194,14 @@ class TestMPS(TestCaseMPS):
         r_cpu = y_cpu + 1
         self.assertEqual(r, r_cpu)
 
+    def test_reshape_basic(self):
+        t_cpu = torch.ones(2, 6)[1].reshape(2, 3)
+        t_mps = torch.ones(2, 6, device="mps")[1].reshape(2, 3)
+        t_cpu = t_cpu + 1
+        # This used to crash, see https://github.com/pytorch/pytorch/issues/96153
+        t_mps = t_mps + 1
+        self.assertEqual(t_cpu, t_mps)
+
     def test_slice_reshape(self):
         x = torch.randn([1, 6, 4, 2], dtype=torch.float, device="mps")
         x_cpu = x.detach().clone().to("cpu")


### PR DESCRIPTION
I ran into this issue while trying to run [mamba-minimal](https://github.com/johnma2006/mamba-minimal) on MPS. I saw multiple issues running into a similar issue, like #96153. I'm not the most familiar with the code but here's what I think it was supposed to do, and how this should fix it

I believe that the original intention was for `firstDimToSlice` to have the index of the dimension of srcTensorNDArray that differs from the view requested. After the while loop comparing `src_base_shape` and `src_view_shape`, `firstDimToSlice` contains the index of the dimension that differs between the base and the view. the following `for` loop was starting one index greater, so when the base shape and view shape were the same, it would eventually yield with the subrange start being higher than the length of the dimension it should have selected for, giving this error when the test case runs:

```
failed assertion `[MPSNDArrayDescriptor sliceDimension:withSubrange:] error: subRange.start (6) is not less than length of dimension[0] (6)'
```
After this fix, the test I added passes. 

This is my first contribution to PyTorch, let me know if I need to do anything else (I signed the CLA thing) ! @DenisVieriu97 I think you've contributed the most here, would definitely appreciate your input here. 

Fixes #96153
