### PR TITLE
Increased compile time max GPUs to 512. Switched to int16_t DeviceIndex.

### DIFF
--- a/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h
+++ b/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h
@@ -74,6 +74,7 @@ namespace impl {
   // Additionally, we support lists, dicts and optionals containing these types.
   using supported_primitive_arg_types = guts::typelist::typelist<
     int64_t,
+    int8_t, // For backwards compatibility, because DeviceIndex is now int16_t
     double,
     bool,
     c10::string_view,

--- a/aten/src/ATen/core/op_registration/infer_schema.h
+++ b/aten/src/ATen/core/op_registration/infer_schema.h
@@ -37,8 +37,8 @@ constexpr int checkStaticTypes() {
  // Give nice error messages for some of the common error cases.
  // Use a LOUD ERROR MESSAGE SO USERS SEE THE STATIC_ASSERT
  static_assert(std::conjunction<
-     bool_t<!std::is_integral<Types>::value || std::is_same<Types, int16_t>::value || std::is_same<Types, int64_t>::value || std::is_same<Types, bool>::value>...
-   >::value, "INVALID TYPE: Only int16_t, int64_t and bool are supported as an integral argument type");
+     bool_t<!std::is_integral<Types>::value || std::is_same<Types, int8_t>::value || std::is_same<Types, int16_t>::value || std::is_same<Types, int64_t>::value || std::is_same<Types, bool>::value>...
+   >::value, "INVALID TYPE: Only int8_t, int16_t, int64_t and bool are supported as an integral argument type");
  static_assert(std::conjunction<
      bool_t<!std::is_same<Types, float>::value>...
    >::value, "INVALID TYPE: float is not supported as an argument type, use double instead");

--- a/aten/src/ATen/core/op_registration/infer_schema.h
+++ b/aten/src/ATen/core/op_registration/infer_schema.h
@@ -37,8 +37,8 @@ constexpr int checkStaticTypes() {
  // Give nice error messages for some of the common error cases.
  // Use a LOUD ERROR MESSAGE SO USERS SEE THE STATIC_ASSERT
  static_assert(std::conjunction<
-     bool_t<!std::is_integral<Types>::value || std::is_same<Types, int8_t>::value || std::is_same<Types, int64_t>::value || std::is_same<Types, bool>::value>...
-   >::value, "INVALID TYPE: Only int8_t, int64_t and bool are supported as an integral argument type");
+     bool_t<!std::is_integral<Types>::value || std::is_same<Types, int16_t>::value || std::is_same<Types, int64_t>::value || std::is_same<Types, bool>::value>...
+   >::value, "INVALID TYPE: Only int16_t, int64_t and bool are supported as an integral argument type");
  static_assert(std::conjunction<
      bool_t<!std::is_same<Types, float>::value>...
    >::value, "INVALID TYPE: float is not supported as an argument type, use double instead");

--- a/aten/src/ATen/cuda/jiterator.cu
+++ b/aten/src/ATen/cuda/jiterator.cu
@@ -43,8 +43,7 @@ static inline void launch_jitted_vectorized_kernel_dynamic(
   ss << static_cast<int>(at::cuda::jit::BinaryFuncVariant::NoScalar);
   ss << extra_args_types;
   ss << vec_size;
-// DeviceIndex, e.g. int8_t, is not treated as a number by the stream, cast to int as a workaround
-  ss << static_cast<int>(dev_idx);
+  ss << dev_idx;
   const std::string cache_key = ss.str();
 
   static std::mutex _jiterator_mutex;

--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -261,10 +261,17 @@ using IndicesT = std::vector<size_t>;
 using nested_optional_tensorvec_t =
     std::vector<std::vector<std::optional<at::Tensor>>>;
 using TensorsAndIndicesT = std::pair<nested_optional_tensorvec_t, IndicesT>;
-using FlatMap = std::unordered_map<
-    DeviceDtypeKey,
-    TensorsAndIndicesT,
-    ParamsHash<DeviceDtypeKey>>;
+
+// Warning: Do not use ParamsHash for keys with potentially uninitialized
+// padding bytes!
+struct _DeviceDtypeHasher {
+  std::size_t operator()(const DeviceDtypeKey& k) const noexcept {
+    return std::hash<at::Device>{}(k.first) ^
+        std::hash<at::ScalarType>{}(k.second);
+  }
+};
+using FlatMap =
+    std::unordered_map<DeviceDtypeKey, TensorsAndIndicesT, _DeviceDtypeHasher>;
 
 inline FlatMap _group_tensors_by_first_tensors_device_and_dtype(
     const nested_optional_tensorvec_t& nested_tensorlist,

--- a/aten/src/ATen/native/utils/ParamsHash.h
+++ b/aten/src/ATen/native/utils/ParamsHash.h
@@ -10,6 +10,8 @@ namespace at::native {
 // Fowler–Noll–Vo hash function
 // see
 // https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+// WARNING: This hash function will produce unexpected results for `Params` with uninitialized padding values, as the
+// padding is also part of the hash. Use with caution.
 template <typename Params>
 struct ParamsHash {
   // Params must be a POD because we read out its memory

--- a/c10/core/Device.cpp
+++ b/c10/core/Device.cpp
@@ -125,19 +125,29 @@ Device::Device(const std::string& device_string) : Device(Type::CPU) {
 
   TORCH_CHECK(!has_error, "Invalid device string: '", device_string, "'");
 
-  try {
-    if (!device_index_str.empty()) {
-      index_ = static_cast<c10::DeviceIndex>(std::stoi(device_index_str));
+  if (!device_index_str.empty()) {
+    // If the user passed an index in the device string, check if it is a valid
+    // int between 0 and c10::Device::MAX_NUM_DEVICES - 1 inclusively
+    int full_index = -1;
+    try {
+      full_index = std::stoi(device_index_str);
+    } catch (const std::exception&) {
+      TORCH_CHECK(
+          false,
+          "Could not parse device index '",
+          device_index_str,
+          "' in device string '",
+          device_string,
+          "'");
     }
-  } catch (const std::exception&) {
     TORCH_CHECK(
-        false,
-        "Could not parse device index '",
-        device_index_str,
-        "' in device string '",
-        device_string,
-        "'");
+        0 <= full_index && full_index < c10::Device::MAX_NUM_DEVICES,
+        "Device index must be between 0 and ",
+        c10::Device::MAX_NUM_DEVICES - 1,
+        " inclusively.");
+    index_ = static_cast<c10::DeviceIndex>(full_index);
   }
+
   type_ = parse_type(device_name);
   validate();
 }

--- a/c10/core/Device.h
+++ b/c10/core/Device.h
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <functional>
 #include <iosfwd>
-#include <limits>
 #include <string>
 
 namespace c10 {

--- a/c10/core/Device.h
+++ b/c10/core/Device.h
@@ -34,12 +34,7 @@ struct C10_API Device final {
   /// our DeviceIndex is a int16_t. Note that this does not include the default
   /// device index -1, but instead defines the range from 0 to MAX_NUM_DEVICES-1
   /// inclusively.
-#ifdef FBCODE_CAFFE2
-  // fbcode depends on this value being 16
-  static constexpr DeviceIndex MAX_NUM_DEVICES = 16;
-#else
   static constexpr DeviceIndex MAX_NUM_DEVICES = 512;
-#endif
 
   using Type = DeviceType;
 

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -3190,7 +3190,7 @@ class C10_TensorImpl_Size_Check_Dummy_Class : private TensorImpl {
 #if UINTPTR_MAX == 0xFFFFFFFF
   // This is a 32-bit system
   static constexpr bool check_sizes() {
-    constexpr size_t tsize = 20 * sizeof(int64_t);
+    constexpr size_t tsize = 21 * sizeof(int64_t);
 
     // clang-format off
     are_equal<sizeof(storage_),            4,  FieldNameEnum::storage_>();
@@ -3202,7 +3202,7 @@ class C10_TensorImpl_Size_Check_Dummy_Class : private TensorImpl {
     are_equal<sizeof(storage_offset_),     8,  FieldNameEnum::storage_offset_>();
     are_equal<sizeof(numel_),              8,  FieldNameEnum::numel_>();
     are_equal<sizeof(data_type_),          2,  FieldNameEnum::data_type_>();
-    are_equal<sizeof(device_opt_),         3,  FieldNameEnum::device_opt_>();
+    are_equal<sizeof(device_opt_),         6,  FieldNameEnum::device_opt_>();
     are_equal<sizeof(key_set_),            8,  FieldNameEnum::key_set_>();
     is_le<sizeof(TensorImpl),          tsize,  FieldNameEnum::TOTAL_SIZE>();
     // clang-format on
@@ -3227,7 +3227,7 @@ class C10_TensorImpl_Size_Check_Dummy_Class : private TensorImpl {
     are_equal<sizeof(storage_offset_),     8,  FieldNameEnum::storage_offset_>();
     are_equal<sizeof(numel_),              8,  FieldNameEnum::numel_>();
     are_equal<sizeof(data_type_),          2,  FieldNameEnum::data_type_>();
-    are_equal<sizeof(device_opt_),         3,  FieldNameEnum::device_opt_>();
+    are_equal<sizeof(device_opt_),         6,  FieldNameEnum::device_opt_>();
     are_equal<sizeof(key_set_),            8,  FieldNameEnum::key_set_>();
     is_le<sizeof(TensorImpl),          tsize,  FieldNameEnum::TOTAL_SIZE>();
     // clang-format on

--- a/c10/cuda/CUDAFunctions.cpp
+++ b/c10/cuda/CUDAFunctions.cpp
@@ -99,7 +99,7 @@ DeviceIndex device_count() noexcept {
     try {
       auto result = device_count_impl(/*fail_if_no_driver=*/false);
       TORCH_INTERNAL_ASSERT(
-          result <= std::numeric_limits<DeviceIndex>::max(),
+          result <= c10::Device::MAX_NUM_DEVICES,
           "Too many CUDA devices, DeviceIndex overflowed");
       return result;
     } catch (const c10::Error& ex) {
@@ -118,7 +118,7 @@ DeviceIndex device_count_ensure_non_zero() {
   // Zero gpus doesn't produce a warning in `device_count` but we fail here
   TORCH_CHECK(count, "No CUDA GPUs are available");
   TORCH_INTERNAL_ASSERT(
-      count <= std::numeric_limits<DeviceIndex>::max(),
+      count <= c10::Device::MAX_NUM_DEVICES,
       "Too many CUDA devices, DeviceIndex overflowed");
   return static_cast<DeviceIndex>(count);
 }
@@ -219,8 +219,7 @@ cudaError_t GetDevice(DeviceIndex* device) {
   auto err = cudaGetDevice(&tmp_device);
   if (err == cudaSuccess) {
     TORCH_INTERNAL_ASSERT(
-        tmp_device >= 0 &&
-            tmp_device <= std::numeric_limits<DeviceIndex>::max(),
+        tmp_device >= 0 && tmp_device < c10::Device::MAX_NUM_DEVICES,
         "cudaGetDevice returns invalid device ",
         tmp_device);
     *device = static_cast<DeviceIndex>(tmp_device);
@@ -270,8 +269,7 @@ DeviceIndex MaybeExchangeDevice(DeviceIndex to_device) {
   int tmp_cur_device = -1;
   C10_CUDA_CHECK(cudaGetDevice(&tmp_cur_device));
   TORCH_INTERNAL_ASSERT(
-      tmp_cur_device >= 0 &&
-          tmp_cur_device <= std::numeric_limits<DeviceIndex>::max(),
+      tmp_cur_device >= 0 && tmp_cur_device < c10::Device::MAX_NUM_DEVICES,
       "cudaGetDevice returns invalid device ",
       tmp_cur_device);
   auto cur_device = static_cast<DeviceIndex>(tmp_cur_device);
@@ -297,8 +295,7 @@ cudaError_t GetDevice(DeviceIndex* device) {
   auto err = cudaGetDevice(&tmp_device);
   if (err == cudaSuccess) {
     TORCH_INTERNAL_ASSERT(
-        tmp_device >= 0 &&
-            tmp_device <= std::numeric_limits<DeviceIndex>::max(),
+        tmp_device >= 0 && tmp_device < c10::Device::MAX_NUM_DEVICES,
         "cudaGetDevice returns invalid device ",
         tmp_device);
     *device = static_cast<DeviceIndex>(tmp_device);

--- a/c10/cuda/CUDAMacros.h
+++ b/c10/cuda/CUDAMacros.h
@@ -37,15 +37,3 @@
 #else
 #define C10_CUDA_API C10_CUDA_IMPORT
 #endif
-
-/**
- * The maximum number of GPUs that we recognizes. Increasing this beyond the
- * initial limit of 16 broke Caffe2 testing, hence the ifdef guards.
- * This value cannot be more than 128 because our DeviceIndex is a uint8_t.
-o */
-#ifdef FBCODE_CAFFE2
-// fbcode depends on this value being 16
-#define C10_COMPILE_TIME_MAX_GPUS 16
-#else
-#define C10_COMPILE_TIME_MAX_GPUS 120
-#endif

--- a/c10/cuda/CUDAStream.cpp
+++ b/c10/cuda/CUDAStream.cpp
@@ -49,7 +49,7 @@ static std::array<
 static std::array<
     std::array<
         std::array<cudaStream_t, kStreamsPerPool>,
-c10::Device::MAX_NUM_DEVICES>,
+        c10::Device::MAX_NUM_DEVICES>,
     c10::cuda::max_compile_time_stream_priorities>
     streams;
 #ifdef USE_ROCM

--- a/c10/cuda/CUDAStream.cpp
+++ b/c10/cuda/CUDAStream.cpp
@@ -39,23 +39,23 @@ static int max_stream_priorities;
 // the destruction.
 #if !defined(USE_ROCM)
 // CUDA-only: used to initializes the stream pools (once)
-static std::array<c10::once_flag, C10_COMPILE_TIME_MAX_GPUS> device_flags;
+static std::array<c10::once_flag, c10::Device::MAX_NUM_DEVICES> device_flags;
 #endif
 static std::array<
-    std::array<std::atomic<uint32_t>, C10_COMPILE_TIME_MAX_GPUS>,
+    std::array<std::atomic<uint32_t>, c10::Device::MAX_NUM_DEVICES>,
     c10::cuda::max_compile_time_stream_priorities>
     priority_counters;
 
 static std::array<
     std::array<
         std::array<cudaStream_t, kStreamsPerPool>,
-        C10_COMPILE_TIME_MAX_GPUS>,
+c10::Device::MAX_NUM_DEVICES>,
     c10::cuda::max_compile_time_stream_priorities>
     streams;
 #ifdef USE_ROCM
 static c10::once_flag
     stream_flags[c10::cuda::max_compile_time_stream_priorities]
-                [C10_COMPILE_TIME_MAX_GPUS][kStreamsPerPool];
+                [c10::Device::MAX_NUM_DEVICES][kStreamsPerPool];
 #endif
 
 // Note [HIP Lazy Streams]
@@ -175,10 +175,10 @@ static void initGlobalStreamState() {
   // Check if the number of GPUs matches the expected compile-time max number
   // of GPUs.
   TORCH_CHECK(
-      num_gpus <= C10_COMPILE_TIME_MAX_GPUS,
+      num_gpus <= c10::Device::MAX_NUM_DEVICES,
       "Number of CUDA devices on the machine is larger than the compiled "
       "max number of gpus expected (",
-      C10_COMPILE_TIME_MAX_GPUS,
+      c10::Device::MAX_NUM_DEVICES,
       "). Increase that and recompile.");
   int leastPriority = -1, greatestPriority = -1;
   C10_CUDA_CHECK(

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3445,6 +3445,21 @@ def foo(x):
             else:
                 cu.define(full)
 
+    def test_int16_device_index(self):
+        # This used to fail after the switch from int8 to int16 DeviceIndex as the ArgumentInfo struct hardcoded
+        # the bit width. Thus, the default device (-1) wrapped around to 255.
+        # See https://github.com/pytorch/pytorch/issues/115331
+        tensor = torch.tensor([1.])
+        code_template = """
+        def fn(x):
+            return x.device
+        """
+        cu = torch.jit.CompilationUnit()
+        cu.define(code_template)
+        res = cu.fn(tensor)
+        self.assertEqual(tensor.device, res)
+
+
     def test_namedtuple_python(self):
         global MyTuple, MyMod  # see [local resolution in python]
         MyTuple = namedtuple('MyTuple', ['a'])

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1188,7 +1188,7 @@ class TestDeviceUtils(TestCase):
     def test_int16_device_index(self):
         # Test if index does not wrap around when larger than int8
         large_index = 500
-        x = torch.device('meta', large_index)
+        x = torch.device("meta", large_index)
         self.assertEqual(x.index, large_index)
 
     def test_raise_on_device_index_out_of_bounds(self):
@@ -1197,10 +1197,11 @@ class TestDeviceUtils(TestCase):
         error_msg_regex = "^Device index must be.*"
         # Explicit index
         with self.assertRaisesRegex(RuntimeError, error_msg_regex):
-            x = torch.device('meta', index=index_larger_than_max)
+            x = torch.device("meta", index=index_larger_than_max)
         # Index in device string
         with self.assertRaisesRegex(RuntimeError, error_msg_regex):
-            x = torch.device(f'meta:{index_larger_than_max}')
+            x = torch.device(f"meta:{index_larger_than_max}")
+
 
 instantiate_device_type_tests(TestDeviceUtils, globals())
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1185,6 +1185,22 @@ class TestDeviceUtils(TestCase):
 
             self.assertTrue(tree_all_only(torch.Tensor, is_meta_device, r))
 
+    def test_int16_device_index(self):
+        # Test if index does not wrap around when larger than int8
+        large_index = 500
+        x = torch.device('meta', large_index)
+        self.assertEqual(x.index, large_index)
+
+    def test_raise_on_device_index_out_of_bounds(self):
+        # Tests if an error is raised when the device index is out of bounds
+        index_larger_than_max = 100000
+        error_msg_regex = "^Device index must be.*"
+        # Explicit index
+        with self.assertRaisesRegex(RuntimeError, error_msg_regex):
+            x = torch.device('meta', index=index_larger_than_max)
+        # Index in device string
+        with self.assertRaisesRegex(RuntimeError, error_msg_regex):
+            x = torch.device(f'meta:{index_larger_than_max}')
 
 instantiate_device_type_tests(TestDeviceUtils, globals())
 

--- a/torch/csrc/Device.cpp
+++ b/torch/csrc/Device.cpp
@@ -31,10 +31,7 @@ PyObject* THPDevice_repr(THPDevice* self) {
   std::ostringstream oss;
   oss << "device(type=\'" << self->device.type() << "\'";
   if (self->device.has_index()) {
-    // `self->device.index()` returns uint8_t which is treated as ascii while
-    // printing, hence casting it to uint16_t.
-    // https://stackoverflow.com/questions/19562103/uint8-t-cant-be-printed-with-cout
-    oss << ", index=" << static_cast<uint16_t>(self->device.index());
+    oss << ", index=" << self->device.index();
   }
   oss << ")";
   return THPUtils_packString(oss.str().c_str());
@@ -77,7 +74,11 @@ PyObject* THPDevice_pynew(
       device_index = r.toInt64(1);
       // -1 is allowed in ATen/C++, to mean the default device, but not in
       // Python.
-      TORCH_CHECK(device_index >= 0, "Device index must not be negative");
+      TORCH_CHECK(
+          device_index >= 0 && device_index < c10::Device::MAX_NUM_DEVICES,
+          "Device index must be between 0 and ",
+          c10::Device::MAX_NUM_DEVICES - 1,
+          " inclusively.");
     }
     at::Device device(
         as_device.type(), static_cast<c10::DeviceIndex>(device_index));

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -2230,23 +2230,6 @@ Call this whenever a new thread is created in order to propagate values from
         return torch::should_allow_numbers_as_tensors(name);
       });
 
-  // FIXME(crcrpar): Better to have `at::ScalarType` get mapped to `torch.dtype`
-  // Currently I see the second item of the key is displayed as
-  // e.g. `torch._C._te.ScalarType at 0x7fcf318adab0`
-  // I thought adding an appropriate type_caster of `at::ScalarType` to
-  // torch/csrc/pybind.h` would solve this but it caused segmentation fault in
-  // my environment.
-  using _DeviceDtypeKey = std::pair<at::Device, std::string>;
-  struct _DeviceDtypeHasher {
-    std::size_t operator()(const _DeviceDtypeKey& k) const noexcept {
-      return std::hash<at::Device>{}(k.first) ^
-          std::hash<std::string>{}(k.second);
-    }
-  };
-  using _FlatMap = std::unordered_map<
-      _DeviceDtypeKey,
-      at::native::TensorsAndIndicesT,
-      _DeviceDtypeHasher>;
   py_module.def(
       "_group_tensors_by_device_and_dtype",
       [](const std::vector<std::vector<std::optional<at::Tensor>>>&

--- a/torch/csrc/cuda/device_set.h
+++ b/torch/csrc/cuda/device_set.h
@@ -1,11 +1,12 @@
 #pragma once
 
+#include <c10/core/Device.h>
 #include <c10/cuda/CUDAMacros.h>
 #include <bitset>
 #include <cstddef>
 
 namespace torch {
 
-using device_set = std::bitset<C10_COMPILE_TIME_MAX_GPUS>;
+using device_set = std::bitset<c10::Device::MAX_NUM_DEVICES>;
 
 } // namespace torch

--- a/torch/csrc/jit/runtime/argument_spec.h
+++ b/torch/csrc/jit/runtime/argument_spec.h
@@ -2,6 +2,7 @@
 
 #include <ATen/core/jit_type.h>
 #include <ATen/core/stack.h>
+#include <c10/core/Device.h>
 #include <c10/util/hash.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/Export.h>
@@ -56,12 +57,10 @@ struct ArgumentInfo {
  private:
   unsigned defined_ : 1;
   unsigned requires_grad_ : 1;
-  unsigned : 5;
   unsigned dim_ : 8;
-  unsigned device_ : 8;
+  signed device_ : sizeof(c10::DeviceIndex) * 8;
   unsigned type_ : 8;
   unsigned dev_type_ : 16;
-  unsigned : 16;
 };
 
 static_assert(
@@ -69,7 +68,7 @@ static_assert(
     "ArgumentInfo is to be a POD struct");
 static_assert(
     sizeof(ArgumentInfo) == sizeof(ArgumentInfo::plain_data_type),
-    "ArgumentInfo is expected to be a 32-bit struct");
+    "ArgumentInfo is expected to be a 64-bit struct");
 
 struct ArgumentSpec {
   ArgumentSpec(size_t num_flat_tensor_inputs, size_t num_flat_optional_inputs)
@@ -223,8 +222,8 @@ struct CompleteArgumentInfoPOD {
   unsigned type : 8; // scalar type
   unsigned defined : 1;
   unsigned requires_grad : 1;
-  signed device : 14;
-  unsigned dev_type : 16;
+  signed dev_type : sizeof(c10::DeviceType) * 8;
+  signed device : sizeof(c10::DeviceIndex) * 8;
   unsigned
       total_dims : 16; // all TensorInfoPODs are in CompleteArgumentSpec's
                        // tensor_info() array. total_dims is the total number of

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -805,7 +805,11 @@ inline std::optional<at::Layout> PythonArgs::layoutOptional(int i) {
 }
 
 inline at::Device deviceFromLong(int64_t device_index) {
-  TORCH_CHECK(device_index >= 0, "Device index must not be negative");
+  TORCH_CHECK(
+      device_index >= 0 && device_index < c10::Device::MAX_NUM_DEVICES,
+      "Device index must be between 0 and ",
+      c10::Device::MAX_NUM_DEVICES - 1,
+      " inclusively.");
   return at::Device(
       at::getAccelerator(true).value(),
       static_cast<c10::DeviceIndex>(device_index));

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -5258,12 +5258,12 @@ class TensorPipeAgentCudaRpcTest(RpcAgentTestFixture, RpcTestCommon):
         options = self.rpc_backend_options
         dst = worker_name((self.rank + 1) % self.world_size)
         with self.assertRaisesRegex(
-            RuntimeError, "Device index must not be negative"
+            RuntimeError, "Device index must .*"
         ):
             options.set_device_map(dst, {-1: 0})
 
         with self.assertRaisesRegex(
-            RuntimeError, "Device index must not be negative"
+            RuntimeError, "Device index must .*"
         ):
             options.set_device_map(dst, {0: -1})
 


### PR DESCRIPTION
Fixes #115331.

This PR increases the number of valid GPU devices to 512 (from 64) in order to future-proof PyTorch for providers that offer [single nodes with a large device count](https://www.tensorwave.com/). Until now, `DeviceIndex` was an `int8_t`, thus multiple changes were necessary:

- `DeviceIndex` changed to `int16_t`. Updated consumers that assume it to be an `int8_t`.
- Updated bounds checking for `torch.device()` in the Python frontend. Right now, we allow funny things like `torch.device('cpu', 200).index == -56`, which is undefined behavior. I inserted some checks to only allow values between 0 and `c10::Device::MAX_NUM_DEVICES - 1`.
- Updated the `ArgumentInfo` struct as it hardcodes the device index as 8 bit field [^1]. Might be a breaking change, not sure if users rely on this.
- Introduced `c10::Device::MAX_NUM_DEVICES` as a replacement for the old `C10_COMPILE_TIME_MAX_GPUS`


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @penguinwu @tianyu-l @yf225

[^1]: This field was unsigned, so I guess this has also been undef behavior the whole time? Our default device index is -1, so this always wrapped around to 255 when written to the `ArgumentInfo` struct. When I switched the `DeviceIndex` to `int16_t`, it actually stayed 255 after unpacking from `ArgumentInfo` again, as the `DeviceIndex` was now wide enough that it didn't wrap back to -1.