### PR TITLE
[codemod] Remove unused variables in caffe2/caffe2/operators/conv_op_cudnn.cc

### DIFF
--- a/caffe2/operators/conv_op_cudnn.cc
+++ b/caffe2/operators/conv_op_cudnn.cc
@@ -523,7 +523,7 @@ bool CudnnConvOp::DoRunWithType() {
   auto* Y = Output(0, output_sizes, at::dtype<T_Y>());
 
   int N = 0, C = 0, H = 0, W = 0, D = 0, H_out = 0, W_out = 0, D_out = 0;
-  int group_offset_X = 0, group_offset_Y = 0;
+  [[maybe_unused]] int group_offset_X = 0, group_offset_Y = 0;
 
   switch (order_) {
     case StorageOrder::NHWC:
@@ -905,7 +905,7 @@ bool CudnnConvGradientOp::DoRunWithType() {
 
   const int M = filter.dim32(0);
   int N = 0, C = 0, H = 0, W = 0, D = 0, H_out = 0, W_out = 0, D_out = 0;
-  int group_offset_X = 0, group_offset_Y = 0;
+  [[maybe_unused]] int group_offset_X = 0, group_offset_Y = 0;
 
   switch (order_) {
     case StorageOrder::NHWC:


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Test Plan: Sandcastle

Reviewed By: dmm-fb

Differential Revision: D52981087


