### PR TITLE
[codemod] Remove unused variables in caffe2/caffe2/operators/softmax_op_cudnn.cc

### DIFF
--- a/caffe2/operators/softmax_op_cudnn.cc
+++ b/caffe2/operators/softmax_op_cudnn.cc
@@ -5,14 +5,6 @@
 
 namespace caffe2 {
 
-namespace {
-constexpr int NUM_DESCRIPTORS = 2;
-constexpr int GRADIENT_NUM_DESCRIPTORS = 3;
-constexpr int BOTTOM_DESC_ID = 0;
-constexpr int TOP_DESC_ID = 1;
-constexpr int TOP_GRADIENT_DESC_ID = 2;
-} // namespace
-
 class CuDNNSoftmaxOp final : public Operator<CUDAContext> {
  public:
   template <class... Args>

--- a/torch/csrc/distributed/c10d/ProcessGroupUCC.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupUCC.cpp
@@ -12,7 +12,6 @@
 namespace c10d {
 
 namespace {
-constexpr int64_t kBusyWaitMillis = 10;
 
 const std::map<c10::DeviceType, ucc_memory_type_t> ucc_mtype_map = {
     {c10::kCPU, UCC_MEMORY_TYPE_HOST},


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Test Plan: Sandcastle

Reviewed By: palmje

Differential Revision: D54931224




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang