### PR TITLE
[WIP][inductor][mypy] Remove follow_imports=silent

### DIFF
--- a/mypy-inductor.ini
+++ b/mypy-inductor.ini
@@ -8,7 +8,6 @@ warn_redundant_casts = True
 show_error_codes = True
 show_column_numbers = True
 check_untyped_defs = True
-follow_imports = silent
 
 # do not reenable this:
 # https://github.com/pytorch/pytorch/pull/60006#issuecomment-866130657


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #117600

Looks like there are no new errors.

The bigger goal is to enable the use of dmypy (#117438), which does not
support follow_imports=silent. However, `dmypy check` still raises some
errors, so we cannot enable it yet.