### PR TITLE
Changing watchdog timer from named pipe to file based

### DIFF
--- a/docs/source/elastic/agent.rst
+++ b/docs/source/elastic/agent.rst
@@ -64,13 +64,13 @@ to implement.
 Watchdog in the Agent
 ---------------------
 
-A named pipe based watchdog can be enabled in ```LocalElasticAgent``` if an
+A file based watchdog can be enabled in ```LocalElasticAgent``` if an
 environment variable ``TORCHELASTIC_ENABLE_FILE_TIMER`` with value 1 has
 been defined in the ```LocalElasticAgent``` process.
 Optionally, another environment variable ```TORCHELASTIC_TIMER_FILE```
-can be set with a unique file name for the named pipe. If the environment
-variable ```TORCHELASTIC_TIMER_FILE``` is not set, ```LocalElasticAgent```
+can be set with a unique file name. If the environment variable
+```TORCHELASTIC_TIMER_FILE``` is not set, ```LocalElasticAgent```
 will internally create a unique file name and set it to the environment
 variable ```TORCHELASTIC_TIMER_FILE```, and this environment variable will
 be propagated to the worker processes to allow them to connect to the same
-named pipe that ```LocalElasticAgent``` uses.
+file that ```LocalElasticAgent``` uses.

--- a/test/distributed/elastic/timer/file_based_local_timer_test.py
+++ b/test/distributed/elastic/timer/file_based_local_timer_test.py
@@ -6,7 +6,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 import multiprocessing as mp
+import os
 import signal
+import tempfile
 import time
 import unittest
 import unittest.mock as mock
@@ -25,20 +27,23 @@ from torch.testing._internal.common_utils import (
 # timer is not supported on windows or macos
 if not (IS_WINDOWS or IS_MACOS):
     # func2 should time out
-    def func2(n, file_path):
+    def func2(n, file_path, scope_id):
         if file_path is not None:
-            timer.configure(timer.FileTimerClient(file_path))
+            timer.configure(timer.FileTimerClient(file_path, 0.1, scope_id))
         if n > 0:
             with timer.expires(after=0.1):
-                func2(n - 1, None)
+                func2(n - 1, None, None)
                 time.sleep(0.2)
 
     class FileTimerTest(TestCase):
         def setUp(self):
             super().setUp()
             self.max_interval = 0.01
-            self.file_path = "/tmp/test_file_path_" + str(uuid.uuid4())
-            self.server = timer.FileTimerServer(self.file_path, self.max_interval)
+            self.num_clients = 10
+            td = tempfile.mkdtemp(prefix="test-watchdog")
+            self.server = timer.FileTimerServer(td, self.num_clients, self.max_interval)
+            self.scope_ids = [f"rank{i}" for i in range(self.num_clients)]
+            self.file_paths = [f"{td}/{scope}" for scope in self.scope_ids]
             self.server.start()
 
         def tearDown(self):
@@ -60,7 +65,7 @@ if not (IS_WINDOWS or IS_MACOS):
         def test_client_interaction(self):
             # no timer client configured but one passed in explicitly
             # no exception expected
-            timer_client = timer.FileTimerClient(self.file_path)
+            timer_client = timer.FileTimerClient(self.file_paths[0], 1, self.scope_ids[0])
             timer_client.acquire = mock.MagicMock(wraps=timer_client.acquire)
             timer_client.release = mock.MagicMock(wraps=timer_client.release)
             with timer.expires(after=1, scope="test", client=timer_client):
@@ -70,59 +75,54 @@ if not (IS_WINDOWS or IS_MACOS):
             timer_client.release.assert_called_once_with("test")
 
         def test_happy_path(self):
-            timer.configure(timer.FileTimerClient(self.file_path))
+            timer.configure(timer.FileTimerClient(self.file_paths[0], 0.5, self.scope_ids[0]))
             with timer.expires(after=0.5):
                 time.sleep(0.1)
 
         def test_get_timer_recursive(self):
-            """
-            If a function acquires a countdown timer with default scope,
-            then recursive calls to the function should re-acquire the
-            timer rather than creating a new one. That is only the last
-            recursive call's timer will take effect.
-            """
-            timer.configure(timer.FileTimerClient(self.file_path))
-
+            timer_client = timer.FileTimerClient(self.file_paths[0], 1, self.scope_ids[0])
             # func should not time out
             def func(n):
                 if n > 0:
-                    with timer.expires(after=0.1):
-                        func(n - 1)
-                        time.sleep(0.05)
+                    print("here...", n)
+                    timer_client.acquire("test",1)
+                    time.sleep(0.5)
+                    func(n - 1)
 
             func(4)
+            self.server.stop()
 
-            p = mp.Process(target=func2, args=(2, self.file_path))
+        def test_get_timer_recursive_process(self):
+            p = mp.Process(target=func2, args=(2, self.file_paths[0], self.scope_ids[0]))
             p.start()
             p.join()
             self.assertEqual(-signal.SIGKILL, p.exitcode)
 
         def test_multiple_clients_interaction(self):
             # func should not time out
-            def func(n, file_path):
+            def func(n, file_path, scope_id):
                 if file_path is not None:
-                    timer.configure(timer.FileTimerClient(file_path))
+                    timer.configure(timer.FileTimerClient(file_path, 100, scope_id))
                 if n > 0:
                     with timer.expires(after=100):
                         func(n - 1, None)
                         time.sleep(0.01)
 
-            num_clients = 10
             num_requests_per_client = 10
             processes = []
-            for i in range(num_clients):
-                p = mp.Process(target=func, args=(num_requests_per_client, self.file_path))
+            for i in range(self.num_clients):
+                p = mp.Process(target=func, args=(num_requests_per_client, self.file_paths[i], self.scope_ids[i]))
                 processes.append(p)
                 p.start()
             for p in processes:
                 p.join()
 
             self.server.run_once()  # Allows the server to process all requests
-            self.assertEqual(2 * num_clients * num_requests_per_client, self.server._request_count)
+            self.assertEqual(self.num_clients, len(self.server._timers))
 
         @staticmethod
-        def _run(file_path, timeout, duration):
-            client = timer.FileTimerClient(file_path)
+        def _run(file_path, scope_id, timeout, duration):
+            client = timer.FileTimerClient(file_path, timeout, scope_id)
             timer.configure(client)
             with timer.expires(after=timeout):
                 time.sleep(duration)
@@ -131,7 +131,7 @@ if not (IS_WINDOWS or IS_MACOS):
         def test_timer(self):
             timeout = 0.1
             duration = 1
-            p = mp.Process(target=self._run, args=(self.file_path, timeout, duration))
+            p = mp.Process(target=self._run, args=(self.file_paths[0], self.scope_ids[0], timeout, duration))
             p.start()
             p.join()
             self.assertEqual(-signal.SIGKILL, p.exitcode)
@@ -141,7 +141,7 @@ if not (IS_WINDOWS or IS_MACOS):
         enqueues ``n`` timer requests into ``mp_queue`` one element per
         interval seconds. Releases the given semaphore once before going to work.
         """
-        client = timer.FileTimerClient(file_path)
+        client = timer.FileTimerClient(file_path, 1, self.scope_ids[0])
         sem.release()
         for i in range(0, n):
             client.acquire("test_scope", 0)
@@ -150,9 +150,9 @@ if not (IS_WINDOWS or IS_MACOS):
 
     class FileTimerClientTest(TestCase):
         def test_send_request_without_server(self):
-            client = timer.FileTimerClient("test_file")
-            timer.configure(client)
-            with self.assertRaises(BrokenPipeError):
+            with self.assertRaises(FileNotFoundError):
+                client = timer.FileTimerClient("/tmp/watchdognotexist/test_file", 0.1, "test")
+                timer.configure(client)
                 with timer.expires(after=0.1):
                     time.sleep(0.1)
 
@@ -160,9 +160,12 @@ if not (IS_WINDOWS or IS_MACOS):
     class FileTimerServerTest(TestCase):
         def setUp(self):
             super().setUp()
-            self.file_path = "/tmp/test_file_path_" + str(uuid.uuid4())
+            td = tempfile.mkdtemp(prefix="test-watchdog")
             self.max_interval = 0.01
-            self.server = timer.FileTimerServer(self.file_path, self.max_interval)
+            self.num_clients = 4
+            self.server = timer.FileTimerServer(td, self.num_clients, self.max_interval)
+            self.scope_ids = [f"rank{i}" for i in range(self.num_clients)]
+            self.file_paths = [f"{td}/{scope}" for scope in self.scope_ids]
 
         def tearDown(self):
             super().tearDown()
@@ -175,9 +178,8 @@ if not (IS_WINDOWS or IS_MACOS):
             self.server._run_watchdog = mock.MagicMock(wraps=self.server._run_watchdog)
             self.server.start()
 
-            test_pid = -3
-            client = timer.FileTimerClient(self.file_path)
-            client._send_request(self._valid_timer(pid=test_pid, scope="test0"))
+            client = timer.FileTimerClient(self.file_paths[0], 1, self.scope_ids[0])
+            client.acquire("test0", 60)
 
             wait = 0.1
             time.sleep(wait)
@@ -190,20 +192,9 @@ if not (IS_WINDOWS or IS_MACOS):
 
         def test_watchdog_empty_queue(self):
             """
-            checks that the watchdog can run on an empty pipe
+            checks that the watchdog can run on an empty file
             """
             self.server.start()
-
-        def _expired_timer(self, pid, scope):
-            expired = time.time() - 60
-            return timer.FileTimerRequest(worker_pid=pid, scope_id=scope, expiration_time=expired, signal=signal.SIGKILL)
-
-        def _valid_timer(self, pid, scope):
-            valid = time.time() + 60
-            return timer.FileTimerRequest(worker_pid=pid, scope_id=scope, expiration_time=valid, signal=signal.SIGKILL)
-
-        def _release_timer(self, pid, scope):
-            return timer.FileTimerRequest(worker_pid=pid, scope_id=scope, expiration_time=-1)
 
         @mock.patch("os.kill")
         def test_expired_timers(self, mock_os_kill):
@@ -213,32 +204,17 @@ if not (IS_WINDOWS or IS_MACOS):
             """
             self.server.start()
 
-            test_pid = -3
-            client = timer.FileTimerClient(self.file_path)
-            client._send_request(self._expired_timer(pid=test_pid, scope="test1"))
-            client._send_request(self._valid_timer(pid=test_pid, scope="test2"))
+            client1 = timer.FileTimerClient(self.file_paths[0], 1, self.scope_ids[0])
+            client2 = timer.FileTimerClient(self.file_paths[1], 2, self.scope_ids[1])
+
+            client1.acquire("test1", 1)
+            client2.acquire("test2", 1)
+            time.sleep(1.5)
 
             self.server.run_once()  # Allows the server to process all requests
-            self.assertEqual(0, len(self.server._timers))
-            mock_os_kill.assert_called_once_with(test_pid, signal.SIGKILL)
-
-        @mock.patch("os.kill")
-        def test_send_request_release(self, mock_os_kill):
-            """
-            tests that:
-            1. a timer can be acquired then released (should not terminate process)
-            2. a timer can be vacuously released (e.g. no-op)
-            """
-            self.server.start()
-
-            client = timer.FileTimerClient(self.file_path)
-            test_pid = -3
-            client._send_request(self._valid_timer(pid=test_pid, scope="test1"))
-            client._send_request(self._release_timer(pid=test_pid, scope="test1"))
-            client._send_request(self._release_timer(pid=test_pid, scope="test2"))
-
-            self.assertEqual(0, len(self.server._timers))
-            mock_os_kill.assert_not_called()
+            print(self.server._timers)
+            self.assertEqual(1, len(self.server._timers))
+            mock_os_kill.assert_called_once_with(os.getpid(), signal.SIGKILL)
 
         @mock.patch("os.kill")
         def test_valid_timers(self, mock_os_kill):
@@ -247,18 +223,15 @@ if not (IS_WINDOWS or IS_MACOS):
             """
             self.server.start()
 
-            client = timer.FileTimerClient(self.file_path)
-            client._send_request(self._valid_timer(pid=-3, scope="test1"))
-            client._send_request(self._valid_timer(pid=-3, scope="test2"))
-            client._send_request(self._valid_timer(pid=-2, scope="test1"))
-            client._send_request(self._valid_timer(pid=-2, scope="test2"))
+            client1 = timer.FileTimerClient(self.file_paths[0], 60, self.scope_ids[0])
+            client2 = timer.FileTimerClient(self.file_paths[1], 60, self.scope_ids[1])
+            client3 = timer.FileTimerClient(self.file_paths[2], 60, self.scope_ids[2])
+            client4 = timer.FileTimerClient(self.file_paths[3], 60, self.scope_ids[3])
 
             self.server.run_once()  # Allows the server to process all requests
             self.assertEqual(4, len(self.server._timers))
-            self.assertTrue((-3, "test1") in self.server._timers)
-            self.assertTrue((-3, "test2") in self.server._timers)
-            self.assertTrue((-2, "test1") in self.server._timers)
-            self.assertTrue((-2, "test2") in self.server._timers)
+            for scope in self.scope_ids:
+                self.assertTrue(scope in self.server._timers)
             mock_os_kill.assert_not_called()
 
 

--- a/torch/distributed/elastic/timer/file_based_local_timer.py
+++ b/torch/distributed/elastic/timer/file_based_local_timer.py
@@ -6,9 +6,9 @@
 
 import io
 import json
-import logging
 import os
 import select
+import shutil
 import signal
 import sys
 import threading
@@ -16,10 +16,11 @@ import time
 from typing import Callable, Dict, List, Optional, Set, Tuple
 
 from torch.distributed.elastic.timer.api import TimerClient, TimerRequest
+from torch.distributed.elastic.utils.logging import get_logger
 
 __all__ = ["FileTimerClient", "FileTimerRequest", "FileTimerServer"]
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 class FileTimerRequest(TimerRequest):
     """
@@ -31,10 +32,9 @@ class FileTimerRequest(TimerRequest):
     process.
     """
 
-    __slots__ = ["version", "worker_pid", "scope_id", "expiration_time", "signal"]
+    __slots__ = ["worker_pid", "scope_id", "expiration_time", "signal"]
 
     def __init__(self, worker_pid: int, scope_id: str, expiration_time: float, signal: int = 0) -> None:
-        self.version = 1
         self.worker_pid = worker_pid
         self.scope_id = scope_id
         self.expiration_time = expiration_time
@@ -43,8 +43,7 @@ class FileTimerRequest(TimerRequest):
     def __eq__(self, other) -> bool:
         if isinstance(other, FileTimerRequest):
             return (
-                self.version == other.version
-                and self.worker_pid == other.worker_pid
+                self.worker_pid == other.worker_pid
                 and self.scope_id == other.scope_id
                 and self.expiration_time == other.expiration_time
                 and self.signal == other.signal
@@ -54,7 +53,6 @@ class FileTimerRequest(TimerRequest):
     def to_json(self) -> str:
         return json.dumps(
             {
-                "version": self.version,
                 "pid": self.worker_pid,
                 "scope_id": self.scope_id,
                 "expiration_time": self.expiration_time,
@@ -68,69 +66,67 @@ class FileTimerClient(TimerClient):
     Client side of ``FileTimerServer``. This client is meant to be used
     on the same host that the ``FileTimerServer`` is running on and uses
     pid to uniquely identify a worker.
-    This client uses a named_pipe to send timer requests to the
+    This client uses a temp file to send timer requests to the
     ``FileTimerServer``. This client is a producer while the
     ``FileTimerServer`` is a consumer. Multiple clients can work with
     the same ``FileTimerServer``.
 
     Args:
 
-        file_path: str, the path of a FIFO special file. ``FileTimerServer``
-                        must have created it by calling os.mkfifo().
+        file_path: str, the path of a watchdog file.
+
+        timeout_sec: int, watchdog timeout.
+
+        scope_id: str, scope ID of worker
 
         signal: signal, the signal to use to kill the process. Using a
                         negative or zero signal will not kill the process.
     """
-    def __init__(self, file_path: str, signal=(signal.SIGKILL if sys.platform != "win32" else
-                                               signal.CTRL_C_EVENT)) -> None:  # type: ignore[attr-defined]
+    def __init__(self,
+        file_path: str,
+        timeout_sec: int,
+        scope_id: str,
+        signal=(signal.SIGKILL if sys.platform != "win32" else
+            signal.CTRL_C_EVENT),
+    ) -> None:  # type: ignore[attr-defined]
         super().__init__()
         self._file_path = file_path
+        self._timeout_sec = timeout_sec
         self.signal = signal
-
-    def _open_non_blocking(self) -> Optional[io.TextIOWrapper]:
-        try:
-            fd = os.open(self._file_path, os.O_WRONLY | os.O_NONBLOCK)
-            return os.fdopen(fd, "wt")
-        except Exception:
-            return None
-
-    def _send_request(self, request: FileTimerRequest) -> None:
-        # The server may have crashed or may haven't started yet.
-        # In such case, calling open() in blocking model blocks the client.
-        # To avoid such issue, open it in non-blocking mode, and an OSError will
-        # be raised if the server is not there.
-        file = self._open_non_blocking()
-        if file is None:
-            raise BrokenPipeError("Could not send the FileTimerRequest because FileTimerServer is not available.")
-        with file:
+        log.info(
+            "Starting %s..."
+            " file_path=%s,"
+            " timeout=%s,"
+            " signal=%s",
+            type(self).__name__,
+            self._file_path,
+            self._timeout_sec,
+            self.signal,
+        )
+        with open(self._file_path, "w") as file:
+            # FileTimerRequest at init is used to write client level
+            # metadata once to watchdog file, later acquire will not
+            # write duplicate data
+            request = FileTimerRequest(
+                worker_pid=os.getpid(),
+                scope_id=scope_id,
+                expiration_time=timeout_sec,
+                signal=signal,
+            )
             json_request = request.to_json()
-            # Write request with no greater than select.PIPE_BUF is guarantee to be atomic.
-            if len(json_request) > select.PIPE_BUF:
-                raise RuntimeError(
-                    f"FileTimerRequest larger than {select.PIPE_BUF} bytes "
-                    f"is not supported: {json_request}"
-                )
             file.write(json_request + "\n")
 
     def acquire(self, scope_id: str, expiration_time: float) -> None:
-        self._send_request(
-            request=FileTimerRequest(
-                worker_pid=os.getpid(),
-                scope_id=scope_id,
-                expiration_time=expiration_time,
-                signal=self.signal
-            ),
-        )
+        if not os.path.isfile(self._file_path):
+            raise FileNotFoundError("Could not send the FileTimerRequest because FileTimerServer is not available.")
+        # updating watchdog file modified time to current time as heartbeat
+        # avoid writing duplicate FileTimerRequest, expiration time is
+        # calcuated using 'modified time + timeout'
+        os.utime(self._file_path)
 
     def release(self, scope_id: str) -> None:
-        self._send_request(
-            request=FileTimerRequest(
-                worker_pid=os.getpid(),
-                scope_id=scope_id,
-                expiration_time=-1,
-                signal=0
-            ),
-        )
+        # release is no-op as timer are alive until end of server shutdown
+        pass
 
 
 class FileTimerServer:
@@ -143,7 +139,10 @@ class FileTimerServer:
 
     Args:
 
-        file_path: str, the path of a FIFO special file to be created.
+        dir_path: str, the path of directory where watchdog files will be
+        created.
+
+        num_clients: int, number of worker clients.
 
         max_interval: float, max interval in seconds for each watchdog loop.
 
@@ -155,25 +154,23 @@ class FileTimerServer:
 
     def __init__(
         self,
-        file_path: str,
+        dir_path: str,
+        num_clients: int,
         max_interval: float = 10,
         daemon: bool = True,
         log_event: Optional[Callable[[str, Optional[FileTimerRequest]], None]] = None
     ) -> None:
-        self._file_path = file_path
+        self._dir_path = dir_path
+        self._num_clients = num_clients
         self._max_interval = max_interval
         self._daemon = daemon
-        self._timers: Dict[Tuple[int, str], FileTimerRequest] = {}
+        self._timers: Dict[str, FileTimerRequest] = {}
         self._stop_signaled = False
         self._watchdog_thread: Optional[threading.Thread] = None
-        if os.path.exists(self._file_path):
-            os.remove(self._file_path)
-        os.mkfifo(self._file_path)
-        # For test only. Count the number of requests received.
-        self._request_count = 0
         # For test only. Process all requests and stop the server.
         self._run_once = False
         self._log_event = log_event if log_event is not None else lambda name, request: None
+        self._clients_metadata: Dict[str, Optional[FileTimerRequest]] = {}
 
 
     def start(self) -> None:
@@ -197,8 +194,8 @@ class FileTimerServer:
             self._watchdog_thread = None
         else:
             log.info("No watchdog thread running, doing nothing")
-        if os.path.exists(self._file_path):
-            os.remove(self._file_path)
+        if os.path.exists(self._dir_path):
+            shutil.rmtree(self._dir_path)
         self._log_event("watchdog stopped", None)
 
     def run_once(self) -> None:
@@ -209,84 +206,73 @@ class FileTimerServer:
             self._watchdog_thread = None
         else:
             log.info("No watchdog thread running, doing nothing")
-        if os.path.exists(self._file_path):
-            os.remove(self._file_path)
 
     def _watchdog_loop(self) -> None:
-        # Open the pipe in blocking mode blocks the server thread.
-        # This is fine for the following reasons:
-        #  1. No client case usually does not happen.
-        #  2. We are running the watchdog loop in a separate daemon
-        #     thread, which will not block the process to stop.
-        with open(self._file_path) as fd:
-            while not self._stop_signaled:
-                try:
-                    run_once = self._run_once
-                    self._run_watchdog(fd)
-                    if run_once:
-                        break
-                except Exception:
-                    log.exception("Error running watchdog")
+        while not self._stop_signaled:
+            try:
+                run_once = self._run_once
+                self._load_clients()
+                self._run_watchdog()
+                if run_once:
+                    break
+            except Exception:
+                log.exception("Error running watchdog")
 
-    def _run_watchdog(self, fd: io.TextIOWrapper) -> None:
-        timer_requests = self._get_requests(fd, self._max_interval)
+    def _load_clients(self) -> None:
+        if len(self._clients_metadata) == self._num_clients:
+            return
+
+        client_files = os.listdir(self._dir_path)
+        for file in client_files:
+            if file not in self._clients_metadata:
+                file_name = f"{self._dir_path}/{file}"
+                with open(file_name, "r") as fd:
+                    request = json.loads(fd.readline())
+                    self._clients_metadata[file] = FileTimerRequest(
+                        worker_pid=request["pid"],
+                        scope_id=request["scope_id"],
+                        expiration_time=request["expiration_time"],
+                        signal=request["signal"],
+                    )
+
+    def _run_watchdog(self) -> None:
+        timer_requests = self._get_requests(self._max_interval)
         self.register_timers(timer_requests)
         now = time.time()
-        reaped_worker_pids = set()
-        for worker_pid, expired_timers in self.get_expired_timers(now).items():
-            log.info("Reaping worker_pid=[%s]. Expired timers: %s", worker_pid, self._get_scopes(expired_timers))
-            reaped_worker_pids.add(worker_pid)
-            # In case we have multiple expired timers, we find the first timer
-            # with a valid signal (>0) in the expiration time order.
-            expired_timers.sort(key=lambda timer: timer.expiration_time)
-            signal = 0
-            expired_timer = None
-            for timer in expired_timers:
-                self._log_event("timer expired", timer)
-                if timer.signal > 0:
-                    signal = timer.signal
-                    expired_timer = timer
-                    break
-            if signal <= 0:
-                log.info("No signal specified with worker=[%s]. Do not reap it.", worker_pid)
+        reaped_workers = set()
+        for etimer in self.get_expired_timers(now):
+            log.info("Reaping worker_pid=[%s]. Expired timer: %s", etimer.worker_pid, etimer.scope_id)
+            reaped_workers.add(etimer.scope_id)
+            self._log_event("timer expired", etimer)
+            if etimer.signal <= 0:
+                log.info("No signal specified with worker=[%s]. Do not reap it.", etimer.worker_pid)
                 continue
-            if self._reap_worker(worker_pid, signal):
-                log.info("Successfully reaped worker=[%s] with signal=%s", worker_pid, signal)
-                self._log_event("kill worker process", expired_timer)
+            # clear metadata for reaped worker to avoid keep reaping in future
+            self._clients_metadata[etimer.scope_id] = None
+            if self._reap_worker(etimer.worker_pid, etimer.signal):
+                log.info("Successfully reaped worker=[%s] with signal=%s", etimer.worker_pid, etimer.signal)
+                self._log_event("kill worker process", etimer)
             else:
-                log.error("Error reaping worker=[%s]. Will retry on next watchdog.", worker_pid)
-        self.clear_timers(reaped_worker_pids)
+                log.error("Error reaping worker=[%s]. Will retry on next watchdog.", etimer.worker_pid)
+        self.clear_timers(reaped_workers)
 
-    def _get_scopes(self, timer_requests: List[FileTimerRequest]) -> List[str]:
-        return [r.scope_id for r in timer_requests]
-
-    def _get_requests(self, fd: io.TextIOWrapper, max_interval: float) -> List[FileTimerRequest]:
+    def _get_requests(self, max_interval: float) -> List[FileTimerRequest]:
         start = time.time()
         requests = []
         while not self._stop_signaled or self._run_once:
-            # For named pipe, readline() is blocking when at least one writer opens.
-            # It returns only when flush() is called at the writer side.
-            # Note that flush() is automatically called inside close().
-            # After the last writer closes, readline() is not blocking.
-            # It will return an empty string when it's at end-of-file.
-            # Since the client side always opens the pipe, writes a message and closes
-            # the pipe immediately, the readline() call below is not blocking for long.
-            json_request = fd.readline()
-            if len(json_request) == 0:
-                if self._run_once:
-                    break
-                time.sleep(min(max_interval, 1))
-            else:
-                request = json.loads(json_request)
-                pid = request["pid"]
-                scope_id = request["scope_id"]
-                expiration_time = request["expiration_time"]
-                signal = request["signal"]
+            for metadata in self._clients_metadata.values():
+                if not metadata:
+                    continue
+                last_mtime = os.path.getmtime(f"{self._dir_path}/{metadata.scope_id}")
                 requests.append(
                     FileTimerRequest(
-                        worker_pid=pid, scope_id=scope_id, expiration_time=expiration_time, signal=signal
+                        worker_pid=metadata.worker_pid,
+                        scope_id=metadata.scope_id,
+                        expiration_time=last_mtime + metadata.expiration_time,
+                        signal=metadata.signal,
                     )
                 )
+            time.sleep(min(max_interval, 10))
             now = time.time()
             if now - start > max_interval:
                 break
@@ -294,32 +280,23 @@ class FileTimerServer:
 
     def register_timers(self, timer_requests: List[FileTimerRequest]) -> None:
         for request in timer_requests:
-            pid = request.worker_pid
             scope_id = request.scope_id
             expiration_time = request.expiration_time
-            self._request_count += 1
 
-            key = (pid, scope_id)
             # negative expiration is a proxy for a release call
             if expiration_time < 0:
-                if key in self._timers:
-                    del self._timers[key]
+                if scope_id in self._timers:
+                    del self._timers[scope_id]
             else:
-                self._timers[key] = request
+                self._timers[scope_id] = request
 
-    def clear_timers(self, worker_pids: Set[int]) -> None:
-        for (pid, scope_id) in list(self._timers.keys()):
-            if pid in worker_pids:
-                del self._timers[(pid, scope_id)]
+    def clear_timers(self, workers: Set[str]) -> None:
+        for worker in workers:
+            if worker in self._timers:
+                del self._timers[worker]
 
-    def get_expired_timers(self, deadline: float) -> Dict[int, List[FileTimerRequest]]:
-        # pid -> [timer_requests...]
-        expired_timers: Dict[int, List[FileTimerRequest]] = {}
-        for request in self._timers.values():
-            if request.expiration_time <= deadline:
-                expired_scopes = expired_timers.setdefault(request.worker_pid, [])
-                expired_scopes.append(request)
-        return expired_timers
+    def get_expired_timers(self, deadline: float) -> List[FileTimerRequest]:
+        return [timer for timer in self._timers.values() if timer.expiration_time <= deadline]
 
     def _reap_worker(self, worker_pid: int, signal: int) -> bool:
         try:


### PR DESCRIPTION
Summary: Changing underlying mechanism for local watchdog timer to use physical file instead of named pipe. this change is to make watchdog timer more robust as earlier named pipe method requires connection to be established from both side.

Test Plan:
buck test mode/opt caffe2/test/distributed/elastic/timer:file_based_timer_test

Tests finished: Pass 12. Fail 0. Fatal 0. Skip 1. Build failure 0

Differential Revision: D53953039


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang