### PR TITLE
[Torchelastic][Bug] Return status when trapping graceful exit exception

### DIFF
--- a/test/distributed/elastic/agent/server/test/api_test.py
+++ b/test/distributed/elastic/agent/server/test/api_test.py
@@ -590,7 +590,8 @@ class SimpleElasticAgentTest(unittest.TestCase):
         agent = TestAgent(spec)
         invoke_run.side_effect = RendezvousGracefulExitError()
         with patch.object(agent, "_shutdown"):
-            agent.run()
+            result = agent.run()
+            self.assertFalse(result.is_failed(), "run shouldn't be a failure on RendezvousGracefulExitError")
 
 
 if __name__ == "__main__":

--- a/torch/distributed/elastic/agent/server/api.py
+++ b/torch/distributed/elastic/agent/server/api.py
@@ -737,6 +737,7 @@ class SimpleElasticAgent(ElasticAgent):
             return result
         except RendezvousGracefulExitError as e:
             log.info("Rendezvous gracefully exited: %s", e)
+            return RunResult(state=WorkerState.SUCCEEDED)
         except SignalException as e:
             log.warning("Received %s death signal, shutting down workers", e.sigval)
             self._shutdown(e.sigval)


### PR DESCRIPTION
Summary:
https://github.com/pytorch/pytorch/pull/117066 Introduced concept of redundancy and when the rendezvous closes, redundant nodes will use "graceful" exception to terminate pending rendezvous.
For those cases we need return result that is used to check the status:
https://github.com/pytorch/pytorch/blob/main/torch/distributed/launcher/api.py#L266

Test Plan: unit test

Differential Revision: D53371727




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @rohan-varma