### PR TITLE
Pass CPU offload flag when loading optimizer state

### DIFF
--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -389,7 +389,10 @@ def _shard_orig_param_state(
     param_idx = fsdp_param_info.param_indices[fqn]
     shard_param_info = flat_param._shard_param_infos[param_idx]  # type: ignore[attr-defined]
     optim_state = _gather_state_dict(
-        optim_state, pg=fsdp_state.process_group, device=fsdp_state.compute_device
+        optim_state,
+        pg=fsdp_state.process_group,
+        device=fsdp_state.compute_device,
+        cpu_offload=fsdp_state.cpu_offload,
     )
     if not shard_param_info.in_shard:
         return {}


### PR DESCRIPTION
Pass CPU offload flag when loading optimizer state. This flag is not correctly propagated.

As a side, I'm not sure why this all-gather is needed (eg compared to model state). PyTorch seems to use a lot more (GPU) memory for loading optimizer compared to GPU. 

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225