### PR TITLE
[PT2][Inductor] Add decompose_mem_bound_mm to the customization pre and post grad passes

### DIFF
--- a/torch/_inductor/fx_passes/decompose_mem_bound_mm.py
+++ b/torch/_inductor/fx_passes/decompose_mem_bound_mm.py
@@ -1,18 +1,14 @@
 import logging
-from typing import List, Optional
+from typing import List
 
 import torch
 from torch import Tensor
 from torch._dynamo.utils import counters
 
-from ..pattern_matcher import (
-    Arg,
-    CallFunction,
-    config_flag,
-    Match,
-    register_graph_pattern,
-)
-from .post_grad import decompose_mm_pass
+from .. import config
+
+from ..pattern_matcher import Arg, CallFunction, Match, register_graph_pattern
+from .split_cat import construct_pattern_matcher_pass, get_config_flag
 
 aten = torch.ops.aten
 log = logging.getLogger(__name__)
@@ -21,15 +17,19 @@ log = logging.getLogger(__name__)
 MIN_FIRST_DIMENSION_DECOMPOSITION = 10240
 MAX_OTHER_DIMENSION_DECOMPOSITION = 32
 
+min_first_dimension_decomposition = MIN_FIRST_DIMENSION_DECOMPOSITION
+max_other_dimention_decomposition = MAX_OTHER_DIMENSION_DECOMPOSITION
+if "decompose_mem_bound_mm" in config.post_grad_fusion_options:
+    min_first_dimension_decomposition = config.post_grad_fusion_options[
+        "decompose_mem_bound_mm"
+    ].get("min_first_dimension_decomposition", MIN_FIRST_DIMENSION_DECOMPOSITION)
+    max_other_dimention_decomposition = config.post_grad_fusion_options[
+        "decompose_mem_bound_mm"
+    ].get("max_other_dimention_decomposition", MAX_OTHER_DIMENSION_DECOMPOSITION)
+
 
 def check_device(a: Tensor, b: Tensor) -> bool:
     return a.is_cuda and b.is_cuda
-
-
-def should_decompose_common(
-    mat1: Tensor, mat2: Tensor, input: Optional[Tensor] = None
-) -> bool:
-    return torch._inductor.config.decompose_mem_bound_mm and check_device(mat1, mat2)
 
 
 def should_decompose_bmm(mat1, mat2) -> bool:
@@ -38,17 +38,17 @@ def should_decompose_bmm(mat1, mat2) -> bool:
         mat2 = mat2.meta["val"]
     else:
         return False
-    if not should_decompose_common(mat1, mat2):
+    if not check_device(mat1, mat2):
         return False
     else:
         if len(mat1.shape) != 3 or len(mat2.shape) != 3:
             return False
-        if mat1.shape[0] < MIN_FIRST_DIMENSION_DECOMPOSITION:
+        if mat1.shape[0] < min_first_dimension_decomposition:
             return False
         # 2 of m, n, k must be <= MAX_OTHER_DIMENSION_DECOMPOSITION
-        if (mat1.shape[1] < MAX_OTHER_DIMENSION_DECOMPOSITION) + (
-            mat1.shape[2] < MAX_OTHER_DIMENSION_DECOMPOSITION
-        ) + (mat2.shape[2] < MAX_OTHER_DIMENSION_DECOMPOSITION) < 2:
+        if (mat1.shape[1] < max_other_dimention_decomposition) + (
+            mat1.shape[2] < max_other_dimention_decomposition
+        ) + (mat2.shape[2] < max_other_dimention_decomposition) < 2:
             return False
     return True
 
@@ -60,12 +60,12 @@ def should_decompose_mm(mat1, mat2) -> bool:
     else:
         return False
     return (
-        should_decompose_common(mat1, mat2)
+        check_device(mat1, mat2)
         and len(mat1.shape) == 2
         and len(mat2.shape) == 2
-        and mat1.shape[0] >= MIN_FIRST_DIMENSION_DECOMPOSITION
-        and mat2.shape[0] < MAX_OTHER_DIMENSION_DECOMPOSITION
-        and mat2.shape[1] < MAX_OTHER_DIMENSION_DECOMPOSITION
+        and mat1.shape[0] >= min_first_dimension_decomposition
+        and mat2.shape[0] < max_other_dimention_decomposition
+        and mat2.shape[1] < max_other_dimention_decomposition
     )
 
 
@@ -87,8 +87,8 @@ def print_decompose_pattern(match: Match, inputs: List[torch.fx.Node]):
 
 @register_graph_pattern(
     CallFunction(aten.bmm, Arg(), Arg()),
-    pass_dict=decompose_mm_pass,
-    extra_check=config_flag("decompose_mem_bound_mm"),
+    pass_dict=construct_pattern_matcher_pass("decompose_mm_pass"),
+    extra_check=get_config_flag("decompose_mm_pass", "decompose_mem_bound_mm"),
 )
 def decompose_bmm(match: Match, mat1: torch.fx.Node, mat2: torch.fx.Node):
     def repl(mat1, mat2):
@@ -103,8 +103,8 @@ def decompose_bmm(match: Match, mat1: torch.fx.Node, mat2: torch.fx.Node):
 
 @register_graph_pattern(
     CallFunction(aten.addmm, Arg(), Arg(), Arg()),
-    pass_dict=decompose_mm_pass,
-    extra_check=config_flag("decompose_mem_bound_mm"),
+    pass_dict=construct_pattern_matcher_pass("decompose_mm_pass"),
+    extra_check=get_config_flag("decompose_mm_pass", "decompose_mem_bound_mm"),
 )
 def decompose_addmm(
     match: Match,
@@ -124,8 +124,8 @@ def decompose_addmm(
 
 @register_graph_pattern(
     CallFunction(aten.mm, Arg(), Arg()),
-    pass_dict=decompose_mm_pass,
-    extra_check=config_flag("decompose_mem_bound_mm"),
+    pass_dict=construct_pattern_matcher_pass("decompose_mm_pass"),
+    extra_check=get_config_flag("decompose_mm_pass", "decompose_mem_bound_mm"),
 )
 def decompose_mm(
     match: Match,

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -63,7 +63,6 @@ pass_patterns = [
 ]
 # patterns applied only in inference
 inference_patterns = PatternMatcherPass()
-decompose_mm_pass = PatternMatcherPass()
 
 
 def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
@@ -103,7 +102,6 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
                 ] = upload_graph(gm.graph)
         if is_inference:
             inference_patterns.apply(gm.graph)  # type: ignore[arg-type]
-        decompose_mm_pass.apply(gm.graph)  # type: ignore[arg-type]
 
     if config._fuse_ddp_communication:
         fuse_ddp_communication(


### PR DESCRIPTION
Summary: Titled. It can give more flexibility to customize passes

Test Plan:
# unit test
```
buck2 test @mode/dev-nosan //caffe2/test/inductor:decompose_mem_bound_mm
```

# local reproduce
### with decompose

```
buck2 run @mode/opt //scripts/jackiexu0313/pt2:local_model_with_pt2 -- --test_mode batch-split-decompose --model_type "cmf" --flow_id 540761965
```
optimus parameter sent to the scuba:
P1204802500
```
{'before_recompile_pre_grad': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GLxXNRNO6q8ixo4CAIn5QalwADlsbr0LAAAz', 'BatchLayernormFusion': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GN8MQhmQrZaii4sFAJ37FLW-yjkobr0LAAAz', 'BatchSigmoidPreGradFusion': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GKYr2xa3vOkEKIQDAL5eKqkDWQAebr0LAAAz', 'normalization_pass_pre_grad': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GAjzORm9OYV951kBAF5WyqbckVY2br0LAAAz', 'remove_split_with_size_one_pass_pre_grad': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GMpzQhbeucEI_BwDAOK0nUGoCsZkbr0LAAAz', 'merge_getitem_cat_pass_pre_grad': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GDJ2whaLisgDsYMDABd4ox_-2gp5br0LAAAz', 'merge_splits_pass_pre_grad': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GJY4Pxkg0hntj9UCALgYP3xMdmMMbr0LAAAz', 'after_recompile_pre_grad': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GO1gCxfWSaDFqhIBABzCPhU827F7br0LAAAz', 'before_recompile_post_grad': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GPzyNBaxHtNFJdADADH7AsWMwixBbr0LAAAz', 'BatchMulPostGradFusion': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GBxaWAofHuojr0EBALKAINF-n_Ebbr0LAAAz', 'after_recompile_post_grad': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GPTR_RZdqWhlGmwEADUfB1t_xKN-br0LAAAz', 'inductor': Counter({'pattern_matcher_nodes': 3615, 'pattern_matcher_count': 3231, 'normalization_pass': 825, 'remove_split_with_size_one_pass': 673, 'merge_splits_pass': 85, 'merge_getitem_cat_pass': 11, 'batch_aten_mul': 11, 'scmerge_split_sections_removed': 5, 'scmerge_split_removed': 4, 'scmerge_cat_removed': 4, 'decompose_mm': 4, 'decompose_mmt': 4, 'batch_aten_sub': 3, 'batch_sigmoid': 2, 'batch_linear': 2, 'batch_aten_add': 2, 'batch_layernorm': 1, 'scmerge_split_added': 1, 'scmerge_cat_added': 1, 'batch_relu': 1, 'batch_linear_post_grad': 1}), 'PreGradBatchLinearFusion': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GEp2SBdLi4Q9SfYCALG5AsLl-LJubr0LAAAz', 'BatchReLuPreGradFusion': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GMry_BbFwSc8epcBAP7-LFeL-aRbbr0LAAAz', 'BatchAddPostGradFusion': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GKpamxaU2v4MlyANANGbWkDgUAQabr0LAAAz', 'BatchSubPostGradFusion': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GOMotxYcfE3jsWEBAFi0ABcmUboYbr0LAAAz', 'PostGradBatchLinearFusion': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GC3yQRku3hY9VmkBAH3QvuAf5z8Cbr0LAAAz'}
```
### without decompose
optimus parameter sent to the scuba:
P1204807273
```
{'before_recompile_pre_grad': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GLDLYxbo4HnP1ssDAKDGl5fN9SUnbr0LAAAz', 'BatchLayernormFusion': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GOKrQBnK6dfZg3YDALrJX7r23dN8br0LAAAz', 'BatchSigmoidPreGradFusion': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GER6ChcNzZ9NX94DAH6ZWJFFD5Uzbr0LAAAz', 'normalization_pass_pre_grad': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GNmRphbUGk2zvswAAJ3sOh3WWGBAbr0LAAAz', 'remove_split_with_size_one_pass_pre_grad': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GDYJJBQRWfOYB0wFAJpCr7RsFnsQbr0LAAAz', 'merge_getitem_cat_pass_pre_grad': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GM2ABxPOewvvdm8FAMPnyXSb6Fwzbr0LAAAz', 'merge_splits_pass_pre_grad': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GOkqSBYgyv9G4tQCAFBtGCq1OUhkbr0LAAAz', 'after_recompile_pre_grad': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GMdbSBeSWQGyOGkDANtexORtG0lMbr0LAAAz', 'before_recompile_post_grad': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GF8rvghuhGGVZXMBAPKAC7WPIeUGbr0LAAAz', 'BatchMulPostGradFusion': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GDWyCheBejGMvq0FAApYMMDOu7Jwbr0LAAAz', 'after_recompile_post_grad': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GDRgqxE_qCrmMyIDAL5TQ977TQknbr0LAAAz', 'inductor': Counter({'pattern_matcher_nodes': 2323, 'pattern_matcher_count': 2071, 'normalization_pass': 825, 'remove_split_with_size_one_pass': 673, 'merge_splits_pass': 85, 'merge_getitem_cat_pass': 11, 'scmerge_split_sections_removed': 5, 'scmerge_split_removed': 4, 'scmerge_cat_removed': 4, 'batch_sigmoid': 2, 'batch_linear': 2, 'batch_layernorm': 1, 'scmerge_split_added': 1, 'scmerge_cat_added': 1, 'batch_aten_mul': 1, 'batch_relu': 1}), 'PreGradBatchLinearFusion': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GNyUxRYGchkL_gMLAKk5mC-cbU9zbr0LAAAz', 'BatchReLuPreGradFusion': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GD19_BZMbHm46BMNAE05wMFtvB9mbr0LAAAz'}
```
# e2e
ads_dper3:f044a2eb340c5477d3347540114a83b0
training_platform:cb4809460a19df86785e790d3a9b92a6

### with decompose
use old config:
```
"decompose_mem_bound_mm": true
```
f549189471
{F1478026031}
add to the post grad fusion options:
```
"post_grad_fusion_options": {
            "batch_linear_post_grad": {},
            "decompose_mm_pass": {
              "min_first_dimension_decomposition": 10240,
              "max_other_dimention_decomposition": 32
            }
          },
```
f549189811
{F1478026133}
### without decompose
with optimize_compress off
f549190692
 {F1478027534}
with optimize_compress on
f549191653
### QPS and NE

 {F1481917745} 

 {F1481917870}{F1481917871}

### conclusion
1. when compare  with no optimize_compress, has ~2% qps gain with NE neutral
2. when compare with  optimize_compress, qps is neutral but the optimize_compress shows NE gap compared to the baseline

Differential Revision: D55679277




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang