### PR TITLE
[AOTInductor] Add Runtime Constant-folding for AOTInductor

### DIFF
--- a/test/cpp/aot_inductor/test.cpp
+++ b/test/cpp/aot_inductor/test.cpp
@@ -15,16 +15,19 @@
 
 namespace {
 
-void test_aoti(const std::string& device) {
+void test_aoti(const std::string& device, bool use_runtime_constant_folding) {
   torch::NoGradGuard no_grad;
 
   std::string data_path =
       (std::filesystem::path(STRINGIZE(CMAKE_CURRENT_BINARY_DIR)) / "data.pt")
            .string();
   torch::jit::script::Module data_loader = torch::jit::load(data_path);
-  std::string path_attr = "model_so_path_" + device;
-  std::string inputs_attr = "inputs_" + device;
-  std::string outputs_attr = "outputs_" + device;
+  std::string suffix = use_runtime_constant_folding
+      ? device + "_use_runtime_constant_folding"
+      : device;
+  std::string path_attr = "model_so_path_" + suffix;
+  std::string inputs_attr = "inputs_" + suffix;
+  std::string outputs_attr = "outputs_" + suffix;
   const auto& model_so_path = data_loader.attr(path_attr.c_str()).toStringRef();
   auto input_tensors =
       data_loader.attr(inputs_attr.c_str()).toTensorList().vec();
@@ -72,7 +75,9 @@ void test_aoti_script(const std::string& device) {
   }
 }
 
-void test_aoti_constants_update(const std::string& device) {
+void test_aoti_constants_update(
+    const std::string& device,
+    bool use_runtime_constant_folding) {
   torch::NoGradGuard no_grad;
 
   std::string data_path =
@@ -80,11 +85,14 @@ void test_aoti_constants_update(const std::string& device) {
            .string();
 
   torch::jit::script::Module data_loader = torch::jit::load(data_path);
-  std::string path_attr = "model_so_path_" + device;
-  std::string inputs_attr = "inputs_" + device;
-  std::string outputs_attr = "outputs_" + device;
-  std::string weights_attr = "fc_weight_" + device;
-  std::string bias_attr = "fc_bias_" + device;
+  std::string suffix = use_runtime_constant_folding
+      ? device + "_use_runtime_constant_folding"
+      : device;
+  std::string path_attr = "model_so_path_" + suffix;
+  std::string inputs_attr = "inputs_" + suffix;
+  std::string outputs_attr = "outputs_" + suffix;
+  std::string weights_attr = "w_pre_" + suffix;
+  std::string add_attr = "w_add_" + suffix;
   const auto& model_so_path = data_loader.attr(path_attr.c_str()).toStringRef();
   auto input_tensors =
       data_loader.attr(inputs_attr.c_str()).toTensorList().vec();
@@ -93,15 +101,14 @@ void test_aoti_constants_update(const std::string& device) {
 
   const auto& weight_tensors =
       data_loader.attr(weights_attr.c_str()).toTensor();
-  const auto& bias_tensors = data_loader.attr(bias_attr.c_str()).toTensor();
+  const auto& add_tensors = data_loader.attr(add_attr.c_str()).toTensor();
 
   torch::inductor::TensorConstantMap missing_map, rand_map, real_map;
-  missing_map.emplace(
-      "L__self___fc_weight", new at::Tensor(at::randn({10, 64})));
-  rand_map.emplace("L__self___fc_weight", new at::Tensor(at::randn({10, 64})));
-  rand_map.emplace("L__self___fc_bias", new at::Tensor(at::randn({10})));
-  real_map.emplace("L__self___fc_weight", new at::Tensor(weight_tensors));
-  real_map.emplace("L__self___fc_bias", new at::Tensor(bias_tensors));
+  missing_map.emplace("L__self___w_pre", new at::Tensor(at::randn({4, 4})));
+  rand_map.emplace("L__self___w_pre", new at::Tensor(at::randn({10})));
+  rand_map.emplace("L__self___w_add", new at::Tensor(at::randn({10})));
+  real_map.emplace("L__self___w_pre", new at::Tensor(weight_tensors));
+  real_map.emplace("L__self___w_add", new at::Tensor(add_tensors));
 
   std::unique_ptr<torch::inductor::AOTIModelContainerRunner> runner;
   if (device == "cuda") {
@@ -125,22 +132,39 @@ void test_aoti_constants_update(const std::string& device) {
   // Update random weight to buffer #1.
   runner->update_constant_buffer(missing_map, false, false);
   actual_output_tensors = runner->run(input_tensors);
+  if (use_runtime_constant_folding) {
+    // At this moment, this update is applied on the original weight.
+    // The weight being consumed is "folded", so will have no affect.
+    ASSERT_TRUE(
+        torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
+    runner->run_const_fold(/* use_inactive = */ false);
+    actual_output_tensors = runner->run(input_tensors);
+  }
   ASSERT_FALSE(
       torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
 
-  // Update with real weight.
+  // Update with real map.
   runner->update_constant_buffer(real_map, false, false);
+  actual_output_tensors = runner->run(input_tensors);
+  if (use_runtime_constant_folding) {
+    runner->run_const_fold(/* use_inactive = */ false);
+  }
   actual_output_tensors = runner->run(input_tensors);
   ASSERT_TRUE(torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
 
-  // Update with full random weight.
-  runner->update_constant_buffer(rand_map, false, true);
+  // Update with full random map.
+  runner->update_constant_buffer(rand_map, false, false);
+  if (use_runtime_constant_folding) {
+    runner->run_const_fold(/* use_inactive = */ false);
+  }
   actual_output_tensors = runner->run(input_tensors);
   ASSERT_FALSE(
       torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
 }
 
-void test_aoti_double_buffering(const std::string& device) {
+void test_aoti_double_buffering(
+    const std::string& device,
+    bool use_runtime_constant_folding) {
   torch::NoGradGuard no_grad;
 
   std::string data_path =
@@ -148,11 +172,14 @@ void test_aoti_double_buffering(const std::string& device) {
            .string();
 
   torch::jit::script::Module data_loader = torch::jit::load(data_path);
-  std::string path_attr = "model_so_path_" + device;
-  std::string inputs_attr = "inputs_" + device;
-  std::string outputs_attr = "outputs_" + device;
-  std::string weights_attr = "fc_weight_" + device;
-  std::string bias_attr = "fc_bias_" + device;
+  std::string suffix = use_runtime_constant_folding
+      ? device + "_use_runtime_constant_folding"
+      : device;
+  std::string path_attr = "model_so_path_" + suffix;
+  std::string inputs_attr = "inputs_" + suffix;
+  std::string outputs_attr = "outputs_" + suffix;
+  std::string weights_attr = "w_pre_" + suffix;
+  std::string add_attr = "w_add_" + suffix;
   const auto& model_so_path = data_loader.attr(path_attr.c_str()).toStringRef();
   auto input_tensors =
       data_loader.attr(inputs_attr.c_str()).toTensorList().vec();
@@ -161,13 +188,13 @@ void test_aoti_double_buffering(const std::string& device) {
 
   const auto& weight_tensors =
       data_loader.attr(weights_attr.c_str()).toTensor();
-  const auto& bias_tensors = data_loader.attr(bias_attr.c_str()).toTensor();
+  const auto& add_tensors = data_loader.attr(add_attr.c_str()).toTensor();
 
   torch::inductor::TensorConstantMap rand_map, real_map;
-  rand_map.emplace("L__self___fc_weight", new at::Tensor(at::randn({10, 64})));
-  rand_map.emplace("L__self___fc_bias", new at::Tensor(at::randn({10})));
-  real_map.emplace("L__self___fc_weight", new at::Tensor(weight_tensors));
-  real_map.emplace("L__self___fc_bias", new at::Tensor(bias_tensors));
+  rand_map.emplace("L__self___w_pre", new at::Tensor(at::randn({4, 4})));
+  rand_map.emplace("L__self___w_add", new at::Tensor(at::randn({4, 4})));
+  real_map.emplace("L__self___w_pre", new at::Tensor(weight_tensors));
+  real_map.emplace("L__self___w_add", new at::Tensor(add_tensors));
 
   std::unique_ptr<torch::inductor::AOTIModelContainerRunner> runner;
   if (device == "cuda") {
@@ -186,17 +213,23 @@ void test_aoti_double_buffering(const std::string& device) {
   // We update the weights to buffer #2 and activate it. This should still
   // produce correct result, as it's the real constant map.
   runner->update_inactive_constant_buffer(real_map);
+  if (use_runtime_constant_folding) {
+    runner->run_const_fold(/* use_inactive = */ true);
+  }
   runner->swap_constant_buffer();
   actual_output_tensors = runner->run(input_tensors);
   ASSERT_TRUE(torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
 
   // We update random weights to buffer #1. But do not swap in the weight yet.
   runner->update_inactive_constant_buffer(rand_map);
+  if (use_runtime_constant_folding) {
+    runner->run_const_fold(/* use_inactive = */ true);
+  }
   actual_output_tensors = runner->run(input_tensors);
   ASSERT_TRUE(torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
 
   // We swap and activate the weight to buffer #1. This is random weight and
-  // should produce in correct results.
+  // should produce incorrect results.
   runner->swap_constant_buffer();
   actual_output_tensors = runner->run(input_tensors);
   ASSERT_FALSE(
@@ -214,7 +247,7 @@ namespace torch {
 namespace inductor {
 
 TEST(AotInductorTest, BasicTestCpu) {
-  test_aoti("cpu");
+  test_aoti("cpu", false);
 }
 
 TEST(AotInductorTest, BasicScriptTestCpu) {
@@ -223,19 +256,28 @@ TEST(AotInductorTest, BasicScriptTestCpu) {
 
 #ifdef USE_CUDA
 TEST(AotInductorTest, BasicTestCuda) {
-  test_aoti("cuda");
+  test_aoti("cuda", true);
+  test_aoti("cuda", false);
 }
 
 TEST(AotInductorTest, BasicScriptTestCuda) {
   test_aoti_script("cuda");
 }
 
+TEST(AotInductorTest, RuntimeUpdateConstantsCuda) {
+  test_aoti_constants_update("cuda", true);
+}
+
 TEST(AotInductorTest, UpdateConstantsCuda) {
-  test_aoti_constants_update("cuda");
+  test_aoti_constants_update("cuda", false);
+}
+
+TEST(AotInductorTest, RuntimeUpdateInactiveConstantsCuda) {
+  test_aoti_double_buffering("cuda", true);
 }
 
 TEST(AotInductorTest, UpdateInactiveConstantsCuda) {
-  test_aoti_double_buffering("cuda");
+  test_aoti_double_buffering("cuda", false);
 }
 #endif
 

--- a/test/cpp/aot_inductor/test.py
+++ b/test/cpp/aot_inductor/test.py
@@ -6,36 +6,49 @@ from torch.export import Dim
 torch.manual_seed(1337)
 
 class Net(torch.nn.Module):
-    def __init__(self):
+    def __init__(self, device):
         super().__init__()
-        self.fc = torch.nn.Linear(64, 10)
+        self.w_pre = torch.randn(4, 4, device=device)
+        self.w_add = torch.randn(4, 4, device=device)
 
-    def forward(self, x, y):
-        return self.fc(torch.sin(x) + torch.cos(y))
+    def forward(self, x):
+        w_transpose = torch.transpose(self.w_pre, 0, 1)
+        w_relu = torch.nn.functional.relu(w_transpose)
+        w = w_relu + self.w_add
+        return torch.matmul(x, w)
 
 data = {}
 
 for device in ["cpu", "cuda"]:
-    model = Net().to(device=device)
-    x = torch.randn((32, 64), device=device)
-    y = torch.randn((32, 64), device=device)
-    with torch.no_grad():
-        ref_output = model(x, y)
+    for use_runtime_constant_folding in [True, False]:
+        if device == "cpu" and use_runtime_constant_folding:
+            # We do not test runtime const folding for cpu mode.
+            continue
+        model = Net(device).to(device=device)
+        x = torch.randn((4, 4), device=device)
+        with torch.no_grad():
+            ref_output = model(x)
 
-    torch._dynamo.reset()
-    with torch.no_grad():
-        dim0_x = Dim("dim0_x", min=1, max=1024)
-        dynamic_shapes = {"x": {0: dim0_x}, "y": {0: dim0_x}}
-        model_so_path = aot_compile(model, (x, y), dynamic_shapes=dynamic_shapes)
+        torch._dynamo.reset()
+        with torch.no_grad():
+            dim0_x = Dim("dim0_x", min=1, max=1024)
+            dynamic_shapes = {"x": {0: dim0_x}}
+            model_so_path = aot_compile(
+                model,
+                (x,),
+                dynamic_shapes=dynamic_shapes,
+                options={"aot_inductor.use_runtime_constant_folding": use_runtime_constant_folding})
 
-    params = dict(model.named_parameters())
-    data.update({
-        f"model_so_path_{device}": model_so_path,
-        f"inputs_{device}": [x, y],
-        f"outputs_{device}": [ref_output],
-        f"fc_weight_{device}": params["fc.weight"],
-        f"fc_bias_{device}": params["fc.bias"],
-    })
+        suffix = f"{device}"
+        if use_runtime_constant_folding:
+            suffix += "_use_runtime_constant_folding"
+        data.update({
+            f"model_so_path_{suffix}": model_so_path,
+            f"inputs_{suffix}": [x],
+            f"outputs_{suffix}": [ref_output],
+            f"w_pre_{suffix}": model.w_pre,
+            f"w_add_{suffix}": model.w_add,
+        })
 
 # Use this to communicate tensors to the cpp code
 class Serializer(torch.nn.Module):

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1511,6 +1511,10 @@ class CudaKernelParamCache:
     def get(cls, key: str) -> Optional[Dict[str, str]]:
         return cls.cache.get(key, None)
 
+    @classmethod
+    def get_keys(cls):
+        return cls.cache.keys()
+
 
 class AotCodeCompiler:
     @classmethod
@@ -1692,7 +1696,9 @@ class AotCodeCompiler:
                 return bytes(raw_array.contents)
 
             aot_constants = b"".join(
-                _to_bytes(tensor) for tensor in graph.constants.values()
+                _to_bytes(tensor)
+                for name, tensor in graph.constants.items()
+                if name not in graph.folded_constants
             )
             consts_o = {
                 "linux": _compile_consts_linux,

--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -184,6 +184,22 @@ AOTIRuntimeError AOTInductorModelContainerUpdateInactiveConstantBuffer(
           /*validate_full_update*/ true);
 }
 
+AOTIRuntimeError AOTInductorModelContainerRunConstantFolding(
+    AOTInductorModelContainerHandle container_handle,
+    bool use_inactive,
+    AOTInductorStreamHandle stream_handle,
+    AOTIProxyExecutorHandle proxy_executor_handle) {
+  auto* container =
+      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
+          container_handle);
+  auto stream =
+      reinterpret_cast<torch::aot_inductor::DeviceStreamType>(stream_handle);
+  CONVERT_EXCEPTION_TO_ERROR_CODE({
+    AOTINoGradGuard guard;
+    container->run_const_fold(use_inactive, stream, proxy_executor_handle);
+  })
+}
+
 AOTIRuntimeError AOTInductorModelContainerSwapConstantBuffer(
     AOTInductorModelContainerHandle container_handle) {
   auto* container =

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1466,6 +1466,10 @@ class CppWrapperCodeGen(WrapperCodeGen):
         self.header.writeline(f"// {name} {hashed}")
 
     def write_header(self):
+        if V.graph.is_const_graph:
+            # We do not write header for constant graph, it will be written by main module.
+            return
+
         if V.graph.aot_mode:
             for header_cpp_file in ("interface.cpp", "implementation.cpp"):
                 with open(
@@ -1543,6 +1547,10 @@ class CppWrapperCodeGen(WrapperCodeGen):
         self.output_is_tensor = output_is_tensor
 
     def write_prefix(self):
+        if V.graph.is_const_graph:
+            # We do not write prefix for constant graph, it will be written by main module.
+            return
+
         if V.graph.aot_mode:
             self.prefix.writeline("namespace torch {")
             self.prefix.writeline("namespace aot_inductor {")
@@ -1571,7 +1579,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
     def write_wrapper_decl(self):
         inputs_len = len(V.graph.graph_inputs.keys())
         if V.graph.aot_mode:
-            if config.use_minimal_arrayref_interface:
+            if config.use_minimal_arrayref_interface and not V.graph.is_const_graph:
                 from .cpp import DTYPE_TO_CPP
 
                 input_cpp_types = ", ".join(
@@ -1591,64 +1599,93 @@ class CppWrapperCodeGen(WrapperCodeGen):
                     """
                 )
 
-            run_impl_proto = """
-                void AOTInductorModel::run_impl(
-                    AtenTensorHandle*
-                        input_handles, // array of input AtenTensorHandle; handles
-                                        // are stolen; the array itself is borrowed
-                    AtenTensorHandle*
-                        output_handles, // array for writing output AtenTensorHandle; handles
-                                        // will be stolen by the caller; the array itself is
-                                        // borrowed
-                    DeviceStreamType stream,
-                    AOTIProxyExecutorHandle proxy_executor
-                ) {
-                """
-            if config.use_minimal_arrayref_interface:
+            if V.graph.const_module:
+                self.header.splice(V.graph.const_module.wrapper_code.header)
+                self.prefix.splice(V.graph.const_code)
+
+            if V.graph.is_const_graph:
                 self.prefix.splice(
                     """
-                    template <>
-                    AOTInductorModelOutputs AOTInductorModel::run_impl_minimal_arrayref_interface<
-                      AOTInductorModelInputs, AOTInductorModelOutputs>(
-                        const AOTInductorModelInputs& inputs,
+                    void AOTInductorModel::_const_run_impl(
+                        std::vector<AtenTensorHandle>& output_handles,
                         DeviceStreamType stream,
                         AOTIProxyExecutorHandle proxy_executor
                     ) {
                     """
                 )
-                self.suffix.splice(run_impl_proto)
-                self.suffix.splice(
-                    """
-                        AOTInductorModelInputs inputs;
-                        convert_handles_to_inputs(input_handles, inputs);
-                        auto outputs = run_impl_minimal_arrayref_interface<AOTInductorModelInputs, AOTInductorModelOutputs>(
-                            inputs, stream, proxy_executor);
-                        // NOTE: outputs is full of ArrayRef to thread_local storage. If in the future we need this
-                        // interface to perform well for a DSO using the minimal arrayref interface, all we need
-                        // to do is provide ThreadLocalCachedTensor for each one!
-                        convert_outputs_to_handles(outputs, output_handles);
-                    }
-                """
-                )
-
-                self.suffix.splice(
-                    """
-                    extern "C" AOTIRuntimeError AOTInductorModelRunMinimalArrayrefInterface(
-                        AOTInductorModelHandle model_handle,
-                        const AOTInductorModelInputs& inputs,
-                        AOTInductorModelOutputs& outputs) {
-                      auto model = reinterpret_cast<torch::aot_inductor::AOTInductorModel*>(model_handle);
-                      CONVERT_EXCEPTION_TO_ERROR_CODE({
-                          outputs = model->run_impl_minimal_arrayref_interface<AOTInductorModelInputs, AOTInductorModelOutputs>(
-                              inputs,
-                              (torch::aot_inductor::DeviceStreamType)nullptr,
-                              nullptr);
-                      })
-                    }
-                """
-                )
             else:
-                self.prefix.splice(run_impl_proto)
+                if not config.aot_inductor.use_runtime_constant_folding:
+                    # If we do not split the constant graph, we'll just create
+                    # an empty implementation when wrapping the main module.
+                    self.prefix.splice(
+                        """
+                        void AOTInductorModel::_const_run_impl(
+                            std::vector<AtenTensorHandle>& output_handles,
+                            DeviceStreamType stream,
+                            AOTIProxyExecutorHandle proxy_executor
+                        ) {}
+
+                        """
+                    )
+
+                run_impl_proto = """
+                    void AOTInductorModel::run_impl(
+                        AtenTensorHandle*
+                            input_handles, // array of input AtenTensorHandle; handles
+                                            // are stolen; the array itself is borrowed
+                        AtenTensorHandle*
+                            output_handles, // array for writing output AtenTensorHandle; handles
+                                            // will be stolen by the caller; the array itself is
+                                            // borrowed
+                        DeviceStreamType stream,
+                        AOTIProxyExecutorHandle proxy_executor
+                    ) {
+                    """
+                if config.use_minimal_arrayref_interface:
+                    self.prefix.splice(
+                        """
+                        template <>
+                        AOTInductorModelOutputs AOTInductorModel::run_impl_minimal_arrayref_interface<
+                          AOTInductorModelInputs, AOTInductorModelOutputs>(
+                            const AOTInductorModelInputs& inputs,
+                            DeviceStreamType stream,
+                            AOTIProxyExecutorHandle proxy_executor
+                        ) {
+                        """
+                    )
+                    self.suffix.splice(run_impl_proto)
+                    self.suffix.splice(
+                        """
+                            AOTInductorModelInputs inputs;
+                            convert_handles_to_inputs(input_handles, inputs);
+                            auto outputs = run_impl_minimal_arrayref_interface<AOTInductorModelInputs, AOTInductorModelOutputs>(
+                                inputs, stream, proxy_executor);
+                            // NOTE: outputs is full of ArrayRef to thread_local storage. If in the future we need this
+                            // interface to perform well for a DSO using the minimal arrayref interface, all we need
+                            // to do is provide ThreadLocalCachedTensor for each one!
+                            convert_outputs_to_handles(outputs, output_handles);
+                        }
+                    """
+                    )
+
+                    self.suffix.splice(
+                        """
+                        extern "C" AOTIRuntimeError AOTInductorModelRunMinimalArrayrefInterface(
+                            AOTInductorModelHandle model_handle,
+                            const AOTInductorModelInputs& inputs,
+                            AOTInductorModelOutputs& outputs) {
+                          auto model = reinterpret_cast<torch::aot_inductor::AOTInductorModel*>(model_handle);
+                          CONVERT_EXCEPTION_TO_ERROR_CODE({
+                              outputs = model->run_impl_minimal_arrayref_interface<AOTInductorModelInputs, AOTInductorModelOutputs>(
+                                  inputs,
+                                  (torch::aot_inductor::DeviceStreamType)nullptr,
+                                  nullptr);
+                          })
+                        }
+                    """
+                    )
+                else:
+                    self.prefix.splice(run_impl_proto)
         else:
             self.prefix.splice(
                 f"""std::vector<at::Tensor> {self.call_func_name}(const std::vector<at::Tensor>& inputs) {{"""
@@ -1657,19 +1694,20 @@ class CppWrapperCodeGen(WrapperCodeGen):
             # assign inputs and outputs in both cases so the later codegen can be simplified
             if not config.use_minimal_arrayref_interface:
                 if V.graph.aot_mode:
-                    if config.aot_inductor.abi_compatible:
-                        self.prefix.splice(
-                            """
-                                auto inputs = steal_from_raw_handles_to_raii_handles(input_handles, num_inputs());
-                            """
-                        )
-                    else:
-                        # This looks dumb, but can avoid creating two versions of code in the AOTInductor runtime.
-                        self.prefix.splice(
-                            """
-                                auto inputs = alloc_tensors_by_stealing_from_handles(input_handles, num_inputs());
-                            """
-                        )
+                    if not V.graph.is_const_graph:
+                        if config.aot_inductor.abi_compatible:
+                            self.prefix.splice(
+                                """
+                                    auto inputs = steal_from_raw_handles_to_raii_handles(input_handles, num_inputs());
+                                """
+                            )
+                        else:
+                            # This looks dumb, but can avoid creating two versions of code in the AOTInductor runtime.
+                            self.prefix.splice(
+                                """
+                                    auto inputs = alloc_tensors_by_stealing_from_handles(input_handles, num_inputs());
+                                """
+                            )
                 else:
                     self.prefix.splice(
                         """
@@ -1733,11 +1771,12 @@ class CppWrapperCodeGen(WrapperCodeGen):
             self.codegen_inputs(self.prefix, V.graph.graph_inputs)
 
             if V.graph.aot_mode:
-                if config.use_minimal_arrayref_interface:
-                    # TODO: input shape checking for regular tensor interface as well?
-                    self.codegen_input_numel_asserts()
-                else:
-                    self.prefix.writeline("inputs.clear();")
+                if not V.graph.is_const_graph:
+                    if config.use_minimal_arrayref_interface:
+                        # TODO: input shape checking for regular tensor interface as well?
+                        self.codegen_input_numel_asserts()
+                    else:
+                        self.prefix.writeline("inputs.clear();")
                 self.prefix.writeline(
                     "auto& kernels = static_cast<AOTInductorModelKernels&>(*this->kernels_.get());"
                 )
@@ -1777,9 +1816,13 @@ class CppWrapperCodeGen(WrapperCodeGen):
             "class AOTInductorModelKernels : public AOTInductorModelKernelsBase {"
         )
         self.prefix.writeline("  public:")
-        for kernel in chain(
-            self.src_to_kernel.values(), self.user_defined_kernel_cache.values()
-        ):
+        declare_kernel = set(self.src_to_kernel.values())
+        declare_kernel.update(self.user_defined_kernel_cache.values())
+        if V.graph.const_module:
+            declare_kernel.update(
+                V.graph.const_module.wrapper_code.src_to_kernel.values()
+            )
+        for kernel in declare_kernel:
             self.prefix.writeline(f"    CUfunction {kernel}{{nullptr}};")
         self.prefix.writeline("};")
         self.prefix.writeline("}  // namespace")
@@ -1836,6 +1879,10 @@ class CppWrapperCodeGen(WrapperCodeGen):
                 self.prefix.writeline(
                     f"constants_info_[{idx}].data_size = {tensor.untyped_storage().nbytes()};"
                 )
+                from_folded = "true" if name in V.graph.folded_constants else "false"
+                self.prefix.writeline(
+                    f"constants_info_[{idx}].from_folded = {from_folded};"
+                )
 
                 size_str = ", ".join([str(s) for s in tensor.size()])
                 self.prefix.writeline(f"constants_info_[{idx}].shape = {{{size_str}}};")
@@ -1880,10 +1927,93 @@ class CppWrapperCodeGen(WrapperCodeGen):
 
         self.prefix.writeline("}")
 
+    def codegen_const_run_driver(self):
+        """
+        // Generated code example
+        std::unordered_map<std::string, AtenTensorHandle> AOTInductorModel::const_run_impl(
+            DeviceStreamType stream,
+            AOTIProxyExecutorHandle proxy_executor,
+            bool initialization
+        ) {
+            std::unordered_map<std::string, AtenTensorHandle> folded_constants_map;
+            std::vector<AtenTensorHandle> output_handles;
+            // build up output_handles over here.
+            _const_run_impl(output_handles, stream, proxy_executor);
+            // build up folded_constants_map
+            return folded_constants_map;
+        }
+        """
+
+        self.prefix.splice(
+            """
+            std::unordered_map<std::string, AtenTensorHandle> AOTInductorModel::const_run_impl(
+                DeviceStreamType stream,
+                AOTIProxyExecutorHandle proxy_executor,
+                bool initialization
+            ) {
+            """
+        )
+        if not config.aot_inductor.use_runtime_constant_folding:
+            self.prefix.splice(
+                """
+                    if (!initialization) {
+                        throw std::runtime_error(std::string("use_runtime_constant_folding is not set."));
+                    }
+                    return {};
+                }
+                """
+            )
+            return
+
+        with self.prefix.indent():
+            # This is a mapping to the index of constant folding graph's output
+            const_index_mapping: List[Optional[Tuple[int, str]]] = [None] * len(
+                V.graph.const_output_index
+            )
+            for idx, (name, _) in enumerate(V.graph.constants.items()):
+                if name in V.graph.const_output_index:
+                    const_index_mapping[V.graph.const_output_index[name]] = (idx, name)  # type: ignore[call-overload]
+            assert (
+                None not in const_index_mapping
+            ), "Not all constant gets mapped for constant folding graph."
+
+            self.prefix.writeline(
+                f"""
+                std::unordered_map<std::string, AtenTensorHandle> folded_constants_map;
+                folded_constants_map.reserve({len(const_index_mapping)});
+                std::vector<AtenTensorHandle> output_handles({len(const_index_mapping)});
+                """
+            )
+
+            self.prefix.splice(
+                """
+                // The below assignment of output_handles to constants is not used directly.
+                // It's only used to memo the correspondence of handle and constants.
+                """
+            )
+
+            for output_idx, (const_idx, _) in enumerate(const_index_mapping):  # type: ignore[misc]
+                self.prefix.writeline(
+                    f"output_handles[{output_idx}] = constants_->at({const_idx});"
+                )
+
+            self.prefix.writeline(
+                "_const_run_impl(output_handles, stream, proxy_executor);"
+            )
+
+            for output_idx, (_, const_name) in enumerate(const_index_mapping):  # type: ignore[misc]
+                self.prefix.writeline(
+                    f'folded_constants_map["{const_name}"] = output_handles[{output_idx}];'
+                )
+            self.prefix.writeline("return folded_constants_map;")
+
+        self.prefix.writeline("}")
+
     def generate(self, is_inference):
-        if V.graph.aot_mode:
+        if V.graph.aot_mode and not V.graph.is_const_graph:
             self.codegen_model_kernels()
             self.codegen_model_constructor()
+            self.codegen_const_run_driver()
         self.write_wrapper_decl()
         return super().generate(is_inference)
 
@@ -1920,7 +2050,9 @@ class CppWrapperCodeGen(WrapperCodeGen):
     def generate_return(self, output_refs):
         if V.graph.aot_mode:
             cst_names = V.graph.constants.keys()
-            arr_iface = config.use_minimal_arrayref_interface  # For brevity.
+            arr_iface = (
+                not V.graph.is_const_graph and config.use_minimal_arrayref_interface
+            )  # For brevity.
 
             def use_thread_local_cached_output_tensor(idx, output):
                 cached_output_name = f"cached_output_{next(self.cached_output_id)}"
@@ -1977,7 +2109,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
                         f"if constexpr ({output_is_tensor_handle_expr}) {{"
                     )
                     with self.wrapper_call.indent():
-                        if config.use_minimal_arrayref_interface:
+                        if arr_iface:
                             cached_output_name = (
                                 f"cached_output_{next(self.cached_output_id)}"
                             )
@@ -2045,13 +2177,16 @@ class CppWrapperCodeGen(WrapperCodeGen):
             self.wrapper_call.writeline(f"return {{{', '.join(output_refs)}}};\n}}")
 
     def generate_before_suffix(self, result):
-        if V.graph.aot_mode:
+        if V.graph.aot_mode and not V.graph.is_const_graph:
             result.writeline("} // AOTInductorModel::run_impl")
 
     def generate_end(self, result):
         if V.graph.aot_mode:
-            result.writeline("} // namespace aot_inductor")
-            result.writeline("} // namespace torch")
+            if V.graph.is_const_graph:
+                result.writeline("} // AOTInductorModel::_const_run_impl")
+            else:
+                result.writeline("} // namespace aot_inductor")
+                result.writeline("} // namespace torch")
             return
 
         result.writeline("'''\n)")
@@ -2912,6 +3047,10 @@ class CudaWrapperCodeGen(CppWrapperCodeGen):
         self.cuda = True
 
     def write_header(self):
+        if V.graph.is_const_graph:
+            # We do not write header for constant graph, it will be written by main module.
+            return
+
         super().write_header()
 
         self.header.splice("#include <filesystem>")
@@ -3081,7 +3220,7 @@ class CudaWrapperCodeGen(CppWrapperCodeGen):
         params = CudaKernelParamCache.get(name)
         assert (
             params is not None
-        ), f"cuda kernel parameters for {name} should already exist at this moment"
+        ), f"cuda kernel parameters for {name} should already exist at this moment, only found {CudaKernelParamCache.get_keys()}"
         block_cfg = {
             "XBLOCK": params["x_block"],
             "YBLOCK": params["y_block"],

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -200,6 +200,63 @@ def _unlift_graph(mod, gm, graph_signature):
     return unlifted_gm
 
 
+def split_const_gm(
+    gm: torch.fx.GraphModule,
+) -> Tuple[torch.fx.GraphModule, Dict[str, int]]:
+    """
+    This function takes an GraphModule input "gm".
+    The gm will be split into 2 components,
+      1) const_gm, which consists the subgraph of gm that can be constant folded.
+      2) gm (being inplace modified,) which returns the graph after constant folding.
+
+    const_output_index is a mapping of corresponding node name from gm to the
+    output index of const_gm.
+    Returns (const_gm, const_output_index)
+    """
+    from torch._inductor.constant_folding import (
+        CONST_MODULE_TAG,
+        META_TAG,
+        MODULE_TAG,
+        replace_node_with_constant,
+        run_and_get_constant_graph,
+    )
+
+    const_gm = run_and_get_constant_graph(gm)
+    const_result = const_gm()
+
+    const_outputs = {
+        x.name: idx for idx, x in enumerate(tuple(const_gm.graph.nodes)[-1].args[0])
+    }
+
+    to_erase_node = []
+    to_replace_node = []
+    const_output_index = {}
+    for node in gm.graph.nodes:
+        if node.name in const_outputs:
+            to_replace_node.append(node)
+        elif node.meta[META_TAG] == CONST_MODULE_TAG:
+            to_erase_node.append(node)
+
+    for node in to_replace_node:
+        new_const_name = "_FOLDED_CONST_" + node.name
+        replace_node_with_constant(
+            gm,
+            node,
+            const_result[const_outputs[node.name]],
+            new_const_name,
+        )
+        const_output_index[new_const_name] = const_outputs[node.name]
+    for node in to_erase_node[::-1]:
+        if node.users:
+            for n in node.users:
+                assert n.meta[META_TAG] == MODULE_TAG, f"node: {node} user not empty."
+        else:
+            gm.graph.erase_node(node)
+    gm.recompile()
+
+    return const_gm, const_output_index
+
+
 def is_tf32_warning_applicable(gm: torch.fx.GraphModule):
     aten = torch.ops.aten
     tf32_ops = {
@@ -569,6 +626,32 @@ def fx_codegen_and_compile(
         )
 
     with V.set_fake_mode(fake_mode):
+        const_output_index = None
+        const_graph = None
+        const_code = None
+
+        if aot_mode and config.aot_inductor.use_runtime_constant_folding:
+            const_gm, const_output_index = split_const_gm(gm)
+
+            const_graph = GraphLowering(
+                const_gm,
+                example_inputs=[],
+                shape_env=shape_env,
+                num_static_inputs=num_fixed,
+                graph_id=graph_id,
+                cpp_wrapper=cpp_wrapper,
+                aot_mode=aot_mode,
+                user_visible_outputs=user_visible_outputs,
+                extern_node_serializer=extern_node_serializer,
+                is_inference=is_inference,
+                is_const_graph=True,
+            )
+            with V.set_graph_handler(const_graph):
+                assert cpp_wrapper, "AOT mode only supports C++ wrapper"
+                const_graph.run()
+
+                const_code, _ = const_graph.codegen_with_cpp_wrapper()
+
         graph = GraphLowering(
             gm,
             # example_inputs will be used by AOTInductor to dry-run the generated code for Triton kernel tuning.
@@ -583,6 +666,9 @@ def fx_codegen_and_compile(
             user_visible_outputs=user_visible_outputs,
             extern_node_serializer=extern_node_serializer,
             is_inference=is_inference,
+            const_output_index=const_output_index,
+            const_code=const_code,
+            const_module=const_graph,
         )
         with V.set_graph_handler(graph):
             graph.run(*example_inputs)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -601,6 +601,9 @@ class aot_inductor:
     # Serialized tree spec for flattening outputs
     serialized_out_spec = ""
 
+    # flag to decide whether to create a submodule for constant graph.
+    use_runtime_constant_folding: bool = False
+
 
 class cuda:
     # CUDA arch to use for CUDA template kernel compilation.

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -203,6 +203,10 @@ class GraphLowering(torch.fx.Interpreter):
         layout_opt=None,
         extern_node_serializer=None,
         is_inference=False,
+        is_const_graph=False,
+        const_output_index=None,
+        const_code=None,
+        const_module=None,
     ):
         super().__init__(gm)
 
@@ -214,6 +218,9 @@ class GraphLowering(torch.fx.Interpreter):
         )
         self.num_channels_last_conv = 0
         self.is_inference = is_inference
+        self.is_const_graph = is_const_graph
+        self.const_code = const_code
+        self.const_module = const_module
 
         self.extra_traceback = False  # we do our own error wrapping
         if shape_env is None:
@@ -226,11 +233,21 @@ class GraphLowering(torch.fx.Interpreter):
         self.sizevars = SizeVarAllocator(shape_env)
         self.graph_inputs: Dict[str, TensorBox] = {}
         self.graph_inputs_original: Dict[str, InputBuffer] = {}
-        self.device_types: Set[str] = set()
-        self.device_idxs: Set[int] = set()
+        self.device_types: Set[str] = (
+            const_module.device_types if const_module else set()
+        )
+        self.device_idxs: Set[int] = const_module.device_idxs if const_module else set()
         self.cuda = False
         self.buffers: List[ir.Buffer] = []
-        self.constants: Dict[str, torch.Tensor] = {}
+        self.const_output_index: Dict[str, int] = (
+            const_output_index if const_output_index else {}
+        )
+        self.folded_constants: Set[str] = (
+            set(const_output_index.keys()) if const_output_index else set()
+        )
+        self.constants: Dict[str, torch.Tensor] = (
+            const_module.constants if const_module else {}
+        )
         self.constant_reprs: Dict[str, str] = {}
         self.removed_buffers: Set[str] = set()
         self.removed_inplace_buffers: Set[str] = set()
@@ -597,16 +614,17 @@ class GraphLowering(torch.fx.Interpreter):
 
     def add_tensor_constant(self, data, name=None):
         def allocate(name):
-            for constant_name, value in self.constants.items():
-                if (
-                    not data.is_mkldnn
-                    and data.size() == value.size()
-                    and data.stride() == value.stride()
-                    and data.dtype == value.dtype
-                    and data.device == value.device
-                    and torch.eq(data, value).all()
-                ):
-                    return constant_name
+            if not config.aot_inductor.use_runtime_constant_folding:
+                for constant_name, value in self.constants.items():
+                    if (
+                        not data.is_mkldnn
+                        and data.size() == value.size()
+                        and data.stride() == value.stride()
+                        and data.dtype == value.dtype
+                        and data.device == value.device
+                        and torch.eq(data, value).all()
+                    ):
+                        return constant_name
 
             if name is None:
                 name = f"constant{len(self.constants)}"
@@ -757,7 +775,11 @@ class GraphLowering(torch.fx.Interpreter):
         # this is a constant
         value = getattr_recursive(self.module, target)
 
-        if config.always_keep_tensor_constants or unsupported_output_tensor(value):
+        if (
+            config.aot_inductor.use_runtime_constant_folding
+            or config.always_keep_tensor_constants
+            or unsupported_output_tensor(value)
+        ):
             return self.add_tensor_constant(value, target)
 
         with no_dispatch():

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4406,9 +4406,13 @@ class IndexPutFallback(ExternKernel):
 class DeviceCopy(ExternKernelOut):
     @classmethod
     def create(cls, x, device):
-        if not x.is_extern() and all(
-            (r.name in V.graph.constants and isinstance(r, dependencies.MemoryDep))
-            for r in x.get_reads()
+        if (
+            not x.is_extern()
+            and all(
+                (r.name in V.graph.constants and isinstance(r, dependencies.MemoryDep))
+                for r in x.get_reads()
+            )
+            and not config.aot_inductor.use_runtime_constant_folding
         ):
             return x.constant_to_device(device)
 

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
@@ -38,6 +38,8 @@ AOTIModelContainerRunner::AOTIModelContainerRunner(
       reinterpret_cast<decltype(update_inactive_constant_buffer_func_)>(
           model_so_->sym(
               "AOTInductorModelContainerUpdateInactiveConstantBuffer"));
+  run_const_fold_func_ = reinterpret_cast<decltype(run_const_fold_func_)>(
+      model_so_->sym("AOTInductorModelContainerRunConstantFolding"));
   swap_constant_buffer_func_ =
       reinterpret_cast<decltype(swap_constant_buffer_func_)>(
           model_so_->sym("AOTInductorModelContainerSwapConstantBuffer"));
@@ -134,6 +136,16 @@ void AOTIModelContainerRunner::update_inactive_constant_buffer(
     const TensorConstantMap& const_map) {
   AOTI_RUNTIME_ERROR_CODE_CHECK(update_inactive_constant_buffer_func_(
       container_handle_, (AOTInductorConstantMapHandle)&const_map));
+}
+
+void AOTIModelContainerRunner::run_const_fold(
+    bool use_inactive,
+    AOTInductorStreamHandle cuda_stream_handle) {
+  AOTI_RUNTIME_ERROR_CODE_CHECK(run_const_fold_func_(
+      container_handle_,
+      use_inactive,
+      cuda_stream_handle,
+      proxy_executor_handle_));
 }
 
 void AOTIModelContainerRunner::swap_constant_buffer() {

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.h
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.h
@@ -35,6 +35,9 @@ class TORCH_API AOTIModelContainerRunner {
       const TensorConstantMap& const_map,
       bool use_inactive,
       bool validate_full_updates);
+  void run_const_fold(
+      bool use_inactive,
+      AOTInductorStreamHandle cuda_stream_handle = nullptr);
   void swap_constant_buffer();
 
   std::vector<std::string> get_call_spec();
@@ -64,6 +67,8 @@ class TORCH_API AOTIModelContainerRunner {
       update_constant_buffer_func_{nullptr};
   decltype(&AOTInductorModelContainerUpdateInactiveConstantBuffer)
       update_inactive_constant_buffer_func_{nullptr};
+  decltype(&AOTInductorModelContainerRunConstantFolding) run_const_fold_func_{
+      nullptr};
   decltype(&AOTInductorModelContainerSwapConstantBuffer)
       swap_constant_buffer_func_{nullptr};
   decltype(&AOTInductorModelContainerGetCallSpec) get_call_spec_func_{nullptr};

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -120,6 +120,13 @@ AOTIRuntimeError AOTInductorModelContainerUpdateInactiveConstantBuffer(
     AOTInductorModelContainerHandle container_handle,
     AOTInductorConstantMapHandle constant_map_handle);
 
+// Run constant folding on constant buffer.
+AOTIRuntimeError AOTInductorModelContainerRunConstantFolding(
+    AOTInductorModelContainerHandle container_handle,
+    bool use_inactive,
+    AOTInductorStreamHandle stream_handle,
+    AOTIProxyExecutorHandle proxy_executor_handle);
+
 // Swap the constant buffer being used to the inactive one.
 AOTIRuntimeError AOTInductorModelContainerSwapConstantBuffer(
     AOTInductorModelContainerHandle container_handle);

--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -24,6 +24,7 @@ class AOTInductorModelContainer {
     constants_map_ = std::make_shared<ConstantMap>();
     constants_array_ = std::make_shared<std::vector<ConstantHandle>>();
     use_secondary_ = false;
+    constant_folded_ = false;
     models_.reserve(num_models);
     available_models_.reserve(num_models);
     for (size_t i = 0; i < num_models; ++i) {
@@ -80,6 +81,27 @@ class AOTInductorModelContainer {
       AOTIProxyExecutorHandle proxy_executor) {
     std::shared_lock model_lk(model_exec_mutex_);
     auto* model = get_available_model();
+
+    if (!constant_folded_) {
+      // At this point, constant is not ready yet. We need to call constant
+      // folding before we execute the model. We obtain a unique lock at this
+      // point to make sure constant is ready for all.
+      model_lk.unlock();
+      std::unique_lock constants_folding_lk(model_exec_mutex_);
+      // Double locking to make sure constant folding is only ran once.
+      if (!constant_folded_) {
+        auto folded_const_map = model->const_run_impl(
+            stream, proxy_executor, /* initialization = */ true);
+        update_constant_buffer(
+            folded_const_map,
+            /* use_inactive = */ false,
+            /* validate_full_update = */ false);
+        constant_folded_ = true;
+      }
+      constants_folding_lk.unlock();
+      model_lk.lock();
+    }
+
     try {
       model->run(input_handles, output_handles, stream, proxy_executor);
     } catch (...) {
@@ -123,6 +145,68 @@ class AOTInductorModelContainer {
     return models_[0]->constant_dtype(idx);
   }
 
+  void run_const_fold(
+      bool inactive_buffer,
+      DeviceStreamType stream,
+      AOTIProxyExecutorHandle proxy_executor) {
+    std::shared_lock model_lk(model_exec_mutex_);
+    auto* model = get_available_model();
+
+    if (!inactive_buffer) {
+      // We would need to acquire a unique lock if we want to run constant
+      // folding on the active buffer.
+      model_lk.unlock();
+      std::unique_lock constants_folding_lk(model_exec_mutex_);
+      try {
+        auto folded_const_map = model->const_run_impl(stream, proxy_executor);
+        update_constant_buffer(
+            folded_const_map,
+            /* use_inactive = */ false,
+            /* validate_full_update = */ false);
+      } catch (...) {
+        std::lock_guard lk(models_mutex_);
+        available_models_.push_back(model);
+        throw;
+      }
+      constants_folding_lk.unlock();
+      model_lk.lock();
+    } else {
+      // We swap the constant mapping to the inactive buffer in the model to run
+      // const run.
+      auto constants_map = get_constants_map(/* get_inactive= */ true);
+      auto constants_array = get_constants_array(/* get_inactive= */ true);
+
+      try {
+        model->update_constants_map(
+            constants_map, /* remap_constants_array= */ false);
+        model->update_constants_array(constants_array);
+
+        auto folded_const_map = model->const_run_impl(stream, proxy_executor);
+        update_constant_buffer(
+            folded_const_map,
+            /* use_inactive = */ true,
+            /* validate_full_update = */ false);
+
+        // Swap back the model's constants mapping
+        constants_map = get_constants_map(/* get_inactive= */ false);
+        constants_array = get_constants_array(/* get_inactive= */ false);
+        model->update_constants_map(
+            constants_map, /* remap_constants_array= */ false);
+        model->update_constants_array(constants_array);
+      } catch (...) {
+        std::lock_guard lk(models_mutex_);
+        available_models_.push_back(model);
+        throw;
+      }
+    }
+
+    {
+      std::lock_guard lk(models_mutex_);
+      pending_models_.push_back(model);
+    }
+    pending_models_available_.notify_one();
+  }
+
   // This function updates the buffer for storing constants.
   // It will update the buffer, the mapping and the array mapping.
   void update_constant_buffer(
@@ -141,6 +225,10 @@ class AOTInductorModelContainer {
 
     if (validate_full_update) {
       for (size_t idx = 0; idx < num_constants; idx++) {
+        if (models_[0]->constant_from_folded(idx)) {
+          continue;
+        }
+
         auto constant_name = std::string(models_[0]->constant_name(idx));
         auto it = constants_map.find(constant_name);
         if (it == constants_map.end()) {
@@ -210,8 +298,11 @@ class AOTInductorModelContainer {
       std::shared_ptr<ConstantMap> constants_map) {
     auto num_constants = models_[0]->num_constants();
     for (size_t idx = 0; idx < num_constants; idx++) {
-      constants_array->at(idx) = ConstantHandle(
-          constants_map->find(models_[0]->constant_name(idx))->second);
+      if (constants_map->find(models_[0]->constant_name(idx)) !=
+          constants_map->end()) {
+        constants_array->at(idx) = ConstantHandle(
+            constants_map->find(models_[0]->constant_name(idx))->second);
+      }
     }
   }
 
@@ -280,6 +371,9 @@ class AOTInductorModelContainer {
   // constants_map_secondary/constant_blob_secondary/constants_array_secondary
   // is being used.
   bool use_secondary_;
+
+  // Determine whether we have ran constant folding
+  bool constant_folded_;
 
   // Holds the mapping of constants to at::Tensor.
   // The underlying data of at::Tensor is in either constant_blob_ (for CUDA).


### PR DESCRIPTION
Summary:
Add Runtime Constant-folding for AOTInductor.
This also include the invocation of constant folding at load time.

The constant folding lowering is a 2-step process.
First, we split the graph into 2 modules, one of it is the constant module, which doesn't depend on any input and the whole module could be inferred (constant-folded) one-time and be reused. The constant module, is lowered, and being codegen-ed as usual and cached (let's call this constant code). The constant code reuses the whole lowering/profiling/etc. process, only difference is that we do not generate any headers or initialization for the constant code.
Second, after handling the constant module, we take care of the main module (which is the part that would depend on the user input.) For the main module, we take in one additional component, the constant code, compare with a normal lowering. Addition step we do here is that, we inject the constant code into the codegen-ed main module, and create the caller for the main module to consume the result of the constant module.

Test Plan: Unit tests included in commit.

Differential Revision: D53274382



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @aakhundov @ColinPeppler