### PR TITLE
MPS FFT implementation bug

### DIFF
--- a/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
+++ b/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
@@ -95,10 +95,22 @@ Tensor& _fft_r2c_mps_out(const Tensor& self, IntArrayRef dim, int64_t normalizat
       auto inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
       auto descriptor = [MPSGraphFFTDescriptor descriptor];
       descriptor.scalingMode = normalization_to_ScalingMode(normalization);
-      auto outputTensor = [mpsGraph realToHermiteanFFTWithTensor:inputTensor
+      MPSGraphTensor* outputTensor;
+      if (onesided) {
+        // Return only unique results:
+        outputTensor = [mpsGraph realToHermiteanFFTWithTensor:inputTensor
                                                             axes:IntArrayToNSArray(dim)
                                                       descriptor:descriptor
                                                             name:nil];
+      } else {
+        // Return with Hermitean conjugate results:
+        auto useDataType = (inputTensor.dataType == MPSDataTypeFloat16) ? MPSDataTypeComplexFloat16 : MPSDataTypeComplexFloat32;
+        auto cTensor =  [mpsGraph castTensor: inputTensor toType: useDataType name: nil];
+        outputTensor = [mpsGraph fastFourierTransformWithTensor:cTensor
+                                                           axes:IntArrayToNSArray(dim)
+                                                     descriptor:descriptor
+                                                           name:nil];
+      }
       newCachedGraph->inputTensor_ = inputTensor;
       newCachedGraph->outputTensor_ = outputTensor;
     });

--- a/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
+++ b/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
@@ -99,13 +99,14 @@ Tensor& _fft_r2c_mps_out(const Tensor& self, IntArrayRef dim, int64_t normalizat
       if (onesided) {
         // Return only unique results:
         outputTensor = [mpsGraph realToHermiteanFFTWithTensor:inputTensor
-                                                            axes:IntArrayToNSArray(dim)
-                                                      descriptor:descriptor
-                                                            name:nil];
+                                                         axes:IntArrayToNSArray(dim)
+                                                   descriptor:descriptor
+                                                         name:nil];
       } else {
         // Return with Hermitean conjugate results:
-        auto useDataType = (inputTensor.dataType == MPSDataTypeFloat16) ? MPSDataTypeComplexFloat16 : MPSDataTypeComplexFloat32;
-        auto cTensor =  [mpsGraph castTensor: inputTensor toType: useDataType name: nil];
+        auto useDataType =
+            (inputTensor.dataType == MPSDataTypeFloat16) ? MPSDataTypeComplexFloat16 : MPSDataTypeComplexFloat32;
+        auto cTensor = [mpsGraph castTensor:inputTensor toType:useDataType name:nil];
         outputTensor = [mpsGraph fastFourierTransformWithTensor:cTensor
                                                            axes:IntArrayToNSArray(dim)
                                                      descriptor:descriptor


### PR DESCRIPTION
Current implementation drops the negative frequency components even when the user doesn't ask for the one-sided transform. The tests for the negative frequency components seem to have worked by accident due to internal implementation details but the issue becomes evident in MacOs 14.4.