### PR TITLE
[codemod] Remove unused variables in caffe2/caffe2/opt/nql/graphmatcher.cc

### DIFF
--- a/caffe2/opt/nql/graphmatcher.cc
+++ b/caffe2/opt/nql/graphmatcher.cc
@@ -251,9 +251,7 @@ std::string convertToNQLString(NNGraph& g) {
   // doesn't mutate the graph and use const reference in this function too.
   auto topoMatch = nom::algorithm::tarjans(&g);
   std::vector<NNGraph::NodeRef> nodes;
-  int sccNum = 0;
   for (auto scc : topoMatch) {
-    sccNum++;
     for (auto node : scc.getNodes()) {
       nodes.emplace_back(node);
     }


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Test Plan: Sandcastle

Reviewed By: malfet, dmm-fb

Differential Revision: D52981072


