### PR TITLE
Mitigate shape mismatch issue for optimize_ddp_lazy_compile=True

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -294,6 +294,18 @@ def convert_frame_assert(
         cache_size = compute_cache_size(frame, cache_entry)
         recompile_reasons = None
         if is_recompilation(cache_size):
+            if config.optimize_ddp and config.optimize_ddp_lazy_compile:
+                from torch._dynamo.exc import UserError, UserErrorType
+
+                raise UserError(
+                    UserErrorType.DYNAMIC_DIM,
+                    "When turning on both config.ddp_optimizer and config.optimize_ddp_lazy_compile, "
+                    "we expect input tensor shapes remain static but found dynamic shapes instead. "
+                    "Please try to a) pad the input tensor to a static shape, or "
+                    "b) set config.optimize_ddp_lazy_compile = False. If there is still a stride mismatch "
+                    "error, please set config.ddp_optimizer=False. Note that config.ddp_optimizer=False "
+                    "may slowdown the performance",
+                )
             recompile_reasons = get_and_maybe_log_recompilation_reason(
                 cache_entry, frame
             )


### PR DESCRIPTION
Summary:
`DDP Optimizer lazy compile` does not support dynamic shape yet and may report shape mismatch error. See detail: https://github.com/pytorch/pytorch/issues/116300

The root cause is that, in lazy compile, compilation is not conducted until the first `forward` call, while the symbolic shape  information is missing at that time.

This diff detects dynamic shapes and explicitly raise an user error.

Test Plan: CI

Differential Revision: D54091447




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng