### PR TITLE
[export] turn on replace_set_grad_with_hop_pass in pre_dispatch

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -70,12 +70,21 @@ class TestSerialize(TestCase):
                 with torch.enable_grad():
                     return x + x
 
+        inp = (torch.ones(10),)
         with torch.no_grad():
             from torch.export._trace import _export
-            ep = _export(Foo(), (torch.ones(10),), pre_dispatch=True)
+            ep = _export(Foo(), inp, pre_dispatch=True)
 
-        with self.assertRaisesRegex(SerializeError, "Failed serializing node _set_grad_enabled"):
-            torch.export.save(ep, io.BytesIO())
+        buffer = io.BytesIO()
+        torch.export.save(ep, buffer)
+        buffer.seek(0)
+        loaded_ep = torch.export.load(buffer)
+
+        exp_out = ep.module()(*inp)
+        actual_out = loaded_ep.module()(*inp)
+        self.assertEqual(exp_out, actual_out)
+        self.assertEqual(exp_out.requires_grad, actual_out.requires_grad)
+
 
     def test_serialize_multiple_returns_from_node(self) -> None:
         class MyModule(torch.nn.Module):

--- a/torch/_export/passes/replace_set_grad_with_hop_pass.py
+++ b/torch/_export/passes/replace_set_grad_with_hop_pass.py
@@ -96,6 +96,7 @@ def _replace_with_hop(node: torch.fx.Node):
                 raise NotImplementedError(
                     "Cannot replace a call_module with a hop if it has no output. This module will gets DCEed."
                 )
+        sub_graph.erase_node(set_grad_node)
 
 
 def _remove_set_grad_and_inline(node: torch.fx.Node):

--- a/torch/_export/passes/replace_set_grad_with_hop_pass.py
+++ b/torch/_export/passes/replace_set_grad_with_hop_pass.py
@@ -1,9 +1,8 @@
-import functools
-
 import torch
 from torch._higher_order_ops.wrap import wrap_with_set_grad_enabled
 
 from ..utils import (
+    node_inline_,
     node_replace_,
     nodes_filter,
     nodes_first,
@@ -32,7 +31,11 @@ def _is_set_grad_enabled_sub_mod(node: torch.fx.Node, omit_if_same_with_ambient=
             and first_non_ph.op == "call_function"
             and first_non_ph.target == torch._C._set_grad_enabled
         ):
-            return True
+            return (
+                first_non_ph.args[0] != torch.is_grad_enabled()
+                if omit_if_same_with_ambient
+                else True
+            )
     return False
 
 
@@ -47,20 +50,91 @@ def _replace_with_hop(node: torch.fx.Node):
     if len(set_grad_nodes) > 0:
         assert len(set_grad_nodes) == 1
         set_grad_node = set_grad_nodes[0]
-        enable_grad = set_grad_node.args[0]
+        enable_grad_val = set_grad_node.args[0]
         with graph.inserting_before(node):
             get_attr_node = graph.get_attr(node.target)
-            call_func_node = graph.call_function(
-                wrap_with_set_grad_enabled, (enable_grad, get_attr_node, *node.args)
-            )
-        node_replace_(node, call_func_node, delete_old=True)
+            output_node = next(iter(reversed(sub_gm.graph.nodes)), None)
+            if output_node is not None:
+                assert len(output_node.args) == 1
+                output_args = output_node.args[0]
+                if isinstance(output_args, (tuple, list)):
+                    call_func_node = graph.call_function(
+                        wrap_with_set_grad_enabled,
+                        (enable_grad_val, get_attr_node, *node.args),
+                        {},
+                    )
+                    # Create the metadata
+                    call_func_node.meta["val"] = tuple(
+                        arg.meta["val"] for arg in output_args
+                    )
+                    node_replace_(node, call_func_node, delete_old=True)
+
+                    # Rename the name of getitem nodes to the actual name of its contents
+                    # for passing verifier and better readability, also propagate metadata
+                    for get_item_node in call_func_node.users.keys():
+                        idx: int = get_item_node.args[1]
+                        output_node = output_args[idx]
+                        get_item_node._rename(output_node.name)
+                        get_item_node.meta = output_node.meta
+                        pass
+
+                elif isinstance(output_args, torch.fx.Node):
+                    call_func_node = graph.create_node(
+                        "call_function",
+                        wrap_with_set_grad_enabled,
+                        (enable_grad_val, get_attr_node, *node.args),
+                        {},
+                        output_args.name,
+                    )
+                    call_func_node.meta = output_args.meta
+                    node_replace_(node, call_func_node, delete_old=True)
+                else:
+                    raise NotImplementedError(
+                        f"repalce_set_grad_with_hop_pass doesnt' support output type {type(output_args)}"
+                    )
+            else:
+                raise NotImplementedError(
+                    "Cannot replace a call_module with a hop if it has no output. This module will gets DCEed."
+                )
+
+
+def _remove_set_grad_and_inline(node: torch.fx.Node):
+    assert node.op == "call_module"
+    graph: torch.fx.Graph = node.graph
+    gm: torch.fx.GraphModule = graph.owning_module
+    assert isinstance(node.target, str)
+    sub_gm = getattr(gm, node.target)
+    sub_graph = sub_gm.graph
+    nodes_map(
+        sub_graph.nodes,
+        lambda n: graph.erase_node(n) if _is_set_grad_enabled_node(n) else n,
+    )
+    node_inline_(node)
 
 
 def replace_set_grad_with_hop_pass(gm: torch.fx.GraphModule):
+    # If there is no set_grad_enabled node, return the original graph module
+    need_replacing = False
+    for node in gm.graph.nodes:
+        if _is_set_grad_enabled_node(node):
+            need_replacing = True
+
+    if not need_replacing:
+        return gm
+
     new_gm = sequential_split(gm, _is_set_grad_enabled_node)
-    call_module_nodes = nodes_filter(
+
+    def _maybe_inline_or_replace_with_hop(node: torch.fx.Node):
+        if _is_set_grad_enabled_sub_mod(node, omit_if_same_with_ambient=True):
+            _replace_with_hop(node)
+        else:
+            _remove_set_grad_and_inline(node)
+
+    nodes_map(
         list(new_gm.graph.nodes),
-        functools.partial(_is_set_grad_enabled_sub_mod, omit_if_same_with_ambient=True),
+        lambda node: _maybe_inline_or_replace_with_hop(node)
+        if node.op == "call_module"
+        else node,
     )
-    nodes_map(call_module_nodes, _replace_with_hop)
+    new_gm.graph.lint()
     return new_gm

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -1305,6 +1305,16 @@ class GraphModuleDeserializer:
 
         elif isinstance(target, torch._ops.HigherOrderOperator):
             args, kwargs = self.deserialize_hoo_inputs(serialized_node.inputs)
+            # If HOP returns a single tensor, name the
+            # newly-created node after it. This ensures that these tensor values
+            # have names that are consistent with serialized.
+            #
+            # HOPs don't have schema yet, just check the output lengths and as_tensor attribute
+            name = (
+                serialized_node.outputs[0].as_tensor.name
+                if len(serialized_node.outputs) == 1 and hasattr(serialized_node.outputs[0], "as_tensor")
+                else None
+            )
             fx_node = self.graph.create_node(
                 "call_function", target, args, kwargs, None
             )

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -1316,7 +1316,7 @@ class GraphModuleDeserializer:
                 else None
             )
             fx_node = self.graph.create_node(
-                "call_function", target, args, kwargs, None
+                "call_function", target, args, kwargs, name
             )
             self.deserialize_outputs(serialized_node, fx_node)
             fx_node.meta.update(self.deserialize_metadata(serialized_node.metadata))

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -853,7 +853,6 @@ def _export(
         ),
         len(export_graph_signature.input_specs),
     )
-    breakpoint()
     range_constraints = _process_constraints(
         gm,
         num_lifted,

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -368,6 +368,13 @@ def _export_non_strict(
     if isinstance(mod, torch.fx.GraphModule) and hasattr(mod, "meta"):
         gm.meta.update(mod.meta)
 
+    if pre_dispatch:
+        from torch._export.passes.replace_set_grad_with_hop_pass import (
+            replace_set_grad_with_hop_pass,
+        )
+
+        gm = replace_set_grad_with_hop_pass(gm)
+
     # NOTE: aot_export adds symint metadata for placeholders with int values;
     # since these become specialized, we replace such metadata with the original values
     flat_args = pytree.tree_leaves((fake_args, fake_kwargs))
@@ -846,6 +853,7 @@ def _export(
         ),
         len(export_graph_signature.input_specs),
     )
+    breakpoint()
     range_constraints = _process_constraints(
         gm,
         num_lifted,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #119915
* #119914
* #119913
* #119810
* #119736
* #119732

This PR turns on replace_set_grad_with_hop_pass for pre_dispatch export. To do that, we need to propagate the meta-data from original submodule to the new higher order op and fix the names of nodes as is required by the _sig_to_specs pass.