### PR TITLE
Revert "[TorchGen] Add mutable parameter to valuetype_type function in api/cpp.py (#121415)"

### DIFF
--- a/torchgen/api/cpp.py
+++ b/torchgen/api/cpp.py
@@ -91,7 +91,6 @@ def valuetype_type(
     t: Type,
     *,
     binds: ArgName,
-    mutable: bool = True,
     remove_non_owning_ref_types: bool = False,
     symint: bool = False,
 ) -> Optional[NamedCType]:
@@ -111,12 +110,9 @@ def valuetype_type(
         # All other BaseType currently map directly to BaseCppTypes.
         return NamedCType(binds, BaseCType(BaseTypeToCppMapping[t.name]))
     elif isinstance(t, OptionalType):
-        elem = valuetype_type(t.elem, binds=binds, mutable=mutable, symint=symint)
+        elem = valuetype_type(t.elem, binds=binds, symint=symint)
         if elem is None:
             return None
-        if not mutable:
-            if str(t.elem) == "Generator":
-                return NamedCType(binds, ConstRefCType(OptionalCType(elem.type)))
         return NamedCType(binds, OptionalCType(elem.type))
     elif isinstance(t, ListType):
         if str(t.elem) == "bool":
@@ -144,7 +140,6 @@ def argumenttype_type(
     r = valuetype_type(
         t,
         binds=binds,
-        mutable=mutable,
         symint=symint,
         remove_non_owning_ref_types=remove_non_owning_ref_types,
     )
@@ -233,7 +228,7 @@ def returntype_type(t: Type, *, mutable: bool, symint: bool = False) -> CType:
     # placeholder is ignored
     # NB: symint is ALWAYS respected for return types.  So symint argument
     # here is IGNORED
-    r = valuetype_type(t, binds="__placeholder__", mutable=mutable, symint=True)
+    r = valuetype_type(t, binds="__placeholder__", symint=True)
     if r is not None:
         return r.type
 

--- a/torchgen/api/structured.py
+++ b/torchgen/api/structured.py
@@ -48,7 +48,7 @@ def argumenttype_type(t: Type, *, mutable: bool, binds: ArgName) -> NamedCType:
     # CompositeExplicitAutograd and the meta function (which could
     # hypothetically be SymInt), but for simplicity we plan for these to just
     # be handled in Python
-    r = cpp.valuetype_type(t, symint=False, binds=binds, mutable=mutable)
+    r = cpp.valuetype_type(t, symint=False, binds=binds)
     if r is not None:
         return r
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #122636
* __->__ #122640

This reverts commit c1fe09dc37358d8121f119d66e9e8c8d57035158.