### PR TITLE
Revert "[fake_impls] fix max_seqlen return values in efficient_attention_forward (#120842)"

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2244,7 +2244,6 @@ class TestFakeTensor(TestCase):
                 ):
                     if not isinstance(fake_out, torch.Tensor):
                         self.assertTrue(not isinstance(real_out, torch.Tensor))
-                        self.assertEqual(fake_out, real_out)
                         continue
 
                     self.assertTrue(isinstance(fake_out, FakeTensor))

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -804,9 +804,8 @@ def meta__efficient_attention_forward(fake_mode, func, *args, **kwargs):
     value = kwargs["value"]
     cu_seqlens_q = kwargs["cu_seqlens_q"]
     max_seqlen_q = kwargs["max_seqlen_q"]
-    max_seqlen_k = kwargs["max_seqlen_k"]
     compute_log_sumexp = kwargs["compute_log_sumexp"]
-    # unused: bias, cu_seqlens_k, dropout_p, custom_mask_type, scale, causal_diagonal, seqlen_k
+    # unused: bias, cu_seqlens_k, max_seqlen_k, dropout_p, custom_mask_type, scale, causal_diagonal, seqlen_k
 
     def convert_tensor(t, device):
         return FakeTensor(fake_mode, t, device)
@@ -828,7 +827,6 @@ def meta__efficient_attention_forward(fake_mode, func, *args, **kwargs):
     if cu_seqlens_q is not None:
         assert max_seqlen_q is not None
         actual_max_seqlen_q = max_seqlen_q
-    actual_max_seqlen_k = max_seqlen_k if max_seqlen_k is not None else N
     logsumexp_dim = (
         math.ceil(actual_max_seqlen_q / 32) * 32 if compute_log_sumexp else 0
     )
@@ -845,7 +843,7 @@ def meta__efficient_attention_forward(fake_mode, func, *args, **kwargs):
     seed = convert_tensor(torch.empty((), dtype=torch.long, device="meta"), "cpu")
     offset = convert_tensor(torch.empty((), dtype=torch.long, device="meta"), "cpu")
 
-    return res, logsum_exp, seed, offset, actual_max_seqlen_q, actual_max_seqlen_k
+    return res, logsum_exp, seed, offset, M, N
 
 
 FAST_OP_IMPLEMENTATIONS = {}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121442

This reverts commit df1e8553130e84fd259cc1949d14568afb51ef31.

It regresses cuda graphs performance for sdpa.