### PR TITLE
[export] Only deepcopy graph in unlift

### DIFF
--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -251,7 +251,7 @@ def _create_stateful_graph_module(
 
 
 def _unlift_exported_program_lifted_states(ep: ExportedProgram) -> torch.nn.Module:
-    new_gm = copy.deepcopy(ep.graph_module)
+    new_gm = torch.fx.GraphModule(ep.graph_module, copy.deepcopy(ep.graph))
     _register_attrs_to_new_gm(new_gm, ep.graph_signature, ep.state_dict, ep.constants)
 
     lifted_inputs: List[Optional[str]] = [


### PR DESCRIPTION
Summary: We only need to deepcopy the graph because we're modifying the graph by unlifting its parameter/buffer inputs. We don't need to deepcopy the graph module state/contents. This causes an error when the graph module contains an ExecuTorch LoweredModule which stores tensors.

Test Plan: Fixes the following diff

Differential Revision: D53290077


