### PR TITLE
[tp] add clarification to doc and improve TP examples

### DIFF
--- a/docs/source/distributed.tensor.parallel.rst
+++ b/docs/source/distributed.tensor.parallel.rst
@@ -42,6 +42,11 @@ the ``parallelize_plan`` of ``parallelize_module``:
   :members:
   :undoc-members:
 
+.. note:: when using the ``Shard(dim)`` as the input/output layouts for the above
+  ParallelStyles, we assume the input/output activation tensors are evenly sharded on
+  the tensor dimension ``dim`` on the DeviceMesh that TP operates on. For instance,
+  ``RowwiseParallel`` accepts input that is sharded on the last dimension, it assumes
+  the input tensor already been evenly sharded on the last dimension.
 
 For models like Transformer, we recommend users to use ``ColwiseParallel``
 and ``RowwiseParallel`` together in the parallelize_plan for achieve the desired

--- a/docs/source/distributed.tensor.parallel.rst
+++ b/docs/source/distributed.tensor.parallel.rst
@@ -31,8 +31,8 @@ Tensor Parallelism supports the following parallel styles:
 
 To simply configure the nn.Module's inputs and outputs with DTensor layouts
 and perform necessary layout redistributions, without distribute the module
-parameters to DTensors, the following classes can be used in
-the ``parallelize_plan`` of ``parallelize_module``:
+parameters to DTensors, the following ``ParallelStyle``s can be used in
+the ``parallelize_plan`` when calling ``parallelize_module``:
 
 .. autoclass:: torch.distributed.tensor.parallel.PrepareModuleInput
   :members:
@@ -46,10 +46,10 @@ the ``parallelize_plan`` of ``parallelize_module``:
   ``ParallelStyle``s, we assume the input/output activation tensors are evenly sharded on
   the tensor dimension ``dim`` on the ``DeviceMesh`` that TP operates on. For instance,
   since ``RowwiseParallel`` accepts input that is sharded on the last dimension, it assumes
-  the input tensor has already been evenly sharded on the last dimension. If needs uneven
-  sharded activation tensors, one can pass in DTensor directly to the partitioned modules,
+  the input tensor has already been evenly sharded on the last dimension. For the case of uneven
+  sharded activation tensors, one could pass in DTensor directly to the partitioned modules,
   and use ``use_local_output=False`` to return DTensor after each ``ParallelStyle``, where
-  DTensor could track the uneven sharded information.
+  DTensor could track the uneven sharding information.
 
 For models like Transformer, we recommend users to use ``ColwiseParallel``
 and ``RowwiseParallel`` together in the parallelize_plan for achieve the desired

--- a/docs/source/distributed.tensor.parallel.rst
+++ b/docs/source/distributed.tensor.parallel.rst
@@ -43,10 +43,13 @@ the ``parallelize_plan`` of ``parallelize_module``:
   :undoc-members:
 
 .. note:: when using the ``Shard(dim)`` as the input/output layouts for the above
-  ParallelStyles, we assume the input/output activation tensors are evenly sharded on
-  the tensor dimension ``dim`` on the DeviceMesh that TP operates on. For instance,
-  ``RowwiseParallel`` accepts input that is sharded on the last dimension, it assumes
-  the input tensor already been evenly sharded on the last dimension.
+  ``ParallelStyle``s, we assume the input/output activation tensors are evenly sharded on
+  the tensor dimension ``dim`` on the ``DeviceMesh`` that TP operates on. For instance,
+  since ``RowwiseParallel`` accepts input that is sharded on the last dimension, it assumes
+  the input tensor has already been evenly sharded on the last dimension. If needs uneven
+  sharded activation tensors, one can pass in DTensor directly to the partitioned modules,
+  and use ``use_local_output=False`` to return DTensor after each ``ParallelStyle``, where
+  DTensor could track the uneven sharded information.
 
 For models like Transformer, we recommend users to use ``ColwiseParallel``
 and ``RowwiseParallel`` together in the parallelize_plan for achieve the desired

--- a/torch/distributed/tensor/parallel/style.py
+++ b/torch/distributed/tensor/parallel/style.py
@@ -50,15 +50,15 @@ class ColwiseParallel(ParallelStyle):
     Example::
         >>> # xdoctest: +SKIP(failing)
         >>> from torch.distributed.tensor.parallel import parallelize_module, ColwiseParallel
+        >>> from torch.distributed.device_mesh import init_device_mesh
         >>> ...
-        >>> # By default, the input of the "w1" Linear will be annotated to Replicated DTensor
+        >>> m = Model(...)  # m is a nn.Module that contains a "w1" nn.Linear submodule
+        >>> tp_mesh = init_device_mesh("cuda", (8,))
+        >>>
+        >>> # By default, the input of the "w1" Linear will be converted to Replicated DTensor
         >>> # and the output of "w1" will return :class:`torch.Tensor` that shards on the last dim.
-        >>>>
-        >>> parallelize_module(
-        >>>     module=block, # this can be a submodule or module
-        >>>     ...,
-        >>>     parallelize_plan={"w1": ColwiseParallel()},
-        >>> )
+        >>>
+        >>> sharded_mod = parallelize_module(m, tp_mesh, {"w1": ColwiseParallel()})
         >>> ...
 
     .. note:: By default ``ColwiseParallel`` output is sharded on the last dimension if the ``output_layouts`` not
@@ -157,15 +157,15 @@ class RowwiseParallel(ParallelStyle):
     Example::
         >>> # xdoctest: +SKIP(failing)
         >>> from torch.distributed.tensor.parallel import parallelize_module, RowwiseParallel
+        >>> from torch.distributed.device_mesh import init_device_mesh
         >>> ...
-        >>> # By default, the input of the "w2" Linear will be annotated to DTensor that shards on the last dim
+        >>> m = Model(...)  # m is a nn.Module that contains a "w2" nn.Linear submodule
+        >>> tp_mesh = init_device_mesh("cuda", (8,))
+        >>>
+        >>> # By default, the input of the "w2" Linear will be converted to DTensor that shards on the last dim
         >>> # and the output of "w2" will return a replicated :class:`torch.Tensor`.
         >>>
-        >>> parallelize_module(
-        >>>     module=block, # this can be a submodule or module
-        >>>     ...,
-        >>>     parallelize_plan={"w2": RowwiseParallel()},
-        >>> )
+        >>> sharded_mod = parallelize_module(m, tp_mesh, {"w2": RowwiseParallel()}),
         >>> ...
     """
 
@@ -247,12 +247,16 @@ class PrepareModuleInput(ParallelStyle):
     Example::
         >>> # xdoctest: +SKIP(failing)
         >>> from torch.distributed.tensor.parallel import parallelize_module, PrepareModuleInput
+        >>> from torch.distributed.device_mesh import init_device_mesh
         >>> ...
+        >>> block = TransformerBlock(...)  # block is a nn.Module that contains an "attn" Attention submodule
+        >>> tp_mesh = init_device_mesh("cuda", (8,))
+        >>>
         >>> # According to the style specified below, the first input of attn will be annotated to Sharded DTensor
         >>> # and then redistributed to Replicated DTensor.
         >>> parallelize_module(
-        >>>     module=block, # this can be a submodule or module
-        >>>     ...,
+        >>>     block, # this can be a submodule or module
+        >>>     tp_mesh,
         >>>     parallelize_plan={
         >>>         "attn": PrepareModuleInput(
         >>>             input_layouts=(Shard(0), None, None, ...),
@@ -324,18 +328,20 @@ class PrepareModuleOutput(ParallelStyle):
     Example::
         >>> # xdoctest: +SKIP(failing)
         >>> from torch.distributed.tensor.parallel import parallelize_module, PrepareModuleOutput
+        >>> from torch.distributed.device_mesh import init_device_mesh
         >>> ...
-        >>> # According to the style specified below, the first input of attn will be annotated to Sharded DTensor
-        >>> # and then redistributed to Replicated DTensor.
+        >>> block = TransformerBlock(...)  # block is a nn.Module that contains an "attn" Attention submodule
+        >>> tp_mesh = init_device_mesh("cuda", (8,))
+        >>>
+        >>> # According to the style specified below, the output of the TransformerBlock will be converted to Replicated DTensor
+        >>> # and then redistributed to Sharded DTensor.
         >>> parallelize_module(
-        >>>     module=block, # this can be a submodule or module
-        >>>     ...,
-        >>>     parallelize_plan={
-        >>>         "submodule": PrepareModuleOutput(
-        >>>             output_layouts=Replicate(),
-        >>>             desired_output_layouts=Shard(0)
-        >>>         ),
-        >>>     }
+        >>>     block, # this can be a submodule or module
+        >>>     tp_mesh,
+        >>>     parallelize_plan = PrepareModuleOutput(
+        >>>         output_layouts=Replicate(),
+        >>>         desired_output_layouts=Shard(0)
+        >>>     )
         >>> )
     """
     def __init__(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #117618

This PR adds a clarification about evenly sharded assumption in the main
tp doc and improved the tp examples by adding device mesh constructions

fixes https://github.com/pytorch/pytorch/issues/100044

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @fduwjj @wz337 @tianyu-l @wconstab @yf225