### PR TITLE
fix graph deepcopy to also copy `_tracer_extras`

### DIFF
--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -4,6 +4,7 @@ import math
 import numbers
 import operator
 import pickle
+import copy
 import sys
 import sympy
 import tempfile
@@ -638,6 +639,15 @@ class TestFXExperimental(JitTestCase):
 
                 torch.testing.assert_close(loaded(x), mttm(x))
 
+                # Test serialization/deserialization of copy
+                gm_copy = copy.deepcopy(gm)
+                with open(f'{tmp_dir}/meta_module_copy.pkl', 'wb') as f:
+                    pickle.dump(gm_copy, f)
+
+                with open(f'{tmp_dir}/meta_module_copy.pkl', 'rb') as f:
+                    loaded_copy = pickle.load(f)
+
+                torch.testing.assert_close(loaded_copy(x), mttm(x))
 
     def test_call_to_assert_with_msg(self):
         class M(torch.nn.Module):

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -866,7 +866,7 @@ class Graph:
         nodes or other parts of the Graph from a custom GraphModule implementation.
         """
         memo = memo if memo else {}
-        g = Graph(tracer_cls=self._tracer_cls)
+        g = Graph(tracer_cls=self._tracer_cls, tracer_extras=copy.deepcopy(self._tracer_extras))
         output_vals = g.graph_copy(self, val_map=memo, return_output_node=True)
         g._codegen = copy.deepcopy(self._codegen)
         assert isinstance(output_vals, tuple)


### PR DESCRIPTION
When deepcopying an fx graph, `_tracer_extras` is not copied.
An error occurs when serializing/deserializing a deepcopied graph in custom fx tracer (e.g. [MetaTracer](https://github.com/pytorch/pytorch/blob/5837e95d303464141009b8072636bb4442e2fcb2/torch/fx/experimental/meta_tracer.py#L254))