### PR TITLE
[CPUInductor] Fix out-of-bounds read/write in cvt_int64_to_[fp32|int32]

### DIFF
--- a/torch/_inductor/codegen/cpp_prefix.h
+++ b/torch/_inductor/codegen/cpp_prefix.h
@@ -500,9 +500,9 @@ inline at::vec::Vectorized<float> cvt_int64_to_fp32(at::vec::VectorizedN<int64_t
   __at_align__ float result[float_vec_size];
   __at_align__ int64_t src_buf[int64_vec_size];
   for (int i = 0; i < 2; i++) {
-    src[i].store(src_buf + i * int64_vec_size);
+    src[i].store(src_buf);
     for (int j = 0; j < int64_vec_size; j++) {
-      result[i * int64_vec_size + j] = static_cast<float>(src_buf[i * int64_vec_size + j]);
+      result[i * int64_vec_size + j] = static_cast<float>(src_buf[j]);
     }
   }
   return at::vec::Vectorized<float>::loadu(result);

--- a/torch/_inductor/codegen/cpp_prefix.h
+++ b/torch/_inductor/codegen/cpp_prefix.h
@@ -551,9 +551,9 @@ inline at::vec::Vectorized<int32_t> cvt_int64_to_int32(at::vec::VectorizedN<int6
   __at_align__ int32_t result[int32_vec_size];
   __at_align__ int64_t src_buf[int64_vec_size];
   for (int i = 0; i < 2; i++) {
-    src[i].store(src_buf + i * int64_vec_size);
+    src[i].store(src_buf);
     for (int j = 0; j < int64_vec_size; j++) {
-      result[i * int64_vec_size + j] = static_cast<int32_t>(src_buf[i * int64_vec_size + j]);
+      result[i * int64_vec_size + j] = static_cast<int32_t>(src_buf[j]);
     }
   }
   return at::vec::Vectorized<int32_t>::loadu(result);


### PR DESCRIPTION
Discovered while debugging regressions in enabling vectorization on ARM platform

Without this change `test_div2_cpu` will fail with invalid values on non-x86 CPU


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang