### PR TITLE
[DTensor][BE] re-enable test_dtensor_ops in CPU CI

### DIFF
--- a/test/distributed/_tensor/test_dtensor_ops.py
+++ b/test/distributed/_tensor/test_dtensor_ops.py
@@ -704,7 +704,4 @@ instantiate_device_type_tests(TestDTensorOps, globals(), only_for=(DEVICE_TYPE,)
 
 
 if __name__ == "__main__":
-    # NB: CPU dtensor ops test frequently timeout https://github.com/pytorch/pytorch/issues/98816
-    # so running it only on CUDA
-    if torch.cuda.is_available():
-        run_tests()
+    run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118134
* #118132
* #117726

**Test**
`pytest test/distributed/_tensor/test_dtensor_ops.py`
This only runs CPU test and completes in 1 minute on local.
<img width="3002" alt="image" src="https://github.com/pytorch/pytorch/assets/12968408/bfbcaff0-2581-41a7-817d-f68e4041b8b1">

CI Run: https://hud.pytorch.org/pr/pytorch/pytorch/118134
Search for "distributed" test and click any of them. Then search for "test_dtensor_ops". Saw successful run of `test_dtensor_ops`.


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225