### PR TITLE
[BE][optim] Simplify _init_group.

### DIFF
--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -53,10 +53,7 @@ class SGD(Optimizer):
                     has_sparse_grad = True
 
                 state = self.state[p]
-                if 'momentum_buffer' not in state:
-                    momentum_buffer_list.append(None)
-                else:
-                    momentum_buffer_list.append(state['momentum_buffer'])
+                momentum_buffer_list.append(state.get('momentum_buffer'))
 
         return has_sparse_grad
 


### PR DESCRIPTION
This version is more concise and avoids second lookup in case `momentum_buffer` is in the `state`.