### PR TITLE
Upgrade sccache to v0.8.2 for CPU targets

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -414,9 +414,6 @@ case "$image" in
     DB=yes
     VISION=yes
     CONDA_CMAKE=yes
-    # snadampal: skipping sccache due to the following issue
-    # https://github.com/pytorch/pytorch/issues/121559
-    SKIP_SCCACHE_INSTALL=yes
     # snadampal: skipping llvm src build install because the current version
     # from pytorch/llvm:9.0.1 is x86 specific
     SKIP_LLVM_SRC_BUILD_INSTALL=yes
@@ -429,9 +426,6 @@ case "$image" in
     DB=yes
     VISION=yes
     CONDA_CMAKE=yes
-    # snadampal: skipping sccache due to the following issue
-    # https://github.com/pytorch/pytorch/issues/121559
-    SKIP_SCCACHE_INSTALL=yes
     # snadampal: skipping llvm src build install because the current version
     # from pytorch/llvm:9.0.1 is x86 specific
     SKIP_LLVM_SRC_BUILD_INSTALL=yes

--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -50,10 +50,30 @@ chmod a+x /opt/cache/bin/sccache
 function write_sccache_stub() {
   # Unset LD_PRELOAD for ps because of asan + ps issues
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90589
-  if [ $1 == "gcc"]; then
-    printf "#!/bin/sh\nif [ \"$1\" = \"-E\" ]; then\n  exec $(which $1)  \"\$@\"\nelif [ \$(env -u LD_PRELOAD ps -p \$PPID -o comm=) != sccache ]; then\n  exec sccache $(which $1) \"\$@\"\nelse\n  exec $(which $1) \"\$@\"\nfi" > "/opt/cache/bin/$1"
+  if [ $1 == "gcc" ]; then
+  # Do not call sccache recursively when dumping preprocessor argument
+  # For some reason it's very important for the first cached nvcc invocation
+    cat > "/opt/cache/bin/$1" <<EOF
+#!/bin/sh
+
+if [ "\$1" = "-E" ] -o [ "\$2" = "-E" ]; then
+  exec $(which $1) "\$@"
+elif [ \$(env -u LD_PRELOAD ps -p \$PPID -o comm=) != sccache ]; then
+  exec sccache $(which $1) "\$@"
+else
+  exec $(which $1) "\$@"
+fi
+EOF
   else
-    printf "#!/bin/sh\nif [ \$(env -u LD_PRELOAD ps -p \$PPID -o comm=) != sccache ]; then\n  exec sccache $(which $1) \"\$@\"\nelse\n  exec $(which $1) \"\$@\"\nfi" > "/opt/cache/bin/$1"
+    cat > "/opt/cache/bin/$1" <<EOF
+#!/bin/sh
+
+if [ \$(env -u LD_PRELOAD ps -p \$PPID -o comm=) != sccache ]; then
+  exec sccache $(which $1) "\$@"
+else
+  exec $(which $1) "\$@"
+fi
+EOF
   fi
   chmod a+x "/opt/cache/bin/$1"
 }

--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -9,7 +9,12 @@ install_ubuntu() {
   # Instead use lib and headers from OpenSSL1.1 installed in `install_openssl.sh``
   apt-get install -y cargo
   echo "Checking out sccache repo"
-  git clone https://github.com/mozilla/sccache -b v0.8.2
+  if [ -n "$CUDA_VERSION" ]; then
+      # TODO: Remove this
+      git clone https://github.com/pytorch/sccache
+  else
+      git clone https://github.com/mozilla/sccache -b v0.8.2
+  fi
   cd sccache
   echo "Building sccache"
   cargo build --release

--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -32,7 +32,9 @@ sed -e 's|PATH="\(.*\)"|PATH="/opt/cache/bin:\1"|g' -i /etc/environment
 export PATH="/opt/cache/bin:$PATH"
 
 # Setup compiler cache
-if [ -n "$ROCM_VERSION" ]; then
+if [ $(uname -m) == aarch64]; then
+  install_ubuntu
+elif [ -n "$ROCM_VERSION" ]; then
   curl --retry 3 http://repo.radeon.com/misc/.sccache_amd/sccache -o /opt/cache/bin/sccache
 else
   ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')

--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -9,7 +9,7 @@ install_ubuntu() {
   # Instead use lib and headers from OpenSSL1.1 installed in `install_openssl.sh``
   apt-get install -y cargo
   echo "Checking out sccache repo"
-  git clone https://github.com/mozilla/sccache -b v0.7.7
+  git clone https://github.com/mozilla/sccache -b v0.8.2
   cd sccache
   echo "Building sccache"
   cargo build --release

--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -56,7 +56,7 @@ function write_sccache_stub() {
     cat > "/opt/cache/bin/$1" <<EOF
 #!/bin/sh
 
-if [ "\$1" = "-E" ] -o [ "\$2" = "-E" ]; then
+if [ "\$1" = "-E" ] || [ "\$2" = "-E" ]; then
   exec $(which $1) "\$@"
 elif [ \$(env -u LD_PRELOAD ps -p \$PPID -o comm=) != sccache ]; then
   exec sccache $(which $1) "\$@"

--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -50,7 +50,11 @@ chmod a+x /opt/cache/bin/sccache
 function write_sccache_stub() {
   # Unset LD_PRELOAD for ps because of asan + ps issues
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90589
-  printf "#!/bin/sh\nif [ \$(env -u LD_PRELOAD ps -p \$PPID -o comm=) != sccache ]; then\n  exec sccache $(which $1) \"\$@\"\nelse\n  exec $(which $1) \"\$@\"\nfi" > "/opt/cache/bin/$1"
+  if [ $1 == "gcc"]; then
+    printf "#!/bin/sh\nif [ \"$1\" = \"-E\" ]; then\n  exec $(which $1)  \"\$@\"\nelif [ \$(env -u LD_PRELOAD ps -p \$PPID -o comm=) != sccache ]; then\n  exec sccache $(which $1) \"\$@\"\nelse\n  exec $(which $1) \"\$@\"\nfi" > "/opt/cache/bin/$1"
+  else
+    printf "#!/bin/sh\nif [ \$(env -u LD_PRELOAD ps -p \$PPID -o comm=) != sccache ]; then\n  exec sccache $(which $1) \"\$@\"\nelse\n  exec $(which $1) \"\$@\"\nfi" > "/opt/cache/bin/$1"
+  fi
   chmod a+x "/opt/cache/bin/$1"
 }
 

--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -24,6 +24,10 @@ install_ubuntu() {
   rm -rf sccache
   apt-get remove -y cargo rustc
   apt-get autoclean && apt-get clean
+
+  echo "Downloading old sccache binary from S3 repo for PCH builds"
+  curl --retry 3 https://s3.amazonaws.com/ossci-linux/sccache -o /opt/cache/bin/sccache-0.2.14a
+  chmod 755 /opt/cache/bin/sccache-0.2.14a
 }
 
 install_binary() {

--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -41,14 +41,15 @@ if [ -n "$ROCM_VERSION" ]; then
   curl --retry 3 http://repo.radeon.com/misc/.sccache_amd/sccache -o /opt/cache/bin/sccache
 else
   ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
-  case "$ID" in
-    ubuntu)
-      install_ubuntu
-      ;;
-    *)
-      install_binary
-      ;;
-  esac
+  if [ -n "$CUDA_VERSION" ]; then
+    # TODO: Install the pre-built binary from S3 as building from source
+    # https://github.com/pytorch/sccache has started failing mysteriously
+    # in which sccache server couldn't start with the following error:
+    #   sccache: error: Invalid argument (os error 22)
+    install_binary
+  else
+    install_ubuntu
+  fi
 fi
 chmod a+x /opt/cache/bin/sccache
 

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -398,8 +398,6 @@ if [[ "$BUILD_ENVIRONMENT" != *libtorch* && "$BUILD_ENVIRONMENT" != *bazel* ]]; 
   python tools/stats/export_test_times.py
 fi
 
-# snadampal: skipping it till sccache support added for aarch64
-# https://github.com/pytorch/pytorch/issues/121559
-if [[ "$BUILD_ENVIRONMENT" != *aarch64* &&  "$BUILD_ENVIRONMENT" != *s390x* ]]; then
+if [[ "$BUILD_ENVIRONMENT" != *s390x* ]]; then
   print_sccache_stats
 fi

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -218,6 +218,10 @@ fi
 
 if [[ "${BUILD_ENVIRONMENT}" == *-pch* ]]; then
     export USE_PRECOMPILED_HEADERS=1
+
+    # This is really weird, but newer sccache somehow produces broken binary
+    # see https://github.com/pytorch/pytorch/issues/139188
+    sudo mv /opt/sccache/bin/sccache-0.2.14a /opt/sccache/bin/sccache
 fi
 
 if [[ "${BUILD_ENVIRONMENT}" != *android* && "${BUILD_ENVIRONMENT}" != *cuda* ]]; then

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -218,10 +218,6 @@ fi
 
 if [[ "${BUILD_ENVIRONMENT}" == *-pch* ]]; then
     export USE_PRECOMPILED_HEADERS=1
-
-    # This is really weird, but newer sccache somehow produces broken binary
-    # see https://github.com/pytorch/pytorch/issues/139188
-    sudo mv /opt/cache/bin/sccache-0.2.14a /opt/cache/bin/sccache
 fi
 
 if [[ "${BUILD_ENVIRONMENT}" != *android* && "${BUILD_ENVIRONMENT}" != *cuda* ]]; then

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -221,7 +221,7 @@ if [[ "${BUILD_ENVIRONMENT}" == *-pch* ]]; then
 
     # This is really weird, but newer sccache somehow produces broken binary
     # see https://github.com/pytorch/pytorch/issues/139188
-    sudo mv /opt/sccache/bin/sccache-0.2.14a /opt/sccache/bin/sccache
+    sudo mv /opt/cache/bin/sccache-0.2.14a /opt/cache/bin/sccache
 fi
 
 if [[ "${BUILD_ENVIRONMENT}" != *android* && "${BUILD_ENVIRONMENT}" != *cuda* ]]; then

--- a/.ci/pytorch/common-build.sh
+++ b/.ci/pytorch/common-build.sh
@@ -6,6 +6,12 @@ if [[ "$BUILD_ENVIRONMENT" != *win-* ]]; then
     # Save the absolute path in case later we chdir (as occurs in the gpu perf test)
     script_dir="$( cd "$(dirname "${BASH_SOURCE[0]}")" || exit ; pwd -P )"
 
+    if [[ "${BUILD_ENVIRONMENT}" == *-pch* ]]; then
+        # This is really weird, but newer sccache somehow produces broken binary
+        # see https://github.com/pytorch/pytorch/issues/139188
+        sudo mv /opt/cache/bin/sccache-0.2.14a /opt/cache/bin/sccache
+    fi
+
     if which sccache > /dev/null; then
         # Save sccache logs to file
         sccache --stop-server > /dev/null  2>&1 || true

--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -42,11 +42,14 @@ runs:
         PR_NUMBER: ${{ github.event.pull_request.number }}
         SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
         SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
+        SCCACHE_REGION: us-east-1
         DOCKER_IMAGE: ${{ inputs.docker-image  }}
         MATRIX_ARCH: ${{ inputs.arch }}
       run: |
         # detached container should get cleaned up by teardown_ec2_linux
         set -exo pipefail
+        # Fetch aws credential from IMDs
+        eval "$(python3 .github/scripts/get_aws_session_tokens.py)"
         export container_name
         container_name=$(docker run \
           -e BUILD_ENVIRONMENT \
@@ -56,6 +59,7 @@ runs:
           -e SHA1 \
           -e BRANCH \
           -e SCCACHE_BUCKET \
+          -e SCCACHE_REGION \
           -e SKIP_SCCACHE_INITIALIZATION=1 \
           --env-file="/tmp/github_env_${GITHUB_RUN_ID}" \
           --security-opt seccomp=unconfined \

--- a/.github/workflows/_android-build-test.yml
+++ b/.github/workflows/_android-build-test.yml
@@ -95,9 +95,13 @@ jobs:
           BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
           TORCH_CUDA_ARCH_LIST: 5.2
           SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
+          SCCACHE_REGION: us-east-1
+          AWS_DEFAULT_REGION: us-east-1
           DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
         run: |
           set -e
+          # Fetch aws credential from IMDs
+          eval "$(python3 .github/scripts/get_aws_session_tokens.py)"
           # Unlike other gradle jobs, it's not worth building libtorch in a separate CI job and share via docker, because:
           # 1) Not shareable: it's custom selective build, which is different from default libtorch mobile build;
           # 2) Not parallelizable by architecture: it only builds libtorch for one architecture;
@@ -113,6 +117,7 @@ jobs:
           id=$(docker run -e BUILD_ENVIRONMENT \
             -e MAX_JOBS="$(nproc --ignore=2)" \
             -e SCCACHE_BUCKET \
+            -e SCCACHE_REGION \
             -e SKIP_SCCACHE_INITIALIZATION=1 \
             -e TORCH_CUDA_ARCH_LIST \
             -e BUILD_LITE_INTERPRETER \

--- a/.github/workflows/_android-full-build-test.yml
+++ b/.github/workflows/_android-full-build-test.yml
@@ -145,9 +145,13 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
           SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
+          SCCACHE_REGION: us-east-1
           ID_X86_32: ${{ steps.build-x86_32.outputs.container_id }}
         run: |
           set -eux
+
+          # Fetch aws credential from IMDs
+          eval "$(python3 .github/scripts/get_aws_session_tokens.py)"
 
           # Putting everything together
           # ID_X86_32 container were created during build-x86_32 step
@@ -165,6 +169,7 @@ jobs:
             -e SHA1 \
             -e BRANCH \
             -e SCCACHE_BUCKET \
+            -e SCCACHE_REGION \
             -e SKIP_SCCACHE_INITIALIZATION=1 \
             --env-file="/tmp/github_env_${GITHUB_RUN_ID}" \
             --user jenkins \

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -137,11 +137,14 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
           SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
           SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
+          SCCACHE_REGION: us-east-1
           TORCH_CUDA_ARCH_LIST: 5.2
           DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
           OUR_GITHUB_JOB_ID: ${{ steps.get-job-id.outputs.job-id }}
           CUDA_VERSION: ${{ inputs.cuda-version }}
         run: |
+          # Fetch aws credential from IMDs
+          eval "$(python3 .github/scripts/get_aws_session_tokens.py)"
           export SHARD_NUMBER=0
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase
@@ -163,6 +166,7 @@ jobs:
             -e NUM_TEST_SHARDS \
             -e MAX_JOBS="$(nproc --ignore=2)" \
             -e SCCACHE_BUCKET \
+            -e SCCACHE_REGION \
             -e SKIP_SCCACHE_INITIALIZATION=1 \
             -e REENABLED_ISSUES \
             -e TORCH_CUDA_ARCH_LIST \

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -143,6 +143,7 @@ jobs:
           OUR_GITHUB_JOB_ID: ${{ steps.get-job-id.outputs.job-id }}
           CUDA_VERSION: ${{ inputs.cuda-version }}
         run: |
+          python3 -m pip install boto3==1.19.12
           # Fetch aws credential from IMDs
           eval "$(python3 .github/scripts/get_aws_session_tokens.py)"
           export SHARD_NUMBER=0

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -198,6 +198,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
           SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
+          SCCACHE_REGION: us-east-1
           SCCACHE_S3_KEY_PREFIX: ${{ github.workflow }}
           XLA_CLANG_CACHE_S3_BUCKET_NAME: ossci-compiler-clang-cache-circleci-xla
           PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -222,8 +222,9 @@ jobs:
           else
             JENKINS_USER="--user jenkins"
             USED_IMAGE="${DOCKER_IMAGE}"
+            # Fetch aws credential from IMDs
+            eval $(python3 -c 'import boto3; import json; c=boto3.Session().get_credentials().get_frozen_credentials()._asdict(); print(f"export AWS_ACCESS_KEY_ID=\"%s\"" % c["access_key"]); print(f"export AWS_SECRET_ACCESS_KEY=\"%s\"" % c["secret_key"]); print(f"export AWS_SESSION_TOKEN=\"%s\"" % c["token"])')
           fi
-
           # detached container should get cleaned up by teardown_ec2_linux
           # Used for JENKINS_USER, which can be empty
           # shellcheck disable=SC2086
@@ -231,10 +232,14 @@ jobs:
             -e BUILD_ENVIRONMENT \
             -e MAX_JOBS="$(nproc --ignore=2)" \
             -e AWS_DEFAULT_REGION \
+            -e AWS_ACCESS_KEY_ID \
+            -e AWS_SECRET_ACCESS_KEY \
+            -e AWS_SESSION_TOKEN \
             -e PR_NUMBER \
             -e SHA1 \
             -e BRANCH \
             -e SCCACHE_BUCKET \
+            -e SCCACHE_REGION \
             -e SCCACHE_S3_KEY_PREFIX \
             -e XLA_CUDA \
             -e XLA_CLANG_CACHE_S3_BUCKET_NAME \

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -223,7 +223,7 @@ jobs:
             JENKINS_USER="--user jenkins"
             USED_IMAGE="${DOCKER_IMAGE}"
             # Fetch aws credential from IMDs
-            eval $(python3 .github/scripts/get_aws_session_tokens.py)
+            eval "$(python3 .github/scripts/get_aws_session_tokens.py)"
           fi
           # detached container should get cleaned up by teardown_ec2_linux
           # Used for JENKINS_USER, which can be empty

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -223,7 +223,7 @@ jobs:
             JENKINS_USER="--user jenkins"
             USED_IMAGE="${DOCKER_IMAGE}"
             # Fetch aws credential from IMDs
-            eval $(python3 -c 'import boto3; import json; c=boto3.Session().get_credentials().get_frozen_credentials()._asdict(); print(f"export AWS_ACCESS_KEY_ID=\"%s\"" % c["access_key"]); print(f"export AWS_SECRET_ACCESS_KEY=\"%s\"" % c["secret_key"]); print(f"export AWS_SESSION_TOKEN=\"%s\"" % c["token"])')
+            eval $(python3 .github/scripts/get_aws_session_tokens.py)
           fi
           # detached container should get cleaned up by teardown_ec2_linux
           # Used for JENKINS_USER, which can be empty

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -234,6 +234,9 @@ jobs:
         run: |
           set -x
 
+          # Fetch aws credential from IMDs
+          eval $(python3 .github/scripts/get_aws_session_tokens.py)
+
           if [[ $TEST_CONFIG == 'multigpu' ]]; then
             TEST_COMMAND=.ci/pytorch/multigpu-test.sh
           elif [[ $BUILD_ENVIRONMENT == *onnx* ]]; then

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -235,7 +235,7 @@ jobs:
           set -x
 
           # Fetch aws credential from IMDs
-          eval $(python3 .github/scripts/get_aws_session_tokens.py)
+          eval "$(python3 .github/scripts/get_aws_session_tokens.py)"
 
           if [[ $TEST_CONFIG == 'multigpu' ]]; then
             TEST_COMMAND=.ci/pytorch/multigpu-test.sh

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -266,6 +266,9 @@ jobs:
             -e BRANCH \
             -e SHA1 \
             -e AWS_DEFAULT_REGION \
+            -e AWS_ACCESS_KEY_ID \
+            -e AWS_SECRET_ACCESS_KEY \
+            -e AWS_SESSION_TOKEN \
             -e IN_WHEEL_TEST \
             -e SHARD_NUMBER \
             -e TEST_CONFIG \

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -232,10 +232,9 @@ jobs:
           IS_A100_RUNNER: ${{ contains(matrix.runner, 'a100') && '1' || '0' }}
           ARTIFACTS_FILE_SUFFIX: ${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}_${{ steps.get-job-id.outputs.job-id }}
         run: |
-          set -x
-
           # Fetch aws credential from IMDs
           eval "$(python3 .github/scripts/get_aws_session_tokens.py)"
+          set -x
 
           if [[ $TEST_CONFIG == 'multigpu' ]]; then
             TEST_COMMAND=.ci/pytorch/multigpu-test.sh


### PR DESCRIPTION
This essentially reverts https://github.com/pytorch/pytorch/pull/95997 but switches to builds from source to official mozilla's sccache repo for CPU builds, except PCH one, see https://github.com/pytorch/pytorch/issues/139188
- Define `SCCACHE_REGION` for the jobs that needs it. 
- Enable aarch64 builds to use sccache, which allows one to do incremental rebuilds under 10 min, see https://github.com/pytorch/pytorch/actions/runs/11565944328/job/32197278296


Fixes https://github.com/pytorch/pytorch/issues/121559