### PR TITLE
Add a shape inference tool

### DIFF
--- a/test/fx/test_shape_inference.py
+++ b/test/fx/test_shape_inference.py
@@ -1,0 +1,110 @@
+# Owner(s): ["module: fx"]
+
+import copy
+import unittest
+from collections import defaultdict
+
+import torch
+import torch.fx as fx
+from torch._dynamo.source import LocalSource
+from torch.fx.experimental.shape_inference.infer_shape import infer_shape
+from torch.fx.experimental.shape_inference.infer_symbol_values import (
+    infer_symbol_values,
+)
+from torch.fx.experimental.symbolic_shapes import DimDynamic, ShapeEnv
+
+
+class TestShapeInference(unittest.TestCase):
+    def test_infer_symbol_values(self):
+        def mksym(shape_env, value, source, dynamic_dim) -> None:
+            return shape_env.create_symintnode(
+                shape_env.create_symbol(
+                    value,
+                    source=source,
+                    dynamic_dim=dynamic_dim,
+                ),
+                hint=value,
+                source=source,
+            )
+
+        shape_env = ShapeEnv()
+        N = 8
+        sample = {f"s{i}": 2 for i in range(N)}
+        init_symints = [
+            mksym(shape_env, v, LocalSource(k), DimDynamic.DYNAMIC)
+            for k, v in sample.items()
+        ]
+        symints = copy.deepcopy(init_symints)
+        symbol_to_idx_dict = {f"s{i}": i for i in range(N)}
+        padding_constraints = defaultdict(list)
+
+        # prepare constraints strings
+        constraints = []
+        constraints.append(
+            "The size of tensor a (s1) must match the size of tensor b (1773) at non-singleton dimension 1)"
+        )
+        constraints.append(
+            "Expected size for first two dimensions of batch2 tensor to be: [s0, (s2//2) + 12] but got: [s0, 120]."
+        )
+        constraints.append("shape '[s0, -1, 32]' is invalid for input of size s0*s3")
+        constraints.append(
+            "a and b must have same reduction dim, but got [32*s0, s3] X [20, 15]."
+        )
+        constraints.append(
+            "a and b must have same reduction dim, but got [s0, s4 + 1568] X [5728, 1024]."
+        )
+        constraints.append(
+            "Expected size for first two dimensions of batch2 tensor to be: [s0, 40] but got: [s0, s5]."
+        )
+        constraints.append(
+            "shape '[s0, -1, 32]' is invalid for input of size s0*s6 + 1344*s0"
+        )
+        constraints.append(
+            "shape '[-1, 47]' is invalid for input of size 32*s0*s6 + 1344*s0"
+        )
+        constraints.append(
+            "Expected size for first two dimensions of batch2 tensor to be: [s0, 47*s6] but got: [s0*s6, 47]."
+        )
+        constraints.append("Split sizes add up to 4258 but got the tensor's size of s7")
+
+        for constraint in constraints:
+            infer_symbol_values(
+                symints,
+                init_symints,
+                symbol_to_idx_dict,
+                padding_constraints,
+                constraint,
+            )
+
+        self.assertEqual(symints[1], 1773)
+        self.assertEqual(symints[2], 216)
+        self.assertEqual(symints[3], 640)
+        self.assertEqual(symints[4], 4160)
+        self.assertEqual(symints[5], 40)
+        self.assertEqual(symints[6], 160)
+        self.assertEqual(symints[7], 4258)
+
+    def test_infer_shape(self):
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w_1 = torch.empty([256, 328])
+                self.b_1 = torch.empty([256])
+                self.w_2 = torch.empty([328, 256])
+                self.b_2 = torch.empty([328])
+
+            def forward(self, x):
+                l_1 = torch.nn.functional.linear(x, self.w_1, bias=self.b_1)
+                s_1 = torch.sigmoid(l_1)
+                l_2 = torch.nn.functional.linear(s_1, self.w_2, bias=self.b_2)
+                t_1 = torch.tanh(l_2)
+                return t_1
+
+        def generate_graph_module(model):
+            gm = fx.symbolic_trace(model)
+            return gm
+
+        m = TestModule()
+        gm = generate_graph_module(m)
+        input_tensors = [torch.randn(1, 1)]
+        infer_shape(gm, input_tensors)

--- a/torch/fx/experimental/shape_inference/infer_shape.py
+++ b/torch/fx/experimental/shape_inference/infer_shape.py
@@ -1,0 +1,98 @@
+import copy
+from collections import defaultdict
+
+import torch
+from torch._dynamo.source import LocalSource
+from torch._subclasses import FakeTensorMode
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch.fx.experimental.shape_inference.infer_symbol_values import (
+    infer_symbol_values,
+)
+from torch.fx.experimental.symbolic_shapes import DimDynamic, ShapeEnv
+from torch.utils import _pytree
+
+
+"""
+This is the function that runs shape inference. It will modify the input graph module so that shapes are annotated.
+"""
+
+
+def infer_shape(gm, input_tensors):
+    # Prepare environments
+    shape_env = ShapeEnv()
+    fake_mode = FakeTensorMode(shape_env=shape_env, allow_non_fake_inputs=True)
+
+    flatten_inputs, spec = _pytree.tree_flatten(input_tensors)
+    dim_count = 1
+    for input_tensor in flatten_inputs:
+        dim_count += input_tensor.dim() - 1
+
+    sample = {f"s{i}": 2 for i in range(dim_count)}
+    init_symints = [
+        mksym(shape_env, v, LocalSource(k), DimDynamic.DYNAMIC)
+        for k, v in sample.items()
+    ]
+    symints = copy.deepcopy(init_symints)
+    symbol_to_idx_dict = {f"s{i}": i for i in range(dim_count)}
+    padding_constraints = defaultdict(list)  # type: ignore[var-annotated]
+
+    complete_flag = False
+    allowed_try_times = dim_count * 2
+
+    while not complete_flag and allowed_try_times > 0:
+        # Create symbolic input tensors
+        with fake_mode:
+            sym_tensors = []
+            i = 1
+            for input_tensor in flatten_inputs:
+                curr_dim = input_tensor.dim()
+                desired_size = [symints[0]] + [
+                    symints[ii] for ii in range(i, i + curr_dim - 1)
+                ]
+                sym_tensor = torch.randn(desired_size)
+                sym_tensors.append(sym_tensor)
+                i += curr_dim - 1
+            sym_tensors = _pytree.tree_unflatten(sym_tensors, spec)
+        try:
+            with fake_mode:
+                make_fx(
+                    gm,
+                    tracing_mode="symbolic",
+                    _allow_non_fake_inputs=True,
+                    pre_dispatch=True,
+                    _allow_fake_constant=True,
+                )(*sym_tensors)
+            complete_flag = True
+            return (gm, input_tensors, fake_mode, symints[0])
+        except RuntimeError as e:
+            if e:
+                infer_symbol_values(
+                    symints,
+                    init_symints,
+                    symbol_to_idx_dict,
+                    padding_constraints,
+                    str(e),
+                )
+                allowed_try_times -= 1
+        except ValueError as e:
+            if e:
+                infer_symbol_values(
+                    symints,
+                    init_symints,
+                    symbol_to_idx_dict,
+                    padding_constraints,
+                    str(e),
+                )
+                allowed_try_times -= 1
+
+
+def mksym(shape_env, value, source, dynamic_dim):
+    return shape_env.create_symintnode(
+        shape_env.create_symbol(
+            value,
+            source=source,
+            dynamic_dim=dynamic_dim,
+        ),
+        hint=value,
+        source=source,
+    )

--- a/torch/fx/experimental/shape_inference/infer_symbol_values.py
+++ b/torch/fx/experimental/shape_inference/infer_symbol_values.py
@@ -1,0 +1,133 @@
+import re
+from typing import Any, DefaultDict, Dict, List, Tuple, Union
+
+import numpy as np
+
+import sympy as sp
+import torch
+
+square_brackets_pattern = r"\[([^]]+)\]"
+parentheses_pattern = r"\((.*?)\)"
+s_pattern = r"s\d+"
+
+
+def infer_symbol_values(
+    symints: List[Union[torch.SymInt, int]],
+    init_symints: List[Union[torch.SymInt, int]],
+    symbol_idx_dict: Dict[str, int],
+    padding_constraints: DefaultDict[torch.SymInt, List[Union[sp.Expr, int]]],
+    constraint: str,
+) -> None:
+    if constraint.find("non-singleton") != -1:
+        left_expression, right_expression = re.findall(parentheses_pattern, constraint)
+        calculate_value(left_expression, right_expression, symints, symbol_idx_dict)
+
+    elif constraint.find("first two dimensions of batch2 tensor to be") != -1:
+        matches = re.findall(square_brackets_pattern, constraint)
+        left_expression, right_expression = (
+            matches[i].split(",")[1].strip() for i in (0, 1)
+        )
+        calculate_value(left_expression, right_expression, symints, symbol_idx_dict)
+
+    elif constraint.find("a and b must have same reduction dim") != -1:
+        matches = re.findall(square_brackets_pattern, constraint)
+        left_expression = matches[0].split(",")[1].strip()
+        right_expression = matches[1].split(",")[0].strip()
+        calculate_value(left_expression, right_expression, symints, symbol_idx_dict)
+
+    elif constraint.find("Split sizes add up to") != -1:
+        match_1 = re.search(r"to\s+(.*?)\s+but", constraint)
+        extracted_value_1 = match_1.group(1) if match_1 else None
+        match_2 = re.search(r"of\s+(.*?)$", constraint)
+        extracted_value_2 = match_2.group(1) if match_2 else None
+        calculate_value(extracted_value_1, extracted_value_2, symints, symbol_idx_dict)
+
+    elif constraint.find("is invalid for input of size") != -1:
+        matches = re.findall(square_brackets_pattern, constraint)
+        left_elements = matches[0].split(",")
+        left_equation = sp.sympify(1)
+        left_num = 1
+        right_equation = sp.sympify(constraint.split("size")[1].strip())
+
+        for left_element in left_elements:
+            if sp.sympify(left_element) == sp.sympify("-1"):
+                continue
+            elif sp.sympify(left_element).is_number:
+                left_num *= int(left_element)
+            else:
+                left_equation *= sp.sympify(left_element)
+        right_equation = sp.cancel(right_equation / left_equation)
+
+        right_vars = list(right_equation.free_symbols)
+        for right_var in right_vars:
+            if sp.sympify(right_var) == sp.sympify("s0"):
+                right_equation = sp.cancel(right_equation / right_var)
+                right_vars.remove(right_var)
+
+        var = right_vars[0]
+        idx = symbol_idx_dict[str(var)]
+        if var not in padding_constraints:
+            padding_constraints[var].append(right_equation)
+        update_equation(
+            symints,
+            init_symints,
+            padding_constraints,
+            padding_constraints[var][0],  # type: ignore[arg-type]
+            left_num,
+            var,
+            idx,
+        )
+
+
+def calculate_value(
+    left_expression: Union[str, Any, None],
+    right_expression: Union[str, Any, None],
+    symints: List[Union[torch.SymInt, int]],
+    symbol_idx_dict: Dict[str, int],
+) -> None:
+    var, val = solve_equation(left_expression, right_expression)
+    idx = symbol_idx_dict[var]
+    pre_equation = sp.sympify(f"{symints[idx]}")
+    symints[idx] = pre_equation.subs(sp.sympify(var), val)
+
+
+def solve_equation(
+    left_expression: Union[str, Any, None],
+    right_expression: Union[str, Any, None],
+) -> Tuple[str, int]:
+    expression = f"{left_expression} - {right_expression}"
+    var = re.findall(s_pattern, expression)[0]
+    if re.findall(parentheses_pattern, expression):
+        sub_expression = re.findall(parentheses_pattern, expression)[0]
+        var, coeff = sub_expression.split("//")
+        x = sp.symbols("x")
+        sub_equation = sp.sympify(f"{var} - {coeff} * {x}")
+        modified_equation = (
+            sp.sympify(x) + sp.sympify(expression) - sp.sympify(sub_expression)
+        )
+
+        solution = sp.solve((modified_equation, sub_equation), (x, var))
+        return (var, int(solution[sp.sympify(var)]))
+    else:
+        solution = sp.solve(expression, var)
+        val = int(solution[0])
+        return (var, val)
+
+
+def update_equation(
+    symints: List[Union[torch.SymInt, int]],
+    init_symints: List[Union[torch.SymInt, int]],
+    padding_constraints: DefaultDict[torch.SymInt, List[Union[sp.Expr, int]]],
+    init_eq: sp.Expr,
+    new_mod_num: int,
+    var: torch.SymInt,
+    idx: int,
+) -> None:
+    padding_constraints[var].append(new_mod_num)
+    mod_num = np.lcm.reduce(padding_constraints[var][1:])  # type: ignore[arg-type]
+    eq = mod_num * init_symints[idx]
+    eq_const = [arg for arg in init_eq.args if arg.is_number]
+    if eq_const:
+        rem = int(eq_const[0] % mod_num)
+        eq -= rem
+    symints[idx] = eq


### PR DESCRIPTION
Summary:
Add a shape inference tool that helps to infer each node shape of a given graph module.
1. Given a fx graph, and an example of an input(don't need to be an accurate input that can be forward, but should have valid dims and data structures), `infer shape` creates an input of symbolic shape
2. Shape prop this symbolic input can catch runtime or value exceptions.
3. These errors are constraints for symbol values, and the constraint solver `infer symbolic values` helps us figure out specific values for each symbol.
4. Finally, we run the shape propagation based on input tensor to get tensor shapes for all nodes in the FX traced module.

Test Plan:
### 1. Test `infer symbol values`
Command:
```
buck2 test mode/opt //caffe2/test:fx_experimental -- test_infer_symbol_values
```

### 2. Test `infer shape`
Command:
```
buck2 test mode/opt //caffe2/test:fx_experimental -- test_infer_symbol_values
```
Inferred shape result like: P897560514

Differential Revision: D53593702


