### PR TITLE
[codemod] Remove unused variables in caffe2/caffe2/opt/nql/ast.h

### DIFF
--- a/caffe2/opt/nql/ast.h
+++ b/caffe2/opt/nql/ast.h
@@ -21,10 +21,12 @@ struct ASTExpr {
     return starInputsFlag;
   }
   void dump(int level = 0) const {
-    for (const auto i : c10::irange(level))std::cout << "  ";
-    if (!isCall())
+    for ([[maybe_unused]] const auto _ : c10::irange(level)) {
+      std::cout << "  ";
+    }
+    if (!isCall()) {
       std::cout << "Var: " << name << std::endl;
-    else {
+    } else {
       std::cout << "Function: " << name << ", args: " << std::endl;
       for (auto* e : children) {
         e->dump(level + 1);
@@ -41,11 +43,14 @@ struct ASTStmt {
     delete rhs;
   }
   void dump(int level = 0) const {
-    for (const auto i : c10::irange(level))std::cout << "  ";
+    for ([[maybe_unused]] const auto _ : c10::irange(level)) {
+      std::cout << "  ";
+    }
     std::cout << "LHS:" << std::endl;
     for (auto s : lhs) {
-      for (int i = 0; i < level + 1; i++)
+      for (int i = 0; i < level + 1; i++) {
         std::cout << "  ";
+      }
       std::cout << s << std::endl;
     }
     rhs->dump(level);


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Test Plan: Sandcastle

Reviewed By: palmje

Differential Revision: D53779579


