### PR TITLE
Fixed FxGraphDrawer compat constructor

### DIFF
--- a/torch/fx/passes/graph_drawer.py
+++ b/torch/fx/passes/graph_drawer.py
@@ -412,7 +412,10 @@ else:
                 graph_module: torch.fx.GraphModule,
                 name: str,
                 ignore_getattr: bool = False,
+                ignore_parameters_and_buffers: bool = False,
+                skip_node_names_in_args: bool = True,
                 parse_stack_trace: bool = False,
+                dot_graph_shape: Optional[str] = None,
             ):
                 raise RuntimeError('FXGraphDrawer requires the pydot package to be installed. Please install '
                                    'pydot through your favorite Python package manager.')


### PR DESCRIPTION
Match FxGraphDrawer compat constructor signature to avoid the following failure when `pydot` is not installed:
```
  File "/pytorch/torch/_functorch/partitioners.py", line 933, in draw_graph
    g = graph_drawer.FxGraphDrawer(
torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
TypeError: __init__() got an unexpected keyword argument 'dot_graph_shape'
```