### PR TITLE
[state_dict] Calls wait() for the DTensor to_local() result

### DIFF
--- a/torch/distributed/_state_dict_utils.py
+++ b/torch/distributed/_state_dict_utils.py
@@ -172,8 +172,9 @@ def _gather_state_dict(
             device_mesh=value.device_mesh,
             placements=placements,
         )
-        value = value.to_local()
-        return value
+        # Call `wait()` to force the tensor is synchronous with respect
+        # to the main stream.
+        return value.to_local().wait()
 
     return _iterate_state_dict(
         state_dict,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #118196
* #118195
* __->__ #118197

See the discussion in https://github.com/pytorch/pytorch/pull/117799.

There are some issues when returning a AsyncCollectiveTensor (haven't found the
root causes), including OOM and unexpected values.

This PR forces `_gather_state_dict()` to be synchronous with respect to the mian stream.

Differential Revision: [D53049807](https://our.internmc.facebook.com/intern/diff/D53049807/)

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225