### PR TITLE
[c10d] Deprecate torch.distributed.pipeline

### DIFF
--- a/docs/source/pipeline.rst
+++ b/docs/source/pipeline.rst
@@ -8,7 +8,10 @@ Pipeline parallelism was original introduced in the
 technique to train large models on multiple GPUs.
 
 .. warning ::
-     Pipeline Parallelism is experimental and subject to change.
+     torch.distributed.pipeline is deprecated, so is this document. For
+     up-to-date pipeline parallel implementation, please refer to the
+     `PiPPy <https://github.com/pytorch/PiPPy>`__ library under the PyTorch
+     organization (Pipeline Parallelism for PyTorch).
 
 Model Parallelism using multiple GPUs
 -------------------------------------

--- a/torch/distributed/pipeline/__init__.py
+++ b/torch/distributed/pipeline/__init__.py
@@ -1,0 +1,7 @@
+import warnings
+warnings.warn(
+    "torch.distributed.pipeline is deprecated. For up-to-date pipeline parallel "
+    "implementation, please refer to the PiPPy library under the PyTorch "
+    "organization (Pipeline Parallelism for PyTorch): "
+    "https://github.com/pytorch/PiPPy"
+)


### PR DESCRIPTION
In favor of PiPPy (Pipeline Parallelism for PyTorch) https://github.com/pytorch/PiPPy

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang