### PR TITLE
[PyTorch] Back scalar value to pinned memory for .item()

### DIFF
--- a/aten/src/ATen/native/cuda/CUDAScalar.cu
+++ b/aten/src/ATen/native/cuda/CUDAScalar.cu
@@ -1,6 +1,7 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/core/Tensor.h>
 #include <ATen/Dispatch_v2.h>
+#include <ATen/EmptyTensor.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/NativeFunctions.h>
@@ -16,10 +17,19 @@ Scalar _local_scalar_dense_cuda(const Tensor& self) {
   Scalar r;
   AT_DISPATCH_V2(
     self.scalar_type(), "_local_scalar_dense_cuda", AT_WRAP([&] {
-        scalar_t value;
+        // Create pinned memory for the scalar value to avoid implicit
+        // locking/sync in cuda library due to pageable memory
+        auto value = at::detail::empty_cpu(
+          {1}, /* size */
+          c10::CppTypeToScalarType<scalar_t>(), /* dtype */
+          c10::nullopt, /* layout */
+          c10::nullopt, /* device */
+          true, /* pin_memory */
+          c10::nullopt /* memory format */
+        );
         cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-        at::cuda::memcpy_and_sync(&value, self.const_data_ptr<scalar_t>(), sizeof(scalar_t), cudaMemcpyDeviceToHost, stream);
-        r = Scalar(value);
+        at::cuda::memcpy_and_sync((void *)value.const_data_ptr<scalar_t>(), self.const_data_ptr<scalar_t>(), sizeof(scalar_t), cudaMemcpyDeviceToHost, stream);
+        r = Scalar(*value.const_data_ptr<scalar_t>());
       }), AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX), kComplexHalf, kHalf, kBool, kBFloat16, AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES));
   return r;
 }


### PR DESCRIPTION
Summary: This diff optimizes the .item() call by backing the scalar value storage with pinned memory, so we dont create an implicit synchronization with libcuda library.

Test Plan:
# Prod VDD model on H100
Vanguard runs
9.8k qps -> 10.1k qps (~3% improvement)

# .item() Benchmark
1 thread 50k iterations

consistent ~2-3% improvements

With pinned memory
item() took 1.627608060836792 seconds
item() took 1.635591983795166 seconds
item() took 1.6398141384124756 seconds
item() took 1.6378591060638428 seconds
item() took 1.618534803390503 seconds
item() took 1.6467158794403076 seconds
item() took 1.6278800964355469 seconds
item() took 1.6205573081970215 seconds
item() took 1.64951753616333 seconds
item() took 1.6286702156066895 seconds

w/o pinned memory
item() took 1.6783554553985596 seconds
item() took 1.6670520305633545 seconds
item() took 1.6748230457305908 seconds
item() took 1.6708712577819824 seconds
item() took 1.6836023330688477 seconds
item() took 1.6518056392669678 seconds
item() took 1.6769678592681885 seconds
item() took 1.661888837814331 seconds
item() took 1.6627326011657715 seconds
item() took 1.6908581256866455 seconds

Differential Revision: D53431148


