### PR TITLE
[ET-VK] Enable Dynamic shape support via tensor virtual and physical resizing

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Resource.h
+++ b/aten/src/ATen/native/vulkan/api/Resource.h
@@ -151,6 +151,10 @@ class VulkanBuffer final {
     return (memory_.allocation != VK_NULL_HANDLE);
   }
 
+  inline bool owns_memory() const {
+    return owns_memory_;
+  }
+
   operator bool() const {
     return (handle_ != VK_NULL_HANDLE);
   }
@@ -370,6 +374,10 @@ class VulkanImage final {
 
   inline bool has_memory() const {
     return (memory_.allocation != VK_NULL_HANDLE);
+  }
+
+  inline bool owns_memory() const {
+    return owns_memory_;
   }
 
   inline operator bool() const {

--- a/aten/src/ATen/native/vulkan/api/ShaderRegistry.h
+++ b/aten/src/ATen/native/vulkan/api/ShaderRegistry.h
@@ -12,6 +12,9 @@
 #define VK_KERNEL(shader_name) \
   ::at::native::vulkan::api::shader_registry().get_shader_info(#shader_name)
 
+#define VK_KERNEL_FROM_STR(shader_name_str) \
+  ::at::native::vulkan::api::shader_registry().get_shader_info(shader_name_str)
+
 namespace at {
 namespace native {
 namespace vulkan {

--- a/aten/src/ATen/native/vulkan/api/Utils.h
+++ b/aten/src/ATen/native/vulkan/api/Utils.h
@@ -328,14 +328,27 @@ inline ivec3 make_ivec3(uvec3 ints) {
 }
 
 /*
- * Given an vector of up to 4 int64_t representing the sizes of a tensor,
+ * Given an vector of up to 4 uint64_t representing the sizes of a tensor,
  * constructs a uvec4 containing those elements in reverse order.
  */
-inline uvec4 make_nchw_uvec4(const std::vector<int64_t>& arr) {
+inline uvec4 make_whcn_uvec4(const std::vector<int64_t>& arr) {
   uint32_t w = safe_downcast<uint32_t>(val_at(-1, arr));
   uint32_t h = safe_downcast<uint32_t>(val_at(-2, arr));
   uint32_t c = safe_downcast<uint32_t>(val_at(-3, arr));
   uint32_t n = safe_downcast<uint32_t>(val_at(-4, arr));
+
+  return {w, h, c, n};
+}
+
+/*
+ * Given an vector of up to 4 int64_t representing the sizes of a tensor,
+ * constructs an ivec4 containing those elements in reverse order.
+ */
+inline ivec4 make_whcn_ivec4(const std::vector<int64_t>& arr) {
+  int32_t w = val_at(-1, arr);
+  int32_t h = val_at(-2, arr);
+  int32_t c = val_at(-3, arr);
+  int32_t n = val_at(-4, arr);
 
   return {w, h, c, n};
 }

--- a/tools/gen_vulkan_spv.py
+++ b/tools/gen_vulkan_spv.py
@@ -28,11 +28,74 @@ except ImportError:
 
 CPP_H_NAME = "spv.h"
 CPP_SRC_NAME = "spv.cpp"
-DEFAULT_ENV = {
+
+DEFAULT_ENV: Dict[str, Any] = {
     "PRECISION": "highp",
     "FLOAT_IMAGE_FORMAT": "rgba16f",
     "INT_IMAGE_FORMAT": "rgba32i",
     "UINT_IMAGE_FORMAT": "rgba32ui",
+}
+
+TYPES_ENV: Dict[str, Any] = {
+    "IMAGE_FORMAT": {
+        "float": "rgba32f",
+        "half": "rgba16f",
+        "int": "rgba32i",
+        "uint": "rgba32ui",
+        "int8": "rgba8i",
+        "uint8": "rgba8ui",
+    },
+    "IMAGE_T": {
+        3: {
+            "float": "image3D",
+            "half": "image3D",
+            "int": "iimage3D",
+            "uint": "uimage3D",
+        },
+        2: {
+            "float": "image2D",
+            "half": "image2D",
+            "int": "iimage2D",
+            "uint": "uimage2D",
+        },
+    },
+    "SAMPLER_T": {
+        3: {
+            "float": "sampler3D",
+            "half": "sampler3D",
+            "int": "isampler3D",
+            "uint": "usampler3D",
+        },
+        2: {
+            "float": "sampler2D",
+            "half": "sampler2D",
+            "int": "isampler2D",
+            "uint": "usampler2D",
+        },
+    },
+    "VEC4_T": {
+        "float": "vec4",
+        "half": "vec4",
+        "int": "ivec4",
+        "uint": "uvec4",
+        "int8": "vec4",
+        "uint8": "uvec4",
+    },
+    "T": {
+        "float": "float",
+        "half": "float",
+        "int": "int",
+        "uint": "uint",
+        "int8": "int",
+        "uint8": "uint8",
+    },
+}
+
+FUNCS_ENV: Dict[str, Any] = {
+    "GET_POS": {
+        3: lambda pos: pos,
+        2: lambda pos: f"{pos}.xy",
+    }
 }
 
 
@@ -671,7 +734,10 @@ def main(argv: List[str]) -> int:
     )
     options = parser.parse_args()
 
+    DEFAULT_ENV.update(TYPES_ENV)
+    DEFAULT_ENV.update(FUNCS_ENV)
     env = DEFAULT_ENV
+
     for key, value in parse_arg_env(options.env).items():
         env[key] = value
 


### PR DESCRIPTION
Summary:
## Context

This changeset lays the foundations for supporting dynamic shapes in the ExecuTorch Vulkan delegate via allowing Tensors to be resized in one of two ways:

1. Discarding underlying `vkImage` or `vkBuffer` and reallocating a new `vkImage` or `vkBuffer` with updated sizes. This method is intended to be used when the current `vkImage` or `vkBuffer` is not large enough to contain the new sizes.
2. Update the tensor's size metadata without reallocating any new resources. This allows shaders to interpret the underlying `vkImage` or `vkBuffer` as if it were smaller than it actually is, and allows command buffers to be preserved when sizes are changed.

Test Plan: Check CI. Tests have also been added to `vulkan_compute_api_test` that test the two methods of tensor resizing.

Differential Revision: D54728401


