### PR TITLE
[Inductor][CPU] fix flash attention last_stride!=1 issue

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -3591,6 +3591,30 @@ class CPUReproTests(TestCase):
                 (v,),
             )
 
+    def test_fused_attention_conv(self):
+        # https://github.com/pytorch/pytorch/issues/121174.
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.q_conv = torch.nn.Conv2d(4, 4, 1)
+                self.k_conv = torch.nn.Conv2d(4, 4, 1)
+                self.v_conv = torch.nn.Conv2d(4, 4, 1)
+
+            def forward(self, x):
+                q = self.q_conv(x)
+                k = self.k_conv(x)
+                v = self.v_conv(x)
+                q = q.permute(0, 2, 1, 3)
+                k = k.permute(0, 2, 1, 3)
+                v = v.permute(0, 2, 1, 3)
+                return torch.nn.functional.scaled_dot_product_attention(
+                    q, k, v, dropout_p=0.0, is_causal=False
+                )
+
+        fn = Model()
+        x = torch.randn(1, 4, 2, 2)
+        self.common(fn, (x,))
+
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2205,13 +2205,14 @@ def sdpa_constraint(fx_node, *args, **kwargs):
             return arg
 
         meta_val = fx_arg.meta["val"]
-        if not meta_val.is_cuda:
-            return arg
 
         stride_order = ir.get_stride_order(meta_val.stride())
         if stride_order and stride_order[-1] != 0:
             # contiguous stride order
             stride_order = list(reversed(range(len(arg.get_size()))))
+
+        if not meta_val.is_cuda:
+            return ir.ExternKernel.require_stride_order(arg, stride_order)
 
         # This is the minimum alignment required by SDPA kernels for attention_bias.
         # This value can be found in pytorch/aten/src/ATen/native/transformers/attention.cpp preprocess_mask


### PR DESCRIPTION
Fixes #121174.

Conv converts the input of sdpa to channel last, resulting in accuracy issue. Ensure the layout in lowering.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang