### PR TITLE
Teach dynamo to print namedtuple's constructor as a dict key

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -2477,6 +2477,20 @@ utils_device.CURRENT_DEVICE == None""".split(
         # Extra calls don't recompile
         self.assertEqual(cnts.frame_count, 2)
 
+    def test_dict_namedtuple(self):
+        def fn(d):
+            return d[3] * 2
+
+        args1 = {collections.namedtuple: None, 3: torch.randn(3)}
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch._dynamo.optimize(cnts)(fn)
+        self.assertEqual(fn(args1), opt_fn(args1))
+        self.assertEqual(cnts.frame_count, 1)
+        # Test a failing namedtuple guard
+        args2 = {2: None, 3: torch.randn(3)}
+        self.assertEqual(fn(args2), opt_fn(args2))
+        self.assertEqual(cnts.frame_count, 2)
+
     def test_dict_order_keys_tensors(self):
         def fn(d, x):
             return d[x] + 3

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1101,6 +1101,8 @@ def const_repr(x, *, local) -> str:
             return module + "." + klass.__qualname__
 
         return fullname(x)
+    elif x == collections.namedtuple:
+        return 'G["collections"].namedtuple'
     else:
         return f"{x!r}"
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #117631
* #117625
* __->__ #117659
* #117639
* #108420
* #110524
* #117630
* #112252

Fixing this to unblock, but we should come up with a better story for
how to put guards on dict keys...

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng