### PR TITLE
[export] set AOTAutograd ctx to enable_grad with pre-dispatch export

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -3715,23 +3715,6 @@ def forward(self, p_bar_linear_weight, p_bar_linear_bias, x):
 
     def test_predispatch_cond(self):
         class Model(torch.nn.Module):
-            def forward(self, x, y):
-                with torch.enable_grad():
-                    x = x - y
-                return x + y
-
-        model = Model()
-        with torch.no_grad():
-            exported_program = torch.export._trace._export(
-                model,
-                (torch.tensor(10), torch.tensor(12)),
-                {},
-                dynamic_shapes=None,
-                pre_dispatch=True,
-                strict=False,
-            )
-
-        class Model(torch.nn.Module):
             def __init__(self):
                 super().__init__()
                 self.register_buffer("pred", torch.tensor(False))
@@ -3789,6 +3772,56 @@ def forward(self, arg1_1, arg0_1, arg2_1):
     add_1 = torch.ops.aten.add.Tensor(add, arg2_1);  add = arg2_1 = None
     return add_1""",
         )
+
+    def test_predispatch_grad_wrappers(self):
+        class Model(torch.nn.Module):
+            def forward(self, x, y):
+                with torch.enable_grad():
+                    x = x - y
+                with torch.no_grad():
+                    x = x + y
+                return x
+
+        # no grad
+        model = Model()
+        with torch.no_grad():
+            ep_nograd = torch.export._trace._export(
+                model,
+                (torch.tensor(10), torch.tensor(12)),
+                {},
+                dynamic_shapes=None,
+                pre_dispatch=True,
+                strict=False,
+            )
+        # check that only sub op is wrapped with grad_enabled
+        getattr_nodes = [
+            node for node in ep_nograd.graph.nodes if node.op == "get_attr"
+        ]
+        self.assertEqual(len(getattr_nodes), 1)
+        grad_subgraph = getattr(ep_nograd.graph_module, getattr_nodes[0].target)
+        op_node = [
+            node for node in grad_subgraph.graph.nodes if node.op == "call_function"
+        ][0]
+        self.assertEqual(op_node.target._name, "aten::sub.Tensor")
+
+        # enable grad
+        model = Model()
+        ep_grad = torch.export._trace._export(
+            model,
+            (torch.tensor(10), torch.tensor(12)),
+            {},
+            dynamic_shapes=None,
+            pre_dispatch=True,
+            strict=False,
+        )
+        # check that only add op is wrapped with grad_enabled
+        getattr_nodes = [node for node in ep_grad.graph.nodes if node.op == "get_attr"]
+        self.assertEqual(len(getattr_nodes), 1)
+        grad_subgraph = getattr(ep_grad.graph_module, getattr_nodes[0].target)
+        op_node = [
+            node for node in grad_subgraph.graph.nodes if node.op == "call_function"
+        ][0]
+        self.assertEqual(op_node.target._name, "aten::add.Tensor")
 
     def test_non_persistent_buffer(self):
         class MyModule(torch.nn.Module):

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -2837,7 +2837,8 @@ def forward(self, arg0_1, arg1_1):
         mod = TestMod(fn)
         inp = torch.randn(2, 2)
 
-        gm, _ = aot_export_module(mod, [inp], trace_joint=False, pre_dispatch=True)
+        with torch.no_grad():
+            gm, _ = aot_export_module(mod, [inp], trace_joint=False, pre_dispatch=True)
         self.assertExpectedInline(str(gm.code).strip(), """\
 def forward(self, arg0_1, arg1_1):
     add = torch.ops.aten.add.Tensor(arg1_1, 2)
@@ -2858,7 +2859,8 @@ def forward(self, arg0_1, arg1_1):
         mod = TestMod(fn)
         inp = torch.randn(2, 2)
 
-        gm, _ = aot_export_module(mod, [inp], trace_joint=False, pre_dispatch=True)
+        with torch.no_grad():
+            gm, _ = aot_export_module(mod, [inp], trace_joint=False, pre_dispatch=True)
         self.assertExpectedInline(str(gm.code).strip(), """\
 def forward(self, arg0_1, arg1_1):
     _set_grad_enabled = torch._C._set_grad_enabled(True)
@@ -2994,7 +2996,8 @@ def forward(self, arg0_1, arg1_1):
         inp = torch.randn(2, 2)
         mod = TestMod(foo)
 
-        gm, _ = aot_export_module(mod, [inp], trace_joint=False, pre_dispatch=True)
+        with torch.no_grad():
+            gm, _ = aot_export_module(mod, [inp], trace_joint=False, pre_dispatch=True)
         self.assertExpectedInline(str(gm.code).strip(), """\
 def forward(self, arg0_1, arg1_1):
     _set_grad_enabled = torch._C._set_grad_enabled(True)

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -626,7 +626,7 @@ or otherwise set torch._functorch.config.functionalize_rng_ops = False.""")
 
         # crappy version of dispatcher
         # TODO: Do this properly
-        if needs_autograd:
+        if needs_autograd and not aot_config.pre_dispatch:
             # For now, aot_dispatch_autograd knows to explicitly return a graph
             # when run with export, and an opaque callable otherwise.
             # In theory we could factor these out, but I wanted to let the dust
@@ -1045,7 +1045,8 @@ We require the output marked as the loss (at index {output_loss_index}) to be a 
         ctx = nullcontext
     else:
         # Run under no_grad, so our tracing machinery only traces an inference graph.
-        ctx = torch.no_grad
+        # However if pre_dispatch=True, we want to correctly trace set_grad_enabled calls for training.
+        ctx = nullcontext if pre_dispatch else torch.no_grad
         fn_to_trace = functional_call
 
     full_args = []


### PR DESCRIPTION
Summary:
Currently, torch.export (through AOTAutograd) compiles with a torch.no_grad() wrapper, which affects the presence of `set_grad_enabled` nodes in pre-dispatch export graphs. This changes the wrapper to nullcontext (i.e. enable grad) if `pre_dispatch=True`.

An example that previously failed without `with torch.no_grad()` is below:

```
class Model(torch.nn.Module):
    def forward(self, x, y):
        with torch.enable_grad():
            x = x + y
        return x

model = Model()
exported_program = torch.export._trace._export(
    model,
    (torch.tensor(2), torch.tensor(3)),
    dynamic_shapes=None,
    pre_dispatch=True,
    strict=False
)
```

The pass would inline the add call, but then try to construct a HOO subgraph with no inputs/outputs:
```
def forward(self):
    _set_grad_enabled_1 = torch._C._set_grad_enabled(False)
```

Test Plan: Test case checking that nullcontext & no_grad wrappers lead to different export behaviors (regarding set grad subgraphs).

Reviewed By: tugsbayasgalan

Differential Revision: D55777804
