### PR TITLE
[codemod][lowrisk] Remove semicolon(s) from 3 files inc caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/src/deconv-run.cc

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/deconv-run.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/deconv-run.cc
@@ -78,7 +78,7 @@ static void compute_q8conv(
       c_stride,
       output_channel_index,
       &context->quantization_params);
-};
+}
 
 struct QnnpackDeleter {
   void operator()(pytorch_qnnp_operator_t op) {

--- a/c10/core/SymNodeImpl.h
+++ b/c10/core/SymNodeImpl.h
@@ -30,61 +30,61 @@ class C10_API SymNodeImpl : public c10::intrusive_ptr_target {
   // these could be pure virtual when we implement LTC versions
   virtual bool is_int() {
     TORCH_CHECK(false, "NYI");
-  };
+  }
   virtual bool is_bool() {
     TORCH_CHECK(false, "NYI");
-  };
+  }
   virtual bool is_float() {
     TORCH_CHECK(false, "NYI");
-  };
+  }
   virtual SymNode add(const SymNode& other) {
     TORCH_CHECK(false, "NYI");
-  };
+  }
   virtual SymNode sub(const SymNode& other) {
     TORCH_CHECK(false, "NYI");
-  };
+  }
   virtual SymNode mul(const SymNode& other) {
     TORCH_CHECK(false, "NYI");
-  };
+  }
   virtual SymNode truediv(const SymNode& other) {
     TORCH_CHECK(false, "NYI");
-  };
+  }
   virtual SymNode pow(const SymNode& other) {
     TORCH_CHECK(false, "NYI");
-  };
+  }
   virtual SymNode floordiv(const SymNode& other) {
     TORCH_CHECK(false, "NYI");
-  };
+  }
   virtual SymNode mod(const SymNode& other) {
     TORCH_CHECK(false, "NYI");
-  };
+  }
   virtual SymNode eq(const SymNode& other) {
     TORCH_CHECK(false, "NYI");
-  };
+  }
   virtual SymNode ne(const SymNode& other) {
     TORCH_CHECK(false, "NYI");
-  };
+  }
   virtual SymNode gt(const SymNode& other) {
     TORCH_CHECK(false, "NYI");
-  };
+  }
   virtual SymNode lt(const SymNode& other) {
     TORCH_CHECK(false, "NYI");
-  };
+  }
   virtual SymNode le(const SymNode& other) {
     TORCH_CHECK(false, "NYI");
-  };
+  }
   virtual SymNode ge(const SymNode& other) {
     TORCH_CHECK(false, "NYI");
-  };
+  }
   virtual SymNode ceil() {
     TORCH_CHECK(false, "NYI");
-  };
+  }
   virtual SymNode floor() {
     TORCH_CHECK(false, "NYI");
-  };
+  }
   virtual SymNode neg() {
     TORCH_CHECK(false, "NYI");
-  };
+  }
   virtual SymNode sym_min(const SymNode& other) {
     TORCH_CHECK(false, "NYI");
   };

--- a/c10/core/impl/PyInterpreter.cpp
+++ b/c10/core/impl/PyInterpreter.cpp
@@ -108,7 +108,7 @@ struct NoopPyInterpreterVTable final : public PyInterpreterVTable {
 
   void reset_backward_hooks(const TensorImpl* self) const override {
     PANIC(reset_backward_hooks);
-  };
+  }
 };
 
 // Construct this in Global scope instead of within `disarm`


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt` found an extra semi

If the code compiles, this is safe to land.

Test Plan: Sandcastle

Reviewed By: palmje, dmm-fb

Differential Revision: D53776222




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10