### PR TITLE
[TorchElastic] Changing doc attribute from classmodule to automodule to resolve doc build issue

### DIFF
--- a/docs/source/elastic/agent.rst
+++ b/docs/source/elastic/agent.rst
@@ -86,7 +86,10 @@ Adding interface for health check server which can be extended by starting tcp/h
 server on the specified port number.
 Additionally, health check server will have callback to check watchdog is alive.
 
+.. automodule:: torch.distributed.elastic.agent.server.health_check_server
 .. currentmodule:: torch.distributed.elastic.agent.server.health_check_server
 
 .. autoclass:: HealthCheckServer
    :members:
+
+.. autofunction:: create_healthcheck_server


### PR DESCRIPTION
Summary: To resolve doc build issue: https://hud.pytorch.org/pytorch/pytorch/commit/61d431fab07f65d3e54c28f1ec420c517c7ada92?

Test Plan: will check OSS doc build

Differential Revision: D55830934


