### PR TITLE
[CI] Filter should not fail if pr_body is empty

### DIFF
--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -588,7 +588,7 @@ def main() -> None:
         labels=labels,
         test_matrix=filtered_test_matrix,
         job_name=args.job_name,
-        pr_body=pr_body,
+        pr_body=pr_body if pr_body else "",
     )
 
     # Set the filtered test matrix as the output


### PR DESCRIPTION
Otherwise it will fail with `TypeError: argument of type 'NoneType' is not iterable` (see https://github.com/pytorch/pytorch/actions/runs/7748725174/job/21131915226 for example)
 
```
% gh api /repos/pytorch/pytorch/issues/118927|
{
  "url": "https://api.github.com/repos/pytorch/pytorch/issues/118927",
  ...
  "body": null,
  ...
  "state_reason": null
}
```


TODO: Can we add a test for it?