### PR TITLE
Add a mode to avoid clone() in DDPSink

### DIFF
--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -2204,7 +2204,10 @@ class DistributedDataParallel(Module, Joinable):
                 "Communication hook: return annotation should be torch.futures.Future[torch.Tensor].",
             )
 
-        if hook.__name__ in ["bf16_compress_hook", "bf16_compress_wrapper_hook",] and (
+        if hook.__name__ in [
+            "bf16_compress_hook",
+            "bf16_compress_wrapper_hook",
+        ] and (
             (torch.version.cuda is None and torch.version.hip is None)
             or (
                 torch.version.cuda is not None

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -242,9 +242,11 @@ class _DDPSink(Function):
         # None and are not filled with zeros.
         ctx.set_materialize_grads(False)
         ctx.ddp_weakref = ddp_weakref
-        ret = tuple(
-            inp.clone() if isinstance(inp, torch.Tensor) else inp for inp in inputs
-        )
+        ret = inputs
+        if ddp_weakref().ddp_sink_clone:
+            ret = tuple(
+                inp.clone() if isinstance(inp, torch.Tensor) else inp for inp in inputs
+            )
         return ret
 
     @staticmethod
@@ -900,6 +902,9 @@ class DistributedDataParallel(Module, Joinable):
         )
         if self._use_python_reducer:
             self._register_accum_grad_hook()
+
+        # Whether or not DDPSink performs a clone.
+        self.ddp_sink_clone = True
 
     def _register_accum_grad_hook(self):
         import torch.distributed._functional_collectives as fcol
@@ -2361,3 +2366,16 @@ class DistributedDataParallel(Module, Joinable):
         if not _rank_not_in_group(new_process_group):
             self.process_group = new_process_group
             self.reducer._update_process_group(new_process_group)
+
+    def _set_ddp_sink_clone(self, val: bool):
+        """
+        Sets whether or not DDPSink should clone the output tensors or not.
+        The default is True since if the loss is modified in place we run
+        into the view is modified in-place error.
+
+        Although, cloning the tensors can add significant memory and
+        performance hit if the number and size of tensors are large. As
+        a result, this can be set to False if you are not modifying the
+        loss in place.
+        """
+        self.ddp_sink_clone = val

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -243,7 +243,7 @@ class _DDPSink(Function):
         ctx.set_materialize_grads(False)
         ctx.ddp_weakref = ddp_weakref
         ret = inputs
-        if ddp_weakref().ddp_sink_clone:
+        if ddp_weakref()._ddp_sink_clone:
             ret = tuple(
                 inp.clone() if isinstance(inp, torch.Tensor) else inp for inp in inputs
             )
@@ -904,7 +904,7 @@ class DistributedDataParallel(Module, Joinable):
             self._register_accum_grad_hook()
 
         # Whether or not DDPSink performs a clone.
-        self.ddp_sink_clone = True
+        self._ddp_sink_clone = True
 
     def _register_accum_grad_hook(self):
         import torch.distributed._functional_collectives as fcol
@@ -2204,10 +2204,7 @@ class DistributedDataParallel(Module, Joinable):
                 "Communication hook: return annotation should be torch.futures.Future[torch.Tensor].",
             )
 
-        if hook.__name__ in [
-            "bf16_compress_hook",
-            "bf16_compress_wrapper_hook",
-        ] and (
+        if hook.__name__ in ["bf16_compress_hook", "bf16_compress_wrapper_hook",] and (
             (torch.version.cuda is None and torch.version.hip is None)
             or (
                 torch.version.cuda is not None
@@ -2378,4 +2375,4 @@ class DistributedDataParallel(Module, Joinable):
         a result, this can be set to False if you are not modifying the
         loss in place.
         """
-        self.ddp_sink_clone = val
+        self._ddp_sink_clone = val


### PR DESCRIPTION
DDPSink clones the outputs of DDP to avoid in-place modification of loss (see https://github.com/pytorch/pytorch/issues/61982). However, when outputs are really large (2-3GB) this adds a lot of overhead for peak memory.

As a result, adding a mode to avoid this clone in cases where users are not modifying loss in-place.

cc @mrshenli @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang