### PR TITLE
[minifier] Add config flag to ignore non-fp values

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -187,6 +187,13 @@ repro_forward_only = os.environ.get("TORCHDYNAMO_REPRO_FORWARD_ONLY") == "1"
 # [@compile_ignored: debug]
 repro_tolerance = 1e-3
 
+
+# Whether to ignore non-floating point values when checking accuracy.
+# Checking accuracy of non-floating point values such as boolean tensors
+# can lead to false positives.
+# [@compile_ignored: debug]
+repro_ignore_non_fp = os.environ.get("TORCHDYNAMO_REPRO_IGNORE_NON_FP") == "1"
+
 # If True, when testing if two models are the same, we will test them against
 # a third fp64 reference and only report a problem if the RMSE relative to the
 # fp64 is greater.  However, this will use more memory; you may disable this

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -143,6 +143,7 @@ def wrap_compiler_debug(unconfigured_compiler_fn, compiler_name: str):
                     inner_compiled_fn,
                     real_inputs,
                     only_fwd=True,
+                    ignore_non_fp=config.repro_ignore_non_fp,
                 )
 
                 if failed:
@@ -495,6 +496,11 @@ def repro_common(options, mod, load_args):
     return mod, args
 
 
+ACCURACY_KWARGS: Dict[str, Dict[str, Any]] = {
+    "accuracy": dict(require_fp64=True, ignore_non_fp=True),
+    "strict_accuracy": dict(require_fp64=False, ignore_non_fp=False),
+}
+
 ACCURACY_FAILS: Dict[str, Callable[[nn.Module, Any], bool]] = {
     "": inductor_fails,
     # This might look inverted but it's not.  strict_accuracy means "we will
@@ -709,7 +715,13 @@ def repro_run(options, mod, load_args):
     if options.accuracy != "":
         # We don't really respect --accuracy vs --strict-accuracy here, it
         # seems counterintuitive
-        if not same_two_models(mod, compiled, args, only_fwd=True):
+        if not same_two_models(
+            mod,
+            compiled,
+            args,
+            only_fwd=True,
+            ignore_non_fp=config.repro_ignore_non_fp,
+        ):
             raise AccuracyError("Bad accuracy detected")
     else:
         need_sync = False

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -496,11 +496,6 @@ def repro_common(options, mod, load_args):
     return mod, args
 
 
-ACCURACY_KWARGS: Dict[str, Dict[str, Any]] = {
-    "accuracy": dict(require_fp64=True, ignore_non_fp=True),
-    "strict_accuracy": dict(require_fp64=False, ignore_non_fp=False),
-}
-
 ACCURACY_FAILS: Dict[str, Callable[[nn.Module, Any], bool]] = {
     "": inductor_fails,
     # This might look inverted but it's not.  strict_accuracy means "we will

--- a/torch/_dynamo/repro/after_dynamo.py
+++ b/torch/_dynamo/repro/after_dynamo.py
@@ -45,6 +45,14 @@ use_buck = inductor_config.is_fbcode()
 #                           MAIN ENTRY POINT
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
+def _accuracy_fails(gm, example_inputs, compiler_fn):
+    return backend_accuracy_fails(
+        gm,
+        example_inputs,
+        compiler_fn,
+        fwd_only=config.repro_forward_only,
+        ignore_non_fp=config.repro_ignore_non_fp,
+    )
 
 def wrap_backend_debug(unconfigured_compiler_fn, compiler_name: str):
     """
@@ -78,7 +86,7 @@ def wrap_backend_debug(unconfigured_compiler_fn, compiler_name: str):
             if config.repro_level == 4:
                 # Check Accuracy
                 compiled_gm = compiler_fn(copy.deepcopy(gm), example_inputs)
-                if backend_accuracy_fails(gm, example_inputs, compiler_fn):
+                if _accuracy_fails(gm, example_inputs, compiler_fn):
                     log.warning(
                         "Accuracy failed for the TorchDynamo produced graph. Creating script to minify the error."
                     )
@@ -304,17 +312,14 @@ def dynamo_accuracy_minifier_backend(gm, example_inputs, compiler_name):
     gm.eval()
 
     # Check Accuracy
-    if backend_accuracy_fails(
-        gm, example_inputs, compiler_fn, only_fwd=config.repro_forward_only
-    ):
+    if _accuracy_fails(gm, example_inputs, compiler_fn):
         log.warning("Accuracy failed for the TorchDynamo produced graph")
         dump_state_fn = functools.partial(
             dump_backend_state, compiler_name=compiler_name, check_accuracy=True
         )
         fails_fn = functools.partial(
-            backend_accuracy_fails,
+            _accuracy_fails,
             compiler_fn=compiler_fn,
-            only_fwd=config.repro_forward_only,
         )
         dump_state_fn(fx.GraphModule(gm, copy.deepcopy(gm.graph)), example_inputs)
         minifier(
@@ -424,7 +429,13 @@ def repro_run(options, mod, load_args):
             # TODO: disable clone
             args = run_load_args(options, mod, load_args)
             assert same_two_models(mod, mod, args), "Eager itself failed"
-            if not same_two_models(mod, opt_mod, args):
+            if not same_two_models(
+                mod,
+                opt_mod,
+                args,
+                fwd_only=config.repro_fwd_only,
+                ignore_non_fp=config.repro_ignore_non_fp,
+            ):
                 raise AccuracyError("Dynamo failed")
     else:
         with torch.cuda.amp.autocast(enabled=options.autocast):

--- a/torch/_dynamo/repro/after_dynamo.py
+++ b/torch/_dynamo/repro/after_dynamo.py
@@ -45,14 +45,16 @@ use_buck = inductor_config.is_fbcode()
 #                           MAIN ENTRY POINT
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
+
 def _accuracy_fails(gm, example_inputs, compiler_fn):
     return backend_accuracy_fails(
         gm,
         example_inputs,
         compiler_fn,
-        fwd_only=config.repro_forward_only,
+        only_fwd=config.repro_forward_only,
         ignore_non_fp=config.repro_ignore_non_fp,
     )
+
 
 def wrap_backend_debug(unconfigured_compiler_fn, compiler_name: str):
     """
@@ -433,7 +435,7 @@ def repro_run(options, mod, load_args):
                 mod,
                 opt_mod,
                 args,
-                fwd_only=config.repro_fwd_only,
+                only_fwd=config.repro_forward_only,
                 ignore_non_fp=config.repro_ignore_non_fp,
             ):
                 raise AccuracyError("Dynamo failed")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #123006
* #123005

When minifying, the after-aot minifier ignores non-floating values by
default but does check them when running the the initial graph dump step.
This means we may capture a graph that doesn't fail the tester and doesn't have
any meaningful divergence.

For example, the derivative of `elu(x)` depends on `x > 0` so this value is
saved for backwards and so becomes a graph output. However, the difference
between `FLT_MIN` and `0` in `x` is now enough to trigger an accuracy failure.

I fix this by adding a config variable and environment variable to ignore these
non floating point values.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang