### PR TITLE
Refactor release only changes to two step execution

### DIFF
--- a/scripts/release/apply-release-changes.sh
+++ b/scripts/release/apply-release-changes.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
 #
+# Step 2 after branch cut is complete.
+#
+# Creates PR with release only changes.
+#
 # Usage (run from root of project):
-#  DRY_RUN=disabled RELEASE_VERSION=2.2 ./scripts/release/apply-release-changes.sh
+#  DRY_RUN=disabled ./scripts/release/apply-release-changes.sh
 #
 # RELEASE_VERSION: Version of this current release
 
 set -eou pipefail
 
-# Create and Check out to Release Branch
-# git checkout -b "${RELEASE_BRANCH}"
-
+GIT_TOP_DIR=$(git rev-parse --show-toplevel)
+RELEASE_VERSION=${RELEASE_VERSION:-$(cut -d'.' -f1-2 "${GIT_TOP_DIR}/version.txt")}
 DRY_RUN=${DRY_RUN:-enabled}
-python3 .github/scripts/tag_docker_images_for_release.py --version ${RELEASE_VERSION} --dry-run ${DRY_RUN}
 
 # Change all GitHub Actions to reference the test-infra release branch
 # as opposed to main.
@@ -49,5 +51,5 @@ sed -i -e s#disabled-jobs.json#"disabled-jobs.json?versionId=${DISABLED_VER}"# .
 sed -i -e s#slow-tests.json#"slow-tests.json?versionId=${SLOW_VER}"#  tools/stats/import_test_stats.py
 sed -i -e s#disabled-tests-condensed.json#"disabled-tests-condensed.json?versionId=${DISABLED_TESTS_VER}"# tools/stats/import_test_stats.py
 # Optional
-# git commit -m "[RELEASE-ONLY CHANGES] Branch Cut for Release {RELEASE_VERSION}"
-# git push origin "${RELEASE_BRANCH}"
+git commit -m "[RELEASE-ONLY CHANGES] Branch Cut for Release {RELEASE_VERSION}"
+git push origin "${RELEASE_BRANCH}"

--- a/scripts/release/apply-release-changes.sh
+++ b/scripts/release/apply-release-changes.sh
@@ -4,6 +4,8 @@
 #
 # Creates PR with release only changes.
 #
+# Prerequisite: Must be  successfully authenticated in aws fbossci account.
+#
 # Usage (run from root of project):
 #  DRY_RUN=disabled ./scripts/release/apply-release-changes.sh
 #

--- a/scripts/release/tag-docker-images.sh
+++ b/scripts/release/tag-docker-images.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Step 1 after branch cut is complete.
+#
+# Tags latest docker images for release branch.
+# In case of failure. The script can be rerun.
+#
+#  Before executing this script do:
+#  1. Create and Check out to Release Branch
+#  git checkout -b "${RELEASE_BRANCH}"
+#  2. Update submodules
+#  git submodule update --init --recursive
+#
+# Usage (run from root of project):
+#  DRY_RUN=disabled ./scripts/release/tag_docker_images.sh
+#
+
+set -eou pipefail
+
+GIT_TOP_DIR=$(git rev-parse --show-toplevel)
+RELEASE_VERSION=${RELEASE_VERSION:-$(cut -d'.' -f1-2 "${GIT_TOP_DIR}/version.txt")}
+DRY_RUN=${DRY_RUN:-enabled}
+
+python3 .github/scripts/tag_docker_images_for_release.py --version ${RELEASE_VERSION} --dry-run ${DRY_RUN}


### PR DESCRIPTION
Refactor release only changes to two step execution.

1. Step ``tag-docker-images.sh`` . Tags latest docker images for current release. This step takes about 30min to complete. This step may fail due to space issues on the local host or http connection when pulling image. Hence should be rerun if failed.

2. Apply release only changes ``apply-release-changes.sh`` prepares a PR with release only changes.