### PR TITLE
[Traceable FSDP2][3/n] Check all_gather_work is distributed_c10d.Work before calling .wait()

### DIFF
--- a/torch/distributed/_composable/fsdp/_fsdp_collectives.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_collectives.py
@@ -3,7 +3,6 @@ from typing import List, NamedTuple, Optional, Tuple, Union
 import torch
 import torch.distributed as dist
 from torch.distributed.distributed_c10d import ReduceOp
-from torch.distributed._functional_collectives import AsyncCollectiveTensor
 from ._fsdp_common import (
     _get_dim0_padded_size,
     _raise_assert_with_print,

--- a/torch/distributed/_composable/fsdp/_fsdp_collectives.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_collectives.py
@@ -3,6 +3,7 @@ from typing import List, NamedTuple, Optional, Tuple, Union
 import torch
 import torch.distributed as dist
 from torch.distributed.distributed_c10d import ReduceOp
+from torch.distributed._functional_collectives import AsyncCollectiveTensor
 from ._fsdp_common import (
     _get_dim0_padded_size,
     _raise_assert_with_print,
@@ -78,7 +79,7 @@ def foreach_all_gather_copy_out(
     ) = all_gather_result
     if all_gather_event is not None:  # sync op
         torch.cuda.current_stream().wait_event(all_gather_event)
-    if all_gather_work is not None:  # async op
+    if isinstance(all_gather_work, AsyncCollectiveTensor):  # async op
         all_gather_work.wait()
     world_size = group.size()
     dtype, device = all_gather_output.dtype, all_gather_output.device

--- a/torch/distributed/_composable/fsdp/_fsdp_collectives.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_collectives.py
@@ -79,7 +79,7 @@ def foreach_all_gather_copy_out(
     ) = all_gather_result
     if all_gather_event is not None:  # sync op
         torch.cuda.current_stream().wait_event(all_gather_event)
-    if isinstance(all_gather_work, AsyncCollectiveTensor):  # async op
+    if isinstance(all_gather_work, dist.distributed_c10d.Work):  # async op
         all_gather_work.wait()
     world_size = group.size()
     dtype, device = all_gather_output.dtype, all_gather_output.device


### PR DESCRIPTION
In FSDP2, we have this:
```python
if all_gather_work is not None:  # async op
    all_gather_work.wait()
```

In eager, there are only two possible values for `all_gather_work`:
1. `distributed_c10d.Work` object (when `async_op=True`)
2. `None` (when `async_op=False`)

So the existing `if` statement is sufficient for eager mode.

In compile, there is one additional possible value for `all_gather_work` which is `FakeTensor` object (not None), because we return regular tensor for collective call in compile mode. If we use the existing `if` statement as-is, we will always call `.wait()` on `all_gather_work`, which is not the same semantics as eager.

There are a few ways to fix this:
Option 1: Properly support `distributed_c10d.Work` in Dynamo. This is the best long-term fix but it will take much more time to make it work.

Option 2: Allow calling `.wait()` on FakeTensor in compile mode (and just return None there) - this seems hacky because FakeTensor wouldn't normally have this method.

Option 3: Check whether `all_gather_work` is `distributed_c10d.Work` before calling `.wait()` on it. **<-- This PR**

Option 3 is chosen in this PR because it seems to also make the eager program semantics clearer (we don't need to think about whether `all_gather_work` can be `.wait()` on in all scenarios, as long as we know `distributed_c10d.Work` can be waited on).

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @chauhang