### PR TITLE
Fix the return of distributed.new_group()

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1476,7 +1476,7 @@ def _new_process_group_helper(
             # out of sync.
             if split_from:
                 split_from.perform_nocolor_split(_get_default_group().bound_device_id)
-            return GroupMember.NON_GROUP_MEMBER, None
+            return None, GroupMember.NON_GROUP_MEMBER
 
     prefix_store = PrefixStore(f"{group_name}/", store)
     base_pg_options = ProcessGroup.Options(backend=str(backend))


### PR DESCRIPTION
As documented, the function `new_group()` should return None, if the ranks is not inside the subgroup. However, it now returns GroupMember.NON_GROUP_MEMBER.



cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang