### PR TITLE
Equivalent diff of PR 120232

### DIFF
--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -273,7 +273,7 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
             comptime.assert_static(x.size(0))
             return x + 1
 
-        opt_fn = torch.compile(fn, dynamic=True)
+        opt_fn = torch.compile(fn, dynamic=True, fullgraph=True)
         opt_fn(torch.randn(12, 23))
 
     def test_shape_graph_break(self):

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -187,6 +187,7 @@ manual_torch_name_rule_map = {
     "torch._C._functorch._add_batch_dim": TorchInGraphFunctionVariable,
     "torch._C._functorch._remove_batch_dim": TorchInGraphFunctionVariable,
     "torch._C._functorch.is_batchedtensor": TorchInGraphFunctionVariable,
+    "torch._dynamo.mark_static": UserFunctionVariable,
 }
 
 


### PR DESCRIPTION
Summary: This is an equivalent diff for PR [120232](https://github.com/pytorch/pytorch/pull/120232). We use this diff for faster landing than importing it from Github, since we need it to fix a QPS regression on CMF v0 model

Test Plan:
Need to comment out here: https://fburl.com/code/1w6vlsrw  
  buck2 test caffe2/test/dynamo:test_dynamo -- -r test_mark_static_inside

Differential Revision: D53953549

@diff-train-skip-merge


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng