### PR TITLE
DTensor: add ring attention for _scaled_dot_product_flash_attention

### DIFF
--- a/test/distributed/_tensor/test_attention.py
+++ b/test/distributed/_tensor/test_attention.py
@@ -1,0 +1,302 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+# Owner(s): ["oncall: distributed"]
+import unittest
+
+import torch
+from torch import nn
+from torch.distributed._tensor import DeviceMesh, distribute_tensor, Shard
+from torch.distributed._tensor.debug import CommDebugMode
+from torch.distributed._tensor.experimental.attention import (
+    _CausalBehavior,
+    _is_causal_behavior,
+    _scaled_dot_product_chunk_flash_attention,
+    attention_context_parallel,
+    AttentionContextParallel,
+)
+from torch.distributed.tensor.parallel import parallelize_module
+from torch.nn.attention import sdpa_kernel, SDPBackend
+from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FLASH_ATTENTION
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+)
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    DTensorTestBase,
+    ModelArgs,
+    Transformer,
+    with_comms,
+)
+
+
+c10d_functional = torch.ops.c10d_functional
+
+
+class RingAttentionTest(DTensorTestBase):
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @skip_if_lt_x_gpu(2)
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support flash attention"
+    )
+    @with_comms
+    @parametrize("is_causal", [True, False])
+    def test_ring_attention_sdpa(self, is_causal: bool) -> None:
+        device_mesh = DeviceMesh(
+            self.device_type,
+            torch.arange(0, self.world_size),
+        )
+        dtype = torch.bfloat16
+        bs = 8
+        query_tokens = 8
+        context_tokens = query_tokens if is_causal else 8
+        dim = 32
+        nheads = 8
+        query = torch.rand(
+            (bs, nheads, self.world_size * query_tokens, dim),
+            device=self.device_type,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        key = torch.rand(
+            (bs, nheads, self.world_size * context_tokens, dim),
+            device=self.device_type,
+            dtype=dtype,
+        )
+        value = torch.rand(
+            (bs, nheads, self.world_size * context_tokens, dim),
+            device=self.device_type,
+            dtype=dtype,
+        )
+
+        query_placement = [Shard(2)]
+        dquery = distribute_tensor(query, device_mesh, query_placement)
+        self.assertEqual(query.shape, (bs, nheads, self.world_size * query_tokens, dim))
+
+        context_placement = [Shard(2)]
+        dkey = distribute_tensor(key, device_mesh, context_placement)
+        dvalue = distribute_tensor(value, device_mesh, context_placement)
+        for t in [dkey, dvalue]:
+            self.assertEqual(
+                t.shape, (bs, nheads, context_tokens * self.world_size, dim)
+            )
+            self.assertEqual(t.to_local().shape, (bs, nheads, context_tokens, dim))
+
+        # local tensors
+        out, logsumexp, *others = torch.ops.aten._scaled_dot_product_flash_attention(
+            query, key, value, is_causal=is_causal
+        )
+
+        self.assertEqual(out.shape, (bs, nheads, self.world_size * query_tokens, dim))
+        out.sum().backward()
+        out_grad = query.grad
+        query.grad = None
+        self.assertIsNotNone(out_grad)
+
+        # compute chunked version to compare distributed to chunked implementations
+        # chunked isn't numerically identical to single operator version
+        (
+            out_chunk,
+            logsumexp_chunk,
+            *others,
+        ) = _scaled_dot_product_chunk_flash_attention(
+            query,
+            key,
+            value,
+            size=self.world_size,
+            is_causal=is_causal,
+        )
+
+        out_chunk.sum().backward()
+        self.assertEqual(
+            out_chunk.shape, (bs, nheads, self.world_size * query_tokens, dim)
+        )
+        self.assertEqual(logsumexp_chunk, logsumexp)
+        self.assertEqual(out_chunk, out)
+        out_chunk_grad = query.grad
+        query.grad = None
+        # gradient doesn't match due to numerical issues with chunk size > 1
+        # self.assertEqual(out_chunk_grad, out_grad)
+
+        # parallel behavior
+        with attention_context_parallel(), CommDebugMode() as comm_mode:
+            (
+                out_parallel,
+                logsumexp_parallel,
+                *others,
+            ) = torch.ops.aten._scaled_dot_product_flash_attention(
+                dquery, dkey, dvalue, is_causal=is_causal
+            )
+        self.assertDictEqual(
+            comm_mode.get_comm_counts(),
+            {
+                c10d_functional.all_to_all_single: self.world_size - 1,
+            },
+        )
+        self.assertEqual(out_parallel.placements, (Shard(2),))
+        self.assertEqual(
+            out_parallel._local_tensor.shape, (bs, nheads, query_tokens, dim)
+        )
+        self.assertEqual(
+            out_parallel.shape, (bs, nheads, self.world_size * query_tokens, dim)
+        )
+        out_parallel_tensor = out_parallel.full_tensor()
+        self.assertEqual(out_parallel_tensor, out)
+        logsumexp_parallel_tensor = logsumexp_parallel.full_tensor()
+        self.assertEqual(logsumexp_parallel_tensor, logsumexp)
+
+        self.assertIsNone(dquery.grad)
+        with attention_context_parallel(), CommDebugMode() as comm_mode:
+            out_parallel.sum().backward()
+
+        self.assertDictEqual(
+            comm_mode.get_comm_counts(),
+            {
+                c10d_functional.all_to_all_single: (self.world_size - 1) * 2,
+            },
+        )
+        out_parallel_grad = dquery.grad.full_tensor()
+        dquery.grad = None
+        self.assertEqual(out_parallel_grad, out_chunk_grad)
+
+    @skip_if_lt_x_gpu(2)
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support flash attention"
+    )
+    @with_comms
+    @sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION])
+    @parametrize("is_causal", [True, False])
+    def test_ring_attention_native_transformer(self, is_causal: bool) -> None:
+        device_mesh = DeviceMesh(
+            self.device_type,
+            torch.arange(0, self.world_size),
+        )
+        dtype = torch.bfloat16
+        bs = 8
+        ntokens = 8
+        dim = 32
+        nheads = 8
+        num_layers = 2
+
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=dim,
+            nhead=nheads,
+            dim_feedforward=dim,
+            batch_first=True,
+        ).to(dtype)
+        encoder_layer = parallelize_module(
+            module=encoder_layer,
+            device_mesh=device_mesh,
+            parallelize_plan={
+                "self_attn": AttentionContextParallel(),
+            },
+        )
+        model = nn.TransformerEncoder(encoder_layer, num_layers=num_layers)
+        model = model.to(self.device_type).to(dtype)
+
+        mask = (
+            nn.Transformer.generate_square_subsequent_mask(
+                ntokens, device=self.device_type, dtype=dtype
+            )
+            if is_causal
+            else None
+        )
+        seq = torch.rand((bs, ntokens, dim), device=self.device_type, dtype=dtype)
+
+        with CommDebugMode() as comm_mode:
+            out = model(seq, mask=mask, is_causal=is_causal)
+        self.assertDictEqual(
+            comm_mode.get_comm_counts(),
+            {
+                c10d_functional.all_to_all_single: (self.world_size - 1) * num_layers,
+            },
+        )
+
+        with CommDebugMode() as comm_mode:
+            out.sum().backward()
+        self.assertDictEqual(
+            comm_mode.get_comm_counts(),
+            {
+                c10d_functional.all_to_all_single: (self.world_size - 1)
+                * 2
+                * num_layers,
+            },
+        )
+
+    def test_is_causal_behavior(self) -> None:
+        # not causal
+        self.assertEqual(
+            _is_causal_behavior(rank=0, world_size=4, i=0, is_causal=False),
+            _CausalBehavior.NOT_IS_CAUSAL,
+        )
+
+        ranks = [
+            [_CausalBehavior.IS_CAUSAL, _CausalBehavior.SKIP],
+            [_CausalBehavior.IS_CAUSAL, _CausalBehavior.NOT_IS_CAUSAL],
+        ]
+        for rank, iters in enumerate(ranks):
+            for i, behavior in enumerate(iters):
+                self.assertEqual(
+                    _is_causal_behavior(rank=rank, world_size=2, i=i, is_causal=True),
+                    behavior,
+                )
+
+    @skip_if_lt_x_gpu(2)
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support flash attention"
+    )
+    @with_comms
+    @sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION])
+    def test_ring_attention_custom_transformer(self) -> None:
+        device_mesh = DeviceMesh(
+            self.device_type,
+            torch.arange(0, self.world_size),
+        )
+        dtype = torch.bfloat16
+        bs = 2
+        args = ModelArgs()
+
+        model = Transformer(args).to(dtype).to(self.device_type)
+
+        model = parallelize_module(
+            module=model,
+            device_mesh=device_mesh,
+            parallelize_plan={
+                f"layers.{i}.attention": AttentionContextParallel()
+                for i in range(args.n_layers)
+            },
+        )
+
+        seq = torch.randint(
+            args.vocab_size, (bs, args.max_seq_len), device=self.device_type
+        )
+
+        with CommDebugMode() as comm_mode:
+            out = model(seq)
+        self.assertDictEqual(
+            comm_mode.get_comm_counts(),
+            {
+                c10d_functional.all_to_all_single: (self.world_size - 1)
+                * args.n_layers,
+            },
+        )
+
+        with CommDebugMode() as comm_mode:
+            out.sum().backward()
+        self.assertDictEqual(
+            comm_mode.get_comm_counts(),
+            {
+                c10d_functional.all_to_all_single: (self.world_size - 1)
+                * 2
+                * args.n_layers,
+            },
+        )
+
+
+instantiate_parametrized_tests(RingAttentionTest)
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/_tensor/experimental/attention.py
+++ b/torch/distributed/_tensor/experimental/attention.py
@@ -1,0 +1,514 @@
+import contextlib
+import weakref
+from enum import Enum
+from typing import Any, Dict, Generator, List, Optional, Tuple, Union
+
+import torch
+import torch.distributed as dist
+import torch.distributed._functional_collectives as ft_c
+from torch import nn
+from torch.distributed._tensor import distribute_module, DTensor, Replicate
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor.parallel.style import ParallelStyle
+
+aten = torch.ops.aten
+
+
+def sdpa_handler(
+    op_call: torch._ops.OpOverload,
+    args: Tuple[object, ...],
+    kwargs: Dict[str, object],
+) -> object:
+    # extract local tensor and sharding infos to a OpInfo
+    op_info = DTensor._op_dispatcher.unwrap_to_op_info(op_call, args, kwargs)
+
+    # sharding propagation
+    DTensor._op_dispatcher.sharding_propagator.propagate(op_info)
+    output_sharding = op_info.output_sharding
+    assert output_sharding is not None, "output sharding should not be None"
+    assert not output_sharding.needs_redistribute, "inputs need to be redistributed"
+
+    local_results = _scaled_dot_product_ring_flash_attention(
+        op_info.mesh,
+        *op_info.local_args,  # type: ignore[arg-type]
+        **op_info.local_kwargs,  # type: ignore[arg-type]
+    )
+
+    return DTensor._op_dispatcher.wrap(local_results, output_sharding.output_spec)
+
+
+def _merge_sdpa(
+    chunks: List[torch.Tensor], logsumexps: List[torch.Tensor]
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    This merges multiple scaled dot product attention chunks by using the
+    provided logsumexps to rescale the chunks before summing.
+
+    Args:
+        chunks (List[torch.Tensor]): A list of scaled dot product attention chunks
+        logsumexps (List[torch.Tensor]): A list of logsumexps for each chunk
+
+    Returns:
+        out (torch.Tensor): The merged scaled dot product attention
+        softmax_lse (torch.Tensor): The logsumexp of the merged scaled dot product attention
+    """
+    assert len(chunks) == len(logsumexps)
+
+    softmax_lse = torch.stack([lse.exp() for lse in logsumexps]).sum(dim=0).log_()
+
+    out = []
+    for i, (chunk, chunk_lse) in enumerate(zip(chunks, logsumexps)):
+        softmax_lse_corrected = torch.exp(chunk_lse - softmax_lse)
+        out_corrected = chunk * softmax_lse_corrected.unsqueeze(-1).to(chunk.dtype)
+        out.append(out_corrected)
+    out = torch.stack(out).sum(dim=0)
+
+    return out, softmax_lse
+
+
+def _scaled_dot_product_ring_flash_attention(
+    mesh: DeviceMesh,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    dropout_p: float = 0.0,
+    is_causal: bool = False,
+    return_debug_mask: bool = False,
+    *,
+    scale: Optional[float] = None,
+) -> Tuple[torch.Tensor, ...]:
+    if return_debug_mask:
+        raise NotImplementedError("return_debug_mask is not supported yet")
+
+    if is_causal and (query.size(2) != key.size(2)):
+        raise NotImplementedError(
+            "is_causal requires the same query and context sequence lengths"
+        )
+
+    pg = mesh.get_group()
+    assert isinstance(pg, dist.ProcessGroup), "must be single dimension"
+    rank = dist.get_rank(pg)
+    size = dist.get_world_size(pg)
+
+    # rank 0 sends to rank 1, rank 1 sends to rank 2, ..., rank n-1 sends to rank 0
+    right_dsts = list(range(1, size)) + [0]
+
+    next_kv = None
+
+    chunks = []
+    logsumexps = []
+    for i in range(size):
+        # overlap communication with compute
+        if next_kv is not None:
+            next_kv = ft_c.wait_tensor(next_kv)
+            key = next_kv[: key.numel()].reshape(key.shape)
+            value = next_kv[key.numel() :].reshape(value.shape)
+
+        if i < (size - 1):
+            next_kv = torch.cat([key.flatten(), value.flatten()])
+            next_kv = ft_c.permute_tensor(next_kv, right_dsts, pg)
+
+        is_causal_behavior = _is_causal_behavior(
+            rank=rank, world_size=size, i=i, is_causal=is_causal
+        )
+
+        if is_causal_behavior != _CausalBehavior.SKIP:
+            local_results = torch.ops.aten._scaled_dot_product_flash_attention(
+                query,
+                key,
+                value,
+                dropout_p=dropout_p,
+                is_causal=is_causal_behavior.value,
+                scale=scale,
+            )
+            chunks.append(local_results[0])
+            logsumexps.append(local_results[1])
+
+    out, softmax_lse = _merge_sdpa(chunks, logsumexps)
+
+    local_results = (out, softmax_lse) + local_results[2:]
+    return local_results
+
+
+def _scaled_dot_product_chunk_flash_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    size: int,
+    dropout_p: float = 0.0,
+    is_causal: bool = False,
+    return_debug_mask: bool = False,
+    *,
+    scale: Optional[float] = None,
+) -> Tuple[torch.Tensor, ...]:
+    """
+    This is a single node chunked implementation of
+    _scaled_dot_product_ring_flash_attention used for verifying
+    the correctness of the backwards pass.
+    """
+
+    if return_debug_mask:
+        raise NotImplementedError("return_debug_mask is not supported yet")
+
+    if is_causal and (query.size(2) != key.size(2)):
+        raise NotImplementedError(
+            "is_causal requires the same query and context sequence lengths"
+        )
+
+    query_len = query.size(2) // size
+    ctx_len = key.size(2) // size
+
+    global_out = []
+    global_softmax_lse = []
+
+    for rank in range(size):
+        chunks = []
+        logsumexps = []
+
+        chunk_query = query[:, :, rank * query_len : (rank + 1) * query_len]
+
+        for i in range(size):
+            src_rank = (rank - i) % size
+            chunk_key = key[:, :, src_rank * ctx_len : (src_rank + 1) * ctx_len]
+            chunk_value = value[:, :, src_rank * ctx_len : (src_rank + 1) * ctx_len]
+
+            is_causal_behavior = _is_causal_behavior(
+                rank=rank, world_size=size, i=i, is_causal=is_causal
+            )
+
+            if is_causal_behavior != _CausalBehavior.SKIP:
+                local_results = torch.ops.aten._scaled_dot_product_flash_attention(
+                    chunk_query,
+                    chunk_key,
+                    chunk_value,
+                    dropout_p=dropout_p,
+                    is_causal=is_causal_behavior.value,
+                    scale=scale,
+                )
+                chunks.append(local_results[0])
+                logsumexps.append(local_results[1])
+
+        out, softmax_lse = _merge_sdpa(chunks, logsumexps)
+        global_out.append(out)
+        global_softmax_lse.append(softmax_lse)
+
+    global_out = torch.concat(global_out, dim=2)
+    global_softmax_lse = torch.concat(global_softmax_lse, dim=2)
+
+    local_results = (global_out, global_softmax_lse) + local_results[2:]
+    return local_results
+
+
+def sdpa_backward_handler(
+    op_call: torch._ops.OpOverload,
+    args: Tuple[object, ...],
+    kwargs: Dict[str, object],
+) -> object:
+    # Redistribute grad_output tensor to the same placement as output tensor
+    args = list(args)
+    assert isinstance(args[0], DTensor) and isinstance(args[4], DTensor)
+    args[0] = args[0].redistribute(args[4].device_mesh, args[4].placements)
+    args = tuple(args)
+
+    # extract local tensor and sharding infos to a OpInfo
+    op_info = DTensor._op_dispatcher.unwrap_to_op_info(op_call, args, kwargs)
+
+    # sharding propagation
+    DTensor._op_dispatcher.sharding_propagator.propagate(op_info)
+    output_sharding = op_info.output_sharding
+    assert output_sharding is not None, "output sharding should not be None"
+    assert not output_sharding.needs_redistribute, "inputs need to be redistributed"
+
+    local_results = _scaled_dot_product_ring_flash_attention_backward(
+        op_info.mesh,
+        *op_info.local_args,  # type: ignore[arg-type]
+        **op_info.local_kwargs,  # type: ignore[arg-type]
+    )
+
+    return DTensor._op_dispatcher.wrap(local_results, output_sharding.output_spec)
+
+
+def _scaled_dot_product_ring_flash_attention_backward(
+    mesh: DeviceMesh,
+    grad_out: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    out: torch.Tensor,
+    softmax_lse: torch.Tensor,
+    cum_seq_q: torch.Tensor,
+    cum_seq_k: torch.Tensor,
+    max_q: int,
+    max_k: int,
+    dropout_p: float,
+    is_causal: bool,
+    philox_seed: torch.Tensor,
+    philox_offset: torch.Tensor,
+    *,
+    scale: Optional[float] = None,
+) -> Tuple[torch.Tensor, ...]:
+    pg = mesh.get_group()
+    assert isinstance(pg, dist.ProcessGroup), "must be single dimension"
+    rank = dist.get_rank(pg)
+    size = dist.get_world_size(pg)
+
+    # rank 0 sends to rank 1, rank 1 sends to rank 2, ..., rank n-1 sends to rank 0
+    right_dsts = list(range(1, size)) + [0]
+
+    next_kv = None
+
+    out_grad_queries = []
+    out_grad_keys = []
+    out_grad_values = []
+
+    for i in range(size):
+        # overlap communication with compute
+        if next_kv is not None:
+            next_kv = ft_c.wait_tensor(next_kv)
+            key = next_kv[: key.numel()].reshape(key.shape)
+            value = next_kv[key.numel() :].reshape(value.shape)
+
+        if i < (size - 1):
+            next_kv = torch.cat([key.flatten(), value.flatten()])
+            next_kv = ft_c.permute_tensor(next_kv, right_dsts, pg)
+
+        is_causal_behavior = _is_causal_behavior(
+            rank=rank, world_size=size, i=i, is_causal=is_causal
+        )
+
+        if is_causal_behavior != _CausalBehavior.SKIP:
+            # we rerun the forwards pass since we don't have a good way to save the
+            # output/logsumexp
+            (
+                output,
+                logsumexp,
+                cum_seq_q,
+                cum_seq_k,
+                max_q,
+                max_k,
+                philox_seed,
+                philox_offset,
+                _,
+            ) = torch.ops.aten._scaled_dot_product_flash_attention(
+                query,
+                key,
+                value,
+                dropout_p=dropout_p,
+                is_causal=is_causal_behavior.value,
+                scale=scale,
+            )
+
+            softmax_lse_corrected = torch.exp(logsumexp - softmax_lse)
+
+            chunk_grad = grad_out * softmax_lse_corrected.conj().unsqueeze(-1).to(
+                grad_out.dtype
+            )
+
+            (
+                grad_query,
+                grad_key,
+                grad_value,
+            ) = torch.ops.aten._scaled_dot_product_flash_attention_backward(
+                grad_out=chunk_grad,
+                query=query,
+                key=key,
+                value=value,
+                out=output,
+                logsumexp=logsumexp,
+                cum_seq_q=cum_seq_q,
+                cum_seq_k=cum_seq_k,
+                max_q=max_q,
+                max_k=max_k,
+                dropout_p=dropout_p,
+                is_causal=is_causal_behavior.value,
+                philox_seed=philox_seed,
+                philox_offset=philox_offset,
+                scale=scale,
+            )
+        else:
+            grad_query = torch.zeros_like(query)
+            grad_key = torch.zeros_like(key)
+            grad_value = torch.zeros_like(value)
+
+        # TODO overlap grad communication
+        if i == 0:
+            out_grad_queries.append(grad_query)
+            out_grad_keys.append(grad_key)
+            out_grad_values.append(grad_value)
+        elif i > 0:
+            grad_dsts = [(-i) % size for i in range(size)]
+
+            grad_kv = torch.cat([grad_key.flatten(), grad_value.flatten()])
+            grad_kv = ft_c.permute_tensor(grad_kv, grad_dsts, pg)
+            grad_kv = ft_c.wait_tensor(grad_kv)
+            grad_key = grad_kv[: grad_key.numel()].reshape(grad_key.shape)
+            grad_value = grad_kv[grad_key.numel() :].reshape(grad_value.shape)
+
+            out_grad_queries.append(grad_query)
+            out_grad_keys.append(grad_key)
+            out_grad_values.append(grad_value)
+
+    # stack and sum to avoid accumulation errors
+    out_grad_query = torch.stack(out_grad_queries).sum(dim=0)
+    out_grad_key = torch.stack(out_grad_keys).sum(dim=0)
+    out_grad_value = torch.stack(out_grad_values).sum(dim=0)
+
+    return out_grad_query, out_grad_key, out_grad_value
+
+
+customized_ops = {
+    aten._scaled_dot_product_flash_attention.default: sdpa_handler,
+    aten._scaled_dot_product_flash_attention_backward.default: sdpa_backward_handler,
+}
+
+
+@contextlib.contextmanager
+def attention_context_parallel() -> Generator[None, None, None]:
+    """
+    This is a context manager that force enables attention context parallel
+    optimizations for all scaled_dot_product_attention ops.
+
+    This currently only supports ring attention and the
+    SDPBackend.FLASH_ATTENTION backend. See sdpa_kernel.
+
+    Non-flash attention backends will result in incorrect results.
+    """
+    old_handlers = DTensor._op_dispatcher._custom_op_handlers
+    DTensor._op_dispatcher._custom_op_handlers = {**old_handlers, **customized_ops}
+
+    yield
+
+    DTensor._op_dispatcher._custom_op_handlers = old_handlers
+
+
+class AttentionContextParallel(ParallelStyle):
+    """
+    Applies context parallel optimizations to the attention layer.
+
+    This will work for nn.MultiHeadedAttention and custom attention layers that
+    call F.scaled_dotproduct_attention with a simliar signature.
+
+    This expects the `forward` method consumes either:
+
+    * a single tensor for self attention
+    * one argument for each of: query, key, value
+
+    This currently only supports ring attention and the
+    SDPBackend.FLASH_ATTENTION backend. See sdpa_kernel.
+
+    Non-flash attention backends will result in incorrect results.
+    """
+
+    # use a weakref dictionary to store context managers for each nn.Module
+    _CONTEXT_MANAGERS: "weakref.WeakKeyDictionary[nn.Module, Any]" = (
+        weakref.WeakKeyDictionary()
+    )
+
+    def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
+        if not isinstance(device_mesh, DeviceMesh):
+            raise ValueError(
+                f"{type(device_mesh)} is not supported by {type(self)} yet."
+            )
+
+        if not device_mesh.ndim == 1:
+            raise ValueError
+
+        return distribute_module(
+            module,
+            device_mesh,
+            input_fn=self._input_fn,  # type: ignore[arg-type]
+            output_fn=self._output_fn,  # type: ignore[arg-type]
+        )
+
+    @classmethod
+    def _input_fn(
+        cls,
+        module: nn.Module,
+        inputs: Tuple[Union[torch.Tensor, int, float], ...],
+        device_mesh: DeviceMesh,
+    ) -> Tuple[Union[torch.Tensor, int, float], ...]:
+        # TODO(d4l3k); this should be Shard(2), need to fix Linear layer rules
+        placement = [Replicate()]
+
+        def backward_hook(grad: torch.Tensor) -> None:
+            if module in cls._CONTEXT_MANAGERS:
+                cls._CONTEXT_MANAGERS[module].__exit__(None, None, None)
+                del cls._CONTEXT_MANAGERS[module]
+
+        # convert inputs to DTensor
+        inp = []
+        for input in inputs:
+            if isinstance(input, torch.Tensor) and not isinstance(input, DTensor):
+                input = DTensor.from_local(
+                    input, device_mesh, placement, run_check=False
+                )
+
+            if isinstance(input, torch.Tensor) and input.requires_grad:
+                input.register_hook(backward_hook)
+
+            inp.append(input)
+
+        manager = attention_context_parallel()
+        manager.__enter__()
+        cls._CONTEXT_MANAGERS[module] = manager
+
+        return tuple(inp)
+
+    @classmethod
+    def _output_fn(
+        cls,
+        module: nn.Module,
+        outputs: Union[torch.Tensor, Tuple[Union[torch.Tensor, int, float], ...]],
+        device_mesh: DeviceMesh,
+    ) -> Union[
+        Union[torch.Tensor, int, float], Tuple[Union[torch.Tensor, int, float], ...]
+    ]:
+        cls._CONTEXT_MANAGERS[module].__exit__(None, None, None)
+        del cls._CONTEXT_MANAGERS[module]
+
+        def backward_hook(grad: torch.Tensor) -> None:
+            if module not in cls._CONTEXT_MANAGERS:
+                manager = attention_context_parallel()
+                manager.__enter__()
+                cls._CONTEXT_MANAGERS[module] = manager
+
+        # back to local tensor
+        out = []
+        for output in [outputs] if isinstance(outputs, torch.Tensor) else outputs:
+            output = output.to_local() if isinstance(output, DTensor) else output
+
+            if isinstance(output, torch.Tensor) and output.requires_grad:
+                output.register_hook(backward_hook)
+
+            out.append(output)
+
+        if isinstance(outputs, torch.Tensor):
+            return out[0]
+
+        return tuple(out)
+
+
+class _CausalBehavior(Enum):
+    SKIP = None
+    NOT_IS_CAUSAL = False
+    IS_CAUSAL = True
+
+
+def _is_causal_behavior(
+    rank: int, world_size: int, i: int, is_causal: bool
+) -> _CausalBehavior:
+    """
+    Calculate is_causal behavior for each KV block. The attention can either be
+    calculated in full, not at all or with the causal mask applied.
+    """
+    if not is_causal:
+        return _CausalBehavior.NOT_IS_CAUSAL
+
+    if i == 0:
+        return _CausalBehavior.IS_CAUSAL
+
+    source_rank = (rank - i) % world_size
+    if source_rank < rank:
+        return _CausalBehavior.NOT_IS_CAUSAL
+    else:
+        return _CausalBehavior.SKIP


### PR DESCRIPTION
Ring attention support for _scaled_dot_product_flash_attention with DTensor.

This assumes the query and key/value are sharded along the sequence length dimension. See the tests for example usage with PT Transformer as well as direct usage with _scaled_dot_product_flash_attention.

## Notable caveats
* Numerical accuracy: The backwards pass doesn't match numerically with the non-chunked version but the forwards pass does. I assume this is due to accumulated errors. I've added a chunked version that uses autograd to verify that the distributed version matches the chunked version.
* nn.Linear has incorrect behavior when running on a sharded tensor of size (bs, heads, seq_len, dim) with `Shard(2)` and does an unnecessary accumulate which requires `Replicate()` on QKV when using `nn.MultiHeadedAttention` to work around the issue.
* If enabled, it forces sequence parallelism and doesn't interop with tensor parallelism.

## SDPA usage

```py
with attention_context_parallel(), sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
    dquery = distribute_tensor(query, device_mesh, [Shard(2)])
    dkey = distribute_tensor(key, device_mesh, [Shard(2)])
    dvalue = distribute_tensor(value, device_mesh, [Shard(2)])
    
    dout: DTensor = torch.nn.functional.scaled_dot_product_attention(
        dquery, dkey, dvalue, is_causal=is_causal
    )
    out = dout.to_local()
```

## Transformer usage

```py
with attention_context_parallel(), sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
    encoder_layer = nn.TransformerEncoderLayer(
        d_model=dim,
        nhead=nheads,
        dim_feedforward=dim,
        batch_first=True,
    ).to(dtype)
    encoder_layer = parallelize_module(
        module=encoder_layer,
        device_mesh=device_mesh,
        parallelize_plan={
            "self_attn": ContextParallel(),
        },
    )
    model = nn.TransformerEncoder(encoder_layer, num_layers=num_layers)
```


## Test plan

```
pytest test/distributed/_tensor/test_attention.py
```

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang