### PR TITLE
Revert "[c10d] disable compute_duration by default (#122138)"

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -102,11 +102,6 @@ static std::vector<std::string> TORCH_NCCL_COORD_CHECK_MILSEC = {
 static std::vector<std::string> TORCH_NCCL_ABORT_IN_DESTROY_PG = {
     "TORCH_NCCL_ABORT_IN_DESTROY_PG"};
 
-// Whether to compute duration between start and end cuda events.
-// If true, timing (enableTiming_) will also be automatically enabled.
-static std::vector<std::string> TORCH_NCCL_COMPUTE_DURATION = {
-    "TORCH_NCCL_COMPUTE_DURATION"};
-
 constexpr const char* NCCL_BACKEND_NAME = "nccl";
 
 constexpr const char* TIMEOUT_DUMP = "timeout_dump";
@@ -1030,9 +1025,6 @@ class TORCH_API ProcessGroupNCCL : public Backend {
 
   // Whether or not to enable timeout root cause analysis.
   bool desyncDebug_;
-
-  // Whether or not to compute duration between start and end cuda events.
-  bool computeDuration_;
 
   // Whether or not to dump debug info on timeout
   bool dumpOnTimeout_;

--- a/torch/csrc/distributed/c10d/TraceUtils.h
+++ b/torch/csrc/distributed/c10d/TraceUtils.h
@@ -528,12 +528,13 @@ struct NCCLTraceBuffer {
   This is called by the watchdog thread, and is asynchronous from the
   perspective of the main thread.
 
-  compute_duration defaults to false since it requires calling the cuda APIs in
-  getDurationFromEvent which might increase the peak memory usage. Also
-  enableTiming_ automatically enabled if compute_duration is true for
-  computation to work correctly - see TORCH_NCCL_ENABLE_TIMING.
+  compute_duration defaults to true since retire_id is only called in the
+  watchdog thread, which is currently a place we call cuda APIs which may hang,
+  but care should be taken to avoid computing duration in any function that must
+  never hang. (timing must also be enabled for compute_duration - see
+  TORCH_NCCL_ENABLE_TIMING).
   */
-  void retire_id(c10::optional<size_t> id, bool compute_duration = false) {
+  void retire_id(c10::optional<size_t> id, bool compute_duration = true) {
     if (!enabled_ || !id) {
       return;
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #122731
* #122732
* __->__ #122539
* #122538

This reverts commit bf18e967b4abc90c27ad460680497d8f5ec55962.

It is stacked after a fix to elapsed_time that will resolve the memory issues that required in the introduction of this flag.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang