### PR TITLE
[sparse] add missing _values getter for CSR-flavored sparse tensors

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -7260,6 +7260,7 @@
   variants: method
   dispatch:
     SparseCPU, SparseCUDA, SparseMeta: _values_sparse
+    SparseCsrCPU, SparseCsrCUDA, SparseCsrMeta: _values_sparse_csr
   device_check: NoCheck
   device_guard: False
 

--- a/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
@@ -53,6 +53,7 @@
 #include <ATen/ops/sparse_bsc_tensor_native.h>
 #include <ATen/ops/sparse_dim_native.h>
 #include <ATen/ops/values_native.h>
+#include <ATen/ops/_values_native.h>
 #include <ATen/ops/_validate_compressed_sparse_indices.h>
 #include <ATen/ops/where.h>
 #endif

--- a/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
@@ -762,6 +762,10 @@ int64_t _nnz_sparse_csr(const SparseCsrTensor& self) {
   return get_sparse_csr_impl(self)->nnz();
 }
 
+Tensor _values_sparse_csr(const Tensor& self) {
+  return get_sparse_csr_impl(self)->values();
+}
+
 Tensor values_sparse_csr(const Tensor& self) {
   return get_sparse_csr_impl(self)->values().alias();
 }

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -4446,6 +4446,15 @@ class TestSparseMeta(TestCase):
                 result = torch.zeros_like(f, device=f.fake_device)
             self.assertEqual(result, expected)
 
+    @all_sparse_layouts('layout', include_strided=False)
+    @parametrize("dtype", [torch.float64])
+    def test_values_meta(self, dtype, layout):
+        device = 'cpu'
+        index_dtype = torch.int64
+        for t in self.generate_simple_inputs(layout, device=device, dtype=dtype, index_dtype=index_dtype):
+            m = t.to(device='meta')
+            self.assertEqual(t._values().dtype, m._values().dtype)
+
 
 class _SparseDataset(torch.utils.data.Dataset):
     # An utility class used in TestSparseAny.test_dataloader method.


### PR DESCRIPTION
Added the missing getter. This is a small step towards https://github.com/pytorch/pytorch/issues/117188

@pearu to review (this was split of https://github.com/pytorch/pytorch/pull/117907)