### PR TITLE
[ez] Lower windows timeout limit for trunk, set test step timeout

### DIFF
--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -143,6 +143,7 @@ jobs:
       - name: Test
         id: test
         shell: bash
+        timeout-minutes: ${{ fromJson(steps.test-timeout.outputs.timeout) }}
         env:
           USE_CUDA: ${{ inputs.cuda-version != 'cpu' && '1' || '0' }}
           INSTALL_WINDOWS_SDK: 1

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -25,7 +25,7 @@ on:
       timeout-minutes:
         required: false
         type: number
-        default: 300
+        default: 240
         description: |
           Set the maximum (in minutes) how long the workflow should take to finish
 

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -132,6 +132,14 @@ jobs:
           test-matrix: ${{ inputs.test-matrix }}
           job-name: ${{ steps.get-job-id.outputs.job-name }}
 
+      - name: Set Test step time
+        id: test-timeout
+        shell: bash
+        env:
+          JOB_TIMEOUT: ${{ matrix.mem_leak_check == 'mem_leak_check' && 600 || inputs.timeout-minutes }}
+        run: |
+          echo "timeout=$((JOB_TIMEOUT-30))" >> "${GITHUB_OUTPUT}"
+
       - name: Test
         id: test
         shell: bash

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -115,6 +115,7 @@ jobs:
       build-environment: win-vs2019-cuda11.8-py3
       cuda-version: "11.8"
       test-matrix: ${{ needs.win-vs2019-cuda11_8-py3-build.outputs.test-matrix }}
+      timeout-minutes: 300
 
   # TODO: Figure out how to migrate this job to M1 runner
   ios-build-test:

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -115,7 +115,6 @@ jobs:
       build-environment: win-vs2019-cuda11.8-py3
       cuda-version: "11.8"
       test-matrix: ${{ needs.win-vs2019-cuda11_8-py3-build.outputs.test-matrix }}
-      timeout-minutes: 300
 
   # TODO: Figure out how to migrate this job to M1 runner
   ios-build-test:


### PR DESCRIPTION
Lower windows timeout to be the same as linux

Step timeout thing for win (linux version + details for why at https://github.com/pytorch/pytorch/pull/93084)
