### PR TITLE
Adjust logging content for TS usage logging

### DIFF
--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -46,7 +46,6 @@ import torch.package._mangling as package_mangling
 from torch._awaits import _Await
 from torch._C import _Await as CAwait, Future as CFuture
 from torch._sources import fake_range, get_source_lines_and_file, parse_def
-from torch._utils_internal import log_torchscript_usage
 from torch.futures import Future
 
 IS_PY39_PLUS: Final[bool] = sys.version_info >= (3, 9)
@@ -583,7 +582,6 @@ def export(fn):
         # any compiled methods and wasn't decorated with `@torch.jit.export`
         m = torch.jit.script(MyModule())
     """
-    log_torchscript_usage("export")
     fn._torchscript_modifier = FunctionModifiers.EXPORT
     return fn
 
@@ -625,7 +623,6 @@ def unused(fn):
             # exception raised
             m(torch.rand(100))
     """
-    log_torchscript_usage("unused")
     if isinstance(fn, property):
         prop = fn
         setattr(  # noqa: B010
@@ -713,7 +710,6 @@ def ignore(drop=False, **kwargs):
         import os
         os.remove('m.pt')
     """
-    log_torchscript_usage("ignore")
 
     if callable(drop):
         # used without any args, so drop is actually a function


### PR DESCRIPTION
Summary:
Remove unused/ignore/export TS logging because they do not represent independent TS usage and leads to overload of scribe

Log tupperware job's oncall information so that we have better attribution of who launched the job.

Test Plan: manual testing

Reviewed By: davidberard98

Differential Revision: D55610844


