### PR TITLE
avoid redundant event records and event blocks

### DIFF
--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -947,9 +947,11 @@ struct C10_EXPORT ivalue::Future final : c10::intrusive_ptr_target {
     currentDevice_ = impl_.getDevice();
     storages_ = std::move(actualStorages);
     for (const c10::Device& device : usedDevices) {
-      c10::Event event(impl_.type());
-      event.record(impl_.getStream(device));
-      events_.push_back(std::move(event));
+      if (impl_.getDevice() != device) {
+        c10::Event event(impl_.type());
+        event.record(impl_.getStream(device));
+        events_.push_back(std::move(event));
+      }
     }
 
     std::vector<FutureCallback> cbs;


### PR DESCRIPTION
https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/core/ivalue_inl.h#L952
```C++
 void markCompleted(
      IValue value,
      c10::optional<std::vector<WeakStorage>> storages = c10::nullopt) {
 # ....
  for (const c10::Device& device : usedDevices) {
      c10::Event event(impl_.type());
      event.record(impl_.getStream(device));
      events_.push_back(std::move(event));
    }
 # ....
}
```
https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/core/ivalue_inl.h#L1197
```C++
 void synchronizeWithCurrentStreams() {
    for (c10::Event& event : events_) {
      event.block(impl_.getStream(event.device()));
    }
 # ....
}
```
When usedDevices and impl_ is same device, both record and block will be executed on the same stream, which is redundant.
Also, I would like to know under what circumstances different devices will be used? Are the records and blocks necessary here.

Additionally, I also mentioned a suspected bug related to this.
https://github.com/pytorch/pytorch/issues/119266

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @ptrblck