### PR TITLE
[inductor] Assume non-views are aligned, views are unaligned

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -10020,21 +10020,6 @@ fn
         self.assertEqual(expected.stride(), actual.stride())
         self.assertEqual(expected.storage_offset(), actual.storage_offset())
 
-    def test_view_recompiles(self):
-        def fn(x):
-            return x.sin().cos()
-
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch._dynamo.optimize(cnts)(fn)
-
-        x_nonview = torch.rand((5, 4))
-        opt_fn(x_nonview)
-        self.assertEqual(cnts.frame_count, 1)
-
-        x_view = torch.rand(22).as_strided((5, 4), (4, 1), 2)
-        opt_fn(x_view)
-        self.assertEqual(cnts.frame_count, 2)
-
 
 class TestTracer(JitTestCase):
     def test_jit_save(self):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -10020,6 +10020,21 @@ fn
         self.assertEqual(expected.stride(), actual.stride())
         self.assertEqual(expected.storage_offset(), actual.storage_offset())
 
+    def test_view_recompiles(self):
+        def fn(x):
+            return x.sin().cos()
+
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch._dynamo.optimize(cnts)(fn)
+
+        x_nonview = torch.rand((5, 4))
+        opt_fn(x_nonview)
+        self.assertEqual(cnts.frame_count, 1)
+
+        x_view = torch.rand(22).as_strided((5, 4), (4, 1), 2)
+        opt_fn(x_view)
+        self.assertEqual(cnts.frame_count, 2)
+
 
 class TestTracer(JitTestCase):
     def test_jit_save(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -9560,6 +9560,10 @@ if HAS_GPU and RUN_GPU and not TEST_WITH_ASAN:
             def fn(x: torch.Tensor) -> torch.Tensor:
                 return x.sin() + x.cos()
 
+            # views: since these are views, we should expect codegen that assumes
+            # unaligned inputs (even if the offset is 0).
+            # If this handling is at some point improved, it would be reasonable to
+            # remove the unaligned check for the offset-0 case.
             for offset in (0, 1, 2):
                 base = torch.randn(64 * 64 + 64, device=GPU_TYPE)
                 inps = torch.as_strided(base, (64, 64), (64, 1), offset)
@@ -9573,6 +9577,15 @@ if HAS_GPU and RUN_GPU and not TEST_WITH_ASAN:
                 # def triton_(in_ptr0, out_ptr0, xnumel, XBLOCK : tl.constexpr)
 
                 self.assertEqual(arguments_that_are_divisible_by_16, (1, 2))
+
+            # If we're not passing in a view, inductor will assume alignment.
+            torch._dynamo.reset()
+            inp = torch.randn((64, 64), device=GPU_TYPE)
+            kernels = self.get_kernels(fn, [inp])
+            arguments_that_are_divisible_by_16 = (
+                kernels[0].triton_meta["configs"][0].divisible_by_16
+            )
+            self.assertEqual(arguments_that_are_divisible_by_16, (0, 1, 2))
 
         def test_optimize_indexing_dtype(self):
             def fn(x: torch.Tensor) -> torch.Tensor:

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -65,8 +65,9 @@ def signature_to_meta(
 
 def is_unaligned_buffer(arg: TensorArg):
     buf_name = arg.buffer
+    # See Note: [Input Alignment handling in Inductor]
     if buf_name in V.graph.graph_inputs:
-        return not config.assume_aligned_inputs
+        return buf_name not in V.graph.aligned_inputs
 
     if buf_name in V.graph.constants:
         # all constants are assumed to be aligned

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -799,17 +799,19 @@ def get_input_idxs_to_check(
     inputs: Union[List[torch.Tensor], Sequence[int]],
     static_input_idxs: Sequence[int],
 ) -> Sequence[int]:
-    def is_aligned(storage_offset, dtype):
+    def is_aligned(input):
+        # See Note: [Input Alignment handling in Inductor]
+        if input._is_view() and not config.assume_aligned_inputs:
+            return False
+        storage_offset = input.storage_offset()
+        dtype = input.dtype
         return (storage_offset * get_dtype_size(dtype)) % ALIGNMENT == 0
 
     ids_to_check = []
     for i, input in enumerate(inputs):
         if (
             isinstance(input, torch.Tensor)
-            and (
-                i not in static_input_idxs
-                or not is_aligned(input.storage_offset(), input.dtype)
-            )
+            and (i not in static_input_idxs or not is_aligned(input))
             and input.device.type == "cuda"
         ):
             ids_to_check.append(i)
@@ -834,10 +836,7 @@ def align_inputs(
     inputs: List[torch.Tensor],
     static_input_idxs: Sequence[int] = (),
 ):
-    if config.assume_aligned_inputs:
-        inputs_to_check = get_input_idxs_to_check(inputs, static_input_idxs)
-    else:
-        inputs_to_check = []
+    inputs_to_check = get_input_idxs_to_check(inputs, static_input_idxs)
     return align_inputs_from_check_idxs(model, inputs_to_check)
 
 

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -311,6 +311,7 @@ class GraphLowering(torch.fx.Interpreter):
         )  # This is the linemap used by the profiler to mark custom compiled kernels getting run
         # Used if lowering encounters cases where cudagraphs are not supported
         self.disable_cudagraphs_reason: Optional[str] = None
+        self.aligned_inputs: Set[str] = set()
 
         # only keeping one node per device for stack trace purposes
         self.device_node_mapping: Dict[torch.device, torch.fx.Node] = {}
@@ -763,6 +764,23 @@ class GraphLowering(torch.fx.Interpreter):
         self.graph_inputs[target] = tensor
         self.graph_inputs_original[target] = tensor.data.data
         self.add_device_info(example.device)
+
+        # Note: [Input Alignment handling in Inductor]
+        # Alignment matters for generating efficient code. Some operations,
+        # e.g. vectorized loads, can only be performed on aligned inputs.
+        #
+        # But if we codegen assuming aligned inputs and then get unaligned
+        # inputs at runtime, then we are forced to clone - which is bad for
+        # both perf and memory usage.
+        #
+        # One option would be to guard on storage_offset%ALIGNMENT, and then
+        # codegen based on this. But storage_offset guards turned out to be
+        # expensive and cause recompiles; instead we're guarding on whether
+        # the input tensor is a view or not. If a tensor isn't a view, we can
+        # be pretty sure that it was allocated with good alignment; and if a
+        # tensor is a view, we'll codegen code that doesn't assume alignment.
+        if not example._is_view() or config.assume_aligned_inputs:
+            self.aligned_inputs.add(target)
         return tensor
 
     def call_function(self, target, args, kwargs):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #122159
* __->__ #122926

**TL;DR**: After this PR, if assume_aligned_inputs=False: Inductor will generate code based on un-guarded properties of the example input tensors; specifically, if an example input is a view, we generate unaligned triton code; and if it is not a view we generate aligned triton code (and clone any inputs that aren't aligned)

**Details**:
* If an input is a view, we generate unaligned triton. 
* If an input is not a view, we generate aligned triton and do a clone at runtime.
* This change is still hidden behind the `assume_aligned_inputs` flag
* This does not guard on whether tensors are views. I have a version that does guard here: https://github.com/pytorch/pytorch/pull/122867 but it has a failure in `test_issue106555` which is concerning; somehow, adding additional dynamo guards (and making no changes to inductor, because all the changes are still guarded in that PR) causes a size assertion failure in the backward pass.

**Alternatives**
* Guard on storage offset: this would be more accurate, because we would actually know whether the tensor is aligned. For example, there may be some views that are always aligned, but in this PR we will assume that they are not aligned. However, we ran into two issues with this: (1) dynamo guards took way too long, and (2) we'd start recompiling more than we'd like.
* Care about the users of the input: e.g. if it's a matmul, or maybe if it is loaded a lot of times, then it might be worthwhile to do the clone; otherwise, don't clone and generate unaligned code.
* Guard on tensor-is-a-view in case this property changes. As I mentioned above, I tried this in https://github.com/pytorch/pytorch/pull/122926 but ran into some issues; but I can take another look if we think this is important.
* We could also make assume_aligned_inputs=False by default (although we'd have to be careful about getting rid of the config)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang