### PR TITLE
skip moondream for training

### DIFF
--- a/benchmarks/dynamo/torchbench.yaml
+++ b/benchmarks/dynamo/torchbench.yaml
@@ -206,6 +206,7 @@ skip:
       - hf_T5_generate
       - doctr_det_predictor
       - doctr_reco_predictor
+      - moondream
       # doesnt fit in memory
       - phi_1_5
       - detectron2_fcos_r_50_fpn


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122483

The model shows as failed model on the dashboard for training. But the model is not implemented for training (at least for now):
https://github.com/pytorch/benchmark/blob/2196021e9bc0b72a547121bbf298ae854a85a21a/torchbenchmark/models/moondream/__init__.py#L6

Skip it in dashboard.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang