### PR TITLE
[c10d] relax the nccl error check for nonblocking mode

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -231,6 +231,9 @@ class ProcessGroupNCCLTest(MultiProcessTestCase):
         # that use TORCH_NCCL_BLOCKING_WAIT will test it as expected.
         os.environ["TORCH_NCCL_ASYNC_ERROR_HANDLING"] = "1"
         # self.num_gpus = torch.cuda.device_count()
+        # To test NONBLOCKING NCCL calls
+        # os.environ["TORCH_NCCL_USE_COMM_NONBLOCKING"] = "1"
+        # os.environ["TORCH_NCCL_NONBLOCKING_TIMEOUT"] = "10"
         self._spawn_processes()
 
     def tearDown(self):

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1697,7 +1697,10 @@ std::exception_ptr ProcessGroupNCCL::checkForNCCLErrorsInternal(
               *commFailureReason)));
     }
     ncclResult_t ncclAsyncErr = ncclComm->checkForNcclError();
-    if (ncclAsyncErr != ncclSuccess) {
+    // When nonblocking mode is enabled by TORCH_NCCL_USE_COMM_NONBLOCKING,
+    // ncclInProgress could be returned when there are pending NCCL calls.
+    // In this case, no exception should be thrown
+    if (ncclAsyncErr != ncclSuccess && ncclAsyncErr != ncclInProgress) {
       return std::make_exception_ptr(C10_BUILD_ERROR(
           DistBackendError,
           "NCCL error: " + ncclGetErrorWithVersion(ncclAsyncErr) + "\n" +


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #118256
* __->__ #118254

resolve https://github.com/pytorch/pytorch/issues/117749

Summary:
This is the first step to enable NCCL nonblocking mode.

In NCCL nonblocking mode,  ncclInProgress is an expected return value
when checking communicators. Without this relaxation, watchdog thread
would throw NCCL errors during work checking while it is expected.

Test Plan:
Set nonblocking mode in unit tests, and make sure all existing NCCL
tests pass
Reviewers:

Subscribers:

Tasks:

Tags:

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225