### PR TITLE
[Inductor]Fix a couple of broken unit tests

### DIFF
--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -294,7 +294,7 @@ class TestGroupBatchFusion(TestCase):
                 counters["inductor"]["batch_aten_add"],
                 3,
             )
-            self.assertIn("group_batch_fusion_post_grad", optimus_scuba_log)
+            self.assertIn("GroupLinearFusion", optimus_scuba_log)
             counters.clear()
 
     @unittest.skipIf(not has_fbgemm, "requires fbgemm")
@@ -435,8 +435,7 @@ class TestPostGradBatchLinearFusion(TestCase):
             counters["inductor"]["batch_linear_post_grad"],
             2,
         )
-        self.assertNotIn("group_batch_fusion_pre_grad", optimus_scuba_log)
-        self.assertIn("group_batch_fusion_post_grad", optimus_scuba_log)
+        self.assertIn("PostGradBatchLinearFusion", optimus_scuba_log)
 
 
 class TestFindIndependentSubsetGreedy(TestCase):


### PR DESCRIPTION
Summary: Titled

Test Plan:
```
buck2 test mode/dev-nosan //caffe2/test/inductor:group_batch_fusion
```
Buck UI: https://www.internalfb.com/buck2/ad05a43c-cb4a-443e-8904-b4d53e4f4b1e
Test UI: https://www.internalfb.com/intern/testinfra/testrun/13510798909218388
Network: Up: 107KiB  Down: 28KiB  (reSessionID-d7146e4f-773a-46ea-9852-f10f59302479)
Jobs completed: 24. Time elapsed: 1:49.3s.
Cache hits: 0%. Commands: 2 (cached: 0, remote: 0, local: 2)
Tests finished: Pass 9. Fail 0. Fatal 0. Skip 0. Build failure 0

```
buck2 test 'fbcode//mode/opt' fbcode//caffe2/test/inductor/fb:split_cat_fx_passes_fb
```

Buck UI: https://www.internalfb.com/buck2/82dbf3b0-c747-4c07-98b8-53b69afa3157
Test UI: https://www.internalfb.com/intern/testinfra/testrun/1125900267699118
Network: Up: 1.4GiB  Down: 2.3GiB  (reSessionID-0bd22c6d-5dfe-4b4a-bc24-705eadac884b)
Jobs completed: 252570. Time elapsed: 7:25.2s.
Cache hits: 95%. Commands: 123778 (cached: 117999, remote: 2779, local: 3000)
Tests finished: Pass 1. Fail 0. Fatal 0. Skip 0. Build failure 0


Differential Revision: D55378009




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang