### PR TITLE
Make ghstack merge check workflow more readable on hud

### DIFF
--- a/.github/workflows/check_mergeability_ghstack.yml
+++ b/.github/workflows/check_mergeability_ghstack.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened, edited]
 
 jobs:
-  check-regex:
+  check-if-ghstack-pr:
     runs-on: ubuntu-latest
     outputs:
       regex-match: ${{ steps.regex-match.outputs.match }}
@@ -18,8 +18,8 @@ jobs:
           text: ${{ github.head_ref }}
           regex: '^(gh/[^/]+/[0-9]+/)head$'
 
-  pr-dependencies-check:
-    needs: check-regex
+  check-ghstack-mergeability:
+    needs: check-if-ghstack-pr
     if: ${{ needs.check-regex.outputs.regex-match != '' }}
     uses: pytorch/test-infra/.github/workflows/pr-dependencies-check.yml@main
     with:

--- a/.github/workflows/check_mergeability_ghstack.yml
+++ b/.github/workflows/check_mergeability_ghstack.yml
@@ -1,4 +1,4 @@
-name: Check mergeability and dependencies for ghstack prs
+name: Check mergeability for ghstack prs
 
 on:
   pull_request:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #117581

The gha steps' names didn't really make sense on hud, now they make a bit more sense, example
https://hud.pytorch.org/pytorch/pytorch/pull/117410?sha=01a99f1071346d71e39831ba20468e0b7bdf66d5
