### PR TITLE
[easy][AOT] Fix shortcut path for simple tuple/list spec

### DIFF
--- a/torch/_functorch/_aot_autograd/utils.py
+++ b/torch/_functorch/_aot_autograd/utils.py
@@ -126,7 +126,7 @@ class PytreeThunk:
         assert self.spec is None or self.spec == spec
         assert spec is not None
         self.spec: pytree.TreeSpec = spec
-        if type(self.spec) in {tuple, list} and all(
+        if self.spec.type in {tuple, list} and all(
             child.is_leaf() for child in spec.children_specs
         ):
             self.is_simple = True


### PR DESCRIPTION
`type(self.spec)` is always `TreeSpec` and the condition is always `False`. This PR changes it to `self.spec.type`, which is the type of tree that the spec represents.
