### PR TITLE
[export] cleanup to rewrite steps

### DIFF
--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -140,20 +140,13 @@ def _convert_input_to_fake(gm, args, kwargs):
     return fake_args, fake_kwargs, fake_params_buffers, fake_mode
 
 
-def _replace_param_buffer_names(param_buffer_table, sig, constants):
+def _replace_param_buffer_names(param_buffer_table, sig):
     for spec in sig.input_specs:
         if spec.kind in (
             InputKind.PARAMETER,
             InputKind.BUFFER,
         ):
             spec.target = param_buffer_table[spec.target]
-
-            if spec.persistent is False:
-                # we store non-persistent buffers in the constant table, so rewrite
-                # there as well
-                non_persistent_buffer = constants[spec.target]
-                del constants[spec.target]
-                constants[param_buffer_table[spec.target]] = non_persistent_buffer
     for spec in sig.output_specs:
         if spec.kind in (
             OutputKind.BUFFER_MUTATION,
@@ -555,7 +548,7 @@ def _get_params_buffers(mod: torch.nn.Module) -> Dict[str, torch.Tensor]:
     return params_buffers
 
 
-def rewrite_dynamo_tensor_constants(
+def _rewrite_dynamo_tensor_constants(
     orig_mod_buffers: Set[torch.Tensor],
     traced_mod_buffers: Dict[str, torch.Tensor],
     graph_signature: ExportGraphSignature,
@@ -577,7 +570,7 @@ def rewrite_dynamo_tensor_constants(
                 constants[spec.target] = value
 
 
-def rewrite_non_persistent_buffers(
+def _rewrite_non_persistent_buffers(
     orig_mod: torch.nn.Module,
     graph_signature: ExportGraphSignature,
     constants: Dict[str, Union[torch.Tensor, torch.ScriptObject]],
@@ -822,7 +815,7 @@ def _export(
             assert res is not None
             gm = res.graph_module
 
-        rewrite_non_persistent_buffers(f, ep_non_strict.sig, ep_non_strict.constants)
+        _rewrite_non_persistent_buffers(f, ep_non_strict.sig, ep_non_strict.constants)
 
         return ExportedProgram(
             root=gm,
@@ -994,7 +987,7 @@ def _export(
     # Do some cleanups on the graph module to restore the state dict to the
     # expected form. Each of these steps should probably get fixed upstream.
     # 1. Remove tensor constants that were added as buffers.
-    rewrite_dynamo_tensor_constants(
+    _rewrite_dynamo_tensor_constants(
         orig_mod_buffers=set(f.buffers()),
         traced_mod_buffers=dict(gm_torch_level.named_buffers()),
         graph_signature=ep_non_strict.sig,
@@ -1002,10 +995,10 @@ def _export(
     )
     # 2. Restore FQN of param/buffers
     param_buffer_table: Dict[str, str] = _get_param_buffer_mapping(f, gm_torch_level)
-    _replace_param_buffer_names(param_buffer_table, export_graph_signature, constants)
+    _replace_param_buffer_names(param_buffer_table, export_graph_signature)
 
-    # 3. Remove non-persistent buffers from the graph signature
-    rewrite_non_persistent_buffers(f, ep_non_strict.sig, ep_non_strict.constants)
+    # 3. Correctly populate non-persistent buffers
+    _rewrite_non_persistent_buffers(f, ep_non_strict.sig, ep_non_strict.constants)
 
     # 4. Rewrite constants to have the same FQN as the original module.
     _remap_constants(constant_attrs, export_graph_signature, constants)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #121040
* __->__ #121037

1. Some underscores for consistency of private functions.
2. remove dead code in `_replace_param_buffer_names`

Differential Revision: [D54429206](https://our.internmc.facebook.com/intern/diff/D54429206/)