### PR TITLE
[amd] fix unused variable device_flags

### DIFF
--- a/c10/cuda/CUDAStream.cpp
+++ b/c10/cuda/CUDAStream.cpp
@@ -36,7 +36,10 @@ static int max_stream_priorities;
 // already been destroyed and thus invoking cudaStreamDestroy could lead to a
 // crash. It's likely an issue in CUDA, but to be safe - let's just "forget"
 // the destruction.
+#if !defined(USE_ROCM)
+// CUDA-only: used to initializes the stream pools (once)
 static c10::once_flag device_flags[C10_COMPILE_TIME_MAX_GPUS];
+#endif
 static std::atomic<uint32_t>
     priority_counters[c10::cuda::max_compile_time_stream_priorities]
                      [C10_COMPILE_TIME_MAX_GPUS];


### PR DESCRIPTION
Summary:
get build error due to D53986297 (https://github.com/pytorch/pytorch/pull/119996)

```
caffe2/c10/cuda/__fb_c10_hipify_gen__/out/c10/hip/HIPStream.cpp:40:23: error: unused variable 'device_flags' [-Werror,-Wunused-variable]
static c10::once_flag device_flags[C10_COMPILE_TIME_MAX_GPUS];
```

Reviewed By: jianyuh, xw285cornell

Differential Revision: D54027737
