### PR TITLE
[MPS] Fixes GELU, LeakyRELU and MISH on non-contiguous tensors

### DIFF
--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -131,6 +131,10 @@ TORCH_IMPL_FUNC(leaky_relu_out_mps)(const Tensor& self, const Scalar& negative_s
   using CachedGraph = MPSUnaryCachedGraph;
   TORCH_CHECK(output.is_mps());
 
+  if (self.numel() == 0) {
+    return;
+  }
+
   MPSStream* stream = getCurrentMPSStream();
 
   bool executeGatherOp =
@@ -179,6 +183,10 @@ TORCH_IMPL_FUNC(leaky_relu_backward_out_mps)
   using namespace mps;
   using CachedGraph = MPSUnaryGradCachedGraph;
   TORCH_CHECK(output.is_mps());
+
+  if (self.numel() == 0) {
+    return;
+  }
 
   MPSStream* stream = getCurrentMPSStream();
 

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -715,11 +715,12 @@ TORCH_IMPL_FUNC(gelu_backward_out_mps)
   using namespace mps;
   using CachedGraph = MPSUnaryGradCachedGraph;
 
-  Tensor grad_input_ = at::empty_like(self, self.suggest_memory_format());
   // Empty output
-  if (grad_input.numel() == 0) {
-    grad_input.copy_(grad_input_);
+  if (self.numel() == 0) {
+    return;
   }
+
+  Tensor grad_input_ = at::empty_like(self, self.suggest_memory_format());
 
   auto approximate_type = get_gelutype_enum(approximate);
   MPSStream* stream = getCurrentMPSStream();

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6718,7 +6718,7 @@ class TestMPS(TestCaseMPS):
 
         # Test empty shape too
         for dtype in [torch.float, torch.half]:
-            for shape in [(0,), (0, 3), (4,), (4, 3), (5, 4, 3)]: # (0, 3), [] removed, REGRESSION
+            for shape in [[], (0,), (0, 3), (4,), (4, 3), (5, 4, 3)]: # (0, 3), [] removed, REGRESSION
                 for contiguous in [True, False]:
                     helper(shape, dtype, contiguous)
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1491,9 +1491,9 @@ class MPSLeakyReluTest(TestCaseMPS):
         # test backward pass
         cpu_grad = torch.ones_like(cpu_leaky_relu)
         mps_grad = cpu_grad.to('mps')
-        cpu_leaky_relu.backward(gradient=cpu_grad)
         mps_leaky_relu.backward(gradient=mps_grad)
-        torch.testing.assert_close(cpu_x.grad, mps_x.grad.to('cpu'))
+        cpu_leaky_relu.backward(gradient=cpu_grad)
+        self.assertEqual(cpu_x.grad, mps_x.grad)
 
     def testNumbersCPU(self):
         for t in [np.float32]:
@@ -6688,8 +6688,7 @@ class TestMPS(TestCaseMPS):
                 assert not x.is_contiguous()
 
             mish_result = torch.nn.Mish()(x)
-            # GELU is not supported on CPU, so cast it to float
-            mish_result_cpu = torch.nn.GELU()(cpu_x)
+            mish_result_cpu = torch.nn.Mish()(cpu_x)
 
             cpu_grad = torch.ones_like(mish_result_cpu)
             grad = cpu_grad.to('mps')

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1498,8 +1498,7 @@ class MPSLeakyReluTest(TestCaseMPS):
 
         mps_leaky_relu.backward()
         cpu_leaky_relu.backward()
-        assert cpu_x.grad is not None # Check that the grad is well-populated
-
+        assert cpu_x.grad is not None  # Check that the grad is well-populated
         self.assertEqual(cpu_x.grad, mps_x.grad)
 
     def testNumbersCPU(self):
@@ -6665,23 +6664,18 @@ class TestMPS(TestCaseMPS):
             # GELU is not supported on CPU, so cast it to float
             gelu_result_cpu = torch.nn.GELU()(cpu_x.to(torch.float))
 
-            gelu_result = gelu_result.sum()
-            gelu_result_cpu = gelu_result_cpu.sum()
+            cpu_grad = torch.ones_like(gelu_result_cpu)
+            grad = cpu_grad.to('mps')
 
-            gelu_result.backward()
-            gelu_result_cpu.backward()
+            gelu_result.backward(gradient=grad)
+            gelu_result_cpu.backward(gradient=cpu_grad)
 
             atol = 1e-5 if dtype == torch.float else 1e-2
             rtol = 1e-3 if dtype == torch.float else 1e-2
             self.assertEqual(gelu_result, gelu_result_cpu.to(dtype), atol=atol, rtol=rtol)
-            assert x.grad is not None
-            if (dtype, shape, contiguous) not in [(torch.float32, [], True), # Known issues, not a regression
-                                                (torch.float32, [], False),
-                                                (torch.float16, [], True),
-                                                (torch.float16, [], False),
-                                                (torch.float16, (4,), True),
-                                                (torch.float16, (4,), False)]:
-                self.assertEqual(x.grad, cpu_x.grad, atol=atol, rtol=rtol)
+
+            assert x.grad is not None  # Check that the grad is well-populated
+            self.assertEqual(x.grad, cpu_x.grad, atol=atol, rtol=rtol)
 
         # Test empty shape too
         for dtype in [torch.float, torch.half]:
@@ -6709,23 +6703,18 @@ class TestMPS(TestCaseMPS):
             mish_result = torch.nn.Mish()(x)
             mish_result_cpu = torch.nn.Mish()(cpu_x)
 
-            mish_result = mish_result.sum()
-            mish_result_cpu = mish_result_cpu.sum()
+            cpu_grad = torch.ones_like(mish_result_cpu)
+            grad = cpu_grad.to('mps')
 
-            mish_result.backward()
-            mish_result_cpu.backward()
+            mish_result.backward(gradient=grad)
+            mish_result_cpu.backward(gradient=cpu_grad)
 
             atol = 1e-5 if dtype == torch.float else 1e-2
             rtol = 1e-3 if dtype == torch.float else 1e-2
             self.assertEqual(mish_result, mish_result_cpu.to(dtype), atol=atol, rtol=rtol)
-            assert x.grad is not None
-            if (dtype, shape, contiguous) not in [(torch.float32, [], True), # Known issues, not a regression
-                                                (torch.float32, [], False),
-                                                (torch.float16, [], True),
-                                                (torch.float16, [], False),
-                                                (torch.float16, (4,), True),
-                                                (torch.float16, (4,), False)]:
-                self.assertEqual(x.grad, cpu_x.grad, atol=atol, rtol=rtol)
+
+            assert x.grad is not None  # Check that the grad is well-populated
+            self.assertEqual(x.grad, cpu_x.grad, atol=atol, rtol=rtol)
 
         # Test empty shape too
         for dtype in [torch.float, torch.half]:

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6682,6 +6682,13 @@ class TestMPS(TestCaseMPS):
         for dtype in [torch.float, torch.half]:
             for shape in [[], (0,), (0, 3), (4,), (4, 3), (5, 4, 3)]: # (0, 3), [] removed, REGRESSION
                 for contiguous in [True, False]:
+                    if (dtype, shape, contiguous) in [(torch.float32, [], True),
+                                                      (torch.float32, [], False),
+                                                      (torch.float16, [], True),
+                                                      (torch.float16, [], False),
+                                                      (torch.float16, (4,), True),
+                                                      (torch.float16, (4,), False)]:
+                        continue
                     helper(shape, dtype, contiguous)
         # Test that gelu would raise an assert for integral types
         for dtype in [torch.int8, torch.int16, torch.int32, torch.int64]:
@@ -6720,6 +6727,13 @@ class TestMPS(TestCaseMPS):
         for dtype in [torch.float, torch.half]:
             for shape in [[], (0,), (0, 3), (4,), (4, 3), (5, 4, 3)]: # (0, 3), [] removed, REGRESSION
                 for contiguous in [True, False]:
+                    if (dtype, shape, contiguous) in [(torch.float32, [], False),
+                                                      (torch.float32, [], True),
+                                                      (torch.float16, [], True),
+                                                      (torch.float16, [], False),
+                                                      (torch.float16, (4,), True),
+                                                      (torch.float16, (4,), False)]:
+                        continue
                     helper(shape, dtype, contiguous)
 
     def test_gelu(self):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1493,11 +1493,12 @@ class MPSLeakyReluTest(TestCaseMPS):
 
         # test backward pass
 
-        mps_leaky_relu = mps_leaky_relu.sum()
-        cpu_leaky_relu = cpu_leaky_relu.sum()
+        cpu_grad = torch.ones_like(cpu_leaky_relu)
+        mps_grad = cpu_grad.to('mps')
 
-        mps_leaky_relu.backward()
-        cpu_leaky_relu.backward()
+        mps_leaky_relu.backward(gradient=mps_grad)
+        cpu_leaky_relu.backward(gradient=cpu_grad)
+
         assert cpu_x.grad is not None  # Check that the grad is well-populated
         self.assertEqual(cpu_x.grad, mps_x.grad)
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1505,7 +1505,7 @@ class MPSLeakyReluTest(TestCaseMPS):
 
     def testNumbersCPU(self):
         for t in [torch.float, torch.half]:
-            for shape in [(4,), (4, 3), (5, 4, 3)]:
+            for shape in [[], (0,), (0, 3), (4,), (4, 3), (5, 4, 3)]:
                 for contiguous in [True, False]:
                     self._testLeakyRelu(shape,
                                         dtype=t,
@@ -6680,7 +6680,7 @@ class TestMPS(TestCaseMPS):
 
         # Test empty shape too
         for dtype in [torch.float, torch.half]:
-            for shape in [(0,4), (2, 3), (2, 8, 4, 5)]: # (0, 3), [] removed, REGRESSION
+            for shape in [[], (0,), (0, 3), (4,), (4, 3), (5, 4, 3)]: # (0, 3), [] removed, REGRESSION
                 for contiguous in [True, False]:
                     helper(shape, dtype, contiguous)
         # Test that gelu would raise an assert for integral types
@@ -6718,7 +6718,7 @@ class TestMPS(TestCaseMPS):
 
         # Test empty shape too
         for dtype in [torch.float, torch.half]:
-            for shape in [(2, 3), (2, 8, 4, 5)]: # (0, 3), [] removed, REGRESSION
+            for shape in [(0,), (0, 3), (4,), (4, 3), (5, 4, 3)]: # (0, 3), [] removed, REGRESSION
                 for contiguous in [True, False]:
                     helper(shape, dtype, contiguous)
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1490,7 +1490,7 @@ class MPSLeakyReluTest(TestCaseMPS):
         cpu_leaky_relu = relu_op(cpu_x)
         mps_leaky_relu = relu_op(mps_x)
         torch.testing.assert_close(cpu_leaky_relu, mps_leaky_relu.to('cpu'))
-        import pdb; pdb.set_trace()
+
         # test backward pass
 
         mps_leaky_relu = mps_leaky_relu.sum()
@@ -1499,7 +1499,7 @@ class MPSLeakyReluTest(TestCaseMPS):
         mps_leaky_relu.backward()
         cpu_leaky_relu.backward()
         assert cpu_x.grad is not None # Check that the grad is well-populated
-        import pdb; pdb.set_trace()
+
         self.assertEqual(cpu_x.grad, mps_x.grad)
         print(f'With contigous {contiguous} the cpu_x.grad contains {cpu_x.grad} and mps_x.grad {mps_x.grad}')
 
@@ -6680,7 +6680,7 @@ class TestMPS(TestCaseMPS):
 
         # Test empty shape too
         for dtype in [torch.float, torch.half]:
-            for shape in [(2, 3), (2, 8, 4, 5)]: # (0, 3), [] removed, REGRESSION
+            for shape in [(0,4), (2, 3), (2, 8, 4, 5)]: # (0, 3), [] removed, REGRESSION
                 for contiguous in [True, False]:
                     helper(shape, dtype, contiguous)
         # Test that gelu would raise an assert for integral types

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1472,9 +1472,15 @@ class MPSLeakyReluTest(TestCaseMPS):
                                                          0.9]]),
                 negative_slope=0.1))
 
-    def _testLeakyRelu(self, np_features, negative_slope, device):
+    def _testLeakyRelu(self, np_features, negative_slope, contiguous, device):
         cpu_x = torch.from_numpy(np_features).requires_grad_()
         mps_x = torch.from_numpy(np_features).to('mps').requires_grad_()
+
+        if not contiguous:
+            # Tranposing will make the tensor non-contiguous
+            cpu_x = cpu_x.transpose(0, 1)
+            mps_x = mps_x.transpose(0, 1)
+
         relu_op = torch.nn.LeakyReLU(negative_slope)
 
         cpu_leaky_relu = relu_op(cpu_x)
@@ -1490,10 +1496,12 @@ class MPSLeakyReluTest(TestCaseMPS):
 
     def testNumbersCPU(self):
         for t in [np.float32]:
-            self._testLeakyRelu(
-                np.array([[-9, 7, -5, 3, -1], [1, -3, 5, -7, 9]]).astype(t),
-                negative_slope=0.2,
-                device="cpu")
+            for contiguous in [True, False]:
+                self._testLeakyRelu(
+                    np.array([[-9, 7, -5, 3, -1], [1, -3, 5, -7, 9]]).astype(t),
+                    negative_slope=0.2,
+                    contiguous=contiguous,
+                    device="cpu")
 
 
 class TestAvgPool(TestCaseMPS):
@@ -6633,8 +6641,11 @@ class TestMPS(TestCaseMPS):
                 helper((2, 16, 16), (4, 4), return_indices, dtype)
 
     def test_gelu_simple(self):
-        def helper(shape, dtype=torch.float):
+        def helper(shape, dtype=torch.float, contiguous=True):
             cpu_x = torch.randn(shape, device='cpu', dtype=dtype, requires_grad=True)
+            if not contiguous and (0 not in shape and len(shape) >= 2):
+                # Tranposing will make the tensor non-contiguous
+                cpu_x = cpu_x.transpose(0, 1)
             x = cpu_x.detach().clone().to('mps').requires_grad_()
 
             gelu_result = torch.nn.GELU()(x)
@@ -6655,7 +6666,40 @@ class TestMPS(TestCaseMPS):
         # Test empty shape too
         for dtype in [torch.float, torch.half]:
             for shape in [(0, 3), [], (2, 3), (2, 8, 4, 5)]:
-                helper(shape, dtype)
+                for contiguous in [True, False]:
+                    helper(shape, dtype, contiguous)
+        # Test that gelu would raise an assert for integral types
+        for dtype in [torch.int8, torch.int16, torch.int32, torch.int64]:
+            self.assertRaises(RuntimeError, lambda: torch.nn.GELU()(torch.randint(100, (2,), dtype=dtype, device="mps")))
+
+    def test_mish_simple(self):
+        def helper(shape, dtype=torch.float, contiguous=True):
+            cpu_x = torch.randn(shape, device='cpu', dtype=dtype, requires_grad=True)
+            if not contiguous and (0 not in shape and len(shape) >= 2):
+                # Tranposing will make the tensor non-contiguous
+                cpu_x = cpu_x.transpose(0, 1)
+            x = cpu_x.detach().clone().to('mps').requires_grad_()
+
+            mish_result = torch.nn.Mish()(x)
+            # GELU is not supported on CPU, so cast it to float
+            mish_result_cpu = torch.nn.GELU()(cpu_x)
+
+            cpu_grad = torch.ones_like(mish_result_cpu)
+            grad = cpu_grad.to('mps')
+
+            mish_result.backward(gradient=grad)
+            mish_result_cpu.backward(gradient=cpu_grad)
+
+            atol = 1e-5 if dtype == torch.float else 1e-2
+            rtol = 1e-3 if dtype == torch.float else 1e-2
+            self.assertEqual(mish_result, mish_result_cpu.to(dtype), atol=atol, rtol=rtol)
+            self.assertEqual(x.grad, cpu_x.grad, atol=atol, rtol=rtol)
+
+        # Test empty shape too
+        for dtype in [torch.float, torch.half]:
+            for shape in [(0, 3), [], (2, 3), (2, 8, 4, 5)]:
+                for contiguous in [True, False]:
+                    helper(shape, dtype, contiguous)
         # Test that gelu would raise an assert for integral types
         for dtype in [torch.int8, torch.int16, torch.int32, torch.int64]:
             self.assertRaises(RuntimeError, lambda: torch.nn.GELU()(torch.randint(100, (2,), dtype=dtype, device="mps")))


### PR DESCRIPTION
Fixes GELU, LeakyRELU and MISH activation functions on non-contiguous tensors (for instance, when a transpose operation was applied on the tensors prior to the MPS operator), forward and backward passes.

I also extended tests on the 3 activation functions to check: full-precision and half-precision, contiguous and non-contiguous, and several dims of tensors: scalars, 1D, empty, 2D, > 3D.

I had issues with Mish and GELU activations when asserting the gradients vs. CPU with sum() on some cases, so I reverted to the previous setup by setting a gradient parameter on .backwards().
This PR also fixes an issue with LeakyRELU on empty tensors.

Fixes #98212 huggingface/transformers#22468 huggingface/transformers#19353