### PR TITLE
Change the parameter type from int to float in torch.nn.Softplus

### DIFF
--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -418,7 +418,7 @@ def gen_nn_functional(fm: FileManager) -> None:
             "softplus": [
                 "def softplus({}) -> Tensor: ...".format(
                     ", ".join(
-                        ["input: Tensor", "beta: int = ...", "threshold: int = ..."]
+                        ["input: Tensor", "beta: float = ...", "threshold: float = ..."]
                     )
                 )
             ],

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -847,10 +847,10 @@ class Softplus(Module):
     """
 
     __constants__ = ['beta', 'threshold']
-    beta: int
-    threshold: int
+    beta: float
+    threshold: float
 
-    def __init__(self, beta: int = 1, threshold: int = 20) -> None:
+    def __init__(self, beta: float = 1.0, threshold: float = 20.0) -> None:
         super().__init__()
         self.beta = beta
         self.threshold = threshold


### PR DESCRIPTION
Fixes #120175

1 The c_api uses the double
https://github.com/pytorch/pytorch/blob/f2cf0768d10df6eb578db734bf80f5281f7410ae/torch/csrc/api/include/torch/nn/options/activation.h#L501.

2 The type is also double in the test case
https://github.com/pytorch/pytorch/blob/f2cf0768d10df6eb578db734bf80f5281f7410ae/test/cpp/api/functional.cpp#L1788

3 With float parameter in python works perfectly fine
```
m = nn.Softplus(beta=0.1,threshold=1.2)
input = torch.randn(2)
output = m(input)

print(output)
tensor([7.3749, 7.6852])
```



