### PR TITLE
[compiled autograd] add dynamo segfault test

### DIFF
--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -58,6 +58,48 @@ class TestCompiledAutograd(TestCase):
             self.assertEqual(counters["compiled_autograd"]["captures"], count)
             self.assertEqual(counters["compiled_autograd"]["compiles"], count)
 
+    def test_dynamo_flaky_segfault(self):
+        import os
+        import subprocess
+
+        script = """
+import torch
+
+def main():
+    def compiler_fn(gm):
+        return torch.compile(gm, backend="eager")
+
+    def inner():
+        x = torch.randn(1000, 3000)
+        w = torch.randn(1000, 3000, requires_grad=True)
+        def model(i):
+            return torch.nn.functional.linear(i, w)
+        out = model(x)
+        loss = out.sum()
+        with torch._dynamo.compiled_autograd.enable(compiler_fn):
+            loss.backward()
+        assert(w.grad is not None)
+
+    inner()
+    torch._dynamo.reset()
+    inner()
+
+main()
+        """
+        # Run it three times to catch bad dynamo state resets
+        for _ in range(3):
+            try:
+                subprocess.check_output(
+                    [sys.executable, "-c", script],
+                    stderr=subprocess.STDOUT,
+                    # On Windows, opening the subprocess with the default CWD makes `import torch`
+                    # fail, so just set CWD to this script's directory
+                    cwd=os.path.dirname(os.path.realpath(__file__)),
+                )
+            except subprocess.CalledProcessError as e:
+                if e.returncode < 0:
+                    self.fail("Subprocess exited with a fatal signal")
+
     def test_basic(self):
         def fn():
             model = torch.nn.Sequential(


### PR DESCRIPTION
To catch issues like https://github.com/pytorch/pytorch/issues/121862 in CI. This passes because we reverted the PRs, and https://github.com/pytorch/pytorch/pull/121870 confirms that this test can catch it

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122004



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang