### PR TITLE
Allow for git worktree when computing clangtidy scm root

### DIFF
--- a/tools/linter/adapters/clangtidy_linter.py
+++ b/tools/linter/adapters/clangtidy_linter.py
@@ -18,7 +18,7 @@ from typing import Any, List, NamedTuple, Optional, Pattern
 def scm_root() -> str:
     path = os.path.abspath(os.getcwd())
     while True:
-        if os.path.isdir(os.path.join(path, ".git")):
+        if os.path.exists(os.path.join(path, ".git")):
             return path
         if os.path.isdir(os.path.join(path, ".hg")):
             return path


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #123060

When you make a git worktree, the .git "folder" in the worktree
is not a directory, it's a file pointing at the actual .git directory.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>