### PR TITLE
[PyTorch] Use uint32_t for ProcessedNode::num_outputs

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -940,7 +940,6 @@ class TORCH_API ProcessedNode {
 
   uint32_t num_outputs() const {
     DCHECK(fn_ != nullptr);
-    DCHECK_LE(fn_->num_outputs(), std::numeric_limits<uint32_t>::max());
     return static_cast<uint32_t>(fn_->num_outputs());
   }
 

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -938,9 +938,10 @@ class TORCH_API ProcessedNode {
     return values_[outputs_offset_ + i];
   }
 
-  size_t num_outputs() const {
+  uint32_t num_outputs() const {
     DCHECK(fn_ != nullptr);
-    return fn_->num_outputs();
+    DCHECK_LE(fn_->num_outputs(), std::numeric_limits<uint32_t>::max());
+    return static_cast<uint32_t>(fn_->num_outputs());
   }
 
   C10_NODISCARD c10::ArrayRef<const IValue> outputs() const {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121335

We already use uint32_t for indexing, and the notion of a single graph node with more than four billion outputs stretches credulity.

Differential Revision: [D54598821](https://our.internmc.facebook.com/intern/diff/D54598821/)