### PR TITLE
Adding health check server hook in torch elastic

### DIFF
--- a/docs/source/elastic/agent.rst
+++ b/docs/source/elastic/agent.rst
@@ -74,3 +74,19 @@ will internally create a unique file name and set it to the environment
 variable ```TORCHELASTIC_TIMER_FILE```, and this environment variable will
 be propagated to the worker processes to allow them to connect to the same
 named pipe that ```LocalElasticAgent``` uses.
+
+
+Health Check Server
+-------------------
+
+A health check monitoring server can be enabled in ```LocalElasticAgent```
+if an environment variable ``TORCHELASTIC_HEALTH_CHECK_PORT`` has been defined
+in the ```LocalElasticAgent``` process.
+Adding interface for health check server which can be extended by starting tcp/http
+server on the specified port number.
+Additionally, health check server will have callback to check watchdog is alive.
+
+.. currentmodule:: torch.distributed.elastic.agent.server.health_check_server
+
+.. autoclass:: HealthCheckServer
+   :members:

--- a/test/distributed/elastic/agent/server/test/local_elastic_agent_test.py
+++ b/test/distributed/elastic/agent/server/test/local_elastic_agent_test.py
@@ -32,6 +32,7 @@ from torch.distributed.elastic.agent.server.api import (
 )
 from torch.distributed.elastic.agent.server.local_elastic_agent import (
     LocalElasticAgent,
+    TORCHELASTIC_HEALTH_CHECK_PORT,
     TORCHELASTIC_TIMER_FILE,
 )
 from torch.distributed.elastic.multiprocessing import DefaultLogsSpecs, Std
@@ -587,6 +588,53 @@ class LocalElasticAgentTest(unittest.TestCase):
     def test_run_agent_local_watchdog_setup_disabled_c10d(self):
         self.run_test_with_backend(
             backend="c10d", test_to_run=self.run_agent_local_watchdog_setup_disabled
+        )
+
+    def run_agent_healthcheck_setup_enabled(self):
+        # Set the env for healthcheck
+        healthcheck_port_env_name = TORCHELASTIC_HEALTH_CHECK_PORT
+        os.environ[healthcheck_port_env_name] = "12345"
+        # Run the agent
+        node_conf = Conf(entrypoint=_check_local_watchdog_setup, local_world_size=1, args=(TORCHELASTIC_HEALTH_CHECK_PORT, True))
+        spec = self.get_worker_spec(node_conf, max_restarts=2)
+        agent = self.get_agent(spec, node_config=node_conf)
+        res = agent.run()
+        self.assertFalse(res.is_failed())
+
+    def run_agent_healthcheck_setup_disabled(self):
+        # Do not set the env for healthcheck
+        healthcheck_port_env_name = TORCHELASTIC_HEALTH_CHECK_PORT
+        if healthcheck_port_env_name in os.environ:
+            del os.environ[healthcheck_port_env_name]
+        # Run the agent
+        node_conf = Conf(entrypoint=_check_local_watchdog_setup, local_world_size=1, args=(TORCHELASTIC_HEALTH_CHECK_PORT, False))
+        spec = self.get_worker_spec(node_conf, max_restarts=2)
+        agent = self.get_agent(spec, node_config=node_conf)
+        res = agent.run()
+        self.assertFalse(res.is_failed())
+
+    @skip_but_pass_in_sandcastle_if(TEST_WITH_DEV_DBG_ASAN, "test incompatible with dev/dbg asan")
+    def test_run_agent_healthcheck_setup_enabled_etcd(self):
+        self.run_test_with_backend(
+            backend="etcd", test_to_run=self.run_agent_healthcheck_setup_enabled
+        )
+
+    @skip_but_pass_in_sandcastle_if(TEST_WITH_DEV_DBG_ASAN, "test incompatible with dev/dbg asan")
+    def test_run_agent_healthcheck_setup_enabled_c10d(self):
+        self.run_test_with_backend(
+            backend="c10d", test_to_run=self.run_agent_healthcheck_setup_enabled
+        )
+
+    @skip_but_pass_in_sandcastle_if(TEST_WITH_DEV_DBG_ASAN, "test incompatible with dev/dbg asan")
+    def test_run_agent_healthcheck_setup_disabled_etcd(self):
+        self.run_test_with_backend(
+            backend="etcd", test_to_run=self.run_agent_healthcheck_setup_disabled
+        )
+
+    @skip_but_pass_in_sandcastle_if(TEST_WITH_DEV_DBG_ASAN, "test incompatible with dev/dbg asan")
+    def test_run_agent_healthcheck_setup_disabled_c10d(self):
+        self.run_test_with_backend(
+            backend="c10d", test_to_run=self.run_agent_healthcheck_setup_disabled
         )
 
     @skip_but_pass_in_sandcastle_if(TEST_WITH_DEV_DBG_ASAN, "test incompatible with dev/dbg asan")

--- a/torch/distributed/elastic/agent/server/health_check_server.py
+++ b/torch/distributed/elastic/agent/server/health_check_server.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Callable
+
+from torch.distributed.elastic.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+
+class HealthCheckServer:
+    """
+    Interface for health check monitoring server, which can be extended
+    by starting tcp/http server on the specified port.
+
+    Args:
+
+        alive_callback: Callable[[], int], callback to last progress time of agent
+
+        port: int, port number to start tcp/http server
+
+        timeout: int, timeout seconds to decide agent is alive/dead
+    """
+
+    _alive_callback: Callable[[], int]
+    _port: int
+    _timeout: int
+
+    def __init__(
+        self, alive_callback: Callable[[], int], port: int, timeout: int
+    ) -> None:
+        self._alive_callback = alive_callback
+        self._port = port
+        self._timeout = timeout
+
+    def start(self) -> None:
+        """
+        Unsupported functionality for Pytorch, doesn't start any health check server
+        """
+        log.warning("No health check server started")
+
+    def stop(self) -> None:
+        log.info("Stopping noop health check server.")
+
+
+def create_healthcheck_server(
+    alive_callback: Callable[[], int],
+    port: int,
+    timeout: int,
+) -> HealthCheckServer:
+    """
+    creates health check server object
+    """
+    return HealthCheckServer(alive_callback, port, timeout)

--- a/torch/distributed/elastic/timer/file_based_local_timer.py
+++ b/torch/distributed/elastic/timer/file_based_local_timer.py
@@ -174,6 +174,7 @@ class FileTimerServer:
         # For test only. Process all requests and stop the server.
         self._run_once = False
         self._log_event = log_event if log_event is not None else lambda name, request: None
+        self._last_progress_time = int(time.time())
 
 
     def start(self) -> None:
@@ -237,6 +238,7 @@ class FileTimerServer:
                     self._run_watchdog(fd)
                     if run_once:
                         break
+                    self._last_progress_time = int(time.time())
                 except Exception:
                     logger.exception("Error running watchdog")
 
@@ -343,3 +345,6 @@ class FileTimerServer:
         except Exception:
             logger.exception("Error terminating pid=%s", worker_pid)
         return False
+
+    def get_last_progress_time(self) -> int:
+        return self._last_progress_time


### PR DESCRIPTION
Summary:
Building hook for external mechanism to monitor the health of torch elastic launcher. Health check server takes dependency on FileTimerServer to check if launcher is healthy or not. It will be always healthy if FileTimerServer is disabled.

Implementation of start_healthcheck_server is unsupported, however tcp/http server can be started on specific port which can monitor the aliveness of worker_watchdog and accordingly take the action.

Test Plan: buck test mode/opt caffe2/test/distributed/elastic/agent/server/test:local_agent_test

Differential Revision: D55108182




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @rohan-varma