### PR TITLE
[inductor] When generating debug logs don't fail if nvcc not found

### DIFF
--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -233,7 +233,7 @@ def _cuda_system_info_comment():
         cuda_version_lines = cuda_version_out.decode().split("\n")
         comment = "".join([f"# {s} \n" for s in cuda_version_lines if s not in [""]])
         model_str += f"{comment}\n"
-    except FileNotFoundError:
+    except (FileNotFoundError, subprocess.CalledProcessError):
         model_str += "# nvcc not found\n"
 
     gpu_names = Counter(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120346

If nvcc isn't found subprocess throws a CalledProcessError

Differential Revision: [D54028438](https://our.internmc.facebook.com/intern/diff/D54028438/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng