### PR TITLE
Catch some missing unbacked symbol dependencies

### DIFF
--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -12,10 +12,10 @@ import torch._custom_ops as custom_ops
 import torch.library
 from torch._dynamo.testing import make_test_cls_with_patches
 from torch.testing._internal.common_device_type import (
+    expectedFailureCPU,
     instantiate_device_type_tests,
     onlyCPU,
     onlyCUDA,
-    expectedFailureCPU,
 )
 from torch.testing._internal.common_utils import (
     IS_CI,

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -341,6 +341,9 @@ class Loops(IRNode):
     inner_fn: Callable[..., Any]
     ranges: List[Expr]
 
+    def get_unbacked_symbol_uses(self) -> Set[sympy.Symbol]:
+        return set().union(*(free_unbacked_symbols(e) for e in self.ranges))
+
     def __str__(self, names=("ranges",)):
         return self.str_helper(
             [
@@ -579,6 +582,9 @@ class Reduction(Loops):
 
     def __repr__(self):
         return self.__str__()
+
+    def get_unbacked_symbol_uses(self) -> Set[sympy.Symbol]:
+        return super().get_unbacked_symbol_uses() | set().union(*(free_unbacked_symbols(e) for e in self.reduction_ranges))
 
     def get_reduction_size(self):
         return self.reduction_ranges
@@ -1549,6 +1555,16 @@ class Scan(Loops):
     init: Any
 
     # HACK we mimick reduction
+
+    def get_unbacked_symbol_uses(self) -> Set[sympy.Symbol]:
+        # TODO: Can combine_fn/reindex close over unbacked symbols? If so, we
+        # need to explicitly represent the closure so we can pull out unbacked
+        # symbols here
+        return (
+            super().get_unbacked_symbol_uses() |
+            set().union(*(free_unbacked_symbols(e) for e in self.scan_ranges)) |
+            set().union(*(free_unbacked_symbols(e) for e in self.size))
+        )
 
     def __post_init__(self):
         assert len(self.ranges) + len(self.scan_ranges) == len(self.size)
@@ -3031,6 +3047,7 @@ class ComputedBuffer(Buffer):
             free_unbacked_symbols(self.get_size())
             | free_unbacked_symbols(self.get_stride())
             | free_unbacked_symbols(self.get_offset())
+            | self.data.get_unbacked_symbol_uses()
         )
 
     def make_loader(self):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -584,7 +584,9 @@ class Reduction(Loops):
         return self.__str__()
 
     def get_unbacked_symbol_uses(self) -> Set[sympy.Symbol]:
-        return super().get_unbacked_symbol_uses() | set().union(*(free_unbacked_symbols(e) for e in self.reduction_ranges))
+        return super().get_unbacked_symbol_uses() | set().union(
+            *(free_unbacked_symbols(e) for e in self.reduction_ranges)
+        )
 
     def get_reduction_size(self):
         return self.reduction_ranges
@@ -1561,9 +1563,9 @@ class Scan(Loops):
         # need to explicitly represent the closure so we can pull out unbacked
         # symbols here
         return (
-            super().get_unbacked_symbol_uses() |
-            set().union(*(free_unbacked_symbols(e) for e in self.scan_ranges)) |
-            set().union(*(free_unbacked_symbols(e) for e in self.size))
+            super().get_unbacked_symbol_uses()
+            | set().union(*(free_unbacked_symbols(e) for e in self.scan_ranges))
+            | set().union(*(free_unbacked_symbols(e) for e in self.size))
         )
 
     def __post_init__(self):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1323,6 +1323,10 @@ def disableMkldnn(fn):
     return disable_mkldnn
 
 
+def expectedFailureCPU(fn):
+    return expectedFailure('cpu')(fn)
+
+
 def expectedFailureCUDA(fn):
     return expectedFailure('cuda')(fn)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #117679
* #117658
* __->__ #117650

Whenever an IR node has reference to an unbacked SymInt, we must
register it as a use of the unbacked SymInt.

This fix isn't complete but the rest of the fix is fairly difficult, so
putting this in to start.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler