### PR TITLE
[aotinductor] Migrate fuse_split_linear_add from dper_pass to AOTI based on predispatch IR

### DIFF
--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -50,7 +50,6 @@ pattern_matcher_passes: List[PatternMatcherPass] = [
     efficient_conv_bn_eval_pass,
 ]
 pattern_matcher_passes_aten: List[PatternMatcherPass] = [
-    normalization_pass_aten,
     merge_getitem_cat_pass_aten,
     merge_splits_pass_aten,
     split_cat_pass_aten,
@@ -86,6 +85,12 @@ def pre_grad_passes(gm: torch.fx.GraphModule, example_inputs):
             gm_before_fx_passes = gm.__copy__()
         # explicitly run with predispatch atenIR based passes
         if config.is_predispatch:
+            # normalization pass
+            pass_execution_and_save(
+                normalization_pass_aten.apply,
+                gm,
+                "[Pre grad(predispatch IR)]Apply normalization pass",
+            )
             pass_execution_and_save(
                 group_batch_fusion_passes,
                 gm,


### PR DESCRIPTION
Summary: As titled. Added support of fuse_split_linear_add in pregrad passes based on predispatch IR

Test Plan: TORCH_LOGS=inductor,aot   buck2 run  mode/opt mode/inplace caffe2/test/inductor/fb:test_split_cat_fx_passes_aten_fb

Differential Revision: D53302168




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler