### PR TITLE
Correctly read the cache key for remote cache

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -283,9 +283,7 @@ class TestMaxAutotune(TestCase):
                     reset()
                     torch._inductor.codecache.PyCodeCache.clear()
                 self.assertEqual(num_get, 3)
-                # TODO: This should really be 1 but it seems like we write even
-                # when we find it
-                self.assertEqual(num_put, 4)
+                self.assertEqual(num_put, 1)
             num_get = 0
             num_put = 0
             for _ in range(4):
@@ -293,9 +291,7 @@ class TestMaxAutotune(TestCase):
                 reset()
                 torch._inductor.codecache.PyCodeCache.clear()
             self.assertEqual(num_get, 3)
-            # TODO: This should really be 1 but it seems like we write even
-            # when we find it
-            self.assertEqual(num_put, 4)
+            self.assertEqual(num_put, 1)
 
     def test_precompilation_threads(self):
         import threading

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -782,6 +782,8 @@ def load_cached_autotuning(
     configs_hash: str,
     configs: List[Config],
 ):
+    if best_config is None:
+        return None
     if best_config.pop("configs_hash", None) != configs_hash:
         return None
 
@@ -856,12 +858,13 @@ def cached_autotune(
             with open(cache_filename) as fd:
                 best_config = json.loads(fd.read())
         elif remote_cache is not None and remote_cache_key is not None:
-            best_config = remote_cache.get([remote_cache_key])
+            cache_outs = remote_cache.get([remote_cache_key])
+            cache_out = cache_outs.get(remote_cache_key, None)
+            best_config = json.loads(cache_out) if cache_out else None
 
+        best_config = load_cached_autotuning(best_config, configs_hash, configs)
         if best_config:
-            best_config = load_cached_autotuning(best_config, configs_hash, configs)
-            if best_config:
-                configs = [best_config]
+            configs = [best_config]
 
         def save_cache_hook(cfg, found_by_coordesc=False):
             data = json.dumps(


### PR DESCRIPTION
Summary: While investigating why we were calling put each time, I noticed that memcache backend returns a list instead of direct result, which means that we were correctly fetching the cached result but not using it.

Test Plan: The test should now work as expected

Differential Revision: D54500851




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang