### PR TITLE
[EZ][CI] Fetch full history for MPS jobs

### DIFF
--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -41,7 +41,6 @@ jobs:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
         with:
-          fetch-depth: 1
           submodules: false
 
       - name: Select all requested test configurations


### PR DESCRIPTION
Otherwise emitting TD stats will fail with following warning:
```
Emiting td_test_failure_stats
/Users/ec2-user/runner/_work/pytorch/pytorch/tools/testing/target_determination/heuristics/edited_by_pr.py:37: UserWarning: Can't query changed test files due to Command '['git', 'merge-base', 'origin/main', 'HEAD']' returned non-zero exit status 1.
  warn(f"Can't query changed test files due to {e}")
```

Test plan: Observe that MPS jobs finishes without those warnings