### PR TITLE
[inductor] Slightly faster memory allocation on CPU

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -437,6 +437,7 @@ class WrapperCodeGen(CodeGen):
                 aten = torch.ops.aten
                 inductor_ops = torch.ops.inductor
                 assert_size_stride = torch._C._dynamo.guards.assert_size_stride
+                empty_strided_cpu = torch._C._dynamo.guards._empty_strided_cpu
                 alloc_from_pool = torch.ops.inductor._alloc_from_pool
                 reinterpret_tensor = torch.ops.inductor._reinterpret_tensor
                 async_compile = AsyncCompile()
@@ -1161,6 +1162,16 @@ class WrapperCodeGen(CodeGen):
         return self.make_allocation(buffer.get_name(), device, dtype, shape, stride)
 
     def make_allocation(self, name, device, dtype, shape, stride):
+        if device.type == "cpu" and len(shape) <= 8:
+            # optimized path for faster allocations, saving ~2us versus the stuff below
+            # TODO(jansel): can we do similar things on the GPU?
+            return (
+                f"{name} = empty_strided_cpu("
+                f"{self.codegen_shape_tuple(shape)}, "
+                f"{self.codegen_shape_tuple(stride)}, "
+                f"{dtype})"
+            )
+
         try:
             expected = tuple(ir.make_contiguous_strides_for(shape))
         except Exception:  # cannot determine truth value of Relational

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -585,12 +585,56 @@ static PyObject* assert_size_stride(PyObject* dummy, PyObject* args) {
   Py_RETURN_TRUE;
 }
 
+inline static size_t unwrap_size_tuple(
+    PyObject* obj,
+    ssize_t* output,
+    size_t limit) {
+  TORCH_CHECK(PyTuple_CheckExact(obj));
+  size_t len = PyTuple_GET_SIZE(obj);
+  TORCH_CHECK(len <= limit);
+  for (size_t i = 0; i < len; ++i) {
+    auto result = PyLong_AsSsize_t(PyTuple_GET_ITEM(obj, i));
+    TORCH_CHECK(result >= 0);
+    output[i] = result;
+  }
+  return len;
+}
+
+static PyObject* _empty_strided_cpu(PyObject* dummy, PyObject* args) {
+  // at::empty_strided is surprising slow.  This is a lower-overhead
+  // version that saves ~2us on every allocation.  Though it is
+  // CPU-only, tuple-only, and only supports 8D tensors.
+  // These constraints are checked in inductor.
+  try {
+    TORCH_CHECK(PyTuple_CheckExact(args));
+    TORCH_CHECK(PyTuple_GET_SIZE(args) == 3);
+
+    // note PyTuple_GET_ITEM returns a borrowed ref, so no need for refcounts
+    ssize_t sizes[8];
+    size_t ndim1 = unwrap_size_tuple(PyTuple_GET_ITEM(args, 0), sizes, 8);
+
+    ssize_t strides[8];
+    size_t ndim2 = unwrap_size_tuple(PyTuple_GET_ITEM(args, 1), strides, 8);
+
+    PyObject* py_dtype = PyTuple_GET_ITEM(args, 2);
+    TORCH_CHECK(THPDtype_Check(py_dtype));
+    at::ScalarType dtype = reinterpret_cast<THPDtype*>(py_dtype)->scalar_type;
+
+    return THPVariable_Wrap(at::detail::empty_strided_cpu(
+        at::IntArrayRef(sizes, ndim1), at::IntArrayRef(strides, ndim2), dtype));
+  } catch (std::exception const& ex) {
+    PyErr_SetString(PyExc_RuntimeError, ex.what());
+    return nullptr;
+  }
+}
+
 // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 static PyMethodDef _methods[] = {
     {"check_type_id", check_type_id, METH_VARARGS, nullptr},
     {"check_obj_id", check_obj_id, METH_VARARGS, nullptr},
     {"assert_size_stride", assert_size_stride, METH_VARARGS, nullptr},
-    {"dict_version", dict_version, METH_VARARGS, NULL},
+    {"dict_version", dict_version, METH_VARARGS, nullptr},
+    {"_empty_strided_cpu", _empty_strided_cpu, METH_VARARGS, nullptr},
     {nullptr, nullptr, 0, nullptr}};
 
 static struct PyModuleDef _module = {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #118255
* __->__ #118171
* #118070
* #118065

Based on `python benchmarks/dynamo/microbenchmarks/overheads.py`:
- Before `12.2us`
- After `10.5us`

This is inspired by https://github.com/pytorch/pytorch/commit/a2c17a2b00f7c41866bbde28d33b8c50e5632e01 -- but in Python rather than C++


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler