### PR TITLE
[ez] Explicit env for run_test

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -385,6 +385,7 @@ def run_test(
     extra_unittest_args=None,
     env=None,
 ) -> int:
+    env = env or os.environ.copy()
     maybe_set_hip_visible_devies()
     unittest_args = options.additional_unittest_args.copy()
     test_file = test_module.name

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -100,6 +100,7 @@ class TestCheckpoint(TestCase):
     # Test whether checkpoint is being triggered or not. For this, we check
     # the number of times forward pass happens
     def test_checkpoint_trigger(self):
+        self.assertEqual(1, 2)
 
         class Net(nn.Module):
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -100,7 +100,6 @@ class TestCheckpoint(TestCase):
     # Test whether checkpoint is being triggered or not. For this, we check
     # the number of times forward pass happens
     def test_checkpoint_trigger(self):
-        self.assertEqual(1, 2)
 
         class Net(nn.Module):
 


### PR DESCRIPTION
env=None (which is the default) inherits the env from the calling process.  Explicitly set the env to the calling process env so that things can be added to it later 

Tested in: https://hud.pytorch.org/pytorch/pytorch/commit/e7b4d8ec880c56883d684fcc05b6cdb20452aafb
Checked that test-reports (which depend on the CI env var) get made.