### PR TITLE
[DeviceMesh] Cache and reuse submesh slicing results

### DIFF
--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -1,6 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import logging
 import math
+from functools import cached_property
 from typing import Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import torch
@@ -338,6 +339,7 @@ else:
                 and self._flatten_mesh_list == other._flatten_mesh_list
             )
 
+        @cached_property
         def __getitem__(self, mesh_dim_name: str) -> "DeviceMesh":
             """
             Slice the current DeviceMesh based on the mesh_dim_name given to create a child

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -1,7 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import logging
 import math
-from functools import cached_property
+from functools import lru_cache
 from typing import Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import torch
@@ -339,7 +339,7 @@ else:
                 and self._flatten_mesh_list == other._flatten_mesh_list
             )
 
-        @cached_property
+        @lru_cache(maxsize=None)
         def __getitem__(self, mesh_dim_name: str) -> "DeviceMesh":
             """
             Slice the current DeviceMesh based on the mesh_dim_name given to create a child


### PR DESCRIPTION
Fixes #118849 

As PT is now requiring Python 3.8 or later, we can use `functools.lru_cache()` as a straight decorator. 


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @tianyu-l @wconstab @yf225