### PR TITLE
Prevent dup initializers when ONNXProgram.save is called many times

### DIFF
--- a/test/onnx/test_fx_to_onnx.py
+++ b/test/onnx/test_fx_to_onnx.py
@@ -478,6 +478,11 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
                 assert (
                     len(onnx.load(tmp_onnx_file.name).graph.initializer) == 2
                 ), "Initializers must be present after loading it from model_state_dict"
+                # Let's make sure consecutive `save` does not create dupes
+                onnx_program.save(tmp_onnx_file.name, model_state=model_state_dict)
+                assert (
+                    len(onnx.load(tmp_onnx_file.name).graph.initializer) == 2
+                ), "Initializers must be present after loading it from model_state_dict"
         elif checkpoint_type == "checkpoint_file":
             # Variant 2: Save ONNX proto using Model checkpoint file
             with tempfile.NamedTemporaryFile(
@@ -488,6 +493,13 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
                 torch.save(
                     Model().state_dict(), tmp_checkpoint_file.name
                 )  # Create checkpoint file for testing
+                onnx_program.save(
+                    tmp_onnx_file.name, model_state=tmp_checkpoint_file.name
+                )
+                assert (
+                    len(onnx.load(tmp_onnx_file.name).graph.initializer) == 2
+                ), "Initializers must be present after loading it from model_state_dict"
+                # Let's make sure consecutive `save` does not create dupes
                 onnx_program.save(
                     tmp_onnx_file.name, model_state=tmp_checkpoint_file.name
                 )

--- a/test/onnx/test_fx_to_onnx.py
+++ b/test/onnx/test_fx_to_onnx.py
@@ -478,7 +478,7 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
                 assert (
                     len(onnx.load(tmp_onnx_file.name).graph.initializer) == 2
                 ), "Initializers must be present after loading it from model_state_dict"
-                # Let's make sure consecutive `save` does not create dupes
+                # Let's make sure consecutive `save` calls don't create dupes
                 onnx_program.save(tmp_onnx_file.name, model_state=model_state_dict)
                 assert (
                     len(onnx.load(tmp_onnx_file.name).graph.initializer) == 2
@@ -499,7 +499,7 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
                 assert (
                     len(onnx.load(tmp_onnx_file.name).graph.initializer) == 2
                 ), "Initializers must be present after loading it from model_state_dict"
-                # Let's make sure consecutive `save` does not create dupes
+                # Let's make sure consecutive `save` calls don't create dupes
                 onnx_program.save(
                     tmp_onnx_file.name, model_state=tmp_checkpoint_file.name
                 )

--- a/torch/onnx/_internal/fx/serialization.py
+++ b/torch/onnx/_internal/fx/serialization.py
@@ -157,7 +157,7 @@ def save_model_with_external_data(
 
     initializers_to_be_deleted = {}  # Using dict because it is **ordered**
     existing_initializers = {
-        idx: k.name for idx, k in enumerate(onnx_model.graph.initializer)
+        k.name: idx for idx, k in enumerate(onnx_model.graph.initializer)
     }
     onnx_input_names = {input.name for input in onnx_model.graph.input}
     for el in torch_state_dicts:
@@ -225,7 +225,6 @@ def save_model_with_external_data(
             # Mark for deletion - a replacement will be appended next
             if name in existing_initializers:
                 initializers_to_be_deleted[existing_initializers[name]] = name
-
             tensor_proto = _create_tensor_proto_with_external_data(
                 tensor,
                 name,
@@ -237,11 +236,9 @@ def save_model_with_external_data(
             onnx_model.graph.initializer.append(tensor_proto)
     # Remove old duplicated initializers, if any. delete in desc order to not invalidate deletion indices
     initializers_to_be_deleted = dict(
-        sorted(
-            initializers_to_be_deleted.items(), key=lambda item: item[1], reverse=True
-        )
+        sorted(initializers_to_be_deleted.items(), reverse=True)
     )
-    for idx in initializers_to_be_deleted.values():
+    for idx in initializers_to_be_deleted.keys():
         del onnx_model.graph.initializer[idx]
 
     # model_location should be a pure file name such as "file_name.onnx", not "folder/file_name.onnx".

--- a/torch/onnx/_internal/fx/serialization.py
+++ b/torch/onnx/_internal/fx/serialization.py
@@ -155,6 +155,10 @@ def save_model_with_external_data(
     # FIXME: Avoid importing onnx into torch.onnx.
     import onnx
 
+    initializers_to_be_deleted = {}  # Using dict because it is **ordered**
+    existing_initializers = {
+        idx: k.name for idx, k in enumerate(onnx_model.graph.initializer)
+    }
     onnx_input_names = {input.name for input in onnx_model.graph.input}
     for el in torch_state_dicts:
         if isinstance(el, dict):
@@ -182,12 +186,8 @@ def save_model_with_external_data(
                         state_dict = torch.load(el, map_location="cpu")
                     else:
                         raise e
-        for name, tensor in state_dict.items():
-            # Fetching existing initializers in the model proto for eventual replacement (delete + add)
-            existing_initializers = {
-                k.name: idx for idx, k in enumerate(onnx_model.graph.initializer)
-            }
 
+        for name, tensor in state_dict.items():
             if rename_initializer:
                 # Basically, "transformer.attention.self.query.weight" is mapped
                 # to "transformer_attention_self_query_weight" for mimicking the
@@ -222,9 +222,9 @@ def save_model_with_external_data(
             # os.path.join(basepath, relative_tensor_file_path).
             model_input_types = {k.name: k.type for k in onnx_model.graph.input}
 
-            # Delete existing initializer before adding a replacement - otherwise there will be dupes
+            # Mark for deletion - a replacement will be appended next
             if name in existing_initializers:
-                del onnx_model.graph.initializer[existing_initializers[name]]
+                initializers_to_be_deleted[existing_initializers[name]] = name
 
             tensor_proto = _create_tensor_proto_with_external_data(
                 tensor,
@@ -235,6 +235,14 @@ def save_model_with_external_data(
             )
             # Add the tensor_proto to the ONNX model as an initializer with external data.
             onnx_model.graph.initializer.append(tensor_proto)
+    # Remove old duplicated initializers, if any. delete in desc order to not invalidate deletion indices
+    initializers_to_be_deleted = dict(
+        sorted(
+            initializers_to_be_deleted.items(), key=lambda item: item[1], reverse=True
+        )
+    )
+    for idx in initializers_to_be_deleted.values():
+        del onnx_model.graph.initializer[idx]
 
     # model_location should be a pure file name such as "file_name.onnx", not "folder/file_name.onnx".
     onnx.save(onnx_model, os.path.join(basepath, model_location))  # type: ignore[attr-defined]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122435
* #122230
* #122196

Fixes https://github.com/pytorch/pytorch/issues/122351