### PR TITLE
[export] Fix naming if state dict contains colons

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -227,6 +227,22 @@ class TestExport(TestCase):
         ep = export(f, args, strict=False)
         self.assertEqual(ep.module()(*args), f(*args))
 
+    def test_colon_parameter(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_parameter(
+                    "foo:bar",
+                    torch.nn.Parameter(torch.ones(3, 3))
+                )
+
+            def forward(self, x):
+                return x + getattr(self, "foo:bar")
+
+        ep = export(M(), (torch.randn(3, 3),))
+        x = torch.randn(3, 3)
+        self.assertEqual(ep.module()(x), M()(x))
+
     def test_conv_dynamic(self):
         # Simple module for demonstration
         class M(torch.nn.Module):

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -451,11 +451,13 @@ def placeholder_naming_pass(
     def _strip_name(x):
         if x.startswith("L__self___"):
             x = x[len("L__self___") :]
-        return x.replace(".", "_")
+        x = re.sub(r"[^a-zA-Z0-9]", "_", x)
+        return x
 
     def _extract_pytree_key(x):
         if isinstance(x, MappingKey):
-            return str(x.key).replace(".", "_")
+            x = re.sub(r"[^a-zA-Z0-9]", "_", str(x.key))
+            return x
         elif isinstance(x, SequenceKey):
             return str(x.idx)
         elif isinstance(x, GetAttrKey):
@@ -499,6 +501,8 @@ def placeholder_naming_pass(
             base_name = ""
         else:
             base_name = _strip_name(spec.target).lower()
+        base_name = re.sub(r"[^a-zA-Z0-9]", "_", base_name)
+
         _rename_without_collisions(
             name_map,
             spec.arg.name,


### PR DESCRIPTION
Test Plan:
buck2 run mode/opt //aps_models/pyper/ads:train\[inplace\] +training.ir_serializer=on_disk

https://www.internalfb.com/intern/everpaste/?handle=GICWmAB0g_Z1StMCAMxuhJI6U9pHbsIXAAAz

Reviewed By: tugsbayasgalan

Differential Revision: D55894742


