### PR TITLE
[caffe2] replace refernces to np.asscalar (#121332)

### DIFF
--- a/caffe2/python/examples/imagenet_trainer.py
+++ b/caffe2/python/examples/imagenet_trainer.py
@@ -219,12 +219,12 @@ def RunEpoch(
         for _ in range(test_epoch_iters):
             workspace.RunNet(test_model.net.Proto().name)
             for g in test_model._devices:
-                test_accuracy += np.asscalar(workspace.FetchBlob(
+                test_accuracy += workspace.FetchBlob(
                     "{}_{}".format(test_model._device_prefix, g) + '/accuracy'
-                ))
-                test_accuracy_top5 += np.asscalar(workspace.FetchBlob(
+                ).item()
+                test_accuracy_top5 += workspace.FetchBlob(
                     "{}_{}".format(test_model._device_prefix, g) + '/accuracy_top5'
-                ))
+                ).item()
                 ntests += 1
         test_accuracy /= ntests
         test_accuracy_top5 /= ntests

--- a/caffe2/python/hypothesis_test.py
+++ b/caffe2/python/hypothesis_test.py
@@ -590,7 +590,7 @@ class TestOperators(hu.HypothesisTestCase):
     @staticmethod
     def _dense_ftrl(alpha, beta, lambda1, lambda2, w, nz, g):
         if isinstance(alpha, np.ndarray):
-            alpha = np.asscalar(alpha)
+            alpha = alpha.item()
         n = np.take(nz, 0, axis=-1)
         z = np.take(nz, 1, axis=-1)
         # python port of Sigrid's implementation
@@ -636,7 +636,7 @@ class TestOperators(hu.HypothesisTestCase):
     @staticmethod
     def _dense_gftrl(alpha, beta, lambda1, lambda2, w, nz, g):
         if isinstance(alpha, np.ndarray):
-            alpha = np.asscalar(alpha)
+            alpha = alpha.item()
 
         old_shape = g.shape
 

--- a/caffe2/python/operator_test/rank_loss_operator_test.py
+++ b/caffe2/python/operator_test/rank_loss_operator_test.py
@@ -36,12 +36,12 @@ class TestPairWiseLossOps(serial.SerializedTestCase):
         new_output = workspace.FetchBlob('new_output')
         sign = 1 if label[0] > label[1] else -1
         if label[0] == label[1]:
-            self.assertEqual(np.asscalar(output), 0)
+            self.assertEqual(output.item(), 0)
             return
 
         self.assertAlmostEqual(
-            np.asscalar(output),
-            np.asscalar(np.log(1 + np.exp(sign * (X[1] - X[0])))),
+            output.item(),
+            np.log(1 + np.exp(sign * (X[1] - X[0]))).item(),
             delta=1e-4
         )
         # check swapping row order doesn't alter overall loss
@@ -71,14 +71,14 @@ class TestPairWiseLossOps(serial.SerializedTestCase):
         dx = workspace.FetchBlob('dX')
         sign = 1 if label[0] > label[1] else -1
         if label[0] == label[1]:
-            self.assertEqual(np.asscalar(dx[0]), 0)
+            self.assertEqual(dx[0].item(), 0)
             return
         self.assertAlmostEqual(
-            np.asscalar(dx[0]),
-            np.asscalar(-dY[0] * sign / (1 + np.exp(sign * (X[0] - X[1])))),
-            delta=1e-2 * abs(np.asscalar(dx[0])))
+            dx[0].item(),
+            (-dY[0] * sign / (1 + np.exp(sign * (X[0] - X[1])))).item(),
+            delta=1e-2 * abs(dx[0].item()))
 
-        self.assertEqual(np.asscalar(dx[0]), np.asscalar(-dx[1]))
+        self.assertEqual(dx[0].item(), (-dx[1]).item())
         delta = 1e-3
         up_x = np.array([[X[0] + delta], [X[1]]], dtype=np.float32)
         down_x = np.array([[X[0] - delta], [X[1]]], dtype=np.float32)
@@ -94,10 +94,9 @@ class TestPairWiseLossOps(serial.SerializedTestCase):
         down_output_pred = workspace.FetchBlob('down_output')
         up_output_pred = workspace.FetchBlob('up_output')
         np.testing.assert_allclose(
-            np.asscalar(dx[0]),
-            np.asscalar(
-                0.5 * dY[0] *
-                (up_output_pred[0] - down_output_pred[0]) / delta),
+            dx[0].item(),
+            (0.5 * dY[0] *
+                (up_output_pred[0] - down_output_pred[0]) / delta).item(),
             rtol=1e-2, atol=1e-2)
 
     @serial.given(n=st.integers(0, 10), k=st.integers(1, 5), **hu.gcs_cpu_only)

--- a/caffe2/python/utils.py
+++ b/caffe2/python/utils.py
@@ -140,7 +140,7 @@ def MakeArgument(key, value):
         value = value.flatten().tolist()
     elif isinstance(value, np.generic):
         # convert numpy scalar to native python type
-        value = np.asscalar(value)
+        value = value.item()
 
     if type(value) is float:
         argument.f = value


### PR DESCRIPTION
Summary:

`np.asscalar` was deprecated and removed in a recent Numpy. It used to be implemented the following way, and the recommended alternative is to call `item()` directly:
```python
def asscalar(a):
    return a.item()
```
This fixes all of the references.

Test Plan: visual inspection and automated tests

Differential Revision: D54697760


