### PR TITLE
[pt2 export] small fix on non_persistent buffer unlift

### DIFF
--- a/test/export/test_lift_unlift.py
+++ b/test/export/test_lift_unlift.py
@@ -7,6 +7,7 @@ from torch._export.passes.lift_constants_pass import (
     ConstantAttrMap,
     lift_constants_pass,
 )
+from torch.export._unlift import _unlift_exported_program_lifted_states
 from torch.export.exported_program import (
     ExportGraphSignature,
     InputKind,
@@ -349,6 +350,29 @@ class TestLift(TestCase):
         constant_input_spec = graph_signature.input_specs[0]
         self.assertEqual(constant_input_spec.kind, InputKind.CONSTANT_TENSOR)
         self.assertIsInstance(constant_input_spec.arg, TensorArgument)
+
+    def test_unlift_nonpersistent_buffer(self):
+        class Foo(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer(
+                    "non_persistent_buf", torch.zeros(1), persistent=False
+                )
+
+            def forward(self, x):
+                self.non_persistent_buf.add_(1)
+                return x.sum() + self.non_persistent_buf.sum()
+
+        foo = Foo()
+        exported = torch.export.export(foo, (torch.ones(5, 5),), strict=False)
+        stateful_gm = _unlift_exported_program_lifted_states(exported)
+
+        # Check the unlifted stateful_gm contains the original non-persistent buffer
+        self.assertTrue(hasattr(stateful_gm, "non_persistent_buf"))
+        non_persistent_buf = stateful_gm.get_buffer("non_persistent_buf")
+        self.assertEqual(non_persistent_buf, foo.get_buffer("non_persistent_buf"))
+        self.assertIn("non_persistent_buf", stateful_gm._non_persistent_buffers_set)
+        self.assertNotIn("non_persistent_buf", stateful_gm.state_dict())
 
 
 class ConstantAttrMapTest(TestCase):

--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -262,7 +262,7 @@ def _create_stateful_graph_module(
     # here.
     for buffer in graph_signature.non_persistent_buffers:
         _assign_attr(
-            stateful_gm.get_buffer(buffer),
+            plain_graph_module.get_buffer(buffer),
             stateful_gm,
             buffer,
             attr_kind=_AttrKind.BUFFER,


### PR DESCRIPTION
Summary: Change to get_buffer from the input plain_graph_module instead of the new stateful_gm when restoring non_persistent buffers, since the stateful_gm doesn't contain the buffer yet.

Test Plan:
Added test case.
`buck test caffe2/test:test_export -- test_unlift_nonpersistent_buffer`

Differential Revision: D54216772


