### PR TITLE
Remove unneeded linking of torch_shm_manager in CMake

### DIFF
--- a/torch/lib/libshm/CMakeLists.txt
+++ b/torch/lib/libshm/CMakeLists.txt
@@ -7,13 +7,6 @@ if(NOT LIBSHM_INSTALL_LIB_SUBDIR)
   set(LIBSHM_INSTALL_LIB_SUBDIR "lib" CACHE PATH "libshm install library directory")
 endif()
 
-# Flags
-# When using MSVC
-if(MSVC)
-  # we want to respect the standard, and we are bored of those **** .
-  add_definitions(-D_CRT_SECURE_NO_DEPRECATE=1)
-endif(MSVC)
-
 add_library(shm SHARED core.cpp)
 if(HAVE_SOVERSION)
   set_target_properties(shm PROPERTIES
@@ -29,7 +22,7 @@ set_target_properties(shm PROPERTIES
   PREFIX "lib"
   IMPORT_PREFIX "lib"
   CXX_STANDARD 17)
-target_link_libraries(shm PUBLIC torch)
+target_link_libraries(shm PRIVATE torch_cpu)
 
 if(UNIX AND NOT APPLE)
   include(CheckLibraryExists)
@@ -67,7 +60,7 @@ if(UNIX AND NOT APPLE)
 endif()
 
 add_executable(torch_shm_manager manager.cpp)
-target_link_libraries(torch_shm_manager PRIVATE shm)
+target_link_libraries(torch_shm_manager PRIVATE shm c10)
 set_target_properties(torch_shm_manager PROPERTIES
   INSTALL_RPATH "${_rpath_portable_origin}/../lib")
 


### PR DESCRIPTION
This PR aims to clean up torch_shm_manager dependency in CMake.