### PR TITLE
Use -isystem to add search directory for OpenMP headers

### DIFF
--- a/cmake/Modules/FindOpenMP.cmake
+++ b/cmake/Modules/FindOpenMP.cmake
@@ -95,7 +95,7 @@ function(_OPENMP_FLAG_CANDIDATES LANG)
       # default include dir
       find_path(__header_dir "omp.h" HINTS "/usr/local/include")
     endif()
-    set(OMP_FLAG_AppleClang "-Xpreprocessor -fopenmp" "-Xpreprocessor -fopenmp -I${__header_dir}")
+    set(OMP_FLAG_AppleClang "-Xpreprocessor -fopenmp" "-Xpreprocessor -fopenmp -isystem ${__header_dir}")
 
     set(OMP_FLAG_HP "+Oopenmp")
     if(WIN32)


### PR DESCRIPTION
The directories specified by -I are searched before those specified by -isystem. The search directory of protobuf headers is specified by -isystem. If the search directory of OpenMP headers is specified by -I and that directory happens to have headers from an incompatible version of protobuf, we will have a build error.

Fixes #82831
