### PR TITLE
[Quant] Add the operator of decomposed fake quant per channel

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1743,7 +1743,7 @@ class CPUReproTests(TestCase):
             )
             return res
 
-        def test_eager_aten_fake_quant(
+        def run_eager_aten_fake_quant(
             input, scales, zero_points, axis, quant_min, quant_max
         ):
             input.grad = None
@@ -1751,7 +1751,7 @@ class CPUReproTests(TestCase):
             res.sum().backward()
             return res, input.grad
 
-        def test_eager_decomposed_fake_quant(
+        def run_eager_decomposed_fake_quant(
             input, scales, zero_points, axis, quant_min, quant_max
         ):
             input.grad = None
@@ -1759,7 +1759,7 @@ class CPUReproTests(TestCase):
             res.sum().backward()
             return res, input.grad
 
-        def test_compile_decomposed_fake_quant(
+        def run_compile_decomposed_fake_quant(
             input, scales, zero_points, axis, quant_min, quant_max
         ):
             input.grad = None
@@ -1780,13 +1780,13 @@ class CPUReproTests(TestCase):
         aten_input = copy.deepcopy(input)
         compiler_input = copy.deepcopy(input)
 
-        res_aten_eager, input_grad_aten_eager = test_eager_aten_fake_quant(
+        res_aten_eager, input_grad_aten_eager = run_eager_aten_fake_quant(
             aten_input, scales, zero_points, axis, quant_min, quant_max
         )
-        res_decomp_eager, input_grad_decomp_eager = test_eager_decomposed_fake_quant(
+        res_decomp_eager, input_grad_decomp_eager = run_eager_decomposed_fake_quant(
             input, scales, zero_points, axis, quant_min, quant_max
         )
-        res, input_grad = test_compile_decomposed_fake_quant(
+        res, input_grad = run_compile_decomposed_fake_quant(
             compiler_input, scales, zero_points, axis, quant_min, quant_max
         )
 

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1730,6 +1730,72 @@ class CPUReproTests(TestCase):
             res_grad = test_args_for_opt["input"].grad
             self.assertEqual(ref_grad, res_grad)
 
+    def test_decomposed_fake_quant_per_channel(self):
+        def fq(input, scales, zero_points, axis, quant_min, quant_max):
+            res = torch.fake_quantize_per_channel_affine(
+                input, scales, zero_points, axis, quant_min, quant_max
+            )
+            return res
+
+        def qdq(input, scales, zero_points, axis, quant_min, quant_max):
+            res = torch.ops.quantized_decomposed.fake_quant_per_channel(
+                input, scales, zero_points, axis, quant_min, quant_max
+            )
+            return res
+
+        def test_eager_aten_fake_quant(
+            input, scales, zero_points, axis, quant_min, quant_max
+        ):
+            input.grad = None
+            res = fq(input, scales, zero_points, axis, quant_min, quant_max)
+            res.sum().backward()
+            return res, input.grad
+
+        def test_eager_decomposed_fake_quant(
+            input, scales, zero_points, axis, quant_min, quant_max
+        ):
+            input.grad = None
+            res = qdq(input, scales, zero_points, axis, quant_min, quant_max)
+            res.sum().backward()
+            return res, input.grad
+
+        def test_compile_decomposed_fake_quant(
+            input, scales, zero_points, axis, quant_min, quant_max
+        ):
+            input.grad = None
+            compiled_qdq = torch.compile(qdq)
+            res = compiled_qdq(input, scales, zero_points, axis, quant_min, quant_max)
+            res.sum().backward()
+            return res, input.grad
+
+        input = torch.randn(2, 3, 224, 224)
+        input[1, 2, 3, 4] = 257
+        input.requires_grad_()
+        scales = torch.ones((3,))
+        zero_points = torch.zeros((3,))
+        axis = 1
+        quant_min = -128
+        quant_max = 127
+
+        aten_input = copy.deepcopy(input)
+        compiler_input = copy.deepcopy(input)
+
+        res_aten_eager, input_grad_aten_eager = test_eager_aten_fake_quant(
+            aten_input, scales, zero_points, axis, quant_min, quant_max
+        )
+        res_decomp_eager, input_grad_decomp_eager = test_eager_decomposed_fake_quant(
+            input, scales, zero_points, axis, quant_min, quant_max
+        )
+        res, input_grad = test_compile_decomposed_fake_quant(
+            compiler_input, scales, zero_points, axis, quant_min, quant_max
+        )
+
+        self.assertEqual(res_aten_eager, res)
+        self.assertEqual(res_decomp_eager, res)
+        self.assertEqual(input_grad_aten_eager, input_grad)
+        self.assertEqual(input_grad_decomp_eager, input_grad)
+        self.assertEqual(input_grad[1, 2, 3, 4], torch.tensor(0.0))
+
     @patch("torch.cuda.is_available", lambda: False)
     def test_scatter_using_atomic_add(self):
         def fn(a, dim, index, b):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121297

**Summary**
Add the operator of `quantized_decomposed.fake_quant_per_channel` and test the forward and backward of this op with comparing to ATen.

**Test Plan**
```
python -u -m pytest -s -v test_cpu_repro.py -k test_decomposed_fake_quant_per_channel
```

**Next Step**
Optimize the performance: from the generated code of forward and backward graph, the code didn't vectorize.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang