### PR TITLE
[ez][FSDP2] Removed `_contiguous_orig_stride`

### DIFF
--- a/torch/distributed/_composable/fsdp/_fsdp_param.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_param.py
@@ -101,7 +101,6 @@ class FSDPParam:
     param_dtype: Optional[torch.dtype]
     reduce_dtype: Optional[torch.dtype]
     _orig_size: torch.Size  # ND
-    _contiguous_orig_stride: Tuple[int, ...]
     sharded_size: torch.Size  # ND
     contiguous_sharded_stride: Tuple[int, ...]
     padded_sharded_param_size: torch.Size  # ND
@@ -192,7 +191,6 @@ class FSDPParam:
             self._global_stride = param.stride()
             param_data = param
         self._orig_size = param_data.size()
-        self._contiguous_orig_stride = make_contiguous_strides_for(self._orig_size)
         shard_rank = self.mesh_info.shard_mesh_rank
         shard_world_size = self.mesh_info.shard_mesh_size
         chunks = _chunk_with_empty(param_data, shard_world_size, dim=0)
@@ -258,7 +256,7 @@ class FSDPParam:
         unsharded_param = torch.as_strided(
             self.all_gather_output,
             self._orig_size,
-            self._contiguous_orig_stride,
+            make_contiguous_strides_for(self._orig_size),
             storage_offset=0,
         )
         if self.is_dtensor:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #122908
* #119302
* __->__ #123142



cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang