### PR TITLE
Use all bit widths for bf16/fp16 vectorization

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
@@ -44,10 +44,48 @@ struct VecConvert<BFloat16, 1, float, 1> {
 };
 
 template <>
+struct VecConvert<BFloat16, 1, float, 2> {
+  static inline VectorizedN<BFloat16, 1> apply(
+      const VectorizedN<float, 2>& src) {
+    VectorizedN<BFloat16, 1> result;
+    result[0] = convert_float_bfloat16(src[0], src[1]);
+    return result;
+  }
+};
+
+template <>
+struct VecConvert<float, 2, BFloat16, 1> {
+  static inline VectorizedN<float, 2> apply(
+      const VectorizedN<BFloat16, 1>& src) {
+    VectorizedN<float, 2> result;
+    std::tie(result[0], result[1]) = convert_bfloat16_float(src[0]);
+    return result;
+  }
+};
+
+template <>
 struct VecConvert<Half, 1, float, 1> {
   static inline VectorizedN<Half, 1> apply(const VectorizedN<float, 1>& src) {
     VectorizedN<Half, 1> result;
     result[0] = _mm256_castsi128_si256(cvtfp32_fp16(src[0]));
+    return result;
+  }
+};
+
+template <>
+struct VecConvert<Half, 1, float, 2> {
+  static inline VectorizedN<Half, 1> apply(const VectorizedN<float, 2>& src) {
+    VectorizedN<Half, 1> result;
+    result[0] = convert_float_half(src[0], src[1]);
+    return result;
+  }
+};
+
+template <>
+struct VecConvert<float, 2, Half, 1> {
+  static inline VectorizedN<float, 2> apply(const VectorizedN<Half, 1>& src) {
+    VectorizedN<float, 2> result;
+    std::tie(result[0], result[1]) = convert_half_float(src[0]);
     return result;
   }
 };

--- a/aten/src/ATen/cpu/vec/vec256/vec256_mask.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_mask.h
@@ -47,6 +47,20 @@ struct VecMaskCast<int, 1, float, 1> {
   }
 };
 
+template <>
+struct VecMaskCast<float, 2, int, 2> {
+  static inline VecMask<float, 2> apply(const VecMask<int, 2>& vec_mask) {
+    return VectorizedN<float, 2>(_mm256_castsi256_ps(vec_mask[0]), _mm256_castsi256_ps(vec_mask[1]));
+  }
+};
+
+template <>
+struct VecMaskCast<int, 2, float, 2> {
+  static inline VecMask<int, 2> apply(const VecMask<float, 2>& vec_mask) {
+    return VectorizedN<int, 2>(_mm256_castps_si256(vec_mask[0]), _mm256_castps_si256(vec_mask[1]));
+  }
+};
+
 template <typename dst_t>
 struct VecMaskCast<dst_t, 1, int64_t, 2> {
   static inline VecMask<dst_t, 1> apply(const VecMask<int64_t, 2>& vec_mask) {

--- a/aten/src/ATen/cpu/vec/vec512/vec512_convert.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_convert.h
@@ -44,10 +44,48 @@ struct VecConvert<BFloat16, 1, float, 1> {
 };
 
 template <>
+struct VecConvert<BFloat16, 1, float, 2> {
+  static inline VectorizedN<BFloat16, 1> apply(
+      const VectorizedN<float, 2>& src) {
+    VectorizedN<BFloat16, 1> result;
+    result[0] = convert_float_bfloat16(src[0], src[1]);
+    return result;
+  }
+};
+
+template <>
+struct VecConvert<float, 2, BFloat16, 1> {
+  static inline VectorizedN<float, 2> apply(
+      const VectorizedN<BFloat16, 1>& src) {
+    VectorizedN<float, 2> result;
+    std::tie(result[0], result[1]) = convert_bfloat16_float(src[0]);
+    return result;
+  }
+};
+
+template <>
 struct VecConvert<Half, 1, float, 1> {
   static inline VectorizedN<Half, 1> apply(const VectorizedN<float, 1>& src) {
     VectorizedN<Half, 1> result;
     result[0] = _mm512_castsi256_si512(cvtfp32_fp16(src[0]));
+    return result;
+  }
+};
+
+template <>
+struct VecConvert<Half, 1, float, 2> {
+  static inline VectorizedN<Half, 1> apply(const VectorizedN<float, 2>& src) {
+    VectorizedN<Half, 1> result;
+    result[0] = convert_float_half(src[0], src[1]);
+    return result;
+  }
+};
+
+template <>
+struct VecConvert<float, 2, Half, 1> {
+  static inline VectorizedN<float, 2> apply(const VectorizedN<Half, 1>& src) {
+    VectorizedN<float, 2> result;
+    std::tie(result[0], result[1]) = convert_half_float(src[0]);
     return result;
   }
 };

--- a/aten/src/ATen/cpu/vec/vec_n.h
+++ b/aten/src/ATen/cpu/vec/vec_n.h
@@ -88,6 +88,9 @@ class VectorizedN {
   template <int L = N, typename std::enable_if_t<L == 1, int> = 0>
   VectorizedN(const Vectorized<T>& val) : values({val}) {}
 
+  template <int L = N, typename std::enable_if_t<L == 2, int> = 0>
+  VectorizedN(const Vectorized<T>& val_0, const Vectorized<T>& val_1) : values({val_0, val_1}) {}
+
   template <int L = N, typename std::enable_if_t<L == 1, int> = 0>
   inline operator Vectorized<T>() const {
     return values[0];

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -8938,6 +8938,98 @@ class CommonTemplate:
                     elif node.target == "output":
                         self.assertEqual(get_data_type(node), torch.bfloat16)
 
+    @unittest.skipIf(not HAS_CPU, "requires C++ compiler")
+    def test_full_bits_lowp(self):
+        from torch._dynamo.utils import detect_fake_mode
+        from torch._inductor.codegen.cpp import CppKernelProxy, KernelGroup
+        from torch._inductor.compile_fx import _shape_env_from_inputs
+        from torch._inductor.debug import DebugContext
+        from torch._inductor.graph import GraphLowering
+        from torch._inductor.virtualized import V
+        from torch.fx.passes.fake_tensor_prop import FakeTensorProp
+
+        def check_use_full_bits(func, shapes, dtype, mixed):
+            example_inputs = [torch.randn(shape, dtype=dtype) for shape in shapes]
+            if mixed:
+                example_inputs[0] = example_inputs[0].float()
+            self.common(func, example_inputs)
+            gm, _ = torch._dynamo.export(func)(*example_inputs)
+            gm = torch.fx.symbolic_trace(gm)
+            shape_env = _shape_env_from_inputs(example_inputs)
+            fake_mode = detect_fake_mode(example_inputs)
+            if not fake_mode:
+                fake_mode = torch._subclasses.FakeTensorMode()
+                FakeTensorProp(gm, mode=fake_mode).propagate(*example_inputs)
+            else:
+                FakeTensorProp(gm, mode=fake_mode).propagate_dont_convert_inputs(
+                    *example_inputs
+                )
+
+            with V.set_fake_mode(fake_mode):
+                graph = GraphLowering(
+                    gm,
+                    shape_env=shape_env,
+                    num_static_inputs=0,
+                )
+                with V.set_graph_handler(graph), V.set_debug_handler(DebugContext()):
+                    graph.run(*example_inputs)
+                    code, _ = graph.codegen()
+                    scheduler_node = graph.scheduler.nodes[0]
+                    nodes = scheduler_node.get_nodes()
+                    kernel_group = KernelGroup()
+                    cpp_kernel_proxy = CppKernelProxy(kernel_group)
+                    cpp_kernel_proxy.legalize_lowp_fp_dtype(nodes)
+                    cpp_kernel_proxy.data_type_propagation(nodes)
+                    first_node = nodes[0]
+                    vec_dtype = (
+                        first_node._lowp_fp_type
+                        if all(
+                            hasattr(_node, "_lowp_fp_type")
+                            and _node._lowp_fp_type == first_node._lowp_fp_type
+                            for _node in nodes
+                        )
+                        else torch.float
+                    )
+                    self.assertEqual(vec_dtype, dtype)
+                    self.assertTrue(
+                        "at::vec::VectorizedN" in code
+                        or "at::vec::convert<float,2" in code
+                    )
+
+        funcs = []
+
+        def func0(arg0, arg1):
+            return torch.ops.aten.sum(
+                torch.ops.aten.add(torch.ops.aten.atanh(arg0), arg1), (2, 3)
+            )
+
+        funcs.append(func0)
+
+        def func1(arg0):
+            v = torch.ops.prims.convert_element_type.default(arg0, torch.float)
+            v = torch.ops.aten.add(torch.ops.aten.atanh(arg0), v)
+            return torch.ops.prims.convert_element_type.default(v, arg0.dtype)
+
+        funcs.append(func1)
+
+        def func2(arg0, arg1):
+            v = torch.ops.aten.atanh(arg0)
+            v = torch.ops.aten.add(v, arg1)
+            return torch.ops.prims.convert_element_type.default(v, arg1.dtype)
+
+        funcs.append(func2)
+
+        example_shapes = [
+            [(10, 32, 20, 20), (10, 32, 20, 20)],
+            [(10, 32, 20, 20)],
+            [(10, 32, 20, 20), (10, 32, 20, 20)],
+        ]
+        mixed_types = [False, False, True]
+
+        for dtype in [torch.bfloat16, torch.float16]:
+            for func, shapes, mixed in zip(funcs, example_shapes, mixed_types):
+                check_use_full_bits(func, shapes, dtype, mixed)
+
     # Calling div only torch.SymInt arguments is not yet supported.
     # To support this behavior, we need to allow const-propping tensors that store symint data.
     # For now, dynamo will explicitly graph break when it encounters user code with this behavior.

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -6,6 +6,7 @@ import logging
 import math
 import re
 import sys
+import warnings
 from copy import copy, deepcopy
 from enum import Enum
 from typing import Any, cast, Dict, List, Optional, Set, Tuple, Union
@@ -2340,9 +2341,6 @@ class CppVecKernel(CppKernel):
         if self.tiling_idx >= self.reduction_depth:
             # Horizontal reduction
             if is_welford_reduction(reduction_type):
-                assert (
-                    self._get_num_vectors(dtype) == 1
-                ), "Welford reduction does not support VectorizedN (N>1)"
                 next_value = f"welford_vec_reduce_all({acc_vec})"
             else:
                 reduce_all_body = (
@@ -2370,6 +2368,8 @@ class CppVecKernel(CppKernel):
         var = self.args.output(name)
         out_dtype = V.graph.get_dtype(name)
         dtype = torch.float if out_dtype.is_floating_point else torch.int64
+        out_num_vectors = V.kernel._get_num_vectors(out_dtype)
+        src_num_vectors = V.kernel._get_num_vectors(dtype)
         code = IndentedBuffer()
         if self.tiling_idx >= self.reduction_depth:
             # Horizontal reduction
@@ -2380,9 +2380,15 @@ class CppVecKernel(CppKernel):
             # Vertical reduction
             if out_dtype != dtype:
                 converted_value = f"{DTYPE_TO_CPP[out_dtype]}_{value}"
-                code.writeline(
-                    f"auto {converted_value} = at::vec::convert<{DTYPE_TO_CPP[out_dtype]}>({value});"
-                )
+                if src_num_vectors == out_num_vectors == 1:
+                    code.writeline(
+                        f"auto {converted_value} = at::vec::convert<{DTYPE_TO_CPP[out_dtype]}>({value});"
+                    )
+                else:
+                    code.writeline(
+                        f"auto {converted_value} = at::vec::convert<{DTYPE_TO_CPP[out_dtype]},"
+                        f"{out_num_vectors},{DTYPE_TO_CPP[dtype]},{src_num_vectors}>({value});"
+                    )
                 value = converted_value
             code.splice(self._get_store_line(value, var, index, out_dtype))
         self.reduction_suffix.splice(code.map(lambda x: DeferredLine(name, x)))
@@ -2930,6 +2936,7 @@ class CppKernelProxy(CppKernel):
         sub_blocks = [scheduler_node._body.root_block] + list(
             scheduler_node._body.subblocks.values()
         )
+        all_node_support_lowp: bool = True
         for sub_block in sub_blocks:
             for _node in sub_block.graph.nodes:
                 # TODO(Eikan): Regarding get_index and index_expr, we should conclude the
@@ -2948,24 +2955,26 @@ class CppKernelProxy(CppKernel):
                     "neg",
                     "output",
                 ]:
-                    return False
+                    all_node_support_lowp = False
 
                 if hasattr(_node, "meta") and _node.meta:
                     assert OptimizationContext.key in _node.meta
                     opt_ctx: OptimizationContext = _node.meta[OptimizationContext.key]
                     if not opt_ctx.dtype or opt_ctx.dtype not in DTYPE_LOWP_FP:
-                        return False
-                    if _lowp_fp_type:
-                        assert (
-                            _lowp_fp_type == opt_ctx.dtype
-                        ), "scheduler node do not support bf16/fp16 mix"
+                        all_node_support_lowp = False
+                    elif _lowp_fp_type:
+                        if _lowp_fp_type != opt_ctx.dtype:
+                            warnings.warn(
+                                "bf16 and fp16 are mixed in the scheduler node. "
+                                f"Will use the first encountered {_lowp_fp_type}."
+                            )
                     else:
                         _lowp_fp_type = opt_ctx.dtype
+                        scheduler_node._lowp_fp_type = _lowp_fp_type  # type: ignore[attr-defined]
                 else:
-                    return False
+                    all_node_support_lowp = False
 
-        scheduler_node._lowp_fp_type = _lowp_fp_type  # type: ignore[attr-defined]
-        return True
+        return all_node_support_lowp
 
     def legalize_lowp_fp_dtype(self, nodes):
         def add_to_dtype(sub_graph: torch.fx.Graph):

--- a/torch/_inductor/codegen/cpp_prefix.h
+++ b/torch/_inductor/codegen/cpp_prefix.h
@@ -52,15 +52,19 @@ struct Welford {
 
 template <typename T>
 struct IsVecType: std::false_type {};
+template <typename T>
+struct Is2VecType: std::false_type {};
 
 #if INDUCTOR_USE_VECTOR_TYPES()
 template <typename T>
 struct IsVecType<at::vec::Vectorized<T>>: std::true_type {};
+template <typename T>
+struct Is2VecType<at::vec::VectorizedN<T, 2>>: std::true_type {};
 #endif
 
 template <typename T>
 Welford<T> welford_combine(const Welford<T> &a, const Welford<T> &b) {
-  if constexpr (!IsVecType<T>::value) {
+  if constexpr (!IsVecType<T>::value && !Is2VecType<T>::value) {
     if (a.weight == 0) {
       return b;
     }
@@ -71,7 +75,7 @@ Welford<T> welford_combine(const Welford<T> &a, const Welford<T> &b) {
   auto delta = b.mean - a.mean;
   auto new_weight = a.weight + b.weight;
   auto wb_over_w = b.weight / new_weight;
-  if constexpr (IsVecType<T>::value) {
+  if constexpr (IsVecType<T>::value || Is2VecType<T>::value) {
     // Guard against division by zero
     wb_over_w = T::blendv(wb_over_w, T(0), new_weight == T(0));
   }
@@ -176,6 +180,23 @@ Welford<scalar_t> welford_vec_reduce_all(Welford<at::vec::Vectorized<scalar_t>> 
   result.weight = array[0];
 
   return result;
+}
+
+template <typename scalar_t>
+Welford<scalar_t> welford_vec_reduce_all(Welford<at::vec::VectorizedN<scalar_t, 2>> acc) {
+  auto Welford0 = Welford<at::vec::Vectorized<scalar_t>>{
+    acc.mean[0],
+    acc.m2[0],
+    acc.weight[0]
+  };
+  auto Welford1 = Welford<at::vec::Vectorized<scalar_t>>{
+    acc.mean[1],
+    acc.m2[1],
+    acc.weight[1]
+  };
+  auto result0 = welford_vec_reduce_all(Welford0);
+  auto result1 = welford_vec_reduce_all(Welford1);
+  return welford_combine(result0, result1);
 }
 #endif
 


### PR DESCRIPTION
Use all bit widths for bf16/fp16 vectorization since `VectorizedN` is supported.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang