### PR TITLE
Fix broken run_test lint when there are changes to common_utils

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -228,7 +228,18 @@ jobs:
           pip install pytest-rerunfailures==11.1.* pytest-shard==0.1.* pytest-flakefinder==1.1.* pytest-xdist==3.3.* expecttest==0.1.* numpy==1.24.*
           pip install torch --pre --index-url https://download.pytorch.org/whl/nightly/cpu/
       - name: Run run_test.py (nonretryable)
+        shell: bash
         run: |
+          set -ex
+
+          pushd /tmp
+          TORCH_PATH=$(python -c 'import torch; import os; print(os.path.dirname(torch.__file__))')
+          popd
+
+          # Overwrite nightly torch/testing with local checkout files to get the changes there
+          rm -rf "${TORCH_PATH}/testing"
+          cp -r torch/testing "${TORCH_PATH}"
+
           # Run test_vulkan, which is a fast noop on Linux
           python3 test/run_test.py --include test_vulkan --verbose
 


### PR DESCRIPTION
Because we are using nightly when running `run_test` lint job, the job would fail annoyingly if there are changes to the python code in `torch/testing`, for example https://github.com/pytorch/pytorch/actions/runs/7571783765/job/20620100484#step:5:17 where `TEST_WITH_XPU` is introduced.

For the purpose of this lint job, we can take the python code from the PR instead of nightly, no compilation is needed.

This is proven to be working in https://github.com/pytorch/pytorch/pull/115752, but that PR is not yet landed.  This is also better to land this separately because they are unrelated.