### PR TITLE
remove log2 decomposition; add log2 lowering

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -844,6 +844,10 @@ class CppOverrides(OpOverrides):
         return f"std::log10({x})"
 
     @staticmethod
+    def log2(x):
+        return f"std::log2({x})"
+
+    @staticmethod
     def nextafter(x, y):
         return f"std::nextafter({x}, {y})"
 
@@ -1264,6 +1268,10 @@ class CppVecOverrides(CppOverrides):
     @staticmethod
     def log10(x):
         return f"{x}.log10()"
+
+    @staticmethod
+    def log2(x):
+        return f"{x}.log2()"
 
     @staticmethod
     def nextafter(x):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -716,6 +716,10 @@ class TritonOverrides(OpOverrides):
         return f"libdevice.log10({x})"
 
     @staticmethod
+    def log2(x):
+        return f"libdevice.log2({x})"
+
+    @staticmethod
     def nextafter(x, y):
         return f"libdevice.nextafter({x}, {y})"
 

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -180,11 +180,6 @@ def convolution_backward(
     return (grad_inp, grad_weight, grad_bias)
 
 
-@register_decomposition([aten.log2])
-def log2(x):
-    return torch.log(x) * (1.0 / math.log(2.0))
-
-
 @register_decomposition([aten.round.decimals])
 def round_dec(x, decimals=0):
     ten_pow_decimals = 10.0**decimals

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -5600,6 +5600,7 @@ register_pointwise_numeric(aten.erfc)
 register_pointwise_numeric(aten.erfinv)
 register_pointwise_numeric(aten.hypot)
 register_pointwise_numeric(aten.log10)
+register_pointwise_numeric(aten.log2)
 register_pointwise_numeric(aten.nextafter)
 
 from .codegen.common import pointwise_overrides_data

--- a/torch/_inductor/ops_handler.py
+++ b/torch/_inductor/ops_handler.py
@@ -318,6 +318,9 @@ class OpsHandler(Protocol[T]):
     def log10(self, x0: T) -> T:
         ...
 
+    def log2(self, x0: T) -> T:
+        ...
+
     def nextafter(self, x0: T, x1: T) -> T:
         ...
 


### PR DESCRIPTION
Same reason as `log10`. `log2` is a core aten op, we should not decompose it. As https://github.com/pytorch/pytorch/pull/110882 suggested, it often maps to a hardware intrinsic; Furthermore, decomposing it will negatively impact the numerical precision of the output.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang