### PR TITLE
[c10d] add the source rank which detects the timeout

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1280,7 +1280,7 @@ void ProcessGroupNCCL::heartbeatMonitor() {
           }
           errorMsg = c10::str(
               logPrefix(),
-              "Received a global timeout from another rank ",
+              "Received a global timeout signal from rank ",
               timeOutRank,
               ", and will start to dump the debug info. ",
               "Last enqueued NCCL work: ",
@@ -1289,7 +1289,7 @@ void ProcessGroupNCCL::heartbeatMonitor() {
               lastCompletedSeq_,
               ".");
           exitMsg = c10::str(
-              "ProcessGroupNCCL's watchdog detected a collective timeout from another rank ",
+              "ProcessGroupNCCL's watchdog detected a collective timeout signal from rank ",
               timeOutRank,
               " and notified the current rank. ",
               "This is most likely caused by incorrect usages of collectives, e.g., wrong ",
@@ -1594,10 +1594,10 @@ void ProcessGroupNCCL::watchdogHandler() {
               // Set shutdown mode, so the heartbeat monitor thread will not
               // abort process immediately.
               collectiveDebugInfoMode_.store(true);
-              int rank = globalRank();
+              auto rank = globalRank();
               auto vec = std::vector<uint8_t>(
                   reinterpret_cast<uint8_t*>(&rank),
-                  reinterpret_cast<uint8_t*>(&rank) + sizeof(int));
+                  reinterpret_cast<uint8_t*>(&rank) + sizeof(rank));
               globalStore_->set(std::string(TIMEOUT_DUMP), vec);
             }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122850

Summary:
When a rank detects a timeout from tcpstore and triggers the dump. It's good to have more info about the source rank which detects the
collective timeout locally. We just need to put the source rank as the
value in the kvstore
Test Plan:
In unit test, we triggered the timeout on rank 0 and rank 1 should get
the timeout signal from store and log the correct source rank:

```
(sqzhang_1) [sqzhang@devgpu009.cln1 ~/pytorch (34d27652)]$  python
test/distributed/test_c10d_nccl.py NCCLTraceTestTimeoutDumpOnStuckRanks
NCCL version 2.19.3+cuda12.0
[rank0]:[E327 17:04:16.986381360 ProcessGroupNCCL.cpp:565] [Rank 0]
Watchdog caught collective operation timeout: WorkNCCL(SeqNum=2,
OpType=ALLREDUCE, NumelIn=12, NumelOut=12, Timeout(ms)=1000) ran for
1099 milliseconds before timing out.
[rank0]:[E327 17:04:16.988036373 ProcessGroupNCCL.cpp:1582] [PG 0 Rank
0] Timeout at NCCL work: 2, last enqueued NCCL work: 2, last completed
   NCCL work: 1.
   [rank0]:[E327 17:04:16.182548526 ProcessGroupNCCL.cpp:1346] [PG 0
   Rank 0] Received a timeout signal from this local rank and will start
   to dump the debug info. Last enqueued NCCL work: 2, last completed
   NCCL work: 1.
   [rank0]:[E327 17:04:16.247574460 ProcessGroupNCCL.cpp:1167] [PG 0
   Rank 0] ProcessGroupNCCL preparing to dump debug info.
   [rank1]:[E327 17:04:16.273332178 ProcessGroupNCCL.cpp:1346] [PG 0
   Rank 1] Received a global timeout from another rank 0, and will start
   to dump the debug info. Last enqueued NCCL work: 1, last completed
   NCCL work: 1.
   [rank1]:[E327 17:04:16.273565177 ProcessGroupNCCL.cpp:1167] [PG 0
   Rank 1] ProcessGroupNCCL preparing to dump debug info.
   [rank1]:[F327 17:04:16.274256512 ProcessGroupNCCL.cpp:1185] [PG 0
   Rank 1] [PG 0 Rank 1] ProcessGroupNCCL's watchdog detected a
   collective timeout from another rank 0 and notified the current rank.
   This is most likely caused by incorrect usages of collectives, e.g.,
   wrong sizes used across ranks, the order of collectives is not same
   for all ranks or the scheduled collective, for some reason, didn't
   run. Additionally, this can be caused by GIL deadlock or other
   reasons such as network errors or bugs in the communications library
   (e.g. NCCL), etc. We tried our best to dump the debug info into the
   storage to help you debug the issue.
```

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang