### PR TITLE
[pt-vulkan] Introduce `SharedObject` class to `ComputeGraph`

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Tensor.cpp
+++ b/aten/src/ATen/native/vulkan/api/Tensor.cpp
@@ -435,6 +435,44 @@ vTensor::BufferMetadata vTensor::get_cpu_buffer_metadata() const {
   };
 }
 
+VmaAllocationCreateInfo vTensor::get_allocation_create_info() const {
+  switch (storage_type()) {
+    case api::StorageType::BUFFER:
+      return view_->buffer_.allocation_create_info();
+    case api::StorageType::TEXTURE_2D:
+    case api::StorageType::TEXTURE_3D:
+      return view_->image_.allocation_create_info();
+    case api::StorageType::UNKNOWN:
+      return {};
+  }
+}
+
+VkMemoryRequirements vTensor::get_memory_requirements() const {
+  switch (storage_type()) {
+    case api::StorageType::BUFFER:
+      return view_->buffer_.get_memory_requirements();
+    case api::StorageType::TEXTURE_2D:
+    case api::StorageType::TEXTURE_3D:
+      return view_->image_.get_memory_requirements();
+    case api::StorageType::UNKNOWN:
+      return {};
+  }
+}
+
+void vTensor::bind_allocation(const api::MemoryAllocation& allocation) {
+  switch (storage_type()) {
+    case api::StorageType::BUFFER:
+      view_->buffer_.bind_allocation(allocation);
+      break;
+    case api::StorageType::TEXTURE_2D:
+    case api::StorageType::TEXTURE_3D:
+      view_->image_.bind_allocation(allocation);
+      break;
+    case api::StorageType::UNKNOWN:
+      break;
+  }
+}
+
 //
 // vTensorStorage
 //

--- a/aten/src/ATen/native/vulkan/api/Tensor.h
+++ b/aten/src/ATen/native/vulkan/api/Tensor.h
@@ -317,6 +317,21 @@ class vTensor final {
   inline VkDeviceSize gpu_nbytes() const {
     return api::element_size(dtype()) * gpu_numel();
   }
+
+  /*
+   * Return the VmaAllocationCreateInfo of the underlying resource
+   */
+  VmaAllocationCreateInfo get_allocation_create_info() const;
+
+  /*
+   * Return the VkMemoryRequirements of the underlying resource
+   */
+  VkMemoryRequirements get_memory_requirements() const;
+
+  /*
+   * Binds the underlying resource to the given memory allocation
+   */
+  void bind_allocation(const api::MemoryAllocation& allocation);
 };
 
 void add_buffer_barrier(

--- a/aten/src/ATen/native/vulkan/graph/Arithmetic.cpp
+++ b/aten/src/ATen/native/vulkan/graph/Arithmetic.cpp
@@ -42,11 +42,12 @@ ValueRef add_arithmetic_node(
     const ValueRef t1,
     const ValueRef t2,
     const float alpha,
-    const arithmetic::OpType optype) {
+    const arithmetic::OpType optype,
+    const int64_t shared_object_idx) {
   std::vector<int64_t> t1_sizes = graph.get_val_sizes(t1);
   api::ScalarType t1_dtype = graph.get_val_dtype(t1);
 
-  ValueRef out = graph.add_tensor(t1_sizes, t1_dtype);
+  ValueRef out = graph.add_tensor(t1_sizes, t1_dtype, shared_object_idx);
   add_arithmetic_node(graph, t1, t2, out, alpha, optype);
   return out;
 }

--- a/aten/src/ATen/native/vulkan/graph/Arithmetic.h
+++ b/aten/src/ATen/native/vulkan/graph/Arithmetic.h
@@ -23,7 +23,8 @@ ValueRef add_arithmetic_node(
     const ValueRef t1,
     const ValueRef t2,
     const float alpha,
-    const arithmetic::OpType optype);
+    const arithmetic::OpType optype,
+    const int64_t shared_object_idx = -1);
 
 class ArithmeticPrepack : public virtual OpNode {
  public:

--- a/aten/src/ATen/native/vulkan/graph/Graph.cpp
+++ b/aten/src/ATen/native/vulkan/graph/Graph.cpp
@@ -1,8 +1,6 @@
 #include <ATen/native/vulkan/graph/Graph.h>
 #include <ATen/native/vulkan/graph/Staging.h>
 
-#include <iostream>
-
 namespace at {
 namespace native {
 namespace vulkan {

--- a/aten/src/ATen/native/vulkan/graph/Graph.cpp
+++ b/aten/src/ATen/native/vulkan/graph/Graph.cpp
@@ -1,15 +1,80 @@
 #include <ATen/native/vulkan/graph/Graph.h>
 #include <ATen/native/vulkan/graph/Staging.h>
 
+#include <iostream>
+
 namespace at {
 namespace native {
 namespace vulkan {
+
+//
+// SharedObject
+//
+
+void SharedObject::add_user(ComputeGraph* const graph, const ValueRef idx) {
+  vTensor& t = graph->get_val(idx).toTensor();
+
+  //
+  // Aggregate Memory Requirements
+  //
+
+  const VkMemoryRequirements mem_reqs = t.get_memory_requirements();
+  aggregate_memory_requirements.size =
+      std::max(mem_reqs.size, aggregate_memory_requirements.size);
+  aggregate_memory_requirements.alignment =
+      std::max(mem_reqs.alignment, aggregate_memory_requirements.alignment);
+  aggregate_memory_requirements.memoryTypeBits |= mem_reqs.memoryTypeBits;
+
+  //
+  // Aggregate Allocation Create Info
+  //
+
+  const VmaAllocationCreateInfo create_info = t.get_allocation_create_info();
+  // Clear out CREATE_STRATEGY bit flags in case of conflict
+  VmaAllocationCreateFlags clear_mask = ~VMA_ALLOCATION_CREATE_STRATEGY_MASK;
+  VmaAllocationCreateFlags create_flags = create_info.flags & clear_mask;
+  // Use the default allocation strategy
+  aggregate_create_info.flags = create_flags | api::DEFAULT_ALLOCATION_STRATEGY;
+
+  // Set the usage flag if it is currently not set
+  if (aggregate_create_info.usage == VMA_MEMORY_USAGE_UNKNOWN) {
+    aggregate_create_info.usage = create_info.usage;
+  }
+  // Otherwise check that there is no conflict regarding usage
+  VK_CHECK_COND(aggregate_create_info.usage == create_info.usage);
+  aggregate_create_info.requiredFlags |= create_info.requiredFlags;
+  aggregate_create_info.preferredFlags |= create_info.preferredFlags;
+
+  users.emplace_back(idx);
+}
+
+void SharedObject::allocate(ComputeGraph* const graph) {
+  if (aggregate_memory_requirements.size == 0) {
+    return;
+  }
+  allocation = graph->context()->adapter_ptr()->vma().create_allocation(
+      aggregate_memory_requirements, aggregate_create_info);
+}
+
+void SharedObject::bind_users(ComputeGraph* const graph) {
+  if (users.empty()) {
+    return;
+  }
+  for (const ValueRef idx : users) {
+    graph->get_val(idx).toTensor().bind_allocation(allocation);
+  }
+}
+
+//
+// ComputeGraph
+//
 
 ComputeGraph::ComputeGraph(GraphConfig config)
     : config_{config},
       context_{new api::Context(
           api::runtime()->default_adapter_i(),
           config_.contextConfig)},
+      shared_objects_{},
       values_{},
       prepack_nodes_{},
       execute_nodes_{},
@@ -29,9 +94,22 @@ ComputeGraph::~ComputeGraph() {
 
 ValueRef ComputeGraph::add_tensor(
     const std::vector<int64_t>& sizes,
-    const api::ScalarType dtype) {
+    const api::ScalarType dtype,
+    const int64_t shared_object_idx) {
+  bool allocate_memory = shared_object_idx < 0;
+
   ValueRef idx(static_cast<int>(values_.size()));
-  values_.emplace_back(vTensor(context(), sizes, dtype));
+  values_.emplace_back(vTensor(
+      context(),
+      sizes,
+      dtype,
+      api::StorageType::TEXTURE_3D,
+      api::GPUMemoryLayout::TENSOR_CHANNELS_PACKED,
+      allocate_memory));
+
+  if (!allocate_memory) {
+    get_shared_object(shared_object_idx).add_user(this, idx);
+  }
   return idx;
 }
 
@@ -80,6 +158,13 @@ ValueRef ComputeGraph::set_output_tensor(
   return idx;
 }
 
+SharedObject& ComputeGraph::get_shared_object(const int64_t idx) {
+  if (idx >= shared_objects_.size()) {
+    shared_objects_.resize(idx + 1);
+  }
+  return shared_objects_[idx];
+}
+
 void ComputeGraph::copy_into_staging(
     const ValueRef idx,
     const void* data,
@@ -112,12 +197,18 @@ void ComputeGraph::prepack() const {
   context_->submit_cmd_to_gpu(fence.get_submit_handle(), /*final_use = */ true);
   fence.wait();
 
-  // Flush the context and obtain a new command buffer
   context_->flush();
-  context_->set_cmd(/*reusable = */ true);
 }
 
 void ComputeGraph::encode_execute() {
+  context_->flush();
+  context_->set_cmd(/*reusable = */ true);
+
+  for (SharedObject& shared_object : shared_objects_) {
+    shared_object.allocate(this);
+    shared_object.bind_users(this);
+  }
+
   for (std::unique_ptr<OpNode>& node : execute_nodes_) {
     node->encode_execute(this);
   }

--- a/aten/src/ATen/native/vulkan/graph/Graph.h
+++ b/aten/src/ATen/native/vulkan/graph/Graph.h
@@ -16,6 +16,12 @@ namespace native {
 namespace vulkan {
 
 using ValueRef = int32_t;
+
+struct IOValueRef {
+  ValueRef value;
+  ValueRef staging;
+};
+
 class ComputeGraph;
 
 /*
@@ -41,6 +47,21 @@ class OpNode {
   virtual void encode_execute(ComputeGraph* graph) const {}
 };
 
+struct SharedObject {
+  friend class ComputeGraph;
+
+  explicit SharedObject() = default;
+
+  VkMemoryRequirements aggregate_memory_requirements;
+  VmaAllocationCreateInfo aggregate_create_info;
+  std::vector<ValueRef> users;
+  api::MemoryAllocation allocation;
+
+  void add_user(ComputeGraph* const graph, const ValueRef idx);
+  void allocate(ComputeGraph* const graph);
+  void bind_users(ComputeGraph* const graph);
+};
+
 /*
  * This is the core data structure used to execute Vulkan models in graph mode.
  * As opposed to ATen/eager mode where a command buffer is encoded every
@@ -61,6 +82,7 @@ class ComputeGraph final {
  private:
   GraphConfig config_;
   std::unique_ptr<api::Context> context_;
+  std::vector<SharedObject> shared_objects_;
   std::vector<Value> values_;
 
   std::vector<std::unique_ptr<OpNode>> prepack_nodes_;
@@ -127,7 +149,8 @@ class ComputeGraph final {
 
   ValueRef add_tensor(
       const std::vector<int64_t>& sizes,
-      const api::ScalarType dtype);
+      const api::ScalarType dtype = api::ScalarType::Float,
+      const int64_t shared_object_idx = -1);
   ValueRef add_tensorref(
       const std::vector<int64_t>& sizes,
       const api::ScalarType dtype,
@@ -136,6 +159,20 @@ class ComputeGraph final {
 
   ValueRef set_input_tensor(const ValueRef idx, const bool use_staging = true);
   ValueRef set_output_tensor(const ValueRef idx, const bool use_staging = true);
+
+  /*
+   * Convenience function to add an input tensor along with its staging buffer
+   */
+  inline IOValueRef add_input_tensor(
+      const std::vector<int64_t>& sizes,
+      const api::ScalarType dtype,
+      const int64_t shared_object_idx = -1) {
+    ValueRef t = add_tensor(sizes, dtype, shared_object_idx);
+    ValueRef staging = set_input_tensor(t);
+    return {t, staging};
+  }
+
+  SharedObject& get_shared_object(const int64_t idx);
 
   //
   // Input/Output


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118756

## Context

This changeset is part of a stack that enables memory planning (i.e. sharing memory between intermediate tensors) in the PyTorch Vulkan Compute API. Note that Memory Planning can only be used via the ExecuTorch delegate (currently a WIP) and not Lite Interpreter (which does not collect metadata regarding tensor lifetimes).

This changeset builds upon the [previous PR enabling resource aliasing](https://github.com/pytorch/pytorch/pull/118436) and introduces the `SharedObject` class to `ComputeGraph`, which manages resource aliasing in graph execution mode. `SharedObject` tracks which `vTensor` values in a `ComputeGraph` share the same backing memory, and provides functionality to aggregate memory requirements and bind users to same memory allocation.

## Notes for Reviewers

The `SharedObject` class is introduced in `Graph.h`. It's fairly simple and provides three functions:

* `add_user()` which adds a `ValueRef` to the list of users of the `SharedObject`, and updates the aggregate memory requirements with the memory requirements of the new user
* `allocate_memory()` creates a `VmaAllocation` with the aggregated memory requirements
* `bind_users()` iterates over the `users` of the `SharedObject` and binds each `vTensor`'s underlying resource to the memory associated with the `SharedObject`.

As for how `SharedObject` is used in `ComputeGraph`:

* `add_tensor()` now has an additional argument `shared_object_idx` which, if `>0`, will construct a `vTensor` without any backing memory and add the new `vTensor` to the `SharedObject` at `shared_object_idx`
* `encode_execute()` will first iterate through the `SharedObject`s of the graph and allocate + bind users before recording the command buffer.

Differential Revision: [D53271486](https://our.internmc.facebook.com/intern/diff/D53271486/)