### PR TITLE
Update PocketFFT

### DIFF
--- a/.circleci/scripts/build_android_gradle.sh
+++ b/.circleci/scripts/build_android_gradle.sh
@@ -22,7 +22,7 @@ done < <(find /var/lib/jenkins/.gradle -type f -print0)
 
 # Patch pocketfft (as Android does not have aligned_alloc even if compiled with c++17
 if [ -f ~/workspace/third_party/pocketfft/pocketfft_hdronly.h ]; then
-  sed -i -e "s/#if __cplusplus >= 201703L/#if 0/" ~/workspace/third_party/pocketfft/pocketfft_hdronly.h
+  sed -i -e "s/__cplusplus >= 201703L/0/" ~/workspace/third_party/pocketfft/pocketfft_hdronly.h
 fi
 
 export GRADLE_LOCAL_PROPERTIES=~/workspace/android/local.properties

--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -164,7 +164,7 @@ CMAKE_ARGS+=($@)
 
 # Patch pocketfft (as Android does not have aligned_alloc even if compiled with c++17
 if [ -f third_party/pocketfft/pocketfft_hdronly.h ]; then
-  sed -i -e "s/#if __cplusplus >= 201703L/#if 0/" third_party/pocketfft/pocketfft_hdronly.h
+  sed -i -e "s/__cplusplus >= 201703L/0/" third_party/pocketfft/pocketfft_hdronly.h
 fi
 
 # Now, actually build the Android target.


### PR DESCRIPTION
This updates PocketFFT submodule to https://github.com/mreineck/pocketfft/tree/9d3ab05a7fffbc71a492bc6a17be034e83e8f0fe

Probably fixes https://github.com/pytorch/pytorch/issues/117589 (as it includes https://github.com/mreineck/pocketfft/issues/5 that should fix PocketFFT compilation on Windows)

Also adjust `#if __cplusplus >= 201703` replace path in Android scripts (need to submit the fix back to PocketFFT)
