### PR TITLE
Fix return type hint for list types

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1289,7 +1289,7 @@ def tensor_split_tensor_indices_or_sections_py_impl(
     self: Tensor,
     tensor_indices_or_sections: Tensor,
     dim: int = 0,
-) -> List[Tensor]:
+) -> Tuple[Tensor, ...]:
     assert tensor_indices_or_sections.device.type == "cpu"
     assert tensor_indices_or_sections.dtype == torch.int64
     split_dim = tensor_indices_or_sections.dim()

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1689,7 +1689,7 @@ def norm(input, p: Optional[Union[float, str]] = "fro", dim=None, keepdim=False,
             else:
                 return _VF.norm(input, p, _dim, keepdim=keepdim, dtype=dtype, out=out)  # type: ignore[attr-defined]
 
-def unravel_index(indices: Tensor, shape: Union[int, Sequence[int], torch.Size]) -> List[Tensor]:
+def unravel_index(indices: Tensor, shape: Union[int, Sequence[int], torch.Size]) -> Tuple[Tensor, ...]:
     r"""Converts a tensor of flat indices into a tuple of coordinate tensors that
     index into an arbitrary tensor of the specified shape.
 

--- a/torch/nested/__init__.py
+++ b/torch/nested/__init__.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Sequence
 
 import torch
 from torch import SymInt, Tensor
@@ -17,7 +17,7 @@ __all__ = [
 
 
 def as_nested_tensor(
-    tensor_list: List[Tensor],
+    tensor_list: Sequence[Tensor],
     dtype: Optional[DType] = None,
     device: Optional[Device] = None,
     layout=None

--- a/torchgen/api/python.py
+++ b/torchgen/api/python.py
@@ -988,7 +988,7 @@ def return_type_str_pyi(t: Type) -> str:
 
     if isinstance(t, ListType):
         inner = return_type_str_pyi(t.elem)
-        return f"List[{inner}]"
+        return f"Tuple[{inner}, ...]"
 
     return argument_type_str_pyi(t)
 


### PR DESCRIPTION
All single element list types are `Tensor[]` so they will always be Tuple.
I don't know of any way to easily access the pyi type and compare that to a real run so no testing here :( 