### PR TITLE
[PT-Vulkan] aten::conv1d - support any channel-group combo

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/conv1d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/conv1d.glsl
@@ -17,12 +17,13 @@ layout(set = 0, binding = 2) uniform PRECISION sampler3D uKernel;
 layout(set = 0, binding = 3) uniform PRECISION sampler3D uBias;
 
 layout(set = 0, binding = 4) uniform PRECISION restrict Block {
-  int out_channels;
   int in_length;
   int kernel_size;
   int strides;
   int padding;
   int dilation;
+  int in_group_size;
+  int out_group_size;
 }
 uBlock;
 
@@ -33,27 +34,35 @@ int ceil(int a, int b) {
   return (a + b - 1) / b;
 }
 
-// This implementation optimize for simplicity (and partially performance) for a
-// (1, C, L) where C == groups. Hence we only focus on calculating the rolling
-// kernel of the L dimension.
+// Let us define
+//
+// input = (n=1, in_C, in_L),
+// output = (n=1, out_C, out_L),
+// groups = G,
+// kernel = K,
+//
+// which results in shapes
+//
+// weight = (out_C, in_C / G, K),
+// bias = (out_C,).
+//
+// This implementation performs out_C number of shader invocations, where each
+// invocation calculates the rolling kernel of the length dimension, i.e.,
+// computes the out_L results.
 void main() {
   const ivec3 pos = ivec3(gl_GlobalInvocationID);
 
-  const int out_channels = uBlock.out_channels;
   const int in_length = uBlock.in_length;
   const int kernel_size = uBlock.kernel_size;
   const int strides = uBlock.strides;
   const int padding = uBlock.padding;
   const int dilation = uBlock.dilation;
+  const int in_group_size = uBlock.in_group_size;
+  const int out_group_size = uBlock.out_group_size;
 
-  // The global workgroup should have taken care of it. We only perform one
-  // work item for each 1d tensor on lengths
+  // The global workgroup should have taken care of it. We perform one shader
+  // invocation, per 1D length array of the output tensor.
   if (pos.x >= 1) {
-    return;
-  }
-
-  int c = pos.y;
-  if (c >= out_channels) {
     return;
   }
 
@@ -63,51 +72,52 @@ void main() {
     return;
   }
 
-  vec4 bias = texelFetch(uBias, ivec3(c, 0, 0), 0);
+  // "out_c" is the output's channel index where we write our result.
+  int out_c = pos.y;
+  vec4 bias = texelFetch(uBias, ivec3(out_c, 0, 0), 0);
 
-  // "i" tracks the input's start index for our input-kernel overlay region.
-  int start = -padding;
-  int end = in_length + padding - dilation * (kernel_size - 1);
+  // "in_c" tracks the input's channel start index.
+  // We iterate over the input group that corresponds to the output group.
+  int c_start = (out_c / out_group_size) * in_group_size;
+  int c_end = c_start + in_group_size;
 
-  // "r" tracks the output's index where we write our result.
-  int r = 0;
+  // "in_l" tracks the input's length start index for our input-kernel overlay
+  // region.
+  int l_start = -padding;
+  int l_end = in_length + padding - dilation * (kernel_size - 1);
 
-  for (int i = start; i < end; i += strides, ++r) {
+  // "out_l" tracks the output's length index where we write our result.
+  int out_l = 0;
+
+  for (int in_l = l_start; in_l < l_end; in_l += strides, ++out_l) {
     vec4 v = vec4(0,0,0,0);
 
     // "k" tracks the kernel's index for our input-kernel computation.
     // The kstart/kend borders detect when the corresponding input index is out
     // of bounds.
-    int kstart = max(0, ceil(-i, dilation));
-    int kend = min(kernel_size, ceil(in_length-i, dilation));
+    int k_start = max(0, ceil(-in_l, dilation));
+    int k_end = min(kernel_size, ceil(in_length-in_l, dilation));
 
-    for (int k = kstart; k < kend; ++k) {
-      int in_pos_x = i + k * dilation;
-      const ivec3 in_pos = ivec3(in_pos_x, c, 0);
-      const vec4 input_value = texelFetch(uInput, in_pos, 0);
+    for (int in_c = c_start; in_c < c_end; ++in_c) {
+      for (int k = k_start; k < k_end; ++k) {
+        int in_pos_x = in_l + k * dilation;
+        const ivec3 in_pos = ivec3(in_pos_x, in_c, 0);
+        const vec4 input_value = texelFetch(uInput, in_pos, 0);
 
-      // Note that we are reading weight in the inner loop, this could be
-      // improved by moving it before the outer loop. Since the weight vector is
-      // contant for the entire call.
+        // Note that we are reading weight in the inner loop, this could be
+        // improved by moving it before the outer loop. Since the weight vector is
+        // contant for the entire call.
 
-      // weight in input-space: (c, 0, k);
-      // notice that c is 4-packed. We need to mod 4 to get the actual weight.
-      const ivec3 w_pos = ivec3(k, 0, c / 4);
-      const vec4 weight = texelFetch(uKernel, w_pos, 0);
+        // weight in input-space: (out_c, in_c % in_group_size, k);
+        // notice that c is 4-packed. We need to mod 4 to get the actual weight.
+        const ivec3 w_pos = ivec3(k, in_c % in_group_size, out_c / 4);
+        const vec4 weight = texelFetch(uKernel, w_pos, 0);
 
-      float w = weight.x;
-      if (c % 4 == 1) {
-        w = weight.y;
-      } else if (c % 4 == 2) {
-        w = weight.z;
-      } else if (c % 4 == 3) {
-        w = weight.w;
+        v += weight[out_c % 4] * input_value.x;
       }
-
-      v += w * input_value.x;
     }
 
-    ivec3 out_pos = ivec3(r, c, 0);
+    ivec3 out_pos = ivec3(out_l, out_c, 0);
     imageStore(uOutput, out_pos, vec4(v.x + bias.x, 0, 0, 0));
   }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #118835
* #118834
* __->__ #118833

## Main

Part of completing `aten::conv1d`'s implementation. See D53204673 for full context.

This diff relaxes the constraint
```
c_in = c_out = groups
```
to support any legal combination of c_in, c_out, groups.

From the [PyTorch docs](https://pytorch.org/docs/stable/generated/torch.nn.Conv1d.html), both c_in and c_out must be divisible by groups. Apart from that, any combo is now fair game.

## Additional

Improved GLSL comments and variable names, since more indices yield more headaches.

Differential Revision: [D53248767](https://our.internmc.facebook.com/intern/diff/D53248767/)