### PR TITLE
[DeviceMesh] Removed print of `self._dim_group_infos`

### DIFF
--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -387,7 +387,6 @@ else:
                 a DeviceMesh with more than 1 dimension; otherwise, returns a single
                 :class:`ProcessGroup` object.
             """
-            print(f"{self._dim_group_infos=}")
             if not hasattr(self, "_dim_group_infos"):
                 raise RuntimeError("DeviceMesh process groups not initialized!")
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #118298
* #118223
* #118198
* #118188
* #118136
* #118118
* #118017
* #118004
* #117975
* #117973
* #117955
* #117950
* #117881
* #117877
* #117867
* #117814
* #118525
* __->__ #118524



cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225