### PR TITLE
Add quantized gelu

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4992,6 +4992,7 @@
   device_check: NoCheck   # TensorIterator
   python_module: nn
   dispatch:
+    QuantizedCPU: gelu_quantized_cpu_
     NestedTensorCPU, NestedTensorCUDA: NestedTensor_gelu_
 
 - func: gelu(Tensor self, *, str approximate='none') -> Tensor

--- a/aten/src/ATen/native/quantized/cpu/qgelu.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qgelu.cpp
@@ -18,4 +18,12 @@ Tensor gelu_quantized_cpu(const Tensor& qx, c10::string_view approximate) {
   qgelu_stub(qx.device().type(), qx, qy, get_gelutype_enum(approximate));
   return qy;
 }
+
+Tensor& gelu_quantized_cpu_(Tensor& self, c10::string_view approximate) {
+  Tensor qy = gelu_quantized_cpu(self, approximate);
+  // This can be optimized in a future PR if it becomes a bottleneck.
+  self.copy_(qy);
+  return self;
+}
+
 }}  // namespace at::native

--- a/aten/src/ATen/native/vulkan/glsl/quantized_gelu_tanh_qint8.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_gelu_tanh_qint8.glsl
@@ -1,0 +1,35 @@
+#version 450 core
+#define PRECISION ${PRECISION}
+#define FORMAT ${FORMAT}
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, rgba8i)  uniform PRECISION restrict writeonly  iimage3D   uOutput;
+layout(set = 0, binding = 1)          uniform PRECISION                     isampler3D uInput; //quantized input
+layout(set = 0, binding = 2)          uniform PRECISION restrict            Block {
+  ivec4 size;
+  float kBeta; /* M_SQRT2 * M_2_SQRTPI * 0.5 */
+  float scale;
+  int zero_point;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (all(lessThan(pos, uBlock.size.xyz))) {
+    const vec4 qua_inval = texelFetch(uInput, pos, 0);
+
+    const vec4 inval = uBlock.scale * (qua_inval - uBlock.zero_point); //dequantize
+    const vec4 invalcube = inval * inval * inval;
+    const vec4 inner = vec4(uBlock.kBeta) * (inval + vec4(0.044715) * invalcube);
+    const vec4 res = vec4(0.5) * inval * (vec4(1.0) + tanh(inner));
+    const vec4 qua_res = roundEven(res / uBlock.scale) + uBlock.zero_point;
+    const ivec4 outval = ivec4(qua_res);
+
+    imageStore(uOutput, pos, outval);
+  }
+}

--- a/aten/src/ATen/native/vulkan/glsl/quantized_gelu_tanh_qint8_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_gelu_tanh_qint8_.glsl
@@ -1,0 +1,34 @@
+#version 450 core
+#define PRECISION ${PRECISION}
+#define FORMAT ${FORMAT}
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, rgba8i) uniform PRECISION restrict iimage3D uOutput;
+layout(set = 0, binding = 1)         uniform PRECISION restrict Block {
+  ivec4 size;
+  float kBeta; /* M_SQRT2 * M_2_SQRTPI * 0.5 */
+  float scale;
+  int zero_point;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (all(lessThan(pos, uBlock.size.xyz))) {
+    const vec4 qua_inval = imageLoad(uOutput, pos);
+
+    const vec4 inval = uBlock.scale * (qua_inval - uBlock.zero_point); //dequantize
+    const vec4 invalcube = inval * inval * inval;
+    const vec4 inner = vec4(uBlock.kBeta) * (inval + vec4(0.044715) * invalcube);
+    const vec4 res = vec4(0.5) * inval * (vec4(1.0) + tanh(inner));
+    const vec4 qua_res = roundEven(res / uBlock.scale) + uBlock.zero_point;
+    const ivec4 outval = ivec4(qua_res);
+
+    imageStore(uOutput, pos, outval);
+  }
+}

--- a/aten/src/ATen/native/vulkan/glsl/quantized_gelu_tanh_quint8.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_gelu_tanh_quint8.glsl
@@ -1,0 +1,35 @@
+#version 450 core
+#define PRECISION ${PRECISION}
+#define FORMAT ${FORMAT}
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, rgba8ui) uniform PRECISION restrict writeonly uimage3D   uOutput;
+layout(set = 0, binding = 1)          uniform PRECISION                    isampler3D uInput; //quantized input
+layout(set = 0, binding = 2)          uniform PRECISION restrict           Block {
+  ivec4 size;
+  float kBeta; /* M_SQRT2 * M_2_SQRTPI * 0.5 */
+  float scale;
+  int zero_point;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (all(lessThan(pos, uBlock.size.xyz))) {
+    const vec4 qua_inval = texelFetch(uInput, pos, 0);
+
+    const vec4 inval = uBlock.scale * (qua_inval - uBlock.zero_point); //dequantize
+    const vec4 invalcube = inval * inval * inval;
+    const vec4 inner = vec4(uBlock.kBeta) * (inval + vec4(0.044715) * invalcube);
+    const vec4 res = vec4(0.5) * inval * (vec4(1.0) + tanh(inner));
+    const vec4 qua_res = roundEven(res / uBlock.scale) + uBlock.zero_point;
+    const uvec4 outval = uvec4(qua_res);
+
+    imageStore(uOutput, pos, outval);
+  }
+}

--- a/aten/src/ATen/native/vulkan/glsl/quantized_gelu_tanh_quint8_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_gelu_tanh_quint8_.glsl
@@ -1,0 +1,34 @@
+#version 450 core
+#define PRECISION ${PRECISION}
+#define FORMAT ${FORMAT}
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, rgba8ui) uniform PRECISION restrict uimage3D uOutput;
+layout(set = 0, binding = 1)          uniform PRECISION restrict Block {
+  ivec4 size;
+  float kBeta; /* M_SQRT2 * M_2_SQRTPI * 0.5 */
+  float scale;
+  int zero_point;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (all(lessThan(pos, uBlock.size.xyz))) {
+    const vec4 qua_inval = imageLoad(uOutput, pos);
+
+    const vec4 inval = uBlock.scale * (qua_inval - uBlock.zero_point); //dequantize
+    const vec4 invalcube = inval * inval * inval;
+    const vec4 inner = vec4(uBlock.kBeta) * (inval + vec4(0.044715) * invalcube);
+    const vec4 res = vec4(0.5) * inval * (vec4(1.0) + tanh(inner));
+    const vec4 qua_res = roundEven(res / uBlock.scale) + uBlock.zero_point;
+    const uvec4 outval = uvec4(qua_res);
+
+    imageStore(uOutput, pos, outval);
+  }
+}

--- a/aten/src/ATen/native/vulkan/ops/Clamp.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Clamp.cpp
@@ -282,17 +282,40 @@ Tensor activation_scalar(
 
   api::UniformParamsBuffer params;
 
+  if (v_self.is_quantized()) {
+    v_output.set_is_quantized();
+    v_output.set_scale(v_self.get_scale());
+    v_output.set_zero_point(v_self.get_zero_point());
+  }
+
   if (scalar_arg.size() == 1) {
-    const struct Block final {
-      uvec3 extents;
-      uint32_t _;
-      float scalar_value;
-    } block{
-        v_output.extents(),
-        0u,
-        scalar_arg[0].to<float>(),
-    };
-    params = api::UniformParamsBuffer(context, block);
+    if (v_self.is_quantized()) {
+      const struct Block final {
+        uvec3 extents;
+        uint32_t _;
+        float scalar_value;
+        float scale;
+        int zero_point;
+      } block{
+          v_output.extents(),
+          0u,
+          scalar_arg[0].to<float>(),
+          safe_downcast<float>(v_self.get_scale()),
+          safe_downcast<int32_t>(v_self.get_zero_point()),
+      };
+      params = api::UniformParamsBuffer(context, block);
+    } else {
+      const struct Block final {
+        uvec3 extents;
+        uint32_t _;
+        float scalar_value;
+      } block{
+          v_output.extents(),
+          0u,
+          scalar_arg[0].to<float>(),
+      };
+      params = api::UniformParamsBuffer(context, block);
+    }
   } else {
     const struct Block final {
       uvec3 extents;
@@ -348,16 +371,33 @@ Tensor& activation_scalar_(
   api::UniformParamsBuffer params;
 
   if (scalar_arg.size() == 1) {
-    const struct Block final {
-      uvec3 extents;
-      uint32_t _;
-      float scalar_value;
-    } block{
-        v_self.extents(),
-        0u,
-        scalar_arg[0].to<float>(),
-    };
-    params = api::UniformParamsBuffer(context, block);
+    if (v_self.is_quantized()) {
+      const struct Block final {
+        uvec3 extents;
+        uint32_t _;
+        float scalar_value;
+        float scale;
+        int zero_point;
+      } block{
+          v_self.extents(),
+          0u,
+          scalar_arg[0].to<float>(),
+          safe_downcast<float>(v_self.get_scale()),
+          safe_downcast<int32_t>(v_self.get_zero_point()),
+      };
+      params = api::UniformParamsBuffer(context, block);
+    } else {
+      const struct Block final {
+        uvec3 extents;
+        uint32_t _;
+        float scalar_value;
+      } block{
+          v_self.extents(),
+          0u,
+          scalar_arg[0].to<float>(),
+      };
+      params = api::UniformParamsBuffer(context, block);
+    }
   } else {
     const struct Block final {
       uvec3 extents;
@@ -397,13 +437,24 @@ Tensor& activation_scalar_(
   return self_arg;
 }
 
-Tensor gelu(const Tensor& self_arg, c10::string_view approximate) {
+Tensor gelu(const Tensor& self, c10::string_view approximate) {
   TORCH_CHECK(
       approximate == "tanh", "Vulkan: gelu only supported for tanh type");
   Scalar kBetaVec = M_SQRT2 * M_2_SQRTPI * 0.5;
   std::vector<Scalar> scalar;
   scalar.push_back(kBetaVec);
-  return ops::activation_scalar(self_arg, scalar, VK_KERNEL(gelu_tanh));
+
+  if (self.scalar_type() == at::kQUInt8) {
+    return ops::activation_scalar(
+        self, scalar, VK_KERNEL(quantized_gelu_tanh_quint8));
+  }
+
+  if (self.scalar_type() == at::kQInt8) {
+    return ops::activation_scalar(
+        self, scalar, VK_KERNEL(quantized_gelu_tanh_qint8));
+  }
+
+  return ops::activation_scalar(self, scalar, VK_KERNEL(gelu_tanh));
 }
 
 Tensor& gelu_(Tensor& self, c10::string_view approximate) {
@@ -412,6 +463,17 @@ Tensor& gelu_(Tensor& self, c10::string_view approximate) {
   Scalar kBetaVec = M_SQRT2 * M_2_SQRTPI * 0.5;
   std::vector<Scalar> scalar;
   scalar.push_back(kBetaVec);
+
+  if (self.scalar_type() == at::kQUInt8) {
+    return ops::activation_scalar_(
+        self, scalar, VK_KERNEL(quantized_gelu_tanh_quint8_));
+  }
+
+  if (self.scalar_type() == at::kQInt8) {
+    return ops::activation_scalar_(
+        self, scalar, VK_KERNEL(quantized_gelu_tanh_qint8_));
+  }
+
   return ops::activation_scalar_(self, scalar, VK_KERNEL(gelu_tanh_));
 }
 


### PR DESCRIPTION
Summary: Added Quantized gelu for vulkan backend.

Test Plan:
**Tested it on "On Demand RL FBSource"**

LD_LIBRARY_PATH=third-party/swiftshader/lib/linux-x64/ buck2 run fbcode/mode/dev-nosan //xplat/caffe2:pt_vulkan_quantized_api_test_bin -c pt.vulkan_full_precision=1 -- --gtest_filter="VulkanAPITest.gelu_q*"

----------------------------------------------------------------------------------

Note: Google Test filter = VulkanAPITest.gelu_q*
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.gelu_qint8
[       OK ] VulkanAPITest.gelu_qint8 (318 ms)
[ RUN      ] VulkanAPITest.gelu_qint8_self
[       OK ] VulkanAPITest.gelu_qint8_self (214 ms)
[ RUN      ] VulkanAPITest.gelu_quint8
[       OK ] VulkanAPITest.gelu_quint8 (152 ms)
[ RUN      ] VulkanAPITest.gelu_quint8_self
[       OK ] VulkanAPITest.gelu_quint8_self (142 ms)
[----------] 4 tests from VulkanAPITest (828 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (828 ms total)
[  PASSED  ] 4 tests.

Differential Revision: D52985437


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10