### PR TITLE
[dynamo] Slightly better error message if key not in dict

### DIFF
--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -205,6 +205,8 @@ class ConstDictVariable(VariableTracker):
 
     def getitem_const(self, arg: VariableTracker):
         key = ConstDictVariable._HashableTracker(arg)
+        if key not in self.items:
+            raise KeyError(arg.value)
         return self.items[key]
 
     def call_method(


### PR DESCRIPTION
Was debugging an export issue, and currently when `key` does not exist in `self.items`, the error message is 
```
  File "/opt/pytorch/torch/_dynamo/variables/dicts.py", line 208, in getitem_const
    return self.items[key]
           ~~~~~~~~~~^^^^^
torch._dynamo.exc.InternalTorchDynamoError: <torch._dynamo.variables.dicts.ConstDictVariable._HashableTracker object at 0x7fd7697cbf90>
```
This PR changes it to be the following. 
```
File "/data/users/angelayi/pytorch/torch/_dynamo/variables/dicts.py", line 199, in getitem_const
    raise KeyError(arg.value)
torch._dynamo.exc.InternalTorchDynamoError: shape
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng