### PR TITLE
Add quantized.linear_unpacked_dynamic_fp16

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -660,6 +660,121 @@ class QLinearDynamicFp16 final {
 #endif // USE_FBGEMM
 };
 
+class QLinearUnpackedDynamicFp16 final {
+ public:
+#ifdef USE_FBGEMM
+  static at::Tensor run(
+      at::Tensor input,
+      const at::Tensor weight,
+      const at::Tensor bias) {
+    // We make a strong guarantee that models using these operators will have
+    // the same numerics across different machines. Therefore, we do not provide
+    // a fallback path and rather fail loudly if we cannot run FBGEMM.
+    TORCH_CHECK(
+        fbgemm::fbgemmSupportedCPU(), "Your CPU doesn't support FBGEMM.");
+
+    TORCH_CHECK(
+        weight.dim() == 2,
+        "The dimension of weight tensor should be equal to 2");
+
+    auto packed_weight = PackedLinearWeightFp16::prepack(weight, bias);
+    auto output = packed_weight->apply_dynamic(std::move(input));
+
+    return output;
+  }
+
+  static at::Tensor meta(
+      at::Tensor input,
+      const at::Tensor weight,
+      const at::Tensor bias) {
+    // We make a strong guarantee that models using these operators will have
+    // the same numerics across different machines. Therefore, we do not provide
+    // a fallback path and rather fail loudly if we cannot run FBGEMM.
+    TORCH_CHECK(
+        fbgemm::fbgemmSupportedCPU(), "Your CPU doesn't support FBGEMM.");
+
+    TORCH_CHECK(
+        weight.dim() == 2,
+        "The dimension of weight tensor should be equal to 2");
+
+    auto out_channel = weight.sym_sizes().vec()[0];
+    auto out_sizes = input.sym_sizes().vec();
+    out_sizes[out_sizes.size() - 1] = out_channel;
+
+    return at::empty_symint(out_sizes, input.options());
+  }
+#else // USE_FBGEMM
+  static at::Tensor run(
+      at::Tensor /* input */,
+      const at::Tensor weight,
+      const at::Tensor bias) {
+    // We make a strong guarantee that models using these operators will have
+    // the same numerics across different machines. Therefore, we do not provide
+    // a fallback path and rather fail loudly if we cannot run FBGEMM.
+    TORCH_CHECK(
+        false, "This PyTorch installation was not built with FBGEMM operators");
+  }
+
+  static at::Tensor meta(
+      at::Tensor /* input */,
+      const at::Tensor weight,
+      const at::Tensor bias) {
+    TORCH_CHECK(
+        false, "This PyTorch installation was not built with FBGEMM operators");
+  }
+#endif // USE_FBGEMM
+};
+
+at::Tensor wrapped_fbgemm_pack_gemm_matrix_fp16(const at::Tensor weight) {
+#ifdef USE_FBGEMM
+  TORCH_CHECK(
+      weight.dim() == 2,
+      "fbgemm weight packing only packs matrices not vectors.");
+  return at::native::fbgemm_pack_gemm_matrix_fp16(weight);
+#else // USE_FBGEMM
+  TORCH_CHECK(
+      false, "This PyTorch installation was not built with FBGEMM operators");
+#endif // USE_FBGEMM
+}
+
+at::Tensor wrapped_fbgemm_pack_gemm_matrix_fp16_meta(const at::Tensor weight) {
+#ifdef USE_FBGEMM
+  // Strictly speaking this is not correct. However we do not know the exact
+  // size of the packed matrix as it's being maintained by the object itself,
+  // therefore we return the view we have here.
+  return at::empty({8}, weight.options().dtype(at::kByte));
+#else // USE_FBGEMM
+  TORCH_CHECK(
+      false, "This PyTorch installation was not built with FBGEMM operators");
+#endif // USE_FBGEMM
+}
+
+at::Tensor wrapped_fbgemm_linear_fp16_weight(at::Tensor input, const at::Tensor weight, const at::Tensor bias, int64_t out_channel) {
+#ifdef USE_FBGEMM
+  return at::native::fbgemm_linear_fp16_weight(input, weight, bias);
+#else // USE_FBGEMM
+  TORCH_CHECK(
+      false, "This PyTorch installation was not built with FBGEMM operators");
+#endif // USE_FBGEMM
+}
+
+at::Tensor wrapped_fbgemm_linear_fp16_weight_meta(at::Tensor input, const at::Tensor weight, const at::Tensor bias, int64_t out_channel) {
+#ifdef USE_FBGEMM
+  // For the meta function, we need users to provide the dimension explicitly
+  // as we don't have access to the weight.
+  auto out_sizes = input.sym_sizes().vec();
+  if (out_channel == -1) {
+    out_sizes.pop_back();
+  } else {
+    out_sizes.back() = out_channel;
+  }
+  return at::empty_symint(out_sizes, input.options());
+#else // USE_FBGEMM
+  TORCH_CHECK(
+      false, "This PyTorch installation was not built with FBGEMM operators");
+#endif // USE_FBGEMM
+}
+
 TORCH_LIBRARY_IMPL(quantized, CPU, m) {
   register_linear_params();
   m.impl(
@@ -672,8 +787,35 @@ TORCH_LIBRARY_IMPL(quantized, CPU, m) {
       TORCH_SELECTIVE_NAME("quantized::linear_dynamic_fp16"),
       TORCH_FN(QLinearDynamicFp16<false>::run));
   m.impl(
+      TORCH_SELECTIVE_NAME("quantized::linear_unpacked_dynamic_fp16"),
+      TORCH_FN(QLinearUnpackedDynamicFp16::run));
+  m.impl(
       TORCH_SELECTIVE_NAME("quantized::linear_relu_dynamic_fp16"),
       TORCH_FN(QLinearDynamicFp16<true>::run));
+}
+
+TORCH_LIBRARY_IMPL(quantized, Meta, m) {
+  m.impl(
+      TORCH_SELECTIVE_NAME("quantized::linear_unpacked_dynamic_fp16"),
+      TORCH_FN(QLinearUnpackedDynamicFp16::meta));
+}
+
+TORCH_LIBRARY_IMPL(quantized_wrapper, CPU, m) {
+  m.impl(
+      TORCH_SELECTIVE_NAME("quantized_wrapper::wrapped_fbgemm_pack_gemm_matrix_fp16"),
+      wrapped_fbgemm_pack_gemm_matrix_fp16);
+  m.impl(
+      TORCH_SELECTIVE_NAME("quantized_wrapper::wrapped_fbgemm_linear_fp16_weight"),
+      wrapped_fbgemm_linear_fp16_weight);
+}
+
+TORCH_LIBRARY_IMPL(quantized_wrapper, Meta, m) {
+  m.impl(
+      TORCH_SELECTIVE_NAME("quantized_wrapper::wrapped_fbgemm_pack_gemm_matrix_fp16"),
+      wrapped_fbgemm_pack_gemm_matrix_fp16_meta);
+  m.impl(
+      TORCH_SELECTIVE_NAME("quantized_wrapper::wrapped_fbgemm_linear_fp16_weight"),
+      wrapped_fbgemm_linear_fp16_weight_meta);
 }
 
 TORCH_LIBRARY_IMPL(_quantized, CPU, m) {

--- a/aten/src/ATen/native/quantized/library.cpp
+++ b/aten/src/ATen/native/quantized/library.cpp
@@ -149,6 +149,7 @@ TORCH_LIBRARY(quantized, m) {
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_dynamic(Tensor X, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack, bool reduce_range=False) -> Tensor Y"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_relu_dynamic(Tensor X, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack, bool reduce_range=False) -> Tensor Y"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_dynamic_fp16(Tensor X, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack) -> Tensor Y"), {at::Tag::pt2_compliant_tag});
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_unpacked_dynamic_fp16(Tensor X, Tensor weight, Tensor bias) -> Tensor Y"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_relu_dynamic_fp16(Tensor X, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack) -> Tensor Y"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_leaky_relu(Tensor X, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack, float Y_scale_i, int Y_zero_point_i, float negative_slope) -> Tensor Y"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_tanh(Tensor X, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y"), {at::Tag::pt2_compliant_tag});
@@ -222,6 +223,14 @@ TORCH_LIBRARY(quantized, m) {
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::prelu(Tensor qx, Tensor weight, float output_scale, int output_zero_point) -> Tensor"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::sigmoid(Tensor qx, float output_scale, int output_zero_point) -> Tensor"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::softmax(Tensor qx, int dim, float output_scale, int output_zero_point) -> Tensor"), {at::Tag::pt2_compliant_tag});
+}
+
+TORCH_LIBRARY(quantized_wrapper, m) {
+  // Since packed weights are not PT2-compliant yet, we create a set of ops that
+  // wraps around those linear functions that uses packed weights to make it
+  // PT2-compliant.
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized_wrapper::wrapped_fbgemm_pack_gemm_matrix_fp16(Tensor X) -> Tensor Y"), {at::Tag::pt2_compliant_tag});
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized_wrapper::wrapped_fbgemm_linear_fp16_weight(Tensor X, Tensor weight, Tensor bias, int out_channel) -> Tensor Y"), {at::Tag::pt2_compliant_tag});
 }
 
 // According to #33294: The "_" prefix registration will be

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -32,6 +32,7 @@ from torch.testing._internal.common_quantized import (
 )
 from torch.ao.quantization import PerChannelMinMaxObserver
 from torch.testing._internal.common_cuda import TEST_CUDNN, TEST_CUDA
+from torch.testing._internal.optests import opcheck
 import torch.backends.xnnpack
 
 from typing import Optional
@@ -3340,6 +3341,64 @@ class TestDynamicQuantizedOps(TestCase):
                 ref.relu_()
 
             self.assertEqual(out, ref)
+
+    @skipIfNoFBGEMM
+    def test_unpacked_qlinear_dynamic_fp16(self):
+
+        options = itertools.product(
+            (2, 4),         # batch_size
+            (4, 5, 12),     # input_channels
+            (4, 7, 8),      # output_channels
+        )
+        for batch_size, input_channels, output_channels in options:
+            qlinear_dynamic = torch.ops.quantized.linear_unpacked_dynamic_fp16
+
+            x = torch.randn(batch_size, input_channels)
+            w = torch.randn(output_channels, input_channels)
+            bias = torch.randn(output_channels)
+
+            out = qlinear_dynamic(x, w, bias)
+
+            # qlinear_dynamic_fp16 uses FP32 activation tensors and FP16 weight tensors
+            # output is FP32
+            w_fp16 = w.to(torch.float16).to(torch.float32)
+            ref = F.linear(x, w_fp16, bias)
+
+            self.assertEqual(out, ref)
+
+    @skipIfNoFBGEMM
+    def test_wrapped_fbgemm_linear_fp16(self):
+        options = itertools.product(
+            (2, 4),         # batch_size
+            (4, 5),     # input_channels
+            (4, 7),      # output_channels
+        )
+        for batch_size, input_channels, output_channels in options:
+            pack_op = torch.ops.quantized_wrapper.wrapped_fbgemm_pack_gemm_matrix_fp16
+            linear_op = torch.ops.quantized_wrapper.wrapped_fbgemm_linear_fp16_weight
+
+            x = torch.randn(batch_size, input_channels)
+            w = torch.randn(output_channels, input_channels)
+            bias = torch.randn(output_channels)
+
+            w_packed = pack_op(w)
+            out = linear_op(x, w_packed, bias, output_channels)
+
+            w_fp16 = w.to(torch.float16).to(torch.float32)
+            ref = F.linear(x, w_fp16, bias)
+
+            self.assertEqual(out, ref)
+
+    @skipIfNoFBGEMM
+    def test_unpacked_qlinear_dynamic_fp16_opcheck(self):
+        qlinear_dynamic = torch.ops.quantized.linear_unpacked_dynamic_fp16.default
+
+        x = torch.randn(4, 4, device='cpu')
+        w = torch.randn(4, 4, device='cpu')
+        bias = torch.randn(4, device='cpu')
+
+        opcheck(qlinear_dynamic, (x, w, bias))
+
 
     """Tests the correctness of the dynamic quantized lstm/gru."""
 


### PR DESCRIPTION
Summary:
We add a new op quantized.linear_unpacked_dynamic_fp16, which is essentially linear_dynamic_fp16 with different (unpacked) weight/bias format.
This op does packing on the fly for each call with standard at::Tensor weight & bias.

Test Plan:
Included in commit.
test_quantized_op::test_unpacked_qlinear_dynamic_fp16

Differential Revision: D55234298




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10