### PR TITLE
[inductor] skip foreach kernel for benchmark fusion

### DIFF
--- a/test/inductor/test_benchmark_fusion.py
+++ b/test/inductor/test_benchmark_fusion.py
@@ -115,6 +115,20 @@ class BenchmarkFusionTestTemplate:
             opt_f = torch.compile(f)
             opt_f(*inputs)
 
+    def test_foreach_kernel(self):
+        """
+        Benchmark fusion should skip benchmarking kernels involves foreach kernel
+        for now. Without the skipping logic, `codegen_node_schedule` may fail.
+        """
+        a = torch.randn(1024, 256, device=self.device)
+        b = torch.randn(1024, 512, device=self.device)
+
+        def f(a, b):
+            a, b = torch._foreach_abs([a, b])
+            return a + 1, b + 2
+
+        self.common(f, (a, b))
+
 
 if HAS_CUDA and not TEST_WITH_ASAN:
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1709,7 +1709,7 @@ class Scheduler:
         if not config.benchmark_fusion:
             return True
 
-        if node1.is_template():
+        if node1.is_template() or node1.is_foreach() or node2.is_foreach():
             # TODO support benchmarking epilogue fusion
             return True
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121168

benchmark fusion currently does not support foreach kernel. If we don't explicitly skip foreach kernels, we end up with exceptions in `codegen_node_schedule` because individual nodes in a foreach kernel may have incompatible shapes from pointwise/reduction perspective.

cc Manman Ren ( @manman-ren ) who reported the issue when turning on benchmark fusion on BertForMaskedLM.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang