### PR TITLE
Remove llava from ci_expected_accuracy as it's flaky

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_torchbench_inference.csv
@@ -178,10 +178,6 @@ llama,pass,0
 
 
 
-llava,fail_accuracy,0
-
-
-
 maml,pass_due_to_skip,0
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_inductor_torchbench_inference.csv
@@ -138,10 +138,6 @@ llama,pass,0
 
 
 
-llava,fail_accuracy,0
-
-
-
 maml,pass_due_to_skip,0
 
 

--- a/benchmarks/dynamo/torchbench.yaml
+++ b/benchmarks/dynamo/torchbench.yaml
@@ -182,6 +182,7 @@ skip:
       # works on cuda, accuracy failure on cpu
       - hf_Whisper
       - stable_diffusion_text_encoder
+      - llava
 
     cuda: []
 


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/121029 added it into the CI but the test is flaky on hud. It alternates between fail_accuracy and fail_to_run

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang