### PR TITLE
[dynamo] fix compiling Dataclass construction with default_factory

### DIFF
--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1,6 +1,7 @@
 # mypy: ignore-errors
 
 import contextlib
+import dataclasses
 import functools
 import inspect
 import itertools
@@ -1716,13 +1717,26 @@ class BuiltinVariable(VariableTracker):
 
         return None
 
+    def call_is_(self, tx, left, right):
+        # dataclasse.Field generates a piece of code in __init__ of the dataclass to check whether its using the deafult factory or not.
+        if (
+            left.python_type() is dataclasses._HAS_DEFAULT_FACTORY_CLASS
+            or right.python_type() is dataclasses._HAS_DEFAULT_FACTORY_CLASS
+        ):
+            if left.python_type() is not right.python_type():
+                return ConstantVariable.create(False)
+            # This might be a bit too cautious but it's safer that we
+            # also make sure they're the exact global object defined in python dataclasses.
+            return ConstantVariable.create(left.value is right.value)
+
+        return self._comparison(tx, left, right)
+
     call_eq = _comparison
     call_gt = _comparison
     call_lt = _comparison
     call_ge = _comparison
     call_le = _comparison
     call_ne = _comparison
-    call_is_ = _comparison
     call_is_not = _comparison
 
     call_all = _polyfill_call_impl("all")

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1718,7 +1718,9 @@ class BuiltinVariable(VariableTracker):
         return None
 
     def call_is_(self, tx, left, right):
-        # dataclasse.Field generates a piece of code in __init__ of the dataclass to check whether its using the deafult factory or not.
+        # This comparison happens when we inlining into the __init__ method of dataclasses.
+        # It contains a piece of code that check whether the passed in argument is.
+        # the default factory object to to determine a name for the field.
         if (
             left.python_type() is dataclasses._HAS_DEFAULT_FACTORY_CLASS
             or right.python_type() is dataclasses._HAS_DEFAULT_FACTORY_CLASS
@@ -1728,7 +1730,6 @@ class BuiltinVariable(VariableTracker):
             # This might be a bit too cautious but it's safer that we
             # also make sure they're the exact global object defined in python dataclasses.
             return ConstantVariable.create(left.value is right.value)
-
         return self._comparison(tx, left, right)
 
     call_eq = _comparison

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1719,7 +1719,7 @@ class BuiltinVariable(VariableTracker):
 
     def call_is_(self, tx, left, right):
         # This comparison happens when we inlining into the __init__ method of dataclasses.
-        # It contains a piece of code that check whether the passed in argument is.
+        # It contains a piece of code that check whether the argument is
         # the default factory object to to determine a name for the field.
         if (
             left.python_type() is dataclasses._HAS_DEFAULT_FACTORY_CLASS


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120827

Fixes https://github.com/pytorch/pytorch/issues/120108.

For following code:
```python
import torch
from dataclasses import dataclass, field
from typing import Any

@dataclass
class DClass:
   sharding_contexts: Any = field(default_factory=list)
   a: int = 1

def fn(c, x, inp_list):
    d = DClass(inp_list)
    d.sharding_contexts.append(x.sin())
    return d

c = DClass()
x = torch.randn(4)
inp_list = [torch.randn(4)]
opt_fn = torch.compile(fn, fullgraph=True, backend="eager")
opt_ret = opt_fn(c, x, inp_list)
```
The original graph break when inlining into DClass(inp_list) call, which looks like
```
Traceback (most recent call last):
  File "/home/yidi/local/pytorch/repro.py", line 20, in <module>
    opt_ret = opt_fn(c, x, inp_list)
  File "/home/yidi/local/pytorch/torch/_dynamo/eval_frame.py", line 455, in _fn
    return fn(*args, **kwargs)
  File "/home/yidi/local/pytorch/torch/_dynamo/convert_frame.py", line 919, in catch_errors
    return callback(frame, cache_entry, hooks, frame_state, skip=1)
  File "/home/yidi/local/pytorch/torch/_dynamo/convert_frame.py", line 400, in _convert_frame_assert
    return _compile(
  File "/home/yidi/local/miniconda3/envs/pytorch-3.10/lib/python3.10/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/home/yidi/local/pytorch/torch/_dynamo/convert_frame.py", line 675, in _compile
    guarded_code = compile_inner(code, one_graph, hooks, transform)
  File "/home/yidi/local/pytorch/torch/_dynamo/utils.py", line 262, in time_wrapper
    r = func(*args, **kwargs)
  File "/home/yidi/local/pytorch/torch/_dynamo/convert_frame.py", line 534, in compile_inner
    out_code = transform_code_object(code, transform)
  File "/home/yidi/local/pytorch/torch/_dynamo/bytecode_transformation.py", line 1033, in transform_code_object
    transformations(instructions, code_options)
  File "/home/yidi/local/pytorch/torch/_dynamo/convert_frame.py", line 165, in _fn
    return fn(*args, **kwargs)
  File "/home/yidi/local/pytorch/torch/_dynamo/convert_frame.py", line 499, in transform
    tracer.run()
  File "/home/yidi/local/pytorch/torch/_dynamo/symbolic_convert.py", line 2175, in run
    super().run()
  File "/home/yidi/local/pytorch/torch/_dynamo/symbolic_convert.py", line 831, in run
    and self.step()
  File "/home/yidi/local/pytorch/torch/_dynamo/symbolic_convert.py", line 794, in step
    getattr(self, inst.opname)(inst)
  File "/home/yidi/local/pytorch/torch/_dynamo/symbolic_convert.py", line 470, in wrapper
    return inner_fn(self, inst)
  File "/home/yidi/local/pytorch/torch/_dynamo/symbolic_convert.py", line 1245, in CALL_FUNCTION
    self.call_function(fn, args, {})
  File "/home/yidi/local/pytorch/torch/_dynamo/symbolic_convert.py", line 695, in call_function
    self.push(fn.call_function(self, args, kwargs))
  File "/home/yidi/local/pytorch/torch/_dynamo/variables/user_defined.py", line 355, in call_function
    var.call_method(tx, "__init__", args, kwargs)
  File "/home/yidi/local/pytorch/torch/_dynamo/variables/user_defined.py", line 566, in call_method
    return UserMethodVariable(method, self, source=source).call_function(
  File "/home/yidi/local/pytorch/torch/_dynamo/variables/functions.py", line 334, in call_function
    return super().call_function(tx, args, kwargs)
  File "/home/yidi/local/pytorch/torch/_dynamo/variables/functions.py", line 288, in call_function
    return super().call_function(tx, args, kwargs)
  File "/home/yidi/local/pytorch/torch/_dynamo/variables/functions.py", line 89, in call_function
    return tx.inline_user_function_return(
  File "/home/yidi/local/pytorch/torch/_dynamo/symbolic_convert.py", line 701, in inline_user_function_return
    return InliningInstructionTranslator.inline_call(self, fn, args, kwargs)
  File "/home/yidi/local/pytorch/torch/_dynamo/symbolic_convert.py", line 2311, in inline_call
    return cls.inline_call_(parent, func, args, kwargs)
  File "/home/yidi/local/pytorch/torch/_dynamo/symbolic_convert.py", line 2425, in inline_call_
    tracer.run()
  File "/home/yidi/local/pytorch/torch/_dynamo/symbolic_convert.py", line 831, in run
    and self.step()
  File "/home/yidi/local/pytorch/torch/_dynamo/symbolic_convert.py", line 794, in step
    getattr(self, inst.opname)(inst)
  File "/home/yidi/local/pytorch/torch/_dynamo/symbolic_convert.py", line 1664, in IS_OP
    self.COMPARE_OP(new_inst)
  File "/home/yidi/local/pytorch/torch/_dynamo/symbolic_convert.py", line 1233, in COMPARE_OP
    BuiltinVariable(supported_any[op]).call_function(
  File "/home/yidi/local/pytorch/torch/_dynamo/variables/builtin.py", line 697, in call_function
    result = handler(tx, *args, **kwargs)
  File "/home/yidi/local/pytorch/torch/_dynamo/variables/builtin.py", line 1580, in _comparison
    _unimplemented()
  File "/home/yidi/local/pytorch/torch/_dynamo/variables/builtin.py", line 1541, in _unimplemented
    unimplemented(f"comparison {typestr(left)} {op} {typestr(right)}")
  File "/home/yidi/local/pytorch/torch/_dynamo/exc.py", line 190, in unimplemented
    raise Unsupported(msg)
torch._dynamo.exc.Unsupported: comparison ListVariable() <built-in function is_> UserDefinedObjectVariable(_HAS_DEFAULT_FACTORY_CLASS)

from user code:
   File "/home/yidi/local/pytorch/repro.py", line 11, in fn
    d = DClass(inp_list)
  File "<string>", line 3, in __init__

Set TORCH_LOGS="+dynamo" and TORCHDYNAMO_VERBOSE=1 for more information


You can suppress this exception and fall back to eager by setting:
    import torch._dynamo
    torch._dynamo.config.suppress_errors = True
```

This PR modifies the call_is_ operator in builtin.py to support comparing a variable with dataclasses._HAS_DEFAULT_FACTORY defined [here](https://github.com/python/cpython/blob/3.12/Lib/dataclasses.py#L177-L180C1).

This is comparison is generated [here](https://github.com/python/cpython/blob/3.12/Lib/dataclasses.py#L499-L501).

It seems to me we don't need to guard on the constant variable because if left and right has different types, we could safely return False. Because dynamo will recompile if left/right changes its type 



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @aakhundov