### PR TITLE
[Inductor pattern] support int8 woq mm pattern matcher with freezing passe

### DIFF
--- a/torch/_inductor/constant_folding.py
+++ b/torch/_inductor/constant_folding.py
@@ -62,10 +62,11 @@ class ConstantFolder(torch.fx.Interpreter):
     def is_impure(self, node: torch.fx.node.Node):
         if (
             node.target == torch.ops.prims.convert_element_type.default
-            and node.args[0].op == "get_attr"
-            and node.args[0].meta["val"].dtype == torch.int8
+            and node.args[0].op == "get_attr"  # type: ignore[union-attr]
+            and node.args[0].meta["val"].dtype == torch.int8  # type: ignore[union-attr]
             and node.args[1] == torch.bfloat16
         ):
+            # For int8_weight -> dq -> bf16_weight
             return True
         if node.target in [
             torch.ops.quantized_decomposed.dequantize_per_channel.default,

--- a/torch/_inductor/constant_folding.py
+++ b/torch/_inductor/constant_folding.py
@@ -60,6 +60,13 @@ class ConstantFolder(torch.fx.Interpreter):
         self.user_to_last_uses = self.node_to_last_non_output_use()
 
     def is_impure(self, node: torch.fx.node.Node):
+        if (
+            node.target == torch.ops.prims.convert_element_type.default
+            and node.args[0].op == "get_attr"
+            and node.args[0].meta["val"].dtype == torch.int8
+            and node.args[1] == torch.bfloat16
+        ):
+            return True
         if node.target in [
             torch.ops.quantized_decomposed.dequantize_per_channel.default,
             torch.ops.quantized_decomposed.dequantize_per_tensor.default,

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -1151,6 +1151,7 @@ def _register_woq_lowering(pattern, computation_woq, computation_reshape):
 
 
 def _register_woq_mm_int8_pattern1():
+    # F.linear(x, weight.to(dtype=x.dtype)) * scales
     _woq_pattern = CallFunction(
         aten.mul.Tensor,
         CallFunction(
@@ -1202,6 +1203,7 @@ def _register_woq_mm_int8_pattern1():
 
 
 def _register_woq_mm_int8_pattern2():
+    # F.linear(x, weight.to(dtype=x.dtype)) * scales
     _woq_pattern = CallFunction(
         aten.mul.Tensor,
         CallFunction(


### PR DESCRIPTION
There exist some issues in the previous PR (https://github.com/pytorch/pytorch/pull/120985) of supporting int8 WOQ mm pattern matcher. This PR tends to further optimize it.

1. New patterns are added to match int8 woq mm in gpt-fast model, due to different input layouts.

2. In constant folding, `int8_weight -> dq -> bf16_weight` should be kept for pattern match.

3. Currently, GPT-Fast enables `coordinate_descent_tuning` for CPU. This flag is only useful for CUDA, but it could change the graph: from the non-decomposed fallback pass to the decomposed one. We will disable the flag in GPT-Fast script for CPU, in order to have neat patterns. @yanbing-j 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang