### PR TITLE
Ensure torch.library doctests runs under xdoctest

### DIFF
--- a/torch/library.py
+++ b/torch/library.py
@@ -93,8 +93,7 @@ class Library:
             name of the operator as inferred from the schema.
 
         Example::
-            >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_LIBRARY)
-            >>> my_lib = Library("foo", "DEF")
+            >>> my_lib = Library("mylib", "DEF")
             >>> my_lib.define("sum(Tensor self) -> Tensor")
         '''
         # This is added because we also want to disallow PURE_FUNCTION alias analysis which is a valid
@@ -249,7 +248,6 @@ def define(qualname, schema, *, lib=None, tags=()):
             torch.Tag carefully before applying it.
 
     Example::
-        >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_LIBRARY)
         >>> import torch
         >>> import numpy as np
         >>>
@@ -257,14 +255,14 @@ def define(qualname, schema, *, lib=None, tags=()):
         >>> torch.library.define("mylib::sin", "(Tensor x) -> Tensor")
         >>>
         >>> # Add implementations for the operator
-        >>> @torch.library.impl("mylibrary::sin", "cpu")
+        >>> @torch.library.impl("mylib::sin", "cpu")
         >>> def f(x):
         >>>     return torch.from_numpy(np.sin(x.numpy()))
         >>>
         >>> # Call the new operator from torch.ops.
         >>> x = torch.randn(3)
         >>> y = torch.ops.mylib.sin(x)
-        >>> assert torch.allclose(y, x)
+        >>> assert torch.allclose(y, x.sin())
 
     """
     if not isinstance(qualname, str):
@@ -317,15 +315,15 @@ def impl(qualname, types, func=None, *, lib=None):
         >>> import numpy as np
         >>>
         >>> # Define the operator
-        >>> torch.library.define("mylibrary::sin", "(Tensor x) -> Tensor")
+        >>> torch.library.define("mylib::mysin", "(Tensor x) -> Tensor")
         >>>
         >>> # Add implementations for the cpu device
-        >>> @torch.library.impl("mylibrary::sin", "cpu")
+        >>> @torch.library.impl("mylib::mysin", "cpu")
         >>> def f(x):
         >>>     return torch.from_numpy(np.sin(x.numpy()))
         >>>
         >>> x = torch.randn(3)
-        >>> y = torch.ops.mylibrary.sin(x)
+        >>> y = torch.ops.mylib.mysin(x)
         >>> assert torch.allclose(y, x.sin())
     """
     if isinstance(types, str):
@@ -413,7 +411,7 @@ def impl_abstract(qualname, func=None, *, lib=None, _stacklevel=1):
         >>>     "(Tensor x, Tensor weight, Tensor bias) -> Tensor")
         >>>
         >>> @torch.library.impl_abstract("mylib::custom_linear")
-        >>> def custom_linear_abstract(x, weight):
+        >>> def custom_linear_abstract(x, weight, bias):
         >>>     assert x.dim() == 2
         >>>     assert weight.dim() == 2
         >>>     assert bias.dim() == 1
@@ -422,6 +420,14 @@ def impl_abstract(qualname, func=None, *, lib=None, _stacklevel=1):
         >>>     assert x.device == weight.device
         >>>
         >>>     return (x @ weight.t()) + bias
+        >>>
+        >>> with torch._subclasses.fake_tensor.FakeTensorMode():
+        >>>     x = torch.randn(2, 3)
+        >>>     w = torch.randn(3, 3)
+        >>>     b = torch.randn(3)
+        >>>     y = torch.ops.mylib.custom_linear(x, w, b)
+        >>>
+        >>> assert y.shape == (2, 3)
         >>>
         >>> # Example 2: an operator with data-dependent output shape
         >>> torch.library.define("mylib::custom_nonzero", "(Tensor x) -> Tensor")
@@ -443,6 +449,14 @@ def impl_abstract(qualname, func=None, *, lib=None, _stacklevel=1):
         >>>     x_np = x.numpy()
         >>>     res = np.stack(np.nonzero(x_np), axis=1)
         >>>     return torch.tensor(res, device=x.device)
+        >>>
+        >>> from torch.fx.experimental.proxy_tensor import make_fx
+        >>>
+        >>> x = torch.tensor([0, 1, 2, 3, 4, 0])
+        >>> trace = make_fx(torch.ops.mylib.custom_nonzero, tracing_mode="symbolic")(x)
+        >>> trace.print_readable()
+        >>>
+        >>> assert torch.allclose(trace(x), torch.ops.mylib.custom_nonzero(x))
 
     """
     source = torch._library.utils.get_source(_stacklevel + 1)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #123292
* #123291
* __->__ #123282
* #123261

I'm not sure what "TORCH_DOCTEST_LIBRARY" is, but it prevented these
tests from running under xdoctest. This PR fixes the docstrings and
makes them actually run under xdoctest.

Test Plan:
- wait for CI
- I verified locally that the docstrings are now being tested.