### PR TITLE
Disable test_torch_name_rule_map_updated in code

### DIFF
--- a/test/dynamo/test_trace_rules.py
+++ b/test/dynamo/test_trace_rules.py
@@ -314,6 +314,7 @@ class TraceRuleTests(torch._dynamo.test_case.TestCase):
                 f"{m} from trace_rules.MOD_INLINELIST/LEGACY_MOD_INLINELIST is not a python module, please check and correct it.",
             )
 
+    @unittest.skip("This test keeps getting broken and our disable infra is not handling well")
     def test_torch_name_rule_map_updated(self):
         # Generate the allowed objects based on heuristic defined in `allowed_functions.py`,
         objs = gen_allowed_objs_and_ids(record=True, c_binding_only=True)

--- a/test/dynamo/test_trace_rules.py
+++ b/test/dynamo/test_trace_rules.py
@@ -315,7 +315,7 @@ class TraceRuleTests(torch._dynamo.test_case.TestCase):
             )
 
     @unittest.skip(
-        "This test keeps getting broken and our disable infra is not handling well"
+        "This test keeps getting broken and our disable infra is not handling well. see #120627"
     )
     def test_torch_name_rule_map_updated(self):
         # Generate the allowed objects based on heuristic defined in `allowed_functions.py`,

--- a/test/dynamo/test_trace_rules.py
+++ b/test/dynamo/test_trace_rules.py
@@ -314,7 +314,9 @@ class TraceRuleTests(torch._dynamo.test_case.TestCase):
                 f"{m} from trace_rules.MOD_INLINELIST/LEGACY_MOD_INLINELIST is not a python module, please check and correct it.",
             )
 
-    @unittest.skip("This test keeps getting broken and our disable infra is not handling well")
+    @unittest.skip(
+        "This test keeps getting broken and our disable infra is not handling well"
+    )
     def test_torch_name_rule_map_updated(self):
         # Generate the allowed objects based on heuristic defined in `allowed_functions.py`,
         objs = gen_allowed_objs_and_ids(record=True, c_binding_only=True)


### PR DESCRIPTION
I am getting tired of this test  ;-;

It gets disabled because it's broken, and then gets fixed, but something breaks it while it was disabled so its still broken and the infra is not handling it well.

Disable issue is https://github.com/pytorch/pytorch/issues/114831

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang