### PR TITLE
Update DimOrDims typing in torch.sparse

### DIFF
--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -17,7 +17,7 @@ from .semi_structured import (
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from torch.types import _dtype as DType
-    DimOrDims = Optional[Union[int, Tuple[int], List[int]]]
+    DimOrDims = Optional[Union[int, Tuple[int, ...], List[int]]]
 else:
     # The JIT doesn't understand Union, nor torch.dtype here
     DType = int


### PR DESCRIPTION
I noticed the typing of the `torch.sparse.sum`'s `dim` parameter wasn't allowing an int tuple as input and tracked the issue to this type.
