### PR TITLE
[Inductor] Add Int8 data type into Inductor CPP backend vectorized code generation

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -859,12 +859,10 @@ class CPUReproTests(TestCase):
                 self.common(fn, (x,))
                 assert metrics.generated_cpp_vec_kernel_count == 1
 
-    @unittest.skipIf(
-        not codecache.valid_vec_isa_list(), "Does not support vectorization"
-    )
-    @patch("torch.cuda.is_available", lambda: False)
-    def test_decomposed_dequant_relu_quant(self):
-        def fn(x, scale, zero_point, use_dequant, use_quant):
+    def _test_decomposed_dequant_relu_quant_helper(self, dtype):
+        def fn(
+            x, scale, zero_point, use_dequant, use_quant, quant_min, quant_max, dtype
+        ):
             # For quantized_decomposed.dequantize_per_tensor
             # Refer to torch/ao/quantization/fx/_decomposed.py
             if use_dequant:
@@ -876,10 +874,14 @@ class CPUReproTests(TestCase):
             # Refer to torch/ao/quantization/fx/_decomposed.py
             if use_quant:
                 inv_scale = 1.0 / scale
-                x = torch.clamp(torch.round(x * inv_scale) + zero_point, 0, 255).to(
-                    torch.uint8
-                )
+                x = torch.clamp(
+                    torch.round(x * inv_scale) + zero_point, quant_min, quant_max
+                ).to(dtype)
             return x
+
+        assert dtype in [torch.uint8, torch.int8]
+        quant_min = 0 if dtype == torch.uint8 else -128
+        quant_max = 255 if dtype == torch.uint8 else 127
 
         use_dequant_list = [False, True]
         use_quant_list = [False, True]
@@ -887,48 +889,79 @@ class CPUReproTests(TestCase):
             use_dequant_list, use_quant_list
         ):
             x = torch.clamp(
-                torch.randn((1, 7, 7, 9), dtype=torch.float32) * 100, 0, 255
+                torch.randn((1, 7, 7, 9), dtype=torch.float32) * 100,
+                quant_min,
+                quant_max,
             )
             if use_dequant:
-                x = x.to(torch.uint8)
+                x = x.to(dtype)
             zero_point = 100
             scale = 0.01
             with config.patch({"cpp.simdlen": None}):
                 torch._dynamo.reset()
                 metrics.reset()
-                self.common(fn, (x, scale, zero_point, use_dequant, use_quant))
+                self.common(
+                    fn,
+                    (
+                        x,
+                        scale,
+                        zero_point,
+                        use_dequant,
+                        use_quant,
+                        quant_min,
+                        quant_max,
+                        dtype,
+                    ),
+                )
                 assert metrics.generated_cpp_vec_kernel_count == 1
 
     @unittest.skipIf(
         not codecache.valid_vec_isa_list(), "Does not support vectorization"
     )
-    @patch("torch.cuda.is_available", lambda: False)
-    def test_dequant_quant_lowering(self):
-        def fn(x, scale, zero_point, use_dequant, use_quant):
+    def test_decomposed_dequant_relu_quant_uint8(self):
+        self._test_decomposed_dequant_relu_quant_helper(torch.uint8)
+
+    @unittest.skipIf(
+        not codecache.valid_vec_isa_list(), "Does not support vectorization"
+    )
+    def test_decomposed_dequant_relu_quant_int8(self):
+        self._test_decomposed_dequant_relu_quant_helper(torch.int8)
+
+    def _test_dequant_quant_lowering_helper(self, dtype):
+        def fn(
+            x, scale, zero_point, use_dequant, use_quant, quant_min, quant_max, dtype
+        ):
             if use_dequant:
                 x = torch.ops.quantized_decomposed.dequantize_per_tensor(
-                    x, scale, zero_point, 0, 255, torch.uint8
+                    x, scale, zero_point, quant_min, quant_max, dtype
                 )
 
             x = torch.relu(x)
 
             if use_quant:
                 x = torch.ops.quantized_decomposed.quantize_per_tensor(
-                    x, scale, zero_point, 0, 255, torch.uint8
+                    x, scale, zero_point, quant_min, quant_max, dtype
                 )
             return x
 
         use_dequant_list = [False, True]
         use_quant_list = [False, True]
         use_tensor_overload_list = [False, True]
+
+        assert dtype in [torch.uint8, torch.int8]
+        quant_min = 0 if dtype == torch.uint8 else -128
+        quant_max = 255 if dtype == torch.uint8 else 127
+
         for use_dequant, use_quant, use_tensor_overload in itertools.product(
             use_dequant_list, use_quant_list, use_tensor_overload_list
         ):
             x = torch.clamp(
-                torch.randn((1, 7, 7, 9), dtype=torch.float32) * 100, 0, 255
+                torch.randn((1, 7, 7, 9), dtype=torch.float32) * 100,
+                quant_min,
+                quant_max,
             )
             if use_dequant:
-                x = x.to(torch.uint8)
+                x = x.to(dtype)
             zero_point = 100
             scale = 0.01
             if use_tensor_overload:
@@ -937,17 +970,37 @@ class CPUReproTests(TestCase):
             with config.patch({"cpp.simdlen": None}):
                 torch._dynamo.reset()
                 metrics.reset()
-                self.common(fn, (x, scale, zero_point, use_dequant, use_quant))
+                self.common(
+                    fn,
+                    (
+                        x,
+                        scale,
+                        zero_point,
+                        use_dequant,
+                        use_quant,
+                        quant_min,
+                        quant_max,
+                        dtype,
+                    ),
+                )
                 assert metrics.generated_cpp_vec_kernel_count == 1
 
     @unittest.skipIf(
         not codecache.valid_vec_isa_list(), "Does not support vectorization"
     )
-    @patch("torch.cuda.is_available", lambda: False)
-    def test_dequant_maxpool2d_lowering(self):
-        def fn(x, scale, zero_point):
+    def test_dequant_quant_lowering_uint8(self):
+        self._test_dequant_quant_lowering_helper(torch.uint8)
+
+    @unittest.skipIf(
+        not codecache.valid_vec_isa_list(), "Does not support vectorization"
+    )
+    def test_dequant_quant_lowering_int8(self):
+        self._test_dequant_quant_lowering_helper(torch.int8)
+
+    def _test_dequant_maxpool2d_lowering_helper(self, dtype):
+        def fn(x, scale, zero_point, quant_min, quant_max, dtype):
             x = torch.ops.quantized_decomposed.dequantize_per_tensor(
-                x, scale, zero_point, 0, 255, torch.uint8
+                x, scale, zero_point, quant_min, quant_max, dtype
             )
             max_pool2d_with_indices_default = (
                 torch.ops.aten.max_pool2d_with_indices.default(
@@ -956,13 +1009,19 @@ class CPUReproTests(TestCase):
             )
             return max_pool2d_with_indices_default
 
+        assert dtype in [torch.uint8, torch.int8]
+        quant_min = 0 if dtype == torch.uint8 else -128
+        quant_max = 255 if dtype == torch.uint8 else 127
+
         use_tensor_overload_list = [False, True]
         for use_tensor_overload in use_tensor_overload_list:
             x = (
                 torch.clamp(
-                    torch.randn((3, 16, 8, 8), dtype=torch.float32) * 100, 0, 255
+                    torch.randn((3, 16, 8, 8), dtype=torch.float32) * 100,
+                    quant_min,
+                    quant_max,
                 )
-                .to(torch.uint8)
+                .to(dtype)
                 .contiguous(memory_format=torch.channels_last)
             )
             zero_point = 100
@@ -973,8 +1032,14 @@ class CPUReproTests(TestCase):
             with config.patch({"cpp.simdlen": None}):
                 torch._dynamo.reset()
                 metrics.reset()
-                self.common(fn, (x, scale, zero_point))
+                self.common(fn, (x, scale, zero_point, quant_min, quant_max, dtype))
                 assert metrics.generated_cpp_vec_kernel_count == 1
+
+    @unittest.skipIf(
+        not codecache.valid_vec_isa_list(), "Does not support vectorization"
+    )
+    def test_dequant_maxpool2d_lowering_uint8(self):
+        self._test_dequant_maxpool2d_lowering_helper(torch.uint8)
 
     @unittest.skipIf(
         not codecache.valid_vec_isa_list(), "Does not support vectorization"
@@ -1054,6 +1119,49 @@ class CPUReproTests(TestCase):
                 )
                 assert metrics.generated_cpp_vec_kernel_count == 2
 
+    def _test_per_tensor_fake_quant_helper(self, dtype):
+        def fn(input, scales, zero_points, quant_min, quant_max, dtype):
+            input = torch.ops.quantized_decomposed.quantize_per_tensor(
+                input, scales, zero_points, quant_min, quant_max, dtype
+            )
+            input = torch.ops.quantized_decomposed.dequantize_per_tensor(
+                input, scales, zero_points, quant_min, quant_max, dtype
+            )
+            return input
+
+        use_tensor_overload_list = [False, True]
+        for use_tensor_overload in use_tensor_overload_list:
+            assert dtype in [torch.uint8, torch.int8]
+            quant_min = 0 if dtype == torch.uint8 else -128
+            quant_max = 255 if dtype == torch.uint8 else 127
+            x = torch.clamp(
+                torch.randn((1, 7, 7, 9), dtype=torch.float32) * 100,
+                quant_min,
+                quant_max,
+            )
+            zero_point = 100
+            scale = 0.01
+            if use_tensor_overload:
+                zero_point = torch.tensor(zero_point, dtype=torch.int64)
+                scale = torch.tensor(scale)
+            with config.patch({"cpp.simdlen": None}):
+                torch._dynamo.reset()
+                metrics.reset()
+                self.common(fn, (x, scale, zero_point, quant_min, quant_max, dtype))
+                assert metrics.generated_cpp_vec_kernel_count == 1
+
+    @unittest.skipIf(
+        not codecache.valid_vec_isa_list(), "Does not support vectorization"
+    )
+    def test_per_tensor_fake_quant_uint8(self):
+        self._test_per_tensor_fake_quant_helper(torch.uint8)
+
+    @unittest.skipIf(
+        not codecache.valid_vec_isa_list(), "Does not support vectorization"
+    )
+    def test_per_tensor_fake_quant_int8(self):
+        self._test_per_tensor_fake_quant_helper(torch.int8)
+
     @unittest.skipIf(
         not codecache.valid_vec_isa_list(), "Does not support vectorization"
     )
@@ -1126,32 +1234,45 @@ class CPUReproTests(TestCase):
             self.common(channel_shuffle, (x, 2, output_scale, output_zero_point))
             assert metrics.generated_cpp_vec_kernel_count == 2
 
-    @unittest.skipIf(
-        not codecache.valid_vec_isa_list(), "Does not support vectorization"
-    )
-    @patch("torch.cuda.is_available", lambda: False)
-    def test_dequant_relu_quant_dequant_relu_quant_lowering(self):
-        def fn(x, scale, zero_point, scale2, zero_point2, scale3, zero_point3):
+    def _test_dequant_relu_quant_dequant_relu_quant_lowering_helper(self, dtype):
+        def fn(
+            x,
+            scale,
+            zero_point,
+            scale2,
+            zero_point2,
+            scale3,
+            zero_point3,
+            quant_min,
+            quant_max,
+            dtype,
+        ):
             x = torch.ops.quantized_decomposed.dequantize_per_tensor(
-                x, scale, zero_point, 0, 255, torch.uint8
+                x, scale, zero_point, quant_min, quant_max, dtype
             )
             x = torch.relu(x)
             x = torch.ops.quantized_decomposed.quantize_per_tensor(
-                x, scale2, zero_point2, 0, 255, torch.uint8
+                x, scale2, zero_point2, quant_min, quant_max, dtype
             )
             x = torch.ops.quantized_decomposed.dequantize_per_tensor(
-                x, scale2, zero_point2, 0, 255, torch.uint8
+                x, scale2, zero_point2, quant_min, quant_max, dtype
             )
             x = torch.relu(x)
             x = torch.ops.quantized_decomposed.quantize_per_tensor(
-                x, scale3, zero_point3, 0, 255, torch.uint8
+                x, scale3, zero_point3, quant_min, quant_max, dtype
             )
             return x
 
+        assert dtype in [torch.uint8, torch.int8]
+        quant_min = 0 if dtype == torch.uint8 else -128
+        quant_max = 255 if dtype == torch.uint8 else 127
+
         for use_tensor_overload in [True, False]:
             x = torch.clamp(
-                torch.randn((1, 7, 7, 9), dtype=torch.float32) * 100, 0, 255
-            ).to(torch.uint8)
+                torch.randn((1, 7, 7, 9), dtype=torch.float32) * 100,
+                quant_min,
+                quant_max,
+            ).to(dtype)
             zero_point_list = [100, 101, 102]
             scale_list = [0.01, 0.02, 0.03]
             if use_tensor_overload:
@@ -1167,11 +1288,34 @@ class CPUReproTests(TestCase):
                 metrics.reset()
                 self.common(
                     fn,
-                    (x, scale, zero_point, scale2, zero_point2, scale3, zero_point3),
+                    (
+                        x,
+                        scale,
+                        zero_point,
+                        scale2,
+                        zero_point2,
+                        scale3,
+                        zero_point3,
+                        quant_min,
+                        quant_max,
+                        dtype,
+                    ),
                     rtol=1e-2,
                     atol=1e-2,
                 )
                 assert metrics.generated_cpp_vec_kernel_count == 1
+
+    @unittest.skipIf(
+        not codecache.valid_vec_isa_list(), "Does not support vectorization"
+    )
+    def test_dequant_relu_quant_dequant_relu_quant_lowering_uint8(self):
+        self._test_dequant_relu_quant_dequant_relu_quant_lowering_helper(torch.uint8)
+
+    @unittest.skipIf(
+        not codecache.valid_vec_isa_list(), "Does not support vectorization"
+    )
+    def test_dequant_relu_quant_dequant_relu_quant_lowering_int8(self):
+        self._test_dequant_relu_quant_dequant_relu_quant_lowering_helper(torch.int8)
 
     def test_inplace_add_alpha(self):
         def fn(x, y):

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -1335,8 +1335,8 @@ class OptimizationContext:
     dtype: Optional[torch.dtype] = None
     ops_name: str = ""
 
-    # Load uint8 value as float32
-    is_load_uint8_as_float: bool = False
+    # Load int8 value as float32
+    is_load_int8_as_float: bool = False
 
 
 @functools.lru_cache(None)

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1332,6 +1332,7 @@ class CppVecOverrides(CppOverrides):
             torch.bfloat16,
             torch.float16,
             torch.uint8,
+            torch.int8,
             torch.int32,
         ], f"{__name__} does not support {dtype}"
         node: torch.fx.Node = V.interpreter.current_node
@@ -1351,12 +1352,17 @@ class CppVecOverrides(CppOverrides):
         if opt_ctx_x.dtype == torch.uint8 and dtype in (torch.float, torch.float32):
             # Note: this function only convert inputs number of elements equal to at::vec::Vectorized<float>.size()
             return f"at::vec::convert_uint8_to_float({x})"
+        if opt_ctx_x.dtype == torch.int8 and dtype in (torch.float, torch.float32):
+            # Note: this function only convert inputs number of elements equal to at::vec::Vectorized<float>.size()
+            return f"at::vec::convert_int8_to_float({x})"
         if opt_ctx_x.dtype in (torch.float, torch.float32) and dtype == torch.uint8:
             # TODO(Leslie): Add fast path to at::vec::convert_float_to_uint8,
             # if we already handle the saturation previously.
             # * Pattern match of quantization op in the loop body.
             # * Skip the explicit saturation and clamp inside at::vec::convert_float_to_uint8.
             return f"at::vec::convert_float_to_uint8({x})"
+        if opt_ctx_x.dtype in (torch.float, torch.float32) and dtype == torch.int8:
+            return f"at::vec::convert_float_to_int8({x})"
         # TODO(jgong5): support conversion for other types
         # currently we only allow load/store torch.uint8 and handle conversion there
         return f"({x})"
@@ -1809,11 +1815,11 @@ class CppVecKernel(CppKernel):
         assert opt_ctx is not None
         load_mask_str = f"to_float_mask({load_mask})" if load_mask else None
         loadbuf = f"{var} + {cexpr_index(index)}" if index != 0 else var
-        if dtype == torch.uint8 and opt_ctx.is_load_uint8_as_float:
+        if dtype in [torch.uint8, torch.int8] and opt_ctx.is_load_int8_as_float:
             line = (
                 f"masked_load({loadbuf}, {load_mask_str})"
                 if load_mask_str
-                else f"at::vec::Vectorized<uint8_t>::loadu_one_fourth({loadbuf})"
+                else f"at::vec::Vectorized<{DTYPE_TO_CPP[dtype]}>::loadu_one_fourth({loadbuf})"
             )
         elif opt_ctx.is_load_as_mask:
             line = f"flag_to_float_vec({loadbuf})"
@@ -2389,12 +2395,14 @@ class CppVecKernelChecker(CppVecKernel):
             torch.float16,
             torch.bool,
             torch.uint8,
+            torch.int8,
         ]
         self.store_supported_dtypes: List[torch.dtype] = [
             torch.float,
             torch.bfloat16,
             torch.float16,
             torch.uint8,
+            torch.int8,
         ]
         # Cache the dtypes of the store operation. If the store is mixing dtypes, the
         # vectorization would not support it as it is hard to determine the vec dtype
@@ -2433,15 +2441,15 @@ class CppVecKernelChecker(CppVecKernel):
         else:
             return False
 
-    def is_load_uint8_as_float(self, name: str, users: Dict[torch.fx.Node, None]):
+    def is_load_int8_as_float(self, name: str, users: Dict[torch.fx.Node, None]):
         """
         Check:
-        1. load_type is torch.uint8
+        1. load_type is torch.uint8 or torch.int8
         2. has 1 user node of target to_dtype
         3. dtype of to_dtype is torch.float
         """
         load_type = V.graph.get_dtype(name)
-        if load_type is not torch.uint8:
+        if load_type not in [torch.uint8, torch.int8]:
             return False
         if len(users) == 1:
             user = next(iter(users))
@@ -2450,17 +2458,20 @@ class CppVecKernelChecker(CppVecKernel):
             return False
         return False
 
-    def can_store_fp32_as_uint8(self, store_var: str, value_node: torch.fx.Node):
+    def can_store_fp32_as_int8(self, store_var: str, value_node: torch.fx.Node):
         """
         Check:
-        1. store_type is torch.uint8
+        1. store_type is torch.uint8/torch.int8
         2. value_node is of target to_dtype
-        3. dtype of to_dtype node is torch.uint8
+        3. dtype of to_dtype node is torch.uint8/torch.int8
         """
         store_type = V.graph.get_dtype(store_var)
-        if store_type not in [torch.uint8]:
+        if store_type not in [torch.uint8, torch.int8]:
             return False
-        if value_node.target == "to_dtype" and value_node.args[-1] == torch.uint8:
+        if value_node.target == "to_dtype" and value_node.args[-1] in [
+            torch.uint8,
+            torch.int8,
+        ]:
             return True
 
         return False
@@ -2483,7 +2494,7 @@ class CppVecKernelChecker(CppVecKernel):
             assert opt_ctx
             opt_ctx.dtype = load_dtype
             opt_ctx.is_load_as_mask = self.is_mask(name, node_ctx.get_fx_node().users)
-            opt_ctx.is_load_uint8_as_float = self.is_load_uint8_as_float(
+            opt_ctx.is_load_int8_as_float = self.is_load_int8_as_float(
                 name, node_ctx.get_fx_node().users
             )
 
@@ -2493,12 +2504,12 @@ class CppVecKernelChecker(CppVecKernel):
                 self.disable_vec("not a loop")
                 return var
 
-            if load_dtype in [torch.bool, torch.uint8] and not (
-                opt_ctx.is_load_as_mask or opt_ctx.is_load_uint8_as_float
+            if load_dtype in [torch.bool, torch.uint8, torch.int8] and not (
+                opt_ctx.is_load_as_mask or opt_ctx.is_load_int8_as_float
             ):
                 if not opt_ctx.is_load_as_mask:
                     self.disable_vec(f"{load_dtype} not loaded as mask")
-                elif not opt_ctx.is_load_uint8_as_float:
+                elif not opt_ctx.is_load_int8_as_float:
                     self.disable_vec(f"{load_dtype} not loaded as float")
                 return var
 
@@ -2530,10 +2541,10 @@ class CppVecKernelChecker(CppVecKernel):
                 self.disable_vec(f"{store_dtype} not supported by store")
                 return self.simd_vec
 
-            if store_dtype in [torch.uint8]:
+            if store_dtype in [torch.uint8, torch.int8]:
                 value_node = node_ctx.get_fx_node().all_input_nodes[-1]
-                if not self.can_store_fp32_as_uint8(name, value_node):
-                    self.disable_vec("not support store float32 as uint8")
+                if not self.can_store_fp32_as_int8(name, value_node):
+                    self.disable_vec("not support store float32 as uint8/int8")
                     return self.simd_vec
 
             assert "buf" in name
@@ -2784,6 +2795,7 @@ class CppVecKernelChecker(CppVecKernel):
                                 torch.bfloat16,
                                 torch.float,
                                 torch.uint8,
+                                torch.int8,
                             ]:
                                 # Convert from dtype to torch.float
                                 pass
@@ -2818,23 +2830,23 @@ class CppVecKernelChecker(CppVecKernel):
                             return x
                     elif dtype == torch.bool:
                         pass
-                    elif dtype == torch.uint8:
+                    elif dtype in [torch.uint8, torch.int8]:
                         # Only allow below 2 cases:
-                        # Case 1: to_uint8 and store which corresponding to the single quant node
+                        # Case 1: to_int8 and store which corresponding to the single quant node
                         # at last of fusion pattern.
-                        is_to_uint8_and_store = all(
+                        is_to_int8_and_store = all(
                             usr.target in ["store"] for usr in cur_node.users
                         )
-                        # Case 2: to_uint8 and to_float which corresponding to pair of quant/dequant node
+                        # Case 2: to_int8 and to_float which corresponding to pair of quant/dequant node
                         # at middle of fusion pattern.
-                        is_to_uint8_and_to_float = all(
+                        is_to_int8_and_to_float = all(
                             (
                                 usr.target in ["to_dtype"]
                                 and usr.args[2] == torch.float32
                             )
                             for usr in cur_node.users
                         )
-                        if not (is_to_uint8_and_store or is_to_uint8_and_to_float):
+                        if not (is_to_int8_and_store or is_to_int8_and_to_float):
                             self.disable_vec(f"to_dtype: dtype {dtype}")
                     else:
                         self.disable_vec(f"to_dtype: dtype {dtype}")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #119177
* #119176
* #119175
* __->__ #119174

**Summary**
In current implementation, the vectorized code generation only support `uint8` data type. Plan to add the `int8` data type with vectorized code generation. In this PR, we support: `vectorized load`, `vectorized store`, `vectorized float_to_int8`, `vectorized int8_to_float`. 


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler