### PR TITLE
Add attributes to xpu device prop

### DIFF
--- a/c10/xpu/XPUDeviceProp.h
+++ b/c10/xpu/XPUDeviceProp.h
@@ -126,6 +126,16 @@ namespace c10::xpu {
   /* the number of hardware threads per EU of GPU. */    \
   _(gpu_hw_threads_per_eu, 8)
 
+#define AT_FORALL_XPU_DEVICE_ASPECT(_)                  \
+  /* sycl::half is supported on device. */              \
+  _(fp16)                                               \
+                                                        \
+  /* double is supported on device. */                  \
+  _(fp64)                                               \
+                                                        \
+  /* 64-bit atomic operation is supported on device. */ \
+  _(atomic64)
+
 #define _DEFINE_SYCL_PROP(ns, property, member) \
   ns::property::return_type member;
 
@@ -138,18 +148,23 @@ namespace c10::xpu {
 #define DEFINE_EXT_DEVICE_PROP(property, ...) \
   _DEFINE_SYCL_PROP(sycl::ext::intel::info::device, property, property)
 
+#define DEFINE_DEVICE_ASPECT(member) bool has_##member;
+
 struct C10_XPU_API DeviceProp {
   AT_FORALL_XPU_DEVICE_PROPERTIES(DEFINE_DEVICE_PROP);
 
   // the platform name.
   DEFINE_PLATFORM_PROP(name, platform_name);
 
-  AT_FORALL_XPU_EXT_DEVICE_PROPERTIES(DEFINE_EXT_DEVICE_PROP)
+  AT_FORALL_XPU_EXT_DEVICE_PROPERTIES(DEFINE_EXT_DEVICE_PROP);
+
+  AT_FORALL_XPU_DEVICE_ASPECT(DEFINE_DEVICE_ASPECT);
 };
 
 #undef _DEFINE_SYCL_PROP
 #undef DEFINE_DEVICE_PROP
 #undef DEFINE_PLATFORM_PROP
 #undef DEFINE_EXT_DEVICE_PROP
+#undef DEFINE_DEVICE_ASPECT
 
 } // namespace c10::xpu

--- a/c10/xpu/XPUFunctions.cpp
+++ b/c10/xpu/XPUFunctions.cpp
@@ -78,12 +78,17 @@ void initDeviceProperties(DeviceProp* device_prop, int device) {
       ? raw_device.get_info<intel::info::device::property>()                 \
       : default_value;
 
+#define ASSIGN_DEVICE_ASPECT(member) \
+  device_prop->has_##member = raw_device.has(sycl::aspect::member);
+
   AT_FORALL_XPU_DEVICE_PROPERTIES(ASSIGN_DEVICE_PROP);
 
   device_prop->platform_name =
       raw_device.get_info<device::platform>().get_info<platform::name>();
 
   AT_FORALL_XPU_EXT_DEVICE_PROPERTIES(ASSIGN_EXT_DEVICE_PROP);
+
+  AT_FORALL_XPU_DEVICE_ASPECT(ASSIGN_DEVICE_ASPECT);
   return;
 }
 

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -95,6 +95,14 @@ class TestXpu(TestCase):
         device_capability = torch.xpu.get_device_capability(current_device)
         self.assertTrue(device_capability["max_work_group_size"] > 0)
         self.assertTrue(device_capability["max_num_sub_groups"] > 0)
+        self.assertEqual(
+            device_properties.driver_version, device_capability["driver_version"]
+        )
+        self.assertEqual(device_properties.has_fp16, device_capability["has_fp16"])
+        self.assertEqual(device_properties.has_fp64, device_capability["has_fp64"])
+        self.assertEqual(
+            device_properties.has_atomic64, device_capability["has_atomic64"]
+        )
 
     def test_wrong_xpu_fork(self):
         stderr = TestCase.runWithPytorchAPIUsageStderr(

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1912,6 +1912,9 @@ def _xpu_emptyCache() -> None: ...
 class _XpuDeviceProperties:
     name: str
     platform_name: str
+    vendor: str
+    driver_version: str
+    version: str
     total_memory: _int
     max_compute_units: _int
     gpu_eu_count: _int
@@ -1919,6 +1922,9 @@ class _XpuDeviceProperties:
     max_work_group_size: _int
     max_num_sub_groups: _int
     sub_group_sizes: List[_int]
+    has_fp16: _bool
+    has_fp64: _bool
+    has_atomic64: _bool
     type: str
 
 # Defined in torch/csrc/xpu/Stream.cpp

--- a/torch/csrc/xpu/Module.cpp
+++ b/torch/csrc/xpu/Module.cpp
@@ -227,6 +227,9 @@ static void registerXpuDeviceProperties(PyObject* module) {
   py::class_<DeviceProp>(m, "_XpuDeviceProperties")
       .def_readonly("name", &DeviceProp::name)
       .def_readonly("platform_name", &DeviceProp::platform_name)
+      .def_readonly("vendor", &DeviceProp::vendor)
+      .def_readonly("driver_version", &DeviceProp::driver_version)
+      .def_readonly("version", &DeviceProp::version)
       .def_readonly("total_memory", &DeviceProp::global_mem_size)
       .def_readonly("max_compute_units", &DeviceProp::max_compute_units)
       .def_readonly("gpu_eu_count", &DeviceProp::gpu_eu_count)
@@ -234,6 +237,9 @@ static void registerXpuDeviceProperties(PyObject* module) {
       .def_readonly("max_work_group_size", &DeviceProp::max_work_group_size)
       .def_readonly("max_num_sub_groups", &DeviceProp::max_num_sub_groups)
       .def_readonly("sub_group_sizes", &DeviceProp::sub_group_sizes)
+      .def_readonly("has_fp16", &DeviceProp::has_fp16)
+      .def_readonly("has_fp64", &DeviceProp::has_fp64)
+      .def_readonly("has_atomic64", &DeviceProp::has_atomic64)
       .def_property_readonly("type", get_device_type)
       .def(
           "__repr__",
@@ -241,14 +247,18 @@ static void registerXpuDeviceProperties(PyObject* module) {
             std::ostringstream stream;
             stream << "_XpuDeviceProperties(name='" << prop.name
                    << "', platform_name='" << prop.platform_name << "', type='"
-                   << get_device_type(prop) << ", total_memory="
+                   << get_device_type(prop) << "', driver_version='"
+                   << prop.driver_version << "', total_memory="
                    << prop.global_mem_size / (1024ull * 1024)
                    << "MB, max_compute_units=" << prop.max_compute_units
                    << ", gpu_eu_count=" << prop.gpu_eu_count
                    << ", gpu_subslice_count=" << gpu_subslice_count(prop)
                    << ", max_work_group_size=" << prop.max_work_group_size
                    << ", max_num_sub_groups=" << prop.max_num_sub_groups
-                   << ", sub_group_sizes=[" << prop.sub_group_sizes << "])";
+                   << ", sub_group_sizes=[" << prop.sub_group_sizes
+                   << "], has_fp16=" << prop.has_fp16
+                   << ", has_fp64=" << prop.has_fp64
+                   << ", has_atomic64=" << prop.has_atomic64 << ")";
             return stream.str();
           });
 }

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -214,6 +214,7 @@ def get_device_name(device: Optional[_device_t] = None) -> str:
     return get_device_properties(device).name
 
 
+@lru_cache(None)
 def get_device_capability(device: Optional[_device_t] = None) -> Dict[str, Any]:
     r"""Get the xpu capability of a device.
 
@@ -227,11 +228,9 @@ def get_device_capability(device: Optional[_device_t] = None) -> Dict[str, Any]:
     Returns:
         Dict[str, Any]: the xpu capability dictionary of the device
     """
-    prop = get_device_properties(device)
+    props = get_device_properties(device)
     return {
-        "max_work_group_size": prop.max_work_group_size,
-        "max_num_sub_groups": prop.max_num_sub_groups,
-        "sub_group_sizes": prop.sub_group_sizes,
+        prop: getattr(props, prop) for prop in dir(props) if not prop.startswith("__")
     }
 
 


### PR DESCRIPTION
# Motivation
Add some attributes to `XPUDeviceProp` and expose them via `torch.xpu.get_device_properties` and `torch.xpu.get_device_capability`. They can be used in `torch.compile`  or directly passed to triton to generate more optimized code based on device properties.

# Additional Context
expose the following attributes to `torch.xpu.get_device_properties`：
- `has_fp16` (newly added)
- `has_fp64` (newly added)
- `has_atomic64` (newly added)
- `driver_version`
- `vendor`
- `version`


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10