### PR TITLE
[FSDP2] Zeroed padded tensor in `_apply`

### DIFF
--- a/torch/distributed/_composable/fsdp/fully_shard.py
+++ b/torch/distributed/_composable/fsdp/fully_shard.py
@@ -239,7 +239,8 @@ class FSDP:
                     padded_local_tensor[: local_tensor.size(0)].copy_(local_tensor)
                     local_tensor = padded_local_tensor
                 fsdp_param._sharded_param_data = local_tensor.view(-1)
-                cast(DTensor, fsdp_param.sharded_param)._local_tensor = local_tensor[
+                assert isinstance(fsdp_param.sharded_param, DTensor)  # mypy
+                fsdp_param.sharded_param._local_tensor = local_tensor[
                     : fsdp_param.sharded_size[0]
                 ]
         return ret

--- a/torch/distributed/_composable/fsdp/fully_shard.py
+++ b/torch/distributed/_composable/fsdp/fully_shard.py
@@ -232,12 +232,14 @@ class FSDP:
                             "Please set torch.__future__.set_swap_module_params_on_conversion(True) "
                             "to use _apply methods with FSDP"
                         )
-                new_local_tensor = new_param._local_tensor
+                local_tensor = new_param._local_tensor
                 padded_sharded_size = fsdp_param.padded_sharded_param_size
-                if new_param._local_tensor.size() != padded_sharded_size:
-                    new_local_tensor.resize_(padded_sharded_size)
-                fsdp_param._sharded_param_data = new_local_tensor.view(-1)
-                cast(
-                    DTensor, fsdp_param.sharded_param
-                )._local_tensor = new_local_tensor[: fsdp_param.sharded_size[0]]
+                if local_tensor.size() != padded_sharded_size:
+                    padded_local_tensor = local_tensor.new_zeros(padded_sharded_size)
+                    padded_local_tensor[: local_tensor.size(0)].copy_(local_tensor)
+                    local_tensor = padded_local_tensor
+                fsdp_param._sharded_param_data = local_tensor.view(-1)
+                cast(DTensor, fsdp_param.sharded_param)._local_tensor = local_tensor[
+                    : fsdp_param.sharded_size[0]
+                ]
         return ret


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #120256
* #119378
* #119302
* __->__ #121509

This PR replaces the `Tensor.resize_` with an explicit zero-ing of the padded tensor. Uninitialized padding is not good since it can give false positive NaNs.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang