### PR TITLE
[PT2][Optimus][Reliability]Fix a bug in gradients computation for runtime numeric check

### DIFF
--- a/torch/_inductor/fx_passes/numeric_utils.py
+++ b/torch/_inductor/fx_passes/numeric_utils.py
@@ -144,8 +144,8 @@ def run_model(
         logger.info("compare loss/predict. Numerical result : %s", res)
         # tensor may not have a grad_fn
         try:
-            _ = pred_base[0].sum().backward()
-            _ = pred_control[0].sum().backward()
+            _ = pred_base[0].sum().backward(retain_graph=True)
+            _ = pred_control[0].sum().backward(retain_graph=True)
             res = compare_gradients(model_base, model_control, precision)
             logger.info("compare param grad. Numerical result : %s", res)
         except Exception as e:


### PR DESCRIPTION
Summary:
We observed the following error when launch e2e AFOC model test
```
RuntimeError: Trying to backward through the graph a second time (or directly access saved tensors after they have already been freed). Saved intermediate values of the graph are freed when you call .backward() or autograd.grad(). Specify retain_graph=True if you need to backward through the graph a second time or if you need to access saved tensors after calling backward.
```
f524190245

Differential Revision: D53011463




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler