### PR TITLE
split predispatch pass into multiple passes

### DIFF
--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -46,9 +46,20 @@ efficient_conv_bn_eval_pass = PatternMatcherPass(
 merge_getitem_cat_pass = PatternMatcherPass(
     prevent_match_across_mutations=True, pass_name="merge_getitem_cat_pass"
 )
-predispatch_pass = PatternMatcherPass(
-    prevent_match_across_mutations=True, pass_name="predispatch_pass"
+
+fuse_split_linear_add_pass = PatternMatcherPass(
+    prevent_match_across_mutations=True,
+    pass_name="fuse_split_linear_add_pass",
 )
+fuse_chunk_squeeze_cat_pass = PatternMatcherPass(
+    prevent_match_across_mutations=True,
+    pass_name="fuse_chunk_squeeze_cat_pass",
+)
+remove_reshape_pass = PatternMatcherPass(
+    prevent_match_across_mutations=True,
+    pass_name="remove_reshape_pass",
+)
+
 # based on predispatch aten IR
 normalization_pass_aten = PatternMatcherPass(prevent_match_across_mutations=True)
 merge_splits_pass_aten = PatternMatcherPass(prevent_match_across_mutations=True)
@@ -112,10 +123,16 @@ def pre_grad_passes(gm: torch.fx.GraphModule, example_inputs=None):
                 "[Pre grad(predispatch IR)] Apply group_batch_fusion",
             )
             pass_execution_and_save(
-                predispatch_pass.apply,
+                fuse_chunk_squeeze_cat_pass.apply,
                 gm,
-                "[Pre grad(predispatch IR)] Apply predispatch_pass",
+                "[Pre grad(predispatch IR)] Apply fuse_chunk_squeeze_cat_pass",
             )
+            pass_execution_and_save(
+                fuse_split_linear_add_pass.apply,
+                gm,
+                "[Pre grad(predispatch IR)] Apply fuse_split_linear_add_pass",
+            )
+
             log.debug(
                 "[Pre grad(predispatch IR)]Before split cat in pre grad pass. graph: %s",
                 gm.graph,
@@ -128,6 +145,11 @@ def pre_grad_passes(gm: torch.fx.GraphModule, example_inputs=None):
                     gm,
                     f"[Pre grad(predispatch IR)]Apply split_cat, index: {ind}",
                 )
+            pass_execution_and_save(
+                remove_reshape_pass.apply,
+                gm,
+                "[Pre grad(predispatch IR)] Apply remove_reshape_pass",
+            )
         else:
             # We only log the graph with changes to avoid the excessive compilation time
             # https://fb.workplace.com/groups/257735836456307/permalink/633533465543207/


### PR DESCRIPTION
Summary:
It's very difficult to debug the passes ineffectiveness, with them mingled in one single pass container. Here we extract them into seperate passes with diagnostics info. 

This is also required for a later change, where we must run shape prop on each of these passes, in order for the subsequent passes to have the correct shape information.

Reviewed By: frank-wei

Differential Revision: D53579545




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang