### PR TITLE
[BE][EZ] Use `dyspatch_sync_with_rethrow` in searchsorted

### DIFF
--- a/aten/src/ATen/native/mps/operations/Bucketization.mm
+++ b/aten/src/ATen/native/mps/operations/Bucketization.mm
@@ -252,7 +252,7 @@ static void searchsorted_mps_contiguous(Tensor& result,
 
   id<MTLDevice> device = MPSDevice::getInstance()->device();
   MPSStream* mpsStream = getCurrentMPSStream();
-  dispatch_sync(mpsStream->queue(), ^() {
+  dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
 


### PR DESCRIPTION
For the proper exception handling, otherwise raising C++ exception inside dispatch block will crash the app (discovered while enabling more BFloat16 ops)
