### PR TITLE
[PT2] tolist() support for FunctionalTensor

### DIFF
--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -209,6 +209,10 @@ class FunctionalTensor(torch.Tensor):
     def mark_mutation_hidden_from_autograd(self) -> None:
         torch._functionalize_mark_mutation_hidden_from_autograd(self.elem)
 
+    def tolist(self):
+        assert self.elem.dim() == 1, "tolist() only supported on 1D tensors currently"
+        return [elem.item() for elem in self.elem]
+
 
 class FunctionalTensorMode(TorchDispatchMode):
     def __init__(self, pre_dispatch=False, export=False):


### PR DESCRIPTION
Summary: Support tolist() for FunctionalTensor for KJT in torch.export

Test Plan: CI

Differential Revision: D53731064

@diff-train-skip-merge


