### PR TITLE
doc: `torch.utils.data.Sampler`: `__len__` method is optional

### DIFF
--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -19,8 +19,8 @@ class Sampler(Generic[T_co]):
     r"""Base class for all Samplers.
 
     Every Sampler subclass has to provide an :meth:`__iter__` method, providing a
-    way to iterate over indices or lists of indices (batches) of dataset elements, and a :meth:`__len__` method
-    that returns the length of the returned iterators.
+    way to iterate over indices or lists of indices (batches) of dataset elements,
+    and may provide a :meth:`__len__` method that returns the length of the returned iterators.
 
     Args:
         data_source (Dataset): This argument is not used and will be removed in 2.2.0.


### PR DESCRIPTION
`torch.utils.data.Sampler`: `__len__` method is optional.