### PR TITLE
Enable clang-tidy on c10/util/Float8*.h

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -216,7 +216,6 @@ exclude_patterns = [
     'c10/util/complex_math.h',
     'c10/util/complex_utils.h',
     'c10/util/flat_hash_map.h',
-    'c10/util/Float8*.h',
     'c10/util/logging*.h',
     'c10/util/hash.h',
     'c10/util/strong_type.h',

--- a/c10/util/Float8_e4m3fn-inl.h
+++ b/c10/util/Float8_e4m3fn-inl.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <c10/macros/Macros.h>
-#include <cstring>
+#include <cstdint>
 #include <limits>
 
 C10_CLANG_DIAGNOSTIC_PUSH()

--- a/c10/util/Float8_e4m3fn.h
+++ b/c10/util/Float8_e4m3fn.h
@@ -15,9 +15,7 @@
 /// and inspired by Half implementation from pytorch/c10/util/Half.h
 
 #include <c10/macros/Macros.h>
-#include <c10/util/TypeSafeSignMath.h>
 #include <c10/util/floating_point_utils.h>
-#include <type_traits>
 
 #if defined(__cplusplus)
 #include <cmath>
@@ -32,16 +30,7 @@
 #endif
 
 #include <climits>
-#include <cstdint>
-#include <cstring>
-#include <iosfwd>
-#include <limits>
-#include <sstream>
-#include <stdexcept>
-#include <string>
-#include <utility>
-
-#include <typeinfo> // operator typeid
+#include <iostream>
 
 namespace c10 {
 

--- a/c10/util/Float8_e4m3fnuz.cpp
+++ b/c10/util/Float8_e4m3fnuz.cpp
@@ -1,3 +1,4 @@
+#include <c10/macros/Macros.h>
 #include <c10/util/Float8_e4m3fnuz.h>
 
 namespace c10 {

--- a/c10/util/Float8_e4m3fnuz.h
+++ b/c10/util/Float8_e4m3fnuz.h
@@ -17,8 +17,8 @@
 /// Implementation based on the paper https://arxiv.org/pdf/2206.02915.pdf and
 /// the existing Float8_e4m3fn implementation.
 
+#include <c10/macros/Export.h>
 #include <c10/macros/Macros.h>
-#include <c10/util/TypeSafeSignMath.h>
 #include <c10/util/floating_point_utils.h>
 #include <type_traits>
 

--- a/c10/util/Float8_e5m2.cpp
+++ b/c10/util/Float8_e5m2.cpp
@@ -3,7 +3,7 @@
 namespace c10 {
 
 static_assert(
-    std::is_standard_layout<Float8_e5m2>::value,
+    std::is_standard_layout_v<Float8_e5m2>,
     "c10::Float8_e5m2 must be standard layout.");
 
 } // namespace c10

--- a/c10/util/Float8_e5m2fnuz.cpp
+++ b/c10/util/Float8_e5m2fnuz.cpp
@@ -1,3 +1,4 @@
+#include <c10/macros/Macros.h>
 #include <c10/util/Float8_e5m2fnuz.h>
 
 namespace c10 {


### PR DESCRIPTION
This PR clears warnings and enables clang-tidy on c10/util/Float8*.h.