### PR TITLE
[ONNX] Add bfloat16 support for scaled_dot_product_attention

### DIFF
--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -191,6 +191,7 @@ def scaled_dot_product_attention(
     elif _type_utils.JitScalarType.from_value(attn_mask) in (
         _type_utils.JitScalarType.FLOAT,
         _type_utils.JitScalarType.HALF,
+        _type_utils.JitScalarType.BFLOAT16,
     ):
         mul_qk_add = g.op("Add", mul_qk, attn_mask)
     else:


### PR DESCRIPTION
Using ONNX opset 14, the aten scaled_dot_product_attention oeprator can be implemented with bfloat16 support because Add-14 does support bfloat16

This PR simply add bfloat16 to the list of supported types