### PR TITLE
Remove unnecessary use of ctx.resolve_tools.

### DIFF
--- a/aten.bzl
+++ b/aten.bzl
@@ -62,11 +62,10 @@ def generate_aten_impl(ctx):
     outputs = [ops_dir] + ctx.outputs.outs
 
     install_dir = paths.dirname(ops_dir.path)
-    tool_inputs, tool_inputs_manifest = ctx.resolve_tools(tools = [ctx.attr.generator])
-    ctx.actions.run_shell(
+    ctx.actions.run(
         outputs = outputs,
         inputs = ctx.files.srcs,
-        command = ctx.executable.generator.path + " $@",
+        executable = ctx.executable.generator,
         arguments = [
             "--source-path",
             "aten/src/ATen",
@@ -74,8 +73,6 @@ def generate_aten_impl(ctx):
             "--install_dir",
             install_dir,
         ],
-        tools = tool_inputs,
-        input_manifests = tool_inputs_manifest,
         use_default_shell_env = True,
         mnemonic = "GenerateAten",
     )


### PR DESCRIPTION
In this case, it's simpler to use ctx.actions.run(executable = ...), which already ensures that the runfiles associated with the executable are present.

(It's also possible to use ctx.actions.run_shell(tools = ...) with a custom command line, but it's unclear to me that indirecting through the shell is needed here.)
