### PR TITLE
[DeviceIndex][6/N] Use DeviceIndex in more places

### DIFF
--- a/c10/xpu/XPUCachingAllocator.cpp
+++ b/c10/xpu/XPUCachingAllocator.cpp
@@ -3,8 +3,8 @@
 #include <c10/xpu/XPUCachingAllocator.h>
 
 #include <deque>
-#include <map>
 #include <mutex>
+#include <set>
 #include <vector>
 
 namespace c10::xpu::XPUCachingAllocator {
@@ -50,7 +50,12 @@ struct Block {
   Block* next{nullptr}; // next block if split from a larger allocation
   int event_count{0}; // number of outstanding XPU events
 
-  Block(int device, sycl::queue* queue, size_t size, BlockPool* pool, void* ptr)
+  Block(
+      DeviceIndex device,
+      sycl::queue* queue,
+      size_t size,
+      BlockPool* pool,
+      void* ptr)
       : device(device),
         queue(queue),
         stream_uses(),
@@ -60,7 +65,7 @@ struct Block {
         ptr(ptr) {}
 
   // constructor for search key
-  Block(int device, sycl::queue* queue, size_t size)
+  Block(DeviceIndex device, sycl::queue* queue, size_t size)
       : device(device),
         queue(queue),
         stream_uses(),

--- a/c10/xpu/XPUFunctions.cpp
+++ b/c10/xpu/XPUFunctions.cpp
@@ -5,7 +5,6 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include <cmath>
-#include <deque>
 #include <mutex>
 #include <vector>
 
@@ -90,10 +89,12 @@ void initDeviceProperties(DeviceProp* device_prop, int device) {
   return;
 }
 
-inline void check_device(int device) {
-  int total = static_cast<int>(gDevicePool.devices.size());
+inline void check_device(DeviceIndex device) {
   TORCH_CHECK(
-      device >= 0 && device < total,
+      device >= 0 &&
+          device < std::min(
+                       gDevicePool.devices.size(),
+                       std::numeric_limits<DeviceIndex>::max()),
       "device is out of range, device is ",
       device,
       ", total number of device is ",
@@ -103,7 +104,7 @@ inline void check_device(int device) {
 
 } // anonymous namespace
 
-sycl::device& get_raw_device(int device) {
+sycl::device& get_raw_device(DeviceIndex device) {
   initDevicePoolCallOnce();
   check_device(device);
   return *gDevicePool.devices[device];
@@ -117,7 +118,7 @@ sycl::context& get_device_context() {
   return *gDevicePool.context;
 }
 
-void get_device_properties(DeviceProp* device_prop, int device) {
+void get_device_properties(DeviceProp* device_prop, DeviceIndex device) {
   initDevicePoolCallOnce();
   TORCH_CHECK(device_prop, "device_prop is an invalid pointer.");
   check_device(device);

--- a/c10/xpu/XPUFunctions.h
+++ b/c10/xpu/XPUFunctions.h
@@ -18,15 +18,17 @@ C10_XPU_API DeviceIndex current_device();
 
 C10_XPU_API void set_device(DeviceIndex device);
 
-C10_XPU_API c10::DeviceIndex exchange_device(c10::DeviceIndex device);
+C10_XPU_API DeviceIndex exchange_device(DeviceIndex device);
 
-C10_XPU_API c10::DeviceIndex maybe_exchange_device(c10::DeviceIndex to_device);
+C10_XPU_API DeviceIndex maybe_exchange_device(DeviceIndex to_device);
 
-C10_XPU_API sycl::device& get_raw_device(int device);
+C10_XPU_API sycl::device& get_raw_device(DeviceIndex device);
 
 C10_XPU_API sycl::context& get_device_context();
 
-C10_XPU_API void get_device_properties(DeviceProp* device_prop, int device);
+C10_XPU_API void get_device_properties(
+    DeviceProp* device_prop,
+    DeviceIndex device);
 
 C10_XPU_API int get_device_idx_from_pointer(void* ptr);
 

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1250,7 +1250,7 @@ static void bindGetDeviceProperties(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
   m.def(
       "_get_device_properties",
-      [](int device) -> cudaDeviceProp* {
+      [](c10::DeviceIndex device) -> cudaDeviceProp* {
         return at::cuda::getDeviceProperties(device);
       },
       py::return_value_policy::reference);

--- a/torch/csrc/cuda/shared/cudart.cpp
+++ b/torch/csrc/cuda/shared/cudart.cpp
@@ -103,7 +103,7 @@ void initCudartBindings(PyObject* module) {
   cudart.def(
       "cuda"
       "MemGetInfo",
-      [](int device) -> std::pair<size_t, size_t> {
+      [](c10::DeviceIndex device) -> std::pair<size_t, size_t> {
         c10::cuda::CUDAGuard guard(device);
         size_t device_free = 0;
         size_t device_total = 0;

--- a/torch/csrc/xpu/Module.cpp
+++ b/torch/csrc/xpu/Module.cpp
@@ -254,7 +254,7 @@ static void bindGetDeviceProperties(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
   m.def(
       "_get_device_properties",
-      [](int device) -> c10::xpu::DeviceProp* {
+      [](c10::DeviceIndex device) -> c10::xpu::DeviceProp* {
         return at::xpu::getDeviceProperties(device);
       },
       py::return_value_policy::reference);


### PR DESCRIPTION
This PR follows the series of patches beginning with #119142 and fixes various XPU and python related methods to use DeviceIndex.