### PR TITLE
[cpu] Modify inductor opt flag --- ftree-loop-vectorize

### DIFF
--- a/benchmarks/dynamo/expected_ci_speedup_inductor_torchbench_cpu.csv
+++ b/benchmarks/dynamo/expected_ci_speedup_inductor_torchbench_cpu.csv
@@ -5,7 +5,7 @@ basic_gnn_gcn,float32,dynamic,default,1.24639561
 llama_v2_7b_16h,float32,dynamic,default,1.27455818
 resnet50,float32,dynamic,default,2.28794694
 timm_efficientnet,float32,static,cpp,2.72195686
-mobilenet_v3_large,float32,static,cpp,2.9000000
+mobilenet_v3_large,float32,static,cpp,3.02274304
 timm_resnest,float32,dynamic,cpp,2.10118744
 shufflenet_v2_x1_0,float32,dynamic,cpp,1.8976929
 #hf_GPT2,float32,dynamic,cpp,1.6702305

--- a/benchmarks/dynamo/expected_ci_speedup_inductor_torchbench_cpu.csv
+++ b/benchmarks/dynamo/expected_ci_speedup_inductor_torchbench_cpu.csv
@@ -5,7 +5,7 @@ basic_gnn_gcn,float32,dynamic,default,1.24639561
 llama_v2_7b_16h,float32,dynamic,default,1.27455818
 resnet50,float32,dynamic,default,2.28794694
 timm_efficientnet,float32,static,cpp,2.72195686
-mobilenet_v3_large,float32,static,cpp,3.02274304
+mobilenet_v3_large,float32,static,cpp,2.968117
 timm_resnest,float32,dynamic,cpp,2.10118744
 shufflenet_v2_x1_0,float32,dynamic,cpp,1.8976929
 #hf_GPT2,float32,dynamic,cpp,1.6702305

--- a/benchmarks/dynamo/expected_ci_speedup_inductor_torchbench_cpu.csv
+++ b/benchmarks/dynamo/expected_ci_speedup_inductor_torchbench_cpu.csv
@@ -5,7 +5,7 @@ basic_gnn_gcn,float32,dynamic,default,1.24639561
 llama_v2_7b_16h,float32,dynamic,default,1.27455818
 resnet50,float32,dynamic,default,2.28794694
 timm_efficientnet,float32,static,cpp,2.72195686
-mobilenet_v3_large,float32,static,cpp,2.968117
+mobilenet_v3_large,float32,static,cpp,2.9000000
 timm_resnest,float32,dynamic,cpp,2.10118744
 shufflenet_v2_x1_0,float32,dynamic,cpp,1.8976929
 #hf_GPT2,float32,dynamic,cpp,1.6702305

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1255,6 +1255,9 @@ def optimization_flags() -> str:
         base_flags += " -fno-unsafe-math-optimizations"
     if not config.cpp.enable_floating_point_contract_flag:
         base_flags += " -ffp-contract=off"
+    # Disable to fix the following accuracy issues:
+    #   https://github.com/pytorch/pytorch/issues/113017
+    #   https://github.com/pytorch/pytorch/issues/115261
     if not config.cpp.enable_tree_loop_vec_opt_flag:
         base_flags += " -fno-tree-loop-vectorize"
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1255,6 +1255,8 @@ def optimization_flags() -> str:
         base_flags += " -fno-unsafe-math-optimizations"
     if not config.cpp.enable_floating_point_contract_flag:
         base_flags += " -ffp-contract=off"
+    if not config.cpp.enable_tree_loop_vec_opt_flag:
+        base_flags += " -fno-tree-loop-vectorize"
 
     if config.is_fbcode():
         # FIXME: passing `-fopenmp` adds libgomp.so to the generated shared library's dependencies.

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1255,7 +1255,8 @@ def optimization_flags() -> str:
         base_flags += " -fno-unsafe-math-optimizations"
     if not config.cpp.enable_floating_point_contract_flag:
         base_flags += " -ffp-contract=off"
-    # Disable to fix the following accuracy issues:
+    # Disable the flag to fix the following accuracy issues.
+    # Wrongly return in advance when for-loop length is a multiple of simdlen.
     #   https://github.com/pytorch/pytorch/issues/113017
     #   https://github.com/pytorch/pytorch/issues/115261
     if not config.cpp.enable_tree_loop_vec_opt_flag:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -522,6 +522,9 @@ class cpp:
     # Use ffp-contract when compiling
     enable_floating_point_contract_flag = False
 
+    # Use ftree-loop-vectorize when compiling
+    enable_tree_loop_vec_opt_flag = False
+
 
 # config specific to codegen/triton.py
 class triton:


### PR DESCRIPTION
Fixes #115261, #113017.

For CPU inductor path, remove `-ftree-loop-vectorize` from optimization flags to fix functional issues.

### Validation on 3 benchmark suites

#### FP32
![image](https://github.com/pytorch/pytorch/assets/23010269/17fe443e-6b84-42ca-83d3-e837979ee490)

Outlier models (speedup<0.8, single socket):

- Reason of non-vec: `atomic_add` (`scatter_add`) @CaoE 
  - basic_gnn_gcn: 0.58
  - basic_gnn_gin: 0.42
  - basic_gnn_sage: 0.45
- Reason of non-vec: `index_expr` (`batch_norm`)
  _Expected to be fixed by https://github.com/pytorch/pytorch/pull/122961_
  - maml: 0.79

#### BF16
![image](https://github.com/pytorch/pytorch/assets/23010269/8efbc4e6-a45d-40a5-9fe4-5093de5c107b)

Outlier models (speedup<0.8, single socket):

- Reason of non-vec: `atomic_add` (`scatter_add`) @CaoE 
  - basic_gnn_gcn: 0.46
  - basic_gnn_gin: 0.29
  - basic_gnn_sage: 0.30
- Reason of non-vec: `index_expr` (`batch_norm`)
  _Expected to be fixed by https://github.com/pytorch/pytorch/pull/122961_
  - maml: 0.66
  - pytorch_CycleGAN_and_pix2pix: 0.39

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang