### PR TITLE
[wip][export] Add symint input support

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1211,8 +1211,8 @@ def export(
                             value, static_shapes=True
                         )
 
-                    fake_graph_inputs = pytree.tree_map(
-                        ambient_fake_mode.from_tensor, graph_inputs
+                    fake_graph_inputs = pytree.tree_map_only(
+                        torch.Tensor, ambient_fake_mode.from_tensor, graph_inputs
                     )
                     graph_captured_result = torch.func.functional_call(
                         graph, fake_params_buffers, fake_graph_inputs
@@ -1310,7 +1310,9 @@ def export(
             check_signature_rewritable(graph)
 
         # NB: This is mostly hitting the cache; Dynamo already converted these
-        example_fake_inputs = [fake_mode.from_tensor(t) for t in example_inputs]
+        example_fake_inputs = pytree.tree_map_only(
+            torch.Tensor, fake_mode.from_tensor, example_inputs
+        )
 
         if aten_graph:
             # Running graph with interpreter is needed for propagating the stack_trace

--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -55,7 +55,7 @@ def key_path_to_source(kp: KeyPath) -> Source:
 
 
 def _is_constant_argument(t):
-    return t is None or isinstance(t, (int, float, bool, str))
+    return t is None or isinstance(t, (int, float, bool, str, torch.SymInt))
 
 
 def fakify(


### PR DESCRIPTION
Addresses https://github.com/pytorch/pytorch/issues/113682

Exported program looks something like this:
```
ExportedProgram:
    class GraphModule(torch.nn.Module):
        def forward(self, arg0_1: "Sym(s0)", arg1_1: "f32[3, 3]"):
            # File: /data/users/angelayi/pytorch/test/export/test_export.py:3810 in forward, code: return x * y
            mul: "f32[3, 3]" = torch.ops.aten.mul.Tensor(arg1_1, arg0_1);  arg1_1 = arg0_1 = None
            return (mul,)
            
Graph signature: ExportGraphSignature(input_specs=[InputSpec(kind=<InputKind.USER_INPUT: 1>, arg=SymIntArgument(name='arg0_1'), target=None, persistent=None), InputSpec(kind=<InputKind.USER_INPUT: 1>, arg=TensorArgument(name='arg1_1'), target=None, persistent=None)], output_specs=[OutputSpec(kind=<OutputKind.USER_OUTPUT: 1>, arg=TensorArgument(name='mul'), target=None)])
Range constraints: {}
```

Some work/discussion is needed to improve the UX of passing in a symint. If you look at my test case, right now I do some jank stuff to pass in a symint.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang