### PR TITLE
add dynamo config cprofile_rename

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -141,6 +141,9 @@ disable = os.environ.get("TORCH_COMPILE_DISABLE", False)
 # [@compile_ignored: runtime_behaviour] Get a cprofile trace of Dynamo
 cprofile = os.environ.get("TORCH_COMPILE_CPROFILE", False)
 
+# [@compile_ignored: runtime_behaviour] User can set customized rename alias in filename
+cprofile_rename = os.environ.get("TORCH_COMPILE_CPROFILE_RENAME", None)
+
 # legacy config, does nothing now!
 skipfiles_inline_module_allowlist: Dict[Any, Any] = {}
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -141,7 +141,8 @@ def cprofile_wrapper(func):
     def profile_wrapper(*args, **kwargs):
         global timer_counter
         profile_cnt = next(timer_counter)
-        profile_path = Path(func.__name__ + f"{profile_cnt}.profile")
+        profile_suffix = f".{config.cprofile_rename}.profile" if config.cprofile_rename else ".profile"
+        profile_path = Path(func.__name__ + f"{profile_cnt}{profile_suffix}")
         prof = cProfile.Profile()
         prof.enable()
         start_ts = time.time()


### PR DESCRIPTION
Summary: without it, each run will purge svg files when previewed locally.  no affect by default.

Reviewed By: Yuzhen11

Differential Revision: D55453161




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang