### PR TITLE
Use memcache versioning for autotune remote cache

### DIFF
--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -121,6 +121,13 @@ def justknobs_check(name: str) -> bool:
     return True
 
 
+def justknobs_getval_int(name: str) -> int:
+    """
+    Read warning on justknobs_check
+    """
+    return 0
+
+
 @functools.lru_cache(None)
 def max_clock_rate():
     from triton.testing import nvsmi


### PR DESCRIPTION
Summary: Internal training platform doesn't get updated very frequently, so lets use versioning for memcache.

Test Plan: existing tests

Differential Revision: D54818197




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang