### PR TITLE
Fixed `_infer_device_type` warning in `checkpoint`

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -10,6 +10,7 @@ import tempfile
 import traceback
 import textwrap
 import unittest
+import warnings
 from typing import Any, List, Dict
 import torch
 import torch.nn as nn
@@ -471,10 +472,40 @@ class TestCheckpoint(TestCase):
         self.assertTrue(isinstance(device_states[0], torch.Tensor))
         self.assertTrue(isinstance(device_states[1], torch.Tensor))
 
-    def test_infer_device_state_recursive(self):
+    def test_infer_device_state_recursive_meta(self):
         inp = {'foo' : torch.rand(10, device="meta")}
         device_type = _infer_device_type(inp)
         self.assertEqual("meta", device_type)
+
+    @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
+    def test_infer_device_state_recursive_multi_cuda(self):
+        # Check that *no* warning is issued for either cuda:0, cuda:1 or
+        # cuda:0, cuda:0 cases since they are both the same device type
+        inp = {'foo' : torch.rand(10, device="cuda:0"), 'bar': [torch.rand(10, device="cuda:1")]}
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            device_type = _infer_device_type(inp)
+            self.assertEqual("cuda", device_type)
+        inp = {'foo' : torch.rand(10, device="cuda:0"), 'bar': [torch.rand(10, device="cuda:0")]}
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            device_type = _infer_device_type(inp)
+            self.assertEqual("cuda", device_type)
+        # Check that a warning *is* issued for cuda:0, meta and that it
+        # includes device type information
+        inp = {'foo' : torch.rand(10, device="cuda:0"), 'bar': [torch.rand(10, device="meta")]}
+        with warnings.catch_warnings(record=True) as w:
+            device_type = _infer_device_type(inp)
+            self.assertEqual("cuda", device_type)
+        self.assertEqual(len(w), 1)
+        warning_msg = str(w[-1].message)
+        self.assertTrue(
+            "Tensor arguments, excluding CPU tensors, are detected on at least two types of devices"
+            in warning_msg
+        )
+        self.assertTrue("first device type: cuda" in warning_msg)
+        self.assertTrue("Device types: [\'cuda\', \'meta\']" in warning_msg)
+
 
 class TestDataLoaderUtils(TestCase):
     MAX_TIMEOUT_IN_SECOND = 300

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -503,8 +503,8 @@ class TestCheckpoint(TestCase):
             "Tensor arguments, excluding CPU tensors, are detected on at least two types of devices"
             in warning_msg
         )
-        self.assertTrue("first device type: cuda" in warning_msg)
         self.assertTrue("Device types: [\'cuda\', \'meta\']" in warning_msg)
+        self.assertTrue("first device type: cuda" in warning_msg)
 
 
 class TestDataLoaderUtils(TestCase):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -479,7 +479,7 @@ class TestCheckpoint(TestCase):
 
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
     def test_infer_device_state_recursive_multi_cuda(self):
-        # Check that *no* warning is issued for either cuda:0, cuda:1 or
+        # Check that no warning is issued for either cuda:0, cuda:1 or
         # cuda:0, cuda:0 cases since they are both the same device type
         inp = {'foo' : torch.rand(10, device="cuda:0"), 'bar': [torch.rand(10, device="cuda:1")]}
         with warnings.catch_warnings():
@@ -491,8 +491,8 @@ class TestCheckpoint(TestCase):
             warnings.simplefilter("error")
             device_type = _infer_device_type(inp)
             self.assertEqual("cuda", device_type)
-        # Check that a warning *is* issued for cuda:0, meta and that it
-        # includes device type information
+        # Check that a warning is issued for cuda:0, meta and that it includes
+        # device type information
         inp = {'foo' : torch.rand(10, device="cuda:0"), 'bar': [torch.rand(10, device="meta")]}
         with warnings.catch_warnings(record=True) as w:
             device_type = _infer_device_type(inp)

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -140,17 +140,19 @@ def _infer_device_type(*args):
             device_types.append(arg.device.type)
     tree_map(add_device_types, args)
 
-    if len(device_types) > 1:
+    device_types_set = set(device_types)
+    if len(device_types_set) > 1:
         warnings.warn(
             "Tensor arguments, excluding CPU tensors, are detected on at least two types of devices. "
             "Device state will only be saved for devices of a single device type, and the remaining "
             "devices will be ignored. Consequently, if any checkpointed functions involve randomness, "
             "this may result in incorrect gradients. (Note that if CUDA devices are among the devices "
             "detected, it will be prioritized; otherwise, the first device encountered will be selected.)"
+            f"\nDevice types: {sorted(device_types_set)} first device type: {device_types[0]}"
         )
     if len(device_types) == 0:
         return DefaultDeviceType.get_device_type()
-    elif "cuda" in device_types:
+    elif "cuda" in device_types_set:
         return "cuda"
     else:
         return device_types[0]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122726

Previously, we were checking `len(device_types)` where `device_types` is a `list`. This meant that if there were multiple inputs, we would see something like `device_types = ["cuda", "cuda"]` and a false positive warning. We should check `len(set(device_types))`.