### PR TITLE
[torch][perf] Use set comprehensions in _RecreateLookupTables.

### DIFF
--- a/caffe2/python/core.py
+++ b/caffe2/python/core.py
@@ -2011,15 +2011,8 @@ class Net:
         self._recreate_lookup_tables = True
 
     def _RecreateLookupTables(self):
-        self._op_outputs = set()
-        for op in self._net.op:
-            for o in op.output:
-                self._op_outputs.add(o)
-
-        self._external_input_map = set()
-        for inp in self._net.external_input:
-            self._external_input_map.add(inp)
-
+        self._op_outputs = {o for op in self._net.op for o in op.output}
+        self._external_input_map = {inp for inp in self._net.external_input}
         self._recreate_lookup_tables = False
 
     def AddGradientOperators(self, ys, skip=0):

--- a/caffe2/python/core.py
+++ b/caffe2/python/core.py
@@ -2012,7 +2012,7 @@ class Net:
 
     def _RecreateLookupTables(self):
         self._op_outputs = {o for op in self._net.op for o in op.output}
-        self._external_input_map = {inp for inp in self._net.external_input}
+        self._external_input_map = set(self._net.external_input)
         self._recreate_lookup_tables = False
 
     def AddGradientOperators(self, ys, skip=0):


### PR DESCRIPTION
Using set comprehensions is more idiomatic and much more efficient because it avoids repeated method lookups and interpreter overhead.
