### PR TITLE
Reduce register usage of fused adam(w)

### DIFF
--- a/aten/src/ATen/native/cuda/FusedSgdKernel.cu
+++ b/aten/src/ATen/native/cuda/FusedSgdKernel.cu
@@ -61,9 +61,8 @@ struct FusedSgdMathFunctor {
   static_assert(
       depth == 2 || depth == 3,
       "depth of 2 for SGD w/ momentum == 0, 3 for SGD w/ momentum != 0");
-  template <typename index_t>
   C10_DEVICE __forceinline__ void operator()(
-      const index_t chunk_size,
+      const int chunk_size,
       TensorListMetadata<depth>& tl,
       const double weight_decay,
       const double momentum,
@@ -78,14 +77,14 @@ struct FusedSgdMathFunctor {
     if (found_inf_ptr && *found_inf_ptr == 1) {
       return;
     }
-    const index_t tensor_loc = tl.block_to_tensor[blockIdx.x];
-    const index_t chunk_idx = tl.block_to_chunk[blockIdx.x];
+    const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
+    const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
 
     scalar_t* args[depth];
     scalar_t r_args[depth][kILP];
     const auto all_aligned{
         init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc)};
-    const index_t n = tl.numel_for_tensor[tensor_loc] - chunk_idx * chunk_size;
+    const auto n = tl.numel_for_tensor[tensor_loc] - chunk_idx * chunk_size;
 
 #ifndef USE_ROCM
     const auto use_faster_load_store =
@@ -94,12 +93,12 @@ struct FusedSgdMathFunctor {
     const auto use_faster_load_store{false};
 #endif
     if (use_faster_load_store) {
-      for (index_t i_start = threadIdx.x;
+      for (auto i_start = threadIdx.x;
            i_start * kILP < n && i_start * kILP < chunk_size;
            i_start += blockDim.x) {
 #pragma unroll
         for (auto i = 0; i < depth; i++) {
-          load_store(r_args[i], args[i], static_cast<index_t>(0), i_start);
+          load_store(r_args[i], args[i], 0, i_start);
         }
         sgd_math<scalar_t, depth>(
             r_args,
@@ -112,16 +111,16 @@ struct FusedSgdMathFunctor {
             maximize,
             is_first_step,
             grad_scale_ptr);
-        load_store(args[0], r_args[0], i_start, static_cast<index_t>(0));
+        load_store(args[0], r_args[0], i_start, 0);
         if (grad_scale_ptr) {
-          load_store(args[1], r_args[1], i_start, static_cast<index_t>(0));
+          load_store(args[1], r_args[1], i_start, 0);
         }
         if (depth > 2) {
-          load_store(args[2], r_args[2], i_start, static_cast<index_t>(0));
+          load_store(args[2], r_args[2], i_start, 0);
         }
       }
     } else {
-      for (index_t i_start = 0; i_start < n && i_start < chunk_size;
+      for (auto i_start = 0; i_start < n && i_start < chunk_size;
            i_start += blockDim.x * kILP) {
         load_args<depth>(r_args, args, i_start, chunk_size, n);
         sgd_math<scalar_t, depth>(

--- a/aten/src/ATen/native/cuda/fused_adam_amsgrad_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adam_amsgrad_impl.cu
@@ -30,11 +30,11 @@ void _fused_adam_amsgrad_cuda_impl_(
       exp_avg_sqs.vec(),
       max_exp_avg_sqs.vec()};
 
-  float* grad_scale_ptr =
+  const float* grad_scale_ptr =
       grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  float* found_inf_ptr =
+  const float* found_inf_ptr =
       found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  float* lr_ptr = nullptr;
+  const float* lr_ptr = nullptr;
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kHalf,
@@ -81,11 +81,11 @@ void _fused_adam_amsgrad_cuda_impl_(
       exp_avg_sqs.vec(),
       max_exp_avg_sqs.vec()};
 
-  float* grad_scale_ptr =
+  const float* grad_scale_ptr =
       grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  float* found_inf_ptr =
+  const float* found_inf_ptr =
       found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  float* lr_ptr = lr.data_ptr<float>();
+  const float* lr_ptr = lr.data_ptr<float>();
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kHalf,

--- a/aten/src/ATen/native/cuda/fused_adam_amsgrad_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adam_amsgrad_impl.cu
@@ -45,7 +45,7 @@ void _fused_adam_amsgrad_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ORIGINAL>(),
+            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ORIGINAL, true>(),
             lr_ptr, // unused
             lr,
             beta1,
@@ -53,7 +53,6 @@ void _fused_adam_amsgrad_cuda_impl_(
             weight_decay,
             eps,
             maximize,
-            /* amsgrad */ true,
             grad_scale_ptr,
             found_inf_ptr);
       });
@@ -97,7 +96,7 @@ void _fused_adam_amsgrad_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ORIGINAL>(),
+            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ORIGINAL, true>(),
             lr_ptr,
             1.0, // unused
             beta1,
@@ -105,7 +104,6 @@ void _fused_adam_amsgrad_cuda_impl_(
             weight_decay,
             eps,
             maximize,
-            /* amsgrad */ true,
             grad_scale_ptr,
             found_inf_ptr);
       });

--- a/aten/src/ATen/native/cuda/fused_adam_amsgrad_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adam_amsgrad_impl.cu
@@ -45,7 +45,7 @@ void _fused_adam_amsgrad_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 5>(),
+            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ORIGINAL>(),
             lr_ptr, // unused
             lr,
             beta1,
@@ -55,8 +55,7 @@ void _fused_adam_amsgrad_cuda_impl_(
             maximize,
             /* amsgrad */ true,
             grad_scale_ptr,
-            found_inf_ptr,
-            ADAM_MODE::ORIGINAL);
+            found_inf_ptr);
       });
 }
 
@@ -98,7 +97,7 @@ void _fused_adam_amsgrad_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 5>(),
+            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ORIGINAL>(),
             lr_ptr,
             1.0, // unused
             beta1,
@@ -108,8 +107,7 @@ void _fused_adam_amsgrad_cuda_impl_(
             maximize,
             /* amsgrad */ true,
             grad_scale_ptr,
-            found_inf_ptr,
-            ADAM_MODE::ORIGINAL);
+            found_inf_ptr);
       });
 }
 

--- a/aten/src/ATen/native/cuda/fused_adam_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adam_impl.cu
@@ -40,7 +40,7 @@ void _fused_adam_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 4>(),
+            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ORIGINAL>(),
             lr_ptr, // unused
             lr,
             beta1,
@@ -50,8 +50,7 @@ void _fused_adam_cuda_impl_(
             maximize,
             /* amsgrad */ false,
             grad_scale_ptr,
-            found_inf_ptr,
-            ADAM_MODE::ORIGINAL);
+            found_inf_ptr);
       });
 }
 
@@ -88,7 +87,7 @@ void _fused_adam_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 4>(),
+            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ORIGINAL>(),
             lr_ptr,
             1.0, // unused
             beta1,
@@ -98,8 +97,7 @@ void _fused_adam_cuda_impl_(
             maximize,
             /* amsgrad */ false,
             grad_scale_ptr,
-            found_inf_ptr,
-            ADAM_MODE::ORIGINAL);
+            found_inf_ptr);
       });
 }
 

--- a/aten/src/ATen/native/cuda/fused_adam_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adam_impl.cu
@@ -25,11 +25,11 @@ void _fused_adam_cuda_impl_(
   std::vector<std::vector<at::Tensor>> tensor_lists{
       params.vec(), grads.vec(), exp_avgs.vec(), exp_avg_sqs.vec()};
 
-  float* grad_scale_ptr =
+  const float* grad_scale_ptr =
       grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  float* found_inf_ptr =
+  const float* found_inf_ptr =
       found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  float* lr_ptr = nullptr;
+  const float* lr_ptr = nullptr;
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kHalf,
@@ -71,11 +71,11 @@ void _fused_adam_cuda_impl_(
   std::vector<std::vector<at::Tensor>> tensor_lists{
       params.vec(), grads.vec(), exp_avgs.vec(), exp_avg_sqs.vec()};
 
-  float* grad_scale_ptr =
+  const float* grad_scale_ptr =
       grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  float* found_inf_ptr =
+  const float* found_inf_ptr =
       found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  float* lr_ptr = lr.data_ptr<float>();
+  const float* lr_ptr = lr.data_ptr<float>();
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kHalf,

--- a/aten/src/ATen/native/cuda/fused_adam_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adam_impl.cu
@@ -40,7 +40,7 @@ void _fused_adam_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ORIGINAL>(),
+            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ORIGINAL, false>(),
             lr_ptr, // unused
             lr,
             beta1,
@@ -48,7 +48,6 @@ void _fused_adam_cuda_impl_(
             weight_decay,
             eps,
             maximize,
-            /* amsgrad */ false,
             grad_scale_ptr,
             found_inf_ptr);
       });
@@ -87,7 +86,7 @@ void _fused_adam_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ORIGINAL>(),
+            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ORIGINAL, false>(),
             lr_ptr,
             1.0, // unused
             beta1,
@@ -95,7 +94,6 @@ void _fused_adam_cuda_impl_(
             weight_decay,
             eps,
             maximize,
-            /* amsgrad */ false,
             grad_scale_ptr,
             found_inf_ptr);
       });

--- a/aten/src/ATen/native/cuda/fused_adam_utils.cuh
+++ b/aten/src/ATen/native/cuda/fused_adam_utils.cuh
@@ -148,7 +148,7 @@ struct FusedAdamMathFunctor {
            i_start * kILP < n && i_start * kILP < chunk_size;
            i_start += blockDim.x) {
 #pragma unroll
-        for (uint8_t i = 0; i < depth; i++) {
+        for (int i = 0; i < depth; i++) {
           load_store(r_args[i], args[i], 0, i_start);
         }
         adam_math<scalar_type, opmath_t, depth, adam_mode, amsgrad>(
@@ -164,7 +164,7 @@ struct FusedAdamMathFunctor {
             bias_correction1,
             bias_correction2_sqrt);
 #pragma unroll
-        for (uint8_t i = 0; i < depth; i++) {
+        for (int i = 0; i < depth; i++) {
           if (i != kGradIdx || grad_scale_ptr) {
             load_store(args[i], r_args[i], i_start, 0);
           }
@@ -187,7 +187,7 @@ struct FusedAdamMathFunctor {
             bias_correction1,
             bias_correction2_sqrt);
 #pragma unroll
-        for (uint8_t i = 0; i < depth; i++) {
+        for (int i = 0; i < depth; i++) {
           if (i != kGradIdx || grad_scale_ptr) {
             store_args(args[i], r_args[i], i_start, chunk_size, n);
           }

--- a/aten/src/ATen/native/cuda/fused_adam_utils.cuh
+++ b/aten/src/ATen/native/cuda/fused_adam_utils.cuh
@@ -17,8 +17,12 @@ constexpr uint8_t kExpAvgIdx = 2;
 constexpr uint8_t kExpAvgSqIdx = 3;
 constexpr uint8_t kMaxExpAvgSqIdx = 4;
 
-template <typename scalar_type, typename opmath_t, int depth = 4>
-C10_DEVICE __forceinline__ void adam_math(
+template <
+    typename scalar_type,
+    typename opmath_t,
+    int depth,
+    ADAM_MODE adam_mode>
+C10_DEVICE inline void adam_math(
     scalar_type r_args[depth][kILP],
     const float* step_count,
     const double lr,
@@ -29,8 +33,8 @@ C10_DEVICE __forceinline__ void adam_math(
     const bool maximize,
     const bool amsgrad,
     const float* grad_scale_ptr,
-    const float* found_inf_ptr,
-    const ADAM_MODE adam_mode) {
+    const float* found_inf_ptr) {
+  static_assert(depth == 4 || depth == 5);
 #pragma unroll
   for (int ii = 0; ii < kILP; ii++) {
     // Load values.
@@ -51,13 +55,10 @@ C10_DEVICE __forceinline__ void adam_math(
     }
     // Update param, grad, 1st and 2nd order momentum.
     if (weight_decay != 0) {
-      switch (adam_mode) {
-        case ADAM_MODE::ORIGINAL:
-          grad += param * weight_decay;
-          break;
-        case ADAM_MODE::ADAMW:
-          param -= lr * weight_decay * param;
-          break;
+      if constexpr (adam_mode == ADAM_MODE::ORIGINAL) {
+        grad += param * weight_decay;
+      } else if constexpr (adam_mode == ADAM_MODE::ADAMW) {
+        param -= lr * weight_decay * param;
       }
     }
     // todo(crcrpar): use lerp
@@ -102,7 +103,7 @@ C10_DEVICE __forceinline__ void adam_math(
 // parameter updates accordingly. To be functionally on par with `torch.optim`
 // optimizers and `_multi_tensor` ones, the kernel below writes out gradients
 // only when `grad_scale_ptr != nullptr.
-template <typename scalar_type, int depth = 4>
+template <typename scalar_type, int depth, ADAM_MODE adam_mode>
 struct FusedAdamMathFunctor {
   static_assert(
       depth == 4 || depth == 5,
@@ -147,7 +148,7 @@ struct FusedAdamMathFunctor {
         for (int i = 0; i < depth; i++) {
           load_store(r_args[i], args[i], 0, i_start);
         }
-        adam_math<scalar_type, opmath_t, depth>(
+        adam_math<scalar_type, opmath_t, depth, adam_mode>(
             r_args,
             step_count,
             lr_double,
@@ -158,8 +159,7 @@ struct FusedAdamMathFunctor {
             maximize,
             amsgrad,
             grad_scale_ptr,
-            found_inf_ptr,
-            adam_mode);
+            found_inf_ptr);
 #pragma unroll
         for (int i = 0; i < depth; i++) {
           if (i != kGradIdx || grad_scale_ptr) {
@@ -171,7 +171,7 @@ struct FusedAdamMathFunctor {
       for (int64_t i_start = 0; i_start < n && i_start < chunk_size;
            i_start += blockDim.x * kILP) {
         load_args<depth>(r_args, args, i_start, chunk_size, n);
-        adam_math<scalar_type, opmath_t, depth>(
+        adam_math<scalar_type, opmath_t, depth, adam_mode>(
             r_args,
             step_count,
             lr_double,
@@ -182,8 +182,7 @@ struct FusedAdamMathFunctor {
             maximize,
             amsgrad,
             grad_scale_ptr,
-            found_inf_ptr,
-            adam_mode);
+            found_inf_ptr);
 #pragma unroll
         for (int i = 0; i < depth; i++) {
           if (i != kGradIdx || grad_scale_ptr) {

--- a/aten/src/ATen/native/cuda/fused_adam_utils.cuh
+++ b/aten/src/ATen/native/cuda/fused_adam_utils.cuh
@@ -3,6 +3,7 @@
 #include <ATen/native/cuda/ForeachFunctors.cuh>
 #include <ATen/native/cuda/MultiTensorApply.cuh>
 #include <ATen/native/cuda/Pow.cuh>
+#include <utility>
 
 namespace at {
 namespace native {
@@ -25,15 +26,16 @@ template <
     bool amsgrad>
 C10_DEVICE inline void adam_math(
     scalar_type r_args[depth][kILP],
-    const float* step_count,
-    const double lr,
-    const double beta1,
-    const double beta2,
-    const double weight_decay,
-    const double eps,
-    const bool maximize,
+    const double& lr,
+    const double& beta1,
+    const double& beta2,
+    const double& weight_decay,
+    const double& eps,
+    const bool& maximize,
     const float* grad_scale_ptr,
-    const float* found_inf_ptr) {
+    const float* found_inf_ptr,
+    const opmath_t& bias_correction1,
+    const opmath_t& bias_correction2_sqrt) {
   static_assert(depth == 4 || depth == 5);
 #pragma unroll
   for (int ii = 0; ii < kILP; ii++) {
@@ -65,10 +67,7 @@ C10_DEVICE inline void adam_math(
     // ref: https://developer.nvidia.com/blog/lerp-faster-cuda/
     exp_avg = beta1 * exp_avg + (1 - beta1) * grad;
     exp_avg_sq = beta2 * exp_avg_sq + (1 - beta2) * grad * grad;
-    const opmath_t bias_correction1 = 1 - at::native::pow_(beta1, *step_count);
     const opmath_t step_size = lr / bias_correction1;
-    const opmath_t bias_correction2 = 1 - at::native::pow_(beta2, *step_count);
-    const opmath_t bias_correction2_sqrt = std::sqrt(bias_correction2);
     opmath_t denom;
     if (amsgrad) {
       max_exp_avg_sq = std::max(max_exp_avg_sq, exp_avg_sq);
@@ -113,43 +112,48 @@ struct FusedAdamMathFunctor {
       int chunk_size,
       FusedOptimizerTensorListMetadata<depth>& tl,
       const float* lr_ptr,
-      const double lr,
-      const double beta1,
-      const double beta2,
-      const double weight_decay,
-      const double eps,
-      const bool maximize,
+      const double& lr,
+      const double& beta1,
+      const double& beta2,
+      const double& weight_decay,
+      const double& eps,
+      const bool& maximize,
       const float* grad_scale_ptr,
       const float* found_inf_ptr,
       const ADAM_MODE adam_mode) {
-    int tensor_loc = tl.block_to_tensor[blockIdx.x];
-    int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.numel_for_tensor[tensor_loc];
-    double lr_double = lr_ptr ? *lr_ptr : lr;
+    const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
+    const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
+    const double lr_double = lr_ptr ? *lr_ptr : lr;
 
     if (found_inf_ptr && *found_inf_ptr == 1) {
       return;
     }
-    auto* step_count =
-        reinterpret_cast<const float*>(tl.state_steps_addresses[tensor_loc]);
+    const auto [bias_correction1, bias_correction2_sqrt] =
+        [&]() -> std::pair<double, double> {
+      auto* step_count =
+          reinterpret_cast<const float*>(tl.state_steps_addresses[tensor_loc]);
+      const auto bias_correction1 = 1 - at::native::pow_(beta1, *step_count);
+      const auto bias_correction2 = 1 - at::native::pow_(beta2, *step_count);
+      const auto bias_correction2_sqrt = std::sqrt(bias_correction2);
+      return {bias_correction1, bias_correction2_sqrt};
+    }();
 
     scalar_type* args[depth];
+    scalar_type r_args[depth][kILP];
+    const auto n = tl.numel_for_tensor[tensor_loc] - chunk_idx * chunk_size;
+
     const bool all_aligned{
         init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc)};
-    n -= chunk_idx * chunk_size;
-    scalar_type r_args[depth][kILP];
-
     if ((n % kILP == 0) && (chunk_size % kILP == 0) && all_aligned) {
       for (int64_t i_start = threadIdx.x;
            i_start * kILP < n && i_start * kILP < chunk_size;
            i_start += blockDim.x) {
 #pragma unroll
-        for (int i = 0; i < depth; i++) {
+        for (uint8_t i = 0; i < depth; i++) {
           load_store(r_args[i], args[i], 0, i_start);
         }
         adam_math<scalar_type, opmath_t, depth, adam_mode, amsgrad>(
             r_args,
-            step_count,
             lr_double,
             beta1,
             beta2,
@@ -157,9 +161,11 @@ struct FusedAdamMathFunctor {
             eps,
             maximize,
             grad_scale_ptr,
-            found_inf_ptr);
+            found_inf_ptr,
+            bias_correction1,
+            bias_correction2_sqrt);
 #pragma unroll
-        for (int i = 0; i < depth; i++) {
+        for (uint8_t i = 0; i < depth; i++) {
           if (i != kGradIdx || grad_scale_ptr) {
             load_store(args[i], r_args[i], i_start, 0);
           }
@@ -171,7 +177,6 @@ struct FusedAdamMathFunctor {
         load_args<depth>(r_args, args, i_start, chunk_size, n);
         adam_math<scalar_type, opmath_t, depth, adam_mode, amsgrad>(
             r_args,
-            step_count,
             lr_double,
             beta1,
             beta2,
@@ -179,9 +184,11 @@ struct FusedAdamMathFunctor {
             eps,
             maximize,
             grad_scale_ptr,
-            found_inf_ptr);
+            found_inf_ptr,
+            bias_correction1,
+            bias_correction2_sqrt);
 #pragma unroll
-        for (int i = 0; i < depth; i++) {
+        for (uint8_t i = 0; i < depth; i++) {
           if (i != kGradIdx || grad_scale_ptr) {
             store_args(args[i], r_args[i], i_start, chunk_size, n);
           }

--- a/aten/src/ATen/native/cuda/fused_adam_utils.cuh
+++ b/aten/src/ATen/native/cuda/fused_adam_utils.cuh
@@ -21,7 +21,8 @@ template <
     typename scalar_type,
     typename opmath_t,
     int depth,
-    ADAM_MODE adam_mode>
+    ADAM_MODE adam_mode,
+    bool amsgrad>
 C10_DEVICE inline void adam_math(
     scalar_type r_args[depth][kILP],
     const float* step_count,
@@ -31,7 +32,6 @@ C10_DEVICE inline void adam_math(
     const double weight_decay,
     const double eps,
     const bool maximize,
-    const bool amsgrad,
     const float* grad_scale_ptr,
     const float* found_inf_ptr) {
   static_assert(depth == 4 || depth == 5);
@@ -103,7 +103,7 @@ C10_DEVICE inline void adam_math(
 // parameter updates accordingly. To be functionally on par with `torch.optim`
 // optimizers and `_multi_tensor` ones, the kernel below writes out gradients
 // only when `grad_scale_ptr != nullptr.
-template <typename scalar_type, int depth, ADAM_MODE adam_mode>
+template <typename scalar_type, int depth, ADAM_MODE adam_mode, bool amsgrad>
 struct FusedAdamMathFunctor {
   static_assert(
       depth == 4 || depth == 5,
@@ -119,7 +119,6 @@ struct FusedAdamMathFunctor {
       const double weight_decay,
       const double eps,
       const bool maximize,
-      const bool amsgrad,
       const float* grad_scale_ptr,
       const float* found_inf_ptr,
       const ADAM_MODE adam_mode) {
@@ -148,7 +147,7 @@ struct FusedAdamMathFunctor {
         for (int i = 0; i < depth; i++) {
           load_store(r_args[i], args[i], 0, i_start);
         }
-        adam_math<scalar_type, opmath_t, depth, adam_mode>(
+        adam_math<scalar_type, opmath_t, depth, adam_mode, amsgrad>(
             r_args,
             step_count,
             lr_double,
@@ -157,7 +156,6 @@ struct FusedAdamMathFunctor {
             weight_decay,
             eps,
             maximize,
-            amsgrad,
             grad_scale_ptr,
             found_inf_ptr);
 #pragma unroll
@@ -171,7 +169,7 @@ struct FusedAdamMathFunctor {
       for (int64_t i_start = 0; i_start < n && i_start < chunk_size;
            i_start += blockDim.x * kILP) {
         load_args<depth>(r_args, args, i_start, chunk_size, n);
-        adam_math<scalar_type, opmath_t, depth, adam_mode>(
+        adam_math<scalar_type, opmath_t, depth, adam_mode, amsgrad>(
             r_args,
             step_count,
             lr_double,
@@ -180,7 +178,6 @@ struct FusedAdamMathFunctor {
             weight_decay,
             eps,
             maximize,
-            amsgrad,
             grad_scale_ptr,
             found_inf_ptr);
 #pragma unroll

--- a/aten/src/ATen/native/cuda/fused_adam_utils.cuh
+++ b/aten/src/ATen/native/cuda/fused_adam_utils.cuh
@@ -119,8 +119,7 @@ struct FusedAdamMathFunctor {
       const double& eps,
       const bool& maximize,
       const float* grad_scale_ptr,
-      const float* found_inf_ptr,
-      const ADAM_MODE adam_mode) {
+      const float* found_inf_ptr) {
     const auto tensor_loc = tl.block_to_tensor[blockIdx.x];
     const auto chunk_idx = tl.block_to_chunk[blockIdx.x];
     const double lr_double = lr_ptr ? *lr_ptr : lr;

--- a/aten/src/ATen/native/cuda/fused_adamw_amsgrad_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adamw_amsgrad_impl.cu
@@ -46,7 +46,7 @@ void _fused_adamw_amsgrad_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ADAMW>(),
+            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ADAMW, true>(),
             lr_ptr, // unused
             lr,
             beta1,
@@ -54,7 +54,6 @@ void _fused_adamw_amsgrad_cuda_impl_(
             weight_decay,
             eps,
             maximize,
-            /* amsgrad */ true,
             grad_scale_ptr,
             found_inf_ptr);
       });
@@ -98,7 +97,7 @@ void _fused_adamw_amsgrad_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ADAMW>(),
+            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ADAMW, true>(),
             lr_ptr,
             1.0, // unused
             beta1,
@@ -106,7 +105,6 @@ void _fused_adamw_amsgrad_cuda_impl_(
             weight_decay,
             eps,
             maximize,
-            /* amsgrad */ true,
             grad_scale_ptr,
             found_inf_ptr);
       });

--- a/aten/src/ATen/native/cuda/fused_adamw_amsgrad_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adamw_amsgrad_impl.cu
@@ -46,7 +46,7 @@ void _fused_adamw_amsgrad_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 5>(),
+            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ADAMW>(),
             lr_ptr, // unused
             lr,
             beta1,
@@ -56,8 +56,7 @@ void _fused_adamw_amsgrad_cuda_impl_(
             maximize,
             /* amsgrad */ true,
             grad_scale_ptr,
-            found_inf_ptr,
-            ADAM_MODE::ADAMW);
+            found_inf_ptr);
       });
 }
 
@@ -99,7 +98,7 @@ void _fused_adamw_amsgrad_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<5>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 5>(),
+            FusedAdamMathFunctor<scalar_t, 5, ADAM_MODE::ADAMW>(),
             lr_ptr,
             1.0, // unused
             beta1,
@@ -109,8 +108,7 @@ void _fused_adamw_amsgrad_cuda_impl_(
             maximize,
             /* amsgrad */ true,
             grad_scale_ptr,
-            found_inf_ptr,
-            ADAM_MODE::ADAMW);
+            found_inf_ptr);
       });
 }
 

--- a/aten/src/ATen/native/cuda/fused_adamw_amsgrad_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adamw_amsgrad_impl.cu
@@ -31,11 +31,11 @@ void _fused_adamw_amsgrad_cuda_impl_(
       exp_avg_sqs.vec(),
       max_exp_avg_sqs.vec()};
 
-  float* grad_scale_ptr =
+  const float* grad_scale_ptr =
       grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  float* found_inf_ptr =
+  const float* found_inf_ptr =
       found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  float* lr_ptr = nullptr;
+  const float* lr_ptr = nullptr;
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kHalf,
@@ -82,11 +82,11 @@ void _fused_adamw_amsgrad_cuda_impl_(
       exp_avg_sqs.vec(),
       max_exp_avg_sqs.vec()};
 
-  float* grad_scale_ptr =
+  const float* grad_scale_ptr =
       grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  float* found_inf_ptr =
+  const float* found_inf_ptr =
       found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  float* lr_ptr = lr.data_ptr<float>();
+  const float* lr_ptr = lr.data_ptr<float>();
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kHalf,

--- a/aten/src/ATen/native/cuda/fused_adamw_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adamw_impl.cu
@@ -41,7 +41,7 @@ void _fused_adamw_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 4>(),
+            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ADAMW>(),
             lr_ptr, // unused
             lr,
             beta1,
@@ -51,8 +51,7 @@ void _fused_adamw_cuda_impl_(
             maximize,
             /* amsgrad */ false,
             grad_scale_ptr,
-            found_inf_ptr,
-            ADAM_MODE::ADAMW);
+            found_inf_ptr);
       });
 }
 
@@ -89,7 +88,7 @@ void _fused_adamw_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 4>(),
+            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ADAMW>(),
             lr_ptr,
             1.0, // unused
             beta1,
@@ -99,8 +98,7 @@ void _fused_adamw_cuda_impl_(
             maximize,
             /* amsgrad */ false,
             grad_scale_ptr,
-            found_inf_ptr,
-            ADAM_MODE::ADAMW);
+            found_inf_ptr);
       });
 }
 

--- a/aten/src/ATen/native/cuda/fused_adamw_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adamw_impl.cu
@@ -26,11 +26,11 @@ void _fused_adamw_cuda_impl_(
   std::vector<std::vector<at::Tensor>> tensor_lists{
       params.vec(), grads.vec(), exp_avgs.vec(), exp_avg_sqs.vec()};
 
-  float* grad_scale_ptr =
+  const float* grad_scale_ptr =
       grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  float* found_inf_ptr =
+  const float* found_inf_ptr =
       found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  float* lr_ptr = nullptr;
+  const float* lr_ptr = nullptr;
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kHalf,
@@ -72,11 +72,11 @@ void _fused_adamw_cuda_impl_(
   std::vector<std::vector<at::Tensor>> tensor_lists{
       params.vec(), grads.vec(), exp_avgs.vec(), exp_avg_sqs.vec()};
 
-  float* grad_scale_ptr =
+  const float* grad_scale_ptr =
       grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
-  float* found_inf_ptr =
+  const float* found_inf_ptr =
       found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
-  float* lr_ptr = lr.data_ptr<float>();
+  const float* lr_ptr = lr.data_ptr<float>();
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kHalf,

--- a/aten/src/ATen/native/cuda/fused_adamw_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adamw_impl.cu
@@ -41,7 +41,7 @@ void _fused_adamw_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ADAMW>(),
+            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ADAMW, false>(),
             lr_ptr, // unused
             lr,
             beta1,
@@ -49,7 +49,6 @@ void _fused_adamw_cuda_impl_(
             weight_decay,
             eps,
             maximize,
-            /* amsgrad */ false,
             grad_scale_ptr,
             found_inf_ptr);
       });
@@ -88,7 +87,7 @@ void _fused_adamw_cuda_impl_(
         multi_tensor_apply_for_fused_optimizer<4>(
             tensor_lists,
             state_steps,
-            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ADAMW>(),
+            FusedAdamMathFunctor<scalar_t, 4, ADAM_MODE::ADAMW, false>(),
             lr_ptr,
             1.0, // unused
             beta1,
@@ -96,7 +95,6 @@ void _fused_adamw_cuda_impl_(
             weight_decay,
             eps,
             maximize,
-            /* amsgrad */ false,
             grad_scale_ptr,
             found_inf_ptr);
       });


### PR DESCRIPTION
Part of #117872

| branch | cpu time avg (ms) | cuda time avg (ms) |
|--------|--------------|---------------|
| [main](eebe7e1d37f1baa995c694d540cc2fc98884fa18) | 13.430 | 144.117 |
| pr                                               | 13.371 | 49.655  | 

Used torch profiler to measure the avg perf or 20 iterations. 
Model is openlm-research/open_llama_7b_v2 (script is [here](https://gist.github.com/crcrpar/ca951d4e7f3e1c771d502135b798f0d1)).

---

PR
```
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
                                                   Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg       CPU Mem  Self CPU Mem      CUDA Mem  Self CUDA Mem    # of Calls
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
                                          ProfilerStep*         0.00%       0.000us         0.00%       0.000us       0.000us        5.789s        46.42%        5.789s     289.456ms           0 b           0 b           0 b           0 b            20
                                          ProfilerStep*        36.02%        3.119s        67.19%        5.819s     290.958ms       0.000us         0.00%        2.586s     129.276ms      48.00 Kb      -1.47 Mb           0 b    -504.23 Gb            20
                                               aten::mm         2.57%     222.681ms         8.80%     762.415ms      56.475us        2.501s        20.05%        2.501s     185.255us           0 b           0 b     441.39 Gb     441.39 Gb         13500
       autograd::engine::evaluate_function: MmBackward0         0.10%       8.600ms         8.17%     707.935ms     157.319us       0.000us         0.00%        1.625s     361.098us           0 b           0 b     198.65 Gb    -135.03 Gb          4500
                                            MmBackward0         0.39%      33.896ms         7.99%     692.035ms     153.786us       0.000us         0.00%        1.601s     355.710us           0 b           0 b     330.84 Gb    -248.00 Mb          4500
                              Optimizer.step#AdamW.step         0.00%       0.000us         0.00%       0.000us       0.000us        1.007s         8.07%        1.007s      50.329ms           0 b           0 b           0 b           0 b            20
                                             AdamW.step         0.01%     837.000us         3.36%     290.610ms      14.530ms       0.000us         0.00%     993.235ms      49.662ms           0 b           0 b           0 b           0 b            20
                              Optimizer.step#AdamW.step         0.22%      18.825ms         3.35%     289.773ms      14.489ms       0.000us         0.00%     993.235ms      49.662ms           0 b           0 b           0 b           0 b            20
                                    aten::_fused_adamw_         0.12%      10.823ms         3.09%     267.428ms      13.371ms     993.095ms         7.96%     993.095ms      49.655ms           0 b           0 b           0 b           0 b            20
void at::native::(anonymous namespace)::multi_tensor...         0.00%       0.000us         0.00%       0.000us       0.000us     993.095ms         7.96%     993.095ms     154.207us           0 b           0 b           0 b           0 b          6440
                                           aten::matmul         0.19%      16.140ms         1.73%     149.869ms      33.304us       0.000us         0.00%     876.000ms     194.667us           0 b           0 b     107.46 Gb           0 b          4500
sm90_xmma_gemm_bf16bf16_bf16f32_f32_nt_n_tilesize128...         0.00%       0.000us         0.00%       0.000us       0.000us     835.374ms         6.70%     835.374ms     185.639us           0 b           0 b           0 b           0 b          4500
                                           aten::linear         0.27%      23.268ms         1.97%     170.227ms      37.828us       0.000us         0.00%     776.278ms     172.506us           0 b           0 b     107.46 Gb      12.17 Gb          4500
sm90_xmma_gemm_bf16bf16_bf16f32_f32_tn_n_tilesize128...         0.00%       0.000us         0.00%       0.000us       0.000us     707.074ms         5.67%     707.074ms     183.180us           0 b           0 b           0 b           0 b          3860
                                              aten::mul         1.31%     113.614ms         5.14%     445.405ms      22.125us     552.421ms         4.43%     552.780ms      27.459us     256.32 Kb     256.21 Kb     420.38 Gb     419.88 Gb         20131
sm90_xmma_gemm_bf16bf16_bf16f32_f32_nn_n_tilesize128...         0.00%       0.000us         0.00%       0.000us       0.000us     442.209ms         3.55%     442.209ms     138.190us           0 b           0 b           0 b           0 b          3200
      autograd::engine::evaluate_function: MulBackward0         0.25%      21.336ms         5.00%     432.976ms      74.651us       0.000us         0.00%     398.627ms      68.729us           0 b           0 b     -45.71 Gb    -252.76 Gb          5800
                                             aten::add_         0.37%      31.975ms         7.19%     622.433ms      53.658us     391.957ms         3.14%     391.957ms      33.789us           0 b           0 b      -4.35 Gb      -4.35 Gb         11600
sm90_xmma_gemm_bf16bf16_bf16f32_f32_nn_n_tilesize256...         0.00%       0.000us         0.00%       0.000us       0.000us     345.037ms         2.77%     345.037ms     265.413us           0 b           0 b           0 b           0 b          1300
                                            aten::copy_         0.41%      35.727ms        20.62%        1.786s     146.503us     342.386ms         2.75%     342.386ms      28.092us      48.00 Kb      48.00 Kb     -56.00 Mb     -56.00 Mb         12188
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 8.661s
Self CUDA time total: 12.472s
```

main
```
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
                                                   Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg       CPU Mem  Self CPU Mem      CUDA Mem  Self CUDA Mem    # of Calls
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
                                          ProfilerStep*         0.00%       0.000us         0.00%       0.000us       0.000us        7.671s        42.31%        7.671s     383.529ms           0 b           0 b           0 b           0 b            20
                                          ProfilerStep*        28.85%        3.050s        72.83%        7.700s     385.009ms       0.000us         0.00%        4.474s     223.678ms      48.00 Kb      -1.48 Mb           0 b    -504.45 Gb            20
                              Optimizer.step#AdamW.step         0.00%       0.000us         0.00%       0.000us       0.000us        2.896s        15.97%        2.896s     144.787ms           0 b           0 b           0 b           0 b            20
                                             AdamW.step         0.01%     819.000us         2.75%     291.024ms      14.551ms       0.000us         0.00%        2.882s     144.125ms           0 b           0 b           0 b           0 b            20
                              Optimizer.step#AdamW.step         0.17%      18.291ms         2.74%     290.205ms      14.510ms       0.000us         0.00%        2.882s     144.125ms           0 b           0 b           0 b           0 b            20
                                    aten::_fused_adamw_         0.10%      10.893ms         2.54%     268.602ms      13.430ms        2.882s        15.90%        2.882s     144.117ms           0 b           0 b           0 b           0 b            20
void at::native::(anonymous namespace)::multi_tensor...         0.00%       0.000us         0.00%       0.000us       0.000us        2.882s        15.90%        2.882s     447.570us           0 b           0 b           0 b           0 b          6440
                                               aten::mm         2.05%     217.136ms         7.21%     762.211ms      56.460us        2.499s        13.78%        2.499s     185.075us           0 b           0 b     441.37 Gb     441.37 Gb         13500
       autograd::engine::evaluate_function: MmBackward0         0.07%       7.179ms         6.77%     715.673ms     159.038us       0.000us         0.00%        1.624s     360.812us           0 b           0 b     198.65 Gb    -134.64 Gb          4500
                                            MmBackward0         0.32%      34.257ms         6.62%     700.088ms     155.575us       0.000us         0.00%        1.600s     355.460us           0 b           0 b     330.59 Gb    -628.00 Mb          4500
                                           aten::matmul         0.15%      15.892ms         1.32%     139.597ms      31.022us       0.000us         0.00%     874.861ms     194.414us           0 b           0 b     107.46 Gb           0 b          4500
sm90_xmma_gemm_bf16bf16_bf16f32_f32_nt_n_tilesize128...         0.00%       0.000us         0.00%       0.000us       0.000us     834.631ms         4.60%     834.631ms     185.474us           0 b           0 b           0 b           0 b          4500
                                           aten::linear         0.21%      22.460ms         1.51%     159.620ms      35.471us       0.000us         0.00%     774.772ms     172.172us           0 b           0 b     107.46 Gb      11.88 Gb          4500
sm90_xmma_gemm_bf16bf16_bf16f32_f32_tn_n_tilesize128...         0.00%       0.000us         0.00%       0.000us       0.000us     705.996ms         3.89%     705.996ms     182.901us           0 b           0 b           0 b           0 b          3860
                                              aten::mul         1.06%     112.529ms         4.28%     452.473ms      22.488us     552.242ms         3.05%     552.266ms      27.447us     255.90 Kb     255.88 Kb     413.93 Gb     413.90 Gb         20121
sm90_xmma_gemm_bf16bf16_bf16f32_f32_nn_n_tilesize128...         0.00%       0.000us         0.00%       0.000us       0.000us     441.514ms         2.44%     441.514ms     137.973us           0 b           0 b           0 b           0 b          3200
      autograd::engine::evaluate_function: MulBackward0         0.19%      20.517ms         4.18%     442.189ms      76.239us       0.000us         0.00%     398.552ms      68.716us           0 b           0 b     -45.57 Gb    -251.17 Gb          5800
                                             aten::add_         0.30%      31.703ms         6.01%     635.030ms      54.744us     391.897ms         2.16%     391.897ms      33.784us           0 b           0 b      -5.71 Gb      -5.71 Gb         11600
sm90_xmma_gemm_bf16bf16_bf16f32_f32_nn_n_tilesize256...         0.00%       0.000us         0.00%       0.000us       0.000us     344.972ms         1.90%     344.972ms     265.363us           0 b           0 b           0 b           0 b          1300
                                            aten::copy_         0.33%      34.415ms        34.75%        3.674s     301.437us     342.661ms         1.89%     342.661ms      28.115us      80.00 Kb      80.00 Kb    -240.00 Mb    -240.00 Mb         12188
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 10.574s
Self CUDA time total: 18.129s
```