### PR TITLE
Revert "[fake_impls] Fix seed/offset device for attention kernels (#120839)"

### DIFF
--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -666,8 +666,8 @@ def meta__scaled_dot_product_flash(fake_mode, func, *args, **kwargs):
         None,
         max_seqlen_batch_q,
         max_seqlen_batch_k,
-        convert_tensor(torch.empty((), dtype=torch.long, device="meta"), "cpu"),
-        convert_tensor(torch.empty((), dtype=torch.long, device="meta"), "cpu"),
+        convert_tensor(torch.empty((), dtype=torch.long, device="meta"), query.device),
+        convert_tensor(torch.empty((), dtype=torch.long, device="meta"), query.device),
         debug_mask,
     )
 
@@ -716,8 +716,12 @@ def meta__scaled_dot_product_efficient(fake_mode, func, *args, **kwargs):
     res = res.transpose(1, 2)
 
     # See Note [Seed and Offset]:
-    seed = convert_tensor(torch.empty((), dtype=torch.long, device="meta"), "cpu")
-    offset = convert_tensor(torch.empty((), dtype=torch.long, device="meta"), "cpu")
+    seed = convert_tensor(
+        torch.empty((), dtype=torch.long, device="meta"), query.device
+    )
+    offset = convert_tensor(
+        torch.empty((), dtype=torch.long, device="meta"), query.device
+    )
 
     return res, logsum_exp, seed, offset
 
@@ -787,8 +791,8 @@ def meta__flash_attention_forward(fake_mode, func, *args, **kwargs):
     return (
         attention,
         logsumexp,
-        convert_tensor(torch.empty((), dtype=torch.long, device="meta"), "cpu"),
-        convert_tensor(torch.empty((), dtype=torch.long, device="meta"), "cpu"),
+        convert_tensor(torch.empty((), dtype=torch.long, device="meta"), query.device),
+        convert_tensor(torch.empty((), dtype=torch.long, device="meta"), query.device),
         debug_mask,
     )
 
@@ -842,8 +846,12 @@ def meta__efficient_attention_forward(fake_mode, func, *args, **kwargs):
     )
 
     # See Note [Seed and Offset]:
-    seed = convert_tensor(torch.empty((), dtype=torch.long, device="meta"), "cpu")
-    offset = convert_tensor(torch.empty((), dtype=torch.long, device="meta"), "cpu")
+    seed = convert_tensor(
+        torch.empty((), dtype=torch.long, device="meta"), query.device
+    )
+    offset = convert_tensor(
+        torch.empty((), dtype=torch.long, device="meta"), query.device
+    )
 
     return res, logsum_exp, seed, offset, actual_max_seqlen_q, actual_max_seqlen_k
 

--- a/torch/_subclasses/fake_utils.py
+++ b/torch/_subclasses/fake_utils.py
@@ -47,6 +47,28 @@ def output_alias_each_other(outputs):
     return False
 
 
+def is_sdpa_error(func, idx, e):
+    if (
+        (
+            func is aten._scaled_dot_product_flash_attention.default
+            or func is aten._flash_attention_forward.default
+        )
+        and idx in (6, 7)
+        and "Devices" in repr(e)
+    ):
+        return True
+    if (
+        (
+            func is aten._scaled_dot_product_efficient_attention.default
+            or func is aten._efficient_attention_forward.default
+        )
+        and idx in (2, 3)
+        and "Devices" in repr(e)
+    ):
+        return True
+    return False
+
+
 class CrossRefFakeMode(TorchDispatchMode):
     def __init__(
         self,
@@ -157,6 +179,8 @@ class CrossRefFakeMode(TorchDispatchMode):
                             allow_rhs_unbacked=True,
                         )
                     except Exception as e:
+                        if is_sdpa_error(func, idx, e):
+                            continue
                         error_message = (
                             f"{context} mismatched tensor metadata: {e}"
                             if len(r_flat) == 1

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14456,11 +14456,9 @@ op_db: List[OpInfo] = [
         check_batched_forward_grad=False,
         decorators=[skipCUDAIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "This platform doesn't support Flash Attention")],
         skips=(
-            # ROCM fails stride order
-            DecorateInfo(unittest.expectedFailure, "TestFakeTensor", "test_fake_autocast", device_type="cuda",
-                         dtypes=[torch.float16, torch.bfloat16], active_if=TEST_WITH_ROCM and PLATFORM_SUPPORTS_FLASH_ATTENTION),
-            DecorateInfo(unittest.expectedFailure, "TestFakeTensor", "test_fake", device_type="cuda",
-                         dtypes=[torch.float16, torch.bfloat16], active_if=TEST_WITH_ROCM and PLATFORM_SUPPORTS_FLASH_ATTENTION),
+            # Device mismatch due to philox seed and offset
+            DecorateInfo(unittest.expectedFailure, 'TestFakeTensor', 'test_fake_autocast', device_type='cuda'),
+            DecorateInfo(unittest.expectedFailure, 'TestFakeTensor', 'test_fake', device_type='cuda'),
             # meta implementation is in fake_impls.py instead of being a meta registration
             DecorateInfo(unittest.expectedFailure, "TestMeta", "test_meta_inplace"),
             DecorateInfo(unittest.expectedFailure, "TestMeta", "test_meta_outplace"),
@@ -14497,6 +14495,9 @@ op_db: List[OpInfo] = [
         supports_cow_input_no_materialize=False,
         decorators=[skipCUDAIf(TEST_WITH_ROCM, "ROCm doesn't support efficient attention")],
         skips=(
+            # Device mismatch due to philox seed and offset
+            DecorateInfo(unittest.expectedFailure, 'TestFakeTensor', 'test_fake_autocast', device_type='cuda'),
+            DecorateInfo(unittest.expectedFailure, 'TestFakeTensor', 'test_fake', device_type='cuda'),
             # meta implementation is in fake_impls.py instead of being a meta registration
             DecorateInfo(unittest.expectedFailure, "TestMeta", "test_meta_inplace"),
             DecorateInfo(unittest.expectedFailure, "TestMeta", "test_meta_outplace"),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121447

This reverts commit df3c8b8390bc601072b0ee9b2c39e07adf370fe2.

It regressed cudagraphs+PT2 performance on SDPA.