### PR TITLE
Don't use sympy Float functions, use an opaque one with no reasoning

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -2442,7 +2442,6 @@ exclude_patterns = [
     'torch/utils/_stats.py',
     'torch/utils/_sympy/__init__.py',
     'torch/utils/_sympy/functions.py',
-    'torch/utils/_sympy/value_ranges.py',
     'torch/utils/_traceback.py',
     'torch/utils/_zip.py',
     'torch/utils/backcompat/__init__.py',

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -427,7 +427,7 @@ class TestPySymInt(TestCase):
         r = torch._sym_sqrt(a0)
         self.assertEqual(r, 2)
         self.assertIsInstance(r, torch.SymFloat, msg=type(r))
-        self.assertExpectedInline(str(shape_env.guards[0][0]), """Eq(sqrt(s0), 2)""")
+        self.assertExpectedInline(str(shape_env.guards[0][0]), """Eq(OpaqueUnaryFn_sqrt(s0), 2)""")
 
     def test_sym_floor(self):
         shape_env = ShapeEnv()

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -422,18 +422,18 @@ class PythonPrinter(ExprPrinter):
     def _helper_sqrt(self, expr):
         return f"math.sqrt({self._print(expr)})"
 
+    def _print_OpaqueUnaryFn_sqrt(self, expr):
+        return self._helper_sqrt(expr.args[0])
+
     def _print_Pow(self, expr):
         # Pow() confuses triton
         base, exp = expr.args
-        # NB: Remember this is sizevar computation!  You don't typically
-        # expect to have to do floating point computation including exponents
-        # in sizevar compute.  Instead of adding support for floating
-        # point pow, you should make upstream retranslate the Sympy expression
-        # into Tensor expressions earlier and do that instead.
-        if exp == 0.5:
-            return self._helper_sqrt(base)
-        elif exp == -0.5:
-            return "1/" + self._helper_sqrt(base)
+        if exp == 0.5 or exp == -0.5:
+            raise AssertionError(
+                "Direct use of sympy.sqrt is not allowed as its numerics differ "
+                "from floating point sqrt; use OpaqueUnaryFn_sqrt "
+                "instead which ensures accurate floating point behavior."
+            )
         base = self._print(base)
         assert exp == int(exp), exp
         exp = int(exp)
@@ -464,39 +464,39 @@ class PythonPrinter(ExprPrinter):
         assert len(expr.args) >= 2
         return f"min({', '.join(map(self._print, expr.args))})"
 
-    def _print_cos(self, expr):
+    def _print_OpaqueUnaryFn_cos(self, expr):
         assert len(expr.args) == 1
         return f"math.cos({self._print(expr.args[0])})"
 
-    def _print_cosh(self, expr):
+    def _print_OpaqueUnaryFn_cosh(self, expr):
         assert len(expr.args) == 1
         return f"math.cosh({self._print(expr.args[0])})"
 
-    def _print_acos(self, expr):
+    def _print_OpaqueUnaryFn_acos(self, expr):
         assert len(expr.args) == 1
         return f"math.acos({self._print(expr.args[0])})"
 
-    def _print_sin(self, expr):
+    def _print_OpaqueUnaryFn_sin(self, expr):
         assert len(expr.args) == 1
         return f"math.sin({self._print(expr.args[0])})"
 
-    def _print_sinh(self, expr):
+    def _print_OpaqueUnaryFn_sinh(self, expr):
         assert len(expr.args) == 1
         return f"math.sinh({self._print(expr.args[0])})"
 
-    def _print_asin(self, expr):
+    def _print_OpaqueUnaryFn_asin(self, expr):
         assert len(expr.args) == 1
         return f"math.asin({self._print(expr.args[0])})"
 
-    def _print_tan(self, expr):
+    def _print_OpaqueUnaryFn_tan(self, expr):
         assert len(expr.args) == 1
         return f"math.tan({self._print(expr.args[0])})"
 
-    def _print_tanh(self, expr):
+    def _print_OpaqueUnaryFn_tanh(self, expr):
         assert len(expr.args) == 1
         return f"math.tanh({self._print(expr.args[0])})"
 
-    def _print_atan(self, expr):
+    def _print_OpaqueUnaryFn_atan(self, expr):
         assert len(expr.args) == 1
         return f"math.atan({self._print(expr.args[0])})"
 

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -428,12 +428,15 @@ class PythonPrinter(ExprPrinter):
     def _print_Pow(self, expr):
         # Pow() confuses triton
         base, exp = expr.args
-        if exp == 0.5 or exp == -0.5:
-            raise AssertionError(
-                "Direct use of sympy.sqrt is not allowed as its numerics differ "
-                "from floating point sqrt; use OpaqueUnaryFn_sqrt "
-                "instead which ensures accurate floating point behavior."
-            )
+        # NB: Remember this is sizevar computation!  You don't typically
+        # expect to have to do floating point computation including exponents
+        # in sizevar compute.  Instead of adding support for floating
+        # point pow, you should make upstream retranslate the Sympy expression
+        # into Tensor expressions earlier and do that instead.
+        if exp == 0.5:
+            return self._helper_sqrt(base)
+        elif exp == -0.5:
+            return "1/" + self._helper_sqrt(base)
         base = self._print(base)
         assert exp == int(exp), exp
         exp = int(exp)

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -443,39 +443,39 @@ class CppPrinter(ExprPrinter):
         assert len(expr.args) == 1
         return f"std::abs({self._print(expr.args[0])})"
 
-    def _print_cos(self, expr):
+    def _print_OpaqueUnaryFn_cos(self, expr):
         assert len(expr.args) == 1
         return f"std::cos({self._print(expr.args[0])})"
 
-    def _print_cosh(self, expr):
+    def _print_OpaqueUnaryFn_cosh(self, expr):
         assert len(expr.args) == 1
         return f"std::cosh({self._print(expr.args[0])})"
 
-    def _print_acos(self, expr):
+    def _print_OpaqueUnaryFn_acos(self, expr):
         assert len(expr.args) == 1
         return f"std::acos({self._print(expr.args[0])})"
 
-    def _print_sin(self, expr):
+    def _print_OpaqueUnaryFn_sin(self, expr):
         assert len(expr.args) == 1
         return f"std::sin({self._print(expr.args[0])})"
 
-    def _print_sinh(self, expr):
+    def _print_OpaqueUnaryFn_sinh(self, expr):
         assert len(expr.args) == 1
         return f"std::sinh({self._print(expr.args[0])})"
 
-    def _print_asin(self, expr):
+    def _print_OpaqueUnaryFn_asin(self, expr):
         assert len(expr.args) == 1
         return f"std::asin({self._print(expr.args[0])})"
 
-    def _print_tan(self, expr):
+    def _print_OpaqueUnaryFn_tan(self, expr):
         assert len(expr.args) == 1
         return f"std::tan({self._print(expr.args[0])})"
 
-    def _print_tanh(self, expr):
+    def _print_OpaqueUnaryFn_tanh(self, expr):
         assert len(expr.args) == 1
         return f"std::tanh({self._print(expr.args[0])})"
 
-    def _print_atan(self, expr):
+    def _print_OpaqueUnaryFn_atan(self, expr):
         assert len(expr.args) == 1
         return f"std::atan({self._print(expr.args[0])})"
 

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -479,6 +479,9 @@ class CppPrinter(ExprPrinter):
         assert len(expr.args) == 1
         return f"std::atan({self._print(expr.args[0])})"
 
+    def _print_OpaqueUnaryFn_sqrt(self, expr):
+        return f"std::sqrt({self._print(expr.args[0])})"
+
     def _print_Round(self, expr):
         assert len(expr.args) == 1
         return f"std::lrint({self._print(expr.args[0])})"

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -343,39 +343,39 @@ class TritonPrinter(PythonPrinter):
         assert len(expr.args) == 1
         return f"tl_math.abs({self._print(expr.args[0])})"
 
-    def _print_cos(self, expr):
+    def _print_OpaqueUnaryFn_cos(self, expr):
         assert len(expr.args) == 1
         return f"libdevice.cos(({self._print(expr.args[0])}).to(tl.float32))"
 
-    def _print_cosh(self, expr):
+    def _print_OpaqueUnaryFn_cosh(self, expr):
         assert len(expr.args) == 1
         return f"libdevice.cosh(({self._print(expr.args[0])}).to(tl.float32))"
 
-    def _print_acos(self, expr):
+    def _print_OpaqueUnaryFn_acos(self, expr):
         assert len(expr.args) == 1
         return f"libdevice.acos(({self._print(expr.args[0])}).to(tl.float32))"
 
-    def _print_sin(self, expr):
+    def _print_OpaqueUnaryFn_sin(self, expr):
         assert len(expr.args) == 1
         return f"libdevice.sin(({self._print(expr.args[0])}).to(tl.float32))"
 
-    def _print_sinh(self, expr):
+    def _print_OpaqueUnaryFn_sinh(self, expr):
         assert len(expr.args) == 1
         return f"libdevice.sinh(({self._print(expr.args[0])}).to(tl.float32))"
 
-    def _print_asin(self, expr):
+    def _print_OpaqueUnaryFn_asin(self, expr):
         assert len(expr.args) == 1
         return f"libdevice.asin(({self._print(expr.args[0])}).to(tl.float32))"
 
-    def _print_tan(self, expr):
+    def _print_OpaqueUnaryFn_tan(self, expr):
         assert len(expr.args) == 1
         return f"libdevice.tan(({self._print(expr.args[0])}).to(tl.float32))"
 
-    def _print_tanh(self, expr):
+    def _print_OpaqueUnaryFn_tanh(self, expr):
         assert len(expr.args) == 1
         return f"libdevice.tanh(({self._print(expr.args[0])}).to(tl.float32))"
 
-    def _print_atan(self, expr):
+    def _print_OpaqueUnaryFn_atan(self, expr):
         assert len(expr.args) == 1
         return f"libdevice.atan(({self._print(expr.args[0])}).to(tl.float32))"
 

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -716,10 +716,33 @@ current_module = sys.modules[__name__]
 
 
 def _get_sym_math_fn(name):
-    def fn(a):
-        import sympy
+    cache = None
 
-        return getattr(sympy, name)(a)
+    def fn(a):
+        nonlocal cache
+
+        if cache is None:
+            import sympy
+
+            class OpaqueUnaryFn(sympy.Function):
+                _torch_handler_name = name
+
+                @classmethod
+                def eval(cls, a):
+                    if isinstance(a, (sympy.Integer, sympy.Float)):
+                        # Python converts to float64 before computing, c.f.
+                        # >>> math.sin(2**53+1)
+                        # -0.848925964814655
+                        # >>> math.sin(float(2**53+1))
+                        # -0.848925964814655
+                        return sympy.Float(getattr(math, name)(float(a)))
+                    return None
+
+            OpaqueUnaryFn.__name__ = "OpaqueUnaryFn_" + name
+
+            cache = OpaqueUnaryFn
+
+        return cache(a)
 
     return fn
 

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -718,33 +718,10 @@ current_module = sys.modules[__name__]
 
 
 def _get_sym_math_fn(name):
-    cache = None
-
     def fn(a):
-        nonlocal cache
+        import torch.utils._sympy.functions
 
-        if cache is None:
-            import sympy
-
-            class OpaqueUnaryFn(sympy.Function):
-                _torch_handler_name = name
-
-                @classmethod
-                def eval(cls, a):
-                    if isinstance(a, (sympy.Integer, sympy.Float)):
-                        # Python converts to float64 before computing, c.f.
-                        # >>> math.sin(2**53+1)
-                        # -0.848925964814655
-                        # >>> math.sin(float(2**53+1))
-                        # -0.848925964814655
-                        return sympy.Float(getattr(math, name)(float(a)))
-                    return None
-
-            OpaqueUnaryFn.__name__ = "OpaqueUnaryFn_" + name
-
-            cache = OpaqueUnaryFn
-
-        return cache(a)
+        return getattr(torch.utils._sympy.functions, f"OpaqueUnaryFn_{name}")(a)
 
     return fn
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -4225,8 +4225,7 @@ class ShapeEnv:
         try:
             if orig_expr.is_number:
                 self.log.debug("eval %s [trivial]", orig_expr)
-                # NB: don't test float as there may be precision issues
-                if isinstance(hint, (int, bool)):
+                if hint is not None:
                     assert orig_expr == hint, f"{orig_expr} != {hint}"
                 return orig_expr
 
@@ -4237,8 +4236,7 @@ class ShapeEnv:
                                                       size_oblivious=size_oblivious)
             if static_expr is not None:
                 self.log.debug("eval %s == %s [statically known]", orig_expr, static_expr)
-                # NB: don't test float as there may be precision issues
-                if isinstance(hint, (int, bool)):
+                if hint is not None:
                     assert static_expr == hint, f"{static_expr} != {hint}"
                 return static_expr
 

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -1,6 +1,7 @@
 import sympy
 from sympy import S
 from sympy.core.logic import fuzzy_and, fuzzy_not, fuzzy_or
+import math
 
 __all__ = [
     "FloorDiv", "ModularIndexing", "CleanDiv", "CeilDiv", "Pow", "TrueDiv",
@@ -351,3 +352,45 @@ class RoundDecimal(sympy.Function):
         elif isinstance(number, sympy.Number) and isinstance(ndigits, sympy.Integer):
             value_type, output_type = (int, sympy.Integer) if isinstance(number, sympy.Integer) else (float, sympy.Float)
             return output_type(round(value_type(number), int(ndigits)))
+
+
+def make_opaque_unary_fn(name):
+    class OpaqueUnaryFn(sympy.Function):
+        """
+        Unlike the builtin sympy functions on real numbers like sympy.sqrt,
+        these equivalents do not do any nontrivial reasoning besides
+        constant propagation.  This helps avoid performing transformations
+        that are valid for real numbers but are invalid for floating point;
+        in particular, while we are willing to make optimizations that change
+        numerics for Tensor compute, we are NOT willing to make optimziations
+        that change numerics for size compute.
+        """
+
+        _torch_handler_name = name
+
+        @classmethod
+        def eval(cls, a):
+            if isinstance(a, (sympy.Integer, sympy.Float)):
+                # Python converts to float64 before computing, c.f.
+                # >>> math.sin(2**53+1)
+                # -0.848925964814655
+                # >>> math.sin(float(2**53+1))
+                # -0.848925964814655
+                return sympy.Float(getattr(math, name)(float(a)))
+            return None
+
+    OpaqueUnaryFn.__name__ = "OpaqueUnaryFn_" + name
+
+    return OpaqueUnaryFn
+
+# Keep in sync with math_op_names in torch/fx/experimental/sym_node.py
+OpaqueUnaryFn_sqrt = make_opaque_unary_fn("sqrt")
+OpaqueUnaryFn_cos = make_opaque_unary_fn("cos")
+OpaqueUnaryFn_cosh = make_opaque_unary_fn("cosh")
+OpaqueUnaryFn_sin = make_opaque_unary_fn("sin")
+OpaqueUnaryFn_sinh = make_opaque_unary_fn("sinh")
+OpaqueUnaryFn_tan = make_opaque_unary_fn("tan")
+OpaqueUnaryFn_tanh = make_opaque_unary_fn("tanh")
+OpaqueUnaryFn_asin = make_opaque_unary_fn("asin")
+OpaqueUnaryFn_acos = make_opaque_unary_fn("acos")
+OpaqueUnaryFn_atan = make_opaque_unary_fn("atan")

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -376,7 +376,14 @@ def make_opaque_unary_fn(name):
                 # -0.848925964814655
                 # >>> math.sin(float(2**53+1))
                 # -0.848925964814655
-                return sympy.Float(getattr(math, name)(float(a)))
+                try:
+                    return sympy.Float(getattr(math, name)(float(a)))
+                # Just use sympy semantics for infinity/overflow, you might get some
+                # weird objects but ask silly questions, get silly answers
+                except OverflowError:
+                    return getattr(sympy, name)(a)
+            elif a in [sympy.oo, -sympy.oo, sympy.zoo, -sympy.zoo]:
+                return getattr(sympy, name)(a)
             return None
 
     OpaqueUnaryFn.__name__ = "OpaqueUnaryFn_" + name
@@ -394,3 +401,6 @@ OpaqueUnaryFn_tanh = make_opaque_unary_fn("tanh")
 OpaqueUnaryFn_asin = make_opaque_unary_fn("asin")
 OpaqueUnaryFn_acos = make_opaque_unary_fn("acos")
 OpaqueUnaryFn_atan = make_opaque_unary_fn("atan")
+OpaqueUnaryFn_exp = make_opaque_unary_fn("exp")
+OpaqueUnaryFn_log = make_opaque_unary_fn("log")
+OpaqueUnaryFn_asinh = make_opaque_unary_fn("asinh")

--- a/torch/utils/_sympy/interp.py
+++ b/torch/utils/_sympy/interp.py
@@ -106,7 +106,10 @@ def sympy_interp(
 
     # Recursive case
     args = [sympy_interp(analysis, env, arg) for arg in expr.args]  # type: ignore[arg-type]
-    handler_name = handlers()[expr.func]
+    if hasattr(expr.func, "_torch_handler_name"):
+        handler_name = expr.func._torch_handler_name
+    else:
+        handler_name = handlers()[expr.func]
     handler = getattr(analysis, handler_name)
     if handler_name in ASSOCIATIVE_OPS:
         assert len(args) > 1

--- a/torch/utils/_sympy/reference.py
+++ b/torch/utils/_sympy/reference.py
@@ -3,6 +3,11 @@ import math
 import sympy
 
 import torch
+from torch.utils._sympy.functions import (
+    OpaqueUnaryFn_exp,
+    OpaqueUnaryFn_log,
+    OpaqueUnaryFn_sqrt,
+)
 
 
 # The sympy interpretation of operators.  It will also sometimes work with
@@ -111,15 +116,15 @@ class ReferenceAnalysis:
 
     @staticmethod
     def exp(x):
-        return sympy.exp(x)
+        return OpaqueUnaryFn_exp(x)
 
     @staticmethod
     def log(x):
-        return sympy.log(x)
+        return OpaqueUnaryFn_log(x)
 
     @staticmethod
     def sqrt(x):
-        return sympy.sqrt(x)
+        return OpaqueUnaryFn_sqrt(x)
 
     @staticmethod
     def pow(a, b):

--- a/torch/utils/_sympy/value_ranges.py
+++ b/torch/utils/_sympy/value_ranges.py
@@ -2,24 +2,49 @@ from __future__ import annotations
 
 import dataclasses
 import itertools
-import sympy
-from sympy.logic.boolalg import BooleanAtom, Boolean as SympyBoolean
-import operator
-import math
 import logging
-import torch
-from typing import Dict, Optional, SupportsFloat, TypeVar, Generic, Union, overload, Callable, TYPE_CHECKING
+import math
+import operator
+from typing import (
+    Callable,
+    Dict,
+    Generic,
+    Optional,
+    overload,
+    SupportsFloat,
+    TYPE_CHECKING,
+    TypeVar,
+    Union,
+)
+
+import sympy
+from sympy.logic.boolalg import Boolean as SympyBoolean, BooleanAtom
 from typing_extensions import TypeGuard
 
+import torch
+
 from torch._prims_common import dtype_to_type
+from .functions import (
+    OpaqueUnaryFn_acos,
+    OpaqueUnaryFn_asinh,
+    OpaqueUnaryFn_atan,
+    OpaqueUnaryFn_cosh,
+    OpaqueUnaryFn_exp,
+    OpaqueUnaryFn_log,
+    OpaqueUnaryFn_sinh,
+    OpaqueUnaryFn_sqrt,
+    OpaqueUnaryFn_tanh,
+    Round,
+    RoundDecimal,
+)
 from .interp import sympy_interp
-from .functions import Round, RoundDecimal, OpaqueUnaryFn_sqrt
 
 log = logging.getLogger(__name__)
 
 __all__ = ["ValueRanges", "ValueRangeAnalysis", "bound_sympy"]
 
-_T = TypeVar('_T', sympy.Expr, SympyBoolean)
+_T = TypeVar("_T", sympy.Expr, SympyBoolean)
+
 
 class ValueRangeError(RuntimeError):
     pass
@@ -109,8 +134,11 @@ class ValueRanges(Generic[_T]):
         upper = simple_sympify(upper)
         # TODO: when the bounds have free variables, this may be
         # nontrivial to actually verify
-        if not sympy_generic_le(lower, upper):
-            raise ValueRangeError(f"Invalid ranges [{lower}:{upper}]")
+        try:
+            if not sympy_generic_le(lower, upper):
+                raise ValueRangeError(f"Invalid ranges [{lower}:{upper}]")
+        except TypeError:
+            raise TypeError(f"Could not compare {lower} <= {upper}")
         # Because this is a frozen class
         object.__setattr__(self, "lower", lower)
         object.__setattr__(self, "upper", upper)
@@ -130,7 +158,9 @@ class ValueRanges(Generic[_T]):
         return sympy_generic_le(self.lower, x) and sympy_generic_le(x, self.upper)
 
     def issubset(self, other):
-        return sympy_generic_le(other.lower, self.lower) and sympy_generic_le(self.upper, other.upper)
+        return sympy_generic_le(other.lower, self.lower) and sympy_generic_le(
+            self.upper, other.upper
+        )
 
     def tighten(self, other) -> ValueRanges:
         """Given two ValueRanges, returns their intersection"""
@@ -138,11 +168,15 @@ class ValueRanges(Generic[_T]):
 
     # Intersection
     @overload
-    def __and__(self: ValueRanges[sympy.Expr], other: ValueRanges[sympy.Expr]) -> ValueRanges[sympy.Expr]:
+    def __and__(
+        self: ValueRanges[sympy.Expr], other: ValueRanges[sympy.Expr]
+    ) -> ValueRanges[sympy.Expr]:
         ...
 
     @overload
-    def __and__(self: ValueRanges[SympyBoolean], other: ValueRanges[SympyBoolean]) -> ValueRanges[SympyBoolean]:
+    def __and__(
+        self: ValueRanges[SympyBoolean], other: ValueRanges[SympyBoolean]
+    ) -> ValueRanges[SympyBoolean]:
         ...
 
     def __and__(self: AllVR, other: AllVR) -> AllVR:
@@ -152,17 +186,25 @@ class ValueRanges(Generic[_T]):
             return other
         assert self.is_bool == other.is_bool, (self, other)
         if self.is_bool:
-            return ValueRanges(sympy.Or(self.lower, other.lower), sympy.And(self.upper, other.upper))
+            return ValueRanges(
+                sympy.Or(self.lower, other.lower), sympy.And(self.upper, other.upper)
+            )
         else:
-            return ValueRanges(sympy.Max(self.lower, other.lower), sympy.Min(self.upper, other.upper))
+            return ValueRanges(
+                sympy.Max(self.lower, other.lower), sympy.Min(self.upper, other.upper)
+            )
 
     # Union
     @overload
-    def __or__(self: ValueRanges[sympy.Expr], other: ValueRanges[sympy.Expr]) -> ValueRanges[sympy.Expr]:
+    def __or__(
+        self: ValueRanges[sympy.Expr], other: ValueRanges[sympy.Expr]
+    ) -> ValueRanges[sympy.Expr]:
         ...
 
     @overload
-    def __or__(self: ValueRanges[SympyBoolean], other: ValueRanges[SympyBoolean]) -> ValueRanges[SympyBoolean]:
+    def __or__(
+        self: ValueRanges[SympyBoolean], other: ValueRanges[SympyBoolean]
+    ) -> ValueRanges[SympyBoolean]:
         ...
 
     def __or__(self: AllVR, other: AllVR) -> AllVR:
@@ -170,9 +212,13 @@ class ValueRanges(Generic[_T]):
             return ValueRanges.unknown()
         assert self.is_bool == other.is_bool, (self, other)
         if self.is_bool:
-            return ValueRanges(sympy.And(self.lower, other.lower), sympy.Or(self.upper, other.upper))
+            return ValueRanges(
+                sympy.And(self.lower, other.lower), sympy.Or(self.upper, other.upper)
+            )
         else:
-            return ValueRanges(sympy.Min(self.lower, other.lower), sympy.Max(self.upper, other.upper))
+            return ValueRanges(
+                sympy.Min(self.lower, other.lower), sympy.Max(self.upper, other.upper)
+            )
 
     def is_singleton(self) -> bool:
         return self.lower == self.upper
@@ -246,16 +292,22 @@ class ValueRanges(Generic[_T]):
 
     @overload
     @staticmethod
-    def coordinatewise_increasing_map(x: Union[ExprIn, ExprVR], y: Union[ExprIn, ExprVR], fn: ExprFn2) -> ExprVR:
+    def coordinatewise_increasing_map(
+        x: Union[ExprIn, ExprVR], y: Union[ExprIn, ExprVR], fn: ExprFn2
+    ) -> ExprVR:
         ...
 
     @overload
     @staticmethod
-    def coordinatewise_increasing_map(x: Union[BoolIn, BoolVR], y: Union[BoolIn, BoolVR], fn: BoolFn2) -> BoolVR:
+    def coordinatewise_increasing_map(
+        x: Union[BoolIn, BoolVR], y: Union[BoolIn, BoolVR], fn: BoolFn2
+    ) -> BoolVR:
         ...
 
     @staticmethod
-    def coordinatewise_increasing_map(x: Union[AllIn, AllVR], y: Union[AllIn, AllVR], fn: AllFn2) -> AllVR:
+    def coordinatewise_increasing_map(
+        x: Union[AllIn, AllVR], y: Union[AllIn, AllVR], fn: AllFn2
+    ) -> AllVR:
         """
         It's increasing on each coordinate.
 
@@ -279,6 +331,7 @@ class ValueRanges(Generic[_T]):
         ]
         return ValueRanges(min(products), max(products))
 
+
 class SymPyValueRangeAnalysis:
     """
     It gives bounds on a SymPy operator given bounds on its arguments
@@ -289,7 +342,9 @@ class SymPyValueRangeAnalysis:
     def constant(value, dtype):
         # NB: value is NOT a sympy expression, it's a constant!
         is_python = isinstance(value, (int, float, bool))
-        assert is_python or isinstance(value, (BooleanAtom, sympy.Integer, sympy.Number))
+        assert is_python or isinstance(
+            value, (BooleanAtom, sympy.Integer, sympy.Number)
+        )
 
         # using nan makes subsequent computation throw, and for the purposes of optimization
         # returning -math.inf - math.inf is equivalent to giving up
@@ -399,7 +454,9 @@ class SymPyValueRangeAnalysis:
     def truediv(a, b):
         a = ValueRanges.wrap(a)
         b = ValueRanges.wrap(b)
-        if 0 in b or ((-sympy.oo in a or sympy.oo in a) and (-sympy.oo in b or sympy.oo in b)):
+        if 0 in b or (
+            (-sympy.oo in a or sympy.oo in a) and (-sympy.oo in b or sympy.oo in b)
+        ):
             return ValueRanges.unknown()
         else:
             return ValueRanges.coordinatewise_monotone_map(a, b, operator.truediv)
@@ -408,7 +465,9 @@ class SymPyValueRangeAnalysis:
     def floordiv(a, b):
         a = ValueRanges.wrap(a)
         b = ValueRanges.wrap(b)
-        if 0 in b or ((-sympy.oo in a or sympy.oo in a) and (-sympy.oo in b or sympy.oo in b)):
+        if 0 in b or (
+            (-sympy.oo in a or sympy.oo in a) and (-sympy.oo in b or sympy.oo in b)
+        ):
             return ValueRanges.unknown()
         else:
             return ValueRanges.coordinatewise_monotone_map(a, b, operator.floordiv)
@@ -451,7 +510,7 @@ class SymPyValueRangeAnalysis:
         b = b.lower
         if a.is_singleton():
             a = a.lower
-            r = a ** b
+            r = a**b
             if not r.is_finite:
                 return ValueRanges.unknown()
             return ValueRanges.wrap(r)
@@ -473,21 +532,21 @@ class SymPyValueRangeAnalysis:
         if not is_integer(b):
             # If the base is positive, then we're good, otherwise nothing's defined
             if a.lower >= 0:
-                return ValueRanges.increasing_map(a, lambda x: x ** b)
+                return ValueRanges.increasing_map(a, lambda x: x**b)
             else:
                 return ValueRanges.unknown()
         else:
             # b > 0 integer
             if b % 2 == 0:
                 # x^n where n is even
-                return ValueRanges.convex_min_zero_map(a, lambda x: x ** b)
+                return ValueRanges.convex_min_zero_map(a, lambda x: x**b)
             else:
                 # x^n where n is odd
-                return ValueRanges.increasing_map(a, lambda x: x ** b)
+                return ValueRanges.increasing_map(a, lambda x: x**b)
 
     @staticmethod
     def reciprocal(x):
-        """ Needed as it's used in pow, but it won't appear on a SymPy expression """
+        """Needed as it's used in pow, but it won't appear on a SymPy expression"""
         x = ValueRanges.wrap(x)
         if 0 in x:
             return ValueRanges.unknown()
@@ -500,14 +559,14 @@ class SymPyValueRangeAnalysis:
 
     @staticmethod
     def exp(x):
-        return ValueRanges.increasing_map(x, sympy.functions.elementary.exponential.exp)
+        return ValueRanges.increasing_map(x, OpaqueUnaryFn_exp)
 
     @staticmethod
     def log(x):
         x = ValueRanges.wrap(x)
         if x.lower <= 0:
             return ValueRanges.unknown()
-        return ValueRanges.increasing_map(x, sympy.log)
+        return ValueRanges.increasing_map(x, OpaqueUnaryFn_log)
 
     @classmethod
     def minimum(cls, a, b):
@@ -543,7 +602,9 @@ class SymPyValueRangeAnalysis:
 
     @classmethod
     def ceil(cls, x):
-        return ValueRanges.increasing_map(x, sympy.functions.elementary.integers.ceiling)
+        return ValueRanges.increasing_map(
+            x, sympy.functions.elementary.integers.ceiling
+        )
 
     @classmethod
     def round(cls, number, ndigits=None):
@@ -612,9 +673,9 @@ class SymPyValueRangeAnalysis:
     def cosh(x):
         x = ValueRanges.wrap(x)
         if x.lower > 0:
-            return ValueRanges.increasing_map(x, sympy.cosh)
+            return ValueRanges.increasing_map(x, OpaqueUnaryFn_cosh)
         elif x.upper < 0:
-            return ValueRanges.decreasing_map(x, sympy.cosh)
+            return ValueRanges.decreasing_map(x, OpaqueUnaryFn_cosh)
         return ValueRanges(0.0, sympy.oo)
 
     @staticmethod
@@ -625,7 +686,7 @@ class SymPyValueRangeAnalysis:
 
     @staticmethod
     def sinh(x):
-        return ValueRanges.increasing_map(x, sympy.sinh)
+        return ValueRanges.increasing_map(x, OpaqueUnaryFn_sinh)
 
     @staticmethod
     def tan(x):
@@ -633,25 +694,25 @@ class SymPyValueRangeAnalysis:
 
     @staticmethod
     def tanh(x):
-        return ValueRanges.increasing_map(x, sympy.tanh)
+        return ValueRanges.increasing_map(x, OpaqueUnaryFn_tanh)
 
     @staticmethod
     def asin(x):
         x = ValueRanges.wrap(x)
         if -1 <= x.lower and x.upper <= 1:
-            return ValueRanges.increasing_map(x, sympy.asin)
+            return ValueRanges.increasing_map(x, OpaqueUnaryFn_asinh)
         return ValueRanges.unknown()
 
     @staticmethod
     def acos(x):
         x = ValueRanges.wrap(x)
         if -1 <= x.lower and x.upper <= 1:
-            return ValueRanges.decreasing_map(x, sympy.acos)
+            return ValueRanges.decreasing_map(x, OpaqueUnaryFn_acos)
         return ValueRanges.unknown()
 
     @staticmethod
     def atan(x):
-        return ValueRanges.increasing_map(x, sympy.atan)
+        return ValueRanges.increasing_map(x, OpaqueUnaryFn_atan)
 
 
 class ValueRangeAnalysis(SymPyValueRangeAnalysis):
@@ -751,7 +812,9 @@ class ValueRangeAnalysis(SymPyValueRangeAnalysis):
         return self.default_handler
 
 
-def bound_sympy(expr: sympy.Expr, ranges: Optional[Dict[sympy.Symbol, ValueRanges]] = None) -> ValueRanges:
+def bound_sympy(
+    expr: sympy.Expr, ranges: Optional[Dict[sympy.Symbol, ValueRanges]] = None
+) -> ValueRanges:
     if isinstance(expr, sympy.Number):
         return ValueRanges.wrap(expr)
 

--- a/torch/utils/_sympy/value_ranges.py
+++ b/torch/utils/_sympy/value_ranges.py
@@ -13,7 +13,7 @@ from typing_extensions import TypeGuard
 
 from torch._prims_common import dtype_to_type
 from .interp import sympy_interp
-from .functions import Round, RoundDecimal
+from .functions import Round, RoundDecimal, OpaqueUnaryFn_sqrt
 
 log = logging.getLogger(__name__)
 
@@ -564,7 +564,7 @@ class SymPyValueRangeAnalysis:
         x = ValueRanges.wrap(x)
         if x.lower < 0:
             return ValueRanges.unknown()
-        return ValueRanges.increasing_map(x, sympy.sqrt)
+        return ValueRanges.increasing_map(x, OpaqueUnaryFn_sqrt)
 
     @staticmethod
     def where(a, b, c):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #122827
* __->__ #122823

Sympy simplifications don't obey floating point semantics, so don't
use Sympy for this.  Keep them as is, only evaluate with the reference
implementations when all arguments are known.

This may end up getting subsumed by some other changes later, but I
wanted to understand if this was easy and it seems to be easy.

This doesn't actually depend on the earlier diffs on the stack and I can detach it.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang