### PR TITLE
fix segfault in torch.native_channel_shuffle when input is empty

### DIFF
--- a/aten/src/ATen/native/ChanelShuffle.cpp
+++ b/aten/src/ATen/native/ChanelShuffle.cpp
@@ -20,11 +20,16 @@
 namespace at::native {
 
 Tensor channel_shuffle_cpu(const Tensor& self, int64_t groups) {
-  auto memory_format = self.suggest_memory_format();
-  auto output = at::empty({0}, self.options());
-  output.resize_(self.sizes(), memory_format);
-  auto input = self.contiguous(memory_format);
-  channel_shuffle_kernel(kCPU, output, input, groups);
+  Tensor output;
+  if (self.numel() == 0) {
+    output = self.alias();
+  } else {
+    auto memory_format = self.suggest_memory_format();
+    output = at::empty({0}, self.options());
+    output.resize_(self.sizes(), memory_format);
+    auto input = self.contiguous(memory_format);
+    channel_shuffle_kernel(kCPU, output, input, groups);
+  }
   return namedinference::propagate_names_if_nonempty(
       output,
       self.has_names() ? self.names() : at::ArrayRef<Dimname>{});

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6226,6 +6226,8 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         input_tensor = torch.rand([0, 9, 4, 4])
         output = torch.nn.ChannelShuffle(groups)(input_tensor)
         torch.testing.assert_close(output, input_tensor)
+        output2 = torch.native_channel_shuffle(input_tensor, groups)
+        torch.testing.assert_close(output2, input_tensor)
 
     @set_default_dtype(torch.double)
     def test_upsamplingLinear1d(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6226,8 +6226,13 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         input_tensor = torch.rand([0, 9, 4, 4])
         output = torch.nn.ChannelShuffle(groups)(input_tensor)
         torch.testing.assert_close(output, input_tensor)
-        output2 = torch.native_channel_shuffle(input_tensor, groups)
-        torch.testing.assert_close(output2, input_tensor)
+
+    @skipIfTorchDynamo("TorchDynamo fails here for unknown reasons")
+    def test_native_channel_shuffle_return_alias_of_self(self):
+        groups = 3
+        input_tensor = torch.rand([0, 9, 4, 4])
+        output = torch.native_channel_shuffle(input_tensor, groups)
+        torch.testing.assert_close(output, input_tensor)
 
     @set_default_dtype(torch.double)
     def test_upsamplingLinear1d(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):

fix https://github.com/pytorch/pytorch/issues/121092

`torch.channel_shuffle` could handle empty inputs correctly. `torch.native_channel_shuffle` bypassed the `numel == 0` check, this causes divided by zero in underlying kernel.

* __->__ #121199

