### PR TITLE
[Refactor] Use PyTree in pin_memory

### DIFF
--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -4,7 +4,6 @@ These **needs** to be in global scope since Py2 doesn't support serializing
 static methods.
 """
 
-import collections
 import queue
 
 import torch


### PR DESCRIPTION
[`pin_memory` re-implements](https://github.com/pytorch/pytorch/blob/2864a7e161cc107f7e4c00cccdf860a6089c73c3/torch/utils/data/_utils/pin_memory.py#L55-L79
) a custom pytree-like function.

As demonstrated by [this issue](https://github.com/pytorch/tensordict/issues/679), the function loses the metadata during reconstruction of the containers.

I think it would make more sense to use `torch.utils._pytree` in this case. That way, users would be in control of the metadata carried by their containers since they could tell PyTree how to reconstruct them after calling pin_memory.

cc @SsnL @VitalyFedyunin @ejguan @dzhulgakov @zou3519 @NicolasHug @andersonbcdefg @XuehaiPan