### PR TITLE
[AOTI] Fix a bug in the torch._export.aot_load API

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1149,7 +1149,7 @@ def export_aot_inductor(model, example_inputs, device):
 
     def opt_aot_inductor(_, example_inputs, collect_outputs=False):
         example_args, example_kwargs = _normalize_bench_inputs(example_inputs)
-        return optimized(example_args, example_kwargs)
+        return optimized(*example_args, **example_kwargs)
 
     return opt_aot_inductor
 

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -782,7 +782,7 @@ class AOTInductorTestsTemplate:
             with torch.cuda.device(i):
                 example_inputs = tuple(t.cuda(i) for t in inputs)
                 optimized = AOTIRunnerUtil.load("cuda", so_path)
-                result_cuda = optimized(example_inputs)
+                result_cuda = optimized(*example_inputs)
             self.assertTrue(same(result_cpu, result_cuda.cpu()))
 
     def test_pytree_inputs(self):
@@ -993,7 +993,7 @@ class AOTInductorTestsTemplate:
         self.assertTrue(torch.is_grad_enabled())
 
         optimized = AOTIRunnerUtil.load(self.device, so_path)
-        actual = optimized(example_inputs)
+        actual = optimized(*example_inputs)
         actual = pytree.tree_leaves(actual)
 
         self.assertTrue(same(actual, expected))

--- a/test/inductor/test_aot_inductor_utils.py
+++ b/test/inductor/test_aot_inductor_utils.py
@@ -52,11 +52,11 @@ class AOTIRunnerUtil:
         if IS_FBCODE:
             runner = AOTIRunnerUtil.load_runner(device, so_path)
 
-            def optimized(*args):
+            def optimized(*args, **kwargs):
                 call_spec = runner.get_call_spec()
                 in_spec = pytree.treespec_loads(call_spec[0])
                 out_spec = pytree.treespec_loads(call_spec[1])
-                flat_inputs = fx_pytree.tree_flatten_spec((*args, {}), in_spec)
+                flat_inputs = fx_pytree.tree_flatten_spec((args, kwargs), in_spec)
                 flat_outputs = runner.run(flat_inputs)
                 return pytree.tree_unflatten(flat_outputs, out_spec)
 
@@ -82,7 +82,7 @@ class AOTIRunnerUtil:
             disable_constraint_solver=disable_constraint_solver,
         )
         optimized = AOTIRunnerUtil.load(device, so_path)
-        return optimized(example_inputs)
+        return optimized(*example_inputs)
 
     @classmethod
     def run_multiple(
@@ -102,5 +102,5 @@ class AOTIRunnerUtil:
         optimized = AOTIRunnerUtil.load(device, so_path)
         list_output_tensors = []
         for example_inputs in list_example_inputs:
-            list_output_tensors.append(optimized(example_inputs))
+            list_output_tensors.append(optimized(*example_inputs))
         return list_output_tensors

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -425,7 +425,7 @@ def aot_load(so_path: str, device: str) -> Callable:
         call_spec = runner.get_call_spec()  # type: ignore[attr-defined]
         in_spec = pytree.treespec_loads(call_spec[0])
         out_spec = pytree.treespec_loads(call_spec[1])
-        flat_inputs = fx_pytree.tree_flatten_spec((*args, kwargs), in_spec)
+        flat_inputs = fx_pytree.tree_flatten_spec((args, kwargs), in_spec)
         flat_outputs = runner.run(flat_inputs)  # type: ignore[attr-defined]
         return pytree.tree_unflatten(flat_outputs, out_spec)
 


### PR DESCRIPTION
Summary:
tree_flatten_spec should use args instead of *args

clone of https://github.com/pytorch/pytorch/pull/117948 but with some fbcode specific changes

Test Plan: CI

Differential Revision: D52982401




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler