### PR TITLE
[mypy] Remove colorama ignore_missing_imports

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -277,9 +277,6 @@ disallow_any_generics = True
 [mypy-torch._dynamo.*]
 disallow_any_generics = True
 
-[mypy-colorama.*]
-ignore_missing_imports = True
-
 [mypy-cutlass_library.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #118491
* #118481
* #118480
* #118479
* #118475
* #118469
* __->__ #118468
* #118467
* #118432
* #118418
* #118414

Signed-off-by: Edward Z. Yang <ezyang@meta.com>