### PR TITLE
Allow flight recorder to call elasped_time again.

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1621,7 +1621,7 @@ void ProcessGroupNCCL::watchdogHandler() {
       // Clean up completed work
       if (work.isCompleted()) {
         lastCompletedSeq_ = work.seq_;
-        NCCLTraceBuffer::get()->retire_id(work.trace_id_, true);
+        NCCLTraceBuffer::get()->retire_id(work.trace_id_);
         if (onCompletionHook_) {
           // Move Work object to completedWorkList_ to be consumed by the hook
           // thread

--- a/torch/csrc/distributed/c10d/TraceUtils.h
+++ b/torch/csrc/distributed/c10d/TraceUtils.h
@@ -506,6 +506,10 @@ struct NCCLTraceBuffer {
         r.time_discovered_completed_ = c10::getTime();
       }
     }
+    if (r.start_ && r.end_ && r.time_discovered_completed_.has_value() &&
+        !r.duration_.has_value()) {
+      r.duration_ = getDurationFromEvent(*r.start_, *r.end_);
+    }
   }
 
   std::vector<Entry> dump_entries() {
@@ -528,59 +532,18 @@ struct NCCLTraceBuffer {
   This is called by the watchdog thread, and is asynchronous from the
   perspective of the main thread.
 
-  compute_duration defaults to true since retire_id is only called in the
-  watchdog thread, which is currently a place we call cuda APIs which may hang,
-  but care should be taken to avoid computing duration in any function that must
-  never hang. (timing must also be enabled for compute_duration - see
-  TORCH_NCCL_ENABLE_TIMING).
   */
-  void retire_id(c10::optional<size_t> id, bool compute_duration = true) {
+  void retire_id(c10::optional<size_t> id) {
     if (!enabled_ || !id) {
       return;
     }
-
-    bool can_compute_duration = false;
-    Event* startEvent = nullptr;
-    Event* endEvent = nullptr;
-    c10::optional<float> duration = c10::nullopt;
-
     std::unique_lock<std::mutex> guard(mutex_);
-
     Entry* entry = &entries_.at(*id % max_entries_);
     if (entry->id_ == *id) {
       update_state(*entry);
-
-      if (compute_duration) {
-        can_compute_duration = entry->time_discovered_completed_.has_value() &&
-            entry->start_ && entry->end_;
-        startEvent = entry->start_;
-        endEvent = entry->end_;
-      }
+      entry->retired_ = true;
+      entry->start_ = entry->end_ = nullptr;
     }
-
-    if (can_compute_duration) {
-      // Compute duration without without holding the lock, because
-      // cudaEventDuration() can hang, and we need to acquire the lock before we
-      // can dump(), which we never want to block.
-      guard.unlock();
-      duration = getDurationFromEvent(*startEvent, *endEvent);
-      guard.lock();
-
-      // Refresh the entry pointer, see if the entry has been overwritten
-      entry = &entries_.at(*id % max_entries_);
-      if (entry->id_ != *id) {
-        LOG(INFO)
-            << "retire_id abandoned for id " << *id
-            << ", event was overwritten while waiting to compute duration.";
-        return;
-      }
-      if (duration.has_value()) {
-        entry->duration_ = duration.value();
-      }
-    }
-
-    entry->retired_ = true;
-    entry->start_ = entry->end_ = nullptr;
   }
 
   std::string dump(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122731
* #122732
* #122539
* #122538

Previously we had to avoid elapsed_time because it would cause
the dump to get stuck inside cuda if the dump was initiated when
cuda was stuck waiting on nccl communication. However, elapsed_time
only got stuck because we were not setting the device correctly before
calling cudaEventElapsedTime. Now that this is fixed inside of elasped_time,
it no longer gets stuck. This means we can simplify handling of duration
timing in the flight recorder.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k