### PR TITLE
[dynamo][perf] Avoid list copy in encode_exception_table_varint.

### DIFF
--- a/torch/_dynamo/bytecode_transformation.py
+++ b/torch/_dynamo/bytecode_transformation.py
@@ -367,7 +367,7 @@ def encode_exception_table_varint(n: int) -> List[int]:
     while n > 0:
         b.append(n & 63)
         n >>= 6
-    b = list(reversed(b))
+    b.reverse()
     for i in range(len(b) - 1):
         b[i] |= 64
     return b


### PR DESCRIPTION
List copies are fairly expensive and in this particular case there is no advantage of doing so, since previous value is forgotten anyways.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang