### PR TITLE
[Clang-tidy header][21/N] Fix clang-tidy warnings in aten/src/ATEN/*.{cpp,h}

### DIFF
--- a/aten/src/ATen/CPUApplyUtils.h
+++ b/aten/src/ATen/CPUApplyUtils.h
@@ -6,7 +6,6 @@
 #include <c10/util/irange.h>
 #include <cstring>
 #include <limits>
-#include <utility>
 
 namespace at {
 

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -24,7 +24,6 @@
 #include <c10/util/irange.h>
 
 #include <cstdint>
-#include <memory>
 #include <mutex>
 
 namespace at {

--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -305,7 +305,7 @@ Tensor fromDLPack(const DLManagedTensor* src) {
 
 Tensor fromDLPack(
     const DLManagedTensor* src,
-    std::function<void(void*)> deleter) {
+    const std::function<void(void*)>& deleter) {
   Device device = getATenDevice(src->dl_tensor.device, src->dl_tensor.data);
   ScalarType stype = toScalarType(src->dl_tensor.dtype);
   if (!src->dl_tensor.strides) {

--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -305,7 +305,7 @@ Tensor fromDLPack(const DLManagedTensor* src) {
 
 Tensor fromDLPack(
     const DLManagedTensor* src,
-    const std::function<void(void*)>& deleter) {
+    std::function<void(void*)> deleter) {
   Device device = getATenDevice(src->dl_tensor.device, src->dl_tensor.data);
   ScalarType stype = toScalarType(src->dl_tensor.dtype);
   if (!src->dl_tensor.strides) {

--- a/aten/src/ATen/DLConvertor.h
+++ b/aten/src/ATen/DLConvertor.h
@@ -13,8 +13,9 @@ namespace at {
 TORCH_API ScalarType toScalarType(const DLDataType& dtype);
 TORCH_API DLManagedTensor* toDLPack(const Tensor& src);
 TORCH_API Tensor fromDLPack(const DLManagedTensor* src);
-TORCH_API Tensor
-fromDLPack(const DLManagedTensor* src, std::function<void(void*)> deleter);
+TORCH_API Tensor fromDLPack(
+    const DLManagedTensor* src,
+    const std::function<void(void*)>& deleter);
 TORCH_API DLDataType getDLDataType(const Tensor& t);
 TORCH_API DLDevice getDLContext(const Tensor& tensor, const int64_t& device_id);
 

--- a/aten/src/ATen/DLConvertor.h
+++ b/aten/src/ATen/DLConvertor.h
@@ -13,9 +13,8 @@ namespace at {
 TORCH_API ScalarType toScalarType(const DLDataType& dtype);
 TORCH_API DLManagedTensor* toDLPack(const Tensor& src);
 TORCH_API Tensor fromDLPack(const DLManagedTensor* src);
-TORCH_API Tensor fromDLPack(
-    const DLManagedTensor* src,
-    const std::function<void(void*)>& deleter);
+TORCH_API Tensor
+fromDLPack(const DLManagedTensor* src, std::function<void(void*)> deleter);
 TORCH_API DLDataType getDLDataType(const Tensor& t);
 TORCH_API DLDevice getDLContext(const Tensor& tensor, const int64_t& device_id);
 

--- a/aten/src/ATen/FunctionalStorageImpl.h
+++ b/aten/src/ATen/FunctionalStorageImpl.h
@@ -79,7 +79,9 @@ struct ViewMeta {
 struct TORCH_API FunctionalStorageImpl : public c10::StorageImpl {
  public:
   struct Update {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
     const at::Tensor new_val;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
     const std::vector<ViewMeta> view_metas;
   };
 

--- a/aten/src/ATen/FunctionalizeFallbackKernel.cpp
+++ b/aten/src/ATen/FunctionalizeFallbackKernel.cpp
@@ -168,7 +168,7 @@ static const at::Tensor & resize__functionalization(c10::DispatchKeySet dispatch
       return base.as_strided_scatter(mutated_view, size, c10::contiguous_strides(size));
     }
   );
-  at::functionalization::impl::mutate_view_meta(self, std::move(view_meta));
+  at::functionalization::impl::mutate_view_meta(self, view_meta);
   return self;
 }
 

--- a/aten/src/ATen/LegacyBatchedTensorImpl.h
+++ b/aten/src/ATen/LegacyBatchedTensorImpl.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <bitset>
-#include <utility>
 
 #include <ATen/ArrayRef.h>
 #include <ATen/SmallVector.h>

--- a/aten/src/ATen/LegacyVmapTransforms.h
+++ b/aten/src/ATen/LegacyVmapTransforms.h
@@ -113,7 +113,7 @@ struct VmapPhysicalToLogicalMap;
 //   levels: 012345
 struct TORCH_API VmapPhysicalView {
   VmapPhysicalView(Tensor&& tensor, std::bitset<kVmapNumLevels> levels)
-      : levels_(levels), tensor_(tensor) {
+      : levels_(levels), tensor_(std::move(tensor)) {
     TORCH_INTERNAL_ASSERT(!isBatchedTensor(tensor));
   }
 

--- a/aten/src/ATen/LegacyVmapTransforms.h
+++ b/aten/src/ATen/LegacyVmapTransforms.h
@@ -114,7 +114,7 @@ struct VmapPhysicalToLogicalMap;
 struct TORCH_API VmapPhysicalView {
   VmapPhysicalView(Tensor&& tensor, std::bitset<kVmapNumLevels> levels)
       : levels_(levels), tensor_(std::move(tensor)) {
-    TORCH_INTERNAL_ASSERT(!isBatchedTensor(tensor));
+    TORCH_INTERNAL_ASSERT(!isBatchedTensor(tensor_));
   }
 
   Tensor& tensor() {

--- a/aten/src/ATen/MapAllocator.cpp
+++ b/aten/src/ATen/MapAllocator.cpp
@@ -250,11 +250,13 @@ MapAllocator::MapAllocator(WithFd, c10::string_view filename, int fd, int flags,
 
     if (!(flags_ & ALLOCATOR_MAPPED_FROMFD)) {
       if (flags_ & ALLOCATOR_MAPPED_SHARED) {
+        // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
         if ((fd = open(filename_.c_str(), flags, (mode_t)0600)) == -1) {
           TORCH_CHECK(false, "unable to open file <", filename_, "> in read-write mode: ", strerror(errno), " (", errno, ")");
         }
       } else if (flags_ & ALLOCATOR_MAPPED_SHAREDMEM) {
 #ifdef HAVE_SHM_OPEN
+        // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
         if((fd = shm_open(filename_.c_str(), flags, (mode_t)0600)) == -1) {
           TORCH_CHECK(false, "unable to open shared memory object <", filename_, "> in read-write mode: ", strerror(errno), " (", errno, ")");
         }
@@ -262,6 +264,7 @@ MapAllocator::MapAllocator(WithFd, c10::string_view filename, int fd, int flags,
         TORCH_CHECK(false, "unable to open file <", filename_, "> in sharedmem mode, shm_open unavailable on this platform");
 #endif
       } else {
+        // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
         if ((fd = open(filename_.c_str(), O_RDONLY)) == -1) {
           TORCH_CHECK(false, "unable to open file <", filename_, "> in read-only mode: ", strerror(errno), " (", errno, ")");
         }
@@ -282,7 +285,7 @@ MapAllocator::MapAllocator(WithFd, c10::string_view filename, int fd, int flags,
     if (size > 0) {
       if (static_cast<int64_t>(size) > file_stat.st_size) {
         if (flags_) {
-          if (ftruncate(fd, size) == -1) {
+          if (ftruncate(fd, static_cast<off_t>(size)) == -1) {
             TORCH_CHECK(false, "unable to resize file <", filename_, "> to the right size: ", strerror(errno), " (", errno, ")");
           }
           if (fstat(fd, &file_stat) == -1 || file_stat.st_size < static_cast<int64_t>(size)) {
@@ -309,7 +312,7 @@ MapAllocator::MapAllocator(WithFd, c10::string_view filename, int fd, int flags,
       size = file_stat.st_size;
     }
 
-    size_ = size; /* if we are here, it must be the right size */
+    size_ = static_cast<ptrdiff_t>(size); /* if we are here, it must be the right size */
 
     /* map it */
     if (flags_ & (ALLOCATOR_MAPPED_SHARED | ALLOCATOR_MAPPED_SHAREDMEM)) {
@@ -325,7 +328,7 @@ MapAllocator::MapAllocator(WithFd, c10::string_view filename, int fd, int flags,
 
 #if !defined(__APPLE__) && !defined(__ANDROID__)
     /* attempt to use larger block size on Linux, which is important for getting better CUDA upload speed */
-    posix_fadvise(fd, 0, size, POSIX_FADV_SEQUENTIAL);
+    posix_fadvise(fd, 0, static_cast<off_t>(size), POSIX_FADV_SEQUENTIAL);
 #endif
 
     if (flags_ & ALLOCATOR_MAPPED_KEEPFD) {
@@ -604,7 +607,6 @@ void* RefcountedMapAllocator::data() const {
 }
 
 MapAllocator::~MapAllocator() {
-  // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
   close();
   c10::reportMemoryUsageToProfiler(base_ptr_, -size_, 0, 0, c10::Device(c10::DeviceType::CPU));
 }

--- a/aten/src/ATen/NamedTensorUtils.cpp
+++ b/aten/src/ATen/NamedTensorUtils.cpp
@@ -297,7 +297,7 @@ static int64_t num_batch_dims(DimnameList names) {
   if (names.size() <= 2) {
     return 0;
   }
-  return names.size() - 2;
+  return static_cast<int64_t>(names.size() - 2);
 }
 
 static std::vector<Dimname> compute_matmul_outnames(

--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -155,7 +155,7 @@ inline at::Tensor construct_offsets(const at::Tensor& sizes) {
   const int64_t* sizes_ptr = sizes.data_ptr<int64_t>();
   offsets_ptr[0] = 0;
   for (const auto i : c10::irange(ntensors - 1)) {
-    const int64_t row_product = std::accumulate(sizes_ptr, sizes_ptr + orig_dim, 1, std::multiplies<int64_t>());
+    const int64_t row_product = std::accumulate(sizes_ptr, sizes_ptr + orig_dim, 1, std::multiplies());
     offsets_ptr[i + 1] = offsets_ptr[i] + row_product;
     sizes_ptr += orig_dim;
   }

--- a/aten/src/ATen/ParallelCommon.cpp
+++ b/aten/src/ATen/ParallelCommon.cpp
@@ -107,7 +107,7 @@ int intraop_default_num_threads() {
     nthreads = TaskThreadPoolBase::defaultNumThreads();
 #endif
   }
-  return nthreads;
+  return static_cast<int>(nthreads);
 #endif
 }
 

--- a/aten/src/ATen/SparseCsrTensorImpl.h
+++ b/aten/src/ATen/SparseCsrTensorImpl.h
@@ -141,7 +141,7 @@ struct TORCH_API SparseCsrTensorImpl : public TensorImpl {
     copy_tensor_metadata(
         /*src_sparse_impl=*/this,
         /*dest_sparse_impl=*/impl.get(),
-        /*version_counter=*/version_counter,
+        /*version_counter=*/std::move(version_counter),
         /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
     impl->refresh_numel();
     return impl;
@@ -168,12 +168,12 @@ struct TORCH_API SparseCsrTensorImpl : public TensorImpl {
   static void copy_tensor_metadata(
       const SparseCsrTensorImpl* src_sparse_impl,
       SparseCsrTensorImpl* dest_sparse_impl,
-      const c10::VariableVersion& version_counter,
+      c10::VariableVersion version_counter,
       bool allow_tensor_metadata_change) {
     TensorImpl::copy_tensor_metadata(
         src_sparse_impl,
         dest_sparse_impl,
-        version_counter,
+        std::move(version_counter),
         allow_tensor_metadata_change);
 
     // Sparse-specific fields

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -317,8 +317,8 @@ struct TORCH_API SparseTensorImpl : public TensorImpl {
       bool allow_tensor_metadata_change) const override {
     auto impl = c10::make_intrusive<SparseTensorImpl>(key_set(), dtype());
     copy_tensor_metadata(
-        /*src_impl=*/this,
-        /*dest_impl=*/impl.get(),
+        /*src_sparse_impl=*/this,
+        /*dest_sparse_impl=*/impl.get(),
         /*version_counter=*/version_counter,
         /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
     impl->refresh_numel();
@@ -336,9 +336,9 @@ struct TORCH_API SparseTensorImpl : public TensorImpl {
       bool allow_tensor_metadata_change) const override {
     auto impl = c10::make_intrusive<SparseTensorImpl>(key_set(), dtype());
     copy_tensor_metadata(
-        /*src_impl=*/this,
-        /*dest_impl=*/impl.get(),
-        /*version_counter=*/version_counter,
+        /*src_sparse_impl=*/this,
+        /*dest_sparse_impl=*/impl.get(),
+        /*version_counter=*/std::move(version_counter),
         /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
     impl->refresh_numel();
     return impl;
@@ -354,8 +354,8 @@ struct TORCH_API SparseTensorImpl : public TensorImpl {
     AT_ASSERT(has_compatible_shallow_copy_type(impl->key_set()));
     auto sparse_impl = static_cast<const SparseTensorImpl*>(impl.get());
     copy_tensor_metadata(
-        /*src_impl=*/sparse_impl,
-        /*dest_impl=*/this,
+        /*src_sparse_impl=*/sparse_impl,
+        /*dest_sparse_impl=*/this,
         /*version_counter=*/version_counter(),
         /*allow_tensor_metadata_change=*/allow_tensor_metadata_change());
     refresh_numel();
@@ -378,12 +378,12 @@ struct TORCH_API SparseTensorImpl : public TensorImpl {
   static void copy_tensor_metadata(
       const SparseTensorImpl* src_sparse_impl,
       SparseTensorImpl* dest_sparse_impl,
-      const c10::VariableVersion& version_counter,
+      c10::VariableVersion version_counter,
       bool allow_tensor_metadata_change) {
     TensorImpl::copy_tensor_metadata(
         src_sparse_impl,
         dest_sparse_impl,
-        version_counter,
+        std::move(version_counter),
         allow_tensor_metadata_change);
 
     // Sparse-specific fields

--- a/aten/src/ATen/TensorGeometry.h
+++ b/aten/src/ATen/TensorGeometry.h
@@ -20,7 +20,7 @@ struct TORCH_API TensorGeometry {
         strides_(sizes.size()),
         has_symbolic_sizes_strides_(
             !c10::asIntArrayRefSlowOpt(sizes).has_value()) {
-    int64_t dim = sizes.size();
+    int64_t dim = static_cast<int64_t>(sizes.size());
     c10::SymInt expected_stride = 1;
     for (int64_t i = dim - 1; i >= 0; i--) {
       strides_[i] = expected_stride;
@@ -41,7 +41,7 @@ struct TORCH_API TensorGeometry {
   bool is_contiguous() const;
 
   int64_t dim() const {
-    return sizes_.size();
+    return static_cast<int64_t>(sizes_.size());
   }
 
   int64_t size(int64_t dim) const {

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -24,8 +24,8 @@
 
 namespace at::indexing {
 
-const int64_t INDEX_MIN = c10::SymInt::min_representable_int();
-const int64_t INDEX_MAX = -(INDEX_MIN + 1);
+constexpr int64_t INDEX_MIN = c10::SymInt::min_representable_int();
+constexpr int64_t INDEX_MAX = -(INDEX_MIN + 1);
 
 enum class TensorIndexType { None, Ellipsis, SymInt, Boolean, Slice, Tensor };
 
@@ -322,7 +322,7 @@ static inline c10::List<c10::optional<Tensor>> typeConvertIndices(
     std::vector<Tensor>&& indices) {
   c10::List<c10::optional<Tensor>> converted_inds;
   converted_inds.reserve(indices.size());
-  for (const auto& i : indices) {
+  for (auto& i : std::move(indices)) {
     converted_inds.push_back(std::move(i));
   }
   return converted_inds;
@@ -538,9 +538,9 @@ static inline Tensor applySlicing(
         /*prev_dim_result=*/result,
         /*original_tensor=*/self,
         /*index=*/obj,
-        /*dim=*/&dim,
+        /*dim_ptr=*/&dim,
         /*specified_dims_ptr=*/&specified_dims,
-        /*real_dim=*/i,
+        /*real_dim=*/static_cast<int64_t>(i),
         /*outIndices=*/outIndices,
         /*disable_slice_optimization=*/disable_slice_optimization,
         /*original_tensor_device=*/self_device,

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -322,7 +322,7 @@ static inline c10::List<c10::optional<Tensor>> typeConvertIndices(
     std::vector<Tensor>&& indices) {
   c10::List<c10::optional<Tensor>> converted_inds;
   converted_inds.reserve(indices.size());
-  for (auto& i : std::move(indices)) {
+  for (auto&& i : std::move(indices)) {
     converted_inds.push_back(std::move(i));
   }
   return converted_inds;

--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -52,7 +52,7 @@ inline void get_strides(int64_t* strides, ArrayRef<OperandInfo> operands, int64_
   }
   // Always at least 2d strides to support 2d for_each loops
   if (ndim < 2) {
-    const int64_t ntensors = operands.size();
+    auto ntensors = operands.size();
     std::fill_n(strides, (2 - ndim) * ntensors, 0);
   }
 }
@@ -92,7 +92,7 @@ void OperandInfo::tensor(c10::MaybeOwned<TensorBase> &&tensor) {
 
 void OperandInfo::exchange_tensor(c10::MaybeOwned<TensorBase> &&new_tensor) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!original_tensor_base_->defined());
-  original_tensor_base_ = std::exchange(tensor_base_, new_tensor);
+  original_tensor_base_ = std::exchange(tensor_base_, std::move(new_tensor));
   *original_tensor_storage_ = std::exchange(*tensor_storage_, make_otr(*tensor_base_));
 }
 
@@ -549,7 +549,7 @@ void TensorIteratorBase::compute_types(const TensorIteratorConfig& config) {
   }
 }
 
-StrideVector TensorIteratorBase::compatible_stride(int element_size) const {
+StrideVector TensorIteratorBase::compatible_stride(int64_t element_size) const {
   auto stride = StrideVector();
   int64_t next_stride = element_size;
   for (const auto dim : c10::irange(ndim())) {
@@ -576,8 +576,8 @@ void TensorIteratorBase::allocate_or_resize_outputs() {
     auto& op = operands_[i];
     if (!op.tensor_base().defined() || op.will_resize) {
       TORCH_INTERNAL_ASSERT(op.is_type_defined(), "no type for operand", i);
-      int element_size = elementSize(op.target_dtype);
-      op.stride_bytes = compatible_stride(element_size);
+      auto element_size = elementSize(op.target_dtype);
+      op.stride_bytes = compatible_stride(static_cast<int64_t>(element_size));
       // check if permutation is just an inverted order
       bool inverted = true;
       for (const auto j : c10::irange(ndim())) {
@@ -595,7 +595,7 @@ void TensorIteratorBase::allocate_or_resize_outputs() {
       } else {
         auto tensor_stride = invert_perm(op.stride_bytes);
         for (const auto dim : c10::irange(ndim())) {
-          tensor_stride[dim] /= element_size;
+          tensor_stride[dim] /= static_cast<int64_t>(element_size);
         }
         set_output_raw_strided(i, tensor_shape, tensor_stride, original_options(op), names_);
       }
@@ -775,7 +775,7 @@ void TensorIteratorBase::for_each(loop2d_t loop, int64_t grain_size) {
 
 StrideVector TensorIteratorBase::get_strides() const {
   const auto dim = ndim();
-  StrideVector strides(std::max(dim, 2) * ntensors());
+  StrideVector strides(static_cast<size_t>(std::max(dim, 2)) * ntensors());
   at::get_strides(strides.data(), operands_, dim);
   return strides;
 }
@@ -789,7 +789,7 @@ void TensorIteratorBase::serial_for_each(loop2d_t loop, Range range) const {
   const auto ndim = this->ndim();
 
   c10::SmallBuffer<char*, 4> ptrs(ntensors);
-  c10::SmallBuffer<int64_t, 8> strides(ntensors * std::max(ndim, 2));
+  c10::SmallBuffer<int64_t, 8> strides(ntensors * static_cast<size_t>(std::max(ndim, 2)));
 
   at::get_base_ptrs(ptrs.data(), operands_);
   at::get_strides(strides.data(), operands_, ndim);
@@ -1539,6 +1539,7 @@ void TensorIteratorBase::build(TensorIteratorConfig& config) {
   for (auto& op : operands_) {
     TORCH_INTERNAL_ASSERT(op.tensor_base().defined());
     if (op.is_const) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
       op.data = const_cast<void*>(op.tensor_base().const_data_ptr());
     } else {
       op.data = op.tensor_base().mutable_data_ptr();
@@ -1678,7 +1679,7 @@ SplitUntil32Bit::iterator& SplitUntil32Bit::iterator::operator++() {
   vec.pop_back();
   while (!vec.empty() && !vec.back()->can_use_32bit_indexing()) {
     auto& iter = *vec.back();
-    int64_t split_dim = iter.get_dim_to_split();
+    auto split_dim = iter.get_dim_to_split();
     vec.emplace_back(iter.split(split_dim));
   }
   return *this;
@@ -1707,7 +1708,7 @@ DimCounter::DimCounter(IntArrayRef shape, Range range)
   }
 
   int64_t linear_offset = range.begin;
-  int64_t ndim = values.size();
+  auto ndim = values.size();
   for (const auto dim : c10::irange(ndim)) {
     int64_t size = shape[dim];
     if (size > 0) {
@@ -1724,9 +1725,9 @@ bool DimCounter::is_done() const {
 
 void DimCounter::increment(const std::array<int64_t, 2>& step) {
   offset += step[0] * step[1];
-  int64_t ndim = values.size();
+  auto ndim = values.size();
   int64_t overflow = step[0];
-  int i = 0;
+  size_t i = 0;
   if (step[1] != 1) {
     TORCH_INTERNAL_ASSERT(step[0] == shape[0] && values[0] == 0);
     i = 1;
@@ -1743,7 +1744,7 @@ void DimCounter::increment(const std::array<int64_t, 2>& step) {
     } else {
       overflow = 0;
     }
-    values[i] = value;
+    values[i] = static_cast<int64_t>(value);
   }
   TORCH_INTERNAL_ASSERT(overflow == 0 || overflow == 1);
 }

--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -446,7 +446,7 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
   /// Create a strides array for a Tensor with shape of this iterator. The
   /// parameter `element_size` specifies the size of Tensor's data type in
   /// bytes (e.g. `4` for `float`)
-  StrideVector compatible_stride(int element_size) const;
+  StrideVector compatible_stride(int64_t element_size) const;
 
   /// Inverts the re-ordering done by reorder_dimensions. This can only be
   /// called *before* coalesce_dimensions() is called.
@@ -960,7 +960,7 @@ class TORCH_API TensorIteratorConfig final {
   bool promote_integer_inputs_to_float_ = false;
   bool cast_common_dtype_to_outputs_ = false;
 
-  SmallVector<int, 4> const_tensor_indices_;
+  SmallVector<size_t, 4> const_tensor_indices_;
 };
 
 /// A container-like struct that acts as if it contains splits of a
@@ -995,6 +995,7 @@ struct TORCH_API SplitUntil32Bit {
   iterator end() const;
 
  private:
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const TensorIteratorBase& iter;
 };
 

--- a/aten/src/ATen/TensorIteratorInternal.h
+++ b/aten/src/ATen/TensorIteratorInternal.h
@@ -25,8 +25,8 @@ inline void get_data_ptrs(
     ArrayRef<char*> base,
     IntArrayRef strides,
     IntArrayRef counter) {
-  const int64_t ntensors = base.size();
-  const int64_t ndim = counter.size();
+  const auto ntensors = base.size();
+  const auto ndim = counter.size();
   std::copy(base.begin(), base.end(), ptrs);
   for (const auto dim : c10::irange(ndim)) {
     int64_t value = counter[dim];

--- a/aten/src/ATen/TensorNames.cpp
+++ b/aten/src/ATen/TensorNames.cpp
@@ -53,8 +53,9 @@ TensorNames::TensorNames(ArrayRef<Dimname> names) {
 }
 
 TensorNames::TensorNames(ArrayRef<Dimname> names, int64_t start, int64_t end) {
-  start = maybe_wrap_dim(start, names.size());
-  end = maybe_wrap_dim(end, names.size());
+  int64_t names_size = static_cast<int64_t>(names.size());
+  start = maybe_wrap_dim(start, names_size);
+  end = maybe_wrap_dim(end, names_size);
   names_.reserve(end - start);
   for (const auto idx : c10::irange(start, end)) {
     names_.emplace_back(names, idx);
@@ -83,7 +84,7 @@ TensorNames& TensorNames::unifyFromRightInplace(const TensorNames& other, const 
   return *this;
 }
 
-void TensorNames::append(TensorName&& name) {
+void TensorNames::append(TensorName name) {
   names_.emplace_back(name);
 }
 

--- a/aten/src/ATen/TensorNames.h
+++ b/aten/src/ATen/TensorNames.h
@@ -63,11 +63,11 @@ struct TORCH_API TensorNames {
       const char* op_name = "unify");
   void checkUnique(const char* op_name) const;
 
-  void append(TensorName&& name);
+  void append(TensorName name);
   std::vector<Dimname> toDimnameVec() const;
 
  private:
-  explicit TensorNames(TensorNameVec&& names) : names_(names){};
+  explicit TensorNames(TensorNameVec&& names) : names_(std::move(names)){};
 
   TensorNameVec names_;
 };

--- a/aten/src/ATen/TensorUtils.h
+++ b/aten/src/ATen/TensorUtils.h
@@ -20,12 +20,14 @@ namespace at {
 // which do NO argument checking by default.
 
 struct TORCH_API TensorArg {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const Tensor& tensor;
   const char* name;
   int pos; // 1-indexed
   TensorArg(const Tensor& tensor, const char* name, int pos)
       : tensor(tensor), name(name), pos(pos) {}
   // Try to mitigate any possibility of dangling reference to temporaries.
+  // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
   TensorArg(Tensor&& tensor, const char* name, int pos) = delete;
   const Tensor* operator->() const {
     return &tensor;

--- a/c10/util/SmallBuffer.h
+++ b/c10/util/SmallBuffer.h
@@ -55,11 +55,10 @@ class SmallBuffer {
       delete[] data_;
     }
   }
-
-  T& operator[](int64_t idx) {
+  T& operator[](size_t idx) {
     return data()[idx];
   }
-  const T& operator[](int64_t idx) const {
+  const T& operator[](size_t idx) const {
     return data()[idx];
   }
   T* data() {


### PR DESCRIPTION
This PR continues to fix clang-tidy warnings in aten/src/ATEN/*, following #120574.