### PR TITLE
Delete unnecessary _mirror_autograd_meta_to for fakeify functionalization tensor

### DIFF
--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -912,9 +912,7 @@ class MetaConverter:
                                 source=source,
                                 symbolic_context=symbolic_context,
                             )
-                        out = torch._to_functional_tensor(fake_t)
-                        torch._mirror_autograd_meta_to(fake_t, out)
-                        return out
+                        return torch._to_functional_tensor(fake_t)
                     else:
                         # torch.func.functionalize
                         reapply_views = torch._C._functionalization_reapply_views_tls()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122195

This shouldn't be necessary as fakeification is already responsible for appropriately preserving leafness / not of the inner tensor. I checked the tests in https://github.com/pytorch/pytorch/pull/107062 and it also seems to not have been triggered anyway.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>