### PR TITLE
Aviod sync for privateuse1 backend inside Onehot.

### DIFF
--- a/aten/src/ATen/native/Onehot.cpp
+++ b/aten/src/ATen/native/Onehot.cpp
@@ -42,15 +42,17 @@ Tensor one_hot(const Tensor &self, int64_t num_classes) {
     }
 
     // non-empty tensor
-    if (self.device().type() != at::kCUDA && self.device().type() != at::kMPS) {
-      //for cuda, rely on device assert thrown by scatter
+    if (self.device().type() != at::kCUDA && self.device().type() != at::kMPS &&
+        self.device().type() != at::kPrivateUse1) {
+      // for cuda, rely on device assert thrown by scatter
       TORCH_CHECK(self.min().item().toLong() >= 0, "Class values must be non-negative.");
     }
     if (num_classes == -1) {
         num_classes = self.max().item().toLong() + 1;
     } else {
-        if (self.device().type() != at::kCUDA && self.device().type() != at::kMPS) {
-          //rely on device asserts from scatter to avoid sync here
+        if (self.device().type() != at::kCUDA && self.device().type() != at::kMPS &&
+            self.device().type() != at::kPrivateUse1) {
+          // rely on device asserts from scatter to avoid sync here
           TORCH_CHECK(num_classes > self.max().item().toLong(), "Class values must be smaller than num_classes.");
         } else {
             //for cuda, assert that num_classes is at least 1


### PR DESCRIPTION
Onehot skip class value check for cuda and mps backend which avoid sync, and it's also needed for privateuse1. This PR add privateuse1 check to avoid sync too.