### PR TITLE
[triton] Backport https://github.com/openai/triton/pull/3433

### DIFF
--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -972,8 +972,7 @@ def cached_autotune(
             with open(cache_filename) as fd:
                 best_config = json.loads(fd.read())
         elif remote_cache is not None and remote_cache_key is not None:
-            cache_outs = remote_cache.get([remote_cache_key])
-            best_config = cache_outs.get(remote_cache_key, None)
+            best_config = remote_cache.get(remote_cache_key)
 
         best_config = load_cached_autotuning(best_config, configs_hash, configs)
         if best_config:


### PR DESCRIPTION
Summary:
Pull cache API changes from https://github.com/openai/triton/pull/3433.

Among other simplifications, this allows us the cache all files in a "group"
atomically, in a single memcache blob, and avoid needing to use other
approaches to handle these files coming from different runs.

Reviewed By: bertmaher

Differential Revision: D55206000

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang