### PR TITLE
[Inductor] Fix bug around out of order constexprs in inductor

### DIFF
--- a/test/dynamo/test_triton_kernels.py
+++ b/test/dynamo/test_triton_kernels.py
@@ -892,6 +892,38 @@ def forward(self, x_1, output_1):
         compiled_out = torch.compile(f)(x, y)
         self.assertEqual(compiled_out, eager_out)
 
+    @requires_cuda
+    @skipIfRocm
+    def test_triton_kernel_out_of_order(self):
+        @triton.jit
+        def add_kernel(
+            in_ptr0,
+            in_ptr1,
+            BLOCK_SIZE: "tl.constexpr",
+            out_ptr,
+            n_elements,
+        ):
+            pid = tl.program_id(axis=0)
+            block_start = pid * BLOCK_SIZE
+            offsets = block_start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(in_ptr0 + offsets, mask=mask)
+            y = tl.load(in_ptr1 + offsets, mask=mask)
+            output = x + y
+            tl.store(out_ptr + offsets, output, mask=mask)
+
+        def f(x, y):
+            out = torch.zeros_like(x)
+            n_elements = x.numel()
+            add_kernel[(n_elements,)](x, y, 4, out, n_elements)
+            return out
+
+        x = torch.randn(4, device="cuda")
+        y = torch.randn(4, device="cuda")
+        eager_out = f(x, y)
+        compiled_out = torch.compile(f)(x, y)
+        self.assertEqual(compiled_out, eager_out)
+
 
 def make_mutation_test(fn):
     @requires_cuda

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1003,42 +1003,47 @@ class WrapperCodeGen(CodeGen):
 
         signature: List[KernelArgType] = []
         constants = {}
-        for key, arg in kwargs.items():
-            idx = kernel.arg_names.index(key)
+        non_constant_indices = []
+        for idx, key in enumerate(kernel.arg_names):
+            arg = kwargs[key]
             if idx in kernel.constexprs:
                 constants[key] = arg
-            elif isinstance(arg, ir.Buffer):
-                signature.append(
-                    TensorArg(
-                        name=key,
-                        buffer=arg.get_name(),
-                        dtype=arg.get_dtype(),
-                    )
-                )
-            elif isinstance(arg, ir.ReinterpretView):
-                # for ReinterpretView we use the underlying
-                # buffer name and note the (possibly non-zero)
-                # offset relative to the underlying buffer
-                signature.append(
-                    TensorArg(
-                        name=key,
-                        buffer=arg.data.get_name(),
-                        dtype=arg.get_dtype(),
-                        offset=arg.layout.offset,
-                    )
-                )
             else:
-                signature.append(SizeArg(key, arg))
+                non_constant_indices.append(idx)
+                if isinstance(arg, ir.Buffer):
+                    signature.append(
+                        TensorArg(
+                            name=key,
+                            buffer=arg.get_name(),
+                            dtype=arg.get_dtype(),
+                        )
+                    )
+                elif isinstance(arg, ir.ReinterpretView):
+                    # for ReinterpretView we use the underlying
+                    # buffer name and note the (possibly non-zero)
+                    # offset relative to the underlying buffer
+                    signature.append(
+                        TensorArg(
+                            name=key,
+                            buffer=arg.data.get_name(),
+                            dtype=arg.get_dtype(),
+                            offset=arg.layout.offset,
+                        )
+                    )
+                else:
+                    signature.append(SizeArg(key, arg))
         index_dtype = "tl.int32"
         inductor_meta = {
             "kernel_name": name,
         }
         triton_meta = {
-            "signature": signature_to_meta(signature, size_dtype=index_dtype),
+            "signature": signature_to_meta(
+                signature, size_dtype=index_dtype, indices=non_constant_indices
+            ),
             "device": V.graph.scheduler.current_device.index,
             "device_type": V.graph.scheduler.current_device.type,
             "constants": constants,
-            "configs": [config_of(signature)],
+            "configs": [config_of(signature, indices=non_constant_indices)],
         }
         configs = [
             {

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1005,6 +1005,8 @@ class WrapperCodeGen(CodeGen):
         constants = {}
         non_constant_indices = []
         for idx, key in enumerate(kernel.arg_names):
+            if key not in kwargs:
+                continue
             arg = kwargs[key]
             if idx in kernel.constexprs:
                 constants[key] = arg


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120287

Inductor signature/config generation code assumes that all constexprs come as last arguments of the function. This is not always true for user defined kernels.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames