### PR TITLE
Add XPU backend check on NamedTensor

### DIFF
--- a/aten/src/ATen/core/NamedTensor.cpp
+++ b/aten/src/ATen/core/NamedTensor.cpp
@@ -87,8 +87,8 @@ void check_names_valid_for(TensorImpl* impl, DimnameList names) {
 void internal_set_names_inplace(TensorImpl* impl, optional<DimnameList> names, bool validate_names) {
   TORCH_CHECK(impl->layout() == Layout::Strided,
       "NYI: named tensors only support strided layout");
-  TORCH_CHECK(impl->device().is_cpu() || impl->device().is_cuda() || impl->device().is_privateuseone(),
-      "NYI: named tensors only support CPU, CUDA or ", c10::get_privateuse1_backend(), " tensors.");
+  TORCH_CHECK(impl->device().is_cpu() || impl->device().is_cuda() || impl->device().is_xpu() || impl->device().is_privateuseone(),
+      "NYI: named tensors only support CPU, CUDA, XPU or ", c10::get_privateuse1_backend(), " tensors.");
   if (!names) {
     impl->set_named_tensor_meta(nullptr);
     return;

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -277,8 +277,8 @@ Tensor empty_names(
   }
   TORCH_CHECK(options.layout() == Layout::Strided,
       "NYI: named tensors only support strided layout");
-  TORCH_CHECK(options.device().is_cpu() || options.device().is_cuda() || options.device().is_privateuseone(),
-      "NYI: named tensors only support CPU, CUDA or ", c10::get_privateuse1_backend(), " tensors.");
+  TORCH_CHECK(options.device().is_cpu() || options.device().is_cuda() || options.device().is_xpu() || options.device().is_privateuseone(),
+      "NYI: named tensors only support CPU, CUDA, XPU or ", c10::get_privateuse1_backend(), " tensors.");
   auto result = at::empty(size, options, optional_memory_format);
   internal_set_names_inplace(result, names);
   return result;


### PR DESCRIPTION
# Motivation
Support `NamedTensor` on XPU backend.

# Motivation
No need UTs.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10