### PR TITLE
[WIP] Added a target value interval check to BCEWithLogitsLoss.

### DIFF
--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -358,6 +358,10 @@ Tensor binary_cross_entropy_with_logits(const Tensor& input, const Tensor& targe
   const Tensor& weight = *weight_maybe_owned;
   c10::MaybeOwned<Tensor> pos_weight_maybe_owned = at::borrow_from_optional_tensor(pos_weight_opt);
   const Tensor& pos_weight = *pos_weight_maybe_owned;
+  TORCH_CHECK(
+          (target >= 0).logical_and_(target <= 1).all().item().toBool(),
+          "all elements of target should be between 0 and 1"
+  );
 
   Tensor loss;
   if (pos_weight.defined()) {

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4593,6 +4593,20 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaisesRegex(RuntimeError, 'between 0 and 1'):
             loss_too_positive = bceloss(output_too_positive, target)
 
+    def test_bce_loss_and_bce_with_logits_target_range(self):
+        for bceloss in [nn.BCEWithLogitsLoss(), nn.BCELoss()]:
+            target = torch.rand(25, 25)
+            # Outputs from 0-1 are valid for both losses
+            output_valid = torch.rand(25, 25)
+            target_too_negative = output_valid - 1.1
+            target_too_positive = output_valid + 1.1
+
+            loss_valid = bceloss(output_valid, target)
+            with self.assertRaisesRegex(RuntimeError, 'between 0 and 1'):
+                loss_too_negative = bceloss(output_valid, target_too_negative)
+            with self.assertRaisesRegex(RuntimeError, 'between 0 and 1'):
+                loss_too_positive = bceloss(output_valid, target_too_positive)
+
     def test_bce_loss_size_mismatch(self):
         bceloss = nn.BCELoss()
         a = torch.rand(25)

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -3148,7 +3148,7 @@ classification_criterion_no_batch = [
         lambda: torch.sigmoid(torch.randn(9, dtype=torch.double)),
         lambda: torch.randn(9, dtype=torch.double).gt(0).to(torch.double)
     ),
-    ('BCEWithLogitsLoss', lambda: torch.randn(9, dtype=torch.double), lambda: torch.randn(9, dtype=torch.double)),
+    ('BCEWithLogitsLoss', lambda: torch.randn(9, dtype=torch.double), lambda: torch.rand(9, dtype=torch.double)),
     ('HingeEmbeddingLoss', lambda: torch.randn(9, dtype=torch.double), lambda: torch.tensor([-1, 1, 1] * 3)),
     ('MultiLabelMarginLoss', lambda: torch.randn(4, dtype=torch.double), lambda: torch.tensor([3, 0, -1, 1])),
     ('SoftMarginLoss', lambda: torch.randn(9, dtype=torch.double), lambda: torch.tensor([-1, 1, 1] * 3)),


### PR DESCRIPTION
Fixes #123339.

This PR adds a check to `BCEWithLogitsLoss` to ensure the targets are within [0, 1]. This makes it consistent with the current behavior of `BCELoss`. 

I'm not really sure if the overhead of this check is worth it, as it might be on the critical path of many training scripts. The input to the `BCEWithLogitsLoss` tests seems wrong nonetheless (`randn` instead of `rand`), so we should fix that independently if this doesn't get merged.