### PR TITLE
[IntraNodeComm] fix a hybridCubeMeshAllReduceKernel breakage caused by a recent refactor

### DIFF
--- a/torch/csrc/distributed/c10d/intra_node_comm.cu
+++ b/torch/csrc/distributed/c10d/intra_node_comm.cu
@@ -369,8 +369,11 @@ static __global__ void hybridCubeMeshAllReduceKernel(
       buffers[hcmInfo[1]],
       buffers[hcmInfo[2]],
   };
-  at::BFloat16* localRelay = buffers[rank] + bufferSize / 2;
-  at::BFloat16* remoteRelay = buffers[relayRank] + bufferSize / 2;
+  // Use the half second half of the buffer as relay
+  at::BFloat16* localRelay =
+      buffers[rank] + (bufferSize / sizeof(at::BFloat16) / 2);
+  at::BFloat16* remoteRelay =
+      buffers[relayRank] + (bufferSize / sizeof(at::BFloat16) / 2);
 
   for (size_t i = offset; i < N_aligned; i += stride) {
     bf16x8 vals[4];


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121575

`hybridCubeMeshAllReduceKernel` uses the latter half of p2p buffers as relay buffers. The relay buffer address is calculated using a bf16 base pointer and the buffer size in byte. The breakage was caused by not taking element size into account.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang