### PR TITLE
[AOTInductor] Add tensor_constantX to pass constant buffer update's check

### DIFF
--- a/test/cpp/aot_inductor/test.cpp
+++ b/test/cpp/aot_inductor/test.cpp
@@ -241,6 +241,45 @@ void test_aoti_double_buffering(
   ASSERT_TRUE(torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
 }
 
+void test_aoti_double_buffering_with_tensor_constants() {
+  torch::NoGradGuard no_grad;
+
+  std::string data_path = (std::filesystem::path(
+                               STRINGIZE(CMAKE_CURRENT_BINARY_DIR)) /
+                               "data_with_tensor_constants.pt")
+                               .string();
+
+  torch::jit::script::Module data_loader = torch::jit::load(data_path);
+  std::string path_attr = "model_so_path";
+  std::string inputs_attr = "inputs";
+  std::string w_attr = "w";
+  std::string outputs_attr = "outputs";
+  const auto& model_so_path = data_loader.attr(path_attr.c_str()).toStringRef();
+  auto input_tensors =
+      data_loader.attr(inputs_attr.c_str()).toTensorList().vec();
+  const auto& w_tensors = data_loader.attr(w_attr.c_str()).toTensor();
+  const auto& ref_output_tensors =
+      data_loader.attr(outputs_attr.c_str()).toTensorList().vec();
+
+  torch::inductor::TensorConstantMap real_map;
+  real_map.emplace("L__self___w", new at::Tensor(w_tensors));
+
+  std::unique_ptr<torch::inductor::AOTIModelContainerRunner> runner;
+  runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCuda>(
+      model_so_path.c_str());
+
+  // By default, buffer #1 get loaded with burned in weights. Correct results.
+  auto actual_output_tensors = runner->run(input_tensors);
+  ASSERT_TRUE(torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
+
+  // We update the weights to buffer #2 and activate it. This should still
+  // produce correct result, since we would have copied the tensor_constants.
+  runner->update_inactive_constant_buffer(real_map);
+  runner->swap_constant_buffer();
+  actual_output_tensors = runner->run(input_tensors);
+  ASSERT_TRUE(torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
+}
+
 } // namespace
 
 namespace torch {
@@ -278,6 +317,10 @@ TEST(AotInductorTest, RuntimeUpdateInactiveConstantsCuda) {
 
 TEST(AotInductorTest, UpdateInactiveConstantsCuda) {
   test_aoti_double_buffering("cuda", false);
+}
+
+TEST(AotInductorTest, UpdateInactiveConstantsWithTensorConstantsCuda) {
+  test_aoti_double_buffering_with_tensor_constants();
 }
 #endif
 

--- a/test/cpp/aot_inductor/test.py
+++ b/test/cpp/aot_inductor/test.py
@@ -17,38 +17,74 @@ class Net(torch.nn.Module):
         w = w_relu + self.w_add
         return torch.matmul(x, w)
 
+class NetWithTensorConstants(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.w = torch.randn(30, 1, device="cuda")
+
+    def forward(self, x, y):
+        z = self.w * x * y
+        return z[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17]]
+
 data = {}
+data_with_tensor_constants = {}
 
-for device in ["cpu", "cuda"]:
-    for use_runtime_constant_folding in [True, False]:
-        if device == "cpu" and use_runtime_constant_folding:
-            # We do not test runtime const folding for cpu mode.
-            continue
-        model = Net(device).to(device=device)
-        x = torch.randn((4, 4), device=device)
-        with torch.no_grad():
-            ref_output = model(x)
+# Basice AOTI model test generation.
+def generate_basic_tests():
+    for device in ["cpu", "cuda"]:
+        for use_runtime_constant_folding in [True, False]:
+            if device == "cpu" and use_runtime_constant_folding:
+                # We do not test runtime const folding for cpu mode.
+                continue
+            model = Net(device).to(device=device)
+            x = torch.randn((4, 4), device=device)
+            with torch.no_grad():
+                ref_output = model(x)
 
-        torch._dynamo.reset()
-        with torch.no_grad():
-            dim0_x = Dim("dim0_x", min=1, max=1024)
-            dynamic_shapes = {"x": {0: dim0_x}}
-            model_so_path = aot_compile(
-                model,
-                (x,),
-                dynamic_shapes=dynamic_shapes,
-                options={"aot_inductor.use_runtime_constant_folding": use_runtime_constant_folding})
+            torch._dynamo.reset()
+            with torch.no_grad():
+                dim0_x = Dim("dim0_x", min=1, max=1024)
+                dynamic_shapes = {"x": {0: dim0_x}}
+                model_so_path = aot_compile(
+                    model,
+                    (x,),
+                    dynamic_shapes=dynamic_shapes,
+                    options={"aot_inductor.use_runtime_constant_folding": use_runtime_constant_folding})
 
-        suffix = f"{device}"
-        if use_runtime_constant_folding:
-            suffix += "_use_runtime_constant_folding"
-        data.update({
-            f"model_so_path_{suffix}": model_so_path,
-            f"inputs_{suffix}": [x],
-            f"outputs_{suffix}": [ref_output],
-            f"w_pre_{suffix}": model.w_pre,
-            f"w_add_{suffix}": model.w_add,
-        })
+            suffix = f"{device}"
+            if use_runtime_constant_folding:
+                suffix += "_use_runtime_constant_folding"
+            data.update({
+                f"model_so_path_{suffix}": model_so_path,
+                f"inputs_{suffix}": [x],
+                f"outputs_{suffix}": [ref_output],
+                f"w_pre_{suffix}": model.w_pre,
+                f"w_add_{suffix}": model.w_add,
+            })
+
+# AOTI model which will create additional tensors during autograd.
+def generate_test_with_additional_tensors():
+    model = NetWithTensorConstants()
+    x = torch.randn((30, 1), device="cuda")
+    y = torch.randn((30, 1), device="cuda")
+    with torch.no_grad():
+        ref_output = model(x, y)
+
+    torch._dynamo.reset()
+    with torch.no_grad():
+        model_so_path = aot_compile(
+            model,
+            (x, y))
+
+    data_with_tensor_constants.update({
+        "model_so_path": model_so_path,
+        "inputs": [x, y],
+        "outputs": [ref_output],
+        "w": model.w,
+    })
+
+generate_basic_tests()
+generate_test_with_additional_tensors()
 
 # Use this to communicate tensors to the cpp code
 class Serializer(torch.nn.Module):
@@ -58,3 +94,4 @@ class Serializer(torch.nn.Module):
             setattr(self, key, data[key])
 
 torch.jit.script(Serializer(data)).save("data.pt")
+torch.jit.script(Serializer(data_with_tensor_constants)).save("data_with_tensor_constants.pt")


### PR DESCRIPTION
Summary:
During tracing, some constants (tensor_constant{idx}) are being generated internally.
Those constants are neither parameters or buffers, and users have zero control on them.

To accomodate this, we should allow users not passing in those constants generated internally but still be able the constants in the model.

Test Plan:
Included in commit.
```
build/bin/test_aot_inductor
```

Differential Revision: D55286634


