### PR TITLE
[export] Allow constant outputs + None input/outputs

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -2293,60 +2293,6 @@ def forward(self, x):
         out_graph = exported[0]
         self.assertTrue(torch._dynamo.utils.same(torch.ones(3, 3), out_graph()))
 
-    def test_none_out(self):
-        def f(x, y):
-            _ = x + y
-
-        with self.assertRaisesRegex(
-            UserError,
-            "It looks like one of the outputs with type .*None.* "
-            "is not supported or pytree-flattenable",
-        ):
-            torch._dynamo.export(f, aten_graph=False)(torch.randn(10), torch.randn(10))
-
-    def test_primitive_constant_output(self):
-        class Foo(torch.nn.Module):
-            def forward(self, x):
-                # return a constant of primitive type
-                y = 5
-                return y * x, y
-
-        foo = Foo()
-
-        with self.assertRaisesRegex(
-            UserError,
-            "It looks like one of the outputs with type .*int.* "
-            "is not supported or pytree-flattenable",
-        ):
-            torch.export.export(foo, (torch.tensor(3),))
-
-        class Bar(torch.nn.Module):
-            def forward(self, x, y):
-                return y * x, y
-
-        bar = Bar()
-
-        # new behavior
-        with self.assertRaisesRegex(
-            UserError,
-            "It looks like one of the outputs with type .*int.* "
-            "is not supported or pytree-flattenable",
-        ):
-            torch.export.export(bar, (torch.tensor(3), 5))
-
-        class Qux(torch.nn.Module):
-            def forward(self, x, y):
-                return y * x, y - 1
-
-        qux = Qux()
-
-        with self.assertRaisesRegex(
-            UserError,
-            "It looks like one of the outputs with type .*int.* "
-            "is not supported or pytree-flattenable",
-        ):
-            torch.export.export(qux, (torch.tensor(3), 5))
-
     @unittest.skipIf(not TEST_CUDA, "No CUDA available.")
     def test_export_with_parameters(self):
         class MyModule(torch.nn.Module):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -2885,6 +2885,74 @@ def forward(self, l_q_, l_k_, l_v_):
     getitem = _scaled_dot_product_flash_attention[0];  _scaled_dot_product_flash_attention = None
     return (getitem,)""")
 
+    def test_primitive_constant_output(self):
+        class Z(torch.nn.Module):
+            def forward(self, x, y):
+                return y * x
+
+        ep = torch.export.export(Z(), (torch.tensor(3), 5))
+        res = ep(torch.tensor(4), 5)
+        self.assertEqual(res, torch.tensor(20))
+
+        class B(torch.nn.Module):
+            def forward(self, x, y):
+                return y * x, y
+
+        ep = torch.export.export(B(), (torch.tensor(3), 5))
+        res = ep(torch.tensor(4), 5)
+        self.assertEqual(res[0], torch.tensor(20))
+        self.assertEqual(res[1], 5)
+
+        with self.assertRaisesRegex(RuntimeError, "Expected input arg1 to be equal to 5, but got 20"):
+            res = ep(torch.tensor(4), 20)
+
+        class F(torch.nn.Module):
+            def forward(self, x):
+                # return a constant of primitive type
+                y = 5
+                return y * x, y
+
+        ep = torch.export.export(F(), (torch.tensor(3),))
+        res = ep(torch.tensor(4))
+        self.assertEqual(res[0], torch.tensor(20))
+        self.assertEqual(res[1], 5)
+
+        class Q(torch.nn.Module):
+            def forward(self, x, y):
+                return y * x, y - 1
+
+        ep = torch.export.export(Q(), (torch.tensor(3), 5))
+        res = ep(torch.tensor(4), 5)
+        self.assertEqual(res[0], torch.tensor(20))
+        self.assertEqual(res[1], 4)
+
+    def test_none_input_output(self):
+        class Z(torch.nn.Module):
+            def forward(self, x, y):
+                return x * x
+
+        ep = torch.export.export(Z(), (torch.tensor(3), None))
+        res = ep(torch.tensor(4), None)
+        self.assertEqual(res, torch.tensor(16))
+
+        class B(torch.nn.Module):
+            def forward(self, x, y):
+                return x * x, y
+
+        ep = torch.export.export(B(), (torch.tensor(3), None))
+        res = ep(torch.tensor(4), None)
+        self.assertEqual(res[0], torch.tensor(16))
+        self.assertEqual(res[1], None)
+
+        decomp = ep.run_decompositions()
+        res = decomp(torch.tensor(4), None)
+        self.assertEqual(res[0], torch.tensor(16))
+        self.assertEqual(res[1], None)
+
+        gm = decomp.module()
+        res = gm(torch.tensor(4), None)
+        self.assertEqual(res[0], torch.tensor(16))
+        self.assertEqual(res[1], None)
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")
 class TestExportCustomClass(TorchTestCase):

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -70,7 +70,7 @@ from .code_context import code_context
 from .exc import CondOpArgsMismatchError, UserError, UserErrorType
 from .mutation_guard import install_generation_tagging_init
 from .types import CacheEntry, DynamoCallback
-from .utils import compile_times
+from .utils import common_constant_types, compile_times
 
 log = logging.getLogger(__name__)
 
@@ -813,6 +813,7 @@ class FlattenInputOutputSignature(torch.fx.interpreter.Transformer):
         m: torch.fx.GraphModule,
         flat_args: Tuple[Any],
         matched_input_elements_positions: List[int],
+        flat_results: List[Any],
         matched_output_elements_positions: List[int],
         example_fake_inputs: List[torch.Tensor],
         flat_args_dynamic_dims: List[Set[int]],
@@ -851,6 +852,7 @@ class FlattenInputOutputSignature(torch.fx.interpreter.Transformer):
             self.new_args.append(arg)
         self.old_args_gen = (self.new_args[i] for i in matched_input_elements_positions)
         self.matched_output_elements_positions = matched_output_elements_positions
+        self.flat_results = flat_results
 
     def placeholder(self, target, args, kwargs):
         arg = next(self.old_args_gen)
@@ -865,8 +867,17 @@ class FlattenInputOutputSignature(torch.fx.interpreter.Transformer):
     def output(self, target, args, kwargs):
         dynamo_result_flat = args[0]
         lookup = [*dynamo_result_flat, *self.new_args]
-        new_result_flat = [lookup[i] for i in self.matched_output_elements_positions]
-        return super().output(target, (new_result_flat,), {})
+        new_results_flat = []
+        for i in range(len(self.flat_results)):
+            if self.matched_output_elements_positions[i] is not None:
+                new_results_flat.append(
+                    lookup[self.matched_output_elements_positions[i]]
+                )
+            else:
+                const_val = self.flat_results[i]
+                assert isinstance(const_val, tuple(common_constant_types))
+                new_results_flat.append(const_val)
+        return super().output(target, (new_results_flat,), {})
 
     def run_node(self, n):
         self.current_node = n
@@ -955,17 +966,6 @@ def rewrite_signature(
 ):
     orig_args, orig_kwargs = pytree.tree_unflatten(flat_args, in_spec)
 
-    constant_types = [
-        int,
-        str,
-        bool,
-        float,
-        torch.memory_format,
-        torch.device,
-        torch.dtype,
-        torch.layout,
-    ]
-
     def check_user_input_output(flat_values, error_type):
         supported_types = [
             torch.Tensor,
@@ -973,9 +973,7 @@ def rewrite_signature(
             torch.SymFloat,
             torch.SymBool,
             torch._C.ScriptObject,
-        ]
-        if error_type == UserErrorType.INVALID_INPUT:
-            supported_types.extend(constant_types)
+        ] + list(common_constant_types)
 
         def is_supported_type(val):
             return isinstance(val, tuple(supported_types))
@@ -1004,19 +1002,21 @@ def rewrite_signature(
     check_user_input_output(flat_results_traced, UserErrorType.INVALID_OUTPUT)
 
     def produce_matching(debug_type, sources, candidates):
-        matched_elements_positions = []
+        matched_elements_positions: List[Optional[int]] = []
         dict_of_source_vals = {}
         for i, val in enumerate(sources):
             dict_of_source_vals[id(val)] = i
 
         for i, val in enumerate(candidates):
-            if id(val) not in dict_of_source_vals:
+            if isinstance(val, tuple(common_constant_types)):
+                matched_elements_positions.append(None)
+            elif id(val) not in dict_of_source_vals:
                 raise AssertionError(
                     f"Unexpectedly found a {type(val)} in the {debug_type}.\n"
                     'Please file an issue along with a paste of the logs from TORCH_LOGS="+export"'
                 )
-
-            matched_elements_positions.append(dict_of_source_vals[id(val)])
+            else:
+                matched_elements_positions.append(dict_of_source_vals[id(val)])
 
         return matched_elements_positions
 
@@ -1033,6 +1033,7 @@ def rewrite_signature(
         graph,
         flat_args,
         matched_input_elements_positions,
+        flat_results_traced,
         matched_output_elements_positions,
         example_fake_inputs,
         flat_args_dynamic_dims,

--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -344,7 +344,10 @@ def _verify_exported_program_signature(exported_program) -> None:
     # Check outputs
     output_node = list(exported_program.graph.nodes)[-1]
     assert output_node.op == "output"
-    output_nodes = [arg.name for arg in output_node.args[0]]
+    output_nodes = [
+        arg.name if isinstance(arg, torch.fx.Node) else arg
+        for arg in output_node.args[0]
+    ]
 
     if len(output_nodes) != len(gs.output_specs):
         raise SpecViolationError(

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -423,7 +423,13 @@ def _export_non_strict(
     is_joint = graph_signature.backward_signature is not None
 
     def make_argument_spec(node) -> ArgumentSpec:
-        assert "val" in node.meta, f"{node} has no 'val' metadata field"
+        if isinstance(node, (int, bool, float, type(None))):
+            # For const outputs we just directly return this
+            return ConstantArgument(value=node)
+
+        assert (
+            "val" in node.meta
+        ), f"{node} is not a constant or a node with a 'val' metadata field"
         val = node.meta["val"]
         if isinstance(val, FakeTensor):
             return TensorArgument(name=node.name)

--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -42,7 +42,11 @@ def _unlift(
             # In the case that the same node is returned multiple times,
             # node.all_input_nodes will only iterate that node once
             for return_node in pytree.tree_flatten(node.args)[0]:
-                return_node_name = return_node.name
+                return_node_name = (
+                    return_node.name
+                    if isinstance(return_node, torch.fx.Node)
+                    else return_node
+                )
                 # we found a param/buffer mutation
                 if return_node_name in buffers_to_mutate:
                     # TODO Fix situation here to replace dot with underscore...


### PR DESCRIPTION
Added support for constant outputs. We will just embed the constant directly into the output, like `return (x, 1)`.
Also adds support for None input/outputs. For None inputs we address it the same way we do to constants, which is that a placeholder with no users will be inserted into the graph, and the None will be embedded into whatever operator is using the None. For None outputs, we will also address the same way we do constants, which is that we embed it into the output, like `return (x, None)`.

Differential Revision: D52881070



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng