### PR TITLE
Add stack trace to "start tracing" log

### DIFF
--- a/torch/_dynamo/logging.py
+++ b/torch/_dynamo/logging.py
@@ -51,7 +51,7 @@ def get_step_logger(logger):
 
     step = next(_step_counter)
 
-    def log(level, msg):
-        logger.log(level, "Step %s: %s", step, msg)
+    def log(level, msg, **kwargs):
+        logger.log(level, "Step %s: %s", step, msg, **kwargs)
 
     return log

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -2030,6 +2030,7 @@ class InstructionTranslator(InstructionTranslatorBase):
         _step_logger()(
             logging.INFO,
             f"torchdynamo start tracing {f_code.co_name} {code_options['co_filename']}:{code_options['co_firstlineno']}",
+            stack_info=True,
         )
         super().__init__(
             output=OutputGraph(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #118220
* __->__ #118217
* #118215

When debugging problems on unfamiliar model code, I often want to know
"how did I end up in this compiled region."  Printing the stack trace at
tracing start lets me find out this information.

Looks like this:

```
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO] Step 1: torchdynamo start tracing f /data/users/ezyang/c/pytorch/b.py:3
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO] Stack (most recent call last):
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]   File "/data/users/ezyang/c/pytorch/b.py", line 9, in <module>
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]     f(torch.randn(5))
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]   File "/data/users/ezyang/c/pytorch/torch/_dynamo/eval_frame.py", line 437, in _fn
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]     return fn(*args, **kwargs)
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]   File "/data/users/ezyang/c/pytorch/torch/_dynamo/eval_frame.py", line 601, in catch_errors
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]     return callback(frame, cache_entry, hooks, frame_state)
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]   File "/data/users/ezyang/c/pytorch/torch/_dynamo/convert_frame.py", line 743, in _convert_frame
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]     result = inner_convert(frame, cache_entry, hooks, frame_state)
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]   File "/data/users/ezyang/c/pytorch/torch/_dynamo/convert_frame.py", line 386, in _convert_frame_assert
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]     return _compile(
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]   File "/data/users/ezyang/c/pytorch/torch/_dynamo/convert_frame.py", line 645, in _compile
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]     guarded_code = compile_inner(code, one_graph, hooks, transform)
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]   File "/data/users/ezyang/c/pytorch/torch/_dynamo/utils.py", line 248, in time_wrapper
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]     r = func(*args, **kwargs)
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]   File "/data/users/ezyang/c/pytorch/torch/_dynamo/convert_frame.py", line 526, in compile_inner
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]     out_code = transform_code_object(code, transform)
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]   File "/data/users/ezyang/c/pytorch/torch/_dynamo/bytecode_transformation.py", line 1033, in transform_code_object
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]     transformations(instructions, code_options)
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]   File "/data/users/ezyang/c/pytorch/torch/_dynamo/convert_frame.py", line 151, in _fn
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]     return fn(*args, **kwargs)
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]   File "/data/users/ezyang/c/pytorch/torch/_dynamo/convert_frame.py", line 473, in transform
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]     tracer = InstructionTranslator(
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]   File "/data/users/ezyang/c/pytorch/torch/_dynamo/symbolic_convert.py", line 2030, in __init__
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]     _step_logger()(
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]   File "/data/users/ezyang/c/pytorch/torch/_dynamo/logging.py", line 55, in log
[2024-01-24 12:07:11,819] [0/1] torch._dynamo.symbolic_convert: [INFO]     logger.log(level, "Step %s: %s", step, msg, **kwargs)
```

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng