### PR TITLE
Remove semicolon after `return_from_mutable_noop_redispatch`

### DIFF
--- a/torchgen/gen_functionalization_type.py
+++ b/torchgen/gen_functionalization_type.py
@@ -664,7 +664,7 @@ def emit_inplace_functionalization_body(
          // case 2: arguments are not functional tensors, so we no-op and redispatch.
          at::AutoDispatchSkipFunctionalize guard;
          {maybe_create_output(f, 'tmp_output')}at::_ops::{f.func.name.unambiguous_name()}::call({', '.join(inplace_exprs)});
-         {return_from_mutable_noop_redispatch(f, 'tmp_output')};
+         {return_from_mutable_noop_redispatch(f, 'tmp_output')}
         }}
       }} else {{
         {return_type} tmp_output;


### PR DESCRIPTION
[`return_from_mutable_noop_redispatch`](https://github.com/pytorch/pytorch/blob/65f8276bc6ef96951b168cf790191a2f13792324/torchgen/gen_functionalization_type.py#L477) calls
[`return_str`](https://github.com/pytorch/pytorch/blob/65f8276bc6ef96951b168cf790191a2f13792324/torchgen/gen_functionalization_type.py#L159-L166). `return_str`'s output includes `;` so I think the semicolon after the callsite of `return_from_mutable_noop_redispatch` is not needed.