### PR TITLE
[Clang-tidy header][27/N] Fix clang-tidy warnings in aten/src/ATen/core/*.h

### DIFF
--- a/aten/src/ATen/core/Array.h
+++ b/aten/src/ATen/core/Array.h
@@ -6,7 +6,7 @@
 #include <c10/macros/Macros.h>
 #include <c10/util/irange.h>
 
-namespace at { namespace detail {
+namespace at::detail {
 
 template <typename T, int size_>
 struct Array {
@@ -27,7 +27,9 @@ struct Array {
   Array(const Array&) = default;
   Array& operator=(const Array&) = default;
 #endif
-  static constexpr int size(){return size_;}
+  static constexpr int size() {
+    return size_;
+  }
   // Fill the array with x.
   C10_HOST_DEVICE Array(T x) {
     for (int i = 0; i < size_; i++) {
@@ -36,4 +38,4 @@ struct Array {
   }
 };
 
-}}
+} // namespace at::detail

--- a/aten/src/ATen/core/Generator.h
+++ b/aten/src/ATen/core/Generator.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <cstdint>
+#include <deque>
 #include <mutex>
 #include <utility>
-#include <cstdint>
 
 #include <c10/util/Exception.h>
 #include <c10/util/intrusive_ptr.h>

--- a/aten/src/ATen/core/Generator.h
+++ b/aten/src/ATen/core/Generator.h
@@ -1,11 +1,7 @@
 #pragma once
 
 #include <mutex>
-#include <deque>
-#include <atomic>
-#include <typeinfo>
 #include <utility>
-#include <cstddef>
 #include <cstdint>
 
 #include <c10/util/Exception.h>

--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -68,8 +68,8 @@ template<class T, class Iterator>
 class ListElementReference final {
 public:
   operator std::conditional_t<
-      std::is_reference<typename c10::detail::
-                            ivalue_to_const_ref_overload_return<T>::type>::value,
+      std::is_reference_v<typename c10::detail::
+                            ivalue_to_const_ref_overload_return<T>::type>,
       const T&,
       T>() const;
 

--- a/aten/src/ATen/core/List_inl.h
+++ b/aten/src/ATen/core/List_inl.h
@@ -120,8 +120,8 @@ namespace impl {
 
 template <class T, class Iterator>
 ListElementReference<T, Iterator>::operator std::conditional_t<
-    std::is_reference<typename c10::detail::ivalue_to_const_ref_overload_return<
-        T>::type>::value,
+    std::is_reference_v<typename c10::detail::ivalue_to_const_ref_overload_return<
+        T>::type>,
     const T&,
     T>() const {
   return iterator_->template to<T>();

--- a/aten/src/ATen/core/PythonFallbackKernel.h
+++ b/aten/src/ATen/core/PythonFallbackKernel.h
@@ -1,8 +1,8 @@
 #pragma once
 #include <ATen/core/TorchDispatchUtils.h>
 
-namespace at {
-namespace impl {
+
+namespace at::impl {
 
 struct TORCH_API RestorePythonTLSSnapshot {
   RestorePythonTLSSnapshot();
@@ -24,5 +24,4 @@ private:
   bool value_set_;
 };
 
-} // namespace impl
-} // namespace at
+} // namespace at::impl

--- a/aten/src/ATen/core/PythonOpRegistrationTrampoline.h
+++ b/aten/src/ATen/core/PythonOpRegistrationTrampoline.h
@@ -4,8 +4,8 @@
 
 // TODO: this can probably live in c10
 
-namespace at {
-namespace impl {
+
+namespace at::impl {
 
 class TORCH_API PythonOpRegistrationTrampoline final {
   static std::atomic<c10::impl::PyInterpreter*> interpreter_;
@@ -19,5 +19,4 @@ public:
   static c10::impl::PyInterpreter* getInterpreter();
 };
 
-} // namespace impl
-} // namespace at
+} // namespace at::impl

--- a/aten/src/ATen/core/QuantizerBase.h
+++ b/aten/src/ATen/core/QuantizerBase.h
@@ -37,6 +37,7 @@ using QuantizerPtr = c10::intrusive_ptr<Quantizer>;
  * share the same Quantizer. Quantizer should be immutable.
  */
 struct TORCH_API Quantizer : public c10::intrusive_ptr_target {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const ScalarType scalar_type_;
   explicit Quantizer(ScalarType scalar_type) : scalar_type_(scalar_type) {}
   ~Quantizer() override;

--- a/aten/src/ATen/core/Reduction.h
+++ b/aten/src/ATen/core/Reduction.h
@@ -1,16 +1,14 @@
 #pragma once
 
-namespace at {
-namespace Reduction {
+namespace at::Reduction {
 
 // NB: Keep this in sync with Reduction class in torch/nn/_reduction.py
 // These constants control the reduction behavior of loss functions.
 // Ideally, this would be a scoped enum, but jit doesn't support that
 enum Reduction {
-  None,             // Do not reduce
-  Mean,             // (Possibly weighted) mean of losses
-  Sum,              // Sum losses
+  None, // Do not reduce
+  Mean, // (Possibly weighted) mean of losses
+  Sum, // Sum losses
   END
 };
-} // namespace Reduction
-} // namespace at
+} // namespace at::Reduction

--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -28,11 +28,11 @@ namespace c10 {
 class Scalar;
 }
 
-namespace torch { namespace autograd {
+namespace torch::autograd {
 
 struct Node;
 
-}} // namespace torch::autograd
+} // namespace torch::autograd
 
 namespace at {
 
@@ -594,10 +594,10 @@ class TORCH_API TensorBase {
     return mutable_data_ptr();
   }
 
-  template <typename T, std::enable_if_t<!std::is_const<T>::value, int> = 0>
+  template <typename T, std::enable_if_t<!std::is_const_v<T>, int> = 0>
   const T* const_data_ptr() const;
 
-  template <typename T, std::enable_if_t<std::is_const<T>::value, int> = 0>
+  template <typename T, std::enable_if_t<std::is_const_v<T>, int> = 0>
   const std::remove_const_t<T>* const_data_ptr() const;
 
   template <typename T>
@@ -831,9 +831,9 @@ class TORCH_API TensorBase {
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   template <typename T>
-  using hook_return_void_t = std::enable_if_t<std::is_void<typename c10::invoke_result_t<T&, TensorBase>>::value, unsigned>;
+  using hook_return_void_t = std::enable_if_t<std::is_void_v<typename c10::invoke_result_t<T&, TensorBase>>, unsigned>;
   template <typename T>
-  using hook_return_var_t = std::enable_if_t<std::is_same<typename c10::invoke_result_t<T&, TensorBase>, TensorBase>::value, unsigned>;
+  using hook_return_var_t = std::enable_if_t<std::is_same_v<typename c10::invoke_result_t<T&, TensorBase>, TensorBase>, unsigned>;
 
   /// Registers a backward hook.
   ///
@@ -1026,9 +1026,9 @@ inline c10::MaybeOwned<TensorBase> TensorBase::expect_contiguous(MemoryFormat me
 namespace symint {
 
 template <typename T>
-using enable_if_symint = std::enable_if_t<std::is_same<T, c10::SymInt>::value>;
+using enable_if_symint = std::enable_if_t<std::is_same_v<T, c10::SymInt>>;
 template <typename T>
-using enable_if_int = std::enable_if_t<std::is_same<T, int64_t>::value>;
+using enable_if_int = std::enable_if_t<std::is_same_v<T, int64_t>>;
 
 template <typename T, typename = enable_if_symint<T>>
 c10::SymIntArrayRef sizes(const TensorBase& t) { return t.sym_sizes(); }

--- a/aten/src/ATen/core/VariableHooksInterface.h
+++ b/aten/src/ATen/core/VariableHooksInterface.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <c10/macros/Export.h>
 #include <ATen/core/Tensor.h>
+#include <c10/macros/Export.h>
 
 // A little explanation about why this file exists at all.  We have
 // a few methods on Tensor class which require access to reified access to
@@ -29,20 +29,20 @@
 // have weird signatures that are not supported by autograd, and (2)
 // see this bug https://github.com/pytorch/pytorch/issues/30102
 
-namespace torch { namespace autograd {
+namespace torch::autograd {
 
 struct Node;
 
-}} // namespace torch::autograd
+} // namespace torch::autograd
 
-namespace at {
-namespace impl {
+namespace at::impl {
 
 struct TORCH_API VariableHooksInterface {
   virtual ~VariableHooksInterface() = default;
   virtual TensorBase tensor_data(const TensorBase&) const = 0;
   virtual TensorBase variable_data(const TensorBase&) const = 0;
-  virtual const std::shared_ptr<torch::autograd::Node>& grad_fn(const TensorBase&) const = 0;
+  virtual const std::shared_ptr<torch::autograd::Node>& grad_fn(
+      const TensorBase&) const = 0;
   virtual unsigned _register_hook(
       const TensorBase&,
       std::function<TensorBase(const TensorBase&)> hook) const = 0;
@@ -57,9 +57,17 @@ struct TORCH_API VariableHooksInterface {
   virtual int64_t _version(const TensorBase&) const = 0;
   virtual void retain_grad(const TensorBase&) const = 0;
   virtual bool retains_grad(const TensorBase&) const = 0;
-  virtual void _backward(const Tensor&, TensorList, const c10::optional<Tensor>&, c10::optional<bool>, bool) const = 0;
+  virtual void _backward(
+      const Tensor&,
+      TensorList,
+      const c10::optional<Tensor>&,
+      c10::optional<bool>,
+      bool) const = 0;
   virtual void requires_grad_(const TensorBase&, bool) const = 0;
-  virtual void basic_autograd_not_implemented_fallback(const c10::OperatorHandle& op, c10::DispatchKeySet dispatch_keys, torch::jit::Stack* stack) const = 0;
+  virtual void basic_autograd_not_implemented_fallback(
+      const c10::OperatorHandle& op,
+      c10::DispatchKeySet dispatch_keys,
+      torch::jit::Stack* stack) const = 0;
 };
 
 TORCH_API void SetVariableHooks(VariableHooksInterface* hooks);
@@ -72,4 +80,4 @@ struct TORCH_API VariableHooksRegisterer {
   }
 };
 
-}} // namespace at::impl
+} // namespace at::impl

--- a/aten/src/ATen/core/Vitals.h
+++ b/aten/src/ATen/core/Vitals.h
@@ -8,8 +8,7 @@
 
 #include <c10/core/impl/LocalDispatchKeySet.h>
 
-namespace at {
-namespace vitals {
+namespace at::vitals {
 
 TORCH_API bool torchVitalEnabled();
 
@@ -82,8 +81,7 @@ class TORCH_API APIVitals {
 
 extern TORCH_API APIVitals VitalsAPI;
 
-} // namespace vitals
-} // namespace at
+} // namespace at::vitals
 
 #define TORCH_VITAL_DECLARE(name) \
   TORCH_API at::vitals::TorchVital TorchVital_##name;

--- a/aten/src/ATen/core/blob.h
+++ b/aten/src/ATen/core/blob.h
@@ -1,10 +1,6 @@
 #pragma once
 
-#include <cstddef>
-#include <sstream>
 #include <type_traits>
-#include <typeinfo>
-#include <vector>
 
 #include <c10/util/intrusive_ptr.h>
 #include <c10/util/typeid.h>

--- a/aten/src/ATen/core/dynamic_type.h
+++ b/aten/src/ATen/core/dynamic_type.h
@@ -187,7 +187,7 @@ class DynamicType : public SharedType {
   bool equals(const DynamicType& other) const;
 
   template <typename F>
-  bool compareArguments(const DynamicType& other, F&& f) const {
+  bool compareArguments(const DynamicType& other, const F& f) const {
     if (arguments_.elems.size() != other.arguments_.elems.size()) {
       return false;
     }

--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -143,10 +143,10 @@ struct Argument {
         inferred_type_hint);
   }
 
-  Argument cloneWithType(TypePtr new_type) const {
+  Argument cloneWithType(const TypePtr& new_type) const {
     return Argument(
         name_,
-        std::move(new_type),
+        new_type,
         N_,
         default_value_,
         kwarg_only_,

--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -1,9 +1,4 @@
 #pragma once
-#include <vector>
-#include <cstdint>
-#include <string>
-#include <unordered_map>
-#include <algorithm>
 
 #include <c10/macros/Macros.h>
 

--- a/aten/src/ATen/core/interned_strings_class.h
+++ b/aten/src/ATen/core/interned_strings_class.h
@@ -1,5 +1,3 @@
-#include <cstdint>
-#include <cstring>
 #include <mutex>
 #include <string>
 #include <unordered_map>

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -13,7 +13,6 @@
 #include <c10/util/MaybeOwned.h>
 #include <c10/util/intrusive_ptr.h>
 #include <type_traits>
-#include <typeindex>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -491,9 +490,7 @@ struct TORCH_API IValue final {
   // Custom C++ classes
   template <
       typename T,
-      std::enable_if_t<
-          std::is_base_of_v<torch::CustomClassHolder, T>,
-          int> = 0>
+      std::enable_if_t<std::is_base_of_v<torch::CustomClassHolder, T>, int> = 0>
   IValue(intrusive_ptr<T> custom_class);
   bool isCustomClass() const;
   template <typename T>
@@ -743,8 +740,7 @@ struct TORCH_API IValue final {
   // they're not selectable.
   template <class T>
   using enable_if_list_is_ivalue_constructible = std::enable_if_t<
-      std::is_constructible_v<IValue, T> &&
-          !std::is_same_v<T, c10::SymInt>,
+      std::is_constructible_v<IValue, T> && !std::is_same_v<T, c10::SymInt>,
       std::nullptr_t>;
 
   template <class T, enable_if_list_is_ivalue_constructible<T> = nullptr>
@@ -775,7 +771,6 @@ struct TORCH_API IValue final {
   IValue(const std::vector<T>& v);
   template <class T, enable_if_symint<T> = nullptr>
   IValue(std::vector<T>&& v);
-
 
   template <class T>
   using enable_if_ilist_is_ivalue_constructible = std::enable_if_t<
@@ -842,7 +837,7 @@ struct TORCH_API IValue final {
   c10::intrusive_ptr<ivalue::EnumHolder> toEnumHolder() const&;
 
   // None
-  IValue()  {}
+  IValue() = default;
   bool isNone() const {
     return Tag::None == tag;
   }
@@ -941,8 +936,7 @@ struct TORCH_API IValue final {
   }
 
   // Layout
-  IValue(Layout l)
-      : IValue(static_cast<std::underlying_type_t<Layout>>(l)) {}
+  IValue(Layout l) : IValue(static_cast<std::underlying_type_t<Layout>>(l)) {}
   at::Layout toLayout() const {
     return static_cast<at::Layout>(toInt());
   }

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -17,7 +17,6 @@
 #include <memory>
 #include <ostream>
 #include <sstream>
-#include <type_traits>
 #include <utility>
 
 

--- a/aten/src/ATen/core/type_ptr.h
+++ b/aten/src/ATen/core/type_ptr.h
@@ -20,7 +20,7 @@ class SingletonTypePtr {
 
   using element_type = typename std::shared_ptr<T>::element_type;
 
-  template <typename U = T, std::enable_if_t<!std::is_same<std::remove_const_t<U>, void>::value, bool> = true>
+  template <typename U = T, std::enable_if_t<!std::is_same_v<std::remove_const_t<U>, void>, bool> = true>
   T& operator*() const {
     return *repr_;
   }

--- a/aten/src/ATen/cuda/CUDAGeneratorImpl.cpp
+++ b/aten/src/ATen/cuda/CUDAGeneratorImpl.cpp
@@ -4,7 +4,7 @@
 #include <c10/core/StreamGuard.h>
 #include <c10/cuda/CUDAFunctions.h>
 #include <c10/util/CallOnce.h>
-#include <ATen/Utils.h>
+#include <deque>
 
 namespace at {
 namespace cuda::detail {

--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -30,6 +30,7 @@
 #endif
 
 #include <cctype>
+#include <deque>
 #include <string>
 #include <utility>
 #include <vector>

--- a/torch/csrc/jit/passes/concat_opt.cpp
+++ b/torch/csrc/jit/passes/concat_opt.cpp
@@ -1,6 +1,8 @@
 #include <torch/csrc/jit/passes/concat_opt.h>
 
 #include <algorithm>
+#include <deque>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 


### PR DESCRIPTION
This PR fixes various clang-tidy warnings on aten/src/ATen/core/*.h, following #122015