### PR TITLE
[NCCL] Revive past behavior of aborting a comm on all intra-node ranks

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -462,6 +462,7 @@ ProcessGroupNCCL::WorkNCCL::WorkNCCL(const WorkNCCL& w)
       numelIn_(w.numelIn_),
       numelOut_(w.numelOut_),
       store_(w.store_),
+      abortedComms_(w.abortedComms_),
       timingEnabled_(w.timingEnabled_),
       trace_id_(w.trace_id_),
       distDebugLevel_(w.distDebugLevel_) {
@@ -1535,7 +1536,7 @@ void ProcessGroupNCCL::watchdogHandler() {
           }
           abortedComms_.emplace(commId);
          LOG(ERROR) << logPrefix() << "Aborted key in store: " << storeKey << ".";
-        } catch (std::exception& e) {
+        } catch (c10::Error& e) {
           VLOG(1) << "Did not find key in store: " << storeKey << ",  error: " << e.what();
         }
       }

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -388,6 +388,7 @@ at::Device ProcessGroupNCCL::guessDeviceForRank() const {
 }
 
 const int64_t ProcessGroupNCCL::kWatchdogThreadSleepMillis = 100;
+const int64_t ProcessGroupNCCL::kWaitForAbortCommStoreKey = ProcessGroupNCCL::kWatchdogThreadSleepMillis / 10;
 constexpr int64_t kSynchronizeBusyWaitMillis = 10;
 thread_local uint64_t ProcessGroupNCCL::ncclActiveGroupCounter_ = 0;
 
@@ -702,6 +703,14 @@ bool ProcessGroupNCCL::WorkNCCL::wait(std::chrono::milliseconds timeout) {
 void ProcessGroupNCCL::WorkNCCL::abort() {
   // Abort all communicators of this work
   for (const auto& ncclComm : ncclComms_) {
+    LOG(INFO) << logPrefix() << "Aborting comm" << std::endl;
+    auto abortedCommId = buildNcclUniqueIdStr(ncclComm->getNcclId());
+    auto storeKey = getNcclAbortedCommStoreKey(abortedCommId);
+    TORCH_INTERNAL_ASSERT(store_);
+    TORCH_INTERNAL_ASSERT(abortedComms_);
+    abortedComms_->emplace(abortedCommId);
+    store_->set(storeKey, "");
+    LOG(INFO) << logPrefix() << "Wrote aborted comm " << storeKey << std::endl;
     ncclComm->ncclCommAbort();
   }
 
@@ -1497,6 +1506,41 @@ void ProcessGroupNCCL::watchdogHandler() {
     dumpPipe.emplace(rank_);
   }
   while (!done || !terminateProcessGroup_.load()) {
+    std::unordered_set<std::string> allCommIds;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        for (auto it = devNCCLCommMap_.begin(); it != devNCCLCommMap_.end(); it++) {
+          auto& ncclComms = it->second;
+          for (const auto& ncclComm : ncclComms) {
+              allCommIds.emplace(buildNcclUniqueIdStr(ncclComm->getNcclId()));
+          }
+        }
+    }
+    // Abort communicators that have been aborted on other ranks
+    // Otherwise the other ranks may hang indefinitely
+    for (const auto& commId : allCommIds) {
+      // If not already aborted
+      if (abortedComms_.find(commId) == abortedComms_.end()) {
+        const auto& storeKey = getNcclAbortedCommStoreKey(commId);
+        try {
+          store_->wait(
+            {storeKey},
+            std::chrono::milliseconds(kWaitForAbortCommStoreKey));
+          std::lock_guard<std::mutex> lock(mutex_);
+          LOG(ERROR) << logPrefix() << "Found key in store: " << storeKey << ", aborting communicators...";
+          auto it = ncclIdToCommMap_.find(commId);
+          TORCH_INTERNAL_ASSERT(it != ncclIdToCommMap_.end());
+          for (const auto& ncclComm: it->second) {
+            ncclComm->ncclCommAbort();
+          }
+          abortedComms_.emplace(commId);
+         LOG(ERROR) << logPrefix() << "Aborted key in store: " << storeKey << ".";
+        } catch (std::exception& e) {
+          VLOG(1) << "Did not find key in store: " << storeKey << ",  error: " << e.what();
+        }
+      }
+    }
+
     std::unique_lock<std::mutex> lock(workMetaListMutex_);
     // We busy-poll the work vector every kWatchdogThreadSleepMillis
     // milliseconds as long as the atomic is True.
@@ -2361,6 +2405,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::endCoalescing() {
   work->avoidRecordStreams_ = avoidRecordStreams_;
   work->opTimeout_ = options_->timeout;
   work->store_ = store_;
+  work->abortedComms_ = &abortedComms_;
   if (avoidRecordStreams_) {
     // other functions expect an initialized ptr if avoidRecordStreams_ is set
     work->stashed_for_allocator_safety_ =
@@ -2556,6 +2601,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collective(
   work->avoidRecordStreams_ = avoidRecordStreams;
   work->opTimeout_ = options_->timeout;
   work->store_ = store_;
+  work->abortedComms_ = &abortedComms_;
   // Record size info for debug. We only record the size on the first device as
   // multi-device per process is deprecated
   work->numelIn_ = inputs[0].numel();
@@ -2713,6 +2759,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::pointToPoint(
     work->blockingWait_ = blockingWait_;
     work->opTimeout_ = options_->timeout;
     work->store_ = store_;
+    work->abortedComms_ = &abortedComms_;
   }
 
   // Record size info for debug. We only record the size on the first device as

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -313,6 +313,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
     // Reference to the store so that we can write aborted communicators
     // to the store.
     c10::intrusive_ptr<Store> store_;
+    std::unordered_set<std::string>* abortedComms_ = NULL;
 
     // Store a reference to NCCL collective's outputs, used by result and to
     // give a more descriptive message when representing the Work as a string.
@@ -740,6 +741,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   virtual std::string getNCCLWatchdogDebugInfo();
 
   static const int64_t kWatchdogThreadSleepMillis;
+  static const int64_t kWaitForAbortCommStoreKey;
 
   // The store is used to broadcast the NCCL unique ID of rank 0. This store
   // comes with prefix and it is different across ProcessGroup NCCL instances


### PR DESCRIPTION
NCCL has given us feedback that it's now expected that when a communicator is aborted, it's aborted in all ranks.
We've observed a hang in e.g., `test_nccl_propagate_error_reason` that stems from the communicators not being aborted when testing against versions of NCCL newer than 2.19.3 that seem to have this constraint as a hard requirement.

This PR readds the mechanism originally added in #32895 (and removed I believe in #97066). One issue I noticed is that even if #97066 did not remove the abort logic entirely, the implementation as it stood wouldn't cover the use case of this hang, as aborted comms are only checked in `synchronizeInternal`. Here, that logic is moved back to the main watchdog loop as was the case in #32895.

We might consider a follow-up of more rigorously ensuring that all aborted communicators in all code paths are "registered" via this mechanism, not just those aborted from a `WorkNCCL` timeout.

CC @Aidyn-A @ptrblck @kwen2501 @pritamdamania87 

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang