### PR TITLE
[dist][sharded_tensor] Fix ChunkShardingSpec metadata offsets for empty shards

### DIFF
--- a/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
+++ b/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
@@ -262,9 +262,9 @@ class TestShardTensor(ShardedTensorTestBase):
         # Verify.
         self.assertTrue(isinstance(st, sharded_tensor.ShardedTensor))
         sms = st.metadata().shards_metadata
-        self.assertEqual(len(sms) == 4)
+        self.assertEqual(len(sms), 4)
         for sm in sms:
-            self.assertTrue(sm.shard_offsets[0] + sm.shard_sizes[0] <= tensor.size[0])
+            self.assertTrue(sm.shard_offsets[0] + sm.shard_sizes[0] <= tensor.size(0))
 
         local_shard = st.local_tensor()
         self.assertEqual(1, len(st.local_shards()))

--- a/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
+++ b/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
@@ -264,7 +264,7 @@ class TestShardTensor(ShardedTensorTestBase):
         sms = st.metadata().shards_metadata
         self.assertEqual(len(sms) == 4)
         for sm in sms:
-            self.assertTrue(sm.shard_offsets[0] <= 9)
+            self.assertTrue(sm.shard_offsets[0] + sm.shard_sizes[0] <= tensor.size[0])
 
         local_shard = st.local_tensor()
         self.assertEqual(1, len(st.local_shards()))

--- a/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
+++ b/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
@@ -261,6 +261,11 @@ class TestShardTensor(ShardedTensorTestBase):
 
         # Verify.
         self.assertTrue(isinstance(st, sharded_tensor.ShardedTensor))
+        sms = st.metadata().shards_metadata
+        self.assertEqual(len(sms) == 4)
+        for sm in sms:
+            self.assertTrue(sm.shard_offsets[0] <= 9)
+
         local_shard = st.local_tensor()
         self.assertEqual(1, len(st.local_shards()))
         if dist.get_rank() < 3:

--- a/torch/distributed/_shard/sharding_spec/chunk_sharding_spec.py
+++ b/torch/distributed/_shard/sharding_spec/chunk_sharding_spec.py
@@ -93,7 +93,7 @@ class ChunkShardingSpec(ShardingSpec):
             chunked_dim_size = get_chunked_dim_size(sharding_dim_size, split_size, idx)
             shard_size = list(tensor_sizes)
             current_offsets = [0] * tensor_num_dim
-            current_offsets[self.dim] = min(sharding_dim_size, split_size * idx)  # type: ignore[index]
+            current_offsets[self.dim] = split_size * idx  # type: ignore[index]
             shard_size[self.dim] = chunked_dim_size  # type: ignore[index]
 
             shard_metadata = ShardMetadata(

--- a/torch/distributed/_shard/sharding_spec/chunk_sharding_spec.py
+++ b/torch/distributed/_shard/sharding_spec/chunk_sharding_spec.py
@@ -93,7 +93,7 @@ class ChunkShardingSpec(ShardingSpec):
             chunked_dim_size = get_chunked_dim_size(sharding_dim_size, split_size, idx)
             shard_size = list(tensor_sizes)
             current_offsets = [0] * tensor_num_dim
-            current_offsets[self.dim] = split_size * idx  # type: ignore[index]
+            current_offsets[self.dim] = min(sharding_dim_size, split_size * idx)  # type: ignore[index]
             shard_size[self.dim] = chunked_dim_size  # type: ignore[index]
 
             shard_metadata = ShardMetadata(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121002

ChunkShardingSpec generated metadata where offsets exceed the tensor size.

Example:

Torchrec prepared ShardedTensorMetadata:
```
ShardedTensorMetadata(shards_metadata=[
ShardMetadata(shard_offsets=[0, 0], shard_sizes=[2, 512], placement=rank:0/cuda:0), 
ShardMetadata(shard_offsets=[2, 0], shard_sizes=[2, 512], placement=rank:1/cuda:1), 
ShardMetadata(shard_offsets=[4, 0], shard_sizes=[2, 512], placement=rank:2/cuda:2), 
ShardMetadata(shard_offsets=[6, 0], shard_sizes=[2, 512], placement=rank:3/cuda:3), 
ShardMetadata(shard_offsets=[8, 0], shard_sizes=[2, 512], placement=rank:4/cuda:4), 
ShardMetadata(shard_offsets=[10, 0], shard_sizes=[0, 512], placement=rank:5/cuda:5), 
ShardMetadata(shard_offsets=[10, 0], shard_sizes=[0, 512], placement=rank:6/cuda:6)
],
size=torch.Size([10, 512]
), 
```
Calling ShardedTensor._init_from_local_shards_and_global_metadata()
ShardedTensor ShardingSpec builds metadata

```
ShardedTensorMetadata(shards_metadata=[
ShardMetadata(shard_offsets=[0, 0], shard_sizes=[2, 512], placement=rank:0/cuda:0), 
ShardMetadata(shard_offsets=[2, 0], shard_sizes=[2, 512], placement=rank:1/cuda:1), 
ShardMetadata(shard_offsets=[4, 0], shard_sizes=[2, 512], placement=rank:2/cuda:2), 
ShardMetadata(shard_offsets=[6, 0], shard_sizes=[2, 512], placement=rank:3/cuda:3), 
ShardMetadata(shard_offsets=[8, 0], shard_sizes=[2, 512], placement=rank:4/cuda:4), 
ShardMetadata(shard_offsets=[10, 0], shard_sizes=[0, 512], placement=rank:5/cuda:5), 
ShardMetadata(shard_offsets=[12, 0], shard_sizes=[0, 512], placement=rank:6/cuda:6)
],
size=torch.Size([10, 512]), tensor_properties=TensorProperties(dtype=torch.float16, layout=torch.strided, requires_grad=False, memory_format=torch.contiguous_format, pin_memory=False))
```
The deduced ChunkShardingSpec:
```
ChunkShardingSpec(dim=0, placements=[rank:0/cuda:0, rank:1/cuda:1, rank:2/cuda:2, rank:3/cuda:3, rank:4/cuda:4, rank:5/cuda:5, rank:6/cuda:6])
```

The fix is to limit offsets by dim size.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225

Differential Revision: [D54419513](https://our.internmc.facebook.com/intern/diff/D54419513)