### PR TITLE
Make CausalBias a torch.Tensor subclass again

### DIFF
--- a/torch/nn/attention/bias.py
+++ b/torch/nn/attention/bias.py
@@ -79,7 +79,7 @@ class CausalVariant(IntEnum):
     LOWER_RIGHT = auto()
 
 
-class CausalBias:
+class CausalBias(torch.Tensor):
     """
     A bias representing causal attention patterns. For an overview of the bias structure, see the :class:`CausalVariant` enum.
 


### PR DESCRIPTION
# Summary
This was removed in #116071 in order to enable compile support and re-adding this seems to still work with compile