### PR TITLE
[AOTI][refactor] Move ThreadLocalCachedOutputTensor into a separate header

### DIFF
--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -1,7 +1,7 @@
-#include <torch/csrc/inductor/aoti_runtime/arrayref_tensor.h>
 #include <torch/csrc/inductor/aoti_runtime/interface.h>
 #include <torch/csrc/inductor/aoti_runtime/model_container.h>
 #include <torch/csrc/inductor/aoti_runtime/scalar_to_tensor.h>
+#include <torch/csrc/inductor/aoti_runtime/thread_local.h>
 
 #include <iostream>
 #include <sstream>

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1496,7 +1496,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
             return
 
         if V.graph.aot_mode:
-            for header_cpp_file in ("interface.cpp", "implementation.cpp"):
+            for header_cpp_file in ("interface.cpp",):
                 with open(
                     os.path.join(
                         os.path.dirname(__file__), "aoti_runtime", header_cpp_file

--- a/torch/csrc/inductor/aoti_runtime/thread_local.h
+++ b/torch/csrc/inductor/aoti_runtime/thread_local.h
@@ -1,11 +1,8 @@
-// NOTE: Like interface.cpp, this file will be copied into AOTInductor
-// generated output. This file is intended to keep implementation
-// details separate from the implementation of the AOTI public
-// interface. Note also that #includes should go into interface.cpp
-// for simplicity of maintenance.
+#include <torch/csrc/inductor/aoti_runtime/arrayref_tensor.h>
 
 namespace torch {
 namespace aot_inductor {
+
 template <typename T>
 struct ThreadLocalCachedOutputTensor;
 
@@ -239,7 +236,8 @@ template <typename T>
 void assert_numel(const ArrayRefTensor<T>& tensor, int64_t numel) {
   if (tensor.numel() != numel) {
     std::stringstream err;
-    err << "incorrect numel for input tensor. expected " << numel << ", got " << tensor.numel();
+    err << "incorrect numel for input tensor. expected " << numel << ", got "
+        << tensor.numel();
     throw std::runtime_error(err.str());
   }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #119280
* __->__ #119342
* #119066

Summary: Move common functionality into a header file so that later JIT and AOT Inductor can share it.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler

Differential Revision: [D53503058](https://our.internmc.facebook.com/intern/diff/D53503058)