### PR TITLE
Drop hard dependency on `jinja2`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1076,7 +1076,6 @@ def main():
         "typing-extensions>=4.8.0",
         "sympy",
         "networkx",
-        "jinja2",
         "fsspec",
     ]
 

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -1298,14 +1298,16 @@ class OptimizationContext:
 
 @functools.lru_cache(None)
 def jinja2_env():
-    try:
-        import jinja2
+    import jinja2
 
-        return jinja2.Environment(
-            undefined=jinja2.StrictUndefined,
-        )
-    except ImportError:
-        return None
+    return jinja2.Environment(
+        undefined=jinja2.StrictUndefined,
+    )
+
+
+@functools.lru_cache(None)
+def jinja2_template_from_string(template_string):
+    return jinja2_env().from_string(template_string)
 
 
 class ChoiceCaller:
@@ -1346,13 +1348,6 @@ class KernelTemplate:
 
     Children classes: TritonTemplate, CUDATemplate
     """
-
-    @staticmethod
-    def _template_from_string(source):
-        env = jinja2_env()
-        if env is not None:
-            return env.from_string(source)
-        return None
 
     @staticmethod
     def _fake_get_dtype(fake_out):

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -394,18 +394,6 @@ class TritonTemplateKernel(TritonKernel):
             )
 
 
-@functools.lru_cache(None)
-def _jinja2_env():
-    try:
-        import jinja2
-
-        return jinja2.Environment(
-            undefined=jinja2.StrictUndefined,
-        )
-    except ImportError:
-        return None
-
-
 class TritonTemplate(KernelTemplate):
     index_counter = itertools.count()
     all_templates: Dict[str, "TritonTemplate"] = dict()


### PR DESCRIPTION
Sibling of https://github.com/pytorch/pytorch/pull/117535 and https://github.com/pytorch/pytorch/pull/117536.

This PR proposes to drop the hard run-time dependency on Jinja2.

The use of `jinja2` within `torch/` was already (somewhat poorly – it would just return a None instead of letting the user know what was wrong) import-guarded.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang