### PR TITLE
[FSDP] Improved error msg in _init_utils

### DIFF
--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -1042,7 +1042,11 @@ def _get_compute_device(
     if device_from_device_id is not None and compute_device != device_from_device_id:
         raise ValueError(
             f"Inconsistent compute device and `device_id` on rank {rank}: "
-            f"{compute_device} vs {device_from_device_id}"
+            f"{compute_device} vs {device_from_device_id}."
+            "If this error is related to meta device, please ensure"
+            " the passed in param_init_fn to FSDP moves all modules to the compute"
+            " device, else this error will occur since some modules are left on "
+            " meta device."
         )
     return compute_device
 


### PR DESCRIPTION
Spend significant time debugging this crash and it turned out to be because my custom `param_init_fn` had a bug that skipped init of some modules. Think this is common and painful enough to justify specific details in error msg.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang