### PR TITLE
Implement conditional statements in kernel analysis

### DIFF
--- a/test/dynamo/test_triton_kernels.py
+++ b/test/dynamo/test_triton_kernels.py
@@ -1079,6 +1079,42 @@ class MutationTests(torch._dynamo.test_case.TestCase):
             ["out_ptr"],
         )
 
+    @make_mutation_test
+    def test_nested_cond_op_kernel():
+        @triton.jit
+        def nested_cond_op_kernel(
+            in_ptr0,
+            in_ptr1,
+            out_ptr,
+            n_elements,
+            BLOCK_SIZE: "tl.constexpr",
+        ):
+            pid = tl.program_id(axis=0)
+            block_start = pid * BLOCK_SIZE
+            offsets = block_start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(in_ptr0 + offsets, mask=mask)
+            y = tl.load(in_ptr1 + offsets, mask=mask)
+            if tl.program_id(0) == 0:
+                if tl.program_id(1) == 0:
+                    output = x + y
+                    tl.store(out_ptr + offsets, output, mask=mask)
+            else:
+                pass
+
+        t = torch.randn(4)
+        return (
+            nested_cond_op_kernel,
+            {
+                "in_ptr0": t,
+                "in_ptr1": t,
+                "out_ptr": t,
+                "n_elements": 4,
+                "BLOCK_SIZE": 4,
+            },
+            ["out_ptr"],
+        )
+
 
 if HAS_CUDA and HAS_LARK:
     t = torch.randn(4)
@@ -1192,8 +1228,7 @@ if HAS_CUDA and HAS_LARK:
                 "n_elements": 4,
                 "BLOCK_SIZE": 4,
             },
-            # TODO(oulgen): Dynamic control flow is not implemented yet
-            ["in_ptr0", "in_ptr1", "out_ptr"],
+            ["out_ptr"],
         ],
     ]
     for kernel, inputs, outputs in tests:

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -2,7 +2,8 @@ import dataclasses
 import logging
 import threading
 import warnings
-from typing import Any, Dict, List, Union
+from collections import defaultdict
+from typing import Any, Dict, List, Optional, Union
 
 import torch.utils._pytree as pytree
 from torch import Tensor
@@ -79,8 +80,9 @@ class Intermediate:
 @dataclasses.dataclass(frozen=True)
 class Op:
     name: str
-    fn_call_name: str
+    fn_call_name: Optional[str]
     args: List[Union[Param, Intermediate]]
+    ret: Intermediate = dataclasses.field(repr=False)
 
     def __post_init__(self):
         if self.name == "tt.call":
@@ -165,7 +167,6 @@ def parse_ttir(ttir, kwargs):
     parser which further makes parsing much simpler.
     """
     # TODO(oulgen):
-    # - Support parsing of conditionals
     # - Support parsing for/while loops
     # - Support closures (e.g. "tt.reduce")
 
@@ -177,11 +178,6 @@ def parse_ttir(ttir, kwargs):
             "Using slow path for user-defined Triton kernels. `pip install lark` to fix this."
         )
         raise
-
-    functions: Dict[str, Dict[Intermediate, Op]] = {}
-    ops: Dict[Intermediate, Op] = {}
-    current_function = None
-    next_fake_intermediate = 0
 
     # Ops looks like one of the following forms:
     #
@@ -195,7 +191,11 @@ def parse_ttir(ttir, kwargs):
 
         module_block: "module" "{" func_block+ "}" LOC
 
-        func_block: "tt.func" ("public"|"private") FN_NAME "(" /.+/ NEWLINE op+ "}" LOC -> process_func
+        func_block: "tt.func" ("public"|"private") FN_NAME "(" /.+/ NEWLINE stmt* "}" LOC -> process_func
+
+        ?stmt: op | cond
+
+        cond: [assign_lhs "="] "scf.if" args rest stmt* "}" "else" "{" stmt* "}" LOC -> process_cond
 
         op: OP_NAME LOC
           | [assign_lhs "="] OP_NAME [FN_NAME] args rest?  -> process_op
@@ -227,6 +227,8 @@ def parse_ttir(ttir, kwargs):
         %import common.ESCAPED_STRING
         %ignore WS
     """
+
+    next_fake_intermediate = 0
 
     def convert(token):
         if isinstance(token, lark.tree.Tree):
@@ -264,20 +266,46 @@ def parse_ttir(ttir, kwargs):
             return s[1:-1]
         return s
 
+    functions: Dict[str, Dict[Intermediate, List[Op]]] = {}
+
+    def extend_dict_list(d1, d2):
+        for key, values in d2.items():
+            d1[key].extend(values)
+
     @v_args(inline=True)
-    class CalculateOps(Transformer):
+    class TransformOps(Transformer):
         def process_op(self, ret, op_name, fn_name, args, *rest):
-            ops[convert(ret)] = Op(
-                convert_name(op_name), convert_name(fn_name), convert(args)
+            return Op(
+                convert_name(op_name),
+                convert_name(fn_name),
+                convert(args),
+                convert(ret),
             )
 
-        def process_func(self, name, *rest):
-            nonlocal ops
+        def process_func(self, name, _args, *stmts):
+            ops: Dict[Intermediate, List[Op]] = defaultdict(list)
+            for e in stmts:
+                if isinstance(e, Op):
+                    ops[e.ret].append(e)
+                elif isinstance(e, dict):
+                    extend_dict_list(ops, e)
             functions[name.value] = ops
-            ops = {}
+
+        def process_cond(self, ret, _args, _rest, *stmts):
+            ret = convert(ret)
+            ops: Dict[Intermediate, List[Op]] = defaultdict(list)
+            for e in stmts:
+                if isinstance(e, Op):
+                    if e.name == "scf.yield":
+                        ops[ret].append(Op(e.name, None, e.args, ret))
+                    else:
+                        ops[e.ret].append(e)
+                elif isinstance(e, dict):
+                    extend_dict_list(ops, e)
+            return ops
 
     parser = Lark(
-        grammar, parser="lalr", maybe_placeholders=True, transformer=CalculateOps()
+        grammar, parser="lalr", maybe_placeholders=True, transformer=TransformOps()
     )
     parser.parse(ttir)
     return functions
@@ -320,23 +348,24 @@ def analyze_kernel_mutations(functions, fn_name, num_args):
     stack: List[Union[Param, Intermediate]] = []
     visited = set()
     ops = functions[fn_name]
-    for op in ops.values():
-        if op.name in UNKNOWN_OPS:
-            raise Exception(
-                f"ttir analysis hit an op we do not know how to analyze: {op.name}"
-            )
+    for op_list in ops.values():
+        for op in op_list:
+            if op.name in UNKNOWN_OPS:
+                raise Exception(
+                    f"ttir analysis hit an op we do not know how to analyze: {op.name}"
+                )
 
-        if op.name == "tt.call":
-            assert op.fn_call_name in functions
-            mutations = analyze_kernel_mutations(
-                functions, op.fn_call_name, len(op.args)
-            )
-            for idx, mutated in enumerate(mutations):
-                if mutated:
+            if op.name == "tt.call":
+                assert op.fn_call_name in functions
+                mutations = analyze_kernel_mutations(
+                    functions, op.fn_call_name, len(op.args)
+                )
+                for idx, mutated in enumerate(mutations):
+                    if mutated:
+                        stack.append(op.args[idx])
+            else:
+                for idx in MUTATION_OPS.get(op.name, []):
                     stack.append(op.args[idx])
-        else:
-            for idx in MUTATION_OPS.get(op.name, []):
-                stack.append(op.args[idx])
 
     # The following is an iterative DFS algorithm
     mutated = [False] * num_args
@@ -349,13 +378,11 @@ def analyze_kernel_mutations(functions, fn_name, num_args):
 
         if isinstance(arg, Param):
             mutated[arg.idx] = True
-        elif (
-            isinstance(arg, Intermediate)
-            and not arg.fake()
-            # Skip arguments to load
-            and ops[arg].name != "tt.load"
-        ):
-            stack.extend(ops[arg].args)
+        elif isinstance(arg, Intermediate) and not arg.fake():
+            for op in ops[arg]:
+                # Skip arguments to load
+                if op.name != "tt.load":
+                    stack.extend(op.args)
     return mutated
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #119664


This PR makes it so that ops is no longer a dict of RET => OP but rather it is now RET => List[OP] since now multiple OPs can return the same RET. In real execution, only one of these OPs will be executed, so no need to worry about renaming. For analysis, we pessimistically assume any one of them could be executed (which is safest for analysis purposes)

Example TTIRs that can now be handled:
```
    scf.if %13 {
      %14 = tt.get_program_id y : i32 loc(#loc13)
      %c0_i32_1 = arith.constant 0 : i32 loc(#loc14)
      %15 = arith.cmpi eq, %14, %c0_i32_1 : i32 loc(#loc14)
      scf.if %15 {
        %16 = arith.addf %8, %11 : tensor<4xf32> loc(#loc16)
        %17 = tt.splat %arg2 : (!tt.ptr<f32, 1>) -> tensor<4x!tt.ptr<f32, 1>> loc(#loc17)
        %18 = tt.addptr %17, %4 : tensor<4x!tt.ptr<f32, 1>>, tensor<4xi32> loc(#loc17)
        tt.store %18, %16, %5 {cache = 1 : i32, evict = 1 : i32} : tensor<4xf32> loc(#loc18)
      } else {
      } loc(#loc15)
    } else {
    } loc(#loc12)
```

and 

```
    %14 = scf.if %13 -> (tensor<4xf32>) {
      %17 = arith.addf %8, %11 : tensor<4xf32> loc(#loc13)
      scf.yield %17 : tensor<4xf32> loc(#loc13)
    } else {
      %17 = arith.mulf %8, %11 : tensor<4xf32> loc(#loc14)
      scf.yield %17 : tensor<4xf32> loc(#loc14)
    } loc(#loc12)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng