### PR TITLE
[release-only] docker build validations build docker with pytorch-test channel specified

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -26,7 +26,11 @@ env:
   DOCKER_REGISTRY: ghcr.io
   NO_BUILD_SUFFIX: true
   USE_BUILDX: 1
-  WITH_PUSH: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || (startsWith(github.event.ref, 'refs/tags/') && !startsWith(github.event.ref, 'refs/tags/ciflow/'))) }}
+  WITH_PUSH: |
+    ${{ (github.event_name == 'push' &&
+        (github.event.ref == 'refs/heads/nightly' || (startsWith(github.event.ref, 'refs/tags/') && !startsWith(github.event.ref, 'refs/tags/ciflow/')))) ||
+        (github.event_name == 'workflow_dispatch' && github.event.ref == 'refs/heads/release/2.2')
+     }}
 
 jobs:
   generate-matrix:
@@ -50,7 +54,13 @@ jobs:
   build:
     if: ${{ github.repository == 'pytorch/pytorch' }}
     runs-on: [self-hosted, linux.2xlarge]
-    environment: ${{ (github.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v')) && 'docker-build' || '' }}
+    environment: |
+      ${{
+        (github.ref == 'refs/heads/main' ||
+        startsWith(github.event.ref, 'refs/tags/v') ||
+        (github.event_name == 'workflow_dispatch' && github.event.ref == 'refs/heads/release/2.2'))
+        && 'docker-build' || ''
+      }}
     timeout-minutes: 240
     needs: generate-matrix
     strategy:
@@ -99,6 +109,14 @@ jobs:
           echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
           # Generate PyTorch version to use
           echo "PYTORCH_VERSION=$(python3 .github/scripts/generate_pytorch_version.py --no-build-suffix)" >> "${GITHUB_ENV}"
+      - name: Setup test specific variables
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.ref == 'refs/heads/release/2.2' }}
+        run: |
+          {
+            echo "DOCKER_IMAGE=pytorch-test";
+            echo "INSTALL_CHANNEL=pytorch-test";
+            echo "TRITON_VERSION=$(cut -f 1 .ci/docker/triton_version.txt)";
+          } >> "${GITHUB_ENV}"
       - name: Setup nightly specific variables
         if: ${{ github.event.ref == 'refs/heads/nightly' || startsWith(github.event.ref, 'refs/tags/ciflow/nightly/') }}
         run: |

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -27,9 +27,10 @@ env:
   NO_BUILD_SUFFIX: true
   USE_BUILDX: 1
   WITH_PUSH: |
-    ${{ (github.event_name == 'push' &&
-        (github.event.ref == 'refs/heads/nightly' || (startsWith(github.event.ref, 'refs/tags/') && !startsWith(github.event.ref, 'refs/tags/ciflow/')))) ||
-        (github.event_name == 'workflow_dispatch' && github.event.ref == 'refs/heads/release/2.2')
+    ${{
+      (github.event_name == 'push' &&
+      (github.event.ref == 'refs/heads/nightly' || (startsWith(github.event.ref, 'refs/tags/') && !startsWith(github.event.ref, 'refs/tags/ciflow/')))) ||
+      (github.event_name == 'workflow_dispatch' && github.event.ref == 'refs/heads/release/2.2')
      }}
 
 jobs:
@@ -56,8 +57,7 @@ jobs:
     runs-on: [self-hosted, linux.2xlarge]
     environment: |
       ${{
-        (github.ref == 'refs/heads/main' ||
-        startsWith(github.event.ref, 'refs/tags/v') ||
+        (github.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v') ||
         (github.event_name == 'workflow_dispatch' && github.event.ref == 'refs/heads/release/2.2'))
         && 'docker-build' || ''
       }}


### PR DESCRIPTION
We would like to complete validations of PyTorch official images

For future releases we should change this to:
Build using pytorch channel on tag: v[0-9]+.[0-9]+.[0-9]+ 
Build using pytorch test channel on tag: v[0-9]+.[0-9]+.[0-9]+-rc?