### PR TITLE
[AOTI] Serialize large weights

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -2742,6 +2742,7 @@ if TEST_WITH_ROCM:
             "test_bmm_multiple_dynamic": fail_cuda(is_skip=True),
             "test_convolution": fail_cuda(is_skip=True),
             "test_large": fail_cuda(is_skip=True),
+            "test_large_mmaped_weights": fail_cuda(is_skip=True),
             "test_missing_cubin": fail_cuda(is_skip=True),
             "test_multi_device": fail_cuda(is_skip=True),
             "test_poi_multiple_dynamic": fail_cuda(is_skip=True),
@@ -2777,6 +2778,7 @@ if not IS_FBCODE:
             "test_convolution": fail_minimal_arrayref_interface(is_skip=True),
             "test_empty_graph": fail_minimal_arrayref_interface(is_skip=True),
             "test_large": fail_minimal_arrayref_interface(is_skip=True),
+            "test_large_mmaped_weights": fail_minimal_arrayref_interface(is_skip=True),
             "test_missing_output": fail_minimal_arrayref_interface(is_skip=True),
             "test_model_modified_weights": fail_minimal_arrayref_interface(
                 is_skip=True

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -282,7 +282,7 @@ class AOTInductorTestsTemplate:
             torch.randn(1, 250112, device=self.device),
             torch.randn(1, 512, device=self.device),
         )
-        with config.patch({"_force_mmap_aoti_weights": True}):
+        with config.patch({"aot_inductor.force_mmap_weights": True}):
             self.check_model(Model(), example_inputs)
 
     def test_with_offset(self):

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -269,6 +269,22 @@ class AOTInductorTestsTemplate:
         )
         self.check_model(Model(), example_inputs)
 
+    def test_large_mmaped_weights(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(512, 250112)
+
+            def forward(self, x, y):
+                return x + self.linear(y)
+
+        example_inputs = (
+            torch.randn(1, 250112, device=self.device),
+            torch.randn(1, 512, device=self.device),
+        )
+        with config.patch({"_force_mmap_aoti_weights": True}):
+            self.check_model(Model(), example_inputs)
+
     def test_with_offset(self):
         class Model(torch.nn.Module):
             def __init__(self, device):

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -37,6 +37,7 @@ from threading import Thread
 from time import sleep, time
 from types import ModuleType
 from typing import (
+    cast,
     Any,
     Callable,
     Dict,
@@ -1799,7 +1800,7 @@ class AotCodeCompiler:
             )
             # TODO: Fix mmap weights with cuda
             use_mmap_weights = (
-                not cuda and config.is_fbcode() and consts_size > 3_000_000_000
+                not cuda and not config.is_fbcode() and consts_size > 2_000_000_000
             )
             if config._force_mmap_aoti_weights and not cuda:
                 use_mmap_weights = True
@@ -1845,9 +1846,9 @@ class AotCodeCompiler:
                 aot_constants = serialized_weights
                 magic_number = 0
             else:
-                magic_number = torch.randint(
-                    0, torch.iinfo(torch.int64).max, (1,)
-                ).item()
+                magic_number = cast(
+                    int, torch.randint(0, torch.iinfo(torch.int64).max, (1,)).item()
+                )
                 aot_constants = struct.pack("qq", consts_size + 8, magic_number)
             consts_o = {
                 "linux": _compile_consts_linux,

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -19,6 +19,7 @@ import re
 import shlex
 import shutil
 import signal
+import struct
 import subprocess
 import sys
 import sysconfig
@@ -1545,6 +1546,7 @@ def cpp_compile_command(
     aot_mode: bool = False,
     compile_only: bool = False,
     use_absolute_path: bool = False,
+    use_mmap_weights: bool = False,
 ) -> str:
     ipaths, lpaths, libs, macros, build_arch_flags = get_include_and_linking_paths(
         include_pytorch, vec_isa, cuda, aot_mode
@@ -1577,6 +1579,9 @@ def cpp_compile_command(
     if compile_only:
         libs, lpaths = "", ""
     inp_name_str = " ".join(inp_name)
+    if use_mmap_weights:
+        macros += " -D USE_MMAP_SELF"
+
     return re.sub(
         r"[ \n]+",
         " ",
@@ -1655,7 +1660,11 @@ class AotCodeCompiler:
         picked_vec_isa = pick_vec_isa()
         cpp_command = repr(
             cpp_compile_command(
-                "i", "o", vec_isa=picked_vec_isa, cuda=cuda, aot_mode=graph.aot_mode
+                "i",
+                "o",
+                vec_isa=picked_vec_isa,
+                cuda=cuda,
+                aot_mode=graph.aot_mode,
             )
         )
         fbcode_aot_cpu_re = False
@@ -1783,6 +1792,17 @@ class AotCodeCompiler:
             )
 
             output_o = os.path.splitext(input_path)[0] + ".o"
+            consts_size = sum(
+                tensor.untyped_storage().nbytes()
+                for (name, tensor) in graph.constants.items()
+                if name not in graph.folded_constants
+            )
+            # TODO: Fix mmap weights with cuda
+            use_mmap_weights = (
+                not cuda and config.is_fbcode() and consts_size > 3_000_000_000
+            )
+            if config._force_mmap_aoti_weights and not cuda:
+                use_mmap_weights = True
             compile_cmd = cpp_compile_command(
                 input=input_path,
                 output=output_o,
@@ -1791,6 +1811,7 @@ class AotCodeCompiler:
                 aot_mode=graph.aot_mode,
                 compile_only=True,
                 use_absolute_path=use_absolute_path,
+                use_mmap_weights=use_mmap_weights,
             )
             log.debug("aot compilation command: %s", compile_cmd)
             if fbcode_aot_cpu_re:
@@ -1815,11 +1836,19 @@ class AotCodeCompiler:
 
                 return bytes(raw_array.contents)
 
-            aot_constants = b"".join(
+            serialized_weights = b"".join(
                 _to_bytes(graph.get_original_value_of_constant(name))
                 for name in graph.constants.keys()
                 if name not in graph.folded_constants
             )
+            if not use_mmap_weights:
+                aot_constants = serialized_weights
+                magic_number = 0
+            else:
+                magic_number = torch.randint(
+                    0, torch.iinfo(torch.int64).max, (1,)
+                ).item()
+                aot_constants = struct.pack("qq", consts_size + 8, magic_number)
             consts_o = {
                 "linux": _compile_consts_linux,
                 "darwin": _compile_consts_darwin,
@@ -1839,6 +1868,14 @@ class AotCodeCompiler:
                 os.chmod(output_so, 0o755)
             else:
                 run_command_and_check(link_cmd)
+
+            if use_mmap_weights:
+                with open(output_so, "a+b") as f_so:
+                    so_size = f_so.tell()
+                    # Page align the weights
+                    f_so.write(b" " * (4096 - so_size % 4096))
+                    f_so.write(serialized_weights)
+                    f_so.write(struct.pack("q", magic_number))
 
             # Append cmds to the end of codegen-ed wrapper file
             with open(input_path, "a") as f:

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1874,7 +1874,7 @@ class AotCodeCompiler:
                 with open(output_so, "a+b") as f_so:
                     so_size = f_so.tell()
                     # Page align the weights
-                    f_so.write(b" " * (4096 - so_size % 4096))
+                    f_so.write(b" " * (16384 - so_size % 16384))
                     f_so.write(serialized_weights)
                     f_so.write(struct.pack("q", magic_number))
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -37,9 +37,9 @@ from threading import Thread
 from time import sleep, time
 from types import ModuleType
 from typing import (
-    cast,
     Any,
     Callable,
+    cast,
     Dict,
     List,
     Optional,
@@ -1802,7 +1802,7 @@ class AotCodeCompiler:
             use_mmap_weights = (
                 not cuda and not config.is_fbcode() and consts_size > 2_000_000_000
             )
-            if config._force_mmap_aoti_weights and not cuda:
+            if config.aot_inductor.force_mmap_weights and not cuda:
                 use_mmap_weights = True
             compile_cmd = cpp_compile_command(
                 input=input_path,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -373,6 +373,9 @@ _fuse_ddp_communication_passes: List[Union[Callable[..., None], str]] = [
     "schedule_comm_wait",
 ]
 
+# Force apending aoti weights at the end of the file
+_force_mmap_aoti_weights = False
+
 
 def decide_compile_threads():
     """

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -373,9 +373,6 @@ _fuse_ddp_communication_passes: List[Union[Callable[..., None], str]] = [
     "schedule_comm_wait",
 ]
 
-# Force apending aoti weights at the end of the file
-_force_mmap_aoti_weights = False
-
 
 def decide_compile_threads():
     """
@@ -701,6 +698,10 @@ class aot_inductor:
 
     # flag to decide whether to create a submodule for constant graph.
     use_runtime_constant_folding: bool = False
+
+    # flag to force weight to be appened to the shared library and mmaped  by the runtime
+    # rather than embedded into the data section. Needed to support 1B+ parameter models
+    force_mmap_weights: bool = False
 
 
 class cuda:

--- a/torch/csrc/inductor/aoti_runtime/model.h
+++ b/torch/csrc/inductor/aoti_runtime/model.h
@@ -290,12 +290,18 @@ class AOTInductorModelBase {
           reinterpret_cast<const uint64_t*>(_binary_constants_bin_start)[1];
       auto weights_offset = fsize - weights_size;
       AOTI_RUNTIME_CHECK(
-          (weights_offset & 4095) == 0,
-          "weights_offset are not alligned to page size");
-      auto ptr = mmap(NULL, fsize, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
+          (weights_offset & 0x3fff) == 0,
+          "weights_offset must be aligned to 16K boundary");
+      auto ptr = mmap(
+          NULL,
+          weights_size,
+          PROT_READ | PROT_WRITE,
+          MAP_PRIVATE,
+          fd,
+          weights_offset);
       close(fd);
       AOTI_RUNTIME_CHECK(ptr != MAP_FAILED, "mmap() failed");
-      self_mmap = static_cast<uint8_t*>(ptr) + weights_offset;
+      self_mmap = static_cast<uint8_t*>(ptr);
       AOTI_RUNTIME_CHECK(
           reinterpret_cast<uint64_t*>(
               self_mmap + weights_size - sizeof(uint64_t))[0] == magic_number,

--- a/torch/csrc/inductor/aoti_runtime/model.h
+++ b/torch/csrc/inductor/aoti_runtime/model.h
@@ -1,7 +1,12 @@
 #pragma once
 
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
 #include <optional>
 #include <regex>
+#include <stdexcept>
 #include <unordered_map>
 
 // WARNING: Be careful when adding new includes here. This header will be used
@@ -268,7 +273,37 @@ class AOTInductorModelBase {
           cudaMemcpyHostToDevice));
     }
     return internal_ptr;
-#else // !USE_CUDA
+#elif USE_MMAP_SELF
+    // get pointer to constant which is packed in model during compile time.
+    AOTI_RUNTIME_CHECK(!skip_copy, "pure cpu mode doesn't support skip copy");
+    if (!self_mmap) {
+      Dl_info dl_info;
+      // get pointer to constant which are appended to the binary
+      AOTI_RUNTIME_CHECK(
+          dladdr(__func__, &dl_info), "Can't find shared library name");
+      int fd = open(dl_info.dli_fname, O_RDONLY);
+      AOTI_RUNTIME_CHECK(fd >= 0, "Shared library file cannot be opened");
+      auto fsize = lseek(fd, 0, SEEK_END);
+      auto weights_size =
+          reinterpret_cast<const uint64_t*>(_binary_constants_bin_start)[0];
+      auto magic_number =
+          reinterpret_cast<const uint64_t*>(_binary_constants_bin_start)[1];
+      auto weights_offset = fsize - weights_size;
+      AOTI_RUNTIME_CHECK(
+          (weights_offset & 4095) == 0,
+          "weights_offset are not alligned to page size");
+      auto ptr = mmap(NULL, fsize, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
+      close(fd);
+      AOTI_RUNTIME_CHECK(ptr != MAP_FAILED, "mmap() failed");
+      self_mmap = static_cast<uint8_t*>(ptr) + weights_offset;
+      AOTI_RUNTIME_CHECK(
+          reinterpret_cast<uint64_t*>(
+              self_mmap + weights_size - sizeof(uint64_t))[0] == magic_number,
+          "Weigths data seems corrupt");
+    }
+    return self_mmap + bytes_read;
+
+#else // !USE_CUDA&& !USE_MMAP_SELF
     // get pointer to constant which is packed in model during compile time.
     AOTI_RUNTIME_CHECK(!skip_copy, "pure cpu mode doesn't support skip copy");
     return const_cast<uint8_t*>(_binary_constants_bin_start) + bytes_read;
@@ -457,6 +492,9 @@ class AOTInductorModelBase {
   // Holds the blob storage for constants' at::Tensor for CUDA.
   CUDAPtr constant_blob_;
 #endif // USE_CUDA
+#ifdef USE_MMAP_SELF
+  uint8_t* self_mmap = NULL;
+#endif
 
   // A directory with CUDA binary files, e.g. compiled kernels, etc.
   const std::optional<std::string> cubin_dir_;


### PR DESCRIPTION
But appending them to the end of the shared library and mmaping afterwards
Disabled by default, but overridable by `config.aot_inductor.force_mmap_weights`

Implemented by adding `USE_MMAP_SELF` define to `inductor/aoti_runtime/model.h` which is defined when weights are appended to the binary. In that case, shared library name is determined by calling `dladdr`, mmaped and finally checked against random magic number embedded at the end of the weights as well as in const section of the library in question

Added unites to validate that it works as expected
TODO:
  - Extend support to CUDA
  - munmap region if the same library is reused


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang