### PR TITLE
[MPS] Fix lintear for 5D tensors

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -4425,7 +4425,10 @@ def sample_inputs_linear(self, device, dtype, requires_grad, **kwargs):
     input_tensor = create_tensor(2, 1, 2, 1, 2)
     weight = create_tensor(4, 2)
     yield SampleInput(input_tensor, weight)
-    yield SampleInput(input_tensor, weight, create_tensor(4))
+    # Hide for now from test_neg_view/test_conj_view
+    # See https://github.com/pytorch/pytorch/issues/117854
+    if dtype in [torch.float32, torch.float16]:
+        yield SampleInput(input_tensor, weight, create_tensor(4))
 
 def sample_inputs_bilinear(self, device, dtype, requires_grad, **kwargs):
     features_options = [[3, 4, 5], [8, 8, 8]]

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -4421,6 +4421,12 @@ def sample_inputs_linear(self, device, dtype, requires_grad, **kwargs):
         bias = create_tensor([out_feat])
         yield SampleInput(input_tensor, weight, bias)
 
+    # 5D tensor, used to crash on MPS, see https://github.com/pytorch/pytorch/issues/114942
+    input_tensor = create_tensor(2, 1, 2, 1, 2)
+    weight = create_tensor(4, 2)
+    yield SampleInput(input_tensor, weight)
+    yield SampleInput(input_tensor, weight, create_tensor(4))
+
 def sample_inputs_bilinear(self, device, dtype, requires_grad, **kwargs):
     features_options = [[3, 4, 5], [8, 8, 8]]
     batch_options: List[List[int]] = [


### PR DESCRIPTION
torch.nn.Linear crashes with internal assert if invoked with 5D tensors,
due to the bug in MPS framework, i.e. invoking
```swift
import MetalPerformanceShadersGraph

let graph = MPSGraph()
let x = graph.constant(1, shape: [2, 1, 2, 1, 2], dataType: .float32)
let y = graph.constant(1, shape: [2, 3], dataType: .float32)
let z = graph.matrixMultiplication(primary: x, secondary: y, name: nil)
let device = MTLCreateSystemDefaultDevice()!
let buf = device.makeBuffer(length: 48)!
let td = MPSGraphTensorData(buf, shape: [2, 1, 2, 1, 3], dataType: .int32)
let cmdBuf = MPSCommandBuffer(from: device.makeCommandQueue()!)
graph.encode(to: cmdBuf, feeds: [:], targetOperations: nil, resultsDictionary: [z:td], executionDescriptor: nil)
cmdBuf.commit()
```
crashes with
```
AppleInternal/Library/BuildRoots/0032d1ee-80fd-11ee-8227-6aecfccc70fe/Library/Caches/com.apple.xbs/Sources/MetalPerformanceShaders/MPSNDArray/Kernels/MPSNDArrayIdentity.mm:813: failed assertion `New volume: 4 should match old volume: 8 [reshapeWithCommandBuffer] MPSNDArrayIdentity.'
zsh: abort      ./build/matmul
```

Workaround the issue by flattening the forward and backward tensors if number of dimentions is greater than 4

Add regression tests to Linear opinfo samples

Fixes https://github.com/pytorch/pytorch/issues/114942
