### PR TITLE
[ROCm] CatArrayBatchedCopy performance improvement

### DIFF
--- a/aten/src/ATen/native/cuda/Shape.cu
+++ b/aten/src/ATen/native/cuda/Shape.cu
@@ -345,9 +345,14 @@ void parallel_cat(const Tensor &out, const MaterializedITensorListRef& inputs, i
       catMetaData.dimSize[batchCounter] = dimSize;
       catMetaData.nElements[batchCounter] = inputs[i+batchCounter].get().numel();
 
+#ifdef USE_ROCM
+      // On ROCm, CatArrayBatchedCopy_contig is faster
+      isAligned = false;
+#else
       // If at least one of the inputs is not aligned, we can't call the
       // CatArrayBatchedCopy_aligned16_contig
       isAligned &= is_aligned_vec4(catMetaData.input[batchCounter]);
+#endif
 
       if (stride_size > 1) {
         auto strides = inputs[i+batchCounter].get().strides();

--- a/aten/src/ATen/native/cuda/Shape.cu
+++ b/aten/src/ATen/native/cuda/Shape.cu
@@ -52,6 +52,28 @@ inline bool getCatGrid(ptrdiff_t nTensors, dim3& grid) {
 }
 
 template<typename T>
+inline std::tuple<dim3, dim3> getCatGridRocm(unsigned int max_elements_per_tensor,
+  ptrdiff_t nTensors) {
+  constexpr unsigned int threads_per_block = 256;
+  constexpr unsigned int elements_per_thread = 8;
+  constexpr unsigned int max_tb_per_sm = 32;
+
+  unsigned int max_threads = ceil_div(max_elements_per_tensor, elements_per_thread);
+  unsigned int thread_blocks = ceil_div(max_threads, threads_per_block);
+
+  // Limit the number of thread blocks to prevent too many threads to load the metadata
+  // if they operate on very small tensors.
+
+  const unsigned int num_sm = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
+  thread_blocks = std::min(num_sm * max_tb_per_sm, thread_blocks);
+
+  dim3 block = dim3(threads_per_block);
+  dim3 grid = dim3(thread_blocks, (long long)nTensors);
+
+  return std::make_tuple(grid, block);
+}
+
+template<typename T>
 inline std::tuple<dim3, dim3> getCatGridContig(unsigned int max_elements_per_tensor,
   ptrdiff_t nTensors) {
   constexpr unsigned int threads_per_block = 128;
@@ -173,6 +195,34 @@ __global__ void CatArrayBatchedCopy(
         output[dataOffset + elementOffset] = data[inElementOffset];
       }
     tid += stride;
+    }
+}
+
+template <typename T, typename IndexType, int Dims, int batch_size, int stride_size>
+__global__ void CatArrayBatchedCopy_contig(
+    T* output,
+    CatArrInputTensorMetadata<T, IndexType, batch_size, stride_size> inputs,
+    TensorSizeStride<IndexType, CAT_ARRAY_MAX_INPUT_DIMS> os,
+    const int concatDim,
+    IndexType dimStride) {
+
+    IndexType tid = blockIdx.x * blockDim.x + threadIdx.x;
+    IndexType nElements = inputs.nElements[blockIdx.y];
+
+    if(tid >= nElements) return;
+
+    const T* data = inputs.input[blockIdx.y];
+    IndexType offset = inputs.offset[blockIdx.y];
+    IndexType dimSize = inputs.dimSize[blockIdx.y];
+    IndexType dataOffset = offset * dimStride;
+
+    IndexType stride = gridDim.x * blockDim.x;
+
+    while( tid < nElements){
+      IndexType elementOffset = CatArrIndexToOffset<IndexType, Dims>::compute(
+                    os.tensorSize, os.tensorStride, dimSize, concatDim, tid);
+      output[dataOffset + elementOffset] = data[tid];
+      tid += stride;
     }
 }
 
@@ -326,6 +376,15 @@ void parallel_cat(const Tensor &out, const MaterializedITensorListRef& inputs, i
 
     dim3 applyBlock, catGrid;
 
+#ifdef USE_ROCM
+    // always base grid size on max_elements_per_tensor
+    {
+      std::tuple<dim3, dim3> launchParams = getCatGridRocm<scalar_t>(
+          max_elements_per_tensor, batchCounter);
+      catGrid = std::get<0>(launchParams);
+      applyBlock = std::get<1>(launchParams);
+    }
+#else
     if (isContig && sizeof(scalar_t) > 2) {
       std::tuple<dim3, dim3> launchParams = getCatGridContig<scalar_t>(
           max_elements_per_tensor, batchCounter);
@@ -335,6 +394,7 @@ void parallel_cat(const Tensor &out, const MaterializedITensorListRef& inputs, i
       applyBlock = dim3(32 * 16);
       getCatGrid(batchCounter, catGrid);
     }
+#endif
 
     if (memory_format != c10::MemoryFormat::Contiguous) {
       switch (dimension) {
@@ -351,6 +411,10 @@ void parallel_cat(const Tensor &out, const MaterializedITensorListRef& inputs, i
 #define HANDLE_CASE(DIMS) \
     if (isContig && isAligned && sizeof(scalar_t) >= 4 && sizeof(scalar_t) <= 8) {\
       CatArrayBatchedCopy_aligned16_contig<scalar_t, unsigned int, DIMS, batch_size, stride_size><<<\
+          catGrid, applyBlock, 0, stream.stream()>>>(\
+              data, catMetaData, outputParam, dimension, outputParam.tensorStride[dimension]);\
+    } else if (isContig) {\
+      CatArrayBatchedCopy_contig<scalar_t, unsigned int, DIMS, batch_size, stride_size><<<\
           catGrid, applyBlock, 0, stream.stream()>>>(\
               data, catMetaData, outputParam, dimension, outputParam.tensorStride[dimension]);\
     } else {\


### PR DESCRIPTION
Tune the grid and block sizes for ROCm.  Add a contig kernel separate from aligned+contig.

Verified new performance using pytorch/benchmarks/operator_benchmark.

`python -m pt.cat_test --device=cuda --tag-filter all`

On MI200 this improved performance on average 4%, and on MI300 14%.

cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang