### PR TITLE
[Clang-tidy header][29/N] Enable clang-tidy warnings in aten/src/ATen/core/*.h

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -186,11 +186,12 @@ command = [
 [[linter]]
 code = 'CLANGTIDY'
 include_patterns = [
-    'aten/src/ATen/core/*.cpp',
     # Enable coverage of headers in aten/src/ATen
     # and excluding most sub-directories for now.
     'aten/src/ATen/*.h',
     'aten/src/ATen/*.cpp',
+    'aten/src/ATen/core/*.h',
+    'aten/src/ATen/core/*.cpp',
     'c10/**/*.cpp',
     'c10/**/*.h',
     'torch/csrc/*.h',


### PR DESCRIPTION
This PR enables clang-tidy in `aten/src/ATen/core/*.h`, which ends the series of patches beginning from #122015.