### PR TITLE
Add TORCHDYNAMO_EXTENDED_DEBUG_GUARD_ADDED

### DIFF
--- a/torch/fx/experimental/_config.py
+++ b/torch/fx/experimental/_config.py
@@ -29,7 +29,9 @@ check_shape_env_recorded_events = False
 # matches this.  For example, set this to "Ne(s0, 10)" and whenever we issue
 # this guard, we will generate full Python and C++ backtrace
 # [@compile_ignored: debug]
-extended_debug_guard_added = os.environ.get("TORCHDYNAMO_EXTENDED_DEBUG_GUARD_ADDED", None)
+extended_debug_guard_added = os.environ.get(
+    "TORCHDYNAMO_EXTENDED_DEBUG_GUARD_ADDED", None
+)
 
 # [@compile_ignored: debug] Show a warning for every specialization
 print_specializations = False

--- a/torch/fx/experimental/_config.py
+++ b/torch/fx/experimental/_config.py
@@ -25,6 +25,11 @@ translation_validation_no_bisect = (
 # the a ShapeEnv with the same state. This should be used only in testing.
 check_shape_env_recorded_events = False
 
+# Give extended debug information if the string representation of a guard
+# matches this.  For example, set this to "Ne(s0, 10)" and whenever we issue
+# this guard, we will generate full Python and C++ backtrace
+# [@compile_ignored: debug]
+extended_debug_guard_added = os.environ.get("TORCHDYNAMO_EXTENDED_DEBUG_GUARD_ADDED", None)
 
 # [@compile_ignored: debug] Show a warning for every specialization
 print_specializations = False

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -3613,8 +3613,12 @@ class ShapeEnv:
         if self.log.isEnabledFor(logging.INFO):
             fsummary, user_tb, maybe_user_loc = self._get_stack_summary()
 
+            str_g = str(g)
+
             # TODO: make this an artifact
             is_debug = False
+            if config.extended_debug_guard_added is not None and str_g == config.extended_debug_guard_added:
+                is_debug = True
             maybe_extra_debug = ""
             if is_debug and user_tb:
                 maybe_extra_debug = (
@@ -3622,10 +3626,13 @@ class ShapeEnv:
                     '  (snipped, see stack below for prefix)\n' +
                     ''.join(traceback.format_list(user_tb))
                 )
+            if is_debug:
+                cpp_stack = CapturedTraceback.extract(cpp=True)
+                maybe_extra_debug += "\nC++ stack trace:\n" + ''.join(cpp_stack.format())
             self.log.info(
                 "%s %s [guard added]%s (%s)%s",
                 prefix,
-                g,
+                str_g,
                 maybe_user_loc,
                 format_frame(fsummary),
                 maybe_extra_debug,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118750

This allows us to request extended (including C++ backtrace) information
whenever a specific guard occurs.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>