### PR TITLE
[BE][Easy]: Update ruff to 0.1.14

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -2658,7 +2658,7 @@ init_command = [
     'python3',
     'tools/linter/adapters/pip_init.py',
     '--dry-run={{DRYRUN}}',
-    'ruff==0.1.11',
+    'ruff==0.1.14',
 ]
 is_formatter = true
 


### PR DESCRIPTION
Updates ruff to 0.1.14 which has some more autofixes, bugfixes, and fixes some false positives. Full changelog found here: https://github.com/astral-sh/ruff/releases/tag/v0.1.14