### PR TITLE
Back out "[pytree] Require serialized_type_name"

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -727,10 +727,7 @@ class TestExport(TestCase):
             a: Tensor
             b: Tensor
 
-        register_dataclass_as_pytree_node(
-            DataClass,
-            serialized_type_name="test_export_api_with_dynamic_shapes.DataClass"
-        )
+        register_dataclass_as_pytree_node(DataClass)
 
         class Foo(torch.nn.Module):
             def forward(self, inputs):
@@ -916,7 +913,7 @@ class TestExport(TestCase):
         self.assertEqual(
             spec,
             TreeSpec(
-                MyDataClass, [["x", "y"], ["z"]], [LeafSpec(), LeafSpec()]
+                MyDataClass, (MyDataClass, ["x", "y"], ["z"]), [LeafSpec(), LeafSpec()]
             ),
         )
         self.assertEqual(flat, [3, 4])
@@ -949,7 +946,11 @@ class TestExport(TestCase):
             spec,
             TreeSpec(
                 MyOtherDataClass,
-                [["x", "y", "z"], []],
+                (
+                    MyOtherDataClass,
+                    ["x", "y", "z"],
+                    [],
+                ),
                 [LeafSpec(), LeafSpec(), LeafSpec()],
             ),
         )
@@ -1952,10 +1953,7 @@ def forward(self, arg_0):
             f: torch.Tensor
             p: torch.Tensor
 
-        torch._export.utils.register_dataclass_as_pytree_node(
-            Input,
-            serialized_type_name="test_preserve_shape_dynamism_for_unused_inputs.Input"
-        )
+        torch._export.utils.register_dataclass_as_pytree_node(Input)
 
         class Module(torch.nn.Module):
             def forward(self, x: Input):

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -913,6 +913,7 @@ TreeSpec(tuple, None, [*,
         # the namedtuple type.
         self.assertEqual(spec.context._fields, roundtrip_spec.context._fields)
 
+    @unittest.expectedFailure
     def test_pytree_custom_type_serialize_bad(self):
         class DummyType:
             def __init__(self, x, y):

--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -314,19 +314,12 @@ def load(
     )
 
 
-def register_dataclass(
-    cls: Type[Any],
-    *,
-    serialized_type_name: Optional[str] = None,
-) -> None:
+def register_dataclass(cls: Type[Any]) -> None:
     """
     Registers a dataclass as a valid input/output type for :func:`torch.export.export`.
 
     Args:
         cls: the dataclass type to register
-        serialized_type_name: The serialized name for the dataclass. This is
-        required if you want to serialize the pytree TreeSpec containing this
-        dataclass.
 
     Example::
 
@@ -352,6 +345,4 @@ def register_dataclass(
 
     from torch._export.utils import register_dataclass_as_pytree_node
 
-    return register_dataclass_as_pytree_node(
-        cls, serialized_type_name=serialized_type_name
-    )
+    return register_dataclass_as_pytree_node(cls)

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -310,7 +310,7 @@ def _private_register_pytree_node(
             )
 
         if serialized_type_name is None:
-            serialized_type_name = NO_SERIALIZED_TYPE_NAME_FOUND
+            serialized_type_name = f"{cls.__module__}.{cls.__qualname__}"
 
         serialize_node_def = _SerializeNodeDef(
             cls,


### PR DESCRIPTION
Summary:
D53785493 breaks apf.rec.ir.tests.ir_export_deserialize_test.IRExportDeserializeTest: test_export_deserialize_ebc failed:

https://www.internalfb.com/sandcastle/workflow/3436246515685789584

Test Plan: buck2 test mode/opt apf/rec/ir/tests:ir_export_deserialize_test

Differential Revision: D53834881


