### PR TITLE
Revert "use two pass reduction for deterministic reduction order (#11…

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -3371,16 +3371,6 @@ class CPUReproTests(TestCase):
         self.common(fn, (x,))
         assert metrics.generated_cpp_vec_kernel_count == 1
 
-    @config.patch({"cpp.dynamic_threads": True})
-    def test_reduction_with_dynamic_threads(self):
-        def fn(a, b):
-            return a.sum(), b.sum()
-
-        self.common(
-            fn,
-            (torch.randn(1000), torch.rand(1000)),
-        )
-
     def test_no_redundant_to_dtypes_between_fused_scheduler_node(self):
         # https://github.com/pytorch/pytorch/issues/115260
         p0 = torch.tensor([1.0879], dtype=torch.float16)

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -253,9 +253,6 @@ index_value_name_counter = 1
 
 def argmax_argmin_prefix(reduction_type, src_dtype, tmpvar):
     global index_value_name_counter
-    num_threads = (
-        "max_threads" if config.cpp.dynamic_threads else parallel_num_threads()
-    )
     struct_name = f"IndexValue_{index_value_name_counter}"
     index_value_name_counter += 1
 
@@ -264,14 +261,20 @@ def argmax_argmin_prefix(reduction_type, src_dtype, tmpvar):
         f"struct {struct_name} {{size_t index; {DTYPE_TO_CPP[src_dtype]} value;}};",
         f"{struct_name} {tmpvar}{{0, {reduction_init(reduction_type, src_dtype)}}};",
     ]
-    local_init = [
-        f"{struct_name} {tmpvar}_local{{0, {reduction_init(reduction_type, src_dtype)}}};",
-    ]
-    tmpvar_per_thd = f"{tmpvar}_arr[{num_threads}]"
-    parallel_prefix = [
-        f"{struct_name} {tmpvar_per_thd};",
-    ]
-    return prefix, parallel_prefix, local_init
+
+    if reduction_type in ["argmax", "argmin"]:
+        compare_op = "greater_or_nan" if reduction_type == "argmax" else "less_or_nan"
+        prefix.extend(
+            [
+                "#if !defined(__clang_major__) || __clang_major__ > 9",
+                f"#pragma omp declare reduction({reduction_type} : {struct_name} :\\",
+                f"    omp_out = {compare_op}(omp_in.value, omp_out.value, omp_in.index, omp_out.index) ? omp_in : omp_out)\\",
+                f"\tinitializer(omp_priv = {{0, {reduction_init(reduction_type, src_dtype)}}})",
+                "#endif",
+            ]
+        )
+
+    return prefix
 
 
 @functools.lru_cache
@@ -1479,72 +1482,12 @@ class CppKernel(Kernel):
         self.reduction_depth = None
         self.reduction_prefix = IndentedBuffer()
         self.reduction_suffix = IndentedBuffer()
-        self.parallel_reduction_prefix = IndentedBuffer()
-        self.parallel_reduction_suffix = IndentedBuffer()
-        self.local_reduction_init = IndentedBuffer()
-        self.local_reduction_stores = IndentedBuffer()
-        self.is_reduction = False
+        self.reduction_var_map = {}
         self.reduction_cse = CSE(self.newvar_prefix, self.suffix, name_prefix="tmp_acc")
         self.preloads = IndentedBuffer()
         self.poststores = IndentedBuffer()
         self.num_threads = num_threads  # num_threads the kernel specialized for
         self.reduction_omp_dec: Dict[Tuple[str, str], str] = {}
-
-    def _gen_parallel_reduction_buffers(
-        self,
-        acc,
-        acc_type,
-        reduction_type,
-        dtype,
-        reduction_combine_fn=reduction_combine,
-        reduction_init_fn=reduction_init,
-    ):
-        if config.cpp.dynamic_threads and not self.parallel_reduction_prefix:
-            self.parallel_reduction_prefix.writeline(
-                "int max_threads = omp_get_max_threads();"
-            )
-        acc_local = f"{acc}_local"
-        num_threads = (
-            "max_threads" if config.cpp.dynamic_threads else parallel_num_threads()
-        )
-        acc_per_thread = f"{acc}_arr[{num_threads}]"
-        acc_local_in_array = acc_per_thread.replace(f"[{num_threads}]", "[tid]")
-        self.local_reduction_init.writeline(
-            f"{acc_type} {acc_local} = {reduction_init_fn(reduction_type, dtype)};"
-        )
-        self.parallel_reduction_prefix.writeline(f"{acc_type} {acc_per_thread};")
-        self.parallel_reduction_prefix.writelines(
-            [
-                f"for (int tid = 0; tid < {num_threads}; tid++)",
-                "{",
-                f"    {acc_local_in_array} = {reduction_init_fn(reduction_type, dtype)};",
-                "}",
-            ],
-        )
-        self.local_reduction_stores.writelines(
-            [
-                f"{acc_local_in_array} = {acc_local};",
-            ]
-        )
-        self.parallel_reduction_suffix.writelines(
-            [
-                f"for (int tid = 0; tid < {num_threads}; tid++)",
-                "{",
-                f"    {acc} = {reduction_combine_fn(reduction_type, acc, acc_local_in_array)};",
-                "}",
-            ],
-        )
-
-    def get_reduction_var_pattern(self, line: str):
-        return re.search("tmp_acc[0-9]+", line)
-
-    def update_stores_with_parallel_reduction(self):
-        for i, line in enumerate(self.stores._lines):
-            if isinstance(line, str):
-                m = self.get_reduction_var_pattern(line)
-                if m:
-                    var_name = m.group(0)
-                    self.stores._lines[i] = line.replace(var_name, f"{var_name}_local")
 
     @contextlib.contextmanager
     def masked(self, mask):
@@ -1694,14 +1637,11 @@ class CppKernel(Kernel):
         acc = self.reduction_cse.generate(
             self.loads, f"reduction {reduction_key}", write=False
         )
-        self.is_reduction = True
+        self.reduction_var_map[acc] = reduction_type
         if argmax_or_argmin:
-            prefix, parallel_prefix, local_init = argmax_argmin_prefix(
-                reduction_type, src_dtype, acc
+            self.reduction_prefix.writelines(
+                argmax_argmin_prefix(reduction_type, src_dtype, acc)
             )
-            self.local_reduction_init.writelines(local_init)
-            self.reduction_prefix.writelines(prefix)
-            self.parallel_reduction_prefix.writelines(parallel_prefix)
             compare_op = (
                 "greater_or_nan" if reduction_type == "argmax" else "less_or_nan"
             )
@@ -1714,29 +1654,25 @@ class CppKernel(Kernel):
                     f"if(!({compare_op}({acc}.value, {value}, {acc}.index, {cexpr_index(index)}))) {{",
                     f"    {acc}.index = {cexpr_index(index)}; {acc}.value = {value};",
                     "}",
-                ]
-            )
-            acc_local = f"{acc}_local"
-            num_threads = parallel_num_threads()
-            acc_per_thread = f"{acc}_arr[{num_threads}]"
-            acc_local_in_array = acc_per_thread.replace(f"[{num_threads}]", "[tid]")
-            self.parallel_reduction_suffix.writelines(
-                [
-                    f"for (int tid = 0; tid < {num_threads}; tid++)",
-                    "{",
-                    f"    if(!({compare_op}({acc}.value, {acc_local_in_array}.value, {acc}.index, {acc_local_in_array}.index))) {{",
-                    f"        {acc}.index = {acc_local_in_array}.index; {acc}.value = {acc_local_in_array}.value;",
-                    "    }",
-                    "}",
                 ],
-            )
-            self.local_reduction_stores.writelines(
-                [
-                    f"{acc_local_in_array} = {acc_local};",
-                ]
             )
         else:
             acc_type = reduction_acc_type(reduction_type, dtype)
+
+            if (reduction_type, acc_type) not in self.reduction_omp_dec:
+                if RTYPE_TO_CPP[reduction_type] not in NATIVE_OMP_RTYPES:
+                    # Scalar reduction for other reductions are declared by default
+                    self.reduction_prefix.splice(
+                        f"""\
+    #pragma omp declare reduction(\
+    {RTYPE_TO_CPP[reduction_type]}:{acc_type}:\
+    omp_out = {reduction_combine(reduction_type, "omp_out", "omp_in")}) \
+    initializer(omp_priv={{{reduction_init(reduction_type, dtype)}}})
+                """
+                    )
+                self.reduction_omp_dec[reduction_type, acc_type] = RTYPE_TO_CPP[
+                    reduction_type
+                ]
 
             self.reduction_prefix.writeline(
                 f"{acc_type} {acc} = {reduction_init(reduction_type, dtype)};"
@@ -1744,7 +1680,7 @@ class CppKernel(Kernel):
             self.stores.writeline(
                 f"{acc} = {reduction_combine(reduction_type, acc, value)};"
             )
-            self._gen_parallel_reduction_buffers(acc, acc_type, reduction_type, dtype)
+
         result = reduction_project(reduction_type, acc)
         self.reduction_cse.reduction_cache[reduction_key] = result
         return result
@@ -1810,63 +1746,42 @@ class CppKernel(Kernel):
                 if hasattr(kernel, "codegen_inner_loops"):
                     code.splice(kernel.poststores)
 
-            def get_reduction_code_buffer(loops, buffer="prefix"):
-                assert buffer in ("prefix", "suffix", "local")
+            def get_reduction_code_buffer(loops, is_suffix=True):
                 for loop in loops:
                     for kernel in loop.get_kernels():
-                        if buffer == "local":
-                            return (
-                                kernel.local_reduction_init,
-                                kernel.local_reduction_stores,
-                            )
-                        elif buffer == "suffix":
-                            suffix = kernel.reduction_suffix
-                            if loop.parallel:
-                                suffix = kernel.parallel_reduction_suffix + suffix
-                            return suffix
+                        if is_suffix:
+                            return kernel.reduction_suffix
                         else:
-                            prefix = kernel.reduction_prefix
-                            if loop.parallel:
-                                prefix = prefix + kernel.parallel_reduction_prefix
-                            return prefix
+                            return kernel.reduction_prefix
+                return None
 
             def gen_loops(loops: List[LoopLevel], in_reduction=False):
                 with contextlib.ExitStack() as stack_outer:
-                    local_reduction_init = local_reduction_stores = None
                     if loops:
                         loop = loops[0]
-                        if loop.is_reduction and not in_reduction:
-                            reduction_prefix = get_reduction_code_buffer(loops)
+                        if loop.is_reduction() and not in_reduction:
+                            reduction_prefix = get_reduction_code_buffer(
+                                loops, is_suffix=False
+                            )
                             if reduction_prefix:
                                 stack_outer.enter_context(code.indent())
                             code.splice(reduction_prefix)
                         if loop_nest.is_reduction_only() and loop.parallel:
-                            (
-                                local_reduction_init,
-                                local_reduction_stores,
-                            ) = get_reduction_code_buffer(loops, "local")
                             worksharing.parallel(threads)
-                            if local_reduction_init:
-                                assert local_reduction_stores
-                                code.splice(local_reduction_init)
 
                     for loop in loops:
-                        gen_loop(loop)
+                        gen_loop(loop, in_reduction)
 
                     if loops:
                         loop = loops[0]
                         if loop_nest.is_reduction_only() and loop.parallel:
-                            if local_reduction_stores:
-                                code.splice(local_reduction_stores)
                             worksharing.close()
-                        if loop.is_reduction and not in_reduction:
-                            code.splice(get_reduction_code_buffer(loops, "suffix"))
+                        if loop.is_reduction() and not in_reduction:
+                            code.splice(
+                                get_reduction_code_buffer(loops, is_suffix=True)
+                            )
 
-            def gen_loop(loop: LoopLevel):
-                def is_parallel_reduction(loop):
-                    root = loop.get_root()
-                    return root.is_reduction and root.parallel
-
+            def gen_loop(loop: LoopLevel, in_reduction=False):
                 with contextlib.ExitStack() as stack:
                     loop_lines = loop.lines()
                     if loop_lines is None:
@@ -1875,12 +1790,10 @@ class CppKernel(Kernel):
                     stack.enter_context(code.indent())
                     # generate inner loops or loop body
                     if loop.inner:
-                        gen_loops(loop.inner, loop.is_reduction)
+                        gen_loops(loop.inner, loop.is_reduction())
                     else:
                         kernels = loop.get_kernels()
                         assert len(kernels) == 1
-                        if is_parallel_reduction(loop):
-                            kernels[0].update_stores_with_parallel_reduction()
                         gen_kernel(kernels[0])
 
             stack.enter_context(code.indent())
@@ -1970,9 +1883,6 @@ class CppVecKernel(CppKernel):
             return f"at::vec::Vectorized<{DTYPE_TO_CPP[dtype]}>"
         else:
             return f"at::vec::VectorizedN<{DTYPE_TO_CPP[dtype]},{num_vectors}>"
-
-    def get_reduction_var_pattern(self, line: str):
-        return re.search("tmp_acc[0-9]+_vec", line)
 
     def _get_vec_load_line(
         self,
@@ -2237,20 +2147,47 @@ class CppVecKernel(CppKernel):
         if not value.is_vec:
             value = self.broadcast(value)
 
+        acc_type = reduction_acc_type(reduction_type, dtype)
+        acc_type_vec = self.reduction_acc_type_vec(reduction_type, dtype)
+
+        if (reduction_type, acc_type) not in self.reduction_omp_dec:
+            if RTYPE_TO_CPP[reduction_type] not in NATIVE_OMP_RTYPES:
+                # Scalar reduction for other reductions are declared by default
+                self.reduction_prefix.splice(
+                    f"""\
+#pragma omp declare reduction(\
+{RTYPE_TO_CPP[reduction_type]}:{acc_type}:\
+omp_out = {reduction_combine(reduction_type, "omp_out", "omp_in")}) \
+initializer(omp_priv={{{reduction_init(reduction_type, dtype)}}})
+            """
+                )
+            self.reduction_omp_dec[reduction_type, acc_type] = RTYPE_TO_CPP[
+                reduction_type
+            ]
+
+        if (reduction_type, acc_type_vec) not in self.reduction_omp_dec:
+            self.reduction_prefix.splice(
+                f"""\
+#pragma omp declare reduction(\
+{RTYPE_TO_CPP[reduction_type]}:{acc_type_vec}:\
+omp_out = {self.reduction_combine_vec(reduction_type, "omp_out", "omp_in")}) \
+initializer(omp_priv={{{self.reduction_init_vec(reduction_type, dtype)}}})
+            """
+            )
+            self.reduction_omp_dec[reduction_type, acc_type_vec] = RTYPE_TO_CPP[
+                reduction_type
+            ]
+
         reduction_key = src_dtype, reduction_type, value
         if reduction_key in self.reduction_cse.reduction_cache:
             return self.reduction_cse.reduction_cache[reduction_key]
-
-        vec_ns = "at::vec"
-        vec = f"{vec_ns}::Vectorized<{DTYPE_TO_CPP[dtype]}>"
-        acc_type = reduction_acc_type(reduction_type, dtype)
-        acc_type_vec = self.reduction_acc_type_vec(reduction_type, dtype)
 
         acc = self.reduction_cse.generate(
             self.loads, f"reduction {reduction_key}", write=False
         )
         acc_vec = f"{acc}_vec"
-        self.is_reduction = True
+
+        self.reduction_var_map[acc_vec] = reduction_type
         self.reduction_prefix.writeline(
             f"{acc_type} {acc} = {reduction_init(reduction_type, dtype)};"
         )
@@ -2260,20 +2197,7 @@ class CppVecKernel(CppKernel):
         self.stores.writeline(
             f"{acc_vec} = {self.reduction_combine_vec(reduction_type, acc_vec, value)};"
         )
-        self._gen_parallel_reduction_buffers(
-            acc,
-            acc_type,
-            reduction_type,
-            dtype,
-        )
-        self._gen_parallel_reduction_buffers(
-            acc_vec,
-            acc_type_vec,
-            reduction_type,
-            dtype,
-            reduction_combine_fn=self.reduction_combine_vec,
-            reduction_init_fn=self.reduction_init_vec,
-        )
+
         tmpvar: Union[str, CSEVariable]
         if self.tiling_idx >= self.reduction_depth:
             # Horizontal reduction
@@ -3680,9 +3604,6 @@ class WorkSharing:
             else:
                 self.code.writeline(f"#pragma omp parallel num_threads({threads})")
             self.stack.enter_context(self.code.indent())
-            self.code.writeline(
-                "int tid = omp_get_thread_num();",
-            )
 
     def single(self):
         if self.in_parallel:
@@ -3711,7 +3632,7 @@ class LoopLevel:
     simd_omp: bool = False
     simd_vec: bool = False
     collapsed: bool = False
-    is_reduction: bool = False
+    reduction_var_map: Optional[Dict[str, str]] = None
     parent: Optional["LoopLevel"] = None
     # the next inner level of the loop, empty if it is inner-most
     # contains >1 LoopLevel if the inner level of loop is split
@@ -3740,13 +3661,6 @@ class LoopLevel:
             kernels += loop.get_kernels()
         return kernels
 
-    def get_root(self):
-        """Get all kernel objects under this loop level"""
-        root = self
-        while root.parent:
-            root = root.parent
-        return root
-
     def set_kernel(self, kernel: CppKernel):
         """
         Set the kernel under this loop level. No split is allowed under
@@ -3756,6 +3670,13 @@ class LoopLevel:
             self.kernel = kernel
             loop: Optional[LoopLevel] = self
             assert loop is not None
+            if loop.is_reduction():
+                loop.reduction_var_map = kernel.reduction_var_map.copy()
+                loop = loop.parent
+                while loop is not None and loop.is_reduction():
+                    assert loop.reduction_var_map is not None
+                    loop.reduction_var_map.update(kernel.reduction_var_map)
+                    loop = loop.parent
             return
         assert len(self.inner) == 1
         self.inner[0].set_kernel(kernel)
@@ -3768,6 +3689,9 @@ class LoopLevel:
             for loop in self.inner:
                 loops += loop.get_loops_at(depth - 1)
             return loops
+
+    def is_reduction(self):
+        return bool(self.reduction_var_map)
 
     def split_with_tiling(self, depth, factor):
         def clone_inner():
@@ -3785,7 +3709,7 @@ class LoopLevel:
             main_loop.steps = sympy_factor
             main_loop.parallel = self.parallel
             main_loop.collapsed = False
-            main_loop.is_reduction = self.is_reduction
+            main_loop.reduction_var_map = self.reduction_var_map
             main_loop.inner = clone_inner()
             if main_loop.inner:
                 for loop in main_loop.inner:
@@ -3795,7 +3719,7 @@ class LoopLevel:
             tail_loop.offset = offset
             tail_loop.parallel = self.parallel
             tail_loop.collapsed = False
-            tail_loop.is_reduction = self.is_reduction
+            tail_loop.reduction_var_map = self.reduction_var_map
             tail_loop.inner = clone_inner()
             if tail_loop.inner:
                 for loop in tail_loop.inner:
@@ -3831,6 +3755,13 @@ class LoopLevel:
         size_expr = cexpr_index(self.size)
         if config.cpp.no_redundant_loops and offset_expr == size_expr:
             return None
+        if self.reduction_var_map:
+            reduction = " " + " ".join(
+                f"reduction({RTYPE_TO_CPP[rtype]}:{var})"
+                for var, rtype in self.reduction_var_map.items()
+            )
+        else:
+            reduction = ""
         simd = (
             f"simd simdlen({self.simd_nelements}) "
             if self.simd_omp and self.simd_nelements > 1
@@ -3838,7 +3769,7 @@ class LoopLevel:
         )
         if self.parallel:
             # TODO(jansel): look into chunk size and other schedules
-            line1 = "#pragma omp for"
+            line1 = f"#pragma omp for{reduction} "
             if self.parallel > 1:
                 line1 += f" collapse({self.parallel})"
             if self.simd_omp:
@@ -3846,8 +3777,8 @@ class LoopLevel:
         elif self.simd_vec:
             line1 = ""
         elif self.simd_omp:
-            line1 = f"#pragma omp {simd}"
-        elif not self.is_reduction and codecache.is_gcc():
+            line1 = f"#pragma omp {simd}{reduction}"
+        elif not self.reduction_var_map and codecache.is_gcc():
             line1 = "#pragma GCC ivdep"
         else:
             line1 = ""
@@ -3890,7 +3821,7 @@ class LoopNestWithSplit:
         for loop_idx, (var, size) in enumerate(zip(itervars, ranges)):
             loop = LoopLevel(var, size, parent=loop)
             if loop_idx >= reduction_depth:
-                loop.is_reduction = kernel.is_reduction
+                loop.reduction_var_map = kernel.reduction_var_map.copy()
             levels.append(loop)
             levels = loop.inner
         loop_nest = LoopNestWithSplit(root)
@@ -3924,8 +3855,8 @@ class LoopNestWithSplit:
         loops = self.root
         if len(loops) > 1:
             return 1
-        is_reduction = loops[0].is_reduction if loops else False
-        while len(loops) == 1 and loops[0].is_reduction == is_reduction:
+        is_reduction = loops[0].is_reduction() if loops else False
+        while len(loops) == 1 and loops[0].is_reduction() == is_reduction:
             max_depth += 1
             loops = loops[0].inner
         return max_depth
@@ -3936,7 +3867,7 @@ class LoopNestWithSplit:
         are always the inner most ones.
         """
         return (
-            self.root is not None and len(self.root) > 0 and self.root[0].is_reduction
+            self.root is not None and len(self.root) > 0 and self.root[0].is_reduction()
         )
 
     def mark_parallel(self, par_depth):

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -819,13 +819,6 @@ class IndentedBuffer:
     def __repr__(self):
         return f"{type(self)}({self.getvalue()})"
 
-    def __add__(self, other):
-        assert self._indent == other._indent
-        res = IndentedBuffer(initial_indent=self._indent)
-        res.writelines(self._lines)
-        res.writelines(other._lines)
-        return res
-
 
 class DeferredLineBase:
     """A line that can be 'unwritten' at a later time"""


### PR DESCRIPTION
This reverts commit cc7ef43423fe36cf1778a9c9643454d62050a5b5.

Manual revert because of the conflict in: test/inductor/test_cpu_repro.py , conflict with this PR: https://github.com/pytorch/pytorch/pull/118365



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames