### PR TITLE
fixed torch.where and torch.nonzero issue

### DIFF
--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -388,7 +388,7 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
                                                                           axis:0
                                                                           mode:MPSGraphScatterModeSet
                                                                           name:nil];
-      twentyFour = [mpsGraph castTensor:twentyFour toType:[outputTensor dataType] name:nil];
+      twentyFour = [mpsGraph castTensor:twentyFour toType:getMPSDataType(out.scalar_type()) name:nil];
       MPSGraphTensor* highestBitsScatteredInAndShiftedCorrectly = [mpsGraph bitwiseLeftShiftWithPrimaryTensor:highestBitsScatteredIn secondaryTensor:twentyFour name:nil];
 
       MPSGraphTensor* lowestBitsScatteredIn = [mpsGraph scatterWithDataTensor:scatterDataTensor


### PR DESCRIPTION
After careful search it seems mpsGraph's scatter method inadvertently casts an updatesTensor which contains int32s to float32, which leads to rounding for integers larger than 2^(24) due to floating point representation. This has led to errors like #122233 and #122916 , which concern torch.where (really torch.nonzero) calls which give an incorrect answer (explained by the above: it turns out the incorrect output is the result of casting the correct output to float32 and then back to int32...). I am not sure to what extent it is responsible for the other MPS arithmetic issues, but I will investigate. My solution is the straightforward one: split the coordinatesTensor into two tensors with entries which won't be incorrectly rounded by the float32 cast, scatter them both, then recombine.