### PR TITLE
Remove bc linter label triggers after test-infra #4956

### DIFF
--- a/.github/workflows/lint-bc.yml
+++ b/.github/workflows/lint-bc.yml
@@ -6,8 +6,6 @@ on:
       - opened
       - synchronize
       - reopened
-      - labeled
-      - unlabeled
     branches-ignore:
       - nightly
   workflow_dispatch:


### PR DESCRIPTION
After https://github.com/pytorch/test-infra/pull/4956, mergebot will not block merge for a bc linter failure that has been suppressed.  The failure will be ignored instead.

This should help mitigate https://github.com/pytorch/test-infra/issues/4938 because the workflow will not be triggered multiple times when labels are attached.