### PR TITLE
Add quantized.linear_unpacked_dynamic_fp16

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -684,7 +684,7 @@ class QLinearUnpackedDynamicFp16 final {
   }
 
   static at::Tensor meta(
-      const at::Tensor& input,
+      at::Tensor input,
       const at::Tensor& weight,
       const at::Tensor& bias) {
     // We make a strong guarantee that models using these operators will have
@@ -706,8 +706,8 @@ class QLinearUnpackedDynamicFp16 final {
 #else // USE_FBGEMM
   static at::Tensor run(
       at::Tensor /* input */,
-      const at::Tensor weight,
-      const at::Tensor bias) {
+      const at::Tensor& weight,
+      const at::Tensor& bias) {
     // We make a strong guarantee that models using these operators will have
     // the same numerics across different machines. Therefore, we do not provide
     // a fallback path and rather fail loudly if we cannot run FBGEMM.
@@ -717,8 +717,8 @@ class QLinearUnpackedDynamicFp16 final {
 
   static at::Tensor meta(
       at::Tensor /* input */,
-      const at::Tensor weight,
-      const at::Tensor bias) {
+      const at::Tensor& weight,
+      const at::Tensor& bias) {
     TORCH_CHECK(
         false, "This PyTorch installation was not built with FBGEMM operators");
   }

--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -665,8 +665,8 @@ class QLinearUnpackedDynamicFp16 final {
 #ifdef USE_FBGEMM
   static at::Tensor run(
       at::Tensor input,
-      const at::Tensor weight,
-      const at::Tensor bias) {
+      const at::Tensor& weight,
+      const at::Tensor& bias) {
     // We make a strong guarantee that models using these operators will have
     // the same numerics across different machines. Therefore, we do not provide
     // a fallback path and rather fail loudly if we cannot run FBGEMM.
@@ -684,9 +684,9 @@ class QLinearUnpackedDynamicFp16 final {
   }
 
   static at::Tensor meta(
-      at::Tensor input,
-      const at::Tensor weight,
-      const at::Tensor bias) {
+      const at::Tensor& input,
+      const at::Tensor& weight,
+      const at::Tensor& bias) {
     // We make a strong guarantee that models using these operators will have
     // the same numerics across different machines. Therefore, we do not provide
     // a fallback path and rather fail loudly if we cannot run FBGEMM.

--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -737,7 +737,7 @@ TORCH_LIBRARY_IMPL(quantized, CPU, m) {
       TORCH_SELECTIVE_NAME("quantized::linear_dynamic_fp16"),
       TORCH_FN(QLinearDynamicFp16<false>::run));
   m.impl(
-      TORCH_SELECTIVE_NAME("quantized::linear_unpacked_dynamic_fp16"),
+      TORCH_SELECTIVE_NAME("quantized::linear_dynamic_fp16_unpacked_weight"),
       TORCH_FN(QLinearUnpackedDynamicFp16::run));
   m.impl(
       TORCH_SELECTIVE_NAME("quantized::linear_relu_dynamic_fp16"),
@@ -746,7 +746,7 @@ TORCH_LIBRARY_IMPL(quantized, CPU, m) {
 
 TORCH_LIBRARY_IMPL(quantized, Meta, m) {
   m.impl(
-      TORCH_SELECTIVE_NAME("quantized::linear_unpacked_dynamic_fp16"),
+      TORCH_SELECTIVE_NAME("quantized::linear_dynamic_fp16_unpacked_weight"),
       TORCH_FN(QLinearUnpackedDynamicFp16::meta));
 }
 

--- a/aten/src/ATen/native/quantized/library.cpp
+++ b/aten/src/ATen/native/quantized/library.cpp
@@ -149,6 +149,7 @@ TORCH_LIBRARY(quantized, m) {
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_dynamic(Tensor X, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack, bool reduce_range=False) -> Tensor Y"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_relu_dynamic(Tensor X, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack, bool reduce_range=False) -> Tensor Y"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_dynamic_fp16(Tensor X, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack) -> Tensor Y"), {at::Tag::pt2_compliant_tag});
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_unpacked_dynamic_fp16(Tensor X, Tensor weight, Tensor bias) -> Tensor Y"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_relu_dynamic_fp16(Tensor X, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack) -> Tensor Y"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_leaky_relu(Tensor X, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack, float Y_scale_i, int Y_zero_point_i, float negative_slope) -> Tensor Y"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_tanh(Tensor X, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y"), {at::Tag::pt2_compliant_tag});

--- a/aten/src/ATen/native/quantized/library.cpp
+++ b/aten/src/ATen/native/quantized/library.cpp
@@ -149,7 +149,7 @@ TORCH_LIBRARY(quantized, m) {
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_dynamic(Tensor X, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack, bool reduce_range=False) -> Tensor Y"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_relu_dynamic(Tensor X, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack, bool reduce_range=False) -> Tensor Y"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_dynamic_fp16(Tensor X, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack) -> Tensor Y"), {at::Tag::pt2_compliant_tag});
-  m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_unpacked_dynamic_fp16(Tensor X, Tensor weight, Tensor bias) -> Tensor Y"), {at::Tag::pt2_compliant_tag});
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_dynamic_fp16_unpacked_weight(Tensor X, Tensor weight, Tensor bias) -> Tensor Y"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_relu_dynamic_fp16(Tensor X, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack) -> Tensor Y"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_leaky_relu(Tensor X, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack, float Y_scale_i, int Y_zero_point_i, float negative_slope) -> Tensor Y"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_tanh(Tensor X, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y"), {at::Tag::pt2_compliant_tag});

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -3351,7 +3351,7 @@ class TestDynamicQuantizedOps(TestCase):
             (4, 7, 8),      # output_channels
         )
         for batch_size, input_channels, output_channels in options:
-            qlinear_dynamic = torch.ops.quantized.linear_unpacked_dynamic_fp16
+            qlinear_dynamic = torch.ops.quantized.linear_dynamic_fp16_unpacked_weight
 
             x = torch.randn(batch_size, input_channels)
             w = torch.randn(output_channels, input_channels)
@@ -3369,7 +3369,7 @@ class TestDynamicQuantizedOps(TestCase):
 
     @skipIfNoFBGEMM
     def test_unpacked_qlinear_dynamic_fp16_opcheck(self):
-        qlinear_dynamic = torch.ops.quantized.linear_unpacked_dynamic_fp16.default
+        qlinear_dynamic = torch.ops.quantized.linear_dynamic_fp16_unpacked_weight.default
 
         x = torch.randn(4, 4, device='cpu')
         w = torch.randn(4, 4, device='cpu')


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #122763
* __->__ #122762

Summary:

We add a new op quantized.linear_unpacked_dynamic_fp16, which is essentially linear_dynamic_fp16 with different (unpacked) weight/bias format.
This op does packing on the fly for each call with standard at::Tensor weight & bias.

Test Plan:
Included in commit.
test_quantized_op::test_unpacked_qlinear_dynamic_fp16

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10

Differential Revision: [D55433203](https://our.internmc.facebook.com/intern/diff/D55433203)