### PR TITLE
Fixed failing pyhpc_equation_of_state due to cpp nodes fusion with compatible ranges

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -3583,8 +3583,19 @@ class CppScheduling(BaseScheduling):
 
                 def get_indexing_ranges_exprs(node):
                     if isinstance(node, FusedSchedulerNode):
-                        assert len(node.snodes) > 0
-                        return get_indexing_ranges_exprs(node.snodes[0])
+                        assert len(node.snodes) > 0, node.snodes
+                        var_ranges = None
+                        indexing_exprs = set()
+                        for snode in node.snodes:
+                            v, exprs = get_indexing_ranges_exprs(snode)
+                            if var_ranges is None:
+                                var_ranges = v
+                            # TODO: this can be also a strong assumption that fused nodes have
+                            # the same variable and ranges
+                            assert var_ranges == v, (var_ranges, v, node.snodes)
+                            for expr in exprs:
+                                indexing_exprs.add(expr)
+                        return var_ranges, list(indexing_exprs)
                     else:
                         assert isinstance(node, SchedulerNode)
                         comp_buffer = node.node

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3228,6 +3228,7 @@ class ComputedBuffer(Buffer):
             else:
                 self.freeze_layout()
 
+    @cache_on_self
     def get_default_sizes_body(self):
         args, var_ranges = dependencies.index_vars_squeeze(
             self.data.get_pointwise_size(), self.data.get_reduction_size(), prefix="q"


### PR DESCRIPTION
Fixes #122283

Description:

PR https://github.com/pytorch/pytorch/pull/120077 introduced cpp nodes fusion with compatible ranges with an assumption that all scheduler nodes inside the fused nodes are the same, however, it appeared that snodes can have different indexing expressions. This PR fixes the incorrect assumption.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang