### PR TITLE
Add structured trace logs

### DIFF
--- a/test/dynamo/test_structured_trace.py
+++ b/test/dynamo/test_structured_trace.py
@@ -1,0 +1,351 @@
+# Owner(s): ["module: dynamo"]
+import functools
+import io
+import json
+import logging
+import os
+import unittest.mock
+
+import torch
+import torch._dynamo.test_case
+import torch._dynamo.testing
+import torch._logging.structured
+import torch.distributed as dist
+
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+from torch.testing._internal.common_utils import find_free_port, TestCase
+from torch.testing._internal.inductor_utils import HAS_CUDA
+
+requires_cuda = unittest.skipUnless(HAS_CUDA, "requires cuda")
+requires_distributed = functools.partial(
+    unittest.skipIf, not dist.is_available(), "requires distributed"
+)
+
+
+def example_fn(a):
+    output = a.mul(torch.ones(1000, 1000))
+    output = output.add(torch.ones(1000, 1000))
+    return output
+
+
+def dynamo_error_fn(a):
+    output = a.mul(torch.ones(1000, 1000))
+    output = output.add(torch.ones(10, 10))
+    return output
+
+
+def inductor_error_fn(a):
+    output = torch.round(a)
+    return output
+
+
+def inductor_schedule_fn(a):
+    output = a.add(torch.ones(1000, 1000, device="cuda"))
+    return output
+
+
+ARGS = (torch.ones(1000, 1000, requires_grad=True),)
+
+
+class StructuredTraceTestingFilter(logging.Filter):
+    def filter(self, record):
+        if "str" in record.metadata:
+            return False
+        return True
+
+
+class StructuredTraceTestingFormatter(logging.Formatter):
+    def format(self, record):
+        metadata = dict(record.metadata)
+
+        # Stub out values that are not stable across runs
+        # TODO: Check that these match schema
+        if "has_payload" in metadata:
+            metadata["has_payload"] = "HASH"
+        if "compile_stack" in metadata:
+            metadata["compile_stack"] = "STACK"
+
+        return json.dumps(metadata)
+
+
+trace_log = logging.getLogger("torch.__trace")
+
+
+class StructuredTraceTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        torch._dynamo.reset()
+        torch._logging.structured.INTERN_TABLE.clear()
+        self.buffer = io.StringIO()
+        self.old_level = trace_log.level
+        trace_log.setLevel(logging.DEBUG)
+        self.handler = logging.StreamHandler(self.buffer)
+        self.handler.setFormatter(StructuredTraceTestingFormatter())
+        self.handler.addFilter(StructuredTraceTestingFilter())
+        trace_log.addHandler(self.handler)
+
+    def tearDown(self):
+        trace_log.removeHandler(self.handler)
+        trace_log.setLevel(self.old_level)
+
+    @requires_cuda
+    def test_schedule(self):
+        fn_opt = torch._dynamo.optimize("inductor")(inductor_schedule_fn)
+        fn_opt(torch.ones(1000, 1000, device="cuda"))
+        self.assertExpectedInline(
+            self.buffer.getvalue(),
+            """\
+{"compile_stack": "STACK", "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"dynamo_output_graph": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"dynamo_output_graph_sizes": {"l_a_": [1000, 1000], "ones": [1000, 1000], "output": [1000, 1000]}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"aot_forward_graph": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"inductor_post_grad_graph": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"inductor_output_code": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"dynamo_guards": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+""",  # noqa: B950
+        )
+
+    @requires_cuda
+    def test_cudagraphs(self):
+        fn_opt = torch.compile(mode="reduce-overhead")(inductor_schedule_fn)
+        fn_opt(torch.ones(1000, 1000, device="cuda"))
+        self.assertExpectedInline(
+            self.buffer.getvalue(),
+            """\
+{"compile_stack": "STACK", "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"dynamo_output_graph": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"dynamo_output_graph_sizes": {"l_a_": [1000, 1000], "ones": [1000, 1000], "output": [1000, 1000]}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"aot_forward_graph": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"inductor_post_grad_graph": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"inductor_output_code": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"dynamo_guards": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+""",  # noqa: B950
+        )
+
+    def test_recompiles(self):
+        def fn(x, y):
+            return torch.add(x, y)
+
+        fn_opt = torch._dynamo.optimize("inductor")(fn)
+        fn_opt(torch.ones(1000, 1000), torch.ones(1000, 1000))
+        fn_opt(torch.ones(1000, 1000), 1)
+
+        self.assertExpectedInline(
+            self.buffer.getvalue(),
+            """\
+{"compile_stack": "STACK", "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"dynamo_output_graph": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"dynamo_output_graph_sizes": {"l_x_": [1000, 1000], "l_y_": [1000, 1000], "add": [1000, 1000]}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"aot_forward_graph": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"inductor_post_grad_graph": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"inductor_output_code": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"dynamo_guards": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"compile_stack": "STACK", "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
+{"dynamo_output_graph": true, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
+{"dynamo_output_graph_sizes": {"l_x_": [1000, 1000], "add": [1000, 1000]}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
+{"aot_forward_graph": true, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
+{"inductor_post_grad_graph": true, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
+{"inductor_output_code": true, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
+{"dynamo_guards": true, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
+""",  # noqa: B950
+        )
+
+    def test_example_fn(self):
+        fn_opt = torch._dynamo.optimize("inductor")(example_fn)
+        fn_opt(torch.ones(1000, 1000))
+        self.assertExpectedInline(
+            self.buffer.getvalue(),
+            """\
+{"compile_stack": "STACK", "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"dynamo_output_graph": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"dynamo_output_graph_sizes": {"l_a_": [1000, 1000], "ones": [1000, 1000], "output": [1000, 1000], "ones_1": [1000, 1000], "output_1": [1000, 1000]}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"aot_forward_graph": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"inductor_post_grad_graph": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"inductor_output_code": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"dynamo_guards": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+""",  # noqa: B950
+        )
+
+    def test_dynamo_error(self):
+        try:
+            fn_opt = torch._dynamo.optimize("inductor")(dynamo_error_fn)
+            fn_opt(*ARGS)
+        except Exception:
+            pass
+        self.assertExpectedInline(
+            self.buffer.getvalue(),
+            """\
+{"compile_stack": "STACK", "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+""",  # noqa: B950
+        )
+
+    def test_inductor_error(self):
+        import torch._inductor.lowering
+
+        def throw(x):
+            raise AssertionError()
+
+        # inject an error in the lowerings
+        dict_entries = {}
+        for x in list(torch._inductor.lowering.lowerings.keys()):
+            if "round" in x.__name__:
+                dict_entries[x] = throw
+
+        with unittest.mock.patch.dict(torch._inductor.lowering.lowerings, dict_entries):
+            try:
+                fn_opt = torch._dynamo.optimize("inductor")(inductor_error_fn)
+                fn_opt(*ARGS)
+            except Exception:
+                pass
+
+        self.assertExpectedInline(
+            self.buffer.getvalue(),
+            """\
+{"compile_stack": "STACK", "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"dynamo_output_graph": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"dynamo_output_graph_sizes": {"l_a_": [1000, 1000], "output": [1000, 1000]}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"aot_joint_graph": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"aot_forward_graph": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"aot_backward_graph": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"inductor_post_grad_graph": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+""",  # noqa: B950
+        )
+
+    @requires_distributed()
+    @requires_cuda
+    def test_ddp_graphs(self):
+        class ToyModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = torch.nn.Sequential(
+                    torch.nn.Linear(1024, 1024),
+                    torch.nn.Linear(1024, 1024),
+                )
+
+            def forward(self, x):
+                return self.layers(x)
+
+        # TODO: this isn't safely bracketed, will leak
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        dist.init_process_group("gloo", rank=0, world_size=1)
+
+        ddp_model = torch._dynamo.optimize("inductor")(
+            DDP(ToyModel().to("cuda:0"), device_ids=[0], bucket_cap_mb=4)
+        )
+
+        ddp_model(torch.randn(1024, 1024, device="cuda:0"))
+
+        dist.destroy_process_group()
+
+        self.assertExpectedInline(
+            self.buffer.getvalue(),
+            """\
+{"compile_stack": "STACK", "rank": 0, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"dynamo_guards": true, "rank": 0, "frame_id": 0, "frame_compile_id": 0, "attempt": 1, "has_payload": "HASH"}
+{"compile_stack": "STACK", "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0}
+{"dynamo_output_graph": true, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"dynamo_output_graph_sizes": {"l_x_": [1024, 1024], "l__self___layers_0": [1024, 1024], "l__self___layers_1": [1024, 1024]}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0}
+{"optimize_ddp_split_graph": true, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"optimize_ddp_split_child": {"name": "submod_0"}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"optimize_ddp_split_child": {"name": "submod_1"}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"aot_joint_graph": true, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"aot_forward_graph": true, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"aot_backward_graph": true, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"inductor_post_grad_graph": true, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"inductor_output_code": true, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"aot_joint_graph": true, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"aot_forward_graph": true, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"aot_backward_graph": true, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"inductor_post_grad_graph": true, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"inductor_output_code": true, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"dynamo_guards": true, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+""",  # noqa: B950
+        )
+
+    def test_graph_breaks(self):
+        @torch._dynamo.optimize("inductor")
+        def fn(x):
+            torch._dynamo.graph_break()
+            return x + 1
+
+        fn(torch.ones(1))
+
+        self.assertExpectedInline(
+            self.buffer.getvalue(),
+            """\
+{"compile_stack": "STACK", "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"dynamo_guards": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 1, "has_payload": "HASH"}
+{"compile_stack": "STACK", "frame_id": 1, "frame_compile_id": 0, "attempt": 0}
+{"dynamo_output_graph": true, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"dynamo_output_graph_sizes": {"l_x_": [1], "add": [1]}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0}
+{"aot_forward_graph": true, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"inductor_post_grad_graph": true, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"inductor_output_code": true, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"dynamo_guards": true, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+""",  # noqa: B950
+        )
+
+    # TODO: bring in the trace_source tests once we start emitting bytecode
+
+    def test_graph_sizes_dynamic(self):
+        def fn(a, b):
+            return a @ b
+
+        fn_opt = torch._dynamo.optimize("eager", dynamic=False)(fn)
+        fn_opt(torch.randn(10, 20), torch.randn(20, 30))
+
+        fn_opt2 = torch._dynamo.optimize("eager", dynamic=True)(fn)
+        fn_opt2(torch.randn(5, 10), torch.randn(10, 15))
+
+        self.assertExpectedInline(
+            self.buffer.getvalue(),
+            """\
+{"compile_stack": "STACK", "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"dynamo_output_graph": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"dynamo_output_graph_sizes": {"l_a_": [10, 20], "l_b_": [20, 30], "matmul": [10, 30]}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"dynamo_guards": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"compile_stack": "STACK", "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
+{"dynamo_output_graph": true, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
+{"dynamo_output_graph_sizes": {"l_a_": ["s0", "s1"], "l_b_": ["s1", "s3"], "matmul": ["s0", "s3"]}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
+{"dynamo_guards": true, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
+""",  # noqa: B950
+        )
+
+    def test_guards_recompiles(self):
+        def fn(x, ys, zs):
+            return inner(x, ys, zs)
+
+        def inner(x, ys, zs):
+            for y, z in zip(ys, zs):
+                x += y * z
+            return x
+
+        ys = [1.0, 2.0]
+        zs = [3.0]
+        x = torch.tensor([1.0])
+
+        fn_opt = torch._dynamo.optimize("eager")(fn)
+        fn_opt(x, ys, zs)
+        fn_opt(x, ys[:1], zs)
+
+        self.assertExpectedInline(
+            self.buffer.getvalue(),
+            """\
+{"compile_stack": "STACK", "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"dynamo_output_graph": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"dynamo_output_graph_sizes": {"l_x_": [1], "x": [1]}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"dynamo_guards": true, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"compile_stack": "STACK", "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
+{"dynamo_output_graph": true, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
+{"dynamo_output_graph_sizes": {"l_x_": [1], "x": [1]}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
+{"dynamo_guards": true, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
+""",  # noqa: B950
+        )
+
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    run_tests()

--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -78,6 +78,8 @@ def reset() -> None:
         _reset_guarded_backend_cache()
         reset_frame_count()
         torch._C._dynamo.compiled_autograd.clear_cache()
+        convert_frame.FRAME_COUNTER = 0
+        convert_frame.FRAME_COMPILE_COUNTER.clear()
 
 
 def reset_code_caches() -> None:

--- a/torch/_dynamo/backends/distributed.py
+++ b/torch/_dynamo/backends/distributed.py
@@ -9,6 +9,7 @@ import torch
 from torch import fx
 from torch._dynamo.output_graph import GraphCompileReason
 from torch._dynamo.utils import deepcopy_to_fake_tensor, detect_fake_mode
+from torch._logging import trace_structured
 from torch.fx.node import Node
 
 # Regular log messages should go through 'log'.
@@ -311,6 +312,18 @@ class DDPOptimizer:
                 debug_str += f"\n---{name} graph---\n{module.graph}\n"
         debug_str += "\n---------------\n"
         ddp_graph_log.debug(debug_str)
+
+        trace_structured(
+            "optimize_ddp_split_graph",
+            payload_fn=lambda: split_gm.print_readable(print_output=False),
+        )
+        for name, module in split_gm.named_modules():
+            if "." not in name and len(name):
+                trace_structured(
+                    "optimize_ddp_split_child",
+                    lambda: {"name": name},
+                    payload_fn=lambda: module.print_readable(print_output=False),
+                )
 
         # 3 (lazy compile): Replace submodules with lazily compiling submodule
         class SubmoduleReplacer(torch.fx.interpreter.Interpreter):

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -6,7 +6,7 @@ import torch
 from torch._dynamo.external_utils import call_backward, call_hook
 from torch._dynamo.source import GetItemSource, LocalSource
 from torch._dynamo.utils import counters, lazy_format_graph_code
-from torch._logging import getArtifactLogger
+from torch._logging import getArtifactLogger, trace_structured
 from torch._prims_common import clone_preserve_strides
 from torch._subclasses import FakeTensorMode
 from torch.fx import GraphModule
@@ -200,6 +200,10 @@ class AutogradCompilerInstance:
         )
         compiled_autograd_log.info(
             "%s", lazy_format_graph_code("Compiled autograd graph", graph)
+        )
+        trace_structured(
+            "compiled_autograd_graph",
+            payload_fn=lambda: graph.print_readable(print_output=False),
         )
         return self.compiler_fn(graph)
 

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -26,6 +26,7 @@ except ModuleNotFoundError:
 import torch
 import torch._logging
 from torch._guards import compile_context, CompileContext, CompileId, tracing
+from torch._logging import structured
 from torch._utils_internal import signpost_event
 from torch.fx.experimental.symbolic_shapes import (
     ConstraintViolationError,
@@ -665,6 +666,11 @@ def _compile(
             skip + 2,
             # -2: omit current frame, omit contextlib decorator
             "".join(traceback.format_list(traceback.extract_stack()[: -2 - skip])),
+        )
+        # -4: -2 as above, plus trace_structured frames
+        torch._logging.trace_structured(
+            "compile_stack",
+            lambda: structured.from_traceback(traceback.extract_stack()[: -4 - skip]),
         )
         start_time = time.time()
         try:

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -43,12 +43,13 @@ from torch._guards import (
     GuardSource,
     Source,
 )
+
+from torch._logging import structured
 from torch.fx.experimental.symbolic_shapes import (
     EqualityConstraint,
     is_symbolic,
     SYMPY_INTERP,
 )
-
 from torch.utils._traceback import format_frame, report_compile_source_on_error
 from torch.utils.weak import TensorWeakRef
 
@@ -1031,6 +1032,8 @@ class CheckFunctionManager:
         code_parts = ["___check_global_state()"]
         verbose_code_parts = code_parts[:]
 
+        structured_guard_fns = []
+
         def add_code_part(code, guard, log_only=False):
             extra = ""
             if guard.user_stack:
@@ -1042,6 +1045,17 @@ class CheckFunctionManager:
                 extra = f"  # {format_frame(guard.stack.summary()[-1])}"
 
             guards_log.debug("%s", f"{code:<60}{extra}")
+            structured_guard_fns.append(
+                lambda: {
+                    "code": code,
+                    "stack": structured.from_traceback(guard.stack.summary())
+                    if guard.stack
+                    else None,
+                    "user_stack": structured.from_traceback(guard.user_stack)
+                    if guard.user_stack
+                    else None,
+                }
+            )
 
             if verbose_guards_log.isEnabledFor(logging.DEBUG):
                 maybe_stack = ""
@@ -1154,6 +1168,11 @@ class CheckFunctionManager:
         for gcl in builder.shape_env_code:
             for code in gcl.code_list:
                 add_code_part(code, gcl.guard)
+
+        # OK, all done generating guards
+        torch._logging.trace_structured(
+            "dynamo_guards", payload_fn=lambda: [f() for f in structured_guard_fns]
+        )
 
         global_state = convert_frame.initial_global_state
         if global_state is None:

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -999,7 +999,16 @@ class OutputGraph(Checkpointable[OutputGraphState]):
                     self.graph.erase_node(node1)
                     self.graph.erase_node(node2)
 
-    def get_graph_sizes_log_str(self, name):
+    def get_graph_sizes_structured(self):
+        ret = {}
+        for node in self.graph.nodes:
+            example_value = node.meta.get("example_value", None)
+            if isinstance(example_value, torch._subclasses.FakeTensor):
+                size = example_value.size()
+                ret[node.name] = [s if isinstance(s, int) else repr(s) for s in size]
+        return ret
+
+    def get_graph_sizes(self, name: str):
         graph_sizes_str = "TRACED GRAPH TENSOR SIZES\n"
         graph_sizes_str += f"===== {name} =====\n"
         for node in self.graph.nodes:
@@ -1082,9 +1091,14 @@ class OutputGraph(Checkpointable[OutputGraphState]):
         ] = self.dynamo_flat_name_to_original_fqn.copy()
 
         graph_code_log.debug("%s", lazy_format_graph_code(name, gm))
+        torch._logging.trace_structured(
+            "dynamo_output_graph",
+            payload_fn=lambda: gm.print_readable(print_output=False),
+        )
         graph_tabular_log.debug("%s", lazy_format_graph_tabular(name, gm))
-        graph_sizes_log.debug(
-            "%s", LazyString(lambda: self.get_graph_sizes_log_str(name))
+        graph_sizes_log.debug("%s", LazyString(lambda: self.get_graph_sizes(name)))
+        torch._logging.trace_structured(
+            "dynamo_output_graph_sizes", lambda: self.get_graph_sizes_structured()
         )
         self.call_cleanup_hooks()
         old_fake_mode = self.tracing_context.fake_mode

--- a/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
+++ b/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
@@ -8,13 +8,13 @@ a functionalized version of the graph under compilation.
 """
 
 import collections
+import logging
 from functools import wraps
 from typing import Callable, DefaultDict, Dict, List
 
 import torch
 import torch.utils._pytree as pytree
 from torch import Tensor
-from torch._logging import getArtifactLogger
 from torch._subclasses.functional_tensor import FunctionalTensor, FunctionalTensorMode
 from torch._subclasses.meta_utils import safe_is_leaf
 from torch.fx.experimental.symbolic_shapes import is_concrete_int
@@ -45,7 +45,7 @@ from .utils import _get_autocast_states, KNOWN_TYPES, strict_zip
 
 zip = strict_zip
 
-aot_graphs_log = getArtifactLogger(__name__, "aot_graphs")
+log = logging.getLogger(__name__)
 
 
 # This is a version of functionalization that is specifically designed
@@ -413,7 +413,7 @@ def run_functionalized_fw_and_collect_metadata(
                     # However, autograd does not allow users to mutate multi-output views
                     # in any way that can change the autograd metadata of other aliases.
                     # So we hide this aliasing from autograd here.
-                    aot_graphs_log.info(
+                    log.debug(
                         "Encountered AOTAutograd case: differentiable outputs that \
 alias each other from a multi-output view call"
                     )
@@ -455,7 +455,7 @@ alias each other from a multi-output view call"
                         out_tensor_alias_counts[curr_storage] != 1
                         and num_aliased_outs_that_are_not_multi_output_views <= 1
                     ):
-                        aot_graphs_log.info(
+                        log.debug(
                             "Encountered AOTAutograd case: differentiable outputs that alias each other \
 from a multi-output view call"
                         )
@@ -599,7 +599,7 @@ from a multi-output view call"
             torch.set_grad_enabled(
                 prior_grad_enabled
             )  # Restore the prior state after tracing it
-            aot_graphs_log.info(
+            log.debug(
                 (
                     "grad_mode mutation encountered in graph. "
                     "Will emit mutation epilogue, to set grad_mode=%s"

--- a/torch/_functorch/_aot_autograd/dispatch_and_compile_graph.py
+++ b/torch/_functorch/_aot_autograd/dispatch_and_compile_graph.py
@@ -11,7 +11,7 @@ import torch.utils.dlpack
 from torch import Tensor
 from torch._dispatch.python import enable_python_dispatcher
 from torch._dynamo.utils import lazy_format_graph_code
-from torch._logging import getArtifactLogger
+from torch._logging import getArtifactLogger, trace_structured
 from torch._subclasses.functional_tensor import FunctionalTensorMode
 from torch.fx.experimental.proxy_tensor import make_fx
 
@@ -108,6 +108,10 @@ def aot_dispatch_base_graph(
     if aot_config.enable_log:
         aot_graphs_log.info(
             "%s", lazy_format_graph_code("Forward graph", fw_module, aot_config.aot_id)
+        )
+        trace_structured(
+            "aot_forward_graph",
+            payload_fn=lambda: fw_module.print_readable(print_output=False),
         )
 
     # TODO: should factor this into a separate function for export that always only returns just the graph.

--- a/torch/_functorch/_aot_autograd/input_output_analysis.py
+++ b/torch/_functorch/_aot_autograd/input_output_analysis.py
@@ -15,7 +15,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import torch
 import torch.utils._pytree as pytree
 from torch import Tensor
-from torch._logging import getArtifactLogger
 from torch._subclasses.functional_tensor import FunctionalTensor
 from torch.fx.experimental.symbolic_shapes import is_concrete_int
 from .schemas import (
@@ -29,8 +28,6 @@ from .schemas import (
 from .utils import strict_zip
 
 zip = strict_zip
-
-aot_graphs_log = getArtifactLogger(__name__, "aot_graphs")
 
 
 def remove_dupe_metadata(

--- a/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
@@ -18,7 +18,7 @@ import torch.utils.dlpack
 from torch import Tensor
 from torch._dynamo.utils import lazy_format_graph_code
 from torch._guards import detect_fake_mode, tracing, TracingContext
-from torch._logging import getArtifactLogger
+from torch._logging import getArtifactLogger, trace_structured
 from torch._prims_common import CUDARngStateHelper
 from torch._subclasses import FakeTensor
 from torch.fx.experimental.proxy_tensor import is_sym_node
@@ -168,6 +168,10 @@ def aot_dispatch_autograd(
         aot_joint_log.info(
             "%s", lazy_format_graph_code("Joint graph", fx_g, aot_config.aot_id)
         )
+        trace_structured(
+            "aot_joint_graph",
+            payload_fn=lambda: fx_g.print_readable(print_output=False),  # type: ignore[union-attr]
+        )
 
     with torch.no_grad():
         inner_meta = (
@@ -286,6 +290,14 @@ def aot_dispatch_autograd(
             aot_graphs_log.info(
                 "%s",
                 lazy_format_graph_code("Backward graph", bw_module, aot_config.aot_id),
+            )
+            trace_structured(
+                "aot_forward_graph",
+                payload_fn=lambda: fw_module.print_readable(print_output=False),
+            )
+            trace_structured(
+                "aot_backward_graph",
+                payload_fn=lambda: bw_module.print_readable(print_output=False),
             )
 
         with track_graph_compiling(aot_config, "forward"):

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -16,7 +16,7 @@ import torch._logging
 import torch.fx
 from torch._decomp import get_decompositions
 from torch._dynamo.utils import defake, dynamo_timed
-from torch._logging import LazyString
+from torch._logging import LazyString, trace_structured
 from torch._subclasses.fake_tensor import FakeTensor
 from torch.fx.experimental.sym_node import magic_methods, method_to_operator
 from torch.fx.experimental.symbolic_shapes import has_free_symbols, ShapeEnv, SymTypes
@@ -1242,6 +1242,10 @@ class GraphLowering(torch.fx.Interpreter):
         log_module_code(mod.__file__)
         log.debug("Output code written to: %s", mod.__file__)
         output_code_log.debug("Output code: \n%s", code)
+        trace_structured(
+            "inductor_output_code",
+            payload_fn=lambda: code,
+        )
         output_code_log.info("Output code written to: %s", mod.__file__)
         if config.benchmark_kernel:
             print(f"Compiled module path: {mod.__file__}", file=sys.stderr)

--- a/torch/_logging/__init__.py
+++ b/torch/_logging/__init__.py
@@ -11,5 +11,6 @@ from ._internal import (
     getArtifactLogger,
     LazyString,
     set_logs,
+    trace_structured,
     warning_once,
 )

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -1,20 +1,37 @@
 import functools
+import hashlib
 import itertools
+import json
 import logging
 import os
 import os.path
 import re
+import tempfile
 from dataclasses import dataclass, field
 from importlib import __import__
-from typing import Dict, List, Optional, Set, Union
+from typing import Callable, Dict, List, Optional, Set, Union
 from weakref import WeakSet
 
 log = logging.getLogger(__name__)
+
+# This is a synthetic logger which doesn't correspond to an actual logger,
+# but handles all of our "tracing" logging, which is structured and doesn't go
+# to stderr but always goes to a dedicated log file.  We don't put these
+# loggers in the classic module hierarchy, because we don't want a suppression
+# of logs to also cause a trace to get suppressed (traces typically are not
+# collected, unless we are in prod, in which case they always are collected.)
+#
+# TODO: Maybe we should allow for some sub-hierarchy so you can control which
+# traces you want to collect, for performance reasons.
+#
+# See https://docs.google.com/document/d/1CX_hJ0PNy9f3R1y8TJrfkSeLkvGjjjLU84BSXgS2AZ8/edit
+trace_log = logging.getLogger("torch.__trace")
 
 DEFAULT_LOG_LEVEL = logging.WARNING
 LOG_ENV_VAR = "TORCH_LOGS"
 LOG_OUT_ENV_VAR = "TORCH_LOGS_OUT"
 LOG_FORMAT_ENV_VAR = "TORCH_LOGS_FORMAT"
+TRACE_ENV_VAR = "TORCH_TRACE"
 
 
 @dataclass
@@ -697,6 +714,10 @@ def _has_registered_parent(log_qname):
 
 # apply custom formats to artifacts when necessary
 class TorchLogsFormatter(logging.Formatter):
+    def __init__(self, *, trace: bool = False):
+        super().__init__()
+        self._is_trace = trace
+
     def format(self, record):
         artifact_name = getattr(logging.getLogger(record.name), "artifact_name", None)
         if artifact_name is not None:
@@ -725,13 +746,16 @@ class TorchLogsFormatter(logging.Formatter):
                 s = s + "\n"
             s = s + self.formatStack(record.stack_info)
 
-        lines = s.split("\n")
         record.rankprefix = ""
-        if dist.is_available() and dist.is_initialized():
+        if not self._is_trace and dist.is_available() and dist.is_initialized():
             record.rankprefix = f"[rank{dist.get_rank()}]:"
 
         record.traceid = ""
-        if (trace_id := torch._guards.CompileContext.current_trace_id()) is not None:
+        if (
+            not self._is_trace
+            and (trace_id := torch._guards.CompileContext.current_trace_id())
+            is not None
+        ):
             record.traceid = f" [{trace_id}]"
 
         glog_level_to_abbr = {
@@ -749,7 +773,15 @@ class TorchLogsFormatter(logging.Formatter):
             f"{os.path.relpath(record.pathname, os.path.dirname(os.path.dirname(torch.__file__)))}:"
             f"{record.lineno}]{record.traceid}"
         )
-        return "\n".join(f"{prefix} {l}" for l in lines)
+        if self._is_trace:
+            assert s == ""
+            r = f"{prefix} {json.dumps(record.metadata)}"
+            if record.payload is not None:
+                r += "".join(f"\n\t{l}" for l in record.payload.split("\n"))
+            return r
+        else:
+            lines = s.split("\n")
+            return "\n".join(f"{prefix} {l}" for l in lines)
 
 
 def _default_formatter():
@@ -807,6 +839,10 @@ def _reset_logs():
         log.setLevel(logging.NOTSET)
         log.propagate = True
 
+    trace_log.setLevel(logging.WARNING)
+    trace_log.propagate = False
+    _clear_handlers(trace_log)
+
 
 def _get_log_state():
     return log_state
@@ -861,6 +897,84 @@ def _init_logs(log_file_name=None):
         log = logging.getLogger(artifact_log_qname)
         configure_artifact_log(log)
 
+    # Setup handler for the special trace_log, with different default
+    # configuration
+    #
+    # TODO: Automatically initialize this in Tupperware environment to point
+    # to /logs/dedicated_logs_XXX
+    trace_file_name = os.environ.get(TRACE_ENV_VAR, None)
+    handler: Optional[logging.Handler] = None
+    TRACE_LOG_DIR = "/logs"
+    if trace_file_name is not None:
+        handler = logging.FileHandler(trace_file_name)
+    elif (
+        is_fbcode()
+        and os.path.exists(TRACE_LOG_DIR)
+        and os.access(TRACE_LOG_DIR, os.W_OK)
+        and torch._utils_internal.justknobs_check("pytorch/trace:enable")
+    ):
+
+        def filename_cb():
+            ranksuffix = ""
+            if dist.is_available() and dist.is_initialized():
+                ranksuffix = f"rank_{dist.get_rank()}_"
+            _, filename = tempfile.mkstemp(
+                suffix=".log",
+                prefix=f"dedicated_log_torch_trace_{ranksuffix}",
+                dir=TRACE_LOG_DIR,
+            )
+            log.info("Automatically enabled TORCH_TRACE=%s", filename)
+            return filename
+
+        handler = FreshFileHandler(filename_cb)
+    if handler is not None:
+        trace_log.setLevel(logging.DEBUG)
+        trace_log_handler = _track_handler(handler)
+        trace_log_handler.setFormatter(TorchLogsFormatter(trace=True))
+        trace_log.addHandler(trace_log_handler)
+
+
+class FreshFileHandler(logging.StreamHandler):
+    """Like FileHandler, but the file is allocated lazily only upon the first log message"""
+
+    def __init__(self, filename_cb):
+        self.filename_cb = filename_cb
+        self.filename = None
+        # This is implemented in the same way that delay is implemented on
+        # FileHandler
+        logging.Handler.__init__(self)
+        self.stream = None
+        self._builtin_open = open
+
+    # cloned from FileHandler in cpython
+    def close(self):
+        self.acquire()
+        try:
+            try:
+                if self.stream:
+                    try:
+                        self.flush()
+                    finally:
+                        stream = self.stream
+                        self.stream = None
+                        if hasattr(stream, "close"):
+                            stream.close()
+            finally:
+                # Issue #19523: call unconditionally to
+                # prevent a handler leak when delay is set
+                # Also see Issue #42378: we also rely on
+                # self._closed being set to True there
+                logging.StreamHandler.close(self)
+        finally:
+            self.release()
+
+    def emit(self, record):
+        if self.stream is None:
+            open_func = self._builtin_open
+            self.stream = open_func(self.filename_cb(), "w")
+        if self.stream:
+            super().emit(record)
+
 
 @functools.lru_cache(None)
 def warning_once(logger_obj, *args, **kwargs):
@@ -883,5 +997,64 @@ class LazyString:
         return self.func(*self.args, **self.kwargs)
 
 
+def is_fbcode():
+    return not hasattr(torch.version, "git_version")
+
+
+def trace_structured(
+    name: str,
+    metadata_fn: Callable[[], object] = lambda: True,
+    *,
+    payload_fn: Callable[[], Optional[Union[str, object]]] = lambda: None,
+    suppress_context: bool = False,
+):
+    """
+    metadata is an arbitrary JSON compatible struct, but it's expected to not be
+    too long (e.g., less than 1MB)
+
+    payload is an arbitrary string, which can be arbitrarily long (but expected to have
+    newlines so no lines are too long)
+    """
+    assert "name" not in ["rank", "frame_id", "frame_compile_id", "attempt"]
+    assert callable(
+        metadata_fn
+    ), f"metadata_fn should be callable, but got {type(metadata_fn)}"
+    assert callable(
+        payload_fn
+    ), f"payload_fn should be callable, but got {type(payload_fn)}"
+    if trace_log.isEnabledFor(logging.DEBUG):
+        record = {}
+        record[name] = metadata_fn()
+        if not suppress_context:
+            # TODO: Actually, the rank probably should just be emitted once at
+            # the top, and not repeatedly spammed in all the logs, since it
+            # never changes and we assume no interleaving
+            if dist.is_available() and dist.is_initialized():
+                record["rank"] = dist.get_rank()
+            if (
+                trace_id := torch._guards.CompileContext.current_trace_id()
+            ) is not None:
+                record["frame_id"] = trace_id.compile_id.frame_id
+                record["frame_compile_id"] = trace_id.compile_id.frame_compile_id
+                record["attempt"] = trace_id.attempt
+        payload = payload_fn()
+        if payload is not None:
+            if not isinstance(payload, str):
+                if isinstance(payload, list):
+                    # special case to look better
+                    payload = "[\n" + ",\n".join(json.dumps(i) for i in payload) + "\n]"
+                else:
+                    # force newlines so we are unlikely to overflow line limit
+                    payload = json.dumps(payload, indent=0)
+            h = hashlib.md5()
+            h.update(payload.encode("utf-8"))
+            record["has_payload"] = h.hexdigest()
+        trace_log.debug(
+            "", extra={"metadata": record, "payload": payload}, stacklevel=2
+        )
+
+
 import torch._guards
+import torch._utils_internal
 import torch.distributed as dist
+import torch.version

--- a/torch/_logging/structured.py
+++ b/torch/_logging/structured.py
@@ -1,0 +1,37 @@
+"""
+Utilities for converting data types into structured JSON for dumping.
+"""
+
+import traceback
+from typing import Dict, Sequence
+
+import torch._logging._internal
+
+
+INTERN_TABLE: Dict[str, int] = {}
+
+
+def intern_string(s: str) -> int:
+    r = INTERN_TABLE.get(s, None)
+    if r is None:
+        r = len(INTERN_TABLE)
+        INTERN_TABLE[s] = r
+        torch._logging._internal.trace_structured(
+            "str", lambda: [s, r], suppress_context=True
+        )
+    return r
+
+
+def from_traceback(tb: Sequence[traceback.FrameSummary]) -> object:
+    r = []
+    for frame in tb:
+        # dict naming convention here coincides with
+        # python/combined_traceback.cpp
+        r.append(
+            {
+                "line": frame.lineno,
+                "name": frame.name,
+                "filename": intern_string(frame.filename),
+            }
+        )
+    return r

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -95,6 +95,28 @@ def log_export_usage(**kwargs):
     pass
 
 
+def justknobs_check(name: str) -> bool:
+    """
+    This function can be used to killswitch functionality in FB prod,
+    where you can toggle this value to False in JK without having to
+    do a code push.  In OSS, we always have everything turned on all
+    the time, because downstream users can simply choose to not update
+    PyTorch.  (If more fine-grained enable/disable is needed, we could
+    potentially have a map we lookup name in to toggle behavior.  But
+    the point is that it's all tied to source code in OSS, since there's
+    no live server to query.)
+
+    This is the bare minimum functionality I needed to do some killswitches.
+    We have a more detailed plan at
+    https://docs.google.com/document/d/1Ukerh9_42SeGh89J-tGtecpHBPwGlkQ043pddkKb3PU/edit
+    In particular, in some circumstances it may be necessary to read in
+    a knob once at process start, and then use it consistently for the
+    rest of the process.  Future functionality will codify these patterns
+    into a better high level API.
+    """
+    return True
+
+
 @functools.lru_cache(None)
 def max_clock_rate():
     from triton.testing import nvsmi


### PR DESCRIPTION
Summary:
Overall design: https://docs.google.com/document/d/1CX_hJ0PNy9f3R1y8TJrfkSeLkvGjjjLU84BSXgS2AZ8/edit

How to read the diff:
* Most files are me augmenting pre-existing logging with structured variants. For the most part it's simple (esp FX graphs, which have a canonical string representation); it gets more complicated when I decided to JSON-ify some data structure instead of keeping the ad hoc printing (notably, guards and dynamo output graph sizes)
* torch/_functorch/_aot_autograd/collect_metadata_analysis.py is some unrelated fixes I noticed while auditing artifact logs
* torch/_logging/_internal.py has the actual trace log implementation. The trace logger is implement as a logger named torch.__trace which is disconnected from the logging hierarchy. It gets its own handler and formatter (TorchLogsFormatter with _is_trace True). There's a teensy bit of FB specific code to automatically enable trace logging if a /logs directory exists. `trace_structured` is the main way to emit a trace log. Unusually, there's a separate "metadata" and "payload" field. The metadata field should not be too long (as it is serialized as a single line) and is always JSON (we put contextual things like compile id in it); the payload field can be long and is emitted after the metadata log line and can span multiple lines.
* torch/_logging/structured.py contains some helpers for converting Python data structures into JSON form. Notably, we have a string interning implementation here, which helps reduce the cost of serializing filenames into the log.
* test/dynamo/test_structured_trace.py the tests are cribbed from test_logging.py, but all rewritten to use expect tests on munged versions of what we'd actually output. Payloads are never tested, since they tend not be very stable.

https://github.com/ezyang/tlparse is a POC Rust program that can interpret these logs.

Test Plan:
OSS CI

https://www.internalfb.com/mlhub/pipelines/runs/fblearner/534553450

Differential Revision: D54119507




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames