### PR TITLE
Use CUDA if cuda's macro is set for AOTI runner's pybind

### DIFF
--- a/torch/csrc/inductor/aoti_runner/pybind.cpp
+++ b/torch/csrc/inductor/aoti_runner/pybind.cpp
@@ -35,7 +35,7 @@ void initAOTIRunnerBindings(PyObject* module) {
       .def("get_call_spec", &AOTIModelContainerRunnerCuda::get_call_spec)
       .def(
           "get_constant_names_to_original_fqns",
-          &AOTIModelContainerRunnerCpu::getConstantNamesToOriginalFQNs)
+          &AOTIModelContainerRunnerCuda::getConstantNamesToOriginalFQNs)
       .def(
           "get_constant_names_to_dtypes",
           &AOTIModelContainerRunnerCuda::getConstantNamesToDtypes);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #119616

Summary:
Use CUDA if cuda's macro is set for AOTI runner's pybind
This is a duplicate of #119438 for landing issues

Test Plan:
Existing tests (D52303882)

Reviewers:

Subscribers:

Tasks:

Tags: