### PR TITLE
Quantized relu

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/quantized_clamp_qint8.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_clamp_qint8.glsl
@@ -1,0 +1,30 @@
+#version 450 core
+#define PRECISION ${PRECISION}
+#define FORMAT    ${FORMAT}
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, rgba8i) uniform PRECISION restrict writeonly iimage3D   uOutput;
+layout(set = 0, binding = 1)         uniform PRECISION                    isampler3D uInput; // quantized input
+layout(set = 0, binding = 2)         uniform PRECISION restrict           Block {
+  ivec4 size;
+  vec2 clamp;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (all(lessThan(pos, uBlock.size.xyz))) {
+    vec4 temp = texelFetch(uInput, pos, 0);
+    temp = clamp(temp, uBlock.clamp.x, uBlock.clamp.y);
+    ivec4 store = ivec4(temp);
+    imageStore(
+        uOutput,
+        pos,
+        store);
+  }
+}

--- a/aten/src/ATen/native/vulkan/glsl/quantized_clamp_qint8_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_clamp_qint8_.glsl
@@ -1,0 +1,28 @@
+#version 450 core
+#define PRECISION ${PRECISION}
+#define FORMAT    ${FORMAT}
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, rgba8i) uniform PRECISION restrict iimage3D   uOutput;
+layout(set = 0, binding = 1)         uniform PRECISION restrict           Block {
+  ivec4 size;
+  vec2 clamp;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+  if (all(lessThan(pos, uBlock.size.xyz))) {
+    vec4 temp = imageLoad(uOutput, pos);
+    temp = clamp(temp, uBlock.clamp.x, uBlock.clamp.y);
+    ivec4 store = ivec4(temp);
+    imageStore(
+        uOutput,
+        pos,
+        store);
+  }
+}

--- a/aten/src/ATen/native/vulkan/glsl/quantized_clamp_quint8.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_clamp_quint8.glsl
@@ -1,0 +1,30 @@
+#version 450 core
+#define PRECISION ${PRECISION}
+#define FORMAT    ${FORMAT}
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, rgba8ui) uniform PRECISION restrict writeonly uimage3D   uOutput;
+layout(set = 0, binding = 1)         uniform PRECISION                    isampler3D uInput; // quantized input
+layout(set = 0, binding = 2)         uniform PRECISION restrict           Block {
+  ivec4 size;
+  vec2 clamp;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (all(lessThan(pos, uBlock.size.xyz))) {
+    vec4 temp = texelFetch(uInput, pos, 0);
+    temp = clamp(temp, uBlock.clamp.x, uBlock.clamp.y);
+    uvec4 store = uvec4(temp);
+    imageStore(
+        uOutput,
+        pos,
+        store);
+  }
+}

--- a/aten/src/ATen/native/vulkan/glsl/quantized_clamp_quint8_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_clamp_quint8_.glsl
@@ -1,0 +1,29 @@
+#version 450 core
+#define PRECISION ${PRECISION}
+#define FORMAT    ${FORMAT}
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, rgba8ui) uniform PRECISION restrict uimage3D   uOutput;
+layout(set = 0, binding = 1)         uniform PRECISION restrict           Block {
+  ivec4 size;
+  vec2 clamp;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (all(lessThan(pos, uBlock.size.xyz))) {
+    vec4 temp = imageLoad(uOutput, pos);
+    temp = clamp(temp, uBlock.clamp.x, uBlock.clamp.y);
+    uvec4 store = uvec4(temp);
+    imageStore(
+        uOutput,
+        pos,
+        store);
+  }
+}

--- a/aten/src/ATen/native/vulkan/ops/Common.h
+++ b/aten/src/ATen/native/vulkan/ops/Common.h
@@ -90,6 +90,10 @@ inline c10::optional<Scalar> get_optional_scalar(
                                       : c10::optional<Scalar>();
 }
 
+inline float roundevenf(float v) {
+  return (float)nearbyint(v);
+}
+
 } // namespace ops
 } // namespace vulkan
 } // namespace native

--- a/aten/src/ATen/test/vulkan_quantized_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_quantized_api_test.cpp
@@ -3765,6 +3765,68 @@ TEST_F(VulkanAPITest, gelu_quint8_self) {
   test_gelu({200, 20, 30, 10}, c10::ScalarType::QUInt8, true);
 }
 
+void test_relu(
+    const at::IntArrayRef input_shape,
+    const c10::ScalarType dtype,
+    bool inplace) {
+  const auto in_cpu = produce_random_tensor(input_shape);
+
+  const auto input_quant_params = compute_quant_params(in_cpu, dtype);
+  double scale = std::get<0>(input_quant_params);
+  scale = safe_downcast<float>(scale);
+  int zero_point = std::get<1>(input_quant_params);
+
+  auto in_cpu_quantized =
+      at::quantize_per_tensor(in_cpu, scale, zero_point, dtype);
+
+  auto in_vk_quantized =
+      at::quantize_per_tensor(in_cpu.vulkan(), scale, zero_point, dtype);
+
+  const auto out_cpu_quantized =
+      inplace ? at::relu_(in_cpu_quantized) : at::relu(in_cpu_quantized);
+
+  const auto out_vk_quantized =
+      inplace ? at::relu_(in_vk_quantized) : at::relu(in_vk_quantized);
+
+  const auto out_cpu_deq = at::dequantize(out_cpu_quantized);
+  const auto out_vk_deq = at::dequantize(out_vk_quantized);
+  const auto out_vk_deq_cpu = out_vk_deq.cpu();
+
+  const auto check =
+      almostEqual(out_vk_deq_cpu, out_cpu_deq, safe_downcast<float>(scale));
+
+  if (!check) {
+    showRtol(out_cpu_deq, out_vk_deq_cpu);
+  }
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, relu_qint8) {
+  test_relu({200, 20}, c10::ScalarType::QInt8, false);
+  test_relu({200, 20, 10}, c10::ScalarType::QInt8, false);
+  test_relu({200, 20, 30, 10}, c10::ScalarType::QInt8, false);
+}
+
+TEST_F(VulkanAPITest, relu_qint8_inplace) {
+  test_relu({4, 1, 4}, c10::ScalarType::QInt8, true);
+  test_relu({200, 20}, c10::ScalarType::QInt8, true);
+  test_relu({200, 20, 10}, c10::ScalarType::QInt8, true);
+  test_relu({200, 20, 30, 10}, c10::ScalarType::QInt8, true);
+}
+
+TEST_F(VulkanAPITest, relu_quint8) {
+  test_relu({200, 20}, c10::ScalarType::QUInt8, false);
+  test_relu({200, 20, 10}, c10::ScalarType::QUInt8, false);
+  test_relu({200, 20, 30, 10}, c10::ScalarType::QUInt8, false);
+}
+
+TEST_F(VulkanAPITest, relu_quint8_inplace) {
+  test_relu({4, 1, 4}, c10::ScalarType::QUInt8, true);
+  test_relu({200, 20}, c10::ScalarType::QUInt8, true);
+  test_relu({200, 20, 10}, c10::ScalarType::QUInt8, true);
+  test_relu({200, 20, 30, 10}, c10::ScalarType::QUInt8, true);
+}
+
 } // namespace
 
 #endif /* USE_VULKAN_API */


### PR DESCRIPTION
Summary: Add Quantized relu ops.

Test Plan:
Run vulkan api test:
# buck2 build --target-platforms ovr_config//platform/macos:arm64-fbsource  //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1 --show-output"
# buck-out//v2/gen/fbsource/xplat/caffe2/pt_vulkan_api_test_binAppleMac
Running main() from third-party/googletest/1.14.0/googletest/googletest/src/gtest_main.cc
[==========] Running 418 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 418 tests from VulkanAPITest
....
[----------] Global test environment tear-down
[==========] 418 tests from 1 test suite ran. (4510 ms total)
[  PASSED  ] 417 tests.
[  SKIPPED ] 1 test, listed below:
[  SKIPPED ] VulkanAPITest.querypool_flushed_shader_log

  YOU HAVE 9 DISABLED TESTS

Run quantized vulkan api test: Note the linear quantized are failing but all the convolution tests still pass. Linear failures are being debugged.
# buck2 build --target-platforms ovr_config//platform/macos:arm64-fbsource  //xplat/caffe2:pt_vulkan_quantized_api_test_binAppleMac\#macosx-arm64 -c pt.vulkan_full_precision=1 --show-output"
# buck-out//v2/gen/fbsource/xplat/caffe2/pt_vulkan_quantized_api_test_binAppleMac
Running main() from third-party/googletest/1.14.0/googletest/googletest/src/gtest_main.cc
[==========] Running 86 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 86 tests from VulkanAPITest
...
[  PASSED  ] 77 tests.
[  FAILED  ] 9 tests, listed below:
[  FAILED  ] VulkanAPITest.linear_2d_flat
[  FAILED  ] VulkanAPITest.linear_2d_small
[  FAILED  ] VulkanAPITest.linear_2d_large
[  FAILED  ] VulkanAPITest.linear_3d_flat
[  FAILED  ] VulkanAPITest.linear_3d_small
[  FAILED  ] VulkanAPITest.linear_3d_large
[  FAILED  ] VulkanAPITest.linear_4d_flat
[  FAILED  ] VulkanAPITest.linear_4d_small
[  FAILED  ] VulkanAPITest.linear_4d_large

 9 FAILED TESTS
  YOU HAVE 8 DISABLED TESTS

Reviewed By: copyrightly

Differential Revision: D52344264


