### PR TITLE
Get Device instance with correct type when privateuse1 backend is registered

### DIFF
--- a/c10/core/DeviceType.cpp
+++ b/c10/core/DeviceType.cpp
@@ -148,4 +148,8 @@ void register_privateuse1_backend(const std::string& backend_name) {
   privateuse1_backend_name_set.store(true, std::memory_order_relaxed);
 }
 
+bool is_privateuse1_backend_registered() {
+  return privateuse1_backend_name_set.load(std::memory_order_acquire);
+}
+
 } // namespace c10

--- a/c10/core/DeviceType.h
+++ b/c10/core/DeviceType.h
@@ -104,6 +104,8 @@ C10_API std::ostream& operator<<(std::ostream& stream, DeviceType type);
 C10_API void register_privateuse1_backend(const std::string& backend_name);
 C10_API std::string get_privateuse1_backend(bool lower_case = true);
 
+C10_API bool is_privateuse1_backend_registered();
+
 } // namespace c10
 
 namespace std {

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -808,6 +808,11 @@ inline at::Device toDevice(PyObject* obj) {
   if (THPUtils_checkLong(obj)) {
     const auto device_index = THPUtils_unpackLong(obj);
     TORCH_CHECK(device_index >= 0, "Device index must not be negative");
+    if (c10::is_privateuse1_backend_registered()) {
+      return at::Device(
+          c10::DeviceType::PrivateUse1,
+          static_cast<c10::DeviceIndex>(device_index));
+    }
     return at::Device(
         c10::DeviceType::CUDA, static_cast<c10::DeviceIndex>(device_index));
   }


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
If privateuse1 backend is registered. Let torch.device return corresponding instance of Device when only index is given.