### PR TITLE
Remove hard numpy dependency from experimental_ops.py

### DIFF
--- a/torch/distributed/_tensor/ops/experimental_ops.py
+++ b/torch/distributed/_tensor/ops/experimental_ops.py
@@ -2,7 +2,10 @@
 # implement matrix related ops for distributed tensor
 from typing import List
 
-import numpy as np
+try:
+    import numpy as np
+except ModuleNotFoundError:
+    np = None  # type: ignore[assignment]
 
 import torch
 from torch.distributed._tensor.op_schema import OpSchema, OutputSharding


### PR DESCRIPTION
Based on similar code in the codebase

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225