### PR TITLE
[BE] Use modern C++ in ATen tests

### DIFF
--- a/aten/src/ATen/test/half_test.cpp
+++ b/aten/src/ATen/test/half_test.cpp
@@ -86,11 +86,11 @@ TEST(TestHalf, HalfNumericLimits) {
 // Check the declared type of members of numeric_limits<Half> matches
 // the declared type of that member on numeric_limits<float>
 
-#define ASSERT_SAME_TYPE(name)                                \
-  static_assert(                                              \
-      std::is_same<                                           \
-          decltype(std::numeric_limits<Half>::name),          \
-          decltype(std::numeric_limits<float>::name)>::value, \
+#define ASSERT_SAME_TYPE(name)                         \
+  static_assert(                                       \
+      std::is_same_v<                                  \
+          decltype(std::numeric_limits<Half>::name),   \
+          decltype(std::numeric_limits<float>::name)>, \
       "decltype(" #name ") differs")
 
 ASSERT_SAME_TYPE(is_specialized);

--- a/aten/src/ATen/test/pow_test.cpp
+++ b/aten/src/ATen/test/pow_test.cpp
@@ -87,7 +87,7 @@ const std::vector<double> doubles {
 };
 
 template <class T,
-  typename std::enable_if<std::is_floating_point<T>::value,T>::type* = nullptr>
+  typename std::enable_if_t<std::is_floating_point_v<T>, T>* = nullptr>
 void assert_eq(T val, T act, T exp) {
   if (std::isnan(act) || std::isnan(exp)) {
     return;
@@ -96,7 +96,7 @@ void assert_eq(T val, T act, T exp) {
 }
 
 template <class T,
-  typename std::enable_if<std::is_integral<T>::value, T>::type* = nullptr>
+  typename std::enable_if_t<std::is_integral_v<T>, T>* = nullptr>
 void assert_eq(T val, T act, T exp) {
   if (val != 0 && act == 0) {
     return;
@@ -112,12 +112,12 @@ void assert_eq(T val, T act, T exp) {
 }
 
 template <class T,
-  typename std::enable_if<std::is_floating_point<T>::value,T>::type* = nullptr>
+  typename std::enable_if_t<std::is_floating_point_v<T>, T>* = nullptr>
 T typed_pow(T base, T exp) {
   return std::pow(base, exp);
 }
 template <class T,
-  typename std::enable_if<std::is_integral<T>::value,T>::type* = nullptr>
+  typename std::enable_if_t<std::is_integral_v<T>, T>* = nullptr>
 T typed_pow(T base, T exp) {
   return native::powi(base, exp);
 }

--- a/aten/src/ATen/test/rng_test.h
+++ b/aten/src/ATen/test/rng_test.h
@@ -12,49 +12,49 @@ namespace {
 constexpr auto int64_min_val = std::numeric_limits<int64_t>::lowest();
 constexpr auto int64_max_val = std::numeric_limits<int64_t>::max();
 template <typename T,
-          typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
+          typename std::enable_if_t<std::is_floating_point_v<T>, int> = 0>
 constexpr int64_t _min_val() {
   return int64_min_val;
 }
 
 template <typename T,
-          typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+          typename std::enable_if_t<std::is_integral_v<T>, int> = 0>
 constexpr int64_t _min_val() {
   return static_cast<int64_t>(std::numeric_limits<T>::lowest());
 }
 
 template <typename T,
-          typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
+          typename std::enable_if_t<std::is_floating_point_v<T>, int> = 0>
 constexpr int64_t _min_from() {
   return -(static_cast<int64_t>(1) << std::numeric_limits<T>::digits);
 }
 
 template <typename T,
-          typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+          typename std::enable_if_t<std::is_integral_v<T>, int> = 0>
 constexpr int64_t _min_from() {
   return _min_val<T>();
 }
 
 template <typename T,
-          typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
+          typename std::enable_if_t<std::is_floating_point_v<T>, int> = 0>
 constexpr int64_t _max_val() {
   return int64_max_val;
 }
 
 template <typename T,
-          typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+          typename std::enable_if_t<std::is_integral_v<T>, int> = 0>
 constexpr int64_t _max_val() {
   return static_cast<int64_t>(std::numeric_limits<T>::max());
 }
 
 template <typename T,
-          typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
+          typename std::enable_if_t<std::is_floating_point_v<T>, int> = 0>
 constexpr int64_t _max_to() {
   return static_cast<int64_t>(1) << std::numeric_limits<T>::digits;
 }
 
 template <typename T,
-          typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+          typename std::enable_if_t<std::is_integral_v<T>, int> = 0>
 constexpr int64_t _max_to() {
   return _max_val<T>();
 }
@@ -77,7 +77,7 @@ void test_random_from_to(const at::Device& device) {
       1L,
       static_cast<c10::optional<int64_t>>(c10::nullopt)
     };
-  } else if constexpr (::std::is_signed<T>::value) {
+  } else if constexpr (::std::is_signed_v<T>) {
     constexpr int64_t min_from = _min_from<T>();
     froms = {
       min_from,
@@ -186,7 +186,7 @@ void test_random(const at::Device& device) {
     actual.random_(gen);
 
     uint64_t range;
-    if constexpr (::std::is_floating_point<T>::value) {
+    if constexpr (::std::is_floating_point_v<T>) {
       range = static_cast<uint64_t>((1ULL << ::std::numeric_limits<T>::digits) + 1);
     } else if constexpr (::std::is_same_v<T, bool>) {
       range = 2;

--- a/aten/src/ATen/test/vec_test_all_types.cpp
+++ b/aten/src/ATen/test/vec_test_all_types.cpp
@@ -555,7 +555,7 @@ namespace {
         using UVT = UvalueType<vec>;
         UVT tolerance = getDefaultTolerance<UVT>();
         // double: 2e+305  float: 4e+36 (https://sleef.org/purec.xhtml#eg)
-        UVT maxCorrect = std::is_same<UVT, float>::value ? (UVT)4e+36 : (UVT)2e+305;
+        UVT maxCorrect = std::is_same_v<UVT, float> ? (UVT)4e+36 : (UVT)2e+305;
         TestingCase<vec> testCase = TestingCase<vec>::getBuilder()
             .addDomain(CheckWithinDomains<UVT>{ { {(UVT)-100, (UVT)0}}, true, tolerance})
             .addDomain(CheckWithinDomains<UVT>{ { {(UVT)0, (UVT)1000 }}, true, tolerance})

--- a/aten/src/ATen/test/vec_test_all_types.h
+++ b/aten/src/ATen/test/vec_test_all_types.h
@@ -411,7 +411,7 @@ void filter_clamp(T& f, T& s, T& t) {
 }
 
 template <typename T>
-std::enable_if_t<std::is_floating_point<T>::value, void> filter_fmod(T& a, T& b) {
+std::enable_if_t<std::is_floating_point_v<T>, void> filter_fmod(T& a, T& b) {
     // This is to make sure fmod won't cause overflow when doing the div
     if (std::abs(b) < (T)1) {
       b = b < (T)0 ? (T)-1 : T(1);
@@ -419,7 +419,7 @@ std::enable_if_t<std::is_floating_point<T>::value, void> filter_fmod(T& a, T& b)
 }
 
 template <typename T>
-std::enable_if_t<std::is_floating_point<T>::value, void> filter_fmadd(T& a, T& b, T& c) {
+std::enable_if_t<std::is_floating_point_v<T>, void> filter_fmadd(T& a, T& b, T& c) {
     // This is to setup a limit to make sure fmadd (a * b + c) won't overflow
     T max = std::sqrt(std::numeric_limits<T>::max()) / T(2.0);
     T min = ((T)0 - max);
@@ -541,7 +541,7 @@ filter_div_ub(T& val1, T& val2) {
     if (is_zero(val2)) {
         val2 = 1;
     }
-    else if (std::is_integral<T>::value && val1 == std::numeric_limits<T>::min() && val2 == -1) {
+    else if (std::is_integral_v<T> && val1 == std::numeric_limits<T>::min() && val2 == -1) {
         val2 = 1;
     }
 }
@@ -565,7 +565,7 @@ private:
     uint64_t seed;
 };
 
-template <typename T, bool is_floating_point = std::is_floating_point<T>::value, bool is_complex = is_complex<T>::value>
+template <typename T, bool is_floating_point = std::is_floating_point_v<T>, bool is_complex = is_complex<T>::value>
 struct ValueGen
 {
     std::uniform_int_distribution<int64_t> dis;
@@ -927,7 +927,7 @@ void test_unary(
     CACHE_ALIGN VT vals[el_count];
     CACHE_ALIGN VT expected[el_count];
     bool bitwise = testCase.isBitwise();
-    UVT default_start = std::is_floating_point<UVT>::value ? std::numeric_limits<UVT>::lowest() : std::numeric_limits<UVT>::min();
+    UVT default_start = std::is_floating_point_v<UVT> ? std::numeric_limits<UVT>::lowest() : std::numeric_limits<UVT>::min();
     UVT default_end = std::numeric_limits<UVT>::max();
     auto domains = testCase.getDomains();
     auto domains_size = domains.size();
@@ -983,7 +983,7 @@ void test_binary(
     CACHE_ALIGN VT vals1[el_count];
     CACHE_ALIGN VT expected[el_count];
     bool bitwise = testCase.isBitwise();
-    UVT default_start = std::is_floating_point<UVT>::value ? std::numeric_limits<UVT>::lowest() : std::numeric_limits<UVT>::min();
+    UVT default_start = std::is_floating_point_v<UVT> ? std::numeric_limits<UVT>::lowest() : std::numeric_limits<UVT>::min();
     UVT default_end = std::numeric_limits<UVT>::max();
     auto domains = testCase.getDomains();
     auto domains_size = domains.size();
@@ -1044,7 +1044,7 @@ void test_ternary(
     CACHE_ALIGN VT vals2[el_count];
     CACHE_ALIGN VT expected[el_count];
     bool bitwise = testCase.isBitwise();
-    UVT default_start = std::is_floating_point<UVT>::value ? std::numeric_limits<UVT>::lowest() : std::numeric_limits<UVT>::min();
+    UVT default_start = std::is_floating_point_v<UVT> ? std::numeric_limits<UVT>::lowest() : std::numeric_limits<UVT>::min();
     UVT default_end = std::numeric_limits<UVT>::max();
     auto domains = testCase.getDomains();
     auto domains_size = domains.size();
@@ -1456,7 +1456,7 @@ template<typename T>
 TestingCase<T> createDefaultUnaryTestCase(TestSeed seed = TestSeed(), bool bitwise = false, bool checkWithTolerance = false, size_t trials = 0) {
     using UVT = UvalueType<T>;
     TestingCase<T> testCase;
-    if (!bitwise && std::is_floating_point<UVT>::value) {
+    if (!bitwise && std::is_floating_point_v<UVT>) {
         //for float types lets add manual ranges
         UVT tolerance = getDefaultTolerance<UVT>();
         testCase = TestingCase<T>::getBuilder()
@@ -1484,7 +1484,7 @@ template<typename T>
 TestingCase<T> createDefaultBinaryTestCase(TestSeed seed = TestSeed(), bool bitwise = false, bool checkWithTolerance = false, size_t trials = 0) {
     using UVT = UvalueType<T>;
     TestingCase<T> testCase;
-    if (!bitwise && std::is_floating_point<UVT>::value) {
+    if (!bitwise && std::is_floating_point_v<UVT>) {
         //for float types lets add manual ranges
         UVT tolerance = getDefaultTolerance<UVT>();
         testCase = TestingCase<T>::getBuilder()

--- a/aten/src/ATen/test/vec_test_all_types.h
+++ b/aten/src/ATen/test/vec_test_all_types.h
@@ -192,34 +192,34 @@ constexpr size_t size(T(&)[N]) {
 }
 
 template <typename Filter, typename T>
-typename std::enable_if_t<std::is_same<Filter, std::nullptr_t>::value, void>
+typename std::enable_if_t<std::is_same_v<Filter, std::nullptr_t>, void>
 call_filter(Filter filter, T& val) {}
 
 template <typename Filter, typename T>
-typename std::enable_if_t< std::is_same<Filter, std::nullptr_t>::value, void>
+typename std::enable_if_t< std::is_same_v<Filter, std::nullptr_t>, void>
 call_filter(Filter filter, T& first, T& second) { }
 
 template <typename Filter, typename T>
-typename std::enable_if_t< std::is_same<Filter, std::nullptr_t>::value, void>
+typename std::enable_if_t< std::is_same_v<Filter, std::nullptr_t>, void>
 call_filter(Filter filter, T& first, T& second, T& third) {  }
 
 template <typename Filter, typename T>
 typename std::enable_if_t<
-    !std::is_same<Filter, std::nullptr_t>::value, void>
+    !std::is_same_v<Filter, std::nullptr_t>, void>
     call_filter(Filter filter, T& val) {
     return filter(val);
 }
 
 template <typename Filter, typename T>
 typename std::enable_if_t<
-    !std::is_same<Filter, std::nullptr_t>::value, void>
+    !std::is_same_v<Filter, std::nullptr_t>, void>
     call_filter(Filter filter, T& first, T& second) {
     return filter(first, second);
 }
 
 template <typename Filter, typename T>
 typename std::enable_if_t<
-    !std::is_same<Filter, std::nullptr_t>::value, void>
+    !std::is_same_v<Filter, std::nullptr_t>, void>
     call_filter(Filter filter, T& first, T& second, T& third) {
     return filter(first, second, third);
 }
@@ -268,38 +268,30 @@ std::ostream& operator<<(std::ostream& stream, const CheckWithinDomains<T>& dmn)
 }
 
 template <typename T>
-std::enable_if_t<std::is_floating_point<T>::value, bool> check_both_nan(T x,
-    T y) {
-    return std::isnan(x) && std::isnan(y);
-}
-
-template <typename T>
-std::enable_if_t<!std::is_floating_point<T>::value, bool> check_both_nan(T x,
-    T y) {
+bool check_both_nan(T x, T y) {
+    if constexpr (std::is_floating_point_v<T>) {
+        return std::isnan(x) && std::isnan(y);
+    }
     return false;
 }
 
 template <typename T>
-std::enable_if_t<std::is_floating_point<T>::value, bool> check_both_inf(T x,
-    T y) {
-    return std::isinf(x) && std::isinf(y);
-}
-
-template <typename T>
-std::enable_if_t<!std::is_floating_point<T>::value, bool> check_both_inf(T x,
-    T y) {
+bool check_both_inf(T x, T y) {
+    if constexpr (std::is_floating_point_v<T>) {
+        return std::isinf(x) && std::isinf(y);
+    }
     return false;
 }
 
 template<typename T>
-std::enable_if_t<!std::is_floating_point<T>::value, bool> check_both_big(T x, T y) {
+std::enable_if_t<!std::is_floating_point_v<T>, bool> check_both_big(T x, T y) {
     return false;
 }
 
 template<typename T>
-std::enable_if_t<std::is_floating_point<T>::value, bool> check_both_big(T x, T y) {
-    T cmax = std::is_same<T, float>::value ? static_cast<T>(1e+30) : static_cast<T>(1e+300);
-    T cmin = std::is_same<T, float>::value ? static_cast<T>(-1e+30) : static_cast<T>(-1e+300);
+std::enable_if_t<std::is_floating_point_v<T>, bool> check_both_big(T x, T y) {
+    T cmax = std::is_same_v<T, float> ? static_cast<T>(1e+30) : static_cast<T>(1e+300);
+    T cmin = std::is_same_v<T, float> ? static_cast<T>(-1e+30) : static_cast<T>(-1e+300);
     //only allow when one is inf
     bool x_inf = std::isinf(x);
     bool y_inf = std::isinf(y);
@@ -330,7 +322,7 @@ T safe_fpt_division(T f1, T f2)
 }
 
 template<class T>
-std::enable_if_t<std::is_floating_point<T>::value, bool>
+std::enable_if_t<std::is_floating_point_v<T>, bool>
 nearlyEqual(T a, T b, T tolerance) {
     if (check_both_nan<T>(a, b)) return true;
     if (check_both_big(a, b)) return true;
@@ -346,7 +338,7 @@ nearlyEqual(T a, T b, T tolerance) {
 }
 
 template<class T>
-std::enable_if_t<!std::is_floating_point<T>::value, bool>
+std::enable_if_t<!std::is_floating_point_v<T>, bool>
 nearlyEqual(T a, T b, T tolerance) {
     return a == b;
 }
@@ -403,13 +395,12 @@ void copy_interleave(VT(&vals)[N], VT(&interleaved)[N]) {
 }
 
 template <typename T>
-std::enable_if_t<std::is_floating_point<T>::value, bool> is_zero(T val) {
-    return std::fpclassify(val) == FP_ZERO;
-}
-
-template <typename T>
-std::enable_if_t<!std::is_floating_point<T>::value, bool> is_zero(T val) {
-    return val == 0;
+bool is_zero(T val) {
+    if constexpr (std::is_floating_point_v<T>) {
+        return std::fpclassify(val) == FP_ZERO;
+    } else {
+        return val == 0;
+    }
 }
 
 template <typename T>


### PR DESCRIPTION
`std::is_same<A, B>::value` -> `std::is_same_v<A, B>`
`std::is_floating_point<T>::value` -> `std::is_floating_point_v<T>`
And use constexpr instead of defining two mutually exclusive templates