### PR TITLE
Include a warning in cuda get_allany_iter

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1538,8 +1538,8 @@ inline TensorIterator get_allany_iter(
     // `make_reduction`, which doesn't cast input to the result type i.e. kBool.,
     // otherwise we use the overload below which casts the input to kBool (which is
     // an extra operation).
-    TORCH_WARN("Dynamic type casting is leveraged for CUDA reduction operations. "
-               "Any non-zero value, including a pure imaginary number, will be considered as True.");
+    TORCH_WARN("Dynamic type casting is leveraged for CUDA reduction operations.
+               Any non-zero value, including a pure imaginary number, will be considered as True.");
     return meta::make_reduction(self, result, dims, keepdim, self.scalar_type());
   }
   return meta::make_reduction_from_out_ty(

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1538,6 +1538,8 @@ inline TensorIterator get_allany_iter(
     // `make_reduction`, which doesn't cast input to the result type i.e. kBool.,
     // otherwise we use the overload below which casts the input to kBool (which is
     // an extra operation).
+    TORCH_WARN("Dynamic type casting is leveraged for CUDA reduction operations. "
+               "Any non-zero value, including a pure imaginary number, will be considered as True.");
     return meta::make_reduction(self, result, dims, keepdim, self.scalar_type());
   }
   return meta::make_reduction_from_out_ty(


### PR DESCRIPTION
Fixes #120875


The root cause of the discrepancy between CPU and GPU is in this line

https://github.com/pytorch/pytorch/blob/63b259492a8e5519edb45bb34c5b2a275baebf63/aten/src/ATen/native/ReduceOps.cpp#L1536

.

1. torch.all on CPU will explicitly cast everything into bool. However, the cast is done by `Casting complex values to real discards the imaginary part`. Therefore, a pure imaginary number is treated as zero and thus false.
2. torch.all on cuda does dynamical casting, anything non-zero, including pure imaginary numbers treated as True.

Example1
```
input_data = torch.tensor([1+2j, 3-4j, 0.0001j, 6])

result = torch.all(input_data)
print("cpu: ", result)

input_data = input_data.cuda()
result = torch.all(input_data)
print("cuda: ", result)

cpu:  tensor(False)
cuda:  tensor(True, device='cuda:0')
```
Example2
```
input_data = torch.tensor([1+2j, 3-4j, 0j, 6])

cpu:  tensor(False)
cuda:  tensor(False, device='cuda:0')
```

The CUDA dynamic is aligned with the native python, behavior below
```
>>> bool(1+3j)
True
>>> bool(0+3j)
True
>>> bool(3+0j)
True
>>> bool(0+0j)
False
```

It is the CPU version that needs to be corrected, which involves modifying the https://github.com/pytorch/pytorch/blob/498a94a7f5b4426313607313557835bf0625c268/aten/src/ATen/native/Copy.cpp#L300

or create an overload for the complex type which is consumed by reduction.
