### PR TITLE
[dynamo][guards] Remove workaround after #122858

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -1399,6 +1399,8 @@ class GuardBuilder(GuardBuilderBase):
                         code.append(f"{tensor_name}.{term} == {real_value}")
             else:
                 self.tensor_check_examples.append(value)
+                self.tensor_check_names.append(tensor_name)
+                self.tensor_check_guards.append(guard)
 
                 if config.enable_cpp_guard_manager:
                     guard_manager = self.get_guard_manager(guard)
@@ -1424,15 +1426,6 @@ class GuardBuilder(GuardBuilderBase):
                         tensor_name,
                         verbose_code_parts,
                     )
-
-                    if not is_from_optimizer_source(guard.originating_source):
-                        # Skip no tensor aliasing guard for optimizers. We know
-                        # they do not alias.
-                        self.tensor_check_names.append(tensor_name)
-                        self.tensor_check_guards.append(guard)
-                else:
-                    self.tensor_check_names.append(tensor_name)
-                    self.tensor_check_guards.append(guard)
 
             # A frame is valid for reuse with dynamic dimensions if the new
             # (user-requested) dynamic dimensions are a subset of the old


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #123303
* #123302
* #123285

Not needed since https://github.com/pytorch/pytorch/pull/122858 has landed

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang