### PR TITLE
Add torch_dynamo to resume_in for ease of debugging

### DIFF
--- a/torch/_dynamo/resume_execution.py
+++ b/torch/_dynamo/resume_execution.py
@@ -365,7 +365,7 @@ class ContinueExecutionCache:
             freevars = tuple(code_options["co_cellvars"] or []) + tuple(
                 code_options["co_freevars"] or []
             )
-            code_options["co_name"] = f"resume_in_{code_options['co_name']}_at_{lineno}"
+            code_options["co_name"] = f"torch_dynamo_resume_in_{code_options['co_name']}_at_{lineno}"
             if is_py311_plus:
                 qualified_path = code_options["co_qualname"].rsplit(".", maxsplit=1)
                 if len(qualified_path) == 1:
@@ -375,7 +375,7 @@ class ContinueExecutionCache:
                     module_name, co_name = qualified_path
                     code_options[
                         "co_qualname"
-                    ] = f"{module_name}.resume_in_{co_name}_at_{lineno}"
+                    ] = f"{module_name}.torch_dynamo_resume_in_{co_name}_at_{lineno}"
             code_options["co_firstlineno"] = lineno
             code_options["co_cellvars"] = tuple()
             code_options["co_freevars"] = freevars

--- a/torch/_dynamo/resume_execution.py
+++ b/torch/_dynamo/resume_execution.py
@@ -365,7 +365,9 @@ class ContinueExecutionCache:
             freevars = tuple(code_options["co_cellvars"] or []) + tuple(
                 code_options["co_freevars"] or []
             )
-            code_options["co_name"] = f"torch_dynamo_resume_in_{code_options['co_name']}_at_{lineno}"
+            code_options[
+                "co_name"
+            ] = f"torch_dynamo_resume_in_{code_options['co_name']}_at_{lineno}"
             if is_py311_plus:
                 qualified_path = code_options["co_qualname"].rsplit(".", maxsplit=1)
                 if len(qualified_path) == 1:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118201

resume_in_* code objects show up in user backtraces when failures occur
in code that has been Dynamo processed.  It is obvious to me, a PT2
developer, that these are generated by PT2, but it is NOT obvious to a
non-core dev that this is happened.  Add an extra torch_dynamo
breadcrumb to help get people to the right place.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng