### PR TITLE
Skip log line if no tensors were dedupped

### DIFF
--- a/torch/distributed/checkpoint/_dedup_tensors.py
+++ b/torch/distributed/checkpoint/_dedup_tensors.py
@@ -43,7 +43,8 @@ def dedup_tensors(all_plans: List[SavePlan]) -> List[SavePlan]:
     for key, plans in replicated_items.items():
         for plan_idx in plans[1:]:
             plan_to_keys.setdefault(plan_idx, []).append(key)
-    logger.info("Duplicate keys to remove: %s", plan_to_keys)
+    if len(plan_to_keys) > 0:
+        logger.info("Duplicate keys to remove: %s", plan_to_keys)
 
     for plan_idx, keys in plan_to_keys.items():
         key_set = set(keys)


### PR DESCRIPTION
Skips log line if nothing was dedupped. Avoids unhelpful logs like:
```
2024-02-13 01:31:52,113 _dedup_tensors.py:46 INFO p:MainProcess t:MainThread: Duplicate keys to remove: {}
```

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @LucasLLC