### PR TITLE
[ROCm] HIP Lazy Streams

### DIFF
--- a/c10/cuda/CUDAStream.cpp
+++ b/c10/cuda/CUDAStream.cpp
@@ -44,8 +44,9 @@ static std::atomic<uint32_t>
 static cudaStream_t streams[c10::cuda::max_compile_time_stream_priorities]
                            [C10_COMPILE_TIME_MAX_GPUS][kStreamsPerPool];
 #ifdef USE_ROCM
-static c10::once_flag stream_flags[c10::cuda::max_compile_time_stream_priorities]
-                                  [C10_COMPILE_TIME_MAX_GPUS][kStreamsPerPool];
+static c10::once_flag
+    stream_flags[c10::cuda::max_compile_time_stream_priorities]
+                [C10_COMPILE_TIME_MAX_GPUS][kStreamsPerPool];
 #endif
 
 // Note [HIP Lazy Streams]
@@ -195,8 +196,7 @@ static void initSingleStream(int p, DeviceIndex device_index, int i) {
   C10_CUDA_CHECK(cudaStreamCreateWithPriority(&stream, kDefaultFlags, pri));
   const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
   if (C10_UNLIKELY(interp)) {
-    (*interp)->trace_gpu_stream_creation(
-        reinterpret_cast<uintptr_t>(stream));
+    (*interp)->trace_gpu_stream_creation(reinterpret_cast<uintptr_t>(stream));
     priority_counters[p][device_index] = 0;
   }
 }
@@ -285,8 +285,12 @@ cudaStream_t CUDAStream::stream() const {
         ")");
 #ifdef USE_ROCM
     // See Note [HIP Lazy Streams]
-    c10::call_once(stream_flags[st.getStreamType() - 1][device_index][si],
-        initSingleStream, st.getStreamType() - 1, device_index, si);
+    c10::call_once(
+        stream_flags[st.getStreamType() - 1][device_index][si],
+        initSingleStream,
+        st.getStreamType() - 1,
+        device_index,
+        si);
 #endif
     return streams[st.getStreamType() - 1][device_index][si];
   }

--- a/test/test_cuda_trace.py
+++ b/test/test_cuda_trace.py
@@ -74,7 +74,14 @@ class TestCudaTrace(TestCase):
     def test_stream_creation_callback(self):
         cuda_trace.register_callback_for_cuda_stream_creation(self.mock)
 
-        torch.cuda.Stream()
+        # see Note [HIP Lazy Streams]
+        if torch.version.hip:
+            user_stream = torch.cuda.Stream()
+            with torch.cuda.stream(user_stream):
+                tensor = torch.ones(5, device="cuda")
+        else:
+            torch.cuda.Stream()
+
         self.mock.assert_called()
 
     def test_device_synchronization_callback(self):


### PR DESCRIPTION
For ROCm/HIP, each stream is lazily initialized rather than creating all streams when the first stream is requested. HIP streams are not as lightweight as CUDA streams; the pooling strategy can affect performance.

cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang