### PR TITLE
Disable GroupRegistry's thread isolation by default

### DIFF
--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -1,8 +1,10 @@
 # Owner(s): ["module: c10d"]
+import threading
 import unittest
 from typing import List
 
 import torch
+
 import torch.distributed as dist
 import torch.distributed._functional_collectives as funcol
 from torch._C import FileCheck
@@ -54,7 +56,7 @@ if not dist.is_available():
 
 
 @requires_nccl()
-class C10DFunctionalNativeTest(MultiProcessTestCase):
+class TestWithNCCL(MultiProcessTestCase):
     def setUp(self) -> None:
         super().setUp()
         self._spawn_processes()
@@ -379,8 +381,51 @@ class C10DFunctionalNativeTest(MultiProcessTestCase):
             "default",
         )
 
+    @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
+    @skip_if_lt_x_gpu(2)
+    @fresh_inductor_cache()
+    @run_with_native_funcol
+    def test_threading(self):
+        self._init_process_group()
+        device = torch.device(f"cuda:{self.rank}")
 
-class C10DFunctionalNativeCompileTest(TestCase):
+        def func(arg: torch.Tensor) -> torch.Tensor:
+            buf0 = arg + 42
+            ar0 = funcol.all_reduce(buf0, "avg", "0")
+            ar0 = funcol.wait_tensor(ar0)
+            return ar0 + 1
+
+        arg = torch.rand(4, 4, device=device)
+        func(arg)
+
+        compiled = torch.compile(func, fullgraph=True)
+        code = run_and_get_triton_code(compiled, arg)
+        FileCheck().check("all_reduce_.default(buf0, 'avg', '0')").run(code)
+
+        # Unless explicitly specified (e.g. in a custom runtime), the process
+        # group registry is shared among all threads in a process. Here we
+        # verify that a process group registered in main thread can be resolved
+        # in a different thread.
+        class TestThread(threading.Thread):
+            def run(self):
+                self.exc = None
+                try:
+                    func(arg)
+                    compiled(arg)
+                except BaseException as exc:
+                    self.exc = exc
+
+            def join(self):
+                threading.Thread.join(self)
+                if self.exc:
+                    raise self.exc
+
+        t = TestThread()
+        t.start()
+        t.join()
+
+
+class CompileTest(TestCase):
     def setUp(self):
         # Allow testing aoti after torch.compile
         torch._inductor.config.triton.store_cubin = True

--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -63,6 +63,26 @@ class WorkRegistry {
   std::mutex lock_;
 };
 
+static WorkRegistry process_registry;
+
+void register_work(
+    const at::Tensor& tensor,
+    c10::intrusive_ptr<c10d::Work> work) {
+  if (c10d::get_thread_isolation_mode()) {
+    c10d::RankLocal<WorkRegistry>::get().register_work(tensor, work);
+  } else {
+    process_registry.register_work(tensor, work);
+  }
+}
+
+c10::intrusive_ptr<c10d::Work> pop_work(const at::Tensor& tensor) {
+  if (c10d::get_thread_isolation_mode()) {
+    return c10d::RankLocal<WorkRegistry>::get().pop_work(tensor);
+  } else {
+    return process_registry.pop_work(tensor);
+  }
+}
+
 const std::unordered_map<std::string, c10d::ReduceOp> str_to_reduce_op = {
     {"sum", c10d::ReduceOp(c10d::ReduceOp::RedOpType::SUM)},
     {"avg", c10d::ReduceOp(c10d::ReduceOp::RedOpType::AVG)},

--- a/torch/csrc/distributed/c10d/GroupRegistry.cpp
+++ b/torch/csrc/distributed/c10d/GroupRegistry.cpp
@@ -57,23 +57,50 @@ class GroupRegistry {
 
 namespace c10d {
 
+static bool thread_isolation_mode = false;
+static GroupRegistry process_registry;
+
+void set_thread_isolation_mode(bool enable) {
+  thread_isolation_mode = enable;
+}
+
+bool get_thread_isolation_mode() {
+  return thread_isolation_mode;
+}
+
 void register_process_group(
     const std::string& group_name,
     c10::intrusive_ptr<c10d::ProcessGroup> group) {
-  RankLocal<::GroupRegistry>::get().register_group(group_name, group);
+  if (thread_isolation_mode) {
+    RankLocal<::GroupRegistry>::get().register_group(group_name, group);
+  } else {
+    process_registry.register_group(group_name, group);
+  }
 }
 
 c10::intrusive_ptr<c10d::ProcessGroup> resolve_process_group(
     const std::string& group_name) {
-  return RankLocal<::GroupRegistry>::get().resolve_group(group_name);
+  if (thread_isolation_mode) {
+    return RankLocal<::GroupRegistry>::get().resolve_group(group_name);
+  } else {
+    return process_registry.resolve_group(group_name);
+  }
 }
 
 void unregister_process_group(const std::string& group_name) {
-  return RankLocal<::GroupRegistry>::get().unregister_group(group_name);
+  if (thread_isolation_mode) {
+    RankLocal<::GroupRegistry>::get().unregister_group(group_name);
+  } else {
+    process_registry.unregister_group(group_name);
+  }
 }
 
 void unregister_all_process_groups() {
-  return RankLocal<::GroupRegistry>::get().unregister_all_groups();
+  if (thread_isolation_mode) {
+    RankLocal<::GroupRegistry>::get().unregister_all_groups();
+  } else {
+    process_registry.unregister_all_groups();
+  }
 }
 
 } // namespace c10d

--- a/torch/csrc/distributed/c10d/GroupRegistry.hpp
+++ b/torch/csrc/distributed/c10d/GroupRegistry.hpp
@@ -4,6 +4,10 @@
 
 namespace c10d {
 
+void set_thread_isolation_mode(bool enable);
+
+bool get_thread_isolation_mode();
+
 C10_EXPORT void register_process_group(
     const std::string& group_name,
     c10::intrusive_ptr<c10d::ProcessGroup> group);

--- a/torch/csrc/distributed/c10d/GroupRegistry.hpp
+++ b/torch/csrc/distributed/c10d/GroupRegistry.hpp
@@ -4,7 +4,7 @@
 
 namespace c10d {
 
-void set_thread_isolation_mode(bool enable);
+C10_EXPORT void set_thread_isolation_mode(bool enable);
 
 bool get_thread_isolation_mode();
 

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -843,6 +843,11 @@ This class does not support ``__members__`` property.)");
           py::return_value_policy::copy, // seems safest
           py::call_guard<py::gil_scoped_release>());
 
+  module.def(
+      "_set_thread_isolation_mode",
+      &::c10d::set_thread_isolation_mode,
+      py::arg("enable"));
+
   // Bindings for GroupRegistry.hpp
   //
   // Register a process group in the native registry. Process groups registered

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -1029,6 +1029,7 @@ class MultiThreadedTestCase(TestCase):
         """
         Run the current test associated with `test_name` using the threaded process group.
         """
+        torch._C._distributed_c10d._set_thread_isolation_mode(True)
         c10d.init_process_group(
             backend="threaded", rank=rank, world_size=world_size, store=self.__class__.global_store
         )
@@ -1042,6 +1043,7 @@ class MultiThreadedTestCase(TestCase):
         finally:
             c10d.destroy_process_group()
             self.perThreadTearDown()
+            torch._C._distributed_c10d._set_thread_isolation_mode(False)
 
 
     @classmethod


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121457

Today `GroupRegistry` employs thread isolation by default, i.e. every thread sees its own process group registry. This is intended to work for one-device-per-process (for python use cases) and one-device-per-thread case (for custom native runtimes).

However, there's a problem - there are python use cases that initializes/registers process groups in one thread, and runs collectives in another thread. This use case should be supported. However, since `GroupRegistry` employs thread isolation by default, collectives in different threads can't find the registered process groups.

This PR fixes the issue by:
- Make `GroupRegistry` work in non-thread isolation mode by default. This would match the behavior w/o the native process group registry.
- Introduces `set_thread_isolation_mode` so one-device-per-thread runtimes can enable thread isolation mode explicitly.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang

Differential Revision: [D54658515](https://our.internmc.facebook.com/intern/diff/D54658515)