### PR TITLE
Preserve metadata for `MutableMapping` and `MutableSequence` in `pin_memory` and `collate_fn`

### DIFF
--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -9,6 +9,7 @@ static methods.
 
 import collections
 import contextlib
+import copy
 import re
 import torch
 
@@ -62,9 +63,18 @@ def default_convert(data):
         return torch.as_tensor(data)
     elif isinstance(data, collections.abc.Mapping):
         try:
-            return elem_type({key: default_convert(data[key]) for key in data})
+            if isinstance(data, collections.abc.MutableMapping):
+                # The mapping type may have extra properties, so we can't just
+                # use `type(data)(...)` to create the new mapping.
+                # Create a clone and update it if the mapping type is mutable.
+                clone = copy.copy(data)
+                clone.update({key: default_convert(data[key]) for key in data})
+                return clone
+            else:
+                return elem_type({key: default_convert(data[key]) for key in data})
         except TypeError:
-            # The mapping type may not support `__init__(iterable)`.
+            # The mapping type may not support `copy()` / `update(mapping)`
+            # or `__init__(iterable)`.
             return {key: default_convert(data[key]) for key in data}
     elif isinstance(data, tuple) and hasattr(data, '_fields'):  # namedtuple
         return elem_type(*(default_convert(d) for d in data))
@@ -72,9 +82,19 @@ def default_convert(data):
         return [default_convert(d) for d in data]  # Backwards compatibility.
     elif isinstance(data, collections.abc.Sequence) and not isinstance(data, (str, bytes)):
         try:
-            return elem_type([default_convert(d) for d in data])
+            if isinstance(data, collections.abc.MutableSequence):
+                # The sequence type may have extra properties, so we can't just
+                # use `type(data)(...)` to create the new sequence.
+                # Create a clone and update it if the sequence type is mutable.
+                clone = copy.copy(data)  # type: ignore[arg-type]
+                for i, d in enumerate(data):
+                    clone[i] = default_convert(d)
+                return clone
+            else:
+                return elem_type([default_convert(d) for d in data])
         except TypeError:
-            # The sequence type may not support `__init__(iterable)` (e.g., `range`).
+            # The sequence type may not support `copy()` / `__setitem__(index, item)`
+            # or `__init__(iterable)` (e.g., `range`).
             return [default_convert(d) for d in data]
     else:
         return data
@@ -126,9 +146,18 @@ def collate(batch, *, collate_fn_map: Optional[Dict[Union[Type, Tuple[Type, ...]
 
     if isinstance(elem, collections.abc.Mapping):
         try:
-            return elem_type({key: collate([d[key] for d in batch], collate_fn_map=collate_fn_map) for key in elem})
+            if isinstance(elem, collections.abc.MutableMapping):
+                # The mapping type may have extra properties, so we can't just
+                # use `type(data)(...)` to create the new mapping.
+                # Create a clone and update it if the mapping type is mutable.
+                clone = copy.copy(elem)
+                clone.update({key: collate([d[key] for d in batch], collate_fn_map=collate_fn_map) for key in elem})
+                return clone
+            else:
+                return elem_type({key: collate([d[key] for d in batch], collate_fn_map=collate_fn_map) for key in elem})
         except TypeError:
-            # The mapping type may not support `__init__(iterable)`.
+            # The mapping type may not support `copy()` / `update(mapping)`
+            # or `__init__(iterable)`.
             return {key: collate([d[key] for d in batch], collate_fn_map=collate_fn_map) for key in elem}
     elif isinstance(elem, tuple) and hasattr(elem, '_fields'):  # namedtuple
         return elem_type(*(collate(samples, collate_fn_map=collate_fn_map) for samples in zip(*batch)))
@@ -144,9 +173,19 @@ def collate(batch, *, collate_fn_map: Optional[Dict[Union[Type, Tuple[Type, ...]
             return [collate(samples, collate_fn_map=collate_fn_map) for samples in transposed]  # Backwards compatibility.
         else:
             try:
-                return elem_type([collate(samples, collate_fn_map=collate_fn_map) for samples in transposed])
+                if isinstance(elem, collections.abc.MutableSequence):
+                    # The sequence type may have extra properties, so we can't just
+                    # use `type(data)(...)` to create the new sequence.
+                    # Create a clone and update it if the sequence type is mutable.
+                    clone = copy.copy(elem)  # type: ignore[arg-type]
+                    for i, samples in enumerate(transposed):
+                        clone[i] = collate(samples, collate_fn_map=collate_fn_map)
+                    return clone
+                else:
+                    return elem_type([collate(samples, collate_fn_map=collate_fn_map) for samples in transposed])
             except TypeError:
-                # The sequence type may not support `__init__(iterable)` (e.g., `range`).
+                # The sequence type may not support `copy()` / `__setitem__(index, item)`
+                # or `__init__(iterable)` (e.g., `range`).
                 return [collate(samples, collate_fn_map=collate_fn_map) for samples in transposed]
 
     raise TypeError(default_collate_err_msg_format.format(elem_type))


### PR DESCRIPTION
For the user-defined `Mapping` type, it may contain some metadata (e.g., pytorch/tensordict#679, https://github.com/pytorch/pytorch/pull/120195#issue-2141716712). Simply use `type(mapping)({k: v for k, v in mapping.items()})` do not take this metadata into account. This PR uses `copy.copy(mapping)` to create a clone of the original collection and iteratively updates the elements in the cloned collection. This preserves the metadata in the original collection via `copy.copy(...)` rather than relying on the `__init__` method in the user-defined classes.

Reference:

- pytorch/tensordict#679
- #120195

Closes #120195

cc @SsnL @VitalyFedyunin @ejguan @dzhulgakov