### PR TITLE
[DCP] Adds utility for converting torch save to dcp

### DIFF
--- a/docs/source/distributed.checkpoint.rst
+++ b/docs/source/distributed.checkpoint.rst
@@ -99,3 +99,5 @@ an experimental feature and is subject to change.
 For users which are used to using and sharing models in the `torch.save` format, the following utilities are pvoided:
 
 .. autofunction:: torch.distributed.checkpoint.format_utils.dcp_to_torch_save
+
+.. autofunction:: torch.distributed.checkpoint.format_utils.torch_save_to_dcp

--- a/test/distributed/checkpoint/test_format_utils.py
+++ b/test/distributed/checkpoint/test_format_utils.py
@@ -2,7 +2,10 @@
 
 import torch
 import torch.distributed.checkpoint as dcp
-from torch.distributed.checkpoint.format_utils import dcp_to_torch_save
+from torch.distributed.checkpoint.format_utils import (
+    dcp_to_torch_save,
+    torch_save_to_dcp,
+)
 from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
@@ -24,6 +27,20 @@ class TestFormatUtils(DTensorTestBase):
 
         loaded_sd = torch.load(torch_fn)
         self.assertEqual(loaded_sd, {"model": model.state_dict()})
+
+    @with_temp_dir
+    def test_torch_save_to_dcp(self) -> None:
+        model = Transformer(ModelArgs())
+        sd = {"model": model.state_dict()}
+        torch_fn = self.temp_dir + "/model.pt"
+        torch.save(sd, torch_fn)
+
+        torch_save_to_dcp(torch_fn, self.temp_dir)
+
+        model = Transformer(ModelArgs())
+        dcp.load({"model": model}, checkpoint_id=self.temp_dir)
+
+        self.assertEqual({"model": model.state_dict()}, sd)
 
 
 if __name__ == "__main__":

--- a/torch/distributed/checkpoint/format_utils.py
+++ b/torch/distributed/checkpoint/format_utils.py
@@ -2,6 +2,7 @@ import os
 from typing import Union
 
 import torch
+import torch.distributed.checkpoint as dcp
 from torch.distributed.checkpoint import FileSystemReader
 from torch.distributed.checkpoint._traverse import set_element
 from torch.distributed.checkpoint.default_planner import DefaultLoadPlanner
@@ -12,7 +13,8 @@ from torch.distributed.checkpoint.metadata import (
 )
 from torch.distributed.checkpoint.state_dict_loader import _load_state_dict
 
-__all__ = ["dcp_to_torch_save"]
+
+__all__ = ["dcp_to_torch_save", "torch_save_to_dcp"]
 
 
 class _EmptyStateDictLoadPlanner(DefaultLoadPlanner):
@@ -55,7 +57,6 @@ class _EmptyStateDictLoadPlanner(DefaultLoadPlanner):
 def dcp_to_torch_save(
     dcp_checkpoint_dir: Union[str, os.PathLike],
     torch_save_fn: Union[str, os.PathLike],
-    coordinator_rank: int = 0,
 ):
     """
     Given a directory containing a DCP checkpoint, this function will convert it into a
@@ -64,13 +65,7 @@ def dcp_to_torch_save(
     Args:
         dcp_checkpoint_dir: Directory containing the DCP checkpoint.
         torch_save_fn: Filename to store the converted Torch save file.
-        coordinator_rank: Rank that will perform the conversion. Ignored
-            if dist is not available.
-
-    .. warning::
-        To avoid OOM, it's recommended to only run this function on a single rank.
     """
-
     sd = {}
     storage_reader = FileSystemReader(dcp_checkpoint_dir)
 
@@ -81,3 +76,21 @@ def dcp_to_torch_save(
         no_dist=True,
     )
     torch.save(sd, torch_save_fn)
+
+
+def torch_save_to_dcp(
+    torch_save_fn: Union[str, os.PathLike], dcp_checkpoint_dir: Union[str, os.PathLike]
+):
+    """
+    Given the location of a torch save file, converts it into a DCP checkpoint.
+
+    Args:
+        torch_save_fn: Filename to store the converted Torch save file.
+        dcp_checkpoint_dir: Directory containing the DCP checkpoint.
+
+    .. warning::
+        To avoid OOM, it's recommended to only run this function on a single rank.
+    """
+
+    state_dict = torch.load(torch_save_fn)
+    dcp.save(state_dict, checkpoint_id=dcp_checkpoint_dir, no_dist=True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #119335
* __->__ #119333
* #118894
* #119332

[DCP] Adds utility for converting torch save to dcp

Differential Revision: [D53497640](https://our.internmc.facebook.com/intern/diff/D53497640/)

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225