### PR TITLE
fix accidental specialization with faketensor input checks

### DIFF
--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -87,11 +87,14 @@ def _check_input_constraints_for_graph(
                                 f"{existing_dim}, but got {arg_dim}",
                             )
                     else:
-                        if isinstance(arg_dim, torch.SymInt) and isinstance(
-                            node_dim.node.expr, sympy.Symbol
+                        if (
+                            isinstance(arg_dim, torch.SymInt)
+                            and not arg_dim.node.expr.is_number
                         ):
-                            # this can happen when, say, arg is a fake tensor
-                            unification_map[symbol] = arg_dim
+                            # This can happen when, say, arg is a fake tensor.
+                            # We do not run checks on symbolic shapes of fake inputs as
+                            # such checks can affect the shape env.
+                            pass
                         else:
                             solution = try_solve(
                                 sympy.Eq(node_dim.node.expr, arg_dim), symbol


### PR DESCRIPTION
Summary: When fake tensors are passed to a graph module and we do runtime assertions on them, we can accidentally trigger specialization guards. It's better to just relax the checking for these.

Test Plan: confirmed that problem in T181400371 is now fixed

Differential Revision: D54658960
