### PR TITLE
Add a non ideal lintrunner hook using pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: lintrunner
+        name: lintrunner
+        entry: make lint
+        language: system
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,4 +5,4 @@ repos:
         name: lintrunner
         entry: make lint
         language: system
-        pass_filenames: false
+        pass_filenames: true


### PR DESCRIPTION
# Summary

I often forget run lintrunner before committing code. `Git hooks` are the natural solution to solving this issue, but installing them can be annoying.  https://github.com/pre-commit/pre-commit aims to help with managing pre-commit hooks.


This is a proof of concept PR:
Essentially you clone PyTorch and run:
```Shell
❯ pre-commit install
pre-commit installed at .git/hooks/pre-commit
```

This has now installed the "lintrunner" hook.  

Anytime your try to commit, lintrunner will be ran on your staged files, lets say you wrote some bad syntax, if lintrunner did not run successfully, no commit for you!
<img width="674" alt="Screenshot 2024-02-10 at 12 29 11 PM" src="https://github.com/pytorch/pytorch/assets/32754868/ca3c2cd5-fe3d-450e-8ceb-47edd074603a">



You fix your error

<img width="669" alt="Screenshot 2024-02-10 at 12 31 21 PM" src="https://github.com/pytorch/pytorch/assets/32754868/68fc9a3d-4fdc-41ea-8ce7-9d1261a25e52">

And your commit is good to go!

### This Works, but..
This works I think pretty well but I don't think that the hook definition is ideal. The correct way would be to update the lintrunner repo to define its hook/entrypoints and register the correct from there.


See this for more detail: https://pre-commit.com/#new-hooks