### PR TITLE
[aot_inductor] added a utility function aoti_torch_print_tensor_handle

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -819,6 +819,9 @@ class CppWrapperCpu(WrapperCodeGen):
                             )
                         else:
                             self.wrapper_call.writeline(
+                                f"""aoti_torch_print_tensor_handle({output}, "{output}");"""
+                            )
+                            self.wrapper_call.writeline(
                                 f"output_handles[{idx}] = {output}.release();"
                             )
                 self.wrapper_call.writeline("} else {")

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -819,9 +819,6 @@ class CppWrapperCpu(WrapperCodeGen):
                             )
                         else:
                             self.wrapper_call.writeline(
-                                f"""aoti_torch_print_tensor_handle({output}, "{output}");"""
-                            )
-                            self.wrapper_call.writeline(
                                 f"output_handles[{idx}] = {output}.release();"
                             )
                 self.wrapper_call.writeline("} else {")

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -465,7 +465,7 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_view_dtype(
 
 AOTI_TORCH_EXPORT void aoti_torch_print_tensor_handle(
     AtenTensorHandle self,
-    const char* msg = nullptr);
+    const char* msg);
 
 #ifdef USE_CUDA
 

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -463,6 +463,10 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_view_dtype(
     AtenTensorHandle* ret // returns new reference
 );
 
+AOTI_TORCH_EXPORT void aoti_torch_print_tensor_handle(
+    AtenTensorHandle self,
+    const char* msg = nullptr);
+
 #ifdef USE_CUDA
 
 struct CUDAStreamGuardOpaque;

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -846,4 +846,3 @@ AOTITorchError aoti_torch__alloc_from_pool(
         strides));
   });
 }
- 

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -792,7 +792,7 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_view_dtype(
 AOTI_TORCH_EXPORT void aoti_torch_print_tensor_handle(
     AtenTensorHandle self,
     const char* msg) {
-  at::Tensor* t = reinterpret_cast<at::Tensor*>(self);
+  at::Tensor* t = tensor_handle_to_tensor_pointer(self);
   std::cout << "[";
   if (msg) {
     std::cout << msg;

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -791,8 +791,7 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_view_dtype(
 
 AOTI_TORCH_EXPORT void aoti_torch_print_tensor_handle(
     AtenTensorHandle self,
-    const char* msg
-) {
+    const char* msg) {
   at::Tensor* t = reinterpret_cast<at::Tensor*>(self);
   std::cout << "[" << msg << "]:" << *t << "\n";
 }

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -793,7 +793,11 @@ AOTI_TORCH_EXPORT void aoti_torch_print_tensor_handle(
     AtenTensorHandle self,
     const char* msg) {
   at::Tensor* t = reinterpret_cast<at::Tensor*>(self);
-  std::cout << "[" << msg << "]:" << *t << "\n";
+  std::cout << "[";
+  if (msg) {
+    std::cout << msg;
+  }
+  std::cout << "]:" << *t << "\n";
 }
 
 // ProxyExecutor

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -791,7 +791,8 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_view_dtype(
 
 AOTI_TORCH_EXPORT void aoti_torch_print_tensor_handle(
     AtenTensorHandle self,
-    const char* msg {
+    const char* msg
+) {
   at::Tensor* t = reinterpret_cast<at::Tensor*>(self);
   std::cout << "[" << msg << "]:" << *t << "\n";
 }

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -789,6 +789,13 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_view_dtype(
   });
 }
 
+AOTI_TORCH_EXPORT void aoti_torch_print_tensor_handle(
+    AtenTensorHandle self,
+    const char* msg {
+  at::Tensor* t = reinterpret_cast<at::Tensor*>(self);
+  std::cout << "[" << msg << "]:" << *t << "\n";
+}
+
 // ProxyExecutor
 AOTITorchError aoti_torch_proxy_executor_call_function(
     AOTIProxyExecutorHandle proxy_executor,
@@ -839,3 +846,4 @@ AOTITorchError aoti_torch__alloc_from_pool(
         strides));
   });
 }
+ 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120660

Added a function to print tenosr values for a tensor handle.
It can be injected to the cpp wrapper code and help debug
numerical issues.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames