### PR TITLE
[Memory Snapshot] Support capturing without any stack tracing, stacks=None

### DIFF
--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -925,7 +925,7 @@ static void registerCudaDeviceProperties(PyObject* module) {
       static_cast<void (*)(
           c10::optional<std::string>,
           c10::optional<std::string>,
-          const std::string&,
+          c10::optional<std::string>,
           size_t)>(torch::cuda::_record_memory_history));
 
   m.def("_cuda_isHistoryEnabled", []() {

--- a/torch/csrc/cuda/memory_snapshot.h
+++ b/torch/csrc/cuda/memory_snapshot.h
@@ -18,7 +18,7 @@ TORCH_CUDA_CU_API void _record_memory_history(
 TORCH_CUDA_CU_API void _record_memory_history(
     c10::optional<std::string> enabled = "all",
     c10::optional<std::string> context = "all",
-    const std::string& stacks = "all",
+    c10::optional<std::string> stacks = "all",
     size_t max_entries = UINT64_MAX);
 
 TORCH_CUDA_CU_API std::string _memory_snapshot_pickled();

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -703,6 +703,7 @@ def _record_memory_history(enabled="all", *args, **kwargs):
             `"all"`, additionally keep tracebacks for free calls.
             Defaults to "all".
         stacks (Literal["python", "all"], optional):
+            `None`, Do not record any tracebacks.
             `"python"`, include Python, TorchScript, and inductor frames in tracebacks
             `"all"`, additionally include C++ frames
             Defaults to "all".
@@ -718,7 +719,7 @@ def _record_memory_history(enabled="all", *args, **kwargs):
 def _record_memory_history_impl(
     enabled: Optional[str] = "all",
     context: Optional[str] = "all",
-    stacks: str = "all",
+    stacks: Optional[str] = "all",
     max_entries: int = sys.maxsize,
     device: Union[Device, int] = None,
 ):


### PR DESCRIPTION
Summary:
Adding support to turn off all tracebacks including python. After this change, record_memory_history will have the following 3 stacks options:
  - None
  - "python"
  - "all" - includes C++ call stacks

Test Plan:
Ran this locally with stacks=None, and collected a snapshot with no stack tracebacks (Ran D53490039).
```
INFO:scripts.aaronshi.memory.memory_utils:URL to the GPU Memory Snapshot Viewer: https://www.internalfb.com/pytorch_memory_visualizer/ai_efficiency/tree/gpu_snapshot/devvm2184.cco0.facebook.com/devvm2184.cco0.facebook.com.Feb_06_12_33_04.2009682.snapshot.pickle
```

Differential Revision: D53488362


