### PR TITLE
[export] Temporarily block mutating ops in quant tests.

### DIFF
--- a/test/quantization/pt2e/test_xnnpack_quantizer.py
+++ b/test/quantization/pt2e/test_xnnpack_quantizer.py
@@ -857,7 +857,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
             torch.ops.aten.add.Tensor,
             torch.ops.quantized_decomposed.quantize_per_tensor.default,
             torch.ops.quantized_decomposed.dequantize_per_tensor.default,
-            torch.ops.aten.add_.Tensor,
+            # TODO torch.ops.aten.add.Tensor,
             torch.ops.quantized_decomposed.quantize_per_tensor.default,
         ]
         self._test_quantizer(
@@ -887,7 +887,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
             torch.ops.aten.mul.Tensor,
             torch.ops.quantized_decomposed.quantize_per_tensor.default,
             torch.ops.quantized_decomposed.dequantize_per_tensor.default,
-            torch.ops.aten.mul_.Tensor,
+            # TODO torch.ops.aten.mul.Tensor,
             torch.ops.quantized_decomposed.quantize_per_tensor.default,
         ]
         self._test_quantizer(
@@ -906,7 +906,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
         node_occurrence = {
             # two input and one output for first add, and output for second add
             torch.ops.quantized_decomposed.quantize_per_tensor.default: 5,
-            torch.ops.quantized_decomposed.dequantize_per_tensor.default: 7,
+            # TODO torch.ops.quantized_decomposed.dequantize_per_tensor.default: 9,
         }
         node_list = [
             torch.ops.quantized_decomposed.dequantize_per_tensor.default,
@@ -917,10 +917,10 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
             torch.ops.aten.mul.Tensor,
             torch.ops.quantized_decomposed.quantize_per_tensor.default,
             torch.ops.quantized_decomposed.dequantize_per_tensor.default,
-            torch.ops.aten.add_.Tensor,
+            # TODO torch.ops.aten.add.Tensor,
             torch.ops.quantized_decomposed.quantize_per_tensor.default,
             torch.ops.quantized_decomposed.dequantize_per_tensor.default,
-            torch.ops.aten.mul_.Tensor,
+            # TODO torch.ops.aten.mul.Tensor,
             torch.ops.quantized_decomposed.quantize_per_tensor.default,
         ]
         self._test_quantizer(


### PR DESCRIPTION
Summary: After we migrate to torch.export, we won't see ops like add_ and mul_ due to functionalization. We are rolling out pre dispatch export, so for now we just skip those mutating ops in tests.

Test Plan: buck run mode/opt caffe2/test/quantization:test_quantization

Reviewed By: tugsbayasgalan

Differential Revision: D55442019


