### PR TITLE
Timestamp Embedding Indices Generated for TD

### DIFF
--- a/.github/workflows/target-determination-indexer.yml
+++ b/.github/workflows/target-determination-indexer.yml
@@ -107,10 +107,24 @@ jobs:
           TIMESTAMP=$(date -Iseconds)
           ZIP_NAME = "indexer-files-${TIMESTAMP}.zip"
 
+          # Create a zipfile with all the generated indices
           zip -r "${ZIP_NAME}" indexer-files
+
+          # Move the old index into the archived/ folder
+          aws s3 cp \
+            "s3://target-determinator-assets/indexes/latest/*" \
+            "s3://target-determinator-assets/indexes/archived/"
+
+          # Move the new index into the latestl/ folder
           aws s3 cp \
             "${ZIP_NAME}" \
-            "s3://target-determinator-assets/indexes/${ZIP_NAME}"
+            "s3://target-determinator-assets/indexes/latest/${ZIP_NAME}"
+
+          # Note that because the above 2 operations are not atomic, there will
+          # be a period of a few seconds between these where there is no index
+          # present in the latest/ folder. To account for this, the retriever
+          # should have some retry logic with backoff to ensure fetching the
+          # index doesn't fail.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/target-determination-indexer.yml
+++ b/.github/workflows/target-determination-indexer.yml
@@ -104,10 +104,13 @@ jobs:
           conda activate tdenv
           cd "${GITHUB_WORKSPACE}"/llm-target-determinator/assets
 
-          zip -r indexer-files.zip indexer-files
+          TIMESTAMP=$(date -Iseconds)
+          ZIP_NAME = "indexer-files-${TIMESTAMP}.zip"
+
+          zip -r "${ZIP_NAME}" indexer-files
           aws s3 cp \
-            "indexer-files.zip" \
-            "s3://target-determinator-assets/indexes/indexer-files.zip"
+            "${ZIP_NAME}" \
+            "s3://target-determinator-assets/indexes/${ZIP_NAME}"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
Timestamps the generated embedding indices. Moves the old indices to an `archived/` folder and then uploads the index to a `latest/` folder. There will be a short period in between these operations where there is no index in `latest/`. To handle this case, any workflow fetching the index (such as the retriever) should use a retry with backoff when copying from S3.
