### PR TITLE
Add node meta value into UnflattenedModule

### DIFF
--- a/test/export/test_unflatten.py
+++ b/test/export/test_unflatten.py
@@ -456,5 +456,37 @@ class TestUnflatten(TestCase):
         ep = torch.export.export(gm_unflat_non_strict, inp, strict=False)
         self.assertTrue(torch.allclose(ep(*inp), mod(*inp)))
 
+    def test_unflattened_module_nodes_has_meta_val(self):
+        class SubMod(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return x + x, x * x
+
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.submod = SubMod()
+
+            def forward(self, x):
+                return x + sum(self.submod(x))
+
+        orig_eager = MyModule()
+        export_module = torch.export.export(orig_eager, (torch.rand(2, 3),), {})
+        unflattened = unflatten(export_module)
+
+        inputs = (torch.rand(2, 3),)
+        self.compare_outputs(orig_eager, unflattened, inputs)
+
+        def check_meta(gm):
+            for n in gm.graph.nodes:
+                if n.op == "output":
+                    continue
+                self.assertTrue(n.meta.get("val") is not None)
+
+        for m in unflattened.modules():
+            check_meta(m)
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -605,12 +605,19 @@ class _ModuleFrame:
         if parent_out is None:
             return
 
+        parent_out.meta["val"] = (
+            graph_outputs.meta.get("val")
+            if isinstance(graph_outputs, torch.fx.Node)
+            else [o.meta.get("val") for o in graph_outputs]
+        )
+
         if len(orig_outputs) == 1 and signature is None:
             self.parent.node_map[orig_outputs[0]] = parent_out
         else:
             for i, orig_output in enumerate(orig_outputs):
                 # Use Proxy to record getitem access.
                 proxy_out = torch.fx.Proxy(parent_out)[i].node  # type: ignore[index]
+                proxy_out.meta["val"] = copy.copy(orig_output.meta["val"])
                 self.parent.node_map[orig_output] = proxy_out
 
         if self.cached_graph_module is not None:


### PR DESCRIPTION
Fixes #116670 
Following the lead of #116720, added node.meta['val'] back to newly created subgraphs.

node.meta['val'] is essential to ONNX in terms of the shape and type information.

cc @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan @angelayi @suo @ydwu4