### PR TITLE
[jit][nested strided tensor] support nested tensor in check_trace

### DIFF
--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -539,6 +539,20 @@ def _check_trace(
                                 atol=default_tolerances(orig, ref)[1],
                                 equal_nan=True,
                             )
+                        elif getattr(orig, "is_nested", None) or getattr(
+                            ref, "is_nested", None
+                        ):
+                            assert getattr(orig, "is_nested", None) == getattr(
+                                ref, "is_nested", None
+                            )
+                            for t_orig, t_ref in zip(orig.unbind(), ref.unbind()):
+                                torch.testing.assert_close(
+                                    t_orig.double(),
+                                    t_ref.double(),
+                                    rtol=check_tolerance,
+                                    atol=default_tolerances(t_orig, t_ref)[1],
+                                    equal_nan=True,
+                                )
                         else:
                             torch.testing.assert_close(
                                 orig.double(),


### PR DESCRIPTION
Summary:
torch.testing.assert_equal doesn't support nested strided tensors because sizes is not implemented.

This adds special handling for nested tensors by checking for nested tensors unbinding if they are found.

Test Plan: test_trace_with_nested_strided_tensor_output

Differential Revision: D54430238


