### PR TITLE
Keep example_inputs when saving and loading ExportedProgram

### DIFF
--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -226,11 +226,12 @@ def save(
         f = os.fspath(f)
 
     with zipfile.ZipFile(f, 'w') as zipf:
-        # Save every field the SerializedArtifact to a file
+        # Save every field in the SerializedArtifact to a file.
         assert isinstance(artifact.exported_program, bytes)
         zipf.writestr("serialized_exported_program.json", artifact.exported_program)
         zipf.writestr("serialized_state_dict.pt", artifact.state_dict)
         zipf.writestr("serialized_constants.pt", artifact.constants)
+        zipf.writestr("serialized_example_inputs.pt", artifact.example_inputs)
 
         zipf.writestr('version', ".".join(map(str, SCHEMA_VERSION)))
 
@@ -271,6 +272,7 @@ def load(
         serialized_exported_program: Optional[bytes] = None
         serialized_state_dict: Optional[bytes] = None
         serialized_constants: Optional[bytes] = None
+        serialized_example_inputs: Optional[bytes] = None
 
         for file_info in zipf.infolist():
             file_content = zipf.read(file_info.filename)
@@ -287,6 +289,8 @@ def load(
                 serialized_state_dict = file_content
             elif file_info.filename == "serialized_constants.pt":
                 serialized_constants = file_content
+            elif file_info.filename == "serialized_example_inputs.pt":
+                serialized_example_inputs = file_content
             elif file_info.filename.startswith("extra_files"):
                 filename = file_info.filename.split("/", 1)[1]
                 extra_files[filename] = file_content.decode('utf-8')
@@ -294,10 +298,12 @@ def load(
         assert serialized_exported_program is not None
         assert serialized_state_dict is not None
         assert serialized_constants is not None
+        assert serialized_example_inputs is not None
         artifact: SerializedArtifact = SerializedArtifact(
             serialized_exported_program,
             serialized_state_dict,
             serialized_constants,
+            serialized_example_inputs,
         )
 
         # Deserialize ExportedProgram

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -190,6 +190,7 @@ class SerializedArtifact:
     exported_program: bytes
     state_dict: bytes
     constants: bytes
+    example_inputs: bytes
 
 
 @dataclass
@@ -197,6 +198,7 @@ class _SerializedProgram:
     exported_program: ExportedProgram
     state_dict: bytes
     constants: bytes
+    example_inputs: bytes
 
 
 def deserialize_device(d: Device) -> torch.device:
@@ -297,15 +299,15 @@ def serialize_torch_artifact(artifact: Dict[str, Any]) -> bytes:
         del copyreg.dispatch_table[FakeTensor]
 
 
-def deserialize_torch_artifact(serialized: Union[Dict[str, Any], bytes]):
-    if isinstance(serialized, dict):
+def deserialize_torch_artifact(serialized: Union[Dict[str, Any], Tuple[Any, ...], bytes]):
+    if isinstance(serialized, (dict, tuple)):
         return serialized
     if len(serialized) == 0:
         return {}
     buffer = io.BytesIO(serialized)
     buffer.seek(0)
     artifact = torch.load(buffer)
-    assert isinstance(artifact, dict)
+    assert isinstance(artifact, (tuple, dict))
     return artifact
 
 
@@ -1275,6 +1277,7 @@ class ExportedProgramSerializer:
             serialized_ep,
             serialize_torch_artifact(exported_program.state_dict),
             serialize_torch_artifact(constants),
+            serialize_torch_artifact(exported_program.example_inputs),
         )
 
 
@@ -1287,6 +1290,7 @@ class GraphModuleDeserializer:
         names_to_symbols: Dict[str, sympy.Symbol]
         state_dict: Dict[str, Union[torch.Tensor, torch.nn.Parameter]]
         constants: Dict[str, Union[torch.Tensor, torch.ScriptObject]]
+        example_inputs: Optional[Tuple[Tuple[torch.Tensor, ...], Dict[str, Any]]]
 
     def __init__(self):
         self.serialized_name_to_node: Dict[str, torch.fx.Node] = {}
@@ -1670,6 +1674,7 @@ class GraphModuleDeserializer:
         serialized_graph_module: GraphModule,
         serialized_state_dict: Union[Dict[str, torch.Tensor], bytes],
         constants: Union[Dict[str, Any], bytes],
+        example_inputs: Optional[Union[Tuple[Tuple[torch.Tensor, ...], Dict[str, Any]], bytes]] = None,
         symbol_name_to_range: Optional[Dict[str, symbolic_shapes.ValueRanges]] = None,
     ) -> Result:
         global _CURRENT_DESERIALIZER
@@ -1696,6 +1701,10 @@ class GraphModuleDeserializer:
                         lower = max(2, lower)
                     self.symbol_name_to_range[k] = symbolic_shapes.ValueRanges(_int_to_sympy_int(lower), vr.upper)
 
+            if example_inputs is not None and len(example_inputs) > 0:
+                self.example_inputs = deserialize_torch_artifact(example_inputs)
+            else:
+                self.example_inputs = None
             self.deserialize_graph(serialized_graph_module.graph)
 
             module_call_graph = self.deserialize_module_call_graph(
@@ -1710,6 +1719,7 @@ class GraphModuleDeserializer:
                 names_to_symbols=self.symbol_name_to_symbol,
                 state_dict=deserialize_torch_artifact(serialized_state_dict),
                 constants=self.constants,
+                example_inputs=self.example_inputs,
             )
         finally:
             _CURRENT_DESERIALIZER = None
@@ -2042,6 +2052,7 @@ class ExportedProgramDeserializer:
         exported_program: ExportedProgram,
         state_dict: Union[Dict[str, torch.Tensor], bytes],
         constants: Union[Dict[str, torch.Tensor], bytes],
+        example_inputs: Optional[Union[Tuple[Tuple[torch.Tensor, ...], Dict[str, Any]], bytes]] = None,
     ) -> ep.ExportedProgram:
         assert isinstance(exported_program, ExportedProgram)
         version = exported_program.schema_version
@@ -2059,11 +2070,15 @@ class ExportedProgramDeserializer:
             )
             for k, v in exported_program.range_constraints.items()
         }
-        res = GraphModuleDeserializer().deserialize(
-            exported_program.graph_module,
-            state_dict,
-            constants,
-            symbol_name_to_range,
+        res = (
+            GraphModuleDeserializer()
+            .deserialize(
+                exported_program.graph_module,
+                state_dict,
+                constants,
+                example_inputs,
+                symbol_name_to_range,
+            )
         )
         range_constraints = self.deserialize_range_constraints(
             symbol_name_to_range,
@@ -2083,7 +2098,7 @@ class ExportedProgramDeserializer:
             state_dict=res.state_dict,  # type: ignore[arg-type]
             range_constraints=range_constraints,
             module_call_graph=res.module_call_graph,
-            example_inputs=None,
+            example_inputs=res.example_inputs,
             verifier=load_verifier(exported_program.dialect),
             constants=res.constants,
         )
@@ -2179,7 +2194,10 @@ def serialize(
     )
     json_bytes = json_program.encode("utf-8")
     artifact = SerializedArtifact(
-        json_bytes, serialized_program.state_dict, serialized_program.constants
+        json_bytes,
+        serialized_program.state_dict,
+        serialized_program.constants,
+        serialized_program.example_inputs
     )
     return artifact
 
@@ -2226,11 +2244,15 @@ def deserialize(
     assert isinstance(artifact.exported_program, bytes)
     exported_program_str = artifact.exported_program.decode("utf-8")
     exported_program_dict = json.loads(exported_program_str)
-    serialized_exported_program = _dict_to_dataclass(
-        ExportedProgram, exported_program_dict
-    )
-    return ExportedProgramDeserializer(expected_opset_version).deserialize(
-        serialized_exported_program, artifact.state_dict, artifact.constants
+    serialized_exported_program = _dict_to_dataclass(ExportedProgram, exported_program_dict)
+    return (
+        ExportedProgramDeserializer(expected_opset_version)
+        .deserialize(
+            serialized_exported_program,
+            artifact.state_dict,
+            artifact.constants,
+            artifact.example_inputs,
+        )
     )
 
 
@@ -2601,6 +2623,7 @@ def canonicalize(ep: ExportedProgram) -> ExportedProgram:
                     raise AssertionError(f"Unknown sym_int type: {s}")
             elif arg.type in (
                 "as_none",
+                "as_bool",
                 "as_int",
                 "as_float",
                 "as_string",


### PR DESCRIPTION
Summary:
`torch.export` is a powerful tool for creating a structured and shareable package from arbitrary pytorch code. One great use case of `torch.export` is sharing models or subgraphs in a way that allows results to be easily replicated. However, in the current implementation of `export`, the `example_inputs` field is thrown out. When trying to replicate bugs, benchmarks, or behaviors, losing the original input shapes and values makes the process much messier.

This change adds saving and loading for the `example_inputs` attribute of an `ExportedProgram` when using `torch.export.save` and `torch.export.load`. This simple addition makes `ExportedPrograms`s a fantastic tool for performance and accuracy replication. For example, with this change we enable the following workflow:

```
# Script to create a reproducible accuracy issue with my model.
kwargs = {"fastmath_mode": True}
exp_program = export(my_model, sample_inputs, kwargs)
result = exp_program.module()(*sample_inputs, **kwargs)
# Uhoh, I dont like that result, lets send the module to a colleague to take a look.
torch.export.save(exp_program, "my_model.pt2")
```

My colleague can then easily reproduce my results llike so:

```
# Script to load and reproduce results from a saved ExportedProgram.
loaded_program = torch.export.load("my_model.pt2")
# The following line is enabled by this Diff, we pull out the arguments
# and options that caused the issue.
args, kwargs = loaded_program.example_inputs
reproduced_result = loaded_program.module()(*args, **kwargs)
# Oh I see what happened here, lets fix it.
```

Being able to share exact inputs and arguments makes `ExportedPrograms` much
more clean and powerful with little downside. The main potential issue with this change
is that it does slightly increase the size of saved programs. However, the size of
inputs will be much smaller than parameters in most cases. I am curious to hear
discussion on saved file size though.

The deserialization of `example_inputs` is currently implemented as `Optional`. Although this wont effect users of `export.save` and `export.load`, it does give backwards compatibility to any direct users of `serialize` and `deserialize`.

Test Plan:
This diff includes a new test which exercises the save / load flow with multiple args and kwargs.

```
buck test //caffe2/test:test_export -- TestSerialize
```

Differential Revision: D55294614
