### PR TITLE
Updated test_graph_grad_scaling to use new OptimizerInfo infrastructure

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4150,8 +4150,8 @@ class TestBlockStateAbsorption(TestCase):
         self.assertEqual(rc, "False", "Triton was imported when importing torch!")
 
 class TestCudaOptims(TestCase):
-    # This test case uses initiate_device_type_tests to apply the new
-    # OptimizerInfo structure.
+    # These tests will be instantiate with instantiate_device_type_tests 
+    # to apply the new OptimizerInfo structure.
 
     @onlyCUDA
     @unittest.skipIf(not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs")

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4104,7 +4104,7 @@ class TestCudaOptims(TestCase):
     @unittest.skipIf(not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs")
     @parametrize("foreach, fused", [(False, False), (True, False), (False, True)])
     @optims(
-        optim_db,
+        [optim for optim in optim_db if "foreach" in optim.supported_impls and "fused" in optim.supported_impls],
         dtypes=[torch.float32]
     )
     def test_graph_grad_scaling(self, device, dtype, optim_info, foreach, fused):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4157,7 +4157,7 @@ class TestCudaOptims(TestCase):
     @unittest.skipIf(not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs")
     @parametrize("foreach, fused", [(False, False), (True, False), (False, True)])
     @optims(
-        [optim for optim in optim_db if optim.optim_cls == torch.optim.SGD],
+        optim_db,
         dtypes=[torch.float32]
     )
     def test_graph_grad_scaling(self, device, dtype, optim_info, foreach, fused):


### PR DESCRIPTION
This PR targets the issue mentioned in #123451 , and solves the specific task to update`test_graph_grad_scaling` in `test/test_cuda.py` to use the new OptimizerInfo infrastructure.

`test_graph_grad_scaling` is moved to a new `TestCase` class called `TestCudaOptims` in order to use `instantiate_device_type_tests`. The test content remained the same. `@onlyCUDA` is applied to the new test; the original use of the wrapper function is also changed to a `@parametrize` decorator for better style.

If we think that this migration is successful, we can delete the original test item under `TestCuda`. Currently it is left untouched to avoid any unexpected issues. 

Local linter passed. 
```
$ lintrunner test/test_cuda.py
ok No lint issues.
```

Local tests passed.
```
> python .\test\test_cuda.py -k test_graph_grad_scaling
Ran 7 tests in 0.458s
OK (skipped = 3)
```