### PR TITLE
Remove cuda dependencies when building AOTriton (#122982)

### DIFF
--- a/cmake/External/aotriton.cmake
+++ b/cmake/External/aotriton.cmake
@@ -6,7 +6,7 @@ if(NOT __AOTRITON_INCLUDED)
   set(__AOTRITON_INSTALL_DIR "${PROJECT_SOURCE_DIR}/torch")
   ExternalProject_Add(aotriton_external
     GIT_REPOSITORY https://github.com/ROCm/aotriton.git
-    GIT_TAG 5d9a1dbcf5b17ff798ff77f60a8a08fa41953ff0
+    GIT_TAG 24a3fe9cb57e5cda3c923df29743f9767194cc27
     SOURCE_DIR ${__AOTRITON_SOURCE_DIR}
     BINARY_DIR ${__AOTRITON_BUILD_DIR}
     PREFIX ${__AOTRITON_INSTALL_DIR}


### PR DESCRIPTION
Downloading CUDA sometimes failed and breaks the build process, but AOTriton does not need these packages. This commit comments out the related downloading scripts.

This cherry-picks https://github.com/pytorch/pytorch/pull/122982

Note: this PR includes the performance fix discussed in https://github.com/pytorch/pytorch/pull/122967, which is still under review. 

This PR should be cherry-picked **after** the other PR (122967) to avoid "bumping" AOTriton to an older version that does not contain the build fix.