### PR TITLE
[Dynamo] Trace through `cxx_pytree` API with dynamo

### DIFF
--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -3102,6 +3102,7 @@ THIRDPARTY_SKIPLIST = (
     "onnx",
     "onnxruntime",
     "onnx_tf",
+    "optree",
     "pandas",
     "sklearn",
     "tabulate",

--- a/torch/_functorch/autograd_function.py
+++ b/torch/_functorch/autograd_function.py
@@ -2,7 +2,7 @@ import torch
 from torch._ops import HigherOrderOperator
 from torch._C._functorch import TransformType
 from torch._functorch.utils import enable_single_level_autograd_function
-import torch.utils._pytree as pytree
+import torch.utils._cxx_pytree as pytree
 from torch._C._functorch import (
     _wrap_for_grad,
     _unwrap_for_grad,

--- a/torch/_functorch/eager_transforms.py
+++ b/torch/_functorch/eager_transforms.py
@@ -10,7 +10,7 @@ from typing import Callable, Union, Tuple, List, Any, Optional
 import torch
 from functools import partial, wraps
 import contextlib
-from torch.utils._pytree import (
+from torch.utils._cxx_pytree import (
     tree_flatten,
     tree_unflatten,
     tree_map,

--- a/torch/_functorch/vmap.py
+++ b/torch/_functorch/vmap.py
@@ -12,7 +12,7 @@ import functools
 import threading
 from torch import Tensor
 from typing import Any, Callable, Optional, Tuple, Union, List
-from torch.utils._pytree import (
+from torch.utils._cxx_pytree import (
     tree_flatten,
     tree_unflatten,
     tree_map_,

--- a/torch/utils/_cxx_pytree.py
+++ b/torch/utils/_cxx_pytree.py
@@ -356,6 +356,33 @@ def tree_leaves(
     )
 
 
+def arg_tree_leaves(*args: PyTree, **kwargs: PyTree) -> List[Any]:
+    """C++ version of pytree.arg_tree_leaves. This only exists to match the
+    python API.
+
+    See also :func:`tree_flatten`.
+
+    >>> args = (1, None)
+    >>> kwargs = {'b': (2, [3, 4]),}
+    >>> arg_tree_leaves(*args, **kwargs)
+    [1, None, 2, 3, 4]
+    >>> tree_leaves(*args)
+    [1, None]
+    >>> tree_leaves(**kwargs)
+    [2, 3, 4]
+
+    Args:
+        args (pytree): list of args to flatten.
+        kwargs (pytree): list of keyword arguments to flatten.
+
+    Returns:
+        A list of leaf values.
+    """
+    leaves_args: List[Any] = [optree.tree_leaves(a) for a in args]
+    leaves_kw: List[Any] = [optree.tree_leaves(a) for a in kwargs.values()]
+    return leaves_args + leaves_kw
+
+
 def tree_structure(
     tree: PyTree,
     is_leaf: Optional[Callable[[PyTree], bool]] = None,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #121931

Internally, dynamo converts cxx_pytree calls into pytree ones

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang