### PR TITLE
[inductor] Remove `divisible_by_8` from kernel argument descriptor

### DIFF
--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -120,6 +120,4 @@ def config_of(
     # and None args by the Triton compiler
     ids_of_folded_args = tuple(equal_to_1)
 
-    return instance_descriptor(
-        divisible_by_16, equal_to_1, ids_of_folded_args
-    )
+    return instance_descriptor(divisible_by_16, equal_to_1, ids_of_folded_args)

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -108,11 +108,6 @@ def config_of(
         )
     else:
         divisible_by_16 = ()
-    divisible_by_8 = tuple(
-        i
-        for i, arg in zip(indices, args)
-        if is_aligned(arg, alignment=8, include_tensor=False)
-    )
 
     equal_to_1 = tuple(
         i
@@ -126,5 +121,5 @@ def config_of(
     ids_of_folded_args = tuple(equal_to_1)
 
     return instance_descriptor(
-        divisible_by_16, equal_to_1, ids_of_folded_args, divisible_by_8
+        divisible_by_16, equal_to_1, ids_of_folded_args
     )

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -706,13 +706,11 @@ if attrs_descriptor_available:
         divisible_by_16=None,
         equal_to_1=None,
         ids_of_folded_args=None,
-        divisible_by_8=None,
     ):
         # Prepare the arguments for AttrsDescriptor
         kwargs = {
             "divisible_by_16": divisible_by_16,
             "equal_to_1": equal_to_1,
-            "divisible_by_8": divisible_by_8,
         }
 
         # Conditionally add 'ids_of_folded_args' if it's available in AttrsDescriptor
@@ -726,8 +724,8 @@ else:
     # Define a namedtuple as a fallback when AttrsDescriptor is not available
     instance_descriptor = collections.namedtuple(  # type: ignore[no-redef]
         "instance_descriptor",
-        ["divisible_by_16", "equal_to_1", "ids_of_folded_args", "divisible_by_8"],
-        defaults=[tuple(), tuple(), tuple(), tuple()],
+        ["divisible_by_16", "equal_to_1", "ids_of_folded_args"],
+        defaults=[tuple(), tuple(), tuple()],
     )
 
 


### PR DESCRIPTION
Triton has deprecated the `divisible_by_8` hint.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang