### PR TITLE
[AOTI] Fix a RAIIAtenTensorHandle premature deallocation bug

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1683,13 +1683,16 @@ class AOTInductorTestsTemplate:
             class Model(torch.nn.Module):
                 def forward(self, x, i1, i2, y):
                     return torch.ops.aten.index_put(
-                        x, (None, None, i1, i2), y, accumulate=True
+                        x,
+                        (None, None, i1, i2.transpose(0, 1)),
+                        y,
+                        accumulate=True,
                     )
 
             example_inputs = (
                 torch.rand(8, 192, 30, 30, device=self.device),
                 torch.zeros(3, 14, 1, 1, dtype=torch.int64, device=self.device),
-                torch.ones(3, 14, dtype=torch.int64, device=self.device),
+                torch.ones(14, 3, dtype=torch.int64, device=self.device),
                 torch.randn(8, 192, 3, 14, 3, 14, device=self.device),
             )
             self.check_model(Model(), example_inputs)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4399,7 +4399,11 @@ class IndexPutFallback(ExternKernel):
         )
         self.name = V.graph.register_buffer(self)
         self.python_kernel_name = "aten.index_put_"
-        self.cpp_kernel_name = "at::index_put_out"
+        self.cpp_kernel_name = (
+            "aoti_torch_index_put_out"
+            if config.aot_inductor.abi_compatible
+            else "at::index_put_out"
+        )
         mark_node_as_mutating(self, x)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118963

Summary: generate_index_put_fallback currently generates something like the following,

```
AtenTensorHandle tensor_handle_array_1[] = {nullptr, nullptr, arg1_1, wrap_with_raii_handle_if_needed(tmp_tensor_handle_0)};
```

The problem is wrap_with_raii_handle_if_needed creates a RAIIAtenTensorHandle which only lives during this tmp array initialization. After the initialization is done, RAIIAtenTensorHandle dies and releases the underlying Tensor, and when later tensor_handle_array_1 is passed to aoti_torch_index_put_out, some of its element AtenTensorHandle becomes invalid, cauing segfault.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler

Differential Revision: [D53339348](https://our.internmc.facebook.com/intern/diff/D53339348)