### PR TITLE
[jit] ClassType hashing: hash on compilation_unit as well

### DIFF
--- a/torch/csrc/jit/ir/type_hashing.cpp
+++ b/torch/csrc/jit/ir/type_hashing.cpp
@@ -11,7 +11,8 @@ namespace torch::jit {
 namespace {
 size_t hashType(const Type& type) {
   if (auto named_type = type.castRaw<ClassType>()) {
-    return get_hash(named_type->name().value());
+    return c10::get_hash(
+        named_type->name().value(), named_type->compilation_unit());
   }
   size_t hash = 0;
   for (const auto& containedType : type.containedTypes()) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121928
* #121874

Following up on #121874 - it turns out that in our case, we're seeing repeated class names that are from different compilation units.  Our previous hash function wasn't considering the compilation unit, leading to hash collisions (and then exponential memory usage in the number of copies of this class name)

Differential Revision: [D54916455](https://our.internmc.facebook.com/intern/diff/D54916455)