### PR TITLE
[TD] Query Github API for base

### DIFF
--- a/.github/workflows/target_determination.yml
+++ b/.github/workflows/target_determination.yml
@@ -53,6 +53,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          GITHUB_REF: ${{ github.ref }}
           JOB_ID: ${{ steps.get-job-id.outputs.job-id }}
           JOB_NAME: ${{ steps.get-job-id.outputs.job-name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/tools/testing/target_determination/heuristics/mentioned_in_pr.py
+++ b/tools/testing/target_determination/heuristics/mentioned_in_pr.py
@@ -1,4 +1,3 @@
-import os
 import re
 from typing import Any, List
 
@@ -9,6 +8,7 @@ from tools.testing.target_determination.heuristics.interface import (
 from tools.testing.target_determination.heuristics.utils import (
     get_git_commit_info,
     get_issue_or_pr_body,
+    get_pr_number,
 )
 from tools.testing.test_run import TestRun
 
@@ -32,14 +32,11 @@ class MentionedInPR(HeuristicInterface):
             print(f"Can't get commit info due to {e}")
             commit_messages = ""
         try:
-            pr_number = os.environ.get("PR_NUMBER", "")
-            if pr_number == "":
-                re_match = re.match(
-                    r"^refs/tags/.*/(\d+)$", os.environ.get("GITHUB_REF", "")
-                )
-                if re_match is not None:
-                    pr_number = re_match.group(1)
-            pr_body = get_issue_or_pr_body(int(pr_number))
+            pr_number = get_pr_number()
+            if pr_number is not None:
+                pr_body = get_issue_or_pr_body(pr_number)
+            else:
+                pr_body = ""
         except Exception as e:
             print(f"Can't get PR body due to {e}")
             pr_body = ""

--- a/tools/testing/target_determination/heuristics/utils.py
+++ b/tools/testing/target_determination/heuristics/utils.py
@@ -1,10 +1,11 @@
 import json
 import os
+import re
 import subprocess
 from collections import defaultdict
 from functools import lru_cache
 from pathlib import Path
-from typing import cast, Dict, List, Set, Union
+from typing import cast, Dict, List, Optional, Set, Union
 from urllib.request import Request, urlopen
 from warnings import warn
 
@@ -22,20 +23,43 @@ def python_test_file_to_test_name(tests: Set[str]) -> Set[str]:
 
 
 @lru_cache(maxsize=None)
-def query_changed_files() -> List[str]:
-    default_branch = f"origin/{os.environ.get('GIT_DEFAULT_BRANCH', 'main')}"
+def get_pr_number() -> Optional[int]:
+    pr_number = os.environ.get("PR_NUMBER", "")
+    if pr_number == "":
+        re_match = re.match(r"^refs/tags/.*/(\d+)$", os.environ.get("GITHUB_REF", ""))
+        if re_match is not None:
+            pr_number = re_match.group(1)
+    if pr_number != "":
+        return int(pr_number)
+    return None
+
+
+@lru_cache(maxsize=None)
+def get_merge_base() -> str:
+    pr_number = get_pr_number()
+    if pr_number is not None:
+        github_token = os.environ.get("GITHUB_TOKEN")
+        headers = {
+            "Accept": "application/vnd.github.v3+json",
+            "Authorization": f"token {github_token}",
+        }
+        url = f"https://api.github.com/repos/pytorch/pytorch/pulls/{pr_number}"
+        with urlopen(Request(url, headers=headers)) as conn:
+            pr_info = json.loads(conn.read().decode())
+            base = pr_info["base"]["ref"]
+    else:
+        base = "HEAD^"
+
     merge_base = (
-        subprocess.check_output(["git", "merge-base", default_branch, "HEAD"])
+        subprocess.check_output(["git", "merge-base", f"origin/{base}", "HEAD"])
         .decode()
         .strip()
     )
+    return merge_base
 
-    head = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
 
-    base_commit = merge_base
-    if base_commit == head:
-        # We are on the default branch, so check for changes since the last commit
-        base_commit = "HEAD^"
+def query_changed_files() -> List[str]:
+    base_commit = get_merge_base()
 
     proc = subprocess.run(
         ["git", "diff", "--name-only", base_commit, "HEAD"],
@@ -56,20 +80,7 @@ def query_changed_files() -> List[str]:
 @lru_cache(maxsize=None)
 def get_git_commit_info() -> str:
     """Gets the commit info since the last commit on the default branch."""
-    default_branch = f"origin/{os.environ.get('GIT_DEFAULT_BRANCH', 'main')}"
-
-    merge_base = (
-        subprocess.check_output(["git", "merge-base", default_branch, "HEAD"])
-        .decode()
-        .strip()
-    )
-
-    head = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
-
-    base_commit = merge_base
-    if base_commit == head:
-        # We are on the default branch, so check for changes since the last commit
-        base_commit = "HEAD^"
+    base_commit = get_merge_base()
 
     return (
         subprocess.check_output(

--- a/tools/testing/target_determination/heuristics/utils.py
+++ b/tools/testing/target_determination/heuristics/utils.py
@@ -66,7 +66,7 @@ def query_changed_files() -> List[str]:
         capture_output=True,
         check=False,
     )
-    print(f"merge_base: {merge_base}, head: {head}")
+    print(f"base_commit: {base_commit}")
 
     if proc.returncode != 0:
         raise RuntimeError("Unable to get changed files")


### PR DESCRIPTION
A better query for the base commit of a PR.  
Some ghstack PRs are not connected to main so git merge-base doesn't work.  Instead, use the Github API to query for the base of the PR, which should be more accurate

Sanity checked on one of Ed's ghstack PRs