### PR TITLE
Enable test_embedding_jagged

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -833,11 +833,6 @@ class TestNestedTensorDeviceType(TestCase):
             lambda: layer_norm(nt),
         )
 
-    @decorateIf(
-        xfailIfTorchDynamo,
-        # only fails in python 3.11. TODO: Ensure this is fixed once views work!
-        lambda params: params["layout"] == torch.jagged and sys.version_info >= (3, 11)
-    )
     @parametrize("layout", [torch.strided, torch.jagged], name_fn=layout_name)
     def test_embedding(self, device, layout):
         inputs = [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121243

Summary: I have another PR seeing a failure on this test because we're expecting failure, but getting success. But looks like this test is passing and we can re-enable?