### PR TITLE
[DeviceMesh] Fix list index out of range error when calling `get_group` on ranks not participating in the mesh

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -152,6 +152,18 @@ class DeviceMeshTest(DTensorTestBase):
         self.assertEqual(mesh_2d.get_group("tp"), tp_mesh.get_group())
 
     @with_comms
+    def test_submesh_get_group(self):
+        sub_mesh_list = [0, 2]
+        sub_mesh = DeviceMesh(self.device_type, sub_mesh_list)
+
+        if self.rank in sub_mesh_list:
+            self.assertEqual(
+                get_process_group_ranks(sub_mesh.get_group()), sub_mesh_list
+            )
+        else:
+            self.assertEqual(sub_mesh.get_group(), None)
+
+    @with_comms
     def test_get_local_rank_raises_exception(self):
         mesh_shape = (2, self.world_size // 2)
         mesh_2d = init_device_mesh(

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -1,6 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import logging
 import math
+from functools import cached_property
 from typing import Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import torch
@@ -370,6 +371,7 @@ else:
 
             return submesh
 
+        @cached_property
         def get_group(
             self, mesh_dim: Optional[Union[int, str]] = None
         ) -> Optional[Union[ProcessGroup, List[ProcessGroup]]]:

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -372,7 +372,7 @@ else:
 
         def get_group(
             self, mesh_dim: Optional[Union[int, str]] = None
-        ) -> Union[ProcessGroup, List[ProcessGroup]]:
+        ) -> Optional[Union[ProcessGroup, List[ProcessGroup]]]:
             """
             Returns a list of ProcessGroups corresponding to the mesh dimensions, or
             returns a single ProcessGroup if mesh_dim is specified or the given mesh has
@@ -389,6 +389,9 @@ else:
             """
             if not hasattr(self, "_dim_group_infos"):
                 raise RuntimeError("DeviceMesh process groups not initialized!")
+
+            if get_rank() not in self.mesh:
+                return None
 
             if self.mesh.ndim == 1:
                 return not_none(_find_pg_by_ranks_and_tag(*self._dim_group_infos[0]))


### PR DESCRIPTION
When we create a submesh, calling `get_group()` on the ranks not participating in the mesh would result a list out of index error.  This PR fixes the issue for adding additional check and return None for `get_group()` if a given rank is not participated in the mesh. 

Repro as follows: 
```
from torch.distributed.device_mesh import  DeviceMesh
sub_mesh_list = [0, 2]
sub_mesh = DeviceMesh("cuda", sub_mesh_list)

print(f"rank:{self.rank}, {sub_mesh.get_group()=}")
```

```
======================================================================
ERROR: test_submesh_get_group (__main__.DeviceMeshTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/data/users/irisz/pytorch/torch/testing/_internal/common_distributed.py", line 536, in wrapper
    self._join_processes(fn)
  File "/data/users/irisz/pytorch/torch/testing/_internal/common_distributed.py", line 755, in _join_processes
    self._check_return_codes(elapsed_time)
  File "/data/users/irisz/pytorch/torch/testing/_internal/common_distributed.py", line 805, in _check_return_codes
    raise RuntimeError(error)
RuntimeError: Process 1 exited with error code 10 and exception:
Traceback (most recent call last):
  File "/data/users/irisz/pytorch/torch/testing/_internal/common_distributed.py", line 652, in run_test
    getattr(self, test_name)()
  File "/data/users/irisz/pytorch/torch/testing/_internal/common_distributed.py", line 538, in wrapper
    fn()
  File "/data/users/irisz/pytorch/torch/testing/_internal/common_utils.py", line 2698, in wrapper
    method(*args, **kwargs)
  File "/data/users/irisz/pytorch/torch/testing/_internal/distributed/_tensor/common_dtensor.py", line 261, in wrapper
    func(self, *args, **kwargs)  # type: ignore[misc]
  File "/data/users/irisz/pytorch/test/distributed/test_device_mesh.py", line 159, in test_submesh_get_group
    print(f"rank:{self.rank}, {sub_mesh.get_group()=}")
  File "/data/users/irisz/pytorch/torch/distributed/device_mesh.py", line 397, in get_group
    return not_none(_find_pg_by_ranks_and_tag(*self._dim_group_infos[0]))
IndexError: list index out of range
```



cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @tianyu-l @wconstab @yf225 @chauhang