### PR TITLE
[dynamo][PT2D] avoid skipping dynamo_resume_* in torch/testing/_internal

### DIFF
--- a/torch/_dynamo/resume_execution.py
+++ b/torch/_dynamo/resume_execution.py
@@ -30,6 +30,9 @@ CO_COROUTINE = 0x0080
 CO_ITERABLE_COROUTINE = 0x0100
 CO_ASYNC_GENERATOR = 0x0200
 
+# trace_rules.py import this constant for consistency
+TORCH_DYNAMO_RESUME_IN_PREFIX = "torch_dynamo_resume_in"
+
 
 @dataclasses.dataclass(frozen=True)
 class ReenterWith:
@@ -370,7 +373,7 @@ class ContinueExecutionCache:
             )
             code_options[
                 "co_name"
-            ] = f"torch_dynamo_resume_in_{code_options['co_name']}_at_{lineno}"
+            ] = f"{TORCH_DYNAMO_RESUME_IN_PREFIX}_{code_options['co_name']}_at_{lineno}"
             if is_py311_plus:
                 qualified_path = code_options["co_qualname"].rsplit(".", maxsplit=1)
                 if len(qualified_path) == 1:
@@ -380,7 +383,7 @@ class ContinueExecutionCache:
                     module_name, co_name = qualified_path
                     code_options[
                         "co_qualname"
-                    ] = f"{module_name}.torch_dynamo_resume_in_{co_name}_at_{lineno}"
+                    ] = f"{module_name}.{TORCH_DYNAMO_RESUME_IN_PREFIX}_{co_name}_at_{lineno}"
             code_options["co_firstlineno"] = lineno
             code_options["co_cellvars"] = tuple()
             code_options["co_freevars"] = freevars


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #122876
* #123021
* #123014
* __->__ #123013

this PR ensures ``dynamo_resume_`` survives ``trace_rules.py``. As a ground truth, modules defined outside of ``pytorch/torch`` folders can survive ``trace_rules.py``

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang