### PR TITLE
fsdp: hacky poc to functionalize storage resizing while saving allgathered weights for bw

### DIFF
--- a/torch/_dynamo/backends/common.py
+++ b/torch/_dynamo/backends/common.py
@@ -40,6 +40,8 @@ def aot_autograd(**kwargs):
         kwargs["inference_compiler"] = (
             kwargs.get("inference_compiler") or kwargs["fw_compiler"]
         )
+        # input mutations are hardened enough that all of our debugging backends should use them
+        kwargs["keep_inference_input_mutations"] = True
 
         from functorch.compile import nop
 

--- a/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
+++ b/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
@@ -157,6 +157,7 @@ def run_functionalized_fw_and_collect_metadata(
                 mutates_data
                 and are_all_mutations_under_no_grad_or_inference_mode(f_arg)
             )
+            mutation_inductor_storage_resize = isinstance(f_arg, FunctionalTensor) and torch._functionalize_was_inductor_storage_resized(f_arg.elem)
 
             # Here, we're saying that if an input experienced a set call, inp.set_(other),
             # then we can effectively not have to worry about whether its data was mutated.
@@ -185,6 +186,7 @@ def run_functionalized_fw_and_collect_metadata(
                     mutations_hidden_from_autograd=mutations_hidden_from_autograd,
                     mutates_storage_metadata=mutates_storage_metadata,
                     mutations_under_no_grad_or_inference_mode=mutations_under_no_grad_or_inference_mode,
+                    mutation_inductor_storage_resize=mutation_inductor_storage_resize,
                     requires_grad=requires_grad,
                     keep_input_mutations=keep_input_mutations,
                 )

--- a/torch/_functorch/_aot_autograd/input_output_analysis.py
+++ b/torch/_functorch/_aot_autograd/input_output_analysis.py
@@ -147,6 +147,10 @@ def create_synthetic_base_metadata(
             m.input_info[x].mutations_under_no_grad_or_inference_mode
             for x in outer_indices
         )
+        mutation_inductor_storage_resize = all(
+            m.input_info[x].mutation_inductor_storage_resize
+            for x in outer_indices
+        )
 
         inpt_info = InputAliasInfo(
             # If len(outer_indices) > 1, then this input is a synthetic base.
@@ -162,6 +166,7 @@ def create_synthetic_base_metadata(
             if len(outer_indices) > 1
             else m.input_info[outer_indices[0]].mutates_storage_metadata,
             mutations_under_no_grad_or_inference_mode=mutations_under_no_grad_or_inference_mode,
+            mutation_inductor_storage_resize=mutation_inductor_storage_resize,
             is_leaf=any_leaf,
             requires_grad=requires_grad,
             keep_input_mutations=m.keep_input_mutations,

--- a/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
@@ -49,6 +49,8 @@ from .subclass_utils import (
     wrap_tensor_subclasses,
 )
 
+from .functional_utils import reorder_views_before_resize
+
 from .utils import (
     _get_symint_hints,
     call_func_at_runtime_with_args,
@@ -226,6 +228,8 @@ def aot_dispatch_autograd(
             fw_module, bw_module = aot_config.partition_fn(
                 fx_g, joint_inputs, num_fwd_outputs=num_inner_fwd_outputs
             )
+            reorder_views_before_resize(fw_module.graph)
+            fw_module.recompile()
 
             fw_outs = next(n for n in fw_module.graph.nodes if n.op == "output").args[0]
             # we only need to bookkeep the symints that are saved for bw, not any symints

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -100,6 +100,7 @@ class InputAliasInfo:
     mutates_metadata: bool
     mutations_hidden_from_autograd: bool
     mutations_under_no_grad_or_inference_mode: bool
+    mutation_inductor_storage_resize: bool
     mutates_storage_metadata: bool
     requires_grad: bool
     keep_input_mutations: bool
@@ -123,6 +124,7 @@ class InputAliasInfo:
             self.mutates_metadata,
             self.mutations_hidden_from_autograd,
             self.mutations_under_no_grad_or_inference_mode,
+            self.mutation_inductor_storage_resize,
             self.requires_grad,
         ):
             return MutationType.MUTATED_IN_GRAPH

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1009,6 +1009,8 @@ class FakeTensorMode(TorchDispatchMode):
             func.name(), torch._C.DispatchKey.CompositeImplicitAutograd
         ):
             raise _BypassDispatchCache("CompositeImplicitAutograd")
+        if func.is_view:
+            raise _BypassDispatchCache("view caching is broken when we have storage resizing")
 
         key_values = (
             func,
@@ -1449,9 +1451,10 @@ class FakeTensorMode(TorchDispatchMode):
         except NotImplementedError as not_implemented_error:
             return maybe_run_unsafe_fallback(not_implemented_error)
 
-        return self.wrap_meta_outputs_with_default_device_logic(
+        out = self.wrap_meta_outputs_with_default_device_logic(
             r, func, flat_args, device=kwargs.get("device")
         )
+        return out
 
     # WARNING: DO NOT add any additional namespaces/operators here if they refer to operators
     # outside of the pytorch/pytorch library! Any pre-existing things here

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -643,6 +643,10 @@ class MetaConverter:
                 torch._C._set_neg(r, t.is_neg())
             # This can be skipped if necessary for performance reasons
             assert_metadata_eq(assert_eq, t, r, skip_symbolic=True)
+            # HACK: neeed to think more about this.
+            # FakeTensor doesn't properly handle fakeifying tensors with secretly-different storage sizes today.
+            if t.untyped_storage().size() == 0:
+                r.untyped_storage().resize_(0)
             self.set_tensor_memo(t, r)
 
         return self.get_tensor_memo(t)

--- a/torch/csrc/autograd/python_torch_functions_manual.cpp
+++ b/torch/csrc/autograd/python_torch_functions_manual.cpp
@@ -704,6 +704,28 @@ THPVariable__functionalize_are_all_mutations_hidden_from_autograd(
   }
   END_HANDLE_TH_ERRORS
 }
+static PyObject*
+THPVariable__functionalize_was_inductor_storage_resized(
+    PyObject* self,
+    PyObject* args,
+    PyObject* kwargs) {
+  HANDLE_TH_ERRORS
+  static PythonArgParser parser(
+      {"_functionalize_was_inductor_storage_resized(Tensor t)"},
+      /*traceable=*/true);
+
+  ParsedArgs<1> parsed_args;
+  auto r = parser.parse(args, kwargs, parsed_args);
+  auto self_ = r.tensor(0);
+  TORCH_INTERNAL_ASSERT(at::functionalization::impl::isFunctionalTensor(self_));
+  auto functional_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(self_);
+  if (functional_impl->was_inductor_storage_resized()) {
+    Py_RETURN_TRUE;
+  } else {
+    Py_RETURN_FALSE;
+  }
+  END_HANDLE_TH_ERRORS
+}
 
 static PyObject*
 THPVariable__functionalize_are_all_mutations_under_no_grad_or_inference_mode(
@@ -803,6 +825,11 @@ static PyMethodDef torch_functions_manual[] = {
     {"_functionalize_are_all_mutations_under_no_grad_or_inference_mode",
      castPyCFunctionWithKeywords(
          THPVariable__functionalize_are_all_mutations_under_no_grad_or_inference_mode),
+     METH_VARARGS | METH_KEYWORDS | METH_STATIC,
+     nullptr},
+    {"_functionalize_was_inductor_storage_resized",
+     castPyCFunctionWithKeywords(
+         THPVariable__functionalize_was_inductor_storage_resized),
      METH_VARARGS | METH_KEYWORDS | METH_STATIC,
      nullptr},
     {"_functionalize_is_multi_output_view",


### PR DESCRIPTION
Not all problems are fixed yet and this PR contains many hacks, but pushing this out before I go on PTO as a starting point / proof of concept. Detailed description of the issues encountered.

This PR attempts to functionalize resizes from tracing ppFSDP.

Repro I've been working off of (from @yf225): P1190991292 (I rebased this commit on top of the existing fsdp stack: https://github.com/pytorch/pytorch/pull/120442

Outputs from the repro:
Dynamo forward graph: P1191009335
Functionalized forward graph: P1190991754
Backward graph from AOTAutograd (before compiled autograd runs): P1190991999
Compiled autograd graph from dynamo: P1191009635
Backward graph, after compiled autograd, after functionalization (wrong): P1190992138

**Current state**

The repro generates a properly functionalized forward graph, that also includes a `param.storage_resize(0)` at the end of the graph. It fails during functionalization of the backward for reasons that I'll describe below.

**Individual changes / problems ran into**

I ran into many problems, but I would say that (7) and (8) below are the most interesting / hardest to solve.

**(1)** `inductor.resize_storage_bytes_` is functionalized

This op previously did not have alias annotations, so I gave it proper annotations, added a functional variant of the op, and wrote a functionalization rule for it. One interesting thing to note is that the functional variant has **very** strange semantics:

`y = functional_resize(x, size)` returns a fresh tensor y that has the **same** size/strides as x, but a `storage().size()` of `size`. We need to properly maintain this invariant in our fake tensor logic during tracing, or else we risk generating a graph with incorrect sizes/storage sizes.

I also added some pretty strong restrictions to the op: when calling it, we require that either you are always either resizing down to zero or up from zero (you cannot resize a tensor with a nonzero storage size, to another value that is not nonzero).

This makes it safer to add a "basic" decomposition for this functional op (added in the PR but commented out), which is effectively just a tensor of uninitialized data (`torch.empty`). The expectation is that if you have a tensor that you just resized the storage of, its data is invalid and you are about to fill it in with something (which fsdp does when it performs a `copy_()`).


**(2) Needed to hackily remove as_strided storage error checks**

To get the meta impl of "functional_storage_resize" working properly, we need to make sure that we can return an empty tensor that has the **same shape as the input tensor, but a storage size of "new_size"**. In theory, the only way to do this properly is by calling `untyped_storage().resize_()` itself, but I wanted to be able to trace an `empty()` call into the graph  (instead of hiding this all in an opaque `functional_storage_resize()` primitive op).

To do this, I call `torch.empty(new_storage_size).as_strided(input_tensor.shape)`. This loudly trips the asserts in as_strided that the storage and tensor sizes agree, so I deleted the check for now. The right way to get this to work is probably to have the meta function perform `storage().resize_()` (but still arrange for inductor to see an empty() call in the decompositions/lowerings)

There is also a similar version of this problem when tracing through the autograd engine. The repro example uses matmul, and the `aten.mm(self, weight)` has a code path where the backward formula saves `weight` for backward, and then invokes `weight.t()` during the backward formula. However, when we trace out the joint graph, we end up calling `weight.storage().resize_(0)` first (end of the forward), followed by `weight.t()` (during the backward formula), which trips the same as_strided assert.

Why does this error in compile but not in eager? In eager, the pre_backward_hook will properly resize the storage of `weight()` before we run the backward rule for `mm`, so `weight.t()` can run properly. But when we trace, that pre_backward_hook is not run at all! So we end up unsafely tracing with different storage sizes.

**(3) storage resize input mutations are kept in the graph**

If you resize a graph input's storage to zero, this is a graph input mutation: so we emit `storage_resize_bytes(x, final_size)` in the graph epilogue.

One nice optimization: from @awgu, it sounds like it is usually (but not always) the case that the allgathered weight arguments have zero-size-storage both **before and after** the graph executes. AKA there are two resizes that happen (one to size up and one to size back down), but the net effect is that the param didn't change in a way that is visible outside the graph. In this case, we can avoid putting the `resize_storage_()` call in the graph entirely. Instead, we just have the two "functional" `resize_storage()` ops in the graph (which can both desugar to `empty()` calls).

I also added a few hard restrictions to when we can emit a resize_() in the graph:

restriction 1: you can only resize_() down to a size zero storage. This seems to be the common case for fsdp, and we can always lift the restriction later if we have to: but this case is nice and simple, because it means that we don't **also** have to worry about the case where we have to fill the resized tensor with data (via a `copy_()`) - when the final size is zero, there is no data to worry about.

restriction 2: all other input mutations must be kept in the graph. Today, there is also a set of logic that decides when input mutations are safe/unsafe to keep in the graph. For safety, I added the resize logic in a way that errors very loudly if we detected that there was **another** mutation to the input (e.g. a `copy_()`) that we could not keep in the graph for some reason. In general for the FSDP case, we also know that all of these mutations are hidden from autograd so they should be safe to keep in the graph (so if we found a mutation that **was** visible to autograd, we would want to know about it and error loudly).


**(4) (related) - detection of mutations that happen under no_grad is a bit broken**

fsdp copies in the data from the all gather into the parameter buffer under no_grad. Since the mutation is under no_grad it should be safe to keep it in the graph, but there is a bug with how we detect that mutations happen under no_grad when views are involved. I partially fixed the issue (see `FunctionalStorageImpl.h`), but this logic will need some cleanup.

**(5) FakeTensor creation is broken for zero-storage-sized inputs**

When we fakeify a tensor that secretly has a zero-storage-size, we don't properly resize the fake tensor's storage size to be zero as well. I have a bandaid for this in the PR, but this needs more thought.

**(6) FakeTensor caching is broken for views of zero-storage-sized inputs**

FakeTensor caching relies on a cache key, which should reliably hash to the same FakeTensor. Now that we have to support FakeTensors whose storage size can vary independently of the view tensor's shape, we need to include the storage size in the cache key (I tried this briefly but couldn't get it to work, so I banned caching on views as a hack in the PR

**(7) Problem: In eager we save `weight.t()` for backward, while in compile we save `functionalized_weight.t()` for backward**

(This is not true in the paste I put above because I have a partial fix / hack to this problem, described below).

In simple repro above, the forward graph (prior to functionalization) looks something like this (where "weight.t() is saved for backward):
```
def forward(weight, inp):
    weight.storage().resize_(full_size)
    weight.copy_(...)
    out = aten.mm(weight, inp)
    # first argument is the user fw output, second argument is the saved activation
    weight.storage().resize_(0)
    return out, weight.t()
```

The "functionalized" graph therefore looks something like this:
```
def forward_functionalized(weight, inp):
    weight_updated = functional_resize(weight, full_size)
    weight_updated2 = weight_updated.copy(...)
    out = aten.mm(weight_updated2, inp)
    weight_updated3 = functional_resize(weight_updated2, 0)
    # input mutation: put a mutable resize in the graph
    weight.storage().resize_(0)
    # first argument is the user fw output, second argument is the saved activation
    return out, weight_updated3.t()
```

Notice that the activation that we save for backward is the "updated" weight (after mutations have been applied). In general, this is the right thing to do: if the eager code would have saved a tensor **post-mutation** for backward, then the functionalized code should also save the tensor for backward after that mutation has been appplied.

This is a problem for fsdp. To see why: after compiled autograd runs, the backward graph looks something like this (more detailed version is at the paste linked above, reference: P1190992138):

```
def backward_graph_after_compiled_autograd_runs(tangent, saved_activation, closed_over_bw_hook_tensor):
    closed_over_bw_hook_tensor.storage().resize_(full_size)
    closed_over_bw_hook_tensor.copy_(...)  # copy in all gathered data
    grad_inp = aten.mm(tangent, saved_activation)
```

Why is the graph above now problematic? `saved_activation` is a tensor with a secretly-size-zero-storage. `closed_over_bw_hook_tensor` is the model parameter, that we resize and allgather into via the pre-backward-hook.

In eager, fsdp relies on these two tensors being **aliased** (the saved activation is just `weight.t()`). So the resize/allgather into the parameter will also properly resize the saved activation. If functionalization forces these to be two separate tensors, then we will end up with an activation that never gets resized properly!

**(7) (What this PR attempts to do):**

When the autograd engine is saving tensors for backward, the object that it saves is a `FunctionalTensor`. In this case, it is "weight_updated3". In general, it would not be safe to save `weight` instead for the reason mentioned above (`weight` and `weight_updated3` may have different data, due to a mutation).

However, in the case above it happens to be the case that both `weight` and `weight_updated3` **both** have a zero-sized-storage (the result of sizing up at the beginning of the fw, and down at the end of the fw). Since a zero-sized-storage implies no data, it's technically ok to save the original tensor for backward before the mutation happened (`weight`).

In the PR, I implement this by overriding `FunctionalTensorWrapper::value()`: when you ask a FunctionalTensor` for its inner value, if the current (maybe-updated) value and the original value both have size-zero-storages, then I return the original value. I'm not convinced yet that this is safe to do in all cases, but I put it in the PR for discussion.

**(8) Problem: Inputs to the compiled backward graph are aliased and have a zero-sized storage**

Once (7) is fixed, we have another problem (paste above for reference: P1190992138). Looking at the signature of the compiled backward again:
```
def forward(self, L_inputs_0_ : torch.Tensor, L_inputs_1_ : torch.Tensor, L_inputs_2_ : torch.nn.parameter.Parameter):
   ...
```

We have the following:

(1) `L_inputs_1_` and `L_inputs_2_` are aliased tensors (the second is the actual `param` that we closed over in the pre-bw-hook, the first is the `param.t()` activation that we saved for backward thanks to the partitioner)

(2) Both of these inputs have a secretly-zero-sized storage (even though their tensor shapes advertise as normal).

Right now, if you run this code through AOTAutograd, we'll hit the synthetic-base code path and try to generate a base, based on the shared storage() of these two aliases. AOTAutograd will then make that fresh `base` the "real" graph input, and generated the two inputs again inside the graph with an `as_strided()`: `view1`, `view2`.

This blows up pretty loudly: Functionalization will see a mutation to the second tensor, try to generate an as_strided_scatter() call to generate the updated base, and this will blow up because the base advertises as having a shape of size 0.

What do we want to happen? In theory, we have a bunch of information that should make this easier to handle:

(1) Between these two aliased inputs in the graph, all of the mutations they experience are hidden from autograd, and they don't resize any metadata mutations to the individual TensorImpls

(2) Only one of the two inputs is actually mutated (we perform the resize() / copy() on the second tensor, and use the first (the activation) in the actual backward logic).

One idea is that we can try to use this info to eliminate one of the inputs from the graph entirely: In the example above, we could eliminate the activation as a graph input, recognize that the relationships between the two tensors is a transpose(), and regenerate the activation inside the graph with a `L_inputs_2_.t()` (preferably after performing the resize/copy on the input, so we don't have to generate extra functionalization ops).

If we go with that approach though, we'd have to figure out a way to make it:

(a) robust to all cases with fsdp (when fsdp closes over a param, and also saves an alias of that param for backward, are we guaranteed that there is a "simple" view relationship between the two? That depends on which ops are in the graph and what their derivatives save for backward)

(b) safe (The above example is ok, but if you e.g. perform a mutation on `view1` that affects the autograd metadata of `view2` in a user visible way, we would be on the hook for ensuring that the user gets to see `view2`'s autograd metadata get mutated properly.)


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120971



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire