### PR TITLE
[dynamo][cpp-guards] ListGetItemGuardAccessor and TupleGetItemGuardAccessor

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -579,6 +579,19 @@ class GuardBuilder(GuardBuilderBase):
                     source=source_name,
                     example_value=example_value,
                 )
+            elif isinstance(base_example_value, list):
+                return base_guard_manager.list_getitem_manager(
+                    key=source.index,
+                    source=source_name,
+                    example_value=example_value,
+                )
+            elif isinstance(base_example_value, tuple):
+                return base_guard_manager.tuple_getitem_manager(
+                    key=source.index,
+                    source=source_name,
+                    example_value=example_value,
+                )
+
             index = source.index
             if source.index_is_slice:
                 index = source.unpack_slice()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #123396
* #123303
* #123302
* #123285

Speeds up the guard-overhead microbenchmark by around 10% normalized to main-branch CPP guards

~~~
import torch


@torch.compile(backend="eager")
def fn(x, lst):
    for l in lst:
        x = x + l
    return x

n = 1000

lst = [i for i in range(n)]

x = torch.randn(4)
print(fn(x, lst))
print("Sucess")
~~~

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang