### PR TITLE
[pytree] support `X | Y` union type in `tree_map_only`

### DIFF
--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -633,7 +633,7 @@ class TestGenericPytree(TestCase):
         "pytree_impl",
         [
             subtest(py_pytree, name="py"),
-            # cxx tree_map_only does not support passing predicate fn as filter
+            subtest(cxx_pytree, name="cxx"),
         ],
     )
     def test_tree_map_only_predicate_fn(self, pytree_impl):

--- a/torch/utils/_cxx_pytree.py
+++ b/torch/utils/_cxx_pytree.py
@@ -597,6 +597,16 @@ def tree_map_only(
     ...
 
 
+@overload
+def tree_map_only(
+    __type_or_types_or_pred: Callable[[Any], bool],
+    func: FnAny[Any],
+    tree: PyTree,
+    is_leaf: Optional[Callable[[PyTree], bool]] = None,
+) -> PyTree:
+    ...
+
+
 def tree_map_only(
     __type_or_types_or_pred: Union[TypeAny, Callable[[Any], bool]],
     func: FnAny[Any],
@@ -630,6 +640,16 @@ def tree_map_only_(
 def tree_map_only_(
     __type_or_types_or_pred: Type3[T, S, U],
     func: Fn3[T, S, U, Any],
+    tree: PyTree,
+    is_leaf: Optional[Callable[[PyTree], bool]] = None,
+) -> PyTree:
+    ...
+
+
+@overload
+def tree_map_only_(
+    __type_or_types_or_pred: Callable[[Any], bool],
+    func: FnAny[Any],
     tree: PyTree,
     is_leaf: Optional[Callable[[PyTree], bool]] = None,
 ) -> PyTree:

--- a/torch/utils/_cxx_pytree.py
+++ b/torch/utils/_cxx_pytree.py
@@ -13,6 +13,8 @@ collection support for PyTorch APIs.
 """
 
 import functools
+import sys
+import types
 import warnings
 from typing import (
     Any,
@@ -478,7 +480,10 @@ def tree_map_(
 
 Type2 = Tuple[Type[T], Type[S]]
 Type3 = Tuple[Type[T], Type[S], Type[U]]
-TypeAny = Union[Type[Any], Tuple[Type[Any], ...]]
+if sys.version_info >= (3, 10):
+    TypeAny = Union[Type[Any], Tuple[Type[Any], ...], types.UnionType]
+else:
+    TypeAny = Union[Type[Any], Tuple[Type[Any], ...]]
 
 Fn2 = Callable[[Union[T, S]], R]
 Fn3 = Callable[[Union[T, S, U]], R]
@@ -537,15 +542,23 @@ def map_only(
 
     You can also directly use 'tree_map_only'
     """
-    if not isinstance(__type_or_types_or_pred, (tuple, type)):
-        raise ValueError(
-            "cxx_pytree map_only currently only accepts type or tuple of types"
-        )
+    if isinstance(__type_or_types_or_pred, (type, tuple)) or (
+        sys.version_info >= (3, 10)
+        and isinstance(__type_or_types_or_pred, types.UnionType)
+    ):
+
+        def pred(x: Any) -> bool:
+            return isinstance(x, __type_or_types_or_pred)  # type: ignore[arg-type]
+
+    elif callable(__type_or_types_or_pred):
+        pred = __type_or_types_or_pred  # type: ignore[assignment]
+    else:
+        raise TypeError("Argument must be a type, a tuple of types, or a callable.")
 
     def wrapper(func: Callable[[T], Any]) -> Callable[[Any], Any]:
         @functools.wraps(func)
         def wrapped(x: T) -> Any:
-            if isinstance(x, __type_or_types_or_pred):
+            if pred(x):
                 return func(x)
             return x
 
@@ -577,16 +590,6 @@ def tree_map_only(
 @overload
 def tree_map_only(
     __type_or_types_or_pred: Type3[T, S, U],
-    func: Fn3[T, S, U, Any],
-    tree: PyTree,
-    is_leaf: Optional[Callable[[PyTree], bool]] = None,
-) -> PyTree:
-    ...
-
-
-@overload
-def tree_map_only(
-    __type_or_types_or_pred: Callable[[Any], bool],
     func: Fn3[T, S, U, Any],
     tree: PyTree,
     is_leaf: Optional[Callable[[PyTree], bool]] = None,
@@ -626,16 +629,6 @@ def tree_map_only_(
 @overload
 def tree_map_only_(
     __type_or_types_or_pred: Type3[T, S, U],
-    func: Fn3[T, S, U, Any],
-    tree: PyTree,
-    is_leaf: Optional[Callable[[PyTree], bool]] = None,
-) -> PyTree:
-    ...
-
-
-@overload
-def tree_map_only_(
-    __type_or_types_or_pred: Callable[[Any], bool],
     func: Fn3[T, S, U, Any],
     tree: PyTree,
     is_leaf: Optional[Callable[[PyTree], bool]] = None,

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -1053,6 +1053,16 @@ def tree_map_only(
     ...
 
 
+@overload
+def tree_map_only(
+    __type_or_types_or_pred: Callable[[Any], bool],
+    func: FnAny[Any],
+    tree: PyTree,
+    is_leaf: Optional[Callable[[PyTree], bool]] = None,
+) -> PyTree:
+    ...
+
+
 def tree_map_only(
     __type_or_types_or_pred: Union[TypeAny, Callable[[Any], bool]],
     func: FnAny[Any],
@@ -1086,6 +1096,16 @@ def tree_map_only_(
 def tree_map_only_(
     __type_or_types_or_pred: Type3[T, S, U],
     func: Fn3[T, S, U, Any],
+    tree: PyTree,
+    is_leaf: Optional[Callable[[PyTree], bool]] = None,
+) -> PyTree:
+    ...
+
+
+@overload
+def tree_map_only_(
+    __type_or_types_or_pred: Callable[[Any], bool],
+    func: FnAny[Any],
     tree: PyTree,
     is_leaf: Optional[Callable[[PyTree], bool]] = None,
 ) -> PyTree:

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -18,7 +18,9 @@ To improve the performance we can move parts of the implementation to C++.
 import dataclasses
 import importlib
 import json
+import sys
 import threading
+import types
 import warnings
 from collections import defaultdict, deque, namedtuple, OrderedDict
 from typing import (
@@ -934,7 +936,10 @@ def tree_map_(
 
 Type2 = Tuple[Type[T], Type[S]]
 Type3 = Tuple[Type[T], Type[S], Type[U]]
-TypeAny = Union[Type[Any], Tuple[Type[Any], ...]]
+if sys.version_info >= (3, 10):
+    TypeAny = Union[Type[Any], Tuple[Type[Any], ...], types.UnionType]
+else:
+    TypeAny = Union[Type[Any], Tuple[Type[Any], ...]]
 
 Fn2 = Callable[[Union[T, S]], R]
 Fn3 = Callable[[Union[T, S, U]], R]
@@ -993,15 +998,19 @@ def map_only(
 
     You can also directly use 'tree_map_only'
     """
-    if isinstance(__type_or_types_or_pred, (tuple, type)):
-        return _map_only(lambda x: isinstance(x, __type_or_types_or_pred))
+    if isinstance(__type_or_types_or_pred, (type, tuple)) or (
+        sys.version_info >= (3, 10)
+        and isinstance(__type_or_types_or_pred, types.UnionType)
+    ):
+
+        def pred(x: Any) -> bool:
+            return isinstance(x, __type_or_types_or_pred)  # type: ignore[arg-type]
+
     elif callable(__type_or_types_or_pred):
-        return _map_only(__type_or_types_or_pred)
+        pred = __type_or_types_or_pred  # type: ignore[assignment]
     else:
         raise TypeError("Argument must be a type, a tuple of types, or a callable.")
 
-
-def _map_only(pred: Callable[[Any], bool]) -> MapOnlyFn[FnAny[Any]]:
     def wrapper(func: Callable[[T], Any]) -> Callable[[Any], Any]:
         # @functools.wraps(func)  # torch dynamo doesn't support this yet
         def wrapped(x: T) -> Any:
@@ -1038,16 +1047,6 @@ def tree_map_only(
 def tree_map_only(
     __type_or_types_or_pred: Type3[T, S, U],
     func: Fn3[T, S, U, Any],
-    tree: PyTree,
-    is_leaf: Optional[Callable[[PyTree], bool]] = None,
-) -> PyTree:
-    ...
-
-
-@overload
-def tree_map_only(
-    __type_or_types_or_pred: Callable[[Any], bool],
-    func: FnAny[Any],
     tree: PyTree,
     is_leaf: Optional[Callable[[PyTree], bool]] = None,
 ) -> PyTree:


### PR DESCRIPTION
Follow-up PR for #119974 with some small tweaks.

1. Support `X | Y` union type for Python 3.10+
2. Enable predicate function in `tree_map_only` in CXX pytree.
3. Remove unnecessary function definition.

cc @zou3519