### PR TITLE
[TP] Introduce Sequence Parallel Style for Laynorm/RMSNorm/Dropout

### DIFF
--- a/test/distributed/fsdp/test_fsdp_tp_integration.py
+++ b/test/distributed/fsdp/test_fsdp_tp_integration.py
@@ -32,7 +32,10 @@ from torch.testing._internal.common_utils import (
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
 )
-from torch.testing._internal.distributed._tensor.common_dtensor import MLPModule
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    MLPModule,
+    RMSNormPython,
+)
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
@@ -64,21 +67,6 @@ class SimpleModel(torch.nn.Module):
     @staticmethod
     def get_non_sharded_param_names() -> List[str]:
         return ["net3.weight", "net3.bias"]
-
-
-# simple RMSNorm layer for testing
-class RMSNormPython(torch.nn.Module):
-    def __init__(self, dim: int, eps: float = 1e-6):
-        super().__init__()
-        self.eps = eps
-        self.weight = torch.nn.Parameter(torch.ones(dim))
-
-    def _norm(self, x):
-        return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
-
-    def forward(self, x):
-        output = self._norm(x)
-        return output * self.weight
 
 
 def distribute_rmsnorm(module, device_mesh):

--- a/test/distributed/tensor/parallel/test_tp_examples.py
+++ b/test/distributed/tensor/parallel/test_tp_examples.py
@@ -7,7 +7,6 @@ import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 from torch.distributed._tensor import DeviceMesh, DTensor, Replicate, Shard, distribute_tensor
-import torch.distributed._functional_collectives as funcol
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     checkpoint_wrapper,
     CheckpointImpl,
@@ -18,6 +17,7 @@ from torch.distributed.tensor.parallel import (
     parallelize_module,
     PrepareModuleInput,
     RowwiseParallel,
+    SequenceParallel,
 )
 from torch.distributed.tensor.parallel.input_reshard import input_reshard
 from torch.testing._internal.common_utils import (
@@ -184,22 +184,24 @@ class DistTensorParallelExampleTest(DTensorTestBase):
 
         device_mesh = DeviceMesh(self.device_type, torch.arange(0, NUM_DEVICES))
 
-        # Parallelize the embedding submodules.
-        parallelize_module(
-            model_tp.tok_embeddings,
-            device_mesh,
-            ColwiseParallel(
-                output_layouts=Shard(1)
-            ) if is_seq_parallel else ColwiseParallel(output_layouts=Replicate())
-        )
-        parallelize_module(
-            model_tp.pos_embeddings,
-            device_mesh,
-            ColwiseParallel(
-                output_layouts=Shard(0),
-            ) if is_seq_parallel else ColwiseParallel(output_layouts=Replicate())
-        )
+        # Parallelize the root submodules.
+        if is_seq_parallel:
+            root_plan = {
+                "tok_embeddings": ColwiseParallel(output_layouts=Shard(1)),
+                "pos_embeddings": ColwiseParallel(output_layouts=Shard(0)),
+                "norm": SequenceParallel(sequence_dim=1),
+            }
+        else:
+            root_plan = {
+                "tok_embeddings": ColwiseParallel(output_layouts=Replicate()),
+                "pos_embeddings": ColwiseParallel(output_layouts=Replicate()),
+            }
 
+        model_tp = parallelize_module(
+            model_tp,
+            device_mesh,
+            root_plan
+        )
         # Parallelize the attention and feed forward submodules.
         for layer in model_tp.layers:
             layer_parallelize_plan = {}
@@ -208,6 +210,9 @@ class DistTensorParallelExampleTest(DTensorTestBase):
                     input_layouts=Shard(1),
                     desired_input_layouts=Replicate(),
                 )
+                # shard the RMSNorms
+                layer_parallelize_plan["attention_norm"] = SequenceParallel(sequence_dim=1)
+                layer_parallelize_plan["ffn_norm"] = SequenceParallel(sequence_dim=1)
             layer_parallelize_plan["attention.wq"] = ColwiseParallel()
             layer_parallelize_plan["attention.wk"] = ColwiseParallel()
             layer_parallelize_plan["attention.wv"] = ColwiseParallel()
@@ -245,19 +250,6 @@ class DistTensorParallelExampleTest(DTensorTestBase):
         # Manually adjust the number of heads after sharding the attention modules.
         for layer in model_tp.layers:
             layer.attention.n_heads = model_args.n_heads // self.world_size
-
-        # TODO: switch to a TP API once that feature is ready.
-        # Manually register all_reduce hooks for all norm layers as they only process sharded inputs.
-        if is_seq_parallel:
-            def all_reduce_fn(grad):
-                return funcol.all_reduce(grad, reduceOp="SUM", group=device_mesh)
-            for layer in model_tp.layers:
-                layer.attention_norm.weight.register_hook(all_reduce_fn)
-                layer.attention_norm.bias.register_hook(all_reduce_fn)
-                layer.ffn_norm.weight.register_hook(all_reduce_fn)
-                layer.ffn_norm.bias.register_hook(all_reduce_fn)
-            model_tp.norm.weight.register_hook(all_reduce_fn)
-            model_tp.norm.bias.register_hook(all_reduce_fn)
 
         # Manually set output.weight so that parameters and gradients are shared.
         if model_args.weight_tying:

--- a/torch/distributed/tensor/parallel/__init__.py
+++ b/torch/distributed/tensor/parallel/__init__.py
@@ -8,6 +8,7 @@ from torch.distributed.tensor.parallel.style import (
     PrepareModuleInput,
     PrepareModuleOutput,
     RowwiseParallel,
+    SequenceParallel,
 )
 
 __all__ = [
@@ -16,6 +17,7 @@ __all__ = [
     "PrepareModuleInput",
     "PrepareModuleOutput",
     "RowwiseParallel",
+    "SequenceParallel",
     "parallelize_module",
     "loss_parallel"
 ]

--- a/torch/distributed/tensor/parallel/style.py
+++ b/torch/distributed/tensor/parallel/style.py
@@ -294,10 +294,6 @@ class SequenceParallel(ParallelStyle):
             replicated_param = torch.nn.Parameter(
                 DTensor.from_local(param, device_mesh, [Replicate()], run_check=False)
             )
-            # unsafely setattr to bypass the reconstruction of nn.Parameter(to avoid
-            # unnecessary `detach() + requires_grad_`
-            # module._parameters[p_name] = replicated_dtensor  # type: ignore[assignment]
-            # super(nn.Module, module).__setattr__(p_name, replicated_dtensor)
             module.register_parameter(p_name, replicated_param)
 
     @staticmethod

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -53,6 +53,20 @@ if torch.cuda.is_available() and torch.cuda.device_count() > 1:
 T = TypeVar("T")
 
 
+# simple RMSNorm layer for testing
+class RMSNormPython(torch.nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = torch.nn.Parameter(torch.ones(dim))
+
+    def _norm(self, x):
+        return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+
+    def forward(self, x):
+        output = self._norm(x)
+        return output * self.weight
+
 class MLPModule(nn.Module):
     def __init__(self, device):
         super().__init__()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121295
* #121294

As titled, this PR introduces a dedicated `ParallelStyle` to shard the
nn.LayerNorm/nn.Dropout/RMSNorm layers. We were mainly using a manual
distribute_module calls before when sharding the RMSNorm layer, but I
think we should have a dedicate TP API to easily shard those layers,
instead of user manually using DTensors.

I call this SequenceParallel, which might bring some confusion that we
technically "deprecated" a SequenceParallel style months ago. But this
time the SeuqenceParallel style is significantly different with the
previous ones (which used to shard two consecutive Linear layers). I
believe making it the right name is the first priority, instead of
worrying about the issue of reusing the old name

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang