### PR TITLE
Include the bound check and test for slow_conv3d

### DIFF
--- a/aten/src/ATen/native/ConvolutionMM3d.cpp
+++ b/aten/src/ATen/native/ConvolutionMM3d.cpp
@@ -376,6 +376,11 @@ void slow_conv3d_backward_out_cpu_template(
     IntArrayRef stride,
     IntArrayRef padding,
     int64_t groups) {
+
+  TORCH_CHECK(kernel_size.size() >= 3, "kernel_size should be at least 3-dimensional");
+  TORCH_CHECK(padding.size() >= 3, "padding should be at least 3-dimensional");
+  TORCH_CHECK(stride.size() >= 3, "stride should be at least 3-dimensional");
+
   const int64_t kernel_depth = kernel_size[0];
   const int64_t kernel_height = kernel_size[1];
   const int64_t kernel_width = kernel_size[2];
@@ -500,6 +505,10 @@ static void slow_conv3d_backward_parameters_out_cpu_template(
   CheckedFrom c = "slow_conv3d_backward_parameters_cpu";
   auto grad_weight_arg = TensorArg(grad_weight, "grad_weight_arg", 0);
 
+  TORCH_CHECK(kernel_size.size() >= 3, "kernel_size should be at least 3-dimensional");
+  TORCH_CHECK(padding.size() >= 3, "padding should be at least 3-dimensional");
+  TORCH_CHECK(stride.size() >= 3, "stride should be at least 3-dimensional");
+
   const int64_t kernel_depth = kernel_size[0];
   const int64_t kernel_height = kernel_size[1];
   const int64_t kernel_width = kernel_size[2];
@@ -560,6 +569,10 @@ Tensor& slow_conv3d_forward_out_cpu(const Tensor& self,
   // See [Note: hacky wrapper removal for optional tensor]
   c10::MaybeOwned<Tensor> bias_maybe_owned = at::borrow_from_optional_tensor(bias_opt);
   const Tensor& bias = *bias_maybe_owned;
+
+  TORCH_CHECK(kernel_size.size() >= 3, "kernel_size should be at least 3-dimensional");
+  TORCH_CHECK(padding.size() >= 3, "padding should be at least 3-dimensional");
+  TORCH_CHECK(stride.size() >= 3, "stride should be at least 3-dimensional");
 
   const int64_t kernel_depth = kernel_size[0];
   const int64_t kernel_height = kernel_size[1];

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8214,15 +8214,15 @@ class TestNNDeviceType(NNTestCase):
             inp = torch.empty([1, 1, 1, 0], dtype=dtype, device=device)
             weight = torch.empty([1, 0, 1], dtype=dtype, device=device)
             torch._C._nn.slow_conv3d(inp, weight, 1)
-        with self.assertRaisesRegex(RuntimeError):
+        with self.assertRaises(RuntimeError):
             inp = torch.empty([1, 1, 1, 0], dtype=dtype, device=device)
             weight = torch.empty([1, 0, 1], dtype=dtype, device=device)
             torch._C._nn.slow_conv3d(inp, weight, kernel_size=[1], stride=[1, 1, 1], padding=[1, 1, 1])
-        with self.assertRaisesRegex(RuntimeError):
+        with self.assertRaises(RuntimeError):
             inp = torch.empty([1, 1, 1, 0], dtype=dtype, device=device)
             weight = torch.empty([1, 0, 1], dtype=dtype, device=device)
             torch._C._nn.slow_conv3d(inp, weight, kernel_size=[1, 1, 1], stride=[1, 1, 1], padding=[1])
-        with self.assertRaisesRegex(RuntimeError):
+        with self.assertRaises(RuntimeError):
             inp = torch.empty([1, 1, 1, 0], dtype=dtype, device=device)
             weight = torch.empty([1, 0, 1], dtype=dtype, device=device)
             torch._C._nn.slow_conv3d(inp, weight, kernel_size=[1, 1, 1], stride=[1], padding=[1, 1, 1])

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8214,24 +8214,15 @@ class TestNNDeviceType(NNTestCase):
             inp = torch.empty([1, 1, 1, 0], dtype=dtype, device=device)
             weight = torch.empty([1, 0, 1], dtype=dtype, device=device)
             torch._C._nn.slow_conv3d(inp, weight, 1)
-        with self.assertRaisesRegex(
-            RuntimeError,
-            re.escape("kernel_size should be at least 3-dimensional"),
-        ):
+        with self.assertRaisesRegex(RuntimeError):
             inp = torch.empty([1, 1, 1, 0], dtype=dtype, device=device)
             weight = torch.empty([1, 0, 1], dtype=dtype, device=device)
             torch._C._nn.slow_conv3d(inp, weight, kernel_size=[1], stride=[1, 1, 1], padding=[1, 1, 1])
-        with self.assertRaisesRegex(
-            RuntimeError,
-            re.escape("padding should be at least 3-dimensional"),
-        ):
+        with self.assertRaisesRegex(RuntimeError):
             inp = torch.empty([1, 1, 1, 0], dtype=dtype, device=device)
             weight = torch.empty([1, 0, 1], dtype=dtype, device=device)
             torch._C._nn.slow_conv3d(inp, weight, kernel_size=[1, 1, 1], stride=[1, 1, 1], padding=[1])
-        with self.assertRaisesRegex(
-            RuntimeError,
-            re.escape("stride should be at least 3-dimensional"),
-        ):
+        with self.assertRaisesRegex(RuntimeError):
             inp = torch.empty([1, 1, 1, 0], dtype=dtype, device=device)
             weight = torch.empty([1, 0, 1], dtype=dtype, device=device)
             torch._C._nn.slow_conv3d(inp, weight, kernel_size=[1, 1, 1], stride=[1], padding=[1, 1, 1])

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8214,6 +8214,28 @@ class TestNNDeviceType(NNTestCase):
             inp = torch.empty([1, 1, 1, 0], dtype=dtype, device=device)
             weight = torch.empty([1, 0, 1], dtype=dtype, device=device)
             torch._C._nn.slow_conv3d(inp, weight, 1)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            re.escape("kernel_size should be at least 3-dimensional"),
+        ):
+            inp = torch.empty([1, 1, 1, 0], dtype=dtype, device=device)
+            weight = torch.empty([1, 0, 1], dtype=dtype, device=device)
+            torch._C._nn.slow_conv3d(inp, weight, kernel_size=[1], stride=[1, 1, 1], padding=[1, 1, 1])
+        with self.assertRaisesRegex(
+            RuntimeError,
+            re.escape("padding should be at least 3-dimensional"),
+        ):
+            inp = torch.empty([1, 1, 1, 0], dtype=dtype, device=device)
+            weight = torch.empty([1, 0, 1], dtype=dtype, device=device)
+            torch._C._nn.slow_conv3d(inp, weight, kernel_size=[1, 1, 1], stride=[1, 1, 1], padding=[1])
+        with self.assertRaisesRegex(
+            RuntimeError,
+            re.escape("stride should be at least 3-dimensional"),
+        ):
+            inp = torch.empty([1, 1, 1, 0], dtype=dtype, device=device)
+            weight = torch.empty([1, 0, 1], dtype=dtype, device=device)
+            torch._C._nn.slow_conv3d(inp, weight, kernel_size=[1, 1, 1], stride=[1], padding=[1, 1, 1])
+
 
         with self.assertRaisesRegex(RuntimeError, re.escape("2D kernel_size expected")):
             torch._C._nn.thnn_conv2d(torch.rand([1, 1, 1, 1]), kernel_size=[], padding=[1, 1], stride=[1, 1],


### PR DESCRIPTION
Fixes #121095. Beyond the issue of empty input, the function also has issues when the input is not empty.

The values of the array are accessed without bound checking in

https://github.com/pytorch/pytorch/blob/089f4c0bd9237ac67758b7170df18219079681bc/aten/src/ATen/native/ConvolutionMM3d.cpp#L503

This leads to `undefined behavior and garbage values accessed` if the index is out of bounds. For example, repetitive runs of
```
import torch

# Input tensor of shape (batch_size, channels, depth, height, width)
import torch

# Input tensor of shape (batch_size, channels, depth, height, width)
input = torch.randn([1, 2, 7, 8, 9])

# Weight tensor of shape (out_channels, in_channels, kernel_depth, kernel_height, kernel_width)
weight = torch.randn([3, 2, 2, 2, 2])

output = torch._C._nn.slow_conv3d(input, weight, kernel_size = [1, 2, 3], stride= [1], padding=[1, 1, 1])
print(output)
```

gives
```
/home/lancerts/miniconda3/envs/wsl-dev/bin/python /mnt/d/programming/python/playground/slowconv_test.py
❯ /home/lancerts/miniconda3/envs/wsl-dev/bin/python /mnt/d/programming/python/playground/slowconv_test.py
Traceback (most recent call last):
  File "/mnt/d/programming/python/playground/slowconv_test.py", line 9, in <module>
    output = torch._C._nn.slow_conv3d(input, weight, kernel_size = [1, 2, 3], stride= [1], padding=[1, 1, 1])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: stride should be greater than zero, but got: 1 x 0 x 140184341062704 (TxHxW)
❯ /home/lancerts/miniconda3/envs/wsl-dev/bin/python /mnt/d/programming/python/playground/slowconv_test.py
Traceback (most recent call last):
  File "/mnt/d/programming/python/playground/slowconv_test.py", line 9, in <module>
    output = torch._C._nn.slow_conv3d(input, weight, kernel_size = [1, 2, 3], stride= [1], padding=[1, 1, 1])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: stride should be greater than zero, but got: 1 x 0 x 32 (TxHxW)

❯ /home/lancerts/miniconda3/envs/wsl-dev/bin/python /mnt/d/programming/python/playground/slowconv_test.py
Traceback (most recent call last):
  File "/mnt/d/programming/python/playground/slowconv_test.py", line 9, in <module>
    output = torch._C._nn.slow_conv3d(input, weight, kernel_size = [1, 2, 3], stride= [1], padding=[1, 1, 1])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: stride should be greater than zero, but got: 1 x 0 x 32 (TxHxW)
❯ /home/lancerts/miniconda3/envs/wsl-dev/bin/python /mnt/d/programming/python/playground/slowconv_test.py
Traceback (most recent call last):
  File "/mnt/d/programming/python/playground/slowconv_test.py", line 9, in <module>
    output = torch._C._nn.slow_conv3d(input, weight, kernel_size = [1, 2, 3], stride= [1], padding=[1, 1, 1])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: stride should be greater than zero, but got: 1 x 0 x 32 (TxHxW)
❯ /home/lancerts/miniconda3/envs/wsl-dev/bin/python /mnt/d/programming/python/playground/slowconv_test.py
Traceback (most recent call last):
  File "/mnt/d/programming/python/playground/slowconv_test.py", line 9, in <module>
    output = torch._C._nn.slow_conv3d(input, weight, kernel_size = [1, 2, 3], stride= [1], padding=[1, 1, 1])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: stride should be greater than zero, but got: 1 x 0 x 140013802793456 (TxHxW)
❯ /home/lancerts/miniconda3/envs/wsl-dev/bin/python /mnt/d/programming/python/playground/slowconv_test.py
Traceback (most recent call last):
  File "/mnt/d/programming/python/playground/slowconv_test.py", line 9, in <module>
    output = torch._C._nn.slow_conv3d(input, weight, kernel_size = [1, 2, 3], stride= [1], padding=[1, 1, 1])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: stride should be greater than zero, but got: 1 x 0 x 32 (TxHxW)
```

From above, stride[2] is not deterministic, accessed values `32`, `140184341062704`, `140013802793456`.
If we use stride.at(2) instead of stride[2], an error will be thrown whenever the index is out of bounds.
However, with stride[2], no error but garbage value can be accessed. 


- Include the explicit size check for     IntArrayRef kernel_size, IntArrayRef stride, and IntArrayRef padding as we are accessing their 0, 1, and 2 indices. 
- Added the tests.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10