### PR TITLE
[FSDP2] Improved msg when parent mesh but not DTensor

### DIFF
--- a/torch/distributed/_composable/fsdp/_fsdp_param.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_param.py
@@ -183,11 +183,14 @@ class FSDPParam:
             self._global_stride = param.stride()
             param_data = cast(DTensor, param)._local_tensor
         else:
-            if _mesh_resources.get_parent_mesh(self.mesh_info.mesh) is not None:
+            mesh = self.mesh_info.mesh
+            if (parent_mesh := _mesh_resources.get_parent_mesh(mesh)) is not None:
+                module_info = self._module_info
                 raise NotImplementedError(
-                    "Using a parent mesh with pure FSDP/HSDP is not supported"
+                    f"Sharding with FSDP mesh {mesh} and parent mesh {parent_mesh} requires "
+                    f"a DTensor but got non-DTensor {module_info.param_name} on {module_info.module}"
                 )
-            self._global_mesh = self.mesh_info.mesh
+            self._global_mesh = mesh
             self._global_placements = (Shard(0),)
             self._global_size = param.size()
             self._global_stride = param.stride()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #120952
* #121357
* #121356
* __->__ #121244
* #121328
* #120351

Currently, FSDP2 requires that if using a `mesh` that has a parent mesh, then the parameters to shard must be `DTensor`s. This PR improves the error message to help find the parameter that violates this.

Do we _have_ to have this requirement? Maybe not. The sharded state dict could still use the 1D mesh. However, I worry that we could inadvertently have a case where the sharded state dict then has a mix of 1D and 2D `DTensor`s.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang