### PR TITLE
[fix] 'from' in python code generated by inductor, resulting in SyntaxError

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -9315,6 +9315,14 @@ class CommonTemplate:
 
         self.assertTrue(len(result) == 2)
 
+    def test_random_from(self):
+        # https://github.com/pytorch/pytorch/issues/121621
+        def fn(x):
+            x.random_(-10, 10)
+            return x
+
+        x = torch.randn([4, 4, 3])
+        self.common(fn, (x,))
 
 @dataclasses.dataclass
 class TestFailure:

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -634,6 +634,13 @@ class WrapperCodeGen(CodeGen):
             # view operation fallbacks cause issues since inductor
             # doesn't know the memory is still needed and might reuse it.
             ending = f".clone(){ending}"
+
+        # Note: 'from' is python keyword, it is not allowed to appear in python code
+        #       Although, only aten.random(_) has an 'from' overload for now, we handle all possible cases
+        if kernel_name.endswith(".from"):
+            kernel_prefix = kernel_name[:-5]
+            kernel_name = f"getattr({kernel_prefix}, 'from')"
+
         self.writeline(
             f"{self.declare}{output_name} = {kernel_name}({', '.join(args)}){ending}"
         )

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2015,6 +2015,7 @@ fallback_rand_generator = fallback_handler(aten.rand.generator)
 fallback_randn_default = fallback_handler(aten.randn.default)
 fallback_randn_generator = fallback_handler(aten.randn.generator)
 make_fallback(aten.randint)
+make_fallback(aten.random)
 
 
 @register_lowering(aten.rand)


### PR DESCRIPTION
`from` is  a python keyword.  Python code containing `aten.random.from` will result in syntax errors. This PR handle this special case in the codegen of inductor. 

Also add fallback lowering for aten.random

Fixes #121621 



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang