### PR TITLE
Ignore logging.Logger.* calls during dynamo export

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -4070,6 +4070,28 @@ def forward(self, arg0_1):
     return (add, add_1)""",
         )
 
+    def test_logging_logger(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                print("start")
+                x1 = x + x
+                print(x1)
+                x2 = x1 * x1
+                print(1, 2, 3)
+                x3 = x2 + x2
+                return (x1, x3)
+
+        gm = export(M(), (torch.randn(3, 3),)).graph_module
+        self.assertExpectedInline(
+            gm.code.strip(),
+            """\
+def forward(self, arg0_1):
+    add = torch.ops.aten.add.Tensor(arg0_1, arg0_1);  arg0_1 = None
+    mul = torch.ops.aten.mul.Tensor(add, add)
+    add_1 = torch.ops.aten.add.Tensor(mul, mul);  mul = None
+    return (add, add_1)""",
+        )
+
     def test_warning(self):
         class M(torch.nn.Module):
             def forward(self, x):

--- a/test/onnx/test_fx_to_onnx.py
+++ b/test/onnx/test_fx_to_onnx.py
@@ -1,6 +1,8 @@
 # Owner(s): ["module: onnx"]
 from __future__ import annotations
 
+import logging
+
 import tempfile
 
 from typing import Mapping, Tuple
@@ -706,6 +708,18 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
                 return input + torch.tensor(1.0, dtype=float8_type)
 
         _ = torch.onnx.dynamo_export(Float8Module(), torch.randn(1, 2, 3, 4))
+
+    def test_export_with_logging_logger(self):
+        logger = logging.getLogger(__name__)
+
+        class PrintModule(torch.nn.Module):
+            def forward(self, x):
+                logger.log("abc")
+                return x + 1
+
+        input = torch.randn(2, 3)
+        model = PrintModule()
+        _ = torch.onnx.dynamo_export(model, input)
 
     def test_checkpoint_cast(self):
         model_id = "openai/whisper-large-v3"

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -137,6 +137,7 @@ from .misc import (
     GetSetDescriptorVariable,
     InspectSignatureVariable,
     LambdaVariable,
+    LoggingLoggerVariable,
     MethodWrapperVariable,
     NumpyVariable,
     PythonModuleVariable,
@@ -512,6 +513,9 @@ class VariableBuilder:
             # along with other builtin debugging functions
             self.install_guards(GuardBuilder.BUILTIN_MATCH)
             return DebuggingVariable(value, source=self.source)
+        elif isinstance(value, logging.Logger):
+            self.install_guards(GuardBuilder.FUNCTION_MATCH)
+            return LoggingLoggerVariable(value, source=self.source)
         elif is_utils_checkpoint(value):
             return build_checkpoint_variable(source=self.source)
         elif isinstance(value, functools.partial):

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -936,6 +936,27 @@ class DebuggingVariable(VariableTracker):
         return True
 
 
+class LoggingLoggerVariable(VariableTracker):
+    """
+    Represents a call to loggin.Logger function.
+    """
+
+    def __init__(self, value, **kwargs):
+        super().__init__(**kwargs)
+
+    def call_method(
+        self,
+        tx,
+        name,
+        args: "List[VariableTracker]",
+        kwargs: "Dict[str, VariableTracker]",
+    ) -> "VariableTracker":
+        if tx.export:
+            # For export cases, we can just make debugging functions no-ops
+            return
+        unimplemented("Logger not supported for non-export cases")
+
+
 class StopIterationVariable(VariableTracker):
     def __init__(self, args, **kwargs):
         super().__init__(**kwargs)


### PR DESCRIPTION
Follow up for https://github.com/pytorch/pytorch/pull/123368


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @avikchaudhuri @gmagogsfm @zhxchen17 @tugsbayasgalan @angelayi @suo @ydwu4