### PR TITLE
[codemod][highrisk] Fix shadowed variable in caffe2/caffe2/operators/square_root_divide_op.h

### DIFF
--- a/caffe2/operators/square_root_divide_op.h
+++ b/caffe2/operators/square_root_divide_op.h
@@ -43,9 +43,9 @@ class SquareRootDivideOp final : public Operator<Context> {
     auto* dataPtr = data.template data<TData>();
     auto* yPtr = Y->template mutable_data<TData>();
     for (const auto i : c10::irange(0U, batchSize)) {
-      auto scale = scalePtr[i];
-      CAFFE_ENFORCE(scale >= 0, scale, " < 0");
-      auto multiplier = scale == 0 ? 1.0 : 1 / std::sqrt(scale);
+      auto scale_2 = scalePtr[i];
+      CAFFE_ENFORCE(scale_2 >= 0, scale_2, " < 0");
+      auto multiplier = scale_2 == 0 ? 1.0 : 1 / std::sqrt(scale_2);
       math::Scale<float, TData, Context>(
           exampleSize,
           multiplier,


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Test Plan: Sandcastle

Reviewed By: EscapeZero

Differential Revision: D52582800


