### PR TITLE
[AOTI][refactor] Improve logging

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -89,6 +89,8 @@ else:
         return False
 
 
+output_code_log = torch._logging.getArtifactLogger(__name__, "output_code")
+
 LOCK_TIMEOUT = 600
 
 # timing metrics for time spent in the compilation
@@ -1661,6 +1663,7 @@ class AotCodeCompiler:
             extra=cpp_command,
             specified_dir=specified_output_path,
         )
+        output_code_log.info("Output code written to: %s", input_path)
 
         def _compile_consts_linux(consts: bytes) -> str:
             _, consts_path = write(

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -289,7 +289,7 @@ class CppWrapperCpu(WrapperCodeGen):
                     if ({name}_expected_dtype != {name}_dtype) {{
                         std::stringstream ss;
                         ss << "{handle_kind}[{idx}]: unmatched dtype, "
-                           << "expected: {name}_expected_dtype ({expected_dtype_name=}, "
+                           << "expected: " << {name}_expected_dtype << "({expected_dtype_name}), "
                            << "but got: " << {name}_dtype << "\\n";
                         throw std::runtime_error(ss.str());
                     }}

--- a/torch/csrc/inductor/aoti_runtime/thread_local.h
+++ b/torch/csrc/inductor/aoti_runtime/thread_local.h
@@ -80,7 +80,7 @@ struct ThreadLocalCachedOutputTensor<ArrayRefTensor<T>> {
   }
 
   std::unique_ptr<T[]> storage_;
-  size_t capacity_ = 0;
+  int64_t capacity_ = 0;
   RAIIAtenTensorHandle tensor_;
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122932

Summary: Improve some logging msgs, and change a data type to remove a compile time warning.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @chauhang