### PR TITLE
Fix torch.clamp in MPS to handle NaN correctly

### DIFF
--- a/aten/src/ATen/native/mps/operations/TensorCompare.mm
+++ b/aten/src/ATen/native/mps/operations/TensorCompare.mm
@@ -56,19 +56,19 @@ static void clamp_mps_graph(CachedGraph* cachedGraph,
     // and maximumWithNaNPropagationWithPrimaryTensor sequentially
 
     cachedGraph->outputTensor = [mpsGraph minimumWithNaNPropagationWithPrimaryTensor:cachedGraph->inputTensor
-                                                   secondaryTensor:maxTensor
-                                                              name:nil];
+                                                                     secondaryTensor:maxTensor
+                                                                                name:nil];
     cachedGraph->outputTensor = [mpsGraph maximumWithNaNPropagationWithPrimaryTensor:cachedGraph->outputTensor
-                                                    secondaryTensor:minTensor
-                                                                name:nil];
+                                                                     secondaryTensor:minTensor
+                                                                                name:nil];
   } else if (cachedGraph->maxTensor) {
     cachedGraph->outputTensor = [mpsGraph minimumWithNaNPropagationWithPrimaryTensor:cachedGraph->inputTensor
-                                                   secondaryTensor:maxTensor
-                                                              name:nil];
+                                                                     secondaryTensor:maxTensor
+                                                                                name:nil];
   } else if (cachedGraph->minTensor) {
     cachedGraph->outputTensor = [mpsGraph maximumWithNaNPropagationWithPrimaryTensor:cachedGraph->inputTensor
-                                                   secondaryTensor:minTensor
-                                                              name:nil];
+                                                                     secondaryTensor:minTensor
+                                                                                name:nil];
   }
 }
 

--- a/aten/src/ATen/native/mps/operations/TensorCompare.mm
+++ b/aten/src/ATen/native/mps/operations/TensorCompare.mm
@@ -54,13 +54,14 @@ static void clamp_mps_graph(CachedGraph* cachedGraph,
   if (cachedGraph->minTensor && cachedGraph->maxTensor) {
     // clampWithTensor doesn't propagate NaN through so we perform minimumWithNaNPropagationWithPrimaryTensor
     // and maximumWithNaNPropagationWithPrimaryTensor sequentially
-
-    cachedGraph->outputTensor = [mpsGraph minimumWithNaNPropagationWithPrimaryTensor:cachedGraph->inputTensor
-                                                                     secondaryTensor:maxTensor
-                                                                                name:nil];
-    cachedGraph->outputTensor = [mpsGraph maximumWithNaNPropagationWithPrimaryTensor:cachedGraph->outputTensor
-                                                                     secondaryTensor:minTensor
-                                                                                name:nil];
+    cachedGraph->outputTensor = [mpsGraph
+        minimumWithNaNPropagationWithPrimaryTensor:[mpsGraph
+                                                       maximumWithNaNPropagationWithPrimaryTensor:cachedGraph
+                                                                                                      ->inputTensor
+                                                                                  secondaryTensor:minTensor
+                                                                                             name:nil]
+                                   secondaryTensor:maxTensor
+                                              name:nil];
   } else if (cachedGraph->maxTensor) {
     cachedGraph->outputTensor = [mpsGraph minimumWithNaNPropagationWithPrimaryTensor:cachedGraph->inputTensor
                                                                      secondaryTensor:maxTensor

--- a/aten/src/ATen/native/mps/operations/TensorCompare.mm
+++ b/aten/src/ATen/native/mps/operations/TensorCompare.mm
@@ -53,10 +53,10 @@ static void clamp_mps_graph(CachedGraph* cachedGraph,
   if (input_dtype != max_dtype) {
     maxTensor = castMPSTensor(mpsGraph, cachedGraph->maxTensor, input_dtype);
   }
-  // clampWithTensor doesn't propagate NaN through so simulate it as composition of 
+  // clampWithTensor doesn't propagate NaN through so simulate it as composition of
   // minimumWithNaNPropagationWithPrimaryTensor and maximumWithNaNPropagationWithPrimaryTensor
   if (maxTensor) {
-    outputTensor = [mpsGraph minimumWithNaNPropagationWithPrimaryTensor:ouputTensor
+    outputTensor = [mpsGraph minimumWithNaNPropagationWithPrimaryTensor:outputTensor
                                                         secondaryTensor:maxTensor
                                                                    name:nil];
   }

--- a/aten/src/ATen/native/mps/operations/TensorCompare.mm
+++ b/aten/src/ATen/native/mps/operations/TensorCompare.mm
@@ -43,34 +43,29 @@ static void clamp_mps_graph(CachedGraph* cachedGraph,
 
   cachedGraph->inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_tensor);
 
-  MPSGraphTensor* minTensor = cachedGraph->minTensor;
-  MPSGraphTensor* maxTensor = cachedGraph->maxTensor;
+  auto minTensor = cachedGraph->minTensor;
+  auto maxTensor = cachedGraph->maxTensor;
+  auto outputTensor = cachedGraph->inputTensor;
+
   if (input_dtype != min_dtype) {
     minTensor = castMPSTensor(mpsGraph, cachedGraph->minTensor, input_dtype);
   }
   if (input_dtype != max_dtype) {
     maxTensor = castMPSTensor(mpsGraph, cachedGraph->maxTensor, input_dtype);
   }
-  if (cachedGraph->minTensor && cachedGraph->maxTensor) {
-    // clampWithTensor doesn't propagate NaN through so we perform minimumWithNaNPropagationWithPrimaryTensor
-    // and maximumWithNaNPropagationWithPrimaryTensor sequentially
-    cachedGraph->outputTensor = [mpsGraph
-        minimumWithNaNPropagationWithPrimaryTensor:[mpsGraph
-                                                       maximumWithNaNPropagationWithPrimaryTensor:cachedGraph
-                                                                                                      ->inputTensor
-                                                                                  secondaryTensor:minTensor
-                                                                                             name:nil]
-                                   secondaryTensor:maxTensor
-                                              name:nil];
-  } else if (cachedGraph->maxTensor) {
-    cachedGraph->outputTensor = [mpsGraph minimumWithNaNPropagationWithPrimaryTensor:cachedGraph->inputTensor
-                                                                     secondaryTensor:maxTensor
-                                                                                name:nil];
-  } else if (cachedGraph->minTensor) {
-    cachedGraph->outputTensor = [mpsGraph maximumWithNaNPropagationWithPrimaryTensor:cachedGraph->inputTensor
-                                                                     secondaryTensor:minTensor
-                                                                                name:nil];
+  // clampWithTensor doesn't propagate NaN through so simulate it as composition of 
+  // minimumWithNaNPropagationWithPrimaryTensor and maximumWithNaNPropagationWithPrimaryTensor
+  if (maxTensor) {
+    outputTensor = [mpsGraph minimumWithNaNPropagationWithPrimaryTensor:ouputTensor
+                                                        secondaryTensor:maxTensor
+                                                                   name:nil];
   }
+  if (minTensor) {
+    outputTensor = [mpsGraph maximumWithNaNPropagationWithPrimaryTensor:outputTensor
+                                                        secondaryTensor:minTensor
+                                                                   name:nil];
+  }
+  cachedGraph->outputTensor = outputTensor;
 }
 
 static void check_min_max_dims(const OptionalTensorRef clamp_opt, const Tensor& input_t, string op_name) {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5768,6 +5768,25 @@ class TestMPS(TestCaseMPS):
 
         self.assertEqual(clamp_result_mps, clamp_result_cpu)
 
+    def test_clamp_nan(self):
+        t_mps = torch.tensor([torch.nan, 1, 2], device="mps")
+        t_cpu = torch.tensor([torch.nan, 1, 2], device="cpu")
+
+        clamp_min_max_mps = torch.clamp(t_mps, min=-100, max=100)
+        clamp_min_max_cpu = torch.clamp(t_cpu, min=-100, max=100)
+
+        self.assertEqual(clamp_min_max_mps, clamp_min_max_cpu)
+
+        clamp_min_mps = torch.clamp(t_mps, min=-100)
+        clamp_min_cpu = torch.clamp(t_cpu, min=-100)
+
+        self.assertEqual(clamp_min_mps, clamp_min_cpu)
+
+        clamp_max_mps = torch.clamp(t_mps, max=100)
+        clamp_max_cpu = torch.clamp(t_cpu, max=100)
+
+        self.assertEqual(clamp_max_mps, clamp_max_cpu)
+
     # Test clamp_min
     def test_clamp_min(self):
         def helper(n, c, h, w):


### PR DESCRIPTION
Fixes #120899

So this is interesting. There are methods that specifically propagate NaN instead of clamping to real numbers. 
https://developer.apple.com/documentation/metalperformanceshadersgraph/mpsgraph/3857573-maximumwithnanpropagationwithpri
