### PR TITLE
Use numpy 2.0.0rc1 in CI

### DIFF
--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -261,7 +261,7 @@ else
       if [[ "$BUILD_ENVIRONMENT" != *py3.8* ]]; then
         # Install numpy-2.0 release candidate for builds
         # Which should be backward compatible with Numpy-1.X
-        python -mpip install --pre numpy==2.0.0b1
+        python -mpip install --pre numpy==2.0.0rc1
       fi
       WERROR=1 python setup.py bdist_wheel
     else


### PR DESCRIPTION
Bump numpy version to 2.0.0rc1 in CI

Related to: https://github.com/pytorch/pytorch/issues/107302