### PR TITLE
[ez][TD] Hide errors in llm retrieval job

### DIFF
--- a/.github/workflows/llm_td_retrieval.yml
+++ b/.github/workflows/llm_td_retrieval.yml
@@ -84,6 +84,7 @@ jobs:
 
       - name: Run Retriever
         id: run_retriever
+        continue-on-error: true  # ghstack not currently supported due to problems getting git diff
         shell: bash -l {0}
         run: |
           set -euxo pipefail
@@ -101,6 +102,7 @@ jobs:
 
       - name: Upload results to s3
         uses: seemethere/upload-artifact-s3@v5
+        if: ${{ steps.run_retriever.outcome == 'success' }}
         with:
           name: llm_results
           retention-days: 14


### PR DESCRIPTION
The new ghstack does have a base on main anymore, so finding the base for ghstacked PRs is harder.  Something similar to https://github.com/pytorch/pytorch/pull/122214 might be needed, but then I'm worried about tokens

Either way, this is a quick workaround to hide these errors for ghstack users