### PR TITLE
Remove .data call in LSTM as it is not necessary

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1584,7 +1584,6 @@ class TestExport(TestCase):
         self.assertEqual(buffer[1].shape, torch.Size([100]))  # running_var
         self.assertEqual(buffer[2].shape, torch.Size([]))  # num_batches_tracked
 
-    @testing.expectedFailureSerDerPreDispatch  # tracked via: T181382045
     def test_export_dynamo_config(self):
         class MyModule(torch.nn.Module):
             def __init__(self):

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -183,9 +183,10 @@ class RNNBase(Module):
         first_fw = self._flat_weights[0]
         dtype = first_fw.dtype
         for fw in self._flat_weights:
-            if (not isinstance(fw.data, Tensor) or not (fw.data.dtype == dtype) or
-                    not fw.data.is_cuda or
-                    not torch.backends.cudnn.is_acceptable(fw.data)):
+            if (
+                not isinstance(fw, Tensor) or not (fw.dtype == dtype) or
+                not fw.is_cuda or not torch.backends.cudnn.is_acceptable(fw)
+            ):
                 return
 
         # If any parameters alias, we fall back to the slower, copying code path. This is


### PR DESCRIPTION
Summary: Title

Test Plan: CI

Differential Revision: D55392057

Functional pre-dispatch tracing chokes on LSTM .data call today. While we need to fix it, it seems this call seems unnecessary here. 

