### PR TITLE
[sparse] proper sparse iteration

### DIFF
--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -283,12 +283,12 @@ def _iterate_exprs(val: Union[SymInt, torch.Tensor]) -> Iterable[sympy.Basic]:
     elif isinstance(val, (tuple, list)):
         for s in val:
             yield from _iterate_exprs(s)
+    elif is_sparse_any(val):
+        yield from _iterate_exprs(val.size())
     elif isinstance(val, torch.Tensor):
         yield from _iterate_exprs(val.size())
         yield from _iterate_exprs(val.stride())
         yield from _iterate_exprs(val.storage_offset())
-    elif is_sparse_any(val):
-        yield from _iterate_exprs(val.size())
     elif val is None:
         pass
     else:


### PR DESCRIPTION
The branches were in the wrong order (since sparse tensors will also be instances of regular tensors). This puts the branches in the right order.

This is a small step towards #117188

@pearu to review (this was split of https://github.com/pytorch/pytorch/pull/117907)
