### PR TITLE
[dynamo][guards] Use DATA_PTR instead of ID_MATCH for tensors

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -881,6 +881,11 @@ class GuardBuilder(GuardBuilderBase):
         self._guard_on_attribute(guard, "__name__", GuardBuilder.EQUALS_MATCH)
 
     def DATA_PTR_MATCH(self, guard: Guard):
+        # Add a type check. C++ guard has the type check internally, so only
+        # enable it for Python guards.
+        if not config.enable_cpp_guard_manager:
+            self.TYPE_MATCH(guard)
+
         obj = self.get(guard.name)
         code = f"{self.arg_ref(guard)}.data_ptr() == {obj.data_ptr()}"
         self._set_guard_export_info(guard, [code])
@@ -1345,7 +1350,7 @@ class GuardBuilder(GuardBuilderBase):
 
     def TENSOR_MATCH(self, guard: Guard, value=None):
         if guard.is_nn_module() or match_on_id_for_tensor(guard):
-            self.ID_MATCH(guard)
+            self.DATA_PTR_MATCH(guard)
         else:
             if isinstance(value, TensorWeakRef):
                 value = value()

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -724,7 +724,7 @@ class OutputGraph:
                 tracer = self.root_tracer
 
             if get_static_address_type(target) == "guarded":
-                install_guard(source.make_guard(GuardBuilder.ID_MATCH))
+                install_guard(source.make_guard(GuardBuilder.DATA_PTR_MATCH))
             elif not is_constant_source(source):
                 install_guard(source.make_guard(GuardBuilder.TENSOR_MATCH))
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #123303
* __->__ #123302
* #123285

We should sparingly use ID_MATCH guards. When it comes to performance, ID_MATCH is much faster DATA_PTR for Python guards. However, the difference is very small in C++. So, its worth just using DATA_PTR_MATCH.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang