### PR TITLE
[Dynamo] Remove deadcode:  unwrapping script_if_tracing

### DIFF
--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -129,11 +129,6 @@ class UserFunctionVariable(BaseUserFunctionVariable):
         assert isinstance(
             fn, (types.FunctionType, torch.jit.ScriptFunction)
         ), f"expected FunctionType found {typestr(fn)} {fn}"
-        # unpack @torch._dynamo.optimize()(fn) wrapped function
-        fn = inspect.getattr_static(fn, "_torchdynamo_inline", fn)
-        # unpack torch.jit.script_if_tracing
-        if inspect.getattr_static(fn, "__script_if_tracing_wrapper", False):
-            fn = inspect.getattr_static(fn, "__original_fn", fn)
         self.fn: types.FunctionType = fn
 
     def as_python_constant(self):


### PR DESCRIPTION
After the consolidated ```trace_rules.lookup```, we already unwrap at
https://github.com/pytorch/pytorch/blob/2240018c03744ee34ea14ad53481db934c37e384/torch/_dynamo/variables/builder.py#L712



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng