### PR TITLE
Update python binding for in-place foreach to return `List[Tensor]`

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -66,8 +66,7 @@ class ForeachFuncWrapper:
             assert mta_called == (expect_fastpath and (not zero_size))
         else:
             actual = self.func(*inputs, **kwargs)
-        # note(mkozuki): inplace foreach functions are void functions.
-        return inputs[0] if self.is_inplace else actual
+        return actual
 
 
 class InplaceForeachVersionBumpCheck:

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -1364,10 +1364,10 @@ def emit_single_dispatch(
                 return f"""\
 {schema_comment}
 {inits}
-auto dispatch_{name} = []({lambda_formals}) -> ::std::vector<at::Tensor> {{
+auto dispatch_{name} = []({lambda_formals}) -> at::TensorList {{
   pybind11::gil_scoped_release no_gil;
   {dispatch_callee}({dispatch_args});
-  return self.vec();
+  return self;
 }};
 return wrap(dispatch_{name}({lambda_args}){set_requires_grad});
 """

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -1357,10 +1357,10 @@ def emit_single_dispatch(
             if (
                 str(f.func.name).startswith("_foreach_")
                 and f.func.kind() == SchemaKind.inplace
-                and (
-                    self_arg is not None and is_tensor_list_type(self_arg.argument.type)
-                )
             ):
+                # note(crcrpar): `_foreach_pow.ScalarAndTensor` does NOT have its in-place
+                # variant and it unlikely to have it in the future. Thus it's safe to have the following assert.
+                assert self_arg is not None and is_tensor_list_type(self_arg.argument.type)
                 return f"""\
 {schema_comment}
 {inits}


### PR DESCRIPTION
Fixes #104817

Examples of generated foreach functions in torch/csrc/autograd/generated/python_torch_functionsEverything.cpp

```C++
// _foreach_acos
static PyObject * THPVariable__foreach_acos(PyObject* self_, PyObject* args, PyObject* kwargs)
{
  HANDLE_TH_ERRORS
  static PythonArgParser parser({
    "_foreach_acos(TensorList self)",
  }, /*traceable=*/true);

  ParsedArgs<1> parsed_args;
  auto _r = parser.parse(nullptr, args, kwargs, parsed_args);
  if(_r.has_torch_function()) {
    return handle_torch_function(_r, nullptr, args, kwargs, THPVariableFunctionsModule, "torch");
  }
  // aten::_foreach_acos(Tensor[] self) -> Tensor[]

  auto dispatch__foreach_acos = [](at::TensorList self) -> ::std::vector<at::Tensor> {
    pybind11::gil_scoped_release no_gil;
    return at::_foreach_acos(self);
  };
  return wrap(dispatch__foreach_acos(_r.tensorlist(0)));
  Py_RETURN_NONE;
  END_HANDLE_TH_ERRORS
}

// _foreach_acos_
static PyObject * THPVariable__foreach_acos_(PyObject* self_, PyObject* args, PyObject* kwargs)
{
  HANDLE_TH_ERRORS
  static PythonArgParser parser({
    "_foreach_acos_(TensorList self)",
  }, /*traceable=*/false);

  ParsedArgs<1> parsed_args;
  auto _r = parser.parse(nullptr, args, kwargs, parsed_args);
  if(_r.has_torch_function()) {
    return handle_torch_function(_r, nullptr, args, kwargs, THPVariableFunctionsModule, "torch");
  }
  // aten::_foreach_acos_(Tensor(a!)[] self) -> ()

  auto dispatch__foreach_acos_ = [](at::TensorList self) -> ::std::vector<at::Tensor> {
    pybind11::gil_scoped_release no_gil;
    at::_foreach_acos_(self);
    return self.vec();
  };
  return wrap(dispatch__foreach_acos_(_r.tensorlist(0)));
  Py_RETURN_NONE;
  END_HANDLE_TH_ERRORS
}
```