### PR TITLE
[DCP] Adds storage reader and planner classes for online loading/sharding of models in torch.save format

### DIFF
--- a/docs/source/distributed.checkpoint.rst
+++ b/docs/source/distributed.checkpoint.rst
@@ -96,8 +96,16 @@ an experimental feature and is subject to change.
 .. autoclass:: torch.distributed.checkpoint.state_dict.StateDictOptions
    :members:
 
-For users which are used to using and sharing models in the `torch.save` format, the following utilities are pvoided:
+For users which are used to using and sharing models in the `torch.save` format the following methods are provided, which provide offline utilities for converting betweeing formats.
 
 .. autofunction:: torch.distributed.checkpoint.format_utils.dcp_to_torch_save
 
 .. autofunction:: torch.distributed.checkpoint.format_utils.torch_save_to_dcp
+
+The following classes can also be utilized for online loading and resharding of models from the torch.save format.
+
+.. autoclass:: torch.distributed.checkpoint.format_utils.BroadcastingTorchSaveReader
+   :members:
+
+.. autoclass:: torch.distributed.checkpoint.format_utils.DynamicMetaLoadPlanner
+   :members:

--- a/torch/distributed/checkpoint/state_dict_loader.py
+++ b/torch/distributed/checkpoint/state_dict_loader.py
@@ -150,7 +150,8 @@ def load(
             # https://github.com/pytorch/pytorch/issues/118036
             storage_reader = FileSystemReader(checkpoint_id)
 
-        storage_reader.reset(checkpoint_id)
+        if checkpoint_id is not None:
+            storage_reader.reset(checkpoint_id)
 
         if no_dist:
             keys = list(state_dict.keys())


### PR DESCRIPTION
This stack adds three utilities
* dcp_to_torch_save: a function for offline converting from dcp to torch save
* torch_save_to_dcp: a function for offline converting from torch save to dcp
* `DynamicMetaLoadPlanner` and `BroadcastingTorchSaveReader`, two classes that can be used with `dcp.load` to load models using the torch save format.

After this stack is reviewed, an executable will be added to make utilizing these functions more convenient.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__#119335
* #119333
* #118894
* #119332

[DCP] Adds storage reader and planner classes for online loading/sharding of models in torch.save format

Differential Revision: [D53497593](https://our.internmc.facebook.com/intern/diff/D53497593/)

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225