### PR TITLE
Removed unneeded `.detach` in `clip_grad_norm_`

### DIFF
--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -46,7 +46,7 @@ def clip_grad_norm_(
         = _group_tensors_by_device_and_dtype([[g.detach() for g in grads]])  # type: ignore[assignment]
 
     if norm_type == inf:
-        norms = [torch.linalg.vector_norm(g.detach(), inf).to(first_device) for g in grads]
+        norms = [torch.linalg.vector_norm(g, inf).to(first_device) for g in grads]
         total_norm = norms[0] if len(norms) == 1 else torch.max(torch.stack(norms))
     else:
         norms = []

--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -43,7 +43,7 @@ def clip_grad_norm_(
         return torch.tensor(0.)
     first_device = grads[0].device
     grouped_grads: Dict[Tuple[torch.device, torch.dtype], List[List[Tensor]]] \
-        = _group_tensors_by_device_and_dtype([[g.detach() for g in grads]])  # type: ignore[assignment]
+        = _group_tensors_by_device_and_dtype([grads])  # type: ignore[assignment]
 
     if norm_type == inf:
         norms = [torch.linalg.vector_norm(g, inf).to(first_device) for g in grads]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #120617
* #120238
* __->__ #120613
* #120612
* #120231

This PR removes some unneeded `.detach()` calls in `clip_grad_norm_()`.

In the future, we prefer to remove the `g.detach().mul_()` and use `torch.no_grad()` instead, but that is blocked by a circular import issue.