### PR TITLE
Added missing CircularPad*d references so the docs are actually built.

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -131,6 +131,9 @@ Padding Layers
     nn.ConstantPad1d
     nn.ConstantPad2d
     nn.ConstantPad3d
+    nn.CircularPad1d
+    nn.CircularPad2d
+    nn.CircularPad3d
 
 Non-linear Activations (weighted sum, nonlinearity)
 ---------------------------------------------------


### PR DESCRIPTION
Fixes #118429
