### PR TITLE
[Memory Snapshot] Add Total memory used after allocation in Trace View

### DIFF
--- a/torch/utils/viz/MemoryViz.js
+++ b/torch/utils/viz/MemoryViz.js
@@ -901,6 +901,7 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries) {
     current_data.push(e);
     data.push(e);
     total_mem += size;
+    element_obj.max_allocated_mem = total_mem + total_summarized_mem;
   }
 
   for (const elem of initially_allocated) {
@@ -971,6 +972,9 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries) {
       const elem = elements[id];
       let text = `Addr: ${formatAddr(elem)}`;
       text = `${text}, Size: ${formatSize(elem.size)} allocation`;
+      text = `${text}, Total memory used after allocation: ${formatSize(
+        elem.max_allocated_mem,
+      )}`;
       if (elem.stream !== null) {
         text = `${text}, stream ${elem.stream}`;
       }


### PR DESCRIPTION
Summary: Being able to see max allocated helps improve user experience with memory snapshots.

Test Plan:
Before:
![image](https://github.com/pytorch/pytorch/assets/17602366/534001fa-2fbe-4fc5-bd48-cd82f3277941)

After:
![image](https://github.com/pytorch/pytorch/assets/17602366/f8b9a7bc-3a34-4e38-82cb-f766e54b3fd2)

Reviewed By: zdevito

Differential Revision: D53953648

Pulled By: aaronenyeshi


