### PR TITLE
[Clang-tidy header][26/N] Fix clang-tidy warnings in aten/src/ATen/core/*.h

### DIFF
--- a/aten/src/ATen/core/CheckMemoryFormat.h
+++ b/aten/src/ATen/core/CheckMemoryFormat.h
@@ -1,6 +1,6 @@
 #include <c10/core/TensorOptions.h>
 
-namespace c10 { namespace impl {
+namespace c10::impl {
 
 inline c10::optional<MemoryFormat>
 check_tensor_options_and_extract_memory_format(
@@ -22,4 +22,4 @@ check_tensor_options_and_extract_memory_format(
   }
 }
 
-}} // namespace impl namespace c10
+} // namespace impl namespace c10

--- a/aten/src/ATen/core/Dict.h
+++ b/aten/src/ATen/core/Dict.h
@@ -207,7 +207,7 @@ template<class Key, class Value> Dict<IValue, IValue> toGenericDict(Dict<Key, Va
 template<class Key, class Value>
 class Dict final {
 private:
-  static_assert((std::is_same<IValue, Key>::value && std::is_same<IValue, Value>::value) || guts::typelist::contains<impl::valid_dict_key_types, Key>::value, "Invalid Key type for Dict. We only support int64_t, double, bool, and string.");
+  static_assert((std::is_same_v<IValue, Key> && std::is_same_v<IValue, Value>) || guts::typelist::contains<impl::valid_dict_key_types, Key>::value, "Invalid Key type for Dict. We only support int64_t, double, bool, and string.");
 
   // impl_ stores the underlying map as a ska_ordered::order_preserving_flat_hash_map.
   // We intentionally don't offer conversion from/to

--- a/aten/src/ATen/core/IListRef.h
+++ b/aten/src/ATen/core/IListRef.h
@@ -307,10 +307,10 @@ class IListRefTagImplBase {};
  * reference type, then it's left unchanged.
  */
 template <typename T>
-using _MaterializedIListRefElem = typename std::conditional<
-    std::is_reference<T>::value,
-    typename std::reference_wrapper<typename std::remove_reference<T>::type>,
-    T>::type;
+using _MaterializedIListRefElem = std::conditional_t<
+    std::is_reference_v<T>,
+    typename std::reference_wrapper<std::remove_reference_t<T>>,
+    T>;
 
 template <typename T>
 using MaterializedIListRefElem = _MaterializedIListRefElem<IListRefConstRef<T>>;
@@ -540,7 +540,7 @@ class IListRef {
   template <
       typename... UnboxedConstructorArgs,
       typename = std::enable_if_t<
-          std::is_constructible<unboxed_type, UnboxedConstructorArgs...>::value>>
+          std::is_constructible_v<unboxed_type, UnboxedConstructorArgs...>>>
   IListRef(UnboxedConstructorArgs&&... args) : tag_(IListRefTag::Unboxed) {
     payload_.unboxed = unboxed_type(std::forward<UnboxedConstructorArgs>(args)...);
   }

--- a/aten/src/ATen/core/IListRef_inl.h
+++ b/aten/src/ATen/core/IListRef_inl.h
@@ -8,8 +8,8 @@ class Tensor;
 class OptionalTensorRef;
 }
 
-namespace c10 {
-namespace detail {
+
+namespace c10::detail {
 
 /*
  * Specializations of `IListRefTagImplBase` that implement the default
@@ -184,8 +184,8 @@ class IListRefTagImpl<IListRefTag::Materialized, at::OptionalTensorRef>
           at::OptionalTensorRef,
           MaterializedIListRefElem<at::OptionalTensorRef>> {};
 
-} // namespace detail
-} // namespace c10
+} // namespace c10::detail
+
 
 namespace at {
 

--- a/aten/src/ATen/core/NamedTensor.h
+++ b/aten/src/ATen/core/NamedTensor.h
@@ -79,7 +79,7 @@ struct TORCH_API NamesMode {
 // A RAII, thread local (!) guard that enables or disables names upon
 // construction, and sets it back to the original value upon destruction.
 struct TORCH_API NoNamesGuard {
-  NoNamesGuard() : prev_mode(NamesMode::is_enabled()), initialized(true) {
+  NoNamesGuard() : prev_mode(NamesMode::is_enabled()) {
     NamesMode::set_enabled(false);
   }
   ~NoNamesGuard() {
@@ -93,7 +93,7 @@ struct TORCH_API NoNamesGuard {
   }
  private:
   bool prev_mode;
-  bool initialized;
+  bool initialized{true};
 };
 
 void check_names_valid_for(const TensorBase& tensor, DimnameList names);

--- a/aten/src/ATen/core/TensorAccessor.h
+++ b/aten/src/ATen/core/TensorAccessor.h
@@ -7,6 +7,7 @@
 #include <c10/util/irange.h>
 #include <cstddef>
 #include <cstdint>
+#include <type_traits>
 
 namespace at {
 
@@ -131,7 +132,7 @@ public:
   }
 
   // if index_t is not int64_t, we want to have an int64_t constructor
-  template <typename source_index_t, class = typename std::enable_if<std::is_same<source_index_t, int64_t>::value>::type>
+  template <typename source_index_t, class = std::enable_if_t<std::is_same_v<source_index_t, int64_t>>>
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   C10_HOST GenericPackedTensorAccessorBase(
       PtrType data_,
@@ -184,7 +185,7 @@ public:
       : GenericPackedTensorAccessorBase<T, N, PtrTraits, index_t>(data_, sizes_, strides_) {}
 
   // if index_t is not int64_t, we want to have an int64_t constructor
-  template <typename source_index_t, class = typename std::enable_if<std::is_same<source_index_t, int64_t>::value>::type>
+  template <typename source_index_t, class = std::enable_if_t<std::is_same_v<source_index_t, int64_t>>>
   C10_HOST GenericPackedTensorAccessor(
       PtrType data_,
       const source_index_t* sizes_,
@@ -231,7 +232,7 @@ public:
       : GenericPackedTensorAccessorBase<T, 1, PtrTraits, index_t>(data_, sizes_, strides_) {}
 
   // if index_t is not int64_t, we want to have an int64_t constructor
-  template <typename source_index_t, class = typename std::enable_if<std::is_same<source_index_t, int64_t>::value>::type>
+  template <typename source_index_t, class = std::enable_if_t<std::is_same_v<source_index_t, int64_t>>>
   C10_HOST GenericPackedTensorAccessor(
       PtrType data_,
       const source_index_t* sizes_,

--- a/aten/src/ATen/core/TorchDispatchUtils.h
+++ b/aten/src/ATen/core/TorchDispatchUtils.h
@@ -6,12 +6,11 @@
 #include <c10/util/Optional.h>
 #include <c10/core/impl/TorchDispatchModeTLS.h>
 
-namespace at {
-namespace impl {
+namespace at::impl {
 
 TORCH_API bool tensor_has_dispatch(const at::Tensor& t);
 TORCH_API bool tensorlist_has_dispatch(at::ITensorListRef li);
 TORCH_API bool tensorlist_has_dispatch(const c10::List<c10::optional<at::Tensor>>& li);
 using c10::impl::dispatch_mode_enabled;
 
-}}
+}

--- a/aten/src/ATen/core/blob.h
+++ b/aten/src/ATen/core/blob.h
@@ -26,7 +26,7 @@ class TORCH_API Blob final : public c10::intrusive_ptr_target {
   /**
    * Initializes an empty Blob.
    */
-  Blob() noexcept : meta_(), pointer_(nullptr), has_ownership_(false) {}
+  Blob() noexcept : meta_() {}
   ~Blob() override {
     Reset();
   }
@@ -148,11 +148,11 @@ class TORCH_API Blob final : public c10::intrusive_ptr_target {
    * call is made or the blob is destructed.
    */
   template <class T>
-  typename std::remove_const<T>::type* ShareExternal(
-      typename std::remove_const<T>::type* allocated) {
+  std::remove_const_t<T>* ShareExternal(
+      std::remove_const_t<T>* allocated) {
     return static_cast<T*>(ShareExternal(
         static_cast<void*>(allocated),
-        TypeMeta::Make<typename std::remove_const<T>::type>()));
+        TypeMeta::Make<std::remove_const_t<T>>()));
   }
 
   void* ShareExternal(void* allocated, const TypeMeta meta) {
@@ -176,7 +176,7 @@ class TORCH_API Blob final : public c10::intrusive_ptr_target {
   /**
    * @brief Swaps the underlying storage of two blobs.
    */
-  void swap(Blob& rhs) {
+  void swap(Blob& rhs)  noexcept {
     using std::swap;
     swap(meta_, rhs.meta_);
     swap(pointer_, rhs.pointer_);
@@ -191,13 +191,13 @@ class TORCH_API Blob final : public c10::intrusive_ptr_target {
   }
 
   TypeMeta meta_;
-  void* pointer_;
-  bool has_ownership_;
+  void* pointer_{nullptr};
+  bool has_ownership_{false};
 
   C10_DISABLE_COPY_AND_ASSIGN(Blob);
 };
 
-inline void swap(Blob& lhs, Blob& rhs) {
+inline void swap(Blob& lhs, Blob& rhs)  noexcept {
   lhs.swap(rhs);
 }
 

--- a/aten/src/ATen/core/builtin_function.h
+++ b/aten/src/ATen/core/builtin_function.h
@@ -7,8 +7,7 @@
 #include <functional>
 #include <utility>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 struct BuiltinOpFunction : public Function {
   BuiltinOpFunction(
@@ -62,12 +61,16 @@ struct BuiltinOpFunction : public Function {
     return *this;
   }
 
-  bool call(Stack& stack, c10::optional<size_t>, c10::function_ref<void(const Code&)>) override {
+  bool call(
+      Stack& stack,
+      c10::optional<size_t>,
+      c10::function_ref<void(const Code&)>) override {
     run(stack);
     return false;
   }
 
-  bool call(Stack& stack, c10::function_ref<void(const mobile::Code&)>) override {
+  bool call(Stack& stack, c10::function_ref<void(const mobile::Code&)>)
+      override {
     run(stack);
     return false;
   }
@@ -84,5 +87,4 @@ struct BuiltinOpFunction : public Function {
   std::string doc_string_;
 };
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/aten/src/ATen/core/class_type.h
+++ b/aten/src/ATen/core/class_type.h
@@ -6,12 +6,12 @@
 #include <ATen/core/jit_type_base.h>
 #include <c10/util/Optional.h>
 
-namespace torch {
-namespace jit {
+
+namespace torch::jit {
 struct CompilationUnit;
 struct Function;
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit
+
 
 namespace c10 {
 

--- a/aten/src/ATen/core/function.h
+++ b/aten/src/ATen/core/function.h
@@ -14,8 +14,7 @@ namespace at {
 TORCH_API void launch(std::function<void()> func);
 }
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 struct Graph;
 struct Code;
@@ -29,7 +28,9 @@ using Kwargs = std::unordered_map<std::string, at::IValue>;
 struct RecursiveMethodCallError : public std::exception {};
 using TaskLauncher = std::function<void(std::function<void()>)>;
 
-TORCH_API void preoptimizeGraph(std::shared_ptr<Graph>& graph, bool disable_autocast=false);
+TORCH_API void preoptimizeGraph(
+    std::shared_ptr<Graph>& graph,
+    bool disable_autocast = false);
 
 // A Function is a pure Graph with no implicit `self` object bound.
 // It contains schema information and the executor that manages the
@@ -59,9 +60,7 @@ struct TORCH_API Function {
     return {};
   }
 
-  at::IValue operator()(
-    Stack stack,
-    const Kwargs& kwargs = Kwargs()) {
+  at::IValue operator()(Stack stack, const Kwargs& kwargs = Kwargs()) {
     getSchema().checkAndNormalizeInputs(stack, kwargs);
     run(stack);
     return stack.front();
@@ -93,8 +92,12 @@ struct TORCH_API Function {
   // If call() returns true, then callback completes successfully, otherwise
   // call() returns false.
 
-  // Overload for server interpreter, a bailout size is needed for graph executor.
-  virtual bool call(Stack&, c10::optional<size_t>, c10::function_ref<void(const Code&)>) {
+  // Overload for server interpreter, a bailout size is needed for graph
+  // executor.
+  virtual bool call(
+      Stack&,
+      c10::optional<size_t>,
+      c10::function_ref<void(const Code&)>) {
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(false);
     return false;
   }
@@ -107,5 +110,4 @@ struct TORCH_API Function {
 
   virtual ~Function() = default;
 };
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -492,7 +492,7 @@ struct TORCH_API IValue final {
   template <
       typename T,
       std::enable_if_t<
-          std::is_base_of<torch::CustomClassHolder, T>::value,
+          std::is_base_of_v<torch::CustomClassHolder, T>,
           int> = 0>
   IValue(intrusive_ptr<T> custom_class);
   bool isCustomClass() const;
@@ -507,17 +507,17 @@ struct TORCH_API IValue final {
   template <
       typename... Args,
       std::enable_if_t<
-          !std::disjunction<
+          !std::disjunction_v<
               std::is_lvalue_reference<Args>...,
-              std::negation<std::is_constructible<IValue, Args>>...>::value,
+              std::negation<std::is_constructible<IValue, Args>>...>,
           std::nullptr_t> = nullptr>
   IValue(const std::tuple<Args...>& t);
   template <
       typename... Args,
       std::enable_if_t<
-          !std::disjunction<
+          !std::disjunction_v<
               std::is_lvalue_reference<Args>...,
-              std::negation<std::is_constructible<IValue, Args>>...>::value,
+              std::negation<std::is_constructible<IValue, Args>>...>,
           std::nullptr_t> = nullptr>
   IValue(std::tuple<Args...>&& t);
   bool isTuple() const {
@@ -731,7 +731,7 @@ struct TORCH_API IValue final {
   // This SFINAEs the called constructor exists.
   template <class T>
   using enable_if_ivalue_constructible =
-      std::enable_if_t<std::is_constructible<IValue, T>::value, std::nullptr_t>;
+      std::enable_if_t<std::is_constructible_v<IValue, T>, std::nullptr_t>;
 
   // The rule for lists is more complicated; the generic constructor is only
   // acceptable if your element isn't SymInt.  If you do have a SymInt element,
@@ -743,8 +743,8 @@ struct TORCH_API IValue final {
   // they're not selectable.
   template <class T>
   using enable_if_list_is_ivalue_constructible = std::enable_if_t<
-      std::is_constructible<IValue, T>::value &&
-          !std::is_same<T, c10::SymInt>::value,
+      std::is_constructible_v<IValue, T> &&
+          !std::is_same_v<T, c10::SymInt>,
       std::nullptr_t>;
 
   template <class T, enable_if_list_is_ivalue_constructible<T> = nullptr>
@@ -765,7 +765,7 @@ struct TORCH_API IValue final {
   // to prevent implicit conversions
   template <class T>
   using enable_if_symint =
-      std::enable_if_t<std::is_same<T, c10::SymInt>::value, std::nullptr_t>;
+      std::enable_if_t<std::is_same_v<T, c10::SymInt>, std::nullptr_t>;
 
   template <class T, enable_if_symint<T> = nullptr>
   IValue(at::ArrayRef<T> v);
@@ -779,10 +779,9 @@ struct TORCH_API IValue final {
 
   template <class T>
   using enable_if_ilist_is_ivalue_constructible = std::enable_if_t<
-      std::is_constructible<IValue, T>::value &&
-          std::is_constructible<IValue, typename IListRef<T>::boxed_type>::
-              value &&
-          !std::is_same<T, c10::SymInt>::value,
+      std::is_constructible_v<IValue, T> &&
+          std::is_constructible_v<IValue, typename IListRef<T>::boxed_type> &&
+          !std::is_same_v<T, c10::SymInt>,
       std::nullptr_t>;
 
   template <class T, enable_if_ilist_is_ivalue_constructible<T> = nullptr>
@@ -843,7 +842,7 @@ struct TORCH_API IValue final {
   c10::intrusive_ptr<ivalue::EnumHolder> toEnumHolder() const&;
 
   // None
-  IValue() : tag(Tag::None) {}
+  IValue()  {}
   bool isNone() const {
     return Tag::None == tag;
   }
@@ -936,21 +935,21 @@ struct TORCH_API IValue final {
 
   // ScalarType
   IValue(ScalarType t)
-      : IValue(static_cast<std::underlying_type<ScalarType>::type>(t)) {}
+      : IValue(static_cast<std::underlying_type_t<ScalarType>>(t)) {}
   at::ScalarType toScalarType() const {
     return static_cast<at::ScalarType>(toInt());
   }
 
   // Layout
   IValue(Layout l)
-      : IValue(static_cast<std::underlying_type<Layout>::type>(l)) {}
+      : IValue(static_cast<std::underlying_type_t<Layout>>(l)) {}
   at::Layout toLayout() const {
     return static_cast<at::Layout>(toInt());
   }
 
   // MemoryFormat
   IValue(MemoryFormat m)
-      : IValue(static_cast<std::underlying_type<MemoryFormat>::type>(m)) {}
+      : IValue(static_cast<std::underlying_type_t<MemoryFormat>>(m)) {}
   at::MemoryFormat toMemoryFormat() const {
     return static_cast<at::MemoryFormat>(toInt());
   }

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -20,11 +20,11 @@
 #include <type_traits>
 #include <utility>
 
-namespace torch {
-namespace jit {
+
+namespace torch::jit {
 struct Function;
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit
+
 
 namespace c10 {
 

--- a/aten/src/ATen/core/jit_type_base.h
+++ b/aten/src/ATen/core/jit_type_base.h
@@ -118,7 +118,7 @@ struct CastReturnType {
 };
 
 template <typename T>
-struct CastReturnType<T, typename std::enable_if<IsSingletonType<T>::value>::type> {
+struct CastReturnType<T, std::enable_if_t<IsSingletonType<T>::value>> {
   using type = SingletonTypePtr<T>;
 };
 
@@ -128,7 +128,7 @@ struct CastConstReturnType {
 };
 
 template <typename T>
-struct CastConstReturnType<T, typename std::enable_if<IsSingletonType<T>::value>::type> {
+struct CastConstReturnType<T, std::enable_if_t<IsSingletonType<T>::value>> {
   using type = SingletonTypePtr<const T>;
 };
 
@@ -177,7 +177,7 @@ struct TORCH_API Type {
     /* implicit */ SingletonOrSharedTypePtr(std::shared_ptr<T> x)
         : repr_(std::move(x)) {}
 
-    template <typename U, std::enable_if_t<std::is_convertible<U*, T*>::value, bool> = true>
+    template <typename U, std::enable_if_t<std::is_convertible_v<U*, T*>, bool> = true>
     /* implicit */ SingletonOrSharedTypePtr(std::shared_ptr<U> x)
         : repr_(std::move(x)) {}
 
@@ -187,7 +187,7 @@ struct TORCH_API Type {
     /* implicit */ SingletonOrSharedTypePtr(SingletonTypePtr<T> p)
         : repr_(p) {}
 
-    template <typename U, std::enable_if_t<std::is_convertible<U*, T*>::value, bool> = true>
+    template <typename U, std::enable_if_t<std::is_convertible_v<U*, T*>, bool> = true>
     /* implicit */ SingletonOrSharedTypePtr(SingletonTypePtr<U> p)
         : repr_(SingletonTypePtr<T>(p.get())) {}
 
@@ -205,10 +205,10 @@ struct TORCH_API Type {
     // Case 3: Otherwise, T is not a SharedType. (debug-check this
     // assumption!) Use a singleton pointer.
 
-    template <typename U = T, std::enable_if_t<std::is_base_of<SharedType, U>::value, bool> = true>
+    template <typename U = T, std::enable_if_t<std::is_base_of_v<SharedType, U>, bool> = true>
     /* implicit */ SingletonOrSharedTypePtr(T* p) : SingletonOrSharedTypePtr(static_cast<typename detail::as_shared_type<U>::type>(p)->shared_from_this()) {}
 
-    template <typename U = T, std::enable_if_t<std::is_same<Type, U>::value, bool> = true>
+    template <typename U = T, std::enable_if_t<std::is_same_v<Type, U>, bool> = true>
     /* implicit */ SingletonOrSharedTypePtr(T* p) {
       if (auto* shared_p = dynamic_cast<typename detail::as_shared_type<U>::type>(p)) {
         repr_ = Repr(shared_p->shared_from_this());
@@ -217,7 +217,7 @@ struct TORCH_API Type {
       }
     }
 
-    template <typename U = T, std::enable_if_t<!std::is_same<Type, U>::value && !std::is_base_of<SharedType, U>::value, bool> = true>
+    template <typename U = T, std::enable_if_t<!std::is_same_v<Type, U> && !std::is_base_of_v<SharedType, U>, bool> = true>
     /* implicit */ SingletonOrSharedTypePtr(T* p)
         : repr_(p) {
       TORCH_INTERNAL_ASSERT_DEBUG_ONLY(dynamic_cast<typename detail::as_shared_type<U>::type>(p) == nullptr);
@@ -244,7 +244,7 @@ struct TORCH_API Type {
       return repr_.isNonNull();
     }
 
-    template <typename U = T, std::enable_if_t<!std::is_same<std::remove_const_t<U>, void>::value, bool> = true>
+    template <typename U = T, std::enable_if_t<!std::is_same_v<std::remove_const_t<U>, void>, bool> = true>
     U& operator*() const {
       return *get();
     }
@@ -409,37 +409,37 @@ struct TORCH_API Type {
   // Compatibility shims to accommodate existing code that passes shared_ptrs
   // around. Ideally, we would just delete this, but it should be harmless.
   template <typename T>
-  typename std::enable_if<std::is_base_of<Type, T>::value, bool>::type
+  std::enable_if_t<std::is_base_of_v<Type, T>, bool>
   isSubtypeOf(const std::shared_ptr<T>& rhs) const {
     return isSubtypeOf(*rhs);
   }
 
   template <typename T>
-  typename std::enable_if<std::is_base_of<Type, T>::value, bool>::type
+  std::enable_if_t<std::is_base_of_v<Type, T>, bool>
   isSubtypeOf(const SingletonOrSharedTypePtr<T>& rhs) const {
     return isSubtypeOf(*rhs);
   }
 
   template <typename T>
-  typename std::enable_if<std::is_base_of<Type, T>::value, bool>::type
+  std::enable_if_t<std::is_base_of_v<Type, T>, bool>
   isSubtypeOf(SingletonTypePtr<T> rhs) const {
     return isSubtypeOf(*rhs);
   }
 
   template <typename T>
-  typename std::enable_if<std::is_base_of<Type, T>::value, bool>::type
+  std::enable_if_t<std::is_base_of_v<Type, T>, bool>
   isSubtypeOfExt(const SingletonOrSharedTypePtr<T>& rhs, std::ostream* why_not) const {
     return isSubtypeOfExt(*rhs, why_not);
   }
 
   template <typename T>
-  typename std::enable_if<std::is_base_of<Type, T>::value, bool>::type
+  std::enable_if_t<std::is_base_of_v<Type, T>, bool>
   isSubtypeOfExt(const std::shared_ptr<T>& rhs, std::ostream* why_not) const {
     return isSubtypeOfExt(*rhs, why_not);
   }
 
   template <typename T>
-  typename std::enable_if<std::is_base_of<Type, T>::value, bool>::type
+  std::enable_if_t<std::is_base_of_v<Type, T>, bool>
   isSubtypeOfExt(SingletonTypePtr<T> rhs, std::ostream* why_not) const {
     return isSubtypeOfExt(*rhs, why_not);
   }

--- a/aten/src/ATen/core/stack.h
+++ b/aten/src/ATen/core/stack.h
@@ -8,8 +8,8 @@
 
 // TODO move this to c10 namespace
 
-namespace torch {
-namespace jit {
+
+namespace torch::jit {
 
 using c10::IValue;
 using Stack = std::vector<IValue>;
@@ -28,7 +28,7 @@ class Operation {
 
   template <typename F,
             std::enable_if_t<accepts<F, Stack&>::value &&
-                !std::is_same<std::decay_t<F>, Operation>::value, int> = 0>
+                !std::is_same_v<std::decay_t<F>, Operation>, int> = 0>
   Operation(F&& op): op_(std::forward<F>(op)) {}
 
   Operation(std::nullptr_t) noexcept {}
@@ -196,5 +196,4 @@ inline void pack(Stack& stack, std::tuple<Args...>&& t) {
   TuplePacker<sizeof...(Args), Args...>::execute(stack, std::move(t));
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit


### PR DESCRIPTION
This PR fixes various clang-tidy warnings on aten/src/ATen/core/*.h