### PR TITLE
Use ARMV8 fconv insns to seepd up scalar fp16<->fp32

### DIFF
--- a/c10/util/Half-inl.h
+++ b/c10/util/Half-inl.h
@@ -44,6 +44,8 @@ inline C10_HOST_DEVICE Half::Half(float value)
 #if (defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)) && \
     !defined(__APPLE__)
       x(at::vec::float2half_scalar(value))
+#elif defined(__aarch64__) && !defined(C10_MOBILE) && !defined(__CUDACC__)
+      x(detail::native_fp16_from_fp32_value(value))
 #else
       x(detail::fp16_ieee_from_fp32_value(value))
 #endif
@@ -62,6 +64,8 @@ inline C10_HOST_DEVICE Half::operator float() const {
 #if (defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)) && \
     !defined(__APPLE__)
   return at::vec::half2float_scalar(x);
+#elif defined(__aarch64__) && !defined(C10_MOBILE) && !defined(__CUDACC__)
+  return detail::native_fp16_to_fp32_value(x);
 #else
   return detail::fp16_ieee_to_fp32_value(x);
 #endif

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -45,6 +45,10 @@
 #include <sycl/sycl.hpp> // for SYCL 2020
 #endif
 
+#if defined(__aarch64__) && !defined(C10_MOBILE) && !defined(__CUDACC__)
+#include <arm_neon.h>
+#endif
+
 namespace c10 {
 
 namespace detail {
@@ -323,6 +327,34 @@ inline uint16_t fp16_ieee_from_fp32_value(float f) {
       (sign >> 16) |
       (shl1_w > UINT32_C(0xFF000000) ? UINT16_C(0x7E00) : nonsign));
 }
+
+#if defined(__aarch64__) && !defined(C10_MOBILE) && !defined(__CUDACC__)
+constexpr inline float16_t fp16_from_bits(uint16_t h) {
+  union {
+    uint16_t as_bits;
+    float16_t as_value;
+  } fp16 = {h};
+  return fp16.as_value;
+}
+
+constexpr inline uint16_t fp16_to_bits(float16_t f) {
+  union {
+    float16_t as_value;
+    uint16_t as_bits;
+  } fp16 = {.as_value = f};
+  return fp16.as_bits;
+}
+
+// According to https://godbolt.org/z/8s14GvEjo it would translate to single
+// fcvt s0, h0
+inline float native_fp16_to_fp32_value(uint16_t h) {
+  return static_cast<float>(fp16_from_bits(h));
+}
+
+inline uint16_t native_fp16_from_fp32_value(float f) {
+  return fp16_to_bits(static_cast<float16_t>(f));
+}
+#endif
 
 } // namespace detail
 


### PR DESCRIPTION
Thanks to discussion with @mikekgfb I've realized that FP16_ARITH is the feature available by default on Apple Silicon, so let use it to speed up portable but slow bit mashing algorithm implemented as `c10::detail::fp16_ieee_from_fp32_value` by using the following implicit conversion routine:
```cpp
float sve_fp16_to_fp32_value(uint16_t h) {
  union {
     uint16_t h;
     float16_t f16;
  } x = {h};
  return x.f16;
}
```
that according to the https://godbolt.org/z/8s14GvEjo is turned into [`fcvt s0,h0`](https://developer.arm.com/documentation/ddi0602/2023-12/SIMD-FP-Instructions/FCVT--Floating-point-Convert-precision--scalar--?lang=en) 

As results, very slow and naive [`torch.mm`](https://github.com/pytorch/pytorch/blob/edd9ddf73fae023824c854f23abfe2c15bfcfeee/aten/src/ATen/native/cpu/BlasKernel.cpp#L108) runs 3x faster: 85 msec before to 27 msec (measured by running https://github.com/malfet/llm_experiments/blob/e41341df2d75395277d44e3ae770342fca4bdf18/benchmarks/benchmark_torch_mm.py )

This is a reland of https://github.com/pytorch/pytorch/pull/119895 that got reverted because it was not buildable using Jetson toolkit

"Fixed" the problem by guarding the fast conversions with `!defined(__CUDACC__)`  (for internal folks, tested it by running `buck build @arvr/mode/embedded/jetson/linux/opt-stripped //xplat/caffe2:caffe2_ops_cuda_ovrsource` )
But also, extended the conversion to all AARHC64 platforms, not just the ones that support FP16 arithmetic extensions (i.e. ARMv8.2)

cc @snadampal