### PR TITLE
[C10D] Add tests for gather and gather_object with subgroup

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -3532,12 +3532,13 @@ class LargeCommTest(test_c10d_common.AbstractLargeCommTest, MultiProcessTestCase
     @requires_nccl()
     @skip_if_lt_x_gpu(4)
     def test_gather_subgroup(self):
-        if self.rank > 3:
-            # just easier to write the test for exactly 4 gpus
+        world_size = 4
+        if self.rank >= world_size:
+            # just easier to write the test for exactly 4 gpus, even if this test class increased to 8gpu later
             return
 
-        store = c10d.FileStore(self.file_name, self.world_size)
-        torch.distributed.init_process_group(backend="nccl", store=store, rank=self.rank, world_size=self.world_size)
+        store = c10d.FileStore(self.file_name, world_size)
+        torch.distributed.init_process_group(backend="nccl", store=store, rank=self.rank, world_size=world_size)
         process_group = c10d.distributed_c10d._get_default_group()
         a_group = c10d.new_group([0, 1])
         b_group = c10d.new_group([2, 3])
@@ -3557,12 +3558,13 @@ class LargeCommTest(test_c10d_common.AbstractLargeCommTest, MultiProcessTestCase
     @requires_nccl()
     @skip_if_lt_x_gpu(4)
     def test_gather_object_subgroup(self):
-        if self.rank > 3:
-            # just easier to write the test for exactly 4 gpus
+        world_size = 4
+        if self.rank >= world_size:
+            # just easier to write the test for exactly 4 gpus, even if this test class increased to 8gpu later
             return
 
-        store = c10d.FileStore(self.file_name, self.world_size)
-        torch.distributed.init_process_group(backend="nccl", store=store, rank=self.rank, world_size=self.world_size)
+        store = c10d.FileStore(self.file_name, world_size)
+        torch.distributed.init_process_group(backend="nccl", store=store, rank=self.rank, world_size=world_size)
         process_group = c10d.distributed_c10d._get_default_group()
         a_group = c10d.new_group([0, 1])
         b_group = c10d.new_group([2, 3])

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -3056,6 +3056,7 @@ class NcclErrorHandlingTest(MultiProcessTestCase):
                 raise ValueError(f"Rank {self.rank} barrier timed out waiting for rank 0 with error: {str(e)}") from e
 
 
+
 class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
     @property
     def device(self):
@@ -3353,7 +3354,6 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
     def test_tensor_dtype_complex(self):
         self._test_tensor_dtype_complex(backend="nccl")
 
-
 class CompilerTest(test_c10d_common.CompilerTest):
 
     @property
@@ -3528,6 +3528,61 @@ class LargeCommTest(test_c10d_common.AbstractLargeCommTest, MultiProcessTestCase
     @skip_if_lt_x_gpu(4)
     def test_new_group_local_sync_duplicated_pg(self):
         self._test_new_group_local_sync_duplicate_pg(backend="nccl")
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(4)
+    def test_gather_subgroup(self):
+        if self.rank > 3:
+            # just easier to write the test for exactly 4 gpus
+            return
+
+        store = c10d.FileStore(self.file_name, self.world_size)
+        torch.distributed.init_process_group(backend="nccl", store=store, rank=self.rank, world_size=self.world_size)
+        process_group = c10d.distributed_c10d._get_default_group()
+        a_group = c10d.new_group([0, 1])
+        b_group = c10d.new_group([2, 3])
+        my_group = a_group if self.rank < 2 else b_group
+
+        device = torch.device("cuda:%d" % self.rank)
+        input = torch.ones((10,), device=device) * self.rank
+        if self.rank == 0 or self.rank == 2:
+            gather_list = [torch.empty_like(input) for _ in range(my_group.size())]
+            torch.distributed.gather(input, gather_list=gather_list, dst=self.rank, group=my_group, async_op=False)
+            for src in range(len(gather_list)):
+                expected = (torch.ones_like(input) * self.rank) + src
+                self.assertEqual(gather_list[src], expected)
+        else:
+            torch.distributed.gather(input, gather_list=None, dst=self.rank - 1, group=my_group, async_op=False)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(4)
+    def test_gather_object_subgroup(self):
+        if self.rank > 3:
+            # just easier to write the test for exactly 4 gpus
+            return
+
+        store = c10d.FileStore(self.file_name, self.world_size)
+        torch.distributed.init_process_group(backend="nccl", store=store, rank=self.rank, world_size=self.world_size)
+        process_group = c10d.distributed_c10d._get_default_group()
+        a_group = c10d.new_group([0, 1])
+        b_group = c10d.new_group([2, 3])
+        my_group = a_group if self.rank < 2 else b_group
+
+        # discrepancy #1
+        # have to set device or else gather_object gets wrong device from 'current_device = _get_pg_default_device(group)
+        torch.cuda.set_device(self.rank)
+
+        input = {"rank": self.rank}
+        if self.rank == 0 or self.rank == 2:
+            # discrepancy #2
+            # another weird thing- what's the point of making me specify some empty objects in my list?
+            # empty list should be valid imo.  (but it throws an error)
+            gather_list = [{}, {}]
+            torch.distributed.gather_object(input, object_gather_list=gather_list, dst=self.rank, group=my_group)
+            for src in range(len(gather_list)):
+                self.assertEqual(gather_list[src]["rank"], self.rank + src)
+        else:
+            torch.distributed.gather_object(input, object_gather_list=None, dst=self.rank - 1, group=my_group)
 
 
 class SparseCollective(MultiProcessTestCase):

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2369,7 +2369,7 @@ def gather_object(obj, object_gather_list=None, dst=0, group=None):
             should be correctly sized as the size of the group for this
             collective and will contain the output. Must be ``None`` on non-dst
             ranks. (default is ``None``)
-        dst (int, optional): Destination rank. (default is 0)
+        dst (int, optional): Destination rank on global process group (regardless of 'group' argument). (default is 0)
         group: (ProcessGroup, optional): The process group to work on. If None,
             the default process group will be used. Default is ``None``.
 
@@ -2991,7 +2991,7 @@ def gather(tensor, gather_list=None, dst=0, group=None, async_op=False):
         gather_list (list[Tensor], optional): List of appropriately-sized
             tensors to use for gathered data (default is None, must be specified
             on the destination rank)
-        dst (int, optional): Destination rank (default is 0)
+        dst (int, optional): Destination rank on global process group (regardless of 'group' argument). (default is 0)
         group (ProcessGroup, optional): The process group to work on. If None,
             the default process group will be used.
         async_op (bool, optional): Whether this op should be an async op


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118359

Addresses #118337 somewhat- we probably need to update docs. Let's first
confirm what behavior we want.

Identifies a couple of confusing things
1) 'dst' arg for many collectives is always in 'global' rank regardless
   of whether a subgroup is passed in.  This needs a doc update
2) gather_object has a strong dependency on setting the cuda device;
   could we make that smoother?
3) gather_object also should be happy with an empty list on the dst
   side, imo

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @yf225