### PR TITLE
Forward fix for same_shape oblivious guard

### DIFF
--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -1118,7 +1118,8 @@ def forward(self, x_1):
     _local_scalar_dense = torch.ops.aten._local_scalar_dense.default(x_1);  x_1 = None
     randn = torch.ops.aten.randn.default([3, _local_scalar_dense, 3], device = device(type='cpu'), pin_memory = False);  _local_scalar_dense = None
     cumsum = torch.ops.aten.cumsum.default(randn, 0);  randn = None
-    return cumsum""")
+    return cumsum"""  # noqa: B950
+        )
 
 
     def test_repeat_interleave_unbacked_output_size(self):

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -1105,6 +1105,17 @@ def forward(self, y_1, x_1):
     index_select = torch.ops.aten.index_select.default(y_1, 1, repeat_interleave);  y_1 = repeat_interleave = None
     return index_select""")
 
+    def test_cumsum_unbacked(self):
+        def f(x):
+            y = x.item()
+            z = torch.randn((3, y, 3))
+            return z.cumsum(0)
+
+        r = str(make_fx(f, tracing_mode="symbolic")(torch.tensor([5])).code).strip()
+        self.assertExpectedInline(
+            r, """""")
+
+
     def test_repeat_interleave_unbacked_output_size(self):
         def f(x, y):
             s = x.sum().item()

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -1113,7 +1113,12 @@ def forward(self, y_1, x_1):
 
         r = str(make_fx(f, tracing_mode="symbolic")(torch.tensor([5])).code).strip()
         self.assertExpectedInline(
-            r, """""")
+            r, """\
+def forward(self, x_1):
+    _local_scalar_dense = torch.ops.aten._local_scalar_dense.default(x_1);  x_1 = None
+    randn = torch.ops.aten.randn.default([3, _local_scalar_dense, 3], device = device(type='cpu'), pin_memory = False);  _local_scalar_dense = None
+    cumsum = torch.ops.aten.cumsum.default(randn, 0);  randn = None
+    return cumsum""")
 
 
     def test_repeat_interleave_unbacked_output_size(self):

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -107,8 +107,12 @@ def same_shape(a: ShapeType, b: ShapeType, *, allow_rhs_unbacked=False) -> bool:
             # with each other
             if isinstance(y, torch.SymInt):
                 continue
-        # TODO: this is actually kind of weird, why does this one need to be
-        # size oblivious
+        # NB: Naively, you would not expect to have to do an oblivious guard
+        # here because there is seemingly no broadcasting here, but in fact we
+        # use this in some situations to determine if we need to do an expand
+        # on the tensor because they don't line up, so you can definitely end
+        # up trying to prove u0 != 1 in this situation.  See
+        # python test/test_proxy_tensor.py -k test_cumsum_unbacked
         if guard_size_oblivious(x != y):
             return False
 

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -391,6 +391,8 @@ def is_non_overlapping_and_dense(a: Tensor) -> bool:
 def compute_elementwise_output_logical_to_physical_perm(
     *tensors, _skip_checks=False
 ) -> List[int]:
+    from torch.fx.experimental.symbolic_shapes import guard_size_oblivious
+
     if not _skip_checks and len(tensors) == 0:
         msg = "Can't compute elementwise output strides for zero tensors!"
         raise ValueError(msg)
@@ -437,17 +439,17 @@ def compute_elementwise_output_logical_to_physical_perm(
             stride_a = tensor.stride()[idx_a]
             stride_b = tensor.stride()[idx_b]
 
-            if stride_a == 0 or stride_b == 0:
+            if guard_size_oblivious(stride_a == 0) or guard_size_oblivious(stride_b == 0):
                 continue
 
-            if stride_a < stride_b:
+            if guard_size_oblivious(stride_a < stride_b):
                 return -1
 
-            if stride_a > stride_b:
+            if guard_size_oblivious(stride_a > stride_b):
                 return 1
 
             # stride_a == stride_b
-            if shape[idx_a] > shape[idx_b]:
+            if guard_size_oblivious(shape[idx_a] > shape[idx_b]):
                 return 1
 
         # Note: this case is hit if all strides are zero,

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -96,6 +96,8 @@ CustomOutParamAnnotation = "__custom_out_param__"
 
 
 def same_shape(a: ShapeType, b: ShapeType, *, allow_rhs_unbacked=False) -> bool:
+    from torch.fx.experimental.symbolic_shapes import guard_size_oblivious
+
     if len(a) != len(b):
         return False
 
@@ -105,7 +107,9 @@ def same_shape(a: ShapeType, b: ShapeType, *, allow_rhs_unbacked=False) -> bool:
             # with each other
             if isinstance(y, torch.SymInt):
                 continue
-        if x != y:
+        # TODO: this is actually kind of weird, why does this one need to be
+        # size oblivious
+        if guard_size_oblivious(x != y):
             return False
 
     return True

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -439,7 +439,9 @@ def compute_elementwise_output_logical_to_physical_perm(
             stride_a = tensor.stride()[idx_a]
             stride_b = tensor.stride()[idx_b]
 
-            if guard_size_oblivious(stride_a == 0) or guard_size_oblivious(stride_b == 0):
+            if guard_size_oblivious(stride_a == 0) or guard_size_oblivious(
+                stride_b == 0
+            ):
                 continue
 
             if guard_size_oblivious(stride_a < stride_b):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #119383

Fixes internal test

```
buck2 test '@fbcode//mode/opt' fbcode//accelerators/workloads/models/slimdsnn:slimdsnn_test -- --exact 'accelerators/workloads/models/slimdsnn:slimdsnn_test - test_generate (accelerators.workloads.models.slimdsnn.test_slimdsnn.SlimDSNN)'
```

And I added an OSS test that approximates the internal situation.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

Differential Revision: [D53544208](https://our.internmc.facebook.com/intern/diff/D53544208)