### PR TITLE
[codemod] Remove unused variables in caffe2/caffe2/experiments/operators/tt_pad_op.h

### DIFF
--- a/caffe2/experiments/operators/tt_pad_op.h
+++ b/caffe2/experiments/operators/tt_pad_op.h
@@ -79,7 +79,6 @@ class TTPadGradientOp final : public Operator<Context> {
 
     auto old_dim0 = *Input(1).template data<int64_t>();
     auto new_dim0 = G.size(0);
-    auto dim1 = G.size(1);
 
     if (old_dim0 < new_dim0) {
       output->ShrinkTo(old_dim0);


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Test Plan: Sandcastle

Reviewed By: palmje

