### PR TITLE
Fix missing parameter check in at::batch_norm

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -485,6 +485,23 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_cpu_template(
 std::tuple<Tensor, Tensor, Tensor, Tensor, int64_t> _batch_norm_impl_index(
     const Tensor& input, const c10::optional<Tensor>& weight_opt /* optional */, const c10::optional<Tensor>& bias_opt /* optional */, const c10::optional<Tensor>& running_mean_opt /* optional */, const c10::optional<Tensor>& running_var_opt /* optional */,
     bool training, double momentum, double eps, bool cudnn_enabled) {
+  TORCH_CHECK(
+      input.dim() >= 2,
+      "Expected at least 2 input dimensions, but got ",
+      input.dim());
+
+  if (training) {
+    auto size = input.sizes();
+    int64_t size_prods = size[0];
+    for (const auto i : c10::irange(size.size() - 2)) {
+      size_prods *= size[i + 2];
+    }
+    TORCH_CHECK(
+        size_prods != 1,
+        "Expected more than 1 value per channel when training, got input size ",
+        size);
+  }
+
   // See [Note: hacky wrapper removal for optional tensor]
   c10::MaybeOwned<Tensor> weight_maybe_owned = at::borrow_from_optional_tensor(weight_opt);
   const Tensor& weight = *weight_maybe_owned;

--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -1924,6 +1924,37 @@ TEST_F(FunctionalTest, Threshold) {
                   .defined());
 }
 
+TEST_F(FunctionalTest, BatchNormExceptions) {
+  double eps = 1e-05;
+  double momentum = 0.1;
+  auto input = torch::randn({1});
+  ASSERT_THROWS_WITH(
+    F::batch_norm(
+      input,
+      torch::tensor({}),
+      torch::tensor({}),
+      F::BatchNormFuncOptions()
+          .weight(torch::tensor({}))
+          .bias(torch::tensor({}))
+          .momentum(momentum)
+          .eps(eps)
+          .training(false)),
+      "Expected at least 2 input dimensions, but got ");
+
+  ASSERT_THROWS_WITH(
+    at::batch_norm(
+      input,
+      torch::tensor({}),
+      torch::tensor({}),
+      torch::tensor({}),
+      torch::tensor({}),
+      false,
+      momentum,
+      eps,
+      at::globalContext().userEnabledCuDNN()),
+      "Expected at least 2 input dimensions, but got ");
+}
+
 TEST_F(FunctionalTest, BatchNorm1d) {
   int num_features = 5;
   double eps = 1e-05;

--- a/torch/csrc/api/include/torch/nn/functional/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/functional/batchnorm.h
@@ -19,22 +19,6 @@ inline Tensor batch_norm(
     bool training,
     c10::optional<double> momentum,
     double eps) {
-  TORCH_CHECK(
-      input.dim() >= 2,
-      "Expected at least 2 input dimensions, but got ",
-      input.dim());
-  if (training) {
-    auto size = input.sizes();
-    int64_t size_prods = size[0];
-    for (const auto i : c10::irange(size.size() - 2)) {
-      size_prods *= size[i + 2];
-    }
-    TORCH_CHECK(
-        size_prods != 1,
-        "Expected more than 1 value per channel when training, got input size ",
-        size);
-  }
-
   return torch::batch_norm(
       input,
       weight,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -413,8 +413,6 @@ def sample_inputs_batch_norm(op_info, device, dtype, requires_grad, **kwargs):
         ((S, S, S), {'training': True, 'momentum': 0.5, 'eps': 0.6}),
         ((3, 2, 4), {'training': False, 'momentum': -1.2}),
         ((3, 1), {'training': True, 'momentum': 0.0}),
-        ((0,), {'training': True}),
-        ((0,), {'training': False}),
         ((3, 2, 3, 4), {'training': True, 'momentum': -1.0, 'eps': 0.5}),
         ((3, 2, 3, 4), {'training': False, 'momentum': -1.0, 'eps': 0.5}),
         ((2, 1), {}),


### PR DESCRIPTION
Input tensor valid checking are defined in
torch.nn.functional::batch_norm, if at::batch_norm is called, it may access illegal memory addresses.

Move valid checking to inner function to avoid memory corruption.

Fixes #117245


cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki