### PR TITLE
XPU, move oidc to top level workflow and use gha_workflow_s3_and_ecr_read_only policy

### DIFF
--- a/.github/workflows/_xpu-test.yml
+++ b/.github/workflows/_xpu-test.yml
@@ -42,10 +42,6 @@ on:
 env:
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
-permissions:
-  id-token: write
-  contents: read
-
 jobs:
   test:
     # Don't run on forked repos or empty test matrix
@@ -67,7 +63,7 @@ jobs:
         id: aws_creds
         uses: aws-actions/configure-aws-credentials@v1.7.0
         with:
-          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_pytorch_artifacts
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only
           aws-region: us-east-1
 
       - name: Login to Amazon ECR

--- a/.github/workflows/xpu.yml
+++ b/.github/workflows/xpu.yml
@@ -30,6 +30,9 @@ jobs:
     name: linux-jammy-xpu-py3.8
     uses: ./.github/workflows/_xpu-test.yml
     needs: linux-jammy-xpu-py3_8-build
+    permissions:
+      id-token: write
+      contents: read
     with:
       build-environment: linux-jammy-xpu-py3.8
       docker-image: ${{ needs.linux-jammy-xpu-py3_8-build.outputs.docker-image }}


### PR DESCRIPTION
1. oidc permissions need to be set on top level workflow
2. rename gha_workflow_s3_and_ecr_read_only to gha_workflow_s3_and_ecr_read_only policy which better reflects the policy usage
