### PR TITLE
[MPS] Fix sliceOffset calculation in getMPSGraphTensorDataForView

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9202,6 +9202,13 @@ class TestViewOpsMPS(TestCaseMPS):
         nv[0, 0] = 0
         self.assertNotEqual(t[0, 0], nv[0, 0])
 
+    def test_reshape_add(self, device="mps"):
+        t_mps = torch.ones(2, 6, device=device)[1].reshape(2, 3)
+        t_mps = t_mps + 1
+        t_cpu = torch.ones(2, 6)[1].reshape(2, 3)
+        t_cpu = t_cpu + 1
+        self.assertEqual(t_mps, t_cpu)
+
     def test_reshape_view(self, device="mps"):
         t = torch.ones(5, 5, device=device)
         v = torch.reshape(t, (25,))


### PR DESCRIPTION
Description:
This PR addresses an issue in the PyTorch MPS backend where the sliceOffset calculation in the `getMPSGraphTensorDataForView` function was incorrect, leading to issues with reshaped tensors. The problem was caused by the way `sliceOffset` was calculated using `view_numel`.

My fix:
- Simplifies the calculation of `sliceOffset` by using the modulo operator directly with `src_base_shape[firstDimToSlice]` instead of calculating `view_numel`.
- Updates the calculation of `sliceOffset` inside the loop for remaining dimensions to use the modulo operator directly with `src_base_shape[crtSliceOffset]`.

A unit test `test_reshape_add` has been added to verify the correct behavior after applying these changes.

This PR continues the work started in PR #117456.

Fixes #96153

Testing:
- Added a new unit test `test_reshape_add` to test the specific case of reshaping a tensor after indexing.
- The new test passes without causing any issues with existing tests in the PyTorch MPS backend test suite.

Summary:
- Fixed an issue in the PyTorch MPS backend where the sliceOffset calculation in `getMPSGraphTensorDataForView` was incorrect, leading to issues with reshaped tensors.

