### PR TITLE
[quant][bc-breaking] Turn on fold_quantize by default

### DIFF
--- a/torch/ao/quantization/quantize_pt2e.py
+++ b/torch/ao/quantization/quantize_pt2e.py
@@ -243,8 +243,7 @@ def convert_pt2e(
     pm = PassManager([PortNodeMetaForQDQ()])
     model = pm(model).graph_module
 
-    if fold_quantize:
-        constant_fold(model, _quant_node_constraint)
+    constant_fold(model, _quant_node_constraint)
 
     if use_reference_representation:
         model = reference_representation_rewrite(model)


### PR DESCRIPTION
Summary:
Previously by default we don't generate quantized weight, that is, we'll have fp32 weight, and
`fp32 weight -> q -> dq -> linear -> ...` in the quantized model

After this PR, we'll produce a graph with int8 weight by default after convert_pt2e:
`int8 weight -> dq -> linear -> ...`

We'll remove the fold_quantize flag in the next PR

Test Plan: CI

Differential Revision: D51730862


