### PR TITLE
[export] skip export tests when test with dynamo in ci

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -274,6 +274,7 @@ test_dynamo_shard() {
     --exclude-inductor-tests \
     --exclude-jit-executor \
     --exclude-distributed-tests \
+    --exclude-torch-export-tests \
     --shard "$1" "$NUM_TEST_SHARDS" \
     --verbose
   assert_git_not_dirty

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -443,6 +443,7 @@ JIT_EXECUTOR_TESTS = [
 
 INDUCTOR_TESTS = [test for test in TESTS if test.startswith(INDUCTOR_TEST_PREFIX)]
 DISTRIBUTED_TESTS = [test for test in TESTS if test.startswith(DISTRIBUTED_TEST_PREFIX)]
+TORCH_EXPORT_TESTS = [test for test in TESTS if test.startswith("export")]
 FUNCTORCH_TESTS = [test for test in TESTS if test.startswith("functorch")]
 ONNX_TESTS = [test for test in TESTS if test.startswith("onnx")]
 CPP_TESTS = [test for test in TESTS if test.startswith(CPP_TEST_PREFIX)]
@@ -1243,6 +1244,11 @@ def parse_args():
         help="exclude tests that are run for a specific jit config",
     )
     parser.add_argument(
+        "--exclude-torch-export",
+        action="store_true",
+        help="exclude torch export tests",
+    )
+    parser.add_argument(
         "--exclude-distributed-tests",
         action="store_true",
         help="exclude distributed tests",
@@ -1376,6 +1382,9 @@ def get_selected_tests(options) -> List[str]:
 
     if options.exclude_inductor_tests:
         options.exclude.extend(INDUCTOR_TESTS)
+
+    if options.exclude_torch_export:
+        options.exclude.extend(TORCH_EXPORT_TESTS)
 
     # these tests failing in CUDA 11.6 temporary disabling. issue https://github.com/pytorch/pytorch/issues/75375
     if torch.version.cuda is not None:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1244,7 +1244,7 @@ def parse_args():
         help="exclude tests that are run for a specific jit config",
     )
     parser.add_argument(
-        "--exclude-torch-export",
+        "--exclude-torch-export-tests",
         action="store_true",
         help="exclude torch export tests",
     )
@@ -1383,7 +1383,7 @@ def get_selected_tests(options) -> List[str]:
     if options.exclude_inductor_tests:
         options.exclude.extend(INDUCTOR_TESTS)
 
-    if options.exclude_torch_export:
+    if options.exclude_torch_export_tests:
         options.exclude.extend(TORCH_EXPORT_TESTS)
 
     # these tests failing in CUDA 11.6 temporary disabling. issue https://github.com/pytorch/pytorch/issues/75375


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #117988

Fixes https://github.com/pytorch/pytorch/issues/117947.
