### PR TITLE
Fix record issue on XPUGuardImpl

### DIFF
--- a/c10/xpu/test/impl/XPUGuardTest.cpp
+++ b/c10/xpu/test/impl/XPUGuardTest.cpp
@@ -1,7 +1,9 @@
 #include <gtest/gtest.h>
 
 #include <c10/core/DeviceGuard.h>
+#include <c10/core/Event.h>
 #include <c10/xpu/XPUStream.h>
+#include <c10/xpu/test/impl/XPUTest.h>
 
 bool has_xpu() {
   return c10::xpu::device_count() > 0;
@@ -41,4 +43,52 @@ TEST(XPUGuardTest, GuardBehavior) {
   EXPECT_EQ(streams1[0].device_index(), 1);
   EXPECT_EQ(streams1[1].device_index(), 1);
   EXPECT_EQ(c10::xpu::current_device(), 0);
+}
+
+TEST(XPUGuardTest, EventBehavior) {
+  if (!has_xpu()) {
+    return;
+  }
+
+  auto device = c10::Device(c10::kXPU, c10::xpu::current_device());
+  c10::impl::VirtualGuardImpl impl(device.type());
+  c10::Stream stream1 = impl.getStream(device);
+  c10::Stream stream2 = impl.getStream(device);
+  c10::Event event(device.type());
+
+  constexpr int numel = 1024;
+  int hostData1[numel];
+  initHostData(hostData1, numel);
+  int hostData2[numel];
+  clearHostData(hostData2, numel);
+
+  auto xpu_stream1 = c10::xpu::XPUStream(stream1);
+  int* deviceData = sycl::malloc_device<int>(numel, xpu_stream1);
+
+  // Copy hostData1 to deviceData via stream1, and then copy deviceData to
+  // hostData2 via stream2.
+  xpu_stream1.queue().memcpy(deviceData, hostData1, sizeof(int) * numel);
+  // stream2 wait on stream1's completion.
+  event.record(stream1);
+  event.block(stream2);
+  auto xpu_stream2 = c10::xpu::XPUStream(stream2);
+  xpu_stream2.queue().memcpy(hostData2, deviceData, sizeof(int) * numel);
+  xpu_stream2.synchronize();
+
+  EXPECT_TRUE(event.query());
+  validateHostData(hostData2, numel);
+  event.record(stream2);
+  EXPECT_TRUE(event.query());
+
+  clearHostData(hostData2, numel);
+  xpu_stream1.queue().memcpy(deviceData, hostData1, sizeof(int) * numel);
+  // stream2 wait on stream1's completion.
+  event.record(stream1);
+  event.block(stream2);
+  // event will overwrite the previously captured state.
+  event.record(stream2);
+  xpu_stream2.queue().memcpy(hostData2, deviceData, sizeof(int) * numel);
+  xpu_stream2.synchronize();
+  EXPECT_TRUE(event.query());
+  validateHostData(hostData2, numel);
 }


### PR DESCRIPTION
# Motivation
Previously,  `xpu_event` became a dangling pointer because the variable on the stack is destroyed when the scope ends. It results in these event-related functions (`destroyEvent`, `record`, `block`, and `queryEvent`)  used in `c10/core/impl/InlineEvent.h`, which serves `c10::Event`, do not work correctly.

# Solution
Use `new` allocated on the heap to assign `xpu_event` to avoid the dangling pointer.

# Additional Context
Add a UT to cover this.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10