### PR TITLE
[FSDP2][Reland] Introduced initial `fully_shard` frontend

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_state.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_state.py
@@ -1,0 +1,91 @@
+# Owner(s): ["oncall: distributed"]
+
+import copy
+import unittest
+
+import torch
+import torch.nn as nn
+from torch.distributed._composable.fsdp import FSDP, fully_shard
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_fsdp import FSDPTestMultiThread, MLP
+from torch.testing._internal.common_utils import run_tests
+
+
+class TestFullyShardState(FSDPTestMultiThread):
+    @property
+    def world_size(self) -> int:
+        return 1
+
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_fully_shard_state(self):
+        """
+        Tests the ability to get the state object from a fully sharded module.
+        """
+        num_mlps = 3
+        model = nn.Sequential(*[MLP(8, torch.device("cpu")) for _ in range(num_mlps)])
+        for mlp in model:
+            fully_shard(mlp)
+        fully_shard(model)
+        root_state = fully_shard.state(model)
+        self.assertTrue(root_state is not None)
+        all_states = [root_state] + [fully_shard.state(mlp) for mlp in model]
+        # Check that each `fully_shard` call constructs a distinct state object
+        self.assertEqual(len(set(all_states)), num_mlps + 1)
+
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_fully_shard_reapply(self):
+        model = MLP(8, torch.device("cpu"))
+        fully_shard(model)
+        with self.assertRaisesRegex(
+            AssertionError,
+            "Each distinct composable distributed API can only be applied to a module once.",
+        ):
+            fully_shard(model)
+
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_fully_shard_cls(self):
+        # Check that we only swap class for the module passed to `fully_shard`
+        model = MLP(8, torch.device("cpu"))
+        fully_shard(model)
+        self.assertTrue(isinstance(model, MLP))
+        self.assertTrue(isinstance(model, FSDP))
+        self.assertEqual(model.__class__.__name__, "FSDPMLP")
+        for module in model.modules():
+            if module is model:
+                continue
+            self.assertFalse(isinstance(module, FSDP))
+
+        # Check that slicing into a `Sequential` does not preserve FSDP
+        model = nn.Sequential(*[MLP(8, torch.device("cpu")) for _ in range(3)])
+        fully_shard(model)
+        self.assertTrue(isinstance(model, nn.Sequential))
+        self.assertTrue(isinstance(model, FSDP))
+        self.assertEqual(model.__class__.__name__, "FSDPSequential")
+        sliced_model = model[:2]
+        self.assertTrue(isinstance(sliced_model, nn.Sequential))
+        self.assertFalse(isinstance(sliced_model, FSDP))
+
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_fully_shard_unsupported_module_cls(self):
+        regex = (
+            r"fully\_shard does not support containers that do not implement forward"
+        )
+        model = nn.ModuleList([MLP(8, torch.device("cpu")) for _ in range(3)])
+        with self.assertRaisesRegex(ValueError, regex):
+            fully_shard(model)
+        model = nn.ModuleDict(
+            {"1": MLP(8, torch.device("cpu")), "2": MLP(8, torch.device("cpu"))}
+        )
+        with self.assertRaisesRegex(ValueError, regex):
+            fully_shard(model)
+
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_fully_shard_deepcopy(self):
+        model = MLP(8, torch.device("cpu"))
+        fully_shard(model)
+        with self.assertRaisesRegex(AssertionError, "FSDP does not support deepcopy"):
+            copy.deepcopy(model)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/_composable/fsdp/__init__.py
+++ b/torch/distributed/_composable/fsdp/__init__.py
@@ -1,0 +1,1 @@
+from .fully_shard import FSDP, fully_shard

--- a/torch/distributed/_composable/fsdp/fully_shard.py
+++ b/torch/distributed/_composable/fsdp/fully_shard.py
@@ -1,0 +1,48 @@
+from typing import Any
+
+import typing_extensions
+
+import torch.nn as nn
+
+from torch.distributed._composable import contract
+from torch.distributed._composable_state import _insert_module_state
+
+
+# The decorator adds a state object to `module` that can be accessed via
+# `fully_shard.state(module)`. The state object and module are 1:1.
+@contract()
+def fully_shard(
+    module: nn.Module,
+):
+    if isinstance(module, (nn.ModuleList, nn.ModuleDict)):
+        raise ValueError(
+            f"fully_shard does not support containers that do not implement forward: {module}"
+        )
+    state = fully_shard.state(module)
+    _insert_module_state(module, state)
+    # Place FSDP leftmost for highest priority in the method resolution order
+    cls = module.__class__
+    dct = {"__deepcopy__": unimplemented_deepcopy}
+    new_cls = type(f"FSDP{cls.__name__}", (FSDP, cls), dct)
+    module.__class__ = new_cls
+    return module
+
+
+def unimplemented_deepcopy(*args: Any, **kwargs: Any) -> typing_extensions.Never:
+    raise AssertionError(
+        "FSDP does not support deepcopy. Please use state dict for serialization."
+    )
+
+
+class FSDP:
+    def __new__(cls, *args, **kwargs):
+        """
+        Override ``__new__`` to remove the FSDP class and directly construct
+        the original class for cases like indexing into a container module.
+        """
+        # Use index 2 since 0 is the dynamically constructed `FSDP<...>` class
+        # and index 1 is the `FSDP` class itself
+        orig_cls = cls.__mro__[2]
+        self = orig_cls.__new__(orig_cls, *args, **kwargs)
+        self.__init__(*args, **kwargs)
+        return self

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -16,6 +16,7 @@ from unittest import mock
 import torch
 import torch.distributed as dist
 import torch.nn as nn
+import torch.nn.functional as F
 from torch.distributed.fsdp import CPUOffload, FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp._common_utils import TrainingState
 from torch.distributed.fsdp._init_utils import NO_RESHARD_AFTER_FORWARD_STRATEGIES
@@ -817,6 +818,20 @@ class MixtureOfExperts(NestedWrappedModule):
                 fsdp_model = fsdp_model.cuda()
             return fsdp_model
         raise ValueError(f"Unsupported FSDP init mode: {fsdp_init_mode}")
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, device: torch.device, dim_multiplier: int = 4):
+        super().__init__()
+        self.in_proj = nn.Linear(dim, dim_multiplier * dim, device=device)
+        self.out_proj = nn.Linear(dim_multiplier * dim, dim, device=device)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        z = self.in_proj(x)
+        z = F.relu(z)
+        z = self.out_proj(z)
+        z = F.relu(z)
+        return z
 
 
 def run_subtests(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #118584
* #118298
* #118223
* #118198
* #118188
* #118136
* #118118
* #118017
* #118004
* #117975
* #117973
* #117955
* #117950
* #117881
* #117877
* #117867
* #117814
* __->__ #118525

This PR introduces the initial `fully_shard` frontend without any distributed logic that will be built into per-parameter-sharding FSDP.
- We design `fully_shard` to be a _module-level_ API (taking in an `nn.Module`), e.g. as opposed to a tensor-level one.
- We define a `FSDP` class and use a dynamic class swap, setting `module.__class__` to a newly created class that subclasses `FSDP` and `type(module)`, to allow FSDP to override and add methods on the module.
    - We name this class as `FSDP<type(module)>`, e.g. `FSDPLinear` for `Linear`.
    - We disable the `deepcopy` because the state object inserted on the module will not be trivially `deepcopy`-able.
- Calling `fully_shard(module)` inserts a state object on `module` but not any of its children. This state object will be used for any FSDP-specific state.
- We raise an error on `ModuleList` or `ModuleDict` since they do not implement `forward()`, and FSDP will rely on `forward()` to insert logic (https://github.com/pytorch/pytorch/issues/113794).
- In the future, we will deprecate the existing `fully_shard` that calls into the same backend logic as `FullyShardedDataParallel` as there is no adoption for that and we prefer to reuse that name.


**Reland details:** I removed `test/distributed/_composable/fsdp/_test_fully_shard_common.py` and moved its contents to the existing `torch/testing/_internal/common_fsdp.py`, which is already a target for internal tests.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225

Differential Revision: [D53187509](https://our.internmc.facebook.com/intern/diff/D53187509)