### PR TITLE
fix typo in 4 files

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -3822,7 +3822,7 @@ def to_memview(tensor):
 
 class TestAsArray(TestCase):
     def _check(self, original, cvt=lambda t: t, is_alias=True, same_dtype=True, same_device=True, **kwargs):
-        """Check the output of 'asarray', given its input and assertion informations.
+        """Check the output of 'asarray', given its input and assertion information.
 
         Besides calling 'asarray' itself, this function does 4 different checks:
             1. Whether the result is aliased or not, depending on 'is_alias'

--- a/torch/ao/quantization/fx/_model_report/README.md
+++ b/torch/ao/quantization/fx/_model_report/README.md
@@ -93,7 +93,7 @@ format, it will instead be in a:
       -- feature value
 ```
 
-Essentially, all the informations for each of the modules are consolidated across the different reports.
+Essentially, all the information for each of the modules are consolidated across the different reports.
 Moreover, the modules are kept in the same chronological order they would appear in the model's `forward()` method.
 
 Then, when it comes to the visualizer, there are two main things you can do:

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -681,7 +681,7 @@ TORCH_API void handle_view_on_rebase(
 
 struct TORCH_API DifferentiableViewMeta : public AutogradMeta {
  private:
-  /// Informations about the views
+  /// Information about the views
   c10::optional<ViewInfo> backward_info_;
   c10::optional<ViewInfo> forward_info_;
 

--- a/torch/csrc/jit/passes/fold_conv_bn.cpp
+++ b/torch/csrc/jit/passes/fold_conv_bn.cpp
@@ -120,7 +120,7 @@ class FoldConvBatchNormHelper {
   /**
    * In this step we find all Conv - BatchNorm patterns in the graph
    * and extract the corresponding parameters for these two modules,
-   * and record informations for the modifications of the graph without
+   * and record information for the modifications of the graph without
    * actually performing these modifications.
    */
   void analyze(Module& module, const PatternInfo& pattern);


### PR DESCRIPTION
fix typo: `information` has no plural.

