### PR TITLE
fused adam(w): Reduce register usage

### DIFF
--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -26,7 +26,7 @@ template <
     int depth = 1,
     int r_args_depth = 1,
     int res_arg_index = 0,
-    typename index_t = int64_t>
+    typename index_t = uint64_t>
 struct LpNormFunctor {
   static_assert(
       NormType == 1 || NormType == 2,

--- a/aten/src/ATen/native/cuda/MultiTensorApply.cuh
+++ b/aten/src/ATen/native/cuda/MultiTensorApply.cuh
@@ -142,7 +142,7 @@ void multi_tensor_apply(
       tensor_lists[0].cbegin(),
       tensor_lists[0].cend(),
       [](const auto& t) -> bool {
-        return t.numel() > std::numeric_limits<int32_t>::max();
+        return t.numel() > std::numeric_limits<uint32_t>::max();
       });
 
   int loc_block_info = 0;
@@ -188,7 +188,7 @@ void multi_tensor_apply(
             kBlockSize,
             0,
             at::cuda::getCurrentCUDAStream()>>>(
-            needs_64bits_for_indexing ? static_cast<int64_t>(kChunkSize)
+            needs_64bits_for_indexing ? static_cast<uint64_t>(kChunkSize)
                                       : kChunkSize,
             tensorListMeta,
             callable,
@@ -224,7 +224,7 @@ void multi_tensor_apply(
         kBlockSize,
         0,
         at::cuda::getCurrentCUDAStream()>>>(
-        needs_64bits_for_indexing ? static_cast<int64_t>(kChunkSize)
+        needs_64bits_for_indexing ? static_cast<uint64_t>(kChunkSize)
                                   : kChunkSize,
         tensorListMeta,
         callable,
@@ -249,7 +249,7 @@ void multi_tensor_apply(
       tensor_lists[0].cbegin(),
       tensor_lists[0].cend(),
       [](const auto& t) -> bool {
-        return t.numel() > std::numeric_limits<int32_t>::max();
+        return t.numel() > std::numeric_limits<uint32_t>::max();
       });
 
   int loc_block_info = 0;
@@ -287,7 +287,7 @@ void multi_tensor_apply(
             kBlockSize,
             0,
             at::cuda::getCurrentCUDAStream()>>>(
-            needs_64bits_for_indexing ? static_cast<int64_t>(kChunkSize)
+            needs_64bits_for_indexing ? static_cast<uint64_t>(kChunkSize)
                                       : kChunkSize,
             tensorListMeta,
             callable,
@@ -320,7 +320,7 @@ void multi_tensor_apply(
         kBlockSize,
         0,
         at::cuda::getCurrentCUDAStream()>>>(
-        needs_64bits_for_indexing ? static_cast<int64_t>(kChunkSize)
+        needs_64bits_for_indexing ? static_cast<uint64_t>(kChunkSize)
                                   : kChunkSize,
         tensorListMeta,
         callable,
@@ -345,7 +345,7 @@ void multi_tensor_apply_for_fused_optimizer(
       tensor_lists[0].cbegin(),
       tensor_lists[0].cend(),
       [](const auto& t) -> bool {
-        return t.numel() > std::numeric_limits<int32_t>::max();
+        return t.numel() > std::numeric_limits<uint32_t>::max();
       });
 
   int loc_block_info = 0;
@@ -385,7 +385,7 @@ void multi_tensor_apply_for_fused_optimizer(
             kBlockSize,
             0,
             at::cuda::getCurrentCUDAStream()>>>(
-            needs_64bits_for_indexing ? static_cast<int64_t>(kChunkSize)
+            needs_64bits_for_indexing ? static_cast<uint64_t>(kChunkSize)
                                       : kChunkSize,
             tensorListMeta,
             callable,
@@ -418,7 +418,7 @@ void multi_tensor_apply_for_fused_optimizer(
         kBlockSize,
         0,
         at::cuda::getCurrentCUDAStream()>>>(
-        needs_64bits_for_indexing ? static_cast<int64_t>(kChunkSize)
+        needs_64bits_for_indexing ? static_cast<uint64_t>(kChunkSize)
                                   : kChunkSize,
         tensorListMeta,
         callable,

--- a/aten/src/ATen/native/cuda/fused_adam_amsgrad_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adam_amsgrad_impl.cu
@@ -30,11 +30,11 @@ void _fused_adam_amsgrad_cuda_impl_(
       exp_avg_sqs.vec(),
       max_exp_avg_sqs.vec()};
 
-  float* grad_scale_ptr =
+  const float* grad_scale_ptr =
       grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  float* found_inf_ptr =
+  const float* found_inf_ptr =
       found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  float* lr_ptr = nullptr;
+  const float* lr_ptr = nullptr;
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kHalf,
@@ -81,11 +81,11 @@ void _fused_adam_amsgrad_cuda_impl_(
       exp_avg_sqs.vec(),
       max_exp_avg_sqs.vec()};
 
-  float* grad_scale_ptr =
+  const float* grad_scale_ptr =
       grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  float* found_inf_ptr =
+  const float* found_inf_ptr =
       found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  float* lr_ptr = lr.data_ptr<float>();
+  const float* lr_ptr = lr.data_ptr<float>();
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kHalf,

--- a/aten/src/ATen/native/cuda/fused_adam_amsgrad_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adam_amsgrad_impl.cu
@@ -45,7 +45,7 @@ void _fused_adam_amsgrad_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ORIGINAL>(),
+            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ORIGINAL, true>(),
             lr_ptr, // unused
             lr,
             beta1,
@@ -53,7 +53,6 @@ void _fused_adam_amsgrad_cuda_impl_(
             weight_decay,
             eps,
             maximize,
-            /* amsgrad */ true,
             grad_scale_ptr,
             found_inf_ptr);
       });
@@ -97,7 +96,7 @@ void _fused_adam_amsgrad_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ORIGINAL>(),
+            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ORIGINAL, true>(),
             lr_ptr,
             1.0, // unused
             beta1,
@@ -105,7 +104,6 @@ void _fused_adam_amsgrad_cuda_impl_(
             weight_decay,
             eps,
             maximize,
-            /* amsgrad */ true,
             grad_scale_ptr,
             found_inf_ptr);
       });

--- a/aten/src/ATen/native/cuda/fused_adam_amsgrad_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adam_amsgrad_impl.cu
@@ -45,7 +45,7 @@ void _fused_adam_amsgrad_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 5>(),
+            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ORIGINAL>(),
             lr_ptr, // unused
             lr,
             beta1,
@@ -55,8 +55,7 @@ void _fused_adam_amsgrad_cuda_impl_(
             maximize,
             /* amsgrad */ true,
             grad_scale_ptr,
-            found_inf_ptr,
-            ADAM_MODE::ORIGINAL);
+            found_inf_ptr);
       });
 }
 
@@ -98,7 +97,7 @@ void _fused_adam_amsgrad_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 5>(),
+            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ORIGINAL>(),
             lr_ptr,
             1.0, // unused
             beta1,
@@ -108,8 +107,7 @@ void _fused_adam_amsgrad_cuda_impl_(
             maximize,
             /* amsgrad */ true,
             grad_scale_ptr,
-            found_inf_ptr,
-            ADAM_MODE::ORIGINAL);
+            found_inf_ptr);
       });
 }
 

--- a/aten/src/ATen/native/cuda/fused_adam_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adam_impl.cu
@@ -40,7 +40,7 @@ void _fused_adam_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 4>(),
+            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ORIGINAL>(),
             lr_ptr, // unused
             lr,
             beta1,
@@ -50,8 +50,7 @@ void _fused_adam_cuda_impl_(
             maximize,
             /* amsgrad */ false,
             grad_scale_ptr,
-            found_inf_ptr,
-            ADAM_MODE::ORIGINAL);
+            found_inf_ptr);
       });
 }
 
@@ -88,7 +87,7 @@ void _fused_adam_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 4>(),
+            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ORIGINAL>(),
             lr_ptr,
             1.0, // unused
             beta1,
@@ -98,8 +97,7 @@ void _fused_adam_cuda_impl_(
             maximize,
             /* amsgrad */ false,
             grad_scale_ptr,
-            found_inf_ptr,
-            ADAM_MODE::ORIGINAL);
+            found_inf_ptr);
       });
 }
 

--- a/aten/src/ATen/native/cuda/fused_adam_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adam_impl.cu
@@ -25,11 +25,11 @@ void _fused_adam_cuda_impl_(
   std::vector<std::vector<at::Tensor>> tensor_lists{
       params.vec(), grads.vec(), exp_avgs.vec(), exp_avg_sqs.vec()};
 
-  float* grad_scale_ptr =
+  const float* grad_scale_ptr =
       grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  float* found_inf_ptr =
+  const float* found_inf_ptr =
       found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  float* lr_ptr = nullptr;
+  const float* lr_ptr = nullptr;
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kHalf,
@@ -71,11 +71,11 @@ void _fused_adam_cuda_impl_(
   std::vector<std::vector<at::Tensor>> tensor_lists{
       params.vec(), grads.vec(), exp_avgs.vec(), exp_avg_sqs.vec()};
 
-  float* grad_scale_ptr =
+  const float* grad_scale_ptr =
       grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  float* found_inf_ptr =
+  const float* found_inf_ptr =
       found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  float* lr_ptr = lr.data_ptr<float>();
+  const float* lr_ptr = lr.data_ptr<float>();
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kHalf,

--- a/aten/src/ATen/native/cuda/fused_adam_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adam_impl.cu
@@ -40,7 +40,7 @@ void _fused_adam_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ORIGINAL>(),
+            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ORIGINAL, false>(),
             lr_ptr, // unused
             lr,
             beta1,
@@ -48,7 +48,6 @@ void _fused_adam_cuda_impl_(
             weight_decay,
             eps,
             maximize,
-            /* amsgrad */ false,
             grad_scale_ptr,
             found_inf_ptr);
       });
@@ -87,7 +86,7 @@ void _fused_adam_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ORIGINAL>(),
+            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ORIGINAL, false>(),
             lr_ptr,
             1.0, // unused
             beta1,
@@ -95,7 +94,6 @@ void _fused_adam_cuda_impl_(
             weight_decay,
             eps,
             maximize,
-            /* amsgrad */ false,
             grad_scale_ptr,
             found_inf_ptr);
       });

--- a/aten/src/ATen/native/cuda/fused_adamw_amsgrad_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adamw_amsgrad_impl.cu
@@ -46,7 +46,7 @@ void _fused_adamw_amsgrad_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ADAMW>(),
+            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ADAMW, true>(),
             lr_ptr, // unused
             lr,
             beta1,
@@ -54,7 +54,6 @@ void _fused_adamw_amsgrad_cuda_impl_(
             weight_decay,
             eps,
             maximize,
-            /* amsgrad */ true,
             grad_scale_ptr,
             found_inf_ptr);
       });
@@ -98,7 +97,7 @@ void _fused_adamw_amsgrad_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ADAMW>(),
+            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ADAMW, true>(),
             lr_ptr,
             1.0, // unused
             beta1,
@@ -106,7 +105,6 @@ void _fused_adamw_amsgrad_cuda_impl_(
             weight_decay,
             eps,
             maximize,
-            /* amsgrad */ true,
             grad_scale_ptr,
             found_inf_ptr);
       });

--- a/aten/src/ATen/native/cuda/fused_adamw_amsgrad_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adamw_amsgrad_impl.cu
@@ -46,7 +46,7 @@ void _fused_adamw_amsgrad_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 5>(),
+            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ADAMW>(),
             lr_ptr, // unused
             lr,
             beta1,
@@ -56,8 +56,7 @@ void _fused_adamw_amsgrad_cuda_impl_(
             maximize,
             /* amsgrad */ true,
             grad_scale_ptr,
-            found_inf_ptr,
-            ADAM_MODE::ADAMW);
+            found_inf_ptr);
       });
 }
 
@@ -99,7 +98,7 @@ void _fused_adamw_amsgrad_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 5>(),
+            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ADAMW>(),
             lr_ptr,
             1.0, // unused
             beta1,
@@ -109,8 +108,7 @@ void _fused_adamw_amsgrad_cuda_impl_(
             maximize,
             /* amsgrad */ true,
             grad_scale_ptr,
-            found_inf_ptr,
-            ADAM_MODE::ADAMW);
+            found_inf_ptr);
       });
 }
 

--- a/aten/src/ATen/native/cuda/fused_adamw_amsgrad_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adamw_amsgrad_impl.cu
@@ -31,11 +31,11 @@ void _fused_adamw_amsgrad_cuda_impl_(
       exp_avg_sqs.vec(),
       max_exp_avg_sqs.vec()};
 
-  float* grad_scale_ptr =
+  const float* grad_scale_ptr =
       grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  float* found_inf_ptr =
+  const float* found_inf_ptr =
       found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  float* lr_ptr = nullptr;
+  const float* lr_ptr = nullptr;
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kHalf,
@@ -82,11 +82,11 @@ void _fused_adamw_amsgrad_cuda_impl_(
       exp_avg_sqs.vec(),
       max_exp_avg_sqs.vec()};
 
-  float* grad_scale_ptr =
+  const float* grad_scale_ptr =
       grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  float* found_inf_ptr =
+  const float* found_inf_ptr =
       found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  float* lr_ptr = lr.data_ptr<float>();
+  const float* lr_ptr = lr.data_ptr<float>();
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kHalf,

--- a/aten/src/ATen/native/cuda/fused_adamw_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adamw_impl.cu
@@ -41,7 +41,7 @@ void _fused_adamw_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 4>(),
+            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ADAMW>(),
             lr_ptr, // unused
             lr,
             beta1,
@@ -51,8 +51,7 @@ void _fused_adamw_cuda_impl_(
             maximize,
             /* amsgrad */ false,
             grad_scale_ptr,
-            found_inf_ptr,
-            ADAM_MODE::ADAMW);
+            found_inf_ptr);
       });
 }
 
@@ -89,7 +88,7 @@ void _fused_adamw_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 4>(),
+            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ADAMW>(),
             lr_ptr,
             1.0, // unused
             beta1,
@@ -99,8 +98,7 @@ void _fused_adamw_cuda_impl_(
             maximize,
             /* amsgrad */ false,
             grad_scale_ptr,
-            found_inf_ptr,
-            ADAM_MODE::ADAMW);
+            found_inf_ptr);
       });
 }
 

--- a/aten/src/ATen/native/cuda/fused_adamw_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adamw_impl.cu
@@ -26,11 +26,11 @@ void _fused_adamw_cuda_impl_(
   std::vector<std::vector<at::Tensor>> tensor_lists{
       params.vec(), grads.vec(), exp_avgs.vec(), exp_avg_sqs.vec()};
 
-  float* grad_scale_ptr =
+  const float* grad_scale_ptr =
       grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  float* found_inf_ptr =
+  const float* found_inf_ptr =
       found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  float* lr_ptr = nullptr;
+  const float* lr_ptr = nullptr;
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kHalf,
@@ -72,11 +72,11 @@ void _fused_adamw_cuda_impl_(
   std::vector<std::vector<at::Tensor>> tensor_lists{
       params.vec(), grads.vec(), exp_avgs.vec(), exp_avg_sqs.vec()};
 
-  float* grad_scale_ptr =
+  const float* grad_scale_ptr =
       grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  float* found_inf_ptr =
+  const float* found_inf_ptr =
       found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  float* lr_ptr = lr.data_ptr<float>();
+  const float* lr_ptr = lr.data_ptr<float>();
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kHalf,

--- a/aten/src/ATen/native/cuda/fused_adamw_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adamw_impl.cu
@@ -41,7 +41,7 @@ void _fused_adamw_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ADAMW>(),
+            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ADAMW, false>(),
             lr_ptr, // unused
             lr,
             beta1,
@@ -49,7 +49,6 @@ void _fused_adamw_cuda_impl_(
             weight_decay,
             eps,
             maximize,
-            /* amsgrad */ false,
             grad_scale_ptr,
             found_inf_ptr);
       });
@@ -88,7 +87,7 @@ void _fused_adamw_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ADAMW>(),
+            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ADAMW, false>(),
             lr_ptr,
             1.0, // unused
             beta1,
@@ -96,7 +95,6 @@ void _fused_adamw_cuda_impl_(
             weight_decay,
             eps,
             maximize,
-            /* amsgrad */ false,
             grad_scale_ptr,
             found_inf_ptr);
       });


### PR DESCRIPTION
As per title, reducing register usage for better occupancy.

Changes are:
- use 32bit indexing if possible
- convert some arguments of fused adam(w) functor to its template parameters
- give `const` to some arguments

Tables below are before/after of adamw for sm90 with / without amsgrad enabled.

### without amsgrad
| dtype | main | this PR |
|-------|------|---------|
| bf16  | 79   | 64      |
| fp16  | 82   | 64      |
| fp32  | 126  | 64      |
| fp64  | 128  | 109     |

### with amsgrad
| dtype | main | this PR |
|-------|------|---------|
| bf16  | 124  | 74      |
| fp16  | 124  | 74      |
| fp32  | 123  | 76      |
| fp64  | 128  | 121     |

---

`AdamW(..., fused=True)` with llama-2 bf16 on H100 improved to 49.935ms of cuda avg time from 126.648ms according to torch profiler.

This PR:
```
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
                                                   Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg       CPU Mem  Self CPU Mem      CUDA Mem  Self CUDA Mem    # of Calls
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
                                          ProfilerStep*         0.00%       0.000us         0.00%       0.000us       0.000us        5.878s        46.47%        5.878s     293.918ms           0 b           0 b           0 b           0 b            20
                                               aten::mm         2.57%     224.777ms         8.50%     741.993ms      54.962us        2.591s        20.48%        2.591s     191.910us           0 b           0 b     441.39 Gb     441.39 Gb         13500
                                          ProfilerStep*        31.64%        2.763s        67.67%        5.910s     295.485ms       0.000us         0.00%        2.551s     127.547ms      48.00 Kb      -1.44 Mb           0 b    -506.38 Gb            20
       autograd::engine::evaluate_function: MmBackward0         0.13%      11.349ms         7.90%     690.160ms     153.369us       0.000us         0.00%        1.726s     383.544us           0 b           0 b     198.65 Gb    -137.53 Gb          4500
                                            MmBackward0         0.45%      38.959ms         7.68%     670.399ms     148.978us       0.000us         0.00%        1.693s     376.326us           0 b           0 b     332.81 Gb       2.26 Gb          4500
                              Optimizer.step#AdamW.step         0.00%       0.000us         0.00%       0.000us       0.000us        1.012s         8.00%        1.012s      50.617ms           0 b           0 b           0 b           0 b            20
                                             AdamW.step         0.01%     846.000us         3.39%     296.240ms      14.812ms       0.000us         0.00%     998.876ms      49.944ms           0 b           0 b           0 b           0 b            20
                              Optimizer.step#AdamW.step         0.26%      23.113ms         3.38%     295.394ms      14.770ms       0.000us         0.00%     998.876ms      49.944ms           0 b           0 b           0 b           0 b            20
                                    aten::_fused_adamw_         0.13%      11.000ms         3.08%     268.545ms      13.427ms     998.705ms         7.89%     998.705ms      49.935ms           0 b           0 b           0 b           0 b            20
void at::native::(anonymous namespace)::multi_tensor...         0.00%       0.000us         0.00%       0.000us       0.000us     998.705ms         7.89%     998.705ms     155.078us           0 b           0 b           0 b           0 b          6440
sm90_xmma_gemm_bf16bf16_bf16f32_f32_nt_n_tilesize128...         0.00%       0.000us         0.00%       0.000us       0.000us     872.287ms         6.90%     872.287ms     193.842us           0 b           0 b           0 b           0 b          4500
                                           aten::matmul         0.19%      16.721ms         1.82%     159.130ms      35.362us       0.000us         0.00%     864.840ms     192.187us           0 b           0 b     107.46 Gb           0 b          4500
                                           aten::linear         0.28%      24.641ms         2.09%     182.129ms      40.473us       0.000us         0.00%     765.554ms     170.123us           0 b           0 b     107.46 Gb      12.46 Gb          4500
sm90_xmma_gemm_bf16bf16_bf16f32_f32_tn_n_tilesize128...         0.00%       0.000us         0.00%       0.000us       0.000us     690.729ms         5.46%     690.729ms     178.945us           0 b           0 b           0 b           0 b          3860
                                              aten::mul         1.36%     118.465ms         4.89%     427.071ms      21.225us     549.580ms         4.34%     549.697ms      27.320us     224.03 Kb     223.96 Kb     413.51 Gb     413.36 Gb         20121
sm90_xmma_gemm_bf16bf16_bf16f32_f32_nn_n_tilesize128...         0.00%       0.000us         0.00%       0.000us       0.000us     484.455ms         3.83%     484.455ms     151.392us           0 b           0 b           0 b           0 b          3200
      autograd::engine::evaluate_function: MulBackward0         0.27%      23.176ms         4.63%     404.534ms      69.747us       0.000us         0.00%     406.155ms      70.027us           0 b           0 b     -46.01 Gb    -257.12 Gb          5800
                                             aten::add_         0.39%      34.186ms         7.22%     630.849ms      54.384us     394.402ms         3.12%     394.402ms      34.000us           0 b           0 b      -6.68 Gb      -6.68 Gb         11600
sm90_xmma_gemm_bf16bf16_bf16f32_f32_nn_n_tilesize256...         0.00%       0.000us         0.00%       0.000us       0.000us     366.653ms         2.90%     366.653ms     282.041us           0 b           0 b           0 b           0 b          1300
                                            aten::copy_         0.41%      35.934ms        20.61%        1.800s     147.691us     341.572ms         2.70%     341.572ms      28.025us      48.00 Kb      48.00 Kb     -40.00 Mb     -40.00 Mb         12188
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 8.733s
Self CUDA time total: 12.651s

AdamW.step <FunctionEventAvg key=AdamW.step self_cpu_time=846.000us cpu_time=14.812ms  self_cuda_time=0.000us cuda_time=49.944ms input_shapes= cpu_memory_usage=0 cuda_memory_usage=0>
Optimizer.step#AdamW.step <FunctionEventAvg key=Optimizer.step#AdamW.step self_cpu_time=23.113ms cpu_time=14.770ms  self_cuda_time=0.000us cuda_time=49.944ms input_shapes= cpu_memory_usage=0 cuda_memory_usage=0>
Optimizer.step#AdamW.step <FunctionEventAvg key=Optimizer.step#AdamW.step self_cpu_time=0.000us cpu_time=0.000us  self_cuda_time=1.012s cuda_time=50.617ms input_shapes= cpu_memory_usage=0 cuda_memory_usage=0>

```

Main
```
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
                                                   Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg       CPU Mem  Self CPU Mem      CUDA Mem  Self CUDA Mem    # of Calls
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
                                          ProfilerStep*         0.00%       0.000us         0.00%       0.000us       0.000us        7.354s        42.89%        7.354s     367.698ms           0 b           0 b           0 b           0 b            20
                                          ProfilerStep*        28.22%        2.875s        72.48%        7.384s     369.184ms       0.000us         0.00%        4.067s     203.325ms      48.00 Kb      -1.48 Mb           0 b    -508.04 Gb            20
                                               aten::mm         2.24%     228.499ms         7.13%     726.223ms      53.794us        2.563s        14.95%        2.563s     189.873us           0 b           0 b     441.39 Gb     441.39 Gb         13500
                              Optimizer.step#AdamW.step         0.00%       0.000us         0.00%       0.000us       0.000us        2.546s        14.85%        2.546s     127.304ms           0 b           0 b           0 b           0 b            20
                                             AdamW.step         0.01%     821.000us         2.87%     292.871ms      14.644ms       0.000us         0.00%        2.533s     126.654ms           0 b           0 b           0 b           0 b            20
                              Optimizer.step#AdamW.step         0.22%      22.801ms         2.87%     292.050ms      14.602ms       0.000us         0.00%        2.533s     126.654ms           0 b           0 b           0 b           0 b            20
                                    aten::_fused_adamw_         0.11%      11.332ms         2.61%     265.853ms      13.293ms        2.533s        14.77%        2.533s     126.648ms           0 b           0 b           0 b           0 b            20
void at::native::(anonymous namespace)::multi_tensor...         0.00%       0.000us         0.00%       0.000us       0.000us        2.533s        14.77%        2.533s     393.315us           0 b           0 b           0 b           0 b          6440
       autograd::engine::evaluate_function: MmBackward0         0.13%      13.342ms         6.73%     685.250ms     152.278us       0.000us         0.00%        1.706s     379.209us           0 b           0 b     198.65 Gb    -138.02 Gb          4500
                                            MmBackward0         0.38%      38.974ms         6.52%     664.652ms     147.700us       0.000us         0.00%        1.675s     372.113us           0 b           0 b     333.59 Gb       2.75 Gb          4500
sm90_xmma_gemm_bf16bf16_bf16f32_f32_nt_n_tilesize128...         0.00%       0.000us         0.00%       0.000us       0.000us     859.515ms         5.01%     859.515ms     191.003us           0 b           0 b           0 b           0 b          4500
                                           aten::matmul         0.16%      16.431ms         1.49%     152.052ms      33.789us       0.000us         0.00%     856.839ms     190.409us           0 b           0 b     107.46 Gb           0 b          4500
                                           aten::linear         0.23%      23.703ms         1.72%     174.862ms      38.858us       0.000us         0.00%     758.995ms     168.666us           0 b           0 b     107.46 Gb      12.21 Gb          4500
sm90_xmma_gemm_bf16bf16_bf16f32_f32_tn_n_tilesize128...         0.00%       0.000us         0.00%       0.000us       0.000us     682.302ms         3.98%     682.302ms     176.762us           0 b           0 b           0 b           0 b          3860
                                              aten::mul         1.16%     117.854ms         4.12%     420.100ms      20.892us     544.045ms         3.17%     544.157ms      27.062us     240.38 Kb     240.34 Kb     419.45 Gb     419.29 Gb         20108
sm90_xmma_gemm_bf16bf16_bf16f32_f32_nn_n_tilesize128...         0.00%       0.000us         0.00%       0.000us       0.000us     479.767ms         2.80%     479.767ms     149.927us           0 b           0 b           0 b           0 b          3200
      autograd::engine::evaluate_function: MulBackward0         0.27%      27.303ms         3.95%     402.627ms      69.418us       0.000us         0.00%     403.020ms      69.486us           0 b           0 b     -45.56 Gb    -257.26 Gb          5800
                                             aten::add_         0.32%      32.543ms         6.08%     619.248ms      53.383us     393.242ms         2.29%     393.242ms      33.900us           0 b           0 b      -6.21 Gb      -6.21 Gb         11600
sm90_xmma_gemm_bf16bf16_bf16f32_f32_nn_n_tilesize256...         0.00%       0.000us         0.00%       0.000us       0.000us     363.245ms         2.12%     363.245ms     279.419us           0 b           0 b           0 b           0 b          1300
void at::native::vectorized_elementwise_kernel<4, at...         0.00%       0.000us         0.00%       0.000us       0.000us     338.460ms         1.97%     338.460ms      29.228us           0 b           0 b           0 b           0 b         11580
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 10.187s
Self CUDA time total: 17.145s

AdamW.step <FunctionEventAvg key=AdamW.step self_cpu_time=821.000us cpu_time=14.644ms  self_cuda_time=0.000us cuda_time=126.654ms input_shapes= cpu_memory_usage=0 cuda_memory_usage=0>
Optimizer.step#AdamW.step <FunctionEventAvg key=Optimizer.step#AdamW.step self_cpu_time=22.801ms cpu_time=14.602ms  self_cuda_time=0.000us cuda_time=126.654ms input_shapes= cpu_memory_usage=0 cuda_memory_usage=0>
Optimizer.step#AdamW.step <FunctionEventAvg key=Optimizer.step#AdamW.step self_cpu_time=0.000us cpu_time=0.000us  self_cuda_time=2.546s cuda_time=127.304ms input_shapes= cpu_memory_usage=0 cuda_memory_usage=0>
```

Script I used: https://gist.github.com/crcrpar/ca951d4e7f3e1c771d502135b798f0d1

<!--

## adamw

### This PR

```console
$ cuobjdump ./build/caffe2/CMakeFiles/torch_cuda.dir/__/aten/src/ATen/native/cuda/fused_adamw_impl.cu.o -xelf all
Extracting ELF file    1: fused_adamw_impl.sm_70.cubin
Extracting ELF file    2: fused_adamw_impl.sm_80.cubin
Extracting ELF file    3: fused_adamw_impl.sm_90.cubin
$ cuobjdump -res-usage fused_adamw_impl.sm_90.cubin | cu++filt

Resource usage:
 Common:
  GLOBAL:3
 Function void at::native::<unnamed>::multi_tensor_apply_kernel<long, at::native::<unnamed>::FusedOptimizerTensorListMetadata<(int)4>, at::native::<unnamed>::FusedAdamMathFunctor<c10::BFloat16, (int)4, (at::native::ADAM_MODE)1, (bool)0>, const float *, double, double, double, double, double, bool, const float *, const float *>(T1, T2, T3, T4...):
  REG:64 STACK:8 SHARED:0 LOCAL:0 CONSTANT[0]:3952 TEXTURE:0 SURFACE:0 SAMPLER:0
 Function void at::native::<unnamed>::multi_tensor_apply_kernel<long, at::native::<unnamed>::FusedOptimizerTensorListMetadata<(int)4>, at::native::<unnamed>::FusedAdamMathFunctor<c10::Half, (int)4, (at::native::ADAM_MODE)1, (bool)0>, const float *, double, double, double, double, double, bool, const float *, const float *>(T1, T2, T3, T4...):
  REG:64 STACK:8 SHARED:0 LOCAL:0 CONSTANT[0]:3952 TEXTURE:0 SURFACE:0 SAMPLER:0
 Function void at::native::<unnamed>::multi_tensor_apply_kernel<long, at::native::<unnamed>::FusedOptimizerTensorListMetadata<(int)4>, at::native::<unnamed>::FusedAdamMathFunctor<float, (int)4, (at::native::ADAM_MODE)1, (bool)0>, const float *, double, double, double, double, double, bool, const float *, const float *>(T1, T2, T3, T4...):
  REG:64 STACK:0 SHARED:0 LOCAL:0 CONSTANT[0]:3952 TEXTURE:0 SURFACE:0 SAMPLER:0
 Function void at::native::<unnamed>::multi_tensor_apply_kernel<long, at::native::<unnamed>::FusedOptimizerTensorListMetadata<(int)4>, at::native::<unnamed>::FusedAdamMathFunctor<double, (int)4, (at::native::ADAM_MODE)1, (bool)0>, const float *, double, double, double, double, double, bool, const float *, const float *>(T1, T2, T3, T4...):
  REG:109 STACK:0 SHARED:0 LOCAL:0 CONSTANT[0]:3952 TEXTURE:0 SURFACE:0 SAMPLER:0
```

