### PR TITLE
Remove the GPU tensors in the generator once all graphs are released

### DIFF
--- a/aten/src/ATen/cuda/CUDAGeneratorImpl.h
+++ b/aten/src/ATen/cuda/CUDAGeneratorImpl.h
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <limits>
 #include <memory>
+#include <set>
 namespace at {
 
 namespace cuda {
@@ -98,8 +99,7 @@ struct CUDAGeneratorState : public c10::intrusive_ptr_target {
   uint64_t philox_offset_per_thread_;
   uint32_t offset_intragraph_;
   bool capturing_{};
-  bool is_gpu_tensor_allocated_{};
-  cuda::CUDAGraph* current_graph_{};
+  std::set<cuda::CUDAGraph*> registered_graphs_;
   at::TensorBase seed_extragraph_{};
   at::TensorBase offset_extragraph_{};
 
@@ -112,7 +112,10 @@ struct CUDAGeneratorState : public c10::intrusive_ptr_target {
         offset_intragraph_(offset_intragraph) {}
 
   void increase(uint64_t increment);
-  void register_to_graph(cuda::CUDAGraph* graph);
+
+  void register_graph(cuda::CUDAGraph* graph);
+  void unregister_graph(cuda::CUDAGraph* graph);
+
   void capture_prologue();
   // capture_epilogue returns the wholegraph_increment
   uint64_t capture_epilogue();
@@ -143,7 +146,10 @@ struct TORCH_CUDA_CPP_API CUDAGeneratorImpl : public c10::GeneratorImpl {
 
   void set_philox_offset_per_thread(uint64_t offset);
   uint64_t philox_offset_per_thread() const;
-  void register_to_graph(cuda::CUDAGraph* graph);
+
+  void register_graph(cuda::CUDAGraph* graph);
+  void unregister_graph(cuda::CUDAGraph* graph);
+
   // Generates a PhiloxCudaState with a specified increment, and increment
   // current state
   PhiloxCudaState philox_cuda_state(uint64_t increment);

--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -98,7 +98,7 @@ void CUDAGraph::register_generator_state(const at::Generator& generator) {
   c10::intrusive_ptr<CUDAGeneratorImpl> cuda_gen =
       dynamic_intrusive_pointer_cast<CUDAGeneratorImpl>(
           generator.getIntrusivePtr());
-  cuda_gen->register_to_graph(this);
+  cuda_gen->register_graph(this);
 }
 
 void CUDAGraph::capture_begin(MempoolId_t pool/*=0*/, cudaStreamCaptureMode capture_mode) {
@@ -110,7 +110,7 @@ void CUDAGraph::capture_begin(MempoolId_t pool/*=0*/, cudaStreamCaptureMode capt
   // default generator is always registered
   auto* gen = get_generator_or_default<CUDAGeneratorImpl>(
       c10::nullopt, cuda::detail::getDefaultCUDAGenerator());
-  gen->register_to_graph(this);
+  gen->register_graph(this);
 
   for (auto& [generator_state, wholegraph_increments] :
        captured_generator_states_) {
@@ -354,6 +354,10 @@ TORCH_CHECK(has_graph_exec_,
 }
 
 CUDAGraph::~CUDAGraph() {
+  for (auto& [generator_state, wholegraph_increments] :
+       captured_generator_states_) {
+    generator_state->unregister_graph(this);
+  }
   reset();
 }
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1858,6 +1858,83 @@ torch.cuda.synchronize()
             # Compare the states generated outside and inside the graph
             self.assertEqual(random_values, graphed_random_values)
 
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_memory_stats_of_multiple_generators_and_graphs(self):
+        # Function to clear CUDA cache and collect garbage
+        def clear_cuda_cache():
+            gc.collect()
+            torch.cuda.empty_cache()
+
+        # Executes a simple graph task which includes capturing and executing a random number generation within a CUDA graph.
+        def simple_graph_task(graph):
+            s = torch.cuda.Stream()
+            with torch.cuda.stream(s):
+                graph.capture_begin()
+                torch.rand(1, device="cuda")
+                graph.capture_end()
+            torch.cuda.current_stream().wait_stream(s)
+            graph.replay()  # Replays the captured operations
+
+        def get_memory_stats():
+            stats = torch.cuda.memory_stats()
+            num_blocks = stats["active.all.current"]
+            total_size = stats["active_bytes.all.current"]
+            return num_blocks, total_size
+
+        def test(num_graphs, num_generators):
+            baseline = get_memory_stats()
+            baseline_num_blocks, baseline_total_size = baseline
+
+            # Allocate CUDA graphs
+            graphs = [torch.cuda.CUDAGraph() for _ in range(num_graphs)]
+
+            # Allocate and manage generator states
+            default_generator = torch.cuda.default_generators[0]
+            generators = [default_generator.graphsafe_get_state()]
+
+            # Starts from 1 as one state is already added
+            for _ in range(1, num_generators):
+                generators.append(default_generator.clone_state())
+
+            for graph in graphs:
+                for generator_state in generators:
+                    graph.register_generator_state(generator_state)
+                simple_graph_task(graph)
+
+            # Assert conditions after graph tasks
+            num_blocks, total_size = get_memory_stats()
+            # The allocated blocks should only be proportional to the number of generators
+            expected_blocks_diff = 2 * num_generators
+            expected_size_diff = 2 * 512 * num_generators  # Each block's size is 512
+
+            self.assertTrue(
+                (num_blocks - baseline_num_blocks) == expected_blocks_diff,
+                "Unexpected number of active blocks.",
+            )
+            self.assertTrue(
+                (total_size - baseline_total_size) == expected_size_diff,
+                "Unexpected total memory size.",
+            )
+
+            # Cleanup graphs and clear CUDA cache
+            while graphs:
+                graph = graphs.pop()
+                del graph
+            clear_cuda_cache()
+
+            # Assert that memory stats return to baseline after cleanup
+            self.assertTrue(
+                get_memory_stats() == baseline,
+                "Memory stats do not match baseline after cleanup.",
+            )
+
+        # Running the test function with different parameters
+        test(1, 1)
+        test(3, 2)
+        test(10, 20)
+
     @unittest.skipIf(not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs")
     def test_graph_capture_reset_recapture(self):
         s = torch.cuda.Stream()
@@ -2405,27 +2482,7 @@ exit(2)
         gc.collect()
         torch.cuda.empty_cache()
 
-        # Warm up the RNG seed and offset by creating and executing a simple CUDA graph.
-        # This process ensures that the one-element RNG seed and offset holders are allocated
-        # within the default generator. After this initial setup, these elements will be
-        # present and correctly initialized in the generator.
-
         s = torch.cuda.Stream()
-        with torch.cuda.stream(s):
-            g = torch.cuda.CUDAGraph()
-            g.capture_begin()
-            torch.rand(1, device="cuda")  # Execute a simple random number generation.
-            g.capture_end()
-
-        torch.cuda.current_stream().wait_stream(s)
-        g.replay()
-
-        torch.cuda.current_stream().wait_stream(s)
-        del g
-        gc.collect()
-        torch.cuda.empty_cache()
-        # Since the RNG seed and offset holders have been initialized during the warmup,
-        # there is no need to track or calculate any changes (delta) to these buffers afterwards.
 
         for (
             numel,
@@ -2434,8 +2491,14 @@ exit(2)
             delta_cudaMalloc_bytes_post_del_g,
             pool_string,
         ) in cases:
-            delta_active_blocks = 1
-            delta_active_bytes = numel * elem
+            if pool_string == "small_pool":
+                delta_active_blocks = 3  # one from "b" plus a sneaky two from CUDAGraph's one-element rng seed and offset holders
+                delta_active_bytes = (
+                    numel * elem + 1024
+                )  # + 1024 for CUDAGraph's rng seed and offset holders each
+            else:
+                delta_active_blocks = 1  # We only check the large pool, which isn't affected by rng offset holder
+                delta_active_bytes = numel * elem
 
             g = torch.cuda.CUDAGraph()
             s.wait_stream(torch.cuda.current_stream())


### PR DESCRIPTION
Please refer to PR #114068 and issue #122575

Changes proposed in this pull request:

1. GPU tensors are now removed when there are no longer any graph references to the generator states.
2. A new test has been introduced to check memory usage across multiple generators and multiple graphs.

cc @bhack, @xuzhao9, @ezyang