### PR TITLE
[ROCm] Fix NHWC related tests in test_inductor_freezing (#117158)

### DIFF
--- a/test/inductor/test_inductor_freezing.py
+++ b/test/inductor/test_inductor_freezing.py
@@ -24,6 +24,7 @@ from torch.testing._internal.common_utils import (
     IS_CI,
     IS_WINDOWS,
     TEST_WITH_ASAN,
+    TEST_WITH_ROCM,
     TestCase as TorchTestCase,
 )
 
@@ -632,6 +633,10 @@ class OptimizeForInferenceTemplate(TestCase):
         # may be an extra copy
         self.assertTrue(num_diff_stride == 1, f"num_diff_stride is {num_diff_stride}")
 
+
+if TEST_WITH_ROCM:
+    torch._inductor.config.force_layout_optimization = 1
+    os.environ["PYTORCH_MIOPEN_SUGGEST_NHWC"] = "1"
 
 if HAS_CPU and not torch.backends.mps.is_available():
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #117425
* #117218
* #117553
* #116910
* #117500
* __->__ #117591
* #116667
* #117409

Fixes #ISSUE_NUMBER
Approved by: https://github.com/eellison, https://github.com/pruthvistony

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler