### PR TITLE
[inductor] logging meta data for inductor generated triton kernel

### DIFF
--- a/test/inductor/test_metrics.py
+++ b/test/inductor/test_metrics.py
@@ -1,0 +1,75 @@
+# Owner(s): ["module: inductor"]
+from torch._dynamo.test_case import run_tests, TestCase
+from torch._inductor import metrics
+from torch._inductor.wrapper_benchmark import get_kernel_category_by_source_code
+
+example_kernel = """
+@reduction(
+    size_hints=[1024, 2048],
+    reduction_hint=ReductionHint.INNER,
+    filename=__file__,
+    triton_meta={
+        'signature': {0: '*fp32', 1: '*fp32', 2: 'i32', 3: 'i32'},
+        'device': 0,
+        'device_type': 'cuda',
+        'constants': {},
+        'configs': [AttrsDescriptor(divisible_by_16=(0, 1, 2, 3), equal_to_1=(), ids_of_folded_args=(), divisible_by_8=(2, 3))]},
+    inductor_meta={
+        'autotune_hints': set(),
+        'kernel_name': 'triton_red_fused_add_sum_2',
+        'mutated_arg_names': ['in_out_ptr0'],
+        'no_x_dim': False,
+        'kernel_num_gb': 0.0083968
+    }
+)
+@triton.jit
+def triton_red_fused_add_sum_2(in_out_ptr0, in_ptr0, xnumel, rnumel, XBLOCK : tl.constexpr, RBLOCK : tl.constexpr):
+    xnumel = 1024
+    rnumel = 2048
+    xoffset = tl.program_id(0) * XBLOCK
+    xindex = xoffset + tl.arange(0, XBLOCK)[:, None]
+    xmask = xindex < xnumel
+    rbase = tl.arange(0, RBLOCK)[None, :]
+    x0 = xindex
+    _tmp2 = tl.full([XBLOCK, RBLOCK], 0, tl.float32)
+    for roffset in range(0, rnumel, RBLOCK):
+        rindex = roffset + rbase
+        rmask = rindex < rnumel
+        r1 = rindex
+        tmp0 = tl.load(in_ptr0 + (r1 + (2048*x0)), rmask & xmask, eviction_policy='evict_first', other=0.0)
+        tmp1 = tl.broadcast_to(tmp0, [XBLOCK, RBLOCK])
+        tmp3 = _tmp2 + tmp1
+        _tmp2 = tl.where(rmask & xmask, tmp3, _tmp2)
+    tmp2 = tl.sum(_tmp2, 1)[:, None]
+    tmp4 = tl.load(in_out_ptr0 + (x0), xmask, eviction_policy='evict_last')
+    tmp5 = tmp4 + tmp2
+    tl.debug_barrier()
+    tl.store(in_out_ptr0 + (x0), tmp5, xmask)
+"""
+
+
+class TestMetrics(TestCase):
+    def test_parse_proper_kernel_fn_code(self):
+        proper_kernel_fn_code = metrics._parse_proper_kernel_fn_code(example_kernel)
+        assert proper_kernel_fn_code.startswith("def ")
+
+    def test_count_args(self):
+        proper_kernel_fn_code = metrics._parse_proper_kernel_fn_code(example_kernel)
+        self.assertEqual(6, metrics._count_args(proper_kernel_fn_code))
+
+    def test_count_pattern(self):
+        proper_kernel_fn_code = metrics._parse_proper_kernel_fn_code(example_kernel)
+        self.assertEqual(2, metrics._count_pattern(proper_kernel_fn_code, "tl.load"))
+        self.assertEqual(1, metrics._count_pattern(proper_kernel_fn_code, "tl.store"))
+        self.assertEqual(1, metrics._count_pattern(proper_kernel_fn_code, "for "))
+
+    def test_parse_reduction_hint(self):
+        kernel_category = get_kernel_category_by_source_code(example_kernel)
+        self.assertEqual("reduction", kernel_category)
+        self.assertEqual(
+            "INNER", metrics._parse_reduction_hint(kernel_category, example_kernel)
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -29,8 +29,9 @@ from typing import (
 import sympy
 
 import torch
-
 import torch._logging
+
+from torch._inductor.metrics import is_metric_table_enabled, log_kernel_metadata
 from torch._prims_common import is_integer_dtype
 from torch.utils._sympy.functions import FloorDiv, ModularIndexing
 from torch.utils._sympy.value_ranges import ValueRanges
@@ -3512,6 +3513,12 @@ class TritonScheduling(BaseScheduling):
             wrapper.define_kernel(
                 kernel_name, compile_wrapper.getvalue(), metadata_comment
             )
+
+            # log kernel metadata for offline analysis.
+            # E.g. one can find all unaligned inner reduction and check if
+            # padding helps with the perf kernel by kernel.
+            if is_metric_table_enabled("kernel_metadata"):
+                log_kernel_metadata(kernel_name, kernel_path, src_code)
 
         return kernel_name
 

--- a/torch/_inductor/metrics.py
+++ b/torch/_inductor/metrics.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import csv
+import inspect
 import os
+import re
 from dataclasses import dataclass
 from functools import lru_cache
 
@@ -160,6 +162,117 @@ MetricTable.register_table(
         "speedup",
     ],
 )
+
+# Log metadata for pointwise/reduction kernels. E.g., model name, kernel path, numel, rnumel, reduction hint
+MetricTable.register_table(
+    "kernel_metadata",
+    [
+        "kernel_name",
+        "kernel_path",
+        "kernel_category",  # pointwise/reduction/foreach etc.
+        "size_hints",
+        "reduction_hint",
+        "line_of_code",
+        "num_load",
+        "num_store",
+        "num_for_loop",
+        "num_args",
+    ],
+)
+
+
+def _parse_kernel_fn_code(kernel_module_code):
+    """
+    The kernel_module_code is the python module that contains kernel function code.
+    kernel function is the proper triton kernel function annotated with
+    @triton.jit
+    """
+    from .codecache import PyCodeCache
+    from .wrapper_benchmark import get_triton_kernel
+
+    mod = PyCodeCache.load(kernel_module_code)
+    kernel = get_triton_kernel(mod)
+    # kernel is a CachingAutotune; kernel.fn is the JITFunction;
+    # kernel.fn.fn is the function being decorate by triton.jit
+    return inspect.getsource(kernel.fn.fn)
+
+
+def _parse_kernel_line_of_code(proper_kernel_fn_code):
+    """
+    Return the line of code for the kernel excluding the decorators.
+    """
+    return len(proper_kernel_fn_code.splitlines())
+
+
+def _parse_size_hints(kernel_module_code):
+    m = re.search(r"size_hints=(\[[0-9, ]*\]),", kernel_module_code)
+    assert m, "size_hints not found in kernel source code!"
+    return m.group(1)
+
+
+def _parse_reduction_hint(kernel_category, kernel_module_code):
+    if kernel_category not in ("reduction", "persistent_reduction"):
+        return None
+    m = re.search(r"reduction_hint=ReductionHint\.(\w*),", kernel_module_code)
+    assert m, "reduction_hint not found in kernel source code!"
+    return m.group(1)
+
+
+def _count_pattern(proper_kernel_fn_code, pattern):
+    return proper_kernel_fn_code.count(pattern)
+
+
+def _count_args(proper_kernel_fn_code):
+    def_line = proper_kernel_fn_code.splitlines()[0]
+    assert def_line.startswith("def ")
+    start_idx = def_line.index("(")
+    end_idx = def_line.index("):")
+    decl_csv = def_line[start_idx + 1 : end_idx]
+    comps = decl_csv.split(",")
+    return len(comps)
+
+
+def _parse_proper_kernel_fn_code(kernel_fn_code):
+    """
+    Skip decorators.
+    """
+    start_pos = kernel_fn_code.index("def ")
+    return kernel_fn_code[start_pos:]
+
+
+def log_kernel_metadata(kernel_name, kernel_path, kernel_module_code):
+    """
+    An utility to log kernel metadata. We may parse metadata from kernel source code here.
+
+    It's fine to parse the generated kernel code here since the logging is
+    disabled by default. It would hurt compilation time.
+    """
+    from .wrapper_benchmark import get_kernel_category_by_source_code
+
+    kernel_category = get_kernel_category_by_source_code(kernel_module_code)
+    reduction_hint = _parse_reduction_hint(kernel_category, kernel_module_code)
+    size_hints = _parse_size_hints(kernel_module_code)
+    kernel_fn_code = _parse_kernel_fn_code(kernel_module_code)
+
+    proper_kernel_fn_code = _parse_proper_kernel_fn_code(kernel_fn_code)
+
+    # the line of code excluding the decortors
+    kernel_line_of_code = _parse_kernel_line_of_code(proper_kernel_fn_code)
+
+    get_metric_table("kernel_metadata").add_row(
+        lambda: {
+            "kernel_name": kernel_name,
+            "kernel_path": kernel_path,
+            "kernel_category": kernel_category,
+            "size_hints": size_hints,
+            "reduction_hint": reduction_hint,
+            "line_of_code": kernel_line_of_code,
+            "num_load": _count_pattern(proper_kernel_fn_code, "tl.load"),
+            "num_store": _count_pattern(proper_kernel_fn_code, "tl.store"),
+            "num_for_loop": _count_pattern(proper_kernel_fn_code, "for "),
+            "num_args": _count_args(proper_kernel_fn_code),
+        }
+    )
 
 
 def purge_old_log_files():

--- a/torch/_inductor/metrics.py
+++ b/torch/_inductor/metrics.py
@@ -212,9 +212,12 @@ def _parse_kernel_line_of_code(proper_kernel_fn_code):
     return len(proper_kernel_fn_code.splitlines())
 
 
-def _parse_size_hints(kernel_module_code):
+def _parse_size_hints(kernel_module_code, kernel_category):
+    if kernel_category == "foreach":
+        # foreach kernel does not have size_hints
+        return None
     m = re.search(r"size_hints=(\[[0-9, ]*\]),", kernel_module_code)
-    assert m, "size_hints not found in kernel source code!"
+    assert m, "size_hints missing!"
     return m.group(1)
 
 
@@ -267,7 +270,7 @@ def log_kernel_metadata(kernel_name, kernel_path, kernel_module_code):
 
     kernel_category = get_kernel_category_by_source_code(kernel_module_code)
     reduction_hint = _parse_reduction_hint(kernel_category, kernel_module_code)
-    size_hints = _parse_size_hints(kernel_module_code)
+    size_hints = _parse_size_hints(kernel_module_code, kernel_category)
     kernel_fn_code = _parse_kernel_fn_code(kernel_module_code)
 
     proper_kernel_fn_code = _parse_proper_kernel_fn_code(kernel_fn_code)

--- a/torch/_inductor/wrapper_benchmark.py
+++ b/torch/_inductor/wrapper_benchmark.py
@@ -46,6 +46,18 @@ def get_kernel_category(kernel_mod):
         return "unknown"
 
 
+def get_triton_kernel(mod):
+    from torch._inductor.triton_heuristics import CachingAutotuner
+
+    cand_list = [
+        v
+        for k, v in mod.__dict__.items()
+        if k.startswith("triton_") and isinstance(v, CachingAutotuner)
+    ]
+    assert len(cand_list) == 1
+    return cand_list[0]
+
+
 def benchmark_all_kernels(benchmark_name, benchmark_all_configs):
     """
     An experimental API used only when config.benchmark_kernel is true.
@@ -57,17 +69,6 @@ def benchmark_all_kernels(benchmark_name, benchmark_all_configs):
     does not change based on different graph modules being compiled.
     """
     from torch._inductor.codecache import PyCodeCache
-
-    def get_triton_kernel(mod):
-        from torch._inductor.triton_heuristics import CachingAutotuner
-
-        cand_list = [
-            v
-            for k, v in mod.__dict__.items()
-            if k.startswith("triton_") and isinstance(v, CachingAutotuner)
-        ]
-        assert len(cand_list) == 1
-        return cand_list[0]
 
     nfound = 0
     for kernel_key, kernel_mod in PyCodeCache.cache.items():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120048

I want to log metadata for inductor generated triton kernels for a couple of purposes
1. with these metadata, it should be convenient to find unaligned reduction kernels and try the idea here https://github.com/pytorch/pytorch/issues/119929 . I think it's nice to try on kernels that are used in real models
2. I'm thinking that based on the collected kernel metadata, I can build a simple offline tool by benchmarking each kernel with ncu and augment each kernel metadata with: latency, theoretical membw (estimated memory access / latency), and actually achieved membw. Hopefully this can point us to some good optimization opportunities.

Command:
```
TORCHINDUCTOR_CACHE_DIR=`realpath ~/inductor-caches/kernel-metadata-log` TORCHINDUCTOR_ENABLED_METRIC_TABLES=kernel_metadata TORCHINDUCTOR_BENCHMARK_KERNEL=1 TORCHINDUCTOR_UNIQUE_KERNEL_NAMES=1 time python benchmarks/dynamo/huggingface.py --backend inductor --amp --performance --training
```

The best practice here is to point inductor cache to a folder outside of /tmp so that one can always run the kernel again based on the path stored in kernel metadata. (folders under /tmp may get removed by the system)

Here is first 1000 rows of collected metadata for huggingface: https://gist.github.com/shunting314/cf4ebdaaaa7e852efcaa93524c868e5f 

And here is the total 10K kernels collected for huggingface. The gist can not be rendered as a csv since it's too large: https://gist.github.com/shunting314/7f841528e2debdc2ae05dece4ac591be .


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames 
