### PR TITLE
Enable Optimized Performance Boost for 2D Forward Convolution with Channel Last

### DIFF
--- a/aten/src/ATen/native/mkldnn/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/Conv.cpp
@@ -329,7 +329,15 @@ Tensor mkldnn_convolution(
     IntArrayRef stride,
     IntArrayRef dilation,
     int64_t groups) {
-  bool use_channels_last = mkldnn_conv_use_channels_last(input_t, weight_t);
+  bool use_channels_last;
+  // Enables Channel last layout for 2D Convolution with Float datatype.
+  // Boosts performance by calling forward convolution with channel last (NHWC).
+  if (input_t.scalar_type() == at::kFloat &&  input_t.ndimension()==4 && (!(input_t.is_mkldnn() || weight_t.is_mkldnn()))) {
+      use_channels_last =true;
+  }
+  else {
+      use_channels_last = mkldnn_conv_use_channels_last(input_t, weight_t);
+  }
   return _mkldnn_convolution(
       input_t,
       weight_t,


### PR DESCRIPTION
Through code flow analysis, it has been observed that there is notable overhead in convolution operations arising from the mkldnn-to-dense function, particularly when the channel is not last. To address this bottleneck and enhance overall efficiency, this pull request (PR) proposes a change: sending input data to oneDNN in the NHWC (channel last) format. This adjustment is designed to bypass the mkldnn-to-dense function, effectively eliminating the reorder operation in oneDNN for format conversion. This will reduce the execution time of convolution operations, leading to accelerated performance.
The motivation is to specifically enable the forward convolution pass, showcasing an immediate impact on performance.
This PR will impact performance in the following scenarios:
1) 2D Convolution: The proposed change targets the optimization of 2D convolution operations.
2) Forward Convolution: By calling forward convolution with NHWC, this change aims to boost the performance of the forward convolution pass.
The below table shows the performance of convolution-based model: DETR in graviton3 and same behaviour is seen in Icelake as well.

<table>
  <tr>
    <th>Model/Time(ms)</th>
    <th>Without this change</th>
    <th>With this change</th>
  </tr>
  <tr>
    <td>DETR</td>
    <td>1982.4</td>
    <td>1318.8</td>
  </tr>
  
</table>
Same performance behaviour is observed in other models and different convolution shapes.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @frank-wei @milpuz01 @VitalyFedyunin