### PR TITLE
Workaround dind-rootless volumes mount as root

### DIFF
--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -223,6 +223,7 @@ if [[ "${BUILD_ENVIRONMENT}" != *android* && "${BUILD_ENVIRONMENT}" != *cuda* ]]
   export BUILD_STATIC_RUNTIME_BENCHMARK=ON
 fi
 
+# Workaround for dind-rootless userid mapping (https://github.com/pytorch/ci-infra/issues/96)
 WORKSPACE_ORIGINAL_OWNER_ID=$(stat -c '%u' "/var/lib/jenkins/workspace")
 sudo chown -R jenkins /var/lib/jenkins/workspace
 git config --global --add safe.directory /var/lib/jenkins/workspace
@@ -364,4 +365,5 @@ fi
 
 print_sccache_stats
 
+# Workaround for dind-rootless userid mapping (https://github.com/pytorch/ci-infra/issues/96)
 sudo chown -R "$WORKSPACE_ORIGINAL_OWNER_ID" /var/lib/jenkins/workspace

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -6,6 +6,11 @@
 
 set -ex
 
+# Workaround for dind-rootless userid mapping (https://github.com/pytorch/ci-infra/issues/96)
+WORKSPACE_ORIGINAL_OWNER_ID=$(stat -c '%u' "/var/lib/jenkins/workspace")
+sudo chown -R jenkins /var/lib/jenkins/workspace
+git config --global --add safe.directory /var/lib/jenkins/workspace
+
 echo "Environment variables:"
 env
 
@@ -1248,3 +1253,6 @@ else
   test_torch_function_benchmark
   test_benchmarks
 fi
+
+# Workaround for dind-rootless userid mapping (https://github.com/pytorch/ci-infra/issues/96)
+sudo chown -R "$WORKSPACE_ORIGINAL_OWNER_ID" /var/lib/jenkins/workspace


### PR DESCRIPTION
In ARC Runners we are using dind-rootless to run docker-in-docker and in rootless mode volume mounts always mount as root but are mapped to the local `runner` user in ARC. This causes the build.sh and test.sh scripts to fail because they run as the `jenkins` user and expect to be able to write to the workspace path that's being mounted.

