### PR TITLE
Convert MKL symbols from global to local

### DIFF
--- a/cmake/public/mkl.cmake
+++ b/cmake/public/mkl.cmake
@@ -21,3 +21,20 @@ endforeach()
 set_property(
   TARGET caffe2::mkl PROPERTY INTERFACE_LINK_DIRECTORIES
   ${MKL_ROOT}/lib ${MKL_ROOT}/lib/intel64 ${MKL_ROOT}/lib/intel64_win ${MKL_ROOT}/lib/win-x64)
+
+if(UNIX)
+  if(${USE_STATIC_MKL})
+    foreach(MKL_LIB_PATH IN LISTS MKL_LIBRARIES)
+      if(NOT EXISTS "${MKL_LIB_PATH}")
+        continue()
+      endif()
+
+      get_filename_component(MKL_LIB_NAME "${MKL_LIB_PATH}" NAME)
+
+      # Match archive libraries starting with "libmkl_"
+      if(MKL_LIB_NAME MATCHES "^libmkl_" AND MKL_LIB_NAME MATCHES ".a$")
+        target_link_options(caffe2::mkl INTERFACE "-Wl,--exclude-libs,${MKL_LIB_NAME}")
+      endif()
+    endforeach()
+  endif()
+endif()

--- a/cmake/public/mkl.cmake
+++ b/cmake/public/mkl.cmake
@@ -23,7 +23,7 @@ set_property(
   ${MKL_ROOT}/lib ${MKL_ROOT}/lib/intel64 ${MKL_ROOT}/lib/intel64_win ${MKL_ROOT}/lib/win-x64)
 
 if(UNIX)
-  if(${USE_STATIC_MKL})
+  if(USE_STATIC_MKL)
     foreach(MKL_LIB_PATH IN LISTS MKL_LIBRARIES)
       if(NOT EXISTS "${MKL_LIB_PATH}")
         continue()


### PR DESCRIPTION
PyTorch is statically linked to MKL but MKL symbols are visible to global, which may cause symbol conflicts.
Such error has been observed when a different version of MKL is dynamically linked to the other components: `libtorch_cpu.so` was invoked incorrectly when MKL descriptor was freed.
