### PR TITLE
torch.load with weights_only=True to support pickle protocol 3/4/5

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1057,6 +1057,19 @@ class TestSerialization(TestCase, SerializationMixin):
         with self.assertRaisesRegex(RuntimeError, 'ZeroTensor is not serializable'):
             _save_load_check(t)
 
+    @parametrize('pickle_protocol', (2, 3, 4, 5))
+    @parametrize('weights_only', (False, True))
+    def test_serialization_pickle_protocol_version(self, pickle_protocol, weights_only):
+        def _save_load_check(t):
+            with BytesIOContext() as f:
+                torch.save(t, f, pickle_protocol=pickle_protocol)
+                f.seek(0)
+                # Unsafe load should work
+                self.assertEqual(torch.load(f, weights_only=weights_only), t)
+
+        t = torch.randn(2, 2, dtype=torch.float)
+        _save_load_check(t)
+
     def test_serialization_byteorder_mark(self):
         lstm = torch.nn.LSTM(3, 3)
         inputs = [torch.randn(1, 3) for _ in range(5)]

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -17,6 +17,7 @@
 # weights = torch.load(buf, weights_only = True)
 
 import functools as _functools
+import io
 from collections import OrderedDict
 from pickle import (
     APPEND,
@@ -56,6 +57,21 @@ from pickle import (
     TUPLE2,
     TUPLE3,
     UnpicklingError,
+    # Protocol 3
+    BINBYTES,
+    SHORT_BINBYTES,
+    # Protocol 4
+    SHORT_BINUNICODE,
+    BINUNICODE8,
+    BINBYTES8,
+    ADDITEMS,
+    FROZENSET,
+    NEWOBJ_EX,
+    STACK_GLOBAL,
+    MEMOIZE,
+    FRAME,
+    # Protocol 5 (no out-of-band buffer support)
+    BYTEARRAY8,
 )
 from struct import unpack
 from sys import maxsize
@@ -122,11 +138,68 @@ def _get_allowed_globals():
     return rc
 
 
+class _Unframer:
+
+    def __init__(self, file_read, file_readline, file_tell=None):
+        self.file_read = file_read
+        self.file_readline = file_readline
+        self.current_frame = None
+
+    def readinto(self, buf):
+        if self.current_frame:
+            n = self.current_frame.readinto(buf)
+            if n == 0 and len(buf) != 0:
+                self.current_frame = None
+                n = len(buf)
+                buf[:] = self.file_read(n)
+                return n
+            if n < len(buf):
+                raise UnpicklingError(
+                    "pickle exhausted before end of frame")
+            return n
+        else:
+            n = len(buf)
+            buf[:] = self.file_read(n)
+            return n
+
+    def read(self, n):
+        if self.current_frame:
+            data = self.current_frame.read(n)
+            if not data and n != 0:
+                self.current_frame = None
+                return self.file_read(n)
+            if len(data) < n:
+                raise UnpicklingError(
+                    "pickle exhausted before end of frame")
+            return data
+        else:
+            return self.file_read(n)
+
+    def readline(self):
+        if self.current_frame:
+            data = self.current_frame.readline()
+            if not data:
+                self.current_frame = None
+                return self.file_readline()
+            if data[-1] != b'\n'[0]:
+                raise UnpicklingError(
+                    "pickle exhausted before end of frame")
+            return data
+        else:
+            return self.file_readline()
+
+    def load_frame(self, frame_size):
+        if self.current_frame and self.current_frame.read() != b'':
+            raise UnpicklingError(
+                "beginning of a new frame before end of current frame")
+        self.current_frame = io.BytesIO(self.file_read(frame_size))
+
+
 class Unpickler:
     def __init__(self, file, *, encoding: str = "bytes"):
         self.encoding = encoding
-        self.readline = file.readline
-        self.read = file.read
+        self._file_readline = file.readline
+        self._file_read = file.read
         self.memo: Dict[int, Any] = {}
 
     def load(self):
@@ -134,11 +207,16 @@ class Unpickler:
 
         Return the reconstituted object hierarchy specified in the file.
         """
+        self._unframer = _Unframer(self._file_read, self._file_readline)
+        self.read = self._unframer.read
+        self.readline = self._unframer.readline
+        self.readinto = self._unframer.readinto
         self.metastack = []
         self.stack: List[Any] = []
         self.append = self.stack.append
         read = self.read
         readline = self.readline
+        readinto = self.readinto
         while True:
             key = read(1)
             if not key:
@@ -236,11 +314,11 @@ class Unpickler:
             elif key[0] == BININT[0]:
                 self.append(unpack("<i", read(4))[0])
             elif key[0] == BININT1[0]:
-                self.append(self.read(1)[0])
+                self.append(read(1)[0])
             elif key[0] == BININT2[0]:
                 self.append(unpack("<H", read(2))[0])
             elif key[0] == BINFLOAT[0]:
-                self.append(unpack(">d", self.read(8))[0])
+                self.append(unpack(">d", read(8))[0])
             elif key[0] == BINUNICODE[0]:
                 strlen = unpack("<I", read(4))[0]
                 if strlen > maxsize:
@@ -288,6 +366,79 @@ class Unpickler:
             elif key[0] == STOP[0]:
                 rc = self.stack.pop()
                 return rc
+            # Protocol 3
+            elif key[0] == BINBYTES[0]:
+                n, = unpack('<I', read(4))
+                if n > maxsize:
+                    raise UnpicklingError("BINBYTES exceeds system's maximum size "
+                                          "of %d bytes" % maxsize)
+                self.append(read(n))
+            elif key[0] == SHORT_BINBYTES[0]:
+                n = read(1)[0]
+                self.append(read(n))
+            # Protocol 4
+            elif key[0] == SHORT_BINUNICODE[0]:
+                n = read(1)[0]
+                self.append(str(read(n), 'utf-8', 'surrogatepass'))
+            elif key[0] == BINUNICODE8[0]:
+                n, = unpack('<Q', read(8))
+                if n > maxsize:
+                    raise UnpicklingError("BINUNICODE8 exceeds system's maximum size "
+                                          "of %d bytes" % maxsize)
+                self.append(str(read(n), 'utf-8', 'surrogatepass'))
+            elif key[0] == BINBYTES8[0]:
+                n, = unpack('<Q', read(8))
+                if n > maxsize:
+                    raise UnpicklingError("BINBYTES8 exceeds system's maximum size "
+                                          "of %d bytes" % maxsize)
+                self.append(read(n))
+            elif key[0] == EMPTY_SET[0]:
+                self.append(set())
+            elif key[0] == ADDITEMS[0]:
+                items = self.pop_mark()
+                set_obj = self.stack[-1]
+                if isinstance(set_obj, set):
+                    set_obj.update(items)
+                else:
+                    add = set_obj.add
+                    for item in items:
+                        add(item)
+            elif key[0] == FROZENSET[0]:
+                items = self.pop_mark()
+                self.append(frozenset(items))
+            elif key[0] == NEWOBJ_EX[0]:
+                kwargs = self.stack.pop()
+                args = self.stack.pop()
+                cls = self.stack.pop()
+                obj = cls.__new__(cls, *args, **kwargs)
+                self.append(obj)
+            elif key[0] == STACK_GLOBAL[0]:
+                name = self.stack.pop()
+                module = self.stack.pop()
+                if type(name) is not str or type(module) is not str:
+                    raise UnpicklingError("STACK_GLOBAL requires str")
+                full_path = f"{module}.{name}"
+                if full_path in _get_allowed_globals():
+                    self.append(_get_allowed_globals()[full_path])
+                else:
+                    raise RuntimeError(f"Unsupported class {full_path}")
+            elif key[0] == MEMOIZE[0]:
+                memo = self.memo
+                memo[len(memo)] = self.stack[-1]
+            elif key[0] == FRAME[0]:
+                frame_size, = unpack('<Q', read(8))
+                if frame_size > maxsize:
+                    raise ValueError("frame size > sys.maxsize: %d" % frame_size)
+                self._unframer.load_frame(frame_size)
+            # Protocol 5 (no out-of-band buffer support)
+            elif key[0] == BYTEARRAY8[0]:
+                n, = unpack('<Q', read(8))
+                if n > maxsize:
+                    raise UnpicklingError("BYTEARRAY8 exceeds system's maximum size "
+                                          "of %d bytes" % maxsize)
+                b = bytearray(n)
+                readinto(b)
+                self.append(b)
             else:
                 raise RuntimeError(f"Unsupported operand {key[0]}")
 

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -20,8 +20,11 @@ import functools as _functools
 import io
 from collections import OrderedDict
 from pickle import (
+    ADDITEMS,
     APPEND,
     APPENDS,
+    BINBYTES,
+    BINBYTES8,
     BINFLOAT,
     BINGET,
     BININT,
@@ -30,48 +33,42 @@ from pickle import (
     BINPERSID,
     BINPUT,
     BINUNICODE,
+    BINUNICODE8,
     BUILD,
+    BYTEARRAY8,
     bytes_types,
     decode_long,
     EMPTY_DICT,
     EMPTY_LIST,
     EMPTY_SET,
     EMPTY_TUPLE,
+    FRAME,
+    FROZENSET,
     GLOBAL,
     LONG1,
     LONG_BINGET,
     LONG_BINPUT,
     MARK,
+    MEMOIZE,
     NEWFALSE,
     NEWOBJ,
+    NEWOBJ_EX,
     NEWTRUE,
     NONE,
     PROTO,
     REDUCE,
     SETITEM,
     SETITEMS,
+    SHORT_BINBYTES,
     SHORT_BINSTRING,
+    SHORT_BINUNICODE,
+    STACK_GLOBAL,
     STOP,
     TUPLE,
     TUPLE1,
     TUPLE2,
     TUPLE3,
     UnpicklingError,
-    # Protocol 3
-    BINBYTES,
-    SHORT_BINBYTES,
-    # Protocol 4
-    SHORT_BINUNICODE,
-    BINUNICODE8,
-    BINBYTES8,
-    ADDITEMS,
-    FROZENSET,
-    NEWOBJ_EX,
-    STACK_GLOBAL,
-    MEMOIZE,
-    FRAME,
-    # Protocol 5 (no out-of-band buffer support)
-    BYTEARRAY8,
 )
 from struct import unpack
 from sys import maxsize
@@ -139,59 +136,54 @@ def _get_allowed_globals():
 
 
 class _Unframer:
-
-    def __init__(self, file_read, file_readline, file_tell=None):
+    def __init__(self, file_read, file_readline) -> None:
         self.file_read = file_read
         self.file_readline = file_readline
         self.current_frame = None
 
-    def readinto(self, buf):
-        if self.current_frame:
-            n = self.current_frame.readinto(buf)
-            if n == 0 and len(buf) != 0:
-                self.current_frame = None
-                n = len(buf)
-                buf[:] = self.file_read(n)
-                return n
-            if n < len(buf):
-                raise UnpicklingError(
-                    "pickle exhausted before end of frame")
-            return n
-        else:
+    def readinto(self, buf) -> int:
+        def readinto_noframe() -> int:
             n = len(buf)
             buf[:] = self.file_read(n)
             return n
 
+        if not self.current_frame:
+            return readinto_noframe()
+        n = self.current_frame.readinto(buf)
+        if n == 0 and len(buf) != 0:
+            self.current_frame = None
+            return readinto_noframe()
+        if n < len(buf):
+            raise UnpicklingError("pickle exhausted before end of frame")
+        return n
+
     def read(self, n):
-        if self.current_frame:
-            data = self.current_frame.read(n)
-            if not data and n != 0:
-                self.current_frame = None
-                return self.file_read(n)
-            if len(data) < n:
-                raise UnpicklingError(
-                    "pickle exhausted before end of frame")
-            return data
-        else:
+        if not self.current_frame:
             return self.file_read(n)
+        data = self.current_frame.read(n)
+        if not data and n != 0:
+            self.current_frame = None
+            return self.file_read(n)
+        if len(data) < n:
+            raise UnpicklingError("pickle exhausted before end of frame")
+        return data
 
     def readline(self):
-        if self.current_frame:
-            data = self.current_frame.readline()
-            if not data:
-                self.current_frame = None
-                return self.file_readline()
-            if data[-1] != b'\n'[0]:
-                raise UnpicklingError(
-                    "pickle exhausted before end of frame")
-            return data
-        else:
+        if not self.current_frame:
             return self.file_readline()
+        data = self.current_frame.readline()
+        if not data:
+            self.current_frame = None
+            return self.file_readline()
+        if data[-1] != b"\n"[0]:
+            raise UnpicklingError("pickle exhausted before end of frame")
+        return data
 
     def load_frame(self, frame_size):
-        if self.current_frame and self.current_frame.read() != b'':
+        if self.current_frame and self.current_frame.read() != b"":
             raise UnpicklingError(
-                "beginning of a new frame before end of current frame")
+                "beginning of a new frame before end of current frame"
+            )
         self.current_frame = io.BytesIO(self.file_read(frame_size))
 
 
@@ -368,10 +360,12 @@ class Unpickler:
                 return rc
             # Protocol 3
             elif key[0] == BINBYTES[0]:
-                n, = unpack('<I', read(4))
+                (n,) = unpack("<I", read(4))
                 if n > maxsize:
-                    raise UnpicklingError("BINBYTES exceeds system's maximum size "
-                                          "of %d bytes" % maxsize)
+                    raise UnpicklingError(
+                        "BINBYTES exceeds system's maximum size "
+                        "of %d bytes" % maxsize
+                    )
                 self.append(read(n))
             elif key[0] == SHORT_BINBYTES[0]:
                 n = read(1)[0]
@@ -379,18 +373,22 @@ class Unpickler:
             # Protocol 4
             elif key[0] == SHORT_BINUNICODE[0]:
                 n = read(1)[0]
-                self.append(str(read(n), 'utf-8', 'surrogatepass'))
+                self.append(str(read(n), "utf-8", "surrogatepass"))
             elif key[0] == BINUNICODE8[0]:
-                n, = unpack('<Q', read(8))
+                (n,) = unpack("<Q", read(8))
                 if n > maxsize:
-                    raise UnpicklingError("BINUNICODE8 exceeds system's maximum size "
-                                          "of %d bytes" % maxsize)
-                self.append(str(read(n), 'utf-8', 'surrogatepass'))
+                    raise UnpicklingError(
+                        "BINUNICODE8 exceeds system's maximum size "
+                        "of %d bytes" % maxsize
+                    )
+                self.append(str(read(n), "utf-8", "surrogatepass"))
             elif key[0] == BINBYTES8[0]:
-                n, = unpack('<Q', read(8))
+                (n,) = unpack("<Q", read(8))
                 if n > maxsize:
-                    raise UnpicklingError("BINBYTES8 exceeds system's maximum size "
-                                          "of %d bytes" % maxsize)
+                    raise UnpicklingError(
+                        "BINBYTES8 exceeds system's maximum size "
+                        "of %d bytes" % maxsize
+                    )
                 self.append(read(n))
             elif key[0] == EMPTY_SET[0]:
                 self.append(set())
@@ -426,16 +424,18 @@ class Unpickler:
                 memo = self.memo
                 memo[len(memo)] = self.stack[-1]
             elif key[0] == FRAME[0]:
-                frame_size, = unpack('<Q', read(8))
+                (frame_size,) = unpack("<Q", read(8))
                 if frame_size > maxsize:
                     raise ValueError("frame size > sys.maxsize: %d" % frame_size)
                 self._unframer.load_frame(frame_size)
             # Protocol 5 (no out-of-band buffer support)
             elif key[0] == BYTEARRAY8[0]:
-                n, = unpack('<Q', read(8))
+                (n,) = unpack("<Q", read(8))
                 if n > maxsize:
-                    raise UnpicklingError("BYTEARRAY8 exceeds system's maximum size "
-                                          "of %d bytes" % maxsize)
+                    raise UnpicklingError(
+                        "BYTEARRAY8 exceeds system's maximum size "
+                        "of %d bytes" % maxsize
+                    )
                 b = bytearray(n)
                 readinto(b)
                 self.append(b)


### PR DESCRIPTION
PyTorch has a feature gap in torch.load when weights_only = True. The saved file generated by torch.save with protocol 4/5 cannot be loaded using torch.load when weights_only=True.

In torch_weights_only_unpickler.py, it read each pickle op code from the file and unpickle the data manually op by op. The existing implementation only handles op code up to protocol 2. The op codes from protocol 3/4/5 are not handled and thus throw Unsupported operand exception.

This fix adopt the Unpickler op code handling from pickle.py for protocol 3/4/5. And use the same mechanism for frame handling. PyTorch currently doesn't use the out-of-band buffer of protocol 5, the out-of-band buffer is not supported for weights_only unpickler.

Fixes #118092
