### PR TITLE
Remove C10_FALLTHROUGH

### DIFF
--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -361,10 +361,10 @@ struct TORCH_API TupleElements {
     switch (inlineSize_) {
       case 3:
         new (&elementsInline_[2]) IValue(elements[2]);
-        C10_FALLTHROUGH;
+        [[fallthrough]];
       case 2:
         new (&elementsInline_[1]) IValue(elements[1]);
-        C10_FALLTHROUGH;
+        [[fallthrough]];
       case 1:
         new (&elementsInline_[0]) IValue(elements[0]);
         break;

--- a/aten/src/ATen/native/cuda/Normalization.cu
+++ b/aten/src/ATen/native/cuda/Normalization.cu
@@ -124,7 +124,7 @@ void batch_norm_elementwise(
           out, self, *weight, *bias, mean_, invstd_);
       return;
     }
-    C10_FALLTHROUGH;
+    [[fallthrough]];
   }
   case Impl::General: {
     const int64_t ndim = self.dim();
@@ -193,7 +193,7 @@ Tensor batch_norm_elementwise_backward_train(
       return batch_norm_backward_elemt_channels_last_cuda_template(
           grad_out, input, mean, invstd, weight, sum_dy, sum_dy_xmu);
     }
-    C10_FALLTHROUGH;
+    [[fallthrough]];
   }
   case Impl::General: {
     const auto ndim = input.dim();
@@ -317,7 +317,7 @@ void batch_norm_mean_var(const Tensor& self, Tensor& save_mean, Tensor& save_var
       });
       return;
     }
-    C10_FALLTHROUGH;
+    [[fallthrough]];
   }
   case Impl::General: {
     const int64_t ndim = self.dim();

--- a/c10/core/impl/PyObjectSlot.h
+++ b/c10/core/impl/PyObjectSlot.h
@@ -56,7 +56,7 @@ struct C10_API PyObjectSlot {
         // fallthrough, we lost the race.  We are guaranteed not to lose the
         // race with ourself, as calls to init_pyobj with the same interpreter
         // ID must be sequentialized by the GIL
-        C10_FALLTHROUGH;
+        [[fallthrough]];
       case impl::PyInterpreterStatus::TAGGED_BY_OTHER:
         TORCH_CHECK(
             false,

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -235,13 +235,6 @@ using namespace c10::xpu;
 
 #define C10_ERASE C10_ALWAYS_INLINE C10_ATTR_VISIBILITY_HIDDEN
 
-// C10_FALLTHROUGH - Annotate fallthrough to the next case in a switch.
-#if C10_HAS_CPP_ATTRIBUTE(fallthrough)
-#define C10_FALLTHROUGH [[fallthrough]]
-#else
-#define C10_FALLTHROUGH
-#endif
-
 #include <cstdint>
 
 #ifdef __HIPCC__


### PR DESCRIPTION
Since [[fallthrough]] is supported in our C++17 compilers and no other repo is using it.