### PR TITLE
[inductor] Remove ROCm xfail on test_cum{sum,prod}_zero_dim

### DIFF
--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -293,9 +293,7 @@ test_failures = {
 if TEST_WITH_ROCM:
     test_failures.update(
         {
-            "test_cumprod_zero_dim_dynamic_shapes": TestFailure(("cpu", "cuda")),
             "test_cumsum_dynamic_shapes": TestFailure(("cpu", "cuda")),
-            "test_cumsum_zero_dim_dynamic_shapes": TestFailure(("cpu", "cuda")),
         }
     )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118558

Fixes #118540, fixes #118541

Since the zero-dim case reduces to a pointwise operation, we don't fallback on
ROCm.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler