### PR TITLE
[FSDP2][DCP][DSD] Add test to ensure FSDP2 model/optim state_dict work after a full training loop

### DIFF
--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -3,12 +3,16 @@
 import copy
 import sys
 from itertools import chain
-from typing import Callable, Tuple, Union
+from typing import Callable, Tuple, Type, Union
 
 import torch
 import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed._composable import fully_shard, replicate
+
+# importing fully_shard as FSDP2 since the original fully_shard is used in this test.
+# TODO: remove old composable fully_shard so that we don't have to import new fully_shard as FSDP2
+from torch.distributed._composable.fsdp import fully_shard as FSDP2
 from torch.distributed._shard.sharded_tensor import ShardedTensor
 from torch.distributed._tensor import DTensor, init_device_mesh
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
@@ -195,9 +199,26 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         self,
         *,
         reshard_after_forward: Union[bool, int],
-        optim: Optimizer,
+        optimizer_class: Type[Optimizer],
         compile_model: bool,
-    )
+    ):
+        def init_model_optim():
+            orig_model = CompositeParamModel(device=torch.device("cuda"))
+            orig_optim = optimizer_class(orig_model.parameters(), lr=1e-3)
+            copy_optim = optimizer_class(orig_model.parameters(), lr=1e-3)
+
+            dist_model = FSDP2(
+                copy.deepcopy(orig_model),
+                reshard_after_forward=reshard_after_forward,
+            )
+
+            if compile_model:
+                dist_model = torch.compile(dist_model)
+            dist_optim = optimizer_class(dist_model.parameters(), lr=1e-3)
+
+            return orig_model, orig_optim, copy_optim, dist_model, dist_optim
+
+        self._test_save_load(init_model_optim)
 
     @with_comms
     @skip_if_lt_x_gpu(2)
@@ -229,8 +250,9 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         self.run_subtests(
             {
                 "reshard_after_forward": [True, False],
-                "optim": [torch.optim.Adam, torch.optim.AdamW],
-                "compile_model": [False, True],
+                # TODO: Add torch.optim.AdamW to unit test.
+                "optimizer_class": [torch.optim.Adam],
+                "compile_model": [True, False],
             },
             self._test_fsdp2,
         )


### PR DESCRIPTION
This PR adds tests to test distributed state dict work properly for FSDP2's model and optimizer state_dict after a full training loop. 

We test the combination of these options on a evenly sharded model. 
```
{
    "reshard_after_forward": [True, False],
    "optimizer_class": [torch.optim.Adam],
    "compile_model": [True, False],
},
```

Followup: 1. Add test for unevenly sharded model. 2. Add test to include `torch.optim.AdamW` (seems to have some gaps currently, still investigating)

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @tianyu-l @wconstab @yf225 @LucasLLC