### PR TITLE
[export] add sequential_split to prepare replacing set_grad_enabled with hop

### DIFF
--- a/test/expect/TestFXAPIBackwardCompatibility.test_function_back_compat-fx_backcompat_function_signatures.expect
+++ b/test/expect/TestFXAPIBackwardCompatibility.test_function_back_compat-fx_backcompat_function_signatures.expect
@@ -62,7 +62,7 @@ torch.fx.node.Node.update_kwarg(self, key: str, arg: torch.fx.node.Argument) -> 
 torch.fx.node.map_aggregate(a: torch.fx.node.Argument, fn: Callable[[torch.fx.node.Argument], torch.fx.node.Argument]) -> torch.fx.node.Argument
 torch.fx.node.map_arg(a: torch.fx.node.Argument, fn: Callable[[torch.fx.node.Node], torch.fx.node.Argument]) -> torch.fx.node.Argument
 torch.fx.passes.reinplace.reinplace(gm, *sample_args)
-torch.fx.passes.split_module.split_module(m: torch.fx.graph_module.GraphModule, root_m: torch.nn.modules.module.Module, split_callback: Callable[[torch.fx.node.Node], int], qualname_map: Optional[Dict[str, str]] = None, keep_original_order: Optional[bool] = False)
+torch.fx.passes.split_module.split_module(m: torch.fx.graph_module.GraphModule, root_m: torch.nn.modules.module.Module, split_callback: Callable[[torch.fx.node.Node], int], qualname_map: Optional[Dict[str, str]] = None, keep_original_order: Optional[bool] = False, keep_original_node_name: Optional[bool] = False)
 torch.fx.proxy.Attribute.__init__(self, root: torch.fx.proxy.Proxy, attr: str)
 torch.fx.proxy.Proxy.__init__(self, node: torch.fx.node.Node, tracer: 'Optional[TracerBase]' = None)
 torch.fx.proxy.Proxy.keys(self)

--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -28,6 +28,7 @@ from torch.fx.passes.operator_support import OperatorSupport
 from torch.testing import FileCheck
 from torch.testing._internal.common_utils import run_tests, TestCase, skipIfTorchDynamo, IS_WINDOWS
 from torch.utils import _pytree as pytree
+from torch._export.utils import sequential_split, nodes_filter, nodes_first
 
 
 def count_call_function(graph: torch.fx.Graph, target: torch.ops.OpOverload) -> int:
@@ -61,6 +62,43 @@ def _get_output_names(gm: torch.fx.GraphModule) -> List[str]:
     #     args = args[0]
     return [str(arg) for arg in args]
 
+def _set_grad_enabled_tests():
+    from torch.export._trace import _export
+
+    class SetGradOp(torch.nn.Module):
+        def forward(self, x):
+            x = x + 1
+            torch._C._set_grad_enabled(True)
+            c = x.sin().sum()
+            torch._C._set_grad_enabled(False)
+            d = c + 1
+            torch._C._set_grad_enabled(True)
+            e = d - 1
+            return d, e
+
+    class SetGradCtxManager(torch.nn.Module):
+        def forward(self, x):
+            x = x + 1
+            with torch.enable_grad():
+                c = x.sin().sum()
+            with torch.no_grad():
+                d = c + 1
+            with torch.enable_grad():
+                e = d - 1
+            return d, e
+
+    x = torch.randn(2, 2)
+    def _get_predispatch_module(mod, args, ambient_grad_enabled=True):
+        with torch.set_grad_enabled(ambient_grad_enabled):
+            return _export(mod, args, pre_dispatch=True).module()
+
+
+    return {"ctx_manager": (_get_predispatch_module(SetGradCtxManager(), (x,)), (x,)),
+            "ctx_manager_under_no_grad": (_get_predispatch_module(SetGradCtxManager(), (x,), False), (x,)),
+            "op":(_get_predispatch_module(SetGradOp(), (x,)), (x,)),
+            "op_under_no_grad":(_get_predispatch_module(SetGradOp(), (x,), False), (x,))}
+
+SET_GRAD_ENABLED_TESTS = _set_grad_enabled_tests()
 
 @skipIfTorchDynamo("recursively running dynamo on export is unlikely")
 @unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
@@ -352,6 +390,116 @@ class TestPasses(TestCase):
         x = torch.randn(1, dtype=torch.float32)
         ep = torch.export.export(WrapperModule(func), args=(x,))
         _ExportPassBaseDeprecatedDoNotUse()(ep.graph_module)
+
+    def test_predispatceh_set_grad(self):
+        mod, args = SET_GRAD_ENABLED_TESTS["op"]
+        self.assertExpectedInline(mod.code.strip("\n"), """\
+def forward(self, arg_0):
+    arg0_1, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
+    add = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
+    _set_grad_enabled = torch._C._set_grad_enabled(True)
+    sin = torch.ops.aten.sin.default(add);  add = None
+    sum_1 = torch.ops.aten.sum.default(sin);  sin = None
+    _set_grad_enabled_1 = torch._C._set_grad_enabled(False)
+    add_1 = torch.ops.aten.add.Tensor(sum_1, 1);  sum_1 = None
+    _set_grad_enabled_2 = torch._C._set_grad_enabled(True)
+    sub = torch.ops.aten.sub.Tensor(add_1, 1)
+    return pytree.tree_unflatten((add_1, sub), self._out_spec)
+    """)
+        mod, args = SET_GRAD_ENABLED_TESTS["op_under_no_grad"]
+        self.assertExpectedInline(mod.code.strip("\n"), """\
+def forward(self, arg_0):
+    arg0_1, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
+    add = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
+    _set_grad_enabled = torch._C._set_grad_enabled(True)
+    sin = torch.ops.aten.sin.default(add);  add = None
+    sum_1 = torch.ops.aten.sum.default(sin);  sin = None
+    _set_grad_enabled_1 = torch._C._set_grad_enabled(False)
+    add_1 = torch.ops.aten.add.Tensor(sum_1, 1);  sum_1 = None
+    _set_grad_enabled_2 = torch._C._set_grad_enabled(True)
+    sub = torch.ops.aten.sub.Tensor(add_1, 1)
+    return pytree.tree_unflatten((add_1, sub), self._out_spec)
+    """)
+
+        mod, args = SET_GRAD_ENABLED_TESTS["ctx_manager"]
+        self.assertExpectedInline(mod.code.strip("\n"), """\
+def forward(self, arg_0):
+    arg0_1, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
+    add = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
+    sin = torch.ops.aten.sin.default(add);  add = None
+    sum_1 = torch.ops.aten.sum.default(sin);  sin = None
+    _set_grad_enabled = torch._C._set_grad_enabled(False)
+    add_1 = torch.ops.aten.add.Tensor(sum_1, 1);  sum_1 = None
+    _set_grad_enabled_1 = torch._C._set_grad_enabled(True)
+    sub = torch.ops.aten.sub.Tensor(add_1, 1)
+    return pytree.tree_unflatten((add_1, sub), self._out_spec)
+    """)
+        mod, args = SET_GRAD_ENABLED_TESTS["ctx_manager_under_no_grad"]
+        self.assertExpectedInline(mod.code.strip("\n"), """\
+def forward(self, arg_0):
+    arg0_1, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
+    add = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
+    _set_grad_enabled = torch._C._set_grad_enabled(True)
+    sin = torch.ops.aten.sin.default(add);  add = None
+    sum_1 = torch.ops.aten.sum.default(sin);  sin = None
+    _set_grad_enabled_1 = torch._C._set_grad_enabled(False)
+    add_1 = torch.ops.aten.add.Tensor(sum_1, 1);  sum_1 = None
+    _set_grad_enabled_2 = torch._C._set_grad_enabled(True)
+    sub = torch.ops.aten.sub.Tensor(add_1, 1)
+    _set_grad_enabled_3 = torch._C._set_grad_enabled(False)
+    return pytree.tree_unflatten((add_1, sub), self._out_spec)
+    """)
+
+    def test_sequential_split(self):
+        for gm, args in SET_GRAD_ENABLED_TESTS.values():
+            def _is_set_grad_enabled_node(node):
+                return node.op == "call_function" and node.target == torch._C._set_grad_enabled
+
+            def _is_set_grad_enabled_sub_mod(node):
+                if node.op == "call_module":
+                    subgm = getattr(node.graph.owning_module, node.target)
+                    first_non_ph= nodes_first(subgm.graph.nodes, lambda node: node.op != "placeholder")
+                    if first_non_ph and first_non_ph.op == "call_function" and first_non_ph.target == torch._C._set_grad_enabled:
+                        return True
+                return False
+
+            set_grad_counts = len(nodes_filter(gm.graph.nodes, _is_set_grad_enabled_node))
+            new_gm = sequential_split(gm, _is_set_grad_enabled_node)
+            new_set_grad_counts = len(nodes_filter(new_gm.graph.nodes, _is_set_grad_enabled_sub_mod))
+            self.assertEqual(set_grad_counts, new_set_grad_counts)
+
+    def test_sequential_split_graph(self):
+        gm, args = SET_GRAD_ENABLED_TESTS["ctx_manager"]
+        def _is_set_grad_enabled_node(node):
+            return node.op == "call_function" and node.target == torch._C._set_grad_enabled
+        new_gm = sequential_split(gm, _is_set_grad_enabled_node)
+        self.assertExpectedInline(new_gm.code.strip("\n"), """\
+def forward(self, arg_0):
+    sub, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
+    submod_0 = self.submod_0(sub);  sub = None
+    submod_1 = self.submod_1(submod_0);  submod_0 = None
+    submod_2 = self.submod_2(submod_1)
+    return pytree.tree_unflatten((submod_1, submod_2), self._out_spec)
+    """)
+        self.assertExpectedInline(new_gm.submod_0.code.strip("\n"), """\
+def forward(self, arg0_1):
+    add = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
+    sin = torch.ops.aten.sin.default(add);  add = None
+    sum_1 = torch.ops.aten.sum.default(sin);  sin = None
+    return sum_1
+    """)
+        self.assertExpectedInline(new_gm.submod_1.code.strip("\n"), """\
+def forward(self, sum_1):
+    _set_grad_enabled = torch._C._set_grad_enabled(False)
+    add_1 = torch.ops.aten.add.Tensor(sum_1, 1);  sum_1 = None
+    return add_1
+    """)
+        self.assertExpectedInline(new_gm.submod_2.code.strip("\n"), """\
+def forward(self, add_1):
+    _set_grad_enabled_1 = torch._C._set_grad_enabled(True)
+    sub = torch.ops.aten.sub.Tensor(add_1, 1);  add_1 = None
+    return sub
+    """)
 
 
 if __name__ == '__main__':

--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -88,15 +88,16 @@ def _set_grad_enabled_tests():
             return d, e
 
     x = torch.randn(2, 2)
+
     def _get_predispatch_module(mod, args, ambient_grad_enabled=True):
         with torch.set_grad_enabled(ambient_grad_enabled):
             return _export(mod, args, pre_dispatch=True).module()
 
 
-    return {"ctx_manager": (_get_predispatch_module(SetGradCtxManager(), (x,)), (x,)),
-            "ctx_manager_under_no_grad": (_get_predispatch_module(SetGradCtxManager(), (x,), False), (x,)),
-            "op":(_get_predispatch_module(SetGradOp(), (x,)), (x,)),
-            "op_under_no_grad":(_get_predispatch_module(SetGradOp(), (x,), False), (x,))}
+    return {"ctx_manager" : (_get_predispatch_module(SetGradCtxManager(), (x,)), (x,)),
+            "ctx_manager_under_no_grad" : (_get_predispatch_module(SetGradCtxManager(), (x,), False), (x,)),
+            "op" : (_get_predispatch_module(SetGradOp(), (x,)), (x,)),
+            "op_under_no_grad" : (_get_predispatch_module(SetGradOp(), (x,), False), (x,))}
 
 SET_GRAD_ENABLED_TESTS = _set_grad_enabled_tests()
 
@@ -458,7 +459,7 @@ def forward(self, arg_0):
             def _is_set_grad_enabled_sub_mod(node):
                 if node.op == "call_module":
                     subgm = getattr(node.graph.owning_module, node.target)
-                    first_non_ph= nodes_first(subgm.graph.nodes, lambda node: node.op != "placeholder")
+                    first_non_ph = nodes_first(subgm.graph.nodes, lambda node: node.op != "placeholder")
                     if first_non_ph and first_non_ph.op == "call_function" and first_non_ph.target == torch._C._set_grad_enabled:
                         return True
                 return False
@@ -470,6 +471,7 @@ def forward(self, arg_0):
 
     def test_sequential_split_graph(self):
         gm, args = SET_GRAD_ENABLED_TESTS["ctx_manager"]
+
         def _is_set_grad_enabled_node(node):
             return node.op == "call_function" and node.target == torch._C._set_grad_enabled
         new_gm = sequential_split(gm, _is_set_grad_enabled_node)

--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -475,10 +475,11 @@ def forward(self, arg_0):
         def _is_set_grad_enabled_node(node):
             return node.op == "call_function" and node.target == torch._C._set_grad_enabled
         new_gm = sequential_split(gm, _is_set_grad_enabled_node)
+        self.assertEqual(new_gm(*args), gm(*args))
         self.assertExpectedInline(new_gm.code.strip("\n"), """\
 def forward(self, arg_0):
-    sub, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
-    submod_0 = self.submod_0(sub);  sub = None
+    arg0_1, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
+    submod_0 = self.submod_0(arg0_1);  arg0_1 = None
     submod_1 = self.submod_1(submod_0);  submod_0 = None
     submod_2 = self.submod_2(submod_1)
     return pytree.tree_unflatten((submod_1, submod_2), self._out_spec)

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -238,3 +238,38 @@ def get_buffer(
             return program.state_dict[buffer_name]
 
     return None
+
+
+def sequential_split(gm: torch.fx.GraphModule, node_call_back) -> torch.fx.GraphModule:
+    from torch.fx.passes.split_module import split_module
+
+    split_map = {}
+    split_id = 0
+    for node in gm.graph.nodes:
+        if node_call_back(node):
+            split_id += 1
+        split_map[node] = split_id
+
+    new_gm = split_module(
+        gm,
+        gm,
+        lambda node: split_map[node],
+        keep_original_order=True,
+        keep_original_node_name=True,
+    )
+    new_gm.graph._codegen = gm.graph._codegen
+    new_gm.recompile()
+    return new_gm
+
+
+def nodes_filter(nodes: List[torch.fx.Node], node_call_back) -> List[torch.fx.Node]:
+    return [node for node in nodes if node_call_back(node)]
+
+
+def nodes_first(
+    nodes: List[torch.fx.Node], node_call_back=None
+) -> Optional[torch.fx.Node]:
+    ret = nodes_filter(nodes, node_call_back if node_call_back else lambda node: True)
+    if len(ret) > 0:
+        return ret[0]
+    return None

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -241,9 +241,10 @@ def get_buffer(
 
 
 def sequential_split(gm: torch.fx.GraphModule, node_call_back) -> torch.fx.GraphModule:
-    """ Splits the graph module into multiple submodules based on the node_call_back.
-        The node_call_back should return True if the node is a delimiter. Delimiter will be
-        the first node in the next submodule.
+    """
+    Splits the graph module into multiple submodules based on the node_call_back.
+    The node_call_back should return True if the node is a delimiter. Delimiter will be
+    the first node in the next submodule.
     """
     from torch.fx.passes.split_module import split_module
 
@@ -268,16 +269,16 @@ def sequential_split(gm: torch.fx.GraphModule, node_call_back) -> torch.fx.Graph
 
 
 def nodes_filter(nodes: List[torch.fx.Node], node_call_back) -> List[torch.fx.Node]:
-    """ Returns the nodes as a list that match the node_call_back."""
+    """Returns the nodes that match the node_call_back as a list."""
     return [node for node in nodes if node_call_back(node)]
 
 
 def nodes_first(
     nodes: List[torch.fx.Node], node_call_back=None
 ) -> Optional[torch.fx.Node]:
-    """ Returns the first node that matches the node_call_back.
-        If no node matches, returns None.
-        When node_call_back is None, returns the first node in the node list.
+    """
+    Returns the first node that matches the node_call_back. If no node matches, returns None.
+    When node_call_back is None, returns the first node in the node list.
     """
     ret = nodes_filter(nodes, node_call_back if node_call_back else lambda node: True)
     if len(ret) > 0:

--- a/torch/fx/passes/split_module.py
+++ b/torch/fx/passes/split_module.py
@@ -153,8 +153,13 @@ def split_module(
             default_value = (
                 node.args[0] if len(node.args) > 0 else inspect.Signature.empty
             )
-            args = () if default_value is inspect.Signature.empty else (default_value,)
-            base_mod_env[node.name] = base_mod_graph.create_node('placeholder', name, args=args, type_expr=node.type)
+            if keep_original_node_name:
+                args = () if default_value is inspect.Signature.empty else (default_value,)
+                base_mod_env[node.name] = base_mod_graph.create_node('placeholder', node.name, args=args, type_expr=node.type)
+            else:
+                base_mod_env[node.name] = base_mod_graph.placeholder(
+                    node.target, type_expr=node.type, default_value=default_value
+                )
             base_mod_env[node.name].meta = node.meta.copy()
         elif node.op == "get_attr":
             base_mod_env[node.name] = base_mod_graph.get_attr(node.target)

--- a/torch/fx/passes/split_module.py
+++ b/torch/fx/passes/split_module.py
@@ -47,6 +47,7 @@ def split_module(
     split_callback: Callable[[Node], int],
     qualname_map: Optional[Dict[str, str]] = None,
     keep_original_order: Optional[bool] = False,
+    keep_original_node_name: Optional[bool] = False,
 ):
     """
     Creates subgraphs out of main graph
@@ -152,9 +153,8 @@ def split_module(
             default_value = (
                 node.args[0] if len(node.args) > 0 else inspect.Signature.empty
             )
-            base_mod_env[node.name] = base_mod_graph.placeholder(
-                node.target, type_expr=node.type, default_value=default_value
-            )
+            args = () if default_value is inspect.Signature.empty else (default_value,)
+            base_mod_env[node.name] = base_mod_graph.create_node('placeholder', name, args=args, type_expr=node.type)
             base_mod_env[node.name].meta = node.meta.copy()
         elif node.op == "get_attr":
             base_mod_env[node.name] = base_mod_graph.get_attr(node.target)
@@ -394,12 +394,14 @@ def split_module(
 
             assert isinstance(gathered_args, tuple)
             assert isinstance(gathered_kwargs, dict)
+            name = node.name if keep_original_node_name else None
             new_node = partition.graph.create_node(
                 op=node.op,
                 target=target,
                 args=gathered_args,
                 kwargs=gathered_kwargs,
                 type_expr=node.type,
+                name=name,
             )
             new_node.meta = node.meta.copy()
             partition.environment[node] = new_node


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #119915
* #119914
* #119913
* #119810
* #119736
* __->__ #119732

This pr is the 1/N pr of transforming the global state mutating ops  such as torch._C.set_grad_enabled calls in pre-dispatch graph into a higher order op so that the graph becomes more functional. We make use of split_module to help us do the transformation. 

This pr preserves the node.name in original module by adding a new kwarg `keep_original_node_name` to split_module.

For a graph looks like this:
```python
def forward(self, arg_0):
    arg0_1, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
    add = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
    sin = torch.ops.aten.sin.default(add);  add = None
    sum_1 = torch.ops.aten.sum.default(sin);  sin = None
    _set_grad_enabled = torch._C._set_grad_enabled(False)
    add_1 = torch.ops.aten.add.Tensor(sum_1, 1);  sum_1 = None
    _set_grad_enabled_1 = torch._C._set_grad_enabled(True)
    sub = torch.ops.aten.sub.Tensor(add_1, 1)
    return pytree.tree_unflatten((add_1, sub), self._out_spec)
```
Before the change, split graph returns the following graphs and subgraphs (notice the change from `add` -> `add_tensor`, `sin` -> `sin_default`: 
```python
def forward(self, arg_0):
    arg0_1, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
    submod_0 = self.submod_0(arg0_1);  arg0_1 = None
    submod_1 = self.submod_1(submod_0);  submod_0 = None
    submod_2 = self.submod_2(submod_1)
    return pytree.tree_unflatten((submod_1, submod_2), self._out_spec)

# submod_0
def forward(self, arg0_1):
    add_tensor = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
    sin_default = torch.ops.aten.sin.default(add_tensor);  add_tensor = None
    sum_default = torch.ops.aten.sum.default(sin_default);  sin_default = None
    return sum_default

# submod_1
def forward(self, sum_1):
    _set_grad_enabled = torch._C._set_grad_enabled(False)
    add_tensor = torch.ops.aten.add.Tensor(sum_1, 1);  sum_1 = None
    return add_tensor

# submod_2
def forward(self, add_1):
    _set_grad_enabled = torch._C._set_grad_enabled(True)
    sub_tensor = torch.ops.aten.sub.Tensor(add_1, 1);  add_1 = None
    return sub_tensor
    """)

```

After the change, the test produce the following graph, all the node names in original graph module are preserved in sub_modules.
```python

def forward(self, arg_0):
    sub, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
    submod_0 = self.submod_0(sub);  sub = None
    submod_1 = self.submod_1(submod_0);  submod_0 = None
    submod_2 = self.submod_2(submod_1)
    return pytree.tree_unflatten((submod_1, submod_2), self._out_spec)

# submod_0
def forward(self, arg0_1):
    add = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
    sin = torch.ops.aten.sin.default(add);  add = None
    sum_1 = torch.ops.aten.sum.default(sin);  sin = None
    return sum_1

# submod_1
def forward(self, sum_1):
    _set_grad_enabled = torch._C._set_grad_enabled(False)
    add_1 = torch.ops.aten.add.Tensor(sum_1, 1);  sum_1 = None
    return add_1

# submod_2
def forward(self, add_1):
    _set_grad_enabled_1 = torch._C._set_grad_enabled(True)
    sub = torch.ops.aten.sub.Tensor(add_1, 1);  add_1 = None
    return sub

```

Note that currently, we call split_module on the graph after pre-dispatch aot. The difference is even larger if we `split_module` the graph module produced by dynamo, where all the original variables names in user program are preserved after dynamo but  lost after `split_module` without this change. 