### PR TITLE
Remove AWS credentials and fix update-pytorch-labels workflow

### DIFF
--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -66,7 +66,7 @@ jobs:
         uses: ./.github/actions/setup-rocm
 
       - name: configure aws credentials
-        fix-update-pytorch-labelid: aws_creds
+        id: aws_creds
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -66,7 +66,7 @@ jobs:
         uses: ./.github/actions/setup-rocm
 
       - name: configure aws credentials
-        id: aws_creds
+        fix-update-pytorch-labelid: aws_creds
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only

--- a/.github/workflows/update_pytorch_labels.yml
+++ b/.github/workflows/update_pytorch_labels.yml
@@ -11,6 +11,9 @@ concurrency:
 jobs:
   update-labels-in-S3:
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
     if: ${{ github.repository == 'pytorch/pytorch' }}
     steps:
       - name: Checkout PyTorch

--- a/.github/workflows/update_pytorch_labels.yml
+++ b/.github/workflows/update_pytorch_labels.yml
@@ -18,10 +18,14 @@ jobs:
         with:
           fetch-depth: 1
           submodules: false
+
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only
+          aws-region: us-east-1
+
       - name: Update PyTorch labels list in S3
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
         run: |
           python3 -m pip install boto3==1.19.12
           .github/scripts/export_pytorch_labels.py pytorch pytorch


### PR DESCRIPTION
It's failing in trunk https://github.com/pytorch/pytorch/actions/runs/7575989719/job/20633812527 after repo secrets are cleaned up today.

### Testing

https://github.com/pytorch/pytorch/actions/runs/7576771318/job/20636262074