### PR TITLE
[export][ez] minor variable rename

### DIFF
--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -409,7 +409,7 @@ def _gather_constant_attrs(m: torch.nn.Module) -> ConstantAttrMap:
 
 
 def _export_non_strict(
-    mod,
+    mod: torch.nn.Module,
     fake_args,
     fake_kwargs,
     fake_params_buffers,
@@ -624,7 +624,7 @@ def _log_export_wrapper(fn):
 @_log_export_wrapper
 @_disable_prexisiting_fake_mode
 def _export(
-    f: torch.nn.Module,
+    mod: torch.nn.Module,
     args: Tuple[Any, ...],
     kwargs: Optional[Dict[str, Any]] = None,
     dynamic_shapes: Optional[Union[Dict[str, Any], Tuple[Any], List[Any]]] = None,
@@ -674,16 +674,15 @@ def _export(
     log_export_usage(event="export.enter", flags=flags)
     _EXPORT_FLAGS = flags
 
-    constraints = _process_dynamic_shapes(f, args, kwargs, dynamic_shapes) or []
+    constraints = _process_dynamic_shapes(mod, args, kwargs, dynamic_shapes) or []
 
     kwargs = kwargs or {}
 
-    constant_attrs = _gather_constant_attrs(f)
+    constant_attrs = _gather_constant_attrs(mod)
 
     flat_args, orig_in_spec = pytree.tree_flatten((args, kwargs))
 
     if not strict:
-        assert isinstance(f, torch.nn.Module)
         out_spec = None
 
         module_call_specs: Dict[str, Dict[str, pytree.TreeSpec]] = {}
@@ -760,13 +759,13 @@ def _export(
             fake_kwargs,
             equalities_inputs,
             original_signature,
-        ) = make_fake_inputs(f, args, kwargs, constraints)
+        ) = make_fake_inputs(mod, args, kwargs, constraints)
 
         fake_params_buffers = make_fake_params_buffers(
-            fake_mode, _get_params_buffers(f)
+            fake_mode, _get_params_buffers(mod)
         )
         ep_non_strict = _export_non_strict(
-            f,
+            mod,
             fake_args,
             fake_kwargs,
             fake_params_buffers,
@@ -815,13 +814,13 @@ def _export(
             assert res is not None
             gm = res.graph_module
 
-        _rewrite_non_persistent_buffers(f, ep_non_strict.sig, ep_non_strict.constants)
+        _rewrite_non_persistent_buffers(mod, ep_non_strict.sig, ep_non_strict.constants)
 
         return ExportedProgram(
             root=gm,
             graph=gm.graph,
             graph_signature=ep_non_strict.sig,
-            state_dict=f.state_dict(keep_vars=True),
+            state_dict=mod.state_dict(keep_vars=True),
             range_constraints=range_constraints,
             module_call_graph=[
                 ModuleCallEntry(
@@ -839,7 +838,7 @@ def _export(
         )
 
     gm_torch_level = _export_to_torch_ir(
-        f,
+        mod,
         args,
         kwargs,
         constraints,
@@ -927,8 +926,7 @@ def _export(
     )
     gm_torch_level.recompile()
 
-    if isinstance(f, torch.nn.Module):
-        _normalize_nn_module_stack(gm_torch_level, type(f))
+    _normalize_nn_module_stack(gm_torch_level, type(mod))
 
     # NOTE: graph module expects only positional args
     ep_non_strict = _export_non_strict(
@@ -988,17 +986,17 @@ def _export(
     # expected form. Each of these steps should probably get fixed upstream.
     # 1. Remove tensor constants that were added as buffers.
     _rewrite_dynamo_tensor_constants(
-        orig_mod_buffers=set(f.buffers()),
+        orig_mod_buffers=set(mod.buffers()),
         traced_mod_buffers=dict(gm_torch_level.named_buffers()),
         graph_signature=ep_non_strict.sig,
         constants=ep_non_strict.constants,
     )
     # 2. Restore FQN of param/buffers
-    param_buffer_table: Dict[str, str] = _get_param_buffer_mapping(f, gm_torch_level)
+    param_buffer_table: Dict[str, str] = _get_param_buffer_mapping(mod, gm_torch_level)
     _replace_param_buffer_names(param_buffer_table, export_graph_signature)
 
-    # 3. Correctly populate non-persistent buffers
-    _rewrite_non_persistent_buffers(f, ep_non_strict.sig, ep_non_strict.constants)
+    # 3. Remove non-persistent buffers from the graph signature
+    _rewrite_non_persistent_buffers(mod, ep_non_strict.sig, ep_non_strict.constants)
 
     # 4. Rewrite constants to have the same FQN as the original module.
     _remap_constants(constant_attrs, export_graph_signature, constants)
@@ -1018,7 +1016,7 @@ def _export(
         root=gm,
         graph=gm.graph,
         graph_signature=export_graph_signature,
-        state_dict=f.state_dict(keep_vars=True),
+        state_dict=mod.state_dict(keep_vars=True),
         range_constraints=range_constraints,
         module_call_graph=[
             ModuleCallEntry(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121040
* #121037

since `_export()` now takes an `nn.Module` only (which is asserted against at an upper layer), we should change this variable name from `f` to `mod` and remove some unnecessary isinstance checks

Differential Revision: [D54430381](https://our.internmc.facebook.com/intern/diff/D54430381/)