### PR TITLE
[dtensor] refactor schema suggestions in output sharding

### DIFF
--- a/test/distributed/_tensor/test_common_rules.py
+++ b/test/distributed/_tensor/test_common_rules.py
@@ -187,9 +187,9 @@ class CommonRulesTest(DTensorTestBase):
             "mk,kn->mn", OpSchema(mm_call, (mat1_spec, mat2_spec), {})
         )
         self.assertIsNone(output_sharding.output_spec)
-        suggestions = output_sharding.schema_suggestions
+        suggestions = output_sharding.redistribute_schema
         self.assertIsNotNone(suggestions)
-        suggested_spec = suggestions[0].args_schema[0]
+        suggested_spec = suggestions.args_schema[0]
         self.assertFalse(suggested_spec.placements[1].is_partial())
 
         # einop prop with linearity on mm, should give back suggestion
@@ -200,9 +200,9 @@ class CommonRulesTest(DTensorTestBase):
             linearity=True,
         )
         self.assertIsNone(output_sharding.output_spec)
-        suggestions = output_sharding.schema_suggestions
+        suggestions = output_sharding.redistribute_schema
         self.assertIsNotNone(suggestions)
-        mat2_spec = suggestions[0].args_schema[1]
+        mat2_spec = suggestions.args_schema[1]
         # mat2 mesh dim 1 should become partial now!
         self.assertTrue(mat2_spec.placements[1].is_partial())
 
@@ -225,9 +225,9 @@ class CommonRulesTest(DTensorTestBase):
             linearity=True,
         )
         self.assertIsNone(output_sharding.output_spec)
-        suggestions = output_sharding.schema_suggestions
+        suggestions = output_sharding.redistribute_schema
         self.assertIsNotNone(suggestions)
-        mat2_spec = suggestions[0].args_schema[1]
+        mat2_spec = suggestions.args_schema[1]
         # mat2 mesh dim 1 should become partial now!
         self.assertTrue(mat2_spec.placements[1].is_partial())
 
@@ -252,11 +252,11 @@ class CommonRulesTest(DTensorTestBase):
         )
         output_spec = output_sharding.output_spec
         self.assertIsNone(output_spec)
-        self.assertIsNotNone(output_sharding.schema_suggestions)
+        self.assertIsNotNone(output_sharding.redistribute_schema)
 
         # ensure that the suggestion is to reshard the second
         # arg by all_gather its tensor dim sharding
-        schema_suggestion = output_sharding.schema_suggestions[0]
+        schema_suggestion = output_sharding.redistribute_schema
         self.assertEqual(schema_suggestion.args_schema[0].dim_map, [0, -1])
         self.assertEqual(schema_suggestion.args_schema[1].dim_map, [-1, -1])
 
@@ -327,11 +327,11 @@ class CommonRulesTest(DTensorTestBase):
             OpSchema(lerp_call, (mat1_spec, mat2_spec, -1), {})
         )
         self.assertIsNone(output_sharding.output_spec)
-        self.assertIsNotNone(output_sharding.schema_suggestions)
+        self.assertIsNotNone(output_sharding.redistribute_schema)
 
         # ensure that the suggestion from pointwise rules still have
         # the positional args that are not DTensorSpec
-        schema_suggestion = output_sharding.schema_suggestions[0]
+        schema_suggestion = output_sharding.redistribute_schema
         self.assertEqual(len(schema_suggestion.args_schema), 3)
         self.assertEqual(schema_suggestion.args_schema[2], -1)
 
@@ -373,11 +373,11 @@ class CommonRulesTest(DTensorTestBase):
         output_sharding = pointwise_rule(OpSchema(add_call, (mat1_spec, mat2_spec), {}))
         output_spec = output_sharding.output_spec
         self.assertIsNone(output_spec)
-        self.assertIsNotNone(output_sharding.schema_suggestions)
+        self.assertIsNotNone(output_sharding.redistribute_schema)
 
         # ensure that the suggestion is to reshard the first
         # arg by all_gather first tensor dim sharding
-        schema_suggestion = output_sharding.schema_suggestions[0]
+        schema_suggestion = output_sharding.redistribute_schema
         self.assertEqual(schema_suggestion.args_schema[0].dim_map, [-1, -1, -1, 1])
         self.assertEqual(schema_suggestion.args_schema[1].dim_map, mat2)
 
@@ -404,11 +404,11 @@ class CommonRulesTest(DTensorTestBase):
         output_sharding = pointwise_rule(OpSchema(add_call, (mat1_spec, mat2_spec), {}))
         output_spec = output_sharding.output_spec
         self.assertIsNone(output_spec)
-        self.assertIsNotNone(output_sharding.schema_suggestions)
+        self.assertIsNotNone(output_sharding.redistribute_schema)
 
         # ensure that the suggestion is to reshard the second
         # arg as we should enforce the sharding of the first arg
-        schema_suggestion = output_sharding.schema_suggestions[0]
+        schema_suggestion = output_sharding.redistribute_schema
         self.assertEqual(schema_suggestion.args_schema[0].dim_map, mat1)
         self.assertEqual(schema_suggestion.args_schema[1].dim_map, mat1)
 

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -593,8 +593,10 @@ def distribute_tensor(
             f"Found placements length: {len(placements)}, and device_mesh.ndim: {device_mesh.ndim}."
         )
     if isinstance(tensor, DTensor):
-        # if the tensor is already a DTensor, we just need to check if the
-        # device mesh and placements are the same
+        # if the tensor is already a DTensor, we need to check:
+        # 1. if the we can further shard this DTensor if the two device mesh belong to
+        #   the same parenet mesh and further sharding is possible.
+        # 2. check if device mesh and placements are the same
         if tensor.device_mesh != device_mesh:
             raise ValueError(
                 f"Cannot distribute a DTensor with device mesh {tensor.device_mesh} "

--- a/torch/distributed/_tensor/dispatch.py
+++ b/torch/distributed/_tensor/dispatch.py
@@ -164,9 +164,9 @@ class OpDispatcher:
         else:
             if output_sharding.needs_redistribute:
                 # compute locally with redistribute first if needed
-                assert output_sharding.schema_suggestions is not None
+                assert output_sharding.redistribute_schema is not None
                 self.redistribute_local_args(
-                    op_info, output_sharding.schema_suggestions[0]
+                    op_info, output_sharding.redistribute_schema
                 )
 
             local_tensor_args = (

--- a/torch/distributed/_tensor/experimental/tp_transform.py
+++ b/torch/distributed/_tensor/experimental/tp_transform.py
@@ -236,8 +236,8 @@ def _mark_sharding(
                     )
                 placement_strategies[node] = PlacementStrategy(
                     output_specs=_get_output_spec_from_output_sharding(output_sharding),
-                    input_specs=output_sharding.schema_suggestions[0].args_spec
-                    if output_sharding.schema_suggestions is not None
+                    input_specs=output_sharding.redistribute_schema.args_spec
+                    if output_sharding.redistribute_schema is not None
                     else _get_input_node_specs(node, placement_strategies),
                 )
                 node.meta["sharding"] = placement_strategies[node]
@@ -345,7 +345,7 @@ def _generate_default_output_sharding(
         output_spec=pytree.tree_map_only(
             FakeTensor, create_output_spec, node.meta["val"]
         ),
-        schema_suggestions=[new_op_schema],
+        redistribute_schema=new_op_schema,
         failed_reason=f"{node.op} does not have sharding strategy registered",
         needs_redistribute=True,
     )

--- a/torch/distributed/_tensor/op_schema.py
+++ b/torch/distributed/_tensor/op_schema.py
@@ -419,7 +419,7 @@ class OutputSharding:
     """
 
     output_spec: OutputSpecType
-    schema_suggestions: Optional[List[OpSchema]] = None
+    redistribute_schema: Optional[OpSchema] = None
     failed_reason: Optional[str] = None
     needs_redistribute: bool = False
 

--- a/torch/distributed/_tensor/ops/common_rules.py
+++ b/torch/distributed/_tensor/ops/common_rules.py
@@ -39,7 +39,7 @@ def _gen_reshard_suggestions(
     suggested_schema._inplace_rewrap_schema_suggestion(op_schema)
     return OutputSharding(
         None,
-        schema_suggestions=[suggested_schema],
+        redistribute_schema=suggested_schema,
         failed_reason="Input placements op sharding propagation failed, need to reshard!",
     )
 

--- a/torch/distributed/_tensor/ops/view_ops.py
+++ b/torch/distributed/_tensor/ops/view_ops.py
@@ -687,7 +687,7 @@ def register_prop_rule_map(
                 )
                 return OutputSharding(
                     output_spec=output_dtensor_spec,
-                    schema_suggestions=[suggested_schema],
+                    redistribute_schema=suggested_schema,
                     needs_redistribute=True,
                 )
 
@@ -706,20 +706,18 @@ def register_prop_rule_map(
             ]
             return OutputSharding(
                 output_spec=None,
-                schema_suggestions=[
-                    OpSchema(
-                        op=op_schema.op,
-                        args_schema=(
-                            DTensorSpec(
-                                placements=tuple(suggested_placements),
-                                mesh=input_dtensor_spec.mesh,
-                                tensor_meta=input_dtensor_spec.tensor_meta,
-                            ),
-                        )
-                        + op_schema.args_schema[1:],
-                        kwargs_schema=op_schema.kwargs_schema,
+                redistribute_schema=OpSchema(
+                    op=op_schema.op,
+                    args_schema=(
+                        DTensorSpec(
+                            placements=tuple(suggested_placements),
+                            mesh=input_dtensor_spec.mesh,
+                            tensor_meta=input_dtensor_spec.tensor_meta,
+                        ),
                     )
-                ],
+                    + op_schema.args_schema[1:],
+                    kwargs_schema=op_schema.kwargs_schema,
+                ),
             )
 
 

--- a/torch/distributed/_tensor/sharding_prop.py
+++ b/torch/distributed/_tensor/sharding_prop.py
@@ -172,7 +172,7 @@ class ShardingPropagator:
         # special case op, we don't need to propagate for local
         # scalar. TODO: figure out a better way to handle this
         if op_schema.op is aten._local_scalar_dense.default:
-            return OutputSharding(None, [op_schema])
+            return OutputSharding(None, op_schema)
 
         out_tensor_meta = self._propagate_tensor_meta(op_schema)
 
@@ -238,11 +238,10 @@ class ShardingPropagator:
 
                 suggestion_schema = None
                 if needs_redistribute:
-                    reshard_schema = OpSchema(
+                    suggestion_schema = OpSchema(
                         op_schema.op, tuple(expected_input_specs), {}
                     )
-                    reshard_schema._inplace_rewrap_schema_suggestion(op_schema)
-                    suggestion_schema = [reshard_schema]
+                    suggestion_schema._inplace_rewrap_schema_suggestion(op_schema)
 
                 # construct output spec for the op
                 if op_schema.return_type_tuple_tensor_like():
@@ -268,6 +267,7 @@ class ShardingPropagator:
                 else:
                     output_specs = None
 
+                assert suggestion_schema is not None
                 output_sharding = OutputSharding(
                     output_specs,
                     suggestion_schema,
@@ -323,10 +323,9 @@ class ShardingPropagator:
 
                 suggestion_schema = None
                 if needs_redistribute:
-                    reshard_schema = OpSchema(
+                    suggestion_schema = OpSchema(
                         op_schema.op, tuple(suggestion_args), op_schema.kwargs_schema
                     )
-                    suggestion_schema = [reshard_schema]
 
                 output_sharding = OutputSharding(
                     tuple(out_spec_list) if out_tensor_meta is not None else None,
@@ -362,7 +361,7 @@ class ShardingPropagator:
             # with schema suggestions, which can be used to
             # decide how to do redistribute on inputs
             if output_sharding.output_spec is None:
-                if output_sharding.schema_suggestions is None:
+                if output_sharding.redistribute_schema is None:
                     if output_sharding.failed_reason is not None:
                         raise RuntimeError(
                             f"Sharding propagation failed on op {op_schema}!"
@@ -370,14 +369,12 @@ class ShardingPropagator:
                         )
                 else:
                     # we do auto redistribute on inputs if necessary
-                    # to get an eligible input, which we will pick a
-                    # schema suggestion base on the redistribute cost.
-                    # For now we simply pick the first suggestion.
-                    suggested_input_schema = output_sharding.schema_suggestions[0]
                     # run sharding propagation again with suggested schema
-                    propagation_res = sharding_prop_func(suggested_input_schema)
+                    propagation_res = sharding_prop_func(
+                        output_sharding.redistribute_schema
+                    )
                     # we set the output sharding with the new propagation result
-                    # so that dispatching know both output_spec and schema_suggestions
+                    # so that dispatching know both output_spec and redistribute_schema
                     # exist, which indicates a reshard is needed
                     output_sharding.output_spec = propagation_res.output_spec
                     output_sharding.needs_redistribute = True

--- a/torch/distributed/_tensor/sharding_prop.py
+++ b/torch/distributed/_tensor/sharding_prop.py
@@ -267,7 +267,6 @@ class ShardingPropagator:
                 else:
                     output_specs = None
 
-                assert suggestion_schema is not None
                 output_sharding = OutputSharding(
                     output_specs,
                     suggestion_schema,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #122950
* #122949
* __->__ #122929

This PR refactors the schema_suggestions in OuputSharding to be a single
OpSchema instead of list of schemas, which in practice we only have one,
for the multiple resharding case we also moved to OpStrategy so there's
no case that needs it to be a list

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang