### PR TITLE
Check if enable inside run call

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2830,6 +2830,7 @@ This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0"""
             )
 
     def setUp(self):
+        check_if_enable(self)
         set_rng_seed(SEED)
 
         # Save global check sparse tensor invariants state that can be

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2830,7 +2830,6 @@ This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0"""
             )
 
     def setUp(self):
-        check_if_enable(self)
         set_rng_seed(SEED)
 
         # Save global check sparse tensor invariants state that can be

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2811,6 +2811,17 @@ This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0"""
 
 
     def run(self, result=None):
+        # Check if enable here as well so we don't have to worry about
+        # subclasses calling super().setUp().   Call it via a wrapper instead of
+        # directly because the skipTest call will raise an uncaught exception
+        def check_if_enable_wrapper(f):
+            @wraps(f)
+            def wrapper(*args, **kwargs):
+                check_if_enable(self)
+                f(*args, **kwargs)
+            return wrapper
+        setattr(self, self._testMethodName, check_if_enable_wrapper(getattr(self, self._testMethodName)))
+
         with contextlib.ExitStack() as stack:
             if TEST_WITH_CROSSREF:  # noqa: F821
                 stack.enter_context(CrossRefMode())


### PR DESCRIPTION
In theory this way we never have to worry about subclasses calling super().setUp() ever again

Also, dynamically creating classes (ex via type in instantiate_device_type_tests) makes super() calls a bit odd
https://stackoverflow.com/questions/71879642/how-to-pass-function-with-super-when-creating-class-dynamically
https://stackoverflow.com/questions/43782944/super-does-not-work-together-with-type-supertype-obj-obj-must-be-an-i
