### PR TITLE
ci: add "typing_extensions" package to ci requirements list

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -248,7 +248,8 @@ tb-nightly==2.13.0a20230426
 #Pinned versions:
 #test that import:
 
-#typing-extensions
+# needed by torchgen utils
+typing-extensions
 #Description: type hints for python
 #Pinned versions:
 #test that import:


### PR DESCRIPTION
this is required for torchgen

Fixes #ISSUE_NUMBER
