### PR TITLE
[export] Add docs for 2.3 release

### DIFF
--- a/docs/source/export.rst
+++ b/docs/source/export.rst
@@ -74,10 +74,6 @@ following invariants. More specifications about the IR can be found
   from the original programs are inlined to form one fully flattened
   computational graph.
 
-* **Defined Operator Set**: The graph produced contains only a small defined
-  :ref:`Core ATen IR <torch.compiler_ir>` opset and registered custom
-  operators.
-
 * **Graph properties**: The graph is purely functional, meaning it does not
   contain operations with side effects such as mutations or aliasing. It does
   not mutate any intermediate values, parameters, or buffers.
@@ -93,7 +89,7 @@ Under the hood, ``torch.export`` leverages the following latest technologies:
   rewrites needed in order to fully trace the PyTorch code.
 
 * **AOT Autograd** provides a functionalized PyTorch graph and ensures the graph
-  is decomposed/lowered to the small defined Core ATen operator set.
+  is decomposed/lowered to the ATen operator set.
 
 * **Torch FX (torch.fx)** is the underlying representation of the graph,
   allowing flexible Python-based transformations.
@@ -226,9 +222,9 @@ Inspecting the ``ExportedProgram``, we can note the following:
 * The :class:`torch.fx.Graph` contains the computation graph of the original
   program, along with records of the original code for easy debugging.
 
-* The graph contains only ``torch.ops.aten`` operators found in the
-  :ref:`Core ATen IR <torch.compiler_ir>` opset and custom operators, and is
-  fully functional, without any inplace operators such as ``torch.add_``.
+* The graph contains only ``torch.ops.aten`` operators found `here <https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/native_functions.yaml>`__
+  and custom operators, and is fully functional, without any inplace operators
+  such as ``torch.add_``.
 
 * The parameters (weight and bias to conv) are lifted as inputs to the graph,
   resulting in no ``get_attr`` nodes in the graph, which previously existed in
@@ -240,6 +236,59 @@ Inspecting the ``ExportedProgram``, we can note the following:
 * The resulting shape and dtype of tensors produced by each node in the graph is
   noted. For example, the ``convolution`` node will result in a tensor of dtype
   ``torch.float32`` and shape (1, 16, 256, 256).
+
+
+.. _Non-Strict Export:
+
+Non-Strict Export
+^^^^^^^^^^^^^^^^^
+
+In PyTorch 2.3, we introduced a new mode of tracing called **non-strict mode**.
+It's still going through hardening, so if you run into any issues, please file
+them to Github with the "oncall: export" tag.
+
+In *non-strict mode*, we trace through the program using the Python interpreter.
+Your code will execute exactly as it would in eager mode; the only difference is
+that all Tensor objects will be replaced by ProxyTensors, which will record all
+their operations into a graph.
+
+In *strict* mode, which is currently the default, we first trace through the
+program using TorchDynamo, a bytecode analysis engine. TorchDynamo does not
+actually execute your Python code. Instead, it symbolically analyzes it and
+builds a graph based on the results. This analysis allows torch.export to
+provide stronger guarantees about safety, but not all Python code is supported.
+
+An example of a case where one might want to use non-strict mode is if you run
+into a unsupported TorchDynamo feature that might not be easily solved, and you
+know the python code is not exactly needed for computation. For example:
+
+::
+
+    import contextlib
+    import torch
+
+    class ContextManager():
+        def __init__(self):
+            self.count = 0
+        def __enter__(self):
+            self.count += 1
+        def __exit__(self, exc_type, exc_value, traceback):
+            self.count -= 1
+
+    class M(torch.nn.Module):
+        def forward(self, x):
+            with ContextManager():
+                return x.sin() + x.cos()
+
+    torch.export.export(M(), (torch.ones(3, 3),), strict=False)  # Non-strict traces successfully
+    torch.export.export(M(), (torch.ones(3, 3),))  # Strict mode fails with torch._dynamo.exc.Unsupported: ContextManager
+
+In this example, the first call using non-strict mode (through the
+``strict=False`` flag) traces successfully whereas the second call using strict
+mode (default) results with a failure, where TorchDynamo is unable to support
+context managers. One option is to rewrite the code (see :ref:`Limitations of torch.expot <Limitations of
+torch.export>`), but seeing as the context manager does not affect the tensor
+computations in the model, we can go with the non-strict mode's result.
 
 
 Expressing Dynamism
@@ -346,12 +395,6 @@ Some additional things to note:
   `The 0/1 Specialization Problem <https://docs.google.com/document/d/16VPOa3d-Liikf48teAOmxLc92rgvJdfosIy-yoT38Io/edit?fbclid=IwAR3HNwmmexcitV0pbZm_x1a4ykdXZ9th_eJWK-3hBtVgKnrkmemz6Pm5jRQ#heading=h.ez923tomjvyk>`_
   for an in-depth discussion of this topic.
 
-(A legacy mechanism for specifying dynamic shapes
-involves marking and constraining dynamic dimensions with the
-:func:`torch.export.dynamic_dim` API and passing them into :func:`torch.export.export`
-through the ``constraints`` argument. That mechanism is now **deprecated** and will
-not be supported in the future.)
-
 
 Serialization
 ^^^^^^^^^^^^^
@@ -377,17 +420,40 @@ An example:
     saved_exported_program = torch.export.load('exported_program.pt2')
 
 
-Specialization
-^^^^^^^^^^^^^^
+Specializations
+^^^^^^^^^^^^^^^
 
-Input shapes
-~~~~~~~~~~~~
+A key concept in understanding the behavior of ``torch.export`` is the
+difference between *static* and *dynamic* values.
 
-As mentioned before, by default, ``torch.export`` will trace the program
-specializing on the input tensors' shapes, unless a dimension is specified as
-dynamic via the :func:`torch.export.dynamic_dim` API. This means that if there
-exists shape-dependent control flow, ``torch.export`` will specialize on the
-branch that is being taken with the given sample inputs. For example:
+A *dynamic* value is one that can change from run to run. These behave like
+normal arguments to a Python function—you can pass different values for an
+argument and expect your function to do the right thing. Tensor *data* is
+treated as dynamic.
+
+
+A *static* value is a value that is fixed at export time and cannot change
+between executions of the exported program. When the value is encountered during
+tracing, the exporter will treat it as a constant and hard-code it into the
+graph.
+
+When an operation is performed (e.g. ``x + y``) and all inputs are static, then
+the output of the operation will be directly hard-coded into the graph, and the
+operation won’t show up (i.e. it will get constant-folded).
+
+When a value has been hard-coded into the graph, we say that the graph has been
+*specialized* to that value.
+
+The following values are static:
+
+Input Tensor Shapes
+~~~~~~~~~~~~~~~~~~~
+
+By default, ``torch.export`` will trace the program specializing on the input
+tensors' shapes, unless a dimension is specified as dynamic via the
+``dynamic_shapes`` argumen to ``torch.export``. This means that if there exists
+shape-dependent control flow, ``torch.export`` will specialize on the branch
+that is being taken with the given sample inputs. For example:
 
 ::
 
@@ -422,13 +488,15 @@ branching behavior based on the shape of a tensor in the traced graph,
 of the input tensor (``x.shape[0]``) to be dynamic, and the source code will
 need to be :ref:`rewritten <Data/Shape-Dependent Control Flow>`.
 
-Non-tensor inputs
+Note that tensors that are part of the module state (e.g. parameters and
+buffers) always have static shapes.
+
+Python Primitives
 ~~~~~~~~~~~~~~~~~
 
-``torch.export`` also specializes the traced graph based on the values of inputs
-that are not ``torch.Tensor``, such as ``int``, ``float``, ``bool``, and ``str``.
-However, we will likely change this in the near future to not specialize on
-inputs of primitive types.
+``torch.export`` also specializes on Python primtivies,
+such as ``int``, ``float``, ``bool``, and ``str``. However they do have dynamic
+variants such as ``SymInt``, ``SymFloat``, and ``SymBool``.
 
 For example:
 
@@ -458,11 +526,21 @@ For example:
                 return (add_2,)
 
 Because integers are specialized, the ``torch.ops.aten.add.Tensor`` operations
-are all computed with the inlined constant ``1``, rather than ``arg1_1``.
+are all computed with the hard-coded constant ``1``, rather than ``arg1_1``. If
+a user passes a different value for ``arg1_1`` at runtime, like 2, than the one used
+during export time, 1, this will result in an error.
 Additionally, the ``times`` iterator used in the ``for`` loop is also "inlined"
 in the graph through the 3 repeated ``torch.ops.aten.add.Tensor`` calls, and the
 input ``arg2_1`` is never used.
 
+Python Containers
+~~~~~~~~~~~~~~~~~
+
+Python containers (``List``, ``Dict``, ``NamedTuple``, etc.) are considered to
+have static structure.
+
+
+.. _Limitations of torch.export:
 
 Limitations of torch.export
 ---------------------------
@@ -484,6 +562,9 @@ previous tracing frameworks.
 When a graph break is encountered, :ref:`ExportDB <torch.export_db>` is a great
 resource for learning about the kinds of programs that are supported and
 unsupported, along with ways to rewrite programs to make them traceable.
+
+An option to get past dealing with this graph breaks is by using
+:ref:`non-strict export <Non-Strict Export>`
 
 .. _Data/Shape-Dependent Control Flow:
 
@@ -557,6 +638,7 @@ API Reference
     .. automethod:: named_buffers
     .. automethod:: parameters
     .. automethod:: named_parameters
+    .. automethod:: run_decompositions
 
 .. autoclass:: ExportBackwardSignature
 .. autoclass:: ExportGraphSignature


### PR DESCRIPTION
- Added docs about non-strict export
- Added example using derived dims
- Added api docs for ep.run_decompositions() (https://github.com/pytorch/pytorch/issues/119480)
- Tried to include/cover everything in https://docs.google.com/document/d/1kZ_BbB3JnoLbUZleDT6635dHs88ZVYId8jT-yTFgf3A/edit