### PR TITLE
[Dev Container] Fix container build by preventing conda prompt

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,5 +30,5 @@ RUN if [ -n "$CLANG_VERSION" ]; then \
 # Install cuda if version is specified
 ARG CUDA_VERSION
 RUN if [ -n "$CUDA_VERSION" ]; then \
-       conda install cuda -c "nvidia/label/cuda-${CUDA_VERSION}"; \
+       conda install -y cuda -c "nvidia/label/cuda-${CUDA_VERSION}"; \
     fi


### PR DESCRIPTION
Without this the build will freeze with prompt:
  Proceed ([y]/n)?


I'm using rootless podman in vscode instead of docker but I think it should not affect this.
..or does conda somehow detect Docker but not Podman? Anyway, this should not break anything.

Btw, I also had to uncomment the line: "remoteUser": "root" in devcontainer.json to finish the post installation properly but I guess there might be other workarounds - and perhaps you don't want to run as root if your container has root privileges.