### PR TITLE
[PyTorch][Vulkan]remove redundant test of log_softmax

### DIFF
--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -4585,30 +4585,6 @@ TEST_F(VulkanAPITest, log_softmax) {
   }
 }
 
-// TODO: Currently the op is not working correctly. Add it back when it is fixed.
-TEST_F(VulkanAPITest, DISABLED_log_softmax) {
-  at::Tensor test_in[] = {
-    at::rand({1, 196, 302, 5}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
-    at::rand({1, 197, 302, 5}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
-    at::rand({1, 198, 302, 5}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
-    at::rand({1, 199, 302, 5}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
-  };
-
-  for (auto in_cpu : test_in) {
-    const auto out_cpu = at::softmax(in_cpu, 1);
-
-    const auto in_vulkan = in_cpu.vulkan();
-    const auto out_vulkan = at::log_softmax(in_vulkan, 1);
-
-    const auto check = almostEqual(out_cpu, out_vulkan.cpu());
-    if (!check) {
-      showRtol(out_cpu, out_vulkan.cpu());
-    }
-
-    ASSERT_TRUE(check);
-  }
-}
-
 TEST_F(VulkanAPITest, abs) {
   const auto in_cpu = at::rand({17, 197, 302, 5}, at::device(at::kCPU).dtype(at::kFloat)) * 30;
   const auto in_vulkan = in_cpu.vulkan();


### PR DESCRIPTION
Summary: `vulkan_api_test.cpp` already has [a test for `log_softmax`](https://www.internalfb.com/code/fbsource/[c79b73bd7d5f661c81ff3cf999cfa1af664f0c48]/xplat/caffe2/aten/src/ATen/test/vulkan_api_test.cpp?lines=4521), so we remove the redundant `DISABLED_log_softmax`. According to the comment the test was disabled because "the op is not working correctly. Add it back when it is fixed." Actually it's a simple typo mistake: the [CPU output should use `at::log_softmax` instead of `at::softmax`](https://www.internalfb.com/code/fbsource/[c79b73bd7d5f661c81ff3cf999cfa1af664f0c48]/xplat/caffe2/aten/src/ATen/test/vulkan_api_test.cpp?lines=4548). Since we already have a test for `log_softmax`, the fix isn't necessary and we remove this disabled test.

Test Plan:
Full vulkan_api_test P1184744699:
```
LD_LIBRARY_PATH=third-party/swiftshader/lib/linux-x64/ buck2 run fbcode/mode/dev-nosan    //xplat/caffe2:pt_vulkan_api_test_bin
...
[  SKIPPED ] VulkanAPITest.querypool_flushed_shader_log (0 ms)
[----------] 427 tests from VulkanAPITest (23633 ms total)

[----------] Global test environment tear-down
[==========] 427 tests from 1 test suite ran. (23634 ms total)
[  PASSED  ] 426 tests.
[  SKIPPED ] 1 test, listed below:
[  SKIPPED ] VulkanAPITest.querypool_flushed_shader_log
```

Reviewed By: jorgep31415

Differential Revision: D53766200


