### PR TITLE
Cleanup: Remove redundant `inference_patterns` PatternMatcherPass

### DIFF
--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -61,8 +61,6 @@ pass_patterns = [
     PatternMatcherPass(),
     PatternMatcherPass(),
 ]
-# patterns applied only in inference
-inference_patterns = PatternMatcherPass()
 
 
 def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
@@ -100,8 +98,6 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
                 optimus_scuba_log[
                     f"{pattern_matcher_pass.pass_name}_post_grad"
                 ] = upload_graph(gm.graph)
-        if is_inference:
-            inference_patterns.apply(gm.graph)  # type: ignore[arg-type]
 
     if config._fuse_ddp_communication:
         fuse_ddp_communication(


### PR DESCRIPTION
## Summary
Removes a redundant `PatternMatcherPass` in Inductor post-grad passes




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang