### PR TITLE
Revert "[PT2D] Make the speedup benchmark works with DDP + CompiledAutograd (#120454)"

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -674,9 +674,8 @@ def speedup_experiment(args, model_iter_fn, model, example_inputs, **kwargs):
             with maybe_mark_profile(p=p, mark="actual"), maybe_enable_compiled_autograd(
                 args.compiled_autograd
             ):
-                compiled_model = kwargs.get("compiled_model", model)
                 timings[rep, 1], actual_output = timed(
-                    compiled_model,
+                    model,
                     frozen_model_iter_fn,
                     inputs,
                     return_result=True,
@@ -741,16 +740,11 @@ def speedup_experiment(args, model_iter_fn, model, example_inputs, **kwargs):
         for k, v in kwargs["dynamo_stats"].items():
             headers.append(k)
             row.append(v)
-    if (
-        not torch.distributed.is_available()  # no distributed is built
-        or not torch.distributed.is_initialized()  # single gpu
-        or torch.distributed.get_rank() == 0  # distributed + rank0
-    ):
-        output_csv(
-            output_filename,
-            headers,
-            row,
-        )
+    output_csv(
+        output_filename,
+        headers,
+        row,
+    )
     headers, data = torch._dynamo.utils.compile_times(repr="csv", aggregate=True)
     assert (
         output_filename.find(".csv") > 0
@@ -2653,15 +2647,10 @@ class BenchmarkRunner:
             return latency, peak_mem, dynamo_stats
 
         # Cast the model to float16/float32 as necessary
-        orig_model, example_inputs = self.maybe_cast(model, example_inputs)
+        model, example_inputs = self.maybe_cast(model, example_inputs)
 
         # Use distributed wrapping as necessary
-        model = self.deepcopy_and_maybe_parallelize(orig_model)
-        if experiment.func is speedup_experiment:
-            # If DDP + compiler is enabled, we need to use a different
-            compiled_model = self.deepcopy_and_maybe_parallelize(orig_model)
-        else:
-            compiled_model = model
+        model = self.deepcopy_and_maybe_parallelize(model)
 
         self.init_optimizer(name, current_device, model.parameters())
         with self.pick_grad(name, self.args.training):
@@ -2685,7 +2674,7 @@ class BenchmarkRunner:
 
             with maybe_enable_compiled_autograd(self.args.compiled_autograd):
                 dynamo_latency, dynamo_peak_mem, dynamo_stats = warmup(
-                    optimized_model_iter_fn, compiled_model, example_inputs, "dynamo"
+                    optimized_model_iter_fn, model, example_inputs, "dynamo"
                 )
 
             compilation_time = dynamo_latency - eager_latency + aot_compilation_time
@@ -2711,10 +2700,10 @@ class BenchmarkRunner:
                 results = []
                 # run with torch._dynamo few times to populate the cache
                 for _ in range(3):
-                    optimized_model_iter_fn(compiled_model, example_inputs)
+                    optimized_model_iter_fn(model, example_inputs)
                 _, frames_second_pass = Stats.reset_counters()  # should be 0
                 if frames_second_pass > 0:
-                    optimized_model_iter_fn(compiled_model, example_inputs)
+                    optimized_model_iter_fn(model, example_inputs)
                     _, frames_third_pass = Stats.reset_counters()  # should be 0
                 else:
                     frames_third_pass = 0
@@ -2730,7 +2719,6 @@ class BenchmarkRunner:
 
             if not hasattr(model, name):
                 model.name = name
-            experiment_kwargs["compiled_model"] = compiled_model
             results.append(experiment(model, example_inputs, **experiment_kwargs))
             return " ".join(map(str, results))
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This reverts commit 8c2e569928a200893fe971e615b82a2f9ce32630.

Reverted https://github.com/pytorch/pytorch/pull/120454 on behalf of https://github.com/desertfire due to breaks nightly dashboard cudagraphs run ([comment](https://github.com/pytorch/pytorch/pull/120454#issuecomment-1975001824))

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang