### PR TITLE
[Quant] [Inductor] Enable the Inductor Lowering of QConv2d post op HardSwish with int8-mix-bf16

### DIFF
--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -646,6 +646,24 @@ class TestPatternMatcher(TestPatternMatcherBase):
         self._qconv2d_unary_cpu_test_helper(unary_op=torch.nn.Hardswish())
 
     @skipIfNoDynamoSupport
+    @skipIfNoONEDNNBF16
+    @skipIfNoONEDNN
+    @skipIfRocm
+    def test_qconv2d_hardswish_int8_mixed_bf16_cpu(self):
+        r"""
+        This testcase will quantize Conv2d->Hardswish pattern.
+        Match.nodes:
+            [qconv2d_pointwise_default_1, convert_element_type_5, add_1, clamp_min_1,
+             clamp_max_1, mul_2, div, mul_3, round_2, add_2, clamp_min_2, clamp_max_2, convert_element_type_8]
+            [qconv2d_pointwise_default, convert_element_type_13, add_3, clamp_min_3, clamp_max_3, mul_5, div_1]
+        """
+        self._qconv2d_unary_cpu_test_helper(
+            unary_op=torch.nn.Hardswish(),
+            int8_mixed_bf16=True,
+            qconv2d_unary_matcher_nodes=20,
+        )
+
+    @skipIfNoDynamoSupport
     @skipIfNoONEDNN
     @skipIfRocm
     def test_qconv2d_silu_cpu(self):

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -227,29 +227,10 @@ def generate_pattern_with_unary(computation_call, unary_post_op):
                 CallFunction(aten.clamp_min, computation_call, KeywordArg("min_value")),
                 KeywordArg("max_value"),
             )
-        if unary_post_op == aten.hardswish.default:
-            return CallFunction(
-                aten.div,
-                CallFunction(
-                    aten.mul,
-                    computation_call,
-                    CallFunction(
-                        aten.clamp_max,
-                        CallFunction(
-                            aten.clamp_min,
-                            CallFunction(aten.add, computation_call, 3),
-                            0,
-                        ),
-                        6,
-                    ),
-                ),
-                6,
-            )
-        else:
-            return CallFunction(
-                unary_post_op,
-                computation_call,
-            )
+        return CallFunction(
+            unary_post_op,
+            computation_call,
+        )
     return computation_call
 
 
@@ -620,6 +601,7 @@ def _register_quantization_unary_fusion():
     from .mkldnn_fusion import (
         _gelu_fusion_1 as _gelu_fusion_erf,
         _gelu_fusion_2 as _gelu_fusion_tanh,
+        _hardswish_fusion,
         _silu_fusion,
     )
 
@@ -653,10 +635,13 @@ def _register_quantization_unary_fusion():
                 dtype=original_pattern_output_dtype,
             ),
             UnaryAttr("hardswish", [], ""): generate_pattern_with_output_quant(
-                generate_pattern_with_unary(
-                    get_dequantize_qconv_pt2e_pattern(2), aten.hardswish.default
+                _unary_fusion_pattern(
+                    _hardswish_fusion,
+                    get_dequantize_qconv_pt2e_pattern(1 if is_bf16 else 2),
+                    2,
+                    is_bf16,
                 ),
-                dtype=original_pattern_output_dtype,
+                dtype=torch.float32,
             ),
             UnaryAttr("swish", [], ""): generate_pattern_with_output_quant(
                 _unary_fusion_pattern(
@@ -688,8 +673,11 @@ def _register_quantization_unary_fusion():
             UnaryAttr("hardtanh", [], ""): generate_pattern_with_unary(
                 get_dequantize_qconv_pt2e_pattern(1), aten.hardtanh.default
             ),
-            UnaryAttr("hardswish", [], ""): generate_pattern_with_unary(
-                get_dequantize_qconv_pt2e_pattern(2), aten.hardswish.default
+            UnaryAttr("hardswish", [], ""): _unary_fusion_pattern(
+                _hardswish_fusion,
+                get_dequantize_qconv_pt2e_pattern(1 if is_bf16 else 2),
+                2,
+                is_bf16,
             ),
             UnaryAttr("swish", [], ""): _unary_fusion_pattern(
                 _silu_fusion,


### PR DESCRIPTION
**Summary**
Enable the fusion pattern of `QConv2d -> hardswish` lowering for int8-mixed-bf16 case.

**Test Plan**
```
python -m pytest test_mkldnn_pattern_matcher.py -k test_qconv2d_hardswish_int8_mixed_bf16_cpu
```


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #122374
* __->__ #122373
* #122268
* #122267
* #122266



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang