### PR TITLE
Fix TCP Store Windows (#118860)

### DIFF
--- a/torch/csrc/distributed/c10d/TCPStoreBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreBackend.cpp
@@ -539,6 +539,7 @@ void TCPStoreMasterDaemon::run() {
       int rawSocket = socket.handle();
       sockets_.emplace_back(std::move(socket));
       tcputil::addPollfd(fds, rawSocket, POLLIN);
+      addMiscellaneousSocket(rawSocket);
     }
     queryFds(fds);
   }


### PR DESCRIPTION
In https://github.com/pytorch/pytorch/pull/107607 there was added a new Validate flow, however on Windows it was not calling addMiscellaneousSocket. Added missing call to addMiscellaneousSocket on Windows.

Fixes #118737

Pull Request resolved: https://github.com/pytorch/pytorch/pull/118860
Approved by: https://github.com/awgu, https://github.com/malfet

