### PR TITLE
[Dynamo] Install module globals per output_graph

### DIFF
--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -325,14 +325,14 @@ class PyCodegen:
         """
         Generate a LOAD_GLOBAL instruction to fetch a given python module.
         """
-        global_scope = self.tx.output.global_scope
+        output = self.tx.output
+        global_scope = output.global_scope
         name = re.sub(r"^.*[.]", "", mod.__name__)
         if global_scope.get(name, None) is mod:
             return self.create_load_global(name, push_null, add=True)
         mangled_name = f"___module_{name}_{id(mod)}"
-        if mangled_name not in global_scope:
-            self.tx.output.install_global(mangled_name, mod)
-        return self.create_load_global(mangled_name, push_null, add=True)
+        global_name = self.tx.output.install_global_once(mangled_name, mod)
+        return self.create_load_global(global_name, push_null, add=True)
 
     def make_call_generated_code(self, fn_name: str) -> None:
         """Call the generated code function stored in fn_name"""

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1382,8 +1382,7 @@ class OutputGraph(Checkpointable[OutputGraphState]):
 
     def install_global_once(self, name, value) -> str:
         """
-        Install a global once per frame being compiled. A frame graph breaking
-        into e.g. 2 graphs counts as two for the purposes of this function.
+        Install a global once per output_graph.
 
         Returns the name of the newly installed global.
         """

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -252,6 +252,10 @@ class OutputGraph(Checkpointable[OutputGraphState]):
         self.frame_state = frame_state
         self.tensor_weakref_to_sizes_strides = WeakTensorKeyDictionary()
         self.cleanup_hooks: List[Callable[[], Any]] = []
+        # compile_id is an id number for the current torch.compile
+        self.compile_id: int = next(_compile_id_counter)
+        # Set of globals installed via install_global_once
+        self.installed_globals: Set[str] = set()
 
         # TODO: maybe should just pass the entire f_code in here?  Not
         # sure...
@@ -880,7 +884,7 @@ class OutputGraph(Checkpointable[OutputGraphState]):
             self.random_values_var = self.new_var("random_values")
             rand_fn_name = unique_id("__gen_rand_values")
             rand_fn = disable(_get_gen_rand_values_fn(tx.random_calls))
-            self.install_global(rand_fn_name, rand_fn)
+            self.install_global_unsafe(rand_fn_name, rand_fn)
             codegen = PyCodegen(tx, root)
             random_calls_instructions.extend(
                 codegen.load_function_name(rand_fn_name, True)
@@ -1086,7 +1090,7 @@ class OutputGraph(Checkpointable[OutputGraphState]):
         compiled_fn = disable(compiled_fn)
 
         counters["stats"]["unique_graphs"] += 1
-        self.install_global(name, compiled_fn)
+        self.install_global_unsafe(name, compiled_fn)
 
         cg = PyCodegen(tx)
         cg.make_call_generated_code(name)
@@ -1366,8 +1370,29 @@ class OutputGraph(Checkpointable[OutputGraphState]):
         self.output_instructions.extend(prefix)
         self.should_exit = True
 
-    def install_global(self, name, value) -> None:
+    def install_global_unsafe(self, name, value) -> None:
+        """
+        WARNING: prefer the safer `install_global_once`.
+        torch.compile instances should be independent of each other;
+        one footgun is to have one instance depend on the existence of
+        a global installed by another instance. This can happen if we mangle
+        a global the same way across both instances.
+        """
         self.cleanups.append(CleanupHook.create(self.global_scope, name, value))
+
+    def install_global_once(self, name, value) -> str:
+        """
+        Install a global once per frame being compiled. A frame graph breaking
+        into e.g. 2 graphs counts as two for the purposes of this function.
+
+        Returns the name of the newly installed global.
+        """
+        name = f"{name}_c{self.compile_id}"
+        if name in self.installed_globals:
+            return name
+        self.install_global_unsafe(name, value)
+        self.installed_globals.add(name)
+        return name
 
     def cleanup(self) -> None:
         # There is a reference cycle between tracer and OutputGraph, causing
@@ -1468,6 +1493,9 @@ def check_pt2_compliant_op(output_graph, kind, target, args, kwargs):
             )
 
 
+_compile_id_counter = itertools.count()
+
+
 class SubgraphTracer(fx.Tracer):
     """
     Holds an FX graph that is being traced. OutputGraph owns a SubgraphTracer
@@ -1482,6 +1510,7 @@ class SubgraphTracer(fx.Tracer):
         super().__init__()
         self.output_graph = weakref.proxy(output_graph)
         self.graph = torch.fx.Graph()
+
         # The export is only ever set for the ROOT tracer.  It controls
         # whether or not certain inputs are allowed to be added or not.
         # Look at call sites of create_graph_input to see how it is used.

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -882,7 +882,7 @@ class InstructionTranslatorBase(Checkpointable[InstructionTranslatorGraphState])
             else:
                 mangled_name = f"___unnamed_scope_{id(self.f_globals)}"
                 if mangled_name not in self.output.global_scope:
-                    self.output.install_global(mangled_name, self.f_globals)
+                    self.output.install_global_unsafe(mangled_name, self.f_globals)
                 source = GetItemSource(GlobalSource(mangled_name), name)
         return source
 
@@ -1892,7 +1892,7 @@ class InstructionTranslatorBase(Checkpointable[InstructionTranslatorGraphState])
     def store_global_weakref(self, name, value):
         install_guard(GlobalWeakRefSource(name).make_guard(GuardBuilder.WEAKREF_ALIVE))
         if name not in self.output.global_scope:
-            self.output.install_global(name, weakref.ref(value))
+            self.output.install_global_unsafe(name, weakref.ref(value))
 
     @property
     def fake_mode(self):
@@ -2187,7 +2187,7 @@ class InstructionTranslator(InstructionTranslatorBase):
         if new_code.co_freevars:
             cg.make_function_with_closure(name, new_code, True, stack_len)
         else:
-            self.output.install_global(
+            self.output.install_global_unsafe(
                 name, types.FunctionType(new_code, self.f_globals, name)
             )
             cg.extend_output(cg.load_function_name(name, True, stack_len))

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -650,9 +650,6 @@ class CleanupHook:
 
     @staticmethod
     def create(scope, name, val):
-        if name in scope:
-            breakpoint()
-            pass
         assert name not in scope
         CleanupManager.count += 1
         scope[name] = val

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -650,6 +650,9 @@ class CleanupHook:
 
     @staticmethod
     def create(scope, name, val):
+        if name in scope:
+            breakpoint()
+            pass
         assert name not in scope
         CleanupManager.count += 1
         scope[name] = val

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1277,7 +1277,7 @@ def wrap_fx_proxy(tx, proxy, example_value=None, subclass_type=None, **options):
         return wrap_fx_proxy_cls(target_cls=TensorVariable, **kwargs)
     else:
         result = wrap_fx_proxy_cls(target_cls=TensorWithTFOverrideVariable, **kwargs)
-        result.install_global(tx)
+        result.install_global_unsafe(tx)
         return result
 
 

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -592,7 +592,7 @@ class StreamVariable(VariableTracker):
         # design, to unblock current work, we lift the stream into a global and then codegen bytecode to load it from there.
         name = f"_stream_{self.device}_{id(self.value)}"
         if name not in codegen.tx.output.global_scope:
-            codegen.tx.output.install_global(name, self.value)
+            codegen.tx.output.install_global_unsafe(name, self.value)
 
         return [codegen.create_load_global(name, push_null=False, add=True)]
 

--- a/torch/_dynamo/variables/torch_function.py
+++ b/torch/_dynamo/variables/torch_function.py
@@ -165,7 +165,7 @@ class TensorWithTFOverrideVariable(TensorVariable):
         # each time the compiled artifact is run and outputs a wrapped tensor.
         if self.global_mangled_class_name() not in tx.output.global_scope:
             tx.output.install_global_unsafe(
-                self.global_mangled_class_name(), self.class_type, per_frame=False
+                self.global_mangled_class_name(), self.class_type
             )
 
     def python_type(self):

--- a/torch/_dynamo/variables/torch_function.py
+++ b/torch/_dynamo/variables/torch_function.py
@@ -156,15 +156,17 @@ class TensorWithTFOverrideVariable(TensorVariable):
             kwargs.pop("class_type") is torch.Tensor
         ), "invalid class type in TensorWithTFOverrideVariable.from_tensor_var"
         var = cls(torch_function_fn=torch_function_fn, class_type=class_type, **kwargs)
-        var.install_global(tx)
+        var.install_global_unsafe(tx)
         return var
 
-    def install_global(self, tx):
+    def install_global_unsafe(self, tx):
         # stash the subclass type to rewrap an output tensor if needed
         # this is needed because the actual type needs to be available
         # each time the compiled artifact is run and outputs a wrapped tensor.
         if self.global_mangled_class_name() not in tx.output.global_scope:
-            tx.output.install_global(self.global_mangled_class_name(), self.class_type)
+            tx.output.install_global_unsafe(
+                self.global_mangled_class_name(), self.class_type, per_frame=False
+            )
 
     def python_type(self):
         return self.class_type


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #118030
* __->__ #117998

Fixes https://github.com/pytorch/pytorch/issues/117851

In tests, we ran into an issue where:
- In frame A, Dynamo would install a global
- We call reset()
- reset() did not delete the installed global due to a refcycle
- In frame B, Dynamo would re-use the same global
- Python gc ran, deleting the installed global, leading to the compiled
  version of frame B raising NameNotFound

This PR changes the following:
- module globals are now installed at a per-frame basis.
- renames install_global to install_global_unsafe: if the names are not
  unique and end up being re-used across frames, then we've got trouble.

Test Plan:
- I tested that this got rid of the test flakiness locally. I'm not sure
  how to easily write a test for this, because I don't actually know
  what the refcycle in the above is.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng