### PR TITLE
Add TORCH_LOGS_FORMAT=short alias

### DIFF
--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -761,6 +761,8 @@ def _default_formatter():
     if fmt is None:
         return TorchLogsFormatter()
     else:
+        if fmt in ("short", "basic"):
+            fmt = logging.BASIC_FORMAT
         return logging.Formatter(fmt)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120757

Shorthand for `"%(levelname)s:%(name)s:%(message)s"` which is hard to
remember.

I find the default formatter annoying since just the metadata fills up
most of the width of my terminal.