### PR TITLE
graph break on eval() with weird objects as locals

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -4569,6 +4569,19 @@ def fn():
             exp_n_cached_backend,
         )
 
+    def test_eval_locals_with_no_values(self):
+        class Weird:
+            def __getitem__(self, item):
+                return None
+
+        def f():
+            return eval("1", {}, Weird())  # type: ignore[arg-type]
+
+        opt_f = torch._dynamo.optimize(backend="eager")(f)
+        expected = f()
+        result = opt_f()
+        self.assertEqual(result, expected)
+
     def test_backend_match_guard(self):
         x = torch.randn([3, 4])
 

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -237,6 +237,10 @@ def has_tensor_in_frame(frame):
             return False
 
     # Check if the passed arguments are of type Tensor
+    if not hasattr(frame.f_locals, "values"):
+        unimplemented(
+            f"Expected frames.f_locals to be dict-like, got f{type(frame.f_locals)}"
+        )
     for value in frame.f_locals.values():
         if has_tensor(value):
             return True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #118778
* __->__ #118777
* #118768

This happens in some of our TorchScript tests.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng