### PR TITLE
Bugfix consume_prefix_in_state_dict_if_present function to keep the order of the state_dict

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12742,7 +12742,7 @@ class TestFusionUtils(TestCase):
             self.assertEqual(weight.requires_grad, w_rg)
             self.assertEqual(bias.requires_grad, b_rg)
 
-class TestConsumePrefix(TestCase):
+class TestUtils(TestCase):
     # pr-117464 fixes issue-106942
     def test_consume_prefix_in_state_dict_if_present(self):
         # 0. Case non-DDP model empty state_dict

--- a/torch/nn/modules/utils.py
+++ b/torch/nn/modules/utils.py
@@ -57,22 +57,28 @@ def consume_prefix_in_state_dict_if_present(
         state_dict (OrderedDict): a state-dict to be loaded to the model.
         prefix (str): prefix.
     """
-    keys = sorted(state_dict.keys())
-    for key in keys:
+    keys_to_move = [key for key in state_dict.keys()]
+    for key in keys_to_move:
+        # Key starts with the prefix
         if key.startswith(prefix):
-            newkey = key[len(prefix) :]
-            state_dict[newkey] = state_dict.pop(key)
-
-    # also strip the prefix in metadata if any.
-    if "_metadata" in state_dict:
-        metadata = state_dict["_metadata"]
-        for key in list(metadata.keys()):
-            # for the metadata dict, the key can be:
-            # '': for the DDP module, which we want to remove.
-            # 'module': for the actual model.
-            # 'module.xx.xx': for the rest.
-
-            if len(key) == 0:
-                continue
-            newkey = key[len(prefix) :]
-            metadata[newkey] = metadata.pop(key)
+            new_key = key[len(prefix):]
+            state_dict[new_key] = state_dict.pop(key)
+           
+        # Key corresponds to the metadata
+        elif key == "_metadata":
+            metadata = state_dict["_metadata"]
+            metadata_keys = [key for key in state_dict["_metadata"].keys()]
+            for metadata_key in metadata_keys:
+                if len(metadata_key) == 0:
+                    continue
+                new_key = metadata_key
+                if metadata_key.startswith(prefix):
+                    new_key = metadata_key[len(prefix):]
+                metadata[new_key] = metadata.pop(metadata_key)
+               
+            # while the order is kept within _metadata, we need to reinsert it
+            state_dict["_metadata"] = state_dict.pop("_metadata")
+           
+        # if any of the previous options did not work, we reinsert it as it is        
+        else:
+            state_dict[key] = state_dict.pop(key)

--- a/torch/nn/modules/utils.py
+++ b/torch/nn/modules/utils.py
@@ -63,7 +63,7 @@ def consume_prefix_in_state_dict_if_present(
         if key.startswith(prefix):
             new_key = key[len(prefix):]
             state_dict[new_key] = state_dict.pop(key)
-           
+
         # Key corresponds to the metadata
         elif key == "_metadata":
             metadata = state_dict["_metadata"]
@@ -75,10 +75,10 @@ def consume_prefix_in_state_dict_if_present(
                 if metadata_key.startswith(prefix):
                     new_key = metadata_key[len(prefix):]
                 metadata[new_key] = metadata.pop(metadata_key)
-               
+
             # while the order is kept within _metadata, we need to reinsert it
             state_dict["_metadata"] = state_dict.pop("_metadata")
-           
-        # if any of the previous options did not work, we reinsert it as it is        
+
+        # if any of the previous options did not work, we reinsert it as it is
         else:
             state_dict[key] = state_dict.pop(key)

--- a/torch/nn/modules/utils.py
+++ b/torch/nn/modules/utils.py
@@ -57,7 +57,7 @@ def consume_prefix_in_state_dict_if_present(
         state_dict (OrderedDict): a state-dict to be loaded to the model.
         prefix (str): prefix.
     """
-    keys_to_move = [key for key in state_dict.keys()]
+    keys_to_move = list(state_dict.keys())
     for key in keys_to_move:
         # Key starts with the prefix
         if key.startswith(prefix):
@@ -67,7 +67,7 @@ def consume_prefix_in_state_dict_if_present(
         # Key corresponds to the metadata
         elif key == "_metadata":
             metadata = state_dict["_metadata"]
-            metadata_keys = [key for key in state_dict["_metadata"].keys()]
+            metadata_keys = list(state_dict["_metadata"].keys())
             for metadata_key in metadata_keys:
                 if len(metadata_key) == 0:
                     continue

--- a/torch/nn/modules/utils.py
+++ b/torch/nn/modules/utils.py
@@ -73,9 +73,7 @@ def consume_prefix_in_state_dict_if_present(
             # 'module.xx.xx': for the rest.
             if len(key) == 0:
                 continue
-            # we also remove the key 'module'
-            if key == 'module':
-                state_dict._metadata.pop(key)
-            if key.startswith(prefix):
+            # handling both, 'module' case and  'module.' cases
+            if key == prefix.replace('.', '') or key.startswith(prefix):
                 newkey = key[len(prefix) :]
                 state_dict._metadata[newkey] = state_dict._metadata.pop(key)


### PR DESCRIPTION
This PR proposes to keep the original order as the original state_dict, as the issue creator proposed. It also removes a bug concerning how ``_metadata`` is handled (see below), as well as other small changes to properly remove the prefix when is present. 

In the original code, ``_metadata`` was handled as a ``key``.

```
    # also strip the prefix in metadata if any.
    if "_metadata" in state_dict:
```

This is not the case, ``_metadata`` is actually an ``attribute``. Hence, the previous condition is changed to:

```
    # also strip the prefix in metadata if any.
    if hasattr(state_dict, "_metadata"):
```

This PR also includes the necessary test.

Fixes #106942
