### PR TITLE
[BE] Properly mark destructor overrides (Take 2)

### DIFF
--- a/aten/src/ATen/detail/CUDAHooksInterface.h
+++ b/aten/src/ATen/detail/CUDAHooksInterface.h
@@ -62,7 +62,7 @@ constexpr const char* CUDA_HELP =
 struct TORCH_API CUDAHooksInterface : AcceleratorHooksInterface {
   // This should never actually be implemented, but it is used to
   // squelch -Werror=non-virtual-dtor
-  virtual ~CUDAHooksInterface() = default;
+  virtual ~CUDAHooksInterface() override = default;
 
   // Initialize THCState and, transitively, the CUDA state
   virtual void initCUDA() const {

--- a/aten/src/ATen/detail/MPSHooksInterface.h
+++ b/aten/src/ATen/detail/MPSHooksInterface.h
@@ -18,7 +18,7 @@ struct TORCH_API MPSHooksInterface : AcceleratorHooksInterface {
   #define FAIL_MPSHOOKS_FUNC(func) \
     TORCH_CHECK(false, "Cannot execute ", func, "() without MPS backend.");
 
-  virtual ~MPSHooksInterface() = default;
+  virtual ~MPSHooksInterface() override = default;
 
   // Initialize the MPS library state
   virtual void initMPS() const {

--- a/aten/src/ATen/detail/MTIAHooksInterface.h
+++ b/aten/src/ATen/detail/MTIAHooksInterface.h
@@ -20,7 +20,7 @@ constexpr const char* MTIA_HELP =
     "to use some MTIA's functionality without MTIA extension included.";
 
 struct TORCH_API MTIAHooksInterface : AcceleratorHooksInterface {
-  virtual ~MTIAHooksInterface() = default;
+  virtual ~MTIAHooksInterface() override = default;
 
   virtual void initMTIA() const {
     TORCH_CHECK(

--- a/aten/src/ATen/detail/PrivateUse1HooksInterface.h
+++ b/aten/src/ATen/detail/PrivateUse1HooksInterface.h
@@ -9,7 +9,7 @@
 namespace at {
 
 struct TORCH_API PrivateUse1HooksInterface : AcceleratorHooksInterface {
-  virtual ~PrivateUse1HooksInterface() = default;
+  virtual ~PrivateUse1HooksInterface() override = default;
   virtual const at::Generator& getDefaultGenerator(
       c10::DeviceIndex device_index) {
     TORCH_CHECK_NOT_IMPLEMENTED(


### PR DESCRIPTION
Otherwise, at least on MacOS builds are littered with:
```
In file included from /Users/malfet/git/pytorch/pytorch/aten/src/ATen/DeviceAccelerator.h:6:
/Users/malfet/git/pytorch/pytorch/aten/src/ATen/detail/MTIAHooksInterface.h:23:11: warning: '~MTIAHooksInterface' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
  virtual ~MTIAHooksInterface() = default;
          ^
/Users/malfet/git/pytorch/pytorch/aten/src/ATen/detail/CUDAHooksInterface.h:65:11: warning: '~CUDAHooksInterface' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
  virtual ~CUDAHooksInterface() = default;
          ^
/Users/malfet/git/pytorch/pytorch/aten/src/ATen/detail/AcceleratorHooksInterface.h:15:11: note: overridden virtual function is here
  virtual ~AcceleratorHooksInterface() = default;
          ^
/Users/malfet/git/pytorch/pytorch/aten/src/ATen/detail/MPSHooksInterface.h:21:11: warning: '~MPSHooksInterface' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
  virtual ~MPSHooksInterface() = default;
          ^
/Users/malfet/git/pytorch/pytorch/aten/src/ATen/detail/AcceleratorHooksInterface.h:15:11: note: overridden virtual function is here
  virtual ~AcceleratorHooksInterface() = default;
          ^
```

 Likely introduced by https://github.com/pytorch/pytorch/pull/119329
