### PR TITLE
[dynamo] Simplify matched_input_elements_to_fake construction.

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -840,6 +840,7 @@ class FlattenInputOutputSignature(torch.fx.interpreter.Transformer):
         super().__init__(m)
 
         assert len(flat_args_dynamic_dims) == len(flat_args)
+        assert len(example_fake_inputs) >= len(matched_input_elements_positions)
         matched_input_elements_to_fake = dict(zip(matched_input_elements_positions, example_fake_inputs))
 
         self.new_args = []

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -840,10 +840,7 @@ class FlattenInputOutputSignature(torch.fx.interpreter.Transformer):
         super().__init__(m)
 
         assert len(flat_args_dynamic_dims) == len(flat_args)
-        matched_input_elements_to_fake = {
-            val: example_fake_inputs[ix]
-            for ix, val in enumerate(matched_input_elements_positions)
-        }
+        matched_input_elements_to_fake = dict(zip(example_fake_inputs, matched_input_elements_positions))
 
         self.new_args = []
         for i in range(0, len(flat_args)):

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -840,7 +840,7 @@ class FlattenInputOutputSignature(torch.fx.interpreter.Transformer):
         super().__init__(m)
 
         assert len(flat_args_dynamic_dims) == len(flat_args)
-        matched_input_elements_to_fake = dict(zip(example_fake_inputs, matched_input_elements_positions))
+        matched_input_elements_to_fake = dict(zip(matched_input_elements_positions, example_fake_inputs))
 
         self.new_args = []
         for i in range(0, len(flat_args)):


### PR DESCRIPTION
It's more idiomatic and efficient.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @aakhundov