### PR TITLE
[inductor] FX graph cache: Fix bug handling constants

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -248,6 +248,34 @@ class TestFxGraphCache(TestCase):
             self.assertEqual(res1, res2)
 
     @config.patch({"fx_graph_cache": True})
+    @parametrize("device", (GPU_TYPE, "cpu"))
+    def test_constant_handling(self, device):
+        """
+        Test that different constants are recognized correctly.
+        """
+
+        def fn1(x):
+            return x + torch.tensor(list(range(0, 12)), device=device)
+
+        def fn2(x):
+            return x + torch.tensor(list(range(1, 13)), device=device)
+
+        a = torch.rand(12, device=device)
+
+        compiled_fn1 = torch.compile(fn1)
+        compiled_fn2 = torch.compile(fn2)
+
+        # A call to fn1 should miss in the cache.
+        self.assertEqual(fn1(a), compiled_fn1(a))
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+        # A call to fn2 should also miss (the constant is different)
+        self.assertEqual(fn2(a), compiled_fn2(a))
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+    @config.patch({"fx_graph_cache": True})
     def test_generated_kernel_count(self):
         """
         Test that we bump the generated_kernel_count metric on a cache hit.
@@ -313,12 +341,9 @@ class TestFxGraphCache(TestCase):
 class TestFxGraphCacheHashing(TestCase):
     def test_tensor_constants(self):
         """
-        Test the handling of small vs. large tensor constants.
+        Test the hashing of tensor constants.
         """
         data = FxGraphCachePickler.dumps(torch.tensor(list(range(9))))
-        self.assertIsInstance(pickle.loads(data), TensorMetadata)
-
-        data = FxGraphCachePickler.dumps(torch.tensor(list(range(8))))
         self.assertIsInstance(pickle.loads(data), TensorMetadataAndValues)
 
     def test_hash_fake_tensors(self):

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -253,6 +253,8 @@ class TestFxGraphCache(TestCase):
         """
         Test that different constants are recognized correctly.
         """
+        if device == GPU_TYPE and not HAS_GPU:
+            raise unittest.SkipTest(f"requires {GPU_TYPE}")
 
         def fn1(x):
             return x + torch.tensor(list(range(0, 12)), device=device)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121925

Summary: During key calculation for FX graph caching: Rather than specialize on "small" vs. "large" tensor constants (i.e., inlined vs. not inlined), always hash on the tensor value. Doing so avoids the complication of trying to later attach the constant values as attributes to an already-compiled module. Instead, different constants will cause an FX graph cache miss and we'll just compile.

Test Plan: New unit test

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang