### PR TITLE
Skip use_count() debug assert for _nested_get_offsets()

### DIFF
--- a/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
+++ b/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
@@ -378,7 +378,9 @@ static void autogradNotImplementedFallbackImpl(
   _foreach_tensor(
       [&](size_t idx_tensor, size_t idx_ret, const at::Tensor& t) {
         if (at::impl::tensor_has_dispatch(t) ||
-            at::impl::dispatch_mode_enabled())
+            at::impl::dispatch_mode_enabled() ||
+            // NJT offsets are expected to be reused; skip use_count() check
+            op_name == "aten::_nested_get_offsets")
           return;
         if (!is_inplace_output[idx_ret])
           TORCH_INTERNAL_ASSERT(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122917
* #122902

This broke [internal tests](https://www.internalfb.com/intern/test/844425064039866/) that run with unset `NDEBUG`. It wasn't initially caught because we don't test with unset `NDEBUG` in OSS CI. 