### PR TITLE
Add justknobs env helper for pytorch distributed

### DIFF
--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -86,6 +86,10 @@ def print_graph(graph, msg: str):
     pass
 
 
+def set_pytorch_distributed_envs_from_justknobs():
+    pass
+
+
 TEST_MASTER_ADDR = "127.0.0.1"
 TEST_MASTER_PORT = 29500
 # USE_GLOBAL_DEPS controls whether __init__.py tries to load

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -36,6 +36,7 @@ from torch._C._distributed_c10d import (
     get_debug_level,
     Work
 )
+from torch._utils_internal import set_pytorch_distributed_envs_from_justknobs
 from .constants import default_pg_timeout, default_pg_nccl_timeout
 from .c10d_logger import _exception_logger, _time_logger
 from .rendezvous import register_rendezvous_handler, rendezvous  # noqa: F401
@@ -1182,6 +1183,8 @@ def init_process_group(
         "cpu:gloo,cuda:custom_backend".
 
     """
+    set_pytorch_distributed_envs_from_justknobs()
+
     global _world
 
     global _backend


### PR DESCRIPTION
Summary:
Adds a JK killswitch check and configures the env for enabling pytorch
nccl flight recorder.  Note- this only enables recording events in memory, not
dumping them.

Test Plan: CI test

Reviewed By: zdevito

Differential Revision: D52920092




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @yf225