### PR TITLE
Add cherry-pick workflow

### DIFF
--- a/.github/scripts/cherry_pick.py
+++ b/.github/scripts/cherry_pick.py
@@ -167,7 +167,7 @@ def post_comment(org: str, project: str, pr_num: int, msg: str) -> None:
         )
 
     comment = "\n".join(
-        (f"## Cherry picking {pr_num}", f"{msg}", "", f"{internal_debugging}")
+        (f"### Cherry picking #{pr_num}", f"{msg}", "", f"{internal_debugging}")
     )
     gh_post_pr_comment(org, project, pr_num, comment)
 
@@ -185,7 +185,8 @@ def main() -> None:
         classification = args.classification
         if classification in REQUIRES_ISSUE and not args.fixes:
             raise RuntimeError(
-                f"Refuse to cherry pick #{pr_num} because {classification} requires an issue"
+                f"Refuse to cherry pick #{pr_num} because {classification} "
+                + "category requires an issue. Please provide one with --fixes"
             )
 
         commit_sha = get_merge_commit_sha(repo, pr)

--- a/.github/scripts/cherry_pick.py
+++ b/.github/scripts/cherry_pick.py
@@ -94,7 +94,7 @@ def create_cherry_pick_branch(
     github_actor = re.sub("[^0-9a-zA-Z]+", "_", github_actor)
 
     cherry_pick_branch = f"cherry-pick-{pr.pr_num}-by-{github_actor}"
-    repo.checkout(branch=cherry_pick_branch, new_branch=True)
+    repo.create_branch_and_checkout(branch=cherry_pick_branch)
 
     # We might want to support ghstack later
     repo._run_git("cherry-pick", "-x", "-X", "theirs", commit_sha)

--- a/.github/scripts/cherry_pick.py
+++ b/.github/scripts/cherry_pick.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import re
+from typing import Any, Optional
+
+from urllib.error import HTTPError
+
+from github_utils import gh_fetch_url, gh_post_pr_comment
+
+from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
+from trymerge import get_pr_commit_sha, GitHubPR
+
+
+REQUIRES_ISSUE = {
+    "regression",
+    "critical",
+    "fixnewfeature",
+}
+
+
+def parse_args() -> Any:
+    from argparse import ArgumentParser
+
+    parser = ArgumentParser("cherry pick a landed PR onto a release branch")
+    parser.add_argument(
+        "--onto-branch", type=str, required=True, help="the target release branch"
+    )
+    parser.add_argument(
+        "--github-actor", type=str, required=True, help="all the world’s a stage"
+    )
+    parser.add_argument(
+        "--classification",
+        choices=["regression", "critical", "fixnewfeature", "docs", "release"],
+        required=True,
+        help="the cherry pick category",
+    )
+    parser.add_argument("pr_num", type=int)
+    parser.add_argument(
+        "--fixes",
+        type=str,
+        help="the GitHub issue that the cherry pick fixes",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+
+    return parser.parse_args()
+
+
+def get_merge_commit_sha(repo: GitRepo, pr: GitHubPR) -> Optional[str]:
+    """
+    Return the merge commit SHA iff the PR has been merged. For simplicity, we
+    will only cherry pick PRs that have been merged into main
+    """
+    commit_sha = get_pr_commit_sha(repo, pr)
+    return commit_sha if pr.is_closed() else None
+
+
+def cherry_pick(
+    github_actor: str,
+    repo: GitRepo,
+    pr: GitHubPR,
+    commit_sha: str,
+    onto_branch: str,
+    dry_run: bool = False,
+) -> None:
+    """
+    Create a local branch to cherry pick the commit and submit it as a pull request
+    """
+    current_branch = repo.current_branch()
+
+    try:
+        cherry_pick_branch = create_cherry_pick_branch(
+            github_actor, repo, pr, commit_sha, onto_branch
+        )
+    except RuntimeError as error:
+        # Clean up if we fail to create the cherry pick due to conflicts
+        repo._run_git("cherry-pick", "--abort")
+        if current_branch:
+            repo.checkout(branch=current_branch)
+        raise error
+
+    try:
+        if not dry_run:
+            submit_pr(repo, pr, cherry_pick_branch, onto_branch)
+    finally:
+        if current_branch:
+            repo.checkout(branch=current_branch)
+
+
+def create_cherry_pick_branch(
+    github_actor: str, repo: GitRepo, pr: GitHubPR, commit_sha: str, onto_branch: str
+) -> str:
+    """
+    Create a local branch and cherry pick the commit. Return the name of the local
+    cherry picking branch.
+    """
+    repo.checkout(branch=onto_branch)
+    repo._run_git("submodule", "update", "--init", "--recursive")
+
+    # Remove all special characters if we want to include the actor in the branch name
+    github_actor = re.sub("[^0-9a-zA-Z]+", "_", github_actor)
+
+    cherry_pick_branch = f"cherry-pick-{pr.pr_num}-by-{github_actor}"
+    repo.checkout(branch=cherry_pick_branch, new_branch=True)
+
+    # We might want to support ghstack later
+    repo._run_git("cherry-pick", "-x", "-X", "theirs", commit_sha)
+    repo.push(branch=cherry_pick_branch, dry_run=False)
+
+    return cherry_pick_branch
+
+
+def submit_pr(
+    repo: GitRepo,
+    pr: GitHubPR,
+    cherry_pick_branch: str,
+    onto_branch: str,
+) -> None:
+    """
+    Submit the cherry pick PR.
+    """
+    org, project = repo.gh_owner_and_name()
+
+    default_msg = f"Cherry pick #{pr.pr_num} onto {onto_branch} branch"
+    title = pr.info.get("title", default_msg)
+    body = pr.info.get("body", default_msg)
+
+    try:
+        response = gh_fetch_url(
+            f"https://api.github.com/repos/{org}/{project}/pulls",
+            method="POST",
+            data={
+                "title": title,
+                "body": body,
+                "head": cherry_pick_branch,
+                "base": onto_branch,
+            },
+            headers={"Accept": "application/vnd.github.v3+json"},
+            reader=json.load,
+        )
+
+        cherry_pick_pr = response.get("html_url", "")
+        if not cherry_pick_pr:
+            raise RuntimeError(
+                f"Fail to find the cherry pick PR: {json.dumps(response)}"
+            )
+
+        msg = f"The cherry pick PR is at {cherry_pick_pr}"
+        post_comment(org, project, pr.pr_num, msg)
+
+    except HTTPError as error:
+        msg = f"Fail to submit the cherry pick PR: {error}"
+        raise RuntimeError(msg) from error
+
+
+def post_comment(org: str, project: str, pr_num: int, msg: str) -> None:
+    """
+    Post a comment on the PR itself to point to the cherry picking PR when success
+    or print the error when failure
+    """
+    internal_debugging = ""
+
+    run_url = os.getenv("GH_RUN_URL")
+    # Post a comment to tell folks that the PR is being cherry picked
+    if run_url is not None:
+        internal_debugging = "\n".join(
+            line
+            for line in (
+                "<details><summary>Details for Dev Infra team</summary>",
+                f'Raised by <a href="{run_url}">workflow job</a>\n',
+                "</details>",
+            )
+            if line
+        )
+
+    comment = "\n".join(
+        (f"## Cherry picking {pr_num}", f"{msg}", "", f"{internal_debugging}")
+    )
+    gh_post_pr_comment(org, project, pr_num, comment)
+
+
+def main() -> None:
+    args = parse_args()
+    pr_num = args.pr_num
+
+    repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
+    org, project = repo.gh_owner_and_name()
+
+    pr = GitHubPR(org, project, pr_num)
+
+    try:
+        classification = args.classification
+        if classification in REQUIRES_ISSUE and not args.fixes:
+            raise RuntimeError(
+                f"Refuse to cherry pick #{pr_num} because {classification} requires an issue"
+            )
+
+        commit_sha = get_merge_commit_sha(repo, pr)
+        if not commit_sha:
+            raise RuntimeError(
+                f"Refuse to cherry pick #{pr_num} because it hasn't been merged yet"
+            )
+
+        cherry_pick(
+            args.github_actor, repo, pr, commit_sha, args.onto_branch, args.dry_run
+        )
+
+    except RuntimeError as error:
+        if not args.dry_run:
+            post_comment(org, project, pr_num, str(error))
+        else:
+            raise error
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/cherry_pick.py
+++ b/.github/scripts/cherry_pick.py
@@ -68,17 +68,9 @@ def cherry_pick(
     Create a local branch to cherry pick the commit and submit it as a pull request
     """
     current_branch = repo.current_branch()
-
-    try:
-        cherry_pick_branch = create_cherry_pick_branch(
-            github_actor, repo, pr, commit_sha, onto_branch
-        )
-    except RuntimeError as error:
-        # Clean up if we fail to create the cherry pick due to conflicts
-        repo._run_git("cherry-pick", "--abort")
-        if current_branch:
-            repo.checkout(branch=current_branch)
-        raise error
+    cherry_pick_branch = create_cherry_pick_branch(
+        github_actor, repo, pr, commit_sha, onto_branch
+    )
 
     try:
         if not dry_run:

--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -162,8 +162,11 @@ class GitRepo:
             # we are in detached HEAD state
             return None
 
-    def checkout(self, branch: str) -> None:
-        self._run_git("checkout", branch)
+    def checkout(self, branch: str, new_branch: bool = False) -> None:
+        if new_branch:
+            self._run_git("checkout", "-b", branch)
+        else:
+            self._run_git("checkout", branch)
 
     def fetch(self, ref: Optional[str] = None, branch: Optional[str] = None) -> None:
         if branch is None and ref is None:

--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -162,11 +162,11 @@ class GitRepo:
             # we are in detached HEAD state
             return None
 
-    def checkout(self, branch: str, new_branch: bool = False) -> None:
-        if new_branch:
-            self._run_git("checkout", "-b", branch)
-        else:
-            self._run_git("checkout", branch)
+    def checkout(self, branch: str) -> None:
+        self._run_git("checkout", branch)
+
+    def create_branch_and_checkout(self, branch: str) -> None:
+        self._run_git("checkout", "-b", branch)
 
     def fetch(self, ref: Optional[str] = None, branch: Optional[str] = None) -> None:
         if branch is None and ref is None:

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,0 +1,67 @@
+name: Create a cherry pick from a PR
+
+on:
+  repository_dispatch:
+    types: [try-cherry-pick]
+
+jobs:
+  cherry-pick:
+    name: cherry-pick-pr-${{ github.event.client_payload.pr_num }}
+    runs-on: ubuntu-latest
+    environment: cherry-pick-bot
+    permission:
+      contents: read
+      pull-requests: write
+    env:
+        GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Checkout repo
+        id: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      # Not the direct dependencies but the script uses trymerge
+      - run: pip install pyyaml==6.0 rockset==1.0.3
+
+      - name: Setup committer id
+        run: |
+          git config --global user.name "PyTorch Bot"
+          git config --global user.email "pytorchbot@users.noreply.github.com"
+
+      - name: Cherry pick the PR
+        shell: bash
+        env:
+          PR_NUM: ${{ github.event.client_payload.pr_num }}
+          BRANCH: ${{ github.event.client_payload.branch }}
+          CLASSIFICATION: ${{ github.event.client_payload.classification }}
+          FIXES: ${{ github.event.client_payload.fixes || '' }}
+          REQUIRES_ISSUE: ${{ github.event.client_payload.requiresIssue || 'false' }}
+          ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
+        run: |
+          set -ex
+
+          if [[ "${REQUIRES_ISSUE}" == "true" ]]; then
+            python .github/scripts/cherry_pick.py \
+              --onto-branch "${BRANCH}" \
+              --classification "${CLASSIFICATION}" \
+              --fixes "${FIXES}" \
+              --github-actor "${ACTOR}" \
+              "${PR_NUM}"
+          else
+            python .github/scripts/cherry_pick.py \
+              --onto-branch "${BRANCH}" \
+              --classification "${CLASSIFICATION}" \
+              --github-actor "${ACTOR}" \
+              "${PR_NUM}"
+          fi
+
+concurrency:
+  group: cherry-pick-pr-${{ github.event.client_payload.pr_num }}
+  cancel-in-progress: true

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -12,27 +12,26 @@ jobs:
     env:
         GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
-      # Use UPDATEBOT_TOKEN as this will be used to submit PR similar to the daily
-      # commit hash update
       - name: Checkout repo
         id: checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.UPDATEBOT_TOKEN }}
+          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
 
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+          cache: pip
 
       # Not the direct dependencies but the script uses trymerge
       - run: pip install pyyaml==6.0 rockset==1.0.3
 
       - name: Setup committer id
         run: |
-          git config --global user.name "PyTorch UpdateBot"
-          git config --global user.email "pytorchupdatebot@users.noreply.github.com"
+          git config --global user.name "PyTorch Bot"
+          git config --global user.email "pytorchbot@users.noreply.github.com"
 
       - name: Cherry pick the PR
         shell: bash
@@ -43,7 +42,7 @@ jobs:
           FIXES: ${{ github.event.client_payload.fixes || '' }}
           REQUIRES_ISSUE: ${{ github.event.client_payload.requiresIssue || 'false' }}
           ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.UPDATEBOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
         run: |
           set -ex
 

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
+          token: ${{ secrets.GH_PYTORCHBOT_CHERRY_PICK_TOKEN }}
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -42,7 +42,7 @@ jobs:
           FIXES: ${{ github.event.client_payload.fixes || '' }}
           REQUIRES_ISSUE: ${{ github.event.client_payload.requiresIssue || 'false' }}
           ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PYTORCHBOT_CHERRY_PICK_TOKEN }}
         run: |
           set -ex
 

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -40,26 +40,17 @@ jobs:
           BRANCH: ${{ github.event.client_payload.branch }}
           CLASSIFICATION: ${{ github.event.client_payload.classification }}
           FIXES: ${{ github.event.client_payload.fixes || '' }}
-          REQUIRES_ISSUE: ${{ github.event.client_payload.requiresIssue || 'false' }}
           ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GH_PYTORCHBOT_CHERRY_PICK_TOKEN }}
         run: |
           set -ex
 
-          if [[ "${REQUIRES_ISSUE}" == "true" ]]; then
-            python .github/scripts/cherry_pick.py \
-              --onto-branch "${BRANCH}" \
-              --classification "${CLASSIFICATION}" \
-              --fixes "${FIXES}" \
-              --github-actor "${ACTOR}" \
-              "${PR_NUM}"
-          else
-            python .github/scripts/cherry_pick.py \
-              --onto-branch "${BRANCH}" \
-              --classification "${CLASSIFICATION}" \
-              --github-actor "${ACTOR}" \
-              "${PR_NUM}"
-          fi
+          python .github/scripts/cherry_pick.py \
+            --onto-branch "${BRANCH}" \
+            --classification "${CLASSIFICATION}" \
+            --fixes "${FIXES}" \
+            --github-actor "${ACTOR}" \
+            "${PR_NUM}"
 
 concurrency:
   group: cherry-pick-pr-${{ github.event.client_payload.pr_num }}

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -9,17 +9,17 @@ jobs:
     name: cherry-pick-pr-${{ github.event.client_payload.pr_num }}
     runs-on: ubuntu-latest
     environment: cherry-pick-bot
-    permission:
-      contents: read
-      pull-requests: write
     env:
         GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
+      # Use UPDATEBOT_TOKEN as this will be used to submit PR similar to the daily
+      # commit hash update
       - name: Checkout repo
         id: checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.UPDATEBOT_TOKEN }}
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -31,8 +31,8 @@ jobs:
 
       - name: Setup committer id
         run: |
-          git config --global user.name "PyTorch Bot"
-          git config --global user.email "pytorchbot@users.noreply.github.com"
+          git config --global user.name "PyTorch UpdateBot"
+          git config --global user.email "pytorchupdatebot@users.noreply.github.com"
 
       - name: Cherry pick the PR
         shell: bash
@@ -43,7 +43,7 @@ jobs:
           FIXES: ${{ github.event.client_payload.fixes || '' }}
           REQUIRES_ISSUE: ${{ github.event.client_payload.requiresIssue || 'false' }}
           ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.UPDATEBOT_TOKEN }}
         run: |
           set -ex
 


### PR DESCRIPTION
After https://github.com/pytorch/test-infra/pull/4758, we can create a new workflow on PyTorch to receive `try-cherry-pick` dispatch event from the bot, and create the cherry pick PR.

* [x] Cherry pick a PR after it has been landed and create a cherry pick PR to the target release branch.
* [ ] The second part after this is to update the release tracker with the info.  This will be done in a subsequent PR.
* [ ] ghstack is not yet supported
* [ ] Cherry pick a reverted commit is not yet supported (from @kit1980 comment)

### Testing

The script can be used locally:

```
python cherry_pick.py --onto release/2.2 --classification release --github-actor huydhn 118907
The cherry pick PR is at https://github.com/pytorch/pytorch/pull/119351
```

The test cherry pick PR is created at https://github.com/pytorch/pytorch/pull/119351

Unit testing this on CI is tricky, so I test this out on canary instead.

* https://github.com/pytorch/pytorch-canary/pull/193#issuecomment-1933162707 creates the PR at https://github.com/pytorch/pytorch-canary/pull/201
  * One more test on canary with the new token https://github.com/pytorch/pytorch-canary/pull/193#issuecomment-1933229483.  The minimum required permission from what I see is `workflow` 
* Cherry picking conflicts could happen and needs to be handled manually https://github.com/pytorch/pytorch-canary/pull/194#issuecomment-1933142975
* ~Require a linked issue when cherry picking regressions, critical fixes, or fixing new features https://github.com/pytorch/pytorch-canary/pull/193#issuecomment-1933174520~ Relax this requirement to a suggestion