### PR TITLE
[CPU] Optimize softmax as flash attention v2

### DIFF
--- a/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
+++ b/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
@@ -310,9 +310,8 @@ void cpu_flash_attention(
           }
         }
         // Update coefficients with Softmax
-        accum_t tmp_max = 0, tmp_sum = 0, sum_old = 0, exp_tmp = 0;
+        accum_t tmp_max = 0, tmp_sum = 0, exp_tmp = 0;
         for (int64_t row = 0; row < qBlockSize; ++row) {
-          sum_old = qk_sum_data[row];
           if (has_attn_mask) {
             // max per row
             tmp_max = at::vec::reduce_all<accum_t>(

--- a/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
+++ b/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
@@ -23,25 +23,25 @@ namespace {
 
 // 1) out = exp(a - val)
 // 2) val = sum(out)
-template <typename scalar_t>
+template <typename T1, typename T2>
 inline void _exp_reduce_sum_fusion_kernel(
-    scalar_t* a,
+    T1* a,
     const int& size,
-    scalar_t* out,
-    scalar_t& val) {
-  auto vec_size = vec::Vectorized<scalar_t>::size();
-  auto vec_max = vec::Vectorized<scalar_t>(val);
-  scalar_t tmp_sum = 0;
-  auto vec_tmp_sum = vec::Vectorized<scalar_t>(tmp_sum);
+    T2* out,
+    T1& val) {
+  auto vec_size = vec::Vectorized<T1>::size();
+  auto vec_max = vec::Vectorized<T1>(val);
+  T1 tmp_sum = 0;
+  auto vec_tmp_sum = vec::Vectorized<T1>(tmp_sum);
   for (long i = 0; i < vec_size * (size / vec_size); i += vec_size) {
-    auto tmp0 = vec::Vectorized<scalar_t>::loadu(a + i);
+    auto tmp0 = vec::Vectorized<T1>::loadu(a + i);
     auto tmp1 = tmp0 - vec_max;
     auto tmp2 = tmp1.exp_u20();
     vec_tmp_sum += tmp2;
     _store(out + i, tmp2);
   }
-  tmp_sum = vec::vec_reduce_all<scalar_t>(
-      [](vec::Vectorized<scalar_t>& x, vec::Vectorized<scalar_t>& y) {
+  tmp_sum = vec::vec_reduce_all<T1>(
+      [](vec::Vectorized<T1>& x, vec::Vectorized<T1>& y) {
         return x + y;
       },
       vec_tmp_sum);
@@ -53,27 +53,6 @@ inline void _exp_reduce_sum_fusion_kernel(
     out[i] = tmp2;
   }
   val = tmp_sum;
-}
-
-// out = a / sum
-template <typename T1, typename T2>
-inline void _normalization_kernel(
-    const T1* a,
-    const T1& sum,
-    const int& size,
-    T2* out) {
-  auto vec_size = vec::Vectorized<T1>::size();
-  auto vec_sum = vec::Vectorized<T1>(sum);
-  for (long i = 0; i < vec_size * (size / vec_size); i += vec_size) {
-    auto tmp0 = vec::Vectorized<T1>::loadu(a + i);
-    auto tmp1 = tmp0 / vec_sum;
-    _store(out + i, tmp1);
-  }
-  for (long i = vec_size * (size / vec_size); i < size; i++) {
-    auto tmp0 = a[i];
-    auto tmp1 = tmp0 / sum;
-    out[i] = tmp1;
-  }
 }
 
 // 1) out = a * scale
@@ -352,23 +331,20 @@ void cpu_flash_attention(
           tmp_max = qk_max_data[row] > tmp_max ? qk_max_data[row] : tmp_max;
           // qk <- exp(qk - max) and sum per row
           tmp_sum = tmp_max;
-          _exp_reduce_sum_fusion_kernel(qk_data + row * kvBlockSize, kvBlockSize, qk_data + row * kvBlockSize, tmp_sum);
+          _exp_reduce_sum_fusion_kernel(
+              qk_data + row * kvBlockSize, kvBlockSize,
+              conditional_data_ptr(qk_data, qk_reduced_data) + row * kvBlockSize,
+              tmp_sum);
           // exp_tmp <- exp(max[row] - max)
           exp_tmp = std::exp(qk_max_data[row] - tmp_max);
           // sum[row] <- sum + exp_tmp * sum[row]
           qk_sum_data[row] = tmp_sum + exp_tmp * qk_sum_data[row];
           // max[row] <- max
           qk_max_data[row] = tmp_max;
-          // qk <- qk / sum[row]
-          accum_t sum_new = qk_sum_data[row];
-          _normalization_kernel(qk_data + row * kvBlockSize, sum_new, kvBlockSize,
-                conditional_data_ptr(qk_data, qk_reduced_data) + row * kvBlockSize);
-          // dst <- dst * sum_old / sum_new * exp_tmp
+          // dst <- dst * exp_tmp
           if (n > 0) {
-            accum_t sum_cor = sum_old / sum_new;
             vec::map<accum_t>(
-              [sum_cor, exp_tmp](Vec x)
-              { return x * Vec(sum_cor) * Vec(exp_tmp); },
+              [exp_tmp](Vec x) { return x * Vec(exp_tmp); },
               dst_data + row * headSize, dst_data + row * headSize, headSize);
           }
         }
@@ -389,10 +365,12 @@ void cpu_flash_attention(
             dst_data,
             headSize);
       }
+      // dst <- dst / sum[row]
       // reorder MHA output with strides
       for (int64_t row = 0; row < qBlockSize; ++row) {
+        accum_t sum_reciprocal = 1 / qk_sum_data[row];
         vec::map<scalar_t>(
-          [](Vec x) { return x; },
+          [sum_reciprocal](Vec x) { return x * Vec(sum_reciprocal); },
           out_data + i * oStrideB + j * oStrideH + m * oStrideM + row * oStrideM,
           dst_data + row * headSize,
           headSize);

--- a/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
+++ b/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
@@ -91,7 +91,7 @@ inline void _mul_reduce_max_fusion_kernel(
 
 template <typename scalar_t>
 static inline scalar_t* conditional_data_ptr(scalar_t* ptr, scalar_t* ptr2) {
-  TORCH_INTERNAL_ASSERT(ptr2 == nullptr);
+  TORCH_CHECK(ptr2 == nullptr);
   return ptr;
 }
 


### PR DESCRIPTION
### Descriptions
According to flash attention v2, optimize softmax by dividing sum out of the KV inner loop.

### Performance
Stable Diffusion V2.1 on GNR

| Version | Kernel time (s) | Speedup |
|---------|----------------|----------------|
| BF16 Before | 28.67 |
| BF16 After | 23.55 | 17.86% |
| FP32 Before | 54.20 |
| FP32 After | 49.47 | 8.73% |

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10