### PR TITLE
[dynamo] avoid graph break on tensor.element_size()

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -559,6 +559,12 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         return b.type(m.type())
 
     @make_test
+    def test_tensor_element_size(a):
+        if a.element_size() > 1:
+            return (a + a.element_size(), a - a.element_size())
+        return (a - a.element_size(), a + a.element_size())
+
+    @make_test
     def test_ndim(x):
         if x.ndim == 2 and x.ndimension() == 2 and x.dim() == 2:
             return x + 1

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1380,6 +1380,17 @@ utils_device.CURRENT_DEVICE == None""".split(
             expected_ops_dynamic=ifdynstaticdefault(3, 6),
         )
 
+    def test_element_size(self):
+        def fn(a):
+            return (a + a.element_size(), a - a.element_size())
+
+        return torch._dynamo.testing.standard_test(
+            self,
+            fn=fn,
+            nargs=1,
+            expected_ops=2,
+        )
+
     def test_pair(self):
         def fn(a):
             return (

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1380,17 +1380,6 @@ utils_device.CURRENT_DEVICE == None""".split(
             expected_ops_dynamic=ifdynstaticdefault(3, 6),
         )
 
-    def test_element_size(self):
-        def fn(a):
-            return (a + a.element_size(), a - a.element_size())
-
-        return torch._dynamo.testing.standard_test(
-            self,
-            fn=fn,
-            nargs=1,
-            expected_ops=2,
-        )
-
     def test_pair(self):
         def fn(a):
             return (

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -510,9 +510,7 @@ class TensorVariable(VariableTracker):
             index = self.device.index if self.device.type != "cpu" else -1
             constant_result = ConstantVariable.create(index)
         elif name == "element_size":
-            constant_result = ConstantVariable.create(
-                torch._utils._element_size(self.dtype)
-            )
+            constant_result = ConstantVariable.create(self.dtype.itemsize)
         else:
             constant_result = None
 

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -509,6 +509,10 @@ class TensorVariable(VariableTracker):
         elif name == "get_device" and isinstance(self.device, torch.device):
             index = self.device.index if self.device.type != "cpu" else -1
             constant_result = ConstantVariable.create(index)
+        elif name == "element_size":
+            constant_result = ConstantVariable.create(
+                torch._utils._element_size(self.dtype)
+            )
         else:
             constant_result = None
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118229

Before this PR, for the following code, we have a graph break `torch._dynamo.exc.Unsupported: torch.* op returned non-Tensor int call_method element_size`
```python
import torch
def f(x):
  return x.sin().element_size() + x.sin()

x = torch.randn(2, 2)
torch.compile(f, backend="eager", fullgraph=True)(x)
```
After this PR, we got the following graph, where element_size() is baked in as a constant.
```python
[2024-01-24 13:49:02,814] [0/0] torch._dynamo.output_graph.__graph_code: [DEBUG]  <eval_with_key>.0 class GraphModule(torch.nn.Module):
[2024-01-24 13:49:02,814] [0/0] torch._dynamo.output_graph.__graph_code: [DEBUG]     def forward(self, L_x_ : torch.Tensor):
[2024-01-24 13:49:02,814] [0/0] torch._dynamo.output_graph.__graph_code: [DEBUG]         l_x_ = L_x_
[2024-01-24 13:49:02,814] [0/0] torch._dynamo.output_graph.__graph_code: [DEBUG]         
[2024-01-24 13:49:02,814] [0/0] torch._dynamo.output_graph.__graph_code: [DEBUG]         # File: /home/yidi/local/pytorch/test.py:4 in f, code: return x.sin().element_size() + x.sin()
[2024-01-24 13:49:02,814] [0/0] torch._dynamo.output_graph.__graph_code: [DEBUG]         sin = l_x_.sin()
[2024-01-24 13:49:02,814] [0/0] torch._dynamo.output_graph.__graph_code: [DEBUG]         sin_1 = l_x_.sin();  l_x_ = None
[2024-01-24 13:49:02,814] [0/0] torch._dynamo.output_graph.__graph_code: [DEBUG]         add = 4 + sin_1;  sin_1 = None
[2024-01-24 13:49:02,814] [0/0] torch._dynamo.output_graph.__graph_code: [DEBUG]         return (add,)
```
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng