### PR TITLE
Fix RuntimeError: NYI: Named tensors are not supported with the tracer

### DIFF
--- a/aten/src/ATen/StorageUtils.cpp
+++ b/aten/src/ATen/StorageUtils.cpp
@@ -25,10 +25,10 @@ C10_EXPORT void storage_copy(
     const c10::Storage& src,
     bool non_blocking) {
   auto dst_options = c10::TensorOptions().device(dst.device()).dtype(at::kByte);
-  auto dst_t = at::empty({0}, {}, dst_options).set_(dst);
+  auto dst_t = at::empty({0}, dst_options).set_(dst);
 
   auto src_options = c10::TensorOptions().device(src.device()).dtype(at::kByte);
-  auto src_t = at::empty({0}, {}, src_options).set_(src);
+  auto src_t = at::empty({0}, src_options).set_(src);
   dst_t.copy_(src_t, non_blocking);
 }
 

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -273,9 +273,9 @@ static inline Tensor boolToIndexingTensorCPUOrCUDA(
   // booleans add a dimension of size 1. true indexes this dimension as if 0:,
   // false as empty.
   if (value) {
-    return at::empty({1}, {}, self.options().dtype(kLong)).fill_(0.);
+    return at::empty({1}, self.options().dtype(kLong)).fill_(0.);
   } else {
-    return at::empty({0}, {}, self.options().dtype(kLong));
+    return at::empty({0}, self.options().dtype(kLong));
   }
 }
 
@@ -285,9 +285,9 @@ static inline Tensor boolToIndexingTensorNonNativeDeviceType(
   // booleans add a dimension of size 1. true indexes this dimension as if 0:,
   // false as empty.
   if (value) {
-    return at::zeros({1}, {}, self.options().dtype(kLong));
+    return at::zeros({1}, self.options().dtype(kLong));
   } else {
-    return at::empty({0}, {}, self.options().dtype(kLong));
+    return at::empty({0}, self.options().dtype(kLong));
   }
 }
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -16024,6 +16024,11 @@ dedent """
             with torch.jit.fuser(fuser_name):
                 self.checkModule(MyModule(), (x, y))
 
+    def test_zero_dimension_tensor_trace(self):
+        def f(x):
+            return x[x > 0]
+        jf = torch.jit.trace(f, torch.tensor(2., device="cpu"))
+
 # known to be failing in tracer
 EXCLUDE_TRACED = {
     # The following fail due to #12024.

--- a/torch/csrc/StorageMethods.cpp
+++ b/torch/csrc/StorageMethods.cpp
@@ -161,7 +161,7 @@ static PyObject* THPStorage_resize_(PyObject* self, PyObject* number_arg) {
 
     auto src_option =
         c10::TensorOptions().device(storage.device()).dtype(at::kByte);
-    auto src_tensor = at::empty({0}, {}, src_option).set_(storage);
+    auto src_tensor = at::empty({0}, src_option).set_(storage);
     src_tensor.resize_({size_bytes});
 
     // When using resize_ to replace resize_bytes_xxx, in some cases

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -220,7 +220,7 @@ void THPPointer<THPStorage>::free() {
 
 void storage_fill(const at::Storage& self, uint8_t value) {
   auto options = c10::TensorOptions().device(self.device()).dtype(at::kByte);
-  auto self_t = at::empty({0}, {}, options).set_(self);
+  auto self_t = at::empty({0}, options).set_(self);
   self_t.fill_(value);
 }
 
@@ -229,7 +229,7 @@ void storage_set(const at::Storage& self, ptrdiff_t idx, uint8_t value) {
       (idx >= 0) && (idx < static_cast<ptrdiff_t>(self.nbytes())),
       "out of bounds");
   auto options = c10::TensorOptions().device(self.device()).dtype(at::kByte);
-  auto self_t = at::empty({0}, {}, options).set_(self);
+  auto self_t = at::empty({0}, options).set_(self);
   self_t[idx].fill_(value);
 }
 
@@ -238,7 +238,7 @@ uint8_t storage_get(const at::Storage& self, ptrdiff_t idx) {
       (idx >= 0) && (idx < static_cast<ptrdiff_t>(self.nbytes())),
       "out of bounds");
   auto options = c10::TensorOptions().device(self.device()).dtype(at::kByte);
-  auto self_t = at::empty({0}, {}, options).set_(self);
+  auto self_t = at::empty({0}, options).set_(self);
   return self_t[idx].item<uint8_t>();
 }
 


### PR DESCRIPTION
This PR relands #108238 that was closed as stale due to CLA issues and also because the CI check has marked the PR as not mergeable.

Repro 1:

```python
import torch

def f(x):
    return x[x > 0]

jf = torch.jit.trace(f, torch.tensor(2., device="cuda"))
```
Error:

```bash
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/pytorch/torch/jit/_trace.py", line 874, in trace
    traced = torch._C._create_function_from_trace(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<stdin>", line 2, in f
RuntimeError: NYI: Named tensors are not supported with the tracer
```

Repro2:

```python
import torch
import torch.nn.functional as F
from torch import nn
import copy

class Net(nn.Module):
    def __init__(self):
        super().__init__()

    def forward(self, inputs):
        x = copy.deepcopy(inputs) # RuntimeError: NYI: Named tensors are not supported with the tracer
        x = F.relu(x)
        return x

model = Net()
images = torch.randn(8, 28, 28)
torch.jit.trace(model, images)
```

Error 2:

```bash
Traceback (most recent call last):
  File "/opt/pytorch/test_deepcopy.py", line 18, in <module>
  File "/opt/pytorch/torch/jit/_trace.py", line 806, in trace
    return trace_module(
           ^^^^^^^^^^^^^
  File "/opt/pytorch/torch/jit/_trace.py", line 1074, in trace_module
    module._c._create_method_from_trace(
  File "/opt/pytorch/torch/nn/modules/module.py", line 1511, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/torch/nn/modules/module.py", line 1520, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/torch/nn/modules/module.py", line 1501, in _slow_forward
    result = self.forward(*input, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/test_deepcopy.py", line 12, in forward
    x = F.relu(x)
        ^^^^^^^^^^
  File "/opt/conda/envs/ptca/lib/python3.11/copy.py", line 153, in deepcopy
    y = copier(memo)
        ^^^^^^^^^^^^
  File "/opt/pytorch/torch/_tensor.py", line 122, in __deepcopy__
    new_storage = self._typed_storage()._deepcopy(memo)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/torch/storage.py", line 847, in _deepcopy
    return self._new_wrapped_storage(copy.deepcopy(self._untyped_storage, memo))
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/ptca/lib/python3.11/copy.py", line 153, in deepcopy
    y = copier(memo)
        ^^^^^^^^^^^^
  File "/opt/pytorch/torch/storage.py", line 112, in __deepcopy__
    new_storage = self.clone()
                  ^^^^^^^^^^^^
  File "/opt/pytorch/torch/storage.py", line 126, in clone
    return type(self)(self.nbytes(), device=self.device).copy_(self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: NYI: Named tensors are not supported with the tracer
```

----
 #48054 RuntimeError: NYI: Named tensors are not supported with the tracer
 #49538 jit tracer doesn't work with unflatten layer
 #31591 when i try to export a pytorch model to ONNX, got RuntimeError: output of traced region did not have observable data dependence with trace inputs; this probably indicates your program cannot be understood by the tracer.
   - This bug was closed but exists. Multiple comments on it still showing error. This is addressed

Likely fixes the following issues (but untested)

 #63297 Named tensor in tracer
 #2323 [Bug] torch.onnx.errors.UnsupportedOperatorError when convert mask2former to onnx

Fix zero dimensioned tensors when used with jit.trace They are currently assigned an empty set for names {} this is not the same as "no name" so jit.trace bails with
  "NYI: Named tensors are not supported with the tracer"
This happens when I am trying to save a non-trivial model as onnx but the simplest repro I have seen is 48054 above which has been added as test/jit/test_zero_dim_tensor_trace.py

Test plan:
  New unit test added
  Broken scenarios tested locally
  CI

Fixes #48054

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel