### PR TITLE
[Compile FSDP2][1/n] Change FSDP2 hooks to staticmethod

### DIFF
--- a/torch/distributed/_composable/fsdp/_fsdp_state.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_state.py
@@ -55,7 +55,9 @@ class FSDPState(_State):
         self._device = device
         self._mp_policy = mp_policy
         self._pre_forward_hook_handle = module.register_forward_pre_hook(
-            functools.partial(FSDPState._pre_forward, self), prepend=True, with_kwargs=True
+            functools.partial(FSDPState._pre_forward, self),
+            prepend=True,
+            with_kwargs=True,
         )
         self._post_forward_hook_handle = module.register_forward_hook(
             functools.partial(FSDPState._post_forward, self), prepend=False


### PR DESCRIPTION
`torch.compile` hook support doesn't work with instance-bound methods yet, so changing FSDP2 hooks to `staticmethod`.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @chauhang