### PR TITLE
Fix segfault on mac when running vulkan tests

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Command.cpp
+++ b/aten/src/ATen/native/vulkan/api/Command.cpp
@@ -116,7 +116,7 @@ void CommandBuffer::bind_descriptors(VkDescriptorSet descriptors) {
   state_ = CommandBuffer::State::DESCRIPTORS_BOUND;
 }
 
-void CommandBuffer::insert_barrier(const PipelineBarrier& pipeline_barrier) {
+void CommandBuffer::insert_barrier(PipelineBarrier& pipeline_barrier) {
   VK_CHECK_COND(
       state_ == CommandBuffer::State::DESCRIPTORS_BOUND ||
           state_ == CommandBuffer::State::RECORDING,
@@ -124,18 +124,21 @@ void CommandBuffer::insert_barrier(const PipelineBarrier& pipeline_barrier) {
       "is not DESCRIPTORS_BOUND or RECORDING.");
 
   if (pipeline_barrier) {
-    std::vector<VkBufferMemoryBarrier> buffer_memory_barriers(4);
+    if (!pipeline_barrier.buffer_barrier_handles.empty()) {
+      pipeline_barrier.buffer_barrier_handles.clear();
+    }
     for (const api::BufferMemoryBarrier& memory_barrier :
          pipeline_barrier.buffers) {
-      buffer_memory_barriers.push_back(memory_barrier.handle);
+      pipeline_barrier.buffer_barrier_handles.push_back(memory_barrier.handle);
     }
 
-    std::vector<VkImageMemoryBarrier> image_memory_barriers(4);
+    if (!pipeline_barrier.image_barrier_handles.empty()) {
+      pipeline_barrier.image_barrier_handles.clear();
+    }
     for (const api::ImageMemoryBarrier& memory_barrier :
          pipeline_barrier.images) {
-      image_memory_barriers.push_back(memory_barrier.handle);
+      pipeline_barrier.image_barrier_handles.push_back(memory_barrier.handle);
     }
-
     vkCmdPipelineBarrier(
         handle_, // commandBuffer
         pipeline_barrier.stage.src, // srcStageMask
@@ -143,10 +146,14 @@ void CommandBuffer::insert_barrier(const PipelineBarrier& pipeline_barrier) {
         0u, // dependencyFlags
         0u, // memoryBarrierCount
         nullptr, // pMemoryBarriers
-        buffer_memory_barriers.size(), // bufferMemoryBarrierCount
-        buffer_memory_barriers.data(), // pMemoryBarriers
-        image_memory_barriers.size(), // imageMemoryBarrierCount
-        image_memory_barriers.data()); // pImageMemoryBarriers
+        pipeline_barrier.buffers.size(), // bufferMemoryBarrierCount
+        !pipeline_barrier.buffers.empty()
+            ? pipeline_barrier.buffer_barrier_handles.data()
+            : nullptr, // pMemoryBarriers
+        pipeline_barrier.images.size(), // imageMemoryBarrierCount
+        !pipeline_barrier.images.empty()
+            ? pipeline_barrier.image_barrier_handles.data()
+            : nullptr); // pImageMemoryBarriers
   }
 
   state_ = CommandBuffer::State::BARRIERS_INSERTED;

--- a/aten/src/ATen/native/vulkan/api/Command.h
+++ b/aten/src/ATen/native/vulkan/api/Command.h
@@ -84,7 +84,7 @@ class CommandBuffer final {
   void bind_pipeline(VkPipeline, VkPipelineLayout, const utils::uvec3);
   void bind_descriptors(VkDescriptorSet);
 
-  void insert_barrier(const PipelineBarrier& pipeline_barrier);
+  void insert_barrier(PipelineBarrier& pipeline_barrier);
   void dispatch(const utils::uvec3&);
 
   void copy_buffer_to_buffer(

--- a/aten/src/ATen/native/vulkan/api/Context.cpp
+++ b/aten/src/ATen/native/vulkan/api/Context.cpp
@@ -75,7 +75,7 @@ DescriptorSet Context::submit_compute_prologue(
 void Context::submit_compute_epilogue(
     CommandBuffer& command_buffer,
     const DescriptorSet& descriptors,
-    const PipelineBarrier& pipeline_barrier,
+    PipelineBarrier& pipeline_barrier,
     const utils::uvec3& global_workgroup_size) {
   command_buffer.bind_descriptors(descriptors.get_bind_handle());
   command_buffer.insert_barrier(pipeline_barrier);

--- a/aten/src/ATen/native/vulkan/api/Context.h
+++ b/aten/src/ATen/native/vulkan/api/Context.h
@@ -177,13 +177,13 @@ class Context final {
   void submit_compute_epilogue(
       CommandBuffer&,
       const DescriptorSet&,
-      const PipelineBarrier&,
+      PipelineBarrier&,
       const utils::uvec3&);
 
  public:
   template <class S, class D>
   bool submit_copy(
-      const PipelineBarrier&,
+      PipelineBarrier&,
       const S&,
       const D&,
       const api::utils::uvec3&,
@@ -194,7 +194,7 @@ class Context final {
   template <typename... Arguments>
   bool submit_compute_job(
       const ShaderInfo&,
-      const PipelineBarrier&,
+      PipelineBarrier&,
       const utils::uvec3&,
       const utils::uvec3&,
       VkFence fence_handle,
@@ -389,7 +389,7 @@ inline void record_copy<VulkanBuffer, VulkanImage>(
  */
 template <class S, class D>
 inline bool Context::submit_copy(
-    const PipelineBarrier& pipeline_barrier,
+    PipelineBarrier& pipeline_barrier,
     const S& source,
     const D& destination,
     const api::utils::uvec3& copy_range,
@@ -456,7 +456,7 @@ inline bool Context::submit_copy(
 template <typename... Arguments>
 inline bool Context::submit_compute_job(
     const ShaderInfo& shader,
-    const PipelineBarrier& pipeline_barrier,
+    PipelineBarrier& pipeline_barrier,
     const utils::uvec3& global_work_group,
     const utils::uvec3& local_work_group_size,
     VkFence fence_handle,

--- a/aten/src/ATen/native/vulkan/api/Pipeline.h
+++ b/aten/src/ATen/native/vulkan/api/Pipeline.h
@@ -25,6 +25,8 @@ struct PipelineBarrier final {
 
   std::vector<BufferMemoryBarrier> buffers;
   std::vector<ImageMemoryBarrier> images;
+  std::vector<VkBufferMemoryBarrier> buffer_barrier_handles;
+  std::vector<VkImageMemoryBarrier> image_barrier_handles;
 
   inline operator bool() const {
     return (0u != stage.src) || (0u != stage.dst) || !buffers.empty() ||


### PR DESCRIPTION
Summary: Vulkan gtests were segfaulting on mac because the memory for barriers can get destroyed after the local function(CommandBuffer::insert_barrier) exits where it is created. Since we provide this barrier pointer to vulkan library it needs to be around even after the function exit, else we get crashes.

Test Plan:
See that there is no segfault on mac with fix and tests can run:

Compile gtests:
buck2 build --target-platforms ovr_config//platform/macos:arm64-fbsource  //xplat/caffe2:pt_vulkan_quantized_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1 --show-output"

Crash w/o diff
bash-3.2$ buck-out//v2/gen/fbsource/xplat/caffe2/pt_vulkan_quantized_api_test_binAppleMac
Running main() from third-party/googletest/1.14.0/googletest/googletest/src/gtest_main.cc
[==========] Running 85 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 85 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.uniform_buffer_copy
[       OK ] VulkanAPITest.uniform_buffer_copy (88 ms)
[ RUN      ] VulkanAPITest.copy_to_buffer
Segmentation fault: 11

With diff there is no crash:
bash-3.2$ buck-out//v2/gen/fbsource/xplat/caffe2/pt_vulkan_quantized_api_test_binAppleMac
Running main() from third-party/googletest/1.14.0/googletest/googletest/src/gtest_main.cc
[==========] Running 85 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 85 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.uniform_buffer_copy
[       OK ] VulkanAPITest.uniform_buffer_copy (296 ms)
.....
[  FAILED  ] VulkanAPITest.gelu_quint8_self (23 ms)
[----------] 85 tests from VulkanAPITest (1494 ms total)

[----------] Global test environment tear-down
[==========] 85 tests from 1 test suite ran. (1494 ms total)
[  PASSED  ] 72 tests.
[  FAILED  ] 13 tests, listed below:
[  FAILED  ] VulkanAPITest.linear_2d_flat
[  FAILED  ] VulkanAPITest.linear_2d_small
[  FAILED  ] VulkanAPITest.linear_2d_large
[  FAILED  ] VulkanAPITest.linear_3d_flat
[  FAILED  ] VulkanAPITest.linear_3d_small
[  FAILED  ] VulkanAPITest.linear_3d_large
[  FAILED  ] VulkanAPITest.linear_4d_flat
[  FAILED  ] VulkanAPITest.linear_4d_small
[  FAILED  ] VulkanAPITest.linear_4d_large
[  FAILED  ] VulkanAPITest.gelu_qint8
[  FAILED  ] VulkanAPITest.gelu_qint8_self
[  FAILED  ] VulkanAPITest.gelu_quint8
[  FAILED  ] VulkanAPITest.gelu_quint8_self

The above failing tests were failing before as well and are being worked on.

Differential Revision: D54023146


