### PR TITLE
[structural binding][1/N] Replace std::tie with structural binding

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -296,10 +296,7 @@ struct QuantizedCellParams : public CellParamsBase {
   }
   static c10::intrusive_ptr<CellParamsBase> __setstate__(
       CellParamsSerializationType state) {
-    std::vector<at::Tensor> tensors;
-    std::vector<double> doubles;
-    std::vector<int64_t> longs;
-    std::tie(std::ignore, tensors, doubles, longs, std::ignore) =
+    auto [_, tensors, doubles, longs, __] =
         std::move(state);
     TORCH_INTERNAL_ASSERT(tensors.size() == 6);
     TORCH_INTERNAL_ASSERT(doubles.size() == 2);
@@ -344,12 +341,9 @@ c10::intrusive_ptr<CellParamsBase> make_quantized_cell_params(
         std::make_tuple(std::move(packed_weight)), std::move(params));
   };
 
-  at::Tensor qw_ih, qw_hh, packed_ih, packed_hh, col_offsets_ih, col_offsets_hh;
-  at::Scalar scale_ih, scale_hh, zero_point_ih, zero_point_hh;
-
-  std::tie(packed_ih, qw_ih, col_offsets_ih, scale_ih, zero_point_ih) =
+  auto [packed_ih, qw_ih, col_offsets_ih, scale_ih, zero_point_ih] =
       make_vals(w_ih);
-  std::tie(packed_hh, qw_hh, col_offsets_hh, scale_hh, zero_point_hh) =
+  auto [packed_hh, qw_hh, col_offsets_hh, scale_hh, zero_point_hh] =
       make_vals(w_hh);
 
   return c10::make_intrusive<QuantizedCellParams>(
@@ -444,10 +438,7 @@ struct QuantizedCellParamsDynamic : public CellParamsBase {
   }
   static c10::intrusive_ptr<CellParamsBase> __setstate__(
       CellParamsSerializationType state) {
-    std::vector<at::Tensor> tensors;
-    std::vector<c10::intrusive_ptr<LinearPackedParamsBase>> packed_params;
-    std::vector<int64_t> serialized_ints;
-    std::tie(std::ignore, tensors, std::ignore, serialized_ints, packed_params) =
+    auto [_, tensors, __, serialized_ints, packed_params] =
         std::move(state);
     TORCH_INTERNAL_ASSERT(tensors.size() == 2);
     TORCH_INTERNAL_ASSERT(packed_params.size() == 2);
@@ -520,10 +511,7 @@ struct QuantizedCellParamsFP16 : public CellParamsBase {
   }
   static c10::intrusive_ptr<CellParamsBase> __setstate__(
       CellParamsSerializationType state) {
-    std::vector<c10::intrusive_ptr<LinearPackedParamsBase>> packed_params;
-    std::tie(
-        std::ignore, std::ignore, std::ignore, std::ignore, packed_params) =
-        std::move(state);
+    auto packed_params = std::get<4>(std::move(state));
     TORCH_INTERNAL_ASSERT(packed_params.size() == 2);
     return make_quantized_cell_params_fp16(
         /*w_ih_packed=*/std::move(packed_params[0]),

--- a/aten/src/ATen/native/cuda/TensorTopK.cpp
+++ b/aten/src/ATen/native/cuda/TensorTopK.cpp
@@ -26,8 +26,7 @@ void topk_out_with_sort(
   const Tensor& values,
   const Tensor& indices
 ) {
-  Tensor sorted_values, sorted_indices;
-  std::tie(sorted_values, sorted_indices) = at::cuda::sort(self, /* stable= */false, dim, largest);
+  auto [sorted_values, sorted_indices] = at::cuda::sort(self, /* stable= */false, dim, largest);
   values.copy_(sorted_values.narrow(dim, 0, k));
   indices.copy_(sorted_indices.narrow(dim, 0, k));
 }

--- a/c10/core/SymbolicShapeMeta.cpp
+++ b/c10/core/SymbolicShapeMeta.cpp
@@ -101,10 +101,7 @@ SymBool SymbolicShapeMeta::compute_contiguous() const {
     }                                                           \
     auto n = normalize_sym_sizes_strides(sizes_, strides_);     \
     if (n.has_value()) {                                        \
-      SymNode base;                                             \
-      std::vector<SymNode> size_nodes;                          \
-      std::vector<SymNode> stride_nodes;                        \
-      std::tie(base, size_nodes, stride_nodes) = *n;            \
+      auto [base, size_nodes, stride_nodes] = *n;               \
       return SymBool(base->nodeimpl(size_nodes, stride_nodes)); \
     } else {                                                    \
       c10::SymIntArrayRef sizes(sizes_);                        \

--- a/torch/csrc/api/include/torch/nn/functional/upsampling.h
+++ b/torch/csrc/api/include/torch/nn/functional/upsampling.h
@@ -18,12 +18,7 @@ inline std::vector<int64_t> _interp_output_size(
         c10::optional<std::vector<int64_t>>,
         c10::optional<std::vector<double>>,
         c10::optional<bool>> closed_over_args) {
-  Tensor input;
-  c10::optional<std::vector<int64_t>> size;
-  c10::optional<std::vector<double>> scale_factor;
-  c10::optional<bool> recompute_scale_factor;
-  std::tie(input, size, scale_factor, recompute_scale_factor) =
-      closed_over_args;
+  auto [input, size, scale_factor, recompute_scale_factor] = closed_over_args;
   if (size == c10::nullopt && scale_factor == c10::nullopt) {
     TORCH_CHECK(false, "either size or scale_factor should be defined");
   }

--- a/torch/csrc/api/include/torch/nn/modules/conv.h
+++ b/torch/csrc/api/include/torch/nn/modules/conv.h
@@ -107,9 +107,7 @@ class ConvNdImpl : public torch::nn::Cloneable<Derived> {
         /*a=*/std::sqrt(5)); // NOLINT(cppcoreguidelines-avoid-magic-numbers)
 
     if (bias.defined()) {
-      // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-      int64_t fan_in, fan_out;
-      std::tie(fan_in, fan_out) = init::_calculate_fan_in_and_fan_out(weight);
+      auto [fan_in, fan_out] = init::_calculate_fan_in_and_fan_out(weight);
       auto bound = 1 / std::sqrt(fan_in);
       init::uniform_(bias, -bound, bound);
     }

--- a/torch/csrc/api/include/torch/nn/utils/rnn.h
+++ b/torch/csrc/api/include/torch/nn/utils/rnn.h
@@ -212,8 +212,7 @@ inline PackedSequence pack_padded_sequence(
     input = input.index_select(batch_dim, sorted_indices);
   }
 
-  Tensor data, batch_sizes;
-  std::tie(data, batch_sizes) =
+  auto [data, batch_sizes] =
       torch::_pack_padded_sequence(input, lengths, batch_first);
   return PackedSequence(
       std::move(data), std::move(batch_sizes), std::move(sorted_indices), {});
@@ -262,8 +261,7 @@ inline std::tuple<Tensor, Tensor> pad_packed_sequence(
         max_seq_length);
     max_seq_length = total_length_val;
   }
-  Tensor padded_output, lengths;
-  std::tie(padded_output, lengths) = torch::_pad_packed_sequence(
+  auto [padded_output, lengths] = torch::_pad_packed_sequence(
       sequence.data(),
       sequence.batch_sizes(),
       batch_first,

--- a/torch/csrc/api/src/nn/init.cpp
+++ b/torch/csrc/api/src/nn/init.cpp
@@ -134,8 +134,7 @@ Tensor orthogonal_(Tensor tensor, double gain) {
   }
 
   // Compute the qr factorization
-  Tensor q, r;
-  std::tie(q, r) = torch::linalg::qr(flattened);
+  auto [q, r] = torch::linalg::qr(flattened);
   // Make Q uniform according to https://arxiv.org/pdf/math-ph/0609050.pdf
   auto d = torch::diag(r, 0);
   auto ph = d.sign();

--- a/torch/csrc/api/src/nn/modules/linear.cpp
+++ b/torch/csrc/api/src/nn/modules/linear.cpp
@@ -46,9 +46,7 @@ void LinearImpl::reset_parameters() {
   torch::nn::init::kaiming_uniform_(
       weight, std::sqrt(5)); // NOLINT(cppcoreguidelines-avoid-magic-numbers)
   if (bias.defined()) {
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    int64_t fan_in, fan_out;
-    std::tie(fan_in, fan_out) =
+    auto [fan_in, fan_out] =
         torch::nn::init::_calculate_fan_in_and_fan_out(weight);
     const auto bound = 1 / std::sqrt(fan_in);
     torch::nn::init::uniform_(bias, -bound, bound);

--- a/torch/csrc/api/src/nn/modules/rnn.cpp
+++ b/torch/csrc/api/src/nn/modules/rnn.cpp
@@ -526,8 +526,7 @@ std::tuple<Tensor, Tensor> RNNImpl::forward(const Tensor& input, Tensor hx) {
   auto sorted_indices = torch::Tensor();
   auto unsorted_indices = torch::Tensor();
 
-  Tensor output, hidden;
-  std::tie(output, hidden) = this->forward_helper(
+  auto [output, hidden] = this->forward_helper(
       input, batch_sizes, sorted_indices, max_batch_size, std::move(hx));
 
   return std::make_tuple(
@@ -543,8 +542,7 @@ std::tuple<PackedSequence, Tensor> RNNImpl::forward_with_packed_input(
   const auto& unsorted_indices = packed_input.unsorted_indices();
   auto max_batch_size = batch_sizes[0].item<int64_t>();
 
-  Tensor output, hidden;
-  std::tie(output, hidden) = this->forward_helper(
+  auto [output, hidden] = this->forward_helper(
       input, batch_sizes, sorted_indices, max_batch_size, std::move(hx));
 
   auto output_packed =
@@ -678,9 +676,7 @@ std::tuple<Tensor, std::tuple<Tensor, Tensor>> LSTMImpl::forward(
   auto sorted_indices = torch::Tensor();
   auto unsorted_indices = torch::Tensor();
 
-  Tensor output;
-  std::tuple<Tensor, Tensor> hidden;
-  std::tie(output, hidden) = this->forward_helper(
+  auto [output, hidden] = this->forward_helper(
       input, batch_sizes, sorted_indices, max_batch_size, std::move(hx_opt));
 
   return std::make_tuple(
@@ -697,9 +693,7 @@ std::tuple<PackedSequence, std::tuple<Tensor, Tensor>> LSTMImpl::
   const auto& unsorted_indices = packed_input.unsorted_indices();
   auto max_batch_size = batch_sizes[0].item<int64_t>();
 
-  Tensor output;
-  std::tuple<Tensor, Tensor> hidden;
-  std::tie(output, hidden) = this->forward_helper(
+  auto [output, hidden] = this->forward_helper(
       input, batch_sizes, sorted_indices, max_batch_size, std::move(hx_opt));
 
   auto output_packed =
@@ -779,8 +773,7 @@ std::tuple<Tensor, Tensor> GRUImpl::forward(const Tensor& input, Tensor hx) {
   auto sorted_indices = torch::Tensor();
   auto unsorted_indices = torch::Tensor();
 
-  Tensor output, hidden;
-  std::tie(output, hidden) = this->forward_helper(
+  auto [output, hidden] = this->forward_helper(
       input, batch_sizes, sorted_indices, max_batch_size, std::move(hx));
 
   return std::make_tuple(
@@ -796,8 +789,7 @@ std::tuple<PackedSequence, Tensor> GRUImpl::forward_with_packed_input(
   const auto& unsorted_indices = packed_input.unsorted_indices();
   auto max_batch_size = batch_sizes[0].item<int64_t>();
 
-  Tensor output, hidden;
-  std::tie(output, hidden) = this->forward_helper(
+  auto [output, hidden] = this->forward_helper(
       input, batch_sizes, sorted_indices, max_batch_size, std::move(hx));
 
   auto output_packed =

--- a/torch/csrc/api/src/optim/lbfgs.cpp
+++ b/torch/csrc/api/src/optim/lbfgs.cpp
@@ -254,10 +254,7 @@ static std::tuple<double, Tensor, double, int64_t> _strong_wolfe(
   auto d_norm = val(d.abs().max());
   g = g.clone(at::MemoryFormat::Contiguous);
   // evaluate objective and gradient using initial step
-  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  double f_new;
-  Tensor g_new;
-  std::tie(f_new, g_new) = obj_func(x, t, d);
+  auto [f_new, g_new] = obj_func(x, t, d);
   int64_t ls_func_evals = 1;
   auto gtd_new = g_new.dot(d);
 
@@ -330,9 +327,7 @@ static std::tuple<double, Tensor, double, int64_t> _strong_wolfe(
   // exact point satisfying the criteria
   bool insuf_progress = false;
   // find high and low points in bracket
-  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  int64_t low_pos, high_pos;
-  std::tie(low_pos, high_pos) = bracket_f[0] <= bracket_f[1]
+  auto [low_pos, high_pos] = bracket_f[0] <= bracket_f[1]
       ? std::make_tuple(0, 1)
       : std::make_tuple(1, 0);
   while (!done && (ls_iter < max_ls)) {

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -7113,8 +7113,7 @@ Tensor values_backward(const Tensor& grad, const Tensor& self) {
           self.options(),
           /*is_coalesced=*/true);
     } else if (at::sparse_csr::is_sparse_compressed(self)) {
-      Tensor compressed_indices, plain_indices;
-      std::tie(compressed_indices, plain_indices) =
+      auto [compressed_indices, plain_indices] =
           at::sparse_csr::getCompressedPlainIndices(self);
       return at::_sparse_compressed_tensor_unsafe_symint(
           compressed_indices,

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -279,8 +279,9 @@ ArrayRef<ncclComm_t> get_communicators(TensorList inputs) {
   };
   device_list devices = fmap(inputs, get_device);
   auto it = _communicators.find(devices);
-  if (it == _communicators.end())
-    std::tie(it, std::ignore) = _communicators.emplace(devices, devices);
+  if (it == _communicators.end()) {
+    it = _communicators.emplace(devices, devices).first;
+  }
   return it->second.ref();
 }
 

--- a/torch/csrc/cuda/shared/cudnn.cpp
+++ b/torch/csrc/cuda/shared/cudnn.cpp
@@ -66,8 +66,7 @@ version_tuple getRuntimeVersion() {
 
 size_t getVersionInt() {
   // miopen version is MAJOR*1000000 + MINOR*1000 + PATCH
-  size_t major, minor, patch;
-  std::tie(major, minor, patch) = getRuntimeVersion();
+  auto [major, minor, patch] = getRuntimeVersion();
   return major * 1000000 + minor * 1000 + patch;
 }
 

--- a/torch/csrc/distributed/c10d/comm.cpp
+++ b/torch/csrc/distributed/c10d/comm.cpp
@@ -67,8 +67,7 @@ void broadcast_coalesced(
   // Coalesce tensors into buckets taking into account the maximum buffer size.
   // This routine is multi-device aware, so the tensors can be split across
   // multiple devices and can contain a mix of CPU and CUDA tensors.
-  std::vector<std::vector<size_t>> buckets;
-  std::tie(buckets, std::ignore) =
+  auto [buckets, _] =
       compute_bucket_assignment_by_size(tensors.vec(), {buffer_size});
 
   // Returns tensor at specified index in input tensor list.

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -1805,11 +1805,9 @@ bool Reducer::rebuild_buckets() {
           params_.size(),
           " versus rebuilt params size of: ",
           rebuilt_param_indices_.size()));
-  std::vector<std::vector<size_t>> rebuilt_bucket_indices;
   std::vector<size_t> bucket_size_limits;
   bucket_size_limits.push_back(first_bucket_bytes_cap_);
   bucket_size_limits.push_back(bucket_bytes_cap_);
-  std::vector<size_t> per_bucket_size_limits;
   auto ddp_set_last_bucket_as_small =
       (getCvarString({"DDP_SET_LAST_BUCKET_CAP"}, "N/A") == "1");
 
@@ -1822,7 +1820,7 @@ bool Reducer::rebuild_buckets() {
     std::reverse(rebuilt_params_.begin(), rebuilt_params_.end());
     std::reverse(rebuilt_param_indices_.begin(), rebuilt_param_indices_.end());
   }
-  std::tie(rebuilt_bucket_indices, per_bucket_size_limits) =
+  auto [rebuilt_bucket_indices, per_bucket_size_limits] =
       compute_bucket_assignment_by_size(
           rebuilt_params_,
           bucket_size_limits,

--- a/torch/csrc/distributed/rpc/agent_utils.cpp
+++ b/torch/csrc/distributed/rpc/agent_utils.cpp
@@ -176,8 +176,7 @@ int syncCallCount(
     ::c10d::PrefixStore store,
     const int worldSize,
     int activeCalls) {
-  std::string processCountKey, activeCallCountKey, readyKey;
-  std::tie(processCountKey, activeCallCountKey, readyKey) = getNextKeyIds();
+  auto [processCountKey, activeCallCountKey, readyKey] = getNextKeyIds();
 
   // Add to keys which will record the number of processes and active calls
   store.add(activeCallCountKey, activeCalls);

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -564,10 +564,7 @@ void TensorPipeAgent::pipeRead(
       GroupMembershipLockGuard guard(groupMembershipMutex_, isStaticGroup_);
       streams = getStreamsFromPoolForDevices(devices_);
     }
-    tensorpipe::Allocation tpAllocation;
-    TensorpipeReadBuffers tpBuffers;
-    std::tie(tpAllocation, tpBuffers) =
-        tensorpipeAllocate(tpDescriptor, streams);
+    auto [tpAllocation, tpBuffers] = tensorpipeAllocate(tpDescriptor, streams);
 
     pipe->read(
         std::move(tpAllocation),
@@ -597,10 +594,7 @@ void TensorPipeAgent::pipeWrite(
     std::vector<c10::Device>&& devices,
     std::vector<c10::Stream> streams,
     std::function<void(const tensorpipe::Error&)> fn) noexcept {
-  tensorpipe::Message tpMessage;
-  TensorpipeWriteBuffers tpBuffers;
-
-  std::tie(tpMessage, tpBuffers) =
+  auto [tpMessage, tpBuffers] =
       tensorpipeSerialize(std::move(rpcMessage), std::move(devices), streams);
 
   pipe->write(
@@ -816,11 +810,15 @@ c10::intrusive_ptr<JitFuture> TensorPipeAgent::send(
       // An instance of ClientPipe cannot be copied or moved as it contains a
       // mutex, and to force in-place construction in GCC 5 we need piecewise
       // construction in order to work around an issue.
-      std::tie(it, std::ignore) = connectedPipes_.emplace(
-          std::piecewise_construct,
-          std::forward_as_tuple(toWorkerInfo.id_),
-          std::forward_as_tuple(context_->connect(
-              url, tensorpipe::PipeOptions().remoteName(toWorkerInfo.name_))));
+      it = connectedPipes_
+               .emplace(
+                   std::piecewise_construct,
+                   std::forward_as_tuple(toWorkerInfo.id_),
+                   std::forward_as_tuple(context_->connect(
+                       url,
+                       tensorpipe::PipeOptions().remoteName(
+                           toWorkerInfo.name_))))
+               .first;
     }
   }
   ClientPipe& clientPipe = it->second;

--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -612,12 +612,10 @@ uint64_t computeFlops(
     }
     // format of the input is defined in
     // torch.ao.nn.quantized.functional.conv2d()
-    uint64_t minibatch = 0, in_channels = 0, input_h = 0, input_w = 0;
-    uint64_t out_channels = 0, kernel_h = 0, kernel_w = 0;
     const uint64_t conv2d_multiply_factor = 2;
-    std::tie(minibatch, in_channels, input_h, input_w) = std::make_tuple(
+    auto [minibatch, in_channels, input_h, input_w] = std::make_tuple(
         input_sizes[0], input_sizes[1], input_sizes[2], input_sizes[3]);
-    std::tie(out_channels, std::ignore, kernel_h, kernel_w) = std::make_tuple(
+    auto [out_channels, _, kernel_h, kernel_w] = std::make_tuple(
         kernel_sizes[0], kernel_sizes[1], kernel_sizes[2], kernel_sizes[3]);
     uint64_t output_h =
         (input_h + 2 * padding[0] - dilation[0] * (kernel_h - 1) - 1) /


### PR DESCRIPTION
This PR replaces some std::tie calls with structural binding from C++17.  This not only makes the code more compact, but also has some performance gain.


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225