### PR TITLE
[ait] inspect get_attr nodes for _decline_if_input_dtype

### DIFF
--- a/torch/fx/passes/operator_support.py
+++ b/torch/fx/passes/operator_support.py
@@ -188,9 +188,6 @@ class OpSupports:
             node: torch.fx.Node,
         ) -> bool:
             for arg in node.all_input_nodes:
-                # escape dtype check for get_attr node
-                if arg.op == "get_attr":
-                    continue
                 arg_dtype = _get_arg_dtype(arg)
                 if arg_dtype == dtype:
                     return False


### PR DESCRIPTION
Summary:
previously get_attr nodes were skipped, but for example:

%mul_240 : [num_users=1] = call_function[target=torch_tensorrt.fx.tracer.acc_tracer.acc_ops.mul](args = (), kwargs = {input: %_fx_const_folded_attrs_13, other: %add_143})

where %_fx_const_folded_attrs_13 is int64, but add_143 is float causes issues if skipped, e.g. "unsupported dtype='int64' for alignments"

Differential Revision: D53273467


