### PR TITLE
[inductor] skip launching kernels with zero grid in AOTInductor when using backed symints

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -712,13 +712,42 @@ class AOTInductorTestsTemplate:
                 d = (b + c) @ y
                 return d.sum()
 
-        if self.device != "cuda":
-            raise unittest.SkipTest("requires CUDA")
+        # if self.device != "cuda":
+        #     raise unittest.SkipTest("requires CUDA")
         example_inputs = (
             torch.tensor([1, 1, 1], device=self.device),
             torch.randn((1, 32), dtype=torch.float16, device=self.device),
         )
         self.check_model(Repro(), example_inputs)
+
+    def test_zero_grid_with_backed_symbols(self):
+        class Repro(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, b):
+                return x + b
+
+        example_inputs = (
+            x := torch.randn((3, 2), device=self.device),
+            torch.randn((1, 2), device=self.device),
+        )
+        torch._dynamo.mark_dynamic(x, index=0)
+
+        so_path: str = AOTIRunnerUtil.compile(
+            Repro(),
+            example_inputs,
+        )
+        aot_inductor_module = AOTIRunnerUtil.load("cuda", so_path)
+        aot_inductor_module(*example_inputs)
+
+        example_inputs = (
+            torch.randn((0, 2), device=self.device),
+            torch.randn((1, 2), device=self.device),
+        )
+        actual = aot_inductor_module(*example_inputs)
+        expected = Repro()(*example_inputs)
+        torch.testing.assert_close(actual, expected)
 
     def test_repeat_interleave(self):
         class Repro(torch.nn.Module):
@@ -1587,8 +1616,12 @@ class AOTInductorTestsTemplate:
     @config.patch({"aot_inductor.abi_compatible": True})
     def test_triton_kernel_reinterpret_view_mem_leak(self):
         # Check for memory leak when using user-defined Triton Kernel + AOTI.
+<<<<<<< HEAD
         if self.device != "cuda":
             raise unittest.SkipTest("requires CUDA")
+=======
+        device = torch.cuda.current_device()
+>>>>>>> c26135f9dc0 ([inductor] skip launching kernels with zero grid in AOTInductor when using backed symints)
 
         class Model(torch.nn.Module):
             def __init__(self):
@@ -1751,6 +1784,8 @@ CPU_TEST_FAILURES = {
         is_skip=True
     ),
     "test_simple_dynamic": fail_with_and_without_stack_allocation(),
+    "test_zero_grid_with_unbacked_symbols": fail_with_and_without_stack_allocation(is_skip=True),
+    "test_zero_grid_with_backed_symbols": fail_with_and_without_stack_allocation(is_skip=True),
 }
 
 CUDA_TEST_FAILURES = {
@@ -1780,6 +1815,7 @@ if TEST_WITH_ROCM:
             "test_foreach_multiple_dynamic": fail_cuda(is_skip=True),
             "test_reuse_kernel": fail_cuda(is_skip=True),
             "test_zero_grid_with_unbacked_symbols": fail_cuda(is_skip=True),
+            "test_zero_grid_with_backed_symbols": fail_cuda(is_skip=True),
         }
     )
 

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -712,8 +712,6 @@ class AOTInductorTestsTemplate:
                 d = (b + c) @ y
                 return d.sum()
 
-        # if self.device != "cuda":
-        #     raise unittest.SkipTest("requires CUDA")
         example_inputs = (
             torch.tensor([1, 1, 1], device=self.device),
             torch.randn((1, 32), dtype=torch.float16, device=self.device),
@@ -732,8 +730,9 @@ class AOTInductorTestsTemplate:
             x := torch.randn((3, 2), device=self.device),
             torch.randn((1, 2), device=self.device),
         )
-        torch._dynamo.mark_dynamic(x, index=0)
+        torch._dynamo.mark_dynamic(x, index=0) # Create dynamic symbol
 
+        # Compile & run model where dynamic dim size > 0.
         so_path: str = AOTIRunnerUtil.compile(
             Repro(),
             example_inputs,
@@ -741,6 +740,7 @@ class AOTInductorTestsTemplate:
         aot_inductor_module = AOTIRunnerUtil.load("cuda", so_path)
         aot_inductor_module(*example_inputs)
 
+        # Re-run where dynamic dim size is 0.
         example_inputs = (
             torch.randn((0, 2), device=self.device),
             torch.randn((1, 2), device=self.device),

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -730,7 +730,7 @@ class AOTInductorTestsTemplate:
             x := torch.randn((3, 2), device=self.device),
             torch.randn((1, 2), device=self.device),
         )
-        torch._dynamo.mark_dynamic(x, index=0) # Create dynamic symbol
+        torch._dynamo.mark_dynamic(x, index=0)  # Create dynamic symbol
 
         # Compile & run model where dynamic dim size > 0.
         so_path: str = AOTIRunnerUtil.compile(

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1780,8 +1780,12 @@ CPU_TEST_FAILURES = {
         is_skip=True
     ),
     "test_simple_dynamic": fail_with_and_without_stack_allocation(),
-    "test_zero_grid_with_unbacked_symbols": fail_with_and_without_stack_allocation(is_skip=True),
-    "test_zero_grid_with_backed_symbols": fail_with_and_without_stack_allocation(is_skip=True),
+    "test_zero_grid_with_unbacked_symbols": fail_with_and_without_stack_allocation(
+        is_skip=True
+    ),
+    "test_zero_grid_with_backed_symbols": fail_with_and_without_stack_allocation(
+        is_skip=True
+    ),
 }
 
 CUDA_TEST_FAILURES = {

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1616,12 +1616,8 @@ class AOTInductorTestsTemplate:
     @config.patch({"aot_inductor.abi_compatible": True})
     def test_triton_kernel_reinterpret_view_mem_leak(self):
         # Check for memory leak when using user-defined Triton Kernel + AOTI.
-<<<<<<< HEAD
         if self.device != "cuda":
             raise unittest.SkipTest("requires CUDA")
-=======
-        device = torch.cuda.current_device()
->>>>>>> c26135f9dc0 ([inductor] skip launching kernels with zero grid in AOTInductor when using backed symints)
 
         class Model(torch.nn.Module):
             def __init__(self):

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -3111,12 +3111,12 @@ class CudaWrapperCodeGen(CppWrapperCodeGen):
         ), f"expected grid to be a list or tuple but got: {grid=}"
 
         grid = [V.graph.sizevars.simplify(item) for item in grid]
-        grid_has_unbacked_symbols = any(free_unbacked_symbols(item) for item in grid)
+        grid_uses_symbolic_shapes = any(item.free_symbols for item in grid)
         grid_args = [self.grid_expr_printer(item) for item in grid]
         grid_args_str = ", ".join(grid_args)
         self.writeline(f"Grid {grid_name} = Grid({grid_args_str});")
 
-        if grid_has_unbacked_symbols:
+        if grid_uses_symbolic_shapes:
             self.writeline(f"if ({grid_name}.is_non_zero()) {{")
         kernel_var_name = f"kernels.{name}" if V.graph.aot_mode else name
         self.writeline(
@@ -3131,5 +3131,5 @@ class CudaWrapperCodeGen(CppWrapperCodeGen):
                 stream,
             )
         )
-        if grid_has_unbacked_symbols:
+        if grid_uses_symbolic_shapes:
             self.writeline("}")

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -30,7 +30,7 @@ from torch._dynamo.utils import counters, dynamo_timed
 from torch._inductor.codecache import get_cpp_wrapper_cubin_path_name
 
 from torch._inductor.codegen.multi_kernel import MultiKernelState
-from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols, SymTypes
+from torch.fx.experimental.symbolic_shapes import SymTypes
 from torch.fx.node import _get_qualified_name
 from torch.utils._sympy.singleton_int import SingletonInt
 


### PR DESCRIPTION
Like #110312 but we also run this check when backed symints are in the grid (e.g. s1 / 512)

### Why?

Let's say we lower a model and generate GPU kernel grid with symbolic shapes, for e.g. `s1 / 512`. If at some point later, we ran the lowered model with inputs s.t. `s1 = 0`, then we'll launch the kernel with a `0` sized grid. This surfaces as `CUDA driver error: invalid argument`.

To avoid this, we check for a `0` sized grid whenever there's symbolic shapes which includes backed and unbacked symints.

This adds non-zero overhead to the CPU. However, in return, we get better reliability when encountering this scenario. This scenario happened when serving an internal model.

### Test

```
$ python test/inductor/test_aot_inductor.py -k test_zero_grid_with_unbacked_symbols 
OK (skipped=3)

$ python test/inductor/test_aot_inductor.py -k test_zero_grid_with_backed_symbols

# Before
Error: CUDA driver error: invalid argument
FAILED (errors=2, skipped=3)

# Now
OK (skipped=3)
```

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118654



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov