### PR TITLE
Scipy 1.12.0 has added assertions that some edge input cases failed.

### DIFF
--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3926,8 +3926,19 @@ class TestBinaryUfuncs(TestCase):
         test_dx((2, 3, 4), 1, 1, device)
         test_dx((10, 2), 0, 0.1, device)
         test_dx((1, 10), 0, 2.3, device)
-        test_dx((0, 2), 0, 1.0, device)
-        test_dx((0, 2), 1, 1.0, device)
+
+        try:
+            test_dx((0, 2), 0, 1.0, device)
+        except ValueError as e:
+            err_msg = "At least one point is required along `axis`."
+            self.assertEqual(str(e), err_msg)
+
+        try:
+            test_dx((0, 2), 1, 1.0, device)
+        except ValueError as e:
+            err_msg = "At least one point is required along `axis`."
+            self.assertEqual(str(e), err_msg)
+
         test_dx((512, 512), 1, 1.0, device)
         test_dx((100, 100, 100), 1, 1.0, device)
 


### PR DESCRIPTION
Background: Scipy 1.12.0 has added [this assertion](https://github.com/scipy/scipy/commit/fb42116c91e2ff45207350ea19eef0de017fdc64#diff-2ff88b8913ad74b9ea3fe1fe02d6d49164855189168b767076af2e94206c3a2cR493 
) check.
This makes the following case fail the assertion. i.e. when y=[] and the shape is (0,2). 

Currently [pytorch's scipy](https://github.com/pytorch/pytorch/blob/3b417934127920391bc745404f2ac49d3f0db16e/.ci/docker/requirements-ci.txt#L231-L233) is not dependent on 1.12.0 yet. But if scipy version gets updated, tests would fail with the err_msg listed in the PR. 

cc @ptrblck @eqy @malfet 