### PR TITLE
Replace `constraints` with `dynamic_shapes` in caffe2/test/cpp & torchrec/distributed/tests/test_pt2

### DIFF
--- a/test/cpp/aot_inductor/test.py
+++ b/test/cpp/aot_inductor/test.py
@@ -1,6 +1,7 @@
 
 import torch
-from torch._export import aot_compile, dynamic_dim
+from torch._export import aot_compile
+from torch.export import Dim
 
 torch.manual_seed(1337)
 
@@ -23,12 +24,9 @@ for device in ["cpu", "cuda"]:
 
     torch._dynamo.reset()
     with torch.no_grad():
-        constraints = [
-            dynamic_dim(x, 0) >= 1,
-            dynamic_dim(x, 0) <= 1024,
-            dynamic_dim(x, 0) == dynamic_dim(y, 0),
-        ]
-        model_so_path = aot_compile(model, (x, y), constraints=constraints)
+        dim0_x = Dim("dim0_x", min=1, max=1024)
+        dynamic_shapes = {"x": {0: dim0_x}, "y": {0: dim0_x}}
+        model_so_path = aot_compile(model, (x, y), dynamic_shapes=dynamic_shapes)
 
     params = dict(model.named_parameters())
     data.update({


### PR DESCRIPTION
Summary: `constraints` argument for `torch.export` has been deprecated in favor of the `dynamic_shapes` argument. This PR updates the use of the deprecated API in `caffe2/test/cpp` and `torchrec/distributed/test/test_pt2`.

Test Plan: CI

Differential Revision: D52977354


