### PR TITLE
[RFC] TORCHELASTIC_LOG_FOR_FB_TUPPERWARE

### DIFF
--- a/torch/distributed/launcher/api.py
+++ b/torch/distributed/launcher/api.py
@@ -89,6 +89,12 @@ class LaunchConfig:
     metrics_cfg: Dict[str, str] = field(default_factory=dict)
     local_addr: Optional[str] = None
     local_ranks_filter: Optional[Set[int]] = None
+    # This triggers an alternative file layout for how we put log files into
+    # log_dir; specifically, all log files are prefixed with dedicated_log_
+    # and placed in the top-level directory (no subdirectory structure).
+    # If you think this is generally useful, we can refactor this into some
+    # more generic flags (e.g., log_use_flat_structure and log_name_prefix)
+    log_for_fb_tupperware: bool = False
 
     def __post_init__(self):
         default_timeout = 900
@@ -253,6 +259,7 @@ def launch_agent(
         log_dir=config.log_dir,
         log_line_prefix_template=config.log_line_prefix_template,
         local_ranks_filter=config.local_ranks_filter,
+        log_for_fb_tupperware=config.log_for_fb_tupperware,
     )
 
     shutdown_rdzv = True

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -728,6 +728,8 @@ def config_from_args(args) -> Tuple[LaunchConfig, Union[Callable, str], List[str
 
     log_line_prefix_template = os.getenv("TORCHELASTIC_LOG_LINE_PREFIX_TEMPLATE")
 
+    log_for_fb_tupperware = os.getenv("TORCHELASTIC_LOG_FOR_FB_TUPPERWARE", "") == "1"
+
     rdzv_configs = _parse_rendezvous_config(args.rdzv_conf)
 
     if args.rdzv_backend == "static":
@@ -763,6 +765,7 @@ def config_from_args(args) -> Tuple[LaunchConfig, Union[Callable, str], List[str
         log_line_prefix_template=log_line_prefix_template,
         local_addr=args.local_addr,
         local_ranks_filter=ranks,
+        log_for_fb_tupperware=log_for_fb_tupperware,
     )
 
     with_python = not args.no_python


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #119893
* #119869

I haven't tested this PR at all. The purpose of this PR is to open a discussion about how exactly we should program torchelastic so that its logs follow Tupperware's naming conventions. The proposal in this PR is we add a new envvar, TORCHELASTIC_LOG_FOR_FB_TUPPERWARE, which forces a flat directory structure on our logs and adds a `dedicated_log_` prefix. The plumbing does not seem to be too bad, but it is all very Meta specific. I am open to alternative suggestions, and will throw out and rewrite this PR if necessary. If people like this proposal, I will work on adding tests for it.

More context available at https://docs.google.com/document/d/1tf_gJ3KlKFqjsTa39yVNymDSu57Lv3mHiWi9dzJJOUk/edit#heading=h.xtn0uybla19y

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225