### PR TITLE
[Inductor] Enable _sfdp_pattern_18 pattern for CUDA

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -107,7 +107,7 @@ case "$image" in
     ;;
   pytorch-linux-focal-cuda12.1-cudnn8-py3-gcc9-inductor-benchmarks)
     CUDA_VERSION=12.1.1
-    CUDNN_VERSION=8
+    CUDNN_VERSION=8.9.3
     ANACONDA_PYTHON_VERSION=3.10
     GCC_VERSION=9
     PROTOBUF=yes

--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -107,7 +107,7 @@ case "$image" in
     ;;
   pytorch-linux-focal-cuda12.1-cudnn8-py3-gcc9-inductor-benchmarks)
     CUDA_VERSION=12.1.1
-    CUDNN_VERSION=8.9.3
+    CUDNN_VERSION=8
     ANACONDA_PYTHON_VERSION=3.10
     GCC_VERSION=9
     PROTOBUF=yes

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1268,6 +1268,8 @@ def same(
             res.keys()
         ), f"keys mismatch {set(ref.keys())} == {set(res.keys())}"
         for k in sorted(ref.keys()):
+            if k == "loss":
+                print(f"loss: {ref[k]} vs {res[k]}")
             if not (
                 same(
                     ref[k],

--- a/torch/_inductor/fx_passes/fuse_attention.py
+++ b/torch/_inductor/fx_passes/fuse_attention.py
@@ -761,16 +761,14 @@ def _get_sfdp_patterns():
                 _sfdp_replacement_18,
                 [g(), g(), g(), m_bool()],
                 d,
-                # CUDA AOT Inductor CI job's GPT2ForSequenceClassification accuracy test failed
-                _sfdp_extra_check(disable_cuda=True),
+                _sfdp_extra_check(),
             ),
             (
                 _sfdp_pattern_18,
                 _sfdp_replacement_18,
                 [g_bs1(), g_bs1(), g_bs1(), m_bs1_bool()],
                 d,
-                # CUDA AOT Inductor CI job's GPT2ForSequenceClassification accuracy test failed
-                _sfdp_extra_check(disable_cuda=True),
+                _sfdp_extra_check(),
             ),
         ]
         mask_fp32_patterns = ["pattern_16"]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122627

Summary: https://github.com/pytorch/pytorch/pull/121866 added a SDPA pattern matching, but it was hitting some issue on AOTI CI, so CUDA was diabled in that PR.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @chauhang