### PR TITLE
add a note wrt torch.nn.functional.scaled_dot_product_attention

### DIFF
--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -136,7 +136,8 @@ class Transformer(Module):
 
             If a boolean tensor is provided for any of the [src/tgt/memory]_mask arguments, positions with a ``True`` value are
             not allowed to participate in the attention,
-            which is the opposite of the definition for :attr:`attn_mask` in :func:`torch.nn.functional.scaled_dot_product_attention`.
+            which is the opposite of the definition for :attr:`attn_mask`
+            in :func:`torch.nn.functional.scaled_dot_product_attention`.
 
         Args:
             src: the sequence to the encoder (required).

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -134,9 +134,9 @@ class Transformer(Module):
 
         .. note::
 
-        If a boolean tensor is provided for any of the [src/tgt/memory]_mask arguments, positions with a ``True`` value are
-        not allowed to participate in the attention,
-        which is the opposite of the definition for :attr:`attn_mask` in :func:`torch.nn.functional.scaled_dot_product_attention`.
+            If a boolean tensor is provided for any of the [src/tgt/memory]_mask arguments, positions with a ``True`` value are
+            not allowed to participate in the attention,
+            which is the opposite of the definition for :attr:`attn_mask` in :func:`torch.nn.functional.scaled_dot_product_attention`.
 
         Args:
             src: the sequence to the encoder (required).

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -184,8 +184,8 @@ class Transformer(Module):
 
             Note: [src/tgt/memory]_mask ensures that position :math:`i` is allowed to attend the unmasked
             positions. If a BoolTensor is provided, positions with ``True``
-            are not allowed to attend while ``False`` values will be unchanged.
-            If a FloatTensor is provided, it will be added to the attention weight.
+            are not allowed to attend while ``False`` values will be unchanged. If a FloatTensor
+            is provided, it will be added to the attention weight.
             [src/tgt/memory]_key_padding_mask provides specified elements in the key to be ignored by
             the attention. If a BoolTensor is provided, the positions with the
             value of ``True`` will be ignored while the position with the value of ``False`` will be unchanged.

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -179,7 +179,7 @@ class Transformer(Module):
             Note: [src/tgt/memory]_mask ensures that position :math:`i` is allowed to attend the unmasked
             positions. If a BoolTensor is provided, positions with ``True``
             are not allowed to attend while ``False`` values will be unchanged.
-            (This definition is oppsite to that of :attr:`attn_mask` in
+            (This definition is opposite to that of :attr:`attn_mask` in
             torch.nn.functional.scaled_dot_product_attention.)
             If a FloatTensor is provided, it will be added to the attention weight.
             [src/tgt/memory]_key_padding_mask provides specified elements in the key to be ignored by

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -132,6 +132,12 @@ class Transformer(Module):
                 memory_is_causal: bool = False) -> Tensor:
         r"""Take in and process masked source/target sequences.
 
+        .. note::
+
+        If a boolean tensor is provided for any of the [src/tgt/memory]_mask arguments, positions with a ``True`` value are
+        not allowed to participate in the attention,
+        which is the opposite of the definition for :attr:`attn_mask` in :func:`torch.nn.functional.scaled_dot_product_attention`.
+
         Args:
             src: the sequence to the encoder (required).
             tgt: the sequence to the decoder (required).
@@ -179,8 +185,6 @@ class Transformer(Module):
             Note: [src/tgt/memory]_mask ensures that position :math:`i` is allowed to attend the unmasked
             positions. If a BoolTensor is provided, positions with ``True``
             are not allowed to attend while ``False`` values will be unchanged.
-            (This definition is opposite to that of :attr:`attn_mask` in
-            torch.nn.functional.scaled_dot_product_attention.)
             If a FloatTensor is provided, it will be added to the attention weight.
             [src/tgt/memory]_key_padding_mask provides specified elements in the key to be ignored by
             the attention. If a BoolTensor is provided, the positions with the

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -178,8 +178,10 @@ class Transformer(Module):
 
             Note: [src/tgt/memory]_mask ensures that position :math:`i` is allowed to attend the unmasked
             positions. If a BoolTensor is provided, positions with ``True``
-            are not allowed to attend while ``False`` values will be unchanged. If a FloatTensor
-            is provided, it will be added to the attention weight.
+            are not allowed to attend while ``False`` values will be unchanged.
+            (This definition is oppsite to that of :attr:`attn_mask` in
+            torch.nn.functional.scaled_dot_product_attention.)
+            If a FloatTensor is provided, it will be added to the attention weight.
             [src/tgt/memory]_key_padding_mask provides specified elements in the key to be ignored by
             the attention. If a BoolTensor is provided, the positions with the
             value of ``True`` will be ignored while the position with the value of ``False`` will be unchanged.


### PR DESCRIPTION
followup change of https://github.com/pytorch/pytorch/pull/120565 

- Added a note in the transformer class pointing out the mask definition is opposite to that of :attr:`attn_mask` in
            torch.nn.functional.scaled_dot_product_attention.
@mikaylagawarecki 
