### PR TITLE
Adding more information about the MPS backend

### DIFF
--- a/torch/mps/__init__.py
+++ b/torch/mps/__init__.py
@@ -1,8 +1,8 @@
 r"""
 This package enables an interface for accessing MPS (Metal Performance Shaders) backend in Python.
 Metal is Apple's API for programming metal GPU (graphics processor unit). Using MPS means that increased
-performance can be achieved, by running work on the metal GPU(s).
-See https://developer.apple.com/documentation/metalperformanceshaders for more details.
+performance can be achieved, by running work on the metal GPU(s).Note that the MPS backend only works for M-series chips and
+will not work with Intel based Mac's. See https://developer.apple.com/documentation/metalperformanceshaders for more details.
 """
 import torch
 from .. import Tensor


### PR DESCRIPTION
Added more information about the MPS backend, which mentions that the MPS API will only work with Apple silicon based machines, and will not work with Intel based chips