### PR TITLE
Make c10::Error empty backtrace as an optional argument

### DIFF
--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -2321,8 +2321,7 @@ IValue::IValue(c10::intrusive_ptr<T> custom_class) : tag(Tag::Object) {
     } catch (const c10::Error&) {
       throw c10::Error(
           "Trying to instantiate a class that isn't a registered custom class: " +
-          std::string(c10::util::get_fully_qualified_type_name<T>()),
-          "");
+          std::string(c10::util::get_fully_qualified_type_name<T>()));
     }
   }();
   auto ivalue_obj = c10::ivalue::Object::create(std::move(classType), /* numSlots */1);

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -68,7 +68,7 @@ class C10_API Error : public std::exception {
       const void* caller = nullptr);
 
   // Base constructor
-  Error(std::string msg, std::string backtrace, const void* caller = nullptr);
+  Error(std::string msg, std::string backtrace = "", const void* caller = nullptr);
 
   // Add some new context to the message stack.  The last added context
   // will be formatted at the end of the context list upon printing.

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -75,6 +75,8 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/format.h>
+
 namespace torch::jit {
 
 using ::c10::Argument;
@@ -972,10 +974,8 @@ void initJitScriptBindings(PyObject* module) {
           [mm_name](const Object& self, py::args args, py::kwargs kwargs) {
             auto method = self.find_method(mm_name);
             if (!method) {
-              throw c10::NotImplementedError(
-                  "'%s' is not implemented for %s",
-                  mm_name,
-                  self.type()->str().c_str());
+              std::string msg = fmt::format("'{}' is not implemented for {}", mm_name, self.type()->str());
+              throw c10::NotImplementedError(msg);
             }
             return invokeScriptMethodFromPython(
                 *method,

--- a/torch/csrc/jit/runtime/register_ops_utils.cpp
+++ b/torch/csrc/jit/runtime/register_ops_utils.cpp
@@ -133,7 +133,7 @@ void checkDoubleInRange(double a) {
       a > double(std::numeric_limits<int64_t>::max()) ||
       a < double(std::numeric_limits<int64_t>::min())) {
     throw c10::Error(
-        "Cannot convert float " + c10::to_string(a) + " to integer", "");
+        "Cannot convert float " + c10::to_string(a) + " to integer");
     return;
   }
 }


### PR DESCRIPTION
Summary: Split from the main diff in the stack.

Test Plan: Build validation should be enough.

Reviewed By: ezyang

Differential Revision: D55313410


