### PR TITLE
XFAIL detectron2_maskrcnn_r_101_c4 CPU inductor accuracy

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_torchbench_inference.csv
@@ -82,7 +82,7 @@ detectron2_fcos_r_50_fpn,pass,97
 
 
 
-detectron2_maskrcnn_r_101_c4,pass,182
+detectron2_maskrcnn_r_101_c4,fail_accuracy,182
 
 
 


### PR DESCRIPTION
This starts to fail in trunk after the stack https://github.com/pytorch/pytorch/pull/122066 lands


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang