### PR TITLE
Add a trigger to create release when the release is edited

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -5,8 +5,9 @@ on:
     branches:
       - main
       - release/*
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
   release:
-    types: [published]
+    types: [published, edited]
   pull_request:
     paths: [.github/workflows/create_release.yml]
 


### PR DESCRIPTION
After https://github.com/pytorch/pytorch/pull/118681, I thought that I could edit the release slightly to re-trigger the job, but it didn't work that way because that's a different event https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release