### PR TITLE
Enable UFMT on `torch_version.py` and `types.py`

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -2430,8 +2430,6 @@ exclude_patterns = [
     'torch/testing/_internal/test_module/__init__.py',
     'torch/testing/_internal/test_module/future_div.py',
     'torch/testing/_internal/test_module/no_future_div.py',
-    'torch/torch_version.py',
-    'torch/types.py',
     'torch/utils/__init__.py',
     'torch/utils/_contextlib.py',
     'torch/utils/_cpp_extension_versioner.py',

--- a/torch/torch_version.py
+++ b/torch/torch_version.py
@@ -1,10 +1,11 @@
 # mypy: ignore-errors
 
 from typing import Any, Iterable
-from .version import __version__ as internal_version
-from ._vendor.packaging.version import Version, InvalidVersion
 
-__all__ = ['TorchVersion']
+from ._vendor.packaging.version import InvalidVersion, Version
+from .version import __version__ as internal_version
+
+__all__ = ["TorchVersion"]
 
 
 class TorchVersion(str):
@@ -24,6 +25,7 @@ class TorchVersion(str):
             TorchVersion('1.10.0a') > '1.2'
             TorchVersion('1.10.0a') > '1.2.1'
     """
+
     # fully qualified type names here to appease mypy
     def _convert_to_version(self, inp: Any) -> Any:
         if isinstance(inp, Version):
@@ -37,7 +39,7 @@ class TorchVersion(str):
             #   * (1)         -> Version("1")
             #   * (1, 20)     -> Version("1.20")
             #   * (1, 20, 1)  -> Version("1.20.1")
-            return Version('.'.join(str(item) for item in inp))
+            return Version(".".join(str(item) for item in inp))
         else:
             raise InvalidVersion(inp)
 
@@ -53,6 +55,10 @@ class TorchVersion(str):
 
 
 for cmp_method in ["__gt__", "__lt__", "__eq__", "__ge__", "__le__"]:
-    setattr(TorchVersion, cmp_method, lambda x, y, method=cmp_method: x._cmp_wrapper(y, method))
+    setattr(
+        TorchVersion,
+        cmp_method,
+        lambda x, y, method=cmp_method: x._cmp_wrapper(y, method),
+    )
 
 __version__ = TorchVersion(internal_version)

--- a/torch/types.py
+++ b/torch/types.py
@@ -1,16 +1,18 @@
-import torch
+import builtins
 from typing import Any, List, Optional, Sequence, Tuple, Union
 
-import builtins
+import torch
 
 # Convenience aliases for common composite types that we need
 # to talk about in PyTorch
 
 _TensorOrTensors = Union[torch.Tensor, Sequence[torch.Tensor]]
 _TensorOrTensorsOrGradEdge = Union[
-    torch.Tensor, Sequence[torch.Tensor],
+    torch.Tensor,
+    Sequence[torch.Tensor],
     "torch.autograd.graph.GradientEdge",
-    Sequence["torch.autograd.graph.GradientEdge"]]
+    Sequence["torch.autograd.graph.GradientEdge"],
+]
 
 # In some cases, these basic types are shadowed by corresponding
 # top-level values.  The underscore variants let us refer to these
@@ -39,19 +41,22 @@ del Optional
 
 # Storage protocol implemented by ${Type}StorageBase classes
 
+
 class Storage:
     _cdata: int
     device: torch.device
     dtype: torch.dtype
     _torch_load_uninitialized: bool
 
-    def __deepcopy__(self, memo) -> 'Storage':  # type: ignore[empty-body]
+    def __deepcopy__(self, memo) -> "Storage":  # type: ignore[empty-body]
         ...
 
-    def _new_shared(self, int) -> 'Storage':  # type: ignore[empty-body]
+    def _new_shared(self, int) -> "Storage":  # type: ignore[empty-body]
         ...
 
-    def _write_file(self, f: Any, is_real_file: _bool, save_size: _bool, element_size: int) -> None:
+    def _write_file(
+        self, f: Any, is_real_file: _bool, save_size: _bool, element_size: int
+    ) -> None:
         ...
 
     def element_size(self) -> int:  # type: ignore[empty-body]
@@ -60,20 +65,20 @@ class Storage:
     def is_shared(self) -> bool:  # type: ignore[empty-body]
         ...
 
-    def share_memory_(self) -> 'Storage':  # type: ignore[empty-body]
+    def share_memory_(self) -> "Storage":  # type: ignore[empty-body]
         ...
 
     def nbytes(self) -> int:  # type: ignore[empty-body]
         ...
 
-    def cpu(self) -> 'Storage':  # type: ignore[empty-body]
+    def cpu(self) -> "Storage":  # type: ignore[empty-body]
         ...
 
     def data_ptr(self) -> int:  # type: ignore[empty-body]
         ...
 
-    def from_file(self, filename: str, shared: bool = False, nbytes: int = 0) -> 'Storage':  # type: ignore[empty-body]
+    def from_file(self, filename: str, shared: bool = False, nbytes: int = 0) -> "Storage":  # type: ignore[empty-body]
         ...
 
-    def _new_with_file(self, f: Any, element_size: int) -> 'Storage':  # type: ignore[empty-body]
+    def _new_with_file(self, f: Any, element_size: int) -> "Storage":  # type: ignore[empty-body]
         ...


### PR DESCRIPTION
Part of efforts described in #123062.

---

This PR enables the `µfmt` formatting for the following files:

- `torch_version.py`
- `types.py`
