### PR TITLE
Move doc links to point to main

### DIFF
--- a/.github/ISSUE_TEMPLATE/pt2-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/pt2-bug-report.yml
@@ -8,7 +8,7 @@ body:
       value: >
         #### Before submitting a bug, please make sure the issue hasn't been already addressed by searching through [the
         existing and past issues](https://github.com/pytorch/pytorch/issues)
-        It's likely that your bug will be resolved by checking our FAQ or troubleshooting guide [documentation](https://pytorch.org/docs/master/dynamo/index.html)
+        It's likely that your bug will be resolved by checking our FAQ or troubleshooting guide [documentation](https://pytorch.org/docs/main/dynamo/index.html)
   - type: textarea
     attributes:
       label: 🐛 Describe the bug
@@ -33,7 +33,7 @@ body:
       label: Minified repro
       description: |
         Please run the minifier on your example and paste the minified code below
-        Learn more here https://pytorch.org/docs/master/compile/troubleshooting.html
+        Learn more here https://pytorch.org/docs/main/compile/troubleshooting.html
       placeholder: |
         env TORCHDYNAMO_REPRO_AFTER="aot" python your_model.py
         or

--- a/caffe2/python/rnn_cell.py
+++ b/caffe2/python/rnn_cell.py
@@ -289,7 +289,7 @@ class LSTMInitializer:
         ]
 
 
-# based on https://pytorch.org/docs/master/nn.html#torch.nn.RNNCell
+# based on https://pytorch.org/docs/main/nn.html#torch.nn.RNNCell
 class BasicRNNCell(RNNCell):
     def __init__(
         self,

--- a/functorch/docs/source/index.rst
+++ b/functorch/docs/source/index.rst
@@ -12,8 +12,8 @@ functorch is `JAX-like <https://github.com/google/jax>`_ composable function tra
    We've integrated functorch into PyTorch. As the final step of the
    integration, the functorch APIs are deprecated as of PyTorch 2.0.
    Please use the torch.func APIs instead and see the
-   `migration guide <https://pytorch.org/docs/master/func.migrating.html>`_
-   and `docs <https://pytorch.org/docs/master/func.html>`_
+   `migration guide <https://pytorch.org/docs/main/func.migrating.html>`_
+   and `docs <https://pytorch.org/docs/main/func.html>`_
    for more details.
 
 What are composable function transforms?

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -75,7 +75,7 @@ def _rand_shape(dim, min_size, max_size):
 # DOES NOT INCLUDE view ops, which are tested in TestViewOps (currently in
 #   test_torch.py) OR numpy interop (which is also still tested in test_torch.py)
 #
-# See https://pytorch.org/docs/master/torch.html#creation-ops
+# See https://pytorch.org/docs/main/torch.html#creation-ops
 
 class TestTensorCreation(TestCase):
     exact_dtype = True

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -102,8 +102,8 @@ from torch.utils._pytree import tree_map_only
 
 counters: DefaultDict[str, Counter[str]] = collections.defaultdict(collections.Counter)
 optimus_scuba_log: Dict[str, Any] = {}
-troubleshooting_url = "https://pytorch.org/docs/master/compile/troubleshooting.html"
-nnmodule_doc_url = "https://pytorch.org/docs/master/compile/nn-module.html"
+troubleshooting_url = "https://pytorch.org/docs/main/compile/troubleshooting.html"
+nnmodule_doc_url = "https://pytorch.org/docs/main/compile/nn-module.html"
 nnmodule_doc_url_msg = f"See {nnmodule_doc_url} for more information and limitations."
 log = logging.getLogger(__name__)
 

--- a/torch/_functorch/autograd_function.py
+++ b/torch/_functorch/autograd_function.py
@@ -188,7 +188,7 @@ def wrap_outputs_maintaining_identity(
                 f"out_dims has structure {pytree.tree_flatten(out_dims)[1]} "
                 f"but output has structure {spec}. "
                 f"For more details, please see "
-                f"https://pytorch.org/docs/master/notes/extending.func.html"
+                f"https://pytorch.org/docs/main/notes/extending.func.html"
             )
 
     for i, output in enumerate(flat_outputs):
@@ -279,7 +279,7 @@ def custom_function_call_vmap(interpreter, autograd_function, *operands):
                 f"staticmethod. Please set generate_vmap_rule=False or delete "
                 f"the overriden vmap staticmethod to avoid ambiguity. "
                 f"For more details, please see "
-                f"https://pytorch.org/docs/master/notes/extending.func.html")
+                f"https://pytorch.org/docs/main/notes/extending.func.html")
         return custom_function_call_vmap_generate_rule(interpreter, autograd_function, *operands)
 
     if not has_overriden_vmap_rule(autograd_function):
@@ -290,7 +290,7 @@ def custom_function_call_vmap(interpreter, autograd_function, *operands):
             f"it does not have vmap support. Please override and implement the "
             f"vmap staticmethod or set generate_vmap_rule=True. "
             f"For more details, please see "
-            f"https://pytorch.org/docs/master/notes/extending.func.html")
+            f"https://pytorch.org/docs/main/notes/extending.func.html")
 
     current_level = interpreter.level()
     info = VmapInfo(

--- a/torch/_functorch/deprecated.py
+++ b/torch/_functorch/deprecated.py
@@ -26,7 +26,7 @@ def get_warning(api, new_api=None, replace_newlines=False):
         f"2.0 and will be deleted in a future version of PyTorch >= 2.3. \n"
         f"Please use {new_api} instead; see the PyTorch 2.0 release notes \n"
         f"and/or the torch.func migration guide for more details \n"
-        f"https://pytorch.org/docs/master/func.migrating.html"
+        f"https://pytorch.org/docs/main/func.migrating.html"
     )
     if replace_newlines:
         warning = warning.replace("\n", "")

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -637,7 +637,7 @@ class Tensor(torch._C.TensorBase):
             trim(
                 r"""reinforce() was removed.
             Use torch.distributions instead.
-            See https://pytorch.org/docs/master/distributions.html
+            See https://pytorch.org/docs/main/distributions.html
 
             Instead of:
 

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -577,7 +577,7 @@ class Function(_SingleLevelFunction):
                 "In order to use an autograd.Function with functorch transforms "
                 "(vmap, grad, jvp, jacrev, ...), it must override the setup_context "
                 "staticmethod. For more details, please see "
-                "https://pytorch.org/docs/master/notes/extending.func.html"
+                "https://pytorch.org/docs/main/notes/extending.func.html"
             )
 
         return custom_function_call(cls, *args, **kwargs)

--- a/torch/csrc/api/include/torch/fft.h
+++ b/torch/csrc/api/include/torch/fft.h
@@ -6,7 +6,7 @@ namespace torch {
 namespace fft {
 
 /// Computes the 1 dimensional fast Fourier transform over a given dimension.
-/// See https://pytorch.org/docs/master/fft.html#torch.fft.fft.
+/// See https://pytorch.org/docs/main/fft.html#torch.fft.fft.
 ///
 /// Example:
 /// ```
@@ -22,7 +22,7 @@ inline Tensor fft(
 }
 
 /// Computes the 1 dimensional inverse Fourier transform over a given dimension.
-/// See https://pytorch.org/docs/master/fft.html#torch.fft.ifft.
+/// See https://pytorch.org/docs/main/fft.html#torch.fft.ifft.
 ///
 /// Example:
 /// ```
@@ -38,7 +38,7 @@ inline Tensor ifft(
 }
 
 /// Computes the 2-dimensional fast Fourier transform over the given dimensions.
-/// See https://pytorch.org/docs/master/fft.html#torch.fft.fft2.
+/// See https://pytorch.org/docs/main/fft.html#torch.fft.fft2.
 ///
 /// Example:
 /// ```
@@ -54,7 +54,7 @@ inline Tensor fft2(
 }
 
 /// Computes the inverse of torch.fft.fft2
-/// See https://pytorch.org/docs/master/fft.html#torch.fft.ifft2.
+/// See https://pytorch.org/docs/main/fft.html#torch.fft.ifft2.
 ///
 /// Example:
 /// ```
@@ -70,7 +70,7 @@ inline Tensor ifft2(
 }
 
 /// Computes the N dimensional fast Fourier transform over given dimensions.
-/// See https://pytorch.org/docs/master/fft.html#torch.fft.fftn.
+/// See https://pytorch.org/docs/main/fft.html#torch.fft.fftn.
 ///
 /// Example:
 /// ```
@@ -86,7 +86,7 @@ inline Tensor fftn(
 }
 
 /// Computes the N dimensional fast Fourier transform over given dimensions.
-/// See https://pytorch.org/docs/master/fft.html#torch.fft.ifftn.
+/// See https://pytorch.org/docs/main/fft.html#torch.fft.ifftn.
 ///
 /// Example:
 /// ```
@@ -102,7 +102,7 @@ inline Tensor ifftn(
 }
 
 /// Computes the 1 dimensional FFT of real input with onesided Hermitian output.
-/// See https://pytorch.org/docs/master/fft.html#torch.fft.rfft.
+/// See https://pytorch.org/docs/main/fft.html#torch.fft.rfft.
 ///
 /// Example:
 /// ```
@@ -121,7 +121,7 @@ inline Tensor rfft(
 /// Computes the inverse of torch.fft.rfft
 ///
 /// The input is a onesided Hermitian Fourier domain signal, with real-valued
-/// output. See https://pytorch.org/docs/master/fft.html#torch.fft.irfft
+/// output. See https://pytorch.org/docs/main/fft.html#torch.fft.irfft
 ///
 /// Example:
 /// ```
@@ -138,7 +138,7 @@ inline Tensor irfft(
 }
 
 /// Computes the 2-dimensional FFT of real input. Returns a onesided Hermitian
-/// output. See https://pytorch.org/docs/master/fft.html#torch.fft.rfft2
+/// output. See https://pytorch.org/docs/main/fft.html#torch.fft.rfft2
 ///
 /// Example:
 /// ```
@@ -154,7 +154,7 @@ inline Tensor rfft2(
 }
 
 /// Computes the inverse of torch.fft.rfft2.
-/// See https://pytorch.org/docs/master/fft.html#torch.fft.irfft2.
+/// See https://pytorch.org/docs/main/fft.html#torch.fft.irfft2.
 ///
 /// Example:
 /// ```
@@ -170,7 +170,7 @@ inline Tensor irfft2(
 }
 
 /// Computes the N dimensional FFT of real input with onesided Hermitian output.
-/// See https://pytorch.org/docs/master/fft.html#torch.fft.rfftn
+/// See https://pytorch.org/docs/main/fft.html#torch.fft.rfftn
 ///
 /// Example:
 /// ```
@@ -186,7 +186,7 @@ inline Tensor rfftn(
 }
 
 /// Computes the inverse of torch.fft.rfftn.
-/// See https://pytorch.org/docs/master/fft.html#torch.fft.irfftn.
+/// See https://pytorch.org/docs/main/fft.html#torch.fft.irfftn.
 ///
 /// Example:
 /// ```
@@ -205,7 +205,7 @@ inline Tensor irfftn(
 ///
 /// The input represents a Hermitian symmetric time domain signal. The returned
 /// Fourier domain representation of such a signal is a real-valued. See
-/// https://pytorch.org/docs/master/fft.html#torch.fft.hfft
+/// https://pytorch.org/docs/main/fft.html#torch.fft.hfft
 ///
 /// Example:
 /// ```
@@ -224,7 +224,7 @@ inline Tensor hfft(
 /// Computes the inverse FFT of a real-valued Fourier domain signal.
 ///
 /// The output is a onesided representation of the Hermitian symmetric time
-/// domain signal. See https://pytorch.org/docs/master/fft.html#torch.fft.ihfft.
+/// domain signal. See https://pytorch.org/docs/main/fft.html#torch.fft.ihfft.
 ///
 /// Example:
 /// ```
@@ -243,7 +243,7 @@ inline Tensor ihfft(
 /// Computes the 2-dimensional FFT of a Hermitian symmetric input signal.
 ///
 /// The input is a onesided representation of the Hermitian symmetric time
-/// domain signal. See https://pytorch.org/docs/master/fft.html#torch.fft.hfft2.
+/// domain signal. See https://pytorch.org/docs/main/fft.html#torch.fft.hfft2.
 ///
 /// Example:
 /// ```
@@ -263,7 +263,7 @@ inline Tensor hfft2(
 ///
 /// The output is a onesided representation of the Hermitian symmetric time
 /// domain signal. See
-/// https://pytorch.org/docs/master/fft.html#torch.fft.ihfft2.
+/// https://pytorch.org/docs/main/fft.html#torch.fft.ihfft2.
 ///
 /// Example:
 /// ```
@@ -282,7 +282,7 @@ inline Tensor ihfft2(
 /// Computes the N-dimensional FFT of a Hermitian symmetric input signal.
 ///
 /// The input is a onesided representation of the Hermitian symmetric time
-/// domain signal. See https://pytorch.org/docs/master/fft.html#torch.fft.hfftn.
+/// domain signal. See https://pytorch.org/docs/main/fft.html#torch.fft.hfftn.
 ///
 /// Example:
 /// ```
@@ -302,7 +302,7 @@ inline Tensor hfftn(
 ///
 /// The output is a onesided representation of the Hermitian symmetric time
 /// domain signal. See
-/// https://pytorch.org/docs/master/fft.html#torch.fft.ihfftn.
+/// https://pytorch.org/docs/main/fft.html#torch.fft.ihfftn.
 ///
 /// Example:
 /// ```
@@ -321,7 +321,7 @@ inline Tensor ihfftn(
 /// Computes the discrete Fourier Transform sample frequencies for a signal of
 /// size n.
 ///
-/// See https://pytorch.org/docs/master/fft.html#torch.fft.fftfreq
+/// See https://pytorch.org/docs/main/fft.html#torch.fft.fftfreq
 ///
 /// Example:
 /// ```
@@ -338,7 +338,7 @@ inline Tensor fftfreq(int64_t n, const TensorOptions& options = {}) {
 /// Computes the sample frequencies for torch.fft.rfft with a signal of size n.
 ///
 /// Like torch.fft.rfft, only the positive frequencies are included.
-/// See https://pytorch.org/docs/master/fft.html#torch.fft.rfftfreq
+/// See https://pytorch.org/docs/main/fft.html#torch.fft.rfftfreq
 ///
 /// Example:
 /// ```
@@ -355,7 +355,7 @@ inline Tensor rfftfreq(int64_t n, const TensorOptions& options) {
 /// Reorders n-dimensional FFT output to have negative frequency terms first, by
 /// a torch.roll operation.
 ///
-/// See https://pytorch.org/docs/master/fft.html#torch.fft.fftshift
+/// See https://pytorch.org/docs/main/fft.html#torch.fft.fftshift
 ///
 /// Example:
 /// ```
@@ -370,7 +370,7 @@ inline Tensor fftshift(
 
 /// Inverse of torch.fft.fftshift
 ///
-/// See https://pytorch.org/docs/master/fft.html#torch.fft.ifftshift
+/// See https://pytorch.org/docs/main/fft.html#torch.fft.ifftshift
 ///
 /// Example:
 /// ```

--- a/torch/csrc/api/include/torch/linalg.h
+++ b/torch/csrc/api/include/torch/linalg.h
@@ -445,7 +445,7 @@ inline Tensor& inv_out(Tensor& result, const Tensor& input) {
 
 /// Cholesky decomposition
 ///
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.cholesky
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.cholesky
 ///
 /// Example:
 /// ```
@@ -474,7 +474,7 @@ inline Tensor det(const Tensor& self) {
 
 /// Computes the sign and (natural) logarithm of the determinant
 ///
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.slogdet
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.slogdet
 inline std::tuple<Tensor, Tensor> slogdet(const Tensor& input) {
   return detail::slogdet(input);
 }
@@ -489,7 +489,7 @@ inline std::tuple<Tensor&, Tensor&> slogdet_out(
 /// Computes eigenvalues and eigenvectors of non-symmetric/non-hermitian
 /// matrices
 ///
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.eig
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.eig
 inline std::tuple<Tensor, Tensor> eig(const Tensor& self) {
   return detail::eig(self);
 }
@@ -503,7 +503,7 @@ inline std::tuple<Tensor&, Tensor&> eig_out(
 
 /// Computes eigenvalues of non-symmetric/non-hermitian matrices
 ///
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.eigvals
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.eigvals
 inline Tensor eigvals(const Tensor& self) {
   return detail::eigvals(self);
 }
@@ -514,7 +514,7 @@ inline Tensor& eigvals_out(Tensor& result, const Tensor& self) {
 
 /// Computes eigenvalues and eigenvectors
 ///
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.eigh
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.eigh
 inline std::tuple<Tensor, Tensor> eigh(
     const Tensor& self,
     c10::string_view uplo) {
@@ -531,7 +531,7 @@ inline std::tuple<Tensor&, Tensor&> eigh_out(
 
 /// Computes eigenvalues
 ///
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.eigvalsh
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.eigvalsh
 inline Tensor eigvalsh(const Tensor& self, c10::string_view uplo) {
   return detail::eigvalsh(self, uplo);
 }
@@ -546,7 +546,7 @@ inline Tensor& eigvalsh_out(
 /// Computes the product of Householder matrices
 ///
 /// See
-/// https://pytorch.org/docs/master/linalg.html#torch.linalg.householder_product
+/// https://pytorch.org/docs/main/linalg.html#torch.linalg.householder_product
 inline Tensor householder_product(const Tensor& input, const Tensor& tau) {
   return detail::householder_product(input, tau);
 }
@@ -568,7 +568,7 @@ inline std::tuple<Tensor, Tensor, Tensor, Tensor> lstsq(
 
 /// Computes the matrix exponential
 ///
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.matrix_exp
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.matrix_exp
 inline Tensor matrix_exp(const Tensor& input) {
   return detail::matrix_exp(input);
 }
@@ -619,7 +619,7 @@ inline Tensor& linalg_norm_out(
 
 /// Computes the LU factorization with partial pivoting
 ///
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.lu_factor
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.lu_factor
 inline std::tuple<Tensor, Tensor> lu_factor(
     const Tensor& input,
     const bool pivot = true) {
@@ -636,7 +636,7 @@ inline std::tuple<Tensor&, Tensor&> lu_factor_out(
 
 /// Computes the LU factorization with partial pivoting
 ///
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.lu
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.lu
 inline std::tuple<Tensor, Tensor, Tensor> lu(
     const Tensor& input,
     const bool pivot = true) {
@@ -690,7 +690,7 @@ inline Tensor& norm_out(
   return detail::norm_out(result, self, ord, opt_dim, keepdim, opt_dtype);
 }
 
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.vector_norm
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.vector_norm
 inline Tensor vector_norm(
     const Tensor& self,
     Scalar ord,
@@ -711,7 +711,7 @@ inline Tensor& vector_norm_out(
       result, self, ord, opt_dim, keepdim, opt_dtype);
 }
 
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.matrix_norm
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.matrix_norm
 inline Tensor matrix_norm(
     const Tensor& self,
     const Scalar& ord,
@@ -750,7 +750,7 @@ inline Tensor& matrix_norm_out(
   return detail::matrix_norm_out(self, ord, dim, keepdim, dtype, result);
 }
 
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.matrix_power
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.matrix_power
 inline Tensor matrix_power(const Tensor& self, int64_t n) {
   return detail::matrix_power(self, n);
 }
@@ -759,7 +759,7 @@ inline Tensor& matrix_power_out(const Tensor& self, int64_t n, Tensor& result) {
   return detail::matrix_power_out(self, n, result);
 }
 
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.matrix_rank
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.matrix_rank
 inline Tensor matrix_rank(const Tensor& input, double tol, bool hermitian) {
   return detail::matrix_rank(input, tol, hermitian);
 }
@@ -821,7 +821,7 @@ inline Tensor& matrix_rank_out(
   return detail::matrix_rank_out(result, input, atol, rtol, hermitian);
 }
 
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.multi_dot
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.multi_dot
 inline Tensor multi_dot(TensorList tensors) {
   return detail::multi_dot(tensors);
 }
@@ -832,7 +832,7 @@ inline Tensor& multi_dot_out(TensorList tensors, Tensor& result) {
 
 /// Computes the pseudo-inverse
 ///
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.pinv
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.pinv
 inline Tensor pinv(
     const Tensor& input,
     double rcond = 1e-15,
@@ -850,7 +850,7 @@ inline Tensor& pinv_out(
 
 /// Computes the QR decomposition
 ///
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.qr
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.qr
 inline std::tuple<Tensor, Tensor> qr(
     const Tensor& input,
     c10::string_view mode = "reduced") {
@@ -869,7 +869,7 @@ inline std::tuple<Tensor&, Tensor&> qr_out(
 
 /// Computes the LDL decomposition
 ///
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.ldl_factor_ex
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.ldl_factor_ex
 inline std::tuple<Tensor, Tensor, Tensor> ldl_factor_ex(
     const Tensor& input,
     bool hermitian,
@@ -890,7 +890,7 @@ inline std::tuple<Tensor&, Tensor&, Tensor&> ldl_factor_ex_out(
 
 /// Solve a system of linear equations using the LDL decomposition
 ///
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.ldl_solve
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.ldl_solve
 inline Tensor ldl_solve(
     const Tensor& LD,
     const Tensor& pivots,
@@ -910,7 +910,7 @@ inline Tensor& ldl_solve_out(
 
 /// Solves a system linear system AX = B
 ///
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.solve_ex
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.solve_ex
 inline std::tuple<Tensor, Tensor> solve_ex(
     const Tensor& input,
     const Tensor& other,
@@ -931,7 +931,7 @@ inline std::tuple<Tensor&, Tensor&> solve_ex_out(
 
 /// Computes a tensor `x` such that `matmul(input, x) = other`.
 ///
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.solve
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.solve
 inline Tensor solve(const Tensor& input, const Tensor& other, bool left) {
   return detail::solve(input, other, left);
 }
@@ -949,7 +949,7 @@ inline Tensor& solve_out(
 /// the diagonal
 ///
 /// See
-/// https://pytorch.org/docs/master/linalg.html#torch.linalg.solve_triangular
+/// https://pytorch.org/docs/main/linalg.html#torch.linalg.solve_triangular
 inline Tensor solve_triangular(
     const Tensor& input,
     const Tensor& other,
@@ -972,7 +972,7 @@ inline Tensor& solve_triangular_out(
 
 /// Computes the singular values and singular vectors
 ///
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.svd
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.svd
 inline std::tuple<Tensor, Tensor, Tensor> svd(
     const Tensor& input,
     bool full_matrices,
@@ -992,7 +992,7 @@ inline std::tuple<Tensor&, Tensor&, Tensor&> svd_out(
 
 /// Computes the singular values
 ///
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.svdvals
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.svdvals
 inline Tensor svdvals(
     const Tensor& input,
     c10::optional<c10::string_view> driver) {
@@ -1008,7 +1008,7 @@ inline Tensor& svdvals_out(
 
 /// Computes the inverse of a tensor
 ///
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.tensorinv
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.tensorinv
 ///
 /// Example:
 /// ```
@@ -1026,7 +1026,7 @@ inline Tensor& tensorinv_out(Tensor& result, const Tensor& self, int64_t ind) {
 
 /// Computes a tensor `x` such that `tensordot(input, x, dims=x.dim()) = other`.
 ///
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.tensorsolve
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.tensorsolve
 ///
 /// Example:
 /// ```
@@ -1052,7 +1052,7 @@ inline Tensor& tensorsolve_out(
 /// Computes a tensor `inverse_input` such that `dot(input, inverse_input) =
 /// eye(input.size(0))`.
 ///
-/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.inv
+/// See https://pytorch.org/docs/main/linalg.html#torch.linalg.inv
 inline Tensor inv(const Tensor& input) {
   return detail::inv(input);
 }

--- a/torch/csrc/api/include/torch/nested.h
+++ b/torch/csrc/api/include/torch/nested.h
@@ -11,7 +11,7 @@ namespace nested {
 /// Nested tensor
 ///
 /// See
-/// https://pytorch.org/docs/master/nested.html#torch.nested.nested_tensor
+/// https://pytorch.org/docs/main/nested.html#torch.nested.nested_tensor
 ///
 /// ```
 // implemented on python object to allow torch.nested.nested_tensor to be
@@ -67,7 +67,7 @@ inline at::Tensor nested_tensor(
 /// As Nested Tensor
 ///
 /// See
-/// https://pytorch.org/docs/master/nested.html#torch.nested.as_nested_tensor
+/// https://pytorch.org/docs/main/nested.html#torch.nested.as_nested_tensor
 ///
 /// ```
 inline at::Tensor as_nested_tensor(
@@ -81,7 +81,7 @@ inline at::Tensor as_nested_tensor(
 /// Nested to padded tensor
 ///
 /// See
-/// https://pytorch.org/docs/master/nested.html#torch.nested.to_padded_tensor
+/// https://pytorch.org/docs/main/nested.html#torch.nested.to_padded_tensor
 ///
 /// ```
 inline at::Tensor to_padded_tensor(

--- a/torch/csrc/api/include/torch/nn/functional/activation.h
+++ b/torch/csrc/api/include/torch/nn/functional/activation.h
@@ -27,7 +27,7 @@ inline Tensor elu(Tensor input, double alpha, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.elu
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.elu
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::ELUFuncOptions` class to
@@ -57,7 +57,7 @@ inline Tensor selu(Tensor input, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.selu
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.selu
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::SELUFuncOptions` class to
@@ -83,7 +83,7 @@ inline Tensor hardshrink(const Tensor& input, double lambda) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.hardshrink
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.hardshrink
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::HardshrinkFuncOptions`
@@ -119,7 +119,7 @@ inline Tensor hardtanh(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.hardtanh
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.hardtanh
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::HardtanhFuncOptions` class
@@ -154,7 +154,7 @@ inline Tensor leaky_relu(Tensor input, double negative_slope, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.leaky_relu
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.leaky_relu
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::LeakyReLUFuncOptions`
@@ -208,7 +208,7 @@ inline Tensor gumbel_softmax(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.gumbel_softmax
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.gumbel_softmax
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::GumbelSoftmaxFuncOptions`
@@ -248,7 +248,7 @@ inline Tensor softmax(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.softmax
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.softmax
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::SoftmaxFuncOptions` class
@@ -285,7 +285,7 @@ inline Tensor softmin(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.softmin
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.softmin
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::SoftminFuncOptions` class
@@ -322,7 +322,7 @@ inline Tensor log_softmax(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.log_softmax
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.log_softmax
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::LogSoftmaxFuncOptions`
@@ -353,7 +353,7 @@ inline Tensor glu(const Tensor& input, int64_t dim) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.glu
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.glu
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::GLUFuncOptions` class to
@@ -415,7 +415,7 @@ inline Tensor relu(Tensor input, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.relu
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.relu
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::ReLUFuncOptions` class to
@@ -445,7 +445,7 @@ inline Tensor relu6(Tensor input, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.relu6
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.relu6
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::ReLU6FuncOptions` class to
@@ -480,7 +480,7 @@ inline Tensor rrelu(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.rrelu
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.rrelu
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::RReLUFuncOptions` class to
@@ -515,7 +515,7 @@ inline Tensor celu(Tensor input, double alpha, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.celu
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.celu
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::CELUFuncOptions` class to
@@ -541,7 +541,7 @@ inline Tensor softplus(const Tensor& input, double beta, double threshold) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.softplus
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.softplus
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::SoftplusFuncOptions` class
@@ -569,7 +569,7 @@ inline Tensor softshrink(const Tensor& input, double lambda) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.softshrink
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.softshrink
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::SoftshrinkFuncOptions`
@@ -617,7 +617,7 @@ inline Tensor threshold(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.threshold
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.threshold
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::ThresholdFuncOptions`

--- a/torch/csrc/api/include/torch/nn/functional/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/functional/batchnorm.h
@@ -50,7 +50,7 @@ inline Tensor batch_norm(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.batch_norm
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.batch_norm
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::BatchNormFuncOptions`

--- a/torch/csrc/api/include/torch/nn/functional/conv.h
+++ b/torch/csrc/api/include/torch/nn/functional/conv.h
@@ -42,7 +42,7 @@ inline Tensor conv1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.conv1d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.conv1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::Conv1dFuncOptions` class
@@ -88,7 +88,7 @@ inline Tensor conv2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.conv2d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.conv2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::Conv2dFuncOptions` class
@@ -134,7 +134,7 @@ inline Tensor conv3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.conv3d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.conv3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::Conv3dFuncOptions` class
@@ -179,7 +179,7 @@ inline Tensor conv_transpose1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.conv_transpose1d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.conv_transpose1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -224,7 +224,7 @@ inline Tensor conv_transpose2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.conv_transpose2d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.conv_transpose2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -269,7 +269,7 @@ inline Tensor conv_transpose3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.conv_transpose3d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.conv_transpose3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for

--- a/torch/csrc/api/include/torch/nn/functional/distance.h
+++ b/torch/csrc/api/include/torch/nn/functional/distance.h
@@ -19,7 +19,7 @@ inline Tensor cosine_similarity(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.cosine_similarity
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.cosine_similarity
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -55,7 +55,7 @@ inline Tensor pairwise_distance(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.pairwise_distance
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.pairwise_distance
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for

--- a/torch/csrc/api/include/torch/nn/functional/dropout.h
+++ b/torch/csrc/api/include/torch/nn/functional/dropout.h
@@ -27,7 +27,7 @@ inline Tensor dropout(Tensor input, double p, bool training, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.dropout
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.dropout
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::DropoutFuncOptions` class
@@ -96,7 +96,7 @@ inline Tensor dropout2d(Tensor input, double p, bool training, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.dropout2d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.dropout2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::Dropout2dFuncOptions`
@@ -128,7 +128,7 @@ inline Tensor dropout3d(Tensor input, double p, bool training, bool inplace) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.dropout3d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.dropout3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::Dropout3dFuncOptions`
@@ -168,7 +168,7 @@ inline Tensor alpha_dropout(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.alpha_dropout
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.alpha_dropout
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::AlphaDropoutFuncOptions`
@@ -209,7 +209,7 @@ inline Tensor feature_alpha_dropout(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.feature_alpha_dropout
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.feature_alpha_dropout
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for

--- a/torch/csrc/api/include/torch/nn/functional/embedding.h
+++ b/torch/csrc/api/include/torch/nn/functional/embedding.h
@@ -58,7 +58,7 @@ inline Tensor embedding(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.embedding
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.embedding
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::EmbeddingFuncOptions`
@@ -176,7 +176,7 @@ inline Tensor embedding_bag(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.embedding_bag
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.embedding_bag
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::EmbeddingBagFuncOptions`

--- a/torch/csrc/api/include/torch/nn/functional/fold.h
+++ b/torch/csrc/api/include/torch/nn/functional/fold.h
@@ -31,7 +31,7 @@ inline Tensor fold(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.fold
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.fold
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::FoldFuncOptions` class to
@@ -77,7 +77,7 @@ inline Tensor unfold(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.unfold
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.unfold
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::UnfoldFuncOptions` class

--- a/torch/csrc/api/include/torch/nn/functional/instancenorm.h
+++ b/torch/csrc/api/include/torch/nn/functional/instancenorm.h
@@ -32,7 +32,7 @@ inline Tensor instance_norm(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.instance_norm
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.instance_norm
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::InstanceNormFuncOptions`

--- a/torch/csrc/api/include/torch/nn/functional/loss.h
+++ b/torch/csrc/api/include/torch/nn/functional/loss.h
@@ -20,7 +20,7 @@ inline Tensor l1_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.l1_loss
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.l1_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::L1LossFuncOptions` class
@@ -77,7 +77,7 @@ inline Tensor kl_div(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.kl_div
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.kl_div
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::KLDivFuncOptions` class to
@@ -126,7 +126,7 @@ inline Tensor mse_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.mse_loss
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.mse_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::MSELossFuncOptions` class
@@ -179,7 +179,7 @@ inline Tensor binary_cross_entropy(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.binary_cross_entropy
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.binary_cross_entropy
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -216,7 +216,7 @@ inline Tensor hinge_embedding_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.hinge_embedding_loss
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.hinge_embedding_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -265,7 +265,7 @@ inline Tensor multi_margin_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.multi_margin_loss
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.multi_margin_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -308,7 +308,7 @@ inline Tensor cosine_embedding_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.cosine_embedding_loss
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.cosine_embedding_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -371,7 +371,7 @@ inline Tensor smooth_l1_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.smooth_l1_loss
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.smooth_l1_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::SmoothL1LossFuncOptions`
@@ -391,7 +391,7 @@ inline Tensor smooth_l1_loss(
 }
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.smooth_l1_loss
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.smooth_l1_loss
 /// about the exact behavior of this functional.
 ///
 /// Example:
@@ -443,7 +443,7 @@ inline Tensor huber_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.huber_loss
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.huber_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::HuberLossFuncOptions`
@@ -478,7 +478,7 @@ inline Tensor multilabel_margin_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.multilabel_margin_loss
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.multilabel_margin_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -513,7 +513,7 @@ inline Tensor soft_margin_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.soft_margin_loss
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.soft_margin_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::SoftMarginLossFuncOptions`
@@ -571,7 +571,7 @@ inline Tensor multilabel_soft_margin_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.multilabel_soft_margin_loss
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.multilabel_soft_margin_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -619,7 +619,7 @@ inline Tensor triplet_margin_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.triplet_margin_loss
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.triplet_margin_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -701,7 +701,7 @@ inline Tensor triplet_margin_with_distance_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.triplet_margin_with_distance_loss
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.triplet_margin_with_distance_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -754,7 +754,7 @@ inline Tensor ctc_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.ctc_loss
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.ctc_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::CTCLossFuncOptions` class
@@ -805,7 +805,7 @@ inline Tensor poisson_nll_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.poisson_nll_loss
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.poisson_nll_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::PoissonNLLLossFuncOptions`
@@ -856,7 +856,7 @@ inline Tensor margin_ranking_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.margin_ranking_loss
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.margin_ranking_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -913,7 +913,7 @@ inline Tensor nll_loss(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.nll_loss
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.nll_loss
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::NLLLossFuncOptions` class
@@ -960,7 +960,7 @@ inline Tensor cross_entropy(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.cross_entropy
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.cross_entropy
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::CrossEntropyFuncOptions`
@@ -1014,7 +1014,7 @@ inline Tensor binary_cross_entropy_with_logits(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.binary_cross_entropy_with_logits
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.binary_cross_entropy_with_logits
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for

--- a/torch/csrc/api/include/torch/nn/functional/normalization.h
+++ b/torch/csrc/api/include/torch/nn/functional/normalization.h
@@ -29,7 +29,7 @@ inline Tensor normalize(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.normalize
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.normalize
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::NormalizeFuncOptions`
@@ -63,7 +63,7 @@ inline Tensor layer_norm(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.layer_norm
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.layer_norm
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::LayerNormFuncOptions`
@@ -143,7 +143,7 @@ inline Tensor local_response_norm(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.local_response_norm
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.local_response_norm
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -184,7 +184,7 @@ inline Tensor group_norm(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.group_norm
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.group_norm
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::GroupNormFuncOptions`

--- a/torch/csrc/api/include/torch/nn/functional/padding.h
+++ b/torch/csrc/api/include/torch/nn/functional/padding.h
@@ -37,7 +37,7 @@ inline Tensor pad(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.pad
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.pad
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::PadFuncOptions` class to

--- a/torch/csrc/api/include/torch/nn/functional/pixelshuffle.h
+++ b/torch/csrc/api/include/torch/nn/functional/pixelshuffle.h
@@ -19,7 +19,7 @@ inline Tensor pixel_unshuffle(const Tensor& input, int64_t downscale_factor) {
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.pixel_shuffle
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.pixel_shuffle
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::PixelShuffleFuncOptions`

--- a/torch/csrc/api/include/torch/nn/functional/pooling.h
+++ b/torch/csrc/api/include/torch/nn/functional/pooling.h
@@ -25,7 +25,7 @@ inline Tensor avg_pool1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.avg_pool1d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.avg_pool1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::AvgPool1dFuncOptions`
@@ -71,7 +71,7 @@ inline Tensor avg_pool2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.avg_pool2d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.avg_pool2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::AvgPool2dFuncOptions`
@@ -118,7 +118,7 @@ inline Tensor avg_pool3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.avg_pool3d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.avg_pool3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::AvgPool3dFuncOptions`
@@ -160,7 +160,7 @@ inline Tensor max_pool1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.max_pool1d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.max_pool1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::MaxPool1dFuncOptions`
@@ -234,7 +234,7 @@ inline Tensor max_pool2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.max_pool2d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.max_pool2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::MaxPool2dFuncOptions`
@@ -308,7 +308,7 @@ inline Tensor max_pool3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.max_pool3d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.max_pool3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::MaxPool3dFuncOptions`
@@ -402,7 +402,7 @@ inline Tensor adaptive_max_pool1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.adaptive_max_pool1d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.adaptive_max_pool1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -458,7 +458,7 @@ inline Tensor adaptive_max_pool2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.adaptive_max_pool2d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.adaptive_max_pool2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -514,7 +514,7 @@ inline Tensor adaptive_max_pool3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.adaptive_max_pool3d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.adaptive_max_pool3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -545,7 +545,7 @@ inline Tensor adaptive_avg_pool1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.adaptive_avg_pool1d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.adaptive_avg_pool1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -576,7 +576,7 @@ inline Tensor adaptive_avg_pool2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.adaptive_avg_pool2d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.adaptive_avg_pool2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -607,7 +607,7 @@ inline Tensor adaptive_avg_pool3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.adaptive_avg_pool3d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.adaptive_avg_pool3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for
@@ -700,7 +700,7 @@ inline Tensor max_unpool1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.max_unpool1d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.max_unpool1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::MaxUnpool1dFuncOptions`
@@ -743,7 +743,7 @@ inline Tensor max_unpool2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.max_unpool2d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.max_unpool2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::MaxUnpool2dFuncOptions`
@@ -786,7 +786,7 @@ inline Tensor max_unpool3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.max_unpool3d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.max_unpool3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::MaxUnpool3dFuncOptions`
@@ -1027,7 +1027,7 @@ inline Tensor lp_pool1d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.lp_pool1d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.lp_pool1d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::LPPool1dFuncOptions` class
@@ -1076,7 +1076,7 @@ inline Tensor lp_pool2d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.lp_pool2d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.lp_pool2d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::LPPool2dFuncOptions` class
@@ -1126,7 +1126,7 @@ inline Tensor lp_pool3d(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.lp_pool3d
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.lp_pool3d
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::LPPool3dFuncOptions` class

--- a/torch/csrc/api/include/torch/nn/functional/upsampling.h
+++ b/torch/csrc/api/include/torch/nn/functional/upsampling.h
@@ -259,7 +259,7 @@ inline Tensor interpolate(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.interpolate
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.interpolate
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::InterpolateFuncOptions`

--- a/torch/csrc/api/include/torch/nn/functional/vision.h
+++ b/torch/csrc/api/include/torch/nn/functional/vision.h
@@ -95,7 +95,7 @@ inline Tensor grid_sample(
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
 /// See
-/// https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.grid_sample
+/// https://pytorch.org/docs/main/nn.functional.html#torch.nn.functional.grid_sample
 /// about the exact behavior of this functional.
 ///
 /// See the documentation for `torch::nn::functional::GridSampleFuncOptions`

--- a/torch/csrc/api/include/torch/nn/modules/activation.h
+++ b/torch/csrc/api/include/torch/nn/modules/activation.h
@@ -14,7 +14,7 @@ namespace nn {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ELU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies elu over a given input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.ELU to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.ELU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ELUOptions` class to learn what
@@ -49,7 +49,7 @@ TORCH_MODULE(ELU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SELU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the selu function element-wise.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.SELU to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.SELU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::SELUOptions` class to learn what
@@ -84,7 +84,7 @@ TORCH_MODULE(SELU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Hardshrink ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the hard shrinkage function element-wise.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.Hardshrink to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.Hardshrink to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::HardshrinkOptions` class to learn what
@@ -119,7 +119,7 @@ TORCH_MODULE(Hardshrink);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Hardtanh ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the HardTanh function element-wise.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.Hardtanh to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.Hardtanh to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::HardtanhOptions` class to learn what
@@ -155,7 +155,7 @@ TORCH_MODULE(Hardtanh);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LeakyReLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the LeakyReLU function element-wise.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.LeakyReLU to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.LeakyReLU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LeakyReLUOptions` class to learn what
@@ -190,7 +190,7 @@ TORCH_MODULE(LeakyReLU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LogSigmoid ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the LogSigmoid function element-wise.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.LogSigmoid to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.LogSigmoid to learn
 /// about the exact behavior of this module.
 class TORCH_API LogSigmoidImpl : public torch::nn::Cloneable<LogSigmoidImpl> {
  public:
@@ -211,7 +211,7 @@ TORCH_MODULE(LogSigmoid);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softmax ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the Softmax function.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.Softmax to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.Softmax to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::SoftmaxOptions` class to learn what
@@ -246,7 +246,7 @@ TORCH_MODULE(Softmax);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softmin ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the Softmin function element-wise.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.Softmin to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.Softmin to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::SoftminOptions` class to learn what
@@ -281,7 +281,7 @@ TORCH_MODULE(Softmin);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LogSoftmax ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the LogSoftmax function element-wise.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.LogSoftmax to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.LogSoftmax to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LogSoftmaxOptions` class to learn what
@@ -317,7 +317,7 @@ TORCH_MODULE(LogSoftmax);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softmax2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the Softmax2d function element-wise.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.Softmax2d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.Softmax2d to learn
 /// about the exact behavior of this module.
 class TORCH_API Softmax2dImpl : public torch::nn::Cloneable<Softmax2dImpl> {
  public:
@@ -338,7 +338,7 @@ TORCH_MODULE(Softmax2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ PReLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the PReLU function element-wise.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.PReLU to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.PReLU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::PReLUOptions` class to learn what
@@ -376,7 +376,7 @@ TORCH_MODULE(PReLU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ReLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the ReLU function element-wise.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.ReLU to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.ReLU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReLUOptions` class to learn what
@@ -411,7 +411,7 @@ TORCH_MODULE(ReLU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ReLU6 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the ReLU6 function element-wise.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.ReLU6 to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.ReLU6 to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReLU6Options` class to learn what
@@ -446,7 +446,7 @@ TORCH_MODULE(ReLU6);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ RReLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the RReLU function element-wise.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.RReLU to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.RReLU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::RReLUOptions` class to learn what
@@ -481,7 +481,7 @@ TORCH_MODULE(RReLU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CELU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies celu over a given input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.CELU to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.CELU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::CELUOptions` class to learn what
@@ -516,7 +516,7 @@ TORCH_MODULE(CELU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies glu over a given input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.GLU to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.GLU to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::GLUOptions` class to learn what
@@ -551,7 +551,7 @@ TORCH_MODULE(GLU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GELU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies gelu over a given input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.GELU to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.GELU to learn
 /// about the exact behavior of this module.
 class TORCH_API GELUImpl : public torch::nn::Cloneable<GELUImpl> {
  public:
@@ -577,7 +577,7 @@ TORCH_MODULE(GELU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SiLU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies silu over a given input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.SiLU to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.SiLU to learn
 /// about the exact behavior of this module.
 class TORCH_API SiLUImpl : public torch::nn::Cloneable<SiLUImpl> {
  public:
@@ -598,7 +598,7 @@ TORCH_MODULE(SiLU);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Mish ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies mish over a given input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.Mish to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.Mish to learn
 /// about the exact behavior of this module.
 class TORCH_API MishImpl : public torch::nn::Cloneable<MishImpl> {
  public:
@@ -619,7 +619,7 @@ TORCH_MODULE(Mish);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Sigmoid ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies sigmoid over a given input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.Sigmoid to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.Sigmoid to learn
 /// about the exact behavior of this module.
 class TORCH_API SigmoidImpl : public torch::nn::Cloneable<SigmoidImpl> {
  public:
@@ -640,7 +640,7 @@ TORCH_MODULE(Sigmoid);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softplus ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies softplus over a given input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.Softplus to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.Softplus to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::SoftplusOptions` class to learn what
@@ -675,7 +675,7 @@ TORCH_MODULE(Softplus);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softshrink ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the soft shrinkage function element-wise.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.Softshrink to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.Softshrink to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::SoftshrinkOptions` class to learn what
@@ -710,7 +710,7 @@ TORCH_MODULE(Softshrink);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Softsign ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies Softsign over a given input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.Softsign to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.Softsign to learn
 /// about the exact behavior of this module.
 class TORCH_API SoftsignImpl : public torch::nn::Cloneable<SoftsignImpl> {
  public:
@@ -731,7 +731,7 @@ TORCH_MODULE(Softsign);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Tanh ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies Tanh over a given input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.Tanh to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.Tanh to learn
 /// about the exact behavior of this module.
 class TORCH_API TanhImpl : public torch::nn::Cloneable<TanhImpl> {
  public:
@@ -752,7 +752,7 @@ TORCH_MODULE(Tanh);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Tanhshrink ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies Tanhshrink over a given input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.Tanhshrink to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.Tanhshrink to learn
 /// about the exact behavior of this module.
 class TORCH_API TanhshrinkImpl : public torch::nn::Cloneable<TanhshrinkImpl> {
  public:
@@ -773,7 +773,7 @@ TORCH_MODULE(Tanhshrink);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Threshold ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the Threshold function element-wise.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.Threshold to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.Threshold to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ThresholdOptions` class to learn what
@@ -810,7 +810,7 @@ TORCH_MODULE(Threshold);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MultiheadAttention ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the MultiheadAttention function element-wise.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.MultiheadAttention
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.MultiheadAttention
 /// to learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MultiheadAttentionOptions` class to

--- a/torch/csrc/api/include/torch/nn/modules/adaptive.h
+++ b/torch/csrc/api/include/torch/nn/modules/adaptive.h
@@ -30,7 +30,7 @@ struct TORCH_API ASMoutput {
 /// `Efficient softmax approximation for GPUs`_ by Edouard Grave, Armand Joulin,
 /// Moustapha Cissé, David Grangier, and Hervé Jégou.
 /// See
-/// https://pytorch.org/docs/master/nn.html#torch.nn.AdaptiveLogSoftmaxWithLoss
+/// https://pytorch.org/docs/main/nn.html#torch.nn.AdaptiveLogSoftmaxWithLoss
 /// to learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AdaptiveLogSoftmaxWithLossOptions`

--- a/torch/csrc/api/include/torch/nn/modules/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/batchnorm.h
@@ -160,7 +160,7 @@ class BatchNormImplBase : public NormImplBase<D, Derived, BatchNormOptions> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the BatchNorm1d function.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.BatchNorm1d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.BatchNorm1d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::BatchNorm1dOptions` class to learn
@@ -190,7 +190,7 @@ TORCH_MODULE(BatchNorm1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the BatchNorm2d function.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.BatchNorm2d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.BatchNorm2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::BatchNorm2dOptions` class to learn
@@ -220,7 +220,7 @@ TORCH_MODULE(BatchNorm2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the BatchNorm3d function.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.BatchNorm3d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.BatchNorm3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::BatchNorm3dOptions` class to learn

--- a/torch/csrc/api/include/torch/nn/modules/conv.h
+++ b/torch/csrc/api/include/torch/nn/modules/conv.h
@@ -168,7 +168,7 @@ class ConvNdImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Conv1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies convolution over a 1-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.Conv1d to learn about
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.Conv1d to learn about
 /// the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::Conv1dOptions` class to learn what
@@ -200,7 +200,7 @@ TORCH_MODULE(Conv1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Conv2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies convolution over a 2-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.Conv2d to learn about
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.Conv2d to learn about
 /// the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::Conv2dOptions` class to learn what
@@ -235,7 +235,7 @@ TORCH_MODULE(Conv2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Conv3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies convolution over a 3-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.Conv3d to learn about
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.Conv3d to learn about
 /// the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::Conv3dOptions` class to learn what
@@ -325,7 +325,7 @@ class ConvTransposeNdImpl : public ConvNdImpl<D, Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the ConvTranspose1d function.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.ConvTranspose1d to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.ConvTranspose1d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ConvTranspose1dOptions` class to learn
@@ -367,7 +367,7 @@ TORCH_MODULE(ConvTranspose1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the ConvTranspose2d function.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.ConvTranspose2d to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.ConvTranspose2d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ConvTranspose2dOptions` class to learn
@@ -409,7 +409,7 @@ TORCH_MODULE(ConvTranspose2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the ConvTranspose3d function.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.ConvTranspose3d to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.ConvTranspose3d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ConvTranspose3dOptions` class to learn

--- a/torch/csrc/api/include/torch/nn/modules/distance.h
+++ b/torch/csrc/api/include/torch/nn/modules/distance.h
@@ -13,7 +13,7 @@ namespace nn {
 
 /// Returns the cosine similarity between :math:`x_1` and :math:`x_2`, computed
 /// along `dim`.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.CosineSimilarity to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.CosineSimilarity to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::CosineSimilarityOptions` class to
@@ -49,7 +49,7 @@ TORCH_MODULE(CosineSimilarity);
 
 /// Returns the batchwise pairwise distance between vectors :math:`v_1`,
 /// :math:`v_2` using the p-norm.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.PairwiseDistance to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.PairwiseDistance to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::PairwiseDistanceOptions` class to

--- a/torch/csrc/api/include/torch/nn/modules/dropout.h
+++ b/torch/csrc/api/include/torch/nn/modules/dropout.h
@@ -41,7 +41,7 @@ class _DropoutNd : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Dropout ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies dropout over a 1-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.Dropout to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.Dropout to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::DropoutOptions` class to learn what
@@ -71,7 +71,7 @@ TORCH_MODULE(Dropout);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Dropout2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies dropout over a 2-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.Dropout2d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.Dropout2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::Dropout2dOptions` class to learn what
@@ -101,7 +101,7 @@ TORCH_MODULE(Dropout2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Dropout3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies dropout over a 3-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.Dropout3d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.Dropout3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::Dropout3dOptions` class to learn what
@@ -131,7 +131,7 @@ TORCH_MODULE(Dropout3d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AlphaDropout ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies Alpha Dropout over the input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.AlphaDropout to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.AlphaDropout to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AlphaDropoutOptions` class to learn

--- a/torch/csrc/api/include/torch/nn/modules/embedding.h
+++ b/torch/csrc/api/include/torch/nn/modules/embedding.h
@@ -16,7 +16,7 @@ namespace nn {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Performs a lookup in a fixed size embedding table.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.Embedding to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.Embedding to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::EmbeddingOptions` class to learn what
@@ -92,7 +92,7 @@ class Embedding : public torch::nn::ModuleHolder<EmbeddingImpl> {
 
 /// Computes sums or means of 'bags' of embeddings, without instantiating the
 /// intermediate embeddings.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.EmbeddingBag to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.EmbeddingBag to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::EmbeddingBagOptions` class to learn

--- a/torch/csrc/api/include/torch/nn/modules/fold.h
+++ b/torch/csrc/api/include/torch/nn/modules/fold.h
@@ -11,7 +11,7 @@ namespace torch {
 namespace nn {
 
 /// Applies fold over a 3-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.Fold to learn about
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.Fold to learn about
 /// the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::FoldOptions` class to learn what
@@ -49,7 +49,7 @@ TORCH_MODULE(Fold);
 // ============================================================================
 
 /// Applies unfold over a 4-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.Unfold to learn about
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.Unfold to learn about
 /// the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::UnfoldOptions` class to learn what

--- a/torch/csrc/api/include/torch/nn/modules/instancenorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/instancenorm.h
@@ -60,7 +60,7 @@ class InstanceNormImpl
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the InstanceNorm1d function.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.InstanceNorm1d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.InstanceNorm1d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::InstanceNorm1dOptions` class to learn
@@ -91,7 +91,7 @@ TORCH_MODULE(InstanceNorm1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the InstanceNorm2d function.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.InstanceNorm2d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.InstanceNorm2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::InstanceNorm2dOptions` class to learn
@@ -122,7 +122,7 @@ TORCH_MODULE(InstanceNorm2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the InstanceNorm3d function.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.InstanceNorm3d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.InstanceNorm3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::InstanceNorm3dOptions` class to learn

--- a/torch/csrc/api/include/torch/nn/modules/linear.h
+++ b/torch/csrc/api/include/torch/nn/modules/linear.h
@@ -16,7 +16,7 @@ namespace nn {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Identity ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A placeholder identity operator that is argument-insensitive.
-/// See https://pytorch.org/docs/master/generated/torch.nn.Identity.html to
+/// See https://pytorch.org/docs/main/generated/torch.nn.Identity.html to
 /// learn about the exact behavior of this module.
 class TORCH_API IdentityImpl : public Cloneable<IdentityImpl> {
  public:
@@ -37,7 +37,7 @@ TORCH_MODULE(Identity);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Linear ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies a linear transformation with optional bias.
-/// See https://pytorch.org/docs/master/generated/torch.nn.Linear.html to learn
+/// See https://pytorch.org/docs/main/generated/torch.nn.Linear.html to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LinearOptions` class to learn what
@@ -85,7 +85,7 @@ TORCH_MODULE(Linear);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Flatten ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A placeholder for Flatten operator
-/// See https://pytorch.org/docs/master/generated/torch.nn.Flatten.html to learn
+/// See https://pytorch.org/docs/main/generated/torch.nn.Flatten.html to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::FlattenOptions` class to learn what
@@ -122,7 +122,7 @@ TORCH_MODULE(Flatten);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A placeholder for unflatten operator
-/// See https://pytorch.org/docs/master/generated/torch.nn.Unflatten.html to
+/// See https://pytorch.org/docs/main/generated/torch.nn.Unflatten.html to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::UnflattenOptions` class to learn what
@@ -163,7 +163,7 @@ TORCH_MODULE(Unflatten);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Bilinear ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies a billinear transformation with optional bias.
-/// See https://pytorch.org/docs/master/generated/torch.nn.Bilinear.html to
+/// See https://pytorch.org/docs/main/generated/torch.nn.Bilinear.html to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::BilinearOptions` class to learn what

--- a/torch/csrc/api/include/torch/nn/modules/loss.h
+++ b/torch/csrc/api/include/torch/nn/modules/loss.h
@@ -19,7 +19,7 @@ namespace nn {
 
 /// Creates a criterion that measures the mean absolute error (MAE) between each
 /// element in the input : math :`x` and target : `y`.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.L1Loss to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.L1Loss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::L1LossOptions` class to learn what
@@ -54,7 +54,7 @@ TORCH_MODULE(L1Loss);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// The Kullback-Leibler divergence loss measure
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.KLDivLoss to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.KLDivLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::KLDivLossOptions` class to learn what
@@ -89,7 +89,7 @@ TORCH_MODULE(KLDivLoss);
 
 /// Creates a criterion that measures the mean squared error (squared L2 norm)
 /// between each element in the input :math:`x` and target :math:`y`.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.MSELoss to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.MSELoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MSELossOptions` class to learn what
@@ -124,7 +124,7 @@ TORCH_MODULE(MSELoss);
 
 /// Creates a criterion that measures the Binary Cross Entropy
 /// between the target and the output.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.BCELoss to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.BCELoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::BCELossOptions` class to learn what
@@ -160,7 +160,7 @@ TORCH_MODULE(BCELoss);
 
 /// Creates a criterion that measures the loss given an input tensor :math:`x`
 /// and a labels tensor :math:`y` (containing 1 or -1).
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.HingeEmbeddingLoss to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.HingeEmbeddingLoss to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::HingeEmbeddingLossOptions` class to
@@ -199,7 +199,7 @@ TORCH_MODULE(HingeEmbeddingLoss);
 /// loss (margin-based loss) between input :math:`x` (a 2D mini-batch `Tensor`)
 /// and output :math:`y` (which is a 1D tensor of target class indices, :math:`0
 /// \leq y \leq \text{x.size}(1)-1`). See
-/// https://pytorch.org/docs/master/nn.html#torch.nn.MultiMarginLoss to learn
+/// https://pytorch.org/docs/main/nn.html#torch.nn.MultiMarginLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MultiMarginLossOptions` class to learn
@@ -238,7 +238,7 @@ TORCH_MODULE(MultiMarginLoss);
 /// -1. This is used for measuring whether two inputs are similar or
 /// dissimilar, using the cosine distance, and is typically used for learning
 /// nonlinear embeddings or semi-supervised learning.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.CosineEmbeddingLoss to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.CosineEmbeddingLoss to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::CosineEmbeddingLossOptions` class to
@@ -280,7 +280,7 @@ TORCH_MODULE(CosineEmbeddingLoss);
 /// element-wise error falls below beta and an L1 term otherwise.
 /// It is less sensitive to outliers than the `MSELoss` and in some cases
 /// prevents exploding gradients (e.g. see the paper `Fast R-CNN` by Ross
-/// Girshick). See https://pytorch.org/docs/master/nn.html#torch.nn.SmoothL1Loss
+/// Girshick). See https://pytorch.org/docs/main/nn.html#torch.nn.SmoothL1Loss
 /// to learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::SmoothL1LossOptions` class to learn
@@ -316,7 +316,7 @@ TORCH_MODULE(SmoothL1Loss);
 
 /// Creates a criterion that uses a squared term if the absolute
 /// element-wise error falls below delta and a delta-scaled L1 term otherwise.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.HuberLoss to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.HuberLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::HuberLossOptions` class to learn what
@@ -354,7 +354,7 @@ TORCH_MODULE(HuberLoss);
 /// hinge loss (margin-based loss) between input :math:`x` (a 2D mini-batch
 /// `Tensor`) and output :math:`y` (which is a 2D `Tensor` of target class
 /// indices). See
-/// https://pytorch.org/docs/master/nn.html#torch.nn.MultiLabelMarginLoss to
+/// https://pytorch.org/docs/main/nn.html#torch.nn.MultiLabelMarginLoss to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MultiLabelMarginLossOptions` class to
@@ -392,7 +392,7 @@ TORCH_MODULE(MultiLabelMarginLoss);
 /// Creates a criterion that optimizes a two-class classification
 /// logistic loss between input tensor :math:`x` and target tensor :math:`y`
 /// (containing 1 or -1).
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.SoftMarginLoss to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.SoftMarginLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::SoftMarginLossOptions` class to learn
@@ -429,7 +429,7 @@ TORCH_MODULE(SoftMarginLoss);
 /// Creates a criterion that optimizes a multi-label one-versus-all
 /// loss based on max-entropy, between input :math:`x` and target :math:`y` of
 /// size :math:`(N, C)`. See
-/// https://pytorch.org/docs/master/nn.html#torch.nn.MultiLabelSoftMarginLoss to
+/// https://pytorch.org/docs/main/nn.html#torch.nn.MultiLabelSoftMarginLoss to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MultiLabelSoftMarginLossOptions` class
@@ -473,7 +473,7 @@ TORCH_MODULE(MultiLabelSoftMarginLoss);
 /// samples. A triplet is composed by `a`, `p` and `n` (i.e., `anchor`,
 /// `positive examples` and `negative examples` respectively). The
 /// shapes of all input tensors should be :math:`(N, D)`.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.TripletMarginLoss to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.TripletMarginLoss to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::TripletMarginLossOptions` class to
@@ -520,7 +520,7 @@ TORCH_MODULE(TripletMarginLoss);
 /// and positive example ("positive distance") and the anchor and negative
 /// example ("negative distance").
 /// See
-/// https://pytorch.org/docs/master/nn.html#torch.nn.TripletMarginWithDistanceLoss
+/// https://pytorch.org/docs/main/nn.html#torch.nn.TripletMarginWithDistanceLoss
 /// to learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::TripletMarginWithDistanceLossOptions`
@@ -563,7 +563,7 @@ TORCH_MODULE(TripletMarginWithDistanceLoss);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CTCLoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// The Connectionist Temporal Classification loss.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.CTCLoss to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.CTCLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::CTCLossOptions` class to learn what
@@ -603,7 +603,7 @@ TORCH_MODULE(CTCLoss);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Negative log likelihood loss with Poisson distribution of target.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.PoissonNLLLoss to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.PoissonNLLLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::PoissonNLLLossOptions` class to learn
@@ -641,7 +641,7 @@ TORCH_MODULE(PoissonNLLLoss);
 /// Creates a criterion that measures the loss given
 /// inputs :math:`x1`, :math:`x2`, two 1D mini-batch `Tensors`,
 /// and a label 1D mini-batch tensor :math:`y` (containing 1 or -1).
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.MarginRankingLoss to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.MarginRankingLoss to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MarginRankingLossOptions` class to
@@ -681,7 +681,7 @@ TORCH_MODULE(MarginRankingLoss);
 
 /// The negative log likelihood loss. It is useful to train a classification
 /// problem with `C` classes.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.NLLLoss to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.NLLLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::NLLLossOptions` class to learn what
@@ -720,7 +720,7 @@ TORCH_MODULE(NLLLoss);
 
 /// Creates a criterion that computes cross entropy loss between input and
 /// target. See
-/// https://pytorch.org/docs/master/nn.html#torch.nn.CrossEntropyLoss to learn
+/// https://pytorch.org/docs/main/nn.html#torch.nn.CrossEntropyLoss to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::CrossEntropyLossOptions` class to
@@ -762,7 +762,7 @@ TORCH_MODULE(CrossEntropyLoss);
 /// class. This version is more numerically stable than using a plain `Sigmoid`
 /// followed by a `BCELoss` as, by combining the operations into one layer,
 /// we take advantage of the log-sum-exp trick for numerical stability.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.BCEWithLogitsLoss to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.BCEWithLogitsLoss to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::BCEWithLogitsLossOptions` class to

--- a/torch/csrc/api/include/torch/nn/modules/normalization.h
+++ b/torch/csrc/api/include/torch/nn/modules/normalization.h
@@ -17,7 +17,7 @@ namespace nn {
 
 /// Applies Layer Normalization over a mini-batch of inputs as described in
 /// the paper `Layer Normalization`_ .
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.LayerNorm to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.LayerNorm to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LayerNormOptions` class to learn what
@@ -78,7 +78,7 @@ TORCH_MODULE(LayerNorm);
 /// Applies local response normalization over an input signal composed
 /// of several input planes, where channels occupy the second dimension.
 /// Applies normalization across channels.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.LocalResponseNorm to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.LocalResponseNorm to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LocalResponseNormOptions` class to
@@ -152,7 +152,7 @@ TORCH_MODULE(CrossMapLRN2d);
 
 /// Applies Group Normalization over a mini-batch of inputs as described in
 /// the paper `Group Normalization`_ .
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.GroupNorm to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.GroupNorm to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::GroupNormOptions` class to learn what

--- a/torch/csrc/api/include/torch/nn/modules/padding.h
+++ b/torch/csrc/api/include/torch/nn/modules/padding.h
@@ -32,7 +32,7 @@ class TORCH_API ReflectionPadImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ReflectionPad over a 1-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.ReflectionPad1d to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.ReflectionPad1d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReflectionPad1dOptions` class to learn
@@ -59,7 +59,7 @@ TORCH_MODULE(ReflectionPad1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ReflectionPad over a 2-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.ReflectionPad2d to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.ReflectionPad2d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReflectionPad2dOptions` class to learn
@@ -86,7 +86,7 @@ TORCH_MODULE(ReflectionPad2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ReflectionPad over a 3-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.ReflectionPad3d to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.ReflectionPad3d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReflectionPad3dOptions` class to learn
@@ -135,7 +135,7 @@ class TORCH_API ReplicationPadImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ReplicationPad over a 1-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.ReplicationPad1d to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.ReplicationPad1d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReplicationPad1dOptions` class to
@@ -162,7 +162,7 @@ TORCH_MODULE(ReplicationPad1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ReplicationPad over a 2-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.ReplicationPad2d to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.ReplicationPad2d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReplicationPad2dOptions` class to
@@ -189,7 +189,7 @@ TORCH_MODULE(ReplicationPad2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ReplicationPad over a 3-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.ReplicationPad3d to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.ReplicationPad3d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ReplicationPad3dOptions` class to
@@ -299,7 +299,7 @@ class TORCH_API ConstantPadImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ConstantPad1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ConstantPad over a 1-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.ConstantPad1d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.ConstantPad1d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ConstantPad1dOptions` class to learn
@@ -325,7 +325,7 @@ TORCH_MODULE(ConstantPad1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ConstantPad2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ConstantPad over a 2-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.ConstantPad2d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.ConstantPad2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ConstantPad2dOptions` class to learn
@@ -351,7 +351,7 @@ TORCH_MODULE(ConstantPad2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ConstantPad3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies ConstantPad over a 3-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.ConstantPad3d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.ConstantPad3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::ConstantPad3dOptions` class to learn

--- a/torch/csrc/api/include/torch/nn/modules/pixelshuffle.h
+++ b/torch/csrc/api/include/torch/nn/modules/pixelshuffle.h
@@ -15,7 +15,7 @@ namespace nn {
 /// Rearranges elements in a tensor of shape :math:`(*, C \times r^2, H, W)`
 /// to a tensor of shape :math:`(*, C, H \times r, W \times r)`, where r is an
 /// upscale factor. See
-/// https://pytorch.org/docs/master/nn.html#torch.nn.PixelShuffle to learn about
+/// https://pytorch.org/docs/main/nn.html#torch.nn.PixelShuffle to learn about
 /// the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::PixelShuffleOptions` class to learn
@@ -52,7 +52,7 @@ TORCH_MODULE(PixelShuffle);
 /// Reverses the PixelShuffle operation by rearranging elements in a tensor of
 /// shape :math:`(*, C, H \times r, W \times r)` to a tensor of shape :math:`(*,
 /// C \times r^2, H, W)`, where r is a downscale factor. See
-/// https://pytorch.org/docs/master/nn.html#torch.nn.PixelUnshuffle to learn
+/// https://pytorch.org/docs/main/nn.html#torch.nn.PixelUnshuffle to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::PixelUnshuffleOptions` class to learn

--- a/torch/csrc/api/include/torch/nn/modules/pooling.h
+++ b/torch/csrc/api/include/torch/nn/modules/pooling.h
@@ -31,7 +31,7 @@ class TORCH_API AvgPoolImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AvgPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies avgpool over a 1-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.AvgPool1d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.AvgPool1d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AvgPool1dOptions` class to learn what
@@ -57,7 +57,7 @@ TORCH_MODULE(AvgPool1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AvgPool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies avgpool over a 2-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.AvgPool2d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.AvgPool2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AvgPool2dOptions` class to learn what
@@ -83,7 +83,7 @@ TORCH_MODULE(AvgPool2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AvgPool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies avgpool over a 3-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.AvgPool3d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.AvgPool3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AvgPool3dOptions` class to learn what
@@ -128,7 +128,7 @@ class TORCH_API MaxPoolImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies maxpool over a 1-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.MaxPool1d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.MaxPool1d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MaxPool1dOptions` class to learn what
@@ -158,7 +158,7 @@ TORCH_MODULE(MaxPool1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxPool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies maxpool over a 2-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.MaxPool2d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.MaxPool2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MaxPool2dOptions` class to learn what
@@ -188,7 +188,7 @@ TORCH_MODULE(MaxPool2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxPool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies maxpool over a 3-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.MaxPool3d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.MaxPool3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MaxPool3dOptions` class to learn what
@@ -244,7 +244,7 @@ class TORCH_API AdaptiveMaxPoolImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveMaxPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive maxpool over a 1-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.AdaptiveMaxPool1d to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.AdaptiveMaxPool1d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AdaptiveMaxPool1dOptions` class to
@@ -277,7 +277,7 @@ TORCH_MODULE(AdaptiveMaxPool1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveMaxPool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive maxpool over a 2-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.AdaptiveMaxPool2d to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.AdaptiveMaxPool2d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AdaptiveMaxPool2dOptions` class to
@@ -314,7 +314,7 @@ TORCH_MODULE(AdaptiveMaxPool2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveMaxPool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive maxpool over a 3-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.AdaptiveMaxPool3d to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.AdaptiveMaxPool3d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AdaptiveMaxPool3dOptions` class to
@@ -377,7 +377,7 @@ class TORCH_API AdaptiveAvgPoolImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveAvgPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive avgpool over a 1-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.AdaptiveAvgPool1d to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.AdaptiveAvgPool1d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AdaptiveAvgPool1dOptions` class to
@@ -406,7 +406,7 @@ TORCH_MODULE(AdaptiveAvgPool1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveAvgPool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive avgpool over a 2-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.AdaptiveAvgPool2d to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.AdaptiveAvgPool2d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AdaptiveAvgPool2dOptions` class to
@@ -439,7 +439,7 @@ TORCH_MODULE(AdaptiveAvgPool2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ AdaptiveAvgPool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies adaptive avgpool over a 3-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.AdaptiveAvgPool3d to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.AdaptiveAvgPool3d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::AdaptiveAvgPool3dOptions` class to
@@ -491,7 +491,7 @@ class TORCH_API MaxUnpoolImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxUnpool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies maxunpool over a 1-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.MaxUnpool1d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.MaxUnpool1d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MaxUnpool1dOptions` class to learn
@@ -523,7 +523,7 @@ TORCH_MODULE(MaxUnpool1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxUnpool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies maxunpool over a 2-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.MaxUnpool2d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.MaxUnpool2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MaxUnpool2dOptions` class to learn
@@ -555,7 +555,7 @@ TORCH_MODULE(MaxUnpool2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MaxUnpool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies maxunpool over a 3-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.MaxUnpool3d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.MaxUnpool3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::MaxUnpool3dOptions` class to learn
@@ -588,7 +588,7 @@ TORCH_MODULE(MaxUnpool3d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies fractional maxpool over a 2-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.FractionalMaxPool2d to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.FractionalMaxPool2d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::FractionalMaxPool2dOptions` class to
@@ -633,7 +633,7 @@ TORCH_MODULE(FractionalMaxPool2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies fractional maxpool over a 3-D input.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.FractionalMaxPool3d to
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.FractionalMaxPool3d to
 /// learn about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::FractionalMaxPool3dOptions` class to
@@ -695,7 +695,7 @@ class TORCH_API LPPoolImpl : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LPPool1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the LPPool1d function element-wise.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.LPPool1d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.LPPool1d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LPPool1dOptions` class to learn what
@@ -722,7 +722,7 @@ TORCH_MODULE(LPPool1d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LPPool2d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the LPPool2d function element-wise.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.LPPool2d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.LPPool2d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LPPool2dOptions` class to learn what
@@ -750,7 +750,7 @@ TORCH_MODULE(LPPool2d);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LPPool3d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Applies the LPPool3d function element-wise.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.LPPool3d to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.LPPool3d to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LPPool3dOptions` class to learn what

--- a/torch/csrc/api/include/torch/nn/modules/rnn.h
+++ b/torch/csrc/api/include/torch/nn/modules/rnn.h
@@ -91,7 +91,7 @@ class TORCH_API RNNImplBase : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ RNN ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A multi-layer Elman RNN module with Tanh or ReLU activation.
-/// See https://pytorch.org/docs/master/generated/torch.nn.RNN.html to learn
+/// See https://pytorch.org/docs/main/generated/torch.nn.RNN.html to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::RNNOptions` class to learn what
@@ -140,7 +140,7 @@ TORCH_MODULE(RNN);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LSTM ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A multi-layer long-short-term-memory (LSTM) module.
-/// See https://pytorch.org/docs/master/generated/torch.nn.LSTM.html to learn
+/// See https://pytorch.org/docs/main/generated/torch.nn.LSTM.html to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LSTMOptions` class to learn what
@@ -205,7 +205,7 @@ TORCH_MODULE(LSTM);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GRU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A multi-layer gated recurrent unit (GRU) module.
-/// See https://pytorch.org/docs/master/generated/torch.nn.GRU.html to learn
+/// See https://pytorch.org/docs/main/generated/torch.nn.GRU.html to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::GRUOptions` class to learn what
@@ -286,7 +286,7 @@ class TORCH_API RNNCellImplBase : public torch::nn::Cloneable<Derived> {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// An Elman RNN cell with tanh or ReLU non-linearity.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.RNNCell to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.RNNCell to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::RNNCellOptions` class to learn what
@@ -326,7 +326,7 @@ TORCH_MODULE(RNNCell);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A long short-term memory (LSTM) cell.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.LSTMCell to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.LSTMCell to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::LSTMCellOptions` class to learn what
@@ -365,7 +365,7 @@ TORCH_MODULE(LSTMCell);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A gated recurrent unit (GRU) cell.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.GRUCell to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.GRUCell to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::GRUCellOptions` class to learn what

--- a/torch/csrc/api/include/torch/nn/modules/transformercoder.h
+++ b/torch/csrc/api/include/torch/nn/modules/transformercoder.h
@@ -20,7 +20,7 @@ namespace nn {
 
 /// TransformerEncoder module.
 /// See
-/// https://pytorch.org/docs/master/generated/torch.nn.TransformerEncoder.html
+/// https://pytorch.org/docs/main/generated/torch.nn.TransformerEncoder.html
 /// to learn abouut the exact behavior of this encoder layer module.
 ///
 /// See the documentation for `torch::nn::TransformerEncoder` class to learn
@@ -79,7 +79,7 @@ TORCH_MODULE(TransformerEncoder);
 
 /// TransformerDecoder is a stack of N decoder layers.
 /// See
-/// https://pytorch.org/docs/master/generated/torch.nn.TransformerDecoder.html
+/// https://pytorch.org/docs/main/generated/torch.nn.TransformerDecoder.html
 /// to learn abouut the exact behavior of this decoder module
 ///
 /// See the documentation for `torch::nn::TransformerDecoderOptions` class to

--- a/torch/csrc/api/include/torch/nn/modules/transformerlayer.h
+++ b/torch/csrc/api/include/torch/nn/modules/transformerlayer.h
@@ -22,7 +22,7 @@ namespace nn {
 
 /// TransformerEncoderLayer module.
 /// See
-/// https://pytorch.org/docs/master/generated/torch.nn.TransformerEncoderLayer.html
+/// https://pytorch.org/docs/main/generated/torch.nn.TransformerEncoderLayer.html
 /// to learn abouut the exact behavior of this encoder layer model
 ///
 /// See the documentation for `torch::nn::TransformerEncoderLayer` class to
@@ -97,7 +97,7 @@ TORCH_MODULE(TransformerEncoderLayer);
 /// Polosukhin. 2017. Attention is all you need. In Advances in Neural
 /// Information Processing Systems, pages 6000-6010. Users may modify or
 /// implement in a different way during application. See
-/// https://pytorch.org/docs/master/nn.html#transformer-layers to learn about
+/// https://pytorch.org/docs/main/nn.html#transformer-layers to learn about
 /// the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::TransformerDecoderLayerOptions` class

--- a/torch/csrc/api/include/torch/nn/modules/upsampling.h
+++ b/torch/csrc/api/include/torch/nn/modules/upsampling.h
@@ -18,7 +18,7 @@ namespace nn {
 
 /// Upsamples a given multi-channel 1D (temporal), 2D (spatial) or 3D
 /// (volumetric) data.
-/// See https://pytorch.org/docs/master/nn.html#torch.nn.Upsample to learn
+/// See https://pytorch.org/docs/main/nn.html#torch.nn.Upsample to learn
 /// about the exact behavior of this module.
 ///
 /// See the documentation for `torch::nn::UpsampleOptions` class to learn what

--- a/torch/csrc/api/include/torch/special.h
+++ b/torch/csrc/api/include/torch/special.h
@@ -7,7 +7,7 @@ namespace torch {
 namespace special {
 
 /// Computes the natural logarithm of the absolute value of the gamma function
-/// See https://pytorch.org/docs/master/special.html#torch.special.gammaln.
+/// See https://pytorch.org/docs/main/special.html#torch.special.gammaln.
 ///
 /// Example:
 /// ```
@@ -23,7 +23,7 @@ inline Tensor& gammaln_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the regularized lower incomplete gamma function
-/// See https://pytorch.org/docs/master/special.html#torch.special.gammainc.
+/// See https://pytorch.org/docs/main/special.html#torch.special.gammainc.
 ///
 /// Example:
 /// ```
@@ -43,7 +43,7 @@ inline Tensor& gammainc_out(
 }
 
 /// Computes the regularized upper incomplete gamma function
-/// See https://pytorch.org/docs/master/special.html#torch.special.gammainc.
+/// See https://pytorch.org/docs/main/special.html#torch.special.gammainc.
 ///
 /// Example:
 /// ```
@@ -63,7 +63,7 @@ inline Tensor& gammaincc_out(
 }
 
 /// Computes the multivariate log-gamma function with dimension `p`, elementwise
-/// See https://pytorch.org/docs/master/special.html#torch.special.multigammaln.
+/// See https://pytorch.org/docs/main/special.html#torch.special.multigammaln.
 ///
 /// Example:
 /// ```
@@ -79,7 +79,7 @@ inline Tensor& multigammaln_out(Tensor& result, const Tensor& self, int64_t p) {
 }
 
 /// Computes the nth derivative of the digamma function on the input.
-/// See https:://pytorch.org/docs/master/special.html#torch.special.polygamma.
+/// See https:://pytorch.org/docs/main/special.html#torch.special.polygamma.
 ///
 /// Example:
 /// ```
@@ -95,7 +95,7 @@ inline Tensor& polygamma_out(Tensor& result, int64_t n, const Tensor& self) {
 }
 
 /// Computes the logarithmic derivative of the gamma function on input
-/// See https://pytorch.org/docs/master/special.html#torch.special.psi
+/// See https://pytorch.org/docs/main/special.html#torch.special.psi
 ///
 /// Example:
 /// ```
@@ -111,7 +111,7 @@ inline Tensor& psi_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the logarithmic derivative of the gamma function on input
-/// See https://pytorch.org/docs/master/special.html#torch.special.digamma
+/// See https://pytorch.org/docs/main/special.html#torch.special.digamma
 ///
 /// Example:
 /// ```
@@ -127,7 +127,7 @@ inline Tensor& digamma_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes entropy of input, elementwise
-/// See https://pytorch.org/docs/master/special.html#torch.special.entr.
+/// See https://pytorch.org/docs/main/special.html#torch.special.entr.
 ///
 /// Example:
 /// ```
@@ -143,7 +143,7 @@ inline Tensor& entr_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the error function
-/// See https://pytorch.org/docs/master/special.html#torch.special.erf.
+/// See https://pytorch.org/docs/main/special.html#torch.special.erf.
 ///
 /// Example:
 /// ```
@@ -159,7 +159,7 @@ inline Tensor& erf_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the complementary error function
-/// See https://pytorch.org/docs/master/special.html#torch.special.erfc.
+/// See https://pytorch.org/docs/main/special.html#torch.special.erfc.
 ///
 /// Example:
 /// ```
@@ -175,7 +175,7 @@ inline Tensor& erfc_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the scaled complementary error function
-/// See https://pytorch.org/docs/master/special.html#torch.special.erfcx.
+/// See https://pytorch.org/docs/main/special.html#torch.special.erfcx.
 ///
 /// Example:
 /// ```
@@ -191,7 +191,7 @@ inline Tensor& erfcx_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the inverse error function
-/// See https://pytorch.org/docs/master/special.html#torch.special.erfinv.
+/// See https://pytorch.org/docs/main/special.html#torch.special.erfinv.
 ///
 /// Example:
 /// ```
@@ -208,7 +208,7 @@ inline Tensor& erfinv_out(Tensor& result, const Tensor& self) {
 
 /// Computes the log of summed exponentials of each row of input in the given
 /// dimension dim See
-/// https://pytorch.org/docs/master/special.html#torch.special.logsumexp.
+/// https://pytorch.org/docs/main/special.html#torch.special.logsumexp.
 ///
 /// Example:
 /// ```
@@ -230,7 +230,7 @@ inline Tensor& logsumexp_out(
 /// Computes the argument, x, for which the area under the Gaussian probability
 /// density function (integrated from minus infinity to x) is equal to input,
 /// elementwise. See
-/// https://pytorch.org/docs/master/special.html#torch.special.ndtri
+/// https://pytorch.org/docs/main/special.html#torch.special.ndtri
 ///
 /// Example:
 /// ```
@@ -247,7 +247,7 @@ inline Tensor& ndtri_out(Tensor& result, const Tensor& self) {
 
 /// Computes the log of area under the standard Gaussian probability density
 /// function, integrated from minus infinity to :attr:`input`, elementwise See
-/// https://pytorch.org/docs/master/special.html#torch.special.log_ndtr
+/// https://pytorch.org/docs/main/special.html#torch.special.log_ndtr
 ///
 /// Example:
 /// ```
@@ -263,7 +263,7 @@ inline Tensor& log_ndtr_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the logit of input, elementwise.
-/// See https://pytorch.org/docs/master/special.html#torch.special.logit.
+/// See https://pytorch.org/docs/main/special.html#torch.special.logit.
 ///
 /// Example:
 /// ```
@@ -280,7 +280,7 @@ inline Tensor& logit_out(Tensor& result, const Tensor& self) {
 
 /// Computes the expit (also known as the logistic sigmoid function) of input,
 /// elementwise See
-/// https://pytorch.org/docs/master/special.html#torch.special.expit.
+/// https://pytorch.org/docs/main/special.html#torch.special.expit.
 ///
 /// Example:
 /// ```
@@ -296,7 +296,7 @@ inline Tensor& expit_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the base two exponential function of :attr:`input`, elementwise
-/// See https://pytorch.org/docs/master/special.html#torch.special.exp2.
+/// See https://pytorch.org/docs/main/special.html#torch.special.exp2.
 ///
 /// Example:
 /// ```
@@ -312,7 +312,7 @@ inline Tensor& exp2_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the exponential of the elements minus 1, elementwise
-/// See https://pytorch.org/docs/master/special.html#torch.special.expm1.
+/// See https://pytorch.org/docs/main/special.html#torch.special.expm1.
 ///
 /// Example:
 /// ```
@@ -328,7 +328,7 @@ inline Tensor& expm1_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes x * log(y) for inputs, elementwise
-/// See https://pytorch.org/docs/master/special.html#torch.special.xlogy.
+/// See https://pytorch.org/docs/main/special.html#torch.special.xlogy.
 ///
 /// Example:
 /// ```
@@ -370,7 +370,7 @@ inline Tensor& xlogy_out(
 }
 
 /// Computes x * log1p(y) for inputs, elementwise
-/// See https://pytorch.org/docs/master/special.html#torch.special.xlog1py.
+/// See https://pytorch.org/docs/main/special.html#torch.special.xlog1py.
 ///
 /// Example:
 /// ```
@@ -412,7 +412,7 @@ inline Tensor& xlog1py_out(
 }
 
 /// Computes Hurwitz Zeta function for inputs, elementwise
-/// See https://pytorch.org/docs/master/special.html#torch.special.zeta.
+/// See https://pytorch.org/docs/main/special.html#torch.special.zeta.
 ///
 /// Example:
 /// ```
@@ -455,7 +455,7 @@ inline Tensor& zeta_out(
 
 /// Computes the zeroth order modified Bessel function of the first kind of
 /// input, elementwise See
-/// https://pytorch.org/docs/master/special.html#torch.special.i0
+/// https://pytorch.org/docs/main/special.html#torch.special.i0
 ///
 /// Example:
 /// ```
@@ -472,7 +472,7 @@ inline Tensor& i0_out(Tensor& result, const Tensor& self) {
 
 /// Computes the area under the standard Gaussian probability density function,
 /// integrated from minus infinity to :attr:`input`, elementwise
-/// See https://pytorch.org/docs/master/special.html#torch.special.ndtr
+/// See https://pytorch.org/docs/main/special.html#torch.special.ndtr
 ///
 /// Example:
 /// ```
@@ -489,7 +489,7 @@ inline Tensor& ndtr_out(Tensor& result, const Tensor& self) {
 
 /// Computes the exponentially scaled zeroth order modified Bessel function of
 /// the first kind See
-/// https://pytorch.org/docs/master/special.html#torch.special.i0e.
+/// https://pytorch.org/docs/main/special.html#torch.special.i0e.
 ///
 /// Example:
 /// ```
@@ -505,7 +505,7 @@ inline Tensor& i0e_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the first order modified Bessel function of the first kind
-/// See https://pytorch.org/docs/master/special.html#torch.special.i1.
+/// See https://pytorch.org/docs/main/special.html#torch.special.i1.
 ///
 /// Example:
 /// ```
@@ -522,7 +522,7 @@ inline Tensor& i1_out(Tensor& result, const Tensor& self) {
 
 /// Computes the exponentially scaled first order modified Bessel function of
 /// the first kind See
-/// https://pytorch.org/docs/master/special.html#torch.special.i1e.
+/// https://pytorch.org/docs/main/special.html#torch.special.i1e.
 ///
 /// Example:
 /// ```
@@ -538,7 +538,7 @@ inline Tensor& i1e_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes the sinc of input, elementwise
-/// See https://pytorch.org/docs/master/special.html#torch.special.sinc.
+/// See https://pytorch.org/docs/main/special.html#torch.special.sinc.
 ///
 /// Example:
 /// ```
@@ -554,7 +554,7 @@ inline Tensor& sinc_out(Tensor& result, const Tensor& self) {
 }
 
 /// Rounds the elements of the input
-/// See https://pytorch.org/docs/master/special.html#torch.special.round.
+/// See https://pytorch.org/docs/main/special.html#torch.special.round.
 ///
 /// Example:
 /// ```
@@ -570,7 +570,7 @@ inline Tensor& round_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes log(1 + x) of the input, elementwise
-/// See https://pytorch.org/docs/master/special.html#torch.special.log1p.
+/// See https://pytorch.org/docs/main/special.html#torch.special.log1p.
 ///
 /// Example:
 /// ```
@@ -586,7 +586,7 @@ inline Tensor& log1p_out(Tensor& result, const Tensor& self) {
 }
 
 /// Computes log followed by softmax(x) of the input
-/// See https://pytorch.org/docs/master/special.html#torch.special.log_softmax.
+/// See https://pytorch.org/docs/main/special.html#torch.special.log_softmax.
 ///
 /// Example:
 /// ```
@@ -601,7 +601,7 @@ inline Tensor log_softmax(
 }
 
 /// Computes softmax of the input along a given dimension
-/// See https://pytorch.org/docs/master/special.html#torch.special.softmax.
+/// See https://pytorch.org/docs/main/special.html#torch.special.softmax.
 ///
 /// Example:
 /// ```
@@ -617,7 +617,7 @@ inline Tensor softmax(
 
 /// Airy function Ai.
 ///
-/// See https://pytorch.org/docs/master/special.html#torch.special.airy_ai.
+/// See https://pytorch.org/docs/main/special.html#torch.special.airy_ai.
 ///
 /// Example:
 ///
@@ -636,7 +636,7 @@ inline Tensor& airy_ai_out(Tensor& y, const Tensor& x) {
 
 /// Bessel function of the first kind of order 0.
 ///
-/// See https://pytorch.org/docs/master/special.html#torch.special.bessel_j0.
+/// See https://pytorch.org/docs/main/special.html#torch.special.bessel_j0.
 ///
 /// Example:
 ///
@@ -655,7 +655,7 @@ inline Tensor& bessel_j0_out(Tensor& result, const Tensor& self) {
 
 /// Bessel function of the first kind of order 1.
 ///
-/// See https://pytorch.org/docs/master/special.html#torch.special.bessel_j1.
+/// See https://pytorch.org/docs/main/special.html#torch.special.bessel_j1.
 ///
 /// Example:
 ///
@@ -674,7 +674,7 @@ inline Tensor& bessel_j1_out(Tensor& result, const Tensor& self) {
 
 /// Bessel function of the second kind of order 0.
 ///
-/// See https://pytorch.org/docs/master/special.html#torch.special.bessel_y0.
+/// See https://pytorch.org/docs/main/special.html#torch.special.bessel_y0.
 ///
 /// Example:
 ///
@@ -693,7 +693,7 @@ inline Tensor& bessel_y0_out(Tensor& result, const Tensor& self) {
 
 /// Bessel function of the second kind of order 1.
 ///
-/// See https://pytorch.org/docs/master/special.html#torch.special.bessel_y1.
+/// See https://pytorch.org/docs/main/special.html#torch.special.bessel_y1.
 ///
 /// Example:
 ///
@@ -713,7 +713,7 @@ inline Tensor& bessel_y1_out(Tensor& result, const Tensor& self) {
 /// Chebyshev polynomial of the first kind.
 ///
 /// See
-/// https://pytorch.org/docs/master/special.html#torch.special.chebyshev_polynomial_t.
+/// https://pytorch.org/docs/main/special.html#torch.special.chebyshev_polynomial_t.
 ///
 /// Example:
 ///
@@ -759,7 +759,7 @@ inline Tensor& chebyshev_polynomial_t_out(
 /// Chebyshev polynomial of the second kind.
 ///
 /// See
-/// https://pytorch.org/docs/master/special.html#torch.special.chebyshev_polynomial_u.
+/// https://pytorch.org/docs/main/special.html#torch.special.chebyshev_polynomial_u.
 ///
 /// Example:
 ///
@@ -805,7 +805,7 @@ inline Tensor& chebyshev_polynomial_u_out(
 /// Chebyshev polynomial of the third kind.
 ///
 /// See
-/// https://pytorch.org/docs/master/special.html#torch.special.chebyshev_polynomial_v.
+/// https://pytorch.org/docs/main/special.html#torch.special.chebyshev_polynomial_v.
 ///
 /// Example:
 ///
@@ -851,7 +851,7 @@ inline Tensor& chebyshev_polynomial_v_out(
 /// Chebyshev polynomial of the fourth kind.
 ///
 /// See
-/// https://pytorch.org/docs/master/special.html#torch.special.chebyshev_polynomial_w.
+/// https://pytorch.org/docs/main/special.html#torch.special.chebyshev_polynomial_w.
 ///
 /// Example:
 ///
@@ -897,7 +897,7 @@ inline Tensor& chebyshev_polynomial_w_out(
 /// Physicist’s Hermite polynomial.
 ///
 /// See
-/// https://pytorch.org/docs/master/special.html#torch.special.hermite_polynomial_h.
+/// https://pytorch.org/docs/main/special.html#torch.special.hermite_polynomial_h.
 ///
 /// Example:
 ///
@@ -943,7 +943,7 @@ inline Tensor& hermite_polynomial_h_out(
 /// Probabilist’s Hermite polynomial.
 ///
 /// See
-/// https://pytorch.org/docs/master/special.html#torch.special.hermite_polynomial_he.
+/// https://pytorch.org/docs/main/special.html#torch.special.hermite_polynomial_he.
 ///
 /// Example:
 ///
@@ -989,7 +989,7 @@ inline Tensor& hermite_polynomial_he_out(
 /// Laguerre polynomial.
 ///
 /// See
-/// https://pytorch.org/docs/master/special.html#torch.special.laguerre_polynomial_l.
+/// https://pytorch.org/docs/main/special.html#torch.special.laguerre_polynomial_l.
 ///
 /// Example:
 ///
@@ -1035,7 +1035,7 @@ inline Tensor& laguerre_polynomial_l_out(
 /// Legendre polynomial.
 ///
 /// See
-/// https://pytorch.org/docs/master/special.html#torch.special.legendre_polynomial_p.
+/// https://pytorch.org/docs/main/special.html#torch.special.legendre_polynomial_p.
 ///
 /// Example:
 ///
@@ -1081,7 +1081,7 @@ inline Tensor& legendre_polynomial_p_out(
 /// Modified Bessel function of the first kind of order 0.
 ///
 /// See
-/// https://pytorch.org/docs/master/special.html#torch.special.modified_bessel_i0.
+/// https://pytorch.org/docs/main/special.html#torch.special.modified_bessel_i0.
 ///
 /// Example:
 ///
@@ -1101,7 +1101,7 @@ inline Tensor& modified_bessel_i0_out(Tensor& result, const Tensor& self) {
 /// Modified Bessel function of the first kind of order 1.
 ///
 /// See
-/// https://pytorch.org/docs/master/special.html#torch.special.modified_bessel_i1.
+/// https://pytorch.org/docs/main/special.html#torch.special.modified_bessel_i1.
 ///
 /// Example:
 ///
@@ -1121,7 +1121,7 @@ inline Tensor& modified_bessel_i1_out(Tensor& result, const Tensor& self) {
 /// Modified Bessel function of the second kind of order 0.
 ///
 /// See
-/// https://pytorch.org/docs/master/special.html#torch.special.modified_bessel_k0.
+/// https://pytorch.org/docs/main/special.html#torch.special.modified_bessel_k0.
 ///
 /// Example:
 ///
@@ -1141,7 +1141,7 @@ inline Tensor& modified_bessel_k0_out(Tensor& result, const Tensor& self) {
 /// Modified Bessel function of the second kind of order 1.
 ///
 /// See
-/// https://pytorch.org/docs/master/special.html#torch.special.modified_bessel_k1.
+/// https://pytorch.org/docs/main/special.html#torch.special.modified_bessel_k1.
 ///
 /// Example:
 ///
@@ -1161,7 +1161,7 @@ inline Tensor& modified_bessel_k1_out(Tensor& result, const Tensor& self) {
 /// Scaled modified Bessel function of the second kind of order 0.
 ///
 /// See
-/// https://pytorch.org/docs/master/special.html#torch.special.scaled_modified_bessel_k0.
+/// https://pytorch.org/docs/main/special.html#torch.special.scaled_modified_bessel_k0.
 ///
 /// Example:
 ///
@@ -1181,7 +1181,7 @@ inline Tensor& scaled_modified_bessel_k0_out(Tensor& y, const Tensor& x) {
 /// Scaled modified Bessel function of the second kind of order 1.
 ///
 /// See
-/// https://pytorch.org/docs/master/special.html#torch.special.scaled_modified_bessel_k1.
+/// https://pytorch.org/docs/main/special.html#torch.special.scaled_modified_bessel_k1.
 ///
 /// Example:
 ///
@@ -1201,7 +1201,7 @@ inline Tensor& scaled_modified_bessel_k1_out(Tensor& y, const Tensor& x) {
 /// Shifted Chebyshev polynomial of the first kind.
 ///
 /// See
-/// https://pytorch.org/docs/master/special.html#torch.special.shifted_chebyshev_polynomial_t.
+/// https://pytorch.org/docs/main/special.html#torch.special.shifted_chebyshev_polynomial_t.
 ///
 /// Example:
 ///
@@ -1247,7 +1247,7 @@ inline Tensor& shifted_chebyshev_polynomial_t_out(
 /// Shifted Chebyshev polynomial of the second kind.
 ///
 /// See
-/// https://pytorch.org/docs/master/special.html#torch.special.shifted_chebyshev_polynomial_u.
+/// https://pytorch.org/docs/main/special.html#torch.special.shifted_chebyshev_polynomial_u.
 ///
 /// Example:
 ///
@@ -1293,7 +1293,7 @@ inline Tensor& shifted_chebyshev_polynomial_u_out(
 /// Shifted Chebyshev polynomial of the third kind.
 ///
 /// See
-/// https://pytorch.org/docs/master/special.html#torch.special.shifted_chebyshev_polynomial_v.
+/// https://pytorch.org/docs/main/special.html#torch.special.shifted_chebyshev_polynomial_v.
 ///
 /// Example:
 ///
@@ -1339,7 +1339,7 @@ inline Tensor& shifted_chebyshev_polynomial_v_out(
 /// Shifted Chebyshev polynomial of the fourth kind.
 ///
 /// See
-/// https://pytorch.org/docs/master/special.html#torch.special.shifted_chebyshev_polynomial_w.
+/// https://pytorch.org/docs/main/special.html#torch.special.shifted_chebyshev_polynomial_w.
 ///
 /// Example:
 ///
@@ -1385,7 +1385,7 @@ inline Tensor& shifted_chebyshev_polynomial_w_out(
 /// Spherical Bessel function of the first kind of order 0.
 ///
 /// See
-/// https://pytorch.org/docs/master/special.html#torch.special.spherical_bessel_j0.
+/// https://pytorch.org/docs/main/special.html#torch.special.spherical_bessel_j0.
 ///
 /// Example:
 ///

--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -483,7 +483,7 @@ c10::optional<at::Tensor> runTorchBackendForOnnx(
     at::Tensor indices = inputTensorValues[1];
     auto q = indices.dim();
     // at::index_select only supports indices with rank <= 1.
-    // See https://pytorch.org/docs/master/generated/torch.index_select.html
+    // See https://pytorch.org/docs/main/generated/torch.index_select.html
     if (q > 1) {
       return c10::nullopt;
     }

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -547,7 +547,7 @@ void fixDefaultRnnHiddenState(Block* b, int opset_version) {
       continue;
     }
     // Hidden state is the sixth input for RNN, LSTM, GRU.
-    // See https://pytorch.org/docs/master/nn.html#torch.nn.RNN
+    // See https://pytorch.org/docs/main/nn.html#torch.nn.RNN
     if (n->inputs().size() < 6) {
       continue;
     }
@@ -566,7 +566,7 @@ void fixDefaultLstmCellState(Block* b, int opset_version) {
       continue;
     }
     // Cell state is the seventh input for LSTM.
-    // See https://pytorch.org/docs/master/nn.html#torch.nn.LSTM
+    // See https://pytorch.org/docs/main/nn.html#torch.nn.LSTM
     if (n->inputs().size() < 7) {
       continue;
     }

--- a/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
+++ b/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
@@ -111,7 +111,7 @@ static c10::optional<c10::ScalarType> PromoteScalarTypes(
 
 // Type promotion between scalars and tensors
 // per logic here
-// https://pytorch.org/docs/master/tensor_attributes.html#tensor-attributes
+// https://pytorch.org/docs/main/tensor_attributes.html#tensor-attributes
 static c10::optional<c10::ScalarType> PromoteScalarTypesWithCategory(
     const std::vector<c10::ScalarType>& typesFromTensors,
     const std::vector<c10::ScalarType>& typesFromScalars) {
@@ -272,7 +272,7 @@ static c10::optional<c10::ScalarType> InferExpectedScalarType(const Node* n) {
       // are tensors or scalars. (Previously only scalars support implicit
       // casting).
       // Per logic here
-      // https://pytorch.org/docs/master/tensor_attributes.html#tensor-attributes
+      // https://pytorch.org/docs/main/tensor_attributes.html#tensor-attributes
       st = PromoteScalarTypesWithCategory(typesFromTensors, typesFromScalars);
     }
   }

--- a/torch/csrc/jit/passes/remove_inplace_ops.cpp
+++ b/torch/csrc/jit/passes/remove_inplace_ops.cpp
@@ -118,7 +118,7 @@ void ImplicitCastForBinaryInplaceOps(Block* b) {
       if ((shape_node->kind() == prim::NumToTensor) &&
           (shape_node->inputs().at(0)->node()->kind() == aten::size)) {
         std::cerr
-            << "In-place op on output of tensor.shape. See https://pytorch.org/docs/master/onnx.html#"
+            << "In-place op on output of tensor.shape. See https://pytorch.org/docs/main/onnx.html#"
             << "avoid-inplace-operations-when-using-tensor-shape-in-tracing-mode"
             << std::endl;
       }

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2237,7 +2237,7 @@ def all_reduce_coalesced(tensors, op=ReduceOp.SUM, group=None, async_op=False):
     warnings.warn(
         "torch.distributed.all_reduce_coalesced will be deprecated. If you must "
         "use it, please revisit our documentation later at "
-        "https://pytorch.org/docs/master/distributed.html#collective-functions"
+        "https://pytorch.org/docs/main/distributed.html#collective-functions"
     )
     if isinstance(tensors, torch.Tensor):
         tensors = [tensors]
@@ -3009,7 +3009,7 @@ def all_gather_coalesced(
     warnings.warn(
         "torch.distributed.all_gather_coalesced will be deprecated. If you must "
         "use it, please revisit our documentation later at "
-        "https://pytorch.org/docs/master/distributed.html#collective-functions"
+        "https://pytorch.org/docs/main/distributed.html#collective-functions"
     )
     # We only check basic compatibility with C++ params here, C++ code will
     # do shape and type checking.

--- a/torch/fx/README.md
+++ b/torch/fx/README.md
@@ -66,19 +66,19 @@ Here, we set up a simple Module that exercises different language features: fetc
 
 # Internal Structure
 
-## [Graph](https://pytorch.org/docs/master/fx.html#torch.fx.Graph) ##
+## [Graph](https://pytorch.org/docs/main/fx.html#torch.fx.Graph) ##
 The `fx.Graph` is a core data structure in FX that represents the operations and their dependencies in a structured format. It consists of a List of `fx.Node` representing individual operations and their inputs and outputs. The Graph enables simple manipulation and analysis of the model structure, which is essential for implementing various transformations and optimizations.
 
 ## Node
 An `fx.Node` is a datastructure that represent individual operations within an `fx.Graph`, it maps to callsites such as operators, methods and modules. Each `fx.Node` keeps track of its inputs, the previous and next nodes, the stacktrace so you can map back the node to a line of code in your python file and some optional metadata stored in a `meta` dict.
 
-## [GraphModule](https://pytorch.org/docs/master/fx.html#torch.fx.GraphModule) ##
+## [GraphModule](https://pytorch.org/docs/main/fx.html#torch.fx.GraphModule) ##
 The `fx.GraphModule` is a subclass of `nn.Module` that holds the transformed Graph, the original module's parameter attributes and its source code. It serves as the primary output of FX transformations and can be used like any other `nn.Module`. `fx.GraphModule` allows for the execution of the transformed model, as it generates a valid forward method based on the Graph's structure.
 
 
 # Tracing
 
-## [Symbolic Tracer](https://pytorch.org/docs/master/fx.html#torch.fx.Tracer) ##
+## [Symbolic Tracer](https://pytorch.org/docs/main/fx.html#torch.fx.Tracer) ##
 
 `Tracer` is the class that implements the symbolic tracing functionality of `torch.fx.symbolic_trace`. A call to `symbolic_trace(m)` is equivalent to `Tracer().trace(m)`. Tracer can be subclassed to override various behaviors of the tracing process. The different behaviors that can be overridden are described in the docstrings of the methods on the class.
 
@@ -103,7 +103,7 @@ During the call to `symbolic_trace`, the parameter `x` is transformed into a Pro
 
 If you're doing graph transforms, you can wrap your own Proxy method around a raw Node so that you can use the overloaded operators to add additional things to a Graph.
 
-## [TorchDynamo](https://pytorch.org/docs/master/compile/technical-overview.html) ##
+## [TorchDynamo](https://pytorch.org/docs/main/compile/technical-overview.html) ##
 
 Tracing has limitations in that it can't deal with dynamic control flow and is limited to outputting a single graph at a time, so a better alternative is the new `torch.compile()` infrastructure where you can output multiple subgraphs in either an aten or torch IR using `torch.fx`. [This tutorial](https://colab.research.google.com/drive/1Zh-Uo3TcTH8yYJF-LLo5rjlHVMtqvMdf) gives more context on how this works.
 

--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -212,7 +212,7 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/master/fx.html#torch.fx.Node>`__ for
+                `Node <https://pytorch.org/docs/main/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
@@ -242,7 +242,7 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/master/fx.html#torch.fx.Node>`__ for
+                `Node <https://pytorch.org/docs/main/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
@@ -260,7 +260,7 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/master/fx.html#torch.fx.Node>`__ for
+                `Node <https://pytorch.org/docs/main/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
@@ -280,7 +280,7 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/master/fx.html#torch.fx.Node>`__ for
+                `Node <https://pytorch.org/docs/main/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
@@ -302,7 +302,7 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/master/fx.html#torch.fx.Node>`__ for
+                `Node <https://pytorch.org/docs/main/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
@@ -326,7 +326,7 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/master/fx.html#torch.fx.Node>`__ for
+                `Node <https://pytorch.org/docs/main/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
@@ -459,7 +459,7 @@ class Transformer(Interpreter):
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/master/fx.html#torch.fx.Node>`__ for
+                `Node <https://pytorch.org/docs/main/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
@@ -477,7 +477,7 @@ class Transformer(Interpreter):
 
         Args:
             target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/master/fx.html#torch.fx.Node>`__ for
+                `Node <https://pytorch.org/docs/main/fx.html#torch.fx.Node>`__ for
                 details on semantics
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1115,7 +1115,7 @@ Examples::
     tensor([2])
 
 .. _condition number:
-    https://pytorch.org/docs/master/linalg.html#torch.linalg.cond
+    https://pytorch.org/docs/main/linalg.html#torch.linalg.cond
 .. _full description of these drivers:
     https://www.netlib.org/lapack/lug/node27.html
 """)
@@ -1773,7 +1773,7 @@ Examples::
     tensor(3.0957e-06)
 
 .. _condition number:
-    https://pytorch.org/docs/master/linalg.html#torch.linalg.cond
+    https://pytorch.org/docs/main/linalg.html#torch.linalg.cond
 .. _the resulting vectors will span the same subspace:
     https://en.wikipedia.org/wiki/Singular_value_decomposition#Singular_values,_singular_vectors,_and_their_relation_to_the_SVD
 """)

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -221,7 +221,7 @@ class NLLLoss2d(NLLLoss):
                  reduce=None, reduction: str = 'mean') -> None:
         warnings.warn("NLLLoss2d has been deprecated. "
                       "Please use NLLLoss instead as a drop-in replacement and see "
-                      "https://pytorch.org/docs/master/nn.html#torch.nn.NLLLoss for more details.")
+                      "https://pytorch.org/docs/main/nn.html#torch.nn.NLLLoss for more details.")
         super().__init__(weight, size_average, ignore_index, reduce, reduction)
 
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1892,7 +1892,7 @@ class Module:
             # DeprecationWarning is ignored by default
             warnings.warn(
                 "Positional args are being deprecated, use kwargs instead. Refer to "
-                "https://pytorch.org/docs/master/generated/torch.nn.Module.html#torch.nn.Module.state_dict"
+                "https://pytorch.org/docs/main/generated/torch.nn.Module.html#torch.nn.Module.state_dict"
                 " for details.")
 
         if destination is None:

--- a/torch/onnx/README.md
+++ b/torch/onnx/README.md
@@ -2,7 +2,7 @@
 
 Torch->ONNX converter / exporter.
 
-- User-facing docs: https://pytorch.org/docs/master/onnx.html
+- User-facing docs: https://pytorch.org/docs/main/onnx.html
 - Developer docs: https://github.com/pytorch/pytorch/wiki/PyTorch-ONNX-exporter
 
 > Read the following if you are contributing to `torch.onnx`

--- a/torch/onnx/_internal/fx/passes/type_promotion.py
+++ b/torch/onnx/_internal/fx/passes/type_promotion.py
@@ -1658,7 +1658,7 @@ class InsertTypePromotion(_pass.Transform):
     metadata, specifically the fake tensor stored under node.meta["val"], and ensure it
     reflects the latest changes.
 
-    See [FXE0015: fx_node_insert_type_promotion](https://pytorch.org/docs/master/generated/onnx_dynamo_diagnostics_rules/FXE0015%3Afx-node-insert-type-promotion.html) for more details.  # noqa: B950
+    See [FXE0015: fx_node_insert_type_promotion](https://pytorch.org/docs/main/generated/onnx_dynamo_diagnostics_rules/FXE0015%3Afx-node-insert-type-promotion.html) for more details.  # noqa: B950
     """
 
     def __init__(

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -450,7 +450,7 @@ class AliasInfo:
 #   the operator's output (when given the input, args, and kwargs) to the
 #   portion of the output to gradcheck. For example, consider an operator
 #   like torch.linalg.slogdet
-#   (https://pytorch.org/docs/master/generated/torch.linalg.slogdet.html).
+#   (https://pytorch.org/docs/main/generated/torch.linalg.slogdet.html).
 #   This operator returns a tuple of two tensors, but the first tensor
 #   cannot be backwarded through. Its "output_process_fn_grad" filters
 #   this output tuple to just the second argument, which we can call backward

--- a/torch/utils/bottleneck/__main__.py
+++ b/torch/utils/bottleneck/__main__.py
@@ -156,7 +156,7 @@ exits in a finite amount of time.
 
 For more complicated uses of the profilers, please see
 https://docs.python.org/3/library/profile.html and
-https://pytorch.org/docs/master/autograd.html#profiler for more information.
+https://pytorch.org/docs/main/autograd.html#profiler for more information.
 """.strip()
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #121824
* __->__ #121823

The previous links were pointing to an outdated branch

Command: `find . -type f -exec sed -i "s:docs/main:docs/master:g" {} + `

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng