### PR TITLE
[ignore] make_fx support for NestedTensor

### DIFF
--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -896,7 +896,7 @@ class SubclassSymbolicContext(StatefulSymbolicContext):
 
 
 def is_symbolic(val: Union[int, SymInt, float, SymFloat, bool, SymBool]) -> bool:
-    if isinstance(val, (int, float, bool)):
+    if not isinstance(val, (SymInt, SymFloat, SymBool)):
         return False
     return val.node.is_symbolic()
 

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -287,6 +287,11 @@ class TracerBase:
             kwargs = {field.name: self.create_arg(getattr(a, field.name)) for field in fields(a)}
             return self.create_node("call_function", a.__class__, (), kwargs)
 
+        from torch.fx.experimental.symbolic_shapes import is_singleton, is_symbolic
+
+        if is_singleton(a) and not is_symbolic(a):
+            return a
+
         elif isinstance(a, (*base_types, enum.Enum)) or a is None or a is ...:
             return a
         raise NotImplementedError(f"argument of type: {type(a)}")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #117895
* #117412

Saving some work - This patch enables make_fx to trace through the NestedTensor torch dispatch for some examples. Not sure it works for everything. Also don't think this is incredibly high priority to land though.

```python
a = torch.randn(4, 6) # image 1
b = torch.randn(7, 6) # image 2
nt = torch.nested.nested_tensor([a, b], dtype=torch.float32, layout=torch.jagged, requires_grad=True)

def fn1(nt):
    out = torch.zeros(nt.shape)
    # print(nt.shape == nt.shape)
    out = torch.split_with_sizes(nt, [1, 2, 3], dim=2)
    unbound = out[1].unbind()
    x = unbound[1].sum()

    return out, x

out = make_fx(fn1)(nt)
print(out)
```

Output:
```python
def forward(self, nt_1):
    zeros = torch.ops.aten.zeros.default([11, 6], device = device(type='cpu'), pin_memory = False)
    _tensor_constant0 = self._tensor_constant0
    split_with_sizes = torch.ops.aten.split_with_sizes.default(_tensor_constant0, [1, 2, 3], 1);  _tensor_constant0 = None
    getitem = split_with_sizes[0]
    getitem_1 = split_with_sizes[1]
    getitem_2 = split_with_sizes[2];  split_with_sizes = None
    _tensor_constant1 = self._tensor_constant1
    slice_1 = torch.ops.aten.slice.Tensor(_tensor_constant1, -1, 1, 3);  _tensor_constant1 = None
    _tensor_constant1_1 = self._tensor_constant1
    slice_2 = torch.ops.aten.slice.Tensor(_tensor_constant1_1, -1, 0, 2);  _tensor_constant1_1 = None
    sub = torch.ops.aten.sub.Tensor(slice_1, slice_2);  slice_1 = slice_2 = None
    split_with_sizes_1 = torch.ops.aten.split_with_sizes.default(getitem_1, [4, 7]);  getitem_1 = None
    getitem_3 = split_with_sizes_1[0]
    getitem_4 = split_with_sizes_1[1];  split_with_sizes_1 = None
    sum_1 = torch.ops.aten.sum.default(getitem_4);  getitem_4 = None
    _tensor_constant2 = self._tensor_constant2
    _tensor_constant3 = self._tensor_constant3
    _tensor_constant4 = self._tensor_constant4
    return ((_tensor_constant2, _tensor_constant3, _tensor_constant4), sum_1)
```
