### PR TITLE
[dynamo] Delay cuda device registration

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3231,6 +3231,9 @@ exit(2)
         test_script = f"import os; import torch;os.environ['{VISIBLE_DEVICES}']='32';print(torch.cuda.device_count())"
         rc = check_output(test_script)
         self.assertEqual(rc, "0")
+        test_import = "import torch;import torch._dynamo;print(torch.cuda.device_count.cache_info().currsize)"
+        rc = check_output(test_import)
+        self.assertEqual(rc, "0")  # #122085 import torch._dynamo shouldn't trigger device_count call.
         if not TEST_WITH_ROCM:
             # Check that `cuInit` was not called during the import
             # By using ctypes and calling cuDeviceCountGet() and expect CUDA_ERROR_NOT_INITIALIZED == 3

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3231,9 +3231,6 @@ exit(2)
         test_script = f"import os; import torch;os.environ['{VISIBLE_DEVICES}']='32';print(torch.cuda.device_count())"
         rc = check_output(test_script)
         self.assertEqual(rc, "0")
-        test_import = "import torch;import torch._dynamo;print(torch.cuda.device_count.cache_info().currsize)"
-        rc = check_output(test_import)
-        self.assertEqual(rc, "0")  # #122085 import torch._dynamo shouldn't trigger device_count call.
         if not TEST_WITH_ROCM:
             # Check that `cuInit` was not called during the import
             # By using ctypes and calling cuDeviceCountGet() and expect CUDA_ERROR_NOT_INITIALIZED == 3

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -185,15 +185,20 @@ def register_interface_for_device(
 def get_interface_for_device(device: Union[str, torch.device]) -> Type[DeviceInterface]:
     if isinstance(device, torch.device):
         device = str(device)
+    if not device_interfaces:
+        init_device_reg()
     if device in device_interfaces:
         return device_interfaces[device]
     raise NotImplementedError(f"No interface for device {device}")
 
 
 def get_registered_device_interfaces() -> Iterable[Tuple[str, Type[DeviceInterface]]]:
+    if not device_interfaces:
+        init_device_reg()
     return device_interfaces.items()
 
 
-register_interface_for_device("cuda", CudaInterface)
-for i in range(torch.cuda.device_count()):
-    register_interface_for_device(f"cuda:{i}", CudaInterface)
+def init_device_reg():
+    register_interface_for_device("cuda", CudaInterface)
+    for i in range(torch.cuda.device_count()):
+        register_interface_for_device(f"cuda:{i}", CudaInterface)

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -172,6 +172,7 @@ class CudaInterface(DeviceInterface):
 
 
 device_interfaces: Dict[str, Type[DeviceInterface]] = {}
+_device_initialized = False
 
 
 def register_interface_for_device(
@@ -185,7 +186,7 @@ def register_interface_for_device(
 def get_interface_for_device(device: Union[str, torch.device]) -> Type[DeviceInterface]:
     if isinstance(device, torch.device):
         device = str(device)
-    if not device_interfaces:
+    if not _device_initialized:
         init_device_reg()
     if device in device_interfaces:
         return device_interfaces[device]
@@ -193,12 +194,14 @@ def get_interface_for_device(device: Union[str, torch.device]) -> Type[DeviceInt
 
 
 def get_registered_device_interfaces() -> Iterable[Tuple[str, Type[DeviceInterface]]]:
-    if not device_interfaces:
+    if not _device_initialized:
         init_device_reg()
     return device_interfaces.items()
 
 
 def init_device_reg():
+    global _device_initialized
     register_interface_for_device("cuda", CudaInterface)
     for i in range(torch.cuda.device_count()):
         register_interface_for_device(f"cuda:{i}", CudaInterface)
+    _device_initialized = True


### PR DESCRIPTION
the module-level `torch.cuda.device_count` calls are delayed until reading the registered devices.

Fixes #122085


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang