### PR TITLE
fix cudnn attention check

### DIFF
--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -329,7 +329,6 @@ auto build_graph_and_tensors(
     // scaled_dot_product_flash_attention_options.set_alibi_mask(true);
   }
 
-<<<<<<< HEAD
   auto seq_q = mha_graph->tensor(fe::graph::Tensor_attributes()
                                      .set_name("Seq_q")
                                      .set_dim({b, 1, 1, 1})
@@ -340,18 +339,6 @@ auto build_graph_and_tensors(
                                       .set_dim({b, 1, 1, 1})
                                       .set_stride({1, 1, 1, 1})
                                       .set_data_type(fe::DataType_t::INT32));
-=======
-  // auto seq_q = mha_graph->tensor(fe::graph::Tensor_attributes()
-  //                                    .set_name("seq_q")
-  //                                    .set_dim({b, 1, 1, 1})
-  //                                    .set_stride({1, 1, 1, 1})
-  //                                    .set_data_type(fe::DataType_t::INT32));
-  // auto seq_kv = mha_graph->tensor(fe::graph::Tensor_attributes()
-  //                                     .set_name("seq_kv")
-  //                                     .set_dim({b, 1, 1, 1})
-  //                                     .set_stride({1, 1, 1, 1})
-  //                                     .set_data_type(fe::DataType_t::INT32));
->>>>>>> cced3401825 (fix cudnn attention check)
 
   // if (cudnnGetVersion() >= 8903) {
   //     scaled_dot_product_flash_attention_options.set_bias(bias)

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -329,6 +329,7 @@ auto build_graph_and_tensors(
     // scaled_dot_product_flash_attention_options.set_alibi_mask(true);
   }
 
+<<<<<<< HEAD
   auto seq_q = mha_graph->tensor(fe::graph::Tensor_attributes()
                                      .set_name("Seq_q")
                                      .set_dim({b, 1, 1, 1})
@@ -339,6 +340,18 @@ auto build_graph_and_tensors(
                                       .set_dim({b, 1, 1, 1})
                                       .set_stride({1, 1, 1, 1})
                                       .set_data_type(fe::DataType_t::INT32));
+=======
+  // auto seq_q = mha_graph->tensor(fe::graph::Tensor_attributes()
+  //                                    .set_name("seq_q")
+  //                                    .set_dim({b, 1, 1, 1})
+  //                                    .set_stride({1, 1, 1, 1})
+  //                                    .set_data_type(fe::DataType_t::INT32));
+  // auto seq_kv = mha_graph->tensor(fe::graph::Tensor_attributes()
+  //                                     .set_name("seq_kv")
+  //                                     .set_dim({b, 1, 1, 1})
+  //                                     .set_stride({1, 1, 1, 1})
+  //                                     .set_data_type(fe::DataType_t::INT32));
+>>>>>>> cced3401825 (fix cudnn attention check)
 
   // if (cudnnGetVersion() >= 8903) {
   //     scaled_dot_product_flash_attention_options.set_bias(bias)

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -306,14 +306,14 @@ bool check_cudnn_tensor_shapes(sdp_params const& params, bool debug) {
   const auto head_dim = params.query.sym_size(3);
   long cudnn_version = at::detail::getCUDAHooks().versionCuDNN();
   if (cudnn_version >= 90000) {
-    if (head_dim % 8 != 0 or head_dim > 256) {
+    if (head_dim % 8 != 0 || head_dim > 256) {
       if (debug) {
         TORCH_WARN("head_dim should be a multiple of 8 and no more than 256");
       }
       return false;
     }
   } else {
-    if (head_dim % 8 != 0 or head_dim > 128) {
+    if (head_dim % 8 != 0 || head_dim > 128) {
       if (debug) {
         TORCH_WARN("head_dim should be a multiple of 8 and no more than 128");
       }
@@ -339,7 +339,7 @@ bool check_cudnn_tensor_shapes(sdp_params const& params, bool debug) {
       }
       return false;
     }
-    if ((s_q % 64 != 0 or s_k % 64 != 0) and params.dropout != 0.0) {
+    if ((s_q % 64 != 0 || s_k % 64 != 0) and params.dropout != 0.0) {
       if (debug) {
         TORCH_WARN(
             "s_q not a multiple of 64 with padding/dropout is not supported with cudnn version 9.0.0");
@@ -347,7 +347,7 @@ bool check_cudnn_tensor_shapes(sdp_params const& params, bool debug) {
       return false;
     }
   }
-  if (s_k % 64 != 0 and cudnn_version < 8906) {
+  if (s_k % 64 != 0 && cudnn_version < 8906) {
     if (debug) {
       TORCH_WARN("not-multiple-of-64 seq_kv is not supported below 8.9.6");
     }

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -326,7 +326,7 @@ bool check_cudnn_tensor_shapes(sdp_params const& params, bool debug) {
     }
     return false;
   }
-  if (params.dropout != 0.0 and cudnn_version < 8906) {
+  if (params.dropout != 0.0 && cudnn_version < 8906) {
     if (debug) {
       TORCH_WARN("Dropout reference is only supported on 8.9.6 onwards.");
     }
@@ -339,7 +339,7 @@ bool check_cudnn_tensor_shapes(sdp_params const& params, bool debug) {
       }
       return false;
     }
-    if ((s_q % 64 != 0 || s_k % 64 != 0) and params.dropout != 0.0) {
+    if ((s_q % 64 != 0 || s_k % 64 != 0) && params.dropout != 0.0) {
       if (debug) {
         TORCH_WARN(
             "s_q not a multiple of 64 with padding/dropout is not supported with cudnn version 9.0.0");

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -305,9 +305,9 @@ bool check_cudnn_tensor_shapes(sdp_params const& params, bool debug) {
   const auto s_k = params.key.sym_size(2);
   const auto head_dim = params.query.sym_size(3);
   long cudnn_version = at::detail::getCUDAHooks().versionCuDNN();
-  if (head_dim % 8 != 0 or head_dim > 256) {
+  if (head_dim % 8 != 0 or head_dim > 128) {
     if (debug) {
-      TORCH_WARN("head_dim should be a multiple of 8 and no more than 256");
+      TORCH_WARN("head_dim should be a multiple of 8 and no more than 128");
     }
     return false;
   }

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -603,6 +603,7 @@ SDPBackend select_sdp_backend(sdp_params const& kernel_params) {
     switch (backend) {
       case SDPBackend::cudnn_attention:
         if (sdp::can_use_cudnn_attention(kernel_params, print_debug)) {
+              TORCH_WARN("USING CUDNN SDPA");
               return SDPBackend::cudnn_attention;
         }
         break;

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -603,7 +603,6 @@ SDPBackend select_sdp_backend(sdp_params const& kernel_params) {
     switch (backend) {
       case SDPBackend::cudnn_attention:
         if (sdp::can_use_cudnn_attention(kernel_params, print_debug)) {
-              TORCH_WARN("USING CUDNN SDPA");
               return SDPBackend::cudnn_attention;
         }
         break;

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -305,7 +305,7 @@ bool check_cudnn_tensor_shapes(sdp_params const& params, bool debug) {
       query_lengths{params.query.sym_size(2)},
       head_dim{params.query.sym_size(3)};
   const bool packed_qkv_ok = query_lengths % 64 == 0 && query_lengths <= 512 && head_dim % 64 == 0;
-  const bool qkv_ok = query_lengths % 64 == 0 && head_dim <= 128 && head_dim % 8 == 0;
+  const bool qkv_ok = head_dim <= 128 && head_dim % 8 == 0;
   if (!packed_qkv_ok && !qkv_ok) {
     if (debug) {
       if (!packed_qkv_ok) {
@@ -318,9 +318,7 @@ bool check_cudnn_tensor_shapes(sdp_params const& params, bool debug) {
       }
       if (!qkv_ok) {
         TORCH_WARN(
-          "CuDNN requires sequence length to be divisible by 64 and head dim to be less than or equal to 128 and divisible by 8 for unpacked QKV. Got sequence length: ",
-          query_lengths,
-          ", head dim: ",
+          "CuDNN requires head dim to be less than or equal to 128 and divisible by 8 for unpacked QKV. Got head dim: ",
           head_dim,
           ".");
       }

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -305,11 +305,20 @@ bool check_cudnn_tensor_shapes(sdp_params const& params, bool debug) {
   const auto s_k = params.key.sym_size(2);
   const auto head_dim = params.query.sym_size(3);
   long cudnn_version = at::detail::getCUDAHooks().versionCuDNN();
-  if (head_dim % 8 != 0 or head_dim > 128) {
-    if (debug) {
-      TORCH_WARN("head_dim should be a multiple of 8 and no more than 128");
+  if (cudnn_version >= 90000) {
+    if (head_dim % 8 != 0 or head_dim > 256) {
+      if (debug) {
+        TORCH_WARN("head_dim should be a multiple of 8 and no more than 256");
+      }
+      return false;
     }
-    return false;
+  } else {
+    if (head_dim % 8 != 0 or head_dim > 128) {
+      if (debug) {
+        TORCH_WARN("head_dim should be a multiple of 8 and no more than 128");
+      }
+      return false;
+    }
   }
   if (cudnn_version < 8903) {
     if (debug) {


### PR DESCRIPTION
For CUDNN attention, besides packed QKV layout with limited support of sequence length (seq_len <= 512) and head dim requirements. Also supporting a more generic "arbitrary sequence length with flash attention" as stated in `Transformer Engine`: https://github.com/NVIDIA/TransformerEngine/blob/8e672ff0758033c348e263dbcd6a4b3578c01161/transformer_engine/common/fused_attn/fused_attn.cpp#L126

More about "fused flash attention" in CUDNN graph api: https://docs.nvidia.com/deeplearning/cudnn/developer/graph-api.html#fused-flash-attention-fprop
