### PR TITLE
Add non strict inline constraints and runtime assertions to non-strict exported program

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1826,7 +1826,6 @@ def forward(self, arg_0):
         test_inp = (torch.randint(1, 2, (2, 2)), torch.randint(3, 5, (2, 3)))
         self.assertTrue(torch.allclose(ep.module()(*test_inp), fn(*test_inp)))
 
-    @testing.expectedFailureNonStrict
     def test_constrain_size_with_constrain_value(self):
         class Module(torch.nn.Module):
             def forward(self, x, y):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1955,7 +1955,6 @@ def forward(self, arg_0):
             )
         )
 
-    @testing.expectedFailureNonStrict  # non-strict does not add deferred runtime assertions
     @testing.expectedFailureSerDerPreDispatch  # .item call becomes aten.item in predispatch IR
     def test_automatic_constrain_size(self):
         class M(torch.nn.Module):
@@ -2011,7 +2010,6 @@ def forward(self, arg_0):
             if node.op == "placeholder":
                 self.assertTrue(isinstance(node.meta["val"], (Tensor, int)))
 
-    @testing.expectedFailureNonStrict
     @testing.expectedFailureSerDerPreDispatch  # .item() becomes aten.item in predispatch IR
     def test_export_with_inline_constraints(self):
         class Module(torch.nn.Module):
@@ -2674,7 +2672,6 @@ def forward(self, arg_0):
         inp = torch.randn(2)
         self.assertTrue(torch.allclose(ep.module()(inp), torch.nonzero(inp)))
 
-    @testing.expectedFailureNonStrict
     def test_redundant_asserts(self):
         class Foo(torch.nn.Module):
             def forward(self, x):

--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -260,7 +260,6 @@ def make_constraints(
         if spec.kind == InputKind.USER_INPUT and isinstance(spec.arg, TensorArgument)
     }
 
-    range_constraints = {}
     input_dims = defaultdict(list)
     free_symbols = set()
     input_index = 0

--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -199,8 +199,12 @@ def make_constraints(
     #   - eval_frame.py solves constraints
     #   - _trace.py installs shape metadata in IR.
 
+    inline_constraints = gm.meta.get("inline_constraints", [])
+    range_constraints = {
+        symbol: inline_constraints[symbol] for symbol in inline_constraints
+    }
     if dynamic_shapes == []:
-        return {}
+        return range_constraints
 
     def _is_dynamic_shape_leaf(x):
         if x is None:

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -920,7 +920,7 @@ def _export(
 
         _rewrite_non_persistent_buffers(mod, ep_non_strict.sig, ep_non_strict.constants)
         _verify_nn_module_stack(gm)
-        return ExportedProgram(
+        exported_program = ExportedProgram(
             root=gm,
             graph=gm.graph,
             graph_signature=ep_non_strict.sig,
@@ -933,6 +933,11 @@ def _export(
             constants=ep_non_strict.constants,
             from_export=True,
         )
+        if len(range_constraints) > 0:
+            exported_program = exported_program._transform_do_not_use(
+                _AddRuntimeAssertionsForInlineConstraintsPass(range_constraints)
+            )
+        return exported_program
 
     gm_torch_level = _export_to_torch_ir(
         mod,

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -870,6 +870,11 @@ def _export(
                 pre_dispatch=pre_dispatch,
                 transform=_tuplify_outputs,
             )
+        ep_non_strict.gm.meta["inline_constraints"] = {
+            k: v
+            for k, v in fake_mode.shape_env.var_to_range.items()
+            if free_unbacked_symbols(k)
+        }
         try:
             range_constraints = make_constraints(
                 fake_mode,


### PR DESCRIPTION
This PR reduces the difference between strict and non-strict exported program by

- Support `inline_constraints` for non-strict exported program
- Add runtime assertions for range constraints to non-strict exported program

After this PR, the following unit tests are no longer `expectedFailureNonStrict`:
- test_automatic_constrain_size
- test_export_with_inline_constraints
- test_redundant_asserts
- test_constrain_size_with_constrain_value