### PR TITLE
[export] construct set_grad_enabled HOO subgraph inside other HOO subgraphs

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -3651,6 +3651,23 @@ def forward(self, p_bar_linear_weight, p_bar_linear_bias, x):
 
     def test_predispatch_cond(self):
         class Model(torch.nn.Module):
+            def forward(self, x, y):
+                with torch.enable_grad():
+                    x = x - y
+                return x + y
+
+        model = Model()
+        with torch.no_grad():
+            exported_program = torch.export._trace._export(
+                model,
+                (torch.tensor(10), torch.tensor(12)),
+                {},
+                dynamic_shapes=None,
+                pre_dispatch=True,
+                strict=False
+            )
+
+        class Model(torch.nn.Module):
             def __init__(self):
                 super().__init__()
                 self.register_buffer("pred", torch.tensor(False))
@@ -3669,14 +3686,15 @@ def forward(self, p_bar_linear_weight, p_bar_linear_bias, x):
                 )
 
         model = Model()
-        exported_program = torch.export._trace._export(
-            model,
-            (torch.tensor(10), torch.tensor(12)),
-            {},
-            dynamic_shapes=None,
-            pre_dispatch=True,
-            strict=False
-        )
+        with torch.no_grad():
+            exported_program = torch.export._trace._export(
+                model,
+                (torch.tensor(10), torch.tensor(12)),
+                {},
+                dynamic_shapes=None,
+                pre_dispatch=True,
+                strict=False
+            )
 
         self.assertExpectedInline(str(exported_program.graph_module.code.strip()), """\
 def forward(self, b_pred, b_t, x, y):
@@ -3687,13 +3705,18 @@ def forward(self, b_pred, b_t, x, y):
     return (getitem,)""")  # noqa: B950
 
         self.assertExpectedInline(str(exported_program.graph_module.true_graph_0.code.strip()), """\
-def forward(self, arg0_1, arg1_1, arg2_1):
-    _set_grad_enabled = torch._C._set_grad_enabled(True)
+def forward(self, arg1_1, arg0_1, arg2_1):
+    submod_3 = self.submod_1
+    add_1 = torch._higher_order_ops.wrap.wrap_with_set_grad_enabled(True, submod_3, arg1_1, arg0_1, arg2_1);  submod_3 = arg1_1 = arg0_1 = arg2_1 = None
+    return (add_1,)""")
+
+        self.assertExpectedInline(str(exported_program.graph_module.true_graph_0.submod_1.code.strip()), """\
+def forward(self, arg1_1, arg0_1, arg2_1):
     sub = torch.ops.aten.sub.Tensor(arg1_1, 1);  arg1_1 = None
     add = torch.ops.aten.add.Tensor(sub, arg0_1);  sub = arg0_1 = None
     add_1 = torch.ops.aten.add.Tensor(add, arg2_1);  add = arg2_1 = None
-    _set_grad_enabled_1 = torch._C._set_grad_enabled(False)
-    return (add_1,)""")
+    return add_1""")
+
 
     def test_non_persistent_buffer(self):
         class MyModule(torch.nn.Module):

--- a/torch/_export/passes/replace_set_grad_with_hop_pass.py
+++ b/torch/_export/passes/replace_set_grad_with_hop_pass.py
@@ -56,7 +56,7 @@ def _replace_with_hop(node: torch.fx.Node):
         with graph.inserting_before(node):
             get_attr_node = graph.get_attr(node.target)
             get_attr_node.meta["nn_module_stack"] = copy.copy(
-                set_grad_node.meta["nn_module_stack"]
+                set_grad_node.meta.get("nn_module_stack", {})
             )
             output_node = next(iter(reversed(sub_gm.graph.nodes)), None)
             if output_node is not None:
@@ -73,7 +73,7 @@ def _replace_with_hop(node: torch.fx.Node):
                         arg.meta["val"] for arg in output_args
                     )
                     call_func_node.meta["nn_module_stack"] = copy.copy(
-                        set_grad_node.meta["nn_module_stack"]
+                        set_grad_node.meta.get("nn_module_stack", {})
                     )
                     call_func_node.meta["torch_fn"] = (
                         f"{wrap_with_set_grad_enabled.__name__}",
@@ -125,29 +125,53 @@ def _remove_set_grad_and_inline(node: torch.fx.Node):
     node_inline_(node)
 
 
-def replace_set_grad_with_hop_pass(gm: torch.fx.GraphModule):
+def _sequential_split_and_maybe_inline_subgraphs(gm: torch.fx.GraphModule):
+    """
+    Helper function for replace_set_grad_with_hop_pass().
+    Split the graph module into multiple subgraphs based on the set_grad_enabled nodes.
+    For each subgraph, decides whether to construct a HOO subgraph, or inline the calls
+    back into the parent graph module.
+    """
     # If there is no set_grad_enabled node, return the original graph module
     need_replacing = False
     for node in gm.graph.nodes:
         if _is_set_grad_enabled_node(node):
             need_replacing = True
 
-    if not need_replacing:
-        return gm
+    if need_replacing:
+        new_gm = sequential_split(gm, _is_set_grad_enabled_node)
 
-    new_gm = sequential_split(gm, _is_set_grad_enabled_node)
+        def _maybe_inline_or_replace_with_hop(node: torch.fx.Node):
+            if _is_set_grad_enabled_sub_mod(node, omit_if_same_with_ambient=True):
+                _replace_with_hop(node)
+            else:
+                _remove_set_grad_and_inline(node)
 
-    def _maybe_inline_or_replace_with_hop(node: torch.fx.Node):
-        if _is_set_grad_enabled_sub_mod(node, omit_if_same_with_ambient=True):
-            _replace_with_hop(node)
-        else:
-            _remove_set_grad_and_inline(node)
+        nodes_map(
+            list(new_gm.graph.nodes),
+            lambda node: (
+                _maybe_inline_or_replace_with_hop(node)
+                if node.op == "call_module"
+                else node
+            ),
+        )
+        return new_gm
 
-    nodes_map(
-        list(new_gm.graph.nodes),
-        lambda node: _maybe_inline_or_replace_with_hop(node)
-        if node.op == "call_module"
-        else node,
-    )
+    return gm
+
+
+def replace_set_grad_with_hop_pass(gm: torch.fx.GraphModule):
+    new_gm = _sequential_split_and_maybe_inline_subgraphs(gm)
+
+    # recursively call
+    for node in new_gm.graph.nodes:
+        if node.op == "get_attr":
+            subgm = getattr(new_gm, node.target)
+            if not isinstance(subgm, torch.fx.GraphModule):
+                continue
+            new_subgm = replace_set_grad_with_hop_pass(subgm)
+            setattr(new_gm, node.target, new_subgm)
+
+    new_gm.recompile()
     new_gm.graph.lint()
     return new_gm


### PR DESCRIPTION
Summary:
Reference: https://github.com/pytorch/pytorch/pull/121736

Previously set_grad_enabled nodes in HOO subgraphs (e.g. cond) were inlined and not replaced with their own HOO subgraphs. This diff recursively does that.

Example:
```
class Model(torch.nn.Module):
    def forward(self, x, y):
        def true_fn(x, y):
            with torch.enable_grad():
                return x - y

        return torch.cond(
            x.sum() > 0,
            true_fn,
            lambda x, y: x + y,
            [x, y],
        )
```

Before (printing out `ep.graph_module.true_graph_0`):
```
        class <lambda>(torch.nn.Module):
            def forward(self, arg0_1: "i64[]", arg1_1: "i64[]"):
                # No stacktrace found for following nodes
                _set_grad_enabled = torch._C._set_grad_enabled(True)
                sub: "i64[]" = torch.ops.aten.sub.Tensor(arg0_1, arg1_1);  arg0_1 = arg1_1 = None
                _set_grad_enabled_1 = torch._C._set_grad_enabled(False)
                return (sub,)
```

After:
```
        class GraphModule(torch.nn.Module):
            def forward(self, arg0_1: "i64[]", arg1_1: "i64[]"):
                # No stacktrace found for following nodes
                submod_3 = self.submod_1
                sub: "i64[]" = torch._higher_order_ops.wrap.wrap_with_set_grad_enabled(True, submod_3, arg0_1, arg1_1);  submod_3 = arg0_1 = arg1_1 = None
                return (sub,)

            class GraphModule(torch.nn.Module):
                def forward(self, arg0_1: "i64[]", arg1_1: "i64[]"):
                    # No stacktrace found for following nodes
                    sub: "i64[]" = torch.ops.aten.sub.Tensor(arg0_1, arg1_1);  arg0_1 = arg1_1 = None
                    return sub
```

Differential Revision: D55770138
