### PR TITLE
[Inductor] Add Int8 data type masked load into Inductor CPP backend vectorized code generation

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1044,6 +1044,12 @@ class CPUReproTests(TestCase):
     @unittest.skipIf(
         not codecache.valid_vec_isa_list(), "Does not support vectorization"
     )
+    def test_dequant_maxpool2d_lowering_int8(self):
+        self._test_dequant_maxpool2d_lowering_helper(torch.int8)
+
+    @unittest.skipIf(
+        not codecache.valid_vec_isa_list(), "Does not support vectorization"
+    )
     @patch("torch.cuda.is_available", lambda: False)
     def test_tile2d_load_decomposed_dequant_add_relu_quant(self):
         def fn(

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -2419,9 +2419,9 @@ class CppVecKernelChecker(CppVecKernel):
         load_type = V.graph.get_dtype(name)
         if load_type == torch.bool:
             return all(user.target in ("where", "masked") for user in users.keys())
-        elif load_type == torch.uint8:
+        elif load_type in [torch.uint8, torch.int8]:
             """
-            If the load value is torch.uint8, then we only support the loaded
+            If the load value is torch.int8/uint8, then we only support the loaded
             value is as the mask.
             """
             if not all(

--- a/torch/_inductor/codegen/cpp_prefix.h
+++ b/torch/_inductor/codegen/cpp_prefix.h
@@ -331,7 +331,9 @@ inline masked_load(const T* src, at::vec::Vectorized<float> mask) {
 # endif
 }
 
-inline at::vec::Vectorized<uint8_t> masked_load(const uint8_t* src, at::vec::Vectorized<float> mask) {
+template <typename T>
+typename std::enable_if<std::is_same<T, uint8_t>::value || std::is_same<T, int8_t>::value, at::vec::Vectorized<T>>::type
+inline masked_load(const T* src, at::vec::Vectorized<float> mask) {
 # if defined(CPU_CAPABILITY_AVX512)
     auto all_ones = _mm512_set1_epi32(0xFFFFFFFF);
     auto mmask = _mm512_cmp_epi32_mask(_mm512_castps_si512(mask), all_ones, _MM_CMPINT_EQ);
@@ -343,20 +345,20 @@ inline at::vec::Vectorized<uint8_t> masked_load(const uint8_t* src, at::vec::Vec
     auto mmask_vec = _mm256_cmpeq_epi32(_mm256_castps_si256(mask), all_ones);
     __at_align__ uint32_t mmask[8];
     _mm256_storeu_si256(reinterpret_cast<__m256i*>(mmask), mmask_vec);
-    __at_align__ uint8_t result[32];
+    __at_align__ T result[32];
     for (auto i = 0; i < 8; i++) {
-      result[i] = mmask[i] == 0xFFFFFFFF ? src[i]: uint8_t(0);
+      result[i] = mmask[i] == 0xFFFFFFFF ? src[i]: T(0);
     }
-    return at::vec::Vectorized<uint8_t>::loadu(result);
+    return at::vec::Vectorized<T>::loadu(result);
 # elif defined(CPU_CAPABILITY_ZVECTOR)
-    auto result = at::vec::Vectorized<uint8_t>::loadu(src, 8);
+    auto result = at::vec::Vectorized<T>::loadu(src, 8);
     uint32_t maskdata[8];
-    uint8_t maskdata_dest[32] = { 0 };
+    T maskdata_dest[32] = { 0 };
     mask.store(maskdata);
     for (auto i = 0; i < 8; i++) {
       maskdata_dest[i] = (maskdata[i] == 0xFFFFFFFF) ? 0xFF: 0;
     }
-    auto maskvector = at::vec::Vectorized<uint8_t>::loadu(maskdata_dest);
+    auto maskvector = at::vec::Vectorized<T>::loadu(maskdata_dest);
     return (result & maskvector);
 # else
 # error Unsupported vectorization CPU capability


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #119177
* #119176
* __->__ #119175
* #119174

**Summary**
Further add the int8 vectorized mask load support.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler