### PR TITLE
Workaround for super() calls in test_torchinductor_dynamic_shapes

### DIFF
--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -105,6 +105,33 @@ if HAS_GPU and not TEST_WITH_ASAN:
 class TestInductorDynamic(TestCase):
     compile_fn = partial(torch.compile, dynamic=True)
 
+    def setUp(self):
+        # HAS_CUDA also checks compute capability to skip tests
+        # on older devices
+        if not HAS_GPU:
+            self.skipTest("Triton not available")
+        torch._dynamo.reset()
+        super(TestCase, self).setUp()
+        # this should be in setUpClass, but device-generic tests
+        # don't work with setUpClass well (non-deterministically the wrong setUpClass is resolved),
+        # so put it in test setUp, it's cheap
+        self._stack = contextlib.ExitStack()
+        self._stack.enter_context(
+            torch._inductor.config.patch(
+                {
+                    "debug": False,
+                    "cpp.min_chunk_size": 1,
+                    "triton.autotune_pointwise": False,  # too slow
+                    "implicit_fallbacks": False,
+                }
+            )
+        )
+
+    def tearDown(self):
+        self._stack.close()
+        super(TestCase, self).tearDown()
+        torch._dynamo.reset()
+
     def test_arange_dynamic(self, device):
         def fn(a):
             batch_size = a.numel()

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -102,16 +102,17 @@ if HAS_GPU and not TEST_WITH_ASAN:
     )
 
 
-class TestInductorDynamic(TestCase):
-    compile_fn = partial(torch.compile, dynamic=True)
-
+class TestInductorDynamicBase(TestCase):
+    # This is a base class for TestInductorDynamic because calls to super() in
+    # dynamically created classes do not work properly.  Instead, this base
+    # class is used to hold calls to super().
     def setUp(self):
         # HAS_CUDA also checks compute capability to skip tests
         # on older devices
         if not HAS_GPU:
             self.skipTest("Triton not available")
         torch._dynamo.reset()
-        super(TestCase, self).setUp()
+        super().setUp()
         # this should be in setUpClass, but device-generic tests
         # don't work with setUpClass well (non-deterministically the wrong setUpClass is resolved),
         # so put it in test setUp, it's cheap
@@ -129,8 +130,11 @@ class TestInductorDynamic(TestCase):
 
     def tearDown(self):
         self._stack.close()
-        super(TestCase, self).tearDown()
+        super().tearDown()
         torch._dynamo.reset()
+
+class TestInductorDynamic(TestInductorDynamicBase):
+    compile_fn = partial(torch.compile, dynamic=True)
 
     def test_arange_dynamic(self, device):
         def fn(a):

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -24,6 +24,7 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
     TestCaseBase as TestCase,
+    TEST_CUDA_MEM_LEAK_CHECK,
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU
 
@@ -311,6 +312,7 @@ class TestInductorDynamic(TestCase):
 
         f(torch.tensor([3.0], device=device))
 
+    @unittest.skipIf(TEST_CUDA_MEM_LEAK_CHECK, "failing memory leak check")
     @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_unbacked_index_select(self, device):
         # Tests if unbacked symbols captured by inner_fn are properly tracked

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -21,10 +21,10 @@ from torch.testing._internal.common_utils import (
     IS_CI,
     IS_WINDOWS,
     parametrize,
+    TEST_CUDA_MEM_LEAK_CHECK,
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
     TestCaseBase as TestCase,
-    TEST_CUDA_MEM_LEAK_CHECK,
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -3910,6 +3910,14 @@ This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0"""
         return stderr.decode('ascii')
 
 
+class TestCaseBase(TestCase):
+    # Calls to super() in dynamically created classes are a bit odd.
+    # See https://github.com/pytorch/pytorch/pull/118586 for more info
+    # Subclassing this class and then calling super(TestCaseBase) will run
+    # TestCase's setUp, tearDown etc functions
+    pass
+
+
 def download_file(url, binary=True):
     from urllib.parse import urlsplit
     from urllib import request, error


### PR DESCRIPTION
Info about super in dynamic classes:
https://stackoverflow.com/questions/71879642/how-to-pass-function-with-super-when-creating-class-dynamically
https://stackoverflow.com/questions/43782944/super-does-not-work-together-with-type-supertype-obj-obj-must-be-an-i

Calling super(TestCase) actually calls TestCase's parent's functions, bypassing TestCase itself's functions

Mainly doing this because it's making disable bot spam

Test: checked locally and check that https://github.com/pytorch/pytorch/issues/117954 actually got skipped

Logs for `inductor/test_torchinductor_dynamic_shapes.py::TestInductorDynamicCUDA::test_unbacked_index_select_cuda`
https://ossci-raw-job-status.s3.amazonaws.com/log/21083466405
Afaik this PR doesn't actually cause the test to fail, it just surfaces the error since the mem leak check wasn't running previously

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler