### PR TITLE
[BE][EZ] Flatten preprocessor hierarchy

### DIFF
--- a/c10/util/Half-inl.h
+++ b/c10/util/Half-inl.h
@@ -40,15 +40,13 @@ inline C10_HOST_DEVICE Half::Half(float value)
       x(__half_as_short(__float2half(value)))
 #elif defined(__SYCL_DEVICE_ONLY__)
       x(c10::bit_cast<uint16_t>(sycl::half(value)))
-#else
-#if (defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)) && \
+#elif (defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)) && \
     !defined(__APPLE__)
       x(at::vec::float2half_scalar(value))
 #elif defined(__aarch64__) && !defined(C10_MOBILE) && !defined(__CUDACC__)
       x(detail::native_fp16_from_fp32_value(value))
 #else
       x(detail::fp16_ieee_from_fp32_value(value))
-#endif
 #endif
 {
 }
@@ -60,15 +58,13 @@ inline C10_HOST_DEVICE Half::operator float() const {
   return __half2float(*reinterpret_cast<const __half*>(&x));
 #elif defined(__SYCL_DEVICE_ONLY__)
   return float(c10::bit_cast<sycl::half>(x));
-#else
-#if (defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)) && \
+#elif (defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)) && \
     !defined(__APPLE__)
   return at::vec::half2float_scalar(x);
 #elif defined(__aarch64__) && !defined(C10_MOBILE) && !defined(__CUDACC__)
   return detail::native_fp16_to_fp32_value(x);
 #else
   return detail::fp16_ieee_to_fp32_value(x);
-#endif
 #endif
 }
 


### PR DESCRIPTION
Instead of
```cpp
#if defined(foo)
#else 
#if defined(bar)
#else 
#endif
#endif
```
use
```cpp
#if defined(foo)
#elif defined(bar)
#else 
#endif
```

Fixes #ISSUE_NUMBER
