### PR TITLE
Disable inductor (default) and inductor (dynamic) by default in the perf run launcher

### DIFF
--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -20,12 +20,12 @@ on:
         description: Run inductor_default?
         required: false
         type: boolean
-        default: true
+        default: false
       dynamic:
         description: Run inductor_dynamic_shapes?
         required: false
         type: boolean
-        default: true
+        default: false
       cudagraphs:
         description: Run inductor_cudagraphs?
         required: false


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121914

