### PR TITLE
Slightly faster FX graph iterator

### DIFF
--- a/benchmarks/dynamo/microbenchmarks/fx_microbenchmarks.py
+++ b/benchmarks/dynamo/microbenchmarks/fx_microbenchmarks.py
@@ -1,0 +1,29 @@
+import timeit
+import torch.fx
+
+N = 100000
+K = 1000
+
+
+def huge_graph():
+    def fn(x):
+        for _ in range(N):
+            x = x.sin()
+        return x
+
+    return torch.fx.symbolic_trace(fn)
+
+
+def main():
+    g = huge_graph()
+
+    def fn():
+        for n in g.graph.nodes:
+            pass
+
+    t = min(timeit.repeat(fn, number=K, repeat=3))
+    print(f"iterating over {N*K} FX nodes took {t:.1f}s ({N*K/t:.0f} nodes/s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/dynamo/microbenchmarks/fx_microbenchmarks.py
+++ b/benchmarks/dynamo/microbenchmarks/fx_microbenchmarks.py
@@ -1,4 +1,5 @@
 import timeit
+
 import torch.fx
 
 N = 100000

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -269,12 +269,20 @@ class _node_list:
         return self.graph._len
 
     def __iter__(self):
-        root, direction = self.graph._root, self.direction
-        cur = getattr(root, direction)
-        while cur is not root:
-            if not cur._erased:
-                yield cur
-            cur = getattr(cur, direction)
+        root = self.graph._root
+        if self.direction == "_next":
+            cur = root._next
+            while cur is not root:
+                if not cur._erased:
+                    yield cur
+                cur = cur._next
+        else:
+            assert self.direction == "_prev"
+            cur = root._prev
+            while cur is not root:
+                if not cur._erased:
+                    yield cur
+                cur = cur._prev
 
     def __reversed__(self):
         return _node_list(self.graph, '_next' if self.direction == '_prev' else '_prev')


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121611

Before:
```
iterating over 100000000 FX nodes took 5.9s (16830686 nodes/s)
```

After:
```
iterating over 100000000 FX nodes took 5.0s (19937698 nodes/s)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang