### PR TITLE
use make_storage_impl to create storages for COWStorage.

### DIFF
--- a/c10/core/impl/COW.cpp
+++ b/c10/core/impl/COW.cpp
@@ -107,8 +107,7 @@ c10::intrusive_ptr<StorageImpl> lazy_clone_storage(StorageImpl& storage) {
       *std::move(new_data_ptr),
       storage.allocator(),
       storage.resizable(),
-      storage.device_type()
-  );
+      storage.device_type());
 }
 
 C10_API void materialize_cow_storage(StorageImpl& storage) {

--- a/c10/core/impl/COW.cpp
+++ b/c10/core/impl/COW.cpp
@@ -101,12 +101,14 @@ c10::intrusive_ptr<StorageImpl> lazy_clone_storage(StorageImpl& storage) {
 
   TORCH_INTERNAL_ASSERT(new_data_ptr.has_value());
 
-  return make_intrusive<StorageImpl>(
+  return make_storage_impl(
       StorageImpl::use_byte_size_t(),
       storage.sym_nbytes(),
       *std::move(new_data_ptr),
       storage.allocator(),
-      storage.resizable());
+      storage.resizable(),
+      storage.device_type()
+  );
 }
 
 C10_API void materialize_cow_storage(StorageImpl& storage) {


### PR DESCRIPTION
Thanks to https://github.com/pytorch/pytorch/pull/118459， `make_storage_impl` will use the func ,which register for other backends, to create StorageImpl.

`make_storage_impl` completely overwrites the `make_intrusive<StorageImpl>`, so it makes sense to replace  `make_intrusive<StorageImpl>` with `make_storage_impl` to create storage in cow.