### PR TITLE
[inductor][perf] Replace inefficient use of set.

### DIFF
--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -118,8 +118,7 @@ def may_get_constant_buffer_dtype(constant_buffer):
 
 
 def is_magic_method(op):
-    magic_ops = {method_to_operator(m) for m in magic_methods}
-    return op in magic_ops
+    return op in map(method_to_operator, magic_methods)
 
 
 def getattr_recursive(obj, target):


### PR DESCRIPTION
It makes no sense to create a set in `O(N)` time and memory (including the case when the very first occurrence would match) to perform an amortized `O(1)` lookup with high constant factor instead of doing a simple scan in `O(N)` time and `O(1)` memory and lower constant factor.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov