### PR TITLE
Fix mergeability check for ghstack PRs

### DIFF
--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -155,8 +155,12 @@ class GitRepo:
         )
         return [x.strip() for x in rc.split("\n") if x.strip()] if len(rc) > 0 else []
 
-    def current_branch(self) -> str:
-        return self._run_git("symbolic-ref", "--short", "HEAD").strip()
+    def current_branch(self) -> Optional[str]:
+        try:
+            return self._run_git("symbolic-ref", "--short", "HEAD").strip()
+        except RuntimeError:
+            # we are in detached HEAD state
+            return None
 
     def checkout(self, branch: str) -> None:
         self._run_git("checkout", branch)
@@ -273,6 +277,7 @@ class GitRepo:
 
     def cherry_pick_commits(self, from_branch: str, to_branch: str) -> None:
         orig_branch = self.current_branch()
+        assert orig_branch is not None, "Must be on a branch"
         self.checkout(to_branch)
         from_commits, to_commits = self.compute_branch_diffs(from_branch, to_branch)
         if len(from_commits) == 0:

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -140,6 +140,7 @@ def mock_parse_args(revert: bool = False, force: bool = False) -> Any:
             self.comment_id = 0
             self.reason = "this is for testing"
             self.ignore_current = False
+            self.check_mergeability = False
 
     return Object()
 

--- a/.github/workflows/check_mergeability_ghstack.yml
+++ b/.github/workflows/check_mergeability_ghstack.yml
@@ -5,25 +5,98 @@ on:
     types: [opened, synchronize, reopened, edited]
 
 jobs:
-  check-regex:
+  pr-dependencies-check:
     runs-on: ubuntu-latest
     outputs:
       regex-match: ${{ steps.regex-match.outputs.match }}
     steps:
-      - uses: actions/checkout@v4
-
       - id: regex-match
+        # checks whether the PR is a ghstack PR
         uses: actions-ecosystem/action-regex-match@d50fd2e7a37d0e617aea3d7ada663bd56862b9cc
         with:
           text: ${{ github.head_ref }}
           regex: '^(gh/[^/]+/[0-9]+/)head$'
 
-  pr-dependencies-check:
-    needs: check-regex
-    if: ${{ needs.check-regex.outputs.regex-match != '' }}
-    uses: pytorch/test-infra/.github/workflows/pr-dependencies-check.yml@main
-    with:
-      pr_number: ${{ github.event.pull_request.number }}
+      - name: Determine if should run
+        # checks whether the PR is a ghstack PR or whether PR changes the workflow files
+        id: should-run
+        shell: bash
+        run: |
+          # use GITHUB API to get the files changed in the PR
+          # and check if the following files were changed:
+          # .github/workflows/check_mergeability_ghstack.yml
+          # .github/scripts/trymerge.py
+          FILES_CHANGED=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              "https://api.github.com/repos/pytorch/pytorch/pulls/${{ github.event.pull_request.number }}/files" | \
+              jq -r '.[].filename' | \
+              grep -Ec '^.github/workflows/check_mergeability_ghstack.yml$|^.github/scripts/trymerge.py$')
+
+          IS_GHSTACK_PR="${{ steps.regex-match.outputs.match != '' }}"
+
+          echo "Is ghstack PR: $IS_GHSTACK_PR"
+          echo "Workflow files affected by the PR: $FILES_CHANGED"
+
+          if [ "$IS_GHSTACK_PR" = "true" ] || [ "$FILES_CHANGED" -gt 0 ]; then
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should-run=false" >> "$GITHUB_OUTPUT"
+
+            {
+              echo "# The $PR_NUM is not a ghstack PR"
+              echo "For regular PRs the mergeability is reported correctly by GitHub."
+              echo "To debug the dependencies of the PR manually, run the diagnostic workflow:"
+              echo "https://github.com/pytorch/test-infra/actions/workflows/pr-dependencies-check.yml"
+            } >> "$GITHUB_STEP_SUMMARY"
+
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.should-run.outputs.should-run == 'true'
+        with:
+          fetch-depth: 0
+
+      - name: Setup git
+        if: steps.should-run.outputs.should-run == 'true'
+        shell: bash
+        run: |
+          git config --global user.email "pytorchmergebot@users.noreply.github.com"
+          git config --global user.name "PyTorch MergeBot"
+          git fetch origin main
+
+      - name: Setup Python
+        if: steps.should-run.outputs.should-run == 'true'
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+          cache: pip
+          architecture: x64
+
+      - run: pip install pyyaml==6.0 rockset==1.0.3
+        if: steps.should-run.outputs.should-run == 'true'
+        shell: bash
+
+      - name: Verify mergeability
+        if: steps.should-run.outputs.should-run == 'true'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+        run: |
+          set -ex
+          python3 .github/scripts/trymerge.py --check-mergeability "${PR_NUM}"
+
+      - name: Print debug info
+        if: failure()
+        shell: bash
+        env:
+          PR_NUM: ${{ github.event.pull_request.number }}
+        run: |
+          {
+            echo "# PR $PR_NUM is not mergeable into main"
+            echo "To debug, run the diagnostic workflow:"
+            echo "https://github.com/pytorch/test-infra/actions/workflows/pr-dependencies-check.yml"
+          } >> "$GITHUB_STEP_SUMMARY"
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/check_mergeability_ghstack.yml
+++ b/.github/workflows/check_mergeability_ghstack.yml
@@ -1,16 +1,14 @@
-name: Check mergeability and dependencies for ghstack prs
+name: Check mergeability of ghstack PR
 
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
 jobs:
-  pr-dependencies-check:
+  ghstack-mergeability-check:
     runs-on: ubuntu-latest
-    outputs:
-      regex-match: ${{ steps.regex-match.outputs.match }}
     steps:
-      - id: regex-match
+      - id: check-if-ghstack
         # checks whether the PR is a ghstack PR
         uses: actions-ecosystem/action-regex-match@d50fd2e7a37d0e617aea3d7ada663bd56862b9cc
         with:
@@ -31,7 +29,7 @@ jobs:
               jq -r '.[].filename' | \
               grep -Ec '^.github/workflows/check_mergeability_ghstack.yml$|^.github/scripts/trymerge.py$')
 
-          IS_GHSTACK_PR="${{ steps.regex-match.outputs.match != '' }}"
+          IS_GHSTACK_PR="${{ steps.check-if-ghstack.outputs.match != '' }}"
 
           echo "Is ghstack PR: $IS_GHSTACK_PR"
           echo "Workflow files affected by the PR: $FILES_CHANGED"


### PR DESCRIPTION
# Changes
* introduce `--check-mergeability` trymerge flag that attempts to merge PR locally, using the same merge logic as the mergebot, but requires just a read-only `GITHUB_TOKEN` and git repo.
* change mergeability workflow to utilize the new --check-mergeability logic

# Alternatives considered

1. 
> Rewrite `https://github.com/pytorch/test-infra/actions/workflows/pr-dependencies-check.yml` to correctly support partially merged ghstacks.

That would be a slightly better approach, but ROI is lower, as it requires reimplementing trymerge logic and additional effort to consolidate the codebase (trymerge lives in pytorch repo).

`pr-dependencies-check.yml` still produces human-readable results for partially merged ghstack prs (even if it falsely reports them as non-mergeable).

2. 

> Instead of introducing new trymerge flag, use existing flags, including `--dry-run`.

That didn't work, as no combination of existing flags skips the rule checks and ROCKSET lookups.


# Testing

1. Manual testing  `trymerge.py --check-mergeability`  on the regular and ghstack PRs:

```
export GITHUB_TOKEN=
export GIT_REPO_DIR=`pwd`
export GITHUB_REPOSITORY=pytorch/pytorch
export GIT_REMOTE_URL=https://github.com/pytorch/pytorch


# Test 1 (2 prs, 1 is closed)
python3 ../pytorch/.github/scripts/trymerge.py --check-mergeability  117862
Skipping 1 of 2 PR (#117859) as its already been merged

echo $?
0

# Test 2 (3 prs, 1 is closed)
python3 ../pytorch/.github/scripts/trymerge.py --check-mergeability  118125
Skipping 1 of 3 PR (#117859) as its already been merged

echo $?
0

# Test 3 (3 prs, intentional conflicts introduced into `main`):

python3 ../pytorch/.github/scripts/trymerge.py --check-mergeability  118125
Skipping 1 of 3 PR (#117859) as its already been merged
stdout:
Auto-merging torch/_inductor/ir.py
Auto-merging torch/_inductor/lowering.py
CONFLICT (content): Merge conflict in torch/_inductor/lowering.py
error: could not apply 66ba5b8792f... Realize inputs to DynamicScalar before unwrapping 
...
RuntimeError: Command `git -C /Users/ivanzaitsev/pytorch2 cherry-pick -x 66ba5b8792fa076c4e512d920651e5b6b7e466f4` returned non-zero exit code 1
```

2.  Workflow run:
https://github.com/pytorch/pytorch/actions/runs/7660736172/job/20878651852?pr=118258

<img width="516" alt="image" src="https://github.com/pytorch/pytorch/assets/108101595/28fbf0d2-ac2a-4518-b41d-b32b41373747">
<img width="621" alt="image" src="https://github.com/pytorch/pytorch/assets/108101595/ddbf8566-a417-43ec-9d0e-f623f4a71313">
