### PR TITLE
Switched m1 runners to the lable macos-m1-stable

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -19,7 +19,6 @@ self-hosted-runner:
     - windows.g5.4xlarge.nvidia.gpu
     - bm-runner
     - linux.rocm.gpu
-    - macos-m1-12
     - macos-m1-stable
     - macos-m1-13
     - macos-12-xl

--- a/.github/workflows/mac-mps.yml
+++ b/.github/workflows/mac-mps.yml
@@ -29,7 +29,7 @@ jobs:
       environment-file: .github/requirements/conda-env-macOS-ARM64
       test-matrix: |
         { include: [
-          { config: "mps", shard: 1, num_shards: 1, runner: "macos-m1-12" },
+          { config: "mps", shard: 1, num_shards: 1, runner: "macos-m1-stable" },
           { config: "mps", shard: 1, num_shards: 1, runner: "macos-m2-14" },
         ]}
 

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -105,9 +105,9 @@ jobs:
       environment-file: .github/requirements/conda-env-macOS-ARM64
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 3, runner: "macos-m1-12" },
-          { config: "default", shard: 2, num_shards: 3, runner: "macos-m1-12" },
-          { config: "default", shard: 3, num_shards: 3, runner: "macos-m1-12" },
+          { config: "default", shard: 1, num_shards: 3, runner: "macos-m1-stable" },
+          { config: "default", shard: 2, num_shards: 3, runner: "macos-m1-stable" },
+          { config: "default", shard: 3, num_shards: 3, runner: "macos-m1-stable" },
         ]}
 
   macos-12-py3-arm64-mps-test:
@@ -122,7 +122,7 @@ jobs:
       python-version: 3.9.12
       test-matrix: |
         { include: [
-          { config: "mps", shard: 1, num_shards: 1, runner: "macos-m1-12" },
+          { config: "mps", shard: 1, num_shards: 1, runner: "macos-m1-stable" },
         ]}
 
   macos-12-py3-arm64-test:


### PR DESCRIPTION
Switched m1 runners to use  `macos-m1-stable` label, which points to exactly the same M1 running MacOS-13.2 