### PR TITLE
Add inductor fx pass unit test for shape propagation

### DIFF
--- a/test/dynamo/test_fx_passes_pre_grad.py
+++ b/test/dynamo/test_fx_passes_pre_grad.py
@@ -1,0 +1,38 @@
+# Owner(s): ["module: dynamo"]
+from unittest import mock
+
+import torch
+
+import torch._dynamo
+import torch._dynamo.test_case
+from torch._inductor.utils import pass_execution_and_save
+
+
+class FxPassesPreGradTests(torch._dynamo.test_case.TestCase):
+    @mock.patch("torch._inductor.utils.ShapeProp.propagate")
+    def test_pass_execution_and_save(self, mock_shape_prop):
+        class TestModule(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.param = torch.nn.Parameter(torch.ones(4, 4))
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return self.param + x
+
+        def fx_pass(graph: torch.fx.GraphModule) -> None:
+            return
+
+        sample_input = torch.randn(4, 4)
+        m = TestModule()
+        m(sample_input)
+        exported_program = torch.export.export(m, (sample_input,))
+        gm = exported_program.graph_module
+
+        pass_execution_and_save(fx_pass, gm, sample_input, "Apply testing pass")
+        mock_shape_prop.assert_called_once()
+
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    run_tests()


### PR DESCRIPTION
Summary: Pre-grad fx passes expect information from shape propagation to be present. D55221119 ensured that `pass_execution_and_save` invokes shape propagation, and this diff adds a covering unit test to prevent regression.

Test Plan: New UT passes locally.

Differential Revision: D55440240




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang