### PR TITLE
Remove `voznesenskym` from the list of autoreviewers

### DIFF
--- a/.github/auto_request_review.yml
+++ b/.github/auto_request_review.yml
@@ -6,7 +6,6 @@ reviewers:
       - albanD
       - miladm
       - bdhirsh
-      - voznesenskym
 
   per_author:
     symbolic-shapes:


### PR DESCRIPTION
Mitigates the failures of "Auto Request Review" workflow:
```
Requesting review to ezyang, albanD, miladm, voznesenskym, antoniojkim, SherlockNoMad
Error: HttpError: Reviews may only be requested from collaborators. One or more of the users or teams you specified is not a collaborator of the pytorch/pytorch repository.
```
https://github.com/pytorch/pytorch/actions/runs/7716852492/job/21034629665?pr=118669