### PR TITLE
[dynamo] support dict.clear()

### DIFF
--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -244,7 +244,7 @@ class ConstDictVariable(VariableTracker):
         elif name == "clear":
             tx.output.side_effects.mutation(self)
             self.items.clear()
-            return ConstantVariable(None)
+            return ConstantVariable.create(None)
         elif (
             name == "update"
             and len(args) == 1

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -242,11 +242,9 @@ class ConstDictVariable(VariableTracker):
             tx.output.side_effects.mutation(self)
             return self.items.pop(Hashable(args[0]))
         elif name == "clear":
-            assert len(args) == 0
-            assert len(kwargs) == 0
-            keys_vt = [key.vt for key in self.items]
-            for key_vt in keys_vt:
-                self.call_method(tx, "pop", [key_vt], {})
+            tx.output.side_effects.mutation(self)
+            self.items.clear()
+            return ConstantVariable(None)
         elif (
             name == "update"
             and len(args) == 1

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -241,7 +241,7 @@ class ConstDictVariable(VariableTracker):
         elif name == "pop" and arg_hashable and self.mutable_local:
             tx.output.side_effects.mutation(self)
             return self.items.pop(Hashable(args[0]))
-        elif name == "clear" and arg_hashable and self.mutable_local:
+        elif name == "clear":
             assert len(args) == 0
             assert len(kwargs) == 0
             keys_vt = [key.vt for key in self.items]

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -241,6 +241,11 @@ class ConstDictVariable(VariableTracker):
         elif name == "pop" and arg_hashable and self.mutable_local:
             tx.output.side_effects.mutation(self)
             return self.items.pop(Hashable(args[0]))
+        elif name == "clear" and self.mutable_local:
+            assert len(args) == 0 and len(kwargs) == 0
+            keys_vt = [key.vt for key in self.items]
+            for key_vt in keys_vt:
+                self.call_method(tx, "pop", [key_vt], {})
         elif (
             name == "update"
             and len(args) == 1

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -241,8 +241,9 @@ class ConstDictVariable(VariableTracker):
         elif name == "pop" and arg_hashable and self.mutable_local:
             tx.output.side_effects.mutation(self)
             return self.items.pop(Hashable(args[0]))
-        elif name == "clear" and self.mutable_local:
-            assert len(args) == 0 and len(kwargs) == 0
+        elif name == "clear" and arg_hashable and self.mutable_local:
+            assert len(args) == 0
+            assert len(kwargs) == 0
             keys_vt = [key.vt for key in self.items]
             for key_vt in keys_vt:
                 self.call_method(tx, "pop", [key_vt], {})


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #119197

For code like following:
```python
import torch
def f():
    a = {"a": torch.randn(2, 2)}
    a.clear()
    return a
torch.compile(f, backend="eager", fullgraph=True)()
```

We have a graph break before the pr:
```
torch._dynamo.exc.Unsupported: call_method ConstDictVariable() clear [] {}
```

Test Plan:
Added new tests


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng