### PR TITLE
[inductor] Use list comprehension to initialize unused_views.

### DIFF
--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -156,10 +156,7 @@ def remove_redundant_views(gm: torch.fx.GraphModule):
 
     # Clean up unused views.
     while True:
-        unused_views = []
-        for alias in views:
-            if not alias.users:
-                unused_views.append(alias)
+        unused_views = [alias for alias in views if not alias.users]
         if len(unused_views) == 0:
             break
         for unused in unused_views:


### PR DESCRIPTION
It's more idiomatic and efficient.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler