### PR TITLE
Temporarily increased compile time limit of #GPUs to 120.

### DIFF
--- a/c10/cuda/CUDAMacros.h
+++ b/c10/cuda/CUDAMacros.h
@@ -47,5 +47,5 @@ o */
 // fbcode depends on this value being 16
 #define C10_COMPILE_TIME_MAX_GPUS 16
 #else
-#define C10_COMPILE_TIME_MAX_GPUS 128
+#define C10_COMPILE_TIME_MAX_GPUS 128l
 #endif

--- a/c10/cuda/CUDAMacros.h
+++ b/c10/cuda/CUDAMacros.h
@@ -47,5 +47,5 @@ o */
 // fbcode depends on this value being 16
 #define C10_COMPILE_TIME_MAX_GPUS 16
 #else
-#define C10_COMPILE_TIME_MAX_GPUS 128l
+#define C10_COMPILE_TIME_MAX_GPUS 120
 #endif

--- a/c10/cuda/CUDAMacros.h
+++ b/c10/cuda/CUDAMacros.h
@@ -47,5 +47,5 @@ o */
 // fbcode depends on this value being 16
 #define C10_COMPILE_TIME_MAX_GPUS 16
 #else
-#define C10_COMPILE_TIME_MAX_GPUS 64
+#define C10_COMPILE_TIME_MAX_GPUS 128
 #endif

--- a/c10/cuda/CUDAMacros.h
+++ b/c10/cuda/CUDAMacros.h
@@ -41,7 +41,7 @@
 /**
  * The maximum number of GPUs that we recognizes. Increasing this beyond the
  * initial limit of 16 broke Caffe2 testing, hence the ifdef guards.
- * This value cannot be more than 255 because our DeviceIndex is a uint8_t.
+ * This value cannot be more than 128 because our DeviceIndex is a uint8_t.
 o */
 #ifdef FBCODE_CAFFE2
 // fbcode depends on this value being 16


### PR DESCRIPTION
Fixes #115331.

This is a temporary fix to increase the compile time number of GPUs to 120 until #119639 can be merged. Changing the parameter to 128 leads to annoying errors, as some checks would be tautological (`int8_t` is always < 128).
