### PR TITLE
[dynamo] Fix torch._dynamo.disable on flatten_graph_inputs wrapper

### DIFF
--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: dynamo"]
 import os
+import functools
 import unittest.mock as mock
 from unittest.mock import patch
 
@@ -65,6 +66,23 @@ class DecoratorTests(torch._dynamo.test_case.TestCase):
         res = opt_fn(x)
         self.assertEqual(cnts.frame_count, 2)
         self.assertEqual(ref, res)
+
+    def test_disable_ignores_outer_wraps(self):
+        def orig_inner():
+            pass
+
+        def inner():
+            pass
+
+        inner._torchdynamo_orig_callable = orig_inner
+
+        @functools.wraps(inner)
+        def wrapper():
+            assert False, "wrapper called"
+
+        # This behavior is not ideal, but supporting it would add overhead
+        # to callsites of eval_frame.innermost_fn. A warning would also be very noisy.
+        w = torch._dynamo.disable(fn=wrapper, recursive=True)
 
     def test_allow_in_graph(self):
         cnts = torch._dynamo.testing.CompileCounter()

--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -78,7 +78,7 @@ class DecoratorTests(torch._dynamo.test_case.TestCase):
 
         @functools.wraps(inner)
         def wrapper():
-            assert False, "wrapper called"
+            raise AssertionError("wrapper called")
 
         # This behavior is not ideal, but supporting it would add overhead
         # to callsites of eval_frame.innermost_fn. A warning would also be very noisy.

--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -1,6 +1,6 @@
 # Owner(s): ["module: dynamo"]
-import os
 import functools
+import os
 import unittest.mock as mock
 from unittest.mock import patch
 

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1474,7 +1474,6 @@ def flatten_graph_inputs(gm: torch.fx.GraphModule, inputs, compile_gm):
 
     compiled_fn = compile_gm(GmWrapper(), inputs)
 
-    @functools.wraps(compiled_fn)
     def wrapper(*args):
         # note this doesn't check the spec, assuming it is the same
         return compiled_fn(*pytree.arg_tree_leaves(*args))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #122353
* #123212
* __->__ #123007
* #122746
* #122691

Existing `innermost_fn` handling of `functools.wraps` is not ideal, but I'm not sure if there's a good fix. This can manifest for GmWrapper (used to handle list inputs from Dynamo -> AOTAutograd) where we don't call the unflatten wrapper at runtime.

Since core parts of Dynamo rely on attribute check for `_torchdynamo_orig_callable`, so I'm adding a test to cover it.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang