### PR TITLE
Clean up some obsolete TODOs in run_test and several test files

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -433,7 +433,8 @@ def run_test(
         unittest_args.extend(test_module.get_pytest_args())
         unittest_args = [arg if arg != "-f" else "-x" for arg in unittest_args]
 
-    # TODO: These features are not available for C++ test yet
+    # NB: These features are not available for C++ tests, but there is little incentive
+    # to implement it because we have never seen a flaky C++ test before.
     if IS_CI and not is_cpp_test:
         ci_args = ["--import-slow-tests", "--import-disabled-tests"]
         if RERUN_DISABLED_TESTS:

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -2879,7 +2879,7 @@ class TestNestedTensorAutograd(TestCase):
         data = (a, b)
         assert gradcheck(grad_test_func, inputs=data, check_batched_grad=False)
 
-    # TODO: OOM https://github.com/pytorch/pytorch/issues/95562
+    # https://github.com/pytorch/pytorch/issues/95562
     @skipIfSlowGradcheckEnv
     @parametrize("size", [1024, 1023, 513, 512, 256, 128, 32, 4, 2])
     def test_layer_norm_backward(self, device, size):
@@ -2896,7 +2896,7 @@ class TestNestedTensorAutograd(TestCase):
         data = (a, b, c)
         assert gradcheck(grad_test_func, inputs=data, check_batched_grad=False)
 
-    # TODO: OOM https://github.com/pytorch/pytorch/issues/95562
+    # https://github.com/pytorch/pytorch/issues/95562
     @skipIfSlowGradcheckEnv
     # Could either mark slow or reduce size
     @parametrize("size", [128, 32, 4, 2])

--- a/test/test_ops_fwd_gradients.py
+++ b/test/test_ops_fwd_gradients.py
@@ -7,16 +7,10 @@ import torch
 
 from torch.testing._internal.common_utils import unMarkDynamoStrictTest
 from torch.testing._internal.common_utils import (
-    TestGradients, run_tests, skipIfTorchInductor, IS_MACOS, TestCase)
+    TestGradients, run_tests, skipIfTorchInductor, TestCase)
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, ops, OpDTypes)
-
-# TODO: mitigate flaky issue on macOS https://github.com/pytorch/pytorch/issues/66033
-# AFAIK, c10::ThreadPool looks correct in the way it uses condition_variable wait. The
-# issue seems to point to macOS itself https://github.com/graphia-app/graphia/issues/33
-if IS_MACOS:
-    torch.set_num_threads(1)
 
 # gradcheck requires double precision
 _gradcheck_ops = partial(ops, dtypes=OpDTypes.supported,

--- a/test/test_ops_fwd_gradients.py
+++ b/test/test_ops_fwd_gradients.py
@@ -7,10 +7,16 @@ import torch
 
 from torch.testing._internal.common_utils import unMarkDynamoStrictTest
 from torch.testing._internal.common_utils import (
-    TestGradients, run_tests, skipIfTorchInductor, TestCase)
+    TestGradients, run_tests, skipIfTorchInductor, IS_MACOS, TestCase)
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, ops, OpDTypes)
+
+# TODO: mitigate flaky issue on macOS https://github.com/pytorch/pytorch/issues/66033
+# AFAIK, c10::ThreadPool looks correct in the way it uses condition_variable wait. The
+# issue seems to point to macOS itself https://github.com/graphia-app/graphia/issues/33
+if IS_MACOS:
+    torch.set_num_threads(1)
 
 # gradcheck requires double precision
 _gradcheck_ops = partial(ops, dtypes=OpDTypes.supported,


### PR DESCRIPTION
* The TODOs in `test/test_nestedtensor.py` has been mitigated, I keep the issue for reference.
* ~~The TODOs in `test/test_ops_fwd_gradients.py` doesn't apply anymore~~
* The TODOs in `run_test.py` to support disabling C++ tests is probably not going to happen.  I have never seen a flaky C++ test that needs to be disabled before.