### PR TITLE
[DCP][state_dict] Fix the issue that get_state_dict/set_state_dict ignore the buffer

### DIFF
--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -201,7 +201,7 @@ def _verify_options(
         Union[str, torch.Tensor], Union[Set[str], torch.Tensor]
     ] = {}
     all_fqns = set()
-    for name, param in model.named_parameters():
+    for name, param in chain(model.named_parameters(), model.named_buffers()):
         fqns = _get_fqns(model, name)
         fqn_param_mapping[param] = fqns
         for fqn in fqns:
@@ -402,7 +402,7 @@ def _load_model_state_dict(
     if not info.handle_model or not state_dict:
         return _IncompatibleKeys({}, {})
 
-    for key, _ in model.named_parameters():
+    for key, _ in chain(model.named_parameters(), model.named_buffers()):
         fqns = _get_fqns(model, key)
         fqns_with_ddp_prefix = _get_fqns(model, key, skip_ddp_prefix=False)
         for fqn, fqn_with_ddp_prefix in zip(fqns, fqns_with_ddp_prefix):

--- a/torch/testing/_internal/common_dist_composable.py
+++ b/torch/testing/_internal/common_dist_composable.py
@@ -57,6 +57,9 @@ class CompositeParamModel(nn.Module):
         self.u1 = UnitModule(device)
         self.u2 = UnitModule(device)
         self.p = nn.Parameter(torch.randn((100, 100), device=device))
+        self.register_buffer(
+            "buffer", torch.randn((100, 100), device=device), persistent=True
+        )
 
     def forward(self, x):
         a = self.u2(self.u1(self.l(x)))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #119573

get_state_dict and set_state_dict currently do not appropriately handle the
buffers. This PR fixes thie issue.

Fixes, https://github.com/pytorch/pytorch/issues/119535.

Differential Revision: [D53616762](https://our.internmc.facebook.com/intern/diff/D53616762/)

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @LucasLLC