### PR TITLE
Refine value ranges on inequalities

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -2344,7 +2344,6 @@ def forward(self, x):
         self.assertEqual(dynamo_result, m(inp))
 
     def test_constraint_violation_error_messages(self):
-        """
         class Foo(torch.nn.Module):
             def forward(self, x):
                 if x.shape[0] == x.shape[1] * 2:
@@ -2383,7 +2382,6 @@ def forward(self, x):
             "Not all values.*valid.*inferred to be a constant",
         ):
             torch.export.export(bar, (t,), dynamic_shapes=dynamic_shapes)
-        """
 
         class Qux(torch.nn.Module):
             def forward(self, x):

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -2344,6 +2344,7 @@ def forward(self, x):
         self.assertEqual(dynamo_result, m(inp))
 
     def test_constraint_violation_error_messages(self):
+        """
         class Foo(torch.nn.Module):
             def forward(self, x):
                 if x.shape[0] == x.shape[1] * 2:
@@ -2382,6 +2383,7 @@ def forward(self, x):
             "Not all values.*valid.*inferred to be a constant",
         ):
             torch.export.export(bar, (t,), dynamic_shapes=dynamic_shapes)
+        """
 
         class Qux(torch.nn.Module):
             def forward(self, x):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -5977,7 +5977,7 @@ def fn():
                 first_guard_failure,
             )
         else:
-            self.assertIn("""L['x'].size()[0] < 3""", first_guard_failure)
+            self.assertIn("""2 <= L['x'].size()[0] <= 2""", first_guard_failure)
 
     def test_guard_failure_fn2(self):
         def fn(x, y):

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -146,12 +146,12 @@ def create_symbolic_tensor(name, arg, shape_env):
         )
     return FakeSymbolicTensor(sym_shapes, sym_strides, arg.dtype, arg.layout, arg.requires_grad, arg.device, sym_storage_offset)
 
-def create_symtype(cls, pytype, shape_env, val):
+def create_symtype(cls, pytype, shape_env, val, duck=True):
     from torch._dynamo.source import ConstantSource
     symbol = shape_env.create_symbol(
         val,
         source=ConstantSource(f"__testing_only{len(shape_env.var_to_val)}"),
-        dynamic_dim=DimDynamic.DUCK,
+        dynamic_dim=DimDynamic.DUCK if duck else DimDynamic.DYNAMIC,
         constraint_dim=None,
     )
     return cls(SymNode(
@@ -161,8 +161,9 @@ def create_symtype(cls, pytype, shape_env, val):
         hint=val,
     ))
 
-def create_symint(shape_env, i: int):
-    return create_symtype(SymInt, int, shape_env, i)
+# TODO: default duck to False
+def create_symint(shape_env, i: int, duck=True):
+    return create_symtype(SymInt, int, shape_env, i, duck=duck)
 
 def create_symbool(shape_env, b: bool):
     return create_symtype(SymBool, bool, shape_env, b)
@@ -553,6 +554,70 @@ def forward(self, x_1):
         self.assertEqual(str(ia[-1]), "u10")
         self.assertTrue(expect_true(sum(ia) == 20))
         self.assertEqual(len(shape_env.deferred_runtime_asserts[ia[-1].node.expr]), 1)
+
+    def test_expect_true_refine_range(self):
+        shape_env = ShapeEnv()
+        for rel in [lambda x: x > 4, lambda x: 4 < x, lambda x: x >= 5, lambda x: 5 <= x]:
+            i0 = shape_env.create_unbacked_symint()
+            self.assertTrue(expect_true(rel(i0)))
+            self.assertTrue(statically_known_true(i0 != 3))
+            self.assertTrue(statically_known_true(i0 != 4))
+            self.assertFalse(statically_known_true(i0 != 5))
+            self.assertFalse(statically_known_true(i0 != 6))
+            self.assertTrue(statically_known_true(i0 > 4))
+            self.assertTrue(statically_known_true(i0 >= 5))
+
+        for rel in [lambda x: x < 4, lambda x: 4 > x, lambda x: x <= 3, lambda x: 3 >= x]:
+            i0 = shape_env.create_unbacked_symint()
+            self.assertTrue(expect_true(rel(i0)))
+            self.assertFalse(statically_known_true(i0 != 2))
+            self.assertFalse(statically_known_true(i0 != 3))
+            self.assertTrue(statically_known_true(i0 != 4))
+            self.assertTrue(statically_known_true(i0 != 5))
+            self.assertTrue(statically_known_true(i0 < 4))
+            self.assertTrue(statically_known_true(i0 <= 5))
+
+    def test_guard_refine_range(self):
+        shape_env = ShapeEnv()
+        for rel in [lambda x: x > 4, lambda x: 4 < x, lambda x: x >= 5, lambda x: 5 <= x]:
+            i0 = create_symint(shape_env, 10, duck=False)
+            self.assertTrue(bool(rel(i0)))
+            self.assertTrue(statically_known_true(i0 != 3))
+            self.assertTrue(statically_known_true(i0 != 4))
+            self.assertFalse(statically_known_true(i0 != 5))
+            self.assertFalse(statically_known_true(i0 != 6))
+            self.assertTrue(statically_known_true(i0 > 4))
+            self.assertTrue(statically_known_true(i0 >= 5))
+
+        for rel in [lambda x: x > 4, lambda x: 4 < x, lambda x: x >= 5, lambda x: 5 <= x]:
+            i0 = create_symint(shape_env, 2, duck=False)
+            self.assertFalse(bool(rel(i0)))
+            self.assertFalse(statically_known_true(i0 != 3))
+            self.assertFalse(statically_known_true(i0 != 4))
+            self.assertTrue(statically_known_true(i0 != 5))
+            self.assertTrue(statically_known_true(i0 != 6))
+            self.assertTrue(statically_known_true(i0 <= 4))
+            self.assertTrue(statically_known_true(i0 < 5))
+
+        for rel in [lambda x: x < 4, lambda x: 4 > x, lambda x: x <= 3, lambda x: 3 >= x]:
+            i0 = create_symint(shape_env, 2, duck=False)
+            self.assertTrue(bool(rel(i0)))
+            self.assertFalse(statically_known_true(i0 != 2))
+            self.assertFalse(statically_known_true(i0 != 3))
+            self.assertTrue(statically_known_true(i0 != 4))
+            self.assertTrue(statically_known_true(i0 != 5))
+            self.assertTrue(statically_known_true(i0 < 4))
+            self.assertTrue(statically_known_true(i0 <= 3))
+
+        for rel in [lambda x: x < 4, lambda x: 4 > x, lambda x: x <= 3, lambda x: 3 >= x]:
+            i0 = create_symint(shape_env, 10, duck=False)
+            self.assertFalse(bool(rel(i0)))
+            self.assertTrue(statically_known_true(i0 != 2))
+            self.assertTrue(statically_known_true(i0 != 3))
+            self.assertFalse(statically_known_true(i0 != 4))
+            self.assertFalse(statically_known_true(i0 != 5))
+            self.assertTrue(statically_known_true(i0 >= 4))
+            self.assertTrue(statically_known_true(i0 > 3))
 
     def test_non_overlapping_and_dense(self):
         shape_env = ShapeEnv()

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -557,67 +557,73 @@ def forward(self, x_1):
 
     def test_expect_true_refine_range(self):
         shape_env = ShapeEnv()
-        for rel in [lambda x: x > 4, lambda x: 4 < x, lambda x: x >= 5, lambda x: 5 <= x]:
-            i0 = shape_env.create_unbacked_symint()
-            self.assertTrue(expect_true(rel(i0)))
-            self.assertTrue(statically_known_true(i0 != 3))
-            self.assertTrue(statically_known_true(i0 != 4))
-            self.assertFalse(statically_known_true(i0 != 5))
-            self.assertFalse(statically_known_true(i0 != 6))
-            self.assertTrue(statically_known_true(i0 > 4))
-            self.assertTrue(statically_known_true(i0 >= 5))
+        for i, rel in enumerate([lambda x: x > 4, lambda x: 4 < x, lambda x: x >= 5, lambda x: 5 <= x]):
+            with self.subTest(f"i = {i}"):
+                i0 = shape_env.create_unbacked_symint()
+                self.assertTrue(expect_true(rel(i0)))
+                self.assertTrue(statically_known_true(i0 != 3))
+                self.assertTrue(statically_known_true(i0 != 4))
+                self.assertFalse(statically_known_true(i0 != 5))
+                self.assertFalse(statically_known_true(i0 != 6))
+                self.assertTrue(statically_known_true(i0 > 4))
+                self.assertTrue(statically_known_true(i0 >= 5))
 
-        for rel in [lambda x: x < 4, lambda x: 4 > x, lambda x: x <= 3, lambda x: 3 >= x]:
-            i0 = shape_env.create_unbacked_symint()
-            self.assertTrue(expect_true(rel(i0)))
-            self.assertFalse(statically_known_true(i0 != 2))
-            self.assertFalse(statically_known_true(i0 != 3))
-            self.assertTrue(statically_known_true(i0 != 4))
-            self.assertTrue(statically_known_true(i0 != 5))
-            self.assertTrue(statically_known_true(i0 < 4))
-            self.assertTrue(statically_known_true(i0 <= 5))
+        for i, rel in enumerate([lambda x: x < 4, lambda x: 4 > x, lambda x: x <= 3, lambda x: 3 >= x]):
+            with self.subTest(f"i = {i}"):
+                i0 = shape_env.create_unbacked_symint()
+                self.assertTrue(expect_true(rel(i0)))
+                self.assertFalse(statically_known_true(i0 != 2))
+                self.assertFalse(statically_known_true(i0 != 3))
+                self.assertTrue(statically_known_true(i0 != 4))
+                self.assertTrue(statically_known_true(i0 != 5))
+                self.assertTrue(statically_known_true(i0 < 4))
+                self.assertTrue(statically_known_true(i0 <= 5))
 
     def test_guard_refine_range(self):
         shape_env = ShapeEnv()
-        for rel in [lambda x: x > 4, lambda x: 4 < x, lambda x: x >= 5, lambda x: 5 <= x]:
-            i0 = create_symint(shape_env, 10, duck=False)
-            self.assertTrue(bool(rel(i0)))
-            self.assertTrue(statically_known_true(i0 != 3))
-            self.assertTrue(statically_known_true(i0 != 4))
-            self.assertFalse(statically_known_true(i0 != 5))
-            self.assertFalse(statically_known_true(i0 != 6))
-            self.assertTrue(statically_known_true(i0 > 4))
-            self.assertTrue(statically_known_true(i0 >= 5))
+        for i, rel in enumerate([lambda x: x > 4, lambda x: 4 < x, lambda x: x >= 5, lambda x: 5 <= x]):
+            with self.subTest(f"i = {i}"):
+                i0 = create_symint(shape_env, 10, duck=False)
+                self.assertTrue(bool(rel(i0)))
+                self.assertTrue(statically_known_true(i0 != 3))
+                self.assertTrue(statically_known_true(i0 != 4))
+                self.assertFalse(statically_known_true(i0 != 5))
+                self.assertFalse(statically_known_true(i0 != 6))
+                self.assertTrue(statically_known_true(i0 > 4))
+                self.assertTrue(statically_known_true(i0 >= 5))
 
-        for rel in [lambda x: x > 4, lambda x: 4 < x, lambda x: x >= 5, lambda x: 5 <= x]:
-            i0 = create_symint(shape_env, 2, duck=False)
-            self.assertFalse(bool(rel(i0)))
-            self.assertFalse(statically_known_true(i0 != 3))
-            self.assertFalse(statically_known_true(i0 != 4))
-            self.assertTrue(statically_known_true(i0 != 5))
-            self.assertTrue(statically_known_true(i0 != 6))
-            self.assertTrue(statically_known_true(i0 <= 4))
-            self.assertTrue(statically_known_true(i0 < 5))
+        for i, rel in enumerate([lambda x: x > 4, lambda x: 4 < x, lambda x: x >= 5, lambda x: 5 <= x]):
+            with self.subTest(f"i = {i}"):
+                i0 = create_symint(shape_env, 2, duck=False)
+                self.assertFalse(bool(rel(i0)))
+                self.assertFalse(statically_known_true(i0 != 3))
+                self.assertFalse(statically_known_true(i0 != 4))
+                self.assertTrue(statically_known_true(i0 != 5))
+                self.assertTrue(statically_known_true(i0 != 6))
+                self.assertTrue(statically_known_true(i0 <= 4))
+                self.assertTrue(statically_known_true(i0 < 5))
 
-        for rel in [lambda x: x < 4, lambda x: 4 > x, lambda x: x <= 3, lambda x: 3 >= x]:
-            i0 = create_symint(shape_env, 2, duck=False)
-            self.assertTrue(bool(rel(i0)))
-            self.assertFalse(statically_known_true(i0 != 2))
-            self.assertFalse(statically_known_true(i0 != 3))
-            self.assertTrue(statically_known_true(i0 != 4))
-            self.assertTrue(statically_known_true(i0 != 5))
-            self.assertTrue(statically_known_true(i0 < 4))
-            self.assertTrue(statically_known_true(i0 <= 3))
+        for i, rel in enumerate([lambda x: x < 4, lambda x: 4 > x, lambda x: x <= 3, lambda x: 3 >= x]):
+            with self.subTest(f"i = {i}"):
+                i0 = create_symint(shape_env, 2, duck=False)
+                self.assertTrue(bool(rel(i0)))
+                self.assertFalse(statically_known_true(i0 != 2))
+                self.assertFalse(statically_known_true(i0 != 3))
+                self.assertTrue(statically_known_true(i0 != 4))
+                self.assertTrue(statically_known_true(i0 != 5))
+                self.assertTrue(statically_known_true(i0 < 4))
+                self.assertTrue(statically_known_true(i0 <= 3))
 
-        for rel in [lambda x: x < 4, lambda x: 4 > x, lambda x: x <= 3, lambda x: 3 >= x]:
-            i0 = create_symint(shape_env, 10, duck=False)
-            self.assertFalse(bool(rel(i0)))
-            self.assertTrue(statically_known_true(i0 != 2))
-            self.assertTrue(statically_known_true(i0 != 3))
-            self.assertFalse(statically_known_true(i0 != 4))
-            self.assertFalse(statically_known_true(i0 != 5))
-            self.assertTrue(statically_known_true(i0 >= 4))
-            self.assertTrue(statically_known_true(i0 > 3))
+        for i, rel in enumerate([lambda x: x < 4, lambda x: 4 > x, lambda x: x <= 3, lambda x: 3 >= x]):
+            with self.subTest(f"i = {i}"):
+                i0 = create_symint(shape_env, 10, duck=False)
+                self.assertFalse(bool(rel(i0)))
+                self.assertTrue(statically_known_true(i0 != 2))
+                self.assertTrue(statically_known_true(i0 != 3))
+                self.assertFalse(statically_known_true(i0 != 4))
+                self.assertFalse(statically_known_true(i0 != 5))
+                self.assertTrue(statically_known_true(i0 >= 4))
+                self.assertTrue(statically_known_true(i0 > 3))
 
     def test_non_overlapping_and_dense(self):
         shape_env = ShapeEnv()

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -1068,7 +1068,7 @@ def forward(self, x_1, y_1):
         self.assertTrue(eval_guards(gm, torch.randn(4, 5)))
         self.assertEqual(repr(bind_symbols(gm, torch.randn(4, 5))), "{s0: 4, s1: 5}")
         self.assertFalse(eval_guards(gm, torch.randn(25, 5)))
-        self.assertExpectedInline(show_guards(gm), """L['x'].size()[0] < 20""")
+        self.assertExpectedInline(show_guards(gm), """L['x'].size()[0] <= 19""")
 
     def test_repeat_interleave(self):
         def f(src_tokens, beam_size_src):
@@ -1714,14 +1714,14 @@ def forward(self, x_1):
             assert a.shape[0] > 5 and a.shape[0] > 12
             return a.cos()
         tensor = make_fx(f, tracing_mode="symbolic")(torch.randn(15))
-        self.assertExpectedInline(show_guards(tensor), """L['a'].size()[0] > 12""")
+        self.assertExpectedInline(show_guards(tensor), """13 <= L['a'].size()[0]""")
 
     def test_guard_lowerbound_range_refinement(self):
         def f(a):
             assert a.shape[0] < 20 and a.shape[0] < 30
             return a.cos()
         tensor = make_fx(f, tracing_mode="symbolic")(torch.randn(15))
-        self.assertExpectedInline(show_guards(tensor), """L['a'].size()[0] < 20""")
+        self.assertExpectedInline(show_guards(tensor), """L['a'].size()[0] <= 19""")
 
     def test_guard_upperbound_range_refinement_multivariate(self):
         def f(a):
@@ -1731,7 +1731,7 @@ def forward(self, x_1):
         tensor = make_fx(f, tracing_mode="symbolic")(torch.randn((15, 20)))
         self.assertExpectedInline(show_guards(tensor), """\
 L['a'].size()[1] > L['a'].size()[0]
-L['a'].size()[0] > 12""")
+13 <= L['a'].size()[0]""")
 
     def test_guard_lowerbound_range_refinement_multivariate(self):
         def f(a):
@@ -1743,7 +1743,7 @@ L['a'].size()[0] > 12""")
             show_guards(tensor),
             """\
 L['a'].size()[1] < L['a'].size()[0]
-L['a'].size()[0] < 20""")
+L['a'].size()[0] <= 19""")
 
     def test_sym_storage_offset(self):
         def f(x, y):

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -106,11 +106,6 @@ def functional_assert_async_msg_decomp(tensor, msg):
     return
 
 
-@register_decomposition([aten._assert_scalar.default])
-def assert_scalar_decomp(tensor, msg):
-    return
-
-
 @register_decomposition([aten.sym_constrain_range_for_size.default])
 def sym_constrain_range_for_size(symbol, *, min=None, max=None):
     return

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -106,6 +106,11 @@ def functional_assert_async_msg_decomp(tensor, msg):
     return
 
 
+@register_decomposition([aten._assert_scalar.default])
+def assert_scalar_decomp(tensor, msg):
+    return
+
+
 @register_decomposition([aten.sym_constrain_range_for_size.default])
 def sym_constrain_range_for_size(symbol, *, min=None, max=None):
     return

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -3688,9 +3688,10 @@ class ShapeEnv:
             # TODO: deal with conjunction/disjunction?
             if len(free) == 1:
                 lhs = free[0]
-                res, rhs = try_solve(expr, lhs)
-                if isinstance(res, (sympy.Lt, sympy.Le, sympy.Gt, sympy.Ge)) and isinstance(rhs, sympy.Integer):
-                    bound = int(rhs)
+                r = try_solve(expr, lhs)
+                if r is not None and isinstance(r[0], (sympy.Lt, sympy.Le, sympy.Gt, sympy.Ge)) and isinstance(r[1], sympy.Integer):
+                    res = r[0]
+                    bound = int(r[1])
                     if isinstance(res, sympy.Lt):
                         # lhs < bound
                         update_vr = [-sympy.oo, bound - 1]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #114148
* __->__ #120800

This is basically done the obvious way. For better or worse, I jammed this into what used to be `_maybe_guard_eq` but now is `_maybe_guard_rel`. I was careful to test all the off by one conditions, and each permutation. Let me know if you think I missed anything. Importantly, this now works for unbacked SymInts.

While testing, I noticed we are silently duck sizing all symbolic variables in `test_dynamic_shapes.py`. This may or may not be covering up bugs.

Along the way, I had to fix a bug in export constraints, where we weren't checking that the final var_to_range was consistent with what the user requested at top level.

After I implemented all this, I realized that applying this to non-unbacked SymInts was duplicative with @ysiraichi's previous work on https://github.com/pytorch/pytorch/pull/97963 . The upside is I now understand what Yukio was trying to do in the original PR, and I think my new logic is simpler and less error prone. In Yukio's earlier diff, Yukio tried very hard to avoid changing what guards we actually issue (since this would cause tests to wobble). Thus, when he refined a range, he also saved the guard that actually caused the range to refine. In this PR, I don't bother saving these guards; instead I just tighten var_to_range directly and rely on generating guards on this to be correct. The key insight is that if I assert `x < y`, it's always safe to emit (potentially) more restrictive range guards, because this won't invalidate our guards, it will just make them a little too strong (but actually, I think we are precise along the way.) If these guards make it unnecessary to test `x < y`, because now the ranges for x and y are disjoint, this is fine, we've subsumed the x < y guard and can just not bother testing it. If I've gotten it right, TV will agree with me.

In fact, I had a bug in this PR which TV didn't catch, which is that when we have a recorded var_to_guards for a symbol, we unconditionally never generate the range guard for it, even if the var_to_guards is potentially inconsistent with var_to_range (because var_to_range was updated separately). With var_to_guards removed, I don't have to worry abou this inconsistency.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames