### PR TITLE
Move JK check to on-demand

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -9,15 +9,6 @@ def is_fbcode():
     return not hasattr(torch.version, "git_version")
 
 
-def enable_autotune_remote_cache():
-    if is_fbcode():
-        from torch._utils_internal import justknobs_check
-
-        if justknobs_check("pytorch/autotune_remote_cache:enable"):
-            return True
-    return os.environ.get("TORCH_INDUCTOR_AUTOTUNE_REMOTE_CACHE") == "1"
-
-
 # add some debug printouts
 debug = False
 
@@ -202,7 +193,9 @@ max_autotune_gemm = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_GEMM") == "1"
 use_autotune_local_cache = True
 
 # enable autotune remote cache
-use_autotune_remote_cache = enable_autotune_remote_cache()
+use_autotune_remote_cache = (
+    os.environ.get("TORCH_INDUCTOR_AUTOTUNE_REMOTE_CACHE") == "1"
+)
 
 # force cublas and triton to use the same precision; cublas supports TF32 for matmul operations
 # when m, n, k are multiples of 16, 16, 8, whereas triton supports TF32 for matmul operations

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -832,7 +832,12 @@ def cached_autotune(
         remote_cache_key = None
         if config.use_autotune_local_cache:
             cache_filename = os.path.splitext(filename)[0] + ".best_config"
-        if config.use_autotune_remote_cache:
+        if config.use_autotune_remote_cache or (
+            config.is_fbcode()
+            and torch._utils_internal.justknobs_check(
+                "pytorch/autotune_remote_cache:enable"
+            )
+        ):
             backend_hash = inductor_meta.get("backend_hash", None)
             if backend_hash is not None:
                 key = backend_hash + "autotune-best-config"


### PR DESCRIPTION
Summary: Some tests are failing due to checking JK during forking. Lets move the JK check to on-demand.

Differential Revision: D54518293




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang