### PR TITLE
Change default TORCH_LOGS format to match Meta/glog standard

### DIFF
--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -335,7 +335,7 @@ LoweringException: AssertionError:
             if torch._logging._internal._is_torch_handler(handler):
                 break
         self.assertIsNotNone(handler)
-        self.assertIn("[INFO]", handler.format(records[0]))
+        self.assertIn("I", handler.format(records[0]))
         self.assertEqual("custom format", handler.format(records[1]))
 
     @make_logging_test(dynamo=logging.INFO)
@@ -354,7 +354,7 @@ LoweringException: AssertionError:
         for record in records:
             r = handler.format(record)
             for l in r.splitlines():
-                self.assertIn("[INFO]", l)
+                self.assertIn("I", l)
 
     test_trace_source_simple = within_range_record_test(1, 100, trace_source=True)
 

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -2,6 +2,7 @@ import functools
 import itertools
 import logging
 import os
+import os.path
 import re
 from dataclasses import dataclass, field
 from importlib import __import__
@@ -706,7 +707,7 @@ class TorchLogsFormatter(logging.Formatter):
                 return artifact_formatter.format(record)
 
         record.message = record.getMessage()
-        record.asctime = self.formatTime(record, self.datefmt)
+        record.asctime = self.formatTime(record, "%m%d %H:%M:%S")
 
         # exception handling - copied from logging.Formatter.format
         s = record.message
@@ -733,7 +734,11 @@ class TorchLogsFormatter(logging.Formatter):
         if (trace_id := torch._guards.CompileContext.current_trace_id()) is not None:
             record.traceid = f" [{trace_id}]"
 
-        prefix = f"{record.rankprefix}[{record.asctime}]{record.traceid} {record.name}: [{record.levelname}]"
+        prefix = (
+            f"{record.rankprefix}{record.levelname[0]}{record.asctime}.{int(record.msecs*1000):06d} {record.process} "
+            f"{os.path.relpath(record.pathname, os.path.dirname(os.path.dirname(torch.__file__)))}:"
+            f"{record.lineno}{record.traceid}"
+        )
         return "\n".join(f"{prefix} {l}" for l in lines)
 
 

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -734,8 +734,18 @@ class TorchLogsFormatter(logging.Formatter):
         if (trace_id := torch._guards.CompileContext.current_trace_id()) is not None:
             record.traceid = f" [{trace_id}]"
 
+        glog_level_to_abbr = {
+            'DEBUG': 'V',  # V is for VERBOSE in glog
+            'INFO': 'I',
+            'WARNING': 'W',
+            'ERROR': 'E',
+            'CRITICAL': 'C',
+        }
+
+        shortlevel = glog_level_to_abbr.get(record.levelname, record.levelname)
+
         prefix = (
-            f"{record.rankprefix}{record.levelname[0]}{record.asctime}.{int(record.msecs*1000):06d} {record.process} "
+            f"{record.rankprefix}{shortlevel}{record.asctime}.{int(record.msecs*1000):06d} {record.thread} "
             f"{os.path.relpath(record.pathname, os.path.dirname(os.path.dirname(torch.__file__)))}:"
             f"{record.lineno}{record.traceid}"
         )

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -735,11 +735,11 @@ class TorchLogsFormatter(logging.Formatter):
             record.traceid = f" [{trace_id}]"
 
         glog_level_to_abbr = {
-            'DEBUG': 'V',  # V is for VERBOSE in glog
-            'INFO': 'I',
-            'WARNING': 'W',
-            'ERROR': 'E',
-            'CRITICAL': 'C',
+            "DEBUG": "V",  # V is for VERBOSE in glog
+            "INFO": "I",
+            "WARNING": "W",
+            "ERROR": "E",
+            "CRITICAL": "C",
         }
 
         shortlevel = glog_level_to_abbr.get(record.levelname, record.levelname)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #119893
* __->__ #119869

Before:

```
[2024-02-13 19:34:50,591] [0/0] torch._dynamo.guards.__guards: [DEBUG] GUARDS:
[2024-02-13 19:34:50,591] [0/0] torch._dynamo.guards.__guards: [DEBUG] ___check_type_id(L['x'], 70049616)                            # assert x.shape[0] > 2  # b.py:5 in f
[2024-02-13 19:34:50,592] [0/0] torch._dynamo.guards.__guards: [DEBUG] hasattr(L['x'], '_dynamo_dynamic_indices') == False           # assert x.shape[0] > 2  # b.py:5 in f
```

After this change, the logs look like this:

```
V0214 07:00:49.354000 139646045393920 torch/_dynamo/guards.py:1023 [0/0] GUARDS:
V0214 07:00:49.354000 139646045393920 torch/_dynamo/guards.py:1039 [0/0] ___check_type_id(L['x'], 70050096)                            # assert x.shape[0] > 2  # b.py:5 in f
V0214 07:00:49.355000 139646045393920 torch/_dynamo/guards.py:1039 [0/0] hasattr(L['x'], '_dynamo_dynamic_indices') == False           # assert x.shape[0] > 2  # b.py:5 in f
```

The main differences from what we had before:

* We don't print DEBUG/INFO/WARNING, instead, we only print a single character. DEBUG, somewhat oddly, maps to V, because it corresponds to glog VERBOSE
* The year is omitted, and a more compact representation for date/month is adopted. Somewhat perplexingly, six digits are allocated for the nanoseconds, even though Python typically doesn't have that level of resolution
* The thread ID is included (in a containerized environment, this thread id will be typically much lower)
* Instead of using the module name, we give a filepath, as well as the line the log message was emitted from. I think the line number is a nice touch and improvement over our old logs, but one downside is we do lose the artifact name in the log message, in case anyone was grepping for that.
* I chose to move the compile id prefix to the very end so as to keep a uniform layout before it, but I do think there are benefits to having it before the filename

Meta only: This format was reverse engineered off of https://github.com/fairinternal/xlformers/blob/6b8bbe3b5314a63da19a1b777c16320d54552284/supervisor/logging.py and https://www.internalfb.com/code/fbsource/[e6728305a48540110f2bdba198aa74eee47290f9]/fbcode/tupperware/front_end/log_reader/filter/StreamingLogLineFilter.cpp?lines=105-114

Now, I think this may be slightly controversial, but I have chosen to apply this format *by default* in OSS. My reasoning is that many PT2 developers work with the logs in OSS, and keeping the format identical to what we run in prod will make it easier for these skills to transfer.

The non-negotiable portion of the new format is "V0213 19:28:32"; the date string is expected to be in exactly this form or Tupperware will fail to parse it as a date.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng