### PR TITLE
[SAC][Dynamo] Add support for functools.partial in CheckpointHigherOrderVariable

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -673,7 +673,9 @@ class ActivationCheckpointingViaTagsTests(torch._dynamo.test_case.TestCase):
                 x,
                 y,
                 use_reentrant=False,
-                context_fn=functools.partial(selective_checkpointing_context_fn, [torch.ops.aten.mm.default]),
+                context_fn=functools.partial(
+                    selective_checkpointing_context_fn, [torch.ops.aten.mm.default]
+                ),
             )
 
         x = torch.randn(4, 4, requires_grad=True, device="cuda")

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -659,7 +659,6 @@ class ActivationCheckpointingViaTagsTests(torch._dynamo.test_case.TestCase):
         "_experimental_support_context_fn_in_torch_utils_checkpoint", True
     )
     def test_compile_selective_checkpoint_partial_ctx_fn(self):
-        from functools import partial
         def selective_checkpointing_context_fn(no_recompute_list):
             return _pt2_selective_checkpoint_context_fn_gen(
                 _get_custom_policy(no_recompute_list=no_recompute_list)
@@ -674,7 +673,7 @@ class ActivationCheckpointingViaTagsTests(torch._dynamo.test_case.TestCase):
                 x,
                 y,
                 use_reentrant=False,
-                context_fn=partial(selective_checkpointing_context_fn, [torch.ops.aten.mm.default]),
+                context_fn=functools.partial(selective_checkpointing_context_fn, [torch.ops.aten.mm.default]),
             )
 
         x = torch.randn(4, 4, requires_grad=True, device="cuda")

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -658,6 +658,54 @@ class ActivationCheckpointingViaTagsTests(torch._dynamo.test_case.TestCase):
     @torch._dynamo.config.patch(
         "_experimental_support_context_fn_in_torch_utils_checkpoint", True
     )
+    def test_compile_selective_checkpoint_partial_ctx_fn(self):
+        from functools import partial
+        def selective_checkpointing_context_fn(no_recompute_list):
+            return _pt2_selective_checkpoint_context_fn_gen(
+                _get_custom_policy(no_recompute_list=no_recompute_list)
+            )
+
+        def gn(x, y):
+            return torch.sigmoid(torch.matmul(torch.matmul(x, y), y)) * y
+
+        def fn(x, y):
+            return torch.utils.checkpoint.checkpoint(
+                gn,
+                x,
+                y,
+                use_reentrant=False,
+                context_fn=partial(selective_checkpointing_context_fn, [torch.ops.aten.mm.default]),
+            )
+
+        x = torch.randn(4, 4, requires_grad=True, device="cuda")
+        y = torch.randn(4, 4, requires_grad=True, device="cuda")
+
+        fw_compiler = functools.partial(
+            count_ops,
+            freq=2,
+            op=torch.ops.aten.mm.default,
+        )
+        bw_compiler = functools.partial(
+            count_ops,
+            # We would've expected 6 here
+            # (2 matmul recompute and 2 mm ops per fwd matmul, so 2 + 2 * 2 = 6)
+            # if we didn't enable selective checkpointing.
+            freq=4,
+            op=torch.ops.aten.mm.default,
+        )
+        backend = aot_autograd(
+            fw_compiler=fw_compiler,
+            bw_compiler=bw_compiler,
+            partition_fn=min_cut_rematerialization_partition,
+        )
+        self._validate(fn, backend, x, y)
+        self._compare_orig_and_checkpointed_fns(gn, fn, x, y)
+
+    @requires_cuda()
+    @unittest.skipIf(IS_WINDOWS, "torch.compile doesn't work with windows")
+    @torch._dynamo.config.patch(
+        "_experimental_support_context_fn_in_torch_utils_checkpoint", True
+    )
     def test_compile_selective_checkpoint_outplace_op(self):
         def selective_checkpointing_context_fn():
             no_recompute_list = [

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -1350,7 +1350,13 @@ class CheckpointHigherOrderVariable(WrapHigherOrderVariable):
 
         context_fn = None
         if "context_fn" in kwargs and kwargs["context_fn"] != noop_context_fn:
-            context_fn = kwargs.pop("context_fn").fn
+            ctx = kwargs.pop("context_fn")
+            if isinstance(ctx, torch._dynamo.variables.UserFunctionVariable):
+                context_fn = ctx.fn
+            elif isinstance(ctx, torch._dynamo.variables.functions.FunctoolsPartialVariable):
+                context_fn = ctx.as_python_constant()
+            else:
+                raise NotImplementedError(f"checkpoint not implemented for {type(ctx)} context_fn")
 
         checkpoint_kwargs, gmod_kwargs = TagActivationCheckpoint.divide_kwargs(kwargs)
 

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -1353,10 +1353,14 @@ class CheckpointHigherOrderVariable(WrapHigherOrderVariable):
             ctx = kwargs.pop("context_fn")
             if isinstance(ctx, torch._dynamo.variables.UserFunctionVariable):
                 context_fn = ctx.fn
-            elif isinstance(ctx, torch._dynamo.variables.functions.FunctoolsPartialVariable):
+            elif isinstance(
+                ctx, torch._dynamo.variables.functions.FunctoolsPartialVariable
+            ):
                 context_fn = ctx.as_python_constant()
             else:
-                raise NotImplementedError(f"checkpoint not implemented for {type(ctx)} context_fn")
+                raise NotImplementedError(
+                    f"checkpoint not implemented for {type(ctx)} context_fn"
+                )
 
         checkpoint_kwargs, gmod_kwargs = TagActivationCheckpoint.divide_kwargs(kwargs)
 


### PR DESCRIPTION
# Context

In some cases, we might want to build the `context_fn` with runtime-defined policies. One way of implementing this is to make `context_fn` be a partial, which holds the information that we want to pass. One concrete example is the [automatic policy selection from `xformers`](https://github.com/facebookresearch/xformers/blob/ad986981b141a218bf07bf968e920051ff2c7b41/xformers/checkpoint.py#L185).

# The problem

The previous implementation wouldn't work with partials because `FunctoolsPartialVariable` doesn't have a `fn` attribute.

This PR addresses this case, but ideally we could get this solved in a more general fashion, as callable classes and `NestedUserFunctionVariable` are not supported by this PR.

# Tests

I've added a basic test that mimics the tests around it. The tests could probably be simplified, but I've decided to keep changes to a minimum.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng