### PR TITLE
Enable HIP build for //sigrid/predictor:pytorch_disagg_gpu_task

### DIFF
--- a/aten/src/ATen/cuda/CUDAEvent.h
+++ b/aten/src/ATen/cuda/CUDAEvent.h
@@ -50,7 +50,7 @@ struct TORCH_CUDA_CPP_API CUDAEvent {
         if (C10_UNLIKELY(interp)) {
           (*interp)->trace_gpu_event_deletion(reinterpret_cast<uintptr_t>(event_));
         }
-        cudaEventDestroy(event_);
+        AT_CUDA_CHECK(cudaEventDestroy(event_));
       }
     } catch (...) { /* No throw */ }
   }


### PR DESCRIPTION
Summary: Tweak some header include, as well as explicitly ignore hipEventDestroy return value.

Test Plan: CI

Reviewed By: jiaqizhai

Differential Revision: D52722234


