### PR TITLE
[DCP] Adds utility for converting dcp to torch save format

### DIFF
--- a/docs/source/distributed.checkpoint.rst
+++ b/docs/source/distributed.checkpoint.rst
@@ -95,3 +95,7 @@ an experimental feature and is subject to change.
 
 .. autoclass:: torch.distributed.checkpoint.state_dict.StateDictOptions
    :members:
+
+For users which are used to using and sharing models in the `torch.save` format, the following utilities are pvoided:
+
+.. autofunction:: torch.distributed.checkpoint.format_utils.dcp_to_torch_save

--- a/test/distributed/checkpoint/test_dcp_to_torch_save.py
+++ b/test/distributed/checkpoint/test_dcp_to_torch_save.py
@@ -1,0 +1,34 @@
+# Owner(s): ["oncall: distributed"]
+
+import torch
+import torch.distributed.checkpoint as dcp
+from torch.distributed.checkpoint.format_utils import dcp_to_torch_save
+from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    DTensorTestBase,
+    ModelArgs,
+    skip_if_lt_x_gpu,
+    Transformer,
+    with_comms,
+)
+from torch.testing._internal.distributed.checkpoint_utils import with_temp_dir
+
+
+class TestDCPToTorchSave(DTensorTestBase):
+    @with_comms
+    @skip_if_lt_x_gpu(2)
+    @with_temp_dir
+    def test_dcp_to_torch_save(self) -> None:
+        # Using a transformer model to simulate a 'complicated enough' state dict w/ nested modules
+        model = Transformer(ModelArgs())
+        dcp.save({"model": model}, checkpoint_id=self.temp_dir)
+
+        torch_fn = self.temp_dir + ".pt"
+        dcp_to_torch_save(self.temp_dir, torch_fn)
+
+        loaded_sd = torch.load(torch_fn)
+        self.assertEqual(loaded_sd, {"model": model.state_dict()})
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/checkpoint/test_torch_save_to_dcp.py
+++ b/test/distributed/checkpoint/test_torch_save_to_dcp.py
@@ -110,7 +110,6 @@ def _construct_state_dict_and_metadata(
     state_dict = torch.load(fp_name, map_location="cpu")
 
     state_dict_metadata = {}
-    placement = [Shard(0)]
     for key, value in state_dict.items():
         # Sharded the tensor into a DTensor with each rank contains a shard.
         size = value.size()

--- a/torch/distributed/checkpoint/format_utils.py
+++ b/torch/distributed/checkpoint/format_utils.py
@@ -1,0 +1,68 @@
+import os
+from typing import Union
+
+import torch
+import torch.distributed as dist
+from torch.distributed.checkpoint import FileSystemReader
+from torch.distributed.checkpoint._traverse import set_element
+from torch.distributed.checkpoint.default_planner import DefaultLoadPlanner
+from torch.distributed.checkpoint.metadata import (
+    Metadata,
+    STATE_DICT_TYPE,
+    TensorStorageMetadata,
+)
+from torch.distributed.checkpoint.state_dict_loader import _load_state_dict
+
+__all__ = ["dcp_to_torch_save"]
+
+
+class _DCPToTorchLoadPlanner(DefaultLoadPlanner):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def set_up_planner(
+        self,
+        state_dict: STATE_DICT_TYPE,
+        metadata: Metadata,
+        is_coordinator: bool,
+    ) -> None:
+        # rebuild the state dict from the metadata
+        for k, v in metadata.state_dict_metadata.items():
+            if isinstance(v, TensorStorageMetadata):
+                v = torch.empty(v.size, dtype=v.properties.dtype)
+            if k in metadata.planner_data:
+                set_element(state_dict, metadata.planner_data[k], v)
+            else:
+                state_dict[k] = v
+
+        super().set_up_planner(state_dict, metadata, is_coordinator)
+
+
+def dcp_to_torch_save(
+    dcp_checkpoint_dir: Union[str, os.PathLike],
+    torch_save_fn: Union[str, os.PathLike],
+    coordinator_rank: int = 0,
+):
+    """
+    Given a directory containing a DCP checkpoint, this function will convert it into a
+    Torch save file.
+
+    Args:
+        dcp_checkpoint_dir: Directory containing the DCP checkpoint.
+        torch_save_fn: Filename to store the converted Torch save file.
+        coordinator_rank: Rank that will perform the conversion.
+    """
+    if not dist.is_initialized() or dist.get_rank() == coordinator_rank:
+        sd = {}
+        storage_reader = FileSystemReader(dcp_checkpoint_dir)
+
+        _load_state_dict(
+            sd,
+            storage_reader=storage_reader,
+            planner=_DCPToTorchLoadPlanner(),
+            no_dist=True,
+        )
+        torch.save(sd, torch_save_fn)
+
+    if dist.is_initialized():
+        dist.barrier()

--- a/torch/distributed/checkpoint/format_utils.py
+++ b/torch/distributed/checkpoint/format_utils.py
@@ -65,9 +65,11 @@ def dcp_to_torch_save(
     Args:
         dcp_checkpoint_dir: Directory containing the DCP checkpoint.
         torch_save_fn: Filename to store the converted Torch save file.
-        coordinator_rank: Rank that will perform the conversion.
+        coordinator_rank: Rank that will perform the conversion. Ignored
+            if dist is not available.
     """
-    if not dist.is_initialized() or dist.get_rank() == coordinator_rank:
+    is_dist = dist.is_available() and dist.is_initialized()
+    if is_dist or dist.get_rank() == coordinator_rank:
         sd = {}
         storage_reader = FileSystemReader(dcp_checkpoint_dir)
 
@@ -79,5 +81,5 @@ def dcp_to_torch_save(
         )
         torch.save(sd, torch_save_fn)
 
-    if dist.is_initialized():
+    if is_dist:
         dist.barrier()

--- a/torch/distributed/checkpoint/format_utils.py
+++ b/torch/distributed/checkpoint/format_utils.py
@@ -69,7 +69,7 @@ def dcp_to_torch_save(
             if dist is not available.
     """
     is_dist = dist.is_available() and dist.is_initialized()
-    if is_dist or dist.get_rank() == coordinator_rank:
+    if not is_dist or dist.get_rank() == coordinator_rank:
         sd = {}
         storage_reader = FileSystemReader(dcp_checkpoint_dir)
 


### PR DESCRIPTION
Should address the `dcp -> torch.save` portion of [118207](https://github.com/pytorch/pytorch/issues/118207)

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #119335
* #119333
* __->__ #118894
* #119332
Differential Revision: [D53285982](https://our.internmc.facebook.com/intern/diff/D53285982/)

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225