### PR TITLE
ignore insignificant strides in memory overlap detection

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -112,6 +112,8 @@ def complex_memory_overlap(t: torch.Tensor) -> bool:
         indices = list(range(len(strides)))
         indices = [x for _, x in sorted(zip(strides, indices))]
         for i in range(len(strides)):
+            if sizes[i] <= 1:
+                continue
             prev_stride = 1 if i == 0 else strides[indices[i - 1]]
             prev_size = 1 if i == 0 else sizes[indices[i - 1]]
             if strides[indices[i]] < prev_stride * prev_size:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122730

Inadvertently avoiding this situation is what caused the nanogpt speedup. We should be manually skipping this case.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang