### PR TITLE
Update Dynamo passrate/histogram scripts

### DIFF
--- a/scripts/compile_tests/failures_histogram.py
+++ b/scripts/compile_tests/failures_histogram.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
     )
     # linux-focal-py3.11-clang10 (default) Test Reports (xml) directory
     parser.add_argument("eager_dir")
-    # linux-focal-py3.8-clang10 (dynamo) Test Reports (xml) directory
+    # linux-focal-py3.11-clang10 (dynamo) Test Reports (xml) directory
     parser.add_argument("dynamo_dir")
     args = parser.parse_args()
     failures_histogram(args.eager_dir, args.dynamo_dir)

--- a/scripts/compile_tests/failures_histogram.py
+++ b/scripts/compile_tests/failures_histogram.py
@@ -55,7 +55,7 @@ def repro(testcase):
     return f"PYTORCH_TEST_WITH_DYNAMO=1 pytest {testcase.attrib['file']} -v -k {testcase.attrib['name']}"
 
 
-# e.g. "17c5f69852/dynamo"
+# e.g. "17c5f69852/eager", "17c5f69852/dynamo"
 def failures_histogram(eager_dir, dynamo_dir):
     fail_keys = compute_pass_rate(eager_dir, dynamo_dir)
     xmls = open_test_results(dynamo_dir)

--- a/scripts/compile_tests/failures_histogram.py
+++ b/scripts/compile_tests/failures_histogram.py
@@ -1,15 +1,17 @@
 import argparse
 import re
 
-from common import get_testcases, open_test_results, skipped_test
+from common import get_testcases, key, open_test_results, skipped_test
+
+from passrate import compute_pass_rate
 
 
 """
-python failures_histogram.py dynamo_logs_for_py311/
+python failures_histogram.py eager_logs_for_py311/ dynamo_logs_for_py311/
 
 Analyzes skip reasons for Dynamo tests and prints a histogram with repro
 commands. You'll need to download the test reports for the Dynamo shards
-and put them under the specified directory.
+and put them under the specified directory; ditto for the eager shards.
 """
 
 
@@ -21,22 +23,6 @@ def skip_reason(testcase):
     raise AssertionError("no message?")
 
 
-IGNORED_REASONS = {
-    # We don't run OpInfo tests under Dynamo
-    "Policy: we don't run OpInfo tests w/ Dynamo",
-    # We don't run ModuleInfo tests under Dynamo
-    "Policy: we don't run ModuleInfo tests w/ Dynamo",
-    # We don't run CUDA tests in CI (yet)
-    "Excluded from CUDA tests",
-    # We don't run CUDA tests in CI (yet)
-    "CUDA not found",
-    # We don't run CUDA tests in CI (yet)
-    "Only runs on cuda",
-    # We don't run slow tests in CI
-    "test is slow; run with PYTORCH_TEST_WITH_SLOW to enable test",
-}
-
-
 def skip_reason_normalized(testcase):
     for child in testcase.iter():
         if child.tag != "skipped":
@@ -45,19 +31,16 @@ def skip_reason_normalized(testcase):
         result = result.split(">")[0]
         result = re.sub(r"0x\w+", "0xDEADBEEF", result)
         result = re.sub(r"MagicMock id='\d+'", "MagicMock id='0000000000'", result)
-        result = re.sub(r"issues/\d", "issues/XXX", result)
+        result = re.sub(r"issues/\d+", "issues/XXX", result)
         return result
     raise AssertionError("no message?")
 
 
-def get_failures(xmls):
-    testcases = get_testcases(xmls)
+def get_failures(testcases):
     skipped = [t for t in testcases if skipped_test(t)]
     skipped_dict = {}
     for s in skipped:
         reason = skip_reason_normalized(s)
-        if reason in IGNORED_REASONS:
-            continue
         if reason not in skipped_dict:
             skipped_dict[reason] = []
         skipped_dict[reason].append(s)
@@ -73,14 +56,22 @@ def repro(testcase):
 
 
 # e.g. "17c5f69852/dynamo"
-def failures_histogram(directory):
-    xmls = open_test_results(directory)
-    dct = get_failures(xmls)
+def failures_histogram(eager_dir, dynamo_dir):
+    fail_keys = compute_pass_rate(eager_dir, dynamo_dir)
+    xmls = open_test_results(dynamo_dir)
+
+    testcases = get_testcases(xmls)
+    testcases = [t for t in testcases if key(t) in fail_keys]
+    dct = get_failures(testcases)
 
     a = [(x, y, repro(z[0])) for x, y, z in dct]
 
+    counts, _, _ = zip(*a)
+
+    print("(num_failed_tests, error_msg, sample_test)")
     for row in a:
         print(row)
+    print("[counts]", sum(counts))
 
 
 if __name__ == "__main__":
@@ -88,6 +79,9 @@ if __name__ == "__main__":
         prog="failures_histogram",
         description="See statistics about skipped Dynamo tests",
     )
-    parser.add_argument("directory")
+    # linux-focal-py3.11-clang10 (default) Test Reports (xml) directory
+    parser.add_argument("eager_dir")
+    # linux-focal-py3.8-clang10 (dynamo) Test Reports (xml) directory
+    parser.add_argument("dynamo_dir")
     args = parser.parse_args()
-    failures_histogram(args.directory)
+    failures_histogram(args.eager_dir, args.dynamo_dir)

--- a/scripts/compile_tests/passrate.py
+++ b/scripts/compile_tests/passrate.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
     )
     # linux-focal-py3.11-clang10 (default) Test Reports (xml) directory
     parser.add_argument("eager_dir")
-    # linux-focal-py3.8-clang10 (dynamo) Test Reports (xml) directory
+    # linux-focal-py3.11-clang10 (dynamo) Test Reports (xml) directory
     parser.add_argument("dynamo_dir")
     args = parser.parse_args()
     compute_pass_rate(args.eager_dir, args.dynamo_dir)

--- a/scripts/compile_tests/passrate.py
+++ b/scripts/compile_tests/passrate.py
@@ -40,10 +40,12 @@ def should_exclude(key):
     # C++ tests
     if test_file == "UNKNOWN":
         return True
-    # Policy: "pass rate" does not include inductor or export tests.
+    # Policy: "pass rate" does not include inductor, export, or dynamo tests.
     if test_file.startswith("inductor/"):
         return True
     if test_file.startswith("export/"):
+        return True
+    if test_file.startswith("dynamo/"):
         return True
     return False
 
@@ -57,10 +59,10 @@ def compute_pass_rate(eager_dir, dynamo_dir):
     eager_passed = get_passed_testcases(eager_xmls)
     dynamo_passed = get_passed_testcases(dynamo_xmls)
     dynamo_pass_keys = {key(testcase) for testcase in dynamo_passed}
-    dynamo_pass_keys = {key for key in dynamo_pass_keys if not should_exclude(key)}
+    dynamo_pass_keys = {key_ for key_ in dynamo_pass_keys if not should_exclude(key_)}
     tmp_eager_pass_keys = {key(testcase) for testcase in eager_passed}
     tmp_eager_pass_keys = {
-        key for key in tmp_eager_pass_keys if not should_exclude(key)
+        key_ for key_ in tmp_eager_pass_keys if not should_exclude(key_)
     }
     excluded = [key(t) for t in get_excluded_testcases(dynamo_xmls)]
     eager_pass_keys = tmp_eager_pass_keys - set(excluded)
@@ -69,6 +71,18 @@ def compute_pass_rate(eager_dir, dynamo_dir):
     total_subset = len(subset)
     total_tests = len(eager_pass_keys)
     print("pass rate", total_subset / total_tests, total_subset, total_tests)
+
+    dynamo_testcases = get_testcases(dynamo_xmls)
+    tc = {key(t): t for t in dynamo_testcases}
+
+    # Useful for debugging
+    not_there_keys = set()
+    for key_ in eager_pass_keys:
+        if key_ not in tc:
+            not_there_keys.add(key_)
+
+    fail_keys = eager_pass_keys - subset
+    return fail_keys
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118752

Changelog:
- Don't count running PYTORCH_TEST_WITH_DYNAMO=1 on dynamo/ tests in the pass
rate. This was a bug (we were counting all of these as failing, but in
reality, most of these pass). The net effect is that the passrate is (artifically)
6% higher.
- Have the histogram script filter out skips based on the passrate metric.