### PR TITLE
[pytorch][cuda]assert cache allocator initialization in attachAllocatorTraceTracker

### DIFF
--- a/aten/src/ATen/test/cuda_allocatorTraceTracker_test.cpp
+++ b/aten/src/ATen/test/cuda_allocatorTraceTracker_test.cpp
@@ -26,7 +26,15 @@ static void allocateLargeBuffer() {
   auto buffer = allocator->allocate(_500mb);
 }
 
+TEST(AllocatorTraceTracker, AttachBeforeInit) {
+  EXPECT_THROW(
+      c10::cuda::CUDACachingAllocator::attachAllocatorTraceTracker(
+          &SegmentAllocTraceTracker),
+      ::std::exception);
+}
+
 TEST(AllocatorTraceTracker, TrackMallocFree) {
+  c10::cuda::CUDACachingAllocator::init(1);
   c10::cuda::CUDACachingAllocator::attachAllocatorTraceTracker(
       &SegmentAllocTraceTracker);
   c10::cuda::CUDACachingAllocator::attachAllocatorTraceTracker(
@@ -46,6 +54,5 @@ TEST(AllocatorTraceTracker, TrackMallocFree) {
 
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
-  c10::cuda::CUDACachingAllocator::init(1);
   return RUN_ALL_TESTS();
 }

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -2980,6 +2980,8 @@ class NativeCachingAllocator : public CUDAAllocator {
   }
 
   void attachAllocatorTraceTracker(AllocatorTraceTracker tracker) override {
+    TORCH_INTERNAL_ASSERT(
+        initialized(), "Allocator not initialized: did you call init?");
     for (auto& allocator : device_allocator) {
       allocator->attachAllocatorTraceTracker(tracker);
     }


### PR DESCRIPTION
Summary: `attachAllocatorTraceTracker` is to register trace tracker hooks to initialized device_allocator objects, which must be called after `NativeCachingAllocator->init()`. This patch adds assert in `attachAllocatorTraceTracker` to check it.

Differential Revision: D53735940


