### PR TITLE
Simplify forward AD missing support error

### DIFF
--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -426,7 +426,8 @@ Return run_jit_decomposition_with_args_for_jvp(
       name,
       " that does not support it because it has not been implemented yet.\nPlease file an issue "
       "to PyTorch at https://github.com/pytorch/pytorch/issues/new?template=feature-request.yml "
-      "so that we can prioritize its implementation.\n");
+      "so that we can prioritize its implementation or submit a PR adding the implementation to "
+      "derivatives.yaml");
 
   return c10::KernelFunction::makeFromBoxedKernel(
              c10::BoxedKernel::makeFromFunctor(

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -426,11 +426,7 @@ Return run_jit_decomposition_with_args_for_jvp(
       name,
       " that does not support it because it has not been implemented yet.\nPlease file an issue "
       "to PyTorch at https://github.com/pytorch/pytorch/issues/new?template=feature-request.yml "
-      "so that we can prioritize its implementation.\n"
-      "Note that forward AD support for some operators require PyTorch to be built with "
-      "TorchScript and for JIT to be enabled. "
-      "If the environment var PYTORCH_JIT=0 is set or if the library is not built with TorchScript, "
-      "some operators may no longer be used with forward AD.");
+      "so that we can prioritize its implementation.\n");
 
   return c10::KernelFunction::makeFromBoxedKernel(
              c10::BoxedKernel::makeFromFunctor(


### PR DESCRIPTION
This thing about jit decomposition confuses users greatly and I'm not sure what it adds. So removing it.