### PR TITLE
No TD (test removal) option in CI

### DIFF
--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -37,6 +37,9 @@ outputs:
   ci-no-test-timeout:
     description: True if ci-no-test-timeout label was on PR or [ci-no-test-timeout] in PR body.
     value: ${{ steps.filter.outputs.ci-no-test-timeout }}
+  ci-no-td:
+    description: True if ci-no-td label was on PR or [ci-no-td] in PR body.
+    value: ${{ steps.filter.outputs.ci-no-td }}
 
 runs:
   using: composite

--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -493,9 +493,7 @@ def perform_misc_tasks(
     set_output(
         "ci-no-test-timeout", check_for_setting(labels, pr_body, "ci-no-test-timeout")
     )
-    set_output(
-        "ci-no-td", check_for_setting(labels, pr_body, "ci-no-td")
-    )
+    set_output("ci-no-td", check_for_setting(labels, pr_body, "ci-no-td"))
 
     # Obviously, if the job name includes unstable, then this is an unstable job
     is_unstable = job_name and IssueType.UNSTABLE.value in job_name

--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -493,6 +493,9 @@ def perform_misc_tasks(
     set_output(
         "ci-no-test-timeout", check_for_setting(labels, pr_body, "ci-no-test-timeout")
     )
+    set_output(
+        "ci-no-td", check_for_setting(labels, pr_body, "ci-no-td")
+    )
 
     # Obviously, if the job name includes unstable, then this is an unstable job
     is_unstable = job_name and IssueType.UNSTABLE.value in job_name

--- a/.github/scripts/test_filter_test_configs.py
+++ b/.github/scripts/test_filter_test_configs.py
@@ -640,6 +640,7 @@ class TestConfigFilter(TestCase):
             keep_going: bool = False,
             ci_verbose_test_logs: bool = False,
             ci_no_test_timeout: bool = False,
+            ci_no_td: bool = False,
             is_unstable: bool = False,
             reenabled_issues: str = "",
         ) -> str:
@@ -647,6 +648,7 @@ class TestConfigFilter(TestCase):
                 f"keep-going={keep_going}\n"
                 f"ci-verbose-test-logs={ci_verbose_test_logs}\n"
                 f"ci-no-test-timeout={ci_no_test_timeout}\n"
+                f"ci-no-td={ci_no_td}\n"
                 f"is-unstable={is_unstable}\n"
                 f"reenabled-issues={reenabled_issues}\n"
             )
@@ -693,6 +695,14 @@ class TestConfigFilter(TestCase):
                 "expected": _gen_expected_string(
                     ci_verbose_test_logs=True, ci_no_test_timeout=True
                 ),
+                "description": "No pipe logs in PR body and no test timeout in label (same as the above but swapped)",
+            },
+            {
+                "labels": {"ci-no-td"},
+                "test_matrix": '{include: [{config: "default"}]}',
+                "job_name": "A job name",
+                "pr_body": "",
+                "expected": _gen_expected_string(ci_no_td=True),
                 "description": "No pipe logs in PR body and no test timeout in label (same as the above but swapped)",
             },
             {

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -171,6 +171,7 @@ jobs:
           CONTINUE_THROUGH_ERROR: ${{ steps.keep-going.outputs.keep-going }}
           VERBOSE_TEST_LOGS: ${{ steps.keep-going.outputs.ci-verbose-test-logs }}
           NO_TEST_TIMEOUT: ${{ steps.keep-going.outputs.ci-no-test-timeout }}
+          NO_TD: ${{ steps.keep-going.outputs.ci-no-td }}
           SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
           SCCACHE_S3_KEY_PREFIX: ${{ github.workflow }}
           SHM_SIZE: ${{ contains(inputs.build-environment, 'cuda') && '2g' || '1g' }}
@@ -222,6 +223,7 @@ jobs:
             -e CONTINUE_THROUGH_ERROR \
             -e VERBOSE_TEST_LOGS \
             -e NO_TEST_TIMEOUT \
+            -e NO_TD \
             -e PR_LABELS \
             -e MAX_JOBS="$(nproc --ignore=2)" \
             -e SCCACHE_BUCKET \

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -36,6 +36,7 @@ jobs:
       keep-going: ${{ steps.filter.outputs.keep-going }}
       ci-verbose-test-logs: ${{ steps.filter.outputs.ci-verbose-test-logs }}
       ci-no-test-timeout: ${{ steps.filter.outputs.ci-no-test-timeout }}
+      ci-no-td: ${{ steps.filter.outputs.ci-no-td }}
       reenabled-issues: ${{ steps.filter.outputs.reenabled-issues }}
     steps:
       - name: Checkout PyTorch

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -99,6 +99,7 @@ jobs:
           CONTINUE_THROUGH_ERROR: ${{ needs.filter.outputs.keep-going }}
           VERBOSE_TEST_LOGS: ${{ needs.filter.outputs.ci-verbose-test-logs }}
           NO_TEST_TIMEOUT: ${{ needs.filter.outputs.ci-no-test-timeout }}
+          NO_TD: ${{ needs.filter.outputs.ci-no-td }}
           PIP_REQUIREMENTS_FILE: .github/requirements/pip-requirements-${{ runner.os }}.txt
           REENABLED_ISSUES: ${{ needs.filter.outputs.reenabled-issues }}
         run: |

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -150,6 +150,7 @@ jobs:
           CONTINUE_THROUGH_ERROR: ${{ steps.keep-going.outputs.keep-going }}
           VERBOSE_TEST_LOGS: ${{ steps.keep-going.outputs.ci-verbose-test-logs }}
           NO_TEST_TIMEOUT: ${{ steps.keep-going.outputs.ci-no-test-timeout }}
+          NO_TD: ${{ steps.keep-going.outputs.ci-no-td }}
           PIP_REQUIREMENTS_FILE: .github/requirements/pip-requirements-${{ runner.os }}.txt
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_WORKFLOW: ${{ github.workflow }}

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -151,6 +151,7 @@ jobs:
           CONTINUE_THROUGH_ERROR: ${{ steps.keep-going.outputs.keep-going }}
           VERBOSE_TEST_LOGS: ${{ steps.keep-going.outputs.ci-verbose-test-logs }}
           NO_TEST_TIMEOUT: ${{ steps.keep-going.outputs.ci-no-test-timeout }}
+          NO_TD: ${{ steps.keep-going.outputs.ci-no-td }}
           TEST_CONFIG: ${{ matrix.config }}
           SHARD_NUMBER: ${{ matrix.shard }}
           NUM_TEST_SHARDS: ${{ matrix.num_shards }}
@@ -201,6 +202,7 @@ jobs:
             -e CONTINUE_THROUGH_ERROR \
             -e VERBOSE_TEST_LOGS \
             -e NO_TEST_TIMEOUT \
+            -e NO_TD \
             -e MAX_JOBS="$(nproc --ignore=2)" \
             -e SCCACHE_BUCKET \
             -e XLA_CLANG_CACHE_S3_BUCKET_NAME \

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -142,6 +142,7 @@ jobs:
           CONTINUE_THROUGH_ERROR: ${{ steps.keep-going.outputs.keep-going }}
           VERBOSE_TEST_LOGS: ${{ steps.keep-going.outputs.ci-verbose-test-logs }}
           NO_TEST_TIMEOUT: ${{ steps.keep-going.outputs.ci-no-test-timeout }}
+          NO_TD: ${{ steps.keep-going.outputs.ci-no-td }}
           VC_PRODUCT: "BuildTools"
           VC_VERSION: ""
           VS_VERSION: "16.8.6"

--- a/.github/workflows/_xpu-test.yml
+++ b/.github/workflows/_xpu-test.yml
@@ -145,6 +145,7 @@ jobs:
           CONTINUE_THROUGH_ERROR: ${{ steps.keep-going.outputs.keep-going }}
           VERBOSE_TEST_LOGS: ${{ steps.keep-going.outputs.ci-verbose-test-logs }}
           NO_TEST_TIMEOUT: ${{ steps.keep-going.outputs.ci-no-test-timeout }}
+          NO_TD: ${{ steps.keep-going.outputs.ci-no-td }}
           TEST_CONFIG: ${{ matrix.config }}
           SHARD_NUMBER: ${{ matrix.shard }}
           NUM_TEST_SHARDS: ${{ matrix.num_shards }}
@@ -189,6 +190,7 @@ jobs:
             -e CONTINUE_THROUGH_ERROR \
             -e VERBOSE_TEST_LOGS \
             -e NO_TEST_TIMEOUT \
+            -e NO_TD \
             -e MAX_JOBS="$(nproc --ignore=2)" \
             -e SCCACHE_BUCKET \
             -e XLA_CLANG_CACHE_S3_BUCKET_NAME \

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1142,7 +1142,9 @@ def parse_args():
         "--enable-td",
         action="store_true",
         help="Set a timeout based on the test times json file.  Only works if there are test times available",
-        default=IS_CI and not strtobool(os.environ.get("NO_TD", "False")),
+        default=IS_CI
+        and os.getenv("BRANCH", "") != "main"
+        and not strtobool(os.environ.get("NO_TD", "False")),
     )
     parser.add_argument(
         "additional_unittest_args",

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1141,7 +1141,7 @@ def parse_args():
     parser.add_argument(
         "--enable-td",
         action="store_true",
-        help="Set a timeout based on the test times json file.  Only works if there are test times available",
+        help="Enables removing tests based on TD",
         default=IS_CI
         and os.getenv("BRANCH", "") != "main"
         and not strtobool(os.environ.get("NO_TD", "False")),

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1139,6 +1139,12 @@ def parse_args():
         default=IS_CI and not strtobool(os.environ.get("NO_TEST_TIMEOUT", "False")),
     )
     parser.add_argument(
+        "--enable-td",
+        action="store_true",
+        help="Set a timeout based on the test times json file.  Only works if there are test times available",
+        default=IS_CI and not strtobool(os.environ.get("NO_TD", "False")),
+    )
+    parser.add_argument(
         "additional_unittest_args",
         nargs="*",
         help="additional arguments passed through to unittest, e.g., "


### PR DESCRIPTION
It currently doesn't do anything, but I will want these env vars later.  Maybe I should start using ghstack

Intention: --enable-td actually gets rid of tests

I am open to better names