### PR TITLE
[inductor] Support sympy.expr in user-defined Triton kernel grid fn

### DIFF
--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -1,5 +1,7 @@
 # Owner(s): ["module: inductor"]
 
+import unittest
+
 import torch
 
 from torch._dynamo import config as dynamo_config
@@ -112,6 +114,29 @@ class TestUnbackedSymints(TorchTestCase):
             )  # make sure no unbacked symint in output's stride
 
         example_inputs = (torch.randn(1, 1, 1, 1, device=device),)
+        actual = torch.compile(fn, fullgraph=True)(*example_inputs)
+        expected = fn(*example_inputs)
+        torch.testing.assert_close(actual, expected)
+
+    @skipCUDAIf(not HAS_CUDA, "requires cuda")
+    @dynamo_config.patch({"capture_scalar_outputs": True})
+    @inductor_config.patch({"aot_inductor.abi_compatible": True})
+    def test_triton_kernel_grid(self, device):
+        if device == "cpu":
+            raise unittest.SkipTest("Triton kernel requires GPU")
+
+        from torch.testing._internal.triton_utils import add_kernel
+
+        def fn(x):
+            maxlen = max(x.item(), 512)
+            a = torch.ones(maxlen, device=device)
+            b = torch.ones(maxlen, device=device)
+            out = torch.zeros_like(a)
+            # unbacked symint in grid
+            add_kernel[(1, 1, maxlen)](a, b, out, maxlen, 32)
+            return out
+
+        example_inputs = (torch.randint(high=1024, size=(1,), device=device),)
         actual = torch.compile(fn, fullgraph=True)(*example_inputs)
         expected = fn(*example_inputs)
         torch.testing.assert_close(actual, expected)


### PR DESCRIPTION
## Problem

A user-defined Triton kernel grid may use a sympy magic method like `Max`. This comes in the form of a form of a `sympy.Expr`, namely `sympy.core.function.FunctionClass`.

Handling this is not trivial since `user_defined_kernel_grid_fn_code` is used in Eager & Inductor. Eager usage below.

## Approach

Pass in wrapper when Inductor codegens grid with ints/sympy.Expr, so we can utilize wrapper functions, such as `codegen_shape_tuple()`.

Differential Revision: D53367012



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov