### PR TITLE
c10:intrusive_ptr, self assignment

### DIFF
--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -392,10 +392,10 @@ class intrusive_ptr final {
     return *this;
   }
 
+  // Assignment is implemented using copy and swap. That's safe for self
+  // assignment.
+  // NOLINTNEXTLINE(bugprone-unhandled-self-assignment)
   intrusive_ptr& operator=(const intrusive_ptr& rhs) & noexcept {
-    if (this == &rhs) {
-      return *this;
-    }
     // NOLINTNEXTLINE(*assign-operator, *assignment-signature)
     return operator= <TTarget, NullType>(rhs);
   }


### PR DESCRIPTION
Summary:
In C++ books/sources, self assignment check is often considered a bad practice, since it is very very unlikely.

See, for example libc++ doesn't have it:
https://github.com/llvm/llvm-project/blob/cf94e0082e5e0a9be43a69d9fae588bc2aafab91/libcxx/include/__memory/shared_ptr.h#L651

How about we remove it?

Test Plan:
This check is like 1% of cycles assinged to intrusive_ptr::operator=
https://fburl.com/scuba/strobelight_services/9qqnrkdn

This is not a lot in purely cycles but since it's gpu machines, can be substantial

Differential Revision: D53471639

