### PR TITLE
Use CUDA if cuda's macro is set for AOTI runner's pybind

### DIFF
--- a/torch/csrc/inductor/aoti_runner/pybind.cpp
+++ b/torch/csrc/inductor/aoti_runner/pybind.cpp
@@ -35,7 +35,7 @@ void initAOTIRunnerBindings(PyObject* module) {
       .def("get_call_spec", &AOTIModelContainerRunnerCuda::get_call_spec)
       .def(
           "get_constant_names_to_original_fqns",
-          &AOTIModelContainerRunnerCpu::getConstantNamesToOriginalFQNs)
+          &AOTIModelContainerRunnerCuda::getConstantNamesToOriginalFQNs)
       .def(
           "get_constant_names_to_dtypes",
           &AOTIModelContainerRunnerCuda::getConstantNamesToDtypes);


### PR DESCRIPTION
Summary: Use CUDA if cuda's macro is set for AOTI runner's pybind

Test Plan: Existing tests (D52303882)

Differential Revision: D53557197


