### PR TITLE
[pytorch] Support output types that are non tensors

### DIFF
--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -2360,6 +2360,8 @@ def canonicalize(ep: ExportedProgram) -> ExportedProgram:
                     pass
                 else:
                     raise AssertionError(f"Unknown sym_int type: {s}")
+            elif arg.type in ("as_none", "as_int", "as_float", "as_string"):
+                return
             else:
                 raise AssertionError(f"Unknown input type: {arg}")
         elif spec.type == "loss_output":


### PR DESCRIPTION
Summary:
per title
This is needed because some modules return None and non tensors as output

Test Plan: sandcastle?

Reviewed By: zhxchen17

Differential Revision: D54311609
