### PR TITLE
[dtensor] simplify outputs wrapping handling

### DIFF
--- a/torch/distributed/_tensor/sharding_prop.py
+++ b/torch/distributed/_tensor/sharding_prop.py
@@ -244,7 +244,7 @@ class ShardingPropagator:
                     suggestion_schema = [reshard_schema]
 
                 # construct output spec for the op
-                if op_schema.return_type_tuple_tensors():
+                if op_schema.return_type_tuple_tensor_like():
                     # for ops that return multiple tensors and the output_specs is not
                     # a tuple, we use a tuple of that single output spec as the new
                     # output_specs


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #120298
* __->__ #120297

This PR simplifies the outputs wrapping handling in op dispatch, to make
it simpler and easier to understand.

It also enables a new case, where if the output DTensorSpec for the res is
None, and the res is a scalar tensor, we will just return the scalar
tensor instead of wrapping it with a DTensor.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @fduwjj @wz337 @tianyu-l @wconstab @yf225