### PR TITLE
[export] nn_module_stack to return class name str

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -393,11 +393,10 @@ class TestDeserialize(TestCase):
                 node1.op not in ("get_attr", "placeholder", "output")
             ):
                 # Check "nn_module_stack" metadata
-                # TODO nn_module_stack is not roundtrippable.
-                # self.assertEqual(
-                #     node1.meta.get("nn_module_stack", None),
-                #     node2.meta.get("nn_module_stack", None),
-                # )
+                self.assertEqual(
+                    node1.meta.get("nn_module_stack", None),
+                    node2.meta.get("nn_module_stack", None),
+                )
                 # Check "source_fn_stack" metadata
                 self.assertEqual(
                     node1.meta.get("source_fn_stack", None),

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -70,7 +70,7 @@ def initialize_lazy_module(tx, mod, args, kwargs):
 def record_nn_module_stack(module_key: str, source, tx, mod: torch.nn.Module):
     fully_qualified_name = source.name()
     try:
-        tx.nn_module_stack[module_key] = (fully_qualified_name, type(mod))
+        tx.nn_module_stack[module_key] = (fully_qualified_name, mod.__class__)
         yield
     finally:
         del tx.nn_module_stack[module_key]

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -1582,6 +1582,8 @@ class GraphModuleDeserializer:
             )
 
         fx_node.meta.update(self.deserialize_metadata(serialized_node.metadata))
+        if fx_node.op not in ["placeholder", "output"] and "nn_module_stack" not in fx_node.meta:
+            fx_node.meta["nn_module_stack"] = {}  # serialization throws away empty dicts
 
     def deserialize_input_spec(self, i: InputSpec) -> ep.InputSpec:
         if i.type == "user_input":

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -211,7 +211,10 @@ def _normalize_nn_module_stack(gm_torch_level, root_cls):
                     except Exception:  # TODO(zhxchen17) Remove this.
                         return path
 
-                nn_module_stack = {root_key: (root, root_cls), **nn_module_stack}
+                nn_module_stack = {
+                    root_key: (root, root_cls.__module__ + "." + root_cls.__qualname__),
+                    **nn_module_stack,
+                }
                 node.meta["nn_module_stack"] = {
                     key: (normalize_path(path), ty)
                     for key, (path, ty) in nn_module_stack.items()
@@ -649,9 +652,22 @@ def _verify_nn_module_stack(graph_module: torch.fx.GraphModule) -> None:
         for node in mod.graph.nodes:
             if node.op in ["call_function", "get_attr"]:
                 if i == 0:
-                    if node.meta.get("nn_module_stack", None) is None:
+                    if (
+                        nn_module_stack := node.meta.get("nn_module_stack", None)
+                    ) is None:
                         raise SpecViolationError(
                             f"Node {node} of type {node.op} is missing nn_module_stack metadata"
+                        )
+                    if not all(
+                        isinstance(k, str)
+                        and isinstance(v, tuple)
+                        and len(v) == 2
+                        and all(isinstance(x, str) for x in v)
+                        for k, v in nn_module_stack.items()
+                    ):
+                        raise SpecViolationError(
+                            f"Node {node} of type {node.op} has incorrect nn_module_stack metadata format"
+                            f"expected Dict[str, Tuple[str, str]], but got {nn_module_stack}"
                         )
             elif node.op in ["placeholder", "output"]:
                 if node.meta.get("nn_module_stack", None):

--- a/torch/onnx/_internal/fx/_pass.py
+++ b/torch/onnx/_internal/fx/_pass.py
@@ -10,7 +10,7 @@ import io
 import logging
 import sys
 
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, Optional, Tuple, Union
 
 import torch
 import torch.fx
@@ -32,8 +32,10 @@ class PackageInfo:
         )
 
     @classmethod
-    def from_python_class(cls, python_class: type) -> PackageInfo:
-        package_name = python_class.__module__.split(".")[0]
+    def from_python_class(cls, python_class_name: Union[type, str]) -> PackageInfo:
+        if isinstance(python_class_name, type):
+            python_class_name = python_class_name.__module__
+        package_name = python_class_name.split(".")[0]
         package = __import__(package_name)
         version = getattr(package, "__version__", None)
         # TODO: Figure out how to retrieve commit hash.

--- a/torch/onnx/_internal/fx/passes/modularization.py
+++ b/torch/onnx/_internal/fx/passes/modularization.py
@@ -54,13 +54,16 @@ class _ModuleMeta:
         _raw_meta: The raw meta '(module_name, node.meta["nn_module_stack"][module_name])'.
     """
 
-    _module_class: Final[Optional[type]]
+    _module_class: Final[Optional[Union[type, str]]]
     _module_name: Final[str]
     _raw_meta: Final[Tuple[Any, Any]]
 
     @_beartype.beartype
     def __init__(
-        self, module_name: str, module_class: Optional[type], raw_meta: Tuple[Any, Any]
+        self,
+        module_name: str,
+        module_class: Optional[Union[type, str]],
+        raw_meta: Tuple[Any, Any],
     ):
         self._module_name = module_name
         self._module_class = module_class
@@ -86,9 +89,10 @@ class _ModuleMeta:
         """
         if self._module_class is None:
             return ""
-        return (
-            self._module_class.__module__ + "_" + self._module_class.__name__
-        ).replace(".", "_")
+        mod_cls = self._module_class
+        if isinstance(mod_cls, type):
+            mod_cls = mod_cls.__module__ + "." + mod_cls.__qualname__
+        return mod_cls.replace(".", "_")
 
     @property
     def module_class_name(self) -> str:
@@ -98,7 +102,9 @@ class _ModuleMeta:
         """
         if self._module_class is None:
             return ""
-        return self._module_class.__name__
+        if isinstance(self._module_class, type):
+            return self._module_class.__name__
+        return self._module_class
 
     @property
     def module_name(self) -> str:
@@ -327,7 +333,7 @@ class _ModuleStackMeta:
         return self.top().qualified_module_class_name
 
     @property
-    def module_class(self) -> Optional[type]:
+    def module_class(self) -> Optional[Union[type, str]]:
         """Returns the module class of the top module."""
         return self.top()._module_class
 


### PR DESCRIPTION
Previously, `node.meta["nn_module_stack"]` had type `Dict[str, Tuple[str, class]]` when exported, and later `Dict[str, Tuple[str, str]]` after de/serialization. This PR changes it to consistently be `Dict[str, Tuple[str, str]]` for round-trippability, i.e.
```
{..., 'L__self___conv': ('conv', 'torch.nn.modules.conv.Conv2d')}
```

`source_fn_stack` is left untouched in this PR.

note: the `Union[type, str]` type annotations in ONNX are because ONNX goes through both `export.export()` and `_dynamo.export()` (which still has the original `Dict[str, Tuple[str, class]]` format). nn_module_stack from `export.export()` should consistently have the new format, and we verify/test for that in `_trace.py`. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang