### PR TITLE
Constexpr checks in CUDAAllocatorConfig::roundup_power2_divisions

### DIFF
--- a/c10/cuda/CUDAAllocatorConfig.cpp
+++ b/c10/cuda/CUDAAllocatorConfig.cpp
@@ -25,11 +25,11 @@ size_t CUDAAllocatorConfig::roundup_power2_divisions(size_t size) {
   size_t log_size = (63 - llvm::countLeadingZeros(size));
 
   // Our intervals start at 1MB and end at 64GB
-  const size_t interval_start =
+  constexpr size_t interval_start =
       63 - llvm::countLeadingZeros(static_cast<size_t>(1048576));
-  const size_t interval_end =
+  constexpr size_t interval_end =
       63 - llvm::countLeadingZeros(static_cast<size_t>(68719476736));
-  TORCH_CHECK(
+  static_assert(
       (interval_end - interval_start == kRoundUpPowerOfTwoIntervals),
       "kRoundUpPowerOfTwoIntervals mismatch");
 

--- a/c10/util/llvmMathExtras.h
+++ b/c10/util/llvmMathExtras.h
@@ -147,7 +147,7 @@ std::size_t countTrailingZeros(T Val, ZeroBehavior ZB = ZB_Width) {
 namespace detail {
 template <typename T, std::size_t SizeOfT>
 struct LeadingZerosCounter {
-  static std::size_t count(T Val, ZeroBehavior) {
+  constexpr static std::size_t count(T Val, ZeroBehavior) {
     if (!Val)
       return std::numeric_limits<T>::digits;
 
@@ -167,7 +167,7 @@ struct LeadingZerosCounter {
 #if (defined(__GNUC__) && __GNUC__ >= 4) || defined(_MSC_VER)
 template <typename T>
 struct LeadingZerosCounter<T, 4> {
-  static std::size_t count(T Val, ZeroBehavior ZB) {
+  constexpr static std::size_t count(T Val, ZeroBehavior ZB) {
     if (ZB != ZB_Undefined && Val == 0)
       return 32;
 
@@ -184,7 +184,7 @@ struct LeadingZerosCounter<T, 4> {
 #if !defined(_MSC_VER) || defined(_M_X64)
 template <typename T>
 struct LeadingZerosCounter<T, 8> {
-  static std::size_t count(T Val, ZeroBehavior ZB) {
+  constexpr static std::size_t count(T Val, ZeroBehavior ZB) {
     if (ZB != ZB_Undefined && Val == 0)
       return 64;
 
@@ -209,7 +209,7 @@ struct LeadingZerosCounter<T, 8> {
 /// \param ZB the behavior on an input of 0. Only ZB_Width and ZB_Undefined are
 ///   valid arguments.
 template <typename T>
-std::size_t countLeadingZeros(T Val, ZeroBehavior ZB = ZB_Width) {
+constexpr std::size_t countLeadingZeros(T Val, ZeroBehavior ZB = ZB_Width) {
   static_assert(
       std::numeric_limits<T>::is_integer && !std::numeric_limits<T>::is_signed,
       "Only unsigned integral types are allowed.");

--- a/c10/util/llvmMathExtras.h
+++ b/c10/util/llvmMathExtras.h
@@ -10,6 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Local modifications in Pytorch variant:
+// 1. Add constexpr to countLeadingZeros and
+// llvm::detail::LeadingZerosCounter::count
+
 #pragma once
 
 #include <c10/util/bit_cast.h>


### PR DESCRIPTION
This PR adds constexpr modifier to some template functions to make sure that the checks in CUDAAllocatorConfig::roundup_power2_divisions become compile-time computations.