### PR TITLE
[Inductor max autotune] Multithreaded Precompilation

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -273,7 +273,7 @@ class TestMaxAutotune(TestCase):
                     with config.patch(
                         {
                             "autotune_in_subproc": False,
-                            "autotune_precompilation_workers": len(fake_choices),
+                            "compile_threads": len(fake_choices),
                         }
                     ):
                         asc("test_call", fake_choices, [], Mock())
@@ -311,7 +311,7 @@ class TestMaxAutotune(TestCase):
                 "max_autotune": True,
                 "autotune_in_subproc": True,
                 "max_autotune_gemm_backends": "CUTLASS,Triton,ATen",
-                "autotune_precompilation_workers": 4,
+                "compile_threads": 4,
                 "cuda.cutlass_dir": _CUTLASS_DIR,
                 "cuda.cutlass_max_profiling_configs": 2,
             }

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -220,6 +220,73 @@ class TestMaxAutotune(TestCase):
         with config.patch({"max_autotune": True}):
             torch.compile(mm, dynamic=dynamic)(a, b)
 
+    def test_precompilation_threads(self):
+        import threading
+        from typing import Any, Dict
+        from unittest.mock import Mock, patch
+
+        class FakeChoiceCaller(ChoiceCaller):
+            def __init__(self):
+                super().__init__("none", [], Mock())
+                self.thread_id = None
+
+            def precompile(self):
+                self.thread_id = threading.get_ident()
+
+            def call_name(self) -> str:
+                return None
+
+            def to_callable(self):
+                return None
+
+            def hash_key(self) -> str:
+                return None
+
+            def output_node(self) -> "TensorBox":  # noqa: F821
+                return None
+
+        fake_choices = [FakeChoiceCaller() for i in range(10)]
+        fake_lookup_result = {choice: 0.123 for choice in fake_choices}
+
+        def no_lookup(
+            choices: List[ChoiceCaller],
+            op: str,
+            inputs: str,
+            benchmark: Callable[[Any], Dict[ChoiceCaller, float]],
+        ) -> Dict[ChoiceCaller, float]:
+            return benchmark(choices)
+
+        asc = AlgorithmSelectorCache()
+
+        def fake_benchmark_fn(*args, **kwargs):
+            return fake_lookup_result
+
+        main_thread_id = threading.get_ident()
+        mock_debug_handler = Mock()
+        old_debug_handler = V.debug
+        try:
+            V.set_debug_handler(mock_debug_handler)
+            with patch.object(asc, "lookup", new=no_lookup):
+                with patch.object(
+                    asc, "make_benchmark_fn", return_value=fake_benchmark_fn
+                ):
+                    with config.patch(
+                        {
+                            "autotune_in_subproc": False,
+                            "autotune_precompilation_workers": len(fake_choices),
+                        }
+                    ):
+                        asc("test_call", fake_choices, [], Mock())
+            for fake_choice in fake_choices:
+                assert (
+                    fake_choice.thread_id is not None
+                ), "Expected all ChoiceCaller's precompile method to have been called"
+                assert (
+                    fake_choice.thread_id != main_thread_id
+                ), "Expected all ChoiceCaller's precompile method to have been called on separate thread"
+        finally:
+            V.set_debug_handler(old_debug_handler)
+
     @unittest.skipIf(not SM75OrLater, "need sm_75")
     @unittest.skipIf(config.is_fbcode(), "fbcode requires different CUTLASS path setup")
     @unittest.mock.patch.dict(os.environ, {"PATH": _get_path_without_sccache()})

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -393,6 +393,9 @@ class BenchmarkRequest:
     """
     Only handle triton template benchmark for now. The extern kernel benchmark
     can be done inside the same process since they usually don't cause crash.
+
+    Important: Instances of this class and subclasses have to be serializable
+    across process boundaries. Do not put CUDA Tensors in here!
     """
 
     def __init__(
@@ -483,6 +486,9 @@ class TestBenchmarkRequest(BenchmarkRequest):
 
 
 class TritonBenchmarkRequest(BenchmarkRequest):
+    # Important: Instances of this class have to be serializable
+    # across process boundaries. Do not put CUDA Tensors in here!
+
     def __init__(
         self,
         kernel_name: str,
@@ -539,6 +545,9 @@ class TritonBenchmarkRequest(BenchmarkRequest):
 
 
 class CUDABenchmarkRequest(BenchmarkRequest):
+    # Important: Instances of this class have to be serializable
+    # across process boundaries. Do not put CUDA Tensors in here!
+
     def __init__(
         self,
         kernel_name: str,
@@ -555,6 +564,13 @@ class CUDABenchmarkRequest(BenchmarkRequest):
         self.hash_key: str = ""
         self.source_file: str = ""
         self.hash_key, self.source_file = CUDACodeCache.write(self.source_code, "so")
+
+    def precompile(self):
+        # Prepopulate CUDACodeCache
+        # may happen in separate Threadpool
+        log.debug("Precompiling %s", str(self))
+        CUDACodeCache.load(self.source_code, "so")
+        log.debug("Done precompiling %s", str(self))
 
     def make_run_fn(
         self, *input_tensors: torch.Tensor, output_tensor: torch.Tensor

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -201,6 +201,7 @@ class CacheBase:
     def update_local_cache(self, local_cache: Dict[str, Any]) -> None:
         if not os.path.exists(self.local_cache_path.parent):
             os.makedirs(self.local_cache_path.parent, exist_ok=True)
+
         write_atomic(
             str(self.local_cache_path),
             json.dumps({"system": self.system, "cache": local_cache}, indent=4),
@@ -292,8 +293,18 @@ class PersistentCache(CacheBase):
                 and check_cache(self.get_global_cache(), callback=log_stats)
             ):
                 try:
-                    # re-benchmark everything to try to get consistent numbers from the same machine
-                    timings = benchmark(choices)
+                    uncached_choices = []
+                    timings = dict()
+                    # We re-use results from local cache, but not from global cache, to ensure
+                    # that results are comparable
+                    for choice in choices:
+                        choice_hash = choice.hash_key()
+                        if choice_hash in local_cache.get(op, {}).get(inputs, {}):
+                            # cache hit
+                            timings[choice] = local_cache[op][inputs][choice_hash]
+                        else:
+                            uncached_choices.append(choice)
+                    timings.update(benchmark(uncached_choices))
                     assert all(choice in timings for choice in choices)
                     local_cache.setdefault(op, {})
                     local_cache[op].setdefault(inputs, {}).setdefault(precision, {})
@@ -744,7 +755,7 @@ class FxGraphCache:
         Load a compiled graph from the cache. If a cached entry does not exist,
         compile the graph and save it to the cache.
         """
-        from filelock import FileLock
+        from filelock import FileLock  # type: ignore[import-not-found]
 
         key = compiled_fx_graph_hash(gm, example_inputs, fx_kwargs)
 
@@ -1342,11 +1353,11 @@ def get_include_and_linking_paths(
 
             # check the `OMP_PREFIX` environment first
             if os.getenv("OMP_PREFIX") is not None:
-                header_path = os.path.join(os.getenv("OMP_PREFIX"), "include", "omp.h")
+                header_path = os.path.join(os.getenv("OMP_PREFIX"), "include", "omp.h")  # type: ignore[arg-type]
                 valid_env = os.path.exists(header_path)
                 if valid_env:
-                    ipaths.append(os.path.join(os.getenv("OMP_PREFIX"), "include"))
-                    lpaths.append(os.path.join(os.getenv("OMP_PREFIX"), "lib"))
+                    ipaths.append(os.path.join(os.getenv("OMP_PREFIX"), "include"))  # type: ignore[arg-type]
+                    lpaths.append(os.path.join(os.getenv("OMP_PREFIX"), "lib"))  # type: ignore[arg-type]
                 else:
                     warnings.warn("environment variable `OMP_PREFIX` is invalid.")
                 omp_available = omp_available or valid_env
@@ -1357,8 +1368,8 @@ def get_include_and_linking_paths(
             if not omp_available and os.getenv("CONDA_PREFIX") is not None:
                 omp_available = is_conda_llvm_openmp_installed()
                 if omp_available:
-                    conda_lib_path = os.path.join(os.getenv("CONDA_PREFIX"), "lib")
-                    ipaths.append(os.path.join(os.getenv("CONDA_PREFIX"), "include"))
+                    conda_lib_path = os.path.join(os.getenv("CONDA_PREFIX"), "lib")  # type: ignore[arg-type]
+                    ipaths.append(os.path.join(os.getenv("CONDA_PREFIX"), "include"))  # type: ignore[arg-type]
                     lpaths.append(conda_lib_path)
                     # Prefer Intel OpenMP on x86 machine
                     if os.uname().machine == "x86_64" and os.path.exists(
@@ -2168,6 +2179,7 @@ def _nvcc_compiler_options() -> List[str]:
         config.cuda.compile_opt_level,
         "-std=c++17",
         "--expt-relaxed-constexpr",
+        "-DNDEBUG",
     ]
     if config.cuda.enable_debug_info:
         options.extend(["-lineinfo", "-g", "-DCUTLASS_DEBUG_TRACE_LEVEL=1"])

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -293,18 +293,8 @@ class PersistentCache(CacheBase):
                 and check_cache(self.get_global_cache(), callback=log_stats)
             ):
                 try:
-                    uncached_choices = []
-                    timings = dict()
-                    # We re-use results from local cache, but not from global cache, to ensure
-                    # that results are comparable
-                    for choice in choices:
-                        choice_hash = choice.hash_key()
-                        if choice_hash in local_cache.get(op, {}).get(inputs, {}):
-                            # cache hit
-                            timings[choice] = local_cache[op][inputs][choice_hash]
-                        else:
-                            uncached_choices.append(choice)
-                    timings.update(benchmark(uncached_choices))
+                    # re-benchmark everything to try to get consistent numbers from the same machine
+                    timings = benchmark(choices)
                     assert all(choice in timings for choice in choices)
                     local_cache.setdefault(op, {})
                     local_cache[op].setdefault(inputs, {}).setdefault(precision, {})

--- a/torch/_inductor/codegen/cuda/cuda_kernel.py
+++ b/torch/_inductor/codegen/cuda/cuda_kernel.py
@@ -298,13 +298,17 @@ class CUDATemplateCaller(ChoiceCaller):
         layout: Layout,
         make_kernel_render: Callable[[CUDATemplateBuffer, Optional[List[IRNode]]], str],
         bmreq: CUDABenchmarkRequest,
-        template: "CUDATemplate",
+        template: "CUDATemplate",  # type: ignore[name-defined]
     ):
         super().__init__(name, input_nodes, layout)
         self.category = category
         self.make_kernel_render = make_kernel_render
         self.bmreq = bmreq
         self.template = template
+
+    def precompile(self) -> None:
+        assert self.bmreq is not None
+        self.bmreq.precompile()
 
     def benchmark(self, *args, out) -> float:
         assert self.bmreq is not None

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -200,6 +200,18 @@ max_autotune_gemm_backends = os.environ.get(
     "TORCHINDUCTOR_MAX_AUTOTUNE_GEMM_BACKENDS", "ATEN,TRITON"
 ).upper()
 
+# Number of threads to use for pre-compilation of kernels
+# in order to populate compilation cache.
+autotune_precompilation_workers = min(
+    torch.get_num_threads(),
+    int(
+        os.environ.get(
+            "TORCHINDUCTOR_MAX_AUTOTUNE_PRECOMPILATION_WORKERS",
+            str(torch.get_num_threads() - 8),
+        )
+    ),
+)
+
 # the value used as a fallback for the unbacked SymInts
 # that can appear in the input shapes (e.g., in autotuning)
 unbacked_symint_fallback = 8192

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -200,18 +200,6 @@ max_autotune_gemm_backends = os.environ.get(
     "TORCHINDUCTOR_MAX_AUTOTUNE_GEMM_BACKENDS", "ATEN,TRITON"
 ).upper()
 
-# Number of threads to use for pre-compilation of kernels
-# in order to populate compilation cache.
-autotune_precompilation_workers = min(
-    torch.get_num_threads(),
-    int(
-        os.environ.get(
-            "TORCHINDUCTOR_MAX_AUTOTUNE_PRECOMPILATION_WORKERS",
-            str(torch.get_num_threads()),
-        )
-    ),
-)
-
 # the value used as a fallback for the unbacked SymInts
 # that can appear in the input shapes (e.g., in autotuning)
 unbacked_symint_fallback = 8192

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -207,7 +207,7 @@ autotune_precompilation_workers = min(
     int(
         os.environ.get(
             "TORCHINDUCTOR_MAX_AUTOTUNE_PRECOMPILATION_WORKERS",
-            str(torch.get_num_threads() - 8),
+            str(torch.get_num_threads()),
         )
     ),
 )

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -7,6 +7,7 @@ import operator
 import sys
 import textwrap
 import time
+from concurrent.futures import ThreadPoolExecutor
 from io import StringIO
 
 from typing import Any, Callable, Dict, List, Optional, Type, Union
@@ -744,6 +745,7 @@ class AlgorithmSelectorCache(PersistentCache):
         # arg, the function will be called instead of
         # generating a random torch.Tensor for benchmarking.
         input_gen_fns: Optional[Dict[int, Callable[[ir.Buffer], torch.Tensor]]] = None,
+        precompilation_timeout_seconds: int = 60 * 60,
     ):
         from .codegen.cuda.cuda_kernel import CUDATemplateCaller
 
@@ -765,7 +767,53 @@ class AlgorithmSelectorCache(PersistentCache):
         def make_benchmark_fn():
             return self.make_benchmark_fn(choices, input_nodes, layout, input_gen_fns)
 
+        def precompile(choices):
+            if (
+                precompilation_timeout_seconds is None
+                or precompilation_timeout_seconds <= 0
+            ):
+                return
+            if config.autotune_precompilation_workers <= 0:
+                return
+            num_workers = min(
+                config.autotune_precompilation_workers,
+                torch.get_num_threads(),
+                len(choices),
+            )
+            log.info(
+                "Multithreaded precompilation for %d choices using %d worker threads",
+                len(choices),
+                num_workers,
+            )
+            with ThreadPoolExecutor(max_workers=num_workers) as executor:
+                futures = executor.map(
+                    lambda c: c.precompile(),
+                    [c for c in choices if hasattr(c, "precompile")],
+                    timeout=precompilation_timeout_seconds,
+                )
+                try:
+                    iterator = iter(futures)
+                    while True:
+                        try:
+                            next(iterator)
+                        except CUDACompileError:
+                            log.error("CUDA Compilation error", exc_info=True)
+                except TimeoutError:
+                    log.warning(
+                        f"Precompilation timed out after {precompilation_timeout_seconds} seconds."
+                    )
+                except StopIteration:
+                    pass
+                executor.shutdown(wait=True)
+
         def autotune(choices):
+            try:
+                precompile(choices)
+            except TimeoutError:
+                log.warning(
+                    "Precompilation phase took longer than timeout allowed. Continuing"
+                )
+                pass
             return make_benchmark_fn()(choices)
 
         if config.autotune_in_subproc:

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -773,13 +773,13 @@ class AlgorithmSelectorCache(PersistentCache):
                 or precompilation_timeout_seconds <= 0
             ):
                 return
-            if config.autotune_precompilation_workers <= 0:
-                return
             num_workers = min(
-                config.autotune_precompilation_workers,
+                config.compile_threads,
                 torch.get_num_threads(),
                 len(choices),
             )
+            if num_workers <= 0:
+                return
             log.info(
                 "Multithreaded precompilation for %d choices using %d worker threads",
                 len(choices),

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -797,10 +797,12 @@ class AlgorithmSelectorCache(PersistentCache):
                         try:
                             next(iterator)
                         except CUDACompileError:
-                            log.error("CUDA Compilation error", exc_info=True)
+                            log.error(  # noqa: G201
+                                "CUDA Compilation error", exc_info=True
+                            )
                 except TimeoutError:
                     log.warning(
-                        f"Precompilation timed out after {precompilation_timeout_seconds} seconds."
+                        f"Precompilation timed out after {precompilation_timeout_seconds} seconds."  # noqa: G004
                     )
                 except StopIteration:
                     pass


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #119010
* #119009
* #119008
* #119007
* #119006
* #119004
* __->__ #119003

When using the Cutlass backend, the compilation
of CUDA source files can totally dominate the runtime required for the benchmarking done
as part of Autotuning.

This change adds a multithreaded precompilation phase, which serves to pre-populate the compilation cache ( both in-memory, and a
possible on-disk sccache ).

Also it ensures that no unneccessary compilation
and benchmarking steps are performed, which was peviously the case.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @muchulee8 @aakhundov @ColinPeppler