### PR TITLE
Enable test_ellipsis_index_2 with Torch dynamo

### DIFF
--- a/test/torch_np/numpy_tests/core/test_indexing.py
+++ b/test/torch_np/numpy_tests/core/test_indexing.py
@@ -20,7 +20,6 @@ from torch.testing._internal.common_utils import (
     skipIfTorchDynamo,
     TEST_WITH_TORCHDYNAMO,
     TestCase,
-    xfailIfTorchDynamo,
     xpassIfTorchDynamo,
 )
 
@@ -202,8 +201,11 @@ class TestIndexing(TestCase):
         b[(Ellipsis,)] = 2
         assert_equal(b, 2)
 
-    @xfailIfTorchDynamo  # numpy ndarrays do not have `.tensor` attribute
     def test_ellipsis_index_2(self):
+        # This test spefically testing torch._numpy.array()
+        import torch._numpy as np
+        from torch._numpy.testing import assert_equal
+
         a = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
         assert_(a[...] is not a)
         assert_equal(a[...], a)

--- a/test/torch_np/numpy_tests/core/test_indexing.py
+++ b/test/torch_np/numpy_tests/core/test_indexing.py
@@ -202,15 +202,17 @@ class TestIndexing(TestCase):
         assert_equal(b, 2)
 
     def test_ellipsis_index_2(self):
-        # This test spefically testing torch._numpy.array()
-        import torch._numpy as np
-        from torch._numpy.testing import assert_equal
-
         a = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
         assert_(a[...] is not a)
         assert_equal(a[...], a)
         # `a[...]` was `a` in numpy <1.9.
-        assert_(a[...].tensor._base is a.tensor)
+        if TEST_WITH_TORCHDYNAMO:
+            # numpy.array() is imported.
+            assert_(a[...].base is a)
+        else:
+            # torch_.numpy.array() is imported
+            assert_(a[...].tensor._base is a.tensor)
+
 
     def test_single_int_index(self):
         # Single integer index selects one row

--- a/test/torch_np/numpy_tests/core/test_indexing.py
+++ b/test/torch_np/numpy_tests/core/test_indexing.py
@@ -201,18 +201,13 @@ class TestIndexing(TestCase):
         b[(Ellipsis,)] = 2
         assert_equal(b, 2)
 
+    @xpassIfTorchDynamo  # 'torch_.np.array() does not have base attribute.
     def test_ellipsis_index_2(self):
         a = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
         assert_(a[...] is not a)
         assert_equal(a[...], a)
         # `a[...]` was `a` in numpy <1.9.
-        if TEST_WITH_TORCHDYNAMO:
-            # numpy.array() is imported.
-            assert_(a[...].base is a)
-        else:
-            # torch_.numpy.array() is imported
-            assert_(a[...].tensor._base is a.tensor)
-
+        assert_(a[...].base is a)
 
     def test_single_int_index(self):
         # Single integer index selects one row


### PR DESCRIPTION
Fix issue #118819

test_ellipsis_index_2 is specifically testing properties of torch._numpy.array()
and that a field tensor is being added hence overriding the imports. 
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118773

