### PR TITLE
[pytorch profiler] Add metrics for performance timing and other statistics

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -850,6 +850,15 @@ class TestProfiler(TestCase):
         if use_cuda:
             z = z.cpu()
 
+    def _check_stats(self, profiler_stats):
+        self.assertGreater(profiler_stats.profiling_window_duration_sec, 0)
+        self.assertGreater(profiler_stats.number_of_events, 0)
+        self.assertGreater(profiler_stats.profiler_prepare_call_duration_us, 0)
+        self.assertGreater(profiler_stats.profiler_enable_call_duration_us, 0)
+        self.assertGreater(profiler_stats.profiler_disable_call_duration_us, 0)
+        self.assertGreater(profiler_stats.parse_kineto_call_duration_us, 0)
+        self.assertGreater(profiler_stats.function_events_build_tree_call_duration_us, 0)
+
     @unittest.skipIf(not kineto_available(), "Kineto is required")
     def test_kineto(self):
         use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()
@@ -877,6 +886,7 @@ class TestProfiler(TestCase):
             self.assertTrue(found_memcpy)
         else:
             self.assertTrue(found_mm)
+        self._check_stats(p._stats)
         # p.export_chrome_trace("/tmp/test_trace.json")
 
     @unittest.skipIf(not kineto_available(), "Kineto is required")
@@ -907,6 +917,7 @@ class TestProfiler(TestCase):
         self.assertTrue(found_gemm_0)
         self.assertTrue(found_gemm_1)
         self.assertTrue(found_cuda)
+        self._check_stats(prof._stats())
 
     def test_memory_profiler(self):
         def run_profiler(tensor_creation_fn):

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -736,6 +736,11 @@ class profile(_KinetoProfile):
             for action in action_list:
                 action()
 
+    def _stats(self) -> Optional[prof._ProfilerStats]:
+        if self.profiler is None:
+            return None
+        return self.profiler._stats
+
 
 class ExecutionTraceObserver(_ITraceObserver):
     """Execution Trace Observer


### PR DESCRIPTION
Summary: Measure the performance of various calls in PyTorch profiler and ave them to `_ProfilerStats` structure

Test Plan:
## Run local benchmark

   buck2 run mode/dev-nosan scripts/vandrei/pytorch_samples:mlp_training

Output
```
_ProfilerStats(profiling_window_duration_sec=3.19422982, number_of_events=78151, profiler_prepare_call_duration_us=391.774, profiler_enable_call_duration_us=25341.525, profiler_disable_call_duration_us=2539208.388, parse_kineto_call_duration_us=7926882.588, function_events_build_tree_call_duration_us=1341230.342)
_ProfilerStats(profiling_window_duration_sec=3.453401961, number_of_events=78136, profiler_prepare_call_duration_us=365.423, profiler_enable_call_duration_us=25026.347, profiler_disable_call_duration_us=2788495.183, parse_kineto_call_duration_us=8112022.258, function_events_build_tree_call_duration_us=1344082.309)
_ProfilerStats(profiling_window_duration_sec=3.487087802, number_of_events=78145, profiler_prepare_call_duration_us=401.833, profiler_enable_call_duration_us=25063.468, profiler_disable_call_duration_us=2815397.004, parse_kineto_call_duration_us=8277507.412, function_events_build_tree_call_duration_us=1345286.971)
_ProfilerStats(profiling_window_duration_sec=3.522129304, number_of_events=78149, profiler_prepare_call_duration_us=440.547, profiler_enable_call_duration_us=25371.239, profiler_disable_call_duration_us=2856480.52, parse_kineto_call_duration_us=8213553.866, function_events_build_tree_call_duration_us=1329879.923)
_ProfilerStats(profiling_window_duration_sec=3.512675368, number_of_events=78142, profiler_prepare_call_duration_us=397.346, profiler_enable_call_duration_us=25865.074, profiler_disable_call_duration_us=2832946.163, parse_kineto_call_duration_us=8276488.791, function_events_build_tree_call_duration_us=1359870.38)
_ProfilerStats(profiling_window_duration_sec=3.536105605, number_of_events=78154, profiler_prepare_call_duration_us=426.084, profiler_enable_call_duration_us=26279.467, profiler_disable_call_duration_us=2868401.7, parse_kineto_call_duration_us=8481865.512, function_events_build_tree_call_duration_us=1370873.655)
_ProfilerStats(profiling_window_duration_sec=3.548836496, number_of_events=78141, profiler_prepare_call_duration_us=391.316, profiler_enable_call_duration_us=26807.388, profiler_disable_call_duration_us=2876357.675, parse_kineto_call_duration_us=8038261.01, function_events_build_tree_call_duration_us=1349546.444)
_ProfilerStats(profiling_window_duration_sec=3.543021589, number_of_events=78144, profiler_prepare_call_duration_us=376.18, profiler_enable_call_duration_us=25911.269, profiler_disable_call_duration_us=2861442.669, parse_kineto_call_duration_us=8480880.266, function_events_build_tree_call_duration_us=1360733.55)

```

Differential Revision: D55457386


