### PR TITLE
MPS: Allow tensor::from_blob to create tensor from the shared CPU/MPS MLTBuffer

### DIFF
--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -80,12 +80,15 @@ class TORCH_API Context {
     initCUDAIfNeeded(device_type);
     initHIPIfNeeded(device_type);
     initXPUIfNeeded(device_type);
+    initMPSIfNeeded(device_type);
     if (device_type == at::kCPU) {
       return c10::DeviceType::CPU;
     } else if (device_type == at::kCUDA) {
       return at::detail::getCUDAHooks().getDeviceFromPtr(data);
     } else if (device_type == at::kXPU) {
       return at::detail::getXPUHooks().getDeviceFromPtr(data);
+    } else if (device_type == at::kMPS) {
+      return at::detail::getMPSHooks().getDeviceFromPtr(data);
     } else if (device_type == at::kPrivateUse1) {
       return at::GetPrivateUse1HooksInterface()->getDeviceFromPtr(data);
     } else {
@@ -160,6 +163,9 @@ class TORCH_API Context {
   }
   void lazyInitMTIA() {
     c10::call_once(th_mtia_init, [&] { detail::getMTIAHooks().initMTIA(); });
+  }
+  void lazyInitMPS() {
+    c10::call_once(thm_init, [&] { detail::getMPSHooks().initMPS(); });
   }
   void lazyInitPrivateUse1() {
     c10::call_once(thp_init, [&] {
@@ -350,11 +356,17 @@ class TORCH_API Context {
       lazyInitXPU();
     }
   }
+  void initMPSIfNeeded(c10::DeviceType p) {
+    if (p == c10::DeviceType::MPS) {
+      lazyInitMPS();
+    }
+  }
   static bool checkCuBLASConfigDeterministic();
   c10::once_flag thc_init;
   c10::once_flag thh_init;
   c10::once_flag thx_init;
   c10::once_flag th_mtia_init;
+  c10::once_flag thm_init;
   c10::once_flag thp_init;
   bool enabled_cudnn = true;
   bool deterministic_cudnn = false;

--- a/aten/src/ATen/detail/MPSHooksInterface.h
+++ b/aten/src/ATen/detail/MPSHooksInterface.h
@@ -48,6 +48,9 @@ struct TORCH_API MPSHooksInterface : AcceleratorHooksInterface {
   virtual void* getDispatchQueue() const {
     FAIL_MPSHOOKS_FUNC(__func__);
   }
+  virtual Device getDeviceFromPtr(void* ptr) const {
+    FAIL_MPSHOOKS_FUNC(__func__);
+  }
   virtual void emptyCache() const {
     FAIL_MPSHOOKS_FUNC(__func__);
   }

--- a/aten/src/ATen/mps/MPSHooks.h
+++ b/aten/src/ATen/mps/MPSHooks.h
@@ -17,6 +17,7 @@ struct MPSHooks : public at::MPSHooksInterface {
   // MPSDevice interface
   bool hasMPS() const override;
   bool isOnMacOSorNewer(unsigned major, unsigned minor) const override;
+  Device getDeviceFromPtr(void* ptr) const override;
 
   // MPSGeneratorImpl interface
   const Generator& getDefaultMPSGenerator() const override;

--- a/aten/src/ATen/mps/MPSHooks.mm
+++ b/aten/src/ATen/mps/MPSHooks.mm
@@ -68,6 +68,10 @@ void* MPSHooks::getDispatchQueue() const {
   return at::mps::getDefaultMPSStream()->queue();
 }
 
+Device MPSHooks::getDeviceFromPtr(void* ptr) const {
+  return at::Device(at::DeviceType::MPS, 0);
+}
+
 void MPSHooks::emptyCache() const {
   at::mps::getIMPSAllocator()->emptyCache();
 }

--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -113,7 +113,8 @@ list(APPEND ATen_MPS_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/mps_test_allocator.cpp)
 if(APPLE AND USE_MPS)
   list(APPEND ATen_MPS_TEST_SRCS
-    ${CMAKE_CURRENT_SOURCE_DIR}/mps_test_objc_interface.mm)
+    ${CMAKE_CURRENT_SOURCE_DIR}/mps_test_objc_interface.mm
+    ${CMAKE_CURRENT_SOURCE_DIR}/mps_test_from_blob.mm)
 endif()
 
 list(APPEND ATen_XPU_TEST_SRCS

--- a/aten/src/ATen/test/mps_test_from_blob.mm
+++ b/aten/src/ATen/test/mps_test_from_blob.mm
@@ -1,0 +1,86 @@
+#include <ATen/mps/MPSAllocator.h>
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+
+namespace {
+
+#define ASSERT_TENSORS_EQ(cpu_tensor, mps_tensor)                                     \
+  {                                                                                   \
+    auto const_cpu_tensor_ptr = cpu_tensor.to(torch::kCPU).const_data_ptr<uint8_t>(); \
+    auto const_mps_tensor_ptr = mps_tensor.to(torch::kCPU).const_data_ptr<uint8_t>(); \
+    for (uint32_t i = 0; i < kTestBufferSize; ++i) {                                  \
+      EXPECT_EQ(const_cpu_tensor_ptr[i], const_mps_tensor_ptr[i]) << "I: " << i;      \
+    }                                                                                 \
+  }
+
+#define ASSERT_TENSORS_EQ_AND_PROPERTIES_UNCHANGED(cpu_tensor, mps_tensor) \
+  {                                                                        \
+    ASSERT_TENSORS_EQ(cpu_tensor, mps_tensor);                             \
+    ASSERT_TRUE(cpu_tensor.is_cpu());                                      \
+    ASSERT_TRUE(cpu_tensor.dtype() == torch::kUInt8);                      \
+    ASSERT_TRUE(mps_tensor.is_mps());                                      \
+    ASSERT_TRUE(mps_tensor.dtype() == torch::kUInt8);                      \
+  }
+
+} // namespace
+
+TEST(MPSTestFromBlob, SharedMTLBufferFromBlob) {
+  // fail if mps isn't available
+  ASSERT_TRUE(torch::mps::is_available());
+
+  constexpr uint32_t kTestBufferSize = 10000;
+
+  auto alloc = at::mps::getIMPSAllocator(true);
+
+  c10::DataPtr raw_buffer = alloc->allocate(kTestBufferSize);
+  id<MTLBuffer> buffer = __builtin_bit_cast(id<MTLBuffer>, raw_buffer.mutable_get());
+
+  // An example of editing raw buffer, and sync between CPU/GPU
+  std::memset(buffer.contents, 0xCC, kTestBufferSize);
+  torch::mps::synchronize();
+
+  // Create a CPU tensor from blob.
+  auto cpu_options =
+      torch::TensorOptions().dtype(torch::kUInt8).layout(torch::kStrided).device(torch::kCPU).requires_grad(false);
+  torch::Tensor cpu_tensor = torch::from_blob(buffer.contents, {kTestBufferSize}, {1}, cpu_options);
+
+  // Create a MPS tensor from blob.
+  auto mps_options =
+      torch::TensorOptions().dtype(torch::kUInt8).layout(torch::kStrided).device(torch::kMPS).requires_grad(false);
+  torch::Tensor mps_tensor = torch::from_blob(buffer, {kTestBufferSize}, {1}, mps_options);
+
+  ASSERT_TENSORS_EQ_AND_PROPERTIES_UNCHANGED(cpu_tensor, mps_tensor);
+
+  // Modify the cpu tensor.
+  cpu_tensor -= 3;
+  torch::mps::synchronize();
+  ASSERT_TENSORS_EQ_AND_PROPERTIES_UNCHANGED(cpu_tensor, mps_tensor);
+
+  // Modify the mps tensor
+  mps_tensor += 5;
+  torch::mps::synchronize();
+  ASSERT_TENSORS_EQ_AND_PROPERTIES_UNCHANGED(cpu_tensor, mps_tensor);
+
+  const torch::Tensor cpu_random =
+      torch::randint(255, {kTestBufferSize}, torch::TensorOptions().device(torch::kCPU).dtype(torch::kUInt8));
+
+  std::memset(buffer.contents, 0, kTestBufferSize);
+  cpu_tensor += cpu_random;
+  ASSERT_TENSORS_EQ(cpu_tensor, cpu_random);
+  torch::mps::synchronize();
+  ASSERT_TENSORS_EQ_AND_PROPERTIES_UNCHANGED(cpu_tensor, mps_tensor);
+
+  const torch::Tensor mps_random =
+      torch::randint(255, {kTestBufferSize}, torch::TensorOptions().device(torch::kMPS).dtype(torch::kUInt8));
+
+  std::memset(buffer.contents, 0, kTestBufferSize);
+  torch::mps::synchronize();
+  // Make sure we could interact with other mps tensors.
+  mps_tensor += mps_random;
+  torch::mps::synchronize();
+  ASSERT_TENSORS_EQ(mps_tensor, mps_random);
+  ASSERT_TENSORS_EQ_AND_PROPERTIES_UNCHANGED(cpu_tensor, mps_tensor);
+}
+
+#undef ASSERT_TENSORS_EQ_AND_PROPERTIES_UNCHANGED
+#undef ASSERT_TENSORS_EQ


### PR DESCRIPTION
* Added `getDeviceFromPtr` function for the `MPSHooks` to return a MPS device from the pointer. Currently will always return `mps:0` to so the result tensor could interact with other MPS tensors.
* Added MPS device handling for `getDeviceFromPtr` in `at::Context`.
* Added test to ensure `tensor::from_blob` will work with a `SHARED` MTLBuffer for both CPU/MPS tensor type with synchronizations. 