### PR TITLE
[C10d][NCCL] Refactor complex all_reduce and broadcast

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -2834,6 +2834,42 @@ class DistributedDataParallelTest(
         tensor = torch.ones((2, 16, 768, 1152), dtype=torch.float32, device=device).to(memory_format=torch.channels_last)
         process_group.broadcast([tensor]).wait()
 
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_ddp_complex_params(self):
+        class FFTModel(nn.Module):
+            def __init__(self, hin, win, n_features):
+                super().__init__()
+                self.hin = hin
+                self.win = win
+                self.weight = nn.Parameter(torch.ones((n_features, n_features, hin, win // 2 + 1), dtype=torch.cfloat))
+
+            def forward(self, x):
+                xc = torch.fft.rfft2(x, s=(self.hin, self.win), dim=(-2, -1), norm="ortho")
+                xcw = torch.einsum("nchw,cohw->nohw", xc, self.weight)
+                x = torch.fft.irfft2(xcw, dim=(-2, -1), norm="ortho")
+                return x
+
+        process_group = self._get_process_group()
+        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        N, C, H, W = 1, 16, 64, 64
+        ddp_model = DistributedDataParallel(
+            FFTModel(hin=H, win=W, n_features=C).to(device_id),
+            device_ids=[device_id],
+            process_group=process_group,
+        )
+        optimizer = torch.optim.Adam(ddp_model.parameters(), lr=0.001)
+
+        inp = torch.ones((N, C, H, W), dtype=torch.float32)
+
+        # train step
+        out = ddp_model(inp)
+        loss = torch.sum(out)
+        loss.backward()
+        optimizer.step()
+
+        torch.cuda.synchronize()
+
 
 class WorkHookTest(MultiProcessTestCase):
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -85,6 +85,22 @@ ncclDataType_t getNcclDataType(at::ScalarType type) {
   return it->second;
 }
 
+bool complexViewAsRealAllowed(const ReduceOp reduceOp) {
+  switch (reduceOp) {
+    case ReduceOp::SUM:
+      return true;
+    case ReduceOp::AVG:
+      return true;
+    case ReduceOp::PREMUL_SUM:
+      return true;
+    case ReduceOp::UNUSED:
+      return true;
+    default:
+      return false;
+  }
+  return false;
+}
+
 #ifdef ENABLE_NCCL_PREMUL_SUM_SUPPORT
 template <typename T, ncclDataType_t dataType>
 ncclRedOpRAII unpackPreMulSum(
@@ -2957,6 +2973,14 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::allreduce(
     const AllreduceOptions& opts) {
   TORCH_CHECK(tensors.size() == 1, MULTI_DEVICE_ERROR_MSG);
   auto tensor = tensors.back();
+  if (tensor.is_complex()) {
+    TORCH_CHECK(
+        complexViewAsRealAllowed(opts.reduceOp),
+        "all_reduce does not support",
+        opts.reduceOp,
+        "on complex tensors");
+    tensor = at::view_as_real(tensor);
+  }
   check_gpu_single_tensor(tensor);
 
   if (intraNodeComm_ != nullptr && opts.reduceOp == ReduceOp::SUM) {
@@ -3043,6 +3067,9 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::broadcast(
     const BroadcastOptions& opts) {
   TORCH_CHECK(tensors.size() == 1, MULTI_DEVICE_ERROR_MSG);
   auto tensor = tensors.back();
+  if (tensor.is_complex()) {
+    tensor = at::view_as_real(tensor);
+  }
   check_gpu_single_tensor(tensor);
 
   // @lint-ignore CLANGTIDY
@@ -3131,6 +3158,14 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::reduce(
   TORCH_CHECK(tensors.size() == 1, MULTI_DEVICE_ERROR_MSG);
   // @lint-ignore CLANGTIDY
   auto tensor = tensors.back();
+  if (tensor.is_complex()) {
+    TORCH_CHECK(
+        complexViewAsRealAllowed(opts.reduceOp),
+        "reduce does not support",
+        opts.reduceOp,
+        "on complex tensors");
+    tensor = at::view_as_real(tensor);
+  }
   check_gpu_single_tensor(tensor);
   RECORD_PARAM_COMMS_DATA(
       static_cast<int>(

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2222,8 +2222,6 @@ def all_reduce_coalesced(tensors, op=ReduceOp.SUM, group=None, async_op=False):
         _warn_not_in_group("all_reduce_coalesced")
         return
 
-    tensors = [t if not t.is_complex() else torch.view_as_real(t) for t in tensors]
-
     opts = AllreduceCoalescedOptions()
     opts.reduceOp = op
     if group is None:

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -60,7 +60,7 @@ __all__ = [
     'isend', 'monitored_barrier', 'new_group', 'new_subgroups',
     'new_subgroups_by_enumeration', 'recv', 'reduce',
     'reduce_scatter', 'scatter',
-    'scatter_object_list', 'send', 'supports_complex',
+    'scatter_object_list', 'send',
     'AllreduceCoalescedOptions', 'AllreduceOptions', 'AllToAllOptions',
     'BarrierOptions', 'BroadcastOptions', 'GatherOptions', 'PrefixStore',
     'ProcessGroup', 'ReduceOp', 'ReduceOptions', 'ReduceScatterOptions',
@@ -133,26 +133,6 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 PG_WRAPPER_STORE_PREFIX = "pg_wrapper"
-
-
-# Some reduce ops are not supported by complex numbers and will result in an error.
-# We currently provide complex support to the distributed API by viewing
-# complex tensors as real (torch.view_as_real), meaning that calling
-# these unsupported ops will return garbage values rather than error out.
-# (e.g. max(2+3i, 3+2i) = 3+3i)
-# We'd like calls to unsupported ops to error out accordingly,
-# rather than returning garbage values.
-def supports_complex(reduceOp: ReduceOp) -> bool:
-    """Return true if reduce ops is supported. False otherwise."""
-    denyList = [
-        ReduceOp.MAX,
-        ReduceOp.MIN,
-        ReduceOp.PRODUCT,
-        ReduceOp.BAND,
-        ReduceOp.BOR,
-        ReduceOp.BXOR,
-    ]
-    return reduceOp not in denyList
 
 
 class Backend(str):
@@ -2173,11 +2153,6 @@ def all_reduce(tensor, op=ReduceOp.SUM, group=None, async_op=False):
         _warn_not_in_group("all_reduce")
         return
 
-    if tensor.is_complex():
-        if not supports_complex(op):
-            raise ValueError(f"all_reduce does not support {op} on complex tensors")
-        tensor = torch.view_as_real(tensor)
-
     opts = AllreduceOptions()
     opts.reduceOp = op
     if group is None:
@@ -2246,9 +2221,6 @@ def all_reduce_coalesced(tensors, op=ReduceOp.SUM, group=None, async_op=False):
     if _rank_not_in_group(group):
         _warn_not_in_group("all_reduce_coalesced")
         return
-
-    if any(t.is_complex() for t in tensors) and not supports_complex(op):
-        raise ValueError(f"all_reduce does not support {op} on complex tensors")
 
     tensors = [t if not t.is_complex() else torch.view_as_real(t) for t in tensors]
 


### PR DESCRIPTION
The necessity of this PR lies in the fact that autograd engine + DDP calls `all_reduce` from C++, so the changes must be made in C++.

```
[rank0]: Traceback (most recent call last):
[rank0]:   File "~/complex_ddp.py", line 72, in <module>
[rank0]:     main()
[rank0]:   File "~/complex_ddp.py", line 64, in main
[rank0]:     loss.backward()
[rank0]:   File "/home/usr/pytorch/torch/_tensor.py", line 525, in backward
[rank0]:     torch.autograd.backward(
[rank0]:   File "/home/usr/pytorch/torch/autograd/__init__.py", line 267, in backward
[rank0]:     _engine_run_backward(
[rank0]:   File "/home/usr/pytorch/torch/autograd/graph.py", line 744, in _engine_run_backward
[rank0]:     return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
[rank0]: TypeError: Input tensor data type is not supported for NCCL process group: ComplexFloat
```

I believe, for minimizing the Python overhead, the same could be done for the rest of the ops, what do you think @kwen2501?

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @eqy @ptrblck 