### PR TITLE
Fix broken link compile custom backends link

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1802,7 +1802,7 @@ def compile(model: Optional[Callable] = None, *,
 
         - Experimental or debug in-tree backends can be seen with `torch._dynamo.list_backends(None)`
 
-        - To register an out-of-tree custom backend: https://pytorch.org/docs/main/compile/custom-backends.html
+        - To register an out-of-tree custom backend: https://pytorch.org/docs/stable/torch.compiler_custom_backends.html#registering-custom-backends
        mode (str): Can be either "default", "reduce-overhead", "max-autotune" or "max-autotune-no-cudagraphs"
 
         - "default" is the default mode, which is a good balance between performance and overhead


### PR DESCRIPTION
Fixes #119272

The URL is a bit long, if you like I can change it to a hyperlink with shorter name