### PR TITLE
Drop hard dependency on `fsspec`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1108,7 +1108,6 @@ def main():
         "sympy",
         "networkx",
         "jinja2",
-        "fsspec",
         'mkl>=2021.1.1,<=2021.4.0; platform_system == "Windows"',
     ]
 

--- a/test/distributed/checkpoint/test_fsspec.py
+++ b/test/distributed/checkpoint/test_fsspec.py
@@ -5,6 +5,8 @@ import tempfile
 from functools import wraps
 from typing import Any, Callable, Dict, Optional, Tuple
 
+import pytest
+
 import torch
 import torch.distributed as dist
 import torch.distributed.checkpoint as dcp
@@ -19,6 +21,8 @@ from torch.testing._internal.distributed._shard.sharded_tensor import (
     ShardedTensorTestBase,
     with_comms,
 )
+
+pytest.importorskip("fsspec")
 
 
 def with_temp_dir(


### PR DESCRIPTION
This PR proposes to drop the hard runtime dependency on the `fsspec` library.

In Torch, it is only used by `torch.distributed.checkpoint._fsspec_filesystem`, and given the majority of Torch users are likely  to not do distributed training/checkpointing, they wouldn't need this.



cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @LucasLLC @MeetVadakkanchery @mhorowitz @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @penguinwu @tianyu-l @yf225