### PR TITLE
`_foreach_copy` with different src/dst dtypes

### DIFF
--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -102,12 +102,13 @@ inline void check_foreach_api_restrictions(
 // corresponding tensors (aligning in index across the tensorLists) share the
 // same device and dtype.
 inline bool _check_tensors_share_device_and_dtype(
-    ArrayRef<TensorList> tensorLists) {
+    ArrayRef<TensorList> tensorLists,
+    const bool skip_dtype_check = false) {
   const auto expected_dtype = tensorLists[0][0].dtype();
   const auto expected_device = tensorLists[0][0].device();
 
   auto is_tensor_okay = [&](const Tensor& tensor) {
-    return tensor.dtype() == expected_dtype &&
+    return (skip_dtype_check || tensor.dtype() == expected_dtype) &&
         tensor.device() == expected_device && tensor.layout() == at::kStrided &&
         tensor.is_non_overlapping_and_dense();
   };

--- a/aten/src/ATen/native/cuda/ForeachBinaryOpList.cu
+++ b/aten/src/ATen/native/cuda/ForeachBinaryOpList.cu
@@ -252,14 +252,14 @@ FOREACH_BINARY_OP_LIST(
     /*division_op*/ true);
 
 template <typename dst_t, typename src_t = dst_t>
-struct Identity {
+struct Copy {
   __device__ __forceinline__ dst_t operator()(const src_t& x) {
     return static_cast<dst_t>(x);
   }
 };
 
 template <typename dst_t>
-struct Identity<dst_t, c10::complex<double>> {
+struct Copy<dst_t, c10::complex<double>> {
   __device__ __forceinline__ dst_t operator()(const c10::complex<double>& x) {
     if constexpr (!(std::is_same_v<dst_t, c10::complex<double>> ||
                     std::is_same_v<dst_t, c10::complex<float>>)) {
@@ -271,7 +271,7 @@ struct Identity<dst_t, c10::complex<double>> {
 };
 
 template <typename dst_t>
-struct Identity<dst_t, c10::complex<float>> {
+struct Copy<dst_t, c10::complex<float>> {
   __device__ __forceinline__ dst_t operator()(const c10::complex<float>& x) {
     if constexpr (!(std::is_same_v<dst_t, c10::complex<double>> ||
                     std::is_same_v<dst_t, c10::complex<float>>)) {
@@ -421,7 +421,7 @@ void foreach_tensor_copy_list_kernel_cuda_(
                     /* depth */ 2,
                     /* r_args_depth */ 1,
                     /* res_arg_index */ 1>(),
-                Identity<opmath_t, opmath_t>());
+                Copy<opmath_t, opmath_t>());
           } else {
             // Ref:
             // https://github.com/pytorch/pytorch/blob/656134c38f4737d13c3f43fc5c59470bc23c1d2f/aten/src/ATen/native/Copy.cpp#L299-L301
@@ -437,7 +437,7 @@ void foreach_tensor_copy_list_kernel_cuda_(
                     /* depth */ 2,
                     /* r_args_depth */ 1,
                     /* res_arg_index */ 1>(),
-                Identity<scalar_t, src_t>());
+                Copy<scalar_t, src_t>());
           }
         });
       });

--- a/aten/src/ATen/native/cuda/ForeachBinaryOpList.cu
+++ b/aten/src/ATen/native/cuda/ForeachBinaryOpList.cu
@@ -261,14 +261,24 @@ struct Identity {
 template <typename dst_t>
 struct Identity<dst_t, c10::complex<double>> {
   __device__ __forceinline__ dst_t operator()(const c10::complex<double>& x) {
-    return static_cast<dst_t>(x.real());
+    if constexpr (!(std::is_same_v<dst_t, c10::complex<double>> ||
+                    std::is_same_v<dst_t, c10::complex<float>>)) {
+      return static_cast<dst_t>(x.real());
+    } else {
+      return static_cast<dst_t>(x);
+    }
   }
 };
 
 template <typename dst_t>
 struct Identity<dst_t, c10::complex<float>> {
   __device__ __forceinline__ dst_t operator()(const c10::complex<float>& x) {
-    return static_cast<dst_t>(x.real());
+    if constexpr (!(std::is_same_v<dst_t, c10::complex<double>> ||
+                    std::is_same_v<dst_t, c10::complex<float>>)) {
+      return static_cast<dst_t>(x.real());
+    } else {
+      return static_cast<dst_t>(x);
+    }
   }
 };
 

--- a/aten/src/ATen/native/cuda/ForeachBinaryOpList.cu
+++ b/aten/src/ATen/native/cuda/ForeachBinaryOpList.cu
@@ -328,7 +328,6 @@ template <
     int r_args_depth,
     int res_arg_index>
 struct CopyFunctor {
-  using opmath_t = at::opmath_type<T>;
   static_assert(depth == 2 && r_args_depth == 1 && res_arg_index == 1);
   template <typename Op>
   __device__ __forceinline__ void operator()(

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -838,6 +838,18 @@ class TestForeach(TestCase):
                         copy_(t, s, non_blocking)
                     self.assertEqual(ref_input, sample.input)
 
+    @onlyCUDA
+    @ops(filter(lambda op: op.name == "_foreach_copy", foreach_binary_op_db))
+    def test_foreach_copy_with_multi_dtypes(self, device, dtype, op):
+        foreach_copy_ = ForeachFuncWrapper(op.inplace_variant)
+        for sample in op.sample_inputs(device, dtype, noncontiguous=False):
+            for src_dtype in floating_types_and(torch.half, torch.bfloat16):
+                if src_dtype == dtype:
+                    continue
+                self_tensors = [t.clone() for t in sample.input]
+                src_tensors = [t.to(src_dtype) for t in self_tensors]
+                foreach_copy_((self_tensors, src_tensors), is_cuda=True, expect_fastpath=True)
+
     # Test reverse-mode & forward-mode AD if supported.
     @onlyCUDA
     @ops(

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -841,6 +841,7 @@ class TestForeach(TestCase):
     @onlyCUDA
     @ops(filter(lambda op: op.name == "_foreach_copy", foreach_binary_op_db))
     def test_foreach_copy_with_multi_dtypes(self, device, dtype, op):
+        # check (a) multi_tensor_apply is called and (b) numerical parity with for-loop and Tensor.copy_
         foreach_copy_ = ForeachFuncWrapper(op.inplace_variant)
         for sample in op.sample_inputs(device, dtype, noncontiguous=False):
             for src_dtype in floating_types_and(torch.half, torch.bfloat16):
@@ -848,7 +849,8 @@ class TestForeach(TestCase):
                     continue
                 self_tensors = [t.clone() for t in sample.input]
                 src_tensors = [t.to(src_dtype) for t in self_tensors]
-                foreach_copy_((self_tensors, src_tensors), is_cuda=True, expect_fastpath=True)
+                out = foreach_copy_((self_tensors, src_tensors), is_cuda=True, expect_fastpath=True)
+                self.assertEqual(out, [torch.empty_like(t).copy_(s) for t, s in zip(self_tensors, src_tensors)])
 
     # Test reverse-mode & forward-mode AD if supported.
     @onlyCUDA


### PR DESCRIPTION
Fixes #115171

```
torch.version.git_version = '6bff6372a922fe72be5335c6844c10e2687b967d', torch.cuda.get_device_name() = 'NVIDIA RTX 6000 Ada Generation'
[------------------ foreach copy - self: torch.float32 - shape: (512, 512) -----------------]
                         |  src: torch.float32  |  src: torch.float16  |  src: torch.bfloat16
1 threads: ----------------------------------------------------------------------------------
      num_tensors: 32    |          14.2        |          12.6        |           12.7
      num_tensors: 256   |         688.0        |         510.3        |          514.0
      num_tensors: 1024  |        2768.0        |        2053.3        |         2047.7

Times are in microseconds (us).

[------------------ foreach copy - self: torch.float16 - shape: (512, 512) -----------------]
                         |  src: torch.float32  |  src: torch.float16  |  src: torch.bfloat16
1 threads: ----------------------------------------------------------------------------------
      num_tensors: 32    |          10.0        |           8.9        |            8.8
      num_tensors: 256   |         497.6        |         344.3        |          348.3
      num_tensors: 1024  |        1991.9        |        1392.0        |         1389.0

Times are in microseconds (us).

[----------------- foreach copy - self: torch.bfloat16 - shape: (512, 512) -----------------]
                         |  src: torch.float32  |  src: torch.float16  |  src: torch.bfloat16
1 threads: ----------------------------------------------------------------------------------
      num_tensors: 32    |          10.0        |           8.8        |            8.8
      num_tensors: 256   |         497.5        |         344.5        |          348.0
      num_tensors: 1024  |        1993.2        |        1390.4        |         1387.5

Times are in microseconds (us).

[------------------ foreach copy - self: torch.float32 - shape: (515, 515) -----------------]
                         |  src: torch.float32  |  src: torch.float16  |  src: torch.bfloat16
1 threads: ----------------------------------------------------------------------------------
      num_tensors: 32    |          19.0        |          17.9        |           18.1
      num_tensors: 256   |         707.2        |         540.2        |          543.1
      num_tensors: 1024  |        2900.6        |        2156.6        |         2159.2

Times are in microseconds (us).

[------------------ foreach copy - self: torch.float16 - shape: (515, 515) -----------------]
                         |  src: torch.float32  |  src: torch.float16  |  src: torch.bfloat16
1 threads: ----------------------------------------------------------------------------------
      num_tensors: 32    |          13.8        |          13.7        |           13.1
      num_tensors: 256   |         513.2        |         352.6        |          350.4
      num_tensors: 1024  |        2047.6        |        1404.4        |         1400.4

Times are in microseconds (us).

[----------------- foreach copy - self: torch.bfloat16 - shape: (515, 515) -----------------]
                         |  src: torch.float32  |  src: torch.float16  |  src: torch.bfloat16
1 threads: ----------------------------------------------------------------------------------
      num_tensors: 32    |          13.6        |          12.8        |           14.2
      num_tensors: 256   |         511.9        |         351.8        |          350.6
      num_tensors: 1024  |        2045.4        |        1402.2        |         1401.4

Times are in microseconds (us).

```