### PR TITLE
[ATen-vulkan] Enable deferred descriptor pool initialization

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Descriptor.h
+++ b/aten/src/ATen/native/vulkan/api/Descriptor.h
@@ -119,6 +119,12 @@ class DescriptorPool final {
   std::unordered_map<VkDescriptorSetLayout, DescriptorSetPile> piles_;
 
  public:
+  operator bool() const {
+    return (pool_ != VK_NULL_HANDLE);
+  }
+
+  void init(const DescriptorPoolConfig& config);
+
   DescriptorSet get_descriptor_set(
       VkDescriptorSetLayout handle,
       const ShaderLayout::Signature& signature);


### PR DESCRIPTION
Differential Revision: D54487619

## Context

Allow the descriptor pool of an `api::Context` object to be initialized in a deferred fashion, instead of forcing initialization upon construction. This mode of operation will be used in the ExecuTorch Vulkan delegate, where the exact number of descriptor sets can determined once the graph is built instead of needing to "guess" an adequate amount.

## Implementation Details

* Check `config.descriptorPoolMaxSets > 0` to check if the descriptor pool should be initialized
* Introduce `DescriptorPool::init()` function to trigger intialization
* Introduce safeguards against using an uninitialized descriptor pool
