### PR TITLE
[inductor] disable assert for indirect indexing

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -301,7 +301,7 @@ constant_and_index_propagation = True
 always_keep_tensor_constants = False
 
 # assert that indirect indexing does not read / write out of bounds
-assert_indirect_indexing = True
+assert_indirect_indexing = False
 
 # constant folding on the joint graph
 joint_graph_constant_folding = True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120765

In https://github.com/pytorch/pytorch/issues/120452 we found negative indices handling together with the assertion for indirect indexing can cause perf loss. @htyu also mentioned that the device assert itself can slow things down.

I don't know how much degree of perf loss is caused by the device assert. Sending this PR so I can do a perf test.

