### PR TITLE
[c10d] Improve logPrefix for ND-parallelism

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1443,7 +1443,7 @@ std::string ProcessGroupNCCL::getNCCLWatchdogDebugInfo() {
 }
 
 std::string ProcessGroupNCCL::createLogPrefix() const {
-  return c10::str("[PG ", uid_, " Rank ", rank_, "] ");
+  return c10::str("[PG ", uid_, " Rank ", rank_, "globalRank", globalRank(), "] ");
 }
 
 const std::string& ProcessGroupNCCL::logPrefix() const {


### PR DESCRIPTION
Summary: When we have 2+D parallelism, we have multiple PGs, inter- and intra-host. So just printing PG id (which is by creation order and it's hard to tell which logical PG it is). So i think it has values to log global PG.

Test Plan: CI

Differential Revision: D54687690




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @rohan-varma