### PR TITLE
[CUDA] Use 64-bit indexing in `CUDA_KERNEL_LOOP` in  `im2col`

### DIFF
--- a/aten/src/ATen/native/cuda/im2col.cuh
+++ b/aten/src/ATen/native/cuda/im2col.cuh
@@ -34,7 +34,7 @@ __global__ void im2col_kernel(
     const int64_t height_col,
     const int64_t width_col,
     dt* data_col) {
-  CUDA_KERNEL_LOOP(index, n) {
+  CUDA_KERNEL_LOOP_TYPE(index, n, int64_t) {
     int64_t w_out = index % width_col;
 
     int64_t idx = index / width_col;

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -2000,6 +2000,26 @@ class TestConvolutionNNDeviceType(NNTestCase):
         self.assertEqual(grad1, grad2, atol=5e-2, rtol=5e-3)
 
     @onlyCUDA
+    @skipCUDAIfRocm
+    @largeTensorTest('20GB', 'cpu')
+    @largeTensorTest('60GB', 'cuda')
+    def test_conv_large_batch_1(self, device):
+        in_channels = 514
+        dim = 2048
+        out_channels = 1
+        kernel_size = 3
+        stride = 1
+        padding = 1
+
+        input_tensor = torch.ones(1, in_channels, dim, dim).cuda().half()
+        model = nn.Conv2d(in_channels, out_channels, kernel_size, stride, padding).cuda().half()
+        output = model(input_tensor)
+        model_cpu = model.cpu().float()
+        output_cpu = model(input_tensor.float().cpu())
+        self.assertEqual(output.cpu().float(), output_cpu, atol=1e-3, rtol=1e-3)
+        print(torch.cuda.memory_reserved())
+
+    @onlyCUDA
     @skipCUDAIfNoCudnn
     def test_contig_wrong_stride_cudnn(self, device):
         # x has to have batch_size 1 to test contiguous checks

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -2017,7 +2017,6 @@ class TestConvolutionNNDeviceType(NNTestCase):
         model_cpu = model.cpu().float()
         output_cpu = model(input_tensor.float().cpu())
         self.assertEqual(output.cpu().float(), output_cpu, atol=1e-3, rtol=1e-3)
-        print(torch.cuda.memory_reserved())
 
     @onlyCUDA
     @skipCUDAIfNoCudnn


### PR DESCRIPTION
#117736

cc @ptrblck