### PR TITLE
[rocm][cmake] correctly check the ROCM_SOURCE_DIR environment

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1960,7 +1960,7 @@ if(USE_KINETO)
   endif()
 
   if(NOT LIBKINETO_NOROCTRACER)
-    if(NOT ENV{ROCM_SOURCE_DIR})
+    if("$ENV{ROCM_SOURCE_DIR}" STREQUAL "")
       set(ENV{ROCM_SOURCE_DIR} "/opt/rocm")
     endif()
   endif()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120858

The existing use of "if(NOT ENV{ROCM_SOURCE_DIR})" seems to be
not working correctly, e.g.

```
$ cmake --version
cmake version 3.26.4

$ cat CMakeList.txt
cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
project(FOO)

if(NOT ENV{ROCM_SOURCE_DIR})
  message(INFO ": not defined 1")
else()
  message(INFO ": defined 1: $ENV{ROCM_SOURCE_DIR}")
endif()

if("$ENV{ROCM_SOURCE_DIR}" STREQUAL "")
  message(INFO ": not defined 2")
else()
  message(INFO ": defined 2: $ENV{ROCM_SOURCE_DIR}")
endif()
$ ROCM_SOURCE_DIR=/tmp cmake .
INFO: not defined 1
INFO: defined 2: /tmp
-- Configuring done (0.0s)
-- Generating done (0.0s)
-- Build files have been written to: /home/yangche/tmp/tmp
```

This PR replace it with a STREQUAL check. Note that the choice
of STREQUAL is to avoid cases like:

```
$ ROCM_SOURCE_DIR= cmake .
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang