### PR TITLE
Fix searchsorted function signature in docs

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -13779,7 +13779,7 @@ Args:
 add_docstr(
     torch.searchsorted,
     r"""
-searchsorted(sorted_sequence, values, *, out_int32=False, right=False, side='left', out=None, sorter=None) -> Tensor
+searchsorted(sorted_sequence, values, *, out_int32=False, right=False, side: Optional[str] = None, out=None, sorter=None) -> Tensor
 
 Find the indices from the *innermost* dimension of :attr:`sorted_sequence` such that, if the
 corresponding values in :attr:`values` were inserted before the indices, when sorted, the order

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -13779,7 +13779,7 @@ Args:
 add_docstr(
     torch.searchsorted,
     r"""
-searchsorted(sorted_sequence, values, *, out_int32=False, right=False, side: Optional[str] = None, out=None, sorter=None) -> Tensor
+searchsorted(sorted_sequence, values, *, out_int32=False, right=False, side=None, out=None, sorter=None) -> Tensor
 
 Find the indices from the *innermost* dimension of :attr:`sorted_sequence` such that, if the
 corresponding values in :attr:`values` were inserted before the indices, when sorted, the order


### PR DESCRIPTION
Side should be optional string, to match definition in native_functions: https://github.com/pytorch/pytorch/blob/fbe8e0f92d4c21d0ba192b9101097c575690a3f1/aten/src/ATen/native/native_functions.yaml#L11246

Fixes https://github.com/pytorch/pytorch/issues/119999

Test plan: https://docs-preview.pytorch.org/pytorch/pytorch/120086/generated/torch.searchsorted.html#torch-searchsorted
