### PR TITLE
Express y grid > 2^16 in terms of z grid

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -3,6 +3,8 @@
 import sys
 import unittest
 
+import torch
+
 from torch.testing._internal.common_utils import IS_LINUX
 from torch.testing._internal.inductor_utils import HAS_GPU
 
@@ -29,6 +31,43 @@ class TestTritonHeuristics(TestCase):
             if key not in cfg.kwargs:
                 continue
             self.assertTrue(cfg.kwargs[key] <= config.triton.max_block[label])
+
+    def test_artificial_zgrid(self):
+        def forward(primals_1, primals_2, primals_5):
+            view = torch.ops.aten.reshape.default(primals_5, [-1, 4, 128])
+            primals_5 = None
+            permute = torch.ops.aten.permute.default(view, [0, 2, 1])
+            clone = torch.ops.aten.clone.default(
+                permute, memory_format=torch.contiguous_format
+            )
+            permute = None
+            view_1 = torch.ops.aten.reshape.default(clone, [-1, 4])
+            clone = None
+            permute_1 = torch.ops.aten.permute.default(primals_1, [1, 0])
+            primals_1 = None
+            addmm = torch.ops.aten.addmm.default(primals_2, view_1, permute_1)
+            primals_2 = None
+            return addmm
+
+        s0 = 727828
+        s1 = 512
+
+        args = [
+            torch.rand([2, 4], device="cuda"),
+            torch.rand([2], device="cuda"),
+            torch.rand([s0, s1], device="cuda"),
+        ]
+        torch._dynamo.mark_dynamic(args[-1], 0)
+        foo_c = torch.compile(forward)
+
+        self.assertEqual(forward(*args), foo_c(*args))
+
+        args = [
+            torch.rand([2, 4], device="cuda"),
+            torch.rand([2], device="cuda"),
+            torch.rand([s0, s1], device="cuda"),
+        ]
+        self.assertEqual(forward(*args), foo_c(*args))
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -32,7 +32,10 @@ class TestTritonHeuristics(TestCase):
                 continue
             self.assertTrue(cfg.kwargs[key] <= config.triton.max_block[label])
 
-    def test_artificial_zgrid(self):
+    def _test_artificial_zgrid(self):
+
+        torch._inductor.config.cpp_wrapper = True
+
         def forward(primals_1, primals_2, primals_5):
             view = torch.ops.aten.reshape.default(primals_5, [-1, 4, 128])
             primals_5 = None
@@ -68,6 +71,13 @@ class TestTritonHeuristics(TestCase):
             torch.rand([s0, s1], device="cuda"),
         ]
         self.assertEqual(forward(*args), foo_c(*args))
+
+    def test_artificial_zgrid(self):
+        self._test_artificial_zgrid()
+
+    @config.patch("cpp_wrapper", True)
+    def test_artificial_grid_cpp_wrapper(self):
+        self._test_artificial_zgrid()
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -33,7 +33,6 @@ class TestTritonHeuristics(TestCase):
             self.assertTrue(cfg.kwargs[key] <= config.triton.max_block[label])
 
     def _test_artificial_zgrid(self):
-
         torch._inductor.config.cpp_wrapper = True
 
         def forward(primals_1, primals_2, primals_5):

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -79,6 +79,11 @@ class TestTritonHeuristics(TestCase):
     def test_artificial_grid_cpp_wrapper(self):
         self._test_artificial_zgrid()
 
+    @config.patch("triton.max_tiles", 3)
+    def test_artificial_grid_max_tiles(self):
+        with self.assertRaisesRegex(Exception, "Generated y grid"):
+            self._test_artificial_zgrid()
+
 
 if __name__ == "__main__":
     if IS_LINUX and HAS_GPU:

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1096,9 +1096,12 @@ class IterationRangesRoot(IterationRanges):
     def get_pid(self):
         assert self.grid_dim is not None
         key = f"tl.program_id({self.grid_dim})"
-        # y_grid can only be up to 2^16, so express it in terms of y and z
-        # in case of overflow. z grid is only exercised when max_tiles == 3 (off by default).
-        if self.grid_dim == 1 and config.triton.max_tiles <= 2:
+        # y_grid has a limit, so express it in terms of y and z in case of overflow.
+        # z grid is only exercised when max_tiles == 3 (off by default).
+        MAX_Y_GRID = 65536
+        if self.grid_dim == 1 and config.triton.max_tiles <= 2 and not (
+            isinstance(self.numel, int) and self.numel <= MAX_Y_GRID
+        ):
             key = f'{key} * {f"tl.program_id({self.grid_dim + 1})"}'
         pid = self.pid_cache.get(key, key)
         if self.kernel.index_dtype != "tl.int32":

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -51,6 +51,7 @@ from ..utils import (
     get_dtype_size,
     get_fused_kernel_name,
     get_kernel_metadata,
+    get_max_y_grid,
     green_text,
     is_welford_reduction,
     next_power_of_2,
@@ -1098,11 +1099,12 @@ class IterationRangesRoot(IterationRanges):
         key = f"tl.program_id({self.grid_dim})"
         # y_grid has a limit, so express it in terms of y and z in case of overflow.
         # z grid is only exercised when max_tiles == 3 (off by default).
-        MAX_Y_GRID = 65536
-        if self.grid_dim == 1 and config.triton.max_tiles <= 2 and not (
-            isinstance(self.numel, int) and self.numel <= MAX_Y_GRID
+        if (
+            self.grid_dim == 1
+            and config.triton.max_tiles <= 2
+            and not (isinstance(self.numel, int) and self.numel <= get_max_y_grid())
         ):
-            key = f'{key} * {f"tl.program_id({self.grid_dim + 1})"}'
+            key = f"{key} * (tl.program_id({self.grid_dim + 1}) + 1)"
         pid = self.pid_cache.get(key, key)
         if self.kernel.index_dtype != "tl.int32":
             return f"{pid}.to({self.kernel.index_dtype})"

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1096,6 +1096,10 @@ class IterationRangesRoot(IterationRanges):
     def get_pid(self):
         assert self.grid_dim is not None
         key = f"tl.program_id({self.grid_dim})"
+        # y_grid can only be up to 2^16, so express it in terms of y and z
+        # in case of overflow. z grid is only exercised when max_tiles == 3 (off by default).
+        if self.grid_dim == 1 and config.triton.max_tiles <= 2:
+            key = f'{key} * {f"tl.program_id({self.grid_dim + 1})"}'
         pid = self.pid_cache.get(key, key)
         if self.kernel.index_dtype != "tl.int32":
             return f"{pid}.to({self.kernel.index_dtype})"

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -1443,7 +1443,7 @@ def grid(*numels):
         y_grid = get_grid_dim(ynumel, meta.get("YBLOCK", None))
 
         MAX_Y_GRID = 65536
-        if znumel is None and max_grid_dims:
+        if znumel is None and max_grid_dims <= 2:
             div = ceildiv(y_grid, MAX_Y_GRID)
             y_grid = y_grid // div
             z_grid = div

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -1452,7 +1452,7 @@ def grid(*numels):
             z_grid = get_grid_dim(znumel, meta.get("ZBLOCK", None))
             torch._check(
                 y_grid <= MAX_Y_GRID,
-                lambda: f"Generated y grid behind 2^16 ({y_grid}) not supported with z dimension present. File issue",
+                lambda: f"Generated y grid beyond 2^16 ({y_grid}) not supported with z dimension present. File issue",
             )
 
         return (

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -1436,11 +1436,28 @@ def grid(*numels):
             return numel
         return ceildiv(numel, block)
 
+    max_grid_dims = config.triton.max_tiles
+
     def grid_fn(meta):
+        x_grid = get_grid_dim(xnumel, meta.get("XBLOCK", 1))
+        y_grid = get_grid_dim(ynumel, meta.get("YBLOCK", None))
+
+        if znumel is None and max_grid_dims:
+            z_grid = 1
+            while y_grid > 65535:
+                y_grid = ceildiv(y_grid, 2)
+                z_grid *= 2
+        else:
+            z_grid = get_grid_dim(znumel, meta.get("ZBLOCK", None))
+            torch._check(
+                y_grid <= 65535,
+                lambda: f"Generated y grid behind 2^16 ({y_grid}) not supported with z dimension present. File issue",
+            )
+
         return (
-            get_grid_dim(xnumel, meta.get("XBLOCK", 1)),
-            get_grid_dim(ynumel, meta.get("YBLOCK", None)),
-            get_grid_dim(znumel, meta.get("ZBLOCK", None)),
+            x_grid,
+            y_grid,
+            z_grid,
         )
 
     return grid_fn

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -1442,11 +1442,11 @@ def grid(*numels):
         x_grid = get_grid_dim(xnumel, meta.get("XBLOCK", 1))
         y_grid = get_grid_dim(ynumel, meta.get("YBLOCK", None))
 
+        MAX_Y_GRID = 65536
         if znumel is None and max_grid_dims:
-            z_grid = 1
-            while y_grid > 65535:
-                y_grid = ceildiv(y_grid, 2)
-                z_grid *= 2
+            div = ceildiv(y_grid, MAX_Y_GRID)
+            y_grid = y_grid // div
+            z_grid = div
         else:
             z_grid = get_grid_dim(znumel, meta.get("ZBLOCK", None))
             torch._check(

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -31,6 +31,7 @@ from .utils import (
     conditional_product,
     create_bandwidth_info_str,
     do_bench,
+    get_max_y_grid,
     get_num_bytes,
     next_power_of_2,
     triton_config_to_hashable,
@@ -1442,7 +1443,7 @@ def grid(*numels):
         x_grid = get_grid_dim(xnumel, meta.get("XBLOCK", 1))
         y_grid = get_grid_dim(ynumel, meta.get("YBLOCK", None))
 
-        MAX_Y_GRID = 65536
+        MAX_Y_GRID = get_max_y_grid()
         if znumel is None and max_grid_dims <= 2:
             div = ceildiv(y_grid, MAX_Y_GRID)
             y_grid = y_grid // div
@@ -1450,7 +1451,7 @@ def grid(*numels):
         else:
             z_grid = get_grid_dim(znumel, meta.get("ZBLOCK", None))
             torch._check(
-                y_grid <= 65535,
+                y_grid <= MAX_Y_GRID,
                 lambda: f"Generated y grid behind 2^16 ({y_grid}) not supported with z dimension present. File issue",
             )
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1267,6 +1267,10 @@ def reduction_num_outputs(reduction_type):
     return 3 if is_welford_reduction(reduction_type) else 1
 
 
+def get_max_y_grid():
+    return 65535
+
+
 def is_linux() -> bool:
     return platform.system() == "Linux"
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121554

CUDA has a max y_grid of 65535. If we're computing larger than that we can compose it in terms of z grid, which is currently unused in inductor codegen.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang