### PR TITLE
Add `module: docs` to labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -79,3 +79,6 @@
 "module: distributed_checkpoint":
 - torch/distributed/checkpoint/**
 - test/distributed/checkpoint/**
+
+"module: docs":
+- docs/*


### PR DESCRIPTION
Adding a label for [`module: docs` tag](https://github.com/pytorch/pytorch/pulls?q=is%3Aopen+is%3Apr+label%3A%22module%3A+docs%22) to simplify reviews.