### PR TITLE
[export] do not use tree_flatten_spec

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1946,7 +1946,7 @@ def forward(self, arg_0):
 
         exported_program = export(MyModule(), (torch.rand(2, 3),), {})
         with self.assertRaisesRegex(
-            TypeError, "Trying to flatten user inputs"
+            ValueError, "Trying to flatten user inputs"
         ):
             exported_program.module()(torch.rand(2, 3), torch.rand(2, 3))
 

--- a/test/export/test_tree_utils.py
+++ b/test/export/test_tree_utils.py
@@ -1,0 +1,50 @@
+# Owner(s): ["oncall: export"]
+from collections import OrderedDict
+
+import torch
+from torch._dynamo.test_case import TestCase
+
+from torch.export._tree_utils import is_equivalent, reorder_kwargs
+from torch.testing._internal.common_utils import run_tests
+from torch.utils._pytree import tree_structure
+
+
+class TestTreeUtils(TestCase):
+    def test_reorder_kwargs(self):
+        original_kwargs = {"a": torch.tensor(0), "b": torch.tensor(1)}
+        user_kwargs = {"b": torch.tensor(2), "a": torch.tensor(3)}
+        orig_spec = tree_structure(((), original_kwargs))
+
+        reordered_kwargs = reorder_kwargs(user_kwargs, orig_spec)
+
+        # Key ordering should be the same
+        self.assertEqual(reordered_kwargs.popitem()[0], original_kwargs.popitem()[0]),
+        self.assertEqual(reordered_kwargs.popitem()[0], original_kwargs.popitem()[0]),
+
+    def test_equivalence_check(self):
+        tree1 = {"a": torch.tensor(0), "b": torch.tensor(1), "c": None}
+        tree2 = OrderedDict(a=torch.tensor(0), b=torch.tensor(1), c=None)
+        spec1 = tree_structure(tree1)
+        spec2 = tree_structure(tree2)
+
+        def dict_ordered_dict_eq(type1, context1, type2, context2):
+            if type1 is None or type2 is None:
+                return type1 is type2 and context1 == context2
+
+            if issubclass(type1, (dict, OrderedDict)) and issubclass(
+                type2, (dict, OrderedDict)
+            ):
+                return context1 == context2
+
+            return type1 is type2 and context1 == context2
+
+        self.assertTrue(is_equivalent(spec1, spec2, dict_ordered_dict_eq))
+
+        # Wrong ordering should still fail
+        tree3 = OrderedDict(b=torch.tensor(1), a=torch.tensor(0))
+        spec3 = tree_structure(tree3)
+        self.assertFalse(is_equivalent(spec1, spec3, dict_ordered_dict_eq))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/onnx/test_fx_op_consistency.py
+++ b/test/onnx/test_fx_op_consistency.py
@@ -1619,19 +1619,6 @@ SKIP_XFAIL_SUBTESTS: tuple[onnx_test_common.DecorateMeta, ...] = (
         reason="fixme: LogSoftMax does not support empty tensor as input",
     ),
     xfail(
-        "split",
-        variant_name="list_args",
-        matcher=lambda sample: isinstance(sample.args[0], torch.Size),
-        model_type=pytorch_test_common.TorchModelType.TORCH_EXPORT_EXPORTEDPROGRAM,
-        reason=onnx_test_common.reason_dynamo_does_not_support("pytree flatten error"),
-    ),
-    xfail(
-        "split_with_sizes",
-        matcher=lambda sample: isinstance(sample.args[0], torch.Size),
-        model_type=pytorch_test_common.TorchModelType.TORCH_EXPORT_EXPORTEDPROGRAM,
-        reason=onnx_test_common.reason_dynamo_does_not_support("pytree flatten error"),
-    ),
-    xfail(
         "t",
         matcher=lambda sample: isinstance(sample.input, torch.Tensor)
         and len(sample.input.shape) < 2,

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -661,7 +661,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         )
 
     @pytorch_test_common.xfail_if_model_type_is_exportedprogram(
-        error_message="Trying to flatten user inputs with exported input tree spec"
+        error_message="kwarg key mismatch"
     )
     def test_gpt2_tiny_from_config(self):
         # Model

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -21,7 +21,6 @@ import sympy
 import torch
 import torch._dynamo
 import torch.fx
-import torch.fx._pytree as fx_pytree
 import torch.utils._pytree as pytree
 
 from torch._decomp import core_aten_decompositions, get_decompositions
@@ -35,6 +34,7 @@ from torch._guards import detect_fake_mode
 from torch._ops import OpOverload
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch._subclasses.functional_tensor import FunctionalTensor
+from torch.export._tree_utils import reorder_kwargs
 from torch.export.exported_program import (
     ExportedProgram,
     ModuleCallEntry,
@@ -425,7 +425,7 @@ def aot_load(so_path: str, device: str) -> Callable:
         call_spec = runner.get_call_spec()  # type: ignore[attr-defined]
         in_spec = pytree.treespec_loads(call_spec[0])
         out_spec = pytree.treespec_loads(call_spec[1])
-        flat_inputs = fx_pytree.tree_flatten_spec((args, kwargs), in_spec)
+        flat_inputs = pytree.tree_flatten((args, reorder_kwargs(kwargs, in_spec)))[0]
         flat_outputs = runner.run(flat_inputs)  # type: ignore[attr-defined]
         return pytree.tree_unflatten(flat_outputs, out_spec)
 

--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -22,7 +22,6 @@ from typing import (
 )
 
 import torch
-import torch.fx._pytree as fx_pytree
 import torch.utils._pytree as pytree
 from torch.fx._compatibility import compatibility
 

--- a/torch/export/_tree_utils.py
+++ b/torch/export/_tree_utils.py
@@ -1,0 +1,64 @@
+from typing import Any, Callable, Dict, Optional
+
+from torch.utils._pytree import Context, TreeSpec
+
+
+def reorder_kwargs(user_kwargs: Dict[str, Any], spec: TreeSpec) -> Dict[str, Any]:
+    """Reorder user-provided kwargs to match the order in `spec`. `spec` is
+    expected to be the in_spec of an exported program, i.e. the spec that
+    results from flattening `(args, kwargs)`.
+
+    We need this to provide consistent input ordering, such so that users can
+    pass in foo(a=a, b=b) OR foo(b=b, a=a) and receive the same result.
+    """
+    # Make sure that the spec is actually shaped like (args, kwargs)
+    assert spec.type is tuple
+    assert spec.num_children == 2
+    kwargs_spec = spec.children_specs[1]
+    assert kwargs_spec.type is dict
+
+    if set(user_kwargs) != set(kwargs_spec.context):
+        raise ValueError(
+            f"kwarg key mismatch: "
+            f"Got {list(user_kwargs)} but expected {kwargs_spec.context}"
+        )
+
+    reordered_kwargs = {}
+    for kw in kwargs_spec.context:
+        reordered_kwargs[kw] = user_kwargs[kw]
+
+    return reordered_kwargs
+
+
+def is_equivalent(
+    spec1: TreeSpec,
+    spec2: TreeSpec,
+    equivalence_fn: Callable[[Optional[type], Context, Optional[type], Context], bool],
+) -> bool:
+    """Customizable equivalence check for two TreeSpecs.
+
+    Arguments:
+        spec1: The first TreeSpec to compare
+        spec2: The second TreeSpec to compare
+        equivalence_fn: A function to determine the equivalence of two
+            TreeSpecs by examining their types and contexts. It will be called like:
+
+                equivalence_fn(spec1.type, spec1.context, spec2.type, spec2.context)
+
+            This function will be applied recursively to all children.
+
+    Returns:
+        True if the two TreeSpecs are equivalent, False otherwise.
+    """
+    if not equivalence_fn(spec1.type, spec1.context, spec2.type, spec2.context):
+        return False
+
+    # Recurse on children
+    if len(spec1.children_specs) != len(spec2.children_specs):
+        return False
+
+    for child_spec1, child_spec2 in zip(spec1.children_specs, spec2.children_specs):
+        if not is_equivalent(child_spec1, child_spec2, equivalence_fn):
+            return False
+
+    return True

--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -19,7 +19,7 @@ def _check_input_constraints_pre_hook(self, *args, **kwargs):
     args, received_spec = pytree.tree_flatten(args)
 
     if received_spec != self._in_spec:
-        raise TypeError(  # noqa: TRY200
+        raise ValueError(  # noqa: TRY200
             "Trying to flatten user inputs with exported input tree spec: \n"
             f"{self._in_spec}\n"
             "but actually got inputs with tree spec of: \n"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #118612
* #118611
* #118610
* #118609
* __->__ #118608
* #118607

tree_flatten_spec is bad; it isn't synced up with `register_pytree_node` so it will not handle arbitrary custom pytrees. It's also not really maintained.

We only use it for two purposes:
- To retain kwarg ordering stability, so that if the user passes in kwargs in a different order things will still work.
- To do "structural" checks that ignore types.

In both cases, tree_flatten_spec is probably *not* the ideal way to implement the desired behavior.

## kwargs ordering
- tree_flatten_spec overwrites the behavior of ALL dictionaries, not just kwargs. This is not correct, dictionary ordering is meaningful in Python, and it's pretty trivial to write a program that relies on dict ordering.
- For kwargs, we do sort of expect that the order in which arguments are passed shouldn't matter. BUT there is one exception: `**kwargs`. In fact, [PEP 468](https://peps.python.org/pep-0468/) was introduced specifically to clarify that ordering does matter when the function being called uses `**kwargs`.

In this diff I introduce a utility function that *only* reorders kwargs. This gets us most of the way to correct—dicts are no longer reordered, but kwargs can be passed in any order.

A "fully correct" solution would need fix the corner case from PEP468. We could detect whether the top-level fn being traced uses `**kwargs` (via `inspect`), then serialize a flag for it. In ExportedProgram, we would check that flag and only re-order if `**kwargs` was unused; otherwise error if the key order doesn't match. This is a super corner case though, so I'll file it as a followup task.

## structural equivalence checking

This is another use case, where again `tree_flatten_spec` is too broad. Generally we want to treat a precise two types as the same, not override the behavior of comparison generally. So I introduce an `is_equivalent` util for this purpose.

Differential Revision: [D53168420](https://our.internmc.facebook.com/intern/diff/D53168420/)