### PR TITLE
[Export] Introduce class_fqn into CustomObjArgument

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -754,6 +754,11 @@ class TestSerializeCustomClass(TestCase):
                     node.args = (arg0, custom_node)
 
         serialized_vals = serialize(ep)
+
+        ep_str = serialized_vals.exported_program.decode("utf-8")
+        assert "class_fqn" in ep_str
+        assert custom_obj._type().qualified_name() in ep_str
+
         deserialized_ep = deserialize(serialized_vals)
 
         for node in deserialized_ep.graph.nodes:
@@ -763,6 +768,7 @@ class TestSerializeCustomClass(TestCase):
             ):
                 arg = node.args[0]
                 self.assertTrue(isinstance(arg, torch._C.ScriptObject))
+                self.assertEqual(arg._type(), custom_obj._type())
                 self.assertEqual(arg.__getstate__(), custom_obj.__getstate__())
                 self.assertEqual(arg.top(), 7)
 

--- a/torch/_export/serde/schema.py
+++ b/torch/_export/serde/schema.py
@@ -96,7 +96,8 @@ class TensorMeta:
 
 @dataclass
 class ScriptObjectMeta:
-    constant_name: Optional[str]
+    constant_name: str
+    class_fqn: str
 
 
 # In most cases we will use the "as_name" field to store arguments which are
@@ -147,6 +148,7 @@ class GraphArgument:
 @dataclass
 class CustomObjArgument:
     name: str
+    class_fqn: str
 
 
 # This is actually a union type

--- a/torch/export/custom_obj.py
+++ b/torch/export/custom_obj.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Optional
 
 
 __all__ = ["ScriptObjectMeta"]
@@ -12,4 +11,6 @@ class ScriptObjectMeta:
     """
 
     # Key into constants table to retrieve the real ScriptObject.
-    constant_name: Optional[str]
+    constant_name: str
+
+    class_fqn: str

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -516,7 +516,9 @@ class ExportedProgram:
                 old_input_spec = old_signature.input_specs[i]
                 arg = (
                     old_input_spec.arg
-                    if isinstance(old_input_spec.arg, ConstantArgument)
+                    if isinstance(
+                        old_input_spec.arg, (ConstantArgument, CustomObjArgument)
+                    )
                     else type(old_input_spec.arg)(node.name)
                 )
                 new_input_specs.append(
@@ -534,7 +536,9 @@ class ExportedProgram:
                 old_output_spec = old_signature.output_specs[i]
                 arg = (
                     old_output_spec.arg
-                    if isinstance(old_output_spec.arg, ConstantArgument)
+                    if isinstance(
+                        old_output_spec.arg, (ConstantArgument, CustomObjArgument)
+                    )
                     else type(old_output_spec.arg)(node.name)
                 )
                 new_output_specs.append(

--- a/torch/export/graph_signature.py
+++ b/torch/export/graph_signature.py
@@ -31,6 +31,7 @@ class SymIntArgument:
 @dataclasses.dataclass
 class CustomObjArgument:
     name: str
+    class_fqn: str
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Summary:
Class FQN is needed when unpacking CustomObj instance.
For all other Arguments, e.g. Tensor, TensorList, SymInt, we always know their exact type. However, CustomObjArgument had an opaque type.
Adding this field also helps unveiling the type of this opaque object.

Test Plan: CI

Differential Revision: D53029847


