### PR TITLE
fix leaky fake tensor on attribute assignment, support buffer assignment

### DIFF
--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -394,6 +394,67 @@ def _make_module_call_graph(
     return ret
 
 
+def _get_attributes(mod):
+    # return any attributes of a module that are not standard attributes
+    STD_ATTRS = {
+        "_backward_hooks",
+        "_backward_pre_hooks",
+        "_buffers",
+        "_forward_hooks",
+        "_forward_hooks_always_called",
+        "_forward_hooks_with_kwargs",
+        "_forward_pre_hooks",
+        "_forward_pre_hooks_with_kwargs",
+        "_is_full_backward_hook",
+        "_load_state_dict_post_hooks",
+        "_load_state_dict_pre_hooks",
+        "_modules",
+        "_non_persistent_buffers_set",
+        "_parameters",
+        "_state_dict_hooks",
+        "_state_dict_pre_hooks",
+        "training",
+    }
+    return {k: v for k, v in mod.__dict__.items() if k not in STD_ATTRS}
+
+
+@contextmanager
+def detect_attribute_assignment(mod: torch.nn.Module):
+    # Do not allow assignment of tensor attributes during export unless
+    # the attribute is registered as a buffer.
+
+    # save state of attributes before enter
+    snapshot = pytree.tree_map(lambda x: x, _get_attributes(mod))
+    try:
+        yield
+    finally:
+        # after exit, compare state of attributes with snapshot
+        # to detect which attributes were assigned
+        assigned_attributes = []
+
+        def _collect_assigned_attributes(kp, t, _t):
+            if isinstance(t, torch.Tensor) and _t is not t:
+                attr, *rest = kp
+                assigned_attributes.append(
+                    f"self.{attr.key}{torch.utils._pytree.keystr(rest)}"
+                )
+
+        pytree.tree_map_with_path(
+            _collect_assigned_attributes, snapshot, _get_attributes(mod)
+        )
+
+        if assigned_attributes:
+            if len(assigned_attributes) > 1:
+                msg = f"attributes {', '.join(assigned_attributes)} were"
+            else:
+                msg = f"attribute {assigned_attributes[0]} was"
+            raise ValueError(
+                f"The {msg} assigned during export. "
+                "Such attributes must be registered as buffers using the `register_buffer` API "
+                "(https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.register_buffer)."
+            )
+
+
 def _export_to_torch_ir(
     f: Callable,
     args: Tuple[Any, ...],
@@ -942,7 +1003,8 @@ def _export(
                                     *args, **kwargs
                                 )
                         else:
-                            tree_out = self._export_root(*args, **kwargs)
+                            with detect_attribute_assignment(self._export_root):
+                                tree_out = self._export_root(*args, **kwargs)
                         flat_outs, out_spec = pytree.tree_flatten(tree_out)
                         return tuple(flat_outs)
 


### PR DESCRIPTION
In non-strict, assignment of attributes in a model causes their state to contain fake tensors post-tracing, which leads to incorrect results on running the exported model. We now error when this happens, asking the user to use buffers instead.
Next, we add support for assignment of buffers. The final values of the buffers turn into outputs of the graph. Since the buffers are already lifted as inputs and populated with the initial values when the model is run, this leads to a simple programming model where the driver of the model can feed the outputs back as inputs for successive runs.

Differential Revision: D55146852
