### PR TITLE
Increase recommended logging in DEFAULT_LOGGING

### DIFF
--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -154,14 +154,14 @@ log_state = LogState()
 
 # sample usage: torch._logging.set_logs(**torch._logging.DEFAULT_LOGGING)
 DEFAULT_LOGGING = {
-    "dynamo": logging.INFO,
-    "graph_code": True,
-    "aot": logging.INFO,
+    "dynamo": logging.DEBUG,
+    "aot": logging.DEBUG,
+    "inductor": logging.DEBUG,
+    "ddp_graphs": True,
     "graph_breaks": True,
+    "guards": True,
     "recompiles": True,
     "dynamic": logging.INFO,
-    "guards": True,
-    "trace_source": True,
 }
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #119207

For long running batch jobs, it is best to opt for logs that are too
spammy rather than not spammy enough.  This lines up DEFAULT_LOGGING
with our current internal guidance at Meta.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>