### PR TITLE
Don't use private accessor on SymNode to get _expr

### DIFF
--- a/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
+++ b/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
@@ -92,7 +92,7 @@ class _AddRuntimeAssertionsForInlineConstraintsPass(_ExportPassBaseDeprecatedDoN
             call_backs: List[Callable] = []
             messages: List[str] = []
             if isinstance(val, (torch.SymInt, torch.SymFloat, torch.SymBool)):
-                symbol = val.node._expr
+                symbol = val.node.expr
                 if symbol in self.existing_inline_assertions:
                     return call_backs, messages
                 if isinstance(symbol, sympy.Symbol) and symbol.name.startswith("i"):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118007

This materially impacts https://github.com/pytorch/pytorch/pull/117862
split this out for testing

Signed-off-by: Edward Z. Yang <ezyang@meta.com>