### PR TITLE
Delete 2.29 libstdc++ from jammy builds

### DIFF
--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -111,11 +111,9 @@ fi
   fi
 
   # HACK HACK HACK
-  # gcc-9 for ubuntu-18.04 from http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu
-  # Pulls llibstdc++6 13.1.0-8ubuntu1~18.04 which is too new for conda
+  # Ubuntu-20+ all comes lib libstdc++ newer than 3.30+, but anaconda is stuck with 3.29
   # So remove libstdc++6.so.3.29 installed by https://anaconda.org/anaconda/libstdcxx-ng/files?version=11.2.0
-  # Same is true for gcc-12 from Ubuntu-22.04
-  if grep -e [12][82].04.[623] /etc/issue >/dev/null; then
+  if grep -e 2[02].04.[5623] /etc/issue >/dev/null; then
     rm /opt/conda/envs/py_$ANACONDA_PYTHON_VERSION/lib/libstdc++.so.6
   fi
 


### PR DESCRIPTION
They somehow magically worked, but this is very fragile and also results in a build warnings about missing libcxx magic

