### PR TITLE
fix dupe deprecated warning in dynamo export

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1173,13 +1173,14 @@ def export(
     def inner(*args, **kwargs):
         nonlocal constraints
         if constraints is not None:
-            warnings.warn(
-                "Using `constraints` to specify dynamic shapes for export is DEPRECATED "
-                "and will not be supported in the future. "
-                "Please use `dynamic_shapes` instead (see docs on `torch.export.export`).",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            if _log_export_usage:
+                warnings.warn(
+                    "Using `constraints` to specify dynamic shapes for export is DEPRECATED "
+                    "and will not be supported in the future. "
+                    "Please use `dynamic_shapes` instead (see docs on `torch.export.export`).",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
         else:
             constraints = _process_dynamic_shapes(_f, args, kwargs, dynamic_shapes)
         f = _f

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -173,6 +173,7 @@ def capture_pre_autograd_graph(
             decomposition_table=decomp_table,
             pre_dispatch=True,
             aten_graph=True,
+            _log_export_usage=False,
         )(
             *args,
             **kwargs,

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -323,7 +323,6 @@ def _export_to_torch_ir(
     if _log_export_usage:
         log_export_usage(event="export.private_api", flags={"_export_to_torch_ir"})
 
-    constraints = constraints or []
     kwargs = kwargs or {}
 
     if not isinstance(args, tuple):


### PR DESCRIPTION
Summary:
When we convert `dynamic_shapes` to `constraints` and pass them to `_dynamo.export`, we shouldn't give a deprecation warning. Such conversion happens when calling `torch.export.export`, e.g. But it can also happen when calling `capture_pre_autograd_graph` (which itself has this deprecation warning when `constraints` are passed directly as well).

Since `_log_export_usage` is an indicator of a top-level call (it is `True` by default but set to `False`, or at least passed through, by callers), we can (ab)use it to indicate when to give this deprecation warning.

Test Plan: none

Differential Revision: D54350172


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng