### PR TITLE
[fbcode] Upstream parallel fast cat on cpu in OSS cat op

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -606,6 +606,37 @@ class TestTensorCreation(TestCase):
                 self.assertEqual(c.grad, expected_c_grad)
                 self.assertEqual(d.grad, expected_d_grad)
 
+    @onlyCPU
+    @dtypes(*all_types_and_complex())
+    def test_cat_out_fast_big_in_parallel(self, device, dtype):
+        # Set the size big enough
+        if dtype in integral_types():
+            y = torch.randint(low=0, high=100, size=(10, 1024 * 32), device=device, dtype=dtype)
+        else:
+            y = torch.randn((10, 1024 * 32), device=device, dtype=dtype)
+        # Test concat on dimension 0
+        w = y.clone()
+        a = torch.cat([w[:3].contiguous(), w[3:5].contiguous(), w[5:9].contiguous(), w[9:10].contiguous()])
+        self.assertEqual(a, w)
+        # Finally, we need to make sure backward is not broken
+        # Integral types will not have grad
+        if dtype not in integral_types():
+            a = torch.randn((4, 1024 * 32), device=device, dtype=dtype, requires_grad=True)
+            b = torch.randn((2, 1024 * 32), device=device, dtype=dtype, requires_grad=True)
+            expected_a_grad = torch.ones((4, 1024 * 32), device=device, dtype=dtype)
+            expected_b_grad = torch.ones((2, 1024 * 32), device=device, dtype=dtype)
+            # All the new tensors should be contiguous here. Let us make sure
+            # to explicitly set them contiguous to enforce fast cat
+            dim0_cat = torch.cat([a.contiguous(), b.contiguous()], dim=0)
+            if dtype in complex_types():
+                dim0_cat.sum().abs().backward()
+                self.assertEqual(a.grad.abs(), expected_a_grad.abs())
+                self.assertEqual(b.grad.abs(), expected_b_grad.abs())
+            else:
+                dim0_cat.sum().backward()
+                self.assertEqual(a.grad, expected_a_grad)
+                self.assertEqual(b.grad, expected_b_grad)
+
     def test_cat_out_channels_last(self, device):
         x = torch.randn((4, 3, 8, 8))
         y = torch.randn(x.shape)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120753

Summary:
Previous pull Request closed: https://github.com/pytorch/pytorch/pull/107442

The original implementation in D40433604 is not feasible to be directly upstreamed to OSS for two reasons:
- It is using folly executor, while I see all the intra-op parallelism in OSS repo is using torch parallel_for api (underlying is either native thread pool or simply OpenMP). I believe it is better to avoid additional dependencies there
- It requires some gflags directly specify a magic number of partitioning thresholds in terms of # of bytes. It is not clean

This diff is making use of the heuristic number (https://www.internalfb.com/code/fbsource/[297f89d5823451fe9f4b5985e6537e89a72bb75a]/fbcode/caffe2/aten/src/ATen/TensorIterator.h?lines=86) from PyTorch OSS repo to do a best effort partitioning based on element numbers with a rounding-up. It also uses torch parallel_for api for parallelism

Test Plan:

```
pytest -k test_cat_out test/test_tensor_creation_ops.py -v -s
...
(pytorch) [zhiyuanw@devvm6897.atn0 ~/local/pytorch (export-D48286816)]$ pytest -k test_cat_out test/test_tensor_creation_ops.py -v -s
===================================================================================== test session starts ======================================================================================
platform linux -- Python 3.9.18, pytest-7.4.0, pluggy-1.0.0 -- /home/zhiyuanw/local/miniconda3/envs/pytorch/bin/python
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase(PosixPath('/data/users/zhiyuanw/pytorch/.hypothesis/examples'))
rootdir: /data/users/zhiyuanw/pytorch
configfile: pytest.ini
plugins: hypothesis-6.98.12
collected 634 items / 610 deselected / 24 selected
Running 24 items in this shard

test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_channels_last_cpu PASSED [0.7288s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_cpu PASSED [0.0031s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_fast_big_in_parallel_cpu_complex128 PASSED [0.0722s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_fast_big_in_parallel_cpu_complex64 PASSED [0.0207s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_fast_big_in_parallel_cpu_float32 PASSED [0.0336s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_fast_big_in_parallel_cpu_float64 PASSED [0.0706s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_fast_big_in_parallel_cpu_int16 PASSED [0.0117s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_fast_big_in_parallel_cpu_int32 PASSED [0.0091s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_fast_big_in_parallel_cpu_int64 PASSED [0.0082s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_fast_big_in_parallel_cpu_int8 PASSED [0.0098s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_fast_big_in_parallel_cpu_uint8 PASSED [0.0092s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_fast_path_dim0_dim1_cpu_complex128 PASSED [0.0041s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_fast_path_dim0_dim1_cpu_complex64 PASSED [0.0036s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_fast_path_dim0_dim1_cpu_float32 PASSED [0.0043s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_fast_path_dim0_dim1_cpu_float64 PASSED [0.0030s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_fast_path_dim0_dim1_cpu_int16 PASSED [0.0015s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_fast_path_dim0_dim1_cpu_int32 PASSED [0.0015s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_fast_path_dim0_dim1_cpu_int64 PASSED [0.0015s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_fast_path_dim0_dim1_cpu_int8 PASSED [0.0015s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_fast_path_dim0_dim1_cpu_uint16 PASSED [0.0015s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_fast_path_dim0_dim1_cpu_uint32 PASSED [0.0016s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_fast_path_dim0_dim1_cpu_uint64 PASSED [0.0017s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_fast_path_dim0_dim1_cpu_uint8 PASSED [0.0017s]
test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_cat_out_memory_format_cpu SKIPPED [0.0009s] (Only runs on cuda)

======================================================================== 23 passed, 1 skipped, 610 deselected in 3.03s =========================================================================
```