### PR TITLE
[torch/elastic] Fix the help info of args

### DIFF
--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -413,7 +413,7 @@ def get_args_parser() -> ArgumentParser:
         action=env,
         type=str,
         default="1",
-        help="Number of workers per node; supported values: [auto, cpu, gpu, int].",
+        help=f"Number of workers per node; supported values: [auto, cpu, gpu, {torch._C._get_privateuse1_backend_name()}, int].",
     )
 
     #


### PR DESCRIPTION
To be consistent with this change https://github.com/pytorch/pytorch/pull/105443.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @rohan-varma