### PR TITLE
[inductor] Refactor device guard Python codegen to allow nested indentation

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -282,10 +282,6 @@ class EnterDeviceContextManagerLine:
                 else:
                     code.writeline(f"device_guard.set_index({self.device_idx});")
         else:
-            # Note _DeviceGuard has less overhead than device, but only accepts
-            # integers
-            code.writeline(f"with {V.graph.device_ops.device_guard(self.device_idx)}:")
-            device_cm_stack.enter_context(code.indent())
             code.writeline(V.graph.device_ops.set_device(self.device_idx))
 
 
@@ -293,8 +289,7 @@ class ExitDeviceContextManagerLine:
     def codegen(
         self, code: IndentedBuffer, device_cm_stack: contextlib.ExitStack
     ) -> None:
-        if not V.graph.cpp_wrapper:
-            device_cm_stack.close()
+        pass
 
 
 @dataclasses.dataclass

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -251,9 +251,7 @@ class EnterDeviceContextManagerLine:
     device_idx: int
     last_seen_device_guard_index: Optional[int]
 
-    def codegen(
-        self, code: IndentedBuffer, device_cm_stack: contextlib.ExitStack
-    ) -> None:
+    def codegen(self, code: IndentedBuffer) -> None:
         if V.graph.cpp_wrapper:
             code.writeline("\n")
             if V.graph.aot_mode:
@@ -282,14 +280,17 @@ class EnterDeviceContextManagerLine:
                 else:
                     code.writeline(f"device_guard.set_index({self.device_idx});")
         else:
+            # Note _DeviceGuard has less overhead than device, but only accepts
+            # integers
+            code.writeline(f"with {V.graph.device_ops.device_guard(self.device_idx)}:")
+            code.do_indent()
             code.writeline(V.graph.device_ops.set_device(self.device_idx))
 
 
 class ExitDeviceContextManagerLine:
-    def codegen(
-        self, code: IndentedBuffer, device_cm_stack: contextlib.ExitStack
-    ) -> None:
-        pass
+    def codegen(self, code: IndentedBuffer) -> None:
+        if not V.graph.cpp_wrapper:
+            code.do_unindent()
 
 
 @dataclasses.dataclass
@@ -702,18 +703,16 @@ class WrapperCodeGen(CodeGen):
             else:
                 self.memory_plan_reuse()
 
-            device_cm_stack = contextlib.ExitStack()
             for line in self.lines:
-                if isinstance(line, MemoryPlanningLine):
-                    line.codegen(self.wrapper_call)
-                elif isinstance(
+                if isinstance(
                     line,
                     (
+                        MemoryPlanningLine,
                         EnterDeviceContextManagerLine,
                         ExitDeviceContextManagerLine,
                     ),
                 ):
-                    line.codegen(self.wrapper_call, device_cm_stack)
+                    line.codegen(self.wrapper_call)
                 else:
                     self.wrapper_call.writeline(line)
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -2314,6 +2314,11 @@ class Scheduler:
                 if self.get_backend(device).ready_to_flush():
                     self.flush()
 
+        if self.current_device and self.current_device.type == "cuda":
+            # exit the outermost CUDA device guard. this is
+            # important for nested indentation codegen-ing.
+            V.graph.wrapper_code.codegen_device_guard_exit()
+
         self.flush()
 
     def is_unaligned_buffer(self, buf_name):

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -787,6 +787,12 @@ class IndentedBuffer:
 
         return ctx()
 
+    def do_indent(self, offset=1):
+        self._indent += offset
+
+    def do_unindent(self, offset=1):
+        self._indent -= offset
+
     def splice(self, other_code, strip=False):
         if isinstance(other_code, IndentedBuffer):
             dedent = float("inf")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #119759
* __->__ #119673

Summary: The codegen of `with torch.cuda._DeviceGuard` context manager in the Python wrapper code is implemented via `device_cm_stack: contextlib.ExitStack()`. As the context managers in the stack are `code.indent()`, this means that the whole stack is unindented at once on `device_cm_stack.close()`. This becomes problematic when attempting to codegen indented code (e.g., for control flow in Python and / or nested subgraph codegen-ing).

In this PR, we refactor the device guard codegen-ing in Python by replacing the `device_cm_stack` by explicit indent and unindent calls for entering and exiting the `with torch.cuda._DeviceGuard` context manager. This allows for nested device guard context managers and better aligns with other indented codegen-ing intertwined with it (e.g., for nested subgraph codegen-ing).

This is necessary for the upcoming support for `torch.cond` (and other control flow operators) in Inductor. Before that, the only change in the Python wrapper codegen is that the `return outputs` is now happening outside the `with torch.cuda._DeviceGuard` context manager.

Test Plan: CI

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler