### PR TITLE
Fixed an undefined combination of inputs for torch.fmod.

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -974,8 +974,10 @@ void fmod_kernel(TensorIteratorBase& iter) {
     AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "fmod_cpu", [&]() {
       cpu_kernel(iter, [=](scalar_t x, scalar_t d) -> scalar_t {
         // x % d is undefined if d == 0 or if x / d is not representable in the result type
-        TORCH_CHECK(d != 0 && !(x == std::numeric_limits<scalar_t>::min() && std::is_signed<scalar_t>() && d == -1),
-                    "Invalid input to modulo operation.");
+        bool valid_operands = !(x == std::numeric_limits<scalar_t>::min() &&
+                (std::is_same<scalar_t, int64_t>() || std::is_same<scalar_t, int32_t>()) &&
+                d == -1);
+        TORCH_CHECK(d != 0 && valid_operands, "Invalid input to modulo operation.");
         return x % d;
       });
     });

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -974,7 +974,7 @@ void fmod_kernel(TensorIteratorBase& iter) {
     AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "fmod_cpu", [&]() {
       cpu_kernel(iter, [=](scalar_t x, scalar_t d) -> scalar_t {
         // x % d is undefined if d == 0 or if x / d is not representable in the result type
-        TORCH_CHECK(d != 0 && !(x == std::numeric_limits<scalar_t>::min() && d == -1),
+        TORCH_CHECK(d != 0 && !(x == std::numeric_limits<scalar_t>::min() && static_cast<std::make_signed_t<scalar_t>>(d) == -1),
                     "Invalid input to modulo operation.");
         return x % d;
       });

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -974,7 +974,7 @@ void fmod_kernel(TensorIteratorBase& iter) {
     AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "fmod_cpu", [&]() {
       cpu_kernel(iter, [=](scalar_t x, scalar_t d) -> scalar_t {
         // x % d is undefined if d == 0 or if x / d is not representable in the result type
-        TORCH_CHECK(d != 0 && !(x == std::numeric_limits<scalar_t>::min() && static_cast<std::make_signed_t<scalar_t>>(d) == -1),
+        TORCH_CHECK(d != 0 && !(x == std::numeric_limits<scalar_t>::min() && std::is_signed<scalar_t>() && d == -1),
                     "Invalid input to modulo operation.");
         return x % d;
       });

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -977,7 +977,8 @@ void fmod_kernel(TensorIteratorBase& iter) {
         bool valid_operands = !(x == std::numeric_limits<scalar_t>::min() &&
                 (std::is_same<scalar_t, int64_t>() || std::is_same<scalar_t, int32_t>()) &&
                 d == -1);
-        TORCH_CHECK(d != 0 && valid_operands, "Invalid input to modulo operation.");
+        TORCH_CHECK(valid_operands, "Invalid input to modulo operation.")
+        TORCH_CHECK(d != 0, "ZeroDivisionError");
         return x % d;
       });
     });

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -977,7 +977,7 @@ void fmod_kernel(TensorIteratorBase& iter) {
         bool valid_operands = !(x == std::numeric_limits<scalar_t>::min() &&
                 (std::is_same<scalar_t, int64_t>() || std::is_same<scalar_t, int32_t>()) &&
                 d == -1);
-        TORCH_CHECK(valid_operands, "Invalid input to modulo operation.")
+        TORCH_CHECK(valid_operands, "Invalid input to modulo operation.");
         TORCH_CHECK(d != 0, "ZeroDivisionError");
         return x % d;
       });

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -2689,7 +2689,7 @@ class TestBinaryUfuncs(TestCase):
             zero = torch.zeros_like(x)
             # RuntimeError on CPU
             if self.device_type == "cpu":
-                with self.assertRaisesRegex(RuntimeError, "ZeroDivisionError"):
+                with self.assertRaisesRegex(RuntimeError, "^Invalid input to modulo operation."):
                     fn(x, zero)
             elif torch.version.hip is not None:
                 # ROCm behavior: x % 0 is a no-op; x is returned

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -2689,7 +2689,7 @@ class TestBinaryUfuncs(TestCase):
             zero = torch.zeros_like(x)
             # RuntimeError on CPU
             if self.device_type == "cpu":
-                with self.assertRaisesRegex(RuntimeError, "^Invalid input to modulo operation."):
+                with self.assertRaisesRegex(RuntimeError, "ZeroDivisionError"):
                     fn(x, zero)
             elif torch.version.hip is not None:
                 # ROCm behavior: x % 0 is a no-op; x is returned

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -522,6 +522,19 @@ class TestTorchDeviceType(TestCase):
                 dims_small = [ds] + dims_small
         return (dims_small, dims_large, dims_full)
 
+    def test_fmod_raise_on_invalid_input(self):
+        # This used to throw SIGFPE for -2**63 % -1
+        # see https://github.com/pytorch/pytorch/issues/120597
+        with self.assertRaisesRegex(RuntimeError, "^Invalid input to modulo operation."):
+            x = torch.tensor([-9223372036854775808], dtype=torch.int64)
+            y = torch.tensor([[-1]], dtype=torch.int64)
+            _ = torch.fmod(x, y)
+
+        with self.assertRaisesRegex(RuntimeError, "^Invalid input to modulo operation."):
+            x = torch.tensor([-9223372036854775808], dtype=torch.int64)
+            y = torch.tensor([[0]], dtype=torch.int64)
+            _ = torch.fmod(x, y)
+
     # collected tests of ops that used scalar_check in Declarations.cwrap for
     # correctness
     def test_scalar_check(self, device):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -544,7 +544,6 @@ class TestTorchDeviceType(TestCase):
         y = torch.tensor([[-1]], dtype=torch.int8)
         self.assertEqual(torch.fmod(x, y).item(), 0.)
 
-
     # collected tests of ops that used scalar_check in Declarations.cwrap for
     # correctness
     def test_scalar_check(self, device):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -530,11 +530,6 @@ class TestTorchDeviceType(TestCase):
             y = torch.tensor([[-1]], dtype=torch.int64)
             _ = torch.fmod(x, y)
 
-        with self.assertRaisesRegex(RuntimeError, "^Invalid input to modulo operation."):
-            x = torch.tensor([-9223372036854775808], dtype=torch.int64)
-            y = torch.tensor([[0]], dtype=torch.int64)
-            _ = torch.fmod(x, y)
-
         # Same problem with 32-bit ints
         with self.assertRaisesRegex(RuntimeError, "^Invalid input to modulo operation."):
             x = torch.tensor([-2**31], dtype=torch.int32)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -535,6 +535,21 @@ class TestTorchDeviceType(TestCase):
             y = torch.tensor([[0]], dtype=torch.int64)
             _ = torch.fmod(x, y)
 
+        # Same problem with 32-bit ints
+        with self.assertRaisesRegex(RuntimeError, "^Invalid input to modulo operation."):
+            x = torch.tensor([-2**31], dtype=torch.int32)
+            y = torch.tensor([[-1]], dtype=torch.int32)
+            _ = torch.fmod(x, y)
+
+        # For whatever reason, int16 and int8 are not affected
+        x = torch.tensor([-2**15], dtype=torch.int16)
+        y = torch.tensor([[-1]], dtype=torch.int16)
+        self.assertEqual(torch.fmod(x, y).item(), 0.)
+        x = torch.tensor([-2**7], dtype=torch.int8)
+        y = torch.tensor([[-1]], dtype=torch.int8)
+        self.assertEqual(torch.fmod(x, y).item(), 0.)
+
+
     # collected tests of ops that used scalar_check in Declarations.cwrap for
     # correctness
     def test_scalar_check(self, device):


### PR DESCRIPTION
Fixes #120597.

This PR fixes a problem for `torch.fmod` when trying to calculate `INT64_MIN % -1`. According to the standard, `a % b` is undefined if `a / b` is not representable in the result type.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10