### PR TITLE
Forward fix lint after 121202

### DIFF
--- a/torch/_inductor/fx_passes/fuse_attention.py
+++ b/torch/_inductor/fx_passes/fuse_attention.py
@@ -555,7 +555,7 @@ def _get_sfdp_patterns():
         torch.empty, (1024, 128, 128), device=device, requires_grad=True
     )
 
-    # reshape in matmul decomposition generates a clone when batch_size>1 due to the memory layout change. 
+    # reshape in matmul decomposition generates a clone when batch_size>1 due to the memory layout change.
     # however when batch_size=1, reshape does not change the memory layout, so clone would not be generated.
     # here we need to trace with input of batch_size=1 to generate a pattern graph without clone.
     g_bs1_inp = functools.partial(


### PR DESCRIPTION
Forward fix after #121202, where the lintrunner job failed due to being unable to checkout the pytorch repo

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang