### PR TITLE
Drop hard dependency on `networkx`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1092,7 +1092,6 @@ def main():
         "filelock",
         "typing-extensions>=4.8.0",
         "sympy",
-        "networkx",
         "jinja2",
         "fsspec",
         'mkl>=2021.1.1,<=2021.4.0; platform_system == "Windows"',


### PR DESCRIPTION
Sibling of #117535.

Aside from `caffe2/python/memonger.py`, all of the imports for `networkx` within the library and tests are optional and guarded with user-friendly error messages, so it probably does not need to be a hard dependency.