### PR TITLE
For inductor tests, mock the tmp dir holding all the caches

### DIFF
--- a/torch/_inductor/test_case.py
+++ b/torch/_inductor/test_case.py
@@ -2,6 +2,8 @@ import contextlib
 import tempfile
 import unittest
 
+import torch
+
 from torch._dynamo.test_case import (
     run_tests as dynamo_run_tests,
     TestCase as DynamoTestCase,
@@ -20,30 +22,34 @@ class TestCase(DynamoTestCase):
     the cache directory for each test.
     """
 
-    _stack: contextlib.ExitStack
+    _inductor_test_stack: contextlib.ExitStack
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls._stack = contextlib.ExitStack()
-        cls._stack.enter_context(config.patch({"fx_graph_cache": True}))
+        cls._inductor_test_stack = contextlib.ExitStack()
+        cls._inductor_test_stack.enter_context(config.patch({"fx_graph_cache": True}))
 
     @classmethod
     def tearDownClass(cls):
         super().tearDownClass()
-        cls._stack.close()
+        cls._inductor_test_stack.close()
 
     def setUp(self):
         super().setUp()
 
         # For all tests, mock the tmp directory populated by the inductor
-        # FxGraphCache, both for test isolation and to avoid filling disk.
+        # caches, both for test isolation and to avoid filling disk.
         self._inductor_cache_tmp_dir = tempfile.TemporaryDirectory()
         self._inductor_cache_get_tmp_dir_patch = unittest.mock.patch(
-            "torch._inductor.codecache.FxGraphCache._get_tmp_dir"
+            "torch._inductor.codecache.cache_dir"
         )
         mock_get_dir = self._inductor_cache_get_tmp_dir_patch.start()
         mock_get_dir.return_value = self._inductor_cache_tmp_dir.name
+
+        # This function uses a functools.lru_cache to keep a reference
+        # to the tmp dir, so clear it.
+        torch._inductor.codecache.cpp_prefix_path.cache_clear()
 
     def tearDown(self):
         super().tearDown()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122315

Summary: Previously I was mocking only the subdir holding the FX graph cache. We can mock the whole cache_dir. To get a test with a fresh inductor cache, use `torch._inductor.test_case.TestCase`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang