### PR TITLE
Relax constraint in _mirror_autograd_meta_to to allow requires_grad=True leaf tensor

### DIFF
--- a/torch/csrc/autograd/python_torch_functions_manual.cpp
+++ b/torch/csrc/autograd/python_torch_functions_manual.cpp
@@ -393,13 +393,12 @@ static PyObject* THPVariable__mirror_autograd_meta_to(
   auto r = parser.parse(args, kwargs, parsed_args);
   auto src_ = r.tensor(0);
   auto dst_ = r.tensor(1);
-  // Here, we unsafely set the grad function on the wrapper to be the same as
-  // the inner. We expect this grad_fn to NEVER be used. It's needed so that
-  // .is_leaf metadata is accurate on the wrapper
   auto inner_autograd_meta = impl::get_autograd_meta(src_);
   if (inner_autograd_meta) {
     dst_.set_requires_grad(src_.requires_grad());
-    if (dst_.requires_grad()) {
+    if (inner_autograd_meta->grad_fn_) {
+      // We expect this grad_fn to NEVER be used. It's needed so that
+      // .is_leaf metadata is accurate on the wrapper
       auto new_grad_fn = std::shared_ptr<torch::autograd::Error>(
           new torch::autograd::Error(
               "Cannot backprop through mirrored meta, file a bug in PyTorch"),


### PR DESCRIPTION
The comment above `THPVariable__mirror_autograd_meta_to` mentions that 
```
// - grad_fn
//   (If src has a grad_fn, we install an error grad_fn on dest to avoid
//   difficult bugs.
//    The main purpose is to ensure that dst.is_leaf == src.is_leaf)
```
But the actual logic is "if src has requires_grad=True, we install an error grad_fn on dest", which is too restrictive and prevents the "src has requires_grad=True but grad_fn=None, dst should copy this metadata as-is, and dst.is_leaf == src.is_leaf is still true" use case. This PR relaxes the constraint to allow such use case and to follow the original intent in the code comment.

I hit this when doing FSDP tracing - I tried to call register_post_accumulate_grad_hook on a requires_grad=True grad_fn=None leaf tensor, and it complains that  I can't register post-acc-grad hook on a "non-leaf tensor" even though this tensor is actually leaf.

Call stack that leads to `torch._mirror_autograd_meta_to` call is:
```
Uncaught exception
Traceback (most recent call last):
  File "/home/willfeng/local/test_dynamo_fsdp.py", line 254, in <module>
    losses_compiled = main_compiled()
                      ^^^^^^^^^^^^^^^
  File "/home/willfeng/local/test_dynamo_fsdp.py", line 222, in main_compiled
    res = run(model, optim, compile=True)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/willfeng/local/test_dynamo_fsdp.py", line 185, in run
    out = model(inp)
          ^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/nn/modules/module.py", line 1529, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/nn/modules/module.py", line 1538, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/_dynamo/eval_frame.py", line 455, in _fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/_dynamo/convert_frame.py", line 915, in catch_errors
    return callback(frame, cache_entry, hooks, frame_state, skip=1)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/_dynamo/convert_frame.py", line 399, in _convert_frame_assert
    return _compile(
           ^^^^^^^^^
  File "/data/users/willfeng/miniconda3/lib/python3.11/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/_dynamo/convert_frame.py", line 671, in _compile
    guarded_code = compile_inner(code, one_graph, hooks, transform)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/_dynamo/utils.py", line 256, in time_wrapper
    r = func(*args, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/_dynamo/convert_frame.py", line 543, in compile_inner
    out_code = transform_code_object(code, transform)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/_dynamo/bytecode_transformation.py", line 1033, in transform_code_object
    transformations(instructions, code_options)
  File "/data/users/willfeng/pytorch_yf225/torch/_dynamo/convert_frame.py", line 164, in _fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/_dynamo/convert_frame.py", line 508, in transform
    tracer.run()
  File "/data/users/willfeng/pytorch_yf225/torch/_dynamo/symbolic_convert.py", line 2128, in run
    super().run()
  File "/data/users/willfeng/pytorch_yf225/torch/_dynamo/symbolic_convert.py", line 791, in run
    and self.step()
        ^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/_dynamo/symbolic_convert.py", line 754, in step
    getattr(self, inst.opname)(inst)
  File "/data/users/willfeng/pytorch_yf225/torch/_dynamo/symbolic_convert.py", line 2247, in RETURN_VALUE
    self.output.compile_subgraph(
  File "/data/users/willfeng/pytorch_yf225/torch/_dynamo/output_graph.py", line 983, in compile_subgraph
    self.compile_and_call_fx_graph(tx, pass2.graph_output_vars(), root)
  File "/data/users/willfeng/miniconda3/lib/python3.11/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/_dynamo/output_graph.py", line 1128, in compile_and_call_fx_graph
    compiled_fn = self.call_user_compiler(gm)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/_dynamo/utils.py", line 256, in time_wrapper
    r = func(*args, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/_dynamo/output_graph.py", line 1201, in call_user_compiler
    raise BackendCompilerFailed(self.compiler_fn, e).with_traceback(
  File "/data/users/willfeng/pytorch_yf225/torch/_dynamo/output_graph.py", line 1182, in call_user_compiler
    compiled_fn = compiler_fn(gm, self.example_inputs())
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/_dynamo/repro/after_dynamo.py", line 117, in debug_wrapper
    compiled_gm = compiler_fn(gm, example_inputs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/_dynamo/repro/after_dynamo.py", line 117, in debug_wrapper
    compiled_gm = compiler_fn(gm, example_inputs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/__init__.py", line 1769, in __call__
    return self.compiler_fn(model_, inputs_, **self.kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/_dynamo/backends/common.py", line 57, in compiler_fn
    cg = aot_module_simplified(gm, example_inputs, **kwargs)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/_functorch/aot_autograd.py", line 878, in aot_module_simplified
    compiled_fn = create_aot_dispatcher_function(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/_dynamo/utils.py", line 256, in time_wrapper
    r = func(*args, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/_functorch/aot_autograd.py", line 508, in create_aot_dispatcher_function
    fw_metadata = run_functionalized_fw_and_collect_metadata(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/_functorch/_aot_autograd/collect_metadata_analysis.py", line 110, in inner
    flat_f_args = pytree.tree_map(_to_fun, flat_args)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/utils/_pytree.py", line 897, in tree_map
    return treespec.unflatten(map(func, *flat_args))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/utils/_pytree.py", line 735, in unflatten
    leaves = list(leaves)
             ^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/_functorch/_aot_autograd/collect_metadata_analysis.py", line 84, in _to_fun
    r = to_fun(t)
        ^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/_functorch/_aot_autograd/functional_utils.py", line 32, in to_fun
    return FunctionalTensor.to_functional(t)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/willfeng/pytorch_yf225/torch/_subclasses/functional_tensor.py", line 196, in to_functional
    torch._mirror_autograd_meta_to(x, x_functional)  # type: ignore[attr-defined]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```