### PR TITLE
[easy] Fix test_triton_kernel_reinterpret_view_mem_leak by cloning fwd input

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1656,6 +1656,7 @@ class AOTInductorTestsTemplate:
                 super().__init__()
 
             def forward(self, x, y):
+                x = x.clone()  # Avoid flagging forward input as mutated.
                 out = torch.zeros_like(x)
                 yy = y * y
                 # reshape creates a ReinterpretView


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #119219

```

$ python test/inductor/test_aot_inductor.py -k test_triton_kernel_reinterpret_view_mem_leak

# Before
RuntimeError: 
Found following user inputs located at [0] are mutated. This is currently banned in the aot_export workflow.
If you need this functionality, please file a github issue.

fw_metadata=ViewAndMutationMeta(input_info=[InputAliasInfo(is_leaf=True, mutates_data=True, mutates_metadata=False, mutations_hidden_from_autograd=True, mutations_under_no_grad_or_inference_mode=False, mutates_storage_metadata=False, requires_grad=False, mutation_type=<MutationType.MUTATED_OUT_GRAPH: 3>),...)

# Now
Ran 6 tests in 13.851s
OK (skipped=4)
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov