### PR TITLE
[Dynamo][1/N] Fix clang-tidy warnings in torch/csrc/dynamo/*

### DIFF
--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -34,6 +34,7 @@ struct CacheKeyBuffer {
   }
 
  private:
+  // NOLINTNEXTLINE(*c-array*)
   std::unique_ptr<uint8_t[]> data;
 };
 
@@ -73,7 +74,7 @@ struct NodeCall {
       : id(id_), node(std::move(node_)) {}
 
   void mark_output(int input_nr, int output_idx) {
-    graph_output.emplace_back(std::make_pair(input_nr, output_idx));
+    graph_output.emplace_back(input_nr, output_idx);
   }
 
   uint32_t id;
@@ -167,7 +168,7 @@ struct TensorArgs {
 struct AutogradCompilerCall {
   void add_size_input(const c10::SymInt& s) {
     all_size_inputs.emplace_back(
-        SizeInput(default_dyn_type, s.guard_int(__FILE__, __LINE__)));
+        default_dyn_type, s.guard_int(__FILE__, __LINE__));
   }
 
   int emplace_hook(c10::SafePyObject&& fn) {
@@ -261,8 +262,8 @@ class CompiledNodeArgs {
     if (iv.isList()) {
       c10::List<at::IValue> list = iv.toList();
       collect_size(list.size());
-      for (auto it = list.begin(); it != list.end(); it++) {
-        collect(*it);
+      for (auto&& value : list) {
+        collect(value);
       }
     } else if (iv.isGenericDict()) {
       c10::Dict<at::IValue, at::IValue> ordered_dict = iv.toGenericDict();
@@ -428,7 +429,7 @@ class CompiledNodeArgs {
   void add_tensor_pre_hook(c10::SafePyObject&& obj, int index) {
     auto fn_id = _compiler.emplace_hook(std::move(obj));
     collect_size(static_cast<size_t>(fn_id));
-    _node_call.tensor_pre_hooks.emplace_back(std::make_pair(fn_id, index));
+    _node_call.tensor_pre_hooks.emplace_back(fn_id, index);
   }
 
   void add_pre_hook(c10::SafePyObject&& obj) {

--- a/torch/csrc/dynamo/extra_state.cpp
+++ b/torch/csrc/dynamo/extra_state.cpp
@@ -15,7 +15,7 @@ Py_ssize_t extra_index = -1;
 
 CacheEntry* ExtraState::get_first_entry() {
   if (this->cache_entry_list.empty()) {
-    return NULL;
+    return nullptr;
   }
   return &this->cache_entry_list.front();
 }
@@ -38,28 +38,28 @@ void ExtraState::invalidate(CacheEntry* cache_entry) {
 }
 
 CacheEntry* extract_cache_entry(ExtraState* extra_state) {
-  if (extra_state == NULL || extra_state == SKIP_CODE) {
-    return NULL;
+  if (extra_state == nullptr || extra_state == SKIP_CODE) {
+    return nullptr;
   }
   return extra_state->get_first_entry();
 }
 
 FrameState* extract_frame_state(ExtraState* extra_state) {
-  if (extra_state == NULL || extra_state == SKIP_CODE) {
-    return NULL;
+  if (extra_state == nullptr || extra_state == SKIP_CODE) {
+    return nullptr;
   }
   return (FrameState*)extra_state->frame_state.ptr();
 }
 
 ExtraState* get_extra_state(PyCodeObject* code) {
-  ExtraState* extra = NULL;
+  ExtraState* extra = nullptr;
   _PyCode_GetExtra((PyObject*)code, extra_index, (void**)&extra);
   return extra;
 }
 
 void destroy_extra_state(void* obj) {
   ExtraState* extra = (ExtraState*)obj;
-  if (extra != NULL && extra != SKIP_CODE) {
+  if (extra != nullptr && extra != SKIP_CODE) {
     delete extra;
   }
 }
@@ -67,15 +67,15 @@ void destroy_extra_state(void* obj) {
 void set_extra_state(PyCodeObject* code, ExtraState* extra_state) {
   ExtraState* old_extra_state = get_extra_state(code);
   CHECK(
-      old_extra_state == NULL || old_extra_state == SKIP_CODE ||
+      old_extra_state == nullptr || old_extra_state == SKIP_CODE ||
       old_extra_state != extra_state);
   _PyCode_SetExtra((PyObject*)code, extra_index, extra_state);
 }
 
 ExtraState* init_and_set_extra_state(PyCodeObject* code) {
   // Invariant - Extra state should not have been set before, therefore it
-  // should be NULL.
-  CHECK(get_extra_state(code) == NULL);
+  // should be nullptr.
+  CHECK(get_extra_state(code) == nullptr);
   ExtraState* extra_state = new ExtraState();
   NULL_CHECK(extra_state);
   set_extra_state(code, extra_state);
@@ -114,7 +114,7 @@ PyObject* lookup(
         // this function is called from C, so we cannot repropagate
         // the exception
         e.restore();
-        return NULL;
+        return nullptr;
       }
     }
     if (valid) {

--- a/torch/csrc/dynamo/init.cpp
+++ b/torch/csrc/dynamo/init.cpp
@@ -10,8 +10,7 @@
 static struct PyModuleDef _module =
     {PyModuleDef_HEAD_INIT, "torch._C._dynamo", "", -1, nullptr};
 
-namespace torch {
-namespace dynamo {
+namespace torch::dynamo {
 using torch::dynamo::autograd::torch_c_dynamo_compiled_autograd_init;
 
 void initDynamoBindings(PyObject* torch) {
@@ -50,5 +49,4 @@ void initDynamoBindings(PyObject* torch) {
   m.def("_debug_get_cache_entry_list", &_debug_get_cache_entry_list);
 }
 
-} // namespace dynamo
-} // namespace torch
+} // namespace torch::dynamo

--- a/torch/csrc/dynamo/init.h
+++ b/torch/csrc/dynamo/init.h
@@ -6,8 +6,6 @@
 
 #include <Python.h>
 
-namespace torch {
-namespace dynamo {
+namespace torch::dynamo {
 void initDynamoBindings(PyObject* torch);
 }
-} // namespace torch

--- a/torch/csrc/dynamo/python_compiled_autograd.cpp
+++ b/torch/csrc/dynamo/python_compiled_autograd.cpp
@@ -6,7 +6,7 @@
 #include <torch/csrc/jit/python/pybind_utils.h>
 #include <torch/csrc/python_headers.h>
 #include <torch/csrc/utils/pythoncapi_compat.h>
-#include <iostream>
+#include <sstream>
 #include <vector>
 
 /*
@@ -236,6 +236,7 @@ static PyObject* is_cache_empty(PyObject* dummy, PyObject* args) {
   END_HANDLE_TH_ERRORS;
 }
 
+// NOLINTNEXTLINE(*array*)
 static PyMethodDef _methods[] = {
     {"set_autograd_compiler", set_autograd_compiler, METH_VARARGS, nullptr},
     {"clear_cache", clear_cache, METH_NOARGS, nullptr},


### PR DESCRIPTION
This PR begins a series of works to ensure dynamo C++ code is clang-tidy clean.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang