### PR TITLE
Update documentation for set_flush_denormal support on ARM

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -9872,7 +9872,7 @@ Disables denormal floating numbers on CPU.
 
 Returns ``True`` if your system supports flushing denormal numbers and it
 successfully configures flush denormal mode.  :meth:`~torch.set_flush_denormal`
-is only supported on x86 architectures supporting SSE3.
+is supported on x86 architectures supporting SSE3 and AArch64 architecture.
 
 Args:
     mode (bool): Controls whether to enable flush denormal mode or not


### PR DESCRIPTION
**Documentation update for set_flush_denormal():**
-> set_flush_denormal() is now supported on ARM CPU's.
-> **PR:** https://github.com/pytorch/pytorch/pull/115184  (Already merged)

**Reference page:** https://pytorch.org/docs/stable/generated/torch.set_flush_denormal.html




cc @svekars @brycebortree