### PR TITLE
All tests run with markDynamoStrictTest now

### DIFF
--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -15,7 +15,11 @@ from torch._dynamo.testing import skipIfNotPy311
 
 from torch.nn.parallel import DistributedDataParallel as DDP
 
-from torch.testing._internal.common_utils import find_free_port, munge_exc
+from torch.testing._internal.common_utils import (
+    find_free_port,
+    munge_exc,
+    skipIfTorchDynamo,
+)
 from torch.testing._internal.inductor_utils import HAS_CUDA
 from torch.testing._internal.logging_utils import (
     LoggingTestCase,
@@ -113,6 +117,7 @@ class LoggingTests(LoggingTestCase):
     test_dynamo_debug = within_range_record_test(30, 90, dynamo=logging.DEBUG)
     test_dynamo_info = within_range_record_test(2, 10, dynamo=logging.INFO)
 
+    @skipIfTorchDynamo("too slow")
     @make_logging_test(dynamo=logging.DEBUG)
     def test_dynamo_debug_default_off_artifacts(self, records):
         fn_opt = torch._dynamo.optimize("inductor")(example_fn)
@@ -629,6 +634,7 @@ L['zs'][0] == 3.0                                             # for y, z in zip(
             record_str,
         )
 
+    @skipIfTorchDynamo("too slow")
     @make_logging_test(**torch._logging.DEFAULT_LOGGING)
     def test_default_logging(self, records):
         def fn(a):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -80,7 +80,6 @@ from torch.nn import (
 from .dynamo_test_failures import (
     dynamo_expected_failures,
     dynamo_skips,
-    FIXME_default_non_strict,
     FIXME_inductor_non_strict,
 )
 from torch.onnx import (
@@ -2711,7 +2710,7 @@ This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0"""
                     if TEST_WITH_TORCHINDUCTOR:  # noqa: F821
                         strict_default = filename not in FIXME_inductor_non_strict
                     else:
-                        strict_default = filename not in FIXME_default_non_strict
+                        strict_default = True
             # inspect.getfile can fail with these
             except (OSError, TypeError):
                 pass

--- a/torch/testing/_internal/dynamo_test_failures.py
+++ b/torch/testing/_internal/dynamo_test_failures.py
@@ -13,11 +13,6 @@
 # always execute the test and then suppress the signal, if necessary.
 # If your tests crashes, or is slow, please use @skipIfTorchDynamo instead.
 
-# tests in this list will run without Dynamo strict mode by default.
-FIXME_default_non_strict = {
-    "dynamo/test_logging",
-}
-
 # Tests that run without strict mode in PYTORCH_TEST_WITH_INDUCTOR=1.
 # Please don't add anything to this list.
 FIXME_inductor_non_strict = {
@@ -3725,6 +3720,29 @@ dynamo_expected_failures = {
     "TestPythonDispatch.test_subclass_priority",  # test_python_dispatch
     "TestPythonDispatch.test_exception_handling",  # test_python_dispatch
     "TestPythonDispatch.test_list_ret",  # test_python_dispatch
+    "LoggingTests.test_trace_source_nested",  # dynamo/test_logging
+    "LoggingTests.test_guards_recompiles",  # dynamo/test_logging
+    "LoggingTests.test_inductor_info",  # dynamo/test_logging
+    "LoggingTests.test_output_code",  # dynamo/test_logging
+    "LoggingTests.test_graph_code",  # dynamo/test_logging
+    "LoggingTests.test_graph_sizes",  # dynamo/test_logging
+    "LoggingTests.test_recompiles",  # dynamo/test_logging
+    "LoggingTests.test_inductor_error",  # dynamo/test_logging
+    "LoggingTests.test_graph",  # dynamo/test_logging
+    "LoggingTests.test_custom_format_exc",  # dynamo/test_logging
+    "LoggingTests.test_custom_format",  # dynamo/test_logging
+    "LoggingTests.test_trace_source_cond",  # dynamo/test_logging
+    "LoggingTests.test_multiline_format",  # dynamo/test_logging
+    "LoggingTests.test_aot_joint_graph",  # dynamo/test_logging
+    "LoggingTests.test_inductor_debug",  # dynamo/test_logging
+    "LoggingTests.test_bytecode",  # dynamo/test_logging
+    "LoggingTests.test_graph_sizes_dynamic",  # dynamo/test_logging
+    "LoggingTests.test_dynamo_error",  # dynamo/test_logging
+    "LoggingTests.test_dynamo_debug",  # dynamo/test_logging
+    "LoggingTests.test_aot_graphs",  # dynamo/test_logging
+    "LoggingTests.test_dynamo_info",  # dynamo/test_logging
+    "LoggingTests.test_graph_breaks",  # dynamo/test_logging
+    "LoggingTests.test_aot",  # dynamo/test_logging
 }
 
 # see NOTE [dynamo_test_failures.py] for more details
@@ -8231,6 +8249,11 @@ dynamo_skips = {
     "TestWrapperSubclassAliasingCPU.test_wrapper_subclass_aliasing_custom_NumpySplitCopyWithIntCustomOp_cpu_float32",  # known py38 fail  # noqa: B950
     "TestWrapperSubclassAliasingCPU.test_wrapper_subclass_aliasing_view_cpu_float32",  # known py38 fail
     "TestWrapperSubclassAliasingCPU.test_wrapper_subclass_aliasing_custom_NumpySplitCopyCustomOp_cpu_float32",  # known py38 fail  # noqa: B950
+    "LoggingTests.test_logs_out",  # known py38 fail
+    "LoggingTests.test_distributed_rank_logging",  # known py38 fail
+    "LoggingTests.test_trace_call",  # known py311 fail
+    "LoggingTests.test_trace_call_graph_break",  # known py311 fail
+    "LoggingTests.test_trace_call_inline_call",  # known py311 fail
 }
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #117765
* __->__ #117763
* #117761
* #117754
* #117747
* #117729

Last test to remove from the denylist was dynamo/test_logging.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng