### PR TITLE
[cuBLAS][cuBLASLt][FP8] Enforce restrictions on `amax` computation for scaled fp8 gemms

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -1163,6 +1163,9 @@ void scaled_gemm(
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_AMAX_D_POINTER, amax_ptr);
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_FAST_ACCUM, fastAccuMode);
 #endif
+#if !defined(USE_ROCM)
+  TORCH_CHECK(!isFloat8Type(mat1_dtype) || result_dtype == mat1_dtype, "output dtype must match input dtype for float8 matmuls due to restrictions on amax computation");
+#endif
   CuBlasLtMatrixLayout Adesc(ScalarTypeToCudaDataType(mat1_dtype), m, k, mat1_ld, transa == 't');
   CuBlasLtMatrixLayout Bdesc(ScalarTypeToCudaDataType(mat2_dtype), k, n, mat2_ld, transb == 't');
 #ifdef USE_ROCM

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -1160,11 +1160,10 @@ void scaled_gemm(
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_B_SCALE_POINTER, mat2_scale_ptr);
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_D_SCALE_POINTER, result_scale_ptr);
 #ifndef USE_ROCM
+if (isFloat8Type(result_dtype)) {
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_AMAX_D_POINTER, amax_ptr);
+}
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_FAST_ACCUM, fastAccuMode);
-#endif
-#if !defined(USE_ROCM)
-  TORCH_CHECK(!isFloat8Type(mat1_dtype) || result_dtype == mat1_dtype, "output dtype must match input dtype for float8 matmuls due to restrictions on amax computation");
 #endif
   CuBlasLtMatrixLayout Adesc(ScalarTypeToCudaDataType(mat1_dtype), m, k, mat1_ld, transa == 't');
   CuBlasLtMatrixLayout Bdesc(ScalarTypeToCudaDataType(mat2_dtype), k, n, mat2_ld, transb == 't');

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -800,10 +800,9 @@ static bool _scaled_mm_allowed_device() {
 //    - `mat2`: the second operand of the matrix multiply, can be type `torch.float8_e4m3fn` or `torch.float8_e5m2`
 //    - `bias`: the bias, can be type `torch.float16` or `torch.bfloat16`
 //    - `out_dtype`: the output dtype, can either be a float8 or a higher precision floating point type
-//         (cannot be higher precision in the case of float8 due to restrictions on amax)
 //    - `scale_a`: a scalar tensor with the inverse scale of `mat1`, only needed if `mat1` is a float8 type
 //    - `scale_b`: a scalar tensor with the inverse scale of `mat2`, only needed if `mat2` is a float8 type
-//    - `scale_result`: a scalar tensor with the scale of the output, only needed if the output is a float8 type
+//    - `scale_result`: a scalar tensor with the scale of the output, only set if the output is a float8 type
 //    - `use_fast_accum`: if true, enables fast float8 accumulation
 //    - `out`: a reference to the output tensor
 //    - `amax`: a reference to the amax tensor of the output, only needed if the output is a float8 type and will be updated inplace

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -800,6 +800,7 @@ static bool _scaled_mm_allowed_device() {
 //    - `mat2`: the second operand of the matrix multiply, can be type `torch.float8_e4m3fn` or `torch.float8_e5m2`
 //    - `bias`: the bias, can be type `torch.float16` or `torch.bfloat16`
 //    - `out_dtype`: the output dtype, can either be a float8 or a higher precision floating point type
+//         (cannot be higher precision in the case of float8 due to restrictions on amax)
 //    - `scale_a`: a scalar tensor with the inverse scale of `mat1`, only needed if `mat1` is a float8 type
 //    - `scale_b`: a scalar tensor with the inverse scale of `mat2`, only needed if `mat2` is a float8 type
 //    - `scale_result`: a scalar tensor with the scale of the output, only needed if the output is a float8 type

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -255,11 +255,15 @@ class TestFP8MatmulCuda(TestCase):
         with self.assertRaises(RuntimeError):
             self._test_tautological_mm(device, e5m2_type, e5m2_type)
 
-        self._test_tautological_mm(device, size=64, out_dtype=torch.float16)
-        self._test_tautological_mm(device, size=96, out_dtype=torch.float32)
-        # hipblaslt does not yet support bfloat16 output
+        version = _get_torch_cuda_version()
         if torch.version.hip is None:
+            with self.assertRaises(RuntimeError):
+              self._test_tautological_mm(device, size=96, out_dtype=torch.float32)
+              self._test_tautological_mm(device, size=64, out_dtype=torch.float16)
+
+        with self.assertRaises(RuntimeError):
             self._test_tautological_mm(device, size=80, out_dtype=torch.bfloat16)
+
         with self.assertRaises(RuntimeError):
             self._test_tautological_mm(device, out_dtype=e5m2_type)
 

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -255,13 +255,10 @@ class TestFP8MatmulCuda(TestCase):
         with self.assertRaises(RuntimeError):
             self._test_tautological_mm(device, e5m2_type, e5m2_type)
 
-        version = _get_torch_cuda_version()
+        self._test_tautological_mm(device, size=64, out_dtype=torch.float16)
+        self._test_tautological_mm(device, size=96, out_dtype=torch.float32)
+        # hipblaslt does not yet support bfloat16 output
         if torch.version.hip is None:
-            with self.assertRaises(RuntimeError):
-              self._test_tautological_mm(device, size=96, out_dtype=torch.float32)
-              self._test_tautological_mm(device, size=64, out_dtype=torch.float16)
-
-        with self.assertRaises(RuntimeError):
             self._test_tautological_mm(device, size=80, out_dtype=torch.bfloat16)
 
         with self.assertRaises(RuntimeError):

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -260,7 +260,6 @@ class TestFP8MatmulCuda(TestCase):
         # hipblaslt does not yet support bfloat16 output
         if torch.version.hip is None:
             self._test_tautological_mm(device, size=80, out_dtype=torch.bfloat16)
-
         with self.assertRaises(RuntimeError):
             self._test_tautological_mm(device, out_dtype=e5m2_type)
 


### PR DESCRIPTION
Word from `cuBLAS` is that `amax` computation is unsupported for non-fp8 outputs when the inputs are in fp8, even if it was "silently" executing in the past.

CC @tinglvv 

cc @csarofeen @ptrblck @xwang233