### PR TITLE
Add NEON accelerated `torch.mv` kernel

### DIFF
--- a/aten/src/ATen/native/BlasKernel.cpp
+++ b/aten/src/ATen/native/BlasKernel.cpp
@@ -9,6 +9,10 @@
 #include <climits>
 #include <limits>
 
+#if defined(__ARM_FEATURE_FP16_SCALAR_ARITHMETIC) && !defined(C10_MOBILE)
+#include <arm_neon.h>
+#endif
+
 namespace {
 
 /// Wrapper for const_cast<T*> with type-inference.
@@ -155,7 +159,145 @@ INSTANTIATE(int16_t);
 INSTANTIATE(int);
 INSTANTIATE(int64_t);
 INSTANTIATE(c10::BFloat16);
+#if defined(__ARM_FEATURE_FP16_SCALAR_ARITHMETIC) && !defined(C10_MOBILE)
+template <>
+bool scal_use_fast_path<at::Half>(int64_t n, int64_t incx) {
+  return false;
+}
+
+template <>
+bool gemv_use_fast_path<at::Half>(
+    int64_t m,
+    int64_t n,
+    int64_t lda,
+    int64_t incx,
+    int64_t incy) {
+  return true;
+}
+
+static void gemv_trans(
+    int m,
+    int n,
+    const float16_t alpha,
+    const float16_t* a,
+    const int lda,
+    const float16_t* x,
+    const int incx,
+    const float16_t beta,
+    float16_t* y,
+    int incy) {
+  if (incx == 1 && alpha == 1.0 && beta == 0.0 && m % 4 == 0) {
+    for (const auto i : c10::irange(n)) {
+      float16x4_t sumVec = vdup_n_f16(0);
+      const auto row_ = a + lda * i;
+      for (auto j = 0; j < m; j += 4) {
+        float16x4_t aVec = vld1_f16(row_ + j);
+        float16x4_t xVec = vld1_f16(x + j);
+        sumVec = vadd_f16(sumVec, vmul_f16(aVec, xVec));
+      }
+      auto sum2 = vpadd_f16(sumVec, sumVec);
+      y[i * incy] = vget_lane_f16(vpadd_f16(sum2, sum2), 0);
+    }
+    return;
+  }
+  for (const auto i : c10::irange(n)) {
+    float sum = 0;
+    const auto row_ = a + lda * i;
+    for (const auto j : c10::irange(m)) {
+      sum += x[j * incx] * row_[j];
+    }
+    if (beta == 0.0) {
+      y[i * incy] = alpha * sum;
+    } else {
+      y[i * incy] = beta * y[i * incy] + alpha * sum;
+    }
+  }
+}
+
+static void gemv_notrans(
+    int m,
+    int n,
+    const float16_t alpha,
+    const float16_t* a,
+    const int lda,
+    const float16_t* x,
+    const int incx,
+    const float16_t beta,
+    float16_t* y,
+    int incy) {
+  if (incx == 1 && alpha == 1.0 && beta == 0.0 && m % 4 == 0 && incy == 1) {
+    for (auto j = 0; j < n; j += 4) {
+      auto vecCol = vld1_f16(x + j);
+      const auto* column = a + lda * j;
+      for (auto i = 0; i < m; i += 4) {
+        auto yf16 = y + i;
+        auto matRow = vld1_f16(column + i);
+        auto resVec = j != 0 ? vld1_f16(yf16) : vdup_n_f16(0);
+        resVec = vfma_f16(resVec, matRow, vecCol);
+        vst1_f16(yf16, resVec);
+      }
+    }
+    return;
+  }
+  for (const auto j : c10::irange(n)) {
+    const auto* column_ = a + lda * j;
+    auto z = alpha * x[j * incx];
+    for (const auto i : c10::irange(m)) {
+      if (j == 0) {
+        if (beta == 0.0) {
+          y[i * incy] = 0;
+        } else {
+          y[i * incy] *= beta;
+        }
+      }
+      y[i * incy] += z * column_[i];
+    }
+  }
+}
+
+template <>
+void gemv_fast_path<at::Half>(
+    const char* trans,
+    const int* m,
+    const int* n,
+    const at::Half* alpha,
+    const at::Half* a,
+    const int* lda,
+    const at::Half* x,
+    const int* incx,
+    const at::Half* beta,
+    at::Half* y,
+    const int* incy) {
+  using namespace c10::detail;
+  if ((trans[0] == 'T') || (trans[0] == 't')) {
+    gemv_trans(
+        *m,
+        *n,
+        fp16_from_bits(alpha->x),
+        reinterpret_cast<const float16_t*>(a),
+        *lda,
+        reinterpret_cast<const float16_t*>(x),
+        *incx,
+        fp16_from_bits(beta->x),
+        reinterpret_cast<float16_t*>(y),
+        *incy);
+  } else {
+    gemv_notrans(
+        *m,
+        *n,
+        fp16_from_bits(alpha->x),
+        reinterpret_cast<const float16_t*>(a),
+        *lda,
+        reinterpret_cast<const float16_t*>(x),
+        *incx,
+        fp16_from_bits(beta->x),
+        reinterpret_cast<float16_t*>(y),
+        *incy);
+  }
+}
+#else
 INSTANTIATE(c10::Half);
+#endif
 #undef INSTANTIATE
 
 } // namespace blas_impl


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #119909
* #119895
* #119892

This reduced torch.mv time for 256x768 matrix by 256 element vector from 209 usec to 38 usec for nontransposed case and from 104 to 7 usec if transposed.

Though I wonder if this algorithm should be hidden behind some global config setting, like [`torch.set_float32_matmul_precision`](https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html)