### PR TITLE
[CLANGTIDY] Enable clang-tidy in torch/csrc/xpu

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -204,8 +204,6 @@ exclude_patterns = [
     'c10/**/cuda/*pp',
     'aten/**/cuda/*pp',
     '**/cuda/*pp',
-    '**/*XPU*',
-    '**/xpu/*pp',
     'c10/cuda/CUDAAlgorithm.h',
     'c10/util/complex_math.h',
     'c10/util/complex_utils.h',

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -204,6 +204,8 @@ exclude_patterns = [
     'c10/**/cuda/*pp',
     'aten/**/cuda/*pp',
     '**/cuda/*pp',
+    'c10/xpu/**/*.h',
+    'c10/xpu/**/*.cpp',
     'c10/cuda/CUDAAlgorithm.h',
     'c10/util/complex_math.h',
     'c10/util/complex_utils.h',

--- a/torch/csrc/xpu/Event.cpp
+++ b/torch/csrc/xpu/Event.cpp
@@ -22,7 +22,12 @@ static PyObject* THXPEvent_pynew(
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   constexpr const char* kwlist[] = {"enable_timing", nullptr};
   if (!PyArg_ParseTupleAndKeywords(
-          args, kwargs, "|b", const_cast<char**>(kwlist), &enable_timing)) {
+          args,
+          kwargs,
+          "|b",
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+          const_cast<char**>(kwlist),
+          &enable_timing)) {
     return nullptr;
   }
 
@@ -106,15 +111,13 @@ static PyObject* THXPEvent_synchronize(PyObject* _self, PyObject* noargs) {
   END_HANDLE_TH_ERRORS
 }
 
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,
-// cppcoreguidelines-avoid-non-const-global-variables, modernize-avoid-c-arrays)
+// NOLINTNEXTLINE(*c-arrays*, *global-variables)
 static struct PyGetSetDef THXPEvent_properties[] = {
     {"device", (getter)THXPEvent_get_device, nullptr, nullptr, nullptr},
     {"sycl_event", (getter)THXPEvent_get_sycl_event, nullptr, nullptr, nullptr},
     {nullptr}};
 
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,
-// cppcoreguidelines-avoid-non-const-global-variables, modernize-avoid-c-arrays)
+// NOLINTNEXTLINE(*c-arrays*, *global-variables)
 static PyMethodDef THXPEvent_methods[] = {
     {(char*)"record", THXPEvent_record, METH_O, nullptr},
     {(char*)"wait", THXPEvent_wait, METH_O, nullptr},

--- a/torch/csrc/xpu/Module.cpp
+++ b/torch/csrc/xpu/Module.cpp
@@ -148,6 +148,7 @@ PyObject* THXPModule_setStream_wrap(
           args,
           kwargs,
           "|LLL",
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
           const_cast<char**>(kwlist),
           &stream_id,
           &device_index,
@@ -155,7 +156,9 @@ PyObject* THXPModule_setStream_wrap(
   }
 
   auto stream = at::xpu::XPUStream::unpack3(
-      stream_id, device_index, static_cast<c10::DeviceType>(device_type));
+      stream_id,
+      static_cast<c10::DeviceIndex>(device_index),
+      static_cast<c10::DeviceType>(device_type));
 
   auto device = c10::xpu::current_device();
   if (device != stream.device_index()) {
@@ -237,8 +240,8 @@ static void registerXpuDeviceProperties(PyObject* module) {
             std::ostringstream stream;
             stream << "_XpuDeviceProperties(name='" << prop.name
                    << "', platform_name='" << prop.platform_name << "', type='"
-                   << get_device_type(prop)
-                   << ", total_memory=" << prop.global_mem_size / (1024 * 1024)
+                   << get_device_type(prop) << ", total_memory="
+                   << prop.global_mem_size / (1024ull * 1024)
                    << "MB, max_compute_units=" << prop.max_compute_units
                    << ", gpu_eu_count=" << prop.gpu_eu_count
                    << ", gpu_subslice_count=" << gpu_subslice_count(prop)
@@ -278,9 +281,7 @@ static PyObject* THXPModule_initExtension(PyObject* self, PyObject* noargs) {
   END_HANDLE_TH_ERRORS
 }
 
-// NOLINTNEXTLINE(modernize-avoid-c-arrays,
-// cppcoreguidelines-avoid-non-const-global-variables,
-// cppcoreguidelines-avoid-c-arrays)
+// NOLINTNEXTLINE(*-c-arrays*, *-global-variables)
 static struct PyMethodDef _THXPModule_methods[] = {
     {"_xpu_init", THXPModule_initExtension, METH_NOARGS, nullptr},
     {"_xpu_setDevice", THXPModule_setDevice_wrap, METH_O, nullptr},

--- a/torch/csrc/xpu/Stream.cpp
+++ b/torch/csrc/xpu/Stream.cpp
@@ -30,6 +30,7 @@ static PyObject* THXPStream_pynew(
           args,
           kwargs,
           "|iLLL",
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
           const_cast<char**>(kwlist),
           &priority,
           &stream_id,
@@ -45,11 +46,14 @@ static PyObject* THXPStream_pynew(
 
   at::xpu::XPUStream stream = (stream_id || device_index || device_type)
       ? at::xpu::XPUStream::unpack3(
-            stream_id, device_index, static_cast<c10::DeviceType>(device_type))
+            stream_id,
+            static_cast<c10::DeviceIndex>(device_index),
+            static_cast<c10::DeviceType>(device_type))
       : at::xpu::getStreamFromPool(priority, current_device);
 
   THXPStream* self = (THXPStream*)ptr.get();
   self->stream_id = static_cast<int64_t>(stream.id());
+  // NOLINTNEXTLINE(bugprone-signed-char-misuse)
   self->device_index = static_cast<int64_t>(stream.device_index());
   self->device_type = static_cast<int64_t>(stream.device_type());
   new (&self->xpu_stream) at::xpu::XPUStream(stream);
@@ -116,14 +120,10 @@ static PyObject* THXPStream_eq(PyObject* _self, PyObject* _other) {
   END_HANDLE_TH_ERRORS
 }
 
-// NOLINTNEXTLINE(modernize-avoid-c-arrays,
-// cppcoreguidelines-avoid-non-const-global-variables,
-// cppcoreguidelines-avoid-c-arrays)
+// NOLINTNEXTLINE(*-c-arrays*, *-global-variables)
 static struct PyMemberDef THXPStream_members[] = {{nullptr}};
 
-// NOLINTNEXTLINE(modernize-avoid-c-arrays,
-// cppcoreguidelines-avoid-non-const-global-variables,
-// cppcoreguidelines-avoid-c-arrays)
+// NOLINTNEXTLINE(*-c-arrays*, *-global-variables)
 static struct PyGetSetDef THXPStream_properties[] = {
     {"sycl_queue",
      (getter)THXPStream_get_sycl_queue,
@@ -133,17 +133,15 @@ static struct PyGetSetDef THXPStream_properties[] = {
     {"priority", (getter)THXPStream_get_priority, nullptr, nullptr, nullptr},
     {nullptr}};
 
-// NOLINTNEXTLINE(modernize-avoid-c-arrays,
-// cppcoreguidelines-avoid-non-const-global-variables,
-// cppcoreguidelines-avoid-c-arrays)
+// NOLINTNEXTLINE(*-c-arrays*, *-global-variables)
 static PyMethodDef THXPStream_methods[] = {
-    {(char*)"query", THXPStream_query, METH_NOARGS, nullptr},
-    {(char*)"synchronize", THXPStream_synchronize, METH_NOARGS, nullptr},
-    {(char*)"priority_range",
+    {"query", THXPStream_query, METH_NOARGS, nullptr},
+    {"synchronize", THXPStream_synchronize, METH_NOARGS, nullptr},
+    {"priority_range",
      THXPStream_priority_range,
      METH_STATIC | METH_NOARGS,
      nullptr},
-    {(char*)"__eq__", THXPStream_eq, METH_O, nullptr},
+    {"__eq__", THXPStream_eq, METH_O, nullptr},
     {nullptr}};
 
 PyTypeObject THXPStreamType = {

--- a/torch/csrc/xpu/Stream.h
+++ b/torch/csrc/xpu/Stream.h
@@ -4,6 +4,7 @@
 #include <torch/csrc/Stream.h>
 #include <torch/csrc/python_headers.h>
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct THXPStream : THPStream {
   at::xpu::XPUStream xpu_stream;
 };


### PR DESCRIPTION
# Motivation
refer to [#118504](https://github.com/pytorch/pytorch/pull/118504), enabling clang-tidy in `torch/csrc/xpu`.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10