### PR TITLE
[dtensor] implement scaled dot product attention (flash-attention)

### DIFF
--- a/test/distributed/_tensor/test_matrix_ops.py
+++ b/test/distributed/_tensor/test_matrix_ops.py
@@ -314,9 +314,7 @@ class DistMatrixOpsTest(DTensorTestBase):
                 dropout_p=dropout_p,
                 is_causal=is_causal,
             )
-            full_out = dist_out.full_tensor()
-            if self.rank == 0:
-                self.assertEqual(full_out, out)
+            self.assertEqual(dist_out.full_tensor(), out)
 
         # TODO: add backward test once we support the backward op
 

--- a/torch/distributed/_tensor/ops/matrix_ops.py
+++ b/torch/distributed/_tensor/ops/matrix_ops.py
@@ -1,7 +1,15 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 # implement matrix related ops for distributed tensor
+import itertools
+from typing import List, Optional
+
 import torch
-from torch.distributed._tensor.op_schema import OpSchema, OpStrategy, OutputSharding
+from torch.distributed._tensor.op_schema import (
+    OpSchema,
+    OpStrategy,
+    OutputSharding,
+    PlacementStrategy,
+)
 from torch.distributed._tensor.ops.basic_strategy import gen_einsum_strategies
 from torch.distributed._tensor.ops.common_rules import einop_rule
 from torch.distributed._tensor.ops.utils import (
@@ -12,7 +20,12 @@ from torch.distributed._tensor.ops.utils import (
     register_op_strategy,
     register_prop_rule,
 )
-from torch.distributed._tensor.placement_types import DTensorSpec
+from torch.distributed._tensor.placement_types import (
+    DTensorSpec,
+    Placement,
+    Replicate,
+    Shard,
+)
 
 from torch.distributed.device_mesh import DeviceMesh
 
@@ -128,3 +141,90 @@ def bmm_strategy(mesh: DeviceMesh, op_schema: OpSchema) -> OpStrategy:
 @register_op_strategy(aten.baddbmm.default)
 def baddmm_strategy(mesh: DeviceMesh, op_schema: OpSchema) -> OpStrategy:
     return _addmm_like_strategy("bmk,bkn->bmn", mesh, op_schema)
+
+
+@register_op_strategy(aten._scaled_dot_product_flash_attention.default)
+def scaled_dot_product_attention_strategy(
+    mesh: DeviceMesh, op_schema: OpSchema
+) -> OpStrategy:
+    # NOTE: currently we only support some simple strategies to support tensor parallelism
+    # TODO: sdpa might be a good candidate for us to explore decomposed sharding propagation
+    # as it involves: matmul, pointwise, reduction ops together.
+    return_debug_mask = len(op_schema.args_schema) >= 6 and op_schema.args_schema[5]
+    q_input_strategy = op_schema.args_schema[0]
+    assert isinstance(q_input_strategy, OpStrategy)
+    # q/k/v have the same shape
+    qkv_shape = q_input_strategy.output_shape
+
+    all_mesh_dim_strategies = []
+
+    for mesh_dim in range(mesh.ndim):
+        single_mesh_dim_strategies = []
+
+        # placement list stores placements of [outputs, inputs]
+        # in the spda case, we have 7 tensor outputs and 3 tensor inputs
+        # first we can always accept full replication for inputs and output
+        all_replicate: List[Placement] = [Replicate()] * 6
+        single_mesh_dim_strategies.append(all_replicate)
+
+        # second we can accept the sharding pattern of tensor parallelism, which
+        # shard on the num of head dim
+        qkv_sharding = Shard(1)  # num head dim
+        output_sharding = Shard(1)  # num head dim
+        logsumexp_sharding = Shard(1)  # num head dim
+        philox_seed_sharding = Replicate()
+        philox_offset_sharding = Replicate()
+        if return_debug_mask:
+            debug_attn_mask_sharding: Placement = Shard(1)  # num head dim
+        else:
+            # empty debug mask, replicated
+            debug_attn_mask_sharding = Replicate()
+
+        num_heads_dim_sharding = [
+            output_sharding,
+            logsumexp_sharding,
+            # None,  # philox seed scalar
+            # None,  # philox offset scalar
+            debug_attn_mask_sharding,
+            qkv_sharding,
+            qkv_sharding,
+            qkv_sharding,
+        ]
+        single_mesh_dim_strategies.append(num_heads_dim_sharding)
+
+        all_mesh_dim_strategies.append(single_mesh_dim_strategies)
+
+    strategy_combs = itertools.product(*all_mesh_dim_strategies)
+
+    all_strategies = []
+    for strategy_comb in strategy_combs:
+        spec_list = []
+        for specs in zip(*strategy_comb):
+            spec_list.append(DTensorSpec(mesh, tuple(specs)))
+
+        assert len(spec_list) == 6
+        input_expected_specs = spec_list[3:]
+        output_specs: List[Optional[DTensorSpec]] = list(spec_list[:3])
+        # fill in None for the int and empty tensor return values
+        for i in range(2, 8):
+            output_specs.insert(i, None)
+        if all(is_tensor_shardable(qkv_shape, spec) for spec in input_expected_specs):
+            # only add to the strategy list when all inputs are shardable
+            redistribute_cost = []
+            for input_idx, spec in enumerate(input_expected_specs):
+                qkv_strategy = op_schema.args_schema[input_idx]
+                assert isinstance(qkv_strategy, OpStrategy)
+                qkv_tensor_meta = qkv_strategy.strategies[0].output_spec.tensor_meta
+                spec.tensor_meta = qkv_tensor_meta
+                redistribute_cost.append(
+                    generate_redistribute_costs(qkv_strategy, spec)
+                )
+
+            strat = PlacementStrategy(
+                output_specs=tuple(output_specs),
+                input_specs=tuple(input_expected_specs),
+                redistribute_cost=redistribute_cost,
+            )
+            all_strategies.append(strat)
+
+    return OpStrategy(all_strategies)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120298
* #120297

as titled, this PR implements the sdpa flash attention op in DTensor

Adding flash attention first but efficient attention and other attention
ops should be similar

fixes https://github.com/pytorch/pytorch/issues/120333

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @fduwjj @wz337 @tianyu-l @wconstab @yf225