### PR TITLE
Update docs to point to new sdpa_kernel context manager

### DIFF
--- a/torch/nn/attention/__init__.py
+++ b/torch/nn/attention/__init__.py
@@ -27,8 +27,6 @@ __all__: List[str] = ["SDPBackend", "sdpa_kernel", "WARN_FOR_UNFUSED_KERNELS"]
 WARN_FOR_UNFUSED_KERNELS = False
 
 
-from enum import Enum
-
 from torch._C import _SDPBackend as SDPBackend
 
 # Hacks for Sphinx documentation:

--- a/torch/nn/attention/__init__.py
+++ b/torch/nn/attention/__init__.py
@@ -27,6 +27,8 @@ __all__: List[str] = ["SDPBackend", "sdpa_kernel", "WARN_FOR_UNFUSED_KERNELS"]
 WARN_FOR_UNFUSED_KERNELS = False
 
 
+from enum import Enum
+
 from torch._C import _SDPBackend as SDPBackend
 
 # Hacks for Sphinx documentation:
@@ -34,7 +36,15 @@ from torch._C import _SDPBackend as SDPBackend
 SDPBackend = SDPBackend
 r"""An enum-like class that contains the different backends for scaled dot product attention.
     This backend class is designed to be used with the sdpa_kernel context manager.
-    See :func: torch.nn.attention.sdpa_kernel for more details.
+
+    The following Enums are available:
+        - ERROR: An error occurred when trying to determine the backend.
+        - MATH: The math backend for scaled dot product attention.
+        - FLASH_ATTENTION: The flash attention backend for scaled dot product attention.
+        - EFFICIENT_ATTENTION: The efficient attention backend for scaled dot product attention.
+        - CUDNN_ATTENTION: The cuDNN backend for scaled dot product attention.
+
+    See :func:`torch.nn.attention.sdpa_kernel` for more details.
 
     ... warning:: This class is in beta and subject to change.
 """
@@ -65,6 +75,20 @@ def sdpa_kernel(backends: Union[List[SDPBackend], SDPBackend]):
 
     Args:
         backend (Union[List[SDPBackend], SDPBackend]): A backend or list of backends for scaled dot product attention.
+
+    Example:
+
+    .. code-block:: python
+
+        from torch.nn.functional import scaled_dot_product_attention
+        from torch.nn.attention import SDPBackend, sdpa_kernel
+        # Only enable flash attention backend
+        with sdpa_kernel(SDPBackend.FLASH_ATTENTION):
+            scaled_dot_product_attention(...)
+
+        # Enable the Math or Efficient attention backends
+        with sdpa_kernel([SDPBackend.MATH, SDPBackend.EFFICIENT_ATTENTION]):
+            scaled_dot_product_attention(...)
 
     This context manager can be used to select which backend to use for scaled dot product attention.
     Upon exiting the context manager, the previous state of the flags will be restored, enabling all backends.

--- a/torch/nn/attention/__init__.py
+++ b/torch/nn/attention/__init__.py
@@ -44,7 +44,7 @@ r"""An enum-like class that contains the different backends for scaled dot produ
 
     See :func:`torch.nn.attention.sdpa_kernel` for more details.
 
-    ... warning:: This class is in beta and subject to change.
+    .. warning:: This class is in beta and subject to change.
 """
 SDPBackend.__module__ = __name__
 SDPBackend.__name__ = "SDPBackend"

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5009,10 +5009,10 @@ Note:
     is used, the following functions are provided for enabling and disabling implementations.
     The context manager is the preferred mechanism:
 
-        - :func:`torch.nn.attention.sdpa_kernel`: A context manager used to enable/disable any of the implementations.
-        - :func:`torch.backends.cuda.enable_flash_sdp`: Globally Enables or Disables FlashAttention.
-        - :func:`torch.backends.cuda.enable_mem_efficient_sdp`: Globally Enables or Disables Memory-Efficient Attention.
-        - :func:`torch.backends.cuda.enable_math_sdp`: Globally Enables or Disables the PyTorch C++ implementation.
+        - :func:`torch.nn.attention.sdpa_kernel`: A context manager used to enable or disable any of the implementations.
+        - :func:`torch.backends.cuda.enable_flash_sdp`: Globally enables or disables FlashAttention.
+        - :func:`torch.backends.cuda.enable_mem_efficient_sdp`: Globally enables or disables  Memory-Efficient Attention.
+        - :func:`torch.backends.cuda.enable_math_sdp`: Globally enables or disables  the PyTorch C++ implementation.
 
     Each of the fused kernels has specific input limitations. If the user requires the use of a specific fused implementation,
     disable the PyTorch C++ implementation using :func:`torch.nn.attention.sdpa_kernel`.

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5009,14 +5009,14 @@ Note:
     is used, the following functions are provided for enabling and disabling implementations.
     The context manager is the preferred mechanism:
 
-        - :func:`torch.backends.cuda.sdp_kernel`: A context manager used to enable/disable any of the implementations.
-        - :func:`torch.backends.cuda.enable_flash_sdp`: Enables or Disables FlashAttention.
-        - :func:`torch.backends.cuda.enable_mem_efficient_sdp`: Enables or Disables Memory-Efficient Attention.
-        - :func:`torch.backends.cuda.enable_math_sdp`: Enables or Disables the PyTorch C++ implementation.
+        - :func:`torch.nn.attention.sdpa_kernel`: A context manager used to enable/disable any of the implementations.
+        - :func:`torch.backends.cuda.enable_flash_sdp`: Globally Enables or Disables FlashAttention.
+        - :func:`torch.backends.cuda.enable_mem_efficient_sdp`: Globally Enables or Disables Memory-Efficient Attention.
+        - :func:`torch.backends.cuda.enable_math_sdp`: Globally Enables or Disables the PyTorch C++ implementation.
 
     Each of the fused kernels has specific input limitations. If the user requires the use of a specific fused implementation,
-    disable the PyTorch C++ implementation using :func:`torch.backends.cuda.sdp_kernel`.
-    In the event that a fused implementation is not available, an error will be raised with the
+    disable the PyTorch C++ implementation using :func:`torch.nn.attention.sdpa_kernel`.
+    In the event that a fused implementation is not available, a warning will be raised with the
     reasons why the fused implementation cannot run.
 
     Due to the nature of fusing floating point operations, the output of this function may be different


### PR DESCRIPTION
# Summary

Updates the SDPA docs to fix some small inaccuracies and points to the new sdpa_kernel context manger. The Enum like type binded from cpp SDPBackend does not render its fields for some reason. Manually list them instead for now

cc @svekars @brycebortree