### PR TITLE
[AOTInductor] Support quantized linear on CPU with fbgemm

### DIFF
--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -31,6 +31,7 @@ from . import config, inductor_prims
 log = logging.getLogger(__name__)
 aten = torch.ops.aten
 prims = torch.ops.prims
+quantized = torch.ops.quantized
 quantized_decomposed = torch.ops.quantized_decomposed
 
 inductor_decompositions = get_decompositions(
@@ -70,6 +71,7 @@ inductor_decompositions = get_decompositions(
         aten.tril_indices,
         aten.triu_indices,
         aten.upsample_bilinear2d.vec,
+        quantized.linear_unpacked_dynamic_fp16.default,
     ]
 )
 decompositions = {**core_aten_decompositions(), **inductor_decompositions}
@@ -465,6 +467,18 @@ def randint_like_low(
 @register_decomposition(aten.randint.default)
 def randint(high, size, **kwargs):
     return aten.randint.low(0, high, size, **kwargs)
+
+
+@register_decomposition(quantized.linear_unpacked_dynamic_fp16.default)
+def linear_unpacked_dynamic_fp16(
+    input: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor
+) -> torch.Tensor:
+    packed_weight = torch.ops.quantized_wrapper.wrapped_fbgemm_pack_gemm_matrix_fp16(
+        weight
+    )
+    return torch.ops.quantized_wrapper.wrapped_fbgemm_linear_fp16_weight(
+        input, packed_weight, bias, weight.size()[0]
+    )
 
 
 # The difference between quantize_per_tensor.default and quantize_per_tensor.tensor is

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -424,6 +424,22 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mm_out(
     AtenTensorHandle self,
     AtenTensorHandle mat2);
 
+// This will soon be deprecated after ao_quantization is complete.
+// // Please refrain from using this or increasing callsites.
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch_wrapped_fbgemm_pack_gemm_matrix_fp16(
+    AtenTensorHandle weight,
+    AtenTensorHandle* out);
+
+// This will soon be deprecated after ao_quantization is complete.
+// Please refrain from using this or increasing callsites.
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_wrapped_fbgemm_linear_fp16_weight(
+    AtenTensorHandle input,
+    AtenTensorHandle weight,
+    AtenTensorHandle bias,
+    int64_t out_channel,
+    AtenTensorHandle* out);
+
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_nonzero(AtenTensorHandle self, AtenTensorHandle* out);
 

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -671,12 +671,20 @@ AOTITorchError aoti_torch_mm_out(
 AOTITorchError aoti_torch_wrapped_fbgemm_pack_gemm_matrix_fp16(
     AtenTensorHandle weight,
     AtenTensorHandle* out) {
-  at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
-  auto packed_weight = at::native::fbgemm_pack_gemm_matrix_fp16(*weight_tensor);
+#ifdef USE_FBGEMM
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
+    auto packed_weight =
+        at::native::fbgemm_pack_gemm_matrix_fp16(*weight_tensor);
 
-  at::Tensor* out_tensor = new at::Tensor(std::move(packed_weight));
-  *out = tensor_pointer_to_tensor_handle(out_tensor);
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({});
+    at::Tensor* out_tensor = new at::Tensor(std::move(packed_weight));
+    *out = tensor_pointer_to_tensor_handle(out_tensor);
+  });
+#else // USE_FBGEMM
+  LOG(ERROR)
+      << "This PyTorch installation was not built with FBGEMM operators\n";
+  return AOTI_TORCH_FAILURE;
+#endif // USE_FBGEMM
 }
 
 AOTITorchError aoti_torch_wrapped_fbgemm_linear_fp16_weight(
@@ -685,16 +693,23 @@ AOTITorchError aoti_torch_wrapped_fbgemm_linear_fp16_weight(
     AtenTensorHandle bias,
     int64_t out_channel,
     AtenTensorHandle* out) {
-  at::Tensor* input_tensor = tensor_handle_to_tensor_pointer(input);
-  at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
-  at::Tensor* bias_tensor = tensor_handle_to_tensor_pointer(bias);
+#ifdef USE_FBGEMM
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    at::Tensor* input_tensor = tensor_handle_to_tensor_pointer(input);
+    at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
+    at::Tensor* bias_tensor = tensor_handle_to_tensor_pointer(bias);
 
-  auto out_result = at::native::fbgemm_linear_fp16_weight_fp32_activation(
-      *input_tensor, *weight_tensor, *bias_tensor);
+    auto out_result = at::native::fbgemm_linear_fp16_weight_fp32_activation(
+        *input_tensor, *weight_tensor, *bias_tensor);
 
-  at::Tensor* out_tensor = new at::Tensor(std::move(out_result));
-  *out = tensor_pointer_to_tensor_handle(out_tensor);
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({});
+    at::Tensor* out_tensor = new at::Tensor(std::move(out_result));
+    *out = tensor_pointer_to_tensor_handle(out_tensor);
+  });
+#else // USE_FBGEMM
+  LOG(ERROR)
+      << "This PyTorch installation was not built with FBGEMM operators\n";
+  return AOTI_TORCH_FAILURE;
+#endif // USE_FBGEMM
 }
 
 AOTITorchError aoti_torch_nonzero(

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -672,7 +672,7 @@ AOTITorchError aoti_torch_wrapped_fbgemm_pack_gemm_matrix_fp16(
     AtenTensorHandle weight,
     AtenTensorHandle* out) {
   at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
-  auto packed_weight = at::fbgemm_pack_gemm_matrix_fp16(*weight_tensor);
+  auto packed_weight = at::native::fbgemm_pack_gemm_matrix_fp16(*weight_tensor);
 
   at::Tensor* out_tensor = new at::Tensor(std::move(packed_weight));
   *out = tensor_pointer_to_tensor_handle(out_tensor);
@@ -689,7 +689,7 @@ AOTITorchError aoti_torch_wrapped_fbgemm_linear_fp16_weight(
   at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
   at::Tensor* bias_tensor = tensor_handle_to_tensor_pointer(bias);
 
-  auto out_result = at::fbgemm_linear_fp16_weight_fp32_activation(
+  auto out_result = at::native::fbgemm_linear_fp16_weight_fp32_activation(
       *input_tensor, *weight_tensor, *bias_tensor);
 
   at::Tensor* out_tensor = new at::Tensor(std::move(out_result));

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -27,6 +27,9 @@
 #include <ATen/ops/bmm.h>
 #include <ATen/ops/convolution.h>
 #include <ATen/ops/empty_strided.h>
+#include <ATen/ops/fbgemm_linear_fp16_weight_fp32_activation_native.h>
+#include <ATen/ops/fbgemm_linear_fp16_weight_native.h>
+#include <ATen/ops/fbgemm_pack_gemm_matrix_fp16_native.h>
 #include <ATen/ops/from_blob.h>
 #include <ATen/ops/index_put.h>
 #include <ATen/ops/mm.h>

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -665,6 +665,35 @@ AOTITorchError aoti_torch_mm_out(
   });
 }
 
+AOTITorchError aoti_torch_wrapped_fbgemm_pack_gemm_matrix_fp16(
+    AtenTensorHandle weight,
+    AtenTensorHandle* out) {
+  at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
+  auto packed_weight = at::fbgemm_pack_gemm_matrix_fp16(*weight_tensor);
+
+  at::Tensor* out_tensor = new at::Tensor(std::move(packed_weight));
+  *out = tensor_pointer_to_tensor_handle(out_tensor);
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({});
+}
+
+AOTITorchError aoti_torch_wrapped_fbgemm_linear_fp16_weight(
+    AtenTensorHandle input,
+    AtenTensorHandle weight,
+    AtenTensorHandle bias,
+    int64_t out_channel,
+    AtenTensorHandle* out) {
+  at::Tensor* input_tensor = tensor_handle_to_tensor_pointer(input);
+  at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
+  at::Tensor* bias_tensor = tensor_handle_to_tensor_pointer(bias);
+
+  auto out_result = at::fbgemm_linear_fp16_weight_fp32_activation(
+      *input_tensor, *weight_tensor, *bias_tensor);
+
+  at::Tensor* out_tensor = new at::Tensor(std::move(out_result));
+  *out = tensor_pointer_to_tensor_handle(out_tensor);
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({});
+}
+
 AOTITorchError aoti_torch_nonzero(
     AtenTensorHandle self,
     AtenTensorHandle* out) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122820
* #122763
* #122762

Summary:
Added support for quantized linear on CPU with fbgemm.
Specifically, for torch.ops.quantized.linear_unpacked_dynamic_fp16, we
decompose it into two steps, pack weight, and fbgemm's qlinear with
packed weight.

Test Plan:
Included in commit.
test_aot_inductor::test_quantized_linear

Reviewers:

Subscribers:

Tasks:

Tags:

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @aakhundov @ColinPeppler @amjames @desertfire @chauhang