### PR TITLE
[export] Always decompose dropout_ to dropout

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -3445,6 +3445,33 @@ def forward(self, arg0_1, arg1_1, arg2_1):
     _set_grad_enabled_1 = torch._C._set_grad_enabled(False)
     return (add_1,)""")
 
+    def test_dropout(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return torch.nn.functional.dropout(x, p=0.5, training=True, inplace=True)
+
+        ep = torch.export._trace._export(M(), (torch.ones(4),), {}, pre_dispatch=True)
+        self.assertExpectedInline(
+            str(ep.graph_module.code.strip()),
+            """\
+def forward(self, arg0_1):
+    dropout = torch.ops.aten.dropout.default(arg0_1, 0.5, True)
+    copy = torch.ops.aten.copy.default(arg0_1, dropout);  arg0_1 = dropout = None
+    return (copy, copy)"""
+        )
+
+        ep_aot_dispatch = export(M(), (torch.ones(4),), {})
+
+        self.assertExpectedInline(
+            str(ep_aot_dispatch.graph_module.code.strip()),
+            """\
+def forward(self, arg0_1):
+    native_dropout = torch.ops.aten.native_dropout.default(arg0_1, 0.5, True)
+    getitem = native_dropout[0];  native_dropout = None
+    copy = torch.ops.aten.copy.default(arg0_1, getitem);  arg0_1 = getitem = None
+    return (copy, copy)"""
+        )
+
     def test_non_persistent_buffer(self):
         class MyModule(torch.nn.Module):
             def __init__(self):


### PR DESCRIPTION
Summary: title

Test Plan: CI

Differential Revision: D54928913

This makes downstream pattern matchers to switch between train/eval easier. https://github.com/pytorch/pytorch/pull/117879 As we previously implemented, aten.dropout essentially serves as a functional op as we ban the mutations on output of aten.dropout. 

