### PR TITLE
Simplify split sizes to AllToAllSingle

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7948,8 +7948,8 @@ class AllToAllSingle(OutOfPlaceCollectiveKernel):
             inputs=inputs,
             outputs=outputs,
             constant_args=[tag, ranks, group_size],
-            output_split_sizes=output_split_sizes,
-            input_split_sizes=input_split_sizes,
+            output_split_sizes=[V.graph.sizevars.simplify(s) for s in output_split_sizes],
+            input_split_sizes=[V.graph.sizevars.simplify(s) for s in input_split_sizes],
         )
         return cls.create_output_nodes(packed, outputs)[0]
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121021

This is a one off patch for https://github.com/pytorch/pytorch/issues/118385
that solves this for one particular case (but doesn't solve the general
hazard.)

Test is a bit difficult to write, Flavio will attempt to make one.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov