### PR TITLE
Add torch.backends.mha.get_fastpath_enabled to FUNC_INLINELIST

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -31,7 +31,8 @@ from torch.testing._internal.common_utils import (
     gradcheck,
     make_tensor,
     NOTEST_CPU,
-    IS_WINDOWS
+    IS_WINDOWS,
+    TEST_WITH_TORCHDYNAMO,
 )
 from torch._dynamo.testing import CompileCounterWithBackend
 
@@ -660,7 +661,7 @@ class TestTransformers(NNTestCase):
             torch.arange(3)[None, :].cpu() >= input_seq_len[:, None]
         )
 
-        with self.assertNoLogs(None):
+        with (self.assertNoLogs(None) if not TEST_WITH_TORCHDYNAMO else contextlib.nullcontext()):
             encoder(
                 inputs,
                 mask=src_mask,

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -166,6 +166,7 @@ FUNC_INLINELIST = {
     "torch._constrain_as_size",
     "torch._constrain_as_value",
     "torch._tensor._convert",
+    "torch.backends.mha.get_fastpath_enabled",
     "torch.jit._unwrap_optional",
 }
 


### PR DESCRIPTION
Summary: Add torch.backends.mha.get_fastpath_enabled to FUNC_INLINELIST

Test Plan: See the one in D53154041
Reviewed By: yjhao, yanboliang, Yuzhen11

Differential Revision: D53154041




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng