### PR TITLE
Fixes #105077 alternative 2

### DIFF
--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -1456,6 +1456,41 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             model_type=self.model_type,
         )
 
+    @pytorch_test_common.skip_dynamic_fx_test(
+        reason="Dynamic shape check is not expected for exported program in this test suite.",
+        model_type=pytorch_test_common.TorchModelType.TORCH_EXPORT_EXPORTEDPROGRAM,
+    )
+    @pytorch_test_common.xfail_if_model_type_is_not_exportedprogram(
+        error_message="Expected 4 inputs, got 2",
+        reason="https://github.com/pytorch/pytorch/issues/115745",
+    )
+    def test_fake_tensor_mode_huggingface_tiny_gpt2_torch_load(self):
+        model_name = "sshleifer/tiny-gpt2"
+        device = "cpu"
+
+        def create_model():
+            return transformers.AutoModel.from_pretrained(model_name).to(device).eval()
+
+        def create_args():
+            tokenizer = transformers.AutoTokenizer.from_pretrained(model_name)
+            kwargs = tokenizer("Hello world!", return_tensors="pt")
+            input_ids = kwargs["input_ids"]
+            attention_mask = kwargs["attention_mask"]
+            return input_ids, None, attention_mask
+
+        def create_pytorch_only_extra_kwargs():
+            return {"return_dict": False}
+
+        self._test_fake_tensor_mode_exporter(
+            "huggingface_sshleifer_tiny-gpt2",
+            create_model,
+            create_args,
+            create_pytorch_only_extra_kwargs,
+            load_checkpoint_during_init=self.load_checkpoint_during_init,
+            export_within_fake_mode=self.export_within_fake_mode,
+            model_type=self.model_type,
+        )
+
 
 if __name__ == "__main__":
     common_utils.run_tests()

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -2,7 +2,7 @@
 
 from torch.testing._internal.common_utils import (
     TestCase, TEST_WITH_TORCHDYNAMO, run_tests, skipIfCrossRef, skipIfRocm, skipIfTorchDynamo, parametrize,
-    instantiate_parametrized_tests)
+    instantiate_parametrized_tests, TemporaryFileName)
 import torch
 import torch._dynamo
 import itertools
@@ -1287,7 +1287,6 @@ class FakeTensorPropTest(TestCase):
             FakeTensorProp(graph_model, fake_mode).propagate(value, None, another_optional_value)
 
     def test_torch_load_with_fake_mode(self):
-        import tempfile
 
         class TheModelClass(torch.nn.Module):
             def __init__(self):
@@ -1297,15 +1296,15 @@ class FakeTensorPropTest(TestCase):
             def forward(self, x):
                 return self.fc1(x)
 
-        with tempfile.NamedTemporaryFile() as state_dict_file:
+        with TemporaryFileName() as state_dict_file:
             # Create state_dict to be loaded later
             model = TheModelClass()
-            torch.save(model.state_dict(), state_dict_file.name)
+            torch.save(model.state_dict(), state_dict_file)
 
             fake_mode = FakeTensorMode()
             with fake_mode:
                 # This is where the bug is triggered
-                torch.load(state_dict_file.name)
+                torch.load(state_dict_file)
 
 
 class FakeTensorDispatchCache(TestCase):

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1303,8 +1303,8 @@ class FakeTensorPropTest(TestCase):
 
             fake_mode = FakeTensorMode()
             with fake_mode:
-                # This is where the bug is triggered
-                torch.load(state_dict_file)
+                torch.load(state_dict_file)  # scenario 1
+                torch.load(state_dict_file, map_location="cpu")  # scenario 2
 
 
 class FakeTensorDispatchCache(TestCase):

--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -132,3 +132,4 @@ register_artifact(
 )
 
 register_artifact("custom_format_test_artifact", "Testing only", log_format="")
+register_artifact("not_implemented", "Logs dispatches not implemented by Fake Tensor")

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -177,12 +177,7 @@ def _get_async_or_non_blocking(function_name, non_blocking, kwargs):
 # be a TypedStorage
 def _rebuild_tensor(storage, storage_offset, size, stride):
     # first construct a tensor with the correct dtype/device
-    if torch._guards.detect_fake_mode(None) is not None:
-        t = torch.empty((), dtype=storage.dtype, device=storage._untyped_storage.device)
-    else:
-        t = torch.tensor(
-            [], dtype=storage.dtype, device=storage._untyped_storage.device
-        )
+    t = torch.empty((), dtype=storage.dtype, device=storage._untyped_storage.device)
     return t.set_(storage._untyped_storage, storage_offset, size, stride)
 
 

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -177,7 +177,12 @@ def _get_async_or_non_blocking(function_name, non_blocking, kwargs):
 # be a TypedStorage
 def _rebuild_tensor(storage, storage_offset, size, stride):
     # first construct a tensor with the correct dtype/device
-    t = torch.tensor([], dtype=storage.dtype, device=storage._untyped_storage.device)
+    if torch._guards.detect_fake_mode(None) is not None:
+        t = torch.empty((), dtype=storage.dtype, device=storage._untyped_storage.device)
+    else:
+        t = torch.tensor(
+            [], dtype=storage.dtype, device=storage._untyped_storage.device
+        )
     return t.set_(storage._untyped_storage, storage_offset, size, stride)
 
 

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -221,8 +221,8 @@ def _rebuild_tensor_v3(
     dtype,
     metadata=None,
 ):
-    t = torch.tensor(
-        [],
+    t = torch.empty(
+        (),
         dtype=dtype,
         device=storage._untyped_storage.device,
         requires_grad=requires_grad,

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -1395,6 +1395,9 @@ def _load(zip_file, map_location, pickle_module, pickle_file='data.pkl', overall
         assert typename == 'storage', \
             f"Unknown typename for persistent_load, expected 'storage' but got '{typename}'"
         storage_type, key, location, numel = data
+        if torch._guards.detect_fake_mode(None) is not None:
+            location = 'meta'
+
         if storage_type is torch.UntypedStorage:
             dtype = torch.uint8
         else:

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -1330,6 +1330,8 @@ class StorageType:
 
 
 def _load(zip_file, map_location, pickle_module, pickle_file='data.pkl', overall_storage=None, **pickle_load_args):
+    if torch._guards.detect_fake_mode(None) is not None:
+        map_location = None
     restore_location = _get_restore_location(map_location)
 
     loaded_storages = {}


### PR DESCRIPTION
Fixes #105077 

Repro
```python
from torch._subclasses import fake_tensor
import transformers

fake_mode = fake_tensor.FakeTensorMode(allow_non_fake_inputs=False)
with fake_mode:
    fake_model = transformers.AutoModel.from_pretrained("sshleifer/tiny-gpt2") 
```

Error:

```bash
Traceback (most recent call last):
  File "/opt/conda/envs/ptca/lib/python3.11/site-packages/transformers/modeling_utils.py", line 519, in load_state_dict
    return torch.load(checkpoint_file, map_location=map_location)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/torch/serialization.py", line 1041, in load
    return _legacy_load(opened_file, map_location, pickle_module, **pickle_load_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/torch/serialization.py", line 1283, in _legacy_load
    typed_storage._untyped_storage._set_from_file(
  File "/opt/pytorch/torch/utils/_stats.py", line 20, in wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/torch/_subclasses/fake_tensor.py", line 871, in __torch_dispatch__
    return self.dispatch(func, types, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/torch/_subclasses/fake_tensor.py", line 1207, in dispatch
    return self._cached_dispatch_impl(func, types, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/torch/_subclasses/fake_tensor.py", line 949, in _cached_dispatch_impl
    output = self._dispatch_impl(func, types, args, kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/torch/_subclasses/fake_tensor.py", line 1284, in _dispatch_impl
    (flat_args, flat_arg_fake_tensors) = self.validate_and_convert_non_fake_tensors(
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/torch/_subclasses/fake_tensor.py", line 1515, in validate_and_convert_non_fake_tensors
    validated_args = [validate(a) for a in flat_args]
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/torch/_subclasses/fake_tensor.py", line 1515, in <listcomp>
    validated_args = [validate(a) for a in flat_args]
                      ^^^^^^^^^^^
  File "/opt/pytorch/torch/_subclasses/fake_tensor.py", line 1505, in validate
    raise Exception(
Exception: Please convert all Tensors to FakeTensors first or instantiate FakeTensorMode with 'allow_non_fake_inputs'. Found in aten.copy_.default(tensor(..., device='meta', size=(8192,), dtype=torch.uint8), tensor([...], size=(8192,), dtype=torch.uint8))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/conda/envs/ptca/lib/python3.11/site-packages/transformers/modeling_utils.py", line 523, in load_state_dict
    if f.read(7) == "version":
       ^^^^^^^^^
  File "<frozen codecs>", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 0: invalid start byte

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/pytorch/gh105077.py", line 8, in <module>
    fake_model = transformers.AutoModel.from_pretrained("sshleifer/tiny-gpt2")  # raises OSError: Unable to load weights from pytorch checkpoint file for '...' at  If you tried to load a PyTorch model from a TF 2.0 checkpoint, please set from_tf=True.
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/ptca/lib/python3.11/site-packages/transformers/models/auto/auto_factory.py", line 566, in from_pretrained
    return model_class.from_pretrained(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/ptca/lib/python3.11/site-packages/transformers/modeling_utils.py", line 3381, in from_pretrained
    state_dict = load_state_dict(resolved_archive_file)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/ptca/lib/python3.11/site-packages/transformers/modeling_utils.py", line 535, in load_state_dict
    raise OSError(
OSError: Unable to load weights from pytorch checkpoint file for '/root/.cache/huggingface/hub/models--sshleifer--tiny-gpt2/snapshots/5f91d94bd9cd7190a9f3216ff93cd1dd95f2c7be/pytorch_model.bin' at '/root/.cache/huggingface/hub/models--sshleifer--tiny-gpt2/snapshots/5f91d94bd9cd7190a9f3216ff93cd1dd95f2c7be/pytorch_model.bin'. If you tried to load a PyTorch model from a TF 2.0 checkpoint, please set from_tf=True.
```

cc @eellison