### PR TITLE
fix the scale dot attention doc

### DIFF
--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -608,7 +608,7 @@ at::Tensor post_process_flash_output(
 //     key (Tensor): Key tensor; shape (N, ..., S, E)
 //     value (Tensor): Value tensor; shape (N, ..., S, E)
 //     attn_mask (optional Tensor): Attention mask; shape must be broadcastable to the shape of attention weights,
-//     which is :math:`(N,..., L, S)`.
+//     which is (N,..., L, S)
 //     Two types of masks are supported.
 //       A boolean mask where a value of True indicates that the element *should* take part in attention.
 //       A float mask of the same type as query, key, value that is added to the attention score.

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -608,8 +608,7 @@ at::Tensor post_process_flash_output(
 //     key (Tensor): Key tensor; shape (N, ..., S, E)
 //     value (Tensor): Value tensor; shape (N, ..., S, E)
 //     attn_mask (optional Tensor): Attention mask; shape must be broadcastable to the shape of attention weights,
-//     which is (N,..., L, S)
-//     Two types of masks are supported.
+//     which is (N,..., L, S). Two types of masks are supported.
 //       A boolean mask where a value of True indicates that the element *should* take part in attention.
 //       A float mask of the same type as query, key, value that is added to the attention score.
 //     dropout_p (float): Dropout probability; if greater than 0.0, dropout is applied

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -607,8 +607,10 @@ at::Tensor post_process_flash_output(
 //     query (Tensor): Query tensor; shape (N, ..., L, E)
 //     key (Tensor): Key tensor; shape (N, ..., S, E)
 //     value (Tensor): Value tensor; shape (N, ..., S, E)
-//     attn_mask (optional Tensor): Attention mask; shape (N, ..., L, S) or (L, S). Currently, only a boolean mask
-//         is supported, where a value of True indicates that the element *should* take part in attention.
+//     attn_mask (optional Tensor): Attention mask; shape (..., S) and broadcastable to (N, ..., L, S). 
+//     Two types of masks are supported.
+//       A boolean mask where a value of True indicates that the element *should* take part in attention.
+//       A float mask of the same type as query, key, value that is added to the attention score.
 //     dropout_p (float): Dropout probability; if greater than 0.0, dropout is applied
 //     need_attn_weights (bool): If true, the second return value will contain the attention weights used;
 //         otherwise, the second return value is unspecified
@@ -617,9 +619,8 @@ at::Tensor post_process_flash_output(
 //         to get specialized support for causal masks (and other types of masking e.g. local attention / block
 //         sparse masks) via tensor subclassing, allowing for a leaner API.
 //
-// Returns a tuple containing:
+// Returns a tensor:
 //     output (Tensor): Attention output; shape (N, ..., L, E)
-//     attn_weights (Tensor): Attention weighting; shape (N, ..., L, S)
 //
 // Shape legend:
 //     N: Batch size

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -607,7 +607,8 @@ at::Tensor post_process_flash_output(
 //     query (Tensor): Query tensor; shape (N, ..., L, E)
 //     key (Tensor): Key tensor; shape (N, ..., S, E)
 //     value (Tensor): Value tensor; shape (N, ..., S, E)
-//     attn_mask (optional Tensor): Attention mask; shape (..., S) and broadcastable to (N, ..., L, S). 
+//     attn_mask (optional Tensor): Attention mask; shape must be broadcastable to the shape of attention weights,
+//     which is :math:`(N,..., L, S)`.
 //     Two types of masks are supported.
 //       A boolean mask where a value of True indicates that the element *should* take part in attention.
 //       A float mask of the same type as query, key, value that is added to the attention score.

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -608,9 +608,9 @@ at::Tensor post_process_flash_output(
 //     key (Tensor): Key tensor; shape (N, ..., S, E)
 //     value (Tensor): Value tensor; shape (N, ..., S, E)
 //     attn_mask (optional Tensor): Attention mask; shape must be broadcastable to the shape of attention weights,
-//     which is (N,..., L, S). Two types of masks are supported.
-//       A boolean mask where a value of True indicates that the element *should* take part in attention.
-//       A float mask of the same type as query, key, value that is added to the attention score.
+//         which is (N,..., L, S). Two types of masks are supported.
+//         A boolean mask where a value of True indicates that the element *should* take part in attention.
+//         A float mask of the same type as query, key, value that is added to the attention score.
 //     dropout_p (float): Dropout probability; if greater than 0.0, dropout is applied
 //     need_attn_weights (bool): If true, the second return value will contain the attention weights used;
 //         otherwise, the second return value is unspecified

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5032,7 +5032,8 @@ Args:
     query (Tensor): Query tensor; shape :math:`(N, ..., L, E)`.
     key (Tensor): Key tensor; shape :math:`(N, ..., S, E)`.
     value (Tensor): Value tensor; shape :math:`(N, ..., S, Ev)`.
-    attn_mask (optional Tensor): Attention mask; shape :math:`(N, ..., L, S)`. Two types of masks are supported.
+    attn_mask (optional Tensor): Attention mask; shape :math:`(..., S)` and and broadcastable to :math:`(N,..., L, S)`.
+    Two types of masks are supported.
         A boolean mask where a value of True indicates that the element *should* take part in attention.
         A float mask of the same type as query, key, value that is added to the attention score.
     dropout_p (float): Dropout probability; if greater than 0.0, dropout is applied

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5032,7 +5032,8 @@ Args:
     query (Tensor): Query tensor; shape :math:`(N, ..., L, E)`.
     key (Tensor): Key tensor; shape :math:`(N, ..., S, E)`.
     value (Tensor): Value tensor; shape :math:`(N, ..., S, Ev)`.
-    attn_mask (optional Tensor): Attention mask; shape :math:`(..., S)` and and broadcastable to :math:`(N,..., L, S)`.
+    attn_mask (optional Tensor): Attention mask; shape must be broadcastable to the shape of attention weights,
+    which is :math:`(N,..., L, S)`.
     Two types of masks are supported.
         A boolean mask where a value of True indicates that the element *should* take part in attention.
         A float mask of the same type as query, key, value that is added to the attention score.

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5033,8 +5033,7 @@ Args:
     key (Tensor): Key tensor; shape :math:`(N, ..., S, E)`.
     value (Tensor): Value tensor; shape :math:`(N, ..., S, Ev)`.
     attn_mask (optional Tensor): Attention mask; shape must be broadcastable to the shape of attention weights,
-    which is :math:`(N,..., L, S)`.
-    Two types of masks are supported.
+        which is :math:`(N,..., L, S)`. Two types of masks are supported.
         A boolean mask where a value of True indicates that the element *should* take part in attention.
         A float mask of the same type as query, key, value that is added to the attention score.
     dropout_p (float): Dropout probability; if greater than 0.0, dropout is applied


### PR DESCRIPTION
Fixes #120810

The code verifies the broadcast behavior (from the issue),
```
import torch

B = 3
S = 5
L = 7
E = 16
EV = 32
additional_batches = [2, 4]

query_shape = [B] + additional_batches + [L, E]
key_shape = [B] + additional_batches + [S, E]
value_shape = [B] + additional_batches + [S, EV]


query = torch.rand(*query_shape)
key = torch.rand(*key_shape)
value = torch.rand(*value_shape)
mask = torch.zeros((1, 1, S), dtype=torch.bool)
mask[:, :, S // 2 :] = True

# query.to("cuda")
# key.to("cuda")
# value.to("cuda")
# mask.to("cuda")


attention = torch.nn.functional.scaled_dot_product_attention(query, key, value, mask)

print(f"query shape = {query.shape}")
print(f"key shape = {key.shape}")
print(f"value shape = {value.shape}")
print(f"mask shape = {mask.shape}")
print(f"attention shape = {attention.shape}")

#in both CPU and cuda, output shape is:
# query shape = torch.Size([3, 2, 4, 7, 16])
# key shape = torch.Size([3, 2, 4, 5, 16])
# value shape = torch.Size([3, 2, 4, 5, 32])
# mask shape = torch.Size([1, 1, 5])
# attention shape = torch.Size([3, 2, 4, 7, 32])

## test add is broadcasting mask to query@(key.mT)
res = query@(key.mT)
print(res.shape)
res2 = torch.add(res, mask)
print(res2.shape)
```

At code level, in the default backend,
https://github.com/pytorch/pytorch/blob/ab38354887fe86e611f6f5bef0b9d7cf72e27d8b/aten/src/ATen/native/transformers/attention.cpp#L735

the add operation is broadcasting the `attn_mask` to `auto attn = at::matmul(query, key.transpose(-2, -1) * scaling_factor);`

- Changed the doc in [torch/nn/functional.py](https://github.com/pytorch/pytorch/pull/120859/files#diff-c358c214f663ba0c8b9c6846fbe0042fa29494cf02fe4714a17dcd0d268b035b).
- Also fixed a few inconsistencies in the cpp comments.


@mikaylagawarecki 
