### PR TITLE
[Inductor] Add Int8 data type Tile2D load into Inductor CPP backend vectorized code generation

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1047,11 +1047,7 @@ class CPUReproTests(TestCase):
     def test_dequant_maxpool2d_lowering_int8(self):
         self._test_dequant_maxpool2d_lowering_helper(torch.int8)
 
-    @unittest.skipIf(
-        not codecache.valid_vec_isa_list(), "Does not support vectorization"
-    )
-    @patch("torch.cuda.is_available", lambda: False)
-    def test_tile2d_load_decomposed_dequant_add_relu_quant(self):
+    def _test_tile2d_load_decomposed_dequant_add_relu_quant_helper(self, dtype):
         def fn(
             x,
             scale,
@@ -1064,40 +1060,52 @@ class CPUReproTests(TestCase):
             use_dequant,
             use_dequant2,
             use_quant,
+            quant_min,
+            quant_max,
+            dtype,
         ):
             if use_dequant:
                 x = torch.ops.quantized_decomposed.dequantize_per_tensor(
-                    x, scale, zero_point, 0, 255, torch.uint8
+                    x, scale, zero_point, quant_min, quant_max, dtype
                 )
             if use_dequant2:
                 x2 = torch.ops.quantized_decomposed.dequantize_per_tensor(
-                    x2, scale2, zero_point2, 0, 255, torch.uint8
+                    x2, scale2, zero_point2, quant_min, quant_max, dtype
                 )
             temp = x + x2
             y = torch.relu(temp)
 
             if use_quant:
                 y = torch.ops.quantized_decomposed.quantize_per_tensor(
-                    y, output_scale, output_zero_point, 0, 255, torch.uint8
+                    y, output_scale, output_zero_point, quant_min, quant_max, dtype
                 )
             return y.contiguous()
+
+        assert dtype in [torch.uint8, torch.int8]
+        quant_min = 0 if dtype == torch.uint8 else -128
+        quant_max = 255 if dtype == torch.uint8 else 127
 
         use_dequant_list = [False, True]
         use_dequant_list2 = [False, True]
         use_quant_list = [False, True]
+
         for use_dequant, use_dequant2, use_quant in itertools.product(
             use_dequant_list, use_dequant_list2, use_quant_list
         ):
             x = torch.clamp(
-                torch.randn((1, 1024, 14, 14), dtype=torch.float32) * 100, 0, 255
+                torch.randn((1, 1024, 14, 14), dtype=torch.float32) * 100,
+                quant_min,
+                quant_max,
             ).contiguous(memory_format=torch.channels_last)
             x2 = torch.clamp(
-                torch.randn((1, 1024, 14, 14), dtype=torch.float32) * 100, 0, 255
+                torch.randn((1, 1024, 14, 14), dtype=torch.float32) * 100,
+                quant_min,
+                quant_max,
             ).contiguous(memory_format=torch.channels_last)
             if use_dequant:
-                x = x.to(torch.uint8).contiguous(memory_format=torch.channels_last)
+                x = x.to(dtype).contiguous(memory_format=torch.channels_last)
             if use_dequant2:
-                x2 = x2.to(torch.uint8).contiguous(memory_format=torch.channels_last)
+                x2 = x2.to(dtype).contiguous(memory_format=torch.channels_last)
             zero_point = 1
             scale = 0.01
             zero_point2 = 2
@@ -1121,10 +1129,28 @@ class CPUReproTests(TestCase):
                         use_dequant,
                         use_dequant2,
                         use_quant,
+                        quant_min,
+                        quant_max,
+                        dtype,
                     ),
                 )
                 assert metrics.generated_cpp_vec_kernel_count == 2
 
+    @unittest.skipIf(
+        not codecache.valid_vec_isa_list(), "Does not support vectorization"
+    )
+    def test_tile2d_load_decomposed_dequant_add_relu_quant_uint8(self):
+        self._test_tile2d_load_decomposed_dequant_add_relu_quant_helper(torch.uint8)
+
+    @unittest.skipIf(
+        not codecache.valid_vec_isa_list(), "Does not support vectorization"
+    )
+    def test_tile2d_load_decomposed_dequant_add_relu_quant_int8(self):
+        self._test_tile2d_load_decomposed_dequant_add_relu_quant_helper(torch.int8)
+
+    @unittest.skipIf(
+        not codecache.valid_vec_isa_list(), "Does not support vectorization"
+    )
     def _test_per_tensor_fake_quant_helper(self, dtype):
         def fn(input, scales, zero_points, quant_min, quant_max, dtype):
             input = torch.ops.quantized_decomposed.quantize_per_tensor(
@@ -1168,37 +1194,40 @@ class CPUReproTests(TestCase):
     def test_per_tensor_fake_quant_int8(self):
         self._test_per_tensor_fake_quant_helper(torch.int8)
 
-    @unittest.skipIf(
-        not codecache.valid_vec_isa_list(), "Does not support vectorization"
-    )
-    @patch("torch.cuda.is_available", lambda: False)
-    def test_non_contiguous_load_buf_quant(self):
+    def _test_non_contiguous_load_buf_quant_helper(self, dtype):
         def fn(
             x1,
             x2,
             groups,
+            quant_min,
+            quant_max,
+            dtype,
         ):
             x = torch.cat((x1, x2), dim=1)
             batchsize, num_channels, height, width = x.size()
             channels_per_group = num_channels // groups
             x = torch.ops.quantized_decomposed.dequantize_per_tensor(
-                x, 1.0, 0, 0, 255, torch.uint8
+                x, 1.0, 0, quant_min, quant_max, dtype
             )
             x = x.view(batchsize, groups, channels_per_group, height, width)
             x = torch.ops.quantized_decomposed.quantize_per_tensor(
-                x, 1.0, 0, 0, 255, torch.uint8
+                x, 1.0, 0, quant_min, quant_max, dtype
             )
             x = torch.ops.quantized_decomposed.dequantize_per_tensor(
-                x, 1.0, 0, 0, 255, torch.uint8
+                x, 1.0, 0, quant_min, quant_max, dtype
             )
             x = torch.transpose(x, 1, 2).contiguous()
             x = x.view(batchsize, num_channels, height, width)
             return x
 
-        x = torch.randint(0, 8, (1, 116, 28, 28), dtype=torch.uint8).contiguous(
+        assert dtype in [torch.uint8, torch.int8]
+        quant_min = 0 if dtype == torch.uint8 else -128
+        quant_max = 255 if dtype == torch.uint8 else 127
+
+        x = torch.randint(0, 8, (1, 116, 28, 28), dtype=dtype).contiguous(
             memory_format=torch.channels_last
         )
-        x2 = torch.randint(0, 8, (1, 116, 28, 28), dtype=torch.uint8).contiguous(
+        x2 = torch.randint(0, 8, (1, 116, 28, 28), dtype=dtype).contiguous(
             memory_format=torch.channels_last
         )
 
@@ -1211,6 +1240,9 @@ class CPUReproTests(TestCase):
                     x,
                     x2,
                     2,
+                    quant_min,
+                    quant_max,
+                    dtype,
                 ),
             )
             assert metrics.generated_cpp_vec_kernel_count == 2
@@ -1218,18 +1250,32 @@ class CPUReproTests(TestCase):
     @unittest.skipIf(
         not codecache.valid_vec_isa_list(), "Does not support vectorization"
     )
-    @patch("torch.cuda.is_available", lambda: False)
-    def test_tile2d_store_channel_shuffle_cl_quant_output(self):
-        def channel_shuffle(x, groups, output_scale, output_zero_point):
+    def test_non_contiguous_load_buf_quant_uint8(self):
+        self._test_non_contiguous_load_buf_quant_helper(torch.uint8)
+
+    @unittest.skipIf(
+        not codecache.valid_vec_isa_list(), "Does not support vectorization"
+    )
+    def test_non_contiguous_load_buf_quant_int8(self):
+        self._test_non_contiguous_load_buf_quant_helper(torch.int8)
+
+    def _test_tile2d_store_channel_shuffle_cl_quant_output_helper(self, dtype):
+        def channel_shuffle(
+            x, groups, output_scale, output_zero_point, quant_min, quant_max, dtype
+        ):
             batchsize, num_channels, height, width = x.size()
             channels_per_group = num_channels // groups
             x = x.view(batchsize, groups, channels_per_group, height, width)
             x = torch.transpose(x, 1, 2).contiguous()
             x = x.view(batchsize, -1, height, width)
             x = torch.ops.quantized_decomposed.quantize_per_tensor(
-                x, output_scale, output_zero_point, 0, 255, torch.uint8
+                x, output_scale, output_zero_point, quant_min, quant_max, dtype
             )
             return x.contiguous(memory_format=torch.channels_last)
+
+        assert dtype in [torch.uint8, torch.int8]
+        quant_min = 0 if dtype == torch.uint8 else -128
+        quant_max = 255 if dtype == torch.uint8 else 127
 
         with config.patch({"cpp.simdlen": None}):
             torch._dynamo.reset()
@@ -1237,8 +1283,23 @@ class CPUReproTests(TestCase):
             x = torch.randn(64, 58, 28, 28)
             output_zero_point = 3
             output_scale = 0.03
-            self.common(channel_shuffle, (x, 2, output_scale, output_zero_point))
+            self.common(
+                channel_shuffle,
+                (x, 2, output_scale, output_zero_point, quant_min, quant_max, dtype),
+            )
             assert metrics.generated_cpp_vec_kernel_count == 2
+
+    @unittest.skipIf(
+        not codecache.valid_vec_isa_list(), "Does not support vectorization"
+    )
+    def test_tile2d_store_channel_shuffle_cl_quant_output_uint8(self):
+        self._test_tile2d_store_channel_shuffle_cl_quant_output_helper(torch.uint8)
+
+    @unittest.skipIf(
+        not codecache.valid_vec_isa_list(), "Does not support vectorization"
+    )
+    def test_tile2d_store_channel_shuffle_cl_quant_output_int8(self):
+        self._test_tile2d_store_channel_shuffle_cl_quant_output_helper(torch.int8)
 
     def _test_dequant_relu_quant_dequant_relu_quant_lowering_helper(self, dtype):
         def fn(

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -2334,7 +2334,7 @@ class CppTile2DKernel(CppVecKernel):
             storebuf = f"{tile_var} + {cexpr_index(inner * self.tiling_factor)}"
             if V.graph.get_dtype(name) in DTYPE_LOWP_FP:
                 line = f"{value}.store({storebuf}, {self.tiling_factor});"
-            elif V.graph.get_dtype(name) in [torch.uint8]:
+            elif V.graph.get_dtype(name) in [torch.uint8, torch.int8]:
                 line = f"{value}.store({storebuf}, {self.tiling_factor});"
             else:
                 line = f"{value}.store({storebuf});"

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1066,7 +1066,7 @@ def pointwise_cat(inputs, dim=0):
 
 @register_lowering(aten.cat)
 def cat(inputs, dim=0):
-    if all(input.get_dtype() is torch.uint8 for input in inputs):
+    if all(input.get_dtype() in [torch.int8, torch.uint8] for input in inputs):
         # TODO <leslie> Remove this fallback when we support vectorization
         # code gen with uint8 data type directly.
         for input in inputs:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #119177
* __->__ #119176
* #119175
* #119174

**Summary**
Further add the int8 vectorized Tile2D load/store.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler