### PR TITLE
[Inductor Cutlass backend] Development feature flag

### DIFF
--- a/torch/_inductor/codegen/cuda/cutlass_utils.py
+++ b/torch/_inductor/codegen/cuda/cutlass_utils.py
@@ -16,6 +16,9 @@ from .cuda_env import get_cuda_arch, get_cuda_version
 
 log = logging.getLogger(__name__)
 
+# This is a feature flag. If _DISABLE_CUTLASS_BACKEND is set to true,
+# then the CUDA / CUTLASS backend is entirely disabled, including it's unit tests
+_DISABLE_CUTLASS_BACKEND = False
 
 def _rename_cutlass_import(content: str, cutlass_modules: List[str]) -> str:
     for cutlass_module in cutlass_modules:

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -187,10 +187,14 @@ class GraphLowering(torch.fx.Interpreter):
             register_backend_for_device("cpu", CppScheduling, WrapperCodeGen)
 
         if get_scheduling_for_device("cuda") is None:
-            from .codegen.cuda_combined_scheduling import CUDACombinedScheduling
-
-            # CUDACombinedScheduling combines Triton and CUDA C++ scheduling for CUDA devices via delegation
-            register_backend_for_device("cuda", CUDACombinedScheduling, WrapperCodeGen)
+            from .codegen.cuda.cutlass_utils import _DISABLE_CUTLASS_BACKEND
+            if not _DISABLE_CUTLASS_BACKEND:
+                from .codegen.cuda_combined_scheduling import CUDACombinedScheduling
+                # CUDACombinedScheduling combines Triton and CUDA C++ scheduling for CUDA devices via delegation
+                register_backend_for_device("cuda", CUDACombinedScheduling, WrapperCodeGen)
+            else:
+                from .codegen.triton import TritonScheduling
+                register_backend_for_device("cuda", TritonScheduling, WrapperCodeGen)
 
     def __init__(
         self,

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -883,7 +883,9 @@ def use_triton_template(layout, *, enable_int32=False):
 
 
 def use_cutlass_template(layout):
-    from .codegen.cuda.cutlass_utils import try_import_cutlass
+    from .codegen.cuda.cutlass_utils import try_import_cutlass, _DISABLE_CUTLASS_BACKEND
+    if _DISABLE_CUTLASS_BACKEND:
+        return False
 
     # Do not use cutlass template on ROCm
     if torch.version.hip:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Introducing a feature flag for development purposes, which allows
to disable the CUTLASS backend entirely.

This flag is not intended to be used by users, it is for development
purposes to ensure a working codebase when features are incrementally
added over the course of multiple commits / PRs and it cannot
be ensured that the cutlass backend is functional in-between
incremental commits.

To disable the cutlass backend, set the private variable
cutlass_utils._DISABLE_CUTLASS_BACKEND to True

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @muchulee8 @aakhundov @ColinPeppler