### PR TITLE
[Dynamo] Fix a corner case of reinplace_inplaceable_ops pass for triton kernels

### DIFF
--- a/test/dynamo/test_triton_kernels.py
+++ b/test/dynamo/test_triton_kernels.py
@@ -477,6 +477,26 @@ def forward(self, x_1, output_1):
         self.assertEqual(torch_result, compiled_result)
 
     @requires_cuda()
+    @skipIfRocm
+    def test_triton_kernel_reinplace_inplaceable_pass(self):
+        def call_triton(
+            x: torch.Tensor,
+            y: torch.Tensor,
+        ):
+            output = torch.zeros_like(x)
+            n_elements = output.numel()
+            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+            add_kernel_autotuned[grid](x, y, output, n_elements)
+            add_kernel_autotuned[grid](output, x, output, n_elements)
+            return output
+
+        t1 = torch.rand(5, device="cuda")
+        t2 = torch.rand(5, device="cuda")
+        torch_result = call_triton(t1, t2)
+        compiled_result = torch.compile(call_triton)(t1, t2)
+        self.assertEqual(torch_result, compiled_result)
+
+    @requires_cuda()
     @common_utils.parametrize("grad", [False, True])
     def test_triton_kernel_multi_kernel(self, grad):
         @triton.jit

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -796,15 +796,12 @@ def reinplace_inplaceable_ops(graph):
 
                 node.target = inplaceable_op.inplace_op
 
-    def get_replacement(node):
-        ori_node = node
-        while node in replace_dict:
-            node = replace_dict[node]
-        replace_dict[ori_node] = node
-        return node
+    for node, replacement in replace_dict.items():
+        while replacement in replace_dict:
+            replacement = replace_dict[replacement]
+        replace_dict[node] = replacement
 
-    for node in replace_dict.keys():
-        node.replace_all_uses_with(get_replacement(node))
+        node.replace_all_uses_with(replacement)
         graph.erase_node(node)
 
 

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -3,7 +3,7 @@ import itertools
 import logging
 import operator
 from collections import Counter, defaultdict, namedtuple
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 from sympy import Expr
 
@@ -748,7 +748,7 @@ def reinplace_inplaceable_ops(graph):
                 node, shared_view_nodes, copy_node=None
             )
 
-    replace_list: List[Tuple[Any, Any]] = []
+    replace_dict: Dict[torch.fx.Node, torch.fx.Node] = {}
     for node in graph.nodes:
         if (inplaceable_op := inplaceable_ops.get(node.target, None)) is not None:
             mutated_arg = node.args[inplaceable_op.mutated_arg]
@@ -775,7 +775,7 @@ def reinplace_inplaceable_ops(graph):
                         graph.erase_node(copy_node)
                     for user in node.users:
                         if user.target == operator.getitem and user.args[1] == arg:
-                            replace_list.append((user, mutated_arg))
+                            replace_dict[user] = mutated_arg
                 else:
                     tensors_to_clone.append(arg)
             kwargs = dict(node.kwargs)
@@ -795,8 +795,16 @@ def reinplace_inplaceable_ops(graph):
                     graph.erase_node(copy_node)
 
                 node.target = inplaceable_op.inplace_op
-    for node, replacement in replace_list:
-        node.replace_all_uses_with(replacement)
+
+    def get_replacement(node):
+        ori_node = node
+        while node in replace_dict:
+            node = replace_dict[node]
+        replace_dict[ori_node] = node
+        return node
+
+    for node in replace_dict.keys():
+        node.replace_all_uses_with(get_replacement(node))
         graph.erase_node(node)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #117612

Summary:
We saw the following failure when compiling custom triton kernels:
```
RuntimeError: Argument 'getitem_22' of Node 'triton_kernel_wrapper_functional_proxy_3' was used before it has been defined! Please check that Nodes in the graph are topologically ordered
```
The root-cause is when doing the replacement, the replacement is replaced by another replacement. The fix will keep finding the replacement until it is not replaced

Test Plan:

Added a test case

Reviewers:

Subscribers:

Tasks:

Tags:

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler