### PR TITLE
Do full checkout in lint workflow to rebuild new Docker images

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       timeout: 120
       runner: linux.2xlarge
       docker-image: pytorch-linux-jammy-cuda11.8-cudnn8-py3.9-linter
-      fetch-depth: 1
+      fetch-depth: 0
       submodules: true
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
@@ -35,7 +35,7 @@ jobs:
       timeout: 120
       runner: linux.2xlarge
       docker-image: pytorch-linux-jammy-cuda11.8-cudnn8-py3.9-linter
-      fetch-depth: 1
+      fetch-depth: 0
       submodules: true
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,8 @@ jobs:
       timeout: 120
       runner: linux.2xlarge
       docker-image: pytorch-linux-jammy-cuda11.8-cudnn8-py3.9-linter
+      # NB: A shallow checkout won't work here because calculate-docker-image requires a full checkout
+      # to run git rev-parse HEAD~:.ci/docker when a new image is needed
       fetch-depth: 0
       submodules: true
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -35,6 +37,8 @@ jobs:
       timeout: 120
       runner: linux.2xlarge
       docker-image: pytorch-linux-jammy-cuda11.8-cudnn8-py3.9-linter
+      # NB: A shallow checkout won't work here because calculate-docker-image requires a full checkout
+      # to run git rev-parse HEAD~:.ci/docker when a new image is needed
       fetch-depth: 0
       submodules: true
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
From https://github.com/pytorch/pytorch/pull/119575, using `fetch-depth: 1` didn't work for `calculate-docker-image` when rebuilding a new one.  Specifically, doing a full checkout is needed for `git rev-parse HEAD~:.ci/docker` to get the Docker tag.

This shows up as a trunk failure after the recent Docker image update https://hud.pytorch.org/pytorch/pytorch/commit/507db1767525653dcf8dba80768198b19bd5e9f9