### PR TITLE
Deprecate torch.autograd.function.traceable, is_traceable

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -510,6 +510,47 @@ class TestAutograd(TestCase):
                 # if forward AD ends up being implemented for torch.igamma, choose a different op
                 torch.igamma(dual_x, dual_x)
 
+    def test_traceable_deprecated(self):
+        class MyFunction(Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x * 2
+
+            @staticmethod
+            def backward(ctx, gO):
+                return gO * 2
+
+        with self.assertWarnsRegex(UserWarning, "is_traceable .*is deprecated"):
+            MyFunction.is_traceable
+
+        with self.assertWarnsRegex(UserWarning, "is_traceable .*is deprecated"):
+            MyFunction.is_traceable = True
+
+        with self.assertWarnsRegex(UserWarning, "is_traceable .*is deprecated"):
+            class MyFunction(Function):
+                is_traceable = True
+
+                @staticmethod
+                def forward(ctx, x):
+                    return x * 2
+
+                @staticmethod
+                def backward(ctx, gO):
+                    return gO * 2
+
+        with self.assertWarnsRegex(UserWarning, "traceable .*is deprecated"):
+            @torch.autograd.function.traceable
+            class MyFunction(Function):
+                is_traceable = True
+
+                @staticmethod
+                def forward(ctx, x):
+                    return x * 2
+
+                @staticmethod
+                def backward(ctx, gO):
+                    return gO * 2
+
     def test_will_engine_execute_node(self):
         counter = [0]
 

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -311,6 +311,12 @@ class BackwardCFunction(_C._FunctionBase, FunctionCtx, _HookMixin):
         return self._forward_cls._compiled_autograd_key(self)  # type: ignore[attr-defined]
 
 
+def warn_traceable_deprecated():
+    warnings.warn(
+        "The is_traceable field on torch.autograd.Function is deprecated "
+        "and will be removed in PyTorch 2.4.",
+        stacklevel=3)
+
 class FunctionMeta(type):
     """Function metaclass.
 
@@ -330,7 +336,23 @@ class FunctionMeta(type):
         )
         cls._backward_cls = backward_fn
 
+        if "is_traceable" in attrs and attrs["is_traceable"] is True:
+            warn_traceable_deprecated()
+
         super().__init__(name, bases, attrs)
+
+    def __getattribute__(cls, name):
+        if name == "is_traceable":
+            warn_traceable_deprecated()
+        return super().__getattribute__(name)
+
+    def __setattr__(cls, name, value):
+        if name == "is_traceable" and value is True:
+            warnings.warn(
+                "The is_traceable field on torch.autograd.Function is deprecated "
+                "and will be removed in PyTorch 2.4.",
+                stacklevel=2)
+        return super().__setattr__(name, value)
 
 
 class _SingleLevelFunction(
@@ -645,6 +667,10 @@ def traceable(fn_cls):
     DON'T USE THIS DECORATOR. IT IS FOR INTERNAL USE ONLY AND SHOULD BE HANDLED WITH
     CARE (or can give incorrect results otherwise).
     """
+    warnings.warn(
+        "torch.autograd.function.traceable is deprecated "
+        "and will be removed in PyTorch 2.4.",
+        stacklevel=2)
     fn_cls.is_traceable = True
     return fn_cls
 

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -315,7 +315,9 @@ def warn_traceable_deprecated():
     warnings.warn(
         "The is_traceable field on torch.autograd.Function is deprecated "
         "and will be removed in PyTorch 2.4.",
-        stacklevel=3)
+        stacklevel=3,
+    )
+
 
 class FunctionMeta(type):
     """Function metaclass.
@@ -351,7 +353,8 @@ class FunctionMeta(type):
             warnings.warn(
                 "The is_traceable field on torch.autograd.Function is deprecated "
                 "and will be removed in PyTorch 2.4.",
-                stacklevel=2)
+                stacklevel=2,
+            )
         return super().__setattr__(name, value)
 
 
@@ -670,7 +673,8 @@ def traceable(fn_cls):
     warnings.warn(
         "torch.autograd.function.traceable is deprecated "
         "and will be removed in PyTorch 2.4.",
-        stacklevel=2)
+        stacklevel=2,
+    )
     fn_cls.is_traceable = True
     return fn_cls
 

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -345,7 +345,7 @@ class FunctionMeta(type):
 
     def __getattribute__(cls, name):
         if name == "is_traceable":
-            warn_traceable_deprecated()
+            _warn_traceable_deprecated()
         return super().__getattribute__(name)
 
     def __setattr__(cls, name, value):

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -311,7 +311,7 @@ class BackwardCFunction(_C._FunctionBase, FunctionCtx, _HookMixin):
         return self._forward_cls._compiled_autograd_key(self)  # type: ignore[attr-defined]
 
 
-def warn_traceable_deprecated():
+def _warn_traceable_deprecated():
     warnings.warn(
         "The is_traceable field on torch.autograd.Function is deprecated "
         "and will be removed in PyTorch 2.4.",
@@ -339,7 +339,7 @@ class FunctionMeta(type):
         cls._backward_cls = backward_fn
 
         if "is_traceable" in attrs and attrs["is_traceable"] is True:
-            warn_traceable_deprecated()
+            _warn_traceable_deprecated()
 
         super().__init__(name, bases, attrs)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121413

- There are no usages of this internally.
- There are very few usages of this in OSS (most of these are forks of old
repositories).
- This flag doesn't do anything.

We're deprecating it to prevent confusion. I will delete it immediately
after the branch cut.

Test Plan:
- new tests