### PR TITLE
[export] do not rewrite state dict when unlifting

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -2319,7 +2319,10 @@ def forward(self, x):
         torch.export.save(exp_program, output_buffer)
         loaded_model = torch.export.load(output_buffer)
         self.assertTrue(
-            isinstance(loaded_model.module().features_0_weight, torch.nn.Parameter)
+            isinstance(
+                loaded_model.module().get_parameter("features.0.weight"),
+                torch.nn.Parameter,
+            )
         )
 
     def test_export_meta(self):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1178,12 +1178,12 @@ class TestExport(TestCase):
             """\
 def forward(self, arg_0):
     l_x_, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
-    conv_weight = self.conv_weight
-    conv_bias = self.conv_bias
-    bn_weight = self.bn_weight
-    bn_bias = self.bn_bias
-    bn_running_mean = self.bn_running_mean
-    bn_running_var = self.bn_running_var
+    conv_weight = self.conv.weight
+    conv_bias = self.conv.bias
+    bn_weight = self.bn.weight
+    bn_bias = self.bn.bias
+    bn_running_mean = self.bn.running_mean
+    bn_running_var = self.bn.running_var
     conv2d = torch.ops.aten.conv2d.default(l_x_, conv_weight, conv_bias);  l_x_ = conv_weight = conv_bias = None
     _native_batch_norm_legit_no_training = torch.ops.aten._native_batch_norm_legit_no_training.default(conv2d, bn_weight, bn_bias, bn_running_mean, bn_running_var, 0.1, 1e-05);  conv2d = bn_weight = bn_bias = bn_running_mean = bn_running_var = None
     getitem = _native_batch_norm_legit_no_training[0];  _native_batch_norm_legit_no_training = None
@@ -1197,13 +1197,13 @@ def forward(self, arg_0):
             """\
 def forward(self, arg_0):
     l_x_, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
-    conv_weight = self.conv_weight
-    conv_bias = self.conv_bias
-    bn_weight = self.bn_weight
-    bn_bias = self.bn_bias
-    bn_running_mean = self.bn_running_mean
-    bn_running_var = self.bn_running_var
-    bn_num_batches_tracked = self.bn_num_batches_tracked
+    conv_weight = self.conv.weight
+    conv_bias = self.conv.bias
+    bn_weight = self.bn.weight
+    bn_bias = self.bn.bias
+    bn_running_mean = self.bn.running_mean
+    bn_running_var = self.bn.running_var
+    bn_num_batches_tracked = self.bn.num_batches_tracked
     conv2d = torch.ops.aten.conv2d.default(l_x_, conv_weight, conv_bias);  l_x_ = conv_weight = conv_bias = None
     add = torch.ops.aten.add.Tensor(bn_num_batches_tracked, 1)
     _native_batch_norm_legit_functional = torch.ops.aten._native_batch_norm_legit_functional.default(conv2d, bn_weight, bn_bias, bn_running_mean, bn_running_var, True, 0.1, 1e-05);  conv2d = bn_weight = bn_bias = None
@@ -2599,7 +2599,6 @@ def forward(self, l_x_):
         ep.run_decompositions(decomp_table=torch._decomp.decomposition_table)
         self.assertEqual(ep.module()(t, dim, index, src), output)
 
-    @testing.expectedFailureRetraceability
     def test_fqn(self):
         class NestedChild(torch.nn.Module):
             def forward(self, x):

--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -83,6 +83,15 @@ class _VerifierMeta(type):
         metacls._registry[attrs["dialect"]] = ret  # type: ignore[assignment]
         return ret
 
+def getattr_recursive(obj: Any, target: str) -> Any:
+    target_atoms = target.split('.')
+    attr_itr = obj
+    for i, atom in enumerate(target_atoms):
+        if not hasattr(attr_itr, atom):
+            raise RuntimeError(f"Node referenced nonexistent target {'.'.join(target_atoms[:i])}")
+        attr_itr = getattr(attr_itr, atom)
+    return attr_itr
+
 
 class Verifier(metaclass=_VerifierMeta):
     dialect = "ATEN"
@@ -208,7 +217,7 @@ class Verifier(metaclass=_VerifierMeta):
                             f"Expected get_attr target to be string, but got {type(node.target)}"
                         )
 
-                    attr = getattr(mod, node.target)
+                    attr = getattr_recursive(mod, node.target)
                     if isinstance(attr, torch.nn.Module):
                         def _is_type(name, ty):
                             return isinstance(getattr(attr, name, None), ty)

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -146,13 +146,25 @@ def _warn_tf32_disabled():
 
 
 def _unlift_graph(mod, gm, graph_signature):
+    from torch.export.unflatten import _assign_attr, _AttrKind
+
     state_dict = {}
     for name, param in mod.named_parameters(remove_duplicate=False):
-        gm.register_parameter(name.replace(".", "_"), param)
         state_dict[name] = param
+        _assign_attr(
+            param,
+            gm,
+            name,
+            attr_kind=_AttrKind.PARAMETER,
+        )
     for name, buffer in mod.named_buffers(remove_duplicate=False):
-        gm.register_buffer(name.replace(".", "_"), buffer)
         state_dict[name] = buffer
+        _assign_attr(
+            buffer,
+            gm,
+            name,
+            attr_kind=_AttrKind.BUFFER,
+        )
 
     placeholder_nodes = [node for node in gm.graph.nodes if node.op == "placeholder"]
     lifted_inputs = []


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #118612
* __->__ #118611
* #118610
* #118609
* #118608
* #118607

This is Very Bad; changing state dict keys violates one of the key contracts we have, which is "do not mess with the state dict".

Change unlift to use a similar `_assign_attr` approach that fx.GraphModule and unflatten do.

Also took the opportunity to improve the interface of `_assign_attr` to be more general.

Differential Revision: [D53139277](https://our.internmc.facebook.com/intern/diff/D53139277/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler