### PR TITLE
[pt2] remove 2 decompose patterns

### DIFF
--- a/test/inductor/test_decompose_mem_bound_mm.py
+++ b/test/inductor/test_decompose_mem_bound_mm.py
@@ -158,10 +158,6 @@ class TestDecomposeMemMM(TestCase):
             counters["inductor"]["decompose_mm"] - decompose_mm_fwd,
             expected_val,
         )
-        self.assertEqual(
-            counters["inductor"]["decompose_mmt"],
-            expected_val,
-        )
         counters.clear()
 
     @parametrize(
@@ -201,10 +197,6 @@ class TestDecomposeMemMM(TestCase):
             counters["inductor"]["decompose_mm"] - decompose_mm_fwd,
             expected_val,
         )
-        self.assertEqual(
-            counters["inductor"]["decompose_mm_large_k"],
-            expected_val,
-        )
         counters.clear()
 
     @parametrize("m,k,n, should_decompose", [(20480, 5, 2, True)])
@@ -239,10 +231,6 @@ class TestDecomposeMemMM(TestCase):
         self.assertEqual(
             counters["inductor"]["decompose_mm"],
             1 if has_bias else 2,
-        )
-        self.assertEqual(
-            counters["inductor"]["decompose_mmt"],
-            expected_val,
         )
         counters.clear()
 


### PR DESCRIPTION
Summary:
https://fb.workplace.com/groups/1075192433118967/permalink/1402410947063779/
some investigation. large-k pattern will degrade the perf. remove those patterns. Though mmt patten indeed shows some gain in compiling single operator P1201328502 and  P1201328722. but it will conflict with other opt in inductor and result in a slow down.

Test Plan:
some result from benchmark, manually to hold stride
```
import torch
import torch._inductor.config as inductor_config
import triton

inductor_config.trace.enabled = True

m1 = torch.rand(9388864, 2, device="cuda", dtype=torch.bfloat16)
m2 = torch.rand(9388864, 12, device="cuda", dtype=torch.bfloat16)
print(f"m1.stride {m1.stride()}")
print(f"m2.stride {m2.stride()}")


torch.compile
def fake_mm(a, b):
    return torch.sum(a[:, :, None] * b[:, None, :], dim=0)


tmp = fake_mm(m1, m2)
print(tmp.shape)
s = triton.testing.do_bench(lambda: fake_mm(m1, m2))
print(f"fake mm{s}")
tmp2 = torch.mm(m1.permute(1, 0), m2)
s = triton.testing.do_bench(lambda: torch.mm(m1.permute(1, 0), m2))
print(print(f"mm{s}"))

m3 = m1.permute(1, 0).contiguous()
s = triton.testing.do_bench(lambda: torch.mm(m1.permute(1, 0).contiguous(), m2))
print(print(f"mm without permute{s}"))

result: 
fake mm14.968459129333496
mm507.6383972167969
mm without permute0.7466956973075867
```

 single kernel can be speed up from 5ms->3ms
 {F1477685597} 
 {F1477685813}

Differential Revision: D55759235




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang