### PR TITLE
Update ROCm teardown step to chown workspace

### DIFF
--- a/.github/actions/teardown-rocm/action.yml
+++ b/.github/actions/teardown-rocm/action.yml
@@ -21,4 +21,4 @@ runs:
       if: always()
       shell: bash
       run: |
-        sudo chown -R "${USER}" "${GITHUB_WORKSPACE}"
+        chown -R "${USER}" "${GITHUB_WORKSPACE}"

--- a/.github/actions/teardown-rocm/action.yml
+++ b/.github/actions/teardown-rocm/action.yml
@@ -19,5 +19,6 @@ runs:
       if: always()
     - name: Chown workspace back to pytorchci (Fallout of PR 122922)
       if: always()
+      shell: bash
       run: |
         sudo chown -R "${USER}" "${GITHUB_WORKSPACE}"

--- a/.github/actions/teardown-rocm/action.yml
+++ b/.github/actions/teardown-rocm/action.yml
@@ -20,4 +20,4 @@ runs:
     - name: Chown workspace back to pytorchci (Fallout of PR 122922)
       if: always()
       run: |
-        sudo chown -R pytorchci /home/pytorchci/actions-runner/_work/pytorch/pytorch
+        sudo chown -R pytorchci ${GITHUB_WORKSPACE}

--- a/.github/actions/teardown-rocm/action.yml
+++ b/.github/actions/teardown-rocm/action.yml
@@ -2,11 +2,23 @@ name: Teardown ROCm host
 
 description: Tear down ROCm host for CI
 
+inputs:
+  docker-image:
+    required: true
+    type: string
+    description: Docker image to run in
+  gha-user:
+    required: true
+    type: string
+    description: user that executes Github Actions on bare metal
+
 runs:
   using: composite
   steps:
     - name: Teardown ROCm
       if: always()
+      env:
+        DOCKER_IMAGE: ${{ inputs.docker-image }}
       shell: bash
       run: |
         # ignore expansion of "docker ps -q" since it could be empty
@@ -20,5 +32,18 @@ runs:
     - name: Chown workspace back to pytorchci (Fallout of PR 122922)
       if: always()
       shell: bash
+      env:
+        DOCKER_IMAGE: ${{ inputs.docker-image }}
+        GHA_USER: ${{ inputs.gha-user }}
       run: |
-        chown -R "${USER}" "${GITHUB_WORKSPACE}"
+        container_name=$(docker run \
+            --tty \
+            --detach \
+            --name="RESTORE_WORKSPACE_OWNERSHIP" \
+            --user jenkins \
+            -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
+            -w /var/lib/jenkins/workspace \
+            "${DOCKER_IMAGE}"
+        )
+        # restore workspace permissions to GHA user; fallout of PR #122922 whereby cancelled jobs fail to reset permissions 
+        docker exec -t "${container_name}" sh -c "sudo chown -R ${GHA_USER} ."

--- a/.github/actions/teardown-rocm/action.yml
+++ b/.github/actions/teardown-rocm/action.yml
@@ -17,3 +17,7 @@ runs:
     - name: Runner diskspace health check
       uses: ./.github/actions/diskspace-cleanup
       if: always()
+    - name: Chown workspace back to pytorchci (Fallout of PR 122922)
+      if: always()
+      run: |
+        sudo chown -R pytorchci /home/pytorchci/actions-runner/_work/pytorch/pytorch

--- a/.github/actions/teardown-rocm/action.yml
+++ b/.github/actions/teardown-rocm/action.yml
@@ -20,4 +20,4 @@ runs:
     - name: Chown workspace back to pytorchci (Fallout of PR 122922)
       if: always()
       run: |
-        sudo chown -R pytorchci ${GITHUB_WORKSPACE}
+        sudo chown -R "${USER}" "${GITHUB_WORKSPACE}"

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -278,3 +278,6 @@ jobs:
       - name: Teardown ROCm
         uses: ./.github/actions/teardown-rocm
         if: always()
+        with:
+          docker-image: ${{ inputs.docker-image }}
+          gha-user: ${USER}

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -277,3 +277,4 @@ jobs:
 
       - name: Teardown ROCm
         uses: ./.github/actions/teardown-rocm
+        if: always()


### PR DESCRIPTION
PR https://github.com/pytorch/pytorch/pull/122922 added chown steps to test.sh and used the trap mechanism to ensure that, even if the test scripts fails and exits with a non-zero code, it will call the `cleanup_workspace` function on EXIT.

However, this doesn't work as intended when the CI job gets cancelled for eg. if a PR pushes new commits and the older commit CI job gets cancelled. The trap function doesn't get called as the test script immediately aborts.

Any subsequent jobs scheduled on the **same** runner then fail in the 'Checkout PyTorch' step when they try to delete the workspace.

This has been resulting in a slew of CI failures on the HUD.

Example of this situation playing out on one of the ROCm runners: 
Cancelled job: https://github.com/pytorch/pytorch/actions/runs/8563212279/job/23469711035
![image](https://github.com/pytorch/pytorch/assets/37884920/533b5925-ec17-4a62-bd65-2e307eb1c3b7)

Subsequent failed job: https://github.com/pytorch/pytorch/actions/runs/8564517036/job/23472675041
![image](https://github.com/pytorch/pytorch/assets/37884920/368bb3f7-07c5-4cc4-9581-87a0b9958534)


cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang