### PR TITLE
[ONNX] Fix type promotion pass

### DIFF
--- a/torch/onnx/_internal/fx/passes/type_promotion.py
+++ b/torch/onnx/_internal/fx/passes/type_promotion.py
@@ -24,7 +24,7 @@ from torch._prims_common import (
 from torch._refs import linalg as _linalg_refs, nn as _nn_refs, special as _special_refs
 from torch._refs.nn import functional as _functional_refs
 from torch._subclasses import fake_tensor
-from torch.fx.experimental import proxy_tensor, symbolic_shapes
+from torch.fx.experimental import proxy_tensor
 
 # Imported to resolve beartype issue when type checking node.Argument.
 from torch.fx.node import Node  # noqa: F401
@@ -67,30 +67,6 @@ class TypePromotionSnapshot:
 
     out_dtype: torch.dtype
     """Expected output dtype of the node."""
-
-
-@_beartype.beartype
-def _fake_tensor_from_node_val(
-    node: torch.fx.Node,
-) -> Union[fake_tensor.FakeTensor, int, float, bool]:
-    """Syntactic sugar for retrieving fake tensor from node.meta['val']."""
-    val = node.meta.get("val", None)
-    if isinstance(val, fake_tensor.FakeTensor):
-        return val
-    elif isinstance(val, (torch.SymInt, torch.SymFloat, torch.SymBool)):
-        # For type promotion, the actual value should not matter. For example,
-        # we can return any `int` for a `torch.SymInt` node. Let's
-        # remove this assert and return dummy values (e.g., 0 for SymInt,
-        # 0.0 for SymFloat, and false for SymBool) if finding the hint
-        # becomes a problem.
-        assert symbolic_shapes.has_hint(
-            val.node
-        ), f"Cannot retrieve hint value from torch.Sym* node {node}."
-        return val.node.hint
-    else:
-        raise RuntimeError(
-            f"Cannot retrieve fake tensor from node {node}. Got type({type(val)}) instead."
-        )
 
 
 class TypePromotionRule(abc.ABC):
@@ -1699,7 +1675,19 @@ class InsertTypePromotion(_pass.Transform):
 
     def _fetch_fake_args(
         self,
-    ) -> Sequence[Optional[Union[fake_tensor.FakeTensor, float, int, bool]]]:
+    ) -> Sequence[
+        Optional[
+            Union[
+                fake_tensor.FakeTensor,
+                float,
+                int,
+                bool,
+                torch.SymInt,
+                torch.SymFloat,
+                torch.SymBool,
+            ]
+        ]
+    ]:
         """Fetch fake args from fx graph.
 
         For each argument, try to fetch fake tensor from the matching placeholder node.
@@ -1708,12 +1696,14 @@ class InsertTypePromotion(_pass.Transform):
         for node in self.module.graph.nodes:
             if node.op == "placeholder":
                 try:
-                    fake_tensor = _fake_tensor_from_node_val(node)
+                    # Meta value can be torch.Tensor, int, float, bool,
+                    # torch.SymInt, torch.SymFloat, torch.SymBool.
+                    meta_value = _val = node.meta.get("val", None)
                 except RuntimeError as e:
                     if not node.users:
                         # If the placeholder is not used, we can safely ignore it and put
                         # None as placeholder.
-                        fake_tensor = None
+                        meta_value = None
                     else:
                         raise RuntimeError(
                             "Cannot fetch symbolic fake args from fx graph. "
@@ -1721,7 +1711,7 @@ class InsertTypePromotion(_pass.Transform):
                             "Otherwise the pass will produce inaccurate dynamic shape. "
                         ) from e
 
-                fake_args.append(fake_tensor)
+                fake_args.append(meta_value)
         return fake_args
 
     @_beartype.beartype


### PR DESCRIPTION
Currently, when `node.meta["val"]` is `torch.Sym*`, its `hint` [is extracted](https://github.com/pytorch/pytorch/blob/61865205b6ad366c97159bef424b74c3f3db96df/torch/onnx/_internal/fx/passes/type_promotion.py#L86) and used in type promotion. However, it will [override](https://github.com/pytorch/pytorch/blob/61865205b6ad366c97159bef424b74c3f3db96df/torch/onnx/_internal/fx/passes/type_promotion.py#L1409) dynamic shape information carried in `node.meta["val"]` during [type propagation](https://github.com/pytorch/pytorch/blob/61865205b6ad366c97159bef424b74c3f3db96df/torch/onnx/_internal/fx/passes/type_promotion.py#L1401) and the FX graph seen in `onnxrt` always carries static shapes. Let's use `torch.Sym*` directly so that the type promotion propagates and stores dynamic shapes.