### PR TITLE
Fix for assertion of docstring existence in distributed/rpc/api.py when python is compiled --without-doc-strings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -650,8 +650,6 @@ coverage_ignore_functions = [
     "rendezvous",
     # torch.distributed.rpc.api
     "get_worker_info",
-    "method_factory",
-    "new_method",
     "remote",
     "rpc_async",
     "rpc_sync",

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -1,5 +1,5 @@
 __all__ = ["shutdown", "get_worker_info", "remote", "rpc_sync",
-           "rpc_async", "RRef", "AllGatherStates", "method_factory", "new_method"]
+           "rpc_async", "RRef", "AllGatherStates"]
 
 import collections
 import contextlib
@@ -490,7 +490,7 @@ else:
 # under `.. autoclass:: RRef` does not work.
 # we have to do the following process to replace `rpc.PyRRef` with `rpc.RRef`.
 #
-def method_factory(method_name, docstring):
+def _method_factory(method_name, docstring):
     def method(self, *args, **kwargs):
         return getattr(super(RRef, self), method_name)(*args, **kwargs)
 
@@ -521,7 +521,7 @@ def _update_PyRRef_docstrings():
         docstring = docstring.replace("torch.distributed.rpc.PyRRef", "torch.distributed.rpc.RRef")
 
         # Attach user-facing RRef method with modified docstring.
-        new_method = method_factory(method_name, docstring)
+        new_method = _method_factory(method_name, docstring)
         setattr(RRef, method_name, new_method)
 
 


### PR DESCRIPTION
Fixes #51778

I extracted the docstring check and update into a method and added a guard to stop it being run if python was compiled without docstirngs. 

The second commit was some boy scouting around the public interface as method_factory was only used inside the module and new_method did not exist.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang