### PR TITLE
[Inductor] fix addmm fusion check

### DIFF
--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -205,6 +205,7 @@ class TestPatternMatcherBase(TestCase):
                 torch.compile(mod, fullgraph=True, dynamic=check_dynamic),
                 *clone_inputs,
             )
+            print("source_code: ", source_code)
             for op in include_ops:
                 self.assertIn(op, source_code)
             for op in exclude_ops:
@@ -2152,10 +2153,10 @@ class TestPatternMatcher(TestPatternMatcherBase):
                 include_ops = []
                 exclude_ops = []
                 if (beta != 1.0 and beta != 0.0) or alpha != 1.0:
-                    exclude_ops = ["mkldnn._linear_pointwise.default"]
+                    exclude_ops = ["torch.ops.mkl._mkl_linear"]
                 else:
-                    exclude_ops = ["mkldnn._linear_pointwise.default"]
-                self._test_code_common(mod, (x,), include_ops, [])
+                    include_ops = ["torch.ops.mkl._mkl_linear"]
+                self._test_code_common(mod, (x,), include_ops, exclude_ops)
 
     @skipIfNoDynamoSupport
     @skipIfRocm

--- a/test/test_mkldnn_fusion.py
+++ b/test/test_mkldnn_fusion.py
@@ -338,7 +338,6 @@ class TestMkldnnFusion(JitTestCase):
                     )
                     self.assertEqual(ref, fused)
 
-
     def test_conv_transpose_unary_fusion_ops(self):
         class M(nn.Module):
             def __init__(self, unary_fn, dim, in_channels, out_channels, kernel_size, **kwargs):

--- a/test/test_mkldnn_fusion.py
+++ b/test/test_mkldnn_fusion.py
@@ -338,27 +338,6 @@ class TestMkldnnFusion(JitTestCase):
                     )
                     self.assertEqual(ref, fused)
 
-    # fix issue https://github.com/pytorch/pytorch/issues/121253
-    def test_addmm_fusion_beta_alpha(self):
-        class M(nn.Module):
-            def __init__(self, weight, bias, beta, alpha):
-                super().__init__()
-                self.weight = weight
-                self.bias = bias
-                self.beta = beta
-                self.alpha = alpha
-
-            def forward(self, x):
-                return torch.addmm(self.bias, x, self.weight, beta=self.beta, alpha=self.alpha)
-
-        for beta, alpha in zip([1.0, 0.1], [1.0, 0.1]):
-            func = M(torch.randn(64, 64), torch.randn(64), beta, alpha)
-            with torch.no_grad():
-                func_compiled = torch.compile(func)
-                x = torch.randn(1, 64)
-                res_ref = func(x.clone())
-                res_actual = func_compiled(x.clone())
-                self.assertEqual(res_ref, res_actual)
 
     def test_conv_transpose_unary_fusion_ops(self):
         class M(nn.Module):

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -913,15 +913,9 @@ if torch._C._has_mkldnn:
         linear_node = match.output_node()
         # mkldnn linear only supports beta=1or0 and alpha=1
         if linear_node.target == aten.addmm.default:
-            alpha = (
-                None
-                if "alpha" not in linear_node.kwargs
-                else linear_node.kwargs["alpha"]
-            )
-            beta = (
-                None if "beta" not in linear_node.kwargs else linear_node.kwargs["beta"]
-            )
-            if (beta and beta != 0.0 and beta != 1.0) or (alpha and alpha != 1.0):
+            alpha = linear_node.kwargs.get("alpha", 1.0)
+            beta = linear_node.kwargs.get("beta", 1.0)
+            if (beta != 0.0 and beta != 1.0) or alpha != 1.0:
                 return False
         # weight_idx is 1 for aten.mm and is 2 for aten.addmm
         weight_idx = 2 if linear_node.target == aten.addmm.default else 1
@@ -1128,8 +1122,7 @@ if torch._C._has_mkldnn:
                 if linear_node.target == aten.mm.default
                 or (
                     linear_node.target == aten.addmm.default
-                    and "beta" in linear_node.kwargs
-                    and linear_node.kwargs["beta"] == 0.0
+                    and linear_node.kwargs.get("beta", 1.0) == 0.0
                 )
                 else args[0]
             )

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -913,9 +913,15 @@ if torch._C._has_mkldnn:
         linear_node = match.output_node()
         # mkldnn linear only supports beta=1or0 and alpha=1
         if linear_node.target == aten.addmm.default:
-            beta = linear_node.kwargs["beta"]
-            alpha = linear_node.kwargs["alpha"]
-            if (beta != 0.0 and beta != 1.0) or alpha != 1.0:
+            alpha = (
+                None
+                if "alpha" not in linear_node.kwargs
+                else linear_node.kwargs["alpha"]
+            )
+            beta = (
+                None if "beta" not in linear_node.kwargs else linear_node.kwargs["beta"]
+            )
+            if (beta and beta != 0.0 and beta != 1.0) or (alpha and alpha != 1.0):
                 return False
         # weight_idx is 1 for aten.mm and is 2 for aten.addmm
         weight_idx = 2 if linear_node.target == aten.addmm.default else 1
@@ -1122,6 +1128,7 @@ if torch._C._has_mkldnn:
                 if linear_node.target == aten.mm.default
                 or (
                     linear_node.target == aten.addmm.default
+                    and "beta" in linear_node.kwargs
                     and linear_node.kwargs["beta"] == 0.0
                 )
                 else args[0]


### PR DESCRIPTION
Fixes #121253.

To avoid functional issue, disable pattern match for `addmm` when `beta!=1 or 0` or `alpha!=1`, as either `mkl_linear` or `mkldnn_linear` doesn't accept `beta` or `alpha` as parameters.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang