### PR TITLE
[torch.compile] Provide capability to register callback on compile start/stop

### DIFF
--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -1,6 +1,7 @@
 import torch
 from . import convert_frame, eval_frame, resume_execution
 from .backends.registry import list_backends, lookup_backend, register_backend
+from .callback import callback_handler, on_compile_end, on_compile_start
 from .code_context import code_context
 from .convert_frame import replay
 from .decorators import (
@@ -80,6 +81,7 @@ def reset() -> None:
         torch._C._dynamo.compiled_autograd.clear_cache()
         convert_frame.FRAME_COUNTER = 0
         convert_frame.FRAME_COMPILE_COUNTER.clear()
+        callback_handler.clear()
 
 
 def reset_code_caches() -> None:

--- a/torch/_dynamo/callback.py
+++ b/torch/_dynamo/callback.py
@@ -5,7 +5,7 @@ class CompilationCallbackHandler:
 
     def register_start_callback(self, callback):
         """
-        Register a callback function to be called when the compilation process starts.
+        Register a callback function to be called when the compilation starts.
 
         Args:
         - callback (callable): The callback function to register.
@@ -15,7 +15,7 @@ class CompilationCallbackHandler:
 
     def register_end_callback(self, callback):
         """
-        Register a callback function to be called when the compilation process ends.
+        Register a callback function to be called when the compilation ends.
 
         Args:
         - callback (callable): The callback function to register.
@@ -68,7 +68,7 @@ callback_handler = CompilationCallbackHandler()
 
 def on_compile_start(callback):
     """
-    Decorator to register a callback function for the start of the compilation process.
+    Decorator to register a callback function for the start of the compilation.
     """
     callback_handler.register_start_callback(callback)
     return callback
@@ -76,7 +76,7 @@ def on_compile_start(callback):
 
 def on_compile_end(callback):
     """
-    Decorator to register a callback function for the end of the compilation process.
+    Decorator to register a callback function for the end of the compilation.
     """
     callback_handler.register_end_callback(callback)
     return callback

--- a/torch/_dynamo/callback.py
+++ b/torch/_dynamo/callback.py
@@ -1,0 +1,82 @@
+class CompilationCallbackHandler:
+    def __init__(self):
+        self.start_callbacks = []
+        self.end_callbacks = []
+
+    def register_start_callback(self, callback):
+        """
+        Register a callback function to be called when the compilation process starts.
+
+        Args:
+        - callback (callable): The callback function to register.
+        """
+        self.start_callbacks.append(callback)
+        return callback
+
+    def register_end_callback(self, callback):
+        """
+        Register a callback function to be called when the compilation process ends.
+
+        Args:
+        - callback (callable): The callback function to register.
+        """
+        self.end_callbacks.append(callback)
+        return callback
+
+    def remove_start_callback(self, callback):
+        """
+        Remove a registered start callback function.
+
+        Args:
+        - callback (callable): The callback function to remove.
+        """
+        self.start_callbacks.remove(callback)
+
+    def remove_end_callback(self, callback):
+        """
+        Remove a registered end callback function.
+
+        Args:
+        - callback (callable): The callback function to remove.
+        """
+        self.end_callbacks.remove(callback)
+
+    def run_start_callbacks(self):
+        """
+        Execute all registered start callbacks.
+        """
+        for callback in self.start_callbacks:
+            callback()
+
+    def run_end_callbacks(self):
+        """
+        Execute all registered end callbacks.
+        """
+        for callback in self.end_callbacks:
+            callback()
+
+    def clear(self):
+        """
+        Clear all registered callbacks.
+        """
+        self.start_callbacks.clear()
+        self.end_callbacks.clear()
+
+
+callback_handler = CompilationCallbackHandler()
+
+
+def on_compile_start(callback):
+    """
+    Decorator to register a callback function for the start of the compilation process.
+    """
+    callback_handler.register_start_callback(callback)
+    return callback
+
+
+def on_compile_end(callback):
+    """
+    Decorator to register a callback function for the end of the compilation process.
+    """
+    callback_handler.register_end_callback(callback)
+    return callback

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -472,6 +472,7 @@ def _compile(
     # This is shared across restarts
     mutated_closure_cell_contents: Set[str] = set()
     speculation_log = SpeculationLog()
+    torch._dynamo.callback_handler.run_start_callbacks()
 
     @preserve_global_state
     def transform(instructions, code_options):
@@ -770,6 +771,7 @@ def _compile(
                 compliant_custom_ops,
             )
             record_compilation_metrics(metrics)
+            torch._dynamo.callback_handler.run_end_callbacks()
 
 
 def convert_frame(compiler_fn: CompilerFn, hooks: Hooks):


### PR DESCRIPTION
This is a requirement from Meta internal cases, where ppl wants to register a callback function to detect if a job is stuck during compilation.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng