### PR TITLE
[export] Ban tensor constants in tracing.

### DIFF
--- a/test/export/test_unflatten.py
+++ b/test/export/test_unflatten.py
@@ -526,14 +526,14 @@ class TestUnflatten(TestCase):
                         call_module_input_order.append(sub_node.op)
         self.assertEqual(call_module_input_order, ["placeholder", "get_attr", "get_attr"])
 
-    def test_unflatten_constant_tensor(self):
+    def test_unflatten_non_persistent_buffer(self):
         class SubMod(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.initializer = 0.1
+                self.register_buffer("buffer", torch.tensor(0.1), persistent=False)
 
             def forward(self, x):
-                return x + torch.tensor(self.initializer)
+                return x + self.buffer
 
         class Mod(torch.nn.Module):
             def __init__(self):

--- a/test/export/test_verifier.py
+++ b/test/export/test_verifier.py
@@ -143,7 +143,7 @@ class TestVerifier(TestCase):
         class M(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.a = torch.tensor(3.0)
+                self.register_buffer("a", torch.tensor(3.0))
 
             def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
                 return x + y + self.a

--- a/test/onnx/test_fx_to_onnx.py
+++ b/test/onnx/test_fx_to_onnx.py
@@ -607,8 +607,8 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
     def test_exported_program_torch_distributions_normal_Normal(self):
         class Model(torch.nn.Module):
             def __init__(self):
-                self.normal = torch.distributions.normal.Normal(0, 1)
                 super().__init__()
+                self.register_buffer("normal", torch.distributions.normal.Normal(0, 1))
 
             def forward(self, x):
                 return self.normal.sample(x.shape)

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -523,8 +523,12 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
     )
     def test_expand_as_fill_tensor(self):
         class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("b", torch.tensor([1, 2, 3]))
+
             def forward(self, x):
-                x[:, x.size(0) :] = torch.tensor([1, 2, 3])
+                x[:, x.size(0) :] = self.b
                 return x
 
         x = torch.ones(2, 5, 3)
@@ -540,9 +544,12 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
     )
     def test_expand_as_fill_separate_tensor(self):
         class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("aa", torch.tensor([[0], [1], [2]]))
+
             def forward(self, x):
-                aa = torch.tensor([[0], [1], [2]])
-                return aa.expand_as(x)
+                return self.aa.expand_as(x)
 
         x = torch.ones(3, 2)
         x2 = torch.randn(3, 5)

--- a/test/test_out_dtype_op.py
+++ b/test/test_out_dtype_op.py
@@ -52,7 +52,7 @@ class TestOutDtypeOp(TestCase):
         class M(torch.nn.Module):
             def __init__(self, weight):
                 super().__init__()
-                self.weight = weight
+                self.register_buffer("weight", weight)
 
             def forward(self, x):
                 return out_dtype(
@@ -79,7 +79,7 @@ class TestOutDtypeOp(TestCase):
         class M(torch.nn.Module):
             def __init__(self, weight):
                 super().__init__()
-                self.weight = weight
+                self.register_buffer("weight", weight)
 
             def forward(self, x):
                 return out_dtype(

--- a/torch/_export/db/examples/cond_branch_nonlocal_variables.py
+++ b/torch/_export/db/examples/cond_branch_nonlocal_variables.py
@@ -44,10 +44,10 @@ class CondBranchNonlocalVariables(torch.nn.Module):
 
     def __init__(self):
         super().__init__()
+        self.register_buffer("my_primitive_var", torch.tensor(3.14))
 
     def forward(self, x):
         my_tensor_var = x + 100
-        my_primitive_var = 3.14
 
         def true_fn(x, y, z):
             return x + y + z
@@ -59,5 +59,5 @@ class CondBranchNonlocalVariables(torch.nn.Module):
             x.shape[0] > 5,
             true_fn,
             false_fn,
-            [x, my_tensor_var, torch.tensor(my_primitive_var)],
+            [x, my_tensor_var, self.my_primitive_var],
         )

--- a/torch/_export/error.py
+++ b/torch/_export/error.py
@@ -21,6 +21,9 @@ class ExportErrorType(Enum):
     # User is using an API without proper initialization step.
     UNINITIALIZED = 6
 
+    # User's code use constant tensor that is not a buffer or introduced from tensor constructor.
+    TENSOR_CONSTANT = 7
+
 
 def internal_assert(pred: bool, assert_msg: str) -> None:
     """
@@ -53,4 +56,5 @@ class ExportError(Exception):
 
     def __init__(self, error_code: ExportErrorType, message: str) -> None:
         prefix = f"[{error_code}]: "
+        self.error_code = error_code
         super().__init__(prefix + message)

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -375,6 +375,10 @@ class FakeTensorConfig:
     debug = os.environ.get("TORCH_FAKE_TENSOR_DEBUG", "0") == "1"
 
 
+class NonFakeInputError(Exception):
+    pass
+
+
 class FakeTensor(torch.Tensor):
     """
     Meta tensors give you the ability to run PyTorch code without having to
@@ -1502,9 +1506,8 @@ class FakeTensorMode(TorchDispatchMode):
                     if isinstance(x, FakeTensor) and x.fake_mode is not self:
                         raise AssertionError("Mixing fake modes NYI")
                     args, kwargs = pytree.tree_unflatten(flat_args, args_spec)
-                    raise Exception(
-                        f"Please convert all Tensors to FakeTensors first or instantiate FakeTensorMode "
-                        f"with 'allow_non_fake_inputs'. Found in {render_call(func, args, kwargs)}"
+                    raise NonFakeInputError(
+                        f"Please convert all Tensors to FakeTensors first. Found in {render_call(func, args, kwargs)}"
                     )
 
                 x = converter(self, x)


### PR DESCRIPTION
Summary:
There're two patterns resulting in the similar constant lifting effect during tracing:
```
def forward(self, x):
    return x + torch.tensor(...)
```
and
```
class Model(torch.nn.Module):
     def __init__(self):
         super().__init__()
         self.a = torch.tensor(...)
     def forward(self, x):
         return x + self.a
```
In theory and practice, it will be too implicit to promote them as buffers in tracing, due to two reasons:

1. They don't have a formal FQN.
2. They likely result in baked-in values without being noticed by users.
3. Their values can be easily mutated without being noticed by users.

Therefore we want to make a policy decision to ban any form of tensor constants to show up in the traced graph. To proceed in the tracing, users either need to register these constants explicitly as buffers, or use constructors to properly initialize them. In some cases, users can get away without even wrapping scalars inside a torch.tensor() call.

Test Plan: buck test mode/opt caffe2/test:test_export -- -r test_export_tensor_constants

Differential Revision: D53436364


