### PR TITLE
add an option to specify custom addr2line binary

### DIFF
--- a/torch/csrc/profiler/unwind/unwind.cpp
+++ b/torch/csrc/profiler/unwind/unwind.cpp
@@ -432,7 +432,6 @@ struct Symbolizer {
   }
 };
 
-
 #ifndef FBCODE_CAFFE2
 std::vector<Frame> symbolize(const std::vector<void*>& frames) {
   auto guard = Symbolizer::guard();

--- a/torch/csrc/profiler/unwind/unwind.cpp
+++ b/torch/csrc/profiler/unwind/unwind.cpp
@@ -362,7 +362,7 @@ struct Symbolizer {
       return;
     }
     has_pending_results_ = true;
-    auto& entry = getOrCreate(maybe_library->first, addr2line_binary_);
+    auto& entry = getOrCreate(maybe_library->first);
     entry.queried.push_back(addr);
     auto libaddress = maybe_library->second - 1;
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
@@ -402,17 +402,18 @@ struct Symbolizer {
   ska::flat_hash_map<void*, Frame> frame_map_;
   bool has_pending_results_ = true;
 
-  Entry& getOrCreate(const std::string& name, const char* addr2line_bin) {
+  Entry& getOrCreate(const std::string& name) {
     auto it = entries_.find(name);
     if (it == entries_.end()) {
       // NOLINTNEXTLINE(*-c-arrays*)
       const char* args[] = {
-        addr2line_bin, "-C", "-f", "-e", name.c_str(), nullptr};
-      it = entries_
-               .insert_or_assign(
-                   name,
-                   Entry{std::make_unique<Communicate>(addr2line_bin, args), {}})
-               .first;
+          addr2line_binary_, "-C", "-f", "-e", name.c_str(), nullptr};
+      it =
+        entries_
+        .insert_or_assign(
+          name,
+          Entry{std::make_unique<Communicate>(addr2line_binary_, args), {}})
+        .first;
     }
     return it->second;
   }

--- a/torch/csrc/profiler/unwind/unwind.cpp
+++ b/torch/csrc/profiler/unwind/unwind.cpp
@@ -408,12 +408,13 @@ struct Symbolizer {
       // NOLINTNEXTLINE(*-c-arrays*)
       const char* args[] = {
           addr2line_binary_, "-C", "-f", "-e", name.c_str(), nullptr};
-      it =
-        entries_
-        .insert_or_assign(
-          name,
-          Entry{std::make_unique<Communicate>(addr2line_binary_, args), {}})
-        .first;
+      it = entries_
+               .insert_or_assign(
+                   name,
+                   Entry{
+                       std::make_unique<Communicate>(addr2line_binary_, args),
+                       {}})
+               .first;
     }
     return it->second;
   }

--- a/torch/csrc/utils/cpp_stacktraces.cpp
+++ b/torch/csrc/utils/cpp_stacktraces.cpp
@@ -4,7 +4,6 @@
 #include <cstring>
 
 #include <c10/util/Exception.h>
-// #include <sys/stat.h> // for calling stat()
 
 namespace torch {
 namespace {
@@ -41,7 +40,6 @@ bool compute_disable_addr2line() {
   }
   return false;
 }
-
 } // namespace
 
 bool get_cpp_stacktraces_enabled() {

--- a/torch/csrc/utils/cpp_stacktraces.cpp
+++ b/torch/csrc/utils/cpp_stacktraces.cpp
@@ -4,6 +4,7 @@
 #include <cstring>
 
 #include <c10/util/Exception.h>
+// #include <sys/stat.h> // for calling stat()
 
 namespace torch {
 namespace {
@@ -40,6 +41,7 @@ bool compute_disable_addr2line() {
   }
   return false;
 }
+
 } // namespace
 
 bool get_cpp_stacktraces_enabled() {


### PR DESCRIPTION
There is a need for users to pick their own addr2line binary in their deployment due to reasons like default addr2line being too slow etc... This option would allow user quickly experiment other alternatives.