### PR TITLE
[FSDP] Pass `ignored_modules` to `auto_wrap` if set

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -465,9 +465,12 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
                 "forward_prefetch": forward_prefetch,
                 "limit_all_gathers": limit_all_gathers,
                 "use_orig_params": use_orig_params,
-                "ignored_states": self._ignored_params,
                 "device_mesh": device_mesh,
             }
+            if ignored_modules is not None:
+                root_kwargs["ignored_modules"] = self._ignored_modules
+            else:
+                root_kwargs["ignored_states"] = self._ignored_params
             if sharding_strategy in HYBRID_SHARDING_STRATEGIES:
                 # Share root process groups with children to maintain
                 # the invariant that all FSDP modules will have the same


### PR DESCRIPTION
Fixes #117921

The main issue is due to _materialize_with_param_init_fn only consider modules [_init_utils.py](https://github.com/pytorch/pytorch/blob/main/torch/distributed/fsdp/_init_utils.py#L846) , but fsdp's __init__ always pass all ignored params [init](https://github.com/pytorch/pytorch/blob/main/torch/distributed/fsdp/fully_sharded_data_parallel.py#L468)

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang