### PR TITLE
Increase bazel CUDA tests timeout to 480s

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -982,7 +982,8 @@ test_bazel() {
 
     tools/bazel test --config=cpu-only --test_timeout=480 --test_output=all --test_tag_filters=-gpu-required --test_filter=-*CUDA :all_tests
   else
-    tools/bazel test --test_output=errors \
+    # Increase the test timeout to 480 like CPU tests because modules_test frequently timeout
+    tools/bazel test --test_timeout=480 --test_output=errors \
       //:any_test \
       //:autograd_test \
       //:dataloader_test \


### PR DESCRIPTION
One of the bazel CUDA tests `//:modules_test` frequently timeout in trunk, so I try to increase the timeout value to 480s https://bazel.build/reference/test-encyclopedia to see if it helps fix the issue.  Bazel CPU tests already use this value.

Here is an example timeout https://github.com/pytorch/pytorch/actions/runs/8009308009/job/21877698886#step:13:3316