### PR TITLE
Add method for comparing `ViewMeta` sequences.

### DIFF
--- a/aten/src/ATen/FunctionalStorageImpl.cpp
+++ b/aten/src/ATen/FunctionalStorageImpl.cpp
@@ -10,7 +10,7 @@ namespace at::functionalization {
 
 ViewMeta ViewMeta::to_out_idx(int64_t out_idx) {
   if (out_idx == this->out_index) return *this;
-  return ViewMeta(forward_fn, reverse_fn, is_multi_output, out_idx);
+  return ViewMeta(name, forward_fn, reverse_fn, is_multi_output, out_idx);
 }
 
 // Note [Functionalization: Alias Removal Part 2]

--- a/aten/src/ATen/FunctionalStorageImpl.h
+++ b/aten/src/ATen/FunctionalStorageImpl.h
@@ -29,17 +29,23 @@ namespace at::functionalization {
 // View Inverses] for details.
 struct ViewMeta {
   ViewMeta(
+      c10::string_view opname,
       std::function<Tensor(const Tensor&, int64_t)> forward,
       std::function<Tensor(const Tensor&, const Tensor&, int64_t)> reverse,
       bool is_multi_output = false,
       int64_t out_idx = 0)
-      : forward_fn(std::move(forward)),
+      : name(opname),
+        forward_fn(std::move(forward)),
         reverse_fn(std::move(reverse)),
         out_index(out_idx),
         is_multi_output(is_multi_output) {}
 
+  // Actual name of the operation.
+  c10::string_view name;
+
   std::function<Tensor(const Tensor&, int64_t)> forward_fn;
   std::function<Tensor(const Tensor&, const Tensor&, int64_t)> reverse_fn;
+
   // See Note [out_idx in ViewMeta]
   int64_t out_index;
 

--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -353,7 +353,8 @@ bool FunctionalTensorWrapper::are_view_metas_equal(const Tensor& other) {
 
   // Then, check if the name of each ViewMeta matches with other.
   // This ensures the order and actual view operations are the same.
-  for (int64_t i = 0; i < view_metas_.size(); i++) {
+  int64_t size = static_cast<int64_t>(view_metas_.size());
+  for (int64_t i = 0; i < size; i++) {
     if (view_metas_[i].name != other_functional_tensor->view_metas_[i].name) {
       return false;
     }

--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -353,7 +353,7 @@ bool FunctionalTensorWrapper::are_view_metas_equal(const Tensor& other) {
 
   // Then, check if the name of each ViewMeta matches with other.
   // This ensures the order and actual view operations are the same.
-  for (int i = 0; i < view_metas_.size(); i++) {
+  for (int64_t i = 0; i < view_metas_.size(); i++) {
     if (view_metas_[i].name != other_functional_tensor->view_metas_[i].name) {
       return false;
     }

--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -342,6 +342,26 @@ void FunctionalTensorWrapper::regenerate_from_base() {
   generation_ = storage_impl->generation();
 }
 
+bool FunctionalTensorWrapper::are_view_metas_equal(const Tensor& other) {
+  TORCH_CHECK(at::functionalization::impl::isFunctionalTensor(other));
+  auto other_functional_tensor = at::functionalization::impl::unsafeGetFunctionalWrapper(other);
+
+  // First, check if sizes are equal.
+  if (view_metas_.size() != other_functional_tensor->view_metas_.size()) {
+    return false;
+  }
+
+  // Then, check if the name of each ViewMeta matches with other.
+  // This ensures the order and actual view operations are the same.
+  for (int i = 0; i < view_metas_.size(); i++) {
+    if (view_metas_[i].name != other_functional_tensor->view_metas_[i].name) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 bool FunctionalTensorWrapper::apply_updates() {
   // Apply all updates on alias_
   auto storage_impl = functional_storage_impl();

--- a/aten/src/ATen/FunctionalTensorWrapper.h
+++ b/aten/src/ATen/FunctionalTensorWrapper.h
@@ -95,6 +95,10 @@ struct TORCH_API FunctionalTensorWrapper : public c10::TensorImpl {
         mutation_counter_;
   }
 
+  // Is the recorded ViewMeta sequence of this instance equal to the sequence
+  // on the other FunctionalTensorWrapper instance?
+  bool are_view_metas_equal(const Tensor& other);
+
   // Sync's the underlying tensor with its alias, if it's out of date. This
   // involves two steps: 1) Apply any pending updates/mutations to the alias 2)
   // Replay the views (if any) to regenerate the current tensor off of the

--- a/aten/src/ATen/FunctionalizeFallbackKernel.cpp
+++ b/aten/src/ATen/FunctionalizeFallbackKernel.cpp
@@ -157,6 +157,7 @@ static const at::Tensor & resize__functionalization(c10::DispatchKeySet dispatch
   // We have to emulate this "slicing" with an as_strided call.
   auto reapply_views = at::functionalization::impl::getFunctionalizationReapplyViewsTLS();
   at::functionalization::ViewMeta view_meta = at::functionalization::ViewMeta(
+    "resize_",
     [reapply_views = reapply_views, size = size.vec()](const at::Tensor & base, int64_t mutated_view_idx) -> at::Tensor {
       if (reapply_views) {
         return base.as_strided(size, c10::contiguous_strides(size));
@@ -281,6 +282,7 @@ static at::Tensor _unsafe_view_functionalize(const at::Tensor & self, at::SymInt
   }
 
   at::functionalization::ViewMeta view_meta = at::functionalization::ViewMeta(
+    "_unsafe_view",
     [size = size.vec()](const at::Tensor & base, int64_t mutated_view_idx) -> at::Tensor {
       return at::_unsafe_view_symint(base, size);
     },

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -799,6 +799,9 @@ def gen_pyi(
                 "def _functionalize_are_all_mutations_under_no_grad_or_inference_mode(t: Tensor) -> _bool: ..."
             ],
             "_functionalize_sync": ["def _functionalize_sync(t: Tensor) -> None: ..."],
+            "_functionalize_are_view_metas_equal": [
+                "def _functionalize_are_view_metas_equal(lhs: Tensor, rhs: Tensor) -> bool: ..."
+            ],
             "_enable_functionalization": [
                 "def _enable_functionalization(*, reapply_views: _bool = False): ..."
             ],

--- a/torch/csrc/autograd/python_torch_functions_manual.cpp
+++ b/torch/csrc/autograd/python_torch_functions_manual.cpp
@@ -664,6 +664,28 @@ static PyObject* THPVariable__functionalize_sync(
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject* THPVariable__functionalize_are_view_metas_equal(
+    PyObject* self,
+    PyObject* args,
+    PyObject* kwargs) {
+  HANDLE_TH_ERRORS
+  static PythonArgParser parser(
+      {"_functionalize_are_view_metas_equal(Tensor lhs, Tensor rhs)"},
+      /*traceable=*/true);
+
+  ParsedArgs<2> parsed_args;
+  auto r = parser.parse(args, kwargs, parsed_args);
+  auto lhs = r.tensor(0);
+  auto rhs = r.tensor(1);
+  TORCH_CHECK(at::functionalization::impl::isFunctionalTensor(lhs));
+  if (at::functionalization::impl::unsafeGetFunctionalWrapper(lhs)->are_view_metas_equal(rhs)) {
+    Py_RETURN_TRUE;
+  } else {
+    Py_RETURN_FALSE;
+  }
+  END_HANDLE_TH_ERRORS
+}
+
 static PyObject* THPVariable__functionalize_mark_mutation_hidden_from_autograd(
     PyObject* self,
     PyObject* args,
@@ -775,6 +797,10 @@ static PyMethodDef torch_functions_manual[] = {
      nullptr},
     {"_functionalize_sync",
      castPyCFunctionWithKeywords(THPVariable__functionalize_sync),
+     METH_VARARGS | METH_KEYWORDS | METH_STATIC,
+     nullptr},
+    {"_functionalize_are_view_metas_equal",
+     castPyCFunctionWithKeywords(THPVariable__functionalize_are_view_metas_equal),
      METH_VARARGS | METH_KEYWORDS | METH_STATIC,
      nullptr},
     {"_enable_functionalization",

--- a/torch/csrc/autograd/python_torch_functions_manual.cpp
+++ b/torch/csrc/autograd/python_torch_functions_manual.cpp
@@ -678,7 +678,8 @@ static PyObject* THPVariable__functionalize_are_view_metas_equal(
   auto lhs = r.tensor(0);
   auto rhs = r.tensor(1);
   TORCH_CHECK(at::functionalization::impl::isFunctionalTensor(lhs));
-  if (at::functionalization::impl::unsafeGetFunctionalWrapper(lhs)->are_view_metas_equal(rhs)) {
+  if (at::functionalization::impl::unsafeGetFunctionalWrapper(lhs)
+          ->are_view_metas_equal(rhs)) {
     Py_RETURN_TRUE;
   } else {
     Py_RETURN_FALSE;
@@ -800,7 +801,8 @@ static PyMethodDef torch_functions_manual[] = {
      METH_VARARGS | METH_KEYWORDS | METH_STATIC,
      nullptr},
     {"_functionalize_are_view_metas_equal",
-     castPyCFunctionWithKeywords(THPVariable__functionalize_are_view_metas_equal),
+     castPyCFunctionWithKeywords(
+         THPVariable__functionalize_are_view_metas_equal),
      METH_VARARGS | METH_KEYWORDS | METH_STATIC,
      nullptr},
     {"_enable_functionalization",

--- a/torchgen/gen_functionalization_type.py
+++ b/torchgen/gen_functionalization_type.py
@@ -349,6 +349,7 @@ def emit_view_functionalization_body(
             : at::functionalization::InverseReturnMode::NeverView
       );
       at::functionalization::ViewMeta view_meta = at::functionalization::ViewMeta(
+         "{noop_api_name}",
         {forward_lambda.decl()} {{
           if (reapply_views) {{
             return {forward_lambda.inner_call(reapply_views=True)}
@@ -421,6 +422,7 @@ def emit_view_functionalization_body(
         }}
       }}
       at::functionalization::ViewMeta view_meta = at::functionalization::ViewMeta(
+        "{noop_api_name}",
         {forward_lambda.decl()} {{
           if (reapply_views) {{
             return {forward_lambda.inner_call(reapply_views=True)}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #121007
* __->__ #121074

This PR introduces `FunctionalTensorWrapper::are_view_metas_equal`, which compares the
`ViewMeta` sequence of 2 instances of functional tensor.

In the next PR of this stack, we use this function when comparing two
`OutputAliasInfo`. It's needed there, since we are saving the functional tensor obtained
from the functionalization phase of AOTAutograd.

In summary, the changes are:

- Introduce a `name` field to `ViewMeta`, so that we are able to correctly compare each
  appended `ViewMeta` instance.
- Introduce `FunctionalTensorWrapper::are_view_metas_equal` that compares the `ViewMeta`
  sequence of each functional tensor.
- Modify the codegen as well as manual dispatches, so that they correctly instantiate
  `ViewMeta`, adding the name of the operator to the constructor.
- Add a Python API call to `are_view_metas_equal`
- Add tests for comparing `ViewMeta` sequences of different functional tensors.

cc @miladm @lezcano @JackCaoG @alanwaketan  