### PR TITLE
[inductor] improve kernel metadata logging

### DIFF
--- a/test/inductor/test_metrics.py
+++ b/test/inductor/test_metrics.py
@@ -1,7 +1,11 @@
 # Owner(s): ["module: inductor"]
+import torch
 from torch._dynamo.test_case import run_tests, TestCase
 from torch._inductor import metrics
+from torch._inductor.utils import collect_defined_kernels
 from torch._inductor.wrapper_benchmark import get_kernel_category_by_source_code
+
+from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 example_kernel = """
 @reduction(
@@ -70,6 +74,38 @@ class TestMetrics(TestCase):
             "INNER", metrics._parse_reduction_hint(kernel_category, example_kernel)
         )
 
+    def test_atomic_add(self):
+        @torch.compile
+        def f(lhs, index, rhs):
+            return lhs.index_put_([index], rhs, accumulate=True)
+
+        lhs = torch.randn(1024, device=GPU_TYPE)
+        index = torch.randint(0, 1024, [32], device=GPU_TYPE, dtype=torch.int32)
+        rhs = torch.randn(32, device=GPU_TYPE)
+
+        kernel_list = []
+        with collect_defined_kernels(kernel_list):
+            f(lhs, index, rhs)
+
+        self.assertEqual(len(kernel_list), 1)
+        kernel_code = kernel_list[0]
+        self.assertEqual(metrics._count_pattern(kernel_code, "tl.atomic_add"), 1)
+
+    def test_kernel_args_num_gb(self):
+        @torch.compile
+        def f(x):
+            return x + 1
+
+        x = torch.randn(int(25e7), device=GPU_TYPE)
+        kernel_list = []
+        with collect_defined_kernels(kernel_list):
+            f(x)
+
+        self.assertEqual(len(kernel_list), 1)
+        kernel_code = kernel_list[0]
+        self.assertEqual(metrics._parse_kernel_args_num_gb(kernel_code), 2.0)
+
 
 if __name__ == "__main__":
-    run_tests()
+    if HAS_GPU:
+        run_tests()

--- a/test/inductor/test_metrics.py
+++ b/test/inductor/test_metrics.py
@@ -1,7 +1,7 @@
 # Owner(s): ["module: inductor"]
 import torch
 from torch._dynamo.test_case import run_tests, TestCase
-from torch._inductor import metrics
+from torch._inductor import config, metrics
 from torch._inductor.utils import collect_defined_kernels
 from torch._inductor.wrapper_benchmark import get_kernel_category_by_source_code
 
@@ -91,6 +91,7 @@ class TestMetrics(TestCase):
         kernel_code = kernel_list[0]
         self.assertEqual(metrics._count_pattern(kernel_code, "tl.atomic_add"), 1)
 
+    @config.patch("benchmark_kernel", True)
     def test_kernel_args_num_gb(self):
         @torch.compile
         def f(x):
@@ -103,7 +104,9 @@ class TestMetrics(TestCase):
 
         self.assertEqual(len(kernel_list), 1)
         kernel_code = kernel_list[0]
-        self.assertEqual(metrics._parse_kernel_args_num_gb(kernel_code), 2.0)
+        self.assertEqual(
+            metrics._parse_kernel_args_num_gb(kernel_code, "pointwise"), 2.0
+        )
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/metrics.py
+++ b/torch/_inductor/metrics.py
@@ -266,12 +266,18 @@ def _parse_kernel_args_num_gb(kernel_fn_code, kernel_category):
     inductor meta looks like:
         inductor_meta={... 'mutated_arg_names': [], 'no_x_dim': False, 'kernel_num_gb': 2.0},
     """
-    if kernel_category == "foreach":
-        # foreach kernel does not have kernel_num_gb field in the metadata
-        return None
     m = re.search(r".kernel_num_gb.:\s*([0-9.]+)", kernel_fn_code)
-    assert m, "kernel_num_gb field missing"
-    return float(m.group(1))
+    if m:
+        return float(m.group(1))
+    else:
+        """
+        There are a few cases that kernel_num_gdb field can be missing:
+        1. the field will be missing if config.benchmark_kernel and
+           config.profile_bandwidth are false
+        2. even if config.benchmark_kernel or config.profile_bandwidth is true.
+           foreach kernel does not have kernel_num_gb field in the metadata
+        """
+        return None
 
 
 def log_kernel_metadata(kernel_name, kernel_path, kernel_module_code):

--- a/torch/_inductor/metrics.py
+++ b/torch/_inductor/metrics.py
@@ -261,11 +261,14 @@ def _parse_numel(proper_kernel_fn_code, numel_arg_name):
         return None
 
 
-def _parse_kernel_args_num_gb(kernel_fn_code):
+def _parse_kernel_args_num_gb(kernel_fn_code, kernel_category):
     """
     inductor meta looks like:
         inductor_meta={... 'mutated_arg_names': [], 'no_x_dim': False, 'kernel_num_gb': 2.0},
     """
+    if kernel_category == "foreach":
+        # foreach kernel does not have kernel_num_gb field in the metadata
+        return None
     m = re.search(r".kernel_num_gb.:\s*([0-9.]+)", kernel_fn_code)
     assert m, "kernel_num_gb field missing"
     return float(m.group(1))
@@ -306,7 +309,9 @@ def log_kernel_metadata(kernel_name, kernel_path, kernel_module_code):
             "xnumel": _parse_numel(proper_kernel_fn_code, "xnumel"),
             "ynumel": _parse_numel(proper_kernel_fn_code, "ynumel"),
             "rnumel": _parse_numel(proper_kernel_fn_code, "rnumel"),
-            "kernel_args_num_gb": _parse_kernel_args_num_gb(kernel_fn_code),
+            "kernel_args_num_gb": _parse_kernel_args_num_gb(
+                kernel_fn_code, kernel_category
+            ),
         }
     )
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1286,3 +1286,18 @@ def is_wait(node):
     from . import ir
 
     return isinstance(node, ir.Wait) or type(node) == ir._WaitKernel
+
+
+@contextlib.contextmanager
+def collect_defined_kernels(kernel_list):
+    from .codegen.wrapper import WrapperCodeGen
+
+    orig_define_kernel = WrapperCodeGen.define_kernel
+
+    def new_define_kernel(wrapper, name, kernel_code, metadata, *args, **kwargs):
+        nonlocal kernel_list
+        kernel_list.append(kernel_code)
+        return orig_define_kernel(wrapper, name, kernel_code, metadata, *args, **kwargs)
+
+    with unittest.mock.patch.object(WrapperCodeGen, "define_kernel", new_define_kernel):
+        yield


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120274
* #120266

Log a few more fields
- num_atomic_add: perf of kernels using atomic_add are usually data dependent. Our benchmarking code generate all indices to be 0 which will result in worse perf than reality. 
- kernel_args_num_gb: estimate the amount of read/writes for kernel args. In-place args will be double counted. If we have a good estimation, this should be the lower bound of memory access that the GPU performs. Sometimes GPU will do more memory access since a single buffer may be access multiple times (e.g. for softmax when input tensor is quite large. cache only help a bit here). With this logged, and if we augment the metadata with amount of memory the GPU actually accessed, then it would be nice to dig into kernels that GPU access more memory.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames