### PR TITLE
[Test][FFT] Constrain inputs to [-1, 1] range for fft.hfft2

### DIFF
--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -2509,6 +2509,8 @@ def sample_inputs_spectral_ops(self, device, dtype, requires_grad=False, **kwarg
             "_refs.fft.irfft2",
         ]:
             shapes = ((2, 8, 9), (33,))
+            low = -1.0
+            high = 1.0
         elif self.name in [
             "fft.hfftn",
             "fft.irfftn",


### PR DESCRIPTION
Similar error on precision and fix referring to https://github.com/pytorch/pytorch/pull/81416

```/usr/local/lib/python3.10/dist-packages/torch/testing/_creation.py:231: UserWarning: ComplexHalf support is experimental and many operators don't support it yet. (Triggered internally at /opt/pytorch/pytorch/aten/src/ATen/EmptyTensor.cpp:41.)
  result = torch.empty(shape, device=device, dtype=dtype)
_ TestCommonCUDA.test_complex_half_reference_testing_fft_hfft2_cuda_complex32 __
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/torch/testing/_internal/common_device_type.py", line 920, in test_wrapper
    return test(*args, **kwargs)
  File "/opt/pytorch/pytorch/test/test_ops.py", line 1238, in test_complex_half_reference_testing
    self.assertEqual(actual, expected, exact_dtype=False)
  File "/usr/local/lib/python3.10/dist-packages/torch/testing/_internal/common_utils.py", line 3578, in assertEqual
    raise error_metas.pop()[0].to_error(
AssertionError: Tensor-likes are not close!

Mismatched elements: 1 / 256 (0.4%)
Greatest absolute difference: 0.07051944732666016 at index (0, 4, 10) (up to 0.04 allowed)
Greatest relative difference: 0.36067742109298706 at index (0, 4, 10) (up to 0.04 allowed)
```

cc @Aidyn-A @eqy @ptrblck 
