### PR TITLE
Remove excessive warnings and rewrite FSDP docstrings

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -130,7 +130,8 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
     .. _`Xu et al.`: https://arxiv.org/abs/2004.13336
     .. _DeepSpeed: https://www.deepspeed.ai/
 
-    For advanced notes please refer to :ref:`fsdp_notes`.
+    To understand its advanced features, you can refer to the
+    :ref:`fsdp_notes`.
 
     Example::
 
@@ -145,111 +146,91 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         >>> loss.backward()
         >>> optim.step()
 
-    .. warning::
-        The optimizer must be initialized *after* the module has been wrapped
-        with FSDP since FSDP will shard and transform the module's parameters
-        in a way that may not preserve the original parameter variables. Thus,
-        the previously initialized optimizer may have stale references to the
-        parameters.
+    Using FSDP involves wrapping your module and then initializing your
+    optimizer after. This is required since FSDP changes the parameter
+    variables.
 
-    .. warning::
-        If the destination CUDA device has ID ``dev_id``, either (1)
-        ``module`` should already be placed on that device, (2) the device
-        should be set using ``torch.cuda.set_device(dev_id)``, or (3)
-        ``dev_id`` should be passed into the ``device_id`` constructor
-        argument. This FSDP instance's compute device will be that destination
-        device. For (1) and (3), the FSDP initialization always occurs on GPU.
-        For (2), the FSDP initialization happens on ``module`` 's current
-        device, which may be CPU.
+    When setting up FSDP, you need to consider the destination CUDA
+    device. If the device has an ID (``dev_id``), you have three options:
 
-    .. warning::
-        FSDP currently does not support gradient accumulation outside
-        ``no_sync()`` when using CPU offloading. Trying to do so yields
-        incorrect results since FSDP will use the newly-reduced gradient
-        instead of accumulating with any existing gradient.
+    * Place the module on that device
+    * Set the device using ``torch.cuda.set_device(dev_id)``
+    * Pass ``dev_id`` into the ``device_id`` constructor argument.
 
-    .. warning::
-        Changing the original parameter variable names after construction will
-        lead to undefined behavior.
+    This ensures that the FSDP instance's compute device is the
+    destination device. For option 1 and 3, the FSDP initialization
+    always occurs on GPU. For option 2, the FSDP initialization
+    happens on module's current device, which may be a CPU.
 
-    .. warning::
-        Passing in the ``sync_module_states=True`` flag requires ``module`` to
-        be on GPU or to use the ``device_id`` argument to specify a CUDA device
-        that FSDP will move ``module`` to in the FSDP constructor. This is
-        because ``sync_module_states=True`` requires GPU communication.
+    If you're using the ``sync_module_states=True`` flag, you need to
+    ensure that the module is on a GPU or use the ``device_id``
+    argument to specify a CUDA device that FSDP will move the module
+    to in the FSDP constructor. This is necessary because
+    ``sync_module_states=True`` requires GPU communication.
 
-    .. warning::
-        As of PyTorch 1.12, FSDP only offers limited support for shared parameters
-        (for example, setting one ``Linear`` layer's weight to another's). In
-        particular, modules that share parameters must be wrapped as part of the
-        same FSDP unit. If enhanced shared parameter support is needed for your
-        use case, please ping https://github.com/pytorch/pytorch/issues/77724
+    FSDP also takes care of moving input tensors to the forward method
+    to the GPU compute device, so you don't need to manually move them
+    from CPU.
 
-    .. warning::
-        FSDP has some constraints on freezing parameters (i.e. setting
-        ``param.requires_grad=False``). For ``use_orig_params=False``, each
-        FSDP instance must manage parameters that are all frozen or all
-        non-frozen. For ``use_orig_params=True``, FSDP supports mixing frozen
-        and non-frozen, but we recommend not doing so since then the gradient
-        memory usage will be higher than expected (namely, equivalent to not
-        freezing those parameters). This means that ideally, frozen parameters
-        should be isolated into their own ``nn.Module`` s and wrapped
-        separately with FSDP.
+    For ``use_orig_params=True``,
+    ``ShardingStrategy.SHARD_GRAD_OP`` exposes the unsharded
+    parameters, not the sharded parameters after forward, unlike
+    ``ShardingStrategy.FULL_SHARD``. If you want
+    to inspect the gradients, you can use the ``summon_full_params``
+    method with ``with_grads=True``.
 
-    .. note::
-        Attempting to run the forward pass of a submodule that is contained in an
-        FSDP instance is not supported and will result in errors. This is because the
-        submodule's parameters will be sharded, but it itself is not an FSDP instance,
-        so its forward pass will not all-gather the full parameters appropriately.
-        This could potentially happen when attempting to run only the encoder of a
-        encoder-decoder model, and the encoder is not wrapped in its own FSDP instance. To
-        resolve this, please wrap the submodule in its own FSDP unit.
+    With ``limit_all_gathers=True``, you may see a gap in the FSDP
+    pre-forward where the CPU thread is not issuing any kernels. This is
+    intentional and shows the rate limiter in effect. Synchronizing the CPU
+    thread in that way prevents over-allocating memory for subsequent
+    all-gathers, and it should not actually delay GPU kernel execution.
 
-    .. note::
-        FSDP moves input tensors to the ``forward`` method to the GPU compute
-        device, so the user does not need to manually move them from CPU.
+    FSDP replaces managed modules' parameters with ``torch.Tensor``
+    views during forward and backward computation for autograd-related
+    reasons. If your module's forward relies on saved references to
+    the parameters instead of reacquiring the references each
+    iteration, then it will not see FSDP's newly created views,
+    and autograd will not work correctly.
 
-    .. warning::
-        The user should not modify the parameters between forward and backward
-        without using the :meth:`summon_full_params` context since the
-        modifications may not persist. Moreover, for ``use_orig_params=False``,
-        accessing the original parameters between forward and backward may
-        raise an illegal memory access.
+    Finally, when using ``sharding_strategy=ShardingStrategy.HYBRID_SHARD``
+    with the sharding process group being intra-node and the
+    replication process group being inter-node, setting
+    ``NCCL_CROSS_NIC=1`` can help improve the all-reduce times over
+    the replication process group for some cluster setups.
 
-    .. warning::
-        For ``use_orig_params=True``, ``ShardingStrategy.SHARD_GRAD_OP``
-        exposes the unsharded parameters, not the sharded parameters, after
-        forward since it does not free the unsharded ones, unlike
-        ``ShardingStrategy.FULL_SHARD``. One caveat is that, since gradients
-        are always sharded or ``None``, ``ShardingStrategy.SHARD_GRAD_OP`` will
-        not expose the sharded gradients with the unsharded parameters after
-        forward. If you want to inspect the gradients, try
-        :meth:`summon_full_params` with ``with_grads=True``.
+    **Limitations**
 
-    .. warning::
-        FSDP replaces managed modules' parameters with ``torch.Tensor`` views
-        during forward and backward computation for autograd-related reasons.
-        If your module's forward relies on saved references to the parameters
-        instead of reacquiring the references each iteration, then it will not
-        see FSDP's newly created views, and autograd will not work correctly.
+    There are several limitations to be aware of when using FSDP:
 
-    .. note::
-        With ``limit_all_gathers=True``, you may see a gap in the FSDP
-        pre-forward where the CPU thread is not issuing any kernels. This is
-        intentional and shows the rate limiter in effect. Synchronizing the CPU
-        thread in that way prevents over-allocating memory for subsequent
-        all-gathers, and it should not actually delay GPU kernel execution.
+    * FSDP currently does not support gradient accumulation outside
+      ``no_sync()`` when using CPU offloading. This is because FSDP
+      uses the newly-reduced gradient instead of accumulating with any
+      existing gradient, which can lead to incorrect results.
 
-    .. note::
-        When using ``sharding_strategy=ShardingStrategy.HYBRID_SHARD`` with the
-        sharding process group being intra-node and the replication process
-        group being inter-node, setting ``NCCL_CROSS_NIC=1`` can help improve
-        the all-reduce times over the replication process group for some
-        cluster setups.
+    * FSDP does not support running the forward pass of a submodule
+      that is contained in an FSDP instance. This is because the
+      submodule's parameters will be sharded, but the submodule itself
+      is not an FSDP instance, so its forward pass will not all-gather
+      the full parameters appropriately.
 
-    .. warning::
-        FSDP does not work with double backwards due to how it registers
-        backward hooks.
+    * FSDP does not work with double backwards due to the way it
+      registers backward hooks.
+
+    * When it comes to freezing parameters, FSDP has some constraints.
+      For ``use_orig_params=False``, each FSDP instance must manage
+      parameters that are all frozen or all non-frozen. For
+      ``use_orig_params=True``, FSDP supports mixing frozen and
+      non-frozen parameters, but it's recommended to avoid doing so to
+      prevent higher than expected gradient memory usage.
+
+    * As of PyTorch 1.12, FSDP offers limited support for shared
+      parameters. If enhanced shared parameter support is needed for
+      your use case, please post in
+      `this issue <https://github.com/pytorch/pytorch/issues/77724>`__.
+
+    * You should avoid modifying the parameters between forward and
+      backward without using the ``summon_full_params`` context, as
+      the modifications may not persist.
 
     Args:
         module (nn.Module):
@@ -1083,16 +1064,16 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         Returns:
             Total norm of the parameters (viewed as a single vector).
 
-        .. note:: If every FSDP instance uses ``NO_SHARD``, meaning that no
+            If every FSDP instance uses ``NO_SHARD``, meaning that no
             gradients are sharded across ranks, then you may directly use
             :func:`torch.nn.utils.clip_grad_norm_`.
 
-        .. note:: If at least some FSDP instance uses a sharded strategy (i.e.
+            If at least some FSDP instance uses a sharded strategy (i.e.
             one other than ``NO_SHARD``), then you should use this method
             instead of :func:`torch.nn.utils.clip_grad_norm_` since this method
             handles the fact that gradients are sharded across ranks.
 
-        .. note:: The total norm returned will have the "largest" dtype across
+            The total norm returned will have the "largest" dtype across
             all parameters/gradients as defined by PyTorch's type promotion
             semantics. For example, if *all* parameters/gradients use a low
             precision dtype, then the returned norm's dtype will be that low
@@ -1361,19 +1342,19 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         and ``"param_groups"``. The flattened parameters in ``FSDP`` modules
         contained in ``model`` are mapped back to their unflattened parameters.
 
-        .. warning:: This needs to be called on all ranks since it uses
-            collective communications. However, if ``rank0_only=True``, then
-            the state dict is only populated on rank 0, and all other ranks
-            return an empty :class:`dict`.
+        This needs to be called on all ranks since it uses
+        collective communications. However, if ``rank0_only=True``, then
+        the state dict is only populated on rank 0, and all other ranks
+        return an empty :class:`dict`.
 
-        .. warning:: Unlike ``torch.optim.Optimizer.state_dict()``, this method
-            uses full parameter names as keys instead of parameter IDs.
+        Unlike ``torch.optim.Optimizer.state_dict()``, this method
+        uses full parameter names as keys instead of parameter IDs.
 
-        .. note:: Like in :meth:`torch.optim.Optimizer.state_dict`, the tensors
-            contained in the optimizer state dict are not cloned, so there may
-            be aliasing surprises. For best practices, consider saving the
-            returned optimizer state dict immediately, e.g. using
-            ``torch.save()``.
+        Like in :meth:`torch.optim.Optimizer.state_dict`, the tensors
+        contained in the optimizer state dict are not cloned, so there may
+        be aliasing surprises. For best practices, consider saving the
+        returned optimizer state dict immediately, e.g. using
+        ``torch.save()``.
 
         Args:
             model (torch.nn.Module): Root module (which may or may not be a

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -130,7 +130,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
     .. _`Xu et al.`: https://arxiv.org/abs/2004.13336
     .. _DeepSpeed: https://www.deepspeed.ai/
 
-    To understand its FSDP internals, refer to the
+    To understand FSDP internals, refer to the
     :ref:`fsdp_notes`.
 
     Example::

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -130,7 +130,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
     .. _`Xu et al.`: https://arxiv.org/abs/2004.13336
     .. _DeepSpeed: https://www.deepspeed.ai/
 
-    To understand its advanced features, you can refer to the
+    To understand its FSDP internals, refer to the
     :ref:`fsdp_notes`.
 
     Example::
@@ -1064,21 +1064,21 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         Returns:
             Total norm of the parameters (viewed as a single vector).
 
-            If every FSDP instance uses ``NO_SHARD``, meaning that no
-            gradients are sharded across ranks, then you may directly use
-            :func:`torch.nn.utils.clip_grad_norm_`.
+        If every FSDP instance uses ``NO_SHARD``, meaning that no
+        gradients are sharded across ranks, then you may directly use
+        :func:`torch.nn.utils.clip_grad_norm_`.
 
-            If at least some FSDP instance uses a sharded strategy (i.e.
-            one other than ``NO_SHARD``), then you should use this method
-            instead of :func:`torch.nn.utils.clip_grad_norm_` since this method
-            handles the fact that gradients are sharded across ranks.
+        If at least some FSDP instance uses a sharded strategy (i.e.
+        one other than ``NO_SHARD``), then you should use this method
+        instead of :func:`torch.nn.utils.clip_grad_norm_` since this method
+        handles the fact that gradients are sharded across ranks.
 
-            The total norm returned will have the "largest" dtype across
-            all parameters/gradients as defined by PyTorch's type promotion
-            semantics. For example, if *all* parameters/gradients use a low
-            precision dtype, then the returned norm's dtype will be that low
-            precision dtype, but if there exists at least one parameter/
-            gradient using FP32, then the returned norm's dtype will be FP32.
+        The total norm returned will have the "largest" dtype across
+        all parameters/gradients as defined by PyTorch's type promotion
+        semantics. For example, if *all* parameters/gradients use a low
+        precision dtype, then the returned norm's dtype will be that low
+        precision dtype, but if there exists at least one parameter/
+        gradient using FP32, then the returned norm's dtype will be FP32.
 
         .. warning:: This needs to be called on all ranks since it uses
             collective communications.

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -216,7 +216,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
     * FSDP does not work with double backwards due to the way it
       registers backward hooks.
 
-    * When it comes to freezing parameters, FSDP has some constraints.
+    * FSDP has some constraints when freezing parameters.
       For ``use_orig_params=False``, each FSDP instance must manage
       parameters that are all frozen or all non-frozen. For
       ``use_orig_params=True``, FSDP supports mixing frozen and


### PR DESCRIPTION
The page at https://pytorch.org/docs/stable/fsdp.html contains a series of warnings and notes that, due to their frequency, may detract from their intended purpose: to highlight crucial information. This PR aims to restructure these notes and warnings into a more coherent narrative, thereby enhancing the readability of the page.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @brycebortree