### PR TITLE
[CUDA] Add missing TF32 annotation to `test_uint4x2_mixed_mm`

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2162,6 +2162,7 @@ class CommonTemplate:
             check_lowp=True,
         )
 
+    @with_tf32_off
     @config.patch(use_mixed_mm=True)
     def test_uint4x2_mixed_mm(self):
         def fn(a, b):


### PR DESCRIPTION
Addresses numerical mismatches seen on architectures with TF32.

CC @nWEIdia

cc @ptrblck @zasdfgbnm @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler