### PR TITLE
Revert "Update triton ROCm version to 6.0"

### DIFF
--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -37,7 +37,7 @@ jobs:
         device: ["cuda", "rocm"]
         include:
           - device: "rocm"
-            rocm_version: "6.0"
+            rocm_version: "5.7"
           - device: "cuda"
             rocm_version: ""
     timeout-minutes: 40


### PR DESCRIPTION
Reverting [this commit](https://github.com/pytorch/pytorch/pull/117433) due to failures observed in wheel environment e.g: 
```
ImportError: /tmp/torchinductor_root/triton/0/ebfa57c0b7b95873c96cad6f9bca148d/hip_utils.so: undefined symbol: hipGetDevicePropertiesR0600`
```

Will revert for now and investigate and aim to re-land this as part of https://github.com/pytorch/pytorch/pull/116270


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang