### PR TITLE
[C10] Make Scalar constructable from longs

### DIFF
--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -60,15 +60,16 @@ class C10_API Scalar {
   AT_FORALL_COMPLEX_TYPES(DEFINE_IMPLICIT_CTOR)
 
   // Helper constructors to allow Scalar creation from long and long long types
-  // As std::is_same_v<long, long long> is false, one needs to provide a
-  // constructor from either long or long long in addition to one from int64_t
+  // As std::is_same_v<long, long long> is false(except Android), one needs to
+  // provide a constructor from either long or long long in addition to one from
+  // int64_t
 #if defined(__APPLE__) || defined(__MACOSX)
   static_assert(
       std::is_same_v<long long, int64_t>,
       "int64_t is the same as long long on MacOS");
   Scalar(long vv) : Scalar(vv, true) {}
 #endif
-#ifdef __linux__
+#if defined(__linux__) && !defined(__ANDROID__)
   static_assert(
       std::is_same_v<long, int64_t>,
       "int64_t is the same as long on Linux");

--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -59,6 +59,22 @@ class C10_API Scalar {
       DEFINE_IMPLICIT_CTOR)
   AT_FORALL_COMPLEX_TYPES(DEFINE_IMPLICIT_CTOR)
 
+  // Helper constructors to allow Scalar creation from long and long long types
+  // As std::is_same_v<long, long long> is false, one needs to provide a
+  // constructor from either long or long long in addition to one from int64_t
+  template <
+      typename T = long long,
+      std::enable_if_t<
+          !std::is_same_v<long long, int64_t> && sizeof(T) == 8U,
+          bool> = true>
+  Scalar(T vv) : Scalar(vv, true) {}
+  template <
+      typename T = long,
+      std::enable_if_t<
+          !std::is_same_v<long, int64_t> && sizeof(T) == 8U,
+          bool> = true>
+  Scalar(T vv) : Scalar(vv, true) {}
+
   Scalar(uint16_t vv) : Scalar(vv, true) {}
   Scalar(uint32_t vv) : Scalar(vv, true) {}
   Scalar(uint64_t vv) {

--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -62,18 +62,18 @@ class C10_API Scalar {
   // Helper constructors to allow Scalar creation from long and long long types
   // As std::is_same_v<long, long long> is false, one needs to provide a
   // constructor from either long or long long in addition to one from int64_t
-  template <
-      typename T = long long,
-      std::enable_if_t<
-          !std::is_same_v<long long, int64_t> && sizeof(T) == 8U,
-          bool> = true>
-  Scalar(T vv) : Scalar(vv, true) {}
-  template <
-      typename T = long,
-      std::enable_if_t<
-          !std::is_same_v<long, int64_t> && sizeof(T) == 8U,
-          bool> = true>
-  Scalar(T vv) : Scalar(vv, true) {}
+#if defined(__APPLE__) || defined(__MACOSX)
+  static_assert(
+      std::is_same_v<long long, int64_t>,
+      "int64_t is the same as long long on MacOS");
+  Scalar(long vv) : Scalar(vv, true) {}
+#endif
+#ifdef __linux__
+  static_assert(
+      std::is_same_v<long, int64_t>,
+      "int64_t is the same as long on Linux");
+  Scalar(long long vv) : Scalar(vv, true) {}
+#endif
 
   Scalar(uint16_t vv) : Scalar(vv, true) {}
   Scalar(uint32_t vv) : Scalar(vv, true) {}

--- a/c10/test/core/Scalar_test.cpp
+++ b/c10/test/core/Scalar_test.cpp
@@ -51,5 +51,5 @@ TEST(ScalarTest, Equality) {
 TEST(ScalarTest, LongsAndLongLongs) {
   Scalar longOne = 1L;
   Scalar longlongOne = 1LL;
-  ASSERT_EQ(longOne, longlongOne);
+  ASSERT_EQ(longOne.toInt(), longlongOne.toInt());
 }

--- a/c10/test/core/Scalar_test.cpp
+++ b/c10/test/core/Scalar_test.cpp
@@ -47,3 +47,9 @@ TEST(ScalarTest, Equality) {
   // ensure that we don't incorrectly coerce bitrep
   ASSERT_FALSE(Scalar(-1).equal(0xFFFFFFFFFFFFFFFF));
 }
+
+TEST(ScalarTest, LongsAndLongLongs) {
+  Scalar longOne = 1L;
+  Scalar longlongOne = 1LL;
+  ASSERT_EQ(longOne, longlongOne);
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118149
* #118076
* #118077

On Linux and Mac `int64_t` is an alias to either `long` (Linux) or  `long long` (Mac)

Because of that, attempt to construct `c10::Scalar` from the other type will fail with `conversion from ‘long long int’ to ‘c10::Scalar’ is ambiguous`.

I.e. attempt to compile:
```cpp
int main() {
  c10::Scalar s = 1L;
}
```
on MacOS failed with:
```
foo.cpp:3:15: error: conversion from 'long' to 'c10::Scalar' is ambiguous
  c10::Scalar s = 1L;
              ^   ~~
/Users/nshulga/git/pytorch/pytorch/torch/include/c10/core/Scalar.h:59:7: note: candidate constructor
      DEFINE_IMPLICIT_CTOR)
      ^
/Users/nshulga/git/pytorch/pytorch/torch/include/c10/core/Scalar.h:59:7: note: candidate constructor
/Users/nshulga/git/pytorch/pytorch/torch/include/c10/core/Scalar.h:59:7: note: candidate constructor
/Users/nshulga/git/pytorch/pytorch/torch/include/c10/core/Scalar.h:59:7: note: candidate constructor
/Users/nshulga/git/pytorch/pytorch/torch/include/c10/core/Scalar.h:59:7: note: candidate constructor
/Users/nshulga/git/pytorch/pytorch/torch/include/c10/core/Scalar.h:59:7: note: candidate constructor
/Users/nshulga/git/pytorch/pytorch/torch/include/c10/core/Scalar.h:59:7: note: candidate constructor
/Users/nshulga/git/pytorch/pytorch/torch/include/c10/core/Scalar.h:62:3: note: candidate constructor
  Scalar(uint16_t vv) : Scalar(vv, true) {}
  ^
/Users/nshulga/git/pytorch/pytorch/torch/include/c10/core/Scalar.h:63:3: note: candidate constructor
  Scalar(uint32_t vv) : Scalar(vv, true) {}
  ^
/Users/nshulga/git/pytorch/pytorch/torch/include/c10/core/Scalar.h:64:3: note: candidate constructor
  Scalar(uint64_t vv) {
  ^

```

Prevent this by providing missing constructors when needed. Alas one can not use SFINAE, as template constructors on Scalar mess up a lot of implicit conversions, so I use  `static_asserts` to  detect early on if premise for constructing this class holds.

Add ScalarTest::LongsAndLongLongs that is essentially a compile time test

Discovered while trying to enable AOTI on MacOS