### PR TITLE
accelerate `binary_cross_entropy_with_logits`

### DIFF
--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -76,7 +76,6 @@
 #include <ATen/ops/tanh.h>
 #include <ATen/ops/threshold_backward_native.h>
 #include <ATen/ops/threshold_native.h>
-#include <ATen/ops/zeros_like.h>
 
 #include <utility>
 #endif
@@ -748,9 +747,8 @@ Tensor infinitely_differentiable_gelu_backward(
 }
 
 std::tuple<Tensor, Tensor> log_sigmoid_forward_cpu(const Tensor& input) {
-  // FIXME: do these actually need to be zeros_like or can they be empty_like?
-  auto result = at::zeros_like(input, at::MemoryFormat::Contiguous);
-  auto buffer = at::zeros_like(input, at::MemoryFormat::Contiguous);
+  auto result = at::empty_like(input, at::MemoryFormat::Contiguous);
+  auto buffer = at::empty_like(input, at::MemoryFormat::Contiguous);
   log_sigmoid_cpu_stub(kCPU, result, buffer, input.contiguous());
   return std::make_tuple(result, buffer);
 }


### PR DESCRIPTION
Following https://github.com/pytorch/pytorch/pull/115539

Same benchmark in #115539:
|avg time (ms)|with `pos_weight`|no `pos_weight`|
|-|-|-|
|before #115539 |2049|1736|
|after #115539    |1320|1049|
|this PR               |907  |801|

This PR is faster 24-31% than the version after #115539.


