### PR TITLE
Handle JIT test failure when the GPU is newer than the CUDA compiler or vice versa

### DIFF
--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -245,6 +245,12 @@ class TestCppExtensionJIT(common.TestCase):
                     pass
                 else:
                     raise
+            try:
+                torch.cuda.synchronize()
+            except RuntimeError:
+                # Ignore any error, e.g. unsupported PTX code on current device
+                # to avoid errors from here leaking into other tests
+                pass
 
     @unittest.skipIf(not TEST_CUDNN, "CuDNN not found")
     @unittest.skipIf(TEST_ROCM, "Not supported on ROCm")

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -240,7 +240,7 @@ class TestCppExtensionJIT(common.TestCase):
                 self._run_jit_cuda_archflags(flags, expected)
             except RuntimeError as e:
                 # Using the device default (empty flags) may fail if the device is newer than the CUDA compiler
-                # This raises a RuntimeError with a specific message which we explictely ignore here
+                # This raises a RuntimeError with a specific message which we explicitly ignore here
                 if not flags and "Error building" in str(e):
                     pass
                 else:


### PR DESCRIPTION
The test may fail because it either uses target flags newer than the GPU resulting in failures loading the compiled binary or targetting a GPU for which CUDA has no support yet/anymore