### PR TITLE
[fake_impls] fix max_seqlen return values in efficient_attention_forward

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2162,6 +2162,8 @@ class TestFakeTensor(TestCase):
                 ):
                     if not isinstance(fake_out, torch.Tensor):
                         self.assertTrue(not isinstance(real_out, torch.Tensor))
+                        if isinstance(fake_out, (bool, int, float)):
+                            self.assertEqual(fake_out, real_out)
                         continue
 
                     self.assertTrue(isinstance(fake_out, FakeTensor))

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -799,6 +799,7 @@ def meta__efficient_attention_forward(fake_mode, func, *args, **kwargs):
     value = kwargs["value"]
     cu_seqlens_q = kwargs["cu_seqlens_q"]
     max_seqlen_q = kwargs["max_seqlen_q"]
+    max_seqlen_k = kwargs["max_seqlen_k"]
     compute_log_sumexp = kwargs["compute_log_sumexp"]
     # unused: bias, cu_seqlens_k, max_seqlen_k, dropout_p, custom_mask_type, scale, causal_diagonal, seqlen_k
 
@@ -822,6 +823,7 @@ def meta__efficient_attention_forward(fake_mode, func, *args, **kwargs):
     if cu_seqlens_q is not None:
         assert max_seqlen_q is not None
         actual_max_seqlen_q = max_seqlen_q
+    actual_max_seqlen_k = max_seqlen_k if max_seqlen_k is not None else N
     logsumexp_dim = (
         math.ceil(actual_max_seqlen_q / 32) * 32 if compute_log_sumexp else 0
     )
@@ -838,7 +840,7 @@ def meta__efficient_attention_forward(fake_mode, func, *args, **kwargs):
     seed = convert_tensor(torch.empty((), dtype=torch.long, device="meta"), "cpu")
     offset = convert_tensor(torch.empty((), dtype=torch.long, device="meta"), "cpu")
 
-    return res, logsum_exp, seed, offset, M, N
+    return res, logsum_exp, seed, offset, actual_max_seqlen_q, actual_max_seqlen_k
 
 
 FAST_OP_IMPLEMENTATIONS = {}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120842
* #120682

To match the actual implementation, we should return the max_seqlen_q/k, not M, N, when in the sparse case

https://github.com/pytorch/pytorch/blob/7e185277cd6fadada367fa6318beff9e4127570a/aten/src/ATen/native/transformers/cuda/attention.cu#L981-L996

Note that although the .cu file sets max_seqlen_k = 0 in the sparse case, it actually returns max_seqlen_k or N:

https://github.com/pytorch/pytorch/blob/7e185277cd6fadada367fa6318beff9e4127570a/aten/src/ATen/native/transformers/cuda/attention.cu#L1224-L1231

Tests - added in the next PR (#102839, which also fixes other parts of the test_fake tests so that we can un-xfail them and actually run the tests)