### PR TITLE
Fix default world_size when running on 1 or 0 GPU

### DIFF
--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -58,7 +58,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @property
     def world_size(self) -> int:
-        return min(torch.cuda.device_count(), 2)
+        return 2
 
     def _test_save_load(
         self,

--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -58,7 +58,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
     @property
     def world_size(self) -> int:
-        return 2
+        return min(torch.cuda.device_count(), 2)
 
     def _test_save_load(
         self,

--- a/test/distributed/fsdp/test_fsdp_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_state_dict.py
@@ -152,7 +152,7 @@ class TestDummyModel(torch.nn.Module):
 class TestFSDPStateDict(FSDPTest):
     @property
     def world_size(self):
-        return 2
+        return min(torch.cuda.device_count(),2)
 
     def _broadcast_state_dict(self, model, state_dict):
         # TODO (rohan-varma): remove model
@@ -1236,7 +1236,7 @@ class TestFSDPStateDict(FSDPTest):
 class TestFSDPStateDict4GPUs(FSDPTest):
     @property
     def world_size(self):
-        return max(torch.cuda.device_count(), 2)
+        return torch.cuda.device_count()
 
     @skip_if_lt_x_gpu(4)
     def test_local_state_dict_reshard(self):

--- a/test/distributed/fsdp/test_fsdp_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_state_dict.py
@@ -152,7 +152,7 @@ class TestDummyModel(torch.nn.Module):
 class TestFSDPStateDict(FSDPTest):
     @property
     def world_size(self):
-        return min(torch.cuda.device_count(),2)
+        return min(torch.cuda.device_count(), 2)
 
     def _broadcast_state_dict(self, model, state_dict):
         # TODO (rohan-varma): remove model


### PR DESCRIPTION
the mentioned distributed tests would fail if the number of GPUs available isn't sufficient. need to correct the default world size.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @LucasLLC @eqy 