### PR TITLE
Fix node traversal when setting up stacktrace preservation hooks

### DIFF
--- a/torch/_functorch/_aot_autograd/logging_utils.py
+++ b/torch/_functorch/_aot_autograd/logging_utils.py
@@ -65,7 +65,7 @@ def setup_stacktrace_preservation_hooks(roots: List):
         seen = set()
         q = collections.deque()  # type: ignore[var-annotated]
         for node in roots:
-            if node is not None:
+            if node is not None and node not in seen:
                 seen.add(node)
                 q.append(node)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118252
* #118249
* #118234
* #117552

We only want to traverse over each node in the graph exactly once, and we do that by inserting nodes into the "seen" set. The issue is that we forget to check the "seen" set when inserting the root nodes. Typically that is not a problem, because the root nodes are from the different outputs and thus usually correspond to different nodes. With split_with_sizes, though all of the outputs correspond to the same node, ands this leads to the node being iterated over 3 times, and 3 sets of hooks being attached to the same node.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng