### PR TITLE
[export] Restore original placeholder names (part 1: top-level renaming)

### DIFF
--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -43,12 +43,12 @@ class TestExperiment(TestCase):
         self.assertExpectedInline(
             str(ep.graph_module.code.strip()),
             """\
-def forward(self, arg0_1, arg1_1):
-    sin = torch.ops.aten.sin.default(arg1_1)
+def forward(self, b_submodule_buffer1, x):
+    sin = torch.ops.aten.sin.default(x)
     strict_graph_1 = self.strict_graph_1
-    strict_mode_1 = torch.ops.higher_order.strict_mode(strict_graph_1, (sin, arg0_1));  strict_graph_1 = sin = arg0_1 = None
+    strict_mode_1 = torch.ops.higher_order.strict_mode(strict_graph_1, (sin, b_submodule_buffer1));  strict_graph_1 = sin = b_submodule_buffer1 = None
     getitem_1 = strict_mode_1[0];  strict_mode_1 = None
-    add = torch.ops.aten.add.Tensor(arg1_1, 3);  arg1_1 = None
+    add = torch.ops.aten.add.Tensor(x, 3);  x = None
     return (getitem_1, add)""",
         )
 

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -26,6 +26,7 @@ from torch._export.utils import (
 )
 from torch._subclasses import FakeTensorMode
 from torch.export import Dim, dynamic_dim, export, unflatten
+from torch.export.graph_signature import InputKind
 from torch.export._trace import (
     _export,
     _export_to_torch_ir,
@@ -1081,6 +1082,10 @@ class TestExport(TestCase):
         }
         self._test_export_same_as_eager(kw_func, args, kwargs)
 
+    # TODO(pianpwk): resolve in immediate follow-up PR
+    # add name to ConstantArgument schema for SerDer
+    @testing.expectedFailureSerDer
+    @testing.expectedFailureSerDerPreDispatch
     def test_export_func_with_default_kwargs(self):
         class Module(torch.nn.Module):
             def forward(self, arg1, arg2, a, b=1):
@@ -1860,14 +1865,14 @@ class TestExport(TestCase):
             str(gm.code).strip(),
             """\
 def forward(self, arg_0):
-    arg7_1, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
+    x, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
     conv_weight = self.conv.weight
     conv_bias = self.conv.bias
     bn_weight = self.bn.weight
     bn_bias = self.bn.bias
     bn_running_mean = self.bn.running_mean
     bn_running_var = self.bn.running_var
-    conv2d = torch.ops.aten.conv2d.default(arg7_1, conv_weight, conv_bias);  arg7_1 = conv_weight = conv_bias = None
+    conv2d = torch.ops.aten.conv2d.default(x, conv_weight, conv_bias);  x = conv_weight = conv_bias = None
     _native_batch_norm_legit_no_training = torch.ops.aten._native_batch_norm_legit_no_training.default(conv2d, bn_weight, bn_bias, bn_running_mean, bn_running_var, 0.1, 1e-05);  conv2d = bn_weight = bn_bias = bn_running_mean = bn_running_var = None
     getitem = _native_batch_norm_legit_no_training[0];  _native_batch_norm_legit_no_training = None
     return pytree.tree_unflatten((getitem,), self._out_spec)""",
@@ -1879,7 +1884,7 @@ def forward(self, arg_0):
             str(gm_train.code).strip(),
             """\
 def forward(self, arg_0):
-    arg7_1, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
+    x, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
     conv_weight = self.conv.weight
     conv_bias = self.conv.bias
     bn_weight = self.bn.weight
@@ -1887,7 +1892,7 @@ def forward(self, arg_0):
     bn_running_mean = self.bn.running_mean
     bn_running_var = self.bn.running_var
     bn_num_batches_tracked = self.bn.num_batches_tracked
-    conv2d = torch.ops.aten.conv2d.default(arg7_1, conv_weight, conv_bias);  arg7_1 = conv_weight = conv_bias = None
+    conv2d = torch.ops.aten.conv2d.default(x, conv_weight, conv_bias);  x = conv_weight = conv_bias = None
     add = torch.ops.aten.add.Tensor(bn_num_batches_tracked, 1)
     _native_batch_norm_legit_functional = torch.ops.aten._native_batch_norm_legit_functional.default(conv2d, bn_weight, bn_bias, bn_running_mean, bn_running_var, True, 0.1, 1e-05);  conv2d = bn_weight = bn_bias = None
     getitem = _native_batch_norm_legit_functional[0]
@@ -3395,11 +3400,11 @@ def forward(self, arg_0):
             str(gm_unflat_non_strict.bar.leaf.linear.graph).strip(),
             """\
 graph():
-    %arg3_1 : [num_users=1] = placeholder[target=arg3_1]
+    %x : [num_users=1] = placeholder[target=x]
     %weight : [num_users=1] = get_attr[target=weight]
     %bias : [num_users=1] = get_attr[target=bias]
     %t : [num_users=1] = call_function[target=torch.ops.aten.t.default](args = (%weight,), kwargs = {})
-    %addmm : [num_users=1] = call_function[target=torch.ops.aten.addmm.default](args = (%bias, %arg3_1, %t), kwargs = {})
+    %addmm : [num_users=1] = call_function[target=torch.ops.aten.addmm.default](args = (%bias, %x, %t), kwargs = {})
     return addmm""",
         )
 
@@ -3467,11 +3472,11 @@ graph():
             str(gm_unflat_non_strict.bar.leaf.linear.graph).strip(),
             """\
 graph():
-    %arg5_1 : [num_users=1] = placeholder[target=arg5_1]
+    %x : [num_users=1] = placeholder[target=x]
     %weight : [num_users=1] = get_attr[target=weight]
     %bias : [num_users=1] = get_attr[target=bias]
     %t : [num_users=1] = call_function[target=torch.ops.aten.t.default](args = (%weight,), kwargs = {})
-    %addmm : [num_users=1] = call_function[target=torch.ops.aten.addmm.default](args = (%bias, %arg5_1, %t), kwargs = {})
+    %addmm : [num_users=1] = call_function[target=torch.ops.aten.addmm.default](args = (%bias, %x, %t), kwargs = {})
     return addmm""",
         )
         self.assertExpectedInline(
@@ -3580,11 +3585,11 @@ graph():
         self.assertExpectedInline(
             ep.graph_module.code.strip(),
             """\
-def forward(self, arg0_1, arg1_1, arg2_1):
-    cos = torch.ops.aten.cos.default(arg2_1)
+def forward(self, p_bar_linear_weight, p_bar_linear_bias, x):
+    cos = torch.ops.aten.cos.default(x)
     true_graph_0 = self.true_graph_0
     false_graph_0 = self.false_graph_0
-    conditional = torch.ops.higher_order.cond(False, true_graph_0, false_graph_0, [arg1_1, arg0_1, arg2_1]);  true_graph_0 = false_graph_0 = arg1_1 = arg0_1 = arg2_1 = None
+    conditional = torch.ops.higher_order.cond(False, true_graph_0, false_graph_0, [p_bar_linear_bias, p_bar_linear_weight, x]);  true_graph_0 = false_graph_0 = p_bar_linear_bias = p_bar_linear_weight = x = None
     getitem = conditional[0];  conditional = None
     add = torch.ops.aten.add.Tensor(cos, getitem);  cos = getitem = None
     return (add,)""",
@@ -3674,10 +3679,10 @@ def forward(self, arg0_1, arg1_1, arg2_1):
         )
 
         self.assertExpectedInline(str(exported_program.graph_module.code.strip()), """\
-def forward(self, arg0_1, arg1_1, arg2_1, arg3_1):
+def forward(self, b_pred, b_t, x, y):
     true_graph_0 = self.true_graph_0
     false_graph_0 = self.false_graph_0
-    conditional = torch.ops.higher_order.cond(arg0_1, true_graph_0, false_graph_0, [arg1_1, arg2_1, arg3_1]);  arg0_1 = true_graph_0 = false_graph_0 = arg1_1 = arg2_1 = arg3_1 = None
+    conditional = torch.ops.higher_order.cond(b_pred, true_graph_0, false_graph_0, [b_t, x, y]);  b_pred = true_graph_0 = false_graph_0 = b_t = x = y = None
     getitem = conditional[0];  conditional = None
     return (getitem,)""")  # noqa: B950
 
@@ -3884,18 +3889,18 @@ def forward(self, arg0_1, arg1_1, arg2_1):
 
         ep = torch.export.export(M(), inps)
         self.assertExpectedInline(str(ep.graph_module.code.strip()), """\
-def forward(self, arg0_1):
-    cos = torch.ops.aten.cos.default(arg0_1)
-    auto_functionalized = torch._higher_order_ops.auto_functionalize.auto_functionalized(torch.ops.testlib.foo.default, x = arg0_1, z = cos);  arg0_1 = cos = None
+def forward(self, x):
+    cos = torch.ops.aten.cos.default(x)
+    auto_functionalized = torch._higher_order_ops.auto_functionalize.auto_functionalized(torch.ops.testlib.foo.default, x = x, z = cos);  x = cos = None
     getitem_3 = auto_functionalized[3];  auto_functionalized = None
     cos_1 = torch.ops.aten.cos.default(getitem_3)
     return (getitem_3, getitem_3, cos_1)""")
 
         ep = torch.export._trace._export(M(), inps, pre_dispatch=True)
         self.assertExpectedInline(str(ep.graph_module.code.strip()), """\
-def forward(self, arg0_1):
-    cos = torch.ops.aten.cos.default(arg0_1)
-    auto_functionalized = torch._higher_order_ops.auto_functionalize.auto_functionalized(torch.ops.testlib.foo.default, x = arg0_1, z = cos);  arg0_1 = cos = None
+def forward(self, x):
+    cos = torch.ops.aten.cos.default(x)
+    auto_functionalized = torch._higher_order_ops.auto_functionalize.auto_functionalized(torch.ops.testlib.foo.default, x = x, z = cos);  x = cos = None
     getitem_3 = auto_functionalized[3];  auto_functionalized = None
     cos_1 = torch.ops.aten.cos.default(getitem_3)
     return (getitem_3, getitem_3, cos_1)""")
@@ -3913,9 +3918,9 @@ def forward(self, arg0_1):
 
         ep = torch.export.export(M(), inps)
         self.assertExpectedInline(str(ep.graph_module.code.strip()), """\
-def forward(self, arg0_1):
-    cos = torch.ops.aten.cos.default(arg0_1)
-    cos_1 = torch.ops.aten.cos.default(arg0_1);  arg0_1 = None
+def forward(self, x):
+    cos = torch.ops.aten.cos.default(x)
+    cos_1 = torch.ops.aten.cos.default(x);  x = None
     auto_functionalized = torch._higher_order_ops.auto_functionalize.auto_functionalized(torch.ops.testlib.foo.default, x = cos, z = cos_1);  cos = cos_1 = None
     getitem_3 = auto_functionalized[3];  auto_functionalized = None
     cos_2 = torch.ops.aten.cos.default(getitem_3);  getitem_3 = None
@@ -3923,9 +3928,84 @@ def forward(self, arg0_1):
 
         ep = torch.export._trace._export(M(), inps, pre_dispatch=True)
         self.assertExpectedInline(str(ep.graph_module.code.strip()), """\
-def forward(self, arg0_1):
-    foo_functional = torch.ops.testlib.foo_functional.default(arg0_1);  arg0_1 = None
+def forward(self, x):
+    foo_functional = torch.ops.testlib.foo_functional.default(x);  x = None
     return (foo_functional,)""")
+
+    # original input names aren't retraceable:
+    # compilation will succeed, but names won't match forward() signature.
+    @testing.expectedFailureRetraceability
+    def test_placeholder_naming_collisions(self):
+        # test collisions between nested user inputs
+        class Foo(torch.nn.Module):
+            def forward(self, x, x_foo, x_foo_0):
+                return x['foo'][0] + x_foo[0] + x_foo_0
+
+        inputs = (
+            {'foo': [torch.randn(4, 4)]},
+            (torch.randn(4, 4), ),
+            torch.randn(4, 4),
+        )
+        ep = export(Foo(), inputs)
+        expected_names = [
+            "x_foo_0",
+            "x_foo_0_1",
+            "x_foo_0_2"
+        ]
+        real_names = [spec.arg.name for spec in ep.graph_signature.input_specs]
+        self.assertEqual(expected_names, real_names)
+
+        # test collisions between user inputs and params, buffers, constants
+        class Foo(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.param = torch.nn.Parameter(torch.randn(4))
+                self.register_buffer('alpha', torch.randn(4), persistent=True)
+                self.register_buffer('beta', torch.randn(4), persistent=False)
+                self.gamma = torch.randn(4)
+            def forward(self, p, b_alpha, b, c_gamma):
+                p = p['param'] + self.param
+                b = self.alpha + self.beta + b_alpha + b['beta']
+                c = self.gamma + c_gamma
+                return p, b, c
+
+        inputs = (
+            {"param": torch.randn(4)},
+            torch.randn(4),
+            {"beta": torch.randn(4)},
+            torch.randn(4),
+        )
+        ep = export(Foo(), inputs)
+        expected_names = [  # user inputs should be prioritized, unprefixed
+            ('p_param_1', InputKind.PARAMETER),
+            ('b_alpha_1', InputKind.BUFFER),
+            ('b_beta_1', InputKind.BUFFER),
+            ('c_gamma_1', InputKind.CONSTANT_TENSOR),
+            ('p_param', InputKind.USER_INPUT),
+            ('b_alpha', InputKind.USER_INPUT),
+            ('b_beta', InputKind.USER_INPUT),
+            ('c_gamma', InputKind.USER_INPUT)
+        ]
+        real_names = [(spec.arg.name, spec.kind) for spec in ep.graph_signature.input_specs]
+        self.assertEqual(expected_names, real_names)
+
+        # test collisions between user inputs & call_function nodes
+        class Foo(torch.nn.Module):
+            def forward(self, mul, add, add_1):
+                return mul * mul + add * add_1
+
+        ep = export(Foo(), (torch.randn(4, 4), torch.randn(4, 4), torch.randn(4, 4)))
+        expected_names_and_ops = [
+            ("mul", "placeholder"),
+            ("add", "placeholder"),
+            ("add_1", "placeholder"),
+            ("mul_1", "call_function"),
+            ("mul_2", "call_function"),
+            ("add_2", "call_function"),
+            ("output", "output"),
+        ]
+        real_names_and_ops = [(node.name, node.op) for node in ep.graph.nodes]
+        self.assertEqual(expected_names_and_ops, real_names_and_ops)
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
 class TestOneOffModelExportResult(TestCase):
@@ -3997,8 +4077,8 @@ class TestOneOffModelExportResult(TestCase):
 
         ep = torch.export.export(ScaledDotProductAttention(), (q, k, v))
         self.assertExpectedInline(ep.graph_module.code.strip(), """\
-def forward(self, arg0_1, arg1_1, arg2_1):
-    _scaled_dot_product_flash_attention = torch.ops.aten._scaled_dot_product_flash_attention.default(arg0_1, arg1_1, arg2_1, 0.0, True, scale = 0.125);  arg0_1 = arg1_1 = arg2_1 = None
+def forward(self, q, k, v):
+    _scaled_dot_product_flash_attention = torch.ops.aten._scaled_dot_product_flash_attention.default(q, k, v, 0.0, True, scale = 0.125);  q = k = v = None
     getitem = _scaled_dot_product_flash_attention[0];  _scaled_dot_product_flash_attention = None
     return (getitem,)""")
 
@@ -4124,8 +4204,8 @@ def forward(self, arg0_1, arg1_1, arg2_1):
         self.assertExpectedInline(
             gm.code.strip(),
             """\
-def forward(self, arg0_1):
-    add = torch.ops.aten.add.Tensor(arg0_1, arg0_1);  arg0_1 = None
+def forward(self, x):
+    add = torch.ops.aten.add.Tensor(x, x);  x = None
     mul = torch.ops.aten.mul.Tensor(add, add)
     add_1 = torch.ops.aten.add.Tensor(mul, mul);  mul = None
     return (add, add_1)""",
@@ -4143,8 +4223,8 @@ def forward(self, arg0_1):
         self.assertExpectedInline(
             gm.code.strip(),
             """\
-def forward(self, arg0_1):
-    add = torch.ops.aten.add.Tensor(arg0_1, arg0_1);  arg0_1 = None
+def forward(self, x):
+    add = torch.ops.aten.add.Tensor(x, x);  x = None
     return (add,)""",
         )
 
@@ -4212,8 +4292,8 @@ def forward(self, arg0_1):
         self.assertEqual(len(placeholders), 5)
         self.assertTrue(all(ph.name == ph.target for ph in placeholders))
         # suffix should be added to duplicated constant_name
-        self.assertEqual(placeholders[2].name, "constant")
-        self.assertEqual(placeholders[3].name, "constant_1")
+        self.assertEqual(placeholders[2].name, "c_nested_1_constant")
+        self.assertEqual(placeholders[3].name, "c_nested_2_constant")
 
     def test_nested_retrace(self):
         class Nested(torch.nn.Module):

--- a/test/export/test_lift_unlift.py
+++ b/test/export/test_lift_unlift.py
@@ -115,9 +115,11 @@ class GraphBuilder:
                         kind=self.input_to_kind[node],
                         arg=TensorArgument(name=node.name),
                         target=None,
-                        persistent=True
-                        if self.input_to_kind[node] == InputKind.BUFFER
-                        else None,
+                        persistent=(
+                            True
+                            if self.input_to_kind[node] == InputKind.BUFFER
+                            else None
+                        ),
                     )
                 )
         return input_specs
@@ -197,10 +199,10 @@ class TestLift(TestCase):
         # is at the root submodule.
         # TODO(suo): we shouldn't hardcode these names in the test, this is an
         # internal detail of the pass.
-        self.assertIn("_lifted_tensor_constant0", constants)
-        self.assertEqual(constants["_lifted_tensor_constant0"], const_tensor)
-        self.assertIn("_lifted_custom_obj0", constants)
-        self.assertEqual(constants["_lifted_custom_obj0"], const_obj)
+        self.assertIn("lifted_tensor_0", constants)
+        self.assertEqual(constants["lifted_tensor_0"], const_tensor)
+        self.assertIn("lifted_custom_0", constants)
+        self.assertEqual(constants["lifted_custom_0"], const_obj)
 
         # The constant node should be removed.
         getattr_nodes = [n for n in gm.graph.nodes if n.op == "get_attr"]
@@ -212,17 +214,17 @@ class TestLift(TestCase):
 
         # The lifted constant should be placed before user inputs but after params/buffers
         lifted_tensor_placeholder = placeholder_nodes[2]
-        self.assertEqual(lifted_tensor_placeholder.target, "_lifted_tensor_constant0")
+        self.assertEqual(lifted_tensor_placeholder.target, "lifted_tensor_0")
         # It should have a val equivalent to the constant
         self.assertEqual(lifted_tensor_placeholder.meta["val"], const_tensor)
 
         lifted_obj_placeholder = placeholder_nodes[3]
-        self.assertEqual(lifted_obj_placeholder.target, "_lifted_custom_obj0")
+        self.assertEqual(lifted_obj_placeholder.target, "lifted_custom_0")
         # It should have a val equivalent to the constant
         self.assertEqual(
             lifted_obj_placeholder.meta["val"],
             CustomObjArgument(
-                name="_lifted_custom_obj0",
+                name="lifted_custom_0",
                 class_fqn="__torch__.torch.classes._TorchScriptTesting._Foo",
             ),
         )
@@ -267,8 +269,8 @@ class TestLift(TestCase):
         self.assertEqual(len(constants), 1)
 
         # The key of the constants table should match the fqn of the constant.
-        self.assertIn("foo._lifted_tensor_constant0", constants)
-        self.assertEqual(constants["foo._lifted_tensor_constant0"], const_tensor)
+        self.assertIn("foo.lifted_tensor_0", constants)
+        self.assertEqual(constants["foo.lifted_tensor_0"], const_tensor)
 
         # The constant node should be removed.
         getattr_nodes = [n for n in gm.graph.nodes if n.op == "get_attr"]
@@ -280,7 +282,7 @@ class TestLift(TestCase):
 
         # The lifted constant should be placed before user inputs but after params/buffers
         lifted_constant_placeholder = placeholder_nodes[0]
-        self.assertEqual(lifted_constant_placeholder.target, "_lifted_tensor_constant0")
+        self.assertEqual(lifted_constant_placeholder.target, "lifted_tensor_0")
 
         # Graph signature should have been mutated a way that reflects the placeholders.
         constant_input_spec = graph_signature.input_specs[0]

--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -540,8 +540,8 @@ class TestPasses(TestCase):
         mod, args = self.SET_GRAD_ENABLED_TESTS["op"]
         self.assertExpectedInline(mod.code.strip("\n"), """\
 def forward(self, arg_0):
-    arg0_1, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
-    add = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
+    x, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
+    add = torch.ops.aten.add.Tensor(x, 1);  x = None
     sin = torch.ops.aten.sin.default(add);  add = None
     sum_1 = torch.ops.aten.sum.default(sin);  sin = None
     submod_4 = self.submod_2
@@ -552,8 +552,8 @@ def forward(self, arg_0):
         mod, args = self.SET_GRAD_ENABLED_TESTS["op_under_no_grad"]
         self.assertExpectedInline(mod.code.strip("\n"), """\
 def forward(self, arg_0):
-    arg0_1, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
-    add = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
+    x, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
+    add = torch.ops.aten.add.Tensor(x, 1);  x = None
     sin = torch.ops.aten.sin.default(add);  add = None
     sum_1 = torch.ops.aten.sum.default(sin);  sin = None
     submod_4 = self.submod_2
@@ -565,8 +565,8 @@ def forward(self, arg_0):
         mod, args = self.SET_GRAD_ENABLED_TESTS["ctx_manager"]
         self.assertExpectedInline(mod.code.strip("\n"), """\
 def forward(self, arg_0):
-    arg0_1, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
-    add = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
+    x, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
+    add = torch.ops.aten.add.Tensor(x, 1);  x = None
     sin = torch.ops.aten.sin.default(add);  add = None
     sum_1 = torch.ops.aten.sum.default(sin);  sin = None
     submod_3 = self.submod_1
@@ -577,8 +577,8 @@ def forward(self, arg_0):
         mod, args = self.SET_GRAD_ENABLED_TESTS["ctx_manager_under_no_grad"]
         self.assertExpectedInline(mod.code.strip("\n"), """\
 def forward(self, arg_0):
-    arg0_1, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
-    add = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
+    x, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
+    add = torch.ops.aten.add.Tensor(x, 1);  x = None
     submod_5 = self.submod_1
     sum_1 = torch._higher_order_ops.wrap.wrap_with_set_grad_enabled(True, submod_5, add);  submod_5 = add = None
     add_1 = torch.ops.aten.add.Tensor(sum_1, 1);  sum_1 = None
@@ -589,8 +589,8 @@ def forward(self, arg_0):
         mod, args = self.SET_GRAD_ENABLED_TESTS["ctx_manager_multi_dep"]
         self.assertExpectedInline(mod.code.strip("\n"), """\
 def forward(self, arg_0):
-    arg0_1, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
-    add = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
+    x, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
+    add = torch.ops.aten.add.Tensor(x, 1);  x = None
     sin = torch.ops.aten.sin.default(add)
     sum_1 = torch.ops.aten.sum.default(sin);  sin = None
     cos = torch.ops.aten.cos.default(add);  add = None
@@ -606,8 +606,8 @@ def forward(self, arg_0):
         mod, args = self.SET_GRAD_ENABLED_TESTS["ctx_manager_multi_dep_no_grad"]
         self.assertExpectedInline(mod.code.strip("\n"), """\
 def forward(self, arg_0):
-    arg0_1, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
-    add = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
+    x, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
+    add = torch.ops.aten.add.Tensor(x, 1);  x = None
     submod_5 = self.submod_1
     wrap_with_set_grad_enabled = torch._higher_order_ops.wrap.wrap_with_set_grad_enabled(True, submod_5, add);  submod_5 = add = None
     sum_1 = wrap_with_set_grad_enabled[0]
@@ -636,8 +636,8 @@ def forward(self, arg_0):
         self.assertEqual(gm(*args), new_gm(*args))
         self.assertExpectedInline(new_gm.code.strip("\n"), """\
 def forward(self, arg_0, arg_1):
-    arg0_1, arg1_1, = fx_pytree.tree_flatten_spec(([arg_0, arg_1], {}), self._in_spec)
-    submod_1 = self.submod_1(arg0_1, arg1_1);  arg0_1 = arg1_1 = None
+    x1, x2, = fx_pytree.tree_flatten_spec(([arg_0, arg_1], {}), self._in_spec)
+    submod_1 = self.submod_1(x1, x2);  x1 = x2 = None
     getitem = submod_1[0]
     getitem_1 = submod_1[1];  submod_1 = None
     submod_2 = self.submod_2(getitem, getitem_1);  getitem = getitem_1 = None
@@ -652,10 +652,10 @@ def forward(self, arg_0, arg_1):
     return pytree.tree_unflatten((getitem_4, getitem_5, getitem_6, getitem_7), self._out_spec)
     """)
         self.assertExpectedInline(new_gm.submod_1.code.strip("\n"), """\
-def forward(self, arg0_1, arg1_1):
+def forward(self, x1, x2):
     _set_grad_enabled = torch._C._set_grad_enabled(True)
-    add = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
-    add_1 = torch.ops.aten.add.Tensor(arg1_1, 1);  arg1_1 = None
+    add = torch.ops.aten.add.Tensor(x1, 1);  x1 = None
+    add_1 = torch.ops.aten.add.Tensor(x2, 1);  x2 = None
     return (add, add_1)
     """)
         self.assertExpectedInline(new_gm.submod_2.code.strip("\n"), """\
@@ -768,7 +768,7 @@ def forward(self, sin, cos):
             self.assertEqual(getitems, 2)  # tuple return of len 2
 
             out_specs = inplace_ep.graph_signature.output_specs
-            self.assertEqual(out_specs[0].arg.name, "arg0_1")  # state
+            self.assertEqual(out_specs[0].arg.name, "b_state")  # state
             self.assertEqual(out_specs[1].arg.name, "getitem")  # tuple return 1
             self.assertEqual(out_specs[2].arg.name, "getitem_1")  # tuple return 2
 

--- a/test/export/test_torchbind.py
+++ b/test/export/test_torchbind.py
@@ -152,18 +152,18 @@ class TestExportTorchbind(TestCase):
             ep.module().code.strip(),
             """\
 def forward(self, arg_0, arg_1):
-    arg0_1, arg1_1, = fx_pytree.tree_flatten_spec(([arg_0, arg_1], {}), self._in_spec)
-    attr_1 = self.attr
-    call_torchbind = torch.ops.higher_order.call_torchbind(attr_1, 'add_tensor', arg0_1);  attr_1 = None
-    add = torch.ops.aten.add.Tensor(arg0_1, call_torchbind);  arg0_1 = call_torchbind = None
+    x, arg1_1, = fx_pytree.tree_flatten_spec(([arg_0, arg_1], {}), self._in_spec)
+    attr = self.attr
+    call_torchbind = torch.ops.higher_order.call_torchbind(attr, 'add_tensor', x);  attr = None
+    add = torch.ops.aten.add.Tensor(x, call_torchbind);  x = call_torchbind = None
     return pytree.tree_unflatten((add,), self._out_spec)""",
         )
         self.assertExpectedInline(
             ep.graph_module.code.strip(),
             """\
-def forward(self, attr, arg0_1, arg1_1):
-    call_torchbind = torch.ops.higher_order.call_torchbind(attr, 'add_tensor', arg0_1);  attr = None
-    add = torch.ops.aten.add.Tensor(arg0_1, call_torchbind);  arg0_1 = call_torchbind = None
+def forward(self, obj_attr, x, arg1_1):
+    call_torchbind = torch.ops.higher_order.call_torchbind(obj_attr, 'add_tensor', x);  obj_attr = None
+    add = torch.ops.aten.add.Tensor(x, call_torchbind);  x = call_torchbind = None
     return (add,)""",
         )
 
@@ -184,18 +184,18 @@ def forward(self, attr, arg0_1, arg1_1):
             ep.module().code.strip(),
             """\
 def forward(self, arg_0):
-    arg0_1, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
-    attr_1 = self.attr
-    call_torchbind = torch.ops.higher_order.call_torchbind(attr_1, 'add_tensor', arg0_1);  attr_1 = None
-    add = torch.ops.aten.add.Tensor(arg0_1, call_torchbind);  arg0_1 = call_torchbind = None
+    x, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
+    attr = self.attr
+    call_torchbind = torch.ops.higher_order.call_torchbind(attr, 'add_tensor', x);  attr = None
+    add = torch.ops.aten.add.Tensor(x, call_torchbind);  x = call_torchbind = None
     return pytree.tree_unflatten((add,), self._out_spec)""",
         )
         self.assertExpectedInline(
             ep.graph_module.code.strip(),
             """\
-def forward(self, attr, arg0_1):
-    call_torchbind = torch.ops.higher_order.call_torchbind(attr, 'add_tensor', arg0_1);  attr = None
-    add = torch.ops.aten.add.Tensor(arg0_1, call_torchbind);  arg0_1 = call_torchbind = None
+def forward(self, obj_attr, x):
+    call_torchbind = torch.ops.higher_order.call_torchbind(obj_attr, 'add_tensor', x);  obj_attr = None
+    add = torch.ops.aten.add.Tensor(x, call_torchbind);  x = call_torchbind = None
     return (add,)""",
         )
 
@@ -216,20 +216,20 @@ def forward(self, attr, arg0_1):
             ep.module().code.strip(),
             """\
 def forward(self, arg_0):
-    arg1_1, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
-    attr_1 = self.attr
-    takes_foo_default = torch.ops._TorchScriptTesting.takes_foo.default(attr_1, arg1_1);  attr_1 = None
-    add = torch.ops.aten.add.Tensor(arg1_1, takes_foo_default);  arg1_1 = takes_foo_default = None
+    x, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
+    attr = self.attr
+    takes_foo_default = torch.ops._TorchScriptTesting.takes_foo.default(attr, x);  attr = None
+    add = torch.ops.aten.add.Tensor(x, takes_foo_default);  x = takes_foo_default = None
     return pytree.tree_unflatten((add,), self._out_spec)""",
         )
         self.assertExpectedInline(
             ep.graph_module.code.strip(),
             """\
-def forward(self, arg0_1, attr, arg1_1):
-    with_effects = torch._higher_order_ops.effects.with_effects(arg0_1, torch.ops._TorchScriptTesting.takes_foo.default, attr, arg1_1);  arg0_1 = attr = None
+def forward(self, token, obj_attr, x):
+    with_effects = torch._higher_order_ops.effects.with_effects(token, torch.ops._TorchScriptTesting.takes_foo.default, obj_attr, x);  token = obj_attr = None
     getitem = with_effects[0]
     getitem_1 = with_effects[1];  with_effects = None
-    add = torch.ops.aten.add.Tensor(arg1_1, getitem_1);  arg1_1 = getitem_1 = None
+    add = torch.ops.aten.add.Tensor(x, getitem_1);  x = getitem_1 = None
     return (getitem, add)""",  # noqa: B950
         )
 
@@ -250,17 +250,17 @@ def forward(self, arg0_1, attr, arg1_1):
             ep.module().code.strip(),
             """\
 def forward(self, arg_0, arg_1):
-    arg0_1, arg1_1, = fx_pytree.tree_flatten_spec(([arg_0, arg_1], {}), self._in_spec)
-    call_torchbind = torch.ops.higher_order.call_torchbind(arg1_1, 'add_tensor', arg0_1);  arg1_1 = None
-    add = torch.ops.aten.add.Tensor(arg0_1, call_torchbind);  arg0_1 = call_torchbind = None
+    x, cc, = fx_pytree.tree_flatten_spec(([arg_0, arg_1], {}), self._in_spec)
+    call_torchbind = torch.ops.higher_order.call_torchbind(cc, 'add_tensor', x);  cc = None
+    add = torch.ops.aten.add.Tensor(x, call_torchbind);  x = call_torchbind = None
     return pytree.tree_unflatten((add,), self._out_spec)""",
         )
         self.assertExpectedInline(
             ep.graph_module.code.strip(),
             """\
-def forward(self, arg0_1, arg1_1):
-    call_torchbind = torch.ops.higher_order.call_torchbind(arg1_1, 'add_tensor', arg0_1);  arg1_1 = None
-    add = torch.ops.aten.add.Tensor(arg0_1, call_torchbind);  arg0_1 = call_torchbind = None
+def forward(self, x, cc):
+    call_torchbind = torch.ops.higher_order.call_torchbind(cc, 'add_tensor', x);  cc = None
+    add = torch.ops.aten.add.Tensor(x, call_torchbind);  x = call_torchbind = None
     return (add,)""",
         )
 
@@ -281,19 +281,19 @@ def forward(self, arg0_1, arg1_1):
             ep.module().code.strip(),
             """\
 def forward(self, arg_0, arg_1):
-    arg1_1, arg2_1, = fx_pytree.tree_flatten_spec(([arg_0, arg_1], {}), self._in_spec)
-    takes_foo_default = torch.ops._TorchScriptTesting.takes_foo.default(arg2_1, arg1_1);  arg2_1 = None
-    add = torch.ops.aten.add.Tensor(arg1_1, takes_foo_default);  arg1_1 = takes_foo_default = None
+    x, cc, = fx_pytree.tree_flatten_spec(([arg_0, arg_1], {}), self._in_spec)
+    takes_foo_default = torch.ops._TorchScriptTesting.takes_foo.default(cc, x);  cc = None
+    add = torch.ops.aten.add.Tensor(x, takes_foo_default);  x = takes_foo_default = None
     return pytree.tree_unflatten((add,), self._out_spec)""",
         )
         self.assertExpectedInline(
             ep.graph_module.code.strip(),
             """\
-def forward(self, arg0_1, arg1_1, arg2_1):
-    with_effects = torch._higher_order_ops.effects.with_effects(arg0_1, torch.ops._TorchScriptTesting.takes_foo.default, arg2_1, arg1_1);  arg0_1 = arg2_1 = None
+def forward(self, token, x, cc):
+    with_effects = torch._higher_order_ops.effects.with_effects(token, torch.ops._TorchScriptTesting.takes_foo.default, cc, x);  token = cc = None
     getitem = with_effects[0]
     getitem_1 = with_effects[1];  with_effects = None
-    add = torch.ops.aten.add.Tensor(arg1_1, getitem_1);  arg1_1 = getitem_1 = None
+    add = torch.ops.aten.add.Tensor(x, getitem_1);  x = getitem_1 = None
     return (getitem, add)""",  # noqa: B950
         )
 
@@ -317,24 +317,24 @@ def forward(self, arg0_1, arg1_1, arg2_1):
             ep.module().code.strip(),
             """\
 def forward(self, arg_0):
-    arg1_1, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
-    attr_1 = self.attr
-    takes_foo_default_1 = torch.ops._TorchScriptTesting.takes_foo.default(attr_1, arg1_1)
-    takes_foo_default = torch.ops._TorchScriptTesting.takes_foo.default(attr_1, takes_foo_default_1);  attr_1 = takes_foo_default_1 = None
-    add = torch.ops.aten.add.Tensor(arg1_1, takes_foo_default);  arg1_1 = takes_foo_default = None
+    x, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
+    attr = self.attr
+    takes_foo_default_1 = torch.ops._TorchScriptTesting.takes_foo.default(attr, x)
+    takes_foo_default = torch.ops._TorchScriptTesting.takes_foo.default(attr, takes_foo_default_1);  attr = takes_foo_default_1 = None
+    add = torch.ops.aten.add.Tensor(x, takes_foo_default);  x = takes_foo_default = None
     return pytree.tree_unflatten((add,), self._out_spec)""",  # noqa: B950
         )
         self.assertExpectedInline(
             ep.graph_module.code.strip(),
             """\
-def forward(self, arg0_1, attr, arg1_1):
-    with_effects = torch._higher_order_ops.effects.with_effects(arg0_1, torch.ops._TorchScriptTesting.takes_foo.default, attr, arg1_1);  arg0_1 = None
+def forward(self, token, obj_attr, x):
+    with_effects = torch._higher_order_ops.effects.with_effects(token, torch.ops._TorchScriptTesting.takes_foo.default, obj_attr, x);  token = None
     getitem = with_effects[0]
     getitem_1 = with_effects[1];  with_effects = None
-    with_effects_1 = torch._higher_order_ops.effects.with_effects(getitem, torch.ops._TorchScriptTesting.takes_foo.default, attr, getitem_1);  getitem = attr = getitem_1 = None
+    with_effects_1 = torch._higher_order_ops.effects.with_effects(getitem, torch.ops._TorchScriptTesting.takes_foo.default, obj_attr, getitem_1);  getitem = obj_attr = getitem_1 = None
     getitem_2 = with_effects_1[0]
     getitem_3 = with_effects_1[1];  with_effects_1 = None
-    add = torch.ops.aten.add.Tensor(arg1_1, getitem_3);  arg1_1 = getitem_3 = None
+    add = torch.ops.aten.add.Tensor(x, getitem_3);  x = getitem_3 = None
     return (getitem_2, add)""",  # noqa: B950
         )
 
@@ -359,23 +359,23 @@ def forward(self, arg0_1, attr, arg1_1):
             ep.module().code.strip(),
             """\
 def forward(self, arg_0):
-    arg1_1, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
-    attr_1 = self.attr
-    takes_foo_list_return_default = torch.ops._TorchScriptTesting.takes_foo_list_return.default(attr_1, arg1_1)
+    x, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
+    attr = self.attr
+    takes_foo_list_return_default = torch.ops._TorchScriptTesting.takes_foo_list_return.default(attr, x)
     getitem_2 = takes_foo_list_return_default[0]
     getitem_3 = takes_foo_list_return_default[1]
     getitem_4 = takes_foo_list_return_default[2];  takes_foo_list_return_default = None
     add = torch.ops.aten.add.Tensor(getitem_2, getitem_3);  getitem_2 = getitem_3 = None
     add_1 = torch.ops.aten.add.Tensor(add, getitem_4);  add = getitem_4 = None
-    takes_foo_default = torch.ops._TorchScriptTesting.takes_foo.default(attr_1, add_1);  attr_1 = add_1 = None
-    add_2 = torch.ops.aten.add.Tensor(arg1_1, takes_foo_default);  arg1_1 = takes_foo_default = None
+    takes_foo_default = torch.ops._TorchScriptTesting.takes_foo.default(attr, add_1);  attr = add_1 = None
+    add_2 = torch.ops.aten.add.Tensor(x, takes_foo_default);  x = takes_foo_default = None
     return pytree.tree_unflatten((add_2,), self._out_spec)""",
         )
         self.assertExpectedInline(
             ep.graph_module.code.strip(),
             """\
-def forward(self, arg0_1, attr, arg1_1):
-    with_effects = torch._higher_order_ops.effects.with_effects(arg0_1, torch.ops._TorchScriptTesting.takes_foo_list_return.default, attr, arg1_1);  arg0_1 = None
+def forward(self, token, obj_attr, x):
+    with_effects = torch._higher_order_ops.effects.with_effects(token, torch.ops._TorchScriptTesting.takes_foo_list_return.default, obj_attr, x);  token = None
     getitem = with_effects[0]
     getitem_1 = with_effects[1];  with_effects = None
     getitem_2 = getitem_1[0]
@@ -383,10 +383,10 @@ def forward(self, arg0_1, attr, arg1_1):
     getitem_4 = getitem_1[2];  getitem_1 = None
     add = torch.ops.aten.add.Tensor(getitem_2, getitem_3);  getitem_2 = getitem_3 = None
     add_1 = torch.ops.aten.add.Tensor(add, getitem_4);  add = getitem_4 = None
-    with_effects_1 = torch._higher_order_ops.effects.with_effects(getitem, torch.ops._TorchScriptTesting.takes_foo.default, attr, add_1);  getitem = attr = add_1 = None
+    with_effects_1 = torch._higher_order_ops.effects.with_effects(getitem, torch.ops._TorchScriptTesting.takes_foo.default, obj_attr, add_1);  getitem = obj_attr = add_1 = None
     getitem_5 = with_effects_1[0]
     getitem_6 = with_effects_1[1];  with_effects_1 = None
-    add_2 = torch.ops.aten.add.Tensor(arg1_1, getitem_6);  arg1_1 = getitem_6 = None
+    add_2 = torch.ops.aten.add.Tensor(x, getitem_6);  x = getitem_6 = None
     return (getitem_5, add_2)""",  # noqa: B950
         )
 
@@ -411,29 +411,29 @@ def forward(self, arg0_1, attr, arg1_1):
             ep.module().code.strip(),
             """\
 def forward(self, arg_0):
-    arg1_1, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
-    attr_1 = self.attr
-    takes_foo_tuple_return_default = torch.ops._TorchScriptTesting.takes_foo_tuple_return.default(attr_1, arg1_1)
+    x, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
+    attr = self.attr
+    takes_foo_tuple_return_default = torch.ops._TorchScriptTesting.takes_foo_tuple_return.default(attr, x)
     getitem_1 = takes_foo_tuple_return_default[0]
     getitem_2 = takes_foo_tuple_return_default[1];  takes_foo_tuple_return_default = None
     add = torch.ops.aten.add.Tensor(getitem_1, getitem_2);  getitem_1 = getitem_2 = None
-    takes_foo_default = torch.ops._TorchScriptTesting.takes_foo.default(attr_1, add);  attr_1 = add = None
-    add_1 = torch.ops.aten.add.Tensor(arg1_1, takes_foo_default);  arg1_1 = takes_foo_default = None
+    takes_foo_default = torch.ops._TorchScriptTesting.takes_foo.default(attr, add);  attr = add = None
+    add_1 = torch.ops.aten.add.Tensor(x, takes_foo_default);  x = takes_foo_default = None
     return pytree.tree_unflatten((add_1,), self._out_spec)""",
         )
         self.assertExpectedInline(
             ep.graph_module.code.strip(),
             """\
-def forward(self, arg0_1, attr, arg1_1):
-    with_effects = torch._higher_order_ops.effects.with_effects(arg0_1, torch.ops._TorchScriptTesting.takes_foo_tuple_return.default, attr, arg1_1);  arg0_1 = None
+def forward(self, token, obj_attr, x):
+    with_effects = torch._higher_order_ops.effects.with_effects(token, torch.ops._TorchScriptTesting.takes_foo_tuple_return.default, obj_attr, x);  token = None
     getitem = with_effects[0]
     getitem_1 = with_effects[1]
     getitem_2 = with_effects[2];  with_effects = None
     add = torch.ops.aten.add.Tensor(getitem_1, getitem_2);  getitem_1 = getitem_2 = None
-    with_effects_1 = torch._higher_order_ops.effects.with_effects(getitem, torch.ops._TorchScriptTesting.takes_foo.default, attr, add);  getitem = attr = add = None
+    with_effects_1 = torch._higher_order_ops.effects.with_effects(getitem, torch.ops._TorchScriptTesting.takes_foo.default, obj_attr, add);  getitem = obj_attr = add = None
     getitem_3 = with_effects_1[0]
     getitem_4 = with_effects_1[1];  with_effects_1 = None
-    add_1 = torch.ops.aten.add.Tensor(arg1_1, getitem_4);  arg1_1 = getitem_4 = None
+    add_1 = torch.ops.aten.add.Tensor(x, getitem_4);  x = getitem_4 = None
     return (getitem_3, add_1)""",  # noqa: B950
         )
 

--- a/test/export/test_verifier.py
+++ b/test/export/test_verifier.py
@@ -128,7 +128,7 @@ class TestVerifier(TestCase):
         # Parameter doesn't exist in the state dict
         ep.graph_signature.input_specs[0] = InputSpec(
             kind=InputKind.PARAMETER,
-            arg=TensorArgument(name="arg0_1"),
+            arg=TensorArgument(name="p_a"),
             target="bad_param"
         )
         with self.assertRaisesRegex(SpecViolationError, "not in the state dict"):
@@ -155,7 +155,7 @@ class TestVerifier(TestCase):
         # Buffer doesn't exist in the state dict
         ep.graph_signature.input_specs[0] = InputSpec(
             kind=InputKind.BUFFER,
-            arg=TensorArgument(name="arg0_1"),
+            arg=TensorArgument(name="c_a"),
             target="bad_buffer",
             persistent=True,
         )

--- a/torch/_export/passes/lift_constants_pass.py
+++ b/torch/_export/passes/lift_constants_pass.py
@@ -148,18 +148,18 @@ def lift_constants_pass(
                 constant_kind = InputKind.CUSTOM_OBJ
                 constant_fqn = constant_attrs.get(constant_val)
                 if constant_fqn is not None:
-                    _, _, constant_name = constant_fqn.rpartition(".")
+                    constant_name = constant_fqn.replace(".", "_")
                 else:
-                    constant_name = f"_lifted_custom_obj{num_custom_obj}"
+                    constant_name = f"lifted_custom_{num_custom_obj}"
                     constant_fqn = get_constant_fqn(node, constant_name)
                     num_custom_obj += 1
             elif isinstance(constant_val, torch.Tensor):
                 constant_kind = InputKind.CONSTANT_TENSOR
                 constant_fqn = constant_attrs.get(constant_val)
                 if constant_fqn is not None:
-                    _, _, constant_name = constant_fqn.rpartition(".")
+                    constant_name = constant_fqn.replace(".", "_")
                 else:
-                    constant_name = f"_lifted_tensor_constant{num_tensor_constants}"
+                    constant_name = f"lifted_tensor_{num_tensor_constants}"
                     constant_fqn = get_constant_fqn(node, constant_name)
                     num_tensor_constants += 1
             elif isinstance(constant_val, torch.fx.GraphModule):

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -1474,6 +1474,9 @@ class GraphModuleDeserializer:
             if input_.type in ("as_tensor", "as_sym_int", "as_custom_obj"):
                 node_name = input_.value.name
                 placeholder_node = self.graph.placeholder(node_name)
+                # FX might declare a name illegal (e.g. some nn.Modules use "input" as forward() arguments)
+                # we will overwrite it
+                placeholder_node.name = node_name
                 self.sync_fx_node(node_name, placeholder_node)
             elif input_.type in (
                 "as_int",

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -1,24 +1,39 @@
 import dataclasses
+import inspect
 import math
 import operator
+import re
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Type
 
 import torch
 from torch._subclasses.fake_tensor import FakeTensor
 
 from torch.export import ExportedProgram
+from torch.export.exported_program import _rename_without_collisions
+from torch.export.graph_signature import ConstantArgument, InputKind, OutputKind
 from torch.utils._pytree import (
     _register_pytree_node,
     Context,
     FlattenFunc,
     FromDumpableContextFn,
+    GetAttrKey,
     KeyPath,
     keystr,
     MappingKey,
     SequenceKey,
     ToDumpableContextFn,
+    tree_flatten_with_path,
     UnflattenFunc,
 )
+
+placeholder_prefixes = {
+    InputKind.USER_INPUT: "",
+    InputKind.PARAMETER: "p_",
+    InputKind.BUFFER: "b_",
+    InputKind.CONSTANT_TENSOR: "c_",
+    InputKind.CUSTOM_OBJ: "obj_",
+    InputKind.TOKEN: "token",
+}
 
 
 def _check_input_constraints_for_graph(
@@ -168,6 +183,10 @@ def register_dataclass_as_pytree_node(
         flat_names, none_names = context
         return cls(**dict(zip(flat_names, values)), **dict.fromkeys(none_names))
 
+    def default_flatten_fn_with_keys(obj: Any) -> Tuple[List[Any], Context]:
+        flattened, (flat_names, none_names) = flatten_fn(obj)  # type: ignore[misc]
+        return [(MappingKey(k), v) for k, v in zip(flat_names, flattened)], flat_names
+
     flatten_fn = flatten_fn if flatten_fn is not None else default_flatten_fn
     unflatten_fn = unflatten_fn if unflatten_fn is not None else default_unflatten_fn
 
@@ -182,6 +201,7 @@ def register_dataclass_as_pytree_node(
         flatten_fn,
         unflatten_fn,
         serialized_type_name=serialized_type_name,
+        flatten_with_keys_fn=default_flatten_fn_with_keys,
         to_dumpable_context=to_dumpable_context,
         from_dumpable_context=from_dumpable_context,
     )
@@ -399,3 +419,147 @@ def node_inline_(call_mod_node: torch.fx.Node) -> None:
     gm.delete_all_unused_submodules()
     gm.recompile()
     return gm
+
+
+def placeholder_naming_pass(
+    gm: torch.fx.GraphModule,
+    export_graph_signature: torch.export.ExportGraphSignature,
+    mod: torch.nn.Module,
+    fake_args,
+    fake_kwargs,
+    fake_params_buffers,
+    constants: Dict[str, Any],
+) -> None:
+    """
+    This pass is run at the end of _export_non_strict() to assign better placeholder node names:
+        - User inputs:
+            These follow the signature of mod.forward(), e.g. forward(x, y) produces nodes x, y.
+            For nested inputs from dictionaries, lists, tuples, or dataclasses,
+            the names are a concatenation of the path to the tensor.
+                e.g. x = {
+                    'a': torch.randn(),
+                    'b': [torch.randn(), torch.randn()]
+                }
+            produces nodes x_a, x_b_0, x_b_1.
+        - Parameters/buffers/constants/custom objects:
+            These follow the FQN of the object, prefixed by "p", "b", "c", "obj" respectively.
+                e.g. self.bar.l0.weight produces "p_bar_l0_weight".
+        - Effect tokens:
+            These are named token, token_1, ...
+    """
+
+    def _strip_name(x):
+        if x.startswith("L__self___"):
+            x = x[len("L__self___") :]
+        return x.replace(".", "_")
+
+    def _extract_pytree_key(x):
+        if isinstance(x, MappingKey):
+            return str(x.key).replace(".", "_")
+        elif isinstance(x, SequenceKey):
+            return str(x.idx)
+        elif isinstance(x, GetAttrKey):
+            return x.name
+        else:
+            raise RuntimeError(f"Pytree key of type {type(x)} not handled for {x}")
+
+    name_map: Dict[str, str] = {}
+
+    # map user input names with mod.forward() signature
+    combined_args = (
+        inspect.signature(mod.forward).bind(*fake_args, **fake_kwargs).arguments
+    )
+    flat_args_with_path, _ = tree_flatten_with_path(combined_args)
+    user_input_names = [
+        (None if isinstance(spec.arg, ConstantArgument) else spec.arg.name)
+        for spec in export_graph_signature.input_specs
+        if spec.kind == InputKind.USER_INPUT
+    ]
+
+    # use pytree path to name nested user inputs
+    for (arg_path, arg), user_input_name in zip(flat_args_with_path, user_input_names):
+        if user_input_name:
+            _rename_without_collisions(
+                name_map,
+                user_input_name,
+                placeholder_prefixes[InputKind.USER_INPUT]
+                + "_".join(_extract_pytree_key(x).lower() for x in arg_path),
+                is_placeholder=True,
+            )
+
+    # use graph signature input specs to map param/buffer/constant names
+    # name effect tokens as token, token_1, ... (these aren't visible to user)
+    for spec in export_graph_signature.input_specs:
+        if spec.kind == InputKind.USER_INPUT:
+            continue
+        # this should never be ConstantArgument, but avoid lint issue
+        if isinstance(spec.arg, ConstantArgument):
+            continue
+        if spec.kind == InputKind.TOKEN:
+            base_name = ""
+        else:
+            base_name = _strip_name(spec.target).lower()
+        _rename_without_collisions(
+            name_map,
+            spec.arg.name,
+            placeholder_prefixes[spec.kind] + base_name,
+            is_placeholder=True,
+        )
+
+    # handle naming collisions with call_function/get_attr inputs.
+    # here, we want to prioritize user input names over call_function names
+    # e.g. not have forward(self, mul): lead to a placeholder node called mul_13,
+    # so we increment the suffix of call_function nodes as needed
+    for node in gm.graph.nodes:
+        if node.op == "placeholder":
+            continue
+        _rename_without_collisions(name_map, node.name, node.name)
+
+    # assign new node names
+    for node in gm.graph.nodes:
+        if node.op == "placeholder":
+            if node.name in name_map:  # skip constant inputs
+                node.name = node.target = name_map[node.name]
+        elif node.name in name_map:
+            node.name = name_map[node.name]
+
+    # TODO(pianpwk), in immediate follow-up PR
+    # propagate names to higher order op subgraphs
+    # name_hoo_subgraph_placeholders(gm)
+
+    # re-generate graph module code
+    gm.recompile()
+
+    # modify graph signature (input specs, output specs, user input mutations)
+    for spec in export_graph_signature.input_specs:
+        if isinstance(spec.arg, ConstantArgument):
+            continue
+        assert spec.arg.name in name_map
+        spec.arg.name = name_map[spec.arg.name]
+        if (  # handle targets for custom objects
+            spec.kind == InputKind.CUSTOM_OBJ and spec.target in name_map
+        ):
+            spec.target = name_map[spec.target][4:]  # strip obj_ prefix
+
+    for spec in export_graph_signature.output_specs:
+        if isinstance(spec.arg, ConstantArgument):
+            continue
+        if spec.arg.name in name_map:
+            spec.arg.name = name_map[spec.arg.name]
+        if spec.kind == OutputKind.USER_INPUT_MUTATION and spec.target in name_map:
+            spec.target = name_map[spec.target]
+
+    # rename keys in constants dict for custom objects
+    for name in list(constants.keys()):
+        constant = constants[name]
+        if name in name_map and not isinstance(
+            constant, torch.Tensor
+        ):  # rename custom objects with generic names
+            new_name = name_map[name]
+            if (
+                new_name != name
+                and re.match(r"arg(\d+)_1", name)
+                and new_name != placeholder_prefixes[InputKind.CUSTOM_OBJ] + name
+            ):
+                constants[new_name] = constant
+                del constants[name]

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -28,6 +28,7 @@ from torch._export.passes.lift_constants_pass import (
     lift_constants_pass,
     rewrite_script_object_meta,
 )
+from torch._export.utils import placeholder_naming_pass, placeholder_prefixes
 from torch._export.verifier import SpecViolationError
 from torch._export.wrappers import _wrap_submodules
 from torch._functorch.aot_autograd import aot_export_module
@@ -278,6 +279,59 @@ def _remap_constants(
             constants[spec.target] = constant
 
 
+def _rename_constants_nodes(
+    gm: torch.fx.GraphModule,
+    graph_signature: ExportGraphSignature,
+) -> None:
+    """
+    For strict mode, rename constants nodes that were previously annotated as buffers.
+    """
+    # handle name collisions with existing constants
+    node_names = {node.name for node in gm.graph.nodes}
+
+    def rename_constant(name):
+        if name in node_names:
+            n = 1
+            while (dup_name := f"{name}_{n}") in node_names:
+                n += 1
+            name = dup_name
+        node_names.add(name)
+        return name
+
+    # use input specs to map names from buffers to constants
+    buffer_prefix = placeholder_prefixes[InputKind.BUFFER]
+    const_prefix = placeholder_prefixes[InputKind.CONSTANT_TENSOR]
+    buffer_to_constant = {}
+    for spec in graph_signature.input_specs:
+        if (
+            spec.kind == InputKind.CONSTANT_TENSOR
+            and isinstance(spec.arg, TensorArgument)
+            and not spec.arg.name.startswith(const_prefix)
+        ):
+            if spec.arg.name.startswith(buffer_prefix):  # map from buffer to constants
+                c_name = rename_constant(
+                    const_prefix + spec.arg.name[len(buffer_prefix) :]
+                )
+            else:  # lifted constant
+                c_name = rename_constant(const_prefix + spec.arg.name)
+            buffer_to_constant[spec.arg.name] = c_name
+            spec.arg.name = c_name
+    for spec in graph_signature.output_specs:
+        if isinstance(spec.arg, ConstantArgument):
+            continue
+        if spec.arg.name in buffer_to_constant:
+            spec.arg.name = buffer_to_constant[spec.arg.name]
+
+    # Rename constants nodes for all modules
+    for mod in gm.modules():
+        if not isinstance(mod, torch.fx.GraphModule):
+            continue
+        for node in mod.graph.nodes:
+            if node.name in buffer_to_constant:
+                node.name = node.target = buffer_to_constant[node.name]
+        mod.recompile()
+
+
 def _restore_state_dict(
     original_module: torch.nn.Module, traced_module: torch.fx.GraphModule
 ) -> None:
@@ -483,10 +537,10 @@ def _export_non_strict(
         gm = replace_set_grad_with_hop_pass(gm)
 
     # Remove nn_module_stack, stack_trace metadata from all placeholders/inputs nodes.
-    for mod in gm.modules():
-        if not isinstance(mod, torch.fx.GraphModule):
+    for _mod in gm.modules():
+        if not isinstance(_mod, torch.fx.GraphModule):
             continue
-        for node in mod.graph.nodes:
+        for node in _mod.graph.nodes:
             if node.op in ["placeholder", "output"]:
                 node.meta.pop("nn_module_stack", None)
                 node.meta.pop("stack_trace", None)
@@ -565,6 +619,17 @@ def _export_non_strict(
 
     constants = rewrite_script_object_meta(gm)
     constants.update(lift_constants_pass(gm, export_graph_signature, constant_attrs))
+
+    # prettify names for placeholder nodes
+    placeholder_naming_pass(
+        gm,
+        export_graph_signature,
+        mod,
+        fake_args,
+        fake_kwargs,
+        fake_params_buffers,
+        constants,
+    )
 
     @dataclasses.dataclass
     class _ExportedProgramNonStrict:
@@ -684,6 +749,29 @@ def _verify_stack_trace(graph_module: torch.fx.GraphModule) -> None:
                         f"Node {node} of type {node.op} contains stack_trace metadata, "
                         f"expected None but instead found: {stack_trace}"
                     )
+
+
+def _verify_placeholder_names(gm: torch.fx.GraphModule, sig: ExportGraphSignature):
+    """
+    Performs a sanity check on the placeholder node names.
+    - User input nodes: no restrictions, should match the original forward() signature
+    - Params/buffers/constants/custom_obj nodes: should start with "p", "b", "c", "obj"
+    """
+    name_to_kind = {
+        spec.arg.name: spec.kind
+        for spec in sig.input_specs
+        if not isinstance(spec.arg, ConstantArgument)
+    }
+    for node in gm.graph.nodes:
+        if node.op == "placeholder":
+            if node.name not in name_to_kind:
+                continue
+            node_kind = name_to_kind[node.name]
+            prefix = placeholder_prefixes[node_kind]
+            if not node.name.startswith(prefix):
+                raise SpecViolationError(
+                    f"Placeholder node name {node.name} does not follow spec for {node_kind}, name should have prefix: {prefix}"
+                )
 
 
 def get_ep_stats(ep: ExportedProgram) -> Dict[str, Any]:
@@ -950,7 +1038,8 @@ def _export(
         _rewrite_non_persistent_buffers(mod, ep_non_strict.sig, ep_non_strict.constants)
         _verify_nn_module_stack(gm)
         _verify_stack_trace(gm)
-        return ExportedProgram(
+        _verify_placeholder_names(gm, ep_non_strict.sig)
+        exported_program = ExportedProgram(
             root=gm,
             graph=gm.graph,
             graph_signature=ep_non_strict.sig,
@@ -962,6 +1051,7 @@ def _export(
             example_inputs=(args, kwargs),
             constants=ep_non_strict.constants,
         )
+        return exported_program
 
     gm_torch_level = _export_to_torch_ir(
         mod,
@@ -1132,6 +1222,9 @@ def _export(
     # 4. Rewrite constants to have the same FQN as the original module.
     _remap_constants(constant_attrs, export_graph_signature, constants)
 
+    # 5. Rename constants nodes in graph module from buffers to constants
+    _rename_constants_nodes(gm, export_graph_signature)
+
     module_call_signatures = {
         fqn: ModuleCallSignature(inputs=[], outputs=[], **specs)
         for fqn, specs in gm_torch_level.meta["module_call_specs"].items()
@@ -1145,6 +1238,7 @@ def _export(
     assert orig_out_spec is not None
     _verify_nn_module_stack(gm)
     _verify_stack_trace(gm)
+    _verify_placeholder_names(gm, export_graph_signature)
     exported_program = ExportedProgram(
         root=gm,
         graph=gm.graph,

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -1,6 +1,7 @@
 import copy
 import dataclasses
 import functools
+import re
 import types
 import warnings
 from collections import namedtuple
@@ -109,6 +110,35 @@ def _fx_collection_equivalence_fn(
         return spec1_context == spec2_context
 
     return spec1_type is spec2_type and spec1_context == spec2_context
+
+
+def _rename_without_collisions(
+    name_map: Dict[str, str],
+    orig_name: str,
+    name: str,
+    is_placeholder: bool = False,
+):
+    """
+    Renames nodes to avoid name collisions, with suffixing.
+    name_map: map from original name to new name
+    orig_name: mapping key
+    name: candidate name (potentially suffixed, e.g. mul_2)
+    is_placeholder: if the node is a placeholder, avoid detecting suffix
+    """
+    if name in name_map.values():
+        # non-placeholder nodes may be suffixed with the count
+        # instead of adding another suffix, we will try to increment it
+        match = re.match(r"(.*)_(\d+)", name)
+        if match and not is_placeholder:
+            name, n = match.group(1), int(match.group(2))
+        else:
+            n = 0
+        while (dup_name := f"{name}_{n + 1}") in name_map.values():
+            n += 1
+        name_map[orig_name] = dup_name
+    else:
+        name_map[orig_name] = name
+    return name_map[orig_name]
 
 
 class ExportedProgram:
@@ -500,6 +530,18 @@ class ExportedProgram:
 
         new_placeholders = _get_placeholders(gm)
         new_outputs = list(gm.graph.nodes)[-1].args[0]
+
+        # rename the placeholders
+        assert len(new_placeholders) == len(old_placeholders)
+        for old_ph, new_ph in zip(old_placeholders, new_placeholders):
+            new_ph.name = new_ph.target = old_ph.name
+
+        # handle name collisions with newly decomposed graph nodes
+        name_map = {ph.name: ph.name for ph in new_placeholders}
+        for node in gm.graph.nodes:
+            if node.op == "placeholder":
+                continue
+            node.name = _rename_without_collisions(name_map, node.name, node.name)
 
         # To match the output target with correct input for input mutations
         # need to find the old to new placeholder map

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -344,7 +344,9 @@ class ResolvedExportOptions(ExportOptions):
     decomposition_table: Dict[torch._ops.OpOverload, Callable]
     """A dictionary that maps operators to their decomposition functions."""
 
-    onnxfunction_dispatcher: torch.onnx._internal.fx.onnxfunction_dispatcher.OnnxFunctionDispatcher
+    onnxfunction_dispatcher: (
+        torch.onnx._internal.fx.onnxfunction_dispatcher.OnnxFunctionDispatcher
+    )
     """The ONNX dispatcher used to dispatch ATen operators to ONNX functions."""
 
     fx_tracer: FXGraphExtractor
@@ -785,6 +787,7 @@ class ONNXProgram:
             the last 2 inputs are user inputs (namely x and b).
             The first output is a buffer mutation (namely my_buffer2) and the last output is the actual model output.
 
+            >>> import pprint
             >>> class CustomModule(torch.nn.Module):
             ...     def __init__(self):
             ...         super().__init__()
@@ -813,31 +816,45 @@ class ONNXProgram:
             >>> inputs = (torch.rand((64, 1, 28, 28), dtype=torch.float32), torch.randn(3))
             >>> exported_program = torch.export.export(CustomModule(), args=inputs)
             >>> onnx_program = torch.onnx.dynamo_export(exported_program, *inputs)
-            >>> print(onnx_program.model_signature)
-            ExportGraphSignature(
-                input_specs=[
-                    InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='arg0_1'),
-                              target='conv1.weight', persistent=None),
-                    InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='arg1_1'),
-                              target='conv2.weight', persistent=None),
-                    InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='arg2_1'),
-                              target='fc1.weight', persistent=None),
-                    InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='arg3_1'),
-                              target='fc2.weight', persistent=None),
-                    InputSpec(kind=<InputKind.BUFFER: 3>, arg=TensorArgument(name='arg4_1'),
-                              target='my_buffer2', persistent=True),
-                    InputSpec(kind=<InputKind.BUFFER: 3>, arg=TensorArgument(name='arg5_1'),
-                              target='my_buffer1', persistent=True),
-                    InputSpec(kind=<InputKind.USER_INPUT: 1>, arg=TensorArgument(name='arg6_1'),
-                              target=None, persistent=None),
-                    InputSpec(kind=<InputKind.USER_INPUT: 1>, arg=TensorArgument(name='arg7_1'),
-                              target=None, persistent=None)
-                ],
-                output_specs=[
-                    OutputSpec(kind=<OutputKind.BUFFER_MUTATION: 3>, arg=TensorArgument(name='add'), target='my_buffer2'),
-                    OutputSpec(kind=<OutputKind.USER_OUTPUT: 1>, arg=TensorArgument(name='_log_softmax'), target=None)
-                ]
-            )
+            >>> pprint.pprint(onnx_program.model_signature)
+            ExportGraphSignature(input_specs=[InputSpec(kind=<InputKind.PARAMETER: 2>,
+                                                  arg=TensorArgument(name='p_conv1_weight'),
+                                                  target='conv1.weight',
+                                                  persistent=None),
+                                        InputSpec(kind=<InputKind.PARAMETER: 2>,
+                                                  arg=TensorArgument(name='p_conv2_weight'),
+                                                  target='conv2.weight',
+                                                  persistent=None),
+                                        InputSpec(kind=<InputKind.PARAMETER: 2>,
+                                                  arg=TensorArgument(name='p_fc1_weight'),
+                                                  target='fc1.weight',
+                                                  persistent=None),
+                                        InputSpec(kind=<InputKind.PARAMETER: 2>,
+                                                  arg=TensorArgument(name='p_fc2_weight'),
+                                                  target='fc2.weight',
+                                                  persistent=None),
+                                        InputSpec(kind=<InputKind.BUFFER: 3>,
+                                                  arg=TensorArgument(name='b_my_buffer2'),
+                                                  target='my_buffer2',
+                                                  persistent=True),
+                                        InputSpec(kind=<InputKind.BUFFER: 3>,
+                                                  arg=TensorArgument(name='b_my_buffer1'),
+                                                  target='my_buffer1',
+                                                  persistent=True),
+                                        InputSpec(kind=<InputKind.USER_INPUT: 1>,
+                                                  arg=TensorArgument(name='x'),
+                                                  target=None,
+                                                  persistent=None),
+                                        InputSpec(kind=<InputKind.USER_INPUT: 1>,
+                                                  arg=TensorArgument(name='b'),
+                                                  target=None,
+                                                  persistent=None)],
+                           output_specs=[OutputSpec(kind=<OutputKind.BUFFER_MUTATION: 3>,
+                                                    arg=TensorArgument(name='add'),
+                                                    target='my_buffer2'),
+                                         OutputSpec(kind=<OutputKind.USER_OUTPUT: 1>,
+                                                    arg=TensorArgument(name='_log_softmax'),
+                                                    target=None)])
         """
 
         return self._model_signature


### PR DESCRIPTION
Summary:
This PR restores original names to placeholder nodes, replacing the default names arg0_1, arg1_1, and so on.

User inputs now follow the signature of mod.forward(), for example forward(x, y) produces nodes x, y. If the tensors are nested in dictionaries, lists, tuples, or dataclasses, the names are a concatenation of the path to the tensor, e.g. x = {'a': torch.randn(4), 'b': [torch.randn(4), torch.randn(4)]} produces nodes x_a, x_b_0, x_b_1.

Parameters, buffers, constants, and custom objects follow the FQN of the object, prefixed by "p", "b", "c", and "obj" respectively. For example, self.bar.l0.weight gets you p_bar_l0_weight.
Effect tokens are named token_1, token_2, and so on, since they are not grounded in model inputs or named attributes.

note: breaking the original diff into 3 parts (top-level renaming, higher-order-op subgraphs, constant input de/serialization) because of its size.

Examples:
```python
# params, buffers, constants, inputs, torch.cond

ExportedProgram:
    class GraphModule(torch.nn.Module):
        def forward(self, p_l0_weight: "f32[4, 4]", p_l0_bias: "f32[4]", c_alpha: "f32[4]", b_beta: "f32[4]", x_0_a: "f32[4, 4]", y: "f32[4, 4]"):
            # No stacktrace found for following nodes
            mul: "f32[4, 4]" = torch.ops.aten.mul.Tensor(x_0_a, x_0_a)
            t: "f32[4, 4]" = torch.ops.aten.t.default(p_l0_weight);  p_l0_weight = None
            addmm: "f32[4, 4]" = torch.ops.aten.addmm.default(p_l0_bias, y, t);  p_l0_bias = y = t = None
            return addmm

# model code

class Bar(torch.nn.Module):
    def forward(self, x):
        return x * x
class Foo(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.bar = Bar()
        self.l0 = torch.nn.Linear(4, 4)
        self.alpha = torch.randn(4)
        self.register_buffer('beta', torch.randn(4))
    def forward(self, x, y):
        x = x[0]['a']
        mul = self.bar(x)
        z1 = self.l0(y)
        return z1

# custom objects, dataclasses, tokens, constant inputs

ExportedProgram:
    class GraphModule(torch.nn.Module):
        def forward(self, token_1: "f32[0]", obj_attr, data_x: "f32[4, 4]", data_y: "f32[4, 4]", mode):
            # No stacktrace found for following nodes
            mul: "f32[4, 4]" = torch.ops.aten.mul.Scalar(data_x, 30);  data_x = None
            div: "f32[4, 4]" = torch.ops.aten.div.Tensor_mode(data_y, 1.0, rounding_mode = 'floor');  data_y = None
            add: "f32[4, 4]" = torch.ops.aten.add.Tensor(mul, div);  mul = div = None
            with_effects = torch._higher_order_ops.effects.with_effects(token_1, torch.ops._TorchScriptTesting.takes_foo.default, obj_attr, add);  token_1 = obj_attr = add = None
            getitem: "f32[0]" = with_effects[0]
            getitem_1: "f32[4, 4]" = with_effects[1];  with_effects = None
            return (getitem, getitem_1)

# model code

class Foo(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.attr = torch.classes._TorchScriptTesting._Foo(10, 20)
    def forward(self, data, a=1.0, mode="floor"):
        x = self.attr.add_tensor(data.x) + torch.div(data.y, a, rounding_mode=mode)
        x = torch.ops._TorchScriptTesting.takes_foo(self.attr, x)
        return x

dataclass
class DataClass:
    x: Tensor
    y: Tensor
register_dataclass_as_pytree_node(
    DataClass,
    serialized_type_name="test.DataClass"
)

args = (DataClass(x=torch.randn(4, 4), y=torch.randn(4, 4)), )
kwargs = {'mode': 'floor'}
ep = torch.export.export(Foo(), args, kwargs, strict=False)

```

Test Plan: verification checks on placeholder names for all export() calls, unit test in test/export/test_export.py

Differential Revision: D55456418
