### PR TITLE
[inductor] Fix an internal test issue

### DIFF
--- a/test/inductor/test_cpu_cpp_wrapper.py
+++ b/test/inductor/test_cpu_cpp_wrapper.py
@@ -133,7 +133,6 @@ if RUN_CPU:
         code_string_count: dict = {}
 
     for item in [
-        BaseTest("test_add_complex2"),
         BaseTest("test_add_complex4"),
         BaseTest("test_as_strided"),  # buffer reuse
         BaseTest("test_bernoulli1"),

--- a/test/inductor/test_cuda_cpp_wrapper.py
+++ b/test/inductor/test_cuda_cpp_wrapper.py
@@ -151,7 +151,6 @@ if RUN_CUDA:
 
     # Maintain two separate test lists for cuda and cpp for now
     for item in [
-        BaseTest("test_add_complex2"),
         BaseTest("test_add_complex4"),
         BaseTest("test_as_strided"),  # buffer reuse
         BaseTest("test_batch_norm_2d_2"),

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -719,12 +719,15 @@ class CommonTemplate:
 
         for dtype in [torch.complex32, torch.complex64, torch.complex128]:
             x = torch.tensor(
-                [1 + 1j, -1 + 1j, -2 + 2j, 3 - 3j, 0, 1j, 1, -1], dtype=dtype
+                [1 + 1j, -1 + 1j, -2 + 2j, 3 - 3j, 0, 1j, 1, -1],
+                dtype=dtype,
+                device=self.device,
             )
             y = torch.tensor(
-                [1 + 1j, -1 + 1j, -2 + 2j, 3 - 3j, 0, 1j, 1, -1], dtype=dtype
+                [1 + 1j, -1 + 1j, -2 + 2j, 3 - 3j, 0, 1j, 1, -1],
+                dtype=dtype,
+                device=self.device,
             )
-
             _, code = run_and_get_code(fn, x, y)
             self.assertEqual(
                 code[0].count("::view_dtype" if config.cpp_wrapper else "aten.view"), 3

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -681,21 +681,6 @@ class CommonTemplate:
 
         self.common(fn, (x, y, 2))
 
-    def test_add_complex2(self):
-        @torch.compile
-        def fn(a, b):
-            c = a + b
-            d = a + b
-            return c + d
-
-        x = torch.tensor([1 + 1j, -1 + 1j, -2 + 2j, 3 - 3j, 0, 1j, 1, -1])
-        y = torch.tensor([1 + 1j, -1 + 1j, -2 + 2j, 3 - 3j, 0, 1j, 1, -1])
-
-        _, code = run_and_get_code(fn, x, y)
-        self.assertEqual(
-            code[0].count("::view_dtype" if config.cpp_wrapper else "aten.view"), 3
-        )
-
     def test_add_complex3(self):
         # fix https://github.com/pytorch/pytorch/issues/115071
         @torch.compile
@@ -730,7 +715,10 @@ class CommonTemplate:
             )
             _, code = run_and_get_code(fn, x, y)
             self.assertEqual(
-                code[0].count("::view_dtype" if config.cpp_wrapper else "aten.view"), 3
+                " ".join(code).count(
+                    "::view_dtype" if config.cpp_wrapper else "aten.view"
+                ),
+                3,
             )
 
     def test_concat_add_inplace(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118903

Summary: test_add_complex4 that introduced in https://github.com/pytorch/pytorch/pull/117929  fails internally, because of a cpp compilation issue for cpu. Specify the right device in the test instead.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler

Differential Revision: [D53333919](https://our.internmc.facebook.com/intern/diff/D53333919)