### PR TITLE
[Inductor] Skip triton templates for mixedmm on SM70-

### DIFF
--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -1,5 +1,6 @@
+import functools
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import torch
 from torch._inductor.virtualized import V
@@ -259,11 +260,19 @@ def fallback_mixed_mm(mat1, mat2, *, out):
 aten_fallback_mixed_mm = ExternKernelChoice(fallback_mixed_mm, None)
 
 
+@functools.lru_cache(None)
+def _is_v100_gpu(index: Optional[int]) -> bool:
+    props = torch.cuda.get_device_properties(index or 0)
+    return props.major == 7
+
+
 def tuned_mixed_mm(mat1, mat2, mat2_dtype):
     m, n, k, layout, mat1, mat2 = mm_args(mat1, mat2, layout=None)
     choices = [aten_fallback_mixed_mm.bind((mat1, mat2), layout)]
-    if mat1.layout.dtype != torch.float32 and not mat2.layout.is_contiguous():
-        # can't use triton kernel unless one of these is true
+    if (
+        mat1.layout.dtype != torch.float32 and not mat2.layout.is_contiguous()
+    ) or _is_v100_gpu(layout.device.index):
+        # can't use triton kernel unless one of these is true or if running on v100 (numerical issues)
         return autotune_select_algorithm("mixed_mm", choices, [mat1, mat2], layout)
     if inductor_config.force_mixed_mm:
         choices = []


### PR DESCRIPTION
As it results in numerical errors, see https://github.com/pytorch/pytorch/issues/117144

Fixes https://github.com/pytorch/pytorch/issues/117144


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler