### PR TITLE
[AOTI] fix relocation overflow error when .data is large

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1682,6 +1682,17 @@ class AotCodeCompiler:
                 run_command_and_check(cmd)
             log.debug("aot constant binary command: %s", cmd)
 
+            # .data section is between .text and .bss. When the size of .data is large,
+            # during the linking, the relocation of .data against .bss may overflow.
+            # Rename it to .ldata so that it won't be in between the .text and .bss section
+            cmd = (
+                f"{objcopy_command} --rename-section"
+                " .data=.ldata"
+                f" {consts_o} {consts_o}"
+            )
+            log.debug("aot constant rename section command: %s", cmd)
+            run_command_and_check(cmd)
+
             cmd = f"rm {consts_path}"
             log.debug("aot constant bin removal command: %s", cmd)
             run_command_and_check(cmd)

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1683,7 +1683,7 @@ class AotCodeCompiler:
             log.debug("aot constant binary command: %s", cmd)
 
             # .data section is between .text and .bss. When the size of .data is large,
-            # during the linking, the relocation of .data against .bss may overflow.
+            # during the linking, the relocation of .text against .bss may overflow.
             # Rename it to .ldata so that it won't be in between the .text and .bss section
             cmd = (
                 f"{objcopy_command} --rename-section"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #123639

https://github.com/pytorch/pytorch/pull/123164 removed the below code (so that constants are not readonly) to support module buffer mutation:
https://github.com/pytorch/pytorch/blob/a9a9ce6d9cf25f4fb87e1d74c79781dc404f0c59/torch/_inductor/codecache.py#L1685-L1691

However, it may cause relocation overflow when the `.data` section is large.

Below is part of the output from `ld --versbose` (`GNU ld (GNU Binutils for Ubuntu) 2.38`). `.data` is in between `.text` and `.bss`. When `.data` is too large, during the linking, the relocation of `.text` against `.bss` may overflow. Rename it to `.ldata` (perhaps that's why previously `.lrodata` instead of `.rodata` is used) so that it won't be in between the `.text` and `.bss` section

```
.text
.rodata
.data
.bss
.lrodata
.ldata
```

We met this issue when fixing https://github.com/pytorch/pytorch/issues/114450 and running the below models on CPU:
- AlbertForMaskedLM
- AlbertForQuestionAnswering
- BlenderbotForCausalLM
- DebertaV2ForMaskedLM
- DebertaV2ForQuestionAnswering
- XGLMForCausalLM


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang