### PR TITLE
[Dynamo][2/N] Fix clang-tidy warnings in torch/csrc/dynamo/*

### DIFF
--- a/torch/csrc/dynamo/cache_entry.h
+++ b/torch/csrc/dynamo/cache_entry.h
@@ -8,8 +8,6 @@
 #include <torch/csrc/utils/pybind.h>
 #include <list>
 
-namespace py = pybind11;
-
 extern "C" {
 
 #endif

--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -171,7 +171,7 @@ struct AutogradCompilerCall {
         default_dyn_type, s.guard_int(__FILE__, __LINE__));
   }
 
-  int emplace_hook(c10::SafePyObject&& fn) {
+  size_t emplace_hook(c10::SafePyObject&& fn) {
     hooks.emplace_back(std::move(fn));
     return hooks.size() - 1;
   }
@@ -418,35 +418,35 @@ class CompiledNodeArgs {
         typeid(*node), _specialization_key, _specialization_key_size);
   }
 
-  int add_backward(c10::SafePyObject&& obj) {
+  size_t add_backward(c10::SafePyObject&& obj) {
     return _compiler.emplace_hook(std::move(obj));
   }
 
-  int add_backward_state(c10::SafePyObject&& obj) {
+  size_t add_backward_state(c10::SafePyObject&& obj) {
     return _compiler.emplace_hook(std::move(obj));
   }
 
   void add_tensor_pre_hook(c10::SafePyObject&& obj, int index) {
     auto fn_id = _compiler.emplace_hook(std::move(obj));
-    collect_size(static_cast<size_t>(fn_id));
+    collect_size(fn_id);
     _node_call.tensor_pre_hooks.emplace_back(fn_id, index);
   }
 
   void add_pre_hook(c10::SafePyObject&& obj) {
     auto fn_id = _compiler.emplace_hook(std::move(obj));
-    collect_size(static_cast<size_t>(fn_id));
+    collect_size(fn_id);
     _node_call.pre_hooks.emplace_back(fn_id);
   }
 
   void add_post_hook(c10::SafePyObject&& obj) {
     auto fn_id = _compiler.emplace_hook(std::move(obj));
-    collect_size(static_cast<size_t>(fn_id));
+    collect_size(fn_id);
     _node_call.post_hooks.emplace_back(fn_id);
   }
 
   void add_post_acc_grad_hook(c10::SafePyObject&& obj) {
     auto fn_id = _compiler.emplace_hook(std::move(obj));
-    collect_size(static_cast<size_t>(fn_id));
+    collect_size(fn_id);
     _node_call.post_acc_grad_hooks.emplace_back(fn_id);
   }
 

--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -268,9 +268,9 @@ class CompiledNodeArgs {
     } else if (iv.isGenericDict()) {
       c10::Dict<at::IValue, at::IValue> ordered_dict = iv.toGenericDict();
       collect_size(ordered_dict.size());
-      for (auto it = ordered_dict.begin(); it != ordered_dict.end(); it++) {
-        collect(it->key());
-        collect(it->value());
+      for (auto it : ordered_dict) {
+        collect(it.key());
+        collect(it.value());
       }
     } else {
       try {

--- a/torch/csrc/dynamo/guards.h
+++ b/torch/csrc/dynamo/guards.h
@@ -2,7 +2,6 @@
 #include <torch/csrc/python_headers.h>
 #include <torch/csrc/utils/pybind.h>
 
-namespace py = pybind11;
 
 PyObject* torch_c_dynamo_guards_init();
 

--- a/torch/csrc/dynamo/guards.h
+++ b/torch/csrc/dynamo/guards.h
@@ -2,7 +2,6 @@
 #include <torch/csrc/python_headers.h>
 #include <torch/csrc/utils/pybind.h>
 
-
 PyObject* torch_c_dynamo_guards_init();
 
 // interfaces for extra_state and eval_frame.c because RootGuardManager class is

--- a/torch/csrc/dynamo/python_compiled_autograd.cpp
+++ b/torch/csrc/dynamo/python_compiled_autograd.cpp
@@ -112,7 +112,7 @@ struct CacheNode {
     return next.empty() && !compiled_fn;
   }
 
-  CacheNode() : compiled_fn(nullptr) {}
+  CacheNode() : compiled_fn(nullptr) = default;
   ~CacheNode() {
     if (!Py_IsInitialized()) {
       compiled_fn.release(); // leak on shutdown

--- a/torch/csrc/dynamo/python_compiled_autograd.cpp
+++ b/torch/csrc/dynamo/python_compiled_autograd.cpp
@@ -71,6 +71,7 @@ static PyObject* check(PyObject* pyresult) {
     // see https://github.com/pytorch/pytorch/pull/34845
     python_error err;
     err.persist();
+    // NOLINTNEXTLINE(misc-throw-by-value-catch-by-reference)
     throw err;
   }
   return pyresult;
@@ -112,7 +113,7 @@ struct CacheNode {
     return next.empty() && !compiled_fn;
   }
 
-  CacheNode() : compiled_fn(nullptr) = default;
+  CacheNode() : compiled_fn(nullptr) {}
   ~CacheNode() {
     if (!Py_IsInitialized()) {
       compiled_fn.release(); // leak on shutdown
@@ -311,7 +312,9 @@ CacheNode* _compiled_autograd_impl(
   AutogradCompilerCall compiler_call;
 
   for (const auto i : c10::irange(output_edges.size())) {
-    compiler_call.node_calls.lookup(output_edges[i].function)
+    compiler_call.node_calls
+        .lookup(output_edges[i].function)
+        // NOLINTNEXTLINE(*-narrowing-conversions)
         .mark_output(output_edges[i].input_nr, i);
   }
   const bool check_exec_info = !graph_task.exec_info_.empty();
@@ -510,7 +513,7 @@ variable_list compiled_autograd(
 
 static PyObject* set_autograd_compiler(PyObject* dummy, PyObject* args) {
   HANDLE_TH_ERRORS;
-  PyObject* obj;
+  PyObject* obj = nullptr;
   if (!PyArg_ParseTuple(args, "O", &obj)) {
     return nullptr;
   }


### PR DESCRIPTION
This PR continues to clean clang-tidy warnings in torch/csrc/dynamo/*, following #122259

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang