### PR TITLE
Back out "[ATen][CUDA][CUBLAS] cublasLtMatmul increase workspace_size (#120925)"

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -183,22 +183,13 @@ uint32_t _getAlignment(uintptr_t address) {
 
 static size_t _parseChosenWorkspaceSize() {
   const char * val = getenv("CUBLASLT_WORKSPACE_SIZE");
-  size_t workspace_size = 1024;
 #ifdef USE_ROCM
   if (!val) {
     // accept either env var
     val = getenv("HIPBLASLT_WORKSPACE_SIZE");
   }
-#else
-  cudaDeviceProp* p = at::cuda::getDeviceProperties(c10::cuda::current_device());
-  // Keep workspace_size = 1024 for small Ampere GPUs
-  // See https://github.com/pytorch/pytorch/pull/120925#issuecomment-1977556485
-  if (p->major == 8 && p->totalGlobalMem / 1073741824 >= 24) {
-    workspace_size = 4096;
-  } else if (p->major >= 9) {
-    workspace_size = 32768;
-  }
 #endif
+  size_t workspace_size = 1024; /* default size in KiB according to #73328 */
   if (val) {
     try {
       workspace_size = std::stoi(val);


### PR DESCRIPTION
Summary: as title

Test Plan:
```
[ruilinchen@67394.od /data/sandcastle/boxes/fbsource/fbcode (6bcc6d43f)]$ buck2 test 'fbcode//mode/opt' fbcode//aps_models/ads/icvr/tests/ne/e2e_deterministic_tests:fm_tests -- --exact 'aps_models/ads/icvr/tests/ne/e2e_deterministic_tests:fm_tests - aps_models.ads.icvr.tests.ne.e2e_deterministic_tests.ig_fm_when_uhm_atom_test.IG_FM_WHEN_UHM_ATOM_DeterministicTest: test_ig_fm_when_uhm_atom_single_gpu' --run-disabled
Buck UI: https://www.internalfb.com/buck2/5542f0d8-f964-47ba-b1ba-913d3c12b31b
Test UI: https://www.internalfb.com/intern/testinfra/testrun/9007199279509584
Network: Up: 10KiB  Down: 17KiB  (reSessionID-c07059f3-7859-4e1a-867f-958b8ef50526)
Jobs completed: 6. Time elapsed: 3:24.7s.
Tests finished: Pass 2. Fail 0. Fatal 0. Skip 0. Build failure 0
```

Differential Revision: D54622751
