### PR TITLE
fix bug in init QuantizableLSTM

### DIFF
--- a/torch/ao/nn/quantizable/modules/rnn.py
+++ b/torch/ao/nn/quantizable/modules/rnn.py
@@ -325,7 +325,7 @@ class LSTM(torch.nn.Module):
                              self.bias, batch_first=False,
                              bidirectional=self.bidirectional, **factory_kwargs)]
         for layer in range(1, num_layers):
-            layers.append(_LSTMLayer(self.hidden_size *num_directions, 
+            layers.append(_LSTMLayer(self.hidden_size *num_directions,
                                      self.hidden_size,
                                      self.bias, batch_first=False,
                                      bidirectional=self.bidirectional,

--- a/torch/ao/nn/quantizable/modules/rnn.py
+++ b/torch/ao/nn/quantizable/modules/rnn.py
@@ -325,7 +325,8 @@ class LSTM(torch.nn.Module):
                              self.bias, batch_first=False,
                              bidirectional=self.bidirectional, **factory_kwargs)]
         for layer in range(1, num_layers):
-            layers.append(_LSTMLayer(self.hidden_size, self.hidden_size,
+            layers.append(_LSTMLayer(self.hidden_size *num_directions, 
+                                     self.hidden_size,
                                      self.bias, batch_first=False,
                                      bidirectional=self.bidirectional,
                                      **factory_kwargs))


### PR DESCRIPTION
Stacked layers of QuantizableLSTM are not initialized properly.
This hasn't been detected because QuantizableLSTM is usually initialized using the from_float method that directly look to the shape of the float_module's weight.

This fixes the standard init method


cc @jerryzh168 @jianyuh @raghuramank100 @jamesr66a @vkuzo @jgong5 @Xia-Weiwen @leslie-fang-intel