### PR TITLE
[Dynamo] Fix function overrides

### DIFF
--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -382,18 +382,19 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             assert not (args or kwargs)
             install_guard(TorchFunctionDisableVariable._guards_singleton)
             return ConstantVariable.create(tx.output.torch_function_enabled)
-        elif self.value is torch.overrides.has_torch_function:
-            assert not (kwargs or len(args) != 1)
-            return ConstantVariable.create(
-                any(has_torch_function(a) for a in args[0].unpack_var_sequence(tx)),
-            )
         elif self.value in (
+            torch.overrides.has_torch_function,
             torch.overrides.has_torch_function_variadic,
             torch.overrides.has_torch_function_unary,
         ):
             assert not kwargs
+            elems = (
+                args[0].unpack_var_sequence(tx)
+                if len(args) == 1 and isinstance(args[0], TupleVariable)
+                else args
+            )
             return ConstantVariable.create(
-                any(has_torch_function(a) for a in args),
+                any(has_torch_function(x) for x in elems),
             )
         elif any(
             self.value is method

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -382,8 +382,12 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             assert not (args or kwargs)
             install_guard(TorchFunctionDisableVariable._guards_singleton)
             return ConstantVariable.create(tx.output.torch_function_enabled)
+        elif self.value is torch.overrides.has_torch_function:
+            assert not (kwargs or len(args) != 1)
+            return ConstantVariable.create(
+                any(has_torch_function(a) for a in args[0].unpack_var_sequence(tx)),
+            )
         elif self.value in (
-            torch.overrides.has_torch_function,
             torch.overrides.has_torch_function_variadic,
             torch.overrides.has_torch_function_unary,
         ):


### PR DESCRIPTION
To check existence of `__torch_function__`, the code intended to iterate each element but got `TupleVariable` when the ordinary `has_torch_function()` was being used. Needs further unpack in this case

Fixes #120653


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @aakhundov