### PR TITLE
[Traceable FSDP2][1/n] Support using user-defined object instance method as hook

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -2214,6 +2214,33 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         self.assertTrue(grad_sizes.keys() == backward_hook_handles.keys())
         self.assertTrue(pre_grad_sizes.keys() == pre_backward_hook_handles.keys())
 
+    def test_udo_instance_method_as_hook(self):
+        class CustomClass:
+            def __init__(self, module):
+                self.module = module
+                self.handle = self.module.register_forward_pre_hook(
+                    self.func1, prepend=True, with_kwargs=True
+                )
+
+            def func1(self, module, args, kwargs):
+                return (args[0] + 1,), kwargs
+
+            def __call__(self, x):
+                return self.module(x)
+
+        class ToyModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return x * x
+
+        model = ToyModel()
+        x = torch.zeros((3, 4))
+        obj = CustomClass(model)
+        out = torch.compile(obj, fullgraph=True)(x)
+        self.assertEqual(out, (x + 1) * (x + 1))
+
     def test_module_dict_iter_name(self):
         class MyModule(torch.nn.Module):
             def __init__(self):

--- a/test/torch_np/numpy_tests/core/test_indexing.py
+++ b/test/torch_np/numpy_tests/core/test_indexing.py
@@ -524,7 +524,10 @@ class TestBroadcastedAssignments(TestCase):
         a = np.zeros(5)
 
         # Too large and not only ones.
-        assert_raises((ValueError, RuntimeError), assign, a, s_[...], np.ones((2, 1)))
+        try:
+            assign(a, s_[...], np.ones((2, 1)))
+        except Exception as e:
+            self.assertTrue(isinstance(e, (ValueError, RuntimeError)))
         assert_raises(
             (ValueError, RuntimeError), assign, a, s_[[1, 2, 3],], np.ones((2, 1))
         )
@@ -537,8 +540,14 @@ class TestBroadcastedAssignments(TestCase):
         s_ = np.s_
         a = np.zeros((5, 1))
 
-        assert_raises((ValueError, RuntimeError), assign, a, s_[...], np.zeros((5, 2)))
-        assert_raises((ValueError, RuntimeError), assign, a, s_[...], np.zeros((5, 0)))
+        try:
+            assign(a, s_[...], np.zeros((5, 2)))
+        except Exception as e:
+            self.assertTrue(isinstance(e, (ValueError, RuntimeError)))
+        try:
+            assign(a, s_[...], np.zeros((5, 0)))
+        except Exception as e:
+            self.assertTrue(isinstance(e, (ValueError, RuntimeError)))
         assert_raises(
             (ValueError, RuntimeError), assign, a, s_[:, [0]], np.zeros((5, 2))
         )

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -704,9 +704,11 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                     obj.__class__
                 ).call_function(tx, [var], kwargs)
 
-            func_src = AttrSource(self.source, "__func__") if self.source else None
+            if self.source is None:
+                unimplemented("Sourceless UserDefinedObjectVariable method not supported")
+            func_src = AttrSource(self.source, "__func__")
             func_var = VariableBuilder(tx, func_src)(func)
-            obj_src = AttrSource(self.source, "__self__") if self.source else None
+            obj_src = AttrSource(self.source, "__self__")
             obj_var = VariableBuilder(tx, obj_src)(obj)
             return func_var.call_function(tx, [obj_var] + args, kwargs)
         elif (

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -705,7 +705,9 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 ).call_function(tx, [var], kwargs)
 
             if self.source is None:
-                unimplemented("Sourceless UserDefinedObjectVariable method not supported")
+                unimplemented(
+                    "Sourceless UserDefinedObjectVariable method not supported"
+                )
             func_src = AttrSource(self.source, "__func__")
             func_var = VariableBuilder(tx, func_src)(func)
             obj_src = AttrSource(self.source, "__self__")

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -703,6 +703,12 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 return variables.TorchCtxManagerClassVariable(
                     obj.__class__
                 ).call_function(tx, [var], kwargs)
+
+            func_src = AttrSource(self.source, "__func__") if self.source else None
+            func_var = VariableBuilder(tx, func_src)(func)
+            obj_src = AttrSource(self.source, "__self__") if self.source else None
+            obj_var = VariableBuilder(tx, obj_src)(obj)
+            return func_var.call_function(tx, [obj_var] + args, kwargs)
         elif (
             istype(self.value, functools.partial)
             and trace_rules.lookup(self.value.func)


### PR DESCRIPTION
FSDP2 has this pattern of using user-defined object instance method as hook, and it will throw this error under compile:
`torch._dynamo.exc.Unsupported: call_function UserDefinedObjectVariable(_pre_forward) [FSDPManagedNNModuleVariable(), TupleVariable(), ConstDictVariable()] {}`

This PR adds support for it by always allowing to trace into a UserDefinedObjectVariable that's an instance method (i.e. `MethodType`).

Supersedes https://github.com/pytorch/pytorch/pull/123320.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @chauhang @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @LucasLLC