### PR TITLE
Add SparsePrivateUse1 in backend_to_string, layout_from_backend and check_base_legacy_new.

### DIFF
--- a/c10/core/Layout.h
+++ b/c10/core/Layout.h
@@ -35,6 +35,7 @@ inline Layout layout_from_backend(Backend backend) {
     case Backend::SparseHIP:
     case Backend::SparseVE:
     case Backend::SparseXPU:
+    case Backend::SparsePrivateUse1:
       return Layout::Sparse;
     case Backend::MkldnnCPU:
       return Layout::Mkldnn;

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1446,7 +1446,7 @@ _storage_classes = {
     TypedStorage
 }
 
-# The _tensor_classes set is initialized by the call to _C._initialize_tensor_type_bindings()
+# The _tensor_classes set is initialized by the call to initialize_python_bindings.
 _tensor_classes: Set[Type] = set()
 
 # If you edit these imports, please update torch/__init__.py.in as well

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -1605,7 +1605,6 @@ torch_c_binding_in_graph_functions = dict.fromkeys(
         "torch.cross",
         "torch.crow_indices_copy",
         "torch.ctc_loss",
-        "torch.cuda._get_device_properties",
         "torch.cudnn_affine_grid_generator",
         "torch.cudnn_batch_norm",
         "torch.cudnn_convolution_add_relu",

--- a/torch/csrc/tensor/python_tensor.cpp
+++ b/torch/csrc/tensor/python_tensor.cpp
@@ -25,8 +25,7 @@
 #include <type_traits>
 #include <vector>
 
-namespace torch {
-namespace tensors {
+namespace torch::tensors {
 
 using namespace at;
 using namespace torch::autograd;
@@ -215,29 +214,15 @@ static void py_initialize_tensor_type(
   }
 }
 
-static const char* get_module(Backend backend) {
-  switch (backend) {
-    case Backend::CPU:
-      return "torch";
-    case Backend::CUDA:
-      return "torch.cuda";
-    case Backend::SparseCPU:
-      return "torch.sparse";
-    case Backend::SparseCUDA:
-      return "torch.cuda.sparse";
-    default:
-      AT_ERROR("invalid backend: ", toString(backend));
-  }
-}
-
 static std::string get_name(Backend backend, ScalarType scalarType) {
   std::ostringstream ss;
-  ss << get_module(backend) << "." << toString(scalarType) << "Tensor";
+  ss << torch::utils::backend_to_string(backend) << "." << toString(scalarType)
+     << "Tensor";
   return ss.str();
 }
 
 static THPObjectPtr get_storage_obj(Backend backend, ScalarType dtype) {
-  auto module_name = get_module(backend);
+  auto module_name = torch::utils::backend_to_string(backend);
   auto module_obj = THPObjectPtr(PyImport_ImportModule(module_name));
   if (!module_obj)
     throw python_error();
@@ -478,5 +463,4 @@ ScalarType get_default_scalar_type() {
   return get_default_dtype_as_scalartype();
 }
 
-} // namespace tensors
-} // namespace torch
+} // namespace torch::tensors

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -44,8 +44,7 @@ using at::Tensor;
 using at::TensorOptions;
 using c10::optional;
 
-namespace torch {
-namespace utils {
+namespace torch::utils {
 namespace {
 const int MAX_DIMS = 128;
 
@@ -535,6 +534,7 @@ void check_base_legacy_new(
         c10::DispatchKey::SparseCUDA,
         c10::DispatchKey::SparseHIP,
         c10::DispatchKey::SparseXPU,
+        c10::DispatchKey::SparsePrivateUse1,
     });
     TORCH_CHECK(
         expected_key_set.has(dispatch_key),
@@ -1786,5 +1786,4 @@ Tensor asarray(
   return tensor;
 }
 
-} // namespace utils
-} // namespace torch
+} // namespace torch::utils

--- a/torch/csrc/utils/tensor_types.cpp
+++ b/torch/csrc/utils/tensor_types.cpp
@@ -16,15 +16,16 @@
 
 using namespace at;
 
-namespace torch {
-namespace utils {
+namespace torch::utils {
 
-static const char* parse_privateuseone_backend() {
+static const char* parse_privateuseone_backend(bool is_sparse = false) {
   static std::string backend_name = "torch." + get_privateuse1_backend();
-  return backend_name.c_str();
+  static std::string sparse_backend_name = backend_name + ".sparse";
+  return is_sparse == false ? backend_name.c_str()
+                            : sparse_backend_name.c_str();
 }
 
-static const char* backend_to_string(const at::Backend& backend) {
+const char* backend_to_string(const at::Backend& backend) {
   switch (backend) {
     case at::Backend::CPU:
       return "torch";
@@ -50,6 +51,8 @@ static const char* backend_to_string(const at::Backend& backend) {
       return "torch.mtia";
     case at::Backend::PrivateUse1:
       return parse_privateuseone_backend();
+    case at::Backend::SparsePrivateUse1:
+      return parse_privateuseone_backend(true);
     case at::Backend::Lazy:
       return "torch.lazy";
     case at::Backend::XLA:
@@ -179,5 +182,4 @@ std::vector<std::pair<Backend, ScalarType>> all_declared_types() {
   return ret;
 }
 
-} // namespace utils
-} // namespace torch
+} // namespace torch::utils

--- a/torch/csrc/utils/tensor_types.h
+++ b/torch/csrc/utils/tensor_types.h
@@ -15,5 +15,8 @@ at::TensorOptions options_from_string(const std::string& str);
 // return a vector of all "declared" types, even those that weren't compiled
 std::vector<std::pair<at::Backend, at::ScalarType>> all_declared_types();
 
+// return python module name of backend, like torch.cuda, torch.foo
+const char* backend_to_string(const at::Backend& backend);
+
 } // namespace utils
 } // namespace torch


### PR DESCRIPTION
1) Using items stored in torch._tensor_classes to check item passed from python side;
2) Add SparsePrivateUse1 in backend_to_string, layout_from_backend and check_base_legacy_new;
3) Using more general API to get python module name in get_storage_obj and get_name functions.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @soulitzer @bdhirsh @ezyang @albanD 

Fixes #ISSUE_NUMBER
