### PR TITLE
Wrap remote cache creation with a try-catch

### DIFF
--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -845,14 +845,18 @@ def cached_autotune(
                 key = backend_hash + configs_hash + "autotune-best-config"
                 key = hashlib.sha256(key.encode("utf-8")).hexdigest()
 
-                if config.is_fbcode():
-                    remote_cache = (
-                        triton.runtime.fb_memcache.FbMemcacheRemoteCacheBackend(
-                            key, is_autotune=True
+                try:
+                    if config.is_fbcode():
+                        remote_cache = (
+                            triton.runtime.fb_memcache.FbMemcacheRemoteCacheBackend(
+                                key, is_autotune=True
+                            )
                         )
-                    )
-                else:
-                    remote_cache = triton.runtime.cache.RedisRemoteCacheBackend(key)
+                    else:
+                        remote_cache = triton.runtime.cache.RedisRemoteCacheBackend(key)
+                except Exception:
+                    remote_cache = None
+                    log.warning("Unable to create a remote cache", exc_info=True)
                 # we already sha256 hash the source contents
                 remote_cache_key = os.path.basename(filename)
             else:


### PR DESCRIPTION
Summary: In production I am seeing errors like "AttributeError: module 'triton.runtime' has no attribute 'fb_memcache'", likely due to some package skew. Until this is resolved, lets wrap this code with try-catch.

Test Plan: CI

Differential Revision: D54604339




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang