### PR TITLE
Add DtypeContext

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -800,6 +800,18 @@ def set_default_dtype(d):
     """
     _C._set_default_dtype(d)
 
+class DtypeContext:
+    def __init__(self, dtype):
+        self.dytpe = dtype
+
+    def __enter__(self):
+        self.old_dtype = torch.get_default_dtype()
+        torch.set_default_dtype(self.dytpe)
+        return self.dytpe
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        torch.set_default_dtype(self.old_dtype)
+
 def use_deterministic_algorithms(mode: builtins.bool, *, warn_only: builtins.bool = False) -> None:
     r""" Sets whether PyTorch operations must use "deterministic"
     algorithms. That is, algorithms which, given the same input, and when

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -801,15 +801,36 @@ def set_default_dtype(d):
     _C._set_default_dtype(d)
 
 class DtypeContext:
+    r"""A context manager using `set_default_dtype` to set the default floating point dtype
+
+    Example::
+
+        >>> torch.tensor([1.2, 3]).dtype        # initial default for floating point is torch.float32
+        torch.float32
+        >>> with torch.DtypeContext(torch.float64):
+        ...     torch.tensor([1.2, 3]).dtype    # a new floating point tensor
+        ... 
+        torch.float64
+        >>> torch.tensor([1.2, 3]).dtype        # default for floating point is back to torch.float32
+        torch.float32
+
+    """
     def __init__(self, dtype):
+        r"""Inits DtypeContext class
+        Args:
+            dtype (:class:`torch.dtype`): the floating point dtype to make the default.
+                                          Either torch.float32 or torch.float64.
+        """
         self.dytpe = dtype
 
     def __enter__(self):
+        r"""Uses `set_default_dtype` to set the floating point dtype"""
         self.old_dtype = torch.get_default_dtype()
         torch.set_default_dtype(self.dytpe)
         return self.dytpe
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        r"""Restores default for the floating point dtype"""
         torch.set_default_dtype(self.old_dtype)
 
 def use_deterministic_algorithms(mode: builtins.bool, *, warn_only: builtins.bool = False) -> None:


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/120819.
Mainly refer to ``DeviceContext``'s implementation.
https://github.com/pytorch/pytorch/blob/3600778edeb1ac4eefe36cedb6facf02c58ce0d4/torch/utils/_device.py#L59-L72
Then we can use ``with torch.DtypeContext(torch.float64)`` to set default dtype.
Coulg u please give me some advice, @albanD ?