### PR TITLE
[fx] preserver partiioner order fix

### DIFF
--- a/torch/fx/passes/infra/partitioner.py
+++ b/torch/fx/passes/infra/partitioner.py
@@ -23,7 +23,7 @@ class Partition:
         return str(self.nodes)
 
     def add_node(self, node: Node):
-        self.nodes.update(node=None)
+        self.nodes.update({node: None})
 
     def remove_node(self, node: Node):
         del self.nodes[node]


### PR DESCRIPTION
Summary:
Previous implementation seems to introduce a key value of {"node": none}. This causes an error in logging later on because we extract the name from the "node" but it is a string instead of a torch.fx.node

This seems to cause tests to pass.

Test Plan:
CI

ExecuTorch CI:
buck test mode/dev-nosan //executorch/backends/xnnpack/test:test_xnnpack_models

Reviewed By: larryliu0820

Differential Revision: D55026133


