### PR TITLE
Keep test order due to rename_privateuse1_backend is disposable

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -873,11 +873,12 @@ class DummyPrivateUse1Module:
 
 class TestExtensionUtils(TestCase):
     def tearDown(self):
-        # Clean up from test_external_module_register
-        if hasattr(torch, "xpu"):
-            delattr(torch, "xpu")
-        if "torch.xpu" in sys.modules:
-            del sys.modules["torch.xpu"]
+        # Clean up
+        backend_name = torch._C._get_privateuse1_backend_name()
+        if hasattr(torch, backend_name):
+            delattr(torch, backend_name)
+        if f"torch.{backend_name}" in sys.modules:
+            del sys.modules[f"torch.{backend_name}"]
 
     def test_external_module_register(self):
         # Built-in module
@@ -899,7 +900,7 @@ class TestExtensionUtils(TestCase):
         with self.assertRaisesRegex(RuntimeError, "The runtime module of"):
             torch._register_device_module('privateuseone', DummyPrivateUse1Module)
 
-    def test_external_module_and_backend_register(self):
+    def test_external_module_register_with_renamed_backend(self):
         torch.utils.rename_privateuse1_backend('foo')
         with self.assertRaisesRegex(RuntimeError, "has already been set"):
             torch.utils.rename_privateuse1_backend('dummmy')


### PR DESCRIPTION
With the change in https://github.com/pytorch/pytorch/pull/120399.
As rename_privateuse1_backend is disposable, run test_external_module_register with an renamed backend may cause problem. Try to change the testcase name and keep the right order (ASCII).