### PR TITLE
[DTensor] Initialized RNG tracker if needed

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_init.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_init.py
@@ -14,7 +14,7 @@ from torch.distributed._composable.fsdp._fsdp_init import (
 )
 from torch.distributed._composable.fsdp._fsdp_param import ParamModuleInfo
 from torch.distributed._composable.fsdp._fsdp_param_group import _get_param_module_infos
-from torch.distributed._tensor import DeviceMesh, DTensor, random, Replicate, Shard
+from torch.distributed._tensor import DeviceMesh, DTensor, Replicate, Shard
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor.parallel import (
     ColwiseParallel,
@@ -526,8 +526,6 @@ class TestFullyShardMetaDeviceInit(FSDPTestMultiThread):
         const = 1337
         for tensor in itertools.chain(model.parameters(), model.buffers()):
             tensor.detach().fill_(const)
-        tp_dim = max(0, mesh.mesh.ndim - 1)  # only used for TP
-        random.manual_seed(42, mesh, tp_dim)  # initialize a `CudaRNGStateTracker`
         for module in model.modules():
             if hasattr(module, "reset_parameters"):
                 module.reset_parameters()

--- a/torch/distributed/_composable/fsdp/fully_shard.py
+++ b/torch/distributed/_composable/fsdp/fully_shard.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn as nn
 
 from torch.distributed._composable import contract
-from torch.distributed._tensor import DeviceMesh, DTensor
+from torch.distributed._tensor import DeviceMesh, DTensor, random
 
 from ._fsdp_api import MixedPrecisionPolicy
 from ._fsdp_common import FSDPMeshInfo, HSDPMeshInfo
@@ -123,6 +123,10 @@ def fully_shard(
     for module in managed_modules:
         module._is_fsdp_managed_module = True  # type: ignore[assignment]
         module._fsdp_use_orig_params = True  # type: ignore[assignment]
+
+    if not random._rng_tracker:
+        # Used for DTensor random ops (e.g. for parameter initialization)
+        random._rng_tracker = random.OffsetBasedRNGTracker(mesh.device_type)
 
     # Place FSDP leftmost for highest priority in the method resolution order
     cls = module.__class__

--- a/torch/distributed/_composable/fsdp/fully_shard.py
+++ b/torch/distributed/_composable/fsdp/fully_shard.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn as nn
 
 from torch.distributed._composable import contract
-from torch.distributed._tensor import DeviceMesh, DTensor, random
+from torch.distributed._tensor import DeviceMesh, DTensor
 
 from ._fsdp_api import MixedPrecisionPolicy
 from ._fsdp_common import FSDPMeshInfo, HSDPMeshInfo
@@ -123,10 +123,6 @@ def fully_shard(
     for module in managed_modules:
         module._is_fsdp_managed_module = True  # type: ignore[assignment]
         module._fsdp_use_orig_params = True  # type: ignore[assignment]
-
-    if not random._rng_tracker:
-        # Used for DTensor random ops (e.g. for parameter initialization)
-        random._rng_tracker = random.OffsetBasedRNGTracker(mesh.device_type)
 
     # Place FSDP leftmost for highest priority in the method resolution order
     cls = module.__class__

--- a/torch/distributed/_tensor/dispatch.py
+++ b/torch/distributed/_tensor/dispatch.py
@@ -181,12 +181,9 @@ class OpDispatcher:
             local_tensor_args = cast(Tuple[object, ...], local_tensor_args)
             if op_call in self._random_ops and is_rng_supported_mesh(mesh):
                 if not random._rng_tracker:
-                    raise RuntimeError(
-                        "A CudaRNGStateTracker instance must be instantiated "
-                        "before executing a random op over a DTensor. "
-                        "Try calling random.manual_seed() or distribute_tensor() "
-                        "before executing a DTensor random op."
-                    )
+                    # Default to `OffsetBasedRNGTracker` if the parallelism API
+                    # did not already construct one
+                    random._rng_tracker = random.OffsetBasedRNGTracker(mesh.device_type)
                 # For DTensor random operator, run it within a distribute region
                 with random._rng_tracker._distribute_region(
                     cast(dtensor.DTensor, args[0])._spec


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #120952
* #121244
* __->__ #121328
* #120351

Since we are already checking if the RNG tracker is initialized, there is no real performance difference between erroring vs. just initializing a default RNG tracker (which we choose to be the `OffsetBasedRNGTracker`).


```
pytest test/distributed/_composable/fsdp/test_fully_shard_init.py -k test_meta
```

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang