### PR TITLE
Optimize recursive_add_node in fx splitter

### DIFF
--- a/torch/fx/passes/tools_common.py
+++ b/torch/fx/passes/tools_common.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Union, Dict, Any, Set, Mapping
+from typing import List, Tuple, Union, Dict, Any, Set, Mapping, Optional
 import collections
 from dataclasses import dataclass
 
@@ -123,7 +123,7 @@ class FxNetAccFusionsFinder:
         self,
         fusion_group: "FxNetAccFusionsFinder.FusionGroup",
         inputs: Union[NodeSet, NodeList],
-        visited: NodeSet,
+        visited: Optional[NodeSet] = None,
     ):
         """
         Start from inputs and going reverse topological order. If any upstream node
@@ -131,9 +131,10 @@ class FxNetAccFusionsFinder:
         """
         for arg in inputs:
             # skip the node if already seen
-            if arg in visited:
-                continue
-            visited.add(arg)
+            if visited is not None:
+                if arg in visited:
+                    continue
+                visited.add(arg)
 
             # Skip placeholder and get_attr because they won't be in the fusion group.
             if arg.op not in CALLABLE_NODE_OPS:

--- a/torch/fx/passes/tools_common.py
+++ b/torch/fx/passes/tools_common.py
@@ -123,12 +123,18 @@ class FxNetAccFusionsFinder:
         self,
         fusion_group: "FxNetAccFusionsFinder.FusionGroup",
         inputs: Union[NodeSet, NodeList],
+        visited: NodeSet,
     ):
         """
         Start from inputs and going reverse topological order. If any upstream node
         is in the fusion group, add all the nodes in this path to fusion group.
         """
         for arg in inputs:
+            # skip the node if already seen
+            if arg in visited:
+                continue
+            visited.add(arg)
+
             # Skip placeholder and get_attr because they won't be in the fusion group.
             if arg.op not in CALLABLE_NODE_OPS:
                 continue
@@ -144,7 +150,7 @@ class FxNetAccFusionsFinder:
 
             # Check the upstream nodes of the node, if any of them is in the fusion group
             # we'll add this node to fusion group and return True.
-            if self.recursive_add_node(fusion_group, arg.all_input_nodes):
+            if self.recursive_add_node(fusion_group, arg.all_input_nodes, visited):
                 fusion_group.add_node(arg)
                 return True
 
@@ -172,7 +178,11 @@ class FxNetAccFusionsFinder:
             )
             while fusion_group.nodes_need_process:
                 node = fusion_group.nodes_need_process.pop()
-                self.recursive_add_node(fusion_group, fusion_group.inputs)
+                self.recursive_add_node(
+                    fusion_group,
+                    fusion_group.inputs,
+                    visited=set(),
+                )
 
                 # Optionally add downstream nodes
                 if "tensor_meta" not in node.meta:
@@ -183,7 +193,11 @@ class FxNetAccFusionsFinder:
                             continue
 
                         fusion_group.add_node(user)
-                        self.recursive_add_node(fusion_group, fusion_group.inputs)
+                        self.recursive_add_node(
+                            fusion_group,
+                            fusion_group.inputs,
+                            visited=set(),
+                        )
 
                 # Add some upstream nodes
                 for arg in node.all_input_nodes:
@@ -198,7 +212,11 @@ class FxNetAccFusionsFinder:
                     fusion_group.top_node_idx = min(
                         fusion_group.top_node_idx, self.nodes.index(arg)
                     )
-                    self.recursive_add_node(fusion_group, fusion_group.inputs)
+                    self.recursive_add_node(
+                        fusion_group,
+                        fusion_group.inputs,
+                        visited=set(),
+                    )
 
             if not (set(fusion_group.nodes) <= self.acc_nodes):
                 self.acc_nodes -= fusion_group.nodes


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #117969

Summary: The `FxNetAccFusionsFinder.recursive_add_node` function can run into an exponential complexity when applied to an fx graph with multiple densely connected layers of nodes. Here we add a `visited` set which reduces the worst case complexity to linear.

In the internal MRS models with the densely connected layer structure, this fix reduces the fx split time from forever to < 100ms, hence unblocking the internal enablement.

P.S. As much as I want to add a unit test, I can't find any existing tests for the `_SplitterBase` infra. Happy to add one if pointed to where. Thanks!

Test Plan: CI

Reviewers:

Subscribers:

Tasks:

Tags:

cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv

Differential Revision: [D52951321](https://our.internmc.facebook.com/intern/diff/D52951321)