### PR TITLE
[PT2][split_cat] fix a bug in merge_splits

### DIFF
--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -353,6 +353,10 @@ def merge_splits(
     dim: int,
 ):
     node = match.output_node()
+    # it is possible that the split has no users,
+    # we check the corner case and skip the pattern
+    if len(node.users.keys()) == 0:
+        return
     graph = match.graph
     first_split = node.args[0].args[0]
     next_split_index = node.args[0].args[1]


### PR DESCRIPTION
Summary: Recently, we found merge splits (D45204109) is not working for AFOC model, thus patch a fix.

Test Plan:
The error log: P1046934021
# Flows used to local reproduce
### non-first:
f522317780
after the fix: P1047603217
### first:
f522253163
after the fix: P1047764917

Differential Revision: D52856359




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler