### PR TITLE
Fix typo in private attr of `inference_mode`

### DIFF
--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 import torch
 

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -258,8 +258,6 @@ class inference_mode(_DecoratorContextManager):
     def __init__(self, mode: bool = True) -> None:
         if not torch._jit_internal.is_scripting():
             super().__init__()
-        # Holds a context manager that can enable or disable inference mode
-        self._inference_mode_context: Optional[torch._C._InferenceMode] = None
         self.mode = mode
 
     def __new__(cls, mode=True):

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -259,7 +259,7 @@ class inference_mode(_DecoratorContextManager):
         if not torch._jit_internal.is_scripting():
             super().__init__()
         # Holds a context manager that can enable or disable inference mode
-        self._inference_mode_raii_context: Optional[torch._C._InferenceMode] = None
+        self._inference_mode_context: Optional[torch._C._InferenceMode] = None
         self.mode = mode
 
     def __new__(cls, mode=True):


### PR DESCRIPTION
This PR amends #102642.

`torch.inference_mode`'s attribute to store the actual context is inconsistent between `__init__` and `__enter__`.