### PR TITLE
fix incorrect device for object collectives

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1526,6 +1526,7 @@ def _new_process_group_helper(
         # ProcessGroup instance
         if issubclass(type(backend_class), ProcessGroup):
             pg = backend_class  # type: ignore[assignment]
+            _world.pg_default_device[pg] = torch.device(device)
             break
 
         # Process group wrapper initialization for supported PGs when TORCH_DISTRIBUTED_DEBUG is set


### PR DESCRIPTION
_get_pg_default_device return default cpu device if the type is a subclass of ProcessGroup as the global _world default is not set.
This happens in case of registered backend
like hpu and pg as hccl. so set the pg default
device in this case.




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225