### PR TITLE
Support fakifying method calls of torchbind object

### DIFF
--- a/test/export/test_torchbind.py
+++ b/test/export/test_torchbind.py
@@ -5,6 +5,7 @@ import torch.testing._internal.torchbind_impls  # noqa: F401
 from torch._higher_order_ops.torchbind import enable_torchbind_tracing
 from torch.export import export
 from torch.export._trace import _export
+from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -12,7 +13,6 @@ from torch.testing._internal.common_utils import (
     skipIfTorchDynamo,
     TestCase,
 )
-from torch.fx.experimental.proxy_tensor import make_fx
 
 
 @skipIfTorchDynamo("torchbind not supported with dynamo yet")
@@ -393,7 +393,7 @@ def forward(self, arg0_1, attr, arg1_1):
     return (getitem_3, add_1)""",  # noqa: B950
         )
 
-    def test_tensor_queue_aot_export_methods(self):
+    def test_make_fx_tensor_queue_methods(self):
         class Model(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -430,7 +430,9 @@ def forward(self, arg0_1, arg1_1):
     call_torchbind_5 = torch.ops.higher_order.call_torchbind(arg0_1, 'size')
     sub = torch.ops.aten.sub.Tensor(call_torchbind_4, 0);  call_torchbind_4 = None
     return (sub, add, arg0_1)
-    """)
+    """,
+            )
+
 
 @skipIfTorchDynamo("torchbind not supported with dynamo yet")
 class TestImplAbstractClass(TestCase):

--- a/test/export/test_torchbind.py
+++ b/test/export/test_torchbind.py
@@ -12,6 +12,7 @@ from torch.testing._internal.common_utils import (
     skipIfTorchDynamo,
     TestCase,
 )
+from torch.fx.experimental.proxy_tensor import make_fx
 
 
 @skipIfTorchDynamo("torchbind not supported with dynamo yet")
@@ -392,6 +393,44 @@ def forward(self, arg0_1, attr, arg1_1):
     return (getitem_3, add_1)""",  # noqa: B950
         )
 
+    def test_tensor_queue_aot_export_methods(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(3, 2)
+
+            def forward(self, tq, x):
+                tq.push(x.cos())
+                tq.push(x.sin())
+                x_cos = tq.pop() + tq.size()
+                x_sin = tq.pop() - tq.size()
+                return x_sin, x_cos, tq
+
+        mod = Model()
+        tq = torch.classes._TorchScriptTesting._TensorQueue(
+            torch.empty(
+                0,
+            ).fill_(-1)
+        )
+        x = torch.ones(2, 3)
+        with torch._higher_order_ops.torchbind.enable_torchbind_tracing():
+            gm = make_fx(mod, tracing_mode="fake")(tq, x)
+            self.assertExpectedInline(
+                gm.code.strip("\n"),
+                """\
+def forward(self, arg0_1, arg1_1):
+    cos = torch.ops.aten.cos.default(arg1_1)
+    call_torchbind = torch.ops.higher_order.call_torchbind(arg0_1, 'push', cos);  cos = None
+    sin = torch.ops.aten.sin.default(arg1_1);  arg1_1 = None
+    call_torchbind_1 = torch.ops.higher_order.call_torchbind(arg0_1, 'push', sin);  sin = None
+    call_torchbind_2 = torch.ops.higher_order.call_torchbind(arg0_1, 'pop')
+    call_torchbind_3 = torch.ops.higher_order.call_torchbind(arg0_1, 'size')
+    add = torch.ops.aten.add.Tensor(call_torchbind_2, 1);  call_torchbind_2 = None
+    call_torchbind_4 = torch.ops.higher_order.call_torchbind(arg0_1, 'pop')
+    call_torchbind_5 = torch.ops.higher_order.call_torchbind(arg0_1, 'size')
+    sub = torch.ops.aten.sub.Tensor(call_torchbind_4, 0);  call_torchbind_4 = None
+    return (sub, add, arg0_1)
+    """)
 
 @skipIfTorchDynamo("torchbind not supported with dynamo yet")
 class TestImplAbstractClass(TestCase):

--- a/torch/_library/abstract_impl_class.py
+++ b/torch/_library/abstract_impl_class.py
@@ -52,12 +52,10 @@ def create_abstract_obj(x: torch.ScriptObject):
     abstract_x = _abstract_obj_from_concrete(x)
 
     def _call_torchbind(method_name):
+        from torch._higher_order_ops.torchbind import call_torchbind
+
         def wrapped(self_, *args, **kwargs):
-            from torch._higher_order_ops.torchbind import call_torchbind, ENABLE_TORCHBIND
-            if ENABLE_TORCHBIND:
-                return call_torchbind(self_, method_name, *args, **kwargs)
-            else:
-                return getattr(self_.abstract_obj, method_name)(*args, **kwargs)
+            return call_torchbind(self_, method_name, *args, **kwargs)
 
         return wrapped
 
@@ -73,7 +71,7 @@ def create_abstract_obj(x: torch.ScriptObject):
                 _call_torchbind(name).__get__(abstract_x_wrapped),
             )
         else:
-            log.warning("abstract class doesn't implement method %s.", name)
+            log.warning("Abstract object of %s doesn't implement method %s.", x, name)
     return abstract_x_wrapped
 
 
@@ -192,11 +190,17 @@ def _full_qual_class_name(qualname: str):
     return "__torch__.torch.classes." + ns + "." + name
 
 
-def _find_abstract_class_for_script_object(x: torch.ScriptObject):
-    full_qualname = x._type().qualified_name()  # type: ignore[attr-defined]
+# Return the namespace and class name of a script object.
+def _ns_and_class_name(full_qualname: str):
     splits = full_qualname.split(".")
     assert len(splits) == 5
     _torch, torch_ns, classes, ns, class_name = splits
+    return ns, class_name
+
+
+def _find_abstract_class_for_script_object(x: torch.ScriptObject):
+    full_qualname = x._type().qualified_name()  # type: ignore[attr-defined]
+    ns, class_name = _ns_and_class_name(full_qualname)
     abstract_class = find_abstract_impl(full_qualname)
     if abstract_class is None:
         raise RuntimeError(
@@ -215,8 +219,8 @@ _CONVERT_FROM_REAL_NAME = "from_concrete"
 
 
 class AbstractScriptObject:
-    def __init__(self, abstract_obj):
-        self.abstract_obj = abstract_obj
+    def __init__(self, wrapped_obj):
+        self.wrapped_obj = wrapped_obj
 
 
 def _abstract_obj_from_concrete(x):

--- a/torch/_library/abstract_impl_class.py
+++ b/torch/_library/abstract_impl_class.py
@@ -53,8 +53,11 @@ def create_abstract_obj(x: torch.ScriptObject):
 
     def _call_torchbind(method_name):
         def wrapped(self_, *args, **kwargs):
-            # TODO: wrap with call_torchbind higher order op
-            return getattr(self_.abstract_obj, method_name)(*args, **kwargs)
+            from torch._higher_order_ops.torchbind import call_torchbind, ENABLE_TORCHBIND
+            if ENABLE_TORCHBIND:
+                return call_torchbind(self_, method_name, *args, **kwargs)
+            else:
+                return getattr(self_.abstract_obj, method_name)(*args, **kwargs)
 
         return wrapped
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #122657
* #122656
* __->__ #122623
* #122622
* #122621
* #122620
* #122619

This PR adds support for fakifying torchbind object in make_fx. 

Specifically, when tracing_mode is "fake" or "symbolic", we'll lookup the registered fake class for the script object and wraps the fake class's instance into AbstractScriptObject. The  AbstractScriptObject is a generic container for any fake script object. Its methods are created dynamically by wrapping its contained fake object's method with call_torchbind higher order op. This design allows  us to 1. turn all method calls of script object into call_torchbind higher order op, and 2. generically share a type across all abstract classes so that we could use it to track them as proxies.

Note that this diff haven't fakified torch script objects by default in export. We need to add the fakification logic to export before entering aot. As a result, all current tests will still trace with real script object except the newly added make_fx test. We'll add the support later in this pr stack. 