### PR TITLE
Forward fix for subtly breaking AC with compile in the case of stacked

### DIFF
--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -793,6 +793,9 @@ def min_cut_rematerialization_partition(
         if node.target in [aten.lift_fresh_copy.default, aten.lift_fresh.default]:
             return False
 
+        if node.meta.get("recompute", None) == 0:
+            return True
+
         if BAN_IF_NOT_IN_ALLOWLIST:
             if get_aten_target(node) not in recomputable_ops:
                 return True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #122689
* #122581
* __->__ #122841
* #121692
* #122688
* #122686

checkpoint layers separated by recomputable op