### PR TITLE
[MPS] Enable `index_select` for complex types

### DIFF
--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -602,7 +602,6 @@ Tensor& index_select_out_mps(const Tensor& self, int64_t dim, const Tensor& inde
               " and ",
               output.size(dim),
               ".");
-  TORCH_CHECK(!self.is_complex(), "index_select(): Yet not supported for complex");
 
   for (const auto i : irange(self.dim())) {
     if (i == dim)
@@ -625,6 +624,14 @@ Tensor& index_select_out_mps(const Tensor& self, int64_t dim, const Tensor& inde
   // Scalar input
   if (self.dim() == 0 && self.numel() == 1) {
     output.copy_(self);
+    return output;
+  }
+
+  // As of MacOS 14.4 gatherWithUpdatesTensor: still does not support complex
+  // So back to old view_as_real trick
+  if (self.is_complex()) {
+    auto out_view = at::view_as_real(output);
+    index_select_out_mps(at::view_as_real(self), dim, index, out_view);
     return output;
   }
 

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -39,6 +39,7 @@
 #include <ATen/ops/masked_select_native.h>
 #include <ATen/ops/nonzero.h>
 #include <ATen/ops/nonzero_native.h>
+#include <ATen/ops/view_as_real.h>
 #endif
 
 namespace at::native {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -264,6 +264,7 @@ def mps_ops_modifier(ops):
         'H',
         'hsplit',
         'imag',
+        'index_select',
         'isfinite',
         'isinf',
         'isreal',

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -298,6 +298,7 @@ def mps_ops_modifier(ops):
         'randn',
         'ravel',
         'real',
+        'repeat_interleave',
         'reshape_as',
         'reshape',
         'resolve_conj',


### PR DESCRIPTION
Surprisingly, as of MacOS-14.14 MPS `gatherWithUpdatesTensor:indicesTensor:axis:batchDimensions:name:` still does not support complex types, so emulate them by using `at::view_as_real` trick

Fixes https://github.com/pytorch/pytorch/issues/122427

