### PR TITLE
[pytree] Properly register immutable collections

### DIFF
--- a/torch/fx/immutable_collections.py
+++ b/torch/fx/immutable_collections.py
@@ -100,11 +100,13 @@ register_pytree_node(
     immutable_dict,
     _immutable_dict_flatten,
     _immutable_dict_unflatten,
+    serialized_type_name="torch.fx.immutable_collections.immutable_dict",
     flatten_with_keys_fn=_dict_flatten_with_keys,
 )
 register_pytree_node(
     immutable_list,
     _immutable_list_flatten,
     _immutable_list_unflatten,
+    serialized_type_name="torch.fx.immutable_collections.immutable_list",
     flatten_with_keys_fn=_list_flatten_with_keys,
 )


### PR DESCRIPTION
Summary:
Getting error like:
```
No registered serialization name for <class 'torch.fx.immutable_collections.immutable_dict'> found. Please update your _register_pytree_node call with a `serialized_type_name` kwarg.
```

Reviewed By: suo

Differential Revision: D53833323


