### PR TITLE
Log compilation_metrics to TORCH_TRACE

### DIFF
--- a/test/dynamo/test_structured_trace.py
+++ b/test/dynamo/test_structured_trace.py
@@ -73,23 +73,7 @@ class StructuredTraceTestingFormatter(logging.Formatter):
         if "inductor_output_code" in metadata:
             metadata["inductor_output_code"]["filename"] = "FILENAME"
         if "compilation_metrics" in metadata:
-            metadata["compilation_metrics"] = {
-                k: metadata["compilation_metrics"][k]
-                # Subset of keys that are stable across platforms and runs
-                for k in (
-                    "frame_key",
-                    # NB: do not do co_name, resumption frames have line
-                    # numbers in them
-                    "cache_size",
-                    "accumulated_cache_size",
-                    "graph_op_count",
-                    "graph_node_count",
-                    "graph_input_count",
-                    "fail_type",
-                    "fail_reason",
-                    "restart_reasons",
-                )
-            }
+            metadata["compilation_metrics"] = "METRICS"
 
         return json.dumps(metadata)
 
@@ -154,7 +138,7 @@ class StructuredTraceTest(TestCase):
 {"inductor_post_grad_graph": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_output_code": {"filename": "FILENAME"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "1", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 2, "graph_node_count": 4, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"compilation_metrics": "METRICS", "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -173,7 +157,7 @@ class StructuredTraceTest(TestCase):
 {"inductor_post_grad_graph": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_output_code": {"filename": "FILENAME"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "1", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 2, "graph_node_count": 4, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"compilation_metrics": "METRICS", "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -196,14 +180,14 @@ class StructuredTraceTest(TestCase):
 {"inductor_post_grad_graph": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_output_code": {"filename": "FILENAME"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "1", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 1, "graph_node_count": 4, "graph_input_count": 2, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"compilation_metrics": "METRICS", "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
 {"dynamo_output_graph": {"sizes": {"l_x_": [1000, 1000], "add": [1000, 1000]}}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
 {"aot_forward_graph": {}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
 {"inductor_post_grad_graph": {}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
 {"inductor_output_code": {"filename": "FILENAME"}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "2", "cache_size": 1, "accumulated_cache_size": 1, "graph_op_count": 1, "graph_node_count": 3, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
+{"compilation_metrics": "METRICS", "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -221,7 +205,7 @@ class StructuredTraceTest(TestCase):
 {"inductor_post_grad_graph": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_output_code": {"filename": "FILENAME"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "1", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 4, "graph_node_count": 6, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"compilation_metrics": "METRICS", "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -237,7 +221,7 @@ class StructuredTraceTest(TestCase):
             self.buffer.getvalue(),
             """\
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
-{"compilation_metrics": {"frame_key": "1", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": null, "graph_node_count": null, "graph_input_count": null, "fail_type": "<class 'torch._dynamo.exc.TorchRuntimeError'>", "fail_reason": "Failed running call_method add(*(FakeTensor(..., size=(1000, 1000), grad_fn=<MulBackward0>), FakeTensor(..., size=(10, 10))), **{}):\\nAttempting to broadcast a dimension of length 10 at -1! Mismatching argument at index 1 had torch.Size([10, 10]); but expected shape should be broadcastable to [1000, 1000]", "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"compilation_metrics": "METRICS", "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -271,7 +255,7 @@ class StructuredTraceTest(TestCase):
 {"aot_forward_graph": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"aot_backward_graph": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_post_grad_graph": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "1", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": null, "graph_node_count": null, "graph_input_count": null, "fail_type": "<class 'torch._dynamo.exc.BackendCompilerFailed'>", "fail_reason": "backend='inductor' raised:\\nLoweringException: AssertionError: \\n  target: aten.round.default\\n  args[0]: TensorBox(StorageBox(\\n    InputBuffer(name='primals_1', layout=FixedLayout('cpu', torch.float32, size=[1000, 1000], stride=[1000, 1]))\\n  ))", "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"compilation_metrics": "METRICS", "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -309,7 +293,7 @@ class StructuredTraceTest(TestCase):
             """\
 {"dynamo_start": {"stack": "STACK"}, "rank": 0, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_guards": {}, "rank": 0, "frame_id": 0, "frame_compile_id": 0, "attempt": 1, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "1", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 0, "graph_node_count": 0, "graph_input_count": 0, "fail_type": null, "fail_reason": null, "restart_reasons": ["call_method UserDefinedObjectVariable(instancemethod) __call__ [] {}"]}, "rank": 0, "frame_id": 0, "frame_compile_id": 0, "attempt": 1}
+{"compilation_metrics": "METRICS", "rank": 0, "frame_id": 0, "frame_compile_id": 0, "attempt": 1}
 {"dynamo_start": {"stack": "STACK"}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_output_graph": {"sizes": {"l_x_": [1024, 1024], "l__self___layers_0": [1024, 1024], "l__self___layers_1": [1024, 1024]}}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"optimize_ddp_split_graph": {}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
@@ -326,7 +310,7 @@ class StructuredTraceTest(TestCase):
 {"inductor_post_grad_graph": {}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_output_code": {"filename": "FILENAME"}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "2", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 2, "graph_node_count": 4, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0}
+{"compilation_metrics": "METRICS", "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -345,14 +329,14 @@ class StructuredTraceTest(TestCase):
             """\
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 1, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "1", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 0, "graph_node_count": 0, "graph_input_count": 0, "fail_type": null, "fail_reason": null, "restart_reasons": ["'skip function graph_break in file /data/users/ezyang/b/pytorch/torch/_dynamo/decorators.py'"]}, "frame_id": 0, "frame_compile_id": 0, "attempt": 1}
+{"compilation_metrics": "METRICS", "frame_id": 0, "frame_compile_id": 0, "attempt": 1}
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_output_graph": {"sizes": {"l_x_": [1], "add": [1]}}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"aot_forward_graph": {}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_post_grad_graph": {}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_output_code": {"filename": "FILENAME"}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "2", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 1, "graph_node_count": 3, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0}
+{"compilation_metrics": "METRICS", "frame_id": 1, "frame_compile_id": 0, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -376,11 +360,11 @@ class StructuredTraceTest(TestCase):
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_output_graph": {"sizes": {"l_a_": [10, 20], "l_b_": [20, 30], "matmul": [10, 30]}}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "1", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 1, "graph_node_count": 4, "graph_input_count": 2, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"compilation_metrics": "METRICS", "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
 {"dynamo_output_graph": {"sizes": {"l_a_": ["s0", "s1"], "l_b_": ["s1", "s3"], "matmul": ["s0", "s3"]}}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "2", "cache_size": 1, "accumulated_cache_size": 1, "graph_op_count": 1, "graph_node_count": 7, "graph_input_count": 5, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
+{"compilation_metrics": "METRICS", "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -409,11 +393,11 @@ class StructuredTraceTest(TestCase):
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_output_graph": {"sizes": {"l_x_": [1], "x": [1]}}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "1", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 1, "graph_node_count": 3, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"compilation_metrics": "METRICS", "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
 {"dynamo_output_graph": {"sizes": {"l_x_": [1], "x": [1]}}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "2", "cache_size": 1, "accumulated_cache_size": 1, "graph_op_count": 1, "graph_node_count": 3, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
+{"compilation_metrics": "METRICS", "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
 """,  # noqa: B950
         )
 

--- a/test/dynamo/test_structured_trace.py
+++ b/test/dynamo/test_structured_trace.py
@@ -72,6 +72,23 @@ class StructuredTraceTestingFormatter(logging.Formatter):
             metadata["dynamo_start"]["stack"] = "STACK"
         if "inductor_output_code" in metadata:
             metadata["inductor_output_code"]["filename"] = "FILENAME"
+        if "compilation_metrics" in metadata:
+            metadata["compilation_metrics"] = {
+                k: metadata["compilation_metrics"][k]
+                # Subset of keys that are stable across platforms and runs
+                for k in (
+                    "frame_key",
+                    "co_name",
+                    "cache_size",
+                    "accumulated_cache_size",
+                    "graph_op_count",
+                    "graph_node_count",
+                    "graph_input_count",
+                    "fail_type",
+                    "fail_reason",
+                    "restart_reasons",
+                )
+            }
 
         return json.dumps(metadata)
 
@@ -136,6 +153,7 @@ class StructuredTraceTest(TestCase):
 {"inductor_post_grad_graph": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_output_code": {"filename": "FILENAME"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"compilation_metrics": {"frame_key": "1", "co_name": "inductor_schedule_fn", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 2, "graph_node_count": 4, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -154,6 +172,7 @@ class StructuredTraceTest(TestCase):
 {"inductor_post_grad_graph": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_output_code": {"filename": "FILENAME"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"compilation_metrics": {"frame_key": "1", "co_name": "inductor_schedule_fn", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 2, "graph_node_count": 4, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -176,12 +195,14 @@ class StructuredTraceTest(TestCase):
 {"inductor_post_grad_graph": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_output_code": {"filename": "FILENAME"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"compilation_metrics": {"frame_key": "1", "co_name": "fn", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 1, "graph_node_count": 4, "graph_input_count": 2, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
 {"dynamo_output_graph": {"sizes": {"l_x_": [1000, 1000], "add": [1000, 1000]}}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
 {"aot_forward_graph": {}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
 {"inductor_post_grad_graph": {}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
 {"inductor_output_code": {"filename": "FILENAME"}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
+{"compilation_metrics": {"frame_key": "2", "co_name": "fn", "cache_size": 1, "accumulated_cache_size": 1, "graph_op_count": 1, "graph_node_count": 3, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -199,6 +220,7 @@ class StructuredTraceTest(TestCase):
 {"inductor_post_grad_graph": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_output_code": {"filename": "FILENAME"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"compilation_metrics": {"frame_key": "1", "co_name": "example_fn", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 4, "graph_node_count": 6, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -214,6 +236,7 @@ class StructuredTraceTest(TestCase):
             self.buffer.getvalue(),
             """\
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"compilation_metrics": {"frame_key": "1", "co_name": "dynamo_error_fn", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": null, "graph_node_count": null, "graph_input_count": null, "fail_type": "<class 'torch._dynamo.exc.TorchRuntimeError'>", "fail_reason": "Failed running call_method add(*(FakeTensor(..., size=(1000, 1000), grad_fn=<MulBackward0>), FakeTensor(..., size=(10, 10))), **{}):\\nAttempting to broadcast a dimension of length 10 at -1! Mismatching argument at index 1 had torch.Size([10, 10]); but expected shape should be broadcastable to [1000, 1000]", "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -247,6 +270,7 @@ class StructuredTraceTest(TestCase):
 {"aot_forward_graph": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"aot_backward_graph": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_post_grad_graph": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"compilation_metrics": {"frame_key": "1", "co_name": "inductor_error_fn", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": null, "graph_node_count": null, "graph_input_count": null, "fail_type": "<class 'torch._dynamo.exc.BackendCompilerFailed'>", "fail_reason": "backend='inductor' raised:\\nLoweringException: AssertionError: \\n  target: aten.round.default\\n  args[0]: TensorBox(StorageBox(\\n    InputBuffer(name='primals_1', layout=FixedLayout('cpu', torch.float32, size=[1000, 1000], stride=[1000, 1]))\\n  ))", "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -284,6 +308,7 @@ class StructuredTraceTest(TestCase):
             """\
 {"dynamo_start": {"stack": "STACK"}, "rank": 0, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_guards": {}, "rank": 0, "frame_id": 0, "frame_compile_id": 0, "attempt": 1, "has_payload": "HASH"}
+{"compilation_metrics": {"frame_key": "1", "co_name": "inner", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 0, "graph_node_count": 0, "graph_input_count": 0, "fail_type": null, "fail_reason": null, "restart_reasons": ["call_method UserDefinedObjectVariable(instancemethod) __call__ [] {}"]}, "rank": 0, "frame_id": 0, "frame_compile_id": 0, "attempt": 1}
 {"dynamo_start": {"stack": "STACK"}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_output_graph": {"sizes": {"l_x_": [1024, 1024], "l__self___layers_0": [1024, 1024], "l__self___layers_1": [1024, 1024]}}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"optimize_ddp_split_graph": {}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
@@ -300,6 +325,7 @@ class StructuredTraceTest(TestCase):
 {"inductor_post_grad_graph": {}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_output_code": {"filename": "FILENAME"}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"compilation_metrics": {"frame_key": "2", "co_name": "forward", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 2, "graph_node_count": 4, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -318,12 +344,14 @@ class StructuredTraceTest(TestCase):
             """\
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 1, "has_payload": "HASH"}
+{"compilation_metrics": {"frame_key": "1", "co_name": "fn", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 0, "graph_node_count": 0, "graph_input_count": 0, "fail_type": null, "fail_reason": null, "restart_reasons": ["'skip function graph_break in file /data/users/ezyang/b/pytorch/torch/_dynamo/decorators.py'"]}, "frame_id": 0, "frame_compile_id": 0, "attempt": 1}
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_output_graph": {"sizes": {"l_x_": [1], "add": [1]}}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"aot_forward_graph": {}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_post_grad_graph": {}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_output_code": {"filename": "FILENAME"}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"compilation_metrics": {"frame_key": "2", "co_name": "torch_dynamo_resume_in_fn_at_328", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 1, "graph_node_count": 3, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -347,9 +375,11 @@ class StructuredTraceTest(TestCase):
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_output_graph": {"sizes": {"l_a_": [10, 20], "l_b_": [20, 30], "matmul": [10, 30]}}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"compilation_metrics": {"frame_key": "1", "co_name": "fn", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 1, "graph_node_count": 4, "graph_input_count": 2, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
 {"dynamo_output_graph": {"sizes": {"l_a_": ["s0", "s1"], "l_b_": ["s1", "s3"], "matmul": ["s0", "s3"]}}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
+{"compilation_metrics": {"frame_key": "2", "co_name": "fn", "cache_size": 1, "accumulated_cache_size": 1, "graph_op_count": 1, "graph_node_count": 7, "graph_input_count": 5, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -378,9 +408,11 @@ class StructuredTraceTest(TestCase):
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_output_graph": {"sizes": {"l_x_": [1], "x": [1]}}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
+{"compilation_metrics": {"frame_key": "1", "co_name": "fn", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 1, "graph_node_count": 3, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
 {"dynamo_output_graph": {"sizes": {"l_x_": [1], "x": [1]}}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
+{"compilation_metrics": {"frame_key": "2", "co_name": "fn", "cache_size": 1, "accumulated_cache_size": 1, "graph_op_count": 1, "graph_node_count": 3, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
 """,  # noqa: B950
         )
 

--- a/test/dynamo/test_structured_trace.py
+++ b/test/dynamo/test_structured_trace.py
@@ -78,7 +78,8 @@ class StructuredTraceTestingFormatter(logging.Formatter):
                 # Subset of keys that are stable across platforms and runs
                 for k in (
                     "frame_key",
-                    "co_name",
+                    # NB: do not do co_name, resumption frames have line
+                    # numbers in them
                     "cache_size",
                     "accumulated_cache_size",
                     "graph_op_count",
@@ -153,7 +154,7 @@ class StructuredTraceTest(TestCase):
 {"inductor_post_grad_graph": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_output_code": {"filename": "FILENAME"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "1", "co_name": "inductor_schedule_fn", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 2, "graph_node_count": 4, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"compilation_metrics": {"frame_key": "1", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 2, "graph_node_count": 4, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -172,7 +173,7 @@ class StructuredTraceTest(TestCase):
 {"inductor_post_grad_graph": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_output_code": {"filename": "FILENAME"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "1", "co_name": "inductor_schedule_fn", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 2, "graph_node_count": 4, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"compilation_metrics": {"frame_key": "1", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 2, "graph_node_count": 4, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -195,14 +196,14 @@ class StructuredTraceTest(TestCase):
 {"inductor_post_grad_graph": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_output_code": {"filename": "FILENAME"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "1", "co_name": "fn", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 1, "graph_node_count": 4, "graph_input_count": 2, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"compilation_metrics": {"frame_key": "1", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 1, "graph_node_count": 4, "graph_input_count": 2, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
 {"dynamo_output_graph": {"sizes": {"l_x_": [1000, 1000], "add": [1000, 1000]}}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
 {"aot_forward_graph": {}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
 {"inductor_post_grad_graph": {}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
 {"inductor_output_code": {"filename": "FILENAME"}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "2", "co_name": "fn", "cache_size": 1, "accumulated_cache_size": 1, "graph_op_count": 1, "graph_node_count": 3, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
+{"compilation_metrics": {"frame_key": "2", "cache_size": 1, "accumulated_cache_size": 1, "graph_op_count": 1, "graph_node_count": 3, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -220,7 +221,7 @@ class StructuredTraceTest(TestCase):
 {"inductor_post_grad_graph": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_output_code": {"filename": "FILENAME"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "1", "co_name": "example_fn", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 4, "graph_node_count": 6, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"compilation_metrics": {"frame_key": "1", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 4, "graph_node_count": 6, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -236,7 +237,7 @@ class StructuredTraceTest(TestCase):
             self.buffer.getvalue(),
             """\
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
-{"compilation_metrics": {"frame_key": "1", "co_name": "dynamo_error_fn", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": null, "graph_node_count": null, "graph_input_count": null, "fail_type": "<class 'torch._dynamo.exc.TorchRuntimeError'>", "fail_reason": "Failed running call_method add(*(FakeTensor(..., size=(1000, 1000), grad_fn=<MulBackward0>), FakeTensor(..., size=(10, 10))), **{}):\\nAttempting to broadcast a dimension of length 10 at -1! Mismatching argument at index 1 had torch.Size([10, 10]); but expected shape should be broadcastable to [1000, 1000]", "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"compilation_metrics": {"frame_key": "1", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": null, "graph_node_count": null, "graph_input_count": null, "fail_type": "<class 'torch._dynamo.exc.TorchRuntimeError'>", "fail_reason": "Failed running call_method add(*(FakeTensor(..., size=(1000, 1000), grad_fn=<MulBackward0>), FakeTensor(..., size=(10, 10))), **{}):\\nAttempting to broadcast a dimension of length 10 at -1! Mismatching argument at index 1 had torch.Size([10, 10]); but expected shape should be broadcastable to [1000, 1000]", "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -270,7 +271,7 @@ class StructuredTraceTest(TestCase):
 {"aot_forward_graph": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"aot_backward_graph": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_post_grad_graph": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "1", "co_name": "inductor_error_fn", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": null, "graph_node_count": null, "graph_input_count": null, "fail_type": "<class 'torch._dynamo.exc.BackendCompilerFailed'>", "fail_reason": "backend='inductor' raised:\\nLoweringException: AssertionError: \\n  target: aten.round.default\\n  args[0]: TensorBox(StorageBox(\\n    InputBuffer(name='primals_1', layout=FixedLayout('cpu', torch.float32, size=[1000, 1000], stride=[1000, 1]))\\n  ))", "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"compilation_metrics": {"frame_key": "1", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": null, "graph_node_count": null, "graph_input_count": null, "fail_type": "<class 'torch._dynamo.exc.BackendCompilerFailed'>", "fail_reason": "backend='inductor' raised:\\nLoweringException: AssertionError: \\n  target: aten.round.default\\n  args[0]: TensorBox(StorageBox(\\n    InputBuffer(name='primals_1', layout=FixedLayout('cpu', torch.float32, size=[1000, 1000], stride=[1000, 1]))\\n  ))", "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -308,7 +309,7 @@ class StructuredTraceTest(TestCase):
             """\
 {"dynamo_start": {"stack": "STACK"}, "rank": 0, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_guards": {}, "rank": 0, "frame_id": 0, "frame_compile_id": 0, "attempt": 1, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "1", "co_name": "inner", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 0, "graph_node_count": 0, "graph_input_count": 0, "fail_type": null, "fail_reason": null, "restart_reasons": ["call_method UserDefinedObjectVariable(instancemethod) __call__ [] {}"]}, "rank": 0, "frame_id": 0, "frame_compile_id": 0, "attempt": 1}
+{"compilation_metrics": {"frame_key": "1", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 0, "graph_node_count": 0, "graph_input_count": 0, "fail_type": null, "fail_reason": null, "restart_reasons": ["call_method UserDefinedObjectVariable(instancemethod) __call__ [] {}"]}, "rank": 0, "frame_id": 0, "frame_compile_id": 0, "attempt": 1}
 {"dynamo_start": {"stack": "STACK"}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_output_graph": {"sizes": {"l_x_": [1024, 1024], "l__self___layers_0": [1024, 1024], "l__self___layers_1": [1024, 1024]}}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"optimize_ddp_split_graph": {}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
@@ -325,7 +326,7 @@ class StructuredTraceTest(TestCase):
 {"inductor_post_grad_graph": {}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_output_code": {"filename": "FILENAME"}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "2", "co_name": "forward", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 2, "graph_node_count": 4, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0}
+{"compilation_metrics": {"frame_key": "2", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 2, "graph_node_count": 4, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "rank": 0, "frame_id": 1, "frame_compile_id": 0, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -344,14 +345,14 @@ class StructuredTraceTest(TestCase):
             """\
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 1, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "1", "co_name": "fn", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 0, "graph_node_count": 0, "graph_input_count": 0, "fail_type": null, "fail_reason": null, "restart_reasons": ["'skip function graph_break in file /data/users/ezyang/b/pytorch/torch/_dynamo/decorators.py'"]}, "frame_id": 0, "frame_compile_id": 0, "attempt": 1}
+{"compilation_metrics": {"frame_key": "1", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 0, "graph_node_count": 0, "graph_input_count": 0, "fail_type": null, "fail_reason": null, "restart_reasons": ["'skip function graph_break in file /data/users/ezyang/b/pytorch/torch/_dynamo/decorators.py'"]}, "frame_id": 0, "frame_compile_id": 0, "attempt": 1}
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_output_graph": {"sizes": {"l_x_": [1], "add": [1]}}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"aot_forward_graph": {}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_post_grad_graph": {}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"inductor_output_code": {"filename": "FILENAME"}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "2", "co_name": "torch_dynamo_resume_in_fn_at_328", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 1, "graph_node_count": 3, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0}
+{"compilation_metrics": {"frame_key": "2", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 1, "graph_node_count": 3, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 1, "frame_compile_id": 0, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -375,11 +376,11 @@ class StructuredTraceTest(TestCase):
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_output_graph": {"sizes": {"l_a_": [10, 20], "l_b_": [20, 30], "matmul": [10, 30]}}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "1", "co_name": "fn", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 1, "graph_node_count": 4, "graph_input_count": 2, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"compilation_metrics": {"frame_key": "1", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 1, "graph_node_count": 4, "graph_input_count": 2, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
 {"dynamo_output_graph": {"sizes": {"l_a_": ["s0", "s1"], "l_b_": ["s1", "s3"], "matmul": ["s0", "s3"]}}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "2", "co_name": "fn", "cache_size": 1, "accumulated_cache_size": 1, "graph_op_count": 1, "graph_node_count": 7, "graph_input_count": 5, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
+{"compilation_metrics": {"frame_key": "2", "cache_size": 1, "accumulated_cache_size": 1, "graph_op_count": 1, "graph_node_count": 7, "graph_input_count": 5, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
 """,  # noqa: B950
         )
 
@@ -408,11 +409,11 @@ class StructuredTraceTest(TestCase):
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_output_graph": {"sizes": {"l_x_": [1], "x": [1]}}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "1", "co_name": "fn", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 1, "graph_node_count": 3, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+{"compilation_metrics": {"frame_key": "1", "cache_size": 0, "accumulated_cache_size": 0, "graph_op_count": 1, "graph_node_count": 3, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
 {"dynamo_start": {"stack": "STACK"}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
 {"dynamo_output_graph": {"sizes": {"l_x_": [1], "x": [1]}}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
 {"dynamo_guards": {}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "HASH"}
-{"compilation_metrics": {"frame_key": "2", "co_name": "fn", "cache_size": 1, "accumulated_cache_size": 1, "graph_op_count": 1, "graph_node_count": 3, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
+{"compilation_metrics": {"frame_key": "2", "cache_size": 1, "accumulated_cache_size": 1, "graph_op_count": 1, "graph_node_count": 3, "graph_input_count": 1, "fail_type": null, "fail_reason": null, "restart_reasons": []}, "frame_id": 0, "frame_compile_id": 1, "attempt": 0}
 """,  # noqa: B950
         )
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -673,6 +673,13 @@ _compilation_metrics: Deque[CompilationMetrics] = collections.deque(
 def record_compilation_metrics(compilation_metrics: CompilationMetrics):
     global _compilation_metrics
     _compilation_metrics.append(compilation_metrics)
+    torch._logging.trace_structured(
+        "compilation_metrics",
+        lambda: {
+            k: list(v) if isinstance(v, set) else v
+            for k, v in dataclasses.asdict(compilation_metrics).items()
+        },
+    )
     if config.log_compilation_metrics:
         log_compilation_event(compilation_metrics)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #122644
* __->__ #122638

It's not technically needed as you can get it from Scuba too, but it's
more convenient for tlparse to get at it this way.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang