### PR TITLE
Adding c10 device type to newly added DeviceAccelerator

### DIFF
--- a/aten/src/ATen/DeviceAccelerator.h
+++ b/aten/src/ATen/DeviceAccelerator.h
@@ -22,6 +22,6 @@ namespace at {
 // Ensures that only one accelerator is available (at
 // compile time if possible) and return it.
 // When checked is true, the returned optional always has a value.
-TORCH_API std::optional<DeviceType> getAccelerator(bool checked = false);
+TORCH_API std::optional<c10::DeviceType> getAccelerator(bool checked = false);
 
 } // namespace at


### PR DESCRIPTION
Follow up to https://github.com/pytorch/pytorch/pull/104364,

A new file got submitted yesterday that is using DeviceType without the c10 namespace. This fixes that. I haven't yet figured out a way to setup a test for this, but I will submit a follow up PR once I figure that out.