### PR TITLE
Use recursive blob for package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1393,15 +1393,9 @@ def main():
             ]
         )
     torchgen_package_data = [
-        # Recursive glob doesn't work in setup.py,
-        # https://github.com/pypa/setuptools/issues/1806
-        # To make this robust we should replace it with some code that
-        # returns a list of everything under packaged/
-        "packaged/ATen/*",
-        "packaged/ATen/native/*",
-        "packaged/ATen/templates/*",
-        "packaged/autograd/*",
-        "packaged/autograd/templates/*",
+        "packaged/**/*.cpp",
+        "packaged/**/*.h",
+        "packaged/**/*.yaml",
     ]
     setup(
         name=package_name,


### PR DESCRIPTION
setup.py now supports recursive glob for package data

I only added `.cpp`, `.h`, and `.yaml` files. Not sure if you want to include BAZEL or other files in package_data. 