### PR TITLE
Add tensor step to RMSprop, Rprop, and Adadelta

### DIFF
--- a/test/inductor/test_compiled_optimizers.py
+++ b/test/inductor/test_compiled_optimizers.py
@@ -74,9 +74,9 @@ KERNEL_COUNTS = {
     Adam: KernelCounts(multitensor=2, singletensor=8),
     AdamW: KernelCounts(multitensor=2, singletensor=8),
     NAdam: KernelCounts(multitensor=2, singletensor=12),
-    Rprop: KernelCounts(multitensor=1, singletensor=4),
-    RMSprop: KernelCounts(multitensor=1, singletensor=4),
-    Adadelta: KernelCounts(multitensor=1, singletensor=4),
+    Rprop: KernelCounts(multitensor=2, singletensor=8),
+    RMSprop: KernelCounts(multitensor=2, singletensor=8),
+    Adadelta: KernelCounts(multitensor=2, singletensor=8),
     Adagrad: KernelCounts(multitensor=5, singletensor=8),
     ASGD: KernelCounts(multitensor=2, singletensor=12),
     SGD: KernelCounts(multitensor=2, singletensor=8),
@@ -191,16 +191,13 @@ def check_optim(
 
     self.assertEqual(list(params_eager), list(params_compiled), atol=atol, rtol=rtol)
 
-    # currently we don't mutate step properly until we resolve
-    # https://github.com/pytorch/pytorch/issues/115679
-    if optim_cls not in (Rprop, RMSprop, Adadelta):
-        for p_eager, p_compiled in zip(params_eager, params_compiled):
-            self.assertEqual(
-                state_eager[p_eager],
-                state_compiled[p_compiled],
-                atol=atol,
-                rtol=rtol,
-            )
+    for p_eager, p_compiled in zip(params_eager, params_compiled):
+        self.assertEqual(
+            state_eager[p_eager],
+            state_compiled[p_compiled],
+            atol=atol,
+            rtol=rtol,
+        )
 
 
 def make_test(
@@ -415,9 +412,9 @@ class CompiledOptimizerTests(TestCase):
     test_adamw_recompile = make_recompile_test(AdamW, lr=0.01)
     test_adamax_recompile = make_recompile_test(Adamax, lr=0.01)
     test_nadam_recompile = make_recompile_test(NAdam, lr=0.01)
-    test_rprop_recompile = make_recompile_test(Rprop, kernel_count=1, lr=0.01)
-    test_rmsprop_recompile = make_recompile_test(RMSprop, kernel_count=1, lr=0.01)
-    test_adadelta_recompile = make_recompile_test(Adadelta, kernel_count=1, lr=0.01)
+    test_rprop_recompile = make_recompile_test(Rprop, lr=0.01)
+    test_rmsprop_recompile = make_recompile_test(RMSprop, lr=0.01)
+    test_adadelta_recompile = make_recompile_test(Adadelta, lr=0.01)
     test_adagrad_recompile = make_recompile_test(Adagrad, kernel_count=5, lr=0.01)
     test_asgd_recompile_default = make_recompile_test(ASGD, kernel_count=2, lr=0.01)
     test_asgd_recompile_single = make_recompile_test(

--- a/torch/optim/rprop.py
+++ b/torch/optim/rprop.py
@@ -1,8 +1,18 @@
+from typing import List, Optional
+
 import torch
 from torch import Tensor
-from .optimizer import (Optimizer, _use_grad_for_differentiable, _default_to_fused_or_foreach,
-                        _differentiable_doc, _foreach_doc, _maximize_doc, _view_as_real)
-from typing import List, Optional
+
+from .optimizer import (
+    _default_to_fused_or_foreach,
+    _differentiable_doc,
+    _foreach_doc,
+    _get_scalar_dtype,
+    _maximize_doc,
+    _use_grad_for_differentiable,
+    _view_as_real,
+    Optimizer,
+)
 
 __all__ = ["Rprop", "rprop"]
 
@@ -40,8 +50,15 @@ class Rprop(Optimizer):
             group.setdefault("foreach", None)
             group.setdefault("maximize", False)
             group.setdefault("differentiable", False)
+            for p in group["params"]:
+                p_state = self.state.get(p, [])
+                if len(p_state) != 0 and not torch.is_tensor(p_state["step"]):
+                    step_val = float(p_state["step"])
+                    p_state["step"] = torch.tensor(
+                        step_val, dtype=_get_scalar_dtype(), device=p.device
+                    )
 
-    def _init_group(self, group, params, grads, prevs, step_sizes):
+    def _init_group(self, group, params, grads, prevs, step_sizes, state_steps):
         has_complex = False
         for p in group["params"]:
             if p.grad is None:
@@ -57,23 +74,22 @@ class Rprop(Optimizer):
 
             # State initialization
             if len(state) == 0:
-                state["step"] = 0
-                state["prev"] = torch.zeros_like(
-                    p, memory_format=torch.preserve_format
+                state["step"] = torch.zeros(
+                    (), device=p.device, dtype=_get_scalar_dtype()
                 )
+                state["prev"] = torch.zeros_like(p, memory_format=torch.preserve_format)
                 if p.dtype.is_complex:
                     # Complex Number should be as if they are two independent real numbers.
                     # Hence the step_size shouldn't be zero for imaginary part.
-                    state["step_size"] = (
-                        torch.full_like(grad, complex(group["lr"], group["lr"]))
+                    state["step_size"] = torch.full_like(
+                        grad, complex(group["lr"], group["lr"])
                     )
                 else:
                     state["step_size"] = torch.full_like(grad, group["lr"])
 
             prevs.append(state["prev"])
             step_sizes.append(state["step_size"])
-
-            state["step"] += 1
+            state_steps.append(state["step"])
         return has_complex
 
     @_use_grad_for_differentiable
@@ -94,18 +110,22 @@ class Rprop(Optimizer):
             grads = []
             prevs = []
             step_sizes = []
+            state_steps = []
             etaminus, etaplus = group["etas"]
             step_size_min, step_size_max = group["step_sizes"]
             foreach = group["foreach"]
             maximize = group["maximize"]
 
-            has_complex = self._init_group(group, params, grads, prevs, step_sizes)
+            has_complex = self._init_group(
+                group, params, grads, prevs, step_sizes, state_steps
+            )
 
             rprop(
                 params,
                 grads,
                 prevs,
                 step_sizes,
+                state_steps,
                 step_size_min=step_size_min,
                 step_size_max=step_size_max,
                 etaminus=etaminus,
@@ -119,7 +139,8 @@ class Rprop(Optimizer):
         return loss
 
 
-Rprop.__doc__ = r"""Implements the resilient backpropagation algorithm.
+Rprop.__doc__ = (
+    r"""Implements the resilient backpropagation algorithm.
 
     .. math::
        \begin{aligned}
@@ -153,7 +174,8 @@ Rprop.__doc__ = r"""Implements the resilient backpropagation algorithm.
     For further details regarding the algorithm we refer to the paper
     `A Direct Adaptive Method for Faster Backpropagation Learning: The RPROP Algorithm
     <http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.21.1417>`_.
-    """ + fr"""
+    """
+    + rf"""
     Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups
@@ -168,12 +190,15 @@ Rprop.__doc__ = r"""Implements the resilient backpropagation algorithm.
         {_differentiable_doc}
 
     """
+)
+
 
 def rprop(
     params: List[Tensor],
     grads: List[Tensor],
     prevs: List[Tensor],
     step_sizes: List[Tensor],
+    state_steps: List[Tensor],
     # kwonly args with defaults are not supported by functions compiled with torchscript issue #70627
     # setting this as kwarg for now as functional API is compiled by torch/distributed/optim
     foreach: Optional[bool] = None,
@@ -192,7 +217,9 @@ def rprop(
     """
 
     if foreach is None:
-        _, foreach = _default_to_fused_or_foreach(params, differentiable, use_fused=False)
+        _, foreach = _default_to_fused_or_foreach(
+            params, differentiable, use_fused=False
+        )
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")
@@ -207,6 +234,7 @@ def rprop(
         grads,
         prevs,
         step_sizes,
+        state_steps,
         step_size_min=step_size_min,
         step_size_max=step_size_max,
         etaminus=etaminus,
@@ -222,6 +250,7 @@ def _single_tensor_rprop(
     grads: List[Tensor],
     prevs: List[Tensor],
     step_sizes: List[Tensor],
+    state_steps: List[Tensor],
     *,
     step_size_min: float,
     step_size_max: float,
@@ -237,6 +266,7 @@ def _single_tensor_rprop(
         grad = grad if not maximize else -grad
         prev = prevs[i]
         step_size = step_sizes[i]
+        step = state_steps[i]
 
         if torch.is_complex(param):
             grad = torch.view_as_real(grad)
@@ -251,6 +281,7 @@ def _single_tensor_rprop(
         sign[sign.lt(0)] = etaminus
         sign[sign.eq(0)] = 1
 
+        step += 1
         # update stepsizes with step size updates
         step_size.mul_(sign).clamp_(step_size_min, step_size_max)
 
@@ -269,6 +300,7 @@ def _multi_tensor_rprop(
     grads: List[Tensor],
     prevs: List[Tensor],
     step_sizes: List[Tensor],
+    state_steps: List[Tensor],
     *,
     step_size_min: float,
     step_size_max: float,
@@ -284,11 +316,23 @@ def _multi_tensor_rprop(
 
     assert not differentiable, "_foreach ops don't support autograd"
 
-    grouped_tensors = Optimizer._group_tensors_by_device_and_dtype([params, grads, prevs, step_sizes])
-    for ((grouped_params, grouped_grads, grouped_prevs, grouped_step_sizes), _) in grouped_tensors.values():
+    grouped_tensors = Optimizer._group_tensors_by_device_and_dtype(
+        [params, grads, prevs, step_sizes, state_steps]
+    )
+    for (
+        grouped_params,
+        grouped_grads,
+        grouped_prevs,
+        grouped_step_sizes,
+        grouped_steps,
+    ), _ in grouped_tensors.values():
         # Handle complex params
         if has_complex:
-            _view_as_real(grouped_params, grouped_grads, grouped_prevs, grouped_step_sizes)
+            _view_as_real(
+                grouped_params, grouped_grads, grouped_prevs, grouped_step_sizes
+            )
+
+        torch._foreach_add_(grouped_steps, 1)
 
         signs = torch._foreach_mul(grouped_grads, grouped_prevs)
         if maximize:
@@ -324,7 +368,9 @@ def _multi_tensor_rprop(
 
         # update parameters
         grad_signs = [grad.sign() for grad in grouped_grads]
-        torch._foreach_addcmul_(grouped_params, grad_signs, grouped_step_sizes, value=-1)
+        torch._foreach_addcmul_(
+            grouped_params, grad_signs, grouped_step_sizes, value=-1
+        )
 
         # Logically, you may expect grouped_prevs to get updated to grouped_grads, but that's
         # basically already happened since we've been using grouped_prevs' memory to store


### PR DESCRIPTION
Fixes #115679

Creates a tensor step, and increments it in the compute portion of the optimizers.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang