### PR TITLE
Fix inductor pattern match error for qlinear with bmm

### DIFF
--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -1180,8 +1180,8 @@ class TestPatternMatcher(TestPatternMatcherBase):
         class M(torch.nn.Module):
             def __init__(self, use_bias, do_permute=False):
                 super().__init__()
-                self.linear = torch.nn.Linear(4, 4, use_bias)
-                self.linear2 = torch.nn.Linear(4, 4, use_bias)
+                self.linear = torch.nn.Linear(4, 3, use_bias)
+                self.linear2 = torch.nn.Linear(3, 4, use_bias)
                 self.do_permute = do_permute
 
             def forward(self, x):

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -1508,8 +1508,8 @@ def _is_valid_dequant_linear_pattern(dtype, input_dim_exceeds_two, input_contigu
             # wgt before expand should with dim 2
             # Expand size should with dim 3
             # Expand size[0] should same as act size[0]
-            # Expand size[1] should same as wgt size[0]
-            # Expand size[2] should same as wgt size[1]
+            # Expand size[1] should same as wgt size[1]
+            # Expand size[2] should same as wgt size[0]
             qweight_node = match.kwargs["q_weight"]
             wgt_expand_size = match.kwargs["wgt_expand_size"]
             if not (
@@ -1518,8 +1518,8 @@ def _is_valid_dequant_linear_pattern(dtype, input_dim_exceeds_two, input_contigu
                 and len(qweight_node.meta["val"].size()) == 2
                 and len(wgt_expand_size) == 3
                 and wgt_expand_size[0] == act_node.meta["val"].size()[0]
-                and wgt_expand_size[1] == qweight_node.meta["val"].size()[0]
-                and wgt_expand_size[2] == qweight_node.meta["val"].size()[1]
+                and wgt_expand_size[1] == qweight_node.meta["val"].size()[1]
+                and wgt_expand_size[2] == qweight_node.meta["val"].size()[0]
             ):
                 return False
 


### PR DESCRIPTION
Summary:

PR https://github.com/pytorch/pytorch/pull/116599 convert `bmm` when input dim exceeds 2 and not contiguous to `qlinear`. However, there is an error when check weight size because of not considering the permute op.

Test Plan:
python test_mkldnn_pattern_matcher.py -k test_qlinear_input_dim_exceeds_2_and_not_contiguous

Fixes: -


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler