### PR TITLE
[PT-Vulkan] aten::conv1d - support any stride, padding, dilation

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/conv1d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/conv1d.glsl
@@ -18,10 +18,20 @@ layout(set = 0, binding = 3) uniform PRECISION sampler3D uBias;
 
 layout(set = 0, binding = 4) uniform PRECISION restrict Block {
   int out_channels;
-  int in_lengths;
+  int in_length;
   int kernel_size;
+  int strides;
+  int padding;
+  int dilation;
 }
 uBlock;
+
+// In our shader's usage, both the numerator and denominator are int, so the
+// result of their division is already truncated to int. GLSL's ceil() expects
+// one float input, so instead we introduce our own helper.
+int ceil(int a, int b) {
+  return (a + b - 1) / b;
+}
 
 // This implementation optimize for simplicity (and partially performance) for a
 // (1, C, L) where C == groups. Hence we only focus on calculating the rolling
@@ -30,8 +40,11 @@ void main() {
   const ivec3 pos = ivec3(gl_GlobalInvocationID);
 
   const int out_channels = uBlock.out_channels;
-  const int in_lengths = uBlock.in_lengths;
+  const int in_length = uBlock.in_length;
   const int kernel_size = uBlock.kernel_size;
+  const int strides = uBlock.strides;
+  const int padding = uBlock.padding;
+  const int dilation = uBlock.dilation;
 
   // The global workgroup should have taken care of it. We only perform one
   // work item for each 1d tensor on lengths
@@ -52,10 +65,25 @@ void main() {
 
   vec4 bias = texelFetch(uBias, ivec3(c, 0, 0), 0);
 
-  for (int i = 0; i < in_lengths - kernel_size + 1; i++) {
+  // "i" tracks the input's start index for our input-kernel overlay region.
+  int start = -padding;
+  int end = in_length + padding - dilation * (kernel_size - 1);
+
+  // "r" tracks the output's index where we write our result.
+  int r = 0;
+
+  for (int i = start; i < end; i += strides, ++r) {
     vec4 v = vec4(0,0,0,0);
-    for (int k = 0; k < kernel_size; k++) {
-      const ivec3 in_pos = ivec3(i+k, c, 0);
+
+    // "k" tracks the kernel's index for our input-kernel computation.
+    // The kstart/kend borders detect when the corresponding input index is out
+    // of bounds.
+    int kstart = max(0, ceil(-i, dilation));
+    int kend = min(kernel_size, ceil(in_length-i, dilation));
+
+    for (int k = kstart; k < kend; ++k) {
+      int in_pos_x = i + k * dilation;
+      const ivec3 in_pos = ivec3(in_pos_x, c, 0);
       const vec4 input_value = texelFetch(uInput, in_pos, 0);
 
       // Note that we are reading weight in the inner loop, this could be
@@ -79,7 +107,7 @@ void main() {
       v += w * input_value.x;
     }
 
-    ivec3 out_pos = ivec3(i, c, 0);
+    ivec3 out_pos = ivec3(r, c, 0);
     imageStore(uOutput, out_pos, vec4(v.x + bias.x, 0, 0, 0));
   }
 }

--- a/aten/src/ATen/native/vulkan/ops/Convolution.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.cpp
@@ -834,16 +834,17 @@ Tensor quantized_convolution(
 
 namespace conv1d {
 
-// This implementation only cover a special case. It only supports
-// input = (n=1, input_channel, lengths)
-// ouput = (n=1, output_channel, lengths - kernel_size + 1)
-// stride=1, padding=0, dilation=1, groups=input_channels=output_channels
+// This implementation only supports
 //
-// Hence:
-// weight's shape should be (output_channel, 1, kernel_size)
-// bias's shape (if applicable) should be (output_channel,)
+// input = (n=1, channels, length)
+// output = (n=1, channels, out_length)
 //
-// In this implementation, it reduces to running a 1d convolution for reach
+// where channels = groups. Hence, the shapes we receive should obey:
+//
+// weight = (channels, 1, kernel_size)
+// bias = (channels,)
+//
+// In this implementation, it reduces to running a 1d convolution for each
 // channel.
 // There are multiple perf improvement opportunities: e.g. width-packing
 // input and weight tensors, batch reading when groups is low.
@@ -880,9 +881,6 @@ Tensor run_conv1d_context_impl(
 
   TORCH_CHECK(input.dim() == 3, "input must be a 3-dim tensor");
   TORCH_CHECK(weight.dim() == 3, "weight must be a 3-dim tensor");
-  TORCH_CHECK(stride == IntArrayRef(1), "stride must be 1");
-  TORCH_CHECK(padding == IntArrayRef(0), "padding must be 0");
-  TORCH_CHECK(dilation == IntArrayRef(1), "dilation must be 1");
 
   TORCH_CHECK(input_sizes[0] == 1, "Only support single batch");
   TORCH_CHECK(input_sizes[1] == groups, "input_channel must equals to groups");
@@ -891,29 +889,29 @@ Tensor run_conv1d_context_impl(
   TORCH_CHECK(weight_sizes[1] == 1, "weight.sizes()[1] must equals to 1");
 
   const vTensor& v_input = convert(input);
-  const IntArrayRef v_input_sizes = v_input.sizes();
-
   const vTensor& v_weight = convert(weight);
   const vTensor& v_bias = convert(bias);
 
   vTensor v_output{
       context,
-      {
-          v_input_sizes[0],
-          weight_out_channels,
-          v_input_sizes[2] - kernel_size + 1,
-      },
+      conv_output_size(input_sizes, weight_sizes, padding, stride, dilation),
       v_input.dtype(),
   };
 
   const struct Block final {
     int32_t out_channels;
-    int32_t in_lengths;
+    int32_t in_length;
     int32_t kernel_size;
+    int32_t stride;
+    int32_t padding;
+    int32_t dilation;
   } block{
       weight_out_channels,
       static_cast<int32_t>(input_sizes[2]),
       kernel_size,
+      static_cast<int32_t>(stride[0]),
+      static_cast<int32_t>(padding[0]),
+      static_cast<int32_t>(dilation[0]),
   };
 
   api::UniformParamsBuffer params(context, block);

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -1394,20 +1394,15 @@ TEST_F(VulkanAPITest, conv1d_simple) {
   const auto weights_vk = weights_cpu.vulkan();
   const auto bias_vk = bias_cpu.vulkan();
 
-  std::array<int64_t, 1> stride{1};
-  std::array<int64_t, 1> padding{0};
-  std::array<int64_t, 1> dilation{1};
+  int64_t stride = 1;
+  int64_t padding = 0;
+  int64_t dilation = 1;
 
   const auto output_cpu = at::conv1d(
-      input_cpu, weights_cpu, bias_cpu,
-      stride, padding, dilation, channels);
+      input_cpu, weights_cpu, bias_cpu, stride, padding, dilation, channels);
 
   const auto output_vk = at::conv1d(
-      input_vk, weights_vk, bias_vk,
-      stride,
-      padding,
-      dilation,
-      channels);
+      input_vk, weights_vk, bias_vk, stride, padding, dilation, channels);
   const auto output_vk_cpu = output_vk.cpu();
 
   const bool check = almostEqual(output_cpu, output_vk_cpu);
@@ -1418,7 +1413,13 @@ TEST_F(VulkanAPITest, conv1d_simple) {
   ASSERT_TRUE(check);
 }
 
-void test_conv1d(int64_t kernel_size, int64_t channels, int64_t lengths) {
+void test_conv1d(
+    int64_t kernel_size,
+    int64_t channels,
+    int64_t lengths,
+    int64_t stride = 1,
+    int64_t padding = 0,
+    int64_t dilation = 1) {
   c10::InferenceMode mode;
 
   const auto input_cpu = at::rand({1, channels, lengths}, at::kFloat);
@@ -1429,21 +1430,11 @@ void test_conv1d(int64_t kernel_size, int64_t channels, int64_t lengths) {
   const auto weights_vk = weights_cpu.vulkan();
   const auto bias_vk = bias_cpu.vulkan();
 
-  std::array<int64_t, 1> stride{1};
-  std::array<int64_t, 1> padding{0};
-  std::array<int64_t, 1> dilation{1};
-  int64_t groups = channels;
-
   const auto output_cpu = at::conv1d(
-      input_cpu, weights_cpu, bias_cpu,
-      stride, padding, dilation, groups);
+      input_cpu, weights_cpu, bias_cpu, stride, padding, dilation, channels);
 
   const auto output_vk = at::conv1d(
-      input_vk, weights_vk, bias_vk,
-      stride,
-      padding,
-      dilation,
-      channels);
+      input_vk, weights_vk, bias_vk, stride, padding, dilation, channels);
   const auto output_vk_cpu = output_vk.cpu();
 
   const bool check = almostEqual(output_cpu, output_vk_cpu);
@@ -1460,6 +1451,11 @@ TEST_F(VulkanAPITest, conv1d) {
   test_conv1d(1, 12, 3);
   test_conv1d(1, 12, 1);
   test_conv1d(10, 12, 20);
+  test_conv1d(3, 5, 9, 2, 0, 1);
+  test_conv1d(3, 5, 9, 2, 1, 1);
+  test_conv1d(3, 5, 9, 2, 1, 2);
+  test_conv1d(3, 5, 9, 1, 4, 2);
+  test_conv1d(6, 22, 30, 5, 5, 3);
 }
 
 


### PR DESCRIPTION
Summary:
This diff stack builds on yipjustin's initial special-case implementation: D50914117.

That special-case only covers
```
strides = 1
padding = 0
dilation = 1
in_channels = out_channels = groups
n = 1
```

Test Plan:
```
[jorgep31415@161342.od /data/sandcastle/boxes/fbsource (a0b8b9b7f)]$ LD_LIBRARY_PATH=third-party/swiftshader/lib/linux-x64/ buck2 run fbcode/mode/dev-nosan //xplat/caffe2:pt_vulkan_api_test_bin -- --gtest_filter="*conv1d*"
File changed: fbsource//xplat/caffe2/aten/src/ATen/native/vulkan/glsl/conv1d.glsl
File changed: fbcode//caffe2/aten/src/ATen/test/vulkan_api_test.cpp
File changed: fbcode//caffe2/aten/src/ATen/native/vulkan/glsl/conv1d.glsl
3 additional file change events
Buck UI: https://www.internalfb.com/buck2/ebb61796-c71d-4e0c-8148-de1eb67b5d4c
Network: Up: 10KiB  Down: 53MiB  (reSessionID-5f852cf6-9bf1-4c73-a471-4c121b53ed62)
Jobs completed: 16. Time elapsed: 21.6s.
Cache hits: 43%. Commands: 7 (cached: 3, remote: 0, local: 4)
BUILD SUCCEEDED
Running main() from third-party/googletest/1.14.0/googletest/googletest/src/gtest_main.cc
Note: Google Test filter = *conv1d*
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.conv1d_simple
[       OK ] VulkanAPITest.conv1d_simple (136 ms)
[ RUN      ] VulkanAPITest.conv1d
[       OK ] VulkanAPITest.conv1d (35 ms)
[----------] 2 tests from VulkanAPITest (172 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (172 ms total)
[  PASSED  ] 2 tests.
```

Reviewed By: yipjustin

Differential Revision: D53204673


