### PR TITLE
Add verbose parameter to torch.hub.list

### DIFF
--- a/torch/hub.py
+++ b/torch/hub.py
@@ -379,7 +379,7 @@ def set_dir(d):
     _hub_dir = os.path.expanduser(d)
 
 
-def list(github, force_reload=False, skip_validation=False, trust_repo=None):
+def list(github, force_reload=False, skip_validation=False, trust_repo=None, verbose=True):
     r"""
     List all callable entrypoints available in the repo specified by ``github``.
 
@@ -411,6 +411,9 @@ def list(github, force_reload=False, skip_validation=False, trust_repo=None):
               v2.0.
 
             Default is ``None`` and will eventually change to ``"check"`` in v2.0.
+        verbose (bool, optional): If ``False``, mute messages about hitting
+            local caches. Note that the message about first download cannot be
+            muted. Default is ``True``.
 
     Returns:
         list: The available callables entrypoint
@@ -419,7 +422,7 @@ def list(github, force_reload=False, skip_validation=False, trust_repo=None):
         >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_HUB)
         >>> entrypoints = torch.hub.list('pytorch/vision', force_reload=True)
     """
-    repo_dir = _get_cache_or_reload(github, force_reload, trust_repo, "list", verbose=True,
+    repo_dir = _get_cache_or_reload(github, force_reload, trust_repo, "list", verbose=verbose,
                                     skip_validation=skip_validation)
 
     with _add_to_sys_path(repo_dir):


### PR DESCRIPTION
This PR adds ```verbose``` to ```torch.hub.list``` to let  users being able to disable extraneous outputs. 