### PR TITLE
[codemod][highrisk] Fix shadowed variable in caffe2/caffe2/onnx/onnx_exporter.cc

### DIFF
--- a/caffe2/onnx/onnx_exporter.cc
+++ b/caffe2/onnx/onnx_exporter.cc
@@ -1367,13 +1367,13 @@ ConvertedResult OnnxExporter::CreateGemmNodes(
 
   // capture the outer shape if needed.
   if (axis > 1) {
-    const auto x_shape = dummy_->NewDummyName();
-    nodes.emplace_back(MakeNode("Shape", {x}, {x_shape}));
+    const auto x_shape_2 = dummy_->NewDummyName();
+    nodes.emplace_back(MakeNode("Shape", {x}, {x_shape_2}));
 
     const auto x_shape_outer = dummy_->NewDummyName();
     nodes.emplace_back(MakeNode(
         "Slice",
-        {x_shape},
+        {x_shape_2},
         {x_shape_outer},
         std::vector<AttributeProto>{
             MakeAttribute("starts", std::vector<int64_t>{0}),


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Test Plan: Sandcastle

Reviewed By: igorsugak

Differential Revision: D52582853


