### PR TITLE
[aot] refactor runtime_wrapper's epilogue args access

### DIFF
--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -106,7 +106,7 @@ def create_runtime_wrapper(
                     compiled_fn,
                     args_,
                     disable_amp=disable_amp,
-                    steal_args=True,
+                    steal_args=True
                 )
         else:
             # When we have an inference graph, we run with torch.no_grad.
@@ -119,12 +119,14 @@ def create_runtime_wrapper(
                         compiled_fn,
                         args,
                         disable_amp=disable_amp,
+                        steal_args=True
                     )
             else:
                 all_outs = call_func_at_runtime_with_args(
                     compiled_fn,
                     args,
                     disable_amp=disable_amp,
+                    steal_args=True
                 )
         del args
 

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -103,10 +103,7 @@ def create_runtime_wrapper(
                     args_[idx] = args_[idx].detach()
             with torch.autograd._force_original_view_tracking(True):
                 all_outs = call_func_at_runtime_with_args(
-                    compiled_fn,
-                    args_,
-                    disable_amp=disable_amp,
-                    steal_args=True
+                    compiled_fn, args_, disable_amp=disable_amp, steal_args=True
                 )
         else:
             # When we have an inference graph, we run with torch.no_grad.
@@ -116,17 +113,11 @@ def create_runtime_wrapper(
             if torch.is_grad_enabled():
                 with torch.no_grad():
                     all_outs = call_func_at_runtime_with_args(
-                        compiled_fn,
-                        args,
-                        disable_amp=disable_amp,
-                        steal_args=True
+                        compiled_fn, args, disable_amp=disable_amp, steal_args=True
                     )
             else:
                 all_outs = call_func_at_runtime_with_args(
-                    compiled_fn,
-                    args,
-                    disable_amp=disable_amp,
-                    steal_args=True
+                    compiled_fn, args, disable_amp=disable_amp, steal_args=True
                 )
         del args
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #122535
* #123359
* #122353
* __->__ #123674
* #123630

I want runtime_wrapper args to be stealable by call_func_at_runtime_with_args, since the args may contain activations which we don't want to hold alive in this scope.

The args to runtime_wrapper **should always be** from a list created within aot_autograd, so it **should always be** safe to steal them: https://github.com/pytorch/pytorch/blob/a4a49f77b8c45ea459263c2242ab391b3d0577f2/torch/_functorch/aot_autograd.py#L928-L932

There are some accesses after we execute the compiled_fn, but those index accesses are already inferred at compile time.
