### PR TITLE
[FSDP2] Replaced version-ctx with `no_grad`; removed `no_grad`

### DIFF
--- a/torch/distributed/_composable/fsdp/_fsdp_param.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_param.py
@@ -238,7 +238,6 @@ class FSDPParam:
             all_gather_output_size, dtype=dtype, device=device
         )
 
-    @torch.no_grad()
     def init_unsharded_param(self):
         if hasattr(self, "_unsharded_param"):
             return  # already initialized


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #119551
* #119378
* #119302
* #118298
* #118755
* #118223
* #118136
* __->__ #119550

This PR replaces the `_unsafe_preserve_version_counters` context with a simple `torch.no_grad()` context instead. This decreases CPU overhead from (1 context enter/exit + `N` loop over tensors) with just (1 context enter/exit).

This PR also removes a `torch.no_grad()` from `init_unsharded_param` as it helps compiling but does not affect eager.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225