### PR TITLE
Fix test failure: Add torch.cuda._get_device_properties to dynamo trace rules

### DIFF
--- a/test/dynamo/test_trace_rules.py
+++ b/test/dynamo/test_trace_rules.py
@@ -61,6 +61,7 @@ ignored_c_binding_in_graph_function_names = {
     "torch._lazy_clone",
     "torch._C._storage_address",
     "torch._C._pickle_save",
+    "torch.cuda._get_device_properties",
 }
 if torch._C._llvm_enabled():
     ignored_c_binding_in_graph_function_names |= {

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -190,6 +190,7 @@ manual_torch_name_rule_map = {
     "torch._C._functorch.is_batchedtensor": TorchInGraphFunctionVariable,
     "torch._dynamo.mark_static": UserFunctionVariable,
     "torch.fx.experimental.symbolic_shapes.guard_size_oblivious": TorchInGraphFunctionVariable,
+    "torch.cuda._get_device_properties": TorchInGraphFunctionVariable,
 }
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #119701
* #119600
* #119009
* #119008
* #119601
* #119007
* #119598
* #119597
* #119006
* #119004
* __->__ #120620

In this PR stack, there were unrelated test failures within test_trace_rules.py - It turned out that torch.cuda._get_device_properties should be registered in _dynamoc/trace_rules.py. A test failed because it was not.

This is a small fix which tries to get rid of the test failure by manually registering that function.

Note:
I am not sure whether this is the best way to fix this, as I am neither familiar with the trace rules nor with the introduction of torch.cuda._get_device_properties.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov