### PR TITLE
[optim] lbfgs: handle complex params as independent real params

### DIFF
--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -540,19 +540,6 @@ def optim_inputs_func_lbfgs(device=None):
 
 def optim_error_inputs_func_lbfgs(device, dtype):
     error_inputs = get_error_inputs_for_all_optims(device, dtype)
-    if str(device) == "cpu":
-        complex_param = torch.rand(2, 3, device=device, dtype=torch.complex64)
-        error_inputs += [
-            ErrorOptimizerInput(
-                OptimizerInput(
-                    params=[complex_param],
-                    kwargs=dict(),
-                    desc="complex not supported",
-                ),
-                error_type=ValueError,
-                error_regex="LBFGS doesn't support complex parameters",
-            ),
-        ]
     return error_inputs
 
 

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -1383,11 +1383,6 @@ optim_db: List[OptimizerInfo] = [
                 "TestOptimRenewed",
                 "test_forloop_goes_right_direction_multigpu",
             ),
-            DecorateInfo(
-                unittest.skip("Missing complex support, see #118148"),
-                "TestOptimRenewed",
-                "test_complex",
-            ),
         ),
     ),
     OptimizerInfo(


### PR DESCRIPTION
Ref: #86340

Fixes #118148 

This fixes LBFGS for complex parameters. Complex parameters are handled as R^2.
I also added a test, unfortunately, due to the closure required, I could not use the existing `_test_complex_optimizer` used for all other optimizers.
Lbfgs is special, as it will call the objective function multiple times internally. So I felt making a one-off test for lbfgs might be justifiable. 
We will test if each step taken internally by the optimizer is the same for R^2 and complex parameters.

Let me know if the approach is ok, thanks
