### PR TITLE
[c10d] PGNCCL refactor part 1: adds assert size==1

### DIFF
--- a/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
@@ -258,12 +258,8 @@ class ProcessGroupNCCLErrorsTest : public ::testing::Test {
     TemporaryFile file;
     store_ = c10::make_intrusive<::c10d::FileStore>(file.path, 1);
 
-    at::cuda::OptionalCUDAGuard deviceGuard;
     tensors_.resize(numDevices);
-    for (const auto i : c10::irange(numDevices)) {
-      deviceGuard.set_index(i);
-      tensors_[i] = at::ones({3, 3}, at::kCUDA);
-    }
+    tensors_[0] = at::empty({3, 3}, at::kCUDA);
   }
 
   void TearDown() override {

--- a/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
@@ -258,7 +258,7 @@ class ProcessGroupNCCLErrorsTest : public ::testing::Test {
     // including the init -- when there are GPUs available.
     if (skipTest()) {
       GTEST_SKIP() << "Skipping ProcessGroupNCCLErrorsTest because system "
-                   << "requirement is not met (no CUDA or GPU)."
+                   << "requirement is not met (no CUDA or GPU).";
     }
 
     size_t numDevices = 1; // One device per rank (thread)

--- a/test/cpp/c10d/ProcessGroupNCCLTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLTest.cpp
@@ -71,12 +71,14 @@ class NCCLTest : public NCCLTestBase {
  public:
   NCCLTest(
       const std::string& path,
+      int rank,
       int worldSize,
       std::chrono::milliseconds pgTimeout =
           c10d::kProcessGroupNCCLDefaultTimeout,
       int inputDim = 3)
       : NCCLTestBase(path, pgTimeout),
-        numDevices_(cudaNumDevices()),
+        numDevices_(1), // one device per rank (thread)
+        rank_(rank),
         worldSize_(worldSize) {
     // Each device has a single tensor to perf the NCCL op
     ::at::globalContext().lazyInitCUDA();
@@ -84,8 +86,9 @@ class NCCLTest : public NCCLTestBase {
     inputs_.resize(numDevices_);
     outputs_.resize(numDevices_);
     at::cuda::OptionalCUDAGuard deviceGuard;
+    assert(numDevices_ == 1);
     for (const auto i : c10::irange(numDevices_)) {
-      deviceGuard.set_index(i);
+      deviceGuard.set_index(rank_);
       tensors_[i] = at::empty({inputDim, inputDim}, at::kCUDA);
       inputs_[i].resize(worldSize_ * numDevices_);
       outputs_[i].resize(worldSize_ * numDevices_);
@@ -102,11 +105,9 @@ class NCCLTest : public NCCLTestBase {
     // and pass this along to the collective (since it uses the THC
     // getters to retrieve the current stream).
     //
-    streams_.reserve(numDevices_);
-    for (const auto i : c10::irange(numDevices_)) {
-      deviceGuard.set_index(i);
-      streams_.push_back(at::cuda::getStreamFromPool());
-    }
+    // 1 device only, hence 1 stream only
+    deviceGuard.set_index(rank_);
+    streams_.push_back(at::cuda::getStreamFromPool());
   }
 
   void wait(
@@ -168,7 +169,7 @@ class NCCLTest : public NCCLTestBase {
   void launchDeviceSleep() {
     at::cuda::OptionalCUDAGuard deviceGuard;
     for (const auto i : c10::irange(numDevices_)) {
-      deviceGuard.set_index(i);
+      deviceGuard.set_index(rank_);
       cudaSleep(streams_[i], 2000 * 1000 * 1000);
     }
   }
@@ -177,7 +178,7 @@ class NCCLTest : public NCCLTestBase {
   void valueInitialization() {
     at::cuda::OptionalCUDAGuard deviceGuard;
     for (const auto i : c10::irange(numDevices_)) {
-      deviceGuard.set_index(i);
+      deviceGuard.set_index(rank_);
       tensors_[i].fill_(pg_->getRank() * numDevices_ + i);
     }
   }
@@ -198,7 +199,7 @@ class NCCLTest : public NCCLTestBase {
   void valueInitializationForSparse() {
     at::cuda::OptionalCUDAGuard deviceGuard;
     for (const auto i : c10::irange(numDevices_)) {
-      deviceGuard.set_index(i);
+      deviceGuard.set_index(rank_);
       tensors_[i].fill_(pg_->getRank() * numDevices_ + i + 1);
       // Convert the dense tensor to a sparse tensor in COO row format
       tensors_[i] = to_sparse_row_indices_format(tensors_[i]);
@@ -206,6 +207,7 @@ class NCCLTest : public NCCLTestBase {
   }
 
   const int numDevices_;
+  int rank_;
   int worldSize_;
   std::vector<at::Tensor> tensors_;
   std::vector<std::vector<at::Tensor>> inputs_;
@@ -215,8 +217,8 @@ class NCCLTest : public NCCLTestBase {
 
 class AllreduceNCCLTest : public NCCLTest {
  public:
-  AllreduceNCCLTest(const std::string& path, int worldSize)
-      : NCCLTest(path, worldSize) {}
+  AllreduceNCCLTest(const std::string& path, int rank, int worldSize)
+      : NCCLTest(path, rank, worldSize) {}
 
   c10::intrusive_ptr<c10d::Work> run() {
     // For the duration of this function, make THC use our streams
@@ -238,9 +240,14 @@ class AllreduceNCCLTest : public NCCLTest {
 
 class SparseAllreduceNCCLTest : public NCCLTest {
  public:
-  SparseAllreduceNCCLTest(const std::string& path, int worldSize, int inputDim)
+  SparseAllreduceNCCLTest(
+      const std::string& path,
+      int rank,
+      int worldSize,
+      int inputDim)
       : NCCLTest(
             path,
+            rank,
             worldSize,
             c10d::kProcessGroupNCCLDefaultTimeout,
             inputDim) {}
@@ -257,8 +264,8 @@ class SparseAllreduceNCCLTest : public NCCLTest {
 
 class BroadcastNCCLTest : public NCCLTest {
  public:
-  BroadcastNCCLTest(const std::string& path, int worldSize)
-      : NCCLTest(path, worldSize) {}
+  BroadcastNCCLTest(const std::string& path, int rank, int worldSize)
+      : NCCLTest(path, rank, worldSize) {}
 
   c10::intrusive_ptr<c10d::Work> run(int rootRank, int rootTensor) {
     // For the duration of this function, make THC use our streams
@@ -276,8 +283,8 @@ class BroadcastNCCLTest : public NCCLTest {
 
 class ReduceNCCLTest : public NCCLTest {
  public:
-  ReduceNCCLTest(const std::string& path, int worldSize)
-      : NCCLTest(path, worldSize) {}
+  ReduceNCCLTest(const std::string& path, int rank, int worldSize)
+      : NCCLTest(path, rank, worldSize) {}
 
   c10::intrusive_ptr<c10d::Work> run(int rootRank, int rootTensor) {
     // For the duration of this function, make THC use our streams
@@ -295,8 +302,8 @@ class ReduceNCCLTest : public NCCLTest {
 
 class AllgatherNCCLTest : public NCCLTest {
  public:
-  AllgatherNCCLTest(const std::string& path, int worldSize)
-      : NCCLTest(path, worldSize) {}
+  AllgatherNCCLTest(const std::string& path, int rank, int worldSize)
+      : NCCLTest(path, rank, worldSize) {}
 
   c10::intrusive_ptr<c10d::Work> run() {
     // For the duration of this function, make THC use our streams
@@ -311,8 +318,8 @@ class AllgatherNCCLTest : public NCCLTest {
 
 class AllgatherBaseNCCLTest : public NCCLTest {
  public:
-  AllgatherBaseNCCLTest(const std::string& path, int worldSize)
-      : NCCLTest(path, worldSize) {
+  AllgatherBaseNCCLTest(const std::string& path, int rank, int worldSize)
+      : NCCLTest(path, rank, worldSize) {
     output_tensor_ = at::empty({worldSize_, 3, 3}, at::kCUDA);
   }
 
@@ -343,8 +350,8 @@ class AllgatherBaseNCCLTest : public NCCLTest {
 };
 
 struct ReduceScatterNCCLTest : NCCLTest {
-  ReduceScatterNCCLTest(const std::string& path, int worldSize)
-      : NCCLTest(path, worldSize) {}
+  ReduceScatterNCCLTest(const std::string& path, int rank, int worldSize)
+      : NCCLTest(path, rank, worldSize) {}
 
   c10::intrusive_ptr<c10d::Work> run() {
     // For the duration of this function, make THC use our streams
@@ -354,12 +361,8 @@ struct ReduceScatterNCCLTest : NCCLTest {
     launchDeviceSleep();
 
     // Launch value initialization for every tensor
-    for (const auto i : c10::irange(numDevices_)) {
-      deviceGuard.set_index(i);
-      for (auto j = 0; j < worldSize_ * numDevices_; ++j) {
-        inputs_[i][j].fill_(
-            pg_->getRank() * numDevices_ * worldSize_ + i * worldSize_ + j);
-      }
+    for (auto j = 0; j < worldSize_; ++j) {
+      inputs_[0][j].fill_(rank_ * worldSize_ + j);
     }
 
     return pg_->reduce_scatter(tensors_, inputs_);
@@ -368,8 +371,10 @@ struct ReduceScatterNCCLTest : NCCLTest {
 
 class ReduceScatterBaseNCCLTest : public NCCLTest {
  public:
-  ReduceScatterBaseNCCLTest(const std::string& path, int worldSize)
-      : NCCLTest(path, worldSize) {
+  ReduceScatterBaseNCCLTest(const std::string& path, int rank, int worldSize)
+      : NCCLTest(path, rank, worldSize) {
+    at::cuda::OptionalCUDAGuard deviceGuard;
+    deviceGuard.set_index(rank_);
     output_tensor_ = at::empty({1}, at::kCUDA);
     input_tensor_ = at::empty({worldSize}, at::kCUDA);
     for (const auto i : c10::irange(worldSize)) {
@@ -401,7 +406,7 @@ class ReduceScatterBaseNCCLTest : public NCCLTest {
 };
 
 void testAllreduce(const std::string& path, int rank, int size) {
-  auto test = AllreduceNCCLTest(path, size);
+  auto test = AllreduceNCCLTest(path, rank, size);
   test.initialize(rank, size);
   auto work = test.run();
   // Wait for work to finish
@@ -422,7 +427,7 @@ void testAllreduce(const std::string& path, int rank, int size) {
 
 void testSparseAllreduce(const std::string& path, int rank, int size) {
   const int inputDim = 3;
-  auto test = SparseAllreduceNCCLTest(path, size, inputDim);
+  auto test = SparseAllreduceNCCLTest(path, rank, size, inputDim);
   test.initialize(rank, size);
   auto work = test.run();
   // Wait for work to finish
@@ -473,7 +478,7 @@ void testSparseAllreduce(const std::string& path, int rank, int size) {
 
 void testSparseAllreduceLarge(const std::string& path, int rank, int size) {
   const int inputDim = 2500;
-  auto test = SparseAllreduceNCCLTest(path, size, inputDim);
+  auto test = SparseAllreduceNCCLTest(path, rank, size, inputDim);
   test.initialize(rank, size);
   auto work = test.run();
   // Wait for work to finish
@@ -523,7 +528,7 @@ void testSparseAllreduceLarge(const std::string& path, int rank, int size) {
 }
 
 void testBroadcast(const std::string& path, int rank, int size) {
-  auto test = BroadcastNCCLTest(path, size);
+  auto test = BroadcastNCCLTest(path, rank, size);
   test.initialize(rank, size);
 
   const int numDevices = test.numDevices();
@@ -550,7 +555,7 @@ void testBroadcast(const std::string& path, int rank, int size) {
 }
 
 void testReduce(const std::string& path, int rank, int size) {
-  auto test = ReduceNCCLTest(path, size);
+  auto test = ReduceNCCLTest(path, rank, size);
   test.initialize(rank, size);
 
   const int numDevices = test.numDevices();
@@ -579,7 +584,7 @@ void testReduce(const std::string& path, int rank, int size) {
 }
 
 void testAllgather(const std::string& path, int rank, int size) {
-  auto test = AllgatherNCCLTest(path, size);
+  auto test = AllgatherNCCLTest(path, rank, size);
   test.initialize(rank, size);
   auto work = test.run();
   // Wait for work to finish
@@ -603,7 +608,7 @@ void testAllgather(const std::string& path, int rank, int size) {
 }
 
 void testAllgatherBase(const std::string& path, int rank, int size) {
-  auto test = AllgatherBaseNCCLTest(path, size);
+  auto test = AllgatherBaseNCCLTest(path, rank, size);
   test.initialize(rank, size);
   auto work = test.run();
   // Wait for work to finish
@@ -624,7 +629,7 @@ void testAllgatherBase(const std::string& path, int rank, int size) {
   }
 }
 void testReduceScatterBase(const std::string& path, int rank, int size) {
-  auto test = ReduceScatterBaseNCCLTest(path, size);
+  auto test = ReduceScatterBaseNCCLTest(path, rank, size);
   test.initialize(rank, size);
   auto work = test.run();
   // Wait for work to finish
@@ -646,196 +651,41 @@ void testReduceScatterBase(const std::string& path, int rank, int size) {
 }
 
 void testReduceScatter(const std::string& path, int rank, int size) {
-  auto test = ReduceScatterNCCLTest(path, size);
+  auto test = ReduceScatterNCCLTest(path, rank, size);
   test.initialize(rank, size);
   auto work = test.run();
   // Wait for work to finish
   test.wait(work);
 
-  const auto participants = test.numDevices() * size;
+  const auto participants = size;
   const auto base = (participants * (participants - 1)) / 2;
 
   // Validation
   auto tensors = test.getTensors();
-  // device index
-  for (const auto i : c10::irange(tensors.size())) {
-    const auto modifier = participants * (rank * participants + i);
-    const auto expected = base + modifier;
-    auto& tensor = tensors[i];
-    auto data = tensor.data_ptr<float>();
-    for (const auto j : c10::irange(tensor.numel())) {
-      EXPECT_EQ(data[j], expected)
-          << "ReduceScatter outputs do not match expected outputs!";
-    }
+  const auto modifier = rank * participants;
+  const auto expected = base * participants + modifier;
+  auto& tensor = tensors[0];
+  auto data = tensor.data_ptr<float>();
+  for (const auto j : c10::irange(tensor.numel())) {
+    EXPECT_EQ(data[j], expected)
+        << "ReduceScatter outputs do not match expected outputs!";
   }
 }
 
-void testSequenceNumInit(
-    const std::string& path,
-    int /* unused */,
-    int /* unused */) {
-  // Note: ProcessGroupNCCLTest doesn't support multiprocess testing. So we
-  // simulate world_size > 1 here via threads.
-  const int worldSize = 2;
-  std::mutex m;
-  std::unordered_set<uint64_t> nums;
-  auto runTest = [&](int i) {
-    NCCLTest test(path, worldSize);
-    test.initialize(i, worldSize);
-    test.getProcessGroup()->setSequenceNumberForGroup();
-    std::lock_guard<std::mutex> lock(m);
-    auto seqNum = test.getProcessGroup()->getSequenceNumberForGroup();
-    nums.insert(seqNum);
-  };
-  std::vector<std::thread> threads;
-  threads.reserve(worldSize);
-  for (const auto r : c10::irange(worldSize)) {
-    threads.emplace_back(std::thread([=]() { runTest(r); }));
-  }
-  for (auto& t : threads) {
-    t.join();
-  }
-  EXPECT_EQ(nums.size(), 1);
+void testSequenceNumInit(const std::string& path, int rank, int size) {
+  NCCLTest test(path, rank, size);
+  test.initialize(rank, size);
+  test.getProcessGroup()->setSequenceNumberForGroup();
+  auto seqNum = test.getProcessGroup()->getSequenceNumberForGroup();
+  EXPECT_EQ(seqNum, 0);
 }
 
-class ProcessGroupNCCLTest : public ::testing::Test {
- protected:
-  void SetUp() override {
-    c10::initLogging();
-    // Use WORLD_SIZE and RANK environmental variables to do multi-node
-    // distributed testing
-    auto sizeEnv = std::getenv("WORLD_SIZE");
-    auto rankEnv = std::getenv("RANK");
+void testSplittingCommunicator(const std::string& path, int rank, int size) {
+  auto test1 = BroadcastNCCLTest(path, rank, size);
+  test1.initialize(rank, size);
 
-    if (sizeEnv && rankEnv) {
-      size_ = std::stoi(std::string(sizeEnv));
-      rank_ = std::stoi(std::string(rankEnv));
-    }
-    LOG(INFO) << "Multi-node world size: " << size_ << " rank: " << rank_;
-  }
-
-  void TearDown() override {
-    // Reset TORCH_NCCL_BLOCKING_WAIT environment variable after each run.
-    ASSERT_TRUE(setenv(c10d::TORCH_NCCL_BLOCKING_WAIT[0].c_str(), "0", 1) == 0);
-  }
-
-  bool skipTest() {
-    // Skip tests if CUDA is not available.
-    if (!at::cuda::is_available()) {
-      LOG(INFO) << "CUDA not available, skipping test";
-      return true;
-    }
-    return false;
-  }
-
-  int size_{1};
-  int rank_{0};
-};
-
-TEST_F(ProcessGroupNCCLTest, testAllreduce) {
-  if (skipTest()) {
-    return;
-  }
-  {
-    TemporaryFile file;
-    testAllreduce(file.path, rank_, size_);
-  }
-}
-
-TEST_F(ProcessGroupNCCLTest, testBroadcast) {
-  if (skipTest()) {
-    return;
-  }
-  {
-    TemporaryFile file;
-    testBroadcast(file.path, rank_, size_);
-  }
-}
-
-TEST_F(ProcessGroupNCCLTest, testReduce) {
-  if (skipTest()) {
-    return;
-  }
-  {
-    TemporaryFile file;
-    testReduce(file.path, rank_, size_);
-  }
-}
-
-TEST_F(ProcessGroupNCCLTest, testAllgather) {
-  if (skipTest()) {
-    return;
-  }
-  {
-    TemporaryFile file;
-    testAllgather(file.path, rank_, size_);
-  }
-}
-
-TEST_F(ProcessGroupNCCLTest, testAllgatherBase) {
-  if (skipTest()) {
-    return;
-  }
-  {
-    TemporaryFile file;
-    testAllgatherBase(file.path, rank_, size_);
-  }
-}
-
-TEST_F(ProcessGroupNCCLTest, testReduceScatter) {
-  if (skipTest()) {
-    return;
-  }
-  {
-    TemporaryFile file;
-    testReduceScatter(file.path, rank_, size_);
-  }
-}
-
-TEST_F(ProcessGroupNCCLTest, testSequenceNumInit) {
-  if (skipTest()) {
-    return;
-  }
-  {
-    TemporaryFile file;
-    testSequenceNumInit(file.path, rank_, size_);
-  }
-}
-
-TEST_F(ProcessGroupNCCLTest, testReduceScatterBase) {
-  if (skipTest()) {
-    return;
-  }
-  {
-    TemporaryFile file;
-    testReduceScatterBase(file.path, rank_, size_);
-  }
-}
-
-TEST_F(ProcessGroupNCCLTest, testBackendName) {
-  if (skipTest()) {
-    return;
-  }
-  {
-    TemporaryFile file;
-    auto test = NCCLTestBase(file.path);
-    test.initialize(rank_, size_);
-    EXPECT_EQ(
-        test.getProcessGroup()->getBackendName(),
-        std::string(c10d::NCCL_BACKEND_NAME));
-  }
-}
-
-TEST_F(ProcessGroupNCCLTest, testSplittingCommunicator) {
-  if (skipTest()) {
-    return;
-  }
-  TemporaryFile file;
-  auto test1 = BroadcastNCCLTest(file.path, size_);
-  test1.initialize(rank_, size_);
-
-  auto test2 = BroadcastNCCLTest(file.path, size_);
-  test2.initialize(rank_, size_, test1.getProcessGroup());
+  auto test2 = BroadcastNCCLTest(path, rank, size);
+  test2.initialize(rank, size, test1.getProcessGroup());
 
   // Steal the broadcast test and issue it for both of our groups.
   // This ensures consistent full collective communication.  TODO:
@@ -844,7 +694,7 @@ TEST_F(ProcessGroupNCCLTest, testSplittingCommunicator) {
   for (auto test : {&test1, &test2}) {
     const int numDevices = test->numDevices();
     // try every permutation of root rank and root tensor
-    for (const auto rootRank : c10::irange(size_)) {
+    for (const auto rootRank : c10::irange(size)) {
       for (const auto rootTensor : c10::irange(numDevices)) {
         auto work = test->run(rootRank, rootTensor);
         test->wait(work);
@@ -870,15 +720,132 @@ TEST_F(ProcessGroupNCCLTest, testSplittingCommunicator) {
   EXPECT_EQ(test1.getProcessGroup()->getCommSplitCounter(), test1.numDevices());
 }
 
+// All testAbc's use this signature
+using FuncType = void (*)(const std::string&, int, int);
+
+class ProcessGroupNCCLTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    c10::initLogging();
+    // Use WORLD_SIZE and RANK environmental variables to do multi-node
+    // distributed testing
+    auto sizeEnv = std::getenv("WORLD_SIZE");
+    if (sizeEnv) {
+      size_ = std::stoi(std::string(sizeEnv));
+    }
+    LOG(INFO) << "ProcessGroupNCCLTest world size: " << size_;
+  }
+
+  void TearDown() override {
+    // Reset TORCH_NCCL_BLOCKING_WAIT environment variable after each run.
+    ASSERT_TRUE(setenv(c10d::TORCH_NCCL_BLOCKING_WAIT[0].c_str(), "0", 1) == 0);
+  }
+
+  bool skipTest() {
+    // Skip tests if CUDA is not available.
+    if (!at::cuda::is_available()) {
+      LOG(INFO) << "CUDA not available, skipping test";
+      return true;
+    }
+    return false;
+  }
+
+  void multiThreadRun(FuncType testFunc) {
+    TemporaryFile file;
+    std::vector<std::thread> threads;
+    threads.reserve(size_);
+    for (const auto rank : c10::irange(size_)) {
+      threads.emplace_back(std::thread(testFunc, file.path, rank, size_));
+    }
+    for (const auto rank : c10::irange(size_)) {
+      threads[rank].join();
+    }
+  }
+
+  int size_{1};
+};
+
+TEST_F(ProcessGroupNCCLTest, testAllreduce) {
+  if (skipTest()) {
+    return;
+  }
+  multiThreadRun(testAllreduce);
+}
+
+TEST_F(ProcessGroupNCCLTest, testBroadcast) {
+  if (skipTest()) {
+    return;
+  }
+  multiThreadRun(testBroadcast);
+}
+
+TEST_F(ProcessGroupNCCLTest, testReduce) {
+  if (skipTest()) {
+    return;
+  }
+  multiThreadRun(testReduce);
+}
+
+TEST_F(ProcessGroupNCCLTest, testAllgather) {
+  if (skipTest()) {
+    return;
+  }
+  multiThreadRun(testAllgather);
+}
+
+TEST_F(ProcessGroupNCCLTest, testAllgatherBase) {
+  if (skipTest()) {
+    return;
+  }
+  multiThreadRun(testAllgatherBase);
+}
+
+TEST_F(ProcessGroupNCCLTest, testReduceScatter) {
+  if (skipTest()) {
+    return;
+  }
+  multiThreadRun(testReduceScatter);
+}
+
+TEST_F(ProcessGroupNCCLTest, testSequenceNumInit) {
+  if (skipTest()) {
+    return;
+  }
+  multiThreadRun(testSequenceNumInit);
+}
+
+TEST_F(ProcessGroupNCCLTest, testReduceScatterBase) {
+  if (skipTest()) {
+    return;
+  }
+  multiThreadRun(testReduceScatterBase);
+}
+
+TEST_F(ProcessGroupNCCLTest, testBackendName) {
+  if (skipTest()) {
+    return;
+  }
+  TemporaryFile file;
+  auto test = NCCLTestBase(file.path);
+  test.initialize(/*rank=*/0, /*world_size=*/1);
+  EXPECT_EQ(
+      test.getProcessGroup()->getBackendName(),
+      std::string(c10d::NCCL_BACKEND_NAME));
+}
+
+TEST_F(ProcessGroupNCCLTest, testSplittingCommunicator) {
+  if (skipTest()) {
+    return;
+  }
+  multiThreadRun(testSplittingCommunicator);
+}
+
 #ifdef IS_NCCL_EXP
 TEST_F(ProcessGroupNCCLTest, testSparseAllreduce) {
   if (skipTest()) {
     return;
   }
-  {
-    TemporaryFile file;
-    testSparseAllreduce(file.path, rank_, size_);
-    testSparseAllreduceLarge(file.path, rank_, size_);
-  }
+  multiThreadRun(testSparseAllreduce);
+  multiThreadRun(testSparseAllreduceLarge);
 }
 #endif

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -718,34 +718,28 @@ class ProcessGroupNCCLTest(MultiProcessTestCase):
     def test_gather_checks(self):
         store = c10d.FileStore(self.file_name, self.world_size)
         pg = self._create_process_group_nccl(store, self.opts())
-        local_device_ids = self.rank_to_GPU[self.rank]
-        num_gpus = len(local_device_ids)
+        device_id = self.rank_to_GPU[self.rank][0]
 
         # init input
-        tensors = []
-        for device_id in local_device_ids:
-            tensors.append(torch.tensor([self.rank]).cuda(device_id))
+        tensor = torch.tensor([self.rank]).cuda(device_id)
 
         # init output
         output_ts = []
-        for idx in range(num_gpus):
-            gpu_idx = local_device_ids[idx]
-            output_ts.append([])
-            for rank in range(self.world_size):
-                output_ts[idx].append(torch.tensor([-1]).cuda(gpu_idx))
+        for rank in range(self.world_size):
+            output_ts.append(torch.tensor([-1]).cuda(device_id))
 
         with self.assertRaisesRegex(ValueError, "invalid root rank"):
             opts = c10d.GatherOptions()
             opts.rootRank = -1
-            pg.gather(output_ts, tensors, opts)
+            pg.gather([output_ts], [tensor], opts)
 
         with self.assertRaisesRegex(TypeError, "incompatible function arguments"):
-            pg.gather(output_ts, tensors, 0)
+            pg.gather([output_ts], [tensor], 0)
 
         with self.assertRaisesRegex(ValueError, "invalid root rank"):
             opts = c10d.GatherOptions()
             opts.rootRank = self.world_size
-            pg.gather(output_ts, tensors, opts)
+            pg.gather([output_ts], [tensor], opts)
 
         with self.assertRaisesRegex(
             # throws error message from dispatcher
@@ -753,20 +747,7 @@ class ProcessGroupNCCLTest(MultiProcessTestCase):
         ):
             opts = c10d.GatherOptions()
             opts.rootRank = 0
-            pg.gather(output_ts, [], opts)
-
-        with self.assertRaisesRegex(
-            ValueError, "Tensors must be on distinct GPU devices"
-        ):
-            # init input
-            tensors2 = []
-            for device_id in local_device_ids:
-                tensors2.append(torch.tensor([self.rank]).cuda(device_id))
-                tensors2.append(torch.tensor([self.rank]).cuda(device_id))
-
-            opts = c10d.GatherOptions()
-            opts.rootRank = 0
-            pg.gather(output_ts, tensors2, opts)
+            pg.gather([output_ts], [], opts)
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
@@ -2926,7 +2907,7 @@ class NcclErrorHandlingTest(MultiProcessTestCase):
 
     @property
     def op_timeout_sec(self):
-        return 1
+        return 3
 
     @property
     def world_size(self):

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -714,6 +714,13 @@ void ProcessGroupNCCL::WorkNCCL::abort() {
 
 static std::atomic<size_t> process_group_id = 0;
 
+constexpr const char* MULTI_DEVICE_ERROR_MSG =
+    "Expecting one tensor only but got multiple. You are probably using multiple "
+    "devices under one thread. The support for such usage has been deprecated. "
+    "For details, please refer to "
+    "https://pytorch.org/docs/stable/distributed.html#multi-gpu-collective-functions. "
+    "ProcessGroupNCCL continues supporting multi-process and multi-thread modes.";
+
 ProcessGroupNCCL::ProcessGroupNCCL(
     const c10::intrusive_ptr<Store>& store,
     int rank,
@@ -2831,6 +2838,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::pointToPoint(
 c10::intrusive_ptr<Work> ProcessGroupNCCL::allreduce_sparse(
     std::vector<at::Tensor>& tensors,
     const AllreduceOptions& opts) {
+  TORCH_CHECK(tensors.size() == 1, MULTI_DEVICE_ERROR_MSG);
 #ifdef IS_NCCL_EXP
   std::vector<at::Tensor> outputTensors(tensors.size());
   for (std::vector<at::Tensor>::size_type i = 0; i < tensors.size(); i++) {
@@ -2934,6 +2942,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::allreduce_impl(
 c10::intrusive_ptr<Work> ProcessGroupNCCL::allreduce(
     std::vector<at::Tensor>& tensors,
     const AllreduceOptions& opts) {
+  TORCH_CHECK(tensors.size() == 1, MULTI_DEVICE_ERROR_MSG);
   if (intraNodeComm_ != nullptr && tensors.size() == 1 &&
       opts.reduceOp == ReduceOp::SUM) {
     using namespace intra_node_comm;
@@ -3000,6 +3009,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::allreduce_coalesced(
 c10::intrusive_ptr<Work> ProcessGroupNCCL::broadcast(
     std::vector<at::Tensor>& tensors,
     const BroadcastOptions& opts) {
+  TORCH_CHECK(tensors.size() == 1, MULTI_DEVICE_ERROR_MSG);
   check_gpu_tensors_different_devices(tensors);
 
   // @lint-ignore CLANGTIDY
@@ -3110,6 +3120,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::_broadcast_oop(
 c10::intrusive_ptr<Work> ProcessGroupNCCL::reduce(
     std::vector<at::Tensor>& tensors,
     const ReduceOptions& opts) {
+  TORCH_CHECK(tensors.size() == 1, MULTI_DEVICE_ERROR_MSG);
   check_gpu_tensors_different_devices(tensors);
   // @lint-ignore CLANGTIDY
   auto tensor = tensors.back();
@@ -3226,6 +3237,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::allgather(
     std::vector<std::vector<at::Tensor>>& outputTensors,
     std::vector<at::Tensor>& inputTensors,
     const AllgatherOptions& opts) {
+  TORCH_CHECK(inputTensors.size() == 1, MULTI_DEVICE_ERROR_MSG);
   check_gpu_tensors_different_devices(inputTensors);
   // @lint-ignore CLANGTIDY
   bool same_size = check_same_size(outputTensors.back());
@@ -3370,6 +3382,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::reduce_scatter(
     std::vector<at::Tensor>& outputTensors,
     std::vector<std::vector<at::Tensor>>& inputTensors,
     const ReduceScatterOptions& opts) {
+  TORCH_CHECK(outputTensors.size() == 1, MULTI_DEVICE_ERROR_MSG);
   check_gpu_tensors_different_devices(outputTensors);
   // @lint-ignore CLANGTIDY
   bool same_size = check_same_size(inputTensors.back());
@@ -3849,6 +3862,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::send(
     std::vector<at::Tensor>& tensors,
     int dstRank,
     int /* unused */) {
+  TORCH_CHECK(tensors.size() == 1, MULTI_DEVICE_ERROR_MSG);
   check_gpu_tensors_different_devices(tensors, true);
 
   // @lint-ignore CLANGTIDY
@@ -3889,6 +3903,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::recv(
     std::vector<at::Tensor>& tensors,
     int srcRank,
     int /* unused */) {
+  TORCH_CHECK(tensors.size() == 1, MULTI_DEVICE_ERROR_MSG);
   check_gpu_tensors_different_devices(tensors, true);
 
   // @lint-ignore CLANGTIDY
@@ -4021,6 +4036,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::gather(
   check_gpu_tensors_different_devices(inputTensors, true);
   assertSingleElementInput(invalidArgument, inputTensors);
 
+  TORCH_CHECK(inputTensors.size() == 1, MULTI_DEVICE_ERROR_MSG);
   // @lint-ignore CLANGTIDY
   auto tensor = inputTensors.back();
 
@@ -4110,6 +4126,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::scatter(
   assertSingleElementInput(invalidArgument, outputTensors);
 
   // @lint-ignore CLANGTIDY
+  TORCH_CHECK(outputTensors.size() == 1, MULTI_DEVICE_ERROR_MSG);
   auto tensor = outputTensors.back();
 
   std::vector<at::Tensor> inputs;


### PR DESCRIPTION
Breaking #118674 into multiple smaller PRs. 
This is the first one.
It adds `assert size==1` to PGNCCL, and refactors some old tests written in multi-device style (which would otherwise fail at the assert).


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @ezyang @gchanan