### PR TITLE
[dynamo][guards] Skip aliasing guards for optimizers

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -31,6 +31,7 @@ import torch
 import torch.utils._device
 from torch._dynamo.source import (
     is_from_local_source,
+    is_from_optimizer_source,
     TensorProperty,
     TensorPropertySource,
 )
@@ -70,6 +71,7 @@ from .source import (
     NotNNModuleSource,
     NumpyTensorSource,
     ODictGetItemSource,
+    OptimizerSource,
     ShapeEnvSource,
     TupleIteratorGetItemSource,
     TypeSource,
@@ -535,7 +537,10 @@ class GuardBuilder(GuardBuilderBase):
             return base_guard_manager.type_manager(
                 source=source_name, example_value=example_value
             )
-        elif istype(source, (NNModuleSource, NotNNModuleSource, FSDPNNModuleSource)):
+        elif istype(
+            source,
+            (OptimizerSource, NNModuleSource, NotNNModuleSource, FSDPNNModuleSource),
+        ):
             assert base_guard_manager  # to make mypy happy
             return base_guard_manager
         elif istype(source, AttrSource):
@@ -1113,6 +1118,11 @@ class GuardBuilder(GuardBuilderBase):
         ref_a = self.arg_ref(guard)
         ref_b = self.arg_ref(source_b.name())
 
+        if is_from_optimizer_source(
+            guard.originating_source
+        ) or is_from_optimizer_source(source_b):
+            return
+
         code = [f"{ref_b} is {ref_a}"]
         self._set_guard_export_info(guard, code)
 
@@ -1357,9 +1367,7 @@ class GuardBuilder(GuardBuilderBase):
                     else:
                         code.append(f"{tensor_name}.{term} == {real_value}")
             else:
-                self.tensor_check_names.append(tensor_name)
                 self.tensor_check_examples.append(value)
-                self.tensor_check_guards.append(guard)
 
                 if config.enable_cpp_guard_manager:
                     guard_manager = self.get_guard_manager(guard)
@@ -1385,6 +1393,15 @@ class GuardBuilder(GuardBuilderBase):
                         tensor_name,
                         verbose_code_parts,
                     )
+
+                    if not is_from_optimizer_source(guard.originating_source):
+                        # Skip no tensor aliasing guard for optimizers. We know
+                        # they do not alias.
+                        self.tensor_check_names.append(tensor_name)
+                        self.tensor_check_guards.append(guard)
+                else:
+                    self.tensor_check_names.append(tensor_name)
+                    self.tensor_check_guards.append(guard)
 
             # A frame is valid for reuse with dynamic dimensions if the new
             # (user-requested) dynamic dimensions are a subset of the old

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -437,6 +437,18 @@ class ODictGetItemSource(ChainedSource):
 
 
 @dataclasses.dataclass(frozen=True)
+class OptimizerSource(ChainedSource):
+    def reconstruct(self, codegen):
+        self.base.reconstruct(codegen)
+
+    def guard_source(self):
+        return self.base.guard_source()
+
+    def name(self):
+        return self.base.name()
+
+
+@dataclasses.dataclass(frozen=True)
 class NNModuleSource(ChainedSource):
     def reconstruct(self, codegen):
         self.base.reconstruct(codegen)
@@ -533,6 +545,14 @@ def is_from_local_source(source: Source, *, allow_cell_or_freevar=True):
     if not allow_cell_or_freevar and source.cell_or_freevar:
         return False
     return True
+
+
+def is_from_optimizer_source(source: Source):
+    if isinstance(source, OptimizerSource):
+        return True
+    if isinstance(source, ChainedSource):
+        return is_from_optimizer_source(source.base)
+    return False
 
 
 # TODO: can probably write a generic "test this on everything in the chain"

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -58,6 +58,7 @@ from ..source import (
     is_from_defaults,
     LocalSource,
     NumpyTensorSource,
+    OptimizerSource,
     RandomValueSource,
     Source,
     TupleIteratorGetItemSource,
@@ -664,6 +665,7 @@ class VariableBuilder:
             return self.tx.output.side_effects.track_object_existing(value, result)
         elif isinstance(value, torch.optim.Optimizer):
             self.install_guards(GuardBuilder.TYPE_MATCH)
+            self.source = OptimizerSource(self.source)
             return OptimizerVariable(value, source=self.source)
         elif WorldMetaClassVariable.is_group_member_type(value):
             return WorldMetaClassVariable(value, source=self.source)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #123044


I am ok if people don't want this PR to be merged.


For optimizers, we know that the state dict and param_group have same parameters. So, I think its ok to skip TENSOR_MUST_ALIAS guards.

Similarly for state tensors, all of them are different. Therefore, we can skip the tensor aliasing guards. 

With this PR, these are the numbers for Megatron which has 394 parameters

<img width="290" alt="image" src="https://github.com/pytorch/pytorch/assets/13822661/0ce75dc6-4299-46bb-bf3c-7989ebc7cfc4">

C++ numbers jump a lot because of 2 reasons
1) We are now not doing INCREF/DECREF for a large number of tensors. 
2) For python guards, we can expect higher numbers but that requires some more plumbing because the Python tensor guards are all collapsed into one.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang