### PR TITLE
[jit] AliasDB type hash - don't always return 0

### DIFF
--- a/test/cpp/jit/test_alias_analysis.cpp
+++ b/test/cpp/jit/test_alias_analysis.cpp
@@ -4,6 +4,7 @@
 #include <torch/csrc/jit/frontend/ir_emitter.h>
 #include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/ir/irparser.h>
+#include <torch/csrc/jit/ir/type_hashing.h>
 #include <torch/csrc/jit/passes/utils/subgraph_utils.h>
 #include <torch/csrc/jit/runtime/custom_operator.h>
 #include <torch/csrc/jit/runtime/graph_iterator.h>
@@ -1689,6 +1690,18 @@ TEST(NonDeterminismBackwardsCompatibility, BackwardsCompatibility) {
         c10::OperatorName(schema.name(), schema.overload_name()));
     ASSERT_TRUE(op_handle->hasTag(at::Tag::nondeterministic_seeded));
   }
+}
+
+TEST(TypeHashing, HashTypes) {
+  HashType hasher;
+
+  const TypePtr int_type = IntType::get();
+  const TypePtr float_type = FloatType::get();
+  ASSERT_NE(hasher(int_type), hasher(float_type));
+
+  const TypePtr int2_type = TupleType::create({int_type, int_type});
+  const TypePtr int3_type = TupleType::create({int_type, int_type, int_type});
+  ASSERT_NE(hasher(int2_type), hasher(int3_type));
 }
 
 } // namespace jit

--- a/torch/csrc/jit/ir/type_hashing.cpp
+++ b/torch/csrc/jit/ir/type_hashing.cpp
@@ -17,7 +17,7 @@ size_t hashType(const Type& type) {
   for (const auto& containedType : type.containedTypes()) {
     hash = at::hash_combine(hash, hashType(*containedType));
   }
-  at::hash_combine(hash, get_hash(type.kind()));
+  hash = at::hash_combine(hash, get_hash(type.kind()));
   return hash;
 }
 } // namespace

--- a/torch/csrc/jit/ir/type_hashing.h
+++ b/torch/csrc/jit/ir/type_hashing.h
@@ -6,7 +6,7 @@
 namespace torch {
 namespace jit {
 
-struct HashType {
+struct TORCH_API HashType {
   size_t operator()(const TypePtr& type) const;
   size_t operator()(const c10::ConstTypePtr& type) const;
 };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #121928
* __->__ #121874

This hash was missing an assignment, so for almost all types it was returning "0".

c10::flat_hash_map turns out to have really bad behavior with a terrible hash like this, nearly exponential in memory usage.

Differential Revision: [D54916424](https://our.internmc.facebook.com/intern/diff/D54916424)