### PR TITLE
Simplify indexing when doing ModularIndexing + index propagation.

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -589,7 +589,9 @@ def check_model_gpu(
 check_model_cuda = check_model_gpu
 
 
-def _run_and_assert_no_indirect_indexing(test_case, func, *args, **kwargs):
+def _run_and_assert_no_indirect_indexing(
+    test_case, func, *args, has_wrapping=None, **kwargs
+):
     result, source_codes = run_and_get_code(func, *args, **kwargs)
 
     for code in source_codes:
@@ -615,6 +617,11 @@ def _run_and_assert_no_indirect_indexing(test_case, func, *args, **kwargs):
             test_case.assertTrue(
                 "tmp" not in stmt,
                 msg=f"Found indirect indexing in statement '{stmt}' from code:\n{code}",
+            )
+        if has_wrapping is not None:
+            test_case.assertTrue(
+                ("where" in code or "?" in code) is has_wrapping,
+                msg=f"Wanted {has_wrapping=} but got\n{code}",
             )
 
     return result
@@ -965,7 +972,9 @@ class CommonTemplate:
         repeat_opt = torch._dynamo.optimize("inductor")(repeat)
 
         # this should be collapsed to direct indexing
-        actual = _run_and_assert_no_indirect_indexing(self, repeat_opt, x, 3)
+        actual = _run_and_assert_no_indirect_indexing(
+            self, repeat_opt, x, 3, has_wrapping=False
+        )
         expect = x.repeat(3)
         self.assertEqual(expect, actual)
         self.assertEqual(actual, repeat(x, 3))

--- a/torch/_inductor/index_propagation.py
+++ b/torch/_inductor/index_propagation.py
@@ -258,5 +258,12 @@ class IndexPropagation:
         if isinstance(index, IndexPropVar) and index.is_symbolic:
             # If we are turning a indirect indexing into direct, we need to wrap it.
             index = index.value.expr
+            # If SymPy can prove that idx >= 0, the Where below will evaluate to zero
+            # Alas, SymPy can't prove that index >= when we do ModularIndexing...
+            if (isinstance(index, ModularIndexing) and
+               index.args[1] == 1 and
+               index.args[0].is_positive is not None and
+               index.args[0].is_positive == index.args[2].is_positive):
+                return index
             return index + Where(index >= 0, 0, size)
         return self.fallback("indirect_indexing", (index, size, check), {}).value

--- a/torch/_inductor/index_propagation.py
+++ b/torch/_inductor/index_propagation.py
@@ -258,13 +258,5 @@ class IndexPropagation:
         if isinstance(index, IndexPropVar) and index.is_symbolic:
             # If we are turning a indirect indexing into direct, we need to wrap it.
             index = index.value.expr
-            # If SymPy can prove that idx >= 0, the Where below will evaluate to zero
-            # Alas, SymPy can't prove that index >= when we do ModularIndexing...
-            if (
-                isinstance(index, ModularIndexing)
-                and index.args[1] == 1
-                and index.args[2].is_positive
-            ):
-                return index
             return index + Where(index >= 0, 0, size)
         return self.fallback("indirect_indexing", (index, size, check), {}).value

--- a/torch/_inductor/index_propagation.py
+++ b/torch/_inductor/index_propagation.py
@@ -260,10 +260,11 @@ class IndexPropagation:
             index = index.value.expr
             # If SymPy can prove that idx >= 0, the Where below will evaluate to zero
             # Alas, SymPy can't prove that index >= when we do ModularIndexing...
-            if (isinstance(index, ModularIndexing) and
-               index.args[1] == 1 and
-               index.args[0].is_positive is not None and
-               index.args[0].is_positive == index.args[2].is_positive):
+            if (
+                isinstance(index, ModularIndexing)
+                and index.args[1] == 1
+                and index.args[2].is_positive
+            ):
                 return index
             return index + Where(index >= 0, 0, size)
         return self.fallback("indirect_indexing", (index, size, check), {}).value

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -156,11 +156,11 @@ class ModularIndexing(sympy.Function):
 
     def _eval_is_nonnegative(self):
         p, q = self.args[:2]
-        return fuzzy_eq(p.is_nonnegative, q.is_nonnegative)
+        return fuzzy_eq(p.is_nonnegative, q.is_nonnegative)  # type: ignore[attr-defined]
 
     def _eval_is_positive(self):
         p, q = self.args[:2]
-        return fuzzy_eq(p.is_positive, q.is_positive)
+        return fuzzy_eq(p.is_positive, q.is_positive)  # type: ignore[attr-defined]
 
 
 class Where(sympy.Function):

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -8,6 +8,12 @@ __all__ = [
 ]
 
 
+def fuzzy_eq(x, y):
+    if None in (x, y):
+        return None
+    return x == y
+
+
 class FloorDiv(sympy.Function):
     """
     We maintain this so that:
@@ -95,7 +101,7 @@ class FloorDiv(sympy.Function):
 
 class ModularIndexing(sympy.Function):
     """
-    ModularIndexing(a, b, c) => (a // b) % c
+    ModularIndexing(a, b, c) => (a // b) % c where % is the C modulus
     """
 
     nargs = (3,)
@@ -147,6 +153,15 @@ class ModularIndexing(sympy.Function):
 
         if isinstance(base, FloorDiv):
             return ModularIndexing(base.args[0], base.args[1] * divisor, modulus)
+
+    def _eval_is_nonnegative(self):
+        p, q = self.args[:2]
+        return fuzzy_eq(p.is_nonnegative, q.is_nonnegative)
+
+    def _eval_is_positive(self):
+        p, q = self.args[:2]
+        return fuzzy_eq(p.is_positive, q.is_positive)
+
 
 class Where(sympy.Function):
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #119884
* #119857
* #119864
* __->__ #119863

We now avoid creating an unnecessary ternary operator in some reasonably
common case.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames