### PR TITLE
[DTensor][fix] re-enable [add]mm tensor test

### DIFF
--- a/test/distributed/_tensor/test_dtensor_ops.py
+++ b/test/distributed/_tensor/test_dtensor_ops.py
@@ -572,12 +572,6 @@ class TestDTensorOps(DTensorOpTestBase):
         def test():
             samples = op.sample_inputs(DEVICE_TYPE, dtype, requires_grad=True)
             for sample_input in samples:
-                # Skip mm/add over empty tensors, as test fails with `min() arg is an empty sequence`
-                # For more info see https://github.com/pytorch/pytorch/issues/118043
-                if op.name == "addmm" and sample_input.args[0].numel() == 0:
-                    continue
-                if op.name == "mm" and sample_input.input.numel() == 0:
-                    continue
                 args = [sample_input.input] + list(sample_input.args)
                 kwargs = sample_input.kwargs
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #118134
* __->__ #118132
* #117726

**Summary**
Re-enable tests that were disabled in #118045 as #117726 fixed the empty tensor case for DTensor [add]mm.

**Test Plan**
`pytest test/distributed/_tensor/test_dtensor_ops.py -s -k mm`

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225