### PR TITLE
Fix #83241: torch.nn.TripletMarginLoss allowed margin less or equal to 0

### DIFF
--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -898,6 +898,9 @@ def triplet_margin_loss(
         # msg = "size_average and reduce args are deprecated, please use reduction argument."
         reduction = _get_string_reduction_arg(size_average=size_average, reduce=reduce)
 
+    if margin <= 0:
+        raise ValueError("margin must be greater than 0")
+
     # torch.nn.functional.triplet_margin_with_distance_loss has no ref defined
     # since it's a pure Python implementation.  Use this helper instead.
     return _triplet_margin_with_distance_loss(

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -899,7 +899,7 @@ def triplet_margin_loss(
         reduction = _get_string_reduction_arg(size_average=size_average, reduce=reduce)
 
     if margin <= 0:
-        raise ValueError("margin must be greater than 0")
+        raise ValueError(f"margin must be greater than 0, got {margin}")
 
     # torch.nn.functional.triplet_margin_with_distance_loss has no ref defined
     # since it's a pure Python implementation.  Use this helper instead.

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -4680,6 +4680,8 @@ def triplet_margin_loss(
         reduction_enum = _Reduction.legacy_get_enum(size_average, reduce)
     else:
         reduction_enum = _Reduction.get_enum(reduction)
+    if margin <= 0:
+        raise ValueError("margin must be greater than 0")
     return torch.triplet_margin_loss(anchor, positive, negative, margin, p, eps, swap, reduction_enum)
 
 
@@ -4719,6 +4721,10 @@ def triplet_margin_with_distance_loss(
     # Check validity of reduction mode
     if reduction not in ("mean", "sum", "none"):
         raise ValueError(f"{reduction} is not a valid value for reduction")
+
+    # Check validity of margin
+    if margin <= 0:
+        raise ValueError("margin must be greater than 0")
 
     # Check dimensions
     a_dim = anchor.ndim

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -4681,7 +4681,7 @@ def triplet_margin_loss(
     else:
         reduction_enum = _Reduction.get_enum(reduction)
     if margin <= 0:
-        raise ValueError("margin must be greater than 0")
+        raise ValueError(f"margin must be greater than 0, got {margin}")
     return torch.triplet_margin_loss(anchor, positive, negative, margin, p, eps, swap, reduction_enum)
 
 
@@ -4724,7 +4724,7 @@ def triplet_margin_with_distance_loss(
 
     # Check validity of margin
     if margin <= 0:
-        raise ValueError("margin must be greater than 0")
+        raise ValueError(f"margin must be greater than 0, got {margin}")
 
     # Check dimensions
     a_dim = anchor.ndim

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -1512,6 +1512,10 @@ class TripletMarginLoss(_Loss):
     def __init__(self, margin: float = 1.0, p: float = 2., eps: float = 1e-6, swap: bool = False, size_average=None,
                  reduce=None, reduction: str = 'mean'):
         super().__init__(size_average, reduce, reduction)
+        if margin <= 0:
+            raise ValueError(
+                f"TripletMarginLoss: expected margin to be greater than 0, got {margin} instead"
+            )
         self.margin = margin
         self.p = p
         self.eps = eps
@@ -1627,6 +1631,10 @@ class TripletMarginWithDistanceLoss(_Loss):
     def __init__(self, *, distance_function: Optional[Callable[[Tensor, Tensor], Tensor]] = None,
                  margin: float = 1.0, swap: bool = False, reduction: str = 'mean'):
         super().__init__(size_average=None, reduce=None, reduction=reduction)
+        if margin <= 0:
+            raise ValueError(
+                f"TripletMarginWithDistanceLoss: expected margin to be greater than 0, got {margin} instead"
+            )
         self.distance_function: Optional[Callable[[Tensor, Tensor], Tensor]] = \
             distance_function if distance_function is not None else PairwiseDistance()
         self.margin = margin

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8464,7 +8464,7 @@ def error_inputs_triplet_margin_loss(op_info, device, **kwargs):
         # invalid margin
         (make_input(3, 4), (make_input(3, 4), make_input(3, 4)),
          dict(margin=-1.0),
-         ValueError, "margin must be greater than 0"),
+         ValueError, "margin must be greater than 0, got -1.0"),
 
         # shape mismatch
         (make_input(3, 5), (make_input(3, 4), make_input(3, 4)),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8461,6 +8461,11 @@ def error_inputs_triplet_margin_loss(op_info, device, **kwargs):
          dict(reduction="abc"),
          ValueError, "abc is not a valid value for reduction"),
 
+        # invalid margin
+        (make_input(3, 4), (make_input(3, 4), make_input(3, 4)),
+         dict(margin=-1.0),
+         ValueError, "margin must be greater than 0"),
+
         # shape mismatch
         (make_input(3, 5), (make_input(3, 4), make_input(3, 4)),
          dict(),


### PR DESCRIPTION
Documentation states that the parameter margin of torch.nn.TripletMarginLoss is greater than 0, however any value was being accepted. Also fixed torch.nn.TripletMarginWithDistanceLoss which had the same problem. Added error test input for the new ValueError.

Fixes #83241 
