### PR TITLE
[ez] Fix XLA auto hash updates

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           repo-name: xla
           branch: master
-          pin-folder: .ci/docker/ci_commit_pins
+          pin-folder: .github/ci_commit_pins
           test-infra-ref: main
           updatebot-token: ${{ secrets.UPDATEBOT_TOKEN }}
           pytorchbot-token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}


### PR DESCRIPTION
The xla pin is located in .github/ci_commit_pins not .ci/docker/ci_commit_pins