### PR TITLE
fix xpu build failure

### DIFF
--- a/c10/xpu/XPUFunctions.cpp
+++ b/c10/xpu/XPUFunctions.cpp
@@ -90,7 +90,11 @@ void initDeviceProperties(DeviceProp* device_prop, int device) {
 }
 
 inline void check_device(DeviceIndex device) {
-  auto total = static_cast<int16_t>(gDevicePool.devices.size());
+  // TODO: Use c10::Device::MAX_NUM_DEVICES directly.
+  TORCH_CHECK(
+      gDevicePool.devices.size() <= std::numeric_limits<DeviceIndex>::max(),
+      "Too many XPU devices, DeviceIndex overflowed");
+  auto total = static_cast<DeviceIndex>(gDevicePool.devices.size());
   TORCH_CHECK(
       device >= 0 && device < total,
       "device is out of range, device is ",

--- a/c10/xpu/XPUFunctions.cpp
+++ b/c10/xpu/XPUFunctions.cpp
@@ -90,11 +90,9 @@ void initDeviceProperties(DeviceProp* device_prop, int device) {
 }
 
 inline void check_device(DeviceIndex device) {
+  auto total = gDevicePool.devices.size();
   TORCH_CHECK(
-      device >= 0 &&
-          device < std::min(
-                       gDevicePool.devices.size(),
-                       std::numeric_limits<DeviceIndex>::max()),
+      device >= 0 && device < total,
       "device is out of range, device is ",
       device,
       ", total number of device is ",
@@ -163,7 +161,7 @@ DeviceIndex current_device() {
 
 void set_device(DeviceIndex device) {
   initDevicePoolCallOnce();
-  check_device(static_cast<int>(device));
+  check_device(device);
   curDeviceIndex = device;
 }
 

--- a/c10/xpu/XPUFunctions.cpp
+++ b/c10/xpu/XPUFunctions.cpp
@@ -90,7 +90,7 @@ void initDeviceProperties(DeviceProp* device_prop, int device) {
 }
 
 inline void check_device(DeviceIndex device) {
-  auto total = gDevicePool.devices.size();
+  auto total = static_cast<int16_t>(gDevicePool.devices.size());
   TORCH_CHECK(
       device >= 0 && device < total,
       "device is out of range, device is ",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #118613
* #118528
* #118523
* __->__ #120315

# Motivation
fix build failure introduced by [[DeviceIndex][6/N] Use DeviceIndex in more places](https://github.com/pytorch/pytorch/pull/120133), parameter `total` is undefined in line 100. see https://github.com/pytorch/pytorch/pull/120133/files#diff-00eb8a6f5dfbc341ee9ab9aff0e3dbece8ad73483d4f41a005b1f453cb78221cR91-L102
[PR120133](https://github.com/pytorch/pytorch/pull/120133) forgot to add the label `ciflow/xpu`, so the XPU CI flow was not triggered.

# Solution
refer to [Why is std::cout not printing the correct value for my int8_t number?](https://stackoverflow.com/questions/7587782) , static cast int8_t to int16_t and the condition `device >= 0 && device < total` is enough.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10