### PR TITLE
[DeviceMesh] Temporarily disable re-use subgroup

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -14,15 +14,11 @@ from torch.distributed._tensor.placement_types import _Partial, Shard
 from torch.distributed.device_mesh import _mesh_resources, DeviceMesh, init_device_mesh
 
 from torch.distributed.distributed_c10d import (
-    _get_process_group_name,
-    _world,
     get_global_rank,
-    get_process_group_ranks,
     get_world_size,
     init_process_group,
     is_initialized,
     is_nccl_available,
-    new_group,
     ProcessGroup,
 )
 from torch.testing._internal.common_utils import run_tests
@@ -65,71 +61,6 @@ class DeviceMeshTest(DTensorTestBase):
         DeviceMesh(device_type, mesh_tensor)
         self.assertTrue(is_initialized())
         self.destroy_pg()
-
-    def _get_tags_to_pg_name(self, tags_to_pg):
-        tags_to_pg_name = {}
-        for tag_name, groups in tags_to_pg.items():
-            tags_to_pg_name[tag_name] = []
-            for group in groups:
-                tags_to_pg_name[tag_name].append(_get_process_group_name(group))
-        return tags_to_pg_name
-
-    @with_comms
-    def test_reuse_process_group(self):
-        # Manually create new_group.
-        tp_group_0 = new_group([0, 1])
-        tp_group_1 = new_group([2, 3])
-        dp_group_0 = new_group([0, 2])
-        dp_group_1 = new_group([1, 3])
-
-        # Record the pg tags_to_pg_name so we can check whether init_device_mesh create new pg.
-        # We cannot do a deepcopy of ProcessGroup for comparison,
-        # since we cannot pickle 'torch._C._distributed_c10d.ProcessGroup' object.
-        # Therefore, we rely on the tags_to_pg_name for comparison to make sure
-        # before/after init_device_mesh, tags_to_pg in the current world does not change.
-        ref_tags_to_pg = _world.tags_to_pg
-        ref_tags_to_pg_name = self._get_tags_to_pg_name(ref_tags_to_pg)
-
-        mesh_shape = (2, self.world_size // 2)
-        mesh_dim_names = ("DP", "TP")
-        mesh_2d = init_device_mesh(
-            self.device_type, mesh_shape, mesh_dim_names=mesh_dim_names
-        )
-        tags_to_pg = _world.tags_to_pg
-        tags_to_pg_name = self._get_tags_to_pg_name(tags_to_pg)
-
-        # Check before/after init_device_mesh, tags_to_pg in the current world does not change.
-        self.assertEqual(ref_tags_to_pg_name, tags_to_pg_name)
-
-        # For each rank, there should be 4 tags_to_pg, including tags:
-        #   1) default tag for user PGs (which contains all the pgs on a particular rank)
-        #   2) tag for world size pg
-        #   3) tag for tp pg
-        #   4) tag for dp pg
-        self.assertEqual(len(tags_to_pg), 4)
-        # "" is the default tag for user PGs, and the default tag should only
-        # contain 3 pgs, since we re-use pgs, whenever possible. The 3 pgs are:
-        #   1) pg for the whole world
-        #   2) pg for tp_group
-        #   3) pg for dp_group
-        self.assertEqual(len(tags_to_pg[""]), 3)
-
-        default_user_pgs = tags_to_pg[""]
-        dp_dim = 0
-        tp_dim = 1
-        for idx, group in enumerate(default_user_pgs):
-            # world size pg
-            if idx == 0:
-                self.assertEqual(get_process_group_ranks(group), range(self.world_size))
-            # tp pg
-            if idx == 1:
-                # rank0 - mesh_2d._dim_group_infos is: [('ptd:3', [0, 2]), ('ptd:1', [0, 1])]
-                tp_group_ranks = mesh_2d._dim_group_infos[tp_dim][1]
-                self.assertEqual(get_process_group_ranks(group), tp_group_ranks)
-            # dp pg
-            if idx == 2:
-                dp_group_ranks = mesh_2d._dim_group_infos[dp_dim][1]
-                self.assertEqual(get_process_group_ranks(group), dp_group_ranks)
 
     @with_comms
     def test_get_group(self):

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -285,16 +285,12 @@ else:
                     # for each dim and append the groups
                     for dim_mesh in pg_ranks_by_dim:
                         subgroup_ranks = dim_mesh.tolist()
-                        # if dim_group exists for given subgroup_ranks, we re-use it.
-                        # "" is the default tag for user PGs, and it contains all pgs for a given rank.
-                        dim_group = _find_pg_by_ranks_and_tag(
-                            tag="", ranks=subgroup_ranks
-                        )
-                        if not dim_group:
-                            # call new_group regardless of the current rank in the
-                            # pg or not, it's required that all ranks participate
-                            # in subgroup construction
-                            dim_group = new_group(ranks=subgroup_ranks)
+
+                        # We temporarily revert the re-use subgroup, since it breaks two internal tests.
+                        # Temporarily reverting to resolve test timeout while root-causing.
+                        # TODO: Add two tests to cover internal tests scenarios and re-enable reuse subgroup if exists.
+                        dim_group = new_group(ranks=subgroup_ranks)
+
                         # only add to dim_groups if the current rank in the subgroup
                         if self.get_rank() in subgroup_ranks:
                             if len(dim_group_infos) > dim:
@@ -306,7 +302,7 @@ else:
                                 (
                                     _get_group_tag(not_none(dim_group)),
                                     subgroup_ranks,
-                                    not_none(dim_group).group_name,
+                                    dim_group.group_name,
                                 )
                             )
             self._dim_group_infos = dim_group_infos


### PR DESCRIPTION
Summary:
The reuse subgroup logic is causing GLOO to timeout on two internal modelstore tests (relevant tests in test plan). 
We temporarily disabling re-use subgroup during root-causing to allow the internal tests to be able to run again, as they are now omitted shown in T176426987.

Test Plan:
CI




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @tianyu-l @wconstab @yf225