### PR TITLE
Use ARMV8.2 scalar fp16<->fp32 conversion

### DIFF
--- a/c10/util/Half-inl.h
+++ b/c10/util/Half-inl.h
@@ -44,6 +44,8 @@ inline C10_HOST_DEVICE Half::Half(float value)
 #if (defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)) && \
     !defined(__APPLE__)
       x(at::vec::float2half_scalar(value))
+#elif defined(__ARM_FEATURE_FP16_SCALAR_ARITHMETIC) && !defined(C10_MOBILE)
+      x(detail::sve_fp32_to_fp16_value(value))
 #else
       x(detail::fp16_ieee_from_fp32_value(value))
 #endif
@@ -62,6 +64,8 @@ inline C10_HOST_DEVICE Half::operator float() const {
 #if (defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)) && \
     !defined(__APPLE__)
   return at::vec::half2float_scalar(x);
+#elif defined(__ARM_FEATURE_FP16_SCALAR_ARITHMETIC) && !defined(C10_MOBILE)
+  return detail::sve_fp16_to_fp32_value(x);
 #else
   return detail::fp16_ieee_to_fp32_value(x);
 #endif

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -329,22 +329,30 @@ inline uint16_t fp16_ieee_from_fp32_value(float f) {
 }
 
 #if defined(__ARM_FEATURE_FP16_SCALAR_ARITHMETIC) && !defined(C10_MOBILE)
+constexpr inline float16_t fp16_from_bits(uint16_t h) {
+  union {
+    uint16_t as_bits;
+    float16_t as_value;
+  } fp16 = {h};
+  return fp16.as_value;
+}
+
+constexpr inline uint16_t fp16_to_bits(float16_t f) {
+  union {
+    float16_t as_value;
+    uint16_t as_bits;
+  } fp16 = {.as_value = f};
+  return fp16.as_bits;
+}
+
 // According to https://godbolt.org/z/8s14GvEjo it would translate to single
 // fcvt s0, h0
 inline float sve_fp16_to_fp32_value(uint16_t h) {
-  union {
-    uint16_t h;
-    float16_t f16;
-  } x = {h};
-  return x.f16;
+  return static_cast<float>(fp16_from_bits(h));
 }
 
 inline uint16_t sve_fp32_to_fp16_value(float f) {
-  union {
-    float16_t f16;
-    uint16_t h;
-  } x = {static_cast<float16_t>(f)};
-  return x.h;
+  return fp16_to_bits(static_cast<float16_t>(f));
 }
 #endif
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #119909
* __->__ #119895
* #119892

Thanks to discussion with @mikekgfb I've realized that SVE is the
feature availble by default on Apple Silicon, so let use it to speed up
portable but slow bit mashing algorithm implemented as `c10::detail::fp16_ieee_from_fp32_value` by using the following implicit conversion routine:
```cpp
float sve_fp16_to_fp32_value(uint16_t h) {
  union {
     uint16_t h;
     float16_t f16;
  } x = {h};
  return x.f16;
}
```
that according to the https://godbolt.org/z/8s14GvEjo is turned into [`fcvt s0,h0`](https://developer.arm.com/documentation/ddi0596/2021-12/SVE-Instructions/FCVT--Floating-point-convert-precision--predicated--)

As results, very slow and naive [`torch.mm`](https://github.com/pytorch/pytorch/blob/edd9ddf73fae023824c854f23abfe2c15bfcfeee/aten/src/ATen/native/cpu/BlasKernel.cpp#L108) runs 3x faster: 85 msec before to 27 msec (measured by running https://github.com/malfet/llm_experiments/blob/e41341df2d75395277d44e3ae770342fca4bdf18/benchmarks/benchmark_torch_mm.py )