### PR TITLE
[codemod][bugfix] Fix addressing bug in caffe2/caffe2/video/video_input_op.h

### DIFF
--- a/caffe2/video/video_input_op.h
+++ b/caffe2/video/video_input_op.h
@@ -942,19 +942,19 @@ bool VideoInputOp<Context>::Prefetch() {
     if (!std::is_same<Context, CPUContext>::value) {
       if (get_rgb_) {
         prefetched_clip_rgb_on_device_.CopyFrom(
-            prefetched_clip_rgb_, &context_);
+            prefetched_clip_rgb_, true);
       }
       if (get_optical_flow_) {
-        prefetched_clip_of_on_device_.CopyFrom(prefetched_clip_of_, &context_);
+        prefetched_clip_of_on_device_.CopyFrom(prefetched_clip_of_, true);
       }
-      prefetched_label_on_device_.CopyFrom(prefetched_label_, &context_);
+      prefetched_label_on_device_.CopyFrom(prefetched_label_, true);
       if (get_video_id_) {
         prefetched_video_id_on_device_.CopyFrom(
-            prefetched_video_id_, &context_);
+            prefetched_video_id_, true);
       }
       if (get_start_frame_) {
         prefetched_start_frame_on_device_.CopyFrom(
-            prefetched_start_frame_, &context_);
+            prefetched_start_frame_, true);
       }
     }
   } catch (const std::exception& exc) {
@@ -972,43 +972,43 @@ bool VideoInputOp<Context>::CopyPrefetched() {
     if (get_rgb_) {
       auto* clip_rgb_output = OperatorBase::Output<Tensor>(index++, type);
       if (std::is_same<Context, CPUContext>::value) {
-        clip_rgb_output->CopyFrom(prefetched_clip_rgb_, &context_);
+        clip_rgb_output->CopyFrom(prefetched_clip_rgb_, true);
       } else {
-        clip_rgb_output->CopyFrom(prefetched_clip_rgb_on_device_, &context_);
+        clip_rgb_output->CopyFrom(prefetched_clip_rgb_on_device_, true);
       }
     }
 
     if (get_optical_flow_) {
       auto* clip_of_output = OperatorBase::Output<Tensor>(index++, type);
       if (std::is_same<Context, CPUContext>::value) {
-        clip_of_output->CopyFrom(prefetched_clip_of_, &context_);
+        clip_of_output->CopyFrom(prefetched_clip_of_, true);
       } else {
-        clip_of_output->CopyFrom(prefetched_clip_of_on_device_, &context_);
+        clip_of_output->CopyFrom(prefetched_clip_of_on_device_, true);
       }
     }
 
     auto* label_output = OperatorBase::Output<Tensor>(index++, type);
     if (std::is_same<Context, CPUContext>::value) {
-      label_output->CopyFrom(prefetched_label_, &context_);
+      label_output->CopyFrom(prefetched_label_, true);
     } else {
-      label_output->CopyFrom(prefetched_label_on_device_, &context_);
+      label_output->CopyFrom(prefetched_label_on_device_, true);
     }
 
     if (get_video_id_) {
       auto* video_id_output = OperatorBase::Output<Tensor>(index++, type);
       if (std::is_same<Context, CPUContext>::value) {
-        video_id_output->CopyFrom(prefetched_video_id_, &context_);
+        video_id_output->CopyFrom(prefetched_video_id_, true);
       } else {
-        video_id_output->CopyFrom(prefetched_video_id_on_device_, &context_);
+        video_id_output->CopyFrom(prefetched_video_id_on_device_, true);
       }
     }
     if (get_start_frame_) {
       auto* start_frame_output = OperatorBase::Output<Tensor>(index, type);
       if (std::is_same<Context, CPUContext>::value) {
-        start_frame_output->CopyFrom(prefetched_start_frame_, &context_);
+        start_frame_output->CopyFrom(prefetched_start_frame_, true);
       } else {
         start_frame_output->CopyFrom(
-            prefetched_start_frame_on_device_, &context_);
+            prefetched_start_frame_on_device_, true);
       }
     }
   } catch (const std::exception& exc) {


### PR DESCRIPTION
Summary:
# Diff Specific

The signature of `copyFrom` is
```
void Tensor::CopyFrom(const Tensor& src, bool async) {
```
so the `&context` always evaluated to true.

I could dig around to see if anyone cares about what the flag should actually be, but this is old code in caffe2, so I've just used `true` and we'll keep using whatever behaviour we've been using since 2019 or so when this was written.

# General

A bug in this code was identified by `-Waddress`, which we are working to enable globally.

This diff fixes the bug. There are a few types of fixes it might employ:

The bug could be `const_char_array == "hello"` which compares two addresses and therefore is almost always false. This is fixed with `const_char_array == std::string_view("hello")` because `string_view` has an `==` operator that makes an appropriate comparison.

The bug could be `if(name_of_func)` which always returns true because the function always has an address. Likely you meant to call the function here!

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Test Plan: Sandcastle
