### PR TITLE
[FSDP2][ez] Replaced `groupby` with `all` for same-dtype check

### DIFF
--- a/torch/distributed/_composable/fsdp/_fsdp_collectives.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_collectives.py
@@ -1,5 +1,3 @@
-import itertools
-
 from typing import List, NamedTuple, Optional
 
 import torch
@@ -34,10 +32,8 @@ def foreach_all_gather(
         param_all_gather_inputs = [
             fsdp_param.all_gather_input for fsdp_param in fsdp_params
         ]
-        g = itertools.groupby(t.dtype for t in param_all_gather_inputs)
-        if next(g, True) and not next(g, False):  # same dtype
-            dtype = param_all_gather_inputs[0].dtype
-        else:
+        dtype = param_all_gather_inputs[0].dtype
+        if not all(t.dtype == dtype for t in param_all_gather_inputs):
             raise NotImplementedError(
                 f"Mixed dtype not supported yet: {[t.dtype for t in param_all_gather_inputs]}"
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #119551
* #119378
* #119302
* #118298
* __->__ #119825
* #118755
* #118223
* #118136
* #119550

The `groupby` logic to check if all all-gather inputs have the same dtype is not so readable. Let us use `all` instead.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225