### PR TITLE
[dtensor] fix missing tensor_meta in sharding prop

### DIFF
--- a/torch/distributed/_tensor/sharding_prop.py
+++ b/torch/distributed/_tensor/sharding_prop.py
@@ -231,6 +231,8 @@ class ShardingPropagator:
                         if output_strategy.input_specs is None
                         else output_strategy.input_specs[idx]
                     )
+                    if not desired_spec.tensor_meta:
+                        desired_spec.tensor_meta = input_spec.tensor_meta
                     expected_input_specs.append(desired_spec)
                     if input_spec.placements != desired_spec.placements:
                         needs_redistribute = True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #119509

This helps two things:
1. Better debugability when printing out op strategies.
2. When `needs_redistribute=True`, not fixing this would incur unnecessary `redistribute_local_tensor` calls.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @wconstab @yf225