### PR TITLE
[ATen][CUDA][CUBLAS] cublasLtMatmul increase workspace_size

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -189,7 +189,9 @@ static size_t _parseChosenWorkspaceSize() {
   }
 #else
   cudaDeviceProp* p = at::cuda::getDeviceProperties(c10::cuda::current_device());
-  if (p->major == 8) {
+  // Keep workspace_size = 1024 for small Ampere GPUs
+  // See https://github.com/pytorch/pytorch/pull/120925#issuecomment-1977556485
+  if (p->major == 8 && p->total_memory / 1073741824 >= 24) {
     workspace_size = 4096;
   } else if (p->major >= 9) {
     workspace_size = 32768;

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -179,7 +179,7 @@ uint32_t _getAlignment(uintptr_t address) {
 }
 #endif
 
-static size_t _parseChosenSize() {
+static size_t _parseChosenWorkspaceSize() {
   const char * val = getenv("CUBLASLT_WORKSPACE_SIZE");
   size_t workspace_size = 1024;
 #ifdef USE_ROCM

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -191,7 +191,7 @@ static size_t _parseChosenWorkspaceSize() {
   cudaDeviceProp* p = at::cuda::getDeviceProperties(c10::cuda::current_device());
   // Keep workspace_size = 1024 for small Ampere GPUs
   // See https://github.com/pytorch/pytorch/pull/120925#issuecomment-1977556485
-  if (p->major == 8 && p->total_memory / 1073741824 >= 24) {
+  if (p->major == 8 && p->totalGlobalMem / 1073741824 >= 24) {
     workspace_size = 4096;
   } else if (p->major >= 9) {
     workspace_size = 32768;

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -179,18 +179,19 @@ uint32_t _getAlignment(uintptr_t address) {
 }
 #endif
 
-static size_t _parseChosenWorkspaceSize() {
+static size_t _parseChosenSize() {
   const char * val = getenv("CUBLASLT_WORKSPACE_SIZE");
+  size_t workspace_size = 1024;
 #ifdef USE_ROCM
   if (!val) {
     // accept either env var
     val = getenv("HIPBLASLT_WORKSPACE_SIZE");
   }
-  size_t workspace_size = 1024;
 #else
-  size_t workspace_size = 4096;
   cudaDeviceProp* p = at::cuda::getDeviceProperties(c10::cuda::current_device());
-  if (p->major >= 9) {
+  if (p->major == 8) {
+    workspace_size = 4096;
+  } else if (p->major >= 9) {
     workspace_size = 32768;
   }
 #endif

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -190,8 +190,7 @@ static size_t _parseChosenWorkspaceSize() {
 #else
   size_t workspace_size = 4096;
   cudaDeviceProp* p = at::cuda::getDeviceProperties(c10::cuda::current_device());
-  const int computeCapability = p->major * 10 + p->minor;
-  if (computeCapability >= 90) {
+  if (p->major >= 9) {
     workspace_size = 32768;
   }
 #endif

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -186,8 +186,15 @@ static size_t _parseChosenWorkspaceSize() {
     // accept either env var
     val = getenv("HIPBLASLT_WORKSPACE_SIZE");
   }
+  size_t workspace_size = 1024;
+#else
+  size_t workspace_size = 4096;
+  cudaDeviceProp* p = at::cuda::getDeviceProperties(c10::cuda::current_device());
+  const int computeCapability = p->major * 10 + p->minor;
+  if (computeCapability >= 90) {
+    workspace_size = 32768;
+  }
 #endif
-  size_t workspace_size = 1024; /* default size in KiB according to #73328 */
   if (val) {
     try {
       workspace_size = std::stoi(val);


### PR DESCRIPTION
According to the [cuBLAS API Reference](https://docs.nvidia.com/cuda/cublas/index.html#cublassetworkspace) the recommended workspace size for Hopper is 32 MiB and for the rest architectures 4 MiB. This PR increases the workspace size accordingly. I am not aware of the recommended workspace size for HIP, that is why I am keeping it unchanged.

cc @csarofeen @ptrblck @xwang233