### PR TITLE
Revert pointwise concat heuristics

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -277,6 +277,7 @@ max_fusion_size = 64
 
 # max number of inputs to generate cat as a pointwise op with masked laods
 max_pointwise_cat_inputs = 8
+max_pointwise_cat_inputs = 4
 
 # replace small reductions with pointwise, disable with `= 1`
 unroll_reductions_threshold = 8


### PR DESCRIPTION
Summary:
We detected that D53375778 regressed the cmf_10x model by 10%.

Revert it back to 4 number of inputs to fix this regression.

Test Plan:
Before this Diff:
```
buck2 run mode/opt //pytorch/benchmark:run -- cmf_10x -d cuda -t train --torchdynamo inductor --torchinductor_cudagraph 0
GPU Time per batch:   33.630 milliseconds
CPU Wall Time per batch:  33.701 milliseconds
CPU Wall Time:        33.701 milliseconds
Time to first batch:        21909.9132 ms
GPU 0 Peak Memory:             33.3121 GB
CPU Peak Memory:               11.0186 GB
PT2 Compilation time:      24.003 seconds
```


After this Diff:
```
buck2 run mode/opt //pytorch/benchmark:run -- cmf_10x -d cuda -t train --torchdynamo inductor --torchinductor_cudagraph 0

GPU Time per batch:   28.651 milliseconds
CPU Wall Time per batch:  28.694 milliseconds
CPU Wall Time:        28.694 milliseconds
Time to first batch:        25729.7465 ms
GPU 0 Peak Memory:             33.5153 GB
CPU Peak Memory:               10.6875 GB
PT2 Compilation time:      43.719 seconds
```

Reviewed By: Yuzhen11

Differential Revision: D53723074




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler