### PR TITLE
Avoid always building stack trace strings in c10::Error

### DIFF
--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -2321,8 +2321,7 @@ IValue::IValue(c10::intrusive_ptr<T> custom_class) : tag(Tag::Object) {
     } catch (const c10::Error&) {
       throw c10::Error(
           "Trying to instantiate a class that isn't a registered custom class: " +
-          std::string(c10::util::get_fully_qualified_type_name<T>()),
-          "");
+          std::string(c10::util::get_fully_qualified_type_name<T>()));
     }
   }();
   auto ivalue_obj = c10::ivalue::Object::create(std::move(classType), /* numSlots */1);

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -68,7 +68,7 @@ class C10_API Error : public std::exception {
       const void* caller = nullptr);
 
   // Base constructor
-  Error(std::string msg, std::string backtrace, const void* caller = nullptr);
+  Error(std::string msg, std::string backtrace = "", const void* caller = nullptr);
 
   // Add some new context to the message stack.  The last added context
   // will be formatted at the end of the context list upon printing.

--- a/c10/util/Logging.h
+++ b/c10/util/Logging.h
@@ -126,7 +126,15 @@ constexpr bool IsUsingGoogleLogging() {
  */
 C10_API void ShowLogInfoToStderr();
 
-C10_API void SetStackTraceFetcher(std::function<string(void)> fetcher);
+// Overwrites the return value of GetFetchStackTrace() with the supplied parameter.
+C10_API void SetStackTraceFetcher(std::function<c10::Error::BacktraceGenerator()> fetcher);
+
+// Overwrites the return value of GetFetchStackTrace() with a std::function that always
+// returns the supplied parameter.
+C10_API void SetStackTraceFetcher(c10::Error::BacktraceGenerator fetcher);
+
+// Convenience method as per the overload above - will wrap the function in a shared_ptr.
+C10_API void SetStackTraceFetcher(std::function<std::string()> fetcher);
 
 using EnforceNotMet = ::c10::Error;
 

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -75,6 +75,8 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/format.h>
+
 namespace torch::jit {
 
 using ::c10::Argument;
@@ -972,10 +974,8 @@ void initJitScriptBindings(PyObject* module) {
           [mm_name](const Object& self, py::args args, py::kwargs kwargs) {
             auto method = self.find_method(mm_name);
             if (!method) {
-              throw c10::NotImplementedError(
-                  "'%s' is not implemented for %s",
-                  mm_name,
-                  self.type()->str().c_str());
+              std::string msg = fmt::format("'{}' is not implemented for {}", mm_name, self.type()->str());
+              throw c10::NotImplementedError(msg);
             }
             return invokeScriptMethodFromPython(
                 *method,

--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -929,7 +929,7 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
     } else if (not_implemented_error) {
       throw c10::NotImplementedError(
           ss.str(),
-          not_implemented_error->backtrace(),
+          not_implemented_error->backtraceCallback(),
           not_implemented_error->caller());
     } else {
       if (get_cpp_stacktraces_enabled()) {

--- a/torch/csrc/jit/runtime/register_ops_utils.cpp
+++ b/torch/csrc/jit/runtime/register_ops_utils.cpp
@@ -133,7 +133,7 @@ void checkDoubleInRange(double a) {
       a > double(std::numeric_limits<int64_t>::max()) ||
       a < double(std::numeric_limits<int64_t>::min())) {
     throw c10::Error(
-        "Cannot convert float " + c10::to_string(a) + " to integer", "");
+        "Cannot convert float " + c10::to_string(a) + " to integer");
     return;
   }
 }


### PR DESCRIPTION
Summary:
The `c10::Error` class shows a lot of overhead building stack straces. Additionally, cost aside, this has caused capacity SEVs in the past since when something goes wrong: the exceptions thrown cause additional (and bigger) perf issues since they start putting together all the stack traces.

This is not needed the vast majority of time: an exception would be caught, there would be no logging (i.e., no call to `what()`) and the stack contents would be thrown away.

There are 3 issues here:
1) we have an abnormal number of exceptions thrown; the throw sites are suspicious, e.g., "submodule not found", or "model size mismatch"
2) symbolication is not as efficient as possible
3) we shouldn't care about the stack trace until we do

This diff tackles 3), although all the causes above should be looked at as they compound on each other. Intuitively, 3) should greatly alleviate the costs here.

The solution is borrowed from `FBException`: save the stack information, but the stringify-ing should be lazy:
* changed the `backtrace` expected by `c10::Error::Error` to a function that returns a backtrace instead
* the backtrace generator is invoked the first time `what()` (or, explicitly, `backtrace()`) is called; the result is afterward cached
* the macros constructing these exceptions generated the stacktrace with a cross-platform solution set; now, they build a function that returns a stacktrace. This requires snapshotting a `facebook::process::StackTrace`, and baking into the returned function. When called, this will actually invoke the `toString()` operation. Note that this is only available for the `FBCODE_CAFFE2` flavour - for the other platforms, we still compute the string right away.
* special care is needed for the hack of hijacking this stack trace generation and replacing it on-demand; namely, the introduced API needs to be compatible (and improve) the acrobatics in `SetStackTraceFetcher()` and `registerStacktraceFetcher()`.

Other things worth mentioning:
* for some reason `std::function` is 16-byte aligned, and the iOS flavour requires the exception class to be 8-byte aligned. There's a couple of solutions here, but I went for just wrapping the function in a `shared_ptr`.
* we can't use folly but for thread safety I went for `std::call_once`
* the added copy constructor / assignment operator are needed because the `std::once_flag` can't be copied and requires special handling
* although this class declares that it shouldn't be instantiated manually, there are some places that do so; they used a `""` backtrace, now changed to not supplying a backtrace generator at all in which case it defaults to a function returning an empty string backtrace.

Test Plan:
Added a bunch of relevant tests.

In particular, added tests to ensure the correct stack trace capture and proving that the stack trace is lazily generated.

Differential Revision: D54494101
