### PR TITLE
[inductor] correctly retrieve the "shared" attribute from a Triton binary

### DIFF
--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -394,9 +394,10 @@ class CachingAutotuner(KernelInterface):
             if hasattr(binary, "num_warps")
             else binary.metadata.num_warps
         )
-        scope["shared"] = (
+        binary_shared = (
             binary.shared if hasattr(binary, "shared") else binary.metadata.shared
         )
+        scope["shared"] = binary_shared
 
         exec(
             f"""
@@ -422,7 +423,7 @@ class CachingAutotuner(KernelInterface):
         launcher.config = cfg
         launcher.n_regs = getattr(binary, "n_regs", None)
         launcher.n_spills = getattr(binary, "n_spills", None)
-        launcher.shared = getattr(binary, "shared", None)
+        launcher.shared = binary_shared
         launcher.store_cubin = config.triton.store_cubin
         # store this global variable to avoid the high overhead of reading it when calling run
         if launcher.store_cubin:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120666



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames