### PR TITLE
Expose recordSize in ChunkRecordIterator

### DIFF
--- a/caffe2/serialize/inline_container.h
+++ b/caffe2/serialize/inline_container.h
@@ -104,6 +104,7 @@ class TORCH_API ChunkRecordIterator {
 
   // Read at most `chunkSize` into `buf`. Return the number of actual bytes read.
   size_t next(void* buf);
+  size_t recordSize() const { return recordSize_; }
 
  private:
  ChunkRecordIterator(


### PR DESCRIPTION
Summary: Add a public method to read recordSize in ChunkRecordIterator

Test Plan: ci

Differential Revision: D53931944


