### PR TITLE
[easy] Fix small typo in register_state_dict_pre_hook doc

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1771,7 +1771,7 @@ class Module:
         return handle
 
     def register_state_dict_pre_hook(self, hook):
-        r"""Register a pre-hook for the :meth:`~torch.nn.Module.load_state_dict` method.
+        r"""Register a pre-hook for the :meth:`~torch.nn.Module.state_dict` method.
 
         These hooks will be called with arguments: ``self``, ``prefix``,
         and ``keep_vars`` before calling ``state_dict`` on ``self``. The registered


### PR DESCRIPTION
Fixed https://github.com/pytorch/pytorch/pull/112674#issuecomment-1912849827

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118571

