### PR TITLE
[ROCm] clean up workspace during CI setup

### DIFF
--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -56,6 +56,28 @@ jobs:
     timeout-minutes: ${{ matrix.mem_leak_check == 'mem_leak_check' && 600 || inputs.timeout-minutes }}
     runs-on: ${{ matrix.runner }}
     steps:
+      - name: Chown workspace
+        shell: bash
+        run: |
+          echo "${GITHUB_WORKSPACE}"
+          ORIG_U="$(id -u)"
+          ORIG_G="$(id -g)"
+          export ORIG_U
+          export ORIG_G
+          docker run --rm \
+            -e ORIG_U \
+            -e ORIG_G \
+            -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
+            -w /var/lib/jenkins/workspace \
+            alpine:latest \
+            chown -R ${ORIG_U}:${ORIG_G} /var/lib/jenkins/workspace
+
+      # [see note: pytorch repo ref]
+      - name: Checkout PyTorch
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
+        with:
+          no-sudo: true
+
       - name: Setup ROCm
         uses: ./.github/actions/setup-rocm
 
@@ -82,31 +104,6 @@ jobs:
         uses: pytorch/test-infra/.github/actions/pull-docker-image@main
         with:
           docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
-
-      - name: Chown workspace
-        shell: bash
-        env:
-          DOCKER_IMAGE: ${{ inputs.docker-image }}
-        run: |
-          echo "${GITHUB_WORKSPACE}"
-          ORIG_U="$(id -u)"
-          ORIG_G="$(id -g)"
-          export ORIG_U
-          export ORIG_G
-          docker run --rm \
-            -e ORIG_U \
-            -e ORIG_G \
-            --user jenkins \
-            -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
-            -w /var/lib/jenkins/workspace \
-            "${DOCKER_IMAGE}" \
-            sudo chown -R ${ORIG_U}:${ORIG_G} /var/lib/jenkins/workspace
-
-      # [see note: pytorch repo ref]
-      - name: Checkout PyTorch
-        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
-        with:
-          no-sudo: true
 
       - name: Start monitoring script
         id: monitor-script

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -89,11 +89,13 @@ jobs:
           DOCKER_IMAGE: ${{ inputs.docker-image }}
         run: |
           echo "${GITHUB_WORKSPACE}"
-          export ORIG_U="$(id -u)"
-          export ORIG_G="$(id -g)"
+          ORIG_U="$(id -u)"
+          ORIG_G="$(id -g)"
+          export ORIG_U
+          export ORIG_G
           docker run --rm \
-            -e ORIG_U
-            -e ORIG_G
+            -e ORIG_U \
+            -e ORIG_G \
             --user jenkins \
             -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
             -w /var/lib/jenkins/workspace \

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -83,18 +83,22 @@ jobs:
         with:
           docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
 
-      - name: Clean workspace
+      - name: Chown workspace
         shell: bash
         env:
           DOCKER_IMAGE: ${{ inputs.docker-image }}
         run: |
           echo "${GITHUB_WORKSPACE}"
+          export ORIG_U="$(id -u)"
+          export ORIG_G="$(id -g)"
           docker run --rm \
+            -e ORIG_U
+            -e ORIG_G
             --user jenkins \
             -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
-            -w /var/lib/jenkins \
+            -w /var/lib/jenkins/workspace \
             "${DOCKER_IMAGE}" \
-            sudo rm -rf /var/lib/jenkins/workspace
+            "sudo chown -R ${ORIG_U}:${ORIG_G} /var/lib/jenkins/workspace"
 
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -70,7 +70,7 @@ jobs:
             -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
             -w /var/lib/jenkins/workspace \
             alpine:latest \
-            chown -R ${ORIG_U}:${ORIG_G} /var/lib/jenkins/workspace
+            chown -R "${ORIG_U}":"${ORIG_G}" /var/lib/jenkins/workspace
 
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -56,6 +56,9 @@ jobs:
     timeout-minutes: ${{ matrix.mem_leak_check == 'mem_leak_check' && 600 || inputs.timeout-minutes }}
     runs-on: ${{ matrix.runner }}
     steps:
+      - name: Setup ROCm
+        uses: ./.github/actions/setup-rocm
+        
       - name: Chown workspace
         shell: bash
         run: |
@@ -77,9 +80,6 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
         with:
           no-sudo: true
-
-      - name: Setup ROCm
-        uses: ./.github/actions/setup-rocm
 
       - name: configure aws credentials
         id: aws_creds

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -92,9 +92,9 @@ jobs:
           docker run --rm \
             --user jenkins \
             -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
-            -w /var/lib/jenkins/workspace \
+            -w /var/lib/jenkins \
             "${DOCKER_IMAGE}" \
-            sudo rm -rf /var/lib/jenkins/workspace/*
+            sudo rm -rf /var/lib/jenkins/workspace
 
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -100,7 +100,7 @@ jobs:
             -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
             -w /var/lib/jenkins/workspace \
             "${DOCKER_IMAGE}" \
-            "sudo chown -R ${ORIG_U}:${ORIG_G} /var/lib/jenkins/workspace"
+            sudo chown -R ${ORIG_U}:${ORIG_G} /var/lib/jenkins/workspace
 
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -56,12 +56,6 @@ jobs:
     timeout-minutes: ${{ matrix.mem_leak_check == 'mem_leak_check' && 600 || inputs.timeout-minutes }}
     runs-on: ${{ matrix.runner }}
     steps:
-      # [see note: pytorch repo ref]
-      - name: Checkout PyTorch
-        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
-        with:
-          no-sudo: true
-
       - name: Setup ROCm
         uses: ./.github/actions/setup-rocm
 
@@ -88,6 +82,25 @@ jobs:
         uses: pytorch/test-infra/.github/actions/pull-docker-image@main
         with:
           docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
+
+      - name: Clean workspace
+        shell: bash
+        env:
+          DOCKER_IMAGE: ${{ inputs.docker-image }}
+        run: |
+          echo "${GITHUB_WORKSPACE}"
+          docker run --rm \
+            --user jenkins \
+            -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
+            -w /var/lib/jenkins/workspace \
+            "${DOCKER_IMAGE}" \
+            sudo rm -rf /var/lib/jenkins/workspace/*
+
+      # [see note: pytorch repo ref]
+      - name: Checkout PyTorch
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
+        with:
+          no-sudo: true
 
       - name: Start monitoring script
         id: monitor-script


### PR DESCRIPTION
PR #122922 added chown steps to test.sh and used the trap mechanism to ensure that, even if the test scripts fails and exits with a non-zero code, it will call the cleanup_workspace function on EXIT.

However, this doesn't work as intended when the CI job gets cancelled for eg. if a PR pushes new commits and the older commit CI job gets cancelled. The trap function doesn't get called as the test script immediately aborts.

Any subsequent jobs scheduled on the same runner then fail in the 'Checkout PyTorch' step when they try to delete the workspace.

This has been resulting in a slew of CI failures on the HUD.

This PR moves the pytorch source checkout until after the docker image has been established and adds a new step for cleaning the workspace prior to checkout.

Alternative to #123468.


cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang