### PR TITLE
Add Torch Check for addcdiv input to be contiguous

### DIFF
--- a/aten/src/ATen/native/mps/operations/PointwiseOps.mm
+++ b/aten/src/ATen/native/mps/operations/PointwiseOps.mm
@@ -29,6 +29,8 @@ static void addc_mul_div_out_mps(const Tensor& self,
     return;
   }
 
+  TORCH_CHECK(self.is_contiguous(), "self must be contiguous");
+
   MPSStream* mpsStream = getCurrentMPSStream();
 
   struct CachedGraph : public MPSCachedGraph {


### PR DESCRIPTION
Addresses #118115

Adding a check for now might be useful to prevent silent errors.
