### PR TITLE
Improve the small buffer optimization handling for multi_tensor_apply

### DIFF
--- a/aten/src/ATen/native/cuda/ForeachFunctors.cuh
+++ b/aten/src/ATen/native/cuda/ForeachFunctors.cuh
@@ -18,7 +18,7 @@ inline void increment_version(TensorList tensors) {
 }
 
 // Initializes args and checks if all args are aligned
-template <int depth, typename T, template <int> class TensorListMetadata>
+template <int depth, typename T>
 __device__ bool init_args(
     T** args,
     TensorListMetadata<depth>& tl,
@@ -206,7 +206,7 @@ __device__ __forceinline__ void pointwise_op_scalar(
 template <typename T, int depth, int r_args_depth, int res_arg_index>
 struct BinaryOpScalarFunctor {
   using opmath_t = at::opmath_type<T>;
-  template <typename Op, template <int> class TensorListMetadata>
+  template <typename Op>
   __device__ __forceinline__ void operator()(
       int chunk_size,
       TensorListMetadata<depth>& tl,
@@ -254,7 +254,7 @@ struct BinaryOpScalarListFunctor {
 template <typename T, int depth, int r_args_depth, int res_arg_index>
 struct BinaryOpListAlphaFunctor {
   using opmath_t = at::opmath_type<T>;
-  template <typename Op, template <int> class TensorListMetadata>
+  template <typename Op>
   __device__ __forceinline__ void operator()(
       int chunk_size,
       TensorListMetadata<depth>& tl,
@@ -306,7 +306,7 @@ struct BinaryOpListAlphaFunctor {
 template <typename T, int depth, int r_args_depth, int res_arg_index>
 struct BinaryOpScalarTensorFunctor {
   using opmath_t = at::opmath_type<T>;
-  template <typename Op, template <int> class TensorListMetadata>
+  template <typename Op>
   __device__ __forceinline__ void operator()(
       int chunk_size,
       TensorListMetadata<depth>& tl,
@@ -363,7 +363,6 @@ struct BinaryOpScalarTensorFunctor {
 
 template <typename T, int depth, int r_args_depth, int res_arg_index>
 struct ZeroFunctor {
-  template <template <int> class TensorListMetadata>
   __device__ __forceinline__ void operator()(
       int chunk_size,
       TensorListMetadata<1>& tl) {
@@ -405,7 +404,7 @@ struct ZeroFunctor {
 template <typename T, int depth, int r_args_depth, int res_arg_index>
 struct UnaryOpFunctor {
   using opmath_t = at::opmath_type<T>;
-  template <typename Op, template <int> class TensorListMetadata>
+  template <typename Op>
   __device__ __forceinline__ void operator()(
       int chunk_size,
       TensorListMetadata<depth>& tl,
@@ -457,7 +456,7 @@ struct UnaryOpFunctor {
 template <typename T, int depth, int r_args_depth, int res_arg_index>
 struct PointwiseOpScalarFunctor {
   using opmath_t = at::opmath_type<T>;
-  template <typename Op, template <int> class TensorListMetadata>
+  template <typename Op>
   __device__ __forceinline__ void operator()(
       int chunk_size,
       TensorListMetadata<depth>& tl,
@@ -505,7 +504,7 @@ struct PointwiseOpScalarListFunctor {
 template <typename T, int depth>
 struct PointwiseOpListFunctor {
   using opmath_t = at::opmath_type<T>;
-  template <typename Op, template <int> class TensorListMetadata>
+  template <typename Op>
   __device__ __forceinline__ void operator()(
       int chunk_size,
       TensorListMetadata<depth>& tl,
@@ -556,7 +555,7 @@ struct PointwiseOpListFunctor {
 template <typename T, int depth, int r_args_depth, int res_arg_index>
 struct TernaryOpListFunctor {
   using opmath_t = at::opmath_type<T>;
-  template <typename Op, template <int> class TensorListMetadata>
+  template <typename Op>
   __device__ __forceinline__ void operator()(
       int chunk_size,
       TensorListMetadata<depth>& tl,
@@ -610,7 +609,7 @@ struct TernaryOpListFunctor {
 template <typename T, int depth, int r_args_depth, int res_arg_index>
 struct TernaryOpScalarFunctor {
   using opmath_t = at::opmath_type<T>;
-  template <typename Op, template <int> class TensorListMetadata>
+  template <typename Op>
   __device__ __forceinline__ void operator()(
       int chunk_size,
       TensorListMetadata<depth>& tl,

--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -31,7 +31,6 @@ template <
     int res_arg_index = 0>
 struct LpNormFunctor {
   using opmath_t = typename at::opmath_type<T>;
-  template <template <int> class TensorListMetadata>
   __device__ __forceinline__ void operator()(
       int chunk_size,
       TensorListMetadata<depth>& tl,

--- a/aten/src/ATen/native/cuda/FusedSgdKernel.cu
+++ b/aten/src/ATen/native/cuda/FusedSgdKernel.cu
@@ -61,7 +61,6 @@ struct FusedSgdMathFunctor {
   static_assert(
       depth == 2 || depth == 3,
       "depth of 2 for SGD w/ momentum == 0, 3 for SGD w/ momentum != 0");
-  template <template <int> class TensorListMetadata>
   C10_DEVICE __forceinline__ void operator()(
       const int chunk_size,
       TensorListMetadata<depth>& tl,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #119652
* #119153

#119153 introduced an optimization for `multi_tensor_apply` for large problem sizes. This optimization increased the binary size of libtorch_cuda.so by approximately 5MB due to additional kernel template specializations, and it also expanded the code footprint of multi_tensor_apply.

Currently, this optimization is only applied to `multi_tensor_apply` for tensors. However, we have plans to extend it to `multi_tensor_apply` for tensor + scalar and optimizers. Pursuing the same approach would exacerbate the issues of increased binary size and code footprint.

To address the concerns, this PR introduces a mechanism that allows the optimization in #119153 to be applied to all `multi_tensor_apply` variants, without the drawbacks of increased code footprint, binary size, or compile time.

```
The multi_tensor_apply kernel and the functors take a variant of
TensorListMetadata as an argument. TensorListMetadata contains multiple
arrays with dynamic sizes that may not fit within the 4KB kernel argument
space. Therefore, a dynamically allocated kernel argument is required to
support arbitrary problem sizes. This can be achieved by preparing the
arrays in host memory and copying them to the device with a single
cudaMemcpyAsync. When the problem size is large, the latency of the HtoD
copy is negligible.

However, when the problem size is small, the latency of the cudaMemcpyAsync
becomes more pronounced. In such cases, we try to fit the arrays into the
4kb kernel argument space. The technique is akin to small buffer
optimization.

However, when the problem size is small, the latency of the cudaMemcpyAsync
becomes more pronounced. In such cases, we attempt to fit the arrays into
the 4KB kernel argument space. This technique is akin to the small buffer
optimization.

DevArrayPack is a struct used for packing multiple vectors into a contiguous
buffer. When the combined size of the vectors is small enough, they are
packed into the struct itself, which is passed to the kernel through the
static kernel argument space. Otherwise, the arguments are packed into a
dynamically allocated buffer.

NOTE: Previously, we divided a problem into multiple kernel launches so that
the arguments for every launch would fit in the static kernel argument
space. This approach avoided the need for dynamically allocated kernel
arguments, but it led to multiple kernel launches and lower sustained
occupancy.
```