### PR TITLE
Ignore some known duplicated modules in doc build config script

### DIFF
--- a/.ci/pytorch/python_doc_push_script.sh
+++ b/.ci/pytorch/python_doc_push_script.sh
@@ -105,12 +105,7 @@ if [ "$is_main_doc" = true ]; then
     echo undocumented objects found:
     cat build/coverage/python.txt
     echo "Make sure you've updated relevant .rsts in docs/source!"
-    # NB: Due to some duplication of the following modules/functions, we keep
-    # them as expected failures for the time being instead of return 1
-    # - torch.nn.utils.weight_norm
-    # - torch.nn.utils.spectral_norm
-    # - torch.nn.parallel.data_parallel
-    # - torch.ao.quantization.quantize
+    exit 1
   fi
 else
   # skip coverage, format for stable or tags

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3557,6 +3557,14 @@ html_css_files = [
 
 from sphinx.ext.coverage import CoverageBuilder
 
+# NB: Due to some duplications of the following modules/functions, we keep
+# them as expected failures for the time being instead of return 1
+ignore_duplicated_modules = {
+    "torch.nn.utils.weight_norm",
+    "torch.nn.utils.spectral_norm",
+    "torch.nn.parallel.data_parallel",
+    "torch.ao.quantization.quantize",
+}
 
 def coverage_post_process(app, exception):
     if exception is not None:
@@ -3597,7 +3605,7 @@ def coverage_post_process(app, exception):
         path=torch.__path__, prefix=torch.__name__ + "."
     ):
         if is_not_internal(modname):
-            if modname not in modules:
+            if modname not in modules and modname not in ignore_duplicated_modules:
                 missing.add(modname)
 
     output = []

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3566,6 +3566,7 @@ ignore_duplicated_modules = {
     "torch.ao.quantization.quantize",
 }
 
+
 def coverage_post_process(app, exception):
     if exception is not None:
         return


### PR DESCRIPTION
This is a follow-up fix of https://github.com/pytorch/pytorch/pull/123244#discussion_r1552935150 as @clee2000 points out a better way to ignore those duplicated entries.