### PR TITLE
[Caffe2] Fix bug in `str` on wide types

### DIFF
--- a/c10/test/util/string_util_test.cpp
+++ b/c10/test/util/string_util_test.cpp
@@ -1,0 +1,80 @@
+#include <c10/util/StringUtil.h>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+namespace test_str_narrow_single {
+TEST(StringUtilTest, testStrNarrowSingle) {
+  std::string s = "narrow test string";
+  EXPECT_EQ(s, c10::str(s));
+
+  const char* c_str = s.c_str();
+  EXPECT_EQ(s, c10::str(c_str));
+
+  char c = 'a';
+  EXPECT_EQ(std::string(1, c), c10::str(c));
+}
+} // namespace test_str_narrow_single
+
+namespace test_str_wide_single {
+TEST(StringUtilTest, testStrWideSingle) {
+  std::wstring s = L"wide test string";
+  std::string narrow = "wide test string";
+  EXPECT_EQ(narrow, c10::str(s));
+
+  const wchar_t* c_str = s.c_str();
+  EXPECT_EQ(narrow, c10::str(c_str));
+
+  wchar_t c = L'a';
+  std::string narrowC = "a";
+  EXPECT_EQ(narrowC, c10::str(c));
+}
+} // namespace test_str_wide_single
+
+namespace test_str_wide_single_multibyte {
+TEST(StringUtilTest, testStrWideSingleMultibyte) {
+  std::wstring s = L"\u00EC blah";
+  std::string narrow = "\xC3\xAC blah";
+  EXPECT_EQ(narrow, c10::str(s));
+
+  const wchar_t* c_str = s.c_str();
+  EXPECT_EQ(narrow, c10::str(c_str));
+
+  wchar_t c = L'\u00EC';
+  std::string narrowC = "\xC3\xAC";
+  EXPECT_EQ(narrowC, c10::str(c));
+}
+} // namespace test_str_wide_single_multibyte
+
+namespace test_str_wide_empty {
+TEST(StringUtilTest, testStrWideEmpty) {
+  std::wstring s = L"";
+  std::string narrow = "";
+  EXPECT_EQ(narrow, c10::str(s));
+
+  const wchar_t* c_str = s.c_str();
+  EXPECT_EQ(narrow, c10::str(c_str));
+
+  wchar_t c = L'\0';
+  std::string narrowC(1, '\0');
+  EXPECT_EQ(narrowC, c10::str(c));
+}
+} // namespace test_str_wide_empty
+
+namespace test_str_multi {
+TEST(StringUtilTest, testStrMulti) {
+  std::string result = c10::str(
+      "c_str ",
+      'c',
+      std::string(" std::string "),
+      42,
+      L" wide c_str ",
+      L'w',
+      std::wstring(L" std::wstring "));
+  std::string expected = "c_str c std::string 42 wide c_str w std::wstring ";
+  EXPECT_EQ(expected, result);
+}
+} // namespace test_str_multi
+
+} // namespace

--- a/c10/util/StringUtil.h
+++ b/c10/util/StringUtil.h
@@ -56,6 +56,11 @@ inline std::ostream& _str(std::ostream& ss, const T& t) {
   return ss;
 }
 
+// Overloads of _str for wide types; forces narrowing.
+C10_API std::ostream& _str(std::ostream& ss, const wchar_t* wCStr);
+C10_API std::ostream& _str(std::ostream& ss, const wchar_t& wChar);
+C10_API std::ostream& _str(std::ostream& ss, const std::wstring& wString);
+
 template <>
 inline std::ostream& _str<CompileTimeEmptyString>(
     std::ostream& ss,


### PR DESCRIPTION
Summary:
The current implementation of `str` passes wide types (`wchar_t`, `wchar_t*`, `std::wstring`) directly to `std::ostringstream`. This has the following behavior:

 - C++17, `wchar_t` & `wchar_t *`: print the integer representation of the character or the pointer. This is unexpected and almost certainly a (runtime) bug.
 - C++17, `std::wstring`: compile-time error.
 - C++20, all of the above: compile-time error.

To fix the bug and to enable C++20 migration, this diff performs narrowing on these wide types (assuming UTF-16 encoding) before passing them to `std::ostringstream`. This fixes both the C++20 compile time errors and the C++17 runtime bugs.

This bug surfaced in enabling C++20 windows builds, because windows specific caffe2 code uses `TORCH_CHECK` with wide strings, which references `str` for generating error messages.

Test Plan: CI & https://godbolt.org/z/ecTGd8Ma9

Differential Revision: D52792393


