### PR TITLE
[Clang-tidy header][23/N] Enable clang-tidy coverage on aten/src/ATen/*.{cpp,h}

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -187,9 +187,12 @@ command = [
 code = 'CLANGTIDY'
 include_patterns = [
     'aten/src/ATen/core/*.cpp',
+    # Enable coverage of headers in aten/src/ATen
+    # and excluding most sub-directories for now.
+    'aten/src/ATen/*.h',
+    'aten/src/ATen/*.cpp',
     'c10/**/*.cpp',
     'c10/**/*.h',
-    # Enable coverage of headers in torch/csrc and excluding sub-directories for now.
     'torch/csrc/*.h',
     'torch/csrc/*.cpp',
     'torch/csrc/**/*.h',

--- a/aten/src/ATen/MapAllocator.cpp
+++ b/aten/src/ATen/MapAllocator.cpp
@@ -607,7 +607,7 @@ void* RefcountedMapAllocator::data() const {
 }
 
 MapAllocator::~MapAllocator() {
-  close();
+  MapAllocator::close();
   c10::reportMemoryUsageToProfiler(base_ptr_, -size_, 0, 0, c10::Device(c10::DeviceType::CPU));
 }
 

--- a/aten/src/ATen/MapAllocator.h
+++ b/aten/src/ATen/MapAllocator.h
@@ -128,7 +128,7 @@ class TORCH_API RefcountedMapAllocator : private RefcountedMapAllocatorArgCheck,
   void close() override;
 
   ~RefcountedMapAllocator() override {
-    close();
+    RefcountedMapAllocator::close();
   }
 
  protected:


### PR DESCRIPTION
This PR finishes the works beginning with #https://github.com/pytorch/pytorch/pull/120763 by enabling clang-tidy on aten/src/ATen.
