### PR TITLE
[dynamo][easy]: Add support for `operator.truth`

### DIFF
--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -116,6 +116,7 @@ class BuiltinVariable(VariableTracker):
             operator.pos,
             operator.neg,
             operator.not_,
+            operator.truth,
             operator.invert,
             operator.pow,
             operator.mul,


### PR DESCRIPTION
* This is an old builtin function equivalent to the bool constructor. it is easy enough to add support for. 
* I also realized the tests were in the wrong class (the one reserved for testing default args) so I moved them.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng