### PR TITLE
move disable_cudagraph_reason disabling after codecache is accessed

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -799,11 +799,14 @@ class CompiledFxGraph:
 
     _boxed_call: Optional[bool] = None
 
+    disabled_cudagraphs_reason: Optional[str] = None
+
     def __init__(
         self,
         compiled_artifact: Optional[Callable[..., Any]],
         graph: GraphLowering,
         output_strides: List[Optional[Tuple[int, ...]]],
+        disabled_cudagraphs_reason: Optional[str],
     ):
         self.compiled_artifact = compiled_artifact
         self.cache_key = graph.cache_key
@@ -816,6 +819,7 @@ class CompiledFxGraph:
         self.constants = graph.constants
         self.output_strides = output_strides
         self.guards_expr = None
+        self.disabled_cudagraphs_reason = disabled_cudagraphs_reason
 
     def __call__(self, inputs: List[Any]) -> Any:
         return self.get_current_callable()(inputs)

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -329,6 +329,12 @@ def compile_fx_inner(
     if aot_mode:
         return compiled_graph
 
+    if cudagraphs and compiled_graph.disabled_cudagraphs_reason:
+        perf_hint_log.warning(
+            "skipping cudagraphs due to %s", compiled_graph.disabled_cudagraphs_reason
+        )
+        BoxedBool.disable(cudagraphs)
+
     if cudagraphs:
         # output args are tuple of first argument
         output = list(gm.graph.nodes)[-1]
@@ -553,13 +559,9 @@ def fx_codegen_and_compile(
             if V.aot_compilation is True:
                 return compiled_fn
 
-            if cudagraphs and graph.disable_cudagraphs:
-                perf_hint_log.warning(
-                    "skipping cudagraphs due to %s", V.graph.disable_cudagraphs_reason
-                )
-                BoxedBool.disable(cudagraphs)
-
-            compiled_graph = CompiledFxGraph(compiled_fn, graph, output_strides)
+            compiled_graph = CompiledFxGraph(
+                compiled_fn, graph, output_strides, V.graph.disable_cudagraphs_reason
+            )
 
     return compiled_graph
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #117720
* __->__ #117823

Disabling cudagraphs has to happen after a codecache loading or it wont properly be disabled on a cache hit.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler

Differential Revision: [D52896590](https://our.internmc.facebook.com/intern/diff/D52896590)