### PR TITLE
Remove unused c10/util/C++17.h inclusion and outdated checks

### DIFF
--- a/aten/src/ATen/core/DeprecatedTypePropertiesRegistry.h
+++ b/aten/src/ATen/core/DeprecatedTypePropertiesRegistry.h
@@ -5,6 +5,7 @@
 
 #include <c10/core/Backend.h>
 #include <c10/core/ScalarType.h>
+#include <memory>
 
 namespace at {
 

--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -11,6 +11,7 @@
 #include <c10/core/TensorOptions.h>
 #include <c10/core/UndefinedTensorImpl.h>
 #include <c10/core/WrapDimMinimal.h>
+#include <c10/util/C++17.h>
 #include <c10/util/Exception.h>
 #include <c10/util/ExclusivelyOwned.h>
 #include <c10/util/ExclusivelyOwnedTensorTraits.h>

--- a/aten/src/ATen/core/boxing/KernelFunction_impl.h
+++ b/aten/src/ATen/core/boxing/KernelFunction_impl.h
@@ -3,6 +3,7 @@
 #include <ATen/core/boxing/impl/WrapFunctionIntoFunctor.h>
 #include <ATen/core/boxing/impl/WrapFunctionIntoRuntimeFunctor.h>
 
+#include <c10/util/C++17.h>
 #include <type_traits>
 
 namespace c10 {

--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -6,8 +6,6 @@
 #include <iterator>
 #include <limits>
 
-#include <c10/util/C++17.h>
-
 #include <ATen/cuda/cub_definitions.cuh>
 
 #if USE_GLOBAL_CUB_WRAPPED_NAMESPACE()

--- a/c10/util/C++17.h
+++ b/c10/util/C++17.h
@@ -8,17 +8,6 @@
 #include <type_traits>
 #include <utility>
 
-#if !defined(__clang__) && !defined(_MSC_VER) && defined(__GNUC__) && \
-    __GNUC__ < 5
-#error \
-    "You're trying to build PyTorch with a too old version of GCC. We need GCC 5 or later."
-#endif
-
-#if defined(__clang__) && __clang_major__ < 4
-#error \
-    "You're trying to build PyTorch with a too old version of Clang. We need Clang 4 or later."
-#endif
-
 #if (defined(_MSC_VER) && (!defined(_MSVC_LANG) || _MSVC_LANG < 201703L)) || \
     (!defined(_MSC_VER) && __cplusplus < 201703L)
 #error You need C++17 to compile PyTorch

--- a/c10/util/Float8_e4m3fn.h
+++ b/c10/util/Float8_e4m3fn.h
@@ -15,7 +15,6 @@
 /// and inspired by Half implementation from pytorch/c10/util/Half.h
 
 #include <c10/macros/Macros.h>
-#include <c10/util/C++17.h>
 #include <c10/util/TypeSafeSignMath.h>
 #include <c10/util/floating_point_utils.h>
 #include <type_traits>

--- a/c10/util/Float8_e4m3fnuz.h
+++ b/c10/util/Float8_e4m3fnuz.h
@@ -18,7 +18,6 @@
 /// the existing Float8_e4m3fn implementation.
 
 #include <c10/macros/Macros.h>
-#include <c10/util/C++17.h>
 #include <c10/util/TypeSafeSignMath.h>
 #include <c10/util/floating_point_utils.h>
 #include <type_traits>

--- a/c10/util/Float8_e5m2fnuz.h
+++ b/c10/util/Float8_e5m2fnuz.h
@@ -18,7 +18,6 @@
 /// the existing Float8_e4m3fn implementation.
 
 #include <c10/macros/Macros.h>
-#include <c10/util/C++17.h>
 #include <c10/util/TypeSafeSignMath.h>
 #include <c10/util/floating_point_utils.h>
 

--- a/c10/util/TypeList.h
+++ b/c10/util/TypeList.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <c10/util/C++17.h>
 #include <c10/util/TypeTraits.h>
 #include <algorithm>
 #include <cstddef>
@@ -501,9 +500,9 @@ struct map_types_to_values final {
 template <class... Types>
 struct map_types_to_values<typelist<Types...>> final {
   template <class Func>
-  static std::tuple<c10::invoke_result_t<Func, type_<Types>>...> call(
+  static auto call(
       Func&& func) {
-    return std::tuple<c10::invoke_result_t<Func, type_<Types>>...>{
+    return std::tuple{
         std::forward<Func>(func)(type_<Types>())...};
   }
 };

--- a/c10/util/TypeList.h
+++ b/c10/util/TypeList.h
@@ -500,10 +500,8 @@ struct map_types_to_values final {
 template <class... Types>
 struct map_types_to_values<typelist<Types...>> final {
   template <class Func>
-  static auto call(
-      Func&& func) {
-    return std::tuple{
-        std::forward<Func>(func)(type_<Types>())...};
+  static auto call(Func&& func) {
+    return std::tuple{std::forward<Func>(func)(type_<Types>())...};
   }
 };
 } // namespace detail

--- a/torch/csrc/jit/frontend/lexer.h
+++ b/torch/csrc/jit/frontend/lexer.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <c10/macros/Macros.h>
-#include <c10/util/C++17.h>
 #include <c10/util/Exception.h>
 #include <torch/csrc/Export.h>
 #include <torch/csrc/jit/frontend/parser_constants.h>


### PR DESCRIPTION
This is a continued work to clean up pre-C++17 code.
