### PR TITLE
[c10d][NCCL] Refactor coalesced storage

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -2516,6 +2516,17 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collectiveCoalesced(
   const auto key = getKeyFromDevice(device);
   auto ncclComm = getNCCLComm(key, device, opType);
 
+  if (coalescing_state_ & CoalActive) {
+    coalescing_state_ |= CoalColl;
+    if (coalescedDevice_.index() < 0) {
+      coalescedDevice_ = device;
+    } else {
+      TORCH_CHECK(
+          coalescedDevice_.index() == device.index(), MULTI_DEVICE_ERROR_MSG);
+    }
+    coalescedComm_ = ncclComm;
+  }
+
   // Used many times below, so we stash the unordered_map lookup
   auto ncclStream = ncclStreams_.at(key);
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -2526,21 +2526,6 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collectiveCoalesced(
   const auto key = getKeyFromDevice(device);
   auto ncclComm = getNCCLComm(key, device, opType);
 
-  if (coalescing_state_ & CoalActive) {
-    coalescing_state_ |= CoalColl;
-    if (coalescedDevice_.index() < 0) {
-      coalescedDevice_ = device;
-    } else {
-      TORCH_CHECK(
-          coalescedDevice_.index() == device.index(), MULTI_DEVICE_ERROR_MSG);
-    }
-    if (coalescedComm_ == nullptr) {
-      coalescedComm_ = ncclComm;
-    } else {
-      TORCH_CHECK(coalescedComm_ == ncclComm, MULTI_DEVICE_ERROR_MSG);
-    }
-  }
-
   // Used many times below, so we stash the unordered_map lookup
   auto ncclStream = ncclStreams_.at(key);
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -2261,7 +2261,7 @@ void ProcessGroupNCCL::startCoalescing() {
 // `optype` is for specifying a composite optype, such as ALLGATHER and
 // REDUCE_SCATTER
 c10::intrusive_ptr<Work> ProcessGroupNCCL::endCoalescing(OpType optype) {
-  TORCH_CHECK(coalescedDevice_.index() >= 0, MULTI_DEVICE_ERROR_MSG);
+  TORCH_CHECK(coalescedDevice_.index() >= 1, MULTI_DEVICE_ERROR_MSG);
   auto device = coalescedDevice_;
 
   // `getKeyFromDevice` is how we get keys for both collectives and batch P2P
@@ -2347,10 +2347,11 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collective(
 
   if (coalescing_state_ & CoalActive) {
     coalescing_state_ |= CoalColl;
-    if(coalescedDevice_.index() < 0) {
+    if (coalescedDevice_.index() < 0) {
       coalescedDevice_ = device;
     } else {
-      TORCH_CHECK(coalescedDevice_.index() == device.index(), MULTI_DEVICE_ERROR_MSG);
+      TORCH_CHECK(
+          coalescedDevice_.index() == device.index(), MULTI_DEVICE_ERROR_MSG);
     }
   }
 
@@ -2716,7 +2717,8 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::pointToPoint(
     if (coalescedDevice_.index() < 0) {
       coalescedDevice_ = device;
     } else {
-      TORCH_CHECK(coalescedDevice_.index() == device.index(), MULTI_DEVICE_ERROR_MSG);
+      TORCH_CHECK(
+          coalescedDevice_.index() == device.index(), MULTI_DEVICE_ERROR_MSG);
     }
   }
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -2261,7 +2261,7 @@ void ProcessGroupNCCL::startCoalescing() {
 // `optype` is for specifying a composite optype, such as ALLGATHER and
 // REDUCE_SCATTER
 c10::intrusive_ptr<Work> ProcessGroupNCCL::endCoalescing(OpType optype) {
-  TORCH_CHECK(coalescedDevice_.index() >= 1, MULTI_DEVICE_ERROR_MSG);
+  TORCH_CHECK(coalescedDevice_.index() >= 0, MULTI_DEVICE_ERROR_MSG);
   auto device = coalescedDevice_;
 
   // `getKeyFromDevice` is how we get keys for both collectives and batch P2P

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -2267,11 +2267,14 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::endCoalescing(OpType optype) {
   TORCH_CHECK(
       coalescedComm_ != nullptr,
       "Somthing went wrong. Did you call end_coalescing before start_coalescing?");
+
+  // `coalescedComm_` should have same set of comms across collectives
+  auto comm = coalescedComm_;
+  // `coalescedDevice_` should have same set of devices across collectives
   auto device = coalescedDevice_;
 
   // `getKeyFromDevice` is how we get keys for both collectives and batch P2P
   const auto key = getKeyFromDevice(device);
-  auto comm = coalescedComm_;
   auto ncclStream = ncclStreams_.at(key);
 
   // Create Work object
@@ -2354,11 +2357,11 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collective(
     coalescing_state_ |= CoalColl;
     if (coalescedDevice_.index() < 0) {
       coalescedDevice_ = device;
-      coalescedComm_ = ncclComm;
     } else {
       TORCH_CHECK(
           coalescedDevice_.index() == device.index(), MULTI_DEVICE_ERROR_MSG);
     }
+    coalescedComm_ = ncclComm;
   }
 
   // Used many times below, so we stash the unordered_map lookup
@@ -2722,11 +2725,11 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::pointToPoint(
     coalescing_state_ |= CoalP2P;
     if (coalescedDevice_.index() < 0) {
       coalescedDevice_ = device;
-      coalescedComm_ = ncclComm;
     } else {
       TORCH_CHECK(
           coalescedDevice_.index() == device.index(), MULTI_DEVICE_ERROR_MSG);
     }
+    coalescedComm_ = ncclComm;
   }
 
   // Used many times below, so we stash the unordered_map lookup

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -986,10 +986,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   int coalescing_state_ = 0;
 
   // Stores device indexes for all collectives run inside a coalescing block
-  std::vector<at::Device> coalescedDevices_;
-
-  // Stores communicators for all collectives run inside a coalescing block
-  std::vector<std::shared_ptr<NCCLComm>> coalescedComms_;
+  at::Device coalescedDevice_ = at::Device("cuda");
 
   // map from the key: "group name + pg counter (ID)" to the
   // unique NCCL ID count. This needs to be group and pg specific

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -988,6 +988,9 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // Stores device indexes for all collectives run inside a coalescing block
   at::Device coalescedDevice_ = at::Device("cuda");
 
+  // Stores communicators for all collectives run inside a coalescing block
+  std::shared_ptr<NCCLComm> coalescedComm_ = nullptr;
+
   // map from the key: "group name + pg counter (ID)" to the
   // unique NCCL ID count. This needs to be group and pg specific
   //


### PR DESCRIPTION
The `coalescedDevice_` are `coalescedComms_` used inefficiently and in case of consequent coalescing comms can cause to read-before-write condition.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang