### PR TITLE
[CI] Build M1 conda binaries on M1 runners

### DIFF
--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -342,7 +342,8 @@ MACOS_BINARY_BUILD_WORKFLOWS = [
     BinaryBuildWorkflow(
         os=OperatingSystem.MACOS_ARM64,
         package_type="conda",
-        cross_compile_arm64=True,
+        cross_compile_arm64=False,
+        macos_runner="macos-13-xlarge",
         build_configs=generate_binary_build_matrix.generate_conda_matrix(
             OperatingSystem.MACOS_ARM64
         ),

--- a/.github/workflows/generated-macos-arm64-binary-conda-nightly.yml
+++ b/.github/workflows/generated-macos-arm64-binary-conda-nightly.yml
@@ -27,8 +27,6 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   SKIP_ALL_TESTS: 1
-  CROSS_COMPILE_ARM64: 1
-
 concurrency:
   group: macos-arm64-binary-conda-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
@@ -36,7 +34,7 @@ concurrency:
 jobs:
   conda-py3_8-cpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: macos-12-xl
+    runs-on: macos-13-xlarge
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
@@ -154,7 +152,7 @@ jobs:
     uses: ./.github/workflows/_binary-upload.yml
   conda-py3_9-cpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: macos-12-xl
+    runs-on: macos-13-xlarge
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
@@ -272,7 +270,7 @@ jobs:
     uses: ./.github/workflows/_binary-upload.yml
   conda-py3_10-cpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: macos-12-xl
+    runs-on: macos-13-xlarge
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
@@ -390,7 +388,7 @@ jobs:
     uses: ./.github/workflows/_binary-upload.yml
   conda-py3_11-cpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: macos-12-xl
+    runs-on: macos-13-xlarge
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
@@ -508,7 +506,7 @@ jobs:
     uses: ./.github/workflows/_binary-upload.yml
   conda-py3_12-cpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: macos-12-xl
+    runs-on: macos-13-xlarge
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch


### PR DESCRIPTION
As usual, almost no work on PyTorch side, all changes are on the builder end, namely:
- https://github.com/pytorch/builder/commit/8b67d32929b950c4851066800f5ef57c7646994c - depend on `blas * mkl` only on x86 machines
- https://github.com/pytorch/builder/commit/eb78393f1e4bd68134d87e4059b9b25194af7dbb - install arm64 conda when running on Apple Silicon
- https://github.com/pytorch/builder/commit/0d3aea4ee08e00b76fc263ce58e4c10df9f58e44 - constrain llvmdev-9 to x86 machines only
- https://github.com/pytorch/builder/commit/6c6a33b2712bdb4be4406a10f75e3a404541ccd7 - set correct DEVELOPER_DIR path 

TODO:
 - We should auto-detect this `DEVELOPER_DIR` via `xcode-select`