### PR TITLE
be more consrevative until regression is debugged

### DIFF
--- a/test/inductor/test_perf.py
+++ b/test/inductor/test_perf.py
@@ -246,7 +246,7 @@ class NumBytesMetricTests(TestCase):
             return torch.cat(input) + 10
 
         inp = (T(10, 10) for _ in range(16))
-        self.assertExpectedInline(count_numel(f, *inp), """3200""")
+        self.assertExpectedInline(count_numel(f, *inp), """9600""")
 
     @patch.object(config, "max_pointwise_cat_inputs", 0)
     def test_cat_pointwise_config_option(self):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -276,7 +276,7 @@ enabled_metric_tables = os.environ.get("TORCHINDUCTOR_ENABLED_METRIC_TABLES", ""
 max_fusion_size = 64
 
 # max number of inputs to generate cat as a pointwise op with masked laods
-max_pointwise_cat_inputs = 128
+max_pointwise_cat_inputs = 8
 
 # replace small reductions with pointwise, disable with `= 1`
 unroll_reductions_threshold = 8


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #119583

See, internal regression: https://www.internalfb.com/diff/D53375778?transaction_fbid=953511712782168

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler

Differential Revision: [D53672997](https://our.internmc.facebook.com/intern/diff/D53672997)