### PR TITLE
[export] adopt KeyPath API in nonstrict mode

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -6,6 +6,7 @@ import io
 import unittest
 from contextlib import contextmanager
 from dataclasses import dataclass
+from re import escape
 
 import torch
 import torch._dynamo as torchdynamo
@@ -242,7 +243,7 @@ class TestExport(TestCase):
             torch.ones(4),
         )
         with self.assertRaisesRegex(
-            RuntimeError, "Expected input arg3_1.shape\[0\] to be equal to 6, but got 5"
+            RuntimeError, escape("Expected input at *args[1][0].shape[0] to be equal to 6, but got 5")
         ):
             ep_ns.module()(*bad_runtime_inp1)
 
@@ -253,7 +254,7 @@ class TestExport(TestCase):
             torch.ones(6),
         )
         with self.assertRaisesRegex(
-            RuntimeError, "Expected input arg7_1.shape\[0\] to be equal to 4, but got 6"
+            RuntimeError, escape("Expected input at *args[3].shape[0] to be equal to 4, but got 6")
         ):
             ep_ns.module()(*bad_runtime_inp2)
 
@@ -409,7 +410,6 @@ class TestExport(TestCase):
             constraints = [dynamic_dim(inp_for_g, 0)]
 
     @testing.expectedFailureRetraceability
-    @testing.expectedFailureNonStrict
     def test_map(self):
         def list_tensor_map(xs, y, z):
             def body(x, y, z):
@@ -457,7 +457,6 @@ class TestExport(TestCase):
         kwargs3 = {"b": 1}
         self._test_export_same_as_eager(kw_func2, args, kwargs3)
 
-    @testing.expectedFailureNonStrict
     def test_export_func_with_var_postional_args(self):
         def kw_func(arg1, arg2, *args):
             return arg1 + args[0], arg2 + args[1]
@@ -1542,7 +1541,7 @@ def forward(self, arg_0):
             torch.allclose(exported.module()(torch.ones(8, 5), 5), foo(torch.ones(8, 5), 5))
         )
         with self.assertRaisesRegex(
-            RuntimeError, "Expected input arg1 to be equal to 5, but got 6"
+            RuntimeError, escape("Expected input at *args[1] to be equal to 5, but got 6")
         ):
             _ = exported.module()(torch.ones(8, 5), 6)
 
@@ -1550,7 +1549,7 @@ def forward(self, arg_0):
             foo, (tensor_inp, 5.0), dynamic_shapes=dynamic_shapes
         )
         with self.assertRaisesRegex(
-            RuntimeError, "Expected input arg1 to be equal to 5.0, but got 6.0"
+            RuntimeError, escape("Expected input at *args[1] to be equal to 5.0, but got 6.0")
         ):
             _ = exported.module()(torch.ones(7, 5), 6.0)
 
@@ -1671,7 +1670,7 @@ def forward(self, arg_0):
             Foo(), (inp,), dynamic_shapes={"x": {0: dim0_x_v2}}
         )
         with self.assertRaisesRegex(
-            RuntimeError, "Expected input l_x_.shape\[0\] to be >= 3, but got 2"
+            RuntimeError, escape("Expected input at *args[0].shape[0] to be >= 3, but got 2")
         ):
             torch.export.export(exported_v2.module(), (torch.randn(2, 2),))
 
@@ -2175,10 +2174,10 @@ def forward(self, l_x_):
             Foo(), (inp,), constraints=[dynamic_dim(inp, 0) >= 3], pre_dispatch=True
         ).module()
 
-        with self.assertRaisesRegex(RuntimeError, "Expected input l_x_.shape\[0\]"):
+        with self.assertRaisesRegex(RuntimeError, escape("Expected input at *args[0].shape[0]")):
             gm(torch.randn(2, 2))
 
-        with self.assertRaisesRegex(RuntimeError, "Expected input l_x_.shape\[0\]"):
+        with self.assertRaisesRegex(RuntimeError, escape("Expected input at *args[0].shape[0]")):
             torch.export.export(gm, (torch.randn(2, 2),))
 
         ep = torch.export.export(
@@ -2975,7 +2974,7 @@ def forward(self, l_q_, l_k_, l_v_):
         self.assertEqual(res[0], torch.tensor(20))
         self.assertEqual(res[1], 5)
 
-        with self.assertRaisesRegex(RuntimeError, "Expected input arg1 to be equal to 5, but got 20"):
+        with self.assertRaisesRegex(RuntimeError, escape("Expected input at *args[1] to be equal to 5, but got 20")):
             res = ep(torch.tensor(4), 20)
 
         class F(torch.nn.Module):

--- a/test/export/test_unflatten.py
+++ b/test/export/test_unflatten.py
@@ -5,6 +5,7 @@ import unittest
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import List, Any
+from re import escape
 
 import torch
 import torch._dynamo as torchdynamo
@@ -326,11 +327,11 @@ class TestUnflatten(TestCase):
                 return a
 
         export_module = torch.export.export(Mod(), (torch.randn((2, 3)),))
-        with self.assertRaisesRegex(RuntimeError, "Expected input l_x_.shape\[0\] to be equal to 2, but got 6"):
+        with self.assertRaisesRegex(RuntimeError, escape("Expected input at *args[0].shape[0] to be equal to 2, but got 6")):
             export_module.module()(torch.randn(6, 6))
 
         unflattened = unflatten(export_module)
-        with self.assertRaisesRegex(RuntimeError, "Expected input l_x_.shape\[0\] to be equal to 2, but got 6"):
+        with self.assertRaisesRegex(RuntimeError, escape("Expected input at *args[0].shape[0] to be equal to 2, but got 6")):
             unflattened(torch.randn(6, 6))
 
     def test_unflatten_with_inplace_compile(self):

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -12,6 +12,10 @@ from torch.utils._pytree import (
     DumpableContext,
     FlattenFunc,
     FromDumpableContextFn,
+    KeyPath,
+    keystr,
+    MappingKey,
+    SequenceKey,
     ToDumpableContextFn,
     UnflattenFunc,
 )
@@ -21,12 +25,24 @@ SERIALIZED_DATACLASS_TO_PYTHON_DATACLASS: Dict[str, Type[Any]] = {}
 
 
 def _check_input_constraints_for_graph(
-    input_placeholders: List[torch.fx.Node], args, range_constraints
+    input_placeholders: List[torch.fx.Node], flat_args_with_path, range_constraints
 ):
-    def check(cond, msg):
-        if not cond:
-            # TODO(avik): maybe add more context, e.g., graph signature
-            raise RuntimeError(msg)
+    def get_keystr(key_path: KeyPath) -> str:
+        """For a given index into the flat_args, return a human readable string
+        describing how to access it, e.g. "*args["foo"][0].bar"
+        """
+        # Prefix the keypath with "*args" or "**kwargs" to make it clearer where
+        # the arguments come from. Ultimately we ought to serialize the
+        # original arg names for the best error message here.
+        args_kwargs_key_path = key_path[0]
+        assert isinstance(args_kwargs_key_path, SequenceKey)
+        if args_kwargs_key_path.idx == 0:
+            return f"*args{keystr(key_path[1:])}"
+        else:
+            kwarg_key = key_path[1]
+            assert isinstance(kwarg_key, MappingKey)
+            name = str(kwarg_key)[1:-1]  # get rid of the enclosed []
+            return f"{name}{keystr(key_path[2:])}"
 
     import sympy
 
@@ -34,36 +50,38 @@ def _check_input_constraints_for_graph(
         _convert_range_to_int,
     )
 
-    check(
-        len(args) == len(input_placeholders),
-        "Unexpected number of inputs "
-        f"(expected {len(input_placeholders)}, got {len(args)})",
-    )
+    if len(flat_args_with_path) != len(input_placeholders):
+        raise RuntimeError(
+            "Unexpected number of inputs "
+            f"(expected {len(input_placeholders)}, got {len(flat_args_with_path)})"
+        )
     # NOTE: export already guarantees that the same symbol is used in metadata
     # for all InputDims related by equality constraints, so we can just unify
     # symbols with given input dimension values to check equality constraints.
     unification_map: "Dict[sympy.Symbol, Any]" = {}
-    for arg, node in zip(args, input_placeholders):
+    for (key_path, arg), node in zip(flat_args_with_path, input_placeholders):
         node_val = node.meta.get("val")
         if isinstance(node_val, FakeTensor):
-            check(
-                isinstance(arg, torch.Tensor),
-                f"Expected input {node.name} to be a tensor, but got {type(arg)}",
-            )
-            check(
-                len(node_val.shape) == len(arg.shape),
-                f"Unexpected number of dimensions in input {node.name}.shape "
-                f"(expected {node_val.shape}, got {arg.shape})",
-            )
+            if not isinstance(arg, torch.Tensor):
+                raise RuntimeError(
+                    f"Expected input at {get_keystr(key_path)} to be a tensor, but got {type(arg)}",
+                )
+
+            if len(node_val.shape) != len(arg.shape):
+                raise RuntimeError(
+                    f"Unexpected number of dimensions in input at {get_keystr(key_path)}.shape "
+                    f"(expected {node_val.shape}, got {arg.shape})"
+                )
+
             for j, (arg_dim, node_dim) in enumerate(zip(arg.shape, node_val.shape)):
                 if isinstance(node_dim, torch.SymInt):
                     if node_dim.node.expr in unification_map:
                         existing_dim = unification_map[node_dim.node.expr]
-                        check(
-                            arg_dim == existing_dim,
-                            f"Expected input {node.name}.shape[{j}] to be equal to "
-                            f"{existing_dim}, but got {arg_dim}",
-                        )
+                        if arg_dim != existing_dim:
+                            raise RuntimeError(
+                                f"Expected input at {get_keystr(key_path)}.shape[{j}] to be equal to "
+                                f"{existing_dim}, but got {arg_dim}",
+                            )
                     else:
                         unification_map[node_dim.node.expr] = arg_dim
 
@@ -73,28 +91,28 @@ def _check_input_constraints_for_graph(
                         )
                         # NOTE: we allow dimensions to be 0/1 at runtime
                         if min_val > 2:
-                            check(
-                                arg_dim >= min_val,
-                                f"Expected input {node.name}.shape[{j}] to be >= "
-                                f"{min_val}, but got {arg_dim}",
-                            )
+                            if arg_dim < min_val:
+                                raise RuntimeError(
+                                    f"Expected input at {get_keystr(key_path)}.shape[{j}] to be >= "
+                                    f"{min_val}, but got {arg_dim}",
+                                )
                         if max_val < math.inf:
-                            check(
-                                arg_dim <= max_val,
-                                f"Expected input {node.name}.shape[{j}] to be <= "
-                                f"{max_val}, but got {arg_dim}",
-                            )
+                            if arg_dim > max_val:
+                                raise RuntimeError(
+                                    f"Expected input at {get_keystr(key_path)}.shape[{j}] to be <= "
+                                    f"{max_val}, but got {arg_dim}",
+                                )
                 else:
-                    check(
-                        arg_dim == node_dim,
-                        f"Expected input {node.name}.shape[{j}] to be equal to "
-                        f"{node_dim}, but got {arg_dim}",
-                    )
+                    if arg_dim != node_dim:
+                        raise RuntimeError(
+                            f"Expected input at {get_keystr(key_path)}.shape[{j}] to be equal to "
+                            f"{node_dim}, but got {arg_dim}",
+                        )
         elif isinstance(node_val, (int, float, str)):
-            check(
-                type(arg) == type(node_val) and arg == node_val,
-                f"Expected input {node.name} to be equal to {node_val}, but got {arg}",
-            )
+            if type(arg) != type(node_val) or arg != node_val:
+                raise RuntimeError(
+                    f"Expected input at {get_keystr(key_path)} to be equal to {node_val}, but got {arg}",
+                )
 
 
 def register_dataclass_as_pytree_node(

--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -16,7 +16,7 @@ from .exported_program import (
 
 @torch._dynamo.disable
 def _check_input_constraints_pre_hook(self, *args, **kwargs):
-    args, received_spec = pytree.tree_flatten(args)
+    flat_args_with_path, received_spec = pytree.tree_flatten_with_path(args)
 
     if received_spec != self._in_spec:
         raise ValueError(  # noqa: TRY200
@@ -28,7 +28,7 @@ def _check_input_constraints_pre_hook(self, *args, **kwargs):
 
     return _check_input_constraints_for_graph(
         [node for node in self.graph.nodes if node.op == "placeholder"],
-        args,
+        flat_args_with_path,
         self.range_constraints,
     )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #118612
* #118611
* #118610
* __->__ #118609
* #118608
* #118607

This PR rewrites two paths to use the newly-added keypaths API in pytree:
First: we were hand-rolling a tree_map during fakification because we wanted to track sources. This PR uses keypaths instead, which can do the same thing without needing custom code.

Second: our constraint error formatting was referencing placeholder names in error messages. These placeholder names are not otherwise user-visible, so they are super confusing to users (e.g. "which input does arg1_3 correspond to?"). This diff uses the `keystr` API to format the error message.

This necessitated some small refactors—generating the keystr is expensive so doing it in an f-string was very bad.

It can also be further improved—we can inspect the signature so that instead of `*args[0]` we can give people the actual argument name, which would be the ideal UX. But leaving that for later.

Differential Revision: [D53139358](https://our.internmc.facebook.com/intern/diff/D53139358/)