### PR TITLE
[inductor] Do not reuse buffers across  scopes in mem planning

### DIFF
--- a/test/inductor/test_control_flow.py
+++ b/test/inductor/test_control_flow.py
@@ -267,12 +267,14 @@ class CondTests(TestCase):
         )
 
     @requires_cuda
-    def test_subgraphs_with_parameters(self):
+    @parametrize("device", ["cpu", "cuda"])
+    @parametrize("dynamic", [False, True])
+    def test_subgraphs_with_parameters(self, device, dynamic):
         # nested Modules with parameters
         class InnerModel1(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.layer = torch.nn.Linear(20, 30, device="cuda")
+                self.layer = torch.nn.Linear(20, 30, device=device)
 
             def forward(self, x):
                 return self.layer(x + 1) * 3.14
@@ -280,8 +282,8 @@ class CondTests(TestCase):
         class InnerModel2(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.layer1 = torch.nn.Linear(20, 10, device="cuda")
-                self.layer2 = torch.nn.Linear(10, 30, device="cuda")
+                self.layer1 = torch.nn.Linear(20, 10, device=device)
+                self.layer2 = torch.nn.Linear(10, 30, device=device)
 
             def forward(self, x):
                 return self.layer2(self.layer1(x - 2)) * 3.14
@@ -298,8 +300,8 @@ class CondTests(TestCase):
         self._run_test(
             model=Model(),
             inputs=(torch.randn(10, 20),),
-            device="cuda",
-            dynamic=True,
+            device=device,
+            dynamic=dynamic,
         )
 
     @requires_cuda

--- a/test/inductor/test_control_flow.py
+++ b/test/inductor/test_control_flow.py
@@ -267,6 +267,42 @@ class CondTests(TestCase):
         )
 
     @requires_cuda
+    def test_subgraphs_with_parameters(self):
+        # nested Modules with parameters
+        class InnerModel1(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layer = torch.nn.Linear(20, 30, device="cuda")
+
+            def forward(self, x):
+                return self.layer(x + 1) * 3.14
+
+        class InnerModel2(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layer1 = torch.nn.Linear(20, 10, device="cuda")
+                self.layer2 = torch.nn.Linear(10, 30, device="cuda")
+
+            def forward(self, x):
+                return self.layer2(self.layer1(x - 2)) * 3.14
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.true_fn = InnerModel1()
+                self.false_fn = InnerModel2()
+
+            def forward(self, p, a):
+                return torch.cond(p, self.true_fn, self.false_fn, [a])
+
+        self._run_test(
+            model=Model(),
+            inputs=(torch.randn(10, 20),),
+            device="cuda",
+            dynamic=True,
+        )
+
+    @requires_cuda
     def test_aliasing_outputs(self):
         # output aliasing in subgraphs: not supported
         class Model(torch.nn.Module):

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -755,6 +755,7 @@ class WrapperCodeGen(CodeGen):
             elif isinstance(line, ExitScopeLine):
                 past_planning_states.append(planning_states.pop())
         past_planning_states.append(planning_states.pop())
+        assert len(planning_states) == 0
 
         # conservatively use the sum of all allocated buffer sizes
         # in potentially nested scopes as the total allocated size

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -223,12 +223,12 @@ class WrapperLine:
     pass
 
 
-class IndentLine(WrapperLine):
+class EnterScopeLine(WrapperLine):
     def codegen(self, code: IndentedBuffer) -> None:
         code.do_indent()
 
 
-class UnindentLine(WrapperLine):
+class ExitScopeLine(WrapperLine):
     def codegen(self, code: IndentedBuffer) -> None:
         code.do_unindent()
 
@@ -744,16 +744,28 @@ class WrapperCodeGen(CodeGen):
             self.lines.pop()
 
         # codegen allocations in two passes
-        planning_state = MemoryPlanningState()
+        planning_states = [MemoryPlanningState()]
+        past_planning_states = []
         for i in range(len(self.lines)):
             line = self.lines[i]
             if isinstance(line, MemoryPlanningLine):
-                self.lines[i] = line.plan(planning_state)
+                self.lines[i] = line.plan(planning_states[-1])
+            elif isinstance(line, EnterScopeLine):
+                planning_states.append(MemoryPlanningState())
+            elif isinstance(line, ExitScopeLine):
+                past_planning_states.append(planning_states.pop())
+        past_planning_states.append(planning_states.pop())
+
+        # conservatively use the sum of all allocated buffer sizes
+        # in potentially nested scopes as the total allocated size
+        total_allocated_buffer_size = sum(
+            s.total_allocated_buffer_size for s in past_planning_states
+        )
 
         self.allow_stack_allocation = (
             self.allow_stack_allocation is not False
             and config.allow_stack_allocation
-            and planning_state.total_allocated_buffer_size <= MAX_STACK_ALLOCATION_SIZE
+            and total_allocated_buffer_size <= MAX_STACK_ALLOCATION_SIZE
         )
 
     def codegen_input_size_var_decl(self, code: IndentedBuffer, name):
@@ -1395,13 +1407,13 @@ class WrapperCodeGen(CodeGen):
         # TODO(aakhundov): make this work for C++ wrapper codegen (and ABI mode)
         self.writeline(f"{name} = [None] * {len(conditional.outputs)}")
         self.writeline(f"if {conditional.predicate.codegen_reference()}.item():")
-        self.writeline(IndentLine())
+        self.writeline(EnterScopeLine())
         self.codegen_subgraph(conditional.true_subgraph, outer_inputs, outer_outputs)
-        self.writeline(UnindentLine())
+        self.writeline(ExitScopeLine())
         self.writeline("else:")
-        self.writeline(IndentLine())
+        self.writeline(EnterScopeLine())
         self.codegen_subgraph(conditional.false_subgraph, outer_inputs, outer_outputs)
-        self.writeline(UnindentLine())
+        self.writeline(ExitScopeLine())
 
     @staticmethod
     def statically_known_int_or_none(x):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120777
* #120665

Summary: Previously, in the `memory_plan_reuse` we assumed that the generated code is flat: in the sense of it can't have nested scopes. However, with nested control flow codegen-ing, this is no longer the case. This causes bugs in buffers being reused across the visibility boundaries in different nested scopes.

In this PR, we add nested planning states in `memory_plan_reuse` on entering and exiting scope in the codegen. This restricts the buffer reusability only to the currently active (peak) scope / planning state.

Test Plan:

```
python test/inductor/test_control_flow.py -k test_subgraphs_with_parameters
...
----------------------------------------------------------------------
Ran 27 tests in 149.413s

OK
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire