### PR TITLE
Fix wrong mobile build Docker image

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -233,7 +233,7 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: linux-jammy-py3-clang12-mobile-build
-      docker-image-name: pytorch-linux-jammy-py3-clang12-asan
+      docker-image-name: pytorch-linux-jammy-py3-clang15-asan
       build-generates-artifacts: false
       test-matrix: |
         { include: [


### PR DESCRIPTION
It turns out that the Docker image name hasn't been updated yet referring to a non-existing name, may be we could update `calculate-docker-image` to fail in this case if there is a way to separate a non-existing name failure v.s. missing tag failure.