### PR TITLE
Expose aggressive_recomputation as an inductor config

### DIFF
--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -34,6 +34,11 @@ cse = True
 # Restricts the amount of computation AOTAutograd can do.
 max_dist_from_bw = 3
 
+# Enable aggressive_recomputation in the min-cut algorithm in partitioners to reduce
+# memory usage with some penalty of performance. It allows more ops to be considered
+# as recomputable except random ops and compute-intensive ops.
+aggressive_recomputation = False
+
 if TYPE_CHECKING:
     from torch.utils._config_typing import *  # noqa: F401, F403
 

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -750,12 +750,6 @@ def min_cut_rematerialization_partition(
         print("Ops banned from rematerialization: ", ops_ignored)
         print()
 
-    # `AGGRESSIVE_RECOMPUTATION` is a mode that recomputes everything except
-    # random ops and compute-intensive ops.
-    # It's an internal-only debug mode and is not related to user-facing
-    # (selective) activation checkpointing.
-    AGGRESSIVE_RECOMPUTATION = False
-
     def is_materialized_backwards(node):
         cur_nodes = {node}
         while len(cur_nodes) > 0:
@@ -771,7 +765,7 @@ def min_cut_rematerialization_partition(
     def ban_recomputation(node):
         if "recompute" in node.meta:
             return node.meta["recompute"] == 0
-        elif AGGRESSIVE_RECOMPUTATION:
+        elif config.aggressive_recomputation:
             ignored_ops = random_ops + compute_intensive_ops
             return (node.op == 'call_function' and get_aten_target(node) in ignored_ops)
         else:


### PR DESCRIPTION
Summary:
As title.

We found aggressive_recomputation shows memory savings (7% on APS COFFEE model) with 2% QPS loss.

It also gives very promising signal on our auto ac experiments: https://docs.google.com/document/d/1S2qgMg1CwAQ4U1Ffuk2epbEOx06ogZhioX2jKCwL7ZQ/edit

 {F1426175073}

Test Plan:
APS COFFEE from silverlakeli
- Zoom of baseline job: https://www.internalfb.com/intern/zoomer/?profiling_run_fbid=927380488801910&tab=overview
- Zoom of job with aggressive_recomputation: https://www.internalfb.com/intern/zoomer/?profiling_run_fbid=1126815608217470&tab=overview


APS 1100x shrunk version:
- baseline: https://www.internalfb.com/mast/job/aps-yuzhenhuang-afe049505a
- test: https://www.internalfb.com/mast/job/aps-yuzhenhuang-709e41bf0d
Memory from 42.98% -> 41.04%.

Reviewed By: yf225, yuxihu, silverlakeli, richqyz

Differential Revision: D53248057




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler