### PR TITLE
Don't create world pg variable out of thin air when rewriting c10d collectives

### DIFF
--- a/torch/_dynamo/variables/distributed.py
+++ b/torch/_dynamo/variables/distributed.py
@@ -10,7 +10,7 @@ from .._trace_wrapped_higher_order_op import trace_wrapped
 from ..exc import unimplemented
 from ..external_utils import call_module_hooks_from_backward_state
 from ..guards import GuardBuilder, install_guard
-from ..source import AttrSource, GlobalSource
+from ..source import AttrSource
 from ..utils import istype
 from .base import VariableTracker
 from .constant import ConstantVariable
@@ -285,33 +285,6 @@ class ProcessGroupVariable(DistributedVariable):
         from torch.testing._internal.distributed.fake_pg import FakeProcessGroup
 
         return istype(value, (ProcessGroup, FakeProcessGroup))
-
-    @staticmethod
-    def get_global_pg_variable():
-        """
-        Make a ProcessGroupVariable from torch.distributed.group.WORLD and
-        intall guards.
-        """
-        import torch.distributed as dist
-
-        source = AttrSource(
-            AttrSource(
-                base=AttrSource(
-                    base=GlobalSource(global_name="torch"),
-                    member="distributed",
-                    get_static=False,
-                ),
-                member="group",
-                get_static=False,
-            ),
-            member="WORLD",
-            get_static=False,
-        )
-        install_guard(source.make_guard(GuardBuilder.ID_MATCH))
-        return ProcessGroupVariable(
-            dist.group.WORLD,
-            source=source,
-        )
 
 
 class BackwardHookVariable(VariableTracker):

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -18,7 +18,6 @@ from ..source import AttrSource, ConstantSource, DefaultsSource, GetItemSource
 from ..utils import check_constant_args, get_first_attr, identity, istype, make_cell
 from .base import MutableLocal, typestr, VariableTracker
 from .constant import ConstantVariable
-from .distributed import ProcessGroupVariable
 
 if TYPE_CHECKING:
     from torch._guards import Source
@@ -718,9 +717,6 @@ class CollectiveFunctionRewriteVariable(UserFunctionVariable):
             unimplemented(
                 f"CollectiveFunctionRewriteVariable can't support async_op=True for {self.fn}"
             )
-
-        if kwargs.get("group") is None or kwargs["group"].value is None:
-            kwargs["group"] = ProcessGroupVariable.get_global_pg_variable()
 
         if self.fn == dist.all_reduce:
             reduce_op_var = kwargs.get("op")

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -972,6 +972,10 @@ def all_gather_tensor_inplace(
     assert (
         not async_op
     ), "Can't remap async version of inplace op to functional collective"
+
+    group = group or dist.group.WORLD
+    assert group is not None
+
     return output_tensor.copy_(all_gather_tensor(input_tensor, gather_dim, group, tag))
 
 
@@ -987,6 +991,10 @@ def reduce_scatter_tensor_inplace(
     assert (
         not async_op
     ), "Can't remap async version of inplace op to functional collective"
+
+    group = group or dist.group.WORLD
+    assert group is not None
+
     return output.copy_(reduce_scatter_tensor(input, op, scatter_dim, group, tag))
 
 
@@ -1013,6 +1021,9 @@ def all_reduce_inplace(
         not async_op
     ), "Can't remap async version of inplace op to functional collective"
 
+    group = group or dist.group.WORLD
+    assert group is not None
+
     return tensor.copy_(all_reduce(tensor, op, group, tag))
 
 
@@ -1028,8 +1039,18 @@ def all_to_all_inplace(
     assert (
         not async_op
     ), "Can't remap async version of inplace op to functional collective"
+
+    group = group or dist.group.WORLD
+    assert group is not None
+
     return output.copy_(
-        all_to_all_single(input, output_split_sizes, input_split_sizes, group, tag)
+        all_to_all_single(
+            input,
+            output_split_sizes,
+            input_split_sizes,
+            group,
+            tag,
+        )
     )
 
 
@@ -1046,6 +1067,9 @@ def all_gather_inplace(
     assert all(
         t.size(0) == tensor.size(0) for t in tensor_list
     ), "Remapping variable size all_gather is not yet supported"
+
+    group = group or dist.group.WORLD
+    assert group is not None
 
     output = all_gather_tensor(tensor, 0, group, tag)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122561
* #120560

Fixes https://github.com/pytorch/pytorch/issues/122404

Previously, when rewriting c10d collectives, if the group argument is
unspecified or None, we create a world pg variable out of thin air and
pass it to the rewrite target. The approach was problematic, as it
assumes the symbol `torch` is available in the scope (see #122404).

After #120560, dynamo can now trace dist.group.WORLD. If the group
argument is unspecified, we can just set it with dist.group.WORLD in the
rewrite target.

Testing

pytest test/distributed/test_inductor_collectives.py -k test_dynamo_rewrite_dist_allreduce

Also verified with the repro provided in #122404

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng