### PR TITLE
Add a const version of get function in the Dataset Class

### DIFF
--- a/torch/csrc/api/include/torch/data/datasets/base.h
+++ b/torch/csrc/api/include/torch/data/datasets/base.h
@@ -47,7 +47,7 @@ class BatchDataset {
   virtual ~BatchDataset() = default;
 
   /// Returns a batch of data given an index.
-  virtual Batch get_batch(BatchRequest request) = 0;
+  virtual Batch get_batch(BatchRequest request) const = 0;
 
   /// Returns the size of the dataset, or an empty optional if it is unsized.
   virtual optional<size_t> size() const = 0;
@@ -80,13 +80,16 @@ class Dataset : public BatchDataset<Self, std::vector<SingleExample>> {
   /// Returns the example at the given index.
   virtual ExampleType get(size_t index) = 0;
 
-  /// Returns the example at the given index (const version).
-  virtual ExampleType get(size_t index) const = 0;
+  /// Returns the example at the given index.
+  virtual ExampleType get(size_t index) const {
+    // Cast away constness and call the non-const version of get
+    return const_cast<Dataset*>(this)->get(index);
+  }
 
   /// Returns a batch of data.
   /// The default implementation calls `get()` for every requested index
   /// in the batch.
-  std::vector<ExampleType> get_batch(ArrayRef<size_t> indices) override {
+  std::vector<ExampleType> get_batch(ArrayRef<size_t> indices) const override {
     std::vector<ExampleType> batch;
     batch.reserve(indices.size());
     for (const auto i : indices) {

--- a/torch/csrc/api/include/torch/data/datasets/base.h
+++ b/torch/csrc/api/include/torch/data/datasets/base.h
@@ -80,6 +80,9 @@ class Dataset : public BatchDataset<Self, std::vector<SingleExample>> {
   /// Returns the example at the given index.
   virtual ExampleType get(size_t index) = 0;
 
+  /// Returns the example at the given index (const version).
+  virtual ExampleType get(size_t index) const = 0;
+
   /// Returns a batch of data.
   /// The default implementation calls `get()` for every requested index
   /// in the batch.


### PR DESCRIPTION
## Summary
Add a const version of the get() function in the Dataset Class. 
For all the get() implementation in existing child classes, there is no effect as they are still overriding the original non-const version.
The const version can be used for users who directly use C++ APIs when creating custom datasets. Users can choose to override the const version instead of the non-const version.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10