### PR TITLE
[CI] Skip lib for xpu binary unit test

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -690,8 +690,7 @@ test_xpu_bin(){
   TEST_REPORTS_DIR=$(pwd)/test/test-reports
   mkdir -p "$TEST_REPORTS_DIR"
 
-  for xpu_case in "${BUILD_BIN_DIR}"/*{xpu,sycl}*
-  do
+  for xpu_case in "${BUILD_BIN_DIR}"/*{xpu,sycl}*; do
     if [[ "$xpu_case" != *"*"* && "$xpu_case" != *.so && "$xpu_case" != *.a ]]; then
       case_name=$(basename "$xpu_case")
       echo "Testing ${case_name} ..."

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -692,7 +692,7 @@ test_xpu_bin(){
 
   for xpu_case in "${BUILD_BIN_DIR}"/*{xpu,sycl}*
   do
-    if [[ "$xpu_case" != *"*"* ]]; then
+    if [[ "$xpu_case" != *"*"* && "$xpu_case" != *.so && "$xpu_case" != *.a ]]; then
       case_name=$(basename "$xpu_case")
       echo "Testing ${case_name} ..."
       "$xpu_case" --gtest_output=xml:"$TEST_REPORTS_DIR"/"$case_name".xml


### PR DESCRIPTION
Skip .so and .a libraries under build/bin/ for test_xpu_bin in CI

Works for #114850 also