### PR TITLE
Fix check-labels.yml for ghstack PRs

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -9,15 +9,14 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: [main]
-    paths-ignore: [.github]
 
   # To check labels on ghstack PRs.
   # Note: as pull_request doesn't trigger on PRs targeting main,
   # to test changes to the workflow itself one needs to create
-  # a PR that targets a non-main branch.
+  # a PR that targets a gh/**/base branch.
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    branches-ignore: [main]
+    branches: [gh/**/base]
 
   workflow_dispatch:
 
@@ -28,6 +27,7 @@ concurrency:
 jobs:
   check-labels:
     name: Check labels
+    if: github.repository_owner == 'pytorch'
     runs-on: linux.20_04.4x
     steps:
       - name: Checkout PyTorch

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -11,10 +11,13 @@ on:
     branches: [main]
     paths-ignore: [.github]
 
-  # To check labels on ghstack PRs and to allow testing PRs that change workflows.
-  # May be triggered together with pull_request_target, it's OK.
+  # To check labels on ghstack PRs.
+  # Note: as pull_request doesn't trigger on PRs targeting main,
+  # to test changes to the workflow itself one needs to create
+  # a PR that targets a non-main branch.
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches-ignore: [main]
 
   workflow_dispatch:
 

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -11,11 +11,10 @@ on:
     branches: [main]
     paths-ignore: [.github]
 
-  # To allow testing PRs that change workflows.
+  # To check labels on ghstack PRs and to allow testing PRs that change workflows.
   # May be triggered together with pull_request_target, it's OK.
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    paths: [.github]
 
   workflow_dispatch:
 


### PR DESCRIPTION
Otherwise check-labels doesn't run on ghstack PRs, see https://github.com/pytorch/pytorch/pull/117609 for example: no Check Labels workflow run.
