### PR TITLE
[Dynamic Shapes] Fix error handling for indirectly fully constrained dynamic dimensions

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -7121,6 +7121,20 @@ def fn():
         with self.assertRaises(ConstraintViolationError):
             torch._dynamo.optimize("eager")(my_dyn_fn)(y)
 
+    def test_raise_guard_indirect_full_constraint(self):
+        y = torch.randn([3, 3, 3])
+
+        def my_dyn_fn(x):
+            if x.shape[0] > 3:
+                return x.cos()
+            if x.shape[0] < 3:
+                return x * 2
+            return x.sin()
+
+        torch._dynamo.mark_dynamic(y, 0)
+        with self.assertRaises(ConstraintViolationError):
+            torch._dynamo.optimize("eager")(my_dyn_fn)(y)
+
     # Translation validation changes the exception type, don't run with it
     @torch.fx.experimental._config.patch(translation_validation=False)
     def test_mark_dynamic_with_ranges(self):

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -4438,6 +4438,9 @@ class ShapeEnv:
 
             # Updates the range and the guards corresponding to each bound of the symbol.
             self.var_to_range[symbol] = ValueRanges(lower, upper)
+            # If the range is refined to singleton, set replacement
+            if self.var_to_range[symbol].is_singleton():
+                self._set_replacement(symbol, self.var_to_range[symbol].lower, "range_refined_to_singleton")
             # Clears the cache, since this update can change the result.
             self._maybe_evaluate_static.cache_clear()
 


### PR DESCRIPTION
Resolved an issue where dimensions marked as dynamic, yet indirectly constrained to a static value through multiple conditions, failed to trigger a ConstraintViolationError. The update ensures proper error handling for dimensions that are effectively singleton. Included a regression test to verify the fix and prevent recurrence of the issue.

Fixes #122307 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang