### PR TITLE
Add ability to print histogram as a github issue

### DIFF
--- a/scripts/compile_tests/failures_histogram.py
+++ b/scripts/compile_tests/failures_histogram.py
@@ -102,9 +102,7 @@ def failures_histogram(eager_dir, dynamo_dir, verbose=False, format_issues=False
     print("[counts]", sum_counts)
 
 
-def as_issue(count, msg, repro, tests=None):
-    if tests is None:
-        print("please pass --verbose to use --print-issues")
+def as_issue(count, msg, repro, tests):
     tests = "\n".join(tests)
     result = f"""
 {'-' * 50}
@@ -149,6 +147,12 @@ if __name__ == "__main__":
         action="store_true",
     )
     args = parser.parse_args()
+
+    # args.format_issues implies verbose=True
+    verbose = args.verbose
+    if args.format_issues:
+        verbose = True
+
     failures_histogram(
-        args.eager_dir, args.dynamo_dir, args.verbose, args.format_issues
+        args.eager_dir, args.dynamo_dir, verbose, args.format_issues
     )

--- a/scripts/compile_tests/failures_histogram.py
+++ b/scripts/compile_tests/failures_histogram.py
@@ -32,6 +32,12 @@ def skip_reason_normalized(testcase):
         result = re.sub(r"0x\w+", "0xDEADBEEF", result)
         result = re.sub(r"MagicMock id='\d+'", "MagicMock id='0000000000'", result)
         result = re.sub(r"issues/\d+", "issues/XXX", result)
+        result = re.sub(r"torch.Size\(\[.*\]\)", "torch.Size([...])", result)
+        result = re.sub(
+            r"Could not get qualified name for class '.*'",
+            "Could not get qualified name for class",
+            result,
+        )
         return result
     raise AssertionError("no message?")
 
@@ -60,7 +66,7 @@ def all_tests(testcase):
 
 
 # e.g. "17c5f69852/eager", "17c5f69852/dynamo"
-def failures_histogram(eager_dir, dynamo_dir, verbose=False):
+def failures_histogram(eager_dir, dynamo_dir, verbose=False, format_issues=False):
     fail_keys = compute_pass_rate(eager_dir, dynamo_dir)
     xmls = open_test_results(dynamo_dir)
 
@@ -89,8 +95,40 @@ def failures_histogram(eager_dir, dynamo_dir, verbose=False):
     print(header)
     sum_counts = sum([r[0] for r in result])
     for row in result:
-        print(row)
+        if format_issues:
+            print(as_issue(*row))
+        else:
+            print(row)
     print("[counts]", sum_counts)
+
+
+def as_issue(count, msg, repro, tests=None):
+    if tests is None:
+        print("please pass --verbose to use --print-issues")
+    tests = "\n".join(tests)
+    result = f"""
+{'-' * 50}
+{count} Dynamo test are failing with \"{msg}\".
+
+## Repro
+
+`{repro}`
+
+You will need to remove the skip or expectedFailure before running the repro command.
+This may be just removing a line in
+[dynamo_test_failures.py](https://github.com/pytorch/pytorch/blob/main/torch/testing/_internal/dynamo_test_failures.py)
+
+## Failing tests
+
+Here's a comprehensive list of tests that fail (as of this issue) with the above message:
+<details>
+<summary>Click me</summary>
+```
+{tests}
+```
+</details>
+"""
+    return result
 
 
 if __name__ == "__main__":
@@ -105,5 +143,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "-v", "--verbose", help="Prints all failing test names", action="store_true"
     )
+    parser.add_argument(
+        "--format-issues",
+        help="Prints histogram in a way that they can be copy-pasted as a github issues",
+        action="store_true",
+    )
     args = parser.parse_args()
-    failures_histogram(args.eager_dir, args.dynamo_dir, args.verbose)
+    failures_histogram(
+        args.eager_dir, args.dynamo_dir, args.verbose, args.format_issues
+    )

--- a/scripts/compile_tests/failures_histogram.py
+++ b/scripts/compile_tests/failures_histogram.py
@@ -153,6 +153,4 @@ if __name__ == "__main__":
     if args.format_issues:
         verbose = True
 
-    failures_histogram(
-        args.eager_dir, args.dynamo_dir, verbose, args.format_issues
-    )
+    failures_histogram(args.eager_dir, args.dynamo_dir, verbose, args.format_issues)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #118931
* #118882
* __->__ #118874

Adds the ability to print the failures histogram into lines that can be
copy-pasted into a github issue.

I used this to generate https://github.com/orgs/pytorch/projects/43

Test Plan:
- tested locally