### PR TITLE
[CI] Script to fetch creds from current AWS session

### DIFF
--- a/.github/scripts/get_aws_session_tokens.py
+++ b/.github/scripts/get_aws_session_tokens.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-import boto3
+import boto3  # type: ignore[import]
 
-def main():
-    creds_dict=boto3.Session().get_credentials().get_frozen_credentials()._asdict()
+
+def main() -> None:
+    creds_dict = boto3.Session().get_credentials().get_frozen_credentials()._asdict()
     print(f"export AWS_ACCESS_KEY_ID={creds_dict['access_key']}")
     print(f"export AWS_SECRET_ACCESS_KEY={creds_dict['secret_key']}")
     print(f"export AWS_SESSION_TOKEN={creds_dict['token']}")

--- a/.github/scripts/get_aws_session_tokens.py
+++ b/.github/scripts/get_aws_session_tokens.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+import boto3
+
+def main():
+    creds_dict=boto3.Session().get_credentials().get_frozen_credentials()._asdict()
+    print(f"export AWS_ACCESS_KEY_ID={creds_dict['access_key']}")
+    print(f"export AWS_SECRET_ACCESS_KEY={creds_dict['secret_key']}")
+    print(f"export AWS_SESSION_TOKEN={creds_dict['token']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Because some implementations, like OpenDAL does not work with AWS IMDSv2, but this script will bridge the gap and enables more recent `sccache` releases(that switched from simple-s3 to OpenDAL) to work in current CI system


When launched it prints something like:
```
export AWS_ACCESS_KEY_ID=XXXXX
export AWS_SECRET_ACCESS_KEY=YYYY
export AWS_SESSION_TOKEN=ZZZZ
```
which can be `eval`ed and passed then sccache can use those failures.

Validated in https://github.com/pytorch/pytorch/pull/121323