### PR TITLE
[AARCH64] Hide FP16 scalar arithmetic behind proper feature flag

### DIFF
--- a/aten/src/ATen/native/BlasKernel.cpp
+++ b/aten/src/ATen/native/BlasKernel.cpp
@@ -205,7 +205,7 @@ bool gemv_use_fast_path<at::Half>(
   return true;
 }
 
-#ifndef FBCODE_CAFFE2
+#ifdef __ARM_FEATURE_FP16_SCALAR_ARITHMETIC
 static inline float16_t reduce(float16x4_t x) {
         auto sum = vpadd_f16(x, x);
         return vget_lane_f16(vpadd_f16(sum, sum), 0);
@@ -286,7 +286,7 @@ void fp16_gemv_trans(
     float16_t* y,
     const int incy) {
   if (incx == 1 && alpha == 1.0 && beta == 0.0 && m % 4 == 0 && n % 4 == 0) {
-#ifndef FBCODE_CAFFE2
+#ifdef __ARM_FEATURE_FP16_SCALAR_ARITHMETIC
     return at::globalContext().allowFP16ReductionCPU() ? fp16_gemv_trans_fp16_arith(m, n, a, lda, x, y, incy)
                                                        : fp16_gemv_trans_fp32_arith(m, n, a, lda, x, y, incy);
 #else
@@ -308,7 +308,7 @@ void fp16_gemv_trans(
 }
 
 
-#ifndef FBCODE_CAFFE2
+#ifdef __ARM_FEATURE_FP16_SCALAR_ARITHMETIC
 static void fp16_gemv_notrans_fp16_arith(int m, int n, const float16_t* a, const int lda, const float16_t *x, float16_t *y) {
   for (auto j = 0; j < n; j++) {
     auto vecCol = vdup_n_f16(x[j]);
@@ -355,7 +355,7 @@ void fp16_gemv_notrans(
     float16_t* y,
     const int incy) {
   if (incx == 1 && alpha == 1.0 && beta == 0.0 && m % 4 == 0 && incy == 1) {
-#ifndef FBCODE_CAFFE2
+#ifdef __ARM_FEATURE_FP16_SCALAR_ARITHMETIC
     return at::globalContext().allowFP16ReductionCPU() ? fp16_gemv_notrans_fp16_arith(m, n, a, lda, x, y)
                                                        : fp16_gemv_notrans_fp32_arith(m, n, a, lda, x, y);
 #else


### PR DESCRIPTION
On Apple Silicon:
```
% sysctl machdep.cpu.brand_string; clang -dM -E - < /dev/null|grep __ARM_FEATURE_FP16
machdep.cpu.brand_string: Apple M1
#define __ARM_FEATURE_FP16_FML 1
#define __ARM_FEATURE_FP16_SCALAR_ARITHMETIC 1
#define __ARM_FEATURE_FP16_VECTOR_ARITHMETIC 1
```
On Graviton2 with respective `-march` flag:
```
# ./cpuinfo/build/cpu-info |grep Microarch -A1; gcc -dM -E - -march=armv8.2-a+fp16 </dev/null | grep __ARM_FEATURE_FP16
Microarchitectures:
	8x Neoverse N1
#define __ARM_FEATURE_FP16_SCALAR_ARITHMETIC 1
#define __ARM_FEATURE_FP16_VECTOR_ARITHMETIC 1
```
Test Plan: CI

Reviewed By: dimitribouche

Differential Revision: D55033347


