### PR TITLE
[dtensor] refactor sharding cost model to count for latency

### DIFF
--- a/torch/distributed/_tensor/_collective_utils.py
+++ b/torch/distributed/_tensor/_collective_utils.py
@@ -183,9 +183,9 @@ class MeshTopoInfo:
     @staticmethod
     @lru_cache(None)
     def build_from_mesh(mesh: DeviceMesh) -> "MeshTopoInfo":
-        # Generate bandwidth list for intra-host/inter-host communication pattern
-        # Note that we made bunch of assumptions made here for simplicity:
-        # 1. we assume the mesh is homogeneous
+        # Generate mesh topology info for intra-host/inter-host communication pattern
+        # Note that we made bunch of assumptions for simplicity:
+        # 1. we assume the mesh is homogeneous, and it's gpu/nccl model
         # 2. we assume gpu arch is Ampere or Hopper
         # 3. we assume collectives are all ring base algo for now
         num_devices_per_host = _mesh_resources.num_devices_per_host(mesh.device_type)
@@ -202,12 +202,12 @@ class MeshTopoInfo:
             mesh_dim_devices[mesh_dim] = num_devices
             total_num_devices *= num_devices
             if total_num_devices <= num_devices_per_host:
-                # magic number for intra-host communication bandwidth factor
+                # magic number for intra-host communication bandwidth/latency factor
                 # This number assumes latest GPU arch, i.e. Ampere or Hopper
                 # TODO: see if we need to tweak this or offer a way for user
-                # to specify the bandwidths
+                # to specify the bandwidths/latency
                 mesh_dim_bandwidth[mesh_dim] *= 0.22
-                # set to nvlink latency
+                # set to nvlink latency for intra-host
                 mesh_dim_latency[mesh_dim] = 0.6
 
         return MeshTopoInfo(

--- a/torch/distributed/_tensor/_collective_utils.py
+++ b/torch/distributed/_tensor/_collective_utils.py
@@ -1,5 +1,7 @@
 import logging
 import math
+from dataclasses import dataclass
+from functools import lru_cache
 
 from typing import List, Optional
 
@@ -167,65 +169,85 @@ def spec_to_bytes(spec: "placement_types.DTensorSpec") -> int:
     return spec.tensor_meta.dtype.itemsize * math.prod(spec.shape)
 
 
-def get_bandwidth_factor(mesh: DeviceMesh) -> List[float]:
-    # generate bandwidth factor for intra-host/inter-host communication pattern
-    factors = [1.0] * mesh.ndim
-    num_devices_per_host = _mesh_resources.num_devices_per_host(mesh.device_type)
+@dataclass
+class MeshTopoInfo:
+    """
+    Mesh information for collective cost estimation
+    """
 
-    num_devices = 1
-    for mesh_dim in reversed(range(mesh.ndim)):
-        num_devices *= mesh.size(mesh_dim)
-        if num_devices <= num_devices_per_host:
-            # magic number for intra-host communication bandwidth factor
-            # TODO: see if we need to tweak this or offer a way for user
-            # to specify the bandwidths
-            factors[mesh_dim] = 0.2
+    mesh: DeviceMesh
+    mesh_dim_devices: List[int]
+    mesh_dim_bandwidth: List[float]
+    mesh_dim_latency: List[float]
 
-    return factors
+    @staticmethod
+    @lru_cache(None)
+    def build_from_mesh(mesh: DeviceMesh) -> "MeshTopoInfo":
+        # Generate bandwidth list for intra-host/inter-host communication pattern
+        # Note that we made bunch of assumptions made here for simplicity:
+        # 1. we assume the mesh is homogeneous
+        # 2. we assume gpu arch is Ampere or Hopper
+        # 3. we assume collectives are all ring base algo for now
+        num_devices_per_host = _mesh_resources.num_devices_per_host(mesh.device_type)
+        # the base bw number, GB/s
+        base_bw = 87.7
+        mesh_dim_bandwidth = [base_bw] * mesh.ndim
+        # latency by default start with inter-node
+        mesh_dim_latency = [2.7] * mesh.ndim
+        mesh_dim_devices = [1] * mesh.ndim
+
+        total_num_devices = 1
+        for mesh_dim in reversed(range(mesh.ndim)):
+            num_devices = mesh.size(mesh_dim)
+            mesh_dim_devices[mesh_dim] = num_devices
+            total_num_devices *= num_devices
+            if total_num_devices <= num_devices_per_host:
+                # magic number for intra-host communication bandwidth factor
+                # This number assumes latest GPU arch, i.e. Ampere or Hopper
+                # TODO: see if we need to tweak this or offer a way for user
+                # to specify the bandwidths
+                mesh_dim_bandwidth[mesh_dim] *= 0.22
+                # set to nvlink latency
+                mesh_dim_latency[mesh_dim] = 0.6
+
+        return MeshTopoInfo(
+            mesh, mesh_dim_devices, mesh_dim_bandwidth, mesh_dim_latency
+        )
 
 
-def allgather_cost(num_bytes: float, mesh: DeviceMesh, mesh_dim: int) -> float:
-    num_devices_on_mesh_dim = mesh.size(mesh_dim)
-    bandwidth_factor = get_bandwidth_factor(mesh)[mesh_dim]
-    # constant latency factor + bandwidth cost
-    return (
-        1
-        + bandwidth_factor
-        * num_bytes
-        * (num_devices_on_mesh_dim - 1)
-        / num_devices_on_mesh_dim
-    )
+def allgather_cost(bytes_gb: float, mesh_topo: MeshTopoInfo, mesh_dim: int) -> float:
+    num_devices_on_mesh_dim = mesh_topo.mesh_dim_devices[mesh_dim]
+    mesh_dim_bandwidth = mesh_topo.mesh_dim_bandwidth[mesh_dim]
+    num_hops = num_devices_on_mesh_dim - 1
+    # base latency + comm latency
+    latency = 6.6 + num_hops * mesh_topo.mesh_dim_latency[mesh_dim]  # us
+    bw = (bytes_gb * num_hops / num_devices_on_mesh_dim) / mesh_dim_bandwidth  # s
+    return latency + bw * 1e6  # rescale to us
 
 
-def allreduce_cost(num_bytes: float, mesh: DeviceMesh, mesh_dim: int) -> float:
-    num_devices_on_mesh_dim = mesh.size(mesh_dim)
-    bandwidth_factor = get_bandwidth_factor(mesh)[mesh_dim]
+def allreduce_cost(bytes_gb: float, mesh_topo: MeshTopoInfo, mesh_dim: int) -> float:
+    num_devices_on_mesh_dim = mesh_topo.mesh_dim_devices[mesh_dim]
+    mesh_dim_bandwidth = mesh_topo.mesh_dim_bandwidth[mesh_dim]
     # allreduce have 2x comm bytes compare to allgather/reduce_scatter
-    return (
-        1
-        + 2
-        * bandwidth_factor
-        * num_bytes
-        * (num_devices_on_mesh_dim - 1)
-        / num_devices_on_mesh_dim
-    )
+    num_hops = 2 * num_devices_on_mesh_dim - 1
+
+    latency = 6.6 + num_hops * mesh_topo.mesh_dim_latency[mesh_dim]
+    bw = (bytes_gb * num_hops / num_devices_on_mesh_dim) / mesh_dim_bandwidth
+    return latency + bw * 1e6
 
 
 def reduce_scatter_cost(
-    num_bytes: float,
-    mesh: DeviceMesh,
+    bytes_gb: float,
+    mesh_topo: MeshTopoInfo,
     mesh_dim: int,
 ) -> float:
-    num_devices_on_mesh_dim = mesh.size(mesh_dim)
-    bandwidth_factor = get_bandwidth_factor(mesh)[mesh_dim]
-    # constant latency factor + bandwidth cost
-    return (
-        1
-        + bandwidth_factor
-        * num_bytes
-        * (num_devices_on_mesh_dim - 1)
-        / num_devices_on_mesh_dim
-    )
+    num_devices_on_mesh_dim = mesh_topo.mesh_dim_devices[mesh_dim]
+    mesh_dim_bandwidth = mesh_topo.mesh_dim_bandwidth[mesh_dim]
+    num_hops = num_devices_on_mesh_dim - 1
+    # base latency + comm latency
+    latency = 6.6 + num_hops * mesh_topo.mesh_dim_latency[mesh_dim]
+    bw = (bytes_gb * num_hops / num_devices_on_mesh_dim) / mesh_dim_bandwidth
+    return latency + bw * 1e6
 
 
 def redistribute_cost(
@@ -251,9 +273,11 @@ def redistribute_cost(
         # comm cost is 0 if current spec is already full replication
         return 0.0
 
-    mesh = current_spec.mesh
+    mesh_topo = MeshTopoInfo.build_from_mesh(current_spec.mesh)
     cost = 0.0
-    comm_bytes = spec_to_bytes(current_spec) / current_spec.num_shards
+    comm_bytes_gb = (
+        spec_to_bytes(current_spec) / current_spec.num_shards / 1024 / 1024 / 1024
+    )
     # Transformation that considered for redistribute cost:
     # 1. allgather 2. alltoall
     # 3. allreduce 4. reduce_scatter
@@ -262,23 +286,25 @@ def redistribute_cost(
     ):
         if current == target:
             continue
+
+        num_devices_on_mesh_dim = mesh_topo.mesh_dim_devices[i]
         if current.is_shard() and target.is_replicate():
             # allgather gives larger comm bytes
-            comm_bytes *= mesh.size(i)
+            comm_bytes_gb *= num_devices_on_mesh_dim
             # add up allgather comm cost
-            cost += allgather_cost(comm_bytes, current_spec.mesh, i)
+            cost += allgather_cost(comm_bytes_gb, mesh_topo, i)
         elif current.is_shard() and target.is_shard():
             # should be alltoall comm, since we haven't implement it yet, add penalty
             # to favor allgather instead
-            cost += allgather_cost(comm_bytes, current_spec.mesh, i) + 1.0
+            cost += allgather_cost(comm_bytes_gb, mesh_topo, i) + 1.0
         elif current.is_partial() and target.is_replicate():
             # add up allreduce comm cost
-            cost += allreduce_cost(comm_bytes, current_spec.mesh, i)
+            cost += allreduce_cost(comm_bytes_gb, mesh_topo, i)
         elif current.is_partial() and target.is_shard():
             # add up reduce_scatter comm cost
-            cost += reduce_scatter_cost(comm_bytes, current_spec.mesh, i)
+            cost += reduce_scatter_cost(comm_bytes_gb, mesh_topo, i)
             # after reduce_scatter the comm bytes for further collectives halved.
-            comm_bytes /= mesh.size(i)
+            comm_bytes_gb /= num_devices_on_mesh_dim
         elif current.is_shard() and target.is_partial():
             # ban shard -> partial as it does not make sense to perform
             # this redistribute


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #119897

This PR refactors the shardeing cost model, to do a more accurate
estimation of redistribute cost, including both collective latency and
communciation time.

The previous cost model does not recale the latency and communciation
time, therefore the latency factor is too small to be counted, and in
the case of small tensors, multiple collectives is preferred than a
single collective, which is wrong.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @fduwjj @wz337 @tianyu-l @wconstab @yf225