### PR TITLE
In dynamo tracing for index() use None as the default indicator for end and not -1

### DIFF
--- a/torch/_dynamo/polyfill.py
+++ b/torch/_dynamo/polyfill.py
@@ -20,7 +20,7 @@ def any(iterator):
     return False
 
 
-def index(iterator, item, start=0, end=-1):
+def index(iterator, item, start=0, end=None):
     for i, elem in enumerate(list(iterator))[start:end]:
         if item == elem:
             return i


### PR DESCRIPTION
Summary: In dynamo tracing, `index()`'s implementation currently has the default begin index as `0` and the default end index as`-1` which means that by default we're dropping the last element. Rather we should be doing `None` which will ensure that the last element is also checked.

Test Plan: CI

Differential Revision: D53392287




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng