### PR TITLE
[fbcode] Upstream parallel fast cat on cpu in OSS cat op

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -547,7 +547,7 @@ std::vector<Tensor> broadcast_tensors(TensorList tensors) {
   return expand_outplace(tensors);
 }
 
-static void fastCatOutDim0(const Tensor& out, const MaterializedITensorListRef& inputs) {
+static void singleFastCatOutDim0(const Tensor& out, const MaterializedITensorListRef& inputs) {
   auto outBytes = out.nbytes();
   char* dataPtr = reinterpret_cast<char*>(out.data_ptr());
   size_t totalBytes = 0;
@@ -561,6 +561,83 @@ static void fastCatOutDim0(const Tensor& out, const MaterializedITensorListRef& 
   TORCH_CHECK(outBytes == totalBytes);
 }
 
+static void parallelFastCatOutDim0(
+    const Tensor& out,
+    const MaterializedITensorListRef& inputs) {
+  // Partition inputs into parallel chunks based on number of elements
+  size_t out_elements = out.numel();
+  TORCH_CHECK(out_elements >= at::internal::GRAIN_SIZE && at::get_num_threads() > 1);
+  size_t total_elements = 0;
+  size_t copy_elements = 0;
+  std::vector<std::pair<size_t, size_t>> input_chunks;
+  size_t start = 0;
+  size_t end = 0;
+  for (const auto i: c10::irange(0, inputs.size())) {
+    const Tensor& input = inputs[i];
+    const size_t input_elements = input.numel();
+    total_elements += input_elements;
+    TORCH_CHECK(out_elements >= total_elements);
+    copy_elements += input_elements;
+    if (copy_elements >= at::internal::GRAIN_SIZE) {
+      end = i + 1;
+      input_chunks.emplace_back(start, end);
+      start = end;
+      copy_elements = 0;
+    }
+  }
+  TORCH_CHECK(out_elements == total_elements);
+  if (start < inputs.size()) {
+    // The remaining elements < GRAIN_SIZE, but still have to be copied
+    input_chunks.emplace_back(start, inputs.size());
+  }
+
+  // Record starting bytes offset
+  size_t out_bytes = out.nbytes();
+  size_t total_bytes = 0;
+  std::vector<size_t> out_bytes_offset;
+  out_bytes_offset.reserve(inputs.size() + 1);
+  out_bytes_offset.emplace_back(0);
+  for (const auto i: c10::irange(0, inputs.size())) {
+    const Tensor& input = inputs[i];
+    const auto input_nbytes = input.nbytes();
+    total_bytes += input_nbytes;
+    TORCH_CHECK(out_bytes >= total_bytes);
+    out_bytes_offset.emplace_back(total_bytes);
+  }
+  TORCH_CHECK(out_bytes == total_bytes);
+
+  char* data_ptr = reinterpret_cast<char*>(out.data_ptr());
+  at::parallel_for(
+      0, input_chunks.size(), 1, [&](int64_t chunk_start, int64_t chunk_end) {
+        // Get the input idx range from the element range
+        for (const auto chunk_idx: c10::irange(chunk_start, chunk_end)) {
+          const size_t input_start = input_chunks[chunk_idx].first;
+          const size_t input_end = input_chunks[chunk_idx].second;
+          for (size_t i = input_start; i < input_end; i++) {
+            const Tensor& input = inputs.at(i);
+            if (i == inputs.size() - 1) {
+              TORCH_CHECK((out_bytes_offset.at(i) + input.nbytes()) == total_bytes);
+            } else {
+              TORCH_CHECK((out_bytes_offset.at(i) + input.nbytes()) <= total_bytes);
+            }
+            if (input.nbytes() > 0) {
+              std::memcpy(
+                  data_ptr + out_bytes_offset.at(i),
+                  input.data_ptr(),
+                  input.nbytes());
+            }
+          }
+        }
+      });
+}
+
+static void fastCatOutDim0(const Tensor& out, const MaterializedITensorListRef& inputs) {
+  if (out.numel() < at::internal::GRAIN_SIZE || at::get_num_threads() <= 1) {
+    singleFastCatOutDim0(out, inputs);
+    return;
+  }
+  parallelFastCatOutDim0(out, inputs);
+}
 
 TORCH_IMPL_FUNC(cat_out_cpu)
 (const ITensorListRef& tensors,
@@ -582,7 +659,7 @@ TORCH_IMPL_FUNC(cat_out_cpu)
   bool serial_dtype = at::isFloatingType(dtype);
   // fast path for single thread when both inputs and result are contiguous and
   // not empty, and concat dim is 0
-  if (use_serial_kernel && all_contiguous && all_same_dtype && (MemoryFormat::Contiguous == memory_format)) {
+  if (all_contiguous && all_same_dtype && (MemoryFormat::Contiguous == memory_format)) {
     if (dim == 0) {
       fastCatOutDim0(result, materialized);
       return;

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -606,6 +606,37 @@ class TestTensorCreation(TestCase):
                 self.assertEqual(c.grad, expected_c_grad)
                 self.assertEqual(d.grad, expected_d_grad)
 
+    @onlyCPU
+    @dtypes(*all_types_and_complex())
+    def test_cat_out_fast_big_in_parallel(self, device, dtype):
+        # Set the size big enough
+        if dtype in integral_types():
+            y = torch.randint(low=0, high=100, size=(10, 1024 * 32), device=device, dtype=dtype)
+        else:
+            y = torch.randn((10, 1024 * 32), device=device, dtype=dtype)
+        # Test concat on dimension 0
+        w = y.clone()
+        a = torch.cat([w[:3].contiguous(), w[3:5].contiguous(), w[5:9].contiguous(), w[9:10].contiguous()])
+        self.assertEqual(a, w)
+        # Finally, we need to make sure backward is not broken
+        # Integral types will not have grad
+        if dtype not in integral_types():
+            a = torch.randn((4, 1024 * 32), device=device, dtype=dtype, requires_grad=True)
+            b = torch.randn((2, 1024 * 32), device=device, dtype=dtype, requires_grad=True)
+            expected_a_grad = torch.ones((4, 1024 * 32), device=device, dtype=dtype)
+            expected_b_grad = torch.ones((2, 1024 * 32), device=device, dtype=dtype)
+            # All the new tensors should be contiguous here. Let us make sure
+            # to explicitly set them contiguous to enforce fast cat
+            dim0_cat = torch.cat([a.contiguous(), b.contiguous()], dim=0)
+            if dtype in complex_types():
+                dim0_cat.sum().abs().backward()
+                self.assertEqual(a.grad.abs(), expected_a_grad.abs())
+                self.assertEqual(b.grad.abs(), expected_b_grad.abs())
+            else:
+                dim0_cat.sum().backward()
+                self.assertEqual(a.grad, expected_a_grad)
+                self.assertEqual(b.grad, expected_b_grad)
+
     def test_cat_out_channels_last(self, device):
         x = torch.randn((4, 3, 8, 8))
         y = torch.randn(x.shape)


### PR DESCRIPTION
Summary:
Previous pull Request closed: https://github.com/pytorch/pytorch/pull/107442

The original implementation in D40433604 is not feasible to be directly upstreamed to OSS for two reasons:
- It is using folly executor, while I see all the intra-op parallelism in OSS repo is using torch parallel_for api (underlying is either native thread pool or simply OpenMP). I believe it is better to avoid additional dependencies there
- It requires some gflags directly specify a magic number of partitioning thresholds in terms of # of bytes. It is not clean

This diff is making use of the heuristic number (https://www.internalfb.com/code/fbsource/[297f89d5823451fe9f4b5985e6537e89a72bb75a]/fbcode/caffe2/aten/src/ATen/TensorIterator.h?lines=86) from PyTorch OSS repo to do a best effort partitioning based on element numbers with a rounding-up. It also uses torch parallel_for api for parallelism

Test Plan:
## Unit test

Make sure we don't break things:
```
pytest -k test_cat_out test/test_tensor_creation_ops.py -v -s
...
================================================================ 14 passed, 1 skipped, 619 deselected in 3.73s ================================================================
```
Test for parallel cat:
```
pytest -k test_cat_fast test/test_tensor_creation_ops.py -v -s
============================================================================= test session starts =============================================================================
platform linux -- Python 3.9.18, pytest-7.4.0, pluggy-1.0.0 -- /home/zhiyuanw/local/miniconda3/envs/pytorch/bin/python
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase(PosixPath('/data/users/zhiyuanw/pytorch/.hypothesis/examples'))
rootdir: /data/users/zhiyuanw/pytorch
configfile: pytest.ini
plugins: hypothesis-6.98.12
collected 634 items / 625 deselected / 9 selected
Running 9 items in this shard

test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_fast_big_in_parallel_cpu_complex128 PASSED [0.8632s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_fast_big_in_parallel_cpu_complex64 PASSED [0.0207s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_fast_big_in_parallel_cpu_float32 PASSED [0.0137s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_fast_big_in_parallel_cpu_float64 PASSED [0.0319s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_fast_big_in_parallel_cpu_int16 PASSED [0.0110s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_fast_big_in_parallel_cpu_int32 PASSED [0.0076s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_fast_big_in_parallel_cpu_int64 PASSED [0.0080s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_fast_big_in_parallel_cpu_int8 PASSED [0.0075s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_fast_big_in_parallel_cpu_uint8 PASSED [0.0076s]

====================================================================== 9 passed, 625 deselected in 2.80s ======================================================================
```


