### PR TITLE
[NCCL][c10d] Log failing pointer if deregistration fails

### DIFF
--- a/torch/csrc/distributed/c10d/NCCLUtils.hpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.hpp
@@ -432,6 +432,8 @@ class NCCLComm {
         c10::str(
             "Failed to deregister segment handle ",
             handle,
+            ", with ptr ",
+            ptr,
             " on ncclComm_ ",
             ncclComm_));
     registeredSegmentHandles_.erase(ptr);


### PR DESCRIPTION
For debugging convenience

CC @minsii @Aidyn-A @syed-ahmed @ptrblck 

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225