### PR TITLE
#112848 Added @torch.autocast wrapper to test_ctx_manager.py forward calls

### DIFF
--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -427,6 +427,7 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
             raise unittest.SkipTest("requires bf16")
 
         class MyModule(torch.nn.Module):
+            @torch.autocast(device_type="cuda")
             def forward(self, x):
                 a_float32 = torch.rand((8, 8), device="cuda")
                 b_float32 = torch.rand((8, 8), device="cuda")
@@ -454,6 +455,7 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
     @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
     def test_cuda_amp_autocast(self):
         class MyModule(torch.nn.Module):
+            @torch.autocast(device_type="cuda")
             def forward(self, x):
                 a_float32 = torch.rand((8, 8), device="cuda")
                 b_float32 = torch.rand((8, 8), device="cuda")
@@ -475,7 +477,7 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(exported.device.type, "cuda")
         self.assertEqual(exported.device.index, 0)
         self.assertEqual(exported.dtype, torch.float64)
-
+  
     def test_is_autocast_cpu_enabled(self):
         def fn(a_float32, b_float32):
             with torch.cpu.amp.autocast(dtype=torch.bfloat16):
@@ -497,6 +499,7 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
     )
     def test_autocast_sdpa(self):
         class MyModule(torch.nn.Module):
+            @torch.autocast
             def forward(self, query, key, value):
                 with torch.autocast("cpu"):
                     with torch.autocast("cuda", dtype=torch.float32):
@@ -561,6 +564,7 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
 
     def test_autocast_cpu_graph_break(self):
         class MyModule(torch.nn.Module):
+            @torch.autocast(device_type="cpu")
             def forward(self, x):
                 a_float32 = torch.rand((8, 8), device="cpu")
                 b_float32 = torch.rand((8, 8), device="cpu")
@@ -610,7 +614,7 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
             def mm_breaks(x, y):
                 torch._dynamo.graph_break()
                 return torch.mm(x, y)
-
+            @torch.autocast(device_type="cpu")
             def forward(self, x):
                 a_float32 = torch.rand((8, 8), device="cpu")
                 b_float32 = torch.rand((8, 8), device="cpu")
@@ -663,7 +667,7 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
             def mm_breaks(self, x, y):
                 torch._dynamo.graph_break()
                 return torch.mm(x, y) + self.bias
-
+            @torch.autocast(device_type="cpu")
             def forward(self, x):
                 a_float32 = torch.rand((8, 8), device="cpu")
                 b_float32 = torch.rand((8, 8), device="cpu")
@@ -710,6 +714,7 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
     @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
     def test_autocast_float64(self):
         class MyModule(torch.nn.Module):
+            @torch.autocast
             def forward(self, x):
                 a_float32 = torch.rand((8, 8), device="cuda")
                 b_float32 = torch.rand((8, 8), device="cuda")
@@ -736,6 +741,7 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
     @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
     def test_autocast_device(self):
         class MyModule(torch.nn.Module):
+            @torch.autocast
             def forward(self, x):
                 a_float32 = torch.rand((8, 8), device="cuda")
                 b_float32 = torch.rand((8, 8), device="cuda")


### PR DESCRIPTION
Looked through autocast_mode.py to see uses of @torch.autocast wrapper. Added wrapper to all forward calls except in test_autocast_cpu which caused a runtime error (leading the test to fail). 30 tests were ran and 8 were skipped.
I would further explain the nature of the error however after updating my branch with the latest changes I get:

module 'torch._C' has no attribute '_has_magma' 

Fixes #ISSUE_NUMBER 112848 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang