### PR TITLE
Add missing words to torch.utils.checkpoint doc

### DIFF
--- a/docs/source/checkpoint.rst
+++ b/docs/source/checkpoint.rst
@@ -3,8 +3,8 @@ torch.utils.checkpoint
 
 .. note::
     Checkpointing is implemented by rerunning a forward-pass segment for
-    each checkpointed segment during backward.  This can cause persistent
-    states like the RNG state to be advanced than they would without
+    each checkpointed segment during backward propagation.  This can cause persistent
+    states like the RNG state to be more advanced than they would without
     checkpointing.  By default, checkpointing includes logic to juggle
     the RNG state such that checkpointed passes making use of RNG
     (through dropout for example) have deterministic output as


### PR DESCRIPTION
This PR adds a couple of missing words in the Checkpointing documentation, it doesn't have a specific issue number related to it. 

Changes are: 
- "backward." -> "backward propagation."
- "to be advanced than" -> "to be more advanced than"
