### PR TITLE
[Bug Fix] Fix Cuda 12.4 compilation - Refactor SFINAE boxing logic 

### DIFF
--- a/aten/src/ATen/core/boxing/impl/boxing.h
+++ b/aten/src/ATen/core/boxing/impl/boxing.h
@@ -47,7 +47,7 @@ template <class T>
 using ivalue_to_helper_t = typename ivalue_to_helper<T>::type;
 
 template <class T>
-struct has_ivalue_to<T, guts::void_t<ivalue_to_helper_t<T>>>
+struct has_ivalue_to<T, std::void_t<ivalue_to_helper_t<T>>>
 : std::true_type
 {};
 

--- a/aten/src/ATen/core/boxing/impl/boxing.h
+++ b/aten/src/ATen/core/boxing/impl/boxing.h
@@ -39,7 +39,16 @@ template <class T, class Enable = void>
 struct has_ivalue_to : std::false_type {};
 
 template <class T>
-struct has_ivalue_to<T, std::void_t<decltype(std::declval<IValue>().to<T>())>>
+struct ivalue_to_helper
+{
+    using type = decltype(std::declval<IValue>().template to<T>());
+};
+template <class T>
+using ivalue_to_helper_t = typename ivalue_to_helper<T>::type;
+
+template <class T>
+struct has_ivalue_to<T, guts::void_t<ivalue_to_helper_t<T>>>
+
 : std::true_type
 {};
 

--- a/aten/src/ATen/core/boxing/impl/boxing.h
+++ b/aten/src/ATen/core/boxing/impl/boxing.h
@@ -48,7 +48,6 @@ using ivalue_to_helper_t = typename ivalue_to_helper<T>::type;
 
 template <class T>
 struct has_ivalue_to<T, guts::void_t<ivalue_to_helper_t<T>>>
-
 : std::true_type
 {};
 


### PR DESCRIPTION
Summary:

PyTorch fails to compile from source using CUDA 12.4. The relevant log is extracted below. This was a recurring issue, which would cause the compilation to fail again on further objects if the first offending object was skipped.

While searching for whether others had experienced this issue before attempting a fix myself, I found this suggested fix by @christian-heusel in https://github.com/pytorch/pytorch/issues/122169#issuecomment-2008455468 written by @lahwaacz. The code written by @lahwaacz at https://gitlab.archlinux.org/archlinux/packaging/packages/python-pytorch/-/commit/bb1f1a4c546c9692fb56db57172f14d25b95e645 fixes the issue. 

The original issue (#122169) seems to have gone quiet, so I am submitting this PR. I made no substantive adjustments to @lahwaacz' code. My only adjustment was, for the sake of consistency, to remove the double underscores in the struct name, as double underscores are reserved to the implementation in C++ Standard. My change has no functional effect on the original code.             

The ArchLinux package from which the original code was committed is licensed under the BSD license. https://archlinux.org/packages/extra/x86_64/python-pytorch/

```
[7900/8804] Building CUDA object caffe2/CMakeFiles/torch_cuda.dir/__/torch/csrc/distributed/c10d/quantization/quantization_gpu.cu.o
FAILED: caffe2/CMakeFiles/torch_cuda.dir/__/torch/csrc/distributed/c10d/quantization/quantization_gpu.cu.o 
/usr/bin/ccache /usr/local/cuda-12.4/bin/nvcc -forward-unknown-to-host-compiler -DAT_PER_OPERATOR_HEADERS -DFLASHATTENTION_DISABLE_ALIBI -DHAVE_MALLOC_USABLE_SIZE=1 -DHAVE_MMAP=1 -DHAVE_SHM_OPEN=1 -DHAVE_SHM_UNLINK=1 -DIDEEP_USE_MKL -DMINIZ_DISABLE_ZIP_READER_CRC32_CHECKS -DONNXIFI_ENABLE_EXT=1 -DONNX_ML=1 -DONNX_NAMESPACE=onnx_torch -DTORCH_CUDA_BUILD_MAIN_LIB -DUSE_C10D_GLOO -DUSE_C10D_NCCL -DUSE_CUDA -DUSE_CUSPARSELT -DUSE_DISTRIBUTED -DUSE_EXTERNAL_MZCRC -DUSE_FLASH_ATTENTION -DUSE_MEM_EFF_ATTENTION -DUSE_NCCL -DUSE_RPC -DUSE_TENSORPIPE -D_FILE_OFFSET_BITS=64 -Dtorch_cuda_EXPORTS -I/home/elliot/compile_test-pytorch/build/aten/src -I/home/elliot/compile_test-pytorch/aten/src -I/home/elliot/compile_test-pytorch/build -I/home/elliot/compile_test-pytorch -I/home/elliot/compile_test-pytorch/cmake/../third_party/benchmark/include -I/home/elliot/compile_test-pytorch/third_party/onnx -I/home/elliot/compile_test-pytorch/build/third_party/onnx -I/home/elliot/compile_test-pytorch/third_party/foxi -I/home/elliot/compile_test-pytorch/build/third_party/foxi -I/home/elliot/compile_test-pytorch/aten/src/THC -I/home/elliot/compile_test-pytorch/aten/src/ATen/cuda -I/home/elliot/compile_test-pytorch/aten/src/ATen/../../../third_party/cutlass/include -I/home/elliot/compile_test-pytorch/build/caffe2/aten/src -I/home/elliot/compile_test-pytorch/aten/src/ATen/.. -I/home/elliot/compile_test-pytorch/build/nccl/include -I/home/elliot/compile_test-pytorch/c10/cuda/../.. -I/home/elliot/compile_test-pytorch/c10/.. -I/home/elliot/compile_test-pytorch/third_party/tensorpipe -I/home/elliot/compile_test-pytorch/build/third_party/tensorpipe -I/home/elliot/compile_test-pytorch/third_party/tensorpipe/third_party/libnop/include -I/home/elliot/compile_test-pytorch/torch/csrc/api -I/home/elliot/compile_test-pytorch/torch/csrc/api/include -isystem /home/elliot/compile_test-pytorch/build/third_party/gloo -isystem /home/elliot/compile_test-pytorch/cmake/../third_party/gloo -isystem /home/elliot/compile_test-pytorch/cmake/../third_party/tensorpipe/third_party/libuv/include -isystem /home/elliot/compile_test-pytorch/cmake/../third_party/googletest/googlemock/include -isystem /home/elliot/compile_test-pytorch/cmake/../third_party/googletest/googletest/include -isystem /home/elliot/compile_test-pytorch/third_party/protobuf/src -isystem /home/elliot/miniforge3/envs/torchtest/include -isystem /home/elliot/compile_test-pytorch/third_party/gemmlowp -isystem /home/elliot/compile_test-pytorch/third_party/neon2sse -isystem /home/elliot/compile_test-pytorch/third_party/XNNPACK/include -isystem /home/elliot/compile_test-pytorch/third_party/ittapi/include -isystem /home/elliot/compile_test-pytorch/cmake/../third_party/eigen -isystem /usr/local/cuda-12.4/include -isystem /home/elliot/compile_test-pytorch/third_party/ideep/mkl-dnn/include/oneapi/dnnl -isystem /home/elliot/compile_test-pytorch/third_party/ideep/include -isystem /home/elliot/compile_test-pytorch/cmake/../third_party/cudnn_frontend/include -DLIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_OPERATIONS -D_GLIBCXX_USE_CXX11_ABI=1 -Xfatbin -compress-all -DONNX_NAMESPACE=onnx_torch -gencode arch=compute_86,code=sm_86 -Xcudafe --diag_suppress=cc_clobber_ignored,--diag_suppress=field_without_dll_interface,--diag_suppress=base_class_has_different_dll_interface,--diag_suppress=dll_interface_conflict_none_assumed,--diag_suppress=dll_interface_conflict_dllexport_assumed,--diag_suppress=bad_friend_decl --expt-relaxed-constexpr --expt-extended-lambda  -Wno-deprecated-gpu-targets --expt-extended-lambda -DCUB_WRAPPED_NAMESPACE=at_cuda_detail -DCUDA_HAS_FP16=1 -D__CUDA_NO_HALF_OPERATORS__ -D__CUDA_NO_HALF_CONVERSIONS__ -D__CUDA_NO_HALF2_OPERATORS__ -D__CUDA_NO_BFLOAT16_CONVERSIONS__ -O3 -DNDEBUG -std=c++17 -Xcompiler=-fPIC -DMKL_HAS_SBGEMM -DMKL_HAS_SHGEMM -DTORCH_USE_LIBUV -DCAFFE2_USE_GLOO -Xcompiler=-Wall,-Wextra,-Wdeprecated,-Wno-unused-parameter,-Wno-unused-function,-Wno-missing-field-initializers,-Wno-unknown-pragmas,-Wno-type-limits,-Wno-array-bounds,-Wno-unknown-pragmas,-Wno-strict-overflow,-Wno-strict-aliasing,-Wno-maybe-uninitialized -Wno-deprecated-copy -MD -MT caffe2/CMakeFiles/torch_cuda.dir/__/torch/csrc/distributed/c10d/quantization/quantization_gpu.cu.o -MF caffe2/CMakeFiles/torch_cuda.dir/__/torch/csrc/distributed/c10d/quantization/quantization_gpu.cu.o.d -x cu -c /home/elliot/compile_test-pytorch/torch/csrc/distributed/c10d/quantization/quantization_gpu.cu -o caffe2/CMakeFiles/torch_cuda.dir/__/torch/csrc/distributed/c10d/quantization/quantization_gpu.cu.o
/home/elliot/compile_test-pytorch/aten/src/ATen/core/IListRef_inl.h: In static member function ‘static c10::detail::IListRefConstRef<at::OptionalTensorRef> c10::detail::IListRefTagImpl<c10::IListRefTag::Boxed, at::OptionalTensorRef>::iterator_get(const c10::List<std::optional<at::Tensor> >::const_iterator&)’:
/home/elliot/compile_test-pytorch/aten/src/ATen/core/IListRef_inl.h:171:13: warning: possibly dangling reference to a temporary [-Wdangling-reference]
  171 |     const auto& ivalue = (*it).get();
      |             ^~~~~~
/home/elliot/compile_test-pytorch/aten/src/ATen/core/IListRef_inl.h:171:33: note: the temporary was destroyed at the end of the full expression ‘(& it)->c10::impl::ListIterator<std::optional<at::Tensor>, __gnu_cxx::__normal_iterator<c10::IValue*, std::vector<c10::IValue> > >::operator*().c10::impl::ListElementReference<std::optional<at::Tensor>, __gnu_cxx::__normal_iterator<c10::IValue*, std::vector<c10::IValue> > >::get()’
  171 |     const auto& ivalue = (*it).get();
      |                      ~~~~~~~~~~~^~
/home/elliot/compile_test-pytorch/aten/src/ATen/core/boxing/impl/boxing.h: At global scope:
/home/elliot/compile_test-pytorch/aten/src/ATen/core/boxing/impl/boxing.h:42:103: error: expected primary-expression before ‘>’ token
   42 | struct has_ivalue_to<T, std::void_t<decltype(std::declval<IValue>().to<T>())>>
      |                                                                                                       ^
/home/elliot/compile_test-pytorch/aten/src/ATen/core/boxing/impl/boxing.h:42:106: error: expected primary-expression before ‘)’ token
   42 | struct has_ivalue_to<T, std::void_t<decltype(std::declval<IValue>().to<T>())>>
      |                                                                                                          ^
/home/elliot/compile_test-pytorch/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h: In lambda function:
/home/elliot/compile_test-pytorch/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h:154:24: warning: possibly dangling reference to a temporary [-Wdangling-reference]
  154 |         for (const at::Tensor& tensor : ivalue.toTensorList()) {
      |                        ^~~~~~
/home/elliot/compile_test-pytorch/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h:154:53: note: the temporary was destroyed at the end of the full expression ‘__for_begin .c10::impl::ListIterator<at::Tensor, __gnu_cxx::__normal_iterator<c10::IValue*, std::vector<c10::IValue> > >::operator*().c10::impl::ListElementReference<at::Tensor, __gnu_cxx::__normal_iterator<c10::IValue*, std::vector<c10::IValue> > >::operator std::conditional_t<true, const at::Tensor&, at::Tensor>()’
  154 |         for (const at::Tensor& tensor : ivalue.toTensorList()) {
      |                                                     ^
...

ninja: build stopped: subcommand failed.
```
```
PyTorch version: 2.4.0a0+git595613d
Is debug build: False
CUDA used to build PyTorch: 12.4
ROCM used to build PyTorch: N/A

OS: Ubuntu 23.10 (x86_64)
GCC version: (Ubuntu 13.2.0-4ubuntu3) 13.2.0
Clang version: 16.0.6 (15)
CMake version: version 3.29.0
Libc version: glibc-2.38

Python version: 3.11.8 | packaged by conda-forge | (main, Feb 16 2024, 20:53:32) [GCC 12.3.0] (64-bit runtime)
Python platform: Linux-6.5.0-26-generic-x86_64-with-glibc2.38
Is CUDA available: True
CUDA runtime version: 12.4.131
CUDA_MODULE_LOADING set to: LAZY
GPU models and configuration: GPU 0: NVIDIA GeForce RTX 3090 Ti
Nvidia driver version: 550.67
cuDNN version: Probably one of the following:
/usr/lib/x86_64-linux-gnu/libcudnn.so.9.0.0
/usr/lib/x86_64-linux-gnu/libcudnn_adv.so.9.0.0
/usr/lib/x86_64-linux-gnu/libcudnn_cnn.so.9.0.0
/usr/lib/x86_64-linux-gnu/libcudnn_engines_precompiled.so.9.0.0
/usr/lib/x86_64-linux-gnu/libcudnn_engines_runtime_compiled.so.9.0.0
/usr/lib/x86_64-linux-gnu/libcudnn_graph.so.9.0.0
/usr/lib/x86_64-linux-gnu/libcudnn_heuristic.so.9.0.0
/usr/lib/x86_64-linux-gnu/libcudnn_ops.so.9.0.0
HIP runtime version: N/A
MIOpen runtime version: N/A
Is XNNPACK available: True

CPU:
Architecture:                       x86_64
CPU op-mode(s):                     32-bit, 64-bit
Address sizes:                      46 bits physical, 48 bits virtual
Byte Order:                         Little Endian
CPU(s):                             24
On-line CPU(s) list:                0-23
Vendor ID:                          GenuineIntel
Model name:                         13th Gen Intel(R) Core(TM) i7-13700K
CPU family:                         6
Model:                              183
Thread(s) per core:                 2
Core(s) per socket:                 16
Socket(s):                          1
Stepping:                           1
CPU(s) scaling MHz:                 19%
CPU max MHz:                        5400.0000
CPU min MHz:                        800.0000
BogoMIPS:                           6835.20
Flags:                              fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb intel_pt sha_ni xsaveopt xsavec xgetbv1 xsaves split_lock_detect avx_vnni dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp hwp_pkg_req hfi vnmi umip pku ospke waitpkg gfni vaes vpclmulqdq tme rdpid movdiri movdir64b fsrm md_clear serialize pconfig arch_lbr ibt flush_l1d arch_capabilities
Virtualization:                     VT-x
L1d cache:                          640 KiB (16 instances)
L1i cache:                          768 KiB (16 instances)
L2 cache:                           24 MiB (10 instances)
L3 cache:                           30 MiB (1 instance)
NUMA node(s):                       1
NUMA node0 CPU(s):                  0-23
Vulnerability Gather data sampling: Not affected
Vulnerability Itlb multihit:        Not affected
Vulnerability L1tf:                 Not affected
Vulnerability Mds:                  Not affected
Vulnerability Meltdown:             Not affected
Vulnerability Mmio stale data:      Not affected
Vulnerability Retbleed:             Not affected
Vulnerability Spec rstack overflow: Not affected
Vulnerability Spec store bypass:    Mitigation; Speculative Store Bypass disabled via prctl
Vulnerability Spectre v1:           Mitigation; usercopy/swapgs barriers and __user pointer sanitization
Vulnerability Spectre v2:           Mitigation; Enhanced / Automatic IBRS, IBPB conditional, RSB filling, PBRSB-eIBRS SW sequence
Vulnerability Srbds:                Not affected
Vulnerability Tsx async abort:      Not affected

Versions of relevant libraries:
[pip3] numpy==1.26.4
[pip3] optree==0.11.0
[pip3] pytorch-triton==3.0.0+989adb9a29
[pip3] torch==2.4.0a0+git595613d
[conda] magma-cuda124             2.6.1                         1    pytorch
[conda] mkl-include               2024.1.0              intel_691    intel
[conda] mkl-static                2024.1.0              intel_691    intel
[conda] numpy                     1.26.4          py311h64a7726_0    conda-forge
[conda] optree                    0.11.0          py311h9547e67_0    conda-forge
[conda] pytorch-triton            3.0.0+989adb9a29          pypi_0    pypi
[conda] torch                     2.4.0a0+git595613d          pypi_0    pypi
```

Tagging @colesbury per https://github.com/pytorch/pytorch/issues/122169#issuecomment-2008232619 

cc @malfet @seemethere