### PR TITLE
HSDP + DTensor Support in FSDP

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -472,7 +472,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
                 "ignored_states": self._ignored_params,
                 "device_mesh": device_mesh,
             }
-            if sharding_strategy in HYBRID_SHARDING_STRATEGIES:
+            if sharding_strategy in HYBRID_SHARDING_STRATEGIES and device_mesh is not None:
                 # Share root process groups with children to maintain
                 # the invariant that all FSDP modules will have the same
                 # process groups.

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -472,7 +472,10 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
                 "ignored_states": self._ignored_params,
                 "device_mesh": device_mesh,
             }
-            if sharding_strategy in HYBRID_SHARDING_STRATEGIES and device_mesh is not None:
+            if (
+                sharding_strategy in HYBRID_SHARDING_STRATEGIES
+                and device_mesh is not None
+            ):
                 # Share root process groups with children to maintain
                 # the invariant that all FSDP modules will have the same
                 # process groups.


### PR DESCRIPTION
FSDP should take either process groups or device_mesh. When device_mesh is specified with DTensor, passing in process groups as well seems to make things blow up

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @LucasLLC