### PR TITLE
Augment PropagateUnbackedSymInts to handle tensor/tuple returns

### DIFF
--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -311,6 +311,17 @@ class TestInductorDynamic(TestCase):
 
         f(torch.tensor([3.0], device=device))
 
+    @torch._dynamo.config.patch(
+        capture_dynamic_output_shape_ops=True
+    )
+    def test_nonzero_no_realloc(self, device):
+        @torch.compile(fullgraph=True, dynamic=True)
+        def f(x, y, y2):
+            z = x.nonzero()
+            return torch.split(z, [y.size(0), y2.size(0)])
+
+        f(torch.tensor([1, 0, 1, 1, 0, 1, 0]), torch.randn(2), torch.randn(2))
+
     @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_unbacked_index_select(self, device):
         # Tests if unbacked symbols captured by inner_fn are properly tracked


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118312
* #118125
* #117862
* #117859

It is possible to have an unbacked SymInt entirely sidestep being
a bare SymInt, so this case catches that.

NB: The test case doesn't actually fail without this patch, but if you
inspect logs you can see that without this patch we fail to unify u1
with u0.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler