### PR TITLE
Fix clang-tidy warnings in aten/src/ATen/core/*.cpp

### DIFF
--- a/aten/src/ATen/core/Dict.cpp
+++ b/aten/src/ATen/core/Dict.cpp
@@ -1,7 +1,7 @@
 #include <ATen/core/Dict.h>
 
-namespace c10 {
-namespace detail {
+
+namespace c10::detail {
 bool operator==(const DictImpl& lhs, const DictImpl& rhs) {
   bool isEqualFastChecks =
       *lhs.elementTypes.keyType == *rhs.elementTypes.keyType &&
@@ -25,5 +25,4 @@ bool operator==(const DictImpl& lhs, const DictImpl& rhs) {
 
   return true;
 }
-} // namespace detail
-} // namespace c10
+} // namespace c10::detail

--- a/aten/src/ATen/core/Dimname.cpp
+++ b/aten/src/ATen/core/Dimname.cpp
@@ -20,7 +20,7 @@ bool Dimname::isValidName(const std::string& name) {
   // letters A through Z, the underscore _ and, except for the first
   // character, the digits 0 through 9" (at least length 1)
   // https://docs.python.org/3/reference/lexical_analysis.html#identifiers
-  if (name.length() == 0) {
+  if (name.empty()) {
     return false;
   }
   for (auto it = name.begin(); it != name.end(); ++it) {

--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -160,7 +160,7 @@ static void __printIndent(std::ostream &stream, int64_t indent)
 
 static void printScale(std::ostream & stream, double scale) {
   FormatGuard guard(stream);
-  stream << defaultfloat << scale << " *" << std::endl;
+  stream << defaultfloat << scale << " *" << '\n';
 }
 static void __printMatrix(std::ostream& stream, const Tensor& self, int64_t linesize, int64_t indent)
 {
@@ -178,7 +178,7 @@ static void __printMatrix(std::ostream& stream, const Tensor& self, int64_t line
     }
     if(nColumnPerLine < self.size(1)) {
       if(firstColumn != 0) {
-        stream << std::endl;
+        stream << '\n';
       }
       stream << "Columns " << firstColumn+1 << " to " << lastColumn+1;
       __printIndent(stream, indent);
@@ -193,7 +193,7 @@ static void __printMatrix(std::ostream& stream, const Tensor& self, int64_t line
       for (const auto c : c10::irange(firstColumn, lastColumn+1)) {
         stream << std::setw(sz) << row_ptr[c]/scale;
         if(c == lastColumn) {
-          stream << std::endl;
+          stream << '\n';
           if(l != self.size(0)-1) {
             if(scale != 1) {
               __printIndent(stream, indent);
@@ -239,7 +239,7 @@ static void __printTensor(std::ostream& stream, Tensor& self, int64_t linesize)
     if(start) {
       start = false;
     } else {
-      stream << std::endl;
+      stream << '\n';
     }
     stream << "(";
     Tensor tensor = self;
@@ -247,7 +247,7 @@ static void __printTensor(std::ostream& stream, Tensor& self, int64_t linesize)
       tensor = tensor.select(0, counter[i]);
       stream << counter[i]+1 << ",";
     }
-    stream << ".,.) = " << std::endl;
+    stream << ".,.) = " << '\n';
     __printMatrix(stream, tensor, linesize, 1);
   }
 }
@@ -279,7 +279,7 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
       tensor = tensor_.to(kCPU, kDouble).contiguous();
     }
     if(tensor.ndimension() == 0) {
-      stream << defaultfloat << tensor.data_ptr<double>()[0] << std::endl;
+      stream << defaultfloat << tensor.data_ptr<double>()[0] << '\n';
       stream << "[ " << tensor_.toString() << "{}";
     } else if(tensor.ndimension() == 1) {
       if (tensor.numel() > 0) {
@@ -289,7 +289,7 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
         }
         double* tensor_p = tensor.data_ptr<double>();
         for (const auto i : c10::irange(tensor.size(0))) {
-          stream << std::setw(sz) << tensor_p[i]/scale << std::endl;
+          stream << std::setw(sz) << tensor_p[i]/scale << '\n';
         }
       }
       stream << "[ " << tensor_.toString() << "{" << tensor.size(0) << "}";
@@ -329,7 +329,7 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
     if (tensor.getIntrusivePtr()->autograd_meta()) {
       auto& fw_grad = tensor._fw_grad(/* level */ 0);
       if (fw_grad.defined()) {
-        stream << ", tangent:" << std::endl << fw_grad;
+        stream << ", tangent:" << '\n' << fw_grad;
       }
     }
     stream << " ]";

--- a/aten/src/ATen/core/IListRef_test.cpp
+++ b/aten/src/ATen/core/IListRef_test.cpp
@@ -103,7 +103,7 @@ TEST(ITensorListRefTest, Boxed_GetConstRefTensor) {
   const List<at::Tensor> boxed(vec);
   at::ITensorListRef list(boxed);
   static_assert(
-      std::is_same<decltype(*list.begin()), const at::Tensor&>::value,
+      std::is_same_v<decltype(*list.begin()), const at::Tensor&>,
       "Accessing elements from List<Tensor> through a ITensorListRef should be const references.");
   EXPECT_TRUE(boxed[0].is_same(*list.begin()));
   EXPECT_TRUE(boxed[1].is_same(*(++list.begin())));
@@ -113,7 +113,7 @@ TEST(ITensorListRefTest, Unboxed_GetConstRefTensor) {
   auto vec = get_tensor_vector();
   at::ITensorListRef list(vec);
   static_assert(
-      std::is_same<decltype(*list.begin()), const at::Tensor&>::value,
+      std::is_same_v<decltype(*list.begin()), const at::Tensor&>,
       "Accessing elements from ArrayRef<Tensor> through a ITensorListRef should be const references.");
   EXPECT_TRUE(vec[0].is_same(*list.begin()));
   EXPECT_TRUE(vec[1].is_same(*(++list.begin())));

--- a/aten/src/ATen/core/List.cpp
+++ b/aten/src/ATen/core/List.cpp
@@ -1,7 +1,7 @@
 #include <ATen/core/List.h>
 
-namespace c10 {
-namespace detail {
+
+namespace c10::detail {
 bool operator==(const ListImpl& lhs, const ListImpl& rhs) {
   return *lhs.elementType == *rhs.elementType &&
       lhs.list.size() == rhs.list.size() &&
@@ -16,5 +16,4 @@ bool operator==(const ListImpl& lhs, const ListImpl& rhs) {
 ListImpl::ListImpl(list_type list_, TypePtr elementType_)
   : list(std::move(list_))
   , elementType(std::move(elementType_)) {}
-} // namespace detail
-} // namespace c10
+} // namespace c10::detail

--- a/aten/src/ATen/core/List_test.cpp
+++ b/aten/src/ATen/core/List_test.cpp
@@ -1118,7 +1118,7 @@ TEST(ListTestNonIValueBasedList, sameValueDifferentStorage_thenIsReturnsFalse) {
 TEST(ListTest, canAccessStringByReference) {
   List<std::string> list({"one", "two"});
   const auto& listRef = list;
-  static_assert(std::is_same<decltype(listRef[1]), const std::string&>::value,
+  static_assert(std::is_same_v<decltype(listRef[1]), const std::string&>,
                 "const List<std::string> access should be by const reference");
   std::string str = list[1];
   const std::string& strRef = listRef[1];
@@ -1130,7 +1130,7 @@ TEST(ListTest, canAccessOptionalStringByReference) {
   List<c10::optional<std::string>> list({"one", "two", c10::nullopt});
   const auto& listRef = list;
   static_assert(
-      std::is_same<decltype(listRef[1]), c10::optional<std::reference_wrapper<const std::string>>>::value,
+      std::is_same_v<decltype(listRef[1]), c10::optional<std::reference_wrapper<const std::string>>>,
       "List<c10::optional<std::string>> access should be by const reference");
   c10::optional<std::string> str1 = list[1];
   c10::optional<std::string> str2 = list[2];
@@ -1148,7 +1148,7 @@ TEST(ListTest, canAccessTensorByReference) {
   List<at::Tensor> list;
   const auto& listRef = list;
   static_assert(
-      std::is_same<decltype(listRef[0]), const at::Tensor&>::value,
+      std::is_same_v<decltype(listRef[0]), const at::Tensor&>,
       "List<at::Tensor> access should be by const reference");
 }
 

--- a/aten/src/ATen/core/NamedTensor.cpp
+++ b/aten/src/ATen/core/NamedTensor.cpp
@@ -121,9 +121,9 @@ void internal_set_names_inplace(TensorImpl* impl, std::vector<Dimname>&& names, 
   }
   auto* meta = get_named_tensor_meta(impl);
   if (meta == nullptr) {
-    impl->set_named_tensor_meta(std::make_unique<NamedTensorMeta>(NamedTensorMeta::HasNonWildcard, names));
+    impl->set_named_tensor_meta(std::make_unique<NamedTensorMeta>(NamedTensorMeta::HasNonWildcard, std::move(names)));
   } else {
-    meta->set_names(NamedTensorMeta::HasNonWildcard, names);
+    meta->set_names(NamedTensorMeta::HasNonWildcard, std::move(names));
   }
 }
 

--- a/aten/src/ATen/core/PythonFallbackKernel.cpp
+++ b/aten/src/ATen/core/PythonFallbackKernel.cpp
@@ -120,8 +120,8 @@ void preDispatchFallback(const c10::OperatorHandle& op, c10::DispatchKeySet disp
 
 } // anonymous namespace
 
-namespace at {
-namespace impl {
+
+namespace at::impl {
 
 RestorePythonTLSSnapshot::RestorePythonTLSSnapshot() : saved_(safe_get_tls_on_entry()), guard_(safe_get_tls_on_entry()) {
   tls_on_entry = c10::nullopt;
@@ -148,8 +148,7 @@ MaybeSetTLSOnEntryGuard::~MaybeSetTLSOnEntryGuard() {
 }
 
 
-} // namespace impl
-} // namespace at
+} // namespace at::impl
 
 TORCH_LIBRARY_IMPL(_, Python, m) {
   m.fallback(torch::CppFunction::makeFromBoxedFunction<&pythonFallback>());

--- a/aten/src/ATen/core/PythonOpRegistrationTrampoline.cpp
+++ b/aten/src/ATen/core/PythonOpRegistrationTrampoline.cpp
@@ -1,7 +1,6 @@
 #include <ATen/core/PythonOpRegistrationTrampoline.h>
 
-namespace at {
-namespace impl {
+namespace at::impl {
 
 // The strategy is that all python interpreters attempt to register themselves
 // as the main interpreter, but only one wins.  Only that interpreter is
@@ -9,14 +8,15 @@ namespace impl {
 // logic on that interpreter, we do so hermetically, never setting pyobj field
 // on Tensor.
 
-std::atomic<c10::impl::PyInterpreter*> PythonOpRegistrationTrampoline::interpreter_{nullptr};
+std::atomic<c10::impl::PyInterpreter*>
+    PythonOpRegistrationTrampoline::interpreter_{nullptr};
 
 c10::impl::PyInterpreter* PythonOpRegistrationTrampoline::getInterpreter() {
   return PythonOpRegistrationTrampoline::interpreter_.load();
-
 }
 
-bool PythonOpRegistrationTrampoline::registerInterpreter(c10::impl::PyInterpreter* interp) {
+bool PythonOpRegistrationTrampoline::registerInterpreter(
+    c10::impl::PyInterpreter* interp) {
   c10::impl::PyInterpreter* expected = nullptr;
   interpreter_.compare_exchange_strong(expected, interp);
   if (expected != nullptr) {
@@ -29,5 +29,4 @@ bool PythonOpRegistrationTrampoline::registerInterpreter(c10::impl::PyInterprete
   }
 }
 
-} // namespace impl
-} // namespace at
+} // namespace at::impl

--- a/aten/src/ATen/core/Tensor.cpp
+++ b/aten/src/ATen/core/Tensor.cpp
@@ -72,9 +72,9 @@ void TensorBase::enforce_invariants() {
 
 void TensorBase::print() const {
   if (defined()) {
-    std::cerr << "[" << toString() << " " << sizes() << "]" << std::endl;
+    std::cerr << "[" << toString() << " " << sizes() << "]" << '\n';
   } else {
-    std::cerr << "[UndefinedTensor]" << std::endl;
+    std::cerr << "[UndefinedTensor]" << '\n';
   }
 }
 

--- a/aten/src/ATen/core/TorchDispatchUtils.cpp
+++ b/aten/src/ATen/core/TorchDispatchUtils.cpp
@@ -1,7 +1,7 @@
 #include <ATen/core/TorchDispatchUtils.h>
 
-namespace at {
-namespace impl {
+
+namespace at::impl {
 
 bool tensor_has_dispatch(const at::Tensor& t) {
   DispatchKeySet key_set({DispatchKey::Python, DispatchKey::PythonTLSSnapshot});
@@ -27,5 +27,4 @@ bool tensorlist_has_dispatch(const c10::List<c10::optional<at::Tensor>>& li) {
   return false;
 }
 
-} // namespace impl
-} // namespace at
+} // namespace at::impl

--- a/aten/src/ATen/core/VariableHooksInterface.cpp
+++ b/aten/src/ATen/core/VariableHooksInterface.cpp
@@ -1,6 +1,6 @@
 #include <ATen/core/VariableHooksInterface.h>
 
-namespace at { namespace impl {
+namespace at::impl {
 
 namespace {
 VariableHooksInterface* hooks = nullptr;
@@ -17,4 +17,4 @@ bool HasVariableHooks() {
   return hooks != nullptr;
 }
 
-}} // namespace at::impl
+} // namespace at::impl

--- a/aten/src/ATen/core/Vitals.cpp
+++ b/aten/src/ATen/core/Vitals.cpp
@@ -2,8 +2,7 @@
 #include <cstdlib>
 #include <iostream>
 
-namespace at {
-namespace vitals {
+namespace at::vitals {
 
 APIVitals VitalsAPI;
 
@@ -78,8 +77,7 @@ bool APIVitals::setVital(
   auto iter = name_map_.find(vital_name);
   TorchVital* vital = nullptr;
   if (iter == name_map_.end()) {
-    auto r =
-        name_map_.emplace(vital_name, TorchVital(vital_name));
+    auto r = name_map_.emplace(vital_name, TorchVital(vital_name));
     vital = &r.first->second;
   } else {
     vital = &iter->second;
@@ -95,5 +93,4 @@ APIVitals::APIVitals() : vitals_enabled(false), name_map_() {
   setVital("CUDA", "used", "False", /* force = */ true);
 }
 
-} // namespace vitals
-} // namespace at
+} // namespace at::vitals

--- a/aten/src/ATen/core/adaption.cpp
+++ b/aten/src/ATen/core/adaption.cpp
@@ -1,15 +1,13 @@
 #include <ATen/core/op_registration/adaption.h>
 
-namespace c10 {
-namespace impl {
+
+namespace c10::impl {
 
 void common_device_check_failure(Device common_device, const at::Tensor& tensor, at::CheckedFrom methodName, at::CheckedFrom argName) {
   TORCH_CHECK(false,
     "Expected all tensors to be on the same device, but "
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     "found at least two devices, ", common_device, " and ", tensor.device(), "! "
     "(when checking argument for argument ", argName, " in method ", methodName, ")");
 }
 
-} // namespace impl
-} // namespace c10
+} // namespace c10::impl

--- a/aten/src/ATen/core/library.cpp
+++ b/aten/src/ATen/core/library.cpp
@@ -157,6 +157,7 @@ Library& Library::_def(c10::FunctionSchema&& schema, c10::OperatorName* out_name
 }
 #undef DEF_PRELUDE
 
+// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
 Library& Library::_def(std::variant<c10::OperatorName, c10::FunctionSchema>&& name_or_schema, CppFunction&& f, const std::vector<at::Tag>& tags) & {
   c10::FunctionSchema schema = [&] {
     if (std::holds_alternative<c10::FunctionSchema>(name_or_schema)){
@@ -218,6 +219,7 @@ at::OperatorName Library::_parseNameForLib(const char* name_str) const {
   return name;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
 Library& Library::_impl(const char* name_str, CppFunction&& f, _RegisterOrVerify rv) & {
   at::OperatorName name = _parseNameForLib(name_str);
   // See Note [Redundancy in registration code is OK]
@@ -257,6 +259,7 @@ c10::OperatorName Library::_resolve(const char* name_str) const {
 }
 #undef IMPL_PRELUDE
 
+// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
 Library& Library::_fallback(CppFunction&& f) & {
   TORCH_CHECK(kind_ == IMPL,
     "fallback(...): Cannot define an operator inside of a ", toString(kind_), " block.  "
@@ -279,8 +282,8 @@ Library& Library::_fallback(CppFunction&& f) & {
     registrars_.emplace_back(
       c10::Dispatcher::singleton().registerFallback(
         k,
-        std::move(f.func_),
-        debugString(std::move(f.debug_), file_, line_)
+        f.func_,
+        debugString(f.debug_, file_, line_)
       )
     );
   }


### PR DESCRIPTION
This PR fixes clang-tidy warnings in aten/src/ATen/core/*.cpp.