### PR TITLE
[AMD] turn off triton memcache for amd devices

### DIFF
--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -825,6 +825,8 @@ def should_use_remote_autotune_cache():
         return True
     if not config.is_fbcode():
         return False
+    if torch.version.hip is not None:
+        return False
 
     from triton.runtime.fb_memcache import MEMCACHE_VERSION
 


### PR DESCRIPTION
Summary:
triton memcache is not supported on amd devices yet and causes torch.compile to fail

Created from CodeHub with https://fburl.com/edit-in-codehub

Test Plan:
ci

Sandcastle run

Differential Revision: D55285655




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang