### PR TITLE
[PT-Vulkan][EZ] Adjust string-report width

### DIFF
--- a/aten/src/ATen/native/vulkan/api/QueryPool.cpp
+++ b/aten/src/ATen/native/vulkan/api/QueryPool.cpp
@@ -188,7 +188,7 @@ std::string QueryPool::generate_string_report() {
 
   std::stringstream ss;
 
-  int kernel_name_w = 25;
+  int kernel_name_w = 40;
   int global_size_w = 15;
   int duration_w = 25;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118914

## Before: P1148506541

Some of the shader names are now too long.
```
Kernel Name              Workgroup Size             Duration (ns)
===========              ==============               ===========
vulkan.nchw_to_image     {500, 500, 1}                    4322188
vulkan.nchw_to_image     {500, 500, 1}                    4322240
vulkan.convert_channels_to_height_packed{500, 125, 1}                    1189240
vulkan.zero              {1, 1, 1}                           3744
vulkan.convert_channels_to_width_packed{125, 500, 1}                    1265680
```


## After: P1148506671

Now it's just right; `convert_channels_to_height_packed` is the longest shader name in the codebase.
```
Kernel Name                             Workgroup Size             Duration (ns)
===========                             ==============               ===========
vulkan.nchw_to_image                    {500, 500, 1}                    4327232
vulkan.nchw_to_image                    {500, 500, 1}                    4327960
vulkan.convert_channels_to_height_packed{500, 125, 1}                    1190540
vulkan.zero                             {1, 1, 1}                           3744
vulkan.convert_channels_to_width_packed {125, 500, 1}                    1287468
```

Differential Revision: [D53293924](https://our.internmc.facebook.com/intern/diff/D53293924/)