### PR TITLE
[BE] Replace deprecated `set_default_tensor_type`

### DIFF
--- a/test/onnx/pytorch_test_common.py
+++ b/test/onnx/pytorch_test_common.py
@@ -21,7 +21,7 @@ from torch.testing._internal import common_utils
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.insert(-1, pytorch_test_dir)
 
-torch.set_default_tensor_type("torch.FloatTensor")
+torch.set_default_dtype(torch.float)
 
 BATCH_SIZE = 2
 


### PR DESCRIPTION
Not sure what it was doing there, but replaced it with `set_default_dtype`

