### PR TITLE
Refactor/de-duplicate pooling ops lowerings

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3246,19 +3246,15 @@ class CommonTemplate:
             fn, (torch.randn(2, 4, 16, 16), torch.rand(2, 4, 2)), check_lowp=False
         )
 
-    @config.patch(fallback_random=True)
     def test_fractional_max_pool2d4(self):
-        random.seed(1234)
-        torch.manual_seed(1234)
-
         # check rectangular kernel/output size
 
-        def fn(x):
-            return torch.nn.functional.fractional_max_pool2d_with_indices(
-                x, (4, 3), (3, 2)
-            )
+        def fn(x, samples):
+            return aten.fractional_max_pool2d(x, (4, 3), (3, 2), samples)
 
-        self.common(fn, (torch.randn(1, 4, 16, 16),), check_lowp=False)
+        self.common(
+            fn, (torch.randn(1, 4, 16, 16), torch.rand(1, 4, 2)), check_lowp=False
+        )
 
     def test_multi_threading(self):
         model = torch.nn.Linear(2, 3).eval()

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -216,7 +216,6 @@ inductor_expected_failures_single_sample["cpu"] = {
     "histc": {f16},
     "multinomial": {f16, f32, f64},
     "nn.functional.avg_pool1d": {i64},
-    "nn.functional.avg_pool2d": {i64},
     "nn.functional.local_response_norm": {i64},
     "nn.functional.rrelu": {f32, f64},
     "nonzero_static": {b8, f16, f32, f64, i32, i64},

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -4338,7 +4338,6 @@ def avg_pool2d(
         ones_like(x), 0.0, padding if count_include_pad else None
     )
 
-    # TODO: verify CSE handles when 2nd return is never used for anything
     def getter(idx, increments):
         *prefix, bh, bw = idx
         ih, iw = increments


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121139

This PR defines a few helper functions for two patterns:
1) defining a avg_pool type op by providing a function for loading
   values and a count, optionally providing a constant override to use
   for the divisor

2) defining a max_pool type op by providing a function for loading the
   value and computing an index.

The provided loader methods internalize the logic for using a custom
loader or computing window bounds/padding regions.

The refactor applies the use of the utilities to 2d pooling ops.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @desertfire @chauhang