### PR TITLE
Spectral norm value test

### DIFF
--- a/test/nn/test_parametrization.py
+++ b/test/nn/test_parametrization.py
@@ -1388,6 +1388,20 @@ class TestNNParametrization(NNTestCase):
         expect_out = m(input)
         self.assertEqual(expect_out, out_hat)
 
+    def test_new_spectral_norm_value(self):
+        # a test that the spectral norm (= top singular value)
+        # is in fact properly calculated, using example of a simple diagonal matrix.
+        m = nn.Linear(2, 2)
+        with torch.no_grad():
+            # set weight to diagonal matrix with values 2., 1.
+            # so spectral norm is 2
+            m.weight = nn.Parameter(torch.diag(torch.tensor([2.0, 1.0])))
+            torch.nn.utils.parametrizations.spectral_norm(m)
+            # weights should be rescaled by spectral norm, so should now be
+            # diag(1., 0.5)
+            expected = torch.diag(torch.tensor([1.0, 0.5]))
+            self.assertEqual(m.weight.data, expected)
+
     @skipIfNoLapack
     def test_orthogonal_parametrization(self):
         # Orthogonal implements 6 algorithms (3x parametrizations times 2 options of use_trivialization)

--- a/test/nn/test_parametrization.py
+++ b/test/nn/test_parametrization.py
@@ -11,7 +11,7 @@ import torch.nn.init as init
 import torch.nn.utils.parametrize as parametrize
 from torch.nn import Parameter
 from torch.testing._internal.common_utils import run_tests, skipIfNoLapack, \
-    TemporaryFileName, instantiate_parametrized_tests, set_default_dtype
+    TemporaryFileName, instantiate_parametrized_tests, set_default_dtype, skipIfTorchDynamo
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_cuda import TEST_MULTIGPU
 from torch.testing._internal.common_nn import NNTestCase
@@ -1388,6 +1388,7 @@ class TestNNParametrization(NNTestCase):
         expect_out = m(input)
         self.assertEqual(expect_out, out_hat)
 
+    @skipIfTorchDynamo("Test does not work with TorchDynamo")
     def test_new_spectral_norm_value(self):
         # a test that the spectral norm (= top singular value)
         # is in fact properly calculated, using example of a simple diagonal matrix.


### PR DESCRIPTION

Spectral norm implementation has extensive tests, but there doesn't appear to be any checking that indeed the spectral norm (= top singular value) is correctly calculated. There should at least be one such testcase.

This adds one such testcase for the parameterizations.py implementation of spectral norm.
