### PR TITLE
[Not for landing][Prototype] Add torch._record_scalar

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -26,8 +26,8 @@
 #include <ATen/ops/_print_native.h>
 #include <ATen/ops/_assert_scalar_native.h>
 #include <ATen/ops/_functional_assert_scalar_native.h>
-#include <ATen/ops/_record_scalar.h>
-#include <ATen/ops/_functional_record_scalar.h>
+#include <ATen/ops/_record_scalar_native.h>
+#include <ATen/ops/_functional_record_scalar_native.h>
 #include <ATen/ops/_make_per_tensor_quantized_tensor.h>
 #include <ATen/ops/_unique.h>
 #include <ATen/ops/allclose_native.h>

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -26,6 +26,8 @@
 #include <ATen/ops/_print_native.h>
 #include <ATen/ops/_assert_scalar_native.h>
 #include <ATen/ops/_functional_assert_scalar_native.h>
+#include <ATen/ops/_record_scalar.h>
+#include <ATen/ops/_functional_record_scalar.h>
 #include <ATen/ops/_make_per_tensor_quantized_tensor.h>
 #include <ATen/ops/_unique.h>
 #include <ATen/ops/allclose_native.h>
@@ -432,6 +434,15 @@ void _assert_scalar(const Scalar& scalar, c10::string_view assert_msg) {
 
 Tensor _functional_assert_scalar(const Scalar& scalar, c10::string_view assert_msg, const Tensor& dep_token) {
   _assert_scalar(scalar, assert_msg);
+  return dep_token.clone();
+}
+
+void _record_scalar(const Scalar& scalar, c10::string_view prefix, c10::string_view filename) {
+  std::cout << prefix << ": " << scalar.toDouble() << "\n";
+}
+
+Tensor _functional_record_scalar(const Scalar& scalar, c10::string_view prefix, c10::string_view filename, const Tensor& dep_token) {
+  _record_scalar(scalar, prefix, filename);
   return dep_token.clone();
 }
 

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -438,7 +438,7 @@ Tensor _functional_assert_scalar(const Scalar& scalar, c10::string_view assert_m
 }
 
 void _record_scalar(const Scalar& scalar, c10::string_view prefix, c10::string_view filename) {
-  std::cout << prefix << ": " << scalar.toDouble() << "\n";
+  std::cout << prefix << ": " << scalar << "\n";
 }
 
 Tensor _functional_record_scalar(const Scalar& scalar, c10::string_view prefix, c10::string_view filename, const Tensor& dep_token) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -183,6 +183,14 @@
   dispatch:
     CompositeExplicitAutograd: _functional_assert_scalar
 
+- func: _record_scalar(Scalar self, str prefix, str filename) -> ()
+  dispatch:
+    CompositeExplicitAutograd: _record_scalar
+
+- func: _functional_record_scalar(Scalar self, str prefix, str filename, Tensor dep_token) -> Tensor
+  dispatch:
+    CompositeExplicitAutograd: _functional_record_scalar
+
 - func: _functional_assert_async.msg(Tensor self, str assert_msg, Tensor dep_token) -> Tensor
   dispatch:
     CPU: _functional_assert_async_msg_cpu

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -7657,6 +7657,7 @@ def fn():
     @torch._dynamo.config.patch(
         capture_scalar_outputs=True, capture_dynamic_output_shape_ops=True
     )
+    @unittest.skipIf(not TEST_CUDA, "requires cuda")
     def test_record_scalar(self):
         with tempfile.NamedTemporaryFile(mode="w+b") as f:
             torch.manual_seed(0)

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -69,6 +69,7 @@ from torch.nn import functional as F
 from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FLASH_ATTENTION,
+    SM70OrLater,
     SM80OrLater,
     TEST_CUDA,
     TEST_MULTIGPU,
@@ -7657,7 +7658,7 @@ def fn():
     @torch._dynamo.config.patch(
         capture_scalar_outputs=True, capture_dynamic_output_shape_ops=True
     )
-    @unittest.skipIf(not TEST_CUDA, "requires cuda")
+    @unittest.skipIf(not SM70OrLater, "requires GPU capability >= SM70")
     def test_record_scalar(self):
         with tempfile.NamedTemporaryFile(mode="w+b") as f:
             torch.manual_seed(0)
@@ -7672,7 +7673,7 @@ def fn():
                 def forward(self, x):
                     x = self.relu(self.linear(x) + self.buf0)
                     y = x.sum().item()
-                    torch._record_scalar(y, "x:sum: ", f.name)
+                    torch._record_scalar(y, "x:sum", f.name)
                     return x + 1, y + 1
 
             x = torch.randn(10, 10, device="cuda")

--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -335,6 +335,7 @@ aten::_foreach_zero.out
 aten::_foreach_zero_
 aten::_functional_assert_async.msg
 aten::_functional_assert_scalar
+aten::_functional_record_scalar
 aten::_functional_sym_constrain_range
 aten::_functional_sym_constrain_range_for_size
 aten::_fused_adam

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -2095,6 +2095,8 @@ torch_c_binding_in_graph_functions = dict.fromkeys(
         "torch.slice_inverse",
         "torch._assert_scalar",
         "torch._functional_assert_scalar",
+        "torch._record_scalar",
+        "torch._functional_record_scalar",
     ],
     TorchInGraphFunctionVariable,
 )

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4712,7 +4712,7 @@ class RecordScalar(ExternKernel):
         else:
             wrapper.writeline(f"with open('{self.filename}', 'a') as file:")
             wrapper.writeline(
-                f"    file.write('{self.prefix}' + str({self.scalar}) + '\\n')"
+                f"    file.write('{self.prefix}: ' + str({self.scalar}) + '\\n')"
             )
             # No one should ever use this buffer, but for uniformity
             # define the variable and assign it None

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2663,6 +2663,13 @@ def _assert_scalar(data, msg):
     return buffer
 
 
+@register_lowering(aten._record_scalar)
+def _record_scalar(data, prefix, filename):
+    buffer = ir.RecordScalar(data, prefix, filename)
+    buffer.name = V.graph.register_buffer(buffer)
+    return buffer
+
+
 def _full(fill_value, device, dtype, size):
     value = fill_value
     if not isinstance(fill_value, (int, float)) and hasattr(value, "value"):

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -654,6 +654,7 @@ def has_incompatible_cudagraph_ops(gm):
         # with CUDA graphs, but the operator is also pointless with
         # constant arguments, so might as well ban
         "aten._assert_scalar",
+        "aten._record_scalar",
     }
     if torch.are_deterministic_algorithms_enabled():
         forbidden_set.update(

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -602,6 +602,11 @@ def print_meta(s):
     return
 
 
+@register_meta(aten._record_scalar.default)
+def record_scalar_meta(scalar, prefix, filename):
+    return
+
+
 @register_meta(aten._make_dep_token.default)
 def make_dep_token(
     *,

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -44,6 +44,7 @@ _side_effectful_functions: Set[Callable] = {
     torch._assert_async,
     _ops.aten._assert_async.msg,
     _ops.aten._assert_scalar.default,
+    _ops.aten._record_scalar.default,
     _ops.aten.copy_.default,
     _ops.aten.sym_constrain_range.default,
     _ops.aten.sym_constrain_range_for_size.default,

--- a/torchgen/native_function_generation.py
+++ b/torchgen/native_function_generation.py
@@ -52,6 +52,7 @@ FUNCTIONAL_OPS_THAT_CANNOT_GET_AN_OUT_VARIANT = [
     "_assert_async.msg",  # no return
     "_cslt_sparse_mm_search",  # returns an int
     "_assert_scalar",  # no return
+    "_record_scalar",  # no return
     "_dimI",  # returns an int
     "_dimV",  # returns an int
     "_has_same_storage_numel",  # returns a boolean


### PR DESCRIPTION
I'm adding this prototype to demonstrate a possible way that how intermediate logging works with torch.compile. The following example is a minimized repro and how it ladders up with proposed ```torch._record_scalar``` op. 
```
import torch
import torch.nn as nn
from typing import Tuple
from collections import deque
from functools import partial
from torch.utils.hooks import RemovableHandle

torch._dynamo.config.capture_scalar_outputs = True
torch._dynamo.config.capture_dynamic_output_shape_ops = True


my_config = dict()
my_config["MockModule"] = "mean"
my_config["MockModule.linear"] = "mean"
my_config["MockModule.relu"] = "mean"

record_path = "/tmp/record_scalar"


class MyLinear(torch.nn.Module):
    def __init__(self, in_features, out_features):
        super().__init__()
        self.weight = torch.nn.Parameter(torch.randn(out_features, in_features))
        self.bias = torch.nn.Parameter(torch.randn(out_features))

    def forward(self, x):
        return torch.nn.functional.linear(x, self.weight, self.bias)


class MockModule(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.linear = MyLinear(10, 10)
        self.register_buffer("buf0", torch.randn(10, 10))

    def forward(self, x):
        return torch.nn.functional.relu(self.linear(x) + self.buf0)

def forward_hook(
    module: torch.nn.Module, inputs: torch.Tensor, output: torch.Tensor, prefix: str, aggregate_method: str
) -> torch.Tensor:
    if aggregate_method == "mean":
        torch._record_scalar(output.mean().item(), prefix, record_path)
    elif aggregate_method == "max":
        torch._record_scalar(output.max().item(), prefix, record_path)
    else:
        # demo purpose, using "min"
        torch._record_scalar(output.sum().item(), prefix, record_path)
    return output

def add_hooks(module, config):
    handles: List[RemovableHandle] = []
    q = deque([(module.__class__.__name__, module)])
    while q:
        name, m = q.pop()
        children = [(name + "." + n, y) for (n, y) in m.named_children()]
        q.extend(children)
        prefix = name + ":" + agg_method
        aggregate_method = config.get(name, "mean")
        handle = m.register_forward_hook(partial(forward_hook, prefix=prefix, aggregate_method=aggregate_method))
        if handle:
            handles.append(handle)
    return handles

x = torch.randn(10, 10, device="cuda")
mod = MockModule().to("cuda")

add_hooks(mod, my_config)

opt_mod = torch.compile(backend="inductor")(mod)
print(opt_mod(x))
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang