### PR TITLE
Make translation validation more user friendly

### DIFF
--- a/torch/fx/experimental/recording.py
+++ b/torch/fx/experimental/recording.py
@@ -263,7 +263,7 @@ def record_shapeenv_event(*, save_tracked_fakes: bool = False) -> Callable:
                 self.events.append(event)
                 try:
                     return event.run(self)
-                except:
+                except Exception:
                     self.events.pop()
                     raise
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120880

Two main changes:

- Don't rethrow the exception when we fail in TV, just throw the entire
  thing and trust the user will inspect logs / backtrace to see we
  failed in TV

- Don't add an event to the TV logs until we've confirmed that the event
  actually runs without erroring.  This prevents us from putting events
  that e.g., fail because the guard on data dependent size, and the
  failing in TV.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>