### PR TITLE
[export] modify torch.export tests to pass a Module in

### DIFF
--- a/test/export/test_pass_infra.py
+++ b/test/export/test_pass_infra.py
@@ -1,6 +1,5 @@
 # Owner(s): ["module: dynamo"]
 import unittest
-from typing import List
 
 import torch
 from functorch.experimental import control_flow
@@ -13,9 +12,12 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 @unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
 class TestPassInfra(TestCase):
     def test_export_pass_base(self) -> None:
-        def f(x: torch.Tensor) -> List[torch.Tensor]:
-            y = torch.cat([x, x])
-            return torch.ops.aten.tensor_split.sections(y, 2)
+        class Foo(torch.nn.Module):
+            def forward(self, x):
+                y = torch.cat([x, x])
+                return torch.ops.aten.tensor_split.sections(y, 2)
+
+        f = Foo()
 
         class NullPass(_ExportPassBaseDeprecatedDoNotUse):
             pass

--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -5,27 +5,28 @@ with test_functionalization_with_native_python_assertion)
 
 # Owner(s): ["module: dynamo"]
 import math
+import operator
 import unittest
 from typing import List, Set
-import operator
 
 import torch
-from torch.testing._internal.common_utils import run_tests, TestCase
-from torch.testing import FileCheck
+from functorch.experimental.control_flow import cond
 from torch._dynamo.eval_frame import is_dynamo_supported
-from torch.export import export
 from torch._export.pass_base import _ExportPassBaseDeprecatedDoNotUse
-from torch._export.passes.replace_view_ops_with_view_copy_ops_pass import (
-    is_view_op,
-    get_view_copy_of_view_op,
-    ReplaceViewOpsWithViewCopyOpsPass,
-)
 from torch._export.passes.functionalize_side_effectful_ops_pass import (
     _FunctionalizeSideEffectfulOpsPass,
 )
-from functorch.experimental.control_flow import cond
-from torch.fx.passes.operator_support import OperatorSupport
+from torch._export.passes.replace_view_ops_with_view_copy_ops_pass import (
+    get_view_copy_of_view_op,
+    is_view_op,
+    ReplaceViewOpsWithViewCopyOpsPass,
+)
+from torch.export import export
+from torch.export._wrapper import WrapperModule
 from torch.fx.passes.infra.partitioner import Partition
+from torch.fx.passes.operator_support import OperatorSupport
+from torch.testing import FileCheck
+from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.utils import _pytree as pytree
 
 
@@ -193,7 +194,7 @@ class TestPasses(TestCase):
 
         x = torch.zeros(4, 2, 3)
 
-        ep = export(foo, (x,))._transform_do_not_use(ReplaceViewOpsWithViewCopyOpsPass())
+        ep = export(WrapperModule(foo), (x,))._transform_do_not_use(ReplaceViewOpsWithViewCopyOpsPass())
         # After this pass, there shouldn't be any view nodes in the graph
         self.assertTrue(count_call_function(ep.graph, torch.ops.aten.view.default) == 0)
         self.assertTrue(count_call_function(ep.graph, torch.ops.aten.view_copy.default) > 0)
@@ -344,7 +345,7 @@ class TestPasses(TestCase):
             )
 
         x = torch.randn(1, dtype=torch.float32)
-        ep = torch.export.export(func, args=(x,))
+        ep = torch.export.export(WrapperModule(func), args=(x,))
         _ExportPassBaseDeprecatedDoNotUse()(ep.graph_module)
 
 

--- a/test/export/test_retraceability.py
+++ b/test/export/test_retraceability.py
@@ -12,7 +12,7 @@ test_classes = {}
 
 def mocked_retraceability_export(*args, **kwargs):
     ep = export(*args, **kwargs)
-    ep = export(ep, *(args[1:]), **kwargs)
+    ep = export(ep.module(), *(args[1:]), **kwargs)
     return ep
 
 

--- a/test/export/test_safeguard.py
+++ b/test/export/test_safeguard.py
@@ -12,25 +12,37 @@ class TestSafeguard(TestCase):
     # If the autograd state doesn't change, dynamo eliminates autograd state manager op and later export can succeed.
     # Otherwise, autograd can be preserved in the produced gragh, and export will fail.
     def test_global_autograd(self):
-        def f1(a):
-            with torch.no_grad():
-                b = a + a
-            return b
+        class F1(torch.nn.Module):
+            def forward(self, a):
+                with torch.no_grad():
+                    b = a + a
+                return b
 
-        def f2(a):
-            with torch.enable_grad():
-                b = a + a
-            return b
+        f1 = F1()
 
-        def f3(a):
-            with torch.set_grad_enabled(False):
-                b = a + a
-            return b
+        class F2(torch.nn.Module):
+            def forward(self, a):
+                with torch.enable_grad():
+                    b = a + a
+                return b
 
-        def f4(a):
-            with torch.set_grad_enabled(True):
-                b = a + a
-            return b
+        f2 = F2()
+
+        class F3(torch.nn.Module):
+            def forward(self, a):
+                with torch.set_grad_enabled(False):
+                    b = a + a
+                return b
+
+        f3 = F3()
+
+        class F4(torch.nn.Module):
+            def forward(self, a):
+                with torch.set_grad_enabled(True):
+                    b = a + a
+                return b
+
+        f4 = F4()
 
         a = torch.randn(10)
         with torch.no_grad():
@@ -55,22 +67,31 @@ class TestSafeguard(TestCase):
 
     def test_tensor_autograd(self):
         # dynamo errors when Tensor.requires_grad_ change the autograd state
-        def f1(a):
-            a.requires_grad_(True)
-            b = a + a
-            return b
+        class F1(torch.nn.Module):
+            def forward(self, a):
+                a.requires_grad_(True)
+                b = a + a
+                return b
+
+        f1 = F1()
 
         # dynamo errors when Tensor.requires_grad_ change the autograd state
-        def f2(a):
-            a.requires_grad_(False)
-            b = a + a
-            return b
+        class F2(torch.nn.Module):
+            def forward(self, a):
+                a.requires_grad_(False)
+                b = a + a
+                return b
+
+        f2 = F2()
 
         # dynamo always errors on Tensor.requires_grad
-        def f3(a):
-            a.requires_grad = False
-            b = a + a
-            return b
+        class F3(torch.nn.Module):
+            def forward(self, a):
+                a.requires_grad = False
+                b = a + a
+                return b
+
+        f3 = F3()
 
         export(f1, (torch.randn(10, requires_grad=True),))
         export(f2, (torch.randn(10, requires_grad=False),))

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -11,31 +11,32 @@ import zipfile
 
 import torch
 import torch._dynamo as torchdynamo
-from torch.export import export, save, load, Dim
+import torch.utils._pytree as pytree
 from torch._export.db.case import ExportCase, normalize_inputs, SupportLevel
 from torch._export.db.examples import all_examples
 from torch._export.serde.serialize import (
-    ExportedProgramDeserializer,
-    ExportedProgramSerializer,
     canonicalize,
     deserialize,
+    ExportedProgramDeserializer,
+    ExportedProgramSerializer,
     serialize,
     SerializeError,
 )
 from torch._subclasses.fake_tensor import FakeTensor
+from torch.export import Dim, export, load, save
+from torch.export._wrapper import WrapperModule
 from torch.fx.experimental.symbolic_shapes import is_concrete_int
-import torch.utils._pytree as pytree
 from torch.testing._internal.common_utils import (
+    find_library_location,
     instantiate_parametrized_tests,
-    parametrize,
-    run_tests,
-    TestCase,
-    TemporaryFileName,
     IS_FBCODE,
     IS_MACOS,
     IS_SANDCASTLE,
     IS_WINDOWS,
-    find_library_location,
+    parametrize,
+    run_tests,
+    TemporaryFileName,
+    TestCase,
 )
 
 
@@ -158,10 +159,12 @@ class TestSerialize(TestCase):
         Tests that the kwargs default values are serialized even if they are not
         specified
         """
+        class Foo(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                values = torch.randn(3, 2)
+                return torch.searchsorted(x, values, side="right", right=True)
 
-        def f(x: torch.Tensor) -> torch.Tensor:
-            values = torch.randn(3, 2)
-            return torch.searchsorted(x, values, side="right", right=True)
+        f = Foo()
 
         x, _ = torch.sort(torch.randn(3, 4))
         exported_module = export(f, (x,)).run_decompositions()
@@ -355,17 +358,18 @@ class TestDeserialize(TestCase):
             assert x.size(0) in y
             return x + y
 
-        self.check_graph(f, (torch.ones(1), torch.ones(3)))
+        self.check_graph(WrapperModule(f), (torch.ones(1), torch.ones(3)))
 
     def test_shape(self):
-        def f(x):
-            z, y = x.size()
-            return z + y + x[0], z
+        class Foo(torch.nn.Module):
+            def forward(self, x):
+                z, y = x.size()
+                return z + y + x[0], z
 
         inputs = (torch.ones(2, 3),)
         dim0_x, dim1_x = torch.export.dims("dim0_x", "dim1_x")
         dynamic_shapes = {"x": (dim0_x, dim1_x)}
-        self.check_graph(f, inputs, dynamic_shapes)
+        self.check_graph(Foo(), inputs, dynamic_shapes)
 
     def test_module(self):
         class M(torch.nn.Module):
@@ -425,7 +429,7 @@ class TestDeserialize(TestCase):
             return control_flow.map(f, xs, y)
 
         inputs = (torch.ones(3, 2, 2), torch.ones(2))
-        self.check_graph(g, inputs, _check_meta=False)
+        self.check_graph(WrapperModule(g), inputs, _check_meta=False)
 
     def test_tensor_tensor_list(self):
         from torch.library import Library
@@ -461,13 +465,14 @@ class TestDeserialize(TestCase):
         self.check_graph(MyModule(), inputs)
 
     def test_sym_ite(self):
-        def f(x):
-            b = x.shape[0] == 5
-            ret = torch.sym_ite(b, x.shape[0], x.shape[1])
-            return ret
+        class Foo(torch.nn.Module):
+            def forward(self, x):
+                b = x.shape[0] == 5
+                ret = torch.sym_ite(b, x.shape[0], x.shape[1])
+                return ret
 
         dynamic_shapes = {'x': {0: Dim("dim0"), 1: Dim("dim1")}}
-        self.check_graph(f, (torch.ones(4, 5),), dynamic_shapes=dynamic_shapes)
+        self.check_graph(Foo(), (torch.ones(4, 5),), dynamic_shapes=dynamic_shapes)
 
     @parametrize(
         "name,case",
@@ -486,19 +491,19 @@ class TestDeserialize(TestCase):
             torch._constrain_as_size(n, min=2)
             return y.sum() + torch.ones(n, 5).sum()
 
-        self.check_graph(f, (torch.tensor(3), torch.randn(4, 5)))
+        self.check_graph(WrapperModule(f), (torch.tensor(3), torch.randn(4, 5)))
 
     def test_get_attr(self) -> None:
         def f(x):
             return x + torch.tensor(3)
 
-        self.check_graph(f, (torch.tensor(3),))
+        self.check_graph(WrapperModule(f), (torch.tensor(3),))
 
     def test_get_attr_list(self) -> None:
         def f(x):
             return torch.cat([x, torch.tensor([1, 1])])
 
-        self.check_graph(f, (torch.tensor([1, 1]),))
+        self.check_graph(WrapperModule(f), (torch.tensor([1, 1]),))
 
     @unittest.skipIf(not torch.cuda.is_available(), "Requires cuda")
     def test_device(self) -> None:
@@ -527,7 +532,7 @@ class TestSchemaVersioning(TestCase):
         def f(x):
             return x + x
 
-        ep = export(f, (torch.randn(1, 3),))
+        ep = export(WrapperModule(f), (torch.randn(1, 3),))
 
         serialized_artifact = ExportedProgramSerializer().serialize(ep)
         serialized_artifact.exported_program.schema_version.major = -1
@@ -604,9 +609,11 @@ class TestSaveLoad(TestCase):
         self.assertTrue(torch.allclose(ep(*inp), loaded_ep(*inp)))
 
     def test_save_file(self):
+        class Foo(torch.nn.Module):
+            def forward(self, x):
+                return x * x
 
-        def f(x):
-            return x * x
+        f = Foo()
 
         inp = (torch.randn(2, 2),)
         ep = export(f, inp)
@@ -619,8 +626,11 @@ class TestSaveLoad(TestCase):
         self.assertTrue(torch.allclose(ep(*inp), loaded_ep(*inp)))
 
     def test_save_path(self):
-        def f(x, y):
-            return x + y
+        class Foo(torch.nn.Module):
+            def forward(self, x, y):
+                return x + y
+
+        f = Foo()
 
         inp = (torch.tensor([6]), torch.tensor([7]))
         ep = export(f, inp)
@@ -635,8 +645,11 @@ class TestSaveLoad(TestCase):
     def test_save_extra(self):
         inp = (torch.tensor([0.1, 0.1]),)
 
-        def f(x):
-            return x * x + x
+        class Foo(torch.nn.Module):
+            def forward(self, x):
+                return x * x + x
+
+        f = Foo()
 
         ep = export(f, inp)
 
@@ -650,8 +663,11 @@ class TestSaveLoad(TestCase):
         self.assertEqual(extra_files["extra.txt"], "moo")
 
     def test_version_error(self):
-        def f(x):
-            return x + x
+        class Foo(torch.nn.Module):
+            def forward(self, x):
+                return x + x
+
+        f = Foo()
 
         ep = export(f, (torch.randn(1, 3),))
 

--- a/test/export/test_upgrade.py
+++ b/test/export/test_upgrade.py
@@ -96,8 +96,11 @@ def div__Scalar_mode_0_3(self: torch.Tensor, other: Any,  *, rounding_mode: Opti
         self.assertEqual(len(upgrader.upgrader_passes), 1)
 
     def test_div_upgrader_replaces_op_with_old_version(self):
-        def fn(a: torch.Tensor, b):
-            return torch.ops.aten.div.Scalar_mode(a, b, rounding_mode='trunc')
+        class Foo(torch.nn.Module):
+            def forward(self, a: torch.Tensor, b):
+                return torch.ops.aten.div.Scalar_mode(a, b, rounding_mode='trunc')
+
+        fn = Foo()
 
         inputs = (torch.ones([2, 3]) * 4, 2.)
         ep = export(fn, inputs, [])
@@ -113,8 +116,11 @@ def div__Scalar_mode_0_3(self: torch.Tensor, other: Any,  *, rounding_mode: Opti
         self.assertEqual(custom_op_count, 1)
 
     def test_div_upgrader_pass_return_new_op_after_retrace(self):
-        def fn(a: torch.Tensor, b):
-            return torch.ops.aten.div.Scalar_mode(a, b, rounding_mode='trunc')
+        class Foo(torch.nn.Module):
+            def forward(self, a: torch.Tensor, b):
+                return torch.ops.aten.div.Scalar_mode(a, b, rounding_mode='trunc')
+
+        fn = Foo()
 
         inputs = (torch.ones([2, 3]) * 4, 2.)
         ep = export(fn, inputs)

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -207,6 +207,7 @@ MOD_INLINELIST = {
     "torch.autograd.function",
     "torch.cuda.amp.autocast_mode",
     "torch.distributions",
+    "torch.export._wrapper",
     "torch.fx._pytree",
     "torch.fx.passes.shape_prop",
     "torch.nn",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #117528
* __->__ #117527
* #117526
* #117525

We have a lot of tests that pass a function to torch.export.

We are planning to disallow this, so fix up the tests to pass a module in.

Differential Revision: [D52791309](https://our.internmc.facebook.com/intern/diff/D52791309/)