### PR TITLE
[dtensor][debug] visualize_sharding only compute offset on the first rank in mesh

### DIFF
--- a/torch/distributed/_tensor/debug/visualize_sharding.py
+++ b/torch/distributed/_tensor/debug/visualize_sharding.py
@@ -143,6 +143,15 @@ def visualize_sharding(dtensor, header=""):
     device_mesh = dtensor.device_mesh
     device_type = dtensor.device_mesh.device_type
 
+    # Only display the visualization once for each DTensor, on the rank whose
+    # coordinate is 0 on all dimensions. For example, if the mesh is a full mesh,
+    # we will only print on rank 0.
+    local_rank_zero_on_all_dim = all(
+        device_mesh.get_local_rank(mesh_dim=dim) == 0 for dim in range(device_mesh.ndim)
+    )
+    if not local_rank_zero_on_all_dim:
+        return
+
     device_map = _mesh_to_coordinate(device_mesh, device_type)
     all_offsets = []
     for device in device_map:
@@ -153,9 +162,7 @@ def visualize_sharding(dtensor, header=""):
 
     # Convert offsets to blocks with row_ranges for tabulate
     blocks = _convert_offset_to_ranges(all_offsets)
-    local_rank_zero_on_all_dim = all(
-        device_mesh.get_local_rank(mesh_dim=dim) == 0 for dim in range(device_mesh.ndim)
-    )
-    if local_rank_zero_on_all_dim:
-        print(header)
-        print(_create_table(blocks))
+
+    # Print the table
+    print(header)
+    print(_create_table(blocks))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #121392
* #120265
* #121217
* #121382
* __->__ #121385

**Summary**
avoid computing on ranks where we do not plan to visualize the DTensor.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang