### PR TITLE
[Distributed] [3/N] Fix clang-tidy warnings in torch/csrc/distributed/c10d

### DIFF
--- a/torch/csrc/distributed/c10d/HashStore.cpp
+++ b/torch/csrc/distributed/c10d/HashStore.cpp
@@ -1,12 +1,9 @@
 #include <torch/csrc/distributed/c10d/HashStore.hpp>
 
 #include <unistd.h>
-#include <cerrno>
 #include <cstdint>
 
 #include <chrono>
-#include <cstdio>
-#include <system_error>
 
 #include <c10/util/Exception.h>
 
@@ -100,7 +97,7 @@ int64_t HashStore::add(const std::string& key, int64_t i) {
 
 int64_t HashStore::getNumKeys() {
   std::unique_lock<std::mutex> lock(m_);
-  return map_.size();
+  return static_cast<int64_t>(map_.size());
 }
 
 bool HashStore::deleteKey(const std::string& key) {

--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -257,7 +257,7 @@ class SendBuffer {
   }
 
   void flush() {
-    if (buffer.size() > 0) {
+    if (!buffer.empty()) {
       client.sendRaw(buffer.data(), buffer.size());
       buffer.clear();
     }
@@ -390,7 +390,7 @@ void TCPStore::waitForWorkers() {
   }
 }
 
-void TCPStore::validate(void) {
+void TCPStore::validate() {
   const std::lock_guard<std::mutex> lock(activeOpLock_);
   detail::SendBuffer buffer(*client_, detail::QueryType::VALIDATE);
   buffer.appendValue<std::uint32_t>(c10d::detail::validationMagicNumber);
@@ -625,7 +625,7 @@ bool TCPStore::hasExtendedApi() const {
 std::unordered_map<std::string, std::unordered_map<std::string, double>>
 TCPStore::collectClientCounters() const noexcept {
   std::unordered_map<std::string, std::unordered_map<std::string, double>> res;
-  for (auto kv : clientCounters_) {
+  for (const auto& kv : clientCounters_) {
     res[kv.first] = kv.second.observe();
   }
   return res;

--- a/torch/csrc/distributed/c10d/TCPStore.hpp
+++ b/torch/csrc/distributed/c10d/TCPStore.hpp
@@ -141,7 +141,7 @@ class TORCH_API TCPStore : public Store {
  private:
   int64_t incrementValueBy(const std::string& key, int64_t delta);
 
-  void validate(void);
+  void validate();
 
   std::vector<uint8_t> doGet(const std::string& key);
 

--- a/torch/csrc/distributed/c10d/TCPStoreBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreBackend.cpp
@@ -25,11 +25,10 @@
 
 #include <torch/csrc/distributed/c10d/socket.h>
 
-namespace c10d {
-namespace detail {
+namespace c10d::detail {
 
 // Background thread parent class methods
-BackgroundThread::BackgroundThread() {}
+BackgroundThread::BackgroundThread() = default;
 
 BackgroundThread::~BackgroundThread() = default;
 
@@ -324,7 +323,7 @@ void TCPStoreMasterDaemon::doSet(
 }
 
 void TCPStoreMasterDaemon::validateHandler(int socket) {
-  uint32_t validateNumber;
+  uint32_t validateNumber = 0;
   tcputil::recvBytes<uint32_t>(socket, &validateNumber, 1);
   if (validateNumber != detail::validationMagicNumber) {
     TORCH_CHECK(
@@ -612,5 +611,4 @@ std::unique_ptr<BackgroundThread> create_tcpstore_backend(
   return std::make_unique<TCPStoreMasterDaemon>(std::move(socket));
 }
 
-} // namespace detail
-} // namespace c10d
+} // namespace c10d::detail

--- a/torch/csrc/distributed/c10d/TCPStoreBackend.hpp
+++ b/torch/csrc/distributed/c10d/TCPStoreBackend.hpp
@@ -15,8 +15,7 @@
 #include <unistd.h>
 #endif
 
-namespace c10d {
-namespace detail {
+namespace c10d::detail {
 
 // Magic number for client validation.
 static const uint32_t validationMagicNumber = 0x3C85F7CE;
@@ -63,7 +62,7 @@ class BackgroundThread {
   }
 
  private:
-  std::atomic<bool> is_running_;
+  std::atomic<bool> is_running_{false};
   std::thread daemonThread_{};
 };
 
@@ -73,5 +72,4 @@ std::unique_ptr<BackgroundThread> create_libuv_tcpstore_backend(
     const TCPStoreOptions& opts);
 bool is_libuv_tcpstore_backend_available();
 
-} // namespace detail
-} // namespace c10d
+} // namespace c10d::detail

--- a/torch/csrc/distributed/c10d/Types.hpp
+++ b/torch/csrc/distributed/c10d/Types.hpp
@@ -56,8 +56,8 @@ struct TORCH_API ReduceOp : torch::CustomClassHolder {
 
   ReduceOp(
       RedOpType op,
-      c10::intrusive_ptr<_SupplementBase> optional_supplement) {
-    if (optional_supplement.get()) {
+      const c10::intrusive_ptr<_SupplementBase>& optional_supplement) {
+    if (optional_supplement) {
       op_ = op;
     } else {
       supplement_ = optional_supplement;
@@ -66,14 +66,9 @@ struct TORCH_API ReduceOp : torch::CustomClassHolder {
 
   // The heap resource supplement_, if it exists, is managed by a
   // c10::intrusive_ptr, so constructors and operator= can be simple
-  ReduceOp(const ReduceOp& other)
-      : op_(other.op_), supplement_(other.supplement_) {}
+  ReduceOp(const ReduceOp& other) = default;
 
-  const ReduceOp& operator=(const ReduceOp& other) {
-    op_ = other.op_;
-    supplement_ = other.supplement_;
-    return *this;
-  }
+  ReduceOp& operator=(const ReduceOp& other) = default;
 
   operator RedOpType() const {
     return op_;


### PR DESCRIPTION
This PR continues to fix some clang-tidy warnings in distributed/c10d code, following https://github.com/pytorch/pytorch/pull/122892.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang