### PR TITLE
add `export` to `torch.jit.__all__`

### DIFF
--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -77,6 +77,7 @@ __all__ = [
     "ScriptModule",
     "annotate",
     "enable_onednn_fusion",
+    "export",
     "export_opnames",
     "fork",
     "freeze",


### PR DESCRIPTION
I use pyright in the vscode. When I use `@torch.jit.export`, I always see an annoying error saying `export` is not exported.

![image](https://github.com/pytorch/pytorch/assets/9496702/f7b0e17f-6497-4f9a-87dd-55dc627156c3)

Adding it to `__all__` should fix it.

I have seen #92240 and #101678, and I am not sure why `export` is not there. cc @ringohoffman