### PR TITLE
torch.utils: get_python_cpp_trace

### DIFF
--- a/torch/utils/__init__.py
+++ b/torch/utils/__init__.py
@@ -2,7 +2,7 @@ import os.path as _osp
 import torch
 
 from .throughput_benchmark import ThroughputBenchmark
-from .cpp_backtrace import get_cpp_backtrace
+from .cpp_backtrace import get_cpp_backtrace, get_python_cpp_trace
 from .backend_registration import rename_privateuse1_backend, generate_methods_for_privateuse1_backend
 from . import deterministic
 from . import collect_env

--- a/torch/utils/cpp_backtrace.py
+++ b/torch/utils/cpp_backtrace.py
@@ -1,5 +1,8 @@
 from torch._C import _get_cpp_backtrace
 
+FUNC_FILTERS = ['_PyEval', 'PyEval_', '_PyObject', 'PyObject_',
+                'do_call_core', 'PyVectorcall_', 'PyRun_']
+
 def get_cpp_backtrace(frames_to_skip=0, maximum_number_of_frames=64) -> str:
     r"""
     Return a string containing the C++ stack trace of the current thread.
@@ -9,3 +12,19 @@ def get_cpp_backtrace(frames_to_skip=0, maximum_number_of_frames=64) -> str:
         maximum_number_of_frames (int): the maximum number of frames to return
     """
     return _get_cpp_backtrace(frames_to_skip, maximum_number_of_frames)
+
+def get_python_cpp_trace():
+    from torch._C._profiler import gather_traceback, symbolize_tracebacks
+    tb = symbolize_tracebacks([gather_traceback(python=True, script=True, cpp=True)])[0]
+    tb = [
+        x for x in tb
+        if not any(x['name'].startswith(filter) for filter in FUNC_FILTERS)
+    ]
+    frames_to_skip = next(
+        ind + 1 for ind, x in enumerate(tb)
+        if x['name'] == 'get_python_cpp_trace'
+        and x['filename'].endswith('torch/utils/cpp_backtrace.py')
+    )
+    tb = tb[frames_to_skip:]
+    tb = [f"#{ind} {x['name']} {x['filename']}:{x['line']}" for ind, x in enumerate(tb)]
+    return '\n'.join(tb)


### PR DESCRIPTION
python api to get python+cpp backtrace. we have similar api in cpp ``c10d::get_python_cpp_trace()``: https://github.com/pytorch/pytorch/pull/118924

usage: ``print(get_python_cpp_trace()``

useful for debugging python->cpp->python, like \_\_torch_dispatch\_\_, \_\_torch_function\_\_, PyProcessGroup

example
```
#0 nf4_split /data/users/weif/transformer_nuggets/transformer_nuggets/quant/nf4_tensor.py:78
#1 __torch_dispatch__ /data/users/weif/transformer_nuggets/transformer_nuggets/quant/nf4_tensor.py:581
#2 PyObject_CallFunctionObjArgs /usr/local/src/conda/python-3.10.12/Objects/call.c:841
#3 torch::handle_torch_function_no_python_arg_parser(c10::ArrayRef<_object*>, _object*, _object*, char const*, _object*, char const*, torch::TorchFunctionName) ??:0
#4 (anonymous namespace)::ConcretePyInterpreterVTable::dispatch(c10::OperatorHandle const&, std::vector<c10::IValue, std::allocator<c10::IValue> >*) const PyInterpreter.cpp:0
#5 (anonymous namespace)::pythonFallback(c10::OperatorHandle const&, std::vector<c10::IValue, std::allocator<c10::IValue> >*) PythonFallbackKernel.cpp:0
#6 c10::impl::BoxedKernelWrapper<std::vector<at::Tensor, std::allocator<at::Tensor> > (at::Tensor const&, c10::SymInt, long), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&, c10::SymInt, long) :0
#7 at::_ops::split_Tensor::redispatch(c10::DispatchKeySet, at::Tensor const&, c10::SymInt, long) ??:0
#8 torch::ADInplaceOrView::(anonymous namespace)::split_Tensor(c10::DispatchKeySet, at::Tensor const&, c10::SymInt, long) ADInplaceOrViewType_0.cpp:0
#9 c10::impl::wrap_kernel_functor_unboxed_<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<std::vector<at::Tensor, std::allocator<at::Tensor> > (c10::DispatchKeySet, at::Tensor const&, c10::SymInt, long), &torch::ADInplaceOrView::(anonymous namespace)::split_Tensor>, std::vector<at::Tensor, std::allocator<at::Tensor> >, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&, c10::SymInt, long> >, std::vector<at::Tensor, std::allocator<at::Tensor> > (c10::DispatchKeySet, at::Tensor const&, c10::SymInt, long)>::call(c10::OperatorKernel*, c10::DispatchKeySet, at::Tensor const&, c10::SymInt, long) ADInplaceOrViewType_0.cpp:0
#10 at::_ops::split_Tensor::redispatch(c10::DispatchKeySet, at::Tensor const&, c10::SymInt, long) ??:0
#11 torch::autograd::VariableType::(anonymous namespace)::split_Tensor(c10::DispatchKeySet, at::Tensor const&, c10::SymInt, long) VariableType_0.cpp:0
#12 c10::impl::make_boxed_from_unboxed_functor<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<std::vector<at::Tensor, std::allocator<at::Tensor> > (c10::DispatchKeySet, at::Tensor const&, c10::SymInt, long), &torch::autograd::VariableType::(anonymous namespace)::split_Tensor>, std::vector<at::Tensor, std::allocator<at::Tensor> >, c10::guts::typelist::typelist<c10::DispatchKeySet, at::Tensor const&, c10::SymInt, long> >, false>::call(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*) VariableType_0.cpp:0
#13 void c10::BoxedKernel::make_boxed_function<&(anonymous namespace)::pythonTLSSnapshotFallback>(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*) PythonFallbackKernel.cpp:0
#14 c10::impl::BoxedKernelWrapper<std::vector<at::Tensor, std::allocator<at::Tensor> > (at::Tensor const&, c10::SymInt, long), void>::call(c10::BoxedKernel const&, c10::OperatorHandle const&, c10::DispatchKeySet, at::Tensor const&, c10::SymInt, long) :0
#15 at::_ops::split_Tensor::call(at::Tensor const&, c10::SymInt, long) ??:0
#16 at::native::chunk(at::Tensor const&, long, long) ??:0
#17 c10::impl::make_boxed_from_unboxed_functor<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<std::vector<at::Tensor, std::allocator<at::Tensor> > (at::Tensor const&, long, long), &at::(anonymous namespace)::(anonymous namespace)::wrapper_CompositeImplicitAutograd__chunk>, std::vector<at::Tensor, std::allocator<at::Tensor> >, c10::guts::typelist::typelist<at::Tensor const&, long, long> >, false>::call(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*) RegisterCompositeImplicitAutograd.cpp:0
#18 void c10::BoxedKernel::make_boxed_function<&(anonymous namespace)::pythonTLSSnapshotFallback>(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*) PythonFallbackKernel.cpp:0
#19 at::_ops::chunk::call(at::Tensor const&, long, long) ??:0
#20 torch::autograd::THPVariable_chunk(_object*, _object*, _object*) python_torch_functions_2.cpp:0
#21 cfunction_call /usr/local/src/conda/python-3.10.12/Objects/methodobject.c:543
#22 _chunk_with_empty /home/weif/local/pytorch-official/pytorch/torch/distributed/_composable/fsdp/_fsdp_common.py:97
#23 _init_sharded_param /home/weif/local/pytorch-official/pytorch/torch/distributed/_composable/fsdp/_fsdp_param.py:217
#24 decorate_context /home/weif/local/pytorch-official/pytorch/torch/utils/_contextlib.py:115
#25 __init__ /home/weif/local/pytorch-official/pytorch/torch/distributed/_composable/fsdp/_fsdp_param.py:141
#26 type_call /usr/local/src/conda/python-3.10.12/Objects/typeobject.c:1135
#27 <listcomp> /home/weif/local/pytorch-official/pytorch/torch/distributed/_composable/fsdp/_fsdp_param_group.py:94
```