### PR TITLE
[dynamo] Config to not emit runtime asserts

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -241,6 +241,15 @@ enforce_cond_guards_match = True
 # no optimization.
 optimize_ddp: Union[bool, str] = True
 
+# By default, Dynamo emits runtime asserts (e.g. torch._check, torch._check_is_size) in the graph.
+# In some cases those asserts could be performance costly
+# E.g. torch._check(tensor[0].item() > 2) for tensor on cuda will require cuda sync.
+# Setting this to True keeps them hinting to symbolic shapes engine,
+# but not be emitted in the graph.
+do_not_emit_runtime_asserts: bool = (
+    os.environ.get("TORCH_DYNAMO_DO_NOT_EMIT_RUNTIME_ASSERTS", "0") == "1"
+)
+
 _ddp_optimization_mode = [
     "ddp_optimizer",
     "python_reducer",  # experimental mode

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1092,7 +1092,9 @@ class OutputGraph:
             (self.current_tracer.create_arg(tuple(x.as_proxy() for x in rv)),),
             {},
         )
-        self.insert_deferred_runtime_asserts(root, name)
+        if not config.do_not_emit_runtime_asserts:
+            self.insert_deferred_runtime_asserts(root, name)
+
         # NB: deferred runtime asserts can keep graphargs live, so make sure
         # those are inserted before pruning
         self.remove_unused_graphargs()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122603

Repetition on squashed & merged by mistake https://github.com/pytorch/pytorch/pull/122406

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang

Differential Revision: [D55312394](https://our.internmc.facebook.com/intern/diff/D55312394)