### PR TITLE
[export] fix unlifting of custom class constants

### DIFF
--- a/test/export/test_torchbind.py
+++ b/test/export/test_torchbind.py
@@ -103,6 +103,22 @@ class TestExportTorchbind(TestCase):
             MyModule(), (torch.ones(2, 3), cc), strict=False
         )
 
+    def test_unlift_custom_obj(self):
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.attr = torch.classes._TorchScriptTesting._Foo(10, 20)
+
+            def forward(self, x):
+                return x + torch.ops._TorchScriptTesting.takes_foo(self.attr, x)
+
+        m = MyModule()
+        input = torch.ones(2, 3)
+        with enable_torchbind_tracing():
+            ep = torch.export.export(m, (input,), strict=False)
+
+        unlifted = ep.module()
+        self.assertEqual(m(input), unlifted(input))
 
 if __name__ == "__main__":
     run_tests()

--- a/test/export/test_torchbind.py
+++ b/test/export/test_torchbind.py
@@ -120,5 +120,6 @@ class TestExportTorchbind(TestCase):
         unlifted = ep.module()
         self.assertEqual(m(input), unlifted(input))
 
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -224,7 +224,6 @@ def _construct_inp_pos_to_param_buffer_name(
                 setattr(new_gm, name.replace(".", "_"), value)
                 constant_name_to_corrected_name[name] = name.replace(".", "_")
 
-
     count = 0
     inp_pos_to_param_buffer_name = {}
     for node in new_gm.graph.nodes:

--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -219,6 +219,11 @@ def _construct_inp_pos_to_param_buffer_name(
                 else:
                     setattr(new_gm, name.replace(".", "_"), value)
                 constant_name_to_corrected_name[name] = name.replace(".", "_")
+            elif name in graph_signature.lifted_custom_objs:
+                assert isinstance(value, torch.ScriptObject)
+                setattr(new_gm, name.replace(".", "_"), value)
+                constant_name_to_corrected_name[name] = name.replace(".", "_")
+
 
     count = 0
     inp_pos_to_param_buffer_name = {}
@@ -243,6 +248,16 @@ def _construct_inp_pos_to_param_buffer_name(
             if hasattr(graph_signature, "inputs_to_lifted_tensor_constants"):
                 if node.name in graph_signature.inputs_to_lifted_tensor_constants:
                     constant_name = graph_signature.inputs_to_lifted_tensor_constants[
+                        node.name
+                    ]
+                    if constant_name in constant_name_to_corrected_name:
+                        inp_pos_to_param_buffer_name[
+                            count
+                        ] = constant_name_to_corrected_name[constant_name]
+                    else:
+                        inp_pos_to_param_buffer_name[count] = constant_name
+                elif node.name in graph_signature.inputs_to_lifted_custom_objs:
+                    constant_name = graph_signature.inputs_to_lifted_custom_objs[
                         node.name
                     ]
                     if constant_name in constant_name_to_corrected_name:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #117979
* #117978

we didn't have a test covering this case, add one.

Aside: we should invest in actually unit testing the lifting/unlifting passes, both separately and also against each other. I have a diff cooking for that.

Differential Revision: [D52962180](https://our.internmc.facebook.com/intern/diff/D52962180/)