### PR TITLE
[quant][pt2e] Relax `model_is_exported` input

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -1707,6 +1707,7 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
         fx_traced_gm = torch.fx.symbolic_trace(m, example_inputs)
         self.assertTrue(torch.ao.quantization.pt2e.export_utils.model_is_exported(exported_gm))
         self.assertFalse(torch.ao.quantization.pt2e.export_utils.model_is_exported(fx_traced_gm))
+        self.assertFalse(torch.ao.quantization.pt2e.export_utils.model_is_exported(m))
 
     def test_reentrant(self):
         """Test we can safely call quantization apis multiple times"""

--- a/torch/ao/quantization/pt2e/export_utils.py
+++ b/torch/ao/quantization/pt2e/export_utils.py
@@ -14,10 +14,10 @@ def model_is_exported(m: torch.nn.Module) -> bool:
     Return True if the `torch.nn.Module` was exported, False otherwise
     (e.g. if the model was FX symbolically traced or not traced at all).
     """
-    return (
-        isinstance(m, torch.fx.GraphModule) and
-        any("val" in n.meta for n in m.graph.nodes)
+    return isinstance(m, torch.fx.GraphModule) and any(
+        "val" in n.meta for n in m.graph.nodes
     )
+
 
 def _replace_dropout(m: torch.fx.GraphModule, train_to_eval: bool):
     """

--- a/torch/ao/quantization/pt2e/export_utils.py
+++ b/torch/ao/quantization/pt2e/export_utils.py
@@ -9,13 +9,15 @@ __all__ = [
 ]
 
 
-def model_is_exported(m: torch.fx.GraphModule) -> bool:
+def model_is_exported(m: torch.nn.Module) -> bool:
     """
-    Return True if the `torch.fx.GraphModule` was exported,
-    False otherwise (e.g. if the model was FX symbolically traced).
+    Return True if the `torch.nn.Module` was exported, False otherwise
+    (e.g. if the model was FX symbolically traced or not traced at all).
     """
-    return any("val" in n.meta for n in m.graph.nodes)
-
+    return (
+        isinstance(m, torch.fx.GraphModule) and
+        any("val" in n.meta for n in m.graph.nodes)
+    )
 
 def _replace_dropout(m: torch.fx.GraphModule, train_to_eval: bool):
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120720

Summary: This commit relaxes the `model_is_exported` API to
additionally work for `torch.nn.Module`s in addition to just
`torch.fx.GraphModule`s, simplifying downstream uses.

Test Plan:
python test/test_quantization.py TestQuantizePT2E.test_model_is_exported

Differential Revision: [D54263935](https://our.internmc.facebook.com/intern/diff/D54263935)