### PR TITLE
T159183991: Error: EXC_SOFTWARE / SIGABRT at IGPyTorchFramework:-[MPSImageWrapperTrampoline endSynchronization:] (MPSImageWrapper.mm<line_num>):cpp_exception_clas

### DIFF
--- a/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.mm
@@ -40,8 +40,7 @@ using namespace at::native::metal;
     if (_imageWrapper) {
       _imageWrapper->release();
     }
-    // throw an exception with error details
-    METAL_THROW_IF_ERROR(error, "Command buffer execution failed!");
+    // T159183991: ignore error. We prefer to not crash the app.
   }
 }
 


### PR DESCRIPTION
Summary: Prevent crash by not throwing a C++ exception.

Test Plan: spongebobsandcastle

Reviewed By: SS-JIA

Differential Revision: D55036050
