### PR TITLE
Set py3.x build-environment name consistently

### DIFF
--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -111,7 +111,7 @@ jobs:
     name: linux-jammy-cpu-py3.8-gcc11-inductor
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-jammy-py3_8-gcc11-build
+      build-environment: linux-jammy-py3.8-gcc11-build
       docker-image-name: pytorch-linux-jammy-py3.8-gcc11-inductor-benchmarks
       test-matrix: |
         { include: [
@@ -135,7 +135,7 @@ jobs:
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-jammy-cpu-py3_8-gcc11-inductor-build
     with:
-      build-environment: linux-jammy-py3_8-gcc11-build
+      build-environment: linux-jammy-py3.8-gcc11-build
       docker-image: ${{ needs.linux-jammy-cpu-py3_8-gcc11-inductor-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cpu-py3_8-gcc11-inductor-build.outputs.test-matrix }}
     secrets:

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -319,7 +319,7 @@ jobs:
     name: linux-focal-py3_8-clang9-xla
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-focal-py3_8-clang9-xla
+      build-environment: linux-focal-py3.8-clang9-xla
       docker-image-name: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/xla_base:v1.1-lite
       test-matrix: |
         { include: [
@@ -331,7 +331,7 @@ jobs:
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-focal-py3_8-clang9-xla-build
     with:
-      build-environment: linux-focal-py3_8-clang9-xla
+      build-environment: linux-focal-py3.8-clang9-xla
       docker-image: ${{ needs.linux-focal-py3_8-clang9-xla-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-py3_8-clang9-xla-build.outputs.test-matrix }}
 


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/122157 checks for the Python version using `"$BUILD_ENVIRONMENT" != *py3.8*`, but some build environment uses a different style with `py3_8` instead causing numpy 2.x to be installed there wrongly, i.e. https://hud.pytorch.org/pytorch/pytorch/commit/03b987fe3fa93f398c0af5b40e512950c39a7cb6