### PR TITLE
Move tensor types check in set_default_tensor_type api from c++ to python side.

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -745,6 +745,14 @@ def set_default_tensor_type(t):
     """
     if isinstance(t, str):
         t = _import_dotted_name(t)
+    import warnings
+    warnings.warn("torch.set_default_tensor_type() is deprecated as of PyTorch 2.1, "
+                  "please use torch.set_default_dtype() and torch.set_default_device() "
+                  "as alternatives.")
+    # torch.tensortype only alived in c++ side, so using type(torch.FloatTensor)
+    if not isinstance(t, type(torch.FloatTensor)):
+        raise TypeError("invalid type object: only floating-point types "
+                        "are supported as the default type")
     _C._set_default_tensor_type(t)
 
 

--- a/torch/csrc/tensor/python_tensor.cpp
+++ b/torch/csrc/tensor/python_tensor.cpp
@@ -25,8 +25,7 @@
 #include <type_traits>
 #include <vector>
 
-namespace torch {
-namespace tensors {
+namespace torch::tensors {
 
 using namespace at;
 using namespace torch::autograd;
@@ -434,21 +433,8 @@ static void py_bind_tensor_types(
   }
 }
 
-static bool PyTensorType_Check(PyObject* obj) {
-  auto it = std::find_if(
-      tensor_types.begin(), tensor_types.end(), [obj](PyTensorType* x) {
-        return (PyObject*)x == obj;
-      });
-  return it != tensor_types.end();
-}
-
+// NB: Only can be called from python set_default_tensor_type api.
 void py_set_default_tensor_type(PyObject* obj) {
-  TORCH_WARN_ONCE(
-      "torch.set_default_tensor_type() is deprecated as of PyTorch 2.1, "
-      "please use torch.set_default_dtype() and torch.set_default_device() as alternatives.")
-  TORCH_CHECK_TYPE(
-      PyTensorType_Check(obj),
-      "invalid type object: only floating-point types are supported as the default type");
   PyTensorType* type = (PyTensorType*)obj;
   TORCH_CHECK_TYPE(
       !type->is_cuda || torch::utils::cuda_enabled(),
@@ -478,5 +464,4 @@ ScalarType get_default_scalar_type() {
   return get_default_dtype_as_scalartype();
 }
 
-} // namespace tensors
-} // namespace torch
+} // namespace torch::tensors


### PR DESCRIPTION
@ezyang Hi, Yang. I have moved the modifications related to set_default_tensor_type to this PR. What do you think? We can discuss it here. Thank you.

Fixes #ISSUE_NUMBER
