### PR TITLE
[EZ][BE] Add missing `acosh` op to vec256_float_neon.h

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float_neon.h
@@ -349,6 +349,12 @@ public:
       map(std::acos)
     );
   }
+  Vectorized<float> acosh() const {
+    return USE_SLEEF(
+      Vectorized<float>(Sleef_acoshf4_u10(values.val[0]), Sleef_acoshf4_u10(values.val[1])),
+      map(std::acosh)
+    );
+  }
   Vectorized<float> asin() const {
     return USE_SLEEF(
       Vectorized<float>(Sleef_asinf4_u10(values.val[0]), Sleef_asinf4_u10(values.val[1])),


### PR DESCRIPTION
As base class has it
https://github.com/pytorch/pytorch/blob/ed15370aabf951eec2ba0140de5ff71634868791/aten/src/ATen/cpu/vec/vec_base.h#L367-L369

Discovered while attempting to enabling Inductor vectorization on ARM platform


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10