### PR TITLE
Use zeros for NJT dummy to avoid messing with randomness

### DIFF
--- a/torch/nested/_internal/nested_tensor.py
+++ b/torch/nested/_internal/nested_tensor.py
@@ -420,8 +420,8 @@ def _nt_view_dummy() -> torch.Tensor:
     global _dummy_instance
     if _dummy_instance is None:
         _dummy_instance = NestedTensor(
-            values=torch.randn(3, 3, device="meta"),
-            offsets=torch.randint(3, (2,), device="meta", dtype=torch.int64),
+            values=torch.zeros(3, 3, device="meta"),
+            offsets=torch.zeros(3, device="meta", dtype=torch.int64),
         ).detach()
     return _dummy_instance
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #122917
* __->__ #122902

Use of randomness was breaking vmap.