### PR TITLE
[dynamo][assume_constant_result] Dont put symbolic guards for assume_constant_result

### DIFF
--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1815,7 +1815,11 @@ def wrap_to_fake_tensor_and_record(
             "stride": fake_e.stride(),
         }
 
-        if is_tensor and not (static_shapes and source.is_nn_module()):
+        if (
+            is_tensor
+            and not (static_shapes and source.is_nn_module())
+            and not is_constant_source(source)
+        ):
             tx.output.tracked_fakes.append(
                 TrackedFake(fake_e, source, symbolic_context)
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #118448
* #118420
* #118447
* __->__ #118430



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng