### PR TITLE
Workaround for nvrtcCompileProgram changing locale

### DIFF
--- a/aten/src/ATen/cuda/nvrtc_stub/ATenNVRTC.h
+++ b/aten/src/ATen/cuda/nvrtc_stub/ATenNVRTC.h
@@ -120,6 +120,8 @@ extern "C" typedef struct NVRTC {
 #define CREATE_MEMBER(name) decltype(&name) name;
   AT_FORALL_NVRTC(CREATE_MEMBER)
 #undef CREATE_MEMBER
+  // Must be at end!
+  decltype(nvrtcCompileProgram) nvrtcCompileProgram_real;
 } NVRTC;
 
 extern "C" TORCH_CUDA_CPP_API NVRTC* load_nvrtc();

--- a/caffe2/cuda_rtc/common_rtc.h
+++ b/caffe2/cuda_rtc/common_rtc.h
@@ -1,6 +1,7 @@
 #ifndef CAFFE2_CUDA_RTC_COMMON_RTC_H_
 #define CAFFE2_CUDA_RTC_COMMON_RTC_H_
 
+#include <locale.h>
 #include <sstream>
 #include <string>
 
@@ -46,7 +47,10 @@ class CudaRTCFunction {
     // coding it?
     const char* nvrtc_opts[] = {
         "--gpu-architecture=compute_35", "--use_fast_math"};
+    locale_t oldLocale = uselocale((locale_t) 0);
     nvrtcResult compile_result = nvrtcCompileProgram(prog, 2, nvrtc_opts);
+    if (oldLocale != (locale_t) 0)
+      uselocale(oldLocale);
     if (compile_result != NVRTC_SUCCESS) {
       size_t log_size;
       NVRTC_CHECK(nvrtcGetProgramLogSize(prog, &log_size));


### PR DESCRIPTION
There is a bug in CUDA 11.7 through at least CUDA 12.4 which changes the current thread locale when calling nvrtcCompileProgram.
See e.g. https://stackoverflow.com/questions/74044994 This also includes the encoding used by Python by default for e.g. subsequent invocations of `subprocess` calls. When the user environment is now set to e.g. UTF-8 and changed by CUDA (to ASCII/ANSI_X3.4-1968) Python will fail to decode UTF-8 output from programs invoked.
This happens e.g. in `test_torch` which calls `from scipy import stats` which runs `lscpu` and errors with something like
> UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 96: ordinal not in range(128)

Fix by wrapping the nvrtcCompileProgram saving and restoring the thread locale.


cc @ptrblck @msaroufim