### PR TITLE
[codemod] Deshim //folly:dynamic to //folly/json:dynamic in caffe2

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -43,8 +43,8 @@
 
 #ifdef FBCODE_CAFFE2
 #include <common/logging/logging.h>
-#include <folly/dynamic.h>
-#include <folly/json.h>
+#include <folly/json/dynamic.h>
+#include <folly/json/json.h>
 #endif
 
 // used in test only


### PR DESCRIPTION
Summary:
The following headers were shimmed in //folly:dynamic and were modded:
  - folly/DynamicConverter.h -> folly/json/DynamicConverter.h
  - folly/dynamic.h -> folly/json/dynamic.h
  - folly/dynamic-inl.h -> folly/json/dynamic-inl.h
  - folly/json.h -> folly/json/json.h

`arc lint` was applied

Test Plan: sandcastle

Reviewed By: yuhc

Differential Revision: D53836899


