### PR TITLE
[export] Various fixes to .module()

### DIFF
--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -1,76 +1,102 @@
 import copy
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 import torch.utils._pytree as pytree
 from torch._export.utils import _check_input_constraints_pre_hook
 from torch.fx.graph import _PyTreeCodeGen, _PyTreeInfo
 
-from .exported_program import ExportedProgram
+from .exported_program import (
+    ExportedProgram,
+    ExportGraphSignature,
+    InputKind,
+    OutputKind,
+)
 
 
-def _unlift(
-    gm,
-    inp_pos_to_param_buffer_name,
-    in_spec,
-    out_spec,
-    state_dict,
-    tensor_constants,
-    buffers_to_mutate,
-):
-    count = 0
-    buffer_name_to_node = {}
-    # Step 1: make lifted params as get_attr
+def _unlift_inputs_as_getattr(
+    gm: torch.fx.GraphModule,
+    lifted_inputs: List[Optional[str]],
+) -> Tuple[Dict[str, torch.fx.Node], Dict[str, torch.fx.Node]]:
+    """
+    Unlift inputs referring to params/buffers/constants as getattr nodes in the
+    graph
+    """
+    unlifted_name_to_node = {}
+    input_name_to_node = {}
+
+    placeholder_nodes = [node for node in gm.graph.nodes if node.op == "placeholder"]
+    assert len(lifted_inputs) == len(placeholder_nodes)
+    for input_node, lifted_node in zip(placeholder_nodes, lifted_inputs):
+        if lifted_node is None:
+            input_name_to_node[input_node.name] = input_node
+
+        else:
+            with gm.graph.inserting_after(input_node):
+                getattr_node = gm.graph.get_attr(lifted_node.replace(".", "_"))
+                input_node.replace_all_uses_with(getattr_node)
+                metadata = input_node.meta
+                gm.graph.erase_node(input_node)
+                getattr_node.meta = metadata
+                unlifted_name_to_node[lifted_node.replace(".", "_")] = getattr_node
+
+    return unlifted_name_to_node, input_name_to_node
+
+
+def _insert_copy_for_mutations(
+    gm: torch.fx.GraphModule,
+    mutated_outputs: List[Optional[str]],
+    unlifted_name_to_node: Dict[str, torch.fx.Node],
+    input_name_to_node: Dict[str, torch.fx.Node],
+) -> None:
+    """
+    Find the all the buffers and inputs that were mutated and insert copy_
+    operators to reflect mutations.
+    """
+    output_node = None
     for node in gm.graph.nodes:
-        if node.op == "placeholder":
-            if count in inp_pos_to_param_buffer_name:
-                with gm.graph.inserting_after(node):
-                    getattr_node = gm.graph.get_attr(
-                        inp_pos_to_param_buffer_name[count]
-                    )
-                    node.replace_all_uses_with(getattr_node)
-                    metadata = node.meta
-                    gm.graph.erase_node(node)
-                    getattr_node.meta = metadata
-                    buffer_name_to_node[
-                        inp_pos_to_param_buffer_name[count]
-                    ] = getattr_node
-
-            count += 1
-        # Step 2: Find the all the buffers that were mutated and update them
         if node.op == "output":
-            user_output_nodes = []
-            # In the case that the same node is returned multiple times,
-            # node.all_input_nodes will only iterate that node once
-            for return_node in pytree.tree_flatten(node.args)[0]:
-                return_node_name = (
-                    return_node.name
-                    if isinstance(return_node, torch.fx.Node)
-                    else return_node
-                )
-                # we found a param/buffer mutation
-                if return_node_name in buffers_to_mutate:
-                    # TODO Fix situation here to replace dot with underscore...
-                    buffer_node_name = buffers_to_mutate[return_node_name].replace(
-                        ".", "_"
-                    )
-                    assert buffer_node_name in buffer_name_to_node
-                    buffer_node = buffer_name_to_node[buffer_node_name]
-                    with gm.graph.inserting_before(node):
-                        buffer_update_node = gm.graph.call_function(
-                            torch.ops.aten.copy_.default, (buffer_node, return_node)
-                        )
-                else:
-                    user_output_nodes.append(return_node)
-            with gm.graph.inserting_before(node):
-                # Only return user outputs
-                new_output = gm.graph.output(tuple(user_output_nodes))
-                node.replace_all_uses_with(new_output)
-                gm.graph.erase_node(node)
+            output_node = node
+            break
+    assert output_node is not None
+    outputs = pytree.tree_flatten(output_node.args)[0]
+    assert len(outputs) == len(mutated_outputs)
 
-    # Step 3: Fix the input/output of the graph now that we deleted
-    # some args.
-    gm.graph.lint()
+    user_output_nodes = []
+    for return_node, mutated_node_name in zip(outputs, mutated_outputs):
+        if mutated_node_name is None:
+            user_output_nodes.append(return_node)
+            continue
 
+        mutated_node_name = mutated_node_name.replace(".", "_")
+        if mutated_node_name in unlifted_name_to_node:
+            mutated_node = unlifted_name_to_node[mutated_node_name]
+        elif mutated_node_name in input_name_to_node:
+            mutated_node = input_name_to_node[mutated_node_name]
+        else:
+            raise RuntimeError(
+                f"Could not find {mutated_node_name} in either buffer or input nodes"
+            )
+
+        with gm.graph.inserting_before(output_node):
+            _ = gm.graph.call_function(
+                torch.ops.aten.copy_.default, (mutated_node, return_node)
+            )
+
+    with gm.graph.inserting_before(output_node):
+        # Only return user outputs
+        new_output = gm.graph.output(tuple(user_output_nodes))
+        output_node.replace_all_uses_with(new_output)
+        gm.graph.erase_node(output_node)
+
+
+def _get_codegen(
+    in_spec: pytree.TreeSpec,
+    out_spec: Optional[pytree.TreeSpec],
+) -> _PyTreeCodeGen:
+    """
+    Create the codegen for the graph module based on the in/out specs
+    """
     if (
         in_spec.type == tuple
         and in_spec.num_children == 2
@@ -78,200 +104,219 @@ def _unlift(
         and in_spec.children_specs[1].type == dict
     ):
         # if in_spec contains the args (tuple) and kwargs (dict)
-        num_args = (
-            in_spec.children_specs[0].num_children
-            + in_spec.children_specs[1].num_children
-        )
+        names = [f"arg_{i}" for i in range(in_spec.children_specs[0].num_children)]
+        # add kwarg names
+        names.extend(in_spec.children_specs[1].context)
     else:
-        num_args = in_spec.num_children
+        names = [f"arg_{i}" for i in range(in_spec.num_children)]
 
-    names = [f"arg_{i}" for i in range(num_args)]
-
-    gm.graph._codegen = _PyTreeCodeGen(
+    return _PyTreeCodeGen(
         _PyTreeInfo(
             names,
             in_spec,
             out_spec,
         )
     )
+
+
+def _unlift_submod_inputs(
+    submod: torch.fx.GraphModule,
+    inputs: List[torch.fx.Node],
+    toplevel_gm: torch.fx.GraphModule,
+    toplevel_unlifted_nodes: List[torch.fx.Node],
+) -> Tuple[List[Optional[str]], List[torch.fx.Node]]:
+    """
+    Given a list of nodes being passed to the the submodule, if any of them
+    belong to an input that should be unlifted (ex. parameter/buffer), we should
+    remove it from the argument list and register the actual parameter/bffer
+    value to the submodule. A later recursive call to _unlift() on the submodule
+    parent module will fix the graph inside of the submodule to use unlifted
+    inputs.
+    """
+    submod_lifted_inputs: List[Optional[str]] = []
+    real_inputs = []
+    for inp in inputs:
+        if inp in toplevel_unlifted_nodes:
+            assert isinstance(inp.target, str)
+            submod_lifted_inputs.append(inp.target)
+            if inp.target not in toplevel_gm.state_dict():
+                raise RuntimeError("Unable to find value for ", inp.target)
+
+            submod.register_buffer(inp.target, toplevel_gm.state_dict()[inp.target])
+        else:
+            submod_lifted_inputs.append(None)
+            real_inputs.append(inp)
+
+    return submod_lifted_inputs, real_inputs
+
+
+def _unlift(
+    gm: torch.fx.GraphModule,
+    lifted_inputs: List[Optional[str]],
+    mutated_outputs: List[Optional[str]],
+    in_spec: pytree.TreeSpec,
+    out_spec: Optional[pytree.TreeSpec],
+    state_dict: Dict[str, Any],
+    constants: Dict[str, Any],
+):
+    """
+    Args:
+        lifted_inputs: A list matching the graph module's input nodes. For
+        an input node that is referring to a lifted parameter/buffer, this
+        list will contain the fqn the corresponding attribute. Otherwise, this
+        list will contain None. This is used to unlift the lifted parameters as
+        get_attr nodes.
+
+        mutated_outputs: A list matching the graph module's output nodes. For
+        an output node that is referring to a mutated buffer or user input, this
+        list will contain the name of the corresponding buffer or user input
+        that needs to be mutated. Otherwise, this list will contain None. This
+        is used to re-insert an inplace copy_ operator to copy the mutated
+        values back to the original node.
+    """
+    unlifted_name_to_node, input_name_to_node = _unlift_inputs_as_getattr(
+        gm, lifted_inputs
+    )
+    _insert_copy_for_mutations(
+        gm, mutated_outputs, unlifted_name_to_node, input_name_to_node
+    )
+    unlifted_nodes = list(unlifted_name_to_node.values())
+
+    gm.graph.lint()
+
+    gm.graph._codegen = _get_codegen(in_spec, out_spec)
     gm.recompile()
 
     # Step 4: Find state references in HigherOrderOps and recursively
     # fix them.
     for node in gm.graph.nodes:
-        if node.op == "call_function" and node.target == torch.ops.cond:
+        if node.op == "call_function" and node.target.__name__ == "cond":
             pred, true_graph, false_graph, operands = node.args
             true_gm = getattr(gm, true_graph.name)
             false_gm = getattr(gm, false_graph.name)
-            inp_pos_to_param_buffer_name_for_submod = {}
-            real_operands = []
-            for ix, operand in enumerate(operands):
-                if operand.target in inp_pos_to_param_buffer_name.values():
-                    inp_pos_to_param_buffer_name_for_submod[ix] = operand.target
-                    if operand.target in state_dict:
-                        value = state_dict[operand.target]
-                    elif operand.target in tensor_constants:
-                        value = tensor_constants[operand.target]
-                    else:
-                        raise RuntimeError("Unable to find value for ", operand.target)
-                    true_gm.register_buffer(operand.target, value)
-                    false_gm.register_buffer(operand.target, value)
-                else:
-                    real_operands.append(operand)
-            node.args = (pred, true_graph, false_graph, real_operands)
 
-            _, in_spec = pytree.tree_flatten(real_operands)
+            submod_lifted_inputs1, real_operands1 = _unlift_submod_inputs(
+                true_gm, operands, gm, unlifted_nodes
+            )
+            submod_lifted_inputs2, real_operands2 = _unlift_submod_inputs(
+                false_gm, operands, gm, unlifted_nodes
+            )
+            assert submod_lifted_inputs1 == submod_lifted_inputs2
+            assert real_operands1 == real_operands2
+
+            node.args = (pred, true_graph, false_graph, real_operands1)
+
+            _, in_spec = pytree.tree_flatten(real_operands1)
+
+            # Currently HOO submodules do not allow mutations, so we
+            # will not need to handle this.
+            output_node = None
+            for node in gm.graph.nodes:
+                if node.op == "output":
+                    output_node = node
+                    break
+            assert output_node is not None
+            outputs = pytree.tree_flatten(output_node.args)[0]
+            mutated_outputs = [None for _ in range(len(outputs))]
 
             _unlift(
                 true_gm,
-                inp_pos_to_param_buffer_name_for_submod,
+                submod_lifted_inputs1,
+                mutated_outputs,
                 in_spec,
                 None,
                 state_dict,
-                tensor_constants,
-                buffers_to_mutate,
+                constants,
             )
             _unlift(
                 false_gm,
-                inp_pos_to_param_buffer_name_for_submod,
+                submod_lifted_inputs1,
+                mutated_outputs,
                 in_spec,
                 None,
                 state_dict,
-                tensor_constants,
-                buffers_to_mutate,
+                constants,
             )
-        if node.op == "call_function" and node.target.__name__ == "map_impl":
-            body_graph, mapped_args, operands = node.args
-            num_mapped = len(mapped_args)
-            body_gm = getattr(gm, body_graph.name)
-            inp_pos_to_buffer_name_for_submod = {}
-            # TODO Fix situation here to replace dot with underscore...
-            state_dict_for_lookup = {
-                key.replace(".", "_"): value for key, value in state_dict.items()
-            }
 
-            def _find_real_operands(operands, start_ix):
+        elif node.op == "call_function" and node.target.__name__ == "map_impl":
+            body_graph, mapped_args, operands = node.args
+            body_gm = getattr(gm, body_graph.name)
+
+            def _find_real_operands(operands):
+                submod_lifted_inputs = []
                 real_operands = []
                 for ix, operand in enumerate(operands):
-                    if operand.target in inp_pos_to_param_buffer_name.values():
-                        inp_pos_to_buffer_name_for_submod[
-                            ix + start_ix
-                        ] = operand.target
-                        if operand.target in state_dict_for_lookup:
-                            value = state_dict_for_lookup[operand.target]
-                        elif operand.target in tensor_constants:
-                            value = tensor_constants[operand.target]
+                    if operand.target in lifted_inputs:
+                        submod_lifted_inputs.append(operand.target)
+                        if operand.target in state_dict:
+                            value = state_dict[operand.target]
+                        elif operand.target in constants:
+                            value = constants[operand.target]
                         else:
                             raise RuntimeError(
-                                f"Unable to find value for {operand.target}"
+                                "Unable to find value for ", operand.target
                             )
 
                         body_gm.register_buffer(operand.target, value)
                     else:
+                        submod_lifted_inputs.append(None)
                         real_operands.append(operand)
-                return real_operands
 
-            real_mapped_args = _find_real_operands(mapped_args, 0)
-            real_mapped_operands = _find_real_operands(operands, num_mapped)
+                return submod_lifted_inputs, real_operands
+
+            lifted_args, real_mapped_args = _unlift_submod_inputs(
+                body_gm, mapped_args, gm, unlifted_nodes
+            )
+            lifted_operands, real_mapped_operands = _unlift_submod_inputs(
+                body_gm, operands, gm, unlifted_nodes
+            )
+
             node.args = (body_graph, real_mapped_args, real_mapped_operands)
+            submod_lifted_inputs = lifted_args + lifted_operands
 
             _, in_spec = pytree.tree_flatten(real_mapped_args + real_mapped_operands)
 
+            # Currently HOO submodules do not allow mutations, so we
+            # will not need to handle this.
+            output_node = None
+            for node in gm.graph.nodes:
+                if node.op == "output":
+                    output_node = node
+                    break
+            assert output_node is not None
+            outputs = pytree.tree_flatten(output_node.args)[0]
+            mutated_outputs = [None for _ in range(len(outputs))]
+
             _unlift(
                 body_gm,
-                inp_pos_to_buffer_name_for_submod,
+                submod_lifted_inputs,
+                mutated_outputs,
                 in_spec,
                 None,
                 state_dict,
-                tensor_constants,
-                buffers_to_mutate,
+                constants,
             )
+
     gm.graph.lint()
     gm.graph.eliminate_dead_code()
     gm.recompile()
     return gm
 
 
-def _construct_inp_pos_to_param_buffer_name(
-    new_gm, graph_signature, state_dict, tensor_constants=None
-):
-    # TODO Fix the period in params/buffers names later
-    # maybe a pass to replace graph signature with fixed names
-    param_buffer_name_to_corrected_name = {}
-    constant_name_to_corrected_name = {}
-
+def _register_attrs_to_new_gm(
+    new_gm: torch.fx.GraphModule,
+    graph_signature: ExportGraphSignature,
+    state_dict: Dict[str, Any],
+    constants: Dict[str, Any],
+) -> None:
     for name, value in state_dict.items():
         if name in graph_signature.buffers:
-            if "." in name:
-                new_gm.register_buffer(name.replace(".", "_"), value)
-                param_buffer_name_to_corrected_name[name] = name.replace(".", "_")
-            else:
-                new_gm.register_buffer(name, value)
+            new_gm.register_buffer(name.replace(".", "_"), value)
         if name in graph_signature.parameters:
-            if "." in name:
-                new_gm.register_parameter(name.replace(".", "_"), value)
-                param_buffer_name_to_corrected_name[name] = name.replace(".", "_")
-            else:
-                new_gm.register_parameter(name, value)
+            new_gm.register_parameter(name.replace(".", "_"), value)
 
-    if tensor_constants is not None and len(tensor_constants) > 0:
-        assert hasattr(graph_signature, "lifted_tensor_constants")
-        for name, value in tensor_constants.items():
-            if name in graph_signature.lifted_tensor_constants:
-                if isinstance(value, torch.Tensor):
-                    new_gm.register_buffer(name.replace(".", "_"), value)
-                else:
-                    setattr(new_gm, name.replace(".", "_"), value)
-                constant_name_to_corrected_name[name] = name.replace(".", "_")
-            elif name in graph_signature.lifted_custom_objs:
-                assert isinstance(value, torch.ScriptObject)
-                setattr(new_gm, name.replace(".", "_"), value)
-                constant_name_to_corrected_name[name] = name.replace(".", "_")
-
-    count = 0
-    inp_pos_to_param_buffer_name = {}
-    for node in new_gm.graph.nodes:
-        if node.op == "placeholder":
-            if node.name in graph_signature.inputs_to_buffers:
-                buffer_name = graph_signature.inputs_to_buffers[node.name]
-                if buffer_name in param_buffer_name_to_corrected_name:
-                    inp_pos_to_param_buffer_name[
-                        count
-                    ] = param_buffer_name_to_corrected_name[buffer_name]
-                else:
-                    inp_pos_to_param_buffer_name[count] = buffer_name
-            if node.name in graph_signature.inputs_to_parameters:
-                param_name = graph_signature.inputs_to_parameters[node.name]
-                if param_name in param_buffer_name_to_corrected_name:
-                    inp_pos_to_param_buffer_name[
-                        count
-                    ] = param_buffer_name_to_corrected_name[param_name]
-                else:
-                    inp_pos_to_param_buffer_name[count] = param_name
-            if hasattr(graph_signature, "inputs_to_lifted_tensor_constants"):
-                if node.name in graph_signature.inputs_to_lifted_tensor_constants:
-                    constant_name = graph_signature.inputs_to_lifted_tensor_constants[
-                        node.name
-                    ]
-                    if constant_name in constant_name_to_corrected_name:
-                        inp_pos_to_param_buffer_name[
-                            count
-                        ] = constant_name_to_corrected_name[constant_name]
-                    else:
-                        inp_pos_to_param_buffer_name[count] = constant_name
-                elif node.name in graph_signature.inputs_to_lifted_custom_objs:
-                    constant_name = graph_signature.inputs_to_lifted_custom_objs[
-                        node.name
-                    ]
-                    if constant_name in constant_name_to_corrected_name:
-                        inp_pos_to_param_buffer_name[
-                            count
-                        ] = constant_name_to_corrected_name[constant_name]
-                    else:
-                        inp_pos_to_param_buffer_name[count] = constant_name
-            count += 1
-
-    return inp_pos_to_param_buffer_name
+    for name, value in constants.items():
+        setattr(new_gm, name.replace(".", "_"), value)
 
 
 class _StatefulGraphModuleFactory(type):
@@ -315,17 +360,36 @@ def _create_stateful_graph_module(
 
 def _unlift_exported_program_lifted_states(ep: ExportedProgram) -> torch.nn.Module:
     new_gm = copy.deepcopy(ep.graph_module)
-    inp_pos_to_param_buffer_name = _construct_inp_pos_to_param_buffer_name(
-        new_gm, ep.graph_signature, ep.state_dict, ep.tensor_constants
-    )
+    _register_attrs_to_new_gm(new_gm, ep.graph_signature, ep.state_dict, ep.constants)
+
+    lifted_inputs: List[Optional[str]] = [
+        in_spec.target
+        if in_spec.kind
+        in (
+            InputKind.BUFFER,
+            InputKind.CONSTANT_TENSOR,
+            InputKind.PARAMETER,
+            InputKind.CUSTOM_OBJ,
+        )
+        else None
+        for in_spec in ep.graph_signature.input_specs
+    ]
+
+    mutated_outputs: List[Optional[str]] = [
+        out_spec.target
+        if out_spec.kind in (OutputKind.BUFFER_MUTATION, OutputKind.USER_INPUT_MUTATION)
+        else None
+        for out_spec in ep.graph_signature.output_specs
+    ]
+
     new_gm = _unlift(
         new_gm,
-        inp_pos_to_param_buffer_name,
+        lifted_inputs,
+        mutated_outputs,
         ep.call_spec.in_spec,
         ep.call_spec.out_spec,
         ep.state_dict,
-        ep.tensor_constants,
-        ep.graph_signature.buffers_to_mutate,
+        ep.constants,
     )
     unlift_gm = _create_stateful_graph_module(new_gm, ep.range_constraints)
     unlift_gm.meta.update(ep.graph_module.meta)


### PR DESCRIPTION
Summary: While turning on .module() for all the export tests, I uncovered some bugs with .module() and while fixing them I ended up rewriting some of the code... Some of the bugs were: 

* bad kwargs support on the unlifted module
* no support for user input mutations
* (at the commit hash i was working off of) no support for custom objects
* there were no tests on unlifting weights from cond/map submodules

Test Plan: CI

Differential Revision: D53075380




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler