### PR TITLE
Added error checks for invalid inputs on thnn_conv2d

### DIFF
--- a/aten/src/ATen/native/ConvolutionMM2d.cpp
+++ b/aten/src/ATen/native/ConvolutionMM2d.cpp
@@ -543,6 +543,11 @@ Tensor& slow_conv2d_forward_out_cpu(
     IntArrayRef padding,
     Tensor& output) {
   // See [Note: hacky wrapper removal for optional tensor]
+
+  TORCH_CHECK(kernel_size.size() == 2, "2D kernel_size expected");
+  TORCH_CHECK(stride.size() == 2, "2D stride expected");
+  TORCH_CHECK(padding.size() == 2, "2D padding expected");
+
   c10::MaybeOwned<Tensor> bias_maybe_owned = at::borrow_from_optional_tensor(bias_opt);
   const Tensor& bias = *bias_maybe_owned;
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8205,6 +8205,19 @@ class TestNNDeviceType(NNTestCase):
             weight = torch.empty([1, 0, 1], dtype=dtype, device=device)
             torch._C._nn.slow_conv3d(inp, weight, 1)
 
+        with self.assertRaisesRegex(RuntimeError, re.escape("2D kernel_size expected")):
+            inp = torch.empty([1, 1, 1, 1], dtype=dtype, device=device)
+            weight = torch.empty([1, 1], dtype=dtype, device=device)
+            torch._C._nn.thnn_conv2d(inp, weight, kernel_size=[], stride=[1, 1], padding=[1, 1])
+        with self.assertRaisesRegex(RuntimeError, re.escape("2D stride expected")):
+            inp = torch.empty([1, 1, 1, 1], dtype=dtype, device=device)
+            weight = torch.empty([1, 1], dtype=dtype, device=device)
+            torch._C._nn.thnn_conv2d(inp, weight, kernel_size=[1, 1], stride=[], padding=[1, 1])
+        with self.assertRaisesRegex(RuntimeError, re.escape("2D padding expected")):
+            inp = torch.empty([1, 1, 1, 1], dtype=dtype, device=device)
+            weight = torch.empty([1, 1], dtype=dtype, device=device)
+            torch._C._nn.thnn_conv2d(inp, weight, kernel_size=[1, 1], stride=[1, 1], padding=[])
+
     def test_InstanceNorm1d_general(self, device):
         b = random.randint(3, 5)
         c = random.randint(3, 5)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8206,17 +8206,14 @@ class TestNNDeviceType(NNTestCase):
             torch._C._nn.slow_conv3d(inp, weight, 1)
 
         with self.assertRaisesRegex(RuntimeError, re.escape("2D kernel_size expected")):
-            inp = torch.empty([1, 1, 1, 1], dtype=dtype, device=device)
-            weight = torch.empty([1, 1], dtype=dtype, device=device)
-            torch._C._nn.thnn_conv2d(inp, weight, kernel_size=[], stride=[1, 1], padding=[1, 1])
+            torch._C._nn.thnn_conv2d(torch.rand([1, 1, 1, 1]), kernel_size=[], padding=[1, 1], stride=[1, 1],
+                                     weight=torch.rand([1, 1]))
         with self.assertRaisesRegex(RuntimeError, re.escape("2D stride expected")):
-            inp = torch.empty([1, 1, 1, 1], dtype=dtype, device=device)
-            weight = torch.empty([1, 1], dtype=dtype, device=device)
-            torch._C._nn.thnn_conv2d(inp, weight, kernel_size=[1, 1], stride=[], padding=[1, 1])
+            torch._C._nn.thnn_conv2d(torch.rand([1, 1, 1, 1]), kernel_size=[1, 1], padding=[1, 1], stride=[],
+                                     weight=torch.rand([1, 1]))
         with self.assertRaisesRegex(RuntimeError, re.escape("2D padding expected")):
-            inp = torch.empty([1, 1, 1, 1], dtype=dtype, device=device)
-            weight = torch.empty([1, 1], dtype=dtype, device=device)
-            torch._C._nn.thnn_conv2d(inp, weight, kernel_size=[1, 1], stride=[1, 1], padding=[])
+            torch._C._nn.thnn_conv2d(torch.rand([1, 1, 1, 1]), kernel_size=[1, 1], padding=[], stride=[1, 1],
+                                     weight=torch.rand([1, 1]))
 
     def test_InstanceNorm1d_general(self, device):
         b = random.randint(3, 5)


### PR DESCRIPTION
Fixes #121188
Prevent Segmentation Fault in 'torch._C._nn.thnn_conv2d'

Previously, calling 'torch._C._nn.thnn_conv2d' with invalid arguments for padding, stride, and kernel_size would result in a segmentation fault. This issue has been resolved by implementing argument validation (using Torch Check). Now, when invalid arguments are detected, a runtime error is raised with a debug message detailing the correct format.

Additionally, this commit includes tests to cover the three referenced cases.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10