### PR TITLE
Replace `constraints` with `dynamic_shapes` in deeplearning/aot_inductor test

### DIFF
--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -55,6 +55,7 @@ from torch.export.graph_signature import (
 )
 from torch.export.dynamic_shapes import (
     Constraint,
+    dims,
     dynamic_dim,
     _process_constraints,
     _process_dynamic_shapes,


### PR DESCRIPTION
Summary: `constraints` argument for `torch.export` has been deprecated in favor of the `dynamic_shapes` argument. This PR updates the use of the deprecated API in `deeplearning/aot_inductor/test/test_custom_ops.py`.

Test Plan: buck test mode/dev-nosan fbcode//deeplearning/aot_inductor/test:test_custom_ops -- test_export_extern_fallback_nodes_dynamic_shape

Differential Revision: D52790332


