### PR TITLE
[DeviceMesh] Fix __hash__ and __equal__  in DeviceMesh not being consistent

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -1,7 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 # Owner(s): ["oncall: distributed"]
 import os
-from copy import copy
 
 import torch
 import torch.distributed._functional_collectives as funcol
@@ -250,21 +249,18 @@ class DeviceMeshTestNDim(DTensorTestBase):
         mesh_tensor_2d = torch.arange(8).reshape(4, 2)
         mesh = DeviceMesh(self.device_type, mesh_tensor_2d)
         mesh2 = DeviceMesh(self.device_type, mesh_tensor_2d)
-        # we do a shallow copy here since we want the hash of mesh and mesh_copy to be the same.
-        mesh_copy = copy(mesh)
         self.assertNotEqual(hash(mesh), hash(mesh2))
         self.assertNotEqual(mesh, mesh2)
+
+        # We make a duplicate by = to make sure mesh and mesh_copy have the same reference id.
+        mesh_copy = mesh
         self.assertEqual(hash(mesh), hash(mesh_copy))
         self.assertEqual(mesh, mesh_copy)
 
         mesh_tensor_3d = torch.arange(8).reshape(2, 2, 2)
         mesh3 = DeviceMesh(self.device_type, mesh_tensor_3d)
-        # we do a shallow copy here since we want the hash of mesh3 and mesh3_copy to be the same.
-        mesh3_copy = copy(mesh3)
         self.assertNotEqual(hash(mesh), hash(mesh3))
         self.assertNotEqual(hash(mesh2), hash(mesh3))
-        self.assertEqual(hash(mesh3), hash(mesh3_copy))
-        self.assertEqual(mesh3, mesh3_copy)
 
 
 class InitDeviceMeshTest(DTensorTestBase):

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -1,6 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 # Owner(s): ["oncall: distributed"]
 import os
+from copy import copy
 
 import torch
 import torch.distributed._functional_collectives as funcol
@@ -249,11 +250,21 @@ class DeviceMeshTestNDim(DTensorTestBase):
         mesh_tensor_2d = torch.arange(8).reshape(4, 2)
         mesh = DeviceMesh(self.device_type, mesh_tensor_2d)
         mesh2 = DeviceMesh(self.device_type, mesh_tensor_2d)
+        # we do a shallow copy here since we want the hash of mesh and mesh_copy to be the same.
+        mesh_copy = copy(mesh)
         self.assertNotEqual(hash(mesh), hash(mesh2))
+        self.assertNotEqual(mesh, mesh2)
+        self.assertEqual(hash(mesh), hash(mesh_copy))
+        self.assertEqual(mesh, mesh_copy)
+
         mesh_tensor_3d = torch.arange(8).reshape(2, 2, 2)
         mesh3 = DeviceMesh(self.device_type, mesh_tensor_3d)
+        # we do a shallow copy here since we want the hash of mesh3 and mesh3_copy to be the same.
+        mesh3_copy = copy(mesh3)
         self.assertNotEqual(hash(mesh), hash(mesh3))
         self.assertNotEqual(hash(mesh2), hash(mesh3))
+        self.assertEqual(hash(mesh3), hash(mesh3_copy))
+        self.assertEqual(mesh3, mesh3_copy)
 
 
 class InitDeviceMeshTest(DTensorTestBase):

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -326,11 +326,10 @@ else:
         def __eq__(self, other: object) -> bool:
             if not isinstance(other, DeviceMesh):
                 return False
-            if id(self.mesh) == id(other.mesh):
-                return True
             return (
                 self.mesh.shape == other.mesh.shape
                 and self._flatten_mesh_list == other._flatten_mesh_list
+                and id(self.mesh) == id(other.mesh)
             )
 
         def __getitem__(self, mesh_dim_name: str) -> "DeviceMesh":

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -205,9 +205,7 @@ else:
             )
             self.mesh_dim_names = mesh_dim_names
 
-            # private field to pre-generate DeviceMesh's hash
-            self._flatten_mesh_list = tuple(self.mesh.flatten().tolist())
-            self._hash = hash((self._flatten_mesh_list, self.mesh.shape, id(self)))
+            self._hash = hash(id(self))
 
             # Skip process group initialization if xla device.
             # TODO(yeounoh) implement DeviceMesh backend and register XLA backend.
@@ -326,11 +324,7 @@ else:
         def __eq__(self, other: object) -> bool:
             if not isinstance(other, DeviceMesh):
                 return False
-            return (
-                self.mesh.shape == other.mesh.shape
-                and self._flatten_mesh_list == other._flatten_mesh_list
-                and id(self.mesh) == id(other.mesh)
-            )
+            return id(self) == id(other)
 
         def __getitem__(self, mesh_dim_name: str) -> "DeviceMesh":
             """


### PR DESCRIPTION
__eq__ and __hash__ must agree, as equal objects must have equal hashes. 

We missed updating __eq__ along with the changes in hash in the earlier PR https://github.com/pytorch/pytorch/pull/114812. 
Since we are already using the id to hash, we can drop the other two fields `mesh.shape` and `_flatten_mesh_list` for hashing. In addition, we reflect the change by updating __eq__ to make sure equal meaning hashes of two DeviceMesh are the same. 

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @tianyu-l @wconstab @yf225 @chauhang