### PR TITLE
Make ATen-cpu cuda/rocm agnostic

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -2669,3 +2669,93 @@ command = [
     '@{{PATHSFILE}}'
 ]
 is_formatter = true
+
+[[linter]]
+code = 'ATEN_CPU_GPU_AGNOSTIC'
+include_patterns = [
+    # aten source
+    "aten/src/ATen/*.cpp",
+    "aten/src/ATen/cpu/*.cpp",
+    "aten/src/ATen/functorch/**/*.cpp",
+    "aten/src/ATen/nnapi/*.cpp",
+    "aten/src/ATen/quantized/*.cpp",
+    "aten/src/ATen/vulkan/*.cpp",
+    "aten/src/ATen/metal/*.cpp",
+    "aten/src/ATen/detail/CPUGuardImpl.cpp",
+    "aten/src/ATen/detail/MetaGuardImpl.cpp",
+    # aten native source
+    "aten/src/ATen/native/cpu/*.cpp",
+    "aten/src/ATen/native/ao_sparse/cpu/kernels/*.cpp",
+    "aten/src/ATen/native/ao_sparse/quantized/cpu/kernels/*.cpp",
+    "aten/src/ATen/native/quantized/cpu/kernels/*.cpp",
+    "aten/src/ATen/native/*.cpp",
+    "aten/src/ATen/native/cpu/**/*.cpp",
+    "aten/src/ATen/native/ao_sparse/*.cpp",
+    "aten/src/ATen/native/ao_sparse/**/*.cpp",
+    "aten/src/ATen/native/ao_sparse/quantized/*.cpp",
+    "aten/src/ATen/native/ao_sparse/quantized/**/*.cpp",
+    "aten/src/ATen/native/nested/*.cpp",
+    "aten/src/ATen/native/quantized/*.cpp",
+    "aten/src/ATen/native/quantized/**/*.cpp",
+    "aten/src/ATen/native/sparse/*.cpp",
+    "aten/src/ATen/native/transformers/*.cpp",
+    "aten/src/ATen/native/utils/*.cpp",
+    "aten/src/ATen/native/xnnpack/*.cpp",
+    "aten/src/ATen/native/metal/MetalPrepackOpRegister.cpp",
+    # aten headers
+    "aten/src/ATen/*.h",
+    "aten/src/ATen/functorch/**/*.h",
+    "aten/src/ATen/ops/*.h",
+    "aten/src/ATen/cpu/**/*.h",
+    "aten/src/ATen/nnapi/*.h",
+    "aten/src/ATen/quantized/*.h",
+    "aten/src/ATen/vulkan/*.h",
+    "aten/src/ATen/metal/*.h",
+    "aten/src/ATen/mps/*.h",
+    # aten native headers
+    "aten/src/ATen/native/*.h",
+    "aten/src/ATen/native/cpu/**/*.h",
+    "aten/src/ATen/native/nested/*.h",
+    "aten/src/ATen/native/sparse/*.h",
+    "aten/src/ATen/native/ao_sparse/*.h",
+    "aten/src/ATen/native/ao_sparse/cpu/*.h",
+    "aten/src/ATen/native/ao_sparse/quantized/*.h",
+    "aten/src/ATen/native/ao_sparse/quantized/cpu/*.h",
+    "aten/src/ATen/native/quantized/*.h",
+    "aten/src/ATen/native/quantized/cpu/*.h",
+    "aten/src/ATen/native/transformers/*.h",
+    "aten/src/ATen/native/quantized/cpu/qnnpack/include/*.h",
+    "aten/src/ATen/native/utils/*.h",
+    "aten/src/ATen/native/vulkan/ops/*.h",
+    "aten/src/ATen/native/xnnpack/*.h",
+    "aten/src/ATen/native/metal/MetalPrepackOpContext.h",
+    "aten/src/ATen/native/mps/Copy.h",
+    "aten/src/ATen/native/mkldnn/**/*.h",
+]
+exclude_patterns = [
+    "aten/src/ATen/Context.h",
+    "aten/src/ATen/Context.cpp",
+    "aten/src/ATen/DLConvertor.cpp",
+    "aten/src/ATen/core/Array.h",
+    "aten/src/ATen/native/ConvUtils.h",
+    "aten/src/ATen/native/quantized/ConvUtils.h",
+    "aten/src/ATen/native/sparse/SparseBlasImpl.cpp",  # triton implementation
+    "aten/src/ATen/native/transformers/attention.cpp",
+    "aten/src/ATen/native/**/cudnn/**",  # cudnn is cuda specific
+]
+command = [
+    'python3',
+    'tools/linter/adapters/grep_linter.py',
+    '--pattern=(^#if.*USE_ROCM.*)|(^#if.*USE_CUDA.*)',
+    '--linter-name=ATEN_CPU',
+    '--error-name=aten-cpu should be gpu agnostic',
+    """--error-description=\
+        We strongly discourage the compile-time divergence \
+        on ATen-CPU code for different GPU code. This \
+        disallows sharing the same aten-cpu shared object \
+        between different GPU backends \
+    """,
+    '--',
+    '@{{PATHSFILE}}'
+]
+is_formatter = true

--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -433,25 +433,23 @@ bool NoTF32Guard::should_disable_tf32() {
   return override_allow_tf32_flag;
 }
 
-#ifdef USE_ROCM
 // Ops can query this flag to know they are in the backward pass.
 // This information can be used, for example, to select implementations
 // with different numerical or performance characteristics.
 // See https://pytorch.org/docs/stable/notes/numerical_accuracy.html for details.
-thread_local bool ROCmBackwardPassGuard::is_backward_pass_;
+thread_local bool rocm_is_backward_pass;
 
 ROCmBackwardPassGuard::ROCmBackwardPassGuard() {
-  is_backward_pass_ = true;
+  rocm_is_backward_pass = true;
 }
 
 ROCmBackwardPassGuard::~ROCmBackwardPassGuard() {
-  is_backward_pass_ = false;
+  rocm_is_backward_pass = false;
 }
 
 bool ROCmBackwardPassGuard::is_backward_pass() {
-  return is_backward_pass_;
+  return rocm_is_backward_pass;
 }
-#endif
 
 bool Context::areVmapFallbackWarningsEnabled() const {
   return display_vmap_fallback_warnings_;

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -548,15 +548,10 @@ struct TORCH_API NoTF32Guard {
   bool changed = false;
 };
 
-#ifdef USE_ROCM
 struct TORCH_API ROCmBackwardPassGuard {
   ROCmBackwardPassGuard();
   ~ROCmBackwardPassGuard();
   static bool is_backward_pass();
-
- private:
-  static thread_local bool is_backward_pass_;
 };
-#endif
 
 } // namespace at


### PR DESCRIPTION
Summary: This specific rocm logic will make aten-cpu code diverge between rocm and cuda. This is not good because we won't be able to share aten-cpu.so between rocm and cuda. More specifically, this will prevent us build aten-hip by default, which requires us to set up rocm specific rules which is an extra burden for our build system.

Test Plan: sandcastle + oss ci

Differential Revision: D54453492




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang