### PR TITLE
[FSDP] restore fully_shard after exit from mock.patch

### DIFF
--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -1374,15 +1374,27 @@ def test_compiled_fsdp(compile_compute_on_module: Optional[type] = None):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
+            original_fully_shard = torch.distributed._composable.fsdp.fully_shard
             for fully_shard_patch in FullyShardPatch:
                 if fully_shard_patch != FullyShardPatch.EAGER and not has_triton():
                     warnings.warn("Inductor on GPU needs Triton and recent GPU arch")
                     continue
+                imported_fully_shard = (
+                    f"{func.__module__}.{original_fully_shard.__name__}"
+                )
                 with mock.patch(
-                    f"{func.__module__}.{torch.distributed._composable.fsdp.fully_shard.__name__}",
+                    imported_fully_shard,
                     fully_shard_patch.value,
                 ):
                     func(*args, **kwargs)
+                # mock.patch.__exit__ does not work with multi-thread
+                # thread 1 set func.__module__[fully_shard]
+                # thread 2 read func.__module__[fully_shard] and thought it is original
+                # hence we mannually reset them after __exit__
+                import_path, _ = mock._get_target(imported_fully_shard)  # type: ignore[attr-defined]
+                setattr(
+                    import_path(), original_fully_shard.__name__, original_fully_shard
+                )
 
         return wrapper
 

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -1388,9 +1388,9 @@ def test_compiled_fsdp(compile_compute_on_module: Optional[type] = None):
                 ):
                     func(*args, **kwargs)
                 # mock.patch.__exit__ does not work with multi-thread
-                # thread 1 set func.__module__[fully_shard]
-                # thread 2 read func.__module__[fully_shard] and thought it is original
-                # hence we mannually reset them after __exit__
+                # thread 1 set {func.__module__}.fully_shard
+                # thread 2 read {func.__module__}.fully_shard and thought it is original
+                # hence we manually reset them after __exit__
                 import_path, _ = mock._get_target(imported_fully_shard)  # type: ignore[attr-defined]
                 setattr(
                     import_path(), original_fully_shard.__name__, original_fully_shard

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -1390,7 +1390,7 @@ def test_compiled_fsdp(compile_compute_on_module: Optional[type] = None):
                 # mock.patch.__exit__ does not work with multi-thread
                 # thread 1 set func.__module__[fully_shard]
                 # thread 2 read func.__module__[fully_shard] and thought it is original
-                # hence we mannually reset them after __exit__
+                # hence we manually reset them after __exit__
                 import_path, _ = mock._get_target(imported_fully_shard)  # type: ignore[attr-defined]
                 setattr(
                     import_path(), original_fully_shard.__name__, original_fully_shard

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -1387,6 +1387,7 @@ def test_compiled_fsdp(compile_compute_on_module: Optional[type] = None):
                     fully_shard_patch.value,
                 ):
                     func(*args, **kwargs)
+                    torch.distributed.barrier()
                 # mock.patch.__exit__ does not work with multi-thread
                 # thread 1 set {func.__module__}.fully_shard
                 # thread 2 read {func.__module__}.fully_shard and thought it is original


### PR DESCRIPTION
manually restore fully_shard after \_\_exit\_\_ from mock.patch ctx. This will fix flaky CIs in trunk 
```
pytest test/distributed/_composable/fsdp/test_fully_shard_training.py
```

this is a workaround to make mock.patch(fully_shard) work with multi-thread
* thread 1 set func.\_\_module\_\_[fully_shard] = patched function
* thread 2 read func.\_\_module\_\_[fully_shard], thought it is original and fail to restore fully_shard during \_\_exit\_\_
* this PR manually restore fully_shard after \_\_exit\_\_
