### PR TITLE
update_failures.py: add option to also remove "skipped" tests

### DIFF
--- a/scripts/compile_tests/common.py
+++ b/scripts/compile_tests/common.py
@@ -98,6 +98,22 @@ def is_unexpected_success(testcase):
     return find(testcase, condition)
 
 
+MSG = "This test passed, maybe we can remove the skip from dynamo_test_failures.py"
+
+
+def is_passing_skipped_test(testcase):
+    def condition(children):
+        for child in children:
+            if child.tag != "skipped":
+                continue
+            has_passing_skipped_test_msg = MSG in child.attrib["message"]
+            if has_passing_skipped_test_msg:
+                return True
+        return False
+
+    return find(testcase, condition)
+
+
 # NB: not an unexpected success
 def is_failure(testcase):
     def condition(children):

--- a/scripts/compile_tests/update_failures.py
+++ b/scripts/compile_tests/update_failures.py
@@ -4,6 +4,7 @@ from common import (
     download_reports,
     get_testcases,
     is_failure,
+    is_passing_skipped_test,
     is_unexpected_success,
     key,
     open_test_results,
@@ -32,7 +33,7 @@ https://docs.github.com/en/github-cli/github-cli/quickstart
 """
 
 
-def patch_file(filename, unexpected_successes, new_xfails, new_skips):
+def patch_file(filename, unexpected_successes, new_xfails, new_skips, unexpected_skips):
     with open(filename, "r") as f:
         text = f.readlines()
 
@@ -54,6 +55,9 @@ def patch_file(filename, unexpected_successes, new_xfails, new_skips):
     formatted_unexpected_successes = {
         f"{format(test)}" for test in unexpected_successes.values()
     }
+    formatted_unexpected_skips = {
+        f"{format(test)}" for test in unexpected_skips.values()
+    }
     formatted_new_xfails = [
         f'    "{format(test)}",  # {test.attrib["file"]}\n'
         for test in new_xfails.values()
@@ -63,12 +67,12 @@ def patch_file(filename, unexpected_successes, new_xfails, new_skips):
         for test in new_skips.values()
     ]
 
-    def in_unexpected_successes(line):
+    def is_in(lst, line):
         splits = line.split('"')
         if len(splits) < 3:
             return None
         test_name = splits[1]
-        if test_name in formatted_unexpected_successes:
+        if test_name in lst:
             return test_name
         return None
 
@@ -77,7 +81,7 @@ def patch_file(filename, unexpected_successes, new_xfails, new_skips):
     # dynamo_expected_failures
     while True:
         line = text[i]
-        match = in_unexpected_successes(line)
+        match = is_in(formatted_unexpected_successes, line)
         if match is not None:
             covered_unexpected_successes.add(match)
             i += 1
@@ -104,6 +108,10 @@ def patch_file(filename, unexpected_successes, new_xfails, new_skips):
     # dynamo_skips
     while True:
         line = text[i]
+        match = is_in(formatted_unexpected_skips, line)
+        if match is not None:
+            i += 1
+            continue
         if line == "}\n":
             new_text.extend(formatted_new_skips)
             break
@@ -132,7 +140,10 @@ def get_intersection_and_outside(a_dict, b_dict):
     def build_dict(keys):
         result = {}
         for k in keys:
-            result[k] = a_dict.get(k, b_dict[k])
+            if k in a_dict:
+                result[k] = a_dict[k]
+            else:
+                result[k] = b_dict[k]
         return result
 
     return build_dict(intersection), build_dict(outside)
@@ -146,22 +157,38 @@ def update(filename, py38_dir, py311_dir):
             key(test): test for test in testcases if is_unexpected_success(test)
         }
         failures = {key(test): test for test in testcases if is_failure(test)}
-        return unexpected_successes, failures
+        passing_skipped_tests = {
+            key(test): test for test in testcases if is_passing_skipped_test(test)
+        }
+        return unexpected_successes, failures, passing_skipped_tests
 
-    py38_unexpected_successes, py38_failures = read_test_results(py38_dir)
-    py311_unexpected_successes, py311_failures = read_test_results(py311_dir)
+    (
+        py38_unexpected_successes,
+        py38_failures,
+        py38_passing_skipped_tests,
+    ) = read_test_results(py38_dir)
+    (
+        py311_unexpected_successes,
+        py311_failures,
+        py311_passing_skipped_tests,
+    ) = read_test_results(py311_dir)
 
     unexpected_successes = {**py38_unexpected_successes, **py311_unexpected_successes}
     _, skips = get_intersection_and_outside(
         py38_unexpected_successes, py311_unexpected_successes
     )
     xfails, more_skips = get_intersection_and_outside(py38_failures, py311_failures)
+    unexpected_skips, _ = get_intersection_and_outside(
+        py38_passing_skipped_tests, py311_passing_skipped_tests
+    )
     all_skips = {**skips, **more_skips}
     print(
         f"Discovered {len(unexpected_successes)} new unexpected successes, "
-        f"{len(xfails)} new xfails, {len(all_skips)} new skips"
+        f"{len(xfails)} new xfails, {len(all_skips)} new skips, {len(unexpected_skips)} new unexpected skips"
     )
-    return patch_file(filename, unexpected_successes, xfails, all_skips)
+    return patch_file(
+        filename, unexpected_successes, xfails, all_skips, unexpected_skips
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #119027
* __->__ #118931
* #118882
* #118874

Previously, you could run update_failures.py (with a commit hash) and it
would add new expected failures and skips for newly failing tests and
remove expected failures for newly passing tests.

This PR teaches update_failures.py to also remove skips for tests that
are now passing without them.

The way we do this is:
- dynamo_test_failures.py doesn't actually skip tests -- it runs the
  test and then suppresses the signal.
- if the test actually passed, then the test gets skipped with a special
  skip message
- we teach update_failures.py to look for the presence of that skip
  message.

Test Plan:
- Used this to generate https://github.com/pytorch/pytorch/pull/118928