### PR TITLE
Support generic PyTensorType checking and support getting generic storage in function get_storage_obj.

### DIFF
--- a/c10/core/Layout.h
+++ b/c10/core/Layout.h
@@ -35,6 +35,7 @@ inline Layout layout_from_backend(Backend backend) {
     case Backend::SparseHIP:
     case Backend::SparseVE:
     case Backend::SparseXPU:
+    case Backend::SparsePrivateUse1:
       return Layout::Sparse;
     case Backend::MkldnnCPU:
       return Layout::Mkldnn;

--- a/test/cpp_extensions/open_registration_extension.cpp
+++ b/test/cpp_extensions/open_registration_extension.cpp
@@ -20,6 +20,7 @@
 #include <ATen/EmptyTensor.h>
 #include <ATen/core/GeneratorForPrivateuseone.h>
 #include <ATen/detail/PrivateUse1HooksInterface.h>
+#include <torch/csrc/tensor/python_tensor.h>
 #include <ATen/ops/view.h>
 
 static uint64_t add_counter = 0;
@@ -32,14 +33,13 @@ static uint64_t last_abs_saved_value = 0;
 static uint64_t storageImpl_counter = 0;
 static uint64_t last_storageImpl_saved_value = 0;
 // register guard
-namespace at {
-namespace detail {
+namespace at::detail {
 
 C10_REGISTER_GUARD_IMPL(
     PrivateUse1,
     c10::impl::NoOpDeviceGuardImpl<DeviceType::PrivateUse1>);
 
-}} // namespace at::detail
+} // namespace at::detail
 
 namespace {
 
@@ -47,8 +47,6 @@ void abs_kernel(::at::TensorIteratorBase& iter) {
   // Since this custom device is just for testing, not bothering to implement kernels.
   abs_counter += 1;
 }
-
-} // namespace
 
 void quantize_tensor_per_tensor_affine_privateuse1(
     const at::Tensor& rtensor,
@@ -58,12 +56,15 @@ void quantize_tensor_per_tensor_affine_privateuse1(
     // do nothing
 }
 
+} // namespace
+
 namespace at::native {
 
 REGISTER_PRIVATEUSE1_DISPATCH(abs_stub, &abs_kernel);
 REGISTER_PRIVATEUSE1_DISPATCH(quantize_tensor_per_tensor_affine_stub, &quantize_tensor_per_tensor_affine_privateuse1);
 
 } // namespace at::native
+
 struct CustomBackendMetadata : public c10::BackendMeta {
   // for testing this field will mutate when clone() is called by shallow_copy_from.
   int backend_version_format_{-1};

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1055,6 +1055,7 @@ def _add_docstr(obj: T, doc_obj: str) -> T: ...  # THPModule_addDocStr
 def _init_names(arg: Sequence[Type]) -> None: ...  # THPModule_initNames
 def _has_distributed() -> _bool: ...  # THPModule_hasDistributed
 def _set_default_tensor_type(type) -> None: ...  # THPModule_setDefaultTensorType
+def _register_custom_device_tensor_types() ->None: ...  # THPModule_registerCustomDeviceTensorTypes
 def _set_default_dtype(d: _dtype) -> None: ...  # THPModule_setDefaultDtype
 def _infer_size(arg1: Size, arg2: Size) -> Size: ...  # THPModule_inferSize
 def _crash_if_csrc_asan() -> _int: ...  # THPModule_crashIfCsrcASAN

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1447,7 +1447,7 @@ _storage_classes = {
     TypedStorage
 }
 
-# The _tensor_classes set is initialized by the call to _C._initialize_tensor_type_bindings()
+# The _tensor_classes set is initialized by the call to initialize_python_bindings.
 _tensor_classes: Set[Type] = set()
 
 # If you edit these imports, please update torch/__init__.py.in as well
@@ -1899,6 +1899,18 @@ def _register_device_module(device_type, module):
     setattr(m, device_type, module)
     torch_module_name = '.'.join([__name__, device_type])
     sys.modules[torch_module_name] = module
+
+def _register_custom_device_tensor_types(device_type):
+    r"""Register tensor types to torch._tensor_classes for the specific :attr:`device_type`
+    supported by torch.
+    """
+    # Make sure the device_type represent a supported device type for torch.
+    device_type = torch.device(device_type).type
+    m = sys.modules[__name__]
+    if not hasattr(m, device_type):
+        raise RuntimeError(f"The runtime module of '{device_type}' has not "
+                           f"been registered.")
+    _C._register_custom_device_tensor_types()
 
 # expose return_types
 from . import return_types

--- a/torch/csrc/tensor/python_tensor.h
+++ b/torch/csrc/tensor/python_tensor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/core/Backend.h>
 #include <c10/core/Device.h>
 #include <c10/core/DispatchKey.h>
 #include <c10/core/ScalarType.h>
@@ -14,7 +15,12 @@ namespace tensors {
 
 // Initializes the Python tensor type objects: torch.FloatTensor,
 // torch.DoubleTensor, etc. and binds them in their containing modules.
-void initialize_python_bindings();
+// Pytorch side only register CPU and GPU tensor types, if a third-party device
+// also need to register thire tensor types in torch._tensor_classes, this
+// function can be called at third-party framework.
+void initialize_python_bindings(
+    const std::vector<std::pair<c10::Backend, c10::ScalarType>>&
+        declared_types);
 
 // Same as set_default_tensor_type() but takes a PyObject*
 void py_set_default_tensor_type(PyObject* type_obj);

--- a/torch/csrc/utils/device_lazy_init.h
+++ b/torch/csrc/utils/device_lazy_init.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <aten/src/ATen/Context.h>
 #include <c10/core/TensorOptions.h>
 
 // device_lazy_init() is always compiled, even for CPU-only builds.
@@ -30,6 +31,9 @@ static inline void maybe_initialize_device(at::Device& device) {
   // Add more devices here to enable lazy initialization.
   if (device.is_cuda()) {
     device_lazy_init(device.type());
+  }
+  if (device.is_privateuseone()) {
+    at::globalContext().lazyInitPrivateUse1();
   }
 }
 

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -44,8 +44,7 @@ using at::Tensor;
 using at::TensorOptions;
 using c10::optional;
 
-namespace torch {
-namespace utils {
+namespace torch::utils {
 namespace {
 const int MAX_DIMS = 128;
 
@@ -535,6 +534,7 @@ void check_base_legacy_new(
         c10::DispatchKey::SparseCUDA,
         c10::DispatchKey::SparseHIP,
         c10::DispatchKey::SparseXPU,
+        c10::DispatchKey::SparsePrivateUse1,
     });
     TORCH_CHECK(
         expected_key_set.has(dispatch_key),
@@ -1786,5 +1786,4 @@ Tensor asarray(
   return tensor;
 }
 
-} // namespace utils
-} // namespace torch
+} // namespace torch::utils

--- a/torch/csrc/utils/tensor_types.h
+++ b/torch/csrc/utils/tensor_types.h
@@ -8,12 +8,20 @@
 namespace torch {
 namespace utils {
 
+// return const char* for python module name. Like torch.cuda,
+// torch.cuda.sparse
+const char* backend_to_python_module_name(const at::Backend& backend);
+
 std::string options_to_string(const at::TensorOptions& options);
 std::string type_to_string(const at::DeprecatedTypeProperties& type);
 at::TensorOptions options_from_string(const std::string& str);
 
 // return a vector of all "declared" types, even those that weren't compiled
 std::vector<std::pair<at::Backend, at::ScalarType>> all_declared_types();
+
+// return a vector of all "declared" types, even those that weren't compiled
+std::vector<std::pair<at::Backend, at::ScalarType>>
+all_privateUser1_declared_types();
 
 } // namespace utils
 } // namespace torch


### PR DESCRIPTION
Third party device can do some thing like function py_bind_tensor_types, and to register their tensor type in torch._tensor_class, so maybe we need more generic way to handle tensor PyTensorType.

py_bind_tensor_types:
https://github.com/pytorch/pytorch/blob/main/torch/csrc/tensor/python_tensor.cpp#L405

1) By using torch._tensor_class from python side to check object in py_set_default_tensor_type;
2) Support more device types in function get_storage_obj.

Fixes #ISSUE_NUMBER
cc @soulitzer @bdhirsh  