### PR TITLE
[TorchElastic] Refactoring to support non-default logging strategy

### DIFF
--- a/docs/source/elastic/multiprocessing.rst
+++ b/docs/source/elastic/multiprocessing.rst
@@ -22,3 +22,11 @@ Process Context
 .. autoclass:: SubprocessContext
 
 .. autoclass:: RunProcsResult
+
+.. autoclass:: DefaultLogsSpecs
+    :members:
+
+.. autoclass:: LogsDest
+
+.. autoclass:: LogsSpecs
+    :members:

--- a/test/distributed/elastic/multiprocessing/api_test.py
+++ b/test/distributed/elastic/multiprocessing/api_test.py
@@ -22,6 +22,7 @@ import torch
 import torch.multiprocessing as mp
 from torch.distributed.elastic.multiprocessing import ProcessFailure, start_processes
 from torch.distributed.elastic.multiprocessing.api import (
+    DefaultLogsSpecs,
     MultiprocessContext,
     RunProcsResult,
     SignalException,
@@ -213,8 +214,7 @@ def start_processes_zombie_test(
         entrypoint=entrypoint,
         args=args,
         envs=envs,
-        log_dir=log_dir,
-        redirects=Std.NONE,
+        logs_specs=DefaultLogsSpecs(log_dir=log_dir),
     )
     my_pid = os.getpid()
     mp_queue.put(my_pid)
@@ -273,7 +273,6 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS):
         def test_invalid_log_dir(self):
             with tempfile.NamedTemporaryFile(dir=self.test_dir) as not_a_dir:
                 cases = {
-                    "does_not_exist": FileNotFoundError,
                     not_a_dir.name: NotADirectoryError,
                     # test_dir is not empty since we touched not_a_dir file
                     self.test_dir: RuntimeError,
@@ -282,13 +281,19 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS):
                 for (log_dir, expected_error) in cases.items():
                     with self.subTest(log_dir=log_dir, expected_error=expected_error):
                         with self.assertRaises(expected_error):
-                            start_processes(
-                                name="echo",
-                                entrypoint=echo1,
-                                args={0: ("hello",)},
-                                envs={0: {"RANK": "0"}},
-                                log_dir=log_dir,
-                            )
+                            pc = None
+                            try:
+                                pc = start_processes(
+                                    name="echo",
+                                    entrypoint=echo1,
+                                    args={0: ("hello",)},
+                                    envs={0: {"RANK": "0"}},
+                                    logs_specs=DefaultLogsSpecs(log_dir=log_dir),
+                                )
+                            finally:
+                                if pc:
+                                    pc.close()
+
 
         def test_args_env_len_mismatch(self):
             cases = [
@@ -314,7 +319,7 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS):
                             entrypoint=echo1,
                             args=args,
                             envs=envs,
-                            log_dir=self.log_dir(),
+                            logs_specs=DefaultLogsSpecs(log_dir=self.log_dir()),
                         )
 
         def test_pcontext_wait(self):
@@ -323,7 +328,7 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS):
                 entrypoint=time.sleep,
                 args={0: (1,)},
                 envs={0: {}},
-                log_dir=self.log_dir(),
+                logs_specs=DefaultLogsSpecs(log_dir=self.log_dir()),
                 start_method="spawn",
             )
 
@@ -338,7 +343,7 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS):
                 entrypoint=time.sleep,
                 args={0: (1,)},
                 envs={0: {}},
-                log_dir=self.log_dir(),
+                logs_specs=DefaultLogsSpecs(log_dir=self.log_dir()),
                 start_method="spawn",
             )
 
@@ -354,7 +359,7 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS):
                 entrypoint=bin("zombie_test.py"),
                 args={0: (1,)},
                 envs={0: {}},
-                log_dir=self.log_dir(),
+                logs_specs=DefaultLogsSpecs(log_dir=self.log_dir()),
             )
 
             pids = pc.pids()
@@ -368,7 +373,7 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS):
                     entrypoint=dummy_compute,
                     args={},
                     envs={},
-                    log_dir=self.log_dir(),
+                    logs_specs=DefaultLogsSpecs(log_dir=self.log_dir()),
                     start_method=start_method,
                 )
 
@@ -386,7 +391,7 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS):
                         entrypoint=echo0,
                         args={0: ("hello",), 1: ("world",)},
                         envs={0: {}, 1: {}},
-                        log_dir=self.log_dir(),
+                        logs_specs=DefaultLogsSpecs(log_dir=self.log_dir()),
                         start_method=start_method,
                     )
 
@@ -405,11 +410,11 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS):
             for start_method in self._start_methods:
                 with self.subTest(start_method=start_method):
                     pc = start_processes(
+                        logs_specs=DefaultLogsSpecs(log_dir=self.log_dir()),
                         name="echo",
                         entrypoint=echo_large,
                         args={0: (size,), 1: (size,), 2: (size,), 3: (size,)},
                         envs={0: {}, 1: {}, 2: {}, 3: {}},
-                        log_dir=self.log_dir(),
                         start_method=start_method,
                     )
 
@@ -430,8 +435,10 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS):
                         name="echo",
                         entrypoint=echo2,
                         args={0: ("hello", RAISE), 1: ("world",)},
-                        envs={0: {}, 1: {}},
-                        log_dir=log_dir,
+                        envs={
+                            0: {"TORCHELASTIC_RUN_ID": "run_id"},
+                            1: {"TORCHELASTIC_RUN_ID": "run_id"}},
+                        logs_specs=DefaultLogsSpecs(log_dir=log_dir),
                         start_method=start_method,
                     )
 
@@ -448,9 +455,8 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS):
                     self.assertEqual(1, failure.exitcode)
                     self.assertEqual("<N/A>", failure.signal_name())
                     self.assertEqual(pc.pids()[0], failure.pid)
-                    self.assertEqual(
-                        os.path.join(log_dir, "0", "error.json"), error_file
-                    )
+                    self.assertTrue(error_file.startswith(os.path.join(log_dir, "run_id_")))
+                    self.assertTrue(error_file.endswith("attempt_0/0/error.json"))
                     self.assertEqual(
                         int(error_file_data["message"]["extraInfo"]["timestamp"]),
                         int(failure.timestamp),
@@ -469,8 +475,10 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS):
                 entrypoint=bin("echo1.py"),
                 args={0: ("--exitcode", FAIL, "foo"), 1: ("--exitcode", 0, "bar")},
                 envs={0: {"RANK": "0"}, 1: {"RANK": "1"}},
-                log_dir=self.log_dir(),
-                redirects={0: Std.ALL},
+                logs_specs=DefaultLogsSpecs(
+                    log_dir=self.log_dir(),
+                    redirects={0: Std.ALL},
+                ),
             )
 
             results = pc.wait(period=0.1)
@@ -495,7 +503,7 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS):
                 entrypoint=bin("echo2.py"),
                 args={0: ("--raises", "true", "foo"), 1: ("bar",)},
                 envs={0: {"RANK": "0"}, 1: {"RANK": "1"}},
-                log_dir=self.log_dir(),
+                logs_specs=DefaultLogsSpecs(log_dir=self.log_dir()),
             )
 
             results = pc.wait(period=0.1)
@@ -516,7 +524,7 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS):
                     entrypoint="does_not_exist.py",
                     args={0: ("foo"), 1: ("bar",)},
                     envs={0: {}, 1: {}},
-                    log_dir=self.log_dir(),
+                    logs_specs=DefaultLogsSpecs(log_dir=self.log_dir()),
                 )
 
         def test_validate_full_rank(self):
@@ -533,12 +541,12 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS):
                 name="test_mp",
                 entrypoint=echo0,
                 args={0: (0, 1)},
-                envs={},
-                stdouts={0: {}},
-                stderrs={0: {}},
-                tee_stdouts={0: "tee_stdout"},
-                tee_stderrs={0: "tee_stderr"},
-                error_files={0: "test_file"},
+                envs={0: {}},
+                logs_specs=DefaultLogsSpecs(
+                    log_dir=self.log_dir(),
+                    redirects=Std.ALL,
+                    tee=Std.ALL
+                ),
                 start_method="spawn",
             )
             mp_context._pc = mock.Mock()
@@ -574,9 +582,11 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS):
                         entrypoint=echo1,
                         args={0: ("hello",), 1: ("hello",)},
                         envs={0: {"RANK": "0"}, 1: {"RANK": "1"}},
-                        log_dir=self.log_dir(),
+                        logs_specs=DefaultLogsSpecs(
+                            log_dir=self.log_dir(),
+                            redirects=redirs,
+                        ),
                         start_method=start_method,
-                        redirects=redirs,
                     )
 
                     results = pc.wait(period=0.1)
@@ -609,9 +619,11 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS):
                         entrypoint=bin("echo1.py"),
                         args={0: ("hello",), 1: ("hello",)},
                         envs={0: {"RANK": "0"}, 1: {"RANK": "1"}},
-                        log_dir=self.log_dir(),
+                        logs_specs=DefaultLogsSpecs(
+                            log_dir=self.log_dir(),
+                            redirects=redirs,
+                        ),
                         log_line_prefixes={0: "[rank0]:", 1: "[rank1]:"},
-                        redirects=redirs,
                     )
 
                     results = pc.wait(period=0.1)
@@ -642,11 +654,13 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS):
                 entrypoint=bin("echo1.py"),
                 args={0: ("hello",), 1: ("world",)},
                 envs={0: {"RANK": "0"}, 1: {"RANK": "1"}},
-                log_dir=self.log_dir(),
+                logs_specs=DefaultLogsSpecs(
+                    log_dir=self.log_dir(),
+                    redirects={0: Std.ERR, 1: Std.NONE},
+                    tee={0: Std.OUT, 1: Std.ERR},
+                ),
                 log_line_prefixes={0: "[rank0]:", 1: "[rank1]:"},
                 start_method="spawn",
-                redirects={0: Std.ERR, 1: Std.NONE},
-                tee={0: Std.OUT, 1: Std.ERR},
             )
 
             result = pc.wait()
@@ -702,7 +716,9 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS or IS_CI):
                 entrypoint=bin("echo3.py"),
                 args={0: ("--segfault", "true", "foo"), 1: ("bar",)},
                 envs={0: {"RANK": "0"}, 1: {"RANK": "1"}},
-                log_dir=self.log_dir(),
+                logs_specs=DefaultLogsSpecs(
+                    log_dir=self.log_dir(),
+                ),
             )
 
             results = pc.wait(period=0.1)
@@ -723,16 +739,17 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS or IS_CI):
         def test_function_redirect_and_tee(self):
             for start_method in self._start_methods:
                 with self.subTest(start_method=start_method):
-                    log_dir = self.log_dir()
                     pc = start_processes(
                         name="trainer",
                         entrypoint=echo1,
                         args={0: ("hello",), 1: ("world",)},
                         envs={0: {"RANK": "0"}, 1: {"RANK": "1"}},
-                        log_dir=log_dir,
+                        logs_specs=DefaultLogsSpecs(
+                            log_dir=self.log_dir(),
+                            redirects={0: Std.ERR, 1: Std.NONE},
+                            tee={0: Std.OUT, 1: Std.ERR},
+                        ),
                         start_method="spawn",
-                        redirects={0: Std.ERR, 1: Std.NONE},
-                        tee={0: Std.OUT, 1: Std.ERR},
                     )
 
                     result = pc.wait()
@@ -753,9 +770,11 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS or IS_CI):
                         entrypoint=echo1,
                         args={0: ("hello",), 1: ("hello",)},
                         envs={0: {"RANK": "0"}, 1: {"RANK": "1"}},
-                        log_dir=self.log_dir(),
                         start_method=start_method,
-                        redirects=redirs,
+                        logs_specs=DefaultLogsSpecs(
+                            log_dir=self.log_dir(),
+                            redirects=redirs,
+                        ),
                     )
 
                     results = pc.wait(period=0.1)
@@ -790,15 +809,16 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS or IS_CI):
             FAIL = 138
             for start_method in self._start_methods:
                 with self.subTest(start_method=start_method):
-                    log_dir = self.log_dir()
                     pc = start_processes(
                         name="echo",
                         entrypoint=echo1,
                         args={0: ("hello", FAIL), 1: ("hello",)},
                         envs={0: {"RANK": "0"}, 1: {"RANK": "1"}},
-                        log_dir=log_dir,
+                        logs_specs=DefaultLogsSpecs(
+                            log_dir=self.log_dir(),
+                            redirects={0: Std.ERR},
+                        ),
                         start_method=start_method,
-                        redirects={0: Std.ERR},
                     )
 
                     results = pc.wait(period=0.1)

--- a/test/distributed/launcher/api_test.py
+++ b/test/distributed/launcher/api_test.py
@@ -23,19 +23,21 @@ from unittest.mock import MagicMock, Mock, patch
 import torch
 import torch.distributed as dist
 from torch.distributed.elastic.agent.server.api import RunResult, WorkerState
-from torch.distributed.elastic.multiprocessing.api import SignalException
+from torch.distributed.elastic.multiprocessing.api import (
+    SignalException,
+)
 from torch.distributed.elastic.multiprocessing.errors import ChildFailedError
 from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
 from torch.distributed.elastic.utils import get_socket_with_port
 from torch.distributed.launcher.api import (
-    LaunchConfig,
     _get_entrypoint_name,
     elastic_launch,
     launch_agent,
+    LaunchConfig,
 )
 from torch.testing._internal.common_utils import (
-    TEST_WITH_DEV_DBG_ASAN,
     skip_but_pass_in_sandcastle_if,
+    TEST_WITH_DEV_DBG_ASAN,
 )
 
 

--- a/test/distributed/launcher/run_test.py
+++ b/test/distributed/launcher/run_test.py
@@ -489,7 +489,6 @@ class ElasticLaunchTest(unittest.TestCase):
         # torch.distributed.is_torchelastic_launched() returns True
 
         out_file = f"{os.path.join(self.test_dir, 'out')}"
-
         launch.main(
             [
                 "--run-path",

--- a/torch/backends/xeon/run_cpu.py
+++ b/torch/backends/xeon/run_cpu.py
@@ -133,7 +133,11 @@ from argparse import ArgumentParser, RawTextHelpFormatter, REMAINDER
 from os.path import expanduser
 from typing import Dict, List
 
-from torch.distributed.elastic.multiprocessing import start_processes, Std
+from torch.distributed.elastic.multiprocessing import (
+    DefaultLogsSpecs,
+    start_processes,
+    Std,
+)
 
 format_str = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 logging.basicConfig(level=logging.INFO, format=format_str)
@@ -666,8 +670,7 @@ won't take effect even if it is set explicitly."
             entrypoint=entrypoint,
             args=launch_args,
             envs=launch_envs,
-            log_dir=args.log_path,
-            tee=launch_tee,
+            logs_specs=DefaultLogsSpecs(log_dir=args.log_path, tee=launch_tee),
         )
         ctx.wait()
 

--- a/torch/distributed/elastic/agent/server/api.py
+++ b/torch/distributed/elastic/agent/server/api.py
@@ -29,7 +29,6 @@ from torch.distributed.elastic.metrics import prof, put_metric
 from torch.distributed.elastic.multiprocessing import (
     ProcessFailure,
     SignalException,
-    Std,
 )
 from torch.distributed.elastic.utils.logging import get_logger
 
@@ -90,8 +89,6 @@ class WorkerSpec:
     master_port: Optional[int] = None
     master_addr: Optional[str] = None
     local_addr: Optional[str] = None
-    redirects: Union[Std, Dict[int, Std]] = Std.NONE
-    tee: Union[Std, Dict[int, Std]] = Std.NONE
 
     def __post_init__(self):
         assert self.local_world_size > 0

--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -9,13 +9,11 @@
 
 import json
 import os
-import shutil
 import signal
 import socket
 from string import Template
-import tempfile
 import uuid
-from typing import Any, Dict, Optional, Tuple, Set
+from typing import Any, Dict, Optional, Tuple
 
 import torch.distributed.elastic.timer as timer
 from torch.distributed.elastic import events
@@ -29,7 +27,7 @@ from torch.distributed.elastic.agent.server.api import (
 )
 from torch.distributed.elastic.events.api import EventMetadataValue
 from torch.distributed.elastic.metrics.api import prof
-from torch.distributed.elastic.multiprocessing import PContext, start_processes
+from torch.distributed.elastic.multiprocessing import PContext, start_processes, LogsSpecs
 from torch.distributed.elastic.utils import macros
 from torch.distributed.elastic.utils.logging import get_logger
 
@@ -136,28 +134,19 @@ class LocalElasticAgent(SimpleElasticAgent):
     def __init__(
         self,
         spec: WorkerSpec,
+        logs_specs: LogsSpecs,
         start_method="spawn",
         exit_barrier_timeout: float = 300,
-        log_dir: Optional[str] = None,
         log_line_prefix_template: Optional[str] = None,
-        local_ranks_filter: Optional[Set[int]] = None,
     ):
         super().__init__(spec, exit_barrier_timeout)
         self._start_method = start_method
         self._pcontext: Optional[PContext] = None
-        rdzv_run_id = spec.rdzv_handler.get_run_id()
         self._rdzv_handler = spec.rdzv_handler
-        self._log_dir = self._make_log_dir(log_dir, rdzv_run_id)
         self._log_line_prefix_template = log_line_prefix_template
-        self._local_ranks_filter = local_ranks_filter
         self._worker_watchdog: Optional[timer.FileTimerServer] = None
+        self._logs_specs = logs_specs
 
-    def _make_log_dir(self, log_dir: Optional[str], rdzv_run_id: str):
-        base_log_dir = log_dir or tempfile.mkdtemp(prefix="torchelastic_")
-        os.makedirs(base_log_dir, exist_ok=True)
-        dir = tempfile.mkdtemp(prefix=f"{rdzv_run_id}_", dir=base_log_dir)
-        log.info("log directory set to: %s", dir)
-        return dir
 
     def _setup_local_watchdog(self, envs: Dict[int, Dict[str, str]]) -> None:
         enable_watchdog_env_name = TORCHELASTIC_ENABLE_FILE_TIMER
@@ -283,26 +272,18 @@ class LocalElasticAgent(SimpleElasticAgent):
             worker_args = macros.substitute(worker_args, str(local_rank))
             args[local_rank] = tuple(worker_args)
 
-        # scaling events do not count towards restarts (gets same attempt #)
-        # remove existing log dir if this restart is due to a scaling event
-        attempt_log_dir = os.path.join(self._log_dir, f"attempt_{restart_count}")
-        shutil.rmtree(attempt_log_dir, ignore_errors=True)
-        os.makedirs(attempt_log_dir)
-
         self._setup_local_watchdog(envs=envs)
 
         assert spec.entrypoint is not None
+        assert self._logs_specs is not None
         self._pcontext = start_processes(
             name=spec.role,
             entrypoint=spec.entrypoint,
             args=args,
             envs=envs,
-            log_dir=attempt_log_dir,
+            logs_specs=self._logs_specs,
             log_line_prefixes=log_line_prefixes,
             start_method=self._start_method,
-            redirects=spec.redirects,
-            tee=spec.tee,
-            local_ranks_filter=self._local_ranks_filter,
         )
 
         return self._pcontext.pids()

--- a/torch/distributed/elastic/multiprocessing/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/__init__.py
@@ -67,6 +67,8 @@ from typing import Callable, Dict, Optional, Tuple, Union, Set
 
 from torch.distributed.elastic.multiprocessing.api import (  # noqa: F401
     _validate_full_rank,
+    DefaultLogsSpecs,
+    LogsSpecs,
     MultiprocessContext,
     PContext,
     ProcessFailure,
@@ -86,6 +88,8 @@ __all__ = [
     "RunProcsResult",
     "SignalException",
     "Std",
+    "LogsSpecs",
+    "DefaultLogsSpecs",
     "SubprocessContext",
     "to_map",
 ]
@@ -98,12 +102,9 @@ def start_processes(
     entrypoint: Union[Callable, str],
     args: Dict[int, Tuple],
     envs: Dict[int, Dict[str, str]],
-    log_dir: str,
+    logs_specs: LogsSpecs,
     log_line_prefixes: Optional[Dict[int, str]] = None,
     start_method: str = "spawn",
-    redirects: Union[Std, Dict[int, Std]] = Std.NONE,
-    tee: Union[Std, Dict[int, Std]] = Std.NONE,
-    local_ranks_filter: Optional[Set[int]] = None,
 ) -> PContext:
     """
     Start ``n`` copies of ``entrypoint`` processes with the provided options.
@@ -198,79 +199,10 @@ def start_processes(
         local_ranks_filter: which ranks' logs to print to console
 
     """
-    # listdir raises FileNotFound or NotADirectoryError so no need to check manually
-    if log_dir != os.devnull and os.listdir(log_dir):
-        raise RuntimeError(
-            f"log_dir: {log_dir} is not empty, please provide an empty log_dir"
-        )
 
     nprocs = len(args)
     _validate_full_rank(args, nprocs, "args")
     _validate_full_rank(envs, nprocs, "envs")
-
-    # create subdirs for each local rank in the logs_dir
-    # logs_dir
-    #       |- 0
-    #          |- error.json
-    #          |- stdout.log
-    #          |- stderr.log
-    #       |- ...
-    #       |- (nprocs-1)
-    redirs = to_map(redirects, nprocs)
-    ts = to_map(tee, nprocs)
-
-    # to tee stdout/stderr we first redirect into a file
-    # then tail -f stdout.log/stderr.log so add tee settings to redirects
-    for local_rank, tee_std in ts.items():
-        redirect_std = redirs[local_rank]
-        redirs[local_rank] = redirect_std | tee_std
-
-    SYS_STREAM = ""  # special case to indicate to output to console
-    stdouts = dict.fromkeys(range(nprocs), SYS_STREAM)
-    stderrs = dict.fromkeys(range(nprocs), SYS_STREAM)
-    tee_stdouts: Dict[int, str] = {}
-    tee_stderrs: Dict[int, str] = {}
-    error_files = {}
-
-    for local_rank in range(nprocs):
-        if log_dir == os.devnull:
-            tee_stdouts[local_rank] = os.devnull
-            tee_stderrs[local_rank] = os.devnull
-            error_files[local_rank] = os.devnull
-            envs[local_rank]["TORCHELASTIC_ERROR_FILE"] = ""
-        else:
-            clogdir = os.path.join(log_dir, str(local_rank))
-            os.mkdir(clogdir)
-
-            rd = redirs[local_rank]
-            if (rd & Std.OUT) == Std.OUT:
-                stdouts[local_rank] = os.path.join(clogdir, "stdout.log")
-            if (rd & Std.ERR) == Std.ERR:
-                stderrs[local_rank] = os.path.join(clogdir, "stderr.log")
-
-            t = ts[local_rank]
-            if t & Std.OUT == Std.OUT:
-                tee_stdouts[local_rank] = stdouts[local_rank]
-            if t & Std.ERR == Std.ERR:
-                tee_stderrs[local_rank] = stderrs[local_rank]
-
-            if local_ranks_filter and local_rank not in local_ranks_filter:
-                # If stream is tee'd, only write to file, but don't tail
-                if local_rank in tee_stdouts:
-                    tee_stdouts.pop(local_rank, None)
-                if local_rank in tee_stderrs:
-                    tee_stderrs.pop(local_rank, None)
-
-                # If stream is not redirected, don't print
-                if stdouts[local_rank] == SYS_STREAM:
-                    stdouts[local_rank] = os.devnull
-                if stderrs[local_rank] == SYS_STREAM:
-                    stderrs[local_rank] = os.devnull
-
-            error_file = os.path.join(clogdir, "error.json")
-            error_files[local_rank] = error_file
-            log.info("Setting worker%s reply file to: %s", local_rank, error_file)
-            envs[local_rank]["TORCHELASTIC_ERROR_FILE"] = error_file
 
     context: PContext
     if isinstance(entrypoint, str):
@@ -279,11 +211,7 @@ def start_processes(
             entrypoint=entrypoint,
             args=args,
             envs=envs,
-            stdouts=stdouts,
-            stderrs=stderrs,
-            tee_stdouts=tee_stdouts,
-            tee_stderrs=tee_stderrs,
-            error_files=error_files,
+            logs_specs=logs_specs,
             log_line_prefixes=log_line_prefixes,
         )
     else:
@@ -292,13 +220,9 @@ def start_processes(
             entrypoint=entrypoint,
             args=args,
             envs=envs,
-            stdouts=stdouts,
-            stderrs=stderrs,
-            tee_stdouts=tee_stdouts,
-            tee_stderrs=tee_stderrs,
-            error_files=error_files,
             log_line_prefixes=log_line_prefixes,
             start_method=start_method,
+            logs_specs=logs_specs,
         )
 
     try:

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -380,7 +380,7 @@ from typing import Callable, List, Tuple, Union, Optional, Set
 
 import torch
 from torch.distributed.argparse_util import check_env, env
-from torch.distributed.elastic.multiprocessing import Std
+from torch.distributed.elastic.multiprocessing import Std, DefaultLogsSpecs
 from torch.distributed.elastic.multiprocessing.errors import record
 from torch.distributed.elastic.rendezvous.utils import _parse_rendezvous_config
 from torch.distributed.elastic.utils import macros
@@ -633,7 +633,7 @@ def parse_min_max_nnodes(nnodes: str):
         min_nodes = int(arr[0])
         max_nodes = int(arr[1])
     else:
-        raise RuntimeError(f'nnodes={nnodes} is not in "MIN:MAX" format')
+        raise RuntimeError(f'nnodes={nnodes} is not in "MIN:MAX" format')  # noqa: E231
 
     return min_nodes, max_nodes
 
@@ -681,7 +681,7 @@ def determine_local_world_size(nproc_per_node: str):
 
 def get_rdzv_endpoint(args):
     if args.rdzv_backend == "static" and not args.rdzv_endpoint:
-        return f"{args.master_addr}:{args.master_port}"
+        return f"{args.master_addr}:{args.master_port}"  # noqa: E231
     return args.rdzv_endpoint
 
 
@@ -745,6 +745,13 @@ def config_from_args(args) -> Tuple[LaunchConfig, Union[Callable, str], List[str
                 "--local_ranks_filter must be a comma-separated list of integers e.g. --local_ranks_filter=0,1,2"
             ) from e
 
+    logs_specs = DefaultLogsSpecs(
+        log_dir=args.log_dir,
+        redirects=Std.from_str(args.redirects),
+        tee=Std.from_str(args.tee),
+        local_ranks_filter=ranks,
+    )
+
     config = LaunchConfig(
         min_nodes=min_nodes,
         max_nodes=max_nodes,
@@ -757,12 +764,9 @@ def config_from_args(args) -> Tuple[LaunchConfig, Union[Callable, str], List[str
         max_restarts=args.max_restarts,
         monitor_interval=args.monitor_interval,
         start_method=args.start_method,
-        redirects=Std.from_str(args.redirects),
-        tee=Std.from_str(args.tee),
-        log_dir=args.log_dir,
         log_line_prefix_template=log_line_prefix_template,
         local_addr=args.local_addr,
-        local_ranks_filter=ranks,
+        logs_specs=logs_specs,
     )
 
     with_python = not args.no_python


### PR DESCRIPTION
Summary:
Pulling out logging parameters into a logging specs that can be overridden (follow-up changes on possible mechanism)

Why?
Right now the logging approach is quite rigid:
- Requires for log directory to exist and not be empty
- Will create tempdir otherwise,
- Creates subdir for a run
- creates subdir for each attempt
- creates files named as stdout.log, stderr.log, error.json

In some instances some of the users would like to customize the behavior including file names based on context. And we do have right now a mechanism to template multiplexed teed output prefix.

With current changes, users can create custom log spec that can use env variables to change the behavior.


Notes:
Made `LaunchConf.logs_specs` as an optional field that will be bound to `DefaultLogsSpecs` instance. There are large number of clients (code) that use the API directly without using torchrun API. For those cases, we have to explicitly pass LogSpecs implementation if we would like to override the implementation. For the regular torchrun users, we can use pluggable approach proposed in the follow up change.

Test Plan: CI + unit tests

Differential Revision: D54176265




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225