### PR TITLE
Add torch.cuda.max_clock_rate

### DIFF
--- a/docs/source/cuda.rst
+++ b/docs/source/cuda.rst
@@ -36,6 +36,7 @@ torch.cuda
     temperature
     power_draw
     clock_rate
+    max_clock_rate
     OutOfMemoryError
 
 Random Number Generator

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3888,6 +3888,10 @@ class TestCudaMallocAsync(TestCase):
     def test_clock_speed(self):
         self.assertTrue(torch.cuda.clock_rate() >= 0)
 
+    @unittest.skipIf(TEST_PYNVML, "pynvml is not available")
+    def test_max_clock_speed(self):
+        self.assertTrue(torch.cuda.clock_rate() >= 0)
+
 
 MIN_BLOCK_SIZE = 512
 SMALL_SIZE = 1048576

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -2361,6 +2361,7 @@ torch_non_c_binding_in_graph_functions = {
         "torch.cuda.can_device_access_peer",
         "torch.cuda.check_error",
         "torch.cuda.clock_rate",
+        "torch.cuda.max_clock_rate",
         "torch.cuda.cudart",
         "torch.cuda.current_blas_handle",
         "torch.cuda.current_stream",

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1159,7 +1159,7 @@ def get_device_tflops(dtype):
 
     if inspect.signature(get_max_simd_tflops).parameters.get("clock_rate"):
         # Triton API change in https://github.com/openai/triton/pull/2293
-        cur_sm_clock = _max_clock_rate()
+        cur_sm_clock = torch.cuda.max_clock_rate()
         if dtype in (torch.float16, torch.bfloat16):
             return get_max_tensorcore_tflops(dtype, sm_clock)
 

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1006,6 +1006,18 @@ def clock_rate(device: Optional[Union[Device, int]] = None) -> int:
     return pynvml.nvmlDeviceGetClockInfo(handle, 1)
 
 
+def max_clock_rate(device: Optional[Union[Device, int]] = None) -> int:
+    r"""Return the maximum clock speed of the GPU SM in Hz (Hertz).
+
+    Args:
+        device (torch.device or int, optional): selected device. Returns
+            statistic for the current device, given by :func:`~torch.cuda.current_device`,
+            if :attr:`device` is ``None`` (default).
+    """
+    handle = _get_pynvml_handle(device)
+    return pynvml.nvmlDeviceGetMaxClockInfo(handle, 1)
+
+
 def _get_device(device: Union[int, str, torch.device]) -> torch.device:
     r"""Return the torch.device type object from the passed in device.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118746
* #118662

This is useful for autotuning and benchmarking, and is expose as a standard function in NVML.  Seems like a fairly reasonable addition.

Differential Revision: [D53268291](https://our.internmc.facebook.com/intern/diff/D53268291/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler