### PR TITLE
Construct `c10::Half` from `float16_t` on ARMv8

### DIFF
--- a/c10/test/util/Half_test.cpp
+++ b/c10/test/util/Half_test.cpp
@@ -112,10 +112,10 @@ TEST(HalfConversion, TestNativeConversionToFloat) {
     auto h = c10::Half(x, c10::Half::from_bits());
     auto f = halfbits2float(x);
     // NaNs are not equal to each other
-    if (std::isnan(f) && std::isnan(h.operator float())) {
+    if (std::isnan(f) && std::isnan(static_cast<float>(h))) {
       continue;
     }
-    EXPECT_EQ(f, h.operator float()) << "Conversion error using " << x;
+    EXPECT_EQ(f, static_cast<float>(h)) << "Conversion error using " << x;
   }
 }
 
@@ -125,7 +125,7 @@ TEST(HalfConversion, TestNativeConversionToHalf) {
     auto h_bits = float2halfbits(f);
     // NaNs are not equal to each other, just check that half is NaN
     if (std::isnan(f)) {
-      EXPECT_TRUE(std::isnan(h.operator float()));
+      EXPECT_TRUE(std::isnan(static_cast<float>(h)));
     } else {
       EXPECT_EQ(h.x, h_bits) << "Conversion error using " << f;
     }

--- a/c10/util/Half-inl.h
+++ b/c10/util/Half-inl.h
@@ -5,7 +5,6 @@
 
 #include <cstring>
 #include <limits>
-#include "c10/util/Half.h"
 
 #ifdef __CUDACC__
 #include <cuda_fp16.h>
@@ -35,8 +34,10 @@ namespace c10 {
 
 #if defined(__aarch64__) && !defined(C10_MOBILE) && !defined(__CUDACC__)
 /// Constructors
-inline Half::Half(float16_t value): x(detail::fp16_to_bits(value)) {}
-inline Half::operator float16_t() const { return detail::fp16_from_bits(x); }
+inline Half::Half(float16_t value) : x(detail::fp16_to_bits(value)) {}
+inline Half::operator float16_t() const {
+  return detail::fp16_from_bits(x);
+}
 #else
 
 inline C10_HOST_DEVICE Half::Half(float value)
@@ -71,7 +72,8 @@ inline C10_HOST_DEVICE Half::operator float() const {
 #endif
 }
 
-#endif /* !defined(__aarch64__) || defined(C10_MOBILE) || defined(__CUDACC__) */
+#endif /* !defined(__aarch64__) || defined(C10_MOBILE) || defined(__CUDACC__) \
+        */
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
 inline C10_HOST_DEVICE Half::Half(const __half& value) {

--- a/c10/util/Half-inl.h
+++ b/c10/util/Half-inl.h
@@ -5,6 +5,7 @@
 
 #include <cstring>
 #include <limits>
+#include "c10/util/Half.h"
 
 #ifdef __CUDACC__
 #include <cuda_fp16.h>
@@ -32,7 +33,11 @@ C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
 
 namespace c10 {
 
+#if defined(__aarch64__) && !defined(C10_MOBILE) && !defined(__CUDACC__)
 /// Constructors
+inline Half::Half(float16_t value): x(detail::fp16_to_bits(value)) {}
+inline Half::operator float16_t() const { return detail::fp16_from_bits(x); }
+#else
 
 inline C10_HOST_DEVICE Half::Half(float value)
     :
@@ -40,15 +45,11 @@ inline C10_HOST_DEVICE Half::Half(float value)
       x(__half_as_short(__float2half(value)))
 #elif defined(__SYCL_DEVICE_ONLY__)
       x(c10::bit_cast<uint16_t>(sycl::half(value)))
-#else
-#if (defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)) && \
+#elif (defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)) && \
     !defined(__APPLE__)
       x(at::vec::float2half_scalar(value))
-#elif defined(__aarch64__) && !defined(C10_MOBILE) && !defined(__CUDACC__)
-      x(detail::native_fp16_from_fp32_value(value))
 #else
       x(detail::fp16_ieee_from_fp32_value(value))
-#endif
 #endif
 {
 }
@@ -60,8 +61,7 @@ inline C10_HOST_DEVICE Half::operator float() const {
   return __half2float(*reinterpret_cast<const __half*>(&x));
 #elif defined(__SYCL_DEVICE_ONLY__)
   return float(c10::bit_cast<sycl::half>(x));
-#else
-#if (defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)) && \
+#elif (defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)) && \
     !defined(__APPLE__)
   return at::vec::half2float_scalar(x);
 #elif defined(__aarch64__) && !defined(C10_MOBILE) && !defined(__CUDACC__)
@@ -69,8 +69,9 @@ inline C10_HOST_DEVICE Half::operator float() const {
 #else
   return detail::fp16_ieee_to_fp32_value(x);
 #endif
-#endif
 }
+
+#endif /* !defined(__aarch64__) || defined(C10_MOBILE) || defined(__CUDACC__) */
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
 inline C10_HOST_DEVICE Half::Half(const __half& value) {

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -374,8 +374,13 @@ struct alignas(2) Half {
 #endif
 
   constexpr C10_HOST_DEVICE Half(unsigned short bits, from_bits_t) : x(bits) {}
+#if defined(__aarch64__) && !defined(C10_MOBILE) && !defined(__CUDACC__)
+  inline Half(float16_t value);
+  inline operator float16_t() const;
+#else
   inline C10_HOST_DEVICE Half(float value);
   inline C10_HOST_DEVICE operator float() const;
+#endif
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
   inline C10_HOST_DEVICE Half(const __half& value);


### PR DESCRIPTION
By hiding float32 constructors and exposing float16 ones. This allows compiler do implicit conversions as needed, and in safe cases optimize out unneeded upcasts to fp32, see example [below](https://godbolt.org/z/5TKnY4cos)
```cpp
#include <arm_neon.h>

#ifndef __ARM_FEATURE_FP16_SCALAR_ARITHMETIC
#error Ieeee
#endif

float16_t sum1(float16_t x, float16_t y) {
    return x + y;
}

float16_t sum2(float16_t x, float16_t y) {
    return static_cast<float>(x) + static_cast<float>(y);
}
```
both sum variants are  compiled to scalar fp16 add, if build for the platform that supports fp16 arithmetic
```
sum1(half, half):                            // @sum1(half, half)
        fadd    h0, h0, h1
        ret
sum2(half, half):                            // @sum2(half, half)
        fadd    h0, h0, h1
        ret
```

Fixes build error in some aarch64 configurations after #119483 which are defined as supporting FP16 but don't define _Float16.


cc @snadampal