### PR TITLE
Skip test_none_names_refcount under Dynamo-wrapped CI

### DIFF
--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -2,6 +2,7 @@
 
 import unittest
 from torch.testing._internal.common_utils import TestCase, run_tests, TEST_NUMPY
+from torch.testing._internal.common_utils import skipIfTorchDynamo
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_device_type import get_all_device_types
 from collections import namedtuple, OrderedDict
@@ -148,6 +149,7 @@ class TestNamedTensor(TestCase):
             names65 = ['A' * i for i in range(1, 66)]
             x = factory([1] * 65, names=names64, device=device)
 
+    @skipIfTorchDynamo("not a bug: Dynamo causes the refcounts to be different")
     def test_none_names_refcount(self, N=10):
         def scope():
             unnamed = torch.empty(2, 3)

--- a/torch/testing/_internal/dynamo_test_failures.py
+++ b/torch/testing/_internal/dynamo_test_failures.py
@@ -2828,7 +2828,6 @@ dynamo_expected_failures = {
     "TestNamedTensor.test_addcmul_addcdiv",  # test_namedtensor
     "TestNamedTensor.test_big_tensor_repr_has_names",  # test_namedtensor
     "TestNamedTensor.test_unsupported_op_error_msg",  # test_namedtensor
-    "TestNamedTensor.test_none_names_refcount",  # test_namedtensor
     "TestNamedTensor.test_addmm",  # test_namedtensor
     "TestNamedTensor.test_pow_special",  # test_namedtensor
     "TestNamedTensor.test_autograd_ignores_names",  # test_namedtensor


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118309
* #118152

Fixes https://github.com/pytorch/pytorch/issues/117716
Dynamo does some things that modifies the refcount. Skipping this test.