### PR TITLE
Enable fake tensor caching in fbcode by default (#118546)

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -350,8 +350,7 @@ _autograd_backward_strict_mode_banned_ops.extend(
 
 # Enables caching of dispatches to fake tensors.
 fake_tensor_cache_enabled = (
-    os.environ.get("TORCH_FAKE_TENSOR_DISPATCH_CACHE", "0" if is_fbcode() else "1")
-    == "1"
+    os.environ.get("TORCH_FAKE_TENSOR_DISPATCH_CACHE", "1") == "1"
 )
 
 # Enables cross checking between the fake tensor cache and dispatch.


### PR DESCRIPTION
Summary:


Enabled by default in OSS; this switches the default to "on" in fbcode too.

Test Plan:
Ran torchbench benchmarks in fbcode

cc voznesenskym penguinwu EikanWang jgong5 Guobing-Chen XiaobingSuper zhuhaozhe blzheng wenzhe-nrv jiayisunx chenyang78 aakhundov kadeng

imported-using-ghimport

Differential Revision: D53186906

Pulled By: masnesral




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng