### PR TITLE
Use privateuseone during external module register test

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -845,7 +845,7 @@ class TestStandaloneCPPJIT(TestCase):
             shutil.rmtree(build_dir)
 
 
-class DummyXPUModule:
+class DummyPrivateUse1Module:
     @staticmethod
     def is_available():
         return True
@@ -886,18 +886,18 @@ class TestExtensionUtils(TestCase):
 
         # Wrong device type
         with self.assertRaisesRegex(RuntimeError, "Expected one of cpu"):
-            torch._register_device_module('dummmy', DummyXPUModule)
+            torch._register_device_module('dummmy', DummyPrivateUse1Module)
 
         with self.assertRaises(AttributeError):
-            torch.xpu.is_available()  # type: ignore[attr-defined]
+            torch.privateuseone.is_available()  # type: ignore[attr-defined]
 
-        torch._register_device_module('xpu', DummyXPUModule)
+        torch._register_device_module('privateuseone', DummyPrivateUse1Module)
 
-        torch.xpu.is_available()  # type: ignore[attr-defined]
+        torch.privateuseone.is_available()  # type: ignore[attr-defined]
 
         # No supporting for override
         with self.assertRaisesRegex(RuntimeError, "The runtime module of"):
-            torch._register_device_module('xpu', DummyXPUModule)
+            torch._register_device_module('privateuseone', DummyPrivateUse1Module)
 
     def test_external_module_and_backend_register(self):
         torch.utils.rename_privateuse1_backend('foo')
@@ -913,7 +913,7 @@ class TestExtensionUtils(TestCase):
         with self.assertRaisesRegex(AssertionError, "Tried to use AMP with the"):
             with torch.autocast(device_type=custom_backend_name):
                 pass
-        torch._register_device_module('foo', DummyXPUModule)
+        torch._register_device_module('foo', DummyPrivateUse1Module)
 
         torch.foo.is_available()  # type: ignore[attr-defined]
         with torch.autocast(device_type=custom_backend_name):


### PR DESCRIPTION
Fixes #120397 

Use privateuseone instead of xpu in test_external_module_register.
