### PR TITLE
[AOTI] Handle null outputs

### DIFF
--- a/test/inductor/test_cpu_cpp_wrapper.py
+++ b/test/inductor/test_cpu_cpp_wrapper.py
@@ -75,7 +75,6 @@ if config.abi_compatible:
         "test_conv2d_binary_inplace_fusion_failed_cpu",
         "test_conv2d_binary_inplace_fusion_pass_cpu",
         "test_cumsum_cpu",
-        "test_dtype_sympy_expr_cpu",
         "test_dynamic_qlinear_cpu",
         "test_dynamic_qlinear_qat_cpu",
         "test_lstm_packed_change_input_sizes_cpu",

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2183,13 +2183,12 @@ class CppWrapperCodeCache(CppPythonBindingsCodeCache):
             size_t result_len = cppvec.size();
             PyObject* result = PyList_New(static_cast<Py_ssize_t>(result_len));
             for (size_t i = 0; i < result_len; i++) {
-                if (cppvec[i] == nullptr) {
-                    PyList_SET_ITEM(result, i, Py_None);
-                } else {
-                    // Store AtenTensorHandle as PyCapsulate
-                    PyObject* elem = PyCapsule_New(reinterpret_cast<void*>(cppvec[i]), NULL, NULL);
-                    PyList_SET_ITEM(result, i, elem);
-                }
+                PyObject *elem =
+                    cppvec[i] == nullptr
+                        ? Py_None
+                        // Store AtenTensorHandle as PyCapsulate
+                        : PyCapsule_New(reinterpret_cast<void*>(cppvec[i]), NULL, NULL);
+                PyList_SET_ITEM(result, i, elem);
             }
             return result;
         }

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2183,9 +2183,13 @@ class CppWrapperCodeCache(CppPythonBindingsCodeCache):
             size_t result_len = cppvec.size();
             PyObject* result = PyList_New(static_cast<Py_ssize_t>(result_len));
             for (size_t i = 0; i < result_len; i++) {
-                // Store AtenTensorHandle as PyCapsulate
-                PyObject* elem = PyCapsule_New(reinterpret_cast<void*>(cppvec[i]), NULL, NULL);
-                PyList_SET_ITEM(result, i, elem);
+                if (cppvec[i] == nullptr) {
+                    PyList_SET_ITEM(result, i, Py_None);
+                } else {
+                    // Store AtenTensorHandle as PyCapsulate
+                    PyObject* elem = PyCapsule_New(reinterpret_cast<void*>(cppvec[i]), NULL, NULL);
+                    PyList_SET_ITEM(result, i, elem);
+                }
             }
             return result;
         }

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -928,6 +928,9 @@ class CppWrapperCpu(WrapperCodeGen):
 
         output2idx: Dict[str, int] = {}
         for idx, output in enumerate(output_refs):
+            if output == self.none_str:
+                continue
+
             is_constant_buffer = output in cst_names
             output_buffer = V.graph.graph_outputs[idx]
             if isinstance(output_buffer, ir.BaseView):

--- a/torch/csrc/inductor/aoti_torch/tensor_converter.cpp
+++ b/torch/csrc/inductor/aoti_torch/tensor_converter.cpp
@@ -27,6 +27,11 @@ std::vector<at::Tensor> alloc_tensors_by_stealing_from_handles(
   std::vector<at::Tensor> result;
   result.reserve(length);
   for (size_t i = 0; i < length; i++) {
+    if (handles[i] == nullptr) {
+      result.emplace_back();
+      continue;
+    }
+
     at::Tensor tensor = *tensor_handle_to_tensor_pointer(handles[i]);
     if (lastKnownIdx[handles[i]] != i) {
       result.emplace_back(tensor);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #123460

Summary:

I skipped over the codegen for output handle assignment if the outputs
are null -- in addition to being redundant, it was causing compile
errors.

I also modified the runtime to do the necessary null checks.

Fixes #123173.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang