### PR TITLE
[BE] Use more GTest primitives in XPU unit tests

### DIFF
--- a/aten/src/ATen/test/xpu_device_test.cpp
+++ b/aten/src/ATen/test/xpu_device_test.cpp
@@ -4,14 +4,8 @@
 #include <ATen/xpu/XPUDevice.h>
 #include <torch/torch.h>
 
-#define ASSERT_EQ_XPU(X, Y) \
-  {                         \
-    bool _isEQ = X == Y;    \
-    ASSERT_TRUE(_isEQ);     \
-  }
-
 TEST(XpuDeviceTest, getDeviceProperties) {
-  ASSERT_EQ_XPU(at::xpu::is_available(), torch::xpu::is_available());
+  EXPECT_EQ(at::xpu::is_available(), torch::xpu::is_available());
   if (!at::xpu::is_available()) {
     return;
   }
@@ -19,9 +13,9 @@ TEST(XpuDeviceTest, getDeviceProperties) {
   c10::xpu::DeviceProp* cur_device_prop = at::xpu::getCurrentDeviceProperties();
   c10::xpu::DeviceProp* device_prop = at::xpu::getDeviceProperties(0);
 
-  ASSERT_EQ_XPU(cur_device_prop->name, device_prop->name);
-  ASSERT_EQ_XPU(cur_device_prop->platform_name, device_prop->platform_name);
-  ASSERT_EQ_XPU(cur_device_prop->gpu_eu_count, device_prop->gpu_eu_count);
+  EXPECT_EQ(cur_device_prop->name, device_prop->name);
+  EXPECT_EQ(cur_device_prop->platform_name, device_prop->platform_name);
+  EXPECT_EQ(cur_device_prop->gpu_eu_count, device_prop->gpu_eu_count);
 }
 
 TEST(XpuDeviceTest, getDeviceFromPtr) {
@@ -34,8 +28,8 @@ TEST(XpuDeviceTest, getDeviceFromPtr) {
 
   at::Device device = at::xpu::getDeviceFromPtr(ptr);
   sycl::free(ptr, at::xpu::get_device_context());
-  ASSERT_EQ_XPU(device.index(), 0);
-  ASSERT_EQ_XPU(device.type(), at::kXPU);
+  EXPECT_EQ(device.index(), 0);
+  EXPECT_EQ(device.type(), at::kXPU);
 
   int dummy = 0;
   ASSERT_THROW(at::xpu::getDeviceFromPtr(&dummy), c10::Error);
@@ -49,13 +43,13 @@ TEST(XpuDeviceTest, getGlobalIdxFromDevice) {
   int target_device = 0;
   auto global_index = at::xpu::getGlobalIdxFromDevice(target_device);
   auto devices = sycl::device::get_devices();
-  ASSERT_EQ_XPU(devices[global_index], at::xpu::get_raw_device(target_device));
+  EXPECT_EQ(devices[global_index], at::xpu::get_raw_device(target_device));
 
   void* ptr = sycl::malloc_device(8, devices[global_index], at::xpu::get_device_context());
   at::Device device = at::xpu::getDeviceFromPtr(ptr);
   sycl::free(ptr, at::xpu::get_device_context());
-  ASSERT_EQ_XPU(device.index(), target_device);
-  ASSERT_EQ_XPU(device.type(), at::kXPU);
+  EXPECT_EQ(device.index(), target_device);
+  EXPECT_EQ(device.type(), at::kXPU);
 
   if (at::xpu::device_count() == 1) {
     return;
@@ -63,7 +57,7 @@ TEST(XpuDeviceTest, getGlobalIdxFromDevice) {
   // Test the last device.
   target_device = at::xpu::device_count() - 1;
   global_index = at::xpu::getGlobalIdxFromDevice(target_device);
-  ASSERT_EQ_XPU(devices[global_index], at::xpu::get_raw_device(target_device));
+  EXPECT_EQ(devices[global_index], at::xpu::get_raw_device(target_device));
 
   target_device = at::xpu::device_count();
   ASSERT_THROW(at::xpu::getGlobalIdxFromDevice(target_device), c10::Error);

--- a/c10/xpu/test/impl/XPUDeviceTest.cpp
+++ b/c10/xpu/test/impl/XPUDeviceTest.cpp
@@ -2,12 +2,6 @@
 
 #include <c10/xpu/XPUFunctions.h>
 
-#define ASSERT_EQ_XPU(X, Y) \
-  {                         \
-    bool _isEQ = X == Y;    \
-    ASSERT_TRUE(_isEQ);     \
-  }
-
 bool has_xpu() {
   return c10::xpu::device_count() > 0;
 }
@@ -18,16 +12,16 @@ TEST(XPUDeviceTest, DeviceBehavior) {
   }
 
   c10::xpu::set_device(0);
-  ASSERT_EQ_XPU(c10::xpu::current_device(), 0);
+  EXPECT_EQ(c10::xpu::current_device(), 0);
 
   if (c10::xpu::device_count() <= 1) {
     return;
   }
 
   c10::xpu::set_device(1);
-  ASSERT_EQ_XPU(c10::xpu::current_device(), 1);
-  ASSERT_EQ_XPU(c10::xpu::exchange_device(0), 1);
-  ASSERT_EQ_XPU(c10::xpu::current_device(), 0);
+  EXPECT_EQ(c10::xpu::current_device(), 1);
+  EXPECT_EQ(c10::xpu::exchange_device(0), 1);
+  EXPECT_EQ(c10::xpu::current_device(), 0);
 }
 
 TEST(XPUDeviceTest, DeviceProperties) {
@@ -38,8 +32,8 @@ TEST(XPUDeviceTest, DeviceProperties) {
   c10::xpu::DeviceProp device_prop{};
   c10::xpu::get_device_properties(&device_prop, 0);
 
-  ASSERT_TRUE(device_prop.max_compute_units > 0);
-  ASSERT_TRUE(device_prop.gpu_eu_count > 0);
+  EXPECT_TRUE(device_prop.max_compute_units > 0);
+  EXPECT_TRUE(device_prop.gpu_eu_count > 0);
 }
 
 TEST(XPUDeviceTest, PointerGetDevice) {
@@ -51,7 +45,7 @@ TEST(XPUDeviceTest, PointerGetDevice) {
   void* ptr =
       sycl::malloc_device(8, raw_device, c10::xpu::get_device_context());
 
-  ASSERT_EQ_XPU(c10::xpu::get_device_idx_from_pointer(ptr), 0);
+  EXPECT_EQ(c10::xpu::get_device_idx_from_pointer(ptr), 0);
   sycl::free(ptr, c10::xpu::get_device_context());
 
   int dummy = 0;


### PR DESCRIPTION
# Motivation
Use `EXPECT_EQ` to refine XPU's UT when relying on gtest.

# Solution
use `EXPECT_EQ` directly instead of `ASSERT_EQ_XPU`


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10