### PR TITLE
update the tensor.scatter_ doc

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -4475,7 +4475,7 @@ Example::
     tensor([[2.0000, 2.0000, 3.2300, 2.0000],
             [2.0000, 2.0000, 2.0000, 3.2300]])
 
-.. function:: scatter_(dim, index, value, *, reduce: str) -> Tensor:
+.. function:: scatter_(dim, index, value, *, reduce=None) -> Tensor:
    :noindex:
 
 Writes the value from :attr:`value` into :attr:`self` at the indices

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -4487,7 +4487,7 @@ Args:
     index (LongTensor): the indices of elements to scatter, can be either empty
         or of the same dimensionality as ``src``. When empty, the operation
         returns ``self`` unchanged.
-    value (int, float, bool or complex): the value to scatter.
+    value (Scalar): the value to scatter.
 
 Keyword args:
     reduce (str, optional): reduction operation to apply, can be either

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -4380,7 +4380,7 @@ In-place version of :meth:`~Tensor.rsqrt`
 add_docstr_all(
     "scatter_",
     r"""
-scatter_(dim, index, src, reduce=None) -> Tensor
+scatter_(dim, index, src, *, reduce=None) -> Tensor
 
 Writes all values from the tensor :attr:`src` into :attr:`self` at the indices
 specified in the :attr:`index` tensor. For each value in :attr:`src`, its output
@@ -4443,7 +4443,9 @@ Args:
     index (LongTensor): the indices of elements to scatter, can be either empty
         or of the same dimensionality as ``src``. When empty, the operation
         returns ``self`` unchanged.
-    src (Tensor or float): the source element(s) to scatter.
+    src (Tensor): the source element(s) to scatter.
+
+Keyword args:
     reduce (str, optional): reduction operation to apply, can be either
         ``'add'`` or ``'multiply'``.
 
@@ -4473,6 +4475,31 @@ Example::
     tensor([[2.0000, 2.0000, 3.2300, 2.0000],
             [2.0000, 2.0000, 2.0000, 3.2300]])
 
+.. function:: scatter_(dim, index, value, *, reduce: str) -> Tensor:
+   :noindex:
+
+Writes the value from :attr:`value` into :attr:`self` at the indices
+specified in the :attr:`index` tensor.  This operation is equivalent to the previous version,
+with the :attr:`src` tensor filled entirely with :attr:`value`.
+
+Args:
+    dim (int): the axis along which to index
+    index (LongTensor): the indices of elements to scatter, can be either empty
+        or of the same dimensionality as ``src``. When empty, the operation
+        returns ``self`` unchanged.
+    value (int, float, bool or complex): the value to scatter.
+
+Keyword args:
+    reduce (str, optional): reduction operation to apply, can be either
+        ``'add'`` or ``'multiply'``.
+
+Example::
+    >>> index = torch.tensor([[0, 1]])
+    >>> value = 2
+    >>> torch.zeros(3, 5).scatter_(0, index, value)
+    tensor([[2., 0., 0., 0., 0.],
+            [0., 2., 0., 0., 0.],
+            [0., 0., 0., 0., 0.]])
 """,
 )
 

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -4494,6 +4494,7 @@ Keyword args:
         ``'add'`` or ``'multiply'``.
 
 Example::
+
     >>> index = torch.tensor([[0, 1]])
     >>> value = 2
     >>> torch.zeros(3, 5).scatter_(0, index, value)


### PR DESCRIPTION
Fixes #119543 

- doc fixed with the `reduce` being a kwarg (see below for details)
- doc added another interface `(int dim, Tensor index, Number value, *, str reduce)` where
the full signature in the pyi file after build is
```
def scatter_(self, dim: _int, index: Tensor, value: Union[Number, _complex], *, reduce: str) -> Tensor: 
```
. This can be further verified in
https://github.com/pytorch/pytorch/blob/02fb04352275d18529fd10741a0626f0bc3eab5e/aten/src/ATen/native/native_functions.yaml#L8014

Therefore, the value can be int, bool, float, or complex type.


Besides the issue mentioned in 119543, the `reduce should be a kwarg` as shown below
```
 * (int dim, Tensor index, Tensor src)
 * (int dim, Tensor index, Tensor src, *, str reduce)
 * (int dim, Tensor index, Number value)
 * (int dim, Tensor index, Number value, *, str reduce)
 ```




The test case for scala value is already implemented in

https://github.com/pytorch/pytorch/blob/70bc3b3be4d8aad3029e7270ec37e23f95b3c39f/test/test_scatter_gather_ops.py#L86

so no additional test case required.

@mikaylagawarecki  @janeyx99 


cc @albanD