### PR TITLE
[AOTI] Forward fix https://github.com/pytorch/pytorch/pull/117989

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1864,9 +1864,6 @@ class CppWrapperCodeGen(WrapperCodeGen):
             arr_iface = config.use_minimal_arrayref_interface  # For brevity.
 
             def use_thread_local_cached_output_tensor(idx, output):
-                if self.cuda:
-                    return
-
                 cached_output_name = f"cached_output_{next(self.cached_output_id)}"
                 cache_type = "Array" if arr_iface else "Tensor"
                 self.wrapper_call.writeline(


### PR DESCRIPTION
Summary: https://github.com/pytorch/pytorch/pull/117989 disabled   use_thread_local_cached_output_tensor for cuda, but it is not necessarily true, because we can still have cpu tensors when running cuda models.

Differential Revision: D53089956




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler