### PR TITLE
[dtensor] make local_shard_size_on_dim be staticmethod

### DIFF
--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -114,8 +114,8 @@ class Shard(Placement):
             length=tensor.size(self.dim) - pad_size,
         )
 
+    @staticmethod
     def _local_shard_size_on_dim(
-        self,
         size_on_dim: int,
         num_chunks: int,
         rank: int,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #118080
* #118079
* #113334
* __->__ #118078

As titled, this is so that we can use it for the case when we don't need
to construct a Shard placement

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @fduwjj @wz337 @tianyu-l @wconstab @yf225