### PR TITLE
Fix compiler check

### DIFF
--- a/aten/src/ATen/native/cpu/AmpGradScalerKernels.cpp
+++ b/aten/src/ATen/native/cpu/AmpGradScalerKernels.cpp
@@ -12,8 +12,6 @@
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/cpu/vec/functional.h>
 
-// dummy change.
-
 namespace at::native {
 
 namespace {

--- a/aten/src/ATen/native/cpu/AmpGradScalerKernels.cpp
+++ b/aten/src/ATen/native/cpu/AmpGradScalerKernels.cpp
@@ -12,6 +12,8 @@
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/cpu/vec/functional.h>
 
+// dummy change.
+
 namespace at::native {
 
 namespace {

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1350,7 +1350,13 @@ def check_compiler_is_gcc(compiler):
 
     env = os.environ.copy()
     env['LC_ALL'] = 'C'  # Don't localize output
-    version_string = subprocess.check_output([compiler, '-v'], stderr=subprocess.STDOUT, env=env).decode(*SUBPROCESS_DECODE_ARGS)
+    try:
+        version_string = subprocess.check_output([compiler, '-v'], stderr=subprocess.STDOUT, env=env).decode(*SUBPROCESS_DECODE_ARGS)
+    except Exception as e:
+        try:
+            version_string = subprocess.check_output([compiler, '--version'], stderr=subprocess.STDOUT, env=env).decode(*SUBPROCESS_DECODE_ARGS)
+        except Exception as e:
+            return False
     # Check for 'gcc' or 'g++' for sccache wrapper
     pattern = re.compile("^COLLECT_GCC=(.*)$", re.MULTILINE)
     results = re.findall(pattern, version_string)


### PR DESCRIPTION
Fixes #119304

1. Add try catch to handle the compiler version check.
2. Retry to query compiler version info.
3. Return False if can't get compiler info twice.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10