### PR TITLE
[codemod] Remove unused variables in caffe2/caffe2/contrib/fakelowp/spatial_batch_norm_fp16_fake_op.h

### DIFF
--- a/caffe2/contrib/fakelowp/spatial_batch_norm_fp16_fake_op.h
+++ b/caffe2/contrib/fakelowp/spatial_batch_norm_fp16_fake_op.h
@@ -159,7 +159,7 @@ class SpatialBNFakeLoweredFp16Op : public Operator<CPUContext> {
     const int stride = C * HxW;
     const float* X_ptr = X;
     float* Y_ptr = Y;
-    for (const auto i : c10::irange(N)) {
+    for ([[maybe_unused]] const auto i : c10::irange(N)) {
       EigenArrayMap<float>(Y_ptr, HxW, C) =
           ConstEigenArrayMap<float>(X_ptr, HxW, C).rowwise() -
           mean_arr.transpose();
@@ -356,7 +356,7 @@ class SpatialBNFakeFp16Op : public Operator<CPUContext> {
     float* Y_ptr = Y;
 
     // Do Y = X * scale + bias
-    for (const auto i : c10::irange(N)) {
+    for ([[maybe_unused]] const auto i : c10::irange(N)) {
       for (const auto j : c10::irange(C)) {
         for (const auto k : c10::irange(HxW)) {
           Y_ptr[HxW * j + k] = bias[j];


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Test Plan: Sandcastle

Reviewed By: palmje

Differential Revision: D53779549


