### PR TITLE
[dynamo][cpp-guards] Fix missing decref in GradGuardAccessor

### DIFF
--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -2425,8 +2425,11 @@ class GradGuardAccessor : public GuardAccessor {
     if (!THPVariable_CheckExact(obj) && !THPVariable_Check(obj)) {
       return false;
     }
-    PyObject* grad = THPVariable_Wrap(THPVariable_Unpack(obj).grad());
-    return _guard_manager->check_nopybind(grad);
+    PyObject* grad =
+        THPVariable_Wrap(THPVariable_Unpack(obj).grad()); // New reference
+    bool result = _guard_manager->check_nopybind(grad);
+    Py_XDECREF(grad);
+    return result;
   }
 
   GuardDebugInfo check_verbose_nopybind(
@@ -2436,8 +2439,11 @@ class GradGuardAccessor : public GuardAccessor {
       return GuardDebugInfo(
           false, "not a tensor - grad field is accessed " + get_source(), 0);
     }
-    PyObject* grad = THPVariable_Wrap(THPVariable_Unpack(obj).grad());
-    return _guard_manager->check_verbose_nopybind(grad);
+    PyObject* grad =
+        THPVariable_Wrap(THPVariable_Unpack(obj).grad()); // New reference
+    GuardDebugInfo result = _guard_manager->check_verbose_nopybind(grad);
+    Py_XDECREF(grad);
+    return result;
   }
 
   std::string repr() const override {

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -2428,7 +2428,9 @@ class GradGuardAccessor : public GuardAccessor {
     PyObject* grad =
         THPVariable_Wrap(THPVariable_Unpack(obj).grad()); // New reference
     bool result = _guard_manager->check_nopybind(grad);
-    Py_XDECREF(grad);
+    // For undefined tensor, THPVariable_Wrap returns Py_RETURN_NONE. So, no
+    // need of Py_XDECREF.
+    Py_DECREF(grad);
     return result;
   }
 
@@ -2442,7 +2444,9 @@ class GradGuardAccessor : public GuardAccessor {
     PyObject* grad =
         THPVariable_Wrap(THPVariable_Unpack(obj).grad()); // New reference
     GuardDebugInfo result = _guard_manager->check_verbose_nopybind(grad);
-    Py_XDECREF(grad);
+    // For undefined tensor, THPVariable_Wrap returns Py_RETURN_NONE. So, no
+    // need of Py_XDECREF.
+    Py_DECREF(grad);
     return result;
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #123488
* #123485

Found that there was a peak mem increase while running HF suite. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang