### PR TITLE
Improve Dynamo support for torch function and class methods in general

### DIFF
--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -305,6 +305,9 @@ class DecoratorTests(torch._dynamo.test_case.TestCase):
             def my_class_method(self, arg1):
                 return super().my_class_method(arg1)
 
+            def my_static_method(self, arg1):
+                return super().my_static_method(arg1)
+
         class C(A):
             @classmethod
             def my_class_method(cls, arg1):
@@ -322,13 +325,14 @@ class DecoratorTests(torch._dynamo.test_case.TestCase):
             v4 = A.my_static_method(4)
             v5 = a.my_regular_method(5)
             v6 = b.my_class_method(6)
-            v7 = c.my_class_method(7)
-            v8 = C.my_class_method(8)
+            v7 = b.my_static_method(7)
+            v8 = c.my_class_method(8)
+            v9 = C.my_class_method(9)
             torch.rand(2)
-            return v1, v2, v3, v4, v5, v6, v7, v8
+            return v1, v2, v3, v4, v5, v6, v7, v8, v9
 
         a, b, c = A(), B(), C()
-        v1, v2, v3, v4, v5, v6, v7, v8 = fn(a, b, c)
+        v1, v2, v3, v4, v5, v6, v7, v8, v9 = fn(a, b, c)
 
         self.assertEqual(v1, (A, 1))
         self.assertEqual(v2, (A, 2))
@@ -338,8 +342,9 @@ class DecoratorTests(torch._dynamo.test_case.TestCase):
         # TODO fix me: we do not resolve classmethods properly
         # from a regular method
         # self.assertEqual(v6, (B, 6))
-        self.assertEqual(v7, (C, 7))
+        self.assertEqual(v7, (None, 7))
         self.assertEqual(v8, (C, 8))
+        self.assertEqual(v9, (C, 9))
 
         self.assertEqual(cnt.frame_count, 1)
 

--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -289,7 +289,7 @@ class DecoratorTests(torch._dynamo.test_case.TestCase):
         self._test_mark_static_address(guarded=False)
 
     def test_class_methods(self):
-        class A():
+        class A:
             @classmethod
             def my_class_method(cls, arg1):
                 return cls, arg1
@@ -338,7 +338,7 @@ class DecoratorTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(v6, (B, 6))
         self.assertEqual(v7, (C, 7))
         self.assertEqual(v8, (C, 8))
-        
+
         self.assertEqual(cnt.frame_count, 1)
 
 

--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -335,7 +335,9 @@ class DecoratorTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(v3, (None, 3))
         self.assertEqual(v4, (None, 4))
         self.assertEqual(v5, (a, 5))
-        self.assertEqual(v6, (B, 6))
+        # TODO fix me: we do not resolve classmethods properly
+        # from a regular method
+        # self.assertEqual(v6, (B, 6))
         self.assertEqual(v7, (C, 7))
         self.assertEqual(v8, (C, 8))
 

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -4282,6 +4282,29 @@ def forward(self, s0 : torch.SymInt, s1 : torch.SymInt, L_x_ : torch.Tensor):
         with self.assertRaisesRegex(AssertionError, ""):
             f_fail(torch.ones(6, 4))
 
+    def test_super_in_staticmethod(self):
+        class A:
+            @staticmethod
+            def foo():
+                return super().__init__()
+
+        def fn(obj):
+            return obj.foo()
+
+        obj = A()
+
+        try:
+            fn(obj)
+        except Exception as e:
+            orig_str = str(e)
+        self.assertIn("no arguments", orig_str)
+
+        try:
+            torch.compile(backend="eager")(fn)(obj)
+        except Exception as e:
+            compiled_str = str(e)
+        self.assertEqual(orig_str, compiled_str)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/bytecode_transformation.py
+++ b/torch/_dynamo/bytecode_transformation.py
@@ -792,6 +792,9 @@ def remove_jump_if_none(instructions: List[Instruction]) -> None:
 def explicit_super(code: types.CodeType, instructions: List[Instruction]) -> None:
     """convert super() with no args into explicit arg form"""
     cell_and_free = (code.co_cellvars or tuple()) + (code.co_freevars or tuple())
+    if not len(code.co_varnames):
+        # A function with no argument cannot contain a valid "super()" call
+        return
     output = []
     for idx, inst in enumerate(instructions):
         output.append(inst)

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -224,11 +224,8 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         cache[idx] = (result, value)
         return result
 
-    def __str__(self):
-        return f"{self.__class__.__name__}()"
-
     def __repr__(self):
-        return str(self)
+        return f"{self.__class__.__name__}()"
 
     def python_type(self):
         """

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -26,13 +26,21 @@ from ..utils import (
 )
 from .base import VariableTracker
 from .functions import NestedUserFunctionVariable, UserFunctionVariable
+from .nn_module import NNModuleVariable
 from .user_defined import UserDefinedObjectVariable
 
 
 class SuperVariable(VariableTracker):
     def __init__(self, typevar, objvar=None, specialized=False, **kwargs):
         super().__init__(**kwargs)
+        # typevar is the fist argument to super(). In the case where no argument
+        # is provided to super(), it is the __class__ object where
+        # the super() function is being called
         self.typevar = typevar
+        # objvar here must be an instance or subtype of typevar.
+        # In the case where super() is called without arguments, it is the first argument
+        # to the current function where super() is called from (self for regular method,
+        # cls for a classmethod)
         self.objvar = objvar
         self.specialized = specialized  # directly get attr from self.typevar if true
 
@@ -51,9 +59,13 @@ class SuperVariable(VariableTracker):
             return getattr(self.typevar.as_python_constant(), name)
         search_type = self.typevar.as_python_constant()
 
-        # We default to the python type of the object. However, if this is
-        # a `type` or subclass of `type`, then the original object represents
-        # the user defined type.
+        # This function does two things:
+        #   - Walk the mro to find where the attribute comes from to be
+        #     able to provide accurate source
+        #   - Call the getattr to get the object
+
+        # Find the class object, where the function lives.
+        # When objvar is "self", use type(self), when objvar is "cls", use it as-is
         type_to_use = self.objvar.python_type()
         type_to_use_source = (
             TypeSource(self.objvar.source) if self.objvar.source else None
@@ -78,7 +90,35 @@ class SuperVariable(VariableTracker):
                     break
 
         # TODO(jansel): there is a small chance this could trigger user code, prevent that
-        return getattr(super(search_type, type_to_use), name), source
+        # It is important to call with objvar here to ensure that when we get methods,
+        # they are bound appropriately
+        # Note that what gets bound here for methods depend on how the name method is defined
+        # and does not depend on objvar being self or cls in the current function.
+        objvar_python = (
+            self.objvar.module
+            if isinstance(self.objvar, NNModuleVariable)
+            else self.objvar.value
+        )
+        bound_method = getattr(super(search_type, objvar_python), name)
+
+        add_objvar = None
+        if isinstance(bound_method, (types.MethodWrapperType, types.BuiltinMethodType)):
+            # There is not API provided by CPython to unbind "wrapper-method" or "builtin-method"
+            # So we manually unbind them for the case we know how to handle
+            bound_method = getattr(super(search_type, type_to_use), name)
+            # Do NOT add any classmethod to this list unless you add support for it for add_objvar
+            if bound_method not in (
+                object.__init__,
+                collections.OrderedDict.__getitem__,
+                collections.OrderedDict.__setitem__,
+            ):
+                raise NotImplementedError()
+            # All functions above are regular method (taking self) and their parent is
+            # also a regular method (taking self).
+            # It is thus ok to pass in objvar as the first argument manually
+            add_objvar = True
+
+        return bound_method, source, add_objvar
 
     def var_getattr(self, tx, name: str) -> "VariableTracker":
         # Check if getattr is a constant. If not, delay the actual work by
@@ -89,7 +129,7 @@ class SuperVariable(VariableTracker):
         # special when it comes to finding sources. Compared to other VTs, super
         # requires the attr name to walk the mro and find the actual source (and
         # not just AttrSource).
-        value, source = self._resolved_getattr_and_source(self, name)
+        value, source, _ = self._resolved_getattr_and_source(self, name)
         if not variables.ConstantVariable.is_literal(value):
             return GetAttrVariable(self, name)
         if source:
@@ -104,11 +144,13 @@ class SuperVariable(VariableTracker):
         args: "List[VariableTracker]",
         kwargs: "Dict[str, VariableTracker]",
     ) -> "VariableTracker":
-        inner_fn, source = self._resolved_getattr_and_source(self, name)
+        inner_fn, source, add_objvar = self._resolved_getattr_and_source(self, name)
 
-        if inner_fn is object.__init__:
+        unbound_inner_fn = getattr(inner_fn, "__func__", inner_fn)
+
+        if unbound_inner_fn is object.__init__:
             return LambdaVariable(identity)
-        elif inner_fn is torch.nn.Module.__init__:
+        elif unbound_inner_fn is torch.nn.Module.__init__:
             objvar = self.objvar
             from ..side_effects import AttributeMutationNew
 
@@ -125,16 +167,8 @@ class SuperVariable(VariableTracker):
                 return variables.ConstantVariable.create(None)
             else:
                 unimplemented("super() nn.Module.__init__")
-        elif isinstance(inner_fn, types.FunctionType):
-            return variables.UserFunctionVariable(
-                inner_fn, source=source
-            ).call_function(tx, [self.objvar] + args, kwargs)
-        elif isinstance(inner_fn, types.MethodType):
-            return variables.UserMethodVariable(
-                inner_fn.__func__, self.objvar, source=source
-            ).call_function(tx, args, kwargs)
         elif (
-            inner_fn is collections.OrderedDict.__getitem__
+            unbound_inner_fn is collections.OrderedDict.__getitem__
             and isinstance(self.objvar, variables.UserDefinedObjectVariable)
             and self.objvar.source
             and len(args) == 1
@@ -144,17 +178,41 @@ class SuperVariable(VariableTracker):
             from .builder import VariableBuilder
 
             key = args[0].as_python_constant()
+            assert add_objvar, "Invalid super() resolution"
             return VariableBuilder(tx, ODictGetItemSource(self.objvar.source, key))(
                 collections.OrderedDict.__getitem__(self.objvar.value, key)
             )
-        elif inner_fn in (
+        elif unbound_inner_fn in (
             collections.OrderedDict.__setitem__,
             object.__setattr__,
         ) and isinstance(self.objvar, variables.CustomizedDictVariable):
+            assert add_objvar, "Invalid super() resolution"
             assert not kwargs and len(args) == 2
             return super(variables.CustomizedDictVariable, self.objvar).call_method(
                 tx, "__setitem__", args, kwargs
             )
+        elif isinstance(inner_fn, types.FunctionType):
+            # When the function is defined as a staticmethod
+            return variables.UserFunctionVariable(
+                inner_fn, source=source
+            ).call_function(tx, args, kwargs)
+        elif isinstance(inner_fn, types.MethodType):
+            # When the function is defined as a method or classmethod
+            first_arg = self.objvar
+            objvar_python = (
+                first_arg.module
+                if isinstance(first_arg, NNModuleVariable)
+                else first_arg.value
+            )
+            if objvar_python is not inner_fn.__self__:
+                first_arg = self.objvar.python_type()
+                assert (
+                    first_arg == inner_fn.__self__
+                ), f"{first_arg}|{inner_fn.__self__}"
+                # Don't we need to wrap the raw python type into a VariableTracker here?
+            return variables.UserMethodVariable(
+                inner_fn.__func__, first_arg, source=source
+            ).call_function(tx, args, kwargs)
         else:
             unimplemented(f"non-function or method super: {inner_fn}")
 

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -756,7 +756,9 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             else:
                 return trace_rules.lookup(func)(func)
         elif isinstance(subobj, classmethod):
-            return variables.UserMethodVariable(subobj.__func__, type(subobj), source=source)
+            return variables.UserMethodVariable(
+                subobj.__func__, type(subobj), source=source
+            )
         elif isinstance(subobj, types.FunctionType) or (
             isinstance(subobj, types.MethodType)
             and isinstance(self.value, torch.nn.Module)

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -757,7 +757,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 return trace_rules.lookup(func)(func)
         elif isinstance(subobj, classmethod):
             return variables.UserMethodVariable(
-                subobj.__func__, type(subobj), source=source
+                subobj.__func__, self.var_getattr(tx, "__class__"), source=source
             )
         elif isinstance(subobj, types.FunctionType) or (
             isinstance(subobj, types.MethodType)

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -756,7 +756,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             else:
                 return trace_rules.lookup(func)(func)
         elif isinstance(subobj, classmethod):
-            return variables.UserMethodVariable(subobj.__func__, self, source=source)
+            return variables.UserMethodVariable(subobj.__func__, self.__class__, source=source)
         elif isinstance(subobj, types.FunctionType) or (
             isinstance(subobj, types.MethodType)
             and isinstance(self.value, torch.nn.Module)

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -756,7 +756,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             else:
                 return trace_rules.lookup(func)(func)
         elif isinstance(subobj, classmethod):
-            return variables.UserMethodVariable(subobj.__func__, self.__class__, source=source)
+            return variables.UserMethodVariable(subobj.__func__, type(subobj), source=source)
         elif isinstance(subobj, types.FunctionType) or (
             isinstance(subobj, types.MethodType)
             and isinstance(self.value, torch.nn.Module)


### PR DESCRIPTION
I was originally trying to solve https://github.com/pytorch/pytorch/issues/120799 but got sidetracked along the way.
This PR contains a couple fixes. Let me know if you want me to split them up!

- Properly handle invalid user code when "super()" is called from non-method/classmethod. It will now properly raise the same error as CPython
- Fix base VariableTracker `__str__` method shadowing all `__repr__` methods defined in subclasses
- Fix accessing a classmethod on a user object to bind "cls" and not "self"
- Fix custom class handling of super() call to properly handle mixed regular/class/static methods



Locally , test_repros.py -k test_batch_norm_act still fails where the generated graph module is:
```
Call using an FX-traced Module, line 8 of the traced Module's generated forward function:
    x = self.forward(l_x_);  self = l_x_ = None
    x_1 = self.L__self___act(x);  x = None
```
note that "self" is being unset on the first line even though it is used on the second one.
For reference, this is the test https://github.com/pytorch/pytorch/blob/c268ce4a6d7445d71637ad0d6cb88b94e52bb0a2/test/dynamo/test_repros.py#L1368-L1369
I cannot figure out where the generated forward function comes from though, any hint would be welcome!

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang