### PR TITLE
[Inductor] Track constant's original_fqn mapping 

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -561,10 +561,16 @@ class CppWrapperCpu(WrapperCodeGen):
                     f"constants_info_[{idx}].stride = {{{stride_str}}};"
                 )
                 if name in V.graph.dynamo_flat_name_to_original_fqn:
-                    self.prefix.writeline(
-                        f"""constants_info_[{idx}].original_fqn = "{V.graph.dynamo_flat_name_to_original_fqn[name]}";"""
+                    original_fqn = V.graph.dynamo_flat_name_to_original_fqn.get(
+                        name, name
                     )
-
+                elif name in V.graph.allocated_constant_name:
+                    original_fqn = V.graph.allocated_constant_name[name]
+                else:
+                    raise AssertionError("original_fqn must be set for constant")
+                self.prefix.writeline(
+                    f"""constants_info_[{idx}].original_fqn = "{original_fqn}";"""
+                )
             self.prefix.writeline("update_constants_map(std::move(constants_map));")
             self.prefix.writeline("update_constants_array(std::move(constants_array));")
 

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -307,6 +307,9 @@ class GraphLowering(torch.fx.Interpreter):
         self.dynamo_flat_name_to_original_fqn = self.module.meta.get(
             "dynamo_flat_name_to_original_fqn", {}
         )
+        self.allocated_constant_name = (
+            const_module.allocated_constant_name if const_module is not None else {}
+        )
         self.init_backend_registration()
 
     @staticmethod
@@ -690,11 +693,12 @@ class GraphLowering(torch.fx.Interpreter):
             )
             return name
 
-        name = allocate(name)
+        new_name = allocate(name)
+        self.allocated_constant_name[new_name] = name
 
         return TensorBox.create(
             ir.ConstantBuffer(
-                name,
+                new_name,
                 FixedLayout(data.device, data.dtype, *self.static_sizes_strides(data)),
             )
         )


### PR DESCRIPTION
When compiling an deserialized ExportedProgram, constant’s original_fqn is not populated(). Highlighted line is missing, And a latter assertion is breaking due to original_fqn missing.

```
        constants_info_[0].name = "L__self___w_pre";
	constants_info_[0].dtype = static_cast<int32_t>(cached_torch_dtype_float32);
	constants_info_[0].offset = 0;
	constants_info_[0].data_size = 64;
	constants_info_[0].from_folded = false;
	constants_info_[0].shape = {4, 4};
	constants_info_[0].stride = {4, 1};
	// constants_info_[0].original_fqn = "w_pre";   // this line is missing 
```

Inductor is relying `dynamo_flat_name_to_original_fqn` to populate the original_fqn field. This field originates from `graph_module.meta["dynamo_flat_name_to_original_fqn"]`, and is set during dynamo tracing. However, when compiling 
an deserialized ExportedProgram, we don't do dynamo tracing, thus this field is missing. 

As a fix, I maintain AOTI's own mapping for constant tensor's fqn. 



Differential Revision: D54097073




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames