### PR TITLE
[storage][perf] Reduce _get_device_from_module overhead.

### DIFF
--- a/torch/storage.py
+++ b/torch/storage.py
@@ -478,8 +478,9 @@ def _reset_warn_typed_storage_removal():
     _warn_typed_storage_removal.__dict__['has_warned'] = False
 
 def _get_device_from_module(module: str):
-    if module.split(".")[-1] in ["cuda", torch._C._get_privateuse1_backend_name()]:
-        return module.split(".")[-1]
+    last_part = module.rsplit(".", 1)[-1]
+    if last_part in ["cuda", torch._C._get_privateuse1_backend_name()]:
+        return last_part
     else:
         return "cpu"
 


### PR DESCRIPTION
Using `rsplit` with maxsplit=1 is more efficient since it 1) stops traversal as soon as the first `.` from the right side is encountered 2) creates no more than 2-element list

This change also reuses `last_part` to avoid unnecessary repetition of a split.