### PR TITLE
[Dynamo][4/N] Enable clang-tidy coverage on torch/csrc/dynamo/*

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -225,6 +225,7 @@ exclude_patterns = [
     'torch/csrc/api/**',
     'torch/csrc/autograd/generated/**',
     'torch/csrc/distributed/**/*',
+    'torch/csrc/dynamo/eval_frame.h',
     'torch/csrc/inductor/**/*',
     'torch/csrc/jit/**/*',
     'torch/csrc/jit/serialization/import_legacy.cpp',

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -224,7 +224,6 @@ exclude_patterns = [
     'third_party/**/*',
     'torch/csrc/api/**',
     'torch/csrc/autograd/generated/**',
-    'torch/csrc/dynamo/*',
     'torch/csrc/distributed/**/*',
     'torch/csrc/inductor/**/*',
     'torch/csrc/jit/**/*',

--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -749,10 +749,8 @@ class SwapSavedVariables {
   template <typename T>
   struct StashedVars : public std::unordered_map<const T*, Stashed<T>> {
     void save(const T* key, T&& value) {
-      auto it = this->find(key);
-      if (it == this->end()) {
-        this->emplace(key, std::move(value));
-      } else {
+      auto [it, inserted] = this->try_emplace(key, std::move(value));
+      if (!inserted) {
         // keep the value from the prior save()
         it->second.count++;
       }

--- a/torch/csrc/dynamo/cpython_defs.c
+++ b/torch/csrc/dynamo/cpython_defs.c
@@ -209,7 +209,7 @@ _PyFunction_CopyWithNewCode(PyFunctionObject *o, PyCodeObject* code)
 
 // From https://github.com/python/cpython/blob/e715da6db1d1d70cd779dc48e1ba8110c51cc1bf/Objects/frameobject.c#L1020
 PyFrameObject*
-THP_PyFrame_New_NoTrack(PyCodeObject *code)
+THP_PyFrame_New_NoTrack(const PyCodeObject *code)
 {
     // DYNAMO: commented out
     // CALL_STAT_INC(frame_objects_created);

--- a/torch/csrc/dynamo/extra_state.cpp
+++ b/torch/csrc/dynamo/extra_state.cpp
@@ -85,7 +85,7 @@ ExtraState* init_and_set_extra_state(PyCodeObject* code) {
 PyObject* lookup(
     ExtraState* extra_state,
     PyObject* f_locals,
-    PyObject* backend) {
+    const PyObject* backend) {
   size_t index = 0;
   CacheEntry* found = nullptr;
   py::handle locals(f_locals);

--- a/torch/csrc/dynamo/extra_state.h
+++ b/torch/csrc/dynamo/extra_state.h
@@ -127,7 +127,7 @@ ExtraState* init_and_set_extra_state(PyCodeObject* code);
 PyObject* lookup(
     ExtraState* extra_state,
     PyObject* f_locals,
-    PyObject* callback);
+    const PyObject* backend);
 
 // Create a new cache entry at extra_state holding on to guarded_code.
 // Ownership contract


### PR DESCRIPTION
This PR enables clang-tidy coverage on torch/csrc/dynamo/* and also contains other small improvements.
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang