### PR TITLE
[fix] tmp fix for import issue in dtensor

### DIFF
--- a/torch/distributed/_tensor/ops/math_ops.py
+++ b/torch/distributed/_tensor/ops/math_ops.py
@@ -1,10 +1,10 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
+from enum import Enum
 from typing import cast, List, Optional, Sequence, Tuple
 
 import torch
 
 import torch.distributed.distributed_c10d as c10d
-from torch._decomp.decompositions import Reduction
 from torch.distributed._tensor.op_schema import (
     OpSchema,
     OpStrategy,
@@ -31,6 +31,12 @@ from torch.distributed.device_mesh import DeviceMesh
 
 
 aten = torch.ops.aten
+
+
+class Reduction(Enum):
+    NONE = 0
+    MEAN = 1
+    SUM = 2
 
 
 def _infer_reduction_dims(dims_arg: object, ndim: int) -> Optional[List[int]]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #119582

a temporary fix for S394053 which is likely caused by backward incompatible `import` introduced in D53437243. It's yet to be understood why this may cause an issue but let's forward "fix" it first then draft a follow up diff for a right fix.

Differential Revision: [D53621345](https://our.internmc.facebook.com/intern/diff/D53621345/)

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225