### PR TITLE
Make watchdog sleep interval auto-adaptive

### DIFF
--- a/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
@@ -57,11 +57,6 @@ class ProcessGroupNCCLSimulateErrors : public c10d::ProcessGroupNCCL {
     return c10d::ProcessGroupNCCL::checkForNCCLErrors(ncclComms);
   }
 
-  std::chrono::duration<int64_t, std::milli> getWatchdogSleepInterval() {
-    return std::chrono::milliseconds(
-        ProcessGroupNCCLSimulateErrors::kWatchdogThreadSleepMillis);
-  }
-
   c10::intrusive_ptr<ProcessGroupNCCL::WorkNCCL> initWork(
       std::vector<at::Device> devices,
       int rank,

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -96,6 +96,10 @@ constexpr const char* TIMEOUT_DUMP = "timeout_dump";
 constexpr auto kProcessGroupNCCLDefaultTimeout =
     std::chrono::milliseconds(10 * 60 * 1000);
 
+// Range of watchdog sleep interval
+constexpr int64_t kWatchdogThreadSleepMaxMillis = 64;
+constexpr int64_t kWatchdogThreadSleepMinMillis = 1;
+
 // NoHandling: do not handle asynchronous NCCL errors
 // TearDown: tear down process upon error, see `WorkNCCL::handleException`
 // CleanUpOnly: just clean up collectives and abort communicators without
@@ -962,6 +966,10 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   uint64_t seq_{0};
 
   std::exception_ptr watchDogException_ = nullptr;
+
+  // Adaptive watchdog sleep interval. This can be automatically adjusted based
+  // on length of work queue. Initialized to middle of min and max.
+  int64_t watchdogSleepMillis_ = kWatchdogThreadSleepMaxMillis << 1;
 
   size_t uid_;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #118305
* __->__ #118293
* #118292

The sleep interval would be adaptive to the work queue length:
- if the length is greater than certain threshold (8), we will cut the next sleep interval by half;
- if the queue is empty, we will double the next sleep interval;
- but overall, the sleep interval will be confined between a min (1 ms) and a max (64 ms).

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @rohan-varma