### PR TITLE
[dynamo] add common methods to DistributedVariable

### DIFF
--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -230,6 +230,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         return str(self)
 
     def python_type(self):
+        """Any variable that have a corresponding python type can override this method to return its python type"""
         raise NotImplementedError(f"{self} has no type")
 
     def as_python_constant(self):

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -230,7 +230,29 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         return str(self)
 
     def python_type(self):
-        """Any variable that have a corresponding python type can override this method to return its python type"""
+        """
+        Abstract method to be implemented by subclasses of VariableTracker.
+
+        This method should return the type represented by the instance of the subclass.
+        The purpose is to provide a standardized way to retrieve the Python type information
+        of the variable being tracked.
+
+        Returns:
+            type: The Python type (such as int, str, list, etc.) of the variable tracked by
+                the subclass. If the type cannot be determined or is not relevant,
+                leaving it undefined or invoking super() is always sound.
+
+        Note:
+            This is an abstract method and may be overridden in subclasses.
+
+        Example:
+            class SetVariable(VariableTracker):
+                def python_type(self):
+                    return set
+
+        Raises:
+            NotImplementedError: If the method is not implemented in a subclass.
+        """
         raise NotImplementedError(f"{self} has no type")
 
     def as_python_constant(self):

--- a/torch/_dynamo/variables/distributed.py
+++ b/torch/_dynamo/variables/distributed.py
@@ -10,10 +10,18 @@ from .constant import ConstantVariable
 
 
 class DistributedVariable(VariableTracker):
-    def __init__(self, **kwargs):
+    """
+    The base distributed variable that checks for the distributed existance
+    and hold the value for a distributed object.
+    """
+    def __init__(self, value, **kwargs):
         super().__init__(**kwargs)
         if not DistributedVariable.is_available():
             unimplemented("torch.distributed package is not available!")
+        self.value = value
+
+    def python_type(self):
+        return type(self.value)
 
     @staticmethod
     def is_available():
@@ -47,10 +55,6 @@ def is_constant_pg_functions(value):
 
 
 class PlacementClassVariable(DistributedVariable):
-    def __init__(self, value, **kwargs):
-        super().__init__(**kwargs)
-        self.value = value
-
     @staticmethod
     def is_placement_type(value):
         # we can't rely on importing/accessing torch distributed, it is not always built.
@@ -80,10 +84,6 @@ class PlacementClassVariable(DistributedVariable):
 
 
 class PlacementVariable(DistributedVariable):
-    def __init__(self, value, **kwargs):
-        super().__init__(**kwargs)
-        self.value = value
-
     @staticmethod
     def is_placement(value):
         # we can't rely on importing/accessing torch distributed, it is not always built.
@@ -130,10 +130,6 @@ class PlacementVariable(DistributedVariable):
 
 
 class DeviceMeshVariable(DistributedVariable):
-    def __init__(self, value, **kwargs):
-        super().__init__(**kwargs)
-        self.value = value
-
     @staticmethod
     def is_device_mesh(value):
         # we can't rely on importing/accessing torch distributed, it is not always built.
@@ -172,15 +168,8 @@ class ProcessGroupVariable(DistributedVariable):
           or just graph-break whenever one of our special cases is not hit?
     """
 
-    def __init__(self, value, **kwargs):
-        super().__init__(**kwargs)
-        self.value = value
-
     def as_python_constant(self):
         return self.value
-
-    def python_type(self):
-        return type(self.value)
 
     def call_method(
         self,

--- a/torch/_dynamo/variables/distributed.py
+++ b/torch/_dynamo/variables/distributed.py
@@ -11,8 +11,13 @@ from .constant import ConstantVariable
 
 class DistributedVariable(VariableTracker):
     """
-    The base distributed variable that checks for the distributed existance
-    and hold the value for a distributed object.
+    The base distributed variable that encapsulates common methods
+    for the distributed objects (i.e. ProcessGroup, DeviceMesh, etc.).
+    Concrete distributed objects could inherit this class and add object
+    specific logic.
+
+    i.e. It provides the check on the distributed package existance
+    and hold the tracking value for the corresponding distributed object.
     """
 
     def __init__(self, value, **kwargs):

--- a/torch/_dynamo/variables/distributed.py
+++ b/torch/_dynamo/variables/distributed.py
@@ -14,6 +14,7 @@ class DistributedVariable(VariableTracker):
     The base distributed variable that checks for the distributed existance
     and hold the value for a distributed object.
     """
+
     def __init__(self, value, **kwargs):
         super().__init__(**kwargs)
         if not DistributedVariable.is_available():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #117590

This PR refactors the distributed related variables to use
DistributedVariable for common methods, so that things like
`python_type` works for all distributed variables.

Maybe we can add `as_python_constant` to the DistributedVariable too? I
didn't add in this PR but if that make sense I can update.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng