### PR TITLE
[AMD] Update xplat TARGETS for tunable ops

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -228,6 +228,7 @@ filegroup(
         [
             "aten/src/ATen/cuda/*.cpp",
             "aten/src/ATen/cuda/detail/*.cpp",
+            "aten/src/ATen/cuda/tunable/*.cpp",
             "aten/src/ATen/cudnn/*.cpp",
             "aten/src/ATen/native/cuda/*.cpp",
             "aten/src/ATen/native/cuda/linalg/*.cpp",


### PR DESCRIPTION
Summary: Internal build failures due to missing Tunable ops in the source file

Test Plan: sandcastle

Differential Revision: D53643523