### Main

```console
$ cuobjdump ./build/caffe2/CMakeFiles/torch_cuda.dir/__/aten/src/ATen/native/cuda/fused_adamw_impl.cu.o -xelf all
Extracting ELF file    1: fused_adamw_impl.cu.1.sm_70.cubin
Extracting ELF file    2: fused_adamw_impl.cu.2.sm_80.cubin
Extracting ELF file    3: fused_adamw_impl.cu.3.sm_90.cubin
$ cuobjdump -res-usage fused_adamw_impl.cu.3.sm_90.cubin | cu++filt

Resource usage:
 Common:
  GLOBAL:3
 Function void at::native::<unnamed>::multi_tensor_apply_kernel<at::native::<unnamed>::FusedOptimizerTensorListMetadata<(int)4>, at::native::<unnamed>::FusedAdamMathFunctor<c10::BFloat16, (int)4>, float *, double, double, double, double, double, bool, bool, float *, float *, at::native::ADAM_MODE>(T1, T2, T3...):
  REG:79 STACK:0 SHARED:0 LOCAL:0 CONSTANT[0]:3945 TEXTURE:0 SURFACE:0 SAMPLER:0
 Function void at::native::<unnamed>::multi_tensor_apply_kernel<at::native::<unnamed>::FusedOptimizerTensorListMetadata<(int)4>, at::native::<unnamed>::FusedAdamMathFunctor<c10::Half, (int)4>, float *, double, double, double, double, double, bool, bool, float *, float *, at::native::ADAM_MODE>(T1, T2, T3...):
  REG:82 STACK:0 SHARED:0 LOCAL:0 CONSTANT[0]:3945 TEXTURE:0 SURFACE:0 SAMPLER:0
 Function void at::native::<unnamed>::multi_tensor_apply_kernel<at::native::<unnamed>::FusedOptimizerTensorListMetadata<(int)4>, at::native::<unnamed>::FusedAdamMathFunctor<float, (int)4>, float *, double, double, double, double, double, bool, bool, float *, float *, at::native::ADAM_MODE>(T1, T2, T3...):
  REG:126 STACK:0 SHARED:0 LOCAL:0 CONSTANT[0]:3945 TEXTURE:0 SURFACE:0 SAMPLER:0
 Function void at::native::<unnamed>::multi_tensor_apply_kernel<at::native::<unnamed>::FusedOptimizerTensorListMetadata<(int)4>, at::native::<unnamed>::FusedAdamMathFunctor<double, (int)4>, float *, double, double, double, double, double, bool, bool, float *, float *, at::native::ADAM_MODE>(T1, T2, T3...):
  REG:128 STACK:40 SHARED:0 LOCAL:0 CONSTANT[0]:3945 TEXTURE:0 SURFACE:0 SAMPLER:0
```

## adamw & amsgrad
### This PR
```console
root@1a5180b041f7:/opt/pytorch/pytorch# cuobjdump ./build/caffe2/CMakeFiles/torch_cuda.dir/__/aten/src/ATen/native/cuda/fused_adamw_amsgrad_impl.cu.o -xelf all
Extracting ELF file    1: fused_adamw_amsgrad_impl.sm_70.cubin
Extracting ELF file    2: fused_adamw_amsgrad_impl.sm_80.cubin
Extracting ELF file    3: fused_adamw_amsgrad_impl.sm_90.cubin
root@1a5180b041f7:/opt/pytorch/pytorch# cuobjdump -res-usage fused_adamw_amsgrad_impl.sm_90.cubin

Resource usage:
 Common:
  GLOBAL:3
 Function void at::native::<unnamed>::multi_tensor_apply_kernel<long, at::native::<unnamed>::FusedOptimizerTensorListMetadata<(int)5>, at::native::<unnamed>::FusedAdamMathFunctor<c10::BFloat16, (int)5, (at::native::ADAM_MODE)1, (bool)1>, const float *, double, double, double, double, double, bool, const float *, const float *>(T1, T2, T3, T4...):
  REG:74 STACK:0 SHARED:0 LOCAL:0 CONSTANT[0]:3904 TEXTURE:0 SURFACE:0 SAMPLER:0
 Function void at::native::<unnamed>::multi_tensor_apply_kernel<long, at::native::<unnamed>::FusedOptimizerTensorListMetadata<(int)5>, at::native::<unnamed>::FusedAdamMathFunctor<c10::Half, (int)5, (at::native::ADAM_MODE)1, (bool)1>, const float *, double, double, double, double, double, bool, const float *, const float *>(T1, T2, T3, T4...):
  REG:74 STACK:0 SHARED:0 LOCAL:0 CONSTANT[0]:3904 TEXTURE:0 SURFACE:0 SAMPLER:0
 Function void at::native::<unnamed>::multi_tensor_apply_kernel<long, at::native::<unnamed>::FusedOptimizerTensorListMetadata<(int)5>, at::native::<unnamed>::FusedAdamMathFunctor<float, (int)5, (at::native::ADAM_MODE)1, (bool)1>, const float *, double, double, double, double, double, bool, const float *, const float *>(T1, T2, T3, T4...):
  REG:76 STACK:0 SHARED:0 LOCAL:0 CONSTANT[0]:3904 TEXTURE:0 SURFACE:0 SAMPLER:0
 Function void at::native::<unnamed>::multi_tensor_apply_kernel<long, at::native::<unnamed>::FusedOptimizerTensorListMetadata<(int)5>, at::native::<unnamed>::FusedAdamMathFunctor<double, (int)5, (at::native::ADAM_MODE)1, (bool)1>, const float *, double, double, double, double, double, bool, const float *, const float *>(T1, T2, T3, T4...):
  REG:121 STACK:0 SHARED:0 LOCAL:0 CONSTANT[0]:3904 TEXTURE:0 SURFACE:0 SAMPLER:0
```


### Main
```console
root@7c40321796bc:/opt/pytorch/pytorch# cuobjdump ./build/caffe2/CMakeFiles/torch_cuda.dir/__/aten/src/ATen/native/cuda/fused_adamw_amsgrad_impl.cu.o -xelf all
Extracting ELF file    1: fused_adamw_amsgrad_impl.cu.1.sm_70.cubin
Extracting ELF file    2: fused_adamw_amsgrad_impl.cu.2.sm_80.cubin
Extracting ELF file    3: fused_adamw_amsgrad_impl.cu.3.sm_90.cubin
root@7c40321796bc:/opt/pytorch/pytorch# cuobjdump -res-usave fused_adamw_amsgrad_impl.cu.3.sm_90.cubin
cuobjdump fatal   : Unknown option 'res-usave'
root@7c40321796bc:/opt/pytorch/pytorch# cuobjdump -res-usage fused_adamw_amsgrad_impl.cu.3.sm_90.cubin

Resource usage:
 Common:
  GLOBAL:3
 Function void at::native::<unnamed>::multi_tensor_apply_kernel<at::native::<unnamed>::FusedOptimizerTensorListMetadata<(int)5>, at::native::<unnamed>::FusedAdamMathFunctor<c10::BFloat16, (int)5>, float *, double, double, double, double, double, bool, bool, float *, float *, at::native::ADAM_MODE>(T1, T2, T3...):
  REG:124 STACK:0 SHARED:0 LOCAL:0 CONSTANT[0]:3897 TEXTURE:0 SURFACE:0 SAMPLER:0
 Function void at::native::<unnamed>::multi_tensor_apply_kernel<at::native::<unnamed>::FusedOptimizerTensorListMetadata<(int)5>, at::native::<unnamed>::FusedAdamMathFunctor<c10::Half, (int)5>, float *, double, double, double, double, double, bool, bool, float *, float *, at::native::ADAM_MODE>(T1, T2, T3...):
  REG:124 STACK:0 SHARED:0 LOCAL:0 CONSTANT[0]:3897 TEXTURE:0 SURFACE:0 SAMPLER:0
 Function void at::native::<unnamed>::multi_tensor_apply_kernel<at::native::<unnamed>::FusedOptimizerTensorListMetadata<(int)5>, at::native::<unnamed>::FusedAdamMathFunctor<float, (int)5>, float *, double, double, double, double, double, bool, bool, float *, float *, at::native::ADAM_MODE>(T1, T2, T3...):
  REG:123 STACK:0 SHARED:0 LOCAL:0 CONSTANT[0]:3897 TEXTURE:0 SURFACE:0 SAMPLER:0
 Function void at::native::<unnamed>::multi_tensor_apply_kernel<at::native::<unnamed>::FusedOptimizerTensorListMetadata<(int)5>, at::native::<unnamed>::FusedAdamMathFunctor<double, (int)5>, float *, double, double, double, double, double, bool, bool, float *, float *, at::native::ADAM_MODE>(T1, T2, T3...):
  REG:128 STACK:40 SHARED:0 LOCAL:0 CONSTANT[0]:3897 TEXTURE:0 SURFACE:0 SAMPLER:0
```

-->