### PR TITLE
[MPS][BE] Add native lerp support

### DIFF
--- a/aten/src/ATen/native/mps/operations/Lerp.mm
+++ b/aten/src/ATen/native/mps/operations/Lerp.mm
@@ -1,5 +1,6 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/core/Tensor.h>
+#include <ATen/native/mps/OperationUtils.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -11,8 +12,46 @@
 
 namespace at::native {
 TORCH_IMPL_FUNC(lerp_Tensor_mps)(const Tensor& self, const Tensor& end, const Tensor& weight, const Tensor& out) {
-  // TODO: Write a much better implementation
-  at::add_out(const_cast<Tensor&>(out), self, weight.mul(end.sub(self)));
+  TORCH_CHECK(out.is_mps());
+  std::array<TensorArg, 4> args{{{out, "out", 0}, {self, "self", 1}, {end, "end", 2}, {weight, "weight", 3}}};
+  checkAllSameGPU(__func__, args);
+  using namespace mps;
+  struct CachedGraph : public MPSCachedGraph {
+    CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
+    MPSGraphTensor* selfTensor_ = nil;
+    MPSGraphTensor* endTensor_ = nil;
+    MPSGraphTensor* weightTensor_ = nil;
+    MPSGraphTensor* outputTensor_ = nil;
+  };
+  @autoreleasepool {
+    string key = "lerp_Tensor_mps" + getTensorsStringKey({self, end, weight});
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto graph) {
+      auto selfTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+      auto endTensor = mpsGraphRankedPlaceHolder(mpsGraph, end);
+      auto weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, weight);
+      auto distance = [mpsGraph subtractionWithPrimaryTensor:endTensor secondaryTensor:selfTensor name:nil];
+      auto weighedDistance = [mpsGraph multiplicationWithPrimaryTensor:weightTensor secondaryTensor:distance name:nil];
+      auto output = [mpsGraph additionWithPrimaryTensor:selfTensor secondaryTensor:weighedDistance name:nil];
+      graph->selfTensor_ = selfTensor;
+      graph->endTensor_ = endTensor;
+      graph->weightTensor_ = weightTensor;
+      graph->outputTensor_ = output;
+    });
+    auto selfPlaceholder = Placeholder(cachedGraph->selfTensor_, self);
+    auto endPlaceholder = Placeholder(cachedGraph->endTensor_, end);
+    auto weightPlaceholder = Placeholder(cachedGraph->weightTensor_, weight);
+    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, out);
+    NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds = @{
+      selfPlaceholder.getMPSGraphTensor() : selfPlaceholder.getMPSGraphTensorData(),
+      endPlaceholder.getMPSGraphTensor() : endPlaceholder.getMPSGraphTensorData(),
+      weightPlaceholder.getMPSGraphTensor() : weightPlaceholder.getMPSGraphTensorData(),
+    };
+    NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results = @{
+      outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData(),
+    };
+
+    runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, results);
+  }
 }
 
 } // namespace at::native


### PR DESCRIPTION
By implementing `out = self + weight * (end-self)` as MPS graph

LERP is tested by `test_output_match_lerp_cpu_float[32|16]` based on OpInfo and 10+ tests from `test_optim.py`