### PR TITLE
Use dmypy instead of mypy in lintrunner

### DIFF
--- a/tools/linter/adapters/mypy_linter.py
+++ b/tools/linter/adapters/mypy_linter.py
@@ -122,9 +122,12 @@ def check_files(
     retries: int,
     code: str,
 ) -> List[LintMessage]:
+    # dmypy has a bug where it won't pick up changes if you pass it absolute
+    # file names, see https://github.com/python/mypy/issues/16768
+    filenames = [os.path.relpath(f) for f in filenames]
     try:
         proc = run_command(
-            [sys.executable, "-mmypy", f"--config={config}"] + filenames,
+            ["dmypy", "run", "--", f"--config={config}"] + filenames,
             extra_env={},
             retries=retries,
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #118491
* #118481
* #118480
* #118479
* __->__ #118475
* #118469
* #118468
* #118467
* #118432
* #118418
* #118414

Signed-off-by: Edward Z. Yang <ezyang@meta.com>