### PR TITLE
Add __torch_function__ support for generated tensor methods/property of PrivateUse1

### DIFF
--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1433,6 +1433,11 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         torch.linalg.lstsq: lambda self, b, cond=None, driver=None: -1,
     }
 
+    privateuse1_backend_name = torch.utils.backend_registration._privateuse1_backend_name
+    if privateuse1_backend_name != "privateuseone":
+        ret[getattr(Tensor, privateuse1_backend_name)] = lambda self, device=None, non_blocking=False, **kwargs: -1
+        ret[getattr(Tensor, f'is_{privateuse1_backend_name}').__get__] = lambda self: -1  # noqa: B009
+
     ret2 = {}
     ignored = get_ignored_functions()
 

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1434,7 +1434,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
     }
 
     privateuse1_backend_name = torch.utils.backend_registration._privateuse1_backend_name
-    if privateuse1_backend_name != "privateuseone":
+    if hasattr(Tensor, privateuse1_backend_name):
         ret[getattr(Tensor, privateuse1_backend_name)] = lambda self, device=None, non_blocking=False, **kwargs: -1
         ret[getattr(Tensor, f'is_{privateuse1_backend_name}').__get__] = lambda self: -1  # noqa: B009
 


### PR DESCRIPTION
support following case:
```python
import torch
...
class CustomFooTensor(torch.Tensor):
  @classmethod
  def __torch_function__(cls, func, types, args=(), kwargs=None):
    ...
a = CustomFooTensor([3])
print(a.is_foo)
```