### PR TITLE
[HigherOrderOp] trace subgraph with current tracer instead of creating new ones

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -4111,19 +4111,19 @@ def forward(self, a, b, l_x_, d_true_branch, c_false_branch):
         self.assertExpectedInline(
             gm.true_graph_0.code.strip(),
             """\
-def forward(self, arg0_1, arg1_1):
-    out_dtype = torch.ops.higher_order.out_dtype(torch.ops.aten.mm.default, torch.int32, arg1_1, arg0_1);  arg1_1 = arg0_1 = None
+def forward(self, _constant_input0, arg0_1):
+    out_dtype = torch.ops.higher_order.out_dtype(torch.ops.aten.mm.default, torch.int32, arg0_1, _constant_input0);  arg0_1 = _constant_input0 = None
     sum_1 = torch.ops.aten.sum.default(out_dtype);  out_dtype = None
-    return (sum_1,)""",
+    return (sum_1,)""",  # noqa: B950
         )
 
         self.assertExpectedInline(
             gm.false_graph_0.code.strip(),
             """\
-def forward(self, arg0_1, arg1_1):
-    out_dtype = torch.ops.higher_order.out_dtype(torch.ops.aten.mul.Tensor, torch.int32, arg1_1, arg0_1);  arg1_1 = arg0_1 = None
+def forward(self, _constant_input0, arg0_1):
+    out_dtype = torch.ops.higher_order.out_dtype(torch.ops.aten.mul.Tensor, torch.int32, arg0_1, _constant_input0);  arg0_1 = _constant_input0 = None
     sum_1 = torch.ops.aten.sum.default(out_dtype);  out_dtype = None
-    return (sum_1,)""",
+    return (sum_1,)""",  # noqa: B950
         )
 
     def test_export_nn_module_stack_patched_module(self):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -3552,11 +3552,11 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1):
     return (getitem,)""")  # noqa: B950
 
         self.assertExpectedInline(str(exported_program.graph_module.true_graph_0.code.strip()), """\
-def forward(self, arg0_1, arg1_1, arg2_1):
+def forward(self, arg1_1, arg2_1, arg3_1):
     _set_grad_enabled = torch._C._set_grad_enabled(True)
-    sub = torch.ops.aten.sub.Tensor(arg1_1, 1);  arg1_1 = None
-    add = torch.ops.aten.add.Tensor(sub, arg0_1);  sub = arg0_1 = None
-    add_1 = torch.ops.aten.add.Tensor(add, arg2_1);  add = arg2_1 = None
+    sub = torch.ops.aten.sub.Tensor(arg2_1, 1);  arg2_1 = None
+    add = torch.ops.aten.add.Tensor(sub, arg1_1);  sub = arg1_1 = None
+    add_1 = torch.ops.aten.add.Tensor(add, arg3_1);  add = arg3_1 = None
     _set_grad_enabled_1 = torch._C._set_grad_enabled(False)
     return (add_1,)""")
 

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -3061,8 +3061,8 @@ def forward(self, arg0_1):
     return (getitem,)""")  # noqa: B950
 
         self.assertExpectedInline(str(gm.true_graph_0.true_graph_0.code).strip(), """\
-def forward(self, arg0_1):
-    sin = torch.ops.aten.sin.default(arg0_1);  arg0_1 = None
+def forward(self, cos_1):
+    sin = torch.ops.aten.sin.default(cos_1);  cos_1 = None
     add = torch.ops.aten.add.Tensor(sin, 7);  sin = None
     sin_1 = torch.ops.aten.sin.default(add);  add = None
     return (sin_1,)""")

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -1650,8 +1650,8 @@ def forward(self, x_1):
     getitem = conditional[0];  conditional = None
     return getitem""")  # noqa: B950
         self.assertExpectedInline(gm.true_graph_0.code.strip(), """\
-def forward(self, x_1, _input1, _input2):
-    add = torch.ops.aten.add.Tensor(x_1, _input1);  x_1 = _input1 = None
+def forward(self, x_1, _constant_input1, _constant_input2):
+    add = torch.ops.aten.add.Tensor(x_1, _constant_input1);  x_1 = _constant_input1 = None
     return (add,)""")
 
     def test_cond_with_module_param_closure(self):
@@ -1766,10 +1766,10 @@ def forward(self, pred_1, x_1):
     getitem = map_impl[0];  map_impl = None
     return getitem""")
         self.assertExpectedInline(gm.body_graph_0.code.strip(), """\
-def forward(self, _input0, pred_1):
+def forward(self, _constant_input0, pred_1):
     true_graph_0 = self.true_graph_0
     false_graph_0 = self.false_graph_0
-    conditional = torch.ops.higher_order.cond(pred_1, true_graph_0, false_graph_0, [_input0]);  pred_1 = true_graph_0 = false_graph_0 = _input0 = None
+    conditional = torch.ops.higher_order.cond(pred_1, true_graph_0, false_graph_0, [_constant_input0]);  pred_1 = true_graph_0 = false_graph_0 = _constant_input0 = None
     getitem = conditional[0];  conditional = None
     return [getitem]""")  # noqa: B950
 

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -141,8 +141,9 @@ def trace_subgraph(proxy_mode, func, args):
                 # Sometimes we can have inputs that are not proxies e.g. tensor closures.
                 # They're not tracked by parent graph yet so just give them a name manually.
                 # Note this won't affect the correctness of the sub_graph.
+                const_name = "_constant_input"
                 new_proxy_arg = subgraph_tracer.create_proxy(
-                    "placeholder", f"_input{i}", (), {}, name=f"_constant_input{i}"
+                    "placeholder", f"{const_name}{i}", (), {}, name=f"{const_name}{i}"
                 )
             else:
                 new_proxy_arg = subgraph_tracer.create_proxy(

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -142,7 +142,7 @@ def trace_subgraph(proxy_mode, func, args):
                 # They're not tracked by parent graph yet so just give them a name manually.
                 # Note this won't affect the correctness of the sub_graph.
                 new_proxy_arg = subgraph_tracer.create_proxy(
-                    "placeholder", f"_input{i}", (), {}, name=f"_input{i}"
+                    "placeholder", f"_input{i}", (), {}, name=f"_constant_input{i}"
                 )
             else:
                 new_proxy_arg = subgraph_tracer.create_proxy(

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -689,7 +689,6 @@ class PreDispatchTorchFunctionMode(TorchFunctionMode):
         self.tracer = tracer
 
     def __torch_function__(self, func, types, args=(), kwargs=None):
-        print("PreDispatchTorchFunctionMode")
         kwargs = kwargs or {}
         if func in _side_effectful_need_to_be_preserved_pre_dispatch:
             # It's for passing the export verifier which needs to verify the meta['val']

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -689,6 +689,7 @@ class PreDispatchTorchFunctionMode(TorchFunctionMode):
         self.tracer = tracer
 
     def __torch_function__(self, func, types, args=(), kwargs=None):
+        print("PreDispatchTorchFunctionMode")
         kwargs = kwargs or {}
         if func in _side_effectful_need_to_be_preserved_pre_dispatch:
             # It's for passing the export verifier which needs to verify the meta['val']


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #122972

## Motivation
Previously, exportable higher order ops starts a new make_fx session to trace the subgraphs. But this approach has many limitations:

There are many `global states`, `configs` and `mutable states` tracked by make_fx tracer, and they must be properly handled in the recursive make_fx calls. We've encountered a bunch of bugs due to this reason: 1. inductor uses a different decomposition table, but inner make_fx didn't. 2. top-level make_fx uses pre-dispatch tracing but inner make_fx didn't. 3.  metadata such 'nn_module_stack', that's tracked/mutated as states in _ModuleStackTracer are not captured for inner graph.

## Design
This PR chooses a more aggressive design: we'll use the **same tracer** to trace the subgraph. For tracer states, unless they're explicitly reset and restored in a `_reset_tracer_states_temporarily` function, they'll be preserved after tracing the subgraphs. The rationale are that 1. people generally expect the subgraphs to be treated the same as top-level graph for their new feature (e.g. in cases listed above). So by default newly added states/modified configurations should probably be preserved/tracked when tracing the subgraph. 2. There are a ton of states in the tracer but most of them won't affect the correctness of traced graph even if we allow mutations to them when tracing subgraph.

The current states listed in `_reset_tracer_states_temporarily` may NOT be complete. But the list is can be easily extended when needed.

Test Plan:
existing tests. The placeholder names for subgraph are now the variable names in parent graph when they're tracked by parent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang