### PR TITLE
Add a short code snippet in the RNN doc

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -4971,7 +4971,6 @@ greater than 0.0 is specified. The optional scale argument can only be specified
 
     # Efficient implementation equivalent to the following:
     def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None) -> torch.Tensor:
-        # Efficient implementation equivalent to the following:
         L, S = query.size(-2), key.size(-2)
         scale_factor = 1 / math.sqrt(query.size(-1)) if scale is None else scale
         attn_bias = torch.zeros(L, S, dtype=query.dtype)

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -378,8 +378,9 @@ class RNN(RNNBase):
     the input at time `t`, and :math:`h_{(t-1)}` is the hidden state of the
     previous layer at time `t-1` or the initial hidden state at time `0`.
     If :attr:`nonlinearity` is ``'relu'``, then :math:`\text{ReLU}` is used instead of :math:`\tanh`.
+
     .. code-block:: python
-    
+
         # Efficient implementation equivalent to the following with bidirectional=False
         def forward(x, h_0=None):
             if batch_first:
@@ -404,7 +405,7 @@ class RNN(RNNBase):
             if batch_first:
                 output = output.transpose(0, 1)
             return output, h_t
-    
+
     Args:
         input_size: The number of expected features in the input `x`
         hidden_size: The number of features in the hidden state `h`

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -378,7 +378,33 @@ class RNN(RNNBase):
     the input at time `t`, and :math:`h_{(t-1)}` is the hidden state of the
     previous layer at time `t-1` or the initial hidden state at time `0`.
     If :attr:`nonlinearity` is ``'relu'``, then :math:`\text{ReLU}` is used instead of :math:`\tanh`.
-
+    .. code-block:: python
+    
+        # Efficient implementation equivalent to the following with bidirectional=False
+        def forward(x, h_0=None):
+            if batch_first:
+                x = x.transpose(0, 1)
+            seq_len, batch_size, _ = x.size()
+            if h_0 is None:
+                h_0 = torch.zeros(num_layers, batch_size, hidden_size)
+            h_t_minus_1 = h_0
+            h_t = h_0
+            output = []
+            for t in range(seq_len):
+                for layer in range(num_layers):
+                    h_t[layer] = torch.tanh(
+                        x[t] @ weight_ih[layer].T
+                        + bias_ih[layer]
+                        + h_t_minus_1[layer] @ weight_hh[layer].T
+                        + bias_hh[layer]
+                    )
+                output.append(h_t[-1])
+                h_t_minus_1 = h_t
+            output = torch.stack(output)
+            if batch_first:
+                output = output.transpose(0, 1)
+            return output, h_t
+    
     Args:
         input_size: The number of expected features in the input `x`
         hidden_size: The number of features in the hidden state `h`


### PR DESCRIPTION
Fixes #109443,
also remove a duplicated comment line `# Efficient implementation equivalent to the following:` in scaled_dot_product_attention doc.

@mikaylagawarecki 