### PR TITLE
[export] improve binary op fast path broadcast check

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -2329,6 +2329,25 @@ def forward(self, x):
             )
         )
 
+    def test_export_fast_binary_broadcast_check(self):
+        # This test looks at the case where we erroneously
+        # create a guard when checking the equality of the
+        # operands' shape and the output shape.
+
+        class MyModel(torch.nn.Module):
+            def forward(self, a, b):
+                # final shape is (dim0, 4, 8)
+                # order matters since a & the output have the same shape
+                return b + a
+
+        a = torch.randn(100, 4, 8)
+        b = torch.randn(4, 8)
+        model = MyModel().eval().cuda()
+        batchsize = torch.export.Dim("dim0", min=3, max=1024)
+        dynamic_shape_spec = {"a": [batchsize, None, None], "b": [None, None]}
+
+        torch.export.export(model, (a, b), dynamic_shapes=dynamic_shape_spec)
+
     def test_export_meta(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
@@ -3567,6 +3586,19 @@ G['macademia'], accessed at:
                     msg="test_capture_symbolic_tracing_within_fake_mode_aten_graph_"
                     + str(aten_graph),
                 )
+
+    # def test_colin(self):
+    #     class Model(torch.nn.Module):
+    #         def forward(self, a, b):
+    #             return a + b
+
+    #     a = torch.randn(100, 3, 4)
+    #     b = torch.randn(3, 4)
+
+    #     batchsize = torch.export.Dim("dim0", min=3, max=1024)
+    #     dynamic_shape_spec = {"a": [batchsize, None, None], "b": [None, None]}
+
+    #     gm, _ = torch._dynamo.export(Model(), dynamic_shapes=dynamic_shape_spec)(a, b)
 
     def test_cond_op_param_buffer_lifted(self):
         class A(torch.nn.Module):

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -2330,9 +2330,9 @@ def forward(self, x):
         )
 
     def test_export_fast_binary_broadcast_check(self):
-        # This test looks at the case where we erroneously
-        # create a guard when checking the equality of the
-        # operands' shape and the output shape.
+        # This test looks at the case where we erroneously create a guard
+        # when checking the equality of the operands' shape and the output
+        # shape during FakeTensor's binary op fast path.
 
         class MyModel(torch.nn.Module):
             def forward(self, a, b):
@@ -3586,19 +3586,6 @@ G['macademia'], accessed at:
                     msg="test_capture_symbolic_tracing_within_fake_mode_aten_graph_"
                     + str(aten_graph),
                 )
-
-    # def test_colin(self):
-    #     class Model(torch.nn.Module):
-    #         def forward(self, a, b):
-    #             return a + b
-
-    #     a = torch.randn(100, 3, 4)
-    #     b = torch.randn(3, 4)
-
-    #     batchsize = torch.export.Dim("dim0", min=3, max=1024)
-    #     dynamic_shape_spec = {"a": [batchsize, None, None], "b": [None, None]}
-
-    #     gm, _ = torch._dynamo.export(Model(), dynamic_shapes=dynamic_shape_spec)(a, b)
 
     def test_cond_op_param_buffer_lifted(self):
         class A(torch.nn.Module):

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -939,7 +939,11 @@ def make_fast_binary_impl(slow_ref):
         # Do some extra safety checks to see if the output
         # stride is obvious
         for op in operands:
-            if isinstance(op, torch.Tensor) and op.shape == final_shape:
+            if (
+                isinstance(op, torch.Tensor)
+                and len(op.shape) == len(final_shape)
+                and op.shape == final_shape
+            ):
                 break
         else:
             return slow("both tensors nontrivially broadcast")


### PR DESCRIPTION
# Context
I believe we have an incorrect guard being created during FakeTensor's binary op fast path.

Consider this case
```
# op.shape: (10, 192); final_shape: (s0, 10, 192)
# Guard Ne(s0, 10) is created when we create SymBool(10 == s0)
if isinstance(op, torch.Tensor) and op.shape == final_shape:
    break
```

As of right now, `op.shape == final_shape` checks whether one of the binary op's operands is the same as the binay op's output shape. 
* If one of them is a dynamic shape, then we'll create a guard via`SymBool` creation (i.e. `s0 == 10`).  
* If the `SymBool` expr resolves to `false`, then we'll create the guard `Ne(s0, 10)`.

This is a problem when the # of dimensions aren't the same between `op.shape` & `final_shape`. Take the case above for example, `op.shape: (10, 192); final_shape: (s0, 10, 192)`. Although, the shapes aren't the same, it doesn't necessarily mean that `s0 != 10`.

Some thoughts (feel free to ignore). What if the # of dimensions are equal but one of the shapes has symbols. Here's three cases:
  1. `op.shape: (9000, 10, 192); final_shape: (s0, 10, 192)` -- not broadcastable.
  2. `op.shape: (1, 10, 192); final_shape: (s0, 10, 192)` -- 0/1 specialization wins?
  3. `op.shape: (100, 10, 192); final_shape: (s0, 10, 192) where s0 = 100` -- Ask user to mark `s0` as a constant.

# Test
```
$ TORCHDYNAMO_VERBOSE=1 PYTORCH_TEST_WITH_DYNAMO=1 pytest -s test/dynamo/test_dynamic_shapes.py -k test_export_fast_binary_broadcast_check_dynamic_shapes

torch.fx.experimental.symbolic_shapes.ConstraintViolationError: Constraints violated (dim0)! For more information, run with TORCH_LOGS="+dynamic".
  - Not all values of dim0 = L['a'].size()[0] in the specified range 3 <= dim0 <= 1024 satisfy the generated guard Ne(L['a'].size()[0], 3).
```

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121546


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang