### PR TITLE
[inductor] decompose memory bound mm

### DIFF
--- a/test/inductor/test_decompose_mem_bound_mm.py
+++ b/test/inductor/test_decompose_mem_bound_mm.py
@@ -1,0 +1,156 @@
+# Owner(s): ["module: inductor"]
+
+import logging
+import unittest
+
+import torch
+import torch._inductor
+from torch._dynamo.test_case import run_tests, TestCase
+from torch._dynamo.utils import counters
+
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
+from torch.testing._internal.inductor_utils import HAS_CUDA
+
+requires_cuda = unittest.skipUnless(HAS_CUDA, "requires cuda")
+
+
+class MyModule(torch.nn.Module):
+    def __init__(
+        self, n_input: int, n_output: int, has_bias: bool, device="cuda"
+    ) -> None:
+        super().__init__()
+        self.linear = torch.nn.Linear(n_input, n_output, bias=has_bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear(x)
+
+
+class MyModule2(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input1, input2):
+        output = torch.bmm(input1, input2)
+        return output
+
+
+@requires_cuda
+@torch._inductor.config.patch(
+    decompose_mem_bound_mm=True,
+)
+@instantiate_parametrized_tests
+class TestDecomposeMemMM(TestCase):
+    def compare_dict_tensors(self, ref_dict, res_dict, rtol=1e-3, atol=1e-3):
+        if len(set(ref_dict.keys())) != len(set(res_dict.keys())):
+            return False
+        for key1 in ref_dict.keys():
+            key2 = "_orig_mod." + key1
+            assert key2 in res_dict, f"{key1} does not exist in traced module"
+            if not torch.allclose(ref_dict[key1], res_dict[key2], rtol=rtol, atol=atol):
+                return False
+        return True
+
+    def compare_pred(self, module, traced, input, rtol=1e-3, atol=1e-3):
+        ref = module(*input)
+        res = traced(*input)
+        self.assertEqual(ref, res, rtol=rtol, atol=atol)
+
+    def compare_parameters(self, module, traced, rtol=1e-3, atol=1e-3):
+        ref_params = dict(module.named_parameters())
+        res_params = dict(traced.named_parameters())
+        self.assertTrue(self.compare_dict_tensors(ref_params, res_params, rtol, atol))
+
+    def compare_gradients(self, module, traced, rtol=1e-3, atol=1e-3):
+        ref_grad = {key: param.grad for key, param in module.named_parameters()}
+        res_grad = {key: param.grad for key, param in traced.named_parameters()}
+        self.assertTrue(
+            self.compare_dict_tensors(ref_grad, res_grad, rtol=rtol, atol=atol)
+        )
+
+    @parametrize(
+        "b,m,k,n,should_decompose",
+        [(10240, 2, 2, 2, True), (10240, 2, 32, 32, False), (2000, 2, 2, 2, False)],
+    )
+    def test_decompose_bmm(self, b, m, n, k, should_decompose):
+        torch._logging.set_logs(inductor=logging.DEBUG)
+        mat1 = torch.randn(b, m, k, device="cuda").requires_grad_(True)
+        mat2 = torch.randn(b, k, n, device="cuda").requires_grad_(True)
+
+        counters.clear()
+
+        module = MyModule2().to("cuda")
+        traced = torch.compile(module)
+        input = [mat1, mat2]
+        ref = module(*input)
+        res = traced(*input)
+
+        self.compare_pred(module, traced, input)
+
+        expected_val = 1 if should_decompose else 0
+        self.assertEqual(
+            counters["inductor"]["decompose_bmm"],
+            expected_val,
+        )
+
+        ref.sum().backward()
+        res.sum().backward()
+        self.compare_parameters(module, traced)
+        self.compare_gradients(module, traced)
+
+        expected_val = 3 if should_decompose else 0
+        self.assertEqual(
+            counters["inductor"]["decompose_bmm"],
+            expected_val,
+        )
+        counters.clear()
+
+    @parametrize(
+        "m,k,n, should_decompose",
+        [(20480, 5, 2, True), (20480, 32, 2, False), (2048, 2, 2, False)],
+    )
+    @parametrize("has_bias", [True, False])
+    def test_decompose_linear(self, m, n, k, has_bias, should_decompose):
+        torch._logging.set_logs(inductor=logging.DEBUG)
+        input = torch.randn(m, k, device="cuda").requires_grad_(True)
+
+        counters.clear()
+
+        module = MyModule(k, n, has_bias).to("cuda")
+        traced = torch.compile(module)
+        input = [input]
+        ref = module(*input)
+        res = traced(*input)
+
+        self.compare_pred(module, traced, input)
+
+        expected_val = 1 if should_decompose else 0
+        if has_bias:
+            self.assertEqual(
+                counters["inductor"]["decompose_addmm"],
+                expected_val,
+            )
+        else:
+            self.assertEqual(
+                counters["inductor"]["decompose_mm"],
+                expected_val,
+            )
+        decompose_mm_fwd = counters["inductor"]["decompose_mm"]
+
+        ref.sum().backward()
+        res.sum().backward()
+
+        self.compare_parameters(module, traced)
+        self.compare_gradients(module, traced)
+
+        self.assertEqual(
+            counters["inductor"]["decompose_mm"] - decompose_mm_fwd,
+            expected_val,
+        )
+        counters.clear()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -419,6 +419,9 @@ allow_stack_allocation: bool = True
 # but performance for that interface may be degraded.
 use_minimal_arrayref_interface: bool = False
 
+# decompose some memory bound matmul/bmm to mul
+decompose_mem_bound_mm: bool = False
+
 
 # config specific to codegen/cpp.py
 class cpp:

--- a/torch/_inductor/fx_passes/decompose_mem_bound_mm.py
+++ b/torch/_inductor/fx_passes/decompose_mem_bound_mm.py
@@ -1,0 +1,120 @@
+from typing import Optional
+
+import torch
+from torch import Tensor
+from torch._dynamo.utils import counters
+from torch._inductor import utils
+
+from ..pattern_matcher import (
+    Arg,
+    CallFunction,
+    config_flag,
+    Match,
+    register_graph_pattern,
+)
+from .post_grad import decompose_mm_pass
+
+aten = torch.ops.aten
+
+# TODO: need a better strategy for decomposing mm
+MIN_FIRST_DIMENSION_DECOMPOSITION = 10240
+MAX_OTHER_DIMENSION_DECOMPOSITION = 32
+
+
+def check_device(a: Tensor, b: Tensor) -> bool:
+    return a.is_cuda and b.is_cuda
+
+
+def should_decompose_common(
+    mat1: Tensor, mat2: Tensor, input: Optional[Tensor] = None
+) -> bool:
+    return (
+        torch._inductor.config.decompose_mem_bound_mm
+        and check_device(mat1, mat2)
+        and not utils.any_is_symbolic(mat1, mat2, input)
+    )
+
+
+def should_decompose_bmm(mat1, mat2) -> bool:
+    mat1 = mat1.meta["val"]
+    mat2 = mat2.meta["val"]
+    if not should_decompose_common(mat1, mat2):
+        return False
+    else:
+        if len(mat1.shape) != 3 or len(mat2.shape) != 3:
+            return False
+        if mat1.shape[0] < MIN_FIRST_DIMENSION_DECOMPOSITION:
+            return False
+        # 2 of m, n, k must be <= MAX_OTHER_DIMENSION_DECOMPOSITION
+        if (mat1.shape[1] < MAX_OTHER_DIMENSION_DECOMPOSITION) + (
+            mat1.shape[2] < MAX_OTHER_DIMENSION_DECOMPOSITION
+        ) + (mat2.shape[2] < MAX_OTHER_DIMENSION_DECOMPOSITION) < 2:
+            return False
+    return True
+
+
+def should_decompose_mm(mat1, mat2) -> bool:
+    mat1 = mat1.meta["val"]
+    mat2 = mat2.meta["val"]
+    return (
+        should_decompose_common(mat1, mat2)
+        and len(mat1.shape) == 2
+        and len(mat2.shape) == 2
+        and mat1.shape[0] >= MIN_FIRST_DIMENSION_DECOMPOSITION
+        and mat2.shape[0] < MAX_OTHER_DIMENSION_DECOMPOSITION
+        and mat2.shape[1] < MAX_OTHER_DIMENSION_DECOMPOSITION
+    )
+
+
+@register_graph_pattern(
+    CallFunction(aten.bmm, Arg(), Arg()),
+    pass_dict=decompose_mm_pass,
+    extra_check=config_flag("decompose_mem_bound_mm"),
+)
+def decompose_bmm(match: Match, mat1: torch.fx.Node, mat2: torch.fx.Node):
+    def repl(mat1, mat2):
+        return torch.sum(mat1[:, :, :, None] * mat2[:, None, :, :], dim=-2)
+
+    if should_decompose_bmm(mat1, mat2):
+        counters["inductor"]["decompose_bmm"] += 1
+        match.replace_by_example(repl, [mat1, mat2])
+    return
+
+
+@register_graph_pattern(
+    CallFunction(aten.addmm, Arg(), Arg(), Arg()),
+    pass_dict=decompose_mm_pass,
+    extra_check=config_flag("decompose_mem_bound_mm"),
+)
+def decompose_addmm(
+    match: Match,
+    mat1: torch.fx.Node,
+    mat2: torch.fx.Node,
+    mat3: torch.fx.Node,
+):
+    def repl(mat1, mat2, mat3):
+        return torch.sum(mat2[:, :, None] * mat3[None, :, :], dim=-2) + mat1
+
+    if should_decompose_mm(mat2, mat3):
+        counters["inductor"]["decompose_addmm"] += 1
+        match.replace_by_example(repl, [mat1, mat2, mat3])
+    return
+
+
+@register_graph_pattern(
+    CallFunction(aten.mm, Arg(), Arg()),
+    pass_dict=decompose_mm_pass,
+    extra_check=config_flag("decompose_mem_bound_mm"),
+)
+def decompose_mm(
+    match: Match,
+    mat1: torch.fx.Node,
+    mat2: torch.fx.Node,
+):
+    def repl(mat1, mat2):
+        return torch.sum(mat1[:, :, None] * mat2[None, :, :], dim=-2)
+
+    if should_decompose_mm(mat1, mat2):
+        counters["inductor"]["decompose_mm"] += 1
+        match.replace_by_example(repl, [mat1, mat2])
+    return

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -59,6 +59,7 @@ pass_patterns = [
 ]
 # patterns applied only in inference
 inference_patterns = PatternMatcherPass()
+decompose_mm_pass = PatternMatcherPass()
 
 
 def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
@@ -91,6 +92,7 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
             patterns.apply(gm.graph)  # type: ignore[arg-type]
         if is_inference:
             inference_patterns.apply(gm.graph)  # type: ignore[arg-type]
+        decompose_mm_pass.apply(gm.graph)  # type: ignore[arg-type]
 
     if config.post_grad_custom_post_pass is not None:
         config.post_grad_custom_post_pass(gm.graph)
@@ -113,6 +115,7 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
 @init_once_fakemode
 def lazy_init():
     if torch._C._has_mkldnn:
+        from . import decompose_mem_bound_mm  # noqa: F401
         from .mkldnn_fusion import _mkldnn_fusion_init
 
         _mkldnn_fusion_init()


### PR DESCRIPTION
Summary:
Decompose memory bound mm/bmm. 
Linear decomposition result:  D53502768
BMM decomposition result: D53148650
 We should only decompose when
1)bmm, b is large, m,n,k is relative small
2)mm/addmm. m is large, n and K is relative small. e.g. mm of input gradient in linear backward should not be decomposed since m is small and n is large.
Need to conduct more experiments to see if we can find a better strategy for decomposition. I have tried to use a linear regression model (see the bento results) which does not fit well. For short term, we use heuristics to determine when to decompose.

Test Plan:
```
buck2 test mode/dev-nosan //caffe2/test/inductor:decompose_mem_bound_mm
```

COFFEE APS mc0: 
baseline: aps-lsf-0124-bf16-267ccb7a0d
decompose: aps-lsf-0124-bf16-4e3824db40

FIRST AFOC pyper mc1

Differential Revision: D53602514




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames