### PR TITLE
[torchbench] Update skipped models.

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/aot_eager_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/aot_eager_torchbench_inference.csv
@@ -142,6 +142,14 @@ hf_Bart,pass,0
 
 
 
+hf_Bert,pass,0
+
+
+
+hf_Bert_large,pass,0
+
+
+
 hf_BigBird,pass,0
 
 
@@ -199,6 +207,10 @@ llama,pass,0
 
 
 llama_v2_7b_16h,model_fail_to_load,0
+
+
+
+maml,pass_due_to_skip,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/aot_eager_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/aot_eager_torchbench_training.csv
@@ -106,6 +106,14 @@ hf_Bart,pass,6
 
 
 
+hf_Bert,pass,6
+
+
+
+hf_Bert_large,pass,6
+
+
+
 hf_BigBird,pass,6
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/aot_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/aot_inductor_torchbench_inference.csv
@@ -130,6 +130,14 @@ hf_Bart,fail_to_run,0
 
 
 
+hf_Bert,fail_to_run,0
+
+
+
+hf_Bert_large,fail_to_run,0
+
+
+
 hf_BigBird,fail_to_run,0
 
 
@@ -179,6 +187,10 @@ llama,fail_to_run,0
 
 
 llama_v2_7b_16h,model_fail_to_load,0
+
+
+
+maml,pass_due_to_skip,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_torchbench_inference.csv
@@ -134,6 +134,14 @@ hf_Bart,pass,0
 
 
 
+hf_Bert,pass,0
+
+
+
+hf_Bert_large,pass,0
+
+
+
 hf_DistilBert,pass,0
 
 
@@ -171,6 +179,10 @@ lennard_jones,pass,0
 
 
 llama,pass,0
+
+
+
+maml,pass_due_to_skip,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_torchbench_inference.csv
@@ -138,6 +138,14 @@ hf_Bart,pass,0
 
 
 
+hf_Bert,pass,0
+
+
+
+hf_Bert_large,pass,0
+
+
+
 hf_BigBird,fail_to_run,0
 
 
@@ -195,6 +203,10 @@ llama,pass,0
 
 
 llama_v2_7b_16h,model_fail_to_load,0
+
+
+
+maml,pass_due_to_skip,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_torchbench_training.csv
@@ -102,6 +102,14 @@ hf_Bart,pass,6
 
 
 
+hf_Bert,pass,6
+
+
+
+hf_Bert_large,pass,6
+
+
+
 hf_BigBird,fail_to_run,3
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_inductor_torchbench_inference.csv
@@ -90,6 +90,14 @@ hf_Bart,pass,0
 
 
 
+hf_Bert,pass,0
+
+
+
+hf_Bert_large,pass,0
+
+
+
 hf_DistilBert,pass,0
 
 
@@ -127,6 +135,10 @@ lennard_jones,pass,0
 
 
 llama,pass,0
+
+
+
+maml,pass_due_to_skip,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_torchbench_inference.csv
@@ -138,6 +138,14 @@ hf_Bart,pass,0
 
 
 
+hf_Bert,pass,0
+
+
+
+hf_Bert_large,pass,0
+
+
+
 hf_BigBird,fail_to_run,0
 
 
@@ -195,6 +203,10 @@ llama,pass,0
 
 
 llama_v2_7b_16h,model_fail_to_load,0
+
+
+
+maml,pass_due_to_skip,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_torchbench_training.csv
@@ -102,6 +102,14 @@ hf_Bart,pass,6
 
 
 
+hf_Bert,pass,6
+
+
+
+hf_Bert_large,pass,6
+
+
+
 hf_BigBird,fail_to_run,3
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_torchbench_inference.csv
@@ -142,6 +142,14 @@ hf_Bart,pass,0
 
 
 
+hf_Bert,pass,0
+
+
+
+hf_Bert_large,pass,0
+
+
+
 hf_BigBird,pass,0
 
 
@@ -199,6 +207,10 @@ llama,pass,0
 
 
 llama_v2_7b_16h,model_fail_to_load,0
+
+
+
+maml,pass_due_to_skip,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_torchbench_training.csv
@@ -106,6 +106,14 @@ hf_Bart,pass,6
 
 
 
+hf_Bert,pass,6
+
+
+
+hf_Bert_large,pass,6
+
+
+
 hf_BigBird,pass,6
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_inference.csv
@@ -142,6 +142,14 @@ hf_Bart,pass,0
 
 
 
+hf_Bert,pass,0
+
+
+
+hf_Bert_large,pass,0
+
+
+
 hf_BigBird,fail_accuracy,0
 
 
@@ -199,6 +207,10 @@ llama,pass,0
 
 
 llama_v2_7b_16h,model_fail_to_load,0
+
+
+
+maml,pass_due_to_skip,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_training.csv
@@ -106,6 +106,14 @@ hf_Bart,pass,6
 
 
 
+hf_Bert,pass,6
+
+
+
+hf_Bert_large,pass,6
+
+
+
 hf_BigBird,pass,6
 
 

--- a/benchmarks/dynamo/torchbench_skip_models.yaml
+++ b/benchmarks/dynamo/torchbench_skip_models.yaml
@@ -1,18 +1,10 @@
 skip:
-  # https://github.com/pytorch/torchdynamo/issues/101
+  # OOMs (A100 40G)
   - detectron2_maskrcnn
-  # https://github.com/pytorch/torchdynamo/issues/145
-  - fambench_xlmr
   # TIMEOUT, https://github.com/pytorch/pytorch/issues/98467
   - tacotron2
-  # Error: RelaxedUnspecConstraint(L['input_ids'].size()[0]) - inferred constant (4)
-  - hf_Bert
-  # Error: RelaxedUnspecConstraint(L['input_ids'].size()[0]) - inferred constant (4)
-  - hf_Bert_large
-  # takes too long, extreme slowdown (< .001)
-  - maml
   # Failing in eager mode
-  - clip
+  - hf_clip
   # multi gpu not always available in benchmark runners
   - simple_gpt_tp_manual
 
@@ -37,11 +29,7 @@ device:
     - hf_Whisper
     - stable_diffusion_text_encoder
 
-  cuda:
-    # only works on CPU
-    - gat
-    - gcn
-    - sage
+  cuda: []
 
 test:
   train:

--- a/benchmarks/dynamo/torchbench_skip_models.yaml
+++ b/benchmarks/dynamo/torchbench_skip_models.yaml
@@ -41,6 +41,11 @@ test:
     - llama
     - llama_v2_7b_16h
     - simple_gpt
+    # Model's DEFAULT_TRAIN_BSIZE is not implemented
+    - cm3leon_generate
+    - hf_T5_generate
+    - doctr_det_predictor
+    - doctr_reco_predictor
     # doesnt fit in memory
     - phi_1_5
     # detectron2 benchmarks
@@ -53,6 +58,7 @@ test:
     - detectron2_maskrcnn_r_101_c4
     - detectron2_maskrcnn_r_101_fpn
     - detectron2_maskrcnn_r_50_fpn
+    - detectron2_fcos_r_50_fpn
 
 control_flow:
   - cm3leon_generate


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120117

This PR updates the list of benchmarks that should (not) be skipped. Here's a summary of
the changes:

- `detectron2_maskrcnn`: #120115
- `fambench_xlmr`: moved to canary models
- `hf_Bert` and `hf_Bert_large`: pass
- `maml`: pass
- `clip`: renamed to `hf_clip`
- `gat`, `gcn`, and `sage`: moved to canary models

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @miladm 