### PR TITLE
[Composable APIs] Add composable API `fully_shard` deprecation warning

### DIFF
--- a/torch/distributed/_composable/fully_shard.py
+++ b/torch/distributed/_composable/fully_shard.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Callable, Iterable, Optional, Union
 
 import torch
@@ -57,6 +58,13 @@ def fully_shard(
     """
     Applies ``FullyShardedDataParallel` (FSDP) semantics to ``module``.
     """
+    warnings.warn(
+        "``torch.distributed._composable.fully_shard`` is being deprecated."
+        "You can contintue to use the wrapper based FSDP."
+        "See usage in: https://github.com/pytorch/pytorch/blob/main/torch/distributed/fsdp/fully_sharded_data_parallel.py."
+        "``torch.distributed._composable.fully_shard`` will be removed after PyTorch 2.5."
+    )
+
     torch._C._log_api_usage_once("torch.distributed.fully_shard")
     # Enforce the new auto wrap policy
     if policy is not None and not isinstance(policy, _Policy):


### PR DESCRIPTION
`fully_shard`(https://github.com/pytorch/pytorch/blob/main/torch/distributed/_composable/fsdp/fully_shard.py) will be used by new FSDP2 and we want to add a deprecation warning to the existing composable API's `fully_shard`(https://github.com/pytorch/pytorch/blob/main/torch/distributed/_composable/fully_shard.py#L40). 


Planned release schedule is as follows https://dev-discuss.pytorch.org/t/release-cadence-for-year-2023-2024/1557:

Minor Version | Release branch cut | Release date | First patch release date | Second patch release date
-- | -- | -- | -- | --
2.3 | Mar 2024 | Apr 2024 | May 2024 | Jun 2024
2.4 | May 2024 | Jul 2024 | Aug 2024 | Sep 2024
2.5 | Aug 2024 | Oct 2024 | Nov 2024 | Dec 2024





cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @tianyu-l @wconstab @yf225