### PR TITLE
[TD] Remove credentials requirement for retrieval

### DIFF
--- a/.github/workflows/llm_td_retrieval.yml
+++ b/.github/workflows/llm_td_retrieval.yml
@@ -11,7 +11,7 @@ jobs:
   llm-retrieval:
     runs-on: linux.4xlarge
     continue-on-error: true
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'pytorch/pytorch' }}
+    if: false
     steps:
       - name: Clone PyTorch
         uses: actions/checkout@v3

--- a/.github/workflows/llm_td_retrieval.yml
+++ b/.github/workflows/llm_td_retrieval.yml
@@ -11,6 +11,7 @@ jobs:
   llm-retrieval:
     runs-on: linux.4xlarge
     continue-on-error: true
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'pytorch/pytorch' }}
     steps:
       - name: Clone PyTorch
         uses: actions/checkout@v3

--- a/.github/workflows/llm_td_retrieval.yml
+++ b/.github/workflows/llm_td_retrieval.yml
@@ -11,7 +11,6 @@ jobs:
   llm-retrieval:
     runs-on: linux.4xlarge
     continue-on-error: true
-    if: false
     steps:
       - name: Clone PyTorch
         uses: actions/checkout@v3
@@ -57,12 +56,6 @@ jobs:
           pip install -r requirements.txt
           cd ../codellama
           pip install -e .
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
-        with:
-          role-to-assume: arn:aws:iam::308535385114:role/gha_target_determinator_s3_read
-          aws-region: us-east-1
 
       - name: Fetch CodeLlama Checkpoint
         shell: bash -l {0}


### PR DESCRIPTION
Made the bucket readable by public
https://s3.console.aws.amazon.com/s3/buckets/target-determinator-assets?region=us-east-1&bucketType=general&tab=permissions

The only jobs that matter here are the retrieval and td jobs, which were both successful
