### PR TITLE
Don't suppress error codes in lint job, properly activate conda

### DIFF
--- a/.github/scripts/lintrunner.sh
+++ b/.github/scripts/lintrunner.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-set -x
+set -ex
 
 # The generic Linux job chooses to use base env, not the one setup by the image
 CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+eval "$(command conda 'shell.bash' 'hook' 2> /dev/null)"
 conda activate "${CONDA_ENV}"
 
 CACHE_DIRECTORY="/tmp/.lintbin"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120769

Before:

```
2024-02-28T02:38:24.3757573Z + conda activate /opt/conda/envs/py_3.9
2024-02-28T02:38:24.3757872Z
2024-02-28T02:38:24.3758116Z CondaError: Run 'conda init' before 'conda activate'
```

Now, this would actually fail the job, and I also fix the bug.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>