### PR TITLE
[ez] Windows log printing + save successful test logs

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1047,10 +1047,10 @@ def handle_log_file(
         return
 
     # otherwise: print entire file
-    print_to_stderr(f"\nPRINTING LOG FILE of {test} ({file_path})")
+    print_to_stderr(f"\nPRINTING LOG FILE of {test} ({new_file})")
     for line in full_text.splitlines():
         print_to_stderr(line.rstrip())
-    print_to_stderr(f"FINISHED PRINTING LOG FILE of {test} ({file_path})\n")
+    print_to_stderr(f"FINISHED PRINTING LOG FILE of {test} ({new_file})\n")
 
 
 def get_pytest_args(

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1047,7 +1047,8 @@ def handle_log_file(
         return
     # otherwise: print entire file and then remove it
     print_to_stderr(f"\nPRINTING LOG FILE of {test} ({file_path})")
-    print_to_stderr(full_text)
+    for line in full_text.splitlines():
+        print_to_stderr(line.strip())
     print_to_stderr(f"FINISHED PRINTING LOG FILE of {test} ({file_path})\n")
     os.remove(file_path)
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1026,8 +1026,8 @@ def handle_log_file(
     test: ShardedTest, file_path: str, failed: bool, was_rerun: bool
 ) -> None:
     test = str(test)
-    with open(file_path, "rb") as f:
-        full_text = f.read().decode("utf-8", errors="ignore")
+    with open(file_path, "r", errors="ignore") as f:
+        full_text = f.read()
 
     new_file = "test/test-reports/" + sanitize_file_name(
         f"{test}_{os.urandom(8).hex()}_.log"
@@ -1042,14 +1042,13 @@ def handle_log_file(
         )
         for line in full_text.splitlines():
             if re.search("Running .* items in this shard:", line):
-                print_to_stderr(line.strip())
+                print_to_stderr(line.rstrip())
         print_to_stderr("")
         return
 
     # otherwise: print entire file
     print_to_stderr(f"\nPRINTING LOG FILE of {test} ({new_file})")
-    for line in full_text.splitlines():
-        print_to_stderr(line.rstrip())
+    print_to_stderr(full_text)
     print_to_stderr(f"FINISHED PRINTING LOG FILE of {test} ({new_file})\n")
 
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1029,14 +1029,14 @@ def handle_log_file(
     with open(file_path, "rb") as f:
         full_text = f.read().decode("utf-8", errors="ignore")
 
+    new_file = "test/test-reports/" + sanitize_file_name(
+        f"{test}_{os.urandom(8).hex()}_.log"
+    )
+    os.rename(file_path, REPO_ROOT / new_file)
+
     if not failed and not was_rerun and "=== RERUNS ===" not in full_text:
         # If success + no retries (idk how else to check for test level retries
-        # other than reparse xml), print only what tests ran, rename the log
-        # file so it doesn't get printed later, and do not remove logs.
-        new_file = "test/test-reports/" + sanitize_file_name(
-            f"{test}_{os.urandom(8).hex()}_.log"
-        )
-        os.rename(file_path, REPO_ROOT / new_file)
+        # other than reparse xml), print only what tests ran
         print_to_stderr(
             f"\n{test} was successful, full logs can be found in artifacts with path {new_file}"
         )
@@ -1045,12 +1045,12 @@ def handle_log_file(
                 print_to_stderr(line.strip())
         print_to_stderr("")
         return
-    # otherwise: print entire file and then remove it
+
+    # otherwise: print entire file
     print_to_stderr(f"\nPRINTING LOG FILE of {test} ({file_path})")
     for line in full_text.splitlines():
         print_to_stderr(line.rstrip())
     print_to_stderr(f"FINISHED PRINTING LOG FILE of {test} ({file_path})\n")
-    os.remove(file_path)
 
 
 def get_pytest_args(

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1026,7 +1026,7 @@ def handle_log_file(
     test: ShardedTest, file_path: str, failed: bool, was_rerun: bool
 ) -> None:
     test = str(test)
-    with open(file_path, "r", errors="ignore") as f:
+    with open(file_path, errors="ignore") as f:
         full_text = f.read()
 
     new_file = "test/test-reports/" + sanitize_file_name(

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1048,7 +1048,7 @@ def handle_log_file(
     # otherwise: print entire file and then remove it
     print_to_stderr(f"\nPRINTING LOG FILE of {test} ({file_path})")
     for line in full_text.splitlines():
-        print_to_stderr(line.strip())
+        print_to_stderr(line.rstrip())
     print_to_stderr(f"FINISHED PRINTING LOG FILE of {test} ({file_path})\n")
     os.remove(file_path)
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -100,6 +100,7 @@ class TestCheckpoint(TestCase):
     # Test whether checkpoint is being triggered or not. For this, we check
     # the number of times forward pass happens
     def test_checkpoint_trigger(self):
+        self.assertEqual(1, 2)
 
         class Net(nn.Module):
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -100,7 +100,6 @@ class TestCheckpoint(TestCase):
     # Test whether checkpoint is being triggered or not. For this, we check
     # the number of times forward pass happens
     def test_checkpoint_trigger(self):
-        self.assertEqual(1, 2)
 
         class Net(nn.Module):
 


### PR DESCRIPTION
when doing print(f.read().decode etc etc) it prints an extra new line, so manually splitlines and strip to see if that helps

My guess is windows line ending differences

Also always save log file regardless of success or failure

See https://hud.pytorch.org/pytorch/pytorch/commit/476b81a9bfcc765125984ad521e5e40cdbdbf098 for what it looks like now

Swapped to opening in text mode instead of binary, seems to be ok now.

42483193bf024983060a234dc0262f4840aef4b8 for example