### PR TITLE
Add missing throw of std::runtime_error in dynamo/guards.cpp

### DIFF
--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -3236,7 +3236,7 @@ PyObject* torch_c_dynamo_guards_init() {
              std::string source,
              py::handle example_value) -> GuardManager* {
             if (self.is_exact_dict_type()) {
-              std::runtime_error(
+              throw std::runtime_error(
                   "getattr_manager on a DictGuardManager is supported only for dict subclasses");
             }
             return self.get_child_manager<GetAttrGuardAccessor>(


### PR DESCRIPTION
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang