### PR TITLE
Switched macOS runners type to macos-m1-stable

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -20,6 +20,7 @@ self-hosted-runner:
     - bm-runner
     - linux.rocm.gpu
     - macos-m1-12
+    - macos-m1-stable
     - macos-m1-13
     - macos-12-xl
     - macos-12

--- a/.github/scripts/test_filter_test_configs.py
+++ b/.github/scripts/test_filter_test_configs.py
@@ -662,14 +662,14 @@ class TestConfigFilter(TestCase):
             {
                 "labels": {},
                 "test_matrix": '{include: [{config: "default"}]}',
-                "job_name": "macos-12-py3-arm64 / test (default, 1, 3, macos-m1-12, unstable)",
+                "job_name": "macos-12-py3-arm64 / test (default, 1, 3, macos-m1-stable, unstable)",
                 "expected": "keep-going=False\nis-unstable=True\nreenabled-issues=\n",
                 "description": "Unstable job",
             },
             {
                 "labels": {},
                 "test_matrix": '{include: [{config: "default"}]}',
-                "job_name": "macos-12-py3-arm64 / test (default, 1, 3, macos-m1-12, unstable)",
+                "job_name": "macos-12-py3-arm64 / test (default, 1, 3, macos-m1-stable, unstable)",
                 "expected": "keep-going=False\nis-unstable=True\nreenabled-issues=\n",
                 "description": "Unstable job",
             },

--- a/.github/workflows/mac-mps.yml
+++ b/.github/workflows/mac-mps.yml
@@ -19,7 +19,7 @@ jobs:
     with:
       sync-tag: macos-12-py3-arm64-build
       build-environment: macos-12-py3-arm64
-      runner-type: macos-m1-12
+      runner-type: macos-m1-stable
       build-generates-artifacts: true
       # To match the one pre-installed in the m1 runners
       python-version: 3.9.12

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -95,7 +95,7 @@ jobs:
     with:
       sync-tag: macos-12-py3-arm64-build
       build-environment: macos-12-py3-arm64
-      runner-type: macos-m1-12
+      runner-type: macos-m1-stable
       build-generates-artifacts: true
       # To match the one pre-installed in the m1 runners
       python-version: 3.9.12


### PR DESCRIPTION
Switched macOS runners type to `macos-m1-stable`.