### PR TITLE
[TEST] Failing test for AOTInductor

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -363,7 +363,7 @@ def check_model(
     #         print("Graph", graph)
     if check_has_compiled:
         assert called, "Ran graph without calling compile_fx"
-    assert type(actual) == type(correct)
+    assert type(actual) == type(correct), f"{type(actual)} != {type(correct)}"
 
     correct_flat, correct_spec = tree_flatten(correct)
     actual_flat = pytree.tree_leaves(actual)
@@ -4317,20 +4317,16 @@ class CommonTemplate:
             (torch.randn([1024], dtype=torch.float64) + 10,),
         )
 
+    @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_bitwise(self):
-        def fn(x, y):
-            return (
-                torch.bitwise_not(x),
-                torch.bitwise_or(x, y),
-                torch.bitwise_xor(x, y),
-                torch.bitwise_and(x, y),
-            )
+        def fn():
+            full = torch.full((), 11)
+            i0 = full.item()
+            return torch.full((i0,), 0)
 
         self.common(
             fn,
             (
-                torch.randint(0, 2**30, [64], dtype=torch.int32),
-                torch.randint(0, 2**30, [64], dtype=torch.int32),
             ),
         )
 

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -194,6 +194,7 @@ class UniformValueConstantFolder(ConstantFolder):
 
 @torch.utils._python_dispatch._disable_current_modes()
 def constant_fold_uniform_value(gm: torch.fx.GraphModule):
+    return
     "Runs constant folding and replaces constants which can be constructed with a single `full` call. Calls into remove_no_ops."
     aten = torch.ops.aten
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118296
* #118125
* #117862
* #117859

NOT FOR MERGING

This passes: `python test/inductor/test_torchinductor.py -k test_bitwise`

This fails: `python test/inductor/test_cuda_cpp_wrapper.py -k test_bitwise` with

```
  File "/data/users/ezyang/a/pytorch/test/inductor/test_cuda_cpp_wrapper.py", line 119, in fn
    _, code = test_torchinductor.run_and_get_cpp_code(
  File "/data/users/ezyang/a/pytorch/test/inductor/test_torchinductor.py", line 273, in run_and_get_cpp_code
    result = fn(*args, **kwargs)
  File "/data/users/ezyang/a/pytorch/test/inductor/test_torchinductor.py", line 8337, in new_test
    return value(self)
  File "/home/ezyang/local/a/pytorch-env/lib/python3.10/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/data/users/ezyang/a/pytorch/test/inductor/test_torchinductor.py", line 4327, in test_bitwise
    self.common(
  File "/home/ezyang/local/a/pytorch-env/lib/python3.10/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/data/users/ezyang/a/pytorch/test/inductor/test_torchinductor.py", line 501, in check_model_gpu
    check_model(
  File "/data/users/ezyang/a/pytorch/test/inductor/test_torchinductor.py", line 366, in check_model
    assert type(actual) == type(correct), f"{type(actual)} != {type(correct)}"
AssertionError: <class 'torch._subclasses.fake_tensor.FakeTensor'> != <class 'torch.Tensor'>
```

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler