### PR TITLE
[PyTorch Use MaybeOwned when promoting indices/offsets in embedding_bag

### DIFF
--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -70,16 +70,16 @@ static void make_offset2bag(const Tensor &offsets, Tensor& offset2bag) {
 
 namespace {
 
-std::pair<Tensor, Tensor> promoteIndicesAndOffsets(
+std::pair<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>> promoteIndicesAndOffsets(
     const Tensor& indices,
     const Tensor& offsets) {
   const auto commonType =
       promoteTypes(offsets.scalar_type(), indices.scalar_type());
   return {
-      indices.scalar_type() == commonType ? indices
-                                          : indices.toType(commonType),
-      offsets.scalar_type() == commonType ? offsets
-                                          : offsets.toType(commonType)};
+      indices.scalar_type() == commonType ? c10::MaybeOwned<Tensor>::borrowed(indices)
+                                          : c10::MaybeOwned<Tensor>::owned(indices.toType(commonType)),
+      offsets.scalar_type() == commonType ? c10::MaybeOwned<Tensor>::borrowed(offsets)
+                                          : c10::MaybeOwned<Tensor>::owned(offsets.toType(commonType))};
 }
 
 // Determines if we can use a fast implementation for index_select_add, which
@@ -1210,7 +1210,9 @@ static std::tuple<Tensor, Tensor, Tensor, Tensor> _embedding_bag_cpu_impl(
   TORCH_CHECK(weight.dim() == 2,
       "weight has to be a 2D Tensor, but got Tensor of dimension ",
       weight.dim());
-  auto [indices, offsets] = promoteIndicesAndOffsets(indices_, offsets_);
+  auto [indicesMaybeOwned, offsetsMaybeOwned] = promoteIndicesAndOffsets(indices_, offsets_);
+  const auto& indices = *indicesMaybeOwned;
+  const auto& offsets = *offsetsMaybeOwned;
   check_arguments(weight, indices, offsets, mode, per_sample_weights, include_last_offset);
 
   Tensor output = at::empty(
@@ -1339,7 +1341,9 @@ void _embedding_bag_cpu_out(
     const bool include_last_offset,
     const c10::optional<int64_t>& padding_idx,
     _EmbeddingBagKernelCache* fbgemm_kernel_cache) {
-  auto [indices, offsets] = promoteIndicesAndOffsets(indices_, offsets_);
+  auto [indicesMaybeOwned, offsetsMaybeOwned] = promoteIndicesAndOffsets(indices_, offsets_);
+  const auto& indices = *indicesMaybeOwned;
+  const auto& offsets = *offsetsMaybeOwned;
   at::native::check_arguments(
       weight, indices, offsets, mode, per_sample_weights, include_last_offset);
 
@@ -1410,7 +1414,9 @@ Tensor _embedding_bag_backward_symint(const Tensor &grad, const Tensor &indices_
   c10::MaybeOwned<Tensor> per_sample_weights_maybe_owned = at::borrow_from_optional_tensor(per_sample_weights_opt);
   const Tensor& per_sample_weights = *per_sample_weights_maybe_owned;
 
-  auto [indices, offsets] = promoteIndicesAndOffsets(indices_, offsets_);
+  auto [indicesMaybeOwned, offsetsMaybeOwned] = promoteIndicesAndOffsets(indices_, offsets_);
+  const auto& indices = *indicesMaybeOwned;
+  const auto& offsets = *offsetsMaybeOwned;
   auto indices_arg = TensorArg(indices, "indices", 1);
   checkScalarTypes("embedding_bag", indices_arg, {kLong, kInt});
   checkContiguous("embedding_bag", indices_arg);
@@ -1665,8 +1671,10 @@ Tensor _embedding_bag_per_sample_weights_backward_cpu_template(
   AT_ASSERT(grad.dim() == 2);
   auto embedding_features = grad.sizes()[1];
 
-  Tensor indices, offsets;
-  std::tie(indices, offsets) = promoteIndicesAndOffsets(indices_, offsets_);
+  auto [indicesMaybeOwned, offsetsMaybeOwned] = promoteIndicesAndOffsets(indices_, offsets_);
+  const auto& indices = *indicesMaybeOwned;
+  const auto& offsets = *offsetsMaybeOwned;
+
   AT_ASSERT(indices.dim() == 1);
   auto num_samples = indices.size(0);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120755
* #120752

We're currently doing two unnecessary reference count
operations in the case where promotion doesn't need to happen.

Differential Revision: [D54285999](https://our.internmc.facebook.com/intern/diff/D54285999/)