### PR TITLE
[DCP] Check if pg exists in async before checking for cpu PG

### DIFF
--- a/torch/distributed/checkpoint/state_dict_saver.py
+++ b/torch/distributed/checkpoint/state_dict_saver.py
@@ -206,10 +206,11 @@ def async_save(
     """
     torch._C._log_api_usage_once("torch.distributed.checkpoint.async_save")
 
-    pg = process_group or _get_default_group()
-    assert (
-        torch.device("cpu") in pg._device_types  # type: ignore[attr-defined]
-    ), "A CPU backend must be enabled for async save; try initializing process group with 'cpu:gloo,cuda:ncc'"
+    if dist.is_available() and dist.is_initialized():
+        pg = process_group or _get_default_group()
+        assert (
+            torch.device("cpu") in pg._device_types  # type: ignore[attr-defined]
+        ), "A CPU backend must be enabled for async save; try initializing process group with 'cpu:gloo,cuda:ncc'"
 
     cpu_state_dict = _offload_state_dict_to_cpu(_stateful_to_state_dict(state_dict))
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122316

Check if pg exists in async before checking for cpu PG in async save path. 

This PR enables using async_save even if PG is not initialized.

Differential Revision: [D54868689](https://our.internmc.facebook.com/intern/diff/D54868689/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D54868689/)!

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang