### PR TITLE
[TP] Add wildcard support

### DIFF
--- a/torch/distributed/tensor/parallel/api.py
+++ b/torch/distributed/tensor/parallel/api.py
@@ -1,5 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 from typing import Dict, Union
+from fnmatch import fnmatch
 
 import torch
 import torch.distributed._tensor.random as random
@@ -88,22 +89,29 @@ def parallelize_module(  # type: ignore[return]
         return parallelize_plan._apply(module, device_mesh)
     elif isinstance(parallelize_plan, dict):
         for module_path, parallelize_style in parallelize_plan.items():
-            sub_module = module.get_submodule(module_path)
-            parent_module = module
-            if "." in module_path:
-                path_splits = module_path.split(".")
-                parent_module_path = ".".join(path_splits[:-1])
-                parent_module = module.get_submodule(parent_module_path)
-                module_path = path_splits[-1]
-            parent_module.register_module(  # type: ignore[call-arg] # pyre-ignore[20]
-                module_path,
-                parallelize_module(  # type: ignore[arg-type]
-                    sub_module, device_mesh, parallelize_style  # type: ignore[arg-type] # pyre-ignore[6]
-                ),
-            )
+            path_splits = module_path.split(".")
+            if len(path_splits) == 0:
+                raise ValueError(
+                    "Expect module path to be non-empty, but got empty string!"
+                )
+            while path_splits:
+                atom = path_splits.pop(0)
+                matched_children = filter(
+                    # `t[0]` is child name
+                    lambda t: fnmatch(t[0], atom), module.named_children()
+                )
+                # apply the plan to all matched submodules
+                for _, submodule in matched_children:
+                    if path_splits:
+                        # we haven't reached the leaf, apply in dict style
+                        leaf_path = ".".join(path_splits)   # rest of the path after `atom`
+                        parallelize_module(submodule, device_mesh, {leaf_path: parallelize_style})
+                    else:
+                        # otherwise, directly apply style to this submodule
+                        parallelize_module(submodule, device_mesh, parallelize_style)
         return module
     else:
-        raise RuntimeError(  # pyre-ignore[7]
+        raise TypeError(  # pyre-ignore[7]
             "Expect Union[ParallelStyle, Dict[str, ParallelStyle]] for"
             f" parallelize_plan, {type(parallelize_plan)} found!"
         )

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -78,6 +78,17 @@ class MLPModule(nn.Module):
         self.net2.reset_parameters()
 
 
+class MLPStacked(nn.Module):
+    def __init__(self, device):
+        super().__init__()
+        self.layers = nn.ModuleList([MLPModule(device) for i in range(2)])
+
+    def forward(self, x):
+        for layer in self.layers:
+            x = layer(x)
+        return x
+
+
 @dataclass
 class ModelArgs:
     n_layers: int = 2


### PR DESCRIPTION
Adding wildcard support for TP's `parallelize_module` API.

Example patterns:
`layers.*.linear`: any characters
`layers.?.linear`: single character
`layers.[1-2]`: digit range, matches `layers.1` and `layers.2`

Example use case:
A model have multiple layers, and we want to parallelize the linear module `lin` inside each layer.
```
model_tp = parallelize_module(
    model,
    device_mesh,
    {
        "layers.*.lin": ColwiseParallel(),
    },
)
```

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #123218
* #123199
* __->__ #122968
* #122919



cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang