### PR TITLE
[BE]: Add filelock typing to mypy stubs

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -144,6 +144,7 @@ init_command = [
     'types-pkg-resources==0.1.3',
     'types-Jinja2==2.11.9',
     'types-colorama==0.4.6',
+    'types-filelock==3.2.7',
     'junitparser==2.1.1',
     'rich==10.9.0',
     'pyyaml==6.0',

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -144,7 +144,7 @@ init_command = [
     'types-pkg-resources==0.1.3',
     'types-Jinja2==2.11.9',
     'types-colorama==0.4.6',
-    'types-filelock==3.2.7',
+    'filelock==3.13.1',
     'junitparser==2.1.1',
     'rich==10.9.0',
     'pyyaml==6.0',


### PR DESCRIPTION
Realized we used filelock in some places, but didn't have a mypy type stub for it. Noticed it in this PR: https://github.com/pytorch/pytorch/pull/119386