### PR TITLE
[EZ] Fix argument parsing in build_with_debinfo

### DIFF
--- a/tools/build_with_debinfo.py
+++ b/tools/build_with_debinfo.py
@@ -26,7 +26,7 @@ def parse_args() -> Any:
 
     parser = ArgumentParser(description="Incremental build PyTorch with debinfo")
     parser.add_argument("--verbose", action="store_true")
-    parser.add_argument("files", nargs="?", action="append")
+    parser.add_argument("files", nargs="*")
     return parser.parse_args()
 
 


### PR DESCRIPTION
`nargs="?"` accept 0 or 1 argument, but `nargs="*"` accepts 0 or any number of arguments, which is the intended behavior of the tool

Test plan: Run `python tools/build_with_debinfo.py aten/src/ATen/native/cpu/BlasKernel.cpp aten/src/ATen/native/BlasKernel.cpp` and observe that it generates torch_cpu with those two files containing debug information

