### PR TITLE
[aten] Fix two warnings

### DIFF
--- a/aten/src/ATen/native/cuda/MemoryAccess.cuh
+++ b/aten/src/ATen/native/cuda/MemoryAccess.cuh
@@ -197,7 +197,7 @@ struct unroll {
     data(data), remaining(remaining), input_offset_calculator(ic), output_offset_calculator(oc), loader(l), storer(s) {}
 
   __device__ inline bool check_inbounds(int thread_work_elem) {
-    return ((threadIdx.x  + thread_work_elem*num_threads()) < remaining);
+    return (((int)threadIdx.x  + thread_work_elem*num_threads()) < remaining);
   }
 
   template<typename args_t>
@@ -219,7 +219,6 @@ struct unroll {
   template<typename scalar_t>
   __device__ inline void store(scalar_t *from, int idx) {
     int thread_idx = threadIdx.x;
-    scalar_t *to = reinterpret_cast<scalar_t *>(data[0]) + block_work_size() * idx;
     #pragma unroll
     for (int i = 0; i < thread_work_size(); i++) {
       if (thread_idx >= remaining) {


### PR DESCRIPTION
Summary:
Fixing two issues that causes build break:

buck-out/v2/gen/fbcode/16379dd050272c42/caffe2/__ATen-hip__/buck-headers/ATen/native/hip/MemoryAccess.cuh:223:15: error: unused variable 'to' [-Werror,-Wunused-variable]

buck-out/v2/gen/fbcode/16379dd050272c42/caffe2/__ATen-hip__/buck-headers/ATen/native/hip/MemoryAccess.cuh:201:76: error: expected ';' after return statement
 return ((int)threadIdx.x  + thread_work_elem*num_threads()) < remaining);

Test Plan: buck2 build mode/{opt,amd-gpu,inplace} -c fbcode.triton_backend=amd -c fbcode.enable_gpu_sections=true //hammer/modules/sequential/encoders/tests:hstu_bench --show-output

Differential Revision: D54434588


