### PR TITLE
[codemod] Remove unused variables in caffe2/caffe2/experiments/operators/fully_connected_op_prune.h

### DIFF
--- a/caffe2/experiments/operators/fully_connected_op_prune.h
+++ b/caffe2/experiments/operators/fully_connected_op_prune.h
@@ -263,7 +263,6 @@ class FullyConnectedPruneGradientOp : public Operator<Context> {
     int window_size = 100;
     // TODO(wyiming): this threshold should be
     // based on distribution of the layer weight
-    float thr = 0.01;
     TORCH_DCHECK_EQ(Mask.dim32(0), W.dim32(0));
     TORCH_DCHECK_EQ(Mask.dim32(1), W.dim32(1));
     TORCH_DCHECK_EQ(Ag_dW.dim32(0), W.dim32(0));


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Test Plan: Sandcastle

Reviewed By: dmm-fb

Differential Revision: D54380402


