### PR TITLE
functional_collectives autograd support for all_to_all_single

### DIFF
--- a/test/distributed/test_multi_threaded_pg.py
+++ b/test/distributed/test_multi_threaded_pg.py
@@ -93,6 +93,38 @@ class TestCollectivesWithWrapper(TestCase):
             with self.assertRaises(SkipTest):
                 _test_method(self)
 
+    @spawn_threads_and_init_comms(world_size=4)
+    def test_all_to_all_single_tensor(self):
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+        send = torch.full((world_size, 2), rank)
+        sizes = torch.ones(world_size, dtype=torch.int64)
+
+        out = torch.zeros(world_size, 2, dtype=send.dtype)
+        dist.all_to_all_single(out, send, sizes, sizes)
+        self.assertEqual(out.tolist(), list(zip(range(world_size), range(world_size))))
+
+    @spawn_threads_and_init_comms(world_size=4)
+    def test_all_to_all_single_list(self):
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+        send = torch.full((world_size, 2), rank)
+        sizes = [1] * world_size
+
+        out = torch.zeros(world_size, 2, dtype=send.dtype)
+        dist.all_to_all_single(out, send, sizes, sizes)
+        self.assertEqual(out.tolist(), list(zip(range(world_size), range(world_size))))
+
+    @spawn_threads_and_init_comms(world_size=4)
+    def test_all_to_all_single_none(self):
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+        send = torch.full((world_size, 2), rank)
+
+        out = torch.zeros(world_size, 2, dtype=send.dtype)
+        dist.all_to_all_single(out, send)
+        self.assertEqual(out.tolist(), list(zip(range(world_size), range(world_size))))
+
 class TestCollectivesWithBaseClass(MultiThreadedTestCase):
     @property
     def world_size(self):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -6140,10 +6140,13 @@ try:
         )
 
     @register_lowering(_c10d_functional.all_to_all_single)
-    def _all_to_all_single(inp, output_split_sizes, input_split_sizes, group_name):
+    def _all_to_all_single(
+        output_size, inp, output_split_sizes, input_split_sizes, group_name
+    ):
         return ir.TensorBox.create(
             ir._CollectiveKernel.create_out_of_place(
                 _c10d_functional.all_to_all_single.default,
+                output_size,
                 inp,
                 output_split_sizes,
                 input_split_sizes,

--- a/torch/csrc/distributed/c10d/PyProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/PyProcessGroup.hpp
@@ -102,6 +102,23 @@ class PyProcessGroup : public ProcessGroup {
         opts);
   }
 
+  c10::intrusive_ptr<Work> alltoall_base(
+      at::Tensor& outputBuffer,
+      at::Tensor& inputBuffer,
+      std::vector<int64_t>& outputSplitSizes,
+      std::vector<int64_t>& inputSplitSizes,
+      const AllToAllOptions& opts = AllToAllOptions()) override {
+    PYBIND11_OVERRIDE(
+        c10::intrusive_ptr<Work>, /* Return type */
+        ProcessGroup, /* Parent class */
+        alltoall_base, /* Name of function in C++ */
+        outputBuffer,
+        inputBuffer,
+        outputSplitSizes,
+        inputSplitSizes,
+        opts);
+  }
+
   c10::intrusive_ptr<Work> barrier(
       const BarrierOptions& opts = BarrierOptions()) override {
     PYBIND11_OVERRIDE(

--- a/torch/testing/_internal/distributed/multi_threaded_pg.py
+++ b/torch/testing/_internal/distributed/multi_threaded_pg.py
@@ -76,6 +76,42 @@ class AllToAll:
                 _, input_tensor_list = data[src_rank]
                 output_tensor_list[src_rank].copy_(input_tensor_list[dest_rank])
 
+class AllToAllBase:
+    @torch.no_grad()
+    def work(self, data):
+        world_size = len(data)
+        for dest_rank in range(world_size):
+            output_buffer, _, output_split_sizes, _ = data[dest_rank]
+
+            output_indexes = self._size_cumsum(output_buffer.size(0), output_split_sizes, world_size)
+
+            for src_rank in range(world_size):
+                _, input_buffer, _, input_split_sizes = data[src_rank]
+                input_indexes = self._size_cumsum(input_buffer.size(0), input_split_sizes, world_size)
+
+                output_buffer[output_indexes[src_rank]:output_indexes[src_rank + 1]].copy_(
+                    input_buffer[input_indexes[dest_rank]:input_indexes[dest_rank + 1]]
+                )
+
+    def _size_cumsum(self, buf_size: int, sizes: Union[torch.Tensor, List[int], None], world_size: int) -> torch.Tensor:
+        if sizes is None or len(sizes) == 0:
+            sizes = torch.full(
+                (world_size,), buf_size // world_size, dtype=torch.int64
+            )
+        if not isinstance(sizes, torch.Tensor):
+            sizes = torch.tensor(sizes, dtype=torch.int64)
+        assert sizes.dtype == torch.int64
+        sizes = torch.cumsum(
+            torch.cat(
+                (
+                    torch.tensor([0], dtype=torch.int64, device=sizes.device), sizes
+                ),
+                dim=0
+            ),
+            dim=0
+        )
+        return sizes
+
 class AllReduce:
     def __init__(self, op):
         if op.op not in _reduce_ops:
@@ -277,6 +313,19 @@ class ProcessLocalGroup(dist.ProcessGroup):
         with cls._coll_lock:
             cls._cur_coll_on_pgs = {}
             cls._terminate.clear()
+
+    def alltoall_base(
+        self,
+        output_buffer: torch.Tensor,
+        input_buffer: torch.Tensor,
+        output_split_sizes: Optional[Union[List[int], torch.Tensor]],
+        input_split_sizes: Optional[Union[List[int], torch.Tensor]],
+        opts=AllToAllOptions()
+    ) -> torch.Tensor:
+        coll = ProcessLocalGroup._start_coll(AllToAllBase(), self)
+        res = coll.join(self._rank, (output_buffer, input_buffer, output_split_sizes, input_split_sizes))
+        ProcessLocalGroup._end_coll(coll, self)
+        return res
 
     def alltoall(self, output_tensor_list, input_tensor_list, opts=AllToAllOptions()):
         coll = ProcessLocalGroup._start_coll(AllToAll(), self)


### PR DESCRIPTION
This adds autograd support for all_to_all_single. This allows using it in normal nn.Modules and backpropagating across machines. This should make it much easier to experiment with certain types of distributed operations such as Context Parallelism.

* Compilation works including with the AsyncCollectiveTensor wrapper forwards and backwards.
* I had to make some tweaks to the signature of the all_to_all_single native op as autograd Functions don't support List[int].
* I've verified forwards and backwards accuracy by using the DTensor ring flash attention implementation forwards with no modifications :partying_face: 

Test plan:

```sh
pytest test/distributed/test_functional_api.py -k test_all_to_all_single_compile
# added test that uses the ring_attention forwards implementation
pytest test/distributed/_tensor/test_attention.py -k autograd_is_causal
```

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire