### PR TITLE
Fix delete branches

### DIFF
--- a/.github/scripts/delete_old_branches.py
+++ b/.github/scripts/delete_old_branches.py
@@ -234,14 +234,14 @@ def delete_branches() -> None:
     # updated in 90 days and the branch hasn't been updated in 1.5 years
     for base_branch, (date, sub_branches) in branches.items():
         print(f"[{base_branch}] Updated {(now - date) / SEC_IN_DAY} days ago")
+        if base_branch in keep_branches:
+            print(f"[{base_branch}] Has magic label or open PR, skipping")
+            continue
         pr = prs_by_branch.get(base_branch)
         if pr:
             print(
                 f"[{base_branch}] Has PR {pr['number']}: {pr['state']}, updated {(now - pr['updatedAt']) / SEC_IN_DAY} days ago"
             )
-            if base_branch in keep_branches:
-                print(f"[{base_branch}] Has magic label or open PR, skipping")
-                continue
             if (
                 now - pr["updatedAt"] < CLOSED_PR_RETENTION
                 or (now - date) < CLOSED_PR_RETENTION

--- a/.github/scripts/delete_old_branches.py
+++ b/.github/scripts/delete_old_branches.py
@@ -14,7 +14,6 @@ NO_PR_RETENTION = 1.5 * 365 * SEC_IN_DAY
 PR_WINDOW = 90 * SEC_IN_DAY  # Set to None to look at all PRs (may take a lot of tokens)
 REPO_OWNER = "pytorch"
 REPO_NAME = "pytorch"
-PR_BODY_MAGIC_STRING = "do-not-delete-branch"
 ESTIMATED_TOKENS = [0]
 
 TOKEN = os.environ["GITHUB_TOKEN"]
@@ -42,7 +41,6 @@ query ($owner: String!, $repo: String!, $cursor: String) {
         number
         updatedAt
         state
-        body
       }
     }
   }
@@ -67,7 +65,6 @@ query ($owner: String!, $repo: String!, $cursor: String) {
         number
         updatedAt
         state
-        body
       }
     }
   }
@@ -89,7 +86,6 @@ query ($owner: String!, $repo: String!, $cursor: String) {
           number
           updatedAt
           state
-          body
         }
       }
     }

--- a/.github/scripts/delete_old_branches.py
+++ b/.github/scripts/delete_old_branches.py
@@ -97,6 +97,7 @@ query ($owner: String!, $repo: String!, $cursor: String) {
 }
 """
 
+
 def is_protected(branch: str) -> bool:
     ESTIMATED_TOKENS[0] += 1
     res = gh_fetch_json_dict(
@@ -146,7 +147,10 @@ def get_recent_prs() -> Dict[str, Any]:
     while hasNextPage:
         ESTIMATED_TOKENS[0] += 1
         res = gh_graphql(
-            GRAPHQL_ALL_PRS_BY_UPDATED_AT, owner="pytorch", repo="pytorch", cursor=endCursor
+            GRAPHQL_ALL_PRS_BY_UPDATED_AT,
+            owner="pytorch",
+            repo="pytorch",
+            cursor=endCursor,
         )
         info = res["data"]["repository"]["pullRequests"]
         pr_infos.extend(info["nodes"])
@@ -172,6 +176,7 @@ def get_recent_prs() -> Dict[str, Any]:
                 prs_by_branch_base[branch_base_name] = pr
     return prs_by_branch_base
 
+
 def get_branches_with_magic_label_or_open_pr() -> Set[str]:
     pr_infos: List[Dict[str, Any]] = []
 
@@ -181,7 +186,10 @@ def get_branches_with_magic_label_or_open_pr() -> Set[str]:
     while hasNextPage:
         ESTIMATED_TOKENS[0] += 1
         res = gh_graphql(
-            GRAPHQL_NO_DELETE_BRANCH_LABEL, owner="pytorch", repo="pytorch", cursor=endCursor
+            GRAPHQL_NO_DELETE_BRANCH_LABEL,
+            owner="pytorch",
+            repo="pytorch",
+            cursor=endCursor,
         )
         info = res["data"]["repository"]["label"]["pullRequests"]
         pr_infos.extend(info["nodes"])
@@ -209,6 +217,7 @@ def get_branches_with_magic_label_or_open_pr() -> Set[str]:
             branch_base_name = x.group(1)
         branch_bases.add(branch_base_name)
     return branch_bases
+
 
 def delete_branch(repo: GitRepo, branch: str) -> None:
     repo._run_git("push", "origin", "-d", branch)


### PR DESCRIPTION
Due to PR_WINDOW, if the magic string exists in the body but the pr was not updated recently, the query wouldn't find it and would delete the branch.  Instead, query separately for branches with the no-delete-branch label, which I created recently.

Might as well query for branches with open PRs while we're at it so PRs with the stale label won't get their branches deleted either