### PR TITLE
Update ATen for XNNPACK update

### DIFF
--- a/aten/src/ATen/native/xnnpack/Activation.cpp
+++ b/aten/src/ATen/native/xnnpack/Activation.cpp
@@ -22,9 +22,6 @@ static Tensor& hardswish_impl(Tensor& input, Tensor& output) {
 
   xnn_operator_t hardswish_op{};
   const xnn_status create_status = xnn_create_hardswish_nc_f32(
-    1, // channels
-    1, // input stride
-    1, // output stride
     0, // flags
     &hardswish_op);
 
@@ -37,6 +34,9 @@ static Tensor& hardswish_impl(Tensor& input, Tensor& output) {
   const xnn_status reshape_status = xnn_reshape_hardswish_nc_f32(
     hardswish_op,
     input.numel(),  // Batch
+    1, // channels
+    1, // input stride
+    1, // output stride
     caffe2::pthreadpool_());  // threadpool
 
   TORCH_CHECK(

--- a/aten/src/ATen/native/xnnpack/AveragePooling.cpp
+++ b/aten/src/ATen/native/xnnpack/AveragePooling.cpp
@@ -33,11 +33,6 @@ Tensor global_average_pool(const Tensor& input) {
 
   xnn_operator_t global_average_pooling_op{};
   const xnn_status create_status = xnn_create_global_average_pooling_nwc_f32(
-      input_padded_contig_nhwc.size(Layout::Activation4D::channels), // channels
-      input_padded_contig_nhwc.size(
-          Layout::Activation4D::channels), // input stride
-      input_padded_contig_nhwc.size(
-          Layout::Activation4D::channels), // output stride
       -std::numeric_limits<float>::infinity(),
       std::numeric_limits<float>::infinity(),
       0 /* flags */,
@@ -57,6 +52,11 @@ Tensor global_average_pool(const Tensor& input) {
       input_padded_contig_nhwc.size(Layout::Activation4D::batch), // batch_size
       input_padded_contig_nhwc.size(Layout::Activation4D::width) *
           input_padded_contig_nhwc.size(Layout::Activation4D::height), // width
+      input_padded_contig_nhwc.size(Layout::Activation4D::channels), // channels
+      input_padded_contig_nhwc.size(
+          Layout::Activation4D::channels), // input stride
+      input_padded_contig_nhwc.size(
+          Layout::Activation4D::channels), // output stride
       &workspace_size, // workspace_size
       &workspace_alignment, // workspace_alignment
       caffe2::pthreadpool_());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120224
* #120223
* #120222

Update ATen XNNPACK usages to conform to operator changes in XNNPACK update to 9325fcf.

Differential Revision: [D53933050](https://our.internmc.facebook.com/intern/diff/D53933050/)