### PR TITLE
[DeviceMesh] Ensure mesh tensor is a cpu tensor

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -28,6 +28,7 @@ from torch.testing._internal.common_utils import (
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
+    skip_unless_torch_gpu,
     with_comms,
 )
 from torch.testing._internal.distributed.fake_pg import FakeStore
@@ -67,6 +68,13 @@ class DeviceMeshTest(DTensorTestBase):
         DeviceMesh(device_type, mesh_tensor)
         self.assertTrue(is_initialized())
         self.destroy_pg()
+
+    @with_comms
+    @skip_unless_torch_gpu
+    def test_assert_invalid_mesh_tensor(self):
+        mesh = torch.arange(self.world_size).to(self.rank)
+        with self.assertRaises(AssertionError):
+            device_mesh = DeviceMesh(self.device_type, mesh)
 
     @with_comms
     @run_with_both_funcol_impls

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -73,7 +73,7 @@ class DeviceMeshTest(DTensorTestBase):
     @skip_unless_torch_gpu
     def test_assert_invalid_mesh_tensor(self):
         mesh = torch.arange(self.world_size).to(self.rank)
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             device_mesh = DeviceMesh(self.device_type, mesh)
 
     @with_comms

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -203,6 +203,8 @@ else:
                 if isinstance(mesh, torch.Tensor)
                 else torch.tensor(mesh, dtype=torch.int)
             )
+            if self.mesh.device.type != "cpu":
+                raise RuntimeError(f"`mesh` must be a CPU tensor, got {self.mesh}")
             self.mesh_dim_names = mesh_dim_names
 
             # private field to pre-generate DeviceMesh's hash

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -198,13 +198,13 @@ else:
             mesh_dim_names: Optional[Tuple[str, ...]] = None,
         ) -> None:
             self.device_type = device_type
+            if isinstance(mesh, torch.Tensor) and mesh.device.type != "cpu":
+                raise ValueError(f"`mesh` must be a CPU tensor, got {mesh}")
             self.mesh = (
-                mesh.detach()
+                mesh.detach().cpu()
                 if isinstance(mesh, torch.Tensor)
                 else torch.tensor(mesh, dtype=torch.int)
             )
-            if self.mesh.device.type != "cpu":
-                raise RuntimeError(f"`mesh` must be a CPU tensor, got {self.mesh}")
             self.mesh_dim_names = mesh_dim_names
 
             # private field to pre-generate DeviceMesh's hash


### PR DESCRIPTION
More discussion in the last comment in https://github.com/pytorch/pytorch/pull/118614

In general, users won't pass a cuda tensor to DeviceMesh, as the mesh tensor is just a way to construct a mesh that doesn't require cuda compute. Taking suggestion from @awgu to enforce the tensor to be cpu tensor if it is not already so that we can prevent a device sync. 

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @tianyu-l @wconstab @yf225