### PR TITLE
[dtensor] from_local broadcast use functional collective

### DIFF
--- a/torch/distributed/_tensor/_collective_utils.py
+++ b/torch/distributed/_tensor/_collective_utils.py
@@ -84,6 +84,41 @@ def mesh_scatter(
     return fut
 
 
+def mesh_broadcast(
+    tensor: torch.Tensor,
+    mesh: DeviceMesh,
+    mesh_dim: int = 0,
+    async_op: bool = False,
+) -> Optional[Work]:
+    """
+    broadcast the tensor to a device mesh dimension. We by default
+    use the first rank of the mesh dimension as the source of truth, i.e
+    for a 2d mesh [[0, 1], [2, 3]], if we broadcast on mesh_dim = 1, we will
+    broadcast the tensor on rank 0 to rank 0/1, and tensor on rank 2
+    to rank 2/3.
+
+    Args:
+        tensor (torch.Tensor): tensor to broadcast.
+        mesh_dim (int, optional): indicate which mesh dimension we want
+            to scatter on, we by default choose the first rank on the
+            mesh dimension as source of truth.
+
+    Returns:
+        A :class:`Work` object
+    """
+    # TODO: switch every callsite to use the functional broadcast instead
+    if tensor.is_meta:
+        return None
+    dim_group = mesh.get_group(mesh_dim)
+    assert isinstance(dim_group, ProcessGroup)
+    # src need to be global rank
+    src_for_dim = 0
+    if dim_group is not GroupMember.WORLD:
+        src_for_dim = get_global_rank(dim_group, 0)
+
+    return broadcast(tensor, src=src_for_dim, group=dim_group, async_op=async_op)
+
+
 # TODO: test uneven split on GLOO and NCCL
 def mesh_all_to_all(
     output_tensor_list: List[torch.Tensor],

--- a/torch/distributed/_tensor/_collective_utils.py
+++ b/torch/distributed/_tensor/_collective_utils.py
@@ -84,44 +84,6 @@ def mesh_scatter(
     return fut
 
 
-def mesh_broadcast(
-    tensor: torch.Tensor,
-    mesh: DeviceMesh,
-    mesh_dim: int = 0,
-    async_op: bool = False,
-) -> Optional[Work]:
-    """
-    broadcast the tensor to a device mesh dimension. We by default
-    use the first rank of the mesh dimension as the source of truth, i.e
-    for a 2d mesh [[0, 1], [2, 3]], if we broadcast on mesh_dim = 1, we will
-    broadcast the tensor on rank 0 to rank 0/1, and tensor on rank 2
-    to rank 2/3.
-
-    Args:
-        tensor (torch.Tensor): tensor to broadcast.
-        mesh_dim (int, optional): indicate which mesh dimension we want
-            to scatter on, we by default choose the first rank on the
-            mesh dimension as source of truth.
-
-    Returns:
-        A :class:`Work` object
-    """
-    # TODO: Ideally we should use the meta tensor way
-    # (to register a meta kernel for the collective op)
-    # so that it would avoid the communication. Need to
-    # remove the check below once that is done.
-    if tensor.is_meta:
-        return None
-    dim_group = mesh.get_group(mesh_dim)
-    assert isinstance(dim_group, ProcessGroup)
-    # src need to be global rank
-    src_for_dim = 0
-    if dim_group is not GroupMember.WORLD:
-        src_for_dim = get_global_rank(dim_group, 0)
-
-    return broadcast(tensor, src=src_for_dim, group=dim_group, async_op=async_op)
-
-
 # TODO: test uneven split on GLOO and NCCL
 def mesh_all_to_all(
     output_tensor_list: List[torch.Tensor],

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -160,7 +160,9 @@ class _FromTorchTensor(torch.autograd.Function):
                     # is replicated on the mesh dimension, we only broadcast if
                     # run_check is True TODO: study if this UX is good or not
                     input = input.contiguous()
-                    input = funcol.broadcast(input, device_mesh, mesh_dim=idx).wait()
+                    input = funcol.broadcast(
+                        input, src=0, group=(device_mesh, idx)
+                    ).wait()
 
         # We want a fresh Tensor object that shares memory with the input tensor
         dist_tensor = DTensor(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120457

as titled, switch to use functional collective broadcast in from_local,
we will need to study this UX (about whether we want to by default
broadcast or not)

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k