### PR TITLE
[inductor] Support non-Tensor predicate in torch.cond

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -907,6 +907,33 @@ class AOTInductorTestsTemplate:
             dynamic_shapes=dynamic_shapes,
         )
 
+    @skipIfRocm
+    @common_utils.parametrize("dynamic", [False, True])
+    def test_cond_non_tensor_predicates(self, dynamic):
+        inputs1 = (
+            torch.randn((10, 20), device=self.device),
+            torch.randn((15, 20), device=self.device),
+        )
+        inputs2 = (
+            torch.randn((10, 20), device=self.device),
+            torch.randn((5, 20), device=self.device),
+        )
+        inputs = (inputs1,)
+        dynamic_shapes = None
+        if dynamic:
+            inputs = (inputs1, inputs2)
+            dim0_a = Dim("s0", min=2, max=1024)
+            dim0_b = Dim("s1", min=2, max=1024)
+            dynamic_shapes = {
+                "a": {0: dim0_a, 1: None},
+                "b": {0: dim0_b, 1: None},
+            }
+        self.check_model_with_multiple_inputs(
+            CondModels.WithNonTensorPredicate(),
+            inputs,
+            dynamic_shapes=dynamic_shapes,
+        )
+
     def test_zero_grid_with_backed_symbols(self):
         class Repro(torch.nn.Module):
             def __init__(self):
@@ -2036,6 +2063,10 @@ CPU_TEST_FAILURES = {
     "test_zero_grid_with_backed_symbols": fail_with_and_without_stack_allocation(
         is_skip=True
     ),
+    "test_cond_non_tensor_predicates_dynamic_False": fail_stack_allocation(
+        is_skip=True
+    ),
+    "test_cond_non_tensor_predicates_dynamic_True": fail_stack_allocation(is_skip=True),
 }
 
 CUDA_TEST_FAILURES = {

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -496,6 +496,12 @@ class CppPrinter(ExprPrinter):
             )
         return f"static_cast<double>(std::nearbyint(1e{ndigits} * {self.paren(self._print(number))}) * 1e{-ndigits})"
 
+    def _print_BooleanTrue(self, expr):
+        return "true"
+
+    def _print_BooleanFalse(self, expr):
+        return "false"
+
 
 # A function to print, useful for printing sympy symbols.
 cexpr = CppPrinter().doprint

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1513,8 +1513,13 @@ class WrapperCodeGen(CodeGen):
         outer_inputs = [buf.codegen_reference() for buf in conditional.operands]
         outer_outputs = [f"{name}[{i}]" for i in range(len(conditional.outputs))]
 
+        predicate = conditional.predicate.codegen_reference()
+        if not isinstance(conditional.predicate, ir.ShapeAsConstantBuffer):
+            # move the Tensor predicate to host
+            predicate = f"{predicate}.item()"
+
         self.writeline(f"{name} = [None] * {len(conditional.outputs)}")
-        self.writeline(f"if {conditional.predicate.codegen_reference()}.item():")
+        self.writeline(f"if {predicate}:")
         self.writeline(EnterSubgraphLine(self, conditional.true_subgraph.graph))
         self.codegen_subgraph(conditional.true_subgraph, outer_inputs, outer_outputs)
         self.writeline(ExitSubgraphLine(self))

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7026,7 +7026,7 @@ class Subgraph(IRNode):
 
 @dataclasses.dataclass
 class Conditional(ExternKernel):
-    predicate: Optional[DynamicScalar] = None
+    predicate: Optional[IRNode] = None
     operands: Optional[List[TensorBox]] = None
     true_subgraph: Optional[Subgraph] = None
     false_subgraph: Optional[Subgraph] = None
@@ -7034,7 +7034,7 @@ class Conditional(ExternKernel):
 
     def __init__(
         self,
-        predicate: DynamicScalar,
+        predicate: IRNode,
         operands: List[TensorBox],
         true_subgraph: Subgraph,
         false_subgraph: Subgraph,
@@ -7045,10 +7045,15 @@ class Conditional(ExternKernel):
         self.true_subgraph = true_subgraph
         self.false_subgraph = false_subgraph
 
+        inputs = []
+        if not isinstance(predicate, ShapeAsConstantBuffer):
+            inputs.append(predicate)
+        inputs.extend(operands)
+
         super().__init__(
             name=None,
             layout=layout,  # type: ignore[arg-type]
-            inputs=[predicate, *operands],  # type: ignore[list-item]
+            inputs=inputs,  # type: ignore[list-item]
         )
 
         self.name = V.graph.register_buffer(self)
@@ -7105,13 +7110,22 @@ class Conditional(ExternKernel):
             assert to.get_dtype() == fo.get_dtype(), (i, to, fo)
             assert to.get_layout().offset == fo.get_layout().offset, (i, to, fo)
 
+        if not isinstance(predicate, ShapeAsConstantBuffer):
+            # use predicate device for consistent codegen-ing
+            device = predicate.get_device()
+        else:
+            # predicate is not a Tensor: use first operand's device
+            assert (
+                len(operands) > 0
+            ), "When predicate is not a Tensor, there must be at least one operand in torch.cond."
+            device = operands[0].get_device()
+
         conditional = Conditional(
             predicate=predicate,
             operands=operands,
             true_subgraph=true_fn,
             false_subgraph=false_fn,
-            # use predicate device for consistent codegen-ing
-            layout=MultiOutputLayout(predicate.get_device()),
+            layout=MultiOutputLayout(device),
         )
 
         outputs = [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122378

Summary: Previously, we only supported torch.Tensor boolean scalar predicate in `torch.cond` in Inductor. This PR adds support for SymBool and Python bool predicate, to match the `torch.cond` [sematics](https://pytorch.org/docs/stable/generated/torch.cond.html) in Dynamo / Export.

Test Plan:

```
$ python test/inductor/test_control_flow.py
...
----------------------------------------------------------------------
Ran 34 tests in 56.980s

OK

$ python test/inductor/test_aot_inductor.py -k test_cond
...
----------------------------------------------------------------------
Ran 54 tests in 460.093s

OK (skipped=4)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang