### PR TITLE
[Reland][ONNX] Guard xfail tests with error messages

### DIFF
--- a/test/onnx/test_fx_to_onnx.py
+++ b/test/onnx/test_fx_to_onnx.py
@@ -580,8 +580,9 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
             onnx.shape_inference.infer_shapes(onnx_program.model_proto)
 
     @pytorch_test_common.xfail(
-        "This is addressed in main branch of transformers."
-        "https://github.com/huggingface/transformers/pull/24941"
+        error_message="aten._local_scalar_dense.default",
+        reason="This is addressed in main branch of transformers."
+        "https://github.com/huggingface/transformers/pull/24941",
     )
     def test_fake_tensor_mode_huggingface_databricks_dolly_v2_3b(self):
         config = transformers.GPTNeoXConfig(
@@ -608,9 +609,7 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
             onnx.shape_inference.infer_shapes(onnx_program.model_proto)
 
     @pytorch_test_common.xfail(
-        "Not decorated with xfail because CI doesn't have enough memory to run and then fail."
-        "AssertionError: Mutating module attribute seq_len_cached during export."
-        "self.seq_len_cached = seq_len"
+        error_message="Mutating module attribute seq_len_cached during export."
     )
     def test_fake_tensor_mode_huggingface_tiiuae_falcon(self):
         config = transformers.FalconConfig()

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -95,8 +95,9 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(func, (tensor_x,))
 
     @pytorch_test_common.xfail(
-        "AssertionError: Dynamo input/output is not consistent with traced input/output. "
-        "Ref: https://github.com/pytorch/pytorch/issues/96379"
+        error_message="graph-captured input #2, of type <class 'torch.Tensor'>, "
+        "is not among original inputs of types: (<class 'torch.Tensor'>)",
+        reason="https://github.com/pytorch/pytorch/issues/96379",
     )
     def test_func_with_args_and_tensor_kwargs(self):
         # Non-tensor optional kwargs are always folded into constant and
@@ -167,8 +168,8 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         )
 
     @pytorch_test_common.xfail(
-        "https://github.com/pytorch/pytorch/issues/99534"
-        "Non-tensor input is not traceable in dynamo."
+        error_message="Model inputs incompatible with the format that was exported",
+        reason="https://github.com/pytorch/pytorch/issues/99534",
     )
     def test_xfail_func_with_non_tensor_args(self):
         def func(x, b=1.0):
@@ -306,9 +307,8 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             (dummy_input,),
         )
 
-    @pytorch_test_common.skip_dynamic_fx_test(
-        "[ONNXRuntimeError] : 2 : INVALID_ARGUMENT : "
-        "Got invalid dimensions for input: arg0 for the following indices index: 0 Got: 3 Expected: 1"
+    @pytorch_test_common.xfail_dynamic_fx_test(
+        error_message="[ONNXRuntimeError] : 2 : INVALID_ARGUMENT : Got invalid dimensions for input"
     )
     @skip_if_no_torchvision
     def test_shufflenet_v2(self):
@@ -376,8 +376,8 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             DynamicMatMul(), (x, y), additional_test_inputs=[((input_x, input_y),)]
         )
 
-    @pytorch_test_common.skip_dynamic_fx_test(
-        "fx graph does not capture symbolic value for aten::scalar_tensor."
+    @pytorch_test_common.xfail_dynamic_fx_test(
+        error_message="The values for attribute 'shape' do not match: torch.Size([]) != torch.Size([1])"
     )
     def test_scalar_tensor(self):
         class test(torch.nn.Module):
@@ -413,7 +413,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         )
 
     @pytorch_test_common.xfail(
-        "torch._dynamo.exc.Unsupported: guard on data-dependent symbolic int/float"
+        error_message="zeros() received an invalid combination of arguments - got (FakeTensor, FakeTensor)"
     )
     def test_squeeze_runtime_dim(self):
         class Squeeze(torch.nn.Module):
@@ -448,10 +448,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         )
 
     @pytorch_test_common.xfail_if_model_type_is_exportedprogram(
-        "torch._export.verifier.SpecViolationError: User input output view_1 does not point to a user input that exists."
-        "Dict of user inputs that are mutated, in order: {'view_1': 'l_x_'}"
-        "User input nodes available: ('arg0_1',)"
-        " Github issue: https://github.com/pytorch/pytorch/issues/112429"
+        error_message="Expected 1 outputs, got 2",
     )
     def test_mutation(self):
         class MutationModel(torch.nn.Module):
@@ -480,15 +477,11 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             additional_test_inputs=[((y,),)],
         )
 
-    @pytorch_test_common.xfail_if_model_type_is_exportedprogram(
-        "torch._export.verifier.SpecViolationError: User input output slice_scatter_1 does not point to a user input that exists."
-        "Dict of user inputs that are mutated, in order: {'slice_scatter_1': 'l_x_'}"
-        "User input nodes available: ('arg1_1',)"
+    @pytorch_test_common.xfail_dynamic_fx_test(
+        error_message="[ONNXRuntimeError] : 1 : FAIL : Non-zero status code returned while running Slice node. "
     )
-    @pytorch_test_common.skip_dynamic_fx_test(
-        "[ONNXRuntimeError] : 1 : FAIL : Non-zero status code returned while running Slice node. "
-        "Name:'_inline_aten_slice_scattern13' Status Message: slice.cc:193 "
-        "FillVectorsFromInput Starts must be a 1-D array"
+    @pytorch_test_common.xfail_if_model_type_is_exportedprogram(
+        error_message="Expected 1 outputs, got 2"
     )
     def test_expand_as_fill_zero(self):
         class Model(torch.nn.Module):
@@ -504,15 +497,11 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             additional_test_inputs=[((x2,),)],
         )
 
-    @pytorch_test_common.xfail_if_model_type_is_exportedprogram(
-        "torch._export.verifier.SpecViolationError: User input output slice_scatter_1 does not point to a user input that exists."
-        "Dict of user inputs that are mutated, in order: {'slice_scatter_1': 'l_x_'}"
-        "User input nodes available: ('arg1_1',)"
+    @pytorch_test_common.xfail_dynamic_fx_test(
+        error_message="[ONNXRuntimeError] : 1 : FAIL : Non-zero status code returned while running Slice node. "
     )
-    @pytorch_test_common.skip_dynamic_fx_test(
-        "[ONNXRuntimeError] : 1 : FAIL : Non-zero status code returned while running Slice node. "
-        "Name:'_inline_aten_slice_scattern13' Status Message: slice.cc:193 "
-        "FillVectorsFromInput Starts must be a 1-D array"
+    @pytorch_test_common.xfail_if_model_type_is_exportedprogram(
+        error_message="Expected 1 outputs, got 2"
     )
     def test_expand_as_fill_tensor(self):
         class Model(torch.nn.Module):
@@ -529,8 +518,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         )
 
     @pytorch_test_common.xfail_if_model_type_is_not_exportedprogram(
-        "RuntimeError: at::functionalization::impl::isFunctionalTensor(self_) INTERNAL ASSERT FAILED "
-        "at '/path/to/pytorch/torch/csrc/autograd/python_torch_functions_manual.cpp':514, please report a bug to PyTorch."
+        error_message="at::functionalization::impl::isFunctionalTensor(self_) INTERNAL ASSERT FAILED"
     )
     def test_expand_as_fill_separate_tensor(self):
         class Model(torch.nn.Module):
@@ -619,8 +607,8 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         )
 
     @pytorch_test_common.xfail_if_model_type_is_exportedprogram(
-        "Unsupported: {'call_function': ['<built-in function ge>', 'aten._assert_async.msg', '<built-in function le>']}."
-        " Github issue: https://github.com/pytorch/pytorch/issues/112443"
+        error_message="Unsupported FX nodes: {'call_function': ['aten._assert_async.msg']}.",
+        reason="https://github.com/pytorch/pytorch/issues/112622",
     )
     def test_operator_with_scalar_output(self):
         def func(x, y):
@@ -631,8 +619,8 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         )
 
     @pytorch_test_common.xfail_if_model_type_is_exportedprogram(
-        "Unsupported: Unsupported FX nodes: {'call_function': ['aten._assert_async.msg']}."
-        " Github issue: https://github.com/pytorch/pytorch/issues/112443"
+        error_message="Unsupported FX nodes: {'call_function': ['aten._assert_async.msg']}",
+        reason="https://github.com/pytorch/pytorch/issues/112622",
     )
     def test_operator_with_dynamic_output_shape(self):
         def func(x):
@@ -643,20 +631,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         )
 
     @pytorch_test_common.xfail_if_model_type_is_exportedprogram(
-        "AssertionError: AssertionError: original output #1 is BaseModelOutputWithPastAndCrossAttentions("
-        " last_hidden_state=FakeTensor(..., size=(2, 128, 16), grad_fn=<ViewBackward0>),"
-        " past_key_values=((FakeTensor(..., size=(2, 2, 128, 8), grad_fn=<PermuteBackward0>),"
-        "  FakeTensor(..., size=(2, 2, 128, 8), grad_fn=<PermuteBackward0>)),"
-        "  (FakeTensor(..., size=(2, 2, 128, 8), grad_fn=<PermuteBackward0>),"
-        "  FakeTensor(..., size=(2, 2, 128, 8), grad_fn=<PermuteBackward0>)),"
-        "  (FakeTensor(..., size=(2, 2, 128, 8), grad_fn=<PermuteBackward0>),"
-        "  FakeTensor(..., size=(2, 2, 128, 8), grad_fn=<PermuteBackward0>)),"
-        "  (FakeTensor(..., size=(2, 2, 128, 8), grad_fn=<PermuteBackward0>),"
-        "  FakeTensor(..., size=(2, 2, 128, 8), grad_fn=<PermuteBackward0>))),"
-        " hidden_states=None, attentions=None, cross_attentions=None),"
-        " but only the following types are supported:"
-        " (<class 'torch.Tensor'>, <class 'torch.SymInt'>, <class 'torch.SymFloat'>, <class 'torch.SymBool'>)"
-        " Github issue: https://github.com/pytorch/pytorch/issues/110100"
+        error_message="Trying to flatten user inputs with exported input tree spec"
     )
     def test_gpt2_tiny_from_config(self):
         # Model
@@ -840,8 +815,8 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             for ref_output, ort_output in zip(ref_outputs, ort_outputs):
                 torch.testing.assert_close(ref_output, torch.tensor(ort_output))
 
-    @pytorch_test_common.skip_dynamic_fx_test(
-        "FakeTensor exporting is not supported by dynamic axes."
+    @pytorch_test_common.xfail_dynamic_fx_test(
+        error_message="shape_env should be set if tracing with 'symbolic'"
     )
     def test_fx_symbolic_tracer_large_scale_exporter_with_toy_mlp(self):
         class MLPModel(nn.Module):
@@ -878,13 +853,13 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             create_pytorch_only_extra_kwargs,
         )
 
-    @pytorch_test_common.xfail(
-        "[ONNXRuntimeError] : 1 : FAIL : Type Error: Data in initializer 'h_0_attn_bias' "
-        "has element type tensor(uint8) but usage of initializer in graph expects tensor(bool)"
-        "https://github.com/huggingface/transformers/issues/21013"
+    @pytorch_test_common.xfail_dynamic_fx_test(
+        error_message="shape_env should be set if tracing with 'symbolic'"
     )
-    @pytorch_test_common.skip_dynamic_fx_test(
-        "FakeTensor exporting is not supported by dynamic axes."
+    @pytorch_test_common.xfail(
+        error_message="Type Error: Data in initializer 'h_0_attn_bias' has element type tensor(uint8) "
+        "but usage of initializer in graph expects tensor(bool)",
+        reason="https://github.com/huggingface/transformers/issues/21013",
     )
     def test_fx_symbolic_tracer_large_scale_exporter_with_tiny_gpt2(self):
         model_name = "sshleifer/tiny-gpt2"
@@ -1083,9 +1058,9 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
                 for ref_output, ort_output in zip(ref_outputs, ort_outputs):
                     torch.testing.assert_close(ref_output, torch.tensor(ort_output))
 
-    @pytorch_test_common.skip_dynamic_fx_test(
-        "AssertionError: Dynamic shape check failed for graph inputs",
-        skip_model_type=pytorch_test_common.TorchModelType.TORCH_EXPORT_EXPORTEDPROGRAM,
+    @pytorch_test_common.xfail_dynamic_fx_test(
+        error_message="Dynamic shape check failed for graph inputs",
+        model_type=pytorch_test_common.TorchModelType.TORCH_EXPORT_EXPORTEDPROGRAM,
     )
     def test_fake_tensor_mode_simple(self):
         def create_model() -> nn.Module:
@@ -1116,15 +1091,13 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             model_type=self.model_type,
         )
 
-    @pytorch_test_common.xfail_if_model_type_is_not_exportedprogram(
-        "[ONNXRuntimeError] : 1 : FAIL : Type Error: Data in initializer 'h_0_attn_bias' "
-        "has element type tensor(uint8) but usage of initializer in graph expects tensor(bool)"
-        "https://github.com/huggingface/transformers/issues/21013"
-        "This can be addressed by using GPT2Config, but it is not now supported by FakeTensor exporting."
+    @pytorch_test_common.xfail_dynamic_fx_test(
+        error_message="Dynamic shape check failed for graph inputs",
+        model_type=pytorch_test_common.TorchModelType.TORCH_EXPORT_EXPORTEDPROGRAM,
     )
-    @pytorch_test_common.skip_dynamic_fx_test(
-        "AssertionError: Dynamic shape check failed for graph inputs",
-        skip_model_type=pytorch_test_common.TorchModelType.TORCH_EXPORT_EXPORTEDPROGRAM,
+    @pytorch_test_common.xfail_if_model_type_is_not_exportedprogram(
+        error_message="Expected 4 inputs, got 2",
+        reason="https://github.com/pytorch/pytorch/issues/115745",
     )
     def test_fake_tensor_mode_huggingface_tiny_gpt2(self):
         model_name = "sshleifer/tiny-gpt2"
@@ -1153,9 +1126,9 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             model_type=self.model_type,
         )
 
-    @pytorch_test_common.skip_dynamic_fx_test(
-        "AssertionError: Dynamic shape check failed for graph inputs",
-        skip_model_type=pytorch_test_common.TorchModelType.TORCH_EXPORT_EXPORTEDPROGRAM,
+    @pytorch_test_common.xfail_dynamic_fx_test(
+        error_message="Dynamic shape check failed for graph inputs",
+        model_type=pytorch_test_common.TorchModelType.TORCH_EXPORT_EXPORTEDPROGRAM,
     )
     def test_large_scale_exporter_with_toy_mlp(self):
         class MLPModel(nn.Module):
@@ -1195,9 +1168,9 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             model_type=self.model_type,
         )
 
-    @pytorch_test_common.skip_dynamic_fx_test(
-        "AssertionError: Dynamic shape check failed for graph inputs",
-        skip_model_type=pytorch_test_common.TorchModelType.TORCH_EXPORT_EXPORTEDPROGRAM,
+    @pytorch_test_common.xfail_dynamic_fx_test(
+        error_message="Dynamic shape check failed for graph inputs",
+        model_type=pytorch_test_common.TorchModelType.TORCH_EXPORT_EXPORTEDPROGRAM,
     )
     def test_fake_tensor_mode_huggingface_google_t5(self):
         config = transformers.T5Config(
@@ -1231,9 +1204,9 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             model_type=self.model_type,
         )
 
-    @pytorch_test_common.skip_dynamic_fx_test(
-        "AssertionError: Dynamic shape check failed for graph inputs",
-        skip_model_type=pytorch_test_common.TorchModelType.TORCH_EXPORT_EXPORTEDPROGRAM,
+    @pytorch_test_common.xfail_dynamic_fx_test(
+        error_message="Dynamic shape check failed for graph inputs",
+        model_type=pytorch_test_common.TorchModelType.TORCH_EXPORT_EXPORTEDPROGRAM,
     )
     def test_fake_tensor_mode_huggingface_openai_whisper(self):
         config = transformers.WhisperConfig(
@@ -1289,7 +1262,7 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         )
 
     @pytorch_test_common.xfail(
-        "AssertionError: whole graph export entails exactly one guard export"
+        error_message="whole graph export entails exactly one guard export"
     )
     def test_fake_tensor_mode_huggingface_mosaicml_mpt(self):
         config = transformers.MptConfig(
@@ -1318,8 +1291,13 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             model_type=self.model_type,
         )
 
-    @pytorch_test_common.skip_dynamic_fx_test(
-        "RuntimeError:: SymIntArrayRef expected to contain only concrete integers"
+    @pytorch_test_common.xfail_dynamic_fx_test(
+        error_message="Dynamic shape check failed for graph inputs",
+        model_type=pytorch_test_common.TorchModelType.TORCH_EXPORT_EXPORTEDPROGRAM,
+    )
+    @pytorch_test_common.xfail_dynamic_fx_test(
+        error_message="SymIntArrayRef expected to contain only concrete integers",
+        model_type=pytorch_test_common.TorchModelType.TORCH_NN_MODULE,
     )
     def test_fake_tensor_mode_huggingface_bigscience_bloom_560m(self):
         config = transformers.BloomConfig()
@@ -1346,13 +1324,13 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             model_type=self.model_type,
         )
 
-    @pytorch_test_common.xfail_if_model_type_is_not_exportedprogram(
-        "AssertionError: Expected 5 inputs, got 3"
-        "Github issue: https://github.com/pytorch/pytorch/issues/115745"
+    @pytorch_test_common.xfail_dynamic_fx_test(
+        error_message="Dynamic shape check failed for graph inputs",
+        model_type=pytorch_test_common.TorchModelType.TORCH_EXPORT_EXPORTEDPROGRAM,
     )
-    @pytorch_test_common.skip_dynamic_fx_test(
-        "AssertionError: Dynamic shape check failed for graph inputs",
-        skip_model_type=pytorch_test_common.TorchModelType.TORCH_EXPORT_EXPORTEDPROGRAM,
+    @pytorch_test_common.xfail_if_model_type_is_not_exportedprogram(
+        error_message="Expected 5 inputs, got 3",
+        reason="https://github.com/pytorch/pytorch/issues/115745",
     )
     def test_fake_tensor_mode_huggingface_gpt2(self):
         config = transformers.GPT2Config(

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -413,7 +413,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         )
 
     @pytorch_test_common.xfail(
-        error_message="zeros() received an invalid combination of arguments - got (FakeTensor, FakeTensor)"
+        error_message="Unsupported FX nodes: {'call_function': ['aten._assert_async.msg']}."
     )
     def test_squeeze_runtime_dim(self):
         class Squeeze(torch.nn.Module):


### PR DESCRIPTION
Reland #117425 

Previous to this PR, xfail tests didn't provide (1) guarantee of error message/reason (could be outdated), and (2) execution of the test (xfail_if_model_type_is_not_exportedprogram). Therefore, the tests are less robust with xfail labeled, as we can't be sure if it's still failing with the same reason, and if it's even still failing. This PR fixes the issue with try/except with error message matching to consolidate the xfail truth and reason.