### PR TITLE
add testing support for Vectorized<Half>

### DIFF
--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -4,6 +4,7 @@
 #include <ATen/NumericUtils.h>
 #include <ATen/jiterator_macros.h>
 #include <c10/util/BFloat16.h>
+#include <c10/util/BFloat16-math.h>
 #include <c10/util/Half.h>
 #include <c10/util/MathConstants.h>
 #include <cfloat>

--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -12,6 +12,7 @@
 #include <cstdlib>
 #include <limits>
 #include <type_traits>
+#include "c10/util/BFloat16-math.h"
 
 C10_CLANG_DIAGNOSTIC_PUSH()
 #if C10_CLANG_HAS_WARNING("-Wimplicit-float-conversion")
@@ -147,7 +148,7 @@ jiterator_also_stringify_as(jiterator_code(
 #define CENTRAL_RANGE 0.7
 
 template <typename T>
-static inline typename std::enable_if<std::is_floating_point<T>::value, T>::type
+static inline typename std::enable_if<std::is_floating_point<T>::value || std::is_reduced_floating_point_v<T>, T>::type
 calc_erfinv(T y) {
 /* Function to calculate inverse error function.  Rational approximation
 is used to generate an initial approximation, which is then improved to

--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -12,7 +12,6 @@
 #include <cstdlib>
 #include <limits>
 #include <type_traits>
-#include "c10/util/BFloat16-math.h"
 
 C10_CLANG_DIAGNOSTIC_PUSH()
 #if C10_CLANG_HAS_WARNING("-Wimplicit-float-conversion")
@@ -148,7 +147,7 @@ jiterator_also_stringify_as(jiterator_code(
 #define CENTRAL_RANGE 0.7
 
 template <typename T>
-static inline typename std::enable_if<std::is_floating_point<T>::value || std::is_reduced_floating_point_v<T>, T>::type
+static inline typename std::enable_if_t<std::is_floating_point_v<T>|| std::is_reduced_floating_point_v<T>, T>
 calc_erfinv(T y) {
 /* Function to calculate inverse error function.  Rational approximation
 is used to generate an initial approximation, which is then improved to

--- a/aten/src/ATen/test/vec_test_all_types.cpp
+++ b/aten/src/ATen/test/vec_test_all_types.cpp
@@ -1,6 +1,6 @@
 #include <ATen/test/vec_test_all_types.h>
 #include <c10/util/irange.h>
-#include "c10/util/Half.h"
+#include <c10/util/Half.h>
 namespace {
 #if GTEST_HAS_TYPED_TEST
     template <typename T>
@@ -558,7 +558,7 @@ namespace {
         UVT tolerance = getDefaultTolerance<UVT>();
         // double: 2e+305  float: 4e+36 (https://sleef.org/purec.xhtml#eg)
         // Half not available in Sleef, but we set max at 4e+4.
-        UVT maxCorrect = std::is_same<UVT, c10::Half>::value ? (UVT)4e+4 : (std::is_same<UVT, float>::value ? (UVT)4e+36 : (UVT)2e+305);
+        UVT maxCorrect = std::is_same_v<UVT, c10::Half> ? (UVT)4e+4 : (std::is_same_v<UVT, float> ? (UVT)4e+36 : (UVT)2e+305);
         TestingCase<vec> testCase = TestingCase<vec>::getBuilder()
             .addDomain(CheckWithinDomains<UVT>{ { {(UVT)-100, (UVT)0}}, true, tolerance})
             .addDomain(CheckWithinDomains<UVT>{ { {(UVT)0, (UVT)1000 }}, true, tolerance})

--- a/aten/src/ATen/test/vec_test_all_types.cpp
+++ b/aten/src/ATen/test/vec_test_all_types.cpp
@@ -1,5 +1,6 @@
 #include <ATen/test/vec_test_all_types.h>
 #include <c10/util/irange.h>
+#include "c10/util/Half.h"
 namespace {
 #if GTEST_HAS_TYPED_TEST
     template <typename T>
@@ -68,47 +69,48 @@ namespace {
     class FunctionalTestsReducedFloat : public ::testing::Test {};
     template <typename T>
     class InfiniteTests : public ::testing::Test {};
-    using RealFloatTestedTypes = ::testing::Types<vfloat, vdouble>;
-    using FloatTestedTypes = ::testing::Types<vfloat, vdouble, vcomplex, vcomplexDbl>;
-    using ALLTestedTypes = ::testing::Types<vfloat, vdouble, vcomplex, vlong, vint, vshort, vqint8, vquint8, vqint>;
+    using RealFloatHalfTestedTypes = ::testing::Types<vfloat, vdouble, vHalf>;
+    using FloatHalfTestedTypes = ::testing::Types<vfloat, vdouble, vHalf, vcomplex, vcomplexDbl>;
+    using ALLTestedTypes = ::testing::Types<vfloat, vdouble, vHalf, vcomplex, vlong, vint, vshort, vqint8, vquint8, vqint>;
     using QuantTestedTypes = ::testing::Types<vqint8, vquint8, vqint>;
 #if (defined(CPU_CAPABILITY_AVX2) ||  defined(CPU_CAPABILITY_AVX512))  && !defined(_MSC_VER)
     using Quantization8BitWithTailTestedTypes =
         ::testing::Types<vqint8, vquint8>;
 #endif
+    using RealFloatHalfIntTestedTypes = ::testing::Types<vfloat, vdouble, vHalf, vlong, vint, vshort>;
     using RealFloatIntTestedTypes = ::testing::Types<vfloat, vdouble, vlong, vint, vshort>;
-    using FloatIntTestedTypes = ::testing::Types<vfloat, vdouble, vcomplex, vcomplexDbl, vlong, vint, vshort>;
+    using FloatHalfIntTestedTypes = ::testing::Types<vfloat, vdouble, vHalf, vcomplex, vcomplexDbl, vlong, vint, vshort>;
     using ComplexTypes = ::testing::Types<vcomplex, vcomplexDbl>;
     using ReducedFloatTestedTypes = ::testing::Types<vBFloat16, vHalf>;
     TYPED_TEST_SUITE(Memory, ALLTestedTypes);
-    TYPED_TEST_SUITE(Arithmetics, FloatIntTestedTypes);
-    TYPED_TEST_SUITE(Comparison, RealFloatIntTestedTypes);
-    TYPED_TEST_SUITE(Bitwise, FloatIntTestedTypes);
-    TYPED_TEST_SUITE(MinMax, RealFloatIntTestedTypes);
-    TYPED_TEST_SUITE(Nan, RealFloatTestedTypes);
-    TYPED_TEST_SUITE(Interleave, RealFloatIntTestedTypes);
-    TYPED_TEST_SUITE(SignManipulation, FloatIntTestedTypes);
+    TYPED_TEST_SUITE(Arithmetics, FloatHalfIntTestedTypes);
+    TYPED_TEST_SUITE(Comparison, RealFloatHalfIntTestedTypes);
+    TYPED_TEST_SUITE(Bitwise, FloatHalfIntTestedTypes);
+    TYPED_TEST_SUITE(MinMax, RealFloatHalfIntTestedTypes);
+    TYPED_TEST_SUITE(Nan, RealFloatHalfTestedTypes);
+    TYPED_TEST_SUITE(Interleave, RealFloatHalfIntTestedTypes);
+    TYPED_TEST_SUITE(SignManipulation, FloatHalfIntTestedTypes);
     TYPED_TEST_SUITE(SignManipulationHalfPrecision, ReducedFloatTestedTypes);
-    TYPED_TEST_SUITE(Rounding, RealFloatTestedTypes);
-    TYPED_TEST_SUITE(SqrtAndReciprocal, FloatTestedTypes);
-    TYPED_TEST_SUITE(SqrtAndReciprocalReal, RealFloatTestedTypes);
-    TYPED_TEST_SUITE(FractionAndRemainderReal, RealFloatTestedTypes);
-    TYPED_TEST_SUITE(Trigonometric, RealFloatTestedTypes);
-    TYPED_TEST_SUITE(ErrorFunctions, RealFloatTestedTypes);
-    TYPED_TEST_SUITE(Exponents, RealFloatTestedTypes);
-    TYPED_TEST_SUITE(Hyperbolic, RealFloatTestedTypes);
-    TYPED_TEST_SUITE(InverseTrigonometricReal, RealFloatTestedTypes);
-    TYPED_TEST_SUITE(InverseTrigonometric, FloatTestedTypes);
-    TYPED_TEST_SUITE(LGamma, RealFloatTestedTypes);
-    TYPED_TEST_SUITE(Logarithm, FloatTestedTypes);
-    TYPED_TEST_SUITE(LogarithmReals, RealFloatTestedTypes);
-    TYPED_TEST_SUITE(Pow, RealFloatTestedTypes);
-    TYPED_TEST_SUITE(RealTests, RealFloatTestedTypes);
-    TYPED_TEST_SUITE(RangeFactories, FloatIntTestedTypes);
-    TYPED_TEST_SUITE(BitwiseFloatsAdditional, RealFloatTestedTypes);
-    TYPED_TEST_SUITE(BitwiseFloatsAdditional2, FloatTestedTypes);
+    TYPED_TEST_SUITE(Rounding, RealFloatHalfTestedTypes);
+    TYPED_TEST_SUITE(SqrtAndReciprocal, FloatHalfTestedTypes);
+    TYPED_TEST_SUITE(SqrtAndReciprocalReal, RealFloatHalfTestedTypes);
+    TYPED_TEST_SUITE(FractionAndRemainderReal, RealFloatHalfTestedTypes);
+    TYPED_TEST_SUITE(Trigonometric, RealFloatHalfTestedTypes);
+    TYPED_TEST_SUITE(ErrorFunctions, RealFloatHalfTestedTypes);
+    TYPED_TEST_SUITE(Exponents, RealFloatHalfTestedTypes);
+    TYPED_TEST_SUITE(Hyperbolic, RealFloatHalfTestedTypes);
+    TYPED_TEST_SUITE(InverseTrigonometricReal, RealFloatHalfTestedTypes);
+    TYPED_TEST_SUITE(InverseTrigonometric, FloatHalfTestedTypes);
+    TYPED_TEST_SUITE(LGamma, RealFloatHalfTestedTypes);
+    TYPED_TEST_SUITE(Logarithm, FloatHalfTestedTypes);
+    TYPED_TEST_SUITE(LogarithmReals, RealFloatHalfTestedTypes);
+    TYPED_TEST_SUITE(Pow, RealFloatHalfTestedTypes);
+    TYPED_TEST_SUITE(RealTests, RealFloatHalfTestedTypes);
+    TYPED_TEST_SUITE(RangeFactories, FloatHalfIntTestedTypes);
+    TYPED_TEST_SUITE(BitwiseFloatsAdditional, RealFloatHalfTestedTypes);
+    TYPED_TEST_SUITE(BitwiseFloatsAdditional2, FloatHalfTestedTypes);
     TYPED_TEST_SUITE(QuantizationTests, QuantTestedTypes);
-    TYPED_TEST_SUITE(InfiniteTests, RealFloatTestedTypes);
+    TYPED_TEST_SUITE(InfiniteTests, RealFloatHalfTestedTypes);
 #if (defined(CPU_CAPABILITY_AVX2) ||  defined(CPU_CAPABILITY_AVX512))  && !defined(_MSC_VER)
     TYPED_TEST_SUITE(
         Quantization8BitWithTailTests,
@@ -293,7 +295,7 @@ namespace {
             NAME_INFO(rsqrt),
             rsqrt<ValueType<vec>>,
             [](vec v) { return v.rsqrt(); },
-            createDefaultUnaryTestCase<vec>(TestSeed()),
+            createDefaultUnaryTestCase<vec>(TestSeed(), /*bitwise=*/false, /*checkWithTolerance=*/true),
             RESOLVE_OVERLOAD(filter_zero));
     }
     TYPED_TEST(SqrtAndReciprocalReal, Reciprocal) {
@@ -302,7 +304,7 @@ namespace {
             NAME_INFO(reciprocal),
             reciprocal<ValueType<vec>>,
             [](vec v) { return v.reciprocal(); },
-            createDefaultUnaryTestCase<vec>(TestSeed()),
+            createDefaultUnaryTestCase<vec>(TestSeed(), /*bitwise=*/false, /*checkWithTolerance=*/true),
             RESOLVE_OVERLOAD(filter_zero));
     }
     TYPED_TEST(FractionAndRemainderReal, Frac) {
@@ -470,7 +472,7 @@ namespace {
         auto test_case =
             TestingCase<vec>::getBuilder()
             .addDomain(CheckWithinDomains<UVT>{ { {-1, 1000}}, true, getDefaultTolerance<UVT>()})
-            .addDomain(CheckWithinDomains<UVT>{ { {1000, 1.e+30}}, true, getDefaultTolerance<UVT>()})
+            .addDomain(CheckWithinDomains<UVT>{ { {1000, std::numeric_limits<UVT>::max() / 2.0} }, true, getDefaultTolerance<UVT>()})
             .setTrialCount(65536)
             .setTestSeed(TestSeed());
         test_unary<vec>(
@@ -513,11 +515,17 @@ namespace {
     }
     TYPED_TEST(ErrorFunctions, Erfinv) {
         using vec = TypeParam;
+        using UVT = UvalueType<TypeParam>;
+         auto test_case =
+            TestingCase<vec>::getBuilder()
+            .addDomain(CheckWithinDomains<UVT>{ {{-1, 1}}, true, getDefaultTolerance<UVT>()})
+            .setTrialCount(65536)
+            .setTestSeed(TestSeed());
         test_unary<vec>(
             NAME_INFO(erfinv),
             RESOLVE_OVERLOAD(calc_erfinv),
             [](const vec& v) { return v.erfinv(); },
-            createDefaultUnaryTestCase<vec>(TestSeed(), false, true));
+            test_case);
     }
     TYPED_TEST(Nan, IsNan) {
         using vec = TypeParam;
@@ -549,7 +557,8 @@ namespace {
         using UVT = UvalueType<vec>;
         UVT tolerance = getDefaultTolerance<UVT>();
         // double: 2e+305  float: 4e+36 (https://sleef.org/purec.xhtml#eg)
-        UVT maxCorrect = std::is_same<UVT, float>::value ? (UVT)4e+36 : (UVT)2e+305;
+        // Half not available in Sleef, but we set max at 4e+4.
+        UVT maxCorrect = std::is_same<UVT, c10::Half>::value ? (UVT)4e+4 : (std::is_same<UVT, float>::value ? (UVT)4e+36 : (UVT)2e+305);
         TestingCase<vec> testCase = TestingCase<vec>::getBuilder()
             .addDomain(CheckWithinDomains<UVT>{ { {(UVT)-100, (UVT)0}}, true, tolerance})
             .addDomain(CheckWithinDomains<UVT>{ { {(UVT)0, (UVT)1000 }}, true, tolerance})
@@ -1424,7 +1433,7 @@ namespace {
         for (const auto i : c10::irange(N)) { ref_y[i] = x1[i] + x2[i] + x3[i] + x4[i]; }
         cmp(y, ref_y);
     }
-      TYPED_TEST(FunctionalTestsReducedFloat, Reduce) {
+    TYPED_TEST(FunctionalTestsReducedFloat, Reduce) {
       using vec = TypeParam;
       // Can't use ValueType<TypeParam> here:
       // Vectorized<BFloat16>::value_type returns uint16_t on AVX2/AVX512

--- a/aten/src/ATen/test/vec_test_all_types.h
+++ b/aten/src/ATen/test/vec_test_all_types.h
@@ -15,7 +15,6 @@
 #include <math.h>
 #include <float.h>
 #include <algorithm>
-#include "c10/util/BFloat16-math.h"
 
 #if defined(CPU_CAPABILITY_AVX512)
 #define CACHE_LINE 64
@@ -269,41 +268,41 @@ std::ostream& operator<<(std::ostream& stream, const CheckWithinDomains<T>& dmn)
 }
 
 template <typename T>
-std::enable_if_t<std::is_floating_point<T>::value || std::is_reduced_floating_point_v<T>, bool> check_both_nan(T x,
+std::enable_if_t<std::is_floating_point_v<T>|| std::is_reduced_floating_point_v<T>, bool> check_both_nan(T x,
     T y) {
     return std::isnan(x) && std::isnan(y);
 }
 
 template <typename T>
-std::enable_if_t<!(std::is_floating_point<T>::value || std::is_reduced_floating_point_v<T>), bool> check_both_nan(T x,
+std::enable_if_t<!(std::is_floating_point_v<T>|| std::is_reduced_floating_point_v<T>), bool> check_both_nan(T x,
     T y) {
     return false;
 }
 
 template <typename T>
-std::enable_if_t<std::is_floating_point<T>::value || std::is_reduced_floating_point_v<T>, bool> check_both_inf(T x,
+std::enable_if_t<std::is_floating_point_v<T>|| std::is_reduced_floating_point_v<T>, bool> check_both_inf(T x,
     T y) {
     return std::isinf(x) && std::isinf(y);
 }
 
 template <typename T>
-std::enable_if_t<!(std::is_floating_point<T>::value || std::is_reduced_floating_point_v<T>), bool> check_both_inf(T x,
+std::enable_if_t<!(std::is_floating_point_v<T>|| std::is_reduced_floating_point_v<T>), bool> check_both_inf(T x,
     T y) {
     return false;
 }
 
 template<typename T>
-std::enable_if_t<!(std::is_floating_point<T>::value || std::is_reduced_floating_point_v<T>), bool> check_both_big(T x, T y) {
+std::enable_if_t<!(std::is_floating_point_v<T>|| std::is_reduced_floating_point_v<T>), bool> check_both_big(T x, T y) {
     return false;
 }
 
 template<typename T>
 std::enable_if_t<std::is_floating_point<T>::value || std::is_reduced_floating_point_v<T>, bool> check_both_big(T x, T y) {
-    T cmax = std::is_same<T, c10::Half>::value ? static_cast<T>(5e+4) : (
-        std::is_same<T, float>::value ? static_cast<T>(1e+30) : static_cast<T>(1e+300)
+    T cmax = std::is_same_v<T, c10::Half> ? static_cast<T>(5e+4) : (
+        std::is_same_v<T, float>? static_cast<T>(1e+30) : static_cast<T>(1e+300)
     );
-    T cmin = std::is_same<T, c10::Half>::value ? static_cast<T>(-5e+4) : (
-        std::is_same<T, float>::value ? static_cast<T>(-1e+30) : static_cast<T>(-1e+300)
+    T cmin = std::is_same_v<T, c10::Half>? static_cast<T>(-5e+4) : (
+        std::is_same_v<T, float>? static_cast<T>(-1e+30) : static_cast<T>(-1e+300)
     );
     //only allow when one is inf
     bool x_inf = std::isinf(x);
@@ -335,7 +334,7 @@ T safe_fpt_division(T f1, T f2)
 }
 
 template<class T>
-std::enable_if_t<std::is_floating_point<T>::value || std::is_reduced_floating_point_v<T>, bool>
+std::enable_if_t<std::is_floating_point_v<T>|| std::is_reduced_floating_point_v<T>, bool>
 nearlyEqual(T a, T b, T tolerance) {
     if (check_both_nan<T>(a, b)) return true;
     if (check_both_big(a, b)) return true;
@@ -351,7 +350,7 @@ nearlyEqual(T a, T b, T tolerance) {
 }
 
 template<class T>
-std::enable_if_t<!(std::is_floating_point<T>::value || std::is_reduced_floating_point_v<T>), bool>
+std::enable_if_t<!(std::is_floating_point_v<T> || std::is_reduced_floating_point_v<T>), bool>
 nearlyEqual(T a, T b, T tolerance) {
     return a == b;
 }
@@ -425,7 +424,7 @@ void filter_clamp(T& f, T& s, T& t) {
 }
 
 template <typename T>
-std::enable_if_t<std::is_floating_point<T>::value || std::is_reduced_floating_point_v<T>, void> filter_fmod(T& a, T& b) {
+std::enable_if_t<std::is_floating_point_v<T> || std::is_reduced_floating_point_v<T>, void> filter_fmod(T& a, T& b) {
     // This is to make sure fmod won't cause overflow when doing the div
     if (std::abs(b) < (T)1) {
       b = b < (T)0 ? (T)-1 : T(1);
@@ -433,7 +432,7 @@ std::enable_if_t<std::is_floating_point<T>::value || std::is_reduced_floating_po
 }
 
 template <typename T>
-std::enable_if_t<std::is_floating_point<T>::value || std::is_reduced_floating_point_v<T>, void> filter_fmadd(T& a, T& b, T& c) {
+std::enable_if_t<std::is_floating_point_v<T> || std::is_reduced_floating_point_v<T>, void> filter_fmadd(T& a, T& b, T& c) {
     // This is to setup a limit to make sure fmadd (a * b + c) won't overflow
     T max = std::sqrt(std::numeric_limits<T>::max()) / T(2.0);
     T min = ((T)0 - max);
@@ -1464,7 +1463,7 @@ template<typename T>
 TestingCase<T> createDefaultUnaryTestCase(TestSeed seed = TestSeed(), bool bitwise = false, bool checkWithTolerance = false, size_t trials = 0) {
     using UVT = UvalueType<T>;
     TestingCase<T> testCase;
-    if (!bitwise && (std::is_floating_point<UVT>::value || std::is_reduced_floating_point_v<UVT>)) {
+    if (!bitwise && (std::is_floating_point_v<UVT> || std::is_reduced_floating_point_v<UVT>)) {
         //for float types lets add manual ranges
         UVT tolerance = getDefaultTolerance<UVT>();
         testCase = TestingCase<T>::getBuilder()


### PR DESCRIPTION
Summary: Implement half neon vectorization.

Test Plan:
Adjusted fbcode//caffe2:vec_test_all_types so that Half type is covered by tests.  On x86, this just tests the half type template in vec_base.h.  All tests pass.

```
buck2 test fbcode//caffe2:vec_test_all_types
Buck UI: https://www.internalfb.com/buck2/1062c33e-3e2b-4915-929d-5717f4d05ea8
Test UI: https://www.internalfb.com/intern/testinfra/testrun/15762598722963484
Network: Up: 7.6MiB  Down: 211MiB  (reSessionID-f19e6afc-3fa5-4455-87c5-df6f64d2ef70)
Jobs completed: 2872. Time elapsed: 8:17.6s.
Cache hits: 16%. Commands: 1571 (cached: 247, remote: 1321, local: 3)
Tests finished: Pass 336. Fail 0. Fatal 0. Skip 0. Build failure 0
```

On M1 mac, I built pytorch from source with
```
cd pytorch
python setup.py develop
```

and then executed

```
 .build/bin/vec_test_all_types_DEFAULT
```

This actually tests vec256_half_neon.h and results in
```
[==========] 336 tests from 139 test suites ran. (6492 ms total)
[  PASSED  ] 334 tests.
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] SqrtAndReciprocalReal/2.RSqrt, where TypeParam = at::vec::DEFAULT::Vectorized<c10::Half>
[  FAILED  ] SqrtAndReciprocalReal/2.Reciprocal, where TypeParam = at::vec::DEFAULT::Vectorized<c10::Half>
```

The 2 failing test cases are not failing bad (e.g., 0.000238776 != 0.000238895), I just need to play around with the tolerances a bit.

Differential Revision: D55226003


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10