### PR TITLE
[TD][ez] Set pytest cache bucket default to gha-artifacts

### DIFF
--- a/.github/actions/pytest-cache-download/action.yml
+++ b/.github/actions/pytest-cache-download/action.yml
@@ -12,7 +12,7 @@ inputs:
   s3_bucket:
     description: S3 bucket to upload/download PyTest cache
     required: false
-    default: ""
+    default: "gha-artifacts"
 
 runs:
   using: composite

--- a/.github/actions/pytest-cache-download/action.yml
+++ b/.github/actions/pytest-cache-download/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: Text that uniquely identifies a given job type within a workflow. All shards of a job should share the same job identifier.
     required: true
   s3_bucket:
-    description: S3 bucket to upload/download PyTest cache
+    description: S3 bucket to download PyTest cache
     required: false
     default: "gha-artifacts"
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -101,7 +101,6 @@ class TestCheckpoint(TestCase):
     # Test whether checkpoint is being triggered or not. For this, we check
     # the number of times forward pass happens
     def test_checkpoint_trigger(self):
-        self.assertTrue(1 == 2)
 
         class Net(nn.Module):
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -101,6 +101,7 @@ class TestCheckpoint(TestCase):
     # Test whether checkpoint is being triggered or not. For this, we check
     # the number of times forward pass happens
     def test_checkpoint_trigger(self):
+        self.assertTrue(1 == 2)
 
         class Net(nn.Module):
 


### PR DESCRIPTION
After https://github.com/pytorch/pytorch/pull/121907/files

Example failure: https://github.com/pytorch/pytorch/actions/runs/8473386479/job/23217733984#step:5:130
```
usage: pytest_cache.py [-h] (--upload | --download) --cache_dir CACHE_DIR
                       --pr_identifier PR_IDENTIFIER --job_identifier
                       JOB_IDENTIFIER [--sha SHA] [--test_config TEST_CONFIG]
                       [--shard SHARD] [--repo REPO] [--temp_dir TEMP_DIR]
                       [--bucket BUCKET]
pytest_cache.py: error: argument --bucket: expected one argument
```
