### PR TITLE
triton_kernel_wrap shouldn't access FakeTensor.data_ptr

### DIFF
--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -141,7 +141,7 @@ def generate_ttir(kernel, kwargs):
             ordered_args[name] = 2
         elif isinstance(a, FakeTensor):
             with torch._C._DisableTorchDispatch():
-                ordered_args[name] = torch.empty(2, dtype=a.dtype, device=a.device)
+                ordered_args[name] = torch.empty(2, dtype=a.dtype)
         else:
             ordered_args[name] = a
 

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -140,7 +140,8 @@ def generate_ttir(kernel, kwargs):
         if isinstance(a, (torch.SymInt, torch.SymFloat, torch.SymBool)):
             ordered_args[name] = 2
         elif isinstance(a, FakeTensor):
-            ordered_args[name] = torch.empty(2, dtype=a.dtype)
+            with torch._C._DisableTorchDispatch():
+                ordered_args[name] = torch.empty(2, dtype=a.dtype, device=a.device)
         else:
             ordered_args[name] = a
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #122309
* __->__ #122418

The comment suggests that we need to replace all FakeTensors with real
tensors. `torch.empty` doesn't actually return a real Tensor because
FakeTensorMode is active!

We disable torch dispatch so that torch.empty actually returns a real Tensor.

The motivation for this PR is that we're trying to ban
FakeTensor.data_ptr (or at least warn on it) in torch.compile. See the
next PR up in the stack

Test Plan:
- Existing tests.