### PR TITLE
[Inductor][Optimus] Add pattern to move view out of middle computation op

### DIFF
--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -469,7 +469,7 @@ class BatchLinearLHSFusion(BatchFusion):
 def is_node_meta_valid(node: Optional[torch.fx.Node]):
     if node is None:
         return True
-    if "example_value" not in node.meta:
+    if "example_value" not in node.meta and "val" not in node.meta:
         return False
     return True
 

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -166,6 +166,7 @@ def pre_grad_passes(gm: torch.fx.GraphModule, example_inputs=None):
             if example_inputs is not None:
                 gm = fuse_fx(gm, example_inputs)
             numpy_compat_normalization(gm.graph)
+            optimus_scuba_log["before_pre_grad_transformation"] = upload_graph(gm.graph)
             inductor_before_change = copy.deepcopy(counters["inductor"])
             group_batch_fusion_passes(gm.graph, pre_grad=True)
             if counters["inductor"] != inductor_before_change:
@@ -202,6 +203,8 @@ def pre_grad_passes(gm: torch.fx.GraphModule, example_inputs=None):
             config.fx_passes_numeric_check.get("num_iterations", 1),
             config.fx_passes_numeric_check.get("precision", 1e-4),
         )
+
+    optimus_scuba_log["after_pre_grad_transformation"] = upload_graph(gm.graph)
 
     return gm
 


### PR DESCRIPTION
Summary:
Followup work on the discussion https://fb.workplace.com/groups/1075192433118967/permalink/1388551441783063/
We moved the reshape/view out of the middle computation op

Test Plan:
# unit test
```
 buck2 test mode/dev-nosan //caffe2/test/inductor:split_cat_fx_passes
```
P1194111452
diffing for broadcast (approach 2)
https://www.internalfb.com/intern/diffing/?paste_number=1195116375

Buck UI: https://www.internalfb.com/buck2/22956686-4120-4260-9b34-6c777d9c668d
Test UI: https://www.internalfb.com/intern/testinfra/testrun/6192449656914950
Network: Up: 124KiB  Down: 55KiB  (reSessionID-2f4a93ca-5c0d-4f34-a0c2-e07dc1b81f75)
Jobs completed: 30. Time elapsed: 2:04.7s.
Cache hits: 0%. Commands: 2 (cached: 0, remote: 0, local: 2)
Tests finished: Pass 12. Fail 0. Fatal 0. Skip 0. Build failure 0

# local reproduce
```
CUDA_VISIBLE_DEVICES=7 OC_CAUSE=1 buck2 run mode/opt //scripts/jackiexu0313/pt2:user_embedding_arch_with_pt2 2>&1 | tee ~/user_embedding_arch_pattern_match_fused_after.txt
```

https://www.internalfb.com/intern/diffing/?paste_number=1193263395

Differential Revision: D54615798


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang