### PR TITLE
Improve docstring for tensorboard add_embedding()

### DIFF
--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -932,10 +932,12 @@ class SummaryWriter:
 
         Args:
             mat (torch.Tensor or numpy.ndarray): A matrix which each row is the feature vector of the data point
-            metadata (list): A list of labels, each element will be convert to string
+            metadata (list): A list of labels, each element will be converted to string
             label_img (torch.Tensor): Images correspond to each data point
             global_step (int): Global step value to record
             tag (str): Name for the embedding
+            metadata_header (list): A list of headers for multi-column metadata. If given, each metadata must be
+                a list with values corresponding to headers.
         Shape:
             mat: :math:`(N, D)`, where N is number of data and D is feature dimension
 
@@ -960,6 +962,11 @@ class SummaryWriter:
             writer.add_embedding(torch.randn(100, 5), metadata=meta, label_img=label_img)
             writer.add_embedding(torch.randn(100, 5), label_img=label_img)
             writer.add_embedding(torch.randn(100, 5), metadata=meta)
+
+        .. note::
+            Categorical (i.e. non-numeric) metadata cannot have more than 50 unique values if they are to be used for
+            coloring in the embedding projector.
+
         """
         torch._C._log_api_usage_once("tensorboard.logging.add_embedding")
         mat = make_np(mat)


### PR DESCRIPTION
Fixes missing parameter documentation (`metadata_header`).
Fixes a typo.
Adds a note explaining a somewhat confusing behavior of Tensorboard Projector where categorical values with more than 50 unique values are not permitted to be used for coloring. This was not documented anywhere. The confusion caused https://github.com/tensorflow/tensorboard/issues/61.