### PR TITLE
Use MKL_INT in MKL wrapper interfaces

### DIFF
--- a/aten/src/ATen/native/mkl/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/mkl/LinearAlgebra.cpp
@@ -8,41 +8,41 @@ namespace at { namespace native {
 
 void mkl_gemm_batched(
     const TransposeType trans_A, const TransposeType trans_B,
-    const int batch_size, const int M, const int N, const int K, const float alpha,
-    const float** A, const int lda, const float** B, const int ldb, const float beta,
-    float** C, const int ldc) {
+    const MKL_INT batch_size, const MKL_INT M, const MKL_INT N, const MKL_INT K, const float alpha,
+    const float** A, const MKL_INT lda, const float** B, const MKL_INT ldb, const float beta,
+    float** C, const MKL_INT ldc) {
   TORCH_INTERNAL_ASSERT(false, "mkl_gemm_batched: ATen not compiled with MKL support");
 }
 
 void mkl_gemm_batched(
     const TransposeType trans_A, const TransposeType trans_B,
-    const int batch_size, const int M, const int N, const int K, const double alpha,
-    const double** A, const int lda, const double** B, const int ldb, const double beta,
-    double** C, const int ldc) {
+    const MKL_INT batch_size, const MKL_INT M, const MKL_INT N, const MKL_INT K, const double alpha,
+    const double** A, const MKL_INT lda, const double** B, const MKL_INT ldb, const double beta,
+    double** C, const MKL_INT ldc) {
   TORCH_INTERNAL_ASSERT(false, "mkl_gemm_batched: ATen not compiled with MKL support");
 }
 
 void mkl_gemm_batched(
     const TransposeType trans_A, const TransposeType trans_B,
-    const int batch_size, const int M, const int N, const int K, const c10::complex<float> alpha,
-    const c10::complex<float>** A, const int lda, const c10::complex<float>** B, const int ldb,
-    const c10::complex<float> beta, c10::complex<float>** C, const int ldc) {
+    const MKL_INT batch_size, const MKL_INT M, const MKL_INT N, const MKL_INT K, const c10::complex<float> alpha,
+    const c10::complex<float>** A, const MKL_INT lda, const c10::complex<float>** B, const MKL_INT ldb,
+    const c10::complex<float> beta, c10::complex<float>** C, const MKL_INT ldc) {
   TORCH_INTERNAL_ASSERT(false, "mkl_gemm_batched: ATen not compiled with MKL support");
 }
 
 void mkl_gemm_batched(
     const TransposeType trans_A, const TransposeType trans_B,
-    const int batch_size, const int M, const int N, const int K, const c10::complex<double> alpha,
-    const c10::complex<double>** A, const int lda, const c10::complex<double>** B, const int ldb,
-    const c10::complex<double> beta, c10::complex<double>** C, const int ldc) {
+    const MKL_INT batch_size, const MKL_INT M, const MKL_INT N, const MKL_INT K, const c10::complex<double> alpha,
+    const c10::complex<double>** A, const MKL_INT lda, const c10::complex<double>** B, const MKL_INT ldb,
+    const c10::complex<double> beta, c10::complex<double>** C, const MKL_INT ldc) {
   TORCH_INTERNAL_ASSERT(false, "mkl_gemm_batched: ATen not compiled with MKL support");
 }
 
 void mkl_gemm_bf16bf16f32(
     TransposeType trans_A, TransposeType trans_B,
-    int M, int N, int K, const float alpha,
-    const c10::BFloat16* A, int lda, const c10::BFloat16* B, int ldb,
-    const float beta, float* C, int ldc) {
+    MKL_INT M, MKL_INT N, MKL_INT K, const float alpha,
+    const c10::BFloat16* A, MKL_INT lda, const c10::BFloat16* B, MKL_INT ldb,
+    const float beta, float* C, MKL_INT ldc) {
   TORCH_INTERNAL_ASSERT(false, "mkl_gemm_bf16bf16f32: ATen not compiled with MKL support");
 }
 
@@ -66,9 +66,9 @@ static CBLAS_TRANSPOSE to_cblas(TransposeType x) {
 
 void mkl_gemm_batched(
     const TransposeType trans_A, const TransposeType trans_B,
-    const int batch_size, const int M, const int N, const int K, const float alpha,
-    const float** A, const int lda, const float** B, const int ldb, const float beta,
-    float** C, const int ldc) {
+    const MKL_INT batch_size, const MKL_INT M, const MKL_INT N, const MKL_INT K, const float alpha,
+    const float** A, const MKL_INT lda, const float** B, const MKL_INT ldb, const float beta,
+    float** C, const MKL_INT ldc) {
   auto transa_cblas = to_cblas(trans_A);
   auto transb_cblas = to_cblas(trans_B);
   cblas_sgemm_batch(CblasColMajor, &transa_cblas, &transb_cblas, &M, &N, &K, &alpha,
@@ -77,9 +77,9 @@ void mkl_gemm_batched(
 
 void mkl_gemm_batched(
     const TransposeType trans_A, const TransposeType trans_B,
-    const int batch_size, const int M, const int N, const int K, const double alpha,
-    const double** A, const int lda, const double** B, const int ldb, const double beta,
-    double** C, const int ldc) {
+    const MKL_INT batch_size, const MKL_INT M, const MKL_INT N, const MKL_INT K, const double alpha,
+    const double** A, const MKL_INT lda, const double** B, const MKL_INT ldb, const double beta,
+    double** C, const MKL_INT ldc) {
   auto transa_cblas = to_cblas(trans_A);
   auto transb_cblas = to_cblas(trans_B);
   cblas_dgemm_batch(CblasColMajor, &transa_cblas, &transb_cblas, &M, &N, &K, &alpha,
@@ -88,9 +88,9 @@ void mkl_gemm_batched(
 
 void mkl_gemm_batched(
     const TransposeType trans_A, const TransposeType trans_B,
-    const int batch_size, const int M, const int N, const int K, const c10::complex<float> alpha,
-    const c10::complex<float>** A, const int lda, const c10::complex<float>** B, const int ldb,
-    const c10::complex<float> beta, c10::complex<float>** C, const int ldc) {
+    const MKL_INT batch_size, const MKL_INT M, const MKL_INT N, const MKL_INT K, const c10::complex<float> alpha,
+    const c10::complex<float>** A, const MKL_INT lda, const c10::complex<float>** B, const MKL_INT ldb,
+    const c10::complex<float> beta, c10::complex<float>** C, const MKL_INT ldc) {
   auto transa_cblas = to_cblas(trans_A);
   auto transb_cblas = to_cblas(trans_B);
   cblas_cgemm_batch(CblasColMajor, &transa_cblas, &transb_cblas, &M, &N, &K,
@@ -101,9 +101,9 @@ void mkl_gemm_batched(
 
 void mkl_gemm_batched(
     const TransposeType trans_A, const TransposeType trans_B,
-    const int batch_size, const int M, const int N, const int K, const c10::complex<double> alpha,
-    const c10::complex<double>** A, const int lda, const c10::complex<double>** B, const int ldb,
-    const c10::complex<double> beta, c10::complex<double>** C, const int ldc) {
+    const MKL_INT batch_size, const MKL_INT M, const MKL_INT N, const MKL_INT K, const c10::complex<double> alpha,
+    const c10::complex<double>** A, const MKL_INT lda, const c10::complex<double>** B, const MKL_INT ldb,
+    const c10::complex<double> beta, c10::complex<double>** C, const MKL_INT ldc) {
   auto transa_cblas = to_cblas(trans_A);
   auto transb_cblas = to_cblas(trans_B);
   cblas_zgemm_batch(CblasColMajor, &transa_cblas, &transb_cblas, &M, &N, &K,
@@ -114,9 +114,9 @@ void mkl_gemm_batched(
 
 void mkl_gemm_bf16bf16f32(
     TransposeType trans_A, TransposeType trans_B,
-    int M, int N, int K, const float alpha,
-    const c10::BFloat16* A, int lda, const c10::BFloat16* B, int ldb,
-    const float beta, float* C, int ldc) {
+    MKL_INT M, MKL_INT N, MKL_INT K, const float alpha,
+    const c10::BFloat16* A, MKL_INT lda, const c10::BFloat16* B, MKL_INT ldb,
+    const float beta, float* C, MKL_INT ldc) {
 #ifdef MKL_HAS_SBGEMM
   auto transa_cblas = to_cblas(trans_A);
   auto transb_cblas = to_cblas(trans_B);

--- a/aten/src/ATen/native/mkl/LinearAlgebra.h
+++ b/aten/src/ATen/native/mkl/LinearAlgebra.h
@@ -1,39 +1,46 @@
 #pragma once
+#include <ATen/Config.h>
 #include <ATen/native/TransposeType.h>
 #include <c10/util/complex.h>
 #include <c10/core/ScalarType.h>
+
+#if !AT_MKL_ENABLED()
+#define MKL_INT int
+#else
+#include <mkl.h>
+#endif
 
 namespace at {
 namespace native {
 
 void mkl_gemm_batched(
     TransposeType trans_A, TransposeType trans_B,
-    int batch_size, int M, int N, int K, float alpha,
-    const float** A, int lda, const float** B, int ldb, float beta,
-    float** C, int ldc);
+    MKL_INT batch_size, MKL_INT M, MKL_INT N, MKL_INT K, float alpha,
+    const float** A, MKL_INT lda, const float** B, MKL_INT ldb, float beta,
+    float** C, MKL_INT ldc);
 
 void mkl_gemm_batched(
     TransposeType trans_A, TransposeType trans_B,
-    int batch_size, int M, int N, int K, double alpha,
-    const double** A, int lda, const double** B, int ldb, double beta,
-    double** C, int ldc);
+    MKL_INT batch_size, MKL_INT M, MKL_INT N, MKL_INT K, double alpha,
+    const double** A, MKL_INT lda, const double** B, MKL_INT ldb, double beta,
+    double** C, MKL_INT ldc);
 
 void mkl_gemm_batched(
     TransposeType trans_A, TransposeType trans_B,
-    int batch_size, int M, int N, int K, c10::complex<float> alpha,
-    const c10::complex<float>** A, int lda, const c10::complex<float>** B, int ldb,
-    c10::complex<float> beta, c10::complex<float>** C, int ldc);
+    MKL_INT batch_size, MKL_INT M, MKL_INT N, MKL_INT K, c10::complex<float> alpha,
+    const c10::complex<float>** A, MKL_INT lda, const c10::complex<float>** B, MKL_INT ldb,
+    c10::complex<float> beta, c10::complex<float>** C, MKL_INT ldc);
 
 void mkl_gemm_batched(
     TransposeType trans_A, TransposeType trans_B,
-    int batch_size, int M, int N, int K, c10::complex<double> alpha,
-    const c10::complex<double>** A, int lda, const c10::complex<double>** B, int ldb,
-    c10::complex<double> beta, c10::complex<double>** C, int ldc);
+    MKL_INT batch_size, MKL_INT M, MKL_INT N, MKL_INT K, c10::complex<double> alpha,
+    const c10::complex<double>** A, MKL_INT lda, const c10::complex<double>** B, MKL_INT ldb,
+    c10::complex<double> beta, c10::complex<double>** C, MKL_INT ldc);
 
 void mkl_gemm_bf16bf16f32(
     TransposeType trans_A, TransposeType trans_B,
-    int M, int N, int K, const float alpha,
-    const c10::BFloat16* A, int lda, const c10::BFloat16* B, int ldb,
-    const float beta, float* C, int ldc);
+    MKL_INT M, MKL_INT N, MKL_INT K, const float alpha,
+    const c10::BFloat16* A, MKL_INT lda, const c10::BFloat16* B, MKL_INT ldb,
+    const float beta, float* C, MKL_INT ldc);
 
 }}  // namespace at::native


### PR DESCRIPTION
I encountered the error when built PyTorch on Windows MKL:

```
pytorch\aten\src\ATen\native\mkl\LinearAlgebra.cpp(74): error C2664: “void cblas_sgemm_batch(const CBLAS_LAYOUT,const CBLAS_TRANSPOSE *,const CBLAS_TRANSPOSE *,const __int64 *,const __int64 *,const __int64 *,const float *,const float **,const __int64 *,const float **,const __int64 *,const float *,float **,const __int64 *,const __int64,const __int64 *) noexcept”: 无法将参数 4 从“const int *”转换为“const __int64 *”
pytorch\aten\src\ATen\native\mkl\LinearAlgebra.cpp(74): note: 指向的类型不相关; 转换需要 reinterpret_cast、C 样式强制转换或带圆括号的函数样式强制转换
C:\Program Files (x86)\Intel\oneAPI\2024.0\include\mkl_cblas.h(550): note: 参见“cblas_sgemm_batch”的声明
```
This was because MKL_INT was defined as int64_t. This PR tries to use MKL_INT.
