### PR TITLE
[aoti] Change aot_compile callsites

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1122,6 +1122,9 @@ class AOTInductorModelCache:
 
     @classmethod
     def load(cls, model, example_inputs, device):
+        import torch._inductor
+        import torch.export._trace
+
         key = weakref.ref(model)
         if key not in cls.cache:
             # Register the output dataclass to pytree
@@ -1132,7 +1135,17 @@ class AOTInductorModelCache:
                 example_outputs = copy.deepcopy(model)(*example_args, **example_kwargs)
             _register_dataclass_output_as_pytree(example_outputs)
 
-            so_path = torch._export.aot_compile(model, example_args, example_kwargs)
+            # TODO(angelayi): change this to predispatch
+            gm = torch.export._trace._export_to_torch_ir(
+                model,
+                example_args,
+                example_kwargs,
+            )
+            with torch.no_grad():
+                so_path = torch._inductor.aot_compile(
+                    gm, example_args, example_kwargs
+                )  # type: ignore[arg-type]
+
             cls.cache[key] = torch._export.aot_load(so_path, device)
 
         return cls.cache[key]

--- a/test/inductor/test_aot_inductor_utils.py
+++ b/test/inductor/test_aot_inductor_utils.py
@@ -3,6 +3,7 @@
 import torch
 import torch._export
 import torch._inductor
+import torch.export._trace
 import torch.fx._pytree as fx_pytree
 
 from torch.testing._internal.common_utils import IS_FBCODE
@@ -32,14 +33,25 @@ class AOTIRunnerUtil:
         if not isinstance(model, torch.nn.Module):
             model = WrapperModule(model)
         # The exact API is subject to change
-        so_path = torch._export.aot_compile(
-            model,
-            example_inputs,
-            options=options,
-            dynamic_shapes=dynamic_shapes,
-            remove_runtime_assertions=True,
-            disable_constraint_solver=disable_constraint_solver,
-        )
+        if torch._inductor.config.is_predispatch:
+            ep = torch.export._trace._export(
+                model, example_inputs, dynamic_shapes=dynamic_shapes, pre_dispatch=True
+            )
+            gm = ep.module()
+        else:
+            gm = torch.export._trace._export_to_torch_ir(
+                model,
+                example_inputs,
+                dynamic_shapes=dynamic_shapes,
+                disable_constraint_solver=disable_constraint_solver,
+                # Disabling this flag, because instead we can rely on the mapping
+                # dynamo_flat_name_to_original_fqn which is coming from Dynamo.
+                restore_fqn=False,
+            )
+
+        with torch.no_grad():
+            so_path = torch._inductor.aot_compile(gm, example_inputs, options=options)  # type: ignore[arg-type]
+
         return so_path
 
     @classmethod

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -375,10 +375,9 @@ def aot_compile(
             # dynamo_flat_name_to_original_fqn which is coming from Dynamo.
             restore_fqn=False,
         )
-    flat_example_inputs = pytree.arg_tree_leaves(*args, **(kwargs or {}))
 
     with torch.no_grad():
-        so_path = torch._inductor.aot_compile(gm, flat_example_inputs, options)  # type: ignore[arg-type]
+        so_path = torch._inductor.aot_compile(gm, args, kwargs, options=options)  # type: ignore[arg-type]
 
     return so_path
 

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch.fx
 import torch.utils._pytree as pytree
@@ -30,7 +30,9 @@ def compile(
 
 def aot_compile(
     gm: torch.fx.GraphModule,
-    example_inputs: List[torch.Tensor],
+    args: Tuple[Any],
+    kwargs: Optional[Dict[str, Any]] = None,
+    *,
     options: Optional[Dict[str, Any]] = None,
 ) -> str:
     """
@@ -38,7 +40,8 @@ def aot_compile(
 
     Args:
         gm: The FX graph to compile.
-        example_inputs:  List of tensor inputs.
+        args:  Example arguments
+        kwargs: Example keyword arguments
         options:  Optional dict of config options.  See `torch._inductor.config`.
 
     Returns:
@@ -70,6 +73,19 @@ def aot_compile(
         pytree.treespec_dumps(out_spec) if out_spec is not None else ""
     )
 
+    flat_args_with_path, received_spec = pytree.tree_flatten_with_path(
+        (args, kwargs or {})
+    )
+    flat_example_inputs = tuple(x[1] for x in flat_args_with_path)
+
+    if in_spec is not None and received_spec != in_spec:
+        raise ValueError(  # noqa: TRY200
+            "Trying to flatten user inputs with exported input tree spec: \n"
+            f"{in_spec}\n"
+            "but actually got inputs with tree spec of: \n"
+            f"{received_spec}"
+        )
+
     options = (
         {
             "aot_inductor.serialized_in_spec": serialized_in_spec,
@@ -85,7 +101,7 @@ def aot_compile(
 
     return compile_fx_aot(
         gm,
-        example_inputs,
+        list(flat_example_inputs),
         config_patches=options,
     )
 


### PR DESCRIPTION
Summary:
Replacing `torch._export.aot_compile` callsites with 
```
ep = torch.export._trace._export(.., predispatch=True)   # Traces the given program into predispatch IR
so_path = torch._inductor.aot_compile_ep(ep, ...)  # Takes an exported program and compiles it into a .so
```

This allows us to explicitly split up the export step from AOTInductor. We can later modify tests to do `export + serialize + deserialize + inductor` to mimic internal production use cases better.

Test Plan: CI

Differential Revision: D54808612




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang