### PR TITLE
[DeviceMesh] Manually revert change [DeviceMesh] Reuse sub_group pg if exists #115716

### DIFF
--- a/test/distributed/_tensor/test_init.py
+++ b/test/distributed/_tensor/test_init.py
@@ -199,7 +199,7 @@ class DTensorConstructorTest(DTensorTestBase):
         # default world_size is 4
         # construct a cuda device 1d mesh, with no sub pg initialized
         sub_mesh_list = [0, 3]
-        mesh = DeviceMesh(self.device_type, sub_mesh_list)
+        mesh = DeviceMesh(self.device_type, sub_mesh_list, _init_process_groups=False)
         placements = [Shard(0)]
         size = [32, 3]
         dist_tensor = zeros(size, device_mesh=mesh, placements=placements)
@@ -215,7 +215,7 @@ class DTensorConstructorTest(DTensorTestBase):
 
         # construct a cuda device 1d mesh: unevenly, with subpg initialized
         sub_mesh_list = [0, 1, 3]
-        mesh = DeviceMesh(self.device_type, sub_mesh_list)
+        mesh = DeviceMesh(self.device_type, sub_mesh_list, _init_process_groups=False)
         placements = [Shard(0)]
         size = [32, 3]
         dist_tensor = zeros(size, device_mesh=mesh, placements=placements)

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -13,16 +13,13 @@ from torch.distributed._tensor._collective_utils import (
 from torch.distributed._tensor.placement_types import _Partial, Shard
 from torch.distributed.device_mesh import _mesh_resources, DeviceMesh, init_device_mesh
 
+
 from torch.distributed.distributed_c10d import (
-    _get_process_group_name,
-    _world,
     get_global_rank,
-    get_process_group_ranks,
     get_world_size,
     init_process_group,
     is_initialized,
     is_nccl_available,
-    new_group,
     ProcessGroup,
 )
 from torch.testing._internal.common_utils import run_tests
@@ -65,71 +62,6 @@ class DeviceMeshTest(DTensorTestBase):
         DeviceMesh(device_type, mesh_tensor)
         self.assertTrue(is_initialized())
         self.destroy_pg()
-
-    def _get_tags_to_pg_name(self, tags_to_pg):
-        tags_to_pg_name = {}
-        for tag_name, groups in tags_to_pg.items():
-            tags_to_pg_name[tag_name] = []
-            for group in groups:
-                tags_to_pg_name[tag_name].append(_get_process_group_name(group))
-        return tags_to_pg_name
-
-    @with_comms
-    def test_reuse_process_group(self):
-        # Manually create new_group.
-        tp_group_0 = new_group([0, 1])
-        tp_group_1 = new_group([2, 3])
-        dp_group_0 = new_group([0, 2])
-        dp_group_1 = new_group([1, 3])
-
-        # Record the pg tags_to_pg_name so we can check whether init_device_mesh create new pg.
-        # We cannot do a deepcopy of ProcessGroup for comparison,
-        # since we cannot pickle 'torch._C._distributed_c10d.ProcessGroup' object.
-        # Therefore, we rely on the tags_to_pg_name for comparison to make sure
-        # before/after init_device_mesh, tags_to_pg in the current world does not change.
-        ref_tags_to_pg = _world.tags_to_pg
-        ref_tags_to_pg_name = self._get_tags_to_pg_name(ref_tags_to_pg)
-
-        mesh_shape = (2, self.world_size // 2)
-        mesh_dim_names = ("DP", "TP")
-        mesh_2d = init_device_mesh(
-            self.device_type, mesh_shape, mesh_dim_names=mesh_dim_names
-        )
-        tags_to_pg = _world.tags_to_pg
-        tags_to_pg_name = self._get_tags_to_pg_name(tags_to_pg)
-
-        # Check before/after init_device_mesh, tags_to_pg in the current world does not change.
-        self.assertEqual(ref_tags_to_pg_name, tags_to_pg_name)
-
-        # For each rank, there should be 4 tags_to_pg, including tags:
-        #   1) default tag for user PGs (which contains all the pgs on a particular rank)
-        #   2) tag for world size pg
-        #   3) tag for tp pg
-        #   4) tag for dp pg
-        self.assertEqual(len(tags_to_pg), 4)
-        # "" is the default tag for user PGs, and the default tag should only
-        # contain 3 pgs, since we re-use pgs, whenever possible. The 3 pgs are:
-        #   1) pg for the whole world
-        #   2) pg for tp_group
-        #   3) pg for dp_group
-        self.assertEqual(len(tags_to_pg[""]), 3)
-
-        default_user_pgs = tags_to_pg[""]
-        dp_dim = 0
-        tp_dim = 1
-        for idx, group in enumerate(default_user_pgs):
-            # world size pg
-            if idx == 0:
-                self.assertEqual(get_process_group_ranks(group), range(self.world_size))
-            # tp pg
-            if idx == 1:
-                # rank0 - mesh_2d._dim_group_infos is: [('ptd:3', [0, 2]), ('ptd:1', [0, 1])]
-                tp_group_ranks = mesh_2d._dim_group_infos[tp_dim][1]
-                self.assertEqual(get_process_group_ranks(group), tp_group_ranks)
-            # dp pg
-            if idx == 2:
-                dp_group_ranks = mesh_2d._dim_group_infos[dp_dim][1]
-                self.assertEqual(get_process_group_ranks(group), dp_group_ranks)
 
     @with_comms
     def test_get_group(self):
@@ -202,6 +134,13 @@ class DeviceMeshTest(DTensorTestBase):
                 dim_ranks[0] if self.rank in dim_ranks[0] else dim_ranks[1]
             )
             self.assertEqual(global_ranks, current_rank_expected_group_ranks)
+
+    @with_comms
+    def test_lazy_init_device_mesh(self):
+        mesh = DeviceMesh(self.device_type, [1], _init_process_groups=False)
+
+        with self.assertRaisesRegex(RuntimeError, "process groups not initialized!"):
+            mesh.get_group()
 
     def test_fake_pg_device_mesh(self):
         fake_store = FakeStore()

--- a/torch/distributed/tensor/parallel/_utils.py
+++ b/torch/distributed/tensor/parallel/_utils.py
@@ -167,7 +167,7 @@ def _create_1d_device_mesh(device_mesh: DeviceMesh, tp_mesh_dim: int = 0) -> Dev
         -1, device_mesh.mesh.size(tp_mesh_dim)
     )
     for mesh_1d in pg_ranks_by_dim:
-        sub_mesh = DeviceMesh(device_mesh.device_type, mesh_1d)
+        sub_mesh = DeviceMesh(device_mesh.device_type, mesh_1d, _init_process_groups=False)
         if cur_rank in mesh_1d:
             res_sub_mesh = sub_mesh
 


### PR DESCRIPTION
Manually revert https://github.com/pytorch/pytorch/pull/115716 [D53122872] as it seems breaking two internal APS tests and causing them to be disabled now. Not sure why it was not caught in the Sandcastle test in the diff train in the beginning.

Note: cannot manually revert using co-dev with fbcode first, since export doesn't patch the revert change properly and fail to export to github. Therefore, creating the revert from Github first. 

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @tianyu-l @wconstab @yf225