### PR TITLE
Upgrade configuration for Ruff v0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,9 @@ target-version = ["py38", "py39", "py310", "py311"]
 
 [tool.ruff]
 target-version = "py38"
+line-length = 120
 
+[tool.ruff.lint]
 # NOTE: Synchoronize the ignores with .flake8
 ignore = [
     # these ignores are from flake8-bugbear; please fix!
@@ -31,7 +33,6 @@ ignore = [
     "B019",
     "B023",
     "B028", # No explicit `stacklevel` keyword argument found
-    "B904",
     "E402",
     "C408", # C408 ignored because we like the dict keyword argument syntax
     "E501", # E501 is not flexible enough, we're using B950 instead
@@ -67,7 +68,6 @@ ignore = [
     "UP006", # keep-runtime-typing
     "UP007", # keep-runtime-typing
 ]
-line-length = 120
 select = [
     "B",
     "C4",
@@ -109,12 +109,11 @@ select = [
     "RUF015", # access first ele in constant time
     "RUF016", # type error non-integer index
     "RUF017",
-    "TRY200",
     "TRY302",
     "UP",
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = [
     "F401",
 ]


### PR DESCRIPTION
 In Ruff v0.2.0, we've started to warn when linter-only configuration is included at the top-level (`[tool.ruff]`) instead of the linter-specific section (`[tool.ruff.linter]`). These changes are backwards-compatible with earlier versions of Ruff, and so will work regardless of when folks upgrade to v0.2.0.