### PR TITLE
[export] preserve constant fqn

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -874,7 +874,7 @@ class TestSerializeCustomClass(TestCase):
 
         serialized_vals = serialize(ep)
         ep = deserialize(serialized_vals)
-        self.assertTrue(isinstance(ep.constants["_lifted_custom_obj0"].get(), FakeTensor))
+        self.assertTrue(isinstance(ep.constants["custom_obj"].get(), FakeTensor))
 
 
 if __name__ == '__main__':

--- a/torch/_export/passes/lift_constants_pass.py
+++ b/torch/_export/passes/lift_constants_pass.py
@@ -1,4 +1,5 @@
-from typing import Dict, Union
+import collections
+from typing import Any, Dict, Union
 
 import torch
 from torch._export.verifier import SpecViolationError
@@ -13,14 +14,92 @@ from torch.export.exported_program import (
 )
 
 
+class ConstantAttrMap(collections.abc.MutableMapping):
+    """A mapping class that understands how to use module constants (tensors and
+    ScriptObjects) as keys. We store tensors normally, but ScriptObjects are
+    stored by hash, because different torch.ScriptObjects can point to the same
+    underlying value (but we guarantee that they will `hash()` to the same value
+    if that's the case).
+    """
+
+    def __init__(self):
+        # Underlying dict that we use to implement this mapping.
+        self._constant_attrs: Dict[Union[int, torch.Tensor], Any] = {}
+        # Map from the hash(ScriptObject) to the ScriptObject itself. Used for
+        # APIs like `__iter__` that should look like they're returning the
+        # original ScriptObjects.
+        self._script_object_map: Dict[int, torch.ScriptObject] = {}
+
+    def __getitem__(self, key: Union[torch.Tensor, torch.ScriptObject]) -> Any:
+        real_key = hash(key) if isinstance(key, torch.ScriptObject) else key
+        assert isinstance(real_key, (int, torch.Tensor))
+        return self._constant_attrs[real_key]
+
+    def __setitem__(
+        self, key: Union[torch.Tensor, torch.ScriptObject], value: Any
+    ) -> None:
+        if isinstance(key, torch.ScriptObject):
+            self._constant_attrs[hash(key)] = value
+            self._script_object_map[hash(key)] = key
+        elif isinstance(key, torch.Tensor):
+            self._constant_attrs[key] = value
+        else:
+            raise TypeError(
+                f"Expected key to be a tensor or ScriptObject, got {type(key)}"
+            )
+
+    def __delitem__(self, key):
+        real_key = hash(key) if isinstance(key, torch.ScriptObject) else key
+
+        del self._constant_attrs[real_key]
+
+    def __iter__(self):
+        for key in self._constant_attrs:
+            if isinstance(key, int):
+                yield self._script_object_map[key]
+            else:
+                yield key
+
+    def __len__(self):
+        return len(self._constant_attrs)
+
+    def __contains__(self, key: object) -> bool:
+        real_key = hash(key) if isinstance(key, torch.ScriptObject) else key
+        return real_key in self._constant_attrs
+
+
+def get_constant_fqn(node: torch.fx.Node, constant_name: str) -> str:
+    # The FQN of the constant tensor in the state dict should
+    # correspond to the module where the constant tensor was
+    # originally used.
+    parent_fqn = list(node.meta["nn_module_stack"].values())[-1][0]
+    if len(parent_fqn) > 0:
+        return f"{parent_fqn}.{constant_name}"
+    else:
+        return constant_name
+
+
 def lift_constants_pass(
     gm: torch.fx.GraphModule,
     graph_signature: ExportGraphSignature,
+    constant_attrs: ConstantAttrMap,
 ) -> Dict[str, Union[torch.Tensor, torch._C.ScriptObject]]:
     """
     Takes a graph module, graph signature, and modifies them implace to lift any
     constants (tensors or custom classes) as inputs to the graph. Returns a
     dictionary of names to constants.
+
+    Arguments:
+        gm (torch.fx.GraphModule): The graph module containing the graph and constants to lift.
+        graph_signature (ExportGraphSignature): This graph signature will be
+            mutated to add additional CONSTANT_TENSOR and CUSTOM_OBJ inputs.
+        constant_attrs (ConstantAttr): A mapping from a constant value to its
+            fully-qualified path in `gm`. This is used to maintain consistent
+            location of constants between the original module and the exported
+            version.
+
+    Returns:
+        A dictionary of fqn => constant value.
     """
     all_constants: Dict[str, Union[torch.Tensor, torch._C.ScriptObject]] = {}
 
@@ -46,36 +125,46 @@ def lift_constants_pass(
             break
         first_user_input_loc += 1
 
-    # For de-duplicating lifted tensor/objs, we need to keep a table of
-    # already-lifted objects to their corresponding placeholder node so we can
-    # re-use that node.
-    #
-    # Unfortunately, we *must* store the `hash()` of the value, becuase
-    # different torch.ScriptObjects can point to the same underlying value (but
-    # we guarantee that they will `hash()` to the same value if that's the
-    # case).
-    lifted_objs: Dict[int, torch.fx.Node] = {}
-
+    lifted_objs = ConstantAttrMap()
     for node in gm.graph.nodes:
         if node.op == "get_attr":
             constant_val = getattr(gm, node.target)
-            if hash(constant_val) in lifted_objs:
+            if constant_val in lifted_objs:
                 # We already lifted this constant elsewhere. Just rewrite uses
                 # of this get_attr to point to the already-existing placeholder
                 # node.
-                const_placeholder_node = lifted_objs[hash(constant_val)]
+                const_placeholder_node = lifted_objs[constant_val]
                 node.replace_all_uses_with(const_placeholder_node)
                 gm.graph.erase_node(node)
                 continue
 
+            # For ScriptObject and Tensor constants:
+            # First check if the constant was an attribute on some module by
+            # consulting `constant_attrs` map. If it is, use the fqn that keeps
+            # its location consistent with the eager module.
+            #
+            # If it's not in the `constant_attrs` map, that means it's an inline
+            # constant (e.g. x + torch.tensor(0)), and thus did not have a
+            # specific location in the eager module. In that case, just generate
+            # some name and attach it to the module in which it was used.
             if isinstance(constant_val, torch.ScriptObject):
-                constant_name = f"_lifted_custom_obj{num_custom_obj}"
                 constant_kind = InputKind.CUSTOM_OBJ
-                num_custom_obj += 1
+                constant_fqn = constant_attrs.get(constant_val)
+                if constant_fqn is not None:
+                    _, _, constant_name = constant_fqn.rpartition(".")
+                else:
+                    constant_name = f"_lifted_custom_obj{num_custom_obj}"
+                    constant_fqn = get_constant_fqn(node, constant_name)
+                    num_custom_obj += 1
             elif isinstance(constant_val, torch.Tensor):
-                constant_name = f"_lifted_tensor_constant{num_tensor_constants}"
                 constant_kind = InputKind.CONSTANT_TENSOR
-                num_tensor_constants += 1
+                constant_fqn = constant_attrs.get(constant_val)
+                if constant_fqn is not None:
+                    _, _, constant_name = constant_fqn.rpartition(".")
+                else:
+                    constant_name = f"_lifted_tensor_constant{num_tensor_constants}"
+                    constant_fqn = get_constant_fqn(node, constant_name)
+                    num_tensor_constants += 1
             elif isinstance(constant_val, torch.fx.GraphModule):
                 continue
             elif "LoweredBackendModule" in type(constant_val).__name__:
@@ -91,17 +180,6 @@ def lift_constants_pass(
 
                 for k, v in node.meta.items():
                     const_placeholder_node.meta[k] = v
-
-                # The FQN of the constant tensor in the state dict should
-                # correspond to the module where the constant tensor was
-                # originally used.
-                parent_fqn = list(
-                    const_placeholder_node.meta["nn_module_stack"].values()
-                )[-1][0]
-                if len(parent_fqn) > 0:
-                    constant_fqn = f"{parent_fqn}.{constant_name}"
-                else:
-                    constant_fqn = constant_name
 
                 input_spec_arg: ArgumentSpec
                 if isinstance(constant_val, torch.Tensor):
@@ -126,7 +204,7 @@ def lift_constants_pass(
                         f"tried to lift unsupported type {type(constant_val)} from node {node.format_node()}"
                     )
 
-                lifted_objs[hash(constant_val)] = const_placeholder_node
+                lifted_objs[constant_val] = const_placeholder_node
                 node.replace_all_uses_with(const_placeholder_node)
                 gm.graph.erase_node(node)
 

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -24,6 +24,7 @@ from torch._export.passes.add_runtime_assertions_for_constraints_pass import (
 )
 from torch._export.passes.collect_tracepoints_pass import CollectTracepointsPass
 from torch._export.passes.lift_constants_pass import (
+    ConstantAttrMap,
     lift_constants_pass,
     rewrite_script_object_meta,
 )
@@ -242,6 +243,31 @@ def _get_param_buffer_mapping(
     return param_buffer_table
 
 
+def _remap_constants(
+    orig_constant_attrs: ConstantAttrMap,
+    graph_signature: ExportGraphSignature,
+    constants: Dict[str, Union[torch.Tensor, torch.ScriptObject]],
+) -> None:
+    """Rewrite the graph signature and constants table to use the FQN from the original module."""
+    remap_table: Dict[str, str] = {}
+    for name, value in constants.items():
+        if value in orig_constant_attrs:
+            remap_table[name] = orig_constant_attrs[value]
+
+    for spec in graph_signature.input_specs:
+        if spec.kind in (
+            InputKind.CONSTANT_TENSOR,
+            InputKind.CUSTOM_OBJ,
+        ):
+            orig_target = spec.target
+            assert orig_target is not None
+            spec.target = remap_table.get(orig_target, orig_target)
+
+            constant = constants[orig_target]
+            del constants[orig_target]
+            constants[spec.target] = constant
+
+
 def _restore_state_dict(
     original_module: torch.nn.Module, traced_module: torch.fx.GraphModule
 ) -> None:
@@ -345,11 +371,43 @@ def _export_to_torch_ir(
     return gm_torch_level
 
 
+def _gather_constant_attrs(m: torch.nn.Module) -> ConstantAttrMap:
+    """Search the module hierarchy, gathering up all tensor and ScriptObject constants.
+
+    Returns a dictionary mapping hash(value) to the name of the constant. We
+    have to abuse `hash` here unfortunately, see: [ScriptObject hash].
+    """
+    constants = ConstantAttrMap()
+    buffers_parameters = set(m.buffers())
+    buffers_parameters.update(m.parameters())
+
+    def inner(m: torch.nn.Module, prefix_atoms: List[str], constants):
+        for k, v in m.__dict__.items():
+            if isinstance(v, (torch.Tensor, torch.ScriptObject)):
+                if v in buffers_parameters:
+                    # filter out buffers and parameters, leaving only constants
+                    continue
+
+                fqn = ".".join(prefix_atoms + [k])
+                if v in constants:
+                    raise ValueError(
+                        f"Duplicate reference to constant attribute found: '{constants[v]}' and '{fqn}'."
+                    )
+
+                constants[v] = fqn
+        for k, v in m.named_children():
+            inner(v, prefix_atoms + [k], constants)
+
+    inner(m, [], constants)
+    return constants
+
+
 def _export_non_strict(
     mod,
     fake_args,
     fake_kwargs,
     fake_params_buffers,
+    constant_attrs: ConstantAttrMap,
     *,
     transform=lambda x: x,  # TODO(zhxchen17) Revisit if this is needed later.
     pre_dispatch=False,
@@ -449,7 +507,7 @@ def _export_non_strict(
     )
 
     constants = rewrite_script_object_meta(gm)
-    constants.update(lift_constants_pass(gm, export_graph_signature))
+    constants.update(lift_constants_pass(gm, export_graph_signature, constant_attrs))
 
     @dataclasses.dataclass
     class _ExportedProgramNonStrict:
@@ -624,6 +682,8 @@ def _export(
 
     kwargs = kwargs or {}
 
+    constant_attrs = _gather_constant_attrs(f)
+
     flat_args, orig_in_spec = pytree.tree_flatten((args, kwargs))
 
     if not strict:
@@ -714,6 +774,7 @@ def _export(
             fake_args,
             fake_kwargs,
             fake_params_buffers,
+            constant_attrs,
             pre_dispatch=pre_dispatch,
             transform=_tuplify_outputs,
         )
@@ -872,6 +933,7 @@ def _export(
         _convert_to_positional_args(orig_arg_names, fake_args, fake_kwargs),
         {},
         fake_params_buffers,
+        constant_attrs,
         pre_dispatch=pre_dispatch,
     )
 
@@ -933,6 +995,9 @@ def _export(
 
     # 3. Remove non-persistent buffers from the graph signature
     rewrite_non_persistent_buffers(f, ep_non_strict.sig, ep_non_strict.constants)
+
+    # 4. Rewrite constants to have the same FQN as the original module.
+    _remap_constants(constant_attrs, export_graph_signature, constants)
 
     module_call_signatures = {
         fqn: ModuleCallSignature(inputs=[], outputs=[], **specs)

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -454,7 +454,10 @@ class ExportedProgram:
         from torch._export.passes.add_runtime_assertions_for_constraints_pass import (
             _AddRuntimeAssertionsForInlineConstraintsPass,
         )
-        from torch._export.passes.lift_constants_pass import lift_constants_pass
+        from torch._export.passes.lift_constants_pass import (
+            ConstantAttrMap,
+            lift_constants_pass,
+        )
         from torch._export.passes.replace_sym_size_ops_pass import (
             _replace_sym_size_ops_pass,
         )
@@ -548,7 +551,7 @@ class ExportedProgram:
 
         new_range_constraints = _get_updated_range_constraints(gm)
 
-        constants = lift_constants_pass(gm, new_graph_signature)
+        constants = lift_constants_pass(gm, new_graph_signature, ConstantAttrMap())
         for k, v in constants.items():
             assert k not in self.constants
             self.constants[k] = v


### PR DESCRIPTION
Summary:
Previously we were renaming constants to `lifted_constant_tensor0` or equivalent. This PR changes things so that the constants retain the same FQN as in the original eager module.

Actually, `symbolic_trace` already is supposed to do this, but the code path is not triggered when used from `make_fx`, since we don't pass an actual `nn.Module` instance to `trace()`, but rather a multiply-wrapped-functionalized-lambda-thing.

So, I reproduced the essential logic outside of make_fx, at the export layer.

Test Plan: added a unit test

Differential Revision: D54221616


