### PR TITLE
Ban passing in free function into capture_pre_autograd_graph

### DIFF
--- a/test/fx/test_matcher_utils.py
+++ b/test/fx/test_matcher_utils.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+from typing import Callable
 
 import torch
 import torch.nn.functional as F
@@ -10,12 +11,24 @@ from torch.fx.experimental.proxy_tensor import make_fx
 
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(pytorch_test_dir)
-from torch.fx.passes.utils.matcher_utils import SubgraphMatcher
-from torch.testing._internal.jit_utils import JitTestCase
-from torch.fx.passes.utils.matcher_with_name_node_map_utils import SubgraphMatcherWithNameNodeMap
-from torch.testing._internal.common_utils import IS_WINDOWS
-from torch.testing._internal.common_utils import run_tests
 import unittest
+
+from torch.fx.passes.utils.matcher_utils import SubgraphMatcher
+from torch.fx.passes.utils.matcher_with_name_node_map_utils import (
+    SubgraphMatcherWithNameNodeMap,
+)
+from torch.testing._internal.common_utils import IS_WINDOWS, run_tests
+from torch.testing._internal.jit_utils import JitTestCase
+
+
+class WrapperModule(torch.nn.Module):
+    def __init__(self, fn: Callable):
+        super().__init__()
+        self.fn = fn
+
+    def forward(self, *args, **kwargs):
+        return self.fn(*args, **kwargs)
+
 
 class TestMatcher(JitTestCase):
     def test_subgraph_matcher_with_attributes(self):
@@ -145,7 +158,7 @@ class TestMatcher(JitTestCase):
             torch.randn(1, 3, 3, 3) * 10,
             torch.randn(3, 3, 3, 3),
         )
-        pattern_gm = capture_pre_autograd_graph(pattern, example_inputs)
+        pattern_gm = capture_pre_autograd_graph(WrapperModule(pattern), example_inputs)
         before_split_res = pattern_gm(*example_inputs)
         pattern_gm, name_node_map = _split_to_graph_and_name_node_map(pattern_gm)
         after_split_res = pattern_gm(*example_inputs)
@@ -177,9 +190,9 @@ class TestMatcher(JitTestCase):
             torch.randn(1, 3, 3, 3) * 10,
             torch.randn(3, 3, 3, 3),
         )
-        pattern_gm = capture_pre_autograd_graph(pattern, example_inputs)
+        pattern_gm = capture_pre_autograd_graph(WrapperModule(pattern), example_inputs)
         matcher = SubgraphMatcherWithNameNodeMap(pattern_gm)
-        target_gm = capture_pre_autograd_graph(target_graph, example_inputs)
+        target_gm = capture_pre_autograd_graph(WrapperModule(target_graph), example_inputs)
         internal_matches = matcher.match(target_gm.graph)
         for internal_match in internal_matches:
             name_node_map = internal_match.name_node_map

--- a/test/quantization/pt2e/test_generate_numeric_debug_handle.py
+++ b/test/quantization/pt2e/test_generate_numeric_debug_handle.py
@@ -6,6 +6,7 @@ import unittest
 import torch
 from torch._export import capture_pre_autograd_graph
 from torch.ao.quantization import generate_numeric_debug_handle
+from torch.ao.quantization.pt2e.export_utils import _WrapperModule
 from torch.ao.quantization.quantize_pt2e import convert_pt2e, prepare_pt2e
 from torch.ao.quantization.quantizer.xnnpack_quantizer import (
     get_symmetric_quantization_config,
@@ -38,7 +39,9 @@ def _extract_conv2d_pattern_debug_handle_map(model):
         torch.randn(1, 1, 1, 1),  # weight
         torch.randn(1),  # bias
     )
-    conv_gm = capture_pre_autograd_graph(conv_pattern, conv_pattern_example_inputs)
+    conv_gm = capture_pre_autograd_graph(
+        _WrapperModule(conv_pattern), conv_pattern_example_inputs
+    )
     conv_pm = SubgraphMatcherWithNameNodeMap(conv_gm)
     matches = conv_pm.match(model.graph)
     assert len(matches) == 1, "Expecting to have one match"

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -91,7 +91,7 @@ class ExportDynamoConfig:
 
 @compatibility(is_backward_compatible=False)
 def capture_pre_autograd_graph(
-    f: Callable,
+    f: torch.nn.Module,
     args: Tuple[Any],
     kwargs: Optional[Dict[str, Any]] = None,
     constraints: Optional[List[Constraint]] = None,
@@ -104,7 +104,7 @@ def capture_pre_autograd_graph(
     torch.export API.
 
     Args:
-      f: A callable to be traced
+      f: nn.Module to be traced
 
       args: example positional inputs.
 
@@ -141,6 +141,8 @@ def capture_pre_autograd_graph(
     from torch.export.dynamic_shapes import _process_dynamic_shapes
 
     log_export_usage(event="export.private_api", flags={"capture_pre_autograd_graph"})
+
+    assert isinstance(f, torch.nn.Module), "Expected an nn.Module instance."
 
     if kwargs is None:
         kwargs = {}

--- a/torch/ao/quantization/pt2e/export_utils.py
+++ b/torch/ao/quantization/pt2e/export_utils.py
@@ -6,7 +6,22 @@ import torch.nn.functional as F
 
 __all__ = [
     "model_is_exported",
+    "_WrapperModule",
 ]
+
+
+class _WrapperModule(torch.nn.Module):
+    """Class to wrap a callable in an :class:`torch.nn.Module`. Use this if you
+    are trying to export a callable.
+    """
+
+    def __init__(self, fn):
+        super().__init__()
+        self.fn = fn
+
+    def forward(self, *args, **kwargs):
+        """Simple forward that just calls the ``fn`` provided to :meth:`WrapperModule.__init__`."""
+        return self.fn(*args, **kwargs)
 
 
 def model_is_exported(m: torch.nn.Module) -> bool:
@@ -47,11 +62,19 @@ def _replace_dropout(m: torch.fx.GraphModule, train_to_eval: bool):
 
         example_inputs = (torch.randn(1),)
         if train_to_eval:
-            match_pattern = get_aten_graph_module(dropout_train, example_inputs)
-            replacement_pattern = get_aten_graph_module(dropout_eval, example_inputs)
+            match_pattern = get_aten_graph_module(
+                _WrapperModule(dropout_train), example_inputs
+            )
+            replacement_pattern = get_aten_graph_module(
+                _WrapperModule(dropout_eval), example_inputs
+            )
         else:
-            match_pattern = get_aten_graph_module(dropout_eval, example_inputs)
-            replacement_pattern = get_aten_graph_module(dropout_train, example_inputs)
+            match_pattern = get_aten_graph_module(
+                _WrapperModule(dropout_eval), example_inputs
+            )
+            replacement_pattern = get_aten_graph_module(
+                _WrapperModule(dropout_train), example_inputs
+            )
 
         from torch.fx.subgraph_rewriter import replace_pattern_with_filters
 
@@ -114,11 +137,15 @@ def _replace_batchnorm(m: torch.fx.GraphModule, train_to_eval: bool):
         torch.randn(1),  # bn_running_var
     )
     if train_to_eval:
-        match_pattern = get_aten_graph_module(bn_train, example_inputs)
-        replacement_pattern = get_aten_graph_module(bn_eval, example_inputs)
+        match_pattern = get_aten_graph_module(_WrapperModule(bn_train), example_inputs)
+        replacement_pattern = get_aten_graph_module(
+            _WrapperModule(bn_eval), example_inputs
+        )
     else:
-        match_pattern = get_aten_graph_module(bn_eval, example_inputs)
-        replacement_pattern = get_aten_graph_module(bn_train, example_inputs)
+        match_pattern = get_aten_graph_module(_WrapperModule(bn_eval), example_inputs)
+        replacement_pattern = get_aten_graph_module(
+            _WrapperModule(bn_train), example_inputs
+        )
 
     from torch.fx.subgraph_rewriter import replace_pattern_with_filters
 

--- a/torch/ao/quantization/pt2e/qat_utils.py
+++ b/torch/ao/quantization/pt2e/qat_utils.py
@@ -11,6 +11,7 @@ from torch.fx.subgraph_rewriter import (
 )
 import torch.nn.functional as F
 from torch.ao.quantization.fx._decomposed import quantized_decomposed_lib  # noqa: F401
+from torch.ao.quantization.pt2e.export_utils import _WrapperModule
 from torch.ao.quantization.quantizer import (
     DerivedQuantizationSpec,
     EdgeOrNode,
@@ -89,7 +90,7 @@ def _get_conv_bn_pattern(conv_fn: Callable) -> Callable:
         x = conv_fn(x, conv_weight, conv_bias)
         x = F.batch_norm(x, bn_running_mean, bn_running_var, bn_weight, bn_bias, training=True)
         return x
-    return _conv_bn_pattern
+    return _WrapperModule(_conv_bn_pattern)
 
 # TODO: merge this with the `no_conv_bias` case
 def _get_qat_conv_bn_pattern(conv_fn: Callable) -> Callable:
@@ -122,7 +123,7 @@ def _get_qat_conv_bn_pattern(conv_fn: Callable) -> Callable:
         x = x + conv_bias.reshape(bias_shape)
         x = F.batch_norm(x, bn_running_mean, bn_running_var, bn_weight, bn_bias, training=True, eps=bn_eps)
         return x
-    return _qat_conv_bn_pattern
+    return _WrapperModule(_qat_conv_bn_pattern)
 
 def _get_qat_conv_bn_pattern_no_conv_bias(conv_fn: Callable) -> Callable:
     def _qat_conv_bn_pattern_no_conv_bias(
@@ -151,7 +152,7 @@ def _get_qat_conv_bn_pattern_no_conv_bias(conv_fn: Callable) -> Callable:
         x = x / scale_factor.reshape(bias_shape)
         x = F.batch_norm(x, bn_running_mean, bn_running_var, bn_weight, bn_bias, training=True, eps=bn_eps)
         return x
-    return _qat_conv_bn_pattern_no_conv_bias
+    return _WrapperModule(_qat_conv_bn_pattern_no_conv_bias)
 
 def _append_qdq(x, is_per_channel, kwargs):
     """
@@ -224,7 +225,7 @@ def _get_quantized_qat_conv_bn_pattern(
             x = x + kwargs["conv_bias"].reshape(bias_shape)
         x = F.batch_norm(x, bn_running_mean, bn_running_var, bn_weight, bn_bias, training=bn_is_training, eps=bn_eps)
         return x
-    return _quantized_qat_conv_bn_pattern
+    return _WrapperModule(_quantized_qat_conv_bn_pattern)
 
 def _get_folded_quantized_qat_conv_bn_pattern(
     is_per_channel: bool,
@@ -258,7 +259,7 @@ def _get_folded_quantized_qat_conv_bn_pattern(
         x = conv_fn(x, conv_weight, bias)
         x = F.batch_norm(x, bn_running_mean, bn_running_var, bn_weight, bn_bias, training=bn_is_training, eps=bn_eps)
         return x
-    return _folded_quantized_qat_conv_bn_pattern
+    return _WrapperModule(_folded_quantized_qat_conv_bn_pattern)
 
 def _has_conv_bias_filter(
     match: "InternalMatch",

--- a/torch/ao/quantization/pt2e/representation/rewrite.py
+++ b/torch/ao/quantization/pt2e/representation/rewrite.py
@@ -1,5 +1,6 @@
 import torch
 from torch.fx import GraphModule
+from ..export_utils import _WrapperModule
 from ..utils import (
     get_aten_graph_module,
     remove_tensor_overload_for_qdq_ops,
@@ -501,8 +502,8 @@ class _RewriteInfo:
 _REWRITE_INFO_LIST = [
     _RewriteInfo(
         _DYNAMIC_QUANTIZED_LINEAR_EXAMPLE_INPUTS,
-        _qdq_dynamic_quantized_linear,
-        _reference_dynamic_quantized_linear,
+        _WrapperModule(_qdq_dynamic_quantized_linear),
+        _WrapperModule(_reference_dynamic_quantized_linear),
         partial(
             _replace_literals_with_existing_placeholders,
             literal_to_ph_idx={
@@ -522,55 +523,56 @@ _REWRITE_INFO_LIST = [
     ),
     _RewriteInfo(
         _QUANTIZED_LINEAR_EXAMPLE_INPUTS,
-        _qdq_quantized_linear,
-        _reference_quantized_linear,
+        _WrapperModule(_qdq_quantized_linear),
+        _WrapperModule(_reference_quantized_linear),
         _replace_literals_with_new_placeholders,
         _replace_literals_with_new_placeholders,
     ),
     _RewriteInfo(
         _QUANTIZED_CONV2d_EXAMPLE_INPUTS,
-        _qdq_quantized_conv2d,
-        _reference_quantized_conv2d,
+        _WrapperModule(_qdq_quantized_conv2d),
+        _WrapperModule(_reference_quantized_conv2d),
         partial(_replace_literals_with_new_placeholders, exclude_literals=[-1]),
         partial(_replace_literals_with_new_placeholders, exclude_literals=[-1]),
     ),
     _RewriteInfo(
         _QUANTIZED_ADD_OR_ADD_RELU_EXAMPLE_INPUTS,
-        _qdq_quantized_add_relu,
-        _reference_quantized_add_relu
+        _WrapperModule(_qdq_quantized_add_relu),
+        _WrapperModule(_reference_quantized_add_relu),
     ),
     _RewriteInfo(
         _QUANTIZED_ADD_OR_ADD_RELU_EXAMPLE_INPUTS,
-        _qdq_quantized_add,
-        _reference_quantized_add
+        _WrapperModule(_qdq_quantized_add),
+        _WrapperModule(_reference_quantized_add),
     ),
     _RewriteInfo(
         _QUANTIZED_MAX_POOL2D_EXAMPLE_INPUTS,
-        _qdq_quantized_max_pool2d,
-        _reference_quantized_max_pool2d,
+        _WrapperModule(_qdq_quantized_max_pool2d),
+        _WrapperModule(_reference_quantized_max_pool2d),
         _replace_literals_with_new_placeholders,
         _replace_literals_with_new_placeholders
     ),
     _RewriteInfo(
         _QUANTIZE_PER_TENSOR_INT8_EXAMPLE_INPUTS,
-        _quantize_per_tensor_int8,
-        _reference_quantize_per_tensor_int8),
+        _WrapperModule(_quantize_per_tensor_int8),
+        _WrapperModule(_reference_quantize_per_tensor_int8),
+    ),
     _RewriteInfo(
         _DEQUANTIZE_PER_TENSOR_INT8_EXAMPLE_INPUTS,
-        _dequantize_per_tensor_int8,
-        _reference_dequantize_per_tensor_int8
+        _WrapperModule(_dequantize_per_tensor_int8),
+        _WrapperModule(_reference_dequantize_per_tensor_int8),
     ),
     _RewriteInfo(
         _QUANTIZE_PER_CHANNEL_INT8_EXAMPLE_INPUTS,
-        _quantize_per_channel_int8,
-        _reference_quantize_per_channel_int8,
+        _WrapperModule(_quantize_per_channel_int8),
+        _WrapperModule(_reference_quantize_per_channel_int8),
         _replace_ph_qdq_per_channel_replacement,
         _replace_ph_qdq_per_channel_replacement
     ),
     _RewriteInfo(
         _DEQUANTIZE_PER_CHANNEL_INT8_EXAMPLE_INPUTS,
-        _dequantize_per_channel_int8,
-        _reference_dequantize_per_channel_int8,
+        _WrapperModule(_dequantize_per_channel_int8),
+        _WrapperModule(_reference_dequantize_per_channel_int8),
         _replace_ph_qdq_per_channel_replacement,
         _replace_ph_qdq_per_channel_replacement
     ),

--- a/torch/ao/quantization/quantizer/xnnpack_quantizer_utils.py
+++ b/torch/ao/quantization/quantizer/xnnpack_quantizer_utils.py
@@ -7,6 +7,7 @@ import torch
 import torch.nn.functional as F
 from torch._subclasses import FakeTensor
 from torch.ao.quantization.fx.utils import get_new_attr_name_with_prefix
+from torch.ao.quantization.pt2e.export_utils import _WrapperModule
 from torch.ao.quantization.pt2e.graph_utils import find_sequential_partitions
 from torch.ao.quantization.pt2e.utils import (
     _conv1d_bn_example_inputs,
@@ -445,7 +446,7 @@ def _do_annotate_conv_bn(
                 "output": output,
             }
 
-        return _conv_bn
+        return _WrapperModule(_conv_bn)
 
     # Needed for matching, otherwise the matches gets filtered out due to unused
     # nodes returned by batch norm


### PR DESCRIPTION
Summary: Today we don't allow free functions to be tracing callable in torch.export. As a part of migrating capture_preautograd_graph usages to torch.export, we need to ban free functions to capture_preautograd_graph  as well

Test Plan: CI

Differential Revision: D54319597


