### PR TITLE
Add cpp stack traces to our own reruns

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -26,6 +26,7 @@ from torch.testing._internal.common_utils import (
     FILE_SCHEMA,
     get_report_path,
     IS_CI,
+    IS_MACOS,
     parser as common_parser,
     retry_shell,
     set_cwd,
@@ -618,8 +619,15 @@ def run_test_retries(
             sc_command = f"--sc={stepcurrent_key}"
         print_to_file("Retrying...")
         # Print full c++ stack traces during retries
-        env = env or {}
-        env["TORCH_SHOW_CPP_STACKTRACES"] = "1"
+        # Don't do it for macos inductor tests as it makes them
+        # segfault for some reason
+        if not (
+            IS_MACOS
+            and len(command) >= 2
+            and command[2] == "inductor/test_torchinductor_opinfo.py"
+        ):
+            env = env or {}
+            env["TORCH_SHOW_CPP_STACKTRACES"] = "1"
         print_items = []  # do not continue printing them, massive waste of space
 
     consistent_failures = [x[1:-1] for x in num_failures.keys() if num_failures[x] >= 3]

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -624,7 +624,7 @@ def run_test_retries(
         if not (
             IS_MACOS
             and len(command) >= 2
-            and command[2] == "inductor/test_torchinductor_opinfo.py"
+            and command[2].startswith(INDUCTOR_TEST_PREFIX)
         ):
             env = env or {}
             env["TORCH_SHOW_CPP_STACKTRACES"] = "1"

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -617,6 +617,9 @@ def run_test_retries(
         else:
             sc_command = f"--sc={stepcurrent_key}"
         print_to_file("Retrying...")
+        # Print full c++ stack traces during retries
+        env = env or {}
+        env["TORCH_SHOW_CPP_STACKTRACES"] = "1"
         print_items = []  # do not continue printing them, massive waste of space
 
     consistent_failures = [x[1:-1] for x in num_failures.keys() if num_failures[x] >= 3]

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -161,10 +161,6 @@ class TestAutograd(TestCase):
         self.assertEqual(len(w), 0)
 
     def test_tensor_grad_warnings(self):
-        # Have a test that raises a c++ exception
-        a = torch.rand(2)
-        torch.nn.functional.conv2d(a, a)
-
         dummy = torch.empty(1)
 
         with warnings.catch_warnings(record=True) as w:

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -161,6 +161,10 @@ class TestAutograd(TestCase):
         self.assertEqual(len(w), 0)
 
     def test_tensor_grad_warnings(self):
+        # Have a test that raises a c++ exception
+        a = torch.rand(2)
+        torch.nn.functional.conv2d(a, a)
+
         dummy = torch.empty(1)
 
         with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
Note that I'm not sure why we both have pytest rerun the failing test twice via https://github.com/pytorch/pytorch/blob/81abc2b2494ab7d48394b63d528eb5dddfa9d3d5/test/run_test.py#L966 before our own logic retries it as well?

The failing test is only here to make sure it works as expected in the CI env. Will remove before landing.