### PR TITLE
[dtensor] make sure expected input spec have correct tensor meta

### DIFF
--- a/torch/distributed/_tensor/sharding_prop.py
+++ b/torch/distributed/_tensor/sharding_prop.py
@@ -233,7 +233,9 @@ class ShardingPropagator:
                         else output_strategy.input_specs[idx]
                     )
                     expected_input_specs.append(
-                        desired_spec.shallow_copy_with_tensor_meta(input_spec.tensor_meta)
+                        desired_spec.shallow_copy_with_tensor_meta(
+                            input_spec.tensor_meta
+                        )
                     )
                     if input_spec.placements != desired_spec.placements:
                         needs_redistribute = True

--- a/torch/distributed/_tensor/sharding_prop.py
+++ b/torch/distributed/_tensor/sharding_prop.py
@@ -232,7 +232,9 @@ class ShardingPropagator:
                         if output_strategy.input_specs is None
                         else output_strategy.input_specs[idx]
                     )
-                    expected_input_specs.append(desired_spec)
+                    expected_input_specs.append(
+                        desired_spec.shallow_copy_with_tensor_meta(input_spec.tensor_meta)
+                    )
                     if input_spec.placements != desired_spec.placements:
                         needs_redistribute = True
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #122950
* __->__ #122949
* #122929

as titled, previously we could possibly return the expected input spec
that shared by multiple args, this is not ok since different args might
have different tensor metas, why it was working before is because
redistribute in these cases become a no-op.

This PR fixes it by making each expected input spec to shallow clone the
corresponding input metadata

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang