### PR TITLE
[PT] [ST] support non contiguous rank validation in sharded tensor

### DIFF
--- a/torch/distributed/_shard/sharded_tensor/api.py
+++ b/torch/distributed/_shard/sharded_tensor/api.py
@@ -281,12 +281,7 @@ class ShardedTensor(ShardedTensorBase):
         self._init_rrefs = init_rrefs
         self._sharded_tensor_id = None
 
-        self._process_group = (
-            process_group
-            if process_group is not None
-            else distributed_c10d._get_default_group()
-        )
-
+        self._process_group = self._normalize_pg(process_group)
         self._remote_shards: Dict[int, List[rpc.RRef[Shard]]] = {}
 
     def _post_init(self):
@@ -674,6 +669,11 @@ class ShardedTensor(ShardedTensorBase):
         )
         return st_to
 
+    @classmethod
+    def _normalize_pg(cls, process_group: Optional[dist.ProcessGroup]) -> dist.ProcessGroup:
+        if process_group is not None:
+            return process_group
+        return distributed_c10d._get_default_group()
 
     @classmethod
     def _init_from_local_shards(
@@ -684,12 +684,8 @@ class ShardedTensor(ShardedTensorBase):
         init_rrefs=False,
     ):
         # STEP 1: Validate the Shardmetadatas locally
-        process_group = (
-            process_group
-            if process_group is not None
-            else distributed_c10d._get_default_group()
-        )
-        current_rank = dist.get_rank(process_group)
+        process_group = cls._normalize_pg(process_group)
+        current_rank = dist.get_rank()  # intentional to get global rank
         world_size = dist.get_world_size(process_group)
 
         local_sharded_tensor_metadata: Optional[ShardedTensorMetadata] = None
@@ -819,12 +815,8 @@ class ShardedTensor(ShardedTensorBase):
             tensor_properties
         )
 
-        process_group = (
-            process_group
-            if process_group is not None
-            else distributed_c10d._get_default_group()
-        )
-        current_rank = dist.get_rank(process_group)
+        process_group = cls._normalize_pg(process_group)
+        current_rank = dist.get_rank()  # intentional to get global rank
 
         local_shards: List[Shard] = []
         for shard_metadata in sharded_tensor_metadata.shards_metadata:
@@ -859,12 +851,8 @@ class ShardedTensor(ShardedTensorBase):
                  not do cross rank validations, and fully rely on the user
                  for the correctness of sharded_tensor_metadata on each rank
         """
-        process_group = (
-            process_group
-            if process_group is not None
-            else distributed_c10d._get_default_group()
-        )
-        current_rank = dist.get_rank(process_group)
+        process_group = cls._normalize_pg(process_group)
+        current_rank = dist.get_rank()  # intentional to get global rank
 
         shards_metadata = sharded_tensor_metadata.shards_metadata
 

--- a/torch/distributed/_shard/sharded_tensor/utils.py
+++ b/torch/distributed/_shard/sharded_tensor/utils.py
@@ -3,7 +3,7 @@ import copy
 from typing import Optional, List, Sequence
 
 import torch
-from torch.distributed import distributed_c10d
+from torch.distributed import distributed_c10d as c10d
 from torch.distributed import rpc
 from torch.distributed._shard.sharding_spec._internals import (
     check_tensor,
@@ -23,20 +23,25 @@ def _parse_and_validate_remote_device(pg, remote_device):
     device = remote_device.device()
 
     # Validate rank, skip validation if rank is not part of process group.
-    if not distributed_c10d._rank_not_in_group(pg):
-        if rank is not None and (rank < 0 or rank >= distributed_c10d.get_world_size(pg)):
-            raise ValueError(f'Invalid rank: {rank}')
+    if not c10d._rank_not_in_group(pg):
+        pg_global_ranks = c10d.get_process_group_ranks(pg)
+        if rank not in pg_global_ranks:
+            raise ValueError(
+                f"Global rank {rank} does not exist in input process group: {pg_global_ranks}"
+            )
 
     if worker_name is not None:
         if not rpc._is_current_rpc_agent_set():
-            raise RuntimeError(f'RPC framework needs to be initialized for using worker names: {worker_name}')
+            raise RuntimeError(
+                f"RPC framework needs to be initialized for using worker names: {worker_name}"
+            )
 
         workers = rpc._get_current_rpc_agent().get_worker_infos()
         for worker in workers:
             if worker.name == worker_name:
                 return worker.id, device
 
-        raise ValueError(f'Invalid worker name: {worker_name}')
+        raise ValueError(f"Invalid worker name: {worker_name}")
 
     return rank, device
 
@@ -97,7 +102,7 @@ def build_metadata_from_local_shards(
     local_shards: List[Shard],
     global_size: torch.Size,
     current_rank: int,
-    pg: distributed_c10d.ProcessGroup
+    pg: c10d.ProcessGroup
 ) -> ShardedTensorMetadata:
 
     assert len(local_shards) > 0, "must have local shards!"


### PR DESCRIPTION
Summary:
Previously the validation logic assumes the sharded tensors' global ranks range from `[0 .. WS]`

This is true if we do 1d flat sharding.
But once we get into 2d+, the ranks may not be contiguous any more.

e.g.
```
[0, 2]
[1, 3]
```
The group size is 2 but ranks may be >= 2.

Going forward, the ST will be replaced by DTensor so it's less of an issue but this is just to make it work for stacks still relying on ST (like torchrec).

Test Plan:
added UT
CI

Differential Revision: D55671872




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang