### PR TITLE
[while_loop] fix mode not on stack error

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -353,6 +353,11 @@ class TestControlFlowTraced(TestCase):
             self.assertEqual(graph(*args), eager_res)
         return graphs
 
+    def _check_compile(self, fn, args, *, backend="eager"):
+        eager_res = fn(*args)
+        compiled_fn = torch.compile(fn, backend=backend)
+        self.assertEqual(compiled_fn(*args), eager_res)
+
     def test_cond_traced_not_nested(self):
         def true_fn(x):
             return x.sin()
@@ -511,6 +516,11 @@ def forward(self, arg0_1):
             mode = mode if mode is not None else contextlib.nullcontext()
             with mode:
                 self._check_tracing(fn, inp)
+
+    def test_while_loop_aot_eager(self):
+        for backend in ["eager", "aot_eager"]:
+            for fn, inp in _while_loop_tests().values():
+                self._check_compile(fn, inp, backend="aot_eager")
 
     def test_while_loop_nested2_traced(self):
         fn, inp = _while_loop_tests()["nested2"]

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -200,7 +200,8 @@ def while_loop_tracing(mode, cond_fn, body_fn, operands):
 
 @while_loop_op.py_impl(FakeTensorMode)
 def while_loop_fake_tensor_mode(mode, cond_fn, body_fn, operands):
-    return body_fn(*operands)
+    with mode:
+        return body_fn(*operands)
 
 
 @while_loop_op.py_functionalize_impl


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122323
* #122244

Fixes https://github.com/pytorch/pytorch/issues/121453.

This is caused by missing  `with mode` in FakeTensor mode.

Test Plan:
add new tests.
