### PR TITLE
[pt2 export]fix name collision on constant name

### DIFF
--- a/torch/_export/passes/lift_constants_pass.py
+++ b/torch/_export/passes/lift_constants_pass.py
@@ -174,6 +174,9 @@ def lift_constants_pass(
             with gm.graph.inserting_before(first_user_input):
                 # Insert the constant node before the first user input
                 const_placeholder_node = gm.graph.placeholder(constant_name)
+                # match target name with its node name in case there is name collision
+                # and suffix is added to node name in fx
+                const_placeholder_node.target = const_placeholder_node.name
 
                 for k, v in node.meta.items():
                     const_placeholder_node.meta[k] = v


### PR DESCRIPTION
Summary: Taking the right most part of the fqn will cause name conflict when having multiple instances of the same class. Changed to replace "." in fqn by "_" to avoid invalid syntax in input args.

Test Plan: added test case

Differential Revision: D54435230


