### PR TITLE
[inductor] Add max_clock_rate to _utils_internal to find max frequency

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1156,9 +1156,9 @@ def get_device_tflops(dtype):
 
     if inspect.signature(get_max_simd_tflops).parameters.get("clock_rate"):
         # Triton API change in https://github.com/openai/triton/pull/2293
-        from triton.testing import nvsmi
+        from torch._utils_internal import max_clock_rate
 
-        sm_clock = nvsmi(["clocks.max.sm"])[0]
+        sm_clock = max_clock_rate()
         if dtype in (torch.float16, torch.bfloat16):
             return get_max_tensorcore_tflops(dtype, sm_clock)
 

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import os
 import sys
@@ -88,6 +89,13 @@ def print_graph(graph, msg: str):
 
 def set_pytorch_distributed_envs_from_justknobs():
     pass
+
+
+@functools.lru_cache(None)
+def max_clock_rate():
+    from triton.testing import nvsmi
+
+    return nvsmi(["clocks.max.sm"])[0]
 
 
 TEST_MASTER_ADDR = "127.0.0.1"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #119831

`triton.testing.nvsmi` invokes `nvidia-smi` as a subprocess, and Meta
prod usually doesn't make nvidia-smi available.  We want to be able to override
this internally, and _utils_internal is the right place to do that.

Differential Revision: [D53235814](https://our.internmc.facebook.com/intern/diff/D53235814/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler