### PR TITLE
[flight recorder] record NCCL commHash

### DIFF
--- a/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
@@ -62,6 +62,7 @@ class ProcessGroupNCCLSimulateErrors : public c10d::ProcessGroupNCCL {
 
   c10::intrusive_ptr<ProcessGroupNCCL::WorkNCCL> initWork(
       at::Device& device,
+      std::shared_ptr<c10d::NCCLComm>& ncclComm,
       int rank,
       c10d::OpType opType,
       const char* profilingTitle,
@@ -124,6 +125,7 @@ class ProcessGroupNCCLTimedOutErrors : public ProcessGroupNCCLSimulateErrors {
 
   c10::intrusive_ptr<ProcessGroupNCCL::WorkNCCL> initWork(
       at::Device& device,
+      std::shared_ptr<c10d::NCCLComm>& ncclComm,
       int rank,
       c10d::OpType opType,
       const char* profilingTitle,

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -4111,6 +4111,8 @@ class NCCLTraceTest(NCCLTraceTestBase):
         self.assertEqual(last['input_sizes'], ((3, 4),))
         self.assertEqual(last['output_sizes'], ((3, 4),))
         self.assertEqual(last['seq_id'], 2)
+        nch = last['nccl_comm_hash']
+        self.assertIsNotNone(nch)
         now = datetime.now()
         event_created_time = datetime.fromtimestamp(last['time_created_ns'] / 1000000000)
         before_test = now - timedelta(minutes=1)

--- a/torch/csrc/distributed/c10d/NCCLUtils.hpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.hpp
@@ -472,6 +472,17 @@ class NCCLComm {
 #endif
   }
 
+  uint64_t getCommHash() {
+#ifdef NCCL_COMM_GET_UNIQUE_HASH
+    // query from NCCL when first time called
+    if (commHash_ == 0) {
+      C10D_NCCL_CHECK(
+          ncclCommGetUniqueHash(ncclComm_, &commHash_), c10::nullopt);
+    }
+#endif
+    return commHash_;
+  }
+
   friend class ProcessGroupNCCL;
 
  protected:
@@ -480,6 +491,7 @@ class NCCLComm {
   ncclComm_t ncclComm_;
   // Unique nccl_id for this communicator.
   ncclUniqueId ncclId_;
+  uint64_t commHash_{0};
   bool aborted_;
   uint64_t ncclCommSplitCounter_{0};
   ncclResult_t ncclAsyncErr_;

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -658,6 +658,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // workEnqueue
   virtual c10::intrusive_ptr<ProcessGroupNCCL::WorkNCCL> initWork(
       at::Device& device,
+      std::shared_ptr<NCCLComm>& ncclComm,
       int rank,
       OpType opType,
       const char* profilingTitle = nullptr,


### PR DESCRIPTION
Summary: NCCL commHash can be used to map the entry in flight recorder to NCCL trace dumped.  This PR includes using NCCL commHash when defining work as well as exposing commHash to flight recorder output.

Differential Revision: D54349909




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @rohan-varma