### PR TITLE
[DCP] Automatically set `no_dist` if distributed is unavailable

### DIFF
--- a/torch/distributed/checkpoint/state_dict_loader.py
+++ b/torch/distributed/checkpoint/state_dict_loader.py
@@ -50,7 +50,7 @@ def load(
     planner: Optional[LoadPlanner] = None,
     process_group: Optional[dist.ProcessGroup] = None,
     coordinator_rank: int = 0,
-    no_dist: bool = False,
+    no_dist: Optional[bool] = None,
 ) -> None:
     """
     Load a distributed ``state_dict`` in SPMD style.
@@ -99,8 +99,8 @@ def load(
             (Default: ``None``)
         coordinator_rank (int): Rank to use to coordinate the checkpoint.
             rank0 is used by default. (Default: ``0``)
-        no_dist (bool): If ``True``, distributed checkpoint will not save
-            in SPMD style. (Default: ``False``)
+        no_dist (Optional[bool]): If ``True``, distributed checkpoint will not save
+            in SPMD style. (Default: ``False`` when torch.distributed is available and initialized)
 
     Returns:
         None.
@@ -130,6 +130,14 @@ def load(
         and it is the user's responsibility to ensure that this is set so that each
         rank has an individual GPU, via ``torch.cuda.set_device()``.
     """
+
+    if no_dist is None:
+        no_dist = not (dist.is_available() and dist.is_initialized())
+        if no_dist:
+            warnings.warn(
+                "Loading with `no_dist` set to True because torch.distributed"
+                " is unavailable or uninitialized."
+            )
 
     with _profile():
         if not storage_reader:

--- a/torch/distributed/checkpoint/state_dict_saver.py
+++ b/torch/distributed/checkpoint/state_dict_saver.py
@@ -56,7 +56,7 @@ def save(
     planner: Optional[SavePlanner] = None,
     process_group: Optional[dist.ProcessGroup] = None,
     coordinator_rank: int = 0,
-    no_dist: bool = False,
+    no_dist: Optional[bool] = None,
 ) -> Metadata:
     """
     Save a distributed model in SPMD style.
@@ -83,6 +83,7 @@ def save(
     .. note::
         This function can be used to save a state_dict without having a process group
         initialized by passing ``no_dist=True``.
+        (Default: ``False`` when torch.distributed is available and initialized)
 
 
     Args:
@@ -132,6 +133,14 @@ def save(
         each rank has an individual GPU, via ``torch.cuda.set_device()``.
     """
     torch._C._log_api_usage_once("torch.distributed.checkpoint.save")
+
+    if no_dist is None:
+        no_dist = not (dist.is_available() and dist.is_initialized())
+        if no_dist:
+            warnings.warn(
+                "Saving with `no_dist` set to True because torch.distributed"
+                " is unavailable or uninitialized."
+            )
 
     with _profile():
         if not storage_writer:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #119335
* #119333
* #118894
* __->__#119332

Automatically set `no_dist` if distributed is unavailable

Differential Revision: [D53497641](https://our.internmc.facebook.com/intern/diff/D53497641/)

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225