### PR TITLE
[dynamo] inlining into __iter__ of user defined object

### DIFF
--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -970,8 +970,8 @@ class TestSingleProc(DynamoDistributedSingleProcTestCase):
                 .check("""local "L['self']" ID_MATCH""") \
                 .check(f"""{expected_guard_source} "L['self'].net" TYPE_MATCH""") \
                 .check(f"""{expected_guard_source} "L['self'].net" ID_MATCH""") \
-                .check(f"""{expected_guard_source} "L['self'].net._modules[\'0\']" TYPE_MATCH""") \
-                .check(f"""{expected_guard_source} "L['self'].net._modules[\'0\']" ID_MATCH""") \
+                .check(f"""{expected_guard_source} "L['self'].net[0]" TYPE_MATCH""") \
+                .check(f"""{expected_guard_source} "L['self'].net[0]" ID_MATCH""") \
                 .run(GUARDS_FILE.getvalue())
             self.assertTrue(same(correct_outputs, outputs))
 

--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -970,8 +970,8 @@ class TestSingleProc(DynamoDistributedSingleProcTestCase):
                 .check("""local "L['self']" ID_MATCH""") \
                 .check(f"""{expected_guard_source} "L['self'].net" TYPE_MATCH""") \
                 .check(f"""{expected_guard_source} "L['self'].net" ID_MATCH""") \
-                .check(f"""{expected_guard_source} "L['self'].net[0]" TYPE_MATCH""") \
-                .check(f"""{expected_guard_source} "L['self'].net[0]" ID_MATCH""") \
+                .check(f"""{expected_guard_source} "L['self'].net._modules[\'0\']" TYPE_MATCH""") \
+                .check(f"""{expected_guard_source} "L['self'].net._modules[\'0\']" ID_MATCH""") \
                 .run(GUARDS_FILE.getvalue())
             self.assertTrue(same(correct_outputs, outputs))
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -852,6 +852,42 @@ class MiscTests(torch._dynamo.test_case.TestCase):
         else:
             self.assertExpectedInline(counts.op_count, """4""")
 
+    def test_user_defined_iter(self):
+        class Mod:
+            def __init__(self):
+                self.a = [torch.randn(2, 2), torch.randn(2, 2)]
+
+            def __iter__(self):
+                return iter(self.a)
+
+        def f(mod):
+            ret = []
+            for x in mod:
+                ret.append(x + 1)
+            return ret
+
+        mod = Mod()
+        counts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch._dynamo.optimize(counts, nopython=True)(f)
+        ref = f(mod)
+        res = opt_fn(mod)
+        res = opt_fn(mod)
+        res = opt_fn(mod)
+        res = opt_fn(mod)
+        self.assertTrue(same(ref, res))
+        self.assertEqual(counts.frame_count, 1)
+
+        mod.a.append(torch.randn(2, 2))
+        # `for x in mod` is inlined, where iter(m.a) creates a guard on the list length of m.a
+        # Mutating length of mod.a causes a re-compilation.
+        ref2 = f(mod)
+        res2 = opt_fn(mod)
+        res2 = opt_fn(mod)
+        res2 = opt_fn(mod)
+        res2 = opt_fn(mod)
+        self.assertTrue(same(ref2, res2))
+        self.assertEqual(counts.frame_count, 2)
+
     def test_compare_shapes_eq(self):
         def compare_shapes(a, b, to_list):
             x = list(a.unsqueeze(-1).shape) if to_list else a.shape

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -932,7 +932,7 @@ class BuiltinVariable(VariableTracker):
         ret = self._call_iter_tuple_list(tx, obj, *args, **kwargs)
 
         if ret is None:
-            # If the object doesn't implement a __iter__ method, it will be an error in eager mode.
+            # If the object doesn't implement a __iter__ method, it will be an error in eager mode when calling iter on it anyway.
             # If the object implements a __iter__ method, inlining effectively forwards the call to another iter call
             # (e.g. when __iter__ just returns iter(self.list)) or return a user-defined iterator.
             return obj.call_method(tx, "__iter__", args, kwargs)

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -524,7 +524,7 @@ class BuiltinVariable(VariableTracker):
     def call_function(
         self, tx, args: "List[VariableTracker]", kwargs: "Dict[str, VariableTracker]"
     ) -> "VariableTracker":
-        from . import UserDefinedObjectVariable, UserFunctionVariable
+        from . import UserFunctionVariable
         from .builder import wrap_fx_proxy, wrap_fx_proxy_cls
 
         args = [v.realize() for v in args]
@@ -717,15 +717,6 @@ class BuiltinVariable(VariableTracker):
                     **{k: v.as_python_constant() for k, v in kwargs.items()},
                 ),
             )
-
-        # Handle `for t in iter(user_obj)`, where user_obj defines a __iter__ method.
-        if self.fn is iter and args and isinstance(args[0], UserDefinedObjectVariable):
-            assert len(args) == 1
-            assert len(kwargs) == 0
-            maybe_iter_method = args[0].var_getattr(tx, "__iter__")
-            if isinstance(maybe_iter_method, variables.UserMethodVariable):
-                return maybe_iter_method.call_function(tx, [], {})
-            unimplemented(f"__iter__ is not implemented for {args[0]} {args[0].value}")
 
         return super().call_function(tx, args, kwargs)
 

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -668,8 +668,9 @@ class BuiltinVariable(VariableTracker):
             assert len(args) == 1
             assert len(kwargs) == 0
             maybe_iter_method = args[0].var_getattr(tx, "__iter__")
-            assert isinstance(maybe_iter_method, variables.UserMethodVariable)
-            return maybe_iter_method.call_function(tx, [], {})
+            if isinstance(maybe_iter_method, variables.UserMethodVariable):
+                return maybe_iter_method.call_function(tx, [], {})
+            unimplemented(f"__iter___ is not implemented fol {args[0]} {args[0].value}")
 
         # Handle binary ops (e.g. __add__ / __radd__, __iadd__, etc.)
         # NB: Tensor args are handled above and not here

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -936,7 +936,17 @@ class BuiltinVariable(VariableTracker):
                 mutable_local=MutableLocal(),
             )
 
-    call_iter = _call_iter_tuple_list
+    def call_iter(self, tx, obj, *args, **kwargs):
+        # Handle the case where we are iterating over a tuple, list or iterator
+        ret = self._call_iter_tuple_list(tx, obj, *args, **kwargs)
+
+        if ret is None:
+            # If the object doesn't implement a __iter__ method, it will be an error in eager mode.
+            # If the object implements a __iter__ method, inlining effectively forwards the call to another iter call
+            # (e.g. when __iter__ just returns iter(self.list)) or return a user-defined iterator.
+            return obj.call_method(tx, "__iter__", args, kwargs)
+        return ret
+
     call_tuple = _call_iter_tuple_list
     call_list = _call_iter_tuple_list
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #119243

Fixes #119198.

This PR make dynamo inline `__iter__` of a user defined object instead of creating a graph break. Also added a new test, which shows:
1. the loop is unrolled
2. the length of the loop is guarded when inlining `__iter__`
```python
class Mod:
    def __init__(self):
        self.a = [torch.randn(2, 2), torch.randn(2, 2)]

    def __iter__(self):
        return iter(self.a)

def f(mod):
    ret = []
    for x in mod:
        ret.append(x + 1)
    return ret
```


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng