### PR TITLE
AOTAutograd: add config to error when overlapping input checks would cause slow compile / runtimes

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -4267,8 +4267,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnt.frame_count, 1)
 
     def test_overlapping_inputs_with_dynamic_shapes_error(self):
-
-        @torch.compile(backend='aot_eager')
+        @torch.compile(backend="aot_eager")
         def fn(a, b, c, d, e, f):
             a.mul_(2)
             b.mul_(2)
@@ -4286,7 +4285,9 @@ class ReproTests(torch._dynamo.test_case.TestCase):
             f = base[:, 10:12]
             f2 = base[:, 10:14]
             out = fn(a, b, c, d, e, f)
-            with self.assertRaisesRegex(AssertionError, "is being compiled with dynamic shapes"):
+            with self.assertRaisesRegex(
+                AssertionError, "is being compiled with dynamic shapes"
+            ):
                 out2 = fn(a, b, c, d, e, f2)
 
     def test_user_ctor_ctx_manager_custom_init(self):

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -4266,6 +4266,29 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         opt_fn(lengths)
         self.assertEqual(cnt.frame_count, 1)
 
+    def test_overlapping_inputs_with_dynamic_shapes_error(self):
+
+        @torch.compile(backend='aot_eager')
+        def fn(a, b, c, d, e, f):
+            a.mul_(2)
+            b.mul_(2)
+            c.mul_(2)
+            d.mul_(2)
+            e.mul_(2)
+            f.mul_(2)
+
+            base = torch.ones(2, 20)
+            a = base[:, 0:2]
+            b = base[:, 2:4]
+            c = base[:, 4:6]
+            d = base[:, 6:8]
+            e = base[:, 8:10]
+            f = base[:, 10:12]
+            f2 = base[:, 10:14]
+            out = fn(a, b, c, d, e, f)
+            with self.assertRaisesRegex(AssertionError, "is being compiled with dynamic shapes"):
+                out2 = fn(a, b, c, d, e, f2)
+
     def test_user_ctor_ctx_manager_custom_init(self):
         class UserCtxManager:
             def __init__(self, x):

--- a/torch/_functorch/_aot_autograd/input_output_analysis.py
+++ b/torch/_functorch/_aot_autograd/input_output_analysis.py
@@ -336,9 +336,19 @@ def _tensors_definitely_do_not_overlap(x, y):
 
 
 def compute_overlapping_inputs(fwd_inputs, aliased_input_indices):
+    max_aliased_inps_w_dyn_shapes = (
+        config._max_aliased_inputs_with_dynamic_shapes_enabled
+    )
+    if torch._inductor.config.is_fbcode():
+        tmp = torch._utils_internal.justknobs_getval_int(
+            "pytorch/dynamo:_max_aliased_inputs_with_dynamic_shapes_enabled"
+        )
+        if tmp > 0:
+            max_aliased_inps_w_dyn_shapes = tmp
+
     actual_aliased_indices = set()
     num_aliases = len(aliased_input_indices)
-    if num_aliases > config._max_aliased_inputs_with_dynamic_shapes_enabled:
+    if num_aliases > max_aliased_inps_w_dyn_shapes:
         dynamic_shape_indices = set()
         for j in range(num_aliases):
             j_ = aliased_input_indices[j]
@@ -357,6 +367,8 @@ Encountered a graph where:
 - {num_aliases} graph inputs all share the same storage (input indices: {str(aliased_input_indices)})
 - at least one of these aliased inputs was mutated
 - at least one of these inputs is being compiled with dynamic shapes (indices: {str(dynamic_shape_indices)})
+
+Current limit: {str(max_aliased_inps_w_dyn_shapes)}
 
 The most common way to run into this situation is when your model parameters are allocated as one giant buffer
 and are all mutated by the optimizer, and some of your parameters end up getting compiled with dynamic shapes.

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -26,6 +26,16 @@ debug_assert = False
 
 debug_partitioner = os.environ.get("AOT_PARTITIONER_DEBUG", False)
 
+# Today, if you are in a situation where there is "false aliasing"
+# (e.g. you have a bunch of model parameters that all alias the same underlying buffer),
+# our checks for this situation are very slow if these inputs have dynamic shapes.
+# This config is set to ensure that there aren't too many aliased inputs in this situation,
+# so that we error loudly instead of compiling forever.
+# Eventually, we should make these checks faster.
+# For now, however, you can simply turn off dynamic shapes by marking your inputs static
+# when you run into this situation.
+_max_aliased_inputs_with_dynamic_shapes_enabled = 5
+
 static_weight_shapes = True
 
 # Applies CSE to the graph before partitioning

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -40,7 +40,7 @@ if torch._inductor.config.is_fbcode():
     # but we should really default to 1 here (1 aliased input == no aliasing)
     _max_aliased_inputs_with_dynamic_shapes_enabled = max(
         torch._utils_internal.justknobs_getval_int(
-            "pytorch/dynamo:pytorch/dynamo:_max_aliased_inputs_with_dynamic_shapes_enabled"
+            "pytorch/dynamo:_max_aliased_inputs_with_dynamic_shapes_enabled"
         ),
         1
     )

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -10,7 +10,6 @@ Global flags for aot autograd
 import os
 import sys
 from typing import TYPE_CHECKING
-import torch
 
 # Converts torch rng ops to their functional philox rng equivalents. Note that
 # we functionalize only CUDA rng ops today.
@@ -35,17 +34,7 @@ debug_partitioner = os.environ.get("AOT_PARTITIONER_DEBUG", False)
 # Eventually, we should make these checks faster.
 # For now, however, you can simply turn off dynamic shapes by marking your inputs static
 # when you run into this situation.
-if torch._inductor.config.is_fbcode():
-    # Mostly for safety: if justknobs isn't available, getval_int defaults to zero,
-    # but we should really default to 1 here (1 aliased input == no aliasing)
-    _max_aliased_inputs_with_dynamic_shapes_enabled = max(
-        torch._utils_internal.justknobs_getval_int(
-            "pytorch/dynamo:_max_aliased_inputs_with_dynamic_shapes_enabled"
-        ),
-        1
-    )
-else:
-    _max_aliased_inputs_with_dynamic_shapes_enabled = 5
+_max_aliased_inputs_with_dynamic_shapes_enabled = 5
 
 static_weight_shapes = True
 


### PR DESCRIPTION
We should eventually make the non-overlapping checks faster when dynamic shapes are enabled, but this is pretty difficult to do. So for now this PR adds a config that lets us fail fast when this situation happens, instead of causing compile times to secretly come to a crawl.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #123455



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang