### PR TITLE
Fix linking issue on Windows

### DIFF
--- a/torch/csrc/dynamo/cpython_defs.h
+++ b/torch/csrc/dynamo/cpython_defs.h
@@ -28,6 +28,14 @@ void THP_PyThreadState_PopFrame(
 
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // pointers to _PyOpcode_Caches for C++
 extern const uint8_t* THP_PyOpcode_Caches;
 extern const int THP_PyOpcode_Caches_size;
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Fix Windows not linking when using python 3.11.
This also happens on CI https://[ossci-raw-job-status.s3.amazonaws.com/log/23293648896](https://ossci-raw-job-status.s3.amazonaws.com/log/23293648896)
```2024-04-01T08:02:18.0648283Z init.cpp.obj : error LNK2019: unresolved external symbol "unsigned char const * const THP_PyOpcode_Caches" (?THP_PyOpcode_Caches@@3PEBEEB) referenced in function "void __cdecl torch::dynamo::`dynamic initializer for '_PyOpcode_Caches_vec''(void)" (??__E_PyOpcode_Caches_vec@dynamo@torch@@YAXXZ)```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang