### PR TITLE
[c10d] disable compute_duration by default

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -4180,11 +4180,7 @@ class NCCLTraceTest(NCCLTraceTestBase):
         event_created_time = datetime.fromtimestamp(last['time_created_ns'] / 1000000000)
         before_test = now - timedelta(minutes=1)
         self.assertTrue(before_test < event_created_time < now)
-        if timing_enabled:
-            # very loose bounds, measured 0.036 ms on devgpu
-            self.assertTrue(0 < last['duration_ms'] < 100)
-        else:
-            self.assertTrue("duration_ms" not in last)
+        self.assertTrue("duration_ms" not in last)
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
@@ -4428,11 +4424,7 @@ class NCCLTraceTest(NCCLTraceTestBase):
             self.assertEqual(t['entries'][coalesced_op]['state'], 'completed')
             self.assertEqual(t['entries'][coalesced_op]['input_sizes'], [])
             self.assertEqual(t['entries'][coalesced_op]['output_sizes'], [])
-            if timing_enabled:
-                duration = t['entries'][coalesced_op]['duration_ms']
-                self.assertTrue(0.001 < duration < 100000, duration)
-            else:
-                self.assertTrue('duration_ms' not in t['entries'][coalesced_op])
+            self.assertTrue('duration_ms' not in t['entries'][coalesced_op])
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
@@ -4483,12 +4475,7 @@ class NCCLTraceTest(NCCLTraceTestBase):
             self.assertEqual(t['entries'][seq]['input_sizes'], [input_sizes])
             self.assertEqual(t['entries'][seq]['output_sizes'], [input_sizes])
             self.assertEqual(t['entries'][seq]['state'], 'completed')
-
-            if timing_enabled:
-                duration = t['entries'][seq]['duration_ms']
-                self.assertTrue(0.001 < duration < 100000, duration)
-            else:
-                self.assertTrue('duration_ms' not in t['entries'][seq])
+            self.assertTrue('duration_ms' not in t['entries'][seq])
 
     # TODO(whc) support and test coalesced collectives that use the c++ start/end group thingy instead of python
     # coalescing manager
@@ -4536,11 +4523,7 @@ class NCCLTraceTest(NCCLTraceTestBase):
         self.assertEqual(t['entries'][0]['input_sizes'], [[2, 2], [2, 2]])
         self.assertEqual(t['entries'][0]['output_sizes'], [[2,], [2,]])
         self.assertEqual(t['entries'][0]['state'], 'completed')
-        if timing_enabled:
-            duration = t['entries'][0]['duration_ms']
-            self.assertTrue(0.001 < duration < 100000, duration)
-        else:
-            self.assertTrue('duration_ms' not in t['entries'][0])
+        self.assertTrue('duration_ms' not in t['entries'][0])
 
 class NCCLTraceTestDumpOnTimeoutBase(NCCLTraceTestBase):
     timeout_sec = 1

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -4183,7 +4183,7 @@ class NCCLTraceTest(NCCLTraceTestBase):
         event_created_time = datetime.fromtimestamp(last['time_created_ns'] / 1000000000)
         before_test = now - timedelta(minutes=1)
         self.assertTrue(before_test < event_created_time < now)
-        if timing_enabled and compute_duration:
+        if compute_duration:
             # very loose bounds, measured 0.036 ms on devgpu
             self.assertTrue(0 < last['duration_ms'] < 100)
         else:
@@ -4433,7 +4433,7 @@ class NCCLTraceTest(NCCLTraceTestBase):
             self.assertEqual(t['entries'][coalesced_op]['state'], 'completed')
             self.assertEqual(t['entries'][coalesced_op]['input_sizes'], [])
             self.assertEqual(t['entries'][coalesced_op]['output_sizes'], [])
-            if timing_enabled and compute_duration:
+            if compute_duration:
                 duration = t['entries'][coalesced_op]['duration_ms']
                 self.assertTrue(0.001 < duration < 10000, duration)
             else:
@@ -4491,7 +4491,7 @@ class NCCLTraceTest(NCCLTraceTestBase):
             self.assertEqual(t['entries'][seq]['input_sizes'], [input_sizes])
             self.assertEqual(t['entries'][seq]['output_sizes'], [input_sizes])
             self.assertEqual(t['entries'][seq]['state'], 'completed')
-            if timing_enabled and compute_duration:
+            if compute_duration:
                 duration = t['entries'][seq]['duration_ms']
                 self.assertTrue(0.001 < duration < 10000, duration)
             else:
@@ -4546,7 +4546,7 @@ class NCCLTraceTest(NCCLTraceTestBase):
         self.assertEqual(t['entries'][0]['input_sizes'], [[2, 2], [2, 2]])
         self.assertEqual(t['entries'][0]['output_sizes'], [[2,], [2,]])
         self.assertEqual(t['entries'][0]['state'], 'completed')
-        if timing_enabled and compute_duration:
+        if compute_duration:
             duration = t['entries'][0]['duration_ms']
             self.assertTrue(0.001 < duration < 10000, duration)
         else:

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -4394,7 +4394,7 @@ class NCCLTraceTest(NCCLTraceTestBase):
 
         torch.cuda.synchronize()
 
-        if timing_enabled:
+        if timing_enabled or compute_duration:
             # wait for watchdog thread to process the queue of works
             time.sleep(1)
 
@@ -4472,7 +4472,7 @@ class NCCLTraceTest(NCCLTraceTestBase):
                     dist.send(tensor, 0)
 
         torch.cuda.synchronize()
-        if timing_enabled:
+        if timing_enabled or compute_duration:
             # wait for watchdog thread to process the queue of works
             time.sleep(1)
 
@@ -4534,7 +4534,7 @@ class NCCLTraceTest(NCCLTraceTestBase):
 
         torch.cuda.synchronize()
 
-        if timing_enabled:
+        if timing_enabled or compute_duration:
             # wait for watchdog thread to process the queue of works
             time.sleep(1)
 

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -4430,7 +4430,7 @@ class NCCLTraceTest(NCCLTraceTestBase):
             self.assertEqual(t['entries'][coalesced_op]['output_sizes'], [])
             if timing_enabled:
                 duration = t['entries'][coalesced_op]['duration_ms']
-                self.assertTrue(0.001 < duration < 10000, duration)
+                self.assertTrue(0.001 < duration < 100000, duration)
             else:
                 self.assertTrue('duration_ms' not in t['entries'][coalesced_op])
 
@@ -4486,7 +4486,7 @@ class NCCLTraceTest(NCCLTraceTestBase):
 
             if timing_enabled:
                 duration = t['entries'][seq]['duration_ms']
-                self.assertTrue(0.001 < duration < 10000, duration)
+                self.assertTrue(0.001 < duration < 100000, duration)
             else:
                 self.assertTrue('duration_ms' not in t['entries'][seq])
 
@@ -4538,7 +4538,7 @@ class NCCLTraceTest(NCCLTraceTestBase):
         self.assertEqual(t['entries'][0]['state'], 'completed')
         if timing_enabled:
             duration = t['entries'][0]['duration_ms']
-            self.assertTrue(0.001 < duration < 10000, duration)
+            self.assertTrue(0.001 < duration < 100000, duration)
         else:
             self.assertTrue('duration_ms' not in t['entries'][0])
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1526,8 +1526,6 @@ void ProcessGroupNCCL::watchdogHandler() {
       lastStatusUpdateTime = std::chrono::steady_clock::now();
     }
 
-    bool computeDuration = enableTiming_.load();
-
     for (auto it = workMetaList_.begin(); it != workMetaList_.end();
          /* no increment */) {
       auto& work = *it;
@@ -1611,7 +1609,7 @@ void ProcessGroupNCCL::watchdogHandler() {
       // Clean up completed work
       if (work.isCompleted()) {
         lastCompletedSeq_ = work.seq_;
-        NCCLTraceBuffer::get()->retire_id(work.trace_id_, computeDuration);
+        NCCLTraceBuffer::get()->retire_id(work.trace_id_);
         if (onCompletionHook_) {
           // Move Work object to completedWorkList_ to be consumed by the hook
           // thread

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -746,7 +746,7 @@ ProcessGroupNCCL::ProcessGroupNCCL(
       getCvarInt(TORCH_NCCL_WAIT_TIMEOUT_DUMP_MILSEC, 60 * 1000 /*60 Sec*/);
   coordCheckIntervalMilSec_ = getCvarInt(TORCH_NCCL_COORD_CHECK_MILSEC, 1000);
   ncclTraceBufferSize_ = getCvarInt(TORCH_NCCL_TRACE_BUFFER_SIZE, 0);
-  computeDuratoin_ = getCvarBool(TORCH_NCCL_COMPUTE_DURATION, false);
+  computeDuration_ = getCvarBool(TORCH_NCCL_COMPUTE_DURATION, false);
   NCCLTraceBuffer::get()->record_pg_ranks(uid_, groupRanks());
   enableCollecticeHashDebug_ = (dist_debug_level_ >= DebugLevel::Detail);
   // store_ usually is wrapped with PrefixStore and the prefix is different
@@ -758,7 +758,8 @@ ProcessGroupNCCL::ProcessGroupNCCL(
       prefixStore ? prefixStore->getUnderlyingNonPrefixStore() : store_;
 #ifdef ENABLE_NCCL_ERROR_CHECKING
   enableTiming_.store(
-      getCvarBool(TORCH_NCCL_ENABLE_TIMING, false) || desyncDebug_);
+      getCvarBool(TORCH_NCCL_ENABLE_TIMING, false) || desyncDebug_ ||
+      computeDuration_);
 #endif
   avoidRecordStreams_ = getCvarBool(TORCH_NCCL_AVOID_RECORD_STREAMS, false);
 #ifdef NCCL_HAS_COMM_REGISTER
@@ -812,7 +813,7 @@ ProcessGroupNCCL::ProcessGroupNCCL(
             << waitTimeoutDumpInMilSec_
             << ", TORCH_NCCL_DESYNC_DEBUG: " << desyncDebug_
             << ", TORCH_NCCL_ENABLE_TIMING: " << enableTiming_.load()
-            << ", TORCH_NCCL_COMPUTE_DURATION: " << computeDuratoin_
+            << ", TORCH_NCCL_COMPUTE_DURATION: " << computeDuration_
             << ", TORCH_NCCL_BLOCKING_WAIT: " << blockingWait_
             << ", TIMEOUT(ms): " << options_->timeout.count()
             << ", USE_HIGH_PRIORITY_STREAM: "
@@ -1611,7 +1612,7 @@ void ProcessGroupNCCL::watchdogHandler() {
       // Clean up completed work
       if (work.isCompleted()) {
         lastCompletedSeq_ = work.seq_;
-        NCCLTraceBuffer::get()->retire_id(work.trace_id_, computeDuratoin_);
+        NCCLTraceBuffer::get()->retire_id(work.trace_id_, computeDuration_);
         if (onCompletionHook_) {
           // Move Work object to completedWorkList_ to be consumed by the hook
           // thread

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -746,6 +746,7 @@ ProcessGroupNCCL::ProcessGroupNCCL(
       getCvarInt(TORCH_NCCL_WAIT_TIMEOUT_DUMP_MILSEC, 60 * 1000 /*60 Sec*/);
   coordCheckIntervalMilSec_ = getCvarInt(TORCH_NCCL_COORD_CHECK_MILSEC, 1000);
   ncclTraceBufferSize_ = getCvarInt(TORCH_NCCL_TRACE_BUFFER_SIZE, 0);
+  computeDuratoin_ = getCvarBool(TORCH_NCCL_COMPUTE_DURATION, false);
   NCCLTraceBuffer::get()->record_pg_ranks(uid_, groupRanks());
   enableCollecticeHashDebug_ = (dist_debug_level_ >= DebugLevel::Detail);
   // store_ usually is wrapped with PrefixStore and the prefix is different
@@ -811,6 +812,7 @@ ProcessGroupNCCL::ProcessGroupNCCL(
             << waitTimeoutDumpInMilSec_
             << ", TORCH_NCCL_DESYNC_DEBUG: " << desyncDebug_
             << ", TORCH_NCCL_ENABLE_TIMING: " << enableTiming_.load()
+            << ", TORCH_NCCL_COMPUTE_DURATION: " << computeDuratoin_
             << ", TORCH_NCCL_BLOCKING_WAIT: " << blockingWait_
             << ", TIMEOUT(ms): " << options_->timeout.count()
             << ", USE_HIGH_PRIORITY_STREAM: "
@@ -1609,7 +1611,7 @@ void ProcessGroupNCCL::watchdogHandler() {
       // Clean up completed work
       if (work.isCompleted()) {
         lastCompletedSeq_ = work.seq_;
-        NCCLTraceBuffer::get()->retire_id(work.trace_id_);
+        NCCLTraceBuffer::get()->retire_id(work.trace_id_, computeDuratoin_);
         if (onCompletionHook_) {
           // Move Work object to completedWorkList_ to be consumed by the hook
           // thread

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1526,6 +1526,8 @@ void ProcessGroupNCCL::watchdogHandler() {
       lastStatusUpdateTime = std::chrono::steady_clock::now();
     }
 
+    bool computeDuration = enableTiming_.load();
+
     for (auto it = workMetaList_.begin(); it != workMetaList_.end();
          /* no increment */) {
       auto& work = *it;
@@ -1609,7 +1611,7 @@ void ProcessGroupNCCL::watchdogHandler() {
       // Clean up completed work
       if (work.isCompleted()) {
         lastCompletedSeq_ = work.seq_;
-        NCCLTraceBuffer::get()->retire_id(work.trace_id_, true);
+        NCCLTraceBuffer::get()->retire_id(work.trace_id_, computeDuration);
         if (onCompletionHook_) {
           // Move Work object to completedWorkList_ to be consumed by the hook
           // thread

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -102,6 +102,10 @@ static std::vector<std::string> TORCH_NCCL_COORD_CHECK_MILSEC = {
 static std::vector<std::string> TORCH_NCCL_ABORT_IN_DESTROY_PG = {
     "TORCH_NCCL_ABORT_IN_DESTROY_PG"};
 
+// Whether to compute duration between start and end cuda events.
+static std::vector<std::string> TORCH_NCCL_COMPUTE_DURATION = {
+    "TORCH_NCCL_COMPUTE_DURATION"};
+
 constexpr const char* NCCL_BACKEND_NAME = "nccl";
 
 constexpr const char* TIMEOUT_DUMP = "timeout_dump";
@@ -1025,6 +1029,9 @@ class TORCH_API ProcessGroupNCCL : public Backend {
 
   // Whether or not to enable timeout root cause analysis.
   bool desyncDebug_;
+
+  // Whether or not to compute duration between start and end cuda events.
+  bool computeDuratoin_;
 
   // Whether or not to dump debug info on timeout
   bool dumpOnTimeout_;

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -103,6 +103,7 @@ static std::vector<std::string> TORCH_NCCL_ABORT_IN_DESTROY_PG = {
     "TORCH_NCCL_ABORT_IN_DESTROY_PG"};
 
 // Whether to compute duration between start and end cuda events.
+// If true, timing (enableTiming_) will also be automatically enabled.
 static std::vector<std::string> TORCH_NCCL_COMPUTE_DURATION = {
     "TORCH_NCCL_COMPUTE_DURATION"};
 
@@ -1031,7 +1032,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   bool desyncDebug_;
 
   // Whether or not to compute duration between start and end cuda events.
-  bool computeDuratoin_;
+  bool computeDuration_;
 
   // Whether or not to dump debug info on timeout
   bool dumpOnTimeout_;

--- a/torch/csrc/distributed/c10d/TraceUtils.h
+++ b/torch/csrc/distributed/c10d/TraceUtils.h
@@ -528,9 +528,10 @@ struct NCCLTraceBuffer {
   This is called by the watchdog thread, and is asynchronous from the
   perspective of the main thread.
 
-  compute_duration defaults to false since calling cuda APIs may hang,
-  timing must also be enabled for compute_duration - see
-  TORCH_NCCL_ENABLE_TIMING.
+  compute_duration defaults to false since it requires calling the cuda APIs in
+  getDurationFromEvent which might increase the peak memory usage. Also
+  enableTiming_ automatically enabled if compute_duration is true for
+  computation to work correctly - see TORCH_NCCL_ENABLE_TIMING.
   */
   void retire_id(c10::optional<size_t> id, bool compute_duration = false) {
     if (!enabled_ || !id) {

--- a/torch/csrc/distributed/c10d/TraceUtils.h
+++ b/torch/csrc/distributed/c10d/TraceUtils.h
@@ -528,13 +528,11 @@ struct NCCLTraceBuffer {
   This is called by the watchdog thread, and is asynchronous from the
   perspective of the main thread.
 
-  compute_duration defaults to true since retire_id is only called in the
-  watchdog thread, which is currently a place we call cuda APIs which may hang,
-  but care should be taken to avoid computing duration in any function that must
-  never hang. (timing must also be enabled for compute_duration - see
-  TORCH_NCCL_ENABLE_TIMING).
+  compute_duration defaults to false since calling cuda APIs may hang,
+  timing must also be enabled for compute_duration - see
+  TORCH_NCCL_ENABLE_TIMING.
   */
-  void retire_id(c10::optional<size_t> id, bool compute_duration = true) {
+  void retire_id(c10::optional<size_t> id, bool compute_duration = false) {
     if (!enabled_ || !id) {
       return;
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122138

Summary:
Compute duration would invoke additional cuda overhead and possibly
GPU mem increase and possible hang, so we want to disable it by default and enable it only
when needed, or at least when timing is enabled.

Test Plan:
Test with existing unit test

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang