### PR TITLE
[PyTorch] fix mixed int32/int64 indices/offsets for embedding_bag_out

### DIFF
--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -1330,8 +1330,8 @@ void _embedding_bag_cpu_out(
     at::Tensor& bag_size,
     at::Tensor* p_max_indices,
     const at::Tensor& weight,
-    const at::Tensor& indices,
-    const at::Tensor& offsets,
+    const at::Tensor& indices_,
+    const at::Tensor& offsets_,
     const bool /* scale_grad_by_freq */,
     const int64_t mode,
     const bool /* sparse */,
@@ -1339,6 +1339,7 @@ void _embedding_bag_cpu_out(
     const bool include_last_offset,
     const c10::optional<int64_t>& padding_idx,
     _EmbeddingBagKernelCache* fbgemm_kernel_cache) {
+  auto [indices, offsets] = promoteIndicesAndOffsets(indices_, offsets_);
   at::native::check_arguments(
       weight, indices, offsets, mode, per_sample_weights, include_last_offset);
 

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -649,6 +649,19 @@ TEST(StaticRuntime, EmbeddingBagWithExtraneousOutput) {
   testStaticRuntime(embedding_bag_max_last_offset_ir, args, args2);
 }
 
+TEST(StaticRuntime, EmbeddingBagWithMixedInt32Int64Input) {
+  const std::string embedding_bag_default = R"JIT(
+    def forward(self, a: Tensor, b: Tensor, c: Tensor):
+        x, y, z, _ = torch.embedding_bag(a, b, c)
+        return (x.clone(), y.clone(), z.clone(), _.clone())
+  )JIT";
+  auto weight = torch::randn({3, 11}, at::ScalarType::Float);
+  auto input = torch::tensor({0, 1, 0, 2}, at::ScalarType::Long);
+  auto offset = torch::tensor({0, 2, 4}, at::ScalarType::Int);
+  std::vector<IValue> args{weight, input, offset};
+  testStaticRuntime(embedding_bag_default, args);
+}
+
 TEST(StaticRuntime, LayerNorm) {
   const std::string layer_norm_with_weights = R"JIT(
     def forward(self, input: Tensor, normalized_shape: List[int], weight: Tensor, bias: Tensor):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #120755
* __->__ #120752

This was an oversight in D27482738 (#55189) -- it only patched the regular embedding_bag operator, but static runtime uses the out variant.

Differential Revision: [D54285460](https://our.internmc.facebook.com/intern/diff/D54285460/)