### PR TITLE
fix: make OneCycleLR pickleable

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -1703,7 +1703,7 @@ class TestLRScheduler(TestCase):
         self._test_cycle_lr(scheduler, lr_targets, momentum_targets, 10, use_beta1=True)
         self.opt = old_opt  # set optimizer back to SGD
 
-    def test_onecycle_lr_pickleable(self):
+    def test_onecycle_lr_picklable(self):
         adam_opt = Adam(self.net.parameters())
         scheduler = OneCycleLR(adam_opt, max_lr=5, total_steps=200)
         state = scheduler.state_dict()
@@ -1717,17 +1717,19 @@ class TestLRScheduler(TestCase):
         scheduler = OneCycleLR(adam_opt, max_lr=5, total_steps=200, anneal_strategy='cos')
         restored_scheduler = OneCycleLR(adam_opt, max_lr=5, total_steps=200)
         restored_scheduler.load_state_dict(scheduler.state_dict())
-        self.assertTrue(restored_scheduler.anneal_strategy == scheduler.anneal_strategy == 'cos')
         self.assertIsNotNone(restored_scheduler.anneal_func)
         self.assertIsNotNone(scheduler.anneal_func)
+        self.assertEqual(restored_scheduler.anneal_strategy, scheduler.anneal_strategy)
+        self.assertEqual(restored_scheduler.anneal_stragety, 'cos')
 
         # case 2: linear annealing
         scheduler = OneCycleLR(adam_opt, max_lr=5, total_steps=200, anneal_strategy='linear')
         restored_scheduler = OneCycleLR(adam_opt, max_lr=5, total_steps=200)
         restored_scheduler.load_state_dict(scheduler.state_dict())
-        self.assertTrue(restored_scheduler.anneal_strategy == scheduler.anneal_strategy == 'linear')
         self.assertIsNotNone(restored_scheduler.anneal_func)
         self.assertIsNotNone(scheduler.anneal_func)
+        self.assertEqual(restored_scheduler.anneal_strategy, scheduler.anneal_strategy)
+        self.assertEqual(restored_scheduler.anneal_stragety, 'linear')
 
     def test_lambda_lr(self):
         epochs = 10

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -1720,7 +1720,7 @@ class TestLRScheduler(TestCase):
         self.assertIsNotNone(restored_scheduler.anneal_func)
         self.assertIsNotNone(scheduler.anneal_func)
         self.assertEqual(restored_scheduler.anneal_strategy, scheduler.anneal_strategy)
-        self.assertEqual(restored_scheduler.anneal_stragety, 'cos')
+        self.assertEqual(restored_scheduler.anneal_strategy, 'cos')
 
         # case 2: linear annealing
         scheduler = OneCycleLR(adam_opt, max_lr=5, total_steps=200, anneal_strategy='linear')
@@ -1729,7 +1729,7 @@ class TestLRScheduler(TestCase):
         self.assertIsNotNone(restored_scheduler.anneal_func)
         self.assertIsNotNone(scheduler.anneal_func)
         self.assertEqual(restored_scheduler.anneal_strategy, scheduler.anneal_strategy)
-        self.assertEqual(restored_scheduler.anneal_stragety, 'linear')
+        self.assertEqual(restored_scheduler.anneal_strategy, 'linear')
 
     def test_lambda_lr(self):
         epochs = 10

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1744,7 +1744,7 @@ class OneCycleLR(LRScheduler):
     def _init_anneal_func(self):
         if self.anneal_strategy not in ['cos', 'linear']:
             raise ValueError(
-                "anneal_strategy must by one of 'cos' or 'linear', instead got {}".format(self.anneal_strategy))
+                f"anneal_strategy must by one of 'cos' or 'linear', instead got {self.anneal_strategy}")
         elif self.anneal_strategy == 'cos':
             self.anneal_func = self._annealing_cos
         elif self.anneal_strategy == 'linear':


### PR DESCRIPTION
Fixes #94450

Drop `anneal_func` from the state_dict and reinitialize it when loading state_dict.