### PR TITLE
[Clang-tidy header][20/N] Fix clang-tidy warnings in aten/src/ATEN/*.{cpp,h}

### DIFF
--- a/aten/src/ATen/CPUGeneratorImpl.cpp
+++ b/aten/src/ATen/CPUGeneratorImpl.cpp
@@ -141,8 +141,8 @@ void CPUGeneratorImpl::set_state(const c10::TensorImpl& new_state) {
   using detail::CPUGeneratorImplState;
   using detail::CPUGeneratorImplStateLegacy;
 
-  static_assert(std::is_standard_layout<CPUGeneratorImplStateLegacy>::value, "CPUGeneratorImplStateLegacy is not a PODType");
-  static_assert(std::is_standard_layout<CPUGeneratorImplState>::value, "CPUGeneratorImplState is not a PODType");
+  static_assert(std::is_standard_layout_v<CPUGeneratorImplStateLegacy>, "CPUGeneratorImplStateLegacy is not a PODType");
+  static_assert(std::is_standard_layout_v<CPUGeneratorImplState>, "CPUGeneratorImplState is not a PODType");
 
   static const size_t size_legacy = sizeof(CPUGeneratorImplStateLegacy);
   static const size_t size_current = sizeof(CPUGeneratorImplState);
@@ -155,8 +155,7 @@ void CPUGeneratorImpl::set_state(const c10::TensorImpl& new_state) {
   auto double_normal_sample = c10::optional<double>();
 
   // Construct the state of at::CPUGeneratorImpl based on input byte tensor size.
-  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  CPUGeneratorImplStateLegacy* legacy_pod;
+  CPUGeneratorImplStateLegacy* legacy_pod{nullptr};
   auto new_state_size = new_state.numel();
   if (new_state_size == size_legacy) {
     legacy_pod = (CPUGeneratorImplStateLegacy*)new_state.data();
@@ -221,7 +220,7 @@ c10::intrusive_ptr<c10::TensorImpl> CPUGeneratorImpl::get_state() const {
   using detail::CPUGeneratorImplState;
 
   static const size_t size = sizeof(CPUGeneratorImplState);
-  static_assert(std::is_standard_layout<CPUGeneratorImplState>::value, "CPUGeneratorImplState is not a PODType");
+  static_assert(std::is_standard_layout_v<CPUGeneratorImplState>, "CPUGeneratorImplState is not a PODType");
 
   auto state_tensor = at::detail::empty_cpu({(int64_t)size}, ScalarType::Byte, c10::nullopt, c10::nullopt, c10::nullopt, c10::nullopt);
   auto rng_state = state_tensor.data_ptr();

--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -148,7 +148,7 @@ static Device getATenDevice(const DLDevice& ctx, void* data) {
 }
 
 ScalarType toScalarType(const DLDataType& dtype) {
-  ScalarType stype;
+  ScalarType stype = ScalarType::Undefined;
   TORCH_CHECK(dtype.lanes == 1, "ATen does not support lanes != 1");
   switch (dtype.code) {
     case DLDataTypeCode::kDLUInt:
@@ -306,7 +306,7 @@ Tensor fromDLPack(const DLManagedTensor* src) {
 
 Tensor fromDLPack(
     const DLManagedTensor* src,
-    std::function<void(void*)> deleter) {
+    const std::function<void(void*)>& deleter) {
   Device device = getATenDevice(src->dl_tensor.device, src->dl_tensor.data);
   ScalarType stype = toScalarType(src->dl_tensor.dtype);
   if (!src->dl_tensor.strides) {

--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -242,8 +242,7 @@ ScalarType toScalarType(const DLDataType& dtype) {
       }
       break;
     default:
-      TORCH_CHECK(
-          false, "Unsupported code " + c10::to_string(dtype.code));
+      TORCH_CHECK(false, "Unsupported code " + c10::to_string(dtype.code));
   }
   return stype;
 }
@@ -265,7 +264,7 @@ DLManagedTensor* toDLPack(const Tensor& src) {
   // gh-83069
   auto shape = src.sizes();
   auto strides = src.strides().vec();
-  for (int i=0; i<src.dim(); i++) {
+  for (int i = 0; i < src.dim(); i++) {
     if (shape[i] < 2) {
       strides[i] = 1;
     }
@@ -306,14 +305,14 @@ Tensor fromDLPack(const DLManagedTensor* src) {
 
 Tensor fromDLPack(
     const DLManagedTensor* src,
-    const std::function<void(void*)>& deleter) {
+    std::function<void(void*)> deleter) {
   Device device = getATenDevice(src->dl_tensor.device, src->dl_tensor.data);
   ScalarType stype = toScalarType(src->dl_tensor.dtype);
   if (!src->dl_tensor.strides) {
     return at::from_blob(
         src->dl_tensor.data,
         IntArrayRef(src->dl_tensor.shape, src->dl_tensor.ndim),
-        deleter,
+        std::move(deleter),
         at::device(device).dtype(stype),
         {device});
   }
@@ -323,6 +322,6 @@ Tensor fromDLPack(
       IntArrayRef(src->dl_tensor.strides, src->dl_tensor.ndim),
       deleter,
       at::device(device).dtype(stype),
-      { device });
+      {device});
 }
 } // namespace at

--- a/aten/src/ATen/DLConvertor.h
+++ b/aten/src/ATen/DLConvertor.h
@@ -13,8 +13,9 @@ namespace at {
 TORCH_API ScalarType toScalarType(const DLDataType& dtype);
 TORCH_API DLManagedTensor* toDLPack(const Tensor& src);
 TORCH_API Tensor fromDLPack(const DLManagedTensor* src);
-TORCH_API Tensor
-fromDLPack(const DLManagedTensor* src, std::function<void(void*)> deleter);
+TORCH_API Tensor fromDLPack(
+    const DLManagedTensor* src,
+    const std::function<void(void*)>& deleter);
 TORCH_API DLDataType getDLDataType(const Tensor& t);
 TORCH_API DLDevice getDLContext(const Tensor& tensor, const int64_t& device_id);
 

--- a/aten/src/ATen/DLConvertor.h
+++ b/aten/src/ATen/DLConvertor.h
@@ -13,9 +13,8 @@ namespace at {
 TORCH_API ScalarType toScalarType(const DLDataType& dtype);
 TORCH_API DLManagedTensor* toDLPack(const Tensor& src);
 TORCH_API Tensor fromDLPack(const DLManagedTensor* src);
-TORCH_API Tensor fromDLPack(
-    const DLManagedTensor* src,
-    const std::function<void(void*)>& deleter);
+TORCH_API Tensor
+fromDLPack(const DLManagedTensor* src, std::function<void(void*)> deleter);
 TORCH_API DLDataType getDLDataType(const Tensor& t);
 TORCH_API DLDevice getDLContext(const Tensor& tensor, const int64_t& device_id);
 

--- a/aten/src/ATen/DynamicLibrary.cpp
+++ b/aten/src/ATen/DynamicLibrary.cpp
@@ -25,9 +25,7 @@ static void* checkDL(void* x) {
 
   return x;
 }
-DynamicLibrary::DynamicLibrary(const char* name, const char* alt_name, bool leak_handle_): leak_handle(leak_handle_) {
-  // NOLINTNEXTLINE(hicpp-signed-bitwise)
-  handle = dlopen(name, RTLD_LOCAL | RTLD_NOW);
+DynamicLibrary::DynamicLibrary(const char* name, const char* alt_name, bool leak_handle_): leak_handle(leak_handle_), handle(dlopen(name, RTLD_LOCAL | RTLD_NOW)) {
   if (!handle) {
     if (alt_name) {
       handle = dlopen(alt_name, RTLD_LOCAL | RTLD_NOW);

--- a/aten/src/ATen/EmptyTensor.cpp
+++ b/aten/src/ATen/EmptyTensor.cpp
@@ -91,7 +91,7 @@ size_t computeStorageNbytes(
       return 0;
     }
 
-    uint64_t strided_size;
+    uint64_t strided_size = 0;
     overflowed |= c10::mul_overflows(strides[i], sizes[i] - 1, &strided_size);
     overflowed |= c10::add_overflows(size, strided_size, &size);
   }

--- a/aten/src/ATen/FunctionalStorageImpl.cpp
+++ b/aten/src/ATen/FunctionalStorageImpl.cpp
@@ -94,7 +94,7 @@ FunctionalStorageImpl::FunctionalStorageImpl(const Tensor& base)
       get_nbytes(base),
       DataPtr{nullptr, base.device()},
       GetAllocator(kMeta),
-      /*resizeable=*/true
+      /*resizable=*/true
     ),
     base_(base)
   {

--- a/aten/src/ATen/FunctionalTensorWrapper.h
+++ b/aten/src/ATen/FunctionalTensorWrapper.h
@@ -56,7 +56,7 @@ struct TORCH_API FunctionalTensorWrapper : public c10::TensorImpl {
   explicit FunctionalTensorWrapper(
       const Tensor& view_value,
       const FunctionalTensorWrapper* base,
-      functionalization::ViewMeta meta);
+      const functionalization::ViewMeta& meta);
 
   // Get the underlying, actual tensor, that doesn't know anything about
   // functionalization.
@@ -130,7 +130,7 @@ struct TORCH_API FunctionalTensorWrapper : public c10::TensorImpl {
   // from the base tensor. This method is used by inplace-view ops like
   // transpose_. It appends a ViewMeta to the existing stack, and refreshes the
   // tensor by replaying the views off of the alias.
-  void mutate_view_meta(at::functionalization::ViewMeta meta);
+  void mutate_view_meta(const at::functionalization::ViewMeta& meta);
 
   // Custom implementation of self.set_(src)
   void set__impl(const FunctionalTensorWrapper* other);
@@ -221,7 +221,7 @@ struct TORCH_API FunctionalTensorWrapper : public c10::TensorImpl {
   // Note that value is not taken by reference: internally, the wrapper will
   // change the value tensor that it points to over time.
   Tensor value_;
-  int64_t level_;
+  int64_t level_{};
   // These two counters are used for identifying
   // whether all the mutations on a given tensor are hidden from autograd or
   // not. If we have an input mutation that is hidden from autograd, then once
@@ -324,9 +324,11 @@ Tensor create_functional_tensor_with_view_meta(
 std::vector<Tensor> create_functional_tensor_with_view_meta(
     ITensorListRef view_to_wrap,
     const Tensor& base,
-    functionalization::ViewMeta meta);
+    const functionalization::ViewMeta& meta);
 
-void mutate_view_meta(const Tensor& self, functionalization::ViewMeta meta);
+void mutate_view_meta(
+    const Tensor& self,
+    const functionalization::ViewMeta& meta);
 
 void set_sizes_strides_offset(const Tensor& out, const Tensor& meta_out);
 void set_sizes_strides_offset(

--- a/aten/src/ATen/MapAllocator.cpp
+++ b/aten/src/ATen/MapAllocator.cpp
@@ -63,7 +63,6 @@ constexpr const char* unknown_eventname = "eventname not specified";
 
 MapAllocator::MapAllocator(WithFd, c10::string_view filename, int fd, int flags, size_t size)
   : filename_(filename.empty() ? unknown_filename : filename)
-  , flags_(0) // to be filled later
   , size_(0) // to be filled later
 #ifdef _WIN32
   , handle_(INVALID_HANDLE_VALUE) // to be filled later
@@ -72,7 +71,6 @@ MapAllocator::MapAllocator(WithFd, c10::string_view filename, int fd, int flags,
 #else
   , fd_(fd)
 #endif
-  , base_ptr_(nullptr)
 {
 
   if (!(flags & ALLOCATOR_MAPPED_SHARED) && !(flags & ALLOCATOR_MAPPED_SHAREDMEM)) {
@@ -272,7 +270,7 @@ MapAllocator::MapAllocator(WithFd, c10::string_view filename, int fd, int flags,
       fd = fd_;
     }
 
-    struct stat file_stat;
+    struct stat file_stat{};
     if (fstat(fd, &file_stat) == -1) {
       int last_err = errno;
       if (!(flags_ & ALLOCATOR_MAPPED_FROMFD)) {

--- a/aten/src/ATen/MatrixRef.h
+++ b/aten/src/ATen/MatrixRef.h
@@ -94,16 +94,16 @@ class MatrixRef {
   /// The declaration here is extra complicated so that "arrayRef = {}"
   /// continues to select the move assignment operator.
   template <typename U>
-  typename std::enable_if<std::is_same<U, T>::value, MatrixRef<T>>::type&
-  operator=(U&& Temporary) = delete;
+  std::enable_if_t<std::is_same_v<U, T>, MatrixRef<T>>& operator=(
+      U&& Temporary) = delete;
 
   /// Disallow accidental assignment from a temporary.
   ///
   /// The declaration here is extra complicated so that "arrayRef = {}"
   /// continues to select the move assignment operator.
   template <typename U>
-  typename std::enable_if<std::is_same<U, T>::value, MatrixRef<T>>::type&
-  operator=(std::initializer_list<U>) = delete;
+  std::enable_if_t<std::is_same_v<U, T>, MatrixRef<T>>& operator=(
+      std::initializer_list<U>) = delete;
 };
 
 } // end namespace at

--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -10,6 +10,7 @@
 
 #include <numeric>
 #include <functional>
+#include <utility>
 
 namespace {
 inline void validate_nested_tensor_metadata(
@@ -67,8 +68,8 @@ c10::DispatchKeySet get_view_key_set(const at::Tensor& base) {
 }
 
 } // namespace
-namespace at {
-namespace native {
+
+namespace at::native {
 
 inline std::vector<int64_t> construct_opt_sizes(const at::Tensor& sizes) {
   // torch.tensor([]) is considered to have `dim() = 1` and `size(0) = 0`
@@ -188,7 +189,7 @@ NestedTensorImpl::NestedTensorImpl(
 }
 
 NestedTensorImpl::NestedTensorImpl(
-    at::Tensor buffer,
+    const at::Tensor& buffer,
     at::Tensor nested_sizes,
     at::Tensor nested_strides,
     at::Tensor storage_offsets)
@@ -196,9 +197,9 @@ NestedTensorImpl::NestedTensorImpl(
           buffer.storage(),
           generate_nested_key_set_from_buffer(buffer),
           buffer.dtype(),
-          nested_sizes,
-          nested_strides,
-          storage_offsets) {
+          std::move(nested_sizes),
+          std::move(nested_strides),
+          std::move(storage_offsets)) {
 
   TORCH_INTERNAL_ASSERT(
       buffer.dim() == 1,
@@ -210,8 +211,8 @@ NestedTensorImpl::NestedTensorImpl(
 // assume contiguous, `nested_strides` and `offsets`
 // can be infered from `nested_sizes`
 NestedTensorImpl::NestedTensorImpl(
-    at::Tensor buffer,
-    at::Tensor nested_sizes)
+    const at::Tensor& buffer,
+    const at::Tensor& nested_sizes)
     : NestedTensorImpl(
           buffer,
           nested_sizes,
@@ -359,5 +360,4 @@ int64_t get_numel_from_nested_size_tensor(const at::Tensor& tensor) {
   return static_cast<int64_t>(num_elements);
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -25,13 +25,15 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
       at::Tensor storage_offsets);
 
   explicit NestedTensorImpl(
-      at::Tensor buffer,
+      const at::Tensor& buffer,
       at::Tensor nested_sizes,
       at::Tensor nested_strides,
       at::Tensor storage_offsets);
   // assume contiguous, `nested_strides` and `offsets`
   // can be infered from `nested_sizes`
-  explicit NestedTensorImpl(at::Tensor buffer, at::Tensor nested_sizes);
+  explicit NestedTensorImpl(
+      const at::Tensor& buffer,
+      const at::Tensor& nested_sizes);
 
   // This constructor is used creating view tensors from nested tensors
   explicit NestedTensorImpl(

--- a/aten/src/ATen/NumericUtils.h
+++ b/aten/src/ATen/NumericUtils.h
@@ -22,16 +22,12 @@ namespace at {
 // (uselessly) convert to floating point and then do the test.
 // This function is.
 
-template <
-    typename T,
-    typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
 inline C10_HOST_DEVICE bool _isnan(T /*val*/) {
   return false;
 }
 
-template <
-    typename T,
-    typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
+template <typename T, std::enable_if_t<std::is_floating_point_v<T>, int> = 0>
 inline C10_HOST_DEVICE bool _isnan(T val) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return ::isnan(val);
@@ -40,24 +36,19 @@ inline C10_HOST_DEVICE bool _isnan(T val) {
 #endif
 }
 
-template <
-    typename T,
-    typename std::enable_if<c10::is_complex<T>::value, int>::type = 0>
+template <typename T, std::enable_if_t<c10::is_complex<T>::value, int> = 0>
 inline C10_HOST_DEVICE bool _isnan(T val) {
   return std::isnan(val.real()) || std::isnan(val.imag());
 }
 
-template <
-    typename T,
-    typename std::enable_if<std::is_same<T, at::Half>::value, int>::type = 0>
+template <typename T, std::enable_if_t<std::is_same_v<T, at::Half>, int> = 0>
 inline C10_HOST_DEVICE bool _isnan(T val) {
   return at::_isnan(static_cast<float>(val));
 }
 
 template <
     typename T,
-    typename std::enable_if<std::is_same<T, at::BFloat16>::value, int>::type =
-        0>
+    std::enable_if_t<std::is_same_v<T, at::BFloat16>, int> = 0>
 inline C10_HOST_DEVICE bool _isnan(at::BFloat16 val) {
   return at::_isnan(static_cast<float>(val));
 }
@@ -68,32 +59,28 @@ inline C10_HOST_DEVICE bool _isnan(at::BFloat16 val) {
 
 template <
     typename T,
-    typename std::enable_if<std::is_same<T, at::Float8_e5m2>::value, int>::
-        type = 0>
+    std::enable_if_t<std::is_same_v<T, at::Float8_e5m2>, int> = 0>
 inline C10_HOST_DEVICE bool _isnan(T val) {
   return val.isnan();
 }
 
 template <
     typename T,
-    typename std::enable_if<std::is_same<T, at::Float8_e4m3fn>::value, int>::
-        type = 0>
+    std::enable_if_t<std::is_same_v<T, at::Float8_e4m3fn>, int> = 0>
 inline C10_HOST_DEVICE bool _isnan(T val) {
   return val.isnan();
 }
 
 template <
     typename T,
-    typename std::enable_if<std::is_same<T, at::Float8_e5m2fnuz>::value, int>::
-        type = 0>
+    std::enable_if_t<std::is_same_v<T, at::Float8_e5m2fnuz>, int> = 0>
 inline C10_HOST_DEVICE bool _isnan(T val) {
   return val.isnan();
 }
 
 template <
     typename T,
-    typename std::enable_if<std::is_same<T, at::Float8_e4m3fnuz>::value, int>::
-        type = 0>
+    std::enable_if_t<std::is_same_v<T, at::Float8_e4m3fnuz>, int> = 0>
 inline C10_HOST_DEVICE bool _isnan(T val) {
   return val.isnan();
 }
@@ -102,16 +89,12 @@ inline C10_HOST_DEVICE bool _isnan(T val) {
 // (uselessly) convert to floating point and then do the test.
 // This function is.
 
-template <
-    typename T,
-    typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
 inline C10_HOST_DEVICE bool _isinf(T /*val*/) {
   return false;
 }
 
-template <
-    typename T,
-    typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
+template <typename T, std::enable_if_t<std::is_floating_point_v<T>, int> = 0>
 inline C10_HOST_DEVICE bool _isinf(T val) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return ::isinf(val);
@@ -147,7 +130,7 @@ inline C10_HOST_DEVICE bool _isinf(at::Float8_e4m3fnuz val) {
 template <typename T>
 C10_HOST_DEVICE inline T exp(T x) {
   static_assert(
-      !std::is_same<T, double>::value,
+      !std::is_same_v<T, double>,
       "this template must be used with float or less precise type");
 #if defined(__CUDA_ARCH__) || defined(__HIP_ARCH__)
   // use __expf fast approximation for peak bandwidth
@@ -165,7 +148,7 @@ C10_HOST_DEVICE inline double exp<double>(double x) {
 template <typename T>
 C10_HOST_DEVICE inline T log(T x) {
   static_assert(
-      !std::is_same<T, double>::value,
+      !std::is_same_v<T, double>,
       "this template must be used with float or less precise type");
 #if defined(__CUDA_ARCH__) || defined(__HIP_ARCH__)
   // use __logf fast approximation for peak bandwidth
@@ -183,7 +166,7 @@ C10_HOST_DEVICE inline double log<double>(double x) {
 template <typename T>
 C10_HOST_DEVICE inline T log1p(T x) {
   static_assert(
-      !std::is_same<T, double>::value,
+      !std::is_same_v<T, double>,
       "this template must be used with float or less precise type");
 #if defined(__CUDA_ARCH__) || defined(__HIP_ARCH__)
   // use __logf fast approximation for peak bandwidth
@@ -202,7 +185,7 @@ C10_HOST_DEVICE inline double log1p<double>(double x) {
 template <typename T>
 C10_HOST_DEVICE inline T tan(T x) {
   static_assert(
-      !std::is_same<T, double>::value,
+      !std::is_same_v<T, double>,
       "this template must be used with float or less precise type");
 #if defined(__CUDA_ARCH__) || defined(__HIP_ARCH__)
   // use __tanf fast approximation for peak bandwidth

--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -33,6 +33,7 @@ struct TORCH_API OpaqueTensorImpl : public TensorImpl {
     set_custom_sizes_strides(SizesStridesPolicy::CustomStrides);
     sizes_and_strides_.set_sizes(sizes);
     refresh_numel();
+    // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
     is_non_overlapping_and_dense_ = is_non_overlapping_and_dense;
   }
 

--- a/aten/src/ATen/ParallelCommon.cpp
+++ b/aten/src/ATen/ParallelCommon.cpp
@@ -46,30 +46,30 @@ std::string get_parallel_info() {
   std::ostringstream ss;
 
   ss << "ATen/Parallel:\n\tat::get_num_threads() : "
-     << at::get_num_threads() << std::endl;
+     << at::get_num_threads() << '\n';
   ss << "\tat::get_num_interop_threads() : "
-     << at::get_num_interop_threads() << std::endl;
+     << at::get_num_interop_threads() << '\n';
 
-  ss << at::get_openmp_version() << std::endl;
+  ss << at::get_openmp_version() << '\n';
 #ifdef _OPENMP
-  ss << "\tomp_get_max_threads() : " << omp_get_max_threads() << std::endl;
+  ss << "\tomp_get_max_threads() : " << omp_get_max_threads() << '\n';
 #endif
 
-  ss << at::get_mkl_version() << std::endl;
+  ss << at::get_mkl_version() << '\n';
 #if AT_MKL_ENABLED()
-  ss << "\tmkl_get_max_threads() : " << mkl_get_max_threads() << std::endl;
+  ss << "\tmkl_get_max_threads() : " << mkl_get_max_threads() << '\n';
 #endif
 
-  ss << at::get_mkldnn_version() << std::endl;
+  ss << at::get_mkldnn_version() << '\n';
 
   ss << "std::thread::hardware_concurrency() : "
-     << std::thread::hardware_concurrency() << std::endl;
+     << std::thread::hardware_concurrency() << '\n';
 
-  ss << "Environment variables:" << std::endl;
+  ss << "Environment variables:" << '\n';
   ss << "\tOMP_NUM_THREADS : "
-     << get_env_var("OMP_NUM_THREADS", "[not set]") << std::endl;
+     << get_env_var("OMP_NUM_THREADS", "[not set]") << '\n';
   ss << "\tMKL_NUM_THREADS : "
-     << get_env_var("MKL_NUM_THREADS", "[not set]") << std::endl;
+     << get_env_var("MKL_NUM_THREADS", "[not set]") << '\n';
 
   ss << "ATen parallel backend: ";
   #if AT_PARALLEL_OPENMP
@@ -82,7 +82,7 @@ std::string get_parallel_info() {
   #ifdef C10_MOBILE
   ss << " [mobile]";
   #endif
-  ss << std::endl;
+  ss << '\n';
 
   #if AT_EXPERIMENTAL_SINGLE_THREAD_POOL
   ss << "Experimental: single thread pool" << std::endl;

--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -11,10 +11,8 @@
 #include <omp.h>
 #endif
 
-namespace at {
-
 #ifdef _OPENMP
-namespace internal {
+namespace at::internal {
 template <typename F>
 inline void invoke_parallel(
     int64_t begin,
@@ -52,7 +50,5 @@ inline void invoke_parallel(
     std::rethrow_exception(eptr);
   }
 }
-} // namespace internal
+} // namespace at::internal
 #endif // _OPENMP
-
-} // namespace at

--- a/aten/src/ATen/SparseCsrTensorUtils.h
+++ b/aten/src/ATen/SparseCsrTensorUtils.h
@@ -137,8 +137,7 @@
       AT_DISPATCH_CASE_ALL_TYPES_AND_COMPLEX_AND4(      \
           kComplexHalf, kHalf, kBool, kBFloat16, __VA_ARGS__))
 
-namespace at {
-namespace sparse_csr {
+namespace at::sparse_csr {
 
 using SparseCsrTensor = Tensor;
 
@@ -366,12 +365,12 @@ inline bool only_sparse_compressed_add_trivial_cases(
       });
 }
 
-inline Tensor to_type(Tensor input, ScalarType dtype) {
+inline Tensor to_type(const Tensor& input, ScalarType dtype) {
   auto [compressed_indices, plain_indices] =
       at::sparse_csr::getCompressedPlainIndices(input);
   return at::_sparse_compressed_tensor_unsafe(
-      std::move(compressed_indices),
-      std::move(plain_indices),
+      compressed_indices,
+      plain_indices,
       std::move(input.values()).to(dtype),
       input.sizes(),
       dtype,
@@ -386,7 +385,7 @@ inline std::tuple<Tensor, Tensor> create_acc_buffer(
     ScalarType type,
     int64_t nnz = -1) {
   Tensor new_values, new_values_acc;
-  constexpr bool need_acc = !std::is_same<scalar_t, acc_t>::value;
+  constexpr bool need_acc = !std::is_same_v<scalar_t, acc_t>;
   bool is_integral = at::isIntegralType(type, /*includeBool=*/true);
   if constexpr (need_acc) {
     auto acc_dtype = CppTypeToScalarType<acc_t>::value;
@@ -409,5 +408,4 @@ inline void copy_from_acc_buffer(Tensor& new_values, Tensor& new_values_acc) {
   }
 }
 
-} // namespace sparse_csr
-} // namespace at
+} // namespace at::sparse_csr

--- a/aten/src/ATen/SparseTensorImpl.cpp
+++ b/aten/src/ATen/SparseTensorImpl.cpp
@@ -35,7 +35,6 @@ SparseTensorImpl::SparseTensorImpl(at::DispatchKeySet key_set, const caffe2::Typ
 SparseTensorImpl::SparseTensorImpl(at::DispatchKeySet key_set, const caffe2::TypeMeta data_type, at::Tensor indices, at::Tensor values)
     : TensorImpl(key_set, data_type, values.device())
     , sparse_dim_(1)
-    , dense_dim_(0)
     , indices_(std::move(indices))
     , values_(std::move(values)) {
   // we proxy to this constructor so we can initialize the device correctly, but really only indices/values of this shape are allowed.

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -338,7 +338,7 @@ struct TORCH_API SparseTensorImpl : public TensorImpl {
     copy_tensor_metadata(
         /*src_impl=*/this,
         /*dest_impl=*/impl.get(),
-        /*version_counter=*/std::move(version_counter),
+        /*version_counter=*/version_counter,
         /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
     impl->refresh_numel();
     return impl;

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -130,9 +130,7 @@ struct TORCH_API TensorIndex final {
   TensorIndex(int integer) : TensorIndex(SymInt(integer)) {}
 
   // Case 4: Boolean value
-  template <
-      class T,
-      class = typename std::enable_if<std::is_same<bool, T>::value>::type>
+  template <class T, class = std::enable_if_t<std::is_same_v<bool, T>>>
   TensorIndex(T boolean) : boolean_(boolean), type_(TensorIndexType::Boolean) {}
 
   // Case 5: Slice represented in `at::indexing::Slice` form

--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -79,7 +79,7 @@ constexpr int64_t GRAIN_SIZE = 32768;
 
 // Storage for a non-owning Tensor, without needing to include Tensor.h
 class TORCH_API OpaqueOptionalTensorRef {
-  alignas(alignof(TensorBase)) std::array<char, sizeof(TensorBase)> data_;
+  alignas(alignof(TensorBase)) std::array<char, sizeof(TensorBase)> data_{};
 
  public:
   OpaqueOptionalTensorRef();
@@ -416,10 +416,10 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
   template <
       typename loop1d_t,
       std::enable_if_t<
-          std::is_convertible<
+          std::is_convertible_v<
               loop1d_t,
               c10::function_ref<
-                  void(char**, const int64_t* strides, int64_t size)>>::value,
+                  void(char**, const int64_t* strides, int64_t size)>>,
           int> = 0>
   void for_each(loop1d_t loop, int64_t grain_size = at::internal::GRAIN_SIZE) {
     for_each(loop_2d_from_1d(loop), grain_size);
@@ -432,10 +432,10 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
   template <
       typename loop1d_t,
       std::enable_if_t<
-          std::is_convertible<
+          std::is_convertible_v<
               loop1d_t,
               c10::function_ref<
-                  void(char**, const int64_t* strides, int64_t size)>>::value,
+                  void(char**, const int64_t* strides, int64_t size)>>,
           int> = 0>
   void serial_for_each(loop1d_t loop, Range range) {
     serial_for_each(loop_2d_from_1d(loop), range);

--- a/aten/src/ATen/TensorUtils.cpp
+++ b/aten/src/ATen/TensorUtils.cpp
@@ -9,7 +9,7 @@
 
 namespace at {
 
-std::ostream& operator<<(std::ostream & out, TensorGeometryArg t) {
+std::ostream& operator<<(std::ostream & out, const TensorGeometryArg& t) {
   if (t.pos == 0) {
     // 0 is distinguished; it usually indicates 'self' or the return
     // tensor
@@ -91,7 +91,7 @@ void checkSize(CheckedFrom c, const TensorGeometryArg& t, int64_t dim, int64_t s
     " (while checking arguments for ", c, ")");
 }
 
-void checkSize_symint(CheckedFrom c, const TensorGeometryArg& t, int64_t dim, c10::SymInt size) {
+void checkSize_symint(CheckedFrom c, const TensorGeometryArg& t, int64_t dim, const c10::SymInt& size) {
   TORCH_CHECK(
     t->sym_size(dim) == size,
     "Expected tensor to have size ", size, " at dimension ", dim,

--- a/aten/src/ATen/TensorUtils.h
+++ b/aten/src/ATen/TensorUtils.h
@@ -66,7 +66,9 @@ using CheckedFrom = const char*;
 // not TensorGeometryArg, because the Tensor to TensorGeometry
 // conversion will blow up if you have undefined tensors.
 
-TORCH_API std::ostream& operator<<(std::ostream& out, TensorGeometryArg t);
+TORCH_API std::ostream& operator<<(
+    std::ostream& out,
+    const TensorGeometryArg& t);
 TORCH_API void checkDim(
     CheckedFrom c,
     const Tensor& tensor,
@@ -103,7 +105,7 @@ TORCH_API void checkSize_symint(
     CheckedFrom c,
     const TensorGeometryArg& t,
     int64_t dim,
-    c10::SymInt size);
+    const c10::SymInt& size);
 TORCH_API void checkNumel(
     CheckedFrom c,
     const TensorGeometryArg& t,

--- a/aten/src/ATen/ceil_div.h
+++ b/aten/src/ATen/ceil_div.h
@@ -7,7 +7,7 @@ namespace at {
 /**
    Computes ceil(a / b)
 */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
+template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
 C10_ALWAYS_INLINE C10_HOST_DEVICE T ceil_div(T a, T b) {
   return (a + b - 1) / b;
 }

--- a/aten/src/ATen/code_template.h
+++ b/aten/src/ATen/code_template.h
@@ -7,8 +7,7 @@
 #include <unordered_map>
 #include <vector>
 
-namespace at {
-namespace jit {
+namespace at::jit {
 
 // A template environment is a mapping from template variable names, e.g.,
 // identifier (corresponding to $identifier) to their expansions.
@@ -241,5 +240,4 @@ static inline std::string format(const std::string& fmt, TemplateEnv& env) {
   return CodeTemplate(fmt).format(env);
 }
 
-} // namespace jit
-} // namespace at
+} // namespace at::jit

--- a/aten/src/ATen/cpp_custom_type_hack.h
+++ b/aten/src/ATen/cpp_custom_type_hack.h
@@ -57,8 +57,7 @@
 #include <ATen/ops/empty.h>
 #endif
 
-namespace at {
-namespace cpp_custom_type_hack {
+namespace at::cpp_custom_type_hack {
 
 template <typename T>
 [[deprecated(
@@ -108,5 +107,4 @@ create(std::unique_ptr<T> ptr, TensorOptions options) {
   return retval;
 }
 
-} // namespace cpp_custom_type_hack
-} // namespace at
+} // namespace at::cpp_custom_type_hack

--- a/aten/src/ATen/ops/from_blob.h
+++ b/aten/src/ATen/ops/from_blob.h
@@ -16,9 +16,8 @@ TORCH_API inline void noopDelete(void*) {}
 ///
 ///     at::Tensor tensor = at::for_blob(data, sizes)
 ///             .strides(strides)
-///             .context(context, [](void *ctx) { delete static_cast<Ctx*>(ctx); })
-///             .options(...)
-///             .make_tensor();
+///             .context(context, [](void *ctx) { delete static_cast<Ctx*>(ctx);
+///             }) .options(...) .make_tensor();
 ///
 class TORCH_API TensorMaker {
   friend TensorMaker for_blob(void* data, IntArrayRef sizes) noexcept;
@@ -140,11 +139,11 @@ inline Tensor from_blob(
 inline Tensor from_blob(
     void* data,
     IntArrayRef sizes,
-    const std::function<void(void*)>& deleter,
+    std::function<void(void*)> deleter,
     const TensorOptions& options = {},
     const c10::optional<Device> target_device = c10::nullopt) {
   return for_blob(data, sizes)
-      .deleter(deleter)
+      .deleter(std::move(deleter))
       .options(options)
       .target_device(target_device)
       .make_tensor();
@@ -155,10 +154,7 @@ inline Tensor from_blob(
     IntArrayRef sizes,
     IntArrayRef strides,
     const TensorOptions& options = {}) {
-  return for_blob(data, sizes)
-      .strides(strides)
-      .options(options)
-      .make_tensor();
+  return for_blob(data, sizes).strides(strides).options(options).make_tensor();
 }
 
 inline Tensor from_blob(
@@ -168,4 +164,4 @@ inline Tensor from_blob(
   return for_blob(data, sizes).options(options).make_tensor();
 }
 
-}  // namespace at
+} // namespace at

--- a/aten/src/ATen/record_function.cpp
+++ b/aten/src/ATen/record_function.cpp
@@ -226,7 +226,7 @@ CallbackHandle GlobalCallbackManager::addCallback(RecordFunctionCallback cb) {
   std::lock_guard<std::mutex> guard(update_mutex_);
   ++version_;
   auto handle = next_unique_callback_handle();
-  global_callbacks_.emplace_back(std::move(cb), handle);
+  global_callbacks_.emplace_back(cb, handle);
   return handle;
 }
 
@@ -416,7 +416,7 @@ CallbackHandle LocalCallbackManager::addCallback(
     RecordFunctionCallback callback) {
   auto handle = next_unique_callback_handle();
   auto& callbacks = registered_callbacks_.sorted_tls_callbacks_;
-  callbacks.emplace_back(std::move(callback), handle);
+  callbacks.emplace_back(callback, handle);
   rebuild_callback_scopes(
       GlobalCallbackManager::get().getSnapshot(), callbacks.back().callback_);
   return handle;
@@ -647,12 +647,12 @@ bool hasThreadLocalCallbacks() {
 
 CallbackHandle addThreadLocalCallback(
     RecordFunctionCallback cb) {
-  return LocalCallbackManager::get().addCallback(std::move(cb));
+  return LocalCallbackManager::get().addCallback(cb);
 }
 
 CallbackHandle addGlobalCallback(
     RecordFunctionCallback cb) {
-  return GlobalCallbackManager::get().addCallback(std::move(cb));
+  return GlobalCallbackManager::get().addCallback(cb);
 }
 
 void removeCallback(CallbackHandle handle) {

--- a/aten/src/ATen/record_function.h
+++ b/aten/src/ATen/record_function.h
@@ -7,7 +7,6 @@
 #include <c10/util/SmallVector.h>
 
 #include <array>
-#include <atomic>
 #include <functional>
 #include <memory>
 #include <variant>
@@ -244,7 +243,7 @@ constexpr CallbackHandle INVALID_CALLBACK_HANDLE{0};
 // thread-local function callbacks. Moreover, it prevents saving to
 // ThreadLocalState because std::atomic is non-copyable.
 struct RecordFunctionCallbacksEntry {
-  RecordFunctionCallbacksEntry(RecordFunctionCallback&& cb, CallbackHandle h)
+  RecordFunctionCallbacksEntry(RecordFunctionCallback cb, CallbackHandle h)
       : callback_(cb), handle_(h) {}
 
   RecordFunctionCallback callback_;


### PR DESCRIPTION
This PR fixes some clang-tidy warnings in aten/src/ATEN/*.