### PR TITLE
[Functorch] Bump tolerances for `test_per_sample_grads_embeddingnet_mechanism_functional_call_cuda`

### DIFF
--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -1568,15 +1568,13 @@ class TestVmapOfGrad(TestCase):
             expected = zip(*expected)
             expected = tuple(torch.stack(shards) for shards in expected)
             for r, e in zip(result, expected):
-                # TODO: Check if the rtol is a problem
-                self.assertEqual(r, e, atol=0, rtol=1e-3)
+                self.assertEqual(r, e, atol=0, rtol=1.5e-3)
         else:
             assert mechanism == "functional_call"
             expected = {k: tuple(d[k] for d in expected) for k, v in expected[0].items()}
             expected = {k: torch.stack(shards) for k, shards in expected.items()}
             for key in result:
-                # TODO: Check if the rtol is a problem
-                self.assertEqual(result[key], expected[key], atol=0, rtol=1e-3)
+                self.assertEqual(result[key], expected[key], atol=0, rtol=1.5e-3)
 
     @parametrize("mechanism", ["make_functional", "functional_call"])
     def test_per_sample_grads_embeddingnet(self, device, mechanism):


### PR DESCRIPTION
the `rtol` was indeed a problem on Grace Hopper

cc @ptrblck @zou3519 @Chillee @samdow @kshitij12345 @janeyx99