### PR TITLE
[DeviceMesh] Fix hash and eq not match

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -225,7 +225,7 @@ class DeviceMeshTestNDim(DTensorTestBase):
         mesh_tensor_2d = torch.arange(8).reshape(4, 2)
         mesh = DeviceMesh(self.device_type, mesh_tensor_2d)
         mesh2 = DeviceMesh(self.device_type, mesh_tensor_2d)
-        self.assertNotEqual(hash(mesh), hash(mesh2))
+        self.assertEqual(hash(mesh), hash(mesh2))
         mesh_tensor_3d = torch.arange(8).reshape(2, 2, 2)
         mesh3 = DeviceMesh(self.device_type, mesh_tensor_3d)
         self.assertNotEqual(hash(mesh), hash(mesh3))
@@ -268,6 +268,40 @@ class DeviceMeshTestNDim(DTensorTestBase):
         dp_rank = mesh_3d.get_local_rank("dp")
         expected_dp_rank = self.rank // 4
         self.assertEqual(dp_rank, expected_dp_rank)
+
+    def test_device_mesh_parent_child_hash(self):
+        mesh_2d = init_device_mesh(
+            self.device_type, (2, 4), mesh_dim_names=("DP", "TP")
+        )
+        mesh_group_1 = [0, 1, 2, 3]
+        mesh_group_2 = [4, 5, 6, 7]
+        ep_mesh = (
+            DeviceMesh(self.device_type, mesh_group_1)
+            if self.rank < 2
+            else DeviceMesh(self.device_type, mesh_group_2)
+        )
+        # ep_mesh is considered different from mesh_2d["TP"]
+        # since mesh_2d["TP"] has a parent mesh while ep_mesh does not.
+        self.assertEqual(mesh_2d["TP"]._flatten_mesh_list, ep_mesh._flatten_mesh_list)
+        self.assertEqual(mesh_2d["TP"].mesh.shape, ep_mesh.mesh.shape)
+        self.assertEqual(mesh_2d["TP"].device_type, ep_mesh.device_type)
+        self.assertNotEqual(mesh_2d["TP"].mesh_dim_names, ep_mesh.mesh_dim_names)
+        self.assertNotEqual(mesh_2d["TP"]._hash, ep_mesh._hash)
+        self.assertNotEqual(mesh_2d["TP"], ep_mesh)
+
+        # another_mesh is considered the same as ep_mesh
+        # since they have the same mesh and no parent mesh.
+        another_mesh = (
+            DeviceMesh(self.device_type, mesh_group_1)
+            if self.rank < 2
+            else DeviceMesh(self.device_type, mesh_group_2)
+        )
+        self.assertEqual(ep_mesh._flatten_mesh_list, another_mesh._flatten_mesh_list)
+        self.assertEqual(ep_mesh.mesh.shape, another_mesh.mesh.shape)
+        self.assertEqual(ep_mesh.device_type, another_mesh.device_type)
+        self.assertEqual(ep_mesh.mesh_dim_names, another_mesh.mesh_dim_names)
+        self.assertEqual(ep_mesh._hash, another_mesh._hash)
+        self.assertEqual(ep_mesh, another_mesh)
 
 
 class InitDeviceMeshTest(DTensorTestBase):

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -271,35 +271,26 @@ class DeviceMeshTestNDim(DTensorTestBase):
 
     def test_device_mesh_parent_child_hash(self):
         mesh_2d = init_device_mesh(
-            self.device_type, (2, 4), mesh_dim_names=("DP", "TP")
+            self.device_type, (2, self.world_size // 2), mesh_dim_names=("DP", "TP")
         )
-        mesh_group_1 = [0, 1, 2, 3]
-        mesh_group_2 = [4, 5, 6, 7]
-        ep_mesh = (
-            DeviceMesh(self.device_type, mesh_group_1)
-            if self.rank < 4
-            else DeviceMesh(self.device_type, mesh_group_2)
-        )
-        # ep_mesh is considered different from mesh_2d["TP"]
-        # since mesh_2d["TP"] has a parent mesh while ep_mesh does not.
-        self.assertEqual(mesh_2d["TP"]._flatten_mesh_list, ep_mesh._flatten_mesh_list)
-        self.assertEqual(mesh_2d["TP"].mesh.shape, ep_mesh.mesh.shape)
-        self.assertEqual(mesh_2d["TP"].device_type, ep_mesh.device_type)
-        self.assertNotEqual(mesh_2d["TP"].mesh_dim_names, ep_mesh.mesh_dim_names)
+
+        mesh_group_1 = torch.arange(0, self.world_size // 2)
+        mesh_group_2 = torch.arange(self.world_size // 2, self.world_size)
+        ep_mesh_1 = DeviceMesh(self.device_type, mesh_group_1)
+        ep_mesh_2 = DeviceMesh(self.device_type, mesh_group_2)
+        ep_mesh = ep_mesh_1 if self.rank < self.world_size // 2 else ep_mesh_2
+        # # ep_mesh is considered different from mesh_2d["TP"]
+        # # since mesh_2d["TP"] has a parent mesh while ep_mesh does not.
         self.assertNotEqual(mesh_2d["TP"]._hash, ep_mesh._hash)
         self.assertNotEqual(mesh_2d["TP"], ep_mesh)
 
+        another_mesh_1 = DeviceMesh(self.device_type, mesh_group_1)
+        another_mesh_2 = DeviceMesh(self.device_type, mesh_group_2)
+        another_mesh = (
+            another_mesh_1 if self.rank < self.world_size // 2 else another_mesh_2
+        )
         # another_mesh is considered the same as ep_mesh
         # since they have the same mesh and no parent mesh.
-        another_mesh = (
-            DeviceMesh(self.device_type, mesh_group_1)
-            if self.rank < 4
-            else DeviceMesh(self.device_type, mesh_group_2)
-        )
-        self.assertEqual(ep_mesh._flatten_mesh_list, another_mesh._flatten_mesh_list)
-        self.assertEqual(ep_mesh.mesh.shape, another_mesh.mesh.shape)
-        self.assertEqual(ep_mesh.device_type, another_mesh.device_type)
-        self.assertEqual(ep_mesh.mesh_dim_names, another_mesh.mesh_dim_names)
         self.assertEqual(ep_mesh._hash, another_mesh._hash)
         self.assertEqual(ep_mesh, another_mesh)
 
@@ -312,19 +303,19 @@ class InitDeviceMeshTest(DTensorTestBase):
     @with_comms
     def test_init_device_mesh(self):
         mesh_shape = (2, 4)
-        ref_mesh = DeviceMesh(self.device_type, torch.arange(8).view(mesh_shape))
+        mesh_dim_names = ("DP", "TP")
+        ref_mesh = DeviceMesh(
+            self.device_type,
+            torch.arange(8).view(mesh_shape),
+            mesh_dim_names=mesh_dim_names,
+        )
 
         # test init_device_mesh with mesh_dim_names
-        mesh_dim_names = ("DP", "TP")
         mesh_2d = init_device_mesh(
             self.device_type, mesh_shape, mesh_dim_names=mesh_dim_names
         )
         self.assertEqual(mesh_2d, ref_mesh)
         self.assertEqual(mesh_2d.mesh_dim_names, mesh_dim_names)
-
-        # test init_device_mesh without mesh_dim_names
-        mesh_2d = init_device_mesh(self.device_type, mesh_shape)
-        self.assertEqual(mesh_2d, ref_mesh)
 
     @with_comms
     def test_raises_duplicate_mesh_dim_names(self):

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -277,7 +277,7 @@ class DeviceMeshTestNDim(DTensorTestBase):
         mesh_group_2 = [4, 5, 6, 7]
         ep_mesh = (
             DeviceMesh(self.device_type, mesh_group_1)
-            if self.rank < 2
+            if self.rank < 4
             else DeviceMesh(self.device_type, mesh_group_2)
         )
         # ep_mesh is considered different from mesh_2d["TP"]
@@ -293,7 +293,7 @@ class DeviceMeshTestNDim(DTensorTestBase):
         # since they have the same mesh and no parent mesh.
         another_mesh = (
             DeviceMesh(self.device_type, mesh_group_1)
-            if self.rank < 2
+            if self.rank < 4
             else DeviceMesh(self.device_type, mesh_group_2)
         )
         self.assertEqual(ep_mesh._flatten_mesh_list, another_mesh._flatten_mesh_list)

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -269,6 +269,7 @@ class DeviceMeshTestNDim(DTensorTestBase):
         expected_dp_rank = self.rank // 4
         self.assertEqual(dp_rank, expected_dp_rank)
 
+    @with_comms
     def test_device_mesh_parent_child_hash(self):
         mesh_2d = init_device_mesh(
             self.device_type, (2, self.world_size // 2), mesh_dim_names=("DP", "TP")
@@ -281,7 +282,13 @@ class DeviceMeshTestNDim(DTensorTestBase):
         ep_mesh = ep_mesh_1 if self.rank < self.world_size // 2 else ep_mesh_2
         # # ep_mesh is considered different from mesh_2d["TP"]
         # # since mesh_2d["TP"] has a parent mesh while ep_mesh does not.
-        self.assertNotEqual(mesh_2d["TP"]._hash, ep_mesh._hash)
+        self.assertEqual(mesh_2d["TP"]._flatten_mesh_list, ep_mesh._flatten_mesh_list)
+        self.assertEqual(mesh_2d["TP"].mesh.shape, ep_mesh.mesh.shape)
+        self.assertEqual(mesh_2d["TP"].device_type, ep_mesh.device_type)
+        self.assertNotEqual(mesh_2d["TP"].mesh_dim_names, ep_mesh.mesh_dim_names)
+        self.assertEqual(mesh_2d["TP"]._thread_id, ep_mesh._thread_id)
+        self.assertNotEqual(mesh_2d["TP"]._parent_mesh, ep_mesh._parent_mesh)
+        self.assertNotEqual(hash(mesh_2d["TP"]), hash(ep_mesh))
         self.assertNotEqual(mesh_2d["TP"], ep_mesh)
 
         another_mesh_1 = DeviceMesh(self.device_type, mesh_group_1)
@@ -291,7 +298,13 @@ class DeviceMeshTestNDim(DTensorTestBase):
         )
         # another_mesh is considered the same as ep_mesh
         # since they have the same mesh and no parent mesh.
-        self.assertEqual(ep_mesh._hash, another_mesh._hash)
+        self.assertEqual(ep_mesh._flatten_mesh_list, another_mesh._flatten_mesh_list)
+        self.assertEqual(ep_mesh.mesh.shape, another_mesh.mesh.shape)
+        self.assertEqual(ep_mesh.device_type, another_mesh.device_type)
+        self.assertEqual(ep_mesh.mesh_dim_names, another_mesh.mesh_dim_names)
+        self.assertEqual(ep_mesh._thread_id, another_mesh._thread_id)
+        self.assertEqual(ep_mesh._parent_mesh, another_mesh._parent_mesh)
+        self.assertEqual(hash(ep_mesh), hash(another_mesh))
         self.assertEqual(ep_mesh, another_mesh)
 
 

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -74,10 +74,8 @@ else:
             # swap the current dim to the last dim then reshape to flatten out other
             # dims, so we can just extract the list of ranks which contains cur_rank.
             cur_rank = device_mesh.get_rank()
-            pg_ranks_by_dim = (
-                device_mesh.mesh.swapdims(-1, mesh_dim)
-                .reshape(-1, device_mesh.mesh.size(mesh_dim))
-                .to(torch.int32)
+            pg_ranks_by_dim = device_mesh.mesh.swapdims(-1, mesh_dim).reshape(
+                -1, device_mesh.mesh.size(mesh_dim)
             )
 
             for mesh_1d in pg_ranks_by_dim:
@@ -219,21 +217,14 @@ else:
 
             # private field to pre-generate DeviceMesh's hash
             self._flatten_mesh_list = tuple(self.mesh.flatten().tolist())
-            hash_obj = (
+            self._hash = hash(
                 (
                     self._flatten_mesh_list,
                     self.mesh.shape,
                     self.device_type,
                     self.mesh_dim_names,
                 )
-                if self.mesh_dim_names
-                else (
-                    self._flatten_mesh_list,
-                    self.mesh.shape,
-                    self.device_type,
-                )
             )
-            self._hash = hash(hash_obj)
 
             # Skip process group initialization if xla device or init backend is False
             # TODO(yeounoh) implement DeviceMesh backend and register XLA backend.


### PR DESCRIPTION
Fixes #121799

We fix DeviceMesh hash such that two mesh are considered equal if they have the same mesh and same parent_mesh. 
Examples can be found here: https://github.com/pytorch/pytorch/issues/121799

Also need this to unblock https://github.com/pytorch/pytorch/pull/123394

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @tianyu-l @wconstab @yf225 @chauhang @d4l3k @rohan-varma