### PR TITLE
Remove incorrect check

### DIFF
--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -724,7 +724,6 @@ class Node:
         update = False
         if (
                 hasattr(self, name) and
-                getattr(self, name) != value and
                 hasattr(self.graph, "_find_nodes_lookup_table") and
                 self in self.graph._find_nodes_lookup_table
         ):


### PR DESCRIPTION
Summary: This was a micro optimization that I thought would save time but it is not correct. For example, we cannot compare fake tensors.

Test Plan:
```
buck2 run 'fbcode//mode/opt' fbcode//langtech/edge/ns/tools/tests:test_ns_jit_traced_model_all_optimization_f328819347_portal_ns
```
now passes

Differential Revision: D55904083


