### PR TITLE
Revert "Use ARMV8.2 scalar fp16<->fp32 conversion (#119895)"

### DIFF
--- a/c10/util/Half-inl.h
+++ b/c10/util/Half-inl.h
@@ -44,8 +44,6 @@ inline C10_HOST_DEVICE Half::Half(float value)
 #if (defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)) && \
     !defined(__APPLE__)
       x(at::vec::float2half_scalar(value))
-#elif defined(__ARM_FEATURE_FP16_SCALAR_ARITHMETIC) && !defined(C10_MOBILE)
-      x(detail::sve_fp32_to_fp16_value(value))
 #else
       x(detail::fp16_ieee_from_fp32_value(value))
 #endif
@@ -64,8 +62,6 @@ inline C10_HOST_DEVICE Half::operator float() const {
 #if (defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)) && \
     !defined(__APPLE__)
   return at::vec::half2float_scalar(x);
-#elif defined(__ARM_FEATURE_FP16_SCALAR_ARITHMETIC) && !defined(C10_MOBILE)
-  return detail::sve_fp16_to_fp32_value(x);
 #else
   return detail::fp16_ieee_to_fp32_value(x);
 #endif

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -45,10 +45,6 @@
 #include <sycl/sycl.hpp> // for SYCL 2020
 #endif
 
-#if defined(__ARM_FEATURE_FP16_SCALAR_ARITHMETIC) && !defined(C10_MOBILE)
-#include <arm_neon.h>
-#endif
-
 namespace c10 {
 
 namespace detail {
@@ -327,34 +323,6 @@ inline uint16_t fp16_ieee_from_fp32_value(float f) {
       (sign >> 16) |
       (shl1_w > UINT32_C(0xFF000000) ? UINT16_C(0x7E00) : nonsign));
 }
-
-#if defined(__ARM_FEATURE_FP16_SCALAR_ARITHMETIC) && !defined(C10_MOBILE)
-constexpr inline float16_t fp16_from_bits(uint16_t h) {
-  union {
-    uint16_t as_bits;
-    float16_t as_value;
-  } fp16 = {h};
-  return fp16.as_value;
-}
-
-constexpr inline uint16_t fp16_to_bits(float16_t f) {
-  union {
-    float16_t as_value;
-    uint16_t as_bits;
-  } fp16 = {.as_value = f};
-  return fp16.as_bits;
-}
-
-// According to https://godbolt.org/z/8s14GvEjo it would translate to single
-// fcvt s0, h0
-inline float sve_fp16_to_fp32_value(uint16_t h) {
-  return static_cast<float>(fp16_from_bits(h));
-}
-
-inline uint16_t sve_fp32_to_fp16_value(float f) {
-  return fp16_to_bits(static_cast<float16_t>(f));
-}
-#endif
 
 } // namespace detail
 


### PR DESCRIPTION
This reverts commit d833e2f2364a01c6fdab689a8bb5bbf55a5b60f7.

This is failing some RL builds internally using clang 13 D53791577

https://github.com/pytorch/pytorch/pull/119895#issuecomment-1946859332.  The bot doesn't like a commit being merged into the stack base and fails to revert the PR.
