### PR TITLE
Add windows constraint to mkl package in wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1092,9 +1092,8 @@ def main():
         "networkx",
         "jinja2",
         "fsspec",
+        "mkl>=2021.1.1,<=2021.4.0; platform_system == \"Windows\" and platform_machine == \"x86_64\"",
     ]
-    if IS_WINDOWS:
-        install_requires.append("mkl>=2021.1.1,<=2021.4.0; platform_system == \"Windows\" and platform_machine == \"x86_64\"")
 
     # Parse the command line and check the arguments before we proceed with
     # building deps and setup. We need to set values so `--help` works.

--- a/setup.py
+++ b/setup.py
@@ -1092,7 +1092,7 @@ def main():
         "networkx",
         "jinja2",
         "fsspec",
-        'mkl>=2021.1.1,<=2021.4.0; platform_system == "Windows" and platform_machine == "x86_64"',
+        'mkl>=2021.1.1,<=2021.4.0; platform_system == "Windows"',
     ]
 
     # Parse the command line and check the arguments before we proceed with

--- a/setup.py
+++ b/setup.py
@@ -1094,7 +1094,7 @@ def main():
         "fsspec",
     ]
     if IS_WINDOWS:
-        install_requires.append("mkl>=2021.1.1,<=2021.4.0")
+        install_requires.append("mkl>=2021.1.1,<=2021.4.0; platform_system == \"Windows\" and platform_machine == \"x86_64\"")
 
     # Parse the command line and check the arguments before we proceed with
     # building deps and setup. We need to set values so `--help` works.

--- a/setup.py
+++ b/setup.py
@@ -1092,7 +1092,7 @@ def main():
         "networkx",
         "jinja2",
         "fsspec",
-        "mkl>=2021.1.1,<=2021.4.0; platform_system == \"Windows\" and platform_machine == \"x86_64\"",
+        'mkl>=2021.1.1,<=2021.4.0; platform_system == "Windows" and platform_machine == "x86_64"',
     ]
 
     # Parse the command line and check the arguments before we proceed with


### PR DESCRIPTION
Follow up on: https://github.com/pytorch/pytorch/pull/102604
Address this comment: https://github.com/pytorch/pytorch/pull/102604#discussion_r1419944305

Whl metadata for all wheels published to pypi must match, otherwise poetry install will fail see this comment:
https://github.com/pytorch/pytorch/issues/88049#issuecomment-1302555269
