### PR TITLE
[export] handle Dim.lower = 0, 1 for ep.run_decompositions()

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1056,7 +1056,6 @@ class TestExport(TestCase):
         ):
             _ = export(foo, inputs, dynamic_shapes=((dx, 9), (dy, 4), (3, 3)))
 
-    @testing.expectedFailurePreDispatchRunDecomp  # T183703911
     def test_dim_1_2(self):
         class Foo(torch.nn.Module):
             def forward(self, x):
@@ -1074,7 +1073,6 @@ class TestExport(TestCase):
         self.assertEqual(vr.lower, 1)
         self.assertEqual(vr.upper, 2)
 
-    @testing.expectedFailurePreDispatchRunDecomp  # T183703911
     def test_derived_dim_1_2(self):
         class Bar(torch.nn.Module):
             def forward(self, x, y):

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -1768,7 +1768,7 @@ class GraphModuleDeserializer(metaclass=Final):
             if symbol_name_to_range:
                 for k, vr in symbol_name_to_range.items():
                     lower = int(vr.lower)
-                    if vr.upper >= 2:  # no specialization on 0/1
+                    if vr.upper >= 2:  # max is >= 2, not sym bool range
                         lower = max(2, lower)
                     self.symbol_name_to_range[k] = symbolic_shapes.ValueRanges(_int_to_sympy_int(lower), vr.upper)
 

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -866,7 +866,7 @@ def _get_updated_range_constraints(
     # runtime_var_to_range will make a difference compated to var_to_range.
     # e.g. [2, oo) -> [0, oo)
     for k, v in shape_env.var_to_range.items():
-        if k not in shape_env.replacements:
+        if k not in shape_env.replacements and k not in range_constraints:
             range_constraints[k] = v
     return range_constraints
 


### PR DESCRIPTION
Summary:
With pre-dispatch export and ep.run_decompositions(), range constraints are updated through looking at ShapeEnv.var_to_range. However the lower bounds on these may be incorrect - analysis on un-specialized symbols are done with lower bounds of 2, which mismatch with user-specified bounds (may be 0, 1).

This updates `_get_updated_range_constraints()` to use the old range constraints if possible.

Test Plan: Existing pre-dispatch/dynamic shapes test case.

Differential Revision: D55899872
