### PR TITLE
[codemod] Remove unused variables in caffe2/caffe2/video/video_decoder.cc

### DIFF
--- a/caffe2/video/video_decoder.cc
+++ b/caffe2/video/video_decoder.cc
@@ -436,7 +436,6 @@ void VideoDecoder::decodeLoop(
     // transport and getting decoded frames back.
     // Therefore, after EOF, continue going while
     // the decoder is still giving us frames.
-    int ipacket = 0;
     while ((!eof || gotPicture) &&
            /* either you must decode all frames or decode up to maxFrames
             * based on status of the mustDecodeAll flag */
@@ -463,7 +462,6 @@ void VideoDecoder::decodeLoop(
             LOG(ERROR) << "Error reading packet : " << ffmpegErrorStr(ret);
             return;
           }
-          ipacket++;
 
           auto si = packet.stream_index;
           if (params.getAudio_ && audioStreamIndex_ >= 0 &&


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Test Plan: Sandcastle

Differential Revision: D54378401


