### PR TITLE
Fix handling of torch.return_types in dynamo

### DIFF
--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -307,7 +307,12 @@ class UserDefinedClassVariable(UserDefinedVariable):
 
         elif is_namedtuple_cls(self.value):
             fields = namedtuple_fields(self.value)
-            field_defaults = self.value._field_defaults
+            # check if this a quasi-namedtuple or a real one
+            if getattr(self.value, "__module__") == "torch.return_types":
+                # create pseudo-defaults from values of the quasi-namedtuple
+                field_defaults = {f: v for f, v in zip(fields, args[0].items)}
+            else:
+                field_defaults = self.value._field_defaults
 
             items = list(args)
             items.extend([None] * (len(fields) - len(items)))

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -308,9 +308,9 @@ class UserDefinedClassVariable(UserDefinedVariable):
         elif is_namedtuple_cls(self.value):
             fields = namedtuple_fields(self.value)
             # check if this a quasi-namedtuple or a real one
-            if getattr(self.value, "__module__") == "torch.return_types":
+            if self.value.__module__ == "torch.return_types":
                 # create pseudo-defaults from values of the quasi-namedtuple
-                field_defaults = {f: v for f, v in zip(fields, args[0].items)}
+                field_defaults = dict(zip(fields, args[0].items))
             else:
                 field_defaults = self.value._field_defaults
 


### PR DESCRIPTION
Handle quasi-namedtuples as a special case in dynamo

Fixes #120651


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng