### PR TITLE
[non-strict export] support tensor attribute without other args

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -2395,6 +2395,20 @@ def forward(self, arg_0):
         self.assertEqual(len(ep.graph_signature.input_specs), 4)
         self.assertTrue(torch.allclose(ep.module()(*inp), transform.module()(*inp)))
 
+    @testing.expectedFailureRetraceability
+    def test_tensor_attribute_zero_args(self):
+        class Foo(torch.nn.Module):
+            def __init__(self, value):
+                super().__init__()
+                self.x = torch.tensor(value)
+
+            def forward(self):
+                return self.x.clone()
+
+        m = Foo([1, 2])
+        ep = export(m, ())
+        self.assertEqual(ep.graph_signature.lifted_tensor_constants, ["x"])
+
     def test_preserve_shape_dynamism_for_unused_inputs(self):
         @dataclass
         class Input:

--- a/torch/_export/passes/lift_constants_pass.py
+++ b/torch/_export/passes/lift_constants_pass.py
@@ -103,9 +103,6 @@ def lift_constants_pass(
     """
     all_constants: Dict[str, Union[torch.Tensor, torch._C.ScriptObject]] = {}
 
-    if len([node for node in gm.graph.nodes if node.op == "placeholder"]) == 0:
-        return {}
-
     inputs = graph_signature.input_specs
     num_custom_obj = sum(
         input_specs.kind == InputKind.CUSTOM_OBJ for input_specs in inputs

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -772,15 +772,16 @@ def _export(
         fake_params_buffers = make_fake_params_buffers(
             fake_mode, _get_params_buffers(mod)
         )
-        ep_non_strict = _export_non_strict(
-            mod,
-            fake_args,
-            fake_kwargs,
-            fake_params_buffers,
-            constant_attrs,
-            pre_dispatch=pre_dispatch,
-            transform=_tuplify_outputs,
-        )
+        with fake_mode:
+            ep_non_strict = _export_non_strict(
+                mod,
+                fake_args,
+                fake_kwargs,
+                fake_params_buffers,
+                constant_attrs,
+                pre_dispatch=pre_dispatch,
+                transform=_tuplify_outputs,
+            )
         try:
             range_constraints = make_constraints(
                 fake_mode,


### PR DESCRIPTION
Summary: Without args we have a hard time detecting fake modes. This causes a fake mode mismatch error in non-strict (specifically, `aot_export_module`) when the module contains tensor attributes, because we create a fresh fake mode when we cannot detect one. The fix is to pass the same fake mode throughout.

Test Plan: added test

Differential Revision: D54516595
