### PR TITLE
update triton pin for release 2.3

### DIFF
--- a/.ci/docker/ci_commit_pins/triton.txt
+++ b/.ci/docker/ci_commit_pins/triton.txt
@@ -1,1 +1,1 @@
-a9bc1a36470eefafe0e2ab2503b8698f1e89e7e3
+release/2.2.x


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121780
* #121779
* #121778

