### PR TITLE
combine loops so fn_name correct in error message

### DIFF
--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -221,7 +221,6 @@ def while_loop_func(ctx, cond_fn, body_fn, operands):
                     f"torch.while_loop's {fn_name} might be modifying the input!"
                 )
 
-        for fn in [functional_cond_fn, functional_body_fn]:
             if _has_potential_branch_input_alias(
                 fn, unwrapped_operands, pre_dispatch=pre_dispatch
             ):


### PR DESCRIPTION
The error message shown when input aliasing is detected in `while_loop_func` may not have the correct `fn_name` as it set only in the previous for loop.  This change merges the two loops so that `fn_name` has the correct value.

No Issue Number for this minor change.
