### PR TITLE
[cond] make sure subgraphs in cond are decomposed according to current decomp table

### DIFF
--- a/torch/_higher_order_ops/cond.py
+++ b/torch/_higher_order_ops/cond.py
@@ -157,11 +157,18 @@ def trace_cond(proxy_mode, func_overload, pred, true_fn, false_fn, operands):
     pre_dispatch = getattr(proxy_mode, "pre_dispatch", False)
 
     with disable_proxy_modes_tracing():
+        # We'll use the current decomposition table to make sure operatos in subgraphs are
+        # decomposed properly.
+        decomp_table = torch.fx.experimental.proxy_tensor.CURRENT_DECOMPOSITION_TABLE
         true_graph = make_fx(
-            _maybe_run_with_interpreter(true_fn), pre_dispatch=pre_dispatch
+            _maybe_run_with_interpreter(true_fn),
+            decomposition_table=decomp_table,
+            pre_dispatch=pre_dispatch,
         )(*operands)
         false_graph = make_fx(
-            _maybe_run_with_interpreter(false_fn), pre_dispatch=pre_dispatch
+            _maybe_run_with_interpreter(false_fn),
+            decomposition_table=decomp_table,
+            pre_dispatch=pre_dispatch,
         )(*operands)
 
     true_outs = []


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #120412
* __->__ #120366

Fixes https://github.com/pytorch/pytorch/issues/120160. The issue is because previously cond doesn't pass in the global decomposition table in ProxyMode. This PR adds the current_decomposition_table to the recursive make_fx call.

Test Plan:
see added tests.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames