### PR TITLE
Add the missing test_dynamo_list_index from #119151 (D53392287)

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -4407,6 +4407,15 @@ def forward(self, x, b, y):
         ):
             gm, _ = torch._dynamo.export(fn)(x, b, y)
 
+    def test_dynamo_list_index(self):
+        def fn(x, in_list):
+            return x + in_list.index(2)
+
+        inputs = (torch.ones(2,2), [1, 2])
+        graph, _ = torch._dynamo.export(fn)(*inputs)
+        out = graph(*inputs)
+        self.assertEqual(out, torch.ones(2, 2) + 1)
+
 
 common_utils.instantiate_parametrized_tests(ExportTests)
 

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -4411,7 +4411,7 @@ def forward(self, x, b, y):
         def fn(x, in_list):
             return x + in_list.index(2)
 
-        inputs = (torch.ones(2,2), [1, 2])
+        inputs = (torch.ones(2, 2), [1, 2])
         graph, _ = torch._dynamo.export(fn)(*inputs)
         out = graph(*inputs)
         self.assertEqual(out, torch.ones(2, 2) + 1)


### PR DESCRIPTION
D53392287 botched the export somehow and the exported PR https://github.com/pytorch/pytorch/pull/119151 didn't contain the added test.  The discrepancy is showing up on diff train patch up diff D53694548

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng