### PR TITLE
Separate GridSample Coordinate Types from Data Types

### DIFF
--- a/aten/src/ATen/native/GridSampler.h
+++ b/aten/src/ATen/native/GridSampler.h
@@ -175,7 +175,7 @@ static inline scalar_t grid_sampler_compute_source_index(
 // `d output / d input` via pointer argument `grad_in`.
 // This is useful in the backward pass of grid_sampler.
 template <typename coord_scalar_t, typename grad_scalar_t>
-static inline scalar_t grid_sampler_compute_source_index_set_grad(
+static inline coord_scalar_t grid_sampler_compute_source_index_set_grad(
     coord_scalar_t coord,
     int64_t size,
     GridSamplerPadding padding_mode,
@@ -210,7 +210,7 @@ static inline bool within_bounds_3d(int64_t d, int64_t h, int64_t w, int64_t D, 
 }
 
 template<typename data_scalar_t, typename coord_scalar_t>
-static inline scalar_t get_value_bounded(
+static inline data_scalar_t get_value_bounded(
     data_scalar_t* data,
     coord_scalar_t x,
     coord_scalar_t y,

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -133,10 +133,10 @@ namespace {
           #pragma unroll 4
           for (index_t i = 0; i < 4; ++i) {
             coefficients[i] = cubic_interp1d(
-              get_value_bounded<opmath_t>(inp_ptr_NC, ix_nw - 1, iy_nw - 1 + i, inp_W, inp_H, inp_sW, inp_sH, padding_mode, align_corners),
-              get_value_bounded<opmath_t>(inp_ptr_NC, ix_nw + 0, iy_nw - 1 + i, inp_W, inp_H, inp_sW, inp_sH, padding_mode, align_corners),
-              get_value_bounded<opmath_t>(inp_ptr_NC, ix_nw + 1, iy_nw - 1 + i, inp_W, inp_H, inp_sW, inp_sH, padding_mode, align_corners),
-              get_value_bounded<opmath_t>(inp_ptr_NC, ix_nw + 2, iy_nw - 1 + i, inp_W, inp_H, inp_sW, inp_sH, padding_mode, align_corners),
+              get_value_bounded<scalar_t, opmath_t>(inp_ptr_NC, ix_nw - 1, iy_nw - 1 + i, inp_W, inp_H, inp_sW, inp_sH, padding_mode, align_corners),
+              get_value_bounded<scalar_t, opmath_t>(inp_ptr_NC, ix_nw + 0, iy_nw - 1 + i, inp_W, inp_H, inp_sW, inp_sH, padding_mode, align_corners),
+              get_value_bounded<scalar_t, opmath_t>(inp_ptr_NC, ix_nw + 1, iy_nw - 1 + i, inp_W, inp_H, inp_sW, inp_sH, padding_mode, align_corners),
+              get_value_bounded<scalar_t, opmath_t>(inp_ptr_NC, ix_nw + 2, iy_nw - 1 + i, inp_W, inp_H, inp_sW, inp_sH, padding_mode, align_corners),
               tx);
           }
 
@@ -396,10 +396,10 @@ namespace {
 
           if (input_requires_grad) {
             // calculate and set grad_input. See Note [Passing pointer and offset to fastAtomicAdd].
-            safe_add_2d(grad_input.data, iy_nw, ix_nw, gInp_sH, gInp_sW, inp_H, inp_W, nw * gOut, NC_offset, grad_input_memory_span);
-            safe_add_2d(grad_input.data, iy_ne, ix_ne, gInp_sH, gInp_sW, inp_H, inp_W, ne * gOut, NC_offset, grad_input_memory_span);
-            safe_add_2d(grad_input.data, iy_sw, ix_sw, gInp_sH, gInp_sW, inp_H, inp_W, sw * gOut, NC_offset, grad_input_memory_span);
-            safe_add_2d(grad_input.data, iy_se, ix_se, gInp_sH, gInp_sW, inp_H, inp_W, se * gOut, NC_offset, grad_input_memory_span);
+            safe_add_2d(grad_input.data, iy_nw, ix_nw, gInp_sH, gInp_sW, inp_H, inp_W, static_cast<scalar_t>(nw * gOut), NC_offset, grad_input_memory_span);
+            safe_add_2d(grad_input.data, iy_ne, ix_ne, gInp_sH, gInp_sW, inp_H, inp_W, static_cast<scalar_t>(ne * gOut), NC_offset, grad_input_memory_span);
+            safe_add_2d(grad_input.data, iy_sw, ix_sw, gInp_sH, gInp_sW, inp_H, inp_W, static_cast<scalar_t>(sw * gOut), NC_offset, grad_input_memory_span);
+            safe_add_2d(grad_input.data, iy_se, ix_se, gInp_sH, gInp_sW, inp_H, inp_W, static_cast<scalar_t>(se * gOut), NC_offset, grad_input_memory_span);
           }
 
           // calculate grad_grid
@@ -646,21 +646,21 @@ namespace {
 
           // calculate and set grad_input. See Note [Passing pointer and offset to fastAtomicAdd].
           if (input_requires_grad) {
-            safe_add_3d(grad_input.data, iz_tnw, iy_tnw, ix_tnw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tnw * gOut,
+            safe_add_3d(grad_input.data, iz_tnw, iy_tnw, ix_tnw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, static_cast<scalar_t>(tnw * gOut),
                         NC_offset, grad_input_memory_span);
-            safe_add_3d(grad_input.data, iz_tne, iy_tne, ix_tne, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tne * gOut,
+            safe_add_3d(grad_input.data, iz_tne, iy_tne, ix_tne, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, static_cast<scalar_t>(tne * gOut),
                         NC_offset, grad_input_memory_span);
-            safe_add_3d(grad_input.data, iz_tsw, iy_tsw, ix_tsw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tsw * gOut,
+            safe_add_3d(grad_input.data, iz_tsw, iy_tsw, ix_tsw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, static_cast<scalar_t>(tsw * gOut),
                         NC_offset, grad_input_memory_span);
-            safe_add_3d(grad_input.data, iz_tse, iy_tse, ix_tse, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tse * gOut,
+            safe_add_3d(grad_input.data, iz_tse, iy_tse, ix_tse, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, static_cast<scalar_t>(tse * gOut),
                         NC_offset, grad_input_memory_span);
-            safe_add_3d(grad_input.data, iz_bnw, iy_bnw, ix_bnw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bnw * gOut,
+            safe_add_3d(grad_input.data, iz_bnw, iy_bnw, ix_bnw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, static_cast<scalar_t>(bnw * gOut),
                         NC_offset, grad_input_memory_span);
-            safe_add_3d(grad_input.data, iz_bne, iy_bne, ix_bne, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bne * gOut,
+            safe_add_3d(grad_input.data, iz_bne, iy_bne, ix_bne, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, static_cast<scalar_t>(bne * gOut),
                         NC_offset, grad_input_memory_span);
-            safe_add_3d(grad_input.data, iz_bsw, iy_bsw, ix_bsw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bsw * gOut,
+            safe_add_3d(grad_input.data, iz_bsw, iy_bsw, ix_bsw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, static_cast<scalar_t>(bsw * gOut),
                         NC_offset, grad_input_memory_span);
-            safe_add_3d(grad_input.data, iz_bse, iy_bse, ix_bse, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bse * gOut,
+            safe_add_3d(grad_input.data, iz_bse, iy_bse, ix_bse, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, static_cast<scalar_t>(bse * gOut),
                         NC_offset, grad_input_memory_span);
           }
           // calculate grad_grid


### PR DESCRIPTION
Follow up PR #96586

The operator math can be used for two situations in GridSample forward call:
1. Fractional coordinate computation.
2. Output activation interpolation (because it involves accumulation).

The operator math can also be used for two situations in GridSample backward call:
1. Fractional coordinate computation.
2. Input activation gradient computation.

Currently, on PyTorch main, the GridSample forward call uses operator math for both 1 and 2. However, the GridSample backward call does not use operator math at all for 1 and 2. 

Ideally, the operator math usages should be consistent between the forward call and the backward call, especially for the fractional coordinate computation. Otherwise, the input gradient will be updated for "incorrect" pixels from the input tensor.

The input activation gradient computation of the GridSample backward call can hardly use operator math because it uses atomic operations for gradient accumulation and this can hardly be replaced without significantly changing the implementation.

In this patch, I updated the GridSample backward call so that it uses operator math for the fractional coordinate computation and it will be consistent with the forward call.