### PR TITLE
Update nn.Module._apply to not gate on should_use_set_data when swap_tensors is set

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -895,7 +895,6 @@ class TestModule(TestCase):
                 g_no_swap = device_ == prev_device and dtype_ == prev_dtype
                 prev_device, prev_dtype = device_, dtype_
 
-
                 p_ids_before = [id(p) for p in m.parameters()]
                 p_cdatas_before = [p._cdata for p in m.parameters()]
                 if set_grad:

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -869,7 +869,6 @@ class TestModule(TestCase):
 
         for module_input in module_inputs:
             c_args, c_kwargs = module_input.constructor_input.args, module_input.constructor_input.kwargs
-            fw_args, fw_kwargs = module_input.forward_input.args, module_input.forward_input.kwargs
 
             m = module_cls(*c_args, **c_kwargs)
 
@@ -896,6 +895,7 @@ class TestModule(TestCase):
                 g_no_swap = device_ == prev_device and dtype_ == prev_dtype
                 prev_device, prev_dtype = device_, dtype_
 
+
                 p_ids_before = [id(p) for p in m.parameters()]
                 p_cdatas_before = [p._cdata for p in m.parameters()]
                 if set_grad:
@@ -904,7 +904,7 @@ class TestModule(TestCase):
 
                 m.to(device=device_, dtype=dtype_)
 
-                self.assertTrue(isinstance(p, torch.nn.Parameter) for p in m.parameters())
+                self.assertTrue(all(isinstance(p, torch.nn.Parameter) for p in m.parameters()))
                 self.assertTrue(all(p.device.type == device_ for p in m.parameters()))
                 self.assertTrue(all(p.dtype == dtype_ for p in m.parameters()))
                 p_ids_after = [id(p) for p in m.parameters()]
@@ -930,6 +930,47 @@ class TestModule(TestCase):
                     if set_grad:
                         self.assertTrue(all(a == b for a, b in zip(g_cdatas_before, g_cdatas_after)))
                         self.assertTrue(all(a == b for a, b in zip(g_ids_before, g_ids_after)))
+
+
+    @modules([module for module in module_db if not module.is_lazy], allowed_dtypes=[torch.float32])
+    @parametrize('swap', [True, False])
+    @wrapSwapTensorsTest()
+    def test_to_empty(self, device, dtype, module_info, swap, training):
+        module_cls = module_info.module_cls
+
+        with torch.device("meta"):
+            module_inputs = module_info.module_inputs_func(module_info, device=None, dtype=dtype,
+                                                           requires_grad=False, training=training)
+
+        torch.__future__.set_swap_module_params_on_conversion(swap)
+        device_ = torch.device(device)
+
+        for module_input in module_inputs:
+            c_args, c_kwargs = module_input.constructor_input.args, module_input.constructor_input.kwargs
+
+            with torch.device("meta"):
+                m = module_cls(*c_args, **c_kwargs)
+
+            p_ids_before = [id(p) for p in m.parameters()]
+            p_cdatas_before = [p._cdata for p in m.parameters()]
+            m.to_empty(device=device_)
+
+            self.assertTrue(all(isinstance(p, torch.nn.Parameter) for p in m.parameters()))
+            self.assertTrue(all(p.device == device_ for p in m.parameters()))
+            self.assertTrue(all(p.dtype == dtype for p in m.parameters()))
+            p_ids_after = [id(p) for p in m.parameters()]
+            p_cdatas_after = [p._cdata for p in m.parameters()]
+
+            if swap:
+                # id same, ._cdata differs --> swapped cdata of THPVariable
+                self.assertTrue(all(a == b for a, b in zip(p_ids_before, p_ids_after)))
+                self.assertTrue(all(a != b for a, b in zip(p_cdatas_before, p_cdatas_after)))
+            else:
+                # id and ._cdata differ
+                # meta and device have different shallow copy types, so this will create a new
+                # parameter and assign it to the module
+                self.assertTrue(all(a != b for a, b in zip(p_ids_before, p_ids_after)))
+                self.assertTrue(all(a != b for a, b in zip(p_cdatas_before, p_cdatas_after)))
 
 
 instantiate_device_type_tests(TestModule, globals(), allow_mps=True)

--- a/torch/__future__.py
+++ b/torch/__future__.py
@@ -9,10 +9,10 @@ def set_overwrite_module_params_on_conversion(value: bool) -> None:
 
     When enabled, the following methods will assign new parameters to the module:
 
-    #. ``module.{device}()`` (e.g. ``module.cuda()``) for moving a module between devices
-    #. ``module.{dtype}()`` (e.g. ``module.float()``) for converting a module to a different dtype
-       (for converting a module to a different dtype)
-    #. ``module.to()``
+    #. ``module.{device}()`` (e.g. :meth:`nn.Module.cuda()`) for moving a module between devices
+    #. ``module.{dtype}()`` (e.g. :meth:`nn.Module.float()`) for converting a module to a different dtype
+    #. :meth:`nn.Module.to`
+    #. :meth:`nn.Module.to_empty`
 
     Args:
         value (bool): Whether to assign new tensors or not.
@@ -25,7 +25,7 @@ def set_overwrite_module_params_on_conversion(value: bool) -> None:
 def get_overwrite_module_params_on_conversion() -> bool:
     """
     Returns whether to assign new tensors to the parameters instead of changing the
-    existing parameters in-place when converting an ``nn.Module``. Defaults to ``False``.
+    existing parameters in-place when converting an :class:`torch.nn.Module`. Defaults to ``False``.
 
     See :func:`~torch.__future__.set_overwrite_module_params_on_conversion` for more information.
     """
@@ -39,20 +39,19 @@ def set_swap_module_params_on_conversion(value: bool) -> None:
     of ``param.copy_(state_dict[key])`` when loading a state dict into an ``nn.Module``.
 
     .. note::
-        If :func:`~torch.__future__.get_overwrite_module_params_on_conversion` returns ``True``,
-        for methods other than :meth:`~nn.Module.load_state_dict` no swapping will occur.
+        This function takes precedence over :func:`~torch.__future__.get_overwrite_module_params_on_conversion`
 
     When enabled, the following methods will swap the existing parameters in-place:
 
-    #. ``module.{device}()`` (e.g. ``module.cuda()``) for moving a module between devices
-    #. ``module.{dtype}()`` (e.g. ``module.float()``) for converting a module to a different dtype
-       (for converting a module to a different dtype)
-    #. ``module.to()``
-    #. ``module.load_state_dict(state_dict)``
+    #. ``module.{device}()`` (e.g. :meth:`nn.Module.cuda()`) for moving a module between devices
+    #. ``module.{dtype}()`` (e.g. :meth:`nn.Module.float()`) for converting a module to a different dtype
+    #. :meth:`nn.Module.to`
+    #. :meth:`nn.Module.to_empty`
+    #. :meth:`nn.Module.load_state_dict`
 
     The semantics for :meth:`~nn.Module.load_state_dict` when this is set are as follows:
 
-    #. For each parameter/buffer, its corresponding``state_dict['key']`` is transformed via
+    #. For each parameter/buffer, its corresponding ``state_dict['key']`` is transformed via
        :meth:`~torch.Tensor.module_load` (i.e. ``res = param.module_load(state_dict['key'])``)
     #. If necessary, ``res`` will be wrapped in an :class:`~nn.Parameter`
     #. The parameter/buffer in the module will be swapped via :func:`~torch.utils.swap_tensors`

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -4295,7 +4295,9 @@ module_db: List[ModuleInfo] = [
                module_error_inputs_func=module_error_inputs_torch_nn_RNN_GRU,
                skips=(
                    # RNNBase overrides `_apply` and adds weakrefs to params
-                   DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_to', active_if=lambda p: p['swap']),),
+                   DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_to', active_if=lambda p: p['swap']),
+                   # RNNBase overrides `_apply` and adds weakrefs to params
+                   DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_to_empty', active_if=lambda p: p['swap']),),
                decorators=rnn_gru_lstm_module_info_decorators
                ),
     ModuleInfo(torch.nn.GRU,
@@ -4304,7 +4306,9 @@ module_db: List[ModuleInfo] = [
                module_error_inputs_func=module_error_inputs_torch_nn_RNN_GRU,
                skips=(
                    # RNNBase overrides `_apply` and adds weakrefs to params
-                   DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_to', active_if=lambda p: p['swap']),),
+                   DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_to', active_if=lambda p: p['swap']),
+                   # RNNBase overrides `_apply` and adds weakrefs to params
+                   DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_to_empty', active_if=lambda p: p['swap']),),
                decorators=rnn_gru_lstm_module_info_decorators),
     ModuleInfo(torch.nn.LSTM,
                train_and_eval_differ=True,
@@ -4314,7 +4318,9 @@ module_db: List[ModuleInfo] = [
                    # LSTM with projections is not currently supported with MPS
                    DecorateInfo(skipMPS),
                    # RNNBase overrides `_apply` and adds weakrefs to params
-                   DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_to', active_if=lambda p: p['swap'])),
+                   DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_to', active_if=lambda p: p['swap']),
+                   # RNNBase overrides `_apply` and adds weakrefs to params
+                   DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_to_empty', active_if=lambda p: p['swap']),),
                decorators=rnn_gru_lstm_module_info_decorators),
     ModuleInfo(torch.nn.ReflectionPad1d,
                module_inputs_func=module_inputs_torch_nn_ReflectionPad1d,


### PR DESCRIPTION
This updates the nesting of if statements in `nn.Module._apply` such that if 

`torch.__future__.set_swap_module_params_on_conversion(True)`, we always try to swap regardless of whether
- `torch._has_compatible_shallow_copy_type(param, fn(param)`
- `torch.__future__.set_overwrite_module_params_on_conversion` is set

This means that `meta_module.to_empty('device')` can now use the swap_tensors path cc @awgu 

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120659

