### PR TITLE
[TP] Add wildcard support for *

### DIFF
--- a/torch/distributed/tensor/parallel/api.py
+++ b/torch/distributed/tensor/parallel/api.py
@@ -102,8 +102,9 @@ def parallelize_module(  # type: ignore[return]
             while path_splits:
                 atom = path_splits.pop(0)
                 if atom == "*":
-                    # recursively apply the plan to all submodules
+                    # Rest of the path after "*"
                     leaf_path = ".".join(path_splits)
+                    # recursively apply the plan to all submodules
                     for submodule in parent_module.children():  # corresponds to "*"
                         if leaf_path:
                             # we haven't reached the leaf, apply in dict style


### PR DESCRIPTION
This PR adds support for the following specification:
```
parallelize_module(
    model,
    device_mesh,
    {"layers.*.linear" : ColwiseParallel},
)
``` 
where `*` replaces what would typically be 0, 1, 2, ... (layer ids).

Rules:
- `*` can be at any hierarchy of the path;
- Multiple `*`s are supported, e.g. `*.*.linear`;
- Mixing `*` with other characters are not supported at the moment, e.g. `layer*.linear` (though it may be useful too).

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #122966
* __->__ #122923
* #122919



cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang