### PR TITLE
[onnx.export] Avoid dict <-> unordered_map implicit copies

### DIFF
--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -15,7 +15,7 @@
 #include <torch/csrc/jit/python/python_ir.h>
 #include <torch/csrc/utils/pybind.h>
 #include <sstream>
-#include <unordered_map>
+#include <unordered_set>
 namespace torch {
 namespace jit {
 
@@ -168,7 +168,7 @@ std::shared_ptr<Graph> ToONNX(
   auto constant_value_map = ConstantValueMap::getInstance();
   ConstantValueMap::ClearMaps();
   auto new_graph = std::make_shared<Graph>(graph->current_scope());
-  std::unordered_map<Value*, Value*> env;
+  py::dict env;
   try {
     BlockToONNX(graph->block(), new_graph->block(), operator_export_type, env);
   } catch (std::runtime_error& ex) {
@@ -187,11 +187,11 @@ std::shared_ptr<Graph> ToONNX(
 // (e.g., if sub block), and we want to convert it into its parent block in onnx
 // graph. In this case, we don't register the input/output or eliminate the dead
 // code.
-std::unordered_map<Value*, Value*> BlockToONNX(
+py::dict BlockToONNX(
     Block* old_block,
     Block* new_block,
     ::torch::onnx::OperatorExportTypes operator_export_type,
-    std::unordered_map<Value*, Value*>& env,
+    py::dict& env,
     bool is_sub_block) {
   torch::autograd::SymbolicContext ctx{};
   ctx.block = new_block;
@@ -204,7 +204,7 @@ std::unordered_map<Value*, Value*> BlockToONNX(
   if (!is_sub_block) {
     for (auto input : old_block->inputs()) {
       auto n = ctx.block->addInput()->copyMetadata(input);
-      env[input] = n;
+      env[py::cast(input)] = py::cast(n);
     }
   }
 
@@ -218,7 +218,9 @@ std::unordered_map<Value*, Value*> BlockToONNX(
   }
 
   for (auto output : old_block->outputs()) {
-    ctx.block->registerOutput(env.at(output));
+    auto py_value = env[py::cast(output)];
+    Value* value = py_value.cast<Value*>();
+    ctx.block->registerOutput(value);
   }
   // Run dce to clean-up unused functional and inplace ops.
   EliminateDeadCode(
@@ -226,7 +228,7 @@ std::unordered_map<Value*, Value*> BlockToONNX(
       true,
       DCESideEffectPolicy::ALLOW_DELETING_NODES_WITH_SIDE_EFFECTS);
 
-  return {};
+  return py::dict();
 }
 
 bool ConstantFoldCondition(torch::jit::Value* output) {
@@ -241,7 +243,7 @@ void NodeToONNX(
     Node* old_node,
     Block* new_block,
     ::torch::onnx::OperatorExportTypes operator_export_type,
-    std::unordered_map<Value*, Value*>& env) {
+    py::dict& env) {
   py::object onnx = py::module::import("torch.onnx");
   py::object onnx_globals = py::module::import("torch.onnx._globals");
   py::object onnx_registration =
@@ -251,10 +253,12 @@ void NodeToONNX(
 
   // Returns a node that n maps to in the new graph
   auto envFn = [&env](Value* n) -> Value* {
-    auto it = env.find(n);
-    TORCH_CHECK(it != env.end(), "Dangling node reference");
-    TORCH_CHECK(it->second, "Unused node was subsequently used");
-    return it->second;
+    auto py_n = py::cast(n);
+    TORCH_CHECK(env.contains(py_n), "Dangling node reference");
+    auto py_value = env[py_n];
+    TORCH_CHECK(!py_value.is_none(), "Unused node was subsequently used");
+    Value* value = py_value.cast<Value*>();
+    return value;
   };
 
   // Put the new outputs in our environment map, and copy the type from the
@@ -280,12 +284,14 @@ void NodeToONNX(
     for (const auto i : c10::irange(num_old_outputs)) {
       auto old = old_outputs[i];
       if (outputs[i]) {
-        bool exist_in_env =
-            (env.end() !=
-             std::find_if(
-                 env.begin(), env.end(), [&outputs, i](const auto& vt) {
-                   return vt.second == outputs[i];
-                 }));
+        bool exist_in_env = false;
+        for (const auto& it : env) {
+          Value* v = it.second.cast<Value*>();
+          if (v == outputs[i]) {
+            exist_in_env = true;
+            break;
+          }
+        }
         // Update ONNX value debug name with ATen value debug name if existed.
         // Skip if ONNX value already exist in environment.
         // This implies the op is a noop, and the value is owned by
@@ -325,7 +331,7 @@ void NodeToONNX(
           const_node->copyMetadata(node);
           new_block->appendNode(const_node);
           ONNXShapeTypeInference(const_node, empty_params_dict, opset_version);
-          env[old] = const_node->output();
+          env[py::cast(old)] = py::cast(const_node->output());
         } else {
           // An update in ConstantValueMap is also needed here, since
           // the user setType can be only accessed in this step, and it
@@ -348,12 +354,12 @@ void NodeToONNX(
           if (!exist_in_env) {
             outputs[i]->node()->copyMetadata(node);
           }
-          env[old] = outputs[i];
+          env[py::cast(old)] = py::cast(outputs[i]);
         }
       } else {
         // Null output means that the ONNX op doesn't have outputs corresponding
         // to certain PyTorch outputs
-        env[old] = nullptr;
+        env[py::cast(old)] = py::none();
         if (!old->uses().empty()) {
           std::ostringstream ss;
           ss << "symbolic for " << op_name << " returned None for the output "
@@ -373,7 +379,7 @@ void NodeToONNX(
         new_block->owningGraph()->createClone(node, envFn));
     for (const auto i : c10::irange(node->outputs().size())) {
       // n_->outputs()[i]->setType(node->outputs()[i]->type());
-      env[node->output(i)] = n_->output(i);
+      env[py::cast(node->output(i))] = py::cast(n_->output(i));
     }
   };
 
@@ -381,13 +387,15 @@ void NodeToONNX(
   auto inlineAutograd = [&](Node* PythonOpNode) {
     for (auto subblock : PythonOpNode->blocks()) {
       for (const auto i : c10::irange(PythonOpNode->inputs().size())) {
-        env[subblock->inputs()[i]] = env[PythonOpNode->inputs()[i]];
+        env[py::cast(subblock->inputs()[i])] =
+            env[py::cast(PythonOpNode->inputs()[i])];
       }
       for (auto* node : subblock->nodes()) {
         NodeToONNX(node, new_block, operator_export_type, env);
       }
       for (const auto i : c10::irange(PythonOpNode->outputs().size())) {
-        env[PythonOpNode->outputs()[i]] = env[subblock->outputs()[i]];
+        env[py::cast(PythonOpNode->outputs()[i])] =
+            env[py::cast(subblock->outputs()[i])];
       }
     }
   };

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -284,10 +284,10 @@ void NodeToONNX(
     for (const auto i : c10::irange(num_old_outputs)) {
       auto old = old_outputs[i];
       if (outputs[i]) {
+        py::object py_output = py::cast(outputs[i]);
         bool exist_in_env = false;
-        for (const auto& it : env) {
-          Value* v = it.second.cast<Value*>();
-          if (v == outputs[i]) {
+        for (auto it : env) {
+          if (it.second.equal(py_output)) {
             exist_in_env = true;
             break;
           }

--- a/torch/csrc/jit/passes/onnx.h
+++ b/torch/csrc/jit/passes/onnx.h
@@ -2,7 +2,7 @@
 
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/onnx/onnx.h>
-#include <unordered_map>
+#include <torch/csrc/utils/pybind.h>
 
 namespace torch {
 namespace jit {
@@ -10,17 +10,17 @@ namespace jit {
 TORCH_API std::shared_ptr<Graph> ToONNX(
     std::shared_ptr<Graph>& state,
     ::torch::onnx::OperatorExportTypes operator_export_type);
-TORCH_API std::unordered_map<Value*, Value*> BlockToONNX(
+TORCH_API py::dict BlockToONNX(
     Block* old_block,
     Block* new_block,
     ::torch::onnx::OperatorExportTypes operator_export_type,
-    std::unordered_map<Value*, Value*>& env,
+    py::dict& env,
     bool is_sub_block = false);
 TORCH_API void NodeToONNX(
     Node* old_node,
     Block* new_block,
     ::torch::onnx::OperatorExportTypes operator_export_type,
-    std::unordered_map<Value*, Value*>& env);
+    py::dict& env);
 TORCH_API void RemovePrintOps(std::shared_ptr<Graph>& graph);
 TORCH_API void PreprocessCaffe2Ops(std::shared_ptr<Graph>& graph);
 

--- a/torch/csrc/jit/passes/onnx/pattern_conversion/pattern_conversion.cpp
+++ b/torch/csrc/jit/passes/onnx/pattern_conversion/pattern_conversion.cpp
@@ -69,7 +69,7 @@ std::unordered_map<int64_t, ConvertedIndex> MergeSliceAndSelectToIndices(
     Node* index_put_node,
     const std::vector<Node*>& slice_and_select_nodes,
     Value* orig_data,
-    const std::unordered_map<Value*, Value*>& env) {
+    const py::dict& env) {
   std::unordered_map<int64_t, ConvertedIndex> dim_index_map;
 
   // Loop over fetched slice and select nodes and convert them to index tensors.
@@ -87,7 +87,10 @@ std::unordered_map<int64_t, ConvertedIndex> MergeSliceAndSelectToIndices(
     int64_t dim = node->inputs().at(1)->node()->t(attr::value).item().toLong();
 
     if (dim < 0) {
-      auto input_type = env.at(orig_data)->type()->expect<TensorType>();
+      // auto input_type = env.at(orig_data)->type()->expect<TensorType>();
+      auto py_value = env[py::cast(orig_data)];
+      Value* value = py_value.cast<Value*>();
+      auto input_type = value->type()->expect<TensorType>();
       if (input_type->dim().has_value()) {
         auto rank = static_cast<int64_t>(input_type->dim().value());
         // Rank of original tensor to index on.
@@ -283,7 +286,7 @@ std::vector<Value*> ReshapeToAdvancedIndexingFormat(
 std::vector<Value*> ConvertIndexPutToONNX(
     Block* new_block,
     Node* old_node,
-    std::unordered_map<Value*, Value*>& env) {
+    py::dict& env) {
   if (old_node->kind() != Symbol::fromQualString("onnx::Placeholder") ||
       (old_node->s(attr::name) != "index_put" &&
        old_node->s(attr::name) != "index_put_")) {
@@ -353,7 +356,9 @@ std::vector<Value*> ConvertIndexPutToONNX(
   // Find onnx outputs corresponding to the aten outputs of index_put.
   std::vector<Value*> outs;
   for (auto o : subblock->return_node()->inputs()) {
-    outs.emplace_back(env[o]);
+    auto py_value = env[py::cast(o)];
+    Value* value = py_value.cast<Value*>();
+    outs.emplace_back(value);
   }
   return outs;
 }
@@ -363,7 +368,7 @@ std::vector<Value*> ConvertIndexPutToONNX(
 std::vector<Value*> ConvertPatternFromSubblock(
     Block* new_block,
     Node* old_node,
-    std::unordered_map<Value*, Value*>& env) {
+    py::dict& env) {
   std::vector<Value*> res;
 
   if (old_node->kind() != Symbol::fromQualString("onnx::Placeholder")) {

--- a/torch/csrc/jit/passes/onnx/pattern_conversion/pattern_conversion.h
+++ b/torch/csrc/jit/passes/onnx/pattern_conversion/pattern_conversion.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/utils/pybind.h>
 
 namespace torch {
 namespace jit {
@@ -38,7 +39,7 @@ namespace jit {
 TORCH_API std::vector<Value*> ConvertPatternFromSubblock(
     Block* new_block,
     Node* old_node,
-    std::unordered_map<Value*, Value*>& env);
+    py::dict& env);
 
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
This PR is part of an effort to speed up torch.onnx.export (#121422).

- Avoid [implicit copy](https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html#automatic-conversion) between `pybind11::dict` and `std::unordered_map` that
  happens for every node that gets processed. The copy scales with N
  (number of nodes), so this creates a quadratic time complexity.
  Solution is to always use `pybind11::dict`.
- This alone speeds up exports by x2 for large models.
- Resolves (1) in #121422.

(partial fix of #121422)