### PR TITLE
[Triton-MTIA] add kernel dump for opinfo tests

### DIFF
--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -26,7 +26,7 @@ from typing import (
 import sympy
 
 import torch
-from torch._dynamo.utils import dynamo_timed
+from torch._dynamo.utils import counters, dynamo_timed
 from torch._inductor.metrics import get_metric_table, is_metric_table_enabled
 from torch.utils._triton import has_triton
 
@@ -2240,6 +2240,7 @@ class Scheduler:
         # the current kernel from where 'allocate' retrieve those decisions.
         # We have to make sure there is a non-NULL kernel handler to store
         # those inplace update decisions.
+        counters["inductor"]["extern_calls"] += 1
         with V.set_kernel_handler(Kernel(increase_kernel_count=False)):
             scheduler_node.decide_inplace_update()
             scheduler_node.allocate()


### PR DESCRIPTION
Summary: Add kernel dumping to `run_all_opinfo.py`.

Test Plan:
`buck run @//mode/{dev-nosan,mtia} //triton_mtia/python/test/mtia/inductor/coverage:run_all_opinfo -- opinfo_results.csv -l opinfo_log.txt -k kernels`

Also added unit tests for kernel dump.

Differential Revision: D54885001


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang