### PR TITLE
add __repr__ function to FunctionSchema for Python

### DIFF
--- a/torch/_inductor/fx_passes/fuse_attention.py
+++ b/torch/_inductor/fx_passes/fuse_attention.py
@@ -555,7 +555,7 @@ def _get_sfdp_patterns():
         torch.empty, (1024, 128, 128), device=device, requires_grad=True
     )
 
-    # reshape in matmul decomposition generates a clone when batch_size>1 due to the memory layout change. 
+    # reshape in matmul decomposition generates a clone when batch_size>1 due to the memory layout change.
     # however when batch_size=1, reshape does not change the memory layout, so clone would not be generated.
     # here we need to trace with input of batch_size=1 to generate a pattern graph without clone.
     g_bs1_inp = functools.partial(

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1870,6 +1870,13 @@ void initJITBindings(PyObject* module) {
             ss << self;
             return ss.str();
           })
+      .def(
+          "__repr__",
+          [](FunctionSchema& self) {
+            std::stringstream ss;
+            ss << self;
+            return ss.str();
+          })
       .def_property_readonly(
           "is_mutable", [](FunctionSchema& self) { return self.is_mutable(); });
   py::class_<Argument>(m, "Argument")


### PR DESCRIPTION
Fixes #118566

Unlike **OpOverload** or **OpOverloadPacket**, there is a lot of complex information in the schema, so for me keeping it as is is probably a good choice, but in theory the **\_\_repr__** function should show the class name as well as some other key information.

If you have any choices, please show me, thank you.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang