### PR TITLE
Mock inductor cache_dir for all tests

### DIFF
--- a/torch/_inductor/test_case.py
+++ b/torch/_inductor/test_case.py
@@ -20,34 +20,15 @@ class TestCase(DynamoTestCase):
     the cache directory for each test.
     """
 
-    _stack: contextlib.ExitStack
+    _inductor_stack: contextlib.ExitStack
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls._stack = contextlib.ExitStack()
-        cls._stack.enter_context(config.patch({"fx_graph_cache": True}))
+        cls._inductor_stack = contextlib.ExitStack()
+        cls._inductor_stack.enter_context(config.patch({"fx_graph_cache": True}))
 
     @classmethod
     def tearDownClass(cls):
         super().tearDownClass()
-        cls._stack.close()
-
-    def setUp(self):
-        super().setUp()
-
-        # For all tests, mock the tmp directory populated by the inductor
-        # FxGraphCache, both for test isolation and to avoid filling disk.
-        self._inductor_cache_tmp_dir = tempfile.TemporaryDirectory()
-        self._inductor_cache_get_tmp_dir_patch = unittest.mock.patch(
-            "torch._inductor.codecache.FxGraphCache._get_tmp_dir"
-        )
-        mock_get_dir = self._inductor_cache_get_tmp_dir_patch.start()
-        mock_get_dir.return_value = self._inductor_cache_tmp_dir.name
-
-    def tearDown(self):
-        super().tearDown()
-
-        # Clean up the FxGraphCache tmp dir.
-        self._inductor_cache_get_tmp_dir_patch.stop()
-        self._inductor_cache_tmp_dir.cleanup()
+        cls._inductor_stack.close()

--- a/torch/_inductor/test_case.py
+++ b/torch/_inductor/test_case.py
@@ -1,6 +1,4 @@
 import contextlib
-import tempfile
-import unittest
 
 from torch._dynamo.test_case import (
     run_tests as dynamo_run_tests,

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2912,8 +2912,9 @@ This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0"""
             assert torch.get_default_dtype() == torch.float
 
         # Clean up the inductor cache dir mock.
-        self._inductor_cache_get_tmp_dir_patch.stop()
-        self._inductor_cache_tmp_dir.cleanup()
+        if hasattr(self, '_inductor_cache_get_tmp_dir_patch'):
+            self._inductor_cache_get_tmp_dir_patch.stop()
+            self._inductor_cache_tmp_dir.cleanup()
 
     @staticmethod
     def _make_crow_indices(n_rows, n_cols, nnz,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122229

Summary: Put a mock for the indcutor cache_dir() in the base TestCase class to get a fresh inductor cache for every test.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang