### PR TITLE
[Inductor] Fix AFOC QPS Regression.

### DIFF
--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -136,7 +136,11 @@ def normalize_split_base(
 
     new_args = (split_input, split_sections)
     new_kwargs = {"dim": split_dim}
-    if split_node.args == new_args and split_node.kwargs == new_kwargs:
+    if (
+        split_node.args == new_args
+        and split_node.kwargs == new_kwargs
+        and split_node.op == "call_function"
+    ):
         return
 
     with graph.inserting_after(split_node):
@@ -290,7 +294,11 @@ def normalize_cat_default(match: Match, *args, **kwargs):
 
     new_args = (tensors,)
     new_kwargs = {"dim": cat_dim}
-    if cat_node.args == new_args and cat_node.kwargs == new_kwargs:
+    if (
+        cat_node.args == new_args
+        and cat_node.kwargs == new_kwargs
+        and cat_node.op == "call_function"
+    ):
         return
 
     with graph.inserting_after(cat_node):


### PR DESCRIPTION
Summary: Recently, we observed ~8% qps regression for AFOC model. After dig into the problem, I found it was introduced by D55272024, where the split node normalization was skipped or call_method split node, while our pattern detection based on the assumption that all split node has been normalized to call_funciton node. More context: https://docs.google.com/document/d/19h-fu2BqdUXMaSqbd7c0-Qe00ic7quUN-emJqH_1-SA/edit

Test Plan:
# unit test
```
buck2 test @mode/dev-nosan //caffe2/test/inductor:split_cat_fx_passes
```
Buck UI: https://www.internalfb.com/buck2/0792d406-3d64-4b9c-95cc-15fb0cc76a96
Test UI: https://www.internalfb.com/intern/testinfra/testrun/11258999096315690
Network: Up: 113KiB  Down: 535KiB  (reSessionID-6132c09b-2ce7-4e89-b61d-d6c6142630cc)
Jobs completed: 26. Time elapsed: 1:25.6s.
Cache hits: 0%. Commands: 2 (cached: 0, remote: 0, local: 2)
Tests finished: Pass 10. Fail 0. Fatal 0. Skip 0. Build failure 0
```
buck2 test @mode/dev-nosan //caffe2/test/inductor:group_batch_fusion
```
Test UI: https://www.internalfb.com/intern/testinfra/testrun/13792273886410433
Network: Up: 1.3MiB  Down: 960KiB  (reSessionID-0bea8575-f163-4c5d-b201-69e05806af98)
Jobs completed: 68. Time elapsed: 2:47.2s.
Cache hits: 0%. Commands: 13 (cached: 0, remote: 1, local: 12)
Tests finished: Pass 9. Fail 0. Fatal 0. Skip 0. Build failure 0

# local reproduce
```
buck2 run @mode/opt //scripts/jackiexu0313/pt2:local_model_with_pt2 -- --test_mode batch-split --model_type "afoc" --flow_id 545665840
```
Now the merge_splits_pass is conducted.
```
'inductor': Counter({'pattern_matcher_nodes': 1614, 'pattern_matcher_count': 1566, 'normalization_pass': 645, 'remove_split_with_size_one_pass': 629, 'batch_aten_mul': 13, 'scmerge_split_sections_removed': 11, 'scmerge_cat_removed': 5, 'scmerge_cat_added': 4, 'merge_splits_pass': 3, 'merge_getitem_cat_pass': 2, 'scmerge_split_removed': 2, 'batch_linear_post_grad': 2, 'batch_aten_sub': 2, 'batch_layernorm': 1, 'scmerge_split_added': 1})}
```

# e2e
baseline:
f545633808

before_fix:
f545665840

After_fix:
f546227494

proposal:

Differential Revision: D55513494




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang