### PR TITLE
[CI] Test that NumPy-2.X builds are backward compatible with 1.X

### DIFF
--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -255,7 +255,7 @@ else
     # or building non-XLA tests.
     if [[ "$BUILD_ENVIRONMENT" != *rocm*  &&
           "$BUILD_ENVIRONMENT" != *xla* ]]; then
-      if [[ "$BUILD_ENVRIONMENT" != *py3.8* ]]; then    
+      if [[ "$BUILD_ENVIRONMENT" != *py3.8* ]]; then    
         # Install numpy-2.0 release candidate for builds
         # Which should be backward compatible with Numpy-1.X
         python -mpip install --pre numpy==2.0.0b1

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -255,7 +255,7 @@ else
     # or building non-XLA tests.
     if [[ "$BUILD_ENVIRONMENT" != *rocm*  &&
           "$BUILD_ENVIRONMENT" != *xla* ]]; then
-      if [[ "$BUILD_ENVIRONMENT" != *py3.8* ]]; then    
+      if [[ "$BUILD_ENVIRONMENT" != *py3.8* ]]; then
         # Install numpy-2.0 release candidate for builds
         # Which should be backward compatible with Numpy-1.X
         python -mpip install --pre numpy==2.0.0b1

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -255,6 +255,9 @@ else
     # or building non-XLA tests.
     if [[ "$BUILD_ENVIRONMENT" != *rocm*  &&
           "$BUILD_ENVIRONMENT" != *xla* ]]; then
+      # Install numpy-2.0 release candidate for builds
+      # Which should be backward compatible with Numpy-1.X
+      python -mpip install --pre numpy==2.0.0b1
       WERROR=1 python setup.py bdist_wheel
     else
       python setup.py bdist_wheel

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -255,9 +255,11 @@ else
     # or building non-XLA tests.
     if [[ "$BUILD_ENVIRONMENT" != *rocm*  &&
           "$BUILD_ENVIRONMENT" != *xla* ]]; then
-      # Install numpy-2.0 release candidate for builds
-      # Which should be backward compatible with Numpy-1.X
-      python -mpip install --pre numpy==2.0.0b1
+      if [[ "$BUILD_ENVRIONMENT" != *py3.8* ]]; then    
+        # Install numpy-2.0 release candidate for builds
+        # Which should be backward compatible with Numpy-1.X
+        python -mpip install --pre numpy==2.0.0b1
+      fi
       WERROR=1 python setup.py bdist_wheel
     else
       python setup.py bdist_wheel


### PR DESCRIPTION
By compiling PyTorch against 2.x RC, but running all the tests with Numpy-1.X

This has no affects on binary builds