### PR TITLE
Move VariableInfo into its own file to avoid circular dependency

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -123,6 +123,7 @@ core_trainer_sources = [
     "torch/csrc/autograd/autograd_not_implemented_fallback.cpp",
     "torch/csrc/autograd/cpp_hook.cpp",
     "torch/csrc/autograd/custom_function.cpp",
+    "torch/csrc/autograd/variable_info.cpp",
     "torch/csrc/autograd/engine.cpp",
     "torch/csrc/autograd/function.cpp",
     "torch/csrc/autograd/input_metadata.cpp",

--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -8,26 +8,6 @@
 namespace torch {
 namespace autograd {
 
-VariableInfo::VariableInfo(const Variable& var)
-    : layout(var.layout()),
-      device(var.device()),
-      scalar_type(var.scalar_type()),
-      size(var.sym_sizes().vec()),
-      requires_grad(var.requires_grad()),
-      is_empty(false) {}
-
-VariableInfo::VariableInfo() : requires_grad(false), is_empty(true) {}
-
-Variable VariableInfo::zeros(at::OptionalDeviceGuard& device_guard) const {
-  if (is_empty) {
-    // Return undefined tensor.
-    return at::Tensor();
-  } else {
-    return at::zeros_symint(
-        size, at::TensorOptions(scalar_type).device(device).layout(layout));
-  }
-}
-
 // This function has two main goals:
 //  1) Use the user-provided jvp function to populate the outputs' forward
 //  gradient 2) Perform error checking to ensure that view and inplace ops are

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -6,6 +6,7 @@
 #include <c10/util/irange.h>
 #include <torch/csrc/autograd/function.h>
 #include <torch/csrc/autograd/variable.h>
+#include <torch/csrc/autograd/variable_info.h>
 #include <vector>
 
 namespace torch::autograd {
@@ -155,20 +156,6 @@ struct TORCH_API AutogradContext {
 
   template <class T>
   friend struct CppNode;
-};
-
-struct TORCH_API VariableInfo {
-  explicit VariableInfo();
-  explicit VariableInfo(const Variable& var);
-
-  Variable zeros(at::OptionalDeviceGuard& device_guard) const;
-
-  at::Layout layout = at::Layout::Strided;
-  at::Device device = at::kCPU;
-  at::ScalarType scalar_type = at::kFloat;
-  std::vector<c10::SymInt> size;
-  bool requires_grad;
-  bool is_empty;
 };
 
 // CppNode<T> is the Node in the autograd graph that represents the user defined

--- a/torch/csrc/autograd/variable_info.cpp
+++ b/torch/csrc/autograd/variable_info.cpp
@@ -1,0 +1,29 @@
+#include <torch/csrc/autograd/variable_info.h>
+#include <torch/csrc/autograd/variable.h>
+#include "ATen/ops/zeros.h"
+
+namespace torch {
+namespace autograd {
+
+VariableInfo::VariableInfo(const Variable& var)
+    : layout(var.layout()),
+      device(var.device()),
+      scalar_type(var.scalar_type()),
+      size(var.sym_sizes().vec()),
+      requires_grad(var.requires_grad()),
+      is_empty(false) {}
+
+VariableInfo::VariableInfo() : requires_grad(false), is_empty(true) {}
+
+Variable VariableInfo::zeros(at::OptionalDeviceGuard& device_guard) const {
+  if (is_empty) {
+    // Return undefined tensor.
+    return at::Tensor();
+  } else {
+    return at::zeros_symint(
+        size, at::TensorOptions(scalar_type).device(device).layout(layout));
+  }
+}
+
+}
+}

--- a/torch/csrc/autograd/variable_info.h
+++ b/torch/csrc/autograd/variable_info.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <torch/csrc/autograd/variable.h>
+
+namespace torch::autograd {
+
+struct TORCH_API VariableInfo {
+  explicit VariableInfo();
+  explicit VariableInfo(const Variable& var);
+
+  Variable zeros(at::OptionalDeviceGuard& device_guard) const;
+
+  at::Layout layout = at::Layout::Strided;
+  at::Device device = at::kCPU;
+  at::ScalarType scalar_type = at::kFloat;
+  std::vector<c10::SymInt> size;
+  bool requires_grad;
+  bool is_empty;
+};
+
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #120681
* __->__ #120732

VariableInfo is used by both `custom_function.h` (in a templated class) and `compiled_autograd.h` (in a class with some templated methods). Another way could have been to make a `compiled_autograd.cpp` and forward declare VariableInfo, but this VariableInfo was also being used in other nodes like PyNode so it felt cleaner to do it this way.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng

Differential Revision: [D54287007](https://our.internmc.facebook.com/intern/diff/D54287007)