### PR TITLE
Fix empty_like on sparse compressed fake tensors

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -4446,6 +4446,22 @@ class TestSparseMeta(TestCase):
                 result = torch.zeros_like(f, device=f.fake_device)
             self.assertEqual(result, expected)
 
+    @all_sparse_layouts('layout', include_strided=False)
+    @parametrize("dtype", [torch.float64])
+    def test_empty_like_fake(self, dtype, layout):
+        from torch._subclasses.fake_tensor import FakeTensorMode, FakeTensor
+        from torch.utils._mode_utils import no_dispatch
+        fake_mode = FakeTensorMode()
+        index_dtype = torch.int64
+        device = 'cpu'
+        for t in self.generate_simple_inputs(layout, device=device, dtype=dtype, index_dtype=index_dtype):
+            f = FakeTensor.from_tensor(t, fake_mode)
+            # empty_like on a fake sparse tensor is equivalent to zeros_like:
+            expected = torch.zeros_like(t)
+            with no_dispatch():
+                result = torch.empty_like(f, device=f.fake_device)
+            self.assertEqual(result, expected)
+
 
 class _SparseDataset(torch.utils.data.Dataset):
     # An utility class used in TestSparseAny.test_dataloader method.


### PR DESCRIPTION
Fixes the following failure:
```python
>>> import torch
>>> from torch._subclasses.fake_tensor import FakeTensorMode, FakeTensor
>>> from torch.utils._mode_utils import no_dispatch
>>> fake_mode = FakeTensorMode()
>>> t = torch.tensor([[0, 1], [2, 3.]]).to_sparse_csr()
>>> f = FakeTensor.from_tensor(t, fake_mode)
>>> with no_dispatch(): result = torch.empty_like(f, device=f.fake_device)
... 
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NotImplementedError: Cannot copy out of meta tensor; no data!
```

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #123160
* #123084



cc @alexsamardzic @nikitaved @cpuhrsch @amjames @bhosmer @jcaip @eellison