### PR TITLE
[AOTInductor] Add tensor_constantX to pass constant buffer update's check (#122562)

### DIFF
--- a/test/cpp/aot_inductor/test.cpp
+++ b/test/cpp/aot_inductor/test.cpp
@@ -241,6 +241,45 @@ void test_aoti_double_buffering(
   ASSERT_TRUE(torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
 }
 
+void test_aoti_double_buffering_with_tensor_constants() {
+  torch::NoGradGuard no_grad;
+
+  std::string data_path = (std::filesystem::path(
+                               STRINGIZE(CMAKE_CURRENT_BINARY_DIR)) /
+                               "data_with_tensor_constants.pt")
+                               .string();
+
+  torch::jit::script::Module data_loader = torch::jit::load(data_path);
+  std::string path_attr = "model_so_path";
+  std::string inputs_attr = "inputs";
+  std::string w_attr = "w";
+  std::string outputs_attr = "outputs";
+  const auto& model_so_path = data_loader.attr(path_attr.c_str()).toStringRef();
+  auto input_tensors =
+      data_loader.attr(inputs_attr.c_str()).toTensorList().vec();
+  const auto& w_tensors = data_loader.attr(w_attr.c_str()).toTensor();
+  const auto& ref_output_tensors =
+      data_loader.attr(outputs_attr.c_str()).toTensorList().vec();
+
+  torch::inductor::TensorConstantMap real_map;
+  real_map.emplace("L__self___w", new at::Tensor(w_tensors));
+
+  std::unique_ptr<torch::inductor::AOTIModelContainerRunner> runner;
+  runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCuda>(
+      model_so_path.c_str());
+
+  // By default, buffer #1 get loaded with burned in weights. Correct results.
+  auto actual_output_tensors = runner->run(input_tensors);
+  ASSERT_TRUE(torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
+
+  // We update the weights to buffer #2 and activate it. This should still
+  // produce correct result, since we would have copied the tensor_constants.
+  runner->update_inactive_constant_buffer(real_map);
+  runner->swap_constant_buffer();
+  actual_output_tensors = runner->run(input_tensors);
+  ASSERT_TRUE(torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
+}
+
 } // namespace
 
 namespace torch {
@@ -278,6 +317,10 @@ TEST(AotInductorTest, RuntimeUpdateInactiveConstantsCuda) {
 
 TEST(AotInductorTest, UpdateInactiveConstantsCuda) {
   test_aoti_double_buffering("cuda", false);
+}
+
+TEST(AotInductorTest, UpdateInactiveConstantsWithTensorConstantsCuda) {
+  test_aoti_double_buffering_with_tensor_constants();
 }
 #endif
 

--- a/test/cpp/aot_inductor/test.py
+++ b/test/cpp/aot_inductor/test.py
@@ -17,38 +17,74 @@ class Net(torch.nn.Module):
         w = w_relu + self.w_add
         return torch.matmul(x, w)
 
+class NetWithTensorConstants(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.w = torch.randn(30, 1, device="cuda")
+
+    def forward(self, x, y):
+        z = self.w * x * y
+        return z[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17]]
+
 data = {}
+data_with_tensor_constants = {}
 
-for device in ["cpu", "cuda"]:
-    for use_runtime_constant_folding in [True, False]:
-        if device == "cpu" and use_runtime_constant_folding:
-            # We do not test runtime const folding for cpu mode.
-            continue
-        model = Net(device).to(device=device)
-        x = torch.randn((4, 4), device=device)
-        with torch.no_grad():
-            ref_output = model(x)
+# Basice AOTI model test generation.
+def generate_basic_tests():
+    for device in ["cpu", "cuda"]:
+        for use_runtime_constant_folding in [True, False]:
+            if device == "cpu" and use_runtime_constant_folding:
+                # We do not test runtime const folding for cpu mode.
+                continue
+            model = Net(device).to(device=device)
+            x = torch.randn((4, 4), device=device)
+            with torch.no_grad():
+                ref_output = model(x)
 
-        torch._dynamo.reset()
-        with torch.no_grad():
-            dim0_x = Dim("dim0_x", min=1, max=1024)
-            dynamic_shapes = {"x": {0: dim0_x}}
-            model_so_path = aot_compile(
-                model,
-                (x,),
-                dynamic_shapes=dynamic_shapes,
-                options={"aot_inductor.use_runtime_constant_folding": use_runtime_constant_folding})
+            torch._dynamo.reset()
+            with torch.no_grad():
+                dim0_x = Dim("dim0_x", min=1, max=1024)
+                dynamic_shapes = {"x": {0: dim0_x}}
+                model_so_path = aot_compile(
+                    model,
+                    (x,),
+                    dynamic_shapes=dynamic_shapes,
+                    options={"aot_inductor.use_runtime_constant_folding": use_runtime_constant_folding})
 
-        suffix = f"{device}"
-        if use_runtime_constant_folding:
-            suffix += "_use_runtime_constant_folding"
-        data.update({
-            f"model_so_path_{suffix}": model_so_path,
-            f"inputs_{suffix}": [x],
-            f"outputs_{suffix}": [ref_output],
-            f"w_pre_{suffix}": model.w_pre,
-            f"w_add_{suffix}": model.w_add,
-        })
+            suffix = f"{device}"
+            if use_runtime_constant_folding:
+                suffix += "_use_runtime_constant_folding"
+            data.update({
+                f"model_so_path_{suffix}": model_so_path,
+                f"inputs_{suffix}": [x],
+                f"outputs_{suffix}": [ref_output],
+                f"w_pre_{suffix}": model.w_pre,
+                f"w_add_{suffix}": model.w_add,
+            })
+
+# AOTI model which will create additional tensors during autograd.
+def generate_test_with_additional_tensors():
+    model = NetWithTensorConstants()
+    x = torch.randn((30, 1), device="cuda")
+    y = torch.randn((30, 1), device="cuda")
+    with torch.no_grad():
+        ref_output = model(x, y)
+
+    torch._dynamo.reset()
+    with torch.no_grad():
+        model_so_path = aot_compile(
+            model,
+            (x, y))
+
+    data_with_tensor_constants.update({
+        "model_so_path": model_so_path,
+        "inputs": [x, y],
+        "outputs": [ref_output],
+        "w": model.w,
+    })
+
+generate_basic_tests()
+generate_test_with_additional_tensors()
 
 # Use this to communicate tensors to the cpp code
 class Serializer(torch.nn.Module):
@@ -58,3 +94,4 @@ class Serializer(torch.nn.Module):
             setattr(self, key, data[key])
 
 torch.jit.script(Serializer(data)).save("data.pt")
+torch.jit.script(Serializer(data_with_tensor_constants)).save("data_with_tensor_constants.pt")

--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -218,6 +218,9 @@ class AOTInductorModelContainer {
     pending_models_available_.notify_one();
   }
 
+  bool _is_tensor_constant(const std::string& constant_name) const {
+    return constant_name.rfind("_tensor_constant", 0) == 0;
+  }
   // This function updates the buffer for storing constants.
   // It will update the buffer, the mapping and the array mapping.
   void update_constant_buffer(
@@ -232,6 +235,7 @@ class AOTInductorModelContainer {
 
     auto* constants_blob_ptr =
         static_cast<uint8_t*>(get_constant_blob_ptr(use_inactive));
+    auto original_constants_map = get_constants_map(!use_inactive);
     auto constants_map_to_update = get_constants_map(use_inactive);
 
     if (validate_full_update) {
@@ -243,6 +247,13 @@ class AOTInductorModelContainer {
         auto constant_name = std::string(models_[0]->constant_name(idx));
         auto it = constants_map.find(constant_name);
         if (it == constants_map.end()) {
+          if (_is_tensor_constant(constant_name)) {
+            // tracing sometimes creates tensors that are non-existent in
+            // original graph. We could skip those and do a direct copy.
+            std::cerr << "[WARNING] Found constant " << constant_name
+                      << " in model, but not provided by user!\n";
+            continue;
+          }
           throw std::runtime_error(
               std::string("Cannot find constants ") + constant_name +
               std::string(" in constants_map!"));
@@ -253,8 +264,16 @@ class AOTInductorModelContainer {
     for (size_t idx = 0; idx < num_constants; idx++) {
       auto constant_name = std::string(models_[0]->constant_name(idx));
       auto it = constants_map.find(constant_name);
-      if (it == constants_map.end()) {
+      if (it == constants_map.end() &&
+          !(_is_tensor_constant(constant_name) && use_inactive)) {
         continue;
+      }
+
+      AtenTensorHandle tensor;
+      if (_is_tensor_constant(constant_name) && use_inactive) {
+        tensor = original_constants_map->find(constant_name)->second.get();
+      } else {
+        tensor = it->second;
       }
 
       // Move the data to container handled blob.
@@ -262,8 +281,8 @@ class AOTInductorModelContainer {
           constants_blob_ptr + constants_internal_offset_[idx];
       void* user_constant_ptr;
       int64_t constant_size;
-      aoti_torch_get_data_ptr(it->second, &user_constant_ptr);
-      aoti_torch_get_storage_size(it->second, &constant_size);
+      aoti_torch_get_data_ptr(tensor, &user_constant_ptr);
+      aoti_torch_get_storage_size(tensor, &constant_size);
 
       AOTI_RUNTIME_DEVICE_CHECK(cudaMemcpy(
           internal_constants_ptr,
@@ -278,9 +297,9 @@ class AOTInductorModelContainer {
       int64_t* stride;
       int64_t offset;
       int device_idx = models_[0]->get_device_idx();
-      AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_get_strides(it->second, &stride));
+      AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_get_strides(tensor, &stride));
       AOTI_TORCH_ERROR_CODE_CHECK(
-          aoti_torch_get_storage_offset(it->second, &offset));
+          aoti_torch_get_storage_offset(tensor, &offset));
       AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_create_tensor_from_blob(
           internal_constants_ptr,
           models_[0]->constant_ndim(idx),


### PR DESCRIPTION
Summary:

During tracing, some constants (tensor_constant{idx}) are being generated internally.
Those constants are neither parameters or buffers, and users have zero control on them.

To accomodate this, we should allow users not passing in those constants generated internally but still be able the constants in the model.

Test Plan:
Included in commit.
```
build/bin/test_aot_inductor
```

Reviewed By: zoranzhao

Differential Revision: D55354548


