### PR TITLE
Update python binding for in-place foreach to return `List[Tensor]`

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -66,6 +66,8 @@ class ForeachFuncWrapper:
             assert mta_called == (expect_fastpath and (not zero_size))
         else:
             actual = self.func(*inputs, **kwargs)
+        if self.is_inplace:
+            assert all(id(a) == id(b) for a, b in zip(inputs[0], actual))
         return actual
 
 

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -67,7 +67,7 @@ class ForeachFuncWrapper:
         else:
             actual = self.func(*inputs, **kwargs)
         if self.is_inplace:
-            assert all(id(a) == id(b) for a, b in zip(inputs[0], actual))
+            assert id(inputs[0]) == id(actual)
         return actual
 
 

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -66,8 +66,7 @@ class ForeachFuncWrapper:
             assert mta_called == (expect_fastpath and (not zero_size))
         else:
             actual = self.func(*inputs, **kwargs)
-        # note(mkozuki): inplace foreach functions are void functions.
-        return inputs[0] if self.is_inplace else actual
+        return actual
 
 
 class InplaceForeachVersionBumpCheck:

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -1360,7 +1360,9 @@ def emit_single_dispatch(
             ):
                 # note(crcrpar): `_foreach_pow.ScalarAndTensor` does NOT have its in-place
                 # variant and it unlikely to have it in the future. Thus it's safe to have the following assert.
-                assert self_arg is not None and is_tensor_list_type(self_arg.argument.type)
+                assert self_arg is not None and is_tensor_list_type(
+                    self_arg.argument.type
+                )
                 return f"""\
 {schema_comment}
 {inits}

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -1366,12 +1366,14 @@ def emit_single_dispatch(
                 return f"""\
 {schema_comment}
 {inits}
-auto dispatch_{name} = []({lambda_formals}) -> at::TensorList {{
+auto dispatch_{name} = []({lambda_formals}) -> void {{
   pybind11::gil_scoped_release no_gil;
   {dispatch_callee}({dispatch_args});
-  return self;
 }};
-return wrap(dispatch_{name}({lambda_args}){set_requires_grad});
+dispatch_{name}({lambda_args}){set_requires_grad};
+PyObject* self_tensorlist = _r.args[0];
+Py_INCREF(self_tensorlist);
+return self_tensorlist;
 """
             else:
                 return f"""\

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -1373,7 +1373,7 @@ return self_tensorlist;
             return f"""\
 {schema_comment}
 {inits}
-auto dispatch_{name} = []({lambda_formals}) -> void {{
+auto dispatch_{name} = []({lambda_formals}) -> {lambda_return} {{
   pybind11::gil_scoped_release no_gil;
   {dispatch_callee}({dispatch_args});
 }};

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -1364,10 +1364,10 @@ def emit_single_dispatch(
                 return f"""\
 {schema_comment}
 {inits}
-auto dispatch_{name} = []({lambda_formals}) -> ::std::vector<at::Tensor> {{
+auto dispatch_{name} = []({lambda_formals}) -> at::TensorList {{
   pybind11::gil_scoped_release no_gil;
   {dispatch_callee}({dispatch_args});
-  return self.vec();
+  return self;
 }};
 return wrap(dispatch_{name}({lambda_args}){set_requires_grad});
 """

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -1357,10 +1357,10 @@ def emit_single_dispatch(
             if (
                 str(f.func.name).startswith("_foreach_")
                 and f.func.kind() == SchemaKind.inplace
-                and (
-                    self_arg is not None and is_tensor_list_type(self_arg.argument.type)
-                )
             ):
+                # note(crcrpar): `_foreach_pow.ScalarAndTensor` does NOT have its in-place
+                # variant and it unlikely to have it in the future. Thus it's safe to have the following assert.
+                assert self_arg is not None and is_tensor_list_type(self_arg.argument.type)
                 return f"""\
 {schema_comment}
 {inits}


### PR DESCRIPTION
fixes #104817 
taking over #118622

```c++
// _foreach_atan_
static PyObject * THPVariable__foreach_atan_(PyObject* self_, PyObject* args, PyObject* kwargs)
{
  HANDLE_TH_ERRORS
  static PythonArgParser parser({
    "_foreach_atan_(TensorList self)",
  }, /*traceable=*/false);

  ParsedArgs<1> parsed_args;
  auto _r = parser.parse(nullptr, args, kwargs, parsed_args);
  if(_r.has_torch_function()) {
    return handle_torch_function(_r, nullptr, args, kwargs, THPVariableFunctionsModule, "torch");
  }
  // aten::_foreach_atan_(Tensor(a!)[] self) -> ()

  // auto dispatch__foreach_atan_ = [](at::TensorList self) -> at::TensorList {
  auto dispatch__foreach_atan_ = [](at::TensorList self) -> void {
    pybind11::gil_scoped_release no_gil;
    at::_foreach_atan_(self);
  };
  dispatch__foreach_atan_(_r.tensorlist(0));
  PyObject* self_tensorlist = _r.args[0];
  Py_INCREF(self_tensorlist);
  return self_tensorlist;
  Py_RETURN_NONE;
  END_HANDLE_TH_ERRORS
}
...
// _foreach_div_
static PyObject * THPVariable__foreach_div_(PyObject* self_, PyObject* args, PyObject* kwargs)
{
  HANDLE_TH_ERRORS
  static PythonArgParser parser({
    "_foreach_div_(TensorList self, ScalarList scalars)",
    "_foreach_div_(TensorList self, Tensor other)",
    "_foreach_div_(TensorList self, TensorList other)",
    "_foreach_div_(TensorList self, Scalar scalar)",
  }, /*traceable=*/false);

  ParsedArgs<2> parsed_args;
  auto _r = parser.parse(nullptr, args, kwargs, parsed_args);
  if(_r.has_torch_function()) {
    return handle_torch_function(_r, nullptr, args, kwargs, THPVariableFunctionsModule, "torch");
  }
  switch (_r.idx) {
    case 0: {
      // aten::_foreach_div_.ScalarList(Tensor(a!)[] self, Scalar[] scalars) -> ()

      // auto dispatch__foreach_div_ = [](at::TensorList self, at::ArrayRef<at::Scalar> scalars) -> at::TensorList {
      auto dispatch__foreach_div_ = [](at::TensorList self, at::ArrayRef<at::Scalar> scalars) -> void {
        pybind11::gil_scoped_release no_gil;
        at::_foreach_div_(self, scalars);
      };
      dispatch__foreach_div_(_r.tensorlist(0), _r.scalarlist(1));
      PyObject* self_tensorlist = _r.args[0];
      Py_INCREF(self_tensorlist);
      return self_tensorlist;
    }
    case 1: {
      // aten::_foreach_div_.Tensor(Tensor(a!)[] self, Tensor other) -> ()

      // auto dispatch__foreach_div_ = [](at::TensorList self, const at::Tensor & other) -> at::TensorList {
      auto dispatch__foreach_div_ = [](at::TensorList self, const at::Tensor & other) -> void {
        pybind11::gil_scoped_release no_gil;
        at::_foreach_div_(self, other);
      };
      dispatch__foreach_div_(_r.tensorlist(0), _r.tensor(1));
      PyObject* self_tensorlist = _r.args[0];
      Py_INCREF(self_tensorlist);
      return self_tensorlist;
    }
    case 2: {
      // aten::_foreach_div_.List(Tensor(a!)[] self, Tensor[] other) -> ()

      // auto dispatch__foreach_div_ = [](at::TensorList self, at::TensorList other) -> at::TensorList {
      auto dispatch__foreach_div_ = [](at::TensorList self, at::TensorList other) -> void {
        pybind11::gil_scoped_release no_gil;
        at::_foreach_div_(self, other);
      };
      dispatch__foreach_div_(_r.tensorlist(0), _r.tensorlist(1));
      PyObject* self_tensorlist = _r.args[0];
      Py_INCREF(self_tensorlist);
      return self_tensorlist;
    }
    case 3: {
      // aten::_foreach_div_.Scalar(Tensor(a!)[] self, Scalar scalar) -> ()

      // auto dispatch__foreach_div_ = [](at::TensorList self, const at::Scalar & scalar) -> at::TensorList {
      auto dispatch__foreach_div_ = [](at::TensorList self, const at::Scalar & scalar) -> void {
        pybind11::gil_scoped_release no_gil;
        at::_foreach_div_(self, scalar);
      };
      dispatch__foreach_div_(_r.tensorlist(0), _r.scalar(1));
      PyObject* self_tensorlist = _r.args[0];
      Py_INCREF(self_tensorlist);
      return self_tensorlist;
    }
  }
  Py_RETURN_NONE;
  END_HANDLE_TH_ERRORS
}
```