### PR TITLE
[C10d][UCC] Retain CUDA context in progress_loop

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupUCC.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupUCC.cpp
@@ -1,5 +1,6 @@
 #ifdef USE_C10D_UCC
 
+#include <ATen/cuda/nvrtc_stub/ATenNVRTC.h>
 #include <torch/csrc/distributed/c10d/ProcessGroupUCC.hpp>
 #include <torch/csrc/distributed/c10d/UCCTracing.hpp>
 #include <torch/csrc/distributed/c10d/UCCUtils.hpp>
@@ -528,6 +529,12 @@ void Comm::progress_loop() {
 #ifdef USE_CUDA
     if ((!device_set) && (cuda_device_index != TORCH_UCC_DEVICE_NOT_SET)) {
       c10::cuda::set_device(cuda_device_index);
+      CUcontext pctx = nullptr;
+      at::globalContext().getNVRTC().cuCtxGetCurrent(&pctx);
+      if (C10_UNLIKELY(!pctx)) {
+        at::globalContext().getNVRTC().cuDevicePrimaryCtxRetain(&pctx, cuda_device_index);
+        at::globalContext().getNVRTC().cuCtxSetCurrent(pctx);
+      }
       device_set = true;
     }
 #endif

--- a/torch/csrc/distributed/c10d/ProcessGroupUCC.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupUCC.cpp
@@ -532,7 +532,8 @@ void Comm::progress_loop() {
       CUcontext pctx = nullptr;
       at::globalContext().getNVRTC().cuCtxGetCurrent(&pctx);
       if (C10_UNLIKELY(!pctx)) {
-        at::globalContext().getNVRTC().cuDevicePrimaryCtxRetain(&pctx, cuda_device_index);
+        at::globalContext().getNVRTC().cuDevicePrimaryCtxRetain(
+            &pctx, cuda_device_index);
         at::globalContext().getNVRTC().cuCtxSetCurrent(pctx);
       }
       device_set = true;


### PR DESCRIPTION
UCC requires CUDA context be present, while `progress_loop` https://github.com/pytorch/pytorch/blob/f61192b014647947b52371bb03368b66694f5a34/torch/csrc/distributed/c10d/ProcessGroupUCC.cpp#L333 runs on the side thread and it does not have context present (even though it sets the device).

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang