### PR TITLE
[BE] [MPS] Fix `out` resize logic in `torch.where`

### DIFF
--- a/aten/src/ATen/native/mps/operations/TensorCompare.mm
+++ b/aten/src/ATen/native/mps/operations/TensorCompare.mm
@@ -289,7 +289,11 @@ TORCH_IMPL_FUNC(clamp_max_out_mps)
   mps::clamp_scalar_out_mps(input_t, at::OptionalScalarRef(), max, output_t, __func__);
 }
 
-Tensor& where_self_out_mps(const Tensor& condition, const Tensor& self, const Tensor& other, Tensor& out) {
+static void where_kernel_mps(TensorIterator& iter) {
+  const auto& condition = iter.input(0);
+  const auto& self = iter.input(1);
+  const auto& other = iter.input(2);
+  auto& out = iter.output(0);
   TORCH_CHECK(condition.device() == self.device() && self.device() == other.device(),
               "Expected all tensors to be on the same device, but found at least two devices.");
   TORCH_CHECK(self.dtype() == other.dtype(), "expected scalar type ", self.dtype(), " but found ", other.dtype());
@@ -308,8 +312,9 @@ Tensor& where_self_out_mps(const Tensor& condition, const Tensor& self, const Te
   MPSStream* stream = getCurrentMPSStream();
 
   // Empty output
-  if (out.numel() == 0)
-    return out;
+  if (out.numel() == 0) {
+    return;
+  }
 
   // Derive from MPSCachedGraph
   struct CachedGraph : public MPSCachedGraph {
@@ -367,51 +372,6 @@ Tensor& where_self_out_mps(const Tensor& condition, const Tensor& self, const Te
     auto feeds = dictionaryFromPlaceholders(conditionPlaceholder, selfPlaceholder, otherPlaceholder);
     runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
   }
-
-  return out;
-}
-
-Tensor where_mps(const Tensor& condition, const Tensor& self, const Tensor& other) {
-  auto max_dim = std::max(condition.dim(), std::max(self.dim(), other.dim()));
-
-  // How many leading dimensions do we broadcast across for each Tensor?
-  int cond_num_implicit_ones = (max_dim - condition.dim());
-  int self_num_implicit_ones = (max_dim - self.dim());
-  int other_num_implicit_ones = (max_dim - other.dim());
-
-  std::vector<int64_t> out_arr(max_dim);
-
-  // Broadcasted output shape
-  for (int i = 0; i < max_dim; i++) {
-    // Use up the leading broadcast dimensions for each Tensor, then continue from the start of the "actual" shape
-    int64_t cond_idx = i < cond_num_implicit_ones ? 1 : (condition.size(i - cond_num_implicit_ones));
-    int64_t self_idx = i < self_num_implicit_ones ? 1 : (self.size(i - self_num_implicit_ones));
-    int64_t other_idx = i < other_num_implicit_ones ? 1 : (other.size(i - other_num_implicit_ones));
-
-    auto max_idx = std::max({cond_idx, self_idx, other_idx});
-
-    TORCH_CHECK(cond_idx == max_idx || cond_idx == 1 || (cond_idx == 0 && max_idx == 1),
-                i,
-                "'th index ",
-                cond_idx,
-                " of condition tensor does not match the other tensors")
-    TORCH_CHECK(self_idx == max_idx || self_idx == 1 || (self_idx == 0 && max_idx == 1),
-                i,
-                "'th index ",
-                self_idx,
-                " of x tensor does not match the other tensors")
-    TORCH_CHECK(other_idx == max_idx || other_idx == 1 || (other_idx == 0 && max_idx == 1),
-                i,
-                "'th index ",
-                other_idx,
-                " of x tensor does not match the other tensors")
-
-    out_arr[i] = (cond_idx == 0 || self_idx == 0 || other_idx == 0) ? 0 : max_idx;
-  }
-
-  Tensor ret = at::empty(
-      IntArrayRef(out_arr), self.scalar_type(), c10::nullopt, kMPS, c10::nullopt, self.suggest_memory_format());
-  return where_self_out_mps(condition, self, other, ret);
 }
 
 Tensor& nan_to_num_out_mps(const Tensor& self,
@@ -509,5 +469,7 @@ Tensor& nan_to_num_out_mps(const Tensor& self,
   }
   return result;
 }
+
+REGISTER_DISPATCH(where_kernel, &where_kernel_mps);
 
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6347,15 +6347,13 @@
   device_check: NoCheck   # TensorIterator
   variants: function, method
   dispatch:
-    CPU, CUDA: where
-    MPS: where_mps
+    CPU, CUDA, MPS: where
   tags: [core, pointwise]
 
 - func: where.self_out(Tensor condition, Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   dispatch:
-    CPU, CUDA: where_self_out
-    MPS: where_self_out_mps
+    CPU, CUDA, MPS: where_self_out
 
 - func: where.ScalarSelf(Tensor condition, Scalar self, Tensor other) -> Tensor
   variants: function

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7475,6 +7475,14 @@ class TestMPS(TestCaseMPS):
         helper((2, 3), (5, 2, 3), (2, 3))
         helper((2, 3), (2, 3), (5, 2, 3))
         helper((2, 3), (5, 2, 3), (6, 5, 2, 3))
+        # Test that output is correctly resizes
+        output = torch.tensor(0.0, device="mps")
+        cond = torch.randint(2, (3, 3), dtype=torch.bool, device="mps")
+        inp = torch.rand(3, 3, device="mps")
+        other = torch.rand(3, 3, device="mps")
+        out = torch.where(cond, inp, other, out=output)
+        self.assertEqual(id(out), id(output))
+        self.assertEqual(out.shape, (3, 3))
 
     # Test normal
     def test_normal(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121476
* #121494
* #121473

By deleting `where_mps`  and registering MPS dispatch for `where_kernel`. 
As result of this change resizing and type-checking logic is shared between MPS, CPU and  CUDA backends.

Add test_case to `TestMPS.test_where` (that should eventually be removed, when `out` OpInfo testing is enabled for MPS