### PR TITLE
[easy] Enable test_neg_view for 5D SampleInput for torch.nn.functional.linear

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -4422,13 +4422,8 @@ def sample_inputs_linear(self, device, dtype, requires_grad, **kwargs):
         yield SampleInput(input_tensor, weight, bias)
 
     # 5D tensor, used to crash on MPS, see https://github.com/pytorch/pytorch/issues/114942
-    input_tensor = create_tensor(2, 1, 2, 1, 2)
-    weight = create_tensor(4, 2)
-    yield SampleInput(input_tensor, weight)
-    # Hide for now from test_neg_view/test_conj_view
-    # See https://github.com/pytorch/pytorch/issues/117854
-    if dtype in [torch.float32, torch.float16]:
-        yield SampleInput(input_tensor, weight, create_tensor(4))
+    yield SampleInput(create_tensor(2, 1, 2, 1, 2), create_tensor(4, 2))
+    yield SampleInput(create_tensor(2, 1, 2, 1, 2), create_tensor(4, 2), create_tensor(4))
 
 def sample_inputs_bilinear(self, device, dtype, requires_grad, **kwargs):
     features_options = [[3, 4, 5], [8, 8, 8]]


### PR DESCRIPTION
Fixes #117854
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118815

