### PR TITLE
[DTensor][Test] Improve math_ops test

### DIFF
--- a/test/distributed/_tensor/test_math_ops.py
+++ b/test/distributed/_tensor/test_math_ops.py
@@ -223,17 +223,11 @@ class DistMathOpsTest(DTensorTestBase):
         # for op in [torch.add, torch.sub, torch.mul, torch.div]:
         for op in [torch.add, torch.sub, torch.mul, torch.div]:
             expect_rs = op(global_tensor, 2)
-            actual_double_shard_rs = op(double_shard_tensor, 2).redistribute(
-                mesh, [Replicate(), Replicate()]
-            )
-            actual_double_shard_local_rs = actual_double_shard_rs.to_local()
-            self.assertEqual(actual_double_shard_local_rs, expect_rs)
+            double_shard_full_tensor = op(double_shard_tensor, 2).full_tensor()
+            self.assertEqual(double_shard_full_tensor, expect_rs)
 
-            actual_fully_shard_rs = op(fully_shard_tensor, 2).redistribute(
-                mesh, [Replicate(), Replicate()]
-            )
-            actual_fully_shard_local_rs = actual_fully_shard_rs.to_local()
-            self.assertEqual(actual_fully_shard_local_rs, expect_rs)
+            fully_shard_full_tensor = op(fully_shard_tensor, 2).full_tensor()
+            self.assertEqual(fully_shard_full_tensor, expect_rs)
 
     @with_comms
     def test_layer_norm_fwd(self):

--- a/test/distributed/_tensor/test_math_ops.py
+++ b/test/distributed/_tensor/test_math_ops.py
@@ -206,7 +206,7 @@ class DistMathOpsTest(DTensorTestBase):
                     x.grad.zero_()
 
     @with_comms
-    def test_full_shard_math_ops(self):
+    def test_shard_math_ops(self):
         mesh_shape = (2, self.world_size // 2)
         mesh = DeviceMesh(
             self.device_type,
@@ -223,11 +223,17 @@ class DistMathOpsTest(DTensorTestBase):
         # for op in [torch.add, torch.sub, torch.mul, torch.div]:
         for op in [torch.add, torch.sub, torch.mul, torch.div]:
             expect_rs = op(global_tensor, 2)
-            actual_rs = op(double_shard_tensor, 2).redistribute(
+            actual_double_shard_rs = op(double_shard_tensor, 2).redistribute(
                 mesh, [Replicate(), Replicate()]
             )
-            actual_local_res = actual_rs.to_local()
-            self.assertEqual(actual_local_res, expect_rs)
+            actual_double_shard_local_rs = actual_double_shard_rs.to_local()
+            self.assertEqual(actual_double_shard_local_rs, expect_rs)
+
+            actual_fully_shard_rs = op(fully_shard_tensor, 2).redistribute(
+                mesh, [Replicate(), Replicate()]
+            )
+            actual_fully_shard_local_rs = actual_fully_shard_rs.to_local()
+            self.assertEqual(actual_fully_shard_local_rs, expect_rs)
 
     @with_comms
     def test_layer_norm_fwd(self):


### PR DESCRIPTION
The DTensor fully_shard_tensor was created but not used in shard_math_ops test previously. 

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @tianyu-l @wconstab @yf225