### PR TITLE
docker: Only match tags that start with v*

### DIFF
--- a/docker.Makefile
+++ b/docker.Makefile
@@ -21,7 +21,8 @@ CUDA_CHANNEL              = nvidia
 INSTALL_CHANNEL          ?= pytorch
 
 PYTHON_VERSION           ?= 3.10
-PYTORCH_VERSION          ?= $(shell git describe --tags --always)
+# Match versions that start with v followed by a number, to avoid matching with tags like ciflow
+PYTORCH_VERSION          ?= $(shell git describe --tags --always --match "v[1-9]*.*")
 # Can be either official / dev
 BUILD_TYPE               ?= dev
 BUILD_PROGRESS           ?= auto


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120670

To avoid issues where version could be confused with a ciflow tag.

Example:

```
❯ git describe --tags --always
ciflow/periodic/c3496d50f0bb437c70f27085f71155209277bfd4-47-g4ca24959d1a
❯ git describe --tags --always --match "v[1-9]*.*"
v1.8.0-rc1-36500-g4ca24959d1a
```

Resolves https://github.com/pytorch/pytorch/issues/120392

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>