### PR TITLE
Revert "Switch cudagraph backend to cudagraph trees (#121019)" and "Add Cudagraphs disable checking (#121018)"

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -19,11 +19,9 @@ from torch.testing import FileCheck
 
 from torch.testing._internal.common_cuda import TEST_MULTIGPU
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
     IS_CI,
     IS_LINUX,
     IS_WINDOWS,
-    parametrize,
     skipIfRocm,
     TEST_CUDA_GRAPH,
     TEST_WITH_ASAN,
@@ -50,13 +48,6 @@ requires_multigpu = functools.partial(
     unittest.skipIf, not TEST_MULTIGPU, "requires multiple cuda devices"
 )
 from io import StringIO
-
-
-def get_compile_fn(backend):
-    if backend == "cudagraphs":
-        return functools.partial(torch.compile, backend="cudagraphs")
-    else:
-        return functools.partial(torch.compile, mode="reduce-overhead")
 
 
 class capture_stderr(list):
@@ -253,16 +244,15 @@ if HAS_CUDA and not TEST_WITH_ASAN:
                 opt = torch.compile(model.forward, mode="reduce-overhead")(x, y, z)
 
             FileCheck().check(
-                "skipping cudagraphs due to mutation on input. Found from"
+                "skipping cudagraphs due to mutaton on input. Found from"
             ).check("torch.logical_xor").run(captured_output[0])
 
         @requires_multigpu()
-        @parametrize("backend", ("inductor", "cudagraphs"))
-        def test_multiple_devices_msg(self, backend):
+        def test_multiple_devices_msg(self):
+            @torch.compile()
             def foo(x, y):
                 return (x + 1, y + 2)
 
-            foo = get_compile_fn(backend)(foo)
             with capture_stderr() as captured_output:
                 foo(torch.ones([10], device="cuda"), torch.ones([20]))
 
@@ -279,14 +269,11 @@ if HAS_CUDA and not TEST_WITH_ASAN:
                 captured_output[0]
             )
 
-        @parametrize("backend", ("inductor", "cudagraphs"))
-        @torch._dynamo.config.patch("cudagraph_backend_keep_input_mutation", True)
-        def test_mutation_on_inp(self, backend):
+        def test_mutation(self):
+            @torch.compile()
             def foo(x):
                 x.add_(2)
                 return x
-
-            foo = get_compile_fn(backend)(foo)
 
             def inp():
                 return torch.ones([10], device="cuda")
@@ -294,7 +281,7 @@ if HAS_CUDA and not TEST_WITH_ASAN:
             with capture_stderr() as captured_output:
                 foo(inp())
 
-            FileCheck().check("skipping cudagraphs due to mutation on input.").check(
+            FileCheck().check("skipping cudagraphs due to mutaton on input.").check(
                 ".add_(2)"
             ).run(captured_output[0])
 
@@ -444,15 +431,13 @@ if HAS_CUDA and not TEST_WITH_ASAN:
 
             self.assertFalse(self.get_manager().running_forwards_with_pending_backwards)
 
-        @parametrize("backend", ("inductor", "cudagraphs"))
-        def test_forward_backward_not_called(self, backend):
+        def test_forward_backward_not_called(self):
+            @torch.compile(mode="reduce-overhead")
             def foo(x, y):
                 x_out = x * x * x
                 torch._dynamo.graph_break()
                 y_out = y * y * y
                 return x_out, y_out
-
-            foo = get_compile_fn(backend)(foo)
 
             for _ in range(3):
                 inps = [
@@ -1469,7 +1454,6 @@ if HAS_CUDA and not TEST_WITH_ASAN:
             with self.assertRaisesRegex(Exception, "custom error msg"):
                 device = x.untyped_storage()
 
-    instantiate_parametrized_tests(CudaGraphTreeTests)
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1767,10 +1767,6 @@ class _TorchCompileWrapper:
     def __call__(self, model_, inputs_):
         return self.compiler_fn(model_, inputs_, **self.kwargs)
 
-    def reset(self):
-        if hasattr(self.compiler_fn, "reset"):
-            self.compiler_fn.reset()
-
 
 def compile(model: Optional[Callable] = None, *,
             fullgraph: builtins.bool = False,

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -353,11 +353,6 @@ _save_config_ignore = {
     "skipfiles_inline_module_allowlist",
 }
 
-# for backend="cudagraphs", mutations on input be sent to the cudagraph backend
-# or replayed in aot_autograd epilogue. default is False because mutation on inputs
-# can prevent cudagraphing.
-cudagraph_backend_keep_input_mutation = False
-
 # When True, only ops that have the torch.Tag.pt2_compliant tag
 # will be allowed into the graph; all other ops will be disallowed
 # and will fall back to eager-mode PyTorch. Useful to ensure

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1,4 +1,5 @@
 import contextlib
+import dataclasses
 import functools
 import logging
 import os
@@ -38,7 +39,6 @@ from torch._dynamo.utils import (
 )
 from torch._functorch.aot_autograd import aot_export_module, make_boxed_func
 from torch._inductor.codecache import code_hash, CompiledFxGraph, FxGraphCache
-from torch._inductor.cudagraph_utils import BoxedDeviceIndex
 
 from torch._inductor.debug import save_args_for_compile_fx_inner
 from torch._inductor.utils import BoxedBool, count_tangents
@@ -59,7 +59,7 @@ from .fx_passes.post_grad import post_grad_passes, view_to_reshape
 from .fx_passes.pre_grad import pre_grad_passes
 from .graph import GraphLowering
 from .ir import ExternKernelNode
-from .utils import get_dtype_size, has_incompatible_cudagraph_ops, output_node
+from .utils import get_dtype_size, has_incompatible_cudagraph_ops
 from .virtualized import V
 
 if config.is_fbcode():
@@ -74,6 +74,15 @@ log = logging.getLogger(__name__)
 perf_hint_log = torch._logging.getArtifactLogger(__name__, "perf_hints")
 post_grad_graphs_log = torch._logging.getArtifactLogger(__name__, "post_grad_graphs")
 ALIGNMENT = 16
+
+
+@dataclasses.dataclass
+class BoxedDeviceIndex:
+    value: Optional[int]
+
+    def set(self, device_idx):
+        assert device_idx is None or isinstance(device_idx, int)
+        self.value = device_idx
 
 
 # copy_ fails when trying to write to tensors with memory overlap,
@@ -459,7 +468,7 @@ def compile_fx_inner(
 
     if cudagraphs:
         # output args are tuple of first argument
-        output = output_node(gm)
+        output = list(gm.graph.nodes)[-1]
         assert len(output.args) == 1
         stack_traces = [
             (arg.stack_trace if isinstance(arg, torch.fx.node.Node) else None)
@@ -1356,6 +1365,13 @@ def _shape_env_from_inputs(inputs: List[torch.Tensor]):
 
     # TODO(voz): Should we always have one anyway?
     return None
+
+
+def output_node(gm: torch.fx.GraphModule):
+    """Get the output node from an FX graph"""
+    last_node = next(iter(reversed(gm.graph.nodes)))
+    assert last_node.op == "output"
+    return last_node
 
 
 def graph_returns_tuple(gm: torch.fx.GraphModule):

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -680,13 +680,6 @@ def has_incompatible_cudagraph_ops(gm):
     return False
 
 
-def output_node(gm: torch.fx.GraphModule):
-    """Get the output node from an FX graph"""
-    last_node = next(iter(reversed(gm.graph.nodes)))
-    assert last_node.op == "output"
-    return last_node
-
-
 # Attempt to import AttrsDescriptor from Triton
 try:
     from triton.compiler.compiler import AttrsDescriptor


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121864

This reverts commit 9373ad0bb87b364375a468c296d2daef0e8817d7.

Revert "Add Cudagraphs disable checking (#121018)"

This reverts commit 4af0e634bf02309583dfe3b5c3421442fda5ec7e.

Causes compilation time increase.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang