### PR TITLE
Fix incorrect type hints of `Module.to`

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1032,12 +1032,12 @@ class Module:
         return self._apply(lambda t: torch.empty_like(t, device=device), recurse=recurse)
 
     @overload
-    def to(self, device: Optional[DeviceLikeType] = ..., dtype: Optional[Union[dtype, str]] = ...,
+    def to(self, device: Optional[DeviceLikeType] = ..., dtype: Optional[dtype] = ...,
            non_blocking: bool = ...) -> Self:
         ...
 
     @overload
-    def to(self, dtype: Union[dtype, str], non_blocking: bool = ...) -> Self:
+    def to(self, dtype: dtype, non_blocking: bool = ...) -> Self:
         ...
 
     @overload


### PR DESCRIPTION
Fixes #117936

While #113647 fixed the issue that `device` did not accept strings, it did not get the type hints fully correct. This PR removes the `str` variants from the type hints for the `dtype` parameter(s) in all overloads.