### PR TITLE
Make `argnums` in `jacrev` and `jacfwd` truely optional.

### DIFF
--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -2081,12 +2081,13 @@ class TestJac(TestCase):
         name = jacapi.__name__
         with self.assertRaisesRegex(
             TypeError,
-            f"{name}: `argnums` should be int or Tuple\[int, \.\.\.\], got: <class 'float'>",
+            f"{name}: `argnums` should be int or Tuple\\[int, \\.\\.\\.\\], got: <class 'float'>",
         ):
             jacapi(torch.sin, argnums=0.0)(x)
         with self.assertRaisesRegex(
             TypeError,
-            f"{name}: `argnums` should be int or Tuple\[int, \.\.\.\], got: Tuple\[<class 'int'>, <class 'float'>\]",
+            f"{name}: `argnums` should be int or Tuple\\[int, \\.\\.\\.\\], got: "
+            f"Tuple\\[<class 'int'>, <class 'float'>\\]",
         ):
             jacapi(torch.multiply, argnums=(1, 0.0))(x, x)
 

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -2078,12 +2078,16 @@ class TestJac(TestCase):
     @jacrev_and_jacfwd
     def test_float_argnums(self, device, jacapi):
         x = torch.randn(3, device=device)
-        with self.assertRaisesRegex(TypeError, f"{jacapi.__name__}: `argnums` should be int or "
-                                                f"Tuple[int, ...], got: <class 'float'>"):
+        name = jacapi.__name__
+        with self.assertRaisesRegex(
+            TypeError,
+            f"{name}: `argnums` should be int or Tuple[int, ...], got: <class 'float'>",
+        ):
             jacapi(torch.sin, argnums=0.0)(x)
-        with self.assertRaisesRegex(TypeError, f"{jacapi.__name__}: `argnums` should be int or "
-                                                f"Tuple[int, ...], got: Tuple[<class 'int'>, "
-                                                f"<class 'float'>]"):
+        with self.assertRaisesRegex(
+            TypeError,
+            f"{name}: `argnums` should be int or Tuple[int, ...], got: Tuple[<class 'int'>, <class 'float'>]",
+        ):
             jacapi(torch.multiply, argnums=(1, 0.0))(x, x)
 
     def test_hessian_simple(self, device):

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -2081,12 +2081,12 @@ class TestJac(TestCase):
         name = jacapi.__name__
         with self.assertRaisesRegex(
             TypeError,
-            f"{name}: `argnums` should be int or Tuple[int, ...], got: <class 'float'>",
+            f"TypeError: {name}: `argnums` should be int or Tuple\[int, \.\.\.\], got: <class 'float'>",
         ):
             jacapi(torch.sin, argnums=0.0)(x)
         with self.assertRaisesRegex(
             TypeError,
-            f"{name}: `argnums` should be int or Tuple[int, ...], got: Tuple[<class 'int'>, <class 'float'>]",
+            f"TypeError: {name}: `argnums` should be int or Tuple\[int, \.\.\.\], got: <class 'float'>",
         ):
             jacapi(torch.multiply, argnums=(1, 0.0))(x, x)
 

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -2078,9 +2078,12 @@ class TestJac(TestCase):
     @jacrev_and_jacfwd
     def test_float_argnums(self, device, jacapi):
         x = torch.randn(3, device=device)
-        with self.assertRaisesRegex(RuntimeError, f"{jacapi.__name__}: `argnums` should be int or Tuple[int, ...], got: <class \'float\'>"):
+        with self.assertRaisesRegex(ValueError, f"{jacapi.__name__}: `argnums` should be int or "
+                                                f"Tuple[int, ...], got: <class 'float'>"):
             jacapi(torch.sin, argnums=0.0)(x)
-        with self.assertRaisesRegex(RuntimeError, f"{jacapi.__name__}: `argnums` should be int or Tuple[int, ...], got: Tuple[<class 'int'>, <class 'float'>]"):
+        with self.assertRaisesRegex(ValueError, f"{jacapi.__name__}: `argnums` should be int or "
+                                                f"Tuple[int, ...], got: Tuple[<class 'int'>, "
+                                                f"<class 'float'>]"):
             jacapi(torch.multiply, argnums=(1, 0.0))(x, x)
 
     def test_hessian_simple(self, device):

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -2081,7 +2081,7 @@ class TestJac(TestCase):
         name = jacapi.__name__
         with self.assertRaisesRegex(
             TypeError,
-            f"TypeError: {name}: `argnums` should be int or Tuple\[int, \.\.\.\], got: <class 'float'>",
+            f"{name}: `argnums` should be int or Tuple\[int, \.\.\.\], got: <class 'float'>",
         ):
             jacapi(torch.sin, argnums=0.0)(x)
         with self.assertRaisesRegex(

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -2086,7 +2086,7 @@ class TestJac(TestCase):
             jacapi(torch.sin, argnums=0.0)(x)
         with self.assertRaisesRegex(
             TypeError,
-            f"TypeError: {name}: `argnums` should be int or Tuple\[int, \.\.\.\], got: <class 'float'>",
+            f"{name}: `argnums` should be int or Tuple\[int, \.\.\.\], got: Tuple\[<class 'int'>, <class 'float'>\]",
         ):
             jacapi(torch.multiply, argnums=(1, 0.0))(x, x)
 

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -2078,10 +2078,10 @@ class TestJac(TestCase):
     @jacrev_and_jacfwd
     def test_float_argnums(self, device, jacapi):
         x = torch.randn(3, device=device)
-        with self.assertRaisesRegex(ValueError, f"{jacapi.__name__}: `argnums` should be int or "
+        with self.assertRaisesRegex(TypeError, f"{jacapi.__name__}: `argnums` should be int or "
                                                 f"Tuple[int, ...], got: <class 'float'>"):
             jacapi(torch.sin, argnums=0.0)(x)
-        with self.assertRaisesRegex(ValueError, f"{jacapi.__name__}: `argnums` should be int or "
+        with self.assertRaisesRegex(TypeError, f"{jacapi.__name__}: `argnums` should be int or "
                                                 f"Tuple[int, ...], got: Tuple[<class 'int'>, "
                                                 f"<class 'float'>]"):
             jacapi(torch.multiply, argnums=(1, 0.0))(x, x)

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -2035,18 +2035,6 @@ class TestJac(TestCase):
         assert isinstance(z, torch.Tensor)
         assert torch.allclose(z, expected0)
 
-    @xfailIfTorchDynamo
-    @jacrev_and_jacfwd
-    def test_argnums_none(self, device, jacapi):
-        x = torch.randn(3, device=device)
-        y = torch.randn(3, device=device)
-        z = jacapi(torch.multiply, argnums=None)(x, y)
-        expected0 = torch.diagflat(y)
-        expected1 = torch.diagflat(x)
-        assert len(z) == 2
-        assert torch.allclose(z[0], expected0)
-        assert torch.allclose(z[1], expected1)
-
     @FIXME_skip_jacrev_dynamo
     def test_argnums_defaults_to_zero(self, device, jacapi):
         def f(x, y):

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -2078,9 +2078,9 @@ class TestJac(TestCase):
     @jacrev_and_jacfwd
     def test_float_argnums(self, device, jacapi):
         x = torch.randn(3, device=device)
-        with self.assertRaisesRegex(RuntimeError, "must be int or Tuple"):
+        with self.assertRaisesRegex(RuntimeError, f"{jacapi.__name__}: `argnums` should be int or Tuple[int, ...], got: <class \'float\'>"):
             jacapi(torch.sin, argnums=0.0)(x)
-        with self.assertRaisesRegex(RuntimeError, "must be int"):
+        with self.assertRaisesRegex(RuntimeError, f"{jacapi.__name__}: `argnums` should be int or Tuple[int, ...], got: Tuple[<class 'int'>, <class 'float'>]"):
             jacapi(torch.multiply, argnums=(1, 0.0))(x, x)
 
     def test_hessian_simple(self, device):

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -2035,6 +2035,18 @@ class TestJac(TestCase):
         assert isinstance(z, torch.Tensor)
         assert torch.allclose(z, expected0)
 
+    @xfailIfTorchDynamo
+    @jacrev_and_jacfwd
+    def test_argnums_none(self, device, jacapi):
+        x = torch.randn(3, device=device)
+        y = torch.randn(3, device=device)
+        z = jacapi(torch.multiply, argnums=None)(x, y)
+        expected0 = torch.diagflat(y)
+        expected1 = torch.diagflat(x)
+        assert len(z) == 2
+        assert torch.allclose(z[0], expected0)
+        assert torch.allclose(z[1], expected1)
+
     @FIXME_skip_jacrev_dynamo
     def test_argnums_defaults_to_zero(self, device, jacapi):
         def f(x, y):

--- a/torch/_functorch/eager_transforms.py
+++ b/torch/_functorch/eager_transforms.py
@@ -505,7 +505,7 @@ def jacrev(func: Callable, argnums: argnums_t = 0, *, has_aux=False,
     if not (chunk_size is None or chunk_size > 0):
         raise ValueError("jacrev: `chunk_size` should be greater than 0.")
 
-    _error_if_not_argnum_t("jarev", "argnums", argnums)
+    _error_if_not_argnum_t("jacrev", "argnums", argnums)
 
     @wraps(func)
     def wrapper_fn(*args):

--- a/torch/_functorch/eager_transforms.py
+++ b/torch/_functorch/eager_transforms.py
@@ -366,10 +366,10 @@ def error_if_complex(func_name, args, is_input):
 
 def _error_if_not_argnum_t(caller: str, arg_name: str, value: Any) -> None:
     if not isinstance(value, int) and not isinstance(value, tuple):
-        raise ValueError(f"{caller}: `{arg_name}` should be int or Tuple[int, ...], got: {type(value)}")
+        raise TypeError(f"{caller}: `{arg_name}` should be int or Tuple[int, ...], got: {type(value)}")
     elif isinstance(value, tuple) and not all(isinstance(element, int) for element in value):
         types = ', '.join([str(type(element)) for element in value])
-        raise ValueError(f"{caller}: `{arg_name}` should be int or Tuple[int, ...], got: Tuple[{types}]")
+        raise TypeError(f"{caller}: `{arg_name}` should be int or Tuple[int, ...], got: Tuple[{types}]")
 
 
 @exposed_in("torch.func")

--- a/torch/_functorch/eager_transforms.py
+++ b/torch/_functorch/eager_transforms.py
@@ -1130,7 +1130,7 @@ def jacfwd(func: Callable, argnums: argnums_t = 0, has_aux: bool = False, *, ran
         >>> assert torch.allclose(jacobian[1], expectedY)
 
     """
-    _error_if_not_argnum_t("jafwd", "argnums", argnums)
+    _error_if_not_argnum_t("jacfwd", "argnums", argnums)
 
     @wraps(func)
     def wrapper_fn(*args):

--- a/torch/_functorch/eager_transforms.py
+++ b/torch/_functorch/eager_transforms.py
@@ -364,7 +364,7 @@ def error_if_complex(func_name, args, is_input):
             raise RuntimeError(err_msg)
 
 @exposed_in("torch.func")
-def jacrev(func: Callable, argnums: Union[int, Tuple[int]] = 0, *, has_aux=False,
+def jacrev(func: Callable, argnums: Optional[argnums_t] = 0, *, has_aux=False,
            chunk_size: Optional[int] = None,
            _preallocate_and_copy=False):
     """
@@ -379,8 +379,9 @@ def jacrev(func: Callable, argnums: Union[int, Tuple[int]] = 0, *, has_aux=False
     Args:
         func (function): A Python function that takes one or more arguments,
             one of which must be a Tensor, and returns one or more Tensors
-        argnums (int or Tuple[int]): Optional, integer or tuple of integers,
+        argnums (int or Tuple[int, ...]): Optional, integer or tuple of integers,
             saying which arguments to get the Jacobian with respect to.
+            If None, the Jacobian is computed with respect to all inputs.
             Default: 0.
         has_aux (bool): Flag indicating that ``func`` returns a
             ``(output, aux)`` tuple where the first element is the output of
@@ -514,7 +515,7 @@ def jacrev(func: Callable, argnums: Union[int, Tuple[int]] = 0, *, has_aux=False
         # Step 1: Construct grad_outputs by splitting the standard basis
         flat_output_numels = tuple(out.numel() for out in flat_output)
 
-        primals = _slice_argnums(args, argnums)
+        primals = args if argnums is None else _slice_argnums(args, argnums)
         flat_primals, primals_spec = tree_flatten(primals)
 
         def compute_jacobian_stacked():

--- a/torch/_functorch/eager_transforms.py
+++ b/torch/_functorch/eager_transforms.py
@@ -6,7 +6,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Callable, Union, Tuple, List, Any, Optional
+from typing import Callable, Tuple, List, Any, Optional
 import torch
 from functools import partial, wraps
 import contextlib

--- a/torch/_functorch/eager_transforms.py
+++ b/torch/_functorch/eager_transforms.py
@@ -363,6 +363,15 @@ def error_if_complex(func_name, args, is_input):
                        f"to be real but received complex tensor at flattened input idx: {idx}")
             raise RuntimeError(err_msg)
 
+
+def _error_if_not_argnum_t(caller: str, arg_name: str, value: Any) -> None:
+    if not isinstance(value, int) and not isinstance(value, tuple):
+        raise ValueError(f"{caller}: `{arg_name}` should be int or Tuple[int, ...], got: {type(value)}")
+    elif isinstance(value, tuple) and not all(isinstance(element, int) for element in value):
+        types = ', '.join([str(type(element)) for element in value])
+        raise ValueError(f"{caller}: `{arg_name}` should be int or Tuple[int, ...], got: Tuple[{types}]")
+
+
 @exposed_in("torch.func")
 def jacrev(func: Callable, argnums: argnums_t = 0, *, has_aux=False,
            chunk_size: Optional[int] = None,
@@ -496,8 +505,7 @@ def jacrev(func: Callable, argnums: argnums_t = 0, *, has_aux=False,
     if not (chunk_size is None or chunk_size > 0):
         raise ValueError("jacrev: `chunk_size` should be greater than 0.")
 
-    if not isinstance(argnums, int) and not isinstance(argnums, tuple):
-        raise ValueError(f"jacrev: `argnums` should be int or Tuple[int, ...], got: {type(argnums)}")
+    _error_if_not_argnum_t("jarev", "argnums", argnums)
 
     @wraps(func)
     def wrapper_fn(*args):
@@ -1122,8 +1130,7 @@ def jacfwd(func: Callable, argnums: argnums_t = 0, has_aux: bool = False, *, ran
         >>> assert torch.allclose(jacobian[1], expectedY)
 
     """
-    if not isinstance(argnums, int) and not isinstance(argnums, tuple):
-        raise ValueError(f"jacrev: `argnums` should be int or Tuple[int, ...], got: {type(argnums)}")
+    _error_if_not_argnum_t("jafwd", "argnums", argnums)
 
     @wraps(func)
     def wrapper_fn(*args):

--- a/torch/_functorch/eager_transforms.py
+++ b/torch/_functorch/eager_transforms.py
@@ -1015,7 +1015,7 @@ def safe_unflatten(tensor, dim, shape):
 
 
 @exposed_in("torch.func")
-def jacfwd(func: Callable, argnums: argnums_t = 0, has_aux: bool = False, *, randomness: str = "error"):
+def jacfwd(func: Callable, argnums: Optional[argnums_t] = 0, has_aux: bool = False, *, randomness: str = "error"):
     """
     Computes the Jacobian of ``func`` with respect to the arg(s) at index
     ``argnum`` using forward-mode autodiff
@@ -1023,8 +1023,9 @@ def jacfwd(func: Callable, argnums: argnums_t = 0, has_aux: bool = False, *, ran
     Args:
         func (function): A Python function that takes one or more arguments,
             one of which must be a Tensor, and returns one or more Tensors
-        argnums (int or Tuple[int]): Optional, integer or tuple of integers,
+        argnums (int or Tuple[int, ...]): Optional, integer or tuple of integers,
             saying which arguments to get the Jacobian with respect to.
+            If None, the Jacobian is computed with respect to all inputs.
             Default: 0.
         has_aux (bool): Flag indicating that ``func`` returns a
             ``(output, aux)`` tuple where the first element is the output of


### PR DESCRIPTION
Fixes #118861

For both `jacrev` and `jacfwd`:
- Fixes the typing of `argnums` to `Optional[argnums_t]`.
- Improves the doc to specify behavior in case of `None`, in this case we take the jacobian w.r.t. all inputs.
- Tests the `None` parameter.

I was able to lint the PR, however I could not run tests despite my best efforts to make it work. The only test that can fail should be the one I wrote.

As a side comment, it feels like the default value for `argnums` in both `jacrev` and `jacfwd` would be more naturally `None` instead of `0`. The problem is that it would make the change not backward compatible and in particular the typical use of default argument is when we have only one argument to differentiate with respect to it but in that case we would return a tuple containing only one tensor instead of the said tensor. Therefore it feels hard to make that change.