### PR TITLE
[torch export] replace traceback.extract_stack with CapturedTraceback.extract

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -8,7 +8,6 @@ import random
 import sys
 import threading
 import time
-import traceback
 import types
 import typing
 import weakref
@@ -17,6 +16,7 @@ from typing import Any, Callable, Dict, List, Optional, Set
 from torch.fx._lazy_graph_module import (  # type: ignore[attr-defined]
     _use_lazy_graph_module,
 )
+from torch.utils._traceback import CapturedTraceback
 
 try:
     import numpy as np
@@ -656,14 +656,14 @@ def _compile(
             code.co_firstlineno,
             skip + 2,
             # -2: omit current frame, omit contextlib decorator
-            "".join(traceback.format_list(traceback.extract_stack()[: -2 - skip])),
+            "".join(CapturedTraceback.extract(skip=2 + skip).format()),
         )
         # -4: -2 as above, plus trace_structured frames
         torch._logging.trace_structured(
             "dynamo_start",
             lambda: {
                 "stack": structured.from_traceback(
-                    traceback.extract_stack()[: -4 - skip]
+                    CapturedTraceback.extract(skip=4 + skip).summary()
                 )
             },
         )
@@ -883,9 +883,11 @@ def catch_errors_wrapper(callback, hooks: Hooks):
                 skip_reason = (
                     "traced frame already"
                     if frame.f_lasti >= first_real_inst_idx(frame.f_code)
-                    else "in skipfiles"
-                    if trace_rules.check(frame.f_code)
-                    else "dynamo tracing is disabled"
+                    else (
+                        "in skipfiles"
+                        if trace_rules.check(frame.f_code)
+                        else "dynamo tracing is disabled"
+                    )
                 )
                 if not is_skipfile or config.verbose:
                     log.debug(

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -35,9 +35,9 @@ from torch.utils._python_dispatch import (
     is_traceable_wrapper_subclass,
     TorchDispatchMode,
 )
-
 from torch.utils._pytree import PyTree, tree_map
 from torch.utils._stats import count
+from torch.utils._traceback import CapturedTraceback
 from torch.utils.weak import WeakIdRef
 
 if TYPE_CHECKING:
@@ -499,11 +499,8 @@ class FakeTensor(torch.Tensor):
         self.constant = constant  # type: ignore[attr-defined]
         self._nonzero_memo = None  # type: ignore[attr-defined]
         self._nonzero_memo_vc = None  # type: ignore[attr-defined]
-
         if FakeTensorConfig.debug:
-            import traceback
-
-            self._debug_trace = traceback.extract_stack()  # type: ignore[attr-defined]
+            self._debug_trace = CapturedTraceback.extract()  # type: ignore[attr-defined]
         return self
 
     # In some circumstances, a conventional torch.Tensor constructor

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -7,13 +7,13 @@ import sys
 import torch
 import inspect
 import operator
-import traceback
 import collections
 
 from dataclasses import is_dataclass, fields
 
 
 from .graph import magic_methods, reflectable_magic_methods, Graph
+from torch.utils._traceback import CapturedTraceback
 from typing import Tuple, Dict, OrderedDict, Optional, Any, Iterator, Callable
 from .node import Target, Node, Argument, base_types, map_aggregate
 from ._compatibility import compatibility
@@ -197,12 +197,8 @@ class TracerBase:
             proxy = proxy_factory_fn(node)
 
         if self.record_stack_traces and not proxy.node.stack_trace:
-            user_frame = self._find_user_frame()
-            if user_frame:
-                summary = traceback.extract_stack(user_frame)
-                tb_lines = summary.format()
-                # stack_trace would have innermost frame at the bottom
-                proxy.node.stack_trace = ''.join(tb_lines)
+            proxy.node.stack_trace = ''.join(CapturedTraceback.extract().format())
+
 
         return proxy
 


### PR DESCRIPTION
Summary:
with a simple bench in TestDeserializer.test_basic function: 
```
time_start = time.time()
for i in range(1000):
    self.check_graph(MyModule(), inputs)
warnings.warn(f"time_taken: {time.time() - time_start}")
```
and forcing FakeTensorConfig.debug to True, record_stack_traces to True, logging level to debug, it shows that the the changed code is consistently ard 20 secs faster (~90s vs originally ~110s)

Test Plan:
test passed, see summary

compared debug trace before and after: 
- exactly the same for fake tensor and proxy callsite https://www.internalfb.com/intern/diffing/?paste_number=1189883685
- slightly different for the user frame in proxy node https://www.internalfb.com/intern/diffing/?paste_number=1189884347

Differential Revision: D54237017




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang