### PR TITLE
[Pytorch] auto format _python_dispatch file

### DIFF
--- a/torch/utils/_python_dispatch.py
+++ b/torch/utils/_python_dispatch.py
@@ -1,12 +1,18 @@
 import contextlib
-from typing import Optional, Union, List, Set, Dict, Any
 
 import warnings
 from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Set, Union
+
 import torch
 import torchgen
-from torch._C import _len_torch_dispatch_stack, _get_dispatch_stack_at, \
-    _pop_torch_dispatch_stack, _push_on_torch_dispatch_stack, DispatchKey
+from torch._C import (
+    _get_dispatch_stack_at,
+    _len_torch_dispatch_stack,
+    _pop_torch_dispatch_stack,
+    _push_on_torch_dispatch_stack,
+    DispatchKey,
+)
 
 
 # TODO: Limitations and things about enable_torch_dispatch_mode we should fix before exposing it:
@@ -14,6 +20,7 @@ from torch._C import _len_torch_dispatch_stack, _get_dispatch_stack_at, \
 #   is able to selectively disable __torch_dispatch__ of a particular class.
 # - It doesn't work with the tensor constructors (torch.tensor, torch.Tensor)
 # - Better name (see https://github.com/pytorch/pytorch/pull/63496#discussion_r694091694)
+
 
 class TorchDispatchMode:
     """
@@ -49,7 +56,7 @@ class TorchDispatchMode:
     def __init__(self, _dispatch_key=None):
         if _dispatch_key is not None:
             assert isinstance(_dispatch_key, torch._C.DispatchKey)
-            self.__dict__['_dispatch_key'] = _dispatch_key
+            self.__dict__["_dispatch_key"] = _dispatch_key
 
     def __torch_dispatch__(self, func, types, args=(), kwargs=None):
         raise NotImplementedError()
@@ -68,9 +75,12 @@ class TorchDispatchMode:
 
     @classmethod
     def push(cls, *args, **kwargs):
-        warnings.warn("`Mode.push()` is no longer necessary and can be replaced with just `with Mode()`")
+        warnings.warn(
+            "`Mode.push()` is no longer necessary and can be replaced with just `with Mode()`"
+        )
         instance = cls(*args, **kwargs)
         return instance
+
 
 def _get_current_dispatch_mode():
     stack_len = _len_torch_dispatch_stack()
@@ -82,22 +92,33 @@ def _get_current_dispatch_mode():
 
 def _detect_functional_mode():
     from torch._ops import _get_dispatch_mode_pre_dispatch
-    pre_dispatch_functional_mode = _get_dispatch_mode_pre_dispatch(torch._C._TorchDispatchModeKey.FUNCTIONAL)
-    post_dispatch_functional_mode = torch._C._get_dispatch_mode(torch._C._TorchDispatchModeKey.FUNCTIONAL)
 
-    assert (pre_dispatch_functional_mode is None) or (post_dispatch_functional_mode is None)
+    pre_dispatch_functional_mode = _get_dispatch_mode_pre_dispatch(
+        torch._C._TorchDispatchModeKey.FUNCTIONAL
+    )
+    post_dispatch_functional_mode = torch._C._get_dispatch_mode(
+        torch._C._TorchDispatchModeKey.FUNCTIONAL
+    )
+
+    assert (pre_dispatch_functional_mode is None) or (
+        post_dispatch_functional_mode is None
+    )
 
     if pre_dispatch_functional_mode is None:
         return post_dispatch_functional_mode
 
     return pre_dispatch_functional_mode
 
+
 def _unset_infra_mode(key):
-    from torch._ops import unset_mode_pre_dispatch, _get_dispatch_mode_pre_dispatch
+    from torch._ops import _get_dispatch_mode_pre_dispatch, unset_mode_pre_dispatch
+
     pre_dispatch_mode = _get_dispatch_mode_pre_dispatch(key)
     post_dispatch_mode = torch._C._get_dispatch_mode(key)
     if pre_dispatch_mode and post_dispatch_mode:
-        raise AssertionError("Can't have active infra mode on both pre and post dispatch mode stack")
+        raise AssertionError(
+            "Can't have active infra mode on both pre and post dispatch mode stack"
+        )
 
     if pre_dispatch_mode:
         mode = unset_mode_pre_dispatch(key)
@@ -107,7 +128,10 @@ def _unset_infra_mode(key):
 
 
 def _disable_infra_mode(key):
-    assert key in (torch._C._TorchDispatchModeKey.FUNCTIONAL, torch._C._TorchDispatchModeKey.PROXY)
+    assert key in (
+        torch._C._TorchDispatchModeKey.FUNCTIONAL,
+        torch._C._TorchDispatchModeKey.PROXY,
+    )
     mode_unset = _unset_infra_mode(key)
     try:
         yield mode_unset
@@ -128,7 +152,8 @@ def _push_mode(mode):
         _push_on_torch_dispatch_stack(mode)
         return
 
-    from torch._ops import get_cached_ops, _set_mode_pre_dispatch
+    from torch._ops import _set_mode_pre_dispatch, get_cached_ops
+
     # See Note [Not Caching Per-Dispatch-Key Mode Handlers]
     # Clear the cache of every op that has been used so far, for this particular key.
     ks = torch._C._functionality_to_backend_keys(k)
@@ -141,10 +166,12 @@ def _push_mode(mode):
 def _pop_mode(k: Optional[Union[DispatchKey, torch._C._TorchDispatchModeKey]] = None):
     if k == torch._C.DispatchKey.PreDispatch:  # type: ignore[attr-defined]
         from torch._ops import _pop_mode_from_pre_dispatch
+
         return _pop_mode_from_pre_dispatch()
 
     if k is None or isinstance(k, torch._C._TorchDispatchModeKey):
         return _pop_torch_dispatch_stack(k)
+
 
 @contextlib.contextmanager
 def _pop_mode_temporarily(k: Optional[DispatchKey] = None):
@@ -154,13 +181,20 @@ def _pop_mode_temporarily(k: Optional[DispatchKey] = None):
     finally:
         _push_mode(old)
 
+
 @contextlib.contextmanager
 def _disable_current_modes():
-    from torch._ops import _len_torch_dispatch_stack_pre_dispatch, _pop_mode_from_pre_dispatch
+    from torch._ops import (
+        _len_torch_dispatch_stack_pre_dispatch,
+        _pop_mode_from_pre_dispatch,
+    )
     from torch._subclasses.functional_tensor import FunctionalTensorMode
     from torch.fx.experimental.proxy_tensor import ProxyTorchDispatchMode
+
     mode_len_pre_dispatch = _len_torch_dispatch_stack_pre_dispatch()
-    old_pre_dispatch_modes = [_pop_mode_from_pre_dispatch() for _ in range(mode_len_pre_dispatch)]
+    old_pre_dispatch_modes = [
+        _pop_mode_from_pre_dispatch() for _ in range(mode_len_pre_dispatch)
+    ]
 
     has_proxy_mode_in_pre_dispatch = False
     has_functional_mode_in_pre_dispatch = False
@@ -175,10 +209,17 @@ def _disable_current_modes():
     old_modes = [_pop_mode() for _ in range(mode_len)]
 
     for old in old_modes:
-        if isinstance(old, FunctionalTensorMode) and has_functional_mode_in_pre_dispatch:
-            raise AssertionError("Can't have FunctionalMode available both in PreDispatch and Python Key")
+        if (
+            isinstance(old, FunctionalTensorMode)
+            and has_functional_mode_in_pre_dispatch
+        ):
+            raise AssertionError(
+                "Can't have FunctionalMode available both in PreDispatch and Python Key"
+            )
         if isinstance(old, ProxyTorchDispatchMode) and has_proxy_mode_in_pre_dispatch:
-            raise AssertionError("Can't have ProxyTorchDispatchMode available both in PreDispatch and Python Key")
+            raise AssertionError(
+                "Can't have ProxyTorchDispatchMode available both in PreDispatch and Python Key"
+            )
 
     # Manually disable proxy and fake modes, if any are active
     try:
@@ -195,6 +236,7 @@ class BaseTorchDispatchMode(TorchDispatchMode):
         if kwargs is None:
             kwargs = {}
         return func(*args, **kwargs)
+
 
 def is_traceable_wrapper_subclass(t):
     """
@@ -227,7 +269,12 @@ def is_traceable_wrapper_subclass(t):
                 safely ignored.
     """
     is_subclass = isinstance(t, torch.Tensor) and type(t) != torch.Tensor
-    return is_subclass and hasattr(t, "__tensor_flatten__") and hasattr(t, "__tensor_unflatten__")
+    return (
+        is_subclass
+        and hasattr(t, "__tensor_flatten__")
+        and hasattr(t, "__tensor_unflatten__")
+    )
+
 
 def transform_subclass(t, callback, outer_size=None, outer_stride=None):
     """
@@ -257,14 +304,17 @@ def transform_subclass(t, callback, outer_size=None, outer_stride=None):
     # NB: Purposefully guard here to simplify the inner / outer symbols.
     # Using sym_eq() for symbolic comparison can result in an expression that's too
     # difficult to guard on, so we use == here.
-    assert sub.shape == outer_size, \
-        f"Expected return value from {type(t)}__tensor_unflatten__() to have " \
+    assert sub.shape == outer_size, (
+        f"Expected return value from {type(t)}__tensor_unflatten__() to have "
         f"shape equal to {outer_size}, but got: {sub.shape}"
-    assert sub.stride() == outer_stride, \
-        f"Expected return value from {type(t)}__tensor_unflatten__() to have " \
+    )
+    assert sub.stride() == outer_stride, (
+        f"Expected return value from {type(t)}__tensor_unflatten__() to have "
         f"stride equal to {outer_stride}, but got: {sub.stride()}"
+    )
 
     return sub
+
 
 def _correct_storage_aliasing(func, schema_info, args, outs):
     """
@@ -293,7 +343,9 @@ def _correct_storage_aliasing(func, schema_info, args, outs):
         if is_traceable_wrapper_subclass(arg) or is_traceable_wrapper_subclass(ret):
             ret_list = ret if isinstance(ret, list) else [ret]
             for r in ret_list:
-                assert type(arg) == type(r), f"""Called {str(func)} with input of type {type(arg)}
+                assert type(arg) == type(
+                    r
+                ), f"""Called {str(func)} with input of type {type(arg)}
 and output of type {type(ret)}. But expected types to match."""
         # Need to run under no_dispatch, because we explicitly do **not**
         # want our subclass to intercept the set_() call.
@@ -316,11 +368,20 @@ and output of type {type(ret)}. But expected types to match."""
                 if isinstance(ret, list):
                     for r in ret:
                         torch.ops.aten.set_.source_Storage_storage_offset(
-                            r, arg.untyped_storage(), r.storage_offset(), r.shape, r.stride())
+                            r,
+                            arg.untyped_storage(),
+                            r.storage_offset(),
+                            r.shape,
+                            r.stride(),
+                        )
                 else:
                     assert isinstance(ret, torch.Tensor), f"type: {type(ret)}"
                     torch.ops.aten.set_.source_Storage_storage_offset(
-                        ret, arg.untyped_storage(), ret.storage_offset(), ret.shape, ret.stride()
+                        ret,
+                        arg.untyped_storage(),
+                        ret.storage_offset(),
+                        ret.shape,
+                        ret.stride(),
                     )
             finally:
                 torch._C._set_meta_in_tls_dispatch_include(meta_in_tls)
@@ -333,8 +394,11 @@ and output of type {type(ret)}. But expected types to match."""
     num_returns = len(func._schema.returns)
     for arg_idx in range(num_args):
         for return_idx in range(num_returns):
-            if is_read_only_alias_match(schema_info.args[arg_idx], schema_info.outs[return_idx]):
+            if is_read_only_alias_match(
+                schema_info.args[arg_idx], schema_info.outs[return_idx]
+            ):
                 alias_non_inplace_storage(args[arg_idx], outs[return_idx])
+
 
 # This abstracts over the fact that in return_and_correct_aliasing,
 # we sometimes use torchgen schema parsing (for aten ops, since torchscript's schema parsing is sometimes buggy),
@@ -345,13 +409,16 @@ class AliasInfo:
     is_write: bool
     name: Optional[str]
 
+
 @dataclass
 class SchemaInfo:
     args: List[AliasInfo]
     outs: List[AliasInfo]
 
+
 # Can't import torch._ops.OpOverload due to circular reference
 parsed_schema_map: Dict[Any, SchemaInfo] = {}
+
 
 # Given an OpOverload, returns schema information on it.
 # This is cached for efficiency, since it can involve running torchgen
@@ -367,38 +434,60 @@ def get_alias_info(func) -> SchemaInfo:
         # and torchgen doesn't know how to handle
         torchgen_schema_str = torchgen_schema_str[6:]
         import re
+
         # the torchscript parser ends up converting int[2]=1 into int[2]=[1, 1],
         # which torchgen chokes on.
-        torchgen_schema_str = re.sub(r'=\[[0, ]+\]', '=0', torchgen_schema_str)
-        torchgen_schema_str = re.sub(r'=\[[1, ]+\]', '=1', torchgen_schema_str)
+        torchgen_schema_str = re.sub(r"=\[[0, ]+\]", "=0", torchgen_schema_str)
+        torchgen_schema_str = re.sub(r"=\[[1, ]+\]", "=1", torchgen_schema_str)
         # for aten::rot90
         torchgen_schema_str = torchgen_schema_str.replace("=[0, 1]", "=[0,1]")
         torchgen_schema = torchgen.model.FunctionSchema.parse(torchgen_schema_str)
-        arg_schemas = [AliasInfo(
-            alias_set=set() if a.annotation is None else set(a.annotation.alias_set),
-            is_write=a.annotation is not None and a.annotation.is_write,
-            name=a.name,
-        ) for a in torchgen_schema.arguments.flat_all]
-        out_schemas = [AliasInfo(
-            alias_set=set() if a.annotation is None else set(a.annotation.alias_set),
-            is_write=a.annotation is not None and a.annotation.is_write,
-            name=a.name,
-        ) for a in torchgen_schema.returns]
+        arg_schemas = [
+            AliasInfo(
+                alias_set=(
+                    set() if a.annotation is None else set(a.annotation.alias_set)
+                ),
+                is_write=a.annotation is not None and a.annotation.is_write,
+                name=a.name,
+            )
+            for a in torchgen_schema.arguments.flat_all
+        ]
+        out_schemas = [
+            AliasInfo(
+                alias_set=(
+                    set() if a.annotation is None else set(a.annotation.alias_set)
+                ),
+                is_write=a.annotation is not None and a.annotation.is_write,
+                name=a.name,
+            )
+            for a in torchgen_schema.returns
+        ]
     else:
         # For non-aten ops, torchgen is untested so we rely on torchscript schema parsing
-        arg_schemas = [AliasInfo(
-            alias_set=set() if a.alias_info is None else set(a.alias_info.before_set),
-            is_write=a.alias_info is not None and a.alias_info.is_write,
-            name=a.name,
-        ) for a in func._schema.arguments]
-        out_schemas = [AliasInfo(
-            alias_set=set() if a.alias_info is None else set(a.alias_info.before_set),
-            is_write=a.alias_info is not None and a.alias_info.is_write,
-            name=a.name,
-        ) for a in func._schema.returns]
+        arg_schemas = [
+            AliasInfo(
+                alias_set=(
+                    set() if a.alias_info is None else set(a.alias_info.before_set)
+                ),
+                is_write=a.alias_info is not None and a.alias_info.is_write,
+                name=a.name,
+            )
+            for a in func._schema.arguments
+        ]
+        out_schemas = [
+            AliasInfo(
+                alias_set=(
+                    set() if a.alias_info is None else set(a.alias_info.before_set)
+                ),
+                is_write=a.alias_info is not None and a.alias_info.is_write,
+                name=a.name,
+            )
+            for a in func._schema.returns
+        ]
     schema_info = SchemaInfo(args=arg_schemas, outs=out_schemas)
     parsed_schema_map[func] = schema_info
     return schema_info
+
 
 def return_and_correct_aliasing(func, args, kwargs, out):
     """
@@ -431,11 +520,12 @@ def return_and_correct_aliasing(func, args, kwargs, out):
         return None
 
     def get_arg_from_alias(output_alias, schema_info, args, kwargs):
-        new_args, new_kwargs = torch.fx.operator_schemas.normalize_function(func, args=args, kwargs=kwargs)
+        new_args, new_kwargs = torch.fx.operator_schemas.normalize_function(
+            func, args=args, kwargs=kwargs
+        )
 
         arg_indices = [
-            i for i, a in enumerate(schema_info.args)
-            if output_alias in a.alias_set
+            i for i, a in enumerate(schema_info.args) if output_alias in a.alias_set
         ]
         # For any dispatcher op with an output alias, we expect it to map to exactly one alias in the schema's input arguments.
         assert len(arg_indices) == 1
@@ -447,14 +537,20 @@ def return_and_correct_aliasing(func, args, kwargs, out):
 
     # Fix up the storages of any outs so that they point to the same storage as the input,
     # if func is a view op.
-    _correct_storage_aliasing(func, schema_info, args, (out,) if not isinstance(out, tuple) else out)
+    _correct_storage_aliasing(
+        func, schema_info, args, (out,) if not isinstance(out, tuple) else out
+    )
 
     # For inplace_view ops in particular, we'll try hard to make sure that the wrapper subclass's
     # metadata is set correctly.
     if torch.Tag.inplace_view in func.tags:
         # no_dispatch() to make sure that we secretly change the metadata on the wrapper,
         # but don't end up dispatching the op anywhere else.
-        mutated_args = [x for i, x in enumerate(args) if get_write_alias(schema_info.args[i]) is not None]
+        mutated_args = [
+            x
+            for i, x in enumerate(args)
+            if get_write_alias(schema_info.args[i]) is not None
+        ]
         # Assumption: we have a very small number of inplace_view ops that follow a strict schema:
         # there is only a single argument that gets its metadata mutated.
         assert len(mutated_args) == 1
@@ -462,6 +558,7 @@ def return_and_correct_aliasing(func, args, kwargs, out):
         # but FunctionalTensor is special: it overrides all size/stride calls to plumb to the inner tensor.
         # so we don't actually need to update the metadata (and attempting to do so causes errors)
         from torch._subclasses.functional_tensor import FunctionalTensor
+
         if not isinstance(mutated_args[0], FunctionalTensor):
             with torch.utils._mode_utils.no_dispatch():
                 # See Note: [Fake Tensor Dispatch Keys]
@@ -484,12 +581,21 @@ def return_and_correct_aliasing(func, args, kwargs, out):
         raise RuntimeError("Unsupported schema: " + str(func._schema))
 
     if len(func._schema.returns) == 1:
-        return get_arg_from_alias(get_write_alias(schema_info.outs[0]), schema_info, args, kwargs)
+        return get_arg_from_alias(
+            get_write_alias(schema_info.outs[0]), schema_info, args, kwargs
+        )
 
     # In the multi-return case, all aten ops return a tuple / list, so cast accordingly.
-    outs_to_return = type(out)([
-        get_arg_from_alias(get_write_alias(schema_info.outs[i]), schema_info, args, kwargs)
-        if get_write_alias(r) is not None else o
-        for ((i, r), o) in zip(enumerate(schema_info.outs), out)
-    ])
+    outs_to_return = type(out)(
+        [
+            (
+                get_arg_from_alias(
+                    get_write_alias(schema_info.outs[i]), schema_info, args, kwargs
+                )
+                if get_write_alias(r) is not None
+                else o
+            )
+            for ((i, r), o) in zip(enumerate(schema_info.outs), out)
+        ]
+    )
     return outs_to_return


### PR DESCRIPTION
Summary: Auto format the _python_dispatch file, to make D55091453 easier to review

Test Plan: `arc lint`

Differential Revision: D55091454


