### PR TITLE
Support tt.reduce in Triton kernel analysis pass

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -1183,6 +1183,35 @@ class MutationTests(torch._dynamo.test_case.TestCase):
         )
 
     @make_mutation_test
+    def test_reduce_sum():
+        @triton.jit
+        def reduce_sum_kernel(a_ptr, c_ptr, stride_am, stride_an):
+            offs_am = tl.arange(0, 4)
+            offs_an = tl.arange(0, 4)
+            a_ptrs = a_ptr + (
+                offs_am[:, None] * stride_am + offs_an[None, :] * stride_an
+            )
+            a = tl.load(a_ptrs)
+            m = tl.sum(a, axis=1)
+            tl.store(c_ptr + tl.arange(0, 4), m)
+
+        return (
+            reduce_sum_kernel,
+            {
+                "a_ptr": torch.randn(4, 4),
+                "c_ptr": torch.randn(4),
+                "stride_am": 4,
+                "stride_an": 4,
+            },
+            # TODO(aakhundov): tt.reduce is now supported, but only
+            # in the new MLIR-based Triton analysis pass (not in the
+            # old TTIR string parsing-based one). change the line
+            # below to ["c_ptr"] when new Triton pin lands and this
+            # test starts failing.
+            ["a_ptr", "c_ptr"],
+        )
+
+    @make_mutation_test
     def test_argmax():
         @triton.jit
         def argmax_kernel(a_ptr, c_ptr, stride_am, stride_an):
@@ -1204,7 +1233,11 @@ class MutationTests(torch._dynamo.test_case.TestCase):
                 "stride_am": 4,
                 "stride_an": 4,
             },
-            # TODO(oulgen): tt.reduce closures are not implemented yet
+            # TODO(aakhundov): tt.reduce is now supported, but only
+            # in the new MLIR-based Triton analysis pass (not in the
+            # old TTIR string parsing-based one). change the line
+            # below to ["c_ptr"] when new Triton pin lands and this
+            # test starts failing.
             ["a_ptr", "c_ptr"],
         )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121706

Summary: Previously, we bailed out of the Triton kernel analysis pass when seeing a `tt.reduce` op. In this PR, we support the op and don't bail out anymore.

Test Plan: This is a bit tricky, as the extension is added to the MLIR walk-based analysis code path which is active only on when the MLIR bindings added in https://github.com/openai/triton/pull/3191 are available. So for now I've run the `test_argmax` and `test_reduce_sum` manually with a newer Triton version than the current pin. When pin updates, we'll make those tests official (left a TODO comment).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang