### PR TITLE
[BE]: FURB187 Use inplace reverse on lists: faster, more readable.

### DIFF
--- a/torch/_dynamo/bytecode_transformation.py
+++ b/torch/_dynamo/bytecode_transformation.py
@@ -367,7 +367,7 @@ def encode_exception_table_varint(n: int) -> List[int]:
     while n > 0:
         b.append(n & 63)
         n >>= 6
-    b = list(reversed(b))
+    b.reverse()
     for i in range(len(b) - 1):
         b[i] |= 64
     return b

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2212,7 +2212,7 @@ class View(GenericView):
             var, size_new = stack_new.pop()
             V.graph.sizevars.guard_equals(size_new, 1)  # type: ignore[arg-type]
 
-        view_expr = list(reversed(view_expr))
+        view_expr.reverse()
         assert len(view_expr) == len(old_size)
 
         def reindex(index):

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -384,8 +384,8 @@ def make_graphed_callables(
         per_callable_static_grad_inputs.append(static_grad_inputs)
 
     # Reverses the most recent two lists
-    per_callable_static_grad_outputs = list(reversed(per_callable_static_grad_outputs))
-    per_callable_static_grad_inputs = list(reversed(per_callable_static_grad_inputs))
+    per_callable_static_grad_outputs.reverse()
+    per_callable_static_grad_inputs.reverse()
     # Now for every per_callable list, per_callable_*[i] holds the stuff for the ith callable.
 
     def make_graphed_autograd_function(


### PR DESCRIPTION
Use `reverse()` method as it's faster and inplace. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang