### PR TITLE
Improve compiler detection on MacOS

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -917,6 +917,10 @@ def install_gcc_via_conda() -> str:
 
 
 def is_gcc() -> bool:
+    # Mac OS not support real gcc, it is acturally a clang.
+    _IS_MACOS = sys.platform.startswith("darwin")
+    if _IS_MACOS:
+        return False
     return bool(re.search(r"(gcc|g\+\+)", cpp_compiler()))
 
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -917,8 +917,7 @@ def install_gcc_via_conda() -> str:
 
 
 def is_gcc() -> bool:
-    # Mac OS not support real gcc, it is acturally a clang.
-    if sys.platform == "darwin":
+    if sys.platform == "darwin" and is_apple_clang():
         return False
     return bool(re.search(r"(gcc|g\+\+)", cpp_compiler()))
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -923,15 +923,18 @@ def is_gcc() -> bool:
     return bool(re.search(r"(gcc|g\+\+)", cpp_compiler()))
 
 
-def is_clang() -> bool:
-    return bool(re.search(r"(clang|clang\+\+)", cpp_compiler()))
-
-
 @functools.lru_cache(None)
 def is_apple_clang() -> bool:
     cxx = cpp_compiler()
     version_string = subprocess.check_output([cxx, "--version"]).decode("utf8")
     return "Apple" in version_string.splitlines()[0]
+
+
+def is_clang() -> bool:
+    # Mac OS apple clang maybe named as gcc, need check compiler info.
+    if sys.platform == "darwin":
+        return is_apple_clang()
+    return bool(re.search(r"(clang|clang\+\+)", cpp_compiler()))
 
 
 class VecISA:

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -918,8 +918,7 @@ def install_gcc_via_conda() -> str:
 
 def is_gcc() -> bool:
     # Mac OS not support real gcc, it is acturally a clang.
-    _IS_MACOS = sys.platform.startswith("darwin")
-    if _IS_MACOS:
+    if sys.platform == "darwin":
         return False
     return bool(re.search(r"(gcc|g\+\+)", cpp_compiler()))
 


### PR DESCRIPTION
By relying on `is_apple_clang` helper function rather than on compiler name (as `gcc` is clang on MacOS):
```
% which gcc; gcc -v
/usr/bin/gcc
Apple clang version 15.0.0 (clang-1500.3.9.4)
Target: arm64-apple-darwin23.3.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```
But
```
% /opt/homebrew/bin/gcc-13 -v
Using built-in specs.
COLLECT_GCC=/opt/homebrew/bin/gcc-13
COLLECT_LTO_WRAPPER=/opt/homebrew/Cellar/gcc/13.2.0/bin/../libexec/gcc/aarch64-apple-darwin23/13/lto-wrapper
Target: aarch64-apple-darwin23
Configured with: ../configure --prefix=/opt/homebrew/opt/gcc --libdir=/opt/homebrew/opt/gcc/lib/gcc/current --disable-nls --enable-checking=release --with-gcc-major-version-only --enable-languages=c,c++,objc,obj-c++,fortran --program-suffix=-13 --with-gmp=/opt/homebrew/opt/gmp --with-mpfr=/opt/homebrew/opt/mpfr --with-mpc=/opt/homebrew/opt/libmpc --with-isl=/opt/homebrew/opt/isl --with-zstd=/opt/homebrew/opt/zstd --with-pkgversion='Homebrew GCC 13.2.0' --with-bugurl=https://github.com/Homebrew/homebrew-core/issues --with-system-zlib --build=aarch64-apple-darwin23 --with-sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 13.2.0 (Homebrew GCC 13.2.0) 
```

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang