### PR TITLE
Register COLLECTIVE_COMM profiler activity type, if available

### DIFF
--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -203,6 +203,14 @@ class ExperimentalConfigWrapper {
 };
 } // namespace
 
+bool collectivesProfilerExists() {
+#ifdef KINETO_HAS_NCCL_PROFILER
+  return true;
+#else
+  return false;
+#endif
+}
+
 void prepareTrace(
     const bool cpuOnly,
     const ActivitySet& activities,
@@ -236,6 +244,9 @@ void prepareTrace(
       LOG(INFO) << "Enabling CUDA Sync Events";
       k_activities.insert(libkineto::ActivityType::CUDA_SYNC);
     }
+  }
+  if (collectivesProfilerExists()) {
+    k_activities.insert(libkineto::ActivityType::COLLECTIVE_COMM);
   }
 
   ExperimentalConfigWrapper configWrap(config);

--- a/torch/csrc/profiler/kineto_shim.h
+++ b/torch/csrc/profiler/kineto_shim.h
@@ -125,6 +125,7 @@ void pushUserCorrelationId(uint64_t correlation_id);
 void popCorrelationId();
 void popUserCorrelationId();
 void recordThreadInfo();
+bool collectivesProfilerExists();
 
 void logInvariantViolation(
     const std::string& assertion,


### PR DESCRIPTION
**Summary:**
Instantiate a collective communications profiler. If a collectives profiler exists then add COLLECTIVE_COMM activity type to the CUDA activity types.

**Test Plan:**
Sample output trace (**internal** use only): https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/traces/clientAPI/0/1707520266/devgpu007.pci1/nccl_activities_2643654_1707520266977.json.gz&bucket=gpu_traces