### PR TITLE
[ROCm] Hipify trie re-engineering and adding unit tests

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -700,7 +700,7 @@ class TestHipify(TestCase):
     
 
 class TestHipifyTrie(TestCase):
-    def setup(self):
+    def setUp(self):
         self.trie = torch.utils.hipify.hipify_python.Trie()
 
     def test_add_and_search_trie(self):
@@ -709,9 +709,59 @@ class TestHipifyTrie(TestCase):
         self.assertFalse(self.trie.search("ban"))
         self.assertFalse(self.trie.search("dog"))
 
+    def test_add_multiple_and_search_trie(self):
+        words_to_add = ["banana", "apple", "orange"]
+        for word in words_to_add:
+            self.trie.add(word)
 
+        for word in words_to_add:
+            self.assertTrue(self.trie.search(word))
+
+        for word in ["ban", "dog", "okay", "app"]:
+            self.assertFalse(self.trie.search(word))
+
+    def test_quote_escape(self):
+        orig_chars=["*", "[", ".", "+", "a", "z", "-"]
+        quoted_strs=["\\*", "\\[", "\\.", "\\+", "a", "z", "\\-"]
+        for i in range(len(orig_chars)):
+            self.assertEqual(self.trie._quote(orig_chars[i]), quoted_strs[i])
     
+    def test_export_trie_to_regex(self):
+        words_to_add=["__CUDACC__", "CUDA_ERROR_CONTEXT_ALREADY_CURRENT", "CUDA_ERROR_ARRAY_IS_MAPPED","CUDA_ERROR_NOT_MAPPED", "CUDA_ERROR_INVALID_SOURCE"]
+        for word in words_to_add:
+            self.trie.add(word)
+        regex = self.trie.export_to_regex()
+        expected_regex=r"(?:CUDA_ERROR_(?:ARRAY_IS_MAPPED|CONTEXT_ALREADY_CURRENT|INVALID_SOURCE|NOT_MAPPED)|__CUDACC__)"
+        self.assertEqual(regex, expected_regex)
 
+
+    def test_prefix_words_export_trie_to_regex(self):
+        # test case where some nodes have both children and are also leaf nodes.
+        words_to_add=["apple", "app", "ban","banana"]
+        for word in words_to_add:
+            self.trie.add(word)
+        regex = self.trie.export_to_regex()
+        expected_regex=r"(?:app(?:le)?|ban(?:ana)?)"
+        self.assertEqual(regex, expected_regex)
+
+    def test_single_export_trie_to_regex(self):
+        words_to_add=["cudaErrorInvalidMemcpyDirection"]
+        for word in words_to_add:
+            self.trie.add(word)
+        regex = self.trie.export_to_regex()
+        expected_regex="cudaErrorInvalidMemcpyDirection"
+        self.assertEqual(regex, expected_regex)
+
+
+    def test_char_export_trie_to_regex(self):
+        self.trie.add("a")
+        self.assertEqual(self.trie.export_to_regex(), "a")
+        self.trie.add("b")
+        self.assertEqual(self.trie.export_to_regex(), "[ab]")
+    
+    def test_special_char_export_trie_to_regex(self):
+        self.trie.add(r"c*")
+        self.assertEqual(self.trie.export_to_regex(), r"c\*")
 
 class TestAssert(TestCase):
     def test_assert_true(self):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -697,7 +697,7 @@ class TestHipify(TestCase):
 
     def test_import_hipify(self):
         from torch.utils.hipify import hipify_python  # noqa: F401
-    
+
 
 class TestHipifyTrie(TestCase):
     def setUp(self):
@@ -721,35 +721,36 @@ class TestHipifyTrie(TestCase):
             self.assertFalse(self.trie.search(word))
 
     def test_quote_escape(self):
-        orig_chars=["*", "[", ".", "+", "a", "z", "-"]
-        quoted_strs=["\\*", "\\[", "\\.", "\\+", "a", "z", "\\-"]
+        orig_chars = ["*", "[", ".", "+", "a", "z", "-"]
+        quoted_strs = ["\\*", "\\[", "\\.", "\\+", "a", "z", "\\-"]
         for i in range(len(orig_chars)):
             self.assertEqual(self.trie.quote(orig_chars[i]), quoted_strs[i])
-    
+
     def test_export_trie_to_regex(self):
-        words_to_add=["__CUDACC__", "CUDA_ERROR_CONTEXT_ALREADY_CURRENT", "CUDA_ERROR_ARRAY_IS_MAPPED","CUDA_ERROR_NOT_MAPPED", "CUDA_ERROR_INVALID_SOURCE"]
+        words_to_add = ["__CUDACC__", "CUDA_ERROR_CONTEXT_ALREADY_CURRENT", "CUDA_ERROR_ARRAY_IS_MAPPED",
+                        "CUDA_ERROR_NOT_MAPPED", "CUDA_ERROR_INVALID_SOURCE"]
         for word in words_to_add:
             self.trie.add(word)
         regex = self.trie.export_to_regex()
-        expected_regex=r"(?:CUDA_ERROR_(?:ARRAY_IS_MAPPED|CONTEXT_ALREADY_CURRENT|INVALID_SOURCE|NOT_MAPPED)|__CUDACC__)"
+        expected_regex = r"(?:CUDA_ERROR_(?:ARRAY_IS_MAPPED|CONTEXT_ALREADY_CURRENT|INVALID_SOURCE|NOT_MAPPED)|__CUDACC__)"
         self.assertEqual(regex, expected_regex)
 
 
     def test_prefix_words_export_trie_to_regex(self):
         # test case where some nodes have both children and are also leaf nodes.
-        words_to_add=["apple", "app", "ban","banana"]
+        words_to_add = ["apple", "app", "ban", "banana"]
         for word in words_to_add:
             self.trie.add(word)
         regex = self.trie.export_to_regex()
-        expected_regex=r"(?:app(?:le)?|ban(?:ana)?)"
+        expected_regex = r"(?:app(?:le)?|ban(?:ana)?)"
         self.assertEqual(regex, expected_regex)
 
     def test_single_export_trie_to_regex(self):
-        words_to_add=["cudaErrorInvalidMemcpyDirection"]
+        words_to_add = ["cudaErrorInvalidMemcpyDirection"]
         for word in words_to_add:
             self.trie.add(word)
         regex = self.trie.export_to_regex()
-        expected_regex="cudaErrorInvalidMemcpyDirection"
+        expected_regex = "cudaErrorInvalidMemcpyDirection"
         self.assertEqual(regex, expected_regex)
 
 
@@ -758,7 +759,7 @@ class TestHipifyTrie(TestCase):
         self.assertEqual(self.trie.export_to_regex(), "a")
         self.trie.add("b")
         self.assertEqual(self.trie.export_to_regex(), "[ab]")
-    
+
     def test_special_char_export_trie_to_regex(self):
         self.trie.add(r"c*")
         self.assertEqual(self.trie.export_to_regex(), r"c\*")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -694,8 +694,23 @@ class TestONNXUtils(TestCase):
 
 
 class TestHipify(TestCase):
+
     def test_import_hipify(self):
         from torch.utils.hipify import hipify_python  # noqa: F401
+    
+
+class TestHipifyTrie(TestCase):
+    def setup(self):
+        self.trie = torch.utils.hipify.hipify_python.Trie()
+
+    def test_add_and_search_trie(self):
+        self.trie.add("banana")
+        self.assertTrue(self.trie.search("banana"))
+        self.assertFalse(self.trie.search("ban"))
+        self.assertFalse(self.trie.search("dog"))
+
+
+    
 
 
 class TestAssert(TestCase):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -724,7 +724,7 @@ class TestHipifyTrie(TestCase):
         orig_chars=["*", "[", ".", "+", "a", "z", "-"]
         quoted_strs=["\\*", "\\[", "\\.", "\\+", "a", "z", "\\-"]
         for i in range(len(orig_chars)):
-            self.assertEqual(self.trie._quote(orig_chars[i]), quoted_strs[i])
+            self.assertEqual(self.trie.quote(orig_chars[i]), quoted_strs[i])
     
     def test_export_trie_to_regex(self):
         words_to_add=["__CUDACC__", "CUDA_ERROR_CONTEXT_ALREADY_CURRENT", "CUDA_ERROR_ARRAY_IS_MAPPED","CUDA_ERROR_NOT_MAPPED", "CUDA_ERROR_INVALID_SOURCE"]

--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -665,7 +665,7 @@ class TrieNode:
     """
 
     def __init__(self):
-        self.children={}
+        self.children = {}
 
 class Trie:
     """Creates a Trie out of a list of words. The trie can be exported to a Regex pattern.
@@ -682,7 +682,7 @@ class Trie:
         for char in word:
             node.children.setdefault(char, TrieNode())
             node = node.children[char]
-        node.children[''] = True # Mark the end of the word
+        node.children[''] = True    # Mark the end of the word
 
     def dump(self):
         """Return the root node of Trie. """
@@ -702,7 +702,8 @@ class Trie:
             else:
                 return False
 
-        return '' in node.children # make sure to check the end-of-word marker present
+        # make sure to check the end-of-word marker present
+        return '' in node.children
 
     def _pattern(self, root):
         """Convert a Trie into a regular expression pattern"""
@@ -711,9 +712,9 @@ class Trie:
         if "" in node.children and len(node.children.keys()) == 1:
             return None
 
-        alt = [] # store alternative patterns
-        cc = [] # to store char to char classes
-        q = 0 # for node representing the end of word
+        alt = []    # store alternative patterns
+        cc = []     # store char to char classes
+        q = 0       # for node representing the end of word
         for char in sorted(node.children.keys()):
             if isinstance(node.children[char], TrieNode):
                 try:

--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -675,7 +675,7 @@ class Trie:
         node[''] = True # Mark the end of the word
 
     def _dump(self):
-        """Return the data of Trie. """
+        """Return the root node of Trie. """
         return self.root
 
     def _quote(self, char):
@@ -687,28 +687,27 @@ class Trie:
         Returns True if yes, else return False"""
         node = self.root
         for char in word:
-            if char in word:
+            if char in node:
                 node = node[char]
             else:
                 return False
 
         return '' in node # make sure to check the end-of-word marker present
 
-    def _pattern(self, node):
-        """Convert a nested dictionary into a regular expression pattern"""
-        # import pdb;pdb.set_trace()
-        data = node
+    def _pattern(self, root):
+        """Convert a nested dictionary represented by a trie into a regular expression pattern"""
+        node = root
 
-        if "" in data and len(data.keys()) == 1:
+        if "" in node and len(node.keys()) == 1:
             return None
 
         alt = [] # store alternative patterns
         cc = [] # to store char to char classes
-        q = 0
-        for char in sorted(data.keys()):
-            if isinstance(data[char], dict):
+        q = 0 # for node representing the end of word
+        for char in sorted(node.keys()):
+            if isinstance(node[char], dict):
                 try:
-                    recurse = self._pattern(data[char])
+                    recurse = self._pattern(node[char])
                     alt.append(self._quote(char) + recurse)
                 except Exception:
                     cc.append(self._quote(char))
@@ -735,8 +734,7 @@ class Trie:
         return result
 
     def export_to_regex(self):
-        """ Export the Trie to a regex pattern. """
-    # def pattern(self):
+        """Export the Trie to a regex pattern."""
         return self._pattern(self.root)
 
 


### PR DESCRIPTION
Fixes #[117504](https://github.com/pytorch/pytorch/issues/117504)

Re-engineering Hipify Trie:
(1) Re-engineering Trie.
(2) More documentation or comments for easier understanding
(3) Created a set of unit test (class `TestHipifyTrie`) to test the Trie data structure and APIs.

Test:
```
root@xxx:/development/pytorch# pytest test/test_utils.py -k TestHipifyTrie
==================================================================================================== test session starts ====================================================================================================
platform linux -- Python 3.9.18, pytest-7.3.2, pluggy-1.3.0
rootdir: /dockerx/development/pytorch
configfile: pytest.ini
plugins: flakefinder-1.1.0, rerunfailures-13.0, xdist-3.3.1, xdoctest-1.1.0, cpp-2.3.0, shard-0.1.2, hypothesis-5.35.1
collected 11453 items / 11445 deselected / 8 selected                                                                                                                                                                       
Running 8 items in this shard

test/test_utils.py ........                                                                                                                                                                                           [100%]

============================================================================================ 8 passed, 11445 deselected in 3.84s ============================================================================================
root@xxx:/development/pytorch# 
```
Also performed diff on modified and generated contents by this tool with the original code and the new code of the hipify_python.py script. Verified no difference.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo