### PR TITLE
allow explicit ints in `dynamic_shapes`

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -755,6 +755,32 @@ class TestExport(TestCase):
                 dynamic_shapes={"x": (batch, M, K), "y": (batch, K, N)},
             )
 
+        # pass dynamic shapes of inputs [specialized, tuple]
+        def foo(x, y):
+            return torch.matmul(x, y)
+
+        inputs = (torch.randn(10, 2, 3), torch.randn(10, 3, 4))
+        batch, K1, N = dims("batch", "K1", "N")
+        efoo = export(
+            foo,
+            inputs,
+            dynamic_shapes={"x": (batch, 2, K1), "y": (batch, K1, N)},
+        )
+        self.assertEqual(efoo(*inputs).shape, foo(*inputs).shape)
+
+        # pass dynamic shapes of inputs [specialized, dict]
+        def foo(x, y):
+            return torch.matmul(x, y)
+
+        inputs = (torch.randn(10, 2, 3), torch.randn(10, 3, 4))
+        batch, K1, N = dims("batch", "K1", "N")
+        efoo = export(
+            foo,
+            inputs,
+            dynamic_shapes={"x": {0: batch, 1: 2, 2: K1}, "y": {0: batch, 1: K1, 2: N}},
+        )
+        self.assertEqual(efoo(*inputs).shape, foo(*inputs).shape)
+
     def test_dynamic_shapes_spec_with_pytree(self):
         from torch.export import Dim, export
         from torch.utils._pytree import tree_map


### PR DESCRIPTION
Summary:
`dynamic_shapes` requires `None`s for dimensions with static shapes, which will be decided during compilation time as the same shape as the example inputs given to `torch.export.export()` call.

However, users may want to specify a static shape regardless of the example inputs.

This task enables explicitly specifying `int`s in `dynamic_shapes`.

Differential Revision: D52771777


