### PR TITLE
[c10d] fix the macro definition of NCCL_COMM_DUMP

### DIFF
--- a/torch/csrc/distributed/c10d/NCCLUtils.hpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.hpp
@@ -300,8 +300,7 @@ class NCCLComm {
   }
 #endif
 
-#ifdef IS_NCCL_EXP
-#ifdef NCCL_COMM_DUMP
+#if defined(IS_NCCL_EXP) && defined(NCCL_COMM_DUMP)
   std::unordered_map<std::string, std::string> ncclCommDump() {
     std::unordered_map<std::string, std::string> dump;
     if (isAborted()) {
@@ -311,7 +310,6 @@ class NCCLComm {
     C10D_NCCL_CHECK(::ncclCommDump(ncclComm_, dump), c10::nullopt);
     return dump;
   }
-#endif
 #endif
 
   ncclUniqueId getNcclId() {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -309,8 +309,7 @@ void cacheAllocatorDeregisterHook(
   }
 }
 
-#ifdef IS_NCCL_EXP
-#ifdef NCCL_COMM_DUMP
+#if defined(IS_NCCL_EXP) && defined(NCCL_COMM_DUMP)
 std::string dump_nccl_trace() {
   std::unordered_map<
       std::string /* ncclUniqueID */,
@@ -333,7 +332,6 @@ std::string dump_nccl_trace() {
   }
   return NCCLTraceBuffer::get()->dump(ncclDumpMap);
 }
-#endif
 #else
 std::string dump_nccl_trace() {
   return NCCLTraceBuffer::get()->dump(c10::nullopt);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120502

Summary:
Only if both macros are defined, should we dump the comm dump,
otherwise, use the original definition.

The previous implementation missed the function definition when IS_NCCL_EXP is defined but NCCL_COMM_DUMP is not defined 

Test Plan:
Build and unit test

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225