### PR TITLE
Fix printing sparse COO meta tensors

### DIFF
--- a/test/expect/TestSparseMeta.test_print_meta_SparseBSC_float64.expect
+++ b/test/expect/TestSparseMeta.test_print_meta_SparseBSC_float64.expect
@@ -1,24 +1,24 @@
 ########## torch.float64/torch.int64/size=()+(4, 6)+(2, 3)+() ##########
 # sparse meta tensor
-tensor(ccol_indices=tensor(..., dtype=torch.int64),
+tensor(ccol_indices=tensor(..., size=(3,), dtype=torch.int64),
        row_indices=tensor(..., size=(0,)),
        values=tensor(..., size=(0, 2, 3)), device='meta', size=(4, 6),
        dtype=torch.float64, layout=torch.sparse_bsc)
 ########## torch.float64/torch.int64/size=()+(4, 6)+(2, 3)+(3,) ##########
 # sparse meta tensor
-tensor(ccol_indices=tensor(..., dtype=torch.int64),
+tensor(ccol_indices=tensor(..., size=(3,), dtype=torch.int64),
        row_indices=tensor(..., size=(0,)),
        values=tensor(..., size=(0, 2, 3, 3)), device='meta', size=(4, 6, 3),
        dtype=torch.float64, layout=torch.sparse_bsc)
 ########## torch.float64/torch.int64/size=(2,)+(4, 6)+(2, 3)+() ##########
 # sparse meta tensor
-tensor(ccol_indices=tensor(..., dtype=torch.int64),
+tensor(ccol_indices=tensor(..., size=(2, 3), dtype=torch.int64),
        row_indices=tensor(..., size=(2, 0)),
        values=tensor(..., size=(2, 0, 2, 3)), device='meta', size=(2, 4, 6),
        dtype=torch.float64, layout=torch.sparse_bsc)
 ########## torch.float64/torch.int64/size=(2,)+(4, 6)+(2, 3)+(3,) ##########
 # sparse meta tensor
-tensor(ccol_indices=tensor(..., dtype=torch.int64),
+tensor(ccol_indices=tensor(..., size=(2, 3), dtype=torch.int64),
        row_indices=tensor(..., size=(2, 0)),
        values=tensor(..., size=(2, 0, 2, 3, 3)), device='meta',
        size=(2, 4, 6, 3), dtype=torch.float64, layout=torch.sparse_bsc)

--- a/test/expect/TestSparseMeta.test_print_meta_SparseBSC_float64.expect
+++ b/test/expect/TestSparseMeta.test_print_meta_SparseBSC_float64.expect
@@ -1,0 +1,24 @@
+########## torch.float64/torch.int64/size=()+(4, 6)+(2, 3)+() ##########
+# sparse meta tensor
+tensor(ccol_indices=tensor(..., dtype=torch.int64),
+       row_indices=tensor(..., size=(0,)),
+       values=tensor(..., size=(0, 2, 3)), device='meta', size=(4, 6),
+       dtype=torch.float64, layout=torch.sparse_bsc)
+########## torch.float64/torch.int64/size=()+(4, 6)+(2, 3)+(3,) ##########
+# sparse meta tensor
+tensor(ccol_indices=tensor(..., dtype=torch.int64),
+       row_indices=tensor(..., size=(0,)),
+       values=tensor(..., size=(0, 2, 3, 3)), device='meta', size=(4, 6, 3),
+       dtype=torch.float64, layout=torch.sparse_bsc)
+########## torch.float64/torch.int64/size=(2,)+(4, 6)+(2, 3)+() ##########
+# sparse meta tensor
+tensor(ccol_indices=tensor(..., dtype=torch.int64),
+       row_indices=tensor(..., size=(2, 0)),
+       values=tensor(..., size=(2, 0, 2, 3)), device='meta', size=(2, 4, 6),
+       dtype=torch.float64, layout=torch.sparse_bsc)
+########## torch.float64/torch.int64/size=(2,)+(4, 6)+(2, 3)+(3,) ##########
+# sparse meta tensor
+tensor(ccol_indices=tensor(..., dtype=torch.int64),
+       row_indices=tensor(..., size=(2, 0)),
+       values=tensor(..., size=(2, 0, 2, 3, 3)), device='meta',
+       size=(2, 4, 6, 3), dtype=torch.float64, layout=torch.sparse_bsc)

--- a/test/expect/TestSparseMeta.test_print_meta_SparseBSR_float64.expect
+++ b/test/expect/TestSparseMeta.test_print_meta_SparseBSR_float64.expect
@@ -1,24 +1,24 @@
 ########## torch.float64/torch.int64/size=()+(4, 6)+(2, 3)+() ##########
 # sparse meta tensor
-tensor(crow_indices=tensor(..., dtype=torch.int64),
+tensor(crow_indices=tensor(..., size=(3,), dtype=torch.int64),
        col_indices=tensor(..., size=(0,)),
        values=tensor(..., size=(0, 2, 3)), device='meta', size=(4, 6),
        dtype=torch.float64, layout=torch.sparse_bsr)
 ########## torch.float64/torch.int64/size=()+(4, 6)+(2, 3)+(3,) ##########
 # sparse meta tensor
-tensor(crow_indices=tensor(..., dtype=torch.int64),
+tensor(crow_indices=tensor(..., size=(3,), dtype=torch.int64),
        col_indices=tensor(..., size=(0,)),
        values=tensor(..., size=(0, 2, 3, 3)), device='meta', size=(4, 6, 3),
        dtype=torch.float64, layout=torch.sparse_bsr)
 ########## torch.float64/torch.int64/size=(2,)+(4, 6)+(2, 3)+() ##########
 # sparse meta tensor
-tensor(crow_indices=tensor(..., dtype=torch.int64),
+tensor(crow_indices=tensor(..., size=(2, 3), dtype=torch.int64),
        col_indices=tensor(..., size=(2, 0)),
        values=tensor(..., size=(2, 0, 2, 3)), device='meta', size=(2, 4, 6),
        dtype=torch.float64, layout=torch.sparse_bsr)
 ########## torch.float64/torch.int64/size=(2,)+(4, 6)+(2, 3)+(3,) ##########
 # sparse meta tensor
-tensor(crow_indices=tensor(..., dtype=torch.int64),
+tensor(crow_indices=tensor(..., size=(2, 3), dtype=torch.int64),
        col_indices=tensor(..., size=(2, 0)),
        values=tensor(..., size=(2, 0, 2, 3, 3)), device='meta',
        size=(2, 4, 6, 3), dtype=torch.float64, layout=torch.sparse_bsr)

--- a/test/expect/TestSparseMeta.test_print_meta_SparseBSR_float64.expect
+++ b/test/expect/TestSparseMeta.test_print_meta_SparseBSR_float64.expect
@@ -1,0 +1,24 @@
+########## torch.float64/torch.int64/size=()+(4, 6)+(2, 3)+() ##########
+# sparse meta tensor
+tensor(crow_indices=tensor(..., dtype=torch.int64),
+       col_indices=tensor(..., size=(0,)),
+       values=tensor(..., size=(0, 2, 3)), device='meta', size=(4, 6),
+       dtype=torch.float64, layout=torch.sparse_bsr)
+########## torch.float64/torch.int64/size=()+(4, 6)+(2, 3)+(3,) ##########
+# sparse meta tensor
+tensor(crow_indices=tensor(..., dtype=torch.int64),
+       col_indices=tensor(..., size=(0,)),
+       values=tensor(..., size=(0, 2, 3, 3)), device='meta', size=(4, 6, 3),
+       dtype=torch.float64, layout=torch.sparse_bsr)
+########## torch.float64/torch.int64/size=(2,)+(4, 6)+(2, 3)+() ##########
+# sparse meta tensor
+tensor(crow_indices=tensor(..., dtype=torch.int64),
+       col_indices=tensor(..., size=(2, 0)),
+       values=tensor(..., size=(2, 0, 2, 3)), device='meta', size=(2, 4, 6),
+       dtype=torch.float64, layout=torch.sparse_bsr)
+########## torch.float64/torch.int64/size=(2,)+(4, 6)+(2, 3)+(3,) ##########
+# sparse meta tensor
+tensor(crow_indices=tensor(..., dtype=torch.int64),
+       col_indices=tensor(..., size=(2, 0)),
+       values=tensor(..., size=(2, 0, 2, 3, 3)), device='meta',
+       size=(2, 4, 6, 3), dtype=torch.float64, layout=torch.sparse_bsr)

--- a/test/expect/TestSparseMeta.test_print_meta_SparseCOO_float64.expect
+++ b/test/expect/TestSparseMeta.test_print_meta_SparseCOO_float64.expect
@@ -1,0 +1,23 @@
+########## torch.float64/torch.int64/size=()+(4, 6)+()+() ##########
+# sparse meta tensor
+tensor(indices=tensor(..., size=(2, 0), dtype=torch.int64),
+       values=tensor(..., size=(0,)),
+       device='meta', size=(4, 6), dtype=torch.float64, layout=torch.sparse_coo)
+########## torch.float64/torch.int64/size=()+(4, 6)+()+(3,) ##########
+# sparse meta tensor
+tensor(indices=tensor(..., size=(2, 0), dtype=torch.int64),
+       values=tensor(..., size=(0, 3)),
+       device='meta', size=(4, 6, 3), dtype=torch.float64,
+       layout=torch.sparse_coo)
+########## torch.float64/torch.int64/size=()+(3, 5, 7)+()+() ##########
+# sparse meta tensor
+tensor(indices=tensor(..., size=(3, 0), dtype=torch.int64),
+       values=tensor(..., size=(0,)),
+       device='meta', size=(3, 5, 7), dtype=torch.float64,
+       layout=torch.sparse_coo)
+########## torch.float64/torch.int64/size=()+(3, 5, 7)+()+(3,) ##########
+# sparse meta tensor
+tensor(indices=tensor(..., size=(3, 0), dtype=torch.int64),
+       values=tensor(..., size=(0, 3)),
+       device='meta', size=(3, 5, 7, 3), dtype=torch.float64,
+       layout=torch.sparse_coo)

--- a/test/expect/TestSparseMeta.test_print_meta_SparseCSC_float64.expect
+++ b/test/expect/TestSparseMeta.test_print_meta_SparseCSC_float64.expect
@@ -1,24 +1,24 @@
 ########## torch.float64/torch.int64/size=()+(4, 6)+()+() ##########
 # sparse meta tensor
-tensor(ccol_indices=tensor(..., dtype=torch.int64),
+tensor(ccol_indices=tensor(..., size=(7,), dtype=torch.int64),
        row_indices=tensor(..., size=(0,)),
        values=tensor(..., size=(0,)), device='meta', size=(4, 6),
        dtype=torch.float64, layout=torch.sparse_csc)
 ########## torch.float64/torch.int64/size=()+(4, 6)+()+(3,) ##########
 # sparse meta tensor
-tensor(ccol_indices=tensor(..., dtype=torch.int64),
+tensor(ccol_indices=tensor(..., size=(7,), dtype=torch.int64),
        row_indices=tensor(..., size=(0,)),
        values=tensor(..., size=(0, 3)), device='meta', size=(4, 6, 3),
        dtype=torch.float64, layout=torch.sparse_csc)
 ########## torch.float64/torch.int64/size=(2,)+(4, 6)+()+() ##########
 # sparse meta tensor
-tensor(ccol_indices=tensor(..., dtype=torch.int64),
+tensor(ccol_indices=tensor(..., size=(2, 7), dtype=torch.int64),
        row_indices=tensor(..., size=(2, 0)),
        values=tensor(..., size=(2, 0)), device='meta', size=(2, 4, 6),
        dtype=torch.float64, layout=torch.sparse_csc)
 ########## torch.float64/torch.int64/size=(2,)+(4, 6)+()+(3,) ##########
 # sparse meta tensor
-tensor(ccol_indices=tensor(..., dtype=torch.int64),
+tensor(ccol_indices=tensor(..., size=(2, 7), dtype=torch.int64),
        row_indices=tensor(..., size=(2, 0)),
        values=tensor(..., size=(2, 0, 3)), device='meta', size=(2, 4, 6, 3),
        dtype=torch.float64, layout=torch.sparse_csc)

--- a/test/expect/TestSparseMeta.test_print_meta_SparseCSC_float64.expect
+++ b/test/expect/TestSparseMeta.test_print_meta_SparseCSC_float64.expect
@@ -1,0 +1,24 @@
+########## torch.float64/torch.int64/size=()+(4, 6)+()+() ##########
+# sparse meta tensor
+tensor(ccol_indices=tensor(..., dtype=torch.int64),
+       row_indices=tensor(..., size=(0,)),
+       values=tensor(..., size=(0,)), device='meta', size=(4, 6),
+       dtype=torch.float64, layout=torch.sparse_csc)
+########## torch.float64/torch.int64/size=()+(4, 6)+()+(3,) ##########
+# sparse meta tensor
+tensor(ccol_indices=tensor(..., dtype=torch.int64),
+       row_indices=tensor(..., size=(0,)),
+       values=tensor(..., size=(0, 3)), device='meta', size=(4, 6, 3),
+       dtype=torch.float64, layout=torch.sparse_csc)
+########## torch.float64/torch.int64/size=(2,)+(4, 6)+()+() ##########
+# sparse meta tensor
+tensor(ccol_indices=tensor(..., dtype=torch.int64),
+       row_indices=tensor(..., size=(2, 0)),
+       values=tensor(..., size=(2, 0)), device='meta', size=(2, 4, 6),
+       dtype=torch.float64, layout=torch.sparse_csc)
+########## torch.float64/torch.int64/size=(2,)+(4, 6)+()+(3,) ##########
+# sparse meta tensor
+tensor(ccol_indices=tensor(..., dtype=torch.int64),
+       row_indices=tensor(..., size=(2, 0)),
+       values=tensor(..., size=(2, 0, 3)), device='meta', size=(2, 4, 6, 3),
+       dtype=torch.float64, layout=torch.sparse_csc)

--- a/test/expect/TestSparseMeta.test_print_meta_SparseCSR_float64.expect
+++ b/test/expect/TestSparseMeta.test_print_meta_SparseCSR_float64.expect
@@ -1,24 +1,24 @@
 ########## torch.float64/torch.int64/size=()+(4, 6)+()+() ##########
 # sparse meta tensor
-tensor(crow_indices=tensor(..., dtype=torch.int64),
+tensor(crow_indices=tensor(..., size=(5,), dtype=torch.int64),
        col_indices=tensor(..., size=(0,)),
        values=tensor(..., size=(0,)), device='meta', size=(4, 6),
        dtype=torch.float64, layout=torch.sparse_csr)
 ########## torch.float64/torch.int64/size=()+(4, 6)+()+(3,) ##########
 # sparse meta tensor
-tensor(crow_indices=tensor(..., dtype=torch.int64),
+tensor(crow_indices=tensor(..., size=(5,), dtype=torch.int64),
        col_indices=tensor(..., size=(0,)),
        values=tensor(..., size=(0, 3)), device='meta', size=(4, 6, 3),
        dtype=torch.float64, layout=torch.sparse_csr)
 ########## torch.float64/torch.int64/size=(2,)+(4, 6)+()+() ##########
 # sparse meta tensor
-tensor(crow_indices=tensor(..., dtype=torch.int64),
+tensor(crow_indices=tensor(..., size=(2, 5), dtype=torch.int64),
        col_indices=tensor(..., size=(2, 0)),
        values=tensor(..., size=(2, 0)), device='meta', size=(2, 4, 6),
        dtype=torch.float64, layout=torch.sparse_csr)
 ########## torch.float64/torch.int64/size=(2,)+(4, 6)+()+(3,) ##########
 # sparse meta tensor
-tensor(crow_indices=tensor(..., dtype=torch.int64),
+tensor(crow_indices=tensor(..., size=(2, 5), dtype=torch.int64),
        col_indices=tensor(..., size=(2, 0)),
        values=tensor(..., size=(2, 0, 3)), device='meta', size=(2, 4, 6, 3),
        dtype=torch.float64, layout=torch.sparse_csr)

--- a/test/expect/TestSparseMeta.test_print_meta_SparseCSR_float64.expect
+++ b/test/expect/TestSparseMeta.test_print_meta_SparseCSR_float64.expect
@@ -1,0 +1,24 @@
+########## torch.float64/torch.int64/size=()+(4, 6)+()+() ##########
+# sparse meta tensor
+tensor(crow_indices=tensor(..., dtype=torch.int64),
+       col_indices=tensor(..., size=(0,)),
+       values=tensor(..., size=(0,)), device='meta', size=(4, 6),
+       dtype=torch.float64, layout=torch.sparse_csr)
+########## torch.float64/torch.int64/size=()+(4, 6)+()+(3,) ##########
+# sparse meta tensor
+tensor(crow_indices=tensor(..., dtype=torch.int64),
+       col_indices=tensor(..., size=(0,)),
+       values=tensor(..., size=(0, 3)), device='meta', size=(4, 6, 3),
+       dtype=torch.float64, layout=torch.sparse_csr)
+########## torch.float64/torch.int64/size=(2,)+(4, 6)+()+() ##########
+# sparse meta tensor
+tensor(crow_indices=tensor(..., dtype=torch.int64),
+       col_indices=tensor(..., size=(2, 0)),
+       values=tensor(..., size=(2, 0)), device='meta', size=(2, 4, 6),
+       dtype=torch.float64, layout=torch.sparse_csr)
+########## torch.float64/torch.int64/size=(2,)+(4, 6)+()+(3,) ##########
+# sparse meta tensor
+tensor(crow_indices=tensor(..., dtype=torch.int64),
+       col_indices=tensor(..., size=(2, 0)),
+       values=tensor(..., size=(2, 0, 3)), device='meta', size=(2, 4, 6, 3),
+       dtype=torch.float64, layout=torch.sparse_csr)

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -4361,8 +4361,10 @@ class TestSparseMeta(TestCase):
                 [(), (2,)], [(4, 6), (3, 5, 7)], [(), (3,)]
         ):
             if layout is torch.sparse_coo and batch_shape:
+                # COO tensors don't have batch dimensions
                 continue
             if layout is not torch.sparse_coo and len(sparse_shape) != 2:
+                # CSR/CSC/BSR/BSC tensors must have 2 sparse dimensions
                 continue
             printed += self._test_print_meta_data(dtype, layout, batch_shape, sparse_shape, dense_shape)
 

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -445,28 +445,29 @@ def _str_intern(inp, *, tensor_contents=None):
         suffixes.append("size=" + str(tuple(self.shape)))
         from torch._subclasses.fake_tensor import FakeTensor
 
-        if not self.is_meta and not isinstance(self, FakeTensor):
+        is_meta = self.is_meta or isinstance(self, FakeTensor)
+        if not is_meta:
             suffixes.append("nnz=" + str(self._nnz()))
         if not has_default_dtype:
             suffixes.append("dtype=" + str(self.dtype))
         if not custom_contents_provided:
             indices_prefix = "indices=tensor("
             indices = self._indices().detach()
-            if indices.is_meta:
+            if is_meta:
                 indices_str = "..."
             else:
                 indices_str = _tensor_str(indices, indent + len(indices_prefix))
-            if indices.numel() == 0:
+            if indices.numel() == 0 or is_meta:
                 indices_str += ", size=" + str(tuple(indices.shape))
-            if indices.is_meta:
+            if is_meta:
                 indices_str += ", dtype=" + str(indices.dtype)
             values_prefix = "values=tensor("
             values = self._values().detach()
-            if values.is_meta:
+            if is_meta:
                 values_str = "..."
             else:
                 values_str = _tensor_str(values, indent + len(values_prefix))
-            if values.numel() == 0:
+            if values.numel() == 0 or is_meta:
                 values_str += ", size=" + str(tuple(values.shape))
             tensor_str = (
                 indices_prefix
@@ -484,7 +485,10 @@ def _str_intern(inp, *, tensor_contents=None):
         torch.sparse_bsc,
     }:
         suffixes.append("size=" + str(tuple(self.shape)))
-        if not self.is_meta:
+        from torch._subclasses.fake_tensor import FakeTensor
+
+        is_meta = self.is_meta or isinstance(self, FakeTensor)
+        if not is_meta:
             suffixes.append("nnz=" + str(self._nnz()))
         if not has_default_dtype:
             suffixes.append("dtype=" + str(self.dtype))
@@ -501,35 +505,35 @@ def _str_intern(inp, *, tensor_contents=None):
                 cdimname, pdimname = "column", "row"
             compressed_indices_prefix = f"c{cdimname[:3]}_indices=tensor("
             compressed_indices = compressed_indices_method(self).detach()
-            if compressed_indices.is_meta:
+            if is_meta:
                 compressed_indices_str = "..."
             else:
                 compressed_indices_str = _tensor_str(
                     compressed_indices, indent + len(compressed_indices_prefix)
                 )
-            if compressed_indices.numel() == 0:
+            if compressed_indices.numel() == 0 or is_meta:
                 compressed_indices_str += ", size=" + str(
                     tuple(compressed_indices.shape)
                 )
-            if compressed_indices.is_meta:
+            if is_meta:
                 compressed_indices_str += ", dtype=" + str(compressed_indices.dtype)
             plain_indices_prefix = f"{pdimname[:3]}_indices=tensor("
             plain_indices = plain_indices_method(self).detach()
-            if plain_indices.is_meta:
+            if is_meta:
                 plain_indices_str = "..."
             else:
                 plain_indices_str = _tensor_str(
                     plain_indices, indent + len(plain_indices_prefix)
                 )
-            if plain_indices.numel() == 0:
+            if plain_indices.numel() == 0 or is_meta:
                 plain_indices_str += ", size=" + str(tuple(plain_indices.shape))
             values_prefix = "values=tensor("
             values = self.values().detach()
-            if values.is_meta:
+            if is_meta:
                 values_str = "..."
             else:
                 values_str = _tensor_str(values, indent + len(values_prefix))
-            if values.numel() == 0:
+            if values.numel() == 0 or is_meta:
                 values_str += ", size=" + str(tuple(values.shape))
             tensor_str = (
                 compressed_indices_prefix

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -452,12 +452,20 @@ def _str_intern(inp, *, tensor_contents=None):
         if not custom_contents_provided:
             indices_prefix = "indices=tensor("
             indices = self._indices().detach()
-            indices_str = _tensor_str(indices, indent + len(indices_prefix))
+            if indices.is_meta:
+                indices_str = "..."
+            else:
+                indices_str = _tensor_str(indices, indent + len(indices_prefix))
             if indices.numel() == 0:
                 indices_str += ", size=" + str(tuple(indices.shape))
+            if indices.is_meta:
+                indices_str += ", dtype=" + str(indices.dtype)
             values_prefix = "values=tensor("
             values = self._values().detach()
-            values_str = _tensor_str(values, indent + len(values_prefix))
+            if values.is_meta:
+                values_str = "..."
+            else:
+                values_str = _tensor_str(values, indent + len(values_prefix))
             if values.numel() == 0:
                 values_str += ", size=" + str(tuple(values.shape))
             tensor_str = (


### PR DESCRIPTION
As in the title. Also, add tests for printing sparse COO/CSR/CSC/BSR/BSC meta tensors.

The PR fixes the following failure:

<details>

```
>>> import torch
>>> indices = torch.empty((2, 1), device='meta', dtype=torch.int64)
>>> values = torch.empty((1,), device='meta')
>>> torch.sparse_coo_tensor(indices, values, (2, 2))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/pearu/git/pytorch/pytorch-mm/torch/_tensor.py", line 463, in __repr__
    return torch._tensor_str._str(self, tensor_contents=tensor_contents)
  File "/home/pearu/git/pytorch/pytorch-mm/torch/_tensor_str.py", line 697, in _str
    return _str_intern(self, tensor_contents=tensor_contents)
  File "/home/pearu/git/pytorch/pytorch-mm/torch/_tensor_str.py", line 458, in _str_intern
    indices_str = _tensor_str(indices, indent + len(indices_prefix))
  File "/home/pearu/git/pytorch/pytorch-mm/torch/_tensor_str.py", line 350, in _tensor_str
    return _tensor_str_with_formatter(self, indent, summarize, formatter)
  File "/home/pearu/git/pytorch/pytorch-mm/torch/_tensor_str.py", line 291, in _tensor_str_with_formatter
    slices = [
  File "/home/pearu/git/pytorch/pytorch-mm/torch/_tensor_str.py", line 292, in <listcomp>
    _tensor_str_with_formatter(
  File "/home/pearu/git/pytorch/pytorch-mm/torch/_tensor_str.py", line 272, in _tensor_str_with_formatter
    return _vector_str(self, indent, summarize, formatter1, formatter2)
  File "/home/pearu/git/pytorch/pytorch-mm/torch/_tensor_str.py", line 253, in _vector_str
    data = [_val_formatter(val) for val in self.tolist()]
NotImplementedError: Cannot copy out of meta tensor; no data!

```

</details>


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #120588
* __->__ #120562



cc @alexsamardzic @nikitaved @cpuhrsch @amjames @bhosmer @jcaip