### PR TITLE
[ATen-Vulkan][EZ] Small fixes: fix gpu size calculation and Half scalartype ctype mapping

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Types.h
+++ b/aten/src/ATen/native/vulkan/api/Types.h
@@ -17,15 +17,15 @@
 #define VK_FORMAT_FLOAT4 VK_FORMAT_R32G32B32A32_SFLOAT
 #endif /* USE_VULKAN_FP16_INFERENCE */
 
-#define VK_FORALL_SCALAR_TYPES(_)                        \
-  _(uint8_t, VK_FORMAT_R8G8B8A8_UINT, Byte)              \
-  _(int8_t, VK_FORMAT_R8G8B8A8_SINT, Char)               \
-  _(int32_t, VK_FORMAT_R32G32B32A32_SINT, Int)           \
-  _(bool, VK_FORMAT_R8G8B8A8_SINT, Bool)                 \
-  _(unsigned short, VK_FORMAT_R16G16B16A16_SFLOAT, Half) \
-  _(float, VK_FORMAT_FLOAT4, Float)                      \
-  _(int8_t, VK_FORMAT_R8G8B8A8_SINT, QInt8)              \
-  _(uint8_t, VK_FORMAT_R8G8B8A8_UINT, QUInt8)            \
+#define VK_FORALL_SCALAR_TYPES(_)               \
+  _(uint8_t, VK_FORMAT_R8G8B8A8_UINT, Byte)     \
+  _(int8_t, VK_FORMAT_R8G8B8A8_SINT, Char)      \
+  _(int32_t, VK_FORMAT_R32G32B32A32_SINT, Int)  \
+  _(bool, VK_FORMAT_R8G8B8A8_SINT, Bool)        \
+  _(float, VK_FORMAT_R16G16B16A16_SFLOAT, Half) \
+  _(float, VK_FORMAT_FLOAT4, Float)             \
+  _(int8_t, VK_FORMAT_R8G8B8A8_SINT, QInt8)     \
+  _(uint8_t, VK_FORMAT_R8G8B8A8_UINT, QUInt8)   \
   _(int32_t, VK_FORMAT_R32G32B32A32_SINT, QInt32)
 
 namespace at {


### PR DESCRIPTION
Summary:
## Context

Some small fixes to the ATen-Vulkan backend.

The first is that GPU sizes for a 4 dimensional tensor with width packing had a small bug:

```
      case 4:
        switch (memory_layout) {
          case api::GPUMemoryLayout::TENSOR_WIDTH_PACKED:
            gpu_sizes.at(0) = sizes.at(0);
            gpu_sizes.at(1) = sizes.at(1);
            // should be gpu_sizes.at(2) == sizes.at(2)
            gpu_sizes.at(2) = sizes.at(3);
            gpu_sizes.at(3) = api::utils::align_up(sizes.at(3), INT64_C(4));
            break;
```

This was fixed by simplifying the logic of GPU size calculation for texture storage.

The second was to modify the ctype mapping of the `api::kHalf` scalar type to be `float` instead of `unsigned short`. This is because GLSL does not natively support `float16`, so even with a FP16 texture type CPU/GPU transfer shaders will have to read from and write to `float` buffers.

In the future, we will look into integrating [VK_KHR_shader_float16_int8](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_shader_float16_int8.html) into ATen-Vulkan to allow for 16 bit and 8 bit types to be referenced explicitly.

Test Plan: CI

Differential Revision: D55018171


