### PR TITLE
[inductor][fx] Fix broadcast_tensors with unbacked symints when translation validation is off

### DIFF
--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -330,7 +330,7 @@ class SizeVarAllocator:
 
     def expect_true(self, expr: Expr, *, msg: str) -> None:
         expr = sympy_subs(expr, self.inv_precomputed_replacements)
-        self.shape_env.defer_runtime_assert(expr, msg, fx_node=V.graph.current_node)
+        self.shape_env.defer_runtime_assert(expr, msg, fx_node=None)
 
     def expect_equals(self, left: Expr, right: Expr, *, msg: str) -> Expr:
         # Prefer returning the expression without unbacked symints

--- a/torch/fx/experimental/recording.py
+++ b/torch/fx/experimental/recording.py
@@ -116,12 +116,6 @@ class ShapeEnvEvent:
                 # Don't do anything to x if it's not an FX node.
                 return x
 
-            if not shape_env._translation_validation_enabled:
-                assert not hasattr(
-                    shape_env, "name_to_node"
-                ), "Translation validation is not on, we shouldn't have name_to_node."
-                return x.name
-
             # If, at some point, we created an FX node, it means that translation validation is on.
             # It also means we are building an FX graph for symbolic shapes at shape_env.graph, and
             # we are tracking node names at shape_env.name_to_node.

--- a/torch/fx/experimental/recording.py
+++ b/torch/fx/experimental/recording.py
@@ -115,6 +115,13 @@ class ShapeEnvEvent:
             if not isinstance(x, torch.fx.Node):
                 # Don't do anything to x if it's not an FX node.
                 return x
+
+            if not shape_env._translation_validation_enabled:
+                assert not hasattr(
+                    shape_env, "name_to_node"
+                ), "Translation validation is not on, we shouldn't have name_to_node."
+                return x.name
+
             # If, at some point, we created an FX node, it means that translation validation is on.
             # It also means we are building an FX graph for symbolic shapes at shape_env.graph, and
             # we are tracking node names at shape_env.name_to_node.


### PR DESCRIPTION
## Context
This is an example that runs into an AssertionError while lowering in Inductor.
```
# While lowering, b will be expanded because b.size(1) == 1.
a = torch.zeros([u0, 512])
b = torch.ones([u0, 1])
return a * b
```

Below's the tail-end of the stack trace. Here's the important bits:
1. In _inductor/sizevars.py, we'll call `self.shape_env.defer_runtime_assert(expr, msg, fx_node=V.graph.current_node)`. 
2. This leads to the creation of a `ShapeEnvEvent` with an FX node via `kwargs={"fx_node": V.graph.current_node}` ([see](https://github.com/pytorch/pytorch/blob/0c9b5134701ab04552bc1724c5f148d22f98f20d/torch/fx/experimental/recording.py#L245-L247)).
3. Eventually, we try to call `maybe_convert_node()` but it expects translation validation to be on ([see](https://github.com/pytorch/pytorch/blob/0c9b5134701ab04552bc1724c5f148d22f98f20d/torch/fx/experimental/recording.py#L118-L121)).
```
  File "pytorch/torch/_inductor/lowering.py", line 221, in transform_args
    for i, x in zip(indices, broadcast_tensors(*[args[i] for i in indices])):
  File "pytorch/torch/_inductor/lowering.py", line 294, in wrapped
    out = decomp_fn(*args, **kwargs)
  File "pytorch/torch/_inductor/lowering.py", line 676, in broadcast_tensors
    x = expand(x, target)
  File "pytorch/torch/_inductor/lowering.py", line 294, in wrapped
    out = decomp_fn(*args, **kwargs)
  File "pytorch/torch/_inductor/lowering.py", line 793, in expand
    return TensorBox(ExpandView.create(x.data, tuple(sizes)))
  File "pytorch/torch/_inductor/ir.py", line 1871, in create
    new_size = cls._normalize_size(x, new_size)
  File "pytorch/torch/_inductor/ir.py", line 1862, in _normalize_size
    new_size[i] = V.graph.sizevars.expect_equals(
  File "pytorch/torch/_inductor/sizevars.py", line 338, in expect_equals
    self.expect_true(sympy.Eq(left, right), msg=msg)
  File "pytorch/torch/_inductor/sizevars.py", line 333, in expect_true
    self.shape_env.defer_runtime_assert(expr, msg, fx_node=V.graph.current_node)  # (1) is here
  File "pytorch/torch/fx/experimental/recording.py", line 257, in wrapper
    return event.run(self)   # (2) happens right before this
  File "pytorch/torch/fx/experimental/recording.py", line 155, in run
    replacearg(index=3, key="fx_node", fn=maybe_convert_node)
  File "pytorch/torch/fx/experimental/recording.py", line 138, in replacearg
    kwargs[key] = fn(kwargs[key])
  File "pytorch/torch/fx/experimental/recording.py", line 128, in maybe_convert_node
    assert hasattr(shape_env, "name_to_node")  # (3) is here
```

## Approach
~~Since [translation validation](https://github.com/pytorch/pytorch/blob/c6be5d55a56cc12b7a004acdb6a7da92ee2142f7/torch/fx/experimental/validator.py#L574) may not be on during Inductor lowering, we can check if that's True and return the FX node's name in this case.~~

Pass in `None` for fx_node.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118066



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov