### PR TITLE
[Traceback] Expose jit line information

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2113,7 +2113,7 @@ class PyCodeCache:
             regex = r'File "(.+)", line (\d+), in (.+)\n'
             matches = re.findall(regex, stack_trace)
             return [
-                {"filename": f, "line": int(l), "name": n}
+                {"filename": f, "lineno": int(l), "name": n}
                 for f, l, n in reversed(matches)
             ]
 

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -1571,7 +1571,9 @@ def format_tb(frames):
 
     for entry in frames:
         formatted_traceback.append(
-            traceback.FrameSummary(entry["filename"], entry["line"], entry["name"])
+            traceback.FrameSummary(
+                entry["filename"], entry["lineno"], entry["name"], line=entry["line"]
+            )
         )
 
     return "".join(traceback.format_list(formatted_traceback))

--- a/torch/csrc/cuda/memory_snapshot.cpp
+++ b/torch/csrc/cuda/memory_snapshot.cpp
@@ -50,15 +50,17 @@ std::vector<IValue> ivalue_symbolize(
   }
   auto s = symbolize(unique_frames);
 
-  IValue line_s = "line";
+  IValue lineno_s = "lineno";
   IValue name_s = "name";
   IValue filename_s = "filename";
+  IValue line_s = "line";
   std::vector<IValue> all_frames;
   for (const auto& f : s.all_frames) {
     auto d = new_dict();
     d.insert(name_s, f.funcname);
     d.insert(filename_s, f.filename);
-    d.insert(line_s, int64_t(f.lineno));
+    d.insert(lineno_s, int64_t(f.lineno));
+    d.insert(line_s, f.line);
     all_frames.emplace_back(std::move(d));
   }
 

--- a/torch/csrc/profiler/combined_traceback.cpp
+++ b/torch/csrc/profiler/combined_traceback.cpp
@@ -139,9 +139,11 @@ SymbolizedTracebacks symbolize(
         if (flc) {
           size_t col = 0;
           std::tie(frame.filename, frame.lineno, col) = *flc;
+          frame.line = f.range.source()->get_line(frame.lineno - 1).str();
         } else {
           frame.filename = "??";
           frame.lineno = 0;
+          frame.line = "??";
         }
         r.tracebacks.back().push_back(r.all_frames.size());
         r.all_frames.emplace_back(std::move(frame));

--- a/torch/csrc/profiler/python/combined_traceback.cpp
+++ b/torch/csrc/profiler/python/combined_traceback.cpp
@@ -70,7 +70,7 @@ struct PythonTraceback : public CapturedTraceback::Python {
       const std::vector<CapturedTraceback::PyFrame>& to_symbolize,
       SymbolizedTracebacks& result) override {
     py::gil_scoped_acquire acquire;
-    py::str line_s = "line";
+    py::str lineno_s = "lineno";
     py::str name_s = "name";
     py::str filename_s = "filename";
 
@@ -105,7 +105,7 @@ struct PythonTraceback : public CapturedTraceback::Python {
             result.all_frames.emplace_back(unwind::Frame{
                 py::cast<std::string>(h[filename_s]),
                 py::cast<std::string>(h[name_s]),
-                py::cast<uint64_t>(h[line_s])});
+                py::cast<uint64_t>(h[lineno_s])});
           }
         }
       }
@@ -130,15 +130,17 @@ std::vector<py::object> py_symbolize(
   }
   auto s = symbolize(unique_frames);
 
-  py::str line_s = "line";
+  py::str lineno_s = "lineno";
   py::str name_s = "name";
   py::str filename_s = "filename";
+  py::str line_s = "line";
   std::vector<py::dict> all_frames;
   for (const auto& f : s.all_frames) {
     py::dict d;
     d[name_s] = f.funcname;
     d[filename_s] = f.filename;
-    d[line_s] = f.lineno;
+    d[lineno_s] = f.lineno;
+    d[line_s] = f.line;
     all_frames.emplace_back(std::move(d));
   }
 

--- a/torch/csrc/profiler/unwind/unwind.h
+++ b/torch/csrc/profiler/unwind/unwind.h
@@ -14,6 +14,7 @@ struct Frame {
   std::string filename;
   std::string funcname;
   uint64_t lineno;
+  std::string line;
 };
 
 // note: symbolize is really slow

--- a/torch/csrc/profiler/unwind/unwind_fb.cpp
+++ b/torch/csrc/profiler/unwind/unwind_fb.cpp
@@ -18,7 +18,7 @@ std::vector<Frame> symbolize(const std::vector<void*>& frames) {
   results.reserve(frames.size());
   for (auto addr : frames) {
     if (!frame_map_.count(addr)) {
-      auto frame = Frame{"??", "<unwind unsupported>", 0};
+      auto frame = Frame{"??", "<unwind unsupported>", 0, "??"};
       auto maybe_library = libraryFor(addr);
       if (maybe_library) {
         auto libaddress = maybe_library->second - 1;
@@ -29,6 +29,7 @@ std::vector<Frame> symbolize(const std::vector<void*>& frames) {
           frame.filename = r->FileName;
           frame.funcname = r->FunctionName;
           frame.lineno = r->Line;
+          // TODO: Expose LineSource information.
         }
       }
       frame_map_[addr] = std::move(frame);

--- a/torch/utils/_traceback.py
+++ b/torch/utils/_traceback.py
@@ -250,5 +250,12 @@ def _extract_symbolized_tb(tb, skip):
     """
     stack = traceback.StackSummary()
     for f in reversed(tb[skip:]):
-        stack.append(traceback.FrameSummary(f['filename'], f['line'], f['name']))
+        stack.append(
+            traceback.FrameSummary(
+                f["filename"],
+                f["lineno"],
+                f["name"],
+                line=f["line"] if f["line"] else None,
+            )
+        )
     return stack


### PR DESCRIPTION
Summary: Align unwind::frame with traceback.FrameSummary. Add source line information.

Differential Revision: D53771058




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang