### PR TITLE
[dtensor] change distribute_module input/output_fn to accept module

### DIFF
--- a/test/distributed/_tensor/test_api.py
+++ b/test/distributed/_tensor/test_api.py
@@ -185,10 +185,10 @@ class DTensorAPITest(DTensorTestBase):
         module_to_replicate = MyModel(20, 1, device=self.device_type)
 
         # mark input sharding on dim 0
-        def input_fn(inputs, device_mesh):
+        def input_fn(mod, inputs, device_mesh):
             return DTensor.from_local(inputs[0], device_mesh, [Shard(0)])
 
-        def output_fn(outputs, device_mesh):
+        def output_fn(mod, outputs, device_mesh):
             assert isinstance(outputs, DTensor)
             return outputs.to_local()
 
@@ -207,7 +207,7 @@ class DTensorAPITest(DTensorTestBase):
         # full replicate (even on inputs)
         model = MyModel(10, 10, device=self.device_type)
 
-        def replicate_input_fn(inputs, device_mesh):
+        def replicate_input_fn(mod, inputs, device_mesh):
             return DTensor.from_local(inputs[0], device_mesh, [Replicate()])
 
         replica_model = distribute_module(

--- a/test/distributed/_tensor/test_api.py
+++ b/test/distributed/_tensor/test_api.py
@@ -223,6 +223,34 @@ class DTensorAPITest(DTensorTestBase):
         self.assertTrue(isinstance(param_grad.placements[0], Replicate))
 
     @with_comms
+    def test_distribute_module_input_fn_output_fn_warning(self):
+        device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
+
+        # fully replicate all linear modules
+        module_to_replicate = MyModel(20, 1, device=self.device_type)
+
+        # mark input sharding on dim 0
+        def input_fn(inputs, device_mesh):
+            return DTensor.from_local(inputs[0], device_mesh, [Shard(0)])
+
+        def output_fn(outputs, device_mesh):
+            assert isinstance(outputs, DTensor)
+            return outputs.to_local()
+
+        with self.assertWarnsRegex(UserWarning, "Deprecating"):
+            replica_module = distribute_module(
+                module_to_replicate,
+                device_mesh,
+                input_fn=input_fn,
+                output_fn=output_fn,
+            )
+
+        input_tensor = torch.randn(5, 20, device=self.device_type)
+        local_out = replica_module(input_tensor)
+        self.assertIsInstance(local_out, torch.Tensor)
+        self.assertNotIsInstance(local_out, DTensor)
+
+    @with_comms
     def test_distribute_module_meta(self):
         # If  the model is too big, the user may first the create entire model on the meta device and then initialize
         # it on the device in the partition function.

--- a/test/distributed/_tensor/test_optimizers.py
+++ b/test/distributed/_tensor/test_optimizers.py
@@ -38,14 +38,14 @@ def shard_fn(name, module, device_mesh):
 
 
 # prepare input
-def input_fn(inputs, device_mesh):
+def input_fn(mod, inputs, device_mesh):
     # split the input tensor to be sharded input
     dist_inp = distribute_tensor(inputs[0], device_mesh, [Shard(0)])
     return dist_inp
 
 
 # prepare output to be local torch.Tensor
-def output_fn(outputs, device_mesh):
+def output_fn(mod, outputs, device_mesh):
     assert isinstance(outputs, DTensor)
     return outputs.redistribute(placements=[Replicate()] * device_mesh.ndim).to_local()
 

--- a/test/distributed/fsdp/test_fsdp_tp_integration.py
+++ b/test/distributed/fsdp/test_fsdp_tp_integration.py
@@ -82,11 +82,11 @@ class RMSNormPython(torch.nn.Module):
 
 
 def distribute_rmsnorm(module, device_mesh):
-    def prepare_input_fn(inputs, device_mesh):
+    def prepare_input_fn(mod, inputs, device_mesh):
         shard_tensor = DTensor.from_local(inputs[0], device_mesh, [Shard(0)])
         return shard_tensor
 
-    def prepare_output_fn(outputs, device_mesh):
+    def prepare_output_fn(mod, outputs, device_mesh):
         return outputs.to_local()
 
     return distribute_module(

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import warnings
-from typing import Callable, cast, Optional, Sequence, Tuple
+from typing import Any, Callable, cast, Optional, Sequence, Tuple
 
 import torch
 
@@ -643,8 +643,8 @@ def distribute_module(
     module: nn.Module,
     device_mesh: Optional[DeviceMesh] = None,
     partition_fn: Optional[Callable[[str, nn.Module, DeviceMesh], None]] = None,
-    input_fn: Optional[Callable[..., None]] = None,
-    output_fn: Optional[Callable[..., None]] = None,
+    input_fn: Optional[Callable[[nn.Module, Any, DeviceMesh], None]] = None,
+    output_fn: Optional[Callable[[nn.Module, Any, DeviceMesh], None]] = None,
 ) -> nn.Module:
     """
     This function converts all module parameters to :class:`DTensor` parameters
@@ -704,11 +704,11 @@ def distribute_module(
 
     # register input_fn as module forward pre hook
     if input_fn is not None:
-        module.register_forward_pre_hook(lambda _, inputs: input_fn(inputs, device_mesh))  # type: ignore[misc]
-    # register input_fn as module forward hook
+        module.register_forward_pre_hook(lambda mod, inputs: input_fn(mod, inputs, device_mesh))  # type: ignore[misc]
+    # register output_fn as module forward hook
     if output_fn is not None:
         module.register_forward_hook(
-            lambda mod, inputs, outputs: output_fn(outputs, device_mesh)  # type: ignore[misc]
+            lambda mod, inputs, outputs: output_fn(mod, outputs, device_mesh)  # type: ignore[misc]
         )
 
     return module

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -1,4 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
+import inspect
 import warnings
 from typing import Any, Callable, cast, Optional, Sequence, Tuple
 
@@ -704,11 +705,43 @@ def distribute_module(
 
     # register input_fn as module forward pre hook
     if input_fn is not None:
-        module.register_forward_pre_hook(lambda mod, inputs: input_fn(mod, inputs, device_mesh))  # type: ignore[misc]
+        # check the input_fn signature
+        num_args = len(inspect.signature(input_fn).parameters)
+        if num_args == 2:
+            # input_fn only takes in inputs and device mesh
+            warnings.warn(
+                "Deprecating input_fn that takes two arguments (inputs, device_mesh), "
+                "please use input_fn that takes in (module, inputs, device_mesh) instead!",
+            )
+            module.register_forward_pre_hook(lambda _, inputs: input_fn(inputs, device_mesh))  # type: ignore[call-arg]
+        elif num_args == 3:
+            # input_fn takes in module, inputs, device mesh
+            module.register_forward_pre_hook(
+                lambda mod, inputs: input_fn(mod, inputs, device_mesh)
+            )
+        else:
+            raise ValueError(
+                f"input_fn should take in 3 arguments, but got {num_args} arguments!"
+            )
     # register output_fn as module forward hook
     if output_fn is not None:
-        module.register_forward_hook(
-            lambda mod, inputs, outputs: output_fn(mod, outputs, device_mesh)  # type: ignore[misc]
-        )
+        num_args = len(inspect.signature(output_fn).parameters)
+        if num_args == 2:
+            # output_fn only takes in outputs and device mesh
+            warnings.warn(
+                "Deprecating output_fn that takes two arguments (inputs, device_mesh), "
+                "please use output_fn that takes in (module, inputs, device_mesh) instead!",
+            )
+            module.register_forward_hook(
+                lambda mod, inputs, outputs: output_fn(outputs, device_mesh)  # type: ignore[call-arg]
+            )
+        elif num_args == 3:
+            module.register_forward_hook(
+                lambda mod, inputs, outputs: output_fn(mod, outputs, device_mesh)
+            )
+        else:
+            raise ValueError(
+                f"output_fn should take in 3 arguments, but got {num_args} arguments!"
+            )
 
     return module

--- a/torch/distributed/_tensor/examples/checkpoint_example.py
+++ b/torch/distributed/_tensor/examples/checkpoint_example.py
@@ -76,10 +76,10 @@ def gen_partial_replicate_2d(model: nn.Module, mesh: DeviceMesh) -> nn.Module:
                 module.register_parameter(name, dist_param)
 
     # mark input replicating on mesh
-    def input_fn(inputs, device_mesh):
+    def input_fn(mod, inputs, device_mesh):
         return DTensor.from_local(inputs[0], device_mesh, [Replicate(), Replicate()])
 
-    def output_fn(outputs, device_mesh):
+    def output_fn(mod, outputs, device_mesh):
         assert isinstance(outputs, DTensor)
         return outputs.to_local()
 
@@ -117,10 +117,10 @@ def gen_model_param_in_submesh(model: nn.Module, sub_mesh: DeviceMesh) -> nn.Mod
                 module.register_parameter(name, dist_param)
 
     # mark input replicating on mesh
-    def input_fn(inputs, device_mesh):
+    def input_fn(mod, inputs, device_mesh):
         return DTensor.from_local(inputs[0], device_mesh, [Replicate()])
 
-    def output_fn(outputs, device_mesh):
+    def output_fn(mod, outputs, device_mesh):
         assert isinstance(outputs, DTensor)
         return outputs.to_local()
 

--- a/torch/distributed/tensor/parallel/style.py
+++ b/torch/distributed/tensor/parallel/style.py
@@ -83,7 +83,7 @@ class ColwiseParallel(ParallelStyle):
         self.use_local_output = use_local_output
 
     @staticmethod
-    def _prepare_input_fn(input_layouts, desired_input_layouts, inputs, device_mesh):
+    def _prepare_input_fn(input_layouts, desired_input_layouts, mod, inputs, device_mesh):
         # TODO: figure out dynamo support for instance method and switch this to instance method
 
         # annotate module input placements/sharding with input_layouts
@@ -115,7 +115,7 @@ class ColwiseParallel(ParallelStyle):
             module.register_parameter(name, dist_param)
 
     @staticmethod
-    def _prepare_output_fn(output_layouts, use_local_output, outputs, device_mesh):
+    def _prepare_output_fn(output_layouts, use_local_output, mod, outputs, device_mesh):
         # outputs is a shard on last dimension DTensor, i.e. Shard(-1)
         outputs = outputs.redistribute(placements=output_layouts)
         # back to local tensor
@@ -184,7 +184,7 @@ class RowwiseParallel(ParallelStyle):
         self.use_local_output = use_local_output
 
     @staticmethod
-    def _prepare_input_fn(input_layouts, desired_input_layouts, inputs, device_mesh):
+    def _prepare_input_fn(input_layouts, desired_input_layouts, mod, inputs, device_mesh):
         input_tensor = inputs[0]
         if not isinstance(input_tensor, DTensor):
             input_tensor = DTensor.from_local(input_tensor, device_mesh, input_layouts, run_check=False)
@@ -214,7 +214,7 @@ class RowwiseParallel(ParallelStyle):
             module.register_parameter(name, dist_param)
 
     @staticmethod
-    def _prepare_output_fn(output_layouts, use_local_output, outputs, device_mesh):
+    def _prepare_output_fn(output_layouts, use_local_output, mod, outputs, device_mesh):
         # Rowwise sharding produces partial output, depending on output layouts:
         # 1. to replicate -> allreduce
         # 2. to shard -> reduce_scatter


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120895

This is a BC breaking change to distribute_module. The underlying rationle
for this change is that sometimes in the input_fn/output_fn, user would want
to access to the current module for some attributes. This might not be
common enough, but in some cases it's worth to access to the module.

An outstanding use case we want to support is float8, if we want to make
float8 works with the TP API, the input_fn/output_fn of TP parallel
styles would need to get access to the module, where the module might
encapsulates `dynamic_linear.emulate` attribute, that is useful for
input/output casting

Since this is needed for fp8 and DTensor still under prototype release,
I feel it's worth the change and it's better we make the change as
early.

Right now making it a soft BC breaking, which means we maintain BC still
but throw deprecation messages.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @ezyang @gchanan