### PR TITLE
Exclude operators that produce unbacked symbols

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -1435,7 +1435,6 @@ if HAS_CUDA and not TEST_WITH_ASAN:
             self.assertEqual(foo(torch.tensor(6.0, device="cuda")), 6.0)
 
         @torch._dynamo.config.patch("capture_dynamic_output_shape_ops", True)
-        @unittest.expectedFailure
         def test_incompatible_cudagraph_ops_nonzero(self):
             @torch.compile(mode="reduce-overhead")
             def foo(x):

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -638,6 +638,8 @@ def any_is_symbolic(*args: Any) -> bool:
 
 
 def has_incompatible_cudagraph_ops(gm):
+    from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
+
     forbidden_set = {
         "aten._fused_moving_avg_obs_fq_helper.default",
         "aten._fused_moving_avg_obs_fq_helper_functional.default",
@@ -666,6 +668,8 @@ def has_incompatible_cudagraph_ops(gm):
         )
     for node in gm.graph.nodes:
         if str(node.target) in forbidden_set:
+            return True
+        if (val := node.meta.get("val")) is not None and free_unbacked_symbols(val):
             return True
     return False
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -282,7 +282,7 @@ def _iterate_exprs(val: Union[SymInt, torch.Tensor]) -> Iterable[sympy.Basic]:
     elif isinstance(val, (tuple, list)):
         for s in val:
             yield from _iterate_exprs(s)
-    elif isinstance(val, None):
+    elif val is None:
         pass
     else:
         raise AssertionError(f"cannot extract sympy expressions from {val} {type(val)}")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120917

Unbacked symbols vary at runtime which means they are not CUDA
graphable.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire