### PR TITLE
Replace `constraints` with `dynamic_shapes` in scripts/sijiac/prototypes and test/inductor

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -7,7 +7,6 @@ import unittest
 from typing import Dict, Tuple
 
 import torch
-import torch._export
 import torch._inductor
 from torch._dynamo.testing import same
 from torch._dynamo.utils import counters
@@ -15,6 +14,7 @@ from torch._inductor import config
 from torch._inductor.exc import CppWrapperCodeGenError
 from torch._inductor.utils import cache_dir
 
+from torch.export import Dim, export
 from torch.testing import FileCheck
 from torch.testing._internal import common_utils
 from torch.testing._internal.common_cuda import SM80OrLater
@@ -66,7 +66,7 @@ def check_model(
     model,
     example_inputs,
     options=None,
-    constraints=None,
+    dynamic_shapes=None,
     disable_constraint_solver=False,
 ):
     with torch.no_grad(), config.patch(
@@ -88,7 +88,7 @@ def check_model(
             model,
             example_inputs,
             options,
-            constraints,
+            dynamic_shapes,
             disable_constraint_solver,
         )
 
@@ -100,7 +100,7 @@ def check_model_with_multiple_inputs(
     model,
     list_example_inputs,
     options=None,
-    constraints=None,
+    dynamic_shapes=None,
 ):
     with torch.no_grad(), config.patch(
         {
@@ -116,7 +116,7 @@ def check_model_with_multiple_inputs(
 
         torch.manual_seed(0)
         list_actual = AOTIRunnerUtil.run_multiple(
-            self.device, model, list_example_inputs, options, constraints
+            self.device, model, list_example_inputs, options, dynamic_shapes
         )
 
     self.assertTrue(same(list_actual, list_expected))
@@ -466,15 +466,12 @@ class AOTInductorTestsTemplate:
                 add_0 = x + y
                 return torch.nn.functional.relu(input=add_0, inplace=False)
 
-        a = torch.randn(128, 2048, device=self.device)
-        b = torch.randn(128, 2048, device=self.device)
-        constraints = [
-            torch._export.dynamic_dim(a, 0) >= 1,
-            torch._export.dynamic_dim(a, 0) <= 2048,
-            torch._export.dynamic_dim(a, 0) == torch._export.dynamic_dim(b, 0),
-        ]
-        example_inputs = (a, b)
-        self.check_model(Model(), example_inputs, constraints=constraints)
+        x = torch.randn(128, 2048, device=self.device)
+        y = torch.randn(128, 2048, device=self.device)
+        dim0_x = Dim("dim0_x", min=1, max=2048)
+        dynamic_shapes = {"x": {0: dim0_x}, "y": {0: dim0_x}}
+        example_inputs = (x, y)
+        self.check_model(Model(), example_inputs, dynamic_shapes=dynamic_shapes)
 
     @unittest.skipIf(
         not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0),
@@ -511,14 +508,12 @@ class AOTInductorTestsTemplate:
 
         x_shape = (16, 16)
         x = torch.rand(*x_shape, device="cuda", dtype=dtype).to(torch.float8_e4m3fn)
-        constraints = [
-            torch._export.dynamic_dim(x, 0) >= 1,
-            torch._export.dynamic_dim(x, 0) <= 2048,
-        ]
+        dim0_x = Dim("dim0_x", min=1, max=2048)
+        dynamic_shapes = ({0: dim0_x}, None, None, None, None)
         self.check_model(
             Model(dtype),
             (x, weight, input_bias, a_inverse_scale, b_inverse_scale),
-            constraints=constraints,
+            dynamic_shapes=dynamic_shapes,
         )
 
     def test_poi_multiple_dynamic(self):
@@ -530,14 +525,11 @@ class AOTInductorTestsTemplate:
                 add_0 = x + y
                 return torch.nn.functional.relu(input=add_0, inplace=False)
 
-        a = torch.randn(128, 2048, device=self.device)
-        b = torch.randn(128, 2048, device=self.device)
-        constraints = [
-            torch._export.dynamic_dim(a, 0) >= 1,
-            torch._export.dynamic_dim(a, 0) <= 2048,
-            torch._export.dynamic_dim(a, 0) == torch._export.dynamic_dim(b, 0),
-        ]
-        list_example_inputs = [(a, b)]
+        x = torch.randn(128, 2048, device=self.device)
+        y = torch.randn(128, 2048, device=self.device)
+        dim0_x = Dim("dim0_x", min=1, max=2048)
+        dynamic_shapes = {"x": {0: dim0_x}, "y": {0: dim0_x}}
+        list_example_inputs = [(x, y)]
         list_example_inputs.append(
             (
                 torch.randn(64, 2048, device=self.device),
@@ -551,7 +543,7 @@ class AOTInductorTestsTemplate:
             ),
         )
         self.check_model_with_multiple_inputs(
-            Model(), list_example_inputs, constraints=constraints
+            Model(), list_example_inputs, dynamic_shapes=dynamic_shapes
         )
 
     def test_addmm_multiple_dynamic(self):
@@ -570,10 +562,8 @@ class AOTInductorTestsTemplate:
         model = Model(N, K, self.device)
         batch = 2
         a = torch.randn(batch, M, K, device=self.device)
-        constraints = [
-            torch._export.dynamic_dim(a, 0) >= 1,
-            torch._export.dynamic_dim(a, 0) <= 2048,
-        ]
+        dim0_a = Dim("dim0_a", min=1, max=2048)
+        dynamic_shapes = {"a": {0: dim0_a}}
         list_example_inputs = [(a,)]
         batch = 2048
         list_example_inputs.append(
@@ -586,7 +576,7 @@ class AOTInductorTestsTemplate:
         self.check_model_with_multiple_inputs(
             model,
             list_example_inputs,
-            constraints=constraints,
+            dynamic_shapes=dynamic_shapes,
             options={
                 "max_autotune": True,
                 "max_autotune_gemm_backends": "TRITON",
@@ -608,11 +598,8 @@ class AOTInductorTestsTemplate:
         batch = 1024
         a = torch.randn(batch, M, K, device=self.device)
         b = torch.randn(batch, K, N, device=self.device)
-        constraints = [
-            torch._export.dynamic_dim(a, 0) >= 1,
-            torch._export.dynamic_dim(a, 0) <= 2048,
-            torch._export.dynamic_dim(a, 0) == torch._export.dynamic_dim(b, 0),
-        ]
+        dim0_a = Dim("dim0_a", min=1, max=2048)
+        dynamic_shapes = {"a": {0: dim0_a}, "b": {0: dim0_a}}
         list_example_inputs = [(a, b)]
         batch = 2048
         list_example_inputs.append(
@@ -635,7 +622,7 @@ class AOTInductorTestsTemplate:
                 "max_autotune": True,
                 "max_autotune_gemm_backends": "TRITON",
             },
-            constraints=constraints,
+            dynamic_shapes=dynamic_shapes,
         )
 
     def test_foreach_multiple_dynamic(self):
@@ -650,14 +637,11 @@ class AOTInductorTestsTemplate:
                 return cat
 
         model = Model()
-        a = torch.randn(128, 2048, device=self.device)
-        b = torch.randn(128, 2048, device=self.device)
-        constraints = [
-            torch._export.dynamic_dim(a, 0) >= 1,
-            torch._export.dynamic_dim(a, 0) <= 2048,
-            torch._export.dynamic_dim(a, 0) == torch._export.dynamic_dim(b, 0),
-        ]
-        list_example_inputs = [(a, b)]
+        x = torch.randn(128, 2048, device=self.device)
+        y = torch.randn(128, 2048, device=self.device)
+        dim0_x = Dim("dim0_x", min=1, max=2048)
+        dynamic_shapes = {"x": {0: dim0_x}, "y": {0: dim0_x}}
+        list_example_inputs = [(x, y)]
         list_example_inputs.append(
             (
                 torch.randn(64, 2048, device=self.device),
@@ -673,7 +657,7 @@ class AOTInductorTestsTemplate:
         self.check_model_with_multiple_inputs(
             model,
             list_example_inputs,
-            constraints=constraints,
+            dynamic_shapes=dynamic_shapes,
         )
 
     # scaled_dot_product_flash_attention
@@ -751,19 +735,16 @@ class AOTInductorTestsTemplate:
             def __init__(self):
                 super().__init__()
 
-            def forward(self, x1, x2):
-                return torch.cat([x1, x2], dim=0)
+            def forward(self, a, b):
+                return torch.cat([a, b], dim=0)
 
         a = torch.randn(2, 4, device=self.device)
         b = torch.randn(3, 4, device=self.device)
-        constraints = [
-            torch._export.dynamic_dim(a, 0) >= 1,
-            torch._export.dynamic_dim(a, 0) <= 10,
-            torch._export.dynamic_dim(b, 0) >= 1,
-            torch._export.dynamic_dim(b, 0) <= 20,
-        ]
+        dim0_a = Dim("dim0_a", min=1, max=10)
+        dim0_b = Dim("dim0_b", min=1, max=20)
+        dynamic_shapes = {"a": {0: dim0_a}, "b": {0: dim0_b}}
         example_inputs = (a, b)
-        self.check_model(Model(), example_inputs, constraints=constraints)
+        self.check_model(Model(), example_inputs, dynamic_shapes=dynamic_shapes)
 
     @skipIfRocm
     @requires_multigpu()
@@ -897,11 +878,7 @@ class AOTInductorTestsTemplate:
         example_inputs = (torch.randn(10, 10), torch.randn(10, 10))
 
         # Export on CPU
-        exported_program = torch._export.export(
-            Model(),
-            example_inputs,
-            constraints=[],
-        )
+        exported_program = export(Model(), example_inputs)
 
         # Compile exported model on CUDA
         gm = exported_program.graph_module.to(self.device)
@@ -1179,17 +1156,14 @@ class AOTInductorTestsTemplate:
                 return output
 
         dims = [10] * num_dims
-        a = torch.randn(*dims, device=self.device)
-        b = torch.randn(*dims, device=self.device)
-        constraints = []
+        x = torch.randn(*dims, device=self.device)
+        y = torch.randn(*dims, device=self.device)
+        dynamic_shapes = []
         if dynamic:
-            constraints = [
-                torch._export.dynamic_dim(a, 0) >= 1,
-                torch._export.dynamic_dim(a, 0) <= 10,
-                torch._export.dynamic_dim(b, 0) >= 1,
-                torch._export.dynamic_dim(b, 0) <= 10,
-            ]
-        self.check_model(Model(), (a, b), constraints=constraints)
+            dim0_x = Dim("dim0_x", min=1, max=10)
+            dim0_y = Dim("dim0_y", min=1, max=10)
+            dynamic_shapes = {"x": {0: dim0_x}, "y": {0: dim0_y}}
+        self.check_model(Model(), (x, y), dynamic_shapes=dynamic_shapes)
 
     def test_triton_kernel_dynamic_shape_with_div(self):
         if self.device != "cuda":
@@ -1212,12 +1186,10 @@ class AOTInductorTestsTemplate:
                 pass_kernel[grid](x, num)
                 return x
 
-        a = torch.randn(10, device=self.device)
-        constraints = [
-            torch._export.dynamic_dim(a, 0) >= 1,
-            torch._export.dynamic_dim(a, 0) <= 10,
-        ]
-        self.check_model(Model(), (a,), constraints=constraints)
+        x = torch.randn(10, device=self.device)
+        dim0_x = Dim("dim0_x", min=1, max=10)
+        dynamic_shapes = {"x": {0: dim0_x}}
+        self.check_model(Model(), (x,), dynamic_shapes=dynamic_shapes)
 
     def test_triton_kernel_reinterpret_view(self):
         if self.device != "cuda":
@@ -1299,18 +1271,13 @@ class AOTInductorTestsTemplate:
 
         a = torch.randn((4, 5), device=self.device)
         b = torch.randn((5, 5), device=self.device)
-
-        constraints = [
-            torch._export.dynamic_dim(a, 0) >= 2,
-            torch._export.dynamic_dim(a, 0) <= 1024,
-            torch._export.dynamic_dim(b, 0) >= 3,
-            torch._export.dynamic_dim(b, 0) <= 1025,
-        ]
-
+        dim0_x = Dim("dim0_x", min=2, max=1024)
+        dim0_y = Dim("dim0_y", min=3, max=1025)
+        dynamic_shapes = {"x": {0: dim0_x}, "y": {0: dim0_y}}
         self.check_model(
             Model(),
             (a, b),
-            constraints=constraints,
+            dynamic_shapes=dynamic_shapes,
             disable_constraint_solver=True,
         )
 

--- a/test/inductor/test_aot_inductor_utils.py
+++ b/test/inductor/test_aot_inductor_utils.py
@@ -17,7 +17,7 @@ class AOTIRunnerUtil:
         model,
         example_inputs,
         options=None,
-        constraints=None,
+        dynamic_shapes=None,
         disable_constraint_solver=False,
     ):
         # The exact API is subject to change
@@ -25,7 +25,7 @@ class AOTIRunnerUtil:
             model,
             example_inputs,
             options=options,
-            constraints=constraints,
+            dynamic_shapes=dynamic_shapes,
             remove_runtime_assertions=True,
             disable_constraint_solver=disable_constraint_solver,
         )
@@ -71,14 +71,14 @@ class AOTIRunnerUtil:
         model,
         example_inputs,
         options=None,
-        constraints=None,
+        dynamic_shapes=None,
         disable_constraint_solver=False,
     ):
         so_path = AOTIRunnerUtil.compile(
             model,
             example_inputs,
             options=options,
-            constraints=constraints,
+            dynamic_shapes=dynamic_shapes,
             disable_constraint_solver=disable_constraint_solver,
         )
         optimized = AOTIRunnerUtil.load(device, so_path)
@@ -91,13 +91,13 @@ class AOTIRunnerUtil:
         model,
         list_example_inputs,
         options=None,
-        constraints=None,
+        dynamic_shapes=None,
     ):
         so_path = AOTIRunnerUtil.compile(
             model,
             list_example_inputs[0],
             options=options,
-            constraints=constraints,
+            dynamic_shapes=dynamic_shapes,
         )
         optimized = AOTIRunnerUtil.load(device, so_path)
         list_output_tensors = []

--- a/test/inductor/test_memory_planning.py
+++ b/test/inductor/test_memory_planning.py
@@ -13,7 +13,6 @@ if IS_WINDOWS and IS_CI:
     raise unittest.SkipTest("requires sympy/functorch/filelock")  # noqa: F821
 
 import unittest
-from typing import List
 
 import torch
 from test_torchinductor import run_and_get_cpp_code
@@ -21,6 +20,7 @@ from torch._C import FileCheck
 from torch._dynamo.test_case import run_tests, TestCase
 from torch._dynamo.utils import same
 from torch._inductor import config
+from torch.export import Dim
 from torch.utils._triton import has_triton
 
 
@@ -83,13 +83,13 @@ class TestMemoryPlanning(TestCase):
         from test_aot_inductor import AOTIRunnerUtil
 
         f, args = self._generate(device="cuda")
-        constraints: List[torch.export.Constraint] = [
-            torch._export.dynamic_dim(args[0], 0) >= 1,
-            torch._export.dynamic_dim(args[0], 0) <= 2048,
-        ]
+        dim0_x = Dim("dim0_x", min=1, max=2048)
+        dynamic_shapes = ({0: dim0_x}, None, None)
         with config.patch("aot_inductor.abi_compatible", True):
             result, code = run_and_get_cpp_code(
-                lambda: AOTIRunnerUtil.run("cuda", f, args, constraints=constraints)
+                lambda: AOTIRunnerUtil.run(
+                    "cuda", f, args, dynamic_shapes=dynamic_shapes
+                )
             )
 
         FileCheck().check(


### PR DESCRIPTION
Summary: `constraints` argument for `torch.export` has been deprecated in favor of the `dynamic_shapes` argument. This PR updates the use of the deprecated API in `scripts/sijiac/prototypes` and `test/inductor`.

Test Plan: buck test mode/dev-nosan fbcode//caffe2/test/inductor:test_aot_inductor

Differential Revision: D52931743




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler