### PR TITLE
Remove third_party/QNNPACK

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -86,10 +86,6 @@
     ignore = dirty
     path = third_party/gemmlowp/gemmlowp
     url = https://github.com/google/gemmlowp.git
-[submodule "third_party/QNNPACK"]
-    ignore = dirty
-    path = third_party/QNNPACK
-    url = https://github.com/pytorch/QNNPACK
 [submodule "third_party/neon2sse"]
     ignore = dirty
     path = third_party/neon2sse

--- a/setup.py
+++ b/setup.py
@@ -355,7 +355,6 @@ def get_submodule_folders():
             "tbb",
             "onnx",
             "foxi",
-            "QNNPACK",
             "fbgemm",
             "cutlass",
         ]


### PR DESCRIPTION
Fixes #112330, removing QNNPACK from the collection of third-party dependencies. 

PyTorch is building successfully but there may be more that must be done to remove every trace of the original (non-forked) version of QNNPACK from the codebase. Running against the CI to ensure tests pass.

cc @malfet 