### PR TITLE
[AOTInductor, SymbolicShape] Pass shape_env.var_to_range to BoundVars

### DIFF
--- a/torch/_inductor/bounds.py
+++ b/torch/_inductor/bounds.py
@@ -1,8 +1,8 @@
 import operator
 from functools import partial
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Optional
 
-from sympy import Expr
+from sympy import Expr, Symbol
 
 import torch
 from torch.utils._sympy.value_ranges import bound_sympy, ValueRangeAnalysis, ValueRanges
@@ -21,12 +21,12 @@ class BoundVars:
     the case a bounded variable is returned by a kernel and fed into another.
     """
 
-    def __init__(self, loop_body: LoopBody) -> None:
+    def __init__(self, loop_body: LoopBody, ranges: Optional[Dict[Symbol, ValueRanges]] = None) -> None:
         self.loop_body = loop_body
         self.replacement_vals = {
             k: ValueRanges[Expr](0, v - 1)
             if (isinstance(v, int) or v.is_number)
-            else bound_sympy(v)
+            else bound_sympy(v, ranges)
             for k, v in loop_body.var_ranges.items()
         }
         # avoid computing these values, pessimistically assume that they are unbounded

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7061,7 +7061,7 @@ class LoopBody:
         # Doing a local import to avoid dumping all the code here
         from .bounds import BoundVars
 
-        return BoundVars(self)
+        return BoundVars(self, V.graph.sizevars.shape_env.var_to_range)
 
     def debug_str(self):
         lines = [f"var_ranges = {dict(self.var_ranges)}"]


### PR DESCRIPTION
Summary:
In production's setup, AOTInductor would compile an ExportedProgram deserialized from the archive. In such case, `torch._guards.TracingContext` is not available. However, AOTI is heavily relying on `TracingContext` in its current implementation. 

For example, as shown in this diff, `BoundVars` is reading from `TracingContext` to get the shape_env's `var_to_range` field. 

As a workaround, I am passing V.graph.shape_env.var_to_range to `BoundVars` instead.

Test Plan: buck2 test  mode/dev-nosan caffe2/test/inductor/fb:test_aot_inductor_pt2_inference

Differential Revision: D54563608




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang