### PR TITLE
[easy] Fix pass_manager type annotation

### DIFF
--- a/torch/fx/passes/pass_manager.py
+++ b/torch/fx/passes/pass_manager.py
@@ -218,7 +218,7 @@ class PassManager:
         self.constraints.append(constraint)
         self._validated = False
 
-    def remove_pass(self, _passes: List[Callable]):
+    def remove_pass(self, _passes: List[str]):
         if _passes is None:
             return
         passes_left = []


### PR DESCRIPTION
Summary: passes are str not callable here.

Test Plan: lint

Reviewed By: frank-wei

Differential Revision: D53592166


