### PR TITLE
Allow custom attributes for torch function subclasses

### DIFF
--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -33,7 +33,7 @@ from torch.testing._internal.inductor_utils import HAS_CUDA
 from torch.testing._internal.two_tensor import TwoTensor
 
 
-def test_subclass(c):
+def traceable_subclass(c):
     return torch._dynamo.config.patch("traceable_tensor_subclasses", {c})
 
 
@@ -549,7 +549,7 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
         def fn(x):
             return x.x + torch.ones(2, 2)
 
-        with test_subclass(AttrSubclass):
+        with traceable_subclass(AttrSubclass):
             input = torch.ones(2, 2).as_subclass(AttrSubclass)
             fn_opt = compile_full_eager(fn)
 

--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -32,7 +32,10 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.inductor_utils import HAS_CUDA
 from torch.testing._internal.two_tensor import TwoTensor
 
-test_subclass = lambda x: torch._dynamo.config.patch("traceable_tensor_subclasses", {x})
+
+def test_subclass(c):
+    return torch._dynamo.config.patch("traceable_tensor_subclasses", {c})
+
 
 requires_cuda = unittest.skipUnless(HAS_CUDA, "requires cuda")
 

--- a/torch/_dynamo/variables/torch_function.py
+++ b/torch/_dynamo/variables/torch_function.py
@@ -195,7 +195,7 @@ class TensorWithTFOverrideVariable(TensorVariable):
         import torch
         from .builder import SourcelessBuilder
 
-        if name in banned_attrs or not hasattr(torch.Tensor, name):
+        if name in banned_attrs:
             unimplemented(
                 f"Accessing {name} on a tensor subclass with a __torch_function__ override is not supported"
             )
@@ -206,7 +206,7 @@ class TensorWithTFOverrideVariable(TensorVariable):
                 " subclass with a __torch_function__ override is not supported"
             )
 
-        if tx.output.torch_function_enabled:
+        if tx.output.torch_function_enabled and hasattr(torch.Tensor, name):
             if self.source:
                 install_guard(
                     AttrSource(AttrSource(self.source, "__class__"), name).make_guard(


### PR DESCRIPTION
Added custom attribute access with test

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang