### PR TITLE
Remove set_ exclusion in FakeTensor dispatch cache

### DIFF
--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1739,10 +1739,6 @@ class FakeTensorMode(TorchDispatchMode):
         if func == aten._unsafe_view.default:
             raise _BypassDispatchCache("unsafe view")
 
-        # TODO: Unnecessary after https://github.com/pytorch/pytorch/pull/115769
-        if func == aten.set_.source_Tensor:
-            raise _BypassDispatchCache("set source")
-
         if func in self.lift_fns:
             raise _BypassDispatchCache("lift")
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118154

Summary: Now that set_ is marked as a view op, this special case is no longer necessary

Test Plan: CI exposed the need for this special case in the first place, so I think we can just rely on the existing tests