### PR TITLE
Prefer construction via DLPack to costly element-by-element copy

### DIFF
--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -355,6 +355,23 @@ Tensor internal_new_from_data(
   }
 #endif
 
+  if (PyObject_HasAttrString(data, "__dlpack__")) {
+    py::object tensor_o =
+        py::module::import("torch").attr("utils").attr("dlpack").attr(
+            "from_dlpack")(py::handle(data));
+    Tensor tensor = py::cast<Tensor>(tensor_o);
+    const auto& inferred_scalar_type =
+        type_inference ? tensor.scalar_type() : scalar_type;
+    auto device = device_opt.has_value() ? *device_opt : tensor.device();
+    pybind11::gil_scoped_release no_gil;
+    maybe_initialize_device(device);
+    return tensor.to(
+        device,
+        inferred_scalar_type,
+        /*non_blocking=*/false,
+        /*copy=*/copy_variables);
+  }
+
   auto device = device_opt.has_value() ? *device_opt : options.device();
 
   auto sizes = compute_sizes(data, scalar_type);


### PR DESCRIPTION
Fixes #120614

## Copy of pitch:

Consider the following statement
```python
torch_array = torch.tensor(other_array)
```
where `other_array` is an array instance constructed by another array programming framework. If this other framework is principally designed around the [DLPack](https://dmlc.github.io/dlpack/latest/) array exchange protocol, something very bad happens.

Basically PyTorch ignores the DLPack interface (`other_array.__dlpack__`) altogether. Furthermore, if ``other_array`` exposes the sequence protocol (``__len__`` and ``__getitem__``), PyTorch will perform a brute-force element-wise copy potentially requiring hundreds of millions of separate PCI-express transactions to copy individual floating point values from the GPU. To the user, it will seem that the application has crashed because nothing happens and attempting to interrupt the Python kernel doesn't work since this is all done on the C++ side.

Fortunately PyTorch supports the DLPack protocol to efficiently exchange tensors with other libraries. But it only does so when the user creates the arrays in a sort of awkward way:

```python
from torch.utils.dlpack import from_dlpack
torch_array = from_dlpack(other_array)
```
It's easy to forget to do this, with extremely unpleasant results. It would be very easy for PyTorch to _check_ if `other_array` implements the DLPack protocol and then simply to switch to this construction method. I will create a separate PR proposing a prototype of this idea.