### PR TITLE
run some cuda testcases on other devices if available.

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -669,6 +669,7 @@ PYTORCH_CUDA_MEMCHECK = os.getenv('PYTORCH_CUDA_MEMCHECK', '0') == '1'
 
 PYTORCH_TESTING_DEVICE_ONLY_FOR_KEY = 'PYTORCH_TESTING_DEVICE_ONLY_FOR'
 PYTORCH_TESTING_DEVICE_EXCEPT_FOR_KEY = 'PYTORCH_TESTING_DEVICE_EXCEPT_FOR'
+PYTORCH_TESTING_DEVICE_FOR_CUSTOM_KEY = 'PYTORCH_TESTING_DEVICE_FOR_CUSTOM'
 
 
 def get_desired_device_type_test_bases(except_for=None, only_for=None, include_lazy=False, allow_mps=False):
@@ -692,6 +693,14 @@ def get_desired_device_type_test_bases(except_for=None, only_for=None, include_l
 
     def split_if_not_empty(x: str):
         return x.split(",") if x else []
+
+    # run some cuda testcases on other devices if available
+    # Usage:
+    # export PYTORCH_TESTING_DEVICE_FOR_CUSTOM = 'privateuse1'
+    env_custom_only_for = split_if_not_empty(os.getenv(PYTORCH_TESTING_DEVICE_FOR_CUSTOM_KEY, ''))
+    if env_custom_only_for:
+        desired_device_type_test_bases += filter(lambda x: x.device_type in env_custom_only_for, test_cases)
+        desired_device_type_test_bases = list(set(desired_device_type_test_bases))
 
     # Filter out the device types based on environment variables if available
     # Usage:

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -696,7 +696,7 @@ def get_desired_device_type_test_bases(except_for=None, only_for=None, include_l
 
     # run some cuda testcases on other devices if available
     # Usage:
-    # export PYTORCH_TESTING_DEVICE_FOR_CUSTOM = 'privateuse1'
+    # export PYTORCH_TESTING_DEVICE_FOR_CUSTOM=privateuse1
     env_custom_only_for = split_if_not_empty(os.getenv(PYTORCH_TESTING_DEVICE_FOR_CUSTOM_KEY, ''))
     if env_custom_only_for:
         desired_device_type_test_bases += filter(lambda x: x.device_type in env_custom_only_for, test_cases)

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -699,7 +699,7 @@ def get_desired_device_type_test_bases(except_for=None, only_for=None, include_l
     # export PYTORCH_TESTING_DEVICE_FOR_CUSTOM=privateuse1
     env_custom_only_for = split_if_not_empty(os.getenv(PYTORCH_TESTING_DEVICE_FOR_CUSTOM_KEY, ''))
     if env_custom_only_for:
-        desired_device_type_test_bases += filter(lambda x: x.device_type in env_custom_only_for, test_cases)
+        desired_device_type_test_bases += filter(lambda x: x.device_type in env_custom_only_for, test_bases)
         desired_device_type_test_bases = list(set(desired_device_type_test_bases))
 
     # Filter out the device types based on environment variables if available


### PR DESCRIPTION
If users want to run some cuda testcases on other devices throw setting an environment variable for testing the performance on custom devices, I think it can be used like this pr.

Fixes #ISSUE_NUMBER
