### PR TITLE
[inductor] add decompostition for mm in backward (#120933)

### DIFF
--- a/test/inductor/test_decompose_mem_bound_mm.py
+++ b/test/inductor/test_decompose_mem_bound_mm.py
@@ -37,6 +37,15 @@ class MyModule2(torch.nn.Module):
         return output
 
 
+class MyModule3(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input1, input2):
+        output = torch.mm(input1, input2)
+        return output
+
+
 @requires_cuda
 @torch._inductor.config.patch(
     decompose_mem_bound_mm=True,
@@ -147,6 +156,53 @@ class TestDecomposeMemMM(TestCase):
 
         self.assertEqual(
             counters["inductor"]["decompose_mm"] - decompose_mm_fwd,
+            expected_val,
+        )
+        self.assertEqual(
+            counters["inductor"]["decompose_mmt"],
+            expected_val,
+        )
+        counters.clear()
+
+    @parametrize(
+        "m,k,n, should_decompose",
+        [(20480, 5, 2, True), (20480, 32, 2, False), (2048, 2, 2, False)],
+    )
+    @parametrize("has_bias", [True, False])
+    def test_decompose_mm(self, m, n, k, has_bias, should_decompose):
+        torch._logging.set_logs(inductor=logging.DEBUG)
+        mat1 = torch.randn(m, k, device="cuda").requires_grad_(True)
+        mat2 = torch.randn(k, n, device="cuda").requires_grad_(True)
+
+        counters.clear()
+
+        module = MyModule3().to("cuda")
+        traced = torch.compile(module)
+        input = [mat1, mat2]
+        ref = module(*input)
+        res = traced(*input)
+
+        self.compare_pred(module, traced, input)
+
+        expected_val = 1 if should_decompose else 0
+        self.assertEqual(
+            counters["inductor"]["decompose_mm"],
+            expected_val,
+        )
+        decompose_mm_fwd = counters["inductor"]["decompose_mm"]
+
+        ref.sum().backward()
+        res.sum().backward()
+        self.compare_parameters(module, traced)
+        self.compare_gradients(module, traced)
+
+        expected_val = 1 if should_decompose else 0
+        self.assertEqual(
+            counters["inductor"]["decompose_mm"] - decompose_mm_fwd,
+            expected_val,
+        )
+        self.assertEqual(
+            counters["inductor"]["decompose_mm_large_k"],
             expected_val,
         )
         counters.clear()

--- a/torch/_inductor/fx_passes/decompose_mem_bound_mm.py
+++ b/torch/_inductor/fx_passes/decompose_mem_bound_mm.py
@@ -1,4 +1,5 @@
-from typing import Optional
+import logging
+from typing import List, Optional
 
 import torch
 from torch import Tensor
@@ -9,12 +10,14 @@ from ..pattern_matcher import (
     Arg,
     CallFunction,
     config_flag,
+    Ignored,
     Match,
     register_graph_pattern,
 )
 from .post_grad import decompose_mm_pass
 
 aten = torch.ops.aten
+log = logging.getLogger(__name__)
 
 # TODO: need a better strategy for decomposing mm
 MIN_FIRST_DIMENSION_DECOMPOSITION = 10240
@@ -36,8 +39,11 @@ def should_decompose_common(
 
 
 def should_decompose_bmm(mat1, mat2) -> bool:
-    mat1 = mat1.meta["val"]
-    mat2 = mat2.meta["val"]
+    if is_node_meta_valid(mat1) and is_node_meta_valid(mat2):
+        mat1 = mat1.meta["val"]
+        mat2 = mat2.meta["val"]
+    else:
+        return False
     if not should_decompose_common(mat1, mat2):
         return False
     else:
@@ -54,8 +60,11 @@ def should_decompose_bmm(mat1, mat2) -> bool:
 
 
 def should_decompose_mm(mat1, mat2) -> bool:
-    mat1 = mat1.meta["val"]
-    mat2 = mat2.meta["val"]
+    if is_node_meta_valid(mat1) and is_node_meta_valid(mat2):
+        mat1 = mat1.meta["val"]
+        mat2 = mat2.meta["val"]
+    else:
+        return False
     return (
         should_decompose_common(mat1, mat2)
         and len(mat1.shape) == 2
@@ -63,6 +72,54 @@ def should_decompose_mm(mat1, mat2) -> bool:
         and mat1.shape[0] >= MIN_FIRST_DIMENSION_DECOMPOSITION
         and mat2.shape[0] < MAX_OTHER_DIMENSION_DECOMPOSITION
         and mat2.shape[1] < MAX_OTHER_DIMENSION_DECOMPOSITION
+    )
+
+
+def should_decompose_mmt(mat1, mat2) -> bool:
+    if is_node_meta_valid(mat1) and is_node_meta_valid(mat2):
+        mat1 = mat1.meta["val"]
+        mat2 = mat2.meta["val"]
+    else:
+        return False
+    return (
+        should_decompose_common(mat1, mat2)
+        and len(mat1.shape) == 2
+        and len(mat2.shape) == 2
+        and mat1.shape[0] >= MIN_FIRST_DIMENSION_DECOMPOSITION
+        and mat1.shape[1] < MAX_OTHER_DIMENSION_DECOMPOSITION
+        and mat2.shape[1] < MAX_OTHER_DIMENSION_DECOMPOSITION
+    )
+
+
+def should_decompose_mm_largek(mat1, mat2) -> bool:
+    if is_node_meta_valid(mat1) and is_node_meta_valid(mat2):
+        mat1 = mat1.meta["val"]
+        mat2 = mat2.meta["val"]
+    else:
+        return False
+    return (
+        should_decompose_common(mat1, mat2)
+        and len(mat1.shape) == 2
+        and len(mat2.shape) == 2
+        and mat1.shape[1] >= MIN_FIRST_DIMENSION_DECOMPOSITION
+        and mat1.shape[0] < MAX_OTHER_DIMENSION_DECOMPOSITION
+        and mat2.shape[1] < MAX_OTHER_DIMENSION_DECOMPOSITION
+    )
+
+
+def is_node_meta_valid(node: torch.fx.Node):
+    return "val" in node.meta
+
+
+def print_decompose_pattern(match: Match, inputs: List[torch.fx.Node]):
+    node = match.nodes[-1]
+    log.debug(
+        "Decompose %s with input shape: %s",
+        node.target,
+        ", ".join(
+            str(input.meta["val"].shape) if "val" in input.meta else "None"
+            for input in inputs
+        ),
     )
 
 
@@ -78,6 +135,7 @@ def decompose_bmm(match: Match, mat1: torch.fx.Node, mat2: torch.fx.Node):
     if should_decompose_bmm(mat1, mat2):
         counters["inductor"]["decompose_bmm"] += 1
         match.replace_by_example(repl, [mat1, mat2])
+        print_decompose_pattern(match, [mat1, mat2])
     return
 
 
@@ -98,6 +156,27 @@ def decompose_addmm(
     if should_decompose_mm(mat2, mat3):
         counters["inductor"]["decompose_addmm"] += 1
         match.replace_by_example(repl, [mat1, mat2, mat3])
+        print_decompose_pattern(match, [mat1, mat2, mat3])
+    return
+
+
+@register_graph_pattern(
+    CallFunction(aten.mm, CallFunction(aten.permute, Arg(), Ignored()), Arg()),
+    pass_dict=decompose_mm_pass,
+    extra_check=config_flag("decompose_mem_bound_mm"),
+)
+def decompose_mmt(
+    match: Match,
+    mat1: torch.fx.Node,
+    mat2: torch.fx.Node,
+):
+    def repl(mat1, mat2):
+        return torch.sum(mat1[:, :, None] * mat2[:, None, :], dim=0)
+
+    if should_decompose_mmt(mat1, mat2):
+        counters["inductor"]["decompose_mmt"] += 1
+        match.replace_by_example(repl, [mat1, mat2])
+        print_decompose_pattern(match, [mat1, mat2])
     return
 
 
@@ -117,4 +196,26 @@ def decompose_mm(
     if should_decompose_mm(mat1, mat2):
         counters["inductor"]["decompose_mm"] += 1
         match.replace_by_example(repl, [mat1, mat2])
+        print_decompose_pattern(match, [mat1, mat2])
+    return
+
+
+@register_graph_pattern(
+    CallFunction(aten.mm, Arg(), Arg()),
+    pass_dict=decompose_mm_pass,
+    extra_check=config_flag("decompose_mem_bound_mm"),
+)
+def decompose_mm_large_k(
+    match: Match,
+    mat1: torch.fx.Node,
+    mat2: torch.fx.Node,
+):
+    def repl(mat1, mat2):
+        mat1 = mat1.permute(1, 0)
+        return torch.sum(mat1[:, :, None] * mat2[:, None, :], dim=0)
+
+    if should_decompose_mm_largek(mat1, mat2):
+        counters["inductor"]["decompose_mm_large_k"] += 1
+        match.replace_by_example(repl, [mat1, mat2])
+        print_decompose_pattern(match, [mat1, mat2])
     return


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Summary:
1) As a follow up in D53602514. Found a new way to decompose mm in backward. Sum the permuted input and reduce along 0 dim. Some benchmark result P1190140001. 30x speedup
Some explanations on why the original mm decomposition is slow. For mxkxn mm, when m is small and k is large, the stride for lhs is [m,1], hence it need to access memory k times to load all the data. As a result, decomposition will be effective with permute since the stride will be [k,1].

2) add another pattern for large k. benchmark result P1190596489 28x speedup

3) fix the value not found error in ig ctr. f536115499

Test Plan:
pt2 decompose:

 {F1462894821}
decompose: f536159404
baseline: f536282578
705k vs 725k 4% for ig ctr

Differential Revision: D54294491
Approved by: https://github.com/mengluy0125

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang