### PR TITLE
Don't plumb shape_env per tensor conversion.

### DIFF
--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -218,46 +218,32 @@ Model:
   ==> L['shape'][0]: 0
   ==> L['shape'][1]: 0
   ==> L['shape'][2]: 0
-  ==> L['x'].size()[0]: 3
-  ==> L['x'].storage_offset(): 0
-  ==> L['x'].stride()[0]: 1
-  ==> s0: 3
+  ==> s0: 0
   ==> s1: 0
   ==> s2: 0
-  ==> s3: 0
 
 Assertions:
-  ==> (== 0 L['x'].storage_offset())
-  ==> (== 1 L['x'].stride()[0])
-  ==> (== L['shape'][0] s1)
-  ==> (== L['shape'][1] s2)
-  ==> (== L['shape'][2] s3)
-  ==> (== L['x'].size()[0] s0)
-  ==> (> s0 1)
+  ==> (== L['shape'][0] s0)
+  ==> (== L['shape'][1] s1)
+  ==> (== L['shape'][2] s2)
   ==> (True)
 
 Target Expressions:
+  ==> (<= 0 s0)
   ==> (<= 0 s1)
   ==> (<= 0 s2)
-  ==> (<= 0 s3)
-  ==> (<= 2 s0)
   ==> (== 0 L['shape'][0])
   ==> (== 0 L['shape'][1])
   ==> (== 0 L['shape'][2])
-  ==> (== 0 L['x'].storage_offset())
+  ==> (== 0 s0)
   ==> (== 0 s1)
   ==> (== 0 s2)
-  ==> (== 0 s3)
-  ==> (== 1 L['x'].stride()[0])
-  ==> (== L['x'].size()[0] s0)
-  ==> (> s0 0)
+  ==> (>= 0 s0)
   ==> (>= 0 s1)
   ==> (>= 0 s2)
-  ==> (>= 0 s3)
-  ==> (>= 9223372036854775806 s0)
 
 Failed Source Expressions:
-  ==> (== (+ L['shape'][0] L['shape'][1] L['shape'][2]) L['x'].size()[0])""",
+  ==> (== 20 (+ L['shape'][0] L['shape'][1] L['shape'][2]))""",
         )
 
     @skipIf(not TEST_Z3, "z3 not installed")

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -340,10 +340,20 @@ class FakeTensorConverter:
         t,
         *,
         make_constant=False,
-        source=None,
         symbolic_context=None,
+        source=None,
         memoized_only=False,
     ):
+        from torch.fx.experimental.symbolic_shapes import (
+            DimDynamic,
+            StatelessSymbolicContext,
+        )
+
+        # Direct calls here ALWAYS end up with static shapes
+        if symbolic_context is None:
+            symbolic_context = StatelessSymbolicContext(
+                dynamic_sizes=[DimDynamic.STATIC] * t.ndim
+            )
         return self.from_real_tensor(
             fake_mode,
             t,

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -350,7 +350,7 @@ class FakeTensorConverter:
         )
 
         # Direct calls here ALWAYS end up with static shapes
-        if symbolic_context is None and self.shape_env is not None:
+        if self.shape_env is not None:
             symbolic_context = StatelessSymbolicContext(
                 dynamic_sizes=[DimDynamic.STATIC] * t.ndim
             )

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -350,7 +350,7 @@ class FakeTensorConverter:
         )
 
         # Direct calls here ALWAYS end up with static shapes
-        if symbolic_context is None:
+        if symbolic_context is None and self.shape_env is not None:
             symbolic_context = StatelessSymbolicContext(
                 dynamic_sizes=[DimDynamic.STATIC] * t.ndim
             )

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -2483,7 +2483,7 @@ class ShapeEnv:
         """
         source_name = source.name() if source else None
 
-        if self._translation_validation_enabled and source is not None:
+        if self._translation_validation_enabled and source is not None and not isinstance(sym, sympy.Integer):
             # Create a new symbol for this source.
             symbol = self._create_symbol_for_source(source)
             assert symbol is not None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121855

The only reason we did this was when static_shapes is True,
we would nub out the shape_env, but we can do this better with
a policy instead.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang