### PR TITLE
Revert D52920092: Multisect successfully blamed "D52920092: Add justknobs env helper for pytorch distributed " for otest failure

### DIFF
--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -86,10 +86,6 @@ def print_graph(graph, msg: str):
     pass
 
 
-def set_pytorch_distributed_envs_from_justknobs():
-    pass
-
-
 TEST_MASTER_ADDR = "127.0.0.1"
 TEST_MASTER_PORT = 29500
 # USE_GLOBAL_DEPS controls whether __init__.py tries to load

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -36,7 +36,6 @@ from torch._C._distributed_c10d import (
     get_debug_level,
     Work
 )
-from torch._utils_internal import set_pytorch_distributed_envs_from_justknobs
 from .constants import default_pg_timeout, default_pg_nccl_timeout
 from .c10d_logger import _exception_logger, _time_logger
 from .rendezvous import register_rendezvous_handler, rendezvous  # noqa: F401
@@ -1183,8 +1182,6 @@ def init_process_group(
         "cpu:gloo,cuda:custom_backend".
 
     """
-    set_pytorch_distributed_envs_from_justknobs()
-
     global _world
 
     global _backend


### PR DESCRIPTION
Summary:
This diff is reverting D52920092
D52920092: Add justknobs env helper for pytorch distributed  by wconstab has been identified to be causing the following test failure:

Tests affected:
- [content_understanding/framework/training/utils/tests:test_straggle_detector - content_understanding.framework.training.utils.tests.test_straggle_detector.StraggleDetectorTest: test_allreduce_ops_0](https://www.internalfb.com/intern/test/844425044166211/)

Here's the Multisect link:
https://www.internalfb.com/multisect/4167112
Here are the tasks that are relevant to this breakage:


We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Test Plan: NA

Reviewed By: wconstab

Differential Revision: D53181614




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @yf225