### PR TITLE
[Inductor] GEMM shape padding improvements

### DIFF
--- a/test/inductor/test_pad_mm.py
+++ b/test/inductor/test_pad_mm.py
@@ -1,0 +1,189 @@
+# Owner(s): ["module: inductor"]
+
+
+from unittest.mock import patch
+
+import torch
+
+from torch._inductor import config
+from torch._inductor.fx_passes.pad_mm import (
+    addmm_replace,
+    bmm_replace,
+    call_addmm,
+    call_bmm,
+    call_mm,
+    get_alignment_size,
+    mm_replace,
+    should_pad_common,
+)
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    TestCase,
+)
+from torch.testing._internal.inductor_utils import HAS_CUDA
+
+
+@config.patch({"shape_padding": True})
+@instantiate_parametrized_tests
+class PadMMTest(TestCase):
+    @staticmethod
+    def _check_tensor_alignment(tensor, expected_alignment):
+        contiguous_dim_count = 0
+        for stride in reversed(tensor.stride()):
+            assert (stride == 1) or (
+                stride % expected_alignment == 0
+            ), f"Expected all non-contiguous strides of tensor with shape {tensor.shape} and strides {tensor.stride()} to be aligned to a multiple of {expected_alignment}"  # noqa: B950
+            if stride == 1:
+                contiguous_dim_count += 1
+
+    @parametrize(
+        "m,n,k", [(1, 1, 1), (16, 32, 64), (17, 33, 65), (16, 15, 8), (15, 32, 16)]
+    )
+    @parametrize("shape_pad_use_transpose", (False, True))
+    def test_pad_nobatch(self, m=6, n=9, k=11, shape_pad_use_transpose: bool = True):
+        with config.patch(
+            {
+                "shape_pad_use_transpose": shape_pad_use_transpose,
+                "force_shape_pad": True,
+            }
+        ):
+            mat1 = torch.ones((m, k), device="cuda", dtype=torch.float16)
+            mat2 = torch.ones((k, n), device="cuda", dtype=torch.float16)
+            bias = torch.ones((m, n), device="cuda", dtype=torch.float16)
+            expected_alignment = get_alignment_size(mat1)
+            assert (
+                expected_alignment >= 2
+            ), "Expected alignment should be greater or equal to 2"
+            assert should_pad_common(
+                mat1, mat2
+            ), "This should pass the common padding criteria"
+            assert should_pad_common(
+                mat1, mat2, bias
+            ), "This should pass the common padding criteria"
+
+            orig_addmm = call_addmm
+            called_checked = False
+
+            def aten_addmm_checked(b, m1, m2, *args, **kwargs):
+                nonlocal called_checked
+                self._check_tensor_alignment(b, expected_alignment)
+                self._check_tensor_alignment(m1, expected_alignment)
+                self._check_tensor_alignment(m2, expected_alignment)
+                res = orig_addmm(b, m1, m2, *args, **kwargs)
+                self._check_tensor_alignment(res, expected_alignment)
+                called_checked = True
+                return res
+
+            with patch(
+                "torch._inductor.fx_passes.pad_mm.call_addmm", aten_addmm_checked
+            ):
+                addmm_result = addmm_replace(bias, mat1, mat2)
+
+            addmm_expected_result = torch.addmm(bias, mat1, mat2)
+            assert torch.allclose(
+                addmm_result, addmm_expected_result
+            ), "ADDMM results are not identical"
+
+            addmm_compiled_result = torch.compile(
+                lambda bias, mat1, mat2: torch.addmm(bias, mat1, mat2), dynamic=False
+            )(bias, mat1, mat2)
+            assert torch.allclose(
+                addmm_compiled_result, addmm_expected_result
+            ), "Compiled ADDMM results are not identical"
+            self._check_tensor_alignment(addmm_compiled_result, expected_alignment)
+
+            orig_mm = call_mm
+            called_checked = False
+
+            def aten_mm_checked(m1, m2, *args, **kwargs):
+                nonlocal called_checked
+                self._check_tensor_alignment(m1, expected_alignment)
+                self._check_tensor_alignment(m2, expected_alignment)
+                res = orig_mm(m1, m2, *args, **kwargs)
+                self._check_tensor_alignment(res, expected_alignment)
+                called_checked = True
+                return res
+
+            with patch("torch._inductor.fx_passes.pad_mm.call_mm", aten_mm_checked):
+                mm_result = mm_replace(mat1, mat2)
+            assert called_checked, "patched / checked aten.mm was not called at all"
+
+            mm_expected_result = torch.mm(mat1, mat2)
+            assert torch.allclose(
+                mm_result, mm_expected_result
+            ), "MM results are not identical"
+
+            mm_compiled_result = torch.compile(lambda m1, m2: m1 @ m2, dynamic=False)(
+                mat1, mat2
+            )
+            assert torch.allclose(
+                mm_compiled_result, mm_expected_result
+            ), "Compiled MM results are not identical"
+            self._check_tensor_alignment(mm_compiled_result, expected_alignment)
+
+    @parametrize(
+        "m,n,k,batch_size",
+        [
+            (1, 1, 1, 8),
+            (16, 32, 64, 8),
+            (17, 33, 65, 7),
+            (16, 33, 64, 4),
+            (15, 32, 62, 3),
+        ],
+    )
+    @parametrize("shape_pad_use_transpose", (False, True))
+    def test_pad_batch(
+        self, m=6, n=9, k=11, batch_size=3, shape_pad_use_transpose: bool = True
+    ):
+        with config.patch(
+            {
+                "shape_pad_use_transpose": shape_pad_use_transpose,
+                "force_shape_pad": True,
+            }
+        ):
+            mat1 = torch.ones((batch_size, m, k), device="cuda", dtype=torch.float16)
+            mat2 = torch.ones((batch_size, k, n), device="cuda", dtype=torch.float16)
+            expected_alignment = get_alignment_size(mat1)
+
+            assert expected_alignment == 8, "Alignment for float16 should be 8"
+            assert should_pad_common(
+                mat1, mat2
+            ), "This should pass the common padding criteria"
+
+            orig_bmm = call_bmm
+            called_checked = False
+
+            def aten_bmm_checked(m1, m2, *args, **kwargs):
+                nonlocal called_checked
+                self._check_tensor_alignment(m1, expected_alignment)
+                self._check_tensor_alignment(m2, expected_alignment)
+                res = orig_bmm(m1, m2, *args, **kwargs)
+                self._check_tensor_alignment(res, expected_alignment)
+                called_checked = True
+                return res
+
+            with patch("torch._inductor.fx_passes.pad_mm.call_bmm", aten_bmm_checked):
+                bmm_result = bmm_replace(mat1, mat2)
+
+            bmm_expected_result = torch.bmm(mat1, mat2)
+
+            assert torch.allclose(
+                bmm_result, bmm_expected_result
+            ), "BMM results are not identical"
+            self._check_tensor_alignment(bmm_result, expected_alignment)
+
+            bmm_compiled_result = torch.compile(
+                lambda mat1, mat2: torch.bmm(mat1, mat2), dynamic=False
+            )(mat1, mat2)
+            assert torch.allclose(
+                bmm_compiled_result, bmm_expected_result
+            ), "Compiled BMM results are not identical"
+            self._check_tensor_alignment(bmm_compiled_result, expected_alignment)
+
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    if HAS_CUDA:
+        run_tests()

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -79,7 +79,7 @@ device_codegens: Dict[str, DeviceCodegen] = {}
 #
 # Intel has developed a new backend on top of Triton to support Intel GPUs, leveraging these interfaces.
 # This backend can be used as a reference:
-# https://github.com/intel/intel-extension-for-pytorch/blob/5dcc9d57e5422cf295e1a1ee97896d6b6a554a85/intel_extension_for_pytorch/_inductor/__init__.py#L9
+# https://github.com/intel/intel-extension-for-pytorch/blob/5dcc9d57e5422cf295e1a1ee97896d6b6a554a85/intel_extension_for_pytorch/_inductor/__init__.py#L9  # noqa: B950
 def register_backend_for_device(
     device: str, device_scheduling: type, device_wrapper_codegen: type
 ):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -361,6 +361,19 @@ kernel_name_max_ops = 10
 # Pad input tensors of matmul/bmm/addmm to leverage Tensor Cores in NVIDIA GPUs
 shape_padding = os.environ.get("TORCHINDUCTOR_SHAPE_PADDING", "1") == "1"
 
+# When, during shape padding, dimension N would have to be padded, but
+# dimension M would not, then we can avoid a padding if we perform an
+# explicit transpose ( e.g. matmul(A,B) = matmul(B.T, A.T) ).T in order to
+# put the M dimension in the N position, therefore ensuring an aligned
+# GEMM result without padding. This can have dramatic
+# performance benefits if it is possible. Also, if this flag is enabled,
+# dimension M is not padded if N is aligned, since that's unneccessary
+# for an aligned result.
+shape_pad_use_transpose: bool = True
+
+# Whether to always use shape padding if it is enabled and possible
+force_shape_pad: bool = False
+
 # Fx-based linear/matmul/bmm + permute/transpose vertical fusion
 permute_fusion = os.environ.get("TORCHINDUCTOR_PERMUTE_FUSION", "0") == "1"
 

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -5,9 +5,11 @@ import torch
 from torch import Tensor
 from torch._inductor import utils
 from torch.utils._mode_utils import no_dispatch
-from torch.utils._triton import has_triton
+from ...utils._triton import has_triton
+from ..ir import FixedLayout
 
 from ..pattern_matcher import fwd_only, joint_fwd_bwd, Match, register_replacement
+from ..utils import use_cutlass_template
 
 aten = torch.ops.aten
 
@@ -75,33 +77,26 @@ def addmm_pattern(
     return aten.addmm(input, mat1, mat2, beta=beta, alpha=alpha)
 
 
+# addmm wrapper for testing purposes
+def call_addmm(*args, **kwargs):
+    return aten.addmm(*args, **kwargs)
+
+
+# bmm wrapper for testing purposes
+def call_bmm(*args, **kwargs):
+    return aten.bmm(*args, **kwargs)
+
+
+# mm wrapper for testing purposes
+def call_mm(*args, **kwargs):
+    return aten.mm(*args, **kwargs)
+
+
 def should_pad_addmm(match: Match) -> bool:
     mat1, mat2, input = fetch_fake_tensors(match, ("mat1", "mat2", "input"))
     return should_pad_common(mat1, mat2, input) and should_pad_bench(
         mat1, mat2, torch.ops.aten.addmm, input=input
     )
-
-
-def addmm_replace(
-    input: Optional[Tensor], mat1: Tensor, mat2: Tensor, beta=1.0, alpha=1.0
-) -> Tensor:
-    m_padded_length = get_padded_length(mat1.shape[0], get_alignment_size(mat1))
-    k_padded_length = get_padded_length(mat1.shape[1], get_alignment_size(mat1))
-    n_padded_length = get_padded_length(mat2.shape[1], get_alignment_size(mat2))
-
-    if m_padded_length != 0 or k_padded_length != 0 or n_padded_length != 0:
-        return pad_addmm(
-            input,
-            mat1,
-            mat2,
-            m_padded_length,
-            k_padded_length,
-            n_padded_length,
-            beta,
-            alpha,
-        )
-
-    return aten.addmm(input, mat1, mat2, beta=beta, alpha=alpha)
 
 
 def pad_addmm(
@@ -113,36 +108,101 @@ def pad_addmm(
     n_padded_length: int,
     beta=1.0,
     alpha=1.0,
+    explicit_transpose=False,
 ):
-    # addmm decomp with padding will go through pad_addmm multiple times if multiple dimensions are needed to be padded
-    if k_padded_length != 0:
-        mat1 = pad_dim(mat1, k_padded_length, 1)
-        mat2 = pad_dim(mat2, k_padded_length, 0)
-    elif n_padded_length != 0:
-        mat2 = pad_dim(mat2, n_padded_length, 1)
-    elif m_padded_length != 0:
-        mat1 = pad_dim(mat1, m_padded_length, 0)
-
-    # the add broadcasts, so we only pad if the dimension != 1
-    if input is not None and k_padded_length == 0:
-        if n_padded_length != 0:
-            if input.dim() == 2 and input.shape[1] != 1:
-                input = pad_dim(input, n_padded_length, 1)
-            elif input.dim() == 1 and input.shape[0] != 1:
-                input = pad_dim(input, n_padded_length, 0)
-        elif m_padded_length != 0 and input.dim() == 2 and input.shape[0] != 1:
-            input = pad_dim(input, m_padded_length, 0)
-
-    if k_padded_length != 0:
-        return addmm_replace(input, mat1, mat2, beta=beta, alpha=alpha)
-    elif n_padded_length != 0:
-        return addmm_replace(input, mat1, mat2, beta=beta, alpha=alpha)[
-            :, :-n_padded_length
-        ]
+    # for paddings, dim order is reversed for some reasons
+    # and for every dim, we need to specify left and right padding
+    if k_padded_length != 0 or m_padded_length != 0:
+        mat1_padded = aten.constant_pad_nd(
+            mat1, [0, k_padded_length, 0, m_padded_length]
+        )
     else:
-        return addmm_replace(input, mat1, mat2, beta=beta, alpha=alpha)[
-            :-m_padded_length, :
-        ]
+        mat1_padded = mat1
+    if k_padded_length != 0 or n_padded_length != 0:
+        mat2_padded = aten.constant_pad_nd(
+            mat2, [0, n_padded_length, 0, k_padded_length]
+        )
+    else:
+        mat2_padded = mat2
+    if input is not None:
+        if len(input.shape) < 2:
+            # make sure we have at least two dimensions
+            # the first one to be broadcasted over is sometimes implicit
+            input = input.unsqueeze(0)
+        if n_padded_length != 0 or m_padded_length != 0:
+            bias_n_padded_length = n_padded_length
+            bias_m_padded_length = m_padded_length
+            # What if we're broadcasting?
+            if input.shape[0] == 1 and mat1.shape[0] > 1:
+                bias_m_padded_length = 0
+            if input.shape[1] == 1 and mat2.shape[1] > 1:
+                bias_n_padded_length = 0
+            if bias_m_padded_length > 0 or bias_n_padded_length > 0:
+                input_padded = aten.constant_pad_nd(
+                    input, [0, bias_n_padded_length, 0, bias_m_padded_length]
+                )
+            else:
+                input_padded = input
+        else:
+            input_padded = input
+    else:
+        input_padded = None
+    if explicit_transpose:
+        # If M dimension is aligned but N is not, this is an alternative to a padding N
+        # which has the advantage of enabling downstream epilogue fusions
+        # padding on K dim, transpose and contiguous should be fuseable into a single op
+
+        res = aten.addmm(
+            input_padded.transpose(-1, -2),
+            mat2_padded.transpose(-1, -2).contiguous(),
+            mat1_padded.transpose(-1, -2),
+        ).transpose(-1, -2)
+    else:
+        try:
+            res = call_addmm(
+                input_padded, mat1_padded, mat2_padded, beta=beta, alpha=alpha
+            )
+        except RuntimeError as e:
+            if input_padded is not None:
+                note1 = f"\npad_addmm was called with argument shapes: input.shape={input.shape}, mat1.shape={mat1.shape}, mat2.shape={mat2.shape}, m_padded_length={m_padded_length}, k_padded_length={k_padded_length}, n_padded_length={n_padded_length}, explicit_transpose={explicit_transpose}"  # type: ignore[union-attr] # noqa: B950
+            else:
+                note1 = f"pad_addmm was called with argument shapes: input_padded=None, mat1.shape={mat1.shape}, mat2.shape={mat2.shape}, m_padded_length={m_padded_length}, k_padded_length={k_padded_length}, n_padded_length={n_padded_length}, explicit_transpose={explicit_transpose}"  # noqa: B950
+
+            note2 = f"\naten.addmm was called with shapes: input_padded.shape={input_padded.shape}, mat1_padded.shape={mat1_padded.shape}, mat2_padded.shape={mat2_padded.shape}, beta={beta}, alpha={alpha}"  # noqa: B950
+            raise RuntimeError(str(e) + note1 + note2) from e
+
+    if m_padded_length != 0:
+        res = res[:-m_padded_length, :]
+    if n_padded_length != 0:
+        res = res[:, :-n_padded_length]
+    return res
+
+
+def addmm_replace(
+    input: Optional[Tensor], mat1: Tensor, mat2: Tensor, beta=1.0, alpha=1.0
+) -> Tensor:
+    k_padded_length = get_padded_length(mat1.shape[1], get_alignment_size(mat1))
+    n_padded_length = get_padded_length(mat2.shape[1], get_alignment_size(mat2))
+    m_padded_length = get_padded_length(mat1.shape[0], get_alignment_size(mat1))
+    explicit_transpose = 0
+    if torch._inductor.config.shape_pad_use_transpose:
+        if m_padded_length == 0 and n_padded_length != 0:
+            explicit_transpose = True
+            n_padded_length = 0
+            m_padded_length = 0
+        elif m_padded_length != 0 and n_padded_length == 0:
+            m_padded_length = 0
+    return pad_addmm(
+        input,
+        mat1,
+        mat2,
+        m_padded_length,
+        k_padded_length,
+        n_padded_length,
+        beta,
+        alpha,
+        explicit_transpose=explicit_transpose,
+    )
 
 
 def is_mm_compute_bound(M: int, K: int, N: int, dtype: torch.dtype) -> bool:
@@ -197,6 +257,7 @@ def should_pad_bench_key(
         op,
         input if input is None else tensor_key(input),
         tf32_key,
+        torch._inductor.config.force_shape_pad,
     )
 
     return str(key)
@@ -205,35 +266,59 @@ def should_pad_bench_key(
 def should_pad_bench(
     mat1: Tensor, mat2: Tensor, op, input: Optional[Tensor] = None
 ) -> bool:
-    if not has_triton():
-        return False
-
     do_bench = functools.partial(
         utils.do_bench,
         warmup=5,
     )
-
+    m_padded_length = 0
+    n_padded_length = 0
+    batchsize = 1
+    explicit_transpose = False
     with no_dispatch():
         if op is torch.ops.aten.mm or op is torch.ops.aten.addmm:
             m = mat1.shape[0]
             k = mat1.shape[1]
             n = mat2.shape[1]
-
-            m_padded_length = get_padded_length(m, get_alignment_size(mat1))
             k_padded_length = get_padded_length(k, get_alignment_size(mat1))
             n_padded_length = get_padded_length(n, get_alignment_size(mat2))
+            m_padded_length = get_padded_length(m, get_alignment_size(mat1))
         elif op is torch.ops.aten.bmm:
+            batchsize = mat1.shape[0]
             m = mat1.shape[1]
             k = mat1.shape[2]
             n = mat2.shape[2]
-
-            m_padded_length = get_padded_length(m, get_alignment_size(mat1))
             k_padded_length = get_padded_length(k, get_alignment_size(mat1))
+            m_padded_length = get_padded_length(m, get_alignment_size(mat1))
             n_padded_length = get_padded_length(n, get_alignment_size(mat2))
         else:
             return False
 
-        if m_padded_length == k_padded_length == n_padded_length == 0:
+        if torch._inductor.config.shape_pad_use_transpose:
+            if m_padded_length == 0 and n_padded_length != 0:
+                n_padded_length = 0
+                m_padded_length = 0
+                explicit_transpose = True
+            elif n_padded_length == 0 and m_padded_length != 0:
+                m_padded_length = 0
+        if (
+            m_padded_length == k_padded_length == n_padded_length == 0
+        ) and not explicit_transpose:
+            return False
+
+        if torch._inductor.config.force_shape_pad:
+            return True
+
+        fake_layout = FixedLayout(
+            device=mat1.device,
+            dtype=mat1.dtype,
+            size=[batchsize, m, n],
+            stride=[n * m, n, 1],
+        )
+        if use_cutlass_template(fake_layout):
+            # We cannot use I/O efficient Cutlass templates if the alignment doesn't meet TMA requirements
+            return True
+
+        if not has_triton():
             return False
 
         if not is_mm_compute_bound(m, k, n, mat1.dtype):
@@ -275,6 +360,7 @@ def should_pad_bench(
                     m_padded_length,
                     k_padded_length,
                     n_padded_length,
+                    explicit_transpose=explicit_transpose,
                 ),
             )
         elif op is torch.ops.aten.mm:
@@ -285,6 +371,7 @@ def should_pad_bench(
                     m_padded_length,
                     k_padded_length,
                     n_padded_length,
+                    explicit_transpose=explicit_transpose,
                 ),
             )
         else:
@@ -295,6 +382,7 @@ def should_pad_bench(
                     m_padded_length,
                     k_padded_length,
                     n_padded_length,
+                    explicit_transpose=explicit_transpose,
                 ),
             )
 
@@ -318,32 +406,64 @@ def should_pad_mm(match: Match) -> bool:
     )
 
 
-def mm_replace(mat1: Tensor, mat2: Tensor) -> Tensor:
-    m_padded_length = get_padded_length(mat1.shape[0], get_alignment_size(mat1))
-    k_padded_length = get_padded_length(mat1.shape[1], get_alignment_size(mat1))
-    n_padded_length = get_padded_length(mat2.shape[1], get_alignment_size(mat2))
-
-    return pad_mm(mat1, mat2, m_padded_length, k_padded_length, n_padded_length)
-
-
 def pad_mm(
     mat1: Tensor,
     mat2: Tensor,
     m_padded_length: int,
     k_padded_length: int,
     n_padded_length: int,
+    explicit_transpose: bool = False,
 ) -> Tensor:
-    # mm_replace will go through pad_mm multiple times if multiple dimensions are needed to be padded
-    if k_padded_length != 0:
-        mat1 = pad_dim(mat1, k_padded_length, 1)
-        mat2 = pad_dim(mat2, k_padded_length, 0)
-        return torch.ops.aten.mm(mat1, mat2)
-    elif n_padded_length != 0:
-        mat2 = pad_dim(mat2, n_padded_length, 1)
-        return torch.ops.aten.mm(mat1, mat2)[:, :-n_padded_length]
+    if k_padded_length != 0 or m_padded_length != 0:
+        # dim order is reversed for constant_pad_nd, for every dim we specify right and left padding
+        mat1_padded = aten.constant_pad_nd(
+            mat1, [0, k_padded_length, 0, m_padded_length]
+        )
     else:
-        mat1 = pad_dim(mat1, m_padded_length, 0)
-        return torch.ops.aten.mm(mat1, mat2)[:-m_padded_length, :]
+        mat1_padded = mat1
+    if k_padded_length != 0 or n_padded_length != 0:
+        # dim order is reversed for constant_pad_nd, for every dim we specify right and left padding
+        mat2_padded = aten.constant_pad_nd(
+            mat2, [0, n_padded_length, 0, k_padded_length]
+        )
+    else:
+        mat2_padded = mat2
+    if explicit_transpose:
+        # If M dimension is aligned but N is not, this is an alternative to a padding N
+        # which has the advantage of enabling downstream epilogue fusions
+        # padding on K dim, transpose and contiguous should be fuseable into a single op
+        res = call_mm(
+            mat2_padded.transpose(-1, -2).contiguous(), mat1_padded.transpose(-1, -2)
+        ).transpose(-1, -2)
+    else:
+        res = call_mm(mat1_padded, mat2_padded)
+    if m_padded_length != 0:
+        res = res[:-m_padded_length, :]
+    if n_padded_length != 0:
+        res = res[:, :-n_padded_length]
+    return res
+
+
+def mm_replace(mat1: Tensor, mat2: Tensor) -> Tensor:
+    k_padded_length = get_padded_length(mat1.shape[1], get_alignment_size(mat1))
+    explicit_transpose = False
+    m_padded_length = get_padded_length(mat1.shape[0], get_alignment_size(mat1))
+    n_padded_length = get_padded_length(mat2.shape[1], get_alignment_size(mat2))
+    if torch._inductor.config.shape_pad_use_transpose:
+        if m_padded_length == 0 and n_padded_length != 0:
+            explicit_transpose = True
+            n_padded_length = 0
+            m_padded_length = 0
+        elif m_padded_length != 0 and n_padded_length == 0:
+            m_padded_length = 0
+    return pad_mm(
+        mat1,
+        mat2,
+        m_padded_length,
+        k_padded_length,
+        n_padded_length,
+        explicit_transpose=explicit_transpose,
+    )
 
 
 def bmm_pattern(mat1: Tensor, mat2: Tensor) -> Tensor:
@@ -357,36 +477,62 @@ def should_pad_bmm(match: Match) -> bool:
     )
 
 
-def bmm_replace(mat1: Tensor, mat2: Tensor) -> Tensor:
-    m_padded_length = get_padded_length(mat1.shape[1], get_alignment_size(mat1))
-    k_padded_length = get_padded_length(mat1.shape[2], get_alignment_size(mat1))
-    n_padded_length = get_padded_length(mat2.shape[2], get_alignment_size(mat2))
-
-    if m_padded_length != 0 or k_padded_length != 0 or n_padded_length != 0:
-        return pad_bmm(mat1, mat2, m_padded_length, k_padded_length, n_padded_length)
-
-    return aten.bmm(mat1, mat2)
-
-
 def pad_bmm(
     mat1: Tensor,
     mat2: Tensor,
     m_padded_length: int,
     k_padded_length: int,
     n_padded_length: int,
+    explicit_transpose: bool = False,
 ) -> Tensor:
-    # bmm_replace will go through pad_bmm multiple times if multiple dimensions are needed to be padded
-    if k_padded_length != 0:
-        mat1 = pad_dim(mat1, k_padded_length, 2)
-        mat2 = pad_dim(mat2, k_padded_length, 1)
-
-        return aten.bmm(mat1, mat2)
-    elif n_padded_length != 0:
-        mat2 = pad_dim(mat2, n_padded_length, 2)
-        return aten.bmm(mat1, mat2)[:, :, :-n_padded_length].contiguous()
+    if k_padded_length != 0 or m_padded_length != 0:
+        mat1_padded = aten.constant_pad_nd(
+            mat1, [0, k_padded_length, 0, m_padded_length, 0, 0]
+        )
     else:
-        mat1 = pad_dim(mat1, m_padded_length, 1)
-        return aten.bmm(mat1, mat2)[:, :-m_padded_length, :].contiguous()
+        mat1_padded = mat1
+    if k_padded_length != 0 or n_padded_length != 0:
+        mat2_padded = aten.constant_pad_nd(
+            mat2, [0, n_padded_length, 0, k_padded_length, 0, 0]
+        )
+    else:
+        mat2_padded = mat2
+    if explicit_transpose:
+        # If M dimension is aligned but N is not, this is an alternative to a padding N
+        # which has the advantage of enabling downstream epilogue fusions
+        # padding on K dim, transpose and contiguous should be fuseable into a single op
+        res = call_bmm(
+            mat2_padded.transpose(-1, -2).contiguous(), mat1_padded.transpose(-1, -2)
+        ).transpose(-1, -2)
+    else:
+        res = call_bmm(mat1_padded, mat2_padded)
+    if m_padded_length != 0:
+        res = res[:, :-m_padded_length, :]
+    if n_padded_length != 0:
+        res = res[:, :, :-n_padded_length]
+    return res
+
+
+def bmm_replace(mat1: Tensor, mat2: Tensor) -> Tensor:
+    k_padded_length = get_padded_length(mat1.shape[2], get_alignment_size(mat1))
+    n_padded_length = get_padded_length(mat2.shape[2], get_alignment_size(mat2))
+    m_padded_length = get_padded_length(mat1.shape[1], get_alignment_size(mat1))
+    explicit_transpose = False
+    if torch._inductor.config.shape_pad_use_transpose:
+        if m_padded_length == 0 and n_padded_length != 0:
+            explicit_transpose = True
+            n_padded_length = 0
+            m_padded_length = 0
+        elif m_padded_length != 0 and n_padded_length == 0:
+            m_padded_length = 0
+    return pad_bmm(
+        mat1,
+        mat2,
+        m_padded_length,
+        k_padded_length,
+        n_padded_length,
+        explicit_transpose=explicit_transpose,
+    )
 
 
 @functools.lru_cache(None)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4566,7 +4566,7 @@ class FallbackKernel(ExternKernelAlloc):
 
         self.cpp_kernel_name = kernel._schema.name
         self.cpp_kernel_overload_name = kernel._schema.overload_name
-        self.cpp_kernel_key = f"{self.cpp_kernel_name.replace('::', '_')}_{self.cpp_kernel_overload_name}"  # type: ignore[union-attr]
+        self.cpp_kernel_key = f"{self.cpp_kernel_name.replace('::', '_')}_{self.cpp_kernel_overload_name}"  # type: ignore[union-attr]  # noqa: B950
 
         self.cpp_op_schema = get_cpp_op_schema(kernel)
         self.init_args_default_value(kernel._schema)
@@ -7337,7 +7337,7 @@ class _CollectiveKernel(FallbackKernel):
 
         self.cpp_kernel_name = kernel._schema.name
         self.cpp_kernel_overload_name = kernel._schema.overload_name
-        self.cpp_kernel_key = f"{self.cpp_kernel_name.replace('::', '_')}_{self.cpp_kernel_overload_name}"  # type: ignore[union-attr]
+        self.cpp_kernel_key = f"{self.cpp_kernel_name.replace('::', '_')}_{self.cpp_kernel_overload_name}"  # type: ignore[union-attr]  # noqa: B950
 
         self.cpp_op_schema = get_cpp_op_schema(kernel)
         self.ordered_kwargs_for_cpp_kernel = [

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -868,7 +868,7 @@ def _use_template_for_cuda(layout, allowed_layout_dtypes: List[torch.dtype]) -> 
 
 
 def _use_autotune_backend(backend: str) -> bool:
-    return backend.upper() in [
+    return backend.upper() in [  # noqa: C412
         x.strip() for x in config.max_autotune_gemm_backends.upper().split(",")
     ]
 


### PR DESCRIPTION
Improvements to shape padding logic in torch/_inductor/pad_mm.py

These changes could lead up to 14% perf improvement for certain Meta internal models in experiments.

Most notably:
  * 1.) Use aten.const_pad_nd operation to pad Tensors in a single op instead of using multiple steps involving intermediate buffers. This appears to be more performant than the previous logic, confirmed by Profiling & Benchmarking results ( Meta internal )
 * 2.) Make many paddings unneccessary using explicitly transposed GEMM when either M or N dimension is properly aligned but the other is not, configurable via config.shape_pad_use_transpose (default: True).  
  * 3.) Enable shape padding for the Inductor CUDA  /  Cutlass backend for all GEMM ops where Cutlass would be enabled, without benchmarking in that case.
  * Add config flag to always pad shapes (without benchmarking first), configurable via config.force_shape_pad (default: False )
  * Added several new unit tests to ensure tensors are padded such that they meet all alignment requirements after padding.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang