### PR TITLE
[BE] Move pull job linux-jammy-py3_8-gcc11-build to use ARC runners

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -32,7 +32,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: ./.github/workflows/_linux-build-label.yml
+    uses: ./.github/workflows/_linux-build-rg.yml
     with:
       aws-role-to-assume: arn:aws:iam::391835788720:role/gha-pytorch-ci-artifacts-role
       build-environment: linux-jammy-py3.8-gcc11


### PR DESCRIPTION
This is mostly a infra change. As experiment to enable one of the runners from the new infrastructure provided by Pytorch Foundation (sponsored by Linux Foundation) and helped to integrate by Meta.

This is moving the `pull.yml` job `linux-jammy-py3_8-gcc11-build` to use `arc-lf-linux.2xlarge` runner group [that is defined in test-infra](https://github.com/pytorch/test-infra/blob/main/.github/arc-runner-config.yaml).

This PR have [been already tested](https://github.com/pytorch/pytorch/pull/121930/commits/c725209cc67627749b34564705b2dc67516e597a).