### PR TITLE
[DCP][DSD] Fix to remove non_persistent buffer in distributed state dict

### DIFF
--- a/test/distributed/checkpoint/fsdp/test_fsdp_dsd.py
+++ b/test/distributed/checkpoint/fsdp/test_fsdp_dsd.py
@@ -8,12 +8,25 @@ from torch.distributed._composable.fsdp import fully_shard
 from torch.distributed._tensor import DTensor
 from torch.distributed.checkpoint.state_dict import (
     get_model_state_dict,
+    set_model_state_dict,
     StateDictOptions,
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest, MLP
 from torch.testing._internal.common_utils import run_tests
 from torch.utils._pytree import tree_all_only
+
+
+class ModelWithBuffers(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lin1 = nn.Linear(4, 4)
+        self.lin2 = nn.Linear(4, 4)
+        self.register_buffer(
+            "non_persistent_buffer", torch.randn((4,)), persistent=False
+        )
+        self.register_buffer("persistent_buffer", torch.randn((4,)), persistent=True)
+        self.weight = nn.Parameter(torch.randn((4, 4)))
 
 
 class TestFullyShardWithDistributedStateDict(FSDPTest):
@@ -93,6 +106,18 @@ class TestFullyShardWithDistributedStateDict(FSDPTest):
             self.assertTrue(tree_all_only((torch.Tensor, DTensor), is_cpu, osd))
         else:
             self.assertEqual(dsd, {})
+
+    @skip_if_lt_x_gpu(2)
+    def test_compiled_model_with_buffers(self):
+        model = ModelWithBuffers()
+        model = torch.compile(model)
+
+        print(f"{model._persistent_buffers_set=}")
+
+        sharded_sd = get_model_state_dict(model)
+        self.assertTrue("non_persistent_buffer" not in sharded_sd)
+        self.assertTrue("persistent_buffer" in sharded_sd)
+        set_model_state_dict(model, sharded_sd)
 
 
 if __name__ == "__main__":

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -121,9 +121,9 @@ class StateDictOptions:
 
 @dataclass
 class _StateDictInfo(StateDictOptions):
-    fqn_param_mapping: Dict[
-        Union[str, torch.Tensor], Union[FQNS_T, torch.Tensor]
-    ] = field(default_factory=dict)
+    fqn_param_mapping: Dict[Union[str, torch.Tensor], Union[FQNS_T, torch.Tensor]] = (
+        field(default_factory=dict)
+    )
     all_fqns: Set[str] = field(default_factory=set)
     submodule_prefixes: Set[str] = field(default_factory=set)
     handle_model: bool = True
@@ -207,11 +207,12 @@ def _verify_options(
 
     options = options or StateDictOptions()
 
-    fqn_param_mapping: Dict[
-        Union[str, torch.Tensor], Union[Set[str], torch.Tensor]
-    ] = {}
+    fqn_param_mapping: Dict[Union[str, torch.Tensor], Union[Set[str], torch.Tensor]] = (
+        {}
+    )
     all_fqns = set()
-    for name, param in chain(model.named_parameters(), model.named_buffers()):
+
+    for name, param in model.state_dict().items():
         fqns = _get_fqns(model, name)
         fqn_param_mapping[param] = fqns
         for fqn in fqns:
@@ -406,7 +407,7 @@ def _load_model_state_dict(
     if not info.handle_model or not state_dict:
         return _IncompatibleKeys({}, {})
 
-    for key, _ in chain(model.named_parameters(), model.named_buffers()):
+    for key in model.state_dict().keys():
         fqns = _get_fqns(model, key)
         fqns_with_prefix = _get_fqns(
             model, key, skip_ddp_prefix=False, skip_compiler_prefix=False


### PR DESCRIPTION
Fixes #122792

`state_dict` includes only persistent buffers, while `named_buffers()` would include non_persistent buffers.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @tianyu-l @wconstab @yf225 @chauhang @LucasLLC