### PR TITLE
[BE][Ez]: FURB129: remove unneeded readlines()

### DIFF
--- a/functorch/op_analysis/gen_data.py
+++ b/functorch/op_analysis/gen_data.py
@@ -148,19 +148,19 @@ def remove_prefix(input_string, prefix):
 
 if True:
     with open("run_ops.txt") as f:
-        opinfo_ops = [remove_suffix(i.strip(), ".default") for i in f.readlines()]
+        opinfo_ops = [remove_suffix(i.strip(), ".default") for i in f]
     with open("count_ops.txt") as f:
-        opinfo_counts = [i.strip() for i in f.readlines()]
+        opinfo_counts = [i.strip() for i in f]
         opinfo_counts = defaultdict(int, dict(zip(opinfo_ops, opinfo_counts)))
 
     def count_fn(x):
         return opinfo_counts[x["full_name"]]
 
     with open("run_decompositions.txt") as f:
-        decomposed_ops = [remove_suffix(i.strip(), ".default") for i in f.readlines()]
+        decomposed_ops = [remove_suffix(i.strip(), ".default") for i in f]
 
     with open("public_api") as f:
-        ref_api = [i.strip() for i in f.readlines()]
+        ref_api = [i.strip() for i in f]
 
     def has_ref_impl(x):
         name = x["name"]

--- a/setup.py
+++ b/setup.py
@@ -365,7 +365,7 @@ def get_submodule_folders():
     with open(git_modules_path) as f:
         return [
             os.path.join(cwd, line.split("=", 1)[1].strip())
-            for line in f.readlines()
+            for line in f
             if line.strip().startswith("path")
         ]
 

--- a/test/distributed/elastic/multiprocessing/redirects_test.py
+++ b/test/distributed/elastic/multiprocessing/redirects_test.py
@@ -123,7 +123,7 @@ class RedirectsTest(unittest.TestCase):
                 print_fn(i)
 
         with open(stdout_log) as fp:
-            actual = {int(line.split(":")[1]) for line in fp.readlines()}
+            actual = {int(line.split(":")[1]) for line in fp}
             expected = set(range(num_lines))
             self.assertSetEqual(expected, actual)
 

--- a/test/mobile/test_upgrader_codegen.py
+++ b/test/mobile/test_upgrader_codegen.py
@@ -22,9 +22,9 @@ class TestLiteScriptModule(TestCase):
         with tempfile.TemporaryDirectory() as tmpdirname:
             write_cpp(tmpdirname, sorted_upgrader_list)
             with open(os.path.join(tmpdirname, 'upgrader_mobile.cpp')) as file_name:
-                actual_output = [line.strip() for line in file_name.readlines() if line]
+                actual_output = [line.strip() for line in file_name if line]
             with open(str(upgrader_mobile_cpp_path)) as file_name:
-                expect_output = [line.strip() for line in file_name.readlines() if line]
+                expect_output = [line.strip() for line in file_name if line]
             actual_output_filtered = list(filter(lambda token: len(token) != 0, actual_output))
             expect_output_filtered = list(filter(lambda token: len(token) != 0, expect_output))
 

--- a/test/test_hub.py
+++ b/test/test_hub.py
@@ -43,7 +43,7 @@ class TestHub(TestCase):
 
     def _assert_in_trusted_list(self, line):
         with open(self.trusted_list_path) as f:
-            assert line in (l.strip() for l in f.readlines())
+            assert line in (l.strip() for l in f)
 
     @retry(Exception, tries=3)
     def test_load_from_github(self):

--- a/tools/nvcc_fix_deps.py
+++ b/tools/nvcc_fix_deps.py
@@ -39,7 +39,7 @@ Tried the following paths, but none existed:
 def repair_depfile(depfile: TextIO, include_dirs: List[Path]) -> None:
     changes_made = False
     out = ""
-    for line in depfile.readlines():
+    for line in depfile:
         if ":" in line:
             colon_pos = line.rfind(":")
             out += line[: colon_pos + 1]

--- a/tools/setup_helpers/gen_version_header.py
+++ b/tools/setup_helpers/gen_version_header.py
@@ -62,7 +62,7 @@ def main(args: argparse.Namespace) -> None:
 
     with open(args.template_path) as input:
         with open(args.output_path, "w") as output:
-            for line in input.readlines():
+            for line in input:
                 output.write(apply_replacements(replacements, line))
 
 

--- a/torch/utils/data/datapipes/gen_pyi.py
+++ b/torch/utils/data/datapipes/gen_pyi.py
@@ -70,7 +70,7 @@ def parse_datapipe_file(file_path: str) -> Tuple[Dict[str, str], Dict[str, str],
         open_paren_count = 0
         method_name, class_name, signature = "", "", ""
         skip = False
-        for line in f.readlines():
+        for line in f:
             if line.count("\"\"\"") % 2 == 1:
                 skip = not skip
             if skip or "\"\"\"" in line:  # Saving docstrings


### PR DESCRIPTION
Applies a refurb rule to remove any readlines() in a for loop iteration as it just creates a temporary list in memory.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225