### PR TITLE
Add inline constraints to non-strict exported program

### DIFF
--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -199,8 +199,12 @@ def make_constraints(
     #   - eval_frame.py solves constraints
     #   - _trace.py installs shape metadata in IR.
 
+    inline_constraints = gm.meta.get("inline_constraints", [])
+    range_constraints = {
+        symbol: inline_constraints[symbol] for symbol in inline_constraints
+    }
     if dynamic_shapes == []:
-        return {}
+        return range_constraints
 
     def _is_dynamic_shape_leaf(x):
         if x is None:
@@ -257,7 +261,6 @@ def make_constraints(
         if spec.kind == InputKind.USER_INPUT and isinstance(spec.arg, TensorArgument)
     }
 
-    range_constraints = {}
     input_dims = defaultdict(list)
     free_symbols = set()
     input_index = 0

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -872,6 +872,11 @@ def _export(
                 pre_dispatch=pre_dispatch,
                 transform=_tuplify_outputs,
             )
+        ep_non_strict.gm.meta["inline_constraints"] = {
+            k: v
+            for k, v in fake_mode.shape_env.var_to_range.items()
+            if free_unbacked_symbols(k)
+        }
         try:
             range_constraints = make_constraints(
                 fake_mode,


### PR DESCRIPTION
Summary: This PR reduces the difference between strict and non-strict exported program by supporting inline_constraints for non-strict exported program,

Test Plan: CI

Differential Revision: D55547830


