### PR TITLE
[pt2] add symbolic shape support for decompose mm and expose max_block to user config

### DIFF
--- a/torch/_inductor/fx_passes/decompose_mem_bound_mm.py
+++ b/torch/_inductor/fx_passes/decompose_mem_bound_mm.py
@@ -4,7 +4,6 @@ from typing import List, Optional
 import torch
 from torch import Tensor
 from torch._dynamo.utils import counters
-from torch._inductor import utils
 
 from ..pattern_matcher import (
     Arg,
@@ -31,11 +30,7 @@ def check_device(a: Tensor, b: Tensor) -> bool:
 def should_decompose_common(
     mat1: Tensor, mat2: Tensor, input: Optional[Tensor] = None
 ) -> bool:
-    return (
-        torch._inductor.config.decompose_mem_bound_mm
-        and check_device(mat1, mat2)
-        and not utils.any_is_symbolic(mat1, mat2, input)
-    )
+    return torch._inductor.config.decompose_mem_bound_mm and check_device(mat1, mat2)
 
 
 def should_decompose_bmm(mat1, mat2) -> bool:


### PR DESCRIPTION
Summary:
1) As described in https://fb.workplace.com/groups/1075192433118967/permalink/1381918665779674/
As a follow up, we can increase max_block["y"] to sovle the issue
2) add symbolic shape support for decompose mm pass. I did not find a good way to compare symint with int. So when there is a symbolic shape, i would assume it is a "large" dim.

Test Plan:
Without change block: aps-pt2-7c23cea900

increase y_block: aps-pt2_dynamic_shape-25a027423c

Differential Revision: D54525453




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang