### PR TITLE
Fix compilation error: load_fp32_from_fp16’ was not declared in this scope for ppc64le

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_bfloat16_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_bfloat16_vsx.h
@@ -51,6 +51,23 @@ inline void load_fp32_from_bf16(
   load_fp32_from_bf16(data, out2);
 }
 
+inline void load_fp32_from_fp16(const c10::Half* data, Vectorized<float>& out) {
+  __at_align__ float values[Vectorized<float>::size()];
+  for (const auto k : c10::irange(Vectorized<float>::size())) {
+    values[k] = data[k];
+  }
+  out = Vectorized<float>::loadu(values);
+}
+
+inline void load_fp32_from_fp16(
+    const c10::Half* data,
+    Vectorized<float>& out1,
+    Vectorized<float>& out2) {
+  load_fp32_from_fp16(data, out1);
+  data += Vectorized<float>::size();
+  load_fp32_from_fp16(data, out2);
+}
+
 } // namespace
 } // namespace vec
 } // namespace at


### PR DESCRIPTION
This patch adds missing Implementation of load_fp32_from_fp16 for half. Fixes the error  load_fp32_from_fp16’ was not declared in this scope . 

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10