### PR TITLE
[ROCm] avoid heap buffer overflow in hiprtc failure logs

### DIFF
--- a/aten/src/ATen/native/cuda/jit_utils.cpp
+++ b/aten/src/ATen/native/cuda/jit_utils.cpp
@@ -1565,11 +1565,9 @@ NvrtcFunction jit_pwise_function(
   if (compilation_result != NVRTC_SUCCESS) {
     size_t logsize;
     AT_CUDA_NVRTC_CHECK(nvrtc.nvrtcGetProgramLogSize(program, &logsize));
-    std::vector<char> log(logsize);
-    AT_CUDA_NVRTC_CHECK(nvrtc.nvrtcGetProgramLog(program, log.data()));
-    std::stringstream cu;
-    cu << log.data();
-    throw std::runtime_error(code + cu.str());
+    std::string log(logsize, '\0');
+    AT_CUDA_NVRTC_CHECK(nvrtc.nvrtcGetProgramLog(program, &log[0]));
+    throw std::runtime_error(code + log);
   }
 
   size_t ptx_size = 0;

--- a/caffe2/cuda_rtc/common_rtc.h
+++ b/caffe2/cuda_rtc/common_rtc.h
@@ -50,11 +50,11 @@ class CudaRTCFunction {
     if (compile_result != NVRTC_SUCCESS) {
       size_t log_size;
       NVRTC_CHECK(nvrtcGetProgramLogSize(prog, &log_size));
-      vector<char> nvrtc_log(log_size);
-      NVRTC_CHECK(nvrtcGetProgramLog(prog, nvrtc_log.data()));
+      std::string nvrtc_log(log_size, '\0');
+      NVRTC_CHECK(nvrtcGetProgramLog(prog, &nvrtc_log[0]));
       LOG(FATAL) << "Compilation failure for nvrtc("
                  << nvrtcGetErrorString(compile_result) << "): \n"
-                 << nvrtc_log.data();
+                 << nvrtc_log;
     }
     size_t ptx_size;
     NVRTC_CHECK(nvrtcGetPTXSize(prog, &ptx_size));


### PR DESCRIPTION
hiprtc doesn't seem to include the null byte automatically in the failure logs, resulting in heap buffer overflow. Initializing the log string with the null byte avoids the problem.

Found by rocm address sanitizer.


cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang