### PR TITLE
[inductor] Enable ABI-compatible mode for cpp wrapper codegen

### DIFF
--- a/test/inductor/test_cuda_cpp_wrapper.py
+++ b/test/inductor/test_cuda_cpp_wrapper.py
@@ -93,6 +93,26 @@ if TEST_WITH_ROCM:
             dynamic_shapes_test_name
         ] = test_torchinductor.TestFailure(("cuda_wrapper",), is_skip=True)
 
+if config.abi_compatible:
+    exclude_list = [
+        "test_bernoulli1_cuda",
+        "test_conv_backward_cuda",
+        "test_custom_op_cuda",
+        "test_index_put_deterministic_fallback_cuda",
+        "test_linear1_cuda",
+        "test_multi_device_cuda",
+        "test_profiler_mark_wrapper_call",
+    ]
+
+    # Create skip entries for both the cuda and cuda_dynamic_shapes variants
+    for test_name in exclude_list:
+        test_failures_cuda_wrapper[test_name] = test_torchinductor.TestFailure(
+            ("cuda_wrapper",), is_skip=True
+        )
+        test_failures_cuda_wrapper[
+            f"{test_name}_dynamic_shapes"
+        ] = test_torchinductor.TestFailure(("cuda_wrapper",), is_skip=True)
+
 
 def make_test_case(
     name,

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -769,7 +769,7 @@ class CommonTemplate:
             _, code = run_and_get_code(fn, x, y)
             self.assertEqual(
                 " ".join(code).count(
-                    "::view_dtype" if config.cpp_wrapper else "aten.view"
+                    "view_dtype" if config.cpp_wrapper else "aten.view"
                 ),
                 3,
             )

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1313,7 +1313,7 @@ def get_include_and_linking_paths(
                     ]
                 )
 
-        if aot_mode and cuda:
+        if cuda:
             if macros is None:
                 macros = ""
             macros += " -D USE_ROCM" if torch.version.hip else " -D USE_CUDA"
@@ -2014,8 +2014,7 @@ class CppWrapperCodeCache(CppPythonBindingsCodeCache):
         }
 
         std::vector<at::Tensor> inductor_entry_cpp(std::vector<at::Tensor>&& inputs) {
-            auto input_handles =
-                torch::aot_inductor::unsafe_alloc_new_handles_from_tensors(inputs);
+            auto input_handles = unsafe_alloc_new_handles_from_tensors(inputs);
             // For outputs, we only allocate a vector to hold returned tensor handles,
             // not allocating the actual output tensor storage here
             std::vector<AtenTensorHandle> output_handles(%s);
@@ -2030,8 +2029,7 @@ class CppWrapperCodeCache(CppPythonBindingsCodeCache):
                 return {};
             }
 
-            return torch::aot_inductor::alloc_tensors_by_stealing_from_handles(
-                output_handles.data(), output_handles.size());
+            return alloc_tensors_by_stealing_from_handles(output_handles.data(), output_handles.size());
         }
         """
     )

--- a/torch/_inductor/codegen/aoti_runtime/implementation.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/implementation.cpp
@@ -76,17 +76,6 @@ void convert_handles_to_inputs(
 }
 
 template <typename T>
-const T& convert_arrayref_tensor_to_tensor(const T& t) {
-  return t;
-}
-
-template <typename T>
-RAIIAtenTensorHandle convert_arrayref_tensor_to_tensor(
-    const ArrayRefTensor<T>& art) {
-  return art.expensiveCopyToTensor();
-}
-
-template <typename T>
 void assert_numel(const ArrayRefTensor<T>& tensor, int64_t numel) {
   if (tensor.numel() != numel) {
     std::stringstream err;

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -275,7 +275,9 @@ class EnterDeviceContextManagerLine:
             else:
                 if self.last_seen_device_guard_index is None:
                     code.writeline(
-                        f"at::cuda::CUDAGuard device_guard({self.device_idx});"
+                        f"AOTICudaGuard device_guard({self.device_idx});"
+                        if config.abi_compatible
+                        else f"at::cuda::CUDAGuard device_guard({self.device_idx});"
                     )
                 else:
                     code.writeline(f"device_guard.set_index({self.device_idx});")
@@ -1489,7 +1491,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
                 grid_fn,
             )
         else:
-            if V.graph.aot_mode and config.abi_compatible:
+            if config.abi_compatible:
                 assert arg_types is not None and len(call_args) == len(
                     arg_types
                 ), "Mismatch call_args and arg_types in generate_kernel_call"
@@ -1537,10 +1539,21 @@ class CppWrapperCodeGen(WrapperCodeGen):
             )
 
         if config.abi_compatible:
-            self.header.splice("#include <torch/csrc/inductor/aoti_torch/c/shim.h>")
+            self.header.splice(
+                """
+                #include <torch/csrc/inductor/aoti_runtime/arrayref_tensor.h>
+                #include <torch/csrc/inductor/aoti_runtime/thread_local.h>
+                #include <torch/csrc/inductor/aoti_runtime/scalar_to_tensor.h>
+                #include <torch/csrc/inductor/aoti_runtime/utils.h>
+                """
+            )
+            if V.graph.aot_mode:
+                self.header.splice(
+                    """
+                    #include <torch/csrc/inductor/aoti_runtime/model.h>
+                    """
+                )
         else:
-            if not V.graph.aot_mode:
-                self.header.splice("#include <pybind11/pybind11.h>")
             self.header.splice(
                 """
                 #include <ATen/ATen.h>
@@ -1556,14 +1569,17 @@ class CppWrapperCodeGen(WrapperCodeGen):
                 #define alloc_from_pool torch::inductor::_alloc_from_pool
                 """
             )
-            if V.graph.cuda:
-                self.header.splice(
-                    """
-                    #include <ATen/cuda/EmptyTensor.h>
-                    """
-                )
 
         self.header.splice("#include <c10/util/generic_math.h>")
+
+        if not V.graph.aot_mode:
+            self.header.splice(
+                """
+                #include <pybind11/pybind11.h>
+
+                using namespace torch::aot_inductor;
+                """
+            )
 
         from .memory_planning import ALIGN_BYTES
 
@@ -1747,31 +1763,31 @@ class CppWrapperCodeGen(WrapperCodeGen):
         with self.prefix.indent():
             # assign inputs and outputs in both cases so the later codegen can be simplified
             if not config.use_minimal_arrayref_interface:
-                if V.graph.aot_mode:
-                    if not V.graph.is_const_graph:
-                        if config.abi_compatible:
-                            self.prefix.splice(
-                                """
-                                    auto inputs = steal_from_raw_handles_to_raii_handles(input_handles, num_inputs());
-                                """
-                            )
-                        else:
-                            # This looks dumb, but can avoid creating two versions of code in the AOTInductor runtime.
-                            self.prefix.splice(
-                                """
-                                    auto inputs = alloc_tensors_by_stealing_from_handles(input_handles, num_inputs());
-                                """
-                            )
-                else:
-                    # The use of alloc_tensors_by_stealing_from_handles will be consolidated
-                    num_args = len(V.graph.graph_inputs) + len(V.graph.constants)
-                    self.prefix.splice(
-                        f"""
-                            pybind11::gil_scoped_release release;
+                if not V.graph.is_const_graph:
+                    if V.graph.aot_mode:
+                        num_args = len(V.graph.graph_inputs)
+                    else:
+                        # Weights are promoted in the JIT mode
+                        num_args = len(V.graph.graph_inputs) + len(V.graph.constants)
+                        self.prefix.splice(
+                            """
+                                pybind11::gil_scoped_release release;
+                            """
+                        )
 
-                            auto inputs = torch::aot_inductor::alloc_tensors_by_stealing_from_handles(input_handles, {num_args});
-                        """
-                    )
+                    if config.abi_compatible:
+                        self.prefix.splice(
+                            f"""
+                                auto inputs = steal_from_raw_handles_to_raii_handles(input_handles, {num_args});
+                            """
+                        )
+                    else:
+                        # This looks dumb, but can avoid creating two versions of code in the AOTInductor runtime.
+                        self.prefix.splice(
+                            f"""
+                                auto inputs = alloc_tensors_by_stealing_from_handles(input_handles, {num_args});
+                            """
+                        )
 
             if inputs_len != 0:
                 for idx, input_key in enumerate(V.graph.graph_inputs.keys()):
@@ -1792,12 +1808,16 @@ class CppWrapperCodeGen(WrapperCodeGen):
                             dtype is not None
                         ), "Fails to get the dtype of the sympy.Expr"
                         cpp_dtype = DTYPE_TO_CPP[dtype]
-                        assert (
-                            not config.abi_compatible
-                        ), "Need to add .item support for abi_compatible AOTInductor codegen"
-                        self.prefix.writeline(
-                            f"{cpp_dtype} {input_key} = inputs[{idx}].item<{cpp_dtype}>();"
-                        )
+                        if config.abi_compatible:
+                            self.prefix.writeline(f"{cpp_dtype} {input_key};")
+                            dtype_str = str(dtype).split(".")[-1]
+                            self.prefix.writeline(
+                                f"aoti_torch_item_{dtype_str}(inputs[{idx}], &{input_key});"
+                            )
+                        else:
+                            self.prefix.writeline(
+                                f"{cpp_dtype} {input_key} = inputs[{idx}].item<{cpp_dtype}>();"
+                            )
                     else:
                         self.prefix.writeline(
                             f"auto {input_key} = std::move(inputs[{idx}]);"
@@ -2275,7 +2295,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
             # Append constants to the input args for cpp wrapper.
             # Python wrapper directly gets the value inside the wrapper call
             # as a global variable passed when calling exec(code, mod.__dict__, mod.__dict__).
-            # For cpp wrapper, we need to pass this python value to the inductor_entry_cpp function explicitly.
+            # For cpp wrapper, we need to pass this python value to the inductor_entry_impl function explicitly.
             assert all(
                 isinstance(v, torch.Tensor) for v in list(V.graph.constants.values())
             ), "Expect all constants to be Tensor"
@@ -2335,7 +2355,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
         self.writeline(f"RAIIAtenTensorHandle {name}({output_handle_name});")
 
     def generate_extern_kernel_alloc(self, extern_kernel, args):
-        if V.graph.aot_mode and config.abi_compatible:
+        if config.abi_compatible:
             self.generate_c_shim_extern_kernel_alloc(extern_kernel, args)
         else:
             super().generate_extern_kernel_alloc(extern_kernel, args)
@@ -2376,7 +2396,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
             self.writeline(raii_handle)
 
     def generate_fallback_kernel(self, fallback_kernel, args):
-        if V.graph.aot_mode and config.abi_compatible:
+        if config.abi_compatible:
             self.generate_c_shim_fallback_kernel(fallback_kernel, args)
         else:
             super().generate_fallback_kernel(fallback_kernel, args)
@@ -2391,7 +2411,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
         else:
             args.insert(0, f"{codegen_reference}")
 
-        if V.graph.aot_mode and config.abi_compatible:
+        if config.abi_compatible:
             self.generate_c_shim_extern_kernel_call(kernel, args)
         else:
             self.writeline(self.wrap_kernel_call(kernel, args))
@@ -2423,7 +2443,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
         self, output, inputs, kernel, python_kernel_name, src_is_tensor, reduce, kwargs
     ):
         # TODO: support other overload for cpp wrapper and remove the below assertions
-        if V.graph.aot_mode and config.abi_compatible:
+        if config.abi_compatible:
             # call the ABI shim function instead of the ATen one
             kernel = kernel.replace("at::", "aoti_torch_")
         line = f"{kernel}({output}, {','.join(map(str, inputs))}"
@@ -2444,7 +2464,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
         if V.graph.aot_mode and V.graph.cpp_wrapper and config.abi_compatible:
             # See the comment in codegen_reinterpret_view about why having something like
             # RAIIAtenTensorHandle(tmp_tensor_handle_2) in a tmp array can cause the correponding
-            # tensor prematurely deallocated, thus this std:vector().data() trick here.
+            # tensor prematurely deallocated, thus this std::vector().data() trick here.
             indices_str = (
                 f"std::vector<AtenTensorHandle>{{{', '.join(indices)}}}.data()"
             )
@@ -2467,7 +2487,7 @@ class CppWrapperCodeGen(WrapperCodeGen):
         return self.expr_printer(V.graph.sizevars.simplify(x))
 
     def codegen_tuple_access(self, basename: str, name: str, index: str) -> str:
-        if V.graph.aot_mode and config.abi_compatible:
+        if config.abi_compatible:
             # in the abi_compatible mode, outputs are returned via arguments
             return name
         else:
@@ -3123,6 +3143,7 @@ class CudaWrapperCodeGen(CppWrapperCodeGen):
                 """
                 #include <c10/cuda/CUDAGuard.h>
                 #include <c10/cuda/CUDAStream.h>
+                #include <ATen/cuda/EmptyTensor.h>
                 """
             )
 
@@ -3199,8 +3220,9 @@ class CudaWrapperCodeGen(CppWrapperCodeGen):
 
     def write_get_raw_stream(self, index):
         name = f"stream{index}"
+        self.writeline(f"cudaStream_t {name};")
         self.writeline(
-            f"cudaStream_t {name} = at::cuda::getCurrentCUDAStream({index});"
+            f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_get_current_cuda_stream({index}, (void**)&{name}));"
         )
         return name
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4238,7 +4238,11 @@ class InplaceBernoulliFallback(ExternKernel):
         )
         self.name = V.graph.register_buffer(self)
         self.python_kernel_name = "aten.bernoulli_"
-        self.cpp_kernel_name = "at::native::bernoulli_"
+        self.cpp_kernel_name = (
+            "aoti_torch_bernoulli_"
+            if config.abi_compatible
+            else "at::native::bernoulli_"
+        )
         mark_node_as_mutating(self, x)
 
 

--- a/torch/csrc/inductor/aoti_runtime/arrayref_tensor.h
+++ b/torch/csrc/inductor/aoti_runtime/arrayref_tensor.h
@@ -352,5 +352,16 @@ inline AtenTensorHandle expensive_copy_to_tensor_if_needed(
   return handle;
 }
 
+template <typename T>
+const T& convert_arrayref_tensor_to_tensor(const T& t) {
+  return t;
+}
+
+template <typename T>
+RAIIAtenTensorHandle convert_arrayref_tensor_to_tensor(
+    const ArrayRefTensor<T>& art) {
+  return art.expensiveCopyToTensor();
+}
+
 } // namespace aot_inductor
 } // namespace torch

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -465,6 +465,20 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_view_dtype(
 
 #ifdef USE_CUDA
 
+struct CUDAGuardOpaque;
+using CUDAGuardHandle = CUDAGuardOpaque*;
+
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_create_cuda_guard(
+    int32_t device_index,
+    CUDAGuardHandle* ret_guard // returns new reference
+);
+
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch_delete_cuda_guard(CUDAGuardHandle guard);
+
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch_cuda_guard_set_index(CUDAGuardHandle guard, int32_t device_index);
+
 struct CUDAStreamGuardOpaque;
 using CUDAStreamGuardHandle = CUDAStreamGuardOpaque*;
 
@@ -476,6 +490,10 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_create_cuda_stream_guard(
 
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_delete_cuda_stream_guard(CUDAStreamGuardHandle guard);
+
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch_get_current_cuda_stream(int32_t device_index, void** ret_stream);
+
 #endif
 
 // See `ProxyExecutor Design Note` in ir.py for more details

--- a/torch/csrc/inductor/aoti_torch/shim_cuda.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_cuda.cpp
@@ -5,6 +5,29 @@
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
 
+AOTITorchError aoti_torch_create_cuda_guard(
+    int32_t device_index,
+    CUDAGuardHandle* ret_guard // returns new reference
+) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    at::cuda::CUDAGuard* guard = new at::cuda::CUDAGuard(device_index);
+    *ret_guard = reinterpret_cast<CUDAGuardHandle>(guard);
+  });
+}
+
+AOTITorchError aoti_torch_delete_cuda_guard(CUDAGuardHandle guard) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      { delete reinterpret_cast<at::cuda::CUDAGuard*>(guard); });
+}
+
+AOTITorchError aoti_torch_cuda_guard_set_index(
+    CUDAGuardHandle guard,
+    int32_t device_index) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    reinterpret_cast<at::cuda::CUDAGuard*>(guard)->set_index(device_index);
+  });
+}
+
 AOTITorchError aoti_torch_create_cuda_stream_guard(
     void* stream,
     int32_t device_index,
@@ -21,4 +44,11 @@ AOTITorchError aoti_torch_delete_cuda_stream_guard(
     CUDAStreamGuardHandle guard) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
       { delete reinterpret_cast<at::cuda::CUDAStreamGuard*>(guard); });
+}
+
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch_get_current_cuda_stream(int32_t device_index, void** ret_stream) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    *(cudaStream_t*)(ret_stream) = at::cuda::getCurrentCUDAStream(device_index);
+  });
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121221



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @chauhang