### PR TITLE
[structural binding][2/N] Replace std::tie with structural binding 

### DIFF
--- a/tools/autograd/gen_trace_type.py
+++ b/tools/autograd/gen_trace_type.py
@@ -380,17 +380,6 @@ def format_postrecord_trace(f: NativeFunction) -> str:
         return POST_RECORD_TRACE.substitute(add_trace_outputs=outputs)
 
 
-def declare_returned_variables(f: NativeFunction) -> str:
-    modifies_arguments = f.func.kind() in (SchemaKind.inplace, SchemaKind.out)
-    if modifies_arguments:
-        return ""
-    if len(f.func.returns) == 1:
-        return ""
-    types = [cpp.return_type(r, symint=True) for r in f.func.returns]
-    names = cpp.return_names(f)
-    return "\n".join(f"{type.cpp_type()} {name};" for type, name in zip(types, names))
-
-
 def tie_return_values(f: NativeFunction) -> str:
     if len(f.func.returns) == 1:
         return f'auto {f.func.returns[0].name or "result"}'

--- a/tools/autograd/gen_trace_type.py
+++ b/tools/autograd/gen_trace_type.py
@@ -5,12 +5,7 @@ from torchgen.api import cpp
 from torchgen.api.types import DispatcherSignature
 from torchgen.code_template import CodeTemplate
 from torchgen.context import with_native_function
-from torchgen.model import (
-    Argument,
-    NativeFunction,
-    SchemaKind,
-    TensorOptionsArguments,
-)
+from torchgen.model import Argument, NativeFunction, SchemaKind, TensorOptionsArguments
 from torchgen.utils import FileManager
 
 # Note [Manual Backend kernels]

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -96,7 +96,6 @@ from .gen_inplace_or_view_type import (
     WRAPPER_REGISTRATION,
 )
 from .gen_trace_type import (
-    declare_returned_variables,
     get_return_value,
     MANUAL_AUTOGRAD_AND_TRACER,
     MANUAL_BACKEND,
@@ -2130,7 +2129,6 @@ def emit_body(
         body.extend(emit_check_inplace())
         body.extend(emit_original_self_definition())
         body.extend(setup_derivative(differentiable_inputs))
-    body.append(declare_returned_variables(f))
 
     body.append(emit_call(f, unpacked_bindings, try_jit_decomposition))
     if requires_derivative:

--- a/torch/csrc/jit/codegen/onednn/kernel.cpp
+++ b/torch/csrc/jit/codegen/onednn/kernel.cpp
@@ -275,8 +275,7 @@ void LlgaKernel::run(Stack& stack) {
   GRAPH_DEBUG("Preparing runtime tensors");
 #endif
   TensorArgs outputs;
-  RunArgs runInputs, runOutputs;
-  std::tie(runInputs, runOutputs) = prepareRunArgs(inputs, outputs);
+  auto [runInputs, runOutputs] = prepareRunArgs(inputs, outputs);
 #ifdef GRAPH_DEBUG_ENABLED
   GRAPH_DEBUG("Executing partition");
 #endif

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -2892,15 +2892,12 @@ struct to_ir {
 
     // If it's a tensor, copy the RHS data into it
     if (sliceable->type()->isSubtypeOf(*TensorType::get())) {
-      std::vector<Value*> tensorIndices;
-      // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-      Value* sliced;
       // Handle multi-dimensional slicing: first emit int/slice indexing
       // TODO: the Python equivalent code has special-cased copy_to
       // broadcasting to match NumPy semantics (see PR#4853). We can't
       // replicate that without knowing the size of the Tensor; so really that
       // code should be moved into the aten function
-      std::tie(sliced, tensorIndices) = emitIntAndSliceIndexing(
+      auto [sliced, tensorIndices] = emitIntAndSliceIndexing(
           lhs.range(), sliceable, lhs.subscript_exprs());
 
       const auto slicedArg = NamedValue(lhs.range(), sliced);

--- a/torch/csrc/jit/frontend/source_range.cpp
+++ b/torch/csrc/jit/frontend/source_range.cpp
@@ -267,10 +267,7 @@ void SourceRange::print_with_context(
 
   // print out location information
   if (auto flc = file_line_col()) {
-    std::string filename;
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    size_t line, col;
-    std::tie(filename, line, col) = *flc;
+    auto [filename, line, col] = *flc;
     out << "  File \"" << filename << "\", line " << line;
     if (!funcname.empty()) {
       out << ", in " << funcname;

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -354,10 +354,7 @@ std::ostream& Node::print(
       }
     }
     if (auto file_line_col = r.file_line_col()) {
-      std::string filename;
-      // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-      size_t line, col;
-      std::tie(filename, line, col) = *file_line_col;
+      auto [filename, line, col] = *file_line_col;
       out << " # " << filename << ":" << line << ":" << col;
     }
   }

--- a/torch/csrc/jit/mobile/compatibility/model_compatibility.cpp
+++ b/torch/csrc/jit/mobile/compatibility/model_compatibility.cpp
@@ -75,9 +75,7 @@ static uint64_t _get_model_bytecode_version_from_bytes(char* data, size_t size);
 uint64_t _get_model_bytecode_version(std::istream& in) {
   auto orig_pos = in.tellg();
   in.seekg(0, in.beg);
-  std::shared_ptr<char> data;
-  size_t size = 0;
-  std::tie(data, size) = get_stream_content(in);
+  auto [data, size] = get_stream_content(in);
   in.seekg(orig_pos, in.beg);
   return _get_model_bytecode_version_from_bytes(data.get(), size);
 }
@@ -89,9 +87,7 @@ uint64_t _get_model_bytecode_version(const std::string& filename) {
 
 uint64_t _get_model_bytecode_version(
     std::shared_ptr<ReadAdapterInterface> rai) {
-  std::shared_ptr<char> data;
-  size_t size = 0;
-  std::tie(data, size) = get_rai_content(rai.get());
+  auto [data, size] = get_rai_content(rai.get());
   return _get_model_bytecode_version_from_bytes(data.get(), size);
 }
 

--- a/torch/csrc/jit/mobile/debug_info.cpp
+++ b/torch/csrc/jit/mobile/debug_info.cpp
@@ -119,9 +119,7 @@ MobileDebugTable::MobileDebugTable(
   const c10::string_view suffix(".debug_pkl");
   for (const auto& record_name : record_names) {
     if (c10::string_view(record_name).ends_with(suffix)) {
-      at::DataPtr debug_data;
-      size_t debug_size{0};
-      std::tie(debug_data, debug_size) = reader->getRecord(record_name);
+      auto [debug_data, debug_size] = reader->getRecord(record_name);
       auto ivalueTuple = jit::unpickle(
           reinterpret_cast<const char*>(debug_data.get()),
           debug_size,
@@ -157,9 +155,7 @@ MobileDebugTable::MobileDebugTable(
   }
   const std::string callstack_debug_file("callstack_debug_map.pkl");
   if (reader->hasRecord("callstack_debug_map.pkl")) {
-    at::DataPtr callstack_data;
-    size_t callstack_data_size{0};
-    std::tie(callstack_data, callstack_data_size) =
+    auto [callstack_data, callstack_data_size] =
         reader->getRecord(callstack_debug_file);
     CallStackDebugInfoUnpickler unpickler;
     callstack_ptr_map_ = unpickler.unpickle(

--- a/torch/csrc/jit/mobile/flatbuffer_loader.cpp
+++ b/torch/csrc/jit/mobile/flatbuffer_loader.cpp
@@ -827,24 +827,18 @@ mobile::Module load_mobile_module_from_file(
     const std::string& filename,
     c10::optional<c10::Device> device,
     ExtraFilesMap* extra_files) {
-  std::shared_ptr<char> data;
-  size_t size = 0;
-  std::tie(data, size) = get_file_content(filename.c_str());
+  auto [data, size] = get_file_content(filename.c_str());
   return parse_and_initialize_mobile_module(
       std::move(data), size, device, extra_files);
 }
 
 uint64_t get_bytecode_version(std::istream& in) {
-  std::shared_ptr<char> data;
-  size_t size = 0;
-  std::tie(data, size) = get_stream_content(in);
+  auto [data, size] = get_stream_content(in);
   return get_bytecode_version_from_bytes(data.get());
 }
 
 uint64_t get_bytecode_version(const std::string& filename) {
-  std::shared_ptr<char> data;
-  size_t size = 0;
-  std::tie(data, size) = get_file_content(filename.c_str());
+  auto [data, size] = get_file_content(filename.c_str());
   return get_bytecode_version_from_bytes(data.get());
 }
 
@@ -893,9 +887,7 @@ mobile::Module load_mobile_module_from_stream_with_copy(
     std::istream& in,
     c10::optional<at::Device> device,
     ExtraFilesMap* extra_files) {
-  std::shared_ptr<char> data;
-  size_t size = 0;
-  std::tie(data, size) = get_stream_content(in);
+  auto [data, size] = get_stream_content(in);
   return parse_and_initialize_mobile_module(
       std::move(data), size, device, extra_files);
 }

--- a/torch/csrc/jit/mobile/import_data.cpp
+++ b/torch/csrc/jit/mobile/import_data.cpp
@@ -269,18 +269,14 @@ static std::map<std::string, at::Tensor> _load_parameters_bytes(
 std::map<std::string, at::Tensor> _load_parameters(
     std::istream& in,
     c10::optional<at::Device> device) {
-  std::shared_ptr<char> data;
-  size_t size = 0;
-  std::tie(data, size) = get_stream_content(in);
+  auto [data, size] = get_stream_content(in);
   return _load_parameters_bytes(std::move(data), size, device);
 }
 
 std::map<std::string, at::Tensor> _load_parameters(
     const std::string& filename,
     c10::optional<at::Device> device) {
-  std::shared_ptr<char> data;
-  size_t size = 0;
-  std::tie(data, size) = get_file_content(filename.c_str());
+  auto [data, size] = get_file_content(filename.c_str());
   return _load_parameters_bytes(std::move(data), size, device);
 }
 

--- a/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
+++ b/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
@@ -300,8 +300,7 @@ void MKLDNNLayerNormOp(Stack& stack, bool inplace) {
   auto shape = pop(stack).toDimVector();
   auto input = pop(stack).toTensor();
 
-  at::Tensor dst, mean, rstd;
-  std::tie(dst, mean, rstd) =
+  auto [dst, mean, rstd] =
       at::native::mkldnn_layer_norm_last_index_weight_bias_f32(
           input, shape, weight, bias, eps, inplace);
   push(stack, dst);

--- a/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
+++ b/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
@@ -257,9 +257,7 @@ void FixupONNXLoopBlockInputs(Node* n) {
       Value* input_i = block->inputs().at(i);
       if (input_i->type()->cast<OptionalType>() &&
           !block->outputs().at(i)->type()->cast<OptionalType>()) {
-        TypePtr merged_type;
-        bool inferred = false;
-        std::tie(merged_type, inferred) = MergeInferredType(
+        auto [merged_type, inferred] = MergeInferredType(
             input_i->type()->cast<OptionalType>()->getElementType(),
             block->outputs().at(i)->type());
         if (inferred) {
@@ -336,9 +334,7 @@ void FixupONNXLoopNodeInputs(Node* node, int opset_version) {
     // vice-versa.
     if (!input->type()->cast<OptionalType>() && sub_block_input_optional) {
       if (!input->type()->cast<NoneType>()) {
-        TypePtr merged_type;
-        bool inferred = false;
-        std::tie(merged_type, inferred) = MergeInferredType(
+        auto [merged_type, inferred] = MergeInferredType(
             sub_block_input_optional->getElementType(), input->type());
         if (inferred) {
           sub_block_input_optional = OptionalType::create(merged_type);

--- a/torch/csrc/jit/passes/onnx/function_extraction.cpp
+++ b/torch/csrc/jit/passes/onnx/function_extraction.cpp
@@ -877,9 +877,7 @@ std::tuple<FunctionExtractor::scope_ctx_map, node_list> FunctionExtractor::
     }
 
     for (auto* sub_b : n->blocks()) {
-      scope_ctx_map subblock_scope_ctxs;
-      node_list subblock_no_scope_nlist;
-      std::tie(subblock_scope_ctxs, subblock_no_scope_nlist) =
+      auto [subblock_scope_ctxs, subblock_no_scope_nlist] =
           PartitionNodesByScope(sub_b);
 
       for (auto& it : subblock_scope_ctxs) {

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -77,8 +77,7 @@ void MergeInferredTypeAndSetMap(
     Value* dest_v,
     TypePtr existing_type,
     TypePtr inferred_type) {
-  auto [mergedType, inferred] =
-      MergeInferredType(existing_type, inferred_type);
+  auto [mergedType, inferred] = MergeInferredType(existing_type, inferred_type);
   dest_v->setType(mergedType);
   ConstantValueMap::SetUseInferredType(dest_v->debugName(), inferred);
 }

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -77,9 +77,7 @@ void MergeInferredTypeAndSetMap(
     Value* dest_v,
     TypePtr existing_type,
     TypePtr inferred_type) {
-  TypePtr mergedType;
-  bool inferred;
-  std::tie(mergedType, inferred) =
+  auto [mergedType, inferred] =
       MergeInferredType(existing_type, inferred_type);
   dest_v->setType(mergedType);
   ConstantValueMap::SetUseInferredType(dest_v->debugName(), inferred);

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1497,9 +1497,7 @@ void initJITBindings(PyObject* module) {
       .def(
           "get_record",
           [](PyTorchStreamReader& self, const std::string& key) {
-            at::DataPtr data;
-            size_t size = 0;
-            std::tie(data, size) = self.getRecord(key);
+            auto [data, size] = self.getRecord(key);
             return py::bytes(reinterpret_cast<const char*>(data.get()), size);
           })
       .def(

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -259,26 +259,26 @@ void initPythonIRBindings(PyObject* module_) {
              const std::string& onnx_file_path,
              const NodeAttrNameMap& node_attr_to_name) {
             std::string graph;
-            auto [
-                model_proto,
-                export_map,
-                symbol_map,
-                val_use_external_data_format,
-                onnx_node_names] =
-                export_onnx(
-                    g,
-                    initializers,
-                    onnx_opset_version,
-                    dynamic_axes,
-                    defer_weight_export,
-                    operator_export_type,
-                    strip_doc_string,
-                    keep_initializers_as_inputs,
-                    custom_opsets,
-                    add_node_names,
-                    false,
-                    onnx_file_path,
-                    node_attr_to_name);
+            auto
+                [model_proto,
+                 export_map,
+                 symbol_map,
+                 val_use_external_data_format,
+                 onnx_node_names] =
+                    export_onnx(
+                        g,
+                        initializers,
+                        onnx_opset_version,
+                        dynamic_axes,
+                        defer_weight_export,
+                        operator_export_type,
+                        strip_doc_string,
+                        keep_initializers_as_inputs,
+                        custom_opsets,
+                        add_node_names,
+                        false,
+                        onnx_file_path,
+                        node_attr_to_name);
             std::unordered_map<std::string, py::bytes>
                 python_serialized_export_map;
             for (auto& kv : export_map) {

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -259,17 +259,12 @@ void initPythonIRBindings(PyObject* module_) {
              const std::string& onnx_file_path,
              const NodeAttrNameMap& node_attr_to_name) {
             std::string graph;
-            std::shared_ptr<::ONNX_NAMESPACE::ModelProto> model_proto;
-            RawDataExportMap export_map;
-            SymbolDimMap symbol_map;
-            bool val_use_external_data_format = false;
-            NodeNameMap onnx_node_names;
-            std::tie(
+            auto [
                 model_proto,
                 export_map,
                 symbol_map,
                 val_use_external_data_format,
-                onnx_node_names) =
+                onnx_node_names] =
                 export_onnx(
                     g,
                     initializers,
@@ -281,7 +276,7 @@ void initPythonIRBindings(PyObject* module_) {
                     keep_initializers_as_inputs,
                     custom_opsets,
                     add_node_names,
-                    val_use_external_data_format,
+                    false,
                     onnx_file_path,
                     node_attr_to_name);
             std::unordered_map<std::string, py::bytes>

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -82,9 +82,7 @@ FunctionSchema PythonValue::getSchema(
     rets.emplace_back(Argument("0", ret_type, {}, {}, false));
   } else {
     // Use the provided type signature
-    std::vector<TypePtr> arg_types;
-    TypePtr ret_type;
-    std::tie(arg_types, ret_type) =
+    auto [arg_types, ret_type] =
         py::cast<std::pair<std::vector<TypePtr>, TypePtr>>(signature);
 
     // arg_types does not include self but param_names does, so adjust for that
@@ -1022,12 +1020,7 @@ TypePtr registerNamedTuple(
       py::module::import("torch._jit_internal")
           .attr("_get_named_tuple_properties")(obj, loc, py::cpp_function(rcb));
 
-  std::string unqualName;
-  std::vector<std::string> field_names;
-  std::vector<TypePtr> field_types;
-  std::vector<py::object> objects;
-
-  std::tie(unqualName, field_names, field_types, objects) = py::cast<std::tuple<
+  auto [unqualName, field_names, field_types, objects] = py::cast<std::tuple<
       std::string,
       std::vector<std::string>,
       std::vector<TypePtr>,

--- a/torch/csrc/jit/python/python_tree_views.cpp
+++ b/torch/csrc/jit/python/python_tree_views.cpp
@@ -34,9 +34,7 @@ struct SourceRangeFactory {
         leading_whitespace_chars_(leading_whitespace_chars) {}
 
   SourceRange create(int line, int start_col, int end_col) {
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    size_t start_byte_offset, end_byte_offset;
-    std::tie(start_byte_offset, end_byte_offset) = line_col_to_byte_offs(
+    auto [start_byte_offset, end_byte_offset] = line_col_to_byte_offs(
         line,
         // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
         start_col + leading_whitespace_chars_,

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -879,9 +879,7 @@ void initJitScriptBindings(PyObject* module) {
               },
               [](const std::tuple<py::object, std::string>& state_tup)
                   -> Object {
-                py::object state;
-                std::string qualname;
-                std::tie(state, qualname) = state_tup;
+                auto [state, qualname] = state_tup;
                 auto class_type = getCustomClass(qualname);
                 TORCH_CHECK(
                     class_type,

--- a/torch/csrc/jit/runtime/autodiff.cpp
+++ b/torch/csrc/jit/runtime/autodiff.cpp
@@ -391,7 +391,7 @@ static ReverseDetails addReverseInline(Gradient& grad_desc) {
     auto it = grad_map.find(v);
     if (it == grad_map.end()) {
       auto autograd_zero = graph.insertNode(graph.createAutogradZero());
-      std::tie(it, std::ignore) = grad_map.emplace(v, autograd_zero->output());
+      it = grad_map.emplace(v, autograd_zero->output()).first;
     }
     return it->second;
   };

--- a/torch/csrc/jit/serialization/import.cpp
+++ b/torch/csrc/jit/serialization/import.cpp
@@ -260,10 +260,7 @@ Module ScriptModuleDeserializer::deserialize(
   for (const auto& kv : extra_files) {
     const std::string& key = "extra/" + kv.first;
     if (reader_->hasRecord(key)) {
-      at::DataPtr meta_ptr;
-      // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-      size_t meta_size;
-      std::tie(meta_ptr, meta_size) = reader_->getRecord(key);
+      auto [meta_ptr, meta_size] = reader_->getRecord(key);
       extra_files[kv.first] =
           std::string(static_cast<char*>(meta_ptr.get()), meta_size);
     }
@@ -383,9 +380,7 @@ Module import_ir_module(
     ScriptModuleDeserializer deserializer(std::move(cu), std::move(reader));
     return deserializer.deserialize(device, extra_files, restore_shapes);
   }
-  std::shared_ptr<char> data;
-  size_t size = 0;
-  std::tie(data, size) = get_stream_content(in);
+  auto [data, size] = get_stream_content(in);
   return _load_jit_module_from_bytes(
       data, size, cu, device, extra_files, restore_shapes);
 }
@@ -432,9 +427,7 @@ Module import_ir_module(
     ScriptModuleDeserializer deserializer(std::move(cu), std::move(reader));
     return deserializer.deserialize(device, extra_files, restore_shapes);
   }
-  std::shared_ptr<char> data;
-  size_t size = 0;
-  std::tie(data, size) = get_file_content(filename.c_str());
+  auto [data, size] = get_file_content(filename.c_str());
   return _load_jit_module_from_bytes(
       data, size, cu, device, extra_files, restore_shapes);
 }

--- a/torch/csrc/jit/serialization/import_export_helpers.cpp
+++ b/torch/csrc/jit/serialization/import_export_helpers.cpp
@@ -29,19 +29,13 @@ std::shared_ptr<Source> findSourceInArchiveFromQualifier(
   if (!reader.hasRecord(path)) {
     return nullptr;
   }
-  at::DataPtr data;
-  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  size_t size;
-  std::tie(data, size) = reader.getRecord(path);
+  auto [data, size] = reader.getRecord(path);
 
   std::shared_ptr<ConcreteSourceRangeUnpickler> gen_ranges = nullptr;
 
   std::string debug_file = path + ".debug_pkl";
   if (reader.hasRecord(debug_file)) {
-    at::DataPtr debug_data;
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    size_t debug_size;
-    std::tie(debug_data, debug_size) = reader.getRecord(debug_file);
+    auto [debug_data, debug_size] = reader.getRecord(debug_file);
     gen_ranges = std::make_shared<ConcreteSourceRangeUnpickler>(
         std::move(debug_data), debug_size);
   }

--- a/torch/csrc/jit/serialization/import_legacy.cpp
+++ b/torch/csrc/jit/serialization/import_legacy.cpp
@@ -88,10 +88,7 @@ class ScriptModuleDeserializer final {
 Module ScriptModuleDeserializer::LEGACY_deserialize() {
   torch::ModelDef model_def;
 
-  at::DataPtr data_ptr;
-  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  size_t data_size;
-  std::tie(data_ptr, data_size) = reader_->getRecord("model.json");
+  auto [data_ptr, data_size] = reader_->getRecord("model.json");
   // NB: cannot use JsonStringToMessage, since fbcode's protobuf is too old
   // be consistent with JsonStringToMessage
   std::string url_prefix = "type.googleapis.com";
@@ -145,10 +142,7 @@ Module ScriptModuleDeserializer::LEGACY_deserialize() {
 
 IValue ScriptModuleDeserializer::LEGACY_loadPickleArchive(
     const std::string& name) {
-  at::DataPtr attributes_ptr;
-  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  size_t attributes_size;
-  std::tie(attributes_ptr, attributes_size) = reader_->getRecord(name);
+  auto [attributes_ptr, attributes_size] = reader_->getRecord(name);
   auto ivalue = unpickle(
       reinterpret_cast<const char*>(attributes_ptr.get()),
       attributes_size,
@@ -190,10 +184,7 @@ at::Tensor ScriptModuleDeserializer::LEGACY_loadTensor(
 
   auto storage_it = storageMap.find(record_key);
   if (storage_it == storageMap.end()) {
-    at::DataPtr storage_ptr;
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    uint64_t record_size;
-    std::tie(storage_ptr, record_size) = reader_->getRecord(record_key);
+    auto [storage_ptr, record_size] = reader_->getRecord(record_key);
     auto cpu_storage = at::Storage(
         c10::Storage::use_byte_size_t(),
         record_size,
@@ -331,10 +322,7 @@ Module ScriptModuleDeserializer::LEGACY_convertModule(
   // generating code.
   std::shared_ptr<SourceRangeUnpickler> gen_ranges = nullptr;
   if (module_def.has_torchscript_debug_arena()) {
-    at::DataPtr data;
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    size_t size;
-    std::tie(data, size) =
+    auto [data, size] =
         reader_->getRecord(module_def.torchscript_debug_arena().key());
 
     gen_ranges =
@@ -342,10 +330,7 @@ Module ScriptModuleDeserializer::LEGACY_convertModule(
   }
 
   if (module_def.has_torchscript_arena()) {
-    at::DataPtr data;
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    size_t size;
-    std::tie(data, size) =
+    auto [data, size] =
         reader_->getRecord(module_def.torchscript_arena().key());
     std::string data_str(static_cast<const char*>(data.get()), size);
     auto src = std::make_shared<Source>(

--- a/torch/csrc/jit/tensorexpr/loopnest_randomization.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest_randomization.cpp
@@ -288,9 +288,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
             break;
           }
           int n_pivots = (std::rand() % (int)stmts.size()) + 1;
-          std::vector<StmtPtr> pivots;
-          std::vector<int> chosen_indices;
-          std::tie(pivots, chosen_indices) =
+          auto [pivots, chosen_indices] =
               randomization_helper::select_n_randomly<StmtPtr>(
                   stmts, n_pivots, random_engine);
           std::unordered_set<StmtPtr> pivots_set(pivots.begin(), pivots.end());
@@ -371,9 +369,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
           int num_loops_to_fuse =
               std::max(2, (int)(std::rand() % (int)loops.size()));
 
-          std::vector<ForPtr> loops_to_fuse;
-          std::vector<int> chosen_indices;
-          std::tie(loops_to_fuse, chosen_indices) =
+          auto [loops_to_fuse, chosen_indices] =
               randomization_helper::select_n_randomly<ForPtr>(
                   loops, num_loops_to_fuse, random_engine);
 


### PR DESCRIPTION
This PR follows #119774, Python generated code was changed to use structural binding.


cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @EikanWang