### PR TITLE
[FSDP2] Relaxed check for parent mesh

### DIFF
--- a/torch/distributed/_composable/fsdp/_fsdp_param.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_param.py
@@ -183,10 +183,6 @@ class FSDPParam:
             self._global_stride = param.stride()
             param_data = cast(DTensor, param)._local_tensor
         else:
-            if _mesh_resources.get_parent_mesh(self.mesh_info.mesh) is not None:
-                raise NotImplementedError(
-                    "Using a parent mesh with pure FSDP/HSDP is not supported"
-                )
             self._global_mesh = self.mesh_info.mesh
             self._global_placements = (Shard(0),)
             self._global_size = param.size()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #120952
* #121357
* __->__ #121360
* #121328
* #120351

Mixing 1D and 2D `DTensor`s in the same sharded state dict should be okay, so we can remove the check that a parameter for FSDP to shard must be a `DTensor` if passing a child mesh to FSDP.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang