### PR TITLE
[Clang-tidy header][22/N] Fix clang-tidy warnings in aten/src/ATEN/*.{cpp,h}

### DIFF
--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -305,7 +305,7 @@ Tensor fromDLPack(const DLManagedTensor* src) {
 
 Tensor fromDLPack(
     const DLManagedTensor* src,
-    std::function<void(void*)> deleter) {
+    const std::function<void(void*)>& deleter) {
   Device device = getATenDevice(src->dl_tensor.device, src->dl_tensor.data);
   ScalarType stype = toScalarType(src->dl_tensor.dtype);
   if (!src->dl_tensor.strides) {

--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -293,18 +293,17 @@ DLManagedTensor* toDLPack(const Tensor& src) {
   return &(atDLMTensor->tensor);
 }
 
-Tensor fromDLPack(const DLManagedTensor* src) {
+Tensor fromDLPack(DLManagedTensor* src) {
   auto deleter = [src](void* self) {
     if (src->deleter) {
-      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-      src->deleter(const_cast<DLManagedTensor*>(src));
+      src->deleter(src);
     }
   };
   return fromDLPack(src, std::move(deleter));
 }
 
 Tensor fromDLPack(
-    const DLManagedTensor* src,
+    DLManagedTensor* src,
     std::function<void(void*)> deleter) {
   Device device = getATenDevice(src->dl_tensor.device, src->dl_tensor.data);
   ScalarType stype = toScalarType(src->dl_tensor.dtype);

--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -305,7 +305,7 @@ Tensor fromDLPack(const DLManagedTensor* src) {
 
 Tensor fromDLPack(
     const DLManagedTensor* src,
-    const std::function<void(void*)>& deleter) {
+    std::function<void(void*)> deleter) {
   Device device = getATenDevice(src->dl_tensor.device, src->dl_tensor.data);
   ScalarType stype = toScalarType(src->dl_tensor.dtype);
   if (!src->dl_tensor.strides) {

--- a/aten/src/ATen/DLConvertor.h
+++ b/aten/src/ATen/DLConvertor.h
@@ -12,9 +12,9 @@ namespace at {
 
 TORCH_API ScalarType toScalarType(const DLDataType& dtype);
 TORCH_API DLManagedTensor* toDLPack(const Tensor& src);
-TORCH_API Tensor fromDLPack(const DLManagedTensor* src);
+TORCH_API Tensor fromDLPack(DLManagedTensor* src);
 TORCH_API Tensor
-fromDLPack(const DLManagedTensor* src, std::function<void(void*)> deleter);
+fromDLPack(DLManagedTensor* src, std::function<void(void*)> deleter);
 TORCH_API DLDataType getDLDataType(const Tensor& t);
 TORCH_API DLDevice getDLContext(const Tensor& tensor, const int64_t& device_id);
 

--- a/aten/src/ATen/DLConvertor.h
+++ b/aten/src/ATen/DLConvertor.h
@@ -13,8 +13,9 @@ namespace at {
 TORCH_API ScalarType toScalarType(const DLDataType& dtype);
 TORCH_API DLManagedTensor* toDLPack(const Tensor& src);
 TORCH_API Tensor fromDLPack(const DLManagedTensor* src);
-TORCH_API Tensor
-fromDLPack(const DLManagedTensor* src, std::function<void(void*)> deleter);
+TORCH_API Tensor fromDLPack(
+    const DLManagedTensor* src,
+    const std::function<void(void*)>& deleter);
 TORCH_API DLDataType getDLDataType(const Tensor& t);
 TORCH_API DLDevice getDLContext(const Tensor& tensor, const int64_t& device_id);
 

--- a/aten/src/ATen/DLConvertor.h
+++ b/aten/src/ATen/DLConvertor.h
@@ -13,9 +13,8 @@ namespace at {
 TORCH_API ScalarType toScalarType(const DLDataType& dtype);
 TORCH_API DLManagedTensor* toDLPack(const Tensor& src);
 TORCH_API Tensor fromDLPack(const DLManagedTensor* src);
-TORCH_API Tensor fromDLPack(
-    const DLManagedTensor* src,
-    const std::function<void(void*)>& deleter);
+TORCH_API Tensor
+fromDLPack(const DLManagedTensor* src, std::function<void(void*)> deleter);
 TORCH_API DLDataType getDLDataType(const Tensor& t);
 TORCH_API DLDevice getDLContext(const Tensor& tensor, const int64_t& device_id);
 

--- a/aten/src/ATen/ExpandUtils.cpp
+++ b/aten/src/ATen/ExpandUtils.cpp
@@ -15,13 +15,13 @@ namespace {
 // NOTE: are_expandable did a similar check, please keep them sync if change is needed
 template <typename Container, typename ArrayType>
 Container infer_size_impl(ArrayType a, ArrayType b) {
-  size_t dimsA = a.size();
-  size_t dimsB = b.size();
-  size_t ndim = dimsA > dimsB ? dimsA : dimsB;
+  // Use ptrdiff_t to ensure signed comparison.
+  auto dimsA = static_cast<ptrdiff_t>(a.size());
+  auto dimsB = static_cast<ptrdiff_t>(b.size());
+  auto ndim = dimsA > dimsB ? dimsA : dimsB;
   Container expandedSizes(ndim);
 
-  // Use ptrdiff_t to ensure signed comparison.
-  for (ptrdiff_t i = (ptrdiff_t)ndim - 1; i >= 0; --i) {
+  for (ptrdiff_t i = ndim - 1; i >= 0; --i) {
     ptrdiff_t offset = ndim - 1 - i;
     ptrdiff_t dimA = dimsA - 1 - offset;
     ptrdiff_t dimB = dimsB - 1 - offset;
@@ -63,8 +63,8 @@ C10_ALWAYS_INLINE InferExpandGeometryResult<Container> inferExpandGeometryImpl(
     IntArrayRef tensor_sizes,
     IntArrayRef tensor_strides,
     IntArrayRef sizes) {
-  int64_t ndim = sizes.size();
-  int64_t tensor_dim = tensor_sizes.size();
+  int64_t ndim = static_cast<int64_t>(sizes.size());
+  int64_t tensor_dim = static_cast<int64_t>(tensor_sizes.size());
 
   if (tensor_dim == 0) {
     return InferExpandGeometryResult<Container>(sizes, ndim);

--- a/aten/src/ATen/SparseCsrTensorUtils.h
+++ b/aten/src/ATen/SparseCsrTensorUtils.h
@@ -243,22 +243,22 @@ inline std::string plainDimName(Layout layout) {
   }
 }
 
-inline int rowDimension(Layout layout, IntArrayRef size) {
+inline size_t rowDimension(Layout layout, IntArrayRef size) {
   return size.size() - (isCompressedRow(layout) ? 2 : 1);
 }
 
-inline int columnDimension(Layout layout, IntArrayRef size) {
+inline size_t columnDimension(Layout layout, IntArrayRef size) {
   return size.size() - (isCompressedColumn(layout) ? 2 : 1);
 }
 
-inline int compressedDimension(
+inline size_t compressedDimension(
     Layout layout,
     IntArrayRef size,
     size_t dense_ndim = 0) {
   return size.size() - dense_ndim - (isCompressedRow(layout) ? 2 : 1);
 }
 
-inline int plainDimension(
+inline size_t plainDimension(
     Layout layout,
     IntArrayRef size,
     size_t dense_ndim = 0) {

--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -813,7 +813,7 @@ bool TensorIteratorBase::is_contiguous() const {
 }
 
 
-bool TensorIteratorBase::is_scalar(int arg) const {
+bool TensorIteratorBase::is_scalar(int64_t arg) const {
   const auto& stride = operands_[arg].stride_bytes;
   for (const auto i : c10::irange(ndim())) {
     if (stride[i] != 0 && shape_[i] != 1) {
@@ -823,7 +823,7 @@ bool TensorIteratorBase::is_scalar(int arg) const {
   return true;
 }
 
-bool TensorIteratorBase::is_cpu_scalar(int arg) const {
+bool TensorIteratorBase::is_cpu_scalar(int64_t arg) const {
   return is_scalar(arg) && device(arg).is_cpu();
 }
 
@@ -844,15 +844,15 @@ void TensorIteratorBase::cast_outputs() {
   }
 }
 
-void* TensorIteratorBase::data_ptr(int arg) const {
+void* TensorIteratorBase::data_ptr(int64_t arg) const {
   return operands_[arg].data;
 }
 
-void TensorIteratorBase::remove_operand(int arg) {
+void TensorIteratorBase::remove_operand(int64_t arg) {
   operands_.erase(operands_.begin() + arg);
 }
 
-void TensorIteratorBase::unsafe_replace_operand(int arg, void* data) {
+void TensorIteratorBase::unsafe_replace_operand(int64_t arg, void* data) {
   operands_[arg].data = data;
 }
 

--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -293,11 +293,11 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
   bool is_dim_reduced(int dim) const;
 
   /// Accessors for each operand
-  IntArrayRef strides(int arg) const {
+  IntArrayRef strides(int64_t arg) const {
     return operands_[arg].stride_bytes;
   }
-  void* data_ptr(int arg) const;
-  ScalarType dtype(int arg = 0) const {
+  void* data_ptr(int64_t arg) const;
+  ScalarType dtype(int64_t arg = 0) const {
     return operands_[arg].current_dtype;
   }
   ScalarType common_dtype() const {
@@ -306,43 +306,43 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
         "Queried for invalid common dtype!");
     return common_dtype_;
   }
-  ScalarType input_dtype(int arg = 0) const {
+  ScalarType input_dtype(int64_t arg = 0) const {
     return operands_[num_outputs_ + arg].current_dtype;
   }
-  Device device(int arg = 0) const {
+  Device device(int64_t arg = 0) const {
     return operands_[arg].device.value();
   }
-  c10::DeviceType device_type(int arg = 0) const {
+  c10::DeviceType device_type(int64_t arg = 0) const {
     return device(arg).type();
   }
-  int64_t element_size(int arg) const {
+  int64_t element_size(int64_t arg) const {
     return static_cast<int64_t>(elementSize(dtype(arg)));
   }
-  bool is_scalar(int arg) const;
-  bool is_cpu_scalar(int arg) const;
+  bool is_scalar(int64_t arg) const;
+  bool is_cpu_scalar(int64_t arg) const;
 
-  const TensorBase& tensor_base(int arg) const {
+  const TensorBase& tensor_base(int64_t arg) const {
     return operands_[arg].tensor_base();
   }
-  const Tensor& tensor(int arg) const {
+  const Tensor& tensor(int64_t arg) const {
     return operands_[arg].tensor();
   }
 
-  const TensorBase& output_base(int arg = 0) const {
+  const TensorBase& output_base(int64_t arg = 0) const {
     AT_ASSERT(arg < num_outputs_);
     return tensor_base(arg);
   }
 
-  const Tensor& output(int arg = 0) const {
+  const Tensor& output(int64_t arg = 0) const {
     AT_ASSERT(arg < num_outputs_);
     return tensor(arg);
   }
 
-  const TensorBase& input_base(int arg = 0) const {
+  const TensorBase& input_base(int64_t arg = 0) const {
     AT_ASSERT(arg >= 0 && arg < ntensors() - num_outputs_);
     return tensor_base(num_outputs_ + arg);
   }
-  const Tensor& input(int arg = 0) const {
+  const Tensor& input(int64_t arg = 0) const {
     AT_ASSERT(arg >= 0 && arg < ntensors() - num_outputs_);
     return tensor(num_outputs_ + arg);
   }
@@ -352,7 +352,7 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
   void cast_outputs();
 
   /// Removes an operand from this iterator
-  void remove_operand(int arg);
+  void remove_operand(int64_t arg);
   /// Shrinks an iterated dimension
   void narrow(int dim, int64_t start, int64_t size);
   /// Narrows every dim after and including `start_dim` to size one.
@@ -360,7 +360,7 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
   /// Replaces the data pointer for the operand at index `arg`.
   /// The new pointer should have the same sizes, strides and dtype as the
   /// original
-  void unsafe_replace_operand(int arg, void* data);
+  void unsafe_replace_operand(int64_t arg, void* data);
 
   /// Splits this TensorIterator into two iterators. Together they iterate over
   /// the entire operation. Used by `with_32bit_indexing()`.
@@ -370,7 +370,7 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
   int get_dim_to_split() const;
 
   template <typename T>
-  T scalar_value(int arg) {
+  T scalar_value(int64_t arg) {
     auto& op = operands_[arg];
     return c10::fetch_and_cast<T>(op.tensor_base().scalar_type(), op.data);
   }
@@ -380,7 +380,7 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
   /// If the scalar is aleady given in the type of Half, then return scalar
   /// value from tensor_base.
   template <typename T>
-  T original_scalar_value(int arg) {
+  T original_scalar_value(int64_t arg) {
     auto& original_tensor_base = operands_[arg].original_tensor_base();
     if (original_tensor_base.defined()) {
       TORCH_INTERNAL_ASSERT(
@@ -465,10 +465,10 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
   PtrVector get_base_ptrs() const;
 
   // Helper functions for advanced stride manipulations (e.g. torch.flip)
-  void _unsafe_set_arg_strides(const int arg, IntArrayRef strides) {
+  void _unsafe_set_arg_strides(const int64_t arg, IntArrayRef strides) {
     operands_[arg].stride_bytes = strides;
   }
-  void _unsafe_set_arg_data(const int arg, void* data) {
+  void _unsafe_set_arg_data(const int64_t arg, void* data) {
     operands_[arg].data = data;
   }
 

--- a/aten/src/ATen/TensorOperators.h
+++ b/aten/src/ATen/TensorOperators.h
@@ -9,9 +9,6 @@
 #include <ATen/ops/empty_like.h>
 #endif
 
-#include <stdexcept>
-#include <string>
-
 namespace at {
 
 #define AT_FORALL_BINARY_OPS(_)                                             \

--- a/aten/src/ATen/TensorUtils.cpp
+++ b/aten/src/ATen/TensorUtils.cpp
@@ -68,7 +68,7 @@ void checkAllContiguous(CheckedFrom c, at::ArrayRef<TensorArg> ts) {
 }
 
 void checkSize(CheckedFrom c, const TensorGeometryArg& t, IntArrayRef sizes) {
-  checkDim(c, t, sizes.size());
+  checkDim(c, t, static_cast<int64_t>(sizes.size()));
   TORCH_CHECK(
     t->sizes().equals(sizes),
     "Expected tensor of size ", sizes, ", but got tensor of size ", t->sizes(),
@@ -76,7 +76,7 @@ void checkSize(CheckedFrom c, const TensorGeometryArg& t, IntArrayRef sizes) {
 }
 
 void checkSize_symint(CheckedFrom c, const TensorGeometryArg& t, c10::SymIntArrayRef sizes) {
-  checkDim(c, t, sizes.size());
+  checkDim(c, t, static_cast<int64_t>(sizes.size()));
   TORCH_CHECK(
     t->sym_sizes().equals(sizes),
     "Expected tensor of size ", sizes, ", but got tensor of size ", t->sizes(),

--- a/aten/src/ATen/ThreadLocalState.h
+++ b/aten/src/ATen/ThreadLocalState.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <stack>
-
 #include <c10/core/InferenceMode.h>
 #include <c10/core/impl/LocalDispatchKeySet.h>
 #include <c10/util/Exception.h>
@@ -98,6 +96,7 @@ class TORCH_API ThreadLocalStateGuard {
   }
 
  private:
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const ThreadLocalState prev_state_;
 };
 

--- a/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
@@ -151,11 +151,11 @@ static void _validate_sparse_compressed_tensor_args_worker(const Tensor& compres
               "expected ", compressed_indices_name, " to be a strided tensor but got ", compressed_indices.layout(), " tensor");
 
   const int base_ndim = 2;  // corresponds to compressed and plain indices
-  const int batch_ndim = compressed_indices.dim() - 1;
+  const auto batch_ndim = compressed_indices.dim() - 1;
   const int block_ndim = AT_DISPATCH_PLAIN_SPARSE_COMPRESSED_LAYOUTS(
                            layout, "validate_sparse_compressed_tensor_args",
                            [&] { return 0; }, [&] { return 2; });
-  const int dense_ndim = values.dim() - batch_ndim - block_ndim - 1;
+  const auto dense_ndim = values.dim() - batch_ndim - block_ndim - 1;
 
   // 2.3
   TORCH_CHECK(values.layout() == kStrided,
@@ -231,8 +231,7 @@ static void _validate_sparse_compressed_tensor_args_worker(const Tensor& compres
   }
   const int64_t nrows = size[batch_ndim] / blocksize[0];
   const int64_t ncols = size[batch_ndim + 1] / blocksize[1];
-  int64_t compressed_dim_size, plain_dim_size;
-  std::tie(compressed_dim_size, plain_dim_size) = AT_DISPATCH_ROW_SPARSE_COMPRESSED_LAYOUTS(layout, "validate_sparse_compressed_tensor_args",
+  auto [compressed_dim_size, plain_dim_size] = AT_DISPATCH_ROW_SPARSE_COMPRESSED_LAYOUTS(layout, "validate_sparse_compressed_tensor_args",
                                                                                             [&] { return std::make_tuple(nrows, ncols); },
                                                                                             [&] { return std::make_tuple(ncols, nrows); });
   // 3.8
@@ -333,7 +332,7 @@ static SparseCsrTensor new_compressed_tensor(const TensorOptions& options) {
   // constructor.
   // TORCH_INTERNAL_ASSERT(impl::variable_excluded_from_dispatch());
   Layout layout = AT_DISPATCH_ALL_SPARSE_COMPRESSED_LAYOUTS(options.layout(), "new_compressed_tensor", [&] { return the_layout; });
-  DispatchKey dispatch_key;
+  DispatchKey dispatch_key = DispatchKey::Undefined;
 
   switch(options.device().type()) {
   case kCPU:
@@ -419,7 +418,7 @@ static DimVector _estimate_sparse_compressed_tensor_size(
     Layout layout) {
   const int block_ndim = AT_DISPATCH_PLAIN_SPARSE_COMPRESSED_LAYOUTS(layout, "estimate_sparse_compressed_tensor_size", [&] { return 0; }, [&] { return 2; });
   const int base_ndim = 2;  // corresponds to compressed and plain indices
-  const int batch_ndim = compressed_indices.dim() - 1;
+  const auto batch_ndim = compressed_indices.dim() - 1;
   const std::string compressed_indices_name = compressedIndicesName(layout);
   const std::string plain_indices_name = plainIndicesName(layout);
   TORCH_CHECK(
@@ -429,7 +428,7 @@ static DimVector _estimate_sparse_compressed_tensor_size(
               compressed_indices.dim() == plain_indices.dim(),
               compressed_indices_name, " and ", plain_indices_name, " dimensionalities must be equal but got ",
               compressed_indices.dim(), " and ", plain_indices.dim(), ", respectively");
-  const int dense_ndim = values.dim() - batch_ndim - block_ndim - 1;
+  const int64_t dense_ndim = values.dim() - batch_ndim - block_ndim - 1;
   TORCH_CHECK(
               dense_ndim >= 0,
               "values must have dimensionality > sum of batch and block dimensionalities (=",


### PR DESCRIPTION
This PR continues to fix clang-tidy warnings in aten/src/ATEN/*, following #120763.


cc @ezyang @gchanan