### PR TITLE
Fall back to eager mode when viewing with differing bitwidths (#120998)

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -9175,6 +9175,8 @@ class CommonTemplate:
 
         self.common(fn, args, check_lowp=check_lowp)
 
+    # codegen test fails with no dynamic for loop in dynamic shape tests
+    @expectedFailureCodegenDynamic
     def test_view_uint8_through_differing_bitwidths(self):
         # https://github.com/pytorch/pytorch/issues/120998
         def fn(x, view_dtype):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -9175,6 +9175,15 @@ class CommonTemplate:
 
         self.common(fn, args, check_lowp=check_lowp)
 
+    def test_view_uint8_through_differing_bitwidths(self):
+        # https://github.com/pytorch/pytorch/issues/120998
+        def fn(x, view_dtype):
+            return x.view(view_dtype).view(torch.uint8)
+
+        view_dtypes = [torch.int16, torch.int32, torch.int64]
+        for dtype in view_dtypes:
+            x = torch.randint(0, 2**4, [4096, 4096], dtype=torch.uint8)
+            self.common(fn, (x, dtype,))
 
 @dataclasses.dataclass
 class TestFailure:

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -9183,7 +9183,14 @@ class CommonTemplate:
         view_dtypes = [torch.int16, torch.int32, torch.int64]
         for dtype in view_dtypes:
             x = torch.randint(0, 2**4, [4096, 4096], dtype=torch.uint8)
-            self.common(fn, (x, dtype,))
+            self.common(
+                fn,
+                (
+                    x,
+                    dtype,
+                ),
+            )
+
 
 @dataclasses.dataclass
 class TestFailure:

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -565,9 +565,8 @@ def to_dtype_bitcast(x: TensorBox, dtype: torch.dtype, *, copy=False):
     src_bits = _get_primitive_bitwidth(x_dtype)
     dst_bits = _get_primitive_bitwidth(dtype)
     if src_bits != dst_bits:
-        raise NotImplementedError(
-            f"bitcast {x_dtype} to different bitwidth type {dtype} is not supported yet."
-        )
+        # fallback to aten eager implementation for differing bitwidths
+        return fallback_handler(aten.view.dtype)(x, dtype)
 
     def _to_dtype_bitcast(x):
         # Because we may promote tensor type from float16 or bfloat16


### PR DESCRIPTION
The inductor lowering code for viewing a tensor as a type with a different bitwidth currently doesn't generate valid triton code. This change looks for a source and destination dtype and, if different sizes, falls back to the eager mode aten implementation.  Prior to this change, this condition would throw an exception.

Fixes #120998.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang