### PR TITLE
[FSDP] Fixed `summon_full_params` on submodule

### DIFF
--- a/test/distributed/fsdp/test_fsdp_unshard_params.py
+++ b/test/distributed/fsdp/test_fsdp_unshard_params.py
@@ -17,6 +17,8 @@ from torch.distributed.fsdp import (
 )
 from torch.distributed.fsdp._common_utils import clean_tensor_name
 from torch.distributed.fsdp._flat_param import FlatParameter
+from torch.distributed.fsdp.fully_sharded_data_parallel import FLAT_PARAM
+from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 from torch.nn.parallel.distributed import DistributedDataParallel as DDP
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
@@ -621,6 +623,19 @@ class TestUnshardParams(TestUnshardParamsBase):
         with FSDP.summon_full_params(fsdp_model, with_grads=True):
             for param in fsdp_model.parameters():
                 self.assertTrue(param.grad is None)
+
+    @skip_if_lt_x_gpu(2)
+    def test_unshard_submodule(self):
+        model = nn.Sequential(
+            nn.Sequential(nn.Linear(16, 16), nn.Linear(16, 16)),
+            nn.Sequential(nn.Linear(16, 16), nn.Linear(16, 16)),
+        ).cuda()
+        model = FSDP(model, auto_wrap_policy=ModuleWrapPolicy((nn.Sequential,)))
+        with FSDP.summon_full_params(model[0]):
+            # Check that the summoned module does not have its flat parameter
+            for param_name, param in model[0].named_parameters():
+                self.assertFalse(FLAT_PARAM in param_name)
+            self.assertGreater(len(list(model[0].parameters())), 1)
 
 
 class TestUnshardParamsNoShard(TestUnshardParamsBase):

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -100,7 +100,7 @@ from ._unshard_param_utils import (
     _register_flat_param,
     _register_orig_params,
     _unshard_params,
-    _unshard_params_recurse,
+    _unshard_params_for_summon,
 )
 from .wrap import CustomPolicy, ModuleWrapPolicy
 
@@ -600,14 +600,13 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         """
         uninitialized = self._is_root is None
         self._assert_state(TrainingState.IDLE)
-        # Use `_unshard_params_recurse()` with `recurse=False` instead of
+        # Use `_unshard_params_for_summon()` with `recurse=False` instead of
         # `_unshard_fsdp_state_params()` directly to perform lazy
         # initialization, which is needed to initialize `FlatParameter`
         # parameter attributes as required by the unshard logic
-        with _unshard_params_recurse(
+        with _unshard_params_for_summon(
             self,
             self,
-            recurse=False,
             writeback=True,
             rank0_only=False,
             offload_to_cpu=False,
@@ -615,9 +614,9 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         ):
             ret = super().apply(fn)
 
-        # Reset lazy init called in `_unshard_params_recurse()` since `apply()`
-        # may have been called on FSDP instance that is not truly a root, in
-        # which case it will be incorrectly marked as one.
+        # Reset lazy init called in `_unshard_params_for_summon()` since
+        # `apply()` may have been called on FSDP instance that is not truly a
+        # root, in which case it will be incorrectly marked as one.
         if uninitialized and self._is_root:
             for module in traversal_utils._get_fsdp_states(self):
                 module._reset_lazy_init()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #123362
* __->__ #123290
* #122962

This PR fixes https://github.com/pytorch/pytorch/issues/122663.

This PR changes `_unshard_params` to directly look for FSDP modules instead of the two steps of first finding the root FSDP modules and then recursing on their submodules. This should address the issue where we call `summon_full_params` on an FSDP module that is _not_ the root FSDP module.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang