### PR TITLE
Make PyTorch compilable against upcoming Numpy-2.0

### DIFF
--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -414,7 +414,11 @@ at::Tensor tensor_from_cuda_array_interface(PyObject* obj) {
     TORCH_CHECK_VALUE(
         PyArray_DescrConverter(py_typestr, &descr), "cannot parse `typestr`");
     dtype = numpy_dtype_to_aten(descr->type_num);
+#if NPY_ABI_VERSION >= 0x02000000
+    dtype_size_in_bytes = PyDataType_ELSIZE(descr);
+#else
     dtype_size_in_bytes = descr->elsize;
+#endif
     TORCH_INTERNAL_ASSERT(dtype_size_in_bytes > 0);
   }
 


### PR DESCRIPTION
Test plan:
```
% python -c "import torch;import numpy;print(numpy.__version__, torch.tensor(numpy.arange(3, 10)))"
2.1.0.dev0+git20240312.9de8a80 tensor([3, 4, 5, 6, 7, 8, 9])
% python -c "import torch;print(torch.rand(3, 3).numpy())"                                         
[[0.0931946  0.44874293 0.8480404 ]
 [0.93877375 0.10188377 0.67375803]
 [0.02520031 0.89019287 0.5691561 ]]

```
Fixes https://github.com/pytorch/pytorch/issues/121798

