### PR TITLE
[DTensor] Turn on foreach implementation of optimizer for DTensor by default

### DIFF
--- a/test/distributed/_tensor/test_optimizers.py
+++ b/test/distributed/_tensor/test_optimizers.py
@@ -84,23 +84,26 @@ class TestDTensorOptimizer(DTensorTestBase):
                 # Default 'rtol' and 'atol' for attr:`~torch.float32` are ``1.3e-6`` and ``1e-5``
                 self.assertEqual(p1, p2, atol=atol, rtol=rtol)
 
+    def test_optimizer_foreach_supported_types_include_DTensor(self):
+        from torch.optim.optimizer import _foreach_supported_types
+
+        self.assertTrue(DTensor in _foreach_supported_types)
+
     @with_comms
     def test_adam_1d_sharding(self):
         mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
 
         # TODO: add fused_adam support
         adam_configs = [
-            {"lr": 0.1},
+            {"lr": 0.1, "foreach": False},
+            {"lr": 0.1, "weight_decay": 0.05, "foreach": False},
             {"lr": 0.1, "weight_decay": 0.05},
-            {"lr": 0.1, "foreach": True},
-            {"lr": 0.1, "weight_decay": 0.05, "foreach": True},
-            {"lr": 0.1, "weight_decay": 0.05, "amsgrad": True, "foreach": True},
+            {"lr": 0.1, "weight_decay": 0.05, "amsgrad": True},
             {
                 "lr": 0.1,
                 "weight_decay": 0.05,
                 "maximize": True,
                 "amsgrad": True,
-                "foreach": True,
             },
             {"lr": 0.1, "fused": True},
             {"lr": 0.1, "weight_decay": 0.05, "amsgrad": True, "fused": True},
@@ -132,16 +135,15 @@ class TestDTensorOptimizer(DTensorTestBase):
         mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
 
         adamw_configs = [
-            {"lr": 0.1},
+            {"lr": 0.1, "foreach": False},
+            {"lr": 0.1, "weight_decay": 0.05, "foreach": False},
             {"lr": 0.1, "weight_decay": 0.05},
-            {"lr": 0.1, "weight_decay": 0.05, "foreach": True},
             {
                 "lr": 0.1,
                 "betas": (0.6, 0.66),
                 "eps": 1e-6,
                 "weight_decay": 0.05,
                 "amsgrad": True,
-                "foreach": True,
             },
             {
                 "lr": 0.1,
@@ -150,7 +152,6 @@ class TestDTensorOptimizer(DTensorTestBase):
                 "weight_decay": 0.05,
                 "maximize": True,
                 "amsgrad": True,
-                "foreach": True,
             },
             {"lr": 0.1, "weight_decay": 0.05, "fused": True},
             {
@@ -191,16 +192,17 @@ class TestDTensorOptimizer(DTensorTestBase):
         mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
 
         sgd_configs = [
-            {"lr": 0.1},
+            {"lr": 0.1, "foreach": False},
+            {"lr": 0.1, "momentum": 0.05, "foreach": False},
             {"lr": 0.1, "momentum": 0.05},
-            {"lr": 0.1, "momentum": 0.05, "foreach": True},
-            {"lr": 0.1, "momentum": 0.06, "dampening": 0.07, "foreach": True},
+            {"lr": 0.1, "momentum": 0.06, "dampening": 0.07},
             {
                 "lr": 0.1,
                 "momentum": 0.08,
                 "weight_decay": 0.05,
                 "nesterov": True,
                 "maximize": True,
+                "foreach": False,
             },
             {
                 "lr": 0.1,
@@ -208,7 +210,6 @@ class TestDTensorOptimizer(DTensorTestBase):
                 "weight_decay": 0.05,
                 "nesterov": True,
                 "maximize": True,
-                "foreach": True,
             },
         ]
 
@@ -231,14 +232,15 @@ class TestDTensorOptimizer(DTensorTestBase):
         mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
 
         adagrad_configs = [
-            {"lr": 0.1},
-            {"lr": 0.1, "lr_decay": 0.05},
-            {"lr": 0.1, "lr_decay": 0.02, "weight_decay": 0.05},
+            {"lr": 0.1, "foreach": False},
+            {"lr": 0.1, "lr_decay": 0.05, "foreach": False},
+            {"lr": 0.1, "lr_decay": 0.02, "weight_decay": 0.05, "foreach": False},
             {
                 "lr": 0.1,
                 "lr_decay": 0.02,
                 "weight_decay": 0.05,
                 "initial_accumulator_value": 0.03,
+                "foreach": False,
             },
             {
                 "lr": 0.1,
@@ -246,6 +248,7 @@ class TestDTensorOptimizer(DTensorTestBase):
                 "weight_decay": 0.05,
                 "initial_accumulator_value": 0.03,
                 "eps": 1e-6,
+                "foreach": False,
             },
             {
                 "lr": 0.1,
@@ -254,6 +257,7 @@ class TestDTensorOptimizer(DTensorTestBase):
                 "initial_accumulator_value": 0.03,
                 "eps": 1e-6,
                 "maximize": True,
+                "foreach": False,
             },
             {
                 "lr": 0.1,
@@ -262,7 +266,6 @@ class TestDTensorOptimizer(DTensorTestBase):
                 "initial_accumulator_value": 0.03,
                 "eps": 1e-6,
                 "maximize": True,
-                "foreach": True,
             },
         ]
 
@@ -285,16 +288,23 @@ class TestDTensorOptimizer(DTensorTestBase):
         mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
 
         RMSprop_configs = [
-            {"lr": 0.1},
-            {"lr": 0.1, "alpha": 0.85},
-            {"lr": 0.1, "alpha": 0.88, "eps": 1e-6},
-            {"lr": 0.1, "alpha": 0.88, "eps": 1e-6, "weight_decay": 0.05},
+            {"lr": 0.1, "foreach": False},
+            {"lr": 0.1, "alpha": 0.85, "foreach": False},
+            {"lr": 0.1, "alpha": 0.88, "eps": 1e-6, "foreach": False},
+            {
+                "lr": 0.1,
+                "alpha": 0.88,
+                "eps": 1e-6,
+                "weight_decay": 0.05,
+                "foreach": False,
+            },
             {
                 "lr": 0.1,
                 "alpha": 0.88,
                 "eps": 1e-6,
                 "weight_decay": 0.05,
                 "momentum": 0.9,
+                "foreach": False,
             },
             {
                 "lr": 0.1,
@@ -303,6 +313,7 @@ class TestDTensorOptimizer(DTensorTestBase):
                 "weight_decay": 0.05,
                 "momentum": 0.9,
                 "centered": True,
+                "foreach": False,
             },
             {
                 "lr": 0.1,
@@ -312,6 +323,7 @@ class TestDTensorOptimizer(DTensorTestBase):
                 "momentum": 0.9,
                 "centered": True,
                 "maximize": True,
+                "foreach": False,
             },
             {
                 "lr": 0.1,
@@ -321,7 +333,6 @@ class TestDTensorOptimizer(DTensorTestBase):
                 "momentum": 0.9,
                 "centered": True,
                 "maximize": True,
-                "foreach": True,
             },
         ]
 
@@ -344,23 +355,27 @@ class TestDTensorOptimizer(DTensorTestBase):
         mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
 
         adadelta_configs = [
-            {"lr": 0.1},
-            {"lr": 0.1, "rho": 0.85},
-            {"lr": 0.1, "rho": 0.88, "eps": 1e-5},
-            {"lr": 0.1, "rho": 0.88, "eps": 1e-6, "weight_decay": 0.05},
+            {"lr": 0.1, "foreach": False},
+            {"lr": 0.1, "rho": 0.85, "foreach": False},
+            {"lr": 0.1, "rho": 0.88, "eps": 1e-5, "foreach": False},
             {
                 "lr": 0.1,
                 "rho": 0.88,
                 "eps": 1e-6,
                 "weight_decay": 0.05,
-                "foreach": True,
+                "foreach": False,
             },
             {
                 "lr": 0.1,
                 "rho": 0.88,
                 "eps": 1e-6,
                 "weight_decay": 0.05,
-                "foreach": True,
+            },
+            {
+                "lr": 0.1,
+                "rho": 0.88,
+                "eps": 1e-6,
+                "weight_decay": 0.05,
                 "maximize": True,
             },
         ]
@@ -384,15 +399,14 @@ class TestDTensorOptimizer(DTensorTestBase):
         mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
 
         nadam_configs = [
-            {"lr": 0.1},
+            {"lr": 0.1, "foreach": False},
+            {"lr": 0.1, "weight_decay": 0.05, "foreach": False},
             {"lr": 0.1, "weight_decay": 0.05},
-            {"lr": 0.1, "weight_decay": 0.05, "foreach": True},
             {
                 "lr": 0.1,
                 "betas": (0.6, 0.66),
                 "eps": 1e-6,
                 "weight_decay": 0.05,
-                "foreach": True,
             },
             {
                 "lr": 0.1,
@@ -400,7 +414,6 @@ class TestDTensorOptimizer(DTensorTestBase):
                 "eps": 1e-6,
                 "weight_decay": 0.05,
                 "decoupled_weight_decay": True,
-                "foreach": True,
             },
         ]
 
@@ -423,15 +436,17 @@ class TestDTensorOptimizer(DTensorTestBase):
         mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
 
         radam_configs = [
-            {"lr": 0.1},
-            {"lr": 0.1, "weight_decay": 0.05},
-            {"lr": 0.1, "weight_decay": 0.05, "foreach": True},
+            {"lr": 0.1, "foreach": False},
+            {"lr": 0.1, "weight_decay": 0.05, "foreach": False},
+            {
+                "lr": 0.1,
+                "weight_decay": 0.05,
+            },
             {
                 "lr": 0.1,
                 "betas": (0.6, 0.66),
                 "eps": 1e-6,
                 "weight_decay": 0.05,
-                "foreach": True,
             },
             {
                 "lr": 0.1,
@@ -439,7 +454,6 @@ class TestDTensorOptimizer(DTensorTestBase):
                 "eps": 1e-6,
                 "weight_decay": 0.05,
                 "decoupled_weight_decay": True,
-                "foreach": True,
             },
         ]
 
@@ -462,23 +476,27 @@ class TestDTensorOptimizer(DTensorTestBase):
         mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
 
         adamax_configs = [
-            {"lr": 0.1},
-            {"lr": 0.1, "betas": (0.6, 0.66)},
-            {"lr": 0.1, "betas": (0.6, 0.66), "eps": 1e-6},
-            {"lr": 0.1, "betas": (0.6, 0.66), "eps": 1e-6, "weight_decay": 0.05},
+            {"lr": 0.1, "foreach": False},
+            {"lr": 0.1, "betas": (0.6, 0.66), "foreach": False},
+            {"lr": 0.1, "betas": (0.6, 0.66), "eps": 1e-6, "foreach": False},
             {
                 "lr": 0.1,
                 "betas": (0.6, 0.66),
                 "eps": 1e-6,
                 "weight_decay": 0.05,
-                "foreach": True,
+                "foreach": False,
             },
             {
                 "lr": 0.1,
                 "betas": (0.6, 0.66),
                 "eps": 1e-6,
                 "weight_decay": 0.05,
-                "foreach": True,
+            },
+            {
+                "lr": 0.1,
+                "betas": (0.6, 0.66),
+                "eps": 1e-6,
+                "weight_decay": 0.05,
                 "maximize": True,
             },
         ]
@@ -502,11 +520,18 @@ class TestDTensorOptimizer(DTensorTestBase):
         mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
 
         asgd_configs = [
-            {"lr": 0.1},
-            {"lr": 0.1, "lambd": 0.001},
-            {"lr": 0.1, "lambd": 0.001, "alpha": 0.85},
-            {"lr": 0.1, "lambd": 0.001, "alpha": 0.85, "t0": 1e5},
-            {"lr": 0.1, "lambd": 0.001, "alpha": 0.85, "t0": 1e5, "weight_decay": 0.05},
+            {"lr": 0.1, "foreach": False},
+            {"lr": 0.1, "lambd": 0.001, "foreach": False},
+            {"lr": 0.1, "lambd": 0.001, "alpha": 0.85, "foreach": False},
+            {"lr": 0.1, "lambd": 0.001, "alpha": 0.85, "t0": 1e5, "foreach": False},
+            {
+                "lr": 0.1,
+                "lambd": 0.001,
+                "alpha": 0.85,
+                "t0": 1e5,
+                "weight_decay": 0.05,
+                "foreach": False,
+            },
             {
                 "lr": 0.1,
                 "lambd": 0.001,

--- a/test/distributed/tensor/parallel/test_tp_examples.py
+++ b/test/distributed/tensor/parallel/test_tp_examples.py
@@ -262,8 +262,11 @@ class DistTensorParallelExampleTest(DTensorTestBase):
 
         # Ensure model weights are still the same after update.
         optim.step()
-        with CommDebugMode() as comm_mode:
-            optim_tp.step()
+        from torch.distributed._tensor.experimental import implicit_replication
+
+        with implicit_replication():
+            with CommDebugMode() as comm_mode:
+                optim_tp.step()
         self._check_module(model, model_tp)
         if is_seq_parallel:
             self.assertDictEqual(

--- a/torch/distributed/_tensor/__init__.py
+++ b/torch/distributed/_tensor/__init__.py
@@ -10,6 +10,8 @@ from torch.distributed._tensor.api import distribute_module, distribute_tensor, 
 from torch.distributed._tensor.ops.utils import normalize_to_torch_size
 from torch.distributed._tensor.placement_types import Placement, Replicate, Shard
 from torch.distributed.device_mesh import _mesh_resources, DeviceMesh, init_device_mesh
+from torch.optim.optimizer import _foreach_supported_types
+
 
 # All public APIs from dtensor package
 __all__ = [
@@ -21,6 +23,12 @@ __all__ = [
     "Shard",
     "Replicate",
 ]
+
+
+# Append DTensor to the list of supported types for foreach implementation of optimizer
+# so that we will try to use foreach over the for-loop implementation on CUDA.
+if DTensor not in _foreach_supported_types:
+    _foreach_supported_types.append(DTensor)
 
 
 def _dtensor_init_helper(


### PR DESCRIPTION
Append DTensor to the optimizer `_foreach_supported_types` and turn on foreach implementation of optimizer for DTensor if not specified by the users. 


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @tianyu-l @wconstab @yf225 @chauhang @d4l3k @msaroufim @rohan-varma