### PR TITLE
[export] Use forward hooks to capture module signatures.

### DIFF
--- a/torch/_export/wrappers.py
+++ b/torch/_export/wrappers.py
@@ -66,9 +66,6 @@ def _wrap_submodule(mod, path, module_call_specs):
             assert module_call_specs[path]["out_spec"] == out_spec
         module_call_specs[path] = {"in_spec": in_spec, "out_spec": out_spec}
 
-    assert "forward" not in submodule.__dict__
-    wrapped_forward = submodule.forward
-
     def check_flattened(flat_args):
         for a in flat_args:
             if not (isinstance(a, (torch.Tensor, str, int, float, bool)) or a is None):
@@ -76,33 +73,37 @@ def _wrap_submodule(mod, path, module_call_specs):
                     f"Only Tensors or scalars are supported as pytree flattened inputs, got: {a}"
                 )
 
-    def wrapper(self, *args, **kwargs):
+    def pre_hook(module, args, kwargs):
         flat_args, in_spec = pytree.tree_flatten((args, kwargs))
         check_flattened(flat_args)
         flat_args = _export_tracepoint(*flat_args, kind="module_call_inputs", path=path)
         args, kwargs = pytree.tree_unflatten(flat_args, in_spec)
-        res = wrapped_forward(*args, **kwargs)
+        return args, kwargs
+
+    def post_hook(module, args, kwargs, res):
+        _, in_spec = pytree.tree_flatten((args, kwargs))
         flat_res, out_spec = pytree.tree_flatten(res)
         check_flattened(flat_res)
         flat_res = _export_tracepoint(*flat_res, kind="module_call_outputs", path=path)
         update_module_call_signatures(path, in_spec, out_spec)
         return pytree.tree_unflatten(flat_res, out_spec)
 
-    submodule.forward = wrapper.__get__(submodule, type(submodule))
-    return submodule
+    pre_handle = submodule.register_forward_pre_hook(pre_hook, with_kwargs=True)
+    post_handle = submodule.register_forward_hook(post_hook, with_kwargs=True)
+    return pre_handle, post_handle
 
 
 @contextmanager
 def _wrap_submodules(f, preserve_signature, module_call_signatures):
-    tasks = []
+    handles = []
 
     try:
         for path in preserve_signature:
-            tasks.append(_wrap_submodule(f, path, module_call_signatures))
+            handles.extend(_wrap_submodule(f, path, module_call_signatures))
         yield
     finally:
-        for submodule in tasks:
-            del submodule.__dict__["forward"]
+        for handle in handles:
+            handle.remove()
 
 
 def _mark_strict_experimental(cls):


### PR DESCRIPTION
Summary:
When we export in on strict mode and turn on preserve_module_call_signature, the following assertion error will occur today:
```
child_split[: len(parent_split)] == parent_split
```
This is due to the fact that we're monkey patching forward call directly, which kinda breaks the attribute propagation in the tracer. It's actually better to implement this by using forward hook because we don't have to alter the original module structure at all during export.

Test Plan: CI

Differential Revision: D54102714


