### PR TITLE
Skip ao_sparsity TestComposability for missing FBGEMM

### DIFF
--- a/test/ao/sparsity/test_composability.py
+++ b/test/ao/sparsity/test_composability.py
@@ -14,6 +14,7 @@ from torch.ao.quantization.quantize_fx import (
     prepare_fx,
     prepare_qat_fx,
 )
+from torch.testing._internal.common_quantization import skipIfNoFBGEMM
 from torch.testing._internal.common_utils import TestCase
 
 logging.basicConfig(
@@ -70,6 +71,7 @@ def _calculate_sparsity(tensor):
 # This series of tests are to check the composability goals for sparsity and quantization. Namely
 # that performing quantization and sparsity model manipulations in various orderings
 # does not cause problems
+@skipIfNoFBGEMM
 class TestComposability(TestCase):
     # This test checks whether performing quantization prepare before sparse prepare
     # causes any issues and verifies that the correct observers are inserted and that


### PR DESCRIPTION
Those tests (from test_ao_sparsity) require FBGEMM which may not be available. So add the skip decorator.

Fixes https://github.com/pytorch/pytorch/issues/87364