### PR TITLE
Refactor device index bound check for xpu code

### DIFF
--- a/aten/src/ATen/xpu/XPUContext.cpp
+++ b/aten/src/ATen/xpu/XPUContext.cpp
@@ -60,7 +60,7 @@ DeviceProp* getDeviceProperties(DeviceIndex device) {
   c10::call_once(init_flag, initXPUContextVectors);
   if (device == -1)
     device = c10::xpu::current_device();
-  check_device(device);
+  check_device_index(device);
   c10::call_once(device_prop_flags[device], initDeviceProperty, device);
   return &device_properties[device];
 }
@@ -69,7 +69,7 @@ DeviceProp* getDeviceProperties(DeviceIndex device) {
 // index of a XPU device in the framework.
 int32_t getGlobalIdxFromDevice(DeviceIndex device) {
   c10::call_once(init_flag, initXPUContextVectors);
-  check_device(device);
+  check_device_index(device);
   c10::call_once(device_global_idx_flags[device], initDeviceGlobalIdx, device);
   return device_global_idxs[device];
 }

--- a/aten/src/ATen/xpu/XPUContext.cpp
+++ b/aten/src/ATen/xpu/XPUContext.cpp
@@ -49,16 +49,6 @@ void initDeviceGlobalIdx(DeviceIndex device) {
       static_cast<int32_t>(std::distance(devices.begin(), it));
 }
 
-inline void check_device(DeviceIndex device) {
-  TORCH_CHECK(
-      device >= 0 && device < num_gpus,
-      "device is out of range, device is ",
-      static_cast<int>(device),
-      ", total number of device is ",
-      static_cast<int>(num_gpus),
-      ".");
-}
-
 } // anonymous namespace
 
 DeviceProp* getCurrentDeviceProperties() {

--- a/aten/src/ATen/xpu/XPUGeneratorImpl.cpp
+++ b/aten/src/ATen/xpu/XPUGeneratorImpl.cpp
@@ -32,7 +32,7 @@ const Generator& getDefaultXPUGenerator(DeviceIndex device) {
   if (device == -1) {
     device = c10::xpu::current_device();
   }
-  check_device(device);
+  check_device_index(device);
   c10::call_once(xpu_gens_init_flag[device], [&]() {
     default_gens_xpu[device] = make_generator<XPUGeneratorImpl>(device);
     default_gens_xpu[device].seed();
@@ -46,7 +46,7 @@ Generator createXPUGenerator(DeviceIndex device) {
   if (device == -1) {
     device = c10::xpu::current_device();
   }
-  check_device(device);
+  check_device_index(device);
   auto gen = make_generator<XPUGeneratorImpl>(device);
   auto xpu_gen = check_generator<XPUGeneratorImpl>(gen);
   xpu_gen->set_current_seed(default_rng_seed_val);

--- a/aten/src/ATen/xpu/XPUGeneratorImpl.cpp
+++ b/aten/src/ATen/xpu/XPUGeneratorImpl.cpp
@@ -24,16 +24,6 @@ void initXPUGenVector() {
   default_gens_xpu.resize(num_gpus);
 }
 
-inline void check_device(DeviceIndex device) {
-  TORCH_CHECK(
-      device >= 0 && device < num_gpus,
-      "device is out of range, device is ",
-      static_cast<int16_t>(device),
-      ", total number of device is ",
-      static_cast<int16_t>(num_gpus),
-      ".");
-}
-
 } // anonymous namespace
 
 // Get the default generator with a random seed for a specific xpu device.

--- a/c10/xpu/XPUFunctions.h
+++ b/c10/xpu/XPUFunctions.h
@@ -32,4 +32,14 @@ C10_XPU_API void get_device_properties(
 
 C10_XPU_API DeviceIndex get_device_idx_from_pointer(void* ptr);
 
+static inline void check_device(DeviceIndex device) {
+  TORCH_CHECK(
+      device >= 0 && device < device_count(),
+      "device is out of range, device is ",
+      device,
+      ", total number of device is ",
+      device_count(),
+      ".");
+}
+
 } // namespace c10::xpu

--- a/c10/xpu/XPUFunctions.h
+++ b/c10/xpu/XPUFunctions.h
@@ -32,13 +32,13 @@ C10_XPU_API void get_device_properties(
 
 C10_XPU_API DeviceIndex get_device_idx_from_pointer(void* ptr);
 
-static inline void check_device(DeviceIndex device) {
+static inline void check_device_index(DeviceIndex device) {
   TORCH_CHECK(
-      device >= 0 && device < device_count(),
+      device >= 0 && device < c10::xpu::device_count(),
       "device is out of range, device is ",
-      device,
+      static_cast<int>(device),
       ", total number of device is ",
-      device_count(),
+      static_cast<int>(c10::xpu::device_count()),
       ".");
 }
 

--- a/c10/xpu/XPUStream.cpp
+++ b/c10/xpu/XPUStream.cpp
@@ -200,7 +200,7 @@ XPUStream getStreamFromPool(const int priority, DeviceIndex device) {
   if (device == -1) {
     device = c10::xpu::current_device();
   }
-  check_device(device);
+  check_device_index(device);
   TORCH_CHECK(
       priority <= 0,
       "Expected XPU stream priority to be less than or equal to 0, got ",
@@ -228,7 +228,7 @@ XPUStream getCurrentXPUStream(DeviceIndex device) {
   if (device == -1) {
     device = c10::xpu::current_device();
   }
-  check_device(device);
+  check_device_index(device);
   // Initializes the stream pool (once)
   initDeviceStreamOnce(device);
   return XPUStreamForId(device, current_streams[device]);
@@ -266,7 +266,7 @@ void syncStreamsOnDevice(DeviceIndex device) {
   if (device == -1) {
     device = c10::xpu::current_device();
   }
-  check_device(device);
+  check_device_index(device);
   // Initializes the stream pools (once)
   initDeviceStreamOnce(device);
 

--- a/c10/xpu/XPUStream.cpp
+++ b/c10/xpu/XPUStream.cpp
@@ -147,16 +147,6 @@ inline void initDeviceStreamOnce(DeviceIndex device) {
   c10::call_once(device_flags[device], initDeviceStreamState, device);
 }
 
-inline void check_device(DeviceIndex device) {
-  TORCH_CHECK(
-      device >= 0 && device < num_gpus,
-      "device is out of range, device is ",
-      static_cast<int16_t>(device),
-      ", total number of device is ",
-      static_cast<int16_t>(num_gpus),
-      ".");
-}
-
 uint32_t get_idx(std::atomic<uint32_t>& counter) {
   auto raw_idx = counter++;
   return raw_idx % kStreamsPerPool;


### PR DESCRIPTION
# Movitation
refer to [Increased compile time max GPUs to 512. Switched to int16_t DeviceIndex.](https://github.com/pytorch/pytorch/pull/119639), we use `c10::Device::MAX_NUM_DEVICES` to make sure the number of XPU devices is valid in PyTorch.

# Solution
Use `TORCH_CHECK` to check if the number of XPU devices exceeds `c10::Device::MAX_NUM_DEVICES` when enum XPU devices.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10