### PR TITLE
Fix deadlock in ExecutionTraceObserver (#119242)

### DIFF
--- a/torch/csrc/profiler/standalone/execution_trace_observer.cpp
+++ b/torch/csrc/profiler/standalone/execution_trace_observer.cpp
@@ -172,7 +172,7 @@ struct TORCH_API ExecutionTraceObserver {
   enum class RunState { uninitialized, disabled, enabled };
 
   // Mutex for multithreaded access to the shared containers.
-  std::mutex g_mutex{};
+  std::recursive_mutex g_mutex{};
   // Stream to write output JSON.
   std::ofstream out{};
 
@@ -449,7 +449,7 @@ static void recordOperatorStart(
   auto tid = fn.threadId();
 
   try {
-    const std::lock_guard<std::mutex> lock(ob.g_mutex);
+    const std::lock_guard<std::recursive_mutex> lock(ob.g_mutex);
 
     // if current thread stack is empty, push the root node to the stack first
     if (ob.op_stack[tid].empty()) {
@@ -583,7 +583,7 @@ static void onFunctionExit(const RecordFunction& fn, ObserverContext* ctx_ptr) {
     std::vector<std::string> output_shapes;
     std::vector<std::string> output_values;
     try {
-      const std::lock_guard<std::mutex> lock(ob->g_mutex);
+      const std::lock_guard<std::recursive_mutex> lock(ob->g_mutex);
       // remove current op id from stack
 
       ob->op_stack[fn.threadId()].pop();


### PR DESCRIPTION
Summary:

With the compiled PyTorch module, in execution_trace_observer.cpp, function convertIValue calls TensorImpl->storage_offset(). That function call will trigger a recursive call into recordOperatorStart. It will cause a deadlock on ob.g_mutex.

This DIFF is to fix this deadlock by replacing std::mutex with std::recursive_mutex.

Since PyTorch only has one thread for FWD, and one thread for BWD. The contention is very low, the performance should NOT be a concern.

Test Plan:
Unit Test
    buck test  mode/dev-nosan caffe2/test:profiler -- test_execution_trace_with_pt2

Differential Revision: D53533253


