### PR TITLE
Add an autotune cache for inductor generated kernels

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -6,6 +6,7 @@ from typing import Callable, List, Optional
 
 import torch
 from torch import multiprocessing as mp
+from torch._dynamo import reset
 from torch._dynamo.test_case import run_tests, TestCase
 from torch._dynamo.testing import reset_rng_state
 from torch._dynamo.utils import counters
@@ -220,6 +221,81 @@ class TestMaxAutotune(TestCase):
 
         with config.patch({"max_autotune": True}):
             torch.compile(mm, dynamic=dynamic)(a, b)
+
+    @parametrize("dynamic", (False, True))
+    def test_max_autotune_remote_caching(self, dynamic: bool):
+        from unittest.mock import patch
+
+        def mm(a, b):
+            a = torch.sin(a)
+            return a @ b
+
+        a = torch.randn(100, 10).cuda()
+        b = torch.randn(10, 100).cuda()
+
+        class Model(torch.nn.Module):
+            def forward(self, x, y):
+                return x + y
+
+        def f(x, y):
+            return Model()(x, y)
+
+        x = torch.randn(100, 100).cuda()
+        y = torch.randn(100, 100).cuda()
+
+        cache = {}
+        num_get = 0
+        num_put = 0
+
+        class MyCache:
+            def __init__(self, key, is_autotune=False):
+                pass
+
+            def get(self, filenames):
+                nonlocal cache
+                nonlocal num_get
+                ret = {file: cache[file] for file in filenames if file in cache}
+                num_get += len(ret)
+                return ret
+
+            def put(self, filename, data):
+                nonlocal cache
+                nonlocal num_put
+                cache[filename] = data
+                num_put += 1
+
+        cache_module = (
+            "triton.runtime.fb_memcache.FbMemcacheRemoteCacheBackend"
+            if config.is_fbcode()
+            else "triton.runtime.cache.RedisRemoteCacheBackend"
+        )
+
+        with config.patch(
+            {
+                "use_autotune_local_cache": False,
+                "use_autotune_remote_cache": True,
+            }
+        ), patch.dict(os.environ), patch(cache_module, MyCache, create=True):
+            os.environ.pop("TRITON_CACHE_MANAGER", None)
+            with config.patch({"max_autotune": True}):
+                for _ in range(4):
+                    torch.compile(mm, dynamic=dynamic)(a, b)
+                    reset()
+                    torch._inductor.codecache.PyCodeCache.clear()
+                self.assertEqual(num_get, 3)
+                # TODO: This should really be 1 but it seems like we write even
+                # when we find it
+                self.assertEqual(num_put, 4)
+            num_get = 0
+            num_put = 0
+            for _ in range(4):
+                torch.compile(f, dynamic=dynamic)(x, y)
+                reset()
+                torch._inductor.codecache.PyCodeCache.clear()
+            self.assertEqual(num_get, 3)
+            # TODO: This should really be 1 but it seems like we write even
+            # when we find it
+            self.assertEqual(num_put, 4)
 
     def test_precompilation_threads(self):
         import threading

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2749,6 +2749,7 @@ class TritonKernel(Kernel):
             "kernel_name": str(Placeholder.DESCRIPTIVE_NAME),
             "mutated_arg_names": mutated_args,
             "no_x_dim": self.no_x_dim,
+            "backend_hash": torch.utils._triton.triton_hash_with_backend(),
         }
         num_gb = None
         if config.benchmark_kernel or config.profile_bandwidth:

--- a/torch/_inductor/codegen/triton_foreach.py
+++ b/torch/_inductor/codegen/triton_foreach.py
@@ -5,6 +5,8 @@ from typing import Dict, List, Tuple
 
 from sympy import Integer
 
+import torch
+
 from .. import metrics
 from ..scheduler import SchedulerNode
 from ..utils import ceildiv, Placeholder
@@ -162,7 +164,10 @@ class ForeachKernel(Kernel):
             "constants": {},
         }
         triton_meta["configs"] = [config_of(signature)]
-        inductor_meta = {"kernel_name": str(Placeholder.DESCRIPTIVE_NAME)}
+        inductor_meta = {
+            "kernel_name": str(Placeholder.DESCRIPTIVE_NAME),
+            "backend_hash": torch.utils._triton.triton_hash_with_backend(),
+        }
         return (
             f"@foreach(num_warps={self.num_warps}, triton_meta={triton_meta!r}, inductor_meta={inductor_meta!r})\n"
             + "@triton.jit"

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1085,6 +1085,7 @@ class WrapperCodeGen(CodeGen):
 
         inductor_meta = {
             "kernel_name": name,
+            "backend_hash": torch.utils._triton.triton_hash_with_backend(),
         }
 
         configs = [

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -9,6 +9,15 @@ def is_fbcode():
     return not hasattr(torch.version, "git_version")
 
 
+def enable_autotune_remote_cache():
+    if is_fbcode():
+        from torch._utils_internal import justknobs_check
+
+        if justknobs_check("pytorch/autotune_remote_cache:enable"):
+            return True
+    return os.environ.get("TORCH_INDUCTOR_AUTOTUNE_REMOTE_CACHE") == "1"
+
+
 # add some debug printouts
 debug = False
 
@@ -188,6 +197,12 @@ max_autotune_pointwise = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE") 
 
 # enable slow autotuning passes to select gemm algorithms
 max_autotune_gemm = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_GEMM") == "1"
+
+# enable autotune local cache
+use_autotune_local_cache = True
+
+# enable autotune remote cache
+use_autotune_remote_cache = enable_autotune_remote_cache()
 
 # force cublas and triton to use the same precision; cublas supports TF32 for matmul operations
 # when m, n, k are multiples of 16, 16, 8, whereas triton supports TF32 for matmul operations

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -157,6 +157,7 @@ class TritonTemplateKernel(TritonKernel):
 
         inductor_meta = {
             "kernel_name": str(Placeholder.DESCRIPTIVE_NAME),
+            "backend_hash": torch.utils._triton.triton_hash_with_backend(),
         }
         if config.profile_bandwidth or config.benchmark_kernel:
             num_gb = self.estimate_kernel_num_bytes() / 1e9

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -778,16 +778,10 @@ def hash_configs(configs: List[Config]):
 
 
 def load_cached_autotuning(
-    cache_filename: str, configs_hash: str, configs: List[Config]
+    best_config,
+    configs_hash: str,
+    configs: List[Config],
 ):
-    """
-    Read a cached autotuning result from disk
-    """
-    if not os.path.exists(cache_filename):
-        return None
-
-    with open(cache_filename) as fd:
-        best_config = json.loads(fd.read())
     if best_config.pop("configs_hash", None) != configs_hash:
         return None
 
@@ -829,27 +823,62 @@ def cached_autotune(
     save_cache_hook: Optional[Callable[[Any, Any], Any]]
     inductor_meta = {} if inductor_meta is None else inductor_meta
 
-    # on disk caching logic
+    # on disk caching logic and/or remote caching
     if filename is not None and (len(configs) > 1 or config.coordinate_descent_tuning):
-        cache_filename = os.path.splitext(filename)[0] + ".best_config"
         configs_hash = hash_configs(configs)
-        best_config = load_cached_autotuning(cache_filename, configs_hash, configs)
+
+        cache_filename = None
+        remote_cache = None
+        remote_cache_key = None
+        if config.use_autotune_local_cache:
+            cache_filename = os.path.splitext(filename)[0] + ".best_config"
+        if config.use_autotune_remote_cache:
+            backend_hash = inductor_meta.get("backend_hash", None)
+            if backend_hash is not None:
+                key = backend_hash + "autotune-best-config"
+                if config.is_fbcode():
+                    remote_cache = (
+                        triton.runtime.fb_memcache.FbMemcacheRemoteCacheBackend(
+                            key, is_autotune=True
+                        )
+                    )
+                else:
+                    remote_cache = triton.runtime.cache.RedisRemoteCacheBackend(key)
+                # we already sha256 hash the source contents
+                remote_cache_key = os.path.basename(filename)
+            else:
+                log.debug(
+                    "backend_hash is not passed on the inductor_meta, unable to use autotune remote cache"
+                )
+
+        best_config = None
+        if cache_filename is not None and os.path.exists(cache_filename):
+            with open(cache_filename) as fd:
+                best_config = json.loads(fd.read())
+        elif remote_cache is not None and remote_cache_key is not None:
+            best_config = remote_cache.get([remote_cache_key])
+
         if best_config:
-            configs = [best_config]
+            best_config = load_cached_autotuning(best_config, configs_hash, configs)
+            if best_config:
+                configs = [best_config]
 
         def save_cache_hook(cfg, found_by_coordesc=False):
-            with open(cache_filename, "w") as fd:
-                fd.write(
-                    json.dumps(
-                        {
-                            **cfg.kwargs,
-                            "num_warps": cfg.num_warps,
-                            "num_stages": cfg.num_stages,
-                            "configs_hash": configs_hash,
-                            "found_by_coordesc": found_by_coordesc,
-                        }
-                    )
-                )
+            data = json.dumps(
+                {
+                    **cfg.kwargs,
+                    "num_warps": cfg.num_warps,
+                    "num_stages": cfg.num_stages,
+                    "configs_hash": configs_hash,
+                    "found_by_coordesc": found_by_coordesc,
+                }
+            )
+            if cache_filename is not None:
+                with open(cache_filename, "w") as fd:
+                    fd.write(data)
+            if remote_cache is not None and remote_cache_key is not None:
+                remote_cache.put(remote_cache_key, data)
+
             if log.isEnabledFor(logging.DEBUG):
                 type_str = "coordesc" if found_by_coordesc else "heuristic"
                 log.debug("Save %s tuning result to %s", type_str, cache_filename)

--- a/torch/utils/_triton.py
+++ b/torch/utils/_triton.py
@@ -1,4 +1,5 @@
 import functools
+import hashlib
 
 from torch._dynamo.device_interface import get_interface_for_device
 
@@ -28,3 +29,33 @@ def has_triton() -> bool:
         return False
 
     return is_device_compatible_with_triton() and has_triton_package()
+
+
+@functools.lru_cache(None)
+def triton_backend():
+    import torch
+
+    if torch.version.hip:
+        # Does not work with ROCm
+        return None
+
+    from triton.compiler.compiler import make_backend
+    from triton.runtime.driver import driver
+
+    target = driver.active.get_current_target()
+    return make_backend(target)
+
+
+@functools.lru_cache(None)
+def triton_hash_with_backend():
+    import torch
+
+    if torch.version.hip:
+        # Does not work with ROCm
+        return None
+
+    from triton.compiler.compiler import triton_key
+
+    backend = triton_backend()
+    key = f"{triton_key()}-{backend.hash()}"
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()


### PR DESCRIPTION
Summary: Inductor currently has a best config cache for kernels that it generates. This is a local cache done via writing to the file system. This diff takes this local cache to remote by reusing the existing triton caching mechanism built via Memcache internally and Redis externally.

Test Plan:
tested locally using `TORCH_INDUCTOR_AUTOTUNE_REMOTE_CACHE =1`

Look at scuba to verify the local testing: https://fburl.com/scuba/triton_remote_cache/z6pypznk

The plan is to land this diff with this turned off and gradually introduce this.

Differential Revision: D54398076




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang