### PR TITLE
Clone mutated inputs in first pass of CPP wrapper compilation

### DIFF
--- a/test/inductor/test_cpu_cpp_wrapper.py
+++ b/test/inductor/test_cpu_cpp_wrapper.py
@@ -218,6 +218,7 @@ if RUN_CPU:
         BaseTest("test_index_put1"),
         BaseTest("test_index_put_deterministic_fallback"),
         BaseTest("test_adding_tensor_offsets"),
+        BaseTest("test_inductor_layout_optimization_input_mutations"),
         BaseTest("test_int_div", "", test_cpu_repro.CPUReproTests()),
         BaseTest("test_linear1"),
         BaseTest("test_linear2"),

--- a/test/inductor/test_cuda_cpp_wrapper.py
+++ b/test/inductor/test_cuda_cpp_wrapper.py
@@ -76,6 +76,7 @@ if TEST_WITH_ROCM:
         "test_foreach_cpp_wrapper_cuda",
         "test_index_put_deterministic_fallback_cuda",
         "test_index_tensor_cuda",
+        "test_inductor_layout_optimization_input_mutations",
         "test_linear_relu_cuda",
         "test_multi_device_cuda",
         "test_mm_plus_mm2_cuda",

--- a/test/inductor/test_cuda_cpp_wrapper.py
+++ b/test/inductor/test_cuda_cpp_wrapper.py
@@ -193,6 +193,7 @@ if RUN_CUDA:
         BaseTest("test_index_put_deterministic_fallback"),
         BaseTest("test_adding_tensor_offsets"),
         BaseTest("test_index_tensor"),
+        BaseTest("test_inductor_layout_optimization_input_mutations"),
         BaseTest("test_layer_norm"),
         BaseTest("test_linear1"),
         BaseTest("test_linear2"),

--- a/test/inductor/test_cuda_cpp_wrapper.py
+++ b/test/inductor/test_cuda_cpp_wrapper.py
@@ -76,7 +76,7 @@ if TEST_WITH_ROCM:
         "test_foreach_cpp_wrapper_cuda",
         "test_index_put_deterministic_fallback_cuda",
         "test_index_tensor_cuda",
-        "test_inductor_layout_optimization_input_mutations",
+        "test_inductor_layout_optimization_input_mutations_cuda",
         "test_linear_relu_cuda",
         "test_multi_device_cuda",
         "test_mm_plus_mm2_cuda",

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1293,9 +1293,12 @@ class GraphLowering(torch.fx.Interpreter):
                     and isinstance(real_inputs[idx], torch.Tensor)
                 ]
                 for idx in mutated_input_idxs:
-                    # clone mutated Tensor inputs to avoid mutating the them
-                    # in the first pass of the CPP wrapper compilation, as this
-                    # will lead to double mutation otherwise
+                    # clone mutated Tensor inputs to avoid mutating them in
+                    # the first pass of the CPP wrapper-based compilation, as
+                    # this will lead to a side effect on the example inputs:
+                    # e.g. if torch.compile(f)(x) if called on input-mutating
+                    # f, the inputs x will be mutated twice in the process:
+                    # once here, and again when running the compiled model
                     real_inputs[idx] = real_inputs[idx].clone()
 
             with torch.utils._python_dispatch._disable_current_modes():

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1286,6 +1286,8 @@ class GraphLowering(torch.fx.Interpreter):
                 real_inputs = [materialize(x) for x in V.real_inputs]
 
             if self.mutated_inputs:
+                from .compile_fx import clone_preserve_strides
+
                 mutated_input_idxs = [
                     idx
                     for idx, name in enumerate(self.graph_inputs)
@@ -1300,7 +1302,7 @@ class GraphLowering(torch.fx.Interpreter):
                     # f, the inputs x will be mutated twice in the process:
                     # once here, and again when running the compiled model;
                     # this will also lead to a numerically incorrect output
-                    real_inputs[idx] = real_inputs[idx].clone()
+                    real_inputs[idx] = clone_preserve_strides(real_inputs[idx])
 
             with torch.utils._python_dispatch._disable_current_modes():
                 assert self.example_inputs is not None

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1298,7 +1298,8 @@ class GraphLowering(torch.fx.Interpreter):
                     # this will lead to a side effect on the example inputs:
                     # e.g. if torch.compile(f)(x) if called on input-mutating
                     # f, the inputs x will be mutated twice in the process:
-                    # once here, and again when running the compiled model
+                    # once here, and again when running the compiled model;
+                    # this will also lead to a numerically incorrect output
                     real_inputs[idx] = real_inputs[idx].clone()
 
             with torch.utils._python_dispatch._disable_current_modes():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #123316

Summary: CPP wrapper compilation is currently done in two passes: in the first pass, Python wrapper is generated and run to compile Triton kernels as a side effect, in the second pass C++ wrapper is generated and compiled. When model inputs are mutated, running the Python wrapper in the first pass mutates the inputs, although the first pass (including the Python wrapper run) is strictly a part of the compilation process, hence must not introduce any side effects on the example inputs.

In this PR, we clone mutated inputs in the first pass to avoid input mutation.

Fixes https://github.com/pytorch/pytorch/issues/117364.

Test Plan:

```
$ TORCHINDUCTOR_CPP_WRAPPER=1 python test/inductor/test_torchinductor.py -k test_inductor_layout_optimization_input_mutations_cuda
...
.
----------------------------------------------------------------------
Ran 1 test in 6.368s

OK
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang