### PR TITLE
[Quant] [Inductor] Enable the Inductor Lowering of QConv2d post op hardswish

### DIFF
--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -619,6 +619,15 @@ class TestPatternMatcher(TestPatternMatcherBase):
         """
         self._qconv2d_unary_cpu_test_helper(unary_op=torch.nn.Hardtanh())
 
+    @skipIfNoDynamoSupport
+    @skipIfNoONEDNN
+    @skipIfRocm
+    def test_qconv2d_hardswish_cpu(self):
+        r"""
+        This testcase will quantize Conv2d->Hardswish pattern.
+        """
+        self._qconv2d_unary_cpu_test_helper(unary_op=torch.nn.Hardswish())
+
     def _qconv2d_add_cpu_test_helper(self, use_relu=False, int8_mixed_bf16=False):
         r"""
         This testcase will quantize a Conv2d->Add pattern as:
@@ -991,6 +1000,16 @@ class TestPatternMatcher(TestPatternMatcherBase):
         """
 
         self._qat_qconv2d_unary_cpu_test_helper(unary_op=torch.nn.Hardtanh())
+
+    @skipIfNoDynamoSupport
+    @skipIfNoONEDNN
+    @skipIfRocm
+    def test_qat_qconv2d_hardswish(self):
+        r"""
+        This testcase will quantize Conv2d->Hardswish pattern with qat flow.
+        """
+
+        self._qat_qconv2d_unary_cpu_test_helper(unary_op=torch.nn.Hardswish())
 
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -125,26 +125,28 @@ dequantize_per_channel_to_bf16_clone_weight_pattern = CallFunction(
     memory_format=KeywordArg("memory_format"),
 )
 
-dequantize_qconv_pt2e_pattern = CallFunction(
-    torch.ops.onednn.qconv2d_pointwise.default,
-    KeywordArg("x"),
-    KeywordArg("x_scale"),  # x_scale
-    KeywordArg("x_zp"),  # x_zp
-    KeywordArg("packed_weight"),  # packed_weight
-    KeywordArg("w_scale"),  # w_scale
-    KeywordArg("w_zp"),  # w_zp
-    KeywordArg("b"),  # bias
-    KeywordArg("stride"),
-    KeywordArg("padding"),
-    KeywordArg("dilation"),
-    KeywordArg("groups"),
-    KeywordArg("inv_output_scale"),  # inv_output_scale = 1.0
-    KeywordArg("output_zero_point"),  # output_zero_point = 0
-    KeywordArg("output_dtype"),  # output_dtype = None
-    KeywordArg("attr"),  # attr = "none"
-    Arg(),  # scalars
-    Arg(),  # algorithm
-)
+def get_dequantize_qconv_pt2e_pattern(users=1):
+    return CallFunction(
+        torch.ops.onednn.qconv2d_pointwise.default,
+        KeywordArg("x"),
+        KeywordArg("x_scale"),  # x_scale
+        KeywordArg("x_zp"),  # x_zp
+        KeywordArg("packed_weight"),  # packed_weight
+        KeywordArg("w_scale"),  # w_scale
+        KeywordArg("w_zp"),  # w_zp
+        KeywordArg("b"),  # bias
+        KeywordArg("stride"),
+        KeywordArg("padding"),
+        KeywordArg("dilation"),
+        KeywordArg("groups"),
+        KeywordArg("inv_output_scale"),  # inv_output_scale = 1.0
+        KeywordArg("output_zero_point"),  # output_zero_point = 0
+        KeywordArg("output_dtype"),  # output_dtype = None
+        KeywordArg("attr"),  # attr = "none"
+        Arg(),  # scalars
+        Arg(),  # algorithm
+        _users=users,
+    )
 
 qlinear_pt2e_pattern = CallFunction(
     torch.ops.onednn.qlinear_pointwise.default,
@@ -203,6 +205,24 @@ def generate_pattern_with_unary(computation_call, unary_post_op):
                 aten.clamp_max,
                 CallFunction(aten.clamp_min, computation_call, KeywordArg("min_value")),
                 KeywordArg("max_value"),
+            )
+        if unary_post_op == aten.hardswish.default:
+            return CallFunction(
+                aten.div,
+                CallFunction(
+                    aten.mul,
+                    computation_call,
+                    CallFunction(
+                        aten.clamp_max,
+                        CallFunction(
+                            aten.clamp_min,
+                            CallFunction(aten.add, computation_call, 3),
+                            0,
+                        ),
+                        6,
+                    ),
+                ),
+                6,
             )
         else:
             return CallFunction(
@@ -589,18 +609,24 @@ def _register_quantization_unary_fusion():
         # For example: pattern1 is qconv_fp32 -> relu, pattern2 is qconv_fp32 -> relu -> quant
         conv_unary_replace_patterns = {
             UnaryAttr("none", [], ""): generate_pattern_with_output_quant(
-                dequantize_qconv_pt2e_pattern,
+                get_dequantize_qconv_pt2e_pattern(1),
                 dtype=original_pattern_output_dtype,
             ),
             UnaryAttr("relu", [], ""): generate_pattern_with_output_quant(
                 generate_pattern_with_unary(
-                    dequantize_qconv_pt2e_pattern, aten.relu.default
+                    get_dequantize_qconv_pt2e_pattern(1), aten.relu.default
                 ),
                 dtype=original_pattern_output_dtype,
             ),
             UnaryAttr("hardtanh", [], ""): generate_pattern_with_output_quant(
                 generate_pattern_with_unary(
-                    dequantize_qconv_pt2e_pattern, aten.hardtanh.default
+                    get_dequantize_qconv_pt2e_pattern(1), aten.hardtanh.default
+                ),
+                dtype=original_pattern_output_dtype,
+            ),
+            UnaryAttr("hardswish", [], ""): generate_pattern_with_output_quant(
+                generate_pattern_with_unary(
+                    get_dequantize_qconv_pt2e_pattern(2), aten.hardswish.default
                 ),
                 dtype=original_pattern_output_dtype,
             ),
@@ -620,10 +646,13 @@ def _register_quantization_unary_fusion():
         # Priority 2 to match: QConv2d Unary pattern with fp32/bfloat16 output
         conv_unary_replace_float_out_patterns = {
             UnaryAttr("relu", [], ""): generate_pattern_with_unary(
-                dequantize_qconv_pt2e_pattern, aten.relu.default
+                get_dequantize_qconv_pt2e_pattern(1), aten.relu.default
             ),
             UnaryAttr("hardtanh", [], ""): generate_pattern_with_unary(
-                dequantize_qconv_pt2e_pattern, aten.hardtanh.default
+                get_dequantize_qconv_pt2e_pattern(1), aten.hardtanh.default
+            ),
+            UnaryAttr("hardswish", [], ""): generate_pattern_with_unary(
+                get_dequantize_qconv_pt2e_pattern(2), aten.hardswish.default
             ),
         }
 
@@ -703,7 +732,7 @@ def _register_quantization_binary_fusion():
             ): generate_pattern_with_output_quant(
                 generate_pattern_with_binary(
                     aten.add.Tensor,
-                    dequantize_qconv_pt2e_pattern,
+                    get_dequantize_qconv_pt2e_pattern(1),
                     dequantize_accum_pattern,
                     int8_mixed_bf16_with_inplace_add,
                 ),
@@ -717,7 +746,7 @@ def _register_quantization_binary_fusion():
                 generate_pattern_with_unary(
                     generate_pattern_with_binary(
                         aten.add.Tensor,
-                        dequantize_qconv_pt2e_pattern,
+                        get_dequantize_qconv_pt2e_pattern(1),
                         dequantize_accum_pattern,
                         int8_mixed_bf16_with_inplace_add,
                     ),
@@ -743,7 +772,7 @@ def _register_quantization_binary_fusion():
             BinaryUnaryAttr("sum", 1.0, "relu", [], ""): generate_pattern_with_unary(
                 generate_pattern_with_binary(
                     aten.add.Tensor,
-                    dequantize_qconv_pt2e_pattern,
+                    get_dequantize_qconv_pt2e_pattern(1),
                     KeywordArg("accum_after_dequant"),
                     int8_mixed_bf16_with_inplace_add,
                 ),
@@ -780,7 +809,7 @@ def _register_quantization_binary_fusion():
         binary_replace_float_out_patterns = {
             BinaryUnaryAttr("sum", 1.0, "none", [], ""): generate_pattern_with_binary(
                 aten.add.Tensor,
-                dequantize_qconv_pt2e_pattern,
+                get_dequantize_qconv_pt2e_pattern(1),
                 KeywordArg("accum_after_dequant"),
                 int8_mixed_bf16_with_inplace_add,
             ),

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -125,6 +125,7 @@ dequantize_per_channel_to_bf16_clone_weight_pattern = CallFunction(
     memory_format=KeywordArg("memory_format"),
 )
 
+
 def get_dequantize_qconv_pt2e_pattern(users=1):
     return CallFunction(
         torch.ops.onednn.qconv2d_pointwise.default,
@@ -147,6 +148,7 @@ def get_dequantize_qconv_pt2e_pattern(users=1):
         Arg(),  # algorithm
         _users=users,
     )
+
 
 qlinear_pt2e_pattern = CallFunction(
     torch.ops.onednn.qlinear_pointwise.default,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #117489
* #117488
* #117487

**Summary**
Enable the fusion pattern of `QConv2d -> hardswish` lowering to `hardswish` as `QConv2d` post operator. 

**Test Plan**
```
python -m pytest test_mkldnn_pattern_matcher.py -k test_qconv2d_hardswish_cpu
python -m pytest test_mkldnn_pattern_matcher.py -k test_qat_qconv2d_hardswish
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler