### PR TITLE
Fix a potential race condition in the test decorators for enabling/disabling native funcol

### DIFF
--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -1287,12 +1287,8 @@ def with_native_funcol(use_native_funcol: bool, remove_arg: bool):
         def inner(*args, **kwargs):
             if remove_arg:
                 del kwargs["use_native_funcol"]
-            prev = funcol_impl._use_native_funcol
-            funcol_impl._use_native_funcol = use_native_funcol
-            try:
+            with patch.object(funcol_impl, '_use_native_funcol', new=use_native_funcol):
                 return fn(*args, **kwargs)
-            finally:
-                funcol_impl._use_native_funcol = prev
 
         return inner
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120833

Previous, we parametrize some tests to run with both native and py funcol by flipping a global variable. However, some of these tests are multi-threaded tests, and the parametrization mechanism could lead to race condition.

This PR changes the mechansim to use `mock.patch` which is applied on a per-thread basis.
