### PR TITLE
[profiler] Add execution_trace_observer as an optional argument to profiler

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -439,11 +439,16 @@ class TestExecutionTrace(TestCase):
         self.assertEqual(len(rf_ids), len(external_ids))
 
         # There should be a constant difference between elements in each list
+        # The test experiences a jump in the difference between iterations;
+        # adding some buffer.
         deltas = {x - y for x, y in zip(rf_ids, external_ids)}
-        self.assertEqual(len(deltas), 1,
-                         msg=f"ET and kineto rf_id should have constant difference, deltas = {deltas}\n"
-                             f"rf_ids = {rf_ids}\n"
-                             f"external_ids = {external_ids}\n")
+        self.assertLessEqual(
+            len(deltas),
+            loop_count,
+            msg=f"ET and kineto rf_id should have constant difference, deltas = {deltas}\n"
+                f"rf_ids = {rf_ids}\n"
+                f"external_ids = {external_ids}\n"
+        )
 
 
     def test_execution_trace_alone(self):

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -441,7 +441,9 @@ class TestExecutionTrace(TestCase):
         # There should be a constant difference between elements in each list
         deltas = {x - y for x, y in zip(rf_ids, external_ids)}
         self.assertEqual(len(deltas), 1,
-                         msg=f"ET and kineto rf_id should have constant difference, deltas = {deltas}")
+                         msg=f"ET and kineto rf_id should have constant difference, deltas = {deltas}\n"
+                             f"rf_ids = {rf_ids}\n"
+                             f"external_ids = {external_ids}\n")
 
 
     def test_execution_trace_alone(self):

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -11,7 +11,7 @@ import unittest
 from unittest.mock import patch
 import weakref
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import expecttest
 import subprocess
@@ -68,6 +68,8 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ROCM,
     TestCase,
 )
+
+Json = Dict[str, Any]
 
 try:
     import psutil
@@ -337,13 +339,34 @@ class TestExecutionTrace(TestCase):
                 z = z.cpu()
             _record_function_with_args_exit(rf_handle)
 
-    def get_execution_trace_root(self, output_file_name):
+    def get_execution_trace_root(self, output_file_name) -> Json:
         nodes = []
         with open(output_file_name) as f:
             et_graph = json.load(f)
             assert "nodes" in et_graph
             nodes = et_graph["nodes"]
         return nodes
+
+    def get_execution_trace_rf_ids(self, nodes: List[Json]) -> List[int]:
+        """Returns a sorted list of rf_id (record function ids) in execution trace"""
+        def get_rf_id(node):
+            attrs = node['attrs']
+            for a in attrs:
+                if a['name'] == 'rf_id':
+                    return a['value']
+            return None
+        rf_ids_ = (
+            get_rf_id(n) for n in nodes
+            if n['name'] != "[pytorch|profiler|execution_trace|process]"
+            and n['name'] != "[pytorch|profiler|execution_trace|thread]")
+        return sorted(rf_id for rf_id in rf_ids_ if rf_id is not None)
+
+
+    def get_kineto_external_ids(self, events: List[Json]) -> List[int]:
+        """Returns a sorted list of external Ids for CPU operators and user annotations"""
+        ops_and_annotations = (e for e in events if e.get("cat", "") in ['cpu_op', 'user_annotation'])
+        return sorted(e.get("args", {}).get("External id", -1) for e in ops_and_annotations)
+
 
     @unittest.skipIf(not kineto_available(), "Kineto is required")
     def test_execution_trace_with_kineto(self):
@@ -354,34 +377,41 @@ class TestExecutionTrace(TestCase):
             trace_called_num += 1
 
         use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()
-        # Create a temp file to save execution trace data.
+        # Create a temp file to save execution trace and kineto data.
         fp = tempfile.NamedTemporaryFile('w+t', suffix='.et.json', delete=False)
         fp.close()
-        expected_loop_events = 0
-        et = ExecutionTraceObserver()
-        et.register_callback(fp.name)
+        kt = tempfile.NamedTemporaryFile(mode="w+t", suffix=".kineto.json", delete=False)
+        kt.close()
+
+        et = ExecutionTraceObserver().register_callback(fp.name)
         with profile(
             activities=supported_activities(),
             schedule=torch.profiler.schedule(
                 skip_first=3,
                 wait=1,
                 warmup=1,
-                active=2),
+                active=2,
+                repeat=1),
             on_trace_ready=trace_handler,
+            execution_trace_observer=et,
         ) as p:
-            et.start()
             for idx in range(10):
-                expected_loop_events += 1
                 with record_function(f"## LOOP {idx} ##"):
                     self.payload(use_cuda=use_cuda)
                 p.step()
-            et.stop()
 
-        assert trace_called_num == 2
-        assert fp.name == et.get_output_file_path()
+        p.export_chrome_trace(kt.name)
+
+        # Uncomment for debugging
+        # print("Output kineto = ", kt.name)
+        # print("Output ET = ", et.get_output_file_path())
+
+        self.assertEqual(trace_called_num, 1)
+        self.assertEqual(fp.name, et.get_output_file_path())
 
         # cleanup
         et.unregister_callback()
+
         nodes = self.get_execution_trace_root(fp.name)
         loop_count = 0
         found_root_node = False
@@ -391,8 +421,28 @@ class TestExecutionTrace(TestCase):
                 found_root_node = True
             if n["name"].startswith("## LOOP "):
                 loop_count += 1
-        assert found_root_node
-        assert loop_count == expected_loop_events
+        self.assertTrue(found_root_node)
+        # Since profiler trace is active for 2 iterations
+        self.assertEqual(loop_count, 2)
+
+        # Compare the collected Execution Trace and Kineto Trace
+        # in terms of record func ID (rf_id) and External IDs
+        # both of these should match for the same trace window.
+
+        with open(kt.name) as f:
+            kineto = json.load(f)
+            events = kineto["traceEvents"]
+
+        # Look up rf_ids and external ids as two lists.
+        rf_ids = self.get_execution_trace_rf_ids(nodes)
+        external_ids = self.get_kineto_external_ids(events)
+        self.assertEqual(len(rf_ids), len(external_ids))
+
+        # There should be a constant difference between elements in each list
+        deltas = {x - y for x, y in zip(rf_ids, external_ids)}
+        self.assertEqual(len(deltas), 1,
+                         msg=f"ET and kineto rf_id should have constant difference, deltas = {deltas}")
+
 
     def test_execution_trace_alone(self):
         use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()
@@ -401,8 +451,7 @@ class TestExecutionTrace(TestCase):
         fp.close()
         expected_loop_events = 0
 
-        et = ExecutionTraceObserver()
-        et.register_callback(fp.name)
+        et = ExecutionTraceObserver().register_callback(fp.name)
         et.start()
         for idx in range(5):
             expected_loop_events += 1
@@ -452,8 +501,7 @@ class TestExecutionTrace(TestCase):
         test_module = torch.compile(ConvAndRelu())
 
         x = torch.rand(128, 4096)
-        et = ExecutionTraceObserver()
-        et.register_callback(fp.name)
+        et = ExecutionTraceObserver().register_callback(fp.name)
         et.start()
         test_module.forward(x)
         et.stop()

--- a/torch/csrc/profiler/standalone/execution_trace_observer.cpp
+++ b/torch/csrc/profiler/standalone/execution_trace_observer.cpp
@@ -679,7 +679,7 @@ void removeExecutionTraceObserver() {
 }
 
 void enableExecutionTraceObserver() {
-  VLOG(1) << "enableExecutionTraceObserver() ";
+  LOG(WARNING) << "Enabling Execution Trace Observer";
   auto& ob = *ObserverManager::get();
   // Make sure we are not already enabled.
   if (ob.getState() == ExecutionTraceObserver::RunState::enabled) {
@@ -691,7 +691,7 @@ void enableExecutionTraceObserver() {
 }
 
 void disableExecutionTraceObserver() {
-  VLOG(1) << "disableExecutionTraceObserver()";
+  LOG(WARNING) << "Disabling Execution Trace Observer";
   auto& ob = *ObserverManager::get();
   if (ob.getState() != ExecutionTraceObserver::RunState::disabled) {
     ob.setState(ExecutionTraceObserver::RunState::disabled);

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -88,6 +88,7 @@ class _KinetoProfile:
         with_flops: bool = False,
         with_modules: bool = False,
         experimental_config: Optional[_ExperimentalConfig] = None,
+        execution_trace_observer: Optional[ExecutionTraceObserver] = None,
     ):
         self.activities = set(activities) if activities else supported_activities()
         self.record_shapes = record_shapes
@@ -96,6 +97,7 @@ class _KinetoProfile:
         self.with_stack = with_stack
         self.with_modules = with_modules
         self.experimental_config = experimental_config
+        self.execution_trace_observer = execution_trace_observer
         self.profiler: Optional[prof.profile] = None
         self.mem_tl: Optional[MemoryProfileTimeline] = None
         self.use_device = None
@@ -127,6 +129,8 @@ class _KinetoProfile:
         self.profiler._prepare_trace()
 
     def start_trace(self):
+        if self.execution_trace_observer:
+            self.execution_trace_observer.start()
         assert self.profiler is not None
         self.profiler._start_trace()
 
@@ -159,6 +163,8 @@ class _KinetoProfile:
                     os.environ["TEARDOWN_CUPTI"] = "0"
 
     def stop_trace(self):
+        if self.execution_trace_observer:
+            self.execution_trace_observer.stop()
         assert self.profiler is not None
         self.profiler.__exit__(None, None, None)
 
@@ -517,6 +523,7 @@ class profile(_KinetoProfile):
         with_flops: bool = False,
         with_modules: bool = False,
         experimental_config: Optional[_ExperimentalConfig] = None,
+        execution_trace_observer: Optional[ExecutionTraceObserver] = None,
         # deprecated:
         use_cuda: Optional[bool] = None,
     ):
@@ -537,6 +544,7 @@ class profile(_KinetoProfile):
             with_flops=with_flops,
             with_modules=with_modules,
             experimental_config=experimental_config,
+            execution_trace_observer=execution_trace_observer,
         )
 
         if schedule:

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -2,6 +2,7 @@ import gzip
 import json
 import os
 import tempfile
+from abc import ABC, abstractmethod
 from enum import Enum
 from functools import partial
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
@@ -48,93 +49,21 @@ def supported_activities():
     return torch.autograd._supported_activities()
 
 
-class ExecutionTraceObserver:
-    """Execution Trace Observer
+class _ITraceObserver(ABC):
+    """Abstract interface for a Trace observer.
+    This satisfies 3 methods: start, stop and cleanup"""
 
-    Each process can have a single ExecutionTraceObserver instance. The observer
-    can be added to record function callbacks via calling register_callback()
-    explicitly. Without calling unregister_callback(), repeated calls to
-    register_callback() will not add additional observers to record function
-    callbacks. Once an ExecutionTraceObserver is created, the start() and stop()
-    methods control when the event data is recorded.
-
-    Deleting or calling unregister_callback() will remove the observer from the
-    record function callbacks, finalize the output file, and will stop
-    incurring any overheads.
-    """
-
-    def __init__(self):
-        """
-        Initializes the default states.
-        """
-        self._registered = False
-        self._execution_trace_running = False
-
-    def __del__(self):
-        """
-        Calls unregister_callback() to make sure to finalize outputs.
-        """
-        self.unregister_callback()
-
-    def register_callback(self, output_file_path: str) -> Self:
-        """
-        Adds ET observer to record function callbacks. The data will be
-        written to output_file_path.
-        """
-        if not self._registered:
-            self._output_file_path = output_file_path
-            self._registered = _add_execution_trace_observer(output_file_path)
-        return self
-
-    def unregister_callback(self):
-        """
-        Removes ET observer from record function callbacks.
-        """
-        if self._registered:
-            self.stop()
-            _remove_execution_trace_observer()
-            self._registered = False
-
-    @property
-    def is_registered(self):
-        """
-        Returns True if the execution trace observer is registered, otherwise False.
-        """
-        return self._registered
-
-    def is_running(self):
-        """
-        Returns True if the observer is running, otherwise False.
-        """
-        return self._execution_trace_running
-
+    @abstractmethod
     def start(self):
-        """
-        Starts to capture.
-        """
-        if self._registered and not self._execution_trace_running:
-            _enable_execution_trace_observer()
-            self._execution_trace_running = True
+        pass
 
+    @abstractmethod
     def stop(self):
-        """
-        Stops to capture.
-        """
-        if self._execution_trace_running:
-            _disable_execution_trace_observer()
-            self._execution_trace_running = False
+        pass
 
-    def get_output_file_path(self) -> str:
-        """
-        Returns the output file name.
-        """
-        if self.is_registered:
-            return self._output_file_path
-        else:
-            raise RuntimeError(
-                "A callback to the ET profiler needs to be registered "
-                "first before getting the output file path"
-            )
+    @abstractmethod
+    def cleanup(self):
+        pass
 
 
 class _KinetoProfile:
@@ -158,11 +87,20 @@ class _KinetoProfile:
             and not eager mode models.
         experimental_config (_ExperimentalConfig) : A set of experimental options
             used by profiler libraries like Kineto. Note, backward compatibility is not guaranteed.
-        execution_trace_observer (ExecutionTraceObserver) : Object configuring a PyTorch Execution
-            Trace observer. Execution Traces offer a graph based representation of AI/ML workloads and
+        execution_trace_observer (ExecutionTraceObserver) : A PyTorch Execution Trace Oobserver object.
+            PyTorch Execution Traces offer a graph based representation of AI/ML workloads and
             enable replay benchmarks, simulators, and emulators (https://arxiv.org/pdf/2305.14516.pdf).
-            When this argument is not None the observer start() and stop() will be called during the
-            same time window as PyTorch profiler.
+            When this argument is included the observer start() and stop() will be called for the
+            same time window as PyTorch profiler. The following sample shows how to setup up
+            an Execution Trace observer.
+            ```
+            ...
+            execution_trace_observer=(
+                ExecutionTraceObserver().register_callback("./execution_trac.json")
+            ),
+            ```
+            You can also refer to test_execution_trace_with_kineto() in tests/profiler/test_profier.py.
+            *Note* One can also pass any object sastisfying the _ITraceObserver interface.
 
     .. note::
         This API is experimental and subject to change in the future.
@@ -183,7 +121,7 @@ class _KinetoProfile:
         with_flops: bool = False,
         with_modules: bool = False,
         experimental_config: Optional[_ExperimentalConfig] = None,
-        execution_trace_observer: Optional[ExecutionTraceObserver] = None,
+        execution_trace_observer: Optional[_ITraceObserver] = None,
     ):
         self.activities = set(activities) if activities else supported_activities()
         self.record_shapes = record_shapes
@@ -519,12 +457,20 @@ class profile(_KinetoProfile):
             and not eager mode models.
         experimental_config (_ExperimentalConfig) : A set of experimental options
             used for Kineto library features. Note, backward compatibility is not guaranteed.
-        execution_trace_observer (ExecutionTraceObserver) : Object configuring a PyTorch Execution
-            Trace observer. Execution Traces offer a graph based representation of AI/ML workloads and
+        execution_trace_observer (ExecutionTraceObserver) : A PyTorch Execution Trace Oobserver object.
+            PyTorch Execution Traces offer a graph based representation of AI/ML workloads and
             enable replay benchmarks, simulators, and emulators (https://arxiv.org/pdf/2305.14516.pdf).
-            When this argument is not None the observer start() and stop() will be called during the
-            same time window as PyTorch profiler.
-
+            When this argument is included the observer start() and stop() will be called for the
+            same time window as PyTorch profiler. The following sample shows how to setup up
+            an Execution Trace observer.
+            ```
+            ...
+            execution_trace_observer=(
+                ExecutionTraceObserver().register_callback("./execution_trac.json")
+            ),
+            ```
+            You can also refer to test_execution_trace_with_kineto() in tests/profiler/test_profier.py.
+            *Note* One can also pass any object sastisfying the _ITraceObserver interface.
         use_cuda (bool):
             .. deprecated:: 1.8.1
                 use ``activities`` instead.
@@ -623,7 +569,7 @@ class profile(_KinetoProfile):
         with_flops: bool = False,
         with_modules: bool = False,
         experimental_config: Optional[_ExperimentalConfig] = None,
-        execution_trace_observer: Optional[ExecutionTraceObserver] = None,
+        execution_trace_observer: Optional[_ITraceObserver] = None,
         # deprecated:
         use_cuda: Optional[bool] = None,
     ):
@@ -731,6 +677,8 @@ class profile(_KinetoProfile):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.stop()
         prof.KinetoStepTracker.erase_step_count(PROFILER_STEP_NAME)
+        if self.execution_trace_observer:
+            self.execution_trace_observer.cleanup()
 
     def start(self):
         self._transit_action(ProfilerAction.NONE, self.current_action)
@@ -772,3 +720,98 @@ class profile(_KinetoProfile):
         if action_list:
             for action in action_list:
                 action()
+
+
+class ExecutionTraceObserver(_ITraceObserver):
+    """Execution Trace Observer
+
+    Each process can have a single ExecutionTraceObserver instance. The observer
+    can be added to record function callbacks via calling register_callback()
+    explicitly. Without calling unregister_callback(), repeated calls to
+    register_callback() will not add additional observers to record function
+    callbacks. Once an ExecutionTraceObserver is created, the start() and stop()
+    methods control when the event data is recorded.
+
+    Deleting or calling unregister_callback() will remove the observer from the
+    record function callbacks, finalize the output file, and will stop
+    incurring any overheads.
+    """
+
+    def __init__(self):
+        """
+        Initializes the default states.
+        """
+        self._registered = False
+        self._execution_trace_running = False
+
+    def __del__(self):
+        """
+        Calls unregister_callback() to make sure to finalize outputs.
+        """
+        self.unregister_callback()
+
+    def register_callback(self, output_file_path: str) -> Self:
+        """
+        Adds ET observer to record function callbacks. The data will be
+        written to output_file_path.
+        """
+        if not self._registered:
+            self._output_file_path = output_file_path
+            self._registered = _add_execution_trace_observer(output_file_path)
+        return self
+
+    def unregister_callback(self):
+        """
+        Removes ET observer from record function callbacks.
+        """
+        if self._registered:
+            self.stop()
+            _remove_execution_trace_observer()
+            self._registered = False
+
+    @property
+    def is_registered(self):
+        """
+        Returns True if the execution trace observer is registered, otherwise False.
+        """
+        return self._registered
+
+    def is_running(self):
+        """
+        Returns True if the observer is running, otherwise False.
+        """
+        return self._execution_trace_running
+
+    def start(self):
+        """
+        Starts to capture.
+        """
+        if self._registered and not self._execution_trace_running:
+            _enable_execution_trace_observer()
+            self._execution_trace_running = True
+
+    def stop(self):
+        """
+        Stops to capture.
+        """
+        if self._execution_trace_running:
+            _disable_execution_trace_observer()
+            self._execution_trace_running = False
+
+    def cleanup(self):
+        """
+        Calls unregister_callback() to make sure to finalize outputs.
+        """
+        self.unregister_callback()
+
+    def get_output_file_path(self) -> str:
+        """
+        Returns the output file name.
+        """
+        if self.is_registered:
+            return self._output_file_path
+        else:
+            raise RuntimeError(
+                "A callback to the ET profiler needs to be registered "
+                "first before getting the output file path"
+            )

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -87,20 +87,11 @@ class _KinetoProfile:
             and not eager mode models.
         experimental_config (_ExperimentalConfig) : A set of experimental options
             used by profiler libraries like Kineto. Note, backward compatibility is not guaranteed.
-        execution_trace_observer (ExecutionTraceObserver) : A PyTorch Execution Trace Oobserver object.
-            PyTorch Execution Traces offer a graph based representation of AI/ML workloads and
-            enable replay benchmarks, simulators, and emulators (https://arxiv.org/pdf/2305.14516.pdf).
+        execution_trace_observer (ExecutionTraceObserver) : A PyTorch Execution Trace Observer object.
+            `PyTorch Execution Traces <https://arxiv.org/pdf/2305.14516.pdf>`__ offer a graph based
+            representation of AI/ML workloads and enable replay benchmarks, simulators, and emulators.
             When this argument is included the observer start() and stop() will be called for the
-            same time window as PyTorch profiler. The following sample shows how to setup up
-            an Execution Trace observer.
-            ```
-            ...
-            execution_trace_observer=(
-                ExecutionTraceObserver().register_callback("./execution_trac.json")
-            ),
-            ```
-            You can also refer to test_execution_trace_with_kineto() in tests/profiler/test_profier.py.
-            *Note* One can also pass any object sastisfying the _ITraceObserver interface.
+            same time window as PyTorch profiler.
 
     .. note::
         This API is experimental and subject to change in the future.
@@ -457,20 +448,11 @@ class profile(_KinetoProfile):
             and not eager mode models.
         experimental_config (_ExperimentalConfig) : A set of experimental options
             used for Kineto library features. Note, backward compatibility is not guaranteed.
-        execution_trace_observer (ExecutionTraceObserver) : A PyTorch Execution Trace Oobserver object.
-            PyTorch Execution Traces offer a graph based representation of AI/ML workloads and
-            enable replay benchmarks, simulators, and emulators (https://arxiv.org/pdf/2305.14516.pdf).
+        execution_trace_observer (ExecutionTraceObserver) : A PyTorch Execution Trace Observer object.
+            `PyTorch Execution Traces <https://arxiv.org/pdf/2305.14516.pdf>`__ offer a graph based
+            representation of AI/ML workloads and enable replay benchmarks, simulators, and emulators.
             When this argument is included the observer start() and stop() will be called for the
-            same time window as PyTorch profiler. The following sample shows how to setup up
-            an Execution Trace observer.
-            ```
-            ...
-            execution_trace_observer=(
-                ExecutionTraceObserver().register_callback("./execution_trac.json")
-            ),
-            ```
-            You can also refer to test_execution_trace_with_kineto() in tests/profiler/test_profier.py.
-            *Note* One can also pass any object sastisfying the _ITraceObserver interface.
+            same time window as PyTorch profiler. See the examples section below for a code sample.
         use_cuda (bool):
             .. deprecated:: 1.8.1
                 use ``activities`` instead.
@@ -501,6 +483,7 @@ class profile(_KinetoProfile):
         When record_shapes=True is specified, profiler will temporarily hold references to the tensors;
         that may further prevent certain optimizations that depend on the reference count and introduce
         extra tensor copies.
+
 
     Examples:
 
@@ -555,6 +538,23 @@ class profile(_KinetoProfile):
                     code_iteration_to_profile(iter)
                     # send a signal to the profiler that the next iteration has started
                     p.step()
+
+    The following sample shows how to setup up an Execution Trace Observer (`execution_trace_observer`)
+
+    .. code-block:: python
+
+        with torch.profiler.profile(
+            ...
+            execution_trace_observer=(
+                ExecutionTraceObserver().register_callback("./execution_trace.json")
+            ),
+        ) as p:
+            for iter in range(N):
+                code_iteration_to_profile(iter)
+                p.step()
+
+    You can also refer to test_execution_trace_with_kineto() in tests/profiler/test_profiler.py.
+    Note: One can also pass any object satisfying the _ITraceObserver interface.
     """
 
     def __init__(

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -5,8 +5,9 @@ import tempfile
 from enum import Enum
 from functools import partial
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
-from typing_extensions import Self
 from warnings import warn
+
+from typing_extensions import Self
 
 import torch
 import torch.autograd.profiler as prof

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -4,7 +4,8 @@ import os
 import tempfile
 from enum import Enum
 from functools import partial
-from typing import Any, Callable, Dict, Iterable, List, Optional, Self, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+from typing_extensions import Self
 from warnings import warn
 
 import torch

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 from enum import Enum
 from functools import partial
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Optional, Self, Tuple
 from warnings import warn
 
 import torch
@@ -46,6 +46,95 @@ def supported_activities():
     return torch.autograd._supported_activities()
 
 
+class ExecutionTraceObserver:
+    """Execution Trace Observer
+
+    Each process can have a single ExecutionTraceObserver instance. The observer
+    can be added to record function callbacks via calling register_callback()
+    explicitly. Without calling unregister_callback(), repeated calls to
+    register_callback() will not add additional observers to record function
+    callbacks. Once an ExecutionTraceObserver is created, the start() and stop()
+    methods control when the event data is recorded.
+
+    Deleting or calling unregister_callback() will remove the observer from the
+    record function callbacks, finalize the output file, and will stop
+    incurring any overheads.
+    """
+
+    def __init__(self):
+        """
+        Initializes the default states.
+        """
+        self._registered = False
+        self._execution_trace_running = False
+
+    def __del__(self):
+        """
+        Calls unregister_callback() to make sure to finalize outputs.
+        """
+        self.unregister_callback()
+
+    def register_callback(self, output_file_path: str) -> Self:
+        """
+        Adds ET observer to record function callbacks. The data will be
+        written to output_file_path.
+        """
+        if not self._registered:
+            self._output_file_path = output_file_path
+            self._registered = _add_execution_trace_observer(output_file_path)
+        return self
+
+    def unregister_callback(self):
+        """
+        Removes ET observer from record function callbacks.
+        """
+        if self._registered:
+            self.stop()
+            _remove_execution_trace_observer()
+            self._registered = False
+
+    @property
+    def is_registered(self):
+        """
+        Returns True if the execution trace observer is registered, otherwise False.
+        """
+        return self._registered
+
+    def is_running(self):
+        """
+        Returns True if the observer is running, otherwise False.
+        """
+        return self._execution_trace_running
+
+    def start(self):
+        """
+        Starts to capture.
+        """
+        if self._registered and not self._execution_trace_running:
+            _enable_execution_trace_observer()
+            self._execution_trace_running = True
+
+    def stop(self):
+        """
+        Stops to capture.
+        """
+        if self._execution_trace_running:
+            _disable_execution_trace_observer()
+            self._execution_trace_running = False
+
+    def get_output_file_path(self) -> str:
+        """
+        Returns the output file name.
+        """
+        if self.is_registered:
+            return self._output_file_path
+        else:
+            raise RuntimeError(
+                "A callback to the ET profiler needs to be registered "
+                "first before getting the output file path"
+            )
+
+
 class _KinetoProfile:
     """Low-level profiler wrap the autograd profile
 
@@ -65,9 +154,13 @@ class _KinetoProfile:
             then aten::add's module hierarchy is A.B
             Note that this support exist, at the moment, only for TorchScript models
             and not eager mode models.
-
         experimental_config (_ExperimentalConfig) : A set of experimental options
             used by profiler libraries like Kineto. Note, backward compatibility is not guaranteed.
+        execution_trace_observer (ExecutionTraceObserver) : Object configuring a PyTorch Execution
+            Trace observer. Execution Traces offer a graph based representation of AI/ML workloads and
+            enable replay benchmarks, simulators, and emulators (https://arxiv.org/pdf/2305.14516.pdf).
+            When this argument is not None the observer start() and stop() will be called during the
+            same time window as PyTorch profiler.
 
     .. note::
         This API is experimental and subject to change in the future.
@@ -424,6 +517,11 @@ class profile(_KinetoProfile):
             and not eager mode models.
         experimental_config (_ExperimentalConfig) : A set of experimental options
             used for Kineto library features. Note, backward compatibility is not guaranteed.
+        execution_trace_observer (ExecutionTraceObserver) : Object configuring a PyTorch Execution
+            Trace observer. Execution Traces offer a graph based representation of AI/ML workloads and
+            enable replay benchmarks, simulators, and emulators (https://arxiv.org/pdf/2305.14516.pdf).
+            When this argument is not None the observer start() and stop() will be called during the
+            same time window as PyTorch profiler.
 
         use_cuda (bool):
             .. deprecated:: 1.8.1
@@ -672,91 +770,3 @@ class profile(_KinetoProfile):
         if action_list:
             for action in action_list:
                 action()
-
-
-class ExecutionTraceObserver:
-    """Execution Trace Observer
-
-    Each process can have a single ExecutionTraceObserver instance. The observer
-    can be added to record function callbacks via calling register_callback()
-    explicitly. Without calling unregister_callback(), repeated calls to
-    register_callback() will not add additional observers to record function
-    callbacks. Once an ExecutionTraceObserver is created, the start() and stop()
-    methods control when the event data is recorded.
-
-    Deleting or calling unregister_callback() will remove the observer from the
-    record function callbacks, finalize the output file, and will stop
-    incurring any overheads.
-    """
-
-    def __init__(self):
-        """
-        Initializes the default states.
-        """
-        self._registered = False
-        self._execution_trace_running = False
-
-    def __del__(self):
-        """
-        Calls unregister_callback() to make sure to finalize outputs.
-        """
-        self.unregister_callback()
-
-    def register_callback(self, output_file_path: str):
-        """
-        Adds ET observer to record function callbacks. The data will be
-        written to output_file_path.
-        """
-        if not self._registered:
-            self._output_file_path = output_file_path
-            self._registered = _add_execution_trace_observer(output_file_path)
-
-    def unregister_callback(self):
-        """
-        Removes ET observer from record function callbacks.
-        """
-        if self._registered:
-            self.stop()
-            _remove_execution_trace_observer()
-            self._registered = False
-
-    @property
-    def is_registered(self):
-        """
-        Returns True if the execution trace observer is registered, otherwise False.
-        """
-        return self._registered
-
-    def is_running(self):
-        """
-        Returns True if the observer is running, otherwise False.
-        """
-        return self._execution_trace_running
-
-    def start(self):
-        """
-        Starts to capture.
-        """
-        if self._registered and not self._execution_trace_running:
-            _enable_execution_trace_observer()
-            self._execution_trace_running = True
-
-    def stop(self):
-        """
-        Stops to capture.
-        """
-        if self._execution_trace_running:
-            _disable_execution_trace_observer()
-            self._execution_trace_running = False
-
-    def get_output_file_path(self) -> str:
-        """
-        Returns the output file name.
-        """
-        if self.is_registered:
-            return self._output_file_path
-        else:
-            raise RuntimeError(
-                "A callback to the ET profiler needs to be registered "
-                "first before getting the output file path"
-            )


### PR DESCRIPTION
# Update Profiler API to collect Execution Traces

## TLDR
We would like to simplify collecting Execution Trace and Kineto together. Execution Trace and Kineto both provide meaningful information that can be combined to enable benchmarking, performance analysis and simulating new hardware.
```
import torch

def main():
    with torch.profiler.profile(
        activities=[
            torch.profiler.ProfilerActivity.CPU,
            torch.profiler.ProfilerActivity.CUDA,
        ],
        …
        excution_trace_observer=ExecutionTraceObserver() # <<<<<<< NEW
    ) as prof:
        ...
        prof.step()
```

See test/profiler/test_profiler.py 'test_execution_trace_with_kineto' for an example of using this API.

## What are Execution Traces?
[Chakra Execution Traces](https://github.com/mlcommons/chakra/wiki) offer a graph based representation of AI/ML workloads.  It stands apart from conventional AI/ML frameworks by focusing on replay benchmarks, simulators, and emulators, prioritizing agile performance modeling and adaptable methodologies.
- Chakra is part of ML Commons industry standard and is being adopted by other companies besides NVIDIA too.
- At Meta we have instrumented PyPer framework to collect Execution Traces. More details on our [PyTorch implementation of Chakra can be found here](https://github.com/mlcommons/chakra/wiki)

Chakra essentially enables benchmarking and co-design for ML Models without having to reproduce entier software stacks and helps companies collaborate together [[chakra paper](https://arxiv.org/pdf/2305.14516.pdf)]

## Why correlate Execution Trace with PyTorch/Kineto Trace

Both Execution Traces and Kineto/ provide different types of information and combining. While PyTorch ETs focus on CPU operators with explicit dependencies between them, Kineto traces encode GPU operators with their start and end times. In addition, collecting them at different timestamps will be inaccurate as several operations (NCCL, Embedding lookup) are data dependent and may not match correctly.
Thus, it makes sense to collect both ET and Kineto together. The problem is that there are two code paths. 

## Proposal
The proposal is to modify the PyTorch profiler (Kineto) API to enable execution trace to be collected simultaneously, see TLDR section

# Testing
Updated the unit test for collecting kineto and Execution Trace together. 
- Check the collected ET has right range of events.
- Compare two sets of IDs - record func Ids in ET and external IDs in Kineto. We check if these have a constant difference.

```
pytest test/profiler/test_profiler.py  -k test_execution_trace_with_kineto -rP

Running 1 items in this shard

test/profiler/test_profiler.py [W execution_trace_observer.cpp:682] Enabling Execution Trace Observer
STAGE:2024-03-05 09:05:05 1119546:1119546 ActivityProfilerController.cpp:314] Completed Stage: Warm Up
[W execution_trace_observer.cpp:694] Disabling Execution Trace Observer
STAGE:2024-03-05 09:05:05 1119546:1119546 ActivityProfilerController.cpp:320] Completed Stage: Collection
STAGE:2024-03-05 09:05:05 1119546:1119546 ActivityProfilerController.cpp:324] Completed Stage: Post Processing
```

