### PR TITLE
[decomp] Remove pixel_shuffle from core aten decomps

### DIFF
--- a/test/expect/HasDecompTest.test_aten_core_operators.expect
+++ b/test/expect/HasDecompTest.test_aten_core_operators.expect
@@ -386,6 +386,8 @@ aten::normal.float_float_out
 aten::normal.out
 aten::normal_
 aten::permute
+aten::pixel_shuffle
+aten::pixel_shuffle.out
 aten::polar
 aten::polar.out
 aten::pow.Scalar

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -370,7 +370,6 @@ def core_aten_decompositions() -> Dict[torch._ops.OperatorBase, Callable]:
             aten.norm,
             aten.ones,
             aten.ones_like,
-            aten.pixel_shuffle,
             aten.pixel_unshuffle,
             aten._prelu_kernel,
             aten._prelu_kernel_backward,

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -57,6 +57,7 @@ inductor_decompositions = get_decompositions(
         aten.native_batch_norm,
         aten.native_group_norm,
         aten.native_layer_norm,
+        aten.pixel_shuffle,
         aten._softmax,
         aten.sin_,
         aten.sqrt_,


### PR DESCRIPTION
pixel_shuffle is a core aten op
(https://pytorch.org/docs/main/torch.compiler_ir.html#core-aten-ir) so we should not decompose it.

https://github.com/pytorch/pytorch/pull/118239 added a decomp for it which is causing an internal test failure
(https://www.internalfb.com/intern/test/281475090561210/) which cases on the pixel_shuffle operator.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler