### PR TITLE
[dtensor][debug] visualize_sharding skip if the current rank is not in mesh

### DIFF
--- a/torch/distributed/_tensor/debug/visualize_sharding.py
+++ b/torch/distributed/_tensor/debug/visualize_sharding.py
@@ -143,6 +143,9 @@ def visualize_sharding(dtensor, header=""):
     device_mesh = dtensor.device_mesh
     device_type = dtensor.device_mesh.device_type
 
+    if device_mesh.get_coordinate() is None:  # current rank is not in the mesh
+        return
+
     device_map = _mesh_to_coordinate(device_mesh, device_type)
     all_offsets = []
     for device in device_map:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #121392
* #120265
* #121217
* __->__ #121382
* #121385

**Summary**
We should skip the `visualize_sharding()` function on those ranks that are not a part of the DTensor's mesh. If not, exception will be thrown in current visualize logic.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang