### PR TITLE
Remove usage of deprecated volatile

### DIFF
--- a/aten/src/ATen/ParallelNative.cpp
+++ b/aten/src/ATen/ParallelNative.cpp
@@ -152,7 +152,7 @@ void invoke_parallel(
     std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
     std::exception_ptr eptr;
     std::mutex mutex;
-    volatile size_t remaining{0};
+    std::atomic_size_t remaining{0};
     std::condition_variable cv;
   } state;
 


### PR DESCRIPTION
Summary:
When building our iOS app, we get a compile error about the deprecated `volatile` keyword.

This diff attempts to fix it by replacing the usage of the deprecated `volatile` keyword with `atomic` as suggested by malfet

Test Plan: Successfully built the iOS app that previously had a compile error

Differential Revision: D55090518


