### PR TITLE
Migrate rocm test to using oidc (#117160)

### DIFF
--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -42,6 +42,10 @@ on:
 env:
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   test:
     # Don't run on forked repos or empty test matrix
@@ -60,6 +64,17 @@ jobs:
 
       - name: Setup ROCm
         uses: ./.github/actions/setup-rocm
+
+      - name: configure aws credentials
+        id: aws_creds
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Calculate docker image
         id: calculate-docker-image

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -235,6 +235,9 @@ jobs:
         ]}
 
   linux-focal-rocm5_7-py3_8-test:
+    permissions:
+      id-token: write
+      contents: read
     name: linux-focal-rocm5.7-py3.8
     uses: ./.github/workflows/_rocm-test.yml
     needs: linux-focal-rocm5_7-py3_8-build

--- a/.github/workflows/rocm.yml
+++ b/.github/workflows/rocm.yml
@@ -31,6 +31,9 @@ jobs:
         ]}
 
   linux-focal-rocm5_7-py3_8-test:
+    permissions:
+      id-token: write
+      contents: read
     name: linux-focal-rocm5.7-py3.8
     uses: ./.github/workflows/_rocm-test.yml
     needs: linux-focal-rocm5_7-py3_8-build

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -98,6 +98,9 @@ jobs:
         ]}
 
   linux-focal-rocm5_6-py3_8-test:
+    permissions:
+      id-token: write
+      contents: read
     name: linux-focal-rocm5.6-py3.8
     uses: ./.github/workflows/_rocm-test.yml
     needs: linux-focal-rocm5_6-py3_8-build

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -188,6 +188,9 @@ jobs:
         ]}
 
   linux-focal-rocm5_7-py3_8-test:
+    permissions:
+      id-token: write
+      contents: read
     name: linux-focal-rocm5.7-py3.8
     uses: ./.github/workflows/_rocm-test.yml
     needs: linux-focal-rocm5_7-py3_8-build


### PR DESCRIPTION
Similar to Intel XPU, lets use OIDC for rocm runners.

Refer to this PR: #116554

Pull Request resolved: #117160
Approved by: https://github.com/huydhn, https://github.com/malfetFixes #ISSUE_NUMBER


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang