### PR TITLE
Use Vectorized Half for eager and compile

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256.h
@@ -9,6 +9,7 @@
 #if !(defined(__VSX__)  || defined(CPU_CAPABILITY_VSX) || defined(CPU_CAPABILITY_ZVECTOR))
 #include <ATen/cpu/vec/vec256/vec256_float.h>
 #include <ATen/cpu/vec/vec256/vec256_float_neon.h>
+#include <ATen/cpu/vec/vec256/vec256_half_neon.h>
 #include <ATen/cpu/vec/vec256/vec256_bfloat16.h>
 #include <ATen/cpu/vec/vec256/vec256_double.h>
 #include <ATen/cpu/vec/vec256/vec256_int.h>

--- a/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
@@ -1092,11 +1092,17 @@ CONVERT_NON_VECTORIZED_INIT(BFloat16, bfloat16);
 #if defined(__aarch64__) && !defined(C10_MOBILE) && !defined(__CUDACC__)
 inline std::tuple<Vectorized<float>, Vectorized<float>> convert_half_float(const Vectorized<Half>& a) {
   static_assert(Vectorized<Half>::size() == 2 * Vectorized<float>::size());
+#if defined(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC)
   float16x8x2_t arr = a;
   float16x8_t x = arr.val[0];
+  float16x8_t y = arr.val[1];
+#else
+  auto arr = reinterpret_cast<const float16_t*>(a.operator const Half*());
+  float16x8_t x = vld1q_f16(arr);
+  float16x8_t y = vld1q_f16(arr + Vectorized<float>::size());
+#endif
   float32x4_t x1 = vcvt_f32_f16(vget_low_f16(x));
   float32x4_t x2 = vcvt_f32_f16(vget_high_f16(x));
-  float16x8_t y = arr.val[1];
   float32x4_t y1 = vcvt_f32_f16(vget_low_f16(y));
   float32x4_t y2 = vcvt_f32_f16(vget_high_f16(y));
   return { Vectorized<float>(x1, x2), Vectorized<float>(y1, y2) };
@@ -1109,7 +1115,15 @@ inline Vectorized<Half> convert_float_half(const Vectorized<float>& a, const Vec
   float16x4_t x2 = vcvt_f16_f32(x.val[1]);
   float16x4_t y1 = vcvt_f16_f32(y.val[0]);
   float16x4_t y2 = vcvt_f16_f32(y.val[1]);
+#if defined(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC)
   return Vectorized<Half>(vcombine_f16(x1, x2), vcombine_f16(y1, y2));
+#else
+  Vectorized<Half> rc;
+  auto arr = reinterpret_cast<float16_t*>(rc.operator Half*());
+  vst1q_f16(arr, vcombine_f16(x1, x2));
+  vst1q_f16(arr + Vectorized<float>::size(), vcombine_f16(y1, y2));
+  return rc;
+#endif
 }
 #else
 CONVERT_NON_VECTORIZED_INIT(Half, half);

--- a/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
@@ -1092,11 +1092,11 @@ CONVERT_NON_VECTORIZED_INIT(BFloat16, bfloat16);
 #if defined(__aarch64__) && !defined(C10_MOBILE) && !defined(__CUDACC__)
 inline std::tuple<Vectorized<float>, Vectorized<float>> convert_half_float(const Vectorized<Half>& a) {
   static_assert(Vectorized<Half>::size() == 2 * Vectorized<float>::size());
-  auto arr = reinterpret_cast<const float16_t*>(a.operator const Half*());
-  float16x8_t x = vld1q_f16(arr);
+  float16x8x2_t arr = a;
+  float16x8_t x = arr.val[0];
   float32x4_t x1 = vcvt_f32_f16(vget_low_f16(x));
   float32x4_t x2 = vcvt_f32_f16(vget_high_f16(x));
-  float16x8_t y = vld1q_f16(arr + Vectorized<float>::size());
+  float16x8_t y = arr.val[1];
   float32x4_t y1 = vcvt_f32_f16(vget_low_f16(y));
   float32x4_t y2 = vcvt_f32_f16(vget_high_f16(y));
   return { Vectorized<float>(x1, x2), Vectorized<float>(y1, y2) };
@@ -1109,11 +1109,7 @@ inline Vectorized<Half> convert_float_half(const Vectorized<float>& a, const Vec
   float16x4_t x2 = vcvt_f16_f32(x.val[1]);
   float16x4_t y1 = vcvt_f16_f32(y.val[0]);
   float16x4_t y2 = vcvt_f16_f32(y.val[1]);
-  Vectorized<Half> rc;
-  auto arr = reinterpret_cast<float16_t*>(rc.operator Half*());
-  vst1q_f16(arr, vcombine_f16(x1, x2));
-  vst1q_f16(arr + Vectorized<float>::size(), vcombine_f16(y1, y2));
-  return rc;
+  return Vectorized<Half>(vcombine_f16(x1, x2), vcombine_f16(y1, y2));
 }
 #else
 CONVERT_NON_VECTORIZED_INIT(Half, half);

--- a/aten/src/ATen/cpu/vec/vec256/vec256_half_neon.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_half_neon.h
@@ -545,14 +545,13 @@ class Vectorized<c10::Half> {
         vsqrtq_f16(values.val[0]), vsqrtq_f16(values.val[1]));
   }
   Vectorized<c10::Half> reciprocal() const {
-    auto r0 = vrecpeq_f16(values.val[0]);
-    auto r1 = vrecpeq_f16(values.val[1]);
+    auto ones = vdupq_n_f16(1.0f);
+    auto r0 = vdivq_f16(ones, values.val[0]);
+    auto r1 = vdivq_f16(ones, values.val[1]);
     return Vectorized<c10::Half>(r0, r1);
   }
   Vectorized<c10::Half> rsqrt() const {
-    auto r0 = vrsqrteq_f16(values.val[0]);
-    auto r1 = vrsqrteq_f16(values.val[1]);
-    return Vectorized<c10::Half>(r0, r1);
+    return this->sqrt().reciprocal();
   }
   Vectorized<c10::Half> pow(const Vectorized<c10::Half>& exp) const {
     return map2_with_vec_float_method(exp, &Vectorized<float>::pow);

--- a/aten/src/ATen/cpu/vec/vec256/vec256_half_neon.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_half_neon.h
@@ -22,17 +22,10 @@ inline namespace CPU_CAPABILITY {
 //    https://github.com/android/ndk/issues/1248
 //    https://bugs.llvm.org/show_bug.cgi?id=45824
 // Most likely we will do aarch32 support with inline asm.
-#if defined(__aarch64__)
-#if defined(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC)
+#if !defined(C10_MOBILE) && defined(__aarch64__) && defined(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC)
 
 #ifdef __BIG_ENDIAN__
 #error "Big endian is not supported."
-#endif
-
-#if defined(AT_BUILD_ARM_VEC256_WITH_SLEEF)
-#define USE_SLEEF(sleef_code, non_sleef_code) sleef_code
-#else
-#define USE_SLEEF(sleef_code, non_sleef_code) non_sleef_code
 #endif
 
 template <int index, bool mask_val>
@@ -821,8 +814,7 @@ Vectorized<c10::Half> inline fmsub(
   return Vectorized<c10::Half>(r0, r1);
 }
 
-#endif /* __ARM_FEATURE_FP16_VECTOR_ARITHMETIC */
-#endif /* defined(aarch64) */
+#endif /* defined(aarch64) && defined(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC) && !defined(C10_MOBILE) */
 
 } // namespace CPU_CAPABILITY
 } // namespace at::vec


### PR DESCRIPTION
Using implementation added by https://github.com/pytorch/pytorch/pull/122918

Adapt `convert_half_float`/`convert_half_float` to work when better APIs are available
Fix `Vectorized<Half>::reciprocal()` and `::rsqrt()` implementation do use proper divisions rather than `vrecpeq_f16` which computes the estimate, rather than true division. Please note that this pattern already present in `Vectorized<Float>` for NEON, see:
https://github.com/pytorch/pytorch/blob/05289a278c3eaca271061649982f38c435b50674/aten/src/ATen/cpu/vec/vec256/vec256_float_neon.h#L618-L622

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10