### PR TITLE
[AOTInductor] Support quantized linear on CPU with fbgemm

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -728,7 +728,7 @@ class QLinearUnpackedDynamicFp16 final {
 #endif // USE_FBGEMM
 };
 
-at::Tensor wrapped_fbgemm_pack_gemm_matrix_fp16(const at::Tensor weight) {
+at::Tensor wrapped_fbgemm_pack_gemm_matrix_fp16(const at::Tensor& weight) {
 #ifdef USE_FBGEMM
   TORCH_CHECK(
       weight.dim() == 2,
@@ -740,7 +740,7 @@ at::Tensor wrapped_fbgemm_pack_gemm_matrix_fp16(const at::Tensor weight) {
 #endif // USE_FBGEMM
 }
 
-at::Tensor wrapped_fbgemm_pack_gemm_matrix_fp16_meta(const at::Tensor weight) {
+at::Tensor wrapped_fbgemm_pack_gemm_matrix_fp16_meta(const at::Tensor& weight) {
 #ifdef USE_FBGEMM
   // Strictly speaking this is not correct. However we do not know the exact
   // size of the packed matrix as it's being maintained by the object itself,
@@ -752,7 +752,7 @@ at::Tensor wrapped_fbgemm_pack_gemm_matrix_fp16_meta(const at::Tensor weight) {
 #endif // USE_FBGEMM
 }
 
-at::Tensor wrapped_fbgemm_linear_fp16_weight(at::Tensor input, const at::Tensor weight, const at::Tensor bias, int64_t out_channel) {
+at::Tensor wrapped_fbgemm_linear_fp16_weight(const at::Tensor& input, const at::Tensor& weight, const at::Tensor& bias, int64_t out_channel) {
 #ifdef USE_FBGEMM
   return at::native::fbgemm_linear_fp16_weight(input, weight, bias);
 #else // USE_FBGEMM
@@ -761,7 +761,7 @@ at::Tensor wrapped_fbgemm_linear_fp16_weight(at::Tensor input, const at::Tensor 
 #endif // USE_FBGEMM
 }
 
-at::Tensor wrapped_fbgemm_linear_fp16_weight_meta(at::Tensor input, const at::Tensor weight, const at::Tensor bias, int64_t out_channel) {
+at::Tensor wrapped_fbgemm_linear_fp16_weight_meta(const at::Tensor& input, const at::Tensor& weight, const at::Tensor& bias, int64_t out_channel) {
 #ifdef USE_FBGEMM
   // For the meta function, we need users to provide the dimension explicitly
   // as we don't have access to the weight.

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -683,22 +683,6 @@ class AOTInductorTestsTemplate:
             dynamic_shapes=dynamic_shapes,
         )
 
-    def test_quantized_linear(self):
-        class Model(torch.nn.Module):
-            def __init__(self, device):
-                super().__init__()
-                self.weight = torch.randn(10, 10, device=device)
-                self.bias = torch.randn(10, device=device)
-
-            def forward(self, x):
-                return torch.ops.quantized.linear_dynamic_fp16_unpacked_weight(
-                    x, self.weight, self.bias
-                )
-
-        example_inputs = (torch.randn(10, 10, device=self.device),)
-        with config.patch({"aot_inductor.use_runtime_constant_folding": True}):
-            self.check_model(Model(self.device), example_inputs)
-
     def test_foreach_multiple_dynamic(self):
         class Model(torch.nn.Module):
             def __init__(self):
@@ -772,6 +756,22 @@ class AOTInductorTestsTemplate:
             torch.randn(1, 48, 64, 64, dtype=torch.bfloat16, device=self.device),
         )
         self.check_model(Model(), example_inputs)
+
+    def test_quantized_linear(self):
+        class Model(torch.nn.Module):
+            def __init__(self, device):
+                super().__init__()
+                self.weight = torch.randn(10, 10, device=device)
+                self.bias = torch.randn(10, device=device)
+
+            def forward(self, x):
+                return torch.ops.quantized.linear_dynamic_fp16_unpacked_weight(
+                    x, self.weight, self.bias
+                )
+
+        example_inputs = (torch.randn(10, 10, device=self.device),)
+        with config.patch({"aot_inductor.use_runtime_constant_folding": True}):
+            self.check_model(Model(self.device), example_inputs)
 
     def test_zero_grid_with_unbacked_symbols(self):
         class Repro(torch.nn.Module):

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -683,6 +683,22 @@ class AOTInductorTestsTemplate:
             dynamic_shapes=dynamic_shapes,
         )
 
+    def test_quantized_linear(self):
+        class Model(torch.nn.Module):
+            def __init__(self, device):
+                super().__init__()
+                self.weight = torch.randn(10, 10, device=device)
+                self.bias = torch.randn(10, device=device)
+
+            def forward(self, x):
+                return torch.ops.quantized.linear_dynamic_fp16_unpacked_weight(
+                    x, self.weight, self.bias
+                )
+
+        example_inputs = (torch.randn(10, 10, device=self.device),)
+        with config.patch({"aot_inductor.use_runtime_constant_folding": True}):
+            self.check_model(Model(self.device), example_inputs)
+
     def test_foreach_multiple_dynamic(self):
         class Model(torch.nn.Module):
             def __init__(self):
@@ -1136,70 +1152,6 @@ class AOTInductorTestsTemplate:
                     1,
                     exactly=True,
                 ).run(src_code)
-
-    def test_reuse_kernel_dynamic(self):
-        class Model(torch.nn.Module):
-            def __init__(self, device):
-                super().__init__()
-                self.cst = torch.randn(48, device=device, dtype=torch.float)
-                self.weights = torch.randn(6, 48, 48, device=device, dtype=torch.float)
-                self.cst_1 = torch.randn(48, device=device, dtype=torch.float)
-                self.weights_1 = torch.randn(
-                    6, 48, 48, device=device, dtype=torch.float
-                )
-
-            def forward(self, x, y, z):
-                dim0 = x.size(1)
-                add_0 = z + z
-                expand_2 = add_0.expand(-1, -1, 48)
-                # [s0, 6, 48]
-                mul_3 = add_0 * expand_2
-                # [6, s0, 48]
-                permute_4 = torch.permute(mul_3, (1, 0, 2))
-                # [6, s0, 48]
-                bmm_5 = torch.bmm(permute_4, self.weights)
-                add_6 = bmm_5 + self.cst
-                reshape_7 = torch.reshape(add_6, [6, dim0 * 6, 8])
-                # [6*s0, 6, 8]
-                permute_8 = torch.permute(reshape_7, (1, 0, 2))
-                mul_9 = permute_8 * 0.123
-                reshape_10 = torch.reshape(y, [8, dim0 * 6, 4])
-                # [6*s0, 8, 4]
-                permute_11 = torch.permute(reshape_10, (1, 0, 2))
-                bmm_12 = torch.bmm(mul_9, permute_11)
-
-                add_0_1 = z + z
-                expand_2_1 = add_0_1.expand(-1, -1, 48)
-                # [s0, 6, 48]
-                mul_3_1 = add_0_1 * expand_2_1
-                # [6, s0, 48]
-                permute_4_1 = torch.permute(mul_3_1, (1, 0, 2))
-                # [6, s0, 48]
-                bmm_5_1 = torch.bmm(permute_4_1, self.weights_1)
-                add_6_1 = bmm_5_1 + self.cst_1
-                reshape_7_1 = torch.reshape(add_6_1, [6, dim0 * 6, 8])
-                # [6*s0, 6, 8]
-                permute_8_1 = torch.permute(reshape_7_1, (1, 0, 2))
-                mul_9_1 = permute_8_1 * 0.123
-                reshape_10_1 = torch.reshape(y, [8, dim0 * 6, 4])
-                # [6*s0, 8, 4]
-                permute_11_1 = torch.permute(reshape_10_1, (1, 0, 2))
-                bmm_12_1 = torch.bmm(mul_9_1, permute_11_1)
-                return bmm_12 + bmm_12_1
-
-        x = torch.randn(6, 2, 48, device=self.device, dtype=torch.float)
-        y = torch.randn(48, 2, 4, device=self.device, dtype=torch.float)
-        z = torch.randn(2, 6, 1, device=self.device, dtype=torch.float)
-        dim0 = Dim("dim0", min=1, max=2048)
-        dynamic_shapes = {
-            "x": {1: dim0},
-            "y": {1: dim0},
-            "z": {0: dim0},
-        }
-
-        example_inputs = (x, y, z)
-        m = Model(self.device).to(dtype=torch.float)
-        self.check_model(m, example_inputs, dynamic_shapes=dynamic_shapes)
 
     def test_fake_tensor_device_validation(self):
         if self.device != "cuda":
@@ -2405,6 +2357,8 @@ CUDA_TEST_FAILURES = {
     "test_repeat_output": fail_abi_compatible_cuda(is_skip=True),
     # no ABI shim fn for torch.sort; remove this when adding one
     "test_triton_kernel_multi_output_arg": fail_abi_compatible_cuda(is_skip=True),
+    # quantized unsupported for GPU
+    "test_quantized_linear": fail_cuda(is_skip=True),
     # no runtime checks for non_abi_compatible mode
     "test_runtime_checks": fail_non_abi_compatible_cuda(is_skip=True),
     "test_runtime_checks_complex": fail_non_abi_compatible_cuda(is_skip=True),
@@ -2463,7 +2417,6 @@ if not IS_FBCODE:
             "test_repeat_interleave": fail_minimal_arrayref_interface(is_skip=True),
             "test_return_constant": fail_minimal_arrayref_interface(is_skip=True),
             "test_reuse_kernel": fail_minimal_arrayref_interface(is_skip=True),
-            "test_reuse_kernel_dynamic": fail_minimal_arrayref_interface(is_skip=True),
             "test_simple": fail_minimal_arrayref_interface(is_skip=True),
             "test_small_constant": fail_minimal_arrayref_interface(is_skip=True),
             "test_with_no_triton_profiler": fail_minimal_arrayref_interface(

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -5266,7 +5266,15 @@ class FallbackKernel(ExternKernelAlloc):
                     self.init_args_default_value(schema)
             else:
                 self.python_kernel_name = str(kernel)
-
+        elif kernel.namespace == "_quantized":  # type: ignore[union-attr]
+            # Internal Quantized Fallback Ops
+            assert isinstance(kernel, torch._ops.OpOverload)
+            if V.graph.cpp_wrapper:
+                self.set_cpp_kernel(kernel)
+                if not config.abi_compatible:
+                    self.use_runtime_dispatch = True
+            else:
+                self.python_kernel_name = str(kernel)
         elif isinstance(kernel, torch._ops.HigherOrderOperator):
             self.python_kernel_name = f"torch.ops.higher_order.{kernel.__name__}"
         else:

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -73,6 +73,7 @@ foreach_ops: Set[torch._ops.OpOverload] = set()
 inplace_foreach_ops: Set[torch._ops.OpOverload] = set()
 inplaceable_foreach_ops: Dict[torch._ops.OpOverload, torch._ops.OpOverload] = dict()
 quantized_decomposed = torch.ops.quantized_decomposed
+_quantized = torch.ops._quantized
 
 
 def assert_nyi(cond, msg):

--- a/torch/_inductor/quantized_lowerings.py
+++ b/torch/_inductor/quantized_lowerings.py
@@ -2,6 +2,7 @@ import torch
 from . import lowering
 
 quantized = torch.ops.quantized
+_quantized = torch.ops._quantized
 aten = torch.ops.aten
 
 
@@ -9,10 +10,14 @@ def register_quantized_ops():
     lowering.add_needs_realized_inputs(
         [
             quantized.max_pool2d,
+            _quantized.wrapped_fbgemm_pack_gemm_matrix_fp16,
+            _quantized.wrapped_fbgemm_linear_fp16_weight,
         ]
     )
 
     lowering.make_fallback(quantized.max_pool2d)
+    lowering.make_fallback(_quantized.wrapped_fbgemm_pack_gemm_matrix_fp16)
+    lowering.make_fallback(_quantized.wrapped_fbgemm_linear_fp16_weight)
 
 
 def register_woq_mm_ops():

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -424,6 +424,23 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mm_out(
     AtenTensorHandle self,
     AtenTensorHandle mat2);
 
+// This will soon be deprecated after ao_quantization is complete.
+// Please refrain from using this or increasing callsites.
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch_cpu_wrapped_fbgemm_pack_gemm_matrix_fp16(
+    AtenTensorHandle weight,
+    AtenTensorHandle* out);
+
+// This will soon be deprecated after ao_quantization is complete.
+// Please refrain from using this or increasing callsites.
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch_cpu_wrapped_fbgemm_linear_fp16_weight(
+    AtenTensorHandle input,
+    AtenTensorHandle weight,
+    AtenTensorHandle bias,
+    int64_t out_channel,
+    AtenTensorHandle* out);
+
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_nonzero(AtenTensorHandle self, AtenTensorHandle* out);
 

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -27,6 +27,9 @@
 #include <ATen/ops/bmm.h>
 #include <ATen/ops/convolution.h>
 #include <ATen/ops/empty_strided.h>
+#include <ATen/ops/fbgemm_linear_fp16_weight_fp32_activation_native.h>
+#include <ATen/ops/fbgemm_linear_fp16_weight_native.h>
+#include <ATen/ops/fbgemm_pack_gemm_matrix_fp16_native.h>
 #include <ATen/ops/from_blob.h>
 #include <ATen/ops/index_put.h>
 #include <ATen/ops/mm.h>
@@ -663,6 +666,35 @@ AOTITorchError aoti_torch_mm_out(
     at::Tensor* mat2_tensor = tensor_handle_to_tensor_pointer(mat2);
     at::mm_out(*out_tensor, *self_tensor, *mat2_tensor);
   });
+}
+
+AOTITorchError aoti_torch_cpu_wrapped_fbgemm_pack_gemm_matrix_fp16(
+    AtenTensorHandle weight,
+    AtenTensorHandle* out) {
+  at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
+  auto packed_weight = at::native::fbgemm_pack_gemm_matrix_fp16(*weight_tensor);
+
+  at::Tensor* out_tensor = new at::Tensor(std::move(packed_weight));
+  *out = tensor_pointer_to_tensor_handle(out_tensor);
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({});
+}
+
+AOTITorchError aoti_torch_cpu_wrapped_fbgemm_linear_fp16_weight(
+    AtenTensorHandle input,
+    AtenTensorHandle weight,
+    AtenTensorHandle bias,
+    int64_t out_channel,
+    AtenTensorHandle* out) {
+  at::Tensor* input_tensor = tensor_handle_to_tensor_pointer(input);
+  at::Tensor* weight_tensor = tensor_handle_to_tensor_pointer(weight);
+  at::Tensor* bias_tensor = tensor_handle_to_tensor_pointer(bias);
+
+  auto out_result = at::native::fbgemm_linear_fp16_weight_fp32_activation(
+      *input_tensor, *weight_tensor, *bias_tensor);
+
+  at::Tensor* out_tensor = new at::Tensor(std::move(out_result));
+  *out = tensor_pointer_to_tensor_handle(out_tensor);
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({});
 }
 
 AOTITorchError aoti_torch_nonzero(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122939

Summary:
Added support for quantized linear on CPU with fbgemm.
Specifically, for torch.ops.quantized.linear_unpacked_dynamic_fp16, we
decompose it into two steps, pack weight, and fbgemm's qlinear with
packed weight.

Test Plan:
Included in commit.
test_aot_inductor::test_quantized_linear

Reviewers:

Subscribers:

Tasks:

Tags:
@diff-train-skip-merge
cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @aakhundov @ColinPeppler @amjames @desertfire @chauhang

Differential Revision: [D55512029](https://our.internmc.facebook.com/intern/diff/D55512029)