### PR TITLE
fix synchronization behavior for copies with type change

### DIFF
--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -302,9 +302,11 @@ static void copy_kernel_cuda(TensorIterator& iter, bool non_blocking) {
     Tensor src_contig;
 
     // If non_blocking is true - type conversions are performed on the GPU
-    // for CPU-GPU copies, otherwise type conversions are performed on the CPU.
-    // Type conversions are performed on the src device for GPU-GPU copies.
-    if (iter.device_type(0) == kCUDA || non_blocking) {
+    // For blocking transfers conversions are performed on CPU to avoid allocating
+    // extra GPU memory
+    // for GPU-GPU transfers conversions are performed on the source device
+    auto conversion_device = non_blocking ? kCUDA : kCPU;
+    if (iter.device_type(1) == conversion_device) {
       dst_contig = dst.is_contiguous() ? dst : at::empty_like(dst, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
       src_contig = iter.tensor(1).to(iter.dtype(0)).expand_as(dst).contiguous();
     } else {

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -247,6 +247,15 @@ class TestCuda(TestCase):
         y = torch.ones(10000000 - 1, dtype=torch.uint8).cuda()
         _test_copy_non_blocking(x, y)
 
+    def test_copy_non_blocking_type_conversion(self):
+        a = torch.ones(1, device="cuda")
+        b = torch.zeros(1, device="cpu", pin_memory=True)
+        c = torch.empty(1, device="cuda", dtype=torch.long)
+        torch.cuda._sleep(int(100 * get_cycles_per_ms()))
+        b.copy_(a, non_blocking=True)
+        c.copy_(b, non_blocking=True)
+        self.assertEqual(a, c, exact_dtype=False)
+
 
     def test_to_non_blocking(self):
         stream = torch.cuda.current_stream()


### PR DESCRIPTION
Fixes #121320

This is BC-breaking for non-blocking copies between CPU <-> GPU (either way) that also changes the dtype. Instead of doing the dtype conversion on the CPU, we now do it on the GPU. This will increase the GPU memory usage as a temporary buffer needs to be created on the GPU.
