### PR TITLE
Compilation issue workaround for s390x with gcc>=12

### DIFF
--- a/cmake/Codegen.cmake
+++ b/cmake/Codegen.cmake
@@ -330,6 +330,10 @@ if(INTERN_BUILD_ATEN_OPS)
           # See https://github.com/pytorch/pytorch/issues/38855
           set(EXTRA_FLAGS "${EXTRA_FLAGS} -Wno-uninitialized")
         endif()
+        if(("${NAME}" STREQUAL "native/cpu/GridSamplerKernel.cpp") AND ("${CPU_CAPABILITY}" STREQUAL "ZVECTOR"))
+          # Workaround for currently investigated issue for gcc >= 12
+          set(EXTRA_FLAGS "${EXTRA_FLAGS} -fno-strict-aliasing")
+        endif()
         if("${NAME}" STREQUAL "native/quantized/cpu/kernels/QuantizedOpKernels.cpp")
           # See https://github.com/pytorch/pytorch/issues/38854
           set(EXTRA_FLAGS "${EXTRA_FLAGS} -Wno-deprecated-copy")


### PR DESCRIPTION
Currently multiple tests, for example test_grad_grid_sampler_2d_cpu_float32 from test/functorch/test_ops.py, crash when compiled with gcc >= 12 on s390x. It's being investigated. These changes provide a workaround for now..