### PR TITLE
Add symbol guard counts instrumentation

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -9044,6 +9044,9 @@ ShapeEnv not equal: field values don't match:
 ==> name_to_node: values don't match.
   >  Left: {_assert, eq, mod, x_size_0_, x_size_1_, x_storage_offset, x_stride_0_, x_stride_1_}
   > Right: {x_size_0_, x_size_1_, x_storage_offset, x_stride_0_, x_stride_1_}
+==> symbol_guard_counter: values don't match.
+  >  Left: {s0: 1, s1: 0}
+  > Right: {s0: 0, s1: 0}
 """,
         )
         self._replay_and_check(main)
@@ -9081,6 +9084,9 @@ ShapeEnv not equal: field values don't match:
 ==> replacements: values don't match.
   >  Left: {s0: 3}
   > Right: {}
+==> symbol_guard_counter: values don't match.
+  >  Left: {s0: 1, s1: 0}
+  > Right: {s0: 0, s1: 0}
 """,
         )
         self._replay_and_check(main)
@@ -9116,6 +9122,9 @@ ShapeEnv not equal: field values don't match:
 ==> name_to_node: values don't match.
   >  Left: {_assert, ge, x_size_0_, x_size_1_, x_storage_offset, x_stride_0_, x_stride_1_}
   > Right: {x_size_0_, x_size_1_, x_storage_offset, x_stride_0_, x_stride_1_}
+==> symbol_guard_counter: values don't match.
+  >  Left: {s0: 1, s1: 0}
+  > Right: {s0: 0, s1: 0}
 ==> var_to_guards: values don't match.
   >  Left: {s0: (s0 >= 3, None)}
   > Right: {}

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -9044,9 +9044,6 @@ ShapeEnv not equal: field values don't match:
 ==> name_to_node: values don't match.
   >  Left: {_assert, eq, mod, x_size_0_, x_size_1_, x_storage_offset, x_stride_0_, x_stride_1_}
   > Right: {x_size_0_, x_size_1_, x_storage_offset, x_stride_0_, x_stride_1_}
-==> symbol_guard_counter: values don't match.
-  >  Left: {s0: 1, s1: 0}
-  > Right: {s0: 0, s1: 0}
 """,
         )
         self._replay_and_check(main)
@@ -9084,9 +9081,6 @@ ShapeEnv not equal: field values don't match:
 ==> replacements: values don't match.
   >  Left: {s0: 3}
   > Right: {}
-==> symbol_guard_counter: values don't match.
-  >  Left: {s0: 1, s1: 0}
-  > Right: {s0: 0, s1: 0}
 """,
         )
         self._replay_and_check(main)
@@ -9122,9 +9116,6 @@ ShapeEnv not equal: field values don't match:
 ==> name_to_node: values don't match.
   >  Left: {_assert, ge, x_size_0_, x_size_1_, x_storage_offset, x_stride_0_, x_stride_1_}
   > Right: {x_size_0_, x_size_1_, x_storage_offset, x_stride_0_, x_stride_1_}
-==> symbol_guard_counter: values don't match.
-  >  Left: {s0: 1, s1: 0}
-  > Right: {s0: 0, s1: 0}
 ==> var_to_guards: values don't match.
   >  Left: {s0: (s0 >= 3, None)}
   > Right: {}

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1953,6 +1953,9 @@ class ShapeEnv:
             elif key == "name_to_node":
                 # Compare just the set of keys is the same.
                 return set(value.keys())
+            elif key == "symbol_guard_counter":
+                # Skip this for comparisons
+                return None
             return value
 
         shape_env_check_state_equal(self, other, non_state_variable_names, map_value)

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1745,6 +1745,11 @@ class ShapeEnv:
             [ShapeEnvEvent(ShapeEnv, kwargs=kwargs)] if self.should_record_events else []
         )
 
+    # Pro-tip: if you add new field to ShapeEnv, this affects some accept
+    # tests.  Accept their output with:
+    #
+    #   EXPECTTEST_ACCEPT=1 python test/dynamo/test_dynamic_shapes.py -k test_shape_env_equal
+    #
     def _init(
         self, *,
         allow_scalar_outputs=True,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #119349
* #119347
* __->__ #119290

This helps us understand if there are symbols which are extremely hot
(i.e., have a lot of guards mentioning them).  Extremely hot symbols are
candidates for being turned static.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng