### PR TITLE
[ONNX] Perform implicit casting of constants for the onnx::where operator (#118733)

### DIFF
--- a/test/onnx/expect/TestOperators.test_expand.expect
+++ b/test/onnx/expect/TestOperators.test_expand.expect
@@ -3,22 +3,8 @@ producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
   node {
-    output: "onnx::Where_1"
+    output: "onnx::ConstantOfShape_11"
     name: "Constant_4"
-    op_type: "Constant"
-    attribute {
-      name: "value"
-      t {
-        dims: 3
-        data_type: 7
-        raw_data: "\004\000\000\000\000\000\000\000\006\000\000\000\000\000\000\000\002\000\000\000\000\000\000\000"
-      }
-      type: TENSOR
-    }
-  }
-  node {
-    output: "onnx::ConstantOfShape_10"
-    name: "Constant_5"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -31,9 +17,9 @@ graph {
     }
   }
   node {
-    input: "onnx::ConstantOfShape_10"
+    input: "onnx::ConstantOfShape_11"
     output: "onnx::Mul_3"
-    name: "ConstantOfShape_6"
+    name: "ConstantOfShape_5"
     op_type: "ConstantOfShape"
     attribute {
       name: "value"
@@ -47,7 +33,7 @@ graph {
   }
   node {
     output: "onnx::Mul_4"
-    name: "Constant_7"
+    name: "Constant_6"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -62,12 +48,12 @@ graph {
     input: "onnx::Mul_3"
     input: "onnx::Mul_4"
     output: "onnx::Equal_5"
-    name: "Mul_8"
+    name: "Mul_7"
     op_type: "Mul"
   }
   node {
     output: "onnx::Equal_6"
-    name: "Constant_9"
+    name: "Constant_8"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -83,21 +69,35 @@ graph {
     input: "onnx::Equal_6"
     input: "onnx::Equal_5"
     output: "onnx::Where_7"
-    name: "Equal_10"
+    name: "Equal_9"
     op_type: "Equal"
+  }
+  node {
+    output: "onnx::Where_8"
+    name: "Constant_10"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 3
+        data_type: 7
+        raw_data: "\004\000\000\000\000\000\000\000\006\000\000\000\000\000\000\000\002\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
   }
   node {
     input: "onnx::Where_7"
     input: "onnx::Mul_3"
-    input: "onnx::Where_1"
-    output: "onnx::Expand_8"
+    input: "onnx::Where_8"
+    output: "onnx::Expand_9"
     name: "Where_11"
     op_type: "Where"
   }
   node {
     input: "onnx::Expand_0"
-    input: "onnx::Expand_8"
-    output: "9"
+    input: "onnx::Expand_9"
+    output: "10"
     name: "Expand_12"
     op_type: "Expand"
   }
@@ -119,7 +119,7 @@ graph {
     }
   }
   output {
-    name: "9"
+    name: "10"
     type {
       tensor_type {
         elem_type: 1

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -7156,6 +7156,47 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test(DoNotUpcastModel(), x)
 
     @skipIfUnsupportedMinOpsetVersion(9)
+    def test_scalar_type_promotion_onnx_where_two_prim_const(self):
+        class TwoPrimConstCastWhereModel(torch.nn.Module):
+            def forward(self, c):
+                return torch.where(c, 0, 1.0)
+
+        c = torch.ones(8, dtype=torch.bool)
+        self.run_test(TwoPrimConstCastWhereModel(), (c))
+
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_scalar_type_promotion_onnx_where_one_prim_const(self):
+        class OnePrimConstCastWhereModel(torch.nn.Module):
+            def forward(self, c, x):
+                return torch.where(c, x, 1.0)
+
+        c = torch.ones(8, dtype=torch.bool)
+        x = torch.ones(8, dtype=torch.float16)
+        self.run_test(OnePrimConstCastWhereModel(), (c, x))
+
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_scalar_type_promotion_onnx_where_one_tensor_const(self):
+        class OneTensorConstCastWhereModel(torch.nn.Module):
+            def forward(self, c, x):
+                return torch.where(c, x, torch.ones(size=(), dtype=torch.float64))
+
+        c = torch.ones(8, dtype=torch.bool)
+        x = torch.ones(8, dtype=torch.float16)
+        self.run_test(OneTensorConstCastWhereModel(), (c, x))
+
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_scalar_type_upcast_type_promotion_onnx_where_no_const(self):
+        class OnnxWhereUpcastModel(torch.nn.Module):
+            def forward(self, c, x, y):
+                return torch.where(c, x, y)
+
+        c = torch.ones(8, dtype=torch.bool)
+        x = torch.ones(8, dtype=torch.float16)
+        y = torch.ones(8, dtype=torch.float32)
+
+        self.run_test(OnnxWhereUpcastModel(), (c, x, y))
+
+    @skipIfUnsupportedMinOpsetVersion(9)
     def test_full_like(self):
         class FullLikeModel(torch.nn.Module):
             def forward(self, x):


### PR DESCRIPTION
This PR fixes the problem of having the `Where` operator bound to different types in cases where the dtype is not explicitly set. The PR extends the implicit casting to the onnx::Where operator to fix the issue, and includes the corresponding unit test.

Fixes #118733
