### PR TITLE
Add skip models by device in Dynamo Test

### DIFF
--- a/benchmarks/dynamo/runner.py
+++ b/benchmarks/dynamo/runner.py
@@ -389,7 +389,7 @@ def get_skip_tests(suite, device, is_training: bool):
             skip_tests.update(module.SKIP)
         if is_training and hasattr(module, "SKIP_TRAIN"):
             skip_tests.update(module.SKIP_TRAIN)
-    
+
     if device == "cpu":
         skip_tests.update(module.TorchBenchmarkRunner().skip_models_for_cpu)
     elif device == "cuda":

--- a/benchmarks/dynamo/runner.py
+++ b/benchmarks/dynamo/runner.py
@@ -369,7 +369,7 @@ def get_mode(args):
     return "training"
 
 
-def get_skip_tests(suite, is_training: bool):
+def get_skip_tests(suite, device, is_training: bool):
     """
     Generate -x seperated string to skip the unusual setup training tests
     """
@@ -389,6 +389,11 @@ def get_skip_tests(suite, is_training: bool):
             skip_tests.update(module.SKIP)
         if is_training and hasattr(module, "SKIP_TRAIN"):
             skip_tests.update(module.SKIP_TRAIN)
+    
+    if device == "cpu":
+        skip_tests.update(module.TorchBenchmarkRunner().skip_models_for_cpu)
+    elif device == "cuda":
+        skip_tests.update(module.TorchBenchmarkRunner().skip_models_for_cuda)
 
     skip_tests = (f"-x {name}" for name in skip_tests)
     skip_str = " ".join(skip_tests)
@@ -436,7 +441,7 @@ def generate_commands(args, dtypes, suites, devices, compilers, output_dir):
                         launcher_cmd = f"python -m torch.backends.xeon.run_cpu {args.cpu_launcher_args}"
                     cmd = f"{launcher_cmd} benchmarks/dynamo/{suite}.py --{testing} --{dtype} -d{device} --output={output_filename}"
                     cmd = f"{cmd} {base_cmd} {args.extra_args} --no-skip --dashboard"
-                    skip_tests_str = get_skip_tests(suite, args.training)
+                    skip_tests_str = get_skip_tests(suite, device, args.training)
                     cmd = f"{cmd} {skip_tests_str}"
 
                     if args.log_operator_inputs:


### PR DESCRIPTION
Fix skip logic in `runner.py`. Add skip list which was defined by device for dynamo benchmark runner `runner.py`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang