### PR TITLE
[PyTorch][Vulkan] Clean up aten::stack

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Stack.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Stack.cpp
@@ -19,11 +19,11 @@ namespace {
 using namespace api::utils;
 
 Tensor stack(const at::TensorList tensors, const int64_t dim) {
-  TORCH_CHECK(tensors.size() > 0, "Vulkan stack expects at least one tensor");
-  at::Tensor tensor = tensors[0];
+  TORCH_CHECK(!tensors.empty(), "Vulkan stack expects at least one tensor");
+  const at::Tensor& tensor = tensors[0];
   TORCH_CHECK(
-      tensor.dim() >= 1 || tensor.dim() <= 3,
-      "Vulkan stack supports 1d, 2d, 3d tensors as input!");
+      tensor.dim() <= 3,
+      "Vulkan stack only supports up to 3d tensors as input!");
 
   TORCH_CHECK(
       dim >= -tensor.dim() - 1 && dim <= tensor.dim(),

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -6935,6 +6935,12 @@ void test_stack(const at::IntArrayRef input_shape, int64_t dim, int numTensors) 
   ASSERT_TRUE(check);
 }
 
+TEST_F(VulkanAPITest, stack_0d) {
+  test_stack({}, 0, 1);
+  test_stack({}, 0, 2);
+  test_stack({}, 0, 3);
+}
+
 TEST_F(VulkanAPITest, stack_1d) {
   test_stack({221}, 0, 2);
   test_stack({193}, 1, 3);


### PR DESCRIPTION
Summary:
After D50347338, we already support zero-dim tensor input, which was my original task. As a result, this diff doesn't add or change functionality; it just cleans up the following:
1. Fix TORCH_CHECK to only allow `tensor.dim() <= 3`. Previously, it was a no-op since it didn't use `&&`.
2. Add `tensor.dim() == 0` tests.
3. Address `readability-container-size-empty` and `performance-unnecessary-copy-initialization` linter errors.

Test Plan:
Tested on OD.
```
[jorgep31415@29786.od /data/sandcastle/boxes/fbsource (1d0b920e0)]$ LD_LIBRARY_PATH=third-party/swiftshader/lib/linux-x64/ buck2 run fbcode/mode/dev-nosan //xplat/caffe2:pt_vulkan_api_test_bin -c pt.vulkan_full_precision=1 -- --gtest_filter="*stack*"
File changed: fbsource//xplat/caffe2/aten/src/ATen/native/vulkan/ops/Unsqueeze.cpp
File changed: fbsource//xplat/caffe2/aten/src/ATen/native/vulkan/glsl/unsqueeze.glsl
File changed: fbsource//xplat/caffe2/aten/src/ATen/test/vulkan_api_test.cpp
3 additional file change events
Buck UI: https://www.internalfb.com/buck2/98bb3bfa-a1d1-440e-8724-b4990c9cc7ca
Network: Up: 1.4MiB  Down: 377KiB  (reSessionID-6eccf420-3951-4942-9350-998803589b8d)
Jobs completed: 17. Time elapsed: 42.6s.
Cache hits: 38%. Commands: 8 (cached: 3, remote: 0, local: 5)
BUILD SUCCEEDED
Running main() from third-party/googletest/1.14.0/googletest/googletest/src/gtest_main.cc
Note: Google Test filter = *stack*
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.stack_invalid_inputs
[       OK ] VulkanAPITest.stack_invalid_inputs (27 ms)
[ RUN      ] VulkanAPITest.stack_0d
[       OK ] VulkanAPITest.stack_0d (28 ms)
[ RUN      ] VulkanAPITest.stack_1d
[       OK ] VulkanAPITest.stack_1d (1 ms)
[ RUN      ] VulkanAPITest.stack_2d
[       OK ] VulkanAPITest.stack_2d (148 ms)
[ RUN      ] VulkanAPITest.stack_3d
[       OK ] VulkanAPITest.stack_3d (354 ms)
[----------] 5 tests from VulkanAPITest (561 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (561 ms total)
[  PASSED  ] 5 tests.
```

Reviewed By: copyrightly, liuk22

Differential Revision: D53071188


