### PR TITLE
[POC][FSDP2] Ran parameter post acc grad hooks manually

### DIFF
--- a/torch/distributed/_composable/fsdp/_fsdp_collectives.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_collectives.py
@@ -215,8 +215,9 @@ def foreach_reduce(
                 fsdp_param.sharded_param.grad += new_sharded_dtensor_grad
             else:
                 fsdp_param.sharded_param.grad = new_sharded_dtensor_grad
-            for hook in getattr(
-                fsdp_param.sharded_param, "_post_accumulate_grad_hooks", {}
+            for hook in (
+                getattr(fsdp_param.sharded_param, "_post_accumulate_grad_hooks", {})
+                or {}
             ).values():
                 hook(fsdp_param.sharded_param)
             padded_sharded_numel = padded_unsharded_size.numel() // world_size

--- a/torch/distributed/_composable/fsdp/_fsdp_collectives.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_collectives.py
@@ -215,6 +215,10 @@ def foreach_reduce(
                 fsdp_param.sharded_param.grad += new_sharded_dtensor_grad
             else:
                 fsdp_param.sharded_param.grad = new_sharded_dtensor_grad
+            for hook in getattr(
+                fsdp_param.sharded_param, "_post_accumulate_grad_hooks", {}
+            ).values():
+                hook(fsdp_param.sharded_param)
             padded_sharded_numel = padded_unsharded_size.numel() // world_size
             flat_grad_offset += padded_sharded_numel
         post_reduce_view_out_event = view_out_stream.record_event()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122719
* #120256
* #119378
* #119302

FSDP2 accumulates gradients for sharded parameters outside of the autograd engine's normal accumulation logic. We can respect registered post-accumulate-grad hooks by running them manually.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @rohan-varma