### PR TITLE
Add assign argument to torch.Tensor.module_load

### DIFF
--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -736,7 +736,6 @@ class Tensor(torch._C.TensorBase):
             )
 
         if not assign:
-            # In the default case, swap_tensors becomes a no-op
             return self.copy_(other).detach()
         return other.detach()
 

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -711,7 +711,7 @@ class Tensor(torch._C.TensorBase):
         self._typed_storage()._share_memory_()
         return self
 
-    def module_load(self, other):
+    def module_load(self, other, assign=False):
         r"""Defines how to transform ``other`` when loading it into ``self`` in :meth:`~nn.Module.load_state_dict`.
 
         Used when :func:`~torch.__future__.get_swap_module_params_on_conversion` is ``True``.
@@ -727,12 +727,18 @@ class Tensor(torch._C.TensorBase):
 
         Args:
             other (Tensor): value in state dict with key corresponding to ``self``
+            assign (bool): the assign argument passed to :meth:`nn.Module.load_state_dict`
 
         """
         if has_torch_function_variadic(self, other):
-            return handle_torch_function(Tensor.module_load, (self, other), self, other)
-        # In the default case, swap_tensors becomes a no-op
-        return self.copy_(other).detach()
+            return handle_torch_function(
+                Tensor.module_load, (self, other), self, other, assign=assign
+            )
+
+        if not assign:
+            # In the default case, swap_tensors becomes a no-op
+            return self.copy_(other).detach()
+        return other.detach()
 
     def __reversed__(self):
         r"""Reverses the tensor along dimension 0."""

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -723,7 +723,8 @@ class Tensor(torch._C.TensorBase):
 
         .. note::
             This method should always return a new object that is not ``self`` or ``other``.
-            For example, the default implementation returns ``self.copy_(other).detach()``.
+            For example, the default implementation returns ``self.copy_(other).detach()``
+            if ``assign`` is ``False`` or ``other.detach()`` if ``assign`` is ``True``.
 
         Args:
             other (Tensor): value in state dict with key corresponding to ``self``
@@ -735,9 +736,10 @@ class Tensor(torch._C.TensorBase):
                 Tensor.module_load, (self, other), self, other, assign=assign
             )
 
-        if not assign:
+        if assign:
+            return other.detach()
+        else:
             return self.copy_(other).detach()
-        return other.detach()
 
     def __reversed__(self):
         r"""Reverses the tensor along dimension 0."""

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2112,12 +2112,13 @@ class Module:
             strict (bool, optional): whether to strictly enforce that the keys
                 in :attr:`state_dict` match the keys returned by this module's
                 :meth:`~torch.nn.Module.state_dict` function. Default: ``True``
-            assign (bool, optional): whether to assign items in the state
-                dictionary to their corresponding keys in the module instead
-                of copying them inplace into the module's current parameters and buffers.
-                When ``False``, the properties of the tensors in the current
-                module are preserved while when ``True``, the properties of the
-                Tensors in the state dict are preserved.
+            assign (bool, optional): When ``False``, the properties of the tensors
+                in the current module are preserved while when ``True``, the
+                properties of the Tensors in the state dict are preserved. Additionally,
+                the ``requires_grad`` of :class:`~torch.nn.Parameter`s in the
+                ``state_dict`` are preserved, but tensors in the ``state_dict``
+                will adopt the ``requires_grad`` of the corresponding parameter
+                in the module.
                 Default: ``False``
 
         Returns:

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1367,7 +1367,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         Tensor.map_: lambda self, tensor, callable: -1,
         Tensor.map2_: lambda self, x, y, callable: -1,
         Tensor.mm: lambda self, mat2: -1,
-        Tensor.module_load: lambda self, other: -1,
+        Tensor.module_load: lambda self, other, assign=False: -1,
         Tensor.narrow_copy: lambda self, dimension, start, length: -1,
         Tensor.ndimension: lambda self: -1,
         Tensor.nelement: lambda self: -1,


### PR DESCRIPTION
Make `torch.__future__.get_swap_module_params_on_conversion() == True` account for `assign` argument to `nn.Module.load_state_dict`

Similar to when `torch.__future__.set_swap_module_params_on_conversion()` is `False`, `assign=True` means that we do not incur a `self.copy_(other)` and the properties of `other` will be preserved

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121158
* #121157

