### PR TITLE
[export] Remove the branch for skipping verifier.

### DIFF
--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -10,7 +10,6 @@ from torch._subclasses.fake_tensor import FakeTensor
 from torch.export.exported_program import ExportedProgram
 from torch.export.graph_signature import (
     CustomObjArgument,
-    ExportGraphSignature,
     InputKind,
     SymIntArgument,
     TensorArgument,
@@ -129,9 +128,6 @@ class Verifier(metaclass=_VerifierMeta):
 
     @final
     def check(self, ep: ExportedProgram) -> None:
-        if not isinstance(ep.graph_signature, ExportGraphSignature):
-            # TODO Enforce type checking in the constructor.
-            return
         self._check_graph_module(ep.graph_module)
         _verify_exported_program_signature(ep)
 


### PR DESCRIPTION
Summary:
We used to skip verifier when the signature object is not the "correct" one (usually from some deprecated frontend). This was very useful when we wanted to pay a small cost to enable verifier path to be called everywhere for torch export.

Now I believe no tests are relying on this behavior so we should remove this weird branch.

Test Plan: CI

Differential Revision: D53024506


