### PR TITLE
use condition_variable and wait_until in nccl dump on timeout

### DIFF
--- a/c10/util/signal_handler.cpp
+++ b/c10/util/signal_handler.cpp
@@ -10,10 +10,14 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <iostream>
+#include <mutex>
 
 #ifdef C10_ANDROID
 #ifndef SYS_gettid
@@ -109,8 +113,8 @@ FatalSignalHandler::FatalSignalHandler()
     : fatalSignalHandlersInstalled(false),
       fatalSignalReceived(false),
       fatalSignalName("<UNKNOWN>"),
-      writingCond(PTHREAD_COND_INITIALIZER),
-      writingMutex(PTHREAD_MUTEX_INITIALIZER) {}
+      writingCond(),
+      writingMutex() {}
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 FatalSignalHandler::signal_handler FatalSignalHandler::kSignalHandlers[] = {
@@ -157,8 +161,9 @@ void FatalSignalHandler::callPreviousSignalHandler(
 
 // needsLock signals whether we need to lock our writing mutex.
 void FatalSignalHandler::stacktraceSignalHandler(bool needsLock) {
+  std::unique_lock<std::mutex> ul(writingMutex, std::defer_lock);
   if (needsLock) {
-    pthread_mutex_lock(&writingMutex);
+    ul.lock();
   }
   pid_t tid = static_cast<pid_t>(syscall(SYS_gettid));
   std::string backtrace = fmt::format(
@@ -170,8 +175,8 @@ void FatalSignalHandler::stacktraceSignalHandler(bool needsLock) {
       c10::get_backtrace());
   std::cerr << backtrace << std::endl;
   if (needsLock) {
-    pthread_mutex_unlock(&writingMutex);
-    pthread_cond_signal(&writingCond);
+    ul.unlock();
+    writingCond.notify_all();
   }
 }
 
@@ -204,23 +209,27 @@ void FatalSignalHandler::fatalSignalHandler(int signum) {
     pid_t pid = getpid();
     pid_t currentTid = static_cast<pid_t>(syscall(SYS_gettid));
     struct dirent* entry = nullptr;
-    pthread_mutex_lock(&writingMutex);
+    std::unique_lock<std::mutex> ul(writingMutex);
     while ((entry = readdir(procDir)) != nullptr) {
       if (entry->d_name[0] == '.') {
         continue;
       }
       pid_t tid = atoi(entry->d_name);
       // If we've found the current thread then we'll jump into the SIGUSR2
-      // handler before calling pthread_cond_wait thus deadlocking, so branch
-      // our directly to the backtrace handler instead of signaling it.
+      // handler instead of signaling to avoid deadlocking.
       if (tid != currentTid) {
         syscall(SYS_tgkill, pid, tid, SIGUSR2);
-        pthread_cond_wait(&writingCond, &writingMutex);
+        auto now = std::chrono::system_clock::now();
+        using namespace std::chrono_literals;
+        // we use wait_until instead of wait because on ROCm there was
+        // a single thread that wouldn't receive the SIGUSR2
+        if (std::cv_status::timeout == writingCond.wait_until(ul, now + 2s)) {
+          std::cerr << "timed out waiting for SIGUSR2 " << pid << ":" << tid << std::endl;
+        }
       } else {
         stacktraceSignalHandler(false);
       }
     }
-    pthread_mutex_unlock(&writingMutex);
   } else {
     perror("Failed to open /proc/self/task");
   }

--- a/c10/util/signal_handler.cpp
+++ b/c10/util/signal_handler.cpp
@@ -228,7 +228,8 @@ void FatalSignalHandler::fatalSignalHandler(int signum) {
         // a single thread that wouldn't receive the SIGUSR2
         if (std::cv_status::timeout == writingCond.wait_until(ul, now + 2s)) {
           if (!signalReceived) {
-            std::cerr << "signal lost waiting for stacktrace " << pid << ":" << tid << std::endl;
+            std::cerr << "signal lost waiting for stacktrace " << pid << ":"
+                      << tid << std::endl;
             break;
           }
         }

--- a/c10/util/signal_handler.h
+++ b/c10/util/signal_handler.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <condition_variable>
 #include <csignal>
 #include <cstdint>
 #include <mutex>
@@ -89,8 +90,8 @@ class C10_API FatalSignalHandler {
   // This wait condition is used to wait for other threads to finish writing
   // their stack trace when in fatal sig handler (we can't use pthread_join
   // because there's no way to convert from a tid to a pthread_t).
-  pthread_cond_t writingCond;
-  pthread_mutex_t writingMutex;
+  std::condition_variable writingCond;
+  std::mutex writingMutex;
 
   struct signal_handler {
     const char* name;

--- a/c10/util/signal_handler.h
+++ b/c10/util/signal_handler.h
@@ -92,6 +92,8 @@ class C10_API FatalSignalHandler {
   // because there's no way to convert from a tid to a pthread_t).
   std::condition_variable writingCond;
   std::mutex writingMutex;
+  // used to indicate if the other thread responded to the signal
+  bool signalReceived;
 
   struct signal_handler {
     const char* name;

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -4343,6 +4343,8 @@ class NCCLTraceTestTimeoutDumpOnStuckRanks(NCCLTraceTestDumpOnTimeoutBase):
     def test_timeout_dumps_on_stuck_ranks(self):
         # need rank0 to crash quicker after detecting timeout
         os.environ['TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC'] = '1'
+        # restore this env var to its prior default in case another test changed it
+        os.environ['TORCH_NCCL_COORD_CHECK_MILSEC'] = '1000'
 
         if self.rank == self.MAIN_PROCESS_RANK:
             # wait for both rank0 and 1 to crash before looking for both ranks' output


### PR DESCRIPTION
Fixes test_c10d_nccl.py -k test_timeout_dumps_timing_enabled_True.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang