### PR TITLE
Remove lastWorkListUpdateTime_

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1215,7 +1215,7 @@ void ProcessGroupNCCL::heartbeatMonitor() {
       // we haven't polled for `heartbeat_timeout` seconds and there haven't
       // any work added or removed for `watchdog_timeout` seconds.
       if (computeDeltaMS(lastTimePollStore, currentTime) >=
-              coordCheckIntervalMilSec_) {
+          coordCheckIntervalMilSec_) {
         lastTimePollStore = currentTime;
         if (globalStore_->check({std::string(TIMEOUT_DUMP)})) {
           errorMsg = c10::str(

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -867,8 +867,6 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // Vector to Store WorkNCCL pointers
   std::list<ProcessGroupNCCL::WorkNCCL> workMetaList_;
 
-  std::chrono::time_point<std::chrono::steady_clock> lastWorkListUpdateTime_;
-
   // Mutex to Guard workMetaList_
   std::mutex completedWorkListMutex_;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #118305
* #118293
* __->__ #118292

`lastWorkListUpdateTime_` is used when the coordinated dump check was still in the watchdog thread. After move of the dump check to heartbeat thread, it shouldn't be needed anymore.

Removing it also because I'd like to make watchdog sleep interval adaptive, which makes this line less compatible:
https://github.com/pytorch/pytorch/blob/817debeb8976adede8f781c312d85595a4dbb83c/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L1229-L1230

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang