### PR TITLE
[AMD] Clean up hipify base module

### DIFF
--- a/tools/amd_build/build_amd.py
+++ b/tools/amd_build/build_amd.py
@@ -13,7 +13,7 @@ sys.path.append(
     )
 )
 
-from hipify import hipify_python  # type: ignore[import]
+from hipify import hipify_python
 
 parser = argparse.ArgumentParser(
     description="Top-level script for HIPifying, filling in most common parameters"


### PR DESCRIPTION
Summary: Clean up the base module namespace and simplify the hipify script.

Test Plan:
CI 
  buck2 build mode/{opt,amd-gpu} //gen_ai/llm_inference/fb/llm:llama_disagg

Reviewed By: aaronenyeshi

Differential Revision: D55815513


