### PR TITLE
Add lowering to aten.angle

### DIFF
--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -267,6 +267,7 @@ def core_aten_decompositions() -> Dict[torch._ops.OperatorBase, Callable]:
             aten.affine_grid_generator,
             aten.all,
             aten.aminmax,
+            aten.angle,
             aten.arange.default,
             aten.arange.start,
             aten.avg_pool2d_backward,

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -18,6 +18,12 @@ def signature_of(arg: Union[TensorArg, SizeArg], *, size_dtype: str) -> str:
             tye = "*fp8e4nv"
         elif arg.dtype == torch.float8_e5m2:
             tye = "*fp8e5"
+        # Complex arguments are passed in as float-view arguments, see
+        # aten.angle lowering for an example.
+        elif arg.dtype == torch.complex64:
+            tye = "*fp32"
+        elif arg.dtype == torch.complex128:
+            tye = "*fp64"
         else:
             tye = JITFunction._type_of(arg.dtype)
         if V.graph.is_unspec_arg(arg.buffer):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2531,6 +2531,15 @@ class FixedLayout(Layout):
 
         return indexer
 
+    def view(self, dtype):
+        if self.dtype.itemsize == dtype.itemsize:
+            size = self.size[:]
+        else:
+            size = self.size[:-1] + [
+                (self.size[-1] * self.dtype.itemsize) // dtype.itemsize
+            ]
+        return type(self)(self.device, dtype, size, self.stride[:], self.offset)
+
 
 class FlexibleLayout(Layout):
     """A Tensor layout we are allowed to change"""


### PR DESCRIPTION
As in the title.

In addition, this PR introduces `FixedLayout.view` method that enables viewing complex inputs as real tensors. This allows defining triton kernels on complex tensors.

About performance:
```
[------------------------------ angle -------------------------------]
                                  |  Decomposed  |  Lowering  |  Eager
18 threads: ----------------------------------------------------------
      (262144,) torch.int32       |      12      |     12     |     9 
      (262144,) torch.float64     |      12      |     12     |     9 
      (262144,) torch.complex64   |      22      |     12     |    16 
      (262144,) torch.complex128  |     130      |    128     |   149 

Times are in microseconds (us).
```

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #117641
* #117640



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang