### PR TITLE
[export] allow static constraints in dynamic_shapes

### DIFF
--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -207,7 +207,7 @@ def make_constraints(
             return True
         if isinstance(x, dict):
             x = list(x.values())
-        return all(isinstance(y, _Dim) or y is None for y in x)
+        return all(isinstance(y, (_Dim, int)) or y is None for y in x)
 
     flat_dynamic_shapes, _ = tree_flatten(
         dynamic_shapes, is_leaf=_is_dynamic_shape_leaf


### PR DESCRIPTION
This PR allows users to specify int values for dimensions in dynamic_shapes as well as None, for example:

```
class Foo(torch.nn.Module):
    def forward(self, x, y, z):
        ...

    foo = Foo()
    inputs = (torch.randn(4, 6), torch.randn(5, 4), torch.randn(3, 3))

for dynamic_shapes in [
    None
    ((4, 6), (5, 4), (3, 3)),
    ((None, 6), None, {0: 3, 1: 3})
]:
    _ = export(foo, inputs, dynamic_shapes=dynamic_shapes)
```

All of the above should produce the same ExportedProgram.

This is done by temporarily creating a static dim constraint during analysis, where vr.lower == vr.upper. These constraints are then deleted during _process_constraints(), and do not show up in the final ExportedProgram's range_constraints.

Additionally, export() will also fail if the shapes are mis-specified, for example:
```
_ = export(foo, inputs, dynamic_shapes=((5, None), None, None))
```
leads to `torch._dynamo.exc.UserError: Static shape constraint of 5 does not match input size of 4, for L['x'].size()[0]`