### PR TITLE
Add back C++17 compiler checks and increases the minimum allowed versions

### DIFF
--- a/c10/util/C++17.h
+++ b/c10/util/C++17.h
@@ -8,6 +8,17 @@
 #include <type_traits>
 #include <utility>
 
+#if !defined(__clang__) && !defined(_MSC_VER) && defined(__GNUC__) && \
+    __GNUC__ < 9
+#error \
+    "You're trying to build PyTorch with a too old version of GCC. We need GCC 9 or later."
+#endif
+
+#if defined(__clang__) && __clang_major__ < 9
+#error \
+    "You're trying to build PyTorch with a too old version of Clang. We need Clang 9 or later."
+#endif
+
 #if (defined(_MSC_VER) && (!defined(_MSVC_LANG) || _MSVC_LANG < 201703L)) || \
     (!defined(_MSC_VER) && __cplusplus < 201703L)
 #error You need C++17 to compile PyTorch


### PR DESCRIPTION
May fix #120020. This PR re-adds the previous gcc/clang version checks and increases them to the minimum versions found in CI. 
