### PR TITLE
[MPS] Add SDPA implentation

### DIFF
--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -1,3 +1,4 @@
+#include "fmt/core.h"
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <iostream>
 #include <optional>
@@ -17,13 +18,17 @@
 #endif
 
 namespace at::native {
-int64_t _fused_sdp_choice_mps(const Tensor& query_,
+int64_t _fused_sdp_choice_mps(const Tensor& query,
                               const Tensor& key,
                               const Tensor& value,
-                              const std::optional<Tensor>& attn_mask_,
+                              const std::optional<Tensor>& attn_mask,
                               double dropout_p,
                               bool is_causal,
                               std::optional<double> scale) {
+  if (attn_mask.has_value() || dropout_p != 0.0 || query.is_contiguous() || !key.is_contiguous() ||
+      !value.is_contiguous()) {
+    return static_cast<int64_t>(sdp::SDPBackend::math);
+  }
   return static_cast<int64_t>(sdp::SDPBackend::flash_attention);
 }
 

--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -1,0 +1,90 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <iostream>
+#include <optional>
+
+#include <ATen/core/Tensor.h>
+#include <ATen/native/mps/OperationUtils.h>
+#include <ATen/native/transformers/attention.h>
+#include <ATen/native/transformers/sdp_utils_cpp.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/_fused_sdp_choice_native.h>
+#include <ATen/ops/_scaled_dot_product_flash_attention_for_cpu_native.h>
+#include <ATen/ops/empty_native.h>
+#endif
+
+namespace at::native {
+int64_t _fused_sdp_choice_mps(const Tensor& query_,
+                              const Tensor& key,
+                              const Tensor& value,
+                              const std::optional<Tensor>& attn_mask_,
+                              double dropout_p,
+                              bool is_causal,
+                              std::optional<double> scale) {
+  return static_cast<int64_t>(sdp::SDPBackend::flash_attention);
+}
+
+std::tuple<Tensor, Tensor> _scaled_dot_product_flash_attention_mps(const Tensor& query,
+                                                                   const Tensor& key,
+                                                                   const Tensor& value,
+                                                                   double dropout_p,
+                                                                   bool is_causal,
+                                                                   const std::optional<Tensor>& attn_mask,
+                                                                   std::optional<double> scale) {
+  using namespace mps;
+  struct CachedGraph : public MPSCachedGraph {
+    CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
+    MPSGraphTensor* qTensor = nil;
+    MPSGraphTensor* kTensor = nil;
+    MPSGraphTensor* vTensor = nil;
+    MPSGraphTensor* outputTensor = nil;
+  };
+  int64_t batchSize = query.size(0);
+  int64_t qSize = query.size(2);
+  int64_t num_head = query.size(1);
+  int64_t headSize = query.size(3);
+  auto out = at::empty({batchSize, num_head, qSize, headSize}, query.options());
+  auto scale_factor = sdp::calculate_scale(query, scale).as_float_unchecked();
+  @autoreleasepool {
+    auto mkey = __func__ + getTensorsStringKey({query, key, value}) + ":" + std::to_string(is_causal);
+    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(mkey, [&](auto mpsGraph, auto graph) {
+      auto qTensor = mpsGraphRankedPlaceHolder(mpsGraph, query);
+      auto kTensor = mpsGraphRankedPlaceHolder(mpsGraph, key);
+      auto vTensor = mpsGraphRankedPlaceHolder(mpsGraph, value);
+      auto kT = [mpsGraph transposeTensor:kTensor dimension:2 withDimension:3 name:nil];
+      auto qkMM = [mpsGraph matrixMultiplicationWithPrimaryTensor:qTensor secondaryTensor:kT name:nil];
+      auto scaleTensor = [mpsGraph constantWithScalar:scale_factor shape:getMPSShape({1}) dataType:qkMM.dataType];
+      auto maskedMM = [mpsGraph multiplicationWithPrimaryTensor:qkMM secondaryTensor:scaleTensor name:nil];
+      if (is_causal) {
+        auto causalMask = [mpsGraph constantWithScalar:1.0f shape:getMPSShape({qSize, qSize}) dataType:MPSDataTypeBool];
+        causalMask = [mpsGraph bandPartWithTensor:causalMask numLower:-1 numUpper:0 name:nil];
+        // auto minusInf = [mpsGraph constantWithScalar:std::numeric_limits<double>::infinity() shape:maskedMM.shape
+        // dataType:maskedMM.dataType];
+        auto minusInf = [mpsGraph constantWithScalar:-1e20 shape:maskedMM.shape dataType:maskedMM.dataType];
+        maskedMM = [mpsGraph selectWithPredicateTensor:causalMask
+                                   truePredicateTensor:maskedMM
+                                  falsePredicateTensor:minusInf
+                                                  name:nil];
+      }
+      auto sm = [mpsGraph softMaxWithTensor:maskedMM axis:3 name:nil];
+      auto output = [mpsGraph matrixMultiplicationWithPrimaryTensor:sm secondaryTensor:vTensor name:nil];
+      graph->qTensor = qTensor;
+      graph->kTensor = kTensor;
+      graph->vTensor = vTensor;
+      graph->outputTensor = output;
+    });
+    auto qPlaceholder = Placeholder(cachedGraph->qTensor, query);
+    auto kPlaceholder = Placeholder(cachedGraph->kTensor, key);
+    auto vPlaceholder = Placeholder(cachedGraph->vTensor, value);
+    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor, out);
+    auto feeds = dictionaryFromPlaceholders(qPlaceholder, kPlaceholder, vPlaceholder);
+    runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, outputPlaceholder);
+  }
+  return {out, Tensor()};
+}
+
+REGISTER_MPS_DISPATCH(_fused_sdp_choice_stub, &_fused_sdp_choice_mps);
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -25,7 +25,7 @@ int64_t _fused_sdp_choice_mps(const Tensor& query,
                               double dropout_p,
                               bool is_causal,
                               std::optional<double> scale) {
-  if (attn_mask.has_value() || dropout_p != 0.0 || query.is_contiguous() || !key.is_contiguous() ||
+  if (attn_mask.has_value() || dropout_p != 0.0 || !query.is_contiguous() || !key.is_contiguous() ||
       !value.is_contiguous()) {
     return static_cast<int64_t>(sdp::SDPBackend::math);
   }

--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -1,4 +1,3 @@
-#include "fmt/core.h"
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <iostream>
 #include <optional>

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -14666,6 +14666,7 @@
 - func: _fused_sdp_choice(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool is_causal=False, *, float? scale=None) -> int
   dispatch:
     Meta: _fused_sdp_choice_meta
+    MPS: _fused_sdp_choice_mps
     CPU, NestedTensorCPU: _fused_sdp_choice_cpp
     CUDA, NestedTensorCUDA: _fused_sdp_choice_cuda
   tags: nondeterministic_seeded
@@ -14683,6 +14684,7 @@
 - func: _scaled_dot_product_flash_attention_for_cpu(Tensor query, Tensor key, Tensor value, float dropout_p=0.0, bool is_causal=False, *, Tensor? attn_mask=None, float? scale=None) -> (Tensor output, Tensor logsumexp)
   dispatch:
     CPU: _scaled_dot_product_flash_attention_cpu
+    MPS: _scaled_dot_product_flash_attention_mps
   tags: nondeterministic_seeded
 
 - func: _scaled_dot_product_flash_attention_backward(Tensor grad_out, Tensor query, Tensor key, Tensor value, Tensor out, Tensor logsumexp, Tensor cum_seq_q, Tensor cum_seq_k, SymInt max_q, SymInt max_k, float dropout_p, bool is_causal, Tensor philox_seed, Tensor philox_offset, *, float? scale=None) -> (Tensor grad_query, Tensor grad_key, Tensor grad_value)

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -65,9 +65,7 @@
 #endif
 
 #include <ATen/native/nested/NestedTensorTransformerFunctions.h>
-namespace at {
-
-namespace native {
+namespace at::native {
 
 DEFINE_DISPATCH(_fused_sdp_choice_stub);
 
@@ -649,11 +647,13 @@ Tensor scaled_dot_product_attention(
     std::optional<double> scale) {
   validate_sdpa_input(query_, key, value, attn_mask_, dropout_p, is_causal, scale);
   int64_t choice_int = static_cast<int64_t>(sdp::SDPBackend::math);
-  if (query_.device().type() == DeviceType::CUDA
-      || query_.device().type() == DeviceType::CPU
-      || query_.device().type() == DeviceType::HIP
-      || query_.device().type() == DeviceType::PrivateUse1){
-    if (query_.device().type() == DeviceType::PrivateUse1){
+  const auto device_type = query_.device().type();
+  if (device_type == DeviceType::CUDA
+      || device_type == DeviceType::CPU
+      || device_type == DeviceType::MPS
+      || device_type == DeviceType::HIP
+      || device_type == DeviceType::PrivateUse1) {
+    if (device_type == DeviceType::PrivateUse1) {
       choice_int = handle_private_use(
           query_, key, value, attn_mask_, dropout_p, is_causal, scale);
     } else {
@@ -952,5 +952,5 @@ Tensor triton_multi_head_attention(
 #endif
   return proj;
 }
-} // namespace native
-} // namespace at
+
+} // namespace at::native

--- a/aten/src/ATen/native/transformers/transformer.cpp
+++ b/aten/src/ATen/native/transformers/transformer.cpp
@@ -18,9 +18,7 @@
 #include <ATen/ops/layer_norm.h>
 #endif
 
-namespace at {
-
-namespace native {
+namespace at::native {
 
 namespace {
 Tensor linear_for_ffn(
@@ -147,5 +145,4 @@ Tensor transformer_encoder_layer_forward(
   return x;
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native


### PR DESCRIPTION
Still a very naive implementation, but already 2X faster than naive math one. Fallback to math if dropout is non_null or any of the tensors are non contiguous.

Using https://github.com/malfet/llm_experiments/blob/d14f048f44c9cbef0ce3bc3f58ad583e4ba163fb/tinystories-llm.py I'm getting 10 tokens/sec on my M2 Pro vs 3.5 tokens/sec using Math implementation

Tested by `TransformerDecoderLayer` module_db op in `test_modules.py`

Still end-to-end experience on MPS is 8x slower than on CPU