### PR TITLE
[memory traces] display remaining stacktrace at the bottom

### DIFF
--- a/torch/utils/viz/MemoryViz.js
+++ b/torch/utils/viz/MemoryViz.js
@@ -1257,7 +1257,7 @@ function create_trace_view(
     .append('div')
     .attr(
       'style',
-      'grid-column: 1; grid-row: 3; width: 100%; height: 80%; overflow: auto;',
+      'grid-column: 1; grid-row: 3; width: 100%; height: 100%; overflow: auto;',
     );
   const delegate = ContextViewer(context_div.append('pre').text('none'), data);
   plot.set_delegate(delegate);
@@ -1569,7 +1569,7 @@ pre {
 }
 html, body {
   height: 100%;
-  overflow: clip;
+  overflow: auto;
 }`;
 
 const head = d3.select('head');

--- a/torch/utils/viz/MemoryViz.js
+++ b/torch/utils/viz/MemoryViz.js
@@ -1257,7 +1257,7 @@ function create_trace_view(
     .append('div')
     .attr(
       'style',
-      'grid-column: 1; grid-row: 3; width: 100%; height: 100%; overflow: auto;',
+      'grid-column: 1; grid-row: 3; width: 100%; height: 80%; overflow: auto;',
     );
   const delegate = ContextViewer(context_div.append('pre').text('none'), data);
   plot.set_delegate(delegate);


### PR DESCRIPTION
problem: cannot display traces at the bottom with ``python _memory_viz.py trace_plot snapshot.pickle -o trace.html``

<img width="1171" alt="Screenshot 2024-02-05 at 5 52 51 PM" src="https://github.com/pytorch/pytorch/assets/134637289/8ea960ca-7df6-4788-ae9a-3b7b784190ca">

change ``html, body {overflow: clip -> auto }`` we are able to scroll to the bottom. 
<img width="1021" alt="Screenshot 2024-02-05 at 5 52 29 PM" src="https://github.com/pytorch/pytorch/assets/134637289/85f73dd3-fd36-448e-94fc-a9b6610a8a64">



