### PR TITLE
[dynamo][nit] Cleanup analyze_kernel_mutations nits.

### DIFF
--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -316,10 +316,10 @@ def analyze_kernel_mutations(functions, fn_name, num_args):
 
         if op.name == "tt.call":
             assert op.fn_call_name in functions
-            if mutations := analyze_kernel_mutations(
+            mutations = analyze_kernel_mutations(
                 functions, op.fn_call_name, len(op.args)
-            ):
-                stack.extend(arg for arg, mutated in zip(op.args, mutations) if mutated)
+            )
+            stack.extend(arg for arg, mutated in zip(op.args, mutations) if mutated)
         else:
             for idx in MUTATION_OPS.get(op.name, []):
                 stack.append(op.args[idx])

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -316,24 +316,22 @@ def analyze_kernel_mutations(functions, fn_name, num_args):
 
         if op.name == "tt.call":
             assert op.fn_call_name in functions
-            mutations = analyze_kernel_mutations(
+            if mutations := analyze_kernel_mutations(
                 functions, op.fn_call_name, len(op.args)
-            )
-            for idx, mutated in enumerate(mutations):
-                if mutated:
-                    stack.append(op.args[idx])
+            ):
+                stack.extend(arg for arg, mutated in zip(op.args, mutations) if mutated)
         else:
             for idx in MUTATION_OPS.get(op.name, []):
                 stack.append(op.args[idx])
 
     # The following is an iterative DFS algorithm
     mutated = [False] * num_args
-    while len(stack):
+    while stack:
         arg = stack.pop()
         if arg in visited:
             continue
-        else:
-            visited.add(arg)
+        
+        visited.add(arg)
 
         if isinstance(arg, Param):
             mutated[arg.idx] = True


### PR DESCRIPTION
Using `extend` is more efficient and other changes are stylistic.
