### PR TITLE
[Pytoch][Vulkan] Create context for conv1d

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Convolution.h
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.h
@@ -217,6 +217,75 @@ c10::intrusive_ptr<Conv2dOpContext> conv2d_clamp_prepack(
     const c10::optional<Scalar>& output_min,
     const c10::optional<Scalar>& output_max);
 
+class Conv1dPackedContext final : virtual public VulkanPackedContext,
+                                  public torch::jit::CustomClassHolder {
+ private:
+  c10::impl::GenericList unpacked_;
+  api::ShaderInfo compute_shader_{};
+
+ public:
+  Conv1dPackedContext(
+      const Tensor& weight,
+      const c10::optional<Tensor>& bias,
+      const IntArrayRef stride_arg,
+      const IntArrayRef padding_arg,
+      const IntArrayRef dilation_arg,
+      const int64_t groups);
+
+  /*
+   * Assigns a name to each index in the unpacked list.
+   */
+  struct Unpacked final {
+    static constexpr uint32_t Weight = 0u;
+    static constexpr uint32_t Bias = 1u;
+    static constexpr uint32_t Stride = 2u;
+    static constexpr uint32_t Padding = 3u;
+    static constexpr uint32_t Dilation = 4u;
+    static constexpr uint32_t Groups = 5u;
+
+    static constexpr uint32_t NumArgs = 6u;
+  };
+
+  /*
+   * Assigns a name to each index in the packed list.
+   */
+  struct Packed final {
+    static constexpr uint32_t Weight = 0u;
+    static constexpr uint32_t Bias = 1u;
+    static constexpr uint32_t Stride = 2u;
+    static constexpr uint32_t Padding = 3u;
+    static constexpr uint32_t Dilation = 4u;
+    static constexpr uint32_t Groups = 5u;
+    static constexpr uint32_t WeightSizes = 6u;
+
+    static constexpr uint32_t NumArgs = 7u;
+  };
+
+  static Conv1dPackedContext pack(c10::impl::GenericList);
+
+  const c10::impl::GenericList unpack() const override {
+    TORCH_CHECK(unpacked_.size() > 0u, "unpacked_ does not have any elements!");
+
+    return unpacked_;
+  }
+
+  inline api::ShaderInfo& compute_shader() {
+    return compute_shader_;
+  }
+};
+
+c10::intrusive_ptr<Conv1dPackedContext> create_conv1d_context(
+    Tensor&& weight,
+    c10::optional<Tensor>&& bias,
+    std::vector<int64_t>&& stride,
+    std::vector<int64_t>&& padding,
+    std::vector<int64_t>&& dilation,
+    const int64_t groups);
+
+Tensor run_conv1d_context(
+    const Tensor& input,
+    const c10::intrusive_ptr<Conv1dPackedContext>& context);
+
 } // namespace ops
 } // namespace vulkan
 } // namespace native

--- a/aten/src/ATen/native/vulkan/ops/Register.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Register.cpp
@@ -37,6 +37,25 @@ int register_vulkan_conv2d_packed_context() {
   return 0;
 }
 
+int register_vulkan_conv1d_packed_context() {
+  static auto register_vulkan_conv1d_context =
+      torch::selective_class_<Conv1dPackedContext>(
+          "vulkan", TORCH_SELECTIVE_CLASS("Conv1dPackedContext"))
+          .def_pickle(
+              // __getstate__
+              [](const c10::intrusive_ptr<Conv1dPackedContext>& context) {
+                // context is packed
+                return context->unpack();
+              },
+              // __setstate__
+              [](c10::impl::GenericList state) {
+                // state is unpacked
+                return c10::make_intrusive<Conv1dPackedContext>(
+                    Conv1dPackedContext::pack(state));
+              });
+  return 0;
+}
+
 int register_vulkan_linear_packed_context() {
   static auto register_vulkan_linear_context =
       torch::selective_class_<LinearPackedContext>(
@@ -118,6 +137,7 @@ TORCH_LIBRARY(vulkan, m) {
                 LstmPackedContext::pack(state));
           });
   register_vulkan_conv2d_packed_context();
+  register_vulkan_conv1d_packed_context();
   register_vulkan_linear_packed_context();
   register_vulkan_layernorm_packed_context();
   // To maintain backwards compatibility.
@@ -174,6 +194,13 @@ TORCH_LIBRARY(vulkan_prepack, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
       "vulkan_prepack::run_qconv2d_context(Tensor X, float scale, int zero_point, "
       "__torch__.torch.classes.vulkan.Conv2dPackedContext vk_context) -> Tensor Y"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "vulkan_prepack::create_conv1d_context(Tensor W, Tensor? B, int[2] stride, "
+      "int[2] padding, int[2] dilation, int groups) "
+      "-> __torch__.torch.classes.vulkan.Conv1dPackedContext"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "vulkan_prepack::run_conv1d_context(Tensor X, "
+      "__torch__.torch.classes.vulkan.Conv1dPackedContext W_prepack) -> Tensor Y"));
   m.def(TORCH_SELECTIVE_SCHEMA(
       "vulkan_prepack::create_linear_context(Tensor W, Tensor? B) "
       "-> __torch__.torch.classes.vulkan.LinearPackedContext"));
@@ -245,6 +272,9 @@ TORCH_LIBRARY_IMPL(vulkan_prepack, CPU, m) {
       TORCH_SELECTIVE_NAME("vulkan_prepack::create_tconv2d_context"),
       TORCH_FN(create_tconv2d_context));
   m.impl(
+      TORCH_SELECTIVE_NAME("vulkan_prepack::create_conv1d_context"),
+      TORCH_FN(create_conv1d_context));
+  m.impl(
       TORCH_SELECTIVE_NAME("vulkan_prepack::create_linear_context"),
       TORCH_FN(create_linear_context));
   m.impl(
@@ -280,6 +310,9 @@ TORCH_LIBRARY_IMPL(vulkan_prepack, Vulkan, m) {
   m.impl(
       TORCH_SELECTIVE_NAME("vulkan_prepack::run_qconv2d_context"),
       TORCH_FN(run_qconv2d_context));
+  m.impl(
+      TORCH_SELECTIVE_NAME("vulkan_prepack::run_conv1d_context"),
+      TORCH_FN(run_conv1d_context));
   m.impl(
       TORCH_SELECTIVE_NAME("vulkan_prepack::run_linear_context"),
       TORCH_FN(run_linear_context));

--- a/aten/src/ATen/native/vulkan/ops/Register.h
+++ b/aten/src/ATen/native/vulkan/ops/Register.h
@@ -6,6 +6,7 @@ namespace vulkan {
 namespace ops {
 
 int register_vulkan_conv2d_packed_context();
+int register_vulkan_conv1d_packed_context();
 int register_vulkan_linear_packed_context();
 int register_vulkan_layernorm_packed_context();
 


### PR DESCRIPTION
Summary:
`conv1d` has two arguments `weight` and `bias` which are stored as constant tensors on the CPU and they are transferred to GPU at every inference call. We create a context for this operator to avoid the repeated passing. Specifically, we
- created `Conv1dPackedContext`,`create_conv1d_context` and `run_layernorm_context` in `Convolution.h` and `Convolution.cpp`
- registered them in `Register.cpp`
- rewrote the graph representation of the op in `vulkan_rewrite.cpp`

Test Plan:
## Numerical test
```
[luwei@82308.od /data/sandcastle/boxes/fbsource (8a8d911dc)]$ LD_LIBRARY_PATH=third-party/swiftshader/lib/linux-x64/ buck run fbcode/mode/dev-nosan //xplat/caffe2:pt_vulkan_api_test_bin -- --gtest_filter="*conv1d*"
Buck UI: https://www.internalfb.com/buck2/7760800b-fd75-479a-9368-be5fcd5a7fef
Network: Up: 0B  Down: 0B
Jobs completed: 4. Time elapsed: 0.6s.
BUILD SUCCEEDED
Running main() from third-party/googletest/1.14.0/googletest/googletest/src/gtest_main.cc
Note: Google Test filter = *conv1d*
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.conv1d_simple
[       OK ] VulkanAPITest.conv1d_simple (159 ms)
[ RUN      ] VulkanAPITest.conv1d
[       OK ] VulkanAPITest.conv1d (57 ms)
[----------] 2 tests from VulkanAPITest (217 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (217 ms total)
[  PASSED  ] 2 tests.
```

Full test result in P1053644934, summary as below
```
[----------] 419 tests from VulkanAPITest (28080 ms total)
[----------] Global test environment tear-down
[==========] 419 tests from 1 test suite ran. (28080 ms total)
[  PASSED  ] 418 tests.
[  SKIPPED ] 1 test, listed below:
[  SKIPPED ] VulkanAPITest.querypool_flushed_shader_log
```
## Graph representation comparison
We created a model using `conv1d` and traced it as below
```
# Define a simple model that uses conv1d
class MyModel(torch.nn.Module):
    def __init__(self):
        super(MyModel, self).__init__()
        self.conv1d = nn.Conv1d(16, 33, 3)

    def forward(self, x):
        return self.conv1d(x)

# Create an instance of the model
model = MyModel()

# Create a dummy input tensor for tracing
input_tensor = torch.randn(20, 16, 50)

# Use torch.jit.trace to trace the model and generate a graph
traced_model = torch.jit.trace(model, input_tensor)
```
Then we converted the traced model to Vulkan backend using `optimize_for_mobile`
```
from torch.utils import mobile_optimizer

vulkan_model = mobile_optimizer.optimize_for_mobile(
    traced_model, backend="vulkan", preserved_methods=to_preserve
)
```
Next we can print the graph of the `vulkan_model` as `print(vk_model.graph)`
- before this diff: `conv1d` was used 
```
graph(%self.1 : __torch__.___torch_mangle_16.MyModel,
      %x : Tensor):
  %60 : Device = prim::Constant[value="cpu"]()
  %self.conv1d.bias : Float(33, strides=[1], requires_grad=0, device=cpu) = prim::Constant[value=<Tensor>]()
  %37 : bool = prim::Constant[value=0]()
  %36 : NoneType = prim::Constant()
  %59 : Device = prim::Constant[value="vulkan"]()
  %self.conv1d.weight : Float(33, 16, 3, strides=[48, 3, 1], requires_grad=0, device=cpu) = prim::Constant[value=<Tensor>]()
  %7 : int = prim::Constant[value=1](), scope: __module.conv1d # /mnt/xarfuse/uid-23453/243f3953-seed-nspid4026532834_cgpid7972545-ns-4026532831/torch/nn/modules/conv.py:306:0
  %18 : int[] = prim::Constant[value=[1]]()
  %19 : int[] = prim::Constant[value=[0]]()
  %39 : Tensor = aten::to(%x, %59, %36, %37, %37)
  %20 : Tensor = aten::conv1d(%39, %self.conv1d.weight, %self.conv1d.bias, %18, %19, %18, %7)
  %58 : Tensor = aten::to(%20, %60, %36, %37, %37)
  return (%58)
```
- after this diff: `conv1d` was replaced with `run_conv1d_context`
```
graph(%self.1 : __torch__.___torch_mangle_6.MyModel,
      %x : Tensor):
  %85 : Device = prim::Constant[value="cpu"]()
  %51 : bool = prim::Constant[value=0]()
  %50 : NoneType = prim::Constant()
  %84 : Device = prim::Constant[value="vulkan"]()
  %53 : Tensor = aten::to(%x, %84, %50, %51, %51)
  %prepack_folding_forward._jit_pass_packed_weight_0 : __torch__.torch.classes.vulkan.Conv1dPackedContext = prim::GetAttr[name="prepack_folding_forward._jit_pass_packed_weight_0"](%self.1)
  %22 : Tensor = vulkan_prepack::run_conv1d_context(%53, %prepack_folding_forward._jit_pass_packed_weight_0)
  %83 : Tensor = aten::to(%22, %85, %50, %51, %51)
  return (%83)
```

Differential Revision: D52865379


