### PR TITLE
[ONNX] beartype to emit warning instead of error by default

### DIFF
--- a/torch/onnx/_internal/_beartype.py
+++ b/torch/onnx/_internal/_beartype.py
@@ -120,12 +120,12 @@ else:
     _TORCH_ONNX_EXPERIMENTAL_RUNTIME_TYPE_CHECK = os.getenv(
         "TORCH_ONNX_EXPERIMENTAL_RUNTIME_TYPE_CHECK"
     )
-    if _TORCH_ONNX_EXPERIMENTAL_RUNTIME_TYPE_CHECK == "WARNINGS":
-        _runtime_type_check_state = RuntimeTypeCheckState.WARNINGS
+    if _TORCH_ONNX_EXPERIMENTAL_RUNTIME_TYPE_CHECK == "ERRORS":
+        _runtime_type_check_state = RuntimeTypeCheckState.ERRORS
     elif _TORCH_ONNX_EXPERIMENTAL_RUNTIME_TYPE_CHECK == "DISABLED":
         _runtime_type_check_state = RuntimeTypeCheckState.DISABLED
     else:
-        _runtime_type_check_state = RuntimeTypeCheckState.ERRORS
+        _runtime_type_check_state = RuntimeTypeCheckState.WARNINGS
     beartype = _create_beartype_decorator(_runtime_type_check_state)
     # Make sure that the beartype decorator is enabled whichever path we took.
     assert beartype is not None


### PR DESCRIPTION
Making exporter more "robust" to advances in beartype tool. Pull Request resolved: https://github.com/pytorch/pytorch/pull/123205 Approved by: https://github.com/justinchuby, https://github.com/thiagocrepaldi
