### PR TITLE
[ONNX] model_type flag is only supported under `SKIP_XFAIL_SUBTESTS`

### DIFF
--- a/test/onnx/onnx_test_common.py
+++ b/test/onnx/onnx_test_common.py
@@ -689,6 +689,11 @@ def add_decorate_info(
         assert (
             opinfo is not None
         ), f"Couldn't find OpInfo for {decorate_meta}. Did you need to specify variant_name?"
+        assert decorate_meta.model_type is None, (
+            f"Tested op: {decorate_meta.op_name} in wrong position! "
+            "If model_type needs to be specified, it should be "
+            "put under SKIP_XFAIL_SUBTESTS_WITH_MATCHER_AND_MODEL_TYPE."
+        )
         decorators = list(opinfo.decorators)
         new_decorator = opinfo_core.DecorateInfo(
             decorate_meta.decorator,

--- a/test/onnx/test_fx_op_consistency.py
+++ b/test/onnx/test_fx_op_consistency.py
@@ -156,8 +156,8 @@ EXPECTED_SKIPS_OR_FAILS_WITH_DTYPES: Tuple[onnx_test_common.DecorateMeta, ...] =
     ),
     skip(
         "_native_batch_norm_legit",
-        reason=onnx_test_common.reason_onnx_script_does_not_support("cpu is not supported: \
-            https://github.com/microsoft/onnxscript/pull/1289"),
+        dtypes=(torch.float16,),
+        reason="fixme: Assertion error: result mismatch and type error",
     ),
     skip(
         "_batch_norm_with_update",
@@ -763,10 +763,10 @@ EXPECTED_SKIPS_OR_FAILS_WITH_DTYPES: Tuple[onnx_test_common.DecorateMeta, ...] =
         "narrow",
         reason=onnx_test_common.reason_dynamo_does_not_support("data-dependent"),
     ),
-    skip(
+    xfail(
         "native_batch_norm",
-        reason=onnx_test_common.reason_onnx_script_does_not_support("cpu is not supported: \
-            https://github.com/microsoft/onnxscript/pull/1289")
+        dtypes=(torch.float16,),
+        reason="fixme: https://github.com/microsoft/onnxscript/issues/1269",
     ),
     xfail(
         "native_layer_norm",

--- a/test/onnx/test_fx_op_consistency.py
+++ b/test/onnx/test_fx_op_consistency.py
@@ -133,6 +133,8 @@ def skip_torchlib_forward_compatibility(
 #     2a. If a test is now failing because of xpass, because some previous errors
 #     are now fixed, removed the corresponding xfail.
 #     2b. If a test is not failing consistently, use skip.
+# NOTE: EXPECTED_SKIPS_OR_FAILS only supports dtypes. If a matcher or model_type
+# is needed, use the SKIP_XFAIL_SUBTESTS list further down below.
 EXPECTED_SKIPS_OR_FAILS: Tuple[onnx_test_common.DecorateMeta, ...] = (
     xfail(
         "__getitem__",
@@ -1191,13 +1193,6 @@ EXPECTED_SKIPS_OR_FAILS: Tuple[onnx_test_common.DecorateMeta, ...] = (
         reason=onnx_test_common.reason_dynamo_does_not_support("data-dependent"),
     ),
     xfail(
-        "to",
-        dtypes=(torch.int32, torch.int64, torch.float16, torch.float32, torch.bool, torch.complex64),
-        # model_type=pytorch_test_common.TorchModelType.TORCH_EXPORT_EXPORTEDPROGRAM,
-        model_type=pytorch_test_common.TorchModelType.TORCH_NN_MODULE,
-        reason="This op requires torch.dtype as input, which is not supported currently.",
-    ),
-    xfail(
         "topk",
         dtypes=(torch.int64, torch.int32),
         reason="fixme: Assertion error: result mismatch",
@@ -1351,6 +1346,8 @@ EXPECTED_SKIPS_OR_FAILS: Tuple[onnx_test_common.DecorateMeta, ...] = (
 )
 # fmt: on
 
+# NOTE: The xfail and skip with a matcher function or model_type should be
+# at under the `SKIP_XFAIL_SUBTESTS` section.
 SKIP_XFAIL_SUBTESTS: tuple[onnx_test_common.DecorateMeta, ...] = (
     skip(
         "_native_batch_norm_legit",
@@ -1638,6 +1635,19 @@ SKIP_XFAIL_SUBTESTS: tuple[onnx_test_common.DecorateMeta, ...] = (
         matcher=lambda sample: isinstance(sample.input, torch.Tensor)
         and len(sample.input.shape) < 2,
         reason="fixme: IsScalar",
+    ),
+    xfail(
+        "to",
+        dtypes=(
+            torch.int32,
+            torch.int64,
+            torch.float16,
+            torch.float32,
+            torch.bool,
+            torch.complex64,
+        ),
+        model_type=pytorch_test_common.TorchModelType.TORCH_NN_MODULE,
+        reason="This op requires torch.dtype as input, which is not supported currently.",
     ),
     xfail(
         "unflatten",

--- a/test/onnx/test_fx_op_consistency.py
+++ b/test/onnx/test_fx_op_consistency.py
@@ -156,8 +156,8 @@ EXPECTED_SKIPS_OR_FAILS_WITH_DTYPES: Tuple[onnx_test_common.DecorateMeta, ...] =
     ),
     skip(
         "_native_batch_norm_legit",
-        dtypes=(torch.float16,),
-        reason="fixme: Assertion error: result mismatch and type error",
+        reason=onnx_test_common.reason_onnx_script_does_not_support("cpu is not supported: \
+            https://github.com/microsoft/onnxscript/pull/1289"),
     ),
     skip(
         "_batch_norm_with_update",
@@ -763,10 +763,10 @@ EXPECTED_SKIPS_OR_FAILS_WITH_DTYPES: Tuple[onnx_test_common.DecorateMeta, ...] =
         "narrow",
         reason=onnx_test_common.reason_dynamo_does_not_support("data-dependent"),
     ),
-    xfail(
+    skip(
         "native_batch_norm",
-        dtypes=(torch.float16,),
-        reason="fixme: https://github.com/microsoft/onnxscript/issues/1269",
+        reason=onnx_test_common.reason_onnx_script_does_not_support("cpu is not supported: \
+            https://github.com/microsoft/onnxscript/pull/1289")
     ),
     xfail(
         "native_layer_norm",

--- a/test/onnx/test_fx_op_consistency.py
+++ b/test/onnx/test_fx_op_consistency.py
@@ -166,7 +166,8 @@ EXPECTED_SKIPS_OR_FAILS_WITH_DTYPES: Tuple[onnx_test_common.DecorateMeta, ...] =
     ),
     xfail(
         "_softmax_backward_data",
-        reason=onnx_test_common.reason_dynamo_does_not_support("assert all(isinstance(a, KNOWN_TYPES) for a in flat_args)")
+        dtypes=(torch.float16,),
+        reason="fixme: Assertion error: result mismatch",
     ),
     xfail(
         "add", dtypes=onnx_test_common.BOOL_TYPES,

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -833,7 +833,7 @@ class ONNXProgram:
             Union[torch.nn.Module, Callable, torch_export.ExportedProgram]
         ] = None,
         **model_kwargs,
-    ) -> Sequence[Union[torch.Tensor, int, float, bool]]:
+    ) -> Sequence[Union[torch.Tensor, int, float, bool, torch.dtype]]:
         """Converts the PyTorch model inputs to exported ONNX model inputs format.
 
         Due to design differences, input/output format between PyTorch model and exported

--- a/torch/onnx/_internal/io_adapter.py
+++ b/torch/onnx/_internal/io_adapter.py
@@ -71,7 +71,7 @@ class InputAdapter:
             Union[torch.nn.Module, Callable, torch_export.ExportedProgram]
         ] = None,
         **model_kwargs,
-    ) -> Sequence[Union[int, float, bool, str, "torch.Tensor", None]]:
+    ) -> Sequence[Union[int, float, bool, str, "torch.Tensor", torch.dtype, None]]:
         """Converts the PyTorch model inputs to exported ONNX model inputs format.
 
         Args:


### PR DESCRIPTION
Fixes #120918 

To address the confusion that developers usually have on which list to put xfail and skip. This PR provides guidance that `model_type` and `matcher` specified xfail/skip should go to `SKIP_XFAIL_SUBTESTS`.