### PR TITLE
Various CI settings

### DIFF
--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -31,9 +31,9 @@ outputs:
   reenabled-issues:
     description: Comma separated list of issue numbers that should correspond to disable test issues that the PR fixes
     value: ${{ steps.filter.outputs.reenabled-issues }}
-  ci-no-pipe-logs:
-    description: True if ci-no-pipe-logs label was on PR or [ci-no-pipe-logs] in PR body.
-    value: ${{ steps.filter.outputs.ci-no-pipe-logs }}
+  ci-verbose-test-logs:
+    description: True if ci-verbose-test-logs label was on PR or [ci-verbose-test-logs] in PR body.
+    value: ${{ steps.filter.outputs.ci-verbose-test-logs }}
   ci-no-test-timeout:
     description: True if ci-no-test-timeout label was on PR or [ci-no-test-timeout] in PR body.
     value: ${{ steps.filter.outputs.ci-no-test-timeout }}

--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -26,11 +26,17 @@ outputs:
     description: True if the filtered test configs matrix is empty. False otherwise.
     value: ${{ steps.filter.outputs.is-test-matrix-empty }}
   keep-going:
-    description: True if keep-going label was on PR.
+    description: True if keep-going label was on PR or [keep-going] in PR body.
     value: ${{ steps.filter.outputs.keep-going }}
   reenabled-issues:
     description: Comma separated list of issue numbers that should correspond to disable test issues that the PR fixes
     value: ${{ steps.filter.outputs.reenabled-issues }}
+  ci-no-pipe-logs:
+    description: True if ci-no-pipe-logs label was on PR or [ci-no-pipe-logs] in PR body.
+    value: ${{ steps.filter.outputs.ci-no-pipe-logs }}
+  ci-no-test-timeout:
+    description: True if ci-no-test-timeout label was on PR or [ci-no-test-timeout] in PR body.
+    value: ${{ steps.filter.outputs.ci-no-test-timeout }}
 
 runs:
   using: composite

--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -486,7 +486,7 @@ def perform_misc_tasks(
     misc tasks to set keep-going and is-unstable variables
     """
     set_output("keep-going", check_for_setting(labels, pr_body, "keep-going"))
-    set_output("ci-no-pipe-logs", check_for_setting(labels, pr_body, "ci-no-pipe-logs"))
+    set_output("ci-verbose-test-logs", check_for_setting(labels, pr_body, "ci-verbose-test-logs"))
     set_output(
         "ci-no-test-timeout", check_for_setting(labels, pr_body, "ci-no-test-timeout")
     )

--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -474,6 +474,10 @@ def get_reenabled_issues(pr_body: str = "") -> List[str]:
     return parse_reenabled_issues(pr_body) + parse_reenabled_issues(commit_messages)
 
 
+def check_for_setting(labels, body, setting) -> bool:
+    return setting in labels or f"[{setting}]" in body
+
+
 def perform_misc_tasks(
     labels: Set[str], test_matrix: Dict[str, List[Any]], job_name: str, pr_body: str
 ) -> None:
@@ -481,7 +485,8 @@ def perform_misc_tasks(
     In addition to apply the filter logic, the script also does the following
     misc tasks to set keep-going and is-unstable variables
     """
-    set_output("keep-going", "keep-going" in labels)
+    set_output("keep-going", check_for_setting(labels, pr_body, "keep-going"))
+    set_output("ci-no-pipe-logs", check_for_setting(labels, pr_body, "ci-no-pipe-logs"))
 
     # Obviously, if the job name includes unstable, then this is an unstable job
     is_unstable = job_name and IssueType.UNSTABLE.value in job_name

--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -486,7 +486,10 @@ def perform_misc_tasks(
     misc tasks to set keep-going and is-unstable variables
     """
     set_output("keep-going", check_for_setting(labels, pr_body, "keep-going"))
-    set_output("ci-verbose-test-logs", check_for_setting(labels, pr_body, "ci-verbose-test-logs"))
+    set_output(
+        "ci-verbose-test-logs",
+        check_for_setting(labels, pr_body, "ci-verbose-test-logs"),
+    )
     set_output(
         "ci-no-test-timeout", check_for_setting(labels, pr_body, "ci-no-test-timeout")
     )

--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -474,7 +474,7 @@ def get_reenabled_issues(pr_body: str = "") -> List[str]:
     return parse_reenabled_issues(pr_body) + parse_reenabled_issues(commit_messages)
 
 
-def check_for_setting(labels, body, setting) -> bool:
+def check_for_setting(labels: Set[str], body: str, setting: str) -> bool:
     return setting in labels or f"[{setting}]" in body
 
 
@@ -487,6 +487,9 @@ def perform_misc_tasks(
     """
     set_output("keep-going", check_for_setting(labels, pr_body, "keep-going"))
     set_output("ci-no-pipe-logs", check_for_setting(labels, pr_body, "ci-no-pipe-logs"))
+    set_output(
+        "ci-no-test-timeout", check_for_setting(labels, pr_body, "ci-no-test-timeout")
+    )
 
     # Obviously, if the job name includes unstable, then this is an unstable job
     is_unstable = job_name and IssueType.UNSTABLE.value in job_name

--- a/.github/scripts/test_filter_test_configs.py
+++ b/.github/scripts/test_filter_test_configs.py
@@ -638,14 +638,14 @@ class TestConfigFilter(TestCase):
     def test_perform_misc_tasks(self, mocked_subprocess: Any) -> None:
         def _gen_expected_string(
             keep_going: bool = False,
-            ci_no_pipe_logs: bool = False,
+            ci_verbose_test_logs: bool = False,
             ci_no_test_timeout: bool = False,
             is_unstable: bool = False,
             reenabled_issues: str = "",
         ) -> str:
             return (
                 f"keep-going={keep_going}\n"
-                f"ci-no-pipe-logs={ci_no_pipe_logs}\n"
+                f"ci-verbose-test-logs={ci_verbose_test_logs}\n"
                 f"ci-no-test-timeout={ci_no_test_timeout}\n"
                 f"is-unstable={is_unstable}\n"
                 f"reenabled-issues={reenabled_issues}\n"
@@ -681,7 +681,7 @@ class TestConfigFilter(TestCase):
                 "job_name": "A job name",
                 "pr_body": "[ci-no-test-timeout]",
                 "expected": _gen_expected_string(
-                    ci_no_pipe_logs=True, ci_no_test_timeout=True
+                    ci_verbose_test_logs=True, ci_no_test_timeout=True
                 ),
                 "description": "No pipe logs label and no test timeout in PR body",
             },

--- a/.github/scripts/test_filter_test_configs.py
+++ b/.github/scripts/test_filter_test_configs.py
@@ -676,7 +676,7 @@ class TestConfigFilter(TestCase):
                 "description": "Keep-going in PR body",
             },
             {
-                "labels": {"ci-no-pipe-logs"},
+                "labels": {"ci-verbose-test-logs"},
                 "test_matrix": '{include: [{config: "default"}]}',
                 "job_name": "A job name",
                 "pr_body": "[ci-no-test-timeout]",
@@ -684,6 +684,16 @@ class TestConfigFilter(TestCase):
                     ci_verbose_test_logs=True, ci_no_test_timeout=True
                 ),
                 "description": "No pipe logs label and no test timeout in PR body",
+            },
+            {
+                "labels": {"ci-no-test-timeout"},
+                "test_matrix": '{include: [{config: "default"}]}',
+                "job_name": "A job name",
+                "pr_body": "[ci-verbose-test-logs]",
+                "expected": _gen_expected_string(
+                    ci_verbose_test_logs=True, ci_no_test_timeout=True
+                ),
+                "description": "No pipe logs in PR body and no test timeout in label (same as the above but swapped)",
             },
             {
                 "labels": {},

--- a/.github/scripts/test_filter_test_configs.py
+++ b/.github/scripts/test_filter_test_configs.py
@@ -636,55 +636,88 @@ class TestConfigFilter(TestCase):
 
     @mock.patch("subprocess.check_output")
     def test_perform_misc_tasks(self, mocked_subprocess: Any) -> None:
+        def _gen_expected_string(
+            keep_going: bool = False,
+            ci_no_pipe_logs: bool = False,
+            ci_no_test_timeout: bool = False,
+            is_unstable: bool = False,
+            reenabled_issues: str = "",
+        ) -> str:
+            return (
+                f"keep-going={keep_going}\n"
+                f"ci-no-pipe-logs={ci_no_pipe_logs}\n"
+                f"ci-no-test-timeout={ci_no_test_timeout}\n"
+                f"is-unstable={is_unstable}\n"
+                f"reenabled-issues={reenabled_issues}\n"
+            )
+
         mocked_subprocess.return_value = b""
         testcases: List[Dict[str, Any]] = [
             {
                 "labels": {},
                 "test_matrix": '{include: [{config: "default"}]}',
                 "job_name": "A job name",
-                "expected": "keep-going=False\nis-unstable=False\nreenabled-issues=\n",
+                "expected": _gen_expected_string(),
                 "description": "No keep-going, no is-unstable",
             },
             {
                 "labels": {"keep-going"},
                 "test_matrix": '{include: [{config: "default"}]}',
                 "job_name": "A job name",
-                "expected": "keep-going=True\nis-unstable=False\nreenabled-issues=\n",
+                "expected": _gen_expected_string(keep_going=True),
                 "description": "Has keep-going, no is-unstable",
             },
             {
                 "labels": {},
                 "test_matrix": '{include: [{config: "default"}]}',
+                "job_name": "A job name",
+                "pr_body": "[keep-going]",
+                "expected": _gen_expected_string(keep_going=True),
+                "description": "Keep-going in PR body",
+            },
+            {
+                "labels": {"ci-no-pipe-logs"},
+                "test_matrix": '{include: [{config: "default"}]}',
+                "job_name": "A job name",
+                "pr_body": "[ci-no-test-timeout]",
+                "expected": _gen_expected_string(
+                    ci_no_pipe_logs=True, ci_no_test_timeout=True
+                ),
+                "description": "No pipe logs label and no test timeout in PR body",
+            },
+            {
+                "labels": {},
+                "test_matrix": '{include: [{config: "default"}]}',
                 "job_name": None,
-                "expected": "keep-going=False\nis-unstable=False\nreenabled-issues=\n",
+                "expected": _gen_expected_string(),
                 "description": "No job name",
             },
             {
                 "labels": {},
                 "test_matrix": '{include: [{config: "default"}]}',
                 "job_name": "macos-12-py3-arm64 / test (default, 1, 3, macos-m1-stable, unstable)",
-                "expected": "keep-going=False\nis-unstable=True\nreenabled-issues=\n",
+                "expected": _gen_expected_string(is_unstable=True),
                 "description": "Unstable job",
             },
             {
                 "labels": {},
                 "test_matrix": '{include: [{config: "default"}]}',
                 "job_name": "macos-12-py3-arm64 / test (default, 1, 3, macos-m1-stable, unstable)",
-                "expected": "keep-going=False\nis-unstable=True\nreenabled-issues=\n",
+                "expected": _gen_expected_string(is_unstable=True),
                 "description": "Unstable job",
             },
             {
                 "labels": {},
                 "test_matrix": '{include: [{config: "1", unstable: "unstable"}, {config: "2", unstable: "unstable"}]}',
                 "job_name": "macos-12-py3-arm64 / build",
-                "expected": "keep-going=False\nis-unstable=True\nreenabled-issues=\n",
+                "expected": _gen_expected_string(is_unstable=True),
                 "description": "All configs are unstable",
             },
             {
                 "labels": {},
                 "test_matrix": '{include: [{config: "1", unstable: "unstable"}, {config: "2"}]}',
                 "job_name": "macos-12-py3-arm64 / build",
-                "expected": "keep-going=False\nis-unstable=False\nreenabled-issues=\n",
+                "expected": _gen_expected_string(is_unstable=False),
                 "description": "Only mark some configs as unstable",
             },
             {
@@ -692,7 +725,7 @@ class TestConfigFilter(TestCase):
                 "test_matrix": '{include: [{config: "default"}]}',
                 "job_name": "A job name",
                 "pr_body": "resolves #123 fixes #234",
-                "expected": "keep-going=False\nis-unstable=False\nreenabled-issues=123,234\n",
+                "expected": _gen_expected_string(reenabled_issues="123,234"),
                 "description": "Reenable some issues",
             },
         ]

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -169,6 +169,7 @@ jobs:
           NUM_TEST_SHARDS: ${{ matrix.num_shards }}
           REENABLED_ISSUES: ${{ steps.keep-going.outputs.reenabled-issues }}
           CONTINUE_THROUGH_ERROR: ${{ steps.keep-going.outputs.keep-going }}
+          NO_PIPE_LOGS: ${{ steps.keep-going.outputs.ci-no-pipe-logs }}
           SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
           SCCACHE_S3_KEY_PREFIX: ${{ github.workflow }}
           SHM_SIZE: ${{ contains(inputs.build-environment, 'cuda') && '2g' || '1g' }}
@@ -218,6 +219,7 @@ jobs:
             -e NUM_TEST_SHARDS \
             -e REENABLED_ISSUES \
             -e CONTINUE_THROUGH_ERROR \
+            -e NO_PIPE_LOGS \
             -e PR_LABELS \
             -e MAX_JOBS="$(nproc --ignore=2)" \
             -e SCCACHE_BUCKET \

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -170,6 +170,7 @@ jobs:
           REENABLED_ISSUES: ${{ steps.keep-going.outputs.reenabled-issues }}
           CONTINUE_THROUGH_ERROR: ${{ steps.keep-going.outputs.keep-going }}
           NO_PIPE_LOGS: ${{ steps.keep-going.outputs.ci-no-pipe-logs }}
+          NO_TEST_TIMEOUT: ${{ steps.keep-going.outputs.ci-no-test-timeout }}
           SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
           SCCACHE_S3_KEY_PREFIX: ${{ github.workflow }}
           SHM_SIZE: ${{ contains(inputs.build-environment, 'cuda') && '2g' || '1g' }}
@@ -220,6 +221,7 @@ jobs:
             -e REENABLED_ISSUES \
             -e CONTINUE_THROUGH_ERROR \
             -e NO_PIPE_LOGS \
+            -e NO_TEST_TIMEOUT \
             -e PR_LABELS \
             -e MAX_JOBS="$(nproc --ignore=2)" \
             -e SCCACHE_BUCKET \

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -169,7 +169,7 @@ jobs:
           NUM_TEST_SHARDS: ${{ matrix.num_shards }}
           REENABLED_ISSUES: ${{ steps.keep-going.outputs.reenabled-issues }}
           CONTINUE_THROUGH_ERROR: ${{ steps.keep-going.outputs.keep-going }}
-          NO_PIPE_LOGS: ${{ steps.keep-going.outputs.ci-no-pipe-logs }}
+          VERBOSE_TEST_LOGS: ${{ steps.keep-going.outputs.ci-verbose-test-logs }}
           NO_TEST_TIMEOUT: ${{ steps.keep-going.outputs.ci-no-test-timeout }}
           SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
           SCCACHE_S3_KEY_PREFIX: ${{ github.workflow }}
@@ -220,7 +220,7 @@ jobs:
             -e NUM_TEST_SHARDS \
             -e REENABLED_ISSUES \
             -e CONTINUE_THROUGH_ERROR \
-            -e NO_PIPE_LOGS \
+            -e VERBOSE_TEST_LOGS \
             -e NO_TEST_TIMEOUT \
             -e PR_LABELS \
             -e MAX_JOBS="$(nproc --ignore=2)" \

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -34,7 +34,7 @@ jobs:
       test-matrix: ${{ steps.filter.outputs.test-matrix }}
       is-test-matrix-empty: ${{ steps.filter.outputs.is-test-matrix-empty }}
       keep-going: ${{ steps.filter.outputs.keep-going }}
-      ci-no-pipe-logs: ${{ steps.filter.outputs.ci-no-pipe-logs }}
+      ci-verbose-test-logs: ${{ steps.filter.outputs.ci-verbose-test-logs }}
       ci-no-test-timeout: ${{ steps.filter.outputs.ci-no-test-timeout }}
       reenabled-issues: ${{ steps.filter.outputs.reenabled-issues }}
     steps:
@@ -97,7 +97,7 @@ jobs:
           PY_VERS: 3.9
           PR_BODY: ${{ github.event.pull_request.body }}
           CONTINUE_THROUGH_ERROR: ${{ needs.filter.outputs.keep-going }}
-          NO_PIPE_LOGS: ${{ needs.filter.outputs.ci-no-pipe-logs }}
+          VERBOSE_TEST_LOGS: ${{ needs.filter.outputs.ci-verbose-test-logs }}
           NO_TEST_TIMEOUT: ${{ needs.filter.outputs.ci-no-test-timeout }}
           PIP_REQUIREMENTS_FILE: .github/requirements/pip-requirements-${{ runner.os }}.txt
           REENABLED_ISSUES: ${{ needs.filter.outputs.reenabled-issues }}

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -34,6 +34,8 @@ jobs:
       test-matrix: ${{ steps.filter.outputs.test-matrix }}
       is-test-matrix-empty: ${{ steps.filter.outputs.is-test-matrix-empty }}
       keep-going: ${{ steps.filter.outputs.keep-going }}
+      ci-no-pipe-logs: ${{ steps.filter.outputs.ci-no-pipe-logs }}
+      ci-no-test-timeout: ${{ steps.filter.outputs.ci-no-test-timeout }}
       reenabled-issues: ${{ steps.filter.outputs.reenabled-issues }}
     steps:
       - name: Checkout PyTorch
@@ -95,7 +97,8 @@ jobs:
           PY_VERS: 3.9
           PR_BODY: ${{ github.event.pull_request.body }}
           CONTINUE_THROUGH_ERROR: ${{ needs.filter.outputs.keep-going }}
-          NO_PIPE_LOGS: ${{ steps.keep-going.outputs.ci-no-pipe-logs }}
+          NO_PIPE_LOGS: ${{ needs.filter.outputs.ci-no-pipe-logs }}
+          NO_TEST_TIMEOUT: ${{ needs.filter.outputs.ci-no-test-timeout }}
           PIP_REQUIREMENTS_FILE: .github/requirements/pip-requirements-${{ runner.os }}.txt
           REENABLED_ISSUES: ${{ needs.filter.outputs.reenabled-issues }}
         run: |

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -95,6 +95,7 @@ jobs:
           PY_VERS: 3.9
           PR_BODY: ${{ github.event.pull_request.body }}
           CONTINUE_THROUGH_ERROR: ${{ needs.filter.outputs.keep-going }}
+          NO_PIPE_LOGS: ${{ steps.keep-going.outputs.ci-no-pipe-logs }}
           PIP_REQUIREMENTS_FILE: .github/requirements/pip-requirements-${{ runner.os }}.txt
           REENABLED_ISSUES: ${{ needs.filter.outputs.reenabled-issues }}
         run: |

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -148,6 +148,7 @@ jobs:
           PYTORCH_TEST_CUDA_MEM_LEAK_CHECK: ${{ matrix.mem_leak_check && '1' || '0' }}
           PYTORCH_TEST_RERUN_DISABLED_TESTS: ${{ matrix.rerun_disabled_tests && '1' || '0' }}
           CONTINUE_THROUGH_ERROR: ${{ steps.keep-going.outputs.keep-going }}
+          NO_PIPE_LOGS: ${{ steps.keep-going.outputs.ci-no-pipe-logs }}
           PIP_REQUIREMENTS_FILE: .github/requirements/pip-requirements-${{ runner.os }}.txt
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_WORKFLOW: ${{ github.workflow }}

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -148,7 +148,7 @@ jobs:
           PYTORCH_TEST_CUDA_MEM_LEAK_CHECK: ${{ matrix.mem_leak_check && '1' || '0' }}
           PYTORCH_TEST_RERUN_DISABLED_TESTS: ${{ matrix.rerun_disabled_tests && '1' || '0' }}
           CONTINUE_THROUGH_ERROR: ${{ steps.keep-going.outputs.keep-going }}
-          NO_PIPE_LOGS: ${{ steps.keep-going.outputs.ci-no-pipe-logs }}
+          VERBOSE_TEST_LOGS: ${{ steps.keep-going.outputs.ci-verbose-test-logs }}
           NO_TEST_TIMEOUT: ${{ steps.keep-going.outputs.ci-no-test-timeout }}
           PIP_REQUIREMENTS_FILE: .github/requirements/pip-requirements-${{ runner.os }}.txt
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -149,6 +149,7 @@ jobs:
           PYTORCH_TEST_RERUN_DISABLED_TESTS: ${{ matrix.rerun_disabled_tests && '1' || '0' }}
           CONTINUE_THROUGH_ERROR: ${{ steps.keep-going.outputs.keep-going }}
           NO_PIPE_LOGS: ${{ steps.keep-going.outputs.ci-no-pipe-logs }}
+          NO_TEST_TIMEOUT: ${{ steps.keep-going.outputs.ci-no-test-timeout }}
           PIP_REQUIREMENTS_FILE: .github/requirements/pip-requirements-${{ runner.os }}.txt
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_WORKFLOW: ${{ github.workflow }}

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -148,7 +148,7 @@ jobs:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
           SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
           CONTINUE_THROUGH_ERROR: ${{ steps.keep-going.outputs.keep-going }}
-          NO_PIPE_LOGS: ${{ steps.keep-going.outputs.ci-no-pipe-logs }}
+          VERBOSE_TEST_LOGS: ${{ steps.keep-going.outputs.ci-verbose-test-logs }}
           NO_TEST_TIMEOUT: ${{ steps.keep-going.outputs.ci-no-test-timeout }}
           TEST_CONFIG: ${{ matrix.config }}
           SHARD_NUMBER: ${{ matrix.shard }}
@@ -198,7 +198,7 @@ jobs:
             -e NUM_TEST_SHARDS \
             -e REENABLED_ISSUES \
             -e CONTINUE_THROUGH_ERROR \
-            -e NO_PIPE_LOGS \
+            -e VERBOSE_TEST_LOGS \
             -e NO_TEST_TIMEOUT \
             -e MAX_JOBS="$(nproc --ignore=2)" \
             -e SCCACHE_BUCKET \

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -149,6 +149,7 @@ jobs:
           SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
           CONTINUE_THROUGH_ERROR: ${{ steps.keep-going.outputs.keep-going }}
           NO_PIPE_LOGS: ${{ steps.keep-going.outputs.ci-no-pipe-logs }}
+          NO_TEST_TIMEOUT: ${{ steps.keep-going.outputs.ci-no-test-timeout }}
           TEST_CONFIG: ${{ matrix.config }}
           SHARD_NUMBER: ${{ matrix.shard }}
           NUM_TEST_SHARDS: ${{ matrix.num_shards }}
@@ -198,6 +199,7 @@ jobs:
             -e REENABLED_ISSUES \
             -e CONTINUE_THROUGH_ERROR \
             -e NO_PIPE_LOGS \
+            -e NO_TEST_TIMEOUT \
             -e MAX_JOBS="$(nproc --ignore=2)" \
             -e SCCACHE_BUCKET \
             -e XLA_CLANG_CACHE_S3_BUCKET_NAME \

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -148,6 +148,7 @@ jobs:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
           SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
           CONTINUE_THROUGH_ERROR: ${{ steps.keep-going.outputs.keep-going }}
+          NO_PIPE_LOGS: ${{ steps.keep-going.outputs.ci-no-pipe-logs }}
           TEST_CONFIG: ${{ matrix.config }}
           SHARD_NUMBER: ${{ matrix.shard }}
           NUM_TEST_SHARDS: ${{ matrix.num_shards }}
@@ -196,6 +197,7 @@ jobs:
             -e NUM_TEST_SHARDS \
             -e REENABLED_ISSUES \
             -e CONTINUE_THROUGH_ERROR \
+            -e NO_PIPE_LOGS \
             -e MAX_JOBS="$(nproc --ignore=2)" \
             -e SCCACHE_BUCKET \
             -e XLA_CLANG_CACHE_S3_BUCKET_NAME \

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -140,7 +140,7 @@ jobs:
           INSTALL_WINDOWS_SDK: 1
           PYTHON_VERSION: 3.8
           CONTINUE_THROUGH_ERROR: ${{ steps.keep-going.outputs.keep-going }}
-          NO_PIPE_LOGS: ${{ steps.keep-going.outputs.ci-no-pipe-logs }}
+          VERBOSE_TEST_LOGS: ${{ steps.keep-going.outputs.ci-verbose-test-logs }}
           NO_TEST_TIMEOUT: ${{ steps.keep-going.outputs.ci-no-test-timeout }}
           VC_PRODUCT: "BuildTools"
           VC_VERSION: ""

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -141,6 +141,7 @@ jobs:
           PYTHON_VERSION: 3.8
           CONTINUE_THROUGH_ERROR: ${{ steps.keep-going.outputs.keep-going }}
           NO_PIPE_LOGS: ${{ steps.keep-going.outputs.ci-no-pipe-logs }}
+          NO_TEST_TIMEOUT: ${{ steps.keep-going.outputs.ci-no-test-timeout }}
           VC_PRODUCT: "BuildTools"
           VC_VERSION: ""
           VS_VERSION: "16.8.6"

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -140,6 +140,7 @@ jobs:
           INSTALL_WINDOWS_SDK: 1
           PYTHON_VERSION: 3.8
           CONTINUE_THROUGH_ERROR: ${{ steps.keep-going.outputs.keep-going }}
+          NO_PIPE_LOGS: ${{ steps.keep-going.outputs.ci-no-pipe-logs }}
           VC_PRODUCT: "BuildTools"
           VC_VERSION: ""
           VS_VERSION: "16.8.6"

--- a/.github/workflows/_xpu-test.yml
+++ b/.github/workflows/_xpu-test.yml
@@ -143,7 +143,7 @@ jobs:
           PYTORCH_RETRY_TEST_CASES: 1
           PYTORCH_OVERRIDE_FLAKY_SIGNAL: 1
           CONTINUE_THROUGH_ERROR: ${{ steps.keep-going.outputs.keep-going }}
-          NO_PIPE_LOGS: ${{ steps.keep-going.outputs.ci-no-pipe-logs }}
+          VERBOSE_TEST_LOGS: ${{ steps.keep-going.outputs.ci-verbose-test-logs }}
           NO_TEST_TIMEOUT: ${{ steps.keep-going.outputs.ci-no-test-timeout }}
           TEST_CONFIG: ${{ matrix.config }}
           SHARD_NUMBER: ${{ matrix.shard }}
@@ -187,7 +187,7 @@ jobs:
             -e PYTORCH_RETRY_TEST_CASES \
             -e PYTORCH_OVERRIDE_FLAKY_SIGNAL \
             -e CONTINUE_THROUGH_ERROR \
-            -e NO_PIPE_LOGS \
+            -e VERBOSE_TEST_LOGS \
             -e NO_TEST_TIMEOUT \
             -e MAX_JOBS="$(nproc --ignore=2)" \
             -e SCCACHE_BUCKET \

--- a/.github/workflows/_xpu-test.yml
+++ b/.github/workflows/_xpu-test.yml
@@ -144,6 +144,7 @@ jobs:
           PYTORCH_OVERRIDE_FLAKY_SIGNAL: 1
           CONTINUE_THROUGH_ERROR: ${{ steps.keep-going.outputs.keep-going }}
           NO_PIPE_LOGS: ${{ steps.keep-going.outputs.ci-no-pipe-logs }}
+          NO_TEST_TIMEOUT: ${{ steps.keep-going.outputs.ci-no-test-timeout }}
           TEST_CONFIG: ${{ matrix.config }}
           SHARD_NUMBER: ${{ matrix.shard }}
           NUM_TEST_SHARDS: ${{ matrix.num_shards }}
@@ -187,6 +188,7 @@ jobs:
             -e PYTORCH_OVERRIDE_FLAKY_SIGNAL \
             -e CONTINUE_THROUGH_ERROR \
             -e NO_PIPE_LOGS \
+            -e NO_TEST_TIMEOUT \
             -e MAX_JOBS="$(nproc --ignore=2)" \
             -e SCCACHE_BUCKET \
             -e XLA_CLANG_CACHE_S3_BUCKET_NAME \

--- a/.github/workflows/_xpu-test.yml
+++ b/.github/workflows/_xpu-test.yml
@@ -143,6 +143,7 @@ jobs:
           PYTORCH_RETRY_TEST_CASES: 1
           PYTORCH_OVERRIDE_FLAKY_SIGNAL: 1
           CONTINUE_THROUGH_ERROR: ${{ steps.keep-going.outputs.keep-going }}
+          NO_PIPE_LOGS: ${{ steps.keep-going.outputs.ci-no-pipe-logs }}
           TEST_CONFIG: ${{ matrix.config }}
           SHARD_NUMBER: ${{ matrix.shard }}
           NUM_TEST_SHARDS: ${{ matrix.num_shards }}
@@ -185,6 +186,7 @@ jobs:
             -e PYTORCH_RETRY_TEST_CASES \
             -e PYTORCH_OVERRIDE_FLAKY_SIGNAL \
             -e CONTINUE_THROUGH_ERROR \
+            -e NO_PIPE_LOGS \
             -e MAX_JOBS="$(nproc --ignore=2)" \
             -e SCCACHE_BUCKET \
             -e XLA_CLANG_CACHE_S3_BUCKET_NAME \

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -619,7 +619,9 @@ def run_test(
         "BUILD_ENVRIONMENT", ""
     )
     timeout = (
-        THRESHOLD * 6
+        None
+        if not options.set_timeout
+        else THRESHOLD * 6
         if is_slow
         else THRESHOLD * 3
         if should_retry
@@ -1254,6 +1256,12 @@ def parse_args():
         action="store_true",
         help="Print logs to output file while running tests.  True if in CI and env var is not set",
         default=IS_CI and not strtobool(os.environ.get("NO_PIPE_LOGS", "False")),
+    )
+    parser.add_argument(
+        "--set-timeout",
+        type="store_true",
+        help="Set a timeout based on the test times json file.  Only works if there are test times available",
+        default=IS_CI and not strtobool(os.environ.get("NO_TEST_TIMEOUT", "False")),
     )
     parser.add_argument(
         "additional_unittest_args",

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -620,7 +620,7 @@ def run_test(
     )
     timeout = (
         None
-        if not options.set_timeout
+        if not options.enable_timeout
         else THRESHOLD * 6
         if is_slow
         else THRESHOLD * 3
@@ -1258,7 +1258,7 @@ def parse_args():
         default=IS_CI and not strtobool(os.environ.get("VERBOSE_TEST_LOGS", "False")),
     )
     parser.add_argument(
-        "--set-timeout",
+        "--enable-timeout",
         action="store_true",
         help="Set a timeout based on the test times json file.  Only works if there are test times available",
         default=IS_CI and not strtobool(os.environ.get("NO_TEST_TIMEOUT", "False")),

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1259,7 +1259,7 @@ def parse_args():
     )
     parser.add_argument(
         "--set-timeout",
-        type="store_true",
+        action="store_true",
         help="Set a timeout based on the test times json file.  Only works if there are test times available",
         default=IS_CI and not strtobool(os.environ.get("NO_TEST_TIMEOUT", "False")),
     )

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1255,7 +1255,7 @@ def parse_args():
         "--pipe-logs",
         action="store_true",
         help="Print logs to output file while running tests.  True if in CI and env var is not set",
-        default=IS_CI and not strtobool(os.environ.get("NO_PIPE_LOGS", "False")),
+        default=IS_CI and not strtobool(os.environ.get("VERBOSE_TEST_LOGS", "False")),
     )
     parser.add_argument(
         "--set-timeout",


### PR DESCRIPTION
Test [ci-verbose-test-logs] (this worked, the test logs printing while running and interleaved and are really long)

Settings for no timeout (step timeout still applies, only gets rid of ~30 min timeout for shard of test file) and no piping logs/extra verbose test logs (good for debugging deadlocks but results in very long and possibly interleaved logs).

Also allows these to be set via pr body if the label name is in brackets ex [label name] or the test above.

