### PR TITLE
add record function Id to Torch ops

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -406,8 +406,8 @@ class TestExecutionTrace(TestCase):
             )
 
         # Uncomment for debugging
-        # print("Output kineto = ", kt.name)
-        # print("Output ET = ", fp.name)
+        print("Output kineto = ", kt.name)
+        print("Output ET = ", fp.name)
 
         p.export_chrome_trace(kt.name)
         self.assertEqual(trace_called_num, 1)

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -362,10 +362,10 @@ class TestExecutionTrace(TestCase):
         return sorted(rf_id for rf_id in rf_ids_ if rf_id is not None)
 
 
-    def get_kineto_external_ids(self, events: List[Json]) -> List[int]:
-        """Returns a sorted list of external Ids for CPU operators and user annotations"""
+    def get_kineto_rf_ids(self, events: List[Json]) -> List[int]:
+        """Returns a sorted list of Record function IDs for CPU operators and user annotations"""
         ops_and_annotations = (e for e in events if e.get("cat", "") in ['cpu_op', 'user_annotation'])
-        return sorted(e.get("args", {}).get("External id", -1) for e in ops_and_annotations)
+        return sorted(e.get("args", {}).get("Record function id", -1) for e in ops_and_annotations)
 
 
     @unittest.skipIf(not kineto_available(), "Kineto is required")
@@ -433,21 +433,17 @@ class TestExecutionTrace(TestCase):
             kineto = json.load(f)
             events = kineto["traceEvents"]
 
-        # Look up rf_ids and external ids as two lists.
-        rf_ids = self.get_execution_trace_rf_ids(nodes)
-        external_ids = self.get_kineto_external_ids(events)
-        self.assertEqual(len(rf_ids), len(external_ids))
+        # Look up rf_ids in both Execution and Kineto trace as two lists.
+        rf_ids_et = self.get_execution_trace_rf_ids(nodes)
+        rf_ids_kineto = self.get_kineto_rf_ids(events)
 
-        # There should be a constant difference between elements in each list
-        # The test experiences a jump in the difference between iterations;
-        # adding some buffer.
-        deltas = {x - y for x, y in zip(rf_ids, external_ids)}
-        self.assertLessEqual(
-            len(deltas),
-            loop_count,
-            msg=f"ET and kineto rf_id should have constant difference, deltas = {deltas}\n"
-                f"rf_ids = {rf_ids}\n"
-                f"external_ids = {external_ids}\n"
+        self.assertCountEqual(rf_ids_et, rf_ids_kineto)
+        self.assertListEqual(
+            rf_ids_et,
+            rf_ids_kineto,
+            msg=f"ET and kineto rf_id should exactly match\n"
+                f"  rf_ids_et = {rf_ids_et}\n"
+                f"  rf_ids_kineto = {rf_ids_kineto}\n"
         )
 
 

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -268,7 +268,8 @@ struct AddGenericMetadata : public MetadataBase {
       addMetadata("Sequence number", std::to_string(op_event.sequence_number_));
     }
     if (op_event.record_function_id_ >= 0) {
-      addMetadata("Record function ID", std::to_string(op_event.record_function_id_));
+      addMetadata(
+          "Record function ID", std::to_string(op_event.record_function_id_));
     }
   }
 

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -267,6 +267,9 @@ struct AddGenericMetadata : public MetadataBase {
       addMetadata("Fwd thread id", std::to_string(op_event.forward_tid_));
       addMetadata("Sequence number", std::to_string(op_event.sequence_number_));
     }
+    if (op_event.record_function_id_ >= 0) {
+      addMetadata("Record function ID", std::to_string(op_event.record_function_id_));
+    }
   }
 
   void operator()(ExtraFields<EventType::Backend>& backend_event) {

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -267,10 +267,8 @@ struct AddGenericMetadata : public MetadataBase {
       addMetadata("Fwd thread id", std::to_string(op_event.forward_tid_));
       addMetadata("Sequence number", std::to_string(op_event.sequence_number_));
     }
-    if (op_event.record_function_id_ >= 0) {
-      addMetadata(
-          "Record function ID", std::to_string(op_event.record_function_id_));
-    }
+    addMetadata(
+        "Record function id", std::to_string(op_event.record_function_id_));
   }
 
   void operator()(ExtraFields<EventType::Backend>& backend_event) {

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -311,6 +311,7 @@ std::unique_ptr<KinetoObserverContext> ThreadLocalSubqueue::begin_op(
           fn.forwardThreadId(),
           fn.scope(),
           fn.isAsync(),
+          fn.handle(),
           fn.debugHandle(),
           fn.name()});
   if (config_.report_input_shapes) {

--- a/torch/csrc/profiler/collection.h
+++ b/torch/csrc/profiler/collection.h
@@ -106,6 +106,7 @@ struct TorchOpBasicFields {
   uint64_t forward_tid_{0};
   at::RecordScope scope_{};
   bool is_async_{false};
+  int64_t record_function_id_{0};
   int64_t debug_handle_{0};
   std::string name_;
 

--- a/torch/csrc/profiler/collection.h
+++ b/torch/csrc/profiler/collection.h
@@ -106,7 +106,7 @@ struct TorchOpBasicFields {
   uint64_t forward_tid_{0};
   at::RecordScope scope_{};
   bool is_async_{false};
-  int64_t record_function_id_{0};
+  uint64_t record_function_id_{0};
   int64_t debug_handle_{0};
   std::string name_;
 


### PR DESCRIPTION
Fixes #122833
Add record function ID as additional metadata for PyTorch op events. This enables correlation with PyTorch Execution traces. 
* Adds a new field "Record function id" for all PyTorch Op events. This value comes from `handle` in record function callback. This is a unique ID to correlate with the PyTorch Execution Trace.
* Updated unit tests.

## Test
Run a simple example uncommenting the `print trace` in the test below
```pytest test/profiler/test_profiler.py -k test_execution_trace_with_kineto```
   
We can see the new record function ID field in ET and Kineto  **Note: the name is "Record function id" now to match the other strings**
Kineto
![Screenshot 2024-03-28 at 5 48 55 PM](https://github.com/pytorch/pytorch/assets/6922212/08243698-8167-4ea0-9be6-2aede9fe9c43)
Execution Trace.
![Screenshot 2024-03-28 at 5 49 14 PM](https://github.com/pytorch/pytorch/assets/6922212/22e4e876-9fbe-43da-9150-dae2927b6e31)

We also see for cases where "External ID" is drifting but "Record function ID" is still matching.
Kineto
![Screenshot 2024-03-28 at 5 50 34 PM](https://github.com/pytorch/pytorch/assets/6922212/60905ea4-0da1-4c4b-a0d0-24500e8f7006)
Execution Trace
![Screenshot 2024-03-28 at 5 50 28 PM](https://github.com/pytorch/pytorch/assets/6922212/680db244-6725-48bf-a7ab-995c658a01ee)


