### PR TITLE
add test_public_bindings to internal CI

### DIFF
--- a/test/allowlist_for_publicAPI.json
+++ b/test/allowlist_for_publicAPI.json
@@ -149,10 +149,15 @@
     "Optional"
   ],
   "torch.distributed.elastic.events.handlers": [
-    "Dict"
+    "Dict",
+    "Optional",
+    "ScubaLogHandler",
+    "ScubaRdzvLogHandler"
   ],
   "torch.distributed.elastic.metrics": [
-    "Optional"
+    "Optional",
+    "get_logger",
+    "TorchElasticService"
   ],
   "torch.distributed.elastic.multiprocessing": [
     "Callable",
@@ -260,8 +265,7 @@
     "urlparse",
     "urlunparse"
   ],
-  "torch.distributed.rpc": [
-  ],
+  "torch.distributed.rpc": [],
   "torch.fft": [
     "Tensor",
     "fft",
@@ -2434,5 +2438,185 @@
   ],
   "torch.utils.tensorboard": [
     "RecordWriter"
+  ],
+  "torch.ao.quantization.experimental.APoT_tensor": [
+    "APoTQuantizer"
+  ],
+  "torch.ao.quantization.experimental.fake_quantize": [
+    "APoTObserver",
+    "FakeQuantizeBase",
+    "Tensor"
+  ],
+  "torch.ao.quantization.experimental.fake_quantize_function": [
+    "dequantize_APoT",
+    "quantize_APoT",
+    "Tensor"
+  ],
+  "torch.ao.quantization.experimental.linear": [
+    "APoTObserver",
+    "quantize_APoT",
+    "WeightedQuantizedModule"
+  ],
+  "torch.ao.quantization.experimental.observer": [
+    "apot_to_float",
+    "float_to_apot",
+    "ObserverBase"
+  ],
+  "torch.ao.quantization.experimental.qconfig": [
+    "APoTFakeQuantize",
+    "default_symmetric_fake_quant",
+    "default_weight_symmetric_fake_quant",
+    "FakeQuantize",
+    "MinMaxObserver",
+    "QConfig"
+  ],
+  "torch.ao.quantization.experimental.quantizer": [
+    "apot_to_float",
+    "float_to_apot",
+    "quant_dequant_util",
+    "Tensor"
+  ],
+  "torch.ao.sparsity": [
+    "BaseScheduler",
+    "BaseSparsifier",
+    "CubicSL",
+    "FakeSparsity",
+    "fqn_to_module",
+    "get_arg_info_from_tensor_fqn",
+    "get_dynamic_sparse_quantized_mapping",
+    "get_static_sparse_quantized_mapping",
+    "LambdaSL",
+    "module_to_fqn",
+    "NearlyDiagonalSparsifier",
+    "WeightNormSparsifier"
+  ],
+  "torch.ao.sparsity.scheduler.base_scheduler": [
+    "BaseScheduler"
+  ],
+  "torch.ao.sparsity.scheduler.cubic_scheduler": [
+    "CubicSL"
+  ],
+  "torch.ao.sparsity.scheduler.lambda_scheduler": [
+    "LambdaSL"
+  ],
+  "torch.ao.sparsity.sparsifier.base_sparsifier": [
+    "BaseSparsifier"
+  ],
+  "torch.ao.sparsity.sparsifier.nearly_diagonal_sparsifier": [
+    "NearlyDiagonalSparsifier"
+  ],
+  "torch.ao.sparsity.sparsifier.utils": [
+    "FakeSparsity",
+    "fqn_to_module",
+    "get_arg_info_from_tensor_fqn",
+    "module_to_fqn"
+  ],
+  "torch.ao.sparsity.sparsifier.weight_norm_sparsifier": [
+    "WeightNormSparsifier"
+  ],
+  "torch.csrc.jit.tensorexpr.codegen_external": [
+    "FileManager",
+    "parse_native_yaml"
+  ],
+  "torch.distributed.checkpoint.examples.async_checkpointing_example": [
+    "FSDP",
+    "init_device_mesh"
+  ],
+  "torch.distributed.checkpoint.examples.fsdp_checkpoint_example": [
+    "FSDP",
+    "load_sharded_optimizer_state_dict",
+    "StateDictType"
+  ],
+  "torch.distributed.checkpoint.examples.stateful_example": [
+    "FSDP",
+    "init_device_mesh"
+  ],
+  "torch.distributed.elastic.events.fb.scuba": [
+    "await_sync",
+    "cast",
+    "Dict",
+    "Enum",
+    "Event",
+    "EventMetadataValue",
+    "List",
+    "Optional",
+    "RdzvEvent",
+    "RuntimeEnvironment",
+    "TorchelasticRdzvLogEntry",
+    "TorchelasticStatusLogEntry",
+    "WhenceScribeLogged"
+  ],
+  "torch.distributed.elastic.metrics.fb.service_data_metrics": [
+    "MetricHandler",
+    "ServiceDataMetrics"
+  ],
+  "torch.distributed.elastic.metrics.static_init": [
+    "configure",
+    "get_logger",
+    "MetricsConfig",
+    "Optional",
+    "ServiceDataMetricsHandler",
+    "TorchElasticService"
+  ],
+  "torch.distributed.elastic.multiprocessing.errors.fb.error_handler_fb": [
+    "Any",
+    "Dict",
+    "ErrorHandler",
+    "format_exception",
+    "generate_python_trace",
+    "MastReplyFileErrorCode",
+    "Optional",
+    "RuntimeEnvironment",
+    "RuntimeEnvironmentScheduler",
+    "write_formatted_message"
+  ],
+  "torch.distributed.elastic.multiprocessing.errors.handlers": [
+    "ErrorHandlerFB"
+  ],
+  "torch.distributed.elastic.rendezvous.fb.mast_rendezvous": [
+    "create_c10d_store",
+    "DistNetworkError",
+    "DistStoreError",
+    "get_logger",
+    "List",
+    "Optional",
+    "RendezvousClosedError",
+    "RendezvousHandler",
+    "RendezvousParameters",
+    "RendezvousTimeoutError",
+    "Tuple"
+  ],
+  "torch.distributed.elastic.rendezvous.fb.zeus": [
+    "gethostname",
+    "get_logger",
+    "namedtuple",
+    "Optional",
+    "RendezvousClosedError",
+    "RendezvousHandler",
+    "RendezvousParameters",
+    "RendezvousTimeoutError"
+  ],
+  "torch.distributed.elastic.rendezvous.registry": [
+    "create_handler",
+    "RendezvousHandler",
+    "RendezvousParameters"
+  ],
+  "torch.distributed.logging_handlers": [
+    "C10D_CATEGORY",
+    "Dict",
+    "LogCategory",
+    "Optional",
+    "Sample",
+    "ScubaData",
+    "signpost",
+    "SignpostType"
+  ],
+  "torch.utils.benchmark.examples.sparse.op_benchmark": [
+    "BinaryOpSparseFuzzer",
+    "Timer",
+    "UnaryOpSparseFuzzer"
+  ],
+  "torch.version": [
+    "get_file_path"
   ]
 }

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -1,6 +1,8 @@
 # Owner(s): ["module: autograd"]
 
 from torch.testing._internal.common_utils import TestCase, run_tests, IS_JETSON, IS_WINDOWS
+from torch._utils_internal import get_file_path_2
+
 import pkgutil
 import torch
 import importlib
@@ -10,6 +12,47 @@ import json
 import os
 import unittest
 from importlib import import_module
+from itertools import chain
+from pathlib import Path
+
+def _find_all_importables(pkg):
+    """Find all importables in the project.
+
+    Return them in order.
+    """
+    return sorted(
+        set(
+            chain.from_iterable(
+                _discover_path_importables(Path(p), pkg.__name__)
+                for p in pkg.__path__
+            ),
+        ),
+    )
+
+
+def _discover_path_importables(pkg_pth, pkg_name):
+    """Yield all importables under a given path and package.
+
+    This is like pkgutil.walk_packages, but does *not* skip over namespace
+    packages. Taken from https://stackoverflow.com/questions/41203765/init-py-required-for-pkgutil-walk-packages-in-python3
+    """
+    for dir_path, _d, file_names in os.walk(pkg_pth):
+        pkg_dir_path = Path(dir_path)
+
+        if pkg_dir_path.parts[-1] == '__pycache__':
+            continue
+
+        if all(Path(_).suffix != '.py' for _ in file_names):
+            continue
+
+        rel_pt = pkg_dir_path.relative_to(pkg_pth)
+        pkg_pref = '.'.join((pkg_name, ) + rel_pt.parts)
+        yield from (
+            pkg_path
+            for _, pkg_path, _ in pkgutil.walk_packages(
+                (str(pkg_dir_path), ), prefix=f'{pkg_pref}.',
+            )
+        )
 
 
 class TestPublicBindings(TestCase):
@@ -231,9 +274,10 @@ class TestPublicBindings(TestCase):
                 return False
         return True
 
+
     def test_modules_can_be_imported(self):
         failures = []
-        for _, modname, _ in pkgutil.walk_packages(path=torch.__path__, prefix=torch.__name__ + '.'):
+        for _, modname, _ in _discover_path_importables(str(torch.__path__), "torch"):
             try:
                 # TODO: fix "torch/utils/model_dump/__main__.py"
                 # which calls sys.exit() when we try to import it
@@ -309,6 +353,19 @@ class TestPublicBindings(TestCase):
             "torch.distributed.algorithms._optimizer_overlap",
             "torch.distributed.rpc._testing.faulty_agent_backend_registry",
             "torch.distributed.rpc._utils",
+            "torch.ao.pruning._experimental.data_sparsifier.benchmarks.dlrm_utils",
+            "torch.ao.pruning._experimental.data_sparsifier.benchmarks.evaluate_disk_savings",
+            "torch.ao.pruning._experimental.data_sparsifier.benchmarks.evaluate_forward_time",
+            "torch.ao.pruning._experimental.data_sparsifier.benchmarks.evaluate_model_metrics",
+            "torch.ao.pruning._experimental.data_sparsifier.lightning.tests.test_callbacks",
+            "torch.csrc.jit.tensorexpr.scripts.bisect",
+            "torch.csrc.lazy.test_mnist",
+            "torch.distributed._shard.checkpoint._fsspec_filesystem",
+            "torch.distributed._tensor.examples.visualize_sharding_example",
+            "torch.distributed.checkpoint._fsspec_filesystem",
+            "torch.distributed.examples.memory_tracker_example",
+            "torch.testing._internal.distributed.rpc.fb.thrift_rpc_agent_test_fixture",
+            "torch.utils._cxx_pytree",
         }
 
         # No new entries should be added to this list.
@@ -345,6 +402,7 @@ class TestPublicBindings(TestCase):
             "torch.distributed.run",
             "torch.distributed.tensor.parallel",
             "torch.distributed.utils",
+            "torch.utils.tensorboard",
         }
 
         errors = []
@@ -374,7 +432,7 @@ class TestPublicBindings(TestCase):
           `__module__` that start with the current submodule.
         '''
         failure_list = []
-        with open(os.path.join(os.path.dirname(__file__), 'allowlist_for_publicAPI.json')) as json_file:
+        with open(get_file_path_2(os.path.dirname(__file__), 'allowlist_for_publicAPI.json')) as json_file:
             # no new entries should be added to this allow_dict.
             # New APIs must follow the public API guidelines.
             allow_dict = json.load(json_file)
@@ -472,7 +530,7 @@ class TestPublicBindings(TestCase):
                     if not elem.startswith('_'):
                         check_one_element(elem, modname, mod, is_public=True, is_all=False)
 
-        for _, modname, ispkg in pkgutil.walk_packages(path=torch.__path__, prefix=torch.__name__ + '.'):
+        for _, modname, _ in _discover_path_importables(str(torch.__path__), "torch"):
             test_module(modname)
 
         test_module('torch')


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #117712

enable this test in meta-internal CI, since it's mildly infuriating to not be able to locally test this when working inside meta

One change:
This test uses `pkgutil.walk_packages`, which ignores namespace packages. A quirk in Meta's internal python packaging system is that it adds `__init__.py` to each source directory. So this test picks up more files to check internally than in the GitHub CI.

So I changed this test from using raw `pkgutil` to a version that also looks into namespace packages, so we're checking the same thing across both CIs.

Differential Revision: [D52857631](https://our.internmc.facebook.com/intern/diff/D52857631/)