### PR TITLE
[experiment] serial tests

### DIFF
--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -449,7 +449,7 @@ def parse_reenabled_issues(s: Optional[str]) -> List[str]:
 
 
 def get_reenabled_issues(pr_body: str = "") -> List[str]:
-    default_branch = os.getenv("GIT_DEFAULT_BRANCH", "main")
+    default_branch = os.getenv("GIT_DEFAULT_BRANCH", "origin/main")
     try:
         commit_messages = subprocess.check_output(
             f"git cherry -v {default_branch}".split(" ")

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,3 +19,6 @@ filterwarnings =
     ignore:Module already imported so cannot be rewritten.*hypothesis:pytest.PytestAssertRewriteWarning
 
 xfail_strict = True
+
+markers =
+    serial: marks tests as needs to be run serially (deselect with '-m "not serial"')

--- a/test/functorch/test_memory_efficient_fusion.py
+++ b/test/functorch/test_memory_efficient_fusion.py
@@ -13,10 +13,6 @@ from functorch.compile import memory_efficient_fusion
 from torch._functorch.compile_utils import fx_graph_cse
 from torch.nn import functional as F
 from torch.testing._internal.common_utils import TestCase, run_tests, serialTest, TEST_CUDA
-import inspect
-import random
-from typing import Callable
-import unittest
 
 HAS_CUDA = torch.cuda.is_available()
 

--- a/test/functorch/test_memory_efficient_fusion.py
+++ b/test/functorch/test_memory_efficient_fusion.py
@@ -12,7 +12,11 @@ from functorch import make_fx
 from functorch.compile import memory_efficient_fusion
 from torch._functorch.compile_utils import fx_graph_cse
 from torch.nn import functional as F
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import TestCase, run_tests, serialTest, TEST_CUDA
+import inspect
+import random
+from typing import Callable
+import unittest
 
 HAS_CUDA = torch.cuda.is_available()
 
@@ -156,6 +160,7 @@ class TestMemoryEfficientOpAuthoring(TestCase):
         layer_norm_inps = [(bs, ln_size), (ln_size,), (ln_size,)]
         run_and_compare_activation(self, layer_norm, layer_norm_inps)
 
+    @serialTest(TEST_CUDA)
     def test_rmsnorm(self):
         class T5LayerNorm(nn.Module):
             def __init__(self, hidden_size, eps=1e-6):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -70,6 +70,7 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     IS_X86,
     parametrize,
+    serialTest,
     skipIfRocm,
     subtest,
     TEST_WITH_ASAN,
@@ -9278,6 +9279,7 @@ class CommonTemplate:
     @config.patch(
         "triton.autotune_pointwise", True
     )  # needed to introduce config that exceed max shared memory usage
+    @serialTest()
     def test_large_block_sizes(self):
         """
         Inductor will try triton configs like x = 64 and y = 1024 which will

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -5,7 +5,7 @@ import unittest
 
 import torch
 
-from torch.testing._internal.common_utils import IS_LINUX
+from torch.testing._internal.common_utils import IS_LINUX, serialTest
 from torch.testing._internal.inductor_utils import HAS_GPU
 
 try:
@@ -79,6 +79,7 @@ class TestTritonHeuristics(TestCase):
         self._test_artificial_zgrid()
 
     @config.patch("triton.max_tiles", 3)
+    @serialTest()
     def test_artificial_grid_max_tiles(self):
         with self.assertRaisesRegex(Exception, "Generated y grid"):
             self._test_artificial_zgrid()

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -70,6 +70,7 @@ class TestTritonHeuristics(TestCase):
         self.assertEqual(forward(*args), foo_c(*args))
 
     @unittest.skip("https://github.com/pytorch/pytorch/issues/123210")
+    @serialTest()
     def test_artificial_zgrid(self):
         self._test_artificial_zgrid()
 

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -3036,6 +3036,8 @@ class TestConvolutionNNDeviceType(NNTestCase):
 
     @onlyCUDA
     @largeTensorTest("12GB")
+    @largeTensorTest('12GB')
+    @serialTest()
     def test_conv_large_nosplit(self, device):
         # Here we just test the convolution correctly route to the fallback implementation
         # that is, it does not crash. The correctness of fallback implementation should be

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -11,18 +11,6 @@ import torch.autograd.forward_ad as fwAD
 import torch.backends.cudnn as cudnn
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.testing._internal.common_dtype import floating_types_and, floating_and_complex_types_and
-from torch.testing._internal.common_utils import run_tests, \
-    skipIfRocmVersionLessThan, skipIfNotMiopenSuggestNHWC, TEST_SCIPY, TEST_WITH_ROCM, \
-    download_file, parametrize as parametrize_test, subtest, \
-    instantiate_parametrized_tests, set_default_dtype, serialTest
-from torch.testing._internal.common_cuda import TEST_CUDA, TEST_CUDNN
-from torch.testing._internal.common_nn import NNTestCase, _test_module_empty_input
-from torch.testing._internal.common_device_type import instantiate_device_type_tests, dtypes, \
-    dtypesIfCUDA, precisionOverride, skipCUDAIfNoCudnn, skipCUDAIfCudnnVersionLessThan, onlyCUDA, onlyCPU, \
-    skipCUDAIfRocm, skipCUDAIfRocmVersionLessThan, skipCUDAIfNotMiopenSuggestNHWC, \
-    onlyNativeDeviceTypes, largeTensorTest, skipMeta, \
-    disableMkldnn, skipCPUIfNoMkldnn, disablecuDNN, skipCUDAIfMiopen, skipCUDAIfNoMiopen
 
 from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import (
@@ -66,6 +54,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize as parametrize_test,
     run_tests,
+    serialTest,
     set_default_dtype,
     skipIfNotMiopenSuggestNHWC,
     skipIfRocmVersionLessThan,
@@ -3036,7 +3025,6 @@ class TestConvolutionNNDeviceType(NNTestCase):
 
     @onlyCUDA
     @largeTensorTest("12GB")
-    @largeTensorTest('12GB')
     @serialTest()
     def test_conv_large_nosplit(self, device):
         # Here we just test the convolution correctly route to the fallback implementation
@@ -3144,8 +3132,8 @@ class TestConvolutionNNDeviceType(NNTestCase):
 
     @onlyCUDA
     @skipCUDAIfRocm
-    @largeTensorTest('12GB')
-    @serialTest(TEST_CUDA)
+    @largeTensorTest("12GB")
+    @serialTest()
     def test_conv_large(self, device):
         dtype = torch.half if self.device_type == "cuda" else torch.float
         conv = nn.Conv2d(2, 2, 8, 8, bias=False).to(device).to(dtype)

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -11,6 +11,18 @@ import torch.autograd.forward_ad as fwAD
 import torch.backends.cudnn as cudnn
 import torch.nn as nn
 import torch.nn.functional as F
+from torch.testing._internal.common_dtype import floating_types_and, floating_and_complex_types_and
+from torch.testing._internal.common_utils import run_tests, \
+    skipIfRocmVersionLessThan, skipIfNotMiopenSuggestNHWC, TEST_SCIPY, TEST_WITH_ROCM, \
+    download_file, parametrize as parametrize_test, subtest, \
+    instantiate_parametrized_tests, set_default_dtype, serialTest
+from torch.testing._internal.common_cuda import TEST_CUDA, TEST_CUDNN
+from torch.testing._internal.common_nn import NNTestCase, _test_module_empty_input
+from torch.testing._internal.common_device_type import instantiate_device_type_tests, dtypes, \
+    dtypesIfCUDA, precisionOverride, skipCUDAIfNoCudnn, skipCUDAIfCudnnVersionLessThan, onlyCUDA, onlyCPU, \
+    skipCUDAIfRocm, skipCUDAIfRocmVersionLessThan, skipCUDAIfNotMiopenSuggestNHWC, \
+    onlyNativeDeviceTypes, largeTensorTest, skipMeta, \
+    disableMkldnn, skipCPUIfNoMkldnn, disablecuDNN, skipCUDAIfMiopen, skipCUDAIfNoMiopen
 
 from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import (
@@ -3085,6 +3097,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
     @onlyCUDA
     @largeTensorTest("12GB")
     @skipIfRocmVersionLessThan((6, 0))
+    @serialTest()
     def test_conv_transposed_large(self, device):
         dtype = torch.half if self.device_type == "cuda" else torch.float
         conv = nn.ConvTranspose2d(1, 1, 1, 1, bias=False).to(device).to(dtype)

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -3144,7 +3144,8 @@ class TestConvolutionNNDeviceType(NNTestCase):
 
     @onlyCUDA
     @skipCUDAIfRocm
-    @largeTensorTest("12GB")
+    @largeTensorTest('12GB')
+    @serialTest(TEST_CUDA)
     def test_conv_large(self, device):
         dtype = torch.half if self.device_type == "cuda" else torch.float
         conv = nn.Conv2d(2, 2, 8, 8, bias=False).to(device).to(dtype)

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -17,10 +17,6 @@ import torch.nn.functional as F
 from torch import inf, nan
 from torch.autograd import gradcheck, gradgradcheck
 from torch.testing import make_tensor
-from torch.testing._internal.common_utils import TestCase, run_tests, TEST_WITH_UBSAN, set_default_dtype, \
-    instantiate_parametrized_tests, slowTest, parametrize as parametrize_test, subtest, skipIfMps, gcIfJetson, \
-    skipIfTorchDynamo, serialTest
-from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_device_type import (
     dtypes,
     dtypesIfCUDA,
@@ -44,11 +40,13 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize as parametrize_test,
     run_tests,
+    serialTest,
     set_default_dtype,
     skipIfMps,
     skipIfTorchDynamo,
     slowTest,
     subtest,
+    TEST_CUDA,
     TEST_WITH_UBSAN,
     TestCase,
 )
@@ -1825,7 +1823,7 @@ torch.cuda.synchronize()
                 self.assertEqual(x.shape[2], res.shape[2])
 
     @onlyCUDA
-    @largeTensorTest('6GB')
+    @largeTensorTest("6GB")
     @serialTest()
     def test_pooling_large(self, device):
         def helper(pool):

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -1081,6 +1081,7 @@ torch.cuda.synchronize()
     @dtypes(torch.half, torch.bfloat16, torch.float, torch.double)
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     @gcIfJetson
+    @serialTest(TEST_CUDA)
     def test_max_pool2d_nhwc(self, device, dtype):
         def helper(n, c, h, w, kernel_size, stride=None):
             if stride is None:
@@ -1824,7 +1825,8 @@ torch.cuda.synchronize()
                 self.assertEqual(x.shape[2], res.shape[2])
 
     @onlyCUDA
-    @largeTensorTest("6GB")
+    @largeTensorTest('6GB')
+    @serialTest()
     def test_pooling_large(self, device):
         def helper(pool):
             inp = torch.randn(

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -17,6 +17,9 @@ import torch.nn.functional as F
 from torch import inf, nan
 from torch.autograd import gradcheck, gradgradcheck
 from torch.testing import make_tensor
+from torch.testing._internal.common_utils import TestCase, run_tests, TEST_WITH_UBSAN, set_default_dtype, \
+    instantiate_parametrized_tests, slowTest, parametrize as parametrize_test, subtest, skipIfMps, gcIfJetson, \
+    skipIfTorchDynamo, serialTest
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_device_type import (
     dtypes,
@@ -930,6 +933,7 @@ torch.cuda.synchronize()
     @gcIfJetson
     @dtypes(torch.float, torch.double)
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
+    @serialTest(TEST_CUDA)
     def test_avg_pool2d_nhwc(self, device, dtype):
         def helper(
             n,

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1522,7 +1522,9 @@ def run_test_module(
         assert isinstance(return_code, int) and not isinstance(
             return_code, bool
         ), f"While running {str(test)} got non integer return code {return_code}"
-        print(f"TIME INFO: Took {time.time() - start:.2f}s to run {str(test)}, expected time {test.time}s")
+        print(
+            f"TIME INFO: Took {time.time() - start:.2f}s to run {str(test)}, expected time {test.time}s"
+        )
         if return_code == 0:
             return None
 
@@ -1608,10 +1610,7 @@ def run_tests(
                 and not options.continue_through_error
                 and not RERUN_DISABLED_TESTS
             ):
-                raise RuntimeError(
-                    failure.message
-                    + keep_going_message
-                )
+                raise RuntimeError(failure.message + keep_going_message)
 
         for test in selected_tests_parallel:
             options_clone = copy.deepcopy(options)
@@ -1625,10 +1624,7 @@ def run_tests(
                 and not options.continue_through_error
                 and not RERUN_DISABLED_TESTS
             ):
-                raise RuntimeError(
-                    failure.message
-                    + keep_going_message
-                )
+                raise RuntimeError(failure.message + keep_going_message)
 
         os.environ["NUM_PARALLEL_PROCS"] = str(NUM_PROCS)
         for test in selected_tests_parallel:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1513,6 +1513,7 @@ def run_test_module(
         maybe_set_hip_visible_devies()
 
         test_name = test.name
+        start = time.time()
 
         # Printing the date here can help diagnose which tests are slow
         print_to_stderr(f"Running {str(test)} ... [{datetime.now()}]")
@@ -1521,6 +1522,7 @@ def run_test_module(
         assert isinstance(return_code, int) and not isinstance(
             return_code, bool
         ), f"While running {str(test)} got non integer return code {return_code}"
+        print(f"TIME INFO: Took {time.time() - start:.2f}s to run {str(test)}, expected time {test.time}s")
         if return_code == 0:
             return None
 
@@ -1589,6 +1591,11 @@ def run_tests(
         ):
             pool.terminate()
 
+    keep_going_message = (
+        "Tip: You can keep running tests even on failure by passing --keep-going to run_test.py.\n"
+        "If running on CI, add the 'keep-going' label to your PR and rerun your jobs."
+    )
+
     try:
         for test in selected_tests_serial:
             options_clone = copy.deepcopy(options)
@@ -1603,10 +1610,7 @@ def run_tests(
             ):
                 raise RuntimeError(
                     failure.message
-                    + "\n\nTip: You can keep running tests even on failure by "
-                    "passing --keep-going to run_test.py.\n"
-                    "If running on CI, add the 'keep-going' label to "
-                    "your PR and rerun your jobs."
+                    + keep_going_message
                 )
 
         for test in selected_tests_parallel:
@@ -1623,10 +1627,7 @@ def run_tests(
             ):
                 raise RuntimeError(
                     failure.message
-                    + "\n\nTip: You can keep running tests even on failure by "
-                    "passing --keep-going to run_test.py.\n"
-                    "If running on CI, add the 'keep-going' label to "
-                    "your PR and rerun your jobs."
+                    + keep_going_message
                 )
 
         os.environ["NUM_PARALLEL_PROCS"] = str(NUM_PROCS)

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1735,6 +1735,7 @@ def main():
     test_batch = TestBatch("tests to run", include, False)
     test_batch_exclude = TestBatch("excluded", exclude, True)
 
+    print_to_stderr(f"Running parallel tests on {NUM_PROCS} processes")
     print_to_stderr(test_batch)
     print_to_stderr(test_batch_exclude)
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1594,7 +1594,7 @@ def run_tests(
             pool.terminate()
 
     keep_going_message = (
-        "Tip: You can keep running tests even on failure by passing --keep-going to run_test.py.\n"
+        "\n\nTip: You can keep running tests even on failure by passing --keep-going to run_test.py.\n"
         "If running on CI, add the 'keep-going' label to your PR and rerun your jobs."
     )
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -28,7 +28,8 @@ from torch.utils.checkpoint import checkpoint_sequential
 from torch.testing._internal.common_utils import TestCase, freeze_rng_state, run_tests, \
     NO_MULTIPROCESSING_SPAWN, skipIfRocm, load_tests, IS_WINDOWS, \
     slowTest, skipCUDANonDefaultStreamIf, skipCUDAMemoryLeakCheckIf, TEST_CUDA, TEST_CUDA_GRAPH, TEST_WITH_ROCM, TEST_NUMPY, \
-    get_cycles_per_ms, parametrize, instantiate_parametrized_tests, subtest, IS_JETSON, gcIfJetson, NoTest, IS_LINUX, IS_ARM64
+    get_cycles_per_ms, parametrize, instantiate_parametrized_tests, subtest, IS_JETSON, gcIfJetson, NoTest, IS_LINUX, IS_ARM64, \
+    serialTest
 from torch.testing._internal.common_cuda import TEST_CUDNN, TEST_MULTIGPU, \
     _create_scaling_case, _get_torch_cuda_version
 from torch.testing._internal.autocast_test_lists import AutocastTestLists
@@ -171,6 +172,7 @@ class TestCuda(TestCase):
         tensor.fill_(1)
         self.assertTrue((tensor == 1).all())
 
+    @serialTest()
     @unittest.skipIf(TEST_CUDAMALLOCASYNC or IS_JETSON, "Segmentation fault (core dumped)")
     def test_out_of_memory_retry(self):
         torch.cuda.empty_cache()
@@ -850,6 +852,7 @@ except RuntimeError as e:
                 z = x + y
 
     @unittest.skipIf(not TEST_MEDIUM_TENSOR, "not enough memory")
+    @serialTest()
     def test_cuda_kernel_loop_overflow(self):
         # Issue #24309: In extreme cases, the loop variable could overflow and continue
         # the kernel loop with a negative index, causing a RuntimeError (invalid write):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -864,6 +864,7 @@ except RuntimeError as e:
 
     @unittest.skipIf(not TEST_LARGE_TENSOR, "not enough memory")
     @gcIfJetson
+    @serialTest(TEST_CUDA)
     def test_cuda_kernel_loop_overflow_large(self):
         # Make sure input.numel() > INT_MAX is handled:
         x = torch.randn(1, 1, 1, 2**31, dtype=torch.float16, device="cuda")

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2025,6 +2025,7 @@ exit(2)
                 torch.zeros(2 ** 40, device="cuda")
 
     @unittest.skipIf(not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs")
+    @serialTest()
     def test_repeat_graph_capture_cublas_workspace_memory(self):
         (x, y, z) = 1024, 512, 64
         a = torch.rand((x, y), device='cuda')
@@ -2611,6 +2612,7 @@ exit(2)
     # DropoutState's long-lived internal buffer. Calling code perceives this (correct) behavior
     # as a memory leak unless we skip the leak check.
     @skipCUDAMemoryLeakCheckIf(True)
+    @serialTest()
     def test_graph_cudnn_dropout(self):
         # Tests the interaction of cuda graph capture with DropoutState's syncs in ATen/native/cudnn/RNN.cpp.
         # In particular, if user runs a sequence of captured and noncaptured cudnn rnns, DropoutState should

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -257,6 +257,7 @@ class TestCuda(TestCase):
         c.copy_(b, non_blocking=True)
         self.assertEqual(a, c, exact_dtype=False)
 
+    @serialTest()
     def test_to_non_blocking(self):
         stream = torch.cuda.current_stream()
 
@@ -2705,6 +2706,7 @@ exit(2)
             {True: "_allow_unused_input", False: "_not_allow_unused_input"}[z],
         ),
     )
+    @serialTest()
     def test_graph_make_graphed_callables(
         self, with_amp, cache_enabled, allow_unused_input
     ):

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from torch.testing import make_tensor
 from torch.testing._internal.common_utils import (
-    TestCase, run_tests, skipIfTorchDynamo, DeterministicGuard)
+    TestCase, run_tests, skipIfTorchDynamo, DeterministicGuard, serialTest, TEST_CUDA)
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests, onlyCUDA, dtypes, dtypesIfCPU, dtypesIfCUDA,
     onlyNativeDeviceTypes, skipXLA)
@@ -740,6 +740,7 @@ class TestIndexing(TestCase):
             self.assertEqual(len(w), 2)
 
     @skipIfTorchDynamo("This test causes SIGKILL when running with dynamo, https://github.com/pytorch/pytorch/issues/88472")
+    @serialTest(TEST_CUDA)
     def test_index_put_accumulate_large_tensor(self, device):
         # This test is for tensors with number of elements >= INT_MAX (2^31 - 1).
         N = (1 << 31) + 5

--- a/test/test_jit_autocast.py
+++ b/test/test_jit_autocast.py
@@ -7,7 +7,7 @@ from typing import Optional, Tuple
 import unittest
 from test_jit import JitTestCase
 from torch.testing._internal.common_cuda import TEST_CUDA
-from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo
+from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, serialTest
 from torch.testing import FileCheck
 from jit.test_models import MnistNet
 
@@ -800,6 +800,7 @@ class TestJitTraceAutocast(JitTestCase):
         for i in range(self.models.__len__()):
             test_nchw_autocast_jit_trace_model(self.models[i], self.inputs[i])
 
+    @serialTest()
     def test_nhwc_autocast_jit_trace_model(self):
         def test_nhwc_autocast_jit_trace_model(model, x):
             model = model.to(memory_format=torch.channels_last)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -32,7 +32,7 @@ from torch.testing._internal.common_dtype import integral_types, get_all_math_dt
 from torch.testing._internal.common_utils import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, skipIfRocm, \
     TEST_NUMPY, TEST_SCIPY, TEST_WITH_CROSSREF, TEST_WITH_ROCM, \
     download_file, get_function_arglist, load_tests, skipIfMps, \
-    IS_PPC, \
+    IS_PPC, serialTest, \
     parametrize as parametrize_test, subtest, instantiate_parametrized_tests, \
     skipIfTorchDynamo, gcIfJetson, set_default_dtype
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, PLATFORM_SUPPORTS_FLASH_ATTENTION
@@ -11384,6 +11384,7 @@ class TestNNDeviceType(NNTestCase):
     @largeTensorTest("20GB", "cpu")
     @largeTensorTest("20GB", "cuda")
     @parametrize_test("reduction", ("none", "mean", "sum"))
+    @serialTest(TEST_CUDA)
     def test_cross_entropy_64bit(self, device, reduction):
         labels = torch.zeros(190, 50, dtype=torch.long, device=device)
         logits = torch.ones(190, 229000, 50, dtype=torch.float, device=device)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8019,6 +8019,7 @@ class TestNNDeviceType(NNTestCase):
     @onlyCUDA
     @largeTensorTest("60GB", "cpu")
     @largeTensorTest("16GB", "cuda")
+    @serialTest()
     def test_avg_pool_large_tensor(self, device):
         # test for https://github.com/pytorch/pytorch/issues/113833
         a = torch.randn(128, 256, 256, 256, dtype=torch.half, device=device, requires_grad=True)
@@ -8585,6 +8586,7 @@ class TestNNDeviceType(NNTestCase):
             self.assertEqual(x.grad[:, :, -1, -1], g[:, :, -pb - 1 :, -pr - 1 :].sum((-2, -1)))
 
     @largeTensorTest("6GB")
+    @serialTest()
     def test_ReplicationPad3d_large(self, device):
         shapes = ([1, 65736, 2, 2, 2], [65736, 1, 2, 2, 2])
         pl, pr, pt, pbt, pf, pbk = 3, 4, 5, 6, 7, 8
@@ -9774,6 +9776,7 @@ class TestNNDeviceType(NNTestCase):
     @onlyCUDA
     @dtypes(torch.half)
     @largeTensorTest('40GB')
+    @serialTest()
     def test_upsampling_64bit_indexing_channels_last(self, device, dtype):
         x = torch.rand((32, 64, 512, 512), dtype=dtype, device=device)
         out = torch.nn.functional.interpolate(x.to(memory_format=torch.channels_last), scale_factor=2, mode='nearest')
@@ -9784,6 +9787,7 @@ class TestNNDeviceType(NNTestCase):
     @onlyCUDA
     @dtypes(torch.half)
     @largeTensorTest('40GB')
+    @serialTest()
     def test_replicatepad_64bit_indexing(self, device, dtype):
         conv = torch.nn.Conv1d(128, 128, 3, 1, 1, padding_mode="replicate", device=device, dtype=dtype)
         x = torch.randn(size=(256 * 448 * 2, 128, 96), dtype=dtype, device=device)
@@ -10118,6 +10122,7 @@ class TestNNDeviceType(NNTestCase):
     @dtypes(torch.float, torch.half)
     @largeTensorTest("20GB")
     @largeTensorTest("64GB", "cpu")
+    @serialTest()
     def test_warp_softmax_64bit_indexing(self, device, dtype):
         def run_test(*shape):
             x = torch.randn(shape, device="cuda", dtype=torch.float16, requires_grad=True)
@@ -10141,6 +10146,7 @@ class TestNNDeviceType(NNTestCase):
     @dtypes(torch.half)
     @largeTensorTest("20GB")
     @largeTensorTest("2GB", "cpu")
+    @serialTest()
     @precisionOverride({torch.half: 0.001})
     def test_softmax_64bit_indexing(self, device, dtype):
         def run_test(*shape):
@@ -10239,6 +10245,7 @@ class TestNNDeviceType(NNTestCase):
                      #   large_view.grad.numel()) * sizeof(dtype)
                      32769 * (65536 + 3 * 65536 / 128) *
                      torch.tensor([], dtype=dtype).element_size())
+    @serialTest()
     def test_grid_sample_large_index_2d(self, device, dtype):
         # Test 64-bit indexing with grid_sample (gh-41656)
         # Try accessing the corners, there should be no segfault
@@ -10284,6 +10291,7 @@ class TestNNDeviceType(NNTestCase):
                      #   large_view.grad.numel()) * sizeof(dtype)
                      2 * 32769 * (32768 + 3 * 32768 / 128) *
                      torch.tensor([], dtype=dtype).element_size())
+    @serialTest()
     def test_grid_sample_large_index_3d(self, device, dtype):
         # Test 64-bit indexing with grid_sample (gh-41656)
         # Try accessing the corners, there should be no segfault
@@ -11352,6 +11360,7 @@ class TestNNDeviceType(NNTestCase):
     @onlyCUDA
     @largeTensorTest("120GB", "cpu")
     @largeTensorTest("45GB", "cuda")
+    @serialTest()
     @parametrize_test("reduction", ("none", "mean", "sum"))
     def test_nll_loss_large_tensor(self, device, reduction):
         shape = [int(2 ** 16), int(2 ** 16) + 1]
@@ -11385,6 +11394,7 @@ class TestNNDeviceType(NNTestCase):
     @onlyCUDA
     @largeTensorTest("20GB", "cpu")
     @largeTensorTest("20GB", "cuda")
+    @serialTest()
     @parametrize_test("reduction", ("none", "mean", "sum"))
     @serialTest(TEST_CUDA)
     def test_cross_entropy_64bit(self, device, reduction):
@@ -11744,6 +11754,7 @@ if __name__ == '__main__':
     @onlyCUDA
     @largeTensorTest("45GB", "cpu")
     @largeTensorTest("70GB", "cuda")
+    @serialTest()
     @parametrize_test("reduction", ("none", "mean", "sum"))
     def test_cross_entropy_large_tensor(self, device, reduction):
         logits = torch.randn(int(2 ** 16), int(2 ** 16) + 1, dtype=torch.float32, device='cuda', requires_grad=True)
@@ -12628,6 +12639,7 @@ if __name__ == '__main__':
     # reference issue: https://github.com/pytorch/pytorch/issues/111484
     @onlyCUDA
     @largeTensorTest("42GB", "cuda")
+    @serialTest()
     def test_softmax_forward_64bit_indexing(self, device):
         batch_size = 70
         seq_len = 2048
@@ -12642,6 +12654,7 @@ if __name__ == '__main__':
 
     @onlyCUDA
     @largeTensorTest("20GB", "cuda")
+    @serialTest()
     def test_softmax_backward_64bit_indexing(self, device):
         for numel in (2147483650, 2147483650 + 1):
             x = torch.empty([1, 1, numel], device=device, dtype=torch.float16)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11396,7 +11396,6 @@ class TestNNDeviceType(NNTestCase):
     @largeTensorTest("20GB", "cuda")
     @serialTest()
     @parametrize_test("reduction", ("none", "mean", "sum"))
-    @serialTest(TEST_CUDA)
     def test_cross_entropy_64bit(self, device, reduction):
         labels = torch.zeros(190, 50, dtype=torch.long, device=device)
         logits = torch.ones(190, 229000, 50, dtype=torch.float, device=device)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2659,6 +2659,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                     torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths)
 
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+    @serialTest()
     def test_CTCLoss_long_targets(self):
         input_length = 4000
         vocab_size = 3

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8891,6 +8891,7 @@ class TestNNDeviceType(NNTestCase):
 
     @onlyCUDA
     @largeTensorTest('16GB')
+    @serialTest()
     def test_prelu_backward_32bit_indexing(self, device):
         m = torch.nn.PReLU().cuda().half()
         input_ = torch.ones((1024, 1024, 1024, 2), dtype=torch.half, device=device)

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -19,7 +19,7 @@ from torch.testing._internal.common_dtype import (
 )
 from torch.testing._internal.common_utils import (
     TestCase, run_tests, skipIfNoSciPy, slowTest, torch_to_numpy_dtype_dict,
-    IS_WINDOWS)
+    IS_WINDOWS, serialTest, TEST_CUDA)
 from torch.testing._internal.common_device_type import (
     OpDTypes, expectedFailureMeta, instantiate_device_type_tests, onlyCPU, dtypes, dtypesIfCUDA, dtypesIfCPU,
     onlyNativeDeviceTypes, onlyCUDA, largeTensorTest, ops, precisionOverride)

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -400,6 +400,7 @@ class TestReductions(TestCase):
     @largeTensorTest("8gb")
     @ops(filter(lambda op: op.ref is not None, reduction_ops),
          allowed_dtypes=[torch.float64])
+    @serialTest(TEST_CUDA)
     def test_ref_large_input_64bit_indexing(self, device, dtype, op: ReductionOpInfo):
         """Compares op against reference for a very large input tensor that requires 64 bit indexing"""
         self._test_ref(op, make_tensor((275000000,), dtype=dtype, device=device, low=-1, high=1, exclude_zero=True))
@@ -2289,6 +2290,7 @@ class TestReductions(TestCase):
 
     @onlyCUDA
     @largeTensorTest('10GB')
+    @serialTest(TEST_CUDA)
     def test_reduction_split(self, device):
         # Test reduction when there is a 32bit-indexing split
         # https://github.com/pytorch/pytorch/issues/37583
@@ -3601,6 +3603,7 @@ as the input tensor excluding its innermost dimension'):
     @onlyCUDA
     @largeTensorTest("8GB")
     @dtypes(torch.half, torch.chalf, torch.bfloat16)
+    @serialTest(TEST_CUDA)
     def test_reductions_large_half_tensors(self, device, dtype):
         t = torch.ones(2**31, device=device, dtype=dtype)
         t[2**30:] = -1

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2290,7 +2290,7 @@ class TestReductions(TestCase):
 
     @onlyCUDA
     @largeTensorTest('10GB')
-    @serialTest(TEST_CUDA)
+    @serialTest()
     def test_reduction_split(self, device):
         # Test reduction when there is a 32bit-indexing split
         # https://github.com/pytorch/pytorch/issues/37583
@@ -3603,7 +3603,7 @@ as the input tensor excluding its innermost dimension'):
     @onlyCUDA
     @largeTensorTest("8GB")
     @dtypes(torch.half, torch.chalf, torch.bfloat16)
-    @serialTest(TEST_CUDA)
+    @serialTest()
     def test_reductions_large_half_tensors(self, device, dtype):
         t = torch.ones(2**31, device=device, dtype=dtype)
         t[2**30:] = -1

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -27,7 +27,7 @@ from torch.serialization import check_module_version_greater_or_equal, get_defau
 from torch.testing._internal.common_utils import (
     IS_FILESYSTEM_UTF8_ENCODING, TemporaryDirectoryName,
     TestCase, IS_WINDOWS, TEST_DILL, run_tests, download_file, BytesIOContext, TemporaryFileName,
-    parametrize, instantiate_parametrized_tests, AlwaysWarnTypedStorageRemoval)
+    parametrize, instantiate_parametrized_tests, AlwaysWarnTypedStorageRemoval, serialTest)
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_dtype import all_types_and_complex_and
 
@@ -937,6 +937,7 @@ class TestSerialization(TestCase, SerializationMixin):
             torch.load(f)
 
     # Ensure large zip64 serialization works properly
+    @serialTest()
     def test_serialization_2gb_file(self):
         # Run GC to clear up as much memory as possible before running this test
         gc.collect()

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -17,7 +17,7 @@ from torch.testing._internal.common_utils import (
     TestCase, run_tests, do_test_empty_full, TEST_WITH_ROCM, suppress_warnings,
     torch_to_numpy_dtype_dict, numpy_to_torch_dtype_dict, slowTest,
     set_default_dtype, set_default_tensor_type,
-    TEST_SCIPY, IS_MACOS, IS_PPC, IS_JETSON, IS_WINDOWS, parametrize, skipIfTorchDynamo)
+    TEST_SCIPY, IS_MACOS, IS_PPC, IS_JETSON, IS_WINDOWS, parametrize, skipIfTorchDynamo, serialTest)
 from torch.testing._internal.common_device_type import (
     expectedFailureMeta, instantiate_device_type_tests, deviceCountAtLeast, onlyNativeDeviceTypes,
     onlyCPU, largeTensorTest, precisionOverride, dtypes,
@@ -2677,6 +2677,7 @@ class TestTensorCreation(TestCase):
 
     @onlyCUDA
     @largeTensorTest('16GB')
+    @serialTest()
     def test_range_factories_64bit_indexing(self, device):
         bigint = 2 ** 31 + 1
         t = torch.arange(bigint, dtype=torch.long, device=device)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -39,7 +39,7 @@ from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
     skipIfRocm, skipIfNoSciPy, TemporaryFileName, TemporaryDirectoryName,
     wrapDeterministicFlagAPITest, DeterministicGuard, CudaSyncGuard,
     skipIfNotRegistered, bytes_to_scalar, parametrize, skipIfMps, noncontiguous_like,
-    AlwaysWarnTypedStorageRemoval, TEST_WITH_TORCHDYNAMO)
+    AlwaysWarnTypedStorageRemoval, TEST_WITH_TORCHDYNAMO, serialTest)
 from multiprocessing.reduction import ForkingPickler
 from torch.testing._internal.common_device_type import (
     expectedFailureMeta,
@@ -3081,6 +3081,7 @@ else:
     @largeTensorTest('25GB', device='cpu')
     @largeTensorTest('4GB', device='cuda')
     @unittest.skipIf(IS_JETSON, "psutil issue for largeTensorTest. Too large for Jetson.")
+    @serialTest()
     def test_large_cumprod(self, device, dtype):
         # initialization to avoid overflow and half caveats
         x = torch.empty(2**30 + 200, device=device, dtype=dtype)

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -34,6 +34,8 @@ from torch.testing._internal.common_utils import (
     NOTEST_CPU,
     IS_WINDOWS,
     TEST_WITH_TORCHDYNAMO,
+    decorateIf,
+    serialTest,
 )
 from torch._dynamo.testing import CompileCounterWithBackend
 
@@ -2796,6 +2798,10 @@ class TestSDPACudaOnly(NNTestCase):
     @parametrize("dropout_p", [0.0, 0.22, 0.48])
     @parametrize("dtype", [torch.float16, torch.bfloat16])
     @parametrize("scale", [None, "l1"])
+    @decorateIf(
+        serialTest(),
+        lambda params: params["seq_len_q"] >= 2048 and params["seq_len_k"] >= 2048
+    )
     def test_flash_attention_vs_math_ref_grads(self, device, batch_size: int, seq_len_q: int, seq_len_k: int,
                                                head_dim: int, is_causal: bool, dropout_p: float, dtype: torch.dtype,
                                                scale: str):

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -11,13 +11,14 @@ from tools.testing.test_run import ShardedTest, TestRun
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 IS_MEM_LEAK_CHECK = os.getenv("PYTORCH_TEST_CUDA_MEM_LEAK_CHECK", "0") == "1"
+IS_SM86 = 'sm86' in os.getenv("BUILD_ENVIRONMENT", "")
 
 # NUM_PROCS_FOR_SHARDING_CALC must remain consistent across all shards of a job
 # to ensure that sharding is consistent, NUM_PROCS is the actual number of procs
 # used to run tests.  If they are not equal, the only consequence should be
 # unequal shards.
 IS_ROCM = os.path.exists("/opt/rocm")
-NUM_PROCS = 1 if IS_MEM_LEAK_CHECK else 2
+NUM_PROCS = 1 if IS_MEM_LEAK_CHECK else 3 if IS_SM86 else 2
 NUM_PROCS_FOR_SHARDING_CALC = NUM_PROCS if not IS_ROCM or IS_MEM_LEAK_CHECK else 2
 THRESHOLD = 60 * 10  # 10 minutes
 

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -11,7 +11,7 @@ from tools.testing.test_run import ShardedTest, TestRun
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 IS_MEM_LEAK_CHECK = os.getenv("PYTORCH_TEST_CUDA_MEM_LEAK_CHECK", "0") == "1"
-IS_SM86 = 'sm86' in os.getenv("BUILD_ENVIRONMENT", "")
+IS_SM86 = "sm86" in os.getenv("BUILD_ENVIRONMENT", "")
 
 # NUM_PROCS_FOR_SHARDING_CALC must remain consistent across all shards of a job
 # to ensure that sharding is consistent, NUM_PROCS is the actual number of procs

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -11,14 +11,15 @@ from tools.testing.test_run import ShardedTest, TestRun
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 IS_MEM_LEAK_CHECK = os.getenv("PYTORCH_TEST_CUDA_MEM_LEAK_CHECK", "0") == "1"
-IS_SM86 = "sm86" in os.getenv("BUILD_ENVIRONMENT", "") or "cuda" not in os.getenv("BUILD_ENVIRONMENT", "")
+BUILD_ENVIRONMENT = os.getenv("BUILD_ENVIRONMENT", "")
+USE_3_PROCS = "sm86" in BUILD_ENVIRONMENT or "cuda" not in BUILD_ENVIRONMENT
 
 # NUM_PROCS_FOR_SHARDING_CALC must remain consistent across all shards of a job
 # to ensure that sharding is consistent, NUM_PROCS is the actual number of procs
 # used to run tests.  If they are not equal, the only consequence should be
 # unequal shards.
 IS_ROCM = os.path.exists("/opt/rocm")
-NUM_PROCS = 1 if IS_MEM_LEAK_CHECK else 3 if IS_SM86 else 2
+NUM_PROCS = 1 if IS_MEM_LEAK_CHECK else 3 if USE_3_PROCS else 2
 NUM_PROCS_FOR_SHARDING_CALC = NUM_PROCS if not IS_ROCM or IS_MEM_LEAK_CHECK else 2
 THRESHOLD = 60 * 10  # 10 minutes
 

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -12,7 +12,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 IS_MEM_LEAK_CHECK = os.getenv("PYTORCH_TEST_CUDA_MEM_LEAK_CHECK", "0") == "1"
 BUILD_ENVIRONMENT = os.getenv("BUILD_ENVIRONMENT", "")
-USE_3_PROCS = "sm86" in BUILD_ENVIRONMENT or "cuda" not in BUILD_ENVIRONMENT
+USE_3_PROCS = "sm86" in BUILD_ENVIRONMENT
 
 # NUM_PROCS_FOR_SHARDING_CALC must remain consistent across all shards of a job
 # to ensure that sharding is consistent, NUM_PROCS is the actual number of procs

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -11,7 +11,7 @@ from tools.testing.test_run import ShardedTest, TestRun
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 IS_MEM_LEAK_CHECK = os.getenv("PYTORCH_TEST_CUDA_MEM_LEAK_CHECK", "0") == "1"
-IS_SM86 = "sm86" in os.getenv("BUILD_ENVIRONMENT", "")
+IS_SM86 = "sm86" in os.getenv("BUILD_ENVIRONMENT", "") or "cuda" not in os.getenv("BUILD_ENVIRONMENT", "")
 
 # NUM_PROCS_FOR_SHARDING_CALC must remain consistent across all shards of a job
 # to ensure that sharding is consistent, NUM_PROCS is the actual number of procs

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -97,6 +97,11 @@ from torch.utils._import_utils import _check_module_exists
 import torch.utils._pytree as pytree
 
 from .composite_compliance import no_dispatch
+try:
+    import pytest
+    has_pytest = True
+except ImportError:
+    has_pytest = False
 
 
 # Class to keep track of test flags configurable by environment variables.
@@ -1384,6 +1389,15 @@ def skipIfTorchInductor(msg="test doesn't currently work with torchinductor",
 
     return decorator
 
+def serialTest(condition=True):
+    """
+    Decorator for running tests serially.  Requires pytest
+    """
+    def decorator(fn):
+        if has_pytest and condition:
+            return pytest.mark.serial(fn)
+        return fn
+    return decorator
 
 def unMarkDynamoStrictTest(cls=None):
     def decorator(cls):


### PR DESCRIPTION
Add serial marker for individual tests to remove the ci serial list
Run serial marked tests first in serial
Run all other tests afterwards in parallel
3 procs for sm86 runners (20-40 min TTS reduction per shard)
Can probably also do 3 procs for cpu runners

serial no longer looks like a real word to me

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang