### PR TITLE
[AOTI] Disable stack allocation when there is a fallback op

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -1695,6 +1695,8 @@ class CppWrapperCpu(WrapperCodeGen):
         raw_args=None,
         outputs=None,
     ):
+        # No stack allocation when there is a fallback op
+        self.allow_stack_allocation = False
         if config.is_fbcode():
             assert op_overload is not None
             assert raw_args is not None


### PR DESCRIPTION
Summary: Stack allocation is disabled when there is an aten fallback op, see https://github.com/pytorch/pytorch/blob/c84f81b395fff969bbd2f784efad8ab1a8aa52de/torch/_inductor/codegen/cpp_wrapper_cpu.py#L974. But we need to do the same where is a custom op fallback.

Test Plan: CI

Reviewed By: mikekgfb

Differential Revision: D55149369




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @chauhang