### PR TITLE
[AOTInductor] Set tracing_context for inference_compiler

### DIFF
--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -1211,6 +1211,7 @@ class GraphModuleDeserializer:
                 # on deserialization? Probably deserves a follow-up.
 
                 # Here we force symbols corresponding to SymInts to be at least integers.
+                # This is required by downstream Inductor, as it asserts symbols to be integers.
                 # Otherwise some expressions that the shape env would otherwise evaluate to False,
                 # e.g., 2*s = 9, can have rational solutions, e.g., 9/2.
                 sym = sym.subs({s: sympy.Symbol(s.name, integer=True) for s in sym.free_symbols})

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1167,10 +1167,11 @@ class GraphLowering(torch.fx.Interpreter):
                     ), "Unknown type when creating real inputs" + str(type(x))
                     return x
 
-            if tracing_context := torch._guards.TracingContext.try_get():
-                if tracing_context.output_strides:
-                    tracing_context.output_strides.clear()
+            tracing_context = torch._guards.TracingContext.try_get()
+            if tracing_context and tracing_context.output_strides:
+                tracing_context.output_strides.clear()
 
+            if tracing_context and tracing_context.params_flat:
                 params_flat = [
                     param
                     for param in tracing_context.params_flat  # type: ignore[union-attr]


### PR DESCRIPTION
Summary:
Fix more tests in test_aot_inductor_pt2_inference.py

- When deserializer creates new symbols, they needs to be integer. 
- AOTI's inference_compiler() call needs to be called under TracingContext. 
- TracingContext's params_flat and fw_metada are not populated at the moment, as they are not serialized.

Test Plan: buck2 run  mode/dev-nosan caffe2/test/inductor/fb:test_aot_inductor_pt2_inference

Reviewed By: desertfire

Differential Revision: D54669729




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang