### PR TITLE
[ez] test_profiler in serial

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -248,6 +248,7 @@ CI_SERIAL_LIST = [
     "inductor/test_torchinductor",  # OOM on test_large_block_sizes
     "inductor/test_torchinductor_dynamic_shapes",  # OOM on test_large_block_sizes
     "inductor/test_torchinductor_codegen_dynamic_shapes",  # OOM on test_large_block_sizes
+    "test_profiler",  # test_source_multithreaded is probably not compatible with parallelism
 ]
 # A subset of onnx tests that cannot run in parallel due to high memory usage.
 ONNX_SERIAL_LIST = [


### PR DESCRIPTION
Add test_profiler to the serial list since we keep needing to reopen disable issues and I think its due to being incompatible with parallelism