### PR TITLE
[NEON] Speedup float16 convert

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
@@ -1062,17 +1062,17 @@ inline std::tuple<Vectorized<float>, Vectorized<float>> convert_half_float(const
 }
 inline Vectorized<Half> convert_float_half(const Vectorized<float>& a, const Vectorized<float>& b) {
   static_assert(Vectorized<Half>::size() == 2 * Vectorized<float>::size());
-  constexpr int64_t K = Vectorized<Half>::size();
-  __at_align__ float16_t arr2[K];
   float32x4x2_t x = a;
   float32x4x2_t y = b;
   float16x4_t x1 = vcvt_f16_f32(x.val[0]);
   float16x4_t x2 = vcvt_f16_f32(x.val[1]);
   float16x4_t y1 = vcvt_f16_f32(y.val[0]);
   float16x4_t y2 = vcvt_f16_f32(y.val[1]);
-  vst1q_f16(arr2, vcombine_f16(x1, x2));
-  vst1q_f16(arr2 + Vectorized<float>::size(), vcombine_f16(y1, y2));
-  return Vectorized<Half>::loadu(arr2);
+  Vectorized<Half> rc;
+  auto arr = reinterpret_cast<float16_t*>(rc.operator Half*());
+  vst1q_f16(arr, vcombine_f16(x1, x2));
+  vst1q_f16(arr + Vectorized<float>::size(), vcombine_f16(y1, y2));
+  return rc;
 }
 #else
 CONVERT_NON_VECTORIZED_INIT(Half, half);

--- a/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
@@ -1025,6 +1025,7 @@ inline Vectorized<type> convert_float_##name(const Vectorized<float>& a, const V
 }
 CONVERT_VECTORIZED_INIT(BFloat16, bfloat16);
 CONVERT_VECTORIZED_INIT(Half, half);
+
 #else // defined(CPU_CAPABILITY_AVX2) && !defined(_MSC_VER)
 
 #define CONVERT_NON_VECTORIZED_INIT(type, name) \

--- a/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
@@ -1050,18 +1050,18 @@ inline Vectorized<type> convert_float_##name(const Vectorized<float>& a, const V
 CONVERT_NON_VECTORIZED_INIT(BFloat16, bfloat16);
 #if defined(__aarch64__) && !defined(C10_MOBILE) && !defined(__CUDACC__)
 inline std::tuple<Vectorized<float>, Vectorized<float>> convert_half_float(const Vectorized<Half>& a) {
-  constexpr int64_t K = Vectorized<Half>::size();
-  __at_align__ float16_t arr2[K];
-  a.store(arr2);
-  float16x8_t x = vld1q_f16(arr2);
+  static_assert(Vectorized<Half>::size() == 2 * Vectorized<float>::size());
+  auto arr = reinterpret_cast<const float16_t*>(a.operator const Half*());
+  float16x8_t x = vld1q_f16(arr);
   float32x4_t x1 = vcvt_f32_f16(vget_low_f16(x));
   float32x4_t x2 = vcvt_f32_f16(vget_high_f16(x));
-  float16x8_t y = vld1q_f16(arr2 + Vectorized<float>::size());
+  float16x8_t y = vld1q_f16(arr + Vectorized<float>::size());
   float32x4_t y1 = vcvt_f32_f16(vget_low_f16(y));
   float32x4_t y2 = vcvt_f32_f16(vget_high_f16(y));
   return { Vectorized<float>(x1, x2), Vectorized<float>(y1, y2) };
 }
 inline Vectorized<Half> convert_float_half(const Vectorized<float>& a, const Vectorized<float>& b) {
+  static_assert(Vectorized<Half>::size() == 2 * Vectorized<float>::size());
   constexpr int64_t K = Vectorized<Half>::size();
   __at_align__ float16_t arr2[K];
   float32x4x2_t x = a;


### PR DESCRIPTION
By using `vcvt_f16_f32` and back

According to [benchmark_convert.py](https://github.com/malfet/llm_experiments/commit/d3279637ca925a2e28afea9f8d28080e4ecc23de) this makes float32 to float16 tensor conversion roughly 3 times faster: time to convert 4096x4096 float32 tensor drops from  5.23 msec to 1.66 msec on M2 Pro

Test plan: run `vector_test_all_types` + CI

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10