### PR TITLE
[export] Remove from_export flag

### DIFF
--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -2086,7 +2086,6 @@ class ExportedProgramDeserializer:
             example_inputs=None,
             verifier=load_verifier(exported_program.dialect),
             constants=res.constants,
-            from_export=True
         )
         return upgrader.upgrade(exported_program)
 

--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -138,11 +138,11 @@ class Verifier(metaclass=_VerifierMeta):
 
     @final
     def check(self, ep: ExportedProgram) -> None:
-        self._check_graph_module(ep.graph_module, from_export=ep.from_export)
+        self._check_graph_module(ep.graph_module)
         _verify_exported_program_signature(ep)
 
     @final
-    def _check_graph_module(self, gm: torch.fx.GraphModule, from_export: bool = False) -> None:
+    def _check_graph_module(self, gm: torch.fx.GraphModule) -> None:
         def _allowed_getattr_types() -> Tuple[Type[Any], ...]:
             ret = self.allowed_getattr_types()
             assert not any(t is object for t in ret)

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -926,7 +926,6 @@ def _export(
             ),
             example_inputs=(args, kwargs),
             constants=ep_non_strict.constants,
-            from_export=True,
         )
 
     gm_torch_level = _export_to_torch_ir(
@@ -1123,7 +1122,6 @@ def _export(
         ),
         example_inputs=(args, kwargs),
         constants=constants,
-        from_export=True,
     )
     log.debug("Exported program from AOTAutograd:\n%s", exported_program)
 

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -143,7 +143,6 @@ class ExportedProgram:
         constants: Optional[
             Dict[str, Union[torch.Tensor, torch._C.ScriptObject]]
         ] = None,
-        from_export: bool = False,
     ):
         # Remove codegen related things from the graph. It should just be a flat graph.
         graph._codegen = torch.fx.graph.CodeGen()
@@ -167,14 +166,6 @@ class ExportedProgram:
             verifier = Verifier
         assert issubclass(verifier, Verifier)
         self._verifier = verifier
-
-        # from_export is True if the ExportedProgram is created from export/_trace.py or _export/serde/serialize.py
-        # With this we have stronger guarantees on graph metadata, and perform more checks with the verifier.
-        # External users may have their own workflows of constructing ExportedPrograms
-        # (e.g. dynamo trace -> make_fx() -> ExportedProgram() without going through export)
-        # and for this we cannot provide complete guarantees on graph metadata.
-        self.from_export = from_export
-
         # Validate should be always the last step of the constructor.
         self.verifier().check(self)
 
@@ -573,7 +564,6 @@ class ExportedProgram:
             example_inputs=self.example_inputs,
             verifier=self.verifier,
             constants=self.constants,
-            from_export=True,
         )
 
         if len(new_range_constraints) > 0:
@@ -662,7 +652,6 @@ class ExportedProgram:
             example_inputs=self.example_inputs,
             verifier=self.verifier,
             constants=self.constants,
-            from_export=True,
         )
         transformed_ep.graph_module.meta.update(self.graph_module.meta)
         transformed_ep.graph_module.meta.update(res.graph_module.meta)
@@ -698,7 +687,6 @@ class ExportedProgram:
             example_inputs=self.example_inputs,
             verifier=self.verifier,
             tensor_constants=self.tensor_constants,
-            from_export=True,
         )
 
 


### PR DESCRIPTION
Summary: The flag from_export was incorrectly included in a previous diff (https://www.internalfb.com/diff/D54314379) - it was intended for helping with ExportedProgram verification, but was no longer needed in the final implementation.

Test Plan: Changes no functionality, test/export already covers everything

Differential Revision: D55205857


