### PR TITLE
[Dynamic Shapes] Fix error handling for indirectly fully constrained dynamic dimensions

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -7121,6 +7121,20 @@ def fn():
         with self.assertRaises(ConstraintViolationError):
             torch._dynamo.optimize("eager")(my_dyn_fn)(y)
 
+    def test_raise_guard_indirect_full_constraint(self):
+        y = torch.randn([3, 3, 3])
+        
+        def my_dyn_fn(x):
+            if x.shape[0] > 3:
+                return x.cos()
+            if x.shape[0] < 3:
+                return x * 2
+            return x.sin()
+
+        torch._dynamo.mark_dynamic(y, 0)
+        with self.assertRaises(ConstraintViolationError):
+            torch._dynamo.optimize("eager")(my_dyn_fn)(y)
+
     # Translation validation changes the exception type, don't run with it
     @torch.fx.experimental._config.patch(translation_validation=False)
     def test_mark_dynamic_with_ranges(self):

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -3843,8 +3843,8 @@ class ShapeEnv:
             self.var_to_range[symbol] &= ValueRanges(lower, upper)
 
         # If the range is refined to singleton, set replacement
-        if lower == upper:
-            self._set_replacement(symbol, lower, "range_refined_to_singleton")
+        if self.var_to_range[symbol].is_singleton():
+            self._set_replacement(symbol, self.var_to_range[symbol].lower, "range_refined_to_singleton")
 
     def _set_replacement(self, a: "sympy.Symbol", tgt: "sympy.Expr", msg: str) -> None:
         """

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -3842,10 +3842,6 @@ class ShapeEnv:
         else:
             self.var_to_range[symbol] &= ValueRanges(lower, upper)
 
-        # If the range is refined to singleton, set replacement
-        if self.var_to_range[symbol].is_singleton():
-            self._set_replacement(symbol, self.var_to_range[symbol].lower, "range_refined_to_singleton")
-
     def _set_replacement(self, a: "sympy.Symbol", tgt: "sympy.Expr", msg: str) -> None:
         """
         Adds or updates a replacement for a symbol.
@@ -4518,6 +4514,10 @@ class ShapeEnv:
                 continue
 
             self._update_var_to_range(symbol, ValueRanges(lower, upper))
+
+            # If the range is refined to singleton, set replacement
+            if self.var_to_range[symbol].is_singleton():
+                self._set_replacement(symbol, self.var_to_range[symbol].lower, "range_refined_to_singleton")
 
             # Clears the cache, since this update can change the result.
             self._maybe_evaluate_static.cache_clear()

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -3836,15 +3836,15 @@ class ShapeEnv:
         if upper < 2 and symbol in self.size_like:
             upper = 2
 
-        # If the range is refined to singleton, set replacement
-        if lower == upper:
-            self._set_replacement(symbol, lower, "range_refined_to_singleton")
-
         # Updates the range and the guards corresponding to each bound of the symbol.
         if symbol not in self.var_to_range:
             self.var_to_range[symbol] = ValueRanges(lower, upper)
         else:
             self.var_to_range[symbol] &= ValueRanges(lower, upper)
+
+        # If the range is refined to singleton, set replacement
+        if lower == upper:
+            self._set_replacement(symbol, lower, "range_refined_to_singleton")
 
     def _set_replacement(self, a: "sympy.Symbol", tgt: "sympy.Expr", msg: str) -> None:
         """

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -4513,6 +4513,10 @@ class ShapeEnv:
             if vr == ValueRanges(lower, upper):
                 continue
 
+            # If the range is refined to singleton, set replacement
+            if lower == upper:
+                self._set_replacement(symbol, lower, "range_refined_to_singleton")
+
             self._update_var_to_range(symbol, ValueRanges(lower, upper))
 
             # Clears the cache, since this update can change the result.

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -3836,6 +3836,10 @@ class ShapeEnv:
         if upper < 2 and symbol in self.size_like:
             upper = 2
 
+        # If the range is refined to singleton, set replacement
+        if lower == upper:
+            self._set_replacement(symbol, lower, "range_refined_to_singleton")
+
         # Updates the range and the guards corresponding to each bound of the symbol.
         if symbol not in self.var_to_range:
             self.var_to_range[symbol] = ValueRanges(lower, upper)
@@ -4512,10 +4516,6 @@ class ShapeEnv:
             # Do nothing if the new value range is no better than what we already have.
             if vr == ValueRanges(lower, upper):
                 continue
-
-            # If the range is refined to singleton, set replacement
-            if lower == upper:
-                self._set_replacement(symbol, lower, "range_refined_to_singleton")
 
             self._update_var_to_range(symbol, ValueRanges(lower, upper))
 


### PR DESCRIPTION
Resolved an issue where dimensions marked as dynamic, yet indirectly constrained to a static value through multiple conditions, failed to trigger a ConstraintViolationError. The update ensures proper error handling for dimensions that are effectively singleton. Included a regression test to verify the fix and prevent recurrence of the issue.

Fixes #122307


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec @lezcano