### PR TITLE
[test for float8]: make partitioner aware that saving params for bw has no memory cost

### DIFF
--- a/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
@@ -180,7 +180,7 @@ def aot_dispatch_autograd(
                 + inner_meta.num_outputs_rng_offset
             )
             fw_module, bw_module = aot_config.partition_fn(
-                fx_g, joint_inputs, num_fwd_outputs=num_inner_fwd_outputs
+                fx_g, joint_inputs, num_fwd_outputs=num_inner_fwd_outputs, num_params_buffers=aot_config.num_params_buffers,
             )
             fw_outs = next(n for n in fw_module.graph.nodes if n.op == "output").args[0]
             # we only need to bookkeep the symints that are saved for bw, not any symints


### PR DESCRIPTION
need to test that this helps float8 before thinking about whether this makes sense to land. If it does I'll describe the situation in more detail in the PR description

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #117898
* #117667
* #117666

