### PR TITLE
[dynamo] add username in debug path

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -1,3 +1,4 @@
+import getpass
 import inspect
 import os
 import re
@@ -292,7 +293,7 @@ if DEBUG_DIR_VAR_NAME in os.environ:
     )
 elif is_fbcode():
     debug_dir_root = os.path.join(  # [@compile_ignored: debug]
-        tempfile.gettempdir(), "torch_compile_debug"
+        tempfile.gettempdir(), getpass.getuser(), "torch_compile_debug"
     )
 else:
     debug_dir_root = os.path.join(  # [@compile_ignored: debug]


### PR DESCRIPTION
Summary: No user name may cause conflict and permission error when people share a dev server

bypass-github-pytorch-ci-checks

Test Plan: ci

Differential Revision: D52895486



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng