### PR TITLE
[EZ][BE] Fix ResourceWarning

### DIFF
--- a/test/quantization/core/test_docs.py
+++ b/test/quantization/core/test_docs.py
@@ -55,8 +55,8 @@ class TestQuantizationDocs(QuantizationTestCase):
 
         path_to_file = get_correct_path(path_from_pytorch)
         if path_to_file:
-            file = open(path_to_file)
-            content = file.readlines()
+            with open(path_to_file) as file:
+                content = file.readlines()
 
             # it will register as having a newline at the end in python
             if "\n" not in unique_identifier:


### PR DESCRIPTION
By closing the file handle

Fixes 
```
/Users/nshulga/git/pytorch/pytorch/test/quantization/core/test_docs.py:132: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/nshulga/git/pytorch/pytorch/docs/source/quantization.rst' mode='r' encoding='UTF-8'>
```
