### PR TITLE
Change to fix cuda python in environments that don't support nvrtc

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -37,17 +37,20 @@ default_compiler_flags = [
     "-DUSE_FBGEMM",
     "-DUSE_QNNPACK",
     "-DUSE_PYTORCH_QNNPACK",
-    # The dynamically loaded NVRTC trick doesn't work in fbcode,
-    # and it's not necessary anyway, because we have a stub
-    # nvrtc library which we load canonically anyway
-    "-DUSE_DIRECT_NVRTC",
     "-DUSE_RUY_QMATMUL",
 ] + select({
     # XNNPACK depends on an updated version of pthreadpool interface, whose implementation
     # includes <pthread.h> - a header not available on Windows.
     "DEFAULT": ["-DUSE_XNNPACK"],
     "ovr_config//os:windows": [],
-}) + (["-O1"] if native.read_config("fbcode", "build_mode_test_label", "") == "dev-nosan" else [])
+}) + (["-O1"] if native.read_config("fbcode", "build_mode_test_label", "") == "dev-nosan" else []
+) + (
+    # The dynamically loaded NVRTC trick doesn't work in fbcode,
+    # and it's not necessary anyway, because we have a stub
+    # nvrtc library which we load canonically anyway
+    # use '-c fbcode.skip_using_direct_nvrtc=1' to turn off direct nvrtc
+    ["-DUSE_DIRECT_NVRTC"] if not native.read_config("fbcode", "skip_using_direct_nvrtc", None) else []
+)
 
 compiler_specific_flags = {
     "clang": [


### PR DESCRIPTION
Summary: This change moves the compile flag to turn on direct nvrts to allow turning it off from the command line. This enables python par files built using buck to work outside of the prod environment while maintaining the default functionality.

Test Plan:
```
[gstocek:/data/users/gstocek/fbsource/fbcode/frl/agios/agios_model_service/cuda_test: (09b77d096)]$ buck2 build --show-output @//mode/opt  //frl/agios/agios_model_service/cuda_test:cuda_test_py
Buck UI: https://www.internalfb.com/buck2/6e19c9f0-6cc0-4668-b0fb-c8397887512f
Network: Up: 68MiB  Down: 29MiB  (reSessionID-ff55217d-ba16-4db9-b3fa-f9aa0e5c678c)
Jobs completed: 56620. Time elapsed: 6:46.1s.
Cache hits: 90%. Commands: 958 (cached: 862, remote: 88, local: 8)
BUILD SUCCEEDED
fbcode//frl/agios/agios_model_service/cuda_test:cuda_test_py buck-out/v2/gen/fbcode/cb6d26f9d2128d3d/frl/agios/agios_model_service/cuda_test/__cuda_test_py__/cuda_test_py.par
```
running on a pod in the cluster:
```
(base) gstocek@gstocek-mbp frl-conductor-grounding-dino % kubectl exec --stdin --tty frl-conductor-grounding-dino -- /bin/bash
(ctrldev) bash-5.1# /cuda_test_py.par
torch version is 2.2.0a0+fb
gpu is available ? : True
device count : 1
Traceback (most recent call last):
  File "/usr/local/fbcode/platform010/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/fbcode/platform010/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/cuda_test_py.par/__main__.py", line 973, in <module>
  File "/cuda_test_py.par/__main__.py", line 970, in __invoke_main
  File "/cuda_test_py.par/__main__.py", line 596, in main
  File "__par__/meta_only/bootstrap.py", line 60, in run_as_main
  File "__par__/bootstrap.py", line 51, in run_as_main
  File "/usr/local/fbcode/platform010/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/fbcode/platform010/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "frl/agios/agios_model_service/cuda_test/test.py", line 14, in <module>
  File "frl/agios/agios_model_service/cuda_test/test.py", line 10, in main
  File "torch/cuda/__init__.py", line 419, in get_device_name
  File "torch/cuda/__init__.py", line 449, in get_device_properties
  File "torch/cuda/__init__.py", line 298, in _lazy_init
RuntimeError: CUDA driver error: unknown error
```

building with the flag:
```
[gstocek:/data/users/gstocek/fbsource/fbcode/frl/agios/agios_model_service/cuda_test: (09b77d096)]$ buck2 build --show-output @//mode/opt -c fbcode.skip_using_direct_nvrtc=1 //frl/agios/agios_model_service/cuda_test:cuda_test_py
Buck UI: https://www.internalfb.com/buck2/6e19c9f0-6cc0-4668-b0fb-c8397887512f
Network: Up: 68MiB  Down: 29MiB  (reSessionID-ff55217d-ba16-4db9-b3fa-f9aa0e5c678c)
Jobs completed: 56620. Time elapsed: 6:46.1s.
Cache hits: 90%. Commands: 958 (cached: 862, remote: 88, local: 8)
BUILD SUCCEEDED
fbcode//frl/agios/agios_model_service/cuda_test:cuda_test_py buck-out/v2/gen/fbcode/cb6d26f9d2128d3d/frl/agios/agios_model_service/cuda_test/__cuda_test_py__/cuda_test_py.par
```
then running again in the cluster:
```
(ctrldev) bash-5.1# /cuda_test_py.par
torch version is 2.2.0a0+fb
gpu is available ? : True
device count : 1
name : NVIDIA A100-SXM4-80GB
```

Reviewed By: malfet

Differential Revision: D50365612

