### PR TITLE
[Quant] [Inductor] Enable the Inductor Lowering of QConv2d post op HardTanh with int8-mix-bf16

### DIFF
--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -637,6 +637,24 @@ class TestPatternMatcher(TestPatternMatcherBase):
         self._qconv2d_unary_cpu_test_helper(unary_op=torch.nn.Hardtanh())
 
     @skipIfNoDynamoSupport
+    @skipIfNoONEDNNBF16
+    @skipIfNoONEDNN
+    @skipIfRocm
+    def test_qconv2d_hardtanh_int8_mixed_bf16_cpu(self):
+        r"""
+        This testcase will quantize Conv2d->Hardtanh pattern.
+        Match.nodes:
+            [qconv2d_pointwise_default_1, convert_element_type_5, add_1, clamp_min_1,
+             clamp_max_1, mul_2, div, mul_3, round_2, add_2, clamp_min_2, clamp_max_2, convert_element_type_8]
+            [qconv2d_pointwise_default, convert_element_type_13, add_3, clamp_min_3, clamp_max_3, mul_5, div_1]
+        """
+        self._qconv2d_unary_cpu_test_helper(
+            unary_op=torch.nn.Hardtanh(),
+            int8_mixed_bf16=True,
+            qconv2d_unary_matcher_nodes=20,
+        )
+
+    @skipIfNoDynamoSupport
     @skipIfNoONEDNN
     @skipIfRocm
     def test_qconv2d_hardswish_cpu(self):

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -644,14 +644,14 @@ class TestPatternMatcher(TestPatternMatcherBase):
         r"""
         This testcase will quantize Conv2d->Hardtanh pattern.
         Match.nodes:
-            [qconv2d_pointwise_default_1, convert_element_type_5, add_1, clamp_min_1,
-             clamp_max_1, mul_2, div, mul_3, round_2, add_2, clamp_min_2, clamp_max_2, convert_element_type_8]
-            [qconv2d_pointwise_default, convert_element_type_13, add_3, clamp_min_3, clamp_max_3, mul_5, div_1]
+            [qconv2d_pointwise_default_1, convert_element_type_5, clamp_min_1, clamp_max_1, mul_2, round_2, add_1, clamp_min_2,
+             clamp_max_1, mul_2, round_2, add_1, clamp_min_2, clamp_max_2, convert_element_type_8
+            [qconv2d_pointwise_default, convert_element_type_13, clamp_min_3, clamp_max_3]
         """
         self._qconv2d_unary_cpu_test_helper(
             unary_op=torch.nn.Hardtanh(),
             int8_mixed_bf16=True,
-            qconv2d_unary_matcher_nodes=20,
+            qconv2d_unary_matcher_nodes=14,
         )
 
     @skipIfNoDynamoSupport

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -228,7 +228,9 @@ def generate_pattern_with_unary(computation_call, unary_post_op):
     return computation_call
 
 
-def generate_pattern_with_output_quant(computation_call, dtype=torch.float32):
+def generate_pattern_with_output_quant(
+    computation_call, has_to_fp32_before_quant=False
+):
     """
     quantize output:
         output = round(output * o_inv_scale)
@@ -237,7 +239,6 @@ def generate_pattern_with_output_quant(computation_call, dtype=torch.float32):
         output = clamp_max(output, 127)
         output = output.to(uint8)
     """
-    assert dtype in [torch.float32, torch.bfloat16]
     quantized_op_output_pattern_pt2e = CallFunction(
         prims.convert_element_type.default,
         CallFunction(
@@ -253,7 +254,7 @@ def generate_pattern_with_output_quant(computation_call, dtype=torch.float32):
                             _may_generate_pattern_with_dtype_convert(
                                 computation_call,
                                 KeywordArg("autocast_output_quant_dtype"),
-                                dtype == torch.bfloat16,
+                                has_to_fp32_before_quant,
                             ),
                             KeywordArg("o_inv_scale"),
                         ),
@@ -615,13 +616,13 @@ def _register_quantization_unary_fusion():
         conv_unary_replace_patterns = {
             UnaryAttr("none", [], ""): generate_pattern_with_output_quant(
                 get_dequantize_qconv_pt2e_pattern(1),
-                dtype=original_pattern_output_dtype,
+                has_to_fp32_before_quant=is_bf16,
             ),
             UnaryAttr("relu", [], ""): generate_pattern_with_output_quant(
                 generate_pattern_with_unary(
                     get_dequantize_qconv_pt2e_pattern(1), aten.relu.default
                 ),
-                dtype=original_pattern_output_dtype,
+                has_to_fp32_before_quant=is_bf16,
             ),
             UnaryAttr("hardtanh", [], ""): generate_pattern_with_output_quant(
                 _unary_fusion_pattern(
@@ -630,7 +631,7 @@ def _register_quantization_unary_fusion():
                     1,
                     is_bf16,
                 ),
-                dtype=torch.float32,
+                has_to_fp32_before_quant=False,
             ),
             UnaryAttr("hardswish", [], ""): generate_pattern_with_output_quant(
                 _unary_fusion_pattern(
@@ -639,7 +640,7 @@ def _register_quantization_unary_fusion():
                     2,
                     is_bf16,
                 ),
-                dtype=torch.float32,
+                has_to_fp32_before_quant=False,
             ),
             UnaryAttr("swish", [], ""): generate_pattern_with_output_quant(
                 _unary_fusion_pattern(
@@ -648,7 +649,7 @@ def _register_quantization_unary_fusion():
                     2,
                     is_bf16,
                 ),
-                dtype=torch.float32,
+                has_to_fp32_before_quant=False,
             ),
         }
 
@@ -706,11 +707,11 @@ def _register_quantization_unary_fusion():
             linear_unary_replace_patterns = {
                 UnaryAttr("none", [], ""): generate_pattern_with_output_quant(
                     qlinear_pattern,
-                    dtype=original_pattern_output_dtype,
+                    has_to_fp32_before_quant=is_bf16,
                 ),
                 UnaryAttr("relu", [], ""): generate_pattern_with_output_quant(
                     generate_pattern_with_unary(qlinear_pattern, aten.relu.default),
-                    dtype=original_pattern_output_dtype,
+                    has_to_fp32_before_quant=is_bf16,
                 ),
                 UnaryAttr("gelu", [], "none"): generate_pattern_with_output_quant(
                     _unary_fusion_pattern(
@@ -721,7 +722,7 @@ def _register_quantization_unary_fusion():
                         2,
                         is_bf16,
                     ),
-                    dtype=torch.float32,
+                    has_to_fp32_before_quant=False,
                 ),
                 UnaryAttr("gelu", [], "tanh"): generate_pattern_with_output_quant(
                     _unary_fusion_pattern(
@@ -732,7 +733,7 @@ def _register_quantization_unary_fusion():
                         4,
                         is_bf16,
                     ),
-                    dtype=torch.float32,
+                    has_to_fp32_before_quant=False,
                 ),
             }
 
@@ -808,9 +809,7 @@ def _register_quantization_binary_fusion():
                     dequantize_accum_pattern,
                     int8_mixed_bf16_with_inplace_add,
                 ),
-                dtype=torch.bfloat16
-                if int8_mixed_bf16_with_inplace_add
-                else torch.float32,
+                has_to_fp32_before_quant=int8_mixed_bf16_with_inplace_add,
             ),
             BinaryUnaryAttr(
                 "sum", 1.0, "relu", [], ""
@@ -824,9 +823,7 @@ def _register_quantization_binary_fusion():
                     ),
                     aten.relu.default,
                 ),
-                dtype=torch.bfloat16
-                if int8_mixed_bf16_with_inplace_add
-                else torch.float32,
+                has_to_fp32_before_quant=int8_mixed_bf16_with_inplace_add,
             ),
         }
 


### PR DESCRIPTION
**Summary**
Enable the fusion pattern of `QConv2d -> hardtanh` lowering for int8-mixed-bf16 case.

**Test Plan**
```
python -m pytest test_mkldnn_pattern_matcher.py -k test_qconv2d_hardtanh_int8_mixed_bf16_cpu
```


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122374
* #122373
* #122268
* #122267
* #122266



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang