### PR TITLE
Fix admm over empty tensors and broadcastable input

### DIFF
--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -309,7 +309,7 @@ Tensor& addmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& ma
     // That requires some fixing some internal build dependencies though.
     return at::mul_out(
         result,
-        self,
+        self.expand(result.sizes()),
         at::native::scalar_tensor(
             beta,
             self.scalar_type(),

--- a/test/distributed/_tensor/test_matrix_ops.py
+++ b/test/distributed/_tensor/test_matrix_ops.py
@@ -54,13 +54,7 @@ class DistMatrixOpsTest(DTensorTestBase):
 
         dist_res = torch.addmm(inp, mat1, mat2)
         local_res = torch.addmm(input_tensor, tensor_to_shard, tensor_to_replicate)
-        # The behavior of torch.ops.aten.addmm.default is different on CPU and GPU.
-        # For more info see: https://github.com/pytorch/pytorch/issues/118131
-        # TODO: these two tensors should be equal on GPU. fix this.
-        if self.device_type == "cuda":
-            self.assertNotEqual(dist_res.full_tensor(), local_res)
-        else:
-            self.assertEqual(dist_res.full_tensor(), local_res)
+        self.assertEqual(dist_res.full_tensor(), local_res)
 
     @with_comms
     def test_addmm_auto_redistribute(self):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1184,6 +1184,8 @@ def sample_inputs_addmm(op_info, device, dtype, requires_grad, **kwargs):
     # addmm of empty matrices
     if dtype.is_floating_point:
         yield SampleInput(make_arg(S, M), make_arg(S, 0), make_arg(0, M), **kwargs)
+        # empty matmul with broadcastable input
+        yield SampleInput(make_arg(M), make_arg(S, 0), make_arg(0, M), **kwargs).with_metadata(broadcasts_input=True)
 
 def sample_inputs_sparse_sampled_addmm(op_info, device, dtype, requires_grad, **kwargs):
     alpha = 2 + 3j if dtype.is_complex else 0.6


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/118131



cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225