### PR TITLE
[cuDNN][cuDNN RNNv8 API] Fix math type behavior in cuDNN RNN

### DIFF
--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -323,7 +323,7 @@ struct TORCH_CUDA_CPP_API RNNDescriptor : public Descriptor<
     if (prop->major >= 7) {
       if (input_type == CUDNN_DATA_HALF) {
         math_type = CUDNN_TENSOR_OP_MATH;
-      } else if (allow_tf32) {
+      } else if (!allow_tf32) {
         math_type = CUDNN_FMA_MATH;
       }
     }

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -318,6 +318,15 @@ struct TORCH_CUDA_CPP_API RNNDescriptor : public Descriptor<
       }
     }
 #else
+    cudaDeviceProp* prop = at::cuda::getCurrentDeviceProperties();
+    auto math_type = CUDNN_DEFAULT_MATH;
+    if (prop->major >= 7) {
+      if (input_type == CUDNN_DATA_HALF) {
+        math_type = CUDNN_TENSOR_OP_MATH;
+      } else if (allow_tf32) {
+        math_type = CUDNN_FMA_MATH;
+      }
+    }
     AT_CUDNN_CHECK(cudnnSetRNNDescriptor_v8(
           mut_desc(),
           algo,
@@ -327,7 +336,7 @@ struct TORCH_CUDA_CPP_API RNNDescriptor : public Descriptor<
           input_mode,
           input_type,
           datatype,
-          allow_tf32 ? CUDNN_DEFAULT_MATH : CUDNN_FMA_MATH,
+          math_type,
           input_size,
           hidden_size,
           proj_size ? proj_size : hidden_size,


### PR DESCRIPTION
Adds back `CUDNN_TENSOR_OP_MATH` which was erroneously dropped by #115719 

CC @malfet @ptrblck 

cc @csarofeen @ptrblck @xwang233 @zou3519 @mikaylagawarecki