### PR TITLE
[dynamo][DONT REVIEW] Example where graph break in AC leads to unrelated errors

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -1093,12 +1093,15 @@ class ActivationCheckpointingViaTagsTests(torch._dynamo.test_case.TestCase):
                 x = torch.sin(x)
                 x = self.linear(x)
                 x = torch.cos(x)
-                return x * self.c
+                torch._dynamo.graph_break()
+                return x
+                # return x * self.__dict__["c"]
+                # # return x * self.__getattr__("c")
 
-        mod = dist_checkpoint_wrapper(MockModule())
+        mod = dist_checkpoint_wrapper(MockModule(), 2)
         x = torch.randn(4, 4)
         ref = mod(x)
-        opt_mod = torch.compile(mod, backend="eager", fullgraph=True)
+        opt_mod = torch.compile(mod, backend="eager")#, fullgraph=True)
         res = opt_mod(x)
         self.assertEqual(ref, res)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121395
* #121394
* #121388

This stack trace is similar to what we see internally

~~~
I0307 00:24:27.140000 140033164809344 torch/_dynamo/convert_frame.py:822]     result = BuiltinVariable(getattr).call_function(
I0307 00:24:27.140000 140033164809344 torch/_dynamo/convert_frame.py:822]   File "/data/users/anijain/pytorch/torch/_dynamo/variables/builtin.py", line 685, in call_function
I0307 00:24:27.140000 140033164809344 torch/_dynamo/convert_frame.py:822]     result = handler(tx, *args, **kwargs)
I0307 00:24:27.140000 140033164809344 torch/_dynamo/convert_frame.py:822]   File "/data/users/anijain/pytorch/torch/_dynamo/variables/builtin.py", line 1263, in call_getattr
I0307 00:24:27.140000 140033164809344 torch/_dynamo/convert_frame.py:822]     return obj.var_getattr(tx, name)
I0307 00:24:27.140000 140033164809344 torch/_dynamo/convert_frame.py:822]   File "/data/users/anijain/pytorch/torch/_dynamo/variables/nn_module.py", line 240, in var_getattr
I0307 00:24:27.140000 140033164809344 torch/_dynamo/convert_frame.py:822]     unimplemented(
I0307 00:24:27.140000 140033164809344 torch/_dynamo/convert_frame.py:822]   File "/data/users/anijain/pytorch/torch/_dynamo/exc.py", line 190, in unimplemented
I0307 00:24:27.140000 140033164809344 torch/_dynamo/convert_frame.py:822]     raise Unsupported(msg)
I0307 00:24:27.140000 140033164809344 torch/_dynamo/convert_frame.py:822] torch._dynamo.exc.Unsupported: class property __dict__ - CheckpointWrapper getset_descriptor
I0307 00:24:27.140000 140033164809344 torch/_dynamo/convert_frame.py:822]
I0307 00:24:27.140000 140033164809344 torch/_dynamo/convert_frame.py:822] from user code:
I0307 00:24:27.140000 140033164809344 torch/_dynamo/convert_frame.py:822]    File "/data/users/anijain/pytorch/torch/distributed/algorithms/_checkpoint/checkpoint_wrapper.py", line 46, in __getattr__
I0307 00:24:27.140000 140033164809344 torch/_dynamo/convert_frame.py:822]     return super().__getattr__(name)  # defer to nn.Module's logic
I0307 00:24:27.140000 140033164809344 torch/_dynamo/convert_frame.py:822]   File "/data/users/anijain/pytorch/torch/nn/modules/module.py", line 1692, in __getattr__
I0307 00:24:27.140000 140033164809344 torch/_dynamo/convert_frame.py:822]     if '_parameters' in self.__dict__:
I0307 00:24:27.140000 140033164809344 torch/_dynamo/convert_frame.py:822]
I0307 00:24:27.140000 140033164809344 torch/_dynamo/convert_frame.py:822] Set TORCH_LOGS="+dynamo" and TORCHDYNAMO_VERBOSE=1 for more information
~~~

Therefore, the goal is to figure out why we gave up on AC in the first place. In this example its manual graph break. In internal case, its DDP optimizer.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang