### PR TITLE
[export] Fix handling output in remove_effect_tokens_pass

### DIFF
--- a/torch/export/_remove_auto_functionalized_pass.py
+++ b/torch/export/_remove_auto_functionalized_pass.py
@@ -15,22 +15,7 @@ from torch._higher_order_ops.auto_functionalize import (
 from torch.export import ExportedProgram
 
 
-def unsafe_remove_auto_functionalized_pass(
-    ep: ExportedProgram,
-) -> ExportedProgram:
-    """
-    This pass removes an instances of the higher order op 'auto_functionalized',
-    and modifies the calling EP inplace to have the original mutator op.
-    This pass doesn't perform safety checks to make sure that this inplace mutation is safe.
-    """
-    auto_functionalize_nodes: List[torch.fx.Node] = []
-    for module in ep.graph_module.modules():
-        if not isinstance(module, torch.fx.GraphModule):
-            continue
-        for node in ep.graph.nodes:
-            if node.op == "call_function" and node.target is auto_functionalized:
-                auto_functionalize_nodes.append(node)
-
+def _remove_auto_functionalization_from_graph_helper(ep, auto_functionalize_nodes):
     # Update every use of the HOP
     for node in reversed(auto_functionalize_nodes):
         func = node.args[0]
@@ -47,7 +32,6 @@ def unsafe_remove_auto_functionalized_pass(
         node.replace_all_uses_with(new_node)
 
         mutable_args_names = get_mutable_arg_names(new_node.target)
-        output_specs = ep.graph_signature.output_specs
 
         # update the users of the auto_func node (the getitem nodes)
         for user in list(new_node.users.keys()):
@@ -61,10 +45,6 @@ def unsafe_remove_auto_functionalized_pass(
                 # If the result of getitem was used in an output node, update the output spec with the correct name
                 adusted_index = user.args[1] - len(func._schema.returns)
                 original_arg = original_kwargs[mutable_args_names[adusted_index]]
-                for spec in output_specs:
-                    if spec.arg.name == user.name:
-                        spec.arg.name = original_arg.name  # pyre-ignore
-                        break
 
                 # This is a little fragile/implementation dependent, but the order of the mutable args is the same as the order
                 # of the getitem calls following the HOP.
@@ -80,14 +60,29 @@ def unsafe_remove_auto_functionalized_pass(
                 if user.args[1] == 0:
                     user.replace_all_uses_with(new_node)
 
-                    # Same case as above, update the output spec if getitem result used in an output node
-                    for spec in output_specs:
-                        if spec.arg.name == user.name:
-                            spec.arg.name = new_node.name
-                            break
-
         new_node.meta["val"] = node.meta["val"][: len(func._schema.returns)]
         ep.graph.erase_node(node)
 
     ep.graph.eliminate_dead_code()
+
+
+def unsafe_remove_auto_functionalized_pass(
+    ep: ExportedProgram,
+) -> ExportedProgram:
+    """
+    This pass removes an instances of the higher order op 'auto_functionalized',
+    and modifies the calling EP inplace to have the original mutator op.
+    This pass doesn't perform safety checks to make sure that this inplace mutation is safe.
+    """
+    auto_functionalize_nodes: List[torch.fx.Node] = []
+    for module in ep.graph_module.modules():
+        if not isinstance(module, torch.fx.GraphModule):
+            continue
+        for node in ep.graph.nodes:
+            if node.op == "call_function" and node.target is auto_functionalized:
+                auto_functionalize_nodes.append(node)
+
+    with ep.graph_module._set_replace_hook(ep.graph_signature.get_replace_hook()):
+        _remove_auto_functionalization_from_graph_helper(ep, auto_functionalize_nodes)
+
     return ep


### PR DESCRIPTION
Added handling for updating the output_spec in the graph signature if the the result of a with_effects call is an output.