### PR TITLE
[dynamo][comp-time] BuiltinVariableTracker - inspect signature only on failure

### DIFF
--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -15,13 +15,7 @@ import torch
 from torch import sym_float, sym_int
 
 from .. import config, polyfill, variables
-from ..exc import (
-    AttributeMutationError,
-    unimplemented,
-    Unsupported,
-    UserError,
-    UserErrorType,
-)
+from ..exc import AttributeMutationError, unimplemented, UserError, UserErrorType
 from ..guards import GuardBuilder, install_guard
 from ..replay_record import DummyModule
 from ..source import AttrSource, GetItemSource, is_constant_source, TypeSource
@@ -679,26 +673,27 @@ class BuiltinVariable(VariableTracker):
                     return res
 
         handler = getattr(self, f"call_{self.fn.__name__}", None)
-        if handler:
-            try:
-                inspect.signature(handler).bind(tx, *args, **kwargs)
-            except TypeError as exc:
-                has_constant_handler = self.has_constant_handler(args, kwargs)
-                if not has_constant_handler:
-                    log.warning(
-                        "incorrect arg count %s %s and no constant handler",
-                        handler,
-                        exc,
-                    )
-                handler = None
 
         if handler:
             try:
                 result = handler(tx, *args, **kwargs)
                 if result is not None:
                     return result
-            except Unsupported as exc:
+            except Exception as exc:
                 has_constant_handler = self.has_constant_handler(args, kwargs)
+
+                # Check if binding is bad. inspect signature bind is expensive.
+                # So check only when handler call fails.
+                try:
+                    inspect.signature(handler).bind(tx, *args, **kwargs)
+                except TypeError as e:
+                    if not has_constant_handler:
+                        log.warning(
+                            "incorrect arg count %s %s and no constant handler",
+                            handler,
+                            e,
+                        )
+                    handler = None
                 if not has_constant_handler:
                     raise
                 # Actually, we will handle this just fine


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #120825
* #121031
* #121052
* __->__ #121053

Reduces the torch.compile(backend="eager") for this code by 1-2 seconds.
~~~
def fn(x):
    for _ in range(10000):
        # x = torch.sin(x)
        x = torch.ops.aten.sin(x)
        # x = sin(x)

    return x
~~~
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng